### PR TITLE
Fix a deadlock with changing renderer and status bar activity

### DIFF
--- a/src/win/win_stbar.c
+++ b/src/win/win_stbar.c
@@ -149,12 +149,13 @@ ui_sb_update_icon(int tag, int active)
     if ((found != 0xff) && ((sb_part_icons[found] ^ active) & 1) && active) {
 	sb_part_icons[found] |= 1;
 
-	SendMessage(hwndSBAR, SB_SETICON, found,
+	PostMessage(hwndSBAR, SB_SETICON, found,
 		    (LPARAM)hIcon[sb_part_icons[found]]);
 
 	SetTimer(hwndMain, 0x8000 | found, 75, NULL);
     }
 }
+
 
 
 /* API: This is for the drive state indicator. */


### PR DESCRIPTION
Summary
=======
There is a deadlock situation when changing renderer while e.g. booting or other disk activity that updates status bar.

The dead lock occurs when 
- worker thread has locked a mutex with startblit() and tries to SendMessage
- main thread is processing a message event that tries to lock same mutex with startblit()

Changing SendMessage to PostMessage solves the situation, as worker thread can continue to unlock the mutex and allow main thread (and message pump) to continue.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
Here is stack traces of the two threads in dead lock:
```
Worker Thread	86Box.exe!thread_start<void (__cdecl*)(void *),0>	win32u.dll!_NtUserMessageCall@28
[External Code]
86Box.exe!ui_sb_update_icon(int tag, int active) Line 152
86Box.exe!fdc_callback(void * priv) Line 1665
86Box.exe!fdc_sector_finishread(fdc_t * fdc) Line 1990
86Box.exe!d86f_read_sector_data(int drive, int side) Line 1614
86Box.exe!d86f_poll(int drive) Line 2497
86Box.exe!fdd_poll(void * priv) Line 593
86Box.exe!timer_process_inline() Line 233
86Box.exe!exec386(int cycs) Line 218
86Box.exe!pc_run() Line 953
86Box.exe!main_thread(void * param) Line 499
86Box.exe!thread_start<void (__cdecl*)(void *),0>(void * const parameter) Line 101
[External Code]

Main Thread	Main Thread	86Box.exe!startblit
[External Code]
86Box.exe!startblit() Line 1152
86Box.exe!plat_setvid(int api) Line 974
86Box.exe!MainWindowProcedure(HWND__ * hwnd, unsigned int message, unsigned int wParam, long lParam) Line 750
[External Code]
86Box.exe!ui_init(int nCmdShow) Line 1511
86Box.exe!WinMain(HINSTANCE__ * hInst, HINSTANCE__ * hPrev, char * lpszArg, int nCmdShow) Line 466
[External Code]
```
