### PR TITLE
qt: Text update behaviour now identical to Win32

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -113,7 +113,7 @@ MainWindow::MainWindow(QWidget *parent) :
 #ifdef RELEASE_BUILD
     this->setWindowIcon(QIcon(":/settings/win/icons/86Box-green.ico"));
 #elif defined ALPHA_BUILD
-    this->setWindowIcon(QIcon(":/settings/win/icons/86Box-red.ico"))
+    this->setWindowIcon(QIcon(":/settings/win/icons/86Box-red.ico"));
 #elif defined BETA_BUILD
     this->setWindowIcon(QIcon(":/settings/win/icons/86Box-yellow.ico"));
 #else
@@ -1439,7 +1439,7 @@ void MainWindow::on_actionAbout_86Box_triggered()
 #ifdef RELEASE_BUILD
     msgBox.setIconPixmap(QIcon(":/settings/win/icons/86Box-green.ico").pixmap(32, 32));
 #elif defined ALPHA_BUILD
-    msgBox.setIconPixmap(QIcon(":/settings/win/icons/86Box-red.ico").pixmap(32, 32))
+    msgBox.setIconPixmap(QIcon(":/settings/win/icons/86Box-red.ico").pixmap(32, 32));
 #elif defined BETA_BUILD
     msgBox.setIconPixmap(QIcon(":/settings/win/icons/86Box-yellow.ico").pixmap(32, 32));
 #else

--- a/src/qt/qt_ui.cpp
+++ b/src/qt/qt_ui.cpp
@@ -28,6 +28,8 @@
 
 MainWindow* main_window = nullptr;
 
+static QString sb_text, sb_buguitext;
+
 extern "C" {
 
 #include <86box/plat.h>
@@ -96,12 +98,18 @@ int	ui_msgbox(int flags, void *message) {
     return ui_msgbox_header(flags, nullptr, message);
 }
 
+void ui_sb_update_text() {
+    main_window->statusBar()->showMessage(sb_text.isEmpty() ? sb_buguitext : sb_text);
+}
+
 void ui_sb_set_text_w(wchar_t *wstr) {
-    main_window->statusBar()->showMessage(QString::fromWCharArray(wstr));
+    sb_text = QString::fromWCharArray(wstr);
+    ui_sb_update_text();
 }
 
 void ui_sb_set_text(char *str) {
-    main_window->statusBar()->showMessage(QString(str));
+    sb_text = str;
+    ui_sb_update_text();
 }
 
 void
@@ -115,7 +123,8 @@ ui_sb_update_panes() {
 }
 
 void ui_sb_bugui(char *str) {
-    main_window->statusBarMessage(str);
+    sb_buguitext = str;
+    ui_sb_update_text();;
 }
 
 void ui_sb_set_ready(int ready) {


### PR DESCRIPTION
Summary
=======
Text update behaviour now identical to Win32 in Qt.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
win_stbar.c.
