### PR TITLE
Hardware monitor refactoring, part 2

### DIFF
--- a/src/hwm.c
+++ b/src/hwm.c
@@ -11,6 +11,7 @@
  *
  *
  * Author:	RichardG, <richardg867@gmail.com>
+ *
  *		Copyright 2020 RichardG.
  */
 

--- a/src/hwm_lm75.c
+++ b/src/hwm_lm75.c
@@ -1,0 +1,269 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Emulation of the National Semiconductor LM75 temperature sensor chip.
+ *
+ *
+ *
+ * Author:	RichardG, <richardg867@gmail.com>
+ *
+ *		Copyright 2020 RichardG.
+ */
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#define HAVE_STDARG_H
+#include <wchar.h>
+#include <86box/86box.h>
+#include <86box/device.h>
+#include <86box/smbus.h>
+#include <86box/hwm.h>
+
+
+#define LM75_TEMP_TO_REG(t)	((t) << 8)
+
+
+static uint8_t	lm75_smbus_read_byte(uint8_t addr, void *priv);
+static uint8_t	lm75_smbus_read_byte_cmd(uint8_t addr, uint8_t cmd, void *priv);
+static uint16_t	lm75_smbus_read_word_cmd(uint8_t addr, uint8_t cmd, void *priv);
+static void	lm75_smbus_write_byte(uint8_t addr, uint8_t val, void *priv);
+static void	lm75_smbus_write_byte_cmd(uint8_t addr, uint8_t cmd, uint8_t val, void *priv);
+static void	lm75_smbus_write_word_cmd(uint8_t addr, uint8_t cmd, uint16_t val, void *priv);
+static void	lm75_reset(lm75_t *dev);
+
+
+#ifdef ENABLE_LM75_LOG
+int lm75_do_log = ENABLE_LM75_LOG;
+
+
+static void
+lm75_log(const char *fmt, ...)
+{
+    va_list ap;
+
+    if (lm75_do_log) {
+	va_start(ap, fmt);
+	pclog_ex(fmt, ap);
+	va_end(ap);
+    }
+}
+#else
+#define lm75_log(fmt, ...)
+#endif
+
+
+void
+lm75_remap(lm75_t *dev)
+{
+    lm75_log("LM75: remapping to SMBus %02Xh\n", dev->smbus_addr);
+
+    smbus_removehandler(dev->smbus_addr, 1,
+    			lm75_smbus_read_byte, lm75_smbus_read_byte_cmd, lm75_smbus_read_word_cmd, NULL,
+    			lm75_smbus_write_byte, lm75_smbus_write_byte_cmd, lm75_smbus_write_word_cmd, NULL,
+    			dev);
+
+    if (dev->smbus_addr) smbus_sethandler(dev->smbus_addr, 1,
+    			lm75_smbus_read_byte, lm75_smbus_read_byte_cmd, lm75_smbus_read_word_cmd, NULL,
+    			lm75_smbus_write_byte, lm75_smbus_write_byte_cmd, lm75_smbus_write_word_cmd, NULL,
+    			dev);
+}
+
+
+static uint8_t
+lm75_smbus_read_byte(uint8_t addr, void *priv)
+{
+    lm75_t *dev = (lm75_t *) priv;
+    return lm75_read(dev, dev->addr_register);
+}
+
+
+static uint8_t
+lm75_smbus_read_byte_cmd(uint8_t addr, uint8_t cmd, void *priv)
+{
+    lm75_t *dev = (lm75_t *) priv;
+    return lm75_read(dev, cmd);
+}
+
+static uint16_t
+lm75_smbus_read_word_cmd(uint8_t addr, uint8_t cmd, void *priv)
+{
+    lm75_t *dev = (lm75_t *) priv;
+    uint8_t rethi = 0;
+    uint8_t retlo = 0;
+
+    switch (cmd & 0x3) {
+    	case 0x0: /* temperature */
+    		rethi = lm75_read(dev, 0x0);
+    		retlo = lm75_read(dev, 0x1);
+    		break;
+    	case 0x1: /* configuration */
+    		rethi = retlo = lm75_read(dev, 0x2);
+    		break;
+    	case 0x2: /* Thyst */
+    		rethi = lm75_read(dev, 0x3);
+    		retlo = lm75_read(dev, 0x4);
+    		break;
+    	case 0x3: /* Tos */
+    		rethi = lm75_read(dev, 0x5);
+    		retlo = lm75_read(dev, 0x6);
+    		break;
+    }
+
+    return (retlo << 8) | rethi; /* byte-swapped for some reason */
+}
+
+
+uint8_t
+lm75_read(lm75_t *dev, uint8_t reg)
+{
+    uint8_t ret;
+
+    /* The AS99127F hardware monitor uses the addresses of its LM75 devices
+       to access some of its proprietary registers. Pass this operation on to
+       the main monitor address through an internal SMBus call, if necessary. */
+    if ((reg >= 0x80) && (dev->as99127f_smbus_addr))
+    	ret = smbus_read_byte_cmd(dev->as99127f_smbus_addr, reg);
+    else
+    	ret = dev->regs[reg & 0x7];
+
+    lm75_log("LM75: read(%x) = %02x\n", reg, ret);
+
+    return ret;
+}
+
+
+static void
+lm75_smbus_write_byte(uint8_t addr, uint8_t val, void *priv)
+{
+    lm75_t *dev = (lm75_t *) priv;
+    dev->addr_register = val;
+}
+
+
+static void
+lm75_smbus_write_byte_cmd(uint8_t addr, uint8_t cmd, uint8_t val, void *priv)
+{
+    lm75_t *dev = (lm75_t *) priv;
+    lm75_write(dev, cmd, val);
+}
+
+
+static void
+lm75_smbus_write_word_cmd(uint8_t addr, uint8_t cmd, uint16_t val, void *priv)
+{
+    lm75_t *dev = (lm75_t *) priv;
+    uint8_t valhi = (val >> 8);
+    uint8_t vallo = (val & 0xff);
+
+    switch (cmd & 0x3) {
+    	case 0x0: /* temperature */
+    		lm75_write(dev, 0x0, valhi);
+    		lm75_write(dev, 0x1, vallo);
+    		break;
+    	case 0x1: /* configuration */
+    		lm75_write(dev, 0x2, vallo);
+    		break;
+    	case 0x2: /* Thyst */
+    		lm75_write(dev, 0x3, valhi);
+    		lm75_write(dev, 0x4, vallo);
+    		break;
+    	case 0x3: /* Tos */
+    		lm75_write(dev, 0x5, valhi);
+    		lm75_write(dev, 0x6, vallo);
+    		break;
+    	break;
+    }
+}
+
+
+uint8_t
+lm75_write(lm75_t *dev, uint8_t reg, uint8_t val)
+{
+    lm75_log("LM75: write(%x, %02x)\n", reg, val);
+
+    /* The AS99127F hardware monitor uses the addresses of its LM75 devices
+       to access some of its proprietary registers. Pass this operation on to
+       the main monitor address through an internal SMBus call, if necessary. */
+    if ((reg >= 0x80) && (dev->as99127f_smbus_addr)) {
+    	smbus_write_byte_cmd(dev->as99127f_smbus_addr, reg, val);
+    	return 1;
+    }
+
+    uint8_t reg_idx = (reg & 0x7);
+
+    if ((reg_idx <= 0x1) || (reg_idx == 0x7))
+    	return 0; /* read-only registers */
+
+    dev->regs[reg_idx] = val;
+
+    return 1;
+}
+
+
+static void
+lm75_reset(lm75_t *dev)
+{
+    uint16_t temp = LM75_TEMP_TO_REG(dev->values->temperatures[dev->local >> 8]);
+    dev->regs[0x0] = (temp >> 8);
+    dev->regs[0x1] = temp;
+    dev->regs[0x3] = 0x4b;
+    dev->regs[0x5] = 0x50;
+
+    lm75_remap(dev);
+}
+
+
+static void
+lm75_close(void *priv)
+{
+    lm75_t *dev = (lm75_t *) priv;
+    free(dev);
+}
+
+
+static void *
+lm75_init(const device_t *info)
+{
+    lm75_t *dev = (lm75_t *) malloc(sizeof(lm75_t));
+    memset(dev, 0, sizeof(lm75_t));
+
+    dev->local = info->local;
+    dev->values = hwm_get_values();
+
+    dev->smbus_addr = dev->local;
+    dev->as99127f_smbus_addr = 0x00;
+
+    lm75_reset(dev);
+
+    return dev;
+}
+
+
+/* LM75 on SMBus address 4Ah, reporting temperatures[1]. */
+const device_t lm75_1_4a_device = {
+    "National Semiconductor LM75 Temperature Sensor",
+    DEVICE_AT,
+    0x14a,
+    lm75_init, lm75_close, NULL,
+    NULL, NULL, NULL,
+    NULL
+};
+
+
+/* LM75 secondary/tertiary temperature sensors built into
+   the Winbond W83781D family. Not to be used stand-alone. */
+const device_t lm75_w83781d_device = {
+    "Winbond W83781D Secondary Temperature Sensor",
+    DEVICE_AT,
+    0,
+    lm75_init, lm75_close, NULL,
+    NULL, NULL, NULL,
+    NULL
+};

--- a/src/hwm_lm75.c
+++ b/src/hwm_lm75.c
@@ -133,7 +133,7 @@ lm75_read(lm75_t *dev, uint8_t reg)
     else
     	ret = dev->regs[reg & 0x7];
 
-    lm75_log("LM75: read(%x) = %02x\n", reg, ret);
+    lm75_log("LM75: read(%02X) = %02X\n", reg, ret);
 
     return ret;
 }
@@ -186,7 +186,7 @@ lm75_smbus_write_word_cmd(uint8_t addr, uint8_t cmd, uint16_t val, void *priv)
 uint8_t
 lm75_write(lm75_t *dev, uint8_t reg, uint8_t val)
 {
-    lm75_log("LM75: write(%x, %02x)\n", reg, val);
+    lm75_log("LM75: write(%02X, %02X)\n", reg, val);
 
     /* The AS99127F hardware monitor uses the addresses of its LM75 devices
        to access some of its proprietary registers. Pass this operation on to

--- a/src/hwm_lm78.c
+++ b/src/hwm_lm78.c
@@ -142,7 +142,7 @@ lm78_isa_read(uint16_t port, void *priv)
     		}
     		break;
     	default:
-    		lm78_log("LM78: Read from unknown ISA port %x\n", port & 0x7);
+    		lm78_log("LM78: Read from unknown ISA port %d\n", port & 0x7);
     		break;
     }
 
@@ -197,7 +197,7 @@ lm78_read(lm78_t *dev, uint8_t reg, uint8_t bank)
     		ret = dev->regs[reg];
     }
 
-    lm78_log("LM78: read(%02x, %d) = %02x\n", reg, bank, ret);
+    lm78_log("LM78: read(%02X, %d) = %02X\n", reg, bank, ret);
 
     return ret;
 }
@@ -223,7 +223,7 @@ lm78_isa_write(uint16_t port, uint8_t val, void *priv)
     		}
     		break;
     	default:
-    		lm78_log("LM78: Write %02x to unknown ISA port %x\n", val, port & 0x7);
+    		lm78_log("LM78: Write %02X to unknown ISA port %d\n", val, port & 0x7);
     		break;
     }
 }
@@ -258,7 +258,7 @@ lm78_write(lm78_t *dev, uint8_t reg, uint8_t val, uint8_t bank)
 {
     lm75_t *lm75;
 
-    lm78_log("LM78: write(%02x, %d, %02x)\n", reg, bank, val);
+    lm78_log("LM78: write(%02X, %d, %02X)\n", reg, bank, val);
 
     if (((reg >> 4) == 0x5) && (bank != 0)) {
     	/* LM75 registers */
@@ -343,7 +343,7 @@ lm78_write(lm78_t *dev, uint8_t reg, uint8_t val, uint8_t bank)
     		dev->active_bank = (dev->regs[0x4e] & 0x07);
     		break;
     	case 0x87:
-    		/* fixes AS99127F boards hanging after save & exit, probably a reset register */
+    		/* fixes AS99127F boards hanging after BIOS save & exit, probably a reset register */
     		if ((dev->local & LM78_AS99127F) && (val == 0x01)) {
     			lm78_log("LM78: Reset requested through AS99127F\n");
     			resetx86();

--- a/src/include/86box/hwm.h
+++ b/src/include/86box/hwm.h
@@ -27,10 +27,29 @@ typedef struct _hwm_values_ {
     uint16_t	voltages[8];
 } hwm_values_t;
 
+typedef struct {
+    uint32_t	 local;
+    hwm_values_t *values;
+
+    uint8_t	 regs[8];
+    uint8_t	 addr_register;
+    uint8_t	 temp_idx;
+    uint8_t	 smbus_addr;
+
+    uint8_t	 as99127f_smbus_addr;
+} lm75_t;
+
 
 extern void		hwm_set_values(hwm_values_t new_values);
 extern hwm_values_t*	hwm_get_values();
 
+extern void		lm75_remap(lm75_t *dev);
+extern uint8_t		lm75_read(lm75_t *dev, uint8_t reg);
+extern uint8_t		lm75_write(lm75_t *dev, uint8_t reg, uint8_t val);
+
+
+extern const device_t	lm75_1_4a_device;
+extern const device_t	lm75_w83781d_device;
 
 extern const device_t	lm78_device;
 extern const device_t	w83781d_device;

--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -214,7 +214,7 @@ machine_at_p3bf_init(const machine_t *model)
     		3000	/* Power */
     	}, { /* temperatures */
     		30,	/* MB */
-    		0,	/* unused */
+    		30,	/* JTPWR */
     		30	/* CPU */
     	}, { /* voltages */
     		2050,				   /* VCORE (2.05V by default) */

--- a/src/machine/m_at_socket370.c
+++ b/src/machine/m_at_socket370.c
@@ -135,7 +135,7 @@ machine_at_cubx_init(const machine_t *model)
     		3000	/* Power */
     	}, { /* temperatures */
     		30,	/* MB */
-    		0,	/* unused */
+    		30,	/* JTPWR */
     		30	/* CPU */
     	}, { /* voltages */
     		2050,				   /* VCORE (2.05V by default) */

--- a/src/machine/m_at_socket7_s7.c
+++ b/src/machine/m_at_socket7_s7.c
@@ -847,7 +847,8 @@ machine_at_p5mms98_init(const machine_t *model)
     		3000,	/* CPU */
     		3000	/* Chassis */
     	}, { /* temperatures */
-    		28	/* CPU (locked at 28?) */
+    		0,	/* unused */
+    		30	/* CPU */
     	}, { /* voltages */
     		3300,				   /* VCORE (3.3V by default) */
     		3300,				   /* VIO (3.3V) */
@@ -873,6 +874,7 @@ machine_at_p5mms98_init(const machine_t *model)
     }
     hwm_set_values(machine_hwm);
     device_add(&lm78_device);
+    device_add(&lm75_1_4a_device);
 
     return ret;
 }

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -320,7 +320,7 @@ const machine_t machines[] = {
     /* PGA370 machines */
 	/* 440LX */
 #if defined(DEV_BRANCH) && defined(NO_SIO)
-    { "[Socket 370 LX] Supermicro SUPER 370SLM","s370slm",		{{"Intel", cpus_Celeron},     {"", NULL},            {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8,  768,   8, 255,	      machine_at_s370slm_init, NULL			},
+    { "[Socket 370 LX] Supermicro 370SLM",	"s370slm",		{{"Intel", cpus_Celeron},     {"", NULL},            {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8,  768,   8, 255,	      machine_at_s370slm_init, NULL			},
 #endif
     /* 440BX */
     { "[Socket 370 BX] ASUS CUBX",		"cubx",			{{"Intel", cpus_Celeron},     {"VIA", cpus_Cyrix3},  {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8, 1024,   8, 255,		 machine_at_cubx_init, NULL			},

--- a/src/smbus.c
+++ b/src/smbus.c
@@ -69,18 +69,6 @@ smbus_log(const char *fmt, ...)
 #endif
 
 
-#ifdef ENABLE_SMBUS_LOG
-static uint8_t smbus_null_read_byte(uint8_t addr, void *priv) { smbus_log("SMBus: read_byte(%02x)\n", addr); return(0xff); }
-static uint8_t smbus_null_read_byte_cmd(uint8_t addr, uint8_t cmd, void *priv) { smbus_log("SMBus: read_byte_cmd(%02x, %02x)\n", addr, cmd); return(0xff); }
-static uint16_t smbus_null_read_word_cmd(uint8_t addr, uint8_t cmd, void *priv) { smbus_log("SMBus: read_word_cmd(%02x, %02x)\n", addr, cmd); return(0xffff); }
-static uint8_t smbus_null_read_block_cmd(uint8_t addr, uint8_t cmd, uint8_t *data, uint8_t len, void *priv) { smbus_log("SMBus: read_block_cmd(%02x, %02x)\n", addr, cmd); return(0x00); };
-static void smbus_null_write_byte(uint8_t addr, uint8_t val, void *priv) { smbus_log("SMBus: write_byte(%02x, %02x)\n", addr, val); }
-static void smbus_null_write_byte_cmd(uint8_t addr, uint8_t cmd, uint8_t val, void *priv) { smbus_log("SMBus: write_byte_cmd(%02x, %02x, %02x)\n", addr, cmd, val); }
-static void smbus_null_write_word_cmd(uint8_t addr, uint8_t cmd, uint16_t val, void *priv) { smbus_log("SMBus: write_word_cmd(%02x, %02x, %04x)\n", addr, cmd, val); }
-static void smbus_null_write_block_cmd(uint8_t addr, uint8_t cmd, uint8_t *data, uint8_t len, void *priv) { smbus_log("SMBus: write_block_cmd(%02x, %02x, %02x)\n", addr, cmd, len); }
-#endif
-
-
 void
 smbus_init(void)
 {
@@ -106,26 +94,8 @@ smbus_init(void)
     		p = NULL;
     	}
 
-#ifdef ENABLE_SMBUS_LOG
-    	/* smbus[c] should be the only handler, pointing at the NULL catch handler. */
-    	p = (smbus_t *) malloc(sizeof(smbus_t));
-    	memset(p, 0, sizeof(smbus_t));
-    	smbus[c] = smbus_last[c] = p;
-    	p->next = NULL;
-    	p->prev = NULL;
-    	p->read_byte	   = smbus_null_read_byte;
-    	p->read_byte_cmd   = smbus_null_read_byte_cmd;
-    	p->read_word_cmd   = smbus_null_read_word_cmd;
-    	p->read_block_cmd  = smbus_null_read_block_cmd;
-    	p->write_byte	   = smbus_null_write_byte;
-    	p->write_byte_cmd  = smbus_null_write_byte_cmd;
-    	p->write_word_cmd  = smbus_null_write_word_cmd;
-    	p->write_block_cmd = smbus_null_write_block_cmd;
-    	p->priv = NULL;
-#else
     	/* smbus[c] should be NULL. */
     	smbus[c] = smbus_last[c] = NULL;
-#endif
     }
 }
 
@@ -262,6 +232,8 @@ smbus_read_byte(uint8_t addr)
     	}
     }
 
+    smbus_log("SMBus: read_byte(%02X) = %02X\n", addr, ret);
+
     return(ret);
 }
 
@@ -282,6 +254,8 @@ smbus_read_byte_cmd(uint8_t addr, uint8_t cmd)
     		p = p->next;
     	}
     }
+
+    smbus_log("SMBus: read_byte_cmd(%02X, %02X) = %02X\n", addr, cmd, ret);
 
     return(ret);
 }
@@ -304,6 +278,8 @@ smbus_read_word_cmd(uint8_t addr, uint8_t cmd)
     	}
     }
 
+    smbus_log("SMBus: read_word_cmd(%02X, %02X) = %04X\n", addr, cmd, ret);
+
     return(ret);
 }
 
@@ -324,6 +300,8 @@ smbus_read_block_cmd(uint8_t addr, uint8_t cmd, uint8_t *data, uint8_t len)
     		p = p->next;
     	}
     }
+
+    smbus_log("SMBus: read_block_cmd(%02X, %02X) = %02X\n", addr, cmd, len);
 
     return(ret);
 }
@@ -346,6 +324,8 @@ smbus_write_byte(uint8_t addr, uint8_t val)
     	}
     }
 
+    smbus_log("SMBus: write_byte(%02X, %02X)\n", addr, val);
+
     return;
 }
 
@@ -365,6 +345,8 @@ smbus_write_byte_cmd(uint8_t addr, uint8_t cmd, uint8_t val)
     		p = p->next;
     	}
     }
+
+    smbus_log("SMBus: write_byte_cmd(%02X, %02X, %02X)\n", addr, cmd, val);
 
     return;
 }
@@ -386,6 +368,8 @@ smbus_write_word_cmd(uint8_t addr, uint8_t cmd, uint16_t val)
     	}
     }
 
+    smbus_log("SMBus: write_word_cmd(%02X, %02X, %04X)\n", addr, cmd, val);
+
     return;
 }
 
@@ -405,6 +389,8 @@ smbus_write_block_cmd(uint8_t addr, uint8_t cmd, uint8_t *data, uint8_t len)
     		p = p->next;
     	}
     }
+
+    smbus_log("SMBus: write_block_cmd(%02X, %02X, %02X)\n", addr, cmd, len);
 
     return;
 }

--- a/src/spd.c
+++ b/src/spd.c
@@ -73,7 +73,7 @@ spd_read_byte_cmd(uint8_t addr, uint8_t cmd, void *priv)
 {
     spd_t *dev = (spd_t *) priv;
     uint8_t ret = *(spd_data[dev->slot] + cmd);
-    spd_log("SPD: read(%02x, %02x) = %02x\n", addr, cmd, ret);
+    spd_log("SPD: read(%02X, %02X) = %02X\n", addr, cmd, ret);
     return ret;
 }
 
@@ -195,7 +195,7 @@ spd_register(uint8_t ram_type, uint8_t slot_mask, uint16_t max_module_size)
     	/* populate slot */
     	vslots[vslot] = (1 << log2_ui16(MIN(total_size, max_module_size)));
     	if (total_size >= vslots[vslot]) {
-    		spd_log("SPD: vslot %d = %d MB\n", vslot, vslots[vslot]);
+    		spd_log("SPD: initial vslot %d = %d MB\n", vslot, vslots[vslot]);
     		total_size -= vslots[vslot];
     	} else {
     		vslots[vslot] = 0;

--- a/src/win/Makefile.mingw
+++ b/src/win/Makefile.mingw
@@ -535,7 +535,7 @@ MCHOBJ		:= machine.o machine_table.o \
 		    m_at_socket4_5.o m_at_socket7_s7.o m_at_super7_ss7.o \
 			m_at_socket8.o m_at_slot1.o m_at_slot2.o m_at_socket370.o
 
-DEVOBJ		:= bugger.o hwm.o hwm_lm78.o ibm_5161.o isamem.o isartc.o lpt.o postcard.o $(SERIAL) \
+DEVOBJ		:= bugger.o hwm.o hwm_lm75.o hwm_lm78.o ibm_5161.o isamem.o isartc.o lpt.o postcard.o $(SERIAL) \
 		    sio_detect.o sio_acc3221.o \
 		    sio_f82c710.o \
 		    sio_fdc37c66x.o sio_fdc37c669.o \

--- a/src/win/Makefile_ndr.mingw
+++ b/src/win/Makefile_ndr.mingw
@@ -539,7 +539,7 @@ MCHOBJ		:= machine.o machine_table.o \
 		    m_at_socket4_5.o m_at_socket7_s7.o m_at_super7_ss7.o \
 			m_at_socket8.o m_at_slot1.o m_at_slot2.o m_at_socket370.o
 
-DEVOBJ		:= bugger.o hwm.o hwm_lm78.o ibm_5161.o isamem.o isartc.o lpt.o postcard.o $(SERIAL) \
+DEVOBJ		:= bugger.o hwm.o hwm_lm75.o hwm_lm78.o ibm_5161.o isamem.o isartc.o lpt.o postcard.o $(SERIAL) \
 		    sio_acc3221.o \
 		    sio_f82c710.o \
 		    sio_fdc37c66x.o sio_fdc37c669.o \


### PR DESCRIPTION
* Separate LM75 temperature sensor from LM78 emulation
* Add LM75 CPU temperature sensor to the Supermicro P5MMS98 (fixes CPU temperature reading)
* Fix JTPWR readout on AS99127F machines (somehow)
* Fix SMBus logging, enabling logging should no longer return bad values