### PR TITLE
Added Tseng specific variants of the GenDAC ramdac (ICS 53x1).

### DIFF
--- a/src/include/86box/vid_svga.h
+++ b/src/include/86box/vid_svga.h
@@ -275,4 +275,6 @@ extern const device_t sc1502x_ramdac_device;
 extern const device_t sdac_ramdac_device;
 extern const device_t stg_ramdac_device;
 extern const device_t tkd8001_ramdac_device;
+extern const device_t tseng_ics5301_ramdac_device;
+extern const device_t tseng_ics5341_ramdac_device;
 #endif


### PR DESCRIPTION
Fixed (at least in a more correct way) software cursor under OS/2 Warp with the s3 trio/vision drivers.
Implemented 128x128 sprite/hwcursor on the et4000w32 cards per manual.

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
