### PR TITLE
Dev branch all machines with missing SIO chips + added the VS440FX

### DIFF
--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -33,12 +33,14 @@
 #include <86box/intel_sio.h>
 #include <86box/piix.h>
 #include <86box/sio.h>
+#include <86box/intel_sio.h>
 #include <86box/sst_flash.h>
 #include <86box/hwm.h>
 #include <86box/spd.h>
 #include <86box/video.h>
 #include "cpu.h"
 #include <86box/machine.h>
+
 int
 machine_at_p6kfx_init(const machine_t *model)
 {
@@ -69,6 +71,7 @@ machine_at_p6kfx_init(const machine_t *model)
     return ret;
 }
 
+#if defined(DEV_BRANCH) && defined(NO_SIO)
 int
 machine_at_6bxc_init(const machine_t *model)
 {
@@ -93,12 +96,13 @@ machine_at_6bxc_init(const machine_t *model)
     device_add(&i440bx_device);
     device_add(&piix4e_device);
     device_add(&keyboard_ps2_pci_device);
-    device_add(&um8669f_device); /*Placeholder for ITE 8671*/
+    device_add(&um8669f_device); /*ITE 8671*/
     device_add(&sst_flash_39sf020_device);
     spd_register(SPD_TYPE_SDRAM, 0xF, 256);    
 
     return ret;
 }
+#endif
 
 int
 machine_at_p2bls_init(const machine_t *model)

--- a/src/machine/m_at_socket7_s7.c
+++ b/src/machine/m_at_socket7_s7.c
@@ -549,6 +549,7 @@ machine_at_pb680_init(const machine_t *model)
     return ret;
 }
 
+#if defined(DEV_BRANCH) && defined(NO_SIO)
 int
 machine_at_p55xb2_init(const machine_t *model)
 {
@@ -577,7 +578,7 @@ machine_at_p55xb2_init(const machine_t *model)
 
     return ret;
 }
-
+#endif
 
 int
 machine_at_tx97_init(const machine_t *model)
@@ -702,7 +703,7 @@ machine_at_ym430tx_init(const machine_t *model)
     return ret;
 }
 
-
+#if defined(DEV_BRANCH) && defined(NO_SIO)
 int
 machine_at_586t2_init(const machine_t *model)
 {
@@ -796,7 +797,7 @@ machine_at_807ds_init(const machine_t *model)
 
     return ret;
 }
-
+#endif
 
 int
 machine_at_p5mms98_init(const machine_t *model)
@@ -862,6 +863,7 @@ machine_at_p5mms98_init(const machine_t *model)
     return ret;
 }
 
+#if defined(DEV_BRANCH) && defined(NO_SIO)
 int
 machine_at_tx100_init(const machine_t *model)
 {
@@ -920,3 +922,4 @@ machine_at_advanceii_init(const machine_t *model)
 
     return ret;
 }
+#endif

--- a/src/machine/m_at_socket8.c
+++ b/src/machine/m_at_socket8.c
@@ -157,3 +157,35 @@ machine_at_m6mi_init(const machine_t *model)
 
     return ret;
 }
+
+#if defined(DEV_BRANCH) && defined(NO_SIO)
+int
+machine_at_vs440fx_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear_combined2(L"roms/machines/vs440fx/1011CS1_.BIO",
+				     L"roms/machines/vs440fx/1011CS1_.BI1",
+				     L"roms/machines/vs440fx/1011CS1_.BI2",
+				     L"roms/machines/vs440fx/1011CS1_.BI3",
+				     L"roms/machines/vs440fx/1011CS1_.RCV",
+				     0x3a000, 128);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_at_common_init(model);
+
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 0);
+    device_add(&i440fx_device);
+    device_add(&piix3_device);
+    device_add(&keyboard_ps2_ami_pci_device);
+    //device_add(&pc87307_device);
+	device_add(&pc87306_device);
+    device_add(&intel_flash_bxt_ami_device);
+
+    return ret;
+}
+#endif

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -254,18 +254,24 @@ const machine_t machines[] = {
 
     /* 430TX */
     { "[Socket 7 TX] ASUS TX97",		"tx97",			MACHINE_CPUS_PENTIUM_S7,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  256,   8, 255,	         machine_at_tx97_init, NULL			},
+#if defined(DEV_BRANCH) && defined(NO_SIO)
     { "[Socket 7 TX] Gigabyte GA-586T2",        "586t2",		MACHINE_CPUS_PENTIUM_S7,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  256,   8, 255,	        machine_at_586t2_init, NULL			},
+#endif
     { "[Socket 7 TX] Intel YM430TX",		"ym430tx",		MACHINE_CPUS_PENTIUM_S7,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  256,   8, 255,	      machine_at_ym430tx_init, NULL			},
+#if defined(DEV_BRANCH) && defined(NO_SIO)
     { "[Socket 7 TX] Iwill P55XB2",		"p55xb2",		MACHINE_CPUS_PENTIUM_S7,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  256,   8, 255,	       machine_at_p55xb2_init, NULL			},
     { "[Socket 7 TX] PC Partner TXA807DS",	"807ds",		MACHINE_CPUS_PENTIUM_S7,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  256,   8, 255,	        machine_at_807ds_init, NULL			},
+#endif
     { "[Socket 7 TX] SuperMicro P5MMS98",	"p5mms98",		MACHINE_CPUS_PENTIUM_S7,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  256,   8, 255,	      machine_at_p5mms98_init, NULL			},
 
+#if defined(DEV_BRANCH) && defined(NO_SIO)
     /* Apollo VPX */
     { "[Socket 7 VPX] Zida Tomato TX100",	"tx100",		MACHINE_CPUS_PENTIUM_S7,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8,  512,   8, 127,	        machine_at_tx100_init, NULL			},
 
     /* Apollo VP3 */
     { "[Socket 7 VP3] QDI Advance II",		"advanceii",		MACHINE_CPUS_PENTIUM_S7,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8,  128,   8, 127,	    machine_at_advanceii_init, NULL			},
-    
+#endif
+  
     /* Super Socket 7 machines */
     /* Apollo MVP3 */
     { "[Super 7 MVP3] AOpen AX59 Pro",		"ax59pro",		MACHINE_CPUS_PENTIUM_SS7,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8, 1024,  8, 255,	      machine_at_ax59pro_init, NULL			},
@@ -277,6 +283,9 @@ const machine_t machines[] = {
     { "[Socket 8 FX] PC Partner MB600N",	"mb600n",		{{"Intel", cpus_PentiumPro},  {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  512,   8, 127,	       machine_at_mb600n_init, NULL			},
     { "[Socket 8 FX] Biostar MB-8500ttc",	"8500ttc",		{{"Intel", cpus_PentiumPro},  {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  512,   8, 127,	      machine_at_8500ttc_init, NULL			},
     { "[Socket 8 FX] Micronics M6MI",		"m6mi",			{{"Intel", cpus_PentiumPro},  {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  384,   8, 127,	         machine_at_m6mi_init, NULL			},
+#if defined(DEV_BRANCH) && defined(NO_SIO)
+    { "[Socket 8 FX] Intel Venus",			"vs440fx",		{{"Intel", cpus_PentiumPro},  {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  256,   8, 127,	         machine_at_vs440fx_init, NULL		},
+#endif
 
     /* Slot 1 machines */
     /* 440FX */
@@ -285,7 +294,9 @@ const machine_t machines[] = {
     /* 440LX */
 
     /* 440BX */
+#if defined(DEV_BRANCH) && defined(NO_SIO)
     { "[Slot 1 BX] Gigabyte GA-6BXC",		"6bxc",			{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"",      NULL},{"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			  		  8,  768,   8, 255,		 machine_at_6bxc_init, NULL			},
+#endif
     { "[Slot 1 BX] ASUS P2B-LS",		"p2bls",		{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"",      NULL},{"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8, 1024,   8, 255,		machine_at_p2bls_init, NULL			},
     { "[Slot 1 BX] ASUS P3B-F",			"p3bf",			{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"",      NULL},{"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8, 1024,   8, 255,		 machine_at_p3bf_init, NULL			},
     { "[Slot 1 BX] ABit BF6",			"bf6",			{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"",      NULL},{"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			  		  8,  768,   8, 255,		  machine_at_bf6_init, NULL			},

--- a/src/win/Makefile.mingw
+++ b/src/win/Makefile.mingw
@@ -92,6 +92,9 @@ ifeq ($(DEV_BUILD), y)
  ifndef XL24
   XL24		:= y
  endif
+ ifndef NO_SIO
+  NO_SIO	:= y
+ endif
 else
  ifndef DEBUG
   DEBUG		:= n
@@ -149,6 +152,9 @@ else
  endif
  ifndef XL24
   XL24		:= n
+ endif
+ ifndef NO_SIO
+  NO_SIO	:= n
  endif
 endif
 
@@ -482,6 +488,10 @@ endif
 
 ifeq ($(XL24), y)
 OPTS		+= -DUSE_XL24
+endif
+
+ifeq ($(NO_SIO), y)
+OPTS		+= -DNO_SIO
 endif
 
 endif

--- a/src/win/Makefile_ndr.mingw
+++ b/src/win/Makefile_ndr.mingw
@@ -92,6 +92,9 @@ ifeq ($(DEV_BUILD), y)
  ifndef XL24
   XL24		:= y
  endif
+ ifndef NO_SIO
+  NO_SIO	:= y
+ endif
 else
  ifndef DEBUG
   DEBUG		:= n
@@ -152,6 +155,9 @@ else
  endif
  ifndef XL24
   XL24		:= n
+ endif
+ ifndef NO_SIO
+  NO_SIO	:= n
  endif
 endif
 
@@ -491,6 +497,10 @@ endif
 
 ifeq ($(XL24), y)
 OPTS		+= -DUSE_XL24
+endif
+
+ifeq ($(NO_SIO), y)
+OPTS		+= -DNO_SIO
 endif
 
 endif


### PR DESCRIPTION
This board returns D4 POST with no output. Needs further examination. Meant for the future PC87307 implementation.

Also all boards that miss their SIO chips got Dev Branched just in case 2.10 gets released while some miss their SIO.