### PR TITLE
Make DEV_BRANCH available in .rc files when building with make

### DIFF
--- a/src/win/Makefile.mingw
+++ b/src/win/Makefile.mingw
@@ -503,6 +503,7 @@ endif
 # Options for the DEV branch.
 ifeq ($(DEV_BRANCH), y)
 OPTS		+= -DDEV_BRANCH
+RFLAGS		+= -DDEV_BRANCH
 DEVBROBJ	:=
 
 ifeq ($(AMD_K5), y)


### PR DESCRIPTION
Summary
=======
Defining DEV_BRANCH affects only source files when building with make. In CMake it affects both source files and resource files.

#1382 didn't build as expected while this was missing; the experimental menu option is missing.