### PR TITLE
Fix character casing in the managers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ System requirements and recommendations
 Performance may vary depending on both host and guest configuration. Most emulation logic is executed in a single thread, therefore generally systems with better IPC (instructions per clock) should be able to emulate higher clock speeds.
 
 It is also recommended to use a manager application with 86Box for easier handling of multiple virtual machines.
-* [Winbox for 86Box](https://github.com/laciba96/WinBox-for-86Box) by [Laci bá'](https://github.com/laciba96)
+* [WinBox for 86Box](https://github.com/laciba96/WinBox-for-86Box) by [Laci bá'](https://github.com/laciba96)
   * The new manager with improved new user experience; installer, automatic updates of emulator files and more.
 * [86Box Manager](https://github.com/86Box/86BoxManager) by [daviunic](https://github.com/daviunic) (Overdoze)
   * The traditional 86Box manager with simple interface.


### PR DESCRIPTION
Summary
=======
In WinBox for 86Box I wrote the B in the Box word with uppercase in the program everywhere, so I want to apply the same casing in README.md, as in the project itself, and at the project page.

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
N/A
