### PR TITLE
Fix PostScript printer

### DIFF
--- a/src/device/smbus_piix4.c
+++ b/src/device/smbus_piix4.c
@@ -39,9 +39,9 @@ smbus_piix4_log(const char *fmt, ...)
     va_list ap;
 
     if (smbus_piix4_do_log) {
-    	va_start(ap, fmt);
-    	pclog_ex(fmt, ap);
-    	va_end(ap);
+	va_start(ap, fmt);
+	pclog_ex(fmt, ap);
+	va_end(ap);
     }
 }
 #else
@@ -56,30 +56,30 @@ smbus_piix4_read(uint16_t addr, void *priv)
     uint8_t ret = 0x00;
 
     switch (addr - dev->io_base) {
-    	case 0x00:
-    		ret = dev->stat;
-    		break;
-    	case 0x02:
-    		dev->index = 0; /* reading from this resets the block data index */
-    		ret = dev->ctl;
-    		break;
-    	case 0x03:
-    		ret = dev->cmd;
-    		break;
-    	case 0x04:
-    		ret = dev->addr;
-    		break;
-    	case 0x05:
-    		ret = dev->data0;
-    		break;
-    	case 0x06:
-    		ret = dev->data1;
-    		break;
-    	case 0x07:
-    		ret = dev->data[dev->index++];
-    		if (dev->index >= SMBUS_PIIX4_BLOCK_DATA_SIZE)
-    			dev->index = 0;
-    		break;
+	case 0x00:
+		ret = dev->stat;
+		break;
+	case 0x02:
+		dev->index = 0; /* reading from this resets the block data index */
+		ret = dev->ctl;
+		break;
+	case 0x03:
+		ret = dev->cmd;
+		break;
+	case 0x04:
+		ret = dev->addr;
+		break;
+	case 0x05:
+		ret = dev->data0;
+		break;
+	case 0x06:
+		ret = dev->data1;
+		break;
+	case 0x07:
+		ret = dev->data[dev->index++];
+		if (dev->index >= SMBUS_PIIX4_BLOCK_DATA_SIZE)
+			dev->index = 0;
+		break;
     }
 
     smbus_piix4_log("SMBus PIIX4: read(%02x) = %02x\n", addr, ret);
@@ -100,99 +100,100 @@ smbus_piix4_write(uint16_t addr, uint8_t val, void *priv)
     prev_stat = dev->next_stat;
     dev->next_stat = 0;
     switch (addr - dev->io_base) {
-    	case 0x00:
-    		/* some status bits are reset by writing 1 to them */
-    		for (smbus_addr = 0x02; smbus_addr <= 0x10; smbus_addr <<= 1) {
-    			if (val & smbus_addr)
-    				dev->stat &= ~smbus_addr;
-    		}
-    		break;
-    	case 0x02:
-    		dev->ctl = val & ~(0x40); /* START always reads 0 */
-    		if (val & 0x02) { /* cancel an in-progress command if KILL is set */
-    			/* cancel only if a command is in progress */
-    			if (prev_stat) {
-    				dev->stat = 0x10; /* raise FAILED */
-    				timer_disable(&dev->response_timer);
-    			}
-    		}
-    		if (val & 0x40) { /* dispatch command if START is set */
-    			smbus_addr = (dev->addr >> 1);
-    			if (!smbus_has_device(smbus_addr)) {
-    				/* raise DEV_ERR if no device is at this address */
-    				dev->next_stat = 0x4;
-    				break;
-    			}
-    			smbus_read = (dev->addr & 0x01);
+	case 0x00:
+		/* some status bits are reset by writing 1 to them */
+		for (smbus_addr = 0x02; smbus_addr <= 0x10; smbus_addr <<= 1) {
+			if (val & smbus_addr)
+				dev->stat &= ~smbus_addr;
+		}
+		break;
+	case 0x02:
+		dev->ctl = val & ~(0x40); /* START always reads 0 */
+		if (val & 0x02) { /* cancel an in-progress command if KILL is set */
+			/* cancel only if a command is in progress */
+			if (prev_stat) {
+				dev->stat = 0x10; /* raise FAILED */
+				timer_disable(&dev->response_timer);
+			}
+		}
+		if (val & 0x40) { /* dispatch command if START is set */
+			smbus_addr = (dev->addr >> 1);
+			if (!smbus_has_device(smbus_addr)) {
+				/* raise DEV_ERR if no device is at this address */
+				dev->next_stat = 0x4;
+				break;
+			}
+			smbus_read = (dev->addr & 0x01);
 
-    			/* decode the 3-bit command protocol */
-    			switch ((val >> 2) & 0x7) {
-    				case 0x0: /* quick R/W */
-    					dev->next_stat = 0x2;
-    					break;
-    				case 0x1: /* byte R/W */
-    					if (smbus_read)
-    						dev->data0 = smbus_read_byte(smbus_addr);
-    					else
-    						smbus_write_byte(smbus_addr, dev->data0);
-    					dev->next_stat = 0x2;
-    					break;
-    				case 0x2: /* byte data R/W */
-    					if (smbus_read)
-    						dev->data0 = smbus_read_byte_cmd(smbus_addr, dev->cmd);
-    					else
-    						smbus_write_byte_cmd(smbus_addr, dev->cmd, dev->data0);
-    					dev->next_stat = 0x2;
-    					break;
-    				case 0x3: /* word data R/W */
-    					if (smbus_read) {
-    						temp = smbus_read_word_cmd(smbus_addr, dev->cmd);
-    						dev->data0 = (temp & 0xFF);
-    						dev->data1 = (temp >> 8);
-    					} else {
-    						temp = ((dev->data1 << 8) | dev->data0);
-    						smbus_write_word_cmd(smbus_addr, dev->cmd, temp);
-    					}
-    					dev->next_stat = 0x2;
-    					break;
-    				case 0x5: /* block R/W */
-    					if (smbus_read)
-    						dev->data0 = smbus_read_block_cmd(smbus_addr, dev->cmd, dev->data, SMBUS_PIIX4_BLOCK_DATA_SIZE);
-    					else
-    						smbus_write_block_cmd(smbus_addr, dev->cmd, dev->data, dev->data0);
-    					dev->next_stat = 0x2;
-    					break;
-    				default:
-    					/* other command protocols have undefined behavior, but raise DEV_ERR to be safe */
-    					dev->next_stat = 0x4;
-    					break;
-    			}
-    		}
-    		break;
-    	case 0x03:
-    		dev->cmd = val;
-    		break;
-    	case 0x04:
-    		dev->addr = val;
-    		break;
-    	case 0x05:
-    		dev->data0 = val;
-    		break;
-    	case 0x06:
-    		dev->data1 = val;
-    		break;
-    	case 0x07:
-    		dev->data[dev->index++] = val;
-    		if (dev->index >= SMBUS_PIIX4_BLOCK_DATA_SIZE)
-    			dev->index = 0;
-    		break;
+			/* decode the 3-bit command protocol */
+			dev->next_stat = 0x2; /* raise INTER (command completed) by default */
+			switch ((val >> 2) & 0x7) {
+				case 0x0: /* quick R/W */
+					break;
+
+				case 0x1: /* byte R/W */
+					if (smbus_read)
+						dev->data0 = smbus_read_byte(smbus_addr);
+					else
+						smbus_write_byte(smbus_addr, dev->data0);
+					break;
+
+				case 0x2: /* byte data R/W */
+					if (smbus_read)
+						dev->data0 = smbus_read_byte_cmd(smbus_addr, dev->cmd);
+					else
+						smbus_write_byte_cmd(smbus_addr, dev->cmd, dev->data0);
+					break;
+
+				case 0x3: /* word data R/W */
+					if (smbus_read) {
+						temp = smbus_read_word_cmd(smbus_addr, dev->cmd);
+						dev->data0 = (temp & 0xFF);
+						dev->data1 = (temp >> 8);
+					} else {
+						temp = ((dev->data1 << 8) | dev->data0);
+						smbus_write_word_cmd(smbus_addr, dev->cmd, temp);
+					}
+					break;
+
+				case 0x5: /* block R/W */
+					if (smbus_read)
+						dev->data0 = smbus_read_block_cmd(smbus_addr, dev->cmd, dev->data, SMBUS_PIIX4_BLOCK_DATA_SIZE);
+					else
+						smbus_write_block_cmd(smbus_addr, dev->cmd, dev->data, dev->data0);
+					break;
+
+				default:
+					/* other command protocols have undefined behavior, but raise DEV_ERR to be safe */
+					dev->next_stat = 0x4;
+					break;
+			}
+		}
+		break;
+	case 0x03:
+		dev->cmd = val;
+		break;
+	case 0x04:
+		dev->addr = val;
+		break;
+	case 0x05:
+		dev->data0 = val;
+		break;
+	case 0x06:
+		dev->data1 = val;
+		break;
+	case 0x07:
+		dev->data[dev->index++] = val;
+		if (dev->index >= SMBUS_PIIX4_BLOCK_DATA_SIZE)
+			dev->index = 0;
+		break;
     }
 
     /* if a status register update was given, dispatch it after 10ms to ensure nothing breaks */
     if (dev->next_stat) {
-    	dev->stat = 0x1; /* raise HOST_BUSY while waiting */
-    	timer_disable(&dev->response_timer);
-    	timer_set_delay_u64(&dev->response_timer, 10 * TIMER_USEC);
+	dev->stat = 0x1; /* raise HOST_BUSY while waiting */
+	timer_disable(&dev->response_timer);
+	timer_set_delay_u64(&dev->response_timer, 10 * TIMER_USEC);
     }
 }
 
@@ -210,13 +211,13 @@ smbus_piix4_response(void *priv)
 void
 smbus_piix4_remap(smbus_piix4_t *dev, uint16_t new_io_base, uint8_t enable)
 {
-    if (dev->io_base != 0x0000)
+    if (dev->io_base)
 	io_removehandler(dev->io_base, 0x10, smbus_piix4_read, NULL, NULL, smbus_piix4_write, NULL, NULL, dev);
 
     dev->io_base = new_io_base;
-    smbus_piix4_log("SMBus PIIX4: remap to %04Xh (enable %d)\n", dev->io_base, !!enable);
+    smbus_piix4_log("SMBus PIIX4: remap to %04Xh (%sabled)\n", dev->io_base, enable ? "en" : "dis");
 
-    if ((enable) && (dev->io_base != 0x0000))
+    if (enable && dev->io_base)
 	io_sethandler(dev->io_base, 0x10, smbus_piix4_read, NULL, NULL, smbus_piix4_write, NULL, NULL, dev);
 }
 

--- a/src/printer/prt_ps.c
+++ b/src/printer/prt_ps.c
@@ -184,7 +184,7 @@ convert_to_pdf(ps_t *dev)
 
 
 static void
-write_buffer(ps_t *dev, bool newline)
+write_buffer(ps_t *dev, bool finish)
 {
     wchar_t path[1024];
     FILE *fp;
@@ -205,17 +205,19 @@ write_buffer(ps_t *dev, bool newline)
 
     fseek(fp, 0, SEEK_END);
 
-    fprintf(fp, "%.*s%s", POSTSCRIPT_BUFFER_LENGTH, dev->buffer, newline ? "\n" : "");
+    fprintf(fp, "%.*s", POSTSCRIPT_BUFFER_LENGTH, dev->buffer);
 
     fclose(fp);
 
     dev->buffer[0] = 0;
     dev->buffer_pos = 0;
 
-    if (ghostscript_handle != NULL)
-	convert_to_pdf(dev);
+    if (finish) {
+	if (ghostscript_handle != NULL)
+		convert_to_pdf(dev);
 
-    dev->filename[0] = 0;
+	dev->filename[0] = 0;
+    }
 }
 
 
@@ -224,7 +226,7 @@ timeout_timer(void *priv)
 {
     ps_t *dev = (ps_t *) priv;
 
-    write_buffer(dev, false);
+    write_buffer(dev, true);
 
     timer_disable(&dev->timeout_timer);
 }
@@ -263,7 +265,7 @@ process_data(ps_t *dev)
 
 		/* Ctrl+D (0x04) marks the end of the document */
 		case '\4':
-			write_buffer(dev, false);
+			write_buffer(dev, true);
 			return;
 
 		/* Don't bother with the others */
@@ -376,7 +378,7 @@ ps_close(void *p)
 	return;
 
     if (dev->buffer[0] != 0)
-	write_buffer(dev, false);
+	write_buffer(dev, true);
 
     if (ghostscript_handle != NULL) {
 	dynld_close(ghostscript_handle);


### PR DESCRIPTION
The PostScript printer code was ending the document upon reaching 64k of PostScript data, instead of just flushing to the temporary file.