### PR TITLE
Redirect fopen64 functions to fopen for non-Linux Unix systems

### DIFF
--- a/src/include/86box/plat.h
+++ b/src/include/86box/plat.h
@@ -36,7 +36,7 @@ extern int stricmp(const char* s1, const char* s2);
 extern int strnicmp(const char* s1, const char* s2, size_t n);
 #endif
 
-#if defined(UNIX) && defined(FREEBSD) || defined(__APPLE__)
+#if (defined(__unix__) || defined(__APPLE__)) && !defined(__linux__)
 /* FreeBSD has largefile by default. */
 # define fopen64        fopen
 # define fseeko64       fseeko


### PR DESCRIPTION
Summary
=======
This PR redirects fopen64 to fopen for all non-Linux Unix systems instead of just macOS.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
