### PR TITLE
Adding the IBM Ambra's on 86Box

### DIFF
--- a/src/machine/m_at_socket4_5.c
+++ b/src/machine/m_at_socket4_5.c
@@ -109,8 +109,8 @@ machine_at_ambradp60_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/ambrapci/1004AF1P.BIO",
-				    L"roms/machines/ambrapci/1004AF1P.BI1", 0x1c000, 128);
+    ret = bios_load_linear_combined(L"roms/machines/ambradp60/1004AF1P.BIO",
+				    L"roms/machines/ambradp60/1004AF1P.BI1", 0x1c000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -164,8 +164,8 @@ machine_at_ambradp90_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/ambrapciii/1002AX1P.BIO",
-				    L"roms/machines/ambrapciii/1002AX1P.BI1", 0x1d000, 128);
+    ret = bios_load_linear_combined(L"roms/machines/ambradp90/1002AX1P.BIO",
+				    L"roms/machines/ambradp90/1002AX1P.BI1", 0x1d000, 128);
 
     if (bios_only || !ret)
 	return ret;

--- a/src/machine/m_at_socket4_5.c
+++ b/src/machine/m_at_socket4_5.c
@@ -104,6 +104,23 @@ machine_at_batman_init(const machine_t *model)
     return ret;
 }
 
+int
+machine_at_ambradp60_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear_combined(L"roms/machines/ambrapci/1004AF1P.BIO",
+				    L"roms/machines/ambrapci/1004AF1P.BI1", 0x1c000, 128);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_at_premiere_common_init(model);
+
+    device_add(&i430lx_device);
+
+    return ret;
+}
 
 int
 machine_at_586mc1_init(const machine_t *model)
@@ -142,6 +159,23 @@ machine_at_plato_init(const machine_t *model)
     return ret;
 }
 
+int
+machine_at_ambradp90_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear_combined(L"roms/machines/ambrapciii/1002AX1P.BIO",
+				    L"roms/machines/ambrapciii/1002AX1P.BI1", 0x1d000, 128);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_at_premiere_common_init(model);
+
+    device_add(&i430nx_device);
+
+    return ret;
+}
 
 int
 machine_at_430nx_init(const machine_t *model)

--- a/src/machine/machine.h
+++ b/src/machine/machine.h
@@ -222,9 +222,11 @@ extern int	machine_at_portableiii386_init(const machine_t *);
 
 /* m_at_socket4_5.c */
 extern int	machine_at_batman_init(const machine_t *);
+extern int	machine_at_ambradp60_init(const machine_t *);
 extern int	machine_at_586mc1_init(const machine_t *);
 
 extern int	machine_at_plato_init(const machine_t *);
+extern int	machine_at_ambradp90_init(const machine_t *);
 extern int	machine_at_430nx_init(const machine_t *);
 
 extern int	machine_at_p54tp4xe_init(const machine_t *);

--- a/src/machine/machine_table_new.c
+++ b/src/machine/machine_table_new.c
@@ -143,9 +143,11 @@ const machine_t machines[] = {
     { "[486 PCI] Rise Computer R418",		"r418",			{{"Intel", cpus_i486},        {"AMD", cpus_Am486},   {"Cyrix", cpus_Cx486},  {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_VLB | MACHINE_AT | MACHINE_HDC,					  1,  255,   1, 127,		 machine_at_r418_init, NULL			},
 
     { "[Socket 4 LX] Intel Premiere/PCI",	"revenge",		{{"Intel", cpus_Pentium5V},   {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_VLB | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			  2,  128,   2, 127,	       machine_at_batman_init, NULL			},
+    { "[Socket 4 LX] IBM Ambra DP60 PCI",	"ambradp60",		{{"Intel", cpus_Pentium5V},   {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_VLB | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			  2,  128,   2, 127,	       machine_at_ambradp60_init, NULL			},
     { "[Socket 4 LX] Micro Star 586MC1",	"586mc1",		{{"Intel", cpus_Pentium5V},   {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_VLB | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			  2,  128,   2, 127,	       machine_at_586mc1_init, NULL			},
 
     { "[Socket 5 NX] Intel Premiere/PCI II",	"plato",		MACHINE_CPUS_PENTIUM_S5,											    MACHINE_PCI | MACHINE_ISA | MACHINE_VLB | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			  2,  128,   2, 127,		machine_at_plato_init, NULL			},
+    { "[Socket 5 NX] IBM Ambra DP90 PCI",	"ambradp90",		MACHINE_CPUS_PENTIUM_S5,											    MACHINE_PCI | MACHINE_ISA | MACHINE_VLB | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			  2,  128,   2, 127,		machine_at_ambradp90_init, NULL			},
     { "[Socket 5 NX] Gigabyte GA-586IP",	"430nx",		MACHINE_CPUS_PENTIUM_S5,											    MACHINE_PCI | MACHINE_ISA | MACHINE_VLB | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			  2,  128,   2, 127,		machine_at_430nx_init, NULL			},
 
     { "[Socket 5 FX] ASUS P/I-P54TP4XE",	"p54tp4xe",		MACHINE_CPUS_PENTIUM_S5,											    MACHINE_PCI | MACHINE_ISA | MACHINE_VLB | MACHINE_AT | MACHINE_HDC,					  8,  128,   8, 127,	     machine_at_p54tp4xe_init, NULL			},


### PR DESCRIPTION
The IBM Ambra DP60 and DP90 use the standard Intel OEM boards but with their own special BIOS. These machines weren't that famous but they can be a good and special implementation for 86Box.