### PR TITLE
Basic OPTi Python emulation

### DIFF
--- a/src/chipset/optipython.c
+++ b/src/chipset/optipython.c
@@ -1,0 +1,224 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Basic implementation of the OPTi Python Chipset.
+ *
+ *		Emulator maintained by: Miran Grca, <mgrca8@gmail.com>
+ *
+ *
+ *
+ *
+ *		Copyright 2020 Tiseno100.
+ */
+
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+#define HAVE_STDARG_H
+#include <86box/86box.h>
+#include "cpu.h"
+#include <86box/timer.h>
+#include <86box/io.h>
+#include <86box/device.h>
+#include <86box/keyboard.h>
+#include <86box/mem.h>
+#include <86box/fdd.h>
+#include <86box/fdc.h>
+#include <86box/chipset.h>
+
+
+static void
+python_shadow_recalc(uint32_t addr, uint32_t size, int state)
+{
+    switch (state & 3) {
+	case 0:
+		mem_set_mem_state(addr, size, MEM_READ_EXTANY | MEM_WRITE_EXTANY);
+		break;
+	case 1:
+		mem_set_mem_state(addr, size, MEM_READ_EXTANY | MEM_WRITE_INTERNAL);
+		break;
+	case 2:
+		mem_set_mem_state(addr, size, MEM_READ_INTERNAL | MEM_WRITE_EXTANY);
+		break;
+	case 3:
+		mem_set_mem_state(addr, size, MEM_READ_INTERNAL | MEM_WRITE_INTERNAL);
+		break;
+    }
+
+    flushmmucache_nopc();
+}
+
+
+typedef struct
+{
+    uint8_t	cur_reg,
+		regs[256];
+} python_t;
+
+/*
+static void
+python_recalcmapping(python_t *dev) [TODO: Use the current Shadow RAM implementation]
+{
+    uint32_t base;
+    uint32_t i, shflags = 0;
+    uint32_t reg, lowest_bit;
+
+    shadowbios = 0;
+    shadowbios_write = 0;
+
+    for (i = 0; i < 8; i++) {
+    base = 0xc0000 + (i << 14);
+
+    lowest_bit = (i << 2) & 0x07;
+    reg = 0x04 + ((base >> 16) & 0x01);
+
+    shflags = (dev->regs[reg] & (1 << lowest_bit)) ? MEM_READ_INTERNAL : MEM_READ_EXTANY;
+    shflags |= (dev->regs[reg] & (1 << (lowest_bit + 1))) ? MEM_WRITE_INTERNAL : MEM_WRITE_EXTANY;
+    mem_set_mem_state(base, 0x4000, shflags);
+    }
+
+    shadowbios |= !!(dev->regs[0x06] & 0x05);
+    shadowbios_write |= !!(dev->regs[0x06] & 0x0a);
+
+    shflags = (dev->regs[0x06] & 0x01) ? MEM_READ_INTERNAL : MEM_READ_EXTANY;
+    shflags |= (dev->regs[0x06] & 0x02) ? MEM_WRITE_INTERNAL : MEM_WRITE_EXTANY;
+    mem_set_mem_state(0xe0000, 0x10000, shflags);
+
+    shflags = (dev->regs[0x06] & 0x04) ? MEM_READ_INTERNAL : MEM_READ_EXTANY;
+    shflags |= (dev->regs[0x06] & 0x08) ? MEM_WRITE_INTERNAL : MEM_WRITE_EXTANY;
+    mem_set_mem_state(0xf0000, 0x10000, shflags);
+
+    flushmmucache();
+}
+*/
+
+static void
+python_write(uint16_t addr, uint8_t val, void *priv)
+{
+
+    python_t *dev = (python_t *) priv;
+
+switch(addr){
+    
+    //Setting the data to be applied on 24h.
+    case 0x22:
+    dev->cur_reg = val;
+    break;
+
+    case 0x24:
+    
+    pclog("python: Writing %d on Register %dh\n", val, dev->cur_reg);
+
+    switch (dev->cur_reg){
+
+        case 0x04: // Shadow RAM control 1
+		if ((dev->regs[0x04] ^ val) & 0x03)
+			python_shadow_recalc(0xc0000, 0x04000, val & 0x03);
+		if ((dev->regs[0x04] ^ val) & 0x0c)
+			python_shadow_recalc(0xc4000, 0x04000, (val & 0x0c) >> 2);
+		if ((dev->regs[0x04] ^ val) & 0x30)
+			python_shadow_recalc(0xc8000, 0x04000, (val & 0x30) >> 4);
+		if ((dev->regs[0x04] ^ val) & 0xc0)
+			python_shadow_recalc(0xcc000, 0x04000, (val & 0xc0) >> 6);
+		dev->regs[0x04] = val;
+		return;
+        break;
+
+	    case 0x05: // Shadow RAM Control 2
+		if ((dev->regs[0x05] ^ val) & 0x03)
+			python_shadow_recalc(0xd0000, 0x04000, val & 0x03);
+		if ((dev->regs[0x05] ^ val) & 0x0c)
+			python_shadow_recalc(0xd4000, 0x04000, (val & 0x0c) >> 2);
+		if ((dev->regs[0x05] ^ val) & 0x30)
+			python_shadow_recalc(0xd8000, 0x04000, (val & 0x30) >> 4);
+		if ((dev->regs[0x05] ^ val) & 0xc0)
+			python_shadow_recalc(0xdc000, 0x04000, (val & 0xc0) >> 6);
+		dev->regs[0x05] = val;
+		return;
+        break;
+
+	    case 0x06: // Shadow RAM Control 3
+		if ((dev->regs[0x06] ^ val) & 0x30) {
+			python_shadow_recalc(0xf0000, 0x10000, (val & 0x30) >> 4);
+			shadowbios = (((val & 0x30) >> 4) & 0x02);
+		}
+		if ((dev->regs[0x06] ^ val) & 0xc0)
+			python_shadow_recalc(0xe0000, 0x10000, (val & 0xc0) >> 6);
+		dev->regs[0x06] = val;
+		return;
+        break;
+        
+		/*
+        case 0x0d: // ROMCS Register [Let's have it disabled as it fails the Award board]
+            if (!(val & 0x80))
+					mem_set_mem_state(0xe0000, 0x10000, MEM_READ_INTERNAL | MEM_WRITE_DISABLED);
+				else
+					mem_set_mem_state(0xe0000, 0x10000, MEM_READ_EXTANY | MEM_WRITE_INTERNAL);
+        break;
+		*/
+
+    default:
+        dev->regs[addr] = val;
+    break;
+    }
+
+}
+
+}
+
+static uint8_t
+python_read(uint16_t addr, void *priv)
+{
+    uint8_t ret = 0xff;
+    python_t *dev = (python_t *) priv;
+
+    if(addr == 0x24){
+		ret = dev->regs[dev->cur_reg - 0x20];
+    }
+
+    return ret;
+}
+
+static void
+python_close(void *priv)
+{
+
+python_t *dev = (python_t *) priv;
+free(dev);
+
+}
+
+static void *
+python_init(const device_t *info)
+{
+    python_t *dev = (python_t *) malloc(sizeof(python_t));
+    memset(dev, 0, sizeof(python_t));
+
+    //Access Register which writes to 24h instantly
+    io_sethandler(0x0022, 0x0001, python_read, NULL, NULL, python_write, NULL, NULL, dev);
+
+    //R/W register data
+    io_sethandler(0x0024, 0x0001, python_read, NULL, NULL, python_write, NULL, NULL, dev);
+
+    //TODO: Understand it more specifically
+    dev->regs[0x61] = 0x80;
+
+    return dev;
+}
+
+const device_t python_device = {
+    "OPTi Python",
+    0,
+    0,
+    python_init, python_close, NULL,
+    NULL, NULL, NULL,
+    NULL
+};

--- a/src/include/86box/chipset.h
+++ b/src/include/86box/chipset.h
@@ -47,6 +47,7 @@ extern const device_t	i440zx_device;
 
 /* OPTi */
 extern const device_t	opti495_device;
+extern const device_t	python_device;
 
 /* C&T */
 extern const device_t	neat_device;

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -253,7 +253,7 @@ extern const device_t 	*at_cpqiii_get_device(void);
 #endif
 
 /* m_at_socket4_5.c */
-extern int	machine_at_hot523_init(const machine_t *);
+extern int	machine_at_excalibur_init(const machine_t *);
 
 extern int	machine_at_batman_init(const machine_t *);
 extern int	machine_at_ambradp60_init(const machine_t *);
@@ -361,6 +361,7 @@ extern int	machine_at_s2dge_init(const machine_t *);
 /* m_at_socket370.c */
 #if defined(DEV_BRANCH) && defined(NO_SIO)
 extern int	machine_at_s370slm_init(const machine_t *);
+extern int	machine_at_773mr_init(const machine_t *);
 #endif
 extern int	machine_at_cubx_init(const machine_t *);
 extern int	machine_at_atc7020bxii_init(const machine_t *);

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -253,6 +253,8 @@ extern const device_t 	*at_cpqiii_get_device(void);
 #endif
 
 /* m_at_socket4_5.c */
+extern int	machine_at_hot523_init(const machine_t *);
+
 extern int	machine_at_batman_init(const machine_t *);
 extern int	machine_at_ambradp60_init(const machine_t *);
 #if defined(DEV_BRANCH) && defined(USE_VPP60)

--- a/src/machine/m_at_socket4_5.c
+++ b/src/machine/m_at_socket4_5.c
@@ -42,6 +42,32 @@
 #include <86box/video.h>
 #include <86box/machine.h>
 
+int
+machine_at_hot523_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear(L"roms/machines/hot523/523R21.BIN",
+			   0x000e0000, 131072, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    pci_init(PCI_CONFIG_TYPE_2 | PCI_NO_IRQ_STEERING);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL, 0, 0, 0, 0);
+    pci_register_slot(0x03, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x04, PCI_CARD_NORMAL, 2, 3, 4, 1);
+    pci_register_slot(0x05, PCI_CARD_NORMAL, 3, 4, 1, 2);
+    pci_register_slot(0x06, PCI_CARD_NORMAL, 4, 1, 2, 3);
+
+    machine_at_common_init(model);
+	device_add(&keyboard_at_device);
+	device_add(&ide_vlb_2ch_device);
+	device_add(&fdc_at_device);
+	device_add(&python_device);
+
+    return ret;
+}
 
 static void
 machine_at_premiere_common_init(const machine_t *model)

--- a/src/machine/m_at_socket4_5.c
+++ b/src/machine/m_at_socket4_5.c
@@ -58,7 +58,6 @@ machine_at_excalibur_init(const machine_t *model)
 	device_add(&ide_vlb_2ch_device);
 	device_add(&fdc37c665_device);
 	device_add(&python_device);
-    device_add(&opti822_device);
 
     return ret;
 }

--- a/src/machine/m_at_socket4_5.c
+++ b/src/machine/m_at_socket4_5.c
@@ -43,28 +43,22 @@
 #include <86box/machine.h>
 
 int
-machine_at_hot523_init(const machine_t *model)
+machine_at_excalibur_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/hot523/523R21.BIN",
+    ret = bios_load_linear(L"roms/machines/excalibur/S75P.ROM",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
 	return ret;
 
-    pci_init(PCI_CONFIG_TYPE_2 | PCI_NO_IRQ_STEERING);
-    pci_register_slot(0x01, PCI_CARD_SPECIAL, 0, 0, 0, 0);
-    pci_register_slot(0x03, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x04, PCI_CARD_NORMAL, 2, 3, 4, 1);
-    pci_register_slot(0x05, PCI_CARD_NORMAL, 3, 4, 1, 2);
-    pci_register_slot(0x06, PCI_CARD_NORMAL, 4, 1, 2, 3);
-
     machine_at_common_init(model);
-	device_add(&keyboard_at_device);
+	device_add(&keyboard_at_ami_device);
 	device_add(&ide_vlb_2ch_device);
-	device_add(&fdc_at_device);
+	device_add(&fdc37c665_device);
 	device_add(&python_device);
+    device_add(&opti822_device);
 
     return ret;
 }

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -206,6 +206,10 @@ const machine_t machines[] = {
     { "[486 PCI] Zida Tomato 4DP",		"4dps",			{{"Intel", cpus_i486},        {"AMD", cpus_Am486},   {"Cyrix", cpus_Cx486},  {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_HDC,						  1,  255,   1, 127,		 machine_at_4dps_init, NULL			},
 
     /* Socket 4 machines */
+	
+	/* OPTi Python */
+    { "[Socket 4 OPTi] Shuttle HOT-523",	"hot523",		{{"Intel", cpus_Pentium5V},   {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_VLB | MACHINE_HDC | MACHINE_AT,					  2,  128,   2, 127,	    machine_at_hot523_init, NULL			},
+
     /* 430LX */
     { "[Socket 4 LX] IBM Ambra DP60 PCI",	"ambradp60",		{{"Intel", cpus_Pentium5V},   {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  2,  128,   2, 127,	    machine_at_ambradp60_init, NULL			},
 #if defined(DEV_BRANCH) && defined(USE_VPP60)

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -208,7 +208,7 @@ const machine_t machines[] = {
     /* Socket 4 machines */
 	
 	/* OPTi Python */
-    { "[Socket 4 OPTi] Shuttle HOT-523",	"hot523",		{{"Intel", cpus_Pentium5V},   {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_VLB | MACHINE_HDC | MACHINE_AT,					  2,  128,   2, 127,	    machine_at_hot523_init, NULL			},
+    { "[Socket 4 OPTi] AMI Excalibur",	"excalibur",		{{"Intel", cpus_Pentium5V},   {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_VLB | MACHINE_HDC | MACHINE_AT,					  2,  128,   2, 127,	    machine_at_excalibur_init, NULL			},
 
     /* 430LX */
     { "[Socket 4 LX] IBM Ambra DP60 PCI",	"ambradp60",		{{"Intel", cpus_Pentium5V},   {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  2,  128,   2, 127,	    machine_at_ambradp60_init, NULL			},
@@ -319,10 +319,13 @@ const machine_t machines[] = {
     /* 440LX */
 #if defined(DEV_BRANCH) && defined(NO_SIO)
     { "[Socket 370 LX] Supermicro 370SLM",	"s370slm",		{{"Intel", cpus_Celeron},     {"", NULL},            {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8,  768,   8, 255,	      machine_at_s370slm_init, NULL			},
-#endif
+
     /* 440BX */
+    { "[Socket 370 BX] PCChips M773MR",	"773mr",		{{"Intel", cpus_Celeron},     {"VIA", cpus_Cyrix3},  {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8, 512,   8, 255,	  machine_at_773mr_init, NULL			},
+#endif
     { "[Socket 370 BX] ASUS CUBX",		"cubx",			{{"Intel", cpus_Celeron},     {"VIA", cpus_Cyrix3},  {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8, 1024,   8, 255,		 machine_at_cubx_init, NULL			},
     { "[Socket 370 BX] A-Trend ATC7020BXII",	"atc7020bxii",		{{"Intel", cpus_Celeron},     {"VIA", cpus_Cyrix3},  {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8, 1024,   8, 255,	  machine_at_atc7020bxii_init, NULL			},
+    { "[Socket 370 BX] PCChips M773MR",	"773mr",		{{"Intel", cpus_Celeron},     {"VIA", cpus_Cyrix3},  {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8, 512,   8, 255,	  machine_at_773mr_init, NULL			},
 
     /* 440ZX */
     { "[Socket 370 ZX] Soltek SL-63A1",		"63a",			{{"Intel", cpus_Celeron},     {"VIA", cpus_Cyrix3},  {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  512,   8, 255,		  machine_at_63a_init, NULL			},

--- a/src/win/Makefile.mingw
+++ b/src/win/Makefile.mingw
@@ -515,7 +515,7 @@ CPUOBJ		:= cpu.o cpu_table.o \
 		    $(DYNARECOBJ)
 
 CHIPSETOBJ	:= acc2168.o acer_m3a.o cs8230.o ali1429.o headland.o \
-		    intel_4x0.o neat.o opti495.o scamp.o scat.o \
+		    intel_4x0.o neat.o opti495.o optipython.o scamp.o scat.o \
 		    sis_85c471.o sis_85c496.o \
 		    via_apollo.o via_vpx.o wd76c10.o
 

--- a/src/win/Makefile_ndr.mingw
+++ b/src/win/Makefile_ndr.mingw
@@ -519,7 +519,7 @@ CPUOBJ		:= cpu.o cpu_table.o \
 		    $(DYNARECOBJ)
 
 CHIPSETOBJ	:= acc2168.o acer_m3a.o cs8230.o ali1429.o headland.o \
-		    intel_4x0.o neat.o opti495.o scamp.o scat.o \
+		    intel_4x0.o neat.o opti495.o optipython.o scamp.o scat.o \
 		    sis_85c471.o sis_85c496.o \
 		    via_apollo.o via_vpx.o wd76c10.o
 


### PR DESCRIPTION
OPTi Python is a rare chipset used in motherboards when things were transitioning to PCI. Unlike Intel, it allows VLB capabilities on Socket 4 machines it was used upon and some were ISA/VLB exclusively.