### PR TITLE
improve Finnish translation

### DIFF
--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -29,7 +29,7 @@ msgid "&Hide status bar"
 msgstr "&Piilota tilapalkki"
 
 msgid "Hide &toolbar"
-msgstr "Hide &toolbar"
+msgstr "Piilota &työkalupalkki"
 
 msgid "&Resizeable window"
 msgstr "&Salli koon muuttaminen"
@@ -38,7 +38,7 @@ msgid "R&emember size && position"
 msgstr "&Muista koko ja sijainti"
 
 msgid "Re&nderer"
-msgstr "&Renderöijä"
+msgstr "&Hahmonnin"
 
 msgid "&SDL (Software)"
 msgstr "&SDL (ohjelmistopohjainen)"
@@ -59,7 +59,7 @@ msgid "Specify dimensions..."
 msgstr "&Määritä koko..."
 
 msgid "F&orce 4:3 display ratio"
-msgstr "Pakota 4:3 näyttösuhde"
+msgstr "Pakota 4:3-näyttösuhde"
 
 msgid "&Window scale factor"
 msgstr "&Ikkunan kokokerroin"
@@ -107,19 +107,19 @@ msgid "&Integer scale"
 msgstr "&Kokonaislukuskaalaus"
 
 msgid "E&GA/(S)VGA settings"
-msgstr "&EGA/(S)VGA asetukset"
+msgstr "&EGA/(S)VGA-asetukset"
 
 msgid "&Inverted VGA monitor"
 msgstr "&VGA näyttö käänteisillä väreillä"
 
 msgid "VGA screen &type"
-msgstr "VGA näytön &tyyppi"
+msgstr "VGA-näytön &tyyppi"
 
 msgid "RGB &Color"
-msgstr "RGB &värit"
+msgstr "RGB, &värit"
 
 msgid "&RGB Grayscale"
-msgstr "&RGB harmaasävyinen"
+msgstr "&RGB, harmaasävy"
 
 msgid "&Amber monitor"
 msgstr "&Meripihkanvärinen"
@@ -143,16 +143,16 @@ msgid "&Average"
 msgstr "&Keskiarvo"
 
 msgid "CGA/PCjr/Tandy/E&GA/(S)VGA overscan"
-msgstr "CGA/PCjr/Tandy/E&GA/(S)VGA &yliskannaus"
+msgstr "CGA/PCjr/Tandy/E&GA/(S)VGA-&yliskannaus"
 
 msgid "Change contrast for &monochrome display"
 msgstr "&Muuta harmaavärinäytön kontrastia"
 
 msgid "&Media"
-msgstr "&Media"
+msgstr "&Levyt"
 
 msgid "&Tools"
-msgstr "&Työkalut"
+msgstr "Työ&kalut"
 
 msgid "&Settings..."
 msgstr "&Kokoonpano..."
@@ -167,10 +167,10 @@ msgid "&Preferences..."
 msgstr "&Sovellusasetukset..."
 
 msgid "Enable &Discord integration"
-msgstr "Käytä &Discord integraatiota"
+msgstr "Käytä &Discord-integraatiota"
 
 msgid "Sound &gain..."
-msgstr "&Äänen tulotaso..."
+msgstr "&Äänitasot..."
 
 msgid "Begin trace\tCtrl+T"
 msgstr "Aloita jäljitys\tCtrl+T"
@@ -182,19 +182,19 @@ msgid "&Help"
 msgstr "&Ohje"
 
 msgid "&Documentation..."
-msgstr "&Dokumentaatio..."
+msgstr "&Ohjekirja..."
 
 msgid "&About 86Box..."
-msgstr "&Tietoja 86Box:sta..."
+msgstr "&Tietoja 86Boxista..."
 
 msgid "&New image..."
-msgstr "&Uusi kasettikuva..."
+msgstr "&Uusi levykuva..."
 
 msgid "&Existing image..."
-msgstr "&Olemassaoleva kasettikuva..."
+msgstr "&Valmis levykuva..."
 
 msgid "Existing image (&Write-protected)..."
-msgstr "Olemassaoleva kasettikuva (&kirjoitussuojattu)..."
+msgstr "Valmis levykuva (&kirjoitussuojattu)..."
 
 msgid "&Record"
 msgstr "&Nauhoita"
@@ -209,7 +209,7 @@ msgid "&Fast forward to the end"
 msgstr "Kelaa &loppuun"
 
 msgid "E&ject"
-msgstr "&Poista kasettipesästä"
+msgstr "&Poista asemasta"
 
 msgid "&Image..."
 msgstr "&ROM-moduulikuva..."
@@ -251,7 +251,7 @@ msgid "&75 fps"
 msgstr "&75 ruutua/s"
 
 msgid "&VSync"
-msgstr "&VSync"
+msgstr "P&ystytahdistus"
 
 msgid "&Select shader..."
 msgstr "Valitse varjostin&ohjelma..."
@@ -263,7 +263,7 @@ msgid "Preferences"
 msgstr "Sovellusasetukset"
 
 msgid "Sound Gain"
-msgstr "Äänen tulotaso"
+msgstr "Äänen taso"
 
 msgid "New Image"
 msgstr "Uusi levykuva"
@@ -302,7 +302,7 @@ msgid "Disk size:"
 msgstr "Levyn koko:"
 
 msgid "RPM mode:"
-msgstr "RPM tila:"
+msgstr "Kierroslukutila:"
 
 msgid "Progress:"
 msgstr "Edistyminen:"
@@ -470,10 +470,10 @@ msgid "FD Controller:"
 msgstr "Levykeohjain:"
 
 msgid "Tertiary IDE Controller"
-msgstr "Tertinäärinen IDE-ohjain"
+msgstr "Kolmas IDE-ohjain"
 
 msgid "Quaternary IDE Controller"
-msgstr "Kvaternaarinen IDE-ohjain"
+msgstr "Neljäs IDE-ohjain"
 
 msgid "SCSI"
 msgstr "SCSI"
@@ -500,7 +500,7 @@ msgid "&New..."
 msgstr "&Uusi..."
 
 msgid "&Existing..."
-msgstr "&Olemassaoleva..."
+msgstr "&Valmis..."
 
 msgid "&Remove"
 msgstr "&Poista"
@@ -521,7 +521,7 @@ msgid "Sectors:"
 msgstr "Sektorit:"
 
 msgid "Heads:"
-msgstr "Päät:"
+msgstr "Lukupäät:"
 
 msgid "Cylinders:"
 msgstr "Sylinterit:"
@@ -599,7 +599,7 @@ msgid "Fatal error"
 msgstr "Vakava virhe"
 
 msgid " - PAUSED"
-msgstr " - PAUSED"
+msgstr " - TAUKO"
 
 msgid "Press Ctrl+Alt+PgDn to return to windowed mode."
 msgstr "Paina Ctrl+Alt+PgDn palataksesi ikkunoituun tilaan."
@@ -614,7 +614,7 @@ msgid "ZIP images"
 msgstr "ZIP-levykuvat"
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
-msgstr "86Box ei löytänyt käyttökelpoisia ROM-tiedostoja.\n\nVoit <a href=\"https://github.com/86Box/roms/releases/latest\">ladata</a> ROM-paketin ja purkaa sen \"roms\" hakemistoon."
+msgstr "86Box ei löytänyt käyttökelpoisia ROM-tiedostoja.\n\nVoit <a href=\"https://github.com/86Box/roms/releases/latest\">ladata</a> ROM-paketin ja purkaa sen \"roms\"-hakemistoon."
 
 msgid "(empty)"
 msgstr "(tyhjä)"
@@ -689,7 +689,7 @@ msgid "Press F8+F12 or middle button to release mouse"
 msgstr "Paina F8+F12 tai keskipainiketta vapauttaaksesi hiiren"
 
 msgid "Unable to initialize FluidSynth"
-msgstr "FluidSynth:in alustus epäonnistui"
+msgstr "FluidSynthin alustus epäonnistui"
 
 msgid "Bus"
 msgstr "Väylä"
@@ -710,7 +710,7 @@ msgid "KB"
 msgstr "kt"
 
 msgid "Could not initialize the video renderer."
-msgstr "Video-renderöijän alustus epäonnistui"
+msgstr "Videohahmontimen alustus epäonnistui"
 
 msgid "Default"
 msgstr "Oletus"
@@ -782,13 +782,13 @@ msgid "Unable to initialize SDL, SDL2.dll is required"
 msgstr "SDL:n alustus epäonnistui. Tarvitaan SDL2.dll"
 
 msgid "Are you sure you want to hard reset the emulated machine?"
-msgstr "Oletko varma, että haluat käynnistää emuloidun tietokoneen uudelleen?"
+msgstr "Haluatko varmasti käynnistää emuloidun tietokoneen uudelleen?"
 
 msgid "Are you sure you want to exit 86Box?"
-msgstr "Haluatko varmasti sulkea 86Box:in?"
+msgstr "Haluatko varmasti sulkea 86Boxin?"
 
 msgid "Unable to initialize Ghostscript"
-msgstr "Ghostscript:in alustus epäonnistui"
+msgstr "Ghostscriptin alustus epäonnistui"
 
 msgid "MO %i (%ls): %ls"
 msgstr "MO %i (%ls): %ls"
@@ -797,7 +797,7 @@ msgid "MO images"
 msgstr "MO-levykuvat"
 
 msgid "Welcome to 86Box!"
-msgstr "Tervetuloa 86Box:iin!"
+msgstr "Tervetuloa 86Boxiin!"
 
 msgid "Internal controller"
 msgstr "Sisäinen ohjain"
@@ -911,7 +911,7 @@ msgid "Cassette: %s"
 msgstr "Kasetti: %s"
 
 msgid "Cassette images"
-msgstr "Kasetti-tiedostot"
+msgstr "Kasettitiedostot"
 
 msgid "Cartridge %i: %ls"
 msgstr "ROM-moduuli %i: %ls"
@@ -920,28 +920,28 @@ msgid "Cartridge images"
 msgstr "ROM-moduulikuvat"
 
 msgid "Error initializing renderer"
-msgstr "Virhe renderöijän alustuksessa"
+msgstr "Virhe hahmontimen alustuksessa"
 
 msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "OpenGL (3.0 Core) renderöijän alustus epäonnistui. Käytä toista renderöijää."
+msgstr "OpenGL (3.0 Core) -hahmontimen alustus epäonnistui. Käytä toista hahmonninta."
 
 msgid "Resume execution"
-msgstr "Resume execution"
+msgstr "Jatka suoritusta"
 
 msgid "Pause execution"
-msgstr "Pause execution"
+msgstr "Pysäytä suoritus"
 
 msgid "Press Ctrl+Alt+Del"
-msgstr "Press Ctrl+Alt+Del"
+msgstr "Paina Ctrl+Alt+Del"
 
 msgid "Press Ctrl+Alt+Esc"
-msgstr "Press Ctrl+Alt+Esc"
+msgstr "Paina Ctrl+Alt+Esc"
 
 msgid "Hard reset"
-msgstr "Hard reset"
+msgstr "Kylmä uudelleenkäynnistys"
 
 msgid "ACPI shutdown"
-msgstr "ACPI shutdown"
+msgstr "ACPI-sammutus"
 
 msgid "Hard disk (%s)"
 msgstr "Kiintolevy (%s)"
@@ -953,7 +953,7 @@ msgid "%01i"
 msgstr "%01i"
 
 msgid "MFM/RLL or ESDI CD-ROM drives never existed"
-msgstr "MFM/RLL tai ESDI CD-ROM asemia ei ole koskaan ollut olemassa"
+msgstr "MFM/RLL- tai ESDI-CD-ROM-asemia ei ole koskaan ollut olemassa"
 
 msgid "Custom..."
 msgstr "Mukautettu..."
@@ -965,10 +965,10 @@ msgid "Add New Hard Disk"
 msgstr "Lisää uusi kiintolevy"
 
 msgid "Add Existing Hard Disk"
-msgstr "Lisää olemassaoleva kiintolevy"
+msgstr "Lisää valmis kiintolevy"
 
 msgid "HDI disk images cannot be larger than 4 GB."
-msgstr "HDI levykuvan suurin mahdollinen koko on 4 Gt."
+msgstr "HDI-levykuvan suurin mahdollinen koko on 4 Gt."
 
 msgid "Disk images cannot be larger than 127 GB."
 msgstr "Levykuvien suurin mahdollinen koko on 127 Gt."
@@ -1010,16 +1010,16 @@ msgid "Remember to partition and format the newly-created drive."
 msgstr "Muista osioida ja alustaa juuri luomasi asema."
 
 msgid "The selected file will be overwritten. Are you sure you want to use it?"
-msgstr "Valittu tiedosto ylikirjoitetaan. Oletko varma, että haluat käyttää sitä?"
+msgstr "Valittu tiedosto korvataan. Oletko varma, että haluat käyttää sitä?"
 
 msgid "Unsupported disk image"
-msgstr "Levynkuvaa ei tueta"
+msgstr "Levykuvaa ei tueta"
 
 msgid "Overwrite"
-msgstr "Ylikirjoita"
+msgstr "Korvaa"
 
 msgid "Don't overwrite"
-msgstr "Älä ylikirjoita"
+msgstr "Älä korvaa"
 
 msgid "Raw image (.img)"
 msgstr "Raaka levykuva (.img)"
@@ -1169,16 +1169,16 @@ msgid "5.25\" 1.3 GB"
 msgstr "5.25\" 1.3 Gt"
 
 msgid "Perfect RPM"
-msgstr "Täydellinen RPM"
+msgstr "Täydellinen kierrosluku"
 
 msgid "1% below perfect RPM"
-msgstr "1% alle täydellisen RPM:n"
+msgstr "1% alle täydellisen kierrosluvun"
 
 msgid "1.5% below perfect RPM"
-msgstr "1.5% alle täydellisen RPM:n"
+msgstr "1.5% alle täydellisen kierrosluvun"
 
 msgid "2% below perfect RPM"
-msgstr "2% alle täydellisen RPM:n"
+msgstr "2% alle täydellisen kierrosluvun"
 
 msgid "(System Default)"
 msgstr "(Järjestelmän oletus)"

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -38,7 +38,7 @@ msgid "R&emember size && position"
 msgstr "&Muista koko ja sijainti"
 
 msgid "Re&nderer"
-msgstr "&Hahmonnin"
+msgstr "&Renderöijä"
 
 msgid "&SDL (Software)"
 msgstr "&SDL (ohjelmistopohjainen)"
@@ -149,7 +149,7 @@ msgid "Change contrast for &monochrome display"
 msgstr "&Muuta harmaavärinäytön kontrastia"
 
 msgid "&Media"
-msgstr "&Levyt"
+msgstr "&Media"
 
 msgid "&Tools"
 msgstr "Työ&kalut"
@@ -191,10 +191,10 @@ msgid "&New image..."
 msgstr "&Uusi levykuva..."
 
 msgid "&Existing image..."
-msgstr "&Valmis levykuva..."
+msgstr "&Olemassaoleva levykuva..."
 
 msgid "Existing image (&Write-protected)..."
-msgstr "Valmis levykuva (&kirjoitussuojattu)..."
+msgstr "Olemassaoleva levykuva (&kirjoitussuojattu)..."
 
 msgid "&Record"
 msgstr "&Nauhoita"
@@ -251,7 +251,7 @@ msgid "&75 fps"
 msgstr "&75 ruutua/s"
 
 msgid "&VSync"
-msgstr "P&ystytahdistus"
+msgstr "&VSync"
 
 msgid "&Select shader..."
 msgstr "Valitse varjostin&ohjelma..."
@@ -500,7 +500,7 @@ msgid "&New..."
 msgstr "&Uusi..."
 
 msgid "&Existing..."
-msgstr "&Valmis..."
+msgstr "&Olemassaoleva..."
 
 msgid "&Remove"
 msgstr "&Poista"
@@ -710,7 +710,7 @@ msgid "KB"
 msgstr "kt"
 
 msgid "Could not initialize the video renderer."
-msgstr "Videohahmontimen alustus epäonnistui"
+msgstr "Videorenderöijän alustus epäonnistui"
 
 msgid "Default"
 msgstr "Oletus"
@@ -920,10 +920,10 @@ msgid "Cartridge images"
 msgstr "ROM-moduulikuvat"
 
 msgid "Error initializing renderer"
-msgstr "Virhe hahmontimen alustuksessa"
+msgstr "Virhe renderöijän alustuksessa"
 
 msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "OpenGL (3.0 Core) -hahmontimen alustus epäonnistui. Käytä toista hahmonninta."
+msgstr "OpenGL (3.0 Core) -renderöijän alustus epäonnistui. Käytä toista renderöijää."
 
 msgid "Resume execution"
 msgstr "Jatka suoritusta"
@@ -965,7 +965,7 @@ msgid "Add New Hard Disk"
 msgstr "Lisää uusi kiintolevy"
 
 msgid "Add Existing Hard Disk"
-msgstr "Lisää valmis kiintolevy"
+msgstr "Lisää olemassaoleva kiintolevy"
 
 msgid "HDI disk images cannot be larger than 4 GB."
 msgstr "HDI-levykuvan suurin mahdollinen koko on 4 Gt."

--- a/src/win/languages/fi-FI.rc
+++ b/src/win/languages/fi-FI.rc
@@ -32,12 +32,12 @@ BEGIN
     POPUP "&Näytä"
     BEGIN
         MENUITEM "&Piilota tilapalkki",                                 IDM_VID_HIDE_STATUS_BAR
-        MENUITEM "Hide &toolbar",                                       IDM_VID_HIDE_TOOLBAR
+        MENUITEM "Piilota &työkalupalkki",                              IDM_VID_HIDE_TOOLBAR
         MENUITEM SEPARATOR
         MENUITEM "&Salli koon muuttaminen",                             IDM_VID_RESIZE
         MENUITEM "&Muista koko ja sijainti",                            IDM_VID_REMEMBER
         MENUITEM SEPARATOR
-        POPUP "&Renderöijä"
+        POPUP "&Hahmonnin"
         BEGIN
             MENUITEM "&SDL (ohjelmistopohjainen)",                      IDM_VID_SDL_SW
             MENUITEM "SDL (&laitteistokiihdytetty)",                    IDM_VID_SDL_HW
@@ -49,7 +49,7 @@ BEGIN
         END
         MENUITEM SEPARATOR
         MENUITEM "&Määritä koko...",                                    IDM_VID_SPECIFY_DIM
-        MENUITEM "Pakota 4:3 näyttösuhde",                              IDM_VID_FORCE43
+        MENUITEM "Pakota 4:3-näyttösuhde",                              IDM_VID_FORCE43
         POPUP "&Ikkunan kokokerroin"
         BEGIN
             MENUITEM "&0.5x",                                           IDM_VID_SCALE_1X
@@ -72,13 +72,13 @@ BEGIN
             MENUITEM "&Tasasivuiset kuvapisteet (säilytä kuvasuhde)",   IDM_VID_FS_KEEPRATIO
             MENUITEM "&Kokonaislukuskaalaus",                           IDM_VID_FS_INT
         END
-        POPUP "&EGA/(S)VGA asetukset"
+        POPUP "&EGA/(S)VGA-asetukset"
         BEGIN
-            MENUITEM "&VGA näyttö käänteisillä väreillä",               IDM_VID_INVERT
-            POPUP "VGA näytön &tyyppi"
+            MENUITEM "&VGA-näyttö käänteisillä väreillä",               IDM_VID_INVERT
+            POPUP "VGA-näytön &tyyppi"
             BEGIN
-                MENUITEM "RGB &värit",                                  IDM_VID_GRAY_RGB
-                MENUITEM "&RGB harmaasävyinen",                         IDM_VID_GRAY_MONO
+                MENUITEM "RGB, &värit",                                 IDM_VID_GRAY_RGB
+                MENUITEM "&RGB, harmaasävy",                            IDM_VID_GRAY_MONO
                 MENUITEM "&Meripihkanvärinen",                          IDM_VID_GRAY_AMBER
                 MENUITEM "V&ihreä",                                     IDM_VID_GRAY_GREEN
                 MENUITEM "V&alkoinen",                                  IDM_VID_GRAY_WHITE
@@ -94,8 +94,8 @@ BEGIN
         MENUITEM "CGA/PCjr/Tandy/E&GA/(S)VGA &yliskannaus",             IDM_VID_OVERSCAN
         MENUITEM "&Muuta harmaavärinäytön kontrastia",                  IDM_VID_CGACON
     END
-    MENUITEM "&Media",                                                  IDM_MEDIA
-    POPUP "&Työkalut"
+    MENUITEM "&Levyt",                                                  IDM_MEDIA
+    POPUP "Työ&kalut"
     BEGIN
         MENUITEM "&Kokoonpano...",                                      IDM_CONFIG
         MENUITEM "&Päivitä tilapalkin kuvakkeita",                      IDM_UPDATE_ICONS
@@ -103,9 +103,9 @@ BEGIN
         MENUITEM "Ota &kuvakaappaus\tCtrl+F11",                         IDM_ACTION_SCREENSHOT
         MENUITEM SEPARATOR
         MENUITEM "&Sovellusasetukset...",                               IDM_PREFERENCES
-        MENUITEM "Käytä &Discord integraatiota",                        IDM_DISCORD
+        MENUITEM "Käytä &Discord-integraatiota",                        IDM_DISCORD
         MENUITEM SEPARATOR
-        MENUITEM "&Äänen tulotaso...",                                  IDM_SND_GAIN
+        MENUITEM "&Äänitasot...",                                       IDM_SND_GAIN
 #ifdef MTR_ENABLED
         MENUITEM SEPARATOR
         MENUITEM "Aloita jäljitys\tCtrl+T",                             IDM_ACTION_BEGIN_TRACE
@@ -114,8 +114,8 @@ BEGIN
     END
     POPUP "&Ohje"
     BEGIN
-        MENUITEM "&Dokumentaatio...",                                   IDM_DOCS
-        MENUITEM "&Tietoja 86Box:sta...",                               IDM_ABOUT
+        MENUITEM "&Ohjekirja...",                                       IDM_DOCS
+        MENUITEM "&Tietoja 86Boxista...",                               IDM_ABOUT
     END
 END
 
@@ -130,8 +130,8 @@ BEGIN
     BEGIN
         MENUITEM "&Uusi kasettikuva...",                                IDM_CASSETTE_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Olemassaoleva kasettikuva...",                       IDM_CASSETTE_IMAGE_EXISTING
-        MENUITEM "Olemassaoleva kasettikuva (&kirjoitussuojattu)...",   IDM_CASSETTE_IMAGE_EXISTING_WP
+        MENUITEM "&Valmis kasettikuva...",                              IDM_CASSETTE_IMAGE_EXISTING
+        MENUITEM "Valmis kasettikuva (&kirjoitussuojattu)...",          IDM_CASSETTE_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
         MENUITEM "&Nauhoita",                                           IDM_CASSETTE_RECORD
         MENUITEM "&Toista",                                             IDM_CASSETTE_PLAY
@@ -158,8 +158,8 @@ BEGIN
     BEGIN
         MENUITEM "&Uusi levykekuva...",                                 IDM_FLOPPY_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Olemassaoleva levykekuva...",                        IDM_FLOPPY_IMAGE_EXISTING
-        MENUITEM "Olemassaoleva levykekuva (&kirjoitussuojattu)...",    IDM_FLOPPY_IMAGE_EXISTING_WP
+        MENUITEM "&Valmis levykekuva...",                               IDM_FLOPPY_IMAGE_EXISTING
+        MENUITEM "Valmis levykekuva (&kirjoitussuojattu)...",           IDM_FLOPPY_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
         MENUITEM "&Vie 86F-tiedostoon...",                              IDM_FLOPPY_EXPORT_TO_86F
         MENUITEM SEPARATOR
@@ -186,8 +186,8 @@ BEGIN
     BEGIN
         MENUITEM "&Uusi levykuva...",                                   IDM_ZIP_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Olemassaoleva levykuva...",                          IDM_ZIP_IMAGE_EXISTING
-        MENUITEM "Olemassaoleva levykuva (&kirjoitussuojattu)...",      IDM_ZIP_IMAGE_EXISTING_WP
+        MENUITEM "&Valmis levykuva...",                                 IDM_ZIP_IMAGE_EXISTING
+        MENUITEM "Valmis levykuva (&kirjoitussuojattu)...",             IDM_ZIP_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
         MENUITEM "&Poista asemasta",                                    IDM_ZIP_EJECT
         MENUITEM "&Lataa edellinen levykuva uudelleen",                 IDM_ZIP_RELOAD
@@ -200,8 +200,8 @@ BEGIN
     BEGIN
         MENUITEM "&Uusi levykuva...",                                   IDM_MO_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Olemassaoleva levykuva...",                          IDM_MO_IMAGE_EXISTING
-        MENUITEM "Olemassaoleva levykuva (&kirjoitussuojattu)...",      IDM_MO_IMAGE_EXISTING_WP
+        MENUITEM "&Valmis levykuva...",                                 IDM_MO_IMAGE_EXISTING
+        MENUITEM "Valmis levykuva (&kirjoitussuojattu)...",             IDM_MO_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
         MENUITEM "&Poista asemasta",                                    IDM_MO_EJECT
         MENUITEM "&Lataa edellinen levykuva uudelleen",                 IDM_MO_RELOAD
@@ -219,7 +219,7 @@ BEGIN
         MENUITEM "&60 ruutua/s",                IDM_VID_GL_FPS_60
         MENUITEM "&75 ruutua/s",                IDM_VID_GL_FPS_75
     END
-    MENUITEM "&VSync", IDM_VID_GL_VSYNC
+    MENUITEM "P&ystytahdistus",                 IDM_VID_GL_VSYNC
     MENUITEM "Valitse varjostin&ohjelma...",    IDM_VID_GL_SHADER
     MENUITEM "&Poista varjostinohjelma",        IDM_VID_GL_NOSHADER
 END
@@ -231,7 +231,7 @@ END
 //
 
 #define STR_PREFERENCES     "Sovellusasetukset"
-#define STR_SND_GAIN        "Äänen tulotaso"
+#define STR_SND_GAIN        "Äänen taso"
 #define STR_NEW_FLOPPY      "Uusi levykuva"
 #define STR_CONFIG          "Kokoonpano"
 #define STR_SPECIFY_DIM     "Määritä pääikkunan koko"
@@ -247,7 +247,7 @@ END
 
 #define STR_FILE_NAME       "Tiedostonimi:"
 #define STR_DISK_SIZE       "Levyn koko:"
-#define STR_RPM_MODE        "RPM tila:"
+#define STR_RPM_MODE        "Kierroslukutila:"
 #define STR_PROGRESS        "Edistyminen:"
 
 #define STR_WIDTH           "Leveys:"
@@ -311,8 +311,8 @@ END
 
 #define STR_HDC             "Kiintolevyohjain:"
 #define STR_FDC             "Levykeohjain:"
-#define STR_IDE_TER         "Tertinäärinen IDE-ohjain"
-#define STR_IDE_QUA         "Kvaternaarinen IDE-ohjain"
+#define STR_IDE_TER         "Kolmas IDE-ohjain"
+#define STR_IDE_QUA         "Neljäs IDE-ohjain"
 #define STR_SCSI            "SCSI"
 #define STR_SCSI_1          "Ohjain 1:"
 #define STR_SCSI_2          "Ohjain 2:"
@@ -330,7 +330,7 @@ END
 
 #define STR_SPECIFY         "&Määritä..."
 #define STR_SECTORS         "Sektorit:"
-#define STR_HEADS           "Päät:"
+#define STR_HEADS           "Lukupäät:"
 #define STR_CYLS            "Sylinterit:"
 #define STR_SIZE_MB         "Koko (Mt):"
 #define STR_TYPE            "Tyyppi:"
@@ -341,7 +341,7 @@ END
 #define STR_TURBO           "Turbo-ajoitukset"
 #define STR_CHECKBPB        "Tarkista BPB"
 #define STR_CDROM_DRIVES    "CD-ROM-asemat:"
-#define STR_CD_SPEED       "Nopeus:"
+#define STR_CD_SPEED        "Nopeus:"
 
 #define STR_MO_DRIVES       "Magneettisoptiset asemat (MO):"
 #define STR_ZIP_DRIVES      "ZIP-asemat:"
@@ -371,12 +371,12 @@ BEGIN
     2048    "86Box"
     IDS_2049    "Virhe"
     IDS_2050    "Vakava virhe"
-    IDS_2051    " - PAUSED"
+    IDS_2051    " - TAUKO"
     IDS_2052    "Paina Ctrl+Alt+PgDn palataksesi ikkunoituun tilaan."
     IDS_2053    "Nopeus"
     IDS_2054    "ZIP %03i %i (%s): %ls"
     IDS_2055    "ZIP-levykuvat (*.IM?;*.ZDI)\0*.IM?;*.ZDI\0"
-    IDS_2056    "86Box ei löytänyt käyttökelpoisia ROM-tiedostoja.\n\nVoit <a href=""https://github.com/86Box/roms/releases/latest"">ladata</a> ROM-paketin ja purkaa sen ""roms"" hakemistoon."
+    IDS_2056    "86Box ei löytänyt käyttökelpoisia ROM-tiedostoja.\n\nVoit <a href=""https://github.com/86Box/roms/releases/latest"">ladata</a> ROM-paketin ja purkaa sen ""roms""-hakemistoon."
     IDS_2057    "(tyhjä)"
     IDS_2058    "ZIP-levykuvat (*.IM?;*.ZDI)\0*.IM?;*.ZDI\0Kaikki tiedostot (*.*)\0*.*\0"
     IDS_2059    "Turbo"
@@ -408,7 +408,7 @@ END
 
 STRINGTABLE DISCARDABLE
 BEGIN
-    IDS_2080    "FluidSynth:in alustus epäonnistui"
+    IDS_2080    "FluidSynthin alustus epäonnistui"
     IDS_2081    "Väylä"
     IDS_2082    "Tiedosto"
     IDS_2083    "C"
@@ -417,7 +417,7 @@ BEGIN
     IDS_2086    "Mt"
     IDS_2087    "Tarkista BPB"
     IDS_2088    "kt"
-    IDS_2089    "Video-renderöijän alustus epäonnistui"
+    IDS_2089    "Videohahmontimen alustus epäonnistui"
     IDS_2090    "Oletus"
     IDS_2091    "%i odotustilaa"
     IDS_2092    "Tyyppi"
@@ -440,12 +440,12 @@ BEGIN
     IDS_2109    "Kaikki levykuvat (*.0??;*.1??;*.??0;*.86F;*.BIN;*.CQ?;*.D??;*.FLP;*.HDM;*.IM?;*.JSON;*.TD0;*.*FD?;*.MFM;*.XDF)\0*.0??;*.1??;*.??0;*.86F;*.BIN;*.CQ?;*.D??;*.FLP;*.HDM;*.IM?;*.JSON;*.TD0;*.*FD?;*.MFM;*.XDF\0Kehittyneet sektorilevykuvat (*.IMD;*.JSON;*.TD0)\0*.IMD;*.JSON;*.TD0\0Perussektorilevykuvat (*.0??;*.1??;*.??0;*.BIN;*.CQ?;*.D??;*.FLP;*.HDM;*.IM?;*.XDF;*.*FD?)\0*.0??;*.1??;*.??0;*.BIN;*.CQ?;*.D??;*.FLP;*.HDM;*.IM?;*.XDF;*.*FD?\0Flux-levykuvat (*.FDI)\0*.FDI\0Pintalevykuvat (*.86F;*.MFM)\0*.86F;*.MFM\0Kaikki tiedostot (*.*)\0*.*\0"
     IDS_2110    "FreeType:n alustus epäonnistui"
     IDS_2111    "SDL:n alustus epäonnistui. Tarvitaan SDL2.dll"
-    IDS_2112    "Oletko varma, että haluat käynnistää emuloidun tietokoneen uudelleen?"
-    IDS_2113    "Haluatko varmasti sulkea 86Box:in?"
-    IDS_2114    "Ghostscript:in alustus epäonnistui"
+    IDS_2112    "Haluatko varmasti käynnistää emuloidun tietokoneen uudelleen?"
+    IDS_2113    "Haluatko varmasti sulkea 86Boxin?"
+    IDS_2114    "Ghostscriptin alustus epäonnistui"
     IDS_2115    "MO %i (%ls): %ls"
     IDS_2116    "MO-levykuvat (*.IM?;*.MDI)\0*.IM?;*.MDI\0Kaikki tiedostot (*.*)\0*.*\0"
-    IDS_2117    "Tervetuloa 86Box:iin!"
+    IDS_2117    "Tervetuloa 86Boxiin!"
     IDS_2118    "Sisäinen ohjain"
     IDS_2119    "Poistu"
     IDS_2120    "ROM-tiedostoja ei löytynyt"
@@ -498,18 +498,18 @@ BEGIN
     IDS_2146    "Valittuun tietokoneeseen perustuva suoritintyypin suodatus ei ole käytössä tällä emuloidulla koneella.\n\nTämä mahdollistaa muutoin yhteensopimattoman suorittimen valinnan kyseisen tietokoneen kanssa. Voit kuitenkin kohdata ongelmia tietokoneen BIOS:in tai muun ohjelmiston kanssa.\n\nTämän asetuksen käyttö ei ole virallisesti tuettua ja kaikki tehdyt virheraportit voidaan sulkea epäpätevinä."
     IDS_2147    "Jatka"
     IDS_2148    "Kasetti: %s"
-    IDS_2149    "Kasetti-tiedostot (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0Kaikki tiedostot (*.*)\0*.*\0"
+    IDS_2149    "Kasettitiedostot (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0Kaikki tiedostot (*.*)\0*.*\0"
     IDS_2150    "ROM-moduuli %i: %ls"
     IDS_2151    "ROM-moduulikuvat (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0Kaikki tiedostot (*.*)\0*.*\0"
-    IDS_2152	"Virhe renderöijän alustuksessa"
-    IDS_2153	"OpenGL (3.0 Core) renderöijän alustus epäonnistui. Käytä toista renderöijää."
-    IDS_2154	"Resume execution"
-    IDS_2155	"Pause execution"
-    IDS_2156	"Press Ctrl+Alt+Del"
-    IDS_2157	"Press Ctrl+Alt+Esc"
-    IDS_2158	"Hard reset"
-    IDS_2159	"ACPI shutdown"
-    IDS_2160	"Settings"
+    IDS_2152	"Virhe hahmontimen alustuksessa"
+    IDS_2153	"OpenGL (3.0 Core) -hahmontimen alustus epäonnistui. Käytä toista hahmonninta."
+    IDS_2154	"Jatka suoritusta"
+    IDS_2155	"Pysäytä suoritus"
+    IDS_2156	"Paina Ctrl+Alt+Del"
+    IDS_2157	"Paina Ctrl+Alt+Esc"
+    IDS_2158	"Kylmä uudelleenkäynnistys"
+    IDS_2159	"ACPI-sammutus"
+    IDS_2160	"Asetukset"
 END
 
 STRINGTABLE DISCARDABLE
@@ -517,12 +517,12 @@ BEGIN
     IDS_4096    "Kiintolevy (%s)"
     IDS_4097    "%01i:%01i"
     IDS_4098    "%01i"
-    IDS_4099    "MFM/RLL tai ESDI CD-ROM asemia ei ole koskaan ollut olemassa"
+    IDS_4099    "MFM/RLL- tai ESDI-CD-ROM-asemia ei ole koskaan ollut olemassa"
     IDS_4100    "Mukautettu..."
     IDS_4101    "Mukautettu (suuri)..."
     IDS_4102    "Lisää uusi kiintolevy"
-    IDS_4103    "Lisää olemassaoleva kiintolevy"
-    IDS_4104    "HDI levykuvan suurin mahdollinen koko on 4 Gt."
+    IDS_4103    "Lisää valmis kiintolevy"
+    IDS_4104    "HDI-levykuvan suurin mahdollinen koko on 4 Gt."
     IDS_4105    "Levykuvien suurin mahdollinen koko on 127 Gt."
     IDS_4106    "Kiintolevykuvat (*.HD?;*.IM?;*.VHD)\0*.HD?;*.IM?;*.VHD\0Kaikki tiedostot (*.*)\0*.*\0"
     IDS_4107    "Tiedostoa ei voi lukea"
@@ -536,10 +536,10 @@ BEGIN
     IDS_4115    "Varmista, että tiedoston tallennuskansioon on kirjoitusoikeus"
     IDS_4116    "Liian suuri levykuva"
     IDS_4117    "Muista osioida ja alustaa juuri luomasi asema."
-    IDS_4118    "Valittu tiedosto ylikirjoitetaan. Oletko varma, että haluat käyttää sitä?"
-    IDS_4119    "Levynkuvaa ei tueta"
-    IDS_4120    "Ylikirjoita"
-    IDS_4121    "Älä ylikirjoita"
+    IDS_4118    "Valittu tiedosto korvataan. Oletko varma, että haluat käyttää sitä?"
+    IDS_4119    "Levykuvaa ei tueta"
+    IDS_4120    "Korvaa"
+    IDS_4121    "Älä korvaa"
     IDS_4122    "Raaka levykuva (.img)"
     IDS_4123    "HDI-levykuva (.hdi)"
     IDS_4124    "HDX-levykuva (.hdx)"

--- a/src/win/languages/fi-FI.rc
+++ b/src/win/languages/fi-FI.rc
@@ -37,7 +37,7 @@ BEGIN
         MENUITEM "&Salli koon muuttaminen",                             IDM_VID_RESIZE
         MENUITEM "&Muista koko ja sijainti",                            IDM_VID_REMEMBER
         MENUITEM SEPARATOR
-        POPUP "&Hahmonnin"
+        POPUP "&Renderöijä"
         BEGIN
             MENUITEM "&SDL (ohjelmistopohjainen)",                      IDM_VID_SDL_SW
             MENUITEM "SDL (&laitteistokiihdytetty)",                    IDM_VID_SDL_HW
@@ -94,7 +94,7 @@ BEGIN
         MENUITEM "CGA/PCjr/Tandy/E&GA/(S)VGA &yliskannaus",             IDM_VID_OVERSCAN
         MENUITEM "&Muuta harmaavärinäytön kontrastia",                  IDM_VID_CGACON
     END
-    MENUITEM "&Levyt",                                                  IDM_MEDIA
+    MENUITEM "&Media",                                                  IDM_MEDIA
     POPUP "Työ&kalut"
     BEGIN
         MENUITEM "&Kokoonpano...",                                      IDM_CONFIG
@@ -130,8 +130,8 @@ BEGIN
     BEGIN
         MENUITEM "&Uusi kasettikuva...",                                IDM_CASSETTE_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Valmis kasettikuva...",                              IDM_CASSETTE_IMAGE_EXISTING
-        MENUITEM "Valmis kasettikuva (&kirjoitussuojattu)...",          IDM_CASSETTE_IMAGE_EXISTING_WP
+        MENUITEM "&Olemassaoleva kasettikuva...",                       IDM_CASSETTE_IMAGE_EXISTING
+        MENUITEM "Olemassaoleva kasettikuva (&kirjoitussuojattu)...",   IDM_CASSETTE_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
         MENUITEM "&Nauhoita",                                           IDM_CASSETTE_RECORD
         MENUITEM "&Toista",                                             IDM_CASSETTE_PLAY
@@ -158,8 +158,8 @@ BEGIN
     BEGIN
         MENUITEM "&Uusi levykekuva...",                                 IDM_FLOPPY_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Valmis levykekuva...",                               IDM_FLOPPY_IMAGE_EXISTING
-        MENUITEM "Valmis levykekuva (&kirjoitussuojattu)...",           IDM_FLOPPY_IMAGE_EXISTING_WP
+        MENUITEM "&Olemassaoleva levykekuva...",                        IDM_FLOPPY_IMAGE_EXISTING
+        MENUITEM "Olemassaoleva levykekuva (&kirjoitussuojattu)...",    IDM_FLOPPY_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
         MENUITEM "&Vie 86F-tiedostoon...",                              IDM_FLOPPY_EXPORT_TO_86F
         MENUITEM SEPARATOR
@@ -186,8 +186,8 @@ BEGIN
     BEGIN
         MENUITEM "&Uusi levykuva...",                                   IDM_ZIP_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Valmis levykuva...",                                 IDM_ZIP_IMAGE_EXISTING
-        MENUITEM "Valmis levykuva (&kirjoitussuojattu)...",             IDM_ZIP_IMAGE_EXISTING_WP
+        MENUITEM "&Olemassaoleva levykuva...",                          IDM_ZIP_IMAGE_EXISTING
+        MENUITEM "Olemassaoleva levykuva (&kirjoitussuojattu)...",      IDM_ZIP_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
         MENUITEM "&Poista asemasta",                                    IDM_ZIP_EJECT
         MENUITEM "&Lataa edellinen levykuva uudelleen",                 IDM_ZIP_RELOAD
@@ -200,8 +200,8 @@ BEGIN
     BEGIN
         MENUITEM "&Uusi levykuva...",                                   IDM_MO_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Valmis levykuva...",                                 IDM_MO_IMAGE_EXISTING
-        MENUITEM "Valmis levykuva (&kirjoitussuojattu)...",             IDM_MO_IMAGE_EXISTING_WP
+        MENUITEM "&Olemassaoleva levykuva...",                          IDM_MO_IMAGE_EXISTING
+        MENUITEM "Olemassaoleva levykuva (&kirjoitussuojattu)...",      IDM_MO_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
         MENUITEM "&Poista asemasta",                                    IDM_MO_EJECT
         MENUITEM "&Lataa edellinen levykuva uudelleen",                 IDM_MO_RELOAD
@@ -219,7 +219,7 @@ BEGIN
         MENUITEM "&60 ruutua/s",                IDM_VID_GL_FPS_60
         MENUITEM "&75 ruutua/s",                IDM_VID_GL_FPS_75
     END
-    MENUITEM "P&ystytahdistus",                 IDM_VID_GL_VSYNC
+    MENUITEM "&VSync",                          IDM_VID_GL_VSYNC
     MENUITEM "Valitse varjostin&ohjelma...",    IDM_VID_GL_SHADER
     MENUITEM "&Poista varjostinohjelma",        IDM_VID_GL_NOSHADER
 END
@@ -417,7 +417,7 @@ BEGIN
     IDS_2086    "Mt"
     IDS_2087    "Tarkista BPB"
     IDS_2088    "kt"
-    IDS_2089    "Videohahmontimen alustus epäonnistui"
+    IDS_2089    "Videorenderöijän alustus epäonnistui"
     IDS_2090    "Oletus"
     IDS_2091    "%i odotustilaa"
     IDS_2092    "Tyyppi"
@@ -501,8 +501,8 @@ BEGIN
     IDS_2149    "Kasettitiedostot (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0Kaikki tiedostot (*.*)\0*.*\0"
     IDS_2150    "ROM-moduuli %i: %ls"
     IDS_2151    "ROM-moduulikuvat (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0Kaikki tiedostot (*.*)\0*.*\0"
-    IDS_2152	"Virhe hahmontimen alustuksessa"
-    IDS_2153	"OpenGL (3.0 Core) -hahmontimen alustus epäonnistui. Käytä toista hahmonninta."
+    IDS_2152	"Virhe renderöijän alustuksessa"
+    IDS_2153	"OpenGL (3.0 Core) -renderöijän alustus epäonnistui. Käytä toista renderöijää."
     IDS_2154	"Jatka suoritusta"
     IDS_2155	"Pysäytä suoritus"
     IDS_2156	"Paina Ctrl+Alt+Del"
@@ -521,7 +521,7 @@ BEGIN
     IDS_4100    "Mukautettu..."
     IDS_4101    "Mukautettu (suuri)..."
     IDS_4102    "Lisää uusi kiintolevy"
-    IDS_4103    "Lisää valmis kiintolevy"
+    IDS_4103    "Lisää olemassaoleva kiintolevy"
     IDS_4104    "HDI-levykuvan suurin mahdollinen koko on 4 Gt."
     IDS_4105    "Levykuvien suurin mahdollinen koko on 127 Gt."
     IDS_4106    "Kiintolevykuvat (*.HD?;*.IM?;*.VHD)\0*.HD?;*.IM?;*.VHD\0Kaikki tiedostot (*.*)\0*.*\0"


### PR DESCRIPTION
This is an improvement for the 86Box Finnish translation (both Win32 and Qt). I tried to synchronize the changes between the two, although I might've missed some.

Something I noticed is that there are more Win32 strings than Qt ones. For example, the Win32 version has separate strings for tape drives, cartridges, floppies etc. but there's only one set of strings for Qt. For the latter, the first matches had been picked, which meant that the Qt translation used the tape drive strings for all media. That sounded odd, because floppy drive "eject" translated to "remove from cassette tray". I tried to change the Qt translation to be fairly media-agnostic.
