### PR TITLE
Corrected RAM selections and combinations on Sound Blaster AWE64 Gold and Sound Blaster 32 PnP

### DIFF
--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -2342,9 +2342,6 @@ static const device_config_t sb_32_pnp_config[] =
                                 "None", 0
                         },
                         {
-                                "512 KB", 512
-                        },
-                        {
                                 "2 MB", 2048
                         },
                         {

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -2561,19 +2561,16 @@ static const device_config_t sb_awe64_gold_config[] =
                 "onboard_ram", "Onboard RAM", CONFIG_SELECTION, "", 4096, "", { 0 },
                 {
                         {
-                                "None", 0
-                        },
-                        {
-                                "512 KB", 512
-                        },
-                        {
-                                "2 MB", 2048
-                        },
-                        {
                                 "4 MB", 4096
                         },
                         {
                                 "8 MB", 8192
+                        },
+                        {
+                                "12 MB", 12288
+                        },
+                        {
+                                "16 MB", 16384
                         },
                         {
                                 "28 MB", 28*1024


### PR DESCRIPTION
Summary
=======
_I have implemented a change to the RAM selection for the Sound Blaster AWE64 Gold and Sound Blaster 32 PnP cards, which allows for the correct and actual RAM combinations on the real cards._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_https://www.vogons.org/viewtopic.php?p=988235#p988235_
