### PR TITLE
ASUS P2B-LS board

### DIFF
--- a/src/machine/m_at_socket8.c
+++ b/src/machine/m_at_socket8.c
@@ -114,7 +114,7 @@ machine_at_6abx3_init(const machine_t *model)
     if (bios_only || !ret)
 	return ret;
 
-    machine_at_common_init(model);
+    machine_at_common_init_ex(model, 2);
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
@@ -131,6 +131,39 @@ machine_at_6abx3_init(const machine_t *model)
     // device_add(&w83977tf_device);
     // device_add(&intel_flash_bxt_device);
     // device_add(&sst_flash_29ee020_device);
+    device_add(&sst_flash_39sf020_device);
+
+    return ret;
+}
+
+
+int
+machine_at_p2bls_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear(L"roms/machines/p2bls/1014ls.003",
+			   0x000c0000, 262144, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_at_common_init_ex(model, 2);
+
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x06, PCI_CARD_NORMAL, 4, 1, 2, 3);
+    pci_register_slot(0x07, PCI_CARD_NORMAL, 3, 4, 1, 2);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL, 2, 3, 4, 1);
+    pci_register_slot(0x0C, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x09, PCI_CARD_NORMAL, 4, 1, 2, 3);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL, 3, 4, 1, 2);
+    pci_register_slot(0x04, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
+    pci_register_slot(0x01, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    device_add(&i440bx_device);
+    device_add(&piix4_device);
+    device_add(&keyboard_ps2_pci_device);
+    device_add(&w83977tf_device);
     device_add(&sst_flash_39sf020_device);
 
     return ret;

--- a/src/machine/machine.h
+++ b/src/machine/machine.h
@@ -306,6 +306,7 @@ extern int	machine_at_i440fx_init(const machine_t *);
 extern int	machine_at_s1668_init(const machine_t *);
 
 extern int	machine_at_6abx3_init(const machine_t *);
+extern int  machine_at_p2bls_init(const machine_t *);
 #endif
 
 /* m_at_t3100e.c */

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -238,6 +238,7 @@ const machine_t machines[] = {
     { "[Socket 8 FX] Tyan Titan-Pro ATX",	"tpatx",		{{"Intel", cpus_PentiumPro},  {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8, 1024,   8, 127,		machine_at_s1668_init, NULL			},
 
     { "[Slot 1 BX] Lucky Star 6ABX3",		"6abx3",		{{"Intel", cpus_PentiumII},   {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8, 1024,   8, 255,		machine_at_6abx3_init, NULL			},
+    { "[Slot 1 BX] ASUS P2B-LS",		"p2bls",		{{"Intel", cpus_PentiumII},   {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8, 1024,   8, 255,		machine_at_p2bls_init, NULL			},
 #endif
     { NULL,					NULL,			{{"",      0},                {"",    0},            {"",      0},           {"",         0},     {"",      0}},    0,                                                                                                    0,    0,   0,   0,				 NULL, NULL			}
 };


### PR DESCRIPTION
Slot 1 440BX board. coreboot supports this board but we're far from supporting coreboot itself.

* BIOS: [1014ls.003](https://ideafix.name/old/mb/asus/slot1/440bx/p2b-ls/1014ls003.zip) - beta BIOS from 2002
* Super IO: Winbond W83977EF (compatible with -TF)
* Flash: SST of some description
* Hardware monitor: Winbond W83781D on SMBus (not implemented, BIOS will complain, set all monitor entries to Ignore to fix it)
* Slot configuration decoded from coreboot [DSDT](https://github.com/coreboot/coreboot/blob/3b618bb/src/mainboard/asus/p2b-ls/dsdt.asl#L134) and [device tree](https://github.com/coreboot/coreboot/blob/2270a15/src/mainboard/asus/p2b-ls/devicetree.cb)