### PR TITLE
Fix the debug console window not appearing.

### DIFF
--- a/src/win/win.c
+++ b/src/win/win.c
@@ -366,10 +366,6 @@ WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR lpszArg, int nCmdShow)
     /* First, set our (default) language. */
     set_language(0x0409);
 
-    /* Create console window. */
-    if (force_debug)
-	CreateConsole(1);
-
     /* Process the command line for options. */
     argc = ProcessCommandLine(&argw);
 
@@ -391,8 +387,11 @@ WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR lpszArg, int nCmdShow)
     if (enable_crashdump)
 	InitCrashDump();
 
-    if (force_debug)
+    /* Create console window. */
+    if (force_debug) {
+	CreateConsole(1);
 	atexit(CloseConsole);
+}
 
     /* Handle our GUI. */
     i = ui_init(nCmdShow);


### PR DESCRIPTION
Summary
=======
The debug logging console window does not appear even when the `--debug` command line argument is specified. This pull request fixes that.

Approach
========
The relevant variable is now checked after, and not before, the arguments are processed.

Checklist
=========
* [ ] Closes issue #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires inclusion of a ROM in the romset
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [x] My commit messages are descriptive and I have not added any irrelevant files to the repository
