### PR TITLE
Full screen resize fix

### DIFF
--- a/src/win/win_ui.c
+++ b/src/win/win_ui.c
@@ -835,7 +835,7 @@ MainWindowProcedure(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 			doresize = 1;
 		break;
 
-    case WM_WINDOWPOSCHANGED:
+	case WM_WINDOWPOSCHANGED:
 		pos = (WINDOWPOS*)lParam;
 		GetClientRect(hwndMain, &rect);
 
@@ -858,7 +858,7 @@ MainWindowProcedure(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 		}
 
 		if (!(pos->flags & SWP_NOSIZE) || !user_resize) {
-            plat_vidapi_enable(0);
+			plat_vidapi_enable(0);
 
 			MoveWindow(hwndSBAR, 0, rect.bottom - sbar_height, sbar_height, rect.right, TRUE);
 			MoveWindow(hwndRender, 0, 0, rect.right, rect.bottom - sbar_height, TRUE);

--- a/src/win/win_ui.c
+++ b/src/win/win_ui.c
@@ -835,7 +835,7 @@ MainWindowProcedure(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 			doresize = 1;
 		break;
 
-	case WM_WINDOWPOSCHANGED:
+    case WM_WINDOWPOSCHANGED:
 		pos = (WINDOWPOS*)lParam;
 		GetClientRect(hwndMain, &rect);
 
@@ -857,8 +857,8 @@ MainWindowProcedure(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 			config_save();
 		}
 
-		if (!(pos->flags & SWP_NOSIZE)) {
-			plat_vidapi_enable(0);
+		if (!(pos->flags & SWP_NOSIZE) || !user_resize) {
+            plat_vidapi_enable(0);
 
 			MoveWindow(hwndSBAR, 0, rect.bottom - sbar_height, sbar_height, rect.right, TRUE);
 			MoveWindow(hwndRender, 0, 0, rect.right, rect.bottom - sbar_height, TRUE);


### PR DESCRIPTION
Summary
=======
## Problem analysis ##
Returning from full screen has not worked properly after changing `WM_MOVE` and `WM_SIZE` to `WM_WINDOWPOSCHANGED`.
There is a check for `SWP_NOSIZE` flag, but returning from full screen doesn't disable it and thus the rendering window remains the size of full screen window and offset. Mouse capture area is likewise misaligned.
## Fix ##
Adding an additional check for variable `user_resize` alongside the existing check for `SWP_NOSIZE` allows the rendering window resize be triggered when exiting full screen.

Checklist
=========
* [x] Closes #1355 
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
The originating window resize event changes: 220fffc4a211c688f3aeaf77038a447a8eb5e295
