### PR TITLE
My dword/byte mode fix doesn't apply to the Trio64V+ and up (Trio64V2…

### DIFF
--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -2886,11 +2886,6 @@ static void s3_trio64v_recalctimings(svga_t *svga)
 		
 		svga->lowres = !((svga->gdcreg[5] & 0x40) && (svga->crtc[0x3a] & 0x10));
 		if ((svga->gdcreg[5] & 0x40) && (svga->crtc[0x3a] & 0x10)) {
-			if (svga->crtc[0x31] & 0x08) /*This would typically force dword mode, but we are encountering accel bugs with it, so force byte mode instead*/
-				svga->force_byte_mode = 1;
-			else
-				svga->force_byte_mode = 0;
-
 			switch (svga->bpp) {
 				case 8:
 				svga->render = svga_render_8bpp_highres;


### PR DESCRIPTION
…/DX).

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [x] Closes #1669
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
