### PR TITLE
Fixes to CMake/msvc/clang builds and debug builds

### DIFF
--- a/src/win/CMakeLists.txt
+++ b/src/win/CMakeLists.txt
@@ -30,6 +30,9 @@ if(MSVC)
 	target_sources(86Box PRIVATE 86Box.manifest)
 
 	target_sources(plat PRIVATE win_opendir.c)
+
+	# Append null to resource strings (fixes file dialogs)
+	set_property(SOURCE 86Box.rc PROPERTY COMPILE_FLAGS -n)
 endif()
 
 if(DINPUT)

--- a/src/win/win_opendir.c
+++ b/src/win/win_opendir.c
@@ -17,8 +17,6 @@
  *		Copyright 1998-2007 MicroWalt Corporation
  *		Copyright 2017 Fred N. van Kempen
  */
-#define UNICODE
-#include <windows.h>
 #include <io.h>
 #include <stdio.h>
 #include <stdint.h>
@@ -158,10 +156,11 @@ readdir(DIR *p)
 	default:	/* regular entry. */
 #ifdef UNICODE
 		wcsncpy(p->dent.d_name, ffp->name, MAXNAMLEN+1);
+		p->dent.d_reclen = (char)wcslen(p->dent.d_name);
 #else
 		strncpy(p->dent.d_name, ffp->name, MAXNAMLEN+1);
+		p->dent.d_reclen = (char)strlen(p->dent.d_name);
 #endif
-		p->dent.d_reclen = (char) wcslen(p->dent.d_name);
     }
 
     /* Read next entry. */

--- a/src/win/win_settings.c
+++ b/src/win/win_settings.c
@@ -5060,7 +5060,7 @@ static BOOL
 win_settings_categories_init_columns(HWND hdlg)
 {
     LVCOLUMN lvc;
-    int iCol;
+    int iCol = 0;
     HWND hwndList = GetDlgItem(hdlg, IDC_SETTINGSCATLIST);
 
     lvc.mask = LVCF_FMT | LVCF_WIDTH | LVCF_TEXT | LVCF_SUBITEM;


### PR DESCRIPTION
Summary
=======
- Fix missing opendir symbol after recent changes. Defining UNICODE makes it always produce symbols opendirw.
- Fix resouce compiling by adding -n switch to append null to resource strings.
- Fix uninitialized variable causing settings listview missing content randomly.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
