### PR TITLE
qt: Add Unix manager support (client-side interface)

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -20,7 +20,7 @@ if(QT_STATIC AND MINGW)
 endif()
 
 find_package(Threads REQUIRED)
-find_package(Qt${QT_MAJOR} COMPONENTS Core Widgets OpenGL REQUIRED)
+find_package(Qt${QT_MAJOR} COMPONENTS Core Widgets Network OpenGL REQUIRED)
 find_package(Qt${QT_MAJOR}LinguistTools REQUIRED)
 
 add_library(plat STATIC
@@ -127,6 +127,9 @@ add_library(ui STATIC
     qt_util.hpp
     qt_util.cpp
 
+    qt_unixmanagerfilter.cpp
+    qt_unixmanagerfilter.hpp
+
     ../qt_resources.qrc
 )
 
@@ -176,6 +179,7 @@ target_link_libraries(
     PRIVATE
     Qt${QT_MAJOR}::Widgets
     Qt${QT_MAJOR}::Gui
+    Qt${QT_MAJOR}::Network
     Threads::Threads
 )
 
@@ -185,6 +189,7 @@ target_link_libraries(
     Qt${QT_MAJOR}::Widgets
     Qt${QT_MAJOR}::Gui
     Qt${QT_MAJOR}::OpenGL
+    Qt${QT_MAJOR}::Network
     Threads::Threads
 )
 

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -65,7 +65,7 @@ extern "C"
 #include "qt_settings.hpp"
 #include "cocoa_mouse.hpp"
 #include "qt_styleoverride.hpp"
-
+#include "qt_unixmanagerfilter.hpp"
 
 // Void Cast
 #define VC(x) const_cast<wchar_t*>(x)
@@ -238,6 +238,11 @@ int main(int argc, char* argv[]) {
     }
 #endif
 
+    UnixManagerSocket socket;
+    if (qgetenv("86BOX_MANAGER_SOCKET").size())
+    {
+        socket.connectToServer(qgetenv("86BOX_MANAGER_SOCKET"));
+    }
     pc_reset_hard_init();
 
     /* Set the PAUSE mode depending on the renderer. */
@@ -272,5 +277,6 @@ int main(int argc, char* argv[]) {
     cpu_thread_run = 0;
     main_thread.join();
 
+    socket.close();
     return ret;
 }

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -32,6 +32,7 @@
 #include <QTemporaryFile>
 #include <QCoreApplication>
 #include <QDateTime>
+#include <QLocalSocket>
 
 #include <QLibrary>
 #include <QElapsedTimer>

--- a/src/qt/qt_unixmanagerfilter.cpp
+++ b/src/qt/qt_unixmanagerfilter.cpp
@@ -1,0 +1,79 @@
+/*
+ * 86Box A hypervisor and IBM PC system emulator that specializes in
+ *      running old operating systems and software designed for IBM
+ *      PC systems and compatibles from 1981 through fairly recent
+ *      system designs based on the PCI bus.
+ *
+ *      This file is part of the 86Box distribution.
+ *
+ *      Source file for Unix VM-managers (client-side)
+ *
+ * Authors:
+ *      Teemu Korhonen
+    Cacodemon345
+ *
+ *      Copyright 2022 Teemu Korhonen
+ *      Copyright 2022 Cacodemon345
+ */
+
+#include "qt_unixmanagerfilter.hpp"
+
+UnixManagerSocket::UnixManagerSocket(QObject* obj)
+    : QLocalSocket(obj)
+{
+    connect(this, &QLocalSocket::readyRead, this, &UnixManagerSocket::readyToRead);
+}
+
+void UnixManagerSocket::readyToRead()
+{
+    if (canReadLine())
+    {
+        QByteArray line = readLine();
+        if (line.size())
+        {
+            line.resize(line.size() - 2);
+            line.push_back((unsigned char)0);
+            if (line == "showsettings")
+            {
+                emit showsettings();
+            }
+            else if (line == "pause")
+            {
+                emit pause();
+            }
+            else if (line == "cad")
+            {
+                emit ctrlaltdel();
+            }
+            else if (line == "reset")
+            {
+                emit resetVM();
+            }
+            else if (line == "shutdownnoprompt")
+            {
+                emit force_shutdown();
+            }
+            else if (line == "shutdown")
+            {
+                emit request_shutdown();
+            }
+        }
+    }
+}
+
+bool UnixManagerSocket::eventFilter(QObject *obj, QEvent *event)
+{
+    if (state() == QLocalSocket::ConnectedState)
+    {
+        if (event->type() == QEvent::WindowBlocked)
+        {
+            write(QByteArray{"1"});
+        }
+        else if (event->type() == QEvent::WindowUnblocked)
+        {
+            write(QByteArray{"0"});
+        }
+    }
+
+    return QObject::eventFilter(obj, event);
+}

--- a/src/qt/qt_unixmanagerfilter.hpp
+++ b/src/qt/qt_unixmanagerfilter.hpp
@@ -1,0 +1,50 @@
+/*
+ * 86Box A hypervisor and IBM PC system emulator that specializes in
+ *      running old operating systems and software designed for IBM
+ *      PC systems and compatibles from 1981 through fairly recent
+ *      system designs based on the PCI bus.
+ *
+ *      This file is part of the 86Box distribution.
+ *
+ *      Header file for Unix VM-managers (client-side)
+ *
+ * Authors:
+ *      Teemu Korhonen
+	Cacodemon345
+ *
+ *      Copyright 2022 Teemu Korhonen
+ *      Copyright 2022 Cacodemon345
+ */
+
+#ifndef QT_UNIXMANAGERFILTER_HPP
+#define QT_UNIXMANAGERFILTER_HPP
+
+#include <QObject>
+#include <QLocalSocket>
+#include <QEvent>
+
+/*
+ * Filters messages from VM-manager and
+ * window blocked events to notify about open modal dialogs.
+ */
+class UnixManagerSocket : public QLocalSocket
+{
+    Q_OBJECT
+public:
+    UnixManagerSocket(QObject* object = nullptr);
+signals:
+    void pause();
+    void ctrlaltdel();
+    void showsettings();
+    void resetVM();
+    void request_shutdown();
+    void force_shutdown();
+    void dialogstatus(bool open);
+
+protected:
+    bool eventFilter(QObject *obj, QEvent *event) override;
+protected slots:
+    void readyToRead();
+};
+
+#endif


### PR DESCRIPTION
Summary
=======
qt: Add Unix manager support (client-side interface)

This should bring Qt closer to feature parity with Windows.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
