### PR TITLE
Add a filter for CD de-emphasis

### DIFF
--- a/src/include/86box/filters.h
+++ b/src/include/86box/filters.h
@@ -299,6 +299,37 @@ static inline double high_cut_iir(int c, int i, double NewSample) {
     return y[c][i][0];
 }
 
+/* fc=5.283kHz, gain=-9.477dB, width=0.4845 */
+static inline double deemph_iir(int i, double NewSample) {
+    double ACoef[NCoef+1] = {
+        0.46035077886318842566,
+        -0.28440821191249848754,
+        0.03388877229118691936
+    };
+
+    double BCoef[NCoef+1] = {
+        1.00000000000000000000,
+        -1.05429146278569141337,
+        0.26412280202756849290
+    };
+    static double y[2][NCoef+1]; /* output samples */
+    static double x[2][NCoef+1]; /* input samples */
+    int n;
+
+    /* shift the old samples */
+    for(n=NCoef; n>0; n--) {
+       x[i][n] = x[i][n-1];
+       y[i][n] = y[i][n-1];
+    }
+
+    /* Calculate the new output */
+    x[i][0] = NewSample;
+    y[i][0] = ACoef[0] * x[i][0];
+    for(n=1; n<=NCoef; n++)
+        y[i][0] += ACoef[n] * x[i][n] - BCoef[n] * y[i][n];
+
+    return y[i][0];
+}
 
 #undef NCoef
 #define NCoef 2


### PR DESCRIPTION
Summary
=======
This adds an IIR high-shelf filter to perform CD audio de-emphasis, with static coefficients pre-calculated using the algorithm as implemented by the [SoX](https://sourceforge.net/projects/sox/) audio processing tool.

**Important:** this only implements the filter itself and does not integrate it to actually perform the de-emphasis (yet).

Related issue: #1623

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[SoX's source file containing the algorithm used to calculate the coefficients](https://sourceforge.net/p/sox/code/ci/master/tree/src/biquads.c)
