### PR TITLE
Added NCR and Olivetti AT-class machines:

### DIFF
--- a/src/device/keyboard_at.c
+++ b/src/device/keyboard_at.c
@@ -13,10 +13,12 @@
  * Authors:	Sarah Walker, <http://pcem-emulator.co.uk/>
  *		Miran Grca, <mgrca8@gmail.com>
  *		Fred N. van Kempen, <decwiz@yahoo.com>
+ *      EngiNerd <webmaster.crrc@yahoo.it>
  *
  *		Copyright 2008-2020 Sarah Walker.
  *		Copyright 2016-2020 Miran Grca.
  *		Copyright 2017-2020 Fred N. van Kempen.
+ *      Copyright 2020 EngiNerd.
  */
 #include <stdio.h>
 #include <stdint.h>
@@ -87,6 +89,7 @@
 #define KBC_VEN_ACER		0x1c
 #define KBC_VEN_INTEL_AMI	0x20
 #define KBC_VEN_OLIVETTI	0x24
+#define KBC_VEN_NCR			0x28
 #define KBC_VEN_MASK		0x3c
 
 
@@ -1197,6 +1200,17 @@ write64_generic(void *priv, uint8_t val)
 			dev->input_port = ((dev->input_port + 1) & 3) |
 					   (dev->input_port & 0xfc) |
 					   (fdd_is_525(current_drive) ? 0x40 : 0x00);
+		} else if (kbc_ven == KBC_VEN_NCR) {
+			/* switch settings
+			 * bit 7: keyboard disable
+			 * bit 6: display type (0 color, 1 mono)
+			 * bit 5: power-on default speed (0 high, 1 low)
+			 * bit 4: sense RAM size (0 unsupported, 1 512k on system board)
+			 * bits 0-3: unused
+			 */
+			add_to_kbc_queue_front(dev, (dev->input_port | fixed_bits | (video_is_mda() ? 0x40 : 0x00)) & 0xdf);
+			dev->input_port = ((dev->input_port + 1) & 3) |
+					   (dev->input_port & 0xfc);
 		} else {
 			if (((dev->flags & KBC_TYPE_MASK) >= KBC_TYPE_PS2_NOREF) &&
 			    ((dev->flags & KBC_VEN_MASK) != KBC_VEN_INTEL_AMI))
@@ -2277,6 +2291,7 @@ kbd_init(const device_t *info)
 	case KBC_VEN_ACER:
 	case KBC_VEN_GENERIC:
 	case KBC_VEN_OLIVETTI:
+	case KBC_VEN_NCR:
 	case KBC_VEN_IBM_PS1:
 	case KBC_VEN_XI8088:
 		dev->write64_ven = write64_generic;
@@ -2344,6 +2359,16 @@ const device_t keyboard_at_olivetti_device = {
     "PC/AT Keyboard (Olivetti)",
     0,
     KBC_TYPE_ISA | KBC_VEN_OLIVETTI,
+    kbd_init,
+    kbd_close,
+    kbd_reset,
+    { NULL }, NULL, NULL, NULL
+};
+
+const device_t keyboard_at_ncr_device = {
+    "PC/AT Keyboard (NCR)",
+    0,
+    KBC_TYPE_ISA | KBC_VEN_NCR,
     kbd_init,
     kbd_close,
     kbd_reset,

--- a/src/include/86box/keyboard.h
+++ b/src/include/86box/keyboard.h
@@ -74,6 +74,7 @@ extern const device_t	keyboard_at_device;
 extern const device_t	keyboard_at_ami_device;
 extern const device_t	keyboard_at_toshiba_device;
 extern const device_t	keyboard_at_olivetti_device;
+extern const device_t	keyboard_at_ncr_device;
 extern const device_t	keyboard_ps2_device;
 extern const device_t	keyboard_ps2_ps1_device;
 extern const device_t	keyboard_ps2_ps1_pci_device;

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -259,6 +259,10 @@ extern int	machine_at_adi386sx_init(const machine_t *);
 extern int	machine_at_commodore_sl386sx_init(const machine_t *);
 extern int	machine_at_wd76c10_init(const machine_t *);
 
+extern int	machine_at_olim290_init(const machine_t *);
+extern int	machine_at_ncrpc8_init(const machine_t *);
+extern int	machine_at_ncr3302_init(const machine_t *);
+
 extern int	machine_at_awardsx_init(const machine_t *);
 #if defined(DEV_BRANCH) && defined(USE_M6117)
 extern int	machine_at_arb1375_init(const machine_t *);

--- a/src/machine/m_xt_zenith.c
+++ b/src/machine/m_xt_zenith.c
@@ -14,9 +14,11 @@
  * Authors:	Sarah Walker, <http://pcem-emulator.co.uk/>
  *		Miran Grca, <mgrca8@gmail.com>
  *		TheCollector1995, <mariogplayer@gmail.com>
+ *      EngiNerd <webmaster.crrc@yahoo.it>
  *
  *		Copyright 2008-2019 Sarah Walker.
  *		Copyright 2016-2019 Miran Grca.
+ *      Copyright 2020 EngiNerd.
  */
 #include <stdarg.h>
 #include <stdint.h>

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -121,7 +121,9 @@ const machine_t machines[] = {
     { "[ISA] Compaq Portable II",		"portableii",		MACHINE_TYPE_286,		CPU_PKG_286, 0, 0, 0, 0, 0, 0, 0,										MACHINE_AT,									  640, 16384, 128,  127,	   machine_at_portableii_init, NULL			},
     { "[ISA] Compaq Portable III",		"portableiii",		MACHINE_TYPE_286,		CPU_PKG_286, 0, 0, 0, 0, 0, 0, 0,										MACHINE_AT | MACHINE_VIDEO,							  640, 16384, 128,  127,	  machine_at_portableiii_init, at_cpqiii_get_device	},
     { "[ISA] MR 286 clone",			"mr286",		MACHINE_TYPE_286,		CPU_PKG_286, 0, 0, 0, 0, 0, 0, 0,										MACHINE_AT | MACHINE_IDE,							  512, 16384, 128,  127,	        machine_at_mr286_init, NULL			},
-#if defined(DEV_BRANCH) && defined(USE_OPEN_AT)
+    { "[ISA] NCR PC8/810/710/3390/3392",	"ncr_pc8",		MACHINE_TYPE_286,		CPU_PKG_286, 0, 0, 0, 0, 0, 0, 0,                                   					MACHINE_AT,									  512, 16384, 128,  127,		machine_at_ncrpc8_init, NULL			},
+    { "[ISA] Olivetti M290",			"olivetti_m290",	MACHINE_TYPE_286,		CPU_PKG_286, 0, 0, 0, 0, 0, 0, 0,                                   					MACHINE_AT,									  640, 16384, 128, 127,			machine_at_olim290_init, NULL			},
+    #if defined(DEV_BRANCH) && defined(USE_OPEN_AT)
     { "[ISA] OpenAT",				"open_at",		MACHINE_TYPE_286,		CPU_PKG_286, 0, 0, 0, 0, 0, 0, 0,										MACHINE_AT,									  256, 15872, 128,   63,	      machine_at_open_at_init, NULL			},
 #endif
     { "[ISA] Phoenix IBM AT",			"ibmatpx",		MACHINE_TYPE_286,		CPU_PKG_286, 0, 6000000, 8000000, 0, 0, 0, 0,									MACHINE_AT,									  256, 15872, 128,   63,	      machine_at_ibmatpx_init, NULL			},
@@ -131,6 +133,7 @@ const machine_t machines[] = {
     { "[GC103] Quadtel 286 clone",		"quadt286",		MACHINE_TYPE_286,		CPU_PKG_286, 0, 0, 0, 0, 0, 0, 0,										MACHINE_AT,									  512, 16384, 128,  127,	     machine_at_quadt286_init, NULL			},
     { "[GC103] Trigem 286M",			"tg286m",		MACHINE_TYPE_286,		CPU_PKG_286, 0, 0, 0, 0, 0, 0, 0,										MACHINE_AT | MACHINE_IDE,							  512,  8192, 128,  127,	       machine_at_tg286m_init, NULL			},
     { "[NEAT] AMI 286 clone",			"ami286",		MACHINE_TYPE_286,		CPU_PKG_286, 0, 0, 0, 0, 0, 0, 0,										MACHINE_AT,									  512,  8192, 128,  127,	     machine_at_neat_ami_init, NULL			},
+    { "[NEAT] NCR 3302",			"ncr_3302",		MACHINE_TYPE_286,		CPU_PKG_286, 0, 0, 0, 0, 0, 0, 0,                                   					MACHINE_AT | MACHINE_VIDEO,							  512, 16384, 128,  127,		machine_at_ncr3302_init, NULL			},
     { "[NEAT] Phoenix 286 clone",		"px286",		MACHINE_TYPE_286,		CPU_PKG_286, 0, 0, 0, 0, 0, 0, 0,										MACHINE_AT,									  512, 16384, 128,  127,	        machine_at_px286_init, NULL			},
     { "[SCAT] Award 286 clone",			"award286",		MACHINE_TYPE_286,		CPU_PKG_286, 0, 0, 0, 0, 0, 0, 0,										MACHINE_AT,									  512, 16384, 128,  127,	     machine_at_award286_init, NULL			},
     { "[SCAT] GW-286CT GEAR",			"gw286ct",		MACHINE_TYPE_286,		CPU_PKG_286, 0, 0, 0, 0, 0, 0, 0,										MACHINE_AT,									  512, 16384, 128,  127,	      machine_at_gw286ct_init, NULL			},
@@ -365,7 +368,7 @@ const machine_t machines[] = {
 #if defined(DEV_BRANCH) && defined(NO_SIO)
     { "[i440BX] Fujitsu ErgoPro x365",		"ergox365",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 66666667, 100000000, 1800, 3500, 3.5, 5.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,		 		 8192, 393216, 8192, 511,	     machine_at_ergox365_init, NULL			},
 #endif
-
+    
     /* 440GX */
     { "[i440GX] Freeway FW-6400GX",		"fw6400gx_s1",		MACHINE_TYPE_SLOT1,		CPU_PKG_SLOT1, 0, 100000000, 150000000, 1800, 3500, 3.0, 8.0,							MACHINE_AGP | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,				16384,2080768,16384, 511,	     machine_at_fw6400gx_init, NULL			},
 


### PR DESCRIPTION
Summary
=======
Added the following new machines:
- NCR PC8/810/710/3390/3392
- NCR 3302
- Olivetti M290

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [X] This pull request requires changes to the ROM set
  * [X] I have opened a roms pull request - https://github.com/86Box/roms/pull/93

References
==========
NCR PC-8/810/710/3390/3392
Note: several 286-class PCs were produced by NCR with different model names, depending on the case form-factor and on the mainboard layout (passive backplane with ISA CPU card or active mainboard). However, the chipset being used in all those models is the same, and BIOS chips appear to be interchangeable.
- Press releases: http://www.thecorememory.com/html/ncr_servers___pcs.html
- Manual: http://www.thecorememory.com/NCR_286_TRM.pdf

NCR 3302
Note: Chips & Technologies NEAT chipset (82C206, 82C211, 82C212, 82C215), PVGA1A VGA card on-board, IDE controller onboard
- Info on NCR 3000 Series PCs: https://www.ardent-tool.com/NCR/Docs/NCR_3000_Series.pdf
- Mainboard jumper settings: https://stason.org/TULARC/pc/motherboards/N/NCR-CORPORATION-286-CLASS-3302-80286-TYPE-I.html
- Manual unavailable :-(

Olivetti M290:
Note: several Olivetti models are identified by the name M290-XX. They have different mainboards with different chipsets and BIOSes. The machine added here is the first M290 (without dash and digits).
- Service guide: https://www.ardent-tool.com/Olivetti/Docs/service_guide/systems1/cap5.pdf
- Reference disk (required for BIOS setup): https://web.archive.org/web/20150608124240/http://www.retrocomputing.net/parts/olivetti/m290/docs/m290ct.exe
