### PR TITLE
Fix several build issues if built with -DDYNAREC=Off

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -1046,8 +1046,12 @@ pc_reset_hard_init(void)
 	atfullspeed = 0;
 	pc_full_speed();
 
-	cycles = cycles_main = 0;
-	
+
+	cycles = 0;
+#ifdef USE_DYNAREC
+	cycles_main = 0;
+#endif
+
 	update_mouse_msg();
 }
 

--- a/src/cpu/CMakeLists.txt
+++ b/src/cpu/CMakeLists.txt
@@ -14,7 +14,7 @@
 #
 
 add_library(cpu OBJECT cpu.c cpu_table.c fpu.c x86.c 808x.c 386.c 386_common.c 386_dynarec.c
-    386_dynarec_ops.c x86seg.c x87.c x87_timings.c)
+    x86seg.c x87.c x87_timings.c)
 
 if(AMD_K5)
     target_compile_definitions(cpu PRIVATE USE_AMD_K5)
@@ -29,4 +29,5 @@ if(DYNAREC)
         codegen_timing_common.c codegen_timing_k6.c
         codegen_timing_pentium.c codegen_timing_p6.c
         codegen_timing_winchip.c codegen_timing_winchip2.c)
+    add_library(dynarec_ops OBJECT 386_dynarec_ops.c)
 endif()

--- a/src/cpu/x86seg.c
+++ b/src/cpu/x86seg.c
@@ -2415,7 +2415,9 @@ cyrix_load_seg_descriptor(uint32_t addr, x86seg *seg)
 			cpu_cur_status &= ~CPU_STATUS_NOTFLATDS;
 		else
 			cpu_cur_status |= CPU_STATUS_NOTFLATDS;
+#ifdef USE_DYNAREC
 		codegen_flat_ds = 0;
+#endif
 	}
 	if (seg == &cpu_state.seg_ss) {
 		if (seg->base == 0 && seg->limit_low == 0 && seg->limit_high == 0xffffffff)
@@ -2423,7 +2425,9 @@ cyrix_load_seg_descriptor(uint32_t addr, x86seg *seg)
 		else
 			cpu_cur_status |= CPU_STATUS_NOTFLATSS;
 		set_stack32((segdat[3] & 0x40) ? 1 : 0);
+#ifdef USE_DYNAREC
 		codegen_flat_ss = 0;
+#endif
 	}
     }
 }

--- a/src/dma.c
+++ b/src/dma.c
@@ -892,8 +892,10 @@ dma_page_write(uint16_t addr, uint8_t val, void *priv)
 {
     uint8_t convert[8] = CHANNELS;
 
+#ifdef USE_DYNAREC
     if ((addr == 0x84) && cpu_use_dynarec)
 	update_tsc();
+#endif
 
     addr &= 0x0f;
     dmaregs[2][addr] = val;


### PR DESCRIPTION
Summary
=======
cyrix_load_seg_descriptor() touches codegen_flat_ds and codegen_flat_ss even if dynarec is disabled.
386_dynarec_ops.c is built even if dynarec is disabled, references many things, and is not needed in that configuration.
dma_page_write() calls update_tsc(), and while this isn't called if dynarec is disabled in software, the call is still built in if built with dynarec disabled.
pc_hard_reset_init() sets cycles_main, which only exists if build with dynarec.

these prevent the codebase from building if built with -DDYNAREC=Off.

this pull request fixes all of these.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
