### PR TITLE
Fix a compile-breaking typo in qt_progsettings.c

### DIFF
--- a/src/qt/qt_progsettings.cpp
+++ b/src/qt/qt_progsettings.cpp
@@ -122,7 +122,7 @@ void ProgSettings::accept()
     update_mouse_msg();
     main_window->ui->retranslateUi(main_window);
     QString vmname(vm_name);
-    if (vmname.at(vmnames.size() - 1) == "\"" || vmname.at(vmnames.size() - 1) == "'") vmname.truncate(vmname.size() - 1);
+    if (vmname.at(vmname.size() - 1) == "\"" || vmname.at(vmname.size() - 1) == "'") vmname.truncate(vmname.size() - 1);
     main_window->setWindowTitle(QString("%1 - %2 %3").arg(vmname, EMU_NAME, EMU_VERSION_FULL));
     QString msg = main_window->status->getMessage();
     main_window->status.reset(new MachineStatus(main_window));


### PR DESCRIPTION
Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
