### PR TITLE
Direct2D refinements

### DIFF
--- a/src/win/win_d2d.cpp
+++ b/src/win/win_d2d.cpp
@@ -8,7 +8,7 @@
  *
  *		Rendering module for Microsoft Direct2D.
  *
- * Version:	@(#)win_d2d.cpp	1.0.5	2019/12/06
+ * Version:	@(#)win_d2d.cpp	1.0.6	2019/12/10
  *
  * Authors:	David Hrdlička, <hrdlickadavid@outlook.com>
  *

--- a/src/win/win_d2d.cpp
+++ b/src/win/win_d2d.cpp
@@ -21,14 +21,9 @@
 #define UNICODE
 #define BITMAP WINDOWS_BITMAP
 #include <windows.h>
-#ifdef USE_D2D
 #include <d2d1.h>
 #include <d2d1helper.h>
-#endif
 #undef BITMAP
-
-#define PNG_DEBUG 0
-#include <png.h>
 
 #define HAVE_STDARG_H
 #include "../86box.h"
@@ -41,14 +36,12 @@
 #include "win_d2d.h"
 
 
-#ifdef USE_D2D
 static HWND			d2d_hwnd, old_hwndMain;
 static ID2D1Factory		*d2d_factory;
 static ID2D1HwndRenderTarget	*d2d_target;
 static ID2D1Bitmap		*d2d_buffer;
 static int			d2d_width, d2d_height, d2d_screen_width, d2d_screen_height, d2d_fs;
 static volatile int		d2d_enabled = 0;
-#endif
 
 
 /* Pointers to the real functions. */
@@ -85,7 +78,6 @@ d2d_log(const char *fmt, ...)
 #endif
 
 
-#ifdef USE_D2D
 static void
 d2d_stretch(float *w, float *h, float *x, float *y)
 {
@@ -153,10 +145,8 @@ d2d_stretch(float *w, float *h, float *x, float *y)
 			break;
 	}
 }
-#endif
 
 
-#ifdef USE_D2D
 static void
 d2d_blit(int x, int y, int y1, int y2, int w, int h)
 {
@@ -243,7 +233,6 @@ d2d_blit(int x, int y, int y1, int y2, int w, int h)
 		d2d_log("Direct2D: d2d_blit: error 0x%08lx\n", hr);
 	}
 }
-#endif
 
 
 void
@@ -257,7 +246,6 @@ d2d_close(void)
 	if (d2d_enabled)
 		d2d_enabled = 0;
 
-#ifdef USE_D2D
 	if (d2d_buffer)
 	{
 		d2d_buffer->Release();
@@ -290,11 +278,9 @@ d2d_close(void)
 		dynld_close((void *)d2d_handle);
 		d2d_handle = NULL;
 	}
-#endif
 }
 
 
-#ifdef USE_D2D
 static int
 d2d_init_common(int fs)
 {
@@ -384,19 +370,13 @@ d2d_init_common(int fs)
 
 	return(1);
 }
-#endif
 
 
 int
 d2d_init(HWND h)
 {
 	d2d_log("Direct2D: d2d_init(h=0x%08lx)\n", h);
-
-#ifdef USE_D2D
 	return d2d_init_common(0);
-#else
-	return(0);
-#endif
 }
 
 
@@ -404,12 +384,7 @@ int
 d2d_init_fs(HWND h)
 {
 	d2d_log("Direct2D: d2d_init_fs(h=0x%08lx)\n", h);
-
-#ifdef USE_D2D
 	return d2d_init_common(1);
-#else
-	return(0);
-#endif
 }
 
 

--- a/src/win/win_d2d.cpp
+++ b/src/win/win_d2d.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * 86Box	A hypervisor and IBM PC system emulator that specializes in
  *		running old operating systems and software designed for IBM
  *		PC systems and compatibles from 1981 through fairly recent
@@ -224,11 +224,21 @@ d2d_blit(int x, int y, int y1, int y2, int w, int h)
 		return;
 	}
 
-	rectU = D2D1::RectU(x, y + y1, x + w, y + y2);
-	hr = d2d_bitmap->CopyFromMemory(
-		&rectU,
-		&(render_buffer->line[y + y1][x]),
-		render_buffer->w << 2);
+	if (d2d_bitmap == NULL) {
+		// Create a bitmap for storing intermediate data
+		hr = d2d_hwndRT->CreateBitmap(
+			D2D1::SizeU(render_buffer->w, render_buffer->h),
+			D2D1::BitmapProperties(D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_IGNORE)),	
+			&d2d_bitmap);
+	}
+
+	if (SUCCEEDED(hr)) {
+		rectU = D2D1::RectU(x, y + y1, x + w, y + y2);
+		hr = d2d_bitmap->CopyFromMemory(
+			&rectU,
+			&(render_buffer->line[y + y1][x]),
+			render_buffer->w << 2);
+	}
 
 	video_blit_complete();
 
@@ -406,15 +416,6 @@ d2d_init_common(int fs)
 			D2D1::RenderTargetProperties(),
 			props,
 			&d2d_hwndRT);
-	}
-
-	if (SUCCEEDED(hr))
-	{
-		// Create a bitmap for storing intermediate data
-		hr = d2d_hwndRT->CreateBitmap(
-			D2D1::SizeU(2048, 2048),
-			D2D1::BitmapProperties(D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_IGNORE)),	
-			&d2d_bitmap);
 	}	
 
 	if (SUCCEEDED(hr)) 

--- a/src/win/win_d2d.h
+++ b/src/win/win_d2d.h
@@ -8,7 +8,7 @@
  *
  *		Definitions for the Direct2D rendering module.
  *
- * Version:	@(#)win_d2d.h	1.0.1	2019/10/12
+ * Version:	@(#)win_d2d.h	1.0.2	2019/12/13
  *
  * Authors:	David Hrdlička, <hrdlickadavid@outlook.com>
  *
@@ -17,19 +17,10 @@
 #ifndef WIN_D2D_H
 # define WIN_D2D_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 extern void	d2d_close(void);
 extern int	d2d_init(HWND h);
 extern int	d2d_init_fs(HWND h);
 extern int	d2d_pause(void);
 extern void	d2d_enable(int enable);
-
-#ifdef __cplusplus
-}
-#endif
-
 
 #endif	/*WIN_D2D_H*/


### PR DESCRIPTION
After some time, I got into the mood to make some minor adjustments to the Direct2D renderer code.

* Code path for rendering was unified for both windowed and full screen modes.
* The blitter now also copies the contents of `render_buffer` directly into the renderer buffer without doing half the job on its own with secondary buffers and what not.
* The D2D buffer is now lazily initialized in the blitter when it's first used.
* Ported the renderer to C.

Sorry, still Direct2D 1.0. ~~Also, there seems to be some strange crash on optimized builds.~~