### PR TITLE
Tweaks to the Settings dialog

### DIFF
--- a/src/include/86box/language.h
+++ b/src/include/86box/language.h
@@ -96,7 +96,7 @@
 #define IDS_2120	2120		// "No ROMs found"
 #define IDS_2121	2121		// "Save changes\nThis will hard..."
 #define IDS_2122	2122		// "Discard changes\nAll changes..."
-#define IDS_2123	2123		// "Cancel\nGo back to the..."
+#define IDS_2123	2123		// "Do you want to save the settings?"
 #define IDS_2124	2124		// "About 86Box"
 #define IDS_2125	2125		// "86Box v" EMU_VERSION
 #define IDS_2126	2126		// "An emulator of old computers..."

--- a/src/win/86Box.rc
+++ b/src/win/86Box.rc
@@ -988,7 +988,7 @@ BEGIN
     IDS_2120	"No ROMs found"
     IDS_2121	"Save changes\nThis will hard reset the emulated machine."
     IDS_2122	"Discard changes\nAll changes made to the settings will be lost."
-    IDS_2123	"Cancel\nGo back to the Settings window."
+    IDS_2123	"Do you want to save the settings?"
     IDS_2124	"About 86Box"
     IDS_2125	"86Box v" EMU_VERSION
     IDS_2126	"An emulator of old computers\n\nAuthors: Sarah Walker, Miran Grca, Fred N. van Kempen (waltje), SA1988, MoochMcGee, reenigne, leilei, JohnElliott, greatpsycho, and others.\n\nReleased under the GNU General Public License version 2. See LICENSE for more information."

--- a/src/win/86Box.rc
+++ b/src/win/86Box.rc
@@ -1021,9 +1021,9 @@ BEGIN
     IDS_2133	LIB_NAME_FLUIDSYNTH " is required for FluidSynth MIDI output."
     IDS_2134	"Entering fullscreen mode"
     IDS_2135	"Don't show this message again"
-    IDS_2136	"Don't Exit"
+    IDS_2136	"Don't exit"
     IDS_2137	"Reset"
-    IDS_2138	"Don't Reset"
+    IDS_2138	"Don't reset"
     IDS_2139	"MO images (*.IM?;*.MDI)\0*.IM?;*.MDI\0All files (*.*)\0*.*\0"
 END
 
@@ -1035,8 +1035,8 @@ BEGIN
     IDS_4099	"MFM/RLL or ESDI CD-ROM drives never existed"
     IDS_4100	"Custom..."
     IDS_4101	"Custom (large)..."
-    IDS_4102	"Add New Hard Disk"
-    IDS_4103	"Add Existing Hard Disk"
+    IDS_4102	"Add new hard disk"
+    IDS_4103	"Add existing hard disk"
     IDS_4104	"HDI disk images cannot be larger than 4 GB."
     IDS_4105	"Disk images cannot be larger than 127 GB."
     IDS_4106	"Hard disk images (*.HD?;*.IM?;*.VHD)\0*.HD?;*.IM?;*.VHD\0All files (*.*)\0*.*\0"
@@ -1054,7 +1054,7 @@ BEGIN
     IDS_4118	"The selected file will be overwritten. Are you sure you want to use it?"
     IDS_4119	"Unsupported disk image"
     IDS_4120	"Overwrite"
-    IDS_4121	"Don't Overwrite"
+    IDS_4121	"Don't overwrite"
 
     IDS_4352    "MFM/RLL"
     IDS_4353    "XTA"

--- a/src/win/Makefile.mingw
+++ b/src/win/Makefile.mingw
@@ -813,7 +813,7 @@ endif
 ifneq ($(WX), n)
 LIBS		+= $(WX_LIBS) -lm
 endif
-LIBS		+= -lpng -lz -lwsock32 -lshell32 -liphlpapi -lpsapi -lSDL2 -limm32 -lhid -lsetupapi -loleaut32 -lversion -lwinmm -static -lstdc++
+LIBS		+= -lpng -lz -lwsock32 -lshell32 -liphlpapi -lpsapi -lSDL2 -limm32 -lhid -lsetupapi -loleaut32 -luxtheme -lversion -lwinmm -static -lstdc++
 ifneq ($(X64), y)
 LIBS		+= -Wl,--large-address-aware
 endif

--- a/src/win/win_settings.c
+++ b/src/win/win_settings.c
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * 86Box	A hypervisor and IBM PC system emulator that specializes in
  *		running old operating systems and software designed for IBM
  *		PC systems and compatibles from 1981 through fairly recent
@@ -20,6 +20,7 @@
 #define BITMAP WINDOWS_BITMAP
 #include <windows.h>
 #include <windowsx.h>
+#include <uxtheme.h>
 #undef BITMAP
 #ifdef ENABLE_SETTINGS_LOG
 #include <assert.h>
@@ -204,6 +205,17 @@ settings_show_window(HWND hdlg, int id, int condition)
     h = GetDlgItem(hdlg, id);
     EnableWindow(h, condition ? TRUE : FALSE);
     ShowWindow(h, condition ? SW_SHOW : SW_HIDE);
+}
+
+
+static void
+settings_listview_enable_styles(HWND hdlg, int id)
+{
+    HWND h;
+
+    h = GetDlgItem(hdlg, id);
+    SetWindowTheme(h, L"Explorer", NULL);
+    ListView_SetExtendedListViewStyle(h, LVS_EX_FULLROWSELECT | LVS_EX_DOUBLEBUFFER);
 }
 
 
@@ -3124,6 +3136,8 @@ win_settings_hard_disks_proc(HWND hdlg, UINT message, WPARAM wParam, LPARAM lPar
 			lv1_current_sel = -1;
 		recalc_location_controls(hdlg, 0, 0);
 
+		settings_listview_enable_styles(hdlg, IDC_LIST_HARD_DISKS);
+
 		ignore_change = 0;
 		return TRUE;
 
@@ -4178,6 +4192,8 @@ win_settings_floppy_and_cdrom_drives_proc(HWND hdlg, UINT message, WPARAM wParam
 		settings_set_check(hdlg, IDC_CHECKTURBO, temp_fdd_turbo[lv1_current_sel]);
 		settings_set_check(hdlg, IDC_CHECKBPB, temp_fdd_check_bpb[lv1_current_sel]);
 
+		settings_listview_enable_styles(hdlg, IDC_LIST_FLOPPY_DRIVES);
+
 		lv2_current_sel = 0;
 		win_settings_cdrom_drives_init_columns(hdlg);
 		image_list_init(hdlg, IDC_LIST_CDROM_DRIVES, (const uint8_t *) cd_icons);
@@ -4199,6 +4215,8 @@ win_settings_floppy_and_cdrom_drives_proc(HWND hdlg, UINT message, WPARAM wParam
 		}
 		settings_set_cur_sel(hdlg, IDC_COMBO_CD_BUS, b);
 		cdrom_recalc_location_controls(hdlg, 0);
+
+		settings_listview_enable_styles(hdlg, IDC_LIST_CDROM_DRIVES);
 
 		ignore_change = 0;
 		return TRUE;
@@ -4362,6 +4380,8 @@ win_settings_other_removable_devices_proc(HWND hdlg, UINT message, WPARAM wParam
 		settings_set_cur_sel(hdlg, IDC_COMBO_MO_BUS, b);
 		mo_recalc_location_controls(hdlg, 0);
 
+		settings_listview_enable_styles(hdlg, IDC_LIST_MO_DRIVES);
+
 		lv2_current_sel = 0;
 		win_settings_zip_drives_init_columns(hdlg);
 		image_list_init(hdlg, IDC_LIST_ZIP_DRIVES, (const uint8_t *) zip_icons);
@@ -4383,6 +4403,8 @@ win_settings_other_removable_devices_proc(HWND hdlg, UINT message, WPARAM wParam
 		}
 		settings_set_cur_sel(hdlg, IDC_COMBO_ZIP_BUS, b);
 		zip_recalc_location_controls(hdlg, 0);
+
+		settings_listview_enable_styles(hdlg, IDC_LIST_ZIP_DRIVES);
 
 		ignore_change = 0;
 		return TRUE;
@@ -4669,6 +4691,7 @@ win_settings_main_proc(HWND hdlg, UINT message, WPARAM wParam, LPARAM lParam)
 		image_list_init(hdlg, IDC_SETTINGSCATLIST, (const uint8_t *) cat_icons);
 		win_settings_main_insert_categories(h);
 		settings_listview_select(hdlg, IDC_SETTINGSCATLIST, first_cat);
+		settings_listview_enable_styles(hdlg, IDC_SETTINGSCATLIST);
 		return TRUE;
 	case WM_NOTIFY:
 		if ((((LPNMHDR)lParam)->code == LVN_ITEMCHANGED) && (((LPNMHDR)lParam)->idFrom == IDC_SETTINGSCATLIST)) {

--- a/src/win/win_settings.c
+++ b/src/win/win_settings.c
@@ -217,6 +217,17 @@ settings_listview_select(HWND hdlg, int id, int selection)
 }
 
 
+static void
+settings_process_messages()
+{
+    MSG msg;
+    while (PeekMessage(&msg, 0, 0, 0, PM_REMOVE | PM_NOYIELD)) {
+	TranslateMessage(&msg); 
+	DispatchMessage(&msg);
+    }
+}
+
+
 static BOOL
 image_list_init(HWND hdlg, int id, const uint8_t *icon_ids)
 {
@@ -1067,6 +1078,8 @@ win_settings_video_proc(HWND hdlg, UINT message, WPARAM wParam, LPARAM lParam)
 			}
 
 			c++;
+
+			settings_process_messages();
 		}
 
 		settings_enable_window(hdlg, IDC_COMBO_VIDEO, !(machines[temp_machine].flags & MACHINE_VIDEO_ONLY));
@@ -2606,10 +2619,7 @@ win_settings_hard_disks_add_proc(HWND hdlg, UINT message, WPARAM wParam, LPARAM 
 							fwrite(big_buf, 1, 1048576, f);
 							SendMessage(h, PBM_SETPOS, (WPARAM) (i + 1), (LPARAM) 0);
 
-							while (PeekMessage(&msg, 0, 0, 0, PM_REMOVE | PM_NOYIELD)) {
-								TranslateMessage(&msg); 
-								DispatchMessage(&msg);
-							}
+							settings_process_messages();
 						}
 					}
 

--- a/src/win/win_settings.c
+++ b/src/win/win_settings.c
@@ -495,7 +495,7 @@ win_settings_changed(void)
 
 
 static int
-settings_msgbox_reset(void)
+settings_msgbox_reset(int button)
 {
     int changed, i = 0;
     HWND h;
@@ -506,7 +506,7 @@ settings_msgbox_reset(void)
 	h = hwndMain;
 	hwndMain = hwndParentDialog;
 
-	i = ui_msgbox_ex(MBX_QUESTION | MBX_LINKS, (wchar_t *) IDS_2051, NULL, (wchar_t *) IDS_2121, (wchar_t *) IDS_2122, (wchar_t *) IDS_2123);
+	i = ui_msgbox_ex(MBX_QUESTION | MBX_LINKS, (wchar_t *) (button ? IDS_2051 : IDS_2123), NULL, (wchar_t *) IDS_2121, (wchar_t *) IDS_2122, NULL);
 
 	hwndMain = h;
 
@@ -4622,7 +4622,7 @@ win_settings_confirm(HWND hdlg, int button)
     int i;
 
     SendMessage(hwndChildDialog, WM_SAVESETTINGS, 0, 0);
-    i = settings_msgbox_reset();
+    i = settings_msgbox_reset(button);
     if (i > 0) {
 	if (i == 2)
 		win_settings_save();

--- a/src/win/win_settings.c
+++ b/src/win/win_settings.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * 86Box	A hypervisor and IBM PC system emulator that specializes in
  *		running old operating systems and software designed for IBM
  *		PC systems and compatibles from 1981 through fairly recent
@@ -2462,7 +2462,6 @@ win_settings_hard_disks_add_proc(HWND hdlg, UINT message, WPARAM wParam, LPARAM 
     uint8_t id = 0;
     wchar_t *twcs;
     vhd_footer_t *vft = NULL;
-    MSG msg;
 
     switch (message) {
 	case WM_INITDIALOG:


### PR DESCRIPTION
Small tweaks and fixes to the Settings dialog (and the UI in general):
* Changed the save settings dialog to better conform to Windows user interface guidelines (turned the Cancel button to a regular button and changed the wording for when the dialog is invoked by clicking the close button)
* Changed button text to sentence case
* Video card selection now loads instantly
* Made list views in the settings prettier by using the Explorer theme (required adding a link to uxtheme.dll)