### PR TITLE
Assorted Joystick fixes

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -607,7 +607,7 @@ load_input_devices(void)
       else
 	mouse_type = 0;
 
-    joystick_type = config_get_int(cat, "joystick_type", 7);
+    joystick_type = config_get_int(cat, "joystick_type", JOYSTICK_TYPE_NONE);
 
     for (c=0; c<joystick_get_max_joysticks(joystick_type); c++) {
 	sprintf(temp, "joystick_%i_nr", c);
@@ -1266,7 +1266,7 @@ config_load(void)
 	gfxcard = video_get_video_from_internal_name("cga");
 	vid_api = plat_vidapi("default");
 	time_sync = TIME_SYNC_ENABLED;
-	joystick_type = 7;
+	joystick_type = JOYSTICK_TYPE_NONE;
 	hdc_current = hdc_get_from_internal_name("none");
 	serial_enabled[0] = 1;
 	serial_enabled[1] = 1;
@@ -1488,7 +1488,7 @@ save_input_devices(void)
 
     config_set_string(cat, "mouse_type", mouse_get_internal_name(mouse_type));
 
-    if (joystick_type == 7) {
+    if (joystick_type == JOYSTICK_TYPE_NONE) {
 	config_delete_var(cat, "joystick_type");
 
 	for (c = 0; c < 16; c++) {

--- a/src/game/gameport.c
+++ b/src/game/gameport.c
@@ -90,6 +90,7 @@ static const joystick_if_t *joystick_list[] = {
     &joystick_standard_4button,
     &joystick_standard_6button,
     &joystick_standard_8button,
+	&joystick_4axis_4button,
     &joystick_ch_flightstick_pro,
     &joystick_sw_pad,
     &joystick_tm_fcs,
@@ -265,7 +266,7 @@ gameport_init(const device_t *info)
 {
     gameport_t *p = NULL;
 
-    if (joystick_type == 7) {
+    if (joystick_type == JOYSTICK_TYPE_NONE) {
 	p = NULL;
 	return(p);
     }
@@ -284,7 +285,7 @@ gameport_201_init(const device_t *info)
 {
     gameport_t *p;
 
-    if (joystick_type == 7) {
+    if (joystick_type == JOYSTICK_TYPE_NONE) {
 	p = NULL;
 	return(p);
     }

--- a/src/game/gameport.h
+++ b/src/game/gameport.h
@@ -45,8 +45,10 @@
 
 #define POV_X			0x80000000
 #define POV_Y			0x40000000
+#define SLIDER 			0x20000000
 
 #define AXIS_NOT_PRESENT	-99999
+#define JOYSTICK_TYPE_NONE 	8
 
 #define JOYSTICK_PRESENT(n)	(joystick_state[n].plat_joystick_nr != 0)
 
@@ -57,6 +59,7 @@ typedef struct {
     int		a[8];
     int		b[32];
     int		p[4];
+	int 	s[2];
 
     struct {
 	char	name[260];
@@ -73,9 +76,16 @@ typedef struct {
 	int	id;
     }		pov[4];
 
+	struct
+    {
+    char 	name[260];
+    int id;
+    } 		slider[2];
+
     int		nr_axes;
     int		nr_buttons;
     int		nr_povs;
+	int 	nr_sliders;
 } plat_joystick_t;
 
 typedef struct {

--- a/src/game/joystick_standard.c
+++ b/src/game/joystick_standard.c
@@ -144,6 +144,27 @@ static int joystick_standard_read_axis_4button(void *p, int axis)
 		return 0;
         }
 }
+
+static int joystick_standard_read_axis_4axis(void *p, int axis)
+{
+        if (!JOYSTICK_PRESENT(0))
+                return AXIS_NOT_PRESENT;
+
+        switch (axis)
+        {
+				case 0:
+                return joystick_state[0].axis[0];
+				case 1:
+                return joystick_state[0].axis[1];
+				case 2:
+                return joystick_state[0].axis[2];
+				case 3:
+                return joystick_state[0].axis[3];
+        default:
+        return 0;
+        }
+}
+
 static int joystick_standard_read_axis_6button(void *p, int axis)
 {
         if (!JOYSTICK_PRESENT(0))
@@ -225,6 +246,22 @@ const joystick_if_t joystick_standard_4button =
         0,
         1,
         {"X axis", "Y axis"},
+        {"Button 1", "Button 2", "Button 3", "Button 4"}
+};
+const joystick_if_t joystick_4axis_4button =
+{
+        "4-axis 4-button joystick",
+        joystick_standard_init,
+        joystick_standard_close,
+        joystick_standard_read_4button,
+        joystick_standard_write,
+        joystick_standard_read_axis_4axis,
+        joystick_standard_a0_over,
+        4,
+        4,
+        0,
+        1,
+        {"X axis", "Y axis", "Z axis", "zX axis"},
         {"Button 1", "Button 2", "Button 3", "Button 4"}
 };
 const joystick_if_t joystick_standard_6button =

--- a/src/game/joystick_standard.h
+++ b/src/game/joystick_standard.h
@@ -37,5 +37,6 @@
 
 extern const joystick_if_t joystick_standard;
 extern const joystick_if_t joystick_standard_4button;
+extern const joystick_if_t joystick_4axis_4button;
 extern const joystick_if_t joystick_standard_6button;
 extern const joystick_if_t joystick_standard_8button;

--- a/src/machine/m_amstrad.c
+++ b/src/machine/m_amstrad.c
@@ -2508,7 +2508,7 @@ machine_amstrad_init(const machine_t *model, int type)
 	mouse_set_poll(ms_poll, ams);
     }
 
-    if (joystick_type != 7)
+    if (joystick_type != JOYSTICK_TYPE_NONE)
 	device_add(&gameport_device);
 }
 

--- a/src/machine/m_at.c
+++ b/src/machine/m_at.c
@@ -72,7 +72,7 @@ machine_at_common_init_ex(const machine_t *model, int type)
     else if (type == 0)
 	device_add(&at_nvr_device);
 
-    if (joystick_type != 7)
+    if (joystick_type != JOYSTICK_TYPE_NONE)
 	device_add(&gameport_device);
 }
 

--- a/src/machine/m_europc.c
+++ b/src/machine/m_europc.c
@@ -615,7 +615,7 @@ europc_boot(const device_t *info)
 	mouse_bus_set_irq(sys->mouse, 2);
 	/* Configure the port for (Bus Mouse Compatible) Mouse. */
 	b |= 0x01;
-    } else if (joystick_type != 7)
+    } else if (joystick_type != JOYSTICK_TYPE_NONE)
 	b |= 0x02;	/* enable port as joysticks */
     sys->nvr.regs[MRTC_CONF_C] = b;
 

--- a/src/machine/m_olivetti_m24.c
+++ b/src/machine/m_olivetti_m24.c
@@ -892,7 +892,7 @@ machine_olim24_init(const machine_t *model)
 
     keyboard_set_table(scancode_xt);
 
-    if (joystick_type != 7)
+    if (joystick_type != JOYSTICK_TYPE_NONE)
 	device_add(&gameport_device);
 
     /* FIXME: make sure this is correct?? */

--- a/src/machine/m_ps1.c
+++ b/src/machine/m_ps1.c
@@ -525,7 +525,7 @@ ps1_common_init(const machine_t *model)
     device_add(&keyboard_ps2_ps1_device);
 
     /* Audio uses ports 200h and 202-207h, so only initialize gameport on 201h. */
-    if (joystick_type != 7)
+    if (joystick_type != JOYSTICK_TYPE_NONE)
 	device_add(&gameport_201_device);
 }
 

--- a/src/machine/m_tandy.c
+++ b/src/machine/m_tandy.c
@@ -1527,7 +1527,7 @@ machine_tandy1k_init(const machine_t *model, int type)
 		device_add(&eep_1000sl2_device);
     }
 
-    if (joystick_type != 7)
+    if (joystick_type != JOYSTICK_TYPE_NONE)
 	device_add(&gameport_device);
 
     eep_data_out = 0x0000;

--- a/src/machine/m_xt.c
+++ b/src/machine/m_xt.c
@@ -26,7 +26,7 @@ machine_xt_common_init(const machine_t *model)
 
     device_add(&fdc_xt_device);
     nmi_init();
-    if (joystick_type != 7)
+    if (joystick_type != JOYSTICK_TYPE_NONE)
 	device_add(&gameport_device);
 }
 

--- a/src/machine/m_xt_compaq.c
+++ b/src/machine/m_xt_compaq.c
@@ -55,7 +55,7 @@ machine_xt_compaq_init(const machine_t *model)
     device_add(&keyboard_xt_compaq_device);
     device_add(&fdc_xt_device);
     nmi_init();
-    if (joystick_type != 7)
+    if (joystick_type != JOYSTICK_TYPE_NONE)
 	device_add(&gameport_device);
 
     lpt1_remove();

--- a/src/machine/m_xt_laserxt.c
+++ b/src/machine/m_xt_laserxt.c
@@ -171,7 +171,7 @@ machine_xt_lxt3_init(const machine_t *model)
     device_add(&keyboard_xt_lxt3_device);
     device_add(&fdc_xt_device);
     nmi_init();
-    if (joystick_type != 7)
+    if (joystick_type != JOYSTICK_TYPE_NONE)
 	device_add(&gameport_device);
 
     laserxt_init(1);

--- a/src/machine/m_xt_xi8088.c
+++ b/src/machine/m_xt_xi8088.c
@@ -175,7 +175,7 @@ machine_xt_xi8088_init(const machine_t *model)
     nmi_init();
     device_add(&ibmat_nvr_device);
     pic2_init();
-    if (joystick_type != 7)
+    if (joystick_type != JOYSTICK_TYPE_NONE)
 	device_add(&gameport_device);
 
     return ret;

--- a/src/pc.c
+++ b/src/pc.c
@@ -767,7 +767,7 @@ pc_reset_hard_init(void)
     /* Reset and reconfigure the Network Card layer. */
     network_reset();
 
-    if (joystick_type != 7)
+    if (joystick_type != JOYSTICK_TYPE_NONE)
 	gameport_update_joystick_type();
 
     ui_sb_update_panes();

--- a/src/win/win_joystick_xinput.cpp
+++ b/src/win/win_joystick_xinput.cpp
@@ -216,7 +216,7 @@ void joystick_process(void)
 {
         int c, d;
 
-	if (joystick_type == 7) return;
+	if (joystick_type == JOYSTICK_TYPE_NONE) return;
 
         joystick_poll();
 

--- a/src/win/win_jsconf.c
+++ b/src/win/win_jsconf.c
@@ -59,6 +59,10 @@ static void rebuild_axis_button_selections(HWND hdlg)
                                 sprintf(s, "%s (Y axis)", plat_joystick_state[joystick-1].pov[d].name);
                                 SendMessage(h, CB_ADDSTRING, 0, (LPARAM)(LPCSTR)s);
                         }
+						for (d = 0; d < plat_joystick_state[joystick - 1].nr_sliders; d++)
+                        {
+                                SendMessage(h, CB_ADDSTRING, 0, (LPARAM)(LPCSTR)plat_joystick_state[joystick - 1].slider[d].name);
+                        }
                         SendMessage(h, CB_SETCURSEL, sel, 0);
                         EnableWindow(h, TRUE);
                 }
@@ -122,15 +126,23 @@ static int get_axis(HWND hdlg, int id)
         HWND h = GetDlgItem(hdlg, id);
         int axis_sel = SendMessage(h, CB_GETCURSEL, 0, 0);
         int nr_axes = plat_joystick_state[joystick_state[joystick_nr].plat_joystick_nr-1].nr_axes;
-
+		int nr_povs = plat_joystick_state[joystick_state[joystick_nr].plat_joystick_nr - 1].nr_povs;
+        int nr_sliders = plat_joystick_state[joystick_state[joystick_nr].plat_joystick_nr - 1].nr_sliders;
+		
         if (axis_sel < nr_axes)
                 return axis_sel;
         
         axis_sel -= nr_axes;
-        if (axis_sel & 1)
-                return POV_Y | (axis_sel >> 1);
-        else
-                return POV_X | (axis_sel >> 1);
+        if (axis_sel < nr_povs * 2)
+        {
+                if (axis_sel & 1)
+                        return POV_Y | (axis_sel >> 1);
+                else
+                        return POV_X | (axis_sel >> 1);
+        }
+        axis_sel -= nr_povs;
+
+        return SLIDER | (axis_sel >> 1);
 }
 
 static int get_pov(HWND hdlg, int id)
@@ -163,6 +175,7 @@ joystickconfig_dlgproc(HWND hdlg, UINT message, WPARAM wParam, LPARAM lParam)
 	int joystick;
 	int nr_axes;
 	int nr_povs;
+	int nr_sliders;
 	int mapping;
 
         switch (message)
@@ -186,6 +199,8 @@ joystickconfig_dlgproc(HWND hdlg, UINT message, WPARAM wParam, LPARAM lParam)
                         {
                                 nr_axes = plat_joystick_state[joystick-1].nr_axes;
                                 nr_povs = plat_joystick_state[joystick-1].nr_povs;
+								nr_sliders = plat_joystick_state[joystick - 1].nr_sliders;
+								
                                 for (c = 0; c < joystick_get_axis_count(joystick_config_type); c++)
                                 {
                                         int mapping = joystick_state[joystick_nr].axis_mapping[c];
@@ -195,7 +210,9 @@ joystickconfig_dlgproc(HWND hdlg, UINT message, WPARAM wParam, LPARAM lParam)
                                                 SendMessage(h, CB_SETCURSEL, nr_axes + (mapping & 3)*2, 0);
                                         else if (mapping & POV_Y)
                                                 SendMessage(h, CB_SETCURSEL, nr_axes + (mapping & 3)*2 + 1, 0);
-                                        else
+                                        else if (mapping & SLIDER)
+												SendMessage(h, CB_SETCURSEL, nr_axes + nr_povs * 2 + (mapping & 3), 0);										
+										else
                                                 SendMessage(h, CB_SETCURSEL, mapping, 0);
                                         id += 2;
                                 } 

--- a/src/win/win_settings.c
+++ b/src/win/win_settings.c
@@ -971,6 +971,7 @@ static BOOL CALLBACK
 win_settings_input_proc(HWND hdlg, UINT message, WPARAM wParam, LPARAM lParam)
 {
     wchar_t str[128];
+	char *joy_name;
     HWND h;
     int c, d;
 
@@ -1000,9 +1001,15 @@ win_settings_input_proc(HWND hdlg, UINT message, WPARAM wParam, LPARAM lParam)
 
 		h = GetDlgItem(hdlg, IDC_COMBO_JOYSTICK);
 		c = 0;
-		while (joystick_get_name(c)) {
-			SendMessage(h, CB_ADDSTRING, 0, win_get_string(2105 + c));
+		joy_name = joystick_get_name(c);
+		while (joy_name)
+		{
+			mbstowcs(str, joy_name, strlen(joy_name) + 1);
+			SendMessage(h, CB_ADDSTRING, 0, (LPARAM)str);
+
+			// SendMessage(h, CB_ADDSTRING, 0, win_get_string(2105 + c));
 			c++;
+			joy_name = joystick_get_name(c);
 		}
 		EnableWindow(h, TRUE);
 		SendMessage(h, CB_SETCURSEL, temp_joystick, 0);


### PR DESCRIPTION
Implemented use of DirectInput sliders.  They were previously lumped in with axis and then not read or used at all.

Lots of use of joystick_type == 7 or joystick_type != 7 to detect if the joystick_type was none.  Changed this to a define so it's easier to add more joystick types.

The text to enumerate the types of joysticks was contained in a numbered LPARAM sheet.  Switched to using the name listed in the joystick struct so it's easier to add more joystick types.

Joysticks with more than 32 buttons would overflow the plat_joystick_state button array.  Added overflow checks.

Added a 4 axis 4 button joystick type that Win98se can pick up as a generic 4 axis 4 button controller.  Probably other systems too, but I never tried.