### PR TITLE
Unix: Make fullscreen command really toggle

### DIFF
--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -833,7 +833,7 @@ void monitor_thread(void* param)
                 }
                 else if (strncasecmp(xargv[0], "fullscreen", 10) == 0)
                 {
-                    video_fullscreen = 1;
+                    video_fullscreen = video_fullscreen ? 0 : 1;
                     fullscreen_pending = 1;
                 }
                 else if (strncasecmp(xargv[0], "pause", 5) == 0)


### PR DESCRIPTION
Help says that fullscreen TOGGLES fullscreen. Fix this.

Signed-off-by: Andreas J. Reichel <andreas@reichel.bayern>

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
