### PR TITLE
qt: Scale icons based on screen DPI

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -415,6 +415,8 @@ MainWindow::MainWindow(QWidget *parent) :
         });
     }
 #endif
+
+    ui->toolBar->setIconSize(QSize(16 * screen()->devicePixelRatio(), 16 * screen()->devicePixelRatio()));
 }
 
 void MainWindow::closeEvent(QCloseEvent *event) {


### PR DESCRIPTION
Summary
=======
qt: Scale toolbar icons based on screen DPI

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
