### PR TITLE
Added correct IRQs and port ranges for standalone ISA MPU-401 as per...

### DIFF
--- a/src/sound/snd_mpu401.c
+++ b/src/sound/snd_mpu401.c
@@ -1806,10 +1806,31 @@ static const device_config_t mpu401_standalone_config[] =
                 "base", "MPU-401 Address", CONFIG_HEX16, "", 0x330, "", { 0 },
                 {
                         {
+                                "0x220", 0x220
+                        },
+                        {
+                                "0x230", 0x230
+                        },
+                        {
+                                "0x240", 0x240
+                        },
+                        {
+                                "0x250", 0x250
+                        },
+                        {
                                 "0x300", 0x300
                         },
                         {
+                                "0x320", 0x320
+                        },
+                        {
                                 "0x330", 0x330
+                        },
+                        {
+                                "0x340", 0x340
+                        },
+                        {
+                                "0x350", 0x350
                         },
                         {
                                 ""
@@ -1817,10 +1838,10 @@ static const device_config_t mpu401_standalone_config[] =
                 }
         },
         {
-                "irq", "MPU-401 IRQ", CONFIG_SELECTION, "", 9, "", { 0 },
+                "irq", "MPU-401 IRQ", CONFIG_SELECTION, "", 2, "", { 0 },
                 {
                         {
-                                "IRQ 9", 9
+                                "IRQ 2", 2
                         },
                         {
                                 "IRQ 3", 3
@@ -1832,10 +1853,10 @@ static const device_config_t mpu401_standalone_config[] =
                                 "IRQ 5", 5
                         },
                         {
-                                "IRQ 7", 7
+                                "IRQ 6", 6
                         },
                         {
-                                "IRQ 10", 10
+                                "IRQ 7", 7
                         },
                         {
                                 ""


### PR DESCRIPTION
…Roland documentation

Summary
=======
I have added the correct IRQs and port ranges for the standalone ISA MPU-401 based on Roland documentation for the port ranges and IRQs for the Roland MPU-IPC-T.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
Roland MPU-IPC-T MIDI Processing Unit Manual:

https://archive.org/details/rolandmpuipctmidiprocessingunitmanual/

Setting up MPU-401 and Compatible Cards on your PC:

https://oemdrivers.com/sites/default/files/2019-10/Roland-MPU-MIDI-Interface-Setup-Guide.pdf

Installing MPU-401 Compatible Cards in Windows 95:

http://cdn.roland.com/assets/media/pdf/MPU401_Win95.pdf
