### PR TITLE
Fix startup crash on macOS when loading floppy images

### DIFF
--- a/src/floppy/fdd.c
+++ b/src/floppy/fdd.c
@@ -497,7 +497,7 @@ fdd_load(int drive, char *fn)
 	while (loaders[c].ext) {
 		if (!strcasecmp(p, (char *) loaders[c].ext) && (size == loaders[c].size || loaders[c].size == -1)) {
 			driveloaders[drive] = c;
-			strcpy(floppyfns[drive], fn);
+			if (floppyfns[drive] != fn) strcpy(floppyfns[drive], fn);
 			d86f_setup(drive);
 			loaders[c].load(drive, floppyfns[drive]);
 			drive_empty[drive] = 0;


### PR DESCRIPTION
Summary
=======
This PR fixes startup crash on macOS when loading floppy images.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
