### PR TITLE
Explicitly initialize COM library in main and opengl threads

### DIFF
--- a/src/win/win.c
+++ b/src/win/win.c
@@ -417,6 +417,9 @@ WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR lpszArg, int nCmdShow)
 
     SetCurrentProcessExplicitAppUserModelID(AppID);
 
+    /* Initialize the COM library for the main thread. */
+    CoInitializeEx(NULL, COINIT_MULTITHREADED);
+
     /* Check if Windows supports UTF-8 */
     if (GetACP() == CP_UTF8)
 	acp_utf8 = 1;
@@ -464,6 +467,9 @@ WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR lpszArg, int nCmdShow)
 
     /* Handle our GUI. */
     i = ui_init(nCmdShow);
+
+    /* Uninitialize COM before exit. */
+    CoUninitialize();
 
     free(argbuf);
     free(argv);

--- a/src/win/win_opengl.c
+++ b/src/win/win_opengl.c
@@ -468,6 +468,9 @@ static void __stdcall opengl_debugmsg_callback(GLenum source, GLenum type, GLuin
 */
 static void opengl_main(void* param)
 {
+	/* Initialize COM library for this thread before SDL does so. */
+	CoInitializeEx(NULL, COINIT_MULTITHREADED);
+
 	SDL_InitSubSystem(SDL_INIT_VIDEO);
 
 	SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1"); /* Is this actually doing anything...? */
@@ -788,6 +791,8 @@ static void opengl_main(void* param)
 	SDL_DestroyWindow(window);
 
 	window = NULL;
+
+	CoUninitialize();
 }
 
 static void opengl_blit(int x, int y, int y1, int y2, int w, int h)


### PR DESCRIPTION
Summary
=======
There is some indication that improperly initializing COM library could cause hangs or crashes with common file dialogs.
COM library isn't explicitly initialized but SDL does it implicitly. By initializing the library in main and opengl thread, both which create windows and have message pump, there is better control on the initialization.

Related issue #1485

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://docs.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-coinitializeex
https://jackiichan.wordpress.com/2007/09/19/getopenfilename-and-some-deep-crashes/
