### PR TITLE
qt: Set font immediately after QApplication initialization

### DIFF
--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -27,6 +27,7 @@
 #include <QDirIterator>
 #include <QLibraryInfo>
 #include <QString>
+#include <QFont>
 
 #ifdef QT_STATIC
 /* Static builds need plugin imports */

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -26,6 +26,7 @@
 #include <QTranslator>
 #include <QDirIterator>
 #include <QLibraryInfo>
+#include <QString>
 
 #ifdef QT_STATIC
 /* Static builds need plugin imports */
@@ -139,6 +140,11 @@ int main(int argc, char* argv[]) {
 #endif
     QApplication app(argc, argv);
     QLocale::setDefault(QLocale::C);
+#ifdef Q_OS_WINDOWS
+    auto font_name = QObject::tr("FONT_NAME");
+    auto font_size = QObject::tr("FONT_SIZE");
+    QApplication::setFont(QFont(font_name, font_size.toInt()));
+#endif
     qt_set_sequence_auto_mnemonic(false);
     Q_INIT_RESOURCE(qt_resources);
     Q_INIT_RESOURCE(qt_translations);


### PR DESCRIPTION
Summary
=======
qt: Set font immediately after QApplication initialization

Fixes Settings mode on Windows.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
