### PR TITLE
Dynamically load Win7+ APIs

### DIFF
--- a/src/win/win.c
+++ b/src/win/win.c
@@ -19,7 +19,6 @@
  *		Copyright 2017-2019 Fred N. van Kempen.
  */
 #define UNICODE
-#define NTDDI_VERSION 0x06010000
 #include <windows.h>
 #include <shlobj.h>
 #include <shobjidl.h>
@@ -334,6 +333,24 @@ ProcessCommandLine(wchar_t ***argw)
     return(argc);
 }
 
+HRESULT _SetCurrentProcessExplicitAppUserModelID(PCWSTR AppID) {
+    typedef HRESULT (WINAPI *func_t)(PCWSTR);
+    HRESULT result = E_NOTIMPL;
+
+    func_t func = NULL;
+    HINSTANCE hInst = LoadLibrary(L"shell32.dll");
+    if (hInst == NULL) goto end;
+
+    func = (func_t)GetProcAddress(hInst, "SetCurrentProcessExplicitAppUserModelID");
+    if (func == NULL) goto end;
+
+    result = func(AppID);
+    goto end;
+
+end:
+    FreeLibrary(hInst);
+    return result;
+}
 
 /* For the Windows platform, this is the start of the application. */
 int WINAPI
@@ -343,7 +360,7 @@ WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR lpszArg, int nCmdShow)
     int	argc, i;
     wchar_t * AppID = L"86Box.86Box\0";
 
-    SetCurrentProcessExplicitAppUserModelID(AppID);
+    _SetCurrentProcessExplicitAppUserModelID(AppID);
 
     /* Set this to the default value (windowed mode). */
     video_fullscreen = 0;


### PR DESCRIPTION
This makes it possible to build 86Box to run on Windows XP again.

Note:
If compile on MSYS2, you'll need to [downgrade winpthread to a version that supports XP](https://github.com/msys2/MINGW-packages/issues/5139#issuecomment-510575800).
And then dynamically link OpenAL (and dynamically links to the downgrade winpthread DLL), or build OpenAL again and use static library.