### PR TITLE
PCI bridge support

### DIFF
--- a/src/chipset/intel_4x0.c
+++ b/src/chipset/intel_4x0.c
@@ -55,7 +55,7 @@ typedef struct
     uint8_t	pm2_cntrl,
 		smram_locked, max_drb,
 		drb_unit, drb_default;
-    uint8_t	regs[2][256], regs_locked[2][256];
+    uint8_t	regs[256], regs_locked[256];
     int		type;
 } i4x0_t;
 
@@ -137,7 +137,7 @@ i4x0_smram_handler_phase0(i4x0_t *dev)
 static void
 i4x0_smram_handler_phase1(i4x0_t *dev)
 {
-    uint8_t *regs = (uint8_t *) dev->regs[0];
+    uint8_t *regs = (uint8_t *) dev->regs;
     uint32_t tom = (mem_size << 10);
 
     uint32_t s, base[2] = { 0x000a0000, 0x00020000 };
@@ -273,8 +273,8 @@ static void
 i4x0_write(int func, int addr, uint8_t val, void *priv)
 {
     i4x0_t *dev = (i4x0_t *) priv;
-    uint8_t *regs = (uint8_t *) dev->regs[func];
-    uint8_t *regs_l = (uint8_t *) dev->regs_locked[func];
+    uint8_t *regs = (uint8_t *) dev->regs;
+    uint8_t *regs_l = (uint8_t *) dev->regs_locked;
     int i;
 
     if (func)
@@ -1256,7 +1256,7 @@ i4x0_read(int func, int addr, void *priv)
 {
     i4x0_t *dev = (i4x0_t *) priv;
     uint8_t ret = 0xff;
-    uint8_t *regs = (uint8_t *) dev->regs[func];
+    uint8_t *regs = (uint8_t *) dev->regs;
 
     if (func)
 	  ret = 0xff;
@@ -1290,15 +1290,15 @@ i4x0_reset(void *priv)
 	i4x0_write(0, 0x60 + i, dev->drb_default, priv);
 
     if (dev->type >= INTEL_430FX) {
-	dev->regs[0][0x72] &= 0xef;	/* Forcibly unlock the SMRAM register. */
+	dev->regs[0x72] &= 0xef;	/* Forcibly unlock the SMRAM register. */
 	i4x0_write(0, 0x72, 0x02, priv);
     } else {
-	dev->regs[0][0x72] &= 0xf7;	/* Forcibly unlock the SMRAM register. */
+	dev->regs[0x72] &= 0xf7;	/* Forcibly unlock the SMRAM register. */
 	i4x0_write(0, 0x72, 0x00, priv);
     }
 
     if ((dev->type == INTEL_440LX) || (dev->type == INTEL_440BX) || (dev->type == INTEL_440ZX)) {
-	memset(dev->regs_locked[0], 0x00, 256 * sizeof(uint8_t));
+	memset(dev->regs_locked, 0x00, 256 * sizeof(uint8_t));
     }
 }
 
@@ -1322,7 +1322,7 @@ static void
 
     dev->type = info->local & 0xff;
 
-    regs = (uint8_t *) dev->regs[0];
+    regs = (uint8_t *) dev->regs;
 
     regs[0x00] = 0x86; regs[0x01] = 0x80; /*Intel*/
 

--- a/src/chipset/intel_4x0.c
+++ b/src/chipset/intel_4x0.c
@@ -24,8 +24,8 @@
 #include <86box/mem.h>
 #include <86box/io.h>
 #include <86box/rom.h>
-#include <86box/pci.h>
 #include <86box/device.h>
+#include <86box/pci.h>
 #include <86box/keyboard.h>
 #include <86box/chipset.h>
 #include <86box/spd.h>
@@ -52,7 +52,7 @@ enum
 
 typedef struct
 {
-    uint8_t	pm2_cntrl, max_func,
+    uint8_t	pm2_cntrl,
 		smram_locked, max_drb,
 		drb_unit, drb_default;
     uint8_t	regs[2][256], regs_locked[2][256];
@@ -277,7 +277,7 @@ i4x0_write(int func, int addr, uint8_t val, void *priv)
     uint8_t *regs_l = (uint8_t *) dev->regs_locked[func];
     int i;
 
-    if (func > dev->max_func)
+    if (func)
   	return;
 
     if ((addr >= 0x10) && (addr < 0x4f))
@@ -447,7 +447,7 @@ i4x0_write(int func, int addr, uint8_t val, void *priv)
 					regs[0x51] |= 0x10; /* Virtual PC 2007 BIOS requires a reserved bus speed bit to be set */
 				break;
 			case INTEL_440GX:
-            			regs[0x51] = (regs[0x50] & 0x88) | (val & 0x08);
+   				regs[0x51] = (regs[0x50] & 0x88) | (val & 0x08);
 				/*regs[0x51] = (regs[0x50] & 0x88) | (val & 0x77);*/
 				break;
 		}
@@ -1258,7 +1258,7 @@ i4x0_read(int func, int addr, void *priv)
     uint8_t ret = 0xff;
     uint8_t *regs = (uint8_t *) dev->regs[func];
 
-    if (func > dev->max_func)
+    if (func)
 	  ret = 0xff;
     else {
 	ret = regs[addr];
@@ -1298,8 +1298,7 @@ i4x0_reset(void *priv)
     }
 
     if ((dev->type == INTEL_440LX) || (dev->type == INTEL_440BX) || (dev->type == INTEL_440ZX)) {
-	for (i = 0; i <= dev->max_func; i++)
-		memset(dev->regs_locked[i], 0x00, 256 * sizeof(uint8_t));
+	memset(dev->regs_locked[0], 0x00, 256 * sizeof(uint8_t));
     }
 }
 
@@ -1492,8 +1491,6 @@ static void
 		dev->drb_default = 0x02;
 		break;
 	case INTEL_440LX:
-		dev->max_func = 1;
-
 		regs[0x02] = 0x80; regs[0x03] = 0x71;	/* 82443LX */
 		regs[0x06] = 0x90;
 		regs[0x10] = 0x08;
@@ -1517,8 +1514,6 @@ static void
 		dev->drb_default = 0x01;
 		break;
 	case INTEL_440EX:
-		dev->max_func = 1;
-
 		regs[0x02] = 0x80; regs[0x03] = 0x71;	/* 82443EX. Same Vendor ID as 440LX */
 		regs[0x06] = 0x90;
 		regs[0x10] = 0x08;
@@ -1543,7 +1538,6 @@ static void
 		break;
 	case INTEL_440BX: case INTEL_440ZX:
 		regs[0x7a] = (info->local >> 8) & 0xff;
-		dev->max_func = (regs[0x7a] & 0x02) ? 0 : 1;
 
 		regs[0x02] = (regs[0x7a] & 0x02) ? 0x92 : 0x90; regs[0x03] = 0x71;	/* 82443BX */
 		regs[0x06] = (regs[0x7a] & 0x02) ? 0x00 : 0x10;
@@ -1574,7 +1568,6 @@ static void
 		break;
 	case INTEL_440GX:
 		regs[0x7a] = (info->local >> 8) & 0xff;
-		dev->max_func = (regs[0x7a] & 0x02) ? 0 : 1;
 
 		regs[0x02] = (regs[0x7a] & 0x02) ? 0xa2 : 0xa0; regs[0x03] = 0x71;	/* 82443GX */
 		regs[0x06] = (regs[0x7a] & 0x02) ? 0x00 : 0x10;
@@ -1617,41 +1610,12 @@ static void
     i4x0_write(regs[0x5f], 0x5f, 0x00, dev);
     i4x0_write(regs[0x72], 0x72, 0x00, dev);
 
-    if (((dev->type == INTEL_440LX) || (dev->type == INTEL_440EX)) && (dev->max_func == 1)) {
-	regs = (uint8_t *) dev->regs[1];
-
-	regs[0x00] = 0x86; regs[0x01] = 0x80;	/* Intel */
-	regs[0x02] = 0x81; regs[0x03] = 0x71;	/* 82443LX */
-	regs[0x06] = 0xa0; regs[0x07] = 0x02;
-	regs[0x0a] = 0x04; regs[0x0b] = 0x06;
-	regs[0x0e] = 0x01;
-	regs[0x1c] = 0xf0;
-	regs[0x1e] = 0xa0; regs[0x1f] = 0x02;
-	regs[0x20] = 0xf0; regs[0x21] = 0xff;
-	regs[0x24] = 0xf0; regs[0x25] = 0xff;
-    }
-
-    if (((dev->type == INTEL_440BX) || (dev->type == INTEL_440GX) || (dev->type == INTEL_440ZX)) && (dev->max_func == 1)) {
-	regs = (uint8_t *) dev->regs[1];
-
-	regs[0x00] = 0x86; regs[0x01] = 0x80;	/* Intel */
-	if(dev->type != INTEL_440GX) {
-		regs[0x02] = 0x91; regs[0x03] = 0x71;	/* 82443BX */
-	} else {
-		regs[0x02] = 0xa1; regs[0x03] = 0x71; /* 82443GX (They seem to share the same deal*/
-	}
-	regs[0x06] = 0x20; regs[0x07] = 0x02;
-	regs[0x08] = 0x02;
-	regs[0x0a] = 0x04; regs[0x0b] = 0x06;
-	regs[0x0e] = 0x01;
-	regs[0x1c] = 0xf0;
-	regs[0x1e] = 0xa0; regs[0x1f] = 0x02;
-	regs[0x20] = 0xf0; regs[0x21] = 0xff;
-	regs[0x24] = 0xf0; regs[0x25] = 0xff;
-	regs[0x3e] = 0x80;
-    }
-
     pci_add_card(PCI_ADD_NORTHBRIDGE, i4x0_read, i4x0_write, dev);
+
+    if ((dev->type >= INTEL_440BX) && !(regs[0x7a] & 0x02))
+	device_add((dev->type == INTEL_440GX) ? &i440gx_agp_device : &i440bx_agp_device);
+    else if (dev->type >= INTEL_440LX)
+	device_add(&i440lx_agp_device);
 
     return dev;
 }

--- a/src/chipset/via_apollo.c
+++ b/src/chipset/via_apollo.c
@@ -28,8 +28,8 @@
 #include <86box/mem.h>
 #include <86box/io.h>
 #include <86box/rom.h>
-#include <86box/pci.h>
 #include <86box/device.h>
+#include <86box/pci.h>
 #include <86box/keyboard.h>
 #include <86box/chipset.h>
 #include <86box/spd.h>
@@ -38,7 +38,7 @@
 typedef struct via_apollo_t
 {
     uint16_t id;
-    uint8_t pci_conf[2][256];
+    uint8_t pci_conf[256];
 } via_apollo_t;
 
 
@@ -84,80 +84,52 @@ static void
 via_apollo_setup(via_apollo_t *dev)
 {
     /* Host Bridge */
-    dev->pci_conf[0][0x00] = 0x06; /*VIA*/
-    dev->pci_conf[0][0x01] = 0x11;
-    dev->pci_conf[0][0x02] = dev->id & 0xff;
-    dev->pci_conf[0][0x03] = (dev->id >> 8);
+    dev->pci_conf[0x00] = 0x06; /*VIA*/
+    dev->pci_conf[0x01] = 0x11;
+    dev->pci_conf[0x02] = dev->id & 0xff;
+    dev->pci_conf[0x03] = (dev->id >> 8);
 
-    dev->pci_conf[0][0x04] = 6;
-    dev->pci_conf[0][0x05] = 0;
+    dev->pci_conf[0x04] = 6;
+    dev->pci_conf[0x05] = 0;
 
-    dev->pci_conf[0][0x06] = 0x90;
-    dev->pci_conf[0][0x07] = 0x02;
+    dev->pci_conf[0x06] = 0x90;
+    dev->pci_conf[0x07] = 0x02;
 
     if (dev->id == 0x0597)
-	dev->pci_conf[0][0x08] = 1;	/* Production Silicon ("Revision B") */
-    dev->pci_conf[0][0x09] = 0;
-    dev->pci_conf[0][0x0a] = 0;
-    dev->pci_conf[0][0x0b] = 6;
-    dev->pci_conf[0][0x0c] = 0;
-    dev->pci_conf[0][0x0d] = 0;
-    dev->pci_conf[0][0x0e] = 0;
-    dev->pci_conf[0][0x0f] = 0;
-    dev->pci_conf[0][0x10] = 0x08;
-    dev->pci_conf[0][0x34] = 0xa0;
+	dev->pci_conf[0x08] = 1;	/* Production Silicon ("Revision B") */
+    dev->pci_conf[0x09] = 0;
+    dev->pci_conf[0x0a] = 0;
+    dev->pci_conf[0x0b] = 6;
+    dev->pci_conf[0x0c] = 0;
+    dev->pci_conf[0x0d] = 0;
+    dev->pci_conf[0x0e] = 0;
+    dev->pci_conf[0x0f] = 0;
+    dev->pci_conf[0x10] = 0x08;
+    dev->pci_conf[0x34] = 0xa0;
 
     if (dev->id == 0x0691) {
-    	dev->pci_conf[0][0x56] = 0x01;
-	dev->pci_conf[0][0x57] = 0x01;
+    	dev->pci_conf[0x56] = 0x01;
+	dev->pci_conf[0x57] = 0x01;
     }
-    dev->pci_conf[0][0x5a] = 0x01;
-    dev->pci_conf[0][0x5b] = 0x01;
-    dev->pci_conf[0][0x5c] = 0x01;
-    dev->pci_conf[0][0x5d] = 0x01;
-    dev->pci_conf[0][0x5e] = 0x01;
-    dev->pci_conf[0][0x5f] = 0x01;
+    dev->pci_conf[0x5a] = 0x01;
+    dev->pci_conf[0x5b] = 0x01;
+    dev->pci_conf[0x5c] = 0x01;
+    dev->pci_conf[0x5d] = 0x01;
+    dev->pci_conf[0x5e] = 0x01;
+    dev->pci_conf[0x5f] = 0x01;
 
-    dev->pci_conf[0][0x64] = 0xec;
-    dev->pci_conf[0][0x65] = 0xec;
-    dev->pci_conf[0][0x66] = 0xec;
+    dev->pci_conf[0x64] = 0xec;
+    dev->pci_conf[0x65] = 0xec;
+    dev->pci_conf[0x66] = 0xec;
     if (dev->id == 0x0691)
-	dev->pci_conf[0][0x67] = 0xec;	/* DRAM Timing for Banks 6,7. */
-    dev->pci_conf[0][0x6b] = 0x01;
+	dev->pci_conf[0x67] = 0xec;	/* DRAM Timing for Banks 6,7. */
+    dev->pci_conf[0x6b] = 0x01;
 
-    dev->pci_conf[0][0xa0] = 0x02;
-    dev->pci_conf[0][0xa2] = 0x10;
-    dev->pci_conf[0][0xa4] = 0x03;
-    dev->pci_conf[0][0xa5] = 0x02;
-    dev->pci_conf[0][0xa7] = 0x07;
-
-    /* PCI-to-PCI Bridge */
-
-    dev->pci_conf[1][0x00] = 0x06; /*VIA*/
-    dev->pci_conf[1][0x01] = 0x11;
-    dev->pci_conf[1][0x02] = dev->id & 0xff;
-    dev->pci_conf[1][0x03] = (dev->id >> 8) | 0x80;
-
-    dev->pci_conf[1][0x04] = 7;
-    dev->pci_conf[1][0x05] = 0;
-
-    dev->pci_conf[1][0x06] = 0x20;
-    dev->pci_conf[1][0x07] = 0x02;
-
-    dev->pci_conf[1][0x09] = 0;
-    dev->pci_conf[1][0x0a] = 4;
-    dev->pci_conf[1][0x0b] = 6;
-    dev->pci_conf[1][0x0c] = 0;
-    dev->pci_conf[1][0x0d] = 0;
-    dev->pci_conf[1][0x0e] = 1;
-    dev->pci_conf[1][0x0f] = 0;
-
-    dev->pci_conf[1][0x1c] = 0xf0;
-
-    dev->pci_conf[1][0x20] = 0xf0;
-    dev->pci_conf[1][0x21] = 0xff;
-    dev->pci_conf[1][0x24] = 0xf0;
-    dev->pci_conf[1][0x25] = 0xff;
+    dev->pci_conf[0xa0] = 0x02;
+    dev->pci_conf[0xa2] = 0x10;
+    dev->pci_conf[0xa4] = 0x03;
+    dev->pci_conf[0xa5] = 0x02;
+    dev->pci_conf[0xa7] = 0x07;
 }
 
 
@@ -185,98 +157,98 @@ via_apollo_host_bridge_write(int func, int addr, uint8_t val, void *priv)
 
     switch(addr) {
 	case 0x04:
-		dev->pci_conf[0][0x04] = (dev->pci_conf[0][0x04] & ~0x40) | (val & 0x40);
+		dev->pci_conf[0x04] = (dev->pci_conf[0x04] & ~0x40) | (val & 0x40);
 		break;
 	case 0x07:
-		dev->pci_conf[0][0x07] &= ~(val & 0xb0);
+		dev->pci_conf[0x07] &= ~(val & 0xb0);
 		break;
 	case 0x0d:
-		dev->pci_conf[0][0x0d] = (dev->pci_conf[0][0x0d] & ~0x07) | (val & 0x07);
-		dev->pci_conf[0][0x75] = (dev->pci_conf[0][0x75] & ~0x30) | ((val & 0x06) << 3);
+		dev->pci_conf[0x0d] = (dev->pci_conf[0x0d] & ~0x07) | (val & 0x07);
+		dev->pci_conf[0x75] = (dev->pci_conf[0x75] & ~0x30) | ((val & 0x06) << 3);
 		break;
 
 	case 0x12:	/* Graphics Aperture Base */
-		dev->pci_conf[0][0x12] = (val & 0xf0);
+		dev->pci_conf[0x12] = (val & 0xf0);
 		break;
 	case 0x13:	/* Graphics Aperture Base */
-		dev->pci_conf[0][0x13] = val;
+		dev->pci_conf[0x13] = val;
 		break;
 
 	case 0x50:	/* Cache Control 1 */
 		if (dev->id == 0x0691)
-			dev->pci_conf[0][0x50] = val;
+			dev->pci_conf[0x50] = val;
 		else
-			dev->pci_conf[0][0x50] = (dev->pci_conf[0][0x50] & ~0xf8) | (val & 0xf8);
+			dev->pci_conf[0x50] = (dev->pci_conf[0x50] & ~0xf8) | (val & 0xf8);
 		break;
 	case 0x51:	/* Cache Control 2 */
 		if (dev->id == 0x0691)
-			dev->pci_conf[0][0x51] = val;
+			dev->pci_conf[0x51] = val;
 		else
-			dev->pci_conf[0][0x51] = (dev->pci_conf[0][0x51] & ~0xeb) | (val & 0xeb);
+			dev->pci_conf[0x51] = (dev->pci_conf[0x51] & ~0xeb) | (val & 0xeb);
 		break;
 	case 0x52:	/* Non_Cacheable Control */
 		if (dev->id == 0x0691)
-			dev->pci_conf[0][0x52] = (dev->pci_conf[0][0x52] & ~0x9f) | (val & 0x9f);
+			dev->pci_conf[0x52] = (dev->pci_conf[0x52] & ~0x9f) | (val & 0x9f);
 		else
-			dev->pci_conf[0][0x52] = (dev->pci_conf[0][0x52] & ~0xf5) | (val & 0xf5);
+			dev->pci_conf[0x52] = (dev->pci_conf[0x52] & ~0xf5) | (val & 0xf5);
 		break;
 	case 0x53:	/* System Performance Control */
 		if (dev->id == 0x0691)
-			dev->pci_conf[0][0x53] = val;
+			dev->pci_conf[0x53] = val;
 		else
-			dev->pci_conf[0][0x53] = (dev->pci_conf[0][0x53] & ~0xf0) | (val & 0xf0);
+			dev->pci_conf[0x53] = (dev->pci_conf[0x53] & ~0xf0) | (val & 0xf0);
 		break;
 
 	case 0x56: case 0x57: case 0x5a: case 0x5b: case 0x5c: case 0x5d: case 0x5e: case 0x5f: /* DRAM Row Ending Address */
 		if (dev->id >= 0x0691)
-			spd_write_drbs(dev->pci_conf[0], 0x5a, 0x56, 8);
+			spd_write_drbs(dev->pci_conf, 0x5a, 0x56, 8);
 		else if (addr >= 0x5a)
-			spd_write_drbs(dev->pci_conf[0], 0x5a, 0x5f, 8);
+			spd_write_drbs(dev->pci_conf, 0x5a, 0x5f, 8);
 		break;
 
 	case 0x58:
 		if (dev->id == 0x0597)
-			dev->pci_conf[0][0x58] = (dev->pci_conf[0][0x58] & ~0xee) | (val & 0xee);
+			dev->pci_conf[0x58] = (dev->pci_conf[0x58] & ~0xee) | (val & 0xee);
 		else
-			dev->pci_conf[0][0x58] = val;
+			dev->pci_conf[0x58] = val;
 		break;
 	case 0x59:
 		if (dev->id == 0x0691)
-			dev->pci_conf[0][0x59] = val;
+			dev->pci_conf[0x59] = val;
 		else
-			dev->pci_conf[0][0x59] = (dev->pci_conf[0][0x59] & ~0xf0) | (val & 0xf0);
+			dev->pci_conf[0x59] = (dev->pci_conf[0x59] & ~0xf0) | (val & 0xf0);
 		break;
 
 	case 0x61:	/* Shadow RAM Control 1 */
-		if ((dev->pci_conf[0][0x61] ^ val) & 0x03)
+		if ((dev->pci_conf[0x61] ^ val) & 0x03)
 			apollo_map(0xc0000, 0x04000, val & 0x03);
-		if ((dev->pci_conf[0][0x61] ^ val) & 0x0c)
+		if ((dev->pci_conf[0x61] ^ val) & 0x0c)
 			apollo_map(0xc4000, 0x04000, (val & 0x0c) >> 2);
-		if ((dev->pci_conf[0][0x61] ^ val) & 0x30)
+		if ((dev->pci_conf[0x61] ^ val) & 0x30)
 			apollo_map(0xc8000, 0x04000, (val & 0x30) >> 4);
-		if ((dev->pci_conf[0][0x61] ^ val) & 0xc0)
+		if ((dev->pci_conf[0x61] ^ val) & 0xc0)
 			apollo_map(0xcc000, 0x04000, (val & 0xc0) >> 6);
-		dev->pci_conf[0][0x61] = val;
+		dev->pci_conf[0x61] = val;
 		break;
 	case 0x62:	/* Shadow RAM Control 2 */
-		if ((dev->pci_conf[0][0x62] ^ val) & 0x03)
+		if ((dev->pci_conf[0x62] ^ val) & 0x03)
 			apollo_map(0xd0000, 0x04000, val & 0x03);
-		if ((dev->pci_conf[0][0x62] ^ val) & 0x0c)
+		if ((dev->pci_conf[0x62] ^ val) & 0x0c)
 			apollo_map(0xd4000, 0x04000, (val & 0x0c) >> 2);
-		if ((dev->pci_conf[0][0x62] ^ val) & 0x30)
+		if ((dev->pci_conf[0x62] ^ val) & 0x30)
 			apollo_map(0xd8000, 0x04000, (val & 0x30) >> 4);
-		if ((dev->pci_conf[0][0x62] ^ val) & 0xc0)
+		if ((dev->pci_conf[0x62] ^ val) & 0xc0)
 			apollo_map(0xdc000, 0x04000, (val & 0xc0) >> 6);
-		dev->pci_conf[0][0x62] = val;
+		dev->pci_conf[0x62] = val;
 		break;
 	case 0x63:	/* Shadow RAM Control 3 */
-		if ((dev->pci_conf[0][0x63] ^ val) & 0x30) {
+		if ((dev->pci_conf[0x63] ^ val) & 0x30) {
 			apollo_map(0xf0000, 0x10000, (val & 0x30) >> 4);
 			shadowbios = (((val & 0x30) >> 4) & 0x02);
 		}
-		if ((dev->pci_conf[0][0x63] ^ val) & 0xc0)
+		if ((dev->pci_conf[0x63] ^ val) & 0xc0)
 			apollo_map(0xe0000, 0x10000, (val & 0xc0) >> 6);
-		dev->pci_conf[0][0x63] = val;
+		dev->pci_conf[0x63] = val;
 		if (smram[0].size != 0x00000000) {
 			mem_set_mem_state_smram_ex(0, smram[0].host_base, smram[0].size, 0x00);
 			mem_set_mem_state_smram_ex(1, smram[0].host_base, smram[0].size, 0x00);
@@ -340,151 +312,91 @@ via_apollo_host_bridge_write(int func, int addr, uint8_t val, void *priv)
 		break;
 	case 0x68:
 		if (dev->id == 0x0597)
-			dev->pci_conf[0][0x68] = (dev->pci_conf[0][0x6b] & ~0xfe) | (val & 0xfe);
+			dev->pci_conf[0x68] = (dev->pci_conf[0x6b] & ~0xfe) | (val & 0xfe);
 		else if (dev->id == 0x0598)
-			dev->pci_conf[0][0x68] = val;
+			dev->pci_conf[0x68] = val;
 		else
-			dev->pci_conf[0][0x68] = (dev->pci_conf[0][0x6b] & ~0xfd) | (val & 0xfd);
+			dev->pci_conf[0x68] = (dev->pci_conf[0x6b] & ~0xfd) | (val & 0xfd);
 		break;
 	case 0x6b:
 		if (dev->id == 0x0691)
-			dev->pci_conf[0][0x6b] = (dev->pci_conf[0][0x6b] & ~0xcf) | (val & 0xcf);
+			dev->pci_conf[0x6b] = (dev->pci_conf[0x6b] & ~0xcf) | (val & 0xcf);
 		else
-			dev->pci_conf[0][0x6b] = (dev->pci_conf[0][0x6b] & ~0xc1) | (val & 0xc1);
+			dev->pci_conf[0x6b] = (dev->pci_conf[0x6b] & ~0xc1) | (val & 0xc1);
 		break;
 	case 0x6c:
 		if (dev->id == 0x0597)
-			dev->pci_conf[0][0x6c] = (dev->pci_conf[0][0x6c] & ~0x1f) | (val & 0x1f);
+			dev->pci_conf[0x6c] = (dev->pci_conf[0x6c] & ~0x1f) | (val & 0x1f);
 		else if (dev->id == 0x0598)
-			dev->pci_conf[0][0x6c] = (dev->pci_conf[0][0x6c] & ~0x7f) | (val & 0x7f);
+			dev->pci_conf[0x6c] = (dev->pci_conf[0x6c] & ~0x7f) | (val & 0x7f);
 		else
-			dev->pci_conf[0][0x6c] = val;
+			dev->pci_conf[0x6c] = val;
 		break;
 	case 0x6d:
 		if (dev->id == 0x0597)
-			dev->pci_conf[0][0x6d] = (dev->pci_conf[0][0x6d] & ~0x0f) | (val & 0x0f);
+			dev->pci_conf[0x6d] = (dev->pci_conf[0x6d] & ~0x0f) | (val & 0x0f);
 		else if (dev->id == 0x0598)
-			dev->pci_conf[0][0x6d] = (dev->pci_conf[0][0x6d] & ~0x7f) | (val & 0x7f);
+			dev->pci_conf[0x6d] = (dev->pci_conf[0x6d] & ~0x7f) | (val & 0x7f);
 		else
-			dev->pci_conf[0][0x6d] = val;
+			dev->pci_conf[0x6d] = val;
 		break;
 	case 0x6e:
-		dev->pci_conf[0][0x6e] = (dev->pci_conf[0][0x6e] & ~0xb7) | (val & 0xb7);
+		dev->pci_conf[0x6e] = (dev->pci_conf[0x6e] & ~0xb7) | (val & 0xb7);
 		break;
 
 	case 0x70:
 		if (dev->id == 0x0597)
-			dev->pci_conf[0][0x70] = (dev->pci_conf[0][0x70] & ~0xf1) | (val & 0xf1);
+			dev->pci_conf[0x70] = (dev->pci_conf[0x70] & ~0xf1) | (val & 0xf1);
 		else
-			dev->pci_conf[0][0x70] = val;
+			dev->pci_conf[0x70] = val;
 		break;
 	case 0x74:
-		dev->pci_conf[0][0x74] = (dev->pci_conf[0][0x74] & ~0xc0) | (val & 0xc0);
+		dev->pci_conf[0x74] = (dev->pci_conf[0x74] & ~0xc0) | (val & 0xc0);
 		break;
 	case 0x75:
-		dev->pci_conf[0][0x75] = (dev->pci_conf[0][0x75] & ~0xcf) | (val & 0xcf);
+		dev->pci_conf[0x75] = (dev->pci_conf[0x75] & ~0xcf) | (val & 0xcf);
 		break;
 	case 0x76:
-		dev->pci_conf[0][0x76] = (dev->pci_conf[0][0x76] & ~0xf0) | (val & 0xf0);
+		dev->pci_conf[0x76] = (dev->pci_conf[0x76] & ~0xf0) | (val & 0xf0);
 		break;
 	case 0x77:
-		dev->pci_conf[0][0x77] = (dev->pci_conf[0][0x77] & ~0xc0) | (val & 0xc0);
+		dev->pci_conf[0x77] = (dev->pci_conf[0x77] & ~0xc0) | (val & 0xc0);
 		break;
 	case 0x7e:
-		dev->pci_conf[0][0x7e] = (dev->pci_conf[0][0x7e] & ~0x3f) | (val & 0x3f);
+		dev->pci_conf[0x7e] = (dev->pci_conf[0x7e] & ~0x3f) | (val & 0x3f);
 		break;
 
 	case 0x80:
-		dev->pci_conf[0][0x80] = (dev->pci_conf[0][0x80] & ~0x8f) | (val & 0x8f);
+		dev->pci_conf[0x80] = (dev->pci_conf[0x80] & ~0x8f) | (val & 0x8f);
 		break;
 	case 0x84:
 		/* The datasheet first mentions 7-0 but then says 3-0 are reserved -
 		   - minimum of 16 MB for the graphics aperture? */
-		dev->pci_conf[0][0x84] = (dev->pci_conf[0][0x84] & ~0xf0) | (val & 0xf0);
+		dev->pci_conf[0x84] = (dev->pci_conf[0x84] & ~0xf0) | (val & 0xf0);
 		break;
 	case 0x88:
-		dev->pci_conf[0][0x88] = (dev->pci_conf[0][0x88] & ~0x07) | (val & 0x07);
+		dev->pci_conf[0x88] = (dev->pci_conf[0x88] & ~0x07) | (val & 0x07);
 		break;
 	case 0x89:
-		dev->pci_conf[0][0x89] = (dev->pci_conf[0][0x89] & ~0xf0) | (val & 0xf0);
+		dev->pci_conf[0x89] = (dev->pci_conf[0x89] & ~0xf0) | (val & 0xf0);
 		break;
 
 	case 0xa8:
-		dev->pci_conf[0][0xa8] = (dev->pci_conf[0][0xa8] & ~0x03) | (val & 0x03);
+		dev->pci_conf[0xa8] = (dev->pci_conf[0xa8] & ~0x03) | (val & 0x03);
 		break;
 	case 0xa9:
-		dev->pci_conf[0][0xa9] = (dev->pci_conf[0][0xa9] & ~0x03) | (val & 0x03);
+		dev->pci_conf[0xa9] = (dev->pci_conf[0xa9] & ~0x03) | (val & 0x03);
 		break;
 	case 0xac:
-		dev->pci_conf[0][0xac] = (dev->pci_conf[0][0xac] & ~0x0f) | (val & 0x0f);
+		dev->pci_conf[0xac] = (dev->pci_conf[0xac] & ~0x0f) | (val & 0x0f);
 		break;
 	case 0xfc:
 		if (dev->id > 0x0597)
-			dev->pci_conf[0][0xfc] = (dev->pci_conf[0][0xfc] & ~0x01) | (val & 0x01);
+			dev->pci_conf[0xfc] = (dev->pci_conf[0xfc] & ~0x01) | (val & 0x01);
 		break;
 
 	default:
-		dev->pci_conf[0][addr] = val;
-		break;
-    }
-}
-
-
-static void
-via_apollo_pci_bridge_write(int func, int addr, uint8_t val, void *priv)
-{
-    via_apollo_t *dev = (via_apollo_t *) priv;
-
-    if (func != 1)
-	return;
-
-    /*Read-only addresses*/
-
-    if ((addr < 4) || ((addr >= 5) && (addr < 7)) ||
-	((addr >= 8) && (addr < 0x18)) || (addr == 0x1b) ||
-	((addr >= 0x1e) && (addr < 0x20)) || ((addr >= 0x28) && (addr < 0x3e)) ||
-	(addr == 0x3f) || (addr >= 0x43))
-	return;
-
-    switch(addr) {
-	case 0x04:
-		dev->pci_conf[1][0x04] = (dev->pci_conf[1][0x04] & ~0x47) | (val & 0x47);
-		break;
-	case 0x07:
-		dev->pci_conf[1][0x07] &= ~(val & 0x30);
-		break;
-
-	case 0x20:	/* Memory Base */
-		dev->pci_conf[1][0x20] = val & 0xf0;
-		break;
-	case 0x22:	/* Memory Limit */
-		dev->pci_conf[1][0x22] = val & 0xf0;
-		break;
-	case 0x24:	/* Prefetchable Memory Base */
-		dev->pci_conf[1][0x24] = val & 0xf0;
-		break;
-	case 0x26:	/* Prefetchable Memory Limit */
-		dev->pci_conf[1][0x26] = val & 0xf0;
-		break;
-
-	case 0x3e:
-		dev->pci_conf[0][0x3e] = (dev->pci_conf[0][0x3e] & ~0x06) | (val & 0x06);
-		break;
-
-	case 0x41:
-		dev->pci_conf[0][0x41] = (dev->pci_conf[0][0x41] & ~0xfe) | (val & 0xfe);
-		break;
-	case 0x42:
-		if (dev->id == 0x0597)
-			dev->pci_conf[0][0x42] = (dev->pci_conf[0][0x42] & ~0xec) | (val & 0xec);
-		else if (dev->id == 0x0598)
-			dev->pci_conf[0][0x42] = (dev->pci_conf[0][0x42] & ~0xfc) | (val & 0xfc);
-		else
-			dev->pci_conf[0][0x42] = (dev->pci_conf[0][0x42] & ~0xf4) | (val & 0xf4);
-		break;
-
-	default:
-		dev->pci_conf[1][addr] = val;
+		dev->pci_conf[addr] = val;
 		break;
     }
 }
@@ -498,10 +410,7 @@ via_apollo_read(int func, int addr, void *priv)
 
     switch(func) {
         case 0:
-		ret = dev->pci_conf[0][addr];
-		break;
-        case 1:
-		ret = dev->pci_conf[1][addr];
+		ret = dev->pci_conf[addr];
 		break;
     }
 
@@ -515,9 +424,6 @@ via_apollo_write(int func, int addr, uint8_t val, void *priv)
     switch(func) {
 	case 0:
 		via_apollo_host_bridge_write(func, addr, val, priv);
-		break;
-	case 1:
-		via_apollo_pci_bridge_write(func, addr, val, priv);
 		break;
     }
 }
@@ -541,6 +447,14 @@ via_apollo_init(const device_t *info)
     pci_add_card(PCI_ADD_NORTHBRIDGE, via_apollo_read, via_apollo_write, dev);
 
     dev->id = info->local;
+
+    if (dev->id == 0x0597)
+    	device_add(&via_vp3_agp_device);
+    else if (dev->id == 0x0598)
+    	device_add(&via_mvp3_agp_device);
+    else if (dev->id == 0x0691)
+    	device_add(&via_apro_agp_device);
+
     via_apollo_setup(dev);
     via_apollo_reset(dev);
 

--- a/src/chipset/via_apollo.c
+++ b/src/chipset/via_apollo.c
@@ -108,7 +108,7 @@ via_apollo_setup(via_apollo_t *dev)
     dev->pci_conf[0x34] = 0xa0;
 
     if (dev->id == 0x0691) {
-    	dev->pci_conf[0x56] = 0x01;
+ 	dev->pci_conf[0x56] = 0x01;
 	dev->pci_conf[0x57] = 0x01;
     }
     dev->pci_conf[0x5a] = 0x01;
@@ -448,12 +448,19 @@ via_apollo_init(const device_t *info)
 
     dev->id = info->local;
 
-    if (dev->id == 0x0597)
-    	device_add(&via_vp3_agp_device);
-    else if (dev->id == 0x0598)
-    	device_add(&via_mvp3_agp_device);
-    else if (dev->id == 0x0691)
-    	device_add(&via_apro_agp_device);
+    switch (dev->id) {
+	case 0x0597:
+		device_add(&via_vp3_agp_device);
+		break;
+
+	case 0x0598:
+		device_add(&via_mvp3_agp_device);
+		break;
+
+	case 0x0691:
+		device_add(&via_apro_agp_device);
+		break;
+    }
 
     via_apollo_setup(dev);
     via_apollo_reset(dev);

--- a/src/device/pci_bridge.c
+++ b/src/device/pci_bridge.c
@@ -1,0 +1,325 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Implementation of PCI-PCI and host-AGP bridges.
+ *
+ *
+ *
+ * Authors:	RichardG, <richardg867@gmail.com>
+ *
+ *		Copyright 2020 RichardG.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <wchar.h>
+#define HAVE_STDARG_H
+#include <86box/86box.h>
+#include <86box/machine.h>
+#include "cpu.h"
+#include <86box/io.h>
+#include <86box/pic.h>
+#include <86box/mem.h>
+#include <86box/device.h>
+#include <86box/pci.h>
+
+
+#define PCI_BRIDGE_DEC_21150	0x10110022
+#define AGP_BRIDGE_INTEL_440LX	0x80867181
+#define AGP_BRIDGE_INTEL_440BX	0x80867191
+#define AGP_BRIDGE_INTEL_440GX	0x808671a1
+#define AGP_BRIDGE(x)		((x) >= AGP_BRIDGE_INTEL_440LX)
+
+
+typedef struct
+{
+    uint32_t	local;
+    uint8_t	type;
+
+    uint8_t	regs[256];
+    uint8_t	bus_index;
+    int 	slot;
+} pci_bridge_t;
+
+
+#ifdef ENABLE_PCI_BRIDGE_LOG
+int pci_bridge_do_log = ENABLE_PCI_BRIDGE_LOG;
+
+
+static void
+pci_bridge_log(const char *fmt, ...)
+{
+    va_list ap;
+
+    if (pci_bridge_do_log) {
+	va_start(ap, fmt);
+	pclog_ex(fmt, ap);
+	va_end(ap);
+    }
+}
+#else
+#define pci_bridge_log(fmt, ...)
+#endif
+
+
+static void
+pci_bridge_write(int func, int addr, uint8_t val, void *priv)
+{
+    pci_bridge_t *dev = (pci_bridge_t *) priv;
+
+    pci_bridge_log("PCI Bridge %d: write(%d, %02X, %02X)\n", dev->bus_index, func, addr, val);
+
+    if (func > 0)
+	return;
+
+    switch (addr) {
+	case 0x00: case 0x01: case 0x02: case 0x03:
+	case 0x06: case 0x07: case 0x08: case 0x09:
+	case 0x0a: case 0x0b: case 0x0e: case 0x1e:
+	case 0x1f: case 0x34: case 0x3d: case 0x67:
+	case 0xdc: case 0xdd: case 0xde: case 0xdf:
+	case 0xe0: case 0xe1: case 0xe2: case 0xe3:
+		return;
+
+	case 0x04:
+		val &= 0x67;
+		break;
+
+	case 0x05:
+		val &= 0x03;
+		break;
+
+	case 0x19:
+		/* Set our bus number. */
+		pci_bridge_log("PCI Bridge %d: switching from bus %02X to %02X\n", dev->bus_index, dev->regs[addr], val);
+		if (dev->regs[addr])
+			pci_bus_number_to_index_mapping[dev->regs[addr]] = 0xff;
+		if (val)
+			pci_bus_number_to_index_mapping[val] = dev->bus_index;
+		break;
+
+	case 0x1c: case 0x1d: case 0x20: case 0x22:
+	case 0x24: case 0x26:
+		val &= 0xf0;
+		break;
+
+	case 0x3e:
+		val &= 0xef;
+		break;
+
+	case 0x3f:
+		val &= 0x0f;
+		break;
+
+	case 0x40:
+		val &= 0x32;
+		break;
+
+	case 0x41:
+		val &= 0x07;
+		break;
+
+	case 0x43:
+		val &= 0x03;
+		break;
+
+	case 0x64:
+		val &= 0x7e;
+		break;
+
+	case 0x69:
+		val &= 0x3f;
+		break;
+    }
+
+    dev->regs[addr] = val;
+}
+
+
+static uint8_t
+pci_bridge_read(int func, int addr, void *priv)
+{
+    pci_bridge_t *dev = (pci_bridge_t *) priv;
+    uint8_t ret;
+
+    if (func > 0)
+	ret = 0xff;
+    else
+	ret = dev->regs[addr];
+
+    pci_bridge_log("PCI Bridge %d: read(%d, %02X) = %02X\n", dev->bus_index, func, addr, ret);
+    return ret;
+}
+
+
+static void
+pci_bridge_reset(void *priv)
+{
+    pci_bridge_t *dev = (pci_bridge_t *) priv;
+
+    pci_bridge_log("PCI Bridge %d: reset()\n", dev->bus_index);
+
+    /* IDs */
+    dev->regs[0x00] = dev->local >> 16;
+    dev->regs[0x01] = dev->local >> 24;
+    dev->regs[0x02] = dev->local;
+    dev->regs[0x03] = dev->local >> 8;
+
+    switch (dev->local) {
+	case PCI_BRIDGE_DEC_21150:
+		dev->regs[0x06] = 0x80;
+		dev->regs[0x07] = 0x02;
+		break;
+
+	case AGP_BRIDGE_INTEL_440LX:
+		dev->regs[0x06] = 0xa0;
+		dev->regs[0x07] = 0x02;
+		dev->regs[0x08] = 0x03;
+		break;
+
+	case AGP_BRIDGE_INTEL_440BX:
+	case AGP_BRIDGE_INTEL_440GX:
+		dev->regs[0x06] = 0x20;
+		dev->regs[0x07] = dev->regs[0x08] = 0x02;
+		break;
+    }
+
+    dev->regs[0x0a] = 0x04; /* PCI-PCI bridge */
+    dev->regs[0x0b] = 0x06; /* bridge device */
+
+    dev->regs[0x0e] = 0x01;
+
+    /* IO BARs */
+    if (AGP_BRIDGE(dev->local)) {
+	dev->regs[0x1c] = 0xf0;
+    } else {
+	dev->regs[0x1c] = dev->regs[0x1d] = 0x01;
+    }
+
+    dev->regs[0x1e] = AGP_BRIDGE(dev->local) ? 0xa0 : 0x80;
+    dev->regs[0x1f] = 0x02;
+
+    /* prefetchable memory limits */
+    if (AGP_BRIDGE(dev->local)) {
+	dev->regs[0x20] = dev->regs[0x24] = 0xf0;
+	dev->regs[0x21] = dev->regs[0x25] = 0xff;
+    } else {
+	dev->regs[0x24] = dev->regs[0x26] = 0x01;
+    }
+
+    if (dev->local == AGP_BRIDGE_INTEL_440LX)
+	dev->regs[0x3e] = 0x80;
+
+    if (dev->local == PCI_BRIDGE_DEC_21150) {
+    	dev->regs[0x34] = 0xdc;
+	dev->regs[0x43] = 0x02;
+	dev->regs[0xdc] = dev->regs[0xde] = 0x01;
+    }
+}
+
+
+static void *
+pci_bridge_init(const device_t *info)
+{
+    uint8_t interrupts[4], interrupt_count, interrupt_mask, slot_count, i;
+
+    pci_bridge_t *dev = (pci_bridge_t *) malloc(sizeof(pci_bridge_t));
+    memset(dev, 0, sizeof(pci_bridge_t));
+
+    dev->local = info->local;
+    dev->bus_index = last_pci_bus++;
+    pci_bridge_log("PCI Bridge %d: init()\n", dev->bus_index);
+
+    pci_bridge_reset(dev);
+
+    dev->slot = pci_add_card(AGP_BRIDGE(dev->local) ? 0x01 : PCI_ADD_BRIDGE, pci_bridge_read, pci_bridge_write, dev);
+    interrupt_count = sizeof(interrupts);
+    interrupt_mask = interrupt_count - 1;
+    for (i = 0; i < interrupt_count; i++)
+	interrupts[i] = pci_get_int(dev->slot, PCI_INTA + i);
+    pci_bridge_log("PCI Bridge %d: upstream bus %02X slot %02X interrupts %02X %02X %02X %02X\n", dev->bus_index, (dev->slot >> 5) & 0xff, dev->slot & 31, interrupts[0], interrupts[1], interrupts[2], interrupts[3]);
+
+    if (info->local == PCI_BRIDGE_DEC_21150)
+	slot_count = 9; /* 9 bus masters */
+    else
+	slot_count = 1; /* AGP bridges always have 1 slot */
+
+    for (i = 0; i < slot_count; i++) {
+	/* Interrupts for bridge slots are assigned in round-robin: ABCD, BCDA, CDAB and so on. */
+	pci_bridge_log("PCI Bridge %d: downstream slot %02X interrupts %02X %02X %02X %02X\n", dev->bus_index, i, interrupts[i & interrupt_mask], interrupts[(i + 1) & interrupt_mask], interrupts[(i + 2) & interrupt_mask], interrupts[(i + 3) & interrupt_mask]);
+	pci_register_bus_slot(dev->bus_index, i, /*AGP_BRIDGE(dev->local) ? PCI_CARD_SPECIAL : */PCI_CARD_NORMAL,
+			      interrupts[i & interrupt_mask],
+			      interrupts[(i + 1) & interrupt_mask],
+			      interrupts[(i + 2) & interrupt_mask],
+			      interrupts[(i + 3) & interrupt_mask]);
+    }
+
+    return dev;
+}
+
+
+/* PCI bridges */
+const device_t dec21150_device =
+{
+    "DEC 21150 PCI Bridge",
+    DEVICE_PCI,
+    PCI_BRIDGE_DEC_21150,
+    pci_bridge_init,
+    NULL,
+    pci_bridge_reset,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+
+/* AGP bridges */
+const device_t i440lx_agp_device =
+{
+    "Intel 82443LX AGP Bridge",
+    DEVICE_PCI,
+    AGP_BRIDGE_INTEL_440LX,
+    pci_bridge_init,
+    NULL,
+    pci_bridge_reset,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+
+const device_t i440bx_agp_device =
+{
+    "Intel 82443BX AGP Bridge",
+    DEVICE_PCI,
+    AGP_BRIDGE_INTEL_440BX,
+    pci_bridge_init,
+    NULL,
+    pci_bridge_reset,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+
+const device_t i440gx_agp_device =
+{
+    "Intel 82443GX AGP Bridge",
+    DEVICE_PCI,
+    AGP_BRIDGE_INTEL_440GX,
+    pci_bridge_init,
+    NULL,
+    pci_bridge_reset,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};

--- a/src/include/86box/language.h
+++ b/src/include/86box/language.h
@@ -97,8 +97,8 @@
 #define IDS_2121	2121		// "Save changes\nThis will hard..."
 #define IDS_2122	2122		// "Discard changes\nAll changes..."
 #define IDS_2123	2123		// "Cancel\nGo back to the..."
-#define IDS_2124	2124		// "About " EMU_NAME
-#define IDS_2125	2125		// EMU_NAME " v" EMU_VERSION
+#define IDS_2124	2124		// "About 86Box"
+#define IDS_2125	2125		// "86Box v" EMU_VERSION
 #define IDS_2126	2126		// "An emulator of old computers..."
 #define IDS_2127	2127		// "OK"
 #define IDS_2128	2128		// "Hardware not available"

--- a/src/include/86box/pci.h
+++ b/src/include/86box/pci.h
@@ -29,6 +29,7 @@
 
 #define PCI_NO_IRQ_STEERING 0x8000
 #define PCI_CAN_SWITCH_TYPE 0x10000
+#define PCI_NO_BRIDGES	    0x20000
 
 #define PCI_CONFIG_TYPE_1 1
 #define PCI_CONFIG_TYPE_2 2
@@ -50,6 +51,7 @@ enum {
     PCI_CARD_NORTHBRIDGE = 0,
     PCI_CARD_SOUTHBRIDGE,
     PCI_CARD_NORMAL,
+    PCI_CARD_NORMAL_NOBRIDGE,
     PCI_CARD_ONBOARD,
     PCI_CARD_SCSI,
     PCI_CARD_SOUND,
@@ -76,8 +78,6 @@ typedef union {
 
 extern int	pci_burst_time,
 		pci_nonburst_time;
-extern uint8_t	last_pci_bus;
-extern uint8_t	pci_bus_number_to_index_mapping[256];
 
 
 extern void	pci_set_irq_routing(int pci_int, int irq);
@@ -91,19 +91,21 @@ extern uint8_t	pci_use_mirq(uint8_t mirq);
 extern int	pci_irq_is_level(int irq);
 
 extern void	pci_set_mirq(uint8_t mirq, int level);
-extern void	pci_set_irq(int card, uint8_t pci_int);
+extern void	pci_set_irq(uint8_t card, uint8_t pci_int);
 extern void	pci_clear_mirq(uint8_t mirq, int level);
-extern void	pci_clear_irq(int card, uint8_t pci_int);
-extern uint8_t	pci_get_int(int card, uint8_t pci_int);
+extern void	pci_clear_irq(uint8_t card, uint8_t pci_int);
+extern uint8_t	pci_get_int(uint8_t card, uint8_t pci_int);
 
 extern void	pci_reset(void);
 extern void	pci_init(int type);
+extern uint8_t	pci_register_bus();
+extern void	pci_remap_bus(uint8_t bus_index, uint8_t bus_number);
 extern void	pci_register_slot(int card, int type,
 				  int inta, int intb, int intc, int intd);
 extern void	pci_register_bus_slot(int bus, int card, int type,
 				      int inta, int intb, int intc, int intd);
 extern void	pci_close(void);
-extern int	pci_add_card(uint8_t add_type, uint8_t (*read)(int func, int addr, void *priv), void (*write)(int func, int addr, uint8_t val, void *priv), void *priv);
+extern uint8_t	pci_add_card(uint8_t add_type, uint8_t (*read)(int func, int addr, void *priv), void (*write)(int func, int addr, uint8_t val, void *priv), void *priv);
 
 extern void     trc_init(void);
 

--- a/src/include/86box/pci.h
+++ b/src/include/86box/pci.h
@@ -122,6 +122,9 @@ extern const device_t dec21150_device;
 extern const device_t i440lx_agp_device;
 extern const device_t i440bx_agp_device;
 extern const device_t i440gx_agp_device;
+extern const device_t via_vp3_agp_device;
+extern const device_t via_mvp3_agp_device;
+extern const device_t via_apro_agp_device;
 #endif
 
 

--- a/src/include/86box/pci.h
+++ b/src/include/86box/pci.h
@@ -64,7 +64,8 @@ enum {
     PCI_ADD_VIDEO,
     PCI_ADD_SCSI,
     PCI_ADD_SOUND,
-    PCI_ADD_IDE
+    PCI_ADD_IDE,
+    PCI_ADD_BRIDGE
 };
 
 typedef union {
@@ -75,6 +76,8 @@ typedef union {
 
 extern int	pci_burst_time,
 		pci_nonburst_time;
+extern uint8_t	last_pci_bus;
+extern uint8_t	pci_bus_number_to_index_mapping[256];
 
 
 extern void	pci_set_irq_routing(int pci_int, int irq);
@@ -88,16 +91,19 @@ extern uint8_t	pci_use_mirq(uint8_t mirq);
 extern int	pci_irq_is_level(int irq);
 
 extern void	pci_set_mirq(uint8_t mirq, int level);
-extern void	pci_set_irq(uint8_t card, uint8_t pci_int);
+extern void	pci_set_irq(int card, uint8_t pci_int);
 extern void	pci_clear_mirq(uint8_t mirq, int level);
-extern void	pci_clear_irq(uint8_t card, uint8_t pci_int);
+extern void	pci_clear_irq(int card, uint8_t pci_int);
+extern uint8_t	pci_get_int(int card, uint8_t pci_int);
 
 extern void	pci_reset(void);
 extern void	pci_init(int type);
 extern void	pci_register_slot(int card, int type,
 				  int inta, int intb, int intc, int intd);
+extern void	pci_register_bus_slot(int bus, int card, int type,
+				      int inta, int intb, int intc, int intd);
 extern void	pci_close(void);
-extern uint8_t	pci_add_card(uint8_t add_type, uint8_t (*read)(int func, int addr, void *priv), void (*write)(int func, int addr, uint8_t val, void *priv), void *priv);
+extern int	pci_add_card(uint8_t add_type, uint8_t (*read)(int func, int addr, void *priv), void (*write)(int func, int addr, uint8_t val, void *priv), void *priv);
 
 extern void     trc_init(void);
 
@@ -108,6 +114,15 @@ extern void	pci_elcr_set_enabled(int enabled);
 extern void	pci_elcr_io_disable(void);
 extern void	elcr_write(uint16_t port, uint8_t val, void *priv);
 extern uint8_t	elcr_read(uint16_t port, void *priv);
+
+
+#ifdef EMU_DEVICE_H
+extern const device_t dec21150_device;
+
+extern const device_t i440lx_agp_device;
+extern const device_t i440bx_agp_device;
+extern const device_t i440gx_agp_device;
+#endif
 
 
 #endif	/*EMU_PCI_H*/

--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -23,8 +23,8 @@
 #include <86box/mem.h>
 #include <86box/io.h>
 #include <86box/rom.h>
-#include <86box/pci.h>
 #include <86box/device.h>
+#include <86box/pci.h>
 #include <86box/chipset.h>
 #include <86box/hdc.h>
 #include <86box/hdc_ide.h>
@@ -71,11 +71,11 @@ machine_at_kn97_init(const machine_t *model)
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
     pci_register_slot(0x01, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x0C, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x0B, PCI_CARD_NORMAL, 2, 3, 4, 1);
-    pci_register_slot(0x0A, PCI_CARD_NORMAL, 3, 4, 1, 2);
-    pci_register_slot(0x09, PCI_CARD_NORMAL, 4, 1, 2, 3);
-    pci_register_slot(0x0D, PCI_CARD_NORMAL, 4, 1, 2, 3);
+    pci_register_slot(0x09, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x0C, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x0D, PCI_CARD_NORMAL,      4, 1, 2, 3);
     device_add(&i440fx_device);
     device_add(&piix3_device);
     device_add(&keyboard_ps2_pci_device);
@@ -121,17 +121,18 @@ machine_at_lx6_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x0F, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x0D, PCI_CARD_NORMAL, 2, 3, 4, 1);
-    pci_register_slot(0x0B, PCI_CARD_NORMAL, 3, 4, 1, 2);
-    pci_register_slot(0x09, PCI_CARD_NORMAL, 4, 1, 2, 3);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
+    pci_register_slot(0x09, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x0D, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x0F, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 3, 4);
     device_add(&i440lx_device);
     device_add(&piix4e_device);
     device_add(&keyboard_ps2_pci_device);
     device_add(&w83977tf_device);
     device_add(&sst_flash_29ee010_device);
-	spd_register(SPD_TYPE_SDRAM, 0xF, 256);
+    spd_register(SPD_TYPE_SDRAM, 0xF, 256);
 	
     return ret;
 }
@@ -197,10 +198,10 @@ machine_at_p6i440e2_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x09, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x0A, PCI_CARD_NORMAL, 2, 3, 4, 1);
-    pci_register_slot(0x01, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
+    pci_register_slot(0x09, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 3, 4);
     device_add(&i440ex_device);
     device_add(&piix4_device);
     device_add(&keyboard_ps2_pci_device);
@@ -251,14 +252,14 @@ machine_at_p2bls_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x06, PCI_CARD_NORMAL, 4, 1, 2, 3);
-    pci_register_slot(0x07, PCI_CARD_NORMAL, 3, 4, 1, 2);
-    pci_register_slot(0x0B, PCI_CARD_NORMAL, 2, 3, 4, 1);
-    pci_register_slot(0x0C, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x09, PCI_CARD_NORMAL, 4, 1, 2, 3);
-    pci_register_slot(0x0A, PCI_CARD_NORMAL, 3, 4, 1, 2);
     pci_register_slot(0x04, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
-    pci_register_slot(0x01, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x06, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x07, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x0C, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x09, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 3, 4);
     device_add(&i440bx_device);
     device_add(&piix4e_device);
     device_add(&keyboard_ps2_pci_device);
@@ -309,14 +310,14 @@ machine_at_p3bf_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x09, PCI_CARD_NORMAL, 4, 1, 2, 3);
-    pci_register_slot(0x0A, PCI_CARD_NORMAL, 3, 4, 1, 2);
-    pci_register_slot(0x0B, PCI_CARD_NORMAL, 2, 3, 4, 1);
-    pci_register_slot(0x0C, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x0D, PCI_CARD_NORMAL, 4, 1, 2, 3);
-    pci_register_slot(0x0E, PCI_CARD_NORMAL, 3, 4, 1, 2);
     pci_register_slot(0x04, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
-    pci_register_slot(0x01, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x09, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x0C, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x0D, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x0E, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 3, 4);
     device_add(&i440bx_device);
     device_add(&piix4e_device);
     device_add(&keyboard_ps2_pci_device);
@@ -369,15 +370,15 @@ machine_at_bf6_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x13, PCI_CARD_NORMAL,      3, 3, 1, 2);
-    pci_register_slot(0x11, PCI_CARD_NORMAL,      1, 2, 3, 4);
-    pci_register_slot(0x0F, PCI_CARD_NORMAL,      2, 3, 4, 1);
-    pci_register_slot(0x0D, PCI_CARD_NORMAL,      3, 4, 1, 2);
-    pci_register_slot(0x0B, PCI_CARD_NORMAL,      4, 1, 2, 3);
-    pci_register_slot(0x09, PCI_CARD_NORMAL,      2, 1, 4, 3);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
     pci_register_slot(0x08, PCI_CARD_NORMAL,      3, 4, 1, 2);
-    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);    
-    pci_register_slot(0x01, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x09, PCI_CARD_NORMAL,      2, 1, 4, 3);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x11, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x0D, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x0F, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x13, PCI_CARD_NORMAL,      3, 3, 1, 2);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 3, 4);
     device_add(&i440bx_device);
     device_add(&piix4e_device);
     device_add(&keyboard_ps2_pci_device);
@@ -404,13 +405,13 @@ machine_at_ax6bc_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x0C, PCI_CARD_NORMAL,      1, 2, 3, 4);
-    pci_register_slot(0x0B, PCI_CARD_NORMAL,      2, 3, 4, 1);
-    pci_register_slot(0x0A, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
     pci_register_slot(0x09, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x0C, PCI_CARD_NORMAL,      1, 2, 3, 4);
     pci_register_slot(0x0D, PCI_CARD_NORMAL,      4, 1, 2, 3);
-    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);    
-    pci_register_slot(0x01, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 3, 4);
     device_add(&i440bx_device);
     device_add(&piix4e_device);
     device_add(&keyboard_ps2_pci_device);
@@ -454,13 +455,13 @@ machine_at_atc6310bxii_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x0B, PCI_CARD_NORMAL, 2, 3, 4, 1);
-    pci_register_slot(0x0C, PCI_CARD_NORMAL, 3, 4, 1, 2);
-    pci_register_slot(0x0D, PCI_CARD_NORMAL, 4, 1, 2, 3);
-    pci_register_slot(0x0A, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x0E, PCI_CARD_NORMAL, 4, 1, 2, 3);
     pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
-    pci_register_slot(0x01, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x0C, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x0D, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x0E, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 3, 4);
     device_add(&i440bx_device);
     device_add(&slc90e66_device);
     device_add(&keyboard_ps2_pci_device);
@@ -488,13 +489,13 @@ machine_at_p6sba_init(const machine_t *model)
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
     pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
-    pci_register_slot(0x0F, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x10, PCI_CARD_NORMAL, 2, 3, 4, 1);
-    pci_register_slot(0x12, PCI_CARD_NORMAL, 3, 4, 1, 2);
-    pci_register_slot(0x14, PCI_CARD_NORMAL, 4, 1, 2, 3);
-    pci_register_slot(0x0E, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x01, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x0D, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x0F, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x10, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x12, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x14, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x0E, PCI_CARD_NORMAL,      3, 4, 0, 0);
+    pci_register_slot(0x0D, PCI_CARD_NORMAL,      3, 0, 0, 0);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 0, 0);
     device_add(&i440bx_device);
     device_add(&piix4e_device);
     device_add(&w83977tf_device);
@@ -545,14 +546,14 @@ machine_at_tsunamiatx_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
     pci_register_slot(0x0F, PCI_CARD_SOUND,       1, 0, 0, 0);
     pci_register_slot(0x10, PCI_CARD_NORMAL,      1, 2, 3, 4);
     pci_register_slot(0x11, PCI_CARD_NORMAL,      2, 3, 4, 1);
     pci_register_slot(0x12, PCI_CARD_NORMAL,      3, 4, 1, 2);
     pci_register_slot(0x13, PCI_CARD_NORMAL,      4, 1, 2, 3);
     pci_register_slot(0x14, PCI_CARD_NORMAL,      1, 2, 3, 4);
-    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
-    pci_register_slot(0x01, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 3, 4);
     device_add(&i440bx_device);
     device_add(&piix4e_device);
 

--- a/src/machine/m_at_slot2.c
+++ b/src/machine/m_at_slot2.c
@@ -54,12 +54,12 @@ machine_at_6gxu_init(const machine_t *model)
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
     pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
-    pci_register_slot(0x08, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x09, PCI_CARD_NORMAL, 2, 3, 4, 1);
-    pci_register_slot(0x0A, PCI_CARD_NORMAL, 3, 4, 1, 2);
-    pci_register_slot(0x0B, PCI_CARD_NORMAL, 4, 1, 2, 3);
-    pci_register_slot(0x0C, PCI_CARD_NORMAL, 1, 2, 3, 4); /* On-Board SCSI. Not emulated at the moment */
-    pci_register_slot(0x01, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x08, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x09, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x0C, PCI_CARD_NORMAL,      1, 2, 3, 4); /* On-Board SCSI. Not emulated at the moment */
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 3, 4);
 
     device_add(&i440gx_device);
     device_add(&piix4e_device);
@@ -110,14 +110,14 @@ machine_at_s2dge_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
-    pci_register_slot(0x0F, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x10, PCI_CARD_NORMAL, 2, 3, 4, 1);
-    pci_register_slot(0x12, PCI_CARD_NORMAL, 3, 4, 1, 2);
-    pci_register_slot(0x14, PCI_CARD_NORMAL, 4, 1, 2, 3);
-    pci_register_slot(0x0E, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x01, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x0D, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 0, 0);
+    pci_register_slot(0x0F, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x10, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x12, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x14, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x0D, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x0E, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 0, 0);
 
     device_add(&i440gx_device);
     device_add(&piix4e_device);
@@ -169,13 +169,13 @@ machine_at_fw6400gx_init(const machine_t *model)
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
     pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 4);
-    pci_register_slot(0x0A, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x0B, PCI_CARD_NORMAL, 2, 3, 4, 1);
-    pci_register_slot(0x0C, PCI_CARD_NORMAL, 3, 4, 1, 2);
-    pci_register_slot(0x0D, PCI_CARD_NORMAL, 4, 1, 2, 3);
-    pci_register_slot(0x0E, PCI_CARD_NORMAL, 4, 1, 2, 3);
-    pci_register_slot(0x0F, PCI_CARD_NORMAL, 4, 1, 2, 3);
-    pci_register_slot(0x01, PCI_CARD_NORMAL, 1, 2, 0, 0);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x0C, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x0D, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x0E, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x0F, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 0, 0);
 
     device_add(&i440gx_device);
     device_add(&piix4e_device);

--- a/src/machine/m_at_socket370.c
+++ b/src/machine/m_at_socket370.c
@@ -53,13 +53,11 @@ machine_at_s370slm_init(const machine_t *model)
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
     pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
-    pci_register_slot(0x0F, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x10, PCI_CARD_NORMAL, 2, 3, 4, 1);
-    pci_register_slot(0x12, PCI_CARD_NORMAL, 3, 4, 1, 2);
-    pci_register_slot(0x14, PCI_CARD_NORMAL, 4, 1, 2, 3);
-    pci_register_slot(0x0E, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x01, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x0D, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x0F, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x10, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x12, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x14, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 3, 4);
     device_add(&i440lx_device);
     device_add(&piix4e_device);
     device_add(&w83977tf_device);
@@ -107,14 +105,14 @@ machine_at_cubx_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x09, PCI_CARD_NORMAL, 4, 1, 2, 3);
-    pci_register_slot(0x0A, PCI_CARD_NORMAL, 3, 4, 1, 2);
-    pci_register_slot(0x0B, PCI_CARD_NORMAL, 2, 3, 4, 1);
-    pci_register_slot(0x0C, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x0D, PCI_CARD_NORMAL, 4, 1, 2, 3);
-    pci_register_slot(0x0E, PCI_CARD_NORMAL, 3, 4, 1, 2);
     pci_register_slot(0x04, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
-    pci_register_slot(0x01, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x09, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x0C, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x0D, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x0E, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 3, 4);
     device_add(&i440bx_device);
     device_add(&piix4e_device);
     device_add(&keyboard_ps2_pci_device);
@@ -162,13 +160,13 @@ machine_at_atc7020bxii_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x0B, PCI_CARD_NORMAL, 2, 3, 4, 1);
-    pci_register_slot(0x0C, PCI_CARD_NORMAL, 3, 4, 1, 2);
-    pci_register_slot(0x0D, PCI_CARD_NORMAL, 4, 1, 2, 3);
-    pci_register_slot(0x0A, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x0E, PCI_CARD_NORMAL, 4, 1, 2, 3);
     pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
-    pci_register_slot(0x01, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x0C, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x0D, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x0E, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 3, 4);
     device_add(&i440bx_device);
     device_add(&slc90e66_device);
     device_add(&keyboard_ps2_pci_device);
@@ -194,13 +192,13 @@ machine_at_ambx133_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
     pci_register_slot(0x09, PCI_CARD_NORMAL, 	  1, 2, 3, 4);
     pci_register_slot(0x0A, PCI_CARD_NORMAL, 	  2, 3, 4, 1);
     pci_register_slot(0x0B, PCI_CARD_NORMAL, 	  3, 4, 1, 2);
     pci_register_slot(0x0C, PCI_CARD_NORMAL, 	  4, 1, 2, 3);
     pci_register_slot(0x0D, PCI_CARD_NORMAL, 	  4, 1, 2, 3);
-    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
-    pci_register_slot(0x01, PCI_CARD_NORMAL, 	  1, 2, 3, 4);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL, 	  1, 2, 3, 4);
     device_add(&i440bx_device);
     device_add(&piix4e_device);
     device_add(&w83977ef_device);
@@ -226,13 +224,13 @@ machine_at_awo671r_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
     pci_register_slot(0x09, PCI_CARD_NORMAL, 	  1, 2, 3, 4);
     pci_register_slot(0x0A, PCI_CARD_NORMAL, 	  2, 3, 4, 1);
     pci_register_slot(0x0B, PCI_CARD_NORMAL, 	  3, 4, 1, 2);
     pci_register_slot(0x0C, PCI_CARD_NORMAL, 	  4, 1, 2, 3);
     pci_register_slot(0x0D, PCI_CARD_NORMAL, 	  2, 3, 4, 1);
-    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
-    pci_register_slot(0x01, PCI_CARD_NORMAL, 	  1, 2, 3, 4);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 3, 4);
     device_add(&i440bx_device);
     device_add(&piix4e_device);
     device_add_inst(&w83977ef_device, 1);
@@ -259,13 +257,13 @@ machine_at_63a_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
     pci_register_slot(0x08, PCI_CARD_NORMAL, 	  1, 2, 3, 4);
     pci_register_slot(0x09, PCI_CARD_NORMAL, 	  2, 3, 4, 1);
     pci_register_slot(0x0A, PCI_CARD_NORMAL, 	  3, 4, 1, 2);
     pci_register_slot(0x0B, PCI_CARD_NORMAL, 	  4, 1, 2, 3);
-    pci_register_slot(0x0C, PCI_CARD_NORMAL, 	  1, 2, 3, 4); // Integrated Sound?
-    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
-    pci_register_slot(0x01, PCI_CARD_NORMAL, 	  1, 2, 3, 4);
+    pci_register_slot(0x0C, PCI_CARD_NORMAL, 	  1, 2, 3, 4); /* Integrated Sound? */
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 3, 4);
     device_add(&i440zx_device);
     device_add(&piix4e_device);
     device_add(&w83977tf_device);
@@ -292,12 +290,12 @@ machine_at_apas3_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 0, 0);
     pci_register_slot(0x0F, PCI_CARD_NORMAL,      1, 2, 3, 4);
     pci_register_slot(0x10, PCI_CARD_NORMAL,      2, 3, 4, 1);
     pci_register_slot(0x13, PCI_CARD_NORMAL,      3, 4, 1, 2);
     pci_register_slot(0x14, PCI_CARD_NORMAL,      4, 1, 2, 3);
-    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
-    pci_register_slot(0x01, PCI_CARD_NORMAL, 	  1, 2, 3, 4);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 3, 4);
     device_add(&via_apro_device);
     device_add(&via_vt82c586b_device);
     device_add(&fdc37c669_device);

--- a/src/machine/m_at_socket7_s7.c
+++ b/src/machine/m_at_socket7_s7.c
@@ -1064,11 +1064,13 @@ machine_at_ficpa2012_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x08, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x09, PCI_CARD_NORMAL, 2, 3, 4, 1);
-    pci_register_slot(0x0A, PCI_CARD_NORMAL, 3, 4, 1, 2);
-    pci_register_slot(0x0B, PCI_CARD_NORMAL, 4, 1, 2, 3);
     pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
+    pci_register_slot(0x08, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x09, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 3, 4);
+
     device_add(&via_vp3_device);
     device_add(&via_vt82c586b_device);
     device_add(&keyboard_ps2_pci_device);

--- a/src/machine/m_at_sockets7.c
+++ b/src/machine/m_at_sockets7.c
@@ -41,6 +41,7 @@
 #include "cpu.h"
 #include <86box/machine.h>
 
+
 int
 machine_at_ax59pro_init(const machine_t *model)
 {
@@ -56,12 +57,13 @@ machine_at_ax59pro_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x0C, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x0B, PCI_CARD_NORMAL, 2, 3, 4, 1);
-    pci_register_slot(0x0A, PCI_CARD_NORMAL, 3, 4, 1, 2);
-    pci_register_slot(0x09, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
-    pci_register_slot(0x01, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 0, 0);
+    pci_register_slot(0x09, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x0C, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 3, 4);
+
     device_add(&via_mvp3_device);
     device_add(&via_vt82c586b_device);
     device_add(&keyboard_ps2_pci_device);
@@ -88,11 +90,12 @@ machine_at_mvp3_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x08, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x09, PCI_CARD_NORMAL, 2, 3, 4, 1);
-    pci_register_slot(0x0A, PCI_CARD_NORMAL, 3, 4, 1, 2);
-    pci_register_slot(0x01, PCI_CARD_NORMAL, 1, 2, 3, 4);
     pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
+    pci_register_slot(0x08, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x09, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 3, 4);
+
     device_add(&via_mvp3_device);
     device_add(&via_vt82c586b_device);
     device_add(&keyboard_ps2_pci_device);

--- a/src/win/86Box.rc
+++ b/src/win/86Box.rc
@@ -990,7 +990,7 @@ BEGIN
     IDS_2122	"Discard changes\nAll changes made to the settings will be lost."
     IDS_2123	"Cancel\nGo back to the Settings window."
     IDS_2124	"About 86Box"
-    IDS_2125	"86Box v2.10"
+    IDS_2125	"86Box v" EMU_VERSION
     IDS_2126	"An emulator of old computers\n\nAuthors: Sarah Walker, Miran Grca, Fred N. van Kempen (waltje), SA1988, MoochMcGee, reenigne, leilei, JohnElliott, greatpsycho, and others.\n\nReleased under the GNU General Public License version 2. See LICENSE for more information."
     IDS_2127	"OK"
     IDS_2128	"Hardware not available"

--- a/src/win/Makefile.mingw
+++ b/src/win/Makefile.mingw
@@ -660,7 +660,7 @@ MCHOBJ		:= machine.o machine_table.o \
 		    m_at_socket8.o m_at_slot1.o m_at_slot2.o m_at_socket370.o \
 			m_at_misc.o
 
-DEVOBJ		:= bugger.o hwm.o hwm_lm75.o hwm_lm78.o hwm_gl518sm.o ibm_5161.o isamem.o isartc.o lpt.o postcard.o serial.o vpc2007.o \
+DEVOBJ		:= bugger.o hwm.o hwm_lm75.o hwm_lm78.o hwm_gl518sm.o ibm_5161.o isamem.o isartc.o lpt.o pci_bridge.o postcard.o serial.o vpc2007.o \
 		    smbus.o smbus_piix4.o \
 		   keyboard.o \
 		    keyboard_xt.o keyboard_at.o \


### PR DESCRIPTION
This adds:

* Support for multiple PCI bus numbers in `pci.c`
* Emulation of the DEC/Intel 21150 PCI bridge (9 bus masters, so 9 children)
* Automatic insertion of a 21150 PCI bridge upon reaching the last NORMAL slot (never run out of slots)
* Proper emulation of AGP bridges on Intel and VIA chipsets
* A few IRQ steering fixes on AGP machines

Notes:

* The meaning of the `pci_add_card` return value has changed to accomodate for multiple bus numbers. The data type and usage haven't changed.
* Having a PCI device on the AGP bridge is legal at least on Intel platforms. See the Intel C440GX+ motherboard which uses a 21150 bridge attached to the AGP bus providing 66 MHz PCI slots.
* On the other hand, VIA AGP bridges accept PCI devices but not PCI bridges ("not enough resources..."), so the PCI slot on VIA AGP bridges is given a special flag to prevent the automatic 21150 from reaching it. Some VIA machines also don't have IRQ steering table entries for the AGP slot (???)
* Some devices may not like sitting behind bridges. ES1371 gameport is one of them. Can be fixed with a `pci.c` overhaul, as there is no clean way of rearranging PCI cards right now.
* If the amount of PCI devices matches the amount of PCI slots, the last device will be alone behind a 21150 bridge. Not a big deal but can be fixed with a `pci.c` overhaul.
* Additionally, having just enough PCI devices may result in an empty 21150 bridge being added on VIA AGP systems, due to the no-bridges quirk on the VIA AGP bridges. Same as above, not a big deal but can be fixed with a `pci.c` overhaul.
* The PCI_NO_BRIDGES machine PCI type flag disables the automatic 21150 bridge system. It's present just in case there's some BIOS out there that can't handle bridges properly.