### PR TITLE
Improvements to onboard SCSI controller handling

### DIFF
--- a/src/win/win_media_menu.c
+++ b/src/win/win_media_menu.c
@@ -23,6 +23,7 @@
 #include <86box/win.h>
 
 #define MACHINE_HAS_IDE	(machines[machine].flags & MACHINE_IDE_QUAD)
+#define MACHINE_HAS_SCSI	(machines[machine].flags & MACHINE_SCSI_DUAL)
 
 #define FDD_FIRST	0
 #define CDROM_FIRST	FDD_FIRST + FDD_NUM
@@ -294,7 +295,7 @@ is_valid_cdrom(int i)
 {
     if ((cdrom[i].bus_type == CDROM_BUS_ATAPI) && !MACHINE_HAS_IDE)
 	return 0;
-    if ((cdrom[i].bus_type == CDROM_BUS_SCSI) && (scsi_card_current == 0))
+    if ((cdrom[i].bus_type == CDROM_BUS_SCSI) && !MACHINE_HAS_SCSI && (scsi_card_current == 0))
 	return 0;
     return cdrom[i].bus_type != 0;
 }
@@ -304,7 +305,7 @@ is_valid_zip(int i)
 {
     if ((zip_drives[i].bus_type == ZIP_BUS_ATAPI) && !MACHINE_HAS_IDE)
 	return 0;
-    if ((zip_drives[i].bus_type == ZIP_BUS_SCSI) && (scsi_card_current == 0))
+    if ((zip_drives[i].bus_type == ZIP_BUS_SCSI) && !MACHINE_HAS_SCSI && (scsi_card_current == 0))
 	return 0;
     return zip_drives[i].bus_type != 0;
 }
@@ -314,7 +315,7 @@ is_valid_mo(int i)
 {
     if ((mo_drives[i].bus_type == MO_BUS_ATAPI) && !MACHINE_HAS_IDE)
 	return 0;
-    if ((mo_drives[i].bus_type == MO_BUS_SCSI) && (scsi_card_current == 0))
+    if ((mo_drives[i].bus_type == MO_BUS_SCSI) && !MACHINE_HAS_SCSI && (scsi_card_current == 0))
 	return 0;
     return mo_drives[i].bus_type != 0;
 }

--- a/src/win/win_stbar.c
+++ b/src/win/win_stbar.c
@@ -639,7 +639,7 @@ ui_sb_update_panes(void)
 	sb_map[SB_HDD | HDD_BUS_IDE] = sb_parts;
 	sb_parts++;
     }
-    if (c_scsi && (scsi_card_current != 0)) {
+    if (c_scsi && (scsi_int || (scsi_card_current != 0))) {
 	edge += icon_width;
 	iStatusWidths[sb_parts] = edge;
 	sb_part_meanings[sb_parts] = SB_HDD | HDD_BUS_SCSI;


### PR DESCRIPTION
Summary
=======
This fixes a bug where HDDs connected to a machine's onboard SCSI controller would not show an icon in the status bar.
Additionally, CD-ROM drives and other removable devices connected to an onboard SCSI controller now show up in the Media menu.

Checklist
=========
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
