### PR TITLE
Disable Discord integration logging

### DIFF
--- a/src/win/win_discord.c
+++ b/src/win/win_discord.c
@@ -45,7 +45,7 @@ static dllimp_t discord_imports[] = {
   { NULL,		NULL		}
 };
 
-#ifndef ENABLE_DISCORD_LOG
+#ifdef ENABLE_DISCORD_LOG
 int discord_do_log = 1;
 
 


### PR DESCRIPTION
Summary
=======
The Discord Rich Presence integration has debug logging enabled by default. This PR disables it.

Checklist
=========
* [ ] Closes issue #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires inclusion of a ROM in the romset
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [x] My commit messages are descriptive and I have not added any irrelevant files to the repository
