### PR TITLE
Improvements for 486-VIP-IO2

### DIFF
--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -1105,6 +1105,9 @@ machine_at_486vipio2_init(const machine_t *model)
     device_add(&keyboard_ps2_ami_pci_device);
     device_add(&sst_flash_29ee010_device);
 
+    if (fdc_type == FDC_INTERNAL)
+    device_add(&fdc_at_device);
+
     return ret;
 }
 

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -242,7 +242,7 @@ const machine_t machines[] = {
     { "[UMC 8881] A-Trend ATC-1415",		"atc1415",		MACHINE_TYPE_486_S3,		CPU_PKG_SOCKET3, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PCI | MACHINE_IDE_DUAL,							 1024,  65536, 1024, 255,	      machine_at_atc1415_init, NULL			},
     { "[UMC 8881] ECS Elite UM8810PAIO",	"ecs486",		MACHINE_TYPE_486_S3,		CPU_PKG_SOCKET3, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PCI | MACHINE_IDE_DUAL,							 1024, 131072, 1024, 255,	       machine_at_ecs486_init, NULL			},
     { "[UMC 8881] Shuttle HOT-433A",		"hot433",		MACHINE_TYPE_486_S3,		CPU_PKG_SOCKET3, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PCI | MACHINE_IDE_DUAL,							 1024, 262144, 1024, 255,	       machine_at_hot433_init, NULL			},
-    { "[VIA VT82C496G] FIC VIP-IO2",		"486vipio2",		MACHINE_TYPE_486_S3,		CPU_PKG_SOCKET3, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PCIV | MACHINE_IDE_DUAL,						 1024, 131072, 1024, 255,	    machine_at_486vipio2_init, NULL			},
+    { "[VIA VT82C496G] FIC VIP-IO2",		"486vipio2",		MACHINE_TYPE_486_S3,		CPU_PKG_SOCKET3, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PCIV | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,				 1024, 131072, 1024, 255,	    machine_at_486vipio2_init, NULL			},
 
     /* 486 machines - Miscellaneous */
     /* 486 machines with just the ISA slot */


### PR DESCRIPTION
Summary
=======
The FIC 486-VIP-IO2 has an onboard PS/2 Keyboard and Mouse, along with a FDC,
This PR adds support for setting the FDC correctly when using FDC_INTERNAL, and enables PS2 mouse support
on this board

Checklist
=========
* [N] Closes #xxx
* [N] I have discussed this with core contributors already
* [N] This pull request requires changes to the ROM set
  * [N] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
http://cwcyrix.duckdns.org/ftp-archives/ftp.fic.com.tw/motherboard/manual/486/486-vip-io2/Layout.zip