### PR TITLE
Hardware monitor fixes

### DIFF
--- a/src/hwm_lm75.c
+++ b/src/hwm_lm75.c
@@ -128,7 +128,7 @@ lm75_read(lm75_t *dev, uint8_t reg)
     /* The AS99127F hardware monitor uses the addresses of its LM75 devices
        to access some of its proprietary registers. Pass this operation on to
        the main monitor address through an internal SMBus call, if necessary. */
-    if (((reg & 0xf8) != 0x50) && (dev->as99127f_smbus_addr))
+    if ((reg > 0x7) && ((reg & 0xf8) != 0x50) && (dev->as99127f_smbus_addr))
     	ret = smbus_read_byte_cmd(dev->as99127f_smbus_addr, reg);
     else
     	ret = dev->regs[reg & 0x7];
@@ -191,7 +191,7 @@ lm75_write(lm75_t *dev, uint8_t reg, uint8_t val)
     /* The AS99127F hardware monitor uses the addresses of its LM75 devices
        to access some of its proprietary registers. Pass this operation on to
        the main monitor address through an internal SMBus call, if necessary. */
-    if (((reg & 0xf8) != 0x50) && (dev->as99127f_smbus_addr)) {
+    if ((reg > 0x7) && ((reg & 0xf8) != 0x50) && (dev->as99127f_smbus_addr)) {
     	smbus_write_byte_cmd(dev->as99127f_smbus_addr, reg, val);
     	return 1;
     }

--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -229,6 +229,8 @@ machine_at_p3bf_init(const machine_t *model)
     };
     if (model->cpu[cpu_manufacturer].cpus[cpu_effective].cpu_type == CPU_PENTIUM2)
     	machine_hwm.voltages[0] = 2800; /* set higher VCORE (2.8V) for Klamath */
+    else if (model->cpu[cpu_manufacturer].cpus[cpu_effective].cpu_type == CPU_CYRIX3S)
+    	machine_hwm.voltages[0] = 2800; /* P3B-F specific issue: it believes the Cyrix III is a Klamath, and therefore expects a toasty 2.8V */
     hwm_set_values(machine_hwm);
     device_add(&as99127f_device);
 


### PR DESCRIPTION
* Fix secondary temperature readouts on AS99127F machines
* Work around the P3B-F's expected VCORE for Cyrix III