### PR TITLE
Error handling updates on OpenGL 3.0 renderer

### DIFF
--- a/src/include/86box/language.h
+++ b/src/include/86box/language.h
@@ -125,6 +125,8 @@
 #define IDS_2149	2149		// "Cassette images (*.PCM;*.RAW;*..."
 #define IDS_2150	2150		// "Cartridge %i: %ls"
 #define IDS_2151	2151		// "Cartridge images (*.JRC)\0*.JRC\0..."
+#define IDS_2152	2152		// "Error initializing OpenGL 3.0 renderer"
+#define IDS_2153	2153		// "OpenGL (3.0 Core) renderer could not be initialized."
 
 #define IDS_4096	4096		// "Hard disk (%s)"
 #define IDS_4097	4097		// "%01i:%01i"
@@ -233,7 +235,7 @@
 
 #define IDS_LANG_ENUS	IDS_7168
 
-#define STR_NUM_2048	104
+#define STR_NUM_2048	106
 #define STR_NUM_3072	11
 #define STR_NUM_4096	40
 #define STR_NUM_4352	6

--- a/src/include/86box/language.h
+++ b/src/include/86box/language.h
@@ -125,8 +125,8 @@
 #define IDS_2149	2149		// "Cassette images (*.PCM;*.RAW;*..."
 #define IDS_2150	2150		// "Cartridge %i: %ls"
 #define IDS_2151	2151		// "Cartridge images (*.JRC)\0*.JRC\0..."
-#define IDS_2152	2152		// "Error initializing OpenGL 3.0 renderer"
-#define IDS_2153	2153		// "OpenGL (3.0 Core) renderer could not be initialized."
+#define IDS_2152	2152		// "Error initializing renderer"
+#define IDS_2153	2153		// "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
 
 #define IDS_4096	4096		// "Hard disk (%s)"
 #define IDS_4097	4097		// "%01i:%01i"

--- a/src/win/languages/cs-CZ.rc
+++ b/src/win/languages/cs-CZ.rc
@@ -530,6 +530,8 @@ BEGIN
     IDS_2149	"Kazetové nahrávky (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0Všechny soubory (*.*)\0*.*\0"
     IDS_2150	"Cartridge %i: %ls"
     IDS_2151	"Obrazy cartridge (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0Všechny soubory (*.*)\0*.*\0"
+    IDS_2152	"Error initializing renderer"
+    IDS_2153	"OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/de-DE.rc
+++ b/src/win/languages/de-DE.rc
@@ -530,6 +530,8 @@ BEGIN
     IDS_2149	"Kassettenimages (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0Alle Dateien (*.*)\0*.*\0"
     IDS_2150	"Cartridge %i: %ls"
     IDS_2151	"Cartridgeimages (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0Alle Dateien (*.*)\0*.*\0"
+    IDS_2152	"Error initializing renderer"
+    IDS_2153	"OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/en-GB.rc
+++ b/src/win/languages/en-GB.rc
@@ -530,6 +530,8 @@ BEGIN
     IDS_2149	"Cassette images (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0All files (*.*)\0*.*\0"
     IDS_2150	"Cartridge %i: %ls"
     IDS_2151	"Cartridge images (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0All files (*.*)\0*.*\0"
+    IDS_2152	"Error initializing renderer"
+    IDS_2153	"OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/en-US.rc
+++ b/src/win/languages/en-US.rc
@@ -530,6 +530,8 @@ BEGIN
     IDS_2149	"Cassette images (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0All files (*.*)\0*.*\0"
     IDS_2150	"Cartridge %i: %ls"
     IDS_2151	"Cartridge images (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0All files (*.*)\0*.*\0"
+    IDS_2152	"Error initializing renderer"
+    IDS_2153	"OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/es-ES.rc
+++ b/src/win/languages/es-ES.rc
@@ -530,6 +530,8 @@ BEGIN
     IDS_2149	"Imágenes de Cassette (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0All files (*.*)\0*.*\0"
     IDS_2150	"Cartucho %i: %ls"
     IDS_2151	"Imágenes de Cartucho (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0All files (*.*)\0*.*\0"
+    IDS_2152	"Error initializing renderer"
+    IDS_2153	"OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/fi-FI.rc
+++ b/src/win/languages/fi-FI.rc
@@ -530,6 +530,8 @@ BEGIN
     IDS_2149    "Kasetti-tiedostot (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0Kaikki tiedostot (*.*)\0*.*\0"
     IDS_2150    "ROM-moduuli %i: %ls"
     IDS_2151    "ROM-moduulikuvat (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0Kaikki tiedostot (*.*)\0*.*\0"
+    IDS_2152	"Virhe renderöijän alustuksessa"
+    IDS_2153	"OpenGL (3.0 Core) renderöijän alustus epäonnistui. Käytä toista renderöijää."
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/fr-FR.rc
+++ b/src/win/languages/fr-FR.rc
@@ -530,6 +530,8 @@ BEGIN
     IDS_2149	"Images cassette (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0Tous les fichiers (*.*)\0*.*\0"
     IDS_2150	"Cartouche %i: %ls"
     IDS_2151	"Images cartouche (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0Tous les fichiers (*.*)\0*.*\0"
+    IDS_2152	"Error initializing renderer"
+    IDS_2153	"OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/hr-HR.rc
+++ b/src/win/languages/hr-HR.rc
@@ -530,6 +530,8 @@ BEGIN
     IDS_2149	"Slike audio kasete (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0Sve datoteke (*.*)\0*.*\0"
     IDS_2150	"Kaseta %i: %ls"
     IDS_2151	"Slike kasete (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0Sve datoteke (*.*)\0*.*\0"
+    IDS_2152	"Error initializing renderer"
+    IDS_2153	"OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/hu-HU.rc
+++ b/src/win/languages/hu-HU.rc
@@ -532,6 +532,8 @@ BEGIN
     IDS_2149	"Magnókazetta-képek (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0Minden fájl (*.*)\0*.*\0"
     IDS_2150	"ROM-kazetta %i: %ls"
     IDS_2151	"ROM-kazetta képek (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0Minden fájl (*.*)\0*.*\0"
+    IDS_2152	"Error initializing renderer"
+    IDS_2153	"OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/it-IT.rc
+++ b/src/win/languages/it-IT.rc
@@ -530,6 +530,8 @@ BEGIN
     IDS_2149	"Immagini cassetta (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0Tutti i file (*.*)\0*.*\0"
     IDS_2150	"Cartuccia %i: %ls"
     IDS_2151	"Immagini cartuccia (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0Tutti i file (*.*)\0*.*\0"
+    IDS_2152	"Error initializing renderer"
+    IDS_2153	"OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/ja-JP.rc
+++ b/src/win/languages/ja-JP.rc
@@ -530,6 +530,8 @@ BEGIN
     IDS_2149	"カセットイメージ (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0すべてのファイル (*.*)\0*.*\0"
     IDS_2150	"カートリッジ %i: %ls"
     IDS_2151	"カートリッジイメージ (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0すべてのファイル (*.*)\0*.*\0"
+    IDS_2152	"Error initializing renderer"
+    IDS_2153	"OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/ko-KR.rc
+++ b/src/win/languages/ko-KR.rc
@@ -530,6 +530,8 @@ BEGIN
     IDS_2149	"카세트 이미지 (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0모든 파일 (*.*)\0*.*\0"
     IDS_2150	"카트리지 %i: %ls"
     IDS_2151	"카트리지 이미지 (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0모든 파일 (*.*)\0*.*\0"
+    IDS_2152	"Error initializing renderer"
+    IDS_2153	"OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/pt-BR.rc
+++ b/src/win/languages/pt-BR.rc
@@ -531,6 +531,8 @@ BEGIN
     IDS_2149	"Imagens de cassete (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0Todos os arquivos (*.*)\0*.*\0"
     IDS_2150	"Cartucho %i: %ls"
     IDS_2151	"Imagens de cartucho (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0Todos os arquivos (*.*)\0*.*\0"
+    IDS_2152	"Error initializing renderer"
+    IDS_2153	"OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/pt-PT.rc
+++ b/src/win/languages/pt-PT.rc
@@ -530,6 +530,8 @@ BEGIN
     IDS_2149	"Imagens de cassete (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0Todos os ficheiros (*.*)\0*.*\0"
     IDS_2150	"Cartucho %i: %ls"
     IDS_2151	"Imagens de cartucho (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0Todos os ficheiros (*.*)\0*.*\0"
+    IDS_2152	"Error initializing renderer"
+    IDS_2153	"OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/ru-RU.rc
+++ b/src/win/languages/ru-RU.rc
@@ -530,6 +530,8 @@ BEGIN
     IDS_2149	"Образы кассет (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0Все файлы (*.*)\0*.*\0"
     IDS_2150	"Картридж %i: %ls"
     IDS_2151	"Образы картриджей (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0Все файлы (*.*)\0*.*\0"
+    IDS_2152	"Error initializing renderer"
+    IDS_2153	"OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/sl-SI.rc
+++ b/src/win/languages/sl-SI.rc
@@ -530,6 +530,8 @@ BEGIN
     IDS_2149	"Slike kaset (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0Vse datoteke (*.*)\0*.*\0"
     IDS_2150	"Spominski vložek %i: %ls"
     IDS_2151	"Slike spominskega vložka (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0Vse datoteke (*.*)\0*.*\0"
+    IDS_2152	"Error initializing renderer"
+    IDS_2153	"OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/tr-TR.rc
+++ b/src/win/languages/tr-TR.rc
@@ -530,6 +530,8 @@ BEGIN
     IDS_2149	"Kaset imajları (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0Tüm dosyalar (*.*)\0*.*\0"
     IDS_2150	"Kartuş %i: %ls"
     IDS_2151	"Kartuş imajları (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0Tüm dosyalar (*.*)\0*.*\0"
+    IDS_2152	"Error initializing renderer"
+    IDS_2153	"OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/zh-CN.rc
+++ b/src/win/languages/zh-CN.rc
@@ -530,6 +530,8 @@ BEGIN
     IDS_2149	"磁带镜像 (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0所有文件 (*.*)\0*.*\0"
     IDS_2150	"卡带 %i: %ls"
     IDS_2151	"卡带镜像 (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0所有文件 (*.*)\0*.*\0"
+    IDS_2152	"Error initializing renderer"
+    IDS_2153	"OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
 END
 
 STRINGTABLE DISCARDABLE 


### PR DESCRIPTION
Summary
=======
General failure notice message box to OpenGL 3.0 renderer initialization failure.

Fail if reported OpenGL version is less than 3.0 or errors are generated after context is created. This should fix some crashes on unsupported hardware or faulty drivers.

Enable debug output only when logfile is defined as debug mode can include a performance hit.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
