### PR TITLE
Add the TMC PAT54PV machine

### DIFF
--- a/src/device/keyboard_at.c
+++ b/src/device/keyboard_at.c
@@ -1325,6 +1325,11 @@ write64_ami(void *priv, uint8_t val)
 		dev->want60 = 1;
 		return 0;
 
+	case 0xa0:	/* copyright message */
+		add_data(dev, 0x28);
+		add_data(dev, 0x00);
+		break;
+		
 	case 0xa1:	/* get controller version */
 		kbd_log("ATkbc: AMI - get controller version\n");
 		add_data(dev, 'H');

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -381,6 +381,8 @@ extern const device_t 	*at_cpqiii_get_device(void);
 /* m_at_socket4_5.c */
 extern int	machine_at_excalibur_init(const machine_t *);
 
+extern int  machine_at_pat54pv_init(const machine_t *);
+
 extern int	machine_at_hot543_init(const machine_t *);
 extern int	machine_at_p54vl_init(const machine_t *);
 

--- a/src/machine/m_at_socket4_5.c
+++ b/src/machine/m_at_socket4_5.c
@@ -62,7 +62,27 @@ machine_at_excalibur_init(const machine_t *model)
 
     return ret;
 }
+int
+machine_at_pat54pv_init(const machine_t *model)
+{
+    int ret;
 
+    ret = bios_load_linear("roms/machines/pat54pv/pat54pv.bin",
+			   0x000f0000, 65536, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_at_common_init(model);
+
+    device_add(&opti5x7_device);
+    device_add(&keyboard_at_ami_device);
+    
+    if (fdc_type == FDC_INTERNAL)
+    device_add(&fdc_at_device);
+
+    return ret;
+}
 int
 machine_at_hot543_init(const machine_t *model)
 {

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -284,6 +284,9 @@ const machine_t machines[] = {
     { "[i430FX] NEC PowerMate V",  		"powermate_v",		MACHINE_TYPE_SOCKET5,		CPU_PKG_SOCKET5_7, 0, 50000000, 66666667, 3380, 3520, 1.5, 2.0,							MACHINE_PCI | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,				 8192, 131072, 8192, 127,	  machine_at_powermate_v_init, NULL			},
     { "[i430FX] PC Partner MB500N",		"mb500n",		MACHINE_TYPE_SOCKET5,		CPU_PKG_SOCKET5_7, 0, 50000000, 66666667, 3380, 3520, 1.5, 3.0,							MACHINE_PCI | MACHINE_IDE_DUAL,							 8192, 131072, 8192, 127,	       machine_at_mb500n_init, NULL			},
 
+    /* OPTi 596/597 */
+    { "[OPTi 597] TMC PAT54PV",			"pat54pv",		MACHINE_TYPE_SOCKET5,		CPU_PKG_SOCKET5_7, 0, 60000000, 66666667, 3520, 3520, 1.5, 1.5,							MACHINE_VLB,									 2048,  65536, 2048, 127,	      machine_at_pat54pv_init, NULL			},
+    
     /* OPTi 596/597/822 */
     { "[OPTi 597] Shuttle HOT-543",		"hot543",		MACHINE_TYPE_SOCKET5,		CPU_PKG_SOCKET5_7, 0, 60000000, 66666667, 3520, 3520, 1.5, 1.5,							MACHINE_PCI | MACHINE_VLB,				 8192, 131072, 8192, 127,		machine_at_hot543_init, NULL			},
     { "[OPTi 597] Supermicro P54VL-PCI",		"p54vl",		MACHINE_TYPE_SOCKET5,		CPU_PKG_SOCKET5_7, 0, 60000000, 66666667, 3520, 3520, 1.5, 1.5,							MACHINE_PCI | MACHINE_VLB,				 8192, 131072, 8192, 127,		machine_at_p54vl_init, NULL			},

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -285,7 +285,7 @@ const machine_t machines[] = {
     { "[i430FX] PC Partner MB500N",		"mb500n",		MACHINE_TYPE_SOCKET5,		CPU_PKG_SOCKET5_7, 0, 50000000, 66666667, 3380, 3520, 1.5, 3.0,							MACHINE_PCI | MACHINE_IDE_DUAL,							 8192, 131072, 8192, 127,	       machine_at_mb500n_init, NULL			},
 
     /* OPTi 596/597 */
-    { "[OPTi 597] TMC PAT54PV",			"pat54pv",		MACHINE_TYPE_SOCKET5,		CPU_PKG_SOCKET5_7, 0, 60000000, 66666667, 3520, 3520, 1.5, 1.5,							MACHINE_VLB,									 2048,  65536, 2048, 127,	      machine_at_pat54pv_init, NULL			},
+    { "[OPTi 597] TMC PAT54PV",		"pat54pv",		MACHINE_TYPE_SOCKET5,		CPU_PKG_SOCKET5_7, CPU_BLOCK(CPU_K5, CPU_5K86), 60000000, 66666667, 3520, 3520, 1.5, 1.5,				MACHINE_VLB,									 2048,  65536, 2048, 127,	      machine_at_pat54pv_init, NULL			},
     
     /* OPTi 596/597/822 */
     { "[OPTi 597] Shuttle HOT-543",		"hot543",		MACHINE_TYPE_SOCKET5,		CPU_PKG_SOCKET5_7, 0, 60000000, 66666667, 3520, 3520, 1.5, 1.5,							MACHINE_PCI | MACHINE_VLB,				 8192, 131072, 8192, 127,		machine_at_hot543_init, NULL			},


### PR DESCRIPTION

Summary
=======
Adds the TMC PAT54PV, an ISA/VLB only Socket 5 machine. Also makes KBC command A0 return 0x28 then 0 so that the BIOS can function.

Checklist
=========
* [x] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
* [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/113/
