### PR TITLE
Corrected typo in Ensoniq AudioPCI emulation

### DIFF
--- a/src/sound/snd_audiopci.c
+++ b/src/sound/snd_audiopci.c
@@ -251,7 +251,7 @@ es1371_reset(void *p)
        Addressable as byte, word, longword */
     dev->mem_page = 0x00;
 
-    /* Sample Rate Concerter Interface Register, Address 10H
+    /* Sample Rate Converter Interface Register, Address 10H
        Addressable as longword only */
     dev->sr_cir = 0x00000000;
 
@@ -682,7 +682,7 @@ es1371_inl(uint16_t port, void *p)
 		ret = dev->mem_page;
 		break;
 
-	/* Sample Rate Concerter Interface Register, Address 10H
+	/* Sample Rate Converter Interface Register, Address 10H
 	   Addressable as longword only */
 	case 0x10:
 		ret = dev->sr_cir & ~0xffff;
@@ -959,7 +959,7 @@ es1371_outl(uint16_t port, uint32_t val, void *p)
 		dev->mem_page = val & 0xf;
 		break;
 
-	/* Sample Rate Concerter Interface Register, Address 10H
+	/* Sample Rate Converter Interface Register, Address 10H
 	   Addressable as longword only */
 	case 0x10:
 		dev->sr_cir = val;


### PR DESCRIPTION
Summary
=======
I have corrected a minor typo in the Ensoniq AudioPCI emulation.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
ES1371 datasheet - https://datasheetspdf.com/pdf-file/555592/ETC/ES1371/1
