### PR TITLE
Fix OpenGL Core renderer on macOS

### DIFF
--- a/src/qt/qt_opengloptions.hpp
+++ b/src/qt/qt_opengloptions.hpp
@@ -72,14 +72,14 @@ public:
     enum FilterType { Nearest,
                       Linear };
 
-    OpenGLOptions(QObject *parent = nullptr, bool loadConfig = false);
+    OpenGLOptions(QObject *parent, bool loadConfig, const QString &glslVersion);
 
     RenderBehaviorType renderBehavior() const { return m_renderBehavior; }
     int                framerate() const { return m_framerate; }
     bool               vSync() const { return m_vsync; }
     FilterType         filter() const;
 
-    const QList<OpenGLShaderPass> &shaders() const { return m_shaders; };
+    const QList<OpenGLShaderPass> &shaders() const { return m_shaders; }
 
     void setRenderBehavior(RenderBehaviorType value);
     void setFrameRate(int value);
@@ -95,6 +95,7 @@ private:
     bool                    m_vsync          = false;
     FilterType              m_filter         = Nearest;
     QList<OpenGLShaderPass> m_shaders;
+    QString                 m_glslVersion;
 };
 
 #endif

--- a/src/qt/qt_opengloptionsdialog.cpp
+++ b/src/qt/qt_opengloptionsdialog.cpp
@@ -24,9 +24,10 @@
 #include "qt_util.hpp"
 #include "ui_qt_opengloptionsdialog.h"
 
-OpenGLOptionsDialog::OpenGLOptionsDialog(QWidget *parent, const OpenGLOptions &options)
+OpenGLOptionsDialog::OpenGLOptionsDialog(QWidget *parent, const OpenGLOptions &options, std::function<OpenGLOptions *()> optionsFactory)
     : QDialog(parent)
     , ui(new Ui::OpenGLOptionsDialog)
+    , createOptions(optionsFactory)
 {
     ui->setupUi(this);
 
@@ -54,7 +55,7 @@ OpenGLOptionsDialog::~OpenGLOptionsDialog()
 void
 OpenGLOptionsDialog::accept()
 {
-    auto options = new OpenGLOptions();
+    auto options = createOptions();
 
     options->setRenderBehavior(
         ui->syncWithVideo->isChecked()

--- a/src/qt/qt_opengloptionsdialog.hpp
+++ b/src/qt/qt_opengloptionsdialog.hpp
@@ -19,6 +19,8 @@
 
 #include <QDialog>
 
+#include <functional>
+
 #include "qt_opengloptions.hpp"
 
 namespace Ui {
@@ -29,7 +31,7 @@ class OpenGLOptionsDialog : public QDialog {
     Q_OBJECT
 
 public:
-    explicit OpenGLOptionsDialog(QWidget *parent, const OpenGLOptions &options);
+    explicit OpenGLOptionsDialog(QWidget *parent, const OpenGLOptions &options, std::function<OpenGLOptions *()> optionsFactory);
     ~OpenGLOptionsDialog();
 
 signals:
@@ -40,6 +42,8 @@ public slots:
 
 private:
     Ui::OpenGLOptionsDialog *ui;
+
+    std::function<OpenGLOptions *()> createOptions;
 
 private slots:
     void on_addShader_clicked();

--- a/src/qt/qt_openglrenderer.hpp
+++ b/src/qt/qt_openglrenderer.hpp
@@ -77,6 +77,8 @@ private:
     OpenGLOptions *options;
     QTimer        *renderTimer;
 
+    QString glslVersion;
+
     bool isInitialized = false;
     bool isFinalized   = false;
 


### PR DESCRIPTION
Summary
=======
MacOS will use OpenGL 2.1 unless specifically requested for OpenGL 4.1.
Shader language version is now set to what is reported by the driver for best compatibility.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
