### PR TITLE
Fixes for library search on macOS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,6 +63,11 @@ if(MINGW)
 	set(CMAKE_FIND_LIBRARY_SUFFIXES ".a" ".dll.a")
 endif()
 
+if(APPLE)
+	# Force using the newest library if it's installed by homebrew
+	set(CMAKE_FIND_FRAMEWORK LAST)
+endif()
+
 find_package(Freetype REQUIRED)
 include_directories(${FREETYPE_INCLUDE_DIRS})
 


### PR DESCRIPTION
Summary
=======
This change makes CMake search for the newest installed library to avoid conflicts for headers if libraries are installed via homebrew and by another frameworks.
It also fixes the screenshot function on macOS if the user installed libpng via homebrew. Previously it would link to older library versions of libpng if those were installed via other frameworks, while at runtime it decided to run the version installed by homebrew and thus creating a conflict while using the library. The newest CMakeLists.txt changes search for the newest version of the library by invoking the changes mentioned in the PR and really only on macOS.
This means CMake properly detects it via `-- Found PNG: /usr/local/lib/libpng.dylib (found version "1.6.37")` instead previously detecting it falsely as e.g. `-- Found PNG: /usr/local/lib/libpng.dylib (found version "1.4.12") `.
Here's also the proof for successful screenshots (needed the PR for the UI rewrite to access the screenshot function):
![1210907-101912-958](https://user-images.githubusercontent.com/2078457/136346989-e2f07c8e-157a-4d25-807f-086e3f8a573b.png)
![1210907-101937-970](https://user-images.githubusercontent.com/2078457/136347007-39e354c7-63cc-4899-a9d9-6e960b62e053.png)

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://developer.blender.org/rBbb872b25f219d1a9bc2446228b6dc7a9248d7f20 (used the commands inside the `macro(without_system_libs_end)` macro while ommiting `unset(CMAKE_IGNORE_PATH)` and other not needed stuff for 86Box)
