### PR TITLE
STPC IDE improvements and USB device

### DIFF
--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -40,6 +40,7 @@
 #include <86box/video.h>
 #include <86box/flash.h>
 #include <86box/scsi_ncr53c8xx.h>
+#include <86box/hwm.h>
 #include <86box/machine.h>
 
 int
@@ -611,7 +612,7 @@ machine_at_486ap4_init(const machine_t *model)
     return ret;
 }
 
-#include <86box/hwm.h>
+
 #if defined(DEV_BRANCH) && defined(USE_STPC)
 int
 machine_at_itoxstar_init(const machine_t *model)
@@ -633,7 +634,7 @@ machine_at_itoxstar_init(const machine_t *model)
     device_add(&w83977f_device);
     device_add(&keyboard_ps2_ami_pci_device);
     device_add(&stpc_client_device);
-    device_add(&ide_pci_device);
+    device_add(&ide_vlb_device);
     device_add(&sst_flash_39sf020_device);
 
     hwm_values_t machine_hwm = {
@@ -682,7 +683,7 @@ machine_at_arb1479_init(const machine_t *model)
     device_add(&w83977f_device);
     device_add(&keyboard_ps2_ami_pci_device);
     device_add(&stpc_consumer2_device);
-    device_add(&ide_pci_2ch_device);
+    device_add(&ide_vlb_2ch_device);
     device_add(&sst_flash_39sf020_device);
 
     return ret;
@@ -711,7 +712,7 @@ machine_at_pcm9340_init(const machine_t *model)
     device_add(&w83977f_device);
     device_add(&keyboard_ps2_ami_pci_device);
     device_add(&stpc_elite_device);
-    device_add(&ide_pci_device);
+    device_add(&ide_vlb_device);
     device_add(&sst_flash_39sf020_device);
 
     return ret;
@@ -739,7 +740,7 @@ machine_at_pcm5330_init(const machine_t *model)
     device_add(&w83977f_device);
     device_add(&keyboard_ps2_ami_pci_device);
     device_add(&stpc_atlas_device);
-    device_add(&ide_pci_device);
+    device_add(&ide_vlb_device);
     device_add(&sst_flash_29ee020_device);
 
     return ret;

--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -629,7 +629,6 @@ machine_at_itoxstar_init(const machine_t *model)
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x0B, PCI_CARD_SPECIAL, 0, 0, 0, 0);
     pci_register_slot(0x0C, PCI_CARD_SPECIAL, 0, 0, 0, 0);
-    pci_register_slot(0x0D, PCI_CARD_SPECIAL, 0, 0, 0, 0);
     pci_register_slot(0x1F, PCI_CARD_NORMAL, 1, 2, 3, 4);
     device_add(&w83977f_device);
     device_add(&keyboard_ps2_ami_pci_device);
@@ -677,7 +676,6 @@ machine_at_arb1479_init(const machine_t *model)
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x0B, PCI_CARD_SPECIAL, 0, 0, 0, 0);
     pci_register_slot(0x0C, PCI_CARD_SPECIAL, 0, 0, 0, 0);
-    pci_register_slot(0x0D, PCI_CARD_SPECIAL, 0, 0, 0, 0);
     pci_register_slot(0x1F, PCI_CARD_NORMAL, 1, 0, 0, 0);
     pci_register_slot(0x1E, PCI_CARD_NORMAL, 2, 3, 4, 1);
     pci_register_slot(0x1D, PCI_CARD_NORMAL, 3, 4, 1, 2);
@@ -707,7 +705,6 @@ machine_at_pcm9340_init(const machine_t *model)
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x0B, PCI_CARD_SPECIAL, 0, 0, 0, 0);
     pci_register_slot(0x0C, PCI_CARD_SPECIAL, 0, 0, 0, 0);
-    pci_register_slot(0x0D, PCI_CARD_SPECIAL, 0, 0, 0, 0);
     pci_register_slot(0x1D, PCI_CARD_NORMAL, 4, 1, 2, 3);
     pci_register_slot(0x1E, PCI_CARD_NORMAL, 3, 4, 1, 2);
     pci_register_slot(0x1F, PCI_CARD_NORMAL, 2, 3, 4, 1);
@@ -738,6 +735,7 @@ machine_at_pcm5330_init(const machine_t *model)
     pci_register_slot(0x0B, PCI_CARD_SPECIAL, 0, 0, 0, 0);
     pci_register_slot(0x0C, PCI_CARD_SPECIAL, 0, 0, 0, 0);
     pci_register_slot(0x0D, PCI_CARD_SPECIAL, 0, 0, 0, 0);
+    pci_register_slot(0x0E, PCI_CARD_SPECIAL, 0, 0, 0, 0);
     device_add(&w83977f_device);
     device_add(&keyboard_ps2_ami_pci_device);
     device_add(&stpc_atlas_device);


### PR DESCRIPTION
* Fixed PCI IDs
* Fixed IDE device for non-Atlas models (only Atlas has it on a discrete device ID)
* Added the Atlas USB OHCI device
* Refactored `sb` -> `isab`