### PR TITLE
Implement clock-dividing for FPUs on clock-multiplied 386s

### DIFF
--- a/src/cpu/x87_ops_arith.h
+++ b/src/cpu/x87_ops_arith.h
@@ -11,8 +11,8 @@ static int opFADD ## name ## _a ## a_size(uint32_t fetchdat)    \
         ST(0) += use_var;                                       \
         if ((cpu_state.npxc >> 10) & 3)                                   \
                 fesetround(FE_TONEAREST);                       \
-        FP_TAG_VALID;						\
-        CLOCK_CYCLES(x87_timings.fadd ## cycle_postfix);                                        \
+        FP_TAG_VALID;		\
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fadd ## cycle_postfix) : ((x87_timings.fadd ## cycle_postfix) * cpu_multi)); \
         return 0;                                               \
 }                                                               \
 static int opFCOM ## name ## _a ## a_size(uint32_t fetchdat)    \
@@ -24,7 +24,7 @@ static int opFCOM ## name ## _a ## a_size(uint32_t fetchdat)    \
         load_var = get(); if (cpu_state.abrt) return 1;                   \
         cpu_state.npxs &= ~(C0|C2|C3);                                    \
         cpu_state.npxs |= x87_compare(ST(0), (double)use_var);            \
-        CLOCK_CYCLES(x87_timings.fcom ## cycle_postfix);                                        \
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fcom ## cycle_postfix) : ((x87_timings.fcom ## cycle_postfix) * cpu_multi));                                        \
         return 0;                                               \
 }                                                               \
 static int opFCOMP ## name ## _a ## a_size(uint32_t fetchdat)   \
@@ -37,7 +37,7 @@ static int opFCOMP ## name ## _a ## a_size(uint32_t fetchdat)   \
         cpu_state.npxs &= ~(C0|C2|C3);                                    \
         cpu_state.npxs |= x87_compare(ST(0), (double)use_var);            \
         x87_pop();                                              \
-        CLOCK_CYCLES(x87_timings.fcom ## cycle_postfix);                                        \
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fcom ## cycle_postfix) : ((x87_timings.fcom ## cycle_postfix) * cpu_multi));                                        \
         return 0;                                               \
 }                                                               \
 static int opFDIV ## name ## _a ## a_size(uint32_t fetchdat)    \
@@ -49,7 +49,7 @@ static int opFDIV ## name ## _a ## a_size(uint32_t fetchdat)    \
         load_var = get(); if (cpu_state.abrt) return 1;                   \
         x87_div(ST(0), ST(0), use_var);                         \
         FP_TAG_VALID;						\
-        CLOCK_CYCLES(x87_timings.fdiv ## cycle_postfix);                                       \
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fdiv ## cycle_postfix) : ((x87_timings.fdiv ## cycle_postfix) * cpu_multi));                                       \
         return 0;                                               \
 }                                                               \
 static int opFDIVR ## name ## _a ## a_size(uint32_t fetchdat)   \
@@ -61,7 +61,7 @@ static int opFDIVR ## name ## _a ## a_size(uint32_t fetchdat)   \
         load_var = get(); if (cpu_state.abrt) return 1;                   \
         x87_div(ST(0), use_var, ST(0));                         \
         FP_TAG_VALID;						\
-        CLOCK_CYCLES(x87_timings.fdiv ## cycle_postfix);                                       \
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fdiv ## cycle_postfix) : ((x87_timings.fdiv ## cycle_postfix) * cpu_multi));                                       \
         return 0;                                               \
 }                                                               \
 static int opFMUL ## name ## _a ## a_size(uint32_t fetchdat)    \
@@ -73,7 +73,7 @@ static int opFMUL ## name ## _a ## a_size(uint32_t fetchdat)    \
         load_var = get(); if (cpu_state.abrt) return 1;                   \
         ST(0) *= use_var;                                       \
         FP_TAG_VALID;						\
-        CLOCK_CYCLES(x87_timings.fmul ## cycle_postfix);                                       \
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fmul ## cycle_postfix) : ((x87_timings.fmul ## cycle_postfix) * cpu_multi));                                       \
         return 0;                                               \
 }                                                               \
 static int opFSUB ## name ## _a ## a_size(uint32_t fetchdat)    \
@@ -85,7 +85,7 @@ static int opFSUB ## name ## _a ## a_size(uint32_t fetchdat)    \
         load_var = get(); if (cpu_state.abrt) return 1;                   \
         ST(0) -= use_var;                                       \
         FP_TAG_VALID;						\
-        CLOCK_CYCLES(x87_timings.fadd ## cycle_postfix);                                        \
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fadd ## cycle_postfix) : ((x87_timings.fadd ## cycle_postfix) * cpu_multi));                                        \
         return 0;                                               \
 }                                                               \
 static int opFSUBR ## name ## _a ## a_size(uint32_t fetchdat)   \
@@ -97,7 +97,7 @@ static int opFSUBR ## name ## _a ## a_size(uint32_t fetchdat)   \
         load_var = get(); if (cpu_state.abrt) return 1;                   \
         ST(0) = use_var - ST(0);                                \
         FP_TAG_VALID;						\
-        CLOCK_CYCLES(x87_timings.fadd ## cycle_postfix);                                        \
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fadd ## cycle_postfix) : ((x87_timings.fadd ## cycle_postfix) * cpu_multi));                                        \
         return 0;                                               \
 }
 
@@ -127,7 +127,7 @@ static int opFADD(uint32_t fetchdat)
         cpu_state.pc++;
         ST(0) = ST(0) + ST(fetchdat & 7);
 	FP_TAG_VALID;
-        CLOCK_CYCLES(x87_timings.fadd);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fadd) : (x87_timings.fadd * cpu_multi));
         return 0;
 }
 static int opFADDr(uint32_t fetchdat)
@@ -136,7 +136,7 @@ static int opFADDr(uint32_t fetchdat)
         cpu_state.pc++;
         ST(fetchdat & 7) = ST(fetchdat & 7) + ST(0);
 	FP_TAG_VALID_F;
-        CLOCK_CYCLES(x87_timings.fadd);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fadd) : (x87_timings.fadd * cpu_multi));
         return 0;
 }
 static int opFADDP(uint32_t fetchdat)
@@ -146,7 +146,7 @@ static int opFADDP(uint32_t fetchdat)
         ST(fetchdat & 7) = ST(fetchdat & 7) + ST(0);
 	FP_TAG_VALID_F;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fadd);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fadd) : (x87_timings.fadd * cpu_multi));
         return 0;
 }
 
@@ -157,7 +157,7 @@ static int opFCOM(uint32_t fetchdat)
         cpu_state.npxs &= ~(C0|C2|C3);
         if (ST(0) == ST(fetchdat & 7))     cpu_state.npxs |= C3;
         else if (ST(0) < ST(fetchdat & 7)) cpu_state.npxs |= C0;
-        CLOCK_CYCLES(x87_timings.fcom);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fcom) : (x87_timings.fcom * cpu_multi));
         return 0;
 }
 
@@ -168,7 +168,7 @@ static int opFCOMP(uint32_t fetchdat)
         cpu_state.npxs &= ~(C0|C2|C3);
         cpu_state.npxs |= x87_compare(ST(0), ST(fetchdat & 7));
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fcom);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fcom) : (x87_timings.fcom * cpu_multi));
         return 0;
 }
 
@@ -187,7 +187,7 @@ static int opFCOMPP(uint32_t fetchdat)
 
         x87_pop();
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fcom);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fcom) : (x87_timings.fcom * cpu_multi));
         return 0;
 }
 #ifndef FPU_8087
@@ -199,7 +199,7 @@ static int opFUCOMPP(uint32_t fetchdat)
         cpu_state.npxs |= x87_ucompare(ST(0), ST(1));
         x87_pop();
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fucom);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fucom) : (x87_timings.fucom * cpu_multi));
         return 0;
 }
 
@@ -211,7 +211,7 @@ static int opFCOMI(uint32_t fetchdat)
         cpu_state.flags &= ~(Z_FLAG | P_FLAG | C_FLAG);
         if (ST(0) == ST(fetchdat & 7))     cpu_state.flags |= Z_FLAG;
         else if (ST(0) < ST(fetchdat & 7)) cpu_state.flags |= C_FLAG;
-        CLOCK_CYCLES(x87_timings.fcom);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fcom) : (x87_timings.fcom * cpu_multi));
         return 0;
 }
 static int opFCOMIP(uint32_t fetchdat)
@@ -223,7 +223,7 @@ static int opFCOMIP(uint32_t fetchdat)
         if (ST(0) == ST(fetchdat & 7))     cpu_state.flags |= Z_FLAG;
         else if (ST(0) < ST(fetchdat & 7)) cpu_state.flags |= C_FLAG;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fcom);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fcom) : (x87_timings.fcom * cpu_multi));
         return 0;
 }
 #endif
@@ -234,7 +234,7 @@ static int opFDIV(uint32_t fetchdat)
         cpu_state.pc++;
         x87_div(ST(0), ST(0), ST(fetchdat & 7));
 	FP_TAG_VALID;
-        CLOCK_CYCLES(x87_timings.fdiv);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fdiv) : (x87_timings.fdiv * cpu_multi));
         return 0;
 }
 static int opFDIVr(uint32_t fetchdat)
@@ -243,7 +243,7 @@ static int opFDIVr(uint32_t fetchdat)
         cpu_state.pc++;
         x87_div(ST(fetchdat & 7), ST(fetchdat & 7), ST(0));
 	FP_TAG_VALID_F;
-        CLOCK_CYCLES(x87_timings.fdiv);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fdiv) : (x87_timings.fdiv * cpu_multi));
         return 0;
 }
 static int opFDIVP(uint32_t fetchdat)
@@ -253,7 +253,7 @@ static int opFDIVP(uint32_t fetchdat)
         x87_div(ST(fetchdat & 7), ST(fetchdat & 7), ST(0));
 	FP_TAG_VALID_F;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fdiv);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fdiv) : (x87_timings.fdiv * cpu_multi));
         return 0;
 }
 
@@ -263,7 +263,7 @@ static int opFDIVR(uint32_t fetchdat)
         cpu_state.pc++;
         x87_div(ST(0), ST(fetchdat&7), ST(0));
 	FP_TAG_VALID;
-        CLOCK_CYCLES(x87_timings.fdiv);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fdiv) : (x87_timings.fdiv * cpu_multi));
         return 0;
 }
 static int opFDIVRr(uint32_t fetchdat)
@@ -272,7 +272,7 @@ static int opFDIVRr(uint32_t fetchdat)
         cpu_state.pc++;
         x87_div(ST(fetchdat & 7), ST(0), ST(fetchdat & 7));
 	FP_TAG_VALID_F;
-        CLOCK_CYCLES(x87_timings.fdiv);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fdiv) : (x87_timings.fdiv * cpu_multi));
         return 0;
 }
 static int opFDIVRP(uint32_t fetchdat)
@@ -282,7 +282,7 @@ static int opFDIVRP(uint32_t fetchdat)
         x87_div(ST(fetchdat & 7), ST(0), ST(fetchdat & 7));
 	FP_TAG_VALID_F;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fdiv);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fdiv) : (x87_timings.fdiv * cpu_multi));
         return 0;
 }
 
@@ -292,7 +292,7 @@ static int opFMUL(uint32_t fetchdat)
         cpu_state.pc++;
         ST(0) = ST(0) * ST(fetchdat & 7);
 	FP_TAG_VALID;
-        CLOCK_CYCLES(x87_timings.fmul);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fmul) : (x87_timings.fmul * cpu_multi));
         return 0;
 }
 static int opFMULr(uint32_t fetchdat)
@@ -301,7 +301,7 @@ static int opFMULr(uint32_t fetchdat)
         cpu_state.pc++;
         ST(fetchdat & 7) = ST(0) * ST(fetchdat & 7);
 	FP_TAG_VALID_F;
-        CLOCK_CYCLES(x87_timings.fmul);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fmul) : (x87_timings.fmul * cpu_multi));
         return 0;
 }
 static int opFMULP(uint32_t fetchdat)
@@ -311,7 +311,7 @@ static int opFMULP(uint32_t fetchdat)
         ST(fetchdat & 7) = ST(0) * ST(fetchdat & 7);
 	FP_TAG_VALID_F;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fmul);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fmul) : (x87_timings.fmul * cpu_multi));
         return 0;
 }
 
@@ -321,7 +321,7 @@ static int opFSUB(uint32_t fetchdat)
         cpu_state.pc++;
         ST(0) = ST(0) - ST(fetchdat & 7);
 	FP_TAG_VALID;
-        CLOCK_CYCLES(x87_timings.fadd);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fadd) : (x87_timings.fadd * cpu_multi));
         return 0;
 }
 static int opFSUBr(uint32_t fetchdat)
@@ -330,7 +330,7 @@ static int opFSUBr(uint32_t fetchdat)
         cpu_state.pc++;
         ST(fetchdat & 7) = ST(fetchdat & 7) - ST(0);
 	FP_TAG_VALID_F;
-        CLOCK_CYCLES(x87_timings.fadd);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fadd) : (x87_timings.fadd * cpu_multi));
         return 0;
 }
 static int opFSUBP(uint32_t fetchdat)
@@ -340,7 +340,7 @@ static int opFSUBP(uint32_t fetchdat)
         ST(fetchdat & 7) = ST(fetchdat & 7) - ST(0);
 	FP_TAG_VALID_F;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fadd);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fadd) : (x87_timings.fadd * cpu_multi));
         return 0;
 }
 
@@ -350,7 +350,7 @@ static int opFSUBR(uint32_t fetchdat)
         cpu_state.pc++;
         ST(0) = ST(fetchdat & 7) - ST(0);
 	FP_TAG_VALID;
-        CLOCK_CYCLES(x87_timings.fadd);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fadd) : (x87_timings.fadd * cpu_multi));
         return 0;
 }
 static int opFSUBRr(uint32_t fetchdat)
@@ -359,7 +359,7 @@ static int opFSUBRr(uint32_t fetchdat)
         cpu_state.pc++;
         ST(fetchdat & 7) = ST(0) - ST(fetchdat & 7);
 	FP_TAG_VALID_F;
-        CLOCK_CYCLES(x87_timings.fadd);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fadd) : (x87_timings.fadd * cpu_multi));
         return 0;
 }
 static int opFSUBRP(uint32_t fetchdat)
@@ -369,7 +369,7 @@ static int opFSUBRP(uint32_t fetchdat)
         ST(fetchdat & 7) = ST(0) - ST(fetchdat & 7);
 	FP_TAG_VALID_F;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fadd);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fadd) : (x87_timings.fadd * cpu_multi));
         return 0;
 }
 
@@ -380,7 +380,7 @@ static int opFUCOM(uint32_t fetchdat)
         cpu_state.pc++;
         cpu_state.npxs &= ~(C0|C2|C3);
         cpu_state.npxs |= x87_ucompare(ST(0), ST(fetchdat & 7));
-        CLOCK_CYCLES(x87_timings.fucom);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fucom) : (x87_timings.fucom * cpu_multi));
         return 0;
 }
 
@@ -391,7 +391,7 @@ static int opFUCOMP(uint32_t fetchdat)
         cpu_state.npxs &= ~(C0|C2|C3);
         cpu_state.npxs |= x87_ucompare(ST(0), ST(fetchdat & 7));
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fucom);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fucom) : (x87_timings.fucom * cpu_multi));
         return 0;
 }
 
@@ -403,7 +403,7 @@ static int opFUCOMI(uint32_t fetchdat)
         cpu_state.flags &= ~(Z_FLAG | P_FLAG | C_FLAG);
         if (ST(0) == ST(fetchdat & 7))     cpu_state.flags |= Z_FLAG;
         else if (ST(0) < ST(fetchdat & 7)) cpu_state.flags |= C_FLAG;
-        CLOCK_CYCLES(x87_timings.fucom);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fucom) : (x87_timings.fucom * cpu_multi));
         return 0;
 }
 static int opFUCOMIP(uint32_t fetchdat)
@@ -415,7 +415,7 @@ static int opFUCOMIP(uint32_t fetchdat)
         if (ST(0) == ST(fetchdat & 7))     cpu_state.flags |= Z_FLAG;
         else if (ST(0) < ST(fetchdat & 7)) cpu_state.flags |= C_FLAG;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fucom);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fucom) : (x87_timings.fucom * cpu_multi));
         return 0;
 }
 #endif

--- a/src/cpu/x87_ops_loadstore.h
+++ b/src/cpu/x87_ops_loadstore.h
@@ -23,7 +23,7 @@ static int opFILDiw_a16(uint32_t fetchdat)
 	SEG_CHECK_READ(cpu_state.ea_seg);
         temp = geteaw(); if (cpu_state.abrt) return 1;
         x87_push((double)temp);
-        CLOCK_CYCLES(x87_timings.fild_16);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fild_16) : (x87_timings.fild_16 * cpu_multi));
         return 0;
 }
 #ifndef FPU_8087
@@ -35,7 +35,7 @@ static int opFILDiw_a32(uint32_t fetchdat)
 	SEG_CHECK_READ(cpu_state.ea_seg);
         temp = geteaw(); if (cpu_state.abrt) return 1;
         x87_push((double)temp);
-        CLOCK_CYCLES(x87_timings.fild_16);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fild_16) : (x87_timings.fild_16 * cpu_multi));
         return 0;
 }
 #endif
@@ -48,7 +48,7 @@ static int opFISTiw_a16(uint32_t fetchdat)
 	SEG_CHECK_WRITE(cpu_state.ea_seg);
         temp64 = x87_fround(ST(0));
         seteaw((int16_t)temp64);
-        CLOCK_CYCLES(x87_timings.fist_16);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fist_16) : (x87_timings.fist_16 * cpu_multi));
         return cpu_state.abrt;
 }
 #ifndef FPU_8087
@@ -60,7 +60,7 @@ static int opFISTiw_a32(uint32_t fetchdat)
 	SEG_CHECK_WRITE(cpu_state.ea_seg);
         temp64 = x87_fround(ST(0));
         seteaw((int16_t)temp64);
-        CLOCK_CYCLES(x87_timings.fist_16);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fist_16) : (x87_timings.fist_16 * cpu_multi));
         return cpu_state.abrt;
 }
 #endif
@@ -74,7 +74,7 @@ static int opFISTPiw_a16(uint32_t fetchdat)
         temp64 = x87_fround(ST(0));
         seteaw((int16_t)temp64); if (cpu_state.abrt) return 1;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fist_16);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fist_16) : (x87_timings.fist_16 * cpu_multi));
         return 0;
 }
 #ifndef FPU_8087
@@ -87,7 +87,7 @@ static int opFISTPiw_a32(uint32_t fetchdat)
         temp64 = x87_fround(ST(0));
         seteaw((int16_t)temp64); if (cpu_state.abrt) return 1;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fist_16);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fist_16) : (x87_timings.fist_16 * cpu_multi));
         return 0;
 }
 #endif
@@ -103,7 +103,7 @@ static int opFILDiq_a16(uint32_t fetchdat)
         cpu_state.MM[cpu_state.TOP&7].q = temp64;
 	FP_TAG_DEFAULT;
 
-        CLOCK_CYCLES(x87_timings.fild_64);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fild_64) : (x87_timings.fild_64 * cpu_multi));
         return 0;
 }
 #ifndef FPU_8087
@@ -118,7 +118,7 @@ static int opFILDiq_a32(uint32_t fetchdat)
         cpu_state.MM[cpu_state.TOP&7].q = temp64;
 	FP_TAG_DEFAULT;
 
-        CLOCK_CYCLES(x87_timings.fild_64);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fild_64) : (x87_timings.fild_64 * cpu_multi));
         return 0;
 }
 #endif
@@ -147,7 +147,7 @@ static int FBSTP_a16(uint32_t fetchdat)
         if (ST(0) < 0.0) tempc |= 0x80;
         writememb(easeg, cpu_state.eaaddr + 9, tempc); if (cpu_state.abrt) return 1;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fbstp);		
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fbstp) : (x87_timings.fbstp * cpu_multi));		
         return 0;
 }
 #ifndef FPU_8087
@@ -175,7 +175,7 @@ static int FBSTP_a32(uint32_t fetchdat)
         if (ST(0) < 0.0) tempc |= 0x80;
         writememb(easeg, cpu_state.eaaddr + 9, tempc); if (cpu_state.abrt) return 1;
         x87_pop();
-		CLOCK_CYCLES(x87_timings.fbstp);
+		CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fbstp) : (x87_timings.fbstp * cpu_multi));
         return 0;
 }
 #endif
@@ -192,7 +192,7 @@ static int FISTPiq_a16(uint32_t fetchdat)
                 temp64 = x87_fround(ST(0));
         seteaq(temp64); if (cpu_state.abrt) return 1;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fist_64);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fist_64) : (x87_timings.fist_64 * cpu_multi));
         return 0;
 }
 #ifndef FPU_8087
@@ -208,7 +208,7 @@ static int FISTPiq_a32(uint32_t fetchdat)
                 temp64 = x87_fround(ST(0));
         seteaq(temp64); if (cpu_state.abrt) return 1;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fist_64);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fist_64) : (x87_timings.fist_64 * cpu_multi));
         return 0;
 }
 #endif
@@ -221,7 +221,7 @@ static int opFILDil_a16(uint32_t fetchdat)
 	SEG_CHECK_READ(cpu_state.ea_seg);
         templ = geteal(); if (cpu_state.abrt) return 1;
         x87_push((double)templ);
-        CLOCK_CYCLES(x87_timings.fild_32);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fild_32) : (x87_timings.fild_32 * cpu_multi));
         return 0;
 }
 #ifndef FPU_8087
@@ -233,7 +233,7 @@ static int opFILDil_a32(uint32_t fetchdat)
 	SEG_CHECK_READ(cpu_state.ea_seg);
         templ = geteal(); if (cpu_state.abrt) return 1;
         x87_push((double)templ);
-        CLOCK_CYCLES(x87_timings.fild_32);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fild_32) : (x87_timings.fild_32 * cpu_multi));
         return 0;
 }
 #endif
@@ -246,7 +246,7 @@ static int opFISTil_a16(uint32_t fetchdat)
 	SEG_CHECK_WRITE(cpu_state.ea_seg);
         temp64 = x87_fround(ST(0));
         seteal((int32_t)temp64);
-        CLOCK_CYCLES(x87_timings.fist_32);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fist_32) : (x87_timings.fist_32 * cpu_multi));
         return cpu_state.abrt;
 }
 #ifndef FPU_8087
@@ -258,7 +258,7 @@ static int opFISTil_a32(uint32_t fetchdat)
 	SEG_CHECK_WRITE(cpu_state.ea_seg);
         temp64 = x87_fround(ST(0));
         seteal((int32_t)temp64);
-        CLOCK_CYCLES(x87_timings.fist_32);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fist_32) : (x87_timings.fist_32 * cpu_multi));
         return cpu_state.abrt;
 }
 #endif
@@ -272,7 +272,7 @@ static int opFISTPil_a16(uint32_t fetchdat)
         temp64 = x87_fround(ST(0));
         seteal((int32_t)temp64); if (cpu_state.abrt) return 1;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fist_32);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fist_32) : (x87_timings.fist_32 * cpu_multi));
         return 0;
 }
 #ifndef FPU_8087
@@ -285,7 +285,7 @@ static int opFISTPil_a32(uint32_t fetchdat)
         temp64 = x87_fround(ST(0));
         seteal((int32_t)temp64); if (cpu_state.abrt) return 1;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fist_32);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fist_32) : (x87_timings.fist_32 * cpu_multi));
         return 0;
 }
 #endif
@@ -298,7 +298,7 @@ static int opFLDe_a16(uint32_t fetchdat)
 	SEG_CHECK_READ(cpu_state.ea_seg);
         t=x87_ld80(); if (cpu_state.abrt) return 1;
         x87_push(t);
-        CLOCK_CYCLES(x87_timings.fld_80);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fld_80) : (x87_timings.fld_80 * cpu_multi));
         return 0;
 }
 #ifndef FPU_8087
@@ -310,7 +310,7 @@ static int opFLDe_a32(uint32_t fetchdat)
 	SEG_CHECK_READ(cpu_state.ea_seg);
         t=x87_ld80(); if (cpu_state.abrt) return 1;
         x87_push(t);
-        CLOCK_CYCLES(x87_timings.fld_80);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fld_80) : (x87_timings.fld_80 * cpu_multi));
         return 0;
 }
 #endif
@@ -322,7 +322,7 @@ static int opFSTPe_a16(uint32_t fetchdat)
 	SEG_CHECK_WRITE(cpu_state.ea_seg);
         x87_st80(ST(0)); if (cpu_state.abrt) return 1;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fld_80);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fld_80) : (x87_timings.fld_80 * cpu_multi));
         return 0;
 }
 #ifndef FPU_8087
@@ -333,7 +333,7 @@ static int opFSTPe_a32(uint32_t fetchdat)
 	SEG_CHECK_WRITE(cpu_state.ea_seg);
         x87_st80(ST(0)); if (cpu_state.abrt) return 1;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fld_80);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fld_80) : (x87_timings.fld_80 * cpu_multi));
         return 0;
 }
 #endif
@@ -346,7 +346,7 @@ static int opFLDd_a16(uint32_t fetchdat)
 	SEG_CHECK_READ(cpu_state.ea_seg);
         t.i = geteaq(); if (cpu_state.abrt) return 1;
         x87_push(t.d);
-        CLOCK_CYCLES(x87_timings.fld_64);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fld_64) : (x87_timings.fld_64 * cpu_multi));
         return 0;
 }
 #ifndef FPU_8087
@@ -358,7 +358,7 @@ static int opFLDd_a32(uint32_t fetchdat)
 	SEG_CHECK_READ(cpu_state.ea_seg);
         t.i = geteaq(); if (cpu_state.abrt) return 1;
         x87_push(t.d);
-        CLOCK_CYCLES(x87_timings.fld_64);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fld_64) : (x87_timings.fld_64 * cpu_multi));
         return 0;
 }
 #endif
@@ -371,7 +371,7 @@ static int opFSTd_a16(uint32_t fetchdat)
 	SEG_CHECK_WRITE(cpu_state.ea_seg);
         t.d = ST(0);
         seteaq(t.i);
-        CLOCK_CYCLES(x87_timings.fst_64);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fst_64) : (x87_timings.fst_64 * cpu_multi));
         return cpu_state.abrt;
 }
 #ifndef FPU_8087
@@ -383,7 +383,7 @@ static int opFSTd_a32(uint32_t fetchdat)
 	SEG_CHECK_WRITE(cpu_state.ea_seg);
         t.d = ST(0);
         seteaq(t.i);
-        CLOCK_CYCLES(x87_timings.fst_64);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fst_64) : (x87_timings.fst_64 * cpu_multi));
         return cpu_state.abrt;
 }
 #endif
@@ -397,7 +397,7 @@ static int opFSTPd_a16(uint32_t fetchdat)
         t.d = ST(0);
         seteaq(t.i); if (cpu_state.abrt) return 1;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fst_64);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fst_64) : (x87_timings.fst_64 * cpu_multi));
         return 0;
 }
 #ifndef FPU_8087
@@ -410,7 +410,7 @@ static int opFSTPd_a32(uint32_t fetchdat)
         t.d = ST(0);
         seteaq(t.i); if (cpu_state.abrt) return 1;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fst_64);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fst_64) : (x87_timings.fst_64 * cpu_multi));
         return 0;
 }
 #endif
@@ -423,7 +423,7 @@ static int opFLDs_a16(uint32_t fetchdat)
 	SEG_CHECK_READ(cpu_state.ea_seg);
         ts.i = geteal(); if (cpu_state.abrt) return 1;
         x87_push((double)ts.s);
-        CLOCK_CYCLES(x87_timings.fld_32);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fst_32) : (x87_timings.fst_32 * cpu_multi));
         return 0;
 }
 #ifndef FPU_8087
@@ -435,7 +435,7 @@ static int opFLDs_a32(uint32_t fetchdat)
 	SEG_CHECK_READ(cpu_state.ea_seg);
         ts.i = geteal(); if (cpu_state.abrt) return 1;
         x87_push((double)ts.s);
-        CLOCK_CYCLES(x87_timings.fld_32);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fst_32) : (x87_timings.fst_32 * cpu_multi));
         return 0;
 }
 #endif
@@ -448,7 +448,7 @@ static int opFSTs_a16(uint32_t fetchdat)
 	SEG_CHECK_WRITE(cpu_state.ea_seg);
         ts.s = (float)ST(0);
         seteal(ts.i);
-        CLOCK_CYCLES(x87_timings.fst_32);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fst_32) : (x87_timings.fst_32 * cpu_multi));
         return cpu_state.abrt;
 }
 #ifndef FPU_8087
@@ -460,7 +460,7 @@ static int opFSTs_a32(uint32_t fetchdat)
 	SEG_CHECK_WRITE(cpu_state.ea_seg);
         ts.s = (float)ST(0);
         seteal(ts.i);
-        CLOCK_CYCLES(x87_timings.fst_32);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fst_32) : (x87_timings.fst_32 * cpu_multi));
         return cpu_state.abrt;
 }
 #endif
@@ -474,7 +474,7 @@ static int opFSTPs_a16(uint32_t fetchdat)
         ts.s = (float)ST(0);
         seteal(ts.i); if (cpu_state.abrt) return 1;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fst_32);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fst_32) : (x87_timings.fst_32 * cpu_multi));
         return 0;
 }
 #ifndef FPU_8087
@@ -487,7 +487,7 @@ static int opFSTPs_a32(uint32_t fetchdat)
         ts.s = (float)ST(0);
         seteal(ts.i); if (cpu_state.abrt) return 1;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fst_32);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fst_32) : (x87_timings.fst_32 * cpu_multi));
         return 0;
 }
 #endif

--- a/src/cpu/x87_ops_misc.h
+++ b/src/cpu/x87_ops_misc.h
@@ -15,7 +15,7 @@ static int opFSTSW_AX(uint32_t fetchdat)
         FP_ENTER();
         cpu_state.pc++;
         AX = cpu_state.npxs;
-        CLOCK_CYCLES(x87_timings.fstcw_sw);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fstcw_sw) : (x87_timings.fstcw_sw * cpu_multi));
         return 0;
 }
 #endif
@@ -25,7 +25,7 @@ static int opFNOP(uint32_t fetchdat)
 {
         FP_ENTER();
         cpu_state.pc++;
-        CLOCK_CYCLES(x87_timings.fnop);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fnop) : (x87_timings.fnop * cpu_multi));
         return 0;
 }
 
@@ -34,7 +34,7 @@ static int opFCLEX(uint32_t fetchdat)
         FP_ENTER();
         cpu_state.pc++;
         cpu_state.npxs &= 0xff00;
-        CLOCK_CYCLES(x87_timings.fnop);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fnop) : (x87_timings.fnop * cpu_multi));
         return 0;
 }
 
@@ -58,7 +58,7 @@ static int opFINIT(uint32_t fetchdat)
 #endif
         cpu_state.TOP = 0;
 	cpu_state.ismmx = 0;
-        CLOCK_CYCLES(x87_timings.finit);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.finit) : (x87_timings.finit * cpu_multi));
 	CPU_BLOCK_END();
         return 0;
 }
@@ -73,7 +73,7 @@ static int opFFREE(uint32_t fetchdat)
 #else
         cpu_state.tag[(cpu_state.TOP + fetchdat) & 7] = 3;
 #endif
-        CLOCK_CYCLES(x87_timings.ffree);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.ffree) : (x87_timings.ffree * cpu_multi));
         return 0;
 }
 
@@ -83,7 +83,7 @@ static int opFFREEP(uint32_t fetchdat)
         cpu_state.pc++;
         cpu_state.tag[(cpu_state.TOP + fetchdat) & 7] = 3; if (cpu_state.abrt) return 1;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.ffree);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.ffree) : (x87_timings.ffree * cpu_multi));
         return 0;
 }
 
@@ -93,7 +93,7 @@ static int opFST(uint32_t fetchdat)
         cpu_state.pc++;
         ST(fetchdat & 7) = ST(0);
         cpu_state.tag[(cpu_state.TOP + fetchdat) & 7] = cpu_state.tag[cpu_state.TOP & 7];
-        CLOCK_CYCLES(x87_timings.fst);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fst) : (x87_timings.fst * cpu_multi));
         return 0;
 }
 
@@ -104,7 +104,7 @@ static int opFSTP(uint32_t fetchdat)
         ST(fetchdat & 7) = ST(0);
         cpu_state.tag[(cpu_state.TOP + fetchdat) & 7] = cpu_state.tag[cpu_state.TOP & 7];
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fst);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fst) : (x87_timings.fst * cpu_multi));
         return 0;
 }
 
@@ -160,7 +160,7 @@ static int FSTOR()
  #endif
 		cpu_state.ismmx = 1;
 
-        CLOCK_CYCLES(x87_timings.frstor);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.frstor) : (x87_timings.frstor * cpu_multi));
         return cpu_state.abrt;
 }
 static int opFSTOR_a16(uint32_t fetchdat)
@@ -330,7 +330,7 @@ static int FSAVE()
         cpu_state.TOP = 0;
         cpu_state.ismmx = 0;
 
-        CLOCK_CYCLES(x87_timings.fsave);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fsave) : (x87_timings.fsave * cpu_multi));
         return cpu_state.abrt;
 }
 static int opFSAVE_a16(uint32_t fetchdat)
@@ -358,7 +358,7 @@ static int opFSTSW_a16(uint32_t fetchdat)
         fetch_ea_16(fetchdat);
 	SEG_CHECK_WRITE(cpu_state.ea_seg);
         seteaw((cpu_state.npxs & 0xC7FF) | ((cpu_state.TOP & 7) << 11));
-        CLOCK_CYCLES(x87_timings.fstcw_sw);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fstcw_sw) : (x87_timings.fstcw_sw * cpu_multi));
         return cpu_state.abrt;
 }
 #ifndef FPU_8087
@@ -368,7 +368,7 @@ static int opFSTSW_a32(uint32_t fetchdat)
         fetch_ea_32(fetchdat);
 	SEG_CHECK_WRITE(cpu_state.ea_seg);
         seteaw((cpu_state.npxs & 0xC7FF) | ((cpu_state.TOP & 7) << 11));
-        CLOCK_CYCLES(x87_timings.fstcw_sw);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fstcw_sw) : (x87_timings.fstcw_sw * cpu_multi));
         return cpu_state.abrt;
 }
 #endif
@@ -386,7 +386,7 @@ static int opFLD(uint32_t fetchdat)
         x87_push(ST(fetchdat&7));
         cpu_state.tag[cpu_state.TOP&7] = old_tag;
         cpu_state.MM[cpu_state.TOP&7].q = old_i64;
-        CLOCK_CYCLES(x87_timings.fld);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fld) : (x87_timings.fld * cpu_multi));
         return 0;
 }
 
@@ -407,7 +407,7 @@ static int opFXCH(uint32_t fetchdat)
         cpu_state.MM[cpu_state.TOP&7].q = cpu_state.MM[(cpu_state.TOP + fetchdat) & 7].q;
         cpu_state.MM[(cpu_state.TOP + fetchdat) & 7].q = old_i64;
         
-        CLOCK_CYCLES(x87_timings.fxch);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fxch) : (x87_timings.fxch * cpu_multi));
         return 0;
 }
 
@@ -417,7 +417,7 @@ static int opFCHS(uint32_t fetchdat)
         cpu_state.pc++;
         ST(0) = -ST(0);
         FP_TAG_VALID;
-        CLOCK_CYCLES(x87_timings.fchs);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fchs) : (x87_timings.fchs * cpu_multi));
         return 0;
 }
 
@@ -427,7 +427,7 @@ static int opFABS(uint32_t fetchdat)
         cpu_state.pc++;
         ST(0) = fabs(ST(0));
         FP_TAG_VALID;
-        CLOCK_CYCLES(x87_timings.fabs);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fabs) : (x87_timings.fabs * cpu_multi));
         return 0;
 }
 
@@ -438,7 +438,7 @@ static int opFTST(uint32_t fetchdat)
         cpu_state.npxs &= ~(C0|C2|C3);
         if (ST(0) == 0.0)     cpu_state.npxs |= C3;
         else if (ST(0) < 0.0) cpu_state.npxs |= C0;
-        CLOCK_CYCLES(x87_timings.ftst);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.ftst) : (x87_timings.ftst * cpu_multi));
         return 0;
 }
 
@@ -455,7 +455,7 @@ static int opFXAM(uint32_t fetchdat)
         else if (ST(0) == 0.0) cpu_state.npxs |= C3;
         else                   cpu_state.npxs |= C2;
         if (ST(0) < 0.0)       cpu_state.npxs |= C1;
-        CLOCK_CYCLES(x87_timings.fxam);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fxam) : (x87_timings.fxam * cpu_multi));
         return 0;
 }
 
@@ -464,7 +464,7 @@ static int opFLD1(uint32_t fetchdat)
         FP_ENTER();
         cpu_state.pc++;
         x87_push(1.0);
-        CLOCK_CYCLES(x87_timings.fld_z1);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fld_z1) : (x87_timings.fld_z1 * cpu_multi));
         return 0;
 }
 
@@ -473,7 +473,7 @@ static int opFLDL2T(uint32_t fetchdat)
         FP_ENTER();
         cpu_state.pc++;
         x87_push(3.3219280948873623);
-        CLOCK_CYCLES(x87_timings.fld_const);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fld_const) : (x87_timings.fld_const * cpu_multi));
         return 0;
 }
 
@@ -482,7 +482,7 @@ static int opFLDL2E(uint32_t fetchdat)
         FP_ENTER();
         cpu_state.pc++;
         x87_push(1.4426950408889634);
-        CLOCK_CYCLES(x87_timings.fld_const);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fld_const) : (x87_timings.fld_const * cpu_multi));
         return 0;
 }
 
@@ -491,7 +491,7 @@ static int opFLDPI(uint32_t fetchdat)
         FP_ENTER();
         cpu_state.pc++;
         x87_push(3.141592653589793);
-        CLOCK_CYCLES(x87_timings.fld_const);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fld_const) : (x87_timings.fld_const * cpu_multi));
         return 0;
 }
 
@@ -500,7 +500,7 @@ static int opFLDEG2(uint32_t fetchdat)
         FP_ENTER();
         cpu_state.pc++;
         x87_push(0.3010299956639812);
-        CLOCK_CYCLES(x87_timings.fld_const);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fld_const) : (x87_timings.fld_const * cpu_multi));
         return 0;
 }
 
@@ -509,7 +509,7 @@ static int opFLDLN2(uint32_t fetchdat)
         FP_ENTER();
         cpu_state.pc++;
         x87_push_u64(0x3fe62e42fefa39f0ull);
-        CLOCK_CYCLES(x87_timings.fld_const);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fld_const) : (x87_timings.fld_const * cpu_multi));
         return 0;
 }
  
@@ -519,7 +519,7 @@ static int opFLDZ(uint32_t fetchdat)
         cpu_state.pc++;
         x87_push(0.0);
         FP_TAG_VALID;
-        CLOCK_CYCLES(x87_timings.fld_z1);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fld_z1) : (x87_timings.fld_z1 * cpu_multi));
         return 0;
 }
 
@@ -529,7 +529,7 @@ static int opF2XM1(uint32_t fetchdat)
         cpu_state.pc++;
         ST(0) = pow(2.0, ST(0)) - 1.0;
         FP_TAG_VALID;
-        CLOCK_CYCLES(x87_timings.f2xm1);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.f2xm1) : (x87_timings.f2xm1 * cpu_multi));
         return 0;
 }
 
@@ -540,7 +540,7 @@ static int opFYL2X(uint32_t fetchdat)
         ST(1) = ST(1) * (log(ST(0)) / log(2.0));
         FP_TAG_VALID_N;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fyl2x);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fyl2x) : (x87_timings.fyl2x * cpu_multi));
         return 0;
 }
 
@@ -551,7 +551,7 @@ static int opFYL2XP1(uint32_t fetchdat)
         ST(1) = ST(1) * (log1p(ST(0)) / log(2.0));
         FP_TAG_VALID_N;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fyl2xp1);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fyl2xp1) : (x87_timings.fyl2xp1 * cpu_multi));
         return 0;
 }
 
@@ -563,7 +563,7 @@ static int opFPTAN(uint32_t fetchdat)
         FP_TAG_VALID;
         x87_push(1.0);
         cpu_state.npxs &= ~C2;
-        CLOCK_CYCLES(x87_timings.fptan);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fptan) : (x87_timings.fptan * cpu_multi));
         return 0;
 }
 
@@ -574,7 +574,7 @@ static int opFPATAN(uint32_t fetchdat)
         ST(1) = atan2(ST(1), ST(0));
         FP_TAG_VALID_N;
         x87_pop();
-        CLOCK_CYCLES(x87_timings.fpatan);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fpatan) : (x87_timings.fpatan * cpu_multi));
         return 0;
 }
 
@@ -587,7 +587,7 @@ static int opFDECSTP(uint32_t fetchdat)
 #else
         cpu_state.TOP = (cpu_state.TOP - 1) & 7;
 #endif
-        CLOCK_CYCLES(x87_timings.fincdecstp);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fincdecstp) : (x87_timings.fincdecstp * cpu_multi));
         return 0;
 }
 
@@ -600,7 +600,7 @@ static int opFINCSTP(uint32_t fetchdat)
 #else
         cpu_state.TOP = (cpu_state.TOP + 1) & 7;
 #endif
-        CLOCK_CYCLES(x87_timings.fincdecstp);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fincdecstp) : (x87_timings.fincdecstp * cpu_multi));
         return 0;
 }
 
@@ -616,7 +616,7 @@ static int opFPREM(uint32_t fetchdat)
         if (temp64 & 4) cpu_state.npxs|=C0;
         if (temp64 & 2) cpu_state.npxs|=C3;
         if (temp64 & 1) cpu_state.npxs|=C1;
-        CLOCK_CYCLES(x87_timings.fprem);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fprem) : (x87_timings.fprem * cpu_multi));
         return 0;
 }
 #ifndef FPU_8087
@@ -632,7 +632,7 @@ static int opFPREM1(uint32_t fetchdat)
         if (temp64 & 4) cpu_state.npxs|=C0;
         if (temp64 & 2) cpu_state.npxs|=C3;
         if (temp64 & 1) cpu_state.npxs|=C1;
-        CLOCK_CYCLES(x87_timings.fprem1);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fprem1) : (x87_timings.fprem1 * cpu_multi));
         return 0;
 }
 #endif
@@ -643,7 +643,7 @@ static int opFSQRT(uint32_t fetchdat)
         cpu_state.pc++;
         ST(0) = sqrt(ST(0));
         FP_TAG_VALID;
-        CLOCK_CYCLES(x87_timings.fsqrt);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fsqrt) : (x87_timings.fsqrt * cpu_multi));
         return 0;
 }
 
@@ -658,7 +658,7 @@ static int opFSINCOS(uint32_t fetchdat)
         FP_TAG_VALID;
         x87_push(cos(td));
         cpu_state.npxs &= ~C2;
-        CLOCK_CYCLES(x87_timings.fsincos);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fsincos) : (x87_timings.fsincos * cpu_multi));
         return 0;
 }
 #endif
@@ -669,7 +669,7 @@ static int opFRNDINT(uint32_t fetchdat)
         cpu_state.pc++;
         ST(0) = (double)x87_fround(ST(0));
         FP_TAG_VALID;
-        CLOCK_CYCLES(x87_timings.frndint);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.frndint) : (x87_timings.frndint * cpu_multi));
         return 0;
 }
 
@@ -681,7 +681,7 @@ static int opFSCALE(uint32_t fetchdat)
         temp64 = (int64_t)ST(1);
         ST(0) = ST(0) * pow(2.0, (double)temp64);
         FP_TAG_VALID;
-        CLOCK_CYCLES(x87_timings.fscale);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fscale) : (x87_timings.fscale * cpu_multi));
         return 0;
 }
 
@@ -693,7 +693,7 @@ static int opFSIN(uint32_t fetchdat)
         ST(0) = sin(ST(0));
         FP_TAG_VALID;
         cpu_state.npxs &= ~C2;
-        CLOCK_CYCLES(x87_timings.fsin_cos);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fsin_cos) : (x87_timings.fsin_cos * cpu_multi));
         return 0;
 }
 
@@ -704,7 +704,7 @@ static int opFCOS(uint32_t fetchdat)
         ST(0) = cos(ST(0));
         FP_TAG_VALID;
         cpu_state.npxs &= ~C2;
-        CLOCK_CYCLES(x87_timings.fsin_cos);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fsin_cos) : (x87_timings.fsin_cos * cpu_multi));
         return 0;
 }
 #endif
@@ -732,7 +732,7 @@ static int FLDENV()
                 cpu_state.TOP = (cpu_state.npxs >> 11) & 7;
                 break;
         }
-        CLOCK_CYCLES(x87_timings.fldenv);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fldenv) : (x87_timings.fldenv * cpu_multi));
         return cpu_state.abrt;
 }
 
@@ -765,7 +765,7 @@ static int opFLDCW_a16(uint32_t fetchdat)
         if (cpu_state.abrt) return 1;
         cpu_state.npxc = tempw;
         codegen_set_rounding_mode((cpu_state.npxc >> 10) & 3);
-        CLOCK_CYCLES(x87_timings.fldcw);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fldcw) : (x87_timings.fldcw * cpu_multi));
         return 0;
 }
 #ifndef FPU_8087
@@ -779,7 +779,7 @@ static int opFLDCW_a32(uint32_t fetchdat)
         if (cpu_state.abrt) return 1;
         cpu_state.npxc = tempw;
         codegen_set_rounding_mode((cpu_state.npxc >> 10) & 3);
-        CLOCK_CYCLES(x87_timings.fldcw);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fldcw) : (x87_timings.fldcw * cpu_multi));
         return 0;
 }
 #endif
@@ -823,7 +823,7 @@ static int FSTENV()
                 writememl(easeg,cpu_state.eaaddr+24,x87_op_seg);
                 break;
         }
-        CLOCK_CYCLES(x87_timings.fstenv);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fstenv) : (x87_timings.fstenv * cpu_multi));
         return cpu_state.abrt;
 }
 
@@ -852,7 +852,7 @@ static int opFSTCW_a16(uint32_t fetchdat)
         fetch_ea_16(fetchdat);
         SEG_CHECK_WRITE(cpu_state.ea_seg);
         seteaw(cpu_state.npxc);
-        CLOCK_CYCLES(x87_timings.fstcw_sw);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fstcw_sw) : (x87_timings.fstcw_sw * cpu_multi));
         return cpu_state.abrt;
 }
 #ifndef FPU_8087
@@ -862,7 +862,7 @@ static int opFSTCW_a32(uint32_t fetchdat)
         fetch_ea_32(fetchdat);
         SEG_CHECK_WRITE(cpu_state.ea_seg);
         seteaw(cpu_state.npxc);
-        CLOCK_CYCLES(x87_timings.fstcw_sw);
+        CLOCK_CYCLES((fpu_type >= FPU_487SX) ? (x87_timings.fstcw_sw) : (x87_timings.fstcw_sw * cpu_multi));
         return cpu_state.abrt;
 }
 #endif


### PR DESCRIPTION
This is done by making it so that if the FPU is not at least a 487SX, the clock cycles are multiplied by the CPU multiplier.