### PR TITLE
Fix the mouse cursor being locked after leaving fullscreen mode

### DIFF
--- a/src/win/win_sdl.c
+++ b/src/win/win_sdl.c
@@ -326,7 +326,7 @@ sdl_init_common(int flags)
     wchar_t temp[128];
     SDL_version ver;
     int w = 0, h = 0, x = 0, y = 0;
-    RECT rect;
+    RECT rect, oldclip;
 
     sdl_log("SDL: init (fs=%d)\n", fs);
 
@@ -389,6 +389,8 @@ sdl_init_common(int flags)
 	/* Now create the SDL window from that. */
 	sdl_win = SDL_CreateWindowFrom((void *)sdl_hwnd);
 
+	GetClipCursor(&oldclip);
+
 	old_capture = mouse_capture;
 
 	GetWindowRect(sdl_hwnd, &rect);
@@ -406,6 +408,8 @@ sdl_init_common(int flags)
 		GetWindowRect(hwndRender, &rect);
 
 		ClipCursor(&rect);
+	} else {
+		ClipCursor(&oldclip);
 	}
     }
     if (sdl_win == NULL) {


### PR DESCRIPTION
Summary
=======
This fixes an issue where after leaving the fullscreen mode, the host mouse cursor remains locked to the dimensions of the emulated screen.

Checklist
=========
* [x] Closes issue #812
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires inclusion of a ROM in the romset
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [x] My commit messages are descriptive and I have not added any irrelevant files to the repository
