### PR TITLE
Trident TGUI9680 linear framebuffer PCI BAR is now correctly 4 MB ali…

### DIFF
--- a/src/video/vid_tgui9440.c
+++ b/src/video/vid_tgui9440.c
@@ -895,14 +895,20 @@ void tgui_pci_write(int func, int addr, uint8_t val, void *p)
 				break;
 			
                 case 0x12:
-                tgui->linear_base = (tgui->linear_base & 0xff000000) | ((val & 0xe0) << 16);
+		if (tgui->type == TGUI_9680)
+                	tgui->linear_base = (tgui->linear_base & 0xff000000) | ((val & 0xc0) << 16);
+		else
+                	tgui->linear_base = (tgui->linear_base & 0xff000000) | ((val & 0xe0) << 16);
                 tgui->linear_size = tgui->vram_size;
 				svga->decode_mask = tgui->vram_mask;
                 svga->crtc[0x21] = (svga->crtc[0x21] & ~0xf) | (val >> 4);
                 tgui_recalcmapping(tgui);
                 break;
                 case 0x13:
-                tgui->linear_base = (tgui->linear_base & 0xe00000) | (val << 24);
+		if (tgui->type == TGUI_9680)
+			tgui->linear_base = (tgui->linear_base & 0xc00000) | (val << 24);
+		else
+			tgui->linear_base = (tgui->linear_base & 0xe00000) | (val << 24);
                 tgui->linear_size = tgui->vram_size;
 				svga->decode_mask = tgui->vram_mask;
                 svga->crtc[0x21] = (svga->crtc[0x21] & ~0xc0) | (val >> 6);


### PR DESCRIPTION
…gned.

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
