### PR TITLE
Fixed Olivetti M19 display bug

### DIFF
--- a/src/device/keyboard_xt.c
+++ b/src/device/keyboard_xt.c
@@ -685,7 +685,7 @@ kbd_init(const device_t *info)
 
     video_reset(gfxcard);
 
-    if ((kbd->type <= 3) || (kbd->type == 4) || (kbd->type == 6)) {
+    if ((kbd->type <= 3) || (kbd->type == 4) || (kbd->type == 6) || (kbd->type == 8)) {
         /* DIP switch readout: bit set = OFF, clear = ON. */
         if (kbd->type == 8)
 		/* Olivetti M19

--- a/src/device/keyboard_xt.c
+++ b/src/device/keyboard_xt.c
@@ -694,107 +694,107 @@ kbd_init(const device_t *info)
 		 * 10 - color (low-res, disables 640x400x2 mode)
 		 * 00 - autoswitching
 		 */
-		kbd->pd |= 0x00;
-	else
-		/* Switches 7, 8 - floppy drives. */
-		kbd->pd = get_fdd_switch_settings();
+		    kbd->pd |= 0x00;
+	    else
+		    /* Switches 7, 8 - floppy drives. */
+		    kbd->pd = get_fdd_switch_settings();
 
-	kbd->pd |= get_videomode_switch_settings();
+	    kbd->pd |= get_videomode_switch_settings();
 
-	/* Switches 3, 4 - memory size. */
-	if ((kbd->type == 3) || (kbd->type == 4) || (kbd->type == 6)) {
-		switch (mem_size) {
-			case 256:
-				kbd->pd |= 0x00;
-				break;
-			case 512:
-				kbd->pd |= 0x04;
-				break;
-			case 576:
-				kbd->pd |= 0x08;
-				break;
-			case 640:
-			default:
-				kbd->pd |= 0x0c;
-				break;
-		}
-	} else if (kbd->type >= 1) {
-		switch (mem_size) {
-			case 64:
-				kbd->pd |= 0x00;
-				break;
-			case 128:
-				kbd->pd |= 0x04;
-				break;
-			case 192:
-				kbd->pd |= 0x08;
-				break;
-			case 256:
-			default:
-				kbd->pd |= 0x0c;
-				break;
-		}
-	} else {
-		switch (mem_size) {
-			case 16:
-				kbd->pd |= 0x00;
-				break;
-			case 32:
-				kbd->pd |= 0x04;
-				break;
-			case 48:
-				kbd->pd |= 0x08;
-				break;
-			case 64:
-			default:
-				kbd->pd |= 0x0c;
-				break;
-		}
-	}
+        /* Switches 3, 4 - memory size. */
+        if ((kbd->type == 3) || (kbd->type == 4) || (kbd->type == 6)) {
+            switch (mem_size) {
+                case 256:
+                    kbd->pd |= 0x00;
+                    break;
+                case 512:
+                    kbd->pd |= 0x04;
+                    break;
+                case 576:
+                    kbd->pd |= 0x08;
+                    break;
+                case 640:
+                default:
+                    kbd->pd |= 0x0c;
+                    break;
+            }
+	    } else if (kbd->type >= 1) {
+            switch (mem_size) {
+                case 64:
+                    kbd->pd |= 0x00;
+                    break;
+                case 128:
+                    kbd->pd |= 0x04;
+                    break;
+                case 192:
+                    kbd->pd |= 0x08;
+                    break;
+                case 256:
+                default:
+                    kbd->pd |= 0x0c;
+                    break;
+            }
+        } else {
+            switch (mem_size) {
+                case 16:
+                    kbd->pd |= 0x00;
+                    break;
+                case 32:
+                    kbd->pd |= 0x04;
+                    break;
+                case 48:
+                    kbd->pd |= 0x08;
+                    break;
+                case 64:
+                default:
+                    kbd->pd |= 0x0c;
+                    break;
+    		}
+	    }
 
-	/* Switch 2 - 8087 FPU. */
-	if (hasfpu)
-		kbd->pd |= 0x02;
+        /* Switch 2 - 8087 FPU. */
+        if (hasfpu)
+            kbd->pd |= 0x02;
 
-	/* Switch 1 - always off. */
-	kbd->pd |= 0x01;
+        /* Switch 1 - always off. */
+        kbd->pd |= 0x01;
     } else if (kbd-> type == 9) {
-	/* Zenith Data Systems Z-151
-	 * SW2 switch settings:
-	 * bit 7: monitor frequency
-	 * bits 5-6: autoboot (00-11 resident monitor, 10 hdd, 01 fdd)
-	 * bits 0-4: installed memory
-	 */
-	kbd->pd = 0x20;
-	switch (mem_size) {
-		case 128:
-			kbd->pd |= 0x02;
-			break;
-		case 192:
-			kbd->pd |= 0x04;
-			break;
-		case 256:
-			kbd->pd |= 0x06;
-			break;
-		case 320:
-			kbd->pd |= 0x08;
-			break;
-		case 384:
-			kbd->pd |= 0x0a;
-			break;
-		case 448:
-			kbd->pd |= 0x0c;
-			break;
-		case 512:
-			kbd->pd |= 0x0e;
-			break;
-		case 576:
-			kbd->pd |= 0x10;
-			break;
-		case 640:
-		default:
-			kbd->pd |= 0x12;
-			break;
+        /* Zenith Data Systems Z-151
+        * SW2 switch settings:
+        * bit 7: monitor frequency
+        * bits 5-6: autoboot (00-11 resident monitor, 10 hdd, 01 fdd)
+        * bits 0-4: installed memory
+        */
+        kbd->pd = 0x20;
+        switch (mem_size) {
+            case 128:
+                kbd->pd |= 0x02;
+                break;
+            case 192:
+                kbd->pd |= 0x04;
+                break;
+            case 256:
+                kbd->pd |= 0x06;
+                break;
+            case 320:
+                kbd->pd |= 0x08;
+                break;
+            case 384:
+                kbd->pd |= 0x0a;
+                break;
+            case 448:
+                kbd->pd |= 0x0c;
+                break;
+            case 512:
+                kbd->pd |= 0x0e;
+                break;
+            case 576:
+                kbd->pd |= 0x10;
+                break;
+            case 640:
+            default:
+                kbd->pd |= 0x12;
+                break;
         }
     }
 


### PR DESCRIPTION
Summary
=======
While I was debugging the M240 option ROM issue #1861 (which was resolved by OBattler before I committed my modifications), I found out that Olivetti M19 was set to 40x25 CGA text mode instead of 80x25 M24/AT&T text mode. Turned out to be an issue in the way jumper settings are read by the keyboard controller, so I corrected it.

As this bug was identified and corrected by myself, I haven't created an issue. If needed for tracking purposes, I can create one though.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
