### PR TITLE
Add MT-32 LCD message display support in the status bar

### DIFF
--- a/src/include/86box/ui.h
+++ b/src/include/86box/ui.h
@@ -74,6 +74,7 @@ extern void	ui_sb_update_icon_state(int tag, int active);
 extern void	ui_sb_set_text_w(wchar_t *wstr);
 extern void	ui_sb_set_text(char *str);
 extern void	ui_sb_bugui(char *str);
+extern void	ui_sb_mt32lcd(char *str);
 
 #ifdef __cplusplus
 }

--- a/src/qt/qt_ui.cpp
+++ b/src/qt/qt_ui.cpp
@@ -28,7 +28,7 @@
 
 MainWindow* main_window = nullptr;
 
-static QString sb_text, sb_buguitext;
+static QString sb_text, sb_buguitext, sb_mt32lcdtext;
 
 extern "C" {
 
@@ -99,7 +99,13 @@ int	ui_msgbox(int flags, void *message) {
 }
 
 void ui_sb_update_text() {
-    emit main_window->statusBarMessage(sb_text.isEmpty() ? sb_buguitext : sb_text);
+    emit main_window->statusBarMessage( !sb_mt32lcdtext.isEmpty() ? sb_mt32lcdtext : sb_text.isEmpty() ? sb_buguitext : sb_text);
+}
+
+void ui_sb_mt32lcd(char* str)
+{
+    sb_mt32lcdtext = QString(str);
+    ui_sb_update_text();
 }
 
 void ui_sb_set_text_w(wchar_t *wstr) {

--- a/src/sound/midi_mt32.c
+++ b/src/sound/midi_mt32.c
@@ -9,6 +9,7 @@
 #include <86box/mem.h>
 #include <86box/rom.h>
 #include <86box/plat.h>
+#include <86box/ui.h>
 #include <86box/sound.h>
 #include <86box/midi.h>
 
@@ -18,6 +19,19 @@ extern void givealbuffer_midi(void *buf, uint32_t size);
 extern void al_set_midi(int freq, int buf_size);
 #endif
 
+static void display_mt32_message(void *instance_data, const char *message)
+{
+    int sz = 0;
+    char* ui_msg = NULL;
+
+    sz = snprintf(NULL, 0, "MT-32: %s", message);
+    ui_msg = calloc(sz + 1, 1);
+    if (ui_msg)
+    {
+        snprintf(ui_msg, sz, "MT-32: %s", message);
+        ui_sb_mt32lcd(ui_msg);
+    }
+}
 static const mt32emu_report_handler_i_v0 handler_v0 = {
         /** Returns the actual interface version ID */
         NULL, //mt32emu_report_handler_version (*getVersionID)(mt32emu_report_handler_i i);
@@ -28,7 +42,7 @@ static const mt32emu_report_handler_i_v0 handler_v0 = {
         NULL, //void (*onErrorControlROM)(void *instance_data);
         NULL, //void (*onErrorPCMROM)(void *instance_data);
         /** Callback for reporting about displaying a new custom message on LCD */
-        NULL, //void (*showLCDMessage)(void *instance_data, const char *message);
+        display_mt32_message, //void (*showLCDMessage)(void *instance_data, const char *message);
         /** Callback for reporting actual processing of a MIDI message */
         NULL, //void (*onMIDIMessagePlayed)(void *instance_data);
         /**

--- a/src/win/win_stbar.c
+++ b/src/win/win_stbar.c
@@ -1073,3 +1073,9 @@ ui_sb_bugui(char *str)
 	memset(sb_bugtext, 0x00, sizeof(sb_bugtext));
     ui_sb_update_text();
 }
+
+/* API */
+void
+ui_sb_mt32lcd(char* str)
+{
+}


### PR DESCRIPTION
Summary
=======
This PR adds MT-32 LCD message display support in the status bar. Only implemented for Qt.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
