### PR TITLE
Small non-critical changes to networking

### DIFF
--- a/src/chipset/via_pipc.c
+++ b/src/chipset/via_pipc.c
@@ -466,7 +466,7 @@ pipc_write(int func, int addr, uint8_t val, void *priv)
     if (func == 0) { /* PCI-ISA bridge */
 	/* Read-only addresses */
 	if ((addr < 4) || (addr == 5) || ((addr >= 8) && (addr < 0x40)) || (addr == 0x49) || (addr == 0x4b) ||
-	    (addr == 0x53) || ((addr >= 0x5d) && (addr < 0x5f)) || ((addr >= 0x71) && (addr < 0x74)) || (addr >= 0x90))
+	    (addr == 0x53) || ((addr >= 0x5d) && (addr < 0x5f)) || (addr >= 0x90))
 		return;
 
 	if ((dev->local <= VIA_PIPC_586A) && ((addr >= 0x58) && (addr < 0x80)))

--- a/src/network/net_plip.c
+++ b/src/network/net_plip.c
@@ -117,6 +117,8 @@ timeout_timer(void *priv)
 	dev->rx_pkt = NULL;
     }
 
+    network_rx_pause = 0;
+
     timer_disable(&dev->timeout_timer);
 }
 

--- a/src/network/net_slirp.c
+++ b/src/network/net_slirp.c
@@ -331,7 +331,7 @@ poll_thread(void *arg)
     char key[20];
     while (1) {
 	sprintf(key, "%d_protocol", i);
-	udp = strncmp(config_get_string(category, key, "tcp"), "udp", -1) == 0;
+	udp = strcmp(config_get_string(category, key, "tcp"), "udp") == 0;
 	sprintf(key, "%d_external", i);
 	external = config_get_int(category, key, 0);
 	sprintf(key, "%d_internal", i);


### PR DESCRIPTION
* SLiRP forward protocol should be compared using regular strcmp
* Unpause network RX queue on PLIP timeout
* Improve thread safety and add safeguards to the network packet dumping code
* (unrelated) Fix VIA ISA bridge subsystem ID write