### PR TITLE
Add support for a joystick port at 0x209

### DIFF
--- a/src/game/gameport.c
+++ b/src/game/gameport.c
@@ -446,7 +446,7 @@ const device_t gameport_device = {
 };
 
 const device_t gameport_201_device = {
-    "Game port (port 201h only)",
+    "Game port (Port 201h only)",
     0, 0x010201,
     gameport_init,
     gameport_close,
@@ -457,6 +457,15 @@ const device_t gameport_201_device = {
 const device_t gameport_208_device = {
     "Game port (Port 208h-20fh)",
     0, 0x080208,
+    gameport_init,
+    gameport_close,
+    NULL, { NULL }, NULL,
+    NULL
+};
+
+const device_t gameport_209_device = {
+    "Game port (Port 209h only)",
+    0, 0x010209,
     gameport_init,
     gameport_close,
     NULL, { NULL }, NULL,

--- a/src/include/86box/gameport.h
+++ b/src/include/86box/gameport.h
@@ -109,6 +109,7 @@ extern "C" {
 extern const device_t	gameport_device;
 extern const device_t	gameport_201_device;
 extern const device_t	gameport_208_device;
+extern const device_t	gameport_209_device;
 extern const device_t	gameport_pnp_device;
 extern const device_t	gameport_pnp_6io_device;
 extern const device_t	gameport_sio_device;


### PR DESCRIPTION
Summary
=======
Adds support for a gameport at 0x209, like the Thrustmaster ACM has

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://www.flyfoxy.com/images/disable3.jpg