### PR TITLE
Enable New Dynarec on Windows ARM

### DIFF
--- a/src/cpu_common/x87_ops.h
+++ b/src/cpu_common/x87_ops.h
@@ -411,7 +411,7 @@ static __inline uint16_t x87_compare(double a, double b)
 
 static __inline uint16_t x87_ucompare(double a, double b)
 {
-#if defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined WIN32 || defined _WIN32 || defined _WIN32 || defined __amd64__
+#if defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86 || defined _M_AMD64 || defined __amd64__
         uint32_t result;
         
 #ifndef _MSC_VER

--- a/src/cpu_new/codegen_allocator.c
+++ b/src/cpu_new/codegen_allocator.c
@@ -112,7 +112,7 @@ uint8_t *codeblock_allocator_get_ptr(mem_block_t *block)
 
 void codegen_allocator_clean_blocks(struct mem_block_t *block)
 {
-#if defined __ARM_EABI__ || defined __aarch64__
+#if defined __ARM_EABI__ || defined _ARM_ || defined __aarch64__
         while (1)
         {
 		__clear_cache(&mem_block_alloc[block->offset], &mem_block_alloc[block->offset + MEM_BLOCK_SIZE]);

--- a/src/cpu_new/codegen_allocator.h
+++ b/src/cpu_new/codegen_allocator.h
@@ -13,7 +13,7 @@
   Due to the chaining, the total memory size is limited by the range of a jump
   instruction. ARMv7 is restricted to +/- 32 MB, ARMv8 to +/- 128 MB, x86 to
   +/- 2GB. As a result, total memory size is limited to 32 MB on ARMv7*/
-#ifdef __ARM_EABI__
+#if defined __ARM_EABI__ || _ARM_
 #define MEM_BLOCK_NR 32768
 #else
 #define MEM_BLOCK_NR 131072

--- a/src/cpu_new/codegen_backend.h
+++ b/src/cpu_new/codegen_backend.h
@@ -3,7 +3,7 @@
 
 #if defined __amd64__
 #include "codegen_backend_x86-64.h"
-#elif defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined WIN32 || defined _WIN32 || defined _WIN32
+#elif defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86
 #include "codegen_backend_x86.h"
 #elif defined __ARM_EABI__
 #include "codegen_backend_arm.h"

--- a/src/cpu_new/codegen_backend.h
+++ b/src/cpu_new/codegen_backend.h
@@ -5,7 +5,7 @@
 #include "codegen_backend_x86-64.h"
 #elif defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86
 #include "codegen_backend_x86.h"
-#elif defined __ARM_EABI__
+#elif defined __ARM_EABI__ || defined _ARM_
 #include "codegen_backend_arm.h"
 #elif defined __aarch64__
 #include "codegen_backend_arm64.h"

--- a/src/cpu_new/codegen_backend_arm.c
+++ b/src/cpu_new/codegen_backend_arm.c
@@ -1,4 +1,4 @@
-#ifdef __ARM_EABI__
+#if defined __ARM_EABI__ || defined _ARM_
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/cpu_new/codegen_backend_arm_ops.c
+++ b/src/cpu_new/codegen_backend_arm_ops.c
@@ -1,4 +1,4 @@
-#ifdef __ARM_EABI__
+#if defined __ARM_EABI__ || defined _ARM_
 
 #include <stdint.h>
 #include <86box/86box.h>

--- a/src/cpu_new/codegen_backend_arm_uops.c
+++ b/src/cpu_new/codegen_backend_arm_uops.c
@@ -1,4 +1,4 @@
-#ifdef __ARM_EABI__
+#if defined __ARM_EABI__ || defined _ARM_
 
 #include <math.h>
 #include <stdint.h>

--- a/src/cpu_new/codegen_backend_x86.c
+++ b/src/cpu_new/codegen_backend_x86.c
@@ -1,4 +1,4 @@
-#if defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined WIN32 || defined _WIN32 || defined _WIN32
+#if defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86
 
 #include <stddef.h>
 #include <stdint.h>

--- a/src/cpu_new/codegen_backend_x86_ops.c
+++ b/src/cpu_new/codegen_backend_x86_ops.c
@@ -1,4 +1,4 @@
-#if defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined WIN32 || defined _WIN32 || defined _WIN32
+#if defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86
 
 #include <stdint.h>
 #include <86box/86box.h>

--- a/src/cpu_new/codegen_backend_x86_ops_fpu.c
+++ b/src/cpu_new/codegen_backend_x86_ops_fpu.c
@@ -1,4 +1,4 @@
-#if defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined WIN32 || defined _WIN32 || defined _WIN32
+#if defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86
 
 #include <stdint.h>
 #include <86box/86box.h>

--- a/src/cpu_new/codegen_backend_x86_ops_sse.c
+++ b/src/cpu_new/codegen_backend_x86_ops_sse.c
@@ -1,4 +1,4 @@
-#if defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined WIN32 || defined _WIN32 || defined _WIN32
+#if defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86
 
 #include <stdint.h>
 #include <86box/86box.h>

--- a/src/cpu_new/codegen_backend_x86_uops.c
+++ b/src/cpu_new/codegen_backend_x86_uops.c
@@ -1,4 +1,4 @@
-#if defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined WIN32 || defined _WIN32 || defined _WIN32
+#if defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86
 
 #include <stdint.h>
 #include <86box/86box.h>

--- a/src/win/Makefile_ndr.mingw
+++ b/src/win/Makefile_ndr.mingw
@@ -215,12 +215,6 @@ MUNT		:= y
 endif
 ifndef DYNAREC
  DYNAREC		:= y
- ifeq ($(ARM), y)
-  DYNAREC		:= n
- endif
- ifeq ($(ARM64), y)
-  DYNAREC   := n
- endif
 endif
 ifndef DISCORD
  DISCORD	:= y
@@ -374,6 +368,11 @@ ifeq ($(DYNAREC), y)
 ifeq ($(X64), y)
 PLATCG		:= codegen_backend_x86-64.o codegen_backend_x86-64_ops.o codegen_backend_x86-64_ops_sse.o \
 		   codegen_backend_x86-64_uops.o
+else ifeq ($(ARM64), y)
+PLATCG      := codegen_backend_arm64.o codegen_backend_arm64_ops.o codegen_backend_arm64_uops.o \
+            codegen_backend_arm64_imm.o
+else ifeq ($(ARM), y)
+PLATCG      := codegen_backend_arm.o codegen_backend_arm_ops.o codegen_backend_arm_uops.o
 else
 PLATCG		:= codegen_backend_x86.o codegen_backend_x86_ops.o codegen_backend_x86_ops_fpu.o codegen_backend_x86_ops_sse.o \
 		   codegen_backend_x86_uops.o


### PR DESCRIPTION
Enable new dynarec to build for Windows ARM with Clang/LLVM/MinGW.
Still buggy and crashy when run, but this is a beginning.