### PR TITLE
Temporarily dev branch OPTi 822-using machines

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -324,7 +324,9 @@ extern int	machine_at_d824_init(const machine_t *);
 extern int	machine_at_pcs46c_init(const machine_t *);
 
 extern int	machine_at_403tg_init(const machine_t *);
+#if defined(DEV_BRANCH) && defined(USE_OPTI822)  
 extern int	machine_at_pc330_6573_init(const machine_t *);
+#endif
 extern int	machine_at_mvi486_init(const machine_t *);
 
 extern int	machine_at_sis401_init(const machine_t *);
@@ -384,10 +386,12 @@ extern const device_t 	*at_cpqiii_get_device(void);
 /* m_at_socket4_5.c */
 extern int	machine_at_excalibur_init(const machine_t *);
 
-extern int  machine_at_pat54pv_init(const machine_t *);
+extern int	machine_at_pat54pv_init(const machine_t *);
 
+#if defined(DEV_BRANCH) && defined(USE_OPTI822)  
 extern int	machine_at_hot543_init(const machine_t *);
 extern int	machine_at_p54vl_init(const machine_t *);
+#endif
 
 extern int	machine_at_batman_init(const machine_t *);
 extern int	machine_at_ambradp60_init(const machine_t *);

--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -592,7 +592,7 @@ machine_at_403tg_init(const machine_t *model)
     return ret;
 }
 
-
+#if defined(DEV_BRANCH) && defined(USE_OPTI822)  
 int
 machine_at_pc330_6573_init(const machine_t *model)	// doesn't like every CPU other than the iDX4 and the Intel OverDrive, hangs without a PS/2 mouse
 {
@@ -619,7 +619,7 @@ machine_at_pc330_6573_init(const machine_t *model)	// doesn't like every CPU oth
 
     return ret;
 }
-
+#endif
 
 int
 machine_at_mvi486_init(const machine_t *model)

--- a/src/machine/m_at_socket4_5.c
+++ b/src/machine/m_at_socket4_5.c
@@ -83,6 +83,7 @@ machine_at_pat54pv_init(const machine_t *model)
 
     return ret;
 }
+#if defined(DEV_BRANCH) && defined(USE_OPTI822)  
 int
 machine_at_hot543_init(const machine_t *model)
 {
@@ -138,7 +139,7 @@ machine_at_p54vl_init(const machine_t *model)
 
     return ret;
 }
-
+#endif
 static void
 machine_at_premiere_common_init(const machine_t *model, int pci_switch)
 {

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -225,7 +225,9 @@ const machine_t machines[] = {
     /* 486 machines which utilize the PCI bus */
     { "[ALi M1489] ABIT AB-PB4",		"abpb4",		MACHINE_TYPE_486_S3,		CPU_PKG_SOCKET3, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PCI | MACHINE_IDE_DUAL,							 1024,  65536, 1024, 255,		machine_at_abpb4_init, NULL			},
     { "[ALi M1489] AMI WinBIOS 486 PCI",	"win486pci",		MACHINE_TYPE_486_S3,		CPU_PKG_SOCKET3, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PCI | MACHINE_IDE_DUAL,							 1024,  65536, 1024, 255,	    machine_at_win486pci_init, NULL			},
+#if defined(DEV_BRANCH) && defined(USE_OPTI822)  
     { "[OPTi 802G] IBM PC 330 (type 6573)",	"pc330_6573",		MACHINE_TYPE_486_S3,		CPU_PKG_SOCKET3_PC330, 0, 25000000, 33333333, 0, 0, 2.0, 3.0,							MACHINE_PCI | MACHINE_BUS_PS2 | MACHINE_IDE,					 1024, 65536, 1024, 127,	   machine_at_pc330_6573_init, NULL			},
+#endif
     { "[i420EX] ASUS PVI-486AP4",		"486ap4",		MACHINE_TYPE_486_S3,		CPU_PKG_SOCKET3, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PCIV | MACHINE_IDE_DUAL,						 1024, 131072, 1024, 127,	       machine_at_486ap4_init, NULL			},
     { "[i420ZX] ASUS PCI/I-486SP3G",		"486sp3g",		MACHINE_TYPE_486_S3,		CPU_PKG_SOCKET3, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PCI | MACHINE_IDE_DUAL | MACHINE_SCSI,					 1024, 131072, 1024, 127,	      machine_at_486sp3g_init, NULL			},
     { "[i420TX] ASUS PCI/I-486SP3",		"486sp3",		MACHINE_TYPE_486_S3,		CPU_PKG_SOCKET3, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PCI | MACHINE_IDE_DUAL | MACHINE_SCSI,					 1024, 131072, 1024, 127,	       machine_at_486sp3_init, NULL			},
@@ -284,11 +286,11 @@ const machine_t machines[] = {
 
     /* OPTi 596/597 */
     { "[OPTi 597] TMC PAT54PV",			"pat54pv",		MACHINE_TYPE_SOCKET5,		CPU_PKG_SOCKET5_7, CPU_BLOCK(CPU_K5, CPU_5K86), 50000000, 66666667, 3520, 3520, 1.5, 1.5,			MACHINE_VLB,									 2048,  65536, 2048, 127,	      machine_at_pat54pv_init, NULL			},
-    
+#if defined(DEV_BRANCH) && defined(USE_OPTI822)    
     /* OPTi 596/597/822 */
     { "[OPTi 597] Shuttle HOT-543",		"hot543",		MACHINE_TYPE_SOCKET5,		CPU_PKG_SOCKET5_7, 0, 50000000, 66666667, 3520, 3520, 1.5, 1.5,							MACHINE_PCI | MACHINE_VLB,							 8192, 131072, 8192, 127,	       machine_at_hot543_init, NULL			},
     { "[OPTi 597] Supermicro P54VL-PCI",	"p54vl",		MACHINE_TYPE_SOCKET5,		CPU_PKG_SOCKET5_7, 0, 60000000, 66666667, 3520, 3520, 1.5, 1.5,							MACHINE_PCI | MACHINE_VLB,							 8192, 131072, 8192, 127,		machine_at_p54vl_init, NULL			},
-
+#endif
     /* SiS 85C50x */
     { "[SiS 85C50x] ASUS PCI/I-P54SP4",		"p54sp4",		MACHINE_TYPE_SOCKET5,		CPU_PKG_SOCKET5_7, CPU_BLOCK(CPU_K5, CPU_5K86), 40000000, 66666667, 3380, 3520, 1.5, 1.5,			MACHINE_PCI | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,				 8192, 131072, 8192, 127,	       machine_at_p54sp4_init, NULL			},
     { "[SiS 85C50x] BCM SQ-588",		"sq588",		MACHINE_TYPE_SOCKET5,		CPU_PKG_SOCKET5_7, CPU_BLOCK(CPU_PENTIUMMMX), 50000000, 66666667, 3520, 3520, 1.5, 1.5,				MACHINE_PCI | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,				 8192, 131072, 8192, 127,		machine_at_sq588_init, NULL			},

--- a/src/win/Makefile.mingw
+++ b/src/win/Makefile.mingw
@@ -48,6 +48,7 @@ ifeq ($(DEV_BUILD), y)
  ifndef I450KX
   I450KX		:= y
  endif
+ 
  ifndef M154X
   M154X		:= y
  endif
@@ -66,6 +67,9 @@ ifeq ($(DEV_BUILD), y)
  ifndef OPENGL
   OPENGL	:= y
  endif
+ ifndef OPTI822
+  OPTI822	:= y
+ endif 
  ifndef PAS16
   PAS16		:= n
  endif
@@ -139,6 +143,9 @@ else
  ifndef OPENGL
   OPENGL	:= n
  endif
+ ifndef OPTI822
+  OPTI822	:= n
+ endif  
  ifndef PAS16
   PAS16		:= n
  endif
@@ -539,6 +546,11 @@ RFLAGS		+= -DUSE_OPENGL
 DEVBROBJ	+= win_opengl.o win_opengl_glslp.o glad.o
 endif
 
+ifeq ($(OPTI822), y)
+OPTS		+= -DUSE_OPTI822
+DEVBROBJ	+= opti822.o
+endif
+
 ifeq ($(PAS16), y)
 OPTS		+= -DUSE_PAS16
 DEVBROBJ	+= snd_pas16.o
@@ -612,7 +624,7 @@ CPUOBJ		:= cpu.o cpu_table.o fpu.o x86.o \
 
 CHIPSETOBJ	:= acc2168.o cs8230.o ali1217.o ali1429.o ali1489.o et6000.o headland.o intel_82335.o cs4031.o \
 		    intel_420ex.o intel_4x0.o intel_sio.o intel_piix.o ioapic.o \
-		    neat.o opti495.o opti822.o opti895.o opti5x7.o scamp.o scat.o via_vt82c49x.o via_vt82c505.o \
+		    neat.o opti495.o opti895.o opti5x7.o scamp.o scat.o via_vt82c49x.o via_vt82c505.o \
 		    gc100.o \
 		    sis_85c310.o sis_85c4xx.o sis_85c496.o sis_85c50x.o sis_5511.o sis_5571.o sis_5598.o stpc.o opti283.o opti291.o \
 		    umc_8886.o umc_8890.o umc_hb4.o \


### PR DESCRIPTION

Summary
=======
This PR temporarily dev-branches the OPTi 822 machines because currently their PCI IRQ routing is broken.

Checklist
=========
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set


