### PR TITLE
Fix CPU prefetch so that it's disabled on 486 and higher when cache is on, just like the comment near it says

### DIFF
--- a/src/cpu/386_dynarec.c
+++ b/src/cpu/386_dynarec.c
@@ -179,6 +179,7 @@ static __inline void fetch_ea_16_long(uint32_t rmdat)
 
 #include "x86_flags.h"
 
+#define CACHE_ON() (!(cr0 & (1 << 30)) && !(cpu_state.flags & T_FLAG))
 
 /*Prefetch emulation is a fairly simplistic model:
   - All instruction bytes must be fetched before it starts.
@@ -194,6 +195,7 @@ static int prefetch_prefixes = 0;
 
 static void prefetch_run(int instr_cycles, int bytes, int modrm, int reads, int reads_l, int writes, int writes_l, int ea32)
 {
+	if(is486 && CACHE_ON()) return;
 	int mem_cycles = reads*cpu_cycles_read + reads_l*cpu_cycles_read_l + writes*cpu_cycles_write + writes_l*cpu_cycles_write_l;
 
 	if (instr_cycles < mem_cycles)
@@ -271,9 +273,6 @@ static void prefetch_flush()
 #define CLOCK_CYCLES_ALWAYS(c) cycles -= (c)
 
 #include "386_ops.h"
-
-
-#define CACHE_ON() (!(cr0 & (1 << 30)) && !(cpu_state.flags & T_FLAG))
 
 #ifdef USE_DYNAREC
 int cycles_main = 0;


### PR DESCRIPTION
Summary
=======
This change simply brings actual behavior regarding CPU prefetch in line with intended behavior.

Checklist
=========
* [ ] I have discussed this with core contributors already
