### PR TITLE
Eliminated s3->busy completely, fixes S3 928 drivers without FIFO und…

### DIFF
--- a/src/scsi/scsi_pcscsi.c
+++ b/src/scsi/scsi_pcscsi.c
@@ -595,7 +595,6 @@ handle_satn_stop(void *priv)
 	dev->rregs[ESP_RSEQ] = SEQ_CD;
 	esp_log("ESP SCSI Command len = %d, raising IRQ\n", dev->cmdlen);
 	esp_raise_irq(dev);
-	timer_on_auto(&dev->timer, 10.0);
     }
 }
 
@@ -729,6 +728,7 @@ esp_reg_write(esp_t *dev, uint32_t saddr, uint32_t val)
 				dev->rregs[ESP_RINTR] = INTR_FC;
 				dev->rregs[ESP_RSEQ] = 0;
 				dev->rregs[ESP_RFLAGS] = 0;
+				timer_on_auto(&dev->timer, 10.0);
 				break;
 			case CMD_RESET:
 				esp_pci_soft_reset(dev);

--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -2676,7 +2676,7 @@ s3_accel_in(uint16_t port, void *p)
 			if (FIFO_FULL && s3->chip >= S3_VISION964)
 				temp |= 0xf8; /*FIFO full*/
 		} else {
-			if (s3->busy || s3->force_busy) {
+			if (s3->force_busy) {
 				temp |= 0x02; /*Hardware busy*/
 			}
 			s3->force_busy = 0;
@@ -3314,10 +3314,6 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, s3_
             dstbase >>= 2;
         }
 
-	if (((s3_cpu_src(s3) || s3_cpu_dest(s3))) && (s3->chip >= S3_86C928 && s3->chip < S3_TRIO64V)) {
-		s3->busy = 1;
-	}
-
 	if ((s3->accel.cmd & 0x100) && (s3_cpu_src(s3) || s3_cpu_dest(s3)) && !cpu_input) {
 		s3->force_busy = 1;
 	}
@@ -3410,7 +3406,6 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, s3_
 				if (s3->bpp == 0) cpu_dat >>= 8;
 				else	      cpu_dat >>= 16;
 				if (!s3->accel.sy) {
-					s3->busy = 0;
 					break;
 				}
 
@@ -3481,7 +3476,6 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, s3_
 				else	     cpu_dat >>= 16;
 
 				if (!s3->accel.sy) {
-					s3->busy = 0;
 					break;
 				}
 				
@@ -3653,10 +3647,6 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, s3_
 				s3->accel.dest = dstbase + s3->accel.cy * s3->width;
 				s3->accel.sy--;
 
-				if (s3->accel.sy < 0) {
-					s3->busy = 0;
-				}
-
 				if (cpu_input) {
 					if (s3_cpu_dest(s3))
 						s3->data_available = 1;
@@ -3737,7 +3727,6 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, s3_
 					s3->accel.sy--;
 	
 					if (s3->accel.sy < 0) {
-						s3->busy = 0;
 						return;
 					}
 				}
@@ -3824,9 +3813,6 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, s3_
 					s3->accel.dest = dstbase + s3->accel.dy * s3->width;
 
 					s3->accel.sy--;
-
-					if (s3->accel.sy < 0)
-						s3->busy = 0;
 
 					if (cpu_input)
 						return;
@@ -3950,9 +3936,6 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, s3_
 
 				s3->accel.sy--;
 
-				if (s3->accel.sy < 0)
-					s3->busy = 0;
-
 				if (cpu_input/* && (s3->accel.multifunc[0xa] & 0xc0) == 0x80*/) return;
 				if (s3->accel.sy < 0)
 					return;
@@ -4032,7 +4015,6 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, s3_
 			s3->accel.cur_x2 = s3->accel.poly_cx2 & 0xfff;
 			s3->accel.cur_y2 = s3->accel.poly_cy & 0xfff;
 		}
-		s3->busy = 0;
 		break;
 
 		case 11: /*Polygon Fill Pattern (Trio64 only)*/
@@ -4121,7 +4103,6 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, s3_
 			s3->accel.cur_x2 = s3->accel.poly_cx2 & 0xfff;
 			s3->accel.cur_y2 = s3->accel.poly_cy & 0xfff;
 		}
-		s3->busy = 0;
 		break;
 	}
 }


### PR DESCRIPTION
…er NT 3.1 while keeping everything else intact.

Moved the DC390 timer initialization to the Flush write command, where it takes a higher priority, fixes NT 3.1 DC390 specific drivers while keeping the AMD branded drivers intact.

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
