### PR TITLE
Small Makefile fixes

### DIFF
--- a/src/win/Makefile.mingw
+++ b/src/win/Makefile.mingw
@@ -66,9 +66,6 @@ ifeq ($(DEV_BUILD), y)
  ifndef PAS16
   PAS16		:= n
  endif
- ifndef PORTABLE3
-  PORTABLE3	:= y
- endif
  ifndef PS1M2133
   PS1M2133	:= y
  endif
@@ -159,9 +156,6 @@ else
  endif
  ifndef PAS16
   PAS16		:= n
- endif
- ifndef PORTABLE3
-  PORTABLE3	:= n
  endif
  ifndef PS1M2133
   PS1M2133	:= n
@@ -562,10 +556,6 @@ endif
 ifeq ($(PAS16), y)
 OPTS		+= -DUSE_PAS16
 DEVBROBJ	+= snd_pas16.o
-endif
-
-ifeq ($(PORTABLE3), y)
-OPTS		+= -DUSE_PORTABLE3
 endif
 
 ifeq ($(PS1M2133), y)

--- a/src/win/Makefile.mingw
+++ b/src/win/Makefile.mingw
@@ -875,15 +875,15 @@ else
 
 %.d:		%.c $(wildcard $*.d)
 		@echo $<
-		@$(CC) $(CFLAGS) $(DEPS) -E $< >NUL
+		@$(CC) $(CFLAGS) $(DEPS) -E $< >/dev/null
 
 %.d:		%.cc $(wildcard $*.d)
 		@echo $<
-		@$(CPP) $(CXXFLAGS) $(DEPS) -E $< >NUL
+		@$(CPP) $(CXXFLAGS) $(DEPS) -E $< >/dev/null
 
 %.d:		%.cpp $(wildcard $*.d)
 		@echo $<
-		@$(CPP) $(CXXFLAGS) $(DEPS) -E $< >NUL
+		@$(CPP) $(CXXFLAGS) $(DEPS) -E $< >/dev/null
 endif
 
 
@@ -921,18 +921,18 @@ endif
 
 clean:
 		@echo Cleaning objects..
-		@-rm -f *.o 2>NUL
-		@-rm -f *.res 2>NUL
+		@-rm -f *.o 2>/dev/null
+		@-rm -f *.res 2>/dev/null
 
 clobber:	clean
 		@echo Cleaning executables..
-		@-rm -f *.d 2>NUL
-		@-rm -f *.exe 2>NUL
-#		@-rm -f $(DEPFILE) 2>NUL
+		@-rm -f *.d 2>/dev/null
+		@-rm -f *.exe 2>/dev/null
+#		@-rm -f $(DEPFILE) 2>/dev/null
 
 ifneq ($(AUTODEP), y)
 depclean:
-		@-rm -f $(DEPFILE) 2>NUL
+		@-rm -f $(DEPFILE) 2>/dev/null
 		@echo Creating dependencies..
 		@echo # Run "make depends" to re-create this file. >$(DEPFILE)
 


### PR DESCRIPTION
Summary
=======
The Makefile silences the command output in some cases by redirecting it to NUL, which, when run under `bash` in an MSYS2 environment results in the output being redirected to a regular file called `NUL`, which then can't be deleted by standard Windows methods due to NUL being a reserved name.

Approach
========
Since the Makefile is obviously not intended to be run under `cmd.exe`, the input is now redirected to `dev/null` instead. Additionally, an unused leftover variable has been removed as well.

Checklist
=========
* [ ] Closes issue #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires inclusion of a ROM in the romset
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [x] My commit messages are descriptive and I have not added any irrelevant files to the repository
