### PR TITLE
Fix untranslated hide toolbar string

### DIFF
--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -648,7 +648,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Hide tool bar</string>
+    <string>Hide &amp;toolbar</string>
    </property>
    <property name="toolTip">
     <string>Hide tool bar</string>


### PR DESCRIPTION
Summary
=======
qt: Fix untranslated hide toolbar string

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
