### PR TITLE
Adjusts the macOS specific CMakeLists.txt

### DIFF
--- a/src/mac/CMakeLists.txt
+++ b/src/mac/CMakeLists.txt
@@ -18,11 +18,11 @@
 #
 
 # Pick the bundle icon depending on the release channel
-if(RELEASE_BUILD)
+if(BUILD_TYPE STREQUAL "release")
     set(APP_ICON_MACOSX icons/release/86Box.icns)
-elseif(BETA_BUILD)
+elseif(BUILD_TYPE STREQUAL "beta")
     set(APP_ICON_MACOSX icons/beta/86Box.icns)
-elseif(ALPHA_BUILD)
+elseif(BUILD_TYPE STREQUAL "alpha")
     set(APP_ICON_MACOSX icons/dev/86Box.icns)
 else()
     set(APP_ICON_MACOSX icons/branch/86Box.icns)


### PR DESCRIPTION
Summary
=======
This should fix the icon setting for macOS bundle for potential Jenkins builds in the future.
![image](https://user-images.githubusercontent.com/2078457/147697295-8cc470aa-6ad0-4b0c-ac0b-77f9d6fb5374.png)
_Example shown with_ `BUILD_TYPE` _set to_ `beta`

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
