### PR TITLE
unix.c: Add help command to monitor

### DIFF
--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -158,7 +158,8 @@ static const uint16_t sdl_to_xt[0x200] =
 
     [SDL_SCANCODE_LGUI] = 0x15B,
     [SDL_SCANCODE_RGUI] = 0x15C,
-    [SDL_SCANCODE_APPLICATION] = 0x15D
+    [SDL_SCANCODE_APPLICATION] = 0x15D,
+    [SDL_SCANCODE_PRINTSCREEN] = 0x137
 };
 
 typedef struct sdl_blit_params
@@ -759,8 +760,26 @@ void monitor_thread(void* param)
                     xargv[cmdargc++] = local_strsep(&linecpy, " ");
                     if (xargv[cmdargc - 1] == NULL || cmdargc >= 512) break;
                 }
-		cmdargc--;
-                if (strncasecmp(xargv[0], "exit", 4) == 0)
+                cmdargc--;
+                if (strncasecmp(xargv[0], "help", 4) == 0)
+                {
+                    printf(
+                        "fddload <id> <filename> <wp> - Load floppy disk image into drive <id>.\n"
+                        "cdload <id> <filename> - Load CD-ROM image into drive <id>.\n"
+                        "zipload <id> <filename> <wp> - Load ZIP image into ZIP drive <id>.\n"
+                        "cartload <id> <filename> <wp> - Load cartridge image into cartridge drive <id>.\n"
+                        "moload <id> <filename> <wp> - Load MO image into MO drive <id>.\n\n"
+                        "fddeject <id> - eject disk from floppy drive <id>.\n"
+                        "cdeject <id> - eject disc from CD-ROM drive <id>.\n"
+                        "zipeject <id> - eject ZIP image from ZIP drive <id>.\n"
+                        "carteject <id> - eject cartridge from drive <id>.\n"
+                        "moeject <id> - eject image from MO drive <id>.\n\n"
+                        "hardreset - hard reset the emulated system.\n"
+                        "pause - pause the the emulated system.\n"
+                        "fullscreen - toggle fullscreen.\n"
+                        "exit - exit 86Box.\n");
+                }
+                else if (strncasecmp(xargv[0], "exit", 4) == 0)
                 {
                     exit_event = 1;
                 }


### PR DESCRIPTION
Summary
=======
This PR adds the help command to monitor interface and also adds missing PrintScreen key mapping.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
