### PR TITLE
Preliminary Intel Celeron (440BX) emulation

### DIFF
--- a/src/cpu_common/cpu.h
+++ b/src/cpu_common/cpu.h
@@ -80,6 +80,7 @@ enum {
     CPU_PENTIUMPRO,	/* 686 class CPUs */
     CPU_PENTIUM2,
     CPU_PENTIUM2D,
+    CPU_CELERON
 #endif
     CPU_MAX		/* Only really needed to close the enum in a way independent of the #ifdef's. */
 };


### PR DESCRIPTION
This adds preliminary emulation of the Covington and Mendocino cores, used in the Intel Celeron CPU.