### PR TITLE
Set Link State from VBox to 86Box implemented on the PCnet card (any …

### DIFF
--- a/src/include/86box/network.h
+++ b/src/include/86box/network.h
@@ -66,6 +66,7 @@ enum {
 
 typedef void (*NETRXCB)(void *, uint8_t *, int);
 typedef int (*NETWAITCB)(void *);
+typedef int (*NETSETLINKSTATE)(void *);
 
 
 typedef struct {
@@ -76,6 +77,7 @@ typedef struct {
     int			(*poll)(void *);
     NETRXCB		rx;
     NETWAITCB		wait;
+    NETSETLINKSTATE	set_link_state;
 } netcard_t;
 
 typedef struct {
@@ -101,7 +103,7 @@ extern void	network_busy(uint8_t set);
 extern void	network_end(void);
 
 extern void	network_init(void);
-extern void	network_attach(void *, uint8_t *, NETRXCB, NETWAITCB);
+extern void	network_attach(void *, uint8_t *, NETRXCB, NETWAITCB, NETSETLINKSTATE);
 extern void	network_close(void);
 extern void	network_reset(void);
 extern int	network_available(void);

--- a/src/network/net_3c503.c
+++ b/src/network/net_3c503.c
@@ -617,7 +617,7 @@ threec503_nic_init(const device_t *info)
     dev->regs.gacfr = 0x09;	/* Start with RAM mapping enabled. */
 
     /* Attach ourselves to the network module. */
-    network_attach(dev->dp8390, dev->dp8390->physaddr, dp8390_rx, NULL);
+    network_attach(dev->dp8390, dev->dp8390->physaddr, dp8390_rx, NULL, NULL);
 
     return(dev);
 }

--- a/src/network/net_ne2000.c
+++ b/src/network/net_ne2000.c
@@ -1469,7 +1469,7 @@ nic_init(const device_t *info)
 	nic_reset(dev);
 
     /* Attach ourselves to the network module. */
-    network_attach(dev->dp8390, dev->dp8390->physaddr, dp8390_rx, NULL);
+    network_attach(dev->dp8390, dev->dp8390->physaddr, dp8390_rx, NULL, NULL);
 
     nelog(1, "%s: %s attached IO=0x%X IRQ=%d\n", dev->name,
 	dev->is_pci?"PCI":"ISA", dev->base_address, dev->base_irq);

--- a/src/network/net_pcap.c
+++ b/src/network/net_pcap.c
@@ -184,7 +184,7 @@ poll_thread(void *arg)
 	if (pcap == NULL) break;
 
 	/* Wait for the next packet to arrive. */
-	if (network_get_wait() || (poll_card->wait && poll_card->wait(poll_card->priv)))
+	if (network_get_wait() || (poll_card->set_link_state && poll_card->set_link_state(poll_card->priv)) || (poll_card->wait && poll_card->wait(poll_card->priv)))
 		data = NULL;
 	else
 		data = (uint8_t *)f_pcap_next((void *)pcap, &h);

--- a/src/network/net_slirp.c
+++ b/src/network/net_slirp.c
@@ -147,7 +147,7 @@ poll_thread(void *arg)
 	/* Wait for the next packet to arrive. */
 	data_valid = 0;
 
-	if ((!network_get_wait() && !(poll_card->wait && poll_card->wait(poll_card->priv))) && (QueuePeek(slirpq) != 0)) {
+	if ((!network_get_wait() && !(poll_card->set_link_state && poll_card->set_link_state(poll_card->priv)) && !(poll_card->wait && poll_card->wait(poll_card->priv))) && (QueuePeek(slirpq) != 0)) {
 		/* Grab a packet from the queue. */
 		// ui_sb_update_icon(SB_NETWORK, 1);
 

--- a/src/network/net_wd8003.c
+++ b/src/network/net_wd8003.c
@@ -771,7 +771,7 @@ wd_init(const device_t *info)
     mem_mapping_disable(&dev->ram_mapping);		
 
     /* Attach ourselves to the network module. */
-    network_attach(dev->dp8390, dev->dp8390->physaddr, dp8390_rx, NULL);
+    network_attach(dev->dp8390, dev->dp8390->physaddr, dp8390_rx, NULL, NULL);
 
     if (!(dev->board_chip & WE_ID_BUS_MCA)) {
 	wdlog("%s: attached IO=0x%X IRQ=%d, RAM addr=0x%06x\n", dev->name,

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -223,7 +223,7 @@ network_init(void)
  * modules.
  */
 void
-network_attach(void *dev, uint8_t *mac, NETRXCB rx, NETWAITCB wait)
+network_attach(void *dev, uint8_t *mac, NETRXCB rx, NETWAITCB wait, NETSETLINKSTATE set_link_state)
 {
     if (network_card == 0) return;
 
@@ -231,6 +231,7 @@ network_attach(void *dev, uint8_t *mac, NETRXCB rx, NETWAITCB wait)
     net_cards[network_card].priv = dev;
     net_cards[network_card].rx = rx;
     net_cards[network_card].wait = wait;
+    net_cards[network_card].set_link_state = set_link_state;
     network_mac = mac;
 
     network_set_wait(0);


### PR DESCRIPTION
…other nics don't have it and will simply return NULL).

The PCnet-based Racal nic now has its own OID to make its drivers happy (according to VBox).