### PR TITLE
AGP and clock control

### DIFF
--- a/src/chipset/ali1543.c
+++ b/src/chipset/ali1543.c
@@ -891,13 +891,13 @@ ali1543_init(const device_t *info)
     dev->pci_slot = pci_add_card(PCI_ADD_SOUTHBRIDGE, ali1533_read, ali1533_write, dev);
 
     /* Device 0B: M5229 IDE Controller*/
-    dev->ide_slot = pci_add_card(PCI_ADD_IDE, ali5229_read, ali5229_write, dev);
-
-    /* Device 0D: M5237 USB */
-    dev->usb_slot = pci_add_card(PCI_ADD_NORMAL_NOBRIDGE, ali5237_read, ali5237_write, dev);
+    dev->ide_slot = pci_add_card(PCI_ADD_SOUTHBRIDGE, ali5229_read, ali5229_write, dev);
 
     /* Device 0C: M7101 Power Managment Controller */
-    dev->pmu_slot = pci_add_card(PCI_ADD_BRIDGE, ali7101_read, ali7101_write, dev);
+    dev->pmu_slot = pci_add_card(PCI_ADD_SOUTHBRIDGE, ali7101_read, ali7101_write, dev);
+
+    /* Device 0D: M5237 USB */
+    dev->usb_slot = pci_add_card(PCI_ADD_SOUTHBRIDGE, ali5237_read, ali5237_write, dev);
 
     /* Ports 3F0-1h: M1543 Super I/O */
     io_sethandler(0x03f0, 0x0002, ali1533_sio_read, NULL, NULL, ali1533_sio_write, NULL, NULL, dev);

--- a/src/chipset/ali6117.c
+++ b/src/chipset/ali6117.c
@@ -146,6 +146,42 @@ ali6117_reg_write(uint16_t addr, uint8_t val, void *priv)
 
 		case 0x1e:
 			val &= 0x07;
+
+			switch (val) {
+				/* Half PIT clock. */
+				case 0x0:
+					cpu_set_isa_speed(7159091);
+					break;
+
+				/* Divisors on the input clock PCLK2, which is double the CPU clock. */
+				case 0x1:
+					cpu_set_isa_speed(cpu_busspeed / 1.5);
+					break;
+
+				case 0x2:
+					cpu_set_isa_speed(cpu_busspeed / 2);
+					break;
+
+				case 0x3:
+					cpu_set_isa_speed(cpu_busspeed / 2.5);
+					break;
+
+				case 0x4:
+					cpu_set_isa_speed(cpu_busspeed / 3);
+					break;
+
+				case 0x5:
+					cpu_set_isa_speed(cpu_busspeed / 4);
+					break;
+
+				case 0x6:
+					cpu_set_isa_speed(cpu_busspeed / 5);
+					break;
+
+				case 0x7:
+					cpu_set_isa_speed(cpu_busspeed / 6);
+					break;
+			}
 			break;
 
 		case 0x20:
@@ -282,6 +318,8 @@ ali6117_reset(void *priv)
     dev->regs[0x34] = 0x04; /* enable internal RTC */
     dev->regs[0x35] = 0x20; /* enable internal KBC */
     dev->regs[0x36] = dev->local & 0x4; /* M6117D ID */
+
+    cpu_set_isa_speed(7159091);
 }
 
 

--- a/src/chipset/intel_4x0.c
+++ b/src/chipset/intel_4x0.c
@@ -1540,6 +1540,15 @@ static void
 	cpu_update_waitstates();
     }
 
+    /* Out-of-spec PCI and AGP clocks with overclocked bus. */
+    if ((dev->type <= INTEL_440FX) && (cpu_busspeed >= 66666666))
+	cpu_set_pci_speed(cpu_busspeed / 2);
+
+    if ((dev->type >= INTEL_440BX) && (cpu_busspeed >= 100000000))
+	cpu_set_agp_speed(cpu_busspeed / 1.5);
+    else if (dev->type >= INTEL_440LX)
+	cpu_set_agp_speed(cpu_busspeed);
+
     i4x0_write(regs[0x59], 0x59, 0x00, dev);
     i4x0_write(regs[0x5a], 0x5a, 0x00, dev);
     i4x0_write(regs[0x5b], 0x5b, 0x00, dev);

--- a/src/chipset/intel_piix.c
+++ b/src/chipset/intel_piix.c
@@ -1237,9 +1237,10 @@ static void
 piix_speed_changed(void *priv)
 {
     piix_t *dev = (piix_t *) priv;
-    int te;
+    if (!dev)
+	return;
 
-    te = timer_is_enabled(&dev->fast_off_timer);
+    int te = timer_is_enabled(&dev->fast_off_timer);
 
     timer_stop(&dev->fast_off_timer);
     if (te)
@@ -1305,6 +1306,8 @@ static void
     }
 
     dev->port_92 = device_add(&port_92_pci_device);
+
+    cpu_set_isa_pci_div(4);
 
     dma_alias_set();
 

--- a/src/chipset/via_apollo.c
+++ b/src/chipset/via_apollo.c
@@ -157,19 +157,33 @@ via_apollo_setup(via_apollo_t *dev)
     if (dev->id >= VIA_691)
 	dev->pci_conf[0x67] = 0xec;	/* DRAM Timing for Banks 6, 7 */
     if (dev->id >= VIA_693A) {
-	if (cpu_busspeed < 95000000)
-		dev->pci_conf[0x68] |= 0x00; /* 66 MHz */
-	else if (cpu_busspeed < 124000000)
-		dev->pci_conf[0x68] |= 0x01; /* 100 MHz */
-	else
-		dev->pci_conf[0x68] |= (dev->id == VIA_8601) ? 0x03 : 0x02; /* 133 MHz */
+	if (cpu_busspeed < 95000000) { /* 66 MHz */
+		cpu_set_pci_speed(cpu_busspeed / 2);
+		cpu_set_agp_speed(cpu_busspeed);
+		dev->pci_conf[0x68] |= 0x00;
+	} else if (cpu_busspeed < 124000000) { /* 100 MHz */
+		cpu_set_pci_speed(cpu_busspeed / 3);
+		cpu_set_agp_speed(cpu_busspeed / 1.5);
+		dev->pci_conf[0x68] |= 0x01;
+	} else { /* 133 MHz */
+		cpu_set_pci_speed(cpu_busspeed / 4);
+		cpu_set_agp_speed(cpu_busspeed / 2);
+		dev->pci_conf[0x68] |= (dev->id == VIA_8601) ? 0x03 : 0x02;
+	}
     } else if (dev->id >= VIA_598) {
-	if (cpu_busspeed < 75000000)
-		dev->pci_conf[0x68] |= 0x00; /* 66 MHz */
-	else if (cpu_busspeed < 100000000)
-		dev->pci_conf[0x68] |= (dev->id >= VIA_691) ? 0x00 : 0x03; /* 75/83 MHz (66 MHz on 691) */
-	else
-		dev->pci_conf[0x68] |= 0x01; /* 100 MHz */
+	if (cpu_busspeed < ((dev->id >= VIA_691) ? 100000000 : 75000000)) { /* 66 MHz */
+		cpu_set_pci_speed(cpu_busspeed / 2);
+		cpu_set_agp_speed(cpu_busspeed);
+		dev->pci_conf[0x68] |= 0x00;
+	} else if (cpu_busspeed < 100000000) { /* 75/83 MHz (not available on 691) */
+		cpu_set_pci_speed(cpu_busspeed / 2.5);
+		cpu_set_agp_speed(cpu_busspeed / 1.25);
+		dev->pci_conf[0x68] |= 0x03;
+	} else { /* 100 MHz */
+		cpu_set_pci_speed(cpu_busspeed / 3);
+		cpu_set_agp_speed(cpu_busspeed / 1.5);
+		dev->pci_conf[0x68] |= 0x01;
+	}
     }
     dev->pci_conf[0x6b] = 0x01;
 

--- a/src/chipset/via_pipc.c
+++ b/src/chipset/via_pipc.c
@@ -503,6 +503,52 @@ pipc_write(int func, int addr, uint8_t val, void *priv)
 			dev->pci_isa_regs[0x07] &= ~(val & 0xb0);
 			break;
 
+		case 0x42:
+			dev->pci_isa_regs[0x42] = val & 0xcf;
+
+			switch (val & 0xf) {
+				/* Divisors on the PCI clock. */
+				case 0x8:
+					cpu_set_isa_pci_div(3);
+					break;
+
+				case 0x9:
+					cpu_set_isa_pci_div(2);
+					break;
+
+				case 0xa:
+					cpu_set_isa_pci_div(4);
+					break;
+
+				case 0xb:
+					cpu_set_isa_pci_div(6);
+					break;
+
+				case 0xc:
+					cpu_set_isa_pci_div(5);
+					break;
+
+				case 0xd:
+					cpu_set_isa_pci_div(10);
+					break;
+
+				case 0xe:
+					cpu_set_isa_pci_div(12);
+					break;
+
+				/* Half PIT clock. */
+				case 0xf:
+					cpu_set_isa_speed(7159091);
+					break;
+
+				/* Divisor 4 on the PCI clock whenever bit 3 is clear. */
+				default:
+					cpu_set_isa_pci_div(4);
+					break;
+			}
+
+			break;
+
 		case 0x47:
 			if (val & 0x01)
 				trc_write(0x0047, (val & 0x80) ? 0x06 : 0x04, NULL);
@@ -939,6 +985,8 @@ pipc_init(const device_t *info)
     pipc_reset_hard(dev);
 
     device_add(&port_92_pci_device);
+
+    cpu_set_isa_pci_div(4);
 
     dma_alias_set();
 

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -433,7 +433,7 @@ extern uint32_t		oldds,oldss,olddslimit,oldsslimit,olddslimitw,oldsslimitw;
 extern uint32_t		pccache;
 extern uint8_t		*pccache2;
 
-extern double		bus_timing, pci_timing;
+extern double		bus_timing, isa_timing, pci_timing, agp_timing;
 extern uint64_t		pmc[2];
 extern uint16_t		temp_seg_data[4];
 extern uint16_t		cs_msr;
@@ -477,7 +477,7 @@ extern int	cpu_cycles_read, cpu_cycles_read_l, cpu_cycles_write, cpu_cycles_writ
 extern int	cpu_prefetch_cycles, cpu_prefetch_width, cpu_mem_prefetch_cycles, cpu_rom_prefetch_cycles;
 extern int	cpu_waitstates;
 extern int	cpu_cache_int_enabled, cpu_cache_ext_enabled;
-extern int	cpu_pci_speed;
+extern int	cpu_isa_speed, cpu_pci_speed, cpu_agp_speed;
 
 extern int	timing_rr;
 extern int	timing_mr, timing_mrl;
@@ -523,6 +523,10 @@ extern char	*cpu_current_pc(char *bufp);
 
 extern void	cpu_update_waitstates(void);
 extern void	cpu_set(void);
+extern void	cpu_set_isa_speed(int speed);
+extern void	cpu_set_pci_speed(int speed);
+extern void	cpu_set_isa_pci_div(int div);
+extern void	cpu_set_agp_speed(int speed);
 
 extern void	cpu_CPUID(void);
 extern void	cpu_RDMSR(void);

--- a/src/device/clock_ics9xxx.c
+++ b/src/device/clock_ics9xxx.c
@@ -1050,10 +1050,11 @@ ics9xxx_set(ics9xxx_t *dev, uint8_t val)
 	}
     }
 
-#ifdef ENABLE_ICS9xxx_LOG
     uint16_t bus = dev->frequencies_ptr[val].bus;
-    ics9xxx_log("ICS9xxx: set(%d) = hw=%d bus=%d ram=%d pci=%d\n", val, hw_select, bus, bus * dev->frequencies_ptr[val].ram_mult, bus / dev->frequencies_ptr[val].pci_div);
-#endif
+    uint32_t pci = bus / dev->frequencies_ptr[val].pci_div;
+    cpu_set_pci_speed(pci * 10000);
+
+    ics9xxx_log("ICS9xxx: set(%d) = hw=%d bus=%d ram=%d pci=%d\n", val, hw_select, bus, bus * dev->frequencies_ptr[val].ram_mult, pci);
 }
 
 

--- a/src/device/pci_bridge.c
+++ b/src/device/pci_bridge.c
@@ -335,8 +335,7 @@ pci_bridge_init(const device_t *info)
     for (i = 0; i < slot_count; i++) {
 	/* Interrupts for bridge slots are assigned in round-robin: ABCD, BCDA, CDAB and so on. */
 	pci_bridge_log("PCI Bridge %d: downstream slot %02X interrupts %02X %02X %02X %02X\n", dev->bus_index, i, interrupts[i & interrupt_mask], interrupts[(i + 1) & interrupt_mask], interrupts[(i + 2) & interrupt_mask], interrupts[(i + 3) & interrupt_mask]);
-	/* Use _NOBRIDGE for VIA AGP bridges, as they don't like PCI bridges under them. */
-	pci_register_bus_slot(dev->bus_index, i, AGP_BRIDGE_VIA(dev->local) ? PCI_CARD_NORMAL_NOBRIDGE : PCI_CARD_NORMAL,
+	pci_register_bus_slot(dev->bus_index, i, AGP_BRIDGE(dev->local) ? PCI_CARD_AGP : PCI_CARD_NORMAL,
 			      interrupts[i & interrupt_mask],
 			      interrupts[(i + 1) & interrupt_mask],
 			      interrupts[(i + 2) & interrupt_mask],

--- a/src/include/86box/pci.h
+++ b/src/include/86box/pci.h
@@ -51,8 +51,8 @@ enum {
     PCI_CARD_NORTHBRIDGE = 0,
     PCI_CARD_AGPBRIDGE,
     PCI_CARD_SOUTHBRIDGE,
+    PCI_CARD_AGP = 0x0f,
     PCI_CARD_NORMAL = 0x10,
-    PCI_CARD_NORMAL_NOBRIDGE,
     PCI_CARD_VIDEO,
     PCI_CARD_SCSI,
     PCI_CARD_SOUND,
@@ -65,8 +65,8 @@ enum {
     PCI_ADD_NORTHBRIDGE = 0,
     PCI_ADD_AGPBRIDGE,
     PCI_ADD_SOUTHBRIDGE,
+    PCI_ADD_AGP = 0x0f,
     PCI_ADD_NORMAL = 0x10,
-    PCI_ADD_NORMAL_NOBRIDGE,
     PCI_ADD_VIDEO,
     PCI_ADD_SCSI,
     PCI_ADD_SOUND,
@@ -81,8 +81,8 @@ typedef union {
 } bar_t;
 
 
-extern int	pci_burst_time,
-		pci_nonburst_time;
+extern int	pci_burst_time, agp_burst_time,
+		pci_nonburst_time, agp_nonburst_time;
 
 
 extern void	pci_set_irq_routing(int pci_int, int irq);

--- a/src/include/86box/pit.h
+++ b/src/include/86box/pit.h
@@ -49,7 +49,7 @@ typedef struct PIT {
 extern pit_t	*pit,
 		*pit2;
 
-extern double	SYSCLK, PCICLK;
+extern double	SYSCLK, PCICLK, AGPCLK;
 
 extern uint64_t	PITCONST, ISACONST,
 		CGACONST,

--- a/src/include/86box/video.h
+++ b/src/include/86box/video.h
@@ -48,7 +48,8 @@ enum {
     VIDEO_ISA = 0,
     VIDEO_MCA,
     VIDEO_BUS,
-    VIDEO_PCI
+    VIDEO_PCI,
+    VIDEO_AGP
 };
 
 #define VIDEO_FLAG_TYPE_CGA     0
@@ -381,7 +382,9 @@ extern const device_t voodoo_device;
 extern const device_t voodoo_banshee_device;
 extern const device_t creative_voodoo_banshee_device;
 extern const device_t voodoo_3_2000_device;
+extern const device_t voodoo_3_2000_agp_device;
 extern const device_t voodoo_3_3000_device;
+extern const device_t voodoo_3_3000_agp_device;
 
 /* Wyse 700 */
 extern const device_t wy700_device;

--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -215,7 +215,7 @@ machine_at_p2bls_init(const machine_t *model)
     device_add(&piix4e_device);
     device_add(&keyboard_ps2_ami_pci_device);
     device_add(&w83977ef_device);
-    device_add(ics9xxx_get(ICS9150_08));
+    //device_add(ics9xxx_get(ICS9150_08)); /* setting proper speeds requires some interaction with the AS97127F ASIC */
     device_add(&sst_flash_39sf020_device);
     spd_register(SPD_TYPE_SDRAM, 0xF, 256);
     device_add(&w83781d_device); /* fans: Chassis, CPU, Power; temperatures: MB, unused, CPU */

--- a/src/machine/m_at_socket7.c
+++ b/src/machine/m_at_socket7.c
@@ -1049,14 +1049,14 @@ machine_at_m560_init(const machine_t *model)
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
     pci_register_slot(0x02, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
+    pci_register_slot(0x0B, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
+    pci_register_slot(0x0C, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
+    pci_register_slot(0x0D, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
     pci_register_slot(0x03, PCI_CARD_NORMAL, 1, 2, 3, 4);
     pci_register_slot(0x04, PCI_CARD_NORMAL, 2, 3, 4, 1);
     pci_register_slot(0x05, PCI_CARD_NORMAL, 3, 4, 1, 2);
     pci_register_slot(0x06, PCI_CARD_NORMAL, 4, 1, 2, 3);
     pci_register_slot(0x07, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x0B, PCI_CARD_IDE, 1, 2, 3, 4);
-    pci_register_slot(0x0C, PCI_CARD_BRIDGE, 1, 2, 3, 4);
-    pci_register_slot(0x0D, PCI_CARD_NORMAL_NOBRIDGE, 1, 2, 3, 4);
     device_add(&ali1531_device);
     device_add(&ali1543_device);
     device_add(&keyboard_ps2_ami_pci_device);
@@ -1082,14 +1082,14 @@ machine_at_ms5164_init(const machine_t *model)
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
     pci_register_slot(0x02, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
+    pci_register_slot(0x0B, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
+    pci_register_slot(0x0C, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
+    pci_register_slot(0x0D, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
     pci_register_slot(0x03, PCI_CARD_NORMAL, 1, 2, 3, 4);
     pci_register_slot(0x04, PCI_CARD_NORMAL, 2, 3, 4, 1);
     pci_register_slot(0x05, PCI_CARD_NORMAL, 3, 4, 1, 2);
     pci_register_slot(0x06, PCI_CARD_NORMAL, 4, 1, 2, 3);
     pci_register_slot(0x07, PCI_CARD_NORMAL, 1, 2, 3, 4);
-    pci_register_slot(0x0B, PCI_CARD_IDE, 1, 2, 3, 4);
-    pci_register_slot(0x0C, PCI_CARD_BRIDGE, 1, 2, 3, 4);
-    pci_register_slot(0x0D, PCI_CARD_NORMAL_NOBRIDGE, 1, 2, 3, 4);
 
     device_add(&ali1531_device);
     device_add(&ali1543_device);

--- a/src/pci.c
+++ b/src/pci.c
@@ -51,8 +51,8 @@ typedef struct {
 } pci_mirq_t;
 
 
-int			pci_burst_time,
-			pci_nonburst_time;
+int			pci_burst_time, agp_burst_time,
+			pci_nonburst_time, agp_nonburst_time;
 
 static pci_card_t	pci_cards[32];
 static uint8_t		pci_pmc = 0, last_pci_card = 0, last_normal_pci_card = 0, last_pci_bus = 1;
@@ -860,8 +860,7 @@ pci_find_slot(uint8_t add_type, uint8_t ignore_slot)
 
 	if (!dev->read && !dev->write && ((ignore_slot == 0xff) || (i != ignore_slot))) {
 		if (((dev->type == PCI_CARD_NORMAL) && (add_type >= PCI_ADD_NORMAL)) ||
-		    (dev->type == add_type) ||
-		    ((dev->type == PCI_CARD_NORMAL_NOBRIDGE) && (add_type >= PCI_ADD_NORMAL) && (add_type != PCI_ADD_BRIDGE))) {
+		    (dev->type == add_type)) {
 			ret = i;
 			break;
 		}
@@ -878,16 +877,16 @@ pci_add_card(uint8_t add_type, uint8_t (*read)(int func, int addr, void *priv), 
     pci_card_t *dev;
     uint8_t i, j;
 
-    if (add_type < PCI_ADD_NORMAL)
+    if (add_type < PCI_ADD_AGP)
 	pci_log("pci_add_card(): Adding PCI CARD at specific slot %02X [SPECIFIC]\n", add_type);
 
     if (! PCI) {
-	pci_log("pci_add_card(): Adding PCI CARD failed (non-PCI machine) [%s]\n", (add_type == PCI_ADD_NORMAL) ? "NORMAL" : ((add_type == PCI_ADD_VIDEO) ? "VIDEO" : ((add_type == PCI_ADD_SCSI) ? "SCSI" : ((add_type == PCI_ADD_SOUND) ? "SOUND" : "SPECIFIC"))));
+	pci_log("pci_add_card(): Adding PCI CARD failed (non-PCI machine) [%s]\n", (add_type == PCI_ADD_NORMAL) ? "NORMAL" : ((add_type == PCI_ADD_AGP) ? "AGP" : ((add_type == PCI_ADD_VIDEO) ? "VIDEO" : ((add_type == PCI_ADD_SCSI) ? "SCSI" : ((add_type == PCI_ADD_SOUND) ? "SOUND" : "SPECIFIC")))));
 	return 0xff;
     }
 
     if (! last_pci_card) {
-	pci_log("pci_add_card(): Adding PCI CARD failed (no PCI slots) [%s]\n", (add_type == PCI_ADD_NORMAL) ? "NORMAL" : ((add_type == PCI_ADD_VIDEO) ? "VIDEO" : ((add_type == PCI_ADD_SCSI) ? "SCSI" : ((add_type == PCI_ADD_SOUND) ? "SOUND" : "SPECIFIC"))));
+	pci_log("pci_add_card(): Adding PCI CARD failed (no PCI slots) [%s]\n", (add_type == PCI_ADD_NORMAL) ? "NORMAL" : ((add_type == PCI_ADD_AGP) ? "AGP" : ((add_type == PCI_ADD_VIDEO) ? "VIDEO" : ((add_type == PCI_ADD_SCSI) ? "SCSI" : ((add_type == PCI_ADD_SOUND) ? "SOUND" : "SPECIFIC")))));
 	return 0xff;
     }
 
@@ -908,7 +907,7 @@ pci_add_card(uint8_t add_type, uint8_t (*read)(int func, int addr, void *priv), 
 	dev->read = read;
 	dev->write = write;
 	dev->priv = priv;
-	pci_log("pci_add_card(): Adding PCI CARD to pci_cards[%i] (bus %02X slot %02X) [%s]\n", i, dev->bus, dev->id, (add_type == PCI_ADD_NORMAL) ? "NORMAL" : ((add_type == PCI_ADD_VIDEO) ? "VIDEO" : ((add_type == PCI_ADD_SCSI) ? "SCSI" : ((add_type == PCI_ADD_SOUND) ? "SOUND" : "SPECIFIC"))));
+	pci_log("pci_add_card(): Adding PCI CARD to pci_cards[%i] (bus %02X slot %02X) [%s]\n", i, dev->bus, dev->id, (add_type == PCI_ADD_NORMAL) ? "NORMAL" : ((add_type == PCI_ADD_AGP) ? "AGP" : ((add_type == PCI_ADD_VIDEO) ? "VIDEO" : ((add_type == PCI_ADD_SCSI) ? "SCSI" : ((add_type == PCI_ADD_SOUND) ? "SOUND" : "SPECIFIC")))));
 	return i;
     }
 

--- a/src/video/vid_table.c
+++ b/src/video/vid_table.c
@@ -186,6 +186,8 @@ video_cards[] = {
     { "virge375_vbe20_vlb",	&s3_virge_375_4_vlb_device		},
     { "tgui9400cxi_vlb",	&tgui9400cxi_device			},
     { "tgui9440_vlb",		&tgui9440_vlb_device			},
+    { "voodoo3_2k_agp",		&voodoo_3_2000_agp_device		},
+    { "voodoo3_3k_agp",		&voodoo_3_3000_agp_device		},
     { "",			NULL                        		}
 };
 

--- a/src/video/video.c
+++ b/src/video/video.c
@@ -653,6 +653,13 @@ video_update_timing(void)
 	video_timing_write_b = (int)(pci_timing * vid_timings->write_b);
 	video_timing_write_w = (int)(pci_timing * vid_timings->write_w);
 	video_timing_write_l = (int)(pci_timing * vid_timings->write_l);
+    } else if (vid_timings->type == VIDEO_AGP) {
+	video_timing_read_b = (int)(agp_timing * vid_timings->read_b);
+	video_timing_read_w = (int)(agp_timing * vid_timings->read_w);
+	video_timing_read_l = (int)(agp_timing * vid_timings->read_l);
+	video_timing_write_b = (int)(agp_timing * vid_timings->write_b);
+	video_timing_write_w = (int)(agp_timing * vid_timings->write_w);
+	video_timing_write_l = (int)(agp_timing * vid_timings->write_l);
     } else {
 	video_timing_read_b = (int)(bus_timing * vid_timings->read_b);
 	video_timing_read_w = (int)(bus_timing * vid_timings->read_w);

--- a/src/win/win_settings.c
+++ b/src/win/win_settings.c
@@ -826,10 +826,17 @@ machine_type_get_internal_name(int id)
 int
 machine_type_available(int id)
 {
-    if ((id > 0) && (id < MACHINE_TYPE_MAX))
-	return 1;
-    else
-	return 0;
+    int c = 0;
+
+    if ((id > 0) && (id < MACHINE_TYPE_MAX)) {
+	while (machine_get_internal_name_ex(c) != NULL) {
+		if (machine_available(c) && (machines[c].type == id))
+			return 1;
+		c++;
+	}
+    }
+
+    return 0;
 }
 
 


### PR DESCRIPTION
* Add basic AGP support to PCI and video frameworks
* Add ISA/PCI/AGP bus clock control API for chipsets and clock generators
* Add bus clock control on Intel 4x0 and VIA chipsets, M6117 SoC, and ICS9xxx clock generator
* Add Voodoo 3 AGP cards
* Fix Voodoo Banshee/3 video timings
* Fix Voodoo Banshee/3 DDC on Windows 98
* Improve ALi M1543 PCI device assignment
* Hide machine types with no available machines