### PR TITLE
Machine path reorganisation

### DIFF
--- a/src/machine/m_amstrad.c
+++ b/src/machine/m_amstrad.c
@@ -844,7 +844,7 @@ vid_init_1640(amstrad_t *ams)
     vid = (amsvid_t *)malloc(sizeof(amsvid_t));
     memset(vid, 0x00, sizeof(amsvid_t));
 
-    rom_init(&vid->bios_rom, L"roms/machines/pc1640/40100",
+    rom_init(&vid->bios_rom, L"roms/machines/amstrad/pc1640/40100",
 	     0xc0000, 0x8000, 0x7fff, 0, 0);
 
     ega_init(&vid->ega, 9, 0);
@@ -2435,7 +2435,7 @@ machine_amstrad_init(const machine_t *model, int type)
 
     if (gfxcard == VID_INTERNAL) switch(type) {
 	case AMS_PC1512:
-		loadfont(L"roms/machines/pc1512/40078", 8);
+		loadfont(L"roms/machines/amstrad/pc1512/40078", 8);
 		device_context(&vid_1512_device);
 		ams->language = device_get_config_int("language");
 		vid_init_1512(ams);
@@ -2444,7 +2444,7 @@ machine_amstrad_init(const machine_t *model, int type)
 		break;
 	
 	case AMS_PPC512:
-		loadfont(L"roms/machines/ppc512/40109", 1);
+		loadfont(L"roms/machines/amstrad/ppc512/40109", 1);
 		device_context(&vid_ppc512_device);
 		ams->language = device_get_config_int("language");
 		vid_init_200(ams);
@@ -2462,7 +2462,7 @@ machine_amstrad_init(const machine_t *model, int type)
 		break;
 
 	case AMS_PC200:
-		loadfont(L"roms/machines/pc200/40109", 1);
+		loadfont(L"roms/machines/amstrad/pc200/40109", 1);
 		device_context(&vid_200_device);
 		ams->language = device_get_config_int("language");
 		vid_init_200(ams);
@@ -2517,10 +2517,10 @@ machine_pc1512_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/pc1512/40044",
-				L"roms/machines/pc1512/40043",
+    ret = bios_load_interleaved(L"roms/machines/amstrad/pc1512/40044",
+				L"roms/machines/amstrad/pc1512/40043",
 				0x000fc000, 16384, 0);
-    ret &= rom_present(L"roms/machines/pc1512/40078");
+    ret &= rom_present(L"roms/machines/amstrad/pc1512/40078");
 
     if (bios_only || !ret)
 	return ret;
@@ -2536,10 +2536,10 @@ machine_pc1640_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/pc1640/40044.v3",
-				L"roms/machines/pc1640/40043.v3",
+    ret = bios_load_interleaved(L"roms/machines/amstrad/pc1640/40044.v3",
+				L"roms/machines/amstrad/pc1640/40043.v3",
 				0x000fc000, 16384, 0);
-    ret &= rom_present(L"roms/machines/pc1640/40100");
+    ret &= rom_present(L"roms/machines/amstrad/pc1640/40100");
 
     if (bios_only || !ret)
 	return ret;
@@ -2555,10 +2555,10 @@ machine_pc200_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/pc200/pc20v2.1",
-				L"roms/machines/pc200/pc20v2.0",
+    ret = bios_load_interleaved(L"roms/machines/amstrad/pc200/pc20v2.1",
+				L"roms/machines/amstrad/pc200/pc20v2.0",
 				0x000fc000, 16384, 0);
-    ret &= rom_present(L"roms/machines/pc200/40109");
+    ret &= rom_present(L"roms/machines/amstrad/pc200/40109");
 
     if (bios_only || !ret)
 	return ret;
@@ -2574,10 +2574,10 @@ machine_ppc512_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/ppc512/40107.v2",
-				L"roms/machines/ppc512/40108.v2",
+    ret = bios_load_interleaved(L"roms/machines/amstrad/ppc512/40107.v2",
+				L"roms/machines/amstrad/ppc512/40108.v2",
 				0x000fc000, 16384, 0);
-    ret &= rom_present(L"roms/machines/ppc512/40109");
+    ret &= rom_present(L"roms/machines/amstrad/ppc512/40109");
 
     if (bios_only || !ret)
 	return ret;
@@ -2593,10 +2593,10 @@ machine_pc2086_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleavedr(L"roms/machines/pc2086/40179.ic129",
-				 L"roms/machines/pc2086/40180.ic132",
+    ret = bios_load_interleavedr(L"roms/machines/amstrad/pc2086/40179.ic129",
+				 L"roms/machines/amstrad/pc2086/40180.ic132",
 				 0x000fc000, 65536, 0);
-    ret &= rom_present(L"roms/machines/pc2086/40186.ic171");
+    ret &= rom_present(L"roms/machines/amstrad/pc2086/40186.ic171");
 
     if (bios_only || !ret)
 	return ret;
@@ -2612,9 +2612,9 @@ machine_pc3086_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linearr(L"roms/machines/pc3086/fc00.bin",
+    ret = bios_load_linearr(L"roms/machines/amstrad/pc3086/fc00.bin",
 			    0x000fc000, 65536, 0);
-    ret &= rom_present(L"roms/machines/pc3086/c000.bin");
+    ret &= rom_present(L"roms/machines/amstrad/pc3086/c000.bin");
 
     if (bios_only || !ret)
 	return ret;

--- a/src/machine/m_at.c
+++ b/src/machine/m_at.c
@@ -156,8 +156,8 @@ machine_at_ibm_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/ibmat/62x0820.u27",
-				L"roms/machines/ibmat/62x0821.u47",
+    ret = bios_load_interleaved(L"roms/machines/at/ibmat/62x0820.u27",
+				L"roms/machines/at/ibmat/62x0821.u47",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -174,8 +174,8 @@ machine_at_ibmatquadtel_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/ibmatquadtel/BIOS_30MAR90_U27_QUADTEL_ENH_286_BIOS_3.05.01_27256.BIN",
-				L"roms/machines/ibmatquadtel/BIOS_30MAR90_U47_QUADTEL_ENH_286_BIOS_3.05.01_27256.BIN",
+    ret = bios_load_interleaved(L"roms/machines/at/ibmatquadtel/BIOS_30MAR90_U27_QUADTEL_ENH_286_BIOS_3.05.01_27256.BIN",
+				L"roms/machines/at/ibmatquadtel/BIOS_30MAR90_U47_QUADTEL_ENH_286_BIOS_3.05.01_27256.BIN",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -191,8 +191,8 @@ machine_at_ibmatami_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/ibmatami/BIOS_5170_30APR89_U27_AMI_27256.BIN",
-				L"roms/machines/ibmatami/BIOS_5170_30APR89_U47_AMI_27256.BIN",
+    ret = bios_load_interleaved(L"roms/machines/at/ibmatami/BIOS_5170_30APR89_U27_AMI_27256.BIN",
+				L"roms/machines/at/ibmatami/BIOS_5170_30APR89_U47_AMI_27256.BIN",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -208,8 +208,8 @@ machine_at_ibmatpx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/ibmatpx/BIOS ROM - PhoenixBIOS A286 - Version 1.01 - Even.bin",
-				L"roms/machines/ibmatpx/BIOS ROM - PhoenixBIOS A286 - Version 1.01 - Odd.bin",
+    ret = bios_load_interleaved(L"roms/machines/at/ibmatpx/BIOS ROM - PhoenixBIOS A286 - Version 1.01 - Even.bin",
+				L"roms/machines/at/ibmatpx/BIOS ROM - PhoenixBIOS A286 - Version 1.01 - Odd.bin",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -225,8 +225,8 @@ machine_at_ibmxt286_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/ibmxt286/bios_5162_21apr86_u34_78x7460_27256.bin",
-				L"roms/machines/ibmxt286/bios_5162_21apr86_u35_78x7461_27256.bin",
+    ret = bios_load_interleaved(L"roms/machines/at/ibmxt286/bios_5162_21apr86_u34_78x7460_27256.bin",
+				L"roms/machines/at/ibmxt286/bios_5162_21apr86_u35_78x7461_27256.bin",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -243,7 +243,7 @@ machine_at_siemens_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/siemens/286BIOS.BIN",
+    ret = bios_load_linear(L"roms/machines/at/siemens/286BIOS.BIN",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -261,7 +261,7 @@ machine_at_open_at_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/open_at/bios.bin",
+    ret = bios_load_linear(L"roms/machines/at/open_at/bios.bin",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_286_386sx.c
+++ b/src/machine/m_at_286_386sx.c
@@ -43,8 +43,8 @@ machine_at_mr286_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/mr286/V000B200-1",
-				L"roms/machines/mr286/V000B200-2",
+    ret = bios_load_interleaved(L"roms/machines/286_386sx/mr286/V000B200-1",
+				L"roms/machines/286_386sx/mr286/V000B200-2",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -77,7 +77,7 @@ machine_at_headland_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ami386/ami386.bin",
+    ret = bios_load_linear(L"roms/machines/286_386sx/ami386/ami386.bin",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -97,7 +97,7 @@ machine_at_tg286m_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/tg286m/ami.bin",
+    ret = bios_load_linear(L"roms/machines/286_386sx/tg286m/ami.bin",
 			   0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -123,7 +123,7 @@ machine_at_ama932j_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ama932j/ami.bin",
+    ret = bios_load_linear(L"roms/machines/286_386sx/ama932j/ami.bin",
 			   0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -144,8 +144,8 @@ machine_at_quadt286_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/quadt286/QUADT89L.ROM",
-				L"roms/machines/quadt286/QUADT89H.ROM",
+    ret = bios_load_interleaved(L"roms/machines/286_386sx/quadt286/QUADT89L.ROM",
+				L"roms/machines/286_386sx/quadt286/QUADT89H.ROM",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -164,7 +164,7 @@ machine_at_neat_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/dtk386/3cto001.bin",
+    ret = bios_load_linear(L"roms/machines/286_386sx/dtk386/3cto001.bin",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -184,7 +184,7 @@ machine_at_neat_ami_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ami286/amic206.bin",
+    ret = bios_load_linear(L"roms/machines/286_386sx/ami286/amic206.bin",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -205,7 +205,7 @@ machine_at_px286_init(const machine_t *model)
 {
     int ret;
 
-	ret = bios_load_linear(L"roms/machines/px286/KENITEC.BIN",
+	ret = bios_load_linear(L"roms/machines/286_386sx/px286/KENITEC.BIN",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -225,8 +225,8 @@ machine_at_goldstar386_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/goldstar386/386-Goldstar-E.BIN",
-				L"roms/machines/goldstar386/386-Goldstar-O.BIN",
+    ret = bios_load_interleaved(L"roms/machines/286_386sx/goldstar386/386-Goldstar-E.BIN",
+				L"roms/machines/286_386sx/goldstar386/386-Goldstar-O.BIN",
 				0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -245,8 +245,8 @@ machine_at_micronics386_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/micronics386/386-Micronics-09-00021-EVEN.BIN",
-				L"roms/machines/micronics386/386-Micronics-09-00021-ODD.BIN",
+    ret = bios_load_interleaved(L"roms/machines/286_386sx/micronics386/386-Micronics-09-00021-EVEN.BIN",
+				L"roms/machines/286_386sx/micronics386/386-Micronics-09-00021-ODD.BIN",
 				0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -290,7 +290,7 @@ machine_at_award286_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/award286/award.bin",
+    ret = bios_load_linear(L"roms/machines/286_386sx/award286/award.bin",
 			   0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -306,7 +306,7 @@ machine_at_gdc212m_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/gdc212m/gdc212m_72h.bin",
+    ret = bios_load_linear(L"roms/machines/286_386sx/gdc212m/gdc212m_72h.bin",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -322,7 +322,7 @@ machine_at_gw286ct_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/gw286ct/2ctc001.bin",
+    ret = bios_load_linear(L"roms/machines/286_386sx/gw286ct/2ctc001.bin",
 			   0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -341,7 +341,7 @@ machine_at_super286tr_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/super286tr/hyundai_award286.bin",
+    ret = bios_load_linear(L"roms/machines/286_386sx/super286tr/hyundai_award286.bin",
 			   0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -358,7 +358,7 @@ machine_at_spc4200p_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/spc4200p/u8.01",
+    ret = bios_load_linear(L"roms/machines/286_386sx/spc4200p/u8.01",
 			   0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -375,8 +375,8 @@ machine_at_spc4216p_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/spc4216p/7101.u8",
-				L"roms/machines/spc4216p/ac64.u10",
+    ret = bios_load_interleaved(L"roms/machines/286_386sx/spc4216p/7101.u8",
+				L"roms/machines/286_386sx/spc4216p/ac64.u10",
 				0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -393,7 +393,7 @@ machine_at_kmxc02_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/kmxc02/3ctm005.bin",
+    ret = bios_load_linear(L"roms/machines/286_386sx/kmxc02/3ctm005.bin",
 			   0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -409,7 +409,7 @@ machine_at_deskmaster286_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/deskmaster286/SAMSUNG-DESKMASTER-28612-ROM.BIN",
+    ret = bios_load_linear(L"roms/machines/286_386sx/deskmaster286/SAMSUNG-DESKMASTER-28612-ROM.BIN",
 			   0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -425,8 +425,8 @@ machine_at_wd76c10_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/megapc/41651-bios lo.u18",
-				L"roms/machines/megapc/211253-bios hi.u19",
+    ret = bios_load_interleaved(L"roms/machines/286_386sx/megapc/41651-bios lo.u18",
+				L"roms/machines/286_386sx/megapc/211253-bios hi.u19",
 				0x000f0000, 65536, 0x08000);
 
     if (bios_only || !ret)
@@ -455,8 +455,8 @@ machine_at_commodore_sl386sx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/cbm_sl386sx25/cbm-sl386sx-bios-lo-v1.04-390914-04.bin",
-				L"roms/machines/cbm_sl386sx25/cbm-sl386sx-bios-hi-v1.04-390915-04.bin",
+    ret = bios_load_interleaved(L"roms/machines/286_386sx/cbm_sl386sx25/cbm-sl386sx-bios-lo-v1.04-390914-04.bin",
+				L"roms/machines/286_386sx/cbm_sl386sx25/cbm-sl386sx-bios-hi-v1.04-390915-04.bin",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -49,7 +49,7 @@ machine_at_acc386_init(const machine_t *model)
 {
     int ret;
 
-   ret = bios_load_linear(L"roms/machines/acc386/acc386.BIN",
+   ret = bios_load_linear(L"roms/machines/386dx_486/acc386/acc386.BIN",
 			  0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -68,8 +68,8 @@ machine_at_ecs386_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/ecs386/AMI BIOS for ECS-386_32 motherboard - L chip.bin",
-				L"roms/machines/ecs386/AMI BIOS for ECS-386_32 motherboard - H chip.bin",
+    ret = bios_load_interleaved(L"roms/machines/386dx_486/ecs386/AMI BIOS for ECS-386_32 motherboard - L chip.bin",
+				L"roms/machines/386dx_486/ecs386/AMI BIOS for ECS-386_32 motherboard - H chip.bin",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -88,7 +88,7 @@ machine_at_pb410a_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/pb410a/pb410a.080337.4abf.u25.bin",
+    ret = bios_load_linear(L"roms/machines/386dx_486/pb410a/pb410a.080337.4abf.u25.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -125,7 +125,7 @@ machine_at_ali1429_init(const machine_t *model)
 {
     int ret;
 
-   ret = bios_load_linear(L"roms/machines/ami486/ami486.bin",
+   ret = bios_load_linear(L"roms/machines/386dx_486/ami486/ami486.bin",
 			  0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -142,7 +142,7 @@ machine_at_winbios1429_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/win486/ali1429g.amw",
+    ret = bios_load_linear(L"roms/machines/386dx_486/win486/ali1429g.amw",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -159,7 +159,7 @@ machine_at_opti495_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/award495/opt495s.awa",
+    ret = bios_load_linear(L"roms/machines/386dx_486/award495/opt495s.awa",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -193,7 +193,7 @@ machine_at_opti495_ami_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ami495/opt495sx.ami",
+    ret = bios_load_linear(L"roms/machines/386dx_486/ami495/opt495sx.ami",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -210,7 +210,7 @@ machine_at_opti495_mr_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/mr495/opt495sx.mr",
+    ret = bios_load_linear(L"roms/machines/386dx_486/mr495/opt495sx.mr",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -237,7 +237,7 @@ machine_at_ami471_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ami471/SIS471BE.AMI",
+    ret = bios_load_linear(L"roms/machines/386dx_486/ami471/SIS471BE.AMI",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -255,7 +255,7 @@ machine_at_dtk486_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/dtk486/4siw005.bin",
+    ret = bios_load_linear(L"roms/machines/386dx_486/dtk486/4siw005.bin",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -273,7 +273,7 @@ machine_at_px471_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/px471/SIS471A1.PHO",
+    ret = bios_load_linear(L"roms/machines/386dx_486/px471/SIS471A1.PHO",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -292,7 +292,7 @@ machine_at_win471_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/win471/486-SiS_AC0360136.BIN",
+    ret = bios_load_linear(L"roms/machines/386dx_486/win471/486-SiS_AC0360136.BIN",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -331,7 +331,7 @@ machine_at_r418_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/r418/r418i.bin",
+    ret = bios_load_linear(L"roms/machines/386dx_486/r418/r418i.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -354,7 +354,7 @@ machine_at_ls486e_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ls486e/LS486E RevC.BIN",
+    ret = bios_load_linear(L"roms/machines/386dx_486/ls486e/LS486E RevC.BIN",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -378,7 +378,7 @@ machine_at_4dps_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/4dps/4DPS172G.BIN",
+    ret = bios_load_linear(L"roms/machines/386dx_486/4dps/4DPS172G.BIN",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -401,8 +401,8 @@ machine_at_alfredo_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/alfredo/1010AQ0_.BIO",
-				    L"roms/machines/alfredo/1010AQ0_.BI1", 0x1c000, 128);
+    ret = bios_load_linear_combined(L"roms/machines/386dx_486/alfredo/1010AQ0_.BIO",
+				    L"roms/machines/386dx_486/alfredo/1010AQ0_.BI1", 0x1c000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -433,7 +433,7 @@ machine_at_486sp3g_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/486sp3g/PCI-I-486SP3G_0306.001 (Beta).bin",
+    ret = bios_load_linear(L"roms/machines/386dx_486/486sp3g/PCI-I-486SP3G_0306.001 (Beta).bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_commodore.c
+++ b/src/machine/m_at_commodore.c
@@ -97,8 +97,8 @@ machine_at_cmdpc_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/cmdpc30/commodore pc 30 iii even.bin",
-				L"roms/machines/cmdpc30/commodore pc 30 iii odd.bin",
+    ret = bios_load_interleaved(L"roms/machines/commodore/cmdpc30/commodore pc 30 iii even.bin",
+				L"roms/machines/commodore/cmdpc30/commodore pc 30 iii odd.bin",
 				0x000f8000, 32768, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_compaq.c
+++ b/src/machine/m_at_compaq.c
@@ -842,8 +842,8 @@ machine_at_portableii_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleavedr(L"roms/machines/portableii/109740-001.rom",
-				L"roms/machines/portableii/109739-001.rom",
+    ret = bios_load_interleavedr(L"roms/machines/compaq/portableii/109740-001.rom",
+				L"roms/machines/compaq/portableii/109739-001.rom",
 				0x000f8000, 65536, 0);
 
     if (bios_only || !ret)
@@ -860,8 +860,8 @@ machine_at_portableiii_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleavedr(L"roms/machines/portableiii/Compaq Portable III - BIOS - 106779-002 - Even.bin",
-				L"roms/machines/portableiii/Compaq Portable III - BIOS - 106778-002 - Odd.bin",
+    ret = bios_load_interleavedr(L"roms/machines/compaq/portableiii/Compaq Portable III - BIOS - 106779-002 - Even.bin",
+				L"roms/machines/compaq/portableiii/Compaq Portable III - BIOS - 106778-002 - Odd.bin",
 				0x000f8000, 65536, 0);
 
     if (bios_only || !ret)
@@ -878,8 +878,8 @@ machine_at_portableiii386_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleavedr(L"roms/machines/portableiii/Compaq Portable III - BIOS - 106779-002 - Even.bin",
-				L"roms/machines/portableiii/Compaq Portable III - BIOS - 106778-002 - Odd.bin",
+    ret = bios_load_interleavedr(L"roms/machines/compaq/portableiii/Compaq Portable III - BIOS - 106779-002 - Even.bin",
+				L"roms/machines/compaq/portableiii/Compaq Portable III - BIOS - 106778-002 - Odd.bin",
 				0x000f8000, 65536, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -63,7 +63,7 @@ machine_at_p6kfx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p6kfx/kfxa22.bin",
+    ret = bios_load_linear(L"roms/machines/slot1/p6kfx/kfxa22.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -94,7 +94,7 @@ machine_at_6bxc_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/6bxc/powleap.bin",
+    ret = bios_load_linear(L"roms/machines/slot1/6bxc/powleap.bin",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -126,7 +126,7 @@ machine_at_p2bls_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p2bls/1014ls.003",
+    ret = bios_load_linear(L"roms/machines/slot1/p2bls/1014ls.003",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -183,7 +183,7 @@ machine_at_p3bf_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p3bf/bx3f1006.awd",
+    ret = bios_load_linear(L"roms/machines/slot1/p3bf/bx3f1006.awd",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -240,7 +240,7 @@ machine_at_bf6_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/bf6/Beh_70.bin",
+    ret = bios_load_linear(L"roms/machines/slot1/bf6/Beh_70.bin",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -280,7 +280,7 @@ machine_at_p6sba_init(const machine_t *model)
 	
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p6sba/SBAB21.ROM",
+    ret = bios_load_linear(L"roms/machines/slot1/p6sba/SBAB21.ROM",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -341,7 +341,7 @@ machine_at_tsunamiatx_init(const machine_t *model)
 
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/tsunamiatx/bx46200f.rom",
+    ret = bios_load_linear(L"roms/machines/slot1/tsunamiatx/bx46200f.rom",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_slot2.c
+++ b/src/machine/m_at_slot2.c
@@ -55,7 +55,7 @@ machine_at_s2dge_init(const machine_t *model)
 	*/
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/s2dge/2gu7301.rom",
+    ret = bios_load_linear(L"roms/machines/slot2/s2dge/2gu7301.rom",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_socket370.c
+++ b/src/machine/m_at_socket370.c
@@ -47,7 +47,7 @@ machine_at_s370slm_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/s370slm/3LM1202.rom",
+    ret = bios_load_linear(L"roms/machines/socket370/s370slm/3LM1202.rom",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -103,7 +103,7 @@ machine_at_cubx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/cubx/1008cu.004",
+    ret = bios_load_linear(L"roms/machines/socket370/cubx/1008cu.004",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -158,7 +158,7 @@ machine_at_atc7020bxii_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/atc7020bxii/7020s102.bin",
+    ret = bios_load_linear(L"roms/machines/socket370/atc7020bxii/7020s102.bin",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -191,7 +191,7 @@ machine_at_63a_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/63a1/63a-q3.bin",
+    ret = bios_load_linear(L"roms/machines/socket370/63a1/63a-q3.bin",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -224,7 +224,7 @@ machine_at_apas3_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/apas3/V0218SAG.BIN",
+    ret = bios_load_linear(L"roms/machines/socket370/apas3/V0218SAG.BIN",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_socket4_5.c
+++ b/src/machine/m_at_socket4_5.c
@@ -42,7 +42,6 @@
 #include <86box/video.h>
 #include <86box/machine.h>
 
-
 static void
 machine_at_premiere_common_init(const machine_t *model)
 {
@@ -90,8 +89,8 @@ machine_at_batman_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/revenge/1009af2_.bio",
-				    L"roms/machines/revenge/1009af2_.bi1", 0x1c000, 128);
+    ret = bios_load_linear_combined(L"roms/machines/socket4_5/revenge/1009af2_.bio",
+				    L"roms/machines/socket4_5/revenge/1009af2_.bi1", 0x1c000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -109,8 +108,8 @@ machine_at_ambradp60_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/ambradp60/1004AF1P.BIO",
-				    L"roms/machines/ambradp60/1004AF1P.BI1", 0x1c000, 128);
+    ret = bios_load_linear_combined(L"roms/machines/socket4_5/ambradp60/1004AF1P.BIO",
+				    L"roms/machines/socket4_5/ambradp60/1004AF1P.BI1", 0x1c000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -129,8 +128,8 @@ machine_at_valuepointp60_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/valuepointp60/1006AV0M.BIO",
-				    L"roms/machines/valuepointp60/1006AV0M.BI1", 0x1d000, 128);
+    ret = bios_load_linear_combined(L"roms/machines/socket4_5/valuepointp60/1006AV0M.BIO",
+				    L"roms/machines/socket4_5/valuepointp60/1006AV0M.BI1", 0x1d000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -149,7 +148,7 @@ machine_at_586mc1_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/586mc1/IS.34",
+    ret = bios_load_linear(L"roms/machines/socket4_5/586mc1/IS.34",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -168,8 +167,8 @@ machine_at_plato_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/plato/1016ax1_.bio",
-				    L"roms/machines/plato/1016ax1_.bi1", 0x1d000, 128);
+    ret = bios_load_linear_combined(L"roms/machines/socket4_5/plato/1016ax1_.bio",
+				    L"roms/machines/socket4_5/plato/1016ax1_.bi1", 0x1d000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -187,8 +186,8 @@ machine_at_ambradp90_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/ambradp90/1002AX1P.BIO",
-				    L"roms/machines/ambradp90/1002AX1P.BI1", 0x1d000, 128);
+    ret = bios_load_linear_combined(L"roms/machines/socket4_5/ambradp90/1002AX1P.BIO",
+				    L"roms/machines/socket4_5/ambradp90/1002AX1P.BI1", 0x1d000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -206,7 +205,7 @@ machine_at_430nx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/430nx/IP.20",
+    ret = bios_load_linear(L"roms/machines/socket4_5/430nx/IP.20",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -225,7 +224,7 @@ machine_at_p54tp4xe_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p54tp4xe/t15i0302.awd",
+    ret = bios_load_linear(L"roms/machines/socket4_5/p54tp4xe/t15i0302.awd",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -256,8 +255,8 @@ machine_at_endeavor_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/endeavor/1006cb0_.bio",
-				    L"roms/machines/endeavor/1006cb0_.bi1", 0x1d000, 128);
+    ret = bios_load_linear_combined(L"roms/machines/socket4_5/endeavor/1006cb0_.bio",
+				    L"roms/machines/socket4_5/endeavor/1006cb0_.bi1", 0x1d000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -298,8 +297,8 @@ machine_at_zappa_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/zappa/1006bs0_.bio",
-				    L"roms/machines/zappa/1006bs0_.bi1", 0x20000, 128);
+    ret = bios_load_linear_combined(L"roms/machines/socket4_5/zappa/1006bs0_.bio",
+				    L"roms/machines/socket4_5/zappa/1006bs0_.bi1", 0x20000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -327,7 +326,7 @@ machine_at_mb500n_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/mb500n/031396s.bin",
+    ret = bios_load_linear(L"roms/machines/socket4_5/mb500n/031396s.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -357,7 +356,7 @@ machine_at_vectra54_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/vectra54/GT0724.22",
+    ret = bios_load_linear(L"roms/machines/socket4_5/vectra54/GT0724.22",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -388,7 +387,7 @@ machine_at_powermate_v_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/powermate_v/BIOS.ROM",
+    ret = bios_load_linear(L"roms/machines/socket4_5/powermate_v/BIOS.ROM",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_socket7_s7.c
+++ b/src/machine/m_at_socket7_s7.c
@@ -50,7 +50,7 @@ machine_at_chariot_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/chariot/P5IV183.ROM",
+    ret = bios_load_linear(L"roms/machines/socket7/chariot/P5IV183.ROM",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -80,7 +80,7 @@ machine_at_mr586_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/mr586/TRITON.BIO",
+    ret = bios_load_linear(L"roms/machines/socket7/mr586/TRITON.BIO",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -131,8 +131,8 @@ machine_at_thor_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/thor/1006cn0_.bio",
-				    L"roms/machines/thor/1006cn0_.bi1", 0x20000, 128);
+    ret = bios_load_linear_combined(L"roms/machines/socket7/thor/1006cn0_.bio",
+				    L"roms/machines/socket7/thor/1006cn0_.bi1", 0x20000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -148,7 +148,7 @@ machine_at_mrthor_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/mrthor/mr_atx.bio",
+    ret = bios_load_linear(L"roms/machines/socket7/mrthor/mr_atx.bio",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -165,8 +165,8 @@ machine_at_pb640_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/pb640/1007CP0R.BIO",
-				    L"roms/machines/pb640/1007CP0R.BI1", 0x1d000, 128);
+    ret = bios_load_linear_combined(L"roms/machines/socket7/pb640/1007CP0R.BIO",
+				    L"roms/machines/socket7/pb640/1007CP0R.BI1", 0x1d000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -205,7 +205,7 @@ machine_at_acerm3a_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/acerm3a/r01-b3.bin",
+    ret = bios_load_linear(L"roms/machines/socket7/acerm3a/r01-b3.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -238,7 +238,7 @@ machine_at_acerv35n_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/acerv35n/v35nd1s1.bin",
+    ret = bios_load_linear(L"roms/machines/socket7/acerv35n/v35nd1s1.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -271,7 +271,7 @@ machine_at_ap53_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ap53/ap53r2c0.rom",
+    ret = bios_load_linear(L"roms/machines/socket7/ap53/ap53r2c0.rom",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -302,7 +302,7 @@ machine_at_p55t2p4_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p55t2p4/0207_j2.bin",
+    ret = bios_load_linear(L"roms/machines/socket7/p55t2p4/0207_j2.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -332,7 +332,7 @@ machine_at_p55t2s_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p55t2s/s6y08t.rom",
+    ret = bios_load_linear(L"roms/machines/socket7/p55t2s/s6y08t.rom",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -361,7 +361,7 @@ machine_at_m7shi_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/m7shi/m7shi2n.rom",
+    ret = bios_load_linear(L"roms/machines/socket7/m7shi/m7shi2n.rom",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -390,11 +390,11 @@ machine_at_tc430hx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined2(L"roms/machines/tc430hx/1007dh0_.bio",
-				     L"roms/machines/tc430hx/1007dh0_.bi1",
-				     L"roms/machines/tc430hx/1007dh0_.bi2",
-				     L"roms/machines/tc430hx/1007dh0_.bi3",
-				     L"roms/machines/tc430hx/1007dh0_.rcv",
+    ret = bios_load_linear_combined2(L"roms/machines/socket7/tc430hx/1007dh0_.bio",
+				     L"roms/machines/socket7/tc430hx/1007dh0_.bi1",
+				     L"roms/machines/socket7/tc430hx/1007dh0_.bi2",
+				     L"roms/machines/socket7/tc430hx/1007dh0_.bi3",
+				     L"roms/machines/socket7/tc430hx/1007dh0_.rcv",
 				     0x3a000, 128);
 
     if (bios_only || !ret)
@@ -425,11 +425,11 @@ machine_at_equium5200_init(const machine_t *model) // Information about that mac
 {
     int ret;
 
-    ret = bios_load_linear_combined2(L"roms/machines/equium5200/1003DK08.BIO",
-				     L"roms/machines/equium5200/1003DK08.BI1",
-				     L"roms/machines/equium5200/1003DK08.BI2",
-				     L"roms/machines/equium5200/1003DK08.BI3",
-				     L"roms/machines/equium5200/1003DK08.RCV",
+    ret = bios_load_linear_combined2(L"roms/machines/socket7/equium5200/1003DK08.BIO",
+				     L"roms/machines/socket7/equium5200/1003DK08.BI1",
+				     L"roms/machines/socket7/equium5200/1003DK08.BI2",
+				     L"roms/machines/socket7/equium5200/1003DK08.BI3",
+				     L"roms/machines/socket7/equium5200/1003DK08.RCV",
 				     0x3a000, 128);
 
     if (bios_only || !ret)
@@ -475,7 +475,7 @@ machine_at_p55tvp4_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p55tvp4/0204_128.BIN",
+    ret = bios_load_linear(L"roms/machines/socket7/p55tvp4/0204_128.BIN",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -504,7 +504,7 @@ machine_at_i430vx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/430vx/55xwuq0e.bin",
+    ret = bios_load_linear(L"roms/machines/socket7/430vx/55xwuq0e.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -533,7 +533,7 @@ machine_at_p55va_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p55va/va021297.bin",
+    ret = bios_load_linear(L"roms/machines/socket7/p55va/va021297.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -562,7 +562,7 @@ machine_at_brio80xx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/brio80xx/Hf0705.rom",
+    ret = bios_load_linear(L"roms/machines/socket7/brio80xx/Hf0705.rom",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -591,11 +591,11 @@ machine_at_pb680_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined2(L"roms/machines/pb680/1012DN0R.BIO",
-				     L"roms/machines/pb680/1012DN0R.BI1",
-				     L"roms/machines/pb680/1012DN0R.BI2",
-				     L"roms/machines/pb680/1012DN0R.BI3",
-				     L"roms/machines/pb680/1012DN0R.RCV",
+    ret = bios_load_linear_combined2(L"roms/machines/socket7/pb680/1012DN0R.BIO",
+				     L"roms/machines/socket7/pb680/1012DN0R.BI1",
+				     L"roms/machines/socket7/pb680/1012DN0R.BI2",
+				     L"roms/machines/socket7/pb680/1012DN0R.BI3",
+				     L"roms/machines/socket7/pb680/1012DN0R.RCV",
 				     0x3a000, 128);
 
     if (bios_only || !ret)
@@ -625,7 +625,7 @@ machine_at_nupro592_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/nupro592/np590b10.bin",
+    ret = bios_load_linear(L"roms/machines/socket7/nupro592/np590b10.bin",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -692,7 +692,7 @@ machine_at_tx97_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/tx97/0112.001",
+    ret = bios_load_linear(L"roms/machines/socket7/tx97/0112.001",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -760,7 +760,7 @@ machine_at_ym430tx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ym430tx/YM430TX.003",
+    ret = bios_load_linear(L"roms/machines/socket7/ym430tx/YM430TX.003",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -793,7 +793,7 @@ machine_at_586t2_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/586t2/5itw001.bin",
+    ret = bios_load_linear(L"roms/machines/socket7/586t2/5itw001.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -824,7 +824,7 @@ machine_at_807ds_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/807ds/Tx0212g.rom",
+    ret = bios_load_linear(L"roms/machines/socket7/807ds/Tx0212g.rom",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -855,7 +855,7 @@ machine_at_p5mms98_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p5mms98/s981182.rom",
+    ret = bios_load_linear(L"roms/machines/socket7/p5mms98/s981182.rom",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -920,7 +920,7 @@ machine_at_ficva502_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ficva502/VA502bp.BIN",
+    ret = bios_load_linear(L"roms/machines/socket7/ficva502/VA502bp.BIN",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -949,7 +949,7 @@ machine_at_ficpa2012_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ficpa2012/113jb16.awd",
+    ret = bios_load_linear(L"roms/machines/socket7/ficpa2012/113jb16.awd",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -979,7 +979,7 @@ machine_at_advanceii_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/advanceii/VP3_V27.BIN",
+    ret = bios_load_linear(L"roms/machines/socket7/advanceii/VP3_V27.BIN",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_socket8.c
+++ b/src/machine/m_at_socket8.c
@@ -46,7 +46,7 @@ machine_at_686nx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/686nx/6nx.140",
+    ret = bios_load_linear(L"roms/machines/socket8/686nx/6nx.140",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -76,7 +76,7 @@ machine_at_mb600n_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/mb600n/60915cs.rom",
+    ret = bios_load_linear(L"roms/machines/socket8/mb600n/60915cs.rom",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -105,7 +105,7 @@ machine_at_8500ttc_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/8500ttc/TTC0715B.ROM",
+    ret = bios_load_linear(L"roms/machines/socket8/8500ttc/TTC0715B.ROM",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -134,7 +134,7 @@ machine_at_m6mi_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/m6mi/M6MI05.ROM",
+    ret = bios_load_linear(L"roms/machines/socket8/m6mi/M6MI05.ROM",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_super7_ss7.c
+++ b/src/machine/m_at_super7_ss7.c
@@ -50,7 +50,7 @@ machine_at_ax59pro_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ax59pro/AX59P236.BIN",
+    ret = bios_load_linear(L"roms/machines/super7/ax59pro/AX59P236.BIN",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -82,7 +82,7 @@ machine_at_mvp3_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ficva503p/je4333.bin",
+    ret = bios_load_linear(L"roms/machines/super7/ficva503p/je4333.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_europc.c
+++ b/src/machine/m_europc.c
@@ -710,7 +710,7 @@ machine_europc_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/europc/50145",
+    ret = bios_load_linear(L"roms/machines/xt/europc/50145",
 			   0x000f8000, 32768, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_ps1.c
+++ b/src/machine/m_ps1.c
@@ -452,7 +452,7 @@ ps1_setup(int model)
 
     if (model == 2011) {
 	rom_init(&ps->high_rom,
-		 L"roms/machines/ibmps1es/f80000.bin",
+		 L"roms/machines/ps1/ibmps1es/f80000.bin",
 		 0xf80000, 0x80000, 0x7ffff, 0, MEM_MAPPING_EXTERNAL);
 
 	lpt2_remove();
@@ -475,7 +475,7 @@ ps1_setup(int model)
 
 #if 0
 	rom_init(&ps->high_rom,
-		 L"roms/machines/ibmps1_2121/fc0000.bin",
+		 L"roms/machines/ps1/ibmps1_2121/fc0000.bin",
 		 0xfc0000, 0x20000, 0x1ffff, 0, MEM_MAPPING_EXTERNAL);
 #endif
 
@@ -533,7 +533,7 @@ machine_ps1_m2011_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ibmps1es/f80000.bin",
+    ret = bios_load_linear(L"roms/machines/ps1/ibmps1es/f80000.bin",
 			   0x000e0000, 131072, 0x60000);
 
     if (bios_only || !ret)
@@ -552,7 +552,7 @@ machine_ps1_m2121_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ibmps1_2121/fc0000.bin",
+    ret = bios_load_linear(L"roms/machines/ps1/ibmps1_2121/fc0000.bin",
 			   0x000e0000, 131072, 0x20000);
 
     if (bios_only || !ret)
@@ -572,7 +572,7 @@ machine_ps1_m2133_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ibmps1_2133/ps1_2133_52g2974_rom.bin",
+    ret = bios_load_linear(L"roms/machines/ps1/ibmps1_2133/ps1_2133_52g2974_rom.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_ps2_isa.c
+++ b/src/machine/m_ps2_isa.c
@@ -166,7 +166,7 @@ machine_ps2_m30_286_init(const machine_t *model)
 
 	int ret;
 
-	ret = bios_load_linear(L"roms/machines/ibmps2_m30_286/33f5381a.bin",
+	ret = bios_load_linear(L"roms/machines/ps2/ibmps2_m30_286/33f5381a.bin",
 			       0x000e0000, 131072, 0);
 
 	if (bios_only || !ret)

--- a/src/machine/m_ps2_mca.c
+++ b/src/machine/m_ps2_mca.c
@@ -1269,11 +1269,11 @@ machine_ps2_model_50_init(const machine_t *model)
 {
 	int ret;
 
-	ret = bios_load_interleaved(L"roms/machines/ibmps2_m50/90x7420.zm13",
-				    L"roms/machines/ibmps2_m50/90x7429.zm18",
+	ret = bios_load_interleaved(L"roms/machines/ps2/ibmps2_m50/90x7420.zm13",
+				    L"roms/machines/ps2/ibmps2_m50/90x7429.zm18",
 				    0x000f0000, 131072, 0);
-	ret &= bios_load_aux_interleaved(L"roms/machines/ibmps2_m50/90x7423.zm14",
-					 L"roms/machines/ibmps2_m50/90x7426.zm16",
+	ret &= bios_load_aux_interleaved(L"roms/machines/ps2/ibmps2_m50/90x7423.zm14",
+					 L"roms/machines/ps2/ibmps2_m50/90x7426.zm16",
 					 0x000e0000, 65536, 0);
 
 	if (bios_only || !ret)
@@ -1292,8 +1292,8 @@ machine_ps2_model_55sx_init(const machine_t *model)
 {
 	int ret;
 
-	ret = bios_load_interleaved(L"roms/machines/ibmps2_m55sx/33f8146.zm41",
-				    L"roms/machines/ibmps2_m55sx/33f8145.zm40",
+	ret = bios_load_interleaved(L"roms/machines/ps2/ibmps2_m55sx/33f8146.zm41",
+				    L"roms/machines/ps2/ibmps2_m55sx/33f8145.zm40",
 				    0x000e0000, 131072, 0);
 
 	if (bios_only || !ret)
@@ -1312,8 +1312,8 @@ machine_ps2_model_70_type3_init(const machine_t *model)
 {
 	int ret;
 
-	ret = bios_load_interleaved(L"roms/machines/ibmps2_m70_type3/70-a_even.bin",
-				    L"roms/machines/ibmps2_m70_type3/70-a_odd.bin",
+	ret = bios_load_interleaved(L"roms/machines/ps2/ibmps2_m70_type3/70-a_even.bin",
+				    L"roms/machines/ps2/ibmps2_m70_type3/70-a_odd.bin",
 				    0x000e0000, 131072, 0);
 
 	if (bios_only || !ret)
@@ -1333,8 +1333,8 @@ machine_ps2_model_70_type4_init(const machine_t *model)
 {
 	int ret;
 
-	ret = bios_load_interleaved(L"roms/machines/ibmps2_m70_type4/70-b_even.bin",
-				    L"roms/machines/ibmps2_m70_type4/70-b_odd.bin",
+	ret = bios_load_interleaved(L"roms/machines/ps2/ibmps2_m70_type4/70-b_even.bin",
+				    L"roms/machines/ps2/ibmps2_m70_type4/70-b_odd.bin",
 				    0x000e0000, 131072, 0);
 
 	if (bios_only || !ret)
@@ -1354,8 +1354,8 @@ machine_ps2_model_80_init(const machine_t *model)
 {
 	int ret;
 
-	ret = bios_load_interleaved(L"roms/machines/ibmps2_m80/15f6637.bin",
-				    L"roms/machines/ibmps2_m80/15f6639.bin",
+	ret = bios_load_interleaved(L"roms/machines/ps2/ibmps2_m80/15f6637.bin",
+				    L"roms/machines/ps2/ibmps2_m80/15f6639.bin",
 				    0x000e0000, 131072, 0);
 
 	if (bios_only || !ret)

--- a/src/machine/m_tandy.c
+++ b/src/machine/m_tandy.c
@@ -1446,8 +1446,8 @@ init_rom(tandy_t *dev)
     dev->rom = (uint8_t *)malloc(0x80000);
 
 #if 1
-    if (! rom_load_interleaved(L"roms/machines/tandy1000sl2/8079047.hu1",
-			       L"roms/machines/tandy1000sl2/8079048.hu2",
+    if (! rom_load_interleaved(L"roms/machines/tandy/tandy1000sl2/8079047.hu1",
+			       L"roms/machines/tandy/tandy1000sl2/8079048.hu2",
 			       0x000000, 0x80000, 0, dev->rom)) {
 	tandy_log("TANDY: unable to load BIOS for 1000/SL2 !\n");
 	free(dev->rom);
@@ -1455,8 +1455,8 @@ init_rom(tandy_t *dev)
 	return;
     }
 #else
-    f  = rom_fopen(L"roms/machines/tandy1000sl2/8079047.hu1", L"rb");
-    ff = rom_fopen(L"roms/machines/tandy1000sl2/8079048.hu2", L"rb");
+    f  = rom_fopen(L"roms/machines/tandy/tandy1000sl2/8079047.hu1", L"rb");
+    ff = rom_fopen(L"roms/machines/tandy/tandy1000sl2/8079048.hu2", L"rb");
     for (c = 0x0000; c < 0x80000; c += 2) {
 	dev->rom[c] = getc(f);
 	dev->rom[c + 1] = getc(ff);
@@ -1545,7 +1545,7 @@ machine_tandy_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linearr(L"roms/machines/tandy/tandy1t1.020",
+    ret = bios_load_linearr(L"roms/machines/tandy/tandy/tandy1t1.020",
 			    0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -1562,7 +1562,7 @@ machine_tandy1000hx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/tandy1000hx/v020000.u12",
+    ret = bios_load_linear(L"roms/machines/tandy/tandy1000hx/v020000.u12",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -1579,8 +1579,8 @@ machine_tandy1000sl2_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/tandy1000sl2/8079047.hu1",
-				L"roms/machines/tandy1000sl2/8079048.hu2",
+    ret = bios_load_interleaved(L"roms/machines/tandy/tandy1000sl2/8079047.hu1",
+				L"roms/machines/tandy/tandy1000sl2/8079048.hu2",
 				0x000f0000, 65536, 0x18000);
 
     if (bios_only || !ret)

--- a/src/machine/m_xt.c
+++ b/src/machine/m_xt.c
@@ -36,16 +36,16 @@ machine_pc_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ibmpc/BIOS_5150_24APR81_U33.BIN",
+    ret = bios_load_linear(L"roms/machines/xt/ibmpc/BIOS_5150_24APR81_U33.BIN",
 			   0x000fe000, 40960, 0);
     if (ret) {
-	bios_load_aux_linear(L"roms/machines/ibmpc/IBM 5150 - Cassette BASIC version C1.00 - U29 - 5700019.bin",
+	bios_load_aux_linear(L"roms/machines/xt/ibmpc/IBM 5150 - Cassette BASIC version C1.00 - U29 - 5700019.bin",
 			     0x000f6000, 8192, 0);
-	bios_load_aux_linear(L"roms/machines/ibmpc/IBM 5150 - Cassette BASIC version C1.00 - U30 - 5700027.bin",
+	bios_load_aux_linear(L"roms/machines/xt/ibmpc/IBM 5150 - Cassette BASIC version C1.00 - U30 - 5700027.bin",
 			     0x000f8000, 8192, 0);
-	bios_load_aux_linear(L"roms/machines/ibmpc/IBM 5150 - Cassette BASIC version C1.00 - U31 - 5700035.bin",
+	bios_load_aux_linear(L"roms/machines/xt/ibmpc/IBM 5150 - Cassette BASIC version C1.00 - U31 - 5700035.bin",
 			     0x000fa000, 8192, 0);
-	bios_load_aux_linear(L"roms/machines/ibmpc/IBM 5150 - Cassette BASIC version C1.00 - U32 - 5700043.bin",
+	bios_load_aux_linear(L"roms/machines/xt/ibmpc/IBM 5150 - Cassette BASIC version C1.00 - U32 - 5700043.bin",
 			     0x000fc000, 8192, 0);
     }
 
@@ -65,19 +65,19 @@ machine_pc82_init(const machine_t *model)
 {
     int ret, ret2;
 
-    ret = bios_load_linear(L"roms/machines/ibmpc82/pc102782.bin",
+    ret = bios_load_linear(L"roms/machines/xt/ibmpc82/pc102782.bin",
 			   0x000fe000, 40960, 0);
     if (ret) {
-	ret2 = bios_load_aux_linear(L"roms/machines/ibmpc82/ibm-basic-1.10.rom",
+	ret2 = bios_load_aux_linear(L"roms/machines/xt/ibmpc82/ibm-basic-1.10.rom",
 				    0x000f6000, 32768, 0);
 	if (!ret2) {
-		bios_load_aux_linear(L"roms/machines/ibmpc82/basicc11.f6",
+		bios_load_aux_linear(L"roms/machines/xt/ibmpc82/basicc11.f6",
 				     0x000f6000, 8192, 0);
-		bios_load_aux_linear(L"roms/machines/ibmpc82/basicc11.f8",
+		bios_load_aux_linear(L"roms/machines/xt/ibmpc82/basicc11.f8",
 				     0x000f8000, 8192, 0);
-		bios_load_aux_linear(L"roms/machines/ibmpc82/basicc11.fa",
+		bios_load_aux_linear(L"roms/machines/xt/ibmpc82/basicc11.fa",
 				     0x000fa000, 8192, 0);
-		bios_load_aux_linear(L"roms/machines/ibmpc82/basicc11.fc",
+		bios_load_aux_linear(L"roms/machines/xt/ibmpc82/basicc11.fc",
 				     0x000fc000, 8192, 0);
 	}
     }
@@ -108,15 +108,15 @@ machine_xt_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ibmxt/xt.rom",
+    ret = bios_load_linear(L"roms/machines/xt/ibmxt/xt.rom",
 			   0x000f0000, 65536, 0);
     if (!ret) {
-	ret = bios_load_linear(L"roms/machines/ibmxt/1501512.u18",
+	ret = bios_load_linear(L"roms/machines/xt/ibmxt/1501512.u18",
 			       0x000fe000, 65536, 0x6000);
 	if (ret) {
-		bios_load_aux_linear(L"roms/machines/ibmxt/1501512.u18",
+		bios_load_aux_linear(L"roms/machines/xt/ibmxt/1501512.u18",
 				     0x000f8000, 24576, 0);
-		bios_load_aux_linear(L"roms/machines/ibmxt/5000027.u19",
+		bios_load_aux_linear(L"roms/machines/xt/ibmxt/5000027.u19",
 				     0x000f0000, 32768, 0);
 	}
     }
@@ -137,7 +137,7 @@ machine_genxt_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/genxt/pcxt.rom",
+    ret = bios_load_linear(L"roms/machines/xt/genxt/pcxt.rom",
 			   0x000fe000, 8192, 0);
 
     if (bios_only || !ret)
@@ -154,12 +154,12 @@ machine_xt86_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ibmxt86/BIOS_5160_09MAY86_U18_59X7268_62X0890_27256_F800.BIN",
+    ret = bios_load_linear(L"roms/machines/xt/ibmxt86/BIOS_5160_09MAY86_U18_59X7268_62X0890_27256_F800.BIN",
 			   0x000fe000, 65536, 0x6000);
     if (ret) {
-	(void) bios_load_aux_linear(L"roms/machines/ibmxt86/BIOS_5160_09MAY86_U18_59X7268_62X0890_27256_F800.BIN",
+	(void) bios_load_aux_linear(L"roms/machines/xt/ibmxt86/BIOS_5160_09MAY86_U18_59X7268_62X0890_27256_F800.BIN",
 				    0x000f8000, 24576, 0);
-	(void) bios_load_aux_linear(L"roms/machines/ibmxt86/BIOS_5160_09MAY86_U19_62X0819_68X4370_27256_F000.BIN",
+	(void) bios_load_aux_linear(L"roms/machines/xt/ibmxt86/BIOS_5160_09MAY86_U19_62X0819_68X4370_27256_F000.BIN",
 				    0x000f0000, 32768, 0);
     }
 
@@ -189,7 +189,7 @@ machine_xt_amixt_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/amixt/ami_8088_bios_31jan89.bin",
+    ret = bios_load_linear(L"roms/machines/xt/amixt/ami_8088_bios_31jan89.bin",
 			   0x000fe000, 8192, 0);
 
     if (bios_only || !ret)
@@ -206,7 +206,7 @@ machine_xt_dtk_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/dtk/dtk_erso_2.42_2764.bin",
+    ret = bios_load_linear(L"roms/machines/xt/dtk/dtk_erso_2.42_2764.bin",
 			   0x000fe000, 8192, 0);
 
     if (bios_only || !ret)
@@ -223,7 +223,7 @@ machine_xt_jukopc_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/jukopc/000o001.bin",
+    ret = bios_load_linear(L"roms/machines/xt/jukopc/000o001.bin",
 			   0x000fe000, 8192, 0);
 
     if (bios_only || !ret)
@@ -240,7 +240,7 @@ machine_xt_open_xt_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/open_xt/pcxt31.bin",
+    ret = bios_load_linear(L"roms/machines/xt/open_xt/pcxt31.bin",
 			   0x000fe000, 8192, 0);
 
     if (bios_only || !ret)
@@ -256,7 +256,7 @@ machine_xt_hed919_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/hed919/Hedaka_HED-919_bios_version_3.28f.bin",
+    ret = bios_load_linear(L"roms/machines/xt/hed919/Hedaka_HED-919_bios_version_3.28f.bin",
 			   0x000fe000, 8192, 0);
 
     if (bios_only || !ret)
@@ -272,7 +272,7 @@ machine_xt_pxxt_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/pxxt/000p001.bin",
+    ret = bios_load_linear(L"roms/machines/xt/pxxt/000p001.bin",
 			   0x000fe000, 8192, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_xt_compaq.c
+++ b/src/machine/m_xt_compaq.c
@@ -42,7 +42,7 @@ machine_xt_compaq_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/portable/compaq portable plus 100666-001 rev c u47.bin",
+    ret = bios_load_linear(L"roms/machines/compaq/portable/compaq portable plus 100666-001 rev c u47.bin",
 			   0x000fe000, 8192, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_xt_laserxt.c
+++ b/src/machine/m_xt_laserxt.c
@@ -139,7 +139,7 @@ machine_xt_laserxt_init(const machine_t *model)
 {
 	int ret;
 
-	ret = bios_load_linear(L"roms/machines/ltxt/27c64.bin",
+	ret = bios_load_linear(L"roms/machines/xt/ltxt/27c64.bin",
 			       0x000fe000, 8192, 0);
 
 	if (bios_only || !ret)
@@ -158,7 +158,7 @@ machine_xt_lxt3_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/lxt3/27c64d.bin",
+    ret = bios_load_linear(L"roms/machines/xt/lxt3/27c64d.bin",
 			   0x000fe000, 8192, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_xt_t1000.c
+++ b/src/machine/m_xt_t1000.c
@@ -858,7 +858,7 @@ machine_xt_t1000_init(const machine_t *model)
 
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/t1000/t1000.rom",
+    ret = bios_load_linear(L"roms/machines/t1000/t1000/t1000.rom",
 			   0x000f8000, 32768, 0);
 
     if (bios_only || !ret)
@@ -870,7 +870,7 @@ machine_xt_t1000_init(const machine_t *model)
     t1000.ems_port_index = 7;	/* EMS disabled */
 
     /* Load the T1000 CGA Font ROM. */
-    loadfont(L"roms/machines/t1000/t1000font.rom", 2);
+    loadfont(L"roms/machines/t1000/t1000/t1000font.rom", 2);
 
     /*
      * The ROM drive is optional.
@@ -878,7 +878,7 @@ machine_xt_t1000_init(const machine_t *model)
      * If the file is missing, continue to boot; the BIOS will
      * complain 'No ROM drive' but boot normally from floppy.
      */
-    f = rom_fopen(L"roms/machines/t1000/t1000dos.rom", L"rb");
+    f = rom_fopen(L"roms/machines/t1000/t1000/t1000dos.rom", L"rb");
     if (f != NULL) {
 	t1000.romdrive = malloc(T1000_ROMSIZE);
 	if (t1000.romdrive) {
@@ -951,7 +951,7 @@ machine_xt_t1200_init(const machine_t *model)
 
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/t1200/t1200_019e.ic15.bin",
+    ret = bios_load_linear(L"roms/machines/t1000/t1200/t1200_019e.ic15.bin",
 			   0x000f8000, 32768, 0);
 
     if (bios_only || !ret)
@@ -962,7 +962,7 @@ machine_xt_t1200_init(const machine_t *model)
     t1000.ems_port_index = 7;	/* EMS disabled */
 
     /* Load the T1200 CGA Font ROM. */
-    loadfont(L"roms/machines/t1200/t1000font.bin", 2);
+    loadfont(L"roms/machines/t1000/t1200/t1000font.bin", 2);
 
     /* Map the EMS page frame */
     for (pg = 0; pg < 4; pg++) {

--- a/src/machine/m_xt_xi8088.c
+++ b/src/machine/m_xt_xi8088.c
@@ -151,18 +151,18 @@ machine_xt_xi8088_init(const machine_t *model)
     int ret;
 
     if (bios_only) {
-	ret = bios_load_linear_inverted(L"roms/machines/xi8088/bios-xi8088-128k.bin",
+	ret = bios_load_linear_inverted(L"roms/machines/xt/xi8088/bios-xi8088-128k.bin",
 					0x000e0000, 131072, 0);
-	ret |= bios_load_linear(L"roms/machines/xi8088/bios-xi8088.bin",
+	ret |= bios_load_linear(L"roms/machines/xt/xi8088/bios-xi8088.bin",
 				0x000f0000, 65536, 0);
     } else {
 	device_add(&xi8088_device);
 
 	if (xi8088_bios_128kb()) {
-		ret = bios_load_linear_inverted(L"roms/machines/xi8088/bios-xi8088-128k.bin",
+		ret = bios_load_linear_inverted(L"roms/machines/xt/xi8088/bios-xi8088-128k.bin",
 						0x000e0000, 131072, 0);
 	} else {
-		ret = bios_load_linear(L"roms/machines/xi8088/bios-xi8088.bin",
+		ret = bios_load_linear(L"roms/machines/xt/xi8088/bios-xi8088.bin",
 				       0x000f0000, 65536, 0);
 	}
     }

--- a/src/machine/m_xt_zenith.c
+++ b/src/machine/m_xt_zenith.c
@@ -109,7 +109,7 @@ machine_xt_zenith_init(const machine_t *model)
 {		
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/zdsupers/z184m v3.1d.10d",
+    ret = bios_load_linear(L"roms/machines/xt/zdsupers/z184m v3.1d.10d",
 			   0x000f8000, 32768, 0);
 
     if (bios_only || !ret)

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -206,6 +206,7 @@ const machine_t machines[] = {
     { "[486 PCI] Zida Tomato 4DP",		"4dps",			{{"Intel", cpus_i486},        {"AMD", cpus_Am486},   {"Cyrix", cpus_Cx486},  {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_HDC,						  1,  255,   1, 127,		 machine_at_4dps_init, NULL			},
 
     /* Socket 4 machines */
+	
     /* 430LX */
     { "[Socket 4 LX] IBM Ambra DP60 PCI",	"ambradp60",		{{"Intel", cpus_Pentium5V},   {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  2,  128,   2, 127,	    machine_at_ambradp60_init, NULL			},
 #if defined(DEV_BRANCH) && defined(USE_VPP60)


### PR DESCRIPTION
The machine roms have been reorganized according to class(8086 - 286), CPU model (286 - 486) & Socket(Socket 4 - PGA370). Few exceptions are some manufacturer ROMs