### PR TITLE
Fixed a typo.

### DIFF
--- a/src/win/languages/fr-FR.rc
+++ b/src/win/languages/fr-FR.rc
@@ -49,7 +49,7 @@ BEGIN
         MENUITEM SEPARATOR
         MENUITEM "Specifier dimensions...",          IDM_VID_SPECIFY_DIM
         MENUITEM "F&orcer 4:3",    IDM_VID_FORCE43
-        POPUP "&Echelle facteurr"
+        POPUP "&Echelle facteur"
         BEGIN
             MENUITEM "&0.5x",                   IDM_VID_SCALE_1X
             MENUITEM "&1x",                     IDM_VID_SCALE_2X


### PR DESCRIPTION
Fixed a typo under the Vue menu section. The typo is Echelle facteurr while the correct spelling is Echelle facteur.