### PR TITLE
Onboard sound support + onboard ES1371 for Tsunami ATX

### DIFF
--- a/src/hwm_lm78.c
+++ b/src/hwm_lm78.c
@@ -180,11 +180,11 @@ lm78_read(lm78_t *dev, uint8_t reg, uint8_t bank)
     uint8_t ret = 0;
     lm75_t *lm75;
 
-    if (((reg >> 4) == 0x5) && (bank != 0)) {
+    if (((reg & 0xf0) == 0x50) && (bank != 0)) {
     	/* LM75 registers */
     	lm75 = device_get_priv(dev->lm75[bank - 1]);
     	if (lm75)
-    		ret = lm75_read(lm75, reg & 0x7);
+    		ret = lm75_read(lm75, reg & 0xf);
     } else {
     	/* regular registers */
     	if ((reg == 0x4f) && (dev->local & LM78_WINBOND)) /* special case for two-byte vendor ID register */
@@ -260,11 +260,11 @@ lm78_write(lm78_t *dev, uint8_t reg, uint8_t val, uint8_t bank)
 
     lm78_log("LM78: write(%02X, %d, %02X)\n", reg, bank, val);
 
-    if (((reg >> 4) == 0x5) && (bank != 0)) {
+    if (((reg & 0xf0) == 0x50) && (bank != 0)) {
     	/* LM75 registers */
     	lm75 = device_get_priv(dev->lm75[bank - 1]);
     	if (lm75)
-    		lm75_write(lm75, reg & 0x7, val);
+    		lm75_write(lm75, reg & 0xf, val);
     	return 1;
     }
 
@@ -325,6 +325,8 @@ lm78_write(lm78_t *dev, uint8_t reg, uint8_t val, uint8_t bank)
     		if (dev->local & LM78_SMBUS) {
     			for (uint8_t i = 0; i <= 1; i++) {
     				lm75 = device_get_priv(dev->lm75[i]);
+    				if (!lm75)
+    					continue;
     				if (dev->regs[0x4a] & (0x08 * (0x10 * i))) /* DIS_T2 and DIS_T3 bit disable those interfaces */
     					lm75->smbus_addr = 0x00;
     				else

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -38,7 +38,8 @@
 #define MACHINE_VIDEO		0x002000	/* sys has int video */
 #define MACHINE_VIDEO_FIXED	0x004000	/* sys has ONLY int video */
 #define MACHINE_MOUSE		0x008000	/* sys has int mouse */
-#define MACHINE_NONMI		0x010000	/* sys does not have NMI's */
+#define MACHINE_SOUND		0x010000	/* sys has int sound */
+#define MACHINE_NONMI		0x020000	/* sys does not have NMI's */
 #else
 #define MACHINE_PC		0x000000	/* PC architecture */
 #define MACHINE_AT		0x000001	/* PC/AT architecture */
@@ -54,7 +55,8 @@
 #define MACHINE_VIDEO		0x002000	/* sys has int video */
 #define MACHINE_VIDEO_FIXED	0x004000	/* sys has ONLY int video */
 #define MACHINE_MOUSE		0x008000	/* sys has int mouse */
-#define MACHINE_NONMI		0x010000	/* sys does not have NMI's */
+#define MACHINE_SOUND		0x010000	/* sys has int sound */
+#define MACHINE_NONMI		0x020000	/* sys does not have NMI's */
 #endif
 
 #define IS_ARCH(m, a)		(machines[(m)].flags & (a)) ? 1 : 0;
@@ -348,6 +350,12 @@ extern int	machine_at_bf6_init(const machine_t *);
 extern int	machine_at_tsunamiatx_init(const machine_t *);
 #endif
 extern int	machine_at_p6sba_init(const machine_t *);
+
+#ifdef EMU_DEVICE_H
+#if defined(DEV_BRANCH) && defined(NO_SIO)
+extern const device_t 	*at_tsunamiatx_get_device(void);
+#endif
+#endif
 
 /* m_at_slot2.c */
 #if defined(DEV_BRANCH) && defined(NO_SIO)

--- a/src/include/86box/pci.h
+++ b/src/include/86box/pci.h
@@ -51,6 +51,7 @@ enum {
     PCI_CARD_NORMAL,
     PCI_CARD_ONBOARD,
     PCI_CARD_SCSI,
+    PCI_CARD_SOUND,
     PCI_CARD_SPECIAL
 };
 
@@ -59,7 +60,8 @@ enum {
     PCI_ADD_SOUTHBRIDGE,
     PCI_ADD_NORMAL,
     PCI_ADD_VIDEO,
-    PCI_ADD_SCSI
+    PCI_ADD_SCSI,
+    PCI_ADD_SOUND
 };
 
 typedef union {

--- a/src/include/86box/sound.h
+++ b/src/include/86box/sound.h
@@ -28,6 +28,12 @@ extern int sound_gain;
 #define CD_BUFLEN	(CD_FREQ / 10)
 
 
+enum {
+    SOUND_NONE = 0,
+    SOUND_INTERNAL
+};
+
+
 extern int	ppispeakon;
 extern int	gated,
 		speakval,
@@ -79,6 +85,7 @@ extern const device_t azt1605_device;
 
 /* Ensoniq AudioPCI */
 extern const device_t es1371_device;
+extern const device_t es1371_onboard_device;
 
 /* Creative Labs Game Blaster */
 extern const device_t cms_device;

--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -40,6 +40,7 @@
 #include <86box/video.h>
 #include "cpu.h"
 #include <86box/machine.h>
+#include <86box/sound.h>
 
 int
 machine_at_p65up5_cpknd_init(const machine_t *model)
@@ -335,9 +336,9 @@ machine_at_p6sba_init(const machine_t *model)
 int
 machine_at_tsunamiatx_init(const machine_t *model)
 {
-	//AMI 440BX Board. Requires the PC87309 and
-	//doesn't like the i686 CPU's
-	
+    /* AMI 440BX board. Requires the PC87309
+       and doesn't like the i686 CPUs */
+
     int ret;
 
     ret = bios_load_linear(L"roms/machines/tsunamiatx/bx46200f.rom",
@@ -350,20 +351,31 @@ machine_at_tsunamiatx_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x10, PCI_CARD_NORMAL,	  1, 2, 3, 4);
-    pci_register_slot(0x11, PCI_CARD_NORMAL,      2, 3, 4, 1);	
+    pci_register_slot(0x0F, PCI_CARD_SOUND,       1, 0, 0, 0);
+    pci_register_slot(0x10, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x11, PCI_CARD_NORMAL,      2, 3, 4, 1);
     pci_register_slot(0x12, PCI_CARD_NORMAL,      3, 4, 1, 2);
     pci_register_slot(0x13, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x14, PCI_CARD_NORMAL,      1, 2, 3, 4);
     pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
-    pci_register_slot(0x0F, PCI_CARD_NORMAL,      1, 2, 3, 4);
-    pci_register_slot(0x01, PCI_CARD_NORMAL, 	  1, 2, 3, 4);
+    pci_register_slot(0x01, PCI_CARD_NORMAL,      1, 2, 3, 4);
     device_add(&i440bx_device);
     device_add(&piix4e_device);
-    device_add(&pc87306_device); //PC87309
+
+    if (sound_card_current == SOUND_INTERNAL)
+    	device_add(&es1371_onboard_device);
+
+    device_add(&pc87306_device); /* PC87309 */
     device_add(&keyboard_ps2_ami_pci_device);
     device_add(&intel_flash_bxt_device);
     spd_register(SPD_TYPE_SDRAM, 0x7, 256);
 
     return ret;
+}
+
+const device_t *
+at_tsunamiatx_get_device(void)
+{
+    return &es1371_onboard_device;
 }
 #endif

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -307,7 +307,7 @@ const machine_t machines[] = {
     { "[Slot 1 BX] ASUS P3B-F",			"p3bf",			{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"",      NULL},{"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8, 1024,   8, 255,		 machine_at_p3bf_init, NULL			},
     { "[Slot 1 BX] ABit BF6",			"bf6",			{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"",      NULL},{"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			  		  8,  768,   8, 255,		  machine_at_bf6_init, NULL			},
 #if defined(DEV_BRANCH) && defined(NO_SIO)
-    { "[Slot 1 BX] Tyan Tsunami ATX",		"tsunamiatx",		{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"",      NULL},{"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8, 1024,   8, 255,	   machine_at_tsunamiatx_init, NULL			},
+    { "[Slot 1 BX] Tyan Tsunami ATX",		"tsunamiatx",		{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"",      NULL},{"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC | MACHINE_SOUND,	 		  8, 1024,   8, 255,	   machine_at_tsunamiatx_init, at_tsunamiatx_get_device	},
 #endif
     { "[Slot 1 BX] Supermicro P6SBA",		"p6sba",		{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"",      NULL},{"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			  		  8,  768,   8, 255,	        machine_at_p6sba_init, NULL			},
 

--- a/src/pci.c
+++ b/src/pci.c
@@ -809,12 +809,12 @@ pci_add_card(uint8_t add_type, uint8_t (*read)(int func, int addr, void *priv), 
 	pci_log("pci_add_card(): Adding PCI CARD at specific slot %02X [SPECIFIC]\n", add_type);
 
     if (! PCI) {
-	pci_log("pci_add_card(): Adding PCI CARD failed (non-PCI machine) [%s]\n", (add_type == PCI_ADD_NORMAL) ? "NORMAL" : ((add_type == PCI_ADD_VIDEO) ? "VIDEO" : ((add_type == PCI_ADD_SCSI) ? "SCSI" : "SPECIFIC")));
+	pci_log("pci_add_card(): Adding PCI CARD failed (non-PCI machine) [%s]\n", (add_type == PCI_ADD_NORMAL) ? "NORMAL" : ((add_type == PCI_ADD_VIDEO) ? "VIDEO" : ((add_type == PCI_ADD_SCSI) ? "SCSI" : ((add_type == PCI_ADD_SOUND) ? "SOUND" : "SPECIFIC"))));
 	return 0xff;
     }
 
     if (! last_pci_card) {
-	pci_log("pci_add_card(): Adding PCI CARD failed (no PCI slots) [%s]\n", (add_type == PCI_ADD_NORMAL) ? "NORMAL" : ((add_type == PCI_ADD_VIDEO) ? "VIDEO" : ((add_type == PCI_ADD_SCSI) ? "SCSI" : "SPECIFIC")));
+	pci_log("pci_add_card(): Adding PCI CARD failed (no PCI slots) [%s]\n", (add_type == PCI_ADD_NORMAL) ? "NORMAL" : ((add_type == PCI_ADD_VIDEO) ? "VIDEO" : ((add_type == PCI_ADD_SCSI) ? "SCSI" : ((add_type == PCI_ADD_SOUND) ? "SOUND" : "SPECIFIC"))));
 	return 0xff;
     }
 
@@ -825,19 +825,20 @@ pci_add_card(uint8_t add_type, uint8_t (*read)(int func, int addr, void *priv), 
 		if (((dev->type == PCI_CARD_NORMAL) && (add_type >= PCI_ADD_NORMAL)) ||
 		    ((dev->type == PCI_CARD_ONBOARD) && (add_type == PCI_ADD_VIDEO)) ||
 		    ((dev->type == PCI_CARD_SCSI) && (add_type == PCI_ADD_SCSI)) ||
+		    ((dev->type == PCI_CARD_SOUND) && (add_type == PCI_ADD_SOUND)) ||
 		    ((dev->type == PCI_CARD_NORTHBRIDGE) && (add_type == PCI_ADD_NORTHBRIDGE)) ||
 		    ((dev->type == PCI_CARD_SOUTHBRIDGE) && (add_type == PCI_ADD_SOUTHBRIDGE)) ||
 		    ((dev->id == add_type) && (add_type < PCI_ADD_NORTHBRIDGE))) {
 			dev->read = read;
 			dev->write = write;
 			dev->priv = priv;
-			pci_log("pci_add_card(): Adding PCI CARD to pci_cards[%i] (slot %02X) [%s]\n", i, dev->id, (add_type == PCI_ADD_NORMAL) ? "NORMAL" : ((add_type == PCI_ADD_VIDEO) ? "VIDEO" : ((add_type == PCI_ADD_SCSI) ? "SCSI" : "SPECIFIC")));
+			pci_log("pci_add_card(): Adding PCI CARD to pci_cards[%i] (slot %02X) [%s]\n", i, dev->id, (add_type == PCI_ADD_NORMAL) ? "NORMAL" : ((add_type == PCI_ADD_VIDEO) ? "VIDEO" : ((add_type == PCI_ADD_SCSI) ? "SCSI" : ((add_type == PCI_ADD_SOUND) ? "SOUND" : "SPECIFIC"))));
 			return dev->id;
 		}
 	}
     }
 
-    pci_log("pci_add_card(): Adding PCI CARD failed (unable to find a suitable PCI slot) [%s]\n", (add_type == PCI_ADD_NORMAL) ? "NORMAL" : ((add_type == PCI_ADD_VIDEO) ? "VIDEO" : ((add_type == PCI_ADD_SCSI) ? "SCSI" : "SPECIFIC")));
+    pci_log("pci_add_card(): Adding PCI CARD failed (unable to find a suitable PCI slot) [%s]\n", (add_type == PCI_ADD_NORMAL) ? "NORMAL" : ((add_type == PCI_ADD_VIDEO) ? "VIDEO" : ((add_type == PCI_ADD_SCSI) ? "SCSI" : ((add_type == PCI_ADD_SOUND) ? "SOUND" : "SPECIFIC"))));
 
     return 0xff;
 }

--- a/src/sound/snd_audiopci.c
+++ b/src/sound/snd_audiopci.c
@@ -1313,7 +1313,7 @@ static void *es1371_init(const device_t *info)
 		
 	sound_add_handler(es1371_get_buffer, es1371);
 
-	es1371->card = pci_add_card(PCI_ADD_NORMAL, es1371_pci_read, es1371_pci_write, es1371);
+	es1371->card = pci_add_card(info->local ? PCI_ADD_SOUND : PCI_ADD_NORMAL, es1371_pci_read, es1371_pci_write, es1371);
 	
 	timer_add(&es1371->dac[1].timer, es1371_poll, es1371, 1); 
         
@@ -1382,14 +1382,28 @@ void es1371_add_status_info_dac(es1371_t *es1371, char *s, int max_len, int dac_
 
 const device_t es1371_device =
 {
-	"Ensoniq AudioPCI (ES1371)",
-	DEVICE_PCI,
-	0,
-	es1371_init,
-	es1371_close,
-	NULL,
-	NULL,
-	es1371_speed_changed,
-	NULL,
-	NULL
+    "Ensoniq AudioPCI (ES1371)",
+    DEVICE_PCI,
+    0,
+    es1371_init,
+    es1371_close,
+    NULL,
+    NULL,
+    es1371_speed_changed,
+    NULL,
+    NULL
+};
+
+const device_t es1371_onboard_device =
+{
+    "Ensoniq AudioPCI (ES1371) (On-Board)",
+    DEVICE_PCI,
+    1,
+    es1371_init,
+    es1371_close,
+    NULL,
+    NULL,
+    es1371_speed_changed,
+    NULL,
+    NULL
 };

--- a/src/sound/sound.c
+++ b/src/sound/sound.c
@@ -29,6 +29,7 @@
 #include <86box/cdrom.h>
 #include <86box/hdc_ide.h>
 #include <86box/plat.h>
+#include <86box/machine.h>
 #include <86box/sound.h>
 #include <86box/midi.h>
 #include <86box/snd_opl.h>
@@ -79,6 +80,7 @@ static int cd_thread_enable = 0;
 static const SOUND_CARD sound_cards[] =
 {
     { "None",					"none",		NULL				},
+    { "Internal",				"internal",	NULL				},
     { "[ISA] Adlib",				"adlib",	&adlib_device			},
     { "[ISA] Adlib Gold",			"adlibgold",	&adgold_device			},
     { "[ISA] Aztech Sound Galaxy Pro 16 AB (Washington)", "azt2316a",	&azt2316a_device	},
@@ -126,6 +128,9 @@ sound_log(const char *fmt, ...)
 int
 sound_card_available(int card)
 {
+    if ((card == SOUND_INTERNAL) && !(machines[machine].flags & MACHINE_SOUND))
+    	return 0;
+
     if (sound_cards[card].device)
 	return device_available(sound_cards[card].device);
 
@@ -181,7 +186,7 @@ sound_card_get_from_internal_name(char *s)
 void
 sound_card_init(void)
 {
-    if (sound_cards[sound_card_current].device)
+    if ((sound_card_current != SOUND_INTERNAL) && (sound_cards[sound_card_current].device)) /* skip internal sound card */
 	device_add(sound_cards[sound_card_current].device);
 }
 

--- a/src/sound/sound.c
+++ b/src/sound/sound.c
@@ -186,7 +186,7 @@ sound_card_get_from_internal_name(char *s)
 void
 sound_card_init(void)
 {
-    if ((sound_card_current != SOUND_INTERNAL) && (sound_cards[sound_card_current].device)) /* skip internal sound card */
+    if (sound_cards[sound_card_current].device)
 	device_add(sound_cards[sound_card_current].device);
 }
 


### PR DESCRIPTION
* Add onboard sound device support, similar to onboard video; the "Internal" option (visible only on machines with onboard sound) adds the onboard sound device to a PCI_CARD_SOUND slot
* Add onboard ES1371 device
* Add missing PCI slot and fix configuration of the onboard sound slot on the Tyan Tsunami ATX
* Add onboard ES1371 to the Tyan Tsunami ATX
* Small outstanding fixes to the hardware monitor