### PR TITLE
Correct tinyglib data type size macros

### DIFF
--- a/src/include/tinyglib.h
+++ b/src/include/tinyglib.h
@@ -58,16 +58,17 @@
 
 #define G_SPAWN_SEARCH_PATH 0
 
-#if defined(__LP64__) || defined(__LLP64__)
+#if defined(__LP64__) || defined(__LLP64__) || defined(_WIN64)
 # define GLIB_SIZEOF_VOID_P 8
-#else
-# define GLIB_SIZEOF_VOID_P 4
-#endif
-#ifdef __LP64__
-# define GLIB_SIZEOF_LONG 8
+# if defined(__LLP64__) || defined(_WIN64)
+#  define GLIB_SIZEOF_LONG 4
+# else
+#  define GLIB_SIZEOF_LONG 8
+# endif
 # define GLIB_SIZEOF_SIZE_T 8
 # define GLIB_SIZEOF_SSIZE_T 8
 #else
+# define GLIB_SIZEOF_VOID_P 4
 # define GLIB_SIZEOF_LONG 4
 # define GLIB_SIZEOF_SIZE_T 4
 # define GLIB_SIZEOF_SSIZE_T 4

--- a/src/network/net_slirp.c
+++ b/src/network/net_slirp.c
@@ -150,7 +150,7 @@ net_slirp_notify(void *opaque)
 }
 
 
-int
+ssize_t
 net_slirp_send_packet(const void *qp, size_t pkt_len, void *opaque)
 {
     slirp_t *slirp = (slirp_t *) opaque;


### PR DESCRIPTION
Fixes SLiRP on x64.