### PR TITLE
Fixed 256 color modes in the Oak OTI, made the New MMIO-capable S3 cards behave like the ViRGE and fixed some modes in the 868/968 in recalctimings

### DIFF
--- a/src/video/vid_oak_oti.c
+++ b/src/video/vid_oak_oti.c
@@ -405,6 +405,7 @@ oti_init(const device_t *info)
 		  oti_in, NULL, NULL, oti_out, NULL, NULL, oti);
 
     oti->svga.miscout = 1;
+	oti->svga.packed_chain4 = 1;
 
     return(oti);
 }

--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -2232,8 +2232,6 @@ s3_out(uint16_t addr, uint8_t val, void *p)
 			rs2 = !!(svga->crtc[0x43] & 0x02);
 		else
 			rs2 = (svga->crtc[0x55] & 0x01);
-
-		pclog("Write RS2 enabled: crtc43 bit 1 = %02x, crtc55 bits 0-1 = %02x\n", svga->crtc[0x43] & 0x02, svga->crtc[0x55] & 0x03);
 		if (s3->chip >= S3_TRIO32)
 			svga_out(addr, val, svga);
 		else if ((s3->chip == S3_VISION964 && s3->card_type != S3_ELSAWIN2KPROX_964) || (s3->chip == S3_86C928)) {


### PR DESCRIPTION
Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
