### PR TITLE
Replace the P6KFX with the KN97

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -334,7 +334,7 @@ extern int	machine_at_p65up5_cp6nd_init(const machine_t *);
 
 /* m_at_slot1.c */
 extern int	machine_at_p65up5_cpknd_init(const machine_t *);
-extern int	machine_at_p6kfx_init(const machine_t *);
+extern int	machine_at_kn97_init(const machine_t *);
 
 #if defined(DEV_BRANCH) && defined(NO_SIO)
 extern int	machine_at_6bxc_init(const machine_t *);

--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -59,11 +59,11 @@ machine_at_p65up5_cpknd_init(const machine_t *model)
 }
 
 int
-machine_at_p6kfx_init(const machine_t *model)
+machine_at_kn97_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p6kfx/kfxa22.bin",
+    ret = bios_load_linear(L"roms/machines/kn97/0116I.001",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -74,17 +74,42 @@ machine_at_p6kfx_init(const machine_t *model)
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
     pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x09, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x0A, PCI_CARD_NORMAL, 2, 3, 4, 1);
-    pci_register_slot(0x0B, PCI_CARD_NORMAL, 3, 4, 1, 2);
-    pci_register_slot(0x0C, PCI_CARD_NORMAL, 4, 1, 2, 3);
-    pci_register_slot(0x0D, PCI_CARD_NORMAL, 4, 1, 2, 3);
+    pci_register_slot(0x0C, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL, 2, 3, 4, 1);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL, 3, 4, 1, 2);
+    pci_register_slot(0x09, PCI_CARD_NORMAL, 4, 1, 2, 3);
+	pci_register_slot(0x0D, PCI_CARD_NORMAL, 4, 1, 2, 3);
     device_add(&i440fx_device);
     device_add(&piix3_device);
-    device_add(&keyboard_ps2_ami_pci_device); /*Didn't post with regular PS/2 PCI*/
+    device_add(&keyboard_ps2_pci_device);
     device_add(&w83877f_device);
     device_add(&intel_flash_bxt_device);
-
+	spd_register(SPD_TYPE_EDO, 0xF, 256);
+	
+    hwm_values_t machine_hwm = {
+    	{    /* fan speeds */
+    		3000,	/* Chassis */
+    		3000,	/* CPU */
+    		3000	/* Power */
+    	}, { /* temperatures */
+    		30,	/* MB */
+    		0,	/* unused */
+    		27	/* CPU */
+    	}, { /* voltages */
+    		2050,				   /* VCORE (2.05V by default) */
+    		0,				   /* unused */
+    		3300,				   /* +3.3V */
+    		RESISTOR_DIVIDER(5000,   11,  16), /* +5V  (divider values bruteforced) */
+    		RESISTOR_DIVIDER(12000,  28,  10), /* +12V (28K/10K divider suggested in the W83781D datasheet) */
+    		RESISTOR_DIVIDER(12000, 853, 347), /* -12V (divider values bruteforced) */
+    		RESISTOR_DIVIDER(5000,    1,   2)  /* -5V  (divider values bruteforced) */
+    	}
+    };
+    if (model->cpu[cpu_manufacturer].cpus[cpu_effective].cpu_type == CPU_PENTIUM2)
+    	machine_hwm.voltages[0] = 2800; /* set higher VCORE (2.8V) for Klamath */
+    hwm_set_values(machine_hwm);
+    device_add(&lm78_device);
+	
     return ret;
 }
 

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -291,7 +291,7 @@ const machine_t machines[] = {
     /* Slot 1 machines */
     /* 440FX */
     { "[Slot 1 FX] ASUS P/I-P65UP5 (C-PKND)",	"p65up5_cpknd",		{{"Intel", cpus_PentiumII_28v},{"",    NULL},        {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  512,   8, 127,	 machine_at_p65up5_cpknd_init, NULL			},
-    { "[Slot 1 FX] ECS P6KFX-A",		"p6kfx",		{{"Intel", cpus_PentiumII_28v},{"",    NULL},        {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  384,   8, 127,	        machine_at_p6kfx_init, NULL			},
+    { "[Slot 1 FX] ASUS KN97",		"kn97",		{{"Intel", cpus_PentiumII_28v}, {"",    NULL},        {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  384,   8, 127,	        machine_at_kn97_init, NULL			},
 
     /* 440LX */
 


### PR DESCRIPTION
KN97 is a popular Slot 1 FX board included also in the PCem-X days. Thanks to the recent additions it can be reintroduced back.