### PR TITLE
Update plat.h to ensure 86Box compatibility under macOS

### DIFF
--- a/src/include/86box/plat.h
+++ b/src/include/86box/plat.h
@@ -32,7 +32,7 @@
 # define strcasecmp	_stricmp
 #endif
 
-#if defined(UNIX) && defined(FREEBSD)
+#if defined(UNIX) && defined(FREEBSD) && defined(__APPLE__)
 /* FreeBSD has largefile by default. */
 # define fopen64        fopen
 # define fseeko64       fseeko

--- a/src/include/86box/plat.h
+++ b/src/include/86box/plat.h
@@ -32,7 +32,7 @@
 # define strcasecmp	_stricmp
 #endif
 
-#if defined(UNIX) && defined(FREEBSD) && defined(__APPLE__)
+#if defined(UNIX) && defined(FREEBSD) || defined(__APPLE__)
 /* FreeBSD has largefile by default. */
 # define fopen64        fopen
 # define fseeko64       fseeko


### PR DESCRIPTION
Summary
=======
Extends the changes defined for FreeBSD considering fopen64, fseeko64, ftello64 and off64_t towards macOS. This should ensure a clean compile on macOS and make the pull request https://github.com/86Box/86Box/pull/1626 compatible not just with Linux but also with macOS, so that 86Box can start running on the most used UNIX-based operating systems.

Checklist
=========
* [ ] Closes https://github.com/86Box/86Box/issues/136 (partially, mostly for ensuring compatibility with macOS)
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
Implementation of the suggestion by dhrdlicka https://github.com/86Box/86Box/pull/1626#issuecomment-903285900.
