### PR TITLE
Fix opengl core renderer message pump

### DIFF
--- a/src/win/win_opengl.c
+++ b/src/win/win_opengl.c
@@ -200,8 +200,9 @@ static void set_parent_binding(int enable)
  * @param wParam
  * @param lParam 
  * @param fullscreen
+ * @return Was message handled
 */
-static void handle_window_messages(UINT message, WPARAM wParam, LPARAM lParam, int fullscreen)
+static int handle_window_messages(UINT message, WPARAM wParam, LPARAM lParam, int fullscreen)
 {
 	switch (message)
 	{
@@ -219,7 +220,7 @@ static void handle_window_messages(UINT message, WPARAM wParam, LPARAM lParam, i
 			/* Mouse events that enter and exit capture. */
 			PostMessage(parent, message, wParam, lParam);
 		}
-		break;
+		return 1;
 	case WM_KEYDOWN:
 	case WM_KEYUP:
 	case WM_SYSKEYDOWN:
@@ -228,7 +229,7 @@ static void handle_window_messages(UINT message, WPARAM wParam, LPARAM lParam, i
 		{
 			PostMessage(parent, message, wParam, lParam);
 		}
-		break;
+		return 1;
 	case WM_INPUT:
 		if (fullscreen)
 		{
@@ -256,8 +257,10 @@ static void handle_window_messages(UINT message, WPARAM wParam, LPARAM lParam, i
 			}
 			free(raw);
 		}
-		break;
+		return 1;
 	}
+
+	return 0;
 }
 
 /**
@@ -638,12 +641,13 @@ static void opengl_main(void* param)
 
 			/* Handle window messages */
 			MSG msg;
-			if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+			while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
 			{
-				if (msg.hwnd == window_hwnd)
-					handle_window_messages(msg.message, msg.wParam, msg.lParam, fullscreen);
-				TranslateMessage(&msg);
-				DispatchMessage(&msg);
+				if (msg.hwnd != window_hwnd || !handle_window_messages(msg.message, msg.wParam, msg.lParam, fullscreen))
+				{
+					TranslateMessage(&msg);
+					DispatchMessage(&msg);
+				}
 			}
 
 			/* Wait for synchronized events for 1ms before going back to window events */


### PR DESCRIPTION
Summary
=======
Makes OpenGL 3.0 renderer empty the message queue in one go and only translate and dispatch unhandled messages.

This should fix the full screen mouse lag problem which has been introduced by unknown reason; probably a change in SDL library or Nvidia drivers.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
