### PR TITLE
Include SDL.h before anything else

### DIFF
--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -2,10 +2,7 @@
 #define _FILE_OFFSET_BITS 64
 #define _LARGEFILE64_SOURCE 1
 #endif
-#define _POSIX_C_SOURCE 200809L
-#ifdef __APPLE__
-#define _DARWIN_C_SOURCE 1
-#endif
+#include <SDL.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -20,7 +17,7 @@
 #include <inttypes.h>
 #include <dlfcn.h>
 #include <wchar.h>
-#include <SDL.h>
+
 #include <86box/86box.h>
 #include <86box/keyboard.h>
 #include <86box/mouse.h>


### PR DESCRIPTION
Summary
=======
This PR makes unix.c include SDL.h before anything else. This also cleans up the unnecessary source-level defines.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
