### PR TITLE
Fix encoding issues in win_progsett.c and win_icon.c

### DIFF
--- a/src/win/win_icon.c
+++ b/src/win/win_icon.c
@@ -135,7 +135,7 @@ void win_load_icon_set()
 	for (i = 0; i < count; i++)
 	{
 		plat_append_filename(temp, path_root, icon_files[i].filename);
-		mbstowcs(wtemp, temp, strlen(temp) + 1);
+		mbstoc16s(wtemp, temp, strlen(temp) + 1);
 		
 		HICON ictemp;
 		ictemp = LoadImageW(NULL, (LPWSTR)wtemp, IMAGE_ICON, x, y, LR_LOADFROMFILE | LR_DEFAULTCOLOR);  

--- a/src/win/win_progsett.c
+++ b/src/win/win_progsett.c
@@ -102,7 +102,7 @@ progsett_fill_iconsets(HWND hdlg)
 	win_get_icons_path(icon_path_root);
 	
 	wchar_t search[512];
-	mbstowcs(search, icon_path_root, strlen(icon_path_root) + 1);
+	mbstoc16s(search, icon_path_root, strlen(icon_path_root) + 1);
 	wcscat(search, L"*.*");
 	
 	hFind = FindFirstFile((LPCWSTR)search, &data);
@@ -113,7 +113,7 @@ progsett_fill_iconsets(HWND hdlg)
 			  (data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
 			{
 				wchar_t temp[512] = {0}, dispname[512] = {0};
-				mbstowcs(temp, icon_path_root, strlen(icon_path_root) + 1);
+				mbstoc16s(temp, icon_path_root, strlen(icon_path_root) + 1);
 				wcscat(temp, data.cFileName);
 				wcscat(temp, L"\\iconinfo.txt");
 								
@@ -124,14 +124,14 @@ progsett_fill_iconsets(HWND hdlg)
 					char line[512] = {0};
 					if (fgets(line, 511, fp))
 					{
-						mbstowcs(dispname, line, strlen(line) + 1);
+						mbstoc16s(dispname, line, strlen(line) + 1);
 					}
 					
 					fclose(fp);
 				}
 				
 				char filename[512];
-				wcstombs(filename, data.cFileName, 511);
+				c16stombs(filename, data.cFileName, 511);
 				
 				int index = SendMessage(icon_combo, CB_ADDSTRING, 0, (LPARAM)dispname);
 				SendMessage(icon_combo, CB_SETITEMDATA, index, (LPARAM)(strdup(filename)));


### PR DESCRIPTION
Summary
=======
This fix solves the problem, that none of the iconsets are discovered or loadable, when there are non-english characters in the path. By using different conversion functions the problem was solved.

The problem was encoding-related, and made that all related W-version of Windows functions returned error, with GetLastError 0x03 (ERROR_PATH_NOT_FOUND).

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
N/A
