### PR TITLE
Some compile fixes for clang. Still doesn't compile, but still :P

### DIFF
--- a/src/cpu_common/386_common.h
+++ b/src/cpu_common/386_common.h
@@ -19,6 +19,8 @@
 #ifndef _386_COMMON_H_
 #define _386_COMMON_H_
 
+#include <stddef.h>
+
 #ifdef USE_NEW_DYNAREC
 #define readmemb(s,a) ((readlookup2[(uint32_t)((s)+(a))>>12]==-1)?readmembl((s)+(a)): *(uint8_t *)(readlookup2[(uint32_t)((s)+(a))>>12] + (uint32_t)((s) + (a))) )
 #define readmemw(s,a) ((readlookup2[(uint32_t)((s)+(a))>>12]==-1 || (((s)+(a)) & 1))?readmemwl((s)+(a)):*(uint16_t *)(readlookup2[(uint32_t)((s)+(a))>>12]+(uint32_t)((s)+(a))))

--- a/src/cpu_new/codegen.h
+++ b/src/cpu_new/codegen.h
@@ -2,6 +2,7 @@
 #define _CODEGEN_H_
 
 #include <86box/mem.h>
+#include <stddef.h>
 #include "../cpu_common/x86_ops.h"
 
 /*Handling self-modifying code (of which there is a lot on x86) :


### PR DESCRIPTION
The main compile failures are due to MuNT and undefined references now :P