### PR TITLE
SuperMicro WinBios 440LX & 440BX + Slot 2 440GX bringup

### DIFF
--- a/src/cpu_common/cpu.h
+++ b/src/cpu_common/cpu.h
@@ -147,6 +147,7 @@ extern CPU	cpus_Cyrix3[];
 extern CPU	cpus_PentiumPro[];
 extern CPU	cpus_PentiumII_28v[];
 extern CPU	cpus_PentiumII[];
+extern CPU	cpus_Xeon[];
 extern CPU	cpus_Celeron[];
 
 

--- a/src/cpu_common/cpu_table.c
+++ b/src/cpu_common/cpu_table.c
@@ -720,11 +720,15 @@ CPU cpus_PentiumII[] = {
     {"Pentium II Deschutes 350",    CPU_PENTIUM2D,  350000000, 3.5,  0x651,  0x651, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC, 32,32,11,11, 42},
     {"Pentium II Deschutes 400",    CPU_PENTIUM2D,  400000000, 4.0,  0x652,  0x652, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC, 36,36,12,12, 48},
     {"Pentium II Deschutes 450",    CPU_PENTIUM2D,  450000000, 4.5,  0x652,  0x652, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC, 41,41,14,14, 54},
-
-    /*Intel Celeron Mendocino Mobile(Applied on a BGA615 Socket)*/
-    {"Mobile Celeron Mendocino 466",       CPU_PENTIUM2D,  466666666, 7.0,  0x66a,  0x66a, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC, 40,40,14,14, 52},
     {"",                                       -1,          0, 0,        0,      0, 0, 0,  0, 0, 0, 0,  0}
 
+};
+
+CPU cpus_Xeon[] = {
+	/* Slot 2 Xeons. Literal P2D's with more cache */
+    {"Pentium II Xeon 166",    CPU_PENTIUM2D,  166666666, 2.5,  0x653,  0x653, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC, 15,15, 7, 7, 20},
+    {"Pentium II Xeon 400",    CPU_PENTIUM2D,  400000000, 4.0,  0x653,  0x653, 0, CPU_SUPPORTS_DYNAREC | CPU_REQUIRES_DYNAREC, 36,36,12,12, 48},
+    {"",                                       -1,          0,   0,      0,      0, 0, 0,  0, 0, 0, 0,  0}	
 };
 
 CPU cpus_Celeron[] = {

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -279,6 +279,7 @@ extern const device_t	*at_endeavor_get_device(void);
 
 /* m_at_socket7_s7.c */
 extern int	machine_at_chariot_init(const machine_t *);
+extern int	machine_at_mr586_init(const machine_t *);
 extern int	machine_at_thor_init(const machine_t *);
 #if defined(DEV_BRANCH) && defined(USE_MRTHOR)
 extern int	machine_at_mrthor_init(const machine_t *);
@@ -350,11 +351,21 @@ extern int	machine_at_bf6_init(const machine_t *);
 #if defined(DEV_BRANCH) && defined(NO_SIO)
 extern int	machine_at_tsunamiatx_init(const machine_t *);
 #endif
+extern int	machine_at_p6sba_init(const machine_t *);
+
+/* m_at_slot2.c */
+#if defined(DEV_BRANCH) && defined(NO_SIO)
+extern int	machine_at_s2dge_init(const machine_t *);
+#endif
 
 /* m_at_socket370.c */
+#if defined(DEV_BRANCH) && defined(NO_SIO)
+extern int	machine_at_s370slm_init(const machine_t *);
+#endif
 extern int	machine_at_cubx_init(const machine_t *);
 extern int	machine_at_atc7020bxii_init(const machine_t *);
 extern int	machine_at_63a_init(const machine_t *);
+extern int	machine_at_s370sba_init(const machine_t *);
 extern int	machine_at_apas3_init(const machine_t *);
 
 /* m_at_t3100e.c */

--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -274,6 +274,40 @@ machine_at_bf6_init(const machine_t *model)
     return ret;
 }
 
+int
+machine_at_p6sba_init(const machine_t *model)
+{	
+
+    int ret;
+
+    ret = bios_load_linear(L"roms/machines/p6sba/SBAB21.ROM",
+			   0x000c0000, 262144, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_at_common_init_ex(model, 2);
+
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
+    pci_register_slot(0x0F, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x10, PCI_CARD_NORMAL, 2, 3, 4, 1);
+    pci_register_slot(0x12, PCI_CARD_NORMAL, 3, 4, 1, 2);
+    pci_register_slot(0x14, PCI_CARD_NORMAL, 4, 1, 2, 3);
+    pci_register_slot(0x0E, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x01, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x0D, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    device_add(&i440bx_device);
+    device_add(&piix4e_device);
+    device_add(&w83977tf_device);
+    device_add(&keyboard_ps2_ami_pci_device);
+    device_add(&intel_flash_bxt_device);
+    spd_register(SPD_TYPE_SDRAM, 0xF, 256);
+
+    return ret;
+}
+
 #if defined(DEV_BRANCH) && defined(NO_SIO)
 int
 machine_at_tsunamiatx_init(const machine_t *model)

--- a/src/machine/m_at_slot2.c
+++ b/src/machine/m_at_slot2.c
@@ -1,0 +1,79 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Implementation of Slot 2 machines.
+ *
+ *		Slot 2 is quite a rare type of Slot. Used mostly by Pentium II & III Xeons
+ *		These boards were also capable to take Slot 1 CPU's using Slot 2 to 1 adapters.
+ *
+ * Authors:	Miran Grca, <mgrca8@gmail.com>
+ *
+ *		Copyright 2016-2019 Miran Grca.
+ */
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+#include <86box/86box.h>
+#include <86box/mem.h>
+#include <86box/io.h>
+#include <86box/rom.h>
+#include <86box/pci.h>
+#include <86box/device.h>
+#include <86box/chipset.h>
+#include <86box/hdc.h>
+#include <86box/hdc_ide.h>
+#include <86box/keyboard.h>
+#include <86box/intel_flash.h>
+#include <86box/intel_sio.h>
+#include <86box/piix.h>
+#include <86box/sio.h>
+#include <86box/intel_sio.h>
+#include <86box/hwm.h>
+#include <86box/spd.h>
+#include <86box/video.h>
+#include "cpu.h"
+#include <86box/machine.h>
+
+#if defined(DEV_BRANCH) && defined(NO_SIO)
+int
+machine_at_s2dge_init(const machine_t *model)
+{
+	
+	/* 440GX AMI Slot 2 motherboard */
+    int ret;
+
+    ret = bios_load_linear(L"roms/machines/s2dge/2gu7301.rom",
+			   0x000c0000, 262144, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_at_common_init_ex(model, 2);
+
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
+    pci_register_slot(0x0F, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x10, PCI_CARD_NORMAL, 2, 3, 4, 1);
+    pci_register_slot(0x12, PCI_CARD_NORMAL, 3, 4, 1, 2);
+    pci_register_slot(0x14, PCI_CARD_NORMAL, 4, 1, 2, 3);
+    pci_register_slot(0x0E, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x01, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x0D, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    device_add(&i440bx_device); /* i440GX */
+    device_add(&piix4_device);
+    device_add(&keyboard_ps2_ami_pci_device);
+    device_add(&w83977f_device);
+    device_add(&intel_flash_bxt_device);
+    spd_register(SPD_TYPE_SDRAM, 0xF, 256);    
+
+    return ret;
+}
+#endif

--- a/src/machine/m_at_socket7_s7.c
+++ b/src/machine/m_at_socket7_s7.c
@@ -75,6 +75,36 @@ machine_at_chariot_init(const machine_t *model)
     return ret;
 }
 
+int
+machine_at_mr586_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear(L"roms/machines/mr586/TRITON.BIO",
+			   0x000e0000, 131072, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_at_common_init(model);
+
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 0);
+	pci_register_slot(0x0C, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL, 2, 3, 4, 1);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL, 3, 4, 1, 2);
+    pci_register_slot(0x09, PCI_CARD_NORMAL, 4, 1, 2, 3);
+	
+    device_add(&i430fx_device);
+    device_add(&piix_device);
+    device_add(&keyboard_ps2_ami_pci_device);
+    device_add(&fdc37c665_device);
+    device_add(&intel_flash_bxt_device);
+
+    return ret;
+}
+
 static void
 machine_at_thor_common_init(const machine_t *model, int mr)
 {

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -235,6 +235,7 @@ const machine_t machines[] = {
     /* 430FX */
     { "[Socket 7-3V FX] ASUS P/I-P54TP4XE",	"p54tp4xe",		MACHINE_CPUS_PENTIUM_S73V,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  128,   8, 127,	     machine_at_p54tp4xe_init, NULL			},
     { "[Socket 7-3V FX] QDI Chariot",		"chariot",		MACHINE_CPUS_PENTIUM_S73VCH,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_HDC,					  8,  128,   8, 127,	     machine_at_chariot_init, NULL			},
+    { "[Socket 7-3V FX] MR 430FX clone",	"mr586",		MACHINE_CPUS_PENTIUM_S73V,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_HDC,					  8,  128,   8, 127,	     machine_at_mr586_init, NULL			},
     { "[Socket 7-3V FX] Intel Advanced/ATX",	"thor",			MACHINE_CPUS_PENTIUM_S73V,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  128,   8, 127,		 machine_at_thor_init, NULL			},
     { "[Socket 7-3V FX] Intel Advanced/EV",	"endeavor",		MACHINE_CPUS_PENTIUM_S73V,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC | MACHINE_VIDEO,			  8,  128,   8, 127,	     machine_at_endeavor_init, at_endeavor_get_device	},
 #if defined(DEV_BRANCH) && defined(USE_MRTHOR)
@@ -314,8 +315,21 @@ const machine_t machines[] = {
 #if defined(DEV_BRANCH) && defined(NO_SIO)
     { "[Slot 1 BX] Tyan Tsunami ATX",	"tsunamiatx",	{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"",      NULL},{"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8, 1024,   8, 255,		 machine_at_tsunamiatx_init, NULL	},
 #endif
+    { "[Slot 1 BX] Supermicro P6SBA",	"p6sba",		{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"",      NULL},{"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			  		  8,  768,   8, 255,		  machine_at_p6sba_init, NULL			},
+
+	/* Slot 2 machines */
+	/* 440GX */
+#if defined(DEV_BRANCH) && defined(NO_SIO)
+	/*The C3 is meant only for the board to boot due to AMI issues with i686.
+	  Remove after that issue is resolved*/
+    { "[Slot 2 GX] Supermicro S2DGE",	"s2dge",	{{"Intel", cpus_Xeon},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"",      NULL},{"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8, 1024,   8, 255,		 machine_at_s2dge_init, NULL	},
+#endif
 
     /* PGA370 machines */
+	/* 440LX */
+#if defined(DEV_BRANCH) && defined(NO_SIO)
+	{ "[Socket 370 BX] Supermicro S370SLM",		"s370slm",			{{"Intel", cpus_Celeron},     {"VIA", cpus_Cyrix3},  {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8, 1024,   8, 255,		 machine_at_s370slm_init, NULL			},
+#endif
     /* 440BX */
     { "[Socket 370 BX] ASUS CUBX",		"cubx",			{{"Intel", cpus_Celeron},     {"VIA", cpus_Cyrix3},  {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8, 1024,   8, 255,		 machine_at_cubx_init, NULL			},
     { "[Socket 370 BX] A-Trend ATC7020BXII",	"atc7020bxii",		{{"Intel", cpus_Celeron},     {"VIA", cpus_Cyrix3},  {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8, 1024,   8, 255,	  machine_at_atc7020bxii_init, NULL			},

--- a/src/win/Makefile.mingw
+++ b/src/win/Makefile.mingw
@@ -553,7 +553,7 @@ MCHOBJ		:= machine.o machine_table.o \
 		    m_at_compaq.o \
 		    m_at_286_386sx.o m_at_386dx_486.o \
 		    m_at_socket4_5.o m_at_socket7_s7.o m_at_super7_ss7.o \
-			m_at_socket8.o m_at_slot1.o m_at_socket370.o
+			m_at_socket8.o m_at_slot1.o m_at_slot2.o m_at_socket370.o
 
 DEVOBJ		:= bugger.o hwm.o hwm_w83781d.o ibm_5161.o isamem.o isartc.o lpt.o postcard.o $(SERIAL) \
 		    sio_detect.o sio_acc3221.o \

--- a/src/win/Makefile_ndr.mingw
+++ b/src/win/Makefile_ndr.mingw
@@ -557,7 +557,7 @@ MCHOBJ		:= machine.o machine_table.o \
 		    m_at_compaq.o \
 		    m_at_286_386sx.o m_at_386dx_486.o \
 		    m_at_socket4_5.o m_at_socket7_s7.o m_at_super7_ss7.o \
-			m_at_socket8.o m_at_slot1.o m_at_socket370.o
+			m_at_socket8.o m_at_slot1.o m_at_slot2.o m_at_socket370.o
 
 DEVOBJ		:= bugger.o hwm.o hwm_w83781d.o ibm_5161.o isamem.o isartc.o lpt.o postcard.o $(SERIAL) \
 		    sio_acc3221.o \


### PR DESCRIPTION
This PR adds the WinBios boards by SuperMicro + brings Slot 2 to the surface. It'll help debugging why AMI hates i686's and also on the future 440LX + 440GX implementation