### PR TITLE
qt: Fix a typo connecting to resetVM signal on unix manager socket

### DIFF
--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -243,7 +243,7 @@ int main(int argc, char* argv[]) {
     {
         QObject::connect(&socket, &UnixManagerSocket::showsettings, main_window, &MainWindow::showSettings);
         QObject::connect(&socket, &UnixManagerSocket::pause, main_window, &MainWindow::togglePause);
-        QObject::connect(&socket, &UnixManagerSocket::reset, main_window, &MainWindow::hardReset);
+        QObject::connect(&socket, &UnixManagerSocket::resetVM, main_window, &MainWindow::hardReset);
         QObject::connect(&socket, &UnixManagerSocket::request_shutdown, main_window, &MainWindow::close);
         QObject::connect(&socket, &UnixManagerSocket::force_shutdown, [](){
             do_stop();


### PR DESCRIPTION
Summary
=======
This should fix the pipe/socket based manager feature

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
