### PR TITLE
qt: Bugfixes

### DIFF
--- a/src/qt/evdev_mouse.cpp
+++ b/src/qt/evdev_mouse.cpp
@@ -1,3 +1,19 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Linux/FreeBSD libevdev mouse input module.
+ *
+ *
+ *
+ * Authors:	Cacodemon345
+ *
+ *		Copyright 2021-2022 Cacodemon345
+ */
 #include "evdev_mouse.hpp"
 #include <libevdev/libevdev.h>
 #include <unistd.h>

--- a/src/qt/qt.c
+++ b/src/qt/qt.c
@@ -1,4 +1,18 @@
 /*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ */
+/*
  * C functionality for Qt platform, where the C equivalent is not easily
  * implemented in Qt
  */

--- a/src/qt/qt_deviceconfig.cpp
+++ b/src/qt/qt_deviceconfig.cpp
@@ -1,3 +1,21 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Device configuration UI code.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *          Cacodemon345
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ *      Copyright 2022 Cacodemon345
+ */
 #include "qt_deviceconfig.hpp"
 #include "ui_qt_deviceconfig.h"
 

--- a/src/qt/qt_filefield.cpp
+++ b/src/qt/qt_filefield.cpp
@@ -1,3 +1,21 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		File field widget.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *          Cacodemon345
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ *      Copyright 2022 Cacodemon345
+ */
 #include "qt_filefield.hpp"
 #include "ui_qt_filefield.h"
 

--- a/src/qt/qt_harddiskdialog.cpp
+++ b/src/qt/qt_harddiskdialog.cpp
@@ -22,6 +22,7 @@ extern "C" {
 #include <QStringBuilder>
 
 #include "qt_harddrive_common.hpp"
+#include "qt_settings_bus_tracking.hpp"
 #include "qt_models_common.hpp"
 #include "qt_util.hpp"
 
@@ -609,6 +610,7 @@ bool HarddiskDialog::checkAndAdjustCylinders() {
 
 
 void HarddiskDialog::on_comboBoxBus_currentIndexChanged(int index) {
+    int chanIdx = 0;
     if (index < 0) {
         return;
     }
@@ -665,6 +667,27 @@ void HarddiskDialog::on_comboBoxBus_currentIndexChanged(int index) {
     ui->lineEditSectors->setValidator(new QIntValidator(1, max_sectors, this));
 
     Harddrives::populateBusChannels(ui->comboBoxChannel->model(), ui->comboBoxBus->currentData().toInt());
+    switch (ui->comboBoxBus->currentData().toInt())
+    {
+        case HDD_BUS_MFM:
+            chanIdx = (Harddrives::busTrackClass->next_free_mfm_channel());
+            break;
+        case HDD_BUS_XTA:
+            chanIdx = (Harddrives::busTrackClass->next_free_xta_channel());
+            break;
+        case HDD_BUS_ESDI:
+            chanIdx = (Harddrives::busTrackClass->next_free_esdi_channel());
+            break;
+        case HDD_BUS_ATAPI:
+        case HDD_BUS_IDE:
+            chanIdx = (Harddrives::busTrackClass->next_free_ide_channel());
+            break;
+        case HDD_BUS_SCSI:
+            chanIdx = (Harddrives::busTrackClass->next_free_scsi_id());
+            break;
+    }
+
+    ui->comboBoxChannel->setCurrentIndex(chanIdx);
 }
 
 void HarddiskDialog::on_lineEditSize_textEdited(const QString &text) {

--- a/src/qt/qt_harddiskdialog.cpp
+++ b/src/qt/qt_harddiskdialog.cpp
@@ -1,3 +1,21 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Hard disk dialog code.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *          Cacodemon345
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ *      Copyright 2022 Cacodemon345
+ */
 #include "qt_harddiskdialog.hpp"
 #include "ui_qt_harddiskdialog.h"
 

--- a/src/qt/qt_harddrive_common.cpp
+++ b/src/qt/qt_harddrive_common.cpp
@@ -1,3 +1,19 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Common storage devices module.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ */
 #include "qt_harddrive_common.hpp"
 
 #include <cstdint>

--- a/src/qt/qt_hardwarerenderer.cpp
+++ b/src/qt/qt_hardwarerenderer.cpp
@@ -1,3 +1,23 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Hardware renderer module.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *          Cacodemon345
+ *          Teemu Korhonen
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ *      Copyright 2021-2022 Cacodemon345
+ *      Copyright 2021-2022 Teemu Korhonen
+ */
 #include "qt_hardwarerenderer.hpp"
 #include <QApplication>
 #include <QVector2D>

--- a/src/qt/qt_joystickconfiguration.cpp
+++ b/src/qt/qt_joystickconfiguration.cpp
@@ -1,3 +1,19 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Joystick configuration UI module.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ */
 #include "qt_joystickconfiguration.hpp"
 #include "ui_qt_joystickconfiguration.h"
 

--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -1,3 +1,21 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Joystick configuration UI module.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *          Cacodemon345
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ *      Copyright 2021-2022 Cacodemon345
+ */
 #include "qt_machinestatus.hpp"
 
 extern "C" {

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -1,3 +1,22 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *      Main entry point module
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *          Cacodemon345
+ *          Teemu Korhonen
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ *      Copyright 2021-2022 Cacodemon345
+ *      Copyright 2021-2022 Teemu Korhonen
+ */
 #include <QApplication>
 #include <QSurfaceFormat>
 #include <QDebug>

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -1,3 +1,23 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Main window module.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *          Cacodemon345
+ *          Teemu Korhonen
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ *      Copyright 2021-2022 Cacodemon345
+ *      Copyright 2021-2022 Teemu Korhonen
+ */
 #include "qt_mainwindow.hpp"
 #include "ui_qt_mainwindow.h"
 

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -88,7 +88,15 @@ MainWindow::MainWindow(QWidget *parent) :
     auto toolbar_label = new QLabel();
     ui->toolBar->addWidget(toolbar_label);
 
+#ifdef RELEASE_BUILD
+    this->setWindowIcon(QIcon(":/settings/win/icons/86Box-green.ico"));
+#elif defined ALPHA_BUILD
+    this->setWindowIcon(QIcon(":/settings/win/icons/86Box-read.ico"))
+#elif defined BETA_BUILD
     this->setWindowIcon(QIcon(":/settings/win/icons/86Box-yellow.ico"));
+#else
+    this->setWindowIcon(QIcon(":/settings/win/icons/86Box-gray.ico"));
+#endif
     this->setWindowFlag(Qt::MSWindowsFixedSizeDialogHint, vid_resize != 1);
     this->setWindowFlag(Qt::WindowMaximizeButtonHint, vid_resize == 1);
 

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -13,10 +13,12 @@
  * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
  *          Cacodemon345
  *          Teemu Korhonen
+ *          dob205
  *
  *		Copyright 2021 Joakim L. Gilje
  *      Copyright 2021-2022 Cacodemon345
  *      Copyright 2021-2022 Teemu Korhonen
+ *      Copyright 2022 dob205
  */
 #include "qt_mainwindow.hpp"
 #include "ui_qt_mainwindow.h"

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -1415,7 +1415,15 @@ void MainWindow::on_actionAbout_86Box_triggered()
     {
         QDesktopServices::openUrl(QUrl("https://86box.net/"));
     });
+#ifdef RELEASE_BUILD
+    msgBox.setIconPixmap(QIcon(":/settings/win/icons/86Box-green.ico").pixmap(32, 32));
+#elif defined ALPHA_BUILD
+    msgBox.setIconPixmap(QIcon(":/settings/win/icons/86Box-read.ico").pixmap(32, 32))
+#elif defined BETA_BUILD
     msgBox.setIconPixmap(QIcon(":/settings/win/icons/86Box-yellow.ico").pixmap(32, 32));
+#else
+    msgBox.setIconPixmap(QIcon(":/settings/win/icons/86Box-gray.ico").pixmap(32, 32));
+#endif
     msgBox.setWindowFlags(Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
     msgBox.exec();
 }

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -377,7 +377,6 @@ MainWindow::MainWindow(QWidget *parent) :
 
 #ifdef MTR_ENABLED
     {
-        ui->menuTools->addSeparator();
         ui->actionBegin_trace->setVisible(true);
         ui->actionEnd_trace->setVisible(true);
         ui->actionBegin_trace->setShortcut(QKeySequence(Qt::Key_Control + Qt::Key_T));

--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -1,3 +1,23 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Media menu UI module.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *          Cacodemon345
+ *          Teemu Korhonen
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ *      Copyright 2021-2022 Cacodemon345
+ *      Copyright 2021-2022 Teemu Korhonen
+ */
 #include "qt_mediamenu.hpp"
 
 #include "qt_machinestatus.hpp"

--- a/src/qt/qt_models_common.cpp
+++ b/src/qt/qt_models_common.cpp
@@ -1,3 +1,19 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Common storage devices module.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ */
 #include "qt_models_common.hpp"
 
 #include <QAbstractItemModel>

--- a/src/qt/qt_newfloppydialog.cpp
+++ b/src/qt/qt_newfloppydialog.cpp
@@ -1,3 +1,23 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Common storage devices module.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *          Cacodemon345
+ *          Teemu Korhonen
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ *      Copyright 2022 Cacodemon345
+ *      Copyright 2022 Teemu Korhonen
+ */
 #include "qt_newfloppydialog.hpp"
 #include "ui_qt_newfloppydialog.h"
 

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -1,3 +1,22 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *      Main entry point module
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *          Cacodemon345
+ *          Teemu Korhonen
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ *      Copyright 2021-2022 Cacodemon345
+ *      Copyright 2021-2022 Teemu Korhonen
+ */
 #include <cstdio>
 
 #include <mutex>

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -6,7 +6,7 @@
  *
  *		This file is part of the 86Box distribution.
  *
- *      Main entry point module
+ *      Common platform functions.
  *
  *
  * Authors:	Joakim L. Gilje <jgilje@jgilje.net>

--- a/src/qt/qt_progsettings.cpp
+++ b/src/qt/qt_progsettings.cpp
@@ -1,3 +1,19 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Program settings UI module.
+ *
+ *
+ *
+ * Authors: Cacodemon345
+ *
+ *      Copyright 2021-2022 Cacodemon345
+ */
 #include <QDebug>
 
 #include "qt_progsettings.hpp"

--- a/src/qt/qt_renderercommon.cpp
+++ b/src/qt/qt_renderercommon.cpp
@@ -1,3 +1,20 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Program settings UI module.
+ *
+ *
+ *
+ * Authors: Joakim L. Gilje <jgilje@jgilje.net>
+ *
+ *      Copyright 2021 Joakim L. Gilje
+ */
+
 #include "qt_renderercommon.hpp"
 #include "qt_mainwindow.hpp"
 

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -1,3 +1,23 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Program settings UI module.
+ *
+ *
+ *
+ * Authors: Joakim L. Gilje <jgilje@jgilje.net>
+ *          Cacodemon345
+ *          Teemu Korhonen
+ *
+ *      Copyright 2021 Joakim L. Gilje
+ *      Copyright 2021-2021 Teemu Korhonen
+ *      Copyright 2021-2022 Cacodemon345
+ */
 #include "qt_rendererstack.hpp"
 #include "ui_qt_rendererstack.h"
 

--- a/src/qt/qt_settings.cpp
+++ b/src/qt/qt_settings.cpp
@@ -1,3 +1,21 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Program settings UI module.
+ *
+ *
+ *
+ * Authors: Joakim L. Gilje <jgilje@jgilje.net>
+ *          Cacodemon345
+ *
+ *      Copyright 2021 Joakim L. Gilje
+ *      Copyright 2021-2022 Cacodemon345
+ */
 #include "qt_settings.hpp"
 #include "ui_qt_settings.h"
 

--- a/src/qt/qt_settings_bus_tracking.cpp
+++ b/src/qt/qt_settings_bus_tracking.cpp
@@ -1,3 +1,21 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Program settings UI module.
+ *
+ *
+ *
+ * Authors: Miran Grca <mgrca8@gmail.com>
+ *          Cacodemon345
+ *
+ *      Copyright 2022 Miran Grca
+ *      Copyright 2022 Cacodemon345
+ */
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>

--- a/src/qt/qt_settingsdisplay.cpp
+++ b/src/qt/qt_settingsdisplay.cpp
@@ -1,3 +1,19 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Display settings UI module.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ */
 #include "qt_settingsdisplay.hpp"
 #include "ui_qt_settingsdisplay.h"
 

--- a/src/qt/qt_settingsfloppycdrom.cpp
+++ b/src/qt/qt_settingsfloppycdrom.cpp
@@ -1,3 +1,19 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Floppy/CD-ROM devices configuration UI module.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ */
 #include "qt_settingsfloppycdrom.hpp"
 #include "ui_qt_settingsfloppycdrom.h"
 

--- a/src/qt/qt_settingsfloppycdrom.cpp
+++ b/src/qt/qt_settingsfloppycdrom.cpp
@@ -11,7 +11,9 @@
  *
  *
  * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *          Cacodemon345
  *
+ *      Copyright 2021-2022 Cacodemon345
  *		Copyright 2021 Joakim L. Gilje
  */
 #include "qt_settingsfloppycdrom.hpp"

--- a/src/qt/qt_settingsfloppycdrom.cpp
+++ b/src/qt/qt_settingsfloppycdrom.cpp
@@ -173,8 +173,8 @@ void SettingsFloppyCDROM::onCDROMRowChanged(const QModelIndex &current) {
     if (! match.isEmpty()) {
         ui->comboBoxChannel->setCurrentIndex(match.first().row());
     }
-    else ui->comboBoxChannel->setCurrentIndex(8);
-    ui->comboBoxSpeed->setCurrentIndex(speed - 1);
+
+    ui->comboBoxSpeed->setCurrentIndex(speed == 0 ? 7 : speed - 1);
 }
 
 void SettingsFloppyCDROM::on_checkBoxTurboTimings_stateChanged(int arg1) {

--- a/src/qt/qt_settingsharddisks.cpp
+++ b/src/qt/qt_settingsharddisks.cpp
@@ -11,7 +11,9 @@
  *
  *
  * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *          Cacodemon345
  *
+ *      Copyright 2021-2022 Cacodemon345
  *		Copyright 2021 Joakim L. Gilje
  */
 #include "qt_settingsharddisks.hpp"

--- a/src/qt/qt_settingsharddisks.cpp
+++ b/src/qt/qt_settingsharddisks.cpp
@@ -1,3 +1,19 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Hard disk configuration UI module.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ */
 #include "qt_settingsharddisks.hpp"
 #include "ui_qt_settingsharddisks.h"
 

--- a/src/qt/qt_settingsinput.cpp
+++ b/src/qt/qt_settingsinput.cpp
@@ -1,3 +1,19 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Mouse/Joystick configuration UI module.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ */
 #include "qt_settingsinput.hpp"
 #include "ui_qt_settingsinput.h"
 

--- a/src/qt/qt_settingsmachine.cpp
+++ b/src/qt/qt_settingsmachine.cpp
@@ -1,3 +1,19 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Machine selection and configuration UI module.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ */
 #include "qt_settingsmachine.hpp"
 #include "ui_qt_settingsmachine.h"
 

--- a/src/qt/qt_settingsnetwork.cpp
+++ b/src/qt/qt_settingsnetwork.cpp
@@ -1,3 +1,19 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Network devices configuration UI module.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ */
 #include "qt_settingsnetwork.hpp"
 #include "ui_qt_settingsnetwork.h"
 

--- a/src/qt/qt_settingsotherperipherals.cpp
+++ b/src/qt/qt_settingsotherperipherals.cpp
@@ -1,3 +1,19 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Other peripherals configuration UI module.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ */
 #include "qt_settingsotherperipherals.hpp"
 #include "ui_qt_settingsotherperipherals.h"
 

--- a/src/qt/qt_settingsotherremovable.cpp
+++ b/src/qt/qt_settingsotherremovable.cpp
@@ -1,3 +1,19 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Other removable devices configuration UI module.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ */
 #include "qt_settingsotherremovable.hpp"
 #include "ui_qt_settingsotherremovable.h"
 

--- a/src/qt/qt_settingsotherremovable.cpp
+++ b/src/qt/qt_settingsotherremovable.cpp
@@ -11,7 +11,9 @@
  *
  *
  * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *          Cacodemon345
  *
+ *      Copyright 2021-2022 Cacodemon345
  *		Copyright 2021 Joakim L. Gilje
  */
 #include "qt_settingsotherremovable.hpp"

--- a/src/qt/qt_settingsports.cpp
+++ b/src/qt/qt_settingsports.cpp
@@ -1,3 +1,19 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Serial/Parallel ports configuration UI module.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ */
 #include "qt_settingsports.hpp"
 #include "ui_qt_settingsports.h"
 

--- a/src/qt/qt_settingsports.cpp
+++ b/src/qt/qt_settingsports.cpp
@@ -12,6 +12,7 @@
  *
  * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
  *
+ *      Copyright 2022 Cacodemon345
  *		Copyright 2021 Joakim L. Gilje
  */
 #include "qt_settingsports.hpp"

--- a/src/qt/qt_settingsports.cpp
+++ b/src/qt/qt_settingsports.cpp
@@ -11,6 +11,7 @@
  *
  *
  * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *          Cacodemon345
  *
  *      Copyright 2022 Cacodemon345
  *		Copyright 2021 Joakim L. Gilje

--- a/src/qt/qt_settingsports.cpp
+++ b/src/qt/qt_settingsports.cpp
@@ -34,7 +34,7 @@ SettingsPorts::SettingsPorts(QWidget *parent) :
 {
     ui->setupUi(this);
 
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < 4; i++) {
         auto* cbox = findChild<QComboBox*>(QString("comboBoxLpt%1").arg(i+1));
         auto* model = cbox->model();
         int c = 0;
@@ -93,5 +93,10 @@ void SettingsPorts::on_checkBoxParallel2_stateChanged(int state) {
 
 void SettingsPorts::on_checkBoxParallel3_stateChanged(int state) {
     ui->comboBoxLpt3->setEnabled(state == Qt::Checked);
+}
+
+
+void SettingsPorts::on_checkBoxParallel4_stateChanged(int state) {
+    ui->comboBoxLpt4->setEnabled(state == Qt::Checked);
 }
 

--- a/src/qt/qt_settingsports.hpp
+++ b/src/qt/qt_settingsports.hpp
@@ -21,6 +21,8 @@ private slots:
     void on_checkBoxParallel2_stateChanged(int arg1);
     void on_checkBoxParallel1_stateChanged(int arg1);
 
+    void on_checkBoxParallel4_stateChanged(int arg1);
+
 private:
     Ui::SettingsPorts *ui;
 };

--- a/src/qt/qt_settingsports.ui
+++ b/src/qt/qt_settingsports.ui
@@ -58,6 +58,16 @@
      <item row="2" column="1">
       <widget class="QComboBox" name="comboBoxLpt3"/>
      </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>LPT4 Device:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QComboBox" name="comboBoxLpt4"/>
+     </item>
     </layout>
    </item>
    <item>
@@ -108,6 +118,13 @@
       <widget class="QCheckBox" name="checkBoxSerial4">
        <property name="text">
         <string>Serial port 4</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QCheckBox" name="checkBoxParallel4">
+       <property name="text">
+        <string>Parallel port 4</string>
        </property>
       </widget>
      </item>

--- a/src/qt/qt_settingssound.cpp
+++ b/src/qt/qt_settingssound.cpp
@@ -1,3 +1,19 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Sound/MIDI devices configuration UI module.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ */
 #include "qt_settingssound.hpp"
 #include "ui_qt_settingssound.h"
 

--- a/src/qt/qt_settingsstoragecontrollers.cpp
+++ b/src/qt/qt_settingsstoragecontrollers.cpp
@@ -1,3 +1,19 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Storage devices configuration UI module.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ */
 #include "qt_settingsstoragecontrollers.hpp"
 #include "ui_qt_settingsstoragecontrollers.h"
 

--- a/src/qt/qt_softwarerenderer.cpp
+++ b/src/qt/qt_softwarerenderer.cpp
@@ -1,3 +1,23 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Software renderer module.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *          Cacodemon345
+ *          Teemu Korhonen
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ *      Copyright 2021-2022 Cacodemon345
+ *      Copyright 2021-2022 Teemu Korhonen
+ */
 #include "qt_softwarerenderer.hpp"
 #include <QApplication>
 #include <QPainter>

--- a/src/qt/qt_soundgain.cpp
+++ b/src/qt/qt_soundgain.cpp
@@ -1,3 +1,19 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Sound gain dialog UI module.
+ *
+ *
+ *
+ * Authors:	Cacodemon345
+ *
+ *		Copyright 2021-2022 Cacodemon345
+ */
 #include "qt_soundgain.hpp"
 #include "ui_qt_soundgain.h"
 

--- a/src/qt/qt_specifydimensions.cpp
+++ b/src/qt/qt_specifydimensions.cpp
@@ -1,3 +1,19 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Specify dimensions UI module.
+ *
+ *
+ *
+ * Authors:	Cacodemon345
+ *
+ *		Copyright 2021-2022 Cacodemon345
+ */
 #include "qt_specifydimensions.h"
 #include "ui_qt_specifydimensions.h"
 

--- a/src/qt/qt_styleoverride.cpp
+++ b/src/qt/qt_styleoverride.cpp
@@ -1,3 +1,19 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Style override class.
+ *
+ *
+ *
+ * Authors:	Teemu Korhonen
+ *
+ *		Copyright 2022 Teemu Korhonen
+ */
 #include "qt_styleoverride.hpp"
 
 int StyleOverride::styleHint(

--- a/src/qt/qt_ui.cpp
+++ b/src/qt/qt_ui.cpp
@@ -100,6 +100,10 @@ void ui_sb_set_text_w(wchar_t *wstr) {
     main_window->statusBar()->showMessage(QString::fromWCharArray(wstr));
 }
 
+void ui_sb_set_text(char *str) {
+    main_window->statusBar()->showMessage(QString(str));
+}
+
 void
 ui_sb_update_tip(int arg) {
     main_window->updateStatusBarTip(arg);
@@ -115,7 +119,10 @@ void ui_sb_bugui(char *str) {
 }
 
 void ui_sb_set_ready(int ready) {
-    qDebug() << Q_FUNC_INFO << ready;
+    if (ready == 0) {
+        ui_sb_bugui(nullptr);
+        ui_sb_set_text(nullptr);
+    }
 }
 
 void

--- a/src/qt/qt_ui.cpp
+++ b/src/qt/qt_ui.cpp
@@ -1,3 +1,21 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Common UI functions.
+ *
+ *
+ *
+ * Authors:	Joakim L. Gilje <jgilje@jgilje.net>
+ *          Cacodemon345
+ *
+ *		Copyright 2021 Joakim L. Gilje
+ *      Copyright 2021-2022 Cacodemon345
+ */
 #include <cstdint>
 
 #include <QDebug>

--- a/src/qt/qt_util.cpp
+++ b/src/qt/qt_util.cpp
@@ -1,3 +1,19 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Utility functions.
+ *
+ *
+ *
+ * Authors:	Teemu Korhonen
+ *
+ *		Copyright 2022 Teemu Korhonen
+ */
 #include <QStringBuilder>
 #include <QStringList>
 #include "qt_util.hpp"

--- a/src/qt/wl_mouse.cpp
+++ b/src/qt/wl_mouse.cpp
@@ -1,3 +1,19 @@
+/*
+ * 86Box	A hypervisor and IBM PC system emulator that specializes in
+ *		running old operating systems and software designed for IBM
+ *		PC systems and compatibles from 1981 through fairly recent
+ *		system designs based on the PCI bus.
+ *
+ *		This file is part of the 86Box distribution.
+ *
+ *		Wayland mouse input module.
+ *
+ *
+ *
+ * Authors:	Cacodemon345
+ *
+ *		Copyright 2021-2022 Cacodemon345
+ */
 #include "wl_mouse.hpp"
 #include <QGuiApplication>
 #include <wayland-client-core.h>


### PR DESCRIPTION
Summary
=======
* Set main window icon based on release/beta/alpha/build-from-source build.
* Set CD-ROM speed to 8x if it is not specified.
* Implement bus tracking for hard disk creation dialog.
* Fix about dialog having wrong icon.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
