### PR TITLE
qt: XT IDE should be XTA

### DIFF
--- a/src/qt/qt_harddiskdialog.cpp
+++ b/src/qt/qt_harddiskdialog.cpp
@@ -705,6 +705,7 @@ void HarddiskDialog::on_comboBoxBus_currentIndexChanged(int index) {
             break;
     }
 
+    if (chanIdx == 0xFF) chanIdx = 0;
     ui->comboBoxChannel->setCurrentIndex(chanIdx);
 }
 

--- a/src/qt/qt_harddrive_common.cpp
+++ b/src/qt/qt_harddrive_common.cpp
@@ -28,7 +28,7 @@ void Harddrives::populateBuses(QAbstractItemModel *model) {
     model->removeRows(0, model->rowCount());
     model->insertRows(0, 6);
     model->setData(model->index(0, 0), "MFM/RLL");
-    model->setData(model->index(1, 0), "XT IDE");
+    model->setData(model->index(1, 0), "XTA");
     model->setData(model->index(2, 0), "ESDI");
     model->setData(model->index(3, 0), "IDE");
     model->setData(model->index(4, 0), "ATAPI");
@@ -97,7 +97,7 @@ QString Harddrives::BusChannelName(uint8_t bus, uint8_t channel) {
         busName = QString("MFM/RLL (%1:%2)").arg(channel >> 1).arg(channel & 1);
         break;
     case HDD_BUS_XTA:
-        busName = QString("XT IDE (%1:%2)").arg(channel >> 1).arg(channel & 1);
+        busName = QString("XTA (%1:%2)").arg(channel >> 1).arg(channel & 1);
         break;
     case HDD_BUS_ESDI:
         busName = QString("ESDI (%1:%2)").arg(channel >> 1).arg(channel & 1);

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -238,10 +238,12 @@ plat_path_abs(char *path)
 void
 plat_path_normalize(char* path)
 {
+#ifdef Q_OS_WINDOWS
     while (*path++ != 0)
     {
         if (*path == '\\') *path = '/';
     }
+#endif
 }
 
 void

--- a/src/sound/xaudio2.c
+++ b/src/sound/xaudio2.c
@@ -178,6 +178,7 @@ inital()
     }
 
     initialized = 1;
+    atexit(closeal);
 }
 
 void

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -285,10 +285,7 @@ plat_path_abs(char *path)
 void
 plat_path_normalize(char* path)
 {
-    while (*path++ != 0)
-    {
-        if (*path == '\\') *path = '/';
-    }
+    /* No-op. */
 }
 
 void


### PR DESCRIPTION
Summary
=======
* [qt: XT IDE should be XTA](https://github.com/86Box/86Box/commit/40a75379b7db93f2d595ebf4780a10ba243da9c5)
* [qt: Default to 0:0 if bus is full](https://github.com/86Box/86Box/commit/5e4cb50da0d5533cc171d604fbe42571f6f944c0)

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
