### PR TITLE
Make writing to MSR 0x8B cause a GPF on Intel Pentium/Pentium MMX

### DIFF
--- a/src/cpu_common/cpu.c
+++ b/src/cpu_common/cpu.c
@@ -3149,6 +3149,10 @@ void cpu_WRMSR()
                         case 0x10:
 				tsc = EAX | ((uint64_t)EDX << 32);
 				break;
+                        case 0x8B:
+				cpu_log("WRMSR: Invalid MSR: 0x8B/n"); /*Needed for Vista to correctly break on Pentium*/
+				x86gpf(NULL, 0);
+				break;
                 }
                 break;
 #if defined(DEV_BRANCH) && defined(USE_CYRIX_6X86)


### PR DESCRIPTION
Windows Vista will write to this MSR on presumably any CPU with a GenuineIntel vendor ID string. This should (and does on a real one) cause a GPF on Intel Pentium/Pentium MMX CPUs. IDT WinChip, AMD K6, VIA Cyrix III, and Intel P6 family CPUs are not affected.