### PR TITLE
Adding proper support for storing the 86Box ROMs on macOS inside app bundles

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -33,6 +33,7 @@
 #ifdef __APPLE__
 #include <string.h>
 #include <dispatch/dispatch.h>
+#include "mac/macOSXGlue.h"
 #ifdef __aarch64__
 #include <pthread.h>
 #endif
@@ -393,6 +394,7 @@ pc_init(int argc, char *argv[])
 {
 	char path[2048], path2[2048];
 	char *cfg = NULL, *p;
+	char mac_rom_path[2048];
 	char temp[128];
 	struct tm *info;
 	time_t now;
@@ -585,14 +587,14 @@ usage:
 			plat_dir_create(usr_path);
 	}
 
+	#ifdef __APPLE__
+		getDefaultROMPath(mac_rom_path);
+		strcpy(path2, mac_rom_path);
+	#endif
 	if (vmrp && (path2[0] == '\0')) {
-#ifdef __APPLE__
-		sprintf("%s/Library/Application Support/86Box/roms", getenv("HOME") ? getenv("HOME") : getpwuid(getuid())->pw_dir);
-#else
 		strcpy(path2, usr_path);
 		plat_path_slash(path2);
 		strcat(path2, "roms");
-#endif
 		plat_path_slash(path2);
 	}
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,24 +16,33 @@
 #
 
 # Prepare the macOS app bundle icon depending on the release channel
-if(RELEASE_BUILD)
-	set(APP_ICON_MACOSX ${CMAKE_CURRENT_SOURCE_DIR}/mac/icons/release/86Box.icns)
-elseif(BETA_BUILD)
-	set(APP_ICON_MACOSX ${CMAKE_CURRENT_SOURCE_DIR}/mac/icons/beta/86Box.icns)
-elseif(ALPHA_BUILD)
-	set(APP_ICON_MACOSX ${CMAKE_CURRENT_SOURCE_DIR}/mac/icons/dev/86Box.icns)
-else()
-	set(APP_ICON_MACOSX ${CMAKE_CURRENT_SOURCE_DIR}/mac/icons/branch/86Box.icns)
-endif()
+set(APP_ICON_MACOSX)
+if (APPLE)
+	if(RELEASE_BUILD)
+		set(APP_ICON_MACOSX ${CMAKE_CURRENT_SOURCE_DIR}/mac/icons/release/86Box.icns)
+	elseif(BETA_BUILD)
+		set(APP_ICON_MACOSX ${CMAKE_CURRENT_SOURCE_DIR}/mac/icons/beta/86Box.icns)
+	elseif(ALPHA_BUILD)
+		set(APP_ICON_MACOSX ${CMAKE_CURRENT_SOURCE_DIR}/mac/icons/dev/86Box.icns)
+	else()
+		set(APP_ICON_MACOSX ${CMAKE_CURRENT_SOURCE_DIR}/mac/icons/branch/86Box.icns)
+	endif()
 
 set_source_files_properties(${APP_ICON_MACOSX} PROPERTIES
         MACOSX_PACKAGE_LOCATION "Resources")
+endif()
+
+#Adding the macOS glue for ROM paths
+set(MAC_GLUE)
+if (APPLE)
+    set(MAC_GLUE ${CMAKE_CURRENT_SOURCE_DIR}/mac/macOSXGlue.m)
+endif()
         
 # WIN32 marks us as a GUI app on Windows
 # MACOSX_BUNDLE prepares a macOS application bundle including with the app icon
 add_executable(86Box WIN32 MACOSX_BUNDLE 86box.c config.c log.c random.c timer.c io.c acpi.c apm.c
 	dma.c ddma.c nmi.c pic.c pit.c port_6x.c port_92.c ppi.c pci.c mca.c usb.c
-	device.c nvr.c nvr_at.c nvr_ps2.c ${APP_ICON_MACOSX})
+	device.c nvr.c nvr_at.c nvr_ps2.c ${APP_ICON_MACOSX} ${MAC_GLUE})
  
 if(NEW_DYNAREC)
 	add_compile_definitions(USE_NEW_DYNAREC)
@@ -184,7 +193,6 @@ endif()
 if(APPLE)
 	set(APPS ${CMAKE_CURRENT_BINARY_DIR}/86Box.app)
 	install(CODE "
-        	include(InstallRequiredSystemLibraries)
         	include(BundleUtilities)
         	fixup_bundle(\"${APPS}\" \"\" \"\")"
     	COMPONENT Runtime)


### PR DESCRIPTION
Summary
=======
This commit adds the `macOSXglue.m` and `macOSXglue.h` into the project to enable macOS application bundles to store the ROM files independently from the application bundle and it's storage location, such as having the bundle in a separate directory or inside the `Applications` folder on macOS.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
(can be added later if needed)
