### PR TITLE
Fix UART-mode detection on input sysex messages

### DIFF
--- a/src/sound/snd_mpu401.c
+++ b/src/sound/snd_mpu401.c
@@ -1388,7 +1388,7 @@ MPU401_InputSysex(void *p, uint8_t *buffer, uint32_t len, int abort)
 #ifdef DOSBOX_CODE
     if (mpu->mode == M_UART) {
 #else
-    if (!mpu->intelligent && mpu->mode == M_UART) {
+    if (!mpu->intelligent || mpu->mode == M_UART) {
 #endif
 	/* UART mode input. */
 	for (i = 0; i < len; i++)


### PR DESCRIPTION
Summary
=======
`mpu->intelligent` is still true even when mpu-401 has reveived command to switch to UART-mode. Fix the check to only compare `mpu->mode`.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
