### PR TITLE
Menu reloading fixes for Multilanguage UI

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -713,12 +713,7 @@ usage:
 	/* Load the desired language */
 	if (lang_init)
 		lang_id = lang_init;
-	
-	lang_init = lang_id;
-	lang_id = 0;
-	if (lang_init)
-		set_language(lang_init);
-	
+
 	/* All good! */
 	return(1);
 }

--- a/src/include/86box/win.h
+++ b/src/include/86box/win.h
@@ -239,6 +239,9 @@ extern void	media_menu_update_cdrom(int id);
 extern void	media_menu_update_zip(int id);
 extern void	media_menu_update_mo(int id);
 
+/* Functions in win_ui.c */
+extern HMENU	menuMain;
+extern void	ResetAllMenus();
 
 #ifdef __cplusplus
 }

--- a/src/win/win.c
+++ b/src/win/win.c
@@ -269,9 +269,11 @@ set_language(uint32_t id)
 		LoadCommonStrings();
 		
 		/* Reload main menu */
-		SetMenu(hwndMain, LoadMenu(hinstance, L"MainMenu"));
+		menuMain = LoadMenu(hinstance, L"MainMenu");
+		SetMenu(hwndMain, menuMain);
 		
-		/* Re-init media menu */
+		/* Re-init all the menus */
+		ResetAllMenus();
 		media_menu_init();
     } 
 }

--- a/src/win/win_ui.c
+++ b/src/win/win_ui.c
@@ -203,22 +203,22 @@ delete_submenu(HMENU parent, HMENU target)
 }
 #endif
 
+static int menu_vidapi = -1;
+static HMENU cur_menu = NULL;
+
 static void
 show_render_options_menu()
 {
 #if defined(DEV_BRANCH) && defined(USE_OPENGL)
-	static int menu_vidapi = -1;
-	static HMENU cur_menu = NULL;
-	
 	if (vid_api == menu_vidapi)
 		return;
-
+	
 	if (cur_menu != NULL)
 	{
 		if (delete_submenu(menuMain, cur_menu))
 			cur_menu = NULL;
 	}
-
+	
 	if (cur_menu == NULL)
 	{
 		switch (IDM_VID_SDL_SW + vid_api)
@@ -251,7 +251,7 @@ video_set_filter_menu(HMENU menu)
 	EnableMenuItem(menu, IDM_VID_FILTER_LINEAR, vid_api == 0 ? MF_GRAYED : MF_ENABLED);
 }
 
-static void
+void
 ResetAllMenus(void)
 {
     CheckMenuItem(menuMain, IDM_ACTION_RCTRL_IS_LALT, MF_UNCHECKED);
@@ -294,6 +294,9 @@ ResetAllMenus(void)
     CheckMenuItem(menuMain, IDM_VID_SDL_OPENGL, MF_UNCHECKED);
 #if defined(DEV_BRANCH) && defined(USE_OPENGL)
     CheckMenuItem(menuMain, IDM_VID_OPENGL_CORE, MF_UNCHECKED);
+	
+	menu_vidapi = -1;
+	cur_menu = NULL;
     show_render_options_menu();
 #endif
 #ifdef USE_VNC
@@ -1401,9 +1404,10 @@ ui_init(int nCmdShow)
 		ResizeWindowByClientArea(hwndMain, scrnsz_x, scrnsz_y + sbar_height);
     }
 
-    /* Reset all menus to their defaults. */
-    ResetAllMenus();
-    media_menu_init();
+    /* Load the desired language, and reset all menus to their defaults */
+    uint32_t helper_lang = lang_id;
+    lang_id = 0;
+    set_language(helper_lang);	
 
     /* Make the window visible on the screen. */
     ShowWindow(hwnd, nCmdShow);


### PR DESCRIPTION
Summary
=======
This fix is intented for fixing two problems:
  - The menu states are lost when switching lanugages
  - The OpenGL menu disappears when switching languages
  
By saving the reloaded HMENU to the `menuMain` variable and calling `ResetAllMenus` in `set_language`, the first part was solved. As for the OpenGL menu, I had to pull out the two static variables from `win_ui.c/show_render_options_menu()`, and set them to their initial value in `ResetAllMenus`. In this way the OpenGL menu is also recreated correctly.
  
Checklist
=========
* [X] Closes the problem mentioned at Discord
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
N/A
