### PR TITLE
Add the Sound Blaster AWE64 Gold

### DIFF
--- a/src/include/86box/snd_sb.h
+++ b/src/include/86box/snd_sb.h
@@ -30,9 +30,8 @@
 #define SBPRO		5	/* DSP v3.00 */
 #define SBPRO2		6	/* DSP v3.02 + OPL3 */
 #define SB16		7	/* DSP v4.05 + OPL3 */
-#define SADGOLD		8	/* AdLib Gold */
-#define SND_WSS		9	/* Windows Sound System */
-#define SND_PAS16	10	/* Pro Audio Spectrum 16 */
+#define SBAWE32		8	/* DSP v4.13 + OPL3 */
+#define SBAWE64		9	/* DSP v4.16 + OPL3 */
 
 /* SB 2.0 CD version */
 typedef struct sb_ct1335_mixer_t

--- a/src/include/86box/sound.h
+++ b/src/include/86box/sound.h
@@ -116,6 +116,7 @@ extern const device_t sb_16_pnp_device;
 extern const device_t sb_32_pnp_device;
 extern const device_t sb_awe32_device;
 extern const device_t sb_awe32_pnp_device;
+extern const device_t sb_awe64_gold_device;
 
 /* Innovation SSI-2001 */
 extern const device_t ssi2001_device;

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -244,6 +244,81 @@ static uint8_t sb_awe32_pnp_rom[] = {
 
     0x79, 0x00 /* end tag, dummy checksum (filled in by isapnp_add_card) */
 };
+static uint8_t sb_awe64_gold_pnp_rom[] = {
+    0x0e, 0x8c, 0x00, 0x9e, 0x00, 0x00, 0x00, 0x00, 0x00, /* CTL009E, dummy checksum (filled in by isapnp_add_card) */
+    0x0a, 0x10, 0x20, /* PnP version 1.0, vendor version 2.0 */
+    0x82, 0x16, 0x00, 'C', 'r', 'e', 'a', 't', 'i', 'v', 'e', ' ', 'S', 'B', ' ', 'A', 'W', 'E', '6', '4', ' ', 'G', 'o', 'l', 'd', /* ANSI identifier */
+
+    0x16, 0x0e, 0x8c, 0x00, 0x44, 0x00, 0xa9, /* logical device CTL0044, supports vendor-specific registers 0x38/0x3A/0x3C/0x3F */
+	0x82, 0x05, 0x00, 'A', 'u', 'd', 'i', 'o', /* ANSI identifier */
+	0x31, 0x00, /* start dependent functions, preferred */
+		0x22, 0x20, 0x00, /* IRQ 5 */
+		0x2a, 0x02, 0x0c, /* DMA 1, compatibility, no count by word, count by byte, is bus master, 8-bit only */
+		0x2a, 0x20, 0x16, /* DMA 5, compatibility, count by word, no count by byte, is bus master, 16-bit only */
+		0x47, 0x01, 0x20, 0x02, 0x20, 0x02, 0x01, 0x10, /* I/O 0x220, decodes 16-bit, 1-byte alignment, 16 addresses */
+		0x47, 0x01, 0x30, 0x03, 0x30, 0x03, 0x01, 0x02, /* I/O 0x330, decodes 16-bit, 1-byte alignment, 2 addresses */
+		0x47, 0x01, 0x88, 0x03, 0xf8, 0x03, 0x01, 0x04, /* I/O 0x388-0x3F8, decodes 16-bit, 1-byte alignment, 4 addresses */
+	0x30, /* start dependent functions, acceptable */
+		0x22, 0xa0, 0x06, /* IRQ 5/7/9/10 */
+		0x2a, 0x0b, 0x0c, /* DMA 0/1/3, compatibility, no count by word, count by byte, is bus master, 8-bit only */
+		0x2a, 0xe0, 0x16, /* DMA 5/6/7, compatibility, count by word, no count by byte, is bus master, 16-bit only */
+		0x47, 0x01, 0x20, 0x02, 0x80, 0x02, 0x20, 0x10, /* I/O 0x220-0x280, decodes 16-bit, 32-byte alignment, 16 addresses */
+		0x47, 0x01, 0x00, 0x03, 0x30, 0x03, 0x30, 0x02, /* I/O 0x300-0x330, decodes 16-bit, 48-byte alignment, 2 addresses */
+		0x47, 0x01, 0x88, 0x03, 0xf8, 0x03, 0x01, 0x04, /* I/O 0x388-0x3F8, decodes 16-bit, 1-byte alignment, 4 addresses */
+	0x30, /* start dependent functions, acceptable */
+		0x22, 0xa0, 0x06, /* IRQ 5/7/9/10 */
+		0x2a, 0x0b, 0x0c, /* DMA 0/1/3, compatibility, no count by word, count by byte, is bus master, 8-bit only */
+		0x2a, 0xe0, 0x16, /* DMA 5/6/7, compatibility, count by word, no count by byte, is bus master, 16-bit only */
+		0x47, 0x01, 0x20, 0x02, 0x80, 0x02, 0x20, 0x10, /* I/O 0x220-0x280, decodes 16-bit, 32-byte alignment, 16 addresses */
+		0x47, 0x01, 0x00, 0x03, 0x30, 0x03, 0x30, 0x02, /* I/O 0x300-0x330, decodes 16-bit, 48-byte alignment, 2 addresses */
+	0x30, /* start dependent functions, acceptable */
+		0x22, 0xa0, 0x06, /* IRQ 5/7/9/10 */
+		0x2a, 0x0b, 0x0c, /* DMA 0/1/3, compatibility, no count by word, count by byte, is bus master, 8-bit only */
+		0x2a, 0xe0, 0x16, /* DMA 5/6/7, compatibility, count by word, no count by byte, is bus master, 16-bit only */
+		0x47, 0x01, 0x20, 0x02, 0x80, 0x02, 0x20, 0x10, /* I/O 0x220-0x280, decodes 16-bit, 32-byte alignment, 16 addresses */
+	0x30, /* start dependent functions, acceptable */
+		0x22, 0xa0, 0x06, /* IRQ 5/7/9/10 */
+		0x2a, 0x0b, 0x0c, /* DMA 0/1/3, compatibility, no count by word, count by byte, is bus master, 8-bit only */
+		0x47, 0x01, 0x20, 0x02, 0x80, 0x02, 0x20, 0x10, /* I/O 0x220-0x280, decodes 16-bit, 32-byte alignment, 16 addresses */
+		0x47, 0x01, 0x00, 0x03, 0x30, 0x03, 0x30, 0x02, /* I/O 0x300-0x330, decodes 16-bit, 48-byte alignment, 2 addresses */
+		0x47, 0x01, 0x88, 0x03, 0xf8, 0x03, 0x01, 0x04, /* I/O 0x388-0x3F8, decodes 16-bit, 1-byte alignment, 4 addresses */
+	0x30, /* start dependent functions, acceptable */
+		0x22, 0xa0, 0x06, /* IRQ 5/7/9/10 */
+		0x2a, 0x0b, 0x0c, /* DMA 0/1/3, compatibility, no count by word, count by byte, is bus master, 8-bit only */
+		0x47, 0x01, 0x20, 0x02, 0x80, 0x02, 0x20, 0x10, /* I/O 0x220-0x280, decodes 16-bit, 32-byte alignment, 16 addresses */
+		0x47, 0x01, 0x00, 0x03, 0x30, 0x03, 0x30, 0x02, /* I/O 0x300-0x330, decodes 16-bit, 48-byte alignment, 2 addresses */
+	0x30, /* start dependent functions, acceptable */
+		0x22, 0xa0, 0x06, /* IRQ 5/7/9/10 */
+		0x2a, 0x0b, 0x0c, /* DMA 0/1/3, compatibility, no count by word, count by byte, is bus master, 8-bit only */
+		0x47, 0x01, 0x20, 0x02, 0x80, 0x02, 0x20, 0x10, /* I/O 0x220-0x280, decodes 16-bit, 32-byte alignment, 16 addresses */
+	0x31, 0x02, /* start dependent functions, sub-optimal */
+		0x22, 0xa0, 0x06, /* IRQ 5/7/9/10 */
+		0x2a, 0x0b, 0x0c, /* DMA 0/1/3, compatibility, no count by word, count by byte, is bus master, 8-bit only */
+		0x2a, 0xe0, 0x16, /* DMA 5/6/7, compatibility, count by word, no count by byte, is bus master, 16-bit only */
+		0x47, 0x01, 0x20, 0x02, 0x80, 0x02, 0x20, 0x10, /* I/O 0x220-0x280, decodes 16-bit, 32-byte alignment, 16 addresses */
+		0x47, 0x01, 0x00, 0x03, 0x30, 0x03, 0x30, 0x02, /* I/O 0x300-0x330, decodes 16-bit, 48-byte alignment, 2 addresses */
+		0x47, 0x01, 0x88, 0x03, 0x94, 0x03, 0x04, 0x04, /* I/O 0x388-0x394, decodes 16-bit, 4-byte alignment, 4 addresses */
+	0x38, /* end dependent functions */
+
+    0x15, 0x0e, 0x8c, 0x70, 0x02, 0x00, /* logical device CTL7002 */
+	0x1c, 0x41, 0xd0, 0xb0, 0x2f, /* compatible device PNPB02F */
+	0x82, 0x04, 0x00, 'G', 'a', 'm', 'e', /* ANSI identifier */
+	0x47, 0x01, 0x00, 0x02, 0x00, 0x02, 0x01, 0x08, /* I/O 0x200, decodes 16-bit, 1-byte alignment, 8 addresses */
+
+    0x16, 0x0e, 0x8c, 0x00, 0x23, 0x00, 0xa9, /* logical device CTL0023, supports vendor-specific registers 0x38/0x3A/0x3C/0x3F */
+	0x82, 0x09, 0x00, 'W', 'a', 'v', 'e', 'T', 'a', 'b', 'l', 'e', /* ANSI identifier */
+	0x31, 0x00, /* start dependent functions, preferred */
+		0x47, 0x01, 0x20, 0x06, 0x20, 0x06, 0x01, 0x04, /* I/O 0x620, decodes 16-bit, 1-byte alignment, 4 addresses */
+		0x47, 0x01, 0x20, 0x0a, 0x20, 0x0a, 0x01, 0x04, /* I/O 0xA20, decodes 16-bit, 1-byte alignment, 4 addresses */
+		0x47, 0x01, 0x20, 0x0e, 0x20, 0x0e, 0x01, 0x04, /* I/O 0xE20, decodes 16-bit, 1-byte alignment, 4 addresses */
+	0x30, /* start dependent functions, acceptable */
+		0x47, 0x01, 0x20, 0x06, 0x80, 0x06, 0x20, 0x04, /* I/O 0x620-0x680, decodes 16-bit, 32-byte alignment, 4 addresses */
+		0x47, 0x01, 0x20, 0x0a, 0x80, 0x0a, 0x20, 0x04, /* I/O 0xA20-0xA80, decodes 16-bit, 32-byte alignment, 4 addresses */
+		0x47, 0x01, 0x20, 0x0e, 0x80, 0x0e, 0x20, 0x04, /* I/O 0xE20-0xE80, decodes 16-bit, 32-byte alignment, 4 addresses */
+	0x38, /* end dependent functions */
+
+    0x79, 0x00 /* end tag, dummy checksum (filled in by isapnp_add_card) */
+};
 
 
 #ifdef ENABLE_SB_LOG
@@ -1301,6 +1376,27 @@ sb_awe32_pnp_config_changed(uint8_t ld, isapnp_device_config_t *config, void *pr
 }
 
 
+static void
+sb_awe64_gold_pnp_config_changed(uint8_t ld, isapnp_device_config_t *config, void *priv)
+{
+    sb_t *sb = (sb_t *) priv;
+
+    switch (ld) {
+	case 0: /* Audio */
+		sb_16_pnp_config_changed(0, config, sb);
+		break;
+
+	case 1: /* Game */
+		sb_16_pnp_config_changed(1, config, sb);
+		break;
+
+	case 2: /* WaveTable */
+		emu8k_change_addr(&sb->emu8k, (config->activate && (config->io[0].base != ISAPNP_IO_DISABLED)) ? config->io[0].base : 0);
+		break;
+    }
+}
+
+
 void *
 sb_1_init(const device_t *info)
 {
@@ -1753,7 +1849,7 @@ sb_awe32_init(const device_t *info)
     if (sb->opl_enabled)
 	opl3_init(&sb->opl);
 
-    sb_dsp_init(&sb->dsp, SB16 + 1, SB_SUBTYPE_DEFAULT, sb);
+    sb_dsp_init(&sb->dsp, SBAWE32, SB_SUBTYPE_DEFAULT, sb);
     sb_dsp_setaddr(&sb->dsp, addr);
     sb_dsp_setirq(&sb->dsp, device_get_config_int("irq"));
     sb_dsp_setdma8(&sb->dsp, device_get_config_int("dma"));
@@ -1803,7 +1899,7 @@ sb_awe32_pnp_init(const device_t *info)
     sb->opl_enabled = 1;
     opl3_init(&sb->opl);
 
-    sb_dsp_init(&sb->dsp, SB16 + 1, SB_SUBTYPE_DEFAULT, sb);
+    sb_dsp_init(&sb->dsp, ((info->local == 2) ? SBAWE64 : SBAWE32), SB_SUBTYPE_DEFAULT, sb);
     sb_ct1745_mixer_reset(sb);
 
     sb->mixer_enabled = 1;
@@ -1822,7 +1918,9 @@ sb_awe32_pnp_init(const device_t *info)
 
     sb->gameport = gameport_add(&gameport_pnp_device);
 
-    if (info->local == 1)
+    if (info->local == 2)
+	isapnp_add_card(sb_awe64_gold_pnp_rom, sizeof(sb_awe64_gold_pnp_rom), sb_awe64_gold_pnp_config_changed, NULL, NULL, NULL, sb);
+    else if (info->local == 1)
 	isapnp_add_card(sb_32_pnp_rom, sizeof(sb_32_pnp_rom), sb_awe32_pnp_config_changed, NULL, NULL, NULL, sb);
     else
 	isapnp_add_card(sb_awe32_pnp_rom, sizeof(sb_awe32_pnp_rom), sb_awe32_pnp_config_changed, NULL, NULL, NULL, sb);
@@ -2457,6 +2555,45 @@ static const device_config_t sb_awe32_pnp_config[] =
         }
 };
 
+static const device_config_t sb_awe64_gold_config[] =
+{
+        {
+                "onboard_ram", "Onboard RAM", CONFIG_SELECTION, "", 4096, "", { 0 },
+                {
+                        {
+                                "None", 0
+                        },
+                        {
+                                "512 KB", 512
+                        },
+                        {
+                                "2 MB", 2048
+                        },
+                        {
+                                "4 MB", 4096
+                        },
+                        {
+                                "8 MB", 8192
+                        },
+                        {
+                                "28 MB", 28*1024
+                        },
+                        {
+                                ""
+                        }
+                }
+        },
+	{
+		"receive_input", "Receive input (SB MIDI)", CONFIG_BINARY, "", 1
+	},
+	{
+		"receive_input401", "Receive input (MPU-401)", CONFIG_BINARY, "", 0
+	},
+        {
+                "", "", -1
+        }
+};
+
 const device_t sb_1_device =
 {
         "Sound Blaster v1.0",
@@ -2602,4 +2739,16 @@ const device_t sb_awe32_pnp_device =
         sb_speed_changed,
         NULL,
         sb_awe32_pnp_config
+};
+
+const device_t sb_awe64_gold_device =
+{
+        "Sound Blaster AWE64 Gold",
+        DEVICE_ISA | DEVICE_AT,
+	2,
+        sb_awe32_pnp_init, sb_awe32_close, NULL,
+        { sb_awe32_available },
+        sb_speed_changed,
+        NULL,
+        sb_awe64_gold_config
 };

--- a/src/sound/snd_sb_dsp.c
+++ b/src/sound/snd_sb_dsp.c
@@ -66,7 +66,7 @@ static int sb_commands[256]=
 
 
 char sb16_copyright[] = "COPYRIGHT (C) CREATIVE TECHNOLOGY LTD, 1992.";
-uint16_t sb_dsp_versions[] = {0, 0, 0x105, 0x200, 0x201, 0x300, 0x302, 0x405, 0x40d};
+uint16_t sb_dsp_versions[] = {0, 0, 0x105, 0x200, 0x201, 0x300, 0x302, 0x405, 0x40d, 0x410};
 
 
 /*These tables were 'borrowed' from DOSBox*/
@@ -314,7 +314,7 @@ sb_doreset(sb_dsp_t *dsp)
         sb_commands[8] =  1;
         sb_commands[9] =  1;
     } else {
-        if (dsp->sb_type==SB16)
+        if ((dsp->sb_type >= SB16) && (dsp->sb_type < SBAWE64))
 	    sb_commands[8] =  1;
         else
 	    sb_commands[8] = -1;    

--- a/src/sound/sound.c
+++ b/src/sound/sound.c
@@ -99,6 +99,7 @@ static const SOUND_CARD sound_cards[] =
     { "sb32_pnp",	&sb_32_pnp_device		},
     { "sbawe32",	&sb_awe32_device		},
     { "sbawe32_pnp",	&sb_awe32_pnp_device		},
+    { "sbawe64_gold",	&sb_awe64_gold_device		},
 #if defined(DEV_BRANCH) && defined(USE_PAS16)
     { "pas16",		&pas16_device			},
 #endif


### PR DESCRIPTION
Summary
=======
Adds the Sound Blaster AWE64 Gold sound card, as a variation of the AWE32 PnP with 4 MB of Onboard RAM and reported DSP version 4.16.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
https://sourceforge.net/p/alsa/mailman/message/9654275/ - contains ISAPnP dump of a real AWE64 Gold.
