### PR TITLE
Video changes (ET4000W32/i):

### DIFF
--- a/src/video/vid_paradise.c
+++ b/src/video/vid_paradise.c
@@ -231,7 +231,7 @@ uint8_t paradise_in(uint16_t addr, void *p)
 
                 case 0x3cf:
                 if (svga->gdcaddr >= 9 && svga->gdcaddr <= 0x0e) {
-					if ((paradise->pr5 & 7) != 5)
+					if (paradise->pr5 & 0x10)
 						return 0xff;
                 }
 				switch (svga->gdcaddr) {
@@ -354,8 +354,11 @@ void paradise_recalctimings(svga_t *svga)
 	}
 	
 	if (paradise->type < WD90C30) {
-		if (svga->bpp >= 8 && !svga->lowres)
+		if (svga->bpp >= 8 && !svga->lowres) {
+			if ((svga->crtc[0x17] == 0xc2) && (svga->crtc[0x14] & 0x40))
+				paradise->check = 1;
 			svga->render = svga_render_8bpp_highres;
+		}
 	} else {
 		if (svga->bpp >= 8 && !svga->lowres) {
 			if (svga->bpp == 16) {


### PR DESCRIPTION
Bit 1 is of 0x3DA (read only) is apparently required to make the OS/2 Tseng ET4000W32/i drivers work fine, fixes hangs upon reaching the GUI with said drivers.
Avoid division by zero in the blitter of the ET4000W32/i under OS/2.

Video changes (PVGA):
Fixes mode changes of the PVGA1a, including the built-in video card of the Amstrad 2086/3086.

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [x] Closes #1740 
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
