### PR TITLE
Disable excessive GH Actions builds

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,10 +35,10 @@ jobs:
       fail-fast: true
       matrix:
         build:
-        - name: Regular ODR
-          slug: -ODR
-          preset: regular
-          target: install/strip
+#        - name: Regular ODR
+#          slug: -ODR
+#          preset: regular
+#          target: install/strip
         - name: Debug ODR
           slug: -ODR-Debug
           preset: debug
@@ -47,10 +47,10 @@ jobs:
           slug: -ODR-Dev
           preset: experimental
           target: install
-        - name: Regular NDR
-          slug: -NDR
-          preset: regularndr
-          target: install/strip
+#        - name: Regular NDR
+#          slug: -NDR
+#          preset: regularndr
+#          target: install/strip
         - name: Debug NDR
           slug: -NDR-Debug
           preset: debugndr
@@ -114,12 +114,12 @@ jobs:
       fail-fast: true
       matrix:
         build:
-        - name: Regular ODR
-          slug: -ODR
-          type: Release
-          dev-build: off
-          new-dynarec: off
-          strip: --strip
+#        - name: Regular ODR
+#          slug: -ODR
+#          type: Release
+#          dev-build: off
+#          new-dynarec: off
+#          strip: --strip
         - name: Debug ODR
           slug: -ODR-Debug
           type: Debug
@@ -130,12 +130,12 @@ jobs:
           type: Debug
           dev-build: on
           new-dynarec: off
-        - name: Regular NDR
-          slug: -NDR
-          type: Release
-          strip: --strip
-          dev-build: off
-          new-dynarec: on
+#        - name: Regular NDR
+#          slug: -NDR
+#          type: Release
+#          strip: --strip
+#          dev-build: off
+#          new-dynarec: on
         - name: Debug NDR
           slug: -NDR-Debug
           type: Debug
@@ -210,18 +210,18 @@ jobs:
   linux:
     name: "Linux GCC 11 (${{ matrix.build.name }} x86_64)"
 
-    runs-on: ubuntu-2004
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: true
       matrix:
         build:
-        - name: Regular ODR
-          slug: -ODR
-          type: Release
-          dev-build: off
-          new-dynarec: off
-          strip: --strip
+#        - name: Regular ODR
+#          slug: -ODR
+#          type: Release
+#          dev-build: off
+#          new-dynarec: off
+#          strip: --strip
         - name: Debug ODR
           slug: -ODR-Debug
           type: Debug
@@ -232,12 +232,12 @@ jobs:
           type: Debug
           dev-build: on
           new-dynarec: off
-        - name: Regular NDR
-          slug: -NDR
-          type: Release
-          strip: --strip
-          dev-build: off
-          new-dynarec: on
+#        - name: Regular NDR
+#          slug: -NDR
+#          type: Release
+#          strip: --strip
+#          dev-build: off
+#          new-dynarec: on
         - name: Debug NDR
           slug: -NDR-Debug
           type: Debug
@@ -280,12 +280,12 @@ jobs:
       fail-fast: true
       matrix:
         build:
-        - name: Regular ODR
-          slug: -ODR
-          type: Release
-          dev-build: off
-          new-dynarec: off
-          strip: --strip
+#        - name: Regular ODR
+#          slug: -ODR
+#          type: Release
+#          dev-build: off
+#          new-dynarec: off
+#          strip: --strip
         - name: Debug ODR
           slug: -ODR-Debug
           type: Debug
@@ -296,12 +296,12 @@ jobs:
           type: Debug
           dev-build: on
           new-dynarec: off
-        - name: Regular NDR
-          slug: -NDR
-          type: Release
-          strip: --strip
-          dev-build: off
-          new-dynarec: on
+#        - name: Regular NDR
+#          slug: -NDR
+#          type: Release
+#          strip: --strip
+#          dev-build: off
+#          new-dynarec: on
         - name: Debug NDR
           slug: -NDR-Debug
           type: Debug


### PR DESCRIPTION
Summary
=======
Disable stable building on github actions, it doesn't provide any benefit and people should be using the ci builds, not actions builds anyway, they just slow down actions building. Left them in incase they're needed in future though.
Fix silly derp and restore linux actions building again.

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
