### PR TITLE
qt: Only enlarge combo box dropdowns and not the combo box itself

### DIFF
--- a/src/qt/qt_styleoverride.cpp
+++ b/src/qt/qt_styleoverride.cpp
@@ -39,7 +39,7 @@ void StyleOverride::polish(QWidget* widget)
     if (widget->isWindow()) {
         if (widget->layout() && widget->minimumSize() == widget->maximumSize()) {
             if (widget->minimumSize().width() < widget->minimumSizeHint().width()
-		|| widget->minimumSize().height() < widget->minimumSizeHint().height()) {
+                || widget->minimumSize().height() < widget->minimumSizeHint().height()) {
                 widget->setFixedSize(QSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX));
                 widget->layout()->setSizeConstraint(QLayout::SetFixedSize);
             }
@@ -49,7 +49,6 @@ void StyleOverride::polish(QWidget* widget)
     }
 
     if (qobject_cast<QComboBox*>(widget)) {
-        widget->setMinimumWidth(widget->minimumSizeHint().width());
         qobject_cast<QComboBox*>(widget)->view()->setMinimumWidth(widget->minimumSizeHint().width());
     }
 }


### PR DESCRIPTION
Summary
=======
qt: Only enlarge combo box dropdowns and not the combo box itself.

Fixes combo box appearances on macOS.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
