### PR TITLE
Removes timespec_get() from Unix systems

### DIFF
--- a/src/unix/unix_thread.c
+++ b/src/unix/unix_thread.c
@@ -101,11 +101,7 @@ thread_wait_event(event_t *handle, int timeout)
     event_pthread_t *event = (event_pthread_t *)handle;
     struct timespec abstime;
 
-#ifdef HAS_TIMESPEC_GET
-    timespec_get(&abstime, TIME_UTC);
-#else
     clock_gettime(CLOCK_REALTIME, &abstime);
-#endif
     abstime.tv_nsec += (timeout % 1000) * 1000000;
     abstime.tv_sec += (timeout / 1000);
     if (abstime.tv_nsec > 1000000000) {


### PR DESCRIPTION

Summary
=======
This change removes `timespec_get()` from Unix systems inside `unix_threads.c` and makes it also possible to cross-compile binaries on macOS Big Sur (v11) or macOS Monterrey (v12) that target macOS Mojave (v10.14) at minimum since Mojave lacks support for `timespec_get()` as long as the required libraries are working on that OS.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://stackoverflow.com/a/5167506 (for proving that `clock_gettime()` is also available on macOS Sierra and higher)
