### PR TITLE
EGA 32k support

### DIFF
--- a/src/video/vid_ega.c
+++ b/src/video/vid_ega.c
@@ -1169,6 +1169,9 @@ static const device_config_t ega_config[] =
                 "memory", "Memory size", CONFIG_SELECTION, "", 256, "", { 0 },
                 {
                         {
+                                "32 kB", 32
+                        },
+                        {
                                 "64 kB", 64
                         },
                         {


### PR DESCRIPTION
Summary
=======
EGA also supported 32K RAM setting, which is apparently required for the IBM PC model 5150.
Lines 194-205 appear to cover the memory window setting so this looks to be a pretty simple one.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
