### PR TITLE
Exit full screen mode if changing window (with alt-tab)

### DIFF
--- a/src/win/win_opengl.c
+++ b/src/win/win_opengl.c
@@ -258,6 +258,13 @@ static int handle_window_messages(UINT message, WPARAM wParam, LPARAM lParam, in
 			free(raw);
 		}
 		return 1;
+	case WM_MOUSELEAVE:
+		if (fullscreen)
+		{
+			/* Leave fullscreen if mouse leaves the renderer window. */
+			PostMessage(GetAncestor(parent, GA_ROOT), WM_LEAVEFULLSCREEN, 0, 0);
+		}
+		return 0;
 	}
 
 	return 0;
@@ -726,7 +733,14 @@ static void opengl_main(void* param)
 				{
 					SetForegroundWindow(window_hwnd);
 					SetFocus(window_hwnd);
+
+					/* Clip cursor to prevent it moving to another monitor. */
+					RECT rect;
+					GetWindowRect(window_hwnd, &rect);
+					ClipCursor(&rect);
 				}
+				else
+					ClipCursor(NULL);
 			}
 
 			if (fullscreen)

--- a/src/win/win_ui.c
+++ b/src/win/win_ui.c
@@ -961,6 +961,9 @@ MainWindowProcedure(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 		break;
 
 	case WM_WINDOWPOSCHANGED:
+		if (video_fullscreen & 1)
+			PostMessage(hwndMain, WM_LEAVEFULLSCREEN, 0, 0);
+
 		pos = (WINDOWPOS*)lParam;
 		GetClientRect(hwndMain, &rect);
 
@@ -1158,6 +1161,13 @@ MainWindowProcedure(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 			plat_vidapi_enable(0);
 			plat_vidapi_enable(1);
 		}
+		break;
+
+	case WM_ACTIVATEAPP:
+		/* Leave full screen on switching application except
+		   for OpenGL Core and VNC renderers. */
+		if (video_fullscreen & 1 && wParam == FALSE && vid_api < 3)
+			PostMessage(hwndMain, WM_LEAVEFULLSCREEN, 0, 0);
 		break;
 
 	case WM_ENTERSIZEMOVE:


### PR DESCRIPTION
If the user leaves full screen window by alt-tab or similar method (unintended way), 86Box goes into an unstable state; mouse cursor can be hidden or clipped to an arbitrary area and the rendering can be distorted. 

Fixing this "properly" would mean refactoring the way windows and renderers are created and going through the process in which window and video resizing works to ensure proper operation.

In this PR is a simpler solution that makes 86Box leave full screen if the user leaves the program.

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
