### PR TITLE
Fixed 1280x1024x8/16bpp and 1600x1200x8/16bpp video modes in the S3 t…

### DIFF
--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -2565,7 +2565,8 @@ static void s3_recalctimings(svga_t *svga)
 				if (s3->chip == S3_86C928) {
 					if (s3->width == 2048 || s3->width == 1280 || s3->width == 1600)
 						svga->hdisp *= 2;
-				} else if ((s3->chip != S3_86C801) && (s3->chip != S3_86C805)) {
+				} else if ((s3->chip != S3_86C801) && (s3->chip != S3_86C805) && (s3->chip != S3_TRIO32) &&
+							(s3->chip != S3_TRIO64) && (s3->chip != S3_TRIO64V)) {
 					if (s3->width == 1280 || s3->width == 1600)
 						svga->hdisp *= 2;
 				}
@@ -2581,7 +2582,8 @@ static void s3_recalctimings(svga_t *svga)
 				else if (s3->chip != S3_VISION968)
 					svga->hdisp /= 2;
 			}
-			if (s3->chip != S3_VISION868) {
+			if ((s3->chip != S3_VISION868) && (s3->chip != S3_TRIO32) &&
+				(s3->chip != S3_TRIO64) && (s3->chip != S3_TRIO64V)) {
 				if (s3->width == 1280 || s3->width == 1600)
 					svga->hdisp *= 2;
 			}
@@ -2596,7 +2598,8 @@ static void s3_recalctimings(svga_t *svga)
 				else if (s3->chip != S3_VISION968)
 					svga->hdisp /= 2;
 			}
-			if (s3->chip != S3_VISION868) {
+			if ((s3->chip != S3_VISION868) && (s3->chip != S3_TRIO32) &&
+				(s3->chip != S3_TRIO64) && (s3->chip != S3_TRIO64V)) {
 				if (s3->width == 1280 || s3->width == 1600)
 					svga->hdisp *= 2;
 			}


### PR DESCRIPTION
…rio class cards.

The 1990 Spock BIOS uses ID 6 for the boot drive.

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
