### PR TITLE
Default to "build" binary directory for presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -19,7 +19,8 @@
                 "CMAKE_C_FLAGS_OPTIMIZED": "-march=native -mtune=native -O3 -ffp-contract=last -flto",
                 "CMAKE_CXX_FLAGS_OPTIMIZED": "-march=native -mtune=native -O3 -ffp-contract=last -flto"
             },
-            "hidden": true
+            "hidden": true,
+            "binaryDir": "build"
         },
         {
             "name": "regular",


### PR DESCRIPTION
Summary
=======
This PR makes the presets default to "build" for binaryDir.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
