### PR TITLE
Move cpu_override warning dialog after main window is created so that…

### DIFF
--- a/src/win/win_ui.c
+++ b/src/win/win_ui.c
@@ -1339,11 +1339,6 @@ ui_init(int nCmdShow)
     }
 #endif
 
-    /* Warn the user about unsupported configs. */
-    if (cpu_override && ui_msgbox_ex(MBX_WARNING | MBX_QUESTION_OK, (void *) IDS_2145, (void *) IDS_2146, (void *) IDS_2147, (void *) IDS_2119, NULL)) {
-	return(0);
-    }
-
     /* Create our main window's class and register it. */
     wincl.hInstance = hinstance;
     wincl.lpszClassName = CLASS_NAME;
@@ -1437,6 +1432,13 @@ ui_init(int nCmdShow)
 
     /* Make the window visible on the screen. */
     ShowWindow(hwnd, nCmdShow);
+
+    /* Warn the user about unsupported configs. */
+    if (cpu_override && ui_msgbox_ex(MBX_WARNING | MBX_QUESTION_OK, (void*)IDS_2145, (void*)IDS_2146, (void*)IDS_2147, (void*)IDS_2119, NULL))
+    {
+	    DestroyWindow(hwnd);
+	    return(0);
+    }
 
     GetClipCursor(&oldclip);
 


### PR DESCRIPTION
… manager gets the correct window handle.

Summary
=======
This is the easy way to fix 86BoxManager thinking a timeout occurred or getting the warning dialogs handle when VM has cpu_override.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
