### PR TITLE
Fix the mouse getting locked after leaving fullscreen, take 2

### DIFF
--- a/src/include/86box/win.h
+++ b/src/include/86box/win.h
@@ -99,6 +99,7 @@ extern HWND		hwndMain,
 extern HANDLE		ghMutex;
 extern LCID		lang_id;
 extern HICON		hIcon[256];
+extern RECT		oldclip;
 
 // extern int		status_is_open;
 

--- a/src/win/win_sdl.c
+++ b/src/win/win_sdl.c
@@ -326,7 +326,7 @@ sdl_init_common(int flags)
     wchar_t temp[128];
     SDL_version ver;
     int w = 0, h = 0, x = 0, y = 0;
-    RECT rect, oldclip;
+    RECT rect;
 
     sdl_log("SDL: init (fs=%d)\n", fs);
 
@@ -388,8 +388,6 @@ sdl_init_common(int flags)
 
 	/* Now create the SDL window from that. */
 	sdl_win = SDL_CreateWindowFrom((void *)sdl_hwnd);
-
-	GetClipCursor(&oldclip);
 
 	old_capture = mouse_capture;
 

--- a/src/win/win_ui.c
+++ b/src/win/win_ui.c
@@ -1089,6 +1089,8 @@ ui_init(int nCmdShow)
     /* Make the window visible on the screen. */
     ShowWindow(hwnd, nCmdShow);
 
+    GetClipCursor(&oldclip);
+
     /* Initialize the RawInput (keyboard) module. */
     memset(&ridev, 0x00, sizeof(ridev));
     ridev.usUsagePage = 0x01;


### PR DESCRIPTION
Summary
=======
This PR is a rework of #1074, which attempted to fix an issue with the host mouse cursor being locked after leaving the fullscreen mode, except done in a more proper way that resolves the issue even on optimized builds.

Checklist
=========
* [x] Closes #1079 
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires inclusion of a ROM in the romset
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [x] My commit messages are descriptive and I have not added any irrelevant files to the repository
