### PR TITLE
Fix Alt-F4 closing SDL renderer window.

### DIFF
--- a/src/win/win_ui.c
+++ b/src/win/win_ui.c
@@ -1533,7 +1533,15 @@ ui_init(int nCmdShow)
 		break;
 	}
 
-	if (! TranslateAccelerator(hwnd, haccel, &messages)) {
+	if (! TranslateAccelerator(hwnd, haccel, &messages))
+	{
+		/* Don't process other keypresses. */
+		if (messages.message == WM_SYSKEYDOWN ||
+			messages.message == WM_SYSKEYUP ||
+			messages.message == WM_KEYDOWN ||
+			messages.message == WM_KEYUP)
+			continue;
+
                 TranslateMessage(&messages);
                 DispatchMessage(&messages);
 	}


### PR DESCRIPTION
Summary
=======
Pressing Alt+F4 in full screen mode closes SDL renderer window resulting in black screen while emulator continues (debug will throw warning in a while). This is because of default handlers in message pump and can be fixed by ignoring the key messages.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
