### PR TITLE
qt: Set Application attributes before construction

### DIFF
--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -130,6 +130,7 @@ main_thread_fn()
 
 int main(int argc, char* argv[]) {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    QApplication::setAttribute(Qt::AA_DisableHighDpiScaling, false);
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -129,11 +129,11 @@ main_thread_fn()
 }
 
 int main(int argc, char* argv[]) {
-    QApplication app(argc, argv);
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    app.setAttribute(Qt::AA_UseHighDpiPixmaps);
-    app.setAttribute(Qt::AA_EnableHighDpiScaling);
+    QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
+    QApplication app(argc, argv);
     qt_set_sequence_auto_mnemonic(false);
     Q_INIT_RESOURCE(qt_resources);
     Q_INIT_RESOURCE(qt_translations);


### PR DESCRIPTION
Summary
=======
qt: Set Application attributes before construction

Enables HiDPI scaling for real.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
