### PR TITLE
Adapt the DTK FDC to 86Box

### DIFF
--- a/src/floppy/CMakeLists.txt
+++ b/src/floppy/CMakeLists.txt
@@ -13,5 +13,5 @@
 #		Copyright 2020,2021 David Hrdlička.
 #
 
-add_library(fdd OBJECT fdd.c fdc.c fdc_pii15xb.c fdi2raw.c fdd_common.c
+add_library(fdd OBJECT fdd.c fdc.c fdc_magitronic.c fdc_pii15xb.c fdi2raw.c fdd_common.c
 	fdd_86f.c fdd_fdi.c fdd_imd.c fdd_img.c fdd_json.c fdd_mfm.c fdd_td0.c)

--- a/src/floppy/fdc.c
+++ b/src/floppy/fdc.c
@@ -109,6 +109,7 @@ typedef const struct {
 /* All emulated machines have at least one integrated FDC controller */
 static fdc_cards_t fdc_cards[] = {
     { "internal",	NULL			},
+    { "b215",	&fdc_b215_device	},
     { "dtk_pii151b",	&fdc_pii151b_device	},
     { "dtk_pii158b",	&fdc_pii158b_device	},
     { "",		NULL			},

--- a/src/floppy/fdc.c
+++ b/src/floppy/fdc.c
@@ -2426,7 +2426,7 @@ const device_t fdc_at_nsc_device = {
 const device_t fdc_dp8473_device = {
     "NS DP8473 Floppy Drive Controller",
     0,
-    FDC_FLAG_NSDP,
+    FDC_FLAG_AT | FDC_FLAG_NSC,
     fdc_init,
     fdc_close, 
     fdc_reset,

--- a/src/floppy/fdc_magitronic.c
+++ b/src/floppy/fdc_magitronic.c
@@ -1,0 +1,99 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Implementation of the Magitronic B215 XT-FDC Controller.
+ *
+ *      Authors: Tiseno100
+ *
+ *		Copyright 2021 Tiseno100
+ *
+ */
+
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+#define HAVE_STDARG_H
+#include <86box/86box.h>
+#include <86box/timer.h>
+#include <86box/io.h>
+#include <86box/device.h>
+#include <86box/mem.h>
+#include <86box/rom.h>
+#include <86box/fdd.h>
+#include <86box/fdc.h>
+#include <86box/fdc_ext.h>
+
+#define ROM_B215 L"roms/floppy/magitronic/Magitronic B215 - BIOS ROM.bin"
+#define ROM_ADDR (uint32_t)(device_get_config_hex20("bios_addr") & 0x000fffff)
+
+typedef struct
+{
+    fdc_t *fdc_controller;
+    rom_t rom;
+} b215_t;
+
+static void
+b215_close(void *priv)
+{
+    b215_t *dev = (b215_t *)priv;
+
+    free(dev);
+}
+
+static void *
+b215_init(const device_t *info)
+{
+    b215_t *dev = (b215_t *)malloc(sizeof(b215_t));
+    memset(dev, 0, sizeof(b215_t));
+
+    rom_init(&dev->rom, ROM_B215, ROM_ADDR, 0x2000, 0x1fff, 0, MEM_MAPPING_EXTERNAL);
+
+    device_add(&fdc_at_device);
+
+    return dev;
+}
+
+static int b215_available(void)
+{
+    return rom_present(ROM_B215);
+}
+
+static const device_config_t b215_config[] = {
+    {
+	"bios_addr", "BIOS Address:", CONFIG_HEX20, "", 0xca000, "", { 0 },
+	{
+		{
+			"CA00H", 0xca000
+		},
+		{
+			"CC00H", 0xcc000
+		},
+		{
+			""
+		}
+	}
+    },
+    {
+	"", "", -1
+    }
+};
+
+const device_t fdc_b215_device = {
+    "Magitronic B215",
+    DEVICE_ISA,
+    0,
+    b215_init,
+    b215_close,
+    NULL,
+    {b215_available},
+    NULL,
+    NULL,
+    b215_config};

--- a/src/floppy/fdc_pii15xb.c
+++ b/src/floppy/fdc_pii15xb.c
@@ -1,52 +1,63 @@
 /*
  * VARCem	Virtual ARchaeological Computer EMulator.
  *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *		using the ISA,EISA,VLB,MCA and PCI system buses, roughly
  *		spanning the era between 1981 and 1995.
  *
  *		This file is part of the VARCem Project.
  *
- *		Implementation of the DTK PII-151B and PII-158B cards.
+ *	  Implementation of the DTK MiniMicro series of Floppy Disk Controllers.
+ *    Original code from VARCem. Fully rewritten, fixed and improved for 86Box.
  *
- *		These are DP8473-based floppy controller ISA cards for XT
- *		class systems, and allow usage of standard and high-density
- *		drives on them. They have their own BIOS which takes over
- *		from the standard system BIOS.
- *
- * Author:	Fred N. van Kempen, <decwiz@yahoo.com>
+ * Author:	Fred N. van Kempen, <decwiz@yahoo.com>, 
+ *          Tiseno100
  *
  *		Copyright 2019 Fred N. van Kempen.
+ *      Copyright 2021 Tiseno100
  *
- *		Redistribution and  use  in source  and binary forms, with
- *		or  without modification, are permitted  provided that the
+ *		Redistribution and use in source and binary forms, with
+ *		or without modification, are permitted provided that the
  *		following conditions are met:
  *
  *		1. Redistributions of source code must retain the entire
- *		   above notice, this list of conditions and the following
- *		   disclaimer.
+ *		  above notice, this list of conditions and the following
+ *		  disclaimer.
  *
  *		2. Redistributions in binary form must reproduce the above
- *		   copyright  notice,  this list  of  conditions  and  the
- *		   following disclaimer in  the documentation and/or other
- *		   materials provided with the distribution.
+ *		  copyright notice, this list of conditions and the
+ *		  following disclaimer in the documentation and/or other
+ *		  materials provided with the distribution.
  *
- *		3. Neither the  name of the copyright holder nor the names
- *		   of  its  contributors may be used to endorse or promote
- *		   products  derived from  this  software without specific
- *		   prior written permission.
+ *		3. Neither the name of the copyright holder nor the names
+ *		  of its contributors may be used to endorse or promote
+ *		  products derived from this software without specific
+ *		  prior written permission.
  *
- * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
- * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
- * PARTICULAR PURPOSE  ARE  DISCLAIMED. IN  NO  EVENT  SHALL THE COPYRIGHT
- * HOLDER OR  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL,  EXEMPLARY,  OR  CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES;  LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED  AND ON  ANY
- * THEORY OF  LIABILITY, WHETHER IN  CONTRACT, STRICT  LIABILITY, OR  TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING  IN ANY  WAY OUT OF THE USE
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+/*
+Notes:
+VARCem uses the DP8473 for both floppy disk controllers. The statement though is wrong.
+
+MiniMicro 4 uses a Zilog Z0765A08PSC(Clone of the NEC 765)
+MiniMicro 1 uses a National Semiconductor DP8473(Clone of the NEC 765 with additional NSC commands)
+
+Issues:
+MiniMicro 4 WON'T WORK with XT machines. This statement has to be confirmed by someone with the real card itself.
+MiniMicro 4 also won't work with the XT FDC which the Zilog claims to be.
+*/
+
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -66,6 +77,7 @@
 #include <86box/fdc_ext.h>
 
 #define DTK_VARIANT ((info->local == 158) ? ROM_PII_158B : ROM_PII_151B)
+#define DTK_CHIP ((info->local == 158) ? &fdc_at_device : &fdc_dp8473_device)
 #define BIOS_ADDR (uint32_t)(device_get_config_hex20("bios_addr") & 0x000fffff)
 #define ROM_PII_151B L"roms/floppy/dtk/pii-151b.rom"
 #define ROM_PII_158B L"roms/floppy/dtk/pii-158b.rom"
@@ -94,9 +106,9 @@ pii_init(const device_t *info)
     if (BIOS_ADDR != 0)
         rom_init(&dev->bios_rom, DTK_VARIANT, BIOS_ADDR, 0x2000, 0x1ffff, 0, MEM_MAPPING_EXTERNAL);
 
-    device_add(&fdc_at_device); /* Our DP8473 emulation is broken. If fixed this has to be changed! */
+    device_add(DTK_CHIP);
 
-    return (dev);
+    return dev;
 }
 
 static int pii_151b_available(void)

--- a/src/include/86box/fdc.h
+++ b/src/include/86box/fdc.h
@@ -34,7 +34,6 @@ extern int fdc_type;
 #define FDC_FLAG_NSC		0x80	/* PC87306, PC87309 */
 #define FDC_FLAG_TOSHIBA	0x100	/* T1000, T1200 */
 #define FDC_FLAG_AMSTRAD	0x200	/* Non-AT Amstrad machines */
-#define FDC_FLAG_NSDP		0x400   /* DP8473N, DP8473V */
 
 
 typedef struct {

--- a/src/include/86box/fdc_ext.h
+++ b/src/include/86box/fdc_ext.h
@@ -27,6 +27,7 @@ extern int fdc_type;
 /* Controller types. */
 #define FDC_INTERNAL		0
 
+extern const device_t fdc_b215_device;
 extern const device_t fdc_pii151b_device;
 extern const device_t fdc_pii158b_device;
 

--- a/src/win/Makefile.mingw
+++ b/src/win/Makefile.mingw
@@ -658,7 +658,7 @@ SIOOBJ		:= sio_acc3221.o \
 		    sio_um8669f.o \
 		    sio_vt82c686.o
 
-FDDOBJ		:= fdd.o fdc.o fdc_pii15xb.o \
+FDDOBJ		:= fdd.o fdc.o fdc_magitronic.o fdc_pii15xb.o \
 		   fdi2raw.o \
 		   fdd_common.o fdd_86f.o \
 		   fdd_fdi.o fdd_imd.o fdd_img.o fdd_json.o \


### PR DESCRIPTION
Rewrote few parts so the DTK FDC is more adaptive on 86Box standards.

Update: This PR also adds the Magitronic B215 FDC controller. The ROM is at the PR below.
https://github.com/86Box/roms/pull/100