### PR TITLE
Added Kingston MC64 memory expansion card (adf 71d0) which allows up …

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -309,11 +309,11 @@ const machine_t machines[] = {
 
     /* 386DX machines which utilize the MCA bus */
     /* Has IBM PS/2 Type 1 KBC firmware. */
-    { "[MCA] IBM PS/2 model 70 (type 3)",	"ibmps2_m70_type3",	MACHINE_TYPE_386DX,		CPU_PKG_386DX | CPU_PKG_486BL, 0, 0, 0, 0, 0, 0, 0,								MACHINE_MCA | MACHINE_BUS_PS2 | MACHINE_VIDEO,					 2048, 16384, 2048,  63,      machine_ps2_model_70_type3_init, NULL			},
+    { "[MCA] IBM PS/2 model 70 (type 3)",	"ibmps2_m70_type3",	MACHINE_TYPE_386DX,		CPU_PKG_386DX | CPU_PKG_486BL, 0, 0, 0, 0, 0, 0, 0,								MACHINE_MCA | MACHINE_BUS_PS2 | MACHINE_VIDEO,					 2048, 65536, 2048,  63,      machine_ps2_model_70_type3_init, NULL			},
     /* Has IBM PS/2 Type 1 KBC firmware. */
-    { "[MCA] IBM PS/2 model 80",		"ibmps2_m80",		MACHINE_TYPE_386DX,		CPU_PKG_386DX | CPU_PKG_486BL, 0, 0, 0, 0, 0, 0, 0,								MACHINE_MCA | MACHINE_BUS_PS2 | MACHINE_VIDEO,					 1024, 12288, 1024,  63,	    machine_ps2_model_80_init, NULL			},
+    { "[MCA] IBM PS/2 model 80 (type 2)",		"ibmps2_m80",		MACHINE_TYPE_386DX,		CPU_PKG_386DX | CPU_PKG_486BL | CPU_PKG_SOCKET1, 0, 0, 0, 0, 0, 0, 0,								MACHINE_MCA | MACHINE_BUS_PS2 | MACHINE_VIDEO,					 1024, 65536, 1024,  63,	    machine_ps2_model_80_init, NULL			},
     /* Has IBM PS/2 Type 1 KBC firmware. */
-    { "[MCA] IBM PS/2 model 80 (type 3)",	"ibmps2_m80_type3",	MACHINE_TYPE_386DX,		CPU_PKG_386DX | CPU_PKG_486BL, 0, 0, 0, 0, 0, 0, 0,								MACHINE_MCA | MACHINE_BUS_PS2 | MACHINE_VIDEO,					 2048, 12288, 2048,  63,	machine_ps2_model_80_axx_init, NULL			},
+    { "[MCA] IBM PS/2 model 80 (type 3)",	"ibmps2_m80_type3",	MACHINE_TYPE_386DX,		CPU_PKG_386DX | CPU_PKG_486BL | CPU_PKG_SOCKET1, 0, 0, 0, 0, 0, 0, 0,								MACHINE_MCA | MACHINE_BUS_PS2 | MACHINE_VIDEO,					 2048, 65536, 2048,  63,	machine_ps2_model_80_axx_init, NULL			},
 
     /* 386DX/486 machines */
     /* The BIOS sends commands C9 without a parameter and D5, both of which are

--- a/src/video/vid_compaq_cga.c
+++ b/src/video/vid_compaq_cga.c
@@ -315,8 +315,8 @@ compaq_cga_poll(void *p)
 				compaq_cga_log("Lastline %i Firstline %i  %i\n", self->cga.lastline,
 					       self->cga.firstline ,self->cga.lastline - self->cga.firstline);
 
-				if (self->cga.cgamode & 1)	x = (self->cga.crtc[1] << 3);
-				else				x = (self->cga.crtc[1] << 4);
+				if (self->cga.cgamode & 1)	x = (self->cga.crtc[1] << 3) + 16;
+				else				x = (self->cga.crtc[1] << 4) + 16;
 
 				self->cga.lastline++;
 


### PR DESCRIPTION
…to 64MB of RAM in the MCA-based 386DX-based models as well as a IBM CPU planar upgrade which allows 486DX cpu's to be used on the 386DX-based 80 models.

Fixed missing part of the width in the Compaq CGA cards.

Summary
=======
Warning: not all 486dx cpu's are compatible with the 70/80 models!

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
