### PR TITLE
Freeway FW-6400GX fixes

### DIFF
--- a/src/device/hwm_lm75.c
+++ b/src/device/hwm_lm75.c
@@ -64,7 +64,7 @@ lm75_remap(lm75_t *dev, uint8_t addr)
 {
     lm75_log("LM75: remapping to SMBus %02Xh\n", addr);
 
-    smbus_removehandler(dev->smbus_addr, 1,
+    if (dev->smbus_addr < 0x80) smbus_removehandler(dev->smbus_addr, 1,
     			lm75_smbus_read_byte, lm75_smbus_read_byte_cmd, lm75_smbus_read_word_cmd, NULL,
     			lm75_smbus_write_byte, lm75_smbus_write_byte_cmd, lm75_smbus_write_word_cmd, NULL,
     			dev);

--- a/src/device/smbus.c
+++ b/src/device/smbus.c
@@ -115,6 +115,9 @@ smbus_sethandler(uint8_t base, int size,
     int c;
     smbus_t *p, *q = NULL;
 
+    if ((base + size) >= NADDRS)
+    	return;
+
     for (c = 0; c < size; c++) {
     	p = smbus_last[base + c];
     	q = (smbus_t *) malloc(sizeof(smbus_t));
@@ -158,13 +161,17 @@ smbus_removehandler(uint8_t base, int size,
     		    void *priv)
 {
     int c;
-    smbus_t *p;
+    smbus_t *p, *q;
+
+    if ((base + size) >= NADDRS)
+    	return;
 
     for (c = 0; c < size; c++) {
     	p = smbus[base + c];
     	if (!p)
     		continue;
     	while(p) {
+    		q = p->next;
     		if ((p->read_byte == read_byte) && (p->read_byte_cmd == read_byte_cmd) &&
     		    (p->read_word_cmd == read_word_cmd) && (p->read_block_cmd == read_block_cmd) &&
     		    (p->write_byte == write_byte) && (p->write_byte_cmd == write_byte_cmd) &&
@@ -182,7 +189,7 @@ smbus_removehandler(uint8_t base, int size,
     			p = NULL;
     			break;
     		}
-    		p = p->next;
+    		p = q;
     	}
     }
 }

--- a/src/machine/m_at_slot2.c
+++ b/src/machine/m_at_slot2.c
@@ -181,7 +181,7 @@ machine_at_fw6400gx_init(const machine_t *model)
     device_add(&piix4e_device);
     device_add(&keyboard_ps2_ami_pci_device);
     device_add(&pc87309_device);
-    device_add(&intel_flash_bxt_device);
+    device_add(&sst_flash_29ee020_device);
     spd_register(SPD_TYPE_SDRAM, 0xF, 512);
 
     hwm_values_t machine_hwm = {

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -364,7 +364,7 @@ const machine_t machines[] = {
     /* 440GX */
     { "[i440GX] Gigabyte GA-6GXU",		"6gxu",			MACHINE_TYPE_SLOT2,		{{"Intel", cpus_Xeon},        {"",      NULL},	     {"",      NULL},	     {"",      NULL},	  {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		 16, 2048,  16, 511,	         machine_at_6gxu_init, NULL			},
     { "[i440GX] SuperMicro Super S2DGE",	"s2dge",		MACHINE_TYPE_SLOT2,		{{"Intel", cpus_Xeon},        {"",      NULL},	     {"",      NULL},	     {"",      NULL},	  {"",      NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 		 16, 2048,  16, 511,	        machine_at_s2dge_init, NULL			},
-    { "[i440GX] Freeway FW-6400GX",		"fw6400gx",		MACHINE_TYPE_SLOT2,		{{"Intel/Slot1", cpus_PentiumII},{"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"Intel/Slot2", cpus_Xeon},{"", NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 16, 2048,  16, 511,	     machine_at_fw6400gx_init, NULL			},
+    { "[i440GX] Freeway FW-6400GX",		"fw6400gx",		MACHINE_TYPE_SLOT2,		{{"Intel/Slot1", cpus_PentiumII},{"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"Intel/Slot2", cpus_Xeon},{"", NULL}}, MACHINE_PCI | MACHINE_ISA | MACHINE_AT | MACHINE_PS2 | MACHINE_HDC,			 16, 2032,  16, 511,	     machine_at_fw6400gx_init, NULL			},
 
     /* PGA370 machines */
     /* 440LX */


### PR DESCRIPTION
Change flash type to SST (real board has Winbond of some description), limit RAM to 2032 MB (BIOS overflow bug with the full 2048 MB), fix a SMBus-related reset crash that I've reproduced with this board.