### PR TITLE
Properly fixed the Bresenham line draw command on TGUI9440.

### DIFF
--- a/src/include/86box/video.h
+++ b/src/include/86box/video.h
@@ -377,6 +377,7 @@ extern const device_t sigma_device;
 extern const device_t tgui9400cxi_device;
 extern const device_t tgui9440_vlb_device;
 extern const device_t tgui9440_pci_device;
+extern const device_t tgui9680_pci_device;
 
 /* IBM PS/1 (S)VGA */
 extern const device_t ibm_ps1_2121_device;

--- a/src/video/vid_table.c
+++ b/src/video/vid_table.c
@@ -160,6 +160,7 @@ video_cards[] = {
     { "virge375_vbe20_pci",	&s3_virge_375_4_pci_device		},
     { "cl_gd5446_stb_pci",	&gd5446_stb_pci_device			},
     { "tgui9440_pci",		&tgui9440_pci_device			},
+    { "tgui9680_pci",		&tgui9680_pci_device			},
     { "voodoo_banshee_pci",	&voodoo_banshee_device  		},
     { "voodoo3_2k_pci",		&voodoo_3_2000_device 			},
     { "voodoo3_3k_pci",		&voodoo_3_3000_device 			},


### PR DESCRIPTION
Added the TGUI9680 card and its corresponding 32bit mode and clipping.
Patterns on bitblt are more properly emulated.

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/129

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
