### PR TITLE
Philips and Olivetti bugfixes (revised)

### DIFF
--- a/src/include/86box/nvr.h
+++ b/src/include/86box/nvr.h
@@ -92,6 +92,7 @@ extern const device_t at_nvr_device;
 extern const device_t ps_nvr_device;
 extern const device_t amstrad_nvr_device;
 extern const device_t ibmat_nvr_device;
+extern const device_t olivetti_nvr_device;
 extern const device_t piix4_nvr_device;
 extern const device_t ls486e_nvr_device;
 extern const device_t ami_apollo_nvr_device;

--- a/src/machine/m_at_286_386sx.c
+++ b/src/machine/m_at_286_386sx.c
@@ -833,7 +833,7 @@ machine_at_m30008_init(const machine_t *model)
 	return ret;
 
     machine_at_common_init_ex(model, 2);
-    device_add(&ps_nvr_device);
+    device_add(&olivetti_nvr_device);
 
     device_add(&opti283_device);
     device_add(&keyboard_ps2_olivetti_device);
@@ -858,7 +858,7 @@ machine_at_m30015_init(const machine_t *model)
 	return ret;
 
     machine_at_common_init_ex(model, 2);
-    device_add(&ps_nvr_device);
+    device_add(&olivetti_nvr_device);
     
     device_add(&opti283_device);
     device_add(&keyboard_ps2_olivetti_device);

--- a/src/machine/m_at_286_386sx.c
+++ b/src/machine/m_at_286_386sx.c
@@ -43,6 +43,7 @@
 #include <86box/vid_cga.h>
 #include <86box/flash.h>
 #include <86box/machine.h>
+#include <86box/nvr.h>
 
 int
 machine_at_mr286_init(const machine_t *model)
@@ -831,7 +832,8 @@ machine_at_m30008_init(const machine_t *model)
     if (bios_only || !ret)
 	return ret;
 
-    machine_at_common_init(model);
+    machine_at_common_init_ex(model, 2);
+    device_add(&ps_nvr_device);
 
     device_add(&opti283_device);
     device_add(&keyboard_ps2_olivetti_device);
@@ -855,8 +857,9 @@ machine_at_m30015_init(const machine_t *model)
     if (bios_only || !ret)
 	return ret;
 
-    machine_at_common_init(model);
-
+    machine_at_common_init_ex(model, 2);
+    device_add(&ps_nvr_device);
+    
     device_add(&opti283_device);
     device_add(&keyboard_ps2_olivetti_device);
     device_add(&pc87310_ide_device);

--- a/src/machine/m_xt_philips.c
+++ b/src/machine/m_xt_philips.c
@@ -150,9 +150,6 @@ machine_xt_philips_common_init(const machine_t *model)
 
     pit_ctr_set_out_func(&pit->counters[1], pit_refresh_timer_xt);
 
-    /* On-board FDC cannot be disabled */
-    device_add(&fdc_xt_device);
-    
     nmi_init();
 
     if (joystick_type)
@@ -179,6 +176,9 @@ machine_xt_p3105_init(const machine_t *model)
 
     machine_xt_philips_common_init(model);
 
+    /* On-board FDC cannot be disabled */
+	device_add(&fdc_xt_device);
+
     return ret;
 }
 
@@ -196,6 +196,8 @@ machine_xt_p3120_init(const machine_t *model)
     machine_xt_philips_common_init(model);
     
     device_add(&gc100a_device);
+
+    device_add(&fdc_at_device);
     
     return ret;
 }

--- a/src/nvr_at.c
+++ b/src/nvr_at.c
@@ -944,6 +944,8 @@ nvr_at_init(const device_t *info)
 				local->flags |= FLAG_LS_HACK;
 			else if ((info->local & 7) == 6)
 				local->flags |= FLAG_APOLLO_HACK;
+			else
+				local->def = 0xff;
 		}
 		nvr->irq = 8;
 		local->cent = RTC_CENTURY_AT;

--- a/src/nvr_at.c
+++ b/src/nvr_at.c
@@ -938,6 +938,8 @@ nvr_at_init(const device_t *info)
 	case 6:		/* AMI Apollo */
 		if (info->local == 9)
 			local->flags |= FLAG_PIIX4;
+		else if (info->local == 6)
+			local->def = 0x00;
 		else {
 			local->def = 0x00;
 			if ((info->local & 7) == 5)
@@ -1073,6 +1075,15 @@ const device_t ibmat_nvr_device = {
     "IBM AT NVRAM",
     DEVICE_ISA | DEVICE_AT,
     4,
+    nvr_at_init, nvr_at_close, NULL,
+    { NULL }, nvr_at_speed_changed,
+    NULL
+};
+
+const device_t olivetti_nvr_device = {
+    "Olivetti NVRAM",
+    DEVICE_ISA | DEVICE_AT,
+    6,
     nvr_at_init, nvr_at_close, NULL,
     { NULL }, nvr_at_speed_changed,
     NULL

--- a/src/nvr_at.c
+++ b/src/nvr_at.c
@@ -944,8 +944,6 @@ nvr_at_init(const device_t *info)
 				local->flags |= FLAG_LS_HACK;
 			else if ((info->local & 7) == 6)
 				local->flags |= FLAG_APOLLO_HACK;
-			else
-				local->def = 0xff;
 		}
 		nvr->irq = 8;
 		local->cent = RTC_CENTURY_AT;


### PR DESCRIPTION
Summary
=======
Fixed Philips P3120 FDC bug: internal FDC controller now works
Fixed Olivetti M300 NVRAM bug: when initialized for the first time, NVRAM prevented internal FDC and HDC controllers from working once CMOS settings were saved. A specific NVRAM device for Olivetti machines has been created in nvr_at.c

Checklist
=========
* [X] Closes https://github.com/86Box/86Box/issues/1160
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] I have opened a roms pull request

References
==========
N/A
