### PR TITLE
qt: Status bar fixes

### DIFF
--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -172,7 +172,9 @@ struct MachineStatus::States {
     Pixmaps pixmaps;
 
     States(QObject* parent) {
+#ifdef _WIN32
         pixmap_size = QSize(16, 16) * qobject_cast<MainWindow*>(parent->parent())->screen()->devicePixelRatio();
+#endif
         pixmaps.cartridge.load("/cartridge%1.ico");
         pixmaps.cassette.load("/cassette%1.ico");
         pixmaps.floppy_disabled.normal = ProgSettings::loadIcon(QStringLiteral("/floppy_disabled.ico")).pixmap(pixmap_size);
@@ -332,7 +334,7 @@ void MachineStatus::refresh(QStatusBar* sbar) {
     int c_xta = hdd_count(HDD_BUS_XTA);
     int c_ide = hdd_count(HDD_BUS_IDE);
     int c_scsi = hdd_count(HDD_BUS_SCSI);
-    int do_net = (network_type == NET_TYPE_NONE) || (network_card == 0);
+    int do_net = network_available();
 
     sbar->removeWidget(d->cassette.label.get());
     for (int i = 0; i < 2; ++i) {


### PR DESCRIPTION
Summary
=======
* Fix inverted logic for network icon
* Scale the status bar pixmaps only on Windows

Checklist
=========
* [x] Closes #2077
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
