### PR TITLE
Fix that POST card's message is disappearing when language/iconset change occurs

### DIFF
--- a/src/include/86box/ui.h
+++ b/src/include/86box/ui.h
@@ -66,6 +66,7 @@ extern void	ui_status_update(void);
 extern int	ui_sb_find_part(int tag);
 extern void	ui_sb_set_ready(int ready);
 extern void	ui_sb_update_panes(void);
+extern void	ui_sb_update_text(void);
 extern void	ui_sb_update_tip(int meaning);
 extern void	ui_sb_timer_callback(int pane);
 extern void	ui_sb_update_icon(int tag, int val);

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -454,6 +454,12 @@ ui_sb_update_panes()
 }
 
 void
+ui_sb_update_text()
+{
+
+}
+
+void
 plat_get_dirname(char *dest, const char *path)
 {
     int c = (int)strlen(path);

--- a/src/win/win_preferences.c
+++ b/src/win/win_preferences.c
@@ -193,8 +193,9 @@ preferences_settings_save(void)
 	
     /* Update status bar */
     config_changed = 1;	
-    ui_sb_set_ready(0);
+    ui_sb_set_ready(-1);
     ui_sb_update_panes();
+    ui_sb_update_text();
 	
     /* Save the language changes */
     config_save();

--- a/src/win/win_stbar.c
+++ b/src/win/win_stbar.c
@@ -485,6 +485,9 @@ StatusBarDestroyTips(void)
 
 
 /* API: mark the status bar as not ready. */
+/* Values: -1 - not ready, but don't clear POST text
+            0 - not ready 
+            1 - ready */
 void
 ui_sb_set_ready(int ready)
 {
@@ -493,6 +496,9 @@ ui_sb_set_ready(int ready)
 	ui_sb_set_text(NULL);
     }
 
+    if (ready == -1)
+      ready = 0;
+	
     sb_ready = ready;
 }
 
@@ -1022,7 +1028,7 @@ StatusBarCreate(HWND hwndParent, uintptr_t idStatus, HINSTANCE hInst)
 }
 
 
-static void
+void
 ui_sb_update_text()
 {
     uint8_t part = 0xff;


### PR DESCRIPTION
Fix that POST card's message is disappearing when language/iconset change occurs

Summary
=======
Calling ui_sb_set_ready(0) is needed before ui_sb_update_panes() to update the lanugage-specific hints/icons in both cases. Originally  ui_sb_set_ready(0) clears the POST card's text, now a new value is accepted  ui_sb_set_ready(-1), which does the same as value 0, but does not clears the text. Also ui_sb_update_text() call was needed to update the text when the status bar is updated - this call has changed from static to extern.

Checklist
=========
* [X] Closes two bugs discovered by BurnedPinguin at Discord
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
N/A
