### PR TITLE
Replace FIC KA-6100 with KA-6130

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -457,7 +457,7 @@ extern int	machine_at_ax6bc_init(const machine_t *);
 extern int	machine_at_atc6310bxii_init(const machine_t *);
 extern int	machine_at_tsunamiatx_init(const machine_t *);
 extern int	machine_at_p6sba_init(const machine_t *);
-extern int	machine_at_ficka6100_init(const machine_t *);
+extern int	machine_at_ficka6130_init(const machine_t *);
 
 #ifdef EMU_DEVICE_H
 extern const device_t 	*at_tsunamiatx_get_device(void);

--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -577,12 +577,12 @@ at_tsunamiatx_get_device(void)
 
 
 int
-machine_at_ficka6100_init(const machine_t *model)
+machine_at_ficka6130_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ficka6100/610011ex.bin",
-			   0x000e0000, 131072, 0);
+    ret = bios_load_linear(L"roms/machines/ficka6130/qa4163.bin",
+			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
 	  return ret;
@@ -591,16 +591,17 @@ machine_at_ficka6100_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 0, 4);
-    pci_register_slot(0x08, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 4);
+    pci_register_slot(0x08, PCI_CARD_NORMAL,      1, 2, 3, 4);
     pci_register_slot(0x09, PCI_CARD_NORMAL,      2, 3, 4, 1);
     pci_register_slot(0x0A, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL,      4, 1, 2, 3);
     pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 3, 4);
     device_add(&via_apro_device);
     device_add(&via_vt82c596_device);
     device_add(&w83877tf_device);
     device_add(&keyboard_ps2_ami_pci_device);
-    device_add(&sst_flash_29ee010_device);
+    device_add(&sst_flash_29ee020_device);
     spd_register(SPD_TYPE_SDRAM, 0x7, 256);
 
     return ret;

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -376,7 +376,7 @@ const machine_t machines[] = {
     { "[i440GX] Freeway FW-6400GX",		"fw6400gx_s1",		MACHINE_TYPE_SLOT1,		{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"", NULL},	  {"",      NULL}}, MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,				 16, 2032,  16, 511,	     machine_at_fw6400gx_init, NULL			},
 
     /* VIA Apollo Pro */
-    { "[VIA Apollo Pro] FIC KA-6100",		"ficka6100",		MACHINE_TYPE_SLOT1,		{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"", NULL},	  {"",      NULL}}, MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	 			  8,  768,   8, 255,	    machine_at_ficka6100_init, NULL			},
+    { "[VIA Apollo Pro] FIC KA-6130",		"ficka6130",		MACHINE_TYPE_SLOT1,		{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"", NULL},	  {"",      NULL}}, MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	 			  8,  512,   8, 255,	    machine_at_ficka6130_init, NULL			},
 
     /* Slot 2 machines(Including Slot 1/2 Hybrids) */
     /* 440GX */


### PR DESCRIPTION
Better BIOS (ACPI actually works) but has flash corruption issues to be investigated.