### PR TITLE
Added gameport at port 201h to AdLib Gold sound card

### DIFF
--- a/src/sound/snd_adlibgold.c
+++ b/src/sound/snd_adlibgold.c
@@ -939,12 +939,12 @@ static const device_config_t adgold_config[] =
         {
                 "gameport", "Enable Game port", CONFIG_BINARY, "", 1
         },
-		{
+        {
 				"surround", "Surround module", CONFIG_BINARY, "", 1
-		},
-		{
+        },
+        {
 				"receive_input", "Receive input (MIDI)", CONFIG_BINARY, "", 1
-		},
+        },
         {
                 "", "", -1
         }

--- a/src/sound/snd_adlibgold.c
+++ b/src/sound/snd_adlibgold.c
@@ -9,6 +9,7 @@
 #include <86box/dma.h>
 #include <86box/pic.h>
 #include <86box/device.h>
+#include <86box/gameport.h>
 #include <86box/nvr.h>
 #include <86box/sound.h>
 #include <86box/filters.h>
@@ -66,7 +67,9 @@ typedef struct adgold_t
         int16_t mma_buffer[2][SOUNDBUFLEN];
 
         int pos;
-        
+
+        int gameport_enabled;
+
         int surround_enabled;
 } adgold_t;
 
@@ -858,6 +861,8 @@ void *adgold_init(const device_t *info)
         memset(adgold, 0, sizeof(adgold_t));
 
         adgold->surround_enabled = device_get_config_int("surround");
+
+        adgold->gameport_enabled = device_get_config_int("gameport");
         
         opl3_init(&adgold->opl);
         if (adgold->surround_enabled)
@@ -901,6 +906,9 @@ void *adgold_init(const device_t *info)
         /*388/389 are handled by adlib_init*/
         io_sethandler(0x0388, 0x0008, adgold_read, NULL, NULL, adgold_write, NULL, NULL, adgold);
         
+        if (adgold->gameport_enabled)
+        gameport_remap(gameport_add(&gameport_201_device), 0x201);
+        
 		timer_add(&adgold->adgold_mma_timer_count, adgold_timer_poll, adgold, 1);
 
         sound_add_handler(adgold_get_buffer, adgold);
@@ -929,8 +937,11 @@ void adgold_close(void *p)
 static const device_config_t adgold_config[] =
 {
         {
-                "surround", "Surround module", CONFIG_BINARY, "", 1
+                "gameport", "Enable Game port", CONFIG_BINARY, "", 1
         },
+		{
+				"surround", "Surround module", CONFIG_BINARY, "", 1
+		},
 		{
 				"receive_input", "Receive input (MIDI)", CONFIG_BINARY, "", 1
 		},

--- a/src/sound/snd_adlibgold.c
+++ b/src/sound/snd_adlibgold.c
@@ -940,10 +940,10 @@ static const device_config_t adgold_config[] =
                 "gameport", "Enable Game port", CONFIG_BINARY, "", 1
         },
         {
-				"surround", "Surround module", CONFIG_BINARY, "", 1
+                "surround", "Surround module", CONFIG_BINARY, "", 1
         },
         {
-				"receive_input", "Receive input (MIDI)", CONFIG_BINARY, "", 1
+                "receive_input", "Receive input (MIDI)", CONFIG_BINARY, "", 1
         },
         {
                 "", "", -1


### PR DESCRIPTION
Summary
=======
I have added the gameport at port 201h to the AdLib Gold sound card.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
Yamaha YMZ263B-F datasheet: https://pdf1.alldatasheet.com/datasheet-pdf/view/87670/YAMAHA/YMZ263B-F.html
AdLib Gold drivers, software and documents: https://archive.org/details/adlib-gold-bundle/
