### PR TITLE
Fix resource string over bounds issues

### DIFF
--- a/src/win/win.c
+++ b/src/win/win.c
@@ -60,7 +60,7 @@
 #endif
 
 typedef struct {
-    WCHAR str[512];
+    WCHAR str[1024];
 } rc_str_t;
 
 
@@ -165,50 +165,50 @@ LoadCommonStrings(void)
     free_string(&lpRCstr4096);
     free_string(&lpRCstr2048);
 
-    lpRCstr2048 = (rc_str_t *)malloc(STR_NUM_2048*sizeof(rc_str_t));
-    lpRCstr4096 = (rc_str_t *)malloc(STR_NUM_4096*sizeof(rc_str_t));
-    lpRCstr4352 = (rc_str_t *)malloc(STR_NUM_4352*sizeof(rc_str_t));
-    lpRCstr4608 = (rc_str_t *)malloc(STR_NUM_4608*sizeof(rc_str_t));
-    lpRCstr5120 = (rc_str_t *)malloc(STR_NUM_5120*sizeof(rc_str_t));
-    lpRCstr5376 = (rc_str_t *)malloc(STR_NUM_5376*sizeof(rc_str_t));
-    lpRCstr5632 = (rc_str_t *)malloc(STR_NUM_5632*sizeof(rc_str_t));
-    lpRCstr5888 = (rc_str_t *)malloc(STR_NUM_5888*sizeof(rc_str_t));
-    lpRCstr6144 = (rc_str_t *)malloc(STR_NUM_6144*sizeof(rc_str_t));
-    lpRCstr7168 = (rc_str_t *)malloc(STR_NUM_7168*sizeof(rc_str_t));
+    lpRCstr2048 = calloc(STR_NUM_2048, sizeof(rc_str_t));
+    lpRCstr4096 = calloc(STR_NUM_4096, sizeof(rc_str_t));
+    lpRCstr4352 = calloc(STR_NUM_4352, sizeof(rc_str_t));
+    lpRCstr4608 = calloc(STR_NUM_4608, sizeof(rc_str_t));
+    lpRCstr5120 = calloc(STR_NUM_5120, sizeof(rc_str_t));
+    lpRCstr5376 = calloc(STR_NUM_5376, sizeof(rc_str_t));
+    lpRCstr5632 = calloc(STR_NUM_5632, sizeof(rc_str_t));
+    lpRCstr5888 = calloc(STR_NUM_5888, sizeof(rc_str_t));
+    lpRCstr6144 = calloc(STR_NUM_6144, sizeof(rc_str_t));
+    lpRCstr7168 = calloc(STR_NUM_7168, sizeof(rc_str_t));
 
     for (i=0; i<STR_NUM_2048; i++)
-	LoadString(hinstance, 2048+i, lpRCstr2048[i].str, 512);
+	LoadString(hinstance, 2048+i, lpRCstr2048[i].str, 1024);
 
     for (i=0; i<STR_NUM_4096; i++)
-	LoadString(hinstance, 4096+i, lpRCstr4096[i].str, 512);
+	LoadString(hinstance, 4096+i, lpRCstr4096[i].str, 1024);
 
     for (i=0; i<STR_NUM_4352; i++)
-	LoadString(hinstance, 4352+i, lpRCstr4352[i].str, 512);
+	LoadString(hinstance, 4352+i, lpRCstr4352[i].str, 1024);
 
     for (i=0; i<STR_NUM_4608; i++)
-	LoadString(hinstance, 4608+i, lpRCstr4608[i].str, 512);
+	LoadString(hinstance, 4608+i, lpRCstr4608[i].str, 1024);
 
     for (i=0; i<STR_NUM_5120; i++)
-	LoadString(hinstance, 5120+i, lpRCstr5120[i].str, 512);
+	LoadString(hinstance, 5120+i, lpRCstr5120[i].str, 1024);
 
     for (i=0; i<STR_NUM_5376; i++) {
 	if ((i == 0) || (i > 3))
-		LoadString(hinstance, 5376+i, lpRCstr5376[i].str, 512);
+		LoadString(hinstance, 5376+i, lpRCstr5376[i].str, 1024);
     }
 
     for (i=0; i<STR_NUM_5632; i++) {
 	if ((i == 0) || (i > 3))
-		LoadString(hinstance, 5632+i, lpRCstr5632[i].str, 512);
+		LoadString(hinstance, 5632+i, lpRCstr5632[i].str, 1024);
     }
 
     for (i=0; i<STR_NUM_5888; i++)
-	LoadString(hinstance, 5888+i, lpRCstr5888[i].str, 512);
+	LoadString(hinstance, 5888+i, lpRCstr5888[i].str, 1024);
 
     for (i=0; i<STR_NUM_6144; i++)
-	LoadString(hinstance, 6144+i, lpRCstr6144[i].str, 512);
+	LoadString(hinstance, 6144+i, lpRCstr6144[i].str, 1024);
 
     for (i=0; i<STR_NUM_7168; i++)
-	LoadString(hinstance, 7168+i, lpRCstr7168[i].str, 512);
+	LoadString(hinstance, 7168+i, lpRCstr7168[i].str, 1024);
 }
 
 


### PR DESCRIPTION
Summary
=======
The resource strings are limited to 512 characters on read and with the new translations, that limit is hit on atleast the file dialogs. Increased it to 1024 to add some head room. There is also an issue with different builds using different rc-compilers that can end up without terminating null character; this is fixed here by using calloc that initializes the memory with 0.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
