### PR TITLE
Add the ECS P6KFX-A, a 440FX Slot 1 machine.

### DIFF
--- a/src/cpu_common/cpu.h
+++ b/src/cpu_common/cpu.h
@@ -145,6 +145,7 @@ extern CPU	cpus_6x86SS7[];
 #endif
 extern CPU	cpus_Cyrix3[];
 extern CPU	cpus_PentiumPro[];
+extern CPU	cpus_PentiumII_28v[];
 extern CPU	cpus_PentiumII[];
 extern CPU	cpus_Celeron[];
 

--- a/src/cpu_common/cpu_table.c
+++ b/src/cpu_common/cpu_table.c
@@ -686,6 +686,18 @@ CPU cpus_PentiumPro[] = {
     {"Pentium II Overdrive 333",    CPU_PENTIUM2D,  333333333, 5.0, 0x1632, 0x1632, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC, 27,27,13,13, 40},
     {"",                                       -1,          0, 0,   0,      0,      0, 0,  0, 0, 0, 0,  0}
 };
+CPU cpus_PentiumII_28v[] = {
+    /*Intel Pentium II Klamath*/
+    {"Pentium II Klamath 50",        CPU_PENTIUM2,   50000000, 1.0,  0x634,  0x634, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC,  4, 4, 3, 3, 6},
+    {"Pentium II Klamath 60",        CPU_PENTIUM2,   60000000, 1.0,  0x634,  0x634, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC,  6, 6, 3, 3, 7},
+    {"Pentium II Klamath 66",        CPU_PENTIUM2,   66666666, 1.0,  0x634,  0x634, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC,  6, 6, 3, 3, 8},
+    {"Pentium II Klamath 75",        CPU_PENTIUM2,   75000000, 1.5,  0x634,  0x634, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC,  7, 7, 4, 4, 9},
+    {"Pentium II Klamath 233",       CPU_PENTIUM2,  233333333, 3.5,  0x634,  0x634, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC, 21,21,10,10, 28},
+    {"Pentium II Klamath 266",       CPU_PENTIUM2,  266666666, 4.0,  0x634,  0x634, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC, 24,24,12,12, 32},
+    {"Pentium II Klamath 300/66",    CPU_PENTIUM2,  300000000, 4.5,  0x634,  0x634, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC, 25,25,12,12, 36},
+    {"",                                       -1,          0, 0,        0,      0, 0, 0,  0, 0, 0, 0,  0}
+
+};
 
 CPU cpus_PentiumII[] = {
     /*Intel Pentium II Klamath*/
@@ -694,7 +706,7 @@ CPU cpus_PentiumII[] = {
     {"Pentium II Klamath 66",        CPU_PENTIUM2,   66666666, 1.0,  0x634,  0x634, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC,  6, 6, 3, 3, 8},
     {"Pentium II Klamath 75",        CPU_PENTIUM2,   75000000, 1.5,  0x634,  0x634, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC,  7, 7, 4, 4, 9},
     {"Pentium II Klamath 233",       CPU_PENTIUM2,  233333333, 3.5,  0x634,  0x634, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC, 21,21,10,10, 28},
-    {"Pentium II Klamath 266",       CPU_PENTIUM2,  266666666, 4.0,  0x634,  0x634, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC, 24,24,12,12, 29},
+    {"Pentium II Klamath 266",       CPU_PENTIUM2,  266666666, 4.0,  0x634,  0x634, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC, 24,24,12,12, 32},
     {"Pentium II Klamath 300/66",    CPU_PENTIUM2,  300000000, 4.5,  0x634,  0x634, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC, 25,25,12,12, 36},
 
     /*Intel Pentium II Deschutes*/
@@ -702,7 +714,7 @@ CPU cpus_PentiumII[] = {
     {"Pentium II Deschutes 60",     CPU_PENTIUM2D,   60000000, 1.0,  0x652,  0x652, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC,  6, 6, 3, 3, 7},
     {"Pentium II Deschutes 66",     CPU_PENTIUM2D,   66666666, 1.0,  0x652,  0x652, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC,  6, 6, 3, 3, 8},
     {"Pentium II Deschutes 75",     CPU_PENTIUM2D,   75000000, 1.5,  0x652,  0x652, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC,  7, 7, 4, 4, 9},
-    {"Pentium II Deschutes 266",    CPU_PENTIUM2D,  266666666, 4.0,  0x652,  0x652, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC, 24,24,12,12, 29},
+    {"Pentium II Deschutes 266",    CPU_PENTIUM2D,  266666666, 4.0,  0x652,  0x652, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC, 24,24,12,12, 32},
     {"Pentium II Deschutes 300/66", CPU_PENTIUM2D,  300000000, 4.5,  0x651,  0x651, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC, 25,25,12,12, 36},
     {"Pentium II Deschutes 333",    CPU_PENTIUM2D,  333333333, 5.0,  0x651,  0x651, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC, 27,27,13,13, 40},
     {"Pentium II Deschutes 350",    CPU_PENTIUM2D,  350000000, 3.5,  0x651,  0x651, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC, 32,32,11,11, 42},

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -319,6 +319,8 @@ extern int	machine_at_8500ttc_init(const machine_t *);
 extern int	machine_at_m6mi_init(const machine_t *);
 
 /* m_at_slot1.c */
+extern int  machine_at_p6kfx_init(const machine_t *);
+
 extern int	machine_at_6bxc_init(const machine_t *);
 extern int  machine_at_p2bls_init(const machine_t *);
 extern int	machine_at_bf6_init(const machine_t *);

--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -39,6 +39,35 @@
 #include <86box/video.h>
 #include "cpu.h"
 #include <86box/machine.h>
+int
+machine_at_p6kfx_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear(L"roms/machines/p6kfx/kfxa22.bin",
+			   0x000e0000, 131072, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_at_common_init(model);
+
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x09, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL, 2, 3, 4, 1);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL, 3, 4, 1, 2);
+    pci_register_slot(0x0C, PCI_CARD_NORMAL, 4, 1, 2, 3);
+    pci_register_slot(0x0D, PCI_CARD_NORMAL, 4, 1, 2, 3);
+    device_add(&i440fx_device);
+    device_add(&piix3_device);
+    device_add(&keyboard_ps2_ami_pci_device); /*Didn't post with regular PS/2 PCI*/
+    device_add(&w83877f_device);
+    device_add(&intel_flash_bxt_device);
+
+    return ret;
+}
 
 int
 machine_at_6bxc_init(const machine_t *model)

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -262,8 +262,10 @@ const machine_t machines[] = {
     { "[Socket 8 FX] PC Partner MB600N",	"mb600n",		{{"Intel", cpus_PentiumPro},  {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8, 512,   8, 127,		   machine_at_mb600n_init, NULL			},
     { "[Socket 8 FX] Biostar MB-8500ttc",	"8500ttc",		{{"Intel", cpus_PentiumPro},  {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8, 512,   8, 127,		   machine_at_8500ttc_init, NULL		},
     { "[Socket 8 FX] Micronics M6MI",		"m6mi",			{{"Intel", cpus_PentiumPro},  {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8, 384,   8, 127,	       machine_at_m6mi_init, NULL			},
-	
+    
 	//Slot 1 machines
+    { "[Slot 1 FX] ECS P6KFX-A",		"p6kfx",		{{"Intel", cpus_PentiumII_28v},{"",    NULL},        {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					   8, 384,   8, 127,	        machine_at_p6kfx_init, NULL			},
+
     { "[Slot 1 BX] Gigabyte GA-6BXC",		"6bxc",			{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"",      NULL},{"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			  		  8,  768,   8, 255,		 machine_at_6bxc_init, NULL			},
     { "[Slot 1 BX] ASUS P2B-LS",		"p2bls",		{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"",      NULL},{"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8, 1024,   8, 255,		machine_at_p2bls_init, NULL			},
     { "[Slot 1 BX] ABit BF6",			"bf6",			{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"",      NULL},{"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			  		  8,  768,   8, 255,		  machine_at_bf6_init, NULL			},


### PR DESCRIPTION
Adds the ECS P6KFX-A as well as appropriate CPU tables for an early Slot 1 motherboard without Deschutes or 100 MHz FSB support. Also fixes a minor bug with 266 MHz Pentium IIs and ISA clock frequencies.