### PR TITLE
ACPI now always correctly generates a resume event on power on, fixes…

### DIFF
--- a/src/acpi.c
+++ b/src/acpi.c
@@ -1571,6 +1571,9 @@ acpi_reset(void *priv)
 		dev->regs.gpi_val |= 0x00000004;
     }
 
+    /* Power on always generates a resume event. */
+    dev->regs.pmsts |= 0x8000;
+
     acpi_rtc_status = 0;
 }
 


### PR DESCRIPTION
… the HP Vectra VEi 8, fixes #1444.

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
