### PR TITLE
Undo anabate's VIA C3 changes entirely

### DIFF
--- a/src/cpu/cpu_table.c
+++ b/src/cpu/cpu_table.c
@@ -856,13 +856,10 @@ CPU cpus_Cyrix3[] = {
     {"Cyrix III 350", CPU_CYRIX3S, fpus_internal, 350000000, 3.5,   0x660, 0x660, 0, CPU_SUPPORTS_DYNAREC, 32, 32, 11, 11, 42},
     {"Cyrix III 400", CPU_CYRIX3S, fpus_internal, 400000000, 4.0,   0x660, 0x660, 0, CPU_SUPPORTS_DYNAREC, 36, 36, 12, 12, 48},
     {"Cyrix III 450", CPU_CYRIX3S, fpus_internal, 450000000, 4.5,   0x660, 0x660, 0, CPU_SUPPORTS_DYNAREC, 41, 41, 14, 14, 54}, /*^ is lower P2 speeds to allow emulation below 466 mhz*/
-    {"Cyrix III 466", CPU_CYRIX3S, fpus_internal, 466666666, 3.5,   0x660, 0x660, 0, CPU_SUPPORTS_DYNAREC, 42, 42, 14, 14, 56},
     {"Cyrix III 500", CPU_CYRIX3S, fpus_internal, 500000000, 5.0,   0x660, 0x660, 0, CPU_SUPPORTS_DYNAREC, 45, 45, 15, 15, 60},
-    {"Cyrix III 533", CPU_CYRIX3S, fpus_internal, 533333333, 4.0,   0x660, 0x660, 0, CPU_SUPPORTS_DYNAREC, 48, 48, 17, 17, 64},
     {"Cyrix III 550", CPU_CYRIX3S, fpus_internal, 550000000, 5.5,   0x662, 0x662, 0, CPU_SUPPORTS_DYNAREC, 50, 50, 17, 17, 66},
     {"Cyrix III 600", CPU_CYRIX3S, fpus_internal, 600000000, 6.0,   0x662, 0x662, 0, CPU_SUPPORTS_DYNAREC, 54, 54, 18, 18, 72},
     {"Cyrix III 650", CPU_CYRIX3S, fpus_internal, 650000000, 6.5,   0x662, 0x662, 0, CPU_SUPPORTS_DYNAREC, 58, 58, 20, 20, 78},
-    {"Cyrix III 667", CPU_CYRIX3S, fpus_internal, 666666666, 5.0,   0x662, 0x662, 0, CPU_SUPPORTS_DYNAREC, 60, 60, 21, 21, 81},
     {"Cyrix III 700", CPU_CYRIX3S, fpus_internal, 700000000, 7.0,   0x662, 0x662, 0, CPU_SUPPORTS_DYNAREC, 62, 62, 21, 21, 84},
     {"",                       -1,         0, 0.0,       0,     0, 0, 0,                    0,   0, 0,  0,  0}
 };


### PR DESCRIPTION
There are no emulated chipsets which officially support 133 MHz FSB.