### PR TITLE
Add an EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = tab
+indent_size = 8
+tab_width = 8
+
+# Disabled for now since not all editors support setting a tab_width value different from indent_size
+# Relevant VSCode extension issue: https://github.com/editorconfig/editorconfig-vscode/issues/190
+# [*.rc]
+# indent_style = space
+# indent_size = 4
+# tab_width = 8
+
+# [Makefile.*]
+# indent_style = space
+# indent_size = 4
+# tab_width = 8
+
+[*.manifest]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Summary
=======
Add an .editorconfig file standardizing the coding conventions that have been agreed upon. The rules for .rc and Makefiles have been temporarily disabled, because not all editors or their extensions allow for tab width to be different from indent size (see the references section for an example).

Checklist
=========
* [ ] Closes issue #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires inclusion of a ROM in the romset
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [x] My commit messages are descriptive and I have not added any irrelevant files to the repository

References
==========
editorconfig/editorconfig-vscode#190 - a relevant issue in the EditorConfig extension for Visual Studio Code
