### PR TITLE
win_opengl: Fix out-of-bounds texture transfer when y2 is bigger than…

### DIFF
--- a/src/win/win_opengl.c
+++ b/src/win/win_opengl.c
@@ -625,15 +625,18 @@ static void opengl_main(void* param)
 					SetEvent(sync_objects.resize);
 			}
 
+			/* Clip to height. y2 can be out-of-bounds. */
+			int sub_height = MIN(info->y2 - info->y1, info->h - info->y1);
+
 			if (!GLAD_GL_ARB_buffer_storage)
 			{
 				/* Fallback method, copy data to pixel buffer. */
-				glBufferSubData(GL_PIXEL_UNPACK_BUFFER, BUFFERBYTES * read_pos, info->w * (info->y2 - info->y1) * sizeof(uint32_t), info->buffer);
+				glBufferSubData(GL_PIXEL_UNPACK_BUFFER, BUFFERBYTES * read_pos, info->w * sub_height * sizeof(uint32_t), info->buffer);
 			}
 
 			/* Update texture from pixel buffer. */
 			glPixelStorei(GL_UNPACK_SKIP_PIXELS, BUFFERPIXELS * read_pos);
-			glTexSubImage2D(GL_TEXTURE_2D, 0, 0, info->y1, info->w, info->y2 - info->y1, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
+			glTexSubImage2D(GL_TEXTURE_2D, 0, 0, info->y1, info->w, sub_height, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
 
 			/* Add fence to track when above gl commands are complete. */
 			info->sync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);

--- a/src/win/win_opengl.c
+++ b/src/win/win_opengl.c
@@ -626,7 +626,7 @@ static void opengl_main(void* param)
 			}
 
 			/* Clip to height. y2 can be out-of-bounds. */
-			int sub_height = MIN(info->y2 - info->y1, info->h - info->y1);
+			int sub_height = MIN(info->y2, info->h) - info->y1;
 
 			if (!GLAD_GL_ARB_buffer_storage)
 			{


### PR DESCRIPTION
… height.

Summary
=======
Seems that certain EGA modes double y2. It is ignored in SDL renderers and the extra height seems to be blank. Fix by ignoring it in OpenGL Core renderer as well.

Checklist
=========
* [x] Closes #1432
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
