### PR TITLE
Qt fixes for 86BoxManager

### DIFF
--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -199,7 +199,11 @@ int main(int argc, char* argv[]) {
         QObject::connect(wmfilter.get(), &WindowsManagerFilter::showsettings, main_window, &MainWindow::showSettings);
         QObject::connect(wmfilter.get(), &WindowsManagerFilter::pause, main_window, &MainWindow::togglePause);
         QObject::connect(wmfilter.get(), &WindowsManagerFilter::reset, main_window, &MainWindow::hardReset);
-        QObject::connect(wmfilter.get(), &WindowsManagerFilter::shutdown, [](){ plat_power_off(); });
+        QObject::connect(wmfilter.get(), &WindowsManagerFilter::request_shutdown, main_window, &MainWindow::close);
+        QObject::connect(wmfilter.get(), &WindowsManagerFilter::force_shutdown, [](){
+            do_stop();
+            emit main_window->close();
+        });
         QObject::connect(wmfilter.get(), &WindowsManagerFilter::ctrlaltdel, [](){ pc_send_cad(); });
         QObject::connect(wmfilter.get(), &WindowsManagerFilter::dialogstatus, [main_hwnd](bool open){
             PostMessage((HWND)(uintptr_t)source_hwnd, WM_SENDDLGSTATUS, (WPARAM)(open ? 1 : 0), (LPARAM)main_hwnd);

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -67,6 +67,10 @@ extern "C" {
 #include <array>
 #include <unordered_map>
 
+#ifdef Q_OS_WINDOWS
+#include <Shobjidl.h>
+#endif
+
 #include "qt_settings.hpp"
 #include "qt_machinestatus.hpp"
 #include "qt_mediamenu.hpp"
@@ -90,6 +94,8 @@ MainWindow::MainWindow(QWidget *parent) :
     ui(new Ui::MainWindow)
 {
 #ifdef Q_OS_WINDOWS
+    SetCurrentProcessExplicitAppUserModelID(L"86Box.86Box");
+
     auto font_name = tr("FONT_NAME");
     auto font_size = tr("FONT_SIZE");
     QApplication::setFont(QFont(font_name, font_size.toInt()));

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -40,6 +40,8 @@ extern "C" {
 #include <86box/vid_ega.h>
 #include <86box/version.h>
 
+    extern int qt_nvr_save(void);
+
 #ifdef MTR_ENABLED
 #include <minitrace/minitrace.h>
 #endif
@@ -419,7 +421,7 @@ MainWindow::MainWindow(QWidget *parent) :
 }
 
 void MainWindow::closeEvent(QCloseEvent *event) {
-    if (confirm_exit && cpu_thread_run)
+    if (confirm_exit && confirm_exit_cmdl && cpu_thread_run)
     {
         QMessageBox questionbox(QMessageBox::Icon::Question, "86Box", tr("Are you sure you want to exit 86Box?"), QMessageBox::Yes | QMessageBox::No, this);
         QCheckBox *chkbox = new QCheckBox(tr("Don't show this message again"));
@@ -444,6 +446,7 @@ void MainWindow::closeEvent(QCloseEvent *event) {
             window_y = this->geometry().y();
         }
     }
+    qt_nvr_save();
     config_save();
     event->accept();
 }

--- a/src/qt/qt_winmanagerfilter.cpp
+++ b/src/qt/qt_winmanagerfilter.cpp
@@ -12,20 +12,6 @@
  *      Teemu Korhonen
  * 
  *      Copyright 2022 Teemu Korhonen
- * 
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
 #include "qt_winmanagerfilter.hpp"
@@ -51,7 +37,10 @@ bool WindowsManagerFilter::nativeEventFilter(const QByteArray &eventType, void *
                 emit reset();
                 return true;
             case WM_SHUTDOWN:
-                emit shutdown();
+                if (msg->wParam == 1)
+                    emit force_shutdown();
+                else
+                    emit request_shutdown();
                 return true;
             case WM_CTRLALTDEL:
                 emit ctrlaltdel();

--- a/src/qt/qt_winmanagerfilter.hpp
+++ b/src/qt/qt_winmanagerfilter.hpp
@@ -12,20 +12,6 @@
  *      Teemu Korhonen
  * 
  *      Copyright 2022 Teemu Korhonen
- * 
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
 #ifndef QT_WINDOWSMANAGERFILTER_HPP
@@ -58,7 +44,8 @@ signals:
     void ctrlaltdel();
     void showsettings();
     void reset();
-    void shutdown();
+    void request_shutdown();
+    void force_shutdown();
     void dialogstatus(bool open);
 
 protected:


### PR DESCRIPTION
Summary
=======
Fixes and unifies shutdown behavior when initiated by 86BoxManager.
Add implementation for -N command line switch.
Save NVR on close.
Fix taskbar grouping with 86BoxManager.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
