### PR TITLE
Various small fixes

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1040,6 +1040,10 @@ load_storage_controllers(void)
 	hdc_current = hdc_get_from_internal_name("st506_xt_dtc5150x");
     else if (!strcmp(p, "mfm_at"))
 	hdc_current = hdc_get_from_internal_name("st506_at");
+    else if (!strcmp(p, "vlb_isa"))
+	hdc_current = hdc_get_from_internal_name("ide_vlb");
+    else if (!strcmp(p, "vlb_isa_2ch"))
+	hdc_current = hdc_get_from_internal_name("ide_vlb_2ch");
     else
 	hdc_current = hdc_get_from_internal_name(p);
 
@@ -1741,6 +1745,10 @@ load_other_peripherals(void)
 		hdc_current = hdc_get_from_internal_name("st506_xt_dtc5150x");
 	else if (!strcmp(p, "mfm_at"))
 		hdc_current = hdc_get_from_internal_name("st506_at");
+	else if (!strcmp(p, "vlb_isa"))
+		hdc_current = hdc_get_from_internal_name("ide_vlb");
+	else if (!strcmp(p, "vlb_isa_2ch"))
+		hdc_current = hdc_get_from_internal_name("ide_vlb_2ch");
 	else
 		hdc_current = hdc_get_from_internal_name(p);
 	config_delete_var(cat, "hdc");

--- a/src/disk/hdc.c
+++ b/src/disk/hdc.c
@@ -118,8 +118,8 @@ static const struct {
     { "esdi_mca",		&esdi_ps2_device		},
     { "ide_pci",		&ide_pci_device			},
     { "ide_pci_2ch",		&ide_pci_2ch_device		},
-    { "vlb_isa",		&ide_vlb_device			},
-    { "vlb_isa_2ch",		&ide_vlb_2ch_device		},
+    { "ide_vlb",		&ide_vlb_device			},
+    { "ide_vlb_2ch",		&ide_vlb_2ch_device		},
     { "",			NULL				}
 };
 

--- a/src/printer/prt_escp.c
+++ b/src/printer/prt_escp.c
@@ -595,7 +595,7 @@ update_font(escp_t *dev)
     /* Create a full pathname for the ROM file. */
     strcpy(path, dev->fontpath);
     plat_path_slash(path);
-    strcpy(path, fn);
+    strcat(path, fn);
 
     escp_log("Temp file=%s\n", path);
 

--- a/src/printer/prt_ps.c
+++ b/src/printer/prt_ps.c
@@ -145,7 +145,7 @@ convert_to_pdf(ps_t *dev)
     strcat(input_fn, dev->filename);
 
     strcpy(output_fn, input_fn);
-    strcat(output_fn + strlen(output_fn) - 3, ".pdf");
+    strcpy(output_fn + strlen(output_fn) - 3, ".pdf");
 
     gsargv[0] = "";
     gsargv[1] = "-dNOPAUSE";

--- a/src/printer/prt_text.c
+++ b/src/printer/prt_text.c
@@ -154,7 +154,7 @@ dump_page(prnt_t *dev)
     if (! plat_dir_check(path))
         plat_dir_create(path);
     plat_path_slash(path);
-    strcpy(path, dev->filename);
+    strcat(path, dev->filename);
 
     /* Create the file. */
     fp = plat_fopen(path, "a");

--- a/src/win/win_media_menu.c
+++ b/src/win/win_media_menu.c
@@ -293,7 +293,7 @@ is_valid_fdd(int i)
 static inline int
 is_valid_cdrom(int i)
 {
-    if ((cdrom[i].bus_type == CDROM_BUS_ATAPI) && !MACHINE_HAS_IDE)
+    if ((cdrom[i].bus_type == CDROM_BUS_ATAPI) && !MACHINE_HAS_IDE && memcmp(hdc_get_internal_name(hdc_current), "ide", 3))
 	return 0;
     if ((cdrom[i].bus_type == CDROM_BUS_SCSI) && !MACHINE_HAS_SCSI && (scsi_card_current == 0))
 	return 0;
@@ -303,7 +303,7 @@ is_valid_cdrom(int i)
 static inline int
 is_valid_zip(int i)
 {
-    if ((zip_drives[i].bus_type == ZIP_BUS_ATAPI) && !MACHINE_HAS_IDE)
+    if ((zip_drives[i].bus_type == ZIP_BUS_ATAPI) && !MACHINE_HAS_IDE && memcmp(hdc_get_internal_name(hdc_current), "ide", 3))
 	return 0;
     if ((zip_drives[i].bus_type == ZIP_BUS_SCSI) && !MACHINE_HAS_SCSI && (scsi_card_current == 0))
 	return 0;
@@ -313,7 +313,7 @@ is_valid_zip(int i)
 static inline int
 is_valid_mo(int i)
 {
-    if ((mo_drives[i].bus_type == MO_BUS_ATAPI) && !MACHINE_HAS_IDE)
+    if ((mo_drives[i].bus_type == MO_BUS_ATAPI) && !MACHINE_HAS_IDE && memcmp(hdc_get_internal_name(hdc_current), "ide", 3))
 	return 0;
     if ((mo_drives[i].bus_type == MO_BUS_SCSI) && !MACHINE_HAS_SCSI && (scsi_card_current == 0))
 	return 0;

--- a/src/win/win_stbar.c
+++ b/src/win/win_stbar.c
@@ -51,7 +51,6 @@
 #include <86box/plat.h>
 #include <86box/ui.h>
 #include <86box/win.h>
-#include <86box/mo.h>
 
 #ifndef GWL_WNDPROC
 #define GWL_WNDPROC GWLP_WNDPROC


### PR DESCRIPTION
Summary
=======
This includes the following fixes and improvements:
* Fix the generic text printer saving output files into the current working directory, instead of the "printer" sub-directory as intended
* Fix the generic ESC/P printer looking for font files in the wrong directory
* Fix the generic PostScript printer saving output PDFs with a double ".ps.pdf" extension
* Change the internal config name for the VLB IDE controllers to fix an issue where drives attached to these controllers would not appear in the status bar
* Make the "Media" menu recognize drives attached to external IDE controllers
* Remove an extra unneeded #include in win_stbar.c

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

