### PR TITLE
Added length checks to the t128 scsi dma read/write initialization (n…

### DIFF
--- a/src/scsi/scsi_ncr5380.c
+++ b/src/scsi/scsi_ncr5380.c
@@ -657,14 +657,16 @@ ncr_write(uint16_t port, uint8_t val, void *priv)
 		/*a Write 6/10 has occurred, start the timer when the block count is loaded*/
 		ncr->dma_mode = DMA_SEND;
 		if (ncr_dev->type == 3) {
-			memset(ncr_dev->t128.buffer, 0, MIN(512, dev->buffer_length));
+			if (dev->buffer_length > 0) {
+				memset(ncr_dev->t128.buffer, 0, MIN(512, dev->buffer_length));
 
-			ncr_log("DMA send timer start, enabled? = %i\n", timer_is_enabled(&ncr_dev->timer));
-			ncr_dev->t128.block_count = dev->buffer_length >> 9;
-			ncr_dev->t128.block_loaded = 1;
+				ncr_log("DMA send timer start, enabled? = %i\n", timer_is_enabled(&ncr_dev->timer));
+				ncr_dev->t128.block_count = dev->buffer_length >> 9;
+				ncr_dev->t128.block_loaded = 1;
 
-			ncr_dev->t128.host_pos = 0;
-			ncr_dev->t128.status |= 0x04;
+				ncr_dev->t128.host_pos = 0;
+				ncr_dev->t128.status |= 0x04;
+			}
 		} else {
 			if ((ncr->mode & MODE_DMA) && !timer_is_enabled(&ncr_dev->timer)) {
 				memset(ncr_dev->buffer, 0, MIN(128, dev->buffer_length));
@@ -680,19 +682,21 @@ ncr_write(uint16_t port, uint8_t val, void *priv)
 		/*a Read 6/10 has occurred, start the timer when the block count is loaded*/
 		ncr->dma_mode = DMA_INITIATOR_RECEIVE;
 		if (ncr_dev->type == 3) {
-			ncr_log("DMA receive timer start, enabled? = %i, cdb[0] = %02x\n", timer_is_enabled(&ncr_dev->timer), ncr->command[0]);
-			memset(ncr_dev->t128.buffer, 0, MIN(512, dev->buffer_length));
+			ncr_log("DMA receive timer start, enabled? = %i, cdb[0] = %02x, buflen = %i\n", timer_is_enabled(&ncr_dev->timer), ncr->command[0], dev->buffer_length);
+			if (dev->buffer_length > 0) {
+				memset(ncr_dev->t128.buffer, 0, MIN(512, dev->buffer_length));
 
-			ncr_dev->t128.block_count = dev->buffer_length >> 9;
+				ncr_dev->t128.block_count = dev->buffer_length >> 9;
 
-			if (dev->buffer_length < 512)
-				ncr_dev->t128.block_count = 1;
+				if (dev->buffer_length < 512)
+					ncr_dev->t128.block_count = 1;
 
-			ncr_dev->t128.block_loaded = 1;
+				ncr_dev->t128.block_loaded = 1;
 
-			ncr_dev->t128.host_pos = MIN(512, dev->buffer_length);
-			ncr_dev->t128.status |= 0x04;
-			timer_on_auto(&ncr_dev->timer, 0.02);
+				ncr_dev->t128.host_pos = MIN(512, dev->buffer_length);
+				ncr_dev->t128.status |= 0x04;
+				timer_on_auto(&ncr_dev->timer, 0.02);
+			}
 		} else {
 			if ((ncr->mode & MODE_DMA) && !timer_is_enabled(&ncr_dev->timer)) {
 				memset(ncr_dev->buffer, 0, MIN(128, dev->buffer_length));


### PR DESCRIPTION
…cr_write), fixes crashes when length is below 0.

Summary
=======
See above.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
