### PR TITLE
Export P2B-LS to non-dev builds

### DIFF
--- a/src/machine/machine.h
+++ b/src/machine/machine.h
@@ -311,8 +311,8 @@ extern int	machine_at_s1668_init(const machine_t *);
 #endif
 
 extern int	machine_at_6abx3_init(const machine_t *);
-#if defined(DEV_BRANCH) && defined(USE_I686) /*P2B-LS has no VIA C3 BIOS support, so further investigation may be needed*/
 extern int  machine_at_p2bls_init(const machine_t *);
+#if defined(DEV_BRANCH) && defined(USE_I686)
 extern int	machine_at_borapro_init(const machine_t *);
 
 extern int	machine_at_p6bxt_init(const machine_t *);


### PR DESCRIPTION
Fixes a compile error on non-dev builds.