### PR TITLE
Fixes to config file backwards compatibility, take 2

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -928,21 +928,41 @@ load_input_devices(void)
 		joystick_type = joystick_get_from_internal_name("2axis_8button");
 	else if (!strcmp(p, "ch_flighstick_pro")) /* fix typo */
 		joystick_type = joystick_get_from_internal_name("ch_flightstick_pro");
+	else
+		joystick_type = joystick_get_from_internal_name(p);
 
-	joystick_type = joystick_get_from_internal_name(p);
 	if (!joystick_type) {
 		/* Try to read an integer for backwards compatibility with old configs */
-		c = config_get_int(cat, "joystick_type", 8);
-		switch (c) {
-			case 0: case 1: case 2: case 3: /* 2-axis joysticks */
-				joystick_type = c + 1;
-				break;
-			case 4: case 5: case 6: case 7: /* other joysticks */
-				joystick_type = c + 3;
-				break;
-			default: /* "None" (8) or invalid value */
-				joystick_type = 0;
-				break;
+		if (!strcmp(p, "0")) /* workaround for config_get_int returning 0 on non-integer data */
+			joystick_type = joystick_get_from_internal_name("2axis_2button");
+		else {
+			c = config_get_int(cat, "joystick_type", 8);
+			switch (c) {
+				case 1:
+					joystick_type = joystick_get_from_internal_name("2axis_4button");
+					break;
+				case 2:
+					joystick_type = joystick_get_from_internal_name("2axis_6button");
+					break;
+				case 3:
+					joystick_type = joystick_get_from_internal_name("2axis_8button");
+					break;
+				case 4:
+					joystick_type = joystick_get_from_internal_name("4axis_4button");
+					break;
+				case 5:
+					joystick_type = joystick_get_from_internal_name("ch_flightstick_pro");
+					break;
+				case 6:
+					joystick_type = joystick_get_from_internal_name("sidewinder_pad");
+					break;
+				case 7:
+					joystick_type = joystick_get_from_internal_name("thrustmaster_fcs");
+					break;
+				default:
+					joystick_type = 0;
+					break;
+			}
 		}
 	}
     } else

--- a/src/config.c
+++ b/src/config.c
@@ -889,7 +889,10 @@ load_video(void)
 		}
 		free_p = 1;
 	}
-	gfxcard = video_get_video_from_internal_name(p);
+	if (!strcmp(p, "virge375_vbe20_pci")) /* migrate renamed cards */
+		gfxcard = video_get_video_from_internal_name("virge385_pci");
+	else
+		gfxcard = video_get_video_from_internal_name(p);
 	if (free_p)
 		free(p);
     }

--- a/src/config.c
+++ b/src/config.c
@@ -918,7 +918,7 @@ load_input_devices(void)
 
     p = config_get_string(cat, "joystick_type", NULL);
     if (p != NULL) {
-	if (!strcmp(p, "standard_2button"))
+	if (!strcmp(p, "standard_2button")) /* migrate renamed types */
 		joystick_type = joystick_get_from_internal_name("2axis_2button");
 	else if (!strcmp(p, "standard_4button"))
 		joystick_type = joystick_get_from_internal_name("2axis_4button");
@@ -926,6 +926,8 @@ load_input_devices(void)
 		joystick_type = joystick_get_from_internal_name("2axis_6button");
 	else if (!strcmp(p, "standard_8button"))
 		joystick_type = joystick_get_from_internal_name("2axis_8button");
+	else if (!strcmp(p, "ch_flighstick_pro")) /* fix typo */
+		joystick_type = joystick_get_from_internal_name("ch_flightstick_pro");
 
 	joystick_type = joystick_get_from_internal_name(p);
 	if (!joystick_type) {

--- a/src/game/joystick_ch_flightstick_pro.c
+++ b/src/game/joystick_ch_flightstick_pro.c
@@ -116,7 +116,7 @@ static void ch_flightstick_pro_a0_over(void *p)
 const joystick_if_t joystick_ch_flightstick_pro =
 {
         "CH Flightstick Pro",
-        "ch_flighstick_pro",
+        "ch_flightstick_pro",
         ch_flightstick_pro_init,
         ch_flightstick_pro_close,
         ch_flightstick_pro_read,


### PR DESCRIPTION
Summary
=======
Re-submitting PR #1968 after its changes were accidentally overwritten in a conflict resolution:
* Handle the internal name change for the S3 ViRGE/GX card (formerly known as ViRGE/DX VBE 2.0)
* Fix a typo in CH Flightstick Pro's internal name
* Fix joystick type migration not working properly; also map legacy integer-based joystick type options to their string counterparts directly instead of relying on the array index

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
