### PR TITLE
qt: Status bar and window fixes

### DIFF
--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -172,9 +172,6 @@ struct MachineStatus::States {
     Pixmaps pixmaps;
 
     States(QObject* parent) {
-#ifdef _WIN32
-        pixmap_size = QSize(16, 16) * qobject_cast<MainWindow*>(parent->parent())->screen()->devicePixelRatio();
-#endif
         pixmaps.cartridge.load("/cartridge%1.ico");
         pixmaps.cassette.load("/cassette%1.ico");
         pixmaps.floppy_disabled.normal = ProgSettings::loadIcon(QStringLiteral("/floppy_disabled.ico")).pixmap(pixmap_size);

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -129,7 +129,11 @@ main_thread_fn()
 }
 
 int main(int argc, char* argv[]) {
-    QApplication app(argc, argv);    
+    QApplication app(argc, argv);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    app.setAttribute(Qt::AA_UseHighDpiPixmaps);
+    app.setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
     qt_set_sequence_auto_mnemonic(false);
     Q_INIT_RESOURCE(qt_resources);
     Q_INIT_RESOURCE(qt_translations);

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -418,7 +418,6 @@ MainWindow::MainWindow(QWidget *parent) :
 
 #ifdef _WIN32
     ui->toolBar->setIconSize(QSize(16 * screen()->devicePixelRatio(), 16 * screen()->devicePixelRatio()));
-    ui->statusbar->resize(ui->statusbar->width(), ui->statusbar->sizeHint().height() * screen()->devicePixelRatio());
 #endif
 }
 
@@ -460,7 +459,7 @@ void MainWindow::showEvent(QShowEvent *event) {
     if (shownonce) return;
     shownonce = true;
     if (window_remember && !QApplication::platformName().contains("wayland")) {
-        setGeometry(window_x, window_y, window_w, window_h + menuBar()->height() + (hide_status_bar ? 0 : statusBar()->height()));
+        setGeometry(window_x, window_y, window_w, window_h + menuBar()->height() + (hide_status_bar ? 0 : statusBar()->height()) + (hide_tool_bar ? 0 : ui->toolBar->height()));
     }
     if (vid_resize == 2) {
         setFixedSize(fixed_size_x, fixed_size_y
@@ -471,8 +470,11 @@ void MainWindow::showEvent(QShowEvent *event) {
         scrnsz_x = fixed_size_x;
         scrnsz_y = fixed_size_y;
     }
-    else if (window_remember) {
-        emit resizeContents(window_w, window_h);
+    else if (window_remember && vid_resize == 1) {
+        resize(window_w, window_h
+               + menuBar()->height()
+               + (hide_status_bar ? 0 : statusBar()->height())
+               + (hide_tool_bar ? 0 : ui->toolBar->height()) + 1);
         scrnsz_x = window_w;
         scrnsz_y = window_h;
     }


### PR DESCRIPTION
Summary
=======
* Fix remember window option
* Status bar pixmaps are now scaled when building with Qt 5
* Force HiDPI scaling on UI for all platforms with Qt 5

Checklist
=========
* [X] Closes #2078 
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://doc.qt.io/qt-5/qt.html#ApplicationAttribute-enum
