### PR TITLE
MIDI changes:

### DIFF
--- a/src/sound/snd_audiopci.c
+++ b/src/sound/snd_audiopci.c
@@ -1703,24 +1703,17 @@ es1371_poll(void *p)
 		   But if anything sets MIDI Input and Output together we'd have to take account
 		   of the MIDI Output case, and disable IRQ's and RX bits when MIDI Input is
 		   enabled as well but not in the MIDI Output portion */
-		if (dev->uart_ctrl & UART_CTRL_TXINTEN) 
-			dev->int_status |= INT_STATUS_UART;
-		else
-			dev->int_status &= ~INT_STATUS_UART;
+		dev->int_status &= ~INT_STATUS_UART;
+		dev->uart_status |= (UART_STATUS_TXINT | UART_STATUS_TXRDY);
 	} else if (!(dev->uart_ctrl & UART_CTRL_RXINTEN) && ((dev->uart_ctrl & UART_CTRL_TXINTEN))) {
 		/* Or enable the UART IRQ and the respective TX bits only when the MIDI Output is
 		   enabled */
 		dev->int_status |= INT_STATUS_UART;
+	} else {
+		dev->uart_status |= (UART_STATUS_TXINT | UART_STATUS_TXRDY);
 	}
 
-	if (dev->uart_ctrl & UART_CTRL_RXINTEN) {
-		if (dev->uart_ctrl & UART_CTRL_TXINTEN) 
-			dev->uart_status |= (UART_STATUS_TXINT | UART_STATUS_TXRDY);
-		else
-			dev->uart_status &= ~(UART_STATUS_TXINT | UART_STATUS_TXRDY);
-	} else
-		dev->uart_status |= (UART_STATUS_TXINT | UART_STATUS_TXRDY);
-
+	audiopci_log("UART control = %02x\n", dev->uart_ctrl & (UART_CTRL_RXINTEN | UART_CTRL_TXINTEN));
 	es1371_update_irqs(dev);
     }
 

--- a/src/sound/snd_opl.c
+++ b/src/sound/snd_opl.c
@@ -108,12 +108,10 @@ timer_control(opl_t *dev, int tmr, int start)
 		timer_on_auto(&dev->timers[tmr], (tmr == 1) ? 320.0 : 80.0);
     } else {
 		opl_log("Timer %i stopped\n", tmr);
-		if (!(dev->flags & FLAG_OPL3)) {
-			if (tmr == 1) {
-				dev->status &= ~STAT_TMR2_OVER;
-			} else
-				dev->status &= ~STAT_TMR1_OVER;
-		}
+		if (tmr == 1) {
+			dev->status &= ~STAT_TMR2_OVER;
+		} else
+			dev->status &= ~STAT_TMR1_OVER;
 	}
 }
 


### PR DESCRIPTION
Fixed MIDI UART OUT of the ES1371 using NT 4.0's drivers and keeping compatibility with Win9x/2000.
Fixed OPL3 timer status for some games and programs.

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
