### PR TITLE
Philips and Olivetti bugfixes

### DIFF
--- a/src/machine/m_xt_philips.c
+++ b/src/machine/m_xt_philips.c
@@ -150,9 +150,6 @@ machine_xt_philips_common_init(const machine_t *model)
 
     pit_ctr_set_out_func(&pit->counters[1], pit_refresh_timer_xt);
 
-    /* On-board FDC cannot be disabled */
-    device_add(&fdc_xt_device);
-    
     nmi_init();
 
     if (joystick_type)
@@ -179,6 +176,9 @@ machine_xt_p3105_init(const machine_t *model)
 
     machine_xt_philips_common_init(model);
 
+    /* On-board FDC cannot be disabled */
+	device_add(&fdc_xt_device);
+
     return ret;
 }
 
@@ -196,6 +196,8 @@ machine_xt_p3120_init(const machine_t *model)
     machine_xt_philips_common_init(model);
     
     device_add(&gc100a_device);
+
+    device_add(&fdc_at_device);
     
     return ret;
 }

--- a/src/nvr_at.c
+++ b/src/nvr_at.c
@@ -944,8 +944,6 @@ nvr_at_init(const device_t *info)
 				local->flags |= FLAG_LS_HACK;
 			else if ((info->local & 7) == 6)
 				local->flags |= FLAG_APOLLO_HACK;
-			else
-				local->def = 0xff;
 		}
 		nvr->irq = 8;
 		local->cent = RTC_CENTURY_AT;


### PR DESCRIPTION
Summary
=======
Fixed Philips P3120 FDC bug: internal FDC controller now works
Fixed Olivetti M300 NVRAM bug: when initialized for the first time, NVRAM prevented internal FDC and HDC controllers from working once CMOS settings were saved.

Checklist
=========
* [X] Closes https://github.com/86Box/86Box/issues/1160
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] I have opened a roms pull request

References
==========
N/A
