### PR TITLE
Added the Fujitsu ErgoPro x365

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -462,6 +462,9 @@ extern int	machine_at_ax6bc_init(const machine_t *);
 extern int	machine_at_atc6310bxii_init(const machine_t *);
 extern int	machine_at_tsunamiatx_init(const machine_t *);
 extern int	machine_at_p6sba_init(const machine_t *);
+#if defined(DEV_BRANCH) && defined(NO_SIO)
+extern int	machine_at_ergox365_init(const machine_t *);
+#endif
 extern int	machine_at_ficka6130_init(const machine_t *);
 
 #ifdef EMU_DEVICE_H

--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -440,6 +440,37 @@ at_tsunamiatx_get_device(void)
     return &es1371_onboard_device;
 }
 
+#if defined(DEV_BRANCH) && defined(NO_SIO)
+int
+machine_at_ergox365_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear(L"roms/machines/ergox365/M63v115.rom",
+			   0x00080000, 524288, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_at_common_init_ex(model, 2);
+
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
+    pci_register_slot(0x01, PCI_CARD_SPECIAL,     1, 2, 3, 4);
+	pci_register_slot(0x14, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x12, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x08, PCI_CARD_ONBOARD,      3, 0, 0, 0);
+    device_add(&i440bx_device);
+    device_add(&piix4e_device);
+	device_add(&keyboard_ps2_ami_pci_device);
+    device_add(&fdc37c665_device); // Placeholder for the SM(S)C FDC37C675
+    device_add(&sst_flash_39sf040_device); // Placeholder for the Intel 28F004 flash chip
+    spd_register(SPD_TYPE_SDRAM, 0xF, 256);
+
+    return ret;
+}
+#endif
 
 int
 machine_at_ficka6130_init(const machine_t *model)

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -375,6 +375,9 @@ const machine_t machines[] = {
     { "[i440BX] A-Trend ATC6310BXII",		"atc6310bxii",		MACHINE_TYPE_SLOT1,		{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"", NULL},	  {"",      NULL}}, MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8,  768,   8, 255,	  machine_at_atc6310bxii_init, NULL			},
     { "[i440BX] Tyan Tsunami ATX",		"tsunamiatx",		MACHINE_TYPE_SLOT1,		{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"", NULL},	  {"",      NULL}}, MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL | MACHINE_SOUND,	 	  8, 1024,   8, 255,	   machine_at_tsunamiatx_init, at_tsunamiatx_get_device	},
     { "[i440BX] SuperMicro Super P6SBA",	"p6sba",		MACHINE_TYPE_SLOT1,		{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"", NULL},	  {"",      NULL}}, MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		  		  8,  768,   8, 255,	        machine_at_p6sba_init, NULL			},
+#if defined(DEV_BRANCH) && defined(NO_SIO)
+	{ "[i440BX] Fujitsu ErgoPro x365",		"ergox365",		MACHINE_TYPE_SLOT1,		{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"", NULL},        {"",      NULL}}, MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8,  384,   8, 511,	      machine_at_ergox365_init, NULL			},
+#endif
 
     /* 440GX */
     { "[i440GX] Freeway FW-6400GX",		"fw6400gx_s1",		MACHINE_TYPE_SLOT1,		{{"Intel", cpus_PentiumII},   {"Intel/PGA370", cpus_Celeron},{"VIA", cpus_Cyrix3},{"", NULL},	  {"",      NULL}}, MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,				 16, 2032,  16, 511,	     machine_at_fw6400gx_init, NULL			},


### PR DESCRIPTION
Summary
=======
I am submitting the Fujitsu ErgoPro x365 (a new machine).

Approach
========
The first board I considered was the HP Brio 83xx (an i440EX system), but since it required the SM(S)C FDC37C675.
I chose the ErgoPro x365, after tiseno100 opened pull request #1053. 

Checklist
=========
* [ ] Closes issue #xxx
* [x] I have discussed this with core contributors already
* [x] This pull request requires inclusion of a ROM in the romset
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/81/
* [x] My commit messages are descriptive and I have not added any irrelevant files to the repository

References
==========
x365 Quick Reference Guide: http://pub.agrarix.net/HW/Fujitsu/ErgoPro%20x365_bestanden/X365qrg.pdf