### PR TITLE
Fix W^X crashes on Apple Silicon

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -26,6 +26,9 @@
 #include <string.h>
 #include <time.h>
 #include <wchar.h>
+#if defined(__APPLE__) && defined(__aarch64__)
+#include <pthread.h>
+#endif
 
 #define HAVE_STDARG_H
 #include <86box/86box.h>
@@ -780,7 +783,13 @@ pc_init_modules(void)
 	mem_init();
 
 #ifdef USE_DYNAREC
+#if defined(__APPLE__) && defined(__aarch64__)
+	pthread_jit_write_protect_np(0);
+#endif
 	codegen_init();
+#if defined(__APPLE__) && defined(__aarch64__)
+	pthread_jit_write_protect_np(1);
+#endif
 #endif
 
 	keyboard_init();


### PR DESCRIPTION
Summary
=======
This PR should hopefully fix the crash when launching 86Box on Apple Silicon Macs.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
