### PR TITLE
Fix UTF-8 to UTF-16 conversion of displayed paths to MO/ZIP images

### DIFF
--- a/src/win/win_media_menu.c
+++ b/src/win/win_media_menu.c
@@ -140,7 +140,7 @@ media_menu_set_name_zip(int drive)
     } else {
 	mbstoc16s(fn, zip_drives[drive].image_path, sizeof_w(fn));
 	_swprintf(name, plat_get_string(IDS_2054),
-		  type, drive+1, temp, zip_drives[drive].image_path);
+		  type, drive+1, temp, fn);
     }
 
     mii.cbSize = sizeof(mii);

--- a/src/win/win_stbar.c
+++ b/src/win/win_stbar.c
@@ -292,7 +292,7 @@ StatusBarCreateMOTip(int part)
     } else {
 	mbstoc16s(fn, mo_drives[drive].image_path, sizeof_w(fn));
 	_swprintf(tempTip, plat_get_string(IDS_2115),
-		  drive+1, szText, mo_drives[drive].image_path);
+		  drive+1, szText, fn);
     }
 
     if (sbTips[part] != NULL) {


### PR DESCRIPTION
Summary
=======
Fixes paths to loaded MO images displayed in the status bar and ZIP images in the media menu being displayed as a string of random characters due to the intended UTF-8 to UTF-16 conversion not being performed.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set