### PR TITLE
Turn all mutexes into critical sections

### DIFF
--- a/src/include/86box/plat.h
+++ b/src/include/86box/plat.h
@@ -142,7 +142,6 @@ extern void     ioctl_close(uint8_t id);
 typedef void thread_t;
 typedef void event_t;
 typedef void mutex_t;
-typedef void lightmutex_t;
 
 extern thread_t	*thread_create(void (*thread_func)(void *param), void *param);
 extern void	thread_kill(thread_t *arg);
@@ -153,18 +152,13 @@ extern void	thread_reset_event(event_t *arg);
 extern int	thread_wait_event(event_t *arg, int timeout);
 extern void	thread_destroy_event(event_t *arg);
 
+#define MUTEX_DEFAULT_SPIN_COUNT 1024
+
 extern mutex_t	*thread_create_mutex(void);
+extern mutex_t	*thread_create_mutex_with_spin_count(unsigned int spin_count);
 extern void	thread_close_mutex(mutex_t *arg);
 extern int	thread_wait_mutex(mutex_t *arg);
 extern int	thread_release_mutex(mutex_t *mutex);
-
-#define LIGHT_MUTEX_DEFAULT_SPIN_COUNT 1024
-
-lightmutex_t *thread_create_light_mutex();
-lightmutex_t *thread_create_light_mutex_and_spin_count(unsigned int spin_count);
-int thread_wait_light_mutex(lightmutex_t *lightmutex);
-int thread_release_light_mutex(lightmutex_t *lightmutex);
-void thread_close_light_mutex(lightmutex_t *lightmutex);
 
 /* Other stuff. */
 extern void	startblit(void);

--- a/src/include/86box/vid_voodoo_common.h
+++ b/src/include/86box/vid_voodoo_common.h
@@ -491,7 +491,7 @@ typedef struct voodoo_t
 
         int force_blit_count;
         int can_blit;
-        lightmutex_t* force_blit_mutex;
+        mutex_t* force_blit_mutex;
 
         int use_recompiler;
         void *codegen_data;

--- a/src/video/vid_voodoo_display.c
+++ b/src/video/vid_voodoo_display.c
@@ -646,13 +646,13 @@ skip_draw:
                 if (voodoo->line == voodoo->v_disp)
                 {
                         int force_blit = 0;
-                        thread_wait_light_mutex(voodoo->force_blit_mutex);
+                        thread_wait_mutex(voodoo->force_blit_mutex);
                         if(voodoo->force_blit_count) {
                             force_blit = 1;
                             if(--voodoo->force_blit_count < 0)
                                 voodoo->force_blit_count = 0;
                         }
-                        thread_release_light_mutex(voodoo->force_blit_mutex);
+                        thread_release_mutex(voodoo->force_blit_mutex);
 
                         if (voodoo->dirty_line_high > voodoo->dirty_line_low || force_blit)
                                 svga_doblit(0, voodoo->v_disp, voodoo->h_disp, voodoo->v_disp-1, voodoo->svga);

--- a/src/win/win_thread.c
+++ b/src/win/win_thread.c
@@ -133,17 +133,23 @@ thread_destroy_event(event_t *arg)
 
 mutex_t *
 thread_create_mutex(void)
-{
-    return((mutex_t*)CreateMutex(NULL, FALSE, NULL));
+{    
+    mutex_t *mutex = malloc(sizeof(CRITICAL_SECTION));
+
+    InitializeCriticalSection(mutex);
+
+    return mutex;
 }
 
 
-void
-thread_close_mutex(mutex_t *mutex)
+mutex_t *
+thread_create_mutex_with_spin_count(unsigned int spin_count)
 {
-    if (mutex == NULL) return;
+    mutex_t *mutex = malloc(sizeof(CRITICAL_SECTION));
 
-    CloseHandle((HANDLE)mutex);
+    InitializeCriticalSectionAndSpinCount(mutex, spin_count);
+
+    return mutex;
 }
 
 
@@ -152,47 +158,7 @@ thread_wait_mutex(mutex_t *mutex)
 {
     if (mutex == NULL) return(0);
 
-    DWORD dwres = WaitForSingleObject((HANDLE)mutex, INFINITE);
-
-    if (dwres == WAIT_OBJECT_0) return(1);
-
-    return(0);
-}
-
-
-int
-thread_release_mutex(mutex_t *mutex)
-{
-    if (mutex == NULL) return(0);
-
-    return(!!ReleaseMutex((HANDLE)mutex));
-}
-
-
-lightmutex_t *
-thread_create_light_mutex()
-{
-    return thread_create_light_mutex_and_spin_count(LIGHT_MUTEX_DEFAULT_SPIN_COUNT);
-}
-
-
-lightmutex_t *
-thread_create_light_mutex_and_spin_count(unsigned int spin_count)
-{
-    lightmutex_t *lightmutex = malloc(sizeof(CRITICAL_SECTION));
-
-    InitializeCriticalSectionAndSpinCount(lightmutex, spin_count);
-
-    return lightmutex;
-}
-
-
-int
-thread_wait_light_mutex(lightmutex_t *lightmutex)
-{
-    if (lightmutex == NULL) return(0);
-
-    LPCRITICAL_SECTION critsec = (LPCRITICAL_SECTION)lightmutex;
+    LPCRITICAL_SECTION critsec = (LPCRITICAL_SECTION)mutex;
 
     EnterCriticalSection(critsec);
 
@@ -201,11 +167,11 @@ thread_wait_light_mutex(lightmutex_t *lightmutex)
 
 
 int
-thread_release_light_mutex(lightmutex_t *lightmutex)
+thread_release_mutex(mutex_t *mutex)
 {
-    if (lightmutex == NULL) return(0);
+    if (mutex == NULL) return(0);
 
-    LPCRITICAL_SECTION critsec = (LPCRITICAL_SECTION)lightmutex;
+    LPCRITICAL_SECTION critsec = (LPCRITICAL_SECTION)mutex;
 
     LeaveCriticalSection(critsec);
 
@@ -214,11 +180,11 @@ thread_release_light_mutex(lightmutex_t *lightmutex)
 
 
 void
-thread_close_light_mutex(lightmutex_t *lightmutex)
+thread_close_mutex(mutex_t *mutex)
 {
-    if (lightmutex == NULL) return;
+    if (mutex == NULL) return;
 
-    LPCRITICAL_SECTION critsec = (LPCRITICAL_SECTION)lightmutex;
+    LPCRITICAL_SECTION critsec = (LPCRITICAL_SECTION)mutex;
 
     DeleteCriticalSection(critsec);
 


### PR DESCRIPTION
Removing all win32 mutexes and turning them into critical
sections, since mutexes in win32 are meant generally for
inter process communication, tend to be slower, and aren't
really needed for current purposes. Critical sections
are roughly equivalent to std::mutex in the c++ stl.
