### PR TITLE
Add MO settings UI

### DIFF
--- a/src/disk/hdc_ide_cmd640.c
+++ b/src/disk/hdc_ide_cmd640.c
@@ -35,6 +35,7 @@
 #include <86box/hdc_ide.h>
 #include <86box/hdc_ide_sff8038i.h>
 #include <86box/zip.h>
+#include <86box/mo.h>
 
 
 typedef struct
@@ -332,6 +333,11 @@ cmd640_reset(void *p)
 	    (zip_drives[i].ide_channel < 4) && zip_drives[i].priv)
 		zip_reset((scsi_common_t *) zip_drives[i].priv);
     }
+	for (i = 0; i < MO_NUM; i++) {
+	if ((mo_drives[i].bus_type == MO_BUS_ATAPI) &&
+	    (mo_drives[i].ide_channel < 4) && mo_drives[i].priv)
+		mo_reset((scsi_common_t *) mo_drives[i].priv);
+	}
 
     cmd640_set_irq(0x00, p);
     cmd640_set_irq(0x01, p);

--- a/src/disk/hdc_ide_sff8038i.c
+++ b/src/disk/hdc_ide_sff8038i.c
@@ -41,6 +41,7 @@
 #include <86box/hdc_ide.h>
 #include <86box/hdc_ide_sff8038i.h>
 #include <86box/zip.h>
+#include <86box/mo.h>
 
 
 static int	next_id = 0;
@@ -440,6 +441,11 @@ sff_reset(void *p)
 	    (zip_drives[i].ide_channel < 4) && zip_drives[i].priv)
 		zip_reset((scsi_common_t *) zip_drives[i].priv);
     }
+	for (i = 0; i < MO_NUM; i++) {
+	if ((mo_drives[i].bus_type == MO_BUS_ATAPI) &&
+	    (mo_drives[i].ide_channel < 4) && mo_drives[i].priv)
+		mo_reset((scsi_common_t *) mo_drives[i].priv);
+	}
 
     sff_bus_master_set_irq(0x00, p);
     sff_bus_master_set_irq(0x01, p);

--- a/src/include/86box/language.h
+++ b/src/include/86box/language.h
@@ -112,6 +112,7 @@
 #define IDS_2136	2136		// "Don't Exit"
 #define IDS_2137	2137		// "Reset"
 #define IDS_2138	2138		// "Don't Reset"
+#define IDS_2139	2139		// "CD-ROM drives"
 
 #define IDS_4096	4096		// "Hard disk (%s)"
 #define IDS_4097	4097		// "%01i:%01i"
@@ -198,7 +199,7 @@
 
 #define IDS_LANG_ENUS	IDS_7168
 
-#define STR_NUM_2048	71
+#define STR_NUM_2048	92
 #define STR_NUM_3072	11
 #define STR_NUM_4096	18
 #define STR_NUM_4352	7

--- a/src/include/86box/mo.h
+++ b/src/include/86box/mo.h
@@ -59,7 +59,8 @@ typedef struct
     int8_t supported_media[KNOWN_MO_TYPES];
 } mo_drive_type_t;
 
-static const mo_drive_type_t mo_drive_types[22] = {
+#define KNOWN_MO_DRIVE_TYPES 22
+static const mo_drive_type_t mo_drive_types[KNOWN_MO_DRIVE_TYPES] = {
     {"86BOX", "MAGNETO OPTICAL", "1.00",{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}},
     {"FUJITSU", "M2512A", "1314",{1, 1, 0, 0, 0, 0, 0, 0, 0}},
     {"FUJITSU", "M2513-MCC3064SS", "1.00",{1, 1, 1, 1, 0, 0, 0, 0, 0, 0}},
@@ -117,35 +118,31 @@ typedef struct {
 } mo_drive_t;
 
 typedef struct {
-    uint8_t	id,
-		error, status,
-		phase,
-		features,
-		is_dma,
-		do_page_save,
-		unit_attention;
+  mode_sense_pages_t ms_pages_saved;
 
-    mo_drive_t	*drv;
+    mo_drive_t *drv;
 
-    uint16_t	request_length,
-		max_transfer_len;
+    uint8_t *buffer,
+	    atapi_cdb[16],
+	    current_cdb[16],
+	    sense[256];
 
-    int		requested_blocks, packet_status,
-		request_pos, old_len,
-		total_length;
+    uint8_t status, phase,
+	    error, id,
+	    features, pad0,
+	    pad1, pad2;
 
-    uint32_t	sector_pos, sector_len,
-		packet_len, pos,
-		seek_pos;
+    uint16_t request_length, max_transfer_len;
 
-    double	callback;
+    int requested_blocks, packet_status,
+    total_length, do_page_save,
+    unit_attention, request_pos,
+    old_len, pad3;
 
-    mode_sense_pages_t ms_pages_saved;
+    uint32_t sector_pos, sector_len,
+	     packet_len, pos;
 
-    uint8_t	*buffer,
-		atapi_cdb[16],
-		current_cdb[16],
-		sense[256];
+    double callback;
 } mo_t;
 
 

--- a/src/include/86box/resource.h
+++ b/src/include/86box/resource.h
@@ -39,7 +39,8 @@
 #define  DLG_CFG_HARD_DISKS	118	/* sub-dialog of config */
 #define  DLG_CFG_HARD_DISKS_ADD	119	/* sub-dialog of config */
 #define  DLG_CFG_FLOPPY_DRIVES	120	/* sub-dialog of config */
-#define  DLG_CFG_OTHER_REMOVABLE_DEVICES	121	/* sub-dialog of config */
+#define  DLG_CFG_CDROM_DRIVES	121	/* sub-dialog of config */
+#define  DLG_CFG_OTHER_REMOVABLE_DEVICES	122	/* sub-dialog of config */
 
 /* Static text label IDs. */
 #define IDT_1700		1700	/* Language: */
@@ -100,6 +101,11 @@
 #define IDT_1766		1766	/* Board #4: */
 #define IDT_1767		1767	/* ISA RTC: */
 #define IDT_1768		1768	/* Ext FD Controller: */
+#define IDT_1769        1769    /* MO drives: */
+#define IDT_1770        1770    /* Bus: */
+#define IDT_1771        1771    /* ID: */
+#define IDT_1772        1772    /* Channel */
+#define IDT_1773        1773    /* Type: */
 
 
 /*
@@ -236,6 +242,7 @@
 #define IDC_COMBO_MO_ID		1189
 #define IDC_COMBO_MO_LUN	1191
 #define IDC_COMBO_MO_CHANNEL_IDE 1192
+#define IDC_COMBO_MO_TYPE  1193
 
 #define IDC_SLIDER_GAIN		1190	/* sound gain dialog */
 

--- a/src/include/86box/win.h
+++ b/src/include/86box/win.h
@@ -164,7 +164,8 @@ extern void	NewFloppyDialogCreate(HWND hwnd, int id, int part);
 #define SETTINGS_PAGE_PERIPHERALS		6
 #define SETTINGS_PAGE_HARD_DISKS		7
 #define SETTINGS_PAGE_FLOPPY_DRIVES		8
-#define SETTINGS_PAGE_OTHER_REMOVABLE_DEVICES	9
+#define SETTINGS_PAGE_CDROM_DRIVES		9
+#define SETTINGS_PAGE_OTHER_REMOVABLE_DEVICES	10
 
 extern void	win_settings_open(HWND hwnd);
 extern void	win_settings_open_ex(HWND hwnd, int category);

--- a/src/pc.c
+++ b/src/pc.c
@@ -67,6 +67,7 @@
 #include <86box/scsi_device.h>
 #include <86box/cdrom.h>
 #include <86box/zip.h>
+#include <86box/mo.h>
 #include <86box/scsi_disk.h>
 #include <86box/cdrom_image.h>
 #include <86box/network.h>
@@ -519,6 +520,7 @@ usage:
     mouse_init();
     cdrom_global_init();
     zip_global_init();
+    mo_global_init();
 
     /* Load the configuration file. */
     config_load();
@@ -705,6 +707,8 @@ pc_reset_hard_close(void)
 
     zip_close();
 
+    mo_close();
+
     scsi_disk_close();
 
     closeal();
@@ -786,6 +790,8 @@ pc_reset_hard_init(void)
     cdrom_hard_reset();
 
     zip_hard_reset();
+
+    mo_hard_reset();
 
     scsi_disk_hard_reset();
 
@@ -887,6 +893,8 @@ pc_close(thread_t *ptr)
     cdrom_close();
 
     zip_close();
+
+    mo_close();
 
     scsi_disk_close();
 }

--- a/src/win/86Box.rc
+++ b/src/win/86Box.rc
@@ -627,7 +627,7 @@ BEGIN
                     BS_AUTOCHECKBOX | WS_TABSTOP,196,86,64,10
 END
 
-DLG_CFG_OTHER_REMOVABLE_DEVICES DIALOG DISCARDABLE  97, 0, 267, 221
+DLG_CFG_CDROM_DRIVES DIALOG DISCARDABLE 97, 0, 267, 150
 STYLE DS_CONTROL | WS_CHILD
 FONT 9, "Segoe UI"
 BEGIN
@@ -647,6 +647,30 @@ BEGIN
     COMBOBOX        IDC_COMBO_CD_SPEED,33,105,90,12,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
     LTEXT           "Speed:",IDT_1758,7,107,24,8
+END
+
+DLG_CFG_OTHER_REMOVABLE_DEVICES DIALOG DISCARDABLE  97, 0, 267, 221
+STYLE DS_CONTROL | WS_CHILD
+FONT 9, "Segoe UI"
+BEGIN
+
+    CONTROL         "List1",IDC_LIST_MO_DRIVES,"SysListView32",LVS_REPORT | 
+                    LVS_SHOWSELALWAYS | LVS_SINGLESEL | WS_BORDER | 
+                    WS_TABSTOP,7,18,253,60
+    LTEXT           "MO drives:",IDT_1769,7,7,50,8
+    COMBOBOX        IDC_COMBO_MO_BUS,33,85,90,12,CBS_DROPDOWNLIST | 
+                    WS_VSCROLL | WS_TABSTOP
+    LTEXT           "Bus:",IDT_1770,7,87,24,8
+    COMBOBOX        IDC_COMBO_MO_ID,170,85,90,12,CBS_DROPDOWNLIST | 
+                    WS_VSCROLL | WS_TABSTOP
+    LTEXT           "ID:",IDT_1771,131,87,38,8
+    COMBOBOX        IDC_COMBO_MO_CHANNEL_IDE,170,85,90,12,CBS_DROPDOWNLIST | 
+                    WS_VSCROLL | WS_TABSTOP
+    LTEXT           "Channel:",IDT_1772,131,87,38,8
+    COMBOBOX        IDC_COMBO_MO_TYPE,33,105,120,12,CBS_DROPDOWNLIST | 
+                    WS_VSCROLL | WS_TABSTOP
+    LTEXT           "Type:",IDT_1773,7,107,24,8
+
     CONTROL         "List1",IDC_LIST_ZIP_DRIVES,"SysListView32",LVS_REPORT | 
                     LVS_SHOWSELALWAYS | LVS_SINGLESEL | WS_BORDER | 
                     WS_TABSTOP,7,137,253,60
@@ -654,7 +678,7 @@ BEGIN
     COMBOBOX        IDC_COMBO_ZIP_BUS,23,204,90,12,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
     LTEXT           "Bus:",IDT_1753,7,206,14,8
-    COMBOBOX        IDC_COMBO_ZIP_ID,139,204,61,12,CBS_DROPDOWNLIST | 
+    COMBOBOX        IDC_COMBO_ZIP_ID,149,204,61,12,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
     LTEXT           "ID:",IDT_1754,120,206,28,8
     COMBOBOX        IDC_COMBO_ZIP_CHANNEL_IDE,149,204,61,12,CBS_DROPDOWNLIST | 
@@ -708,8 +732,8 @@ END
 161                     ICON    DISCARDABLE     "win/icons/cdrom_empty_active.ico"
 176                     ICON    DISCARDABLE     "win/icons/zip_empty.ico"
 177                     ICON    DISCARDABLE     "win/icons/zip_empty_active.ico"
-183                     ICON    DISCARDABLE     "win/icons/mo_empty.ico"
-184                     ICON    DISCARDABLE     "win/icons/mo_empty_active.ico"
+184                     ICON    DISCARDABLE     "win/icons/mo_empty.ico"
+185                     ICON    DISCARDABLE     "win/icons/mo_empty_active.ico"
 240                     ICON    DISCARDABLE     "win/icons/machine.ico"
 241                     ICON    DISCARDABLE     "win/icons/display.ico"
 242                     ICON    DISCARDABLE     "win/icons/input_devices.ico"
@@ -955,7 +979,7 @@ BEGIN
     IDS_2112	"Are you sure you want to hard reset the emulated machine?"
     IDS_2113	"Are you sure you want to exit 86Box?"
     IDS_2114	"Unable to initialize Ghostscript"
-    IDS_2115	"MO %i (%03i): %ls"
+    IDS_2115	"MO %i (%ls): %ls"
     IDS_2116	"MO images (*.IM?)\0*.IM?\0All files (*.*)\0*.*\0"
     IDS_2117	"Welcome to 86Box!"
     IDS_2118	"Internal controller"
@@ -999,6 +1023,7 @@ BEGIN
     IDS_2136	"Don't Exit"
     IDS_2137	"Reset"
     IDS_2138	"Don't Reset"
+    IDS_2139	"CD-ROM drives"
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/Makefile.mingw
+++ b/src/win/Makefile.mingw
@@ -218,17 +218,17 @@ ifndef NEW_DYNAREC
  NEW_DYNAREC	:= n
 endif
 ifndef DYNAREC
- DYNAREC		:= y
+ DYNAREC	:= y
 endif
 ifeq ($(DYNAREC), y)
  ifeq ($(ARM), y)
   ifeq ($(NEW_DYNAREC), n)
-   DYNAREC		:= n
+   DYNAREC	:= n
   endif
  endif
  ifeq ($(ARM64), y)
   ifeq ($(NEW_DYNAREC), n)
-   DYNAREC		:= n
+   DYNAREC	:= n
   endif
  endif
 endif
@@ -311,13 +311,13 @@ ifeq ($(ARM64), y)
 CPP		:= aarch64-w64-mingw32-g++
 CC		:= aarch64-w64-mingw32-gcc
 WINDRES		:= aarch64-w64-mingw32-windres
-STRIP := aarch64-w64-mingw32-strip
+STRIP		:= aarch64-w64-mingw32-strip
 endif
 ifeq ($(ARM), y)
 CPP		:= armv7-w64-mingw32-g++
 CC		:= armv7-w64-mingw32-gcc
 WINDRES		:= armv7-w64-mingw32-windres
-STRIP := armv7-w64-mingw32-strip
+STRIP		:= armv7-w64-mingw32-strip
 endif
 DEPS		= -MMD -MF $*.d -c $<
 DEPFILE		:= win/.depends
@@ -366,13 +366,13 @@ else
 endif
 AFLAGS		:= -msse2 -mfpmath=sse
 ifeq ($(ARM), y)
- DFLAGS	  := -march=armv7-a
- AOPTIM	  :=
+ DFLAGS		:= -march=armv7-a
+ AOPTIM		:=
  AFLAGS		:= -mfloat-abi=hard
 endif
 ifeq ($(ARM64), y)
- DFLAGS	  := -march=armv8-a
- AOPTIM	  :=
+ DFLAGS		:= -march=armv8-a
+ AOPTIM		:=
  AFLAGS		:= -mfloat-abi=hard
 endif
 RFLAGS		:= --input-format=rc -O coff -Iinclude

--- a/src/win/win_stbar.c
+++ b/src/win/win_stbar.c
@@ -51,6 +51,7 @@
 #include <86box/plat.h>
 #include <86box/ui.h>
 #include <86box/win.h>
+#include <86box/mo.h>
 
 #ifndef GWL_WNDPROC
 #define GWL_WNDPROC GWLP_WNDPROC
@@ -492,6 +493,18 @@ ui_sb_update_panes(void)
 	if (zip_drives[i].bus_type != 0)
 		sb_parts++;
     }
+	for (i=0; i<MO_NUM; i++) {
+	/* Could be Internal or External IDE.. */
+	if ((mo_drives[i].bus_type == MO_BUS_ATAPI) &&
+	    !(hdint || !memcmp(hdc_name, "ide", 3)))
+		continue;
+
+	if ((mo_drives[i].bus_type == MO_BUS_SCSI) &&
+	    (scsi_card_current == 0))
+		continue;
+	if (mo_drives[i].bus_type != 0)
+		sb_parts++;
+    }
     if (c_mfm && (hdint || !memcmp(hdc_name, "st506", 5))) {
 	/* MFM drives, and MFM or Internal controller. */
 	sb_parts++;
@@ -793,6 +806,8 @@ StatusBarCreate(HWND hwndParent, uintptr_t idStatus, HINSTANCE hInst)
 	hIcon[i] = LoadIconEx((PCTSTR) (uintptr_t) i);
     for (i = 48; i < 50; i++)
 	hIcon[i] = LoadIconEx((PCTSTR) (uintptr_t) i);
+	for (i = 56; i < 58; i++)
+	hIcon[i] = LoadIconEx((PCTSTR) (uintptr_t) i);
     for (i = 64; i < 66; i++)
 	hIcon[i] = LoadIconEx((PCTSTR) (uintptr_t) i);
     for (i = 80; i < 82; i++)
@@ -804,6 +819,8 @@ StatusBarCreate(HWND hwndParent, uintptr_t idStatus, HINSTANCE hInst)
     for (i = 160; i < 162; i++)
 	hIcon[i] = LoadIconEx((PCTSTR) (uintptr_t) i);
     for (i = 176; i < 178; i++)
+	hIcon[i] = LoadIconEx((PCTSTR) (uintptr_t) i);
+	for (i = 184; i < 186; i++)
 	hIcon[i] = LoadIconEx((PCTSTR) (uintptr_t) i);
     for (i = 243; i < 244; i++)
 	hIcon[i] = LoadIconEx((PCTSTR) (uintptr_t) i);


### PR DESCRIPTION
Moved CD-ROM to a sperate page, and reserve "Other removable devices" to MO and ZIP.
This change is for UI only, structure of the config file is left intact.

![批注 2020-07-15 090624](https://user-images.githubusercontent.com/22699485/87491349-7df8f980-c67a-11ea-82fb-5316c017db61.png)

![批注 2020-07-15 090606](https://user-images.githubusercontent.com/22699485/87491339-79ccdc00-c67a-11ea-8f85-f3c59f6b873a.png)
