### PR TITLE
Don't warn on machine reset if in standalone settings mode

### DIFF
--- a/src/win/win_settings.c
+++ b/src/win/win_settings.c
@@ -5008,7 +5008,7 @@ win_settings_confirm(HWND hdlg)
 
     if (win_settings_changed()) {
 	if (confirm_save)
-		i = settings_msgbox_ex(MBX_QUESTION_OK | MBX_WARNING | MBX_DONTASK, (wchar_t *) IDS_2121, (wchar_t *) IDS_2122, (wchar_t *) IDS_2123, NULL, NULL);
+		i = settings_msgbox_ex(MBX_QUESTION_OK | MBX_WARNING | MBX_DONTASK, (wchar_t *) IDS_2121, ( !settings_only ? (wchar_t *) IDS_2122 : NULL ), (wchar_t *) IDS_2123, NULL, NULL);
 	else
 		i = 0;
 


### PR DESCRIPTION
Summary
=======
When 86Box is run in settings-only mode (with the `-S` switch), it no longer warns about a hard reset of a machine when saving the machine configuration since there's no machine running.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
