### PR TITLE
Fix some compile breaking stuff under Linux/Mac

### DIFF
--- a/src/chipset/CMakeLists.txt
+++ b/src/chipset/CMakeLists.txt
@@ -14,7 +14,7 @@
 #
 
 add_library(chipset OBJECT 82c100.c acc2168.c cs8230.c ali1429.c ali1489.c ali1531.c ali1541.c ali1543.c
-	ali1621.c ali6117.c headland.c intel_82335.c contaq_82c59x.c cs4031.c intel_420ex.c
+	ali1621.c ali6117.c headland.c ims8848.c intel_82335.c contaq_82c59x.c cs4031.c intel_420ex.c
 	intel_4x0.c intel_i450kx.c intel_sio.c intel_piix.c ../ioapic.c neat.c opti283.c opti291.c opti391.c
 	opti495.c opti822.c opti895.c opti5x7.c scamp.c scat.c sis_85c310.c sis_85c4xx.c
 	sis_85c496.c sis_85c50x.c sis_5511.c sis_5571.c via_vt82c49x.c via_vt82c505.c sis_85c310.c

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -50,6 +50,7 @@ SDL_mutex *blitmtx;
 SDL_threadID eventthread;
 static int exit_event = 0;
 static int fullscreen_pending = 0;
+uint32_t lang_id = 0x0409, lang_sys = 0x0409; // Multilangual UI variables, for now all set to LCID of en-US
 
 static const uint16_t sdl_to_xt[0x200] =
 {
@@ -1234,6 +1235,15 @@ uint32_t plat_language_code(char* langcode)
     /* or maybe not */ 
     return 0;
 }
+
+/* Converts back the language code to LCID */
+void
+plat_language_code_r(uint32_t lcid, char* outbuf, int len)
+{
+    /* or maybe not */ 
+    return;
+}
+
 
 void joystick_init(void) {}
 void joystick_close(void) {}

--- a/src/win/languages/pt-BR.rc
+++ b/src/win/languages/pt-BR.rc
@@ -990,7 +990,7 @@ BEGIN
     IDS_6146	"1.5%% abaixo das RPM perfeita"
     IDS_6147	"2%% abaixo das RPM perfeita"
 
-    IDS_7168	"(Sistema padrão)"
+    IDS_7168	"(Padrão do sistema)"
 END
 #define IDS_LANG_ENUS	IDS_7168
 

--- a/src/win/languages/pt-BR.rc
+++ b/src/win/languages/pt-BR.rc
@@ -990,7 +990,7 @@ BEGIN
     IDS_6146	"1.5%% abaixo das RPM perfeita"
     IDS_6147	"2%% abaixo das RPM perfeita"
 
-    IDS_7168	"Português (Brasil)"
+    IDS_7168	"(Sistema padrão)"
 END
 #define IDS_LANG_ENUS	IDS_7168
 

--- a/src/win/win_lang.c
+++ b/src/win/win_lang.c
@@ -6,7 +6,7 @@
  *
  *		This file is part of the 86Box distribution.
  *
- *		Handle the dialog for specifying the dimensions of the main window.
+ *		Handle the dialog for changing the program's language.
  *
  *
  *


### PR DESCRIPTION
Summary
=======
Add ims8848.c to CMakeLists, and add the new missing plat_ prototypes to unix.c, with some new platform-specific global variables.

Edit: also added a quick fix to pt-BR because the meaning IDS_7168 is changed during the development.

Checklist
=========
* [X] Closes compiling problems under Mac/Linux at Discord
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
N/A
