### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,10 @@ src/*.o
 src/*.exe
 src/*.res
 src/*.d
+src/*.cfg
+src/*.log
+src/*.dll
+src/*.dmp
 src/NUL
+src/nvr/
+src/roms/


### PR DESCRIPTION
Summary
=======
Adds a few more file extensions and paths to .gitignore, preventing accidentally committed config files, ROMs, logs, etc. when 86box is run directly from the src/ directory.

Checklist
=========
* [ ] Closes issue #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires inclusion of a ROM in the romset
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [x] My commit messages are descriptive and I have not added any irrelevant files to the repository
