### PR TITLE
Add ASUS P3V133

### DIFF
--- a/src/chipset/via_apollo.c
+++ b/src/chipset/via_apollo.c
@@ -134,7 +134,7 @@ via_apollo_setup(via_apollo_t *dev)
 	dev->pci_conf[0x57] = 0x01;
     }
 
-    if (dev->id >= VIA_693A)
+    if (dev->id >= VIA_694)
 	dev->pci_conf[0x58] = 0x40;
     else if (dev->id >= VIA_585)
 	dev->pci_conf[0x58] = 0x05;
@@ -211,7 +211,7 @@ via_apollo_host_bridge_write(int func, int addr, uint8_t val, void *priv)
 	return;
     if (((addr == 0x78) || (addr >= 0xad)) && (dev->id == VIA_597))
 	return;
-    if (((addr == 0x67) || ((addr >= 0xf0) && (addr < 0xfc))) && (dev->id != VIA_691))
+    if (((addr == 0x67) || ((addr >= 0xf0) && (addr < 0xfc))) && (dev->id < VIA_691))
 	return;
 
     switch(addr) {
@@ -298,9 +298,9 @@ via_apollo_host_bridge_write(int func, int addr, uint8_t val, void *priv)
 			dev->pci_conf[0x53] = (dev->pci_conf[0x53] & ~0xf0) | (val & 0xf0);
 		break;
 	case 0x54:
-			if(dev->id == VIA_585)
+		if (dev->id == VIA_585)
 			dev->pci_conf[0x54] = val;
-			else
+		else
 			dev->pci_conf[0x54] = (dev->pci_conf[0x54] & ~0x07) | (val & 0x07);
 		break;
 

--- a/src/device/clock_ics9xxx.c
+++ b/src/device/clock_ics9xxx.c
@@ -117,7 +117,6 @@ static const ics9xxx_model_t ics9xxx_models[] = {
 		{0}
 	}
     ICS9xxx_MODEL_END()
-#if 0
     ICS9xxx_MODEL(ICS9248_39)
 	.max_reg = 5,
 	.regs = {0x00, 0x7f, 0xff, 0xbf, 0xf5, 0xff},
@@ -125,6 +124,7 @@ static const ics9xxx_model_t ics9xxx_models[] = {
 	.hw_select = {0, 3},
 	.frequencies_ref = ICS9250_08
     ICS9xxx_MODEL_END()
+#if 0
     ICS9xxx_MODEL(ICS9248_81)
 	.max_reg = 5,
 	.regs = {0x82, 0xfe, 0x7f, 0xff, 0xff, 0xb7},

--- a/src/device/hwm_lm78.c
+++ b/src/device/hwm_lm78.c
@@ -563,7 +563,7 @@ const device_t lm78_device = {
 };
 
 
-/* Winbond W83781D (or ASUS AS97127F) on ISA and SMBus. */
+/* Winbond W83781D on ISA and SMBus. */
 const device_t w83781d_device = {
     "Winbond W83781D Hardware Monitor",
     DEVICE_ISA,

--- a/src/include/86box/clock.h
+++ b/src/include/86box/clock.h
@@ -21,8 +21,8 @@
 enum {
     ICS9xxx_xx,
     ICS9150_08,
-#if 0
     ICS9248_39,
+#if 0
     ICS9248_81,
     ICS9248_95,
     ICS9248_98,

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -469,6 +469,7 @@ extern int	machine_at_p6sba_init(const machine_t *);
 extern int	machine_at_ergox365_init(const machine_t *);
 #endif
 extern int	machine_at_ficka6130_init(const machine_t *);
+extern int	machine_at_p3v133_init(const machine_t *);
 extern int	machine_at_p3v4x_init(const machine_t *);
 
 #ifdef EMU_DEVICE_H

--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -551,6 +551,44 @@ machine_at_ficka6130_init(const machine_t *model)
 
 
 int
+machine_at_p3v133_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear(L"roms/machines/p3v133/1003.002",
+			   0x000c0000, 262144, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_at_common_init_ex(model, 2);
+
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x04, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
+    pci_register_slot(0x09, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x0C, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x0D, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x0E, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x01, PCI_CARD_AGPBRIDGE,   1, 2, 3, 4);
+    device_add(&via_apro133_device);
+    device_add(&via_vt82c596b_device);
+    device_add(&w83977ef_device);
+    device_add(&keyboard_ps2_ami_pci_device);
+    device_add(ics9xxx_get(ICS9248_39));
+    device_add(&sst_flash_39sf020_device);
+    spd_register(SPD_TYPE_SDRAM, 0x7, 512);
+    device_add(&w83781d_device); /* fans: Chassis, CPU, Power; temperatures: MB, unused, CPU */
+    hwm_values.temperatures[1] = 0; /* unused */
+    hwm_values.temperatures[2] -= 3; /* CPU offset */
+
+    return ret;
+}
+
+
+int
 machine_at_p3v4x_init(const machine_t *model)
 {
     int ret;

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -357,6 +357,7 @@ const machine_t machines[] = {
 
     /* VIA Apollo Pro */
     { "[VIA Apollo Pro] FIC KA-6130",		"ficka6130",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 100000000, 1800, 3500, 3.5, 5.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	 			 8192, 524288, 8192, 255,	    machine_at_ficka6130_init, NULL			},
+    { "[VIA Apollo Pro133] ASUS P3V133",	"p3v133",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 150000000, 1300, 3500, 2.0, 8.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	  			 8192,1572864, 8192, 255,	       machine_at_p3v133_init, NULL			},
     { "[VIA Apollo Pro133A] ASUS P3V4X",	"p3v4x",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 150000000, 1300, 3500, 2.0, 8.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,	  			 8192,2097152, 8192, 255,		machine_at_p3v4x_init, NULL			},
 
     /* Slot 2 machines */

--- a/src/sio/sio_vt82c686.c
+++ b/src/sio/sio_vt82c686.c
@@ -33,10 +33,9 @@
 
 
 typedef struct {
-    uint8_t config_enable, cur_reg, regs[32],
-	    fdc_dma, fdc_irq, uart_irq[2], lpt_dma, lpt_irq;
-    fdc_t *fdc;
-    serial_t *uart[2];
+    uint8_t	cur_reg, regs[32], fdc_dma, fdc_irq, uart_irq[2], lpt_dma, lpt_irq;
+    fdc_t	*fdc;
+    serial_t	*uart[2];
 } vt82c686_t;
 
 
@@ -100,9 +99,6 @@ static void
 vt82c686_write(uint16_t port, uint8_t val, void *priv)
 {
     vt82c686_t *dev = (vt82c686_t *) priv;
-    
-    if (!dev->config_enable)
-	return;
 
     if (!(port & 1)) {
 	dev->cur_reg = val;
@@ -196,13 +192,9 @@ vt82c686_sio_write(uint8_t addr, uint8_t val, void *priv)
 		break;
 
 	case 0x85:
-		io_removehandler(0x3f0, 0x0002,
-			     vt82c686_read, NULL, NULL, vt82c686_write, NULL, NULL, dev);
-		if (val & 0x01)
-			io_sethandler(0x3f0, 0x0002,
-				      vt82c686_read, NULL, NULL, vt82c686_write, NULL, NULL, dev);
-
-		dev->config_enable = val & 0x02;
+		io_removehandler(0x3f0, 2, vt82c686_read, NULL, NULL, vt82c686_write, NULL, NULL, dev);
+		if (val & 0x02)
+			io_sethandler(0x3f0, 2, vt82c686_read, NULL, NULL, vt82c686_write, NULL, NULL, dev);
 		break;
     }
 }


### PR DESCRIPTION
VIA 693A machine, not previously added due to a misunderstanding about 693A emulation status.