### PR TITLE
qt: Fix theming bugs under KDE

### DIFF
--- a/src/qt/qt_styleoverride.cpp
+++ b/src/qt/qt_styleoverride.cpp
@@ -31,6 +31,7 @@ int StyleOverride::styleHint(
 
 void StyleOverride::polish(QWidget* widget)
 {
+    QProxyStyle::polish(widget);
     /* Disable title bar context help buttons globally as they are unused. */
     if (widget->isWindow())
         widget->setWindowFlag(Qt::WindowContextHelpButtonHint, false);


### PR DESCRIPTION
Summary
=======
This PR fixes theming bugs under KDE, such as background having the wrong color, glitched scrollbars, buttons having no hovering effect, etc.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
