### PR TITLE
Change the default IRQ for some ISA SCSI controllers

### DIFF
--- a/src/scsi/scsi_aha154x.c
+++ b/src/scsi/scsi_aha154x.c
@@ -940,7 +940,7 @@ static const device_config_t aha_154xb_config[] = {
                 },
         },
         {
-		"irq", "IRQ", CONFIG_SELECTION, "", 9,
+		"irq", "IRQ", CONFIG_SELECTION, "", 11,
                 {
                         {
                                 "IRQ 9", 9
@@ -1070,7 +1070,7 @@ static const device_config_t aha_154x_config[] = {
                 },
         },
         {
-		"irq", "IRQ", CONFIG_SELECTION, "", 9,
+		"irq", "IRQ", CONFIG_SELECTION, "", 11,
                 {
                         {
                                 "IRQ 9", 9
@@ -1169,7 +1169,7 @@ static const device_config_t aha_154xcf_config[] = {
                 },
         },
         {
-		"irq", "IRQ", CONFIG_SELECTION, "", 9,
+		"irq", "IRQ", CONFIG_SELECTION, "", 11,
                 {
                         {
                                 "IRQ 9", 9

--- a/src/scsi/scsi_buslogic.c
+++ b/src/scsi/scsi_buslogic.c
@@ -1768,7 +1768,7 @@ static const device_config_t BT_ISA_Config[] = {
                 },
         },
         {
-		"irq", "IRQ", CONFIG_SELECTION, "", 9,
+		"irq", "IRQ", CONFIG_SELECTION, "", 11,
                 {
                         {
                                 "IRQ 9", 9


### PR DESCRIPTION
Summary
=======
This changes the default IRQ for Adaptec AHA-145x and BusLogicBT-54x/44x SCSI controllers from 9 (this configuration which is known to cause problems and is discouraged in the official documentation) to 11.

Checklist
=========
* [ ] Closes issue #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires inclusion of a ROM in the romset
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [x] My commit messages are descriptive and I have not added any irrelevant files to the repository
