### PR TITLE
More skew changes, fixed the missing pixels in hdisp in 24bpp mode as…

### DIFF
--- a/src/video/vid_et4000w32.c
+++ b/src/video/vid_et4000w32.c
@@ -396,10 +396,10 @@ et4000w32p_recalctimings(svga_t *svga)
 	} else {
 		/* Also adjust the graphics mode clocks in some cases. */
 		if ((svga->gdcreg[5] & 0x40) && (svga->bpp != 32)) {
-			if ((svga->bpp == 15) || (svga->bpp == 16))
-				svga->hdisp += 16;
+			if ((svga->bpp == 15) || (svga->bpp == 16) || (svga->bpp == 24))
+				svga->hdisp += (svga->seqregs[1] & 1) ? 16 : 18;
 			else
-				svga->hdisp += 8;
+				svga->hdisp += (svga->seqregs[1] & 1) ? 8 : 9;
 		}
 	}
     }

--- a/src/video/vid_ht216.c
+++ b/src/video/vid_ht216.c
@@ -628,6 +628,9 @@ ht216_recalctimings(svga_t *svga)
     ht216_t *ht216 = (ht216_t *)svga->p;
     int high_res_256 = 0;
 
+	if (svga->attrregs[0x10] & 0x80)
+		svga->attrregs[0x10] &= ~0x80; /*Otherwise 8-bit color in graphics mode is a bit busted*/
+
     switch (ht216->clk_sel) {
 	case 5:  svga->clock = (cpuclock * (double)(1ull << 32)) / 65000000.0; break;
 	case 6:  svga->clock = (cpuclock * (double)(1ull << 32)) / 40000000.0; break;


### PR DESCRIPTION
… well as properly organized hdisp in other bpp modes.

Clear bit 7 of attr reg 0x10 in the v7 code otherwise it would scramble the colors in 8-bit graphics mode if issued.

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
