### PR TITLE
Fix NULL access crashes on ALSA MIDI close

### DIFF
--- a/src/unix/linux_midi_alsa.c
+++ b/src/unix/linux_midi_alsa.c
@@ -298,14 +298,17 @@ void plat_midi_input_init(void)
 
 void plat_midi_input_close(void)
 {
-	thread_wait_mutex(midiinmtx);
+	if (midiinmtx) thread_wait_mutex(midiinmtx);
 	if (midiin != NULL)
 	{
 		snd_rawmidi_close(midiin);
 		midiin = NULL;
 	}
-	thread_release_mutex(midiinmtx);
-	thread_close_mutex(midiinmtx);
+	if (midiinmtx)
+	{
+		thread_release_mutex(midiinmtx);
+		thread_close_mutex(midiinmtx);
+	}
 	midiinmtx = NULL;
 }
 


### PR DESCRIPTION
Summary
=======
This PR fixes NULL access crashes on ALSA MIDI close

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
