### PR TITLE
Dynarec: Move CR0 into cpu_state

### DIFF
--- a/src/cpu_common/cpu.c
+++ b/src/cpu_common/cpu.c
@@ -173,7 +173,7 @@ int		hasfpu;
 
 uint64_t	tsc = 0;
 msr_t		msr;
-cr0_t		CR0;
+cpu_state_t     cpu_state;
 uint64_t	pmc[2] = {0, 0};
 
 uint16_t	temp_seg_data[4] = {0, 0, 0, 0};

--- a/src/cpu_common/cpu.h
+++ b/src/cpu_common/cpu.h
@@ -233,7 +233,7 @@ typedef union {
 } cr0_t;
 
 
-struct _cpustate_ {
+typedef struct {
     x86reg	regs[8];
 
     uint8_t	tag[8];
@@ -299,7 +299,9 @@ struct _cpustate_ {
 		seg_gs;
 
     uint16_t flags, eflags;
-} cpu_state;
+
+    cr0_t CR0;
+} cpu_state_t;
 
 /*The cpu_state.flags below must match in both cpu_cur_status and block->status for a block
   to be valid*/
@@ -409,6 +411,7 @@ extern uint32_t		cpu_cur_status;
 extern uint64_t		cpu_CR4_mask;
 extern uint64_t		tsc;
 extern msr_t		msr;
+extern cpu_state_t  cpu_state;
 extern uint8_t		opcode;
 extern int		insc;
 extern int		fpucount;
@@ -436,9 +439,8 @@ extern uint64_t		star;
 
 #define FPU_CW_Reserved_Bits (0xe0c0)
 
-extern cr0_t		CR0;
-#define cr0		CR0.l
-#define msw		CR0.w
+#define cr0		cpu_state.CR0.l
+#define msw		cpu_state.CR0.w
 extern uint32_t		cr2, cr3, cr4;
 extern uint32_t		dr[8];
 


### PR DESCRIPTION
Some dynarec backends (x86-64, arm64) expect the offset between cpu_state and CR0 to within a certain limit, otherwise they crashes (e.g: "host_x86_MOV64_REG_ABS - out of range").
Move CR0 to the end of cpu_state, make sure the offset is within limit.

Helps NT4 and Win95 with dynarec on.