### PR TITLE
Fix blit thread related deadlocks

### DIFF
--- a/src/win/win.c
+++ b/src/win/win.c
@@ -719,7 +719,6 @@ plat_setvid(int api)
 
     win_log("Initializing VIDAPI: api=%d\n", api);
     startblit();
-    video_wait_for_blit();
 
     /* Close the (old) API. */
     vid_apis[vid_api].close();
@@ -750,7 +749,6 @@ plat_vidsize(int x, int y)
     if (!vid_api_inited || !vid_apis[vid_api].resize) return;
 
     startblit();
-    video_wait_for_blit();
     vid_apis[vid_api].resize(x, y);
     endblit();
 }
@@ -764,7 +762,6 @@ plat_vidapi_enable(int enable)
     if (!vid_api_inited || !vid_apis[vid_api].enable)
 	return;
 
-    video_wait_for_blit();
     vid_apis[vid_api].enable(enable != 0);
 
     if (! i)
@@ -803,7 +800,6 @@ plat_setfullscreen(int on)
     }
 
     /* OK, claim the video. */
-    video_wait_for_blit();
     win_mouse_close();
 
     /* Close the current mode, and open the new one. */

--- a/src/win/win_ui.c
+++ b/src/win/win_ui.c
@@ -166,7 +166,6 @@ static void
 video_toggle_option(HMENU h, int *val, int id)
 {
     startblit();
-    video_wait_for_blit();
     *val ^= 1;
     CheckMenuItem(h, id, *val ? MF_CHECKED : MF_UNCHECKED);
     endblit();
@@ -1467,8 +1466,6 @@ plat_resize(int x, int y)
 
     /* First, see if we should resize the UI window. */
     if (!vid_resize) {
-	video_wait_for_blit();
-
 
 	/* scale the screen base on DPI */
 	if (dpi_scale) {


### PR DESCRIPTION
Summary
=======
Removed unnecessary calls to video_wait_for_blit(), which in
addition to not doing much were also in a race with the
video_blit_memtoscreen() thread to wait for and reset the
blit_data.blit_complete event signalled by blit_thread(),
causing several deadlocks.
