### PR TITLE
Re-enable VNC on dev builds with new dynarec

### DIFF
--- a/src/win/Makefile_ndr.mingw
+++ b/src/win/Makefile_ndr.mingw
@@ -93,7 +93,7 @@ ifeq ($(DEV_BUILD), y)
   VGAWONDER	:= y
  endif
  ifndef VNC
-  VNC		:= n
+  VNC		:= y
  endif
  ifndef XL24
   XL24		:= y


### PR DESCRIPTION
It's only enabled on old dynarec for some reason.