### PR TITLE
Add support for synchronizing guest clock to UTC

### DIFF
--- a/src/86box.h
+++ b/src/86box.h
@@ -8,7 +8,7 @@
  *
  *		Main include file for the application.
  *
- * Version:	@(#)86box.h	1.0.23	2018/05/25
+ * Version:	@(#)86box.h	1.0.24	2018/08/04
  *
  * Authors:	Miran Grca, <mgrca8@gmail.com>
  *		Fred N. van Kempen, <decwiz@yahoo.com>

--- a/src/86box.h
+++ b/src/86box.h
@@ -104,7 +104,7 @@ extern int	cpu_manufacturer,		/* (C) cpu manufacturer */
 		cpu,				/* (C) cpu type */
 		cpu_use_dynarec,		/* (C) cpu uses/needs Dyna */
 		enable_external_fpu;		/* (C) enable external FPU */
-extern int	enable_sync;			/* (C) enable time sync */
+extern int	time_sync;			/* (C) enable time sync */
 extern int	network_type;			/* (C) net provider type */
 extern int	network_card;			/* (C) net interface num */
 extern char	network_host[512];		/* (C) host network intf */

--- a/src/config.c
+++ b/src/config.c
@@ -8,16 +8,18 @@
  *
  *		Configuration file handler.
  *
- * Version:	@(#)config.c	1.0.48	2018/05/25
+ * Version:	@(#)config.c	1.0.49	2018/08/04
  *
  * Authors:	Sarah Walker,
  *		Miran Grca, <mgrca8@gmail.com>
  *		Fred N. van Kempen, <decwiz@yahoo.com>
  *		Overdoze,
+ *		David Hrdlička, <hrdlickadavid@outlook.com>
  *
  *		Copyright 2008-2018 Sarah Walker.
  *		Copyright 2016-2018 Miran Grca.
  *		Copyright 2017,2018 Fred N. van Kempen.
+ *		Copyright 2018 David Hrdlička.
  *
  * NOTE:	Forcing config files to be in Unicode encoding breaks
  *		it on Windows XP, and possibly also Vista. Use the

--- a/src/machine/m_europc.c
+++ b/src/machine/m_europc.c
@@ -68,7 +68,7 @@
  *
  * WARNING	THIS IS A WORK-IN-PROGRESS MODULE. USE AT OWN RISK.
  *		
- * Version:	@(#)europc.c	1.0.6	2018/04/29
+ * Version:	@(#)europc.c	1.0.7	2018/08/04
  *
  * Author:	Fred N. van Kempen, <decwiz@yahoo.com>
  *

--- a/src/machine/m_europc.c
+++ b/src/machine/m_europc.c
@@ -280,7 +280,7 @@ rtc_start(nvr_t *nvr)
     struct tm tm;
 
     /* Initialize the internal and chip times. */
-    if (enable_sync & TIME_SYNC_ENABLED) {
+    if (time_sync & TIME_SYNC_ENABLED) {
 	/* Use the internal clock's time. */
 	nvr_time_get(&tm);
 	rtc_time_set(nvr->regs, &tm);

--- a/src/machine/m_europc.c
+++ b/src/machine/m_europc.c
@@ -280,7 +280,7 @@ rtc_start(nvr_t *nvr)
     struct tm tm;
 
     /* Initialize the internal and chip times. */
-    if (enable_sync) {
+    if (enable_sync & TIME_SYNC_ENABLED) {
 	/* Use the internal clock's time. */
 	nvr_time_get(&tm);
 	rtc_time_set(nvr->regs, &tm);

--- a/src/machine/m_xt_t1000.c
+++ b/src/machine/m_xt_t1000.c
@@ -258,7 +258,7 @@ tc8521_start(nvr_t *nvr)
     struct tm tm;
 
     /* Initialize the internal and chip times. */
-    if (enable_sync & TIME_SYNC_ENABLED) {
+    if (time_sync & TIME_SYNC_ENABLED) {
 	/* Use the internal clock's time. */
 	nvr_time_get(&tm);
 	tc8521_time_set(nvr->regs, &tm);

--- a/src/machine/m_xt_t1000.c
+++ b/src/machine/m_xt_t1000.c
@@ -258,7 +258,7 @@ tc8521_start(nvr_t *nvr)
     struct tm tm;
 
     /* Initialize the internal and chip times. */
-    if (enable_sync) {
+    if (enable_sync & TIME_SYNC_ENABLED) {
 	/* Use the internal clock's time. */
 	nvr_time_get(&tm);
 	tc8521_time_set(nvr->regs, &tm);

--- a/src/machine/m_xt_t1000.c
+++ b/src/machine/m_xt_t1000.c
@@ -51,7 +51,7 @@
  * NOTE:	Still need to figure out a way to load/save ConfigSys and
  *		HardRAM stuff. Needs to be linked in to the NVR code.
  *
- * Version:	@(#)m_xt_t1000.c	1.0.6	2018/04/29
+ * Version:	@(#)m_xt_t1000.c	1.0.7	2018/08/04
  *
  * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
  *		Miran Grca, <mgrca8@gmail.com>

--- a/src/nvr.c
+++ b/src/nvr.c
@@ -8,11 +8,13 @@
  *
  *		Implement a generic NVRAM/CMOS/RTC device.
  *
- * Version:	@(#)nvr.c	1.0.10	2018/06/08
+ * Version:	@(#)nvr.c	1.0.11	2018/08/04
  *
- * Author:	Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>,
+ * 		David Hrdlička, <hrdlickadavid@outlook.com>
  *
  *		Copyright 2017,2018 Fred N. van Kempen.
+ *		Copyright 2018 David Hrdlička.
  *
  *		Redistribution and  use  in source  and binary forms, with
  *		or  without modification, are permitted  provided that the

--- a/src/nvr.c
+++ b/src/nvr.c
@@ -181,10 +181,13 @@ nvr_init(nvr_t *nvr)
 
     /* Initialize the internal clock as needed. */
     memset(&intclk, 0x00, sizeof(intclk));
-    if (enable_sync) {
+    if (enable_sync & TIME_SYNC_ENABLED) {
 	/* Get the current time of day, and convert to local time. */
 	(void)time(&now);
-	tm = localtime(&now);
+	if(enable_sync & TIME_SYNC_UTC)
+		tm = gmtime(&now);
+	else
+		tm = localtime(&now);
 
 	/* Set the internal clock. */
 	nvr_time_set(tm);

--- a/src/nvr.c
+++ b/src/nvr.c
@@ -181,10 +181,10 @@ nvr_init(nvr_t *nvr)
 
     /* Initialize the internal clock as needed. */
     memset(&intclk, 0x00, sizeof(intclk));
-    if (enable_sync & TIME_SYNC_ENABLED) {
+    if (time_sync & TIME_SYNC_ENABLED) {
 	/* Get the current time of day, and convert to local time. */
 	(void)time(&now);
-	if(enable_sync & TIME_SYNC_UTC)
+	if(time_sync & TIME_SYNC_UTC)
 		tm = gmtime(&now);
 	else
 		tm = localtime(&now);

--- a/src/nvr.h
+++ b/src/nvr.h
@@ -55,6 +55,11 @@
 #define RTC_DCB(x)      ((((x) & 0xf0) >> 4) * 10 + ((x) & 0x0f))
 #define RTC_BCDINC(x,y)	RTC_BCD(RTC_DCB(x) + y)
 
+/* Time sync options */
+#define TIME_SYNC_DISABLED	0
+#define TIME_SYNC_ENABLED	1
+#define TIME_SYNC_UTC		2
+
 
 /* Define a generic RTC/NVRAM device. */
 typedef struct _nvr_ {

--- a/src/nvr.h
+++ b/src/nvr.h
@@ -8,11 +8,13 @@
  *
  *		Definitions for the generic NVRAM/CMOS driver.
  *
- * Version:	@(#)nvr.h	1.0.7	2018/06/08
+ * Version:	@(#)nvr.h	1.0.8	2018/08/04
  *
- * Author:	Fred N. van Kempen, <decwiz@yahoo.com>
+ * Author:	Fred N. van Kempen, <decwiz@yahoo.com>,
+ * 		David Hrdlička, <hrdlickadavid@outlook.com>
  *
  *		Copyright 2017,2018 Fred N. van Kempen.
+ *		Copyright 2018 David Hrdlička.
  *
  *		Redistribution and  use  in source  and binary forms, with
  *		or  without modification, are permitted  provided that the

--- a/src/nvr_at.c
+++ b/src/nvr_at.c
@@ -554,7 +554,7 @@ nvr_write(uint16_t addr, uint8_t val, void *priv)
 
 	if ((local->addr < RTC_REGA) || ((local->cent != 0xff) && (local->addr == local->cent))) {
 		if ((local->addr != 1) && (local->addr != 3) && (local->addr != 5)) {
-			if ((old != val) && !enable_sync) {
+			if ((old != val) && !(enable_sync & TIME_SYNC_ENABLED)) {
 				/* Update internal clock. */
 				time_get(nvr, &tm);
 				nvr_time_set(&tm);
@@ -630,7 +630,7 @@ nvr_start(nvr_t *nvr)
     struct tm tm;
 
     /* Initialize the internal and chip times. */
-    if (enable_sync) {
+    if (time_sync & TIME_SYNC_ENABLED) {
 	/* Use the internal clock's time. */
 	nvr_time_get(&tm);
 	time_set(nvr, &tm);

--- a/src/nvr_at.c
+++ b/src/nvr_at.c
@@ -189,7 +189,7 @@
  *		including the later update (DS12887A) which implemented a
  *		"century" register to be compatible with Y2K.
  *
- * Version:	@(#)nvr_at.c	1.0.9	2018/05/10
+ * Version:	@(#)nvr_at.c	1.0.10	2018/08/04
  *
  * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
  *		Miran Grca, <mgrca8@gmail.com>

--- a/src/nvr_at.c
+++ b/src/nvr_at.c
@@ -554,7 +554,7 @@ nvr_write(uint16_t addr, uint8_t val, void *priv)
 
 	if ((local->addr < RTC_REGA) || ((local->cent != 0xff) && (local->addr == local->cent))) {
 		if ((local->addr != 1) && (local->addr != 3) && (local->addr != 5)) {
-			if ((old != val) && !(enable_sync & TIME_SYNC_ENABLED)) {
+			if ((old != val) && !(time_sync & TIME_SYNC_ENABLED)) {
 				/* Update internal clock. */
 				time_get(nvr, &tm);
 				nvr_time_set(&tm);

--- a/src/pc.c
+++ b/src/pc.c
@@ -119,7 +119,7 @@ int	cpu_manufacturer = 0,			/* (C) cpu manufacturer */
 	cpu_use_dynarec = 0,			/* (C) cpu uses/needs Dyna */
 	cpu = 3,				/* (C) cpu type */
 	enable_external_fpu = 0;		/* (C) enable external FPU */
-int	enable_sync = 0;			/* (C) enable time sync */
+int	time_sync = 0;			/* (C) enable time sync */
 
 /* Statistics. */
 extern int

--- a/src/pc.c
+++ b/src/pc.c
@@ -8,7 +8,7 @@
  *
  *		Main emulator module where most things are controlled.
  *
- * Version:	@(#)pc.c	1.0.73	2018/06/02
+ * Version:	@(#)pc.c	1.0.74	2018/08/04
  *
  * Authors:	Sarah Walker, <http://pcem-emulator.co.uk/>
  *		Miran Grca, <mgrca8@gmail.com>

--- a/src/win/86Box.rc
+++ b/src/win/86Box.rc
@@ -289,11 +289,7 @@ BEGIN
 #endif
 END
 
-#ifdef USE_DYNAREC
-DLG_CFG_MACHINE DIALOG DISCARDABLE  97, 0, 267, 114
-#else
-DLG_CFG_MACHINE DIALOG DISCARDABLE  97, 0, 267, 99
-#endif
+DLG_CFG_MACHINE DIALOG DISCARDABLE  97, 0, 267, 199
 STYLE DS_CONTROL | WS_CHILD
 FONT 9, "Segoe UI"
 BEGIN
@@ -316,13 +312,18 @@ BEGIN
                     12,12
     LTEXT           "MB",IDT_1705,123,64,10,10
     LTEXT           "Memory:",IDT_1706,7,64,30,10
-    CONTROL         "Enable time sync",IDC_CHECK_SYNC,"Button",
-                    BS_AUTOCHECKBOX | WS_TABSTOP,7,81,102,10
     CONTROL         "Enable FPU",IDC_CHECK_FPU,"Button",BS_AUTOCHECKBOX | 
-                    WS_TABSTOP,147,81,113,10
+                    WS_TABSTOP,7,81,113,10
+    GROUPBOX        "Time synchronization",IDC_TIME_SYNC,7,96,100,56
+    CONTROL         "Disabled",IDC_RADIO_TS_DISABLED,"Button",
+                    BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,14,108,84,10
+    CONTROL         "Enabled (local time)", IDC_RADIO_TS_LOCAL,"Button",
+                    BS_AUTORADIOBUTTON | WS_TABSTOP,14,122,84,10
+    CONTROL         "Enabled (UTC)", IDC_RADIO_TS_UTC,"Button",
+                    BS_AUTORADIOBUTTON | WS_TABSTOP,14,136,84,10
 #ifdef USE_DYNAREC
     CONTROL         "Dynamic Recompiler",IDC_CHECK_DYNAREC,"Button",
-                    BS_AUTOCHECKBOX | WS_TABSTOP,7,96,94,10
+                    BS_AUTOCHECKBOX | WS_TABSTOP,147,81,94,10
 #endif
 END
 

--- a/src/win/86Box.rc
+++ b/src/win/86Box.rc
@@ -8,12 +8,14 @@
  *
  *		Application resource script for Windows.
  *
- * Version:	@(#)86Box.rc	1.0.39	2018/07/28
+ * Version:	@(#)86Box.rc	1.0.40	2018/08/04
  *
  * Authors:	Miran Grca, <mgrca8@gmail.com>
  *		Fred N. van Kempen, <decwiz@yahoo.com>
+ *		David Hrdlička, <hrdlickadavid@outlook.com>
  *
  *		Copyright 2016-2018 Miran Grca.
+ *		Copyright 2018 David Hrdlička.
  */
 #include <inttypes.h>
 #define IN_RESOURCE_H

--- a/src/win/resource.h
+++ b/src/win/resource.h
@@ -8,14 +8,16 @@
  *
  *		Windows resource defines.
  *
- * Version:	@(#)resource.h	1.0.26	2018/07/19
+ * Version:	@(#)resource.h	1.0.27	2018/08/04
  *
  * Authors:	Sarah Walker, <http://pcem-emulator.co.uk/>
  *		Miran Grca, <mgrca8@gmail.com>
  *		Fred N. van Kempen, <decwiz@yahoo.com>
+ *		David Hrdlička, <hrdlickadavid@outlook.com>
  *
  *		Copyright 2008-2018 Sarah Walker.
  *		Copyright 2016-2018 Miran Grca.
+ *		Copyright 2018 David Hrdlička.
  */
 #ifndef WIN_RESOURCE_H
 # define WIN_RESOURCE_H

--- a/src/win/resource.h
+++ b/src/win/resource.h
@@ -99,7 +99,10 @@
  */
 #define IDC_SETTINGSCATLIST	1001	/* generic config */
 #define IDC_CFILE		1002	/* Select File dialog */
-#define IDC_CHECK_SYNC		1008
+#define IDC_TIME_SYNC		1005
+#define IDC_RADIO_TS_DISABLED	1006
+#define IDC_RADIO_TS_LOCAL	1007
+#define IDC_RADIO_TS_UTC	1008
 /* Leave this as is until we finally get into localization in 86Box 3.00(?). */
 #if 0
 #define IDC_COMBO_LANG		1009

--- a/src/win/win_settings.c
+++ b/src/win/win_settings.c
@@ -202,7 +202,7 @@ win_settings_init(void)
     temp_dynarec = cpu_use_dynarec;
 #endif
     temp_fpu = enable_external_fpu;
-    temp_sync = time_sync & TIME_SYNC_ENABLED;
+    temp_sync = time_sync;
 
     /* Video category */
     temp_gfxcard = gfxcard;
@@ -305,7 +305,7 @@ win_settings_changed(void)
     i = i || (temp_dynarec != cpu_use_dynarec);
 #endif
     i = i || (temp_fpu != enable_external_fpu);
-    i = i || (temp_sync != (time_sync & TIME_SYNC_ENABLED));
+    i = i || (temp_sync != time_sync);
 
     /* Video category */
     i = i || (gfxcard != temp_gfxcard);
@@ -658,8 +658,24 @@ win_settings_machine_proc(HWND hdlg, UINT message, WPARAM wParam, LPARAM lParam)
 		h2 = GetDlgItem(hdlg, IDC_MEMTEXT);
 		SendMessage(h, UDM_SETBUDDY, (WPARAM)h2, 0);
 
-       	        h=GetDlgItem(hdlg, IDC_CHECK_SYNC);
-                SendMessage(h, BM_SETCHECK, temp_sync, 0);
+		if (temp_sync & TIME_SYNC_ENABLED)
+		{
+			if (temp_sync & TIME_SYNC_UTC)
+			{
+				h=GetDlgItem(hdlg, IDC_RADIO_TS_UTC);
+				SendMessage(h, BM_SETCHECK, BST_CHECKED, 0);
+			}
+			else
+			{
+				h=GetDlgItem(hdlg, IDC_RADIO_TS_LOCAL);
+				SendMessage(h, BM_SETCHECK, BST_CHECKED, 0);
+			}
+		}
+		else
+		{
+			h=GetDlgItem(hdlg, IDC_RADIO_TS_DISABLED);
+			SendMessage(h, BM_SETCHECK, BST_CHECKED, 0);
+		}
 
 		win_settings_machine_recalc_machine(hdlg);
 
@@ -713,8 +729,17 @@ win_settings_machine_proc(HWND hdlg, UINT message, WPARAM wParam, LPARAM lParam)
 		temp_dynarec = SendMessage(h, BM_GETCHECK, 0, 0);
 #endif
 
-       	        h=GetDlgItem(hdlg, IDC_CHECK_SYNC);
-		temp_sync = SendMessage(h, BM_GETCHECK, 0, 0);
+		h=GetDlgItem(hdlg, IDC_RADIO_TS_DISABLED);
+		if(SendMessage(h, BM_GETCHECK, 0, 0))
+			temp_sync = TIME_SYNC_DISABLED;
+
+		h=GetDlgItem(hdlg, IDC_RADIO_TS_LOCAL);
+		if(SendMessage(h, BM_GETCHECK, 0, 0))
+			temp_sync = TIME_SYNC_ENABLED;
+
+		h=GetDlgItem(hdlg, IDC_RADIO_TS_UTC);
+		if(SendMessage(h, BM_GETCHECK, 0, 0))
+			temp_sync = TIME_SYNC_ENABLED | TIME_SYNC_UTC;
 
        	        h=GetDlgItem(hdlg, IDC_CHECK_FPU);
 		temp_fpu = SendMessage(h, BM_GETCHECK, 0, 0);

--- a/src/win/win_settings.c
+++ b/src/win/win_settings.c
@@ -8,11 +8,13 @@
  *
  *		Windows 86Box Settings dialog handler.
  *
- * Version:	@(#)win_settings.c	1.0.51	2018/05/25
+ * Version:	@(#)win_settings.c	1.0.52	2018/08/04
  *
- * Author:	Miran Grca, <mgrca8@gmail.com>
+ * Authors:	Miran Grca, <mgrca8@gmail.com>
+ * 		David Hrdlička, <hrdlickadavid@outlook.com>
  *
  *		Copyright 2016-2018 Miran Grca.
+ *		Copyright 2018 David Hrdlička.
  */
 #define UNICODE
 #define BITMAP WINDOWS_BITMAP

--- a/src/win/win_settings.c
+++ b/src/win/win_settings.c
@@ -202,7 +202,7 @@ win_settings_init(void)
     temp_dynarec = cpu_use_dynarec;
 #endif
     temp_fpu = enable_external_fpu;
-    temp_sync = enable_sync & TIME_SYNC_ENABLED;
+    temp_sync = time_sync & TIME_SYNC_ENABLED;
 
     /* Video category */
     temp_gfxcard = gfxcard;
@@ -305,7 +305,7 @@ win_settings_changed(void)
     i = i || (temp_dynarec != cpu_use_dynarec);
 #endif
     i = i || (temp_fpu != enable_external_fpu);
-    i = i || (temp_sync != (enable_sync & TIME_SYNC_ENABLED));
+    i = i || (temp_sync != (time_sync & TIME_SYNC_ENABLED));
 
     /* Video category */
     i = i || (gfxcard != temp_gfxcard);
@@ -403,7 +403,7 @@ win_settings_save(void)
     cpu_use_dynarec = temp_dynarec;
 #endif
     enable_external_fpu = temp_fpu;
-    enable_sync = temp_sync;
+    time_sync = temp_sync;
 
     /* Video category */
     gfxcard = temp_gfxcard;

--- a/src/win/win_settings.c
+++ b/src/win/win_settings.c
@@ -202,7 +202,7 @@ win_settings_init(void)
     temp_dynarec = cpu_use_dynarec;
 #endif
     temp_fpu = enable_external_fpu;
-    temp_sync = enable_sync;
+    temp_sync = enable_sync & TIME_SYNC_ENABLED;
 
     /* Video category */
     temp_gfxcard = gfxcard;
@@ -305,7 +305,7 @@ win_settings_changed(void)
     i = i || (temp_dynarec != cpu_use_dynarec);
 #endif
     i = i || (temp_fpu != enable_external_fpu);
-    i = i || (temp_sync != enable_sync);
+    i = i || (temp_sync != (enable_sync & TIME_SYNC_ENABLED));
 
     /* Video category */
     i = i || (gfxcard != temp_gfxcard);


### PR DESCRIPTION
Some operating systems are not much fond of the RTC running in local time. This patch introduces a UTC mode for timesync, which is fully configurable from the Settings dialog:
![Imgur](https://i.imgur.com/cCXuvXR.png)

This patch also replaces the numeric `enable_sync` config value with the textual `time_sync` with three possible values: `disabled`, `local` and `utc`. This shouldn't break existing configs. Existing `enable_sync` setings are automatically replaced with an appropriate `time_sync` value. In case `enable_sync` and `time_sync` settings are both present in a configuration file (shouldn't happen without manually editing the config), `time_sync` takes precedence.