### PR TITLE
Made the 868 properly recognize itself as a true 868, instead of 866 …

### DIFF
--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -6026,7 +6026,8 @@ static void *s3_init(const device_t *info)
 		case S3_PHOENIX_VISION868:
 			svga->decode_mask = (4 << 20) - 1;
 			s3->id = 0xe1; /*Vision868*/
-			s3->id_ext = s3->id_ext_pci = 0x80;
+			s3->id_ext = 0x90;
+			s3->id_ext_pci = 0x80;
 			s3->packed_mmio = 1;
 			if (s3->pci) {
 				svga->crtc[0x53] = 0x18;


### PR DESCRIPTION
…(should also fix NT 4.0's graphical bugs with it)

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
