### PR TITLE
Fixes to the previous big PR and other changes

### DIFF
--- a/src/chipset/via_pipc.c
+++ b/src/chipset/via_pipc.c
@@ -58,7 +58,7 @@
    listings on forums, as VIA's datasheets are not very helpful regarding those. */
 #define VIA_PIPC_586A	0x05862500
 #define VIA_PIPC_586B	0x05864700
-#define VIA_PIPC_596A	0x05961200
+#define VIA_PIPC_596A	0x05960900
 #define VIA_PIPC_596B	0x05962300
 #define VIA_PIPC_686A	0x06861400
 #define VIA_PIPC_686B	0x06864000

--- a/src/device/clock_ics9xxx.c
+++ b/src/device/clock_ics9xxx.c
@@ -842,10 +842,8 @@ ics9xxx_init(const device_t *info)
 
 	for (i = 0; i < ICS9xxx_MAX; i++) {
 		for (uint8_t j = 0; j < ICS9xxx_MAX; j++) {
-			if (i == j)
-				continue;
-			if (!memcmp(&ics9xxx_devices[i], &ics9xxx_devices[j], sizeof(ics9xxx_devices[i])))
-				pclog("Optimization warning: %d and %d have duplicate tables\n", i, j);
+			if ((i != j) && !memcmp(&ics9xxx_devices[i], &ics9xxx_devices[j], sizeof(ics9xxx_devices[i])))
+				pclog("Optimization warning: %s and %s have duplicate tables\n", ics9xxx_devices[i].name, ics9xxx_devices[j].name);
 		}
 	}
 

--- a/src/device/clock_ics9xxx.c
+++ b/src/device/clock_ics9xxx.c
@@ -27,10 +27,16 @@
 #include "cpu.h"
 
 
+#define ICS9xxx_DEVICE(model_enum)	}, [model_enum] = {.model = model_enum, .name = #model_enum,
+
+
 enum {
-    ICS9150_08 = 1,
+    ICS9xxx_xx,
+    ICS9150_08,
     ICS9248_39,
+    ICS9248_81,
     ICS9248_98,
+    ICS9248_101,
     ICS9250_08,
     ICS9250_10,
     ICS9250_13,
@@ -47,7 +53,8 @@ enum {
     ICS9250_30,
     ICS9250_32,
     ICS9250_38,
-    ICS9250_50
+    ICS9250_50,
+    ICS9xxx_MAX
 };
 
 typedef struct {
@@ -57,31 +64,40 @@ typedef struct {
 } ics9xxx_frequency_t;
 
 typedef struct {
-    uint8_t	model;
-    uint8_t	max_reg: 3;
-    uint8_t	regs[8];
-    struct {
-	uint8_t	normal_reg: 3;
-	uint8_t	normal_bit: 3;
-	uint8_t	inv_reg: 3;
-	uint8_t	inv_bit: 3;
+    uint8_t	max_reg: 3; /* largest register index */
+    uint8_t	regs[8]; /* default registers */
+    struct { /* for each hardware frequency select bit [FS0:FS4]: */
+	uint8_t	normal_reg: 3; /* which register (or -1) for non-inverted input (FSn) */
+	uint8_t	normal_bit: 3; /* which bit (0-7) for non-inverted input (FSn) */
+	uint8_t	inv_reg: 3; /* which register (or -1) for inverted input (FSn#) */
+	uint8_t	inv_bit: 3; /* which bit (0-7) for inverted input (FSn#) */
     } fs_regs[5];
-    uint8_t	normal_bits_fixed: 1;
+    uint8_t	normal_bits_fixed: 1; /* set to 1 if the non-inverted bits are straps (hardware select only) */
+    struct { /* hardware select bit, which should be cleared for hardware select (latched inputs), or set for programming */
+	uint8_t	normal_reg: 3; /* which register (or -1) */
+	uint8_t	normal_bit: 3; /* which bit (0-7) */
+    } hw_select;
 
-    uint8_t	frequencies_ref;
-    ics9xxx_frequency_t frequencies[32];
-    ics9xxx_frequency_t *frequencies_ptr;
+    uint8_t	frequencies_ref; /* which other model to use the frequency table from (or 0) */
+    ics9xxx_frequency_t frequencies[32]; /* frequency table, if not using another model's table */
 
+    /* remaining fields are "don't care" for the table */
+    uint8_t	model; /* populated by macro */
+    const char	*name; /* populated by macro */
+    ics9xxx_frequency_t *frequencies_ptr; /* populated at runtime */
     int8_t	addr_register;
+    uint8_t	relevant_regs;
     uint8_t	bus_match: 5;
 } ics9xxx_t;
 
 
 static const ics9xxx_t ics9xxx_devices[] = {
-    [ICS9150_08] = {
+    [ICS9xxx_xx] = {0
+    ICS9xxx_DEVICE(ICS9150_08)
 	.max_reg = 5,
 	.regs = {0x00, 0xff, 0xff, 0xff, 0x6f, 0xbf},
 	.fs_regs = {{0, 4, 4, 7}, {0, 5, 4, 4}, {0, 6, 5, 6}, {0, 7, 4, 1}, {-1, -1, -1, -1}},
+	.hw_select = {0, 3},
 	.frequencies = {
 		{.bus =  5000, .pci_div = 2},
 		{.bus =  7500, .pci_div = 2},
@@ -92,11 +108,11 @@ static const ics9xxx_t ics9xxx_devices[] = {
 		{.bus = 13333, .pci_div = 4},
 		{.bus = 10020, .pci_div = 3},
 	}
-    },
-    [ICS9248_39] = {
+    ICS9xxx_DEVICE(ICS9248_39)
 	.max_reg = 5,
 	.regs = {0x00, 0x7f, 0xff, 0xbf, 0xf5, 0xff},
 	.fs_regs = {{0, 4, 3, 6}, {0, 5, 4, 3}, {0, 6, 1, 7}, {0, 7, 4, 1}, {-1, -1, -1, -1}},
+	.hw_select = {0, 3},
 	.frequencies = {
 		{.bus = 12400, .pci_div = 3},
 		{.bus =  7500, .pci_div = 2},
@@ -115,11 +131,34 @@ static const ics9xxx_t ics9xxx_devices[] = {
 		{.bus = 12400, .pci_div = 4},
 		{.bus = 13300, .pci_div = 4}
 	}
-    },
-    [ICS9248_98] = {
+    ICS9xxx_DEVICE(ICS9248_81)
+	.max_reg = 5,
+	.regs = {0x82, 0xfe, 0x7f, 0xff, 0xff, 0xb7},
+	.fs_regs = {{0, 4, 1, 0}, {0, 5, 2, 7}, {0, 6, 5, 6}, {0, 2, 5, 3}, {-1, -1, -1, -1}},
+	.hw_select = {0, 3},
+	.frequencies = {
+		{.bus =  9000, .ram_mult =       1, .pci_div = 3},
+		{.bus =  6670, .ram_mult =     1.5, .pci_div = 2},
+		{.bus =  9500, .ram_mult = 2.0/3.0, .pci_div = 3},
+		{.bus = 10000, .ram_mult = 2.0/3.0, .pci_div = 3},
+		{.bus = 10000, .ram_mult =    0.75, .pci_div = 3},
+		{.bus = 11200, .ram_mult = 2.0/3.0, .pci_div = 3},
+		{.bus = 12400, .ram_mult = 2.0/3.0, .pci_div = 4},
+		{.bus = 13330, .ram_mult = 2.0/3.0, .pci_div = 4},
+		{.bus =  6670, .ram_mult =       1, .pci_div = 2},
+		{.bus =  7500, .ram_mult =       1, .pci_div = 3},
+		{.bus =  8330, .ram_mult =       1, .pci_div = 3},
+		{.bus =  9500, .ram_mult =       1, .pci_div = 3},
+		{.bus = 10000, .ram_mult =       1, .pci_div = 3},
+		{.bus = 11200, .ram_mult =       1, .pci_div = 3},
+		{.bus = 12400, .ram_mult =       1, .pci_div = 4},
+		{.bus = 13330, .ram_mult =       1, .pci_div = 4},
+	}
+    ICS9xxx_DEVICE(ICS9248_98)
 	.max_reg = 6,
 	.regs = {0x00, 0x7f, 0xff, 0xbf, 0xf5, 0xff, 0x06},
-	.fs_regs = {{0, 4, 3, 6}, {0, 5, 4, 3}, {0, 6, 1, 7}, {0, 7, 4, 1}, {-1, -1, -1, -1}},
+	.fs_regs = {{0, 4, 3, 6}, {0, 5, 4, 3}, {0, 6, 1, 7}, {0, 7, 4, 1}, {0, 2, -1, -1}},
+	.hw_select = {0, 3},
 	.frequencies = {
 		{.bus =  8000, .pci_div = 2},
 		{.bus =  7500, .pci_div = 2},
@@ -154,17 +193,39 @@ static const ics9xxx_t ics9xxx_devices[] = {
 		{.bus = 14199, .pci_div = 4},
 		{.bus = 13801, .pci_div = 4}
 	}
-    },
-    [ICS9250_08] = {
+    ICS9xxx_DEVICE(ICS9248_101)
+	.max_reg = 5,
+	.regs = {0x82, 0xff, 0xff, 0xff, 0xf5, 0xff},
+	.fs_regs = {{0, 4, -1, -1}, {0, 5, 4, 3}, {0, 6, -1, -1}, {0, 2, 4, 1}, {-1, -1, -1, -1}},
+	.frequencies = {
+		{.bus = 12400, .pci_div = 3},
+		{.bus = 12000, .pci_div = 3},
+		{.bus = 11499, .pci_div = 3},
+		{.bus = 10999, .pci_div = 3},
+		{.bus = 10500, .pci_div = 3},
+		{.bus =  8331, .pci_div = 2},
+		{.bus = 13700, .pci_div = 4},
+		{.bus =  7500, .pci_div = 2},
+		{.bus = 10000, .pci_div = 3},
+		{.bus =  9500, .pci_div = 3},
+		{.bus =  8331, .pci_div = 3},
+		{.bus = 13333, .pci_div = 4},
+		{.bus =  9000, .pci_div = 3},
+		{.bus =  9622, .pci_div = 3},
+		{.bus =  6682, .pci_div = 2},
+		{.bus =  9150, .pci_div = 3}
+	}
+    ICS9xxx_DEVICE(ICS9250_08)
 	.max_reg = 5,
 	.regs = {0x00, 0xff, 0xff, 0xff, 0x6d, 0xbf},
 	.fs_regs = {{0, 4, 4, 7}, {0, 5, 4, 4}, {0, 6, 5, 6}, {0, 7, 4, 1}, {-1, -1, -1, -1}},
+	.hw_select = {0, 3},
 	.frequencies_ref = ICS9248_39
-    },
-    [ICS9250_10] = {
+    ICS9xxx_DEVICE(ICS9250_10)
 	.max_reg = 5,
 	.regs = {0x1f, 0xff, 0xfe, 0x00, 0x00, 0x06},
-	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
+	.fs_regs = {{5, 0, -1, -1}, {5, 3, -1, -1}, {5, 4, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
+	.hw_select = {-1, -1},
 	.frequencies = {
 		{.bus =  6667, .ram_mult = 1.5, .pci_div = 2},
 		{.bus =  7067, .ram_mult = 1.5, .pci_div = 2},
@@ -183,11 +244,11 @@ static const ics9xxx_t ics9xxx_devices[] = {
 		{.bus = 10900, .ram_mult =   1, .pci_div = 3},
 		{.bus = 13300, .ram_mult =   1, .pci_div = 3}
 	}
-    },
-    [ICS9250_13] = {
+    ICS9xxx_DEVICE(ICS9250_13)
 	.max_reg = 5,
 	.regs = {0x82, 0xcf, 0x7f, 0xff, 0xff, 0xf7},
 	.fs_regs = {{0, 4, 1, 4}, {0, 5, 5, 7}, {0, 6, 1, 5}, {0, 2, 2, 7}, {-1, -1, -1, -1}},
+	.hw_select = {0, 3},
 	.frequencies = {
 		{.bus = 9000, .ram_mult = 1, .pci_div = 2},
 		{.bus = 8901, .ram_mult = 1, .pci_div = 2},
@@ -206,11 +267,11 @@ static const ics9xxx_t ics9xxx_devices[] = {
 		{.bus = 7199, .ram_mult = 1, .pci_div = 2},
 		{.bus = 6682, .ram_mult = 1, .pci_div = 2}
 	}
-    },
-    [ICS9250_14] = {
+    ICS9xxx_DEVICE(ICS9250_14)
 	.max_reg = 5,
 	.regs = {0x02, 0x1f, 0xff, 0xff, 0xeb, 0xff},
 	.fs_regs = {{0, 4, 1, 6}, {0, 5, 4, 2}, {0, 6, 1, 5}, {0, 7, 1, 7}, {0, 2, 4, 4}},
+	.hw_select = {0, 3},
 	.frequencies = {
 		{.bus =  6781, .ram_mult = 1.5, .pci_div = 2},
 		{.bus =  7000, .ram_mult = 1.5, .pci_div = 2},
@@ -245,11 +306,11 @@ static const ics9xxx_t ics9xxx_devices[] = {
 		{.bus = 13975, .ram_mult =   1, .pci_div = 3},
 		{.bus = 14969, .ram_mult =   1, .pci_div = 3}
 	}
-    },
-    [ICS9250_16] = {
+    ICS9xxx_DEVICE(ICS9250_16)
 	.max_reg = 5,
 	.regs = {0x1f, 0xff, 0xff, 0x00, 0x00, 0x06},
-	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
+	.fs_regs = {{5, 0, -1, -1}, {5, 3, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
+	.hw_select = {-1, -1},
 	.frequencies = {
 		{.bus =  6667, .ram_mult =  1.5, .pci_div = 2},
 		{.bus =  7000, .ram_mult =  1.5, .pci_div = 2},
@@ -268,11 +329,11 @@ static const ics9xxx_t ics9xxx_devices[] = {
 		{.bus = 14000, .ram_mult =    1, .pci_div = 4},
 		{.bus = 13299, .ram_mult =    1, .pci_div = 4}
 	}
-    },
-    [ICS9250_18] = {
+    ICS9xxx_DEVICE(ICS9250_18)
 	.max_reg = 5,
 	.regs = {0x02, 0xff, 0xff, 0xff, 0x6d, 0xbf},
 	.fs_regs = {{0, 4, 4, 7}, {0, 5, 4, 4}, {0, 6, 5, 6}, {0, 7, 4, 1}, {-1, -1, -1, -1}},
+	.hw_select = {0, 3},
 	.frequencies = {
 		{.bus =  8000, .pci_div = 2},
 		{.bus =  7500, .pci_div = 2},
@@ -307,17 +368,17 @@ static const ics9xxx_t ics9xxx_devices[] = {
 		{.bus = 14199, .pci_div = 4},
 		{.bus = 13801, .pci_div = 4}
 	}
-    },
-    [ICS9250_19] = {
+    ICS9xxx_DEVICE(ICS9250_19)
 	.max_reg = 5,
 	.regs = {0x02, 0xff, 0xff, 0xff, 0x6d, 0xbf},
 	.fs_regs = {{0, 4, 4, 7}, {0, 5, 4, 4}, {0, 6, 5, 6}, {0, 7, 4, 1}, {-1, -1, -1, -1}},
+	.hw_select = {0, 3},
 	.frequencies_ref = ICS9250_08
-    },
-    [ICS9250_23] = {
+    ICS9xxx_DEVICE(ICS9250_23)
 	.max_reg = 5,
 	.regs = {0x02, 0x1f, 0xff, 0xff, 0xeb, 0xff},
 	.fs_regs = {{0, 4, 1, 6}, {0, 5, 4, 2}, {0, 6, 1, 5}, {0, 7, 1, 7}, {0, 2, 4, 4}},
+	.hw_select = {0, 3},
 	.frequencies = {
 		{.bus =  6900, .ram_mult =  1.5, .pci_div = 2},
 		{.bus =  7000, .ram_mult =  1.5, .pci_div = 2},
@@ -352,11 +413,11 @@ static const ics9xxx_t ics9xxx_devices[] = {
 		{.bus = 15330, .ram_mult = 0.75, .pci_div = 4},
 		{.bus = 16667, .ram_mult = 0.75, .pci_div = 4}
 	}
-    },
-    [ICS9250_25] = {
+    ICS9xxx_DEVICE(ICS9250_25)
 	.max_reg = 6,
 	.regs = {0x02, 0x1f, 0xff, 0xff, 0xeb, 0xff, 0x06},
 	.fs_regs = {{0, 4, 1, 6}, {0, 5, 4, 2}, {0, 6, 1, 5}, {0, 7, 1, 7}, {0, 2, 4, 4}},
+	.hw_select = {0, 3},
 	.frequencies = {
 		{.bus =  5500, .ram_mult =  1.5, .pci_div = 2},
 		{.bus =  6000, .ram_mult =  1.5, .pci_div = 2},
@@ -391,17 +452,17 @@ static const ics9xxx_t ics9xxx_devices[] = {
 		{.bus = 15000, .ram_mult = 0.75, .pci_div = 4},
 		{.bus = 15333, .ram_mult = 0.75, .pci_div = 4}
 	}
-    },
-    [ICS9250_26] = {
+    ICS9xxx_DEVICE(ICS9250_26)
 	.max_reg = 5,
 	.regs = {0x1e, 0xff, 0xff, 0x00, 0x00, 0x06},
-	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
+	.fs_regs = {{5, 0, -1, -1}, {5, 3, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
+	.hw_select = {-1, -1},
 	.frequencies_ref = ICS9250_16
-    },
-    [ICS9250_27] = {
+    ICS9xxx_DEVICE(ICS9250_27)
 	.max_reg = 5,
 	.regs = {0x0f, 0xff, 0xfe, 0x00, 0x00, 0x00},
-	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
+	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {3, 0, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
+	.hw_select = {-1, -1},
 	.frequencies = {
 		{.bus =  6666, .ram_mult =  1.5, .pci_div = 2},
 		{.bus = 13332, .ram_mult =    1, .pci_div = 4},
@@ -412,23 +473,23 @@ static const ics9xxx_t ics9xxx_devices[] = {
 		{.bus = 10000, .ram_mult =    1, .pci_div = 3},
 		{.bus = 13332, .ram_mult =    1, .pci_div = 4}
 	}
-    },
-    [ICS9250_28] = {
+    ICS9xxx_DEVICE(ICS9250_28)
 	.max_reg = 4,
 	.regs = {0x1e, 0xff, 0xfe, 0x00, 0x00},
-	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
+	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {3, 0, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
+	.hw_select = {-1, -1},
 	.frequencies_ref = ICS9250_27
-    },
-    [ICS9250_29] = {
+    ICS9xxx_DEVICE(ICS9250_29)
 	.max_reg = 5,
 	.regs = {0x16, 0xff, 0xfe, 0x00, 0x00, 0x00},
-	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
+	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {3, 0, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
+	.hw_select = {-1, -1},
 	.frequencies_ref = ICS9250_27
-    },
-    [ICS9250_30] = {
+    ICS9xxx_DEVICE(ICS9250_30)
 	.max_reg = 6,
 	.regs = {0x02, 0x0f, 0xff, 0xff, 0xeb, 0xff, 0x06},
 	.fs_regs = {{0, 4, 1, 6}, {0, 5, 4, 2}, {0, 6, 1, 5}, {0, 7, 1, 7}, {0, 2, 4, 4}},
+	.hw_select = {0, 3},
 	.frequencies = {
 		{.bus =  6667, .ram_mult =  1.5, .pci_div = 2},
 		{.bus =  6000, .ram_mult =  1.5, .pci_div = 2},
@@ -463,13 +524,11 @@ static const ics9xxx_t ics9xxx_devices[] = {
 		{.bus = 15000, .ram_mult = 0.75, .pci_div = 4},
 		{.bus = 16000, .ram_mult = 0.75, .pci_div = 4}
 	}
-    },
-    [ICS9250_32] = {
+    ICS9xxx_DEVICE(ICS9250_32)
 	.max_reg = 4,
 	.regs = {0x07, 0xff, 0xff, 0x00, 0x00},
 	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}}
-    },
-    [ICS9250_38] = {
+    ICS9xxx_DEVICE(ICS9250_38)
 	.max_reg = 6,
 	.regs = {0x18, 0x07, 0xfe, 0xc7, 0xfc, 0x00, 0x80},
 	.fs_regs = {{0, 0, -1, -1}, {0, 1, -1, -1}, {0, 2, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
@@ -484,11 +543,11 @@ static const ics9xxx_t ics9xxx_devices[] = {
 		{.bus = 20000, .ram_mult = 1.0/3.0, .pci_div = 6},
 		{.bus = 13333, .ram_mult =     0.5, .pci_div = 2}
 	}
-    },
-    [ICS9250_50] = {
+    ICS9xxx_DEVICE(ICS9250_50)
 	.max_reg = 6,
 	.regs = {0x02, 0x6f, 0xff, 0xff, 0xef, 0xff, 0x06},
-	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {0, 7, 1, 7}, {0, 2, 4, 4}},
+	.fs_regs = {{-1, -1, 1, 6}, {-1, -1, 4, 2}, {-1, -1, 1, 5}, {0, 7, 1, 7}, {0, 2, 4, 4}},
+	.hw_select = {0, 3},
 	.frequencies = {
 		[0]  = {.bus =  6667, .ram_mult =  1.5, .pci_div = 2},
 		[8]  = {.bus = 10000, .ram_mult =    1, .pci_div = 3},
@@ -498,7 +557,7 @@ static const ics9xxx_t ics9xxx_devices[] = {
     }
 };
 
-#define ENABLE_ICS9xxx_LOG 1
+
 #ifdef ENABLE_ICS9xxx_LOG
 int ics9xxx_do_log = ENABLE_ICS9xxx_LOG;
 
@@ -516,6 +575,84 @@ ics9xxx_log(const char *fmt, ...)
 }
 #else
 #define ics9xxx_log(fmt, ...)
+#endif
+
+
+#ifdef ENABLE_ICS9xxx_DETECT
+static uint16_t	detect_bus = 0;
+static uint8_t	detect_reg = 0;
+static uint8_t	discarded[sizeof(ics9xxx_devices) / sizeof(ics9xxx_devices[0])] = {0};
+
+
+static void
+ics9xxx_detect_reset(void *priv)
+{
+    pclog("Please enter the frequency set in the BIOS (7500 for 75.00 MHz)\nAnswer 0 if unsure or set to auto, I'll ask again next reset.\n");
+    scanf("%hu", &detect_bus);
+    if ((detect_bus > 0) && (detect_bus < 1000))
+    	detect_bus *= 100;
+    pclog("Frequency interpreted as %d\n", detect_bus);
+}
+
+
+static void
+ics9xxx_detect(ics9xxx_t *dev)
+{
+    if (!detect_bus) {
+    	pclog("Frequency not entered on this reset, ignoring change.\n");
+    	return;
+    }
+
+    if ((detect_reg == 0) && (dev->regs[detect_reg] >= 0xfe)) {
+    	pclog("Register %d set to %02X, probably not it, trying %d instead\n", detect_reg, dev->regs[detect_reg], 3);
+    	detect_reg = 3;
+    	dev->relevant_regs = 1 << detect_reg;
+    	return;
+    }
+
+    if (!(dev->regs[detect_reg] & 0x40))
+	pclog("Bit 3 of register %d is clear, probably in hardware select mode!\n", detect_reg);
+
+    uint8_t matches = 0, val, bitmask;
+    ics9xxx_frequency_t *frequencies_ptr;
+    uint32_t delta;
+    for (uint8_t j = 0; j < ICS9xxx_MAX; j++) {
+    	if (discarded[j])
+    		continue;
+    	discarded[j] = 1;
+
+	frequencies_ptr = (ics9xxx_frequency_t *) ics9xxx_devices[ics9xxx_devices[j].frequencies_ref ? ics9xxx_devices[j].frequencies_ref : j].frequencies;
+	if (!frequencies_ptr)
+		continue;
+
+	for (uint8_t i = 0; i < (sizeof(ics9xxx_devices[j].frequencies) / sizeof(ics9xxx_devices[j].frequencies[0])); i++) {
+		if (!frequencies_ptr[i].bus)
+			continue;
+
+		delta = ABS((int32_t) (detect_bus - frequencies_ptr[i].bus));
+		if (delta <= 100) {
+			val = bitmask = 0;
+			for (uint8_t k = 0; k < sizeof(ics9xxx_devices[j].fs_regs) / sizeof(ics9xxx_devices[j].fs_regs[0]); k++) {
+				if (ics9xxx_devices[j].fs_regs[k].normal_reg == detect_reg) {
+					bitmask |= 1 << k;
+					val |= (1 << k) * !!(dev->regs[detect_reg] & (1 << ics9xxx_devices[j].fs_regs[k].normal_bit));
+				}
+			}
+			if (bitmask && (val == (i & bitmask))) {
+				matches++;
+				discarded[j] = 0;
+				pclog("> Potential match for %s (frequency %d index %d)\n", ics9xxx_devices[j].name, frequencies_ptr[i].bus, val);
+			}
+		}
+	}
+    }
+
+    pclog("Found a total of %d matches for register %d value %02X and bus frequency %d\n", matches, detect_reg, dev->regs[detect_reg], detect_bus);
+    if (matches == 0) {
+    	pclog("Resetting list of discarded models since there were no matches.\n");
+    	memset(discarded, 0, sizeof(discarded));
+    }
+}
 #endif
 
 
@@ -557,13 +694,23 @@ ics9xxx_read(void *bus, uint8_t addr, void *priv)
 static void
 ics9xxx_set(ics9xxx_t *dev, uint8_t val)
 {
-    /* Add register-defined frequency bits to the static frequency bits we were passed. */
-    for (uint8_t i = 0; i < sizeof(dev->fs_regs) / sizeof(dev->fs_regs[0]); i++) {
-	if ((dev->fs_regs[i].normal_reg < 7) && (dev->regs[dev->fs_regs[i].normal_reg] & (1 << dev->fs_regs[i].normal_bit)))
-		val |= 1 << i;
+    /* Get the active mode, which determines what to add to the static frequency bits we were passed. */
+    uint8_t hw_select = (dev->hw_select.normal_reg < 7) && !(dev->regs[dev->hw_select.normal_reg] & (1 << dev->hw_select.normal_bit));
+    if (hw_select) {
+	/* Hardware select mode: add strapped frequency bits. */
+	val |= dev->bus_match;
+    } else {
+	/* Programmable mode: add register-defined frequency bits. */
+	for (uint8_t i = 0; i < sizeof(dev->fs_regs) / sizeof(dev->fs_regs[0]); i++) {
+		if ((dev->fs_regs[i].normal_reg < 7) && (dev->regs[dev->fs_regs[i].normal_reg] & (1 << dev->fs_regs[i].normal_bit)))
+			val |= 1 << i;
+	}
     }
 
-    ics9xxx_log("ICS9xxx: set(%02X) = %d\n", val, ics9xxx_devices[dev->model].frequencies[val].bus);
+#ifdef ENABLE_ICS9xxx_LOG
+    uint16_t bus = ics9xxx_devices[dev->model].frequencies[val].bus;
+    ics9xxx_log("ICS9xxx: set(%d) = hw=%d bus=%d ram=%d pci=%d\n", val, hw_select, bus, bus * ics9xxx_devices[dev->model].frequencies[val].ram_mult, bus / ics9xxx_devices[dev->model].frequencies[val].pci_div);
+#endif
 }
 
 
@@ -576,28 +723,22 @@ ics9xxx_write(void *bus, uint8_t addr, uint8_t data, void *priv)
 
     if (dev->addr_register >= 0) {
 	/* Preserve fixed bits. */
-	for (uint8_t i = 0; i < sizeof(dev->fs_regs) / sizeof(dev->fs_regs[0]); i++) {
-		if (dev->normal_bits_fixed && (dev->fs_regs[i].normal_reg == dev->addr_register))
-			data = (dev->regs[dev->addr_register] & (1 << dev->fs_regs[i].normal_bit)) | (data & ~(1 << dev->fs_regs[i].normal_bit));
-		if (dev->fs_regs[i].inv_reg == dev->addr_register)
-			data = (dev->regs[dev->addr_register] & (1 << dev->fs_regs[i].inv_bit)) | (data & ~(1 << dev->fs_regs[i].inv_bit));
+#ifdef ENABLE_ICS9xxx_DETECT
+	if (dev->model != ICS9xxx_xx)
+#endif
+	{
+		for (uint8_t i = 0; i < sizeof(dev->fs_regs) / sizeof(dev->fs_regs[0]); i++) {
+			if (dev->normal_bits_fixed && (dev->fs_regs[i].normal_reg == dev->addr_register))
+				data = (dev->regs[dev->addr_register] & (1 << dev->fs_regs[i].normal_bit)) | (data & ~(1 << dev->fs_regs[i].normal_bit));
+			if (dev->fs_regs[i].inv_reg == dev->addr_register)
+				data = (dev->regs[dev->addr_register] & (1 << dev->fs_regs[i].inv_bit)) | (data & ~(1 << dev->fs_regs[i].inv_bit));
+		}
 	}
 
 	switch (dev->addr_register) {
 		case 0:
 			if (dev->model == ICS9250_38)
 				data = (dev->regs[dev->addr_register] & ~0xe8) | (data & 0xe8);
-			else {
-				dev->regs[dev->addr_register] = data;
-				if (dev->model == ICS9250_10)
-					ics9xxx_set(dev, (cpu_busspeed >= 100000000) * 0x08);
-				else if ((dev->model == ICS9250_16) || (dev->model == ICS9250_26))
-					ics9xxx_set(dev, ((cpu_busspeed >= 120000000) * 0x08) | ((((cpu_busspeed >= 100000000) && (cpu_busspeed < 120000000)) || (cpu_busspeed == 150000000) || (cpu_busspeed == 132999999)) * 0x04));
-				else if ((dev->model == ICS9250_27) || (dev->model == ICS9250_28) || (dev->model == ICS9250_29))
-					ics9xxx_set(dev, ((cpu_busspeed == 100000000) * 0x02) | ((cpu_busspeed > 100000000) * 0x01));
-				else
-					ics9xxx_set(dev, 0x00);
-			}
 			break;
 
 		case 1:
@@ -621,8 +762,38 @@ ics9xxx_write(void *bus, uint8_t addr, uint8_t data, void *priv)
 			break;
 	}
 	dev->regs[dev->addr_register] = data;
+
+	/* Update frequency if a relevant register was written to. */
+	if (dev->relevant_regs & (1 << dev->addr_register)) {
+		switch (dev->model) {
+#ifdef ENABLE_ICS9xxx_DETECT
+			case ICS9xxx_xx:
+				ics9xxx_detect(dev);
+				break;
+#endif
+
+			case ICS9250_10:
+				ics9xxx_set(dev, (cpu_busspeed >= 100000000) * 0x08);
+				break;
+
+			case ICS9250_16:
+			case ICS9250_26:
+				ics9xxx_set(dev, ((cpu_busspeed >= 120000000) * 0x08) | ((((cpu_busspeed >= 100000000) && (cpu_busspeed < 120000000)) || (cpu_busspeed == 150000000) || (cpu_busspeed == 132999999)) * 0x04));
+				break;
+
+			case ICS9250_27:
+			case ICS9250_28:
+			case ICS9250_29:
+				ics9xxx_set(dev, ((cpu_busspeed == 100000000) * 0x02) | ((cpu_busspeed > 100000000) * 0x01));
+				break;
+
+			default:
+				ics9xxx_set(dev, 0x00);
+				break;
+		}
+	}
     }
-    
+
     if (++dev->addr_register > dev->max_reg)
 	dev->addr_register = 0; /* roll-over */
 
@@ -631,9 +802,12 @@ ics9xxx_write(void *bus, uint8_t addr, uint8_t data, void *priv)
 
 
 static uint8_t
-find_bus_match(ics9xxx_t *dev, uint32_t bus, uint8_t preset_mask, uint8_t preset) {
+ics9xxx_find_bus_match(ics9xxx_t *dev, uint32_t bus, uint8_t preset_mask, uint8_t preset) {
     uint8_t best_match = 0;
     uint32_t delta, best_delta = -1;
+
+    if (dev->model == ICS9xxx_xx)
+    	return 0;
 
     for (uint8_t i = 0; i < (sizeof(dev->frequencies) / sizeof(dev->frequencies[0])); i++) {
 	if (((i & preset_mask) != preset) || !dev->frequencies_ptr[i].bus)
@@ -646,7 +820,7 @@ find_bus_match(ics9xxx_t *dev, uint32_t bus, uint8_t preset_mask, uint8_t preset
 	}
     }
 
-    ics9xxx_log("ICS9xxx: find_match(%02X, %d) = %d (%02X)\n", dev->model, bus, dev->frequencies_ptr[best_match].bus, best_match);
+    ics9xxx_log("ICS9xxx: find_match(%02X, %d) = match=%d bus=%d\n", dev->model, bus, best_match, dev->frequencies_ptr[best_match].bus);
 
     return best_match;
 }
@@ -658,35 +832,59 @@ ics9xxx_init(const device_t *info)
     ics9xxx_t *dev = (ics9xxx_t *) malloc(sizeof(ics9xxx_t));
     memcpy(dev, &ics9xxx_devices[info->local], sizeof(ics9xxx_t));
 
-    ics9xxx_log("ICS9xxx: init(%02X)\n", info->local);
+    ics9xxx_log("ICS9xxx: init(%s)\n", dev->name);
 
-    dev->model = info->local;
-    dev->frequencies_ptr = (ics9xxx_frequency_t *) ics9xxx_devices[dev->frequencies_ref ? dev->frequencies_ref : dev->model].frequencies;
-    if (!dev->frequencies_ptr)
-	fatal("ICS9xxx: NULL frequency table\n");
-
-    /* Determine which frequency bits cannot be strapped (register only). */
-    uint8_t register_only_bits = 0x00;
     uint8_t i;
-    for (i = 0; i < sizeof(dev->fs_regs) / sizeof(dev->fs_regs[0]); i++) {
-	if ((dev->fs_regs[i].normal_reg == 7) && (dev->fs_regs[i].inv_reg == 7))
-		register_only_bits |= 1 << i;
-    }
+#ifdef ENABLE_ICS9xxx_DETECT
+    if (dev->model == ICS9xxx_xx) { /* detection device */
+	dev->max_reg = 6;
+	dev->relevant_regs = 1 << 0; /* register 0 matters the most on the detection device */
 
-    /* Find bus speed match and set default register bits accordingly. */
-    dev->bus_match = find_bus_match(dev, cpu_busspeed, register_only_bits, 0x00);
-    for (i = 0; i < sizeof(dev->fs_regs) / sizeof(dev->fs_regs[0]); i++) {
-	if (dev->fs_regs[i].normal_reg < 7) {
-		if (dev->bus_match & (1 << i))
-			dev->regs[dev->fs_regs[i].normal_reg] |= 1 << dev->fs_regs[i].normal_bit;
-		else
-			dev->regs[dev->fs_regs[i].normal_reg] &= ~(1 << dev->fs_regs[i].normal_bit);
+	for (i = 0; i < ICS9xxx_MAX; i++) {
+		for (uint8_t j = 0; j < ICS9xxx_MAX; j++) {
+			if (i == j)
+				continue;
+			if (!memcmp(&ics9xxx_devices[i], &ics9xxx_devices[j], sizeof(ics9xxx_devices[i])))
+				pclog("Optimization warning: %d and %d have duplicate tables\n", i, j);
+		}
 	}
-	if (dev->fs_regs[i].inv_reg < 7) {
-		if (dev->bus_match & (1 << i))
-			dev->regs[dev->fs_regs[i].inv_reg] &= ~(1 << dev->fs_regs[i].inv_bit);
-		else
-			dev->regs[dev->fs_regs[i].inv_reg] |= 1 << dev->fs_regs[i].inv_bit;
+
+	ics9xxx_detect_reset(dev);
+    } else
+#endif
+    { /* regular device */
+	dev->frequencies_ptr = (ics9xxx_frequency_t *) ics9xxx_devices[dev->frequencies_ref ? dev->frequencies_ref : dev->model].frequencies;
+	if (!dev->frequencies_ptr)
+		fatal("ICS9xxx: NULL frequency table\n");
+	
+	/* Determine which frequency bits cannot be strapped (register only). */
+	uint8_t register_only_bits = 0x00;
+	for (i = 0; i < sizeof(dev->fs_regs) / sizeof(dev->fs_regs[0]); i++) {
+		if (!dev->normal_bits_fixed && (dev->fs_regs[i].normal_reg < 7)) /* mark a normal, programmable bit as relevant */
+			dev->relevant_regs |= 1 << dev->fs_regs[i].normal_reg;
+		if ((dev->fs_regs[i].normal_reg == 7) && (dev->fs_regs[i].inv_reg == 7)) /* mark as register only */
+			register_only_bits |= 1 << i;
+	}
+	
+	/* Mark the hardware select bit's register as relevant, if there's one. */
+	if (dev->hw_select.normal_reg < 7)
+		dev->relevant_regs |= 1 << dev->hw_select.normal_reg;
+	
+	/* Find bus speed match and set default register bits accordingly. */
+	dev->bus_match = ics9xxx_find_bus_match(dev, cpu_busspeed, register_only_bits, 0x00);
+	for (i = 0; i < sizeof(dev->fs_regs) / sizeof(dev->fs_regs[0]); i++) {
+		if (dev->fs_regs[i].normal_reg < 7) {
+			if (dev->bus_match & (1 << i))
+				dev->regs[dev->fs_regs[i].normal_reg] |= 1 << dev->fs_regs[i].normal_bit;
+			else
+				dev->regs[dev->fs_regs[i].normal_reg] &= ~(1 << dev->fs_regs[i].normal_bit);
+		}
+		if (dev->fs_regs[i].inv_reg < 7) {
+			if (dev->bus_match & (1 << i))
+				dev->regs[dev->fs_regs[i].inv_reg] &= ~(1 << dev->fs_regs[i].inv_bit);
+			else
+				dev->regs[dev->fs_regs[i].inv_reg] |= 1 << dev->fs_regs[i].inv_bit;
+		}
 	}
     }
 
@@ -709,6 +907,18 @@ ics9xxx_close(void *priv)
 }
 
 
+#ifdef ENABLE_ICS9xxx_DETECT
+const device_t ics9xxx_detect_device = {
+    "ICS9xxx-xx Clock Generator",
+    DEVICE_PCI,
+    ICS9xxx_xx,
+    ics9xxx_init, ics9xxx_close, ics9xxx_detect_reset,
+    { NULL }, NULL, NULL,
+    NULL
+};
+#endif
+
+
 const device_t ics9150_08_device = {
     "ICS9150-08 Clock Generator",
     DEVICE_ISA,
@@ -729,10 +939,30 @@ const device_t ics9248_39_device = {
 };
 
 
+const device_t ics9248_81_device = {
+    "ICS9248-81 Clock Generator",
+    DEVICE_ISA,
+    ICS9248_81,
+    ics9xxx_init, ics9xxx_close, NULL,
+    { NULL }, NULL, NULL,
+    NULL
+};
+
+
 const device_t ics9248_98_device = {
     "ICS9248-98 Clock Generator",
     DEVICE_ISA,
     ICS9248_98,
+    ics9xxx_init, ics9xxx_close, NULL,
+    { NULL }, NULL, NULL,
+    NULL
+};
+
+
+const device_t ics9248_101_device = {
+    "ICS9248-101 Clock Generator",
+    DEVICE_ISA,
+    ICS9248_101,
     ics9xxx_init, ics9xxx_close, NULL,
     { NULL }, NULL, NULL,
     NULL

--- a/src/device/clock_ics9xxx.c
+++ b/src/device/clock_ics9xxx.c
@@ -586,7 +586,7 @@ ics9xxx_write(void *bus, uint8_t addr, uint8_t data, void *priv)
 	switch (dev->addr_register) {
 		case 0:
 			if (dev->model == ICS9250_38)
-				data = (dev->regs[dev->addr_register] & ~0xef) | (data & 0xef);
+				data = (dev->regs[dev->addr_register] & ~0xe8) | (data & 0xe8);
 			else {
 				dev->regs[dev->addr_register] = data;
 				if (dev->model == ICS9250_10)
@@ -616,7 +616,7 @@ ics9xxx_write(void *bus, uint8_t addr, uint8_t data, void *priv)
 			break;
 
 		case 6:
-			if (dev->model == ICS9250_38)
+			if (dev->model == ICS9250_38) /* read-only */
 				data = dev->regs[dev->addr_register];
 			break;
 	}

--- a/src/device/clock_ics9xxx.c
+++ b/src/device/clock_ics9xxx.c
@@ -832,7 +832,7 @@ ics9xxx_init(const device_t *info)
     ics9xxx_t *dev = (ics9xxx_t *) malloc(sizeof(ics9xxx_t));
     memcpy(dev, &ics9xxx_devices[info->local], sizeof(ics9xxx_t));
 
-    ics9xxx_log("ICS9xxx: init(%s)\n", dev->name);
+    ics9xxx_log("ICS9xxx: init(%s)\n", ics9xxx_devices[info->local].name);
 
     uint8_t i;
 #ifdef ENABLE_ICS9xxx_DETECT

--- a/src/device/clock_ics9xxx.c
+++ b/src/device/clock_ics9xxx.c
@@ -490,10 +490,10 @@ static const ics9xxx_t ics9xxx_devices[] = {
 	.regs = {0x02, 0x6f, 0xff, 0xff, 0xef, 0xff, 0x06},
 	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {0, 7, 1, 7}, {0, 2, 4, 4}},
 	.frequencies = {
-		{.bus =  6667, .ram_mult =  1.5, .pci_div = 2},
-		{.bus = 10000, .ram_mult =    1, .pci_div = 3},
-		{.bus = 13333, .ram_mult =    1, .pci_div = 4},
-		{.bus = 13333, .ram_mult = 0.75, .pci_div = 4}
+		[0]  = {.bus =  6667, .ram_mult =  1.5, .pci_div = 2},
+		[8]  = {.bus = 10000, .ram_mult =    1, .pci_div = 3},
+		[16] = {.bus = 13333, .ram_mult =    1, .pci_div = 4},
+		[24] = {.bus = 13333, .ram_mult = 0.75, .pci_div = 4}
 	}
     }
 };

--- a/src/device/clock_ics9xxx.c
+++ b/src/device/clock_ics9xxx.c
@@ -587,14 +587,17 @@ ics9xxx_write(void *bus, uint8_t addr, uint8_t data, void *priv)
 		case 0:
 			if (dev->model == ICS9250_38)
 				data = (dev->regs[dev->addr_register] & ~0xef) | (data & 0xef);
-			else if (dev->model == ICS9250_10)
-				ics9xxx_set(dev, (cpu_busspeed >= 100000000) * 0x08);
-			else if ((dev->model == ICS9250_16) || (dev->model == ICS9250_26))
-				ics9xxx_set(dev, ((cpu_busspeed >= 120000000) * 0x08) | ((((cpu_busspeed >= 100000000) && (cpu_busspeed < 120000000)) || (cpu_busspeed == 150000000) || (cpu_busspeed == 132999999)) * 0x04));
-			else if ((dev->model == ICS9250_27) || (dev->model == ICS9250_28) || (dev->model == ICS9250_29))
-				ics9xxx_set(dev, ((cpu_busspeed == 100000000) * 0x02) | ((cpu_busspeed > 100000000) * 0x01));
-			else
-				ics9xxx_set(dev, 0x00);
+			else {
+				dev->regs[dev->addr_register] = data;
+				if (dev->model == ICS9250_10)
+					ics9xxx_set(dev, (cpu_busspeed >= 100000000) * 0x08);
+				else if ((dev->model == ICS9250_16) || (dev->model == ICS9250_26))
+					ics9xxx_set(dev, ((cpu_busspeed >= 120000000) * 0x08) | ((((cpu_busspeed >= 100000000) && (cpu_busspeed < 120000000)) || (cpu_busspeed == 150000000) || (cpu_busspeed == 132999999)) * 0x04));
+				else if ((dev->model == ICS9250_27) || (dev->model == ICS9250_28) || (dev->model == ICS9250_29))
+					ics9xxx_set(dev, ((cpu_busspeed == 100000000) * 0x02) | ((cpu_busspeed > 100000000) * 0x01));
+				else
+					ics9xxx_set(dev, 0x00);
+			}
 			break;
 
 		case 1:

--- a/src/device/clock_ics9xxx.c
+++ b/src/device/clock_ics9xxx.c
@@ -61,10 +61,10 @@ typedef struct {
     uint8_t	max_reg: 3;
     uint8_t	regs[8];
     struct {
-    	uint8_t	normal_reg: 3;
-    	uint8_t	normal_bit: 3;
-    	uint8_t	inv_reg: 3;
-    	uint8_t	inv_bit: 3;
+	uint8_t	normal_reg: 3;
+	uint8_t	normal_bit: 3;
+	uint8_t	inv_reg: 3;
+	uint8_t	inv_bit: 3;
     } fs_regs[5];
     uint8_t	normal_bits_fixed: 1;
 
@@ -79,10 +79,10 @@ typedef struct {
 
 static const ics9xxx_t ics9xxx_devices[] = {
     [ICS9150_08] = {
-    	.max_reg = 5,
-    	.regs = {0x00, 0xff, 0xff, 0xff, 0x6f, 0xbf},
-    	.fs_regs = {{0, 4, 4, 7}, {0, 5, 4, 4}, {0, 6, 5, 6}, {0, 7, 4, 1}, {-1, -1, -1, -1}},
-    	.frequencies = {
+	.max_reg = 5,
+	.regs = {0x00, 0xff, 0xff, 0xff, 0x6f, 0xbf},
+	.fs_regs = {{0, 4, 4, 7}, {0, 5, 4, 4}, {0, 6, 5, 6}, {0, 7, 4, 1}, {-1, -1, -1, -1}},
+	.frequencies = {
 		{.bus =  5000, .pci_div = 2},
 		{.bus =  7500, .pci_div = 2},
 		{.bus =  8333, .pci_div = 2},
@@ -90,37 +90,37 @@ static const ics9xxx_t ics9xxx_devices[] = {
 		{.bus = 10300, .pci_div = 3},
 		{.bus = 11200, .pci_div = 3},
 		{.bus = 13333, .pci_div = 4},
-	    	{.bus = 10020, .pci_div = 3},
+		{.bus = 10020, .pci_div = 3},
 	}
     },
     [ICS9248_39] = {
-    	.max_reg = 5,
-    	.regs = {0x00, 0x7f, 0xff, 0xbf, 0xf5, 0xff},
-    	.fs_regs = {{0, 4, 3, 6}, {0, 5, 4, 3}, {0, 6, 1, 7}, {0, 7, 4, 1}, {-1, -1, -1, -1}},
-    	.frequencies = {
-    		{.bus = 12400, .pci_div = 3},
-	    	{.bus =  7500, .pci_div = 2},
-	    	{.bus =  8333, .pci_div = 2},
-	    	{.bus =  6680, .pci_div = 2},
-	    	{.bus = 10300, .pci_div = 3},
-	    	{.bus = 11200, .pci_div = 3},
-	    	{.bus = 13300, .pci_div = 3},
-	    	{.bus = 10030, .pci_div = 3},
-	    	{.bus = 12000, .pci_div = 3},
-	    	{.bus = 11500, .pci_div = 3},
-	    	{.bus = 11000, .pci_div = 3},
-	    	{.bus = 10500, .pci_div = 3},
-	    	{.bus = 14000, .pci_div = 4},
-	    	{.bus = 15000, .pci_div = 4},
-	    	{.bus = 12400, .pci_div = 4},
-	    	{.bus = 13300, .pci_div = 4}
-    	}
+	.max_reg = 5,
+	.regs = {0x00, 0x7f, 0xff, 0xbf, 0xf5, 0xff},
+	.fs_regs = {{0, 4, 3, 6}, {0, 5, 4, 3}, {0, 6, 1, 7}, {0, 7, 4, 1}, {-1, -1, -1, -1}},
+	.frequencies = {
+		{.bus = 12400, .pci_div = 3},
+		{.bus =  7500, .pci_div = 2},
+		{.bus =  8333, .pci_div = 2},
+		{.bus =  6680, .pci_div = 2},
+		{.bus = 10300, .pci_div = 3},
+		{.bus = 11200, .pci_div = 3},
+		{.bus = 13300, .pci_div = 3},
+		{.bus = 10030, .pci_div = 3},
+		{.bus = 12000, .pci_div = 3},
+		{.bus = 11500, .pci_div = 3},
+		{.bus = 11000, .pci_div = 3},
+		{.bus = 10500, .pci_div = 3},
+		{.bus = 14000, .pci_div = 4},
+		{.bus = 15000, .pci_div = 4},
+		{.bus = 12400, .pci_div = 4},
+		{.bus = 13300, .pci_div = 4}
+	}
     },
     [ICS9248_98] = {
-    	.max_reg = 6,
-    	.regs = {0x00, 0x7f, 0xff, 0xbf, 0xf5, 0xff, 0x06},
-    	.fs_regs = {{0, 4, 3, 6}, {0, 5, 4, 3}, {0, 6, 1, 7}, {0, 7, 4, 1}, {-1, -1, -1, -1}},
-    	.frequencies = {
+	.max_reg = 6,
+	.regs = {0x00, 0x7f, 0xff, 0xbf, 0xf5, 0xff, 0x06},
+	.fs_regs = {{0, 4, 3, 6}, {0, 5, 4, 3}, {0, 6, 1, 7}, {0, 7, 4, 1}, {-1, -1, -1, -1}},
+	.frequencies = {
 		{.bus =  8000, .pci_div = 2},
 		{.bus =  7500, .pci_div = 2},
 		{.bus =  8331, .pci_div = 2},
@@ -156,16 +156,16 @@ static const ics9xxx_t ics9xxx_devices[] = {
 	}
     },
     [ICS9250_08] = {
-    	.max_reg = 5,
-    	.regs = {0x00, 0xff, 0xff, 0xff, 0x6d, 0xbf},
-    	.fs_regs = {{0, 4, 4, 7}, {0, 5, 4, 4}, {0, 6, 5, 6}, {0, 7, 4, 1}, {-1, -1, -1, -1}},
-    	.frequencies_ref = ICS9248_39
+	.max_reg = 5,
+	.regs = {0x00, 0xff, 0xff, 0xff, 0x6d, 0xbf},
+	.fs_regs = {{0, 4, 4, 7}, {0, 5, 4, 4}, {0, 6, 5, 6}, {0, 7, 4, 1}, {-1, -1, -1, -1}},
+	.frequencies_ref = ICS9248_39
     },
     [ICS9250_10] = {
-    	.max_reg = 5,
-    	.regs = {0x1f, 0xff, 0xfe, 0x00, 0x00, 0x06},
-    	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
-    	.frequencies = {
+	.max_reg = 5,
+	.regs = {0x1f, 0xff, 0xfe, 0x00, 0x00, 0x06},
+	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
+	.frequencies = {
 		{.bus =  6667, .ram_mult = 1.5, .pci_div = 2},
 		{.bus =  7067, .ram_mult = 1.5, .pci_div = 2},
 		{.bus =  7466, .ram_mult = 1.5, .pci_div = 2},
@@ -185,10 +185,10 @@ static const ics9xxx_t ics9xxx_devices[] = {
 	}
     },
     [ICS9250_13] = {
-    	.max_reg = 5,
-    	.regs = {0x82, 0xcf, 0x7f, 0xff, 0xff, 0xf7},
-    	.fs_regs = {{0, 4, 1, 4}, {0, 5, 5, 7}, {0, 6, 1, 5}, {0, 2, 2, 7}, {-1, -1, -1, -1}},
-    	.frequencies = {
+	.max_reg = 5,
+	.regs = {0x82, 0xcf, 0x7f, 0xff, 0xff, 0xf7},
+	.fs_regs = {{0, 4, 1, 4}, {0, 5, 5, 7}, {0, 6, 1, 5}, {0, 2, 2, 7}, {-1, -1, -1, -1}},
+	.frequencies = {
 		{.bus = 9000, .ram_mult = 1, .pci_div = 2},
 		{.bus = 8901, .ram_mult = 1, .pci_div = 2},
 		{.bus = 8800, .ram_mult = 1, .pci_div = 2},
@@ -208,10 +208,10 @@ static const ics9xxx_t ics9xxx_devices[] = {
 	}
     },
     [ICS9250_14] = {
-    	.max_reg = 5,
-    	.regs = {0x02, 0x1f, 0xff, 0xff, 0xeb, 0xff},
-    	.fs_regs = {{0, 4, 1, 6}, {0, 5, 4, 2}, {0, 6, 1, 5}, {0, 7, 1, 7}, {0, 2, 4, 4}},
-    	.frequencies = {
+	.max_reg = 5,
+	.regs = {0x02, 0x1f, 0xff, 0xff, 0xeb, 0xff},
+	.fs_regs = {{0, 4, 1, 6}, {0, 5, 4, 2}, {0, 6, 1, 5}, {0, 7, 1, 7}, {0, 2, 4, 4}},
+	.frequencies = {
 		{.bus =  6781, .ram_mult = 1.5, .pci_div = 2},
 		{.bus =  7000, .ram_mult = 1.5, .pci_div = 2},
 		{.bus =  7201, .ram_mult = 1.5, .pci_div = 2},
@@ -247,10 +247,10 @@ static const ics9xxx_t ics9xxx_devices[] = {
 	}
     },
     [ICS9250_16] = {
-    	.max_reg = 5,
-    	.regs = {0x1f, 0xff, 0xff, 0x00, 0x00, 0x06},
-    	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
-    	.frequencies = {
+	.max_reg = 5,
+	.regs = {0x1f, 0xff, 0xff, 0x00, 0x00, 0x06},
+	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
+	.frequencies = {
 		{.bus =  6667, .ram_mult =  1.5, .pci_div = 2},
 		{.bus =  7000, .ram_mult =  1.5, .pci_div = 2},
 		{.bus =  7267, .ram_mult =  1.5, .pci_div = 2},
@@ -270,10 +270,10 @@ static const ics9xxx_t ics9xxx_devices[] = {
 	}
     },
     [ICS9250_18] = {
-    	.max_reg = 5,
-    	.regs = {0x02, 0xff, 0xff, 0xff, 0x6d, 0xbf},
-    	.fs_regs = {{0, 4, 4, 7}, {0, 5, 4, 4}, {0, 6, 5, 6}, {0, 7, 4, 1}, {-1, -1, -1, -1}},
-    	.frequencies = {
+	.max_reg = 5,
+	.regs = {0x02, 0xff, 0xff, 0xff, 0x6d, 0xbf},
+	.fs_regs = {{0, 4, 4, 7}, {0, 5, 4, 4}, {0, 6, 5, 6}, {0, 7, 4, 1}, {-1, -1, -1, -1}},
+	.frequencies = {
 		{.bus =  8000, .pci_div = 2},
 		{.bus =  7500, .pci_div = 2},
 		{.bus =  8331, .pci_div = 2},
@@ -309,15 +309,15 @@ static const ics9xxx_t ics9xxx_devices[] = {
 	}
     },
     [ICS9250_19] = {
-    	.max_reg = 5,
-    	.regs = {0x02, 0xff, 0xff, 0xff, 0x6d, 0xbf},
-    	.fs_regs = {{0, 4, 4, 7}, {0, 5, 4, 4}, {0, 6, 5, 6}, {0, 7, 4, 1}, {-1, -1, -1, -1}},
-    	.frequencies_ref = ICS9250_08
+	.max_reg = 5,
+	.regs = {0x02, 0xff, 0xff, 0xff, 0x6d, 0xbf},
+	.fs_regs = {{0, 4, 4, 7}, {0, 5, 4, 4}, {0, 6, 5, 6}, {0, 7, 4, 1}, {-1, -1, -1, -1}},
+	.frequencies_ref = ICS9250_08
     },
     [ICS9250_23] = {
-    	.max_reg = 5,
-    	.regs = {0x02, 0x1f, 0xff, 0xff, 0xeb, 0xff},
-    	.fs_regs = {{0, 4, 1, 6}, {0, 5, 4, 2}, {0, 6, 1, 5}, {0, 7, 1, 7}, {0, 2, 4, 4}},
+	.max_reg = 5,
+	.regs = {0x02, 0x1f, 0xff, 0xff, 0xeb, 0xff},
+	.fs_regs = {{0, 4, 1, 6}, {0, 5, 4, 2}, {0, 6, 1, 5}, {0, 7, 1, 7}, {0, 2, 4, 4}},
 	.frequencies = {
 		{.bus =  6900, .ram_mult =  1.5, .pci_div = 2},
 		{.bus =  7000, .ram_mult =  1.5, .pci_div = 2},
@@ -354,9 +354,9 @@ static const ics9xxx_t ics9xxx_devices[] = {
 	}
     },
     [ICS9250_25] = {
-    	.max_reg = 6,
-    	.regs = {0x02, 0x1f, 0xff, 0xff, 0xeb, 0xff, 0x06},
-    	.fs_regs = {{0, 4, 1, 6}, {0, 5, 4, 2}, {0, 6, 1, 5}, {0, 7, 1, 7}, {0, 2, 4, 4}},
+	.max_reg = 6,
+	.regs = {0x02, 0x1f, 0xff, 0xff, 0xeb, 0xff, 0x06},
+	.fs_regs = {{0, 4, 1, 6}, {0, 5, 4, 2}, {0, 6, 1, 5}, {0, 7, 1, 7}, {0, 2, 4, 4}},
 	.frequencies = {
 		{.bus =  5500, .ram_mult =  1.5, .pci_div = 2},
 		{.bus =  6000, .ram_mult =  1.5, .pci_div = 2},
@@ -393,16 +393,16 @@ static const ics9xxx_t ics9xxx_devices[] = {
 	}
     },
     [ICS9250_26] = {
-    	.max_reg = 5,
-    	.regs = {0x1e, 0xff, 0xff, 0x00, 0x00, 0x06},
-    	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
-    	.frequencies_ref = ICS9250_16
+	.max_reg = 5,
+	.regs = {0x1e, 0xff, 0xff, 0x00, 0x00, 0x06},
+	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
+	.frequencies_ref = ICS9250_16
     },
     [ICS9250_27] = {
-    	.max_reg = 5,
-    	.regs = {0x0f, 0xff, 0xfe, 0x00, 0x00, 0x00},
-    	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
-    	.frequencies = {
+	.max_reg = 5,
+	.regs = {0x0f, 0xff, 0xfe, 0x00, 0x00, 0x00},
+	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
+	.frequencies = {
 		{.bus =  6666, .ram_mult =  1.5, .pci_div = 2},
 		{.bus = 13332, .ram_mult =    1, .pci_div = 4},
 		{.bus = 10000, .ram_mult =    1, .pci_div = 3},
@@ -414,22 +414,22 @@ static const ics9xxx_t ics9xxx_devices[] = {
 	}
     },
     [ICS9250_28] = {
-    	.max_reg = 4,
-    	.regs = {0x1e, 0xff, 0xfe, 0x00, 0x00},
-    	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
-    	.frequencies_ref = ICS9250_27
+	.max_reg = 4,
+	.regs = {0x1e, 0xff, 0xfe, 0x00, 0x00},
+	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
+	.frequencies_ref = ICS9250_27
     },
     [ICS9250_29] = {
-    	.max_reg = 5,
-    	.regs = {0x16, 0xff, 0xfe, 0x00, 0x00, 0x00},
-    	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
-    	.frequencies_ref = ICS9250_27
+	.max_reg = 5,
+	.regs = {0x16, 0xff, 0xfe, 0x00, 0x00, 0x00},
+	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
+	.frequencies_ref = ICS9250_27
     },
     [ICS9250_30] = {
-    	.max_reg = 6,
-    	.regs = {0x02, 0x0f, 0xff, 0xff, 0xeb, 0xff, 0x06},
-    	.fs_regs = {{0, 4, 1, 6}, {0, 5, 4, 2}, {0, 6, 1, 5}, {0, 7, 1, 7}, {0, 2, 4, 4}},
-    	.frequencies = {
+	.max_reg = 6,
+	.regs = {0x02, 0x0f, 0xff, 0xff, 0xeb, 0xff, 0x06},
+	.fs_regs = {{0, 4, 1, 6}, {0, 5, 4, 2}, {0, 6, 1, 5}, {0, 7, 1, 7}, {0, 2, 4, 4}},
+	.frequencies = {
 		{.bus =  6667, .ram_mult =  1.5, .pci_div = 2},
 		{.bus =  6000, .ram_mult =  1.5, .pci_div = 2},
 		{.bus =  6680, .ram_mult =  1.5, .pci_div = 2},
@@ -465,36 +465,36 @@ static const ics9xxx_t ics9xxx_devices[] = {
 	}
     },
     [ICS9250_32] = {
-    	.max_reg = 4,
-    	.regs = {0x07, 0xff, 0xff, 0x00, 0x00},
-    	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}}
+	.max_reg = 4,
+	.regs = {0x07, 0xff, 0xff, 0x00, 0x00},
+	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}}
     },
     [ICS9250_38] = {
-    	.max_reg = 6,
-    	.regs = {0x18, 0x07, 0xfe, 0xc7, 0xfc, 0x00, 0x80},
-    	.fs_regs = {{0, 0, -1, -1}, {0, 1, -1, -1}, {0, 2, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
-    	.normal_bits_fixed = 1,
-    	.frequencies = {
-	    	{.bus =  6666, .ram_mult =       1, .pci_div = 1},
-	    	{.bus = 10000, .ram_mult = 2.0/3.0, .pci_div = 3},
-	    	{.bus = 20000, .ram_mult = 1.0/3.0, .pci_div = 6},
-	    	{.bus = 13333, .ram_mult =     0.5, .pci_div = 2},
-	    	{.bus =  6666, .ram_mult =       1, .pci_div = 1},
-	    	{.bus = 10000, .ram_mult = 2.0/3.0, .pci_div = 3},
-	    	{.bus = 20000, .ram_mult = 1.0/3.0, .pci_div = 6},
-	    	{.bus = 13333, .ram_mult =     0.5, .pci_div = 2}
+	.max_reg = 6,
+	.regs = {0x18, 0x07, 0xfe, 0xc7, 0xfc, 0x00, 0x80},
+	.fs_regs = {{0, 0, -1, -1}, {0, 1, -1, -1}, {0, 2, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
+	.normal_bits_fixed = 1,
+	.frequencies = {
+		{.bus =  6666, .ram_mult =       1, .pci_div = 1},
+		{.bus = 10000, .ram_mult = 2.0/3.0, .pci_div = 3},
+		{.bus = 20000, .ram_mult = 1.0/3.0, .pci_div = 6},
+		{.bus = 13333, .ram_mult =     0.5, .pci_div = 2},
+		{.bus =  6666, .ram_mult =       1, .pci_div = 1},
+		{.bus = 10000, .ram_mult = 2.0/3.0, .pci_div = 3},
+		{.bus = 20000, .ram_mult = 1.0/3.0, .pci_div = 6},
+		{.bus = 13333, .ram_mult =     0.5, .pci_div = 2}
 	}
     },
     [ICS9250_50] = {
-    	.max_reg = 6,
-    	.regs = {0x02, 0x6f, 0xff, 0xff, 0xef, 0xff, 0x06},
-    	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {0, 7, 1, 7}, {0, 2, 4, 4}},
-    	.frequencies = {
-    		{.bus =  6667, .ram_mult =  1.5, .pci_div = 2},
-    		{.bus = 10000, .ram_mult =    1, .pci_div = 3},
-    		{.bus = 13333, .ram_mult =    1, .pci_div = 4},
-    		{.bus = 13333, .ram_mult = 0.75, .pci_div = 4}
-    	}
+	.max_reg = 6,
+	.regs = {0x02, 0x6f, 0xff, 0xff, 0xef, 0xff, 0x06},
+	.fs_regs = {{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {0, 7, 1, 7}, {0, 2, 4, 4}},
+	.frequencies = {
+		{.bus =  6667, .ram_mult =  1.5, .pci_div = 2},
+		{.bus = 10000, .ram_mult =    1, .pci_div = 3},
+		{.bus = 13333, .ram_mult =    1, .pci_div = 4},
+		{.bus = 13333, .ram_mult = 0.75, .pci_div = 4}
+	}
     }
 };
 
@@ -539,16 +539,16 @@ ics9xxx_read(void *bus, uint8_t addr, void *priv)
     uint8_t ret = 0xff;
 
     if (dev->addr_register < 0) {
-    	dev->addr_register = -1;
+	dev->addr_register = -1;
 	ret = dev->max_reg + 1;
     } else if ((dev->model == ICS9250_50) && (dev->addr_register == 0))
-    	ret = dev->regs[dev->addr_register] & 0x0b; /* -50 reads back revision ID instead */
+	ret = dev->regs[dev->addr_register] & 0x0b; /* -50 reads back revision ID instead */
     else
 	ret = dev->regs[dev->addr_register];
 
     ics9xxx_log("ICS9xxx: read(%02X) = %02X\n", dev->addr_register, ret);
     if (++dev->addr_register > dev->max_reg)
-    	dev->addr_register = 0; /* roll-over */
+	dev->addr_register = 0; /* roll-over */
 
     return ret;
 }
@@ -559,8 +559,8 @@ ics9xxx_set(ics9xxx_t *dev, uint8_t val)
 {
     /* Add register-defined frequency bits to the static frequency bits we were passed. */
     for (uint8_t i = 0; i < sizeof(dev->fs_regs) / sizeof(dev->fs_regs[0]); i++) {
-    	if ((dev->fs_regs[i].normal_reg < 7) && (dev->regs[dev->fs_regs[i].normal_reg] & (1 << dev->fs_regs[i].normal_bit)))
-    		val |= 1 << i;
+	if ((dev->fs_regs[i].normal_reg < 7) && (dev->regs[dev->fs_regs[i].normal_reg] & (1 << dev->fs_regs[i].normal_bit)))
+		val |= 1 << i;
     }
 
     ics9xxx_log("ICS9xxx: set(%02X) = %d\n", val, ics9xxx_devices[dev->model].frequencies[val].bus);
@@ -575,53 +575,53 @@ ics9xxx_write(void *bus, uint8_t addr, uint8_t data, void *priv)
     ics9xxx_log("ICS9xxx: write(%02X, %02X)\n", dev->addr_register, data);
 
     if (dev->addr_register >= 0) {
-    	/* Preserve fixed bits. */
-    	for (uint8_t i = 0; i < sizeof(dev->fs_regs) / sizeof(dev->fs_regs[0]); i++) {
-    		if (dev->normal_bits_fixed && (dev->fs_regs[i].normal_reg == dev->addr_register))
-    			data = (dev->regs[dev->addr_register] & (1 << dev->fs_regs[i].normal_bit)) | (data & ~(1 << dev->fs_regs[i].normal_bit));
-    		if (dev->fs_regs[i].inv_reg == dev->addr_register)
-    			data = (dev->regs[dev->addr_register] & (1 << dev->fs_regs[i].inv_bit)) | (data & ~(1 << dev->fs_regs[i].inv_bit));
-    	}
+	/* Preserve fixed bits. */
+	for (uint8_t i = 0; i < sizeof(dev->fs_regs) / sizeof(dev->fs_regs[0]); i++) {
+		if (dev->normal_bits_fixed && (dev->fs_regs[i].normal_reg == dev->addr_register))
+			data = (dev->regs[dev->addr_register] & (1 << dev->fs_regs[i].normal_bit)) | (data & ~(1 << dev->fs_regs[i].normal_bit));
+		if (dev->fs_regs[i].inv_reg == dev->addr_register)
+			data = (dev->regs[dev->addr_register] & (1 << dev->fs_regs[i].inv_bit)) | (data & ~(1 << dev->fs_regs[i].inv_bit));
+	}
 
-    	switch (dev->addr_register) {
-    		case 0:
-    			if (dev->model == ICS9250_38)
-    				data = (dev->regs[dev->addr_register] & ~0xef) | (data & 0xef);
-    			else if (dev->model == ICS9250_10)
-    				ics9xxx_set(dev, (cpu_busspeed >= 100000000) * 0x08);
-    			else if ((dev->model == ICS9250_16) || (dev->model == ICS9250_26))
-    				ics9xxx_set(dev, ((cpu_busspeed >= 120000000) * 0x08) | ((((cpu_busspeed >= 100000000) && (cpu_busspeed < 120000000)) || (cpu_busspeed == 150000000) || (cpu_busspeed == 132999999)) * 0x04));
-    			else if ((dev->model == ICS9250_27) || (dev->model == ICS9250_28) || (dev->model == ICS9250_29))
-    				ics9xxx_set(dev, ((cpu_busspeed == 100000000) * 0x02) | ((cpu_busspeed > 100000000) * 0x01));
-    			else
-    				ics9xxx_set(dev, 0x00);
-    			break;
+	switch (dev->addr_register) {
+		case 0:
+			if (dev->model == ICS9250_38)
+				data = (dev->regs[dev->addr_register] & ~0xef) | (data & 0xef);
+			else if (dev->model == ICS9250_10)
+				ics9xxx_set(dev, (cpu_busspeed >= 100000000) * 0x08);
+			else if ((dev->model == ICS9250_16) || (dev->model == ICS9250_26))
+				ics9xxx_set(dev, ((cpu_busspeed >= 120000000) * 0x08) | ((((cpu_busspeed >= 100000000) && (cpu_busspeed < 120000000)) || (cpu_busspeed == 150000000) || (cpu_busspeed == 132999999)) * 0x04));
+			else if ((dev->model == ICS9250_27) || (dev->model == ICS9250_28) || (dev->model == ICS9250_29))
+				ics9xxx_set(dev, ((cpu_busspeed == 100000000) * 0x02) | ((cpu_busspeed > 100000000) * 0x01));
+			else
+				ics9xxx_set(dev, 0x00);
+			break;
 
-    		case 1:
-    			if (dev->model == ICS9250_38)
-    				data = (dev->regs[dev->addr_register] & ~0xfe) | (data & 0xfe);
-    			break;
+		case 1:
+			if (dev->model == ICS9250_38)
+				data = (dev->regs[dev->addr_register] & ~0xfe) | (data & 0xfe);
+			break;
 
-    		case 3:
-    			if (dev->model == ICS9250_32)
-    				data ^= 0x70;
-    			break;
+		case 3:
+			if (dev->model == ICS9250_32)
+				data ^= 0x70;
+			break;
 
-    		case 4:
-    			if (dev->model == ICS9250_38)
-    				data = (dev->regs[dev->addr_register] & ~0xfc) | (data & 0xfc);
-    			break;
+		case 4:
+			if (dev->model == ICS9250_38)
+				data = (dev->regs[dev->addr_register] & ~0xfc) | (data & 0xfc);
+			break;
 
-    		case 6:
-    			if (dev->model == ICS9250_38)
-    				data = dev->regs[dev->addr_register];
-    			break;
-    	}
-    	dev->regs[dev->addr_register] = data;
+		case 6:
+			if (dev->model == ICS9250_38)
+				data = dev->regs[dev->addr_register];
+			break;
+	}
+	dev->regs[dev->addr_register] = data;
     }
     
     if (++dev->addr_register > dev->max_reg)
-    	dev->addr_register = 0; /* roll-over */
+	dev->addr_register = 0; /* roll-over */
 
     return 1;
 }
@@ -660,31 +660,31 @@ ics9xxx_init(const device_t *info)
     dev->model = info->local;
     dev->frequencies_ptr = (ics9xxx_frequency_t *) ics9xxx_devices[dev->frequencies_ref ? dev->frequencies_ref : dev->model].frequencies;
     if (!dev->frequencies_ptr)
-    	fatal("ICS9xxx: NULL frequency table\n");
+	fatal("ICS9xxx: NULL frequency table\n");
 
     /* Determine which frequency bits cannot be strapped (register only). */
     uint8_t register_only_bits = 0x00;
     uint8_t i;
     for (i = 0; i < sizeof(dev->fs_regs) / sizeof(dev->fs_regs[0]); i++) {
-    	if ((dev->fs_regs[i].normal_reg == 7) && (dev->fs_regs[i].inv_reg == 7))
-    		register_only_bits |= 1 << i;
+	if ((dev->fs_regs[i].normal_reg == 7) && (dev->fs_regs[i].inv_reg == 7))
+		register_only_bits |= 1 << i;
     }
 
     /* Find bus speed match and set default register bits accordingly. */
     dev->bus_match = find_bus_match(dev, cpu_busspeed, register_only_bits, 0x00);
     for (i = 0; i < sizeof(dev->fs_regs) / sizeof(dev->fs_regs[0]); i++) {
-    	if (dev->fs_regs[i].normal_reg < 7) {
-    		if (dev->bus_match & (1 << i))
-    			dev->regs[dev->fs_regs[i].normal_reg] |= 1 << dev->fs_regs[i].normal_bit;
-    		else
-    			dev->regs[dev->fs_regs[i].normal_reg] &= ~(1 << dev->fs_regs[i].normal_bit);
-    	}
-    	if (dev->fs_regs[i].inv_reg < 7) {
-    		if (dev->bus_match & (1 << i))
-    			dev->regs[dev->fs_regs[i].inv_reg] &= ~(1 << dev->fs_regs[i].inv_bit);
-    		else
-    			dev->regs[dev->fs_regs[i].inv_reg] |= 1 << dev->fs_regs[i].inv_bit;
-    	}
+	if (dev->fs_regs[i].normal_reg < 7) {
+		if (dev->bus_match & (1 << i))
+			dev->regs[dev->fs_regs[i].normal_reg] |= 1 << dev->fs_regs[i].normal_bit;
+		else
+			dev->regs[dev->fs_regs[i].normal_reg] &= ~(1 << dev->fs_regs[i].normal_bit);
+	}
+	if (dev->fs_regs[i].inv_reg < 7) {
+		if (dev->bus_match & (1 << i))
+			dev->regs[dev->fs_regs[i].inv_reg] &= ~(1 << dev->fs_regs[i].inv_bit);
+		else
+			dev->regs[dev->fs_regs[i].inv_reg] |= 1 << dev->fs_regs[i].inv_bit;
+	}
     }
 
     i2c_sethandler(i2c_smbus, 0x69, 1, ics9xxx_start, ics9xxx_read, ics9xxx_write, NULL, dev);

--- a/src/device/smbus_piix4.c
+++ b/src/device/smbus_piix4.c
@@ -241,7 +241,7 @@ smbus_piix4_write(uint16_t addr, uint8_t val, void *priv)
 
 					/* command write */
 					i2c_write(i2c_smbus, smbus_addr, dev->cmd);
-					timer_bytes += 1;
+					timer_bytes++;
 
 					/* fall-through */
 

--- a/src/include/86box/clock.h
+++ b/src/include/86box/clock.h
@@ -18,9 +18,12 @@
 # define EMU_CLOCK_H
 
 /* clock_ics9xxx.c */
+extern const device_t	ics9xxx_detect_device;
 extern const device_t	ics9150_08_device;
 extern const device_t	ics9248_39_device;
+extern const device_t	ics9248_81_device;
 extern const device_t	ics9248_98_device;
+extern const device_t	ics9248_101_device;
 extern const device_t	ics9250_08_device;
 extern const device_t	ics9250_10_device;
 extern const device_t	ics9250_13_device;

--- a/src/include/86box/language.h
+++ b/src/include/86box/language.h
@@ -95,7 +95,7 @@
 #define IDS_2119	2119		// "Exit"
 #define IDS_2120	2120		// "No ROMs found"
 #define IDS_2121	2121		// "Do you want to save the settings?"
-#define IDS_2122	2122		// "This will hard reset the virtual..."
+#define IDS_2122	2122		// "This will hard reset the emulated..."
 #define IDS_2123	2123		// "Save"
 #define IDS_2124	2124		// "About 86Box"
 #define IDS_2125	2125		// "86Box v" EMU_VERSION

--- a/src/machine/m_at_socket370.c
+++ b/src/machine/m_at_socket370.c
@@ -431,6 +431,7 @@ machine_at_6via90ap_init(const machine_t *model)
     device_add(&via_vt82c686b_device);
     device_add(&via_vt82c686_sio_device);
     device_add(&keyboard_ps2_ami_pci_device);
+    device_add(&ics9250_18_device);
     device_add(&sst_flash_39sf020_device);
     spd_register(SPD_TYPE_SDRAM, 0x7, 512);
     device_add(&via_vt82c686_hwm_device); /* fans: CPU1, CPU2; temperatures: CPU, System, unused */

--- a/src/machine/m_at_socket370.c
+++ b/src/machine/m_at_socket370.c
@@ -336,8 +336,8 @@ machine_at_wcf681_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/wcf681/p3tdde.bin",
-			   0x00080000, 524288, 0);
+    ret = bios_load_linear(L"roms/machines/wcf681/681osda2.bin",
+			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
 	return ret;
@@ -346,8 +346,7 @@ machine_at_wcf681_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x10, PCI_CARD_SOUTHBRIDGE, 1, 2, 0, 0);
-    pci_register_slot(0x11, PCI_CARD_SOUTHBRIDGE, 1, 2, 0, 0);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 0, 0);
     pci_register_slot(0x14, PCI_CARD_NORMAL,      2, 3, 4, 1);
     pci_register_slot(0x13, PCI_CARD_NORMAL,      3, 4, 1, 2);
     pci_register_slot(0x12, PCI_CARD_NORMAL,      4, 1, 2, 3);
@@ -355,12 +354,12 @@ machine_at_wcf681_init(const machine_t *model)
     pci_register_slot(0x10, PCI_CARD_NORMAL,      2, 3, 4, 1);
     pci_register_slot(0x01, PCI_CARD_AGPBRIDGE,   1, 2, 3, 4);
     device_add(&via_apro133a_device);
-    device_add(&via_vt82c686b_device);
-    device_add(&via_vt82c686_sio_device);
+    device_add(&via_vt82c596b_device);
+    device_add(&w83977tf_device);
     device_add(&keyboard_ps2_ami_pci_device);
     device_add(&sst_flash_39sf020_device);
     spd_register(SPD_TYPE_SDRAM, 0x3, 512);
-    device_add(&via_vt82c686_hwm_device); /* fans: CPU, unused, unused; temperatures: System, unused, CPU */
+    device_add(&w83781d_device); /* fans: CPU, unused, unused; temperatures: System, unused, CPU */
     hwm_values.voltages[1] = 2500; /* +2.5V */
     hwm_values.fans[1] = 0; /* unused */
     hwm_values.fans[2] = 0; /* unused */
@@ -447,7 +446,7 @@ machine_at_603tcf_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/603tcf/6VX-4X.F8",
+    ret = bios_load_linear(L"roms/machines/603tcf/603tcfA4.BIN",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -463,11 +462,11 @@ machine_at_603tcf_init(const machine_t *model)
     pci_register_slot(0x0A, PCI_CARD_NORMAL,      3, 4, 1, 2);
     pci_register_slot(0x0B, PCI_CARD_NORMAL,      4, 1, 2, 3);
     pci_register_slot(0x01, PCI_CARD_AGPBRIDGE,   1, 2, 3, 4);
-    device_add(&via_apro133a_device);
-    device_add(&via_vt82c686a_device);
+    device_add(&via_vt8601_device);
+    device_add(&via_vt82c686b_device);
     device_add(&via_vt82c686_sio_device);
     device_add(&keyboard_ps2_ami_pci_device);
-    device_add(&sst_flash_29ee020_device);
+    device_add(&sst_flash_39sf020_device);
     spd_register(SPD_TYPE_SDRAM, 0x3, 512);
     device_add(&via_vt82c686_hwm_device); /* fans: 1, 2; temperatures: CPU, System, unused */
     hwm_values.temperatures[0] += 2; /* CPU offset */

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -339,7 +339,6 @@ const machine_t machines[] = {
     { "[i440BX] ASUS P3B-F",			"p3bf",			MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 150000000, 1800, 3500, 2.0, 8.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8, 1024,   8, 255,		 machine_at_p3bf_init, NULL			},
     { "[i440BX] ABIT BF6",			"bf6",			MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 133333333, 1800, 3500, 1.5, 8.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		  		  8,  768,   8, 255,		  machine_at_bf6_init, NULL			},
     { "[i440BX] AOpen AX6BC",			"ax6bc",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 112121212, 1800, 3500, 1.5, 8.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		  		  8,  768,   8, 255,		machine_at_ax6bc_init, NULL			},
-    { "[i440BX] A-Trend ATC6310BXII",		"atc6310bxii",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 133333333, 1800, 3500, 3.0, 8.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8,  768,   8, 255,	  machine_at_atc6310bxii_init, NULL			},
     { "[i440BX] Gigabyte GA-686BX",		"686bx",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 100000000, 1800, 3500, 3.0, 5.5,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	 			  8, 1024,   8, 255,		machine_at_686bx_init, NULL			},
     { "[i440BX] Tyan Tsunami ATX",		"tsunamiatx",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 112121212, 1800, 3500, 3.5, 5.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL | MACHINE_SOUND,	 	  8, 1024,   8, 255,	   machine_at_tsunamiatx_init, at_tsunamiatx_get_device	},
     { "[i440BX] SuperMicro Super P6SBA",	"p6sba",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 100000000, 1800, 3500, 3.0, 8.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		  		  8,  768,   8, 255,	        machine_at_p6sba_init, NULL			},
@@ -350,11 +349,14 @@ const machine_t machines[] = {
     /* 440GX */
     { "[i440GX] Freeway FW-6400GX",		"fw6400gx_s1",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 100000000, 150000000, 1800, 3500, 3.0, 8.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,				 16, 2032,  16, 511,	     machine_at_fw6400gx_init, NULL			},
 
+    /* SMSC VictoryBX-66 */
+    { "[SMSC VictoryBX-66] A-Trend ATC6310BXII","atc6310bxii",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 133333333, 1800, 3500, 3.0, 8.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8,  768,   8, 255,	  machine_at_atc6310bxii_init, NULL			},
+
     /* VIA Apollo Pro */
     { "[VIA Apollo Pro] FIC KA-6130",		"ficka6130",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 100000000, 1800, 3500, 3.5, 5.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	 			  8,  512,   8, 255,	    machine_at_ficka6130_init, NULL			},
     { "[VIA Apollo Pro133A] ASUS P3V4X",	"p3v4x",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 150000000, 1800, 3500, 2.0, 8.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	  			  8, 2048,   8, 255,		machine_at_p3v4x_init, NULL			},
 
-    /* Slot 2 machines(Including Slot 1/2 Hybrids) */
+    /* Slot 2 machines */
     /* 440GX */
     { "[i440GX] Gigabyte GA-6GXU",		"6gxu",			MACHINE_TYPE_SLOT2,		CPU_PKG_SLOT2, 0, 100000000, 133333333, 1800, 3500, 4.0, 6.5,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		 16, 2048,  16, 511,	         machine_at_6gxu_init, NULL			},
     { "[i440GX] Freeway FW-6400GX",		"fw6400gx",		MACHINE_TYPE_SLOT2,		CPU_PKG_SLOT2, 0, 100000000, 150000000, 1800, 3500, 3.0, 8.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,				 16, 2032,  16, 511,	     machine_at_fw6400gx_init, NULL			},
@@ -367,12 +369,14 @@ const machine_t machines[] = {
     /* 440BX */
     { "[i440BX] AEWIN AW-O671R",		"awo671r",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 133333333, 1800, 3500, 0, 0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8,  512,   8, 255,	      machine_at_awo671r_init, NULL			},
     { "[i440BX] ASUS CUBX",			"cubx",			MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 150000000, 1800, 3500, 2.0, 8.0,						MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8, 1024,   8, 255,		 machine_at_cubx_init, NULL			},
-    { "[i440BX] A-Trend ATC7020BXII",		"atc7020bxii",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 133333333, 1800, 3500, 3.0, 8.0,						MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8, 1024,   8, 255,	  machine_at_atc7020bxii_init, NULL			},
     { "[i440BX] AmazePC AM-BX133",		"ambx133",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 133333333, 1800, 3500, 0, 0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8,  768,   8, 255,	      machine_at_ambx133_init, NULL			},
     { "[i440BX] Tyan Trinity 371",		"trinity371",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 133333333, 1800, 3500, 3.5, 7.0,						MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8,  768,   8, 255,	   machine_at_trinity371_init, NULL			},
 
     /* 440ZX */
     { "[i440ZX] Soltek SL-63A1",		"63a",			MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 100000000, 1800, 3500, 2.0, 7.5,						MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,				  8,  512,   8, 255,		  machine_at_63a_init, NULL			},
+
+    /* SMSC VictoryBX-66 */
+    { "[SMSC VictoryBX-66] A-Trend ATC7020BXII","atc7020bxii",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 133333333, 1800, 3500, 3.0, 8.0,						MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8, 1024,   8, 255,	  machine_at_atc7020bxii_init, NULL			},
 
     /* VIA Apollo Pro */
     { "[VIA Apollo Pro] PC Partner APAS3",	"apas3",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 100000000, 1800, 3500, 3.0, 8.0,						MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	  			  8,  768,   8, 255,            machine_at_apas3_init, NULL			},

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -335,8 +335,8 @@ const machine_t machines[] = {
     { "[i440EX] QDI EXCELLENT II",		"p6i440e2",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 83333333, 1800, 3500, 3.0, 8.0,							MACHINE_PCI | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,				  8,  512,   8, 255,	     machine_at_p6i440e2_init, NULL			},
 
     /* 440BX */
-    { "[i440BX] ASUS P2B-LS",			"p2bls",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 50000000, 112121212, 1800, 3500, 2.0, 6.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8, 1024,   8, 255,		machine_at_p2bls_init, NULL			},
-    { "[i440BX] ASUS P3B-F",			"p3bf",			MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 150000000, 1800, 3500, 2.0, 8.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8, 1024,   8, 255,		 machine_at_p3bf_init, NULL			},
+    { "[i440BX] ASUS P2B-LS",			"p2bls",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 50000000, 112121212, 1300, 3500, 2.0, 6.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8, 1024,   8, 255,		machine_at_p2bls_init, NULL			},
+    { "[i440BX] ASUS P3B-F",			"p3bf",			MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 150000000, 1300, 3500, 2.0, 8.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8, 1024,   8, 255,		 machine_at_p3bf_init, NULL			},
     { "[i440BX] ABIT BF6",			"bf6",			MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 133333333, 1800, 3500, 1.5, 8.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		  		  8,  768,   8, 255,		  machine_at_bf6_init, NULL			},
     { "[i440BX] AOpen AX6BC",			"ax6bc",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 112121212, 1800, 3500, 1.5, 8.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		  		  8,  768,   8, 255,		machine_at_ax6bc_init, NULL			},
     { "[i440BX] Gigabyte GA-686BX",		"686bx",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 100000000, 1800, 3500, 3.0, 5.5,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	 			  8, 1024,   8, 255,		machine_at_686bx_init, NULL			},
@@ -350,11 +350,11 @@ const machine_t machines[] = {
     { "[i440GX] Freeway FW-6400GX",		"fw6400gx_s1",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 100000000, 150000000, 1800, 3500, 3.0, 8.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,				 16, 2032,  16, 511,	     machine_at_fw6400gx_init, NULL			},
 
     /* SMSC VictoryBX-66 */
-    { "[SMSC VictoryBX-66] A-Trend ATC6310BXII","atc6310bxii",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 133333333, 1800, 3500, 3.0, 8.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8,  768,   8, 255,	  machine_at_atc6310bxii_init, NULL			},
+    { "[SMSC VictoryBX-66] A-Trend ATC6310BXII","atc6310bxii",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 133333333, 1300, 3500, 3.0, 8.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8,  768,   8, 255,	  machine_at_atc6310bxii_init, NULL			},
 
     /* VIA Apollo Pro */
     { "[VIA Apollo Pro] FIC KA-6130",		"ficka6130",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 100000000, 1800, 3500, 3.5, 5.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	 			  8,  512,   8, 255,	    machine_at_ficka6130_init, NULL			},
-    { "[VIA Apollo Pro133A] ASUS P3V4X",	"p3v4x",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 150000000, 1800, 3500, 2.0, 8.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	  			  8, 2048,   8, 255,		machine_at_p3v4x_init, NULL			},
+    { "[VIA Apollo Pro133A] ASUS P3V4X",	"p3v4x",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 150000000, 1300, 3500, 2.0, 8.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	  			  8, 2048,   8, 255,		machine_at_p3v4x_init, NULL			},
 
     /* Slot 2 machines */
     /* 440GX */
@@ -367,24 +367,24 @@ const machine_t machines[] = {
     { "[i440LX] SuperMicro Super 370SLM",	"s370slm",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 100000000, 1800, 3500, MACHINE_MULTIPLIER_FIXED,				MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8,  768,   8, 255,	      machine_at_s370slm_init, NULL			},
 
     /* 440BX */
-    { "[i440BX] AEWIN AW-O671R",		"awo671r",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 133333333, 1800, 3500, 0, 0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8,  512,   8, 255,	      machine_at_awo671r_init, NULL			},
-    { "[i440BX] ASUS CUBX",			"cubx",			MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 150000000, 1800, 3500, 2.0, 8.0,						MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8, 1024,   8, 255,		 machine_at_cubx_init, NULL			},
-    { "[i440BX] AmazePC AM-BX133",		"ambx133",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 133333333, 1800, 3500, 0, 0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8,  768,   8, 255,	      machine_at_ambx133_init, NULL			},
-    { "[i440BX] Tyan Trinity 371",		"trinity371",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 133333333, 1800, 3500, 3.5, 7.0,						MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8,  768,   8, 255,	   machine_at_trinity371_init, NULL			},
+    { "[i440BX] AEWIN AW-O671R",		"awo671r",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 133333333, 1300, 3500, 0, 0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8,  512,   8, 255,	      machine_at_awo671r_init, NULL			},
+    { "[i440BX] ASUS CUBX",			"cubx",			MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 150000000, 1300, 3500, 2.0, 8.0,						MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8, 1024,   8, 255,		 machine_at_cubx_init, NULL			},
+    { "[i440BX] AmazePC AM-BX133",		"ambx133",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 133333333, 1300, 3500, 0, 0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8,  768,   8, 255,	      machine_at_ambx133_init, NULL			},
+    { "[i440BX] Tyan Trinity 371",		"trinity371",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 133333333, 1300, 3500, 3.5, 7.0,						MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8,  768,   8, 255,	   machine_at_trinity371_init, NULL			},
 
     /* 440ZX */
     { "[i440ZX] Soltek SL-63A1",		"63a",			MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 100000000, 1800, 3500, 2.0, 7.5,						MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,				  8,  512,   8, 255,		  machine_at_63a_init, NULL			},
 
     /* SMSC VictoryBX-66 */
-    { "[SMSC VictoryBX-66] A-Trend ATC7020BXII","atc7020bxii",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 133333333, 1800, 3500, 3.0, 8.0,						MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8, 1024,   8, 255,	  machine_at_atc7020bxii_init, NULL			},
+    { "[SMSC VictoryBX-66] A-Trend ATC7020BXII","atc7020bxii",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 133333333, 1300, 3500, 3.0, 8.0,						MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		  8, 1024,   8, 255,	  machine_at_atc7020bxii_init, NULL			},
 
     /* VIA Apollo Pro */
     { "[VIA Apollo Pro] PC Partner APAS3",	"apas3",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 100000000, 1800, 3500, 3.0, 8.0,						MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	  			  8,  768,   8, 255,            machine_at_apas3_init, NULL			},
-    { "[VIA Apollo Pro133A] AEWIN WCF-681",	"wcf681",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 133333333, 1800, 3500, 0, 0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	  			  8, 1024,   8, 255,           machine_at_wcf681_init, NULL			},
-    { "[VIA Apollo Pro133A] ASUS CUV4X-LS",	"cuv4xls",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 150000000, 1800, 3500, 2.0, 8.0,						(MACHINE_AGP & ~MACHINE_AT) | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 16, 1536,   8, 255,          machine_at_cuv4xls_init, NULL			},
-    { "[VIA Apollo Pro133A] Acorp 6VIA90AP",	"6via90ap",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 150000000, 1800, 3500, MACHINE_MULTIPLIER_FIXED,				MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	  			  8, 1536,   8, 255,         machine_at_6via90ap_init, NULL			},
-    { "[VIA Apollo Pro133A] ECS P6BAP",		"p6bap",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 150000000, 1800, 3500, 2.0, 8.0,						MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	  			  8, 1536,   8, 255,            machine_at_p6bap_init, NULL			},
-    { "[VIA Apollo ProMedia] Jetway 603TCF",	"603tcf",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 150000000, 1800, 3500, 2.0, 8.0,						MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	  			  8, 1024,   8, 255,           machine_at_603tcf_init, NULL			},
+    { "[VIA Apollo Pro133A] AEWIN WCF-681",	"wcf681",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 133333333, 1300, 3500, 0, 0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	  			  8, 1024,   8, 255,           machine_at_wcf681_init, NULL			},
+    { "[VIA Apollo Pro133A] ASUS CUV4X-LS",	"cuv4xls",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 150000000, 1300, 3500, 2.0, 8.0,						(MACHINE_AGP & ~MACHINE_AT) | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 16, 1536,   8, 255,          machine_at_cuv4xls_init, NULL			},
+    { "[VIA Apollo Pro133A] Acorp 6VIA90AP",	"6via90ap",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 150000000, 1300, 3500, MACHINE_MULTIPLIER_FIXED,				MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	  			  8, 1536,   8, 255,         machine_at_6via90ap_init, NULL			},
+    { "[VIA Apollo Pro133A] ECS P6BAP",		"p6bap",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 150000000, 1300, 3500, 2.0, 8.0,						MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	  			  8, 1536,   8, 255,            machine_at_p6bap_init, NULL			},
+    { "[VIA Apollo ProMedia] Jetway 603TCF",	"603tcf",		MACHINE_TYPE_SOCKET370,		CPU_PKG_SOCKET370, 0, 66666667, 150000000, 1300, 3500, 2.0, 8.0,						MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	  			  8, 1024,   8, 255,           machine_at_603tcf_init, NULL			},
 
     /* Miscellaneous/Fake/Hypervisor machines */
     { "[i440BX] Microsoft Virtual PC 2007",	"vpc2007",		MACHINE_TYPE_MISC,		CPU_PKG_SLOT1, CPU_PENTIUM2 | CPU_CYRIX3S, 0, 0, 0, 0, 0, 0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		  		  8, 1024,   8, 255,	      machine_at_vpc2007_init, NULL			},

--- a/src/win/86Box.rc
+++ b/src/win/86Box.rc
@@ -1000,7 +1000,7 @@ BEGIN
     IDS_2119	"Exit"
     IDS_2120	"No ROMs found"
     IDS_2121	"Do you want to save the settings?"
-    IDS_2122	"This will hard reset the virtual machine."
+    IDS_2122	"This will hard reset the emulated machine."
     IDS_2123	"Save"
     IDS_2124	"About 86Box"
     IDS_2125	"86Box v" EMU_VERSION


### PR DESCRIPTION
* Improvements and fixes to ICS9xxx clock generators, including a detection tool
* Fix socket 370 machines accidentally shipped with test configurations
* Change SMSC machines to the VictoryBX-66 marketing name
* Decrease minimum voltage for boards that should have Coppermine support
* Change settings save confirmation text to follow the established "emulated machine" convention
* Fix VIA 596A revision ID, should be up to 0x0F according to Linux pata_via