### PR TITLE
Failback for PCAP to use name as description if the later is blank

### DIFF
--- a/src/network/net_pcap.c
+++ b/src/network/net_pcap.c
@@ -261,17 +261,24 @@ net_pcap_prepare(netdev_t *list)
     }
 
     for (dev=devlist; dev!=NULL; dev=dev->next) {
-	if (strlen(dev->name) <= 127)
-		strcpy(list->device, dev->name);
-	else
-		strncpy(list->device, dev->name, 127);
-	if (dev->description) {
-		if (strlen(dev->description) <= 127)
-			strcpy(list->description, dev->description);
-		else
-			strncpy(list->description, dev->description, 127);
-	} else
+		/**
+		 * we initialize the strings to NULL first for strncpy
+		 */
+
+		memset(list->device, '\0', sizeof(list->device));
 		memset(list->description, '\0', sizeof(list->description));
+
+		strncpy(list->device, dev->name, 127);
+		if (dev->description) {
+			if (strlen(dev->description) <= 127)
+				strcpy(list->description, dev->description);
+			else
+				strncpy(list->description, dev->description, 127);
+		} else {
+			/* if description is NULL, set the name. This allows pcap to display *something* useful under WINE */
+			strncpy(list->description, dev->name, sizeof(list->description)-1);
+		}
+
 	list++; i++;
     }
 


### PR DESCRIPTION
This allows 86Box to use pcap properly under WINE under Linux as most
interfaces on Linux leave the description as a NULL.

Signed-off-by: Michael Casadevall <michael@casadevall.pro>

Summary
=======
Fixes PCAP list being null when under Linux/WINE

Approach
========
Failback to use the interface name if the list is otherwise empty.

Checklist
=========
* [ ] Closes issue #xxx
* [X] I have discussed this with core contributors already
* [X] My commit messages are descriptive and I have not added any irrelevant files to the repository
