### PR TITLE
Suppress GCC false positive warnings in vid_voodoo_codegen_x86[-64].h

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,7 +45,7 @@ if(VNC)
 endif()
 
 target_link_libraries(86Box cpu chipset mch dev mem fdd game cdrom zip mo hdd
-	net print scsi sio snd vid plat ui)
+	net print scsi sio snd vid voodoo plat ui)
 
 find_package(Freetype REQUIRED)
 include_directories(${FREETYPE_INCLUDE_DIRS})

--- a/src/video/CMakeLists.txt
+++ b/src/video/CMakeLists.txt
@@ -24,14 +24,7 @@ add_library(vid OBJECT video.c vid_table.c vid_cga.c vid_cga_comp.c
 	vid_stg_ramdac.c vid_ht216.c vid_oak_oti.c vid_paradise.c vid_rtg310x.c
 	vid_ti_cf62011.c vid_tvga.c vid_tgui9440.c vid_tkd8001_ramdac.c
 	vid_att20c49x_ramdac.c vid_s3.c vid_s3_virge.c vid_ibm_rgb528_ramdac.c
-	vid_sdac_ramdac.c vid_voodoo.c vid_voodoo_banshee.c
-	vid_voodoo_banshee_blitter.c vid_voodoo_blitter.c vid_voodoo_display.c
-	vid_voodoo_fb.c vid_voodoo_fifo.c vid_voodoo_reg.c vid_voodoo_render.c
-	vid_voodoo_setup.c vid_voodoo_texture.c vid_ogc.c vid_nga.c)
-
-if(NOT MSVC)
-	target_compile_options(vid PRIVATE "-msse2")
-endif()
+	vid_sdac_ramdac.c vid_ogc.c vid_nga.c)
 
 if(MGA)
 	target_compile_definitions(vid PRIVATE USE_MGA)
@@ -48,4 +41,19 @@ endif()
 
 if(XL24)
 	target_compile_definitions(vid PRIVATE USE_XL24)
+endif()
+
+add_library(voodoo OBJECT vid_voodoo.c vid_voodoo_banshee.c
+	vid_voodoo_banshee_blitter.c vid_voodoo_blitter.c vid_voodoo_display.c
+	vid_voodoo_fb.c vid_voodoo_fifo.c vid_voodoo_reg.c vid_voodoo_render.c
+	vid_voodoo_setup.c vid_voodoo_texture.c)
+
+if(NOT MSVC)
+	target_compile_options(voodoo PRIVATE "-msse2")
+endif()
+
+# Suppress GCC false positive warnings in vid_voodoo_codegen_x86[-64].h
+# that cause ~3000 lines to be output into the logs each time
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+	target_compile_options(voodoo PRIVATE "-Wstringop-overflow=0")
 endif()

--- a/src/win/Makefile.mingw
+++ b/src/win/Makefile.mingw
@@ -766,15 +766,16 @@ VIDOBJ		:= video.o \
 		    vid_att20c49x_ramdac.o \
 		    vid_s3.o vid_s3_virge.o \
 		    vid_ibm_rgb528_ramdac.o vid_sdac_ramdac.o \
-		    vid_voodoo.o vid_voodoo_banshee.o \
+			vid_ogc.o \
+			vid_nga.o
+
+VOODOOOBJ	:= vid_voodoo.o vid_voodoo_banshee.o \
 		    vid_voodoo_banshee_blitter.o \
 		    vid_voodoo_blitter.o \
 		    vid_voodoo_display.o vid_voodoo_fb.o \
 		    vid_voodoo_fifo.o vid_voodoo_reg.o \
 		    vid_voodoo_render.o vid_voodoo_setup.o \
-		    vid_voodoo_texture.o \
-			vid_ogc.o \
-			vid_nga.o
+		    vid_voodoo_texture.o
 
 PLATOBJ		:= win.o \
 		    win_dynld.o win_thread.o \
@@ -790,7 +791,7 @@ endif
 
 OBJ		:= $(MAINOBJ) $(CPUOBJ) $(CHIPSETOBJ) $(MCHOBJ) $(DEVOBJ) $(MEMOBJ) \
 		   $(FDDOBJ) $(GAMEOBJ) $(CDROMOBJ) $(ZIPOBJ) $(MOOBJ) $(HDDOBJ) $(MINIVHDOBJ) \
-		   $(NETOBJ) $(PRINTOBJ) $(SCSIOBJ) $(SIOOBJ) $(SNDOBJ) $(VIDOBJ) \
+		   $(NETOBJ) $(PRINTOBJ) $(SCSIOBJ) $(SIOOBJ) $(SNDOBJ) $(VIDOBJ) $(VOODOOOBJ) \
 		   $(PLATOBJ) $(UIOBJ) $(FSYNTHOBJ) $(MUNTOBJ) $(DEVBROBJ) \
 		   $(DISCORDOBJ) $(MINITRACEOBJ)
 ifdef EXOBJ
@@ -855,6 +856,9 @@ else
 		@$(CPP) $(CXXFLAGS) $(DEPS) -E $< >/dev/null
 endif
 
+# Suppress false positive warnings in vid_voodoo_codegen_x86[-64].h
+# that cause ~3000 lines to be output into the logs each time.
+$(VOODOOOBJ): CFLAGS += -Wstringop-overflow=0
 
 all:		$(PROG).exe
 


### PR DESCRIPTION
Summary
=======
This suppresses a series of false positive "writing 1 byte into a region of size 0" warnings issued by GCC at vid_voodoo_codegen_x86.h line 49 (or vid_voodoo_codegen_x86_64.h line 51), that result in rest of the header file (about 3000 lines) to be printed to the output several times, causing excessive log sizes.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set