### PR TITLE
Fix null termination issue in opengl shader version replacement

### DIFF
--- a/src/win/win_opengl_glslp.c
+++ b/src/win/win_opengl_glslp.c
@@ -188,13 +188,11 @@ GLuint load_custom_shaders(const char* path)
 
 			if (version_end != NULL)
 			{
-				char version[30];
+				char version[30] = "";
 
 				size_t version_len = MIN(version_end - version_start + 1, 29);
 
-				memcpy(version, version_start, version_len);
-
-				version[version_len] = 0; /* string null terminator */
+				strncat(version, version_start, version_len);
 
 				/* replace the default version directive */
 				vertex_sources[0] = version;


### PR DESCRIPTION
Summary
=======
The fix in #1913 didn't work in 32bit release builds, most likely due to missing null terminating character. Changed the way the string is copied for less error prone method.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
