### PR TITLE
Joystick type option improvements

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -718,16 +718,17 @@ load_input_devices(void)
     p = config_get_string(cat, "joystick_type", NULL);
     if (p != NULL) {
 	joystick_type = joystick_get_from_internal_name(p);
-	if (joystick_type == JOYSTICK_TYPE_NONE) {
+	if (!joystick_type) {
 		/* Try to read an integer for backwards compatibility with old configs */
-		c = config_get_int(cat, "joystick_type", JOYSTICK_TYPE_NONE);
-		if ((c >= 0) && (c <= 8))
-			joystick_type = c;
+		c = config_get_int(cat, "joystick_type", 8);
+		if ((c >= 0) && (c < 8))
+			/* "None" was type 8 instead of 0 previously, shift the number accordingly */
+			joystick_type = c + 1;
 		else
-			joystick_type = JOYSTICK_TYPE_NONE;
+			joystick_type = 0;
 	}
     } else
-	joystick_type = JOYSTICK_TYPE_NONE;
+	joystick_type = 0;
 
     for (c=0; c<joystick_get_max_joysticks(joystick_type); c++) {
 	sprintf(temp, "joystick_%i_nr", c);
@@ -1684,7 +1685,6 @@ config_load(void)
 	gfxcard = video_get_video_from_internal_name("cga");
 	vid_api = plat_vidapi("default");
 	time_sync = TIME_SYNC_ENABLED;
-	joystick_type = JOYSTICK_TYPE_NONE;
 	hdc_current = hdc_get_from_internal_name("none");
 	serial_enabled[0] = 1;
 	serial_enabled[1] = 1;
@@ -1987,7 +1987,7 @@ save_input_devices(void)
 
     config_set_string(cat, "mouse_type", mouse_get_internal_name(mouse_type));
 
-    if (joystick_type == JOYSTICK_TYPE_NONE) {
+    if (!joystick_type) {
 	config_delete_var(cat, "joystick_type");
 
 	for (c = 0; c < 16; c++) {

--- a/src/config.c
+++ b/src/config.c
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * 86Box	A hypervisor and IBM PC system emulator that specializes in
  *		running old operating systems and software designed for IBM
  *		PC systems and compatibles from 1981 through fairly recent
@@ -715,7 +715,19 @@ load_input_devices(void)
       else
 	mouse_type = 0;
 
-    joystick_type = config_get_int(cat, "joystick_type", JOYSTICK_TYPE_NONE);
+    p = config_get_string(cat, "joystick_type", NULL);
+    if (p != NULL) {
+	joystick_type = joystick_get_from_internal_name(p);
+	if (joystick_type == JOYSTICK_TYPE_NONE) {
+		/* Try to read an integer for backwards compatibility with old configs */
+		c = config_get_int(cat, "joystick_type", JOYSTICK_TYPE_NONE);
+		if ((c >= 0) && (c <= 8))
+			joystick_type = c;
+		else
+			joystick_type = JOYSTICK_TYPE_NONE;
+	}
+    } else
+	joystick_type = JOYSTICK_TYPE_NONE;
 
     for (c=0; c<joystick_get_max_joysticks(joystick_type); c++) {
 	sprintf(temp, "joystick_%i_nr", c);
@@ -1996,7 +2008,7 @@ save_input_devices(void)
 		}
 	}
     } else {
-	config_set_int(cat, "joystick_type", joystick_type);
+	config_set_string(cat, "joystick_type", joystick_get_internal_name(joystick_type));
 
 	for (c = 0; c < joystick_get_max_joysticks(joystick_type); c++) {
 		sprintf(tmp2, "joystick_%i_nr", c);

--- a/src/game/gameport.c
+++ b/src/game/gameport.c
@@ -85,17 +85,20 @@ static const joystick_if_t joystick_none = {
 };
 
 
-static const joystick_if_t *joystick_list[] = {
-    &joystick_standard,
-    &joystick_standard_4button,
-    &joystick_standard_6button,
-    &joystick_standard_8button,
-    &joystick_4axis_4button,
-    &joystick_ch_flightstick_pro,
-    &joystick_sw_pad,
-    &joystick_tm_fcs,
-    &joystick_none,
-    NULL
+static const struct {
+    const char		*internal_name;
+    const joystick_if_t	*joystick;
+} joysticks[] = {
+    { "standard_2button",	&joystick_standard		},
+    { "standard_4button",	&joystick_standard_4button	},
+    { "standard_6button",	&joystick_standard_6button	},
+    { "standard_8button",	&joystick_standard_8button	},
+    { "4axis_4button",		&joystick_4axis_4button		},
+    { "ch_flighstick_pro",	&joystick_ch_flightstick_pro	},
+    { "sidewinder_pad",		&joystick_sw_pad		},
+    { "thrustmaster_fcs",	&joystick_tm_fcs		},
+    { "none",			&joystick_none			},
+    { "",			NULL				}
 };
 static gameport_t *gameport_global = NULL;
 
@@ -103,58 +106,81 @@ static gameport_t *gameport_global = NULL;
 char *
 joystick_get_name(int js)
 {
-    if (! joystick_list[js])
+    if (! joysticks[js].joystick)
 	return(NULL);
-    return((char *)joystick_list[js]->name);
+    return((char *)joysticks[js].joystick->name);
+}
+
+
+char *
+joystick_get_internal_name(int js)
+{
+    return((char *) joysticks[js].internal_name);
+}
+
+
+int
+joystick_get_from_internal_name(char *s)
+{
+    int c = 0;
+
+    while (strlen((char *) joysticks[c].internal_name))
+    {
+	if (!strcmp((char *) joysticks[c].internal_name, s))
+		return c;
+	c++;
+    }
+
+    return JOYSTICK_TYPE_NONE;
 }
 
 
 int
 joystick_get_max_joysticks(int js)
 {
-    return(joystick_list[js]->max_joysticks);
+    return(joysticks[js].joystick->max_joysticks);
 }
 
 
 int
 joystick_get_axis_count(int js)
 {
-    return(joystick_list[js]->axis_count);
+    return(joysticks[js].joystick->axis_count);
 }
 
 
 int
 joystick_get_button_count(int js)
 {
-    return(joystick_list[js]->button_count);
+    return(joysticks[js].joystick->button_count);
 }
 
 
 int
 joystick_get_pov_count(int js)
 {
-    return(joystick_list[js]->pov_count);
+    return(joysticks[js].joystick->pov_count);
 }
 
 
 char *
 joystick_get_axis_name(int js, int id)
 {
-    return((char *)joystick_list[js]->axis_names[id]);
+    return((char *)joysticks[js].joystick->axis_names[id]);
 }
 
 
 char *
 joystick_get_button_name(int js, int id)
 {
-    return((char *)joystick_list[js]->button_names[id]);
+    return((char *)joysticks[js].joystick->button_names[id]);
 }
 
 
 char *
 joystick_get_pov_name(int js, int id)
 {
-    return (char *)joystick_list[js]->pov_names[id];
+    return (char *)joysticks[js].joystick->pov_names[id];
 }
 
 
@@ -239,7 +265,7 @@ init_common(void)
     timer_add(&p->axis[2].timer, timer_over, &p->axis[2], 0);
     timer_add(&p->axis[3].timer, timer_over, &p->axis[3], 0);
 
-    p->joystick = joystick_list[joystick_type];
+    p->joystick = joysticks[joystick_type].joystick;
     p->joystick_dat = p->joystick->init();
 
     gameport_global = p;
@@ -255,7 +281,7 @@ gameport_update_joystick_type(void)
 
     if (p != NULL) {
 	p->joystick->close(p->joystick_dat);
-	p->joystick = joystick_list[joystick_type];
+	p->joystick = joysticks[joystick_type].joystick;
 	p->joystick_dat = p->joystick->init();
     }
 }

--- a/src/game/gameport.c
+++ b/src/game/gameport.c
@@ -68,11 +68,11 @@ typedef struct _gameport_ {
 } gameport_t;
 
 
-int	joystick_type;
+int	joystick_type = 0;
 
 
 static const joystick_if_t joystick_none = {
-    "No joystick",
+    "None",
     NULL,
     NULL,
     NULL,
@@ -89,6 +89,7 @@ static const struct {
     const char		*internal_name;
     const joystick_if_t	*joystick;
 } joysticks[] = {
+    { "none",			&joystick_none			},
     { "standard_2button",	&joystick_standard		},
     { "standard_4button",	&joystick_standard_4button	},
     { "standard_6button",	&joystick_standard_6button	},
@@ -97,7 +98,6 @@ static const struct {
     { "ch_flighstick_pro",	&joystick_ch_flightstick_pro	},
     { "sidewinder_pad",		&joystick_sw_pad		},
     { "thrustmaster_fcs",	&joystick_tm_fcs		},
-    { "none",			&joystick_none			},
     { "",			NULL				}
 };
 static gameport_t *gameport_global = NULL;
@@ -131,7 +131,7 @@ joystick_get_from_internal_name(char *s)
 	c++;
     }
 
-    return JOYSTICK_TYPE_NONE;
+    return 0;
 }
 
 
@@ -292,7 +292,7 @@ gameport_init(const device_t *info)
 {
     gameport_t *p = NULL;
 
-    if (joystick_type == JOYSTICK_TYPE_NONE) {
+    if (!joystick_type) {
 	p = NULL;
 	return(p);
     }
@@ -311,7 +311,7 @@ gameport_201_init(const device_t *info)
 {
     gameport_t *p;
 
-    if (joystick_type == JOYSTICK_TYPE_NONE) {
+    if (!joystick_type) {
 	p = NULL;
 	return(p);
     }

--- a/src/include/86box/gameport.h
+++ b/src/include/86box/gameport.h
@@ -140,6 +140,8 @@ extern void	joystick_close(void);
 extern void	joystick_process(void);
 
 extern char	*joystick_get_name(int js);
+extern char	*joystick_get_internal_name(int js);
+extern int 	joystick_get_from_internal_name(char *s);
 extern int	joystick_get_max_joysticks(int js);
 extern int	joystick_get_axis_count(int js);
 extern int	joystick_get_button_count(int js);

--- a/src/include/86box/gameport.h
+++ b/src/include/86box/gameport.h
@@ -48,7 +48,6 @@
 #define SLIDER 			0x20000000
 
 #define AXIS_NOT_PRESENT	-99999
-#define JOYSTICK_TYPE_NONE 	8
 
 #define JOYSTICK_PRESENT(n)	(joystick_state[n].plat_joystick_nr != 0)
 

--- a/src/machine/m_amstrad.c
+++ b/src/machine/m_amstrad.c
@@ -2507,7 +2507,7 @@ machine_amstrad_init(const machine_t *model, int type)
 	mouse_set_poll(ms_poll, ams);
     }
 
-    if (joystick_type != JOYSTICK_TYPE_NONE)
+    if (joystick_type)
 	device_add(&gameport_device);
 }
 

--- a/src/machine/m_at.c
+++ b/src/machine/m_at.c
@@ -74,7 +74,7 @@ machine_at_common_init_ex(const machine_t *model, int type)
     else if (type == 0)
 	device_add(&at_nvr_device);
 
-    if (joystick_type != JOYSTICK_TYPE_NONE)
+    if (joystick_type)
 	device_add(&gameport_device);
 }
 

--- a/src/machine/m_europc.c
+++ b/src/machine/m_europc.c
@@ -615,7 +615,7 @@ europc_boot(const device_t *info)
 	mouse_bus_set_irq(sys->mouse, 2);
 	/* Configure the port for (Bus Mouse Compatible) Mouse. */
 	b |= 0x01;
-    } else if (joystick_type != JOYSTICK_TYPE_NONE)
+    } else if (joystick_type)
 	b |= 0x02;	/* enable port as joysticks */
     sys->nvr.regs[MRTC_CONF_C] = b;
 

--- a/src/machine/m_ps1.c
+++ b/src/machine/m_ps1.c
@@ -517,7 +517,7 @@ ps1_common_init(const machine_t *model)
     device_add(&keyboard_ps2_ps1_device);
 
     /* Audio uses ports 200h and 202-207h, so only initialize gameport on 201h. */
-    if (joystick_type != JOYSTICK_TYPE_NONE)
+    if (joystick_type)
 	device_add(&gameport_201_device);
 }
 

--- a/src/machine/m_tandy.c
+++ b/src/machine/m_tandy.c
@@ -1535,7 +1535,7 @@ machine_tandy1k_init(const machine_t *model, int type)
 		break;
     }
 
-    if (joystick_type != JOYSTICK_TYPE_NONE)
+    if (joystick_type)
 	device_add(&gameport_device);
 
     eep_data_out = 0x0000;

--- a/src/machine/m_xt.c
+++ b/src/machine/m_xt.c
@@ -29,7 +29,7 @@ machine_xt_common_init(const machine_t *model)
 	device_add(&fdc_xt_device);
     
     nmi_init();
-    if (joystick_type != JOYSTICK_TYPE_NONE)
+    if (joystick_type)
 	device_add(&gameport_device);
 }
 

--- a/src/machine/m_xt_compaq.c
+++ b/src/machine/m_xt_compaq.c
@@ -56,7 +56,7 @@ machine_xt_compaq_deskpro_init(const machine_t *model)
     if (fdc_type == FDC_INTERNAL)
 	device_add(&fdc_xt_device);
     nmi_init();
-    if (joystick_type != JOYSTICK_TYPE_NONE)
+    if (joystick_type)
 	device_add(&gameport_device);
 
     lpt1_remove();
@@ -85,7 +85,7 @@ machine_xt_compaq_portable_init(const machine_t *model)
     if (fdc_type == FDC_INTERNAL)
 	device_add(&fdc_xt_device);
     nmi_init();
-    if (joystick_type != JOYSTICK_TYPE_NONE)
+    if (joystick_type)
 	device_add(&gameport_device);
 
     lpt1_remove();

--- a/src/machine/m_xt_laserxt.c
+++ b/src/machine/m_xt_laserxt.c
@@ -171,7 +171,7 @@ machine_xt_lxt3_init(const machine_t *model)
     device_add(&keyboard_xt_lxt3_device);
     device_add(&fdc_xt_device);
     nmi_init();
-    if (joystick_type != JOYSTICK_TYPE_NONE)
+    if (joystick_type)
 	device_add(&gameport_device);
 
     laserxt_init(1);

--- a/src/machine/m_xt_olivetti.c
+++ b/src/machine/m_xt_olivetti.c
@@ -717,7 +717,7 @@ machine_xt_olim24_init(const machine_t *model)
 	/* FIXME: make sure this is correct?? */
     device_add(&at_nvr_device);
 
-    if (joystick_type != JOYSTICK_TYPE_NONE)
+    if (joystick_type)
 		device_add(&gameport_device);
 
     nmi_init();
@@ -760,7 +760,7 @@ machine_xt_olim240_init(const machine_t *model)
 	if (fdc_type == FDC_INTERNAL)	
 		device_add(&fdc_xt_device);
 
-	if (joystick_type != JOYSTICK_TYPE_NONE)
+	if (joystick_type)
 		device_add(&gameport_device);
 
     nmi_init();
@@ -833,7 +833,7 @@ machine_xt_olim15_init(const machine_t *model)
 	if (fdc_type == FDC_INTERNAL)	
 		device_add(&fdc_xt_device);
 
-	if (joystick_type != JOYSTICK_TYPE_NONE)
+	if (joystick_type)
 		device_add(&gameport_device);
 
     nmi_init();

--- a/src/machine/m_xt_xi8088.c
+++ b/src/machine/m_xt_xi8088.c
@@ -177,7 +177,7 @@ machine_xt_xi8088_init(const machine_t *model)
     nmi_init();
     device_add(&ibmat_nvr_device);
     pic2_init();
-    if (joystick_type != JOYSTICK_TYPE_NONE)
+    if (joystick_type)
 	device_add(&gameport_device);
 
     return ret;

--- a/src/pc.c
+++ b/src/pc.c
@@ -809,7 +809,7 @@ pc_reset_hard_init(void)
     /* Reset and reconfigure the Network Card layer. */
     network_reset();
 
-    if (joystick_type != JOYSTICK_TYPE_NONE)
+    if (joystick_type)
 	gameport_update_joystick_type();
 
     ui_sb_update_panes();

--- a/src/win/win_joystick.cpp
+++ b/src/win/win_joystick.cpp
@@ -263,7 +263,7 @@ void joystick_process(void)
 {
         int c, d;
 
-	if (joystick_type == JOYSTICK_TYPE_NONE) return;
+	if (!joystick_type) return;
 
         for (c = 0; c < joysticks_present; c++)
         {                

--- a/src/win/win_joystick_xinput.c
+++ b/src/win/win_joystick_xinput.c
@@ -217,7 +217,7 @@ void joystick_process(void)
 {
         int c, d;
 
-	if (joystick_type == JOYSTICK_TYPE_NONE) return;
+	if (!joystick_type) return;
 
         joystick_poll();
 


### PR DESCRIPTION
Summary
=======
The joystick type configuration option is now stored in the .cfg file as a string referencing the type instead of a direct integer index; backwards compatibility with old configs is provided. Additionally, the "None" option was moved to the top of the list for consistency with other dropdown lists.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
