### PR TITLE
Add support for overridable VM name

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -564,15 +564,12 @@ usage:
 	 * At this point usr_path is perfectly initialized.
 	 * If no --vmname parameter specified we'll use the
 	 *   working directory name as the VM's name.
-	 * The directory name will stored in local buffer 
-	 *   named `path` since it's unused in further parts 
-	 *   of this function.
 	 */
     if (strlen(vm_name) == 0)
 	{
-		plat_get_dirname(path, usr_path);
-		p = plat_get_filename(path);
-		strcpy(vm_name, p);
+		char ltemp[1024] = {'/0'};
+		plat_get_dirname(ltemp, usr_path);
+		strcpy(vm_name, plat_get_filename(ltemp));
 	}
 
 	/*

--- a/src/86box.c
+++ b/src/86box.c
@@ -110,6 +110,7 @@ uint64_t	unique_id = 0;
 uint64_t	source_hwnd = 0;
 #endif
 char	log_path[1024] = { '\0'};		/* (O) full path of logfile */
+char	vm_name[1024]  = { '\0'};		/* (O) display name of the VM */
 
 /* Configuration values. */
 int	window_w;   /* (C) window size and */
@@ -417,6 +418,7 @@ usage:
 			printf("-F or --fullscreen   - start in fullscreen mode\n");
 			printf("-L or --logfile path - set 'path' to be the logfile\n");
 			printf("-P or --vmpath path  - set 'path' to be root for vm\n");
+			printf("-V or --vmname name  - overrides the name of the running VM.\n");
 			printf("-S or --settings     - show only the settings dialog\n");
 			printf("-N or --noconfirm    - do not ask for confirmation on quit\n");
 #ifdef _WIN32
@@ -446,6 +448,11 @@ usage:
 			if ((c+1) == argc) goto usage;
 
 			strcpy(path, argv[++c]);
+		} else if (!strcasecmp(argv[c], "--vmname") ||
+			   !strcasecmp(argv[c], "-V")) {
+			if ((c+1) == argc) goto usage;
+
+			strcpy(vm_name, argv[++c]);
 		} else if (!strcasecmp(argv[c], "--settings") ||
 			   !strcasecmp(argv[c], "-S")) {
 			settings_only = 1;
@@ -550,6 +557,20 @@ usage:
 
 	/* At this point, we can safely create the full path name. */
 	plat_append_filename(cfg_path, usr_path, p);
+
+	/*
+     * Get the current directory's name
+	 *
+	 * At this point usr_path is perfectly initialized.
+	 * If no --vmname parameter specified we'll use the
+	 *   working directory name as the VM's name.
+	 */
+    if (strlen(vm_name) == 0)
+	{
+		plat_get_dirname(vm_name, usr_path);
+		p = plat_get_filename(vm_name);
+		strcpy(vm_name, p);
+	}
 
 	/*
 	 * This is where we start outputting to the log file,

--- a/src/86box.c
+++ b/src/86box.c
@@ -564,11 +564,14 @@ usage:
 	 * At this point usr_path is perfectly initialized.
 	 * If no --vmname parameter specified we'll use the
 	 *   working directory name as the VM's name.
+	 * The directory name will stored in local buffer 
+	 *   named `path` since it's unused in further parts 
+	 *   of this function.
 	 */
     if (strlen(vm_name) == 0)
 	{
-		plat_get_dirname(vm_name, usr_path);
-		p = plat_get_filename(vm_name);
+		plat_get_dirname(path, usr_path);
+		p = plat_get_filename(path);
 		strcpy(vm_name, p);
 	}
 

--- a/src/86box.c
+++ b/src/86box.c
@@ -567,7 +567,7 @@ usage:
 	 */
     if (strlen(vm_name) == 0)
 	{
-		char ltemp[1024] = {'/0'};
+		char ltemp[1024] = { '\0'};
 		plat_get_dirname(ltemp, usr_path);
 		strcpy(vm_name, plat_get_filename(ltemp));
 	}

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -73,6 +73,7 @@ extern uint64_t	unique_id;
 extern uint64_t	source_hwnd;
 #endif
 extern char	log_path[1024];			/* (O) full path of logfile */
+extern char	vm_name[1024];			/* (O) display name of the VM */
 
 
 extern int	window_w, window_h,		/* (C) window size and */

--- a/src/win/win_discord.c
+++ b/src/win/win_discord.c
@@ -68,7 +68,7 @@ void
 discord_update_activity(int paused)
 {
     struct DiscordActivity activity;
-    char config_name[1024], cpufamily[1024];
+    char cpufamily[1024];
     char *paren;
 
     if(discord_activities == NULL)
@@ -78,16 +78,14 @@ discord_update_activity(int paused)
 
     memset(&activity, 0x00, sizeof(activity));
 
-    plat_get_dirname(config_name, usr_path);
-
     strncpy(cpufamily, cpu_f->name, sizeof(cpufamily) - 1);
     paren = strchr(cpufamily, '(');
     if (paren)
 	*(paren - 1) = '\0';
 
-    if (strlen(plat_get_filename(config_name)) < 100)
+    if (strlen(vm_name) < 100)
     {
-	sprintf_s(activity.details, sizeof(activity.details), "Running \"%s\"", plat_get_filename(config_name));
+	sprintf_s(activity.details, sizeof(activity.details), "Running \"%s\"", vm_name);
 	sprintf_s(activity.state, sizeof(activity.state), "%s (%s/%s)", strchr(machine_getname(), ']') + 2, cpufamily, cpu_s->name);
     }
     else


### PR DESCRIPTION
- A global variable added as `vm_name` in `86box.h`
- This variable can be filled with the `--vmname "Name"` or `-V "Name"` parameter, or if there are no such a parameter definied this variable will filled up with the VM's directory name.
- The Discord module displays this global variable, as VM name.
- Various 86Box managers can use this feature to display internal fancy VM names, instead of the GUID folder names.
- This variable can be easily used later for adding cool things, like the VM name in title bar, etc.

Summary
=======
With this features the GUID-based managers for 86Box, can display the VM's internal display names in the Discord module. This PR also helps future changes in UI, such as adding VM name in the title bar, etc..

This feature can be integrated to WinBox-for-86Box, and to the upcoming 86Box Manager v2.0.

**Usage:**

    86Box.exe --vmpath "D:\VMs\{30410B36-0F6A-454F-8846-77834F7B44DB}" --vmname "Árvíztűrő tükörfúrógép"

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/