### PR TITLE
Fixed display start address on S3 pre-ViRGE and ViRGE cards upon reca…

### DIFF
--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -2423,6 +2423,8 @@ s3_out(uint16_t addr, uint8_t val, void *p)
 				if ((svga->crtcreg == 0xc) || (svga->crtcreg == 0xd)) {
                                 	svga->fullchange = 3;
 					svga->ma_latch = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
+						if ((((svga->crtc[0x67] & 0xc) != 0xc) && (s3->chip >= S3_TRIO64V)) || (s3->chip < S3_TRIO64V))
+							svga->ma_latch |= (s3->ma_ext << 16);
 				} else {
 					svga->fullchange = changeframecount;
 	                                svga_recalctimings(svga);

--- a/src/video/vid_s3_virge.c
+++ b/src/video/vid_s3_virge.c
@@ -586,6 +586,8 @@ static void s3_virge_out(uint16_t addr, uint8_t val, void *p)
 				if ((svga->crtcreg == 0xc) || (svga->crtcreg == 0xd)) {
                                 	svga->fullchange = 3;
 					svga->ma_latch = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
+						if ((svga->crtc[0x67] & 0xc) != 0xc)
+							svga->ma_latch |= (virge->ma_ext << 16);
 				} else {
 					svga->fullchange = changeframecount;
 	                                svga_recalctimings(svga);


### PR DESCRIPTION
…lculation of its timings plus when the banking register is enabled, this also fixes the flickering of Quake while having Commander Keen working without glitches.

Summary
=======
A fix for Quake while keeping Commander Keen working glitch-less.

Checklist
=========
* [x] Closes #1585
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
