### PR TITLE
The A1G doesn't have VLB capabilities

### DIFF
--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -148,7 +148,7 @@ machine_at_acera1g_init(const machine_t *model)
     device_add(&ali1429_device);
     device_add(&keyboard_ps2_acer_pci_device);
     device_add(&fdc_at_device);
-    device_add(&ide_vlb_2ch_device);
+    device_add(&ide_isa_2ch_device);
 
     return ret;
 }


### PR DESCRIPTION
Changed the 2CH IDE controller to the ISA variation as the A1G doesn't have any VLB capabilities at all.