### PR TITLE
PostScript printer: actually save .ps files if GhostScript is absent

### DIFF
--- a/src/printer/prt_ps.c
+++ b/src/printer/prt_ps.c
@@ -140,7 +140,7 @@ convert_to_pdf(ps_t *dev)
 
     output_fn[0] = 0;
     wcscat(output_fn, input_fn);
-    wcscpy(output_fn + wcslen(output_fn) - 4, L".pdf");
+    wcscpy(output_fn + wcslen(output_fn) - 3, L".pdf");
 
     gsargv[0] = L"";
     gsargv[1] = L"-dNOPAUSE";
@@ -201,7 +201,7 @@ write_buffer(ps_t *dev, bool newline)
     }
 
     if (dev->filename[0] == 0) {
-	plat_tempfile(dev->filename, NULL, L".tmp");
+	plat_tempfile(dev->filename, NULL, L".ps");
     }
 
     path[0] = 0;


### PR DESCRIPTION
The message box and documentation say .ps files are saved if GhostScript is absent, but the current code only leaves the temporary .tmp files behind. Fix that.