### PR TITLE
Add an OPTi 291-based Award v4.20 machine

### DIFF
--- a/src/chipset/opti291.c
+++ b/src/chipset/opti291.c
@@ -44,27 +44,28 @@ static void opti291_recalc(opti291_t *dev)
 		
 	for (i = 0; i < 4; i++) {
 	base = 0xe0000 + (i << 14);
-	shflags = (dev->regs[0x24] & (1 << i)) ? MEM_READ_INTERNAL : MEM_READ_EXTANY;
-	shflags |= (dev->regs[0x24] & (1 << (i+4))) ? write : MEM_WRITE_EXTANY;
+	shflags = (dev->regs[0x24] & (1 << (i+4))) ? MEM_READ_INTERNAL : MEM_READ_EXTANY;
+	shflags |= (dev->regs[0x24] & (1 << (i))) ? write : MEM_WRITE_EXTANY;
 	write = (dev->regs[0x27] & 0x40) ? MEM_WRITE_DISABLED : MEM_WRITE_INTERNAL;
 	mem_set_mem_state(base, 0x4000, shflags);
 	}
 	for (i = 0; i < 4; i++) {
 	base = 0xd0000 + (i << 14);
-	shflags = (dev->regs[0x25] & (1 << i)) ? MEM_READ_INTERNAL : MEM_READ_EXTANY;
-	shflags |= (dev->regs[0x25] & (1 << (i+4))) ? write : MEM_WRITE_EXTANY;
+	shflags = (dev->regs[0x25] & (1 << (i+4))) ? MEM_READ_INTERNAL : MEM_READ_EXTANY;
+	shflags |= (dev->regs[0x25] & (1 << (i))) ? write : MEM_WRITE_EXTANY;
 	write = (dev->regs[0x27] & 0x20) ? MEM_WRITE_DISABLED : MEM_WRITE_INTERNAL;
 	mem_set_mem_state(base, 0x4000, shflags);
 	}
+	
 	for (i = 0; i < 4; i++) {
 	base = 0xc0000 + (i << 14);
-	shflags = (dev->regs[0x26] & (1 << i)) ? MEM_READ_INTERNAL : MEM_READ_EXTANY;
-	shflags |= (dev->regs[0x26] & (1 << (i+4))) ? write : MEM_WRITE_EXTANY;
+	shflags = (dev->regs[0x26] & (1 << (i+4))) ? MEM_READ_INTERNAL : MEM_READ_EXTANY;
+	shflags |= (dev->regs[0x26] & (1 << i)) ? write : MEM_WRITE_EXTANY;
 	write = (dev->regs[0x27] & 0x10) ? MEM_WRITE_DISABLED : MEM_WRITE_INTERNAL;
 	mem_set_mem_state(base, 0x4000, shflags);
 	}
     flushmmucache();	
-}
+}	
 static void
 opti291_write(uint16_t addr, uint8_t val, void *priv)
 {

--- a/src/chipset/opti291.c
+++ b/src/chipset/opti291.c
@@ -1,0 +1,144 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Implementation of the OPTi 82C546/82C547 & 82C596/82C597 chipsets.
+ 
+ * Authors:	plant/nerd73
+ *
+ *              Copyright 2020 plant/nerd73.
+ */
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+#define HAVE_STDARG_H
+#include <86box/86box.h>
+#include "cpu.h"
+#include <86box/timer.h>
+#include <86box/io.h>
+#include <86box/device.h>
+#include <86box/keyboard.h>
+#include <86box/mem.h>
+#include <86box/fdd.h>
+#include <86box/fdc.h>
+#include <86box/port_92.h>
+#include <86box/chipset.h>
+
+typedef struct
+{
+    uint8_t	index,
+	regs[256];
+} opti291_t;
+
+static void opti291_recalc(opti291_t *dev)
+{
+	uint32_t base;
+	uint32_t i, shflags, write = 0;
+		
+	for (i = 0; i < 4; i++) {
+	base = 0xe0000 + (i << 14);
+	shflags = (dev->regs[0x24] & (1 << i)) ? MEM_READ_INTERNAL : MEM_READ_EXTANY;
+	shflags |= (dev->regs[0x24] & (1 << (i+4))) ? write : MEM_WRITE_EXTANY;
+	write = (dev->regs[0x27] & 0x40) ? MEM_WRITE_DISABLED : MEM_WRITE_INTERNAL;
+	mem_set_mem_state(base, 0x4000, shflags);
+	}
+	for (i = 0; i < 4; i++) {
+	base = 0xd0000 + (i << 14);
+	shflags = (dev->regs[0x25] & (1 << i)) ? MEM_READ_INTERNAL : MEM_READ_EXTANY;
+	shflags |= (dev->regs[0x25] & (1 << (i+4))) ? write : MEM_WRITE_EXTANY;
+	write = (dev->regs[0x27] & 0x20) ? MEM_WRITE_DISABLED : MEM_WRITE_INTERNAL;
+	mem_set_mem_state(base, 0x4000, shflags);
+	}
+	for (i = 0; i < 4; i++) {
+	base = 0xc0000 + (i << 14);
+	shflags = (dev->regs[0x26] & (1 << i)) ? MEM_READ_INTERNAL : MEM_READ_EXTANY;
+	shflags |= (dev->regs[0x26] & (1 << (i+4))) ? write : MEM_WRITE_EXTANY;
+	write = (dev->regs[0x27] & 0x10) ? MEM_WRITE_DISABLED : MEM_WRITE_INTERNAL;
+	mem_set_mem_state(base, 0x4000, shflags);
+	}
+    flushmmucache();	
+}
+static void
+opti291_write(uint16_t addr, uint8_t val, void *priv)
+{
+    opti291_t *dev = (opti291_t *) priv;
+
+    switch (addr) {
+	case 0x22:
+		dev->index = val;
+		break;
+	case 0x24:
+        pclog("OPTi 291: dev->regs[%02x] = %02x\n", dev->index, val);
+		dev->regs[dev->index] = val;
+
+        switch(dev->index){
+				case 0x21:
+					cpu_update_waitstates();
+					break;
+				case 0x24:
+				case 0x25:
+				case 0x26:
+				case 0x27:				
+					opti291_recalc(dev);
+					break;
+        }
+		break;
+    }
+}
+
+
+static uint8_t
+opti291_read(uint16_t addr, void *priv)
+{
+    uint8_t ret = 0xff;
+    opti291_t *dev = (opti291_t *) priv;
+
+    switch (addr) {
+	case 0x24:
+		ret = dev->regs[dev->index];
+		break;
+    }
+
+    return ret;
+}
+
+
+static void
+opti291_close(void *priv)
+{
+    opti291_t *dev = (opti291_t *) priv;
+
+    free(dev);
+}
+
+
+static void *
+opti291_init(const device_t *info)
+{
+    opti291_t *dev = (opti291_t *) malloc(sizeof(opti291_t));
+    memset(dev, 0, sizeof(opti291_t));
+
+    io_sethandler(0x022, 0x0001, opti291_read, NULL, NULL, opti291_write, NULL, NULL, dev);
+    io_sethandler(0x024, 0x0001, opti291_read, NULL, NULL, opti291_write, NULL, NULL, dev);
+
+    opti291_recalc(dev);
+    
+    return dev;
+}
+
+
+const device_t opti291_device = {
+    "OPTi 82C291",
+    0,
+    0,
+    opti291_init, opti291_close, NULL,
+    NULL, NULL, NULL,
+    NULL
+};

--- a/src/include/86box/chipset.h
+++ b/src/include/86box/chipset.h
@@ -61,6 +61,7 @@ extern const device_t	ioapic_device;
 
 /* OPTi */
 extern const device_t	opti283_device;
+extern const device_t	opti291_device;
 extern const device_t	opti493_device;
 extern const device_t	opti495_device;
 extern const device_t	opti802g_device;

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -240,6 +240,8 @@ extern int	machine_at_adi386sx_init(const machine_t *);
 extern int	machine_at_commodore_sl386sx_init(const machine_t *);
 extern int	machine_at_wd76c10_init(const machine_t *);
 
+extern int  machine_at_awardsx_init(const machine_t *);
+
 #ifdef EMU_DEVICE_H
 extern const device_t	*at_ama932j_get_device(void);
 extern const device_t	*at_commodore_sl386sx_get_device(void);

--- a/src/machine/m_at_286_386sx.c
+++ b/src/machine/m_at_286_386sx.c
@@ -515,3 +515,21 @@ machine_at_commodore_sl386sx_init(const machine_t *model)
 
     return ret;
 }
+int
+machine_at_awardsx_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear(L"roms/machines/awardsx/Unknown 386SX OPTi291 - Award (original).BIN",
+			   0x000f0000, 65536, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_at_init(model);
+
+    device_add(&opti291_device);
+    device_add(&fdc_at_device);
+
+    return ret;
+}

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -173,7 +173,8 @@ const machine_t machines[] = {
     { "[SCAT] KMX-C-02",			"kmxc02",		MACHINE_TYPE_386SX,		{{"Intel", cpus_i386SX},      {"AMD", cpus_Am386SX}, {"Cyrix", cpus_486SLC}, {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT,										512,16384, 512, 127,	       machine_at_kmxc02_init, NULL			},
     { "[Intel 82335] Shuttle 386SX",			"shuttle386sx",		MACHINE_TYPE_386SX,		{{"Intel", cpus_i386SX},      {"AMD", cpus_Am386SX}, {"Cyrix", cpus_486SLC}, {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT,								512, 8192, 128, 127,		 machine_at_shuttle386sx_init, NULL			},
     { "[Intel 82335] ADI 386SX",			"adi386sx",		MACHINE_TYPE_386SX,		{{"Intel", cpus_i386SX},      {"AMD", cpus_Am386SX}, {"Cyrix", cpus_486SLC}, {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT,								512, 8192, 128, 127,		 machine_at_adi386sx_init, NULL			},
-
+    { "[OPTi 291] DTK Award 386SX",		"awardsx",		MACHINE_TYPE_386SX,		{{"Intel", cpus_i386SX},      {"AMD", cpus_Am386SX}, {"Cyrix", cpus_486SLC}, {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT | MACHINE_HDC,								512, 8192, 128, 127,		 machine_at_awardsx_init, NULL			},
+    
     /* 386SX machines which utilize the MCA bus */
     { "[MCA] IBM PS/2 model 55SX",		"ibmps2_m55sx",		MACHINE_TYPE_386SX,		{{"Intel", cpus_i386SX},      {"AMD", cpus_Am386SX}, {"Cyrix", cpus_486SLC}, {"IBM",cpus_IBM486SLC},{"",    NULL}}, MACHINE_MCA | MACHINE_AT | MACHINE_PS2 | MACHINE_VIDEO,						  1,    8,   1,  63,	  machine_ps2_model_55sx_init, NULL			},
 

--- a/src/win/Makefile.mingw
+++ b/src/win/Makefile.mingw
@@ -572,7 +572,7 @@ CPUOBJ		:= cpu.o cpu_table.o \
 CHIPSETOBJ	:= acc2168.o cs8230.o ali1429.o headland.o i82335.o \
 		    intel_420ex.o intel_4x0.o intel_sio.o intel_piix.o ioapic.o \
 		    neat.o opti495.o opti895.o opti5x7.o scamp.o scat.o \
-		    sis_85c310.o sis_85c471.o sis_85c496.o opti283.o \
+		    sis_85c310.o sis_85c471.o sis_85c496.o opti283.o opti291.o \
 		    via_apollo.o via_vpx.o via_vt82c586b.o via_vt82c596b.o wd76c10.o vl82c480.o \
 			amd640.o
 


### PR DESCRIPTION
Adds the DTK PPM-3333P, an OPTi 291-based 386SX machine using an Award v4.20 BIOS.