### PR TITLE
opengl: fix for shaders with version directive

### DIFF
--- a/src/win/win_opengl_glslp.c
+++ b/src/win/win_opengl_glslp.c
@@ -173,17 +173,47 @@ GLuint load_custom_shaders(const char* path)
 	{
 		int success = 1;
 
-		const char* vertex_sources[2] = { "#version 130\n#define VERTEX\n", shader };
-		const char* fragment_sources[2] = { "#version 130\n#define FRAGMENT\n", shader };
+		const char* vertex_sources[3] = { "#version 130\n", "#define VERTEX\n", shader };
+		const char* fragment_sources[3] = { "#version 130\n", "#define FRAGMENT\n", shader };
+
+		/* Check if the shader program defines version directive */
+		char* version_start = strstr(shader, "#version");
+
+		/*	If the shader program contains a version directive,
+			it must be captured and placed as the first statement. */
+		if (version_start != NULL)
+		{
+			/* Version directive found, search the line end */
+			char* version_end = strchr(version_start, '\n');
+
+			if (version_end != NULL)
+			{
+				char version[30];
+
+				size_t version_len = MIN(version_end - version_start + 1, 29);
+
+				memcpy(version, version_start, version_len);
+
+				version[version_len] = 0; /* string null terminator */
+
+				/* replace the default version directive */
+				vertex_sources[0] = version;
+				fragment_sources[0] = version;
+			}
+
+			/*	Comment out the original version directive
+				as only one is allowed. */
+			memset(version_start, '/', 2);
+		}
 
 		GLuint vertex_id = glCreateShader(GL_VERTEX_SHADER);
 		GLuint fragment_id = glCreateShader(GL_FRAGMENT_SHADER);
 
-		glShaderSource(vertex_id, 2, vertex_sources, NULL);
+		glShaderSource(vertex_id, 3, vertex_sources, NULL);
 		glCompileShader(vertex_id);
 		success *= check_status(vertex_id, OPENGL_BUILD_TARGET_VERTEX, path);
 
-		glShaderSource(fragment_id, 2, fragment_sources, NULL);
+		glShaderSource(fragment_id, 3, fragment_sources, NULL);
 		glCompileShader(fragment_id);
 		success *= check_status(fragment_id, OPENGL_BUILD_TARGET_FRAGMENT, path);
 


### PR DESCRIPTION
Summary
=======
This fixes using shaders that define the exact language version. The version is searched for, commented out and then prefixed to the program instead of the default one.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
