### PR TITLE
Fix wrong copyright information

### DIFF
--- a/src/rtmidi_midi.cpp
+++ b/src/rtmidi_midi.cpp
@@ -8,9 +8,9 @@
  *
  *		MIDI backend implemented using the RtMidi library.
  *
- * Author:	jgilje,
+ * Author:	Cacodemon345,
  *		Miran Grca, <mgrca8@gmail.com>
- *		Copyright 2021 jgilje.
+ *		Copyright 2021 Cacodemon345.
  *		Copyright 2021 Miran Grca.
  */
 #if defined __has_include


### PR DESCRIPTION
Summary
=======
This PR fixes wrong copyright information in rtmidi_midi.cpp file.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
