### PR TITLE
MSVC compatibility fixes

### DIFF
--- a/src/codegen/codegen_ops.c
+++ b/src/codegen/codegen_ops.c
@@ -15,9 +15,9 @@
 #include "codegen.h"
 #include "codegen_ops.h"
 
-#ifdef __amd64__
+#if defined __amd64__ || defined _M_X64
 #include "codegen_ops_x86-64.h"
-#elif defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86 || defined _M_X64
+#elif defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86
 #include "codegen_ops_x86.h"
 #endif
 

--- a/src/codegen/codegen_ops_x86-64.h
+++ b/src/codegen/codegen_ops_x86-64.h
@@ -57,7 +57,7 @@ static inline void call_long(uintptr_t func)
 
 static inline void load_param_1_32(codeblock_t *block, uint32_t param)
 {
-#if WIN64
+#if _WIN64
         addbyte(0xb9); /*MOVL $fetchdat,%ecx*/
 #else
         addbyte(0xbf); /*MOVL $fetchdat,%edi*/
@@ -66,7 +66,7 @@ static inline void load_param_1_32(codeblock_t *block, uint32_t param)
 }
 static inline void load_param_1_reg_32(int reg)
 {
-#if WIN64
+#if _WIN64
         if (reg & 8)
                 addbyte(0x44);
         addbyte(0x89); /*MOV ECX, EAX*/
@@ -82,7 +82,7 @@ static inline void load_param_1_reg_32(int reg)
 static inline void load_param_1_64(codeblock_t *block, uint64_t param)
 {
 	addbyte(0x48);
-#if WIN64
+#if _WIN64
         addbyte(0xb9); /*MOVL $fetchdat,%ecx*/
 #else
         addbyte(0xbf); /*MOVL $fetchdat,%edi*/
@@ -93,7 +93,7 @@ static inline void load_param_1_64(codeblock_t *block, uint64_t param)
 
 static inline void load_param_2_32(codeblock_t *block, uint32_t param)
 {
-#if WIN64
+#if _WIN64
         addbyte(0xba); /*MOVL $fetchdat,%edx*/
 #else
         addbyte(0xbe); /*MOVL $fetchdat,%esi*/
@@ -102,7 +102,7 @@ static inline void load_param_2_32(codeblock_t *block, uint32_t param)
 }
 static inline void load_param_2_reg_32(int reg)
 {
-#if WIN64
+#if _WIN64
         if (reg & 8)
                 addbyte(0x44);
         addbyte(0x89); /*MOV EDX, EAX*/
@@ -117,7 +117,7 @@ static inline void load_param_2_reg_32(int reg)
 static inline void load_param_2_64(codeblock_t *block, uint64_t param)
 {
 	addbyte(0x48);
-#if WIN64
+#if _WIN64
         addbyte(0xba); /*MOVL $fetchdat,%edx*/
 #else
         addbyte(0xbe); /*MOVL $fetchdat,%esi*/
@@ -128,7 +128,7 @@ static inline void load_param_2_reg_64(int reg)
 {
         if (reg & 8)
         {
-#if WIN64
+#if _WIN64
                 addbyte(0x4c); /*MOVL EDX,reg*/
                 addbyte(0x89);
                 addbyte(0xc0 | REG_EDX | ((reg & 7) << 3));
@@ -140,7 +140,7 @@ static inline void load_param_2_reg_64(int reg)
         }
         else
         {
-#if WIN64
+#if _WIN64
                 addbyte(0x48); /*MOVL EDX,reg*/
                 addbyte(0x89);
                 addbyte(0xc0 | REG_EDX | ((reg & 7) << 3));
@@ -156,7 +156,7 @@ static inline void load_param_3_reg_32(int reg)
 {
         if (reg & 8)
         {
-#if WIN64
+#if _WIN64
                 addbyte(0x45); /*MOVL R8,reg*/
                 addbyte(0x89);
                 addbyte(0xc0 | ((reg & 7) << 3));
@@ -168,7 +168,7 @@ static inline void load_param_3_reg_32(int reg)
         }
         else
         {
-#if WIN64
+#if _WIN64
                 addbyte(0x41); /*MOVL R8,reg*/
                 addbyte(0x89);
                 addbyte(0xc0 | ((reg & 7) << 3));
@@ -183,7 +183,7 @@ static inline void load_param_3_reg_64(int reg)
 {
         if (reg & 8)
         {
-#if WIN64
+#if _WIN64
                 addbyte(0x4d); /*MOVL R8,reg*/
                 addbyte(0x89);
                 addbyte(0xc0 | ((reg & 7) << 3));
@@ -195,7 +195,7 @@ static inline void load_param_3_reg_64(int reg)
         }
         else
         {
-#if WIN64
+#if _WIN64
                 addbyte(0x49); /*MOVL R8,reg*/
                 addbyte(0x89);
                 addbyte(0xc0 | ((reg & 7) << 3));

--- a/src/codegen/codegen_x86-64.c
+++ b/src/codegen/codegen_x86-64.c
@@ -1,4 +1,4 @@
-#ifdef __amd64__
+#if defined __amd64__ || defined _M_X64
 
 #include <stdarg.h>
 #include <stdio.h>

--- a/src/codegen/codegen_x86-64.c
+++ b/src/codegen/codegen_x86-64.c
@@ -24,7 +24,7 @@
 #include <sys/mman.h>
 #include <unistd.h>
 #endif
-#if WIN64
+#if _WIN64
 #include <windows.h>
 #endif
 
@@ -70,7 +70,7 @@ void codegen_init()
 	long pagemask = ~(pagesize - 1);
 #endif
         
-#if WIN64
+#if _WIN64
         codeblock = VirtualAlloc(NULL, BLOCK_SIZE * sizeof(codeblock_t), MEM_COMMIT, PAGE_EXECUTE_READWRITE);
 #else
         codeblock = malloc(BLOCK_SIZE * sizeof(codeblock_t));
@@ -295,7 +295,7 @@ void codegen_block_start_recompile(codeblock_t *block)
         
         block_pos = BLOCK_GPF_OFFSET;
 #ifdef OLD_GPF
-#if WIN64
+#if _WIN64
         addbyte(0x48); /*XOR RCX, RCX*/
         addbyte(0x31);
         addbyte(0xc9);

--- a/src/codegen/codegen_x86.c
+++ b/src/codegen/codegen_x86.c
@@ -36,7 +36,7 @@
  *   Boston, MA 02111-1307
  *   USA.
  */
-#if defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86 || defined _M_X64
+#if defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86
 
 #include <stdio.h>
 #include <stdint.h>

--- a/src/codegen_new/codegen_allocator.c
+++ b/src/codegen_new/codegen_allocator.c
@@ -112,7 +112,7 @@ uint8_t *codeblock_allocator_get_ptr(mem_block_t *block)
 
 void codegen_allocator_clean_blocks(struct mem_block_t *block)
 {
-#if defined __ARM_EABI__ || defined _ARM_ || defined __aarch64__
+#if defined __ARM_EABI__ || defined _ARM_ || defined __aarch64__ || defined _M_ARM || defined _M_ARM64
         while (1)
         {
 		__clear_cache(&mem_block_alloc[block->offset], &mem_block_alloc[block->offset + MEM_BLOCK_SIZE]);

--- a/src/codegen_new/codegen_allocator.c
+++ b/src/codegen_new/codegen_allocator.c
@@ -115,7 +115,11 @@ void codegen_allocator_clean_blocks(struct mem_block_t *block)
 #if defined __ARM_EABI__ || defined _ARM_ || defined __aarch64__ || defined _M_ARM || defined _M_ARM64
         while (1)
         {
+#ifndef _MSC_VER
 		__clear_cache(&mem_block_alloc[block->offset], &mem_block_alloc[block->offset + MEM_BLOCK_SIZE]);
+#else
+		FlushInstructionCache(GetCurrentProcess(), &mem_block_alloc[block->offset], MEM_BLOCK_SIZE);
+#endif
 		if (block->next)
 			block = &mem_blocks[block->next - 1];
 		else

--- a/src/codegen_new/codegen_allocator.h
+++ b/src/codegen_new/codegen_allocator.h
@@ -13,7 +13,7 @@
   Due to the chaining, the total memory size is limited by the range of a jump
   instruction. ARMv7 is restricted to +/- 32 MB, ARMv8 to +/- 128 MB, x86 to
   +/- 2GB. As a result, total memory size is limited to 32 MB on ARMv7*/
-#if defined __ARM_EABI__ || _ARM_
+#if defined __ARM_EABI__ || defined _ARM_ || defined _M_ARM
 #define MEM_BLOCK_NR 32768
 #else
 #define MEM_BLOCK_NR 131072

--- a/src/codegen_new/codegen_backend.h
+++ b/src/codegen_new/codegen_backend.h
@@ -1,13 +1,13 @@
 #ifndef _CODEGEN_BACKEND_H_
 #define _CODEGEN_BACKEND_H_
 
-#if defined __amd64__
+#if defined __amd64__ || defined _M_X64
 #include "codegen_backend_x86-64.h"
 #elif defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86
 #include "codegen_backend_x86.h"
-#elif defined __ARM_EABI__ || defined _ARM_
+#elif defined __ARM_EABI__ || defined _ARM_ || defined _M_ARM
 #include "codegen_backend_arm.h"
-#elif defined __aarch64__
+#elif defined __aarch64__ || defined _M_ARM64
 #include "codegen_backend_arm64.h"
 #else
 #error Dynamic recompiler not implemented on your platform

--- a/src/codegen_new/codegen_backend_arm.c
+++ b/src/codegen_new/codegen_backend_arm.c
@@ -1,4 +1,4 @@
-#if defined __ARM_EABI__ || defined _ARM_
+#if defined __ARM_EABI__ || defined _ARM_ || defined _M_ARM
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/codegen_new/codegen_backend_arm.c
+++ b/src/codegen_new/codegen_backend_arm.c
@@ -327,9 +327,13 @@ printf("block_pos=%i\n", block_pos);
 
         block_write_data = NULL;
 //fatal("block_pos=%i\n", block_pos);
+#if !defined _MSC_VER || defined __clang__
 	asm("vmrs %0, fpscr\n"
                 : "=r" (cpu_state.old_fp_control)
 	);
+#else
+	cpu_state.old_fp_control = _controlfp();
+#endif
 	if ((cpu_state.old_fp_control >> 22) & 3)
 		fatal("VFP not in nearest rounding mode\n");
 }

--- a/src/codegen_new/codegen_backend_arm64.c
+++ b/src/codegen_new/codegen_backend_arm64.c
@@ -1,4 +1,4 @@
-#ifdef __aarch64__
+#if defined __aarch64__ || defined _M_ARM64
 
 #include <stdlib.h>
 #include <stdint.h>

--- a/src/codegen_new/codegen_backend_arm64.c
+++ b/src/codegen_new/codegen_backend_arm64.c
@@ -332,9 +332,13 @@ void codegen_backend_init()
 
 	codegen_allocator_clean_blocks(block->head_mem_block);
 
+#if !defined _MSC_VER || defined __clang__
 	asm("mrs %0, fpcr\n"
                 : "=r" (cpu_state.old_fp_control)
 	);
+#else
+	cpu_state.old_fp_control = _controlfp();
+#endif
 }
 
 void codegen_set_rounding_mode(int mode)

--- a/src/codegen_new/codegen_backend_arm64_ops.c
+++ b/src/codegen_new/codegen_backend_arm64_ops.c
@@ -1,4 +1,4 @@
-#ifdef __aarch64__
+#if defined __aarch64__ || defined _M_ARM64
 
 #include <stdint.h>
 #include <86box/86box.h>

--- a/src/codegen_new/codegen_backend_arm64_uops.c
+++ b/src/codegen_new/codegen_backend_arm64_uops.c
@@ -1,4 +1,4 @@
-#ifdef __aarch64__
+#if defined __aarch64__ || defined _M_ARM64
 
 #include <stdint.h>
 #include <86box/86box.h>

--- a/src/codegen_new/codegen_backend_arm_ops.c
+++ b/src/codegen_new/codegen_backend_arm_ops.c
@@ -1,4 +1,4 @@
-#if defined __ARM_EABI__ || defined _ARM_
+#if defined __ARM_EABI__ || defined _ARM_ || defined _M_ARM
 
 #include <stdint.h>
 #include <86box/86box.h>

--- a/src/codegen_new/codegen_backend_arm_uops.c
+++ b/src/codegen_new/codegen_backend_arm_uops.c
@@ -1,4 +1,4 @@
-#if defined __ARM_EABI__ || defined _ARM_
+#if defined __ARM_EABI__ || defined _ARM_ || defined _M_ARM
 
 #include <math.h>
 #include <stdint.h>

--- a/src/codegen_new/codegen_backend_x86-64.c
+++ b/src/codegen_new/codegen_backend_x86-64.c
@@ -1,4 +1,4 @@
-#ifdef __amd64__
+#if defined __amd64__ || defined _M_X64
 
 #include <stdint.h>
 #include <86box/86box.h>

--- a/src/codegen_new/codegen_backend_x86-64.c
+++ b/src/codegen_new/codegen_backend_x86-64.c
@@ -51,7 +51,7 @@ host_reg_def_t codegen_host_reg_list[CODEGEN_HOST_REGS] =
 
 host_reg_def_t codegen_host_fp_reg_list[CODEGEN_HOST_FP_REGS] =
 {
-#if WIN64
+#if _WIN64
         /*Windows x86-64 calling convention preserves XMM6-XMM15*/
         {REG_XMM6, 0},
         {REG_XMM7, 0},
@@ -123,7 +123,7 @@ static void build_load_routine(codeblock_t *block, int size, int is_float)
                 *misaligned_offset = (uint8_t)((uintptr_t)&block_write_data[block_pos] - (uintptr_t)misaligned_offset) - 1;
         host_x86_PUSH(block, REG_RAX);
         host_x86_PUSH(block, REG_RDX);
-#if WIN64
+#if _WIN64
         host_x86_SUB64_REG_IMM(block, REG_RSP, 0x20);
         //host_x86_MOV32_REG_REG(block, REG_ECX, uop->imm_data);
 #else
@@ -155,7 +155,7 @@ static void build_load_routine(codeblock_t *block, int size, int is_float)
                 host_x86_CALL(block, (void *)readmemql);
                 host_x86_MOVQ_XREG_REG(block, REG_XMM_TEMP, REG_RAX);
         }
-#if WIN64
+#if _WIN64
         host_x86_ADD64_REG_IMM(block, REG_RSP, 0x20);
 #endif
         host_x86_POP(block, REG_RDX);
@@ -221,7 +221,7 @@ static void build_store_routine(codeblock_t *block, int size, int is_float)
                 *misaligned_offset = (uint8_t)((uintptr_t)&block_write_data[block_pos] - (uintptr_t)misaligned_offset) - 1;
         host_x86_PUSH(block, REG_RAX);
         host_x86_PUSH(block, REG_RDX);
-#if WIN64
+#if _WIN64
         host_x86_SUB64_REG_IMM(block, REG_RSP, 0x28);
         if (size == 4 && is_float)
                 host_x86_MOVD_REG_XREG(block, REG_EDX, REG_XMM_TEMP); //data
@@ -248,7 +248,7 @@ static void build_store_routine(codeblock_t *block, int size, int is_float)
                 host_x86_CALL(block, (void *)writememll);
         else if (size == 8)
                 host_x86_CALL(block, (void *)writememql);
-#if WIN64
+#if _WIN64
         host_x86_ADD64_REG_IMM(block, REG_RSP, 0x28);
 #else
         host_x86_ADD64_REG_IMM(block, REG_RSP, 0x8);
@@ -317,7 +317,7 @@ void codegen_backend_init()
         build_loadstore_routines(&codeblock[block_current]);
 
         codegen_gpf_rout = &codeblock[block_current].data[block_pos];
-#if WIN64
+#if _WIN64
         host_x86_XOR32_REG_REG(block, REG_ECX, REG_ECX);
         host_x86_XOR32_REG_REG(block, REG_EDX, REG_EDX);
 #else

--- a/src/codegen_new/codegen_backend_x86-64.c
+++ b/src/codegen_new/codegen_backend_x86-64.c
@@ -22,6 +22,8 @@
 #include <windows.h>
 #endif
 
+#include <xmmintrin.h>
+
 void *codegen_mem_load_byte;
 void *codegen_mem_load_word;
 void *codegen_mem_load_long;
@@ -340,11 +342,7 @@ void codegen_backend_init()
 
         block_write_data = NULL;
 
-        asm(
-                "stmxcsr %0\n"
-                : "=m" (cpu_state.old_fp_control)
-        );
-        cpu_state.trunc_fp_control = cpu_state.old_fp_control | 0x6000;
+        cpu_state.trunc_fp_control = _mm_getcsr() | 0x6000;
 }
 
 void codegen_set_rounding_mode(int mode)

--- a/src/codegen_new/codegen_backend_x86-64_ops.c
+++ b/src/codegen_new/codegen_backend_x86-64_ops.c
@@ -1,4 +1,4 @@
-#ifdef __amd64__
+#if defined __amd64__ || defined _M_X64
 
 #include <stdint.h>
 #include <86box/86box.h>

--- a/src/codegen_new/codegen_backend_x86-64_ops_sse.c
+++ b/src/codegen_new/codegen_backend_x86-64_ops_sse.c
@@ -1,4 +1,4 @@
-#ifdef __amd64__
+#if defined __amd64__ || defined _M_X64
 
 #include <stdint.h>
 #include <86box/86box.h>

--- a/src/codegen_new/codegen_backend_x86-64_uops.c
+++ b/src/codegen_new/codegen_backend_x86-64_uops.c
@@ -803,7 +803,7 @@ static int codegen_FP_ENTER(codeblock_t *block, uop_t *uop)
         host_x86_TEST32_REG_IMM(block, REG_ECX, 0xc);
         branch_offset = host_x86_JZ_long(block);
         host_x86_MOV32_ABS_IMM(block, &cpu_state.oldpc, uop->imm_data);
-#if WIN64
+#if _WIN64
         host_x86_MOV32_REG_IMM(block, REG_ECX, 7);
 #else
         host_x86_MOV32_REG_IMM(block, REG_EDI, 7);
@@ -822,7 +822,7 @@ static int codegen_MMX_ENTER(codeblock_t *block, uop_t *uop)
         host_x86_TEST32_REG_IMM(block, REG_ECX, 0xc);
         branch_offset = host_x86_JZ_long(block);
         host_x86_MOV32_ABS_IMM(block, &cpu_state.oldpc, uop->imm_data);
-#if WIN64
+#if _WIN64
         host_x86_MOV32_REG_IMM(block, REG_ECX, 7);
 #else
         host_x86_MOV32_REG_IMM(block, REG_EDI, 7);
@@ -852,7 +852,7 @@ static int codegen_LOAD_FUNC_ARG0(codeblock_t *block, uop_t *uop)
 
         if (REG_IS_W(src_size))
         {
-#if WIN64
+#if _WIN64
                 host_x86_MOVZX_REG_32_16(block, REG_ECX, src_reg);
 #else
                 host_x86_MOVZX_REG_32_16(block, REG_EDI, src_reg);
@@ -888,7 +888,7 @@ static int codegen_LOAD_FUNC_ARG3(codeblock_t *block, uop_t *uop)
 
 static int codegen_LOAD_FUNC_ARG0_IMM(codeblock_t *block, uop_t *uop)
 {
-#if WIN64
+#if _WIN64
         host_x86_MOV32_REG_IMM(block, REG_ECX, uop->imm_data);
 #else
         host_x86_MOV32_REG_IMM(block, REG_EDI, uop->imm_data);
@@ -897,7 +897,7 @@ static int codegen_LOAD_FUNC_ARG0_IMM(codeblock_t *block, uop_t *uop)
 }
 static int codegen_LOAD_FUNC_ARG1_IMM(codeblock_t *block, uop_t *uop)
 {
-#if WIN64
+#if _WIN64
         host_x86_MOV32_REG_IMM(block, REG_EDX, uop->imm_data);
 #else
         host_x86_MOV32_REG_IMM(block, REG_ESI, uop->imm_data);
@@ -928,7 +928,7 @@ static int codegen_LOAD_SEG(codeblock_t *block, uop_t *uop)
         if (!REG_IS_W(src_size))
                 fatal("LOAD_SEG %02x %p\n", uop->src_reg_a_real, uop->p);
 #endif
-#if WIN64
+#if _WIN64
         host_x86_MOV16_REG_REG(block, REG_CX, src_reg);
         host_x86_MOV64_REG_IMM(block, REG_EDX, (uint64_t)uop->p);
 #else

--- a/src/codegen_new/codegen_backend_x86-64_uops.c
+++ b/src/codegen_new/codegen_backend_x86-64_uops.c
@@ -1,4 +1,4 @@
-#ifdef __amd64__
+#if defined __amd64__ || defined _M_X64
 
 #include <stdint.h>
 #include <86box/86box.h>

--- a/src/cpu/cpu.c
+++ b/src/cpu/cpu.c
@@ -375,40 +375,40 @@ cpu_is_eligible(const cpu_family_t *cpu_family, int cpu, int machine)
 	if (cpu_s->cpu_flags & CPU_FIXED_MULTIPLIER) {
 		return 1; /* don't care about multiplier compatibility on fixed multiplier CPUs */
 	} else if (cpu_family->package & CPU_PKG_SOCKET5_7) {
-		if ((multi == 1.5) && (cpu_s->cpu_type & CPU_5K86) && (machine_s->cpu_min_multi > 1.5)) /* K5 5k86 */
+		if ((multi == 1.5) && (cpu_s->cpu_type == CPU_5K86) && (machine_s->cpu_min_multi > 1.5)) /* K5 5k86 */
 			multi = 2.0;
 		else if (multi == 1.75) /* K5 5k86 */
 			multi = 2.5;
 		else if (multi == 2.0) {
-			if (cpu_s->cpu_type & CPU_5K86) /* K5 5k86 */
+			if (cpu_s->cpu_type == CPU_5K86) /* K5 5k86 */
 				multi = 3.0;
-			else if (cpu_s->cpu_type & (CPU_K6_2P | CPU_K6_3P)) /* K6-2+ / K6-3+ */
+			else if (cpu_s->cpu_type == CPU_K6_2P || cpu_s->cpu_type == CPU_K6_3P) /* K6-2+ / K6-3+ */
 				multi = 2.5;
-			else if ((cpu_s->cpu_type & (CPU_WINCHIP | CPU_WINCHIP2)) && (machine_s->cpu_min_multi > 2.0)) /* WinChip (2) */
+			else if ((cpu_s->cpu_type == CPU_WINCHIP || cpu_s->cpu_type == CPU_WINCHIP2) && (machine_s->cpu_min_multi > 2.0)) /* WinChip (2) */
 				multi = 2.5;
 		}
 		else if (multi == (7.0 / 3.0)) /* WinChip 2A - 2.33x */
 			multi = 5.0;
 		else if (multi == (8.0 / 3.0)) /* WinChip 2A - 2.66x */
 			multi = 5.5;
-		else if ((multi == 3.0) && (cpu_s->cpu_type & (CPU_Cx6x86 | CPU_Cx6x86L))) /* 6x86(L) */
+		else if ((multi == 3.0) && (cpu_s->cpu_type == CPU_Cx6x86 || cpu_s->cpu_type == CPU_Cx6x86L)) /* 6x86(L) */
 			multi = 1.5;
 		else if (multi == (10.0 / 3.0)) /* WinChip 2A - 3.33x */
 			multi = 2.0;
 		else if ((multi == 3.5) && (machine_s->cpu_min_multi < 3.5)) /* standard set by the Pentium MMX */
 			multi = 1.5;
 		else if (multi == 4.0) {
-			if (cpu_s->cpu_type & (CPU_WINCHIP | CPU_WINCHIP2)) { /* WinChip (2) */
+			if (cpu_s->cpu_type == CPU_WINCHIP || cpu_s->cpu_type ==  CPU_WINCHIP2) { /* WinChip (2) */
 				if (machine_s->cpu_min_multi >= 1.5)
 					multi = 1.5;
 				else if (machine_s->cpu_min_multi >= 3.5)
 					multi = 3.5;
 				else if (machine_s->cpu_min_multi >= 4.5)
 					multi = 4.5;
-			} else if (cpu_s->cpu_type & (CPU_Cx6x86 | CPU_Cx6x86L)) /* 6x86(L) */
+			} else if (cpu_s->cpu_type == CPU_Cx6x86 || cpu_s->cpu_type == CPU_Cx6x86L) /* 6x86(L) */
 				multi = 3.0;
 		}
-		else if ((multi == 5.0) && (cpu_s->cpu_type & (CPU_WINCHIP | CPU_WINCHIP2)) && (machine_s->cpu_min_multi > 5.0)) /* WinChip (2) */
+		else if ((multi == 5.0) && (cpu_s->cpu_type == CPU_WINCHIP || cpu_s->cpu_type ==  CPU_WINCHIP2) && (machine_s->cpu_min_multi > 5.0)) /* WinChip (2) */
 			multi = 5.5;
 		else if ((multi == 6.0) && (machine_s->cpu_max_multi < 6.0)) /* K6-2(+) / K6-3(+) */
 			multi = 2.0;

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -32,58 +32,58 @@ enum {
 };
 
 enum {
-    CPU_8088 = (1ULL << 0),		/* 808x class CPUs */
-    CPU_8086 = (1ULL << 1),
+    CPU_8088,		/* 808x class CPUs */
+    CPU_8086,
 #ifdef USE_NEC_808X
-    CPU_V20 = (1ULL << 2),		/* NEC 808x class CPUs - future proofing */
-    CPU_V30 = (1ULL << 3),
+    CPU_V20,		/* NEC 808x class CPUs - future proofing */
+    CPU_V30,
 #endif
-    CPU_286 = (1ULL << 4),		/* 286 class CPUs */
-    CPU_386SX = (1ULL << 5),		/* 386 class CPUs */
-    CPU_386DX = (1ULL << 6),
-    CPU_IBM386SLC = (1ULL << 7),
-    CPU_IBM486SLC = (1ULL << 8),
-    CPU_IBM486BL = (1ULL << 9),
-    CPU_RAPIDCAD = (1ULL << 10),
-    CPU_486SLC = (1ULL << 11),
-    CPU_486DLC = (1ULL << 12),
-    CPU_i486SX = (1ULL << 13),		/* 486 class CPUs */
-    CPU_Am486SX = (1ULL << 14),
-    CPU_Cx486S = (1ULL << 15),
-    CPU_i486SX2 = (1ULL << 16),
-    CPU_Am486SX2 = (1ULL << 17),
-    CPU_i486DX = (1ULL << 18),
-    CPU_i486DX2 = (1ULL << 19),
-    CPU_Am486DX = (1ULL << 20),
-    CPU_Am486DX2 = (1ULL << 21),
-    CPU_Cx486DX = (1ULL << 22),
-    CPU_Cx486DX2 = (1ULL << 23),
-    CPU_iDX4 = (1ULL << 24),
-    CPU_Am486DX4 = (1ULL << 25),
-    CPU_Cx486DX4 = (1ULL << 26),
-    CPU_Am5x86 = (1ULL << 27),
-    CPU_Cx5x86 = (1ULL << 28),
-    CPU_P24T = (1ULL << 29),
-    CPU_WINCHIP = (1ULL << 30),	/* 586 class CPUs */
-    CPU_WINCHIP2 = (1ULL << 31),
-    CPU_PENTIUM = (1ULL << 32),
-    CPU_PENTIUMMMX = (1ULL << 33),
-    CPU_Cx6x86 = (1ULL << 34),
-    CPU_Cx6x86MX = (1ULL << 35),
-    CPU_Cx6x86L = (1ULL << 36),
-    CPU_CxGX1 = (1ULL << 37),
-    CPU_K5 = (1ULL << 38),
-    CPU_5K86 = (1ULL << 39),
-    CPU_K6 = (1ULL << 40),
-    CPU_K6_2 = (1ULL << 41),
-    CPU_K6_2C = (1ULL << 42),
-    CPU_K6_3 = (1ULL << 43),
-    CPU_K6_2P = (1ULL << 44),
-    CPU_K6_3P = (1ULL << 45),
-    CPU_CYRIX3S = (1ULL << 46),
-    CPU_PENTIUMPRO = (1ULL << 47),	/* 686 class CPUs */
-    CPU_PENTIUM2 = (1ULL << 48),
-    CPU_PENTIUM2D = (1ULL << 49)
+    CPU_286,		/* 286 class CPUs */
+    CPU_386SX,		/* 386 class CPUs */
+    CPU_386DX,
+    CPU_IBM386SLC,
+    CPU_IBM486SLC,
+    CPU_IBM486BL,
+    CPU_RAPIDCAD,
+    CPU_486SLC,
+    CPU_486DLC,
+    CPU_i486SX,		/* 486 class CPUs */
+    CPU_Am486SX,
+    CPU_Cx486S,
+    CPU_i486SX2,
+    CPU_Am486SX2,
+    CPU_i486DX,
+    CPU_i486DX2,
+    CPU_Am486DX,
+    CPU_Am486DX2,
+    CPU_Cx486DX,
+    CPU_Cx486DX2,
+    CPU_iDX4,
+    CPU_Am486DX4,
+    CPU_Cx486DX4,
+    CPU_Am5x86,
+    CPU_Cx5x86,
+    CPU_P24T,
+    CPU_WINCHIP,	/* 586 class CPUs */
+    CPU_WINCHIP2,
+    CPU_PENTIUM,
+    CPU_PENTIUMMMX,
+    CPU_Cx6x86,
+    CPU_Cx6x86MX,
+    CPU_Cx6x86L,
+    CPU_CxGX1,
+    CPU_K5,
+    CPU_5K86,
+    CPU_K6,
+    CPU_K6_2,
+    CPU_K6_2C,
+    CPU_K6_3,
+    CPU_K6_2P,
+    CPU_K6_3P,
+    CPU_CYRIX3S,
+    CPU_PENTIUMPRO,	/* 686 class CPUs */
+    CPU_PENTIUM2,
+    CPU_PENTIUM2D
 };
 
 enum {

--- a/src/cpu/x87_ops.h
+++ b/src/cpu/x87_ops.h
@@ -46,6 +46,12 @@ static int rounding_modes[4] = {FE_TONEAREST, FE_DOWNWARD, FE_UPWARD, FE_TOWARDZ
 
 #define STATUS_ZERODIVIDE 4
 
+#if defined(_MSC_VER) && !defined(__clang__)
+# define X87_INLINE_ASM	defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86
+#else
+# define X87_INLINE_ASM defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86 || defined _M_X64 || defined __amd64__
+#endif
+
 #ifdef FPU_8087
 #define x87_div(dst, src1, src2) do                             \
         {                                                       \
@@ -311,7 +317,7 @@ static __inline void x87_stmmx(MMX_REG r)
 
 static __inline uint16_t x87_compare(double a, double b)
 {
-#if defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86 || defined _M_X64
+#if X87_INLINE_ASM
         uint32_t result;
 	double ea = a, eb = b;
 	const uint64_t ia = 0x3fec1a6ff866a936ull;
@@ -325,7 +331,7 @@ static __inline uint16_t x87_compare(double a, double b)
 	    ((a == INFINITY) || (a == -INFINITY)) && ((b == INFINITY) || (b == -INFINITY)))
 		eb = ea;
 
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) || defined(__clang__)
         /* Memory barrier, to force GCC to write to the input parameters
          * before the compare rather than after */
         __asm volatile ("" : : : "memory");
@@ -373,10 +379,10 @@ static __inline uint16_t x87_compare(double a, double b)
 
 static __inline uint16_t x87_ucompare(double a, double b)
 {
-#if defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86 || defined _M_X64 || defined __amd64__
+#if X87_INLINE_ASM
         uint32_t result;
         
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) || defined(__clang__)
         /* Memory barrier, to force GCC to write to the input parameters
          * before the compare rather than after */
         asm volatile ("" : : : "memory");

--- a/src/include/86box/vid_voodoo_codegen_x86-64.h
+++ b/src/include/86box/vid_voodoo_codegen_x86-64.h
@@ -15,7 +15,11 @@
 #undef BITMAP
 #endif
 
+#ifdef _MSC_VER
+#include <intrin.h>
+#else
 #include <xmmintrin.h>
+#endif
 
 #define BLOCK_NUM 8
 #define BLOCK_MASK (BLOCK_NUM-1)

--- a/src/include/86box/vid_voodoo_codegen_x86-64.h
+++ b/src/include/86box/vid_voodoo_codegen_x86-64.h
@@ -9,7 +9,7 @@
 #include <sys/mman.h>
 #include <unistd.h>
 #endif
-#if WIN64
+#if _WIN64
 #define BITMAP windows_BITMAP
 #include <windows.h>
 #undef BITMAP
@@ -752,7 +752,7 @@ static inline void voodoo_generate(uint8_t *code_block, voodoo_t *voodoo, voodoo
         addbyte(0x6f);
         addbyte(0x07 | (3 << 3));
 
-#if WIN64
+#if _WIN64
         addbyte(0x48); /*MOV RDI, RCX (voodoo_state)*/
         addbyte(0x89);
         addbyte(0xcf);
@@ -3428,7 +3428,7 @@ void voodoo_codegen_init(voodoo_t *voodoo)
 {
         int c;
 
-#if WIN64
+#if _WIN64
         voodoo->codegen_data = VirtualAlloc(NULL, sizeof(voodoo_x86_data_t) * BLOCK_NUM * 4, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
 #else
         voodoo->codegen_data = mmap(0, sizeof(voodoo_x86_data_t) * BLOCK_NUM*4, PROT_READ|PROT_WRITE|PROT_EXEC, MAP_ANON|MAP_PRIVATE, 0, 0);
@@ -3458,7 +3458,7 @@ void voodoo_codegen_init(voodoo_t *voodoo)
 
 void voodoo_codegen_close(voodoo_t *voodoo)
 {
-#if WIN64
+#if _WIN64
         VirtualFree(voodoo->codegen_data, 0, MEM_RELEASE);
 #else
         munmap(voodoo->codegen_data, sizeof(voodoo_x86_data_t) * BLOCK_NUM*4);

--- a/src/include/86box/vid_voodoo_codegen_x86.h
+++ b/src/include/86box/vid_voodoo_codegen_x86.h
@@ -15,7 +15,11 @@
 #undef BITMAP
 #endif
 
+#ifdef _MSC_VER
+#include <intrin.h>
+#else
 #include <xmmintrin.h>
+#endif
 
 #define BLOCK_NUM 8
 #define BLOCK_MASK (BLOCK_NUM-1)

--- a/src/include/86box/vid_voodoo_render.h
+++ b/src/include/86box/vid_voodoo_render.h
@@ -1,4 +1,4 @@
-#if !(defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined WIN32 || defined _WIN32 || defined _WIN32) && !(defined __amd64__)
+#if !(defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86 || defined __amd64__ || defined _M_X64)
 #define NO_CODEGEN
 #endif
 

--- a/src/include/slirp/libslirp.h
+++ b/src/include/slirp/libslirp.h
@@ -16,6 +16,17 @@
 
 #include "libslirp-version.h"
 
+/* Windows does not define ssize_t, so we need to define it here. */
+#ifndef _SSIZE_T_DEFINED
+# define _SSIZE_T_DEFINED
+# undef ssize_t
+# ifdef _WIN64
+#  define ssize_t int64_t
+# else
+#  define ssize_t int32_t
+# endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/include/tinyglib.h
+++ b/src/include/tinyglib.h
@@ -77,6 +77,17 @@
 
 /* Types */
 
+/* Windows does not define ssize_t, so we need to define it here. */
+#ifndef _SSIZE_T_DEFINED
+# define _SSIZE_T_DEFINED
+# undef ssize_t
+# ifdef _WIN64
+#  define ssize_t int64_t
+# else
+#  define ssize_t int32_t
+# endif
+#endif
+
 #define gboolean int
 #define gchar char
 #define gint int

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -54,7 +54,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <wchar.h>
-#include <sys/time.h>
+#include <time.h>
 #define HAVE_STDARG_H
 #include <86box/86box.h>
 #include <86box/device.h>

--- a/src/network/slirp/ip.h
+++ b/src/network/slirp/ip.h
@@ -71,6 +71,9 @@ typedef uint32_t n_long; /* long as received from the net */
 /*
  * Structure of an internet header, naked of options.
  */
+#if defined(_MSC_VER) && !defined (__clang__)
+#pragma pack(push, 1)
+#endif
 struct ip {
 #if G_BYTE_ORDER == G_BIG_ENDIAN
     uint8_t ip_v : 4, /* version */
@@ -91,6 +94,9 @@ struct ip {
     uint16_t ip_sum; /* checksum */
     struct in_addr ip_src, ip_dst; /* source and dest address */
 } SLIRP_PACKED;
+#if defined(_MSC_VER) && !defined (__clang__)
+#pragma pack(pop)
+#endif
 
 #define IP_MAXPACKET 65535 /* maximum packet size */
 
@@ -134,6 +140,9 @@ struct ip {
 /*
  * Time stamp option structure.
  */
+#if defined(_MSC_VER) && !defined (__clang__)
+#pragma pack(push, 1)
+#endif
 struct ip_timestamp {
     uint8_t ipt_code; /* IPOPT_TS */
     uint8_t ipt_len; /* size of structure (variable) */
@@ -153,6 +162,9 @@ struct ip_timestamp {
         } ipt_ta[1];
     } ipt_timestamp;
 } SLIRP_PACKED;
+#if defined(_MSC_VER) && !defined (__clang__)
+#pragma pack(pop)
+#endif
 
 /* flag bits for ipt_flg */
 #define IPOPT_TS_TSONLY 0 /* timestamps only */
@@ -178,6 +190,9 @@ struct ip_timestamp {
 
 #define IP_MSS 576 /* default maximum segment size */
 
+#if defined(_MSC_VER) && !defined (__clang__)
+#pragma pack(push, 1)
+#endif
 #if GLIB_SIZEOF_VOID_P == 4
 struct mbuf_ptr {
     struct mbuf *mptr;
@@ -188,6 +203,9 @@ struct mbuf_ptr {
     struct mbuf *mptr;
 } SLIRP_PACKED;
 #endif
+#if defined(_MSC_VER) && !defined (__clang__)
+#pragma pack(pop)
+#endif
 struct qlink {
     void *next, *prev;
 };
@@ -195,6 +213,9 @@ struct qlink {
 /*
  * Overlay for ip header used by other protocols (tcp, udp).
  */
+#if defined(_MSC_VER) && !defined (__clang__)
+#pragma pack(push, 1)
+#endif
 struct ipovly {
     struct mbuf_ptr ih_mbuf; /* backpointer to mbuf */
     uint8_t ih_x1; /* (unused) */
@@ -203,6 +224,9 @@ struct ipovly {
     struct in_addr ih_src; /* source internet address */
     struct in_addr ih_dst; /* destination internet address */
 } SLIRP_PACKED;
+#if defined(_MSC_VER) && !defined (__clang__)
+#pragma pack(pop)
+#endif
 
 /*
  * Ip reassembly queue structure.  Each fragment

--- a/src/network/slirp/ip6_icmp.h
+++ b/src/network/slirp/ip6_icmp.h
@@ -115,6 +115,9 @@ G_STATIC_ASSERT(sizeof(struct icmp6) == 40);
 /*
  * NDP Options
  */
+#if defined(_MSC_VER) && !defined (__clang__)
+#pragma pack(push, 1)
+#endif
 struct ndpopt {
     uint8_t ndpopt_type; /* Option type */
     uint8_t ndpopt_len; /* /!\ In units of 8 octets */
@@ -142,6 +145,9 @@ struct ndpopt {
 #define ndpopt_rdnss ndpopt_body.rdnss
     } ndpopt_body;
 } SLIRP_PACKED;
+#if defined(_MSC_VER) && !defined (__clang__)
+#pragma pack(pop)
+#endif
 
 /* NDP options type */
 #define NDPOPT_LINKLAYER_SOURCE 1 /* Source Link-Layer Address */

--- a/src/network/slirp/libslirp.h
+++ b/src/network/slirp/libslirp.h
@@ -16,6 +16,17 @@
 
 #include "libslirp-version.h"
 
+/* Windows does not define ssize_t, so we need to define it here. */
+#ifndef _SSIZE_T_DEFINED
+# define _SSIZE_T_DEFINED
+# undef ssize_t
+# ifdef _WIN64
+#  define ssize_t int64_t
+# else
+#  define ssize_t int32_t
+# endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/network/slirp/misc.c
+++ b/src/network/slirp/misc.c
@@ -8,7 +8,7 @@
 #include <sys/un.h>
 #endif
 
-inline void insque(void *a, void *b)
+extern inline void insque(void *a, void *b)
 {
     register struct quehead *element = (struct quehead *)a;
     register struct quehead *head = (struct quehead *)b;
@@ -19,7 +19,7 @@ inline void insque(void *a, void *b)
         (struct quehead *)element;
 }
 
-inline void remque(void *a)
+extern inline void remque(void *a)
 {
     register struct quehead *element = (struct quehead *)a;
     ((struct quehead *)(element->qh_link))->qh_rlink = element->qh_rlink;

--- a/src/network/slirp/slirp.h
+++ b/src/network/slirp/slirp.h
@@ -75,6 +75,9 @@ struct ethhdr {
     unsigned short h_proto; /* packet type ID field */
 };
 
+#if defined(_MSC_VER) && !defined (__clang__)
+#pragma pack(push, 1)
+#endif
 struct slirp_arphdr {
     unsigned short ar_hrd; /* format of hardware address */
     unsigned short ar_pro; /* format of protocol address */
@@ -90,6 +93,9 @@ struct slirp_arphdr {
     unsigned char ar_tha[ETH_ALEN]; /* target hardware address */
     uint32_t ar_tip; /* target IP address       */
 } SLIRP_PACKED;
+#if defined(_MSC_VER) && !defined (__clang__)
+#pragma pack(pop)
+#endif
 
 #define ARP_TABLE_SIZE 16
 

--- a/src/network/slirp/tftp.h
+++ b/src/network/slirp/tftp.h
@@ -20,6 +20,9 @@
 #define TFTP_FILENAME_MAX 512
 #define TFTP_BLOCKSIZE_MAX 1428
 
+#if defined(_MSC_VER) && !defined (__clang__)
+#pragma pack(push, 1)
+#endif
 struct tftp_t {
     struct udphdr udp;
     uint16_t tp_op;
@@ -35,6 +38,9 @@ struct tftp_t {
         char tp_buf[TFTP_BLOCKSIZE_MAX + 2];
     } x;
 } SLIRP_PACKED;
+#if defined(_MSC_VER) && !defined (__clang__)
+#pragma pack(pop)
+#endif
 
 struct tftp_session {
     Slirp *slirp;

--- a/src/network/slirp/util.h
+++ b/src/network/slirp/util.h
@@ -59,11 +59,7 @@
 #endif
 
 #ifndef container_of
-#define container_of(ptr, type, member)              \
-    __extension__({                                  \
-        void *__mptr = (void *)(ptr);                \
-        ((type *)(__mptr - offsetof(type, member))); \
-    })
+#define container_of(ptr, type, member) ((type *)((char *)(ptr) - offsetof(type, member)));
 #endif
 
 #ifndef G_SIZEOF_MEMBER

--- a/src/network/slirp/util.h
+++ b/src/network/slirp/util.h
@@ -30,10 +30,11 @@
 #include <stdio.h>
 #include <assert.h>
 #include <errno.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #include <inttypes.h>
 
 #ifdef _WIN32

--- a/src/network/slirp/util.h
+++ b/src/network/slirp/util.h
@@ -46,8 +46,10 @@
 #include <netinet/in.h>
 #endif
 
-#if defined(_WIN32) && (defined(__x86_64__) || defined(__i386__))
-#define SLIRP_PACKED __attribute__((gcc_struct, packed))
+#if defined(_MSC_VER) && !defined(__clang__)
+#define SLIRP_PACKED
+#elif defined(_WIN32) && (defined(__x86_64__) || defined(__i386__))
+#define SLIRP_PACKED  __attribute__((gcc_struct, packed))
 #else
 #define SLIRP_PACKED __attribute__((packed))
 #endif

--- a/src/network/slirp/vmstate.h
+++ b/src/network/slirp/vmstate.h
@@ -39,7 +39,9 @@
 #ifndef VMSTATE_H_
 #define VMSTATE_H_
 
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 #include <stdint.h>
 #include <stdbool.h>
 #include "slirp.h"

--- a/src/sound/resid-fp/sid.cc
+++ b/src/sound/resid-fp/sid.cc
@@ -29,7 +29,7 @@ enum host_cpu_feature {
 };
 
 /* This code is appropriate for 32-bit and 64-bit x86 CPUs. */
-#if defined(__x86_64__) || defined(__i386__) || defined(_MSC_VER)
+#if defined(__x86_64__) || defined(__i386__) || defined(_M_IX86) || defined(_M_X64)
 
 struct cpu_x86_regs_s {
   unsigned int eax;

--- a/src/sound/resid-fp/sid.cc
+++ b/src/sound/resid-fp/sid.cc
@@ -43,7 +43,7 @@ static cpu_x86_regs_t get_cpuid_regs(unsigned int index)
 {
   cpu_x86_regs_t retval;
 
-#if defined(_MSC_VER) /* MSVC assembly */
+#if defined(_MSC_VER) && !defined(__clang__) /* MSVC assembly */
   __asm {
     mov eax, [index]
     cpuid

--- a/src/sound/resid-fp/sid.cc
+++ b/src/sound/resid-fp/sid.cc
@@ -29,7 +29,7 @@ enum host_cpu_feature {
 };
 
 /* This code is appropriate for 32-bit and 64-bit x86 CPUs. */
-#if defined(__x86_64__) || defined(__i386__) || defined(_M_IX86) || defined(_M_X64)
+#if defined(__x86_64__) || defined(__i386__) || defined(_M_IX86) || (defined(_M_X64) && !(defined(_MSC_VER) && !defined(__clang__)))
 
 struct cpu_x86_regs_s {
   unsigned int eax;

--- a/src/sound/resid-fp/siddefs-fp.h
+++ b/src/sound/resid-fp/siddefs-fp.h
@@ -74,7 +74,7 @@ const char* resid_version_string = VERSION;
 // Inlining on/off.
 #define RESID_INLINE inline
 
-#if defined(__SSE__) || (defined(_MSC_VER) && (_MSC_VER >= 1300))
+#if defined(__SSE__) || (defined(_M_IX86_FP ) && _M_IX86_FP >= 1) || defined(_M_X64)
 #define RESID_USE_SSE 1
 #else
 #define RESID_USE_SSE 0

--- a/src/video/vid_voodoo_banshee.c
+++ b/src/video/vid_voodoo_banshee.c
@@ -2083,8 +2083,8 @@ static void banshee_overlay_draw(svga_t *svga, int displine)
                         case VIDPROCCFG_FILTER_MODE_DITHER_4X4:
                         if (banshee->voodoo->scrfilter && banshee->voodoo->scrfilterEnabled)
                         {
-                                uint8_t fil[(svga->overlay_latch.xsize) * 3];
-                                uint8_t fil3[(svga->overlay_latch.xsize) * 3];
+                                uint8_t *fil = malloc((svga->overlay_latch.xsize) * 3);
+                                uint8_t *fil3 = malloc((svga->overlay_latch.xsize) * 3);
 
                                 if (banshee->vidProcCfg & VIDPROCCFG_H_SCALE_ENABLE) /* leilei HACK - don't know of real 4x1 hscaled behavior yet, double for now */
                                 {
@@ -2146,6 +2146,9 @@ static void banshee_overlay_draw(svga_t *svga, int displine)
                                         fil[(x)*3+2] = vb_filter_v1_rb [fil[x*3+2]] [fil3[(x+1) *3+2]];
                                         p[x] = (fil[x*3+2] << 16) | (fil[x*3+1] << 8) | fil[x*3];
                                 }
+
+                                free(fil);
+                                free(fil3);
                         }
                         else  /* filter disabled by emulator option */
                         {
@@ -2168,14 +2171,14 @@ static void banshee_overlay_draw(svga_t *svga, int displine)
                         case VIDPROCCFG_FILTER_MODE_DITHER_2X2:
                         if (banshee->voodoo->scrfilter && banshee->voodoo->scrfilterEnabled)
                         {
-                                uint8_t fil[(svga->overlay_latch.xsize) * 3];
-                                uint8_t soak[(svga->overlay_latch.xsize) * 3];
-                                uint8_t soak2[(svga->overlay_latch.xsize) * 3];
+                                uint8_t *fil = malloc((svga->overlay_latch.xsize) * 3);
+                                uint8_t *soak = malloc((svga->overlay_latch.xsize) * 3);
+                                uint8_t *soak2 = malloc((svga->overlay_latch.xsize) * 3);
 
-                                uint8_t samp1[(svga->overlay_latch.xsize) * 3];
-                                uint8_t samp2[(svga->overlay_latch.xsize) * 3];
-                                uint8_t samp3[(svga->overlay_latch.xsize) * 3];
-                                uint8_t samp4[(svga->overlay_latch.xsize) * 3];
+                                uint8_t *samp1 = malloc((svga->overlay_latch.xsize) * 3);
+                                uint8_t *samp2 = malloc((svga->overlay_latch.xsize) * 3);
+                                uint8_t *samp3 = malloc((svga->overlay_latch.xsize) * 3);
+                                uint8_t *samp4 = malloc((svga->overlay_latch.xsize) * 3);
 
                                 src = &svga->vram[src_addr2 & svga->vram_mask];
                                 OVERLAY_SAMPLE(banshee->overlay_buffer[1]);
@@ -2229,6 +2232,14 @@ static void banshee_overlay_draw(svga_t *svga, int displine)
                                                 p[x] = (fil[x*3+2] << 16) | (fil[x*3+1] << 8) | fil[x*3];
                                         }
                                 }
+
+                                free(fil);
+                                free(soak);
+                                free(soak2);
+                                free(samp1);
+                                free(samp2);
+                                free(samp3);
+                                free(samp4);
                         }
                         else  /* filter disabled by emulator option */
                         {

--- a/src/video/vid_voodoo_display.c
+++ b/src/video/vid_voodoo_display.c
@@ -368,7 +368,7 @@ static void voodoo_filterline_v1(voodoo_t *voodoo, uint8_t *fil, int column, uin
 	int x;
 
 	// Scratchpad for avoiding feedback streaks
-        uint8_t fil3[(voodoo->h_disp) * 3];
+        uint8_t *fil3 = malloc((voodoo->h_disp) * 3);
 
 	/* 16 to 32-bit */
         for (x=0; x<column;x++)
@@ -426,6 +426,8 @@ static void voodoo_filterline_v1(voodoo_t *voodoo, uint8_t *fil, int column, uin
                 fil[(x)*3+1] = voodoo->thefilterg[fil3[x*3+1]][fil3[	(x+1)		*3+1]];
                 fil[(x)*3+2] = voodoo->thefilter[fil3[x*3+2]][fil3[	(x+1)		*3+2]];
         }
+
+	free(fil3);
 }
 
 
@@ -434,7 +436,7 @@ static void voodoo_filterline_v2(voodoo_t *voodoo, uint8_t *fil, int column, uin
 	int x;
 
 	// Scratchpad for blending filter
-        uint8_t fil3[(voodoo->h_disp) * 3];
+        uint8_t *fil3 = malloc((voodoo->h_disp) * 3);
 
 	/* 16 to 32-bit */
         for (x=0; x<column;x++)
@@ -491,6 +493,8 @@ static void voodoo_filterline_v2(voodoo_t *voodoo, uint8_t *fil, int column, uin
 	fil3[(column-1)*3]   = voodoo->thefilterb	[fil[(column-1)*3]][((src[column] & 31) << 3)];
 	fil3[(column-1)*3+1] = voodoo->thefilterg	[fil[(column-1)*3+1]][(((src[column] >> 5) & 63) << 2)];
 	fil3[(column-1)*3+2] = voodoo->thefilter	[fil[(column-1)*3+2]][(((src[column] >> 11) & 31) << 3)];
+
+	free(fil3);
 }
 
 void voodoo_callback(void *p)
@@ -545,7 +549,7 @@ void voodoo_callback(void *p)
 
                                 if (voodoo->scrfilter && voodoo->scrfilterEnabled)
                                 {
-                                        uint8_t fil[(voodoo->h_disp) * 3];              /* interleaved 24-bit RGB */
+                                        uint8_t *fil = malloc((voodoo->h_disp) * 3);              /* interleaved 24-bit RGB */
 
                 			if (voodoo->type == VOODOO_2)
 	                                        voodoo_filterline_v2(voodoo, fil, voodoo->h_disp, src, voodoo->line);
@@ -556,6 +560,8 @@ void voodoo_callback(void *p)
                                         {
                                                 p[x] = (voodoo->clutData256[fil[x*3]].b << 0 | voodoo->clutData256[fil[x*3+1]].g << 8 | voodoo->clutData256[fil[x*3+2]].r << 16);
                                         }
+
+					free(fil);
                                 }
                                 else
                                 {

--- a/src/video/vid_voodoo_render.c
+++ b/src/video/vid_voodoo_render.c
@@ -684,9 +684,9 @@ static inline void voodoo_tmu_fetch_and_blend(voodoo_t *voodoo, voodoo_params_t 
                 state->tex_a[0] ^= 0xff;
 }
 
-#if (defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined WIN32 || defined _WIN32 || defined _WIN32) && !(defined __amd64__)
+#if (defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86) && !(defined __amd64__ || defined _M_X64)
 #include <86box/vid_voodoo_codegen_x86.h>
-#elif (defined __amd64__)
+#elif (defined __amd64__ || defined _M_X64)
 #include <86box/vid_voodoo_codegen_x86-64.h>
 #else
 int voodoo_recomp = 0;

--- a/src/win/86Box.rc
+++ b/src/win/86Box.rc
@@ -15,11 +15,9 @@
  *		Copyright 2016-2019 Miran Grca.
  *		Copyright 2018,2019 David Hrdlička.
  */
-#include <inttypes.h>
 #define IN_RESOURCE_H
 #include <86box/resource.h>
-#include <86box/86box.h>
-#include <86box/plat.h>
+#include <86box/language.h>
 #include <86box/version.h>
 #undef IN_RESOURCE_H
 


### PR DESCRIPTION
Summary
=======
Fix quirks that break the MSVC build, such as variable length arrays, `#ifdef` target platform checks, or inline assembler blocks on platforms other than x86.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
