### PR TITLE
Creative Music System and early Sound Blaster improvements

### DIFF
--- a/src/include/86box/resource.h
+++ b/src/include/86box/resource.h
@@ -163,6 +163,7 @@
 #define IDC_CHECK_FLOAT		1048
 #define IDC_CONFIGURE_GUS	1049
 #define IDC_COMBO_MIDI_IN	1050
+#define IDC_CONFIGURE_CMS	1051
 
 #define IDC_COMBO_NET_TYPE	1060	/* network config */
 #define IDC_COMBO_PCAP		1061

--- a/src/include/86box/snd_cms.h
+++ b/src/include/86box/snd_cms.h
@@ -1,0 +1,35 @@
+#ifndef SOUND_SND_CMS_H
+# define SOUND_SND_CMS_H
+
+#include <stdint.h>
+#include <86box/sound.h>
+
+#define MASTER_CLOCK 7159090
+
+typedef struct cms_t
+{
+        int addrs[2];
+        uint8_t regs[2][32];
+        uint16_t latch[2][6];
+        int freq[2][6];
+        float count[2][6];
+        int vol[2][6][2];
+        int stat[2][6];
+        uint16_t noise[2][2];
+        uint16_t noisefreq[2][2];
+        int noisecount[2][2];
+        int noisetype[2][2];
+
+        uint8_t latched_data;
+
+        int16_t buffer[SOUNDBUFLEN * 2];
+
+        int pos;
+} cms_t;
+
+
+extern void cms_update(cms_t *cms);
+extern void cms_write(uint16_t addr, uint8_t val, void *p);
+extern uint8_t cms_read(uint16_t addr, void *p);
+
+#endif	/*SOUND_SND_CMS_H*/

--- a/src/include/86box/snd_sb.h
+++ b/src/include/86box/snd_sb.h
@@ -22,6 +22,7 @@
 #include <86box/snd_mpu401.h>
 #include <86box/snd_opl.h>
 #include <86box/snd_sb_dsp.h>
+#include <86box/snd_cms.h>
 
 #define SADLIB		1	/* No DSP */
 #define SB1		2	/* DSP v1.05 */
@@ -111,7 +112,8 @@ typedef struct sb_ct1745_mixer_t
 
 typedef struct sb_t
 {
-	uint8_t		opl_enabled, mixer_enabled;
+	uint8_t		cms_enabled, opl_enabled, mixer_enabled;
+        cms_t           cms;
         opl_t           opl, opl2;
         sb_dsp_t        dsp;
         union {

--- a/src/sound/snd_cms.c
+++ b/src/sound/snd_cms.c
@@ -181,7 +181,8 @@ void *cms_init(const device_t *info)
         cms_t *cms = malloc(sizeof(cms_t));
         memset(cms, 0, sizeof(cms_t));
 
-        io_sethandler(0x0220, 0x0010, cms_read, NULL, NULL, cms_write, NULL, NULL, cms);
+        uint16_t addr = device_get_config_hex16("base");
+        io_sethandler(addr, 0x0010, cms_read, NULL, NULL, cms_write, NULL, NULL, cms);
         sound_add_handler(cms_get_buffer, cms);
         return cms;
 }
@@ -193,11 +194,44 @@ void cms_close(void *p)
         free(cms);
 }
 
+static const device_config_t cms_config[] =
+{
+        {
+                "base", "Address", CONFIG_HEX16, "", 0x220, "", { 0 },
+                {
+                        {
+                                "0x210", 0x210
+                        },
+                        {
+                                "0x220", 0x220
+                        },
+                        {
+                                "0x230", 0x230
+                        },
+                        {
+                                "0x240", 0x240
+                        },
+                        {
+                                "0x250", 0x250
+                        },
+                        {
+                                "0x260", 0x260
+                        },
+                        {
+                                ""
+                        }
+                }
+        },
+        {
+                "", "", -1
+        }
+};
+
 const device_t cms_device =
 {
         "Creative Music System / Game Blaster",
         0, 0,
         cms_init, cms_close, NULL,
         { NULL }, NULL, NULL,
-        NULL
+        cms_config
 };

--- a/src/sound/snd_cms.c
+++ b/src/sound/snd_cms.c
@@ -9,31 +9,8 @@
 #include <86box/io.h>
 #include <86box/device.h>
 #include <86box/sound.h>
+#include <86box/snd_cms.h>
 
-
-#define MASTER_CLOCK 7159090
-
-
-typedef struct cms_t
-{
-        int addrs[2];
-        uint8_t regs[2][32];
-        uint16_t latch[2][6];
-        int freq[2][6];
-        float count[2][6];
-        int vol[2][6][2];
-        int stat[2][6];
-        uint16_t noise[2][2];
-        uint16_t noisefreq[2][2];
-        int noisecount[2][2];
-        int noisetype[2][2];
-       
-        uint8_t latched_data;
-
-        int16_t buffer[SOUNDBUFLEN * 2];
-
-        int pos;
-} cms_t;
 
 void cms_update(cms_t *cms)
 {

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -186,34 +186,53 @@ sb_get_buffer_sb2(int32_t *buffer, int len, void *p)
     sb_t *sb = (sb_t *) p;
     sb_ct1335_mixer_t *mixer = &sb->mixer_sb2;            
     int c;
-    double out = 0.0;
+    double out_mono = 0.0, out_l = 0.0, out_r = 0.0;
 
     if (sb->opl_enabled)
 	opl2_update(&sb->opl);
 
     sb_dsp_update(&sb->dsp);
 
-    for (c = 0; c < len * 2; c += 2) {
-	out = 0.0;
+    if (sb->cms_enabled)
+	cms_update(&sb->cms);
 
-	if (sb->opl_enabled) {
-		out = ((double) sb->opl.buffer[c]) * 0.7171630859375;
-		if (sb->mixer_enabled)
-			out *= mixer->fm;
+    for (c = 0; c < len * 2; c += 2) {
+	out_mono = 0.0;
+	out_l = 0.0;
+	out_r = 0.0;
+
+	if (sb->opl_enabled)
+		out_mono = ((double) sb->opl.buffer[c]) * 0.7171630859375;
+
+	if (sb->cms_enabled) {
+		out_l += sb->cms.buffer[c];
+		out_r += sb->cms.buffer[c + 1];
+	}
+	out_l += out_mono;
+	out_r += out_mono;
+
+	if (((sb->opl_enabled) || (sb->cms_enabled)) && sb->mixer_enabled) {
+		out_l *= mixer->fm;
+		out_r *= mixer->fm;
 	}
 
 	/* TODO: Recording: I assume it has direct mic and line in like SB2.
 		 It is unclear from the docs if it has a filter, but it probably does. */
 	/* TODO: Recording: Mic and line In with AGC. */
+	if (sb->mixer_enabled)
+		out_mono = (sb_iir(0, 0, (double) sb->dsp.buffer[c]) * mixer->voice) / 3.9;
+	else
+		out_mono = (((sb_iir(0, 0, (double) sb->dsp.buffer[c]) / 1.3) * 65536.0) / 3.0) / 65536.0;
+	out_l += out_mono;
+	out_r += out_mono;
+
 	if (sb->mixer_enabled) {
-		out += (sb_iir(0, 0, (double) sb->dsp.buffer[c]) * mixer->voice) / 3.9;
+		out_l *= mixer->master;
+		out_r *= mixer->master;
+	}
 
-		out *= mixer->master;
-	} else
-		out += (((sb_iir(0, 0, (double) sb->dsp.buffer[c]) / 1.3) * 65536.0) / 3.0) / 65536.0;
-
-	buffer[c]     += (int32_t) out;
-	buffer[c + 1] += (int32_t) out;
+	buffer[c]     += (int32_t) out_l;
+	buffer[c + 1] += (int32_t) out_r;
     }
 
     sb->pos = 0;
@@ -222,6 +241,9 @@ sb_get_buffer_sb2(int32_t *buffer, int len, void *p)
 	sb->opl.pos = 0;
 
     sb->dsp.pos = 0;
+
+    if (sb->cms_enabled)
+	sb->cms.pos = 0;
 }
 
 
@@ -1261,14 +1283,17 @@ sb_1_init(const device_t *info)
     sb_dsp_setaddr(&sb->dsp, addr);
     sb_dsp_setirq(&sb->dsp, device_get_config_int("irq"));
     sb_dsp_setdma8(&sb->dsp, device_get_config_int("dma"));
-    /* CMS I/O handler is activated on the dedicated sound_cms module
-       DSP I/O handler is activated in sb_dsp_setaddr */
+    /* DSP I/O handler is activated in sb_dsp_setaddr */
     if (sb->opl_enabled) {
 	io_sethandler(addr + 8, 0x0002, opl2_read,    NULL, NULL,
 					opl2_write,   NULL, NULL, &sb->opl);
 	io_sethandler(0x0388,   0x0002, opl2_read,    NULL, NULL,
 					opl2_write,   NULL, NULL, &sb->opl);
     }
+
+    sb->cms_enabled = 1;
+    memset(&sb->cms, 0, sizeof(cms_t));
+    io_sethandler(addr, 0x0004, cms_read, NULL, NULL, cms_write, NULL, NULL, &sb->cms);
 
     sb->mixer_enabled = 0;
     sound_add_handler(sb_get_buffer_sb2, sb);
@@ -1300,13 +1325,18 @@ sb_15_init(const device_t *info)
     sb_dsp_setaddr(&sb->dsp, addr);
     sb_dsp_setirq(&sb->dsp, device_get_config_int("irq"));
     sb_dsp_setdma8(&sb->dsp, device_get_config_int("dma"));
-    /* CMS I/O handler is activated on the dedicated sound_cms module
-       DSP I/O handler is activated in sb_dsp_setaddr */
+    /* DSP I/O handler is activated in sb_dsp_setaddr */
     if (sb->opl_enabled) {
 	io_sethandler(addr + 8, 0x0002, opl2_read,    NULL, NULL,
 					opl2_write,   NULL, NULL, &sb->opl);
 	io_sethandler(0x0388,   0x0002, opl2_read,    NULL, NULL,
 					opl2_write,   NULL, NULL, &sb->opl);
+    }
+
+    sb->cms_enabled = device_get_config_int("cms");
+    if (sb->cms_enabled) {
+	memset(&sb->cms, 0, sizeof(cms_t));
+	io_sethandler(addr, 0x0004, cms_read, NULL, NULL, cms_write, NULL, NULL, &sb->cms);
     }
 
     sb->mixer_enabled = 0;
@@ -1385,10 +1415,11 @@ sb_2_init(const device_t *info)
     sb_dsp_setdma8(&sb->dsp, device_get_config_int("dma"));
     if (mixer_addr > 0x000)
 	sb_ct1335_mixer_reset(sb);
-    /* CMS I/O handler is activated on the dedicated sound_cms module
-       DSP I/O handler is activated in sb_dsp_setaddr */
+
+    sb->cms_enabled = device_get_config_int("cms");
+    /* DSP I/O handler is activated in sb_dsp_setaddr */
     if (sb->opl_enabled) {
-	if (!GAMEBLASTER) {
+	if (!sb->cms_enabled) {
 		io_sethandler(addr,     0x0002, opl2_read,    NULL, NULL,
 						opl2_write,   NULL, NULL, &sb->opl);
 	}
@@ -1396,6 +1427,11 @@ sb_2_init(const device_t *info)
 					opl2_write,   NULL, NULL, &sb->opl);
 	io_sethandler(0x0388,   0x0002, opl2_read,    NULL, NULL,
 					opl2_write,   NULL, NULL, &sb->opl);
+    }
+
+    if (sb->cms_enabled) {
+	memset(&sb->cms, 0, sizeof(cms_t));
+	io_sethandler(addr, 0x0004, cms_read, NULL, NULL, cms_write, NULL, NULL, &sb->cms);
     }
 
     if (mixer_addr > 0x000) {
@@ -1926,6 +1962,74 @@ static const device_config_t sb_config[] =
 };
 
 
+static const device_config_t sb15_config[] =
+{
+        {
+                "base", "Address", CONFIG_HEX16, "", 0x220, "", { 0 },
+                {
+                        {
+                                "0x220", 0x220
+                        },
+                        {
+                                "0x240", 0x240
+                        },
+                        {
+                                "0x260", 0x260
+                        },
+	                {
+				""
+			}
+                }
+        },
+        {
+                "irq", "IRQ", CONFIG_SELECTION, "", 7, "", { 0 },
+                {
+                        {
+                                "IRQ 2", 2
+                        },
+                        {
+                                "IRQ 3", 3
+                        },
+                        {
+                                "IRQ 5", 5
+                        },
+                        {
+                                "IRQ 7", 7
+                        },
+                        {
+                                ""
+                        }
+                }
+        },
+        {
+                "dma", "DMA", CONFIG_SELECTION, "", 1, "", { 0 },
+                {
+                        {
+                                "DMA 1", 1
+                        },
+                        {
+                                "DMA 3", 3
+                        },
+                        {
+                                ""
+                        }
+                }
+        },
+	{
+		"opl", "Enable OPL", CONFIG_BINARY, "", 1
+	},
+	{
+		"cms", "Enable CMS", CONFIG_BINARY, "", 0
+	},
+	{
+		"receive_input", "Receive input (SB MIDI)", CONFIG_BINARY, "", 1
+	},
+        {
+                "", "", -1
+        }
+};
+
+
 static const device_config_t sb2_config[] =
 {
         {
@@ -2001,6 +2105,9 @@ static const device_config_t sb2_config[] =
         },
 	{
 		"opl", "Enable OPL", CONFIG_BINARY, "", 1
+	},
+	{
+		"cms", "Enable CMS", CONFIG_BINARY, "", 0
 	},
 	{
 		"receive_input", "Receive input (SB MIDI)", CONFIG_BINARY, "", 1
@@ -2509,7 +2616,7 @@ const device_t sb_15_device =
         sb_15_init, sb_close, NULL, { NULL },
         sb_speed_changed,
         NULL,
-        sb_config
+        sb15_config
 };
 
 const device_t sb_mcv_device =

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -2050,7 +2050,7 @@ static const device_config_t sb2_config[] =
                 }
         },
         {
-                "mixaddr", "Mixer", CONFIG_HEX16, "", 0x220, "", { 0 },
+                "mixaddr", "Mixer", CONFIG_HEX16, "", 0, "", { 0 },
                 {
                         {
                                 "Disabled", 0

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -1436,7 +1436,7 @@ sb_2_init(const device_t *info)
 
     if (mixer_addr > 0x000) {
 	sb->mixer_enabled = 1;
-	io_sethandler(addr + 4, 0x0002, sb_ct1335_mixer_read,  NULL, NULL,
+	io_sethandler(mixer_addr + 4, 0x0002, sb_ct1335_mixer_read,  NULL, NULL,
 		      sb_ct1335_mixer_write, NULL, NULL, sb);
     } else
 	sb->mixer_enabled = 0;
@@ -2060,6 +2060,9 @@ static const device_config_t sb2_config[] =
                         },
                         {
                                 "0x240", 0x240
+                        },
+                        {
+                                "0x250", 0x250
                         },
                         {
                                 "0x260", 0x260

--- a/src/win/86Box.rc
+++ b/src/win/86Box.rc
@@ -517,15 +517,17 @@ BEGIN
 
     CONTROL         "Innovation SSI-2001",IDC_CHECK_SSI,"Button",
                     BS_AUTOCHECKBOX | WS_TABSTOP,7,84,95,10
+
     CONTROL         "CMS / Game Blaster",IDC_CHECK_CMS,"Button",
-                    BS_AUTOCHECKBOX | WS_TABSTOP,147,84,95,10
+                    BS_AUTOCHECKBOX | WS_TABSTOP,7,102,95,10
+    PUSHBUTTON      "Configure",IDC_CONFIGURE_CMS,214,100,46,12
 
     CONTROL         "Gravis Ultrasound",IDC_CHECK_GUS,"Button",
-                    BS_AUTOCHECKBOX | WS_TABSTOP,7,101,94,10
-    PUSHBUTTON      "Configure",IDC_CONFIGURE_GUS,214,101,46,12
+                    BS_AUTOCHECKBOX | WS_TABSTOP,7,120,94,10
+    PUSHBUTTON      "Configure",IDC_CONFIGURE_GUS,214,118,46,12
     
     CONTROL         "Use FLOAT32 sound",IDC_CHECK_FLOAT,"Button",
-                    BS_AUTOCHECKBOX | WS_TABSTOP,7,117,94,10
+                    BS_AUTOCHECKBOX | WS_TABSTOP,7,138,94,10
 END
 
 DLG_CFG_NETWORK DIALOG DISCARDABLE  107, 0, 267, 65

--- a/src/win/win_settings.c
+++ b/src/win/win_settings.c
@@ -1376,6 +1376,7 @@ win_settings_sound_proc(HWND hdlg, UINT message, WPARAM wParam, LPARAM lParam)
 		settings_enable_window(hdlg, IDC_CHECK_MPU401, mpu401_standalone_allow());
 		settings_enable_window(hdlg, IDC_CONFIGURE_MPU401, mpu401_standalone_allow() && temp_mpu401);
 		settings_set_check(hdlg, IDC_CHECK_CMS, temp_GAMEBLASTER);
+		settings_enable_window(hdlg, IDC_CONFIGURE_CMS, temp_GAMEBLASTER);
 		settings_set_check(hdlg, IDC_CHECK_GUS, temp_GUS);
 		settings_enable_window(hdlg, IDC_CONFIGURE_GUS, temp_GUS);
 		settings_set_check(hdlg, IDC_CHECK_SSI, temp_SSI2001);
@@ -1435,6 +1436,16 @@ win_settings_sound_proc(HWND hdlg, UINT message, WPARAM wParam, LPARAM lParam)
 			case IDC_CONFIGURE_MPU401:
 				temp_deviceconfig |= deviceconfig_open(hdlg, (machines[temp_machine].flags & MACHINE_MCA) ?
 								       (void *)&mpu401_mca_device : (void *)&mpu401_device);
+				break;
+
+			case IDC_CHECK_CMS:
+				temp_GAMEBLASTER = settings_get_check(hdlg, IDC_CHECK_CMS);
+
+				settings_enable_window(hdlg, IDC_CONFIGURE_CMS, temp_GAMEBLASTER);
+				break;
+
+			case IDC_CONFIGURE_CMS:
+				temp_deviceconfig |= deviceconfig_open(hdlg, &cms_device);
 				break;
 
 			case IDC_CHECK_GUS:


### PR DESCRIPTION
Summary
=======
This pull request adds some improvements regarding the Creative Music System and early Sound Blaster emulation:
- C/MS chips as part of the Sound Blaster 1.0, 1.5 and 2.0 are now emulated; always enabled on 1.0, optional (disabled by default) on 1.5 and 2.0;
- Adds an option to select the standalone C/MS / Game Blaster's base I/O address (since the real card had a jumper block to select one) in the range from 210h to 260h.

It also implements several changes concerning the CT1335 mixer chip of the Sound Blaster 2.0 CD Interface card:
- The mixer is now disabled by default;
- The mixer no longer erroneously uses the SB's base address instead of the one selected in the device configuration;
- 0x250 is added as an option for its base address.

Related: https://github.com/86Box/86Box/issues/1476#issuecomment-855304418

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
https://nerdlypleasures.blogspot.com/2012/10/all-you-ever-wanted-to-know-about.html - information on the C/MS
[Creative Sound Blaster Hardware Programming Guide](https://pdos.csail.mit.edu/6.828/2018/readings/hardware/SoundBlaster.pdf) - information on the CT1335 mixer