### PR TITLE
WIP: are/serial - serial Passthrough

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -63,6 +63,7 @@
 #include <86box/isartc.h>
 #include <86box/lpt.h>
 #include <86box/serial.h>
+#include <86box/serial_passthrough.h>
 #include <86box/keyboard.h>
 #include <86box/mouse.h>
 #include <86box/gameport.h>
@@ -704,6 +705,7 @@ usage:
 	cdrom_global_init();
 	zip_global_init();
 	mo_global_init();
+	serial_passthrough_init();
 
 	/* Load the configuration file. */
 	config_load();

--- a/src/86box.c
+++ b/src/86box.c
@@ -63,7 +63,6 @@
 #include <86box/isartc.h>
 #include <86box/lpt.h>
 #include <86box/serial.h>
-#include <86box/serial_passthrough.h>
 #include <86box/keyboard.h>
 #include <86box/mouse.h>
 #include <86box/gameport.h>
@@ -705,8 +704,7 @@ usage:
 	cdrom_global_init();
 	zip_global_init();
 	mo_global_init();
-	serial_passthrough_init();
-
+	
 	/* Load the configuration file. */
 	config_load();
 	
@@ -969,6 +967,7 @@ pc_reset_hard_init(void)
 
 	/* Reset and reconfigure the serial ports. */
 	serial_standalone_init();
+        serial_passthrough_enable();
 
 	/* Reset and reconfigure the Sound Card layer. */
 	sound_card_reset();

--- a/src/86box.c
+++ b/src/86box.c
@@ -18,6 +18,7 @@
  *		Copyright 2016-2020 Miran Grca.
  *		Copyright 2017-2020 Fred N. van Kempen.
  *		Copyright 2021 Laci bá'
+ *		Copyright 2021 Andreas J. Reichel.
  */
 #include <inttypes.h>
 #include <stdarg.h>
@@ -144,6 +145,7 @@ int video_vsync = 0;				/* (C) video */
 int video_framerate = -1;			/* (C) video */
 char video_shader[512] = { '\0' };		/* (C) video */
 int	serial_enabled[SERIAL_MAX] = {0,0};	/* (C) enable serial ports */
+serial_passthrough_t serial_passthrough[SERIAL_MAX] = {0}; /* (C) activation and kind of pass-through for serial ports */
 int bugger_enabled = 0;			/* (C) enable ISAbugger */
 int postcard_enabled = 0;			/* (C) enable POST card */
 int isamem_type[ISAMEM_MAX] = { 0,0,0,0 };	/* (C) enable ISA mem cards */

--- a/src/config.c
+++ b/src/config.c
@@ -52,6 +52,7 @@
 #include <86box/fdc_ext.h>
 #include <86box/gameport.h>
 #include <86box/serial.h>
+#include <86box/serial_passthrough.h>
 #include <86box/machine.h>
 #include <86box/mouse.h>
 #include <86box/network.h>
@@ -1073,10 +1074,8 @@ load_ports(void)
             if (strcmp(p, serpt_names[d]) == 0) {
                 serial_passthrough[c].mode = (enum serial_passthrough_mode)d;
                 serial_passthrough[c].enabled = true;
+		break;
             }
-        }
-        if (serial_passthrough[c].enabled) {    
-            config_log("Serial Port %d: passthrough enabled.\n\n", c+1);
         }
     }
 
@@ -2551,14 +2550,14 @@ save_ports(void)
             config_delete_var(cat, temp);
         } else {
             config_set_int(cat, temp, serial_enabled[c]);
-            if (serial_enabled[c]) {
-                if (serial_passthrough[c].enabled) {
-                    sprintf(temp, "serial%d_passthrough", c + 1);
-                    config_set_string(cat, temp,
-                                      serpt_names[serial_passthrough[c].mode]);
-                }    
-            }   
         }
+        if (serial_enabled[c]) {
+   	    if (serial_passthrough[c].enabled) {
+	        sprintf(temp, "serial%d_passthrough", c + 1);
+	        config_set_string(cat, temp,
+			      serpt_names[serial_passthrough[c].mode]);
+	    }    
+        }   
     }
 
     for (c = 0; c < PARALLEL_MAX; c++) {

--- a/src/device.c
+++ b/src/device.c
@@ -396,6 +396,8 @@ device_get_name(const device_t *d, int bus, char *name)
 		sbus = "AGP";
 	else if (d->flags & DEVICE_AC97)
 		sbus = "AMR";
+        else if (d->flags & DEVICE_COM)
+                sbus = "COM";
 
 	if (sbus != NULL) {
 		/* First concatenate [<Bus>] before the device's name. */
@@ -406,7 +408,7 @@ device_get_name(const device_t *d, int bus, char *name)
 		/* Then change string from ISA16 to ISA if applicable. */
 		if (!strcmp(sbus, "ISA16"))
 			sbus = "ISA";
-		else if (!strcmp(sbus, "LPT")) {
+		else if (!strcmp(sbus, "LPT") || !strcmp(sbus, "COM")) {
 			sbus = NULL;
 			strcat(name, d->name);
 			return;

--- a/src/device/CMakeLists.txt
+++ b/src/device/CMakeLists.txt
@@ -17,7 +17,8 @@ add_library(dev OBJECT bugger.c cassette.c cartridge.c hasp.c hwm.c hwm_lm75.c h
 	hwm_vt82c686.c ibm_5161.c isamem.c isartc.c ../lpt.c pci_bridge.c
 	postcard.c serial.c clock_ics9xxx.c isapnp.c i2c.c i2c_gpio.c
 	smbus_piix4.c smbus_ali7101.c keyboard.c keyboard_xt.c keyboard_at.c
-	mouse.c mouse_bus.c mouse_serial.c mouse_ps2.c phoenix_486_jumper.c)
+	mouse.c mouse_bus.c mouse_serial.c mouse_ps2.c phoenix_486_jumper.c
+        serial_passthrough.c)
 
 if(LASERXT)
 	target_compile_definitions(dev PRIVATE USE_LASERXT)

--- a/src/device/serial.c
+++ b/src/device/serial.c
@@ -551,8 +551,11 @@ serial_read(uint16_t addr, void *p)
 			dev->int_status &= ~SERIAL_INT_RECEIVE;
 			serial_update_ints(dev);
 		}
-		/* if in passthrough mode, just override the input data */
-		passthrough_override_data(dev, &ret);
+		/* if in passthrough mode, just override the input data, but
+ 		 * not if in loopback mode */
+		if (!(dev->mctrl & MCR_LOOPBACK)) {
+			passthrough_override_data(dev, &ret);
+		}
 		serial_log("Read data: %02X\n", ret);
 		break;
 	case 1:

--- a/src/device/serial.c
+++ b/src/device/serial.c
@@ -38,6 +38,7 @@
 #include <86box/mem.h>
 #include <86box/rom.h>
 #include <86box/serial.h>
+#include <86box/serial_passthrough.h>
 #include <86box/mouse.h>
 
 
@@ -550,6 +551,8 @@ serial_read(uint16_t addr, void *p)
 			dev->int_status &= ~SERIAL_INT_RECEIVE;
 			serial_update_ints(dev);
 		}
+		/* if in passthrough mode, just override the input data */
+		passthrough_override_data(dev, &ret);
 		serial_log("Read data: %02X\n", ret);
 		break;
 	case 1:
@@ -574,6 +577,8 @@ serial_read(uint16_t addr, void *p)
 		ret = dev->mctrl;
 		break;
 	case 5:
+		/* If device is in passthrough mode, update flags accordingly */
+		passthrough_update_status(dev);
 		ret = dev->lsr;
 		if (dev->lsr & 0x1f)
 			dev->lsr &= ~0x1e;

--- a/src/device/serial.c
+++ b/src/device/serial.c
@@ -724,6 +724,25 @@ serial_standalone_init(void) {
 };
 
 
+void
+serial_passthrough_enable(void)
+{
+    int c;
+    
+    for (c = 0; c < SERIAL_MAX; c++) {
+        serial_log("Setting passthrough for port %d", c+1);
+	if (serial_passthrough[c].enabled) {
+            if (serial_passthrough_create(c, serial_passthrough[c].mode)) {
+                serial_log("Could not create serial passthrough for port %d",
+                           c+1);
+            } else {
+                printf("Serial Port %d: passthrough enabled.\n\n", c+1);
+            }
+        }
+    }
+}
+
+
 const device_t i8250_device = {
     "Intel 8250(-compatible) UART",
     0,

--- a/src/device/serial.c
+++ b/src/device/serial.c
@@ -15,10 +15,12 @@
  * Author:	Sarah Walker, <http://pcem-emulator.co.uk/>
  *		Miran Grca, <mgrca8@gmail.com>
  *		Fred N. van Kempen, <decwiz@yahoo.com>
+ *		Andreas J. Reichel <webmaster@6th-dimension.com>
  *
  *		Copyright 2008-2020 Sarah Walker.
  *		Copyright 2016-2020 Miran Grca.
  *		Copyright 2017-2020 Fred N. van Kempen.
+ *		Copyright 2021      Andreas J. Reichel.
  */
 #include <stdarg.h>
 #include <stdio.h>
@@ -756,4 +758,9 @@ const device_t ns16550_device = {
     serial_init, serial_close, NULL,
     { NULL }, serial_speed_changed, NULL,
     NULL
+};
+
+const char *serpt_names[SERPT_MODES_MAX] = {
+    [SERPT_VIRTUAL_CON] = "vcon",
+    [SERPT_SOCK_TCP] = "tcp"
 };

--- a/src/device/serial_passthrough.c
+++ b/src/device/serial_passthrough.c
@@ -1,0 +1,130 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Implementation of the Serial Passthrough Virtual Device
+ *
+ *
+ *
+ * Author:	Andreas J. Reichel, <webmaster@6th-dimension.com>
+ *
+ *		Copyright 2021          Andreas J. Reichel.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdint.h>
+
+#include <86box/86box.h>
+#include <86box/device.h>
+#include <86box/timer.h>
+#include <86box/serial.h>
+#include <86box/serial_passthrough.h>
+#include <86box/plat_serial_passthrough.h>
+
+
+static device_t serial_passthrough_devs[SERIAL_MAX];
+static int num_passthrough_devs;
+
+
+static void *
+serpt_dev_init(const struct _device_ *dev)
+{
+        /* FIXME: just allocate some memory to return something.
+
+           This will be the platform specific and generic
+           interface for the host adapter to write and recv
+           data as well as to hold the SOCKET or dev name and
+           things like that */
+        return malloc(sizeof(int));
+} 
+
+
+static void
+serpt_dev_close(void *priv)
+{
+        free(priv);
+}
+
+
+static void
+serpt_dev_reset(void *priv)
+{
+        /* FIXME: Nothing to do yet? */
+}
+
+
+void
+serial_passthrough_init(void)
+{
+        memset(serial_passthrough_devs, 0, sizeof(serial_passthrough_devs)); 
+        num_passthrough_devs = 0;
+}
+
+
+static void
+serpt_rcr(struct serial_s *serial, void *p)
+{
+        /* TODO: Handle register base+4 writes */
+}
+
+
+static void
+serpt_write(struct serial_s *serial, void *p, uint8_t data)
+{
+        /* Serial port writes out data byte to the host,
+           handle it platform specifically */
+        plat_serpt_write(p, data);
+}
+
+
+uint8_t
+serial_passthrough_create(uint8_t com_port)
+{
+        device_t *sp_dev = NULL;
+        char tmp[32];
+        uint8_t i;
+        
+        memset(tmp, 0, sizeof(tmp));
+
+        /* Get free slot in local instance list */
+        if (num_passthrough_devs >= SERIAL_MAX) {
+                return 1;
+        }
+
+        i = num_passthrough_devs;
+        sprintf(tmp, "serpt_dev%u", i);
+        
+        /* Create a serial passthrough-device */
+        serial_passthrough_devs[i].flags = DEVICE_COM;
+        serial_passthrough_devs[i].name = tmp;
+        serial_passthrough_devs[i].close = serpt_dev_close;
+        serial_passthrough_devs[i].init = serpt_dev_init;
+        serial_passthrough_devs[i].reset = serpt_dev_reset;
+
+        /* Add the device to the 'device manager' */
+        void *priv = device_add(&serial_passthrough_devs[i]); 
+       
+        if (!priv) {
+                return 1;
+        } 
+
+        /* Attach the device to the serial port */
+        serial_t *s = serial_attach(com_port, serpt_rcr, serpt_write, priv);
+
+        if (!s) {
+                /* actually we could remove the device here, but that
+                 * should not matter at the moment and there is no
+                 * device_remove API call, so let the dev manager
+                 * clean up in the very end. */
+                return 1;
+        }
+
+        return 0;
+}
+

--- a/src/device/serial_passthrough.c
+++ b/src/device/serial_passthrough.c
@@ -73,6 +73,7 @@ serpt_write(struct serial_s *serial, void *p, uint8_t data)
 {
         /* Serial port writes out data byte to the host,
            handle it platform specifically */
+	printf("Serial passthrough byte: %02X\n", data);
         plat_serpt_write(p, data);
 }
 

--- a/src/device/serial_passthrough.c
+++ b/src/device/serial_passthrough.c
@@ -123,6 +123,7 @@ serial_passthrough_create(uint8_t com_port, serpt_mode_t mode)
         }
 
         priv->serial_dev = s;
+        priv->passthrough_dev = &serial_passthrough_devs[i];
         priv->mode = mode;
 
         if (plat_serpt_open_device(priv)) {
@@ -130,6 +131,46 @@ serial_passthrough_create(uint8_t com_port, serpt_mode_t mode)
                 return 1;
         }
 
+        num_passthrough_devs++;
         return 0;
 }
 
+
+void
+passthrough_override_data(serial_t *dev, uint8_t *data)
+{
+        int i;
+
+        /* look if there is any serial passthrough device that is connected to
+         * dev */
+        for (i = 0; i < num_passthrough_devs; i++) {
+                if (!dev->sd || !dev->sd->priv) {
+                        continue;
+                }
+                if (&serial_passthrough_devs[i] ==
+                    ((serpt_ctx_t *)dev->sd->priv)->passthrough_dev) {
+                        plat_serpt_override_data(dev->sd->priv, data);
+                        break;;
+                }
+        }
+}
+
+
+void
+passthrough_update_status(serial_t *dev)
+{
+        int i;
+
+        /* look if there is any serial passthrough device that is connected to
+         * dev */
+        for (i = 0; i < num_passthrough_devs; i++) {
+                if (!dev->sd || !dev->sd->priv) {
+                        continue;
+                }
+                if (&serial_passthrough_devs[i] ==
+                    ((serpt_ctx_t *)dev->sd->priv)->passthrough_dev) {
+                        plat_serpt_update_status(dev->sd->priv, &dev->lsr);
+                        break;
+                }
+        }
+}

--- a/src/include/86box/device.h
+++ b/src/include/86box/device.h
@@ -66,7 +66,8 @@ enum {
     DEVICE_VLB = 0x200,		/* requires the PCI bus */
     DEVICE_PCI = 0x400,		/* requires the VLB bus */
     DEVICE_AGP = 0x800,		/* requires the AGP bus */
-    DEVICE_AC97 = 0x1000	/* requires the AC'97 bus */
+    DEVICE_AC97 = 0x1000,	/* requires the AC'97 bus */
+    DEVICE_COM = 0x2000		/* requires a serial port */
 };
 
 

--- a/src/include/86box/plat_serial_passthrough.h
+++ b/src/include/86box/plat_serial_passthrough.h
@@ -34,6 +34,8 @@ extern "C" {
 extern void plat_serpt_write(void *p, uint8_t data);
 extern int plat_serpt_open_device(void *p);
 extern void plat_serpt_close(void *p);
+extern void plat_serpt_override_data(void *p, uint8_t *data);
+extern void plat_serpt_update_status(void *p, uint8_t *lsr);
 
 #ifdef __cplusplus
 extern }

--- a/src/include/86box/plat_serial_passthrough.h
+++ b/src/include/86box/plat_serial_passthrough.h
@@ -1,0 +1,41 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Definitions for platform specific serial to host passthrough
+ *
+ *
+ *
+ * Authors:	Andreas J. Reichel <webmaster@6th-dimension.com>
+ *
+ *		Copyright 2021		Andreas J. Reichel
+ */
+#ifndef PLAT_SERIAL_PASSTHROUGH_H
+#define PLAT_SERIAL_PASSTHROUGH_H
+
+#if (defined(__unix__) || defined(__APPLE__)) && !defined(__linux__)
+
+#include <86box/plat_serpt_unix.h>
+
+#elif defined(_WIN32)
+
+#include <86box/plat_serpt_win32.h>
+
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern void plat_serpt_write(void *p, uint8_t data);
+
+#ifdef __cplusplus
+extern }
+#endif
+
+
+#endif

--- a/src/include/86box/plat_serial_passthrough.h
+++ b/src/include/86box/plat_serial_passthrough.h
@@ -32,6 +32,8 @@ extern "C" {
 #endif
 
 extern void plat_serpt_write(void *p, uint8_t data);
+extern int plat_serpt_open_device(void *p);
+extern void plat_serpt_close(void *p);
 
 #ifdef __cplusplus
 extern }

--- a/src/include/86box/plat_serpt_unix.h
+++ b/src/include/86box/plat_serpt_unix.h
@@ -1,0 +1,31 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Definitions for serial to host passthrough on Unix
+ *
+ *
+ *
+ * Authors:	Andreas J. Reichel <webmaster@6th-dimension.com>
+ *
+ *		Copyright 2021		Andreas J. Reichel
+ */
+#ifndef PLAT_SERPT_UNIX_H
+#define PLAT_SERPT_UNIX_H
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif

--- a/src/include/86box/plat_serpt_win32.h
+++ b/src/include/86box/plat_serpt_win32.h
@@ -1,0 +1,31 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Definitions for serial to host passthrough on Unix
+ *
+ *
+ *
+ * Authors:	Andreas J. Reichel <webmaster@6th-dimension.com>
+ *
+ *		Copyright 2021		Andreas J. Reichel
+ */
+#ifndef PLAT_SERPT_WIN32_H
+#define PLAT_SERPT_WIN32_H
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif

--- a/src/include/86box/serial.h
+++ b/src/include/86box/serial.h
@@ -47,6 +47,10 @@
 
 #define MAX_SERIAL		4
 
+/* Bits of Modem Control Register */
+#define MCR_LOOPBACK		(1 << 4)	/* Loop Back Mode */
+
+/* Bits of Line Status Register */
 #define LSR_DATA_READY          (1 << 0)        /* Data ready to receive */
 #define LSR_THR_EMPTY           (1 << 5)        /* Transmitter holding register empty */
 

--- a/src/include/86box/serial.h
+++ b/src/include/86box/serial.h
@@ -47,6 +47,9 @@
 
 #define MAX_SERIAL		4
 
+#define LSR_DATA_READY          (1 << 0)        /* Data ready to receive */
+#define LSR_THR_EMPTY           (1 << 5)        /* Transmitter holding register empty */
+
 
 struct serial_device_s;
 struct serial_s;

--- a/src/include/86box/serial.h
+++ b/src/include/86box/serial.h
@@ -13,13 +13,19 @@
  * Author:	Sarah Walker, <http://pcem-emulator.co.uk/>
  *		Miran Grca, <mgrca8@gmail.com>
  *		Fred N. van Kempen, <decwiz@yahoo.com>
+ *		Andreas J. Reichel, <webmaster@6th-dimension.com>
  *
  *		Copyright 2008-2020 Sarah Walker.
  *		Copyright 2016-2020 Miran Grca.
  *		Copyright 2017-2020 Fred N. van Kempen.
+ *		Copyright 2021      Andreas J. Reichel.
  */
 #ifndef EMU_SERIAL_H
 # define EMU_SERIAL_H
+
+
+#include <stdint.h>
+#include <stdbool.h>
 
 
 #define SERIAL_8250		0
@@ -74,7 +80,19 @@ typedef struct serial_device_s
     serial_t *serial;
 } serial_device_t;
 
+#define SERPT_MODES_MAX 2
+enum serial_passthrough_mode {
+    SERPT_VIRTUAL_CON,
+    SERPT_SOCK_TCP
+};
+extern const char *serpt_names[SERPT_MODES_MAX];
 
+typedef struct serial_passthrough_s {
+    bool enabled;
+    enum serial_passthrough_mode mode;
+} serial_passthrough_t;
+
+extern serial_passthrough_t serial_passthrough[SERIAL_MAX];
 extern serial_t *	serial_attach(int port,
 			      void (*rcr_callback)(struct serial_s *serial, void *p),
 			      void (*dev_write)(struct serial_s *serial, void *p, uint8_t data),

--- a/src/include/86box/serial.h
+++ b/src/include/86box/serial.h
@@ -81,10 +81,11 @@ typedef struct serial_device_s
 } serial_device_t;
 
 #define SERPT_MODES_MAX 2
-enum serial_passthrough_mode {
+typedef enum serial_passthrough_mode {
     SERPT_VIRTUAL_CON,
     SERPT_SOCK_TCP
-};
+} serpt_mode_t;
+
 extern const char *serpt_names[SERPT_MODES_MAX];
 
 typedef struct serial_passthrough_s {
@@ -106,6 +107,7 @@ extern void	serial_set_next_inst(int ni);
 extern void	serial_standalone_init(void);
 extern void	serial_set_clock_src(serial_t *dev, double clock_src);
 extern void	serial_reset_port(serial_t *dev);
+extern void     serial_passthrough_enable(void);
 
 extern const device_t	i8250_device;
 extern const device_t	i8250_pcjr_device;

--- a/src/include/86box/serial_passthrough.h
+++ b/src/include/86box/serial_passthrough.h
@@ -1,0 +1,28 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Definitions for the Serial Passthrough Virtual Device
+ *
+ *
+ *
+ * Author:	Andreas J. Reichel, <webmaster@6th-dimension.com>
+ *
+ *		Copyright 2021          Andreas J. Reichel.
+ */
+
+#ifndef SERIAL_PASSTHROUGH_H
+#define SERIAL_PASSTHROUGH_H
+
+
+#include <stdint.h>
+#include <stdbool.h>
+
+void serial_passthrough_init(void);
+uint8_t serial_passthrough_create(uint8_t com_port);
+
+#endif

--- a/src/include/86box/serial_passthrough.h
+++ b/src/include/86box/serial_passthrough.h
@@ -1,18 +1,18 @@
 /*
- * 86Box	A hypervisor and IBM PC system emulator that specializes in
- *		running old operating systems and software designed for IBM
- *		PC systems and compatibles from 1981 through fairly recent
- *		system designs based on the PCI bus.
+ * 86Box        A hypervisor and IBM PC system emulator that specializes in
+ *              running old operating systems and software designed for IBM
+ *              PC systems and compatibles from 1981 through fairly recent
+ *              system designs based on the PCI bus.
  *
- *		This file is part of the 86Box distribution.
+ *              This file is part of the 86Box distribution.
  *
- *		Definitions for the Serial Passthrough Virtual Device
+ *              Definitions for the Serial Passthrough Virtual Device
  *
  *
  *
- * Author:	Andreas J. Reichel, <webmaster@6th-dimension.com>
+ * Author:      Andreas J. Reichel, <webmaster@6th-dimension.com>
  *
- *		Copyright 2021          Andreas J. Reichel.
+ *              Copyright 2021          Andreas J. Reichel.
  */
 
 #ifndef SERIAL_PASSTHROUGH_H
@@ -27,14 +27,17 @@
 
 
 typedef struct serpt_ctx_s {
-	serial_t *serial_dev;
-	serpt_mode_t mode;
-	char slave_pt[32];	/* used for pseudo terminal name of slave side */
-	int master_fd;		/* file desc for master pseudo termnal or socket or alike */
+        serial_t *serial_dev;
+        device_t *passthrough_dev;
+        serpt_mode_t mode;
+        char slave_pt[32];      /* used for pseudo terminal name of slave side */
+        int master_fd;          /* file desc for master pseudo termnal or socket or alike */
 } serpt_ctx_t;
 
 
 void serial_passthrough_init(void);
 uint8_t serial_passthrough_create(uint8_t com_port, serpt_mode_t mode);
+void passthrough_override_data(serial_t *dev, uint8_t *data);
+void passthrough_update_status(serial_t *dev);
 
 #endif

--- a/src/include/86box/serial_passthrough.h
+++ b/src/include/86box/serial_passthrough.h
@@ -22,7 +22,17 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include <86box/device.h>
+#include <86box/serial.h>
+
+
+typedef struct serpt_ctx_s {
+	serial_t *serial_dev;
+	serpt_mode_t mode;
+} serpt_ctx_t;
+
+
 void serial_passthrough_init(void);
-uint8_t serial_passthrough_create(uint8_t com_port);
+uint8_t serial_passthrough_create(uint8_t com_port, serpt_mode_t mode);
 
 #endif

--- a/src/include/86box/serial_passthrough.h
+++ b/src/include/86box/serial_passthrough.h
@@ -29,6 +29,8 @@
 typedef struct serpt_ctx_s {
 	serial_t *serial_dev;
 	serpt_mode_t mode;
+	char slave_pt[32];	/* used for pseudo terminal name of slave side */
+	int master_fd;		/* file desc for master pseudo termnal or socket or alike */
 } serpt_ctx_t;
 
 

--- a/src/machine/machine.c
+++ b/src/machine/machine.c
@@ -37,6 +37,8 @@
 #include <86box/lpt.h>
 #include <86box/serial.h>
 #include <86box/gameport.h>
+#include <86box/serial.h>
+#include <86box/serial_passthrough.h>
 #include "cpu.h"
 #include <86box/video.h>
 #include <86box/machine.h>
@@ -66,6 +68,7 @@ machine_log(const char *fmt, ...)
 #else
 #define machine_log(fmt, ...)
 #endif
+  
 
 
 static int
@@ -106,7 +109,7 @@ machine_init_ex(int m)
     /* All good, boot the machine! */
     if (machines[m].init)
 	ret = machines[m].init(&machines[m]);
-
+ 
     if (bios_only || !ret)
 	return ret;
 

--- a/src/unix/CMakeLists.txt
+++ b/src/unix/CMakeLists.txt
@@ -8,6 +8,9 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 else()
     set(PLAT_SOURCES unix_midi.c)
 endif()
+
+set (PLAT_SOURCES ${PLAT_SOURCES} unix_serial_passthrough.c)
+
 add_library(plat STATIC ${PLAT_SOURCES} unix_thread.c)
 add_library(ui STATIC unix.c unix_sdl.c unix_cdrom.c)
 target_compile_definitions(ui PUBLIC _FILE_OFFSET_BITS=64)

--- a/src/unix/unix_serial_passthrough.c
+++ b/src/unix/unix_serial_passthrough.c
@@ -1,29 +1,141 @@
 /*
- * 86Box	A hypervisor and IBM PC system emulator that specializes in
- *		running old operating systems and software designed for IBM
- *		PC systems and compatibles from 1981 through fairly recent
- *		system designs based on the PCI bus.
+ * 86Box        A hypervisor and IBM PC system emulator that specializes in
+ *              running old operating systems and software designed for IBM
+ *              PC systems and compatibles from 1981 through fairly recent
+ *              system designs based on the PCI bus.
  *
- *		This file is part of the 86Box distribution.
+ *              This file is part of the 86Box distribution.
  *
- *		Definitions for platform specific serial to host passthrough
+ *              Definitions for platform specific serial to host passthrough
  *
  *
  *
- * Authors:	Andreas J. Reichel <webmaster@6th-dimension.com>
+ * Authors:     Andreas J. Reichel <webmaster@6th-dimension.com>
  *
- *		Copyright 2021		Andreas J. Reichel
+ *              Copyright 2021          Andreas J. Reichel
  */
 
+#define _XOPEN_SOURCE 500
 #include <stdio.h>
-#include <stdint.h>
+#include <fcntl.h>
 #include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/select.h>
+#include <stdint.h>
 
+#include <86box/86box.h>
+#include <86box/log.h>
+#include <86box/timer.h>
 #include <86box/plat.h>
+#include <86box/device.h>
+#include <86box/serial_passthrough.h>
 #include <86box/plat_serial_passthrough.h>
 
 
-void plat_serpt_write(void *p, uint8_t data)
+#define LOG_PREFIX "serial_passthrough: "
+
+
+void
+plat_serpt_close(void *p)
 {
-	/* TODO: write to host */
+        serpt_ctx_t *ctx = (serpt_ctx_t *)p;
+
+        close(ctx->master_fd);
+}
+
+        
+static void
+plat_serpt_write_vcon(serpt_ctx_t *ctx, uint8_t data)
+{
+        /* fd_set wrfds;
+         * int res;
+         */
+
+        /* We cannot use select here, this would block the hypervisor! */
+        /* FD_ZERO(&wrfds);
+           FD_SET(ctx->master_fd, &wrfds);
+        
+           res = select(ctx->master_fd + 1, NULL, &wrfds, NULL, NULL);
+        
+           if (res <= 0) {
+                return;
+           }
+        */
+
+        /* just write it out */
+        write(ctx->master_fd, &data, 1);
+}
+
+
+void
+plat_serpt_write(void *p, uint8_t data)
+{
+        serpt_ctx_t *ctx = (serpt_ctx_t *)p;
+        
+        switch (ctx->mode) {
+        case SERPT_VIRTUAL_CON:
+                plat_serpt_write_vcon(ctx, data);
+                return;
+        default:
+                break;
+        }
+}
+
+
+static int
+open_pseudo_terminal(serpt_ctx_t *ctx)
+{
+        int master_fd = open("/dev/ptmx", O_NONBLOCK | O_RDWR);
+        char *ptname;
+
+        if (!master_fd) {
+                return 0;
+        }
+
+        /* get name of slave device */
+        if (!(ptname = ptsname(master_fd))) {
+                pclog(LOG_PREFIX "could not get name of slave pseudo terminal");
+                close(master_fd);
+                return 0;
+        }
+        memset(ctx->slave_pt, 0, sizeof(ctx->slave_pt));
+        strncpy(ctx->slave_pt, ptname, sizeof(ctx->slave_pt)-1);
+
+        pclog(LOG_PREFIX "Slave side is %s\n", ctx->slave_pt);
+
+        if (grantpt(master_fd)) {
+                pclog(LOG_PREFIX "error in grantpt()\n");
+                close(master_fd);
+                return 0;
+        }
+
+        if (unlockpt(master_fd)) {
+                pclog(LOG_PREFIX "error in unlockpt()\n");
+                close(master_fd);
+                return 0;
+        }
+
+        ctx->master_fd = master_fd;
+
+        return master_fd;
+}
+
+
+int
+plat_serpt_open_device(void *p)
+{
+        serpt_ctx_t *ctx = (serpt_ctx_t *)p;
+
+        switch (ctx->mode) {
+        case SERPT_VIRTUAL_CON:
+                if (!open_pseudo_terminal(ctx)) {
+                        return 1;
+                }
+                break;
+        default:
+                break;
+
+        }
+        return 0;
 }

--- a/src/unix/unix_serial_passthrough.c
+++ b/src/unix/unix_serial_passthrough.c
@@ -1,0 +1,29 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Definitions for platform specific serial to host passthrough
+ *
+ *
+ *
+ * Authors:	Andreas J. Reichel <webmaster@6th-dimension.com>
+ *
+ *		Copyright 2021		Andreas J. Reichel
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <86box/plat.h>
+#include <86box/plat_serial_passthrough.h>
+
+
+void plat_serpt_write(void *p, uint8_t data)
+{
+	/* TODO: write to host */
+}

--- a/src/win/CMakeLists.txt
+++ b/src/win/CMakeLists.txt
@@ -16,7 +16,8 @@
 enable_language(RC)
 
 add_library(plat OBJECT win.c win_dynld.c win_cdrom.c win_thread.c
-	win_keyboard.c win_crashdump.c win_midi.c win_mouse.c)
+	win_keyboard.c win_crashdump.c win_midi.c win_mouse.c
+        win_serial_passthrough.c)
 
 add_library(ui OBJECT win_ui.c win_stbar.c win_sdl.c win_dialog.c win_about.c
 	win_settings.c win_devconf.c win_snd_gain.c win_specify_dim.c win_new_floppy.c

--- a/src/win/win_serial_passthrough.c
+++ b/src/win/win_serial_passthrough.c
@@ -1,0 +1,29 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Definitions for platform specific serial to host passthrough
+ *
+ *
+ *
+ * Authors:	Andreas J. Reichel <webmaster@6th-dimension.com>
+ *
+ *		Copyright 2021		Andreas J. Reichel
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <86box/plat.h>
+#include <86box/plat_serial_passthrough.h>
+
+
+void plat_serpt_write(void *p, uint8_t data)
+{
+	/* TODO: write to host */
+}


### PR DESCRIPTION
Summary
=======
This is WORK IN PROGRESS - Just that people can see what I am doing.

THE COMMITS ARE NOT CLEANED UP YET :dagger: :D

Checklist
=========
* [X] Targets #256 

Explanation
=========
* Add a new serial device type " serial_passthrough "
* If config adds
[Ports (COM & LPT)]
serial1_passthrough = vcon

where "vcon" is the passthrough mode, (there will be different modes for TCP, virtual console, tty, serial, etc...)

the passthrough virtual device is attatched to the specified serial port.
This has been tested on the zenith xt (the one with com port) and the am495 machine.

The passthrough device gets informed by the write_callback of serial_device_t, and then calls a platform specific
function plat_serpt_write.

This way, it is modular and further platform specific implementation can decide how to exactly send and receive the bytes
from and to the host.

