### PR TITLE
Fix T128 timer initialization on reads for faster cpu's.

### DIFF
--- a/src/scsi/scsi_ncr5380.c
+++ b/src/scsi/scsi_ncr5380.c
@@ -692,7 +692,7 @@ ncr_write(uint16_t port, uint8_t val, void *priv)
 
 			ncr_dev->t128.host_pos = MIN(512, dev->buffer_length);
 			ncr_dev->t128.status |= 0x04;
-			timer_on_auto(&ncr_dev->timer, 0.2);
+			timer_on_auto(&ncr_dev->timer, 0.02);
 		} else {
 			if ((ncr->mode & MODE_DMA) && !timer_is_enabled(&ncr_dev->timer)) {
 				memset(ncr_dev->buffer, 0, MIN(128, dev->buffer_length));


### PR DESCRIPTION
Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
