### PR TITLE
S3 changes part 8:

### DIFF
--- a/src/video/vid_att20c49x_ramdac.c
+++ b/src/video/vid_att20c49x_ramdac.c
@@ -50,7 +50,7 @@ att49x_ramdac_control(uint8_t val, void *p, svga_t *svga)
 {
 	att49x_ramdac_t *ramdac = (att49x_ramdac_t *) p;
 	ramdac->ctrl = val;
-	switch (ramdac->ctrl >> 4) {
+	switch ((ramdac->ctrl >> 5) & 7) {
 		case 0:
 		case 1:
 		case 2:
@@ -62,11 +62,9 @@ att49x_ramdac_control(uint8_t val, void *p, svga_t *svga)
 		svga->bpp = 15;
 		break;
 		case 6:
-		case 0xc:
 		svga->bpp = 16;
 		break;
 		case 7:
-		case 0xe:
 		svga->bpp = 24;
 		break;
 	}

--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -385,7 +385,8 @@ static uint32_t s3_accel_in_l(uint16_t port, void *p);
 static uint8_t	s3_pci_read(int func, int addr, void *p);
 static void	s3_pci_write(int func, int addr, uint8_t val, void *p);
 
-/*Remap address for chain-4/doubleword style layout*/
+/*Remap address for chain-4/doubleword style layout.
+  These will stay for convenience.*/
 static __inline uint32_t
 dword_remap(svga_t *svga, uint32_t in_addr)
 {
@@ -516,8 +517,8 @@ static void
 s3_accel_out_pixtrans_w(s3_t *s3, uint16_t val)
 {
 	svga_t *svga = &s3->svga;
-
-	if (s3->accel.cmd & 0x100) {
+	
+	if (s3_cpu_src(s3)) {
 		switch (s3->accel.cmd & 0x600) {
 			case 0x000:
 				if (((s3->accel.multifunc[0xa] & 0xc0) == 0x80) || (s3->accel.cmd & 2)) {
@@ -583,7 +584,7 @@ s3_accel_out_pixtrans_w(s3_t *s3, uint16_t val)
 static void
 s3_accel_out_pixtrans_l(s3_t *s3, uint32_t val)
 {
-	if (s3->accel.cmd & 0x100) {
+	if (s3_cpu_src(s3)) {
 		switch (s3->accel.cmd & 0x600) {
 			case 0x000:
 				if (((s3->accel.multifunc[0xa] & 0xc0) == 0x80) || (s3->accel.cmd & 2)) {
@@ -1276,7 +1277,7 @@ static void
 s3_accel_out_fifo_w(s3_t *s3, uint16_t port, uint16_t val)
 {
 	if (port != 0x9ee8 && port != 0x9d48) {
-		if (port == 0xb2e8) {
+		if (port == 0xb2e8 || port == 0xb148) {
 			s3->accel.b2e8_pix = 1;
 		} else {
 			s3->accel.b2e8_pix = 0;
@@ -1305,7 +1306,7 @@ s3_accel_out_fifo_w(s3_t *s3, uint16_t port, uint16_t val)
 static void
 s3_accel_out_fifo_l(s3_t *s3, uint16_t port, uint32_t val)
 {
-	if (port == 0xb2e8) {
+	if (port == 0xb2e8 || port == 0xb148) {
 		s3->accel.b2e8_pix = 1;
 	} else {
 		s3->accel.b2e8_pix = 0;
@@ -1422,15 +1423,7 @@ s3_accel_write_fifo(s3_t *s3, uint32_t addr, uint8_t val)
 
     if (svga->crtc[0x53] & 0x08) {
 	if ((addr & 0x1ffff) < 0x8000) {
-		if (s3->accel.cmd & 0x100) {
-			if (((s3->accel.multifunc[0xa] & 0xc0) == 0x80) || (s3->accel.cmd & 2)) {
-				if (((s3->accel.frgd_mix & 0x60) != 0x40) || ((s3->accel.bkgd_mix & 0x60) != 0x40))
-					s3_accel_start(8, 1, val | (val << 8) | (val << 16) | (val << 24), 0, s3);
-				else
-					s3_accel_start(1, 1, 0xffffffff, val | (val << 8) | (val << 16) | (val << 24), s3);
-			} else
-				s3_accel_start(1, 1, 0xffffffff, val | (val << 8) | (val << 16) | (val << 24), s3);
-		}
+		s3_accel_out_fifo(s3, 0xe2e8 + (addr & 3), val);
 	} else {
 		switch (addr & 0x1ffff) {
 			case 0x83b0: case 0x83b1: case 0x83b2: case 0x83b3:
@@ -1472,25 +1465,7 @@ s3_accel_write_fifo(s3_t *s3, uint32_t addr, uint8_t val)
 	if (addr & 0x8000) {
 		s3_accel_out_fifo(s3, addr & 0xffff, val);
 	} else {
-		if (s3->accel.cmd & 0x100) {
-			if ((s3->accel.cmd & 0x600) == 0x200) {
-				if (((s3->accel.multifunc[0xa] & 0xc0) == 0x80) || (s3->accel.cmd & 2)) {
-					if (((s3->accel.frgd_mix & 0x60) != 0x40) || ((s3->accel.bkgd_mix & 0x60) != 0x40))
-						s3_accel_start(16, 1, val | (val << 8) | (val << 16) | (val << 24), 0, s3);
-					else
-						s3_accel_start(2, 1, 0xffffffff, val | (val << 8) | (val << 16) | (val << 24), s3);
-				} else
-					s3_accel_start(2, 1, 0xffffffff, val | (val << 8) | (val << 16) | (val << 24), s3);
-			} else {
-				if (((s3->accel.multifunc[0xa] & 0xc0) == 0x80) || (s3->accel.cmd & 2)) {
-					if (((s3->accel.frgd_mix & 0x60) != 0x40) || ((s3->accel.bkgd_mix & 0x60) != 0x40))
-						s3_accel_start(8, 1, val | (val << 8) | (val << 16) | (val << 24), 0, s3);
-					else
-						s3_accel_start(1, 1, 0xffffffff, val | (val << 8) | (val << 16) | (val << 24), s3);
-				} else
-					s3_accel_start(1, 1, 0xffffffff, val | (val << 8) | (val << 16) | (val << 24), s3);
-			}
-		}
+		s3_accel_out_fifo(s3, 0xe2e8 + (addr & 3), val);
 	}    
     }
 }
@@ -2383,10 +2358,13 @@ s3_out(uint16_t addr, uint8_t val, void *p)
 		}
 		if (svga->seqaddr == 4) /*Chain-4 - update banking*/
 		{
-			if (val & 8)
-				svga->write_bank = svga->read_bank = s3->bank << 16;
-			else
-				svga->write_bank = svga->read_bank = s3->bank << 14;
+			svga->chain4 = !!(val & 8);
+			if (svga->crtc[0x31] & 1) {
+				if (svga->chain4)
+					svga->write_bank = svga->read_bank = s3->bank << 16;
+				else
+					svga->write_bank = svga->read_bank = s3->bank << 14;
+			}
 		} else if (svga->seqaddr == 9) {
 			svga->seqregs[svga->seqaddr] = val & 0x80;
 			s3_io_set(s3);
@@ -2428,9 +2406,9 @@ s3_out(uint16_t addr, uint8_t val, void *p)
 			tvp3026_ramdac_out(addr, rs2, rs3, val, svga->ramdac, svga);
 		} else if (((s3->chip == S3_86C801) || (s3->chip == S3_86C805)) && (s3->card_type != S3_MIROCRYSTAL10SD_805 && s3->card_type != S3_MIROCRYSTAL8S_805))
 			att49x_ramdac_out(addr, rs2, val, svga->ramdac, svga);
-		else if (s3->chip <= S3_86C924)
-			sc1148x_ramdac_out(addr, 0, val, svga->ramdac, svga);
-		else
+		else if (s3->chip <= S3_86C924) {
+			sc1148x_ramdac_out(addr, rs2, val, svga->ramdac, svga);
+		} else
 			sdac_ramdac_out(addr, rs2, val, svga->ramdac, svga);
 		return;
 
@@ -2459,8 +2437,6 @@ s3_out(uint16_t addr, uint8_t val, void *p)
 		{
 			case 0x31:
 			s3->ma_ext = (s3->ma_ext & 0x1c) | ((val & 0x30) >> 4);
-			if (!svga->packed_chain4)
-				svga->force_dword_mode = val & 0x08;
 			break;
 			case 0x32:
 			if ((svga->crtc[0x31] & 0x30) && (svga->crtc[0x51] & 0x01) && (val & 0x40))
@@ -2508,11 +2484,14 @@ s3_out(uint16_t addr, uint8_t val, void *p)
 
 			case 0x35:
 			s3->bank = (s3->bank & 0x70) | (val & 0xf);
-			if (svga->chain4)
-				svga->write_bank = svga->read_bank = s3->bank << 16;
-			else
-				svga->write_bank = svga->read_bank = s3->bank << 14;
+			if (svga->crtc[0x31] & 1) {
+				if (svga->chain4)
+					svga->write_bank = svga->read_bank = s3->bank << 16;
+				else
+					svga->write_bank = svga->read_bank = s3->bank << 14;
+			}
 			break;
+
 			case 0x51:
 			if (s3->chip == S3_86C801 || s3->chip == S3_86C805) {
 				s3->bank = (s3->bank & 0x6f) | ((val & 0x4) << 2);
@@ -2521,19 +2500,23 @@ s3_out(uint16_t addr, uint8_t val, void *p)
 				s3->bank = (s3->bank & 0x4f) | ((val & 0xc) << 2);
 				s3->ma_ext = (s3->ma_ext & ~0xc) | ((val & 3) << 2);
 			}
-			if (svga->chain4)
-				svga->write_bank = svga->read_bank = s3->bank << 16;
-			else
-				svga->write_bank = svga->read_bank = s3->bank << 14;
+			if (svga->crtc[0x31] & 1) {
+				if (svga->chain4)
+					svga->write_bank = svga->read_bank = s3->bank << 16;
+				else
+					svga->write_bank = svga->read_bank = s3->bank << 14;
+			}
 			break;
 
 			case 0x6a:
 			if (s3->chip >= S3_VISION964) {
 				s3->bank = val;
-				if (svga->chain4)
-					svga->write_bank = svga->read_bank = s3->bank << 16;
-				else
-					svga->write_bank = svga->read_bank = s3->bank << 14;
+				if (svga->crtc[0x31] & 1) {
+					if (svga->chain4)
+						svga->write_bank = svga->read_bank = s3->bank << 16;
+					else
+						svga->write_bank = svga->read_bank = s3->bank << 14;
+				}
 			}
 			break;
 
@@ -2714,7 +2697,7 @@ s3_in(uint16_t addr, void *p)
 		} else if (((s3->chip == S3_86C801) || (s3->chip == S3_86C805)) && (s3->card_type != S3_MIROCRYSTAL10SD_805 && s3->card_type != S3_MIROCRYSTAL8S_805))
 			return att49x_ramdac_in(addr, rs2, svga->ramdac, svga);
 		else if (s3->chip <= S3_86C924)
-			return sc1148x_ramdac_in(addr, 0, svga->ramdac, svga);
+			return sc1148x_ramdac_in(addr, rs2, svga->ramdac, svga);
 		else
 			return sdac_ramdac_in(addr, rs2, svga->ramdac, svga);
 		break;
@@ -2781,11 +2764,11 @@ static void s3_recalctimings(svga_t *svga)
 
 	if (!svga->scrblank && svga->attr_palette_enable) {
 		if ((svga->gdcreg[6] & 1) || (svga->attrregs[0x10] & 1)) {
-			if (svga->crtc[0x3a] & 0x10) /*256+ color register*/
+			if (svga->crtc[0x3a] & 0x10) { /*256+ color register*/
 				svga->gdcreg[5] |= 0x40;
+			}
 		}
 	}
-
 	svga->ma_latch |= (s3->ma_ext << 16);
 	if (s3->chip >= S3_86C928) {
 		svga->hdisp = svga->hdisp_old;
@@ -2834,7 +2817,7 @@ static void s3_recalctimings(svga_t *svga)
 	if (s3->card_type == S3_MIROCRYSTAL10SD_805 || s3->card_type == S3_MIROCRYSTAL20SD_864 ||
 		s3->card_type == S3_MIROCRYSTAL20SV_964 || s3->card_type == S3_SPEA_MIRAGE_86C801 ||
 		s3->card_type == S3_SPEA_MIRAGE_86C805 || s3->card_type == S3_MIROCRYSTAL8S_805) {
-		if (svga->bpp != 32) {	
+		if (svga->bpp != 32) {
 			if (svga->crtc[0x31] & 2) /*This is needed if the pixel width gets set with delays*/
 				s3->width = 2048;
 		}
@@ -2844,8 +2827,12 @@ static void s3_recalctimings(svga_t *svga)
 				s3->width = 1024;
 		}
 	}
+	
+	if ((svga->crtc[0x43] & 0x08) && (s3->bpp == 0))
+		s3->width = 1024;
 
 	if ((svga->gdcreg[5] & 0x40) && (svga->crtc[0x3a] & 0x10)) {
+		svga->fb_only = 1;
 		switch (svga->bpp) {
 			case 8:
 			svga->render = svga_render_8bpp_highres;
@@ -2867,7 +2854,7 @@ static void s3_recalctimings(svga_t *svga)
 					if (svga->hdisp != 1408)
 						svga->hdisp = s3->width;
 					if (s3->card_type == S3_MIROCRYSTAL20SD_864) {
-						if (s3->width == 2048) {
+						if (s3->width == 2048 || s3->width == 1600 || s3->width == 800) {
 							switch (svga->dispend) {
 								case 400:
 								case 480:
@@ -2879,6 +2866,8 @@ static void s3_recalctimings(svga_t *svga)
 								break;
 								
 								case 600:
+								if (s3->width == 1600)
+									s3->width = 800;
 								svga->hdisp = 800;
 								break;
 								
@@ -2906,8 +2895,6 @@ static void s3_recalctimings(svga_t *svga)
 			break;
 			case 15:
 			svga->render = svga_render_15bpp_highres;
-			if (s3->chip <= S3_86C924)
-				svga->rowoffset >>= 1;
 			if ((s3->chip != S3_VISION964) && (s3->card_type != S3_SPEA_MIRAGE_86C801) && 
 				(s3->card_type != S3_SPEA_MIRAGE_86C805)) {
 				if (s3->chip == S3_86C928)
@@ -2933,8 +2920,6 @@ static void s3_recalctimings(svga_t *svga)
 			break;
 			case 16:
 			svga->render = svga_render_16bpp_highres;
-			if (s3->chip <= S3_86C924)
-				svga->rowoffset >>= 1;
 			if ((s3->chip != S3_VISION964) && (s3->card_type != S3_SPEA_MIRAGE_86C801) && 
 				(s3->card_type != S3_SPEA_MIRAGE_86C805)) {
 				if (s3->chip == S3_86C928)
@@ -2974,7 +2959,7 @@ static void s3_recalctimings(svga_t *svga)
 			}
 			break;
 			case 32:
-			svga->render = svga_render_32bpp_highres; 
+			svga->render = svga_render_32bpp_highres;
 			if ((s3->chip < S3_TRIO32) && (s3->chip != S3_VISION964) &&
 			    (s3->chip != S3_VISION968) && (s3->chip != S3_86C928)) {
 				if (s3->chip == S3_VISION868)
@@ -2989,7 +2974,7 @@ static void s3_recalctimings(svga_t *svga)
 				s3->card_type == S3_SPEA_MERCURY_P64V) {
 				svga->hdisp = s3->width;
 				if (s3->card_type == S3_MIROCRYSTAL20SD_864 || s3->card_type == S3_MIROCRYSTAL20SV_964) {
-					if ((svga->crtc[0x31] & 2) && (svga->crtc[0x50] & 0xc1) != 0x00) {
+					if (s3->width == 800 || s3->width == 1024 || s3->width == 1600) {
 						switch (svga->dispend) {
 							case 400:
 							case 480:
@@ -2997,22 +2982,53 @@ static void s3_recalctimings(svga_t *svga)
 							break;
 							
 							case 576:
+							if (s3->width == 1600)
+								s3->width = 800;
 							svga->hdisp = 768;
 							break;
 							
 							case 600:
+							if (s3->width == 1600)
+								s3->width = 800;	
 							svga->hdisp = 800;
 							break;
-						}
+						}						
 					}
 				}
 			}
 			break;
 		}
 	} else {
-		if (svga->gdcreg[5] & 0x40) {
-			if (!svga->lowres)
-				svga->rowoffset <<= 1;
+		svga->fb_only = 0;
+		if (!svga->scrblank && svga->attr_palette_enable) {
+			if (!(svga->gdcreg[6] & 1) && !(svga->attrregs[0x10] & 1)) { /*Text mode*/
+				if (svga->seqregs[1] & 8) /*40 column*/ {
+					svga->render = svga_render_text_40;
+				} else {
+					svga->render = svga_render_text_80;
+				}
+			} else {
+				if ((svga->crtc[0x31] & 0x08) && ((svga->gdcreg[5] & 0x60) == 0x00)) {
+					svga->render = svga_render_8bpp_highres; /*Enhanced 4bpp mode, just like the 8bpp mode per spec.*/
+					if (svga->hdisp <= 1024)
+						s3->width = 1024;
+				} else {
+					switch (svga->gdcreg[5] & 0x60) {
+						case 0x00: 
+							if (svga->seqregs[1] & 8) /*Low res (320)*/
+								svga->render = svga_render_4bpp_lowres;
+							else
+								svga->render = svga_render_4bpp_highres;
+							break;
+						case 0x20:		/*4 colours*/
+							if (svga->seqregs[1] & 8) /*Low res (320)*/
+								svga->render = svga_render_2bpp_lowres;
+							else
+								svga->render = svga_render_2bpp_highres;
+							break;
+					}
+				}
+			}
 		}
 	}
 }
@@ -3028,9 +3044,7 @@ static void s3_trio64v_recalctimings(svga_t *svga)
 				svga->gdcreg[5] |= 0x40;
 		}
 	}
-
 	svga->hdisp = svga->hdisp_old;
-
 	if (svga->crtc[0x5d] & 0x01) svga->htotal     |= 0x100;
 	if (svga->crtc[0x5d] & 0x02) {
 		svga->hdisp_time |= 0x100;
@@ -3207,24 +3221,24 @@ s3_updatemapping(s3_t *s3)
 			s3->linear_base &= ~(s3->linear_size - 1);
 			if (s3->linear_base == 0xa0000) {
 				mem_mapping_disable(&s3->linear_mapping);
-				if (!(svga->crtc[0x53] & 0x10))
-				{
-					mem_mapping_set_addr(&svga->mapping, 0xa0000, 0x10000);
+				if (!(svga->crtc[0x53] & 0x10)) {
+					mem_mapping_set_addr(&svga->mapping, s3->linear_base, 0x10000);
 					svga->banked_mask = 0xffff;
 				}
 			} else {
 				if (s3->chip >= S3_TRIO64V) {
 					s3->linear_base &= 0xfc000000;
-					svga->fb_only = 1;
 				} else if (s3->chip == S3_VISION968 || s3->chip == S3_VISION868) {
 					s3->linear_base &= 0xfe000000;
-					svga->fb_only = 1;
 				}
+				
 				mem_mapping_set_addr(&s3->linear_mapping, s3->linear_base, s3->linear_size);
 			}
-		} else {		
+			if (s3->chip >= S3_TRIO64V)
+				svga->fb_only = 1;
+		} else {
 			mem_mapping_disable(&s3->linear_mapping);
-			if (s3->chip >= S3_TRIO64V || s3->chip == S3_VISION968 || s3->chip == S3_VISION868)
+			if (s3->chip >= S3_TRIO64V)
 				svga->fb_only = 0;
 		}
 
@@ -3236,8 +3250,9 @@ s3_updatemapping(s3_t *s3)
 					mem_mapping_set_addr(&s3->mmio_mapping, 0xb8000, 0x8000);
 				else
 					mem_mapping_set_addr(&s3->mmio_mapping, 0xa0000, 0x10000);
-			} else
+			} else {
 				mem_mapping_enable(&s3->mmio_mapping);
+			}
 		} else
 			mem_mapping_disable(&s3->mmio_mapping);
 
@@ -3271,15 +3286,12 @@ s3_accel_out(uint16_t port, uint8_t val, void *p)
 	s3_t *s3 = (s3_t *)p;
 	svga_t *svga = &s3->svga;
 
+	if (!s3->enable_8514)
+		return;
+
 	if (port >= 0x8000)
-	{
-		if (!s3->enable_8514)
-			return;
-	
 		s3_accel_out_fifo(s3, port, val);
-	}
-	else
-	{
+	else {
 		switch (port)
 		{
 			case 0x4148: case 0x42e8:
@@ -3927,28 +3939,7 @@ s3_accel_read(uint32_t addr, void *p)
 	if (addr & 0x8000) {
 	    temp = s3_accel_in(addr & 0xffff, p);
 	} else if (s3_cpu_dest(s3)) {
-		READ_PIXTRANS_BYTE_MM
-
-		switch (s3->accel.cmd & 0x600) {
-			case 0x000:
-				if (((s3->accel.multifunc[0xa] & 0xc0) == 0x80) || (s3->accel.cmd & 2)) {
-					if (((s3->accel.frgd_mix & 0x60) != 0x40) || ((s3->accel.bkgd_mix & 0x60) != 0x40))
-						s3_accel_start(8, 1, temp | (temp << 8) | (temp << 16) | (temp << 24), 0, s3);
-					else
-						s3_accel_start(1, 1, 0xffffffff, temp | (temp << 8) | (temp << 16) | (temp << 24), s3);
-				} else
-					s3_accel_start(1, 1, 0xffffffff, temp | (temp << 8) | (temp << 16) | (temp << 24), s3);
-				break;
-			case 0x200:
-				if (((s3->accel.multifunc[0xa] & 0xc0) == 0x80) || (s3->accel.cmd & 2)) {
-					if (((s3->accel.frgd_mix & 0x60) != 0x40) || ((s3->accel.bkgd_mix & 0x60) != 0x40))
-						s3_accel_start(16, 1, temp | (temp << 8) | (temp << 16) | (temp << 24), 0, s3);
-					else
-						s3_accel_start(2, 1, 0xffffffff, temp | (temp << 8) | (temp << 16) | (temp << 24), s3);
-				} else
-					s3_accel_start(2, 1, 0xffffffff, temp | (temp << 8) | (temp << 16) | (temp << 24), s3);
-				break;
-		}
+		temp = s3_accel_in(0xe2e8 + (addr & 3), p);
 	}
     }
 
@@ -4223,8 +4214,8 @@ polygon_setup(s3_t *s3)
 	}
 }
 
-#define READ(addr, dat) if (s3->bpp == 0)      dat = svga->vram[dword_remap(svga, addr) & s3->vram_mask]; \
-			    else if (s3->bpp == 1) dat = vram_w[dword_remap_w(svga, addr) & (s3->vram_mask >> 1)]; \
+#define READ(addr, dat) if (s3->bpp == 0 && !(svga->crtc[0x43] & 0x08))      dat = svga->vram[dword_remap(svga, addr) & s3->vram_mask]; \
+			    else if (s3->bpp == 1 || (svga->crtc[0x43] & 0x08)) dat = vram_w[dword_remap_w(svga, addr) & (s3->vram_mask >> 1)]; \
 				else if (s3->bpp == 2) dat = svga->vram[dword_remap(svga, addr) & s3->vram_mask]; \
 				else dat = vram_l[dword_remap_l(svga, addr) & (s3->vram_mask >> 2)];
 
@@ -4529,12 +4520,12 @@ polygon_setup(s3_t *s3)
 		 }
 
 
-#define WRITE(addr, dat)     if (s3->bpp == 0)									       \
+#define WRITE(addr, dat)     if (s3->bpp == 0 && !(svga->crtc[0x43] & 0x08))									       \
 			{											       \
 				svga->vram[dword_remap(svga, addr) & s3->vram_mask] = dat;					  \
 				svga->changedvram[(dword_remap(svga, addr) & s3->vram_mask) >> 12] = changeframecount;		   \
 			}											       \
-			else if (s3->bpp == 1)									  \
+			else if (s3->bpp == 1 || (svga->crtc[0x43] & 0x08))									  \
 			{											       \
 				vram_w[dword_remap_w(svga, addr) & (s3->vram_mask >> 1)] = dat;				       \
 				svga->changedvram[(dword_remap_w(svga, addr) & (s3->vram_mask >> 1)) >> 11] = changeframecount;	    \
@@ -5040,13 +5031,6 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, s3_
 	uint32_t rd_mask = s3->accel.rd_mask;
 	int cmd = s3->accel.cmd >> 13;
 	uint32_t srcbase, dstbase;
-
-	if (s3->chip <= S3_86C805) { /*Chicago 4.00.58s' s3 driver has a weird bug, not sure on real hardware*/
-		if (s3->bpp == 0 && svga->bpp == 15 && s3->width == 2048) {
-			s3->bpp = 1;
-			s3->width >>= 1;
-		}
-	}
 	
 	if ((s3->chip >= S3_TRIO64 || s3->chip == S3_VISION968 || s3->chip == S3_VISION868) && (s3->accel.cmd & (1 << 11))) {
 		cmd |= 8;
@@ -5063,7 +5047,7 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, s3_
         } else {
             dstbase = 0x100000 * ((s3->accel.multifunc[0xe] >> 0) & 3);
         }
-        if (s3->bpp == 1) {
+        if (s3->bpp == 1 || (svga->crtc[0x43] & 0x08)) {
             srcbase >>= 1;
             dstbase >>= 1;
 		} else if (s3->bpp == 3) {
@@ -5077,8 +5061,8 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, s3_
 
 	if (!cpu_input)
 		s3->accel.dat_count = 0;
-	
-	if (cpu_input && (((s3->accel.multifunc[0xa] & 0xc0) != 0x80) || (!(s3->accel.cmd & 2)))) {
+
+	if (cpu_input && (count <= 4)) {
 		if ((s3->bpp == 3) && count == 2) {
 			if (s3->accel.dat_count) {
 				cpu_dat = ((cpu_dat & 0xffff) << 16) | s3->accel.dat_buf;
@@ -5089,19 +5073,19 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, s3_
 				s3->accel.dat_count = 1;
 			}
 		}
-		if (s3->bpp == 1)
+		if (s3->bpp == 1 || (svga->crtc[0x43] & 0x08))
 			count >>= 1;
 		if (s3->bpp == 3)
 			count >>= 2;
 	}
 
-	if (s3->bpp == 0)
+	if (s3->bpp == 0 && !(svga->crtc[0x43] & 0x08))
 		rd_mask &= 0xff;
-	else if (s3->bpp == 1)
+	else if (s3->bpp == 1 || (svga->crtc[0x43] & 0x08))
 		rd_mask &= 0xffff;
 
-	if (s3->bpp == 0) compare &= 0xff;
-	if (s3->bpp == 1) compare &= 0xffff;
+	if (s3->bpp == 0 && !(svga->crtc[0x43] & 0x08)) compare &= 0xff;
+	if (s3->bpp == 1 || (svga->crtc[0x43] & 0x08)) compare &= 0xffff;
 
 	switch (s3->accel.cmd & 0x600)
 	{
@@ -5154,7 +5138,7 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, s3_
 
 				mix_dat <<= 1;
 				mix_dat |= 1;
-				if (s3->bpp == 0) cpu_dat >>= 8;
+				if (s3->bpp == 0 && !(svga->crtc[0x43] & 0x08)) cpu_dat >>= 8;
 				else	      cpu_dat >>= 16;
 				if (!s3->accel.ssv_len)
 					break;
@@ -5229,7 +5213,7 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, s3_
 
 				mix_dat <<= 1;
 				mix_dat |= 1;
-				if (s3->bpp == 0) cpu_dat >>= 8;
+				if (s3->bpp == 0 && !(svga->crtc[0x43] & 0x08)) cpu_dat >>= 8;
 				else	      cpu_dat >>= 16;
 				if (!s3->accel.sy) {
 					break;
@@ -5254,7 +5238,7 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, s3_
 		}
 		else /*Bresenham*/
 		{
-			if (s3->accel.b2e8_pix && count == 16) { /*Stupid undocumented 0xB2E8 on 911/924*/
+			if (s3->accel.b2e8_pix && s3_cpu_src(s3) && count == 16) { /*Stupid undocumented 0xB2E8 on 911/924*/
 				count = s3->accel.maj_axis_pcnt + 1;
 				s3->accel.temp_cnt = 16;
 			}
@@ -5301,7 +5285,7 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, s3_
 					mix_dat <<= 1;
 					mix_dat |= 1;
 				}
-				if (s3->bpp == 0) cpu_dat >>= 8;
+				if (s3->bpp == 0 && !(svga->crtc[0x43] & 0x08)) cpu_dat >>= 8;
 				else	     cpu_dat >>= 16;
 
 				if (!s3->accel.sy) {
@@ -5446,7 +5430,7 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, s3_
 				mix_dat |= 1;
 			}
 			
-			if (s3->bpp == 0)
+			if (s3->bpp == 0 && !(svga->crtc[0x43] & 0x08))
 				cpu_dat >>= 8;
 			else
 				cpu_dat >>= 16;
@@ -5474,6 +5458,10 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, s3_
 				s3->accel.sy--;
 
 				if (cpu_input) {
+					if (s3->accel.b2e8_pix) {
+						s3->accel.cur_x = s3->accel.cx;
+						s3->accel.cur_y = s3->accel.cy;						
+					}
 					return;
 				}
 				if (s3->accel.sy < 0) {
@@ -5620,7 +5608,6 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, s3_
 		frgd_mix = (s3->accel.frgd_mix >> 5) & 3;
 		bkgd_mix = (s3->accel.bkgd_mix >> 5) & 3;
 
-
 		if (!cpu_input && frgd_mix == 3 && !vram_mask && !compare_mode &&
 		    (s3->accel.cmd & 0xa0) == 0xa0 && (s3->accel.frgd_mix & 0xf) == 7 &&
 			(s3->accel.bkgd_mix & 0xf) == 7)
@@ -5705,7 +5692,7 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, s3_
 				mix_dat <<= 1;
 				mix_dat |= 1;
 
-				if (s3->bpp == 0) cpu_dat >>= 8;
+				if (s3->bpp == 0 && !(svga->crtc[0x43] & 0x08)) cpu_dat >>= 8;
 				else	     cpu_dat >>= 16;
 
 				if (s3->accel.cmd & 0x20)
@@ -6833,7 +6820,6 @@ static void *s3_init(const device_t *info)
 			s3->id_ext_pci = 0;
 			s3->packed_mmio = 0;
 			svga->crtc[0x5a] = 0x0a;
-
 			svga->ramdac = device_add(&bt485_ramdac_device);
 			svga->clock_gen = device_add(&icd2061_device);
 			svga->getclock = icd2061_getclock;
@@ -6843,14 +6829,14 @@ static void *s3_init(const device_t *info)
 		case S3_PHOENIX_VISION864:
 		case S3_MIROCRYSTAL20SD_864:
 			svga->decode_mask = (8 << 20) - 1;
-			if (info->local == S3_PARADISE_BAHAMAS64)
+			if (info->local == S3_PARADISE_BAHAMAS64 || info->local == S3_MIROCRYSTAL20SD_864)
 				stepping = 0xc0; /*Vision864*/
 			else
 				stepping = 0xc1; /*Vision864P*/
 			s3->id = stepping;
 			s3->id_ext = s3->id_ext_pci = stepping;
 			s3->packed_mmio = 0;
-			
+			svga->crtc[0x5a] = 0x0a;
 			svga->ramdac = device_add(&sdac_ramdac_device);
 			svga->clock_gen = svga->ramdac;
 			svga->getclock = sdac_getclock;
@@ -6965,7 +6951,7 @@ static void *s3_init(const device_t *info)
 
 		case S3_TRIO64V2_DX:
 			svga->decode_mask = (4 << 20) - 1;
-			s3->id = 0xe1; /*Trio64V2/DX*/
+			s3->id = 0xe1; /*Trio64V2*/
 			s3->id_ext = s3->id_ext_pci = 0x01;
 			s3->packed_mmio = 1;
 			svga->crtc[0x53] = 0x08;
@@ -6986,9 +6972,8 @@ static void *s3_init(const device_t *info)
 		default:
 			return NULL;
 	}
-
-	if (s3->chip >= S3_TRIO64V || s3->chip == S3_VISION868 || s3->chip == S3_VISION968)
-		svga->packed_chain4 = 1;
+	
+	svga->packed_chain4 = 1;
 
 	if (s3->pci)
 		s3->card = pci_add_card(PCI_ADD_VIDEO, s3_pci_read, s3_pci_write, s3);

--- a/src/video/vid_s3_virge.c
+++ b/src/video/vid_s3_virge.c
@@ -3976,7 +3976,7 @@ static void *s3_virge_init(const device_t *info)
 
 	memset(virge->dmabuffer, 0, 65536);
 
-    virge->card = pci_add_card(PCI_ADD_VIDEO, s3_virge_pci_read, s3_virge_pci_write, virge);
+    virge->card = pci_add_card((info->flags & DEVICE_AGP) ? PCI_ADD_AGP : PCI_ADD_VIDEO, s3_virge_pci_read, s3_virge_pci_write, virge);
 
 	virge->i2c = i2c_gpio_init("ddc_s3_virge");
 	virge->ddc = ddc_init(i2c_gpio_get_bus(virge->i2c));


### PR DESCRIPTION
Properly fixed text/graphics mode of the S3 pre-ViRGE cards.
PIX TRANS cleanups.
Added a sanity check to banking, per bit 0 of CRTC31.
Initial implementation of Enhanced 4-bit mode.
911/924 chips use CRTC43 bit 3 for enabling 15/16bpp mode.
fb_only variable used correctly as of now (depending if on 4bit or 8bit+ modes).

S3 ViRGE changes part 2:
Made the Trio3D/2X AGP use the PCI_ADD_AGP part accordingly

RAMDAC changes:
Sierra 11483 and 11487 don't have an RS2 signal so the four times reading scheme of 0x3c6 is used instead, per documentation.
Fixed AT&T 49x bpp selection.

Other changes:
Fixed remaining rendering issues with the Radius SVGA HT209 card.

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [x] Closes #1739
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
