### PR TITLE
Made bits 16 and 18 of the Sample Rate Converter register of the ES13…

### DIFF
--- a/src/sound/snd_audiopci.c
+++ b/src/sound/snd_audiopci.c
@@ -964,7 +964,7 @@ es1371_outl(uint16_t port, uint32_t val, void *p)
 	/* Sample Rate Converter Interface Register, Address 10H
 	   Addressable as longword only */
 	case 0x10:
-		dev->sr_cir = val;
+		dev->sr_cir = val & 0xfff8ffff; /*Bits 16 to 18 are undefined*/
 		if (dev->sr_cir & SRC_RAM_WE) {
 			dev->sr_ram[dev->sr_cir >> 25] = val & 0xffff;
 			switch (dev->sr_cir >> 25) {


### PR DESCRIPTION
…71 not writeable, fixes hangs with most NT 4.0 ES1371 drivers while keeping compatibility with other operating systems' drivers.

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
