### PR TITLE
Tseng ET4000w32x changes:

### DIFF
--- a/src/video/vid_et4000w32.c
+++ b/src/video/vid_et4000w32.c
@@ -444,7 +444,7 @@ et4000w32p_recalctimings(svga_t *svga)
 					svga->render = svga_render_2bpp_highres;
 				break;
 			case 0x40: case 0x60:			/* 256+ colours */
-				if (et4000->type <= ET4000W32I)
+				if (et4000->type <= ET4000W32P_REVC)
 					svga->clock /= 2;
 
 				switch (svga->bpp) {
@@ -871,7 +871,7 @@ et4000w32p_mmu_read(uint32_t addr, void *p)
 						temp |= ACL_RDST;
 					if (FIFO_FULL)
 						temp |= ACL_WRST;
-					if (temp == ACL_XYST && (et4000->acl.internal.ctrl_routing & 3))
+					if (temp == ACL_XYST && (et4000->acl.internal.ctrl_routing == 1 || et4000->acl.internal.ctrl_routing == 2))
 						temp |= ACL_RDST;
 				} else {
 					et4000->acl.status &= ~(ACL_XYST | ACL_SSO);
@@ -1470,6 +1470,9 @@ et4000w32p_init(const device_t *info)
 
     et4000->type = info->local;
 
+    et4000->pci = (info->flags & DEVICE_PCI) ? 0x80 : 0x00;
+    et4000->vlb = (info->flags & DEVICE_VLB) ? 0x40 : 0x00;
+
     switch(et4000->type) {
 	case ET4000W32:
 		/* ET4000/W32 */
@@ -1548,8 +1551,6 @@ et4000w32p_init(const device_t *info)
 		et4000->svga.getclock = icd2061_getclock;
 		break;
     }
-    et4000->pci = (info->flags & DEVICE_PCI) ? 0x80 : 0x00;
-    et4000->vlb = (info->flags & DEVICE_VLB) ? 0x40 : 0x00;
     if (info->flags & DEVICE_PCI)
 	mem_mapping_disable(&et4000->bios_rom.mapping);
 


### PR DESCRIPTION
Fixed freezes, once and for all, on win2000 (W32p).
Fixed some graphical glitches under win3.x that were caused by the FIFO (W32p).
Fixed vlb flag, now it loads the VLB rom properly (W32i).
Anything using the ICS ramdacs now has a svga->clock /= 2 in recalctimings (W32p rev c and W32/W32i).

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
