### PR TITLE
Removed the IBM PS/2 Model 70. Replaced with the Olivetti 486

### DIFF
--- a/src/chipset/CMakeLists.txt
+++ b/src/chipset/CMakeLists.txt
@@ -13,7 +13,7 @@
 #		Copyright 2020,2021 David Hrdlička.
 #
 
-add_library(chipset OBJECT acc2168.c cs8230.c ali1217.c ali1429.c ali1489.c headland.c
+add_library(chipset OBJECT acc2168.c cs8230.c ali1217.c ali1429.c ali1489.c et6000.c headland.c
 	intel_82335.c cs4031.c intel_420ex.c intel_4x0.c intel_sio.c intel_piix.c ../ioapic.c
 	neat.c opti283.c opti291.c opti495.c opti822.c opti895.c opti5x7.c scamp.c scat.c
 	sis_85c310.c sis_85c4xx.c sis_85c496.c sis_85c50x.c sis_5511.c sis_5571.c sis_5598.c

--- a/src/chipset/et6000.c
+++ b/src/chipset/et6000.c
@@ -1,0 +1,161 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Implementation of the ETEQ Cheetah ET6000 chipset.
+ *
+ *      Authors: Tiseno100
+ *
+ *		Copyright 2021 Tiseno100
+ *
+ */
+
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+#define HAVE_STDARG_H
+#include <86box/86box.h>
+#include "cpu.h"
+#include <86box/timer.h>
+#include <86box/io.h>
+#include <86box/device.h>
+#include <86box/mem.h>
+#include <86box/pit.h>
+#include <86box/port_92.h>
+#include <86box/chipset.h>
+
+#define INDEX (dev->index - 0x10)
+
+typedef struct
+{
+    uint8_t index, regs[6];
+} et6000_t;
+
+#ifdef ENABLE_ET6000_LOG
+int et6000_do_log = ENABLE_ET6000_LOG;
+static void
+et6000_log(const char *fmt, ...)
+{
+    va_list ap;
+
+    if (et6000_do_log)
+    {
+        va_start(ap, fmt);
+        pclog_ex(fmt, ap);
+        va_end(ap);
+    }
+}
+#else
+#define et6000_log(fmt, ...)
+#endif
+
+static void et6000_shadow_control(int base, int size, int can_read, int can_write)
+{
+    mem_set_mem_state_both(base, size, (can_read ? MEM_READ_INTERNAL : MEM_READ_EXTANY) | (can_write ? MEM_WRITE_INTERNAL : MEM_WRITE_EXTANY));
+    flushmmucache_nopc();
+}
+
+static void
+et6000_write(uint16_t addr, uint8_t val, void *priv)
+{
+    et6000_t *dev = (et6000_t *)priv;
+
+    switch (addr)
+    {
+    case 0x22:
+        dev->index = val;
+        break;
+    case 0x23:
+        switch (INDEX)
+        {
+        case 0: /* System Configuration Register */
+            dev->regs[INDEX] = val & 0xdf;
+            et6000_shadow_control(0xa0000, 0x20000, val & 1, val & 1);
+            refresh_at_enable = !(val & 0x10);
+            break;
+
+        case 1: /* CACHE Configuration and Non-Cacheable Block Size */
+            dev->regs[INDEX] = val & 0xf0;
+            break;
+
+        case 2: /* Non-Cacheable Block Address Register */
+            dev->regs[INDEX] = val & 0xfe;
+            break;
+
+        case 3: /* DRAM Bank and Type Configuration Register */
+            dev->regs[INDEX] = val;
+            break;
+
+        case 4: /* DRAM Configuration Register */
+            dev->regs[INDEX] = val;
+            et6000_shadow_control(0xc0000, 0x10000, (dev->regs[0x15] & 2) && (val & 0x20), (dev->regs[0x15] & 2) && (val & 0x20) && (dev->regs[0x15] & 1));
+            et6000_shadow_control(0xd0000, 0x10000, (dev->regs[0x15] & 8) && (val & 0x20), (dev->regs[0x15] & 8) && (val & 0x20) && (dev->regs[0x15] & 4));
+            break;
+
+        case 5: /* Shadow RAM Configuration Register */
+            dev->regs[INDEX] = val;
+            et6000_shadow_control(0xc0000, 0x10000, (val & 2) && (dev->regs[0x14] & 0x20), (val & 2) && (dev->regs[0x14] & 0x20) && (val & 1));
+            et6000_shadow_control(0xd0000, 0x10000, (val & 8) && (dev->regs[0x14] & 0x20), (val & 8) && (dev->regs[0x14] & 0x20) && (val & 4));
+            et6000_shadow_control(0xe0000, 0x10000, val & 0x20, (val & 0x20) && (val & 0x10));
+            et6000_shadow_control(0xf0000, 0x10000, val & 0x40, !(val & 0x40));
+            break;
+        }
+        et6000_log("ET6000: dev->regs[%02x] = %02x\n", dev->index, dev->regs[dev->index]);
+        break;
+    }
+}
+
+static uint8_t
+et6000_read(uint16_t addr, void *priv)
+{
+    et6000_t *dev = (et6000_t *)priv;
+
+    return ((addr == 0x23) && (INDEX >= 0) && (INDEX <= 5)) ? dev->regs[INDEX] : 0xff;
+}
+
+static void
+et6000_close(void *priv)
+{
+    et6000_t *dev = (et6000_t *)priv;
+
+    free(dev);
+}
+
+static void *
+et6000_init(const device_t *info)
+{
+    et6000_t *dev = (et6000_t *)malloc(sizeof(et6000_t));
+    memset(dev, 0, sizeof(et6000_t));
+
+    /* Port 92h */
+    device_add(&port_92_device);
+
+    /* Defaults */
+    dev->regs[0x13] = 1;
+
+    /* Shadow Programming */
+    et6000_shadow_control(0xf0000, 0x10000, 0, 1);
+
+    io_sethandler(0x0022, 2, et6000_read, NULL, NULL, et6000_write, NULL, NULL, dev); /* Ports 22h-23h: ETEQ Cheetah ET6000 */
+
+    return dev;
+}
+
+const device_t et6000_device = {
+    "ETEQ Cheetah ET6000",
+    0,
+    0,
+    et6000_init,
+    et6000_close,
+    NULL,
+    {NULL},
+    NULL,
+    NULL,
+    NULL};

--- a/src/include/86box/chipset.h
+++ b/src/include/86box/chipset.h
@@ -44,6 +44,9 @@ extern const device_t	scat_sx_device;
 extern const device_t	cs8230_device;
 extern const device_t   cs4031_device;
 
+/* ETEQ */
+extern const device_t   et6000_device;
+
 /* G2 */
 extern const device_t   gc100_device;
 extern const device_t   gc100a_device;

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -321,6 +321,8 @@ extern int	machine_at_opti495_mr_init(const machine_t *);
 extern int	machine_at_vect486vl_init(const machine_t *);
 extern int	machine_at_d824_init(const machine_t *);
 
+extern int	machine_at_pcs46c_init(const machine_t *);
+
 extern int	machine_at_403tg_init(const machine_t *);
 extern int	machine_at_pc330_6573_init(const machine_t *);
 extern int	machine_at_mvi486_init(const machine_t *);
@@ -364,6 +366,7 @@ extern int	machine_at_pcm5330_init(const machine_t *);
 extern const device_t 	*at_acera1g_get_device(void);
 extern const device_t 	*at_vect486vl_get_device(void);
 extern const device_t 	*at_d824_get_device(void);
+extern const device_t 	*at_pcs46c_get_device(void);
 extern const device_t 	*at_valuepoint433_get_device(void);
 #endif
 
@@ -611,9 +614,6 @@ extern int	machine_ps2_m30_286_init(const machine_t *);
 extern int	machine_ps2_model_50_init(const machine_t *);
 extern int	machine_ps2_model_55sx_init(const machine_t *);
 extern int	machine_ps2_model_70_type3_init(const machine_t *);
-#if defined(DEV_BRANCH) && defined(USE_PS2M70T4)
-extern int	machine_ps2_model_70_type4_init(const machine_t *);
-#endif
 extern int	machine_ps2_model_80_init(const machine_t *);
 
 /* m_tandy.c */

--- a/src/machine/CMakeLists.txt
+++ b/src/machine/CMakeLists.txt
@@ -44,10 +44,6 @@ if(OPEN_AT)
 	target_compile_definitions(mch PRIVATE USE_OPEN_AT)
 endif()
 
-if(PS2M70T4)
-	target_compile_definitions(mch PRIVATE USE_PS2M70T4)
-endif()
-
 if(M154X)
 	target_compile_definitions(mch PRIVATE USE_M154X)
 endif()

--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -389,6 +389,34 @@ at_d824_get_device(void)
 }
 
 int
+machine_at_pcs46c_init(const machine_t *model)
+{
+    int ret;
+
+   ret = bios_load_linear("roms/machines/pcs46c/OLIVETTI.BIN",
+			  0x000e0000, 131072, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_at_common_ide_init(model);
+
+    device_add(&et6000_device);
+    device_add(&keyboard_ps2_device);
+
+    if (gfxcard == VID_INTERNAL)
+	device_add(&gd5428_onboard_device);
+
+    return ret;
+}
+
+const device_t *
+at_pcs46c_get_device(void)
+{
+    return &gd5428_onboard_device;
+}
+
+int
 machine_at_acera1g_init(const machine_t *model)
 {
     int ret;

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -200,15 +200,11 @@ const machine_t machines[] = {
     /* 486 machines - Socket 1 */
     { "[ALi M1429] Olystar LIL1429",		"ali1429",		MACHINE_TYPE_486,		CPU_PKG_SOCKET1, 0, 0, 0, 0, 0, 0, 0,										MACHINE_VLB | MACHINE_IDE,							 1024, 32768, 1024, 127,	      machine_at_ali1429_init, NULL			},
     { "[CS4031] AMI 486 CS4031",		"cs4031",		MACHINE_TYPE_486,		CPU_PKG_SOCKET1, 0, 0, 0, 0, 0, 0, 0,										MACHINE_VLB,									 1024, 65536, 1024, 127,	       machine_at_cs4031_init, NULL			},
+    { "[ETEQ ET6000] Olivetti PCS-46C",		"pcs46c",		MACHINE_TYPE_486,		CPU_PKG_SOCKET1, 0, 0, 0, 0, 0, 0, 0,										MACHINE_VLB | MACHINE_IDE | MACHINE_VIDEO,							 4096, 32768, 4096, 127,	      machine_at_pcs46c_init, at_pcs46c_get_device			},
     { "[OPTi 895] Mylex MVI486",		"mvi486",		MACHINE_TYPE_486,		CPU_PKG_SOCKET1, 0, 0, 0, 0, 0, 0, 0,										MACHINE_VLB | MACHINE_IDE_DUAL,							 1024, 65536, 1024, 127,	       machine_at_mvi486_init, NULL			},
     { "[VIA VT82C495] FIC 486-VC-HD",		"486vchd",		MACHINE_TYPE_486,		CPU_PKG_SOCKET1, 0, 0, 0, 0, 0, 0, 0,										MACHINE_AT,									 1024, 64512, 1024, 127,	      machine_at_486vchd_init, NULL			},
     { "[VLSI 82C480] HP Vectra 486VL",		"vect486vl",		MACHINE_TYPE_486,		CPU_PKG_SOCKET1, 0, 0, 0, 0, 0, 0, 0,										MACHINE_AT | MACHINE_BUS_PS2 | MACHINE_IDE | MACHINE_VIDEO,			 2048, 32768, 2048, 127,	    machine_at_vect486vl_init, at_vect486vl_get_device	},
     { "[VLSI 82C481] Siemens Nixdorf D824",		"d824",		MACHINE_TYPE_486,		CPU_PKG_SOCKET1, 0, 0, 0, 0, 0, 0, 0,										MACHINE_AT | MACHINE_BUS_PS2 | MACHINE_IDE | MACHINE_VIDEO,			 2048, 32768, 2048, 127,	    machine_at_d824_init, at_d824_get_device	},
-
-    /* 486 machines with utilize the MCA bus */
-#if defined(DEV_BRANCH) && defined(USE_PS2M70T4)
-    { "[MCA] IBM PS/2 model 70 (type 4)",	"ibmps2_m70_type4",	MACHINE_TYPE_486,		CPU_PKG_SOCKET1, 0, 0, 0, 0, 0, 0, 0,										MACHINE_MCA | MACHINE_BUS_PS2 | MACHINE_VIDEO,					 2048,  16384, 2048,  63,     machine_ps2_model_70_type4_init, NULL			},
-#endif
 
     /* 486 machines - Socket 3 */
     /* 486 machines with just the ISA slot */

--- a/src/win/Makefile.mingw
+++ b/src/win/Makefile.mingw
@@ -610,7 +610,7 @@ CPUOBJ		:= cpu.o cpu_table.o fpu.o x86.o \
 		    x86seg.o x87.o x87_timings.o \
 		    $(DYNARECOBJ)
 
-CHIPSETOBJ	:= acc2168.o cs8230.o ali1217.o ali1429.o ali1489.o headland.o intel_82335.o cs4031.o \
+CHIPSETOBJ	:= acc2168.o cs8230.o ali1217.o ali1429.o ali1489.o et6000.o headland.o intel_82335.o cs4031.o \
 		    intel_420ex.o intel_4x0.o intel_sio.o intel_piix.o ioapic.o \
 		    neat.o opti495.o opti822.o opti895.o opti5x7.o scamp.o scat.o via_vt82c49x.o via_vt82c505.o \
 		    gc100.o \


### PR DESCRIPTION
Checklist
=========
* [X] I have discussed this with core contributors already
* [X] This pull request requires changes to the ROM set
