### PR TITLE
Reset the SDL texture to avoid the renderer hanging.

### DIFF
--- a/src/include/86box/win_sdl.h
+++ b/src/include/86box/win_sdl.h
@@ -58,6 +58,7 @@ extern int	sdl_inith_fs(HWND h);
 extern int	sdl_pause(void);
 extern void	sdl_resize(int x, int y);
 extern void	sdl_enable(int enable);
+extern void	sdl_reinit_texture();
 
 
 #endif	/*WIN_SDL_H*/

--- a/src/win/win_sdl.c
+++ b/src/win/win_sdl.c
@@ -181,6 +181,8 @@ sdl_stretch(int *w, int *h, int *x, int *y)
 		*y = (int) dy;
 		break;
     }
+
+    sdl_reinit_texture();
 }
 
 
@@ -489,6 +491,18 @@ sdl_inith_fs(HWND h)
 }
 
 
+void
+sdl_reinit_texture()
+{
+    if (sdl_render == NULL)
+        return;
+
+    SDL_DestroyTexture(sdl_tex);
+    sdl_tex = SDL_CreateTexture(sdl_render, SDL_PIXELFORMAT_ARGB8888,
+				SDL_TEXTUREACCESS_STREAMING, 2048, 2048);
+}
+
+
 int
 sdl_pause(void)
 {
@@ -514,6 +528,8 @@ sdl_resize(int x, int y)
 
     cur_w = x;
     cur_h = y;
+
+    sdl_reinit_texture();
 }
 
 


### PR DESCRIPTION
Sometimes when changing resolutions and resizing the SDL window or stretching it, the SDL renderer would hang with a black screen until the program is restarted or another renderer (e.g. SDL Software or SDL Hardware) is chosen from the menu. This change recreates the SDL texture after the window is resized or stretched, which negates the black screen renderer hang.

I have experimented with lots of different potential solutions but only this approach ever worked reliably and without any side effects and glitches. Any better approach is most certainly welcome (but is most likely outside my knowledge and skill level with SDL2), but this might serve as a good stop gap measure until a better algorithm is coded.

Performance loss from recreating the texture should hopefully be negligible, as this only happens once on a resize/stretch (most commonly this would happen during the resolution change, and tends to happen a few times in a row on many PC BIOS initializations).

Tested in both windowed and fullscreen modes with both SDL Software and SDL Hardware.