### PR TITLE
i386 CPUs don't have the WP bit in CR0. Fixes IBM AIX 1.3

### DIFF
--- a/src/mem/mem.c
+++ b/src/mem/mem.c
@@ -296,7 +296,7 @@ mmutranslatereal_normal(uint32_t addr, int rw)
 
     if ((temp & 0x80) && (cr4 & CR4_PSE)) {
 	/*4MB page*/
-	if (((CPL == 3) && !(temp & 4) && !cpl_override) || (rw && !(temp & 2) && (((CPL == 3) && !cpl_override) || (cr0 & WP_FLAG)))) {
+	if (((CPL == 3) && !(temp & 4) && !cpl_override) || (rw && !(temp & 2) && (((CPL == 3) && !cpl_override) || (!is386 && (cr0 & WP_FLAG))))) {
 		cr2 = addr;
 		temp &= 1;
 		if (CPL == 3)
@@ -317,7 +317,7 @@ mmutranslatereal_normal(uint32_t addr, int rw)
 
     temp = rammap((temp & ~0xfff) + ((addr >> 10) & 0xffc));
     temp3 = temp & temp2;
-    if (!(temp&1) || ((CPL == 3) && !(temp3 & 4) && !cpl_override) || (rw && !(temp3 & 2) && (((CPL == 3) && !cpl_override) || (cr0 & WP_FLAG)))) {
+    if (!(temp&1) || ((CPL == 3) && !(temp3 & 4) && !cpl_override) || (rw && !(temp3 & 2) && (((CPL == 3) && !cpl_override) || (!is386 && (cr0 & WP_FLAG))))) {
 	cr2 = addr;
 	temp &= 1;
 	if (CPL == 3) temp |= 4;


### PR DESCRIPTION
Summary
=======
I looked through the 386 Programmer's Reference Manual to see what bits CR0 had, and it does NOT have the WP (Write-Protect) bit in CR0 on the 386. Once removed, IBM AIX 1.3 no longer page faults immediately upon inserting the installation diskette.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://css.csail.mit.edu/6.858/2014/readings/i386.pdf