### PR TITLE
Correct the onboard AVGA2 BIOS path

### DIFF
--- a/src/video/vid_cl54xx.c
+++ b/src/video/vid_cl54xx.c
@@ -38,7 +38,7 @@
 
 #define BIOS_GD5401_PATH		L"roms/video/cirruslogic/avga1.rom"
 #define BIOS_GD5402_PATH		L"roms/video/cirruslogic/avga2.rom"
-#define BIOS_GD5402_ONBOARD_PATH	L"roms/video/machines/cbm_sl386sx25/Commodore386SX-25_AVGA2.bin"
+#define BIOS_GD5402_ONBOARD_PATH	L"roms/machines/cbm_sl386sx25/Commodore386SX-25_AVGA2.bin"
 #define BIOS_GD5420_PATH		L"roms/video/cirruslogic/5420.vbi"
 
 #if defined(DEV_BRANCH) && defined(USE_CL5422)


### PR DESCRIPTION
Summary
=======
This is a fix for the on-board Acumos AVGA2 graphics card, used by the Commodore SL386SX machine.

Approach
========
The superfluous `video/` was removed from the path to the card's BIOS, matching the current ROM set.

Checklist
=========
* [ ] Closes issue #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires inclusion of a ROM in the romset
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [x] My commit messages are descriptive and I have not added any irrelevant files to the repository
