### PR TITLE
Fix issues with Cyrix DX2/DX4 CPUs and restore Cyrix 6x86 for dev-branch builds

### DIFF
--- a/src/cpu/cpu.c
+++ b/src/cpu/cpu.c
@@ -399,10 +399,10 @@ cpu_set(void)
         hasfpu       = (fpu_type != FPU_NONE);
 	hascache     = (cpu_s->cpu_type >= CPU_486SLC) || (cpu_s->cpu_type == CPU_IBM386SLC || cpu_s->cpu_type == CPU_IBM486SLC || cpu_s->cpu_type == CPU_IBM486BL);
 #if defined(DEV_BRANCH) && defined(USE_CYRIX_6X86)
-        cpu_iscyrix  = (cpu_s->cpu_type == CPU_486SLC || cpu_s->cpu_type == CPU_486DLC || cpu_s->cpu_type == CPU_Cx486S || cpu_s->cpu_type == CPU_Cx486DX || cpu_s->cpu_type == CPU_Cx5x86 || cpu_s->cpu_type == CPU_Cx6x86 || cpu_s->cpu_type == CPU_Cx6x86MX || cpu_s->cpu_type == CPU_Cx6x86L || cpu_s->cpu_type == CPU_CxGX1);
-#else
-        cpu_iscyrix  = (cpu_s->cpu_type == CPU_486SLC || cpu_s->cpu_type == CPU_486DLC || cpu_s->cpu_type == CPU_Cx486S || cpu_s->cpu_type == CPU_Cx486DX || cpu_s->cpu_type == CPU_Cx5x86);
-#endif
+        cpu_iscyrix  = (cpu_s->cpu_type == CPU_486SLC || cpu_s->cpu_type == CPU_486DLC || cpu_s->cpu_type == CPU_Cx486S || cpu_s->cpu_type == CPU_Cx486DX || cpu_s->cpu_type == CPU_Cx486DX2 || cpu_s->cpu_type == CPU_Cx486DX4 || cpu_s->cpu_type == CPU_Cx5x86 || cpu_s->cpu_type == CPU_Cx6x86 || cpu_s->cpu_type == CPU_Cx6x86MX || cpu_s->cpu_type == CPU_Cx6x86L || cpu_s->cpu_type == CPU_CxGX1);
+#else                                                                                                                                                                                                                              
+        cpu_iscyrix  = (cpu_s->cpu_type == CPU_486SLC || cpu_s->cpu_type == CPU_486DLC || cpu_s->cpu_type == CPU_Cx486S || cpu_s->cpu_type == CPU_Cx486DX || cpu_s->cpu_type == CPU_Cx486DX2 || cpu_s->cpu_type == CPU_Cx486DX4 || cpu_s->cpu_type == CPU_Cx5x86);
+#endif                                                                                                                                                                                                                                   
 
         cpu_16bitbus = (cpu_s->cpu_type == CPU_286 || cpu_s->cpu_type == CPU_386SX || cpu_s->cpu_type == CPU_486SLC || cpu_s->cpu_type == CPU_IBM386SLC || cpu_s->cpu_type == CPU_IBM486SLC );
         cpu_64bitbus = (cpu_s->cpu_type >= CPU_WINCHIP);
@@ -935,6 +935,7 @@ cpu_set(void)
                 case CPU_Cx486S:
                 case CPU_Cx486DX:
                 case CPU_Cx486DX2:
+                case CPU_Cx486DX4:
 #ifdef USE_DYNAREC
                 x86_setopcodes(ops_386, ops_486_0f, dynarec_ops_386, dynarec_ops_486_0f);
 #else

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -156,9 +156,7 @@ extern CPU	cpus_K56_SS7[];
 #if defined(DEV_BRANCH) && defined(USE_CYRIX_6X86)
 extern CPU	cpus_6x863V[];
 extern CPU	cpus_6x86[];
-#ifdef USE_NEW_DYNAREC
 extern CPU	cpus_6x86SS7[];
-#endif
 #endif
 extern CPU	cpus_Cyrix3[];
 extern CPU	cpus_PentiumPro[];

--- a/src/win/Makefile.mingw
+++ b/src/win/Makefile.mingw
@@ -42,6 +42,9 @@ ifeq ($(DEV_BUILD), y)
  ifndef CL5422
   CL5422	:= y
  endif
+ ifndef CYRIX_6X86
+  CYRIX_6X86 := y
+ endif 
  ifndef LASERXT
   LASERXT	:= y
  endif
@@ -106,6 +109,9 @@ else
  ifndef CL5422
   CL5422	:= n
  endif
+ ifndef CYRIX_6X86
+  CYRIX_6X86 := n
+ endif 
  ifndef LASERXT
   LASERXT	:= n
  endif
@@ -471,6 +477,10 @@ endif
 
 ifeq ($(CL5422), y)
 OPTS		+= -DUSE_CL5422
+endif
+
+ifeq ($(CYRIX_6X86), y)
+OPTS		+= -DUSE_CYRIX_6X86
 endif
 
 ifeq ($(LASERXT), y)


### PR DESCRIPTION
Fix some issues with the Cyrix DX2 & DX4 CPUs and restore the Cyrix 6x86 for dev-branch builds.