### PR TITLE
Properly close the emulator on ACPI soft power off

### DIFF
--- a/src/acpi.c
+++ b/src/acpi.c
@@ -28,6 +28,7 @@
 #include <86box/io.h>
 #include <86box/pci.h>
 #include <86box/pic.h>
+#include <86box/plat.h>
 #include <86box/timer.h>
 #include <86box/keyboard.h>
 #include <86box/nvr.h>
@@ -448,7 +449,7 @@ acpi_reg_write_common_regs(int size, uint16_t addr, uint8_t val, void *p)
 			switch (sus_typ) {
 				case 0:
 					/* Soft power off. */
-					exit(-1);
+					quited = 1;
 					break;
 				case 1:
 					/* Suspend to RAM. */


### PR DESCRIPTION
Summary
=======
This makes 86Box close normally on ACPI soft power off instead of abruptly terminating without saving the configuration or the emulated machine's NVRAM.

Checklist
=========
* [ ] Closes issue #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires inclusion of a ROM in the romset
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [x] My commit messages are descriptive and I have not added any irrelevant files to the repository
