### PR TITLE
Fix CD volume issue present on SB cards.

### DIFF
--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -518,8 +518,8 @@ void sb_ct1335_mixer_write(uint16_t addr, uint8_t val, void *p)
                 mixer->cd     = sb_att_4dbstep_3bits[(mixer->regs[0x08] >> 1)&0x7];
                 mixer->voice  = sb_att_7dbstep_2bits[(mixer->regs[0x0A] >> 1)&0x3];
 
-                sound_set_cd_volume(((uint32_t)mixer->master * (uint32_t)mixer->cd) / 65535,
-                                    ((uint32_t)mixer->master * (uint32_t)mixer->cd) / 65535);
+                sound_set_cd_volume(((uint32_t)mixer->master * (uint32_t)mixer->cd * 4) / 65535,
+                                    ((uint32_t)mixer->master * (uint32_t)mixer->cd * 4) / 65535);
         }
 }
 
@@ -639,8 +639,8 @@ void sb_ct1345_mixer_write(uint16_t addr, uint8_t val, void *p)
                 }
                 
                 /* TODO: pcspeaker volume? Or is it not worth? */
-                sound_set_cd_volume(((uint32_t)mixer->master_l * (uint32_t)mixer->cd_l) / 65535,
-                                    ((uint32_t)mixer->master_r * (uint32_t)mixer->cd_r) / 65535);
+                sound_set_cd_volume(((uint32_t)mixer->master_l * (uint32_t)mixer->cd_l * 4) / 65535,
+                                    ((uint32_t)mixer->master_r * (uint32_t)mixer->cd_r * 4) / 65535);
         }
 }
 
@@ -805,8 +805,8 @@ void sb_ct1745_mixer_write(uint16_t addr, uint8_t val, void *p)
                 mixer->treble_r = mixer->regs[0x45] >> 4;
 
                 /*TODO: pcspeaker volume, with "output_selector" check? or better not? */
-                sound_set_cd_volume(((uint32_t)mixer->master_l * (uint32_t)mixer->cd_l) / 65535,
-                                    ((uint32_t)mixer->master_r * (uint32_t)mixer->cd_r) / 65535);
+                sound_set_cd_volume(((uint32_t)mixer->master_l * (uint32_t)mixer->cd_l * 4) / 65535,
+                                    ((uint32_t)mixer->master_r * (uint32_t)mixer->cd_r * 4) / 65535);
                 sb_log("sb_ct1745: Received register WRITE: %02X\t%02X\n", mixer->index, mixer->regs[mixer->index]);
         }
 }


### PR DESCRIPTION
The CD sound volume is too quiet with Sound Blaster cards.

The mixing tables give headroom to avoid integer overflow, and the rest of the SB emulation code is written to reflect this. But the headroom needs to be accounted for when setting the CD volume, so as to span the full range of the global CD sound volume. The Ensoniq AudioPCI code has code to compensate of this, but the Sound Blaster code doesn't.

Because two factors (master and CD volumes) are multiplied, this error multiplies up from 50% too quiet, to 25% too quiet. A factor increase of 4 was added to fix this.