### PR TITLE
ALi M1429 rewrite

### DIFF
--- a/src/chipset/ali1429.c
+++ b/src/chipset/ali1429.c
@@ -84,6 +84,7 @@ mem_set_mem_state_both(base, 0x8000, disabled_shadow);
 
 }
 
+flushmmucache();
 }
 
 static void

--- a/src/chipset/ali1429.c
+++ b/src/chipset/ali1429.c
@@ -37,7 +37,6 @@
 #include <86box/chipset.h>
 
 #define disabled_shadow (MEM_READ_EXTANY | MEM_WRITE_EXTANY)
-#define ENABLE_ALI1429_LOG 1
 
 #ifdef ENABLE_ALI1429_LOG
 int ali1429_do_log = ENABLE_ALI1429_LOG;
@@ -99,9 +98,12 @@ ali1429_write(uint16_t addr, uint8_t val, void *priv)
     
 	case 0x23:
 
-        if (!(dev->index == 0x03)) /* Don't log register unlock patterns */
+        /* Don't log register unlock patterns */
+        if(dev->index != 0x03)
+        {
         ali1429_log("M1429: dev->regs[%02x] = %02x\n", dev->index, val);
-
+        }
+        
 		dev->regs[dev->index] = val;
 
         /* Unlock/Lock Registers */

--- a/src/chipset/ali1429.c
+++ b/src/chipset/ali1429.c
@@ -6,103 +6,141 @@
  *
  *		This file is part of the 86Box distribution.
  *
- *		Implementation of the ALi M-1429/1431 chipset.
+ *		Implementation of the ALi M1429 chipset.
  *
+ *      Note: This chipset has no datasheet, everything were done via
+ *      reverse engineering the BIOS of various machines using it.
  *
+ *      Authors: Tiseno100
  *
- * Authors:	Sarah Walker, <tommowalker@tommowalker.co.uk>
- *		Miran Grca, <mgrca8@gmail.com>
+ *		Copyright 2020 Tiseno100
  *
- *		Copyright 2008-2019 Sarah Walker.
- *		Copyright 2016-2019 Miran Grca.
  */
-#include <stdio.h>
+
+#include <stdarg.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <wchar.h>
+#define HAVE_STDARG_H
 #include <86box/86box.h>
 #include "cpu.h"
 #include <86box/timer.h>
 #include <86box/io.h>
-#include <86box/mem.h>
 #include <86box/device.h>
 #include <86box/keyboard.h>
+#include <86box/mem.h>
 #include <86box/fdd.h>
 #include <86box/fdc.h>
-#include <86box/hdc.h>
-#include <86box/hdc_ide.h>
-#include <86box/timer.h>
 #include <86box/port_92.h>
 #include <86box/chipset.h>
+
+#define disabled_shadow (MEM_READ_EXTANY | MEM_WRITE_EXTANY)
+#define ENABLE_ALI1429_LOG 1
+
+#ifdef ENABLE_ALI1429_LOG
+int ali1429_do_log = ENABLE_ALI1429_LOG;
+static void
+ali1429_log(const char *fmt, ...)
+{
+    va_list ap;
+
+    if (ali1429_do_log) {
+	va_start(ap, fmt);
+	pclog_ex(fmt, ap);
+	va_end(ap);
+    }
+}
+#else
+#define ali1429_log(fmt, ...)
+#endif
 
 
 typedef struct
 {
-    uint8_t cur_reg,
-	    regs[256];
+    uint8_t	index, cfg_locked,
+	regs[256];
 } ali1429_t;
 
-
-static void
-ali1429_recalc(ali1429_t *dev)
+static void ali1429_shadow_recalc(ali1429_t *dev)
 {
-    uint32_t base;
-    uint32_t i, shflags = 0;
 
-    shadowbios = 0;
-    shadowbios_write = 0;
+uint32_t base, i, can_write, can_read;
 
-    for (i = 0; i < 8; i++) {
-	base = 0xc0000 + (i << 15);
+shadowbios = (dev->regs[0x13] & 0x40) && (dev->regs[0x14] & 0x01);
+shadowbios_write = (dev->regs[0x13] & 0x40) && (dev->regs[0x14] & 0x02);
 
-	if (dev->regs[0x13] & (1 << i)) {
-		shadowbios |= (base >= 0xe8000) && !!(dev->regs[0x14] & 0x01);
-		shadowbios_write |= (base >= 0xe8000) && !!(dev->regs[0x14] & 0x02);
-		shflags = (dev->regs[0x14] & 0x01) ? MEM_READ_INTERNAL : MEM_READ_EXTANY;
-		shflags |= !(dev->regs[0x14] & 0x02) ? MEM_WRITE_EXTANY : MEM_WRITE_INTERNAL;
-		mem_set_mem_state(base, 0x8000, shflags);
-	} else
-		mem_set_mem_state(base, 0x8000, MEM_READ_EXTANY | MEM_WRITE_EXTANY);
-    }
+can_write = (dev->regs[0x14] & 0x02) ? MEM_WRITE_INTERNAL : MEM_WRITE_EXTANY;
+can_read = (dev->regs[0x14] & 0x01) ? MEM_READ_INTERNAL : MEM_READ_EXTANY;
 
-    flushmmucache();
+for(i = 0; i < 8; i++)
+{
+base = 0xc0000 + (i << 15);
+
+if(dev->regs[0x13] & (1 << i))
+mem_set_mem_state_both(base, 0x8000, can_read | can_write);
+else
+mem_set_mem_state_both(base, 0x8000, disabled_shadow);
+
 }
 
+}
 
 static void
-ali1429_write(uint16_t port, uint8_t val, void *priv)
+ali1429_write(uint16_t addr, uint8_t val, void *priv)
 {
     ali1429_t *dev = (ali1429_t *) priv;
 
-    if (port & 1) {
-	dev->regs[dev->cur_reg] = val;
+    switch (addr) {
+	case 0x22:
+		dev->index = val;
+		break;
+    
+	case 0x23:
 
-	switch (dev->cur_reg) {
-		case 0x13:
-			ali1429_recalc(dev);
-			break;
-		case 0x14:
-			ali1429_recalc(dev);
-			break;
-	}
-    } else
-	dev->cur_reg = val;
+        if (!(dev->index == 0x03)) /* Don't log register unlock patterns */
+        ali1429_log("M1429: dev->regs[%02x] = %02x\n", dev->index, val);
+
+		dev->regs[dev->index] = val;
+
+        /* Unlock/Lock Registers */
+        dev->cfg_locked = !(dev->regs[0x03] && 0xc5);
+
+        if(dev->cfg_locked == 0)
+        {
+        switch(dev->index){
+            /* Shadow RAM */
+            case 0x13:
+            case 0x14:
+            ali1429_shadow_recalc(dev);
+            break;
+
+            /* Cache */
+            case 0x18:
+            cpu_cache_ext_enabled = (val & 0x80);
+            break;
+        }
+        }
+
+		break;
+    }
 }
 
 
 static uint8_t
-ali1429_read(uint16_t port, void *priv)
+ali1429_read(uint16_t addr, void *priv)
 {
     uint8_t ret = 0xff;
     ali1429_t *dev = (ali1429_t *) priv;
 
-    if (!(port & 1)) 
-	ret = dev->cur_reg;
-    else if (((dev->cur_reg >= 0xc0) || (dev->cur_reg == 0x20)) && cpu_iscyrix)
-	ret = 0xff; /*Don't conflict with Cyrix config registers*/
-    else
-	ret = dev->regs[dev->cur_reg];
+    switch (addr) {
+	case 0x23:
+        /* Do not conflict with Cyrix configuration registers */
+        if(!(((dev->index >= 0xc0) || (dev->index == 0x20)) && cpu_iscyrix))
+        ret = dev->regs[dev->index];
+        break;
+    }
 
     return ret;
 }
@@ -123,21 +161,28 @@ ali1429_init(const device_t *info)
     ali1429_t *dev = (ali1429_t *) malloc(sizeof(ali1429_t));
     memset(dev, 0, sizeof(ali1429_t));
 
-    memset(dev->regs, 0xff, 256);
-    dev->regs[0x13] = dev->regs[0x14] = 0x00;
-
-    io_sethandler(0x0022, 0x0002, ali1429_read, NULL, NULL, ali1429_write, NULL, NULL, dev);
-
-    ali1429_recalc(dev);
+    /*
+    M1429 Ports:
+    22h Index Port
+    23h Data Port
+    */
+    io_sethandler(0x022, 0x0001, ali1429_read, NULL, NULL, ali1429_write, NULL, NULL, dev);
+    io_sethandler(0x023, 0x0001, ali1429_read, NULL, NULL, ali1429_write, NULL, NULL, dev);
+    
+    dev->cfg_locked = 1;
 
     device_add(&port_92_device);
+
+    dev->regs[0x13] = 0x00;
+    dev->regs[0x14] = 0x00;
+    ali1429_shadow_recalc(dev);
 
     return dev;
 }
 
 
 const device_t ali1429_device = {
-    "ALi-M1429",
+    "ALi M1429",
     0,
     0,
     ali1429_init, ali1429_close, NULL,

--- a/src/machine/m_at_286_386sx.c
+++ b/src/machine/m_at_286_386sx.c
@@ -152,7 +152,7 @@ machine_at_quadt286_init(const machine_t *model)
     if (bios_only || !ret)
 	return ret;
 
-    machine_at_common_ide_init(model);
+    machine_at_common_init(model);
     device_add(&keyboard_at_device);
     device_add(&fdc_at_device);
     device_add(&headland_gc10x_device);

--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -353,7 +353,7 @@ machine_at_403tg_init(const machine_t *model)
 }
 
 int
-machine_at_pc330_6571_init(const machine_t *model)	// doesn't like every CPU other than the Intel OverDrive, hangs without a PS/2 mouse
+machine_at_pc330_6571_init(const machine_t *model)	// doesn't like every CPU other than the iDX4 and the Intel OverDrive, hangs without a PS/2 mouse
 {
     int ret;
 
@@ -363,10 +363,11 @@ machine_at_pc330_6571_init(const machine_t *model)	// doesn't like every CPU oth
     if (bios_only || !ret)
 	return ret;
 
-    machine_at_common_ide_init(model);
+    machine_at_common_init(model);
 
     device_add(&opti802g_device);
     device_add(&keyboard_ps2_device);
+	device_add(&ide_opti611_vlb_device);
     device_add(&fdc37c665_device);
     device_add(&intel_flash_bxt_device);
 
@@ -702,6 +703,33 @@ machine_at_486vipio2_init(const machine_t *model)
     return ret;
 }
 #endif
+
+int
+machine_at_abpb4_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear(L"roms/machines/abpb4/486-AB-PB4.BIN",
+			   0x000e0000, 131072, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_at_common_init(model);
+    
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x00, PCI_CARD_SPECIAL, 0, 0, 0, 0);
+    pci_register_slot(0x03, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x04, PCI_CARD_NORMAL, 2, 3, 4, 1);
+    pci_register_slot(0x05, PCI_CARD_NORMAL, 3, 4, 1, 2);
+
+    device_add(&ali1489_device);
+    device_add(&ide_pci_2ch_device);
+    device_add(&w83787f_device);
+    device_add(&keyboard_at_device);
+
+    return ret;
+}
 
 #if defined(DEV_BRANCH) && defined(USE_STPC)
 int

--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -342,7 +342,7 @@ machine_at_403tg_init(const machine_t *model)
     if (bios_only || !ret)
 	return ret;
 
-    machine_at_common_ide_init(model);
+    machine_at_common_init(model);
 
     device_add(&opti895_device);
 
@@ -353,7 +353,7 @@ machine_at_403tg_init(const machine_t *model)
 }
 
 int
-machine_at_pc330_6571_init(const machine_t *model)	// doesn't like every CPU other than the iDX4 and the Intel OverDrive, hangs without a PS/2 mouse
+machine_at_pc330_6571_init(const machine_t *model)	// doesn't like every CPU other than the Intel OverDrive, hangs without a PS/2 mouse
 {
     int ret;
 
@@ -363,12 +363,11 @@ machine_at_pc330_6571_init(const machine_t *model)	// doesn't like every CPU oth
     if (bios_only || !ret)
 	return ret;
 
-    machine_at_common_init(model);
+    machine_at_common_ide_init(model);
 
     device_add(&opti802g_device);
     device_add(&keyboard_ps2_device);
     device_add(&fdc37c665_device);
-    device_add(&ide_opti611_vlb_device);
     device_add(&intel_flash_bxt_device);
 
     return ret;
@@ -703,6 +702,33 @@ machine_at_486vipio2_init(const machine_t *model)
     return ret;
 }
 #endif
+
+int
+machine_at_abpb4_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear(L"roms/machines/abpb4/486-AB-PB4.BIN",
+			   0x000e0000, 131072, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_at_common_init(model);
+    
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x00, PCI_CARD_SPECIAL, 0, 0, 0, 0);
+    pci_register_slot(0x03, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x04, PCI_CARD_NORMAL, 2, 3, 4, 1);
+    pci_register_slot(0x05, PCI_CARD_NORMAL, 3, 4, 1, 2);
+
+    device_add(&ali1489_device);
+    device_add(&ide_pci_2ch_device);
+    device_add(&w83787f_device);
+    device_add(&keyboard_at_device);
+
+    return ret;
+}
 
 #if defined(DEV_BRANCH) && defined(USE_STPC)
 int

--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -703,33 +703,6 @@ machine_at_486vipio2_init(const machine_t *model)
 }
 #endif
 
-int
-machine_at_abpb4_init(const machine_t *model)
-{
-    int ret;
-
-    ret = bios_load_linear(L"roms/machines/abpb4/486-AB-PB4.BIN",
-			   0x000e0000, 131072, 0);
-
-    if (bios_only || !ret)
-	return ret;
-
-    machine_at_common_init(model);
-    
-    pci_init(PCI_CONFIG_TYPE_1);
-    pci_register_slot(0x00, PCI_CARD_SPECIAL, 0, 0, 0, 0);
-    pci_register_slot(0x03, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x04, PCI_CARD_NORMAL, 2, 3, 4, 1);
-    pci_register_slot(0x05, PCI_CARD_NORMAL, 3, 4, 1, 2);
-
-    device_add(&ali1489_device);
-    device_add(&ide_pci_2ch_device);
-    device_add(&w83787f_device);
-    device_add(&keyboard_at_device);
-
-    return ret;
-}
-
 #if defined(DEV_BRANCH) && defined(USE_STPC)
 int
 machine_at_itoxstar_init(const machine_t *model)

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -149,7 +149,7 @@ const machine_t machines[] = {
     { "[SCAT] Samsung Deskmaster 286",		"deskmaster286",	MACHINE_TYPE_286,		{{"",      cpus_286},         {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT,										512,16384, 128, 127,	machine_at_deskmaster286_init, NULL			},
     { "[GC103] Quadtel 286 clone",		"quadt286",		MACHINE_TYPE_286,		{{"",      cpus_286},         {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT,										512,16384, 128, 127,	     machine_at_quadt286_init, NULL			},
     { "[GC103] Trigem 286M",			"tg286m",		MACHINE_TYPE_286,		{{"",      cpus_286},         {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT | MACHINE_HDC,							  	512, 8192, 128, 127,	       machine_at_tg286m_init, NULL			},
-    { "[ISA] MR 286 clone",			"mr286",		MACHINE_TYPE_286,		{{"",      cpus_286},         {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT,										512,16384, 128, 127,	        machine_at_mr286_init, NULL			},
+    { "[ISA] MR 286 clone",			"mr286",		MACHINE_TYPE_286,		{{"",      cpus_286},         {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT | MACHINE_HDC,										512,16384, 128, 127,	        machine_at_mr286_init, NULL			},
 #if defined(DEV_BRANCH) && defined(USE_SIEMENS)
     { "[ISA] Siemens PCD-2L",			"siemens",		MACHINE_TYPE_286,		{{"",      cpus_286},         {"",    NULL},         {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT,										256,15872, 128,  63,	      machine_at_siemens_init, NULL			},
 #endif
@@ -170,8 +170,8 @@ const machine_t machines[] = {
 #endif
     { "[WD76C10] Amstrad MegaPC",		"megapc",		MACHINE_TYPE_386SX,		{{"Intel", cpus_i386SX},      {"AMD", cpus_Am386SX}, {"Cyrix", cpus_486SLC}, {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_VIDEO | MACHINE_HDC,				  1,   32,   1, 127,	      machine_at_wd76c10_init, NULL			},
     { "[SCAMP] Commodore SL386SX",		"cbm_sl386sx25",	MACHINE_TYPE_386SX,		{{"Intel", cpus_i386SX},      {"AMD", cpus_Am386SX}, {"Cyrix", cpus_486SLC}, {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_VIDEO | MACHINE_HDC,			       1024, 8192, 512, 127,machine_at_commodore_sl386sx_init, at_commodore_sl386sx_get_device	},  
-    { "[NEAT] DTK 386SX clone",			"dtk386",		MACHINE_TYPE_386SX,		{{"Intel", cpus_i386SX},      {"AMD", cpus_Am386SX}, {"Cyrix", cpus_486SLC}, {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT | MACHINE_HDC,								512, 8192, 128, 127,		 machine_at_neat_init, NULL			},
-    { "[NEAT] Goldstar 386",			"goldstar386",		MACHINE_TYPE_386SX,		{{"Intel", cpus_i386SX},      {"AMD", cpus_Am386SX}, {"Cyrix", cpus_486SLC}, {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT | MACHINE_HDC,								512, 8192, 128, 127,	  machine_at_goldstar386_init, NULL			},
+    { "[NEAT] DTK 386SX clone",			"dtk386",		MACHINE_TYPE_386SX,		{{"Intel", cpus_i386SX},      {"AMD", cpus_Am386SX}, {"Cyrix", cpus_486SLC}, {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT,								512, 8192, 128, 127,		 machine_at_neat_init, NULL			},
+    { "[NEAT] Goldstar 386",			"goldstar386",		MACHINE_TYPE_386SX,		{{"Intel", cpus_i386SX},      {"AMD", cpus_Am386SX}, {"Cyrix", cpus_486SLC}, {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT,								512, 8192, 128, 127,	  machine_at_goldstar386_init, NULL			},
     { "[SCAT] KMX-C-02",			"kmxc02",		MACHINE_TYPE_386SX,		{{"Intel", cpus_i386SX},      {"AMD", cpus_Am386SX}, {"Cyrix", cpus_486SLC}, {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT,										512,16384, 512, 127,	       machine_at_kmxc02_init, NULL			},
 
     { "[Intel 82335] Shuttle 386SX",		"shuttle386sx",		MACHINE_TYPE_386SX,		{{"Intel", cpus_i386SX},      {"AMD", cpus_Am386SX}, {"Cyrix", cpus_486SLC}, {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT,										512, 8192, 128, 127,	 machine_at_shuttle386sx_init, NULL			},
@@ -182,10 +182,10 @@ const machine_t machines[] = {
     { "[MCA] IBM PS/2 model 55SX",		"ibmps2_m55sx",		MACHINE_TYPE_386SX,		{{"Intel", cpus_i386SX},      {"AMD", cpus_Am386SX}, {"Cyrix", cpus_486SLC}, {"IBM",cpus_IBM486SLC},{"",    NULL}}, MACHINE_MCA | MACHINE_AT | MACHINE_PS2 | MACHINE_VIDEO,						  1,    8,   1,  63,	  machine_ps2_model_55sx_init, NULL			},
 
     /* 386DX machines */
-    { "[ACC 2168] AMI 386DX clone",		"acc386",		MACHINE_TYPE_386DX,		{{"Intel", cpus_i386DX},      {"AMD", cpus_Am386DX}, {"Cyrix", cpus_486DLC}, {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT | MACHINE_HDC,							       512, 16384, 128, 127,	       machine_at_acc386_init, NULL			},
+    { "[ACC 2168] AMI 386DX clone",		"acc386",		MACHINE_TYPE_386DX,		{{"Intel", cpus_i386DX},      {"AMD", cpus_Am386DX}, {"Cyrix", cpus_486DLC}, {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT,							       512, 16384, 128, 127,	       machine_at_acc386_init, NULL			},
     { "[SiS 310] ASUS ISA-386C",		"asus386",		MACHINE_TYPE_386DX,		{{"Intel", cpus_i386DX},      {"AMD", cpus_Am386DX}, {"Cyrix", cpus_486DLC}, {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT | MACHINE_HDC,							       512, 16384, 128, 127,	      machine_at_asus386_init, NULL			},
     { "[ISA] Compaq Portable III (386)",	"portableiii386",       MACHINE_TYPE_386DX,		{{"Intel", cpus_i386DX},      {"AMD", cpus_Am386DX}, {"Cyrix", cpus_486DLC}, {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT | MACHINE_HDC | MACHINE_VIDEO,			  			  1,   14,   1, 127,   machine_at_portableiii386_init, at_cpqiii_get_device	},
-    { "[ISA] Micronics 386 clone",		"micronics386",		MACHINE_TYPE_386DX,		{{"Intel", cpus_i386DX},      {"AMD", cpus_Am386DX}, {"Cyrix", cpus_486DLC}, {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT | MACHINE_HDC,								512, 8192, 128, 127,	 machine_at_micronics386_init, NULL			},
+    { "[ISA] Micronics 386 clone",		"micronics386",		MACHINE_TYPE_386DX,		{{"Intel", cpus_i386DX},      {"AMD", cpus_Am386DX}, {"Cyrix", cpus_486DLC}, {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT,								512, 8192, 128, 127,	 machine_at_micronics386_init, NULL			},
     { "[C&T 386] ECS 386/32",			"ecs386",		MACHINE_TYPE_386DX,		{{"Intel", cpus_i386DX},      {"AMD", cpus_Am386DX}, {"Cyrix", cpus_486DLC}, {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT,										  1,   16,   1, 127,	       machine_at_ecs386_init, NULL			},		
 
     /* 386DX machines which utilize the VLB bus */
@@ -201,7 +201,7 @@ const machine_t machines[] = {
     { "[ACC 2168] Packard Bell PB410A",		"pb410a",		MACHINE_TYPE_486,		{{"Intel", cpus_i486},        {"AMD", cpus_Am486},   {"Cyrix", cpus_Cx486},  {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC | MACHINE_VIDEO,			  	  4,   36,   1, 127,	       machine_at_pb410a_init, NULL			},
 
     /* 486 machines */
-    { "[OPTi 283] RYC Leopard LX",		"rycleopardlx",		MACHINE_TYPE_486,		{{"IBM", cpus_IBM486SLC},     {"",      NULL},       {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT | MACHINE_HDC,								  1,   16,   1, 127,     machine_at_rycleopardlx_init, NULL			},
+    { "[OPTi 283] RYC Leopard LX",		"rycleopardlx",		MACHINE_TYPE_486,		{{"IBM", cpus_IBM486SLC},     {"",      NULL},       {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_AT,								  1,   16,   1, 127,     machine_at_rycleopardlx_init, NULL			},
     { "[OPTi 495] Award 486 clone",		"award486",		MACHINE_TYPE_486,		{{"Intel", cpus_i486S1},      {"AMD", cpus_Am486S1}, {"Cyrix", cpus_Cx486S1},{"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_VLB | MACHINE_AT | MACHINE_HDC,						  1,   32,   1, 127,	      machine_at_opti495_init, NULL			},
     { "[OPTi 495] MR 486 clone",		"mr486",		MACHINE_TYPE_486,		{{"Intel", cpus_i486},        {"AMD", cpus_Am486},   {"Cyrix", cpus_Cx486},  {"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_VLB | MACHINE_AT | MACHINE_HDC,						  1,   32,   1, 127,	   machine_at_opti495_mr_init, NULL			},
     { "[OPTi 495] Dataexpert SX495 (486)",	"ami486",		MACHINE_TYPE_486,		{{"Intel", cpus_i486S1},      {"AMD", cpus_Am486S1}, {"Cyrix", cpus_Cx486S1},{"",      NULL},     {"",      NULL}}, MACHINE_ISA | MACHINE_VLB | MACHINE_AT | MACHINE_HDC,						  1,   32,   1, 127,	  machine_at_opti495_ami_init, NULL			},
@@ -236,6 +236,9 @@ const machine_t machines[] = {
 #if defined(DEV_BRANCH) && defined(NO_SIO)
     { "[VIA VT82C496G] FIC VIP-IO2",		"486vipio2",		MACHINE_TYPE_486,		{{"Intel", cpus_i486},        {"AMD", cpus_Am486},   {"Cyrix", cpus_Cx486},  {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_VLB | MACHINE_AT | MACHINE_HDC,					  1,  128,   1, 255,		 machine_at_486vipio2_init, NULL			},
 #endif
+
+    { "[ALi M1489] ABit AB-PB4",		"abpb4",		MACHINE_TYPE_486,		{{"Intel", cpus_i486},        {"AMD", cpus_Am486},   {"Cyrix", cpus_Cx486},  {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_HDC,					  1,  64,   1, 255,		 machine_at_abpb4_init, NULL			},
+
 #if defined(DEV_BRANCH) && defined(USE_STPC)
     { "[STPC Client] ITOX STAR",		"itoxstar",		MACHINE_TYPE_486,		{{"ST", cpus_STPC6675},       {"",      NULL},       {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  128,   8, 255,	     machine_at_itoxstar_init, NULL			},
     { "[STPC Consumer-II] Acrosser AR-B1479",	"arb1479",		MACHINE_TYPE_486,		{{"ST", cpus_STPC133},        {"",      NULL},       {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					 32,  160,   8, 255,	      machine_at_arb1479_init, NULL			},

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -237,8 +237,6 @@ const machine_t machines[] = {
     { "[VIA VT82C496G] FIC VIP-IO2",		"486vipio2",		MACHINE_TYPE_486,		{{"Intel", cpus_i486},        {"AMD", cpus_Am486},   {"Cyrix", cpus_Cx486},  {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_VLB | MACHINE_AT | MACHINE_HDC,					  1,  128,   1, 255,		 machine_at_486vipio2_init, NULL			},
 #endif
 
-    { "[ALi M1489] ABit AB-PB4",		"abpb4",		MACHINE_TYPE_486,		{{"Intel", cpus_i486},        {"AMD", cpus_Am486},   {"Cyrix", cpus_Cx486},  {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_HDC,					  1,  64,   1, 255,		 machine_at_abpb4_init, NULL			},
-
 #if defined(DEV_BRANCH) && defined(USE_STPC)
     { "[STPC Client] ITOX STAR",		"itoxstar",		MACHINE_TYPE_486,		{{"ST", cpus_STPC6675},       {"",      NULL},       {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					  8,  128,   8, 255,	     machine_at_itoxstar_init, NULL			},
     { "[STPC Consumer-II] Acrosser AR-B1479",	"arb1479",		MACHINE_TYPE_486,		{{"ST", cpus_STPC133},        {"",      NULL},       {"",      NULL},        {"",      NULL},     {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,					 32,  160,   8, 255,	      machine_at_arb1479_init, NULL			},


### PR DESCRIPTION
Fully rewrote the M1429 code to adapt the modern coding standards of the emulator.