### PR TITLE
DRB locking fixes

### DIFF
--- a/src/chipset/via_apollo.c
+++ b/src/chipset/via_apollo.c
@@ -32,6 +32,7 @@
 #include <86box/device.h>
 #include <86box/keyboard.h>
 #include <86box/chipset.h>
+#include <86box/spd.h>
 
 
 typedef struct via_apollo_t
@@ -224,6 +225,13 @@ via_apollo_host_bridge_write(int func, int addr, uint8_t val, void *priv)
 			dev->pci_conf[0][0x53] = val;
 		else
 			dev->pci_conf[0][0x53] = (dev->pci_conf[0][0x53] & ~0xf0) | (val & 0xf0);
+		break;
+
+	case 0x56: case 0x57: case 0x5a: case 0x5b: case 0x5c: case 0x5d: case 0x5e: case 0x5f: /* DRAM Row Ending Address */
+		if (dev->id >= 0x0691)
+			spd_write_drbs(dev->pci_conf[0], 0x5a, 0x56, 8);
+		else if (addr >= 0x5a)
+			spd_write_drbs(dev->pci_conf[0], 0x5a, 0x5f, 8);
 		break;
 
 	case 0x58:

--- a/src/chipset/via_vpx.c
+++ b/src/chipset/via_vpx.c
@@ -35,6 +35,7 @@
 #include <86box/device.h>
 #include <86box/keyboard.h>
 #include <86box/chipset.h>
+#include <86box/spd.h>
 
 typedef struct via_vpx_t
 {
@@ -92,6 +93,10 @@ via_vpx_t *dev = (via_vpx_t *) priv;
 
         case 0x07: // Status
         dev->pci_conf[0x07] &= ~(val & 0xb0);
+		break;
+
+	case 0x5a: case 0x5b: case 0x5c: case 0x5d: case 0x5e: case 0x5f: // Bank Ending
+		spd_write_drbs(dev->pci_conf, 0x5a, 0x5f, 4);
 		break;
 
         case 0x61: // Shadow RAM control 1
@@ -201,6 +206,7 @@ via_vpx_init(const device_t *info)
     dev->pci_conf[0x5e] = 1; // Bank 4 Ending
     dev->pci_conf[0x5f] = 1; // Bank 5 Ending
 
+    dev->pci_conf[0x60] = 0x3f; // DRAM type
     dev->pci_conf[0x64] = 0xab; // DRAM reference timing
 
     return dev;

--- a/src/include/86box/spd.h
+++ b/src/include/86box/spd.h
@@ -100,13 +100,8 @@ typedef struct _spd_sdram_ {
 } spd_sdram_t;
 
 
-extern int	spd_present;
-extern spd_t	*spd_devices[SPD_MAX_SLOTS];
-
-
-extern uint8_t log2_ui16(uint16_t i);
-extern void spd_populate(uint16_t *vslots, uint8_t slot_count, uint16_t total_size, uint16_t min_module_size, uint16_t max_module_size, uint8_t enable_asym);
 extern void spd_register(uint8_t ram_type, uint8_t slot_mask, uint16_t max_module_size);
+extern void spd_write_drbs(uint8_t *regs, uint8_t reg_min, uint8_t reg_max, uint8_t drb_unit);
 
 
 #endif	/*EMU_SPD_H*/

--- a/src/machine/m_at_socket7_s7.c
+++ b/src/machine/m_at_socket7_s7.c
@@ -983,6 +983,7 @@ machine_at_ficva502_init(const machine_t *model)
     device_add(&keyboard_ps2_pci_device);
     device_add(&fdc37c669_device);
     device_add(&sst_flash_29ee010_device);
+    spd_register(SPD_TYPE_SDRAM, 0x7, 256);
 
     return ret;
 }

--- a/src/machine/m_at_socket7_s7.c
+++ b/src/machine/m_at_socket7_s7.c
@@ -983,7 +983,7 @@ machine_at_ficva502_init(const machine_t *model)
     device_add(&keyboard_ps2_pci_device);
     device_add(&fdc37c669_device);
     device_add(&sst_flash_29ee010_device);
-    spd_register(SPD_TYPE_SDRAM, 0x7, 256);
+    spd_register(SPD_TYPE_SDRAM, 0x3, 256);
 
     return ret;
 }
@@ -1014,6 +1014,7 @@ machine_at_ficpa2012_init(const machine_t *model)
     device_add(&keyboard_ps2_pci_device);
     device_add(&w83877f_device);
     device_add(&sst_flash_39sf010_device);
+    spd_register(SPD_TYPE_SDRAM, 0x7, 512);
 
     return ret;
 }

--- a/src/machine/m_at_sockets7.c
+++ b/src/machine/m_at_sockets7.c
@@ -67,7 +67,7 @@ machine_at_ax59pro_init(const machine_t *model)
     device_add(&keyboard_ps2_pci_device);
     device_add(&w83877tf_device);
     device_add(&sst_flash_39sf020_device);
-    spd_register(SPD_TYPE_SDRAM, 0xF, 256);
+    spd_register(SPD_TYPE_SDRAM, 0x7, 512);
 
     return ret;
 }
@@ -90,7 +90,7 @@ machine_at_mvp3_init(const machine_t *model)
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
     pci_register_slot(0x08, PCI_CARD_NORMAL, 1, 2, 3, 4);
     pci_register_slot(0x09, PCI_CARD_NORMAL, 2, 3, 4, 1);
-    pci_register_slot(0x0a, PCI_CARD_NORMAL, 3, 4, 1, 2);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL, 3, 4, 1, 2);
     pci_register_slot(0x01, PCI_CARD_NORMAL, 1, 2, 3, 4);
     pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
     device_add(&via_mvp3_device);
@@ -98,6 +98,7 @@ machine_at_mvp3_init(const machine_t *model)
     device_add(&keyboard_ps2_pci_device);
     device_add(&w83877tf_device);
     device_add(&sst_flash_39sf010_device);
+    spd_register(SPD_TYPE_SDRAM, 0x3, 512);
 
     return ret;
 }

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -354,7 +354,7 @@ const machine_t machines[] = {
     { "[i440ZX] Soltek SL-63A1",		"63a",			MACHINE_TYPE_SOCKET370,		{{"Intel", cpus_Celeron},     {"VIA", cpus_Cyrix3},  {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  512,   8, 255,		  machine_at_63a_init, NULL			},
 
     /* VIA Apollo Pro */
-    { "[VIA Apollo Pro] PC Partner APAS3",	"apas3",		MACHINE_TYPE_SOCKET370,		{{"Intel", cpus_Celeron},     {"VIA", cpus_Cyrix3},  {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,	  				  8, 1024,   8, 255,            machine_at_apas3_init, NULL			},
+    { "[VIA Apollo Pro] PC Partner APAS3",	"apas3",		MACHINE_TYPE_SOCKET370,		{{"Intel", cpus_Celeron},     {"VIA", cpus_Cyrix3},  {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,	  				  8,  768,   8, 255,            machine_at_apas3_init, NULL			},
 
     { NULL,					NULL,			MACHINE_TYPE_NONE,		{{"",      0},                {"",    0},            {"",      0},           {"",         0},     {"",      0}},    0,                                                                                                    0,    0,   0,   0,			         NULL, NULL			}
 };

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -297,12 +297,12 @@ const machine_t machines[] = {
     { "[VIA VPX] FIC VA-502",			"ficva502",		MACHINE_TYPE_SOCKET7,		MACHINE_CPUS_PENTIUM_S7,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8,  512,   8, 127,	     machine_at_ficva502_init, NULL			},
 
     /* Apollo VP3 */
-    { "[VIA VP3] FIC PA-2012",			"ficpa2012",		MACHINE_TYPE_SOCKET7,		MACHINE_CPUS_PENTIUM_S7,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8,  192,   8, 127,	    machine_at_ficpa2012_init, NULL			},
+    { "[VIA VP3] FIC PA-2012",			"ficpa2012",		MACHINE_TYPE_SOCKET7,		MACHINE_CPUS_PENTIUM_S7,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8, 1024,   8, 127,	    machine_at_ficpa2012_init, NULL			},
   
     /* Super Socket 7 machines */
     /* Apollo MVP3 */
-    { "[VIA MVP3] AOpen AX59 Pro",		"ax59pro",		MACHINE_TYPE_SOCKETS7,		MACHINE_CPUS_PENTIUM_SS7,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8, 1024,  8, 255,	      machine_at_ax59pro_init, NULL			},
-    { "[VIA MVP3] FIC VA-503+",			"ficva503p",		MACHINE_TYPE_SOCKETS7,		MACHINE_CPUS_PENTIUM_SS7,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  512,  8, 255,	         machine_at_mvp3_init, NULL			},
+    { "[VIA MVP3] AOpen AX59 Pro",		"ax59pro",		MACHINE_TYPE_SOCKETS7,		MACHINE_CPUS_PENTIUM_SS7,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8, 1024,   8, 255,	      machine_at_ax59pro_init, NULL			},
+    { "[VIA MVP3] FIC VA-503+",			"ficva503p",		MACHINE_TYPE_SOCKETS7,		MACHINE_CPUS_PENTIUM_SS7,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  512,   8, 255,	         machine_at_mvp3_init, NULL			},
 
     /* Socket 8 machines */
     /* 440FX */
@@ -348,7 +348,7 @@ const machine_t machines[] = {
     /* 440BX */
     { "[i440BX] ASUS CUBX",			"cubx",			MACHINE_TYPE_SOCKET370,		{{"Intel", cpus_Celeron},     {"VIA", cpus_Cyrix3},  {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8, 1024,   8, 255,		 machine_at_cubx_init, NULL			},
     { "[i440BX] A-Trend ATC7020BXII",		"atc7020bxii",		MACHINE_TYPE_SOCKET370,		{{"Intel", cpus_Celeron},     {"VIA", cpus_Cyrix3},  {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8, 1024,   8, 255,	  machine_at_atc7020bxii_init, NULL			},
-    { "[i440BX] AmazePC AM-BX133",		"ambx133",		MACHINE_TYPE_SOCKET370,		{{"Intel", cpus_Celeron},     {"VIA", cpus_Cyrix3},  {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8, 768,   8, 255,	  machine_at_ambx133_init, NULL			},
+    { "[i440BX] AmazePC AM-BX133",		"ambx133",		MACHINE_TYPE_SOCKET370,		{{"Intel", cpus_Celeron},     {"VIA", cpus_Cyrix3},  {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		  8,  768,   8, 255,	      machine_at_ambx133_init, NULL			},
 
     /* 440ZX */
     { "[i440ZX] Soltek SL-63A1",		"63a",			MACHINE_TYPE_SOCKET370,		{{"Intel", cpus_Celeron},     {"VIA", cpus_Cyrix3},  {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  512,   8, 255,		  machine_at_63a_init, NULL			},

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -302,7 +302,7 @@ const machine_t machines[] = {
     /* Super Socket 7 machines */
     /* Apollo MVP3 */
     { "[VIA MVP3] AOpen AX59 Pro",		"ax59pro",		MACHINE_TYPE_SOCKETS7,		MACHINE_CPUS_PENTIUM_SS7,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8, 1024,   8, 255,	      machine_at_ax59pro_init, NULL			},
-    { "[VIA MVP3] FIC VA-503+",			"ficva503p",		MACHINE_TYPE_SOCKETS7,		MACHINE_CPUS_PENTIUM_SS7,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  512,   8, 255,	         machine_at_mvp3_init, NULL			},
+    { "[VIA MVP3] FIC VA-503+",			"ficva503p",		MACHINE_TYPE_SOCKETS7,		MACHINE_CPUS_PENTIUM_SS7,											    MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8, 1024,   8, 255,	         machine_at_mvp3_init, NULL			},
 
     /* Socket 8 machines */
     /* 440FX */

--- a/src/mem/spd.c
+++ b/src/mem/spd.c
@@ -42,7 +42,7 @@ static uint8_t	spd_read_byte(uint8_t addr, void *priv);
 static uint8_t	spd_read_byte_cmd(uint8_t addr, uint8_t cmd, void *priv);
 static void	spd_write_byte(uint8_t addr, uint8_t val, void *priv);
 
-#define ENABLE_SPD_LOG 1
+
 #ifdef ENABLE_SPD_LOG
 int spd_do_log = ENABLE_SPD_LOG;
 

--- a/src/mem/spd.c
+++ b/src/mem/spd.c
@@ -443,11 +443,8 @@ spd_write_drbs(uint8_t *regs, uint8_t reg_min, uint8_t reg_max, uint8_t drb_unit
 
     	/* Determine the DRB register to write. */
     	drb = reg_min + row;
-
-    	spd_log("want drb reg %02x", drb);
     	if ((apollo) && ((drb & 0xf) < 0xa))
     		drb = apollo + (drb & 0xf);
-    	spd_log(" got %02x\n", drb);
 
     	/* Write DRB register, adding the previous DRB's value. */
     	if (row == 0)

--- a/src/mem/spd.c
+++ b/src/mem/spd.c
@@ -118,6 +118,8 @@ spd_close(void *priv)
     			spd_write_byte, NULL, NULL, NULL,
     			dev);
 
+    spd_present = 0;
+
     free(dev);
 }
 
@@ -133,6 +135,8 @@ spd_init(const device_t *info)
     		     spd_read_byte, spd_read_byte_cmd, spd_read_word_cmd, spd_read_block_cmd,
     		     spd_write_byte, NULL, NULL, NULL,
     		     dev);
+
+    spd_present = 1;
 
     return dev;
 }
@@ -396,6 +400,4 @@ spd_register(uint8_t ram_type, uint8_t slot_mask, uint16_t max_module_size)
     	//device_add(info);
     	vslot++;
     }
-
-    spd_present = 1;
 }


### PR DESCRIPTION
* Single implementation for all chipsets
* Added DRB locking to VIA VPX and Apollo
* Fixed maximum RAM amount on VIA boards (after research into DRAM bank configurations)
* Fixed SPD