### PR TITLE
qt: Fix toolbar hiding menu appearing on KDE when right-clicked on an empty space of the main menu bar

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -419,6 +419,7 @@ MainWindow::MainWindow(QWidget *parent) :
 #ifdef _WIN32
     ui->toolBar->setIconSize(QSize(16 * screen()->devicePixelRatio(), 16 * screen()->devicePixelRatio()));
 #endif
+    setContextMenuPolicy(Qt::PreventContextMenu);
 }
 
 void MainWindow::closeEvent(QCloseEvent *event) {


### PR DESCRIPTION
Summary
=======
qt: Fix toolbar hiding menu appearing on KDE when right-clicked on an empty space of the main menu bar.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
