### PR TITLE
Rewrite the emulator to use UTF-8 internally

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -109,7 +109,7 @@ int	confirm_exit_cmdl = 1;			/* (O) do not ask for confirmation on quit if set t
 uint64_t	unique_id = 0;
 uint64_t	source_hwnd = 0;
 #endif
-wchar_t log_path[1024] = { L'\0'};		/* (O) full path of logfile */
+char	log_path[1024] = { '\0'};		/* (O) full path of logfile */
 
 /* Configuration values. */
 int	window_w;   /* (C) window size and */
@@ -166,9 +166,9 @@ extern int	CPUID;
 extern int	output;
 int	atfullspeed;
 
-wchar_t	exe_path[2048];				/* path (dir) of executable */
-wchar_t	usr_path[1024];				/* path (dir) of user data */
-wchar_t	cfg_path[1024];				/* full path of config file */
+char	exe_path[2048];				/* path (dir) of executable */
+char	usr_path[1024];				/* path (dir) of user data */
+char	cfg_path[1024];				/* full path of config file */
 FILE	*stdlog = NULL;				/* file to log output to */
 int	scrnsz_x = SCREEN_RES_X;		/* current screen size, X */
 int scrnsz_y = SCREEN_RES_Y;		/* current screen size, Y */
@@ -209,8 +209,8 @@ pclog_ex(const char *fmt, va_list ap)
 	return;
 
 	if (stdlog == NULL) {
-	if (log_path[0] != L'\0') {
-		stdlog = plat_fopen(log_path, L"w");
+	if (log_path[0] != '\0') {
+		stdlog = plat_fopen(log_path, "w");
 		if (stdlog == NULL)
 			stdlog = stdout;
 	} else {
@@ -269,8 +269,8 @@ fatal(const char *fmt, ...)
 	va_start(ap, fmt);
 
 	if (stdlog == NULL) {
-	if (log_path[0] != L'\0') {
-		stdlog = plat_fopen(log_path, L"w");
+	if (log_path[0] != '\0') {
+		stdlog = plat_fopen(log_path, "w");
 		if (stdlog == NULL)
 			stdlog = stdout;
 	} else {
@@ -334,10 +334,10 @@ pc_log(const char *fmt, ...)
  * configuration file.
  */
 int
-pc_init(int argc, wchar_t *argv[])
+pc_init(int argc, char *argv[])
 {
-	wchar_t path[2048];
-	wchar_t *cfg = NULL, *p;
+	char path[2048];
+	char *cfg = NULL, *p;
 	char temp[128];
 	struct tm *info;
 	time_t now;
@@ -345,9 +345,9 @@ pc_init(int argc, wchar_t *argv[])
 	uint32_t *uid, *shwnd;
 
 	/* Grab the executable's full path. */
-	plat_get_exe_name(exe_path, sizeof_w(exe_path)-1);
+	plat_get_exe_name(exe_path, sizeof(exe_path)-1);
 	p = plat_get_filename(exe_path);
-	*p = L'\0';
+	*p = '\0';
 
 	/*
 	 * Get the current working directory.
@@ -357,13 +357,13 @@ pc_init(int argc, wchar_t *argv[])
 	 * a shortcut (desktop icon), however, the CWD
 	 * could have been set to something else.
 	 */
-	plat_getcwd(usr_path, sizeof_w(usr_path)-1);
+	plat_getcwd(usr_path, sizeof(usr_path) - 1);
 	memset(path, 0x00, sizeof(path));
 
 	for (c=1; c<argc; c++) {
-		if (argv[c][0] != L'-') break;
+		if (argv[c][0] != '-') break;
 
-		if (!wcscasecmp(argv[c], L"--help") || !wcscasecmp(argv[c], L"-?")) {
+		if (!strcasecmp(argv[c], "--help") || !strcasecmp(argv[c], "-?")) {
 usage:
 			printf("\nUsage: 86box [options] [cfg-file]\n\n");
 			printf("Valid options are:\n\n");
@@ -383,47 +383,47 @@ usage:
 			printf("-R or --crashdump    - enables crashdump on exception\n");
 			printf("\nA config file can be specified. If none is, the default file will be used.\n");
 			return(0);
-		} else if (!wcscasecmp(argv[c], L"--dumpcfg") ||
-			   !wcscasecmp(argv[c], L"-C")) {
+		} else if (!strcasecmp(argv[c], "--dumpcfg") ||
+			   !strcasecmp(argv[c], "-C")) {
 			do_dump_config = 1;
 #ifdef _WIN32
-		} else if (!wcscasecmp(argv[c], L"--debug") ||
-			   !wcscasecmp(argv[c], L"-D")) {
+		} else if (!strcasecmp(argv[c], "--debug") ||
+			   !strcasecmp(argv[c], "-D")) {
 			force_debug = 1;
 #endif
-		} else if (!wcscasecmp(argv[c], L"--fullscreen") ||
-			   !wcscasecmp(argv[c], L"-F")) {
+		} else if (!strcasecmp(argv[c], "--fullscreen") ||
+			   !strcasecmp(argv[c], "-F")) {
 			start_in_fullscreen = 1;
-		} else if (!wcscasecmp(argv[c], L"--logfile") ||
-			   !wcscasecmp(argv[c], L"-L")) {
+		} else if (!strcasecmp(argv[c], "--logfile") ||
+			   !strcasecmp(argv[c], "-L")) {
 			if ((c+1) == argc) goto usage;
 
-			wcscpy(log_path, argv[++c]);
-		} else if (!wcscasecmp(argv[c], L"--vmpath") ||
-			   !wcscasecmp(argv[c], L"-P")) {
+			strcpy(log_path, argv[++c]);
+		} else if (!strcasecmp(argv[c], "--vmpath") ||
+			   !strcasecmp(argv[c], "-P")) {
 			if ((c+1) == argc) goto usage;
 
-			wcscpy(path, argv[++c]);
-		} else if (!wcscasecmp(argv[c], L"--settings") ||
-			   !wcscasecmp(argv[c], L"-S")) {
+			strcpy(path, argv[++c]);
+		} else if (!strcasecmp(argv[c], "--settings") ||
+			   !strcasecmp(argv[c], "-S")) {
 			settings_only = 1;
-		} else if (!wcscasecmp(argv[c], L"--noconfirm") ||
-			   !wcscasecmp(argv[c], L"-N")) {
+		} else if (!strcasecmp(argv[c], "--noconfirm") ||
+			   !strcasecmp(argv[c], "-N")) {
 			confirm_exit_cmdl = 0;
-		} else if (!wcscasecmp(argv[c], L"--crashdump") ||
-			   !wcscasecmp(argv[c], L"-R")) {
+		} else if (!strcasecmp(argv[c], "--crashdump") ||
+			   !strcasecmp(argv[c], "-R")) {
 			enable_crashdump = 1;
 #ifdef _WIN32
-		} else if (!wcscasecmp(argv[c], L"--hwnd") ||
-		   !wcscasecmp(argv[c], L"-H")) {
+		} else if (!strcasecmp(argv[c], "--hwnd") ||
+			   !strcasecmp(argv[c], "-H")) {
+
 			if ((c+1) == argc) goto usage;
 
-			wcstombs(temp, argv[++c], 128);
 			uid = (uint32_t *) &unique_id;
 			shwnd = (uint32_t *) &source_hwnd;
-			sscanf(temp, "%08X%08X,%08X%08X", uid + 1, uid, shwnd + 1, shwnd);
+			sscanf(argv[++c], "%08X%08X,%08X%08X", uid + 1, uid, shwnd + 1, shwnd);
 #endif
-		} else if (!wcscasecmp(argv[c], L"--test")) {
+		} else if (!strcasecmp(argv[c], "--test")) {
 			/* some (undocumented) test function here.. */
 
 			/* .. and then exit. */
@@ -455,13 +455,13 @@ usage:
 			 * to convert it (back) to an absolute path.
 			 */
 			plat_path_slash(usr_path);
-			wcscat(usr_path, path);
+			strcat(usr_path, path);
 		} else {
 			/*
 			 * The user-provided path seems like an
 			 * absolute path, so just use that.
 			 */
-			wcscpy(usr_path, path);
+			strcpy(usr_path, path);
 		}
 
 		/* If the specified path does not yet exist,
@@ -489,7 +489,7 @@ usage:
 		 * path component. Separate the two, and
 		 * add the path component to the cfg path.
 		 */
-		*(p-1) = L'\0';
+		*(p-1) = '\0';
 
 		/*
 		 * If this is an absolute path, keep it, as
@@ -498,9 +498,9 @@ usage:
 		 * relative to whatever the usr_path is.
 		 */
 		if (plat_path_abs(cfg))
-			wcscpy(usr_path, cfg);
+			strcpy(usr_path, cfg);
 		else
-			wcscat(usr_path, cfg);
+			strcat(usr_path, cfg);
 	}
 
 	/* Make sure we have a trailing backslash. */

--- a/src/cdrom/cdrom.c
+++ b/src/cdrom/cdrom.c
@@ -1237,7 +1237,7 @@ cdrom_eject(uint8_t id)
     }
 
     if (dev->host_drive == 200)
-	wcscpy(dev->prev_image_path, dev->image_path);
+	strcpy(dev->prev_image_path, dev->image_path);
 
     dev->prev_host_drive = dev->host_drive;
     dev->host_drive = 0;
@@ -1273,12 +1273,12 @@ cdrom_reload(uint8_t id)
 
     if (dev->prev_host_drive == 200) {
 	/* Reload a previous image. */
-	wcscpy(dev->image_path, dev->prev_image_path);
+	strcpy(dev->image_path, dev->prev_image_path);
 	cdrom_image_open(dev, dev->image_path);
 
 	cdrom_insert(id);
 
-	if (wcslen(dev->image_path) == 0)
+	if (strlen(dev->image_path) == 0)
 		dev->host_drive = 0;
 	  else
 		dev->host_drive = 200;

--- a/src/cdrom/cdrom_image.c
+++ b/src/cdrom/cdrom_image.c
@@ -215,7 +215,7 @@ image_exit(cdrom_t *dev)
 {
     cd_img_t *img = (cd_img_t *)dev->image;
 
-cdrom_image_log("CDROM: image_exit(%ls)\n", dev->image_path);
+cdrom_image_log("CDROM: image_exit(%s)\n", dev->image_path);
     dev->cd_status = CD_STATUS_EMPTY;
 
     if (img) {
@@ -249,11 +249,11 @@ image_open_abort(cdrom_t *dev)
 
 
 int
-cdrom_image_open(cdrom_t *dev, const wchar_t *fn)
+cdrom_image_open(cdrom_t *dev, const char *fn)
 {
     cd_img_t *img;
 
-    wcscpy(dev->image_path, fn);
+    strcpy(dev->image_path, fn);
 
     /* Create new instance of the CDROM_Image class. */
     img = (cd_img_t *) malloc(sizeof(cd_img_t));
@@ -271,7 +271,7 @@ cdrom_image_open(cdrom_t *dev, const wchar_t *fn)
 	return image_open_abort(dev);
 
     /* All good, reset state. */
-    if (! wcscasecmp(plat_get_extension((wchar_t *) fn), L"ISO"))
+    if (! strcasecmp(plat_get_extension((char *) fn), "ISO"))
 	dev->cd_status = CD_STATUS_DATA_ONLY;
     else
 	dev->cd_status = CD_STATUS_STOPPED;
@@ -290,7 +290,7 @@ cdrom_image_open(cdrom_t *dev, const wchar_t *fn)
 void
 cdrom_image_close(cdrom_t *dev)
 {
-    cdrom_image_log("CDROM: image_close(%ls)\n", dev->image_path);
+    cdrom_image_log("CDROM: image_close(%s)\n", dev->image_path);
 
     if (dev && dev->ops && dev->ops->exit)
 	dev->ops->exit(dev);

--- a/src/device/hwm_lm78.c
+++ b/src/device/hwm_lm78.c
@@ -102,14 +102,11 @@ lm78_log(const char *fmt, ...)
 void
 lm78_nvram(lm78_t *dev, uint8_t save)
 {
-    size_t l = strlen(machine_get_internal_name_ex(machine)) + 1;
-    wchar_t *machine_name = (wchar_t *) malloc(l * sizeof(wchar_t));
-    mbstowcs(machine_name, machine_get_internal_name_ex(machine), l);
-    l = wcslen(machine_name) + 14;
-    wchar_t *nvr_path = (wchar_t *) malloc(l * sizeof(wchar_t));
-    swprintf(nvr_path, l, L"%ls_as99127f.nvr", machine_name);
+    size_t l = strlen(machine_get_internal_name_ex(machine)) + 14;
+    char *nvr_path = (char *) malloc(l);
+    sprintf(nvr_path, "%s_as99127f.nvr", machine_get_internal_name_ex(machine));
 
-    FILE *f = nvr_fopen(nvr_path, save ? L"wb": L"rb");
+    FILE *f = nvr_fopen(nvr_path, save ? "wb" : "rb");
     if (f) {
 	if (save)
 		fwrite(&dev->as99127f.nvram, sizeof(dev->as99127f.nvram), 1, f);
@@ -118,7 +115,6 @@ lm78_nvram(lm78_t *dev, uint8_t save)
 	fclose(f);
     }
     
-    free(machine_name);
     free(nvr_path);
 }
 

--- a/src/device/isartc.c
+++ b/src/device/isartc.c
@@ -559,7 +559,7 @@ isartc_init(const device_t *info)
 		  dev->f_rd,NULL,NULL, dev->f_wr,NULL,NULL, dev);
 
     /* Hook into the NVR backend. */
-    dev->nvr.fn = (wchar_t *)isartc_get_internal_name(isartc_type);
+    dev->nvr.fn = isartc_get_internal_name(isartc_type);
     dev->nvr.irq = dev->irq;
     nvr_init(&dev->nvr);
 
@@ -578,7 +578,7 @@ isartc_close(void *priv)
 		     dev->f_rd,NULL,NULL, dev->f_wr,NULL,NULL, dev);
 
     if (dev->nvr.fn != NULL)
-	free((wchar_t *)dev->nvr.fn);
+	free(dev->nvr.fn);
 
     free(dev);
 }

--- a/src/disk/hdc_esdi_at.c
+++ b/src/disk/hdc_esdi_at.c
@@ -44,7 +44,7 @@
 
 
 #define HDC_TIME		(TIMER_USEC*10LL)
-#define BIOS_FILE		L"roms/hdd/esdi_at/62-000279-061.bin"
+#define BIOS_FILE		"roms/hdd/esdi_at/62-000279-061.bin"
 
 #define STAT_ERR		0x01
 #define STAT_INDEX		0x02
@@ -744,7 +744,7 @@ esdi_callback(void *priv)
 
 
 static void
-loadhd(esdi_t *esdi, int hdd_num, int d, const wchar_t *fn)
+loadhd(esdi_t *esdi, int hdd_num, int d, const char *fn)
 {
     drive_t *drive = &esdi->drives[hdd_num];
 

--- a/src/disk/hdc_esdi_mca.c
+++ b/src/disk/hdc_esdi_mca.c
@@ -86,8 +86,8 @@
 #define ESDI_IOADDR_SEC	0x3518
 #define ESDI_IRQCHAN	14
 
-#define BIOS_FILE_L	L"roms/hdd/esdi/90x8969.bin"
-#define BIOS_FILE_H	L"roms/hdd/esdi/90x8970.bin"
+#define BIOS_FILE_L	"roms/hdd/esdi/90x8969.bin"
+#define BIOS_FILE_H	"roms/hdd/esdi/90x8970.bin"
 
 
 #define ESDI_TIME	(200*TIMER_USEC)

--- a/src/disk/hdc_ide.c
+++ b/src/disk/hdc_ide.c
@@ -704,7 +704,7 @@ ide_next_sector(ide_t *ide)
 
 
 static void
-loadhd(ide_t *ide, int d, const wchar_t *fn)
+loadhd(ide_t *ide, int d, const char *fn)
 {
     if (! hdd_image_load(d)) {
 	ide->type = IDE_NONE;

--- a/src/disk/hdc_st506_at.c
+++ b/src/disk/hdc_st506_at.c
@@ -692,7 +692,7 @@ do_callback(void *priv)
 
 
 static void
-loadhd(mfm_t *mfm, int c, int d, const wchar_t *fn)
+loadhd(mfm_t *mfm, int c, int d, const char *fn)
 {
     drive_t *drive = &mfm->drives[c];
 
@@ -725,7 +725,7 @@ mfm_init(const device_t *info)
 	if ((hdd[d].bus == HDD_BUS_MFM) && (hdd[d].mfm_channel < MFM_NUM)) {
 		loadhd(mfm, hdd[d].mfm_channel, d, hdd[d].fn);
 
-		st506_at_log("WD1003(%d): (%ls) geometry %d/%d/%d\n", c, hdd[d].fn,
+		st506_at_log("WD1003(%d): (%s) geometry %d/%d/%d\n", c, hdd[d].fn,
 			     (int)hdd[d].tracks, (int)hdd[d].hpc, (int)hdd[d].spt);
 
 		if (++c >= MFM_NUM) break;

--- a/src/disk/hdc_st506_xt.c
+++ b/src/disk/hdc_st506_xt.c
@@ -91,15 +91,15 @@
 #include <86box/hdd.h>
 
 
-#define XEBEC_BIOS_FILE		L"roms/hdd/st506/ibm_xebec_62x0822_1985.bin"
-#define DTC_BIOS_FILE		L"roms/hdd/st506/dtc_cxd21a.bin"
-#define ST11_BIOS_FILE_OLD	L"roms/hdd/st506/st11_bios_vers_1.7.bin"
-#define ST11_BIOS_FILE_NEW	L"roms/hdd/st506/st11_bios_vers_2.0.bin"
-#define WD1002A_WX1_BIOS_FILE	L"roms/hdd/st506/wd1002a_wx1-62-000094-032.bin"
+#define XEBEC_BIOS_FILE		"roms/hdd/st506/ibm_xebec_62x0822_1985.bin"
+#define DTC_BIOS_FILE		"roms/hdd/st506/dtc_cxd21a.bin"
+#define ST11_BIOS_FILE_OLD	"roms/hdd/st506/st11_bios_vers_1.7.bin"
+#define ST11_BIOS_FILE_NEW	"roms/hdd/st506/st11_bios_vers_2.0.bin"
+#define WD1002A_WX1_BIOS_FILE	"roms/hdd/st506/wd1002a_wx1-62-000094-032.bin"
 /* SuperBIOS was for both the WX1 and 27X, users jumpers readout to determine
    if to use 26 sectors per track, 26 -> 17 sectors per track translation, or
    17 sectors per track. */
-#define WD1002A_27X_BIOS_FILE	L"roms/hdd/st506/wd1002a_27x-62-000094-032.bin"
+#define WD1002A_27X_BIOS_FILE	"roms/hdd/st506/wd1002a_27x-62-000094-032.bin"
 
 
 #define ST506_TIME		(250 * TIMER_USEC)
@@ -1305,7 +1305,7 @@ mem_read(uint32_t addr, void *priv)
  * standard 'rom_init' function here.
  */
 static void
-loadrom(hdc_t *dev, const wchar_t *fn)
+loadrom(hdc_t *dev, const char *fn)
 {
     uint32_t size;
     FILE *fp;
@@ -1317,8 +1317,8 @@ loadrom(hdc_t *dev, const wchar_t *fn)
 	return;
     }
 
-    if ((fp = rom_fopen((wchar_t *) fn, L"rb")) == NULL) {
-	st506_xt_log("ST506: BIOS ROM '%ls' not found!\n", fn);
+    if ((fp = rom_fopen((char *) fn, "rb")) == NULL) {
+	st506_xt_log("ST506: BIOS ROM '%s' not found!\n", fn);
 	return;
     }
 
@@ -1349,7 +1349,7 @@ loadrom(hdc_t *dev, const wchar_t *fn)
 
 
 static void
-loadhd(hdc_t *dev, int c, int d, const wchar_t *fn)
+loadhd(hdc_t *dev, int c, int d, const char *fn)
 {
     drive_t *drive = &dev->drives[c];
 
@@ -1423,7 +1423,7 @@ set_switches(hdc_t *dev)
 static void *
 st506_init(const device_t *info)
 {
-    wchar_t *fn = NULL;
+    char *fn = NULL;
     hdc_t *dev;
     int i, c;
 
@@ -1531,7 +1531,7 @@ st506_init(const device_t *info)
 #endif
     for (c = 0, i = 0; i < HDD_NUM; i++) {
 	if ((hdd[i].bus == HDD_BUS_MFM) && (hdd[i].mfm_channel < MFM_NUM)) {
-		st506_xt_log("ST506: disk '%ls' on channel %i\n",
+		st506_xt_log("ST506: disk '%s' on channel %i\n",
 			     hdd[i].fn, hdd[i].mfm_channel);
 		loadhd(dev, hdd[i].mfm_channel, i, hdd[i].fn);
 

--- a/src/disk/hdc_xta.c
+++ b/src/disk/hdc_xta.c
@@ -110,7 +110,7 @@
 
 #define HDC_TIME	(50*TIMER_USEC)
 
-#define WD_BIOS_FILE	L"roms/hdd/xta/idexywd2.bin"
+#define WD_BIOS_FILE	"roms/hdd/xta/idexywd2.bin"
 
 
 enum {
@@ -995,7 +995,7 @@ static void *
 xta_init(const device_t *info)
 {
     drive_t *drive;
-    wchar_t *fn = NULL;
+    char *fn = NULL;
     hdc_t *dev;
     int c, i;
     int max = XTA_NUM;

--- a/src/disk/hdc_xtide.c
+++ b/src/disk/hdc_xtide.c
@@ -45,10 +45,10 @@
 #include <86box/hdc_ide.h>
 
 
-#define ROM_PATH_XT	L"roms/hdd/xtide/ide_xt.bin"
-#define ROM_PATH_AT	L"roms/hdd/xtide/ide_at.bin"
-#define ROM_PATH_PS2	L"roms/hdd/xtide/SIDE1V12.BIN"
-#define ROM_PATH_PS2AT	L"roms/hdd/xtide/ide_at_1_1_5.bin"
+#define ROM_PATH_XT	"roms/hdd/xtide/ide_xt.bin"
+#define ROM_PATH_AT	"roms/hdd/xtide/ide_at.bin"
+#define ROM_PATH_PS2	"roms/hdd/xtide/SIDE1V12.BIN"
+#define ROM_PATH_PS2AT	"roms/hdd/xtide/ide_at_1_1_5.bin"
 
 
 typedef struct {

--- a/src/disk/hdd.c
+++ b/src/disk/hdd.c
@@ -142,7 +142,7 @@ hdd_is_valid(int c)
     if (hdd[c].bus == HDD_BUS_DISABLED)
 	return(0);
 
-    if (wcslen(hdd[c].fn) == 0)
+    if (strlen(hdd[c].fn) == 0)
 	return(0);
 
     if ((hdd[c].tracks==0) || (hdd[c].hpc==0) || (hdd[c].spt==0))

--- a/src/disk/hdd_image.c
+++ b/src/disk/hdd_image.c
@@ -76,16 +76,9 @@ hdd_image_log(const char *fmt, ...)
 #endif
 
 int
-image_is_hdi(const wchar_t *s)
+image_is_hdi(const char *s)
 {
-	int len;
-	wchar_t ext[5] = { 0, 0, 0, 0, 0 };
-	char *ws = (char *) s;
-	len = wcslen(s);
-	if ((len < 4) || (s[0] == L'.'))
-		return 0;
-	memcpy(ext, ws + ((len - 4) << 1), 8);
-	if (! wcscasecmp(ext, L".HDI"))
+	if (! strcasecmp(plat_get_extension((char *) s), "HDI"))
 		return 1;
 	else
 		return 0;
@@ -93,21 +86,16 @@ image_is_hdi(const wchar_t *s)
 
 
 int
-image_is_hdx(const wchar_t *s, int check_signature)
+image_is_hdx(const char *s, int check_signature)
 {
 	int len;
 	FILE *f;
 	uint64_t filelen;
 	uint64_t signature;
-	char *ws = (char *) s;
-	wchar_t ext[5] = { 0, 0, 0, 0, 0 };
-	len = wcslen(s);
-	if ((len < 4) || (s[0] == L'.'))
-		return 0;
-	memcpy(ext, ws + ((len - 4) << 1), 8);
-	if (wcscasecmp(ext, L".HDX") == 0) {
+
+	if (! strcasecmp(plat_get_extension((char *) s), "HDX")) {
 		if (check_signature) {
-			f = plat_fopen((wchar_t *)s, L"rb");
+			f = plat_fopen(s, "rb");
 			if (!f)
 				return 0;
 			if (fseeko64(f, 0, SEEK_END))
@@ -135,19 +123,14 @@ image_is_hdx(const wchar_t *s, int check_signature)
 
 
 int
-image_is_vhd(const wchar_t *s, int check_signature)
+image_is_vhd(const char *s, int check_signature)
 {
 	int len;
 	FILE* f;
-	char *ws = (char *) s;
-	wchar_t ext[5] = { 0, 0, 0, 0, 0 };
-	len = wcslen(s);
-	if ((len < 4) || (s[0] == L'.'))
-		return 0;
-	memcpy(ext, ws + ((len - 4) << 1), 8);
-	if (wcscasecmp(ext, L".VHD") == 0) {
+
+	if (! strcasecmp(plat_get_extension((char *) s), "VHD")) {
 		if (check_signature) {
-			f = plat_fopen((wchar_t*)s, L"rb");
+			f = plat_fopen(s, "rb");
 			if (!f)
 				return 0;
 
@@ -265,8 +248,7 @@ hdd_image_load(int id)
 	uint64_t spt = 0, hpc = 0, tracks = 0;
 	int c, ret;
 	uint64_t s = 0;
-	wchar_t *fn = hdd[id].fn;
-	char fn_multibyte_buf[1200];
+	char *fn = hdd[id].fn;
 	int is_hdx[2] = { 0, 0 };
 	int is_vhd[2] = { 0, 0 };   
 	int vhd_error = 0; 
@@ -301,7 +283,7 @@ hdd_image_load(int id)
 		memset(hdd[id].fn, 0, sizeof(hdd[id].fn));
 		return 0;
 	}
-	hdd_images[id].file = plat_fopen(fn, L"rb+");
+	hdd_images[id].file = plat_fopen(fn, "rb+");
 	if (hdd_images[id].file == NULL) {
 		/* Failed to open existing hard disk image */
 		if (errno == ENOENT) {
@@ -313,7 +295,7 @@ hdd_image_load(int id)
 				return 0;
 			}
 
-			hdd_images[id].file = plat_fopen(fn, L"wb+");
+			hdd_images[id].file = plat_fopen(fn, "wb+");
 			if (hdd_images[id].file == NULL) {
 				hdd_image_log("Unable to open image\n");
 				memset(hdd[id].fn, 0, sizeof(hdd[id].fn));
@@ -360,8 +342,7 @@ hdd_image_load(int id)
 					            ((uint64_t) hdd[id].tracks) << 9LL;
 					hdd_images[id].last_sector = (full_size >> 9LL) - 1;
 
-					wcstombs(fn_multibyte_buf, fn, sizeof fn_multibyte_buf);
-					hdd_images[id].vhd = mvhd_create_fixed(fn_multibyte_buf, geometry, &vhd_error, NULL);
+					hdd_images[id].vhd = mvhd_create_fixed(fn, geometry, &vhd_error, NULL);
 					if (hdd_images[id].vhd == NULL)
 						fatal("hdd_image_load(): VHD: Could not create VHD : %s\n", mvhd_strerr(vhd_error));
 
@@ -449,16 +430,15 @@ hdd_image_load(int id)
 		} else if (is_vhd[1]) {
 			fclose(hdd_images[id].file);
 			hdd_images[id].file = NULL;
-			wcstombs(fn_multibyte_buf, fn, sizeof fn_multibyte_buf);
-			hdd_images[id].vhd = mvhd_open(fn_multibyte_buf, (bool)0, &vhd_error);
+			hdd_images[id].vhd = mvhd_open(fn, (bool)0, &vhd_error);
 			if (hdd_images[id].vhd == NULL) {
 				if (vhd_error == MVHD_ERR_FILE)
-					fatal("hdd_image_load(): VHD: Error opening VHD file '%s': %s\n", fn_multibyte_buf, strerror(mvhd_errno));
+					fatal("hdd_image_load(): VHD: Error opening VHD file '%s': %s\n", fn, strerror(mvhd_errno));
 				else
-					fatal("hdd_image_load(): VHD: Error opening VHD file '%s': %s\n", fn_multibyte_buf, mvhd_strerr(vhd_error));
+					fatal("hdd_image_load(): VHD: Error opening VHD file '%s': %s\n", fn, mvhd_strerr(vhd_error));
 			}
 			else if (vhd_error == MVHD_ERR_TIMESTAMP) {
-				fatal("hdd_image_load(): VHD: Parent/child timestamp mismatch for VHD file '%s'\n", fn_multibyte_buf);
+				fatal("hdd_image_load(): VHD: Parent/child timestamp mismatch for VHD file '%s'\n", fn);
 			}
 
 			hdd[id].tracks = hdd_images[id].vhd->footer.geom.cyl;
@@ -670,7 +650,7 @@ hdd_image_get_type(uint8_t id)
 void
 hdd_image_unload(uint8_t id, int fn_preserve)
 {
-	if (wcslen(hdd[id].fn) == 0)
+	if (strlen(hdd[id].fn) == 0)
 		return;
 
 	if (hdd_images[id].loaded) {
@@ -688,7 +668,7 @@ hdd_image_unload(uint8_t id, int fn_preserve)
 
 	memset(hdd[id].prev_fn, 0, sizeof(hdd[id].prev_fn));
 	if (fn_preserve)
-		wcscpy(hdd[id].prev_fn, hdd[id].fn);
+		strcpy(hdd[id].prev_fn, hdd[id].fn);
 	memset(hdd[id].fn, 0, sizeof(hdd[id].fn));
 }
 

--- a/src/disk/zip.c
+++ b/src/disk/zip.c
@@ -484,14 +484,14 @@ zip_load_abort(zip_t *dev)
 
 
 int
-zip_load(zip_t *dev, wchar_t *fn)
+zip_load(zip_t *dev, char *fn)
 {
     int size = 0;
 
-    dev->drv->f = plat_fopen(fn, dev->drv->read_only ? L"rb" : L"rb+");
+    dev->drv->f = plat_fopen(fn, dev->drv->read_only ? "rb" : "rb+");
     if (!dev->drv->f) {
 	if (!dev->drv->read_only) {
-		dev->drv->f = plat_fopen(fn, L"rb");
+		dev->drv->f = plat_fopen(fn, "rb");
 		if (dev->drv->f)
 			dev->drv->read_only = 1;
 		else
@@ -529,7 +529,7 @@ zip_load(zip_t *dev, wchar_t *fn)
     if (fseek(dev->drv->f, dev->drv->base, SEEK_SET) == -1)
 	fatal("zip_load(): Error seeking to the beginning of the file\n");
 
-    wcsncpy(dev->drv->image_path, fn, sizeof_w(dev->drv->image_path));
+    strncpy(dev->drv->image_path, fn, sizeof(dev->drv->image_path) - 1);
 
     return 1;
 }
@@ -540,7 +540,7 @@ zip_disk_reload(zip_t *dev)
 {
     int ret = 0;
 
-    if (wcslen(dev->drv->prev_image_path) == 0)
+    if (strlen(dev->drv->prev_image_path) == 0)
 	return;
     else
 	ret = zip_load(dev, dev->drv->prev_image_path);
@@ -673,7 +673,7 @@ static void
 zip_mode_sense_load(zip_t *dev)
 {
     FILE *f;
-    wchar_t file_name[512];
+    char file_name[512];
 
     memset(&dev->ms_pages_saved, 0, sizeof(mode_sense_pages_t));
     if (dev->drv->is_250) {
@@ -688,12 +688,12 @@ zip_mode_sense_load(zip_t *dev)
 	    memcpy(&dev->ms_pages_saved, &zip_mode_sense_pages_default, sizeof(mode_sense_pages_t));
     }
 
-    memset(file_name, 0, 512 * sizeof(wchar_t));
+    memset(file_name, 0, 512);
     if (dev->drv->bus_type == ZIP_BUS_SCSI)
-	swprintf(file_name, 512, L"scsi_zip_%02i_mode_sense_bin", dev->id);
+	sprintf(file_name, "scsi_zip_%02i_mode_sense_bin", dev->id);
     else
-	swprintf(file_name, 512, L"zip_%02i_mode_sense_bin", dev->id);
-    f = plat_fopen(nvr_path(file_name), L"rb");
+	sprintf(file_name, "zip_%02i_mode_sense_bin", dev->id);
+    f = plat_fopen(nvr_path(file_name), "rb");
     if (f) {
 	/* Nothing to read, not used by ZIP. */
 	fclose(f);
@@ -705,14 +705,14 @@ static void
 zip_mode_sense_save(zip_t *dev)
 {
     FILE *f;
-    wchar_t file_name[512];
+    char file_name[512];
 
-    memset(file_name, 0, 512 * sizeof(wchar_t));
+    memset(file_name, 0, 512);
     if (dev->drv->bus_type == ZIP_BUS_SCSI)
-	swprintf(file_name, 512, L"scsi_zip_%02i_mode_sense_bin", dev->id);
+	sprintf(file_name, "scsi_zip_%02i_mode_sense_bin", dev->id);
     else
-	swprintf(file_name, 512, L"zip_%02i_mode_sense_bin", dev->id);
-    f = plat_fopen(nvr_path(file_name), L"wb");
+	sprintf(file_name, "zip_%02i_mode_sense_bin", dev->id);
+    f = plat_fopen(nvr_path(file_name), "wb");
     if (f) {
 	/* Nothing to write, not used by ZIP. */
 	fclose(f);
@@ -2404,7 +2404,7 @@ zip_hard_reset(void)
 
 		zip_init(dev);
 
-		if (wcslen(zip_drives[c].image_path))
+		if (strlen(zip_drives[c].image_path))
 			zip_load(dev, zip_drives[c].image_path);
 
 		zip_mode_sense_load(dev);

--- a/src/floppy/fdc_magitronic.c
+++ b/src/floppy/fdc_magitronic.c
@@ -31,7 +31,7 @@
 #include <86box/fdc.h>
 #include <86box/fdc_ext.h>
 
-#define ROM_B215 L"roms/floppy/magitronic/Magitronic B215 - BIOS ROM.bin"
+#define ROM_B215 "roms/floppy/magitronic/Magitronic B215 - BIOS ROM.bin"
 #define ROM_ADDR (uint32_t)(device_get_config_hex20("bios_addr") & 0x000fffff)
 
 #define DRIVE_SELECT (int)(real_drive(dev->fdc_controller, i))

--- a/src/floppy/fdc_pii15xb.c
+++ b/src/floppy/fdc_pii15xb.c
@@ -79,8 +79,8 @@ MiniMicro 4 also won't work with the XT FDC which the Zilog claims to be.
 #define DTK_VARIANT ((info->local == 158) ? ROM_PII_158B : ROM_PII_151B)
 #define DTK_CHIP ((info->local == 158) ? &fdc_xt_device : &fdc_dp8473_device)
 #define BIOS_ADDR (uint32_t)(device_get_config_hex20("bios_addr") & 0x000fffff)
-#define ROM_PII_151B L"roms/floppy/dtk/pii-151b.rom"
-#define ROM_PII_158B L"roms/floppy/dtk/pii-158b.rom"
+#define ROM_PII_151B "roms/floppy/dtk/pii-151b.rom"
+#define ROM_PII_158B "roms/floppy/dtk/pii-158b.rom"
 
 typedef struct
 {

--- a/src/floppy/fdd.c
+++ b/src/floppy/fdd.c
@@ -77,7 +77,7 @@ typedef struct {
 
 fdd_t		fdd[FDD_NUM];
 
-wchar_t		floppyfns[FDD_NUM][512];
+char		floppyfns[FDD_NUM][512];
 
 pc_timer_t	fdd_poll_time[FDD_NUM];
 
@@ -99,44 +99,44 @@ d86f_handler_t   d86f_handler[FDD_NUM];
 
 static const struct
 {
-    wchar_t *ext;
-    void (*load)(int drive, wchar_t *fn);
+    char *ext;
+    void (*load)(int drive, char *fn);
     void (*close)(int drive);
     int size;
 } loaders[]=
 {
-    {L"001",	 img_load,	 img_close, -1},
-    {L"002",	 img_load,	 img_close, -1},
-    {L"003",	 img_load,	 img_close, -1},
-    {L"004",	 img_load,	 img_close, -1},
-    {L"005",	 img_load,	 img_close, -1},
-    {L"006",	 img_load,	 img_close, -1},
-    {L"007",	 img_load,	 img_close, -1},
-    {L"008",	 img_load,	 img_close, -1},
-    {L"009",	 img_load,	 img_close, -1},
-    {L"010",	 img_load,	 img_close, -1},
-    {L"12",	 img_load,	 img_close, -1},
-    {L"144",	 img_load,	 img_close, -1},
-    {L"360",	 img_load,	 img_close, -1},
-    {L"720",	 img_load,	 img_close, -1},
-    {L"86F",	d86f_load,	d86f_close, -1},
-    {L"BIN",	 img_load,	 img_close, -1},
-    {L"CQ",	 img_load,	 img_close, -1},
-    {L"CQM",	 img_load,	 img_close, -1},
-    {L"DDI",	 img_load,	 img_close, -1},
-    {L"DSK",	 img_load,	 img_close, -1},
-    {L"FDI",	 fdi_load,	 fdi_close, -1},
-    {L"FDF",	 img_load,	 img_close, -1},
-    {L"FLP",	 img_load,	 img_close, -1},
-    {L"HDM",	 img_load,	 img_close, -1},
-    {L"IMA",	 img_load,	 img_close, -1},
-    {L"IMD",	 imd_load,	 imd_close, -1},
-    {L"IMG",	 img_load,	 img_close, -1},
-    {L"JSON",	json_load,	json_close, -1},
-    {L"MFM",	 mfm_load,	 mfm_close, -1},
-    {L"TD0",	 td0_load,	 td0_close, -1},
-    {L"VFD",	 img_load,	 img_close, -1},
-    {L"XDF",	 img_load,	 img_close, -1},
+    {"001",	 img_load,	 img_close, -1},
+    {"002",	 img_load,	 img_close, -1},
+    {"003",	 img_load,	 img_close, -1},
+    {"004",	 img_load,	 img_close, -1},
+    {"005",	 img_load,	 img_close, -1},
+    {"006",	 img_load,	 img_close, -1},
+    {"007",	 img_load,	 img_close, -1},
+    {"008",	 img_load,	 img_close, -1},
+    {"009",	 img_load,	 img_close, -1},
+    {"010",	 img_load,	 img_close, -1},
+    {"12",	 img_load,	 img_close, -1},
+    {"144",	 img_load,	 img_close, -1},
+    {"360",	 img_load,	 img_close, -1},
+    {"720",	 img_load,	 img_close, -1},
+    {"86F",	d86f_load,	d86f_close, -1},
+    {"BIN",	 img_load,	 img_close, -1},
+    {"CQ",	 img_load,	 img_close, -1},
+    {"CQM",	 img_load,	 img_close, -1},
+    {"DDI",	 img_load,	 img_close, -1},
+    {"DSK",	 img_load,	 img_close, -1},
+    {"FDI",	 fdi_load,	 fdi_close, -1},
+    {"FDF",	 img_load,	 img_close, -1},
+    {"FLP",	 img_load,	 img_close, -1},
+    {"HDM",	 img_load,	 img_close, -1},
+    {"IMA",	 img_load,	 img_close, -1},
+    {"IMD",	 imd_load,	 imd_close, -1},
+    {"IMG",	 img_load,	 img_close, -1},
+    {"JSON",	json_load,	json_close, -1},
+    {"MFM",	 mfm_load,	 mfm_close, -1},
+    {"TD0",	 td0_load,	 td0_close, -1},
+    {"VFD",	 img_load,	 img_close, -1},
+    {"XDF",	 img_load,	 img_close, -1},
     {0,		 0,		 0,	     0}
 };
 
@@ -475,20 +475,20 @@ fdd_get_densel(int drive)
 
 
 void
-fdd_load(int drive, wchar_t *fn)
+fdd_load(int drive, char *fn)
 {
     int c = 0, size;
-    wchar_t *p;
+    char *p;
     FILE *f;
 
-    fdd_log("FDD: loading drive %d with '%ls'\n", drive, fn);
+    fdd_log("FDD: loading drive %d with '%s'\n", drive, fn);
 
     if (!fn)
 	return;
     p = plat_get_extension(fn);
     if (!p)
 	return;
-    f = plat_fopen(fn, L"rb");
+    f = plat_fopen(fn, "rb");
     if (!f)
 	return;
     if (fseek(f, -1, SEEK_END) == -1)
@@ -496,9 +496,9 @@ fdd_load(int drive, wchar_t *fn)
     size = ftell(f) + 1;
     fclose(f);        
     while (loaders[c].ext) {
-	if (!wcscasecmp(p, (wchar_t *) loaders[c].ext) && (size == loaders[c].size || loaders[c].size == -1)) {
+	if (!strcasecmp(p, (char *) loaders[c].ext) && (size == loaders[c].size || loaders[c].size == -1)) {
 		driveloaders[drive] = c;
-		memcpy(floppyfns[drive], fn, (wcslen(fn) << 1) + 2);
+		strcpy(floppyfns[drive], fn);
 		d86f_setup(drive);
 		loaders[c].load(drive, floppyfns[drive]);
 		drive_empty[drive] = 0;
@@ -508,7 +508,7 @@ fdd_load(int drive, wchar_t *fn)
 	}
 	c++;
     }
-    fdd_log("FDD: could not load '%ls' %s\n",fn,p);
+    fdd_log("FDD: could not load '%s' %s\n",fn,p);
     drive_empty[drive] = 1;
     fdd_set_head(drive, 0);
     memset(floppyfns[drive], 0, sizeof(floppyfns[drive]));

--- a/src/floppy/fdd_86f.c
+++ b/src/floppy/fdd_86f.c
@@ -204,7 +204,7 @@ typedef struct {
     find_t	data_find;
     crc_t	calc_crc;
     crc_t	track_crc;
-    wchar_t	original_file_name[2048];
+    char	original_file_name[2048];
     uint8_t	*filebuf, *outbuf;
     sector_t	*last_side_sector[2];
 } d86f_t;
@@ -3425,7 +3425,7 @@ d86f_common_handlers(int drive)
 
 
 int
-d86f_export(int drive, wchar_t *fn)
+d86f_export(int drive, char *fn)
 {
     uint32_t tt[512];
     d86f_t *dev = d86f[drive];
@@ -3440,7 +3440,7 @@ d86f_export(int drive, wchar_t *fn)
 
     memset(tt, 0, 512 * sizeof(uint32_t));
 
-    f = plat_fopen(fn, L"wb");
+    f = plat_fopen(fn, "wb");
     if (!f)
 	return 0;
 
@@ -3470,7 +3470,7 @@ d86f_export(int drive, wchar_t *fn)
 
     fclose(f);
 
-    f = plat_fopen(fn, L"rb+");
+    f = plat_fopen(fn, "rb+");
 
     fseek(f, 8, SEEK_SET);
     fwrite(tt, 1, ((d86f_get_sides(drive) == 2) ? 2048 : 1024), f);
@@ -3488,14 +3488,14 @@ d86f_export(int drive, wchar_t *fn)
 
 
 void
-d86f_load(int drive, wchar_t *fn)
+d86f_load(int drive, char *fn)
 {
     d86f_t *dev = d86f[drive];
     uint32_t magic = 0;
     uint32_t len = 0;
     int i = 0, j = 0;
 #ifdef D86F_COMPRESS
-    wchar_t temp_file_name[2048];
+    char temp_file_name[2048];
     uint16_t temp = 0;
     FILE *tf;
 #endif
@@ -3504,9 +3504,9 @@ d86f_load(int drive, wchar_t *fn)
 
     writeprot[drive] = 0;
 
-    dev->f = plat_fopen(fn, L"rb+");
+    dev->f = plat_fopen(fn, "rb+");
     if (! dev->f) {
-	dev->f = plat_fopen(fn, L"rb");
+	dev->f = plat_fopen(fn, "rb");
 	if (! dev->f) {
 		memset(floppyfns[drive], 0, sizeof(floppyfns[drive]));
 		free(dev);
@@ -3617,13 +3617,13 @@ d86f_load(int drive, wchar_t *fn)
 
 #ifdef D86F_COMPRESS
     if (dev->is_compressed) {
-	memcpy(temp_file_name, drive ? nvr_path(L"TEMP$$$1.$$$") : nvr_path(L"TEMP$$$0.$$$"), 256);
-	memcpy(dev->original_file_name, fn, (wcslen(fn) << 1) + 2);
+	memcpy(temp_file_name, drive ? nvr_path("TEMP$$$1.$$$") : nvr_path("TEMP$$$0.$$$"), 256);
+	memcpy(dev->original_file_name, fn, strlen(fn) + 1);
 
 	fclose(dev->f);
 	dev->f = NULL;
 
-	dev->f = plat_fopen(temp_file_name, L"wb");
+	dev->f = plat_fopen(temp_file_name, "wb");
 	if (! dev->f) {
 		d86f_log("86F: Unable to create temporary decompressed file\n");
 		memset(floppyfns[drive], 0, sizeof(floppyfns[drive]));
@@ -3631,7 +3631,7 @@ d86f_load(int drive, wchar_t *fn)
 		return;
 	}
 
-	tf = plat_fopen(fn, L"rb");
+	tf = plat_fopen(fn, "rb");
 
 	for (i = 0; i < 8; i++) {
 		fread(&temp, 1, 2, tf);
@@ -3660,7 +3660,7 @@ d86f_load(int drive, wchar_t *fn)
 		return;
 	}
 
-	dev->f = plat_fopen(temp_file_name, L"rb+");
+	dev->f = plat_fopen(temp_file_name, "rb+");
     }
 #endif
 
@@ -3703,10 +3703,10 @@ d86f_load(int drive, wchar_t *fn)
 
 #ifdef D86F_COMPRESS
 	if (dev->is_compressed)
-		dev->f = plat_fopen(temp_file_name, L"rb");
+		dev->f = plat_fopen(temp_file_name, "rb");
 	else
 #endif
-		dev->f = plat_fopen(fn, L"rb");
+		dev->f = plat_fopen(fn, "rb");
     }
 
     /* OK, set the drive data, other code needs it. */
@@ -3835,13 +3835,13 @@ d86f_close(int drive)
 {
     int i, j;
 
-    wchar_t temp_file_name[2048];
+    char temp_file_name[2048];
     d86f_t *dev = d86f[drive];
 
     /* Make sure the drive is alive. */
     if (dev == NULL) return;
 
-    memcpy(temp_file_name, drive ? nvr_path(L"TEMP$$$1.$$$") : nvr_path(L"TEMP$$$0.$$$"), 26);
+    memcpy(temp_file_name, drive ? nvr_path("TEMP$$$1.$$$") : nvr_path("TEMP$$$0.$$$"), 26);
 
     if (d86f_has_surface_desc(drive)) {
 	for (i = 0; i < 2; i++) {

--- a/src/floppy/fdd_fdi.c
+++ b/src/floppy/fdd_fdi.c
@@ -320,7 +320,7 @@ fdi_seek(int drive, int track)
 
 
 void
-fdi_load(int drive, wchar_t *fn)
+fdi_load(int drive, char *fn)
 {
     char header[26];
     fdi_t *dev;
@@ -339,7 +339,7 @@ fdi_load(int drive, wchar_t *fn)
 
     d86f_unregister(drive);
 
-    dev->f = plat_fopen(fn, L"rb");
+    dev->f = plat_fopen(fn, "rb");
     if (fread(header, 1, 25, dev->f) != 25)
 	fatal("fdi_load(): Error reading header\n");
     if (fseek(dev->f, 0, SEEK_SET) == -1)

--- a/src/floppy/fdd_imd.c
+++ b/src/floppy/fdd_imd.c
@@ -601,7 +601,7 @@ imd_init(void)
 
 
 void
-imd_load(int drive, wchar_t *fn)
+imd_load(int drive, char *fn)
 {
     uint32_t magic = 0;
     uint32_t fsize = 0;
@@ -634,9 +634,9 @@ imd_load(int drive, wchar_t *fn)
     dev = (imd_t *)malloc(sizeof(imd_t));
     memset(dev, 0x00, sizeof(imd_t));
 
-    dev->f = plat_fopen(fn, L"rb+");
+    dev->f = plat_fopen(fn, "rb+");
     if (dev->f == NULL) {
-	dev->f = plat_fopen(fn, L"rb");
+	dev->f = plat_fopen(fn, "rb");
 	if (dev->f == NULL) {
 		memset(floppyfns[drive], 0, sizeof(floppyfns[drive]));
 		free(dev);

--- a/src/floppy/fdd_img.c
+++ b/src/floppy/fdd_img.c
@@ -70,7 +70,7 @@ static img_t	*img[FDD_NUM];
 static fdc_t	*img_fdc;
 
 static double	bit_rate_300;
-static wchar_t	*ext;
+static char	*ext;
 static uint8_t	first_byte,
 		second_byte,
 		third_byte,
@@ -621,7 +621,7 @@ is_divisible(uint16_t total, uint8_t what)
 
 
 void
-img_load(int drive, wchar_t *fn)
+img_load(int drive, char *fn)
 {
     uint16_t bpb_bps;
     uint16_t bpb_total;
@@ -654,9 +654,9 @@ img_load(int drive, wchar_t *fn)
     dev = (img_t *)malloc(sizeof(img_t));
     memset(dev, 0x00, sizeof(img_t));
 
-    dev->f = plat_fopen(fn, L"rb+");
+    dev->f = plat_fopen(fn, "rb+");
     if (dev->f == NULL) {
-	dev->f = plat_fopen(fn, L"rb");
+	dev->f = plat_fopen(fn, "rb");
 	if (dev->f == NULL) {
 		free(dev);
 		memset(floppyfns[drive], 0, sizeof(floppyfns[drive]));
@@ -673,13 +673,13 @@ img_load(int drive, wchar_t *fn)
 
     dev->interleave = dev->skew = 0;
 
-    if (! wcscasecmp(ext, L"DDI")) {
+    if (! strcasecmp(ext, "DDI")) {
 	ddi = 1;
 	dev->base = 0x2400;
     } else
 	dev->base = 0;
 
-    if (! wcscasecmp(ext, L"FDI")) {
+    if (! strcasecmp(ext, "FDI")) {
 	/* This is a Japanese FDI image, so let's read the header */
 	img_log("img_load(): File is a Japanese FDI image...\n");
 	fseek(dev->f, 0x10, SEEK_SET);
@@ -721,7 +721,7 @@ img_load(int drive, wchar_t *fn)
 		img_log("img_load(): File is a FDF image...\n");
 		fwriteprot[drive] = writeprot[drive] = 1;
 		fclose(dev->f);
-		dev->f = plat_fopen(fn, L"rb");
+		dev->f = plat_fopen(fn, "rb");
 
 		fdf = 1;
 		cqm = 0;
@@ -861,7 +861,7 @@ img_load(int drive, wchar_t *fn)
 		img_log("img_load(): File is a CopyQM image...\n");
 		fwriteprot[drive] = writeprot[drive] = 1;
 		fclose(dev->f);
-		dev->f = plat_fopen(fn, L"rb");
+		dev->f = plat_fopen(fn, "rb");
 
 		fseek(dev->f, 0x03, SEEK_SET);
 		fread(&bpb_bps, 1, 2, dev->f);

--- a/src/floppy/fdd_json.c
+++ b/src/floppy/fdd_json.c
@@ -523,7 +523,7 @@ json_init(void)
 
 
 void
-json_load(int drive, wchar_t *fn)
+json_load(int drive, char *fn)
 {
     double bit_rate;
     int temp_rate;
@@ -539,10 +539,10 @@ json_load(int drive, wchar_t *fn)
     memset(dev, 0x00, sizeof(json_t));
 
     /* Open the image file. */
-    dev->f = plat_fopen(fn, L"rb");
+    dev->f = plat_fopen(fn, "rb");
     if (dev->f == NULL) {
 	free(dev);
-	memset(fn, 0x00, sizeof(wchar_t));
+	memset(fn, 0x00, sizeof(char));
 	return;
     }
 
@@ -558,11 +558,11 @@ json_load(int drive, wchar_t *fn)
 	(void)fclose(dev->f);
 	free(dev);
 	images[drive] = NULL;
-	memset(fn, 0x00, sizeof(wchar_t));
+	memset(fn, 0x00, sizeof(char));
 	return;
     }
 
-    json_log("JSON(%d): %ls (%i tracks, %i sides, %i sectors)\n",
+    json_log("JSON(%d): %s (%i tracks, %i sides, %i sectors)\n",
 	drive, fn, dev->tracks, dev->sides, dev->spt[0][0]);
 
     /*
@@ -624,7 +624,7 @@ json_load(int drive, wchar_t *fn)
 	dev->f = NULL;
 	free(dev);
 	images[drive] = NULL;
-	memset(fn, 0x00, sizeof(wchar_t));
+	memset(fn, 0x00, sizeof(char));
 	return;
     }
 
@@ -646,7 +646,7 @@ json_load(int drive, wchar_t *fn)
 	dev->f = NULL;
 	free(dev);
 	images[drive] = NULL;
-	memset(fn, 0x00, sizeof(wchar_t));
+	memset(fn, 0x00, sizeof(char));
 	return;
     }
 

--- a/src/floppy/fdd_mfm.c
+++ b/src/floppy/fdd_mfm.c
@@ -398,7 +398,7 @@ mfm_seek(int drive, int track)
 
 
 void
-mfm_load(int drive, wchar_t *fn)
+mfm_load(int drive, char *fn)
 {
     mfm_t *dev;
     double dbr;
@@ -410,7 +410,7 @@ mfm_load(int drive, wchar_t *fn)
     dev = (mfm_t *)malloc(sizeof(mfm_t));
     memset(dev, 0x00, sizeof(mfm_t));
 
-    dev->f = plat_fopen(fn, L"rb");
+    dev->f = plat_fopen(fn, "rb");
     if (dev->f == NULL) {
 	free(dev);
 	memset(floppyfns[drive], 0, sizeof(floppyfns[drive]));

--- a/src/floppy/fdd_td0.c
+++ b/src/floppy/fdd_td0.c
@@ -1191,7 +1191,7 @@ td0_abort(int drive)
 
 
 void
-td0_load(int drive, wchar_t *fn)
+td0_load(int drive, char *fn)
 {
     td0_t *dev;
     uint32_t i;
@@ -1204,7 +1204,7 @@ td0_load(int drive, wchar_t *fn)
     memset(dev, 0x00, sizeof(td0_t));
     td0[drive] = dev;
 
-    dev->f = plat_fopen(fn, L"rb");
+    dev->f = plat_fopen(fn, "rb");
     if (dev->f == NULL) {
 	memset(floppyfns[drive], 0, sizeof(floppyfns[drive]));
 	return;

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -27,9 +27,9 @@
 #define SCREEN_RES_Y	480
 
 /* Filename and pathname info. */
-#define CONFIG_FILE	L"86box.cfg"
-#define NVR_PATH        L"nvr"
-#define SCREENSHOT_PATH L"screenshots"
+#define CONFIG_FILE	"86box.cfg"
+#define NVR_PATH        "nvr"
+#define SCREENSHOT_PATH "screenshots"
 
 
 #if defined(ENABLE_BUSLOGIC_LOG) || \
@@ -72,7 +72,7 @@ extern int	confirm_exit_cmdl;		/* (O) do not ask for confirmation on quit if set
 extern uint64_t	unique_id;
 extern uint64_t	source_hwnd;
 #endif
-extern wchar_t	log_path[1024];			/* (O) full path of logfile */
+extern char	log_path[1024];			/* (O) full path of logfile */
 
 
 extern int	window_w, window_h,		/* (C) window size and */
@@ -132,9 +132,9 @@ extern int	serial_do_log;
 extern int	nic_do_log;
 #endif
 
-extern wchar_t	exe_path[2048];			/* path (dir) of executable */
-extern wchar_t	usr_path[1024];			/* path (dir) of user data */
-extern wchar_t  cfg_path[1024];			/* full path of config file */
+extern char	exe_path[2048];			/* path (dir) of executable */
+extern char	usr_path[1024];			/* path (dir) of user data */
+extern char	cfg_path[1024];			/* full path of config file */
 #ifndef USE_NEW_DYNAREC
 extern FILE	*stdlog;			/* file to log output to */
 #endif
@@ -158,7 +158,7 @@ extern void	set_screen_size_natural(void);
 extern void	pc_reload(wchar_t *fn);
 #endif
 extern int	pc_init_modules(void);
-extern int	pc_init(int argc, wchar_t *argv[]);
+extern int	pc_init(int argc, char *argv[]);
 extern void	pc_close(void *threadid);
 extern void	pc_reset_hard_close(void);
 extern void	pc_reset_hard_init(void);

--- a/src/include/86box/cdrom.h
+++ b/src/include/86box/cdrom.h
@@ -108,7 +108,7 @@ typedef struct cdrom {
     FILE* img_fp;
     void *priv;
 
-    wchar_t image_path[1024],
+    char image_path[1024],
 	    prev_image_path[1024];
 
     uint32_t sound_on, cdrom_capacity,
@@ -156,7 +156,7 @@ extern void	cdrom_insert(uint8_t id);
 extern void	cdrom_eject(uint8_t id);
 extern void	cdrom_reload(uint8_t id);
 
-extern int	cdrom_image_open(cdrom_t *dev, const wchar_t *fn);
+extern int	cdrom_image_open(cdrom_t *dev, const char *fn);
 extern void	cdrom_image_close(cdrom_t *dev);
 extern void	cdrom_image_reset(cdrom_t *dev);
 

--- a/src/include/86box/cdrom_image_backend.h
+++ b/src/include/86box/cdrom_image_backend.h
@@ -52,7 +52,7 @@ typedef struct {
     uint64_t		(*get_length)(void *p);
     void		(*close)(void *p);
 
-    wchar_t		fn[260];
+    char		fn[260];
     FILE		*file;
 } track_file_t;
 
@@ -72,7 +72,7 @@ typedef struct {
 
 /* Binary file functions. */
 extern void	cdi_close(cd_img_t *cdi);
-extern int	cdi_set_device(cd_img_t *cdi, const wchar_t *path);
+extern int	cdi_set_device(cd_img_t *cdi, const char *path);
 extern int	cdi_get_audio_tracks(cd_img_t *cdi, int *st_track, int *end, TMSF *lead_out);
 extern int	cdi_get_audio_tracks_lba(cd_img_t *cdi, int *st_track, int *end, uint32_t *lead_out);
 extern int	cdi_get_audio_track_info(cd_img_t *cdi, int end, int track, int *track_num, TMSF *start, uint8_t *attr);
@@ -85,8 +85,8 @@ extern int	cdi_read_sector_sub(cd_img_t *cdi, uint8_t *buffer, uint32_t sector);
 extern int	cdi_get_sector_size(cd_img_t *cdi, uint32_t sector);
 extern int	cdi_is_mode2(cd_img_t *cdi, uint32_t sector);
 extern int	cdi_get_mode2_form(cd_img_t *cdi, uint32_t sector);
-extern int	cdi_load_iso(cd_img_t *cdi, const wchar_t *filename);
-extern int	cdi_load_cue(cd_img_t *cdi, const wchar_t *cuefile);
+extern int	cdi_load_iso(cd_img_t *cdi, const char *filename);
+extern int	cdi_load_cue(cd_img_t *cdi, const char *cuefile);
 extern int	cdi_has_data_track(cd_img_t *cdi);
 extern int	cdi_has_audio_track(cd_img_t *cdi);
 

--- a/src/include/86box/config.h
+++ b/src/include/86box/config.h
@@ -139,7 +139,7 @@ typedef struct {
 
 extern void	config_load(void);
 extern void	config_save(void);
-extern void	config_write(wchar_t *fn);
+extern void	config_write(char *fn);
 extern void	config_dump(void);
 
 extern void	config_delete_var(char *head, char *name);

--- a/src/include/86box/fdd.h
+++ b/src/include/86box/fdd.h
@@ -86,7 +86,7 @@ typedef struct {
 
 
 extern DRIVE		drives[FDD_NUM];
-extern wchar_t		floppyfns[FDD_NUM][512];
+extern char		floppyfns[FDD_NUM][512];
 extern pc_timer_t	fdd_poll_time[FDD_NUM];
 extern int		ui_writeprot[FDD_NUM];
 
@@ -96,7 +96,7 @@ extern int	fdd_time;
 extern int64_t	floppytime;
 
 
-extern void	fdd_load(int drive, wchar_t *fn);
+extern void	fdd_load(int drive, char *fn);
 extern void	fdd_new(int drive, char *fn);
 extern void	fdd_close(int drive);
 extern void	fdd_init(void);

--- a/src/include/86box/fdd_86f.h
+++ b/src/include/86box/fdd_86f.h
@@ -54,7 +54,7 @@ extern d86f_handler_t	d86f_handler[FDD_NUM];
 
 
 extern void	d86f_init(void);
-extern void	d86f_load(int drive, wchar_t *fn);
+extern void	d86f_load(int drive, char *fn);
 extern void	d86f_close(int drive);
 extern void	d86f_seek(int drive, int track);
 extern int	d86f_hole(int drive);
@@ -81,7 +81,7 @@ extern uint16_t	d86f_prepare_sector(int drive, int side, int prev_pos, uint8_t *
 				    int data_len, int gap2, int gap3, int flags);
 extern void	d86f_setup(int drive);
 extern void	d86f_destroy(int drive);
-extern int	d86f_export(int drive, wchar_t *fn);
+extern int	d86f_export(int drive, char *fn);
 extern void	d86f_unregister(int drive);
 extern void	d86f_common_handlers(int drive);
 extern void	d86f_set_version(int drive, uint16_t version);

--- a/src/include/86box/fdd_fdi.h
+++ b/src/include/86box/fdd_fdi.h
@@ -24,7 +24,7 @@
 
 
 extern void	fdi_seek(int drive, int track);
-extern void	fdi_load(int drive, wchar_t *fn);
+extern void	fdi_load(int drive, char *fn);
 extern void	fdi_close(int drive);
 
 

--- a/src/include/86box/fdd_imd.h
+++ b/src/include/86box/fdd_imd.h
@@ -39,7 +39,7 @@
 
 
 extern void imd_init(void);
-extern void imd_load(int drive, wchar_t *fn);
+extern void imd_load(int drive, char *fn);
 extern void imd_close(int drive);
 
 

--- a/src/include/86box/fdd_img.h
+++ b/src/include/86box/fdd_img.h
@@ -24,7 +24,7 @@
 
 
 extern void	img_init(void);
-extern void	img_load(int drive, wchar_t *fn);
+extern void	img_load(int drive, char *fn);
 extern void	img_close(int drive);
 
 

--- a/src/include/86box/fdd_json.h
+++ b/src/include/86box/fdd_json.h
@@ -49,7 +49,7 @@
 
 
 extern void	json_init(void);
-extern void	json_load(int drive, wchar_t *fn);
+extern void	json_load(int drive, char *fn);
 extern void	json_close(int drive);
 
 

--- a/src/include/86box/fdd_mfm.h
+++ b/src/include/86box/fdd_mfm.h
@@ -19,7 +19,7 @@
 
 
 extern void	mfm_seek(int drive, int track);
-extern void	mfm_load(int drive, wchar_t *fn);
+extern void	mfm_load(int drive, char *fn);
 extern void	mfm_close(int drive);
 
 

--- a/src/include/86box/fdd_td0.h
+++ b/src/include/86box/fdd_td0.h
@@ -21,7 +21,7 @@
 
 
 extern void td0_init(void);
-extern void td0_load(int drive, wchar_t *fn);
+extern void td0_load(int drive, char *fn);
 extern void td0_close(int drive);
 
 

--- a/src/include/86box/hdd.h
+++ b/src/include/86box/hdd.h
@@ -92,7 +92,7 @@ typedef struct {
 
     void	*priv;
 
-    wchar_t	fn[1024],		/* Name of current image file */
+    char	fn[1024],		/* Name of current image file */
 		prev_fn[1024];		/* Name of previous image file */
 
     uint32_t	res0, pad1,
@@ -127,9 +127,9 @@ extern void	hdd_image_unload(uint8_t id, int fn_preserve);
 extern void	hdd_image_close(uint8_t id);
 extern void	hdd_image_calc_chs(uint32_t *c, uint32_t *h, uint32_t *s, uint32_t size);
 
-extern int	image_is_hdi(const wchar_t *s);
-extern int	image_is_hdx(const wchar_t *s, int check_signature);
-extern int	image_is_vhd(const wchar_t *s, int check_signature);
+extern int	image_is_hdi(const char *s);
+extern int	image_is_hdx(const char *s, int check_signature);
+extern int	image_is_vhd(const char *s, int check_signature);
 
 
 #endif	/*EMU_HDD_H*/

--- a/src/include/86box/mo.h
+++ b/src/include/86box/mo.h
@@ -109,7 +109,7 @@ typedef struct {
     FILE	*f;
     void	*priv;
 
-    wchar_t	image_path[1024],
+    char	image_path[1024],
 		prev_image_path[1024];
 
     uint32_t	type, medium_size,
@@ -170,7 +170,7 @@ extern void	mo_global_init(void);
 extern void	mo_hard_reset(void);
 
 extern void	mo_reset(scsi_common_t *sc);
-extern int	mo_load(mo_t *dev, wchar_t *fn);
+extern int	mo_load(mo_t *dev, char *fn);
 extern void	mo_close();
 
 #ifdef __cplusplus

--- a/src/include/86box/nvr.h
+++ b/src/include/86box/nvr.h
@@ -65,7 +65,7 @@
 
 /* Define a generic RTC/NVRAM device. */
 typedef struct _nvr_ {
-    wchar_t	*fn;			/* pathname of image file */
+    char	*fn;			/* pathname of image file */
     uint16_t	size;			/* device configuration */
     int8_t	irq;
 
@@ -101,8 +101,8 @@ extern const device_t via_nvr_device;
 extern void	rtc_tick(void);
 
 extern void	nvr_init(nvr_t *);
-extern wchar_t	*nvr_path(wchar_t *str);
-extern FILE	*nvr_fopen(wchar_t *str, wchar_t *mode);
+extern char	*nvr_path(char *str);
+extern FILE	*nvr_fopen(char *str, char *mode);
 extern int	nvr_load(void);
 extern void	nvr_close(void);
 extern void	nvr_set_ven_save(void (*ven_save)(void));

--- a/src/include/86box/plat.h
+++ b/src/include/86box/plat.h
@@ -81,24 +81,24 @@ extern int	unscaled_size_x,		/* current unscaled size X */
 		unscaled_size_y;		/* current unscaled size Y */
 
 /* System-related functions. */
-extern wchar_t	*fix_exe_path(wchar_t *str);
-extern FILE	*plat_fopen(wchar_t *path, wchar_t *mode);
-extern FILE	*plat_fopen64(const wchar_t *path, const wchar_t *mode);
-extern void	plat_remove(wchar_t *path);
-extern int	plat_getcwd(wchar_t *bufp, int max);
-extern int	plat_chdir(wchar_t *path);
-extern void	plat_tempfile(wchar_t *bufp, wchar_t *prefix, wchar_t *suffix);
-extern void	plat_get_exe_name(wchar_t *s, int size);
-extern wchar_t	*plat_get_basename(const wchar_t *path);
-extern void	plat_get_dirname(wchar_t *dest, const wchar_t *path);
-extern wchar_t	*plat_get_filename(wchar_t *s);
-extern wchar_t	*plat_get_extension(wchar_t *s);
-extern void	plat_append_filename(wchar_t *dest, wchar_t *s1, wchar_t *s2);
-extern void	plat_put_backslash(wchar_t *s);
-extern void	plat_path_slash(wchar_t *path);
-extern int	plat_path_abs(wchar_t *path);
-extern int	plat_dir_check(wchar_t *path);
-extern int	plat_dir_create(wchar_t *path);
+extern char	*fix_exe_path(char *str);
+extern FILE	*plat_fopen(const char *path, const char *mode);
+extern FILE	*plat_fopen64(const char *path, const char *mode);
+extern void	plat_remove(char *path);
+extern int	plat_getcwd(char *bufp, int max);
+extern int	plat_chdir(char *path);
+extern void	plat_tempfile(char *bufp, char *prefix, char *suffix);
+extern void	plat_get_exe_name(char *s, int size);
+extern char	*plat_get_basename(const char *path);
+extern void	plat_get_dirname(char *dest, const char *path);
+extern char	*plat_get_filename(char *s);
+extern char	*plat_get_extension(char *s);
+extern void	plat_append_filename(char *dest, char *s1, char *s2);
+extern void	plat_put_backslash(char *s);
+extern void	plat_path_slash(char *path);
+extern int	plat_path_abs(char *path);
+extern int	plat_dir_check(char *path);
+extern int	plat_dir_create(char *path);
 extern uint64_t	plat_timer_read(void);
 extern uint32_t	plat_get_ticks(void);
 extern void	plat_delay_ms(uint32_t count);
@@ -128,15 +128,15 @@ extern void	plat_power_off(void);
 
 
 /* Platform-specific device support. */
-extern void	floppy_mount(uint8_t id, wchar_t *fn, uint8_t wp);
+extern void	floppy_mount(uint8_t id, char *fn, uint8_t wp);
 extern void	floppy_eject(uint8_t id);
-extern void	cdrom_mount(uint8_t id, wchar_t *fn);
+extern void	cdrom_mount(uint8_t id, char *fn);
 extern void	plat_cdrom_ui_update(uint8_t id, uint8_t reload);
 extern void	zip_eject(uint8_t id);
-extern void	zip_mount(uint8_t id, wchar_t *fn, uint8_t wp);
+extern void	zip_mount(uint8_t id, char *fn, uint8_t wp);
 extern void	zip_reload(uint8_t id);
 extern void	mo_eject(uint8_t id);
-extern void	mo_mount(uint8_t id, wchar_t *fn, uint8_t wp);
+extern void	mo_mount(uint8_t id, char *fn, uint8_t wp);
 extern void	mo_reload(uint8_t id);
 extern int      ioctl_open(uint8_t id, char d);
 extern void     ioctl_reset(uint8_t id);
@@ -169,6 +169,10 @@ extern int	thread_release_mutex(mutex_t *mutex);
 extern void	startblit(void);
 extern void	endblit(void);
 extern void	take_screenshot(void);
+
+/* Conversion between UTF-8 and UTF-16. */
+extern size_t	mbstoc16s(uint16_t dst[], const char src[], int len);
+extern size_t	c16stombs(char dst[], const uint16_t src[], int len);
 
 #ifdef MTR_ENABLED
 extern void init_trace(void);

--- a/src/include/86box/png_struct.h
+++ b/src/include/86box/png_struct.h
@@ -52,10 +52,10 @@
 extern "C" {
 #endif
 
-extern int	png_write_gray(wchar_t *path, int invert,
+extern int	png_write_gray(char *path, int invert,
 			       uint8_t *pix, int16_t w, int16_t h);
 
-extern void	png_write_rgb(wchar_t *fn,
+extern void	png_write_rgb(char *fn,
 			      uint8_t *pix, int16_t w, int16_t h, uint16_t pitch, PALETTE palcol);
 
 #ifdef __cplusplus

--- a/src/include/86box/printer.h
+++ b/src/include/86box/printer.h
@@ -48,14 +48,14 @@
 # define PRINTER_H
 
 
-#define FONT_FILE_DOTMATRIX	L"dotmatrix.ttf"
+#define FONT_FILE_DOTMATRIX	"dotmatrix.ttf"
 
-#define FONT_FILE_ROMAN		L"roman.ttf"
-#define FONT_FILE_SANSSERIF	L"sansserif.ttf"
-#define FONT_FILE_COURIER	L"courier.ttf"
-#define FONT_FILE_SCRIPT	L"script.ttf"
-#define FONT_FILE_OCRA		L"ocra.ttf"
-#define FONT_FILE_OCRB		L"ocra.ttf"
+#define FONT_FILE_ROMAN		"roman.ttf"
+#define FONT_FILE_SANSSERIF	"sansserif.ttf"
+#define FONT_FILE_COURIER	"courier.ttf"
+#define FONT_FILE_SCRIPT	"script.ttf"
+#define FONT_FILE_OCRA		"ocra.ttf"
+#define FONT_FILE_OCRB		"ocra.ttf"
 
 
 extern void

--- a/src/include/86box/rom.h
+++ b/src/include/86box/rom.h
@@ -45,35 +45,35 @@ extern uint8_t	rom_read(uint32_t addr, void *p);
 extern uint16_t	rom_readw(uint32_t addr, void *p);
 extern uint32_t	rom_readl(uint32_t addr, void *p);
 
-extern FILE	*rom_fopen(wchar_t *fn, wchar_t *mode);
-extern int	rom_getfile(wchar_t *fn, wchar_t *s, int size);
-extern int	rom_present(wchar_t *fn);
+extern FILE	*rom_fopen(char *fn, char *mode);
+extern int	rom_getfile(char *fn, char *s, int size);
+extern int	rom_present(char *fn);
 
-extern int	rom_load_linear_oddeven(wchar_t *fn, uint32_t addr, int sz,
+extern int	rom_load_linear_oddeven(char *fn, uint32_t addr, int sz,
 					int off, uint8_t *ptr);
-extern int	rom_load_linear(wchar_t *fn, uint32_t addr, int sz,
+extern int	rom_load_linear(char *fn, uint32_t addr, int sz,
 				int off, uint8_t *ptr);
-extern int	rom_load_interleaved(wchar_t *fnl, wchar_t *fnh, uint32_t addr,
+extern int	rom_load_interleaved(char *fnl, char *fnh, uint32_t addr,
 				     int sz, int off, uint8_t *ptr);
 
 extern uint8_t	bios_read(uint32_t addr, void *priv);
 extern uint16_t	bios_readw(uint32_t addr, void *priv);
 extern uint32_t	bios_readl(uint32_t addr, void *priv);
 
-extern int	bios_load(wchar_t *fn1, wchar_t *fn2, uint32_t addr, int sz,
+extern int	bios_load(char *fn1, char *fn2, uint32_t addr, int sz,
 			  int off, int flags);
-extern int	bios_load_linear_combined(wchar_t *fn1, wchar_t *fn2,
+extern int	bios_load_linear_combined(char *fn1, char *fn2,
 					  int sz, int off);
-extern int	bios_load_linear_combined2(wchar_t *fn1, wchar_t *fn2,
-					   wchar_t *fn3, wchar_t *fn4, wchar_t *fn5,
+extern int	bios_load_linear_combined2(char *fn1, char *fn2,
+					   char *fn3, char *fn4, char *fn5,
 					   int sz, int off);
 
-extern int	rom_init(rom_t *rom, wchar_t *fn, uint32_t address, int size,
+extern int	rom_init(rom_t *rom, char *fn, uint32_t address, int size,
 			 int mask, int file_offset, uint32_t flags);
-extern int	rom_init_oddeven(rom_t *rom, wchar_t *fn, uint32_t address, int size,
+extern int	rom_init_oddeven(rom_t *rom, char *fn, uint32_t address, int size,
 				 int mask, int file_offset, uint32_t flags);
-extern int	rom_init_interleaved(rom_t *rom, wchar_t *fn_low,
-				     wchar_t *fn_high, uint32_t address,
+extern int	rom_init_interleaved(rom_t *rom, char *fn_low,
+				     char *fn_high, uint32_t address,
 				     int size, int mask, int file_offset,
 				     uint32_t flags);
 

--- a/src/include/86box/scsi_x54x.h
+++ b/src/include/86box/scsi_x54x.h
@@ -450,7 +450,7 @@ typedef struct {
     double	media_period, ha_bps;		/* bytes per second */
 
     /* 8 bytes */
-    wchar_t	*bios_path,			/* path to BIOS image file */
+    char	*bios_path,			/* path to BIOS image file */
 		*mcode_path,			/* path to microcode image file, needed by the AHA-1542CP */
 		*nvr_path;			/* path to NVR image file */
 

--- a/src/include/86box/vid_ati_eeprom.h
+++ b/src/include/86box/vid_ati_eeprom.h
@@ -41,9 +41,9 @@ typedef struct ati_eeprom_t
         int type;
 	int address;
 
-        wchar_t fn[256];
+        char fn[256];
 } ati_eeprom_t;
 
-void ati_eeprom_load(ati_eeprom_t *eeprom, wchar_t *fn, int type);
+void ati_eeprom_load(ati_eeprom_t *eeprom, char *fn, int type);
 void ati_eeprom_write(ati_eeprom_t *eeprom, int ena, int clk, int dat);
 int ati_eeprom_read(ati_eeprom_t *eeprom);

--- a/src/include/86box/video.h
+++ b/src/include/86box/video.h
@@ -172,8 +172,8 @@ extern uint8_t	video_force_resize_get(void);
 extern void	video_force_resize_set(uint8_t res);
 extern void	video_update_timing(void);
 
-extern void	loadfont_ex(wchar_t *s, int format, int offset);
-extern void	loadfont(wchar_t *s, int format);
+extern void	loadfont_ex(char *s, int format, int offset);
+extern void	loadfont(char *s, int format);
 
 extern int	get_actual_size_x(void);
 extern int	get_actual_size_y(void);

--- a/src/include/86box/win.h
+++ b/src/include/86box/win.h
@@ -103,6 +103,7 @@ extern LCID		lang_id;
 extern HICON		hIcon[256];
 extern RECT		oldclip;
 extern int		sbar_height, user_resize;
+extern int		acp_utf8;
 
 // extern int		status_is_open;
 

--- a/src/include/86box/zip.h
+++ b/src/include/86box/zip.h
@@ -57,7 +57,7 @@ typedef struct {
     FILE *f;
     void *priv;
 
-    wchar_t image_path[1024],
+    char image_path[1024],
 	    prev_image_path[1024];
 
     uint32_t is_250, medium_size,
@@ -116,7 +116,7 @@ extern void	zip_global_init(void);
 extern void	zip_hard_reset(void);
 
 extern void	zip_reset(scsi_common_t *sc);
-extern int	zip_load(zip_t *dev, wchar_t *fn);
+extern int	zip_load(zip_t *dev, char *fn);
 extern void	zip_close();
 
 #ifdef __cplusplus

--- a/src/machine/m_amstrad.c
+++ b/src/machine/m_amstrad.c
@@ -842,7 +842,7 @@ vid_init_1640(amstrad_t *ams)
     vid = (amsvid_t *)malloc(sizeof(amsvid_t));
     memset(vid, 0x00, sizeof(amsvid_t));
 
-    rom_init(&vid->bios_rom, L"roms/machines/pc1640/40100",
+    rom_init(&vid->bios_rom, "roms/machines/pc1640/40100",
 	     0xc0000, 0x8000, 0x7fff, 0, 0);
 
     ega_init(&vid->ega, 9, 0);
@@ -2437,7 +2437,7 @@ machine_amstrad_init(const machine_t *model, int type)
 
     if (gfxcard == VID_INTERNAL) switch(type) {
 	case AMS_PC1512:
-		loadfont(L"roms/machines/pc1512/40078", 8);
+		loadfont("roms/machines/pc1512/40078", 8);
 		device_context(&vid_1512_device);
 		ams->language = device_get_config_int("language");
 		vid_init_1512(ams);
@@ -2446,7 +2446,7 @@ machine_amstrad_init(const machine_t *model, int type)
 		break;
 	
 	case AMS_PPC512:
-		loadfont(L"roms/machines/ppc512/40109", 1);
+		loadfont("roms/machines/ppc512/40109", 1);
 		device_context(&vid_ppc512_device);
 		ams->language = device_get_config_int("language");
 		vid_init_200(ams);
@@ -2455,7 +2455,7 @@ machine_amstrad_init(const machine_t *model, int type)
 		break;
 	
 	case AMS_PC1640:
-		loadfont(L"roms/video/mda/mda.rom", 0);
+		loadfont("roms/video/mda/mda.rom", 0);
 		device_context(&vid_1640_device);
 		ams->language = device_get_config_int("language");
 		vid_init_1640(ams);
@@ -2464,7 +2464,7 @@ machine_amstrad_init(const machine_t *model, int type)
 		break;
 
 	case AMS_PC200:
-		loadfont(L"roms/machines/pc200/40109", 1);
+		loadfont("roms/machines/pc200/40109", 1);
 		device_context(&vid_200_device);
 		ams->language = device_get_config_int("language");
 		vid_init_200(ams);
@@ -2520,10 +2520,10 @@ machine_pc1512_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/pc1512/40044",
-				L"roms/machines/pc1512/40043",
+    ret = bios_load_interleaved("roms/machines/pc1512/40044",
+				"roms/machines/pc1512/40043",
 				0x000fc000, 16384, 0);
-    ret &= rom_present(L"roms/machines/pc1512/40078");
+    ret &= rom_present("roms/machines/pc1512/40078");
 
     if (bios_only || !ret)
 	return ret;
@@ -2539,10 +2539,10 @@ machine_pc1640_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/pc1640/40044.v3",
-				L"roms/machines/pc1640/40043.v3",
+    ret = bios_load_interleaved("roms/machines/pc1640/40044.v3",
+				"roms/machines/pc1640/40043.v3",
 				0x000fc000, 16384, 0);
-    ret &= rom_present(L"roms/machines/pc1640/40100");
+    ret &= rom_present("roms/machines/pc1640/40100");
 
     if (bios_only || !ret)
 	return ret;
@@ -2558,10 +2558,10 @@ machine_pc200_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/pc200/pc20v2.1",
-				L"roms/machines/pc200/pc20v2.0",
+    ret = bios_load_interleaved("roms/machines/pc200/pc20v2.1",
+				"roms/machines/pc200/pc20v2.0",
 				0x000fc000, 16384, 0);
-    ret &= rom_present(L"roms/machines/pc200/40109");
+    ret &= rom_present("roms/machines/pc200/40109");
 
     if (bios_only || !ret)
 	return ret;
@@ -2577,10 +2577,10 @@ machine_ppc512_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/ppc512/40107.v2",
-				L"roms/machines/ppc512/40108.v2",
+    ret = bios_load_interleaved("roms/machines/ppc512/40107.v2",
+				"roms/machines/ppc512/40108.v2",
 				0x000fc000, 16384, 0);
-    ret &= rom_present(L"roms/machines/ppc512/40109");
+    ret &= rom_present("roms/machines/ppc512/40109");
 
     if (bios_only || !ret)
 	return ret;
@@ -2596,10 +2596,10 @@ machine_pc2086_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleavedr(L"roms/machines/pc2086/40179.ic129",
-				 L"roms/machines/pc2086/40180.ic132",
+    ret = bios_load_interleavedr("roms/machines/pc2086/40179.ic129",
+				 "roms/machines/pc2086/40180.ic132",
 				 0x000fc000, 65536, 0);
-    ret &= rom_present(L"roms/machines/pc2086/40186.ic171");
+    ret &= rom_present("roms/machines/pc2086/40186.ic171");
 
     if (bios_only || !ret)
 	return ret;
@@ -2615,9 +2615,9 @@ machine_pc3086_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linearr(L"roms/machines/pc3086/fc00.bin",
+    ret = bios_load_linearr("roms/machines/pc3086/fc00.bin",
 			    0x000fc000, 65536, 0);
-    ret &= rom_present(L"roms/machines/pc3086/c000.bin");
+    ret &= rom_present("roms/machines/pc3086/c000.bin");
 
     if (bios_only || !ret)
 	return ret;

--- a/src/machine/m_at.c
+++ b/src/machine/m_at.c
@@ -159,8 +159,8 @@ machine_at_ibm_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/ibmat/62x0820.u27",
-				L"roms/machines/ibmat/62x0821.u47",
+    ret = bios_load_interleaved("roms/machines/ibmat/62x0820.u27",
+				"roms/machines/ibmat/62x0821.u47",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -178,8 +178,8 @@ machine_at_ibmatquadtel_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/ibmatquadtel/BIOS_30MAR90_U27_QUADTEL_ENH_286_BIOS_3.05.01_27256.BIN",
-				L"roms/machines/ibmatquadtel/BIOS_30MAR90_U47_QUADTEL_ENH_286_BIOS_3.05.01_27256.BIN",
+    ret = bios_load_interleaved("roms/machines/ibmatquadtel/BIOS_30MAR90_U27_QUADTEL_ENH_286_BIOS_3.05.01_27256.BIN",
+				"roms/machines/ibmatquadtel/BIOS_30MAR90_U47_QUADTEL_ENH_286_BIOS_3.05.01_27256.BIN",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -196,8 +196,8 @@ machine_at_ibmatami_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/ibmatami/BIOS_5170_30APR89_U27_AMI_27256.BIN",
-				L"roms/machines/ibmatami/BIOS_5170_30APR89_U47_AMI_27256.BIN",
+    ret = bios_load_interleaved("roms/machines/ibmatami/BIOS_5170_30APR89_U27_AMI_27256.BIN",
+				"roms/machines/ibmatami/BIOS_5170_30APR89_U47_AMI_27256.BIN",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -214,8 +214,8 @@ machine_at_ibmatpx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/ibmatpx/BIOS ROM - PhoenixBIOS A286 - Version 1.01 - Even.bin",
-				L"roms/machines/ibmatpx/BIOS ROM - PhoenixBIOS A286 - Version 1.01 - Odd.bin",
+    ret = bios_load_interleaved("roms/machines/ibmatpx/BIOS ROM - PhoenixBIOS A286 - Version 1.01 - Even.bin",
+				"roms/machines/ibmatpx/BIOS ROM - PhoenixBIOS A286 - Version 1.01 - Odd.bin",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -232,8 +232,8 @@ machine_at_ibmxt286_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/ibmxt286/bios_5162_21apr86_u34_78x7460_27256.bin",
-				L"roms/machines/ibmxt286/bios_5162_21apr86_u35_78x7461_27256.bin",
+    ret = bios_load_interleaved("roms/machines/ibmxt286/bios_5162_21apr86_u34_78x7460_27256.bin",
+				"roms/machines/ibmxt286/bios_5162_21apr86_u35_78x7461_27256.bin",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -249,7 +249,7 @@ machine_at_siemens_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/siemens/286BIOS.BIN",
+    ret = bios_load_linear("roms/machines/siemens/286BIOS.BIN",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -267,7 +267,7 @@ machine_at_open_at_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/open_at/bios.bin",
+    ret = bios_load_linear("roms/machines/open_at/bios.bin",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_286_386sx.c
+++ b/src/machine/m_at_286_386sx.c
@@ -49,8 +49,8 @@ machine_at_mr286_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/mr286/V000B200-1",
-				L"roms/machines/mr286/V000B200-2",
+    ret = bios_load_interleaved("roms/machines/mr286/V000B200-1",
+				"roms/machines/mr286/V000B200-2",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -85,7 +85,7 @@ machine_at_tg286m_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/tg286m/ami.bin",
+    ret = bios_load_linear("roms/machines/tg286m/ami.bin",
 			   0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -111,7 +111,7 @@ machine_at_ama932j_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ama932j/ami.bin",
+    ret = bios_load_linear("roms/machines/ama932j/ami.bin",
 			   0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -133,8 +133,8 @@ machine_at_quadt286_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/quadt286/QUADT89L.ROM",
-				L"roms/machines/quadt286/QUADT89H.ROM",
+    ret = bios_load_interleaved("roms/machines/quadt286/QUADT89L.ROM",
+				"roms/machines/quadt286/QUADT89H.ROM",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -157,7 +157,7 @@ machine_at_neat_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/dtk386/3cto001.bin",
+    ret = bios_load_linear("roms/machines/dtk386/3cto001.bin",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -179,7 +179,7 @@ machine_at_neat_ami_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ami286/amic206.bin",
+    ret = bios_load_linear("roms/machines/ami286/amic206.bin",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -203,7 +203,7 @@ machine_at_px286_init(const machine_t *model)
 {
     int ret;
 
-	ret = bios_load_linear(L"roms/machines/px286/KENITEC.BIN",
+	ret = bios_load_linear("roms/machines/px286/KENITEC.BIN",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -225,8 +225,8 @@ machine_at_micronics386_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/micronics386/386-Micronics-09-00021-EVEN.BIN",
-				L"roms/machines/micronics386/386-Micronics-09-00021-ODD.BIN",
+    ret = bios_load_interleaved("roms/machines/micronics386/386-Micronics-09-00021-EVEN.BIN",
+				"roms/machines/micronics386/386-Micronics-09-00021-ODD.BIN",
 				0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -278,7 +278,7 @@ machine_at_award286_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/award286/award.bin",
+    ret = bios_load_linear("roms/machines/award286/award.bin",
 			   0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -294,7 +294,7 @@ machine_at_gdc212m_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/gdc212m/gdc212m_72h.bin",
+    ret = bios_load_linear("roms/machines/gdc212m/gdc212m_72h.bin",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -312,7 +312,7 @@ machine_at_gw286ct_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/gw286ct/2ctc001.bin",
+    ret = bios_load_linear("roms/machines/gw286ct/2ctc001.bin",
 			   0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -331,7 +331,7 @@ machine_at_super286tr_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/super286tr/hyundai_award286.bin",
+    ret = bios_load_linear("roms/machines/super286tr/hyundai_award286.bin",
 			   0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -348,7 +348,7 @@ machine_at_spc4200p_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/spc4200p/u8.01",
+    ret = bios_load_linear("roms/machines/spc4200p/u8.01",
 			   0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -365,8 +365,8 @@ machine_at_spc4216p_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/spc4216p/7101.u8",
-				L"roms/machines/spc4216p/ac64.u10",
+    ret = bios_load_interleaved("roms/machines/spc4216p/7101.u8",
+				"roms/machines/spc4216p/ac64.u10",
 				0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -390,8 +390,8 @@ machine_at_spc4620p_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/spc4620p/31005h.u8",
-				L"roms/machines/spc4620p/31005h.u10",
+    ret = bios_load_interleaved("roms/machines/spc4620p/31005h.u8",
+				"roms/machines/spc4620p/31005h.u10",
 				0x000f0000, 131072, 0x8000);
 
     if (bios_only || !ret)
@@ -411,7 +411,7 @@ machine_at_kmxc02_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/kmxc02/3ctm005.bin",
+    ret = bios_load_linear("roms/machines/kmxc02/3ctm005.bin",
 			   0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -428,7 +428,7 @@ machine_at_deskmaster286_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/deskmaster286/SAMSUNG-DESKMASTER-28612-ROM.BIN",
+    ret = bios_load_linear("roms/machines/deskmaster286/SAMSUNG-DESKMASTER-28612-ROM.BIN",
 			   0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -445,8 +445,8 @@ machine_at_shuttle386sx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/shuttle386sx/386-Shuttle386SX-Even.BIN",
-				L"roms/machines/shuttle386sx/386-Shuttle386SX-Odd.BIN",
+    ret = bios_load_interleaved("roms/machines/shuttle386sx/386-Shuttle386SX-Even.BIN",
+				"roms/machines/shuttle386sx/386-Shuttle386SX-Odd.BIN",
 			   0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -469,8 +469,8 @@ machine_at_adi386sx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/adi386sx/3iip001l.bin",
-				L"roms/machines/adi386sx/3iip001h.bin",
+    ret = bios_load_interleaved("roms/machines/adi386sx/3iip001l.bin",
+				"roms/machines/adi386sx/3iip001h.bin",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -493,8 +493,8 @@ machine_at_wd76c10_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/megapc/41651-bios lo.u18",
-				L"roms/machines/megapc/211253-bios hi.u19",
+    ret = bios_load_interleaved("roms/machines/megapc/41651-bios lo.u18",
+				"roms/machines/megapc/211253-bios hi.u19",
 				0x000f0000, 65536, 0x08000);
 
     if (bios_only || !ret)
@@ -518,8 +518,8 @@ machine_at_commodore_sl386sx16_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/cbm_sl386sx16/cbm-sl386sx-bios-lo-v1.04-390914-04.bin",
-				L"roms/machines/cbm_sl386sx16/cbm-sl386sx-bios-hi-v1.04-390915-04.bin",
+    ret = bios_load_interleaved("roms/machines/cbm_sl386sx16/cbm-sl386sx-bios-lo-v1.04-390914-04.bin",
+				"roms/machines/cbm_sl386sx16/cbm-sl386sx-bios-hi-v1.04-390915-04.bin",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -567,7 +567,7 @@ machine_at_commodore_sl386sx25_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/cbm_sl386sx25/f000.rom",
+    ret = bios_load_linear("roms/machines/cbm_sl386sx25/f000.rom",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -594,7 +594,7 @@ machine_at_spc6033p_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/spc6033p/phoenix.bin",
+    ret = bios_load_linear("roms/machines/spc6033p/phoenix.bin",
 			   0x000f0000, 65536, 0x10000);
 
     if (bios_only || !ret)
@@ -614,7 +614,7 @@ machine_at_awardsx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/awardsx/Unknown 386SX OPTi291 - Award (original).BIN",
+    ret = bios_load_linear("roms/machines/awardsx/Unknown 386SX OPTi291 - Award (original).BIN",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -635,7 +635,7 @@ machine_at_flytech386_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/flytech386/FLYTECH.BIO",
+    ret = bios_load_linear("roms/machines/flytech386/FLYTECH.BIO",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -665,7 +665,7 @@ machine_at_arb1375_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/arb1375/a1375v25.u11-a",
+    ret = bios_load_linear("roms/machines/arb1375/a1375v25.u11-a",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -687,7 +687,7 @@ machine_at_pja511m_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/pja511m/2006915102435734.rom",
+    ret = bios_load_linear("roms/machines/pja511m/2006915102435734.rom",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -714,8 +714,8 @@ machine_at_ncrpc8_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/ncr_pc8/ncr_35117_u127_vers.4-2.bin",
-                L"roms/machines/ncr_pc8/ncr_35116_u113_vers.4-2.bin",
+    ret = bios_load_interleaved("roms/machines/ncr_pc8/ncr_35117_u127_vers.4-2.bin",
+                "roms/machines/ncr_pc8/ncr_35116_u113_vers.4-2.bin",
 	    		0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -739,11 +739,11 @@ machine_at_ncr3302_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ncr_3302/f000-flex_drive_test.bin",
+    ret = bios_load_linear("roms/machines/ncr_3302/f000-flex_drive_test.bin",
 				0x000f0000, 65536, 0);
 
     if (ret) {
-        bios_load_aux_linear(L"roms/machines/ncr_3302/f800-setup_ncr3.5-013190.bin",
+        bios_load_aux_linear("roms/machines/ncr_3302/f800-setup_ncr3.5-013190.bin",
 			     0x000f8000, 32768, 0);
     }
 
@@ -772,8 +772,8 @@ machine_at_ncrpc916sx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/ncr_pc916sx/ncr_386sx_u46-17_7.3.bin",
-                L"roms/machines/ncr_pc916sx/ncr_386sx_u12-19_7.3.bin",
+    ret = bios_load_interleaved("roms/machines/ncr_pc916sx/ncr_386sx_u46-17_7.3.bin",
+                "roms/machines/ncr_pc916sx/ncr_386sx_u12-19_7.3.bin",
 	    		0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -796,7 +796,7 @@ machine_at_olim290_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/olivetti_m290/m290_pep3_1.25.bin",
+    ret = bios_load_linear("roms/machines/olivetti_m290/m290_pep3_1.25.bin",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -825,7 +825,7 @@ machine_at_olim300_08_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/olivetti_m300_08/BIOS.ROM",
+    ret = bios_load_linear("roms/machines/olivetti_m300_08/BIOS.ROM",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -849,7 +849,7 @@ machine_at_olim300_15_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/olivetti_m300_15/BIOS.ROM",
+    ret = bios_load_linear("roms/machines/olivetti_m300_15/BIOS.ROM",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -49,7 +49,7 @@ machine_at_acc386_init(const machine_t *model)
 {
     int ret;
 
-   ret = bios_load_linear(L"roms/machines/acc386/acc386.BIN",
+   ret = bios_load_linear("roms/machines/acc386/acc386.BIN",
 			  0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -71,7 +71,7 @@ machine_at_asus386_init(const machine_t *model)
 {
     int ret;
 
-	ret = bios_load_linear(L"roms/machines/asus386/ASUS_ISA-386C_BIOS.bin",
+	ret = bios_load_linear("roms/machines/asus386/ASUS_ISA-386C_BIOS.bin",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -93,7 +93,7 @@ machine_at_sis401_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/sis401/SIS401-2.AMI",
+    ret = bios_load_linear("roms/machines/sis401/SIS401-2.AMI",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -115,7 +115,7 @@ machine_at_av4_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/av4/amibios_486dx_isa_bios_aa4025963.bin",
+    ret = bios_load_linear("roms/machines/av4/amibios_486dx_isa_bios_aa4025963.bin",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -137,7 +137,7 @@ machine_at_valuepoint433_init(const machine_t *model)	// hangs without the PS/2 
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/valuepoint433/$IMAGEP.FLH",
+    ret = bios_load_linear("roms/machines/valuepoint433/$IMAGEP.FLH",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -167,8 +167,8 @@ machine_at_ecs386_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/ecs386/AMI BIOS for ECS-386_32 motherboard - L chip.bin",
-				L"roms/machines/ecs386/AMI BIOS for ECS-386_32 motherboard - H chip.bin",
+    ret = bios_load_interleaved("roms/machines/ecs386/AMI BIOS for ECS-386_32 motherboard - L chip.bin",
+				"roms/machines/ecs386/AMI BIOS for ECS-386_32 motherboard - H chip.bin",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -191,8 +191,8 @@ machine_at_spc6000a_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/spc6000a/3c80.u27",
-				L"roms/machines/spc6000a/9f80.u26",
+    ret = bios_load_interleaved("roms/machines/spc6000a/3c80.u27",
+				"roms/machines/spc6000a/9f80.u26",
 				0x000f8000, 32768, 0);
 
     if (bios_only || !ret)
@@ -215,7 +215,7 @@ machine_at_rycleopardlx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/rycleopardlx/486-RYC-Leopard-LX.BIN",
+    ret = bios_load_linear("roms/machines/rycleopardlx/486-RYC-Leopard-LX.BIN",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -238,7 +238,7 @@ machine_at_486vchd_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/486vchd/486-4386-VC-HD.BIN",
+    ret = bios_load_linear("roms/machines/486vchd/486-4386-VC-HD.BIN",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -261,7 +261,7 @@ machine_at_cs4031_init(const machine_t *model)
 {
     int ret;
 
-	ret = bios_load_linear(L"roms/machines/cs4031/CHIPS_1.AMI",
+	ret = bios_load_linear("roms/machines/cs4031/CHIPS_1.AMI",
 				0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -283,7 +283,7 @@ machine_at_pb410a_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/pb410a/pb410a.080337.4abf.u25.bin",
+    ret = bios_load_linear("roms/machines/pb410a/pb410a.080337.4abf.u25.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -311,7 +311,7 @@ machine_at_vect486vl_init(const machine_t *model)	// has HDC problems
 {
     int ret;
 
-   ret = bios_load_linear(L"roms/machines/vect486vl/aa0500.ami",
+   ret = bios_load_linear("roms/machines/vect486vl/aa0500.ami",
 			  0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -344,7 +344,7 @@ machine_at_acera1g_init(const machine_t *model)
 {
     int ret;
 
-   ret = bios_load_linear(L"roms/machines/acera1g/4alo001.bin",
+   ret = bios_load_linear("roms/machines/acera1g/4alo001.bin",
 			  0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -392,7 +392,7 @@ machine_at_ali1429_init(const machine_t *model)
 {
     int ret;
 
-   ret = bios_load_linear(L"roms/machines/ami486/ami486.bin",
+   ret = bios_load_linear("roms/machines/ami486/ami486.bin",
 			  0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -409,7 +409,7 @@ machine_at_winbios1429_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/win486/ali1429g.amw",
+    ret = bios_load_linear("roms/machines/win486/ali1429g.amw",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -426,7 +426,7 @@ machine_at_opti495_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/award495/opt495s.awa",
+    ret = bios_load_linear("roms/machines/award495/opt495s.awa",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -464,7 +464,7 @@ machine_at_opti495_ami_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ami495/opt495sx.ami",
+    ret = bios_load_linear("roms/machines/ami495/opt495sx.ami",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -481,7 +481,7 @@ machine_at_opti495_mr_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/mr495/opt495sx.mr",
+    ret = bios_load_linear("roms/machines/mr495/opt495sx.mr",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -497,7 +497,7 @@ machine_at_403tg_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/403tg/403TG.BIN",
+    ret = bios_load_linear("roms/machines/403tg/403TG.BIN",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -521,7 +521,7 @@ machine_at_pc330_6571_init(const machine_t *model)	// doesn't like every CPU oth
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/pc330_6571/$IMAGES.USF",
+    ret = bios_load_linear("roms/machines/pc330_6571/$IMAGES.USF",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -543,7 +543,7 @@ machine_at_mvi486_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/mvi486/MVI627.BIN",
+    ret = bios_load_linear("roms/machines/mvi486/MVI627.BIN",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -576,7 +576,7 @@ machine_at_ami471_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ami471/SIS471BE.AMI",
+    ret = bios_load_linear("roms/machines/ami471/SIS471BE.AMI",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -595,7 +595,7 @@ machine_at_vli486sv2g_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/vli486sv2g/0402.001",
+    ret = bios_load_linear("roms/machines/vli486sv2g/0402.001",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -614,7 +614,7 @@ machine_at_dtk486_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/dtk486/4siw005.bin",
+    ret = bios_load_linear("roms/machines/dtk486/4siw005.bin",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -633,7 +633,7 @@ machine_at_px471_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/px471/SIS471A1.PHO",
+    ret = bios_load_linear("roms/machines/px471/SIS471A1.PHO",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -652,7 +652,7 @@ machine_at_win471_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/win471/486-SiS_AC0360136.BIN",
+    ret = bios_load_linear("roms/machines/win471/486-SiS_AC0360136.BIN",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -671,7 +671,7 @@ machine_at_vi15g_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/vi15g/vi15gr23.rom",
+    ret = bios_load_linear("roms/machines/vi15g/vi15gr23.rom",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -705,7 +705,7 @@ machine_at_r418_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/r418/r418i.bin",
+    ret = bios_load_linear("roms/machines/r418/r418i.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -732,7 +732,7 @@ machine_at_m4li_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/m4li/M4LI.04S",
+    ret = bios_load_linear("roms/machines/m4li/M4LI.04S",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -759,7 +759,7 @@ machine_at_ls486e_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ls486e/LS486E RevC.BIN",
+    ret = bios_load_linear("roms/machines/ls486e/LS486E RevC.BIN",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -786,7 +786,7 @@ machine_at_4dps_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/4dps/4DPS172G.BIN",
+    ret = bios_load_linear("roms/machines/4dps/4DPS172G.BIN",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -815,7 +815,7 @@ machine_at_4sa2_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/4sa2/4saw0911.bin",
+    ret = bios_load_linear("roms/machines/4sa2/4saw0911.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -844,8 +844,8 @@ machine_at_alfredo_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/alfredo/1010AQ0_.BIO",
-				    L"roms/machines/alfredo/1010AQ0_.BI1", 0x1c000, 128);
+    ret = bios_load_linear_combined("roms/machines/alfredo/1010AQ0_.BIO",
+				    "roms/machines/alfredo/1010AQ0_.BI1", 0x1c000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -876,7 +876,7 @@ machine_at_486sp3g_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/486sp3g/PCI-I-486SP3G_0306.001 (Beta).bin",
+    ret = bios_load_linear("roms/machines/486sp3g/PCI-I-486SP3G_0306.001 (Beta).bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -911,7 +911,7 @@ machine_at_486ap4_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/486ap4/0205.002",
+    ret = bios_load_linear("roms/machines/486ap4/0205.002",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -943,7 +943,7 @@ machine_at_486vipio2_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/486vipio2/1175G701.BIN",
+    ret = bios_load_linear("roms/machines/486vipio2/1175G701.BIN",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -975,7 +975,7 @@ machine_at_abpb4_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/abpb4/486-AB-PB4.BIN",
+    ret = bios_load_linear("roms/machines/abpb4/486-AB-PB4.BIN",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -1001,7 +1001,7 @@ machine_at_win486pci_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/win486pci/v1hj3.BIN",
+    ret = bios_load_linear("roms/machines/win486pci/v1hj3.BIN",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -1028,7 +1028,7 @@ machine_at_atc1415_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/atc1415/1415V330.ROM",
+    ret = bios_load_linear("roms/machines/atc1415/1415V330.ROM",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -1058,7 +1058,7 @@ machine_at_ecs486_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ecs486/8810AIO.32J",
+    ret = bios_load_linear("roms/machines/ecs486/8810AIO.32J",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -1088,7 +1088,7 @@ machine_at_hot433_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/hot433/433AUS33.ROM",
+    ret = bios_load_linear("roms/machines/hot433/433AUS33.ROM",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -1118,7 +1118,7 @@ machine_at_itoxstar_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/itoxstar/stara.rom",
+    ret = bios_load_linear("roms/machines/itoxstar/stara.rom",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -1148,7 +1148,7 @@ machine_at_arb1479_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/arb1479/1479a.rom",
+    ret = bios_load_linear("roms/machines/arb1479/1479a.rom",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -1176,7 +1176,7 @@ machine_at_pcm9340_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/pcm9340/9340v110.bin",
+    ret = bios_load_linear("roms/machines/pcm9340/9340v110.bin",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -1205,7 +1205,7 @@ machine_at_pcm5330_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/pcm5330/5330_13b.bin",
+    ret = bios_load_linear("roms/machines/pcm5330/5330_13b.bin",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_commodore.c
+++ b/src/machine/m_at_commodore.c
@@ -98,8 +98,8 @@ machine_at_cmdpc_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/cmdpc30/commodore pc 30 iii even.bin",
-				L"roms/machines/cmdpc30/commodore pc 30 iii odd.bin",
+    ret = bios_load_interleaved("roms/machines/cmdpc30/commodore pc 30 iii even.bin",
+				"roms/machines/cmdpc30/commodore pc 30 iii odd.bin",
 				0x000f8000, 32768, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_compaq.c
+++ b/src/machine/m_at_compaq.c
@@ -852,8 +852,8 @@ machine_at_portableii_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleavedr(L"roms/machines/portableii/109740-001.rom",
-				L"roms/machines/portableii/109739-001.rom",
+    ret = bios_load_interleavedr("roms/machines/portableii/109740-001.rom",
+				"roms/machines/portableii/109739-001.rom",
 				0x000f8000, 65536, 0);
 
     if (bios_only || !ret)
@@ -870,8 +870,8 @@ machine_at_portableiii_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleavedr(L"roms/machines/portableiii/Compaq Portable III - BIOS - 106779-002 - Even.bin",
-				L"roms/machines/portableiii/Compaq Portable III - BIOS - 106778-002 - Odd.bin",
+    ret = bios_load_interleavedr("roms/machines/portableiii/Compaq Portable III - BIOS - 106779-002 - Even.bin",
+				"roms/machines/portableiii/Compaq Portable III - BIOS - 106778-002 - Odd.bin",
 				0x000f8000, 65536, 0);
 
     if (bios_only || !ret)
@@ -888,8 +888,8 @@ machine_at_portableiii386_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleavedr(L"roms/machines/portableiii/Compaq Portable III - BIOS - 106779-002 - Even.bin",
-				L"roms/machines/portableiii/Compaq Portable III - BIOS - 106778-002 - Odd.bin",
+    ret = bios_load_interleavedr("roms/machines/portableiii/Compaq Portable III - BIOS - 106779-002 - Even.bin",
+				"roms/machines/portableiii/Compaq Portable III - BIOS - 106778-002 - Odd.bin",
 				0x000f8000, 65536, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_ebga368.c
+++ b/src/machine/m_at_ebga368.c
@@ -44,7 +44,7 @@ machine_at_arb9673_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/arb9673/W9673.v12",
+    ret = bios_load_linear("roms/machines/arb9673/W9673.v12",
 			   0x00080000, 524288, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_misc.c
+++ b/src/machine/m_at_misc.c
@@ -43,7 +43,7 @@ machine_at_vpc2007_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/vpc2007/13500.bin",
+    ret = bios_load_linear("roms/machines/vpc2007/13500.bin",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -44,7 +44,7 @@ machine_at_p65up5_cpknd_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p65up5/ndkn0218.awd",
+    ret = bios_load_linear("roms/machines/p65up5/ndkn0218.awd",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -61,7 +61,7 @@ machine_at_kn97_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/kn97/0116I.001",
+    ret = bios_load_linear("roms/machines/kn97/0116I.001",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -95,7 +95,7 @@ machine_at_lx6_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/lx6/LX6C_PZ.B00",
+    ret = bios_load_linear("roms/machines/lx6/LX6C_PZ.B00",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -127,7 +127,7 @@ machine_at_spitfire_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/spitfire/SPIHM.02",
+    ret = bios_load_linear("roms/machines/spitfire/SPIHM.02",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -160,7 +160,7 @@ machine_at_p6i440e2_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p6i440e2/E2_v14sl.bin",
+    ret = bios_load_linear("roms/machines/p6i440e2/E2_v14sl.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -193,7 +193,7 @@ machine_at_p2bls_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p2bls/1014ls.003",
+    ret = bios_load_linear("roms/machines/p2bls/1014ls.003",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -231,7 +231,7 @@ machine_at_p3bf_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p3bf/1008f.004",
+    ret = bios_load_linear("roms/machines/p3bf/1008f.004",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -268,7 +268,7 @@ machine_at_bf6_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/bf6/Beh_70.bin",
+    ret = bios_load_linear("roms/machines/bf6/Beh_70.bin",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -303,7 +303,7 @@ machine_at_ax6bc_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ax6bc/AX6BC_R2.59.bin",
+    ret = bios_load_linear("roms/machines/ax6bc/AX6BC_R2.59.bin",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -337,7 +337,7 @@ machine_at_atc6310bxii_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/atc6310bxii/6310s102.bin",
+    ret = bios_load_linear("roms/machines/atc6310bxii/6310s102.bin",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -370,7 +370,7 @@ machine_at_686bx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/686bx/6BX.F2a",
+    ret = bios_load_linear("roms/machines/686bx/6BX.F2a",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -408,7 +408,7 @@ machine_at_p6sba_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p6sba/SBAB21.ROM",
+    ret = bios_load_linear("roms/machines/p6sba/SBAB21.ROM",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -447,7 +447,7 @@ machine_at_tsunamiatx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/tsunamiatx/bx46200f.rom",
+    ret = bios_load_linear("roms/machines/tsunamiatx/bx46200f.rom",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -492,7 +492,7 @@ machine_at_ergox365_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ergox365/M63v115.rom",
+    ret = bios_load_linear("roms/machines/ergox365/M63v115.rom",
 			   0x00080000, 524288, 0);
 
     if (bios_only || !ret)
@@ -523,7 +523,7 @@ machine_at_ficka6130_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ficka6130/qa4163.bin",
+    ret = bios_load_linear("roms/machines/ficka6130/qa4163.bin",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -555,7 +555,7 @@ machine_at_p3v133_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p3v133/1003.002",
+    ret = bios_load_linear("roms/machines/p3v133/1003.002",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -593,7 +593,7 @@ machine_at_p3v4x_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p3v4x/1006.004",
+    ret = bios_load_linear("roms/machines/p3v4x/1006.004",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -628,7 +628,7 @@ machine_at_vei8_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/vei8/QHW1001.BIN",
+    ret = bios_load_linear("roms/machines/vei8/QHW1001.BIN",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_slot2.c
+++ b/src/machine/m_at_slot2.c
@@ -43,7 +43,7 @@ machine_at_6gxu_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/6gxu/6gxu.f1c",
+    ret = bios_load_linear("roms/machines/6gxu/6gxu.f1c",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -82,7 +82,7 @@ machine_at_s2dge_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/s2dge/2gu7301.rom",
+    ret = bios_load_linear("roms/machines/s2dge/2gu7301.rom",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -120,7 +120,7 @@ machine_at_fw6400gx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/fw6400gx/fwgx1211.rom",
+    ret = bios_load_linear("roms/machines/fw6400gx/fwgx1211.rom",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_socket370.c
+++ b/src/machine/m_at_socket370.c
@@ -43,7 +43,7 @@ machine_at_s370slm_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/s370slm/3LM1202.rom",
+    ret = bios_load_linear("roms/machines/s370slm/3LM1202.rom",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -77,7 +77,7 @@ machine_at_trinity371_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/trinity371/BX57200A.ROM",
+    ret = bios_load_linear("roms/machines/trinity371/BX57200A.ROM",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -109,7 +109,7 @@ machine_at_p6bap_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p6bap/bapa14a.BIN",
+    ret = bios_load_linear("roms/machines/p6bap/bapa14a.BIN",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -140,7 +140,7 @@ machine_at_cubx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/cubx/1008cu.004",
+    ret = bios_load_linear("roms/machines/cubx/1008cu.004",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -176,7 +176,7 @@ machine_at_atc7020bxii_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/atc7020bxii/7020s102.bin",
+    ret = bios_load_linear("roms/machines/atc7020bxii/7020s102.bin",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -208,7 +208,7 @@ machine_at_ambx133_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ambx133/mkbx2vg2.bin",
+    ret = bios_load_linear("roms/machines/ambx133/mkbx2vg2.bin",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -240,7 +240,7 @@ machine_at_awo671r_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/awo671r/a08139c.bin",
+    ret = bios_load_linear("roms/machines/awo671r/a08139c.bin",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -273,7 +273,7 @@ machine_at_63a_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/63a1/63a-q3.bin",
+    ret = bios_load_linear("roms/machines/63a1/63a-q3.bin",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -305,7 +305,7 @@ machine_at_apas3_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/apas3/V0218SAG.BIN",
+    ret = bios_load_linear("roms/machines/apas3/V0218SAG.BIN",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -336,7 +336,7 @@ machine_at_wcf681_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/wcf681/681osda2.bin",
+    ret = bios_load_linear("roms/machines/wcf681/681osda2.bin",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -373,7 +373,7 @@ machine_at_cuv4xls_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/cuv4xls/1005LS.001",
+    ret = bios_load_linear("roms/machines/cuv4xls/1005LS.001",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -410,7 +410,7 @@ machine_at_6via90ap_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/6via90ap/90ap10.bin",
+    ret = bios_load_linear("roms/machines/6via90ap/90ap10.bin",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -447,7 +447,7 @@ machine_at_603tcf_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/603tcf/603tcfA4.BIN",
+    ret = bios_load_linear("roms/machines/603tcf/603tcfA4.BIN",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_socket4_5.c
+++ b/src/machine/m_at_socket4_5.c
@@ -47,7 +47,7 @@ machine_at_excalibur_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_inverted(L"roms/machines/excalibur/S75P.ROM",
+    ret = bios_load_linear_inverted("roms/machines/excalibur/S75P.ROM",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -112,8 +112,8 @@ machine_at_batman_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/revenge/1009af2_.bio",
-				    L"roms/machines/revenge/1009af2_.bi1", 0x1c000, 128);
+    ret = bios_load_linear_combined("roms/machines/revenge/1009af2_.bio",
+				    "roms/machines/revenge/1009af2_.bi1", 0x1c000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -131,7 +131,7 @@ machine_at_dellxp60_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_inverted(L"roms/machines/dellxp60/XP60-A08.ROM",
+    ret = bios_load_linear_inverted("roms/machines/dellxp60/XP60-A08.ROM",
 				    0x000e0000, 131072, 0);
 			   
     if (bios_only || !ret)
@@ -164,7 +164,7 @@ machine_at_opti560l_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_inverted(L"roms/machines/opti560l/560L_A06.ROM",
+    ret = bios_load_linear_inverted("roms/machines/opti560l/560L_A06.ROM",
 				    0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -194,8 +194,8 @@ machine_at_ambradp60_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/ambradp60/1004AF1P.BIO",
-				    L"roms/machines/ambradp60/1004AF1P.BI1", 0x1c000, 128);
+    ret = bios_load_linear_combined("roms/machines/ambradp60/1004AF1P.BIO",
+				    "roms/machines/ambradp60/1004AF1P.BI1", 0x1c000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -213,8 +213,8 @@ machine_at_valuepointp60_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/valuepointp60/1006AV0M.BIO",
-				    L"roms/machines/valuepointp60/1006AV0M.BI1", 0x1d000, 128);
+    ret = bios_load_linear_combined("roms/machines/valuepointp60/1006AV0M.BIO",
+				    "roms/machines/valuepointp60/1006AV0M.BI1", 0x1d000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -245,8 +245,8 @@ machine_at_pb520r_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/pb520r/1009bc0r.bio",
-				    L"roms/machines/pb520r/1009bc0r.bi1", 0x1c000, 128);
+    ret = bios_load_linear_combined("roms/machines/pb520r/1009bc0r.bio",
+				    "roms/machines/pb520r/1009bc0r.bi1", 0x1c000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -287,7 +287,7 @@ machine_at_p5mp3_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p5mp3/0205.bin",
+    ret = bios_load_linear("roms/machines/p5mp3/0205.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -318,7 +318,7 @@ machine_at_586mc1_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/586mc1/IS.34",
+    ret = bios_load_linear("roms/machines/586mc1/IS.34",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -339,8 +339,8 @@ machine_at_plato_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/plato/1016ax1_.bio",
-				    L"roms/machines/plato/1016ax1_.bi1", 0x1d000, 128);
+    ret = bios_load_linear_combined("roms/machines/plato/1016ax1_.bio",
+				    "roms/machines/plato/1016ax1_.bi1", 0x1d000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -358,8 +358,8 @@ machine_at_ambradp90_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/ambradp90/1002AX1P.BIO",
-				    L"roms/machines/ambradp90/1002AX1P.BI1", 0x1d000, 128);
+    ret = bios_load_linear_combined("roms/machines/ambradp90/1002AX1P.BIO",
+				    "roms/machines/ambradp90/1002AX1P.BI1", 0x1d000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -377,7 +377,7 @@ machine_at_430nx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/430nx/IP.20",
+    ret = bios_load_linear("roms/machines/430nx/IP.20",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -398,7 +398,7 @@ machine_at_p54tp4xe_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p54tp4xe/t15i0302.awd",
+    ret = bios_load_linear("roms/machines/p54tp4xe/t15i0302.awd",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -429,8 +429,8 @@ machine_at_endeavor_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/endeavor/1006cb0_.bio",
-				    L"roms/machines/endeavor/1006cb0_.bi1", 0x1d000, 128);
+    ret = bios_load_linear_combined("roms/machines/endeavor/1006cb0_.bio",
+				    "roms/machines/endeavor/1006cb0_.bi1", 0x1d000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -471,8 +471,8 @@ machine_at_zappa_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/zappa/1006bs0_.bio",
-				    L"roms/machines/zappa/1006bs0_.bi1", 0x20000, 128);
+    ret = bios_load_linear_combined("roms/machines/zappa/1006bs0_.bio",
+				    "roms/machines/zappa/1006bs0_.bi1", 0x20000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -500,7 +500,7 @@ machine_at_mb500n_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/mb500n/031396s.bin",
+    ret = bios_load_linear("roms/machines/mb500n/031396s.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -530,7 +530,7 @@ machine_at_apollo_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/apollo/S728P.ROM",
+    ret = bios_load_linear("roms/machines/apollo/S728P.ROM",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -561,7 +561,7 @@ machine_at_vectra54_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/vectra54/GT0724.22",
+    ret = bios_load_linear("roms/machines/vectra54/GT0724.22",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -595,7 +595,7 @@ machine_at_powermate_v_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/powermate_v/BIOS.ROM",
+    ret = bios_load_linear("roms/machines/powermate_v/BIOS.ROM",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -624,7 +624,7 @@ machine_at_acerv30_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/acerv30/V30R01N9.BIN",
+    ret = bios_load_linear("roms/machines/acerv30/V30R01N9.BIN",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -679,7 +679,7 @@ machine_at_p5sp4_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p5sp4/0106.001",
+    ret = bios_load_linear("roms/machines/p5sp4/0106.001",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -696,7 +696,7 @@ machine_at_p54sp4_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p54sp4/SI5I0204.AWD",
+    ret = bios_load_linear("roms/machines/p54sp4/SI5I0204.AWD",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -713,7 +713,7 @@ machine_at_sq588_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/sq588/sq588b03.rom",
+    ret = bios_load_linear("roms/machines/sq588/sq588b03.rom",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -744,7 +744,7 @@ machine_at_hot539_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/hot539/539_R17.ROM",
+    ret = bios_load_linear("roms/machines/hot539/539_R17.ROM",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_socket7.c
+++ b/src/machine/m_at_socket7.c
@@ -50,7 +50,7 @@ machine_at_chariot_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/chariot/P5IV183.ROM",
+    ret = bios_load_linear("roms/machines/chariot/P5IV183.ROM",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -80,7 +80,7 @@ machine_at_mr586_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/mr586/TRITON.BIO",
+    ret = bios_load_linear("roms/machines/mr586/TRITON.BIO",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -132,8 +132,8 @@ machine_at_thor_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/thor/1006cn0_.bio",
-				    L"roms/machines/thor/1006cn0_.bi1", 0x20000, 128);
+    ret = bios_load_linear_combined("roms/machines/thor/1006cn0_.bio",
+				    "roms/machines/thor/1006cn0_.bi1", 0x20000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -149,8 +149,8 @@ machine_at_gw2katx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/gw2katx/1003cn0t.bio",
-				    L"roms/machines/gw2katx/1003cn0t.bi1", 0x20000, 128);
+    ret = bios_load_linear_combined("roms/machines/gw2katx/1003cn0t.bio",
+				    "roms/machines/gw2katx/1003cn0t.bi1", 0x20000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -166,7 +166,7 @@ machine_at_mrthor_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/mrthor/mr_atx.bio",
+    ret = bios_load_linear("roms/machines/mrthor/mr_atx.bio",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -183,8 +183,8 @@ machine_at_pb640_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined(L"roms/machines/pb640/1007CP0R.BIO",
-				    L"roms/machines/pb640/1007CP0R.BI1", 0x1d000, 128);
+    ret = bios_load_linear_combined("roms/machines/pb640/1007CP0R.BIO",
+				    "roms/machines/pb640/1007CP0R.BI1", 0x1d000, 128);
 
     if (bios_only || !ret)
 	return ret;
@@ -223,7 +223,7 @@ machine_at_acerm3a_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/acerm3a/r01-b3.bin",
+    ret = bios_load_linear("roms/machines/acerm3a/r01-b3.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -255,7 +255,7 @@ machine_at_acerv35n_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/acerv35n/v35nd1s1.bin",
+    ret = bios_load_linear("roms/machines/acerv35n/v35nd1s1.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -287,7 +287,7 @@ machine_at_ap53_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ap53/ap53r2c0.rom",
+    ret = bios_load_linear("roms/machines/ap53/ap53r2c0.rom",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -318,7 +318,7 @@ machine_at_p55t2p4_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p55t2p4/0207_j2.bin",
+    ret = bios_load_linear("roms/machines/p55t2p4/0207_j2.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -348,7 +348,7 @@ machine_at_p55t2s_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p55t2s/s6y08t.rom",
+    ret = bios_load_linear("roms/machines/p55t2s/s6y08t.rom",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -378,7 +378,7 @@ machine_at_8500tuc_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/8500tuc/Tuc0221b.rom",
+    ret = bios_load_linear("roms/machines/8500tuc/Tuc0221b.rom",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -408,7 +408,7 @@ machine_at_m7shi_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/m7shi/m7shi2n.rom",
+    ret = bios_load_linear("roms/machines/m7shi/m7shi2n.rom",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -437,11 +437,11 @@ machine_at_tc430hx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined2(L"roms/machines/tc430hx/1007dh0_.bio",
-				     L"roms/machines/tc430hx/1007dh0_.bi1",
-				     L"roms/machines/tc430hx/1007dh0_.bi2",
-				     L"roms/machines/tc430hx/1007dh0_.bi3",
-				     L"roms/machines/tc430hx/1007dh0_.rcv",
+    ret = bios_load_linear_combined2("roms/machines/tc430hx/1007dh0_.bio",
+				     "roms/machines/tc430hx/1007dh0_.bi1",
+				     "roms/machines/tc430hx/1007dh0_.bi2",
+				     "roms/machines/tc430hx/1007dh0_.bi3",
+				     "roms/machines/tc430hx/1007dh0_.rcv",
 				     0x3a000, 128);
 
     if (bios_only || !ret)
@@ -472,11 +472,11 @@ machine_at_equium5200_init(const machine_t *model) // Information about that mac
 {
     int ret;
 
-    ret = bios_load_linear_combined2(L"roms/machines/equium5200/1003DK08.BIO",
-				     L"roms/machines/equium5200/1003DK08.BI1",
-				     L"roms/machines/equium5200/1003DK08.BI2",
-				     L"roms/machines/equium5200/1003DK08.BI3",
-				     L"roms/machines/equium5200/1003DK08.RCV",
+    ret = bios_load_linear_combined2("roms/machines/equium5200/1003DK08.BIO",
+				     "roms/machines/equium5200/1003DK08.BI1",
+				     "roms/machines/equium5200/1003DK08.BI2",
+				     "roms/machines/equium5200/1003DK08.BI3",
+				     "roms/machines/equium5200/1003DK08.RCV",
 				     0x3a000, 128);
 
     if (bios_only || !ret)
@@ -506,11 +506,11 @@ machine_at_pcv240_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined2(L"roms/machines/pcv240/1010DD04.BIO",
-				     L"roms/machines/pcv240/1010DD04.BI1",
-				     L"roms/machines/pcv240/1010DD04.BI2",
-				     L"roms/machines/pcv240/1010DD04.BI3",
-				     L"roms/machines/pcv240/1010DD04.RCV",
+    ret = bios_load_linear_combined2("roms/machines/pcv240/1010DD04.BIO",
+				     "roms/machines/pcv240/1010DD04.BI1",
+				     "roms/machines/pcv240/1010DD04.BI2",
+				     "roms/machines/pcv240/1010DD04.BI3",
+				     "roms/machines/pcv240/1010DD04.RCV",
 				     0x3a000, 128);
 
     if (bios_only || !ret)
@@ -540,7 +540,7 @@ machine_at_p65up5_cp55t2d_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p65up5/td5i0201.awd",
+    ret = bios_load_linear("roms/machines/p65up5/td5i0201.awd",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -556,7 +556,7 @@ machine_at_p55tvp4_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p55tvp4/0204_128.BIN",
+    ret = bios_load_linear("roms/machines/p55tvp4/0204_128.BIN",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -585,7 +585,7 @@ machine_at_5ivg_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/5ivg/5IVG.BIN",
+    ret = bios_load_linear("roms/machines/5ivg/5IVG.BIN",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -613,7 +613,7 @@ machine_at_i430vx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/430vx/55xwuq0e.bin",
+    ret = bios_load_linear("roms/machines/430vx/55xwuq0e.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -642,7 +642,7 @@ machine_at_p55va_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p55va/va021297.bin",
+    ret = bios_load_linear("roms/machines/p55va/va021297.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -671,7 +671,7 @@ machine_at_brio80xx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/brio80xx/Hf0705.rom",
+    ret = bios_load_linear("roms/machines/brio80xx/Hf0705.rom",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -700,7 +700,7 @@ machine_at_8500tvxa_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/8500tvxa/tvx0619b.rom",
+    ret = bios_load_linear("roms/machines/8500tvxa/tvx0619b.rom",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -729,7 +729,7 @@ machine_at_presario4500_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/presario4500/B013300I.ROM",
+    ret = bios_load_linear("roms/machines/presario4500/B013300I.ROM",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -757,11 +757,11 @@ machine_at_pb680_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined2(L"roms/machines/pb680/1012DN0R.BIO",
-				     L"roms/machines/pb680/1012DN0R.BI1",
-				     L"roms/machines/pb680/1012DN0R.BI2",
-				     L"roms/machines/pb680/1012DN0R.BI3",
-				     L"roms/machines/pb680/1012DN0R.RCV",
+    ret = bios_load_linear_combined2("roms/machines/pb680/1012DN0R.BIO",
+				     "roms/machines/pb680/1012DN0R.BI1",
+				     "roms/machines/pb680/1012DN0R.BI2",
+				     "roms/machines/pb680/1012DN0R.BI3",
+				     "roms/machines/pb680/1012DN0R.RCV",
 				     0x3a000, 128);
 
     if (bios_only || !ret)
@@ -791,11 +791,11 @@ machine_at_gw2kte_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined2(L"roms/machines/gw2kte/1008CY1T.BIO",
-				     L"roms/machines/gw2kte/1008CY1T.BI1",
-				     L"roms/machines/gw2kte/1008CY1T.BI2",
-				     L"roms/machines/gw2kte/1008CY1T.BI3",
-				     L"roms/machines/gw2kte/1008CY1T.RCV",
+    ret = bios_load_linear_combined2("roms/machines/gw2kte/1008CY1T.BIO",
+				     "roms/machines/gw2kte/1008CY1T.BI1",
+				     "roms/machines/gw2kte/1008CY1T.BI2",
+				     "roms/machines/gw2kte/1008CY1T.BI3",
+				     "roms/machines/gw2kte/1008CY1T.RCV",
 				     0x3a000, 128);
 
     if (bios_only || !ret)
@@ -826,7 +826,7 @@ machine_at_nupro592_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/nupro592/np590b10.bin",
+    ret = bios_load_linear("roms/machines/nupro592/np590b10.bin",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -863,7 +863,7 @@ machine_at_tx97_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/tx97/0112.001",
+    ret = bios_load_linear("roms/machines/tx97/0112.001",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -903,7 +903,7 @@ machine_at_ym430tx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ym430tx/YM430TX.003",
+    ret = bios_load_linear("roms/machines/ym430tx/YM430TX.003",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -937,11 +937,11 @@ machine_at_an430tx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined2(L"roms/machines/an430tx/P10-0095.BIO",
-				     L"roms/machines/an430tx/P10-0095.BI1",
-				     L"roms/machines/an430tx/P10-0095.BI2",
-				     L"roms/machines/an430tx/P10-0095.BI3",
-				     L"roms/machines/an430tx/P10-0095.RCV",
+    ret = bios_load_linear_combined2("roms/machines/an430tx/P10-0095.BIO",
+				     "roms/machines/an430tx/P10-0095.BI1",
+				     "roms/machines/an430tx/P10-0095.BI2",
+				     "roms/machines/an430tx/P10-0095.BI3",
+				     "roms/machines/an430tx/P10-0095.RCV",
 				     0x3a000, 160);
 
     if (bios_only || !ret)
@@ -974,7 +974,7 @@ machine_at_mb540n_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/mb540n/Tx0720ug.bin",
+    ret = bios_load_linear("roms/machines/mb540n/Tx0720ug.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -1005,7 +1005,7 @@ machine_at_p5mms98_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p5mms98/s981182.rom",
+    ret = bios_load_linear("roms/machines/p5mms98/s981182.rom",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -1038,7 +1038,7 @@ machine_at_m560_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/m560/5600410s.ami",
+    ret = bios_load_linear("roms/machines/m560/5600410s.ami",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -1071,7 +1071,7 @@ machine_at_ms5164_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ms5164/W564MS43.005",
+    ret = bios_load_linear("roms/machines/ms5164/W564MS43.005",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -1107,7 +1107,7 @@ machine_at_r534f_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/r534f/r534f008.bin",
+    ret = bios_load_linear("roms/machines/r534f/r534f008.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -1137,7 +1137,7 @@ machine_at_ms5146_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ms5146/A546MS11.ROM",
+    ret = bios_load_linear("roms/machines/ms5146/A546MS11.ROM",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -1167,7 +1167,7 @@ machine_at_ficva502_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ficva502/VA502bp.BIN",
+    ret = bios_load_linear("roms/machines/ficva502/VA502bp.BIN",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -1198,7 +1198,7 @@ machine_at_ficpa2012_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ficpa2012/113jb16.awd",
+    ret = bios_load_linear("roms/machines/ficpa2012/113jb16.awd",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_socket8.c
+++ b/src/machine/m_at_socket8.c
@@ -43,7 +43,7 @@ machine_at_p6rp4_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p6rp4/OR6I0106.SMC",
+    ret = bios_load_linear("roms/machines/p6rp4/OR6I0106.SMC",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -76,7 +76,7 @@ machine_at_686nx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/686nx/6nx.140",
+    ret = bios_load_linear("roms/machines/686nx/6nx.140",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -106,7 +106,7 @@ machine_at_mb600n_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/mb600n/60915cs.rom",
+    ret = bios_load_linear("roms/machines/mb600n/60915cs.rom",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -135,7 +135,7 @@ machine_at_v60n_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/v60n/V60NE5.BIN",
+    ret = bios_load_linear("roms/machines/v60n/V60NE5.BIN",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -165,11 +165,11 @@ machine_at_vs440fx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined2(L"roms/machines/vs440fx/1018CS1_.bio",
-				     L"roms/machines/vs440fx/1018CS1_.bi1",
-				     L"roms/machines/vs440fx/1018CS1_.bi2",
-				     L"roms/machines/vs440fx/1018CS1_.bi3",
-				     L"roms/machines/vs440fx/1018CS1_.rcv",
+    ret = bios_load_linear_combined2("roms/machines/vs440fx/1018CS1_.bio",
+				     "roms/machines/vs440fx/1018CS1_.bi1",
+				     "roms/machines/vs440fx/1018CS1_.bi2",
+				     "roms/machines/vs440fx/1018CS1_.bi3",
+				     "roms/machines/vs440fx/1018CS1_.rcv",
 				     0x3a000, 128);
 
     if (bios_only || !ret)
@@ -199,11 +199,11 @@ machine_at_ap440fx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined2(L"roms/machines/ap440fx/1011CT1_.bio",
-				     L"roms/machines/ap440fx/1011CT1_.bi1",
-				     L"roms/machines/ap440fx/1011CT1_.bi2",
-				     L"roms/machines/ap440fx/1011CT1_.bi3",
-				     L"roms/machines/ap440fx/1011CT1_.rcv",
+    ret = bios_load_linear_combined2("roms/machines/ap440fx/1011CT1_.bio",
+				     "roms/machines/ap440fx/1011CT1_.bi1",
+				     "roms/machines/ap440fx/1011CT1_.bi2",
+				     "roms/machines/ap440fx/1011CT1_.bi3",
+				     "roms/machines/ap440fx/1011CT1_.rcv",
 				     0x3a000, 128);
 
     if (bios_only || !ret)
@@ -232,7 +232,7 @@ machine_at_8500ttc_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/8500ttc/TTC0715B.ROM",
+    ret = bios_load_linear("roms/machines/8500ttc/TTC0715B.ROM",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -261,7 +261,7 @@ machine_at_m6mi_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/m6mi/M6MI05.ROM",
+    ret = bios_load_linear("roms/machines/m6mi/M6MI05.ROM",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -311,7 +311,7 @@ machine_at_p65up5_cp6nd_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/p65up5/nd6i0218.awd",
+    ret = bios_load_linear("roms/machines/p65up5/nd6i0218.awd",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_sockets7.c
+++ b/src/machine/m_at_sockets7.c
@@ -47,7 +47,7 @@ machine_at_ax59pro_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ax59pro/AX59P236.BIN",
+    ret = bios_load_linear("roms/machines/ax59pro/AX59P236.BIN",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)
@@ -80,7 +80,7 @@ machine_at_mvp3_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ficva503p/je4333.bin",
+    ret = bios_load_linear("roms/machines/ficva503p/je4333.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -112,7 +112,7 @@ machine_at_ficva503a_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ficva503a/jo4116.bin",
+    ret = bios_load_linear("roms/machines/ficva503a/jo4116.bin",
 			   0x000c0000, 262144, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_t3100e.c
+++ b/src/machine/m_at_t3100e.c
@@ -749,7 +749,7 @@ int machine_at_t3100e_init(const machine_t *model)
 {
 	int ret;
 
-	ret = bios_load_linear(L"roms/machines/t3100e/t3100e.rom",
+	ret = bios_load_linear("roms/machines/t3100e/t3100e.rom",
 			       0x000f0000, 65536, 0);
 
 	if (bios_only || !ret)

--- a/src/machine/m_at_t3100e_vid.c
+++ b/src/machine/m_at_t3100e_vid.c
@@ -713,7 +713,7 @@ void *t3100e_init(const device_t *info)
 {
         t3100e_t *t3100e = malloc(sizeof(t3100e_t));
         memset(t3100e, 0, sizeof(t3100e_t));
-	loadfont(L"roms/machines/t3100e/t3100e_font.bin", 5);
+	loadfont("roms/machines/t3100e/t3100e_font.bin", 5);
 	cga_init(&t3100e->cga);
 	video_inform(VIDEO_FLAG_TYPE_CGA, &timing_t3100e);
 

--- a/src/machine/m_europc.c
+++ b/src/machine/m_europc.c
@@ -710,7 +710,7 @@ machine_europc_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/europc/50145",
+    ret = bios_load_linear("roms/machines/europc/50145",
 			   0x000f8000, 32768, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_pcjr.c
+++ b/src/machine/m_pcjr.c
@@ -806,7 +806,7 @@ machine_pcjr_init(const machine_t *model)
 
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ibmpcjr/bios.rom",
+    ret = bios_load_linear("roms/machines/ibmpcjr/bios.rom",
 			   0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
@@ -824,7 +824,7 @@ machine_pcjr_init(const machine_t *model)
     cpu_set();
 
     /* Initialize the video controller. */
-    loadfont(L"roms/video/mda/mda.rom", 0);
+    loadfont("roms/video/mda/mda.rom", 0);
     mem_mapping_add(&pcjr->mapping, 0xb8000, 0x08000,
 		    vid_read, NULL, NULL,
 		    vid_write, NULL, NULL,  NULL, 0, pcjr);

--- a/src/machine/m_ps1.c
+++ b/src/machine/m_ps1.c
@@ -460,7 +460,7 @@ ps1_setup(int model)
 
     if (model == 2011) {
 	rom_init(&ps->high_rom,
-		 L"roms/machines/ibmps1es/f80000.bin",
+		 "roms/machines/ibmps1es/f80000.bin",
 		 0xf80000, 0x80000, 0x7ffff, 0, MEM_MAPPING_EXTERNAL);
 
 	lpt2_remove();
@@ -483,7 +483,7 @@ ps1_setup(int model)
 		      ps1_read, NULL, NULL, ps1_write, NULL, NULL, ps);
 
 	rom_init(&ps->high_rom,
-		 L"roms/machines/ibmps1_2121/fc0000.bin",
+		 "roms/machines/ibmps1_2121/fc0000.bin",
 		 0xfc0000, 0x20000, 0x1ffff, 0, MEM_MAPPING_EXTERNAL);
 
 	/* Initialize the video controller. */
@@ -526,7 +526,7 @@ machine_ps1_m2011_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ibmps1es/f80000.bin",
+    ret = bios_load_linear("roms/machines/ibmps1es/f80000.bin",
 			   0x000e0000, 131072, 0x60000);
 
     if (bios_only || !ret)
@@ -545,7 +545,7 @@ machine_ps1_m2121_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ibmps1_2121/fc0000.bin",
+    ret = bios_load_linear("roms/machines/ibmps1_2121/fc0000.bin",
 			   0x000e0000, 131072, 0x20000);
 
     if (bios_only || !ret)
@@ -564,7 +564,7 @@ machine_ps1_m2133_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ibmps1_2133/ps1_2133_52g2974_rom.bin",
+    ret = bios_load_linear("roms/machines/ibmps1_2133/ps1_2133_52g2974_rom.bin",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_ps2_isa.c
+++ b/src/machine/m_ps2_isa.c
@@ -171,7 +171,7 @@ machine_ps2_m30_286_init(const machine_t *model)
 
 	int ret;
 
-	ret = bios_load_linear(L"roms/machines/ibmps2_m30_286/33f5381a.bin",
+	ret = bios_load_linear("roms/machines/ibmps2_m30_286/33f5381a.bin",
 			       0x000e0000, 131072, 0);
 
 	if (bios_only || !ret)

--- a/src/machine/m_ps2_mca.c
+++ b/src/machine/m_ps2_mca.c
@@ -1282,11 +1282,11 @@ machine_ps2_model_50_init(const machine_t *model)
 {
 	int ret;
 
-	ret = bios_load_interleaved(L"roms/machines/ibmps2_m50/90x7420.zm13",
-				    L"roms/machines/ibmps2_m50/90x7429.zm18",
+	ret = bios_load_interleaved("roms/machines/ibmps2_m50/90x7420.zm13",
+				    "roms/machines/ibmps2_m50/90x7429.zm18",
 				    0x000f0000, 131072, 0);
-	ret &= bios_load_aux_interleaved(L"roms/machines/ibmps2_m50/90x7423.zm14",
-					 L"roms/machines/ibmps2_m50/90x7426.zm16",
+	ret &= bios_load_aux_interleaved("roms/machines/ibmps2_m50/90x7423.zm14",
+					 "roms/machines/ibmps2_m50/90x7426.zm16",
 					 0x000e0000, 65536, 0);
 
 	if (bios_only || !ret)
@@ -1305,8 +1305,8 @@ machine_ps2_model_55sx_init(const machine_t *model)
 {
 	int ret;
 
-	ret = bios_load_interleaved(L"roms/machines/ibmps2_m55sx/33f8146.zm41",
-				    L"roms/machines/ibmps2_m55sx/33f8145.zm40",
+	ret = bios_load_interleaved("roms/machines/ibmps2_m55sx/33f8146.zm41",
+				    "roms/machines/ibmps2_m55sx/33f8145.zm40",
 				    0x000e0000, 131072, 0);
 
 	if (bios_only || !ret)
@@ -1325,8 +1325,8 @@ machine_ps2_model_70_type3_init(const machine_t *model)
 {
 	int ret;
 
-	ret = bios_load_interleaved(L"roms/machines/ibmps2_m70_type3/70-a_even.bin",
-				    L"roms/machines/ibmps2_m70_type3/70-a_odd.bin",
+	ret = bios_load_interleaved("roms/machines/ibmps2_m70_type3/70-a_even.bin",
+				    "roms/machines/ibmps2_m70_type3/70-a_odd.bin",
 				    0x000e0000, 131072, 0);
 
 	if (bios_only || !ret)
@@ -1346,8 +1346,8 @@ machine_ps2_model_70_type4_init(const machine_t *model)
 {
 	int ret;
 
-	ret = bios_load_interleaved(L"roms/machines/ibmps2_m70_type4/70-b_even.bin",
-				    L"roms/machines/ibmps2_m70_type4/70-b_odd.bin",
+	ret = bios_load_interleaved("roms/machines/ibmps2_m70_type4/70-b_even.bin",
+				    "roms/machines/ibmps2_m70_type4/70-b_odd.bin",
 				    0x000e0000, 131072, 0);
 
 	if (bios_only || !ret)
@@ -1367,8 +1367,8 @@ machine_ps2_model_80_init(const machine_t *model)
 {
 	int ret;
 
-	ret = bios_load_interleaved(L"roms/machines/ibmps2_m80/15f6637.bin",
-				    L"roms/machines/ibmps2_m80/15f6639.bin",
+	ret = bios_load_interleaved("roms/machines/ibmps2_m80/15f6637.bin",
+				    "roms/machines/ibmps2_m80/15f6639.bin",
 				    0x000e0000, 131072, 0);
 
 	if (bios_only || !ret)

--- a/src/machine/m_tandy.c
+++ b/src/machine/m_tandy.c
@@ -105,7 +105,7 @@ typedef struct {
 } t1kvid_t;
 
 typedef struct {
-    wchar_t		*path;
+    char		*path;
 
     int			state;
     int			count;
@@ -1286,16 +1286,16 @@ eep_init(const device_t *info)
 
     switch (info->local) {
 	case TYPE_TANDY1000HX:
-		eep->path = L"tandy1000hx.bin";
+		eep->path = "tandy1000hx.bin";
 		break;
 
 	case TYPE_TANDY1000SL2:
-		eep->path = L"tandy1000sl2.bin";
+		eep->path = "tandy1000sl2.bin";
 		break;
 
     }
 
-    f = nvr_fopen(eep->path, L"rb");
+    f = nvr_fopen(eep->path, "rb");
     if (f != NULL) {
 	if (fread(eep->store, 1, 128, f) != 128)
 		fatal("eep_init(): Error reading Tandy EEPROM\n");
@@ -1315,7 +1315,7 @@ eep_close(void *priv)
     t1keep_t *eep = (t1keep_t *)priv;
     FILE *f = NULL;
 
-    f = nvr_fopen(eep->path, L"wb");
+    f = nvr_fopen(eep->path, "wb");
     if (f != NULL) {
 	(void)fwrite(eep->store, 128, 1, f);
 	(void)fclose(f);
@@ -1452,8 +1452,8 @@ init_rom(tandy_t *dev)
     dev->rom = (uint8_t *)malloc(0x80000);
 
 #if 1
-    if (! rom_load_interleaved(L"roms/machines/tandy1000sl2/8079047.hu1",
-			       L"roms/machines/tandy1000sl2/8079048.hu2",
+    if (! rom_load_interleaved("roms/machines/tandy1000sl2/8079047.hu1",
+			       "roms/machines/tandy1000sl2/8079048.hu2",
 			       0x000000, 0x80000, 0, dev->rom)) {
 	tandy_log("TANDY: unable to load BIOS for 1000/SL2 !\n");
 	free(dev->rom);
@@ -1461,8 +1461,8 @@ init_rom(tandy_t *dev)
 	return;
     }
 #else
-    f  = rom_fopen(L"roms/machines/tandy1000sl2/8079047.hu1", L"rb");
-    ff = rom_fopen(L"roms/machines/tandy1000sl2/8079048.hu2", L"rb");
+    f  = rom_fopen("roms/machines/tandy1000sl2/8079047.hu1", "rb");
+    ff = rom_fopen("roms/machines/tandy1000sl2/8079048.hu2", "rb");
     for (c = 0x0000; c < 0x80000; c += 2) {
 	dev->rom[c] = getc(f);
 	dev->rom[c + 1] = getc(ff);
@@ -1554,7 +1554,7 @@ machine_tandy_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linearr(L"roms/machines/tandy/tandy1t1.020",
+    ret = bios_load_linearr("roms/machines/tandy/tandy1t1.020",
 			    0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -1571,7 +1571,7 @@ machine_tandy1000hx_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/tandy1000hx/v020000.u12",
+    ret = bios_load_linear("roms/machines/tandy1000hx/v020000.u12",
 			   0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -1588,8 +1588,8 @@ machine_tandy1000sl2_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/tandy1000sl2/8079047.hu1",
-				L"roms/machines/tandy1000sl2/8079048.hu2",
+    ret = bios_load_interleaved("roms/machines/tandy1000sl2/8079047.hu1",
+				"roms/machines/tandy1000sl2/8079048.hu2",
 				0x000f0000, 65536, 0x18000);
 
     if (bios_only || !ret)

--- a/src/machine/m_xt.c
+++ b/src/machine/m_xt.c
@@ -40,16 +40,16 @@ machine_pc_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ibmpc/BIOS_5150_24APR81_U33.BIN",
+    ret = bios_load_linear("roms/machines/ibmpc/BIOS_5150_24APR81_U33.BIN",
 			   0x000fe000, 40960, 0);
     if (ret) {
-	bios_load_aux_linear(L"roms/machines/ibmpc/IBM 5150 - Cassette BASIC version C1.00 - U29 - 5700019.bin",
+	bios_load_aux_linear("roms/machines/ibmpc/IBM 5150 - Cassette BASIC version C1.00 - U29 - 5700019.bin",
 			     0x000f6000, 8192, 0);
-	bios_load_aux_linear(L"roms/machines/ibmpc/IBM 5150 - Cassette BASIC version C1.00 - U30 - 5700027.bin",
+	bios_load_aux_linear("roms/machines/ibmpc/IBM 5150 - Cassette BASIC version C1.00 - U30 - 5700027.bin",
 			     0x000f8000, 8192, 0);
-	bios_load_aux_linear(L"roms/machines/ibmpc/IBM 5150 - Cassette BASIC version C1.00 - U31 - 5700035.bin",
+	bios_load_aux_linear("roms/machines/ibmpc/IBM 5150 - Cassette BASIC version C1.00 - U31 - 5700035.bin",
 			     0x000fa000, 8192, 0);
-	bios_load_aux_linear(L"roms/machines/ibmpc/IBM 5150 - Cassette BASIC version C1.00 - U32 - 5700043.bin",
+	bios_load_aux_linear("roms/machines/ibmpc/IBM 5150 - Cassette BASIC version C1.00 - U32 - 5700043.bin",
 			     0x000fc000, 8192, 0);
     }
 
@@ -69,19 +69,19 @@ machine_pc82_init(const machine_t *model)
 {
     int ret, ret2;
 
-    ret = bios_load_linear(L"roms/machines/ibmpc82/pc102782.bin",
+    ret = bios_load_linear("roms/machines/ibmpc82/pc102782.bin",
 			   0x000fe000, 40960, 0);
     if (ret) {
-	ret2 = bios_load_aux_linear(L"roms/machines/ibmpc82/ibm-basic-1.10.rom",
+	ret2 = bios_load_aux_linear("roms/machines/ibmpc82/ibm-basic-1.10.rom",
 				    0x000f6000, 32768, 0);
 	if (!ret2) {
-		bios_load_aux_linear(L"roms/machines/ibmpc82/basicc11.f6",
+		bios_load_aux_linear("roms/machines/ibmpc82/basicc11.f6",
 				     0x000f6000, 8192, 0);
-		bios_load_aux_linear(L"roms/machines/ibmpc82/basicc11.f8",
+		bios_load_aux_linear("roms/machines/ibmpc82/basicc11.f8",
 				     0x000f8000, 8192, 0);
-		bios_load_aux_linear(L"roms/machines/ibmpc82/basicc11.fa",
+		bios_load_aux_linear("roms/machines/ibmpc82/basicc11.fa",
 				     0x000fa000, 8192, 0);
-		bios_load_aux_linear(L"roms/machines/ibmpc82/basicc11.fc",
+		bios_load_aux_linear("roms/machines/ibmpc82/basicc11.fc",
 				     0x000fc000, 8192, 0);
 	}
     }
@@ -112,15 +112,15 @@ machine_xt_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ibmxt/xt.rom",
+    ret = bios_load_linear("roms/machines/ibmxt/xt.rom",
 			   0x000f0000, 65536, 0);
     if (!ret) {
-	ret = bios_load_linear(L"roms/machines/ibmxt/1501512.u18",
+	ret = bios_load_linear("roms/machines/ibmxt/1501512.u18",
 			       0x000fe000, 65536, 0x6000);
 	if (ret) {
-		bios_load_aux_linear(L"roms/machines/ibmxt/1501512.u18",
+		bios_load_aux_linear("roms/machines/ibmxt/1501512.u18",
 				     0x000f8000, 24576, 0);
-		bios_load_aux_linear(L"roms/machines/ibmxt/5000027.u19",
+		bios_load_aux_linear("roms/machines/ibmxt/5000027.u19",
 				     0x000f0000, 32768, 0);
 	}
     }
@@ -141,7 +141,7 @@ machine_genxt_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/genxt/pcxt.rom",
+    ret = bios_load_linear("roms/machines/genxt/pcxt.rom",
 			   0x000fe000, 8192, 0);
 
     if (bios_only || !ret)
@@ -157,12 +157,12 @@ machine_xt86_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ibmxt86/BIOS_5160_09MAY86_U18_59X7268_62X0890_27256_F800.BIN",
+    ret = bios_load_linear("roms/machines/ibmxt86/BIOS_5160_09MAY86_U18_59X7268_62X0890_27256_F800.BIN",
 			   0x000fe000, 65536, 0x6000);
     if (ret) {
-	(void) bios_load_aux_linear(L"roms/machines/ibmxt86/BIOS_5160_09MAY86_U18_59X7268_62X0890_27256_F800.BIN",
+	(void) bios_load_aux_linear("roms/machines/ibmxt86/BIOS_5160_09MAY86_U18_59X7268_62X0890_27256_F800.BIN",
 				    0x000f8000, 24576, 0);
-	(void) bios_load_aux_linear(L"roms/machines/ibmxt86/BIOS_5160_09MAY86_U19_62X0819_68X4370_27256_F000.BIN",
+	(void) bios_load_aux_linear("roms/machines/ibmxt86/BIOS_5160_09MAY86_U19_62X0819_68X4370_27256_F000.BIN",
 				    0x000f0000, 32768, 0);
     }
 
@@ -191,7 +191,7 @@ machine_xt_americxt_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/americxt/AMERICXT.ROM",
+    ret = bios_load_linear("roms/machines/americxt/AMERICXT.ROM",
 			   0x000fe000, 8192, 0);
 
     if (bios_only || !ret)
@@ -207,7 +207,7 @@ machine_xt_amixt_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/amixt/ami_8088_bios_31jan89.bin",
+    ret = bios_load_linear("roms/machines/amixt/ami_8088_bios_31jan89.bin",
 			   0x000fe000, 8192, 0);
 
     if (bios_only || !ret)
@@ -224,7 +224,7 @@ machine_xt_dtk_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/dtk/dtk_erso_2.42_2764.bin",
+    ret = bios_load_linear("roms/machines/dtk/dtk_erso_2.42_2764.bin",
 			   0x000fe000, 8192, 0);
 
     if (bios_only || !ret)
@@ -241,7 +241,7 @@ machine_xt_jukopc_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/jukopc/000o001.bin",
+    ret = bios_load_linear("roms/machines/jukopc/000o001.bin",
 			   0x000fe000, 8192, 0);
 
     if (bios_only || !ret)
@@ -258,7 +258,7 @@ machine_xt_open_xt_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/open_xt/pcxt31.bin",
+    ret = bios_load_linear("roms/machines/open_xt/pcxt31.bin",
 			   0x000fe000, 8192, 0);
 
     if (bios_only || !ret)
@@ -276,7 +276,7 @@ machine_xt_hed919_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/hed919/Hedaka_HED-919_bios_version_3.28f.bin",
+    ret = bios_load_linear("roms/machines/hed919/Hedaka_HED-919_bios_version_3.28f.bin",
 			   0x000fe000, 8192, 0);
 
     if (bios_only || !ret)
@@ -296,7 +296,7 @@ machine_xt_pxxt_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/pxxt/000p001.bin",
+    ret = bios_load_linear("roms/machines/pxxt/000p001.bin",
 			   0x000fe000, 8192, 0);
 
     if (bios_only || !ret)
@@ -312,8 +312,8 @@ machine_xt_iskra3104_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/iskra3104/198.bin",
-    L"roms/machines/iskra3104/199.bin",
+    ret = bios_load_interleaved("roms/machines/iskra3104/198.bin",
+    "roms/machines/iskra3104/199.bin",
 			   0x000fc000, 16384, 0);
 
     if (bios_only || !ret)
@@ -329,7 +329,7 @@ machine_xt_ncrpc4i_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/ncr_pc4i/NCR_PC4i_BIOSROM_1985.bin",
+    ret = bios_load_linear("roms/machines/ncr_pc4i/NCR_PC4i_BIOSROM_1985.bin",
 			   0x000fc000, 16384, 0);
 
     if (bios_only || !ret)
@@ -345,7 +345,7 @@ machine_xt_mpc1600_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/mpc1600/mpc4.34_merged.bin",
+    ret = bios_load_linear("roms/machines/mpc1600/mpc4.34_merged.bin",
 			   0x000fc000, 16384, 0);
     
     if (bios_only || !ret)
@@ -364,11 +364,11 @@ machine_xt_eaglepcspirit_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/eagle_pcspirit/u1101.bin",
+    ret = bios_load_linear("roms/machines/eagle_pcspirit/u1101.bin",
 			   0x000fe000, 16384, 0);
     
     if (ret) {
-        bios_load_aux_linear(L"roms/machines/eagle_pcspirit/u1103.bin",
+        bios_load_aux_linear("roms/machines/eagle_pcspirit/u1103.bin",
 			     0x000fc000, 8192, 0);
     }
 
@@ -387,7 +387,7 @@ machine_xt_multitechpc700_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/multitech_pc700/multitech pc-700 3.1.bin",
+    ret = bios_load_linear("roms/machines/multitech_pc700/multitech pc-700 3.1.bin",
 			   0x000fe000, 8192, 0);
     
     if (bios_only || !ret)

--- a/src/machine/m_xt_compaq.c
+++ b/src/machine/m_xt_compaq.c
@@ -42,7 +42,7 @@ machine_xt_compaq_deskpro_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/deskpro/Compaq - BIOS - Revision J - 106265-002.bin",
+    ret = bios_load_linear("roms/machines/deskpro/Compaq - BIOS - Revision J - 106265-002.bin",
 			   0x000fe000, 8192, 0);
 
     if (bios_only || !ret)
@@ -71,7 +71,7 @@ machine_xt_compaq_portable_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/portable/compaq portable plus 100666-001 rev c u47.bin",
+    ret = bios_load_linear("roms/machines/portable/compaq portable plus 100666-001 rev c u47.bin",
 			   0x000fe000, 8192, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_xt_laserxt.c
+++ b/src/machine/m_xt_laserxt.c
@@ -140,7 +140,7 @@ machine_xt_laserxt_init(const machine_t *model)
 {
 	int ret;
 
-	ret = bios_load_linear(L"roms/machines/ltxt/27c64.bin",
+	ret = bios_load_linear("roms/machines/ltxt/27c64.bin",
 			       0x000fe000, 8192, 0);
 
 	if (bios_only || !ret)
@@ -159,7 +159,7 @@ machine_xt_lxt3_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/lxt3/27c64d.bin",
+    ret = bios_load_linear("roms/machines/lxt3/27c64d.bin",
 			   0x000fe000, 8192, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_xt_olivetti.c
+++ b/src/machine/m_xt_olivetti.c
@@ -537,7 +537,7 @@ m19_vid_init(olim19_vid_t *vid)
     /* display_type = device_get_config_int("display_type"); */
 
     /* OGC emulation part begin */
-    loadfont_ex(L"roms/machines/olivetti_m19/BIOS.BIN", 1, 90);
+    loadfont_ex("roms/machines/olivetti_m19/BIOS.BIN", 1, 90);
     /* composite is not working yet */
     vid->ogc.cga.composite = 0; // (display_type != CGA_RGB);
     /* vid->ogc.cga.snow_enabled = device_get_config_int("snow_enabled"); */
@@ -708,8 +708,8 @@ machine_xt_olim24_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/olivetti_m24/olivetti_m24_version_1.43_low.bin",
-				L"roms/machines/olivetti_m24/olivetti_m24_version_1.43_high.bin",
+    ret = bios_load_interleaved("roms/machines/olivetti_m24/olivetti_m24_version_1.43_low.bin",
+				"roms/machines/olivetti_m24/olivetti_m24_version_1.43_high.bin",
 				0x000fc000, 16384, 0);
 
     if (bios_only || !ret)
@@ -755,8 +755,8 @@ machine_xt_olim240_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved(L"roms/machines/olivetti_m240/olivetti_m240_pch6_2.04_low.bin",
-				L"roms/machines/olivetti_m240/olivetti_m240_pch5_2.04_high.bin",
+    ret = bios_load_interleaved("roms/machines/olivetti_m240/olivetti_m240_pch6_2.04_low.bin",
+				"roms/machines/olivetti_m240/olivetti_m240_pch5_2.04_high.bin",
 				0x000f8000, 32768, 0);
 
     if (bios_only || !ret)
@@ -800,7 +800,7 @@ machine_xt_olim19_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/olivetti_m19/BIOS.BIN",
+    ret = bios_load_linear("roms/machines/olivetti_m19/BIOS.BIN",
 			   0x000fc000, 16384, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_xt_philips.c
+++ b/src/machine/m_xt_philips.c
@@ -172,7 +172,7 @@ machine_xt_p3105_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/philips_p3105/philipsnms9100.bin",
+    ret = bios_load_linear("roms/machines/philips_p3105/philipsnms9100.bin",
 			   0x000fc000, 16384, 0);
     
     if (bios_only || !ret)
@@ -188,7 +188,7 @@ machine_xt_p3120_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/philips_p3120/philips_p3120.bin",
+    ret = bios_load_linear("roms/machines/philips_p3120/philips_p3120.bin",
 			   0x000f8000, 32768, 0);
     
     if (bios_only || !ret)

--- a/src/machine/m_xt_t1000.c
+++ b/src/machine/m_xt_t1000.c
@@ -857,7 +857,7 @@ machine_xt_t1000_init(const machine_t *model)
 
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/t1000/t1000.rom",
+    ret = bios_load_linear("roms/machines/t1000/t1000.rom",
 			   0x000f8000, 32768, 0);
 
     if (bios_only || !ret)
@@ -869,7 +869,7 @@ machine_xt_t1000_init(const machine_t *model)
     t1000.ems_port_index = 7;	/* EMS disabled */
 
     /* Load the T1000 CGA Font ROM. */
-    loadfont(L"roms/machines/t1000/t1000font.rom", 2);
+    loadfont("roms/machines/t1000/t1000font.rom", 2);
 
     /*
      * The ROM drive is optional.
@@ -877,7 +877,7 @@ machine_xt_t1000_init(const machine_t *model)
      * If the file is missing, continue to boot; the BIOS will
      * complain 'No ROM drive' but boot normally from floppy.
      */
-    f = rom_fopen(L"roms/machines/t1000/t1000dos.rom", L"rb");
+    f = rom_fopen("roms/machines/t1000/t1000dos.rom", "rb");
     if (f != NULL) {
 	t1000.romdrive = malloc(T1000_ROMSIZE);
 	if (t1000.romdrive) {
@@ -950,7 +950,7 @@ machine_xt_t1200_init(const machine_t *model)
 
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/t1200/t1200_019e.ic15.bin",
+    ret = bios_load_linear("roms/machines/t1200/t1200_019e.ic15.bin",
 			   0x000f8000, 32768, 0);
 
     if (bios_only || !ret)
@@ -961,7 +961,7 @@ machine_xt_t1200_init(const machine_t *model)
     t1000.ems_port_index = 7;	/* EMS disabled */
 
     /* Load the T1200 CGA Font ROM. */
-    loadfont(L"roms/machines/t1200/t1000font.bin", 2);
+    loadfont("roms/machines/t1200/t1000font.bin", 2);
 
     /* Map the EMS page frame */
     for (pg = 0; pg < 4; pg++) {
@@ -1020,7 +1020,7 @@ t1000_configsys_load(void)
     int size;
 
     memset(t1000.t1000_nvram, 0x1a, sizeof(t1000.t1000_nvram));
-    f = plat_fopen(nvr_path(L"t1000_config.nvr"), L"rb");
+    f = plat_fopen(nvr_path("t1000_config.nvr"), "rb");
     if (f != NULL) {
 	size = sizeof(t1000.t1000_nvram);
 	if (fread(t1000.t1000_nvram, 1, size, f) != size)
@@ -1036,7 +1036,7 @@ t1000_configsys_save(void)
     FILE *f;
     int size;
 
-    f = plat_fopen(nvr_path(L"t1000_config.nvr"), L"wb");
+    f = plat_fopen(nvr_path("t1000_config.nvr"), "wb");
     if (f != NULL) {
 	size = sizeof(t1000.t1000_nvram);
 	if (fwrite(t1000.t1000_nvram, 1, size, f) != size)
@@ -1053,7 +1053,7 @@ t1200_state_load(void)
     int size;
 
     memset(t1000.t1200_nvram, 0, sizeof(t1000.t1200_nvram));
-    f = plat_fopen(nvr_path(L"t1200_state.nvr"), L"rb");
+    f = plat_fopen(nvr_path("t1200_state.nvr"), "rb");
     if (f != NULL) {
 	size = sizeof(t1000.t1200_nvram);
 	if (fread(t1000.t1200_nvram, 1, size, f) != size)
@@ -1069,7 +1069,7 @@ t1200_state_save(void)
     FILE *f;
     int size;
 
-    f = plat_fopen(nvr_path(L"t1200_state.nvr"), L"wb");
+    f = plat_fopen(nvr_path("t1200_state.nvr"), "wb");
     if (f != NULL) {
 	size = sizeof(t1000.t1200_nvram);
 	if (fwrite(t1000.t1200_nvram, 1, size, f) != size)
@@ -1086,7 +1086,7 @@ t1000_emsboard_load(void)
     FILE *f;
 
     if (mem_size > 512) {
-	f = plat_fopen(nvr_path(L"t1000_ems.nvr"), L"rb");
+	f = plat_fopen(nvr_path("t1000_ems.nvr"), "rb");
 	if (f != NULL) {
 		fread(&ram[512 * 1024], 1024, (mem_size - 512), f);
 		fclose(f);
@@ -1101,7 +1101,7 @@ t1000_emsboard_save(void)
     FILE *f;
 
     if (mem_size > 512) {
-	f = plat_fopen(nvr_path(L"t1000_ems.nvr"), L"wb");
+	f = plat_fopen(nvr_path("t1000_ems.nvr"), "wb");
 	if (f != NULL) {
 		fwrite(&ram[512 * 1024], 1024, (mem_size - 512), f);
 		fclose(f);

--- a/src/machine/m_xt_t1000_vid.c
+++ b/src/machine/m_xt_t1000_vid.c
@@ -676,7 +676,7 @@ static void *t1000_init(const device_t *info)
 {
         t1000_t *t1000 = malloc(sizeof(t1000_t));
         memset(t1000, 0, sizeof(t1000_t));
-	loadfont(L"roms/machines/t1000/t1000font.bin", 8);
+	loadfont("roms/machines/t1000/t1000font.bin", 8);
 	cga_init(&t1000->cga);
 	video_inform(VIDEO_FLAG_TYPE_CGA, &timing_t1000);
 

--- a/src/machine/m_xt_xi8088.c
+++ b/src/machine/m_xt_xi8088.c
@@ -152,18 +152,18 @@ machine_xt_xi8088_init(const machine_t *model)
     int ret;
 
     if (bios_only) {
-	ret = bios_load_linear_inverted(L"roms/machines/xi8088/bios-xi8088-128k.bin",
+	ret = bios_load_linear_inverted("roms/machines/xi8088/bios-xi8088-128k.bin",
 					0x000e0000, 131072, 0);
-	ret |= bios_load_linear(L"roms/machines/xi8088/bios-xi8088.bin",
+	ret |= bios_load_linear("roms/machines/xi8088/bios-xi8088.bin",
 				0x000f0000, 65536, 0);
     } else {
 	device_add(&xi8088_device);
 
 	if (xi8088_bios_128kb()) {
-		ret = bios_load_linear_inverted(L"roms/machines/xi8088/bios-xi8088-128k.bin",
+		ret = bios_load_linear_inverted("roms/machines/xi8088/bios-xi8088-128k.bin",
 						0x000e0000, 131072, 0);
 	} else {
-		ret = bios_load_linear(L"roms/machines/xi8088/bios-xi8088.bin",
+		ret = bios_load_linear("roms/machines/xi8088/bios-xi8088.bin",
 				       0x000f0000, 65536, 0);
 	}
     }

--- a/src/machine/m_xt_zenith.c
+++ b/src/machine/m_xt_zenith.c
@@ -142,7 +142,7 @@ machine_xt_z184_init(const machine_t *model)
 {		
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/zdsupers/z184m v3.1d.10d",
+    ret = bios_load_linear("roms/machines/zdsupers/z184m v3.1d.10d",
 			   0x000f8000, 32768, 0);
 
     if (bios_only || !ret)
@@ -165,10 +165,10 @@ int
 machine_xt_z151_init(const machine_t *model)
 {
     int ret;
-    ret = bios_load_linear(L"roms/machines/zdsz151/444-229-18.bin",
+    ret = bios_load_linear("roms/machines/zdsz151/444-229-18.bin",
 			   0x000fc000, 32768, 0);
     if (ret) {
-        bios_load_aux_linear(L"roms/machines/zdsz151/444-260-18.bin",
+        bios_load_aux_linear("roms/machines/zdsz151/444-260-18.bin",
 			     0x000f8000, 16384, 0);
     }
 
@@ -189,7 +189,7 @@ machine_xt_z159_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear(L"roms/machines/zdsz159/z159m v2.9e.10d",
+    ret = bios_load_linear("roms/machines/zdsz159/z159m v2.9e.10d",
 			   0x000f8000, 32768, 0);
 
     if (bios_only || !ret)

--- a/src/mem/catalyst_flash.c
+++ b/src/mem/catalyst_flash.c
@@ -69,7 +69,7 @@ typedef struct flash_t
 } flash_t;
 
 
-static wchar_t	flash_path[1024];
+static char	flash_path[1024];
 
 
 static uint8_t
@@ -200,22 +200,11 @@ catalyst_flash_init(const device_t *info)
     FILE *f;
     int l;
     flash_t *dev;
-    wchar_t *machine_name, *flash_name;
 
     dev = malloc(sizeof(flash_t));
     memset(dev, 0, sizeof(flash_t));
 
-    l = strlen(machine_get_internal_name_ex(machine))+1;
-    machine_name = (wchar_t *) malloc(l * sizeof(wchar_t));
-    mbstowcs(machine_name, machine_get_internal_name_ex(machine), l);
-    l = wcslen(machine_name)+5;
-    flash_name = (wchar_t *)malloc(l*sizeof(wchar_t));
-    swprintf(flash_name, l, L"%ls.bin", machine_name);
-
-    if (wcslen(flash_name) <= 1024)
-	wcscpy(flash_path, flash_name);
-    else
-	wcsncpy(flash_path, flash_name, 1024);
+    sprintf(flash_path, "%s.bin", machine_get_internal_name_ex(machine));
 
     mem_mapping_disable(&bios_mapping);
     mem_mapping_disable(&bios_high_mapping);
@@ -227,14 +216,11 @@ catalyst_flash_init(const device_t *info)
 
     dev->command = CMD_RESET;
 
-    f = nvr_fopen(flash_path, L"rb");
+    f = nvr_fopen(flash_path, "rb");
     if (f) {
 	fread(dev->array, 0x20000, 1, f);
 	fclose(f);
     }
-
-    free(flash_name);
-    free(machine_name);
 
     return dev;
 }
@@ -246,7 +232,7 @@ catalyst_flash_close(void *p)
     FILE *f;
     flash_t *dev = (flash_t *)p;
 
-    f = nvr_fopen(flash_path, L"wb");
+    f = nvr_fopen(flash_path, "wb");
     fwrite(dev->array, 0x20000, 1, f);
     fclose(f);
 

--- a/src/mem/intel_flash.c
+++ b/src/mem/intel_flash.c
@@ -78,7 +78,7 @@ typedef struct flash_t
 } flash_t;
 
 
-static wchar_t	flash_path[1024];
+static char	flash_path[1024];
 
 
 static uint8_t
@@ -355,23 +355,12 @@ intel_flash_init(const device_t *info)
     FILE *f;
     int l;
     flash_t *dev;
-    wchar_t *machine_name, *flash_name;
     uint8_t type = info->local & 0xff;
 
     dev = malloc(sizeof(flash_t));
     memset(dev, 0, sizeof(flash_t));
 
-    l = strlen(machine_get_internal_name_ex(machine))+1;
-    machine_name = (wchar_t *) malloc(l * sizeof(wchar_t));
-    mbstowcs(machine_name, machine_get_internal_name_ex(machine), l);
-    l = wcslen(machine_name)+5;
-    flash_name = (wchar_t *)malloc(l*sizeof(wchar_t));
-    swprintf(flash_name, l, L"%ls.bin", machine_name);
-
-    if (wcslen(flash_name) <= 1024)
-	wcscpy(flash_path, flash_name);
-    else
-	wcsncpy(flash_path, flash_name, 1024);
+    sprintf(flash_path, "%s.bin", machine_get_internal_name_ex(machine));
 
     dev->flags = info->local & 0xff;
 
@@ -529,7 +518,7 @@ intel_flash_init(const device_t *info)
     dev->command = CMD_READ_ARRAY;
     dev->status = 0;
 
-    f = nvr_fopen(flash_path, L"rb");
+    f = nvr_fopen(flash_path, "rb");
     if (f) {
 	fread(&(dev->array[dev->block_start[BLOCK_MAIN1]]), dev->block_len[BLOCK_MAIN1], 1, f);
 	if (dev->block_len[BLOCK_MAIN2])
@@ -544,9 +533,6 @@ intel_flash_init(const device_t *info)
 	fclose(f);
     }
 
-    free(flash_name);
-    free(machine_name);
-
     return dev;
 }
 
@@ -557,7 +543,7 @@ intel_flash_close(void *p)
     FILE *f;
     flash_t *dev = (flash_t *)p;
 
-    f = nvr_fopen(flash_path, L"wb");
+    f = nvr_fopen(flash_path, "wb");
     fwrite(&(dev->array[dev->block_start[BLOCK_MAIN1]]), dev->block_len[BLOCK_MAIN1], 1, f);
     if (dev->block_len[BLOCK_MAIN2])
 	fwrite(&(dev->array[dev->block_start[BLOCK_MAIN2]]), dev->block_len[BLOCK_MAIN2], 1, f);

--- a/src/mem/rom.c
+++ b/src/mem/rom.c
@@ -59,31 +59,24 @@ rom_log(const char *fmt, ...)
 
 
 FILE *
-rom_fopen(wchar_t *fn, wchar_t *mode)
+rom_fopen(char *fn, char *mode)
 {
-    wchar_t temp[1024];
+    char temp[1024];
 
-    if (wcslen(exe_path) <= 1024)
-	wcscpy(temp, exe_path);
-    else
-	wcsncpy(temp, exe_path, 1024);
-    plat_put_backslash(temp);
-    wcscat(temp, fn);
+    plat_append_filename(temp, exe_path, fn);
 
     return(plat_fopen(temp, mode));
 }
 
 
 int
-rom_getfile(wchar_t *fn, wchar_t *s, int size)
+rom_getfile(char *fn, char *s, int size)
 {
     FILE *f;
 
-    wcscpy(s, exe_path);
-    plat_put_backslash(s);
-    wcscat(s, fn);
+    plat_append_filename(s, exe_path, fn);
 
-    f = plat_fopen(s, L"rb");
+    f = plat_fopen(s, "rb");
     if (f != NULL) {
 	(void)fclose(f);
 	return(1);
@@ -94,11 +87,11 @@ rom_getfile(wchar_t *fn, wchar_t *s, int size)
 
 
 int
-rom_present(wchar_t *fn)
+rom_present(char *fn)
 {
     FILE *f;
 
-    f = rom_fopen(fn, L"rb");
+    f = rom_fopen(fn, "rb");
     if (f != NULL) {
 	(void)fclose(f);
 	return(1);
@@ -163,13 +156,13 @@ rom_readl(uint32_t addr, void *priv)
 
 
 int
-rom_load_linear_oddeven(wchar_t *fn, uint32_t addr, int sz, int off, uint8_t *ptr)
+rom_load_linear_oddeven(char *fn, uint32_t addr, int sz, int off, uint8_t *ptr)
 {
-    FILE *f = rom_fopen(fn, L"rb");
+    FILE *f = rom_fopen(fn, "rb");
     int i;
         
     if (f == NULL) {
-	rom_log("ROM: image '%ls' not found\n", fn);
+	rom_log("ROM: image '%s' not found\n", fn);
 	return(0);
     }
 
@@ -200,12 +193,12 @@ rom_load_linear_oddeven(wchar_t *fn, uint32_t addr, int sz, int off, uint8_t *pt
 
 /* Load a ROM BIOS from its chips, interleaved mode. */
 int
-rom_load_linear(wchar_t *fn, uint32_t addr, int sz, int off, uint8_t *ptr)
+rom_load_linear(char *fn, uint32_t addr, int sz, int off, uint8_t *ptr)
 {
-    FILE *f = rom_fopen(fn, L"rb");
+    FILE *f = rom_fopen(fn, "rb");
         
     if (f == NULL) {
-	rom_log("ROM: image '%ls' not found\n", fn);
+	rom_log("ROM: image '%s' not found\n", fn);
 	return(0);
     }
 
@@ -230,12 +223,12 @@ rom_load_linear(wchar_t *fn, uint32_t addr, int sz, int off, uint8_t *ptr)
 
 /* Load a ROM BIOS from its chips, linear mode with high bit flipped. */
 int
-rom_load_linear_inverted(wchar_t *fn, uint32_t addr, int sz, int off, uint8_t *ptr)
+rom_load_linear_inverted(char *fn, uint32_t addr, int sz, int off, uint8_t *ptr)
 {
-    FILE *f = rom_fopen(fn, L"rb");
+    FILE *f = rom_fopen(fn, "rb");
         
     if (f == NULL) {
-	rom_log("ROM: image '%ls' not found\n", fn);
+	rom_log("ROM: image '%s' not found\n", fn);
 	return(0);
     }
 
@@ -272,16 +265,16 @@ rom_load_linear_inverted(wchar_t *fn, uint32_t addr, int sz, int off, uint8_t *p
 
 /* Load a ROM BIOS from its chips, interleaved mode. */
 int
-rom_load_interleaved(wchar_t *fnl, wchar_t *fnh, uint32_t addr, int sz, int off, uint8_t *ptr)
+rom_load_interleaved(char *fnl, char *fnh, uint32_t addr, int sz, int off, uint8_t *ptr)
 {
-    FILE *fl = rom_fopen(fnl, L"rb");
-    FILE *fh = rom_fopen(fnh, L"rb");
+    FILE *fl = rom_fopen(fnl, "rb");
+    FILE *fh = rom_fopen(fnh, "rb");
     int c;
 
     if (fl == NULL || fh == NULL) {
-	if (fl == NULL) rom_log("ROM: image '%ls' not found\n", fnl);
+	if (fl == NULL) rom_log("ROM: image '%s' not found\n", fnl);
 	  else (void)fclose(fl);
-	if (fh == NULL) rom_log("ROM: image '%ls' not found\n", fnh);
+	if (fh == NULL) rom_log("ROM: image '%s' not found\n", fnh);
 	  else (void)fclose(fh);
 
 	return(0);
@@ -438,7 +431,7 @@ bios_add(void)
 
 /* These four are for loading the BIOS. */
 int
-bios_load(wchar_t *fn1, wchar_t *fn2, uint32_t addr, int sz, int off, int flags)
+bios_load(char *fn1, char *fn2, uint32_t addr, int sz, int off, int flags)
 {
     uint8_t ret = 0;
     uint8_t *ptr = NULL;
@@ -486,7 +479,7 @@ bios_load(wchar_t *fn1, wchar_t *fn2, uint32_t addr, int sz, int off, int flags)
 
 
 int
-bios_load_linear_combined(wchar_t *fn1, wchar_t *fn2, int sz, int off)
+bios_load_linear_combined(char *fn1, char *fn2, int sz, int off)
 {
     uint8_t ret = 0;
 
@@ -498,7 +491,7 @@ bios_load_linear_combined(wchar_t *fn1, wchar_t *fn2, int sz, int off)
 
 
 int
-bios_load_linear_combined2(wchar_t *fn1, wchar_t *fn2, wchar_t *fn3, wchar_t *fn4, wchar_t *fn5, int sz, int off)
+bios_load_linear_combined2(char *fn1, char *fn2, char *fn3, char *fn4, char *fn5, int sz, int off)
 {
     uint8_t ret = 0;
 
@@ -514,7 +507,7 @@ bios_load_linear_combined2(wchar_t *fn1, wchar_t *fn2, wchar_t *fn3, wchar_t *fn
 
 
 int
-rom_init(rom_t *rom, wchar_t *fn, uint32_t addr, int sz, int mask, int off, uint32_t flags)
+rom_init(rom_t *rom, char *fn, uint32_t addr, int sz, int mask, int off, uint32_t flags)
 {
     rom_log("rom_init(%08X, %08X, %08X, %08X, %08X, %08X, %08X)\n", rom, fn, addr, sz, mask, off, flags);
 
@@ -544,7 +537,7 @@ rom_init(rom_t *rom, wchar_t *fn, uint32_t addr, int sz, int mask, int off, uint
 
 
 int
-rom_init_oddeven(rom_t *rom, wchar_t *fn, uint32_t addr, int sz, int mask, int off, uint32_t flags)
+rom_init_oddeven(rom_t *rom, char *fn, uint32_t addr, int sz, int mask, int off, uint32_t flags)
 {
     rom_log("rom_init(%08X, %08X, %08X, %08X, %08X, %08X, %08X)\n", rom, fn, addr, sz, mask, off, flags);
 
@@ -574,7 +567,7 @@ rom_init_oddeven(rom_t *rom, wchar_t *fn, uint32_t addr, int sz, int mask, int o
 
 
 int
-rom_init_interleaved(rom_t *rom, wchar_t *fnl, wchar_t *fnh, uint32_t addr, int sz, int mask, int off, uint32_t flags)
+rom_init_interleaved(rom_t *rom, char *fnl, char *fnh, uint32_t addr, int sz, int mask, int off, uint32_t flags)
 {
     /* Allocate a buffer for the image. */
     rom->rom = malloc(sz);

--- a/src/network/net_ne2000.c
+++ b/src/network/net_ne2000.c
@@ -69,10 +69,10 @@
 
 
 /* ROM BIOS file paths. */
-#define ROM_PATH_NE1000		L"roms/network/ne1000/ne1000.rom"
-#define ROM_PATH_NE2000		L"roms/network/ne2000/ne2000.rom"
-#define ROM_PATH_RTL8019	L"roms/network/rtl8019as/rtl8019as.rom"
-#define ROM_PATH_RTL8029	L"roms/network/rtl8029as/rtl8029as.rom"
+#define ROM_PATH_NE1000		"roms/network/ne1000/ne1000.rom"
+#define ROM_PATH_NE2000		"roms/network/ne2000/ne2000.rom"
+#define ROM_PATH_RTL8019	"roms/network/rtl8019as/rtl8019as.rom"
+#define ROM_PATH_RTL8029	"roms/network/rtl8029as/rtl8029as.rom"
 
 /* PCI info. */
 #define PCI_VENDID		0x10ec		/* Realtek, Inc */
@@ -823,7 +823,7 @@ nic_pci_write(int func, int addr, uint8_t val, void *priv)
 
 
 static void
-nic_rom_init(nic_t *dev, wchar_t *s)
+nic_rom_init(nic_t *dev, char *s)
 {
     uint32_t temp;
     FILE *f;
@@ -832,7 +832,7 @@ nic_rom_init(nic_t *dev, wchar_t *s)
 
     if (dev->bios_addr == 0) return;
 
-    if ((f = rom_fopen(s, L"rb")) != NULL) {
+    if ((f = rom_fopen(s, "rb")) != NULL) {
 	fseek(f, 0L, SEEK_END);
 	temp = ftell(f);
 	fclose(f);
@@ -932,7 +932,7 @@ static void *
 nic_init(const device_t *info)
 {
     uint32_t mac;
-    wchar_t *rom;
+    char *rom;
     nic_t *dev;
 #ifdef ENABLE_NIC_LOG
     int i;

--- a/src/network/net_pcap.c
+++ b/src/network/net_pcap.c
@@ -267,15 +267,12 @@ net_pcap_prepare(netdev_t *list)
 		memset(list->device, '\0', sizeof(list->device));
 		memset(list->description, '\0', sizeof(list->description));
 
-		strncpy(list->device, dev->name, 127);
+		strncpy(list->device, dev->name, sizeof(list->device) - 1);
 		if (dev->description) {
-			if (strlen(dev->description) <= 127)
-				strcpy(list->description, dev->description);
-			else
-				strncpy(list->description, dev->description, 127);
+			strncpy(list->description, dev->description, sizeof(list->description) - 1);
 		} else {
 			/* if description is NULL, set the name. This allows pcap to display *something* useful under WINE */
-			strncpy(list->description, dev->name, sizeof(list->description)-1);
+			strncpy(list->description, dev->name, sizeof(list->description) - 1);
 		}
 
 	list++; i++;

--- a/src/nvr.c
+++ b/src/nvr.c
@@ -172,10 +172,9 @@ nvr_init(nvr_t *nvr)
     int c;
 
     /* Set up the NVR file's name. */
-    sprintf(temp, "%s.nvr", machine_get_internal_name());
-    c = strlen(temp);
-    nvr->fn = (wchar_t *)malloc((c + 1) * sizeof(wchar_t));
-    mbstowcs(nvr->fn, temp, c + 1);
+    c = strlen(machine_get_internal_name()) + 5;
+    nvr->fn = (char *)malloc(c + 1);
+    sprintf(nvr->fn, "%s.nvr", machine_get_internal_name());
 
     /* Initialize the internal clock as needed. */
     memset(&intclk, 0x00, sizeof(intclk));
@@ -210,15 +209,15 @@ nvr_init(nvr_t *nvr)
 
 
 /* Get path to the NVR folder. */
-wchar_t *
-nvr_path(wchar_t *str)
+char *
+nvr_path(char *str)
 {
-    static wchar_t temp[1024];
+    static char temp[1024];
 
     /* Get the full prefix in place. */
     memset(temp, 0x00, sizeof(temp));
-    wcscpy(temp, usr_path);
-    wcscat(temp, NVR_PATH);
+    strcpy(temp, usr_path);
+    strcat(temp, NVR_PATH);
 
     /* Create the directory if needed. */
     if (! plat_dir_check(temp))
@@ -226,7 +225,7 @@ nvr_path(wchar_t *str)
 
     /* Now append the actual filename. */
     plat_path_slash(temp);
-    wcscat(temp, str);
+    strcat(temp, str);
 
     return(temp);
 }
@@ -246,7 +245,7 @@ nvr_path(wchar_t *str)
 int
 nvr_load(void)
 {
-    wchar_t *path;
+    char *path;
     FILE *fp;
 
     /* Make sure we have been initialized. */
@@ -262,8 +261,8 @@ nvr_load(void)
     /* Load the (relevant) part of the NVR contents. */
     if (saved_nvr->size != 0) {
 	path = nvr_path(saved_nvr->fn);
-	nvr_log("NVR: loading from '%ls'\n", path);
-	fp = plat_fopen(path, L"rb");
+	nvr_log("NVR: loading from '%s'\n", path);
+	fp = plat_fopen(path, "rb");
 	if (fp != NULL) {
 		/* Read NVR contents from file. */
 		if (fread(saved_nvr->regs, 1, saved_nvr->size, fp) != saved_nvr->size)
@@ -291,7 +290,7 @@ nvr_set_ven_save(void (*ven_save)(void))
 int
 nvr_save(void)
 {
-    wchar_t *path;
+    char *path;
     FILE *fp;
 
     /* Make sure we have been initialized. */
@@ -299,8 +298,8 @@ nvr_save(void)
 
     if (saved_nvr->size != 0) {
 	path = nvr_path(saved_nvr->fn);
-	nvr_log("NVR: saving to '%ls'\n", path);
-	fp = plat_fopen(path, L"wb");
+	nvr_log("NVR: saving to '%s'\n", path);
+	fp = plat_fopen(path, "wb");
 	if (fp != NULL) {
 		/* Save NVR contents to file. */
 		(void)fwrite(saved_nvr->regs, saved_nvr->size, 1, fp);
@@ -364,7 +363,7 @@ nvr_time_set(struct tm *tm)
 
 /* Open or create a file in the NVR area. */
 FILE *
-nvr_fopen(wchar_t *str, wchar_t *mode)
+nvr_fopen(char *str, char *mode)
 {
     return(plat_fopen(nvr_path(str), mode));
 }

--- a/src/nvr_ps2.c
+++ b/src/nvr_ps2.c
@@ -55,7 +55,7 @@ typedef struct {
 
     uint8_t	ram[8192];
 
-    wchar_t	*fn;
+    char	*fn;
 } ps2_nvr_t;
 
 
@@ -116,15 +116,14 @@ ps2_nvr_init(const device_t *info)
     memset(nvr, 0x00, sizeof(ps2_nvr_t));
 
     /* Set up the NVR file's name. */
-    sprintf(temp, "%s_sec.nvr", machine_get_internal_name());
-    c = strlen(temp);
-    nvr->fn = (wchar_t *)malloc((c + 1) * sizeof(wchar_t));
-    mbstowcs(nvr->fn, temp, c + 1);
+    c = strlen(machine_get_internal_name()) + 9;
+    nvr->fn = (char *)malloc(c + 1);
+    sprintf(nvr->fn, "%s_sec.nvr", machine_get_internal_name());
 
     io_sethandler(0x0074, 3,
 		  ps2_nvr_read,NULL,NULL, ps2_nvr_write,NULL,NULL, nvr);
 
-    f = nvr_fopen(nvr->fn, L"rb");
+    f = nvr_fopen(nvr->fn, "rb");
 
     memset(nvr->ram, 0xff, 8192);
     if (f != NULL) {
@@ -143,7 +142,7 @@ ps2_nvr_close(void *priv)
     ps2_nvr_t *nvr = (ps2_nvr_t *)priv;
     FILE *f = NULL;
 
-    f = nvr_fopen(nvr->fn, L"wb");
+    f = nvr_fopen(nvr->fn, "wb");
 
     if (f != NULL) {
 	(void)fwrite(nvr->ram, 8192, 1, f);

--- a/src/printer/png.c
+++ b/src/printer/png.c
@@ -105,7 +105,7 @@ warning_handler(png_structp arg, const char *str)
 
 /* Write the given image as an 8-bit GrayScale PNG image file. */
 int
-png_write_gray(wchar_t *fn, int inv, uint8_t *pix, int16_t w, int16_t h)
+png_write_gray(char *fn, int inv, uint8_t *pix, int16_t w, int16_t h)
 {
     png_structp png = NULL;
     png_infop info = NULL;
@@ -114,11 +114,11 @@ png_write_gray(wchar_t *fn, int inv, uint8_t *pix, int16_t w, int16_t h)
     FILE *fp;
 
     /* Create the image file. */
-    fp = plat_fopen(fn, L"wb");
+    fp = plat_fopen(fn, "wb");
     if (fp == NULL) {
 	/* Yes, this looks weird. */
 	if (fp == NULL)
-		png_log("PNG: file %ls could not be opened for writing!\n", fn);
+		png_log("PNG: file %s could not be opened for writing!\n", fn);
 	else
 error:
 		png_log("PNG: fatal error, bailing out, error = %i\n", errno);
@@ -185,7 +185,7 @@ error:
 
 /* Write the given BITMAP-format image as an 8-bit RGBA PNG image file. */
 void
-png_write_rgb(wchar_t *fn, uint8_t *pix, int16_t w, int16_t h, uint16_t pitch, PALETTE palcol)
+png_write_rgb(char *fn, uint8_t *pix, int16_t w, int16_t h, uint16_t pitch, PALETTE palcol)
 {
     png_structp png = NULL;
     png_infop info = NULL;
@@ -195,9 +195,9 @@ png_write_rgb(wchar_t *fn, uint8_t *pix, int16_t w, int16_t h, uint16_t pitch, P
     int i;
 
     /* Create the image file. */
-    fp = plat_fopen(fn, L"wb");
+    fp = plat_fopen(fn, "wb");
     if (fp == NULL) {
-	png_log("PNG: File %ls could not be opened for writing!\n", fn);
+	png_log("PNG: File %s could not be opened for writing!\n", fn);
 error:
 	if (png != NULL)
 		PNGFUNC(destroy_write_struct)(&png, &info);

--- a/src/printer/prt_text.c
+++ b/src/printer/prt_text.c
@@ -102,7 +102,7 @@ typedef struct {
     void *	lpt;
 
     /* Output file name. */
-    wchar_t	filename[1024];
+    char	filename[1024];
 
     /* Printer timeout. */
     pc_timer_t	pulse_timer;
@@ -143,23 +143,23 @@ typedef struct {
 static void 
 dump_page(prnt_t *dev)
 {
-    wchar_t path[1024];
+    char path[1024];
     uint16_t x, y;
     uint8_t ch;
     FILE *fp;
 
     /* Create the full path for this file. */
     memset(path, 0x00, sizeof(path));
-    plat_append_filename(path, usr_path, L"printer");
+    plat_append_filename(path, usr_path, "printer");
     if (! plat_dir_check(path))
         plat_dir_create(path);
     plat_path_slash(path);
-    wcscat(path, dev->filename);
+    strcpy(path, dev->filename);
 
     /* Create the file. */
-    fp = plat_fopen(path, L"a");
+    fp = plat_fopen(path, "a");
     if (fp == NULL) {
-	//ERRLOG("PRNT: unable to create print page '%ls'\n", path);
+	//ERRLOG("PRNT: unable to create print page '%s'\n", path);
 	return;
     }
     fseek(fp, 0, SEEK_END);
@@ -250,7 +250,7 @@ reset_printer(prnt_t *dev)
 	dev->page->dirty = 0;
 
     /* Create a file for this page. */
-    plat_tempfile(dev->filename, NULL, L".txt");
+    plat_tempfile(dev->filename, NULL, ".txt");
 
     timer_disable(&dev->pulse_timer);
     timer_disable(&dev->timeout_timer);

--- a/src/scsi/scsi_aha154x.c
+++ b/src/scsi/scsi_aha154x.c
@@ -163,7 +163,7 @@ aha_eeprom_save(x54x_t *dev)
 {
     FILE *f;
 
-    f = nvr_fopen(dev->nvr_path, L"wb");
+    f = nvr_fopen(dev->nvr_path, "wb");
     if (f)
     {
 	fwrite(dev->nvr, 1, NVR_SIZE, f);
@@ -738,8 +738,8 @@ aha_setbios(x54x_t *dev)
     if (dev->bios_path == NULL) return;
 
     /* Open the BIOS image file and make sure it exists. */
-    aha_log("%s: loading BIOS from '%ls'\n", dev->name, dev->bios_path);
-    if ((f = rom_fopen(dev->bios_path, L"rb")) == NULL) {
+    aha_log("%s: loading BIOS from '%s'\n", dev->name, dev->bios_path);
+    if ((f = rom_fopen(dev->bios_path, "rb")) == NULL) {
 	aha_log("%s: BIOS ROM not found!\n", dev->name);
 	return;
     }
@@ -845,7 +845,7 @@ aha_setmcode(x54x_t *dev)
 
     /* Open the microcode image file and make sure it exists. */
     aha_log("%s: loading microcode from '%ls'\n", dev->name, dev->bios_path);
-    if ((f = rom_fopen(dev->mcode_path, L"rb")) == NULL) {
+    if ((f = rom_fopen(dev->mcode_path, "rb")) == NULL) {
 	aha_log("%s: microcode ROM not found!\n", dev->name);
 	return;
     }
@@ -926,7 +926,7 @@ aha_setnvr(x54x_t *dev)
     dev->nvr = (uint8_t *)malloc(NVR_SIZE);
     memset(dev->nvr, 0x00, NVR_SIZE);
 
-    f = nvr_fopen(dev->nvr_path, L"rb");
+    f = nvr_fopen(dev->nvr_path, "rb");
     if (f) {
 	if (fread(dev->nvr, 1, NVR_SIZE, f) != NVR_SIZE)
 		fatal("aha_setnvr(): Error reading data\n");
@@ -1004,7 +1004,7 @@ aha_init(const device_t *info)
 	case AHA_154xA:
 		strcpy(dev->name, "AHA-154xA");
 		dev->fw_rev = "A003";	/* The 3.07 microcode says A006. */
-		dev->bios_path = L"roms/scsi/adaptec/aha1540a307.bin"; /*Only for port 0x330*/
+		dev->bios_path = "roms/scsi/adaptec/aha1540a307.bin"; /*Only for port 0x330*/
 		/* This is configurable from the configuration for the 154xB, the rest of the controllers read it from the EEPROM. */
 		dev->HostID = device_get_config_int("hostid");
 		dev->rom_shram = 0x3F80;	/* shadow RAM address base */
@@ -1017,12 +1017,12 @@ aha_init(const device_t *info)
 		switch(dev->Base) {
 			case 0x0330:
 				dev->bios_path =
-				    L"roms/scsi/adaptec/aha1540b320_330.bin";
+				    "roms/scsi/adaptec/aha1540b320_330.bin";
 				break;
 
 			case 0x0334:
 				dev->bios_path =
-				    L"roms/scsi/adaptec/aha1540b320_334.bin";
+				    "roms/scsi/adaptec/aha1540b320_334.bin";
 				break;
 		}
 		dev->fw_rev = "A005";	/* The 3.2 microcode says A012. */
@@ -1035,8 +1035,8 @@ aha_init(const device_t *info)
 
 	case AHA_154xC:
 		strcpy(dev->name, "AHA-154xC");
-		dev->bios_path = L"roms/scsi/adaptec/aha1542c102.bin";
-		dev->nvr_path = L"aha1542c.nvr";
+		dev->bios_path = "roms/scsi/adaptec/aha1542c102.bin";
+		dev->nvr_path = "aha1542c.nvr";
 		dev->fw_rev = "D001";
 		dev->rom_shram = 0x3F80;	/* shadow RAM address base */
 		dev->rom_shramsz = 128;		/* size of shadow RAM */
@@ -1050,8 +1050,8 @@ aha_init(const device_t *info)
 
 	case AHA_154xCF:
 		strcpy(dev->name, "AHA-154xCF");
-		dev->bios_path = L"roms/scsi/adaptec/aha1542cf211.bin";
-		dev->nvr_path = L"aha1542cf.nvr";
+		dev->bios_path = "roms/scsi/adaptec/aha1542cf211.bin";
+		dev->nvr_path = "aha1542cf.nvr";
 		dev->fw_rev = "E001";
 		dev->rom_shram = 0x3F80;	/* shadow RAM address base */
 		dev->rom_shramsz = 128;		/* size of shadow RAM */
@@ -1068,9 +1068,9 @@ aha_init(const device_t *info)
 
 	case AHA_154xCP:
 		strcpy(dev->name, "AHA-154xCP");
-		dev->bios_path = L"roms/scsi/adaptec/aha1542cp102.bin";
-		dev->mcode_path = L"roms/scsi/adaptec/908301-00_f_mcode_17c9.u12";
-		dev->nvr_path = L"aha1542cp.nvr";
+		dev->bios_path = "roms/scsi/adaptec/aha1542cp102.bin";
+		dev->mcode_path = "roms/scsi/adaptec/908301-00_f_mcode_17c9.u12";
+		dev->nvr_path = "aha1542cp.nvr";
 		dev->fw_rev = "F001";
 		dev->rom_shram = 0x3F80;	/* shadow RAM address base */
 		dev->rom_shramsz = 128;		/* size of shadow RAM */
@@ -1098,7 +1098,7 @@ aha_init(const device_t *info)
 
 	case AHA_1640:
 		strcpy(dev->name, "AHA-1640");
-		dev->bios_path = L"roms/scsi/adaptec/aha1640.bin";
+		dev->bios_path = "roms/scsi/adaptec/aha1640.bin";
 		dev->fw_rev = "BB01";
 
 		dev->flags |= X54X_LBA_BIOS;

--- a/src/scsi/scsi_buslogic.c
+++ b/src/scsi/scsi_buslogic.c
@@ -261,23 +261,23 @@ buslogic_log(const char *fmt, ...)
 #endif
 
 
-static wchar_t *
+static char *
 BuslogicGetNVRFileName(buslogic_data_t *bl)
 {
 	switch(bl->chip)
 	{
 		case CHIP_BUSLOGIC_ISA_542_1991:
-			return L"bt542b.nvr";		
+			return "bt542b.nvr";		
 		case CHIP_BUSLOGIC_ISA_542:
-			return L"bt542bh.nvr";
+			return "bt542bh.nvr";
 		case CHIP_BUSLOGIC_ISA:
-			return L"bt545s.nvr";
+			return "bt545s.nvr";
 		case CHIP_BUSLOGIC_MCA:
-			return L"bt640a.nvr";
+			return "bt640a.nvr";
 		case CHIP_BUSLOGIC_VLB:
-			return L"bt445s.nvr";
+			return "bt445s.nvr";
 		case CHIP_BUSLOGIC_PCI:
-			return L"bt958d.nvr";
+			return "bt958d.nvr";
 		default:
 			fatal("Unrecognized BusLogic chip: %i\n", bl->chip);
 			return NULL;
@@ -409,7 +409,7 @@ BuslogicInitializeAutoSCSIRam(x54x_t *dev)
 
     FILE *f;
 
-    f = nvr_fopen(BuslogicGetNVRFileName(bl), L"rb");
+    f = nvr_fopen(BuslogicGetNVRFileName(bl), "rb");
     if (f)
     {
 	if (fread(&(bl->LocalRAM.structured.autoSCSIData), 1, 64, f) != 64)
@@ -889,7 +889,7 @@ buslogic_cmds(void *p)
 				BuslogicAutoSCSIRamSetDefaults(dev, 3);
 				break;
 			case 1:
-				f = nvr_fopen(BuslogicGetNVRFileName(bl), L"wb");
+				f = nvr_fopen(BuslogicGetNVRFileName(bl), "wb");
 				if (f) {
 					fwrite(&(bl->LocalRAM.structured.autoSCSIData), 1, 64, f);
 					fclose(f);
@@ -1517,14 +1517,14 @@ static void *
 buslogic_init(const device_t *info)
 {
     x54x_t *dev;
-    wchar_t *bios_rom_name;
+    char *bios_rom_name;
     uint16_t bios_rom_size;
     uint16_t bios_rom_mask;
     uint8_t has_autoscsi_rom;
-    wchar_t *autoscsi_rom_name;
+    char *autoscsi_rom_name;
     uint16_t autoscsi_rom_size;
     uint8_t has_scam_rom;
-    wchar_t *scam_rom_name;
+    char *scam_rom_name;
     uint16_t scam_rom_size;
     FILE *f;
     buslogic_data_t *bl;
@@ -1585,7 +1585,7 @@ buslogic_init(const device_t *info)
     {
 	case CHIP_BUSLOGIC_ISA_542_1991:
 		strcpy(dev->name, "BT-542B");
-		bios_rom_name = L"roms/scsi/buslogic/BT-542B_BIOS.rom";
+		bios_rom_name = "roms/scsi/buslogic/BT-542B_BIOS.rom";
 		bios_rom_size = 0x4000;
 		bios_rom_mask = 0x3fff;
 		has_autoscsi_rom = 0;
@@ -1596,7 +1596,7 @@ buslogic_init(const device_t *info)
 		break;		
 	case CHIP_BUSLOGIC_ISA_542:
 		strcpy(dev->name, "BT-542BH");
-		bios_rom_name = L"roms/scsi/buslogic/BT-542BH_BIOS.rom";
+		bios_rom_name = "roms/scsi/buslogic/BT-542BH_BIOS.rom";
 		bios_rom_size = 0x4000;
 		bios_rom_mask = 0x3fff;
 		has_autoscsi_rom = 0;
@@ -1608,11 +1608,11 @@ buslogic_init(const device_t *info)
 	case CHIP_BUSLOGIC_ISA:
 	default:
 		strcpy(dev->name, "BT-545S");
-		bios_rom_name = L"roms/scsi/buslogic/BT-545S_BIOS.rom";
+		bios_rom_name = "roms/scsi/buslogic/BT-545S_BIOS.rom";
 		bios_rom_size = 0x4000;
 		bios_rom_mask = 0x3fff;
 		has_autoscsi_rom = 1;
-		autoscsi_rom_name = L"roms/scsi/buslogic/BT-545S_AutoSCSI.rom";
+		autoscsi_rom_name = "roms/scsi/buslogic/BT-545S_AutoSCSI.rom";
 		autoscsi_rom_size = 0x4000;
 		has_scam_rom = 0;
 		dev->fw_rev = "AA421E";
@@ -1621,7 +1621,7 @@ buslogic_init(const device_t *info)
 		break;
 	case CHIP_BUSLOGIC_MCA:
 		strcpy(dev->name, "BT-640A");
-		bios_rom_name = L"roms/scsi/buslogic/BT-640A_BIOS.rom";
+		bios_rom_name = "roms/scsi/buslogic/BT-640A_BIOS.rom";
 		bios_rom_size = 0x4000;
 		bios_rom_mask = 0x3fff;
 		has_autoscsi_rom = 0;
@@ -1636,14 +1636,14 @@ buslogic_init(const device_t *info)
 		break;
 	case CHIP_BUSLOGIC_VLB:
 		strcpy(dev->name, "BT-445S");
-		bios_rom_name = L"roms/scsi/buslogic/BT-445S_BIOS.rom";
+		bios_rom_name = "roms/scsi/buslogic/BT-445S_BIOS.rom";
 		bios_rom_size = 0x4000;
 		bios_rom_mask = 0x3fff;
 		has_autoscsi_rom = 1;
-		autoscsi_rom_name = L"roms/scsi/buslogic/BT-445S_AutoSCSI.rom";
+		autoscsi_rom_name = "roms/scsi/buslogic/BT-445S_AutoSCSI.rom";
 		autoscsi_rom_size = 0x8000;
 		has_scam_rom = 1;
-		scam_rom_name = L"roms/scsi/buslogic/BT-445S_SCAM.rom";
+		scam_rom_name = "roms/scsi/buslogic/BT-445S_SCAM.rom";
 		scam_rom_size = 0x0200;
 		dev->fw_rev = "AA507B";
 		dev->flags |= X54X_32BIT;
@@ -1652,14 +1652,14 @@ buslogic_init(const device_t *info)
 		break;
 	case CHIP_BUSLOGIC_PCI:
 		strcpy(dev->name, "BT-958D");
-		bios_rom_name = L"roms/scsi/buslogic/BT-958D_BIOS.rom";
+		bios_rom_name = "roms/scsi/buslogic/BT-958D_BIOS.rom";
 		bios_rom_size = 0x4000;
 		bios_rom_mask = 0x3fff;
 		has_autoscsi_rom = 1;
-		autoscsi_rom_name = L"roms/scsi/buslogic/BT-958D_AutoSCSI.rom";
+		autoscsi_rom_name = "roms/scsi/buslogic/BT-958D_AutoSCSI.rom";
 		autoscsi_rom_size = 0x8000;
 		has_scam_rom = 1;
-		scam_rom_name = L"roms/scsi/buslogic/BT-958D_SCAM.rom";
+		scam_rom_name = "roms/scsi/buslogic/BT-958D_SCAM.rom";
 		scam_rom_size = 0x0200;
 		dev->fw_rev = "AA507B";
 		dev->flags |= (X54X_CDROM_BOOT | X54X_32BIT);
@@ -1685,7 +1685,7 @@ buslogic_init(const device_t *info)
 	rom_init(&bl->bios, bios_rom_name, bios_rom_addr, bios_rom_size, bios_rom_mask, 0, MEM_MAPPING_EXTERNAL);
 
 	if (has_autoscsi_rom) {
-		f = rom_fopen(autoscsi_rom_name, L"rb");
+		f = rom_fopen(autoscsi_rom_name, "rb");
 		if (f) {
 			fread(bl->AutoSCSIROM, 1, autoscsi_rom_size, f);
 			fclose(f);
@@ -1694,7 +1694,7 @@ buslogic_init(const device_t *info)
 	}
 
 	if (has_scam_rom) {
-		f = rom_fopen(scam_rom_name, L"rb");
+		f = rom_fopen(scam_rom_name, "rb");
 		if (f) {
 			fread(bl->SCAMData, 1, scam_rom_size, f);
 			fclose(f);

--- a/src/scsi/scsi_cdrom.c
+++ b/src/scsi/scsi_cdrom.c
@@ -442,7 +442,7 @@ static void
 scsi_cdrom_mode_sense_load(scsi_cdrom_t *dev)
 {
     FILE *f;
-    wchar_t file_name[512];
+    char file_name[512];
 
     memset(&dev->ms_pages_saved, 0, sizeof(mode_sense_pages_t));
     if (dev->drv->bus_type == CDROM_BUS_SCSI)
@@ -450,12 +450,12 @@ scsi_cdrom_mode_sense_load(scsi_cdrom_t *dev)
     else
 	memcpy(&dev->ms_pages_saved, &scsi_cdrom_mode_sense_pages_default, sizeof(mode_sense_pages_t));
 
-    memset(file_name, 0, 512 * sizeof(wchar_t));
+    memset(file_name, 0, 512);
     if (dev->drv->bus_type == CDROM_BUS_SCSI)
-	swprintf(file_name, 512, L"scsi_cdrom_%02i_mode_sense_bin", dev->id);
+	sprintf(file_name, "scsi_cdrom_%02i_mode_sense_bin", dev->id);
     else
-	swprintf(file_name, 512, L"cdrom_%02i_mode_sense_bin", dev->id);
-    f = plat_fopen(nvr_path(file_name), L"rb");
+	sprintf(file_name, "cdrom_%02i_mode_sense_bin", dev->id);
+    f = plat_fopen(nvr_path(file_name), "rb");
     if (f) {
 	if (fread(dev->ms_pages_saved.pages[GPMODE_CDROM_AUDIO_PAGE], 1, 0x10, f) != 0x10)
 		fatal("scsi_cdrom_mode_sense_load(): Error reading data\n");
@@ -468,14 +468,14 @@ static void
 scsi_cdrom_mode_sense_save(scsi_cdrom_t *dev)
 {
     FILE *f;
-    wchar_t file_name[512];
+    char file_name[512];
 
-    memset(file_name, 0, 512 * sizeof(wchar_t));
+    memset(file_name, 0, 512);
     if (dev->drv->bus_type == CDROM_BUS_SCSI)
-	swprintf(file_name, 512, L"scsi_cdrom_%02i_mode_sense_bin", dev->id);
+	sprintf(file_name, "scsi_cdrom_%02i_mode_sense_bin", dev->id);
     else
-	swprintf(file_name, 512, L"cdrom_%02i_mode_sense_bin", dev->id);
-    f = plat_fopen(nvr_path(file_name), L"wb");
+	sprintf(file_name, "cdrom_%02i_mode_sense_bin", dev->id);
+    f = plat_fopen(nvr_path(file_name), "wb");
     if (f) {
 	fwrite(dev->ms_pages_saved.pages[GPMODE_CDROM_AUDIO_PAGE], 1, 0x10, f);
 	fclose(f);

--- a/src/scsi/scsi_disk.c
+++ b/src/scsi/scsi_disk.c
@@ -146,14 +146,14 @@ void
 scsi_disk_mode_sense_load(scsi_disk_t *dev)
 {
     FILE *f;
-    wchar_t file_name[512];
+    char file_name[512];
 
     memset(&dev->ms_pages_saved, 0, sizeof(mode_sense_pages_t));
     memcpy(&dev->ms_pages_saved, &scsi_disk_mode_sense_pages_default, sizeof(mode_sense_pages_t));
 
-    memset(file_name, 0, 512 * sizeof(wchar_t));
-    swprintf(file_name, 512, L"scsi_disk_%02i_mode_sense.bin", dev->id);
-    f = plat_fopen(nvr_path(file_name), L"rb");
+    memset(file_name, 0, 512);
+    sprintf(file_name, "scsi_disk_%02i_mode_sense.bin", dev->id);
+    f = plat_fopen(nvr_path(file_name), "rb");
     if (f) {
 	if (fread(dev->ms_pages_saved.pages[0x30], 1, 0x18, f) != 0x18)
 		fatal("scsi_disk_mode_sense_load(): Error reading data\n");
@@ -166,11 +166,11 @@ void
 scsi_disk_mode_sense_save(scsi_disk_t *dev)
 {
     FILE *f;
-    wchar_t file_name[512];
+    char file_name[512];
 
-    memset(file_name, 0, 512 * sizeof(wchar_t));
-    swprintf(file_name, 512, L"scsi_disk_%02i_mode_sense.bin", dev->id);
-    f = plat_fopen(nvr_path(file_name), L"wb");
+    memset(file_name, 0, 512);
+    sprintf(file_name, "scsi_disk_%02i_mode_sense.bin", dev->id);
+    f = plat_fopen(nvr_path(file_name), "wb");
     if (f) {
 	fwrite(dev->ms_pages_saved.pages[0x30], 1, 0x18, f);
 	fclose(f);
@@ -1225,7 +1225,7 @@ scsi_disk_hard_reset(void)
 			continue;
 
 		/* Make sure to ignore any SCSI disk whose image file name is empty. */
-		if (wcslen(hdd[c].fn) == 0)
+		if (strlen(hdd[c].fn) == 0)
 			continue;
 
 		/* Make sure to ignore any SCSI disk whose image fails to load. */

--- a/src/scsi/scsi_ncr5380.c
+++ b/src/scsi/scsi_ncr5380.c
@@ -43,10 +43,10 @@
 #include <86box/scsi_ncr5380.h>
 
 
-#define LCS6821N_ROM	L"roms/scsi/ncr5380/Longshine LCS-6821N - BIOS version 1.04.bin"
-#define RT1000B_810R_ROM	L"roms/scsi/ncr5380/Rancho_RT1000_RTBios_version_8.10R.bin"
-#define RT1000B_820R_ROM	L"roms/scsi/ncr5380/RTBIOS82.rom"
-#define T130B_ROM	L"roms/scsi/ncr5380/trantor_t130b_bios_v2.14.bin"
+#define LCS6821N_ROM	"roms/scsi/ncr5380/Longshine LCS-6821N - BIOS version 1.04.bin"
+#define RT1000B_810R_ROM	"roms/scsi/ncr5380/Rancho_RT1000_RTBios_version_8.10R.bin"
+#define RT1000B_820R_ROM	"roms/scsi/ncr5380/RTBIOS82.rom"
+#define T130B_ROM	"roms/scsi/ncr5380/trantor_t130b_bios_v2.14.bin"
 
 
 #define NCR_CURDATA	0		/* current SCSI data (read only) */
@@ -1157,7 +1157,7 @@ ncr_callback(void *priv)
 static void *
 ncr_init(const device_t *info)
 {
-	wchar_t *fn = NULL;
+    char *fn = NULL;
     char temp[128];
     ncr5380_t *ncr_dev;
 

--- a/src/scsi/scsi_ncr53c8xx.c
+++ b/src/scsi/scsi_ncr53c8xx.c
@@ -46,8 +46,8 @@
 #include <86box/scsi_ncr53c8xx.h>
 
 
-#define NCR53C8XX_SDMS3_ROM	L"roms/scsi/ncr53c8xx/NCR307.BIN"
-#define SYM53C8XX_SDMS4_ROM	L"roms/scsi/ncr53c8xx/8xx_64.ROM"
+#define NCR53C8XX_SDMS3_ROM	"roms/scsi/ncr53c8xx/NCR307.BIN"
+#define SYM53C8XX_SDMS4_ROM	"roms/scsi/ncr53c8xx/8xx_64.ROM"
 
 #define HA_ID		  7
 
@@ -207,7 +207,7 @@ typedef enum
 } scsi_state_t;
 
 typedef struct {
-    wchar_t	*nvr_path;
+    char	*nvr_path;
     uint8_t	pci_slot;
     uint8_t	chip, wide;
     int		has_bios;
@@ -1457,7 +1457,7 @@ ncr53c8xx_eeprom(ncr53c8xx_t *dev, uint8_t save)
 {
     FILE *f;
 
-    f = nvr_fopen(dev->nvr_path, save ? L"wb": L"rb");
+    f = nvr_fopen(dev->nvr_path, save ? "wb": "rb");
     if (f) {
 	if (save)
 		fwrite(&dev->nvram, sizeof(dev->nvram), 1, f);
@@ -2542,25 +2542,25 @@ ncr53c8xx_init(const device_t *info)
 
     if (dev->chip == CHIP_875) {
 	dev->chip_rev = 0x04;
-	dev->nvr_path = L"ncr53c875.nvr";
+	dev->nvr_path = "ncr53c875.nvr";
 	dev->wide = 1;
     } else if (dev->chip == CHIP_860) {
 	dev->chip_rev = 0x04;
-	dev->nvr_path = L"ncr53c860.nvr";
+	dev->nvr_path = "ncr53c860.nvr";
 	dev->wide = 1;
     } else if (dev->chip == CHIP_820) {
-	dev->nvr_path = L"ncr53c820.nvr";
+	dev->nvr_path = "ncr53c820.nvr";
 	dev->wide = 1;
     } else if (dev->chip == CHIP_825) {
 	dev->chip_rev = 0x26;
-	dev->nvr_path = L"ncr53c825a.nvr";
+	dev->nvr_path = "ncr53c825a.nvr";
 	dev->wide = 1;
     } else if (dev->chip == CHIP_810) {
-	dev->nvr_path = L"ncr53c810.nvr";
+	dev->nvr_path = "ncr53c810.nvr";
 	dev->wide = 0;
     } else if (dev->chip == CHIP_815) {
 	dev->chip_rev = 0x04;
-	dev->nvr_path = L"ncr53c815.nvr";	
+	dev->nvr_path = "ncr53c815.nvr";	
 	dev->wide = 0;
     }
 

--- a/src/scsi/scsi_pcscsi.c
+++ b/src/scsi/scsi_pcscsi.c
@@ -45,7 +45,7 @@
 #include <86box/scsi_pcscsi.h>
 #include <86box/vid_ati_eeprom.h>
 
-#define DC390_ROM	L"roms/scsi/esp_pci/INT13.BIN"
+#define DC390_ROM	"roms/scsi/esp_pci/INT13.BIN"
 
 #define ESP_REGS 16
 #define TI_BUFSZ 32
@@ -148,7 +148,7 @@
 
 typedef struct {
     mem_mapping_t mmio_mapping;
-    wchar_t	*nvr_path;
+    char	*nvr_path;
     uint8_t	pci_slot;
     int		has_bios;
     int		BIOSBase;
@@ -1098,7 +1098,7 @@ esp_bios_disable(esp_t *dev)
 static void
 dc390_save_eeprom(esp_t *dev)
 {
-        FILE *f = nvr_fopen(dev->nvr_path, L"wb");
+        FILE *f = nvr_fopen(dev->nvr_path, "wb");
         if (!f) return;
         fwrite(dev->eeprom.data, 1, 128, f);
         fclose(f);
@@ -1234,7 +1234,7 @@ dc390_load_eeprom(esp_t *dev)
 
     eeprom->out = 1;
 
-    f = nvr_fopen(dev->nvr_path, L"rb");
+    f = nvr_fopen(dev->nvr_path, "rb");
     if (f) {
 	esp_log("EEPROM Load\n");
 	if (fread(nvr, 1, 128, f) != 128)
@@ -1452,7 +1452,7 @@ dc390_init(const device_t *info)
     if (dev->has_bios)
 	esp_bios_disable(dev);
 
-    dev->nvr_path = L"dc390.nvr";
+    dev->nvr_path = "dc390.nvr";
 
     /* Load the serial EEPROM. */
     dc390_load_eeprom(dev);

--- a/src/scsi/scsi_spock.c
+++ b/src/scsi/scsi_spock.c
@@ -40,11 +40,11 @@
 #include <86box/scsi_device.h>
 #include <86box/scsi_spock.h>
 
-#define SPOCK_U68_1990_ROM		L"roms/scsi/ibm/64f4376.bin"
-#define SPOCK_U69_1990_ROM		L"roms/scsi/ibm/64f4377.bin"
+#define SPOCK_U68_1990_ROM		"roms/scsi/ibm/64f4376.bin"
+#define SPOCK_U69_1990_ROM		"roms/scsi/ibm/64f4377.bin"
 
-#define SPOCK_U68_1991_ROM		L"roms/scsi/ibm/92F2244.U68"
-#define SPOCK_U69_1991_ROM		L"roms/scsi/ibm/92F2245.U69"
+#define SPOCK_U68_1991_ROM		"roms/scsi/ibm/92F2244.U68"
+#define SPOCK_U69_1991_ROM		"roms/scsi/ibm/92F2245.U69"
 
 #define SPOCK_TIME (20)
 

--- a/src/sound/midi_mt32.c
+++ b/src/sound/midi_mt32.c
@@ -69,14 +69,14 @@ mt32emu_return_code mt32_check(const char* func, mt32emu_return_code ret, mt32em
 int mt32_available()
 {
         if (roms_present[0] < 0)
-                roms_present[0] = (rom_present(L"roms/sound/mt32/mt32_control.rom") && rom_present(L"roms/sound/mt32/mt32_pcm.rom"));
+                roms_present[0] = (rom_present("roms/sound/mt32/mt32_control.rom") && rom_present("roms/sound/mt32/mt32_pcm.rom"));
         return roms_present[0];
 }
 
 int cm32l_available()
 {
         if (roms_present[1] < 0)
-                roms_present[1] = (rom_present(L"roms/sound/cm32l/cm32l_control.rom") && rom_present(L"roms/sound/cm32l/cm32l_pcm.rom"));
+                roms_present[1] = (rom_present("roms/sound/cm32l/cm32l_control.rom") && rom_present("roms/sound/cm32l/cm32l_pcm.rom"));
         return roms_present[1];
 }
 
@@ -165,19 +165,16 @@ void mt32_sysex(uint8_t* data, unsigned int len)
         if (context) mt32_check("mt32emu_play_sysex", mt32emu_play_sysex(context, data, len), MT32EMU_RC_OK);
 }
 
-void* mt32emu_init(wchar_t *control_rom, wchar_t *pcm_rom)
+void* mt32emu_init(char *control_rom, char *pcm_rom)
 {
 	midi_device_t* dev;
-        wchar_t s[512];
         char fn[512];
 
         context = mt32emu_create_context(handler, NULL);
 
-        if (!rom_getfile(control_rom, s, 512)) return 0;
-	wcstombs(fn, s, (wcslen(s) << 1) + 2);
+        if (!rom_getfile(control_rom, fn, 512)) return 0;
         if (!mt32_check("mt32emu_add_rom_file", mt32emu_add_rom_file(context, fn), MT32EMU_RC_ADDED_CONTROL_ROM)) return 0;
-        if (!rom_getfile(pcm_rom, s, 512)) return 0;
-	wcstombs(fn, s, (wcslen(s) << 1) + 2);
+        if (!rom_getfile(pcm_rom, fn, 512)) return 0;
         if (!mt32_check("mt32emu_add_rom_file", mt32emu_add_rom_file(context, fn), MT32EMU_RC_ADDED_PCM_ROM)) return 0;
 
         if (!mt32_check("mt32emu_open_synth", mt32emu_open_synth(context), MT32EMU_RC_OK)) return 0;
@@ -229,12 +226,12 @@ void* mt32emu_init(wchar_t *control_rom, wchar_t *pcm_rom)
 
 void *mt32_init(const device_t *info)
 {
-	return mt32emu_init(L"roms/sound/mt32/mt32_control.rom", L"roms/sound/mt32/mt32_pcm.rom");
+	return mt32emu_init("roms/sound/mt32/mt32_control.rom", "roms/sound/mt32/mt32_pcm.rom");
 }
 
 void *cm32l_init(const device_t *info)
 {
-	return mt32emu_init(L"roms/sound/cm32l/cm32l_control.rom", L"roms/sound/cm32l/cm32l_pcm.rom");
+	return mt32emu_init("roms/sound/cm32l/cm32l_control.rom", "roms/sound/cm32l/cm32l_pcm.rom");
 }
 
 void mt32_close(void* p)

--- a/src/sound/snd_adlibgold.c
+++ b/src/sound/snd_adlibgold.c
@@ -776,7 +776,7 @@ void *adgold_init(const device_t *info)
         for (; c >= 0; c--)
                 attenuation[c] = 0;
 
-        f = nvr_fopen(L"adgold.bin", L"rb");
+        f = nvr_fopen("adgold.bin", "rb");
         if (f)
         {
                 if (fread(adgold->adgold_eeprom, 1, 0x1a, f) != 0x1a)
@@ -817,7 +817,7 @@ void adgold_close(void *p)
         FILE *f;
         adgold_t *adgold = (adgold_t *)p;
         
-        f = nvr_fopen(L"adgold.bin", L"wb");
+        f = nvr_fopen("adgold.bin", "wb");
         if (f)
         {
                 fwrite(adgold->adgold_eeprom, 0x1a, 1, f);

--- a/src/sound/snd_azt2316a.c
+++ b/src/sound/snd_azt2316a.c
@@ -888,7 +888,7 @@ static void *
 azt_init(const device_t *info)
 {
 	FILE *f;
-	wchar_t *fn = NULL;
+	char *fn = NULL;
         int i;
         int loaded_from_eeprom = 0;
 	uint16_t addr_setting;
@@ -899,13 +899,13 @@ azt_init(const device_t *info)
 	azt2316a->type = info->local;
 	
 	if (azt2316a->type == SB_SUBTYPE_CLONE_AZT1605_0X0C) {
-		fn = L"azt1605.nvr";
+		fn = "azt1605.nvr";
 	} else if (azt2316a->type == SB_SUBTYPE_CLONE_AZT2316A_0X11) {
-		fn = L"azt2316a.nvr";
+		fn = "azt2316a.nvr";
 	}
 
         /* config */
-        f = nvr_fopen(fn, L"rb");
+        f = nvr_fopen(fn, "rb");
         if (f) {
                 uint8_t checksum = 0x7f;
                 uint8_t saved_checksum;
@@ -1191,19 +1191,19 @@ static void
 azt_close(void *p)
 {
 	azt2316a_t *azt2316a = (azt2316a_t *)p;
-	wchar_t *fn = NULL;
+	char *fn = NULL;
 	FILE *f;
 	uint8_t checksum = 0x7f;
 	int i;
 
 	if (azt2316a->type == SB_SUBTYPE_CLONE_AZT1605_0X0C) {
-		fn = L"azt1605.nvr";
+		fn = "azt1605.nvr";
 	} else if (azt2316a->type == SB_SUBTYPE_CLONE_AZT2316A_0X11) {
-		fn = L"azt2316a.nvr";
+		fn = "azt2316a.nvr";
 	}
 
 	/* always save to eeprom (recover from bad values) */
-	f = nvr_fopen(fn, L"wb");
+	f = nvr_fopen(fn, "wb");
 	if (f) {
 		for (i = 0; i < AZTECH_EEPROM_SIZE; i++)
 			checksum += azt2316a->sb->dsp.azt_eeprom[i];

--- a/src/sound/snd_emu8k.c
+++ b/src/sound/snd_emu8k.c
@@ -2160,7 +2160,7 @@ void emu8k_init(emu8k_t *emu8k, uint16_t emu_addr, int onboard_ram)
         int c;
         double out;
  
-        f = rom_fopen(L"roms/sound/awe32.raw", L"rb");
+        f = rom_fopen("roms/sound/awe32.raw", "rb");
         if (!f)
                 fatal("AWE32.RAW not found\n");
         

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -1688,7 +1688,7 @@ sb_16_pnp_init(const device_t *info)
 static int
 sb_awe32_available()
 {
-    return rom_present(L"roms/sound/awe32.raw");
+    return rom_present("roms/sound/awe32.raw");
 }
 
 

--- a/src/video/vid_ati18800.c
+++ b/src/video/vid_ati18800.c
@@ -34,10 +34,10 @@
 
 
 #if defined(DEV_BRANCH) && defined(USE_VGAWONDER)
-#define BIOS_ROM_PATH_WONDER	L"roms/video/ati18800/VGA_Wonder_V3-1.02.bin"
+#define BIOS_ROM_PATH_WONDER	"roms/video/ati18800/VGA_Wonder_V3-1.02.bin"
 #endif
-#define BIOS_ROM_PATH_VGA88	L"roms/video/ati18800/vga88.bin"
-#define BIOS_ROM_PATH_EDGE16	L"roms/video/ati18800/vgaedge16.vbi"
+#define BIOS_ROM_PATH_VGA88	"roms/video/ati18800/vga88.bin"
+#define BIOS_ROM_PATH_EDGE16	"roms/video/ati18800/vgaedge16.vbi"
 
 enum {
 #if defined(DEV_BRANCH) && defined(USE_VGAWONDER)
@@ -230,7 +230,7 @@ static void *ati18800_init(const device_t *info)
 
         ati18800->svga.miscout = 1;
 
-	ati_eeprom_load(&ati18800->eeprom, L"ati18800.nvr", 0);
+	ati_eeprom_load(&ati18800->eeprom, "ati18800.nvr", 0);
 
         return ati18800;
 }

--- a/src/video/vid_ati28800.c
+++ b/src/video/vid_ati28800.c
@@ -42,23 +42,23 @@
 #define VGAWONDERXL24		2
 #endif
 
-#define BIOS_ATIKOR_PATH	L"roms/video/ati28800/atikorvga.bin"
-#define BIOS_ATIKOR_4620P_PATH_L	L"roms/machines/spc4620p/31005h.u8"
-#define BIOS_ATIKOR_4620P_PATH_H	L"roms/machines/spc4620p/31005h.u10"
-#define BIOS_ATIKOR_6033P_PATH	L"roms/machines/spc6033p/phoenix.bin"
-#define FONT_ATIKOR_PATH	L"roms/video/ati28800/ati_ksc5601.rom"
-#define FONT_ATIKOR_4620P_PATH	L"roms/machines/spc4620p/svb6120a_font.rom"
-#define FONT_ATIKOR_6033P_PATH	L"roms/machines/spc6033p/svb6120a_font.rom"
+#define BIOS_ATIKOR_PATH	"roms/video/ati28800/atikorvga.bin"
+#define BIOS_ATIKOR_4620P_PATH_L	"roms/machines/spc4620p/31005h.u8"
+#define BIOS_ATIKOR_4620P_PATH_H	"roms/machines/spc4620p/31005h.u10"
+#define BIOS_ATIKOR_6033P_PATH	"roms/machines/spc6033p/phoenix.bin"
+#define FONT_ATIKOR_PATH	"roms/video/ati28800/ati_ksc5601.rom"
+#define FONT_ATIKOR_4620P_PATH	"roms/machines/spc4620p/svb6120a_font.rom"
+#define FONT_ATIKOR_6033P_PATH	"roms/machines/spc6033p/svb6120a_font.rom"
 
-#define BIOS_VGAXL_EVEN_PATH	L"roms/video/ati28800/xleven.bin"
-#define BIOS_VGAXL_ODD_PATH	L"roms/video/ati28800/xlodd.bin"
+#define BIOS_VGAXL_EVEN_PATH	"roms/video/ati28800/xleven.bin"
+#define BIOS_VGAXL_ODD_PATH	"roms/video/ati28800/xlodd.bin"
 
 #if defined(DEV_BRANCH) && defined(USE_XL24)
-#define BIOS_XL24_EVEN_PATH	L"roms/video/ati28800/112-14318-102.bin"
-#define BIOS_XL24_ODD_PATH	L"roms/video/ati28800/112-14319-102.bin"
+#define BIOS_XL24_EVEN_PATH	"roms/video/ati28800/112-14318-102.bin"
+#define BIOS_XL24_ODD_PATH	"roms/video/ati28800/112-14319-102.bin"
 #endif
 
-#define BIOS_ROM_PATH		L"roms/video/ati28800/bios.bin"
+#define BIOS_ROM_PATH		"roms/video/ati28800/bios.bin"
 
 
 typedef struct ati28800_t
@@ -517,7 +517,7 @@ ati28800k_init(const device_t *info)
     ati28800->svga.ksc5601_swap_mode = 0;
     ati28800->svga.ksc5601_english_font_type = 0;
 
-    ati_eeprom_load(&ati28800->eeprom, L"atikorvga.nvr", 0);
+    ati_eeprom_load(&ati28800->eeprom, "atikorvga.nvr", 0);
 
     return ati28800;
 }
@@ -583,17 +583,17 @@ ati28800_init(const device_t *info)
 
     switch (info->local) {
 	case VGAWONDERXL:
-		ati_eeprom_load(&ati28800->eeprom, L"ati28800xl.nvr", 0);
+		ati_eeprom_load(&ati28800->eeprom, "ati28800xl.nvr", 0);
 		break;
 
 #if defined(DEV_BRANCH) && defined(USE_XL24)
 	case VGAWONDERXL24:
-		ati_eeprom_load(&ati28800->eeprom, L"ati28800xl24.nvr", 0);
+		ati_eeprom_load(&ati28800->eeprom, "ati28800xl24.nvr", 0);
 		break;
 #endif
 
 	default:
-		ati_eeprom_load(&ati28800->eeprom, L"ati28800.nvr", 0);
+		ati_eeprom_load(&ati28800->eeprom, "ati28800.nvr", 0);
 		break;
     }	
 

--- a/src/video/vid_ati_eeprom.c
+++ b/src/video/vid_ati_eeprom.c
@@ -28,16 +28,13 @@
 #include <86box/vid_ati_eeprom.h>
 
 
-void ati_eeprom_load(ati_eeprom_t *eeprom, wchar_t *fn, int type)
+void ati_eeprom_load(ati_eeprom_t *eeprom, char *fn, int type)
 {
         FILE *f;
 	int size;
         eeprom->type = type;
-	if (wcslen(fn) <= 256)
-	        wcscpy(eeprom->fn, fn);
-	else
-	        wcsncpy(eeprom->fn, fn, 256);
-        f = nvr_fopen(eeprom->fn, L"rb");
+	strncpy(eeprom->fn, fn, sizeof(eeprom->fn) - 1);
+        f = nvr_fopen(eeprom->fn, "rb");
 	size = eeprom->type ? 512 : 128;
         if (!f) {
                 memset(eeprom->data, 0xff, size);
@@ -50,7 +47,7 @@ void ati_eeprom_load(ati_eeprom_t *eeprom, wchar_t *fn, int type)
 
 void ati_eeprom_save(ati_eeprom_t *eeprom)
 {
-        FILE *f = nvr_fopen(eeprom->fn, L"wb");
+        FILE *f = nvr_fopen(eeprom->fn, "wb");
         if (!f) return;
         fwrite(eeprom->data, 1, eeprom->type ? 512 : 128, f);
         fclose(f);

--- a/src/video/vid_ati_mach64.c
+++ b/src/video/vid_ati_mach64.c
@@ -42,10 +42,10 @@
 #undef CLAMP
 #endif
 
-#define BIOS_ROM_PATH		L"roms/video/mach64/bios.bin"
-#define BIOS_ISA_ROM_PATH	L"roms/video/mach64/M64-1994.VBI"
-#define BIOS_VLB_ROM_PATH	L"roms/video/mach64/mach64_vlb_vram.bin"
-#define BIOS_ROMVT2_PATH	L"roms/video/mach64/atimach64vt2pci.bin"
+#define BIOS_ROM_PATH		"roms/video/mach64/bios.bin"
+#define BIOS_ISA_ROM_PATH	"roms/video/mach64/M64-1994.VBI"
+#define BIOS_VLB_ROM_PATH	"roms/video/mach64/mach64_vlb_vram.bin"
+#define BIOS_ROMVT2_PATH	"roms/video/mach64/atimach64vt2pci.bin"
 
 
 #define FIFO_SIZE 65536
@@ -3388,7 +3388,7 @@ static void *mach64gx_init(const device_t *info)
         else if ((info->flags & DEVICE_VLB) || (info->flags & DEVICE_ISA))
                 mach64->config_stat0 |= 1; /*VLB, 256Kx16 DRAM*/
 
-        ati_eeprom_load(&mach64->eeprom, L"mach64.nvr", 1);
+        ati_eeprom_load(&mach64->eeprom, "mach64.nvr", 1);
 
         if (info->flags & DEVICE_PCI)
 	        rom_init(&mach64->bios_rom, BIOS_ROM_PATH, 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
@@ -3417,7 +3417,7 @@ static void *mach64vt2_init(const device_t *info)
         mach64->config_stat0 = 4;
         mach64->use_block_decoded_io = 4;
         
-        ati_eeprom_load(&mach64->eeprom, L"mach64vt.nvr", 1);
+        ati_eeprom_load(&mach64->eeprom, "mach64vt.nvr", 1);
 
         rom_init(&mach64->bios_rom, BIOS_ROMVT2_PATH, 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
         

--- a/src/video/vid_cl54xx.c
+++ b/src/video/vid_cl54xx.c
@@ -40,23 +40,23 @@
 #include <86box/vid_svga.h>
 #include <86box/vid_svga_render.h>
 
-#define BIOS_GD5401_PATH		L"roms/video/cirruslogic/avga1.rom"
-#define BIOS_GD5402_PATH		L"roms/video/cirruslogic/avga2.rom"
-#define BIOS_GD5402_ONBOARD_PATH	L"roms/machines/cbm_sl386sx25/c000.rom"
-#define BIOS_GD5420_PATH		L"roms/video/cirruslogic/5420.vbi"
-#define BIOS_GD5422_PATH		L"roms/video/cirruslogic/cl5422.bin"
-#define BIOS_GD5426_PATH		L"roms/video/cirruslogic/Diamond SpeedStar PRO VLB v3.04.bin"
-#define BIOS_GD5428_ISA_PATH		L"roms/video/cirruslogic/5428.bin"
-#define BIOS_GD5428_PATH		L"roms/video/cirruslogic/vlbusjapan.BIN"
-#define BIOS_GD5429_PATH		L"roms/video/cirruslogic/5429.vbi"
-#define BIOS_GD5430_VLB_PATH		L"roms/video/cirruslogic/diamondvlbus.bin"
-#define BIOS_GD5430_PCI_PATH		L"roms/video/cirruslogic/pci.bin"
-#define BIOS_GD5434_PATH		L"roms/video/cirruslogic/gd5434.bin"
-#define BIOS_GD5436_PATH		L"roms/video/cirruslogic/5436.vbi"
-#define BIOS_GD5440_PATH		L"roms/video/cirruslogic/BIOS.BIN"
-#define BIOS_GD5446_PATH		L"roms/video/cirruslogic/5446BV.VBI"
-#define BIOS_GD5446_STB_PATH		L"roms/video/cirruslogic/stb nitro64v.BIN"
-#define BIOS_GD5480_PATH		L"roms/video/cirruslogic/clgd5480.rom"
+#define BIOS_GD5401_PATH		"roms/video/cirruslogic/avga1.rom"
+#define BIOS_GD5402_PATH		"roms/video/cirruslogic/avga2.rom"
+#define BIOS_GD5402_ONBOARD_PATH	"roms/machines/cbm_sl386sx25/c000.rom"
+#define BIOS_GD5420_PATH		"roms/video/cirruslogic/5420.vbi"
+#define BIOS_GD5422_PATH		"roms/video/cirruslogic/cl5422.bin"
+#define BIOS_GD5426_PATH		"roms/video/cirruslogic/Diamond SpeedStar PRO VLB v3.04.bin"
+#define BIOS_GD5428_ISA_PATH		"roms/video/cirruslogic/5428.bin"
+#define BIOS_GD5428_PATH		"roms/video/cirruslogic/vlbusjapan.BIN"
+#define BIOS_GD5429_PATH		"roms/video/cirruslogic/5429.vbi"
+#define BIOS_GD5430_VLB_PATH		"roms/video/cirruslogic/diamondvlbus.bin"
+#define BIOS_GD5430_PCI_PATH		"roms/video/cirruslogic/pci.bin"
+#define BIOS_GD5434_PATH		"roms/video/cirruslogic/gd5434.bin"
+#define BIOS_GD5436_PATH		"roms/video/cirruslogic/5436.vbi"
+#define BIOS_GD5440_PATH		"roms/video/cirruslogic/BIOS.BIN"
+#define BIOS_GD5446_PATH		"roms/video/cirruslogic/5446BV.VBI"
+#define BIOS_GD5446_STB_PATH		"roms/video/cirruslogic/stb nitro64v.BIN"
+#define BIOS_GD5480_PATH		"roms/video/cirruslogic/clgd5480.rom"
 
 #define CIRRUS_ID_CLGD5401	  	0x88
 #define CIRRUS_ID_CLGD5402	  	0x89
@@ -3711,7 +3711,7 @@ static void
     svga_t *svga = &gd54xx->svga;
     int id = info->local & 0xff;
     int vram;
-    wchar_t *romfn = NULL;
+    char *romfn = NULL;
     memset(gd54xx, 0, sizeof(gd54xx_t));
 
     gd54xx->pci = !!(info->flags & DEVICE_PCI);	

--- a/src/video/vid_ega.c
+++ b/src/video/vid_ega.c
@@ -38,12 +38,12 @@
 void ega_doblit(int y1, int y2, int wx, int wy, ega_t *ega);
 
 
-#define BIOS_IBM_PATH		L"roms/video/ega/ibm_6277356_ega_card_u44_27128.bin"
-#define BIOS_CPQ_PATH		L"roms/video/ega/108281-001.bin"
-#define BIOS_SEGA_PATH		L"roms/video/ega/lega.vbi"
-#define BIOS_ATIEGA_PATH	L"roms/video/ega/ATI EGA Wonder 800+ N1.00.BIN"
-#define BIOS_ISKRA_PATH		L"roms/video/ega/143-02.bin", L"roms/video/ega/143-03.bin"
-#define BIOS_TSENG_PATH		L"roms/video/ega/EGA ET2000.BIN"
+#define BIOS_IBM_PATH		"roms/video/ega/ibm_6277356_ega_card_u44_27128.bin"
+#define BIOS_CPQ_PATH		"roms/video/ega/108281-001.bin"
+#define BIOS_SEGA_PATH		"roms/video/ega/lega.vbi"
+#define BIOS_ATIEGA_PATH	"roms/video/ega/ATI EGA Wonder 800+ N1.00.BIN"
+#define BIOS_ISKRA_PATH		"roms/video/ega/143-02.bin", "roms/video/ega/143-03.bin"
+#define BIOS_TSENG_PATH		"roms/video/ega/EGA ET2000.BIN"
 
 
 enum {
@@ -1086,7 +1086,7 @@ ega_standalone_init(const device_t *info)
 	io_sethandler(0x01ce, 0x0002, ega_in, NULL, NULL, ega_out, NULL, NULL, ega);
 	ega->eeprom = malloc(sizeof(ati_eeprom_t));
 	memset(ega->eeprom, 0, sizeof(ati_eeprom_t));
-	ati_eeprom_load((ati_eeprom_t *) ega->eeprom, L"egawonder800.nvr", 0);
+	ati_eeprom_load((ati_eeprom_t *) ega->eeprom, "egawonder800.nvr", 0);
     }
 
     return ega;
@@ -1124,7 +1124,7 @@ atiega_standalone_available(void)
 static int
 iskra_ega_standalone_available(void)
 {
-    return rom_present(L"roms/video/ega/143-02.bin") && rom_present(L"roms/video/ega/143-03.bin");
+    return rom_present("roms/video/ega/143-02.bin") && rom_present("roms/video/ega/143-03.bin");
 }
 
 

--- a/src/video/vid_et4000.c
+++ b/src/video/vid_et4000.c
@@ -54,11 +54,11 @@
 #include <86box/vid_svga_render.h>
 
 
-#define BIOS_ROM_PATH		L"roms/video/et4000/et4000.bin"
-#define KOREAN_BIOS_ROM_PATH 	L"roms/video/et4000/tgkorvga.bin"
-#define KOREAN_FONT_ROM_PATH 	L"roms/video/et4000/tg_ksc5601.rom"
-#define KASAN_BIOS_ROM_PATH 	L"roms/video/et4000/et4000_kasan16.bin"
-#define KASAN_FONT_ROM_PATH 	L"roms/video/et4000/kasan_ksc5601.rom"
+#define BIOS_ROM_PATH		"roms/video/et4000/et4000.bin"
+#define KOREAN_BIOS_ROM_PATH 	"roms/video/et4000/tgkorvga.bin"
+#define KOREAN_FONT_ROM_PATH 	"roms/video/et4000/tg_ksc5601.rom"
+#define KASAN_BIOS_ROM_PATH 	"roms/video/et4000/et4000_kasan16.bin"
+#define KASAN_FONT_ROM_PATH 	"roms/video/et4000/kasan_ksc5601.rom"
 
 typedef struct {
     const char		*name;
@@ -638,7 +638,7 @@ et4000_mca_feedb(void *priv)
 static void *
 et4000_init(const device_t *info)
 {
-    const wchar_t *fn;
+    const char *fn;
     et4000_t *dev;
     int i;
 
@@ -737,7 +737,7 @@ et4000_init(const device_t *info)
 
     dev->vram_mask = dev->vram_size - 1;
 
-    rom_init(&dev->bios_rom, (wchar_t *) fn,
+    rom_init(&dev->bios_rom, (char *) fn,
 	     0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
 
     dev->svga.translate_address = get_et4000_addr;

--- a/src/video/vid_et4000w32.c
+++ b/src/video/vid_et4000w32.c
@@ -38,13 +38,13 @@
 #include <86box/vid_svga_render.h>
 
 
-#define BIOS_ROM_PATH_DIAMOND	L"roms/video/et4000w32/et4000w32.bin"
-#define BIOS_ROM_PATH_CARDEX	L"roms/video/et4000w32/cardex.vbi"
-#define BIOS_ROM_PATH_W32	L"roms/video/et4000w32/ET4000W32VLB_bios_MX27C512.BIN"
-#define BIOS_ROM_PATH_W32I_ISA	L"roms/video/et4000w32/ET4KW32I.VBI"
-#define BIOS_ROM_PATH_W32I_VLB	L"roms/video/et4000w32/tseng.u41.bin"
-#define BIOS_ROM_PATH_W32P	L"roms/video/et4000w32/ET4K_W32.BIN"
-#define BIOS_ROM_PATH_W32P_REVC	L"roms/video/et4000w32/et4000w32pcardex.BIN"
+#define BIOS_ROM_PATH_DIAMOND	"roms/video/et4000w32/et4000w32.bin"
+#define BIOS_ROM_PATH_CARDEX	"roms/video/et4000w32/cardex.vbi"
+#define BIOS_ROM_PATH_W32	"roms/video/et4000w32/ET4000W32VLB_bios_MX27C512.BIN"
+#define BIOS_ROM_PATH_W32I_ISA	"roms/video/et4000w32/ET4KW32I.VBI"
+#define BIOS_ROM_PATH_W32I_VLB	"roms/video/et4000w32/tseng.u41.bin"
+#define BIOS_ROM_PATH_W32P	"roms/video/et4000w32/ET4K_W32.BIN"
+#define BIOS_ROM_PATH_W32P_REVC	"roms/video/et4000w32/et4000w32pcardex.BIN"
 
 #define FIFO_SIZE		65536
 #define FIFO_MASK		(FIFO_SIZE - 1)

--- a/src/video/vid_genius.c
+++ b/src/video/vid_genius.c
@@ -33,7 +33,7 @@
 #include <86box/video.h>
 
 
-#define BIOS_ROM_PATH	L"roms/video/genius/8x12.bin"
+#define BIOS_ROM_PATH	"roms/video/genius/8x12.bin"
 
 
 #define GENIUS_XSIZE 728

--- a/src/video/vid_ht216.c
+++ b/src/video/vid_ht216.c
@@ -94,9 +94,9 @@ void ht216_out(uint16_t addr, uint8_t val, void *p);
 uint8_t ht216_in(uint16_t addr, void *p);
 
 
-#define BIOS_G2_GC205_PATH			L"roms/video/video7/BIOS.BIN"
-#define BIOS_VIDEO7_VGA_1024I_PATH		L"roms/video/video7/Video Seven VGA 1024i - BIOS - v2.19 - 435-0062-05 - U17 - 27C256.BIN"
-#define BIOS_HT216_32_PATH			L"roms/video/video7/HT21632.BIN"
+#define BIOS_G2_GC205_PATH			"roms/video/video7/BIOS.BIN"
+#define BIOS_VIDEO7_VGA_1024I_PATH		"roms/video/video7/Video Seven VGA 1024i - BIOS - v2.19 - 435-0062-05 - U17 - 27C256.BIN"
+#define BIOS_HT216_32_PATH			"roms/video/video7/HT21632.BIN"
 
 static video_timings_t	timing_v7vga_isa = {VIDEO_ISA, 3,  3,  6,   5,  5, 10};
 static video_timings_t	timing_v7vga_vlb = {VIDEO_BUS, 5,  5,  9,  20, 20, 30};

--- a/src/video/vid_im1024.c
+++ b/src/video/vid_im1024.c
@@ -66,7 +66,7 @@
 #include <86box/vid_pgc.h>
 
 
-#define BIOS_ROM_PATH	L"roms/video/im1024/im1024font.bin"
+#define BIOS_ROM_PATH	"roms/video/im1024/im1024font.bin"
 
 
 typedef struct {

--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -34,8 +34,8 @@
 #include <86box/vid_svga_render.h>
 
 
-#define ROM_MYSTIQUE			L"roms/video/matrox/MYSTIQUE.VBI"
-#define ROM_MYSTIQUE_220		L"roms/video/matrox/Myst220_66-99mhz.vbi"
+#define ROM_MYSTIQUE			"roms/video/matrox/MYSTIQUE.VBI"
+#define ROM_MYSTIQUE_220		"roms/video/matrox/Myst220_66-99mhz.vbi"
 
 #define FIFO_SIZE 65536
 #define FIFO_MASK (FIFO_SIZE - 1)
@@ -4917,7 +4917,7 @@ mystique_init(const device_t *info)
 {
     int c;
     mystique_t *mystique = malloc(sizeof(mystique_t));
-    wchar_t *romfn;
+    char *romfn;
 
     memset(mystique, 0, sizeof(mystique_t));
 

--- a/src/video/vid_nga.c
+++ b/src/video/vid_nga.c
@@ -566,7 +566,7 @@ nga_init(const device_t *info)
 
     charset = device_get_config_int("charset");
 
-	loadfont_ex(L"roms/video/nga/ncr_nga_35122.bin", 1, 4096 * charset);
+	loadfont_ex("roms/video/nga/ncr_nga_35122.bin", 1, 4096 * charset);
     
 	nga->cga.composite = 0; 
     nga->cga.snow_enabled = device_get_config_int("snow_enabled");

--- a/src/video/vid_oak_oti.c
+++ b/src/video/vid_oak_oti.c
@@ -29,11 +29,11 @@
 #include <86box/video.h>
 #include <86box/vid_svga.h>
 
-#define BIOS_037C_PATH			L"roms/video/oti/bios.bin"
-#define BIOS_067_AMA932J_PATH	L"roms/machines/ama932j/oti067.bin"
-#define BIOS_067_M300_08_PATH	L"roms/machines/olivetti_m300_08/EVC_BIOS.ROM"
-#define BIOS_067_M300_15_PATH	L"roms/machines/olivetti_m300_15/EVC_BIOS.ROM"
-#define BIOS_077_PATH			L"roms/video/oti/oti077.vbi"
+#define BIOS_037C_PATH			"roms/video/oti/bios.bin"
+#define BIOS_067_AMA932J_PATH	"roms/machines/ama932j/oti067.bin"
+#define BIOS_067_M300_08_PATH	"roms/machines/olivetti_m300_08/EVC_BIOS.ROM"
+#define BIOS_067_M300_15_PATH	"roms/machines/olivetti_m300_15/EVC_BIOS.ROM"
+#define BIOS_077_PATH			"roms/video/oti/oti077.vbi"
 
 
 enum {
@@ -340,7 +340,7 @@ static void *
 oti_init(const device_t *info)
 {
     oti_t *oti = malloc(sizeof(oti_t));
-    wchar_t *romfn = NULL;
+    char *romfn = NULL;
 
     memset(oti, 0x00, sizeof(oti_t));
     oti->chip_id = info->local;

--- a/src/video/vid_ogc.c
+++ b/src/video/vid_ogc.c
@@ -603,7 +603,7 @@ ogc_init(const device_t *info)
     memset(ogc, 0x00, sizeof(ogc_t));
     video_inform(VIDEO_FLAG_TYPE_CGA, &timing_ogc);
 
-    loadfont(L"roms/video/ogc/ogc graphics board go380 258 pqbq.bin", 1);
+    loadfont("roms/video/ogc/ogc graphics board go380 258 pqbq.bin", 1);
     
 	/* composite is not working yet */
 	// display_type = device_get_config_int("display_type");

--- a/src/video/vid_paradise.c
+++ b/src/video/vid_paradise.c
@@ -357,7 +357,7 @@ static void *paradise_pvga1a_ncr3302_init(const device_t *info)
         paradise_t *paradise = paradise_init(info, 1 << 18);
         
         if (paradise)
-                rom_init(&paradise->bios_rom, L"roms/machines/ncr_3302/c000-wd_1987-1989-740011-003058-019c.bin", 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
+                rom_init(&paradise->bios_rom, "roms/machines/ncr_3302/c000-wd_1987-1989-740011-003058-019c.bin", 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
                 
         return paradise;
 }
@@ -367,7 +367,7 @@ static void *paradise_pvga1a_pc2086_init(const device_t *info)
         paradise_t *paradise = paradise_init(info, 1 << 18);
         
         if (paradise)
-                rom_init(&paradise->bios_rom, L"roms/machines/pc2086/40186.ic171", 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
+                rom_init(&paradise->bios_rom, "roms/machines/pc2086/40186.ic171", 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
                 
         return paradise;
 }
@@ -377,7 +377,7 @@ static void *paradise_pvga1a_pc3086_init(const device_t *info)
         paradise_t *paradise = paradise_init(info, 1 << 18);
 
         if (paradise)
-                rom_init(&paradise->bios_rom, L"roms/machines/pc3086/c000.bin", 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
+                rom_init(&paradise->bios_rom, "roms/machines/pc3086/c000.bin", 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
                 
         return paradise;
 }
@@ -393,14 +393,14 @@ static void *paradise_pvga1a_standalone_init(const device_t *info)
         paradise = paradise_init(info, memory);
         
         if (paradise)
-                rom_init(&paradise->bios_rom, L"roms/video/pvga1a/BIOS.BIN", 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
+                rom_init(&paradise->bios_rom, "roms/video/pvga1a/BIOS.BIN", 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
         
         return paradise;
 }
 
 static int paradise_pvga1a_standalone_available(void)
 {
-        return rom_present(L"roms/video/pvga1a/BIOS.BIN");
+        return rom_present("roms/video/pvga1a/BIOS.BIN");
 }
 
 static void *paradise_wd90c11_megapc_init(const device_t *info)
@@ -409,8 +409,8 @@ static void *paradise_wd90c11_megapc_init(const device_t *info)
         
         if (paradise)
                 rom_init_interleaved(&paradise->bios_rom,
-                                     L"roms/machines/megapc/41651-bios lo.u18",
-                                     L"roms/machines/megapc/211253-bios hi.u19",
+                                     "roms/machines/megapc/41651-bios lo.u18",
+                                     "roms/machines/megapc/211253-bios hi.u19",
                                      0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
         
         return paradise;
@@ -421,14 +421,14 @@ static void *paradise_wd90c11_standalone_init(const device_t *info)
         paradise_t *paradise = paradise_init(info, 0);
         
         if (paradise)
-                rom_init(&paradise->bios_rom, L"roms/video/wd90c11/WD90C11.VBI", 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
+                rom_init(&paradise->bios_rom, "roms/video/wd90c11/WD90C11.VBI", 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
         
         return paradise;
 }
 
 static int paradise_wd90c11_standalone_available(void)
 {
-        return rom_present(L"roms/video/wd90c11/WD90C11.VBI");
+        return rom_present("roms/video/wd90c11/WD90C11.VBI");
 }
 
 static void *paradise_wd90c30_standalone_init(const device_t *info)
@@ -442,14 +442,14 @@ static void *paradise_wd90c30_standalone_init(const device_t *info)
         paradise = paradise_init(info, memory);
         
         if (paradise)
-                rom_init(&paradise->bios_rom, L"roms/video/wd90c30/90C30-LR.VBI", 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
+                rom_init(&paradise->bios_rom, "roms/video/wd90c30/90C30-LR.VBI", 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
 
         return paradise;
 }
 
 static int paradise_wd90c30_standalone_available(void)
 {
-        return rom_present(L"roms/video/wd90c30/90C30-LR.VBI");
+        return rom_present("roms/video/wd90c30/90C30-LR.VBI");
 }
 
 void paradise_close(void *p)

--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -37,25 +37,25 @@
 #include <86box/vid_svga_render.h>
 #include "cpu.h"
 
-#define ROM_ORCHID_86C911		L"roms/video/s3/BIOS.BIN"
-#define ROM_DIAMOND_STEALTH_VRAM	L"roms/video/s3/Diamond Stealth VRAM BIOS v2.31 U14.BIN"
-#define ROM_AMI_86C924			L"roms/video/s3/S3924AMI.BIN"
-#define ROM_METHEUS_86C928		L"roms/video/s3/928.vbi"
-#define ROM_V7MIRAGE_86C801		L"roms/video/s3/v7mirage.vbi"
-#define ROM_PHOENIX_86C805		L"roms/video/s3/805.vbi"
-#define ROM_PARADISE_BAHAMAS64		L"roms/video/s3/bahamas64.bin"
-#define ROM_PHOENIX_VISION864		L"roms/video/s3/86c864p.bin"
-#define ROM_DIAMOND_STEALTH64_964	L"roms/video/s3/964_107h.rom"
-#define ROM_PHOENIX_TRIO32		L"roms/video/s3/86c732p.bin"
-#define ROM_NUMBER9_9FX			L"roms/video/s3/s3_764.bin"
-#define ROM_PHOENIX_TRIO64		L"roms/video/s3/86c764x1.bin"
-#define ROM_DIAMOND_STEALTH64_764	L"roms/video/s3/stealt64.bin"
-#define ROM_TRIO64V2_DX_VBE20		L"roms/video/s3/86c775_2.bin"
-#define ROM_PHOENIX_TRIO64VPLUS		L"roms/video/s3/64V1506.ROM"
-#define ROM_DIAMOND_STEALTH_SE		L"roms/video/s3/DiamondStealthSE.VBI"
-#define ROM_ELSAWIN2KPROX_964		L"roms/video/s3/elsaw20004m.BIN"
-#define ROM_ELSAWIN2KPROX		L"roms/video/s3/elsaw20008m.BIN"
-#define ROM_PHOENIX_VISION868		L"roms/video/s3/1-DSV3868.BIN"
+#define ROM_ORCHID_86C911		"roms/video/s3/BIOS.BIN"
+#define ROM_DIAMOND_STEALTH_VRAM	"roms/video/s3/Diamond Stealth VRAM BIOS v2.31 U14.BIN"
+#define ROM_AMI_86C924			"roms/video/s3/S3924AMI.BIN"
+#define ROM_METHEUS_86C928		"roms/video/s3/928.vbi"
+#define ROM_V7MIRAGE_86C801		"roms/video/s3/v7mirage.vbi"
+#define ROM_PHOENIX_86C805		"roms/video/s3/805.vbi"
+#define ROM_PARADISE_BAHAMAS64		"roms/video/s3/bahamas64.bin"
+#define ROM_PHOENIX_VISION864		"roms/video/s3/86c864p.bin"
+#define ROM_DIAMOND_STEALTH64_964	"roms/video/s3/964_107h.rom"
+#define ROM_PHOENIX_TRIO32		"roms/video/s3/86c732p.bin"
+#define ROM_NUMBER9_9FX			"roms/video/s3/s3_764.bin"
+#define ROM_PHOENIX_TRIO64		"roms/video/s3/86c764x1.bin"
+#define ROM_DIAMOND_STEALTH64_764	"roms/video/s3/stealt64.bin"
+#define ROM_TRIO64V2_DX_VBE20		"roms/video/s3/86c775_2.bin"
+#define ROM_PHOENIX_TRIO64VPLUS		"roms/video/s3/64V1506.ROM"
+#define ROM_DIAMOND_STEALTH_SE		"roms/video/s3/DiamondStealthSE.VBI"
+#define ROM_ELSAWIN2KPROX_964		"roms/video/s3/elsaw20004m.BIN"
+#define ROM_ELSAWIN2KPROX		"roms/video/s3/elsaw20008m.BIN"
+#define ROM_PHOENIX_VISION868		"roms/video/s3/1-DSV3868.BIN"
 
 enum
 {
@@ -5577,7 +5577,7 @@ static int vram_sizes[] =
 
 static void *s3_init(const device_t *info)
 {
-	const wchar_t *bios_fn;
+	const char *bios_fn;
 	int chip, stepping;
 	s3_t *s3 = malloc(sizeof(s3_t));
 	svga_t *svga = &s3->svga;
@@ -5752,7 +5752,7 @@ static void *s3_init(const device_t *info)
 
 	s3->has_bios = (bios_fn != NULL);
 	if (s3->has_bios) {
-		rom_init(&s3->bios_rom, (wchar_t *) bios_fn, 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
+		rom_init(&s3->bios_rom, (char *) bios_fn, 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
 		if (info->flags & DEVICE_PCI)
 			mem_mapping_disable(&s3->bios_rom.mapping);
 	}

--- a/src/video/vid_s3_virge.c
+++ b/src/video/vid_s3_virge.c
@@ -66,13 +66,13 @@ static int dither[4][4] =
 #define FIFO_TYPE 0xff000000
 #define FIFO_ADDR 0x00ffffff
 
-#define ROM_VIRGE_325			L"roms/video/s3virge/86c325.bin"
-#define ROM_DIAMOND_STEALTH3D_2000	L"roms/video/s3virge/s3virge.bin"
-#define ROM_DIAMOND_STEALTH3D_3000	L"roms/video/s3virge/diamondstealth3000.vbi"
-#define ROM_VIRGE_DX			L"roms/video/s3virge/86c375_1.bin"
-#define ROM_VIRGE_DX_VBE20		L"roms/video/s3virge/86c375_4.bin"
+#define ROM_VIRGE_325			"roms/video/s3virge/86c325.bin"
+#define ROM_DIAMOND_STEALTH3D_2000	"roms/video/s3virge/s3virge.bin"
+#define ROM_DIAMOND_STEALTH3D_3000	"roms/video/s3virge/diamondstealth3000.vbi"
+#define ROM_VIRGE_DX			"roms/video/s3virge/86c375_1.bin"
+#define ROM_VIRGE_DX_VBE20		"roms/video/s3virge/86c375_4.bin"
 #if defined(DEV_BRANCH) && defined(USE_S3TRIO3D2X)
-#define ROM_TRIO3D_2X			L"roms/video/s3virge/TRIO3D2X_8mbsdr.VBI"
+#define ROM_TRIO3D_2X			"roms/video/s3virge/TRIO3D2X_8mbsdr.VBI"
 #endif
 
 enum
@@ -3684,7 +3684,7 @@ static void s3_virge_pci_write(int func, int addr, uint8_t val, void *p)
 
 static void *s3_virge_init(const device_t *info)
 {
-	const wchar_t *bios_fn;
+	const char *bios_fn;
         virge_t *virge = malloc(sizeof(virge_t));
 
         memset(virge, 0, sizeof(virge_t));
@@ -3728,7 +3728,7 @@ static void *s3_virge_init(const device_t *info)
 
 	virge->pci = !!(info->flags & DEVICE_PCI);
 
-        rom_init(&virge->bios_rom, (wchar_t *) bios_fn, 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
+        rom_init(&virge->bios_rom, (char *) bios_fn, 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
         if (info->flags & DEVICE_PCI)
                 mem_mapping_disable(&virge->bios_rom.mapping);
 

--- a/src/video/vid_sigma.c
+++ b/src/video/vid_sigma.c
@@ -31,8 +31,8 @@
 #include <86box/video.h>
 
 
-#define ROM_SIGMA_FONT		L"roms/video/sigma/sigma400_font.rom"
-#define ROM_SIGMA_BIOS		L"roms/video/sigma/sigma400_bios.rom"
+#define ROM_SIGMA_FONT		"roms/video/sigma/sigma400_font.rom"
+#define ROM_SIGMA_BIOS		"roms/video/sigma/sigma400_bios.rom"
 
 /* The Sigma Designs Color 400 is a video card from 1985, presumably intended
  * as an EGA competitor.

--- a/src/video/vid_table.c
+++ b/src/video/vid_table.c
@@ -238,7 +238,7 @@ video_reset(int card)
     vid_table_log("VIDEO: reset (gfxcard=%d, internal=%d)\n",
 		  card, (machines[machine].flags & MACHINE_VIDEO)?1:0);
 
-    loadfont(L"roms/video/mda/mda.rom", 0);
+    loadfont("roms/video/mda/mda.rom", 0);
 
     /* Reset (deallocate) the video font arrays. */
     if (fontdatksc5601) {

--- a/src/video/vid_tgui9440.c
+++ b/src/video/vid_tgui9440.c
@@ -106,8 +106,8 @@
   writes out 16 bytes. I don't think the access size or host data has any affect,
   but the Windows 3.1 driver always reads bytes and write words of 0xffff.*/  
 
-#define ROM_TGUI_9400CXI	L"roms/video/tgui9440/9400CXI.vbi"
-#define ROM_TGUI_9440		L"roms/video/tgui9440/9440.vbi"
+#define ROM_TGUI_9400CXI	"roms/video/tgui9440/9400CXI.vbi"
+#define ROM_TGUI_9440		"roms/video/tgui9440/9440.vbi"
 
 #define EXT_CTRL_16BIT            0x01
 #define EXT_CTRL_MONO_EXPANSION   0x02
@@ -1685,7 +1685,7 @@ void tgui_accel_write_fb_l(uint32_t addr, uint32_t val, void *p)
 
 static void *tgui_init(const device_t *info)
 {
-	const wchar_t *bios_fn;
+	const char *bios_fn;
 	int type = info->local;
 
         tgui_t *tgui = malloc(sizeof(tgui_t));
@@ -1710,7 +1710,7 @@ static void *tgui_init(const device_t *info)
 			return NULL;
 	}
 
-        rom_init(&tgui->bios_rom, (wchar_t *) bios_fn, 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
+        rom_init(&tgui->bios_rom, (char *) bios_fn, 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
 
 	if (info->flags & DEVICE_PCI)
 		video_inform(VIDEO_FLAG_TYPE_SPECIAL, &timing_tgui_pci);
@@ -1749,12 +1749,12 @@ static void *tgui_init(const device_t *info)
 
 static int tgui9400cxi_available()
 {
-        return rom_present(L"roms/video/tgui9440/9400CXI.vbi");
+        return rom_present("roms/video/tgui9440/9400CXI.vbi");
 }
 
 static int tgui9440_available()
 {
-        return rom_present(L"roms/video/tgui9440/9440.vbi");
+        return rom_present("roms/video/tgui9440/9440.vbi");
 }
 
 void tgui_close(void *p)

--- a/src/video/vid_tvga.c
+++ b/src/video/vid_tvga.c
@@ -35,9 +35,9 @@
 #define TVGA9000B_ID		0x23
 #define TVGA8900CLD_ID		0x33
 
-#define ROM_TVGA_8900B		L"roms/video/tvga/tvga8900B.VBI"
-#define ROM_TVGA_8900CLD	L"roms/video/tvga/trident.bin"
-#define ROM_TVGA_9000B		L"roms/video/tvga/tvga9000b.bin"
+#define ROM_TVGA_8900B		"roms/video/tvga/tvga8900B.VBI"
+#define ROM_TVGA_8900CLD	"roms/video/tvga/trident.bin"
+#define ROM_TVGA_9000B		"roms/video/tvga/tvga9000b.bin"
 
 typedef struct tvga_t
 {
@@ -351,7 +351,7 @@ void tvga_recalctimings(svga_t *svga)
 
 static void *tvga_init(const device_t *info)
 {
-	const wchar_t *bios_fn;
+	const char *bios_fn;
         tvga_t *tvga = malloc(sizeof(tvga_t));
         memset(tvga, 0, sizeof(tvga_t));
         
@@ -383,7 +383,7 @@ static void *tvga_init(const device_t *info)
 			return NULL;
 	}
 	
-        rom_init(&tvga->bios_rom, (wchar_t *) bios_fn, 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
+        rom_init(&tvga->bios_rom, (char *) bios_fn, 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
         
         svga_init(info, &tvga->svga, tvga, tvga->vram_size,
                    tvga_recalctimings,

--- a/src/video/vid_vga.c
+++ b/src/video/vid_vga.c
@@ -116,7 +116,7 @@ static void *vga_init(const device_t *info)
         vga_t *vga = malloc(sizeof(vga_t));
         memset(vga, 0, sizeof(vga_t));
 
-        rom_init(&vga->bios_rom, L"roms/video/vga/ibm_vga.bin", 0xc0000, 0x8000, 0x7fff, 0x2000, MEM_MAPPING_EXTERNAL);
+        rom_init(&vga->bios_rom, "roms/video/vga/ibm_vga.bin", 0xc0000, 0x8000, 0x7fff, 0x2000, MEM_MAPPING_EXTERNAL);
 
 	video_inform(VIDEO_FLAG_TYPE_SPECIAL, &timing_vga);
 
@@ -162,7 +162,7 @@ void *ps1vga_init(const device_t *info)
 
 static int vga_available(void)
 {
-        return rom_present(L"roms/video/vga/ibm_vga.bin");
+        return rom_present("roms/video/vga/ibm_vga.bin");
 }
 
 void vga_close(void *p)

--- a/src/video/vid_voodoo.c
+++ b/src/video/vid_voodoo.c
@@ -1229,12 +1229,12 @@ void voodoo_card_close(voodoo_t *voodoo)
         int c;
         
 /* #ifndef RELEASE_BUILD        
-        f = rom_fopen(L"texram.dmp", L"wb");
+        f = rom_fopen("texram.dmp", "wb");
         fwrite(voodoo->tex_mem[0], voodoo->texture_size*1024*1024, 1, f);
         fclose(f);
         if (voodoo->dual_tmus)
         {
-                f = rom_fopen(L"texram2.dmp", L"wb");
+                f = rom_fopen("texram2.dmp", "wb");
                 fwrite(voodoo->tex_mem[1], voodoo->texture_size*1024*1024, 1, f);
                 fclose(f);
         }

--- a/src/video/vid_voodoo_banshee.c
+++ b/src/video/vid_voodoo_banshee.c
@@ -2706,7 +2706,7 @@ static const device_config_t banshee_sdram_config[] =
         }
 };
 
-static void *banshee_init_common(const device_t *info, wchar_t *fn, int has_sgram, int type, int voodoo_type, int agp)
+static void *banshee_init_common(const device_t *info, char *fn, int has_sgram, int type, int voodoo_type, int agp)
 {
         int mem_size;
         banshee_t *banshee = malloc(sizeof(banshee_t));
@@ -2836,19 +2836,19 @@ static void *banshee_init_common(const device_t *info, wchar_t *fn, int has_sgra
 
 static void *banshee_init(const device_t *info)
 {
-        return banshee_init_common(info, L"roms/video/voodoo/Pci_sg.rom", 1, TYPE_BANSHEE, VOODOO_BANSHEE, 0);
+        return banshee_init_common(info, "roms/video/voodoo/Pci_sg.rom", 1, TYPE_BANSHEE, VOODOO_BANSHEE, 0);
 }
 static void *creative_banshee_init(const device_t *info)
 {
-        return banshee_init_common(info, L"roms/video/voodoo/BlasterPCI.rom", 0, TYPE_BANSHEE, VOODOO_BANSHEE, 0);
+        return banshee_init_common(info, "roms/video/voodoo/BlasterPCI.rom", 0, TYPE_BANSHEE, VOODOO_BANSHEE, 0);
 }
 static void *v3_2000_init(const device_t *info)
 {
-        return banshee_init_common(info, L"roms/video/voodoo/2k11sd.rom", 0, TYPE_V3_2000, VOODOO_3, 0);
+        return banshee_init_common(info, "roms/video/voodoo/2k11sd.rom", 0, TYPE_V3_2000, VOODOO_3, 0);
 }
 static void *v3_2000_agp_init(const device_t *info)
 {
-        return banshee_init_common(info, L"roms/video/voodoo/2k11sd.rom", 0, TYPE_V3_2000, VOODOO_3, 1);
+        return banshee_init_common(info, "roms/video/voodoo/2k11sd.rom", 0, TYPE_V3_2000, VOODOO_3, 1);
 }
 static void *v3_2000_agp_onboard_init(const device_t *info)
 {
@@ -2856,29 +2856,29 @@ static void *v3_2000_agp_onboard_init(const device_t *info)
 }
 static void *v3_3000_init(const device_t *info)
 {
-        return banshee_init_common(info, L"roms/video/voodoo/3k12sd.rom", 0, TYPE_V3_3000, VOODOO_3, 0);
+        return banshee_init_common(info, "roms/video/voodoo/3k12sd.rom", 0, TYPE_V3_3000, VOODOO_3, 0);
 }
 static void *v3_3000_agp_init(const device_t *info)
 {
-        return banshee_init_common(info, L"roms/video/voodoo/3k12sd.rom", 0, TYPE_V3_3000, VOODOO_3, 1);
+        return banshee_init_common(info, "roms/video/voodoo/3k12sd.rom", 0, TYPE_V3_3000, VOODOO_3, 1);
 }
 
 static int banshee_available(void)
 {
-        return rom_present(L"roms/video/voodoo/Pci_sg.rom");
+        return rom_present("roms/video/voodoo/Pci_sg.rom");
 }
 static int creative_banshee_available(void)
 {
-        return rom_present(L"roms/video/voodoo/BlasterPCI.rom");
+        return rom_present("roms/video/voodoo/BlasterPCI.rom");
 }
 static int v3_2000_available(void)
 {
-        return rom_present(L"roms/video/voodoo/2k11sd.rom");
+        return rom_present("roms/video/voodoo/2k11sd.rom");
 }
 #define v3_2000_agp_available v3_2000_available
 static int v3_3000_available(void)
 {
-        return rom_present(L"roms/video/voodoo/3k12sd.rom");
+        return rom_present("roms/video/voodoo/3k12sd.rom");
 }
 #define v3_3000_agp_available v3_3000_available
 

--- a/src/video/vid_wy700.c
+++ b/src/video/vid_wy700.c
@@ -906,7 +906,7 @@ void *wy700_init(const device_t *info)
 	/* 128k video RAM */
         wy700->vram = malloc(0x20000);
 
-	loadfont(L"roms/video/wyse700/wy700.rom", 3);
+	loadfont("roms/video/wyse700/wy700.rom", 3);
 
         timer_add(&wy700->timer, wy700_poll, wy700, 1);
 

--- a/src/video/video.c
+++ b/src/video/video.c
@@ -317,7 +317,7 @@ static png_infop	info_ptr;
 
 
 static void
-video_take_screenshot(const wchar_t *fn, int startx, int starty, int y1, int y2, int w, int h)
+video_take_screenshot(const char *fn, int startx, int starty, int y1, int y2, int w, int h)
 {
     int i, x, y;
     png_bytep *b_rgb = NULL;
@@ -325,9 +325,9 @@ video_take_screenshot(const wchar_t *fn, int startx, int starty, int y1, int y2,
     uint32_t temp = 0x00000000;
 
     /* create file */
-    fp = plat_fopen((wchar_t *) fn, (wchar_t *) L"wb");
+    fp = plat_fopen((char *) fn, (char *) "wb");
     if (!fp) {
-	video_log("[video_take_screenshot] File %ls could not be opened for writing", fn);
+	video_log("[video_take_screenshot] File %s could not be opened for writing", fn);
 	return;
     }
 
@@ -390,7 +390,7 @@ video_take_screenshot(const wchar_t *fn, int startx, int starty, int y1, int y2,
 static void
 video_screenshot(int x, int y, int y1, int y2, int w, int h)
 {
-    wchar_t path[1024], fn[128];
+    char path[1024], fn[128];
 
     memset(fn, 0, sizeof(fn));
     memset(path, 0, sizeof(path));
@@ -400,14 +400,14 @@ video_screenshot(int x, int y, int y1, int y2, int w, int h)
     if (! plat_dir_check(path))
 	plat_dir_create(path);
 
-    wcscat(path, L"\\");
+    plat_path_slash(path);
 
-    plat_tempfile(fn, NULL, L".png");
-    wcscat(path, fn);
+    plat_tempfile(fn, NULL, ".png");
+    strcat(path, fn);
 
-    video_log("taking screenshot to: %S\n", path);
+    video_log("taking screenshot to: %s\n", path);
 
-    video_take_screenshot((const wchar_t *) path, x, y, y1, y2, w, h);
+    video_take_screenshot((const char *) path, x, y, y1, y2, w, h);
     png_destroy_write_struct(&png_ptr, &info_ptr);
 }
 
@@ -1051,11 +1051,11 @@ loadfont_common(FILE *f, int format)
 }
 
 void
-loadfont_ex(wchar_t *s, int format, int offset)
+loadfont_ex(char *s, int format, int offset)
 {
 	FILE *f;
     
-    f = rom_fopen(s, L"rb");
+    f = rom_fopen(s, "rb");
     if (f == NULL)
 		return;
 
@@ -1065,7 +1065,7 @@ loadfont_ex(wchar_t *s, int format, int offset)
 }
 
 void
-loadfont(wchar_t *s, int format)
+loadfont(char *s, int format)
 {
     loadfont_ex(s, format, 0);
 }

--- a/src/win/86Box.manifest
+++ b/src/win/86Box.manifest
@@ -29,6 +29,7 @@
     <windowsSettings>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">permonitorv2</dpiAwareness>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
     </windowsSettings>
   </application>
 </assembly>

--- a/src/win/win_cdrom.c
+++ b/src/win/win_cdrom.c
@@ -42,12 +42,12 @@
 
 
 void
-floppy_mount(uint8_t id, wchar_t *fn, uint8_t wp)
+floppy_mount(uint8_t id, char *fn, uint8_t wp)
 {
     fdd_close(id);
     ui_writeprot[id] = wp;
     fdd_load(id, fn);
-    ui_sb_update_icon_state(SB_FLOPPY | id, wcslen(floppyfns[id]) ? 0 : 1);
+    ui_sb_update_icon_state(SB_FLOPPY | id, strlen(floppyfns[id]) ? 0 : 1);
     media_menu_update_floppy(id);
     ui_sb_update_tip(SB_FLOPPY | id);
     config_save();
@@ -80,10 +80,10 @@ plat_cdrom_ui_update(uint8_t id, uint8_t reload)
 }
 
 void
-cdrom_mount(uint8_t id, wchar_t *fn)
+cdrom_mount(uint8_t id, char *fn)
 {
     cdrom[id].prev_host_drive = cdrom[id].host_drive;
-    wcscpy(cdrom[id].prev_image_path, cdrom[id].image_path);
+    strcpy(cdrom[id].prev_image_path, cdrom[id].image_path);
     if (cdrom[id].ops && cdrom[id].ops->exit)
 	cdrom[id].ops->exit(&(cdrom[id]));
     cdrom[id].ops = NULL;
@@ -92,7 +92,7 @@ cdrom_mount(uint8_t id, wchar_t *fn)
     /* Signal media change to the emulated machine. */
     if (cdrom[id].insert)
 	cdrom[id].insert(cdrom[id].priv);
-    cdrom[id].host_drive = (wcslen(cdrom[id].image_path) == 0) ? 0 : 200;
+    cdrom[id].host_drive = (strlen(cdrom[id].image_path) == 0) ? 0 : 200;
     if (cdrom[id].host_drive == 200) {
 	ui_sb_update_icon_state(SB_CDROM | id, 0);
     } else {
@@ -122,7 +122,7 @@ mo_eject(uint8_t id)
 
 
 void
-mo_mount(uint8_t id, wchar_t *fn, uint8_t wp)
+mo_mount(uint8_t id, char *fn, uint8_t wp)
 {
     mo_t *dev = (mo_t *) mo_drives[id].priv;
 
@@ -131,7 +131,7 @@ mo_mount(uint8_t id, wchar_t *fn, uint8_t wp)
     mo_load(dev, fn);
     mo_insert(dev);
 
-    ui_sb_update_icon_state(SB_MO | id, wcslen(mo_drives[id].image_path) ? 0 : 1);
+    ui_sb_update_icon_state(SB_MO | id, strlen(mo_drives[id].image_path) ? 0 : 1);
     media_menu_update_mo(id);
     ui_sb_update_tip(SB_MO | id);
 
@@ -145,7 +145,7 @@ mo_reload(uint8_t id)
     mo_t *dev = (mo_t *) mo_drives[id].priv;
 
     mo_disk_reload(dev);
-    if (wcslen(mo_drives[id].image_path) == 0) {
+    if (strlen(mo_drives[id].image_path) == 0) {
 	ui_sb_update_icon_state(SB_MO|id, 1);
     } else {
 	ui_sb_update_icon_state(SB_MO|id, 0);
@@ -176,7 +176,7 @@ zip_eject(uint8_t id)
 
 
 void
-zip_mount(uint8_t id, wchar_t *fn, uint8_t wp)
+zip_mount(uint8_t id, char *fn, uint8_t wp)
 {
     zip_t *dev = (zip_t *) zip_drives[id].priv;
 
@@ -185,7 +185,7 @@ zip_mount(uint8_t id, wchar_t *fn, uint8_t wp)
     zip_load(dev, fn);
     zip_insert(dev);
 
-    ui_sb_update_icon_state(SB_ZIP | id, wcslen(zip_drives[id].image_path) ? 0 : 1);
+    ui_sb_update_icon_state(SB_ZIP | id, strlen(zip_drives[id].image_path) ? 0 : 1);
     media_menu_update_zip(id);
     ui_sb_update_tip(SB_ZIP | id);
 
@@ -199,7 +199,7 @@ zip_reload(uint8_t id)
     zip_t *dev = (zip_t *) zip_drives[id].priv;
 
     zip_disk_reload(dev);
-    if (wcslen(zip_drives[id].image_path) == 0) {
+    if (strlen(zip_drives[id].image_path) == 0) {
 	ui_sb_update_icon_state(SB_ZIP|id, 1);
     } else {
 	ui_sb_update_icon_state(SB_ZIP|id, 0);

--- a/src/win/win_dialog.c
+++ b/src/win/win_dialog.c
@@ -124,7 +124,7 @@ ui_msgbox_ex(int flags, void *header, void *message, void *btn1, void *btn2, voi
     /* If the message is an ANSI string, convert it. */
     tdconfig.pszContent = (WCHAR *) STRING_OR_RESOURCE(message);
     if (flags & MBX_ANSI) {
-	mbstowcs(temp, (char *)message, strlen((char *)message)+1);
+	mbstoc16s(temp, (char *)message, strlen((char *)message)+1);
 	tdconfig.pszContent = temp;
     }
 
@@ -194,7 +194,7 @@ file_dlg_w(HWND hwnd, WCHAR *f, WCHAR *fn, WCHAR *title, int save)
     plat_chdir(usr_path);
 
     if (r) {
-	wcstombs(openfilestring, wopenfilestring, sizeof(openfilestring));
+	c16stombs(openfilestring, wopenfilestring, sizeof(openfilestring));
 	filterindex = ofn.nFilterIndex;
 
 	return(0);
@@ -209,9 +209,9 @@ file_dlg(HWND hwnd, WCHAR *f, char *fn, char *title, int save)
 {
     WCHAR ufn[512], title_buf[512];
 
-    mbstowcs(ufn, fn, strlen(fn) + 1);
+    mbstoc16s(ufn, fn, strlen(fn) + 1);
     if (title)
-        mbstowcs(title_buf, title, sizeof title_buf);
+        mbstoc16s(title_buf, title, sizeof title_buf);
 
     return(file_dlg_w(hwnd, f, ufn, title ? title_buf : NULL, save));
 }
@@ -222,10 +222,10 @@ file_dlg_mb(HWND hwnd, char *f, char *fn, char *title, int save)
 {
     WCHAR uf[512], ufn[512], title_buf[512];
 
-    mbstowcs(uf, f, strlen(fn) + 1);
-    mbstowcs(ufn, fn, strlen(fn) + 1);
+    mbstoc16s(uf, f, strlen(fn) + 1);
+    mbstoc16s(ufn, fn, strlen(fn) + 1);
     if (title)
-        mbstowcs(title_buf, title, sizeof title_buf);
+        mbstoc16s(title_buf, title, sizeof title_buf);
 
     return(file_dlg_w(hwnd, uf, ufn, title ? title_buf : NULL, save));
 }
@@ -236,7 +236,7 @@ file_dlg_w_st(HWND hwnd, int id, WCHAR *fn, char *title, int save)
 {
     WCHAR title_buf[512];
     if (title)
-        mbstowcs(title_buf, title, sizeof title_buf);
+        mbstoc16s(title_buf, title, sizeof title_buf);
     return(file_dlg_w(hwnd, plat_get_string(id), fn, title ? title_buf : NULL, save));
 }
 

--- a/src/win/win_discord.c
+++ b/src/win/win_discord.c
@@ -68,9 +68,7 @@ void
 discord_update_activity(int paused)
 {
     struct DiscordActivity activity;
-    wchar_t config_name_w[1024];
-    char config_name[128];
-    char *temp;
+    char config_name[1024];
 
     if(discord_activities == NULL)
 	return;
@@ -79,17 +77,16 @@ discord_update_activity(int paused)
 
     memset(&activity, 0x00, sizeof(activity));
 
-    plat_get_dirname(config_name_w, usr_path);
-    if (WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, plat_get_filename(config_name_w), -1, config_name, 128, NULL, NULL) > 0)
+    plat_get_dirname(config_name, usr_path);
+    if (strlen(plat_get_filename(config_name)) < 100)
     {
-	sprintf_s(activity.details, 128, "Running \"%s\"", config_name);
-	sprintf_s(activity.state, 128, "%s (%s)", strchr(machine_getname(), ']') + 2, cpu_s->name);
+	sprintf_s(activity.details, sizeof(activity.details), "Running \"%s\"", plat_get_filename(config_name));
+	sprintf_s(activity.state, sizeof(activity.state), "%s (%s)", strchr(machine_getname(), ']') + 2, cpu_s->name);
     }
     else
     {
-	temp = strchr(machine_getname(), ']') + 2;
-	strncpy(activity.details, temp, 127);
-	strncpy(activity.state, cpu_s->name, 127);
+	strncpy(activity.details, strchr(machine_getname(), ']') + 2, sizeof(activity.details) - 1);
+	strncpy(activity.state, cpu_s->name, sizeof(activity.state) - 1);
     }
 
     activity.timestamps.start = time(NULL);

--- a/src/win/win_media_menu.c
+++ b/src/win/win_media_menu.c
@@ -69,17 +69,18 @@ media_menu_load_resource(wchar_t *lpName)
 static void
 media_menu_set_name_floppy(int drive)
 {
-    wchar_t name[512], temp[512];
+    wchar_t name[512], temp[512], fn[512];
     MENUITEMINFO mii = { 0 };
 
-    mbstowcs(temp, fdd_getname(fdd_get_type(drive)),
+    mbstoc16s(temp, fdd_getname(fdd_get_type(drive)),
 	     strlen(fdd_getname(fdd_get_type(drive))) + 1);
-    if (wcslen(floppyfns[drive]) == 0) {
+    if (strlen(floppyfns[drive]) == 0) {
 	_swprintf(name, plat_get_string(IDS_2108),
 		  drive + 1, temp, plat_get_string(IDS_2057));
     } else {
+	mbstoc16s(fn, floppyfns[drive], sizeof_w(fn));
 	_swprintf(name, plat_get_string(IDS_2108),
-		  drive + 1, temp, floppyfns[drive]);
+		  drive + 1, temp, fn);
     }
 
     mii.cbSize = sizeof(mii);
@@ -92,7 +93,7 @@ media_menu_set_name_floppy(int drive)
 static void
 media_menu_set_name_cdrom(int drive)
 {
-    wchar_t name[512], *temp;
+    wchar_t name[512], *temp, fn[512];
     MENUITEMINFO mii = { 0 };
 
     int bus = cdrom[drive].bus_type;
@@ -101,10 +102,14 @@ media_menu_set_name_cdrom(int drive)
     temp = plat_get_string(id);
 
     if (cdrom[drive].host_drive == 200) {
-	if (wcslen(cdrom[drive].image_path) == 0)
-		_swprintf(name, plat_get_string(IDS_5120), drive+1, temp, plat_get_string(IDS_2057));
-	else
-		_swprintf(name, plat_get_string(IDS_5120), drive+1, temp, cdrom[drive].image_path);
+	if (strlen(cdrom[drive].image_path) == 0) {
+		_swprintf(name, plat_get_string(IDS_5120),
+			  drive+1, temp, plat_get_string(IDS_2057));
+	} else {
+		mbstoc16s(fn, cdrom[drive].image_path, sizeof_w(fn));
+		_swprintf(name, plat_get_string(IDS_5120),
+			  drive+1, temp, fn);
+	}
     } else
 	_swprintf(name, plat_get_string(IDS_5120), drive+1, temp, plat_get_string(IDS_2057));
 
@@ -118,7 +123,7 @@ media_menu_set_name_cdrom(int drive)
 static void
 media_menu_set_name_zip(int drive)
 {
-    wchar_t name[512], *temp;
+    wchar_t name[512], *temp, fn[512];
     MENUITEMINFO mii = { 0 };
 
     int bus = zip_drives[drive].bus_type;
@@ -128,10 +133,11 @@ media_menu_set_name_zip(int drive)
 
     int type = zip_drives[drive].is_250 ? 250 : 100;
 
-    if (wcslen(zip_drives[drive].image_path) == 0) {
+    if (strlen(zip_drives[drive].image_path) == 0) {
 	_swprintf(name, plat_get_string(IDS_2054),
 		  type, drive+1, temp, plat_get_string(IDS_2057));
     } else {
+	mbstoc16s(fn, zip_drives[drive].image_path, sizeof_w(fn));
 	_swprintf(name, plat_get_string(IDS_2054),
 		  type, drive+1, temp, zip_drives[drive].image_path);
     }
@@ -146,7 +152,7 @@ media_menu_set_name_zip(int drive)
 static void
 media_menu_set_name_mo(int drive)
 {
-    wchar_t name[512], *temp;
+    wchar_t name[512], *temp, fn[512];
     MENUITEMINFO mii = { 0 };
 
     int bus = mo_drives[drive].bus_type;
@@ -154,12 +160,13 @@ media_menu_set_name_mo(int drive)
 
     temp = plat_get_string(id);
 
-    if (wcslen(mo_drives[drive].image_path) == 0) {
+    if (strlen(mo_drives[drive].image_path) == 0) {
 	_swprintf(name, plat_get_string(IDS_2115),
 		  drive+1, temp, plat_get_string(IDS_2057));
     } else {
+	mbstoc16s(fn, mo_drives[drive].image_path, sizeof_w(fn));
 	_swprintf(name, plat_get_string(IDS_2115),
-		  drive+1, temp, mo_drives[drive].image_path);
+		  drive+1, temp, fn);
     }
 
     mii.cbSize = sizeof(mii);
@@ -174,7 +181,7 @@ media_menu_update_floppy(int id)
 {
     int i = FDD_FIRST + id;
 
-    if (floppyfns[id][0] == 0x0000) {
+    if (strlen(floppyfns[id]) == 0) {
 	EnableMenuItem(menus[i], IDM_FLOPPY_EJECT | id, MF_BYCOMMAND | MF_GRAYED);
 	EnableMenuItem(menus[i], IDM_FLOPPY_EXPORT_TO_86F | id, MF_BYCOMMAND | MF_GRAYED);
     } else {
@@ -217,12 +224,12 @@ media_menu_update_zip(int id)
 {
     int i = ZIP_FIRST + id;
 
-    if (zip_drives[id].image_path[0] == 0x0000)
+    if (strlen(zip_drives[id].image_path) == 0)
 	EnableMenuItem(menus[i], IDM_ZIP_EJECT | id, MF_BYCOMMAND | MF_GRAYED);
     else
 	EnableMenuItem(menus[i], IDM_ZIP_EJECT | id, MF_BYCOMMAND | MF_ENABLED);
 
-    if(zip_drives[id].prev_image_path[0] == 0x0000)
+    if(strlen(zip_drives[id].prev_image_path) == 0)
 	EnableMenuItem(menus[i], IDM_ZIP_RELOAD | id, MF_BYCOMMAND | MF_GRAYED);
     else
 	EnableMenuItem(menus[i], IDM_ZIP_RELOAD | id, MF_BYCOMMAND | MF_ENABLED);
@@ -235,12 +242,12 @@ media_menu_update_mo(int id)
 {
     int i = MO_FIRST + id;
 
-    if (mo_drives[id].image_path[0] == 0x0000)
+    if (strlen(mo_drives[id].image_path) == 0)
 	EnableMenuItem(menus[i], IDM_MO_EJECT | id, MF_BYCOMMAND | MF_GRAYED);
     else
 	EnableMenuItem(menus[i], IDM_MO_EJECT | id, MF_BYCOMMAND | MF_ENABLED);
 
-    if(mo_drives[id].prev_image_path[0] == 0x0000)
+    if(strlen(mo_drives[id].prev_image_path) == 0)
 	EnableMenuItem(menus[i], IDM_MO_RELOAD | id, MF_BYCOMMAND | MF_GRAYED);
     else
 	EnableMenuItem(menus[i], IDM_MO_RELOAD | id, MF_BYCOMMAND | MF_ENABLED);
@@ -413,9 +420,9 @@ media_menu_proc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 		wp = 1;
 		/* FALLTHROUGH */
 	case IDM_FLOPPY_IMAGE_EXISTING:
-		ret = file_dlg_w_st(hwnd, IDS_2109, floppyfns[id], NULL, 0);
+		ret = file_dlg_st(hwnd, IDS_2109, floppyfns[id], NULL, 0);
 		if (! ret) {
-			floppy_mount(id, wopenfilestring, wp);
+			floppy_mount(id, openfilestring, wp);
 		}
 		break;
 
@@ -424,10 +431,10 @@ media_menu_proc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 		break;
 
 	case IDM_FLOPPY_EXPORT_TO_86F:
-		ret = file_dlg_w_st(hwnd, IDS_2076, floppyfns[id], NULL, 1);
+		ret = file_dlg_st(hwnd, IDS_2076, floppyfns[id], NULL, 1);
 		if (! ret) {
 			plat_pause(1);
-			ret = d86f_export(id, wopenfilestring);
+			ret = d86f_export(id, openfilestring);
 			if (!ret)
 				ui_msgbox_header(MBX_ERROR, (wchar_t *) IDS_4108, (wchar_t *) IDS_4115);
 			plat_pause(0);
@@ -450,8 +457,8 @@ media_menu_proc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 		break;
 
 	case IDM_CDROM_IMAGE:
-		if (!file_dlg_w_st(hwnd, IDS_2140, cdrom[id].image_path, NULL, 0)) {
-			cdrom_mount(id, wopenfilestring);
+		if (!file_dlg_st(hwnd, IDS_2140, cdrom[id].image_path, NULL, 0)) {
+			cdrom_mount(id, openfilestring);
 		}
 		break;
 
@@ -463,9 +470,9 @@ media_menu_proc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 		wp = 1;
 		/* FALLTHROUGH */
 	case IDM_ZIP_IMAGE_EXISTING:
-		ret = file_dlg_w_st(hwnd, IDS_2058, zip_drives[id].image_path, NULL, 0);
+		ret = file_dlg_st(hwnd, IDS_2058, zip_drives[id].image_path, NULL, 0);
 		if (! ret)
-			zip_mount(id, wopenfilestring, wp);
+			zip_mount(id, openfilestring, wp);
 		break;
 
 	case IDM_ZIP_EJECT:
@@ -484,9 +491,9 @@ media_menu_proc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 		wp = 1;
 		/* FALLTHROUGH */
 	case IDM_MO_IMAGE_EXISTING:
-		ret = file_dlg_w_st(hwnd, IDS_2116, mo_drives[id].image_path, NULL, 0);
+		ret = file_dlg_st(hwnd, IDS_2116, mo_drives[id].image_path, NULL, 0);
 		if (! ret)
-			mo_mount(id, wopenfilestring, wp);
+			mo_mount(id, openfilestring, wp);
 		break;
 
 	case IDM_MO_EJECT:

--- a/src/win/win_new_floppy.c
+++ b/src/win/win_new_floppy.c
@@ -71,7 +71,7 @@ static unsigned char	*empty;
 
 
 static int
-create_86f(WCHAR *file_name, disk_size_t disk_size, uint8_t rpm_mode)
+create_86f(char *file_name, disk_size_t disk_size, uint8_t rpm_mode)
 {
     FILE *f;
 
@@ -139,7 +139,7 @@ create_86f(WCHAR *file_name, disk_size_t disk_size, uint8_t rpm_mode)
     memset(tarray, 0, 2048);
     memset(empty, 0, array_size);
 
-    f = plat_fopen(file_name, L"wb");
+    f = plat_fopen(file_name, "wb");
     if (!f)
 	return 0;
 
@@ -178,7 +178,7 @@ static int	is_mo;
 
 
 static int
-create_sector_image(WCHAR *file_name, disk_size_t disk_size, uint8_t is_fdi)
+create_sector_image(char *file_name, disk_size_t disk_size, uint8_t is_fdi)
 {
     FILE *f;
     uint32_t total_size = 0;
@@ -191,7 +191,7 @@ create_sector_image(WCHAR *file_name, disk_size_t disk_size, uint8_t is_fdi)
     uint32_t zero_bytes = 0;
     uint16_t base = 0x1000;
     
-    f = plat_fopen(file_name, L"wb");
+    f = plat_fopen(file_name, "wb");
     if (!f)
 	return 0;
 
@@ -284,7 +284,7 @@ create_sector_image(WCHAR *file_name, disk_size_t disk_size, uint8_t is_fdi)
 
 
 static int
-create_zip_sector_image(WCHAR *file_name, disk_size_t disk_size, uint8_t is_zdi, HWND hwnd)
+create_zip_sector_image(char *file_name, disk_size_t disk_size, uint8_t is_zdi, HWND hwnd)
 {
     HWND h;
     FILE *f;
@@ -301,7 +301,7 @@ create_zip_sector_image(WCHAR *file_name, disk_size_t disk_size, uint8_t is_zdi,
     uint32_t i;
     MSG msg;
     
-    f = plat_fopen(file_name, L"wb");
+    f = plat_fopen(file_name, "wb");
     if (!f)
 	return 0;
 
@@ -521,7 +521,7 @@ create_zip_sector_image(WCHAR *file_name, disk_size_t disk_size, uint8_t is_zdi,
 
 
 static int
-create_mo_sector_image(WCHAR *file_name, int8_t disk_size, uint8_t is_mdi, HWND hwnd)
+create_mo_sector_image(char *file_name, int8_t disk_size, uint8_t is_mdi, HWND hwnd)
 {
     HWND h;
     FILE *f;
@@ -535,7 +535,7 @@ create_mo_sector_image(WCHAR *file_name, int8_t disk_size, uint8_t is_mdi, HWND 
     uint32_t i, j;
     MSG msg;
     
-    f = plat_fopen(file_name, L"wb");
+    f = plat_fopen(file_name, "wb");
     if (!f)
 	return 0;
 
@@ -646,7 +646,7 @@ create_mo_sector_image(WCHAR *file_name, int8_t disk_size, uint8_t is_mdi, HWND 
 static int	fdd_id, sb_part;
 
 static int	file_type = 0;		/* 0 = IMG, 1 = Japanese FDI, 2 = 86F */
-static wchar_t	fd_file_name[1024];
+static char	fd_file_name[1024];
 
 
 /* Show a MessageBox dialog.  This is nasty, I know.  --FvK */
@@ -704,7 +704,7 @@ NewFloppyDialogProcedure(HWND hdlg, UINT message, WPARAM wParam, LPARAM lParam)
     switch (message) {
 	case WM_INITDIALOG:
 		plat_pause(1);
-		memset(fd_file_name, 0, 1024 * sizeof(wchar_t));
+		memset(fd_file_name, 0, 1024);
 		h = GetDlgItem(hdlg, IDC_COMBO_DISK_SIZE);
 		if (is_zip) {
 			zip_types = zip_drives[fdd_id].is_250 ? 2 : 1;
@@ -802,7 +802,7 @@ NewFloppyDialogProcedure(HWND hdlg, UINT message, WPARAM wParam, LPARAM lParam)
 					}
 					SendMessage(h, WM_SETTEXT, 0, (LPARAM) wopenfilestring);
 					memset(fd_file_name, 0, sizeof(fd_file_name));
-					wcscpy(fd_file_name, wopenfilestring);
+					c16stombs(fd_file_name, wopenfilestring, sizeof(fd_file_name));
 					h = GetDlgItem(hdlg, IDC_COMBO_DISK_SIZE);
 					if (!is_zip || zip_drives[fdd_id].is_250)
 						EnableWindow(h, TRUE);

--- a/src/win/win_settings.c
+++ b/src/win/win_settings.c
@@ -2100,7 +2100,7 @@ win_settings_hard_disks_update_item(HWND hdlg, int i, int column)
 {
     HWND hwndList = GetDlgItem(hdlg, IDC_LIST_HARD_DISKS);
     LVITEM lvI;
-    WCHAR szText[256];
+    WCHAR szText[256], usr_path_w[1024];
 
     lvI.mask = LVIF_TEXT | LVIF_IMAGE | LVIF_STATE;
     lvI.stateMask = lvI.iSubItem = lvI.state = 0;
@@ -2132,10 +2132,11 @@ win_settings_hard_disks_update_item(HWND hdlg, int i, int column)
 	lvI.pszText = szText;
 	lvI.iImage = 0;
     } else if (column == 1) {
-	if (!wcsnicmp(temp_hdd[i].fn, usr_path, wcslen(usr_path)))
-		lvI.pszText = temp_hdd[i].fn + wcslen(usr_path);
+	if (!strnicmp(temp_hdd[i].fn, usr_path, strlen(usr_path)))
+		mbstoc16s(szText, temp_hdd[i].fn + strlen(usr_path), sizeof_w(szText));
 	else
-		lvI.pszText = temp_hdd[i].fn;
+		mbstoc16s(szText, temp_hdd[i].fn, sizeof_w(szText));
+	lvI.pszText = szText;
 	lvI.iImage = 0;
     } else if (column == 2) {
 	wsprintf(szText, plat_get_string(IDS_4098), temp_hdd[i].tracks);
@@ -2165,8 +2166,10 @@ win_settings_hard_disks_recalc_list(HWND hdlg)
 {
     LVITEM lvI;
     int i, j = 0;
-    WCHAR szText[256];
+    WCHAR szText[256], usr_path_w[1024];
     HWND hwndList = GetDlgItem(hdlg, IDC_LIST_HARD_DISKS);
+
+    mbstoc16s(usr_path_w, usr_path, sizeof_w(usr_path_w));
 
     hd_listview_items = 0;
     lv1_current_sel = -1;
@@ -2208,10 +2211,11 @@ win_settings_hard_disks_recalc_list(HWND hdlg)
 			return FALSE;
 
 		lvI.iSubItem = 1;
-		if (!wcsnicmp(temp_hdd[i].fn, usr_path, wcslen(usr_path)))
-			lvI.pszText = temp_hdd[i].fn + wcslen(usr_path);
+		if (!strnicmp(temp_hdd[i].fn, usr_path, strlen(usr_path)))
+			mbstoc16s(szText, temp_hdd[i].fn + strlen(usr_path), sizeof_w(szText));
 		else
-			lvI.pszText = temp_hdd[i].fn;
+			mbstoc16s(szText, temp_hdd[i].fn, sizeof_w(szText));
+		lvI.pszText = szText;
 
 		if (ListView_SetItem(hwndList, &lvI) == -1)
 			return FALSE;
@@ -2706,8 +2710,8 @@ win_settings_hard_disks_add_proc(HWND hdlg, UINT message, WPARAM wParam, LPARAM 
 				}
 
 				memset(hdd_ptr->fn, 0, sizeof(hdd_ptr->fn));
-				wcscpy(hdd_ptr->fn, hd_file_name);
-				wcstombs(hd_file_name_multibyte, hd_file_name, sizeof hd_file_name_multibyte);
+				c16stombs(hdd_ptr->fn, hd_file_name, sizeof(hdd_ptr->fn));
+				strcpy(hd_file_name_multibyte, hdd_ptr->fn);
 
 				sector_size = 512;
 
@@ -2867,7 +2871,7 @@ hdd_add_file_open_error:
 						return TRUE;
 					}
 					if (existing & 1) {
-						if (image_is_hdi(wopenfilestring) || image_is_hdx(wopenfilestring, 1)) {
+						if (image_is_hdi(openfilestring) || image_is_hdx(openfilestring, 1)) {
 							fseeko64(f, 0x10, SEEK_SET);
 							fread(&sector_size, 1, 4, f);
 							if (sector_size != 512) {
@@ -2879,10 +2883,9 @@ hdd_add_file_open_error:
 							fread(&spt, 1, 4, f);
 							fread(&hpc, 1, 4, f);
 							fread(&tracks, 1, 4, f);
-						} else if (image_is_vhd(wopenfilestring, 1)) {
+						} else if (image_is_vhd(openfilestring, 1)) {
 							fclose(f);
-							wcstombs(hd_file_name_multibyte, wopenfilestring, sizeof hd_file_name_multibyte);
-							MVHDMeta* vhd = mvhd_open(hd_file_name_multibyte, 0, &vhd_error);
+							MVHDMeta* vhd = mvhd_open(openfilestring, 0, &vhd_error);
 							if (vhd == NULL) {
 								settings_msgbox_header(MBX_ERROR, (existing & 1) ? (wchar_t *) IDS_4114 : (wchar_t *) IDS_4115, (existing & 1) ? (wchar_t *) IDS_4107 : (wchar_t *) IDS_4108);
 								return TRUE;
@@ -3453,7 +3456,7 @@ win_settings_hard_disks_proc(HWND hdlg, UINT message, WPARAM wParam, LPARAM lPar
 				return FALSE;
 
 			case IDC_BUTTON_HDD_REMOVE:
-				memcpy(temp_hdd[lv1_current_sel].fn, L"", sizeof(L""));
+				temp_hdd[lv1_current_sel].fn[0] = '\0';
 				hard_disk_untrack(lv1_current_sel);
 				temp_hdd[lv1_current_sel].bus = HDD_BUS_DISABLED;	/* Only set the bus to zero, the list normalize code below will take care of turning this entire entry to a complete zero. */
 				normalize_hd_list();			/* Normalize the hard disks so that non-disabled hard disks start from index 0, and so they are contiguous. */
@@ -3513,10 +3516,7 @@ win_settings_floppy_drives_recalc_list(HWND hdlg)
 	lvI.iSubItem = 0;
 	if (temp_fdd_types[i] > 0) {
 		t = fdd_getname(temp_fdd_types[i]);
-		if (strlen(t) <= 256)
-			strcpy(s, t);
-		else
-			strncpy(s, t, 256);
+		strncpy(s, t, sizeof(s) - 1);
 		mbstowcs(szText, s, strlen(s) + 1);
 		lvI.pszText = szText;
 	} else
@@ -3950,10 +3950,7 @@ win_settings_floppy_drives_update_item(HWND hdlg, int i)
 
     if (temp_fdd_types[i] > 0) {
 	t = fdd_getname(temp_fdd_types[i]);
-	if (strlen(t) <= 256)
-		strcpy(s, t);
-	else
-		strncpy(s, t, 256);
+	strncpy(s, t, sizeof(s) - 1);
 	mbstowcs(szText, s, strlen(s) + 1);
 	lvI.pszText = szText;
     } else

--- a/src/win/win_stbar.c
+++ b/src/win/win_stbar.c
@@ -180,17 +180,19 @@ StatusBarCreateFloppyTip(int part)
 {
     WCHAR wtext[512];
     WCHAR tempTip[512];
+    WCHAR fn[512];
 
     int drive = sb_part_meanings[part] & 0xf;
 
-    mbstowcs(wtext, fdd_getname(fdd_get_type(drive)),
+    mbstoc16s(wtext, fdd_getname(fdd_get_type(drive)),
 	     strlen(fdd_getname(fdd_get_type(drive))) + 1);
-    if (wcslen(floppyfns[drive]) == 0) {
+    if (strlen(floppyfns[drive]) == 0) {
 	_swprintf(tempTip, plat_get_string(IDS_2108),
 		  drive+1, wtext, plat_get_string(IDS_2057));
     } else {
+	mbstoc16s(fn, floppyfns[drive], sizeof_w(fn));
 	_swprintf(tempTip, plat_get_string(IDS_2108),
-		  drive+1, wtext, floppyfns[drive]);
+		  drive+1, wtext, fn);
     }
 
     if (sbTips[part] != NULL) {
@@ -207,6 +209,7 @@ StatusBarCreateCdromTip(int part)
 {
     WCHAR tempTip[512];
     WCHAR *szText;
+    WCHAR fn[512];
     int id;
     int drive = sb_part_meanings[part] & 0xf;
     int bus = cdrom[drive].bus_type;
@@ -215,10 +218,14 @@ StatusBarCreateCdromTip(int part)
     szText = plat_get_string(id);
 
     if (cdrom[drive].host_drive == 200) {
-	if (wcslen(cdrom[drive].image_path) == 0)
-		_swprintf(tempTip, plat_get_string(IDS_5120), drive+1, szText, plat_get_string(IDS_2057));
-	else
-		_swprintf(tempTip, plat_get_string(IDS_5120), drive+1, szText, cdrom[drive].image_path);
+	if (strlen(cdrom[drive].image_path) == 0) {
+		_swprintf(tempTip, plat_get_string(IDS_5120),
+			  drive+1, szText, plat_get_string(IDS_2057));
+	} else {
+		mbstoc16s(fn, cdrom[drive].image_path, sizeof_w(fn));
+		_swprintf(tempTip, plat_get_string(IDS_5120),
+			  drive+1, szText, fn);
+	}
     } else
 	_swprintf(tempTip, plat_get_string(IDS_5120), drive+1, szText, plat_get_string(IDS_2057));
 
@@ -236,6 +243,7 @@ StatusBarCreateZIPTip(int part)
 {
     WCHAR tempTip[512];
     WCHAR *szText;
+    WCHAR fn[512];
     int id;
     int drive = sb_part_meanings[part] & 0xf;
     int bus = zip_drives[drive].bus_type;
@@ -245,12 +253,13 @@ StatusBarCreateZIPTip(int part)
 
     int type = zip_drives[drive].is_250 ? 250 : 100;
 
-    if (wcslen(zip_drives[drive].image_path) == 0) {
+    if (strlen(zip_drives[drive].image_path) == 0) {
 	_swprintf(tempTip, plat_get_string(IDS_2054),
 		  type, drive+1, szText, plat_get_string(IDS_2057));
     } else {
+	mbstoc16s(fn, zip_drives[drive].image_path, sizeof_w(fn));
 	_swprintf(tempTip, plat_get_string(IDS_2054),
-		  type, drive+1, szText, zip_drives[drive].image_path);
+		  type, drive+1, szText, fn);
     }
 
     if (sbTips[part] != NULL) {
@@ -267,6 +276,7 @@ StatusBarCreateMOTip(int part)
 {
     WCHAR tempTip[512];
     WCHAR *szText;
+    WCHAR fn[512];
     int id;
     int drive = sb_part_meanings[part] & 0xf;
     int bus = mo_drives[drive].bus_type;
@@ -274,10 +284,11 @@ StatusBarCreateMOTip(int part)
     id = IDS_5377 + (bus - 1);
     szText = plat_get_string(id);
 
-    if (wcslen(mo_drives[drive].image_path) == 0) {
+    if (strlen(mo_drives[drive].image_path) == 0) {
 	_swprintf(tempTip, plat_get_string(IDS_2115),
 		  drive+1, szText, plat_get_string(IDS_2057));
     } else {
+	mbstoc16s(fn, mo_drives[drive].image_path, sizeof_w(fn));
 	_swprintf(tempTip, plat_get_string(IDS_2115),
 		  drive+1, szText, mo_drives[drive].image_path);
     }
@@ -652,7 +663,7 @@ ui_sb_update_panes(void)
     for (i=0; i<sb_parts; i++) {
 	switch (sb_part_meanings[i] & 0xf0) {
 		case SB_FLOPPY:		/* Floppy */
-			sb_part_icons[i] = (wcslen(floppyfns[sb_part_meanings[i] & 0xf]) == 0) ? 128 : 0;
+			sb_part_icons[i] = (strlen(floppyfns[sb_part_meanings[i] & 0xf]) == 0) ? 128 : 0;
 			sb_part_icons[i] |= fdd_type_to_icon(fdd_get_type(sb_part_meanings[i] & 0xf));
 			StatusBarCreateFloppyTip(i);
 			break;
@@ -660,7 +671,7 @@ ui_sb_update_panes(void)
 		case SB_CDROM:		/* CD-ROM */
 			id = sb_part_meanings[i] & 0xf;
 			if (cdrom[id].host_drive == 200)
-				sb_part_icons[i] = (wcslen(cdrom[id].image_path) == 0) ? 128 : 0;
+				sb_part_icons[i] = (strlen(cdrom[id].image_path) == 0) ? 128 : 0;
 			else
 				sb_part_icons[i] = 128;
 			sb_part_icons[i] |= 32;
@@ -668,13 +679,13 @@ ui_sb_update_panes(void)
 			break;
 
 		case SB_ZIP:		/* Iomega ZIP */
-			sb_part_icons[i] = (wcslen(zip_drives[sb_part_meanings[i] & 0xf].image_path) == 0) ? 128 : 0;
+			sb_part_icons[i] = (strlen(zip_drives[sb_part_meanings[i] & 0xf].image_path) == 0) ? 128 : 0;
 			sb_part_icons[i] |= 48;
 			StatusBarCreateZIPTip(i);
 			break;
 			
 		case SB_MO:		/* Magneto-Optical disk */	
-			sb_part_icons[i] = (wcslen(mo_drives[sb_part_meanings[i] & 0xf].image_path) == 0) ? 128 : 0;
+			sb_part_icons[i] = (strlen(mo_drives[sb_part_meanings[i] & 0xf].image_path) == 0) ? 128 : 0;
 			sb_part_icons[i] |= 56;
 			StatusBarCreateMOTip(i);
 			break;

--- a/src/win/win_ui.c
+++ b/src/win/win_ui.c
@@ -1399,10 +1399,7 @@ ui_window_title(wchar_t *s)
 {
     if (! video_fullscreen) {
 	if (s != NULL) {
-		if (wcslen(s) <= 512)
-			wcscpy(wTitle, s);
-		else
-			wcsncpy(wTitle, s, 512);
+		wcsncpy(wTitle, s, sizeof_w(wTitle) - 1);
 	} else
 		s = wTitle;
 
@@ -1438,10 +1435,7 @@ plat_pause(int p)
 
     if (p) {
 	t = ui_window_title(NULL);
-	if (wcslen(t) <= 511)
-		wcscpy(oldtitle, ui_window_title(NULL));
-	else
-		wcsncpy(oldtitle, ui_window_title(NULL), 511);
+	wcsncpy(oldtitle, ui_window_title(NULL), sizeof_w(oldtitle) - 1);
 	wcscpy(title, oldtitle);
 	wcscat(title, L" - PAUSED -");
 	ui_window_title(title);


### PR DESCRIPTION
Summary
=======
This converts the emulator APIs to narrow UTF-8 strings, taking advantage of the native support in recent Windows 10 updates. 

The Windows platform module detects whether Windows supports UTF-8 on startup and uses the wide string Windows API functions on older versions.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
