### PR TITLE
Use external libslirp on Unix systems except macOS

### DIFF
--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -16,8 +16,12 @@
 add_library(net OBJECT network.c net_pcap.c net_slirp.c net_dp8390.c net_3c503.c
     net_ne2000.c net_pcnet.c net_wd8003.c net_plip.c)
 
-option(SLIRP_EXTERNAL "Link against the system-provided libslirp library" OFF)
-mark_as_advanced(SLIRP_EXTERNAL)
+if(NOT WIN32 AND NOT APPLE)
+    set(SLIRP_EXTERNAL 1)
+else()
+    option(SLIRP_EXTERNAL "Link against the system-provided libslirp library" OFF)
+    mark_as_advanced(SLIRP_EXTERNAL)
+endif()
 
 if(SLIRP_EXTERNAL)
     find_package(PkgConfig REQUIRED)


### PR DESCRIPTION
Summary
=======
Use external libslirp on Unix systems except macOS

It should hopefully fix networking with SLiRP mode on Linux.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
