### PR TITLE
Fix the close button of about dialog not working.

### DIFF
--- a/src/win/win_about.c
+++ b/src/win/win_about.c
@@ -53,6 +53,7 @@ AboutDialogProcedure(HWND hdlg, UINT message, WPARAM wParam, LPARAM lParam)
 	case WM_COMMAND:
                 switch (LOWORD(wParam)) {
 			case IDOK:
+			case IDCANCEL:
 				EndDialog(hdlg, 0);
 				plat_pause(0);
 				return TRUE;


### PR DESCRIPTION
Now when click the close button, the about dialog won't close.
We should handle the 'IDCANCEL' command, which is associated with the close button.