### PR TITLE
qt: opengl core; fix filter method defaulting to nearest

### DIFF
--- a/src/qt/qt_opengloptions.cpp
+++ b/src/qt/qt_opengloptions.cpp
@@ -49,6 +49,10 @@ OpenGLOptions::OpenGLOptions(QObject *parent, bool loadConfig, const QString &gl
     : QObject(parent)
     , m_glslVersion(glslVersion)
 {
+    m_filter = video_filter_method == 0
+        ? FilterType::Nearest
+        : FilterType::Linear;
+
     if (!loadConfig)
         return;
 
@@ -59,10 +63,6 @@ OpenGLOptions::OpenGLOptions(QObject *parent, bool loadConfig, const QString &gl
     m_renderBehavior = video_framerate == -1
         ? RenderBehaviorType::SyncWithVideo
         : RenderBehaviorType::TargetFramerate;
-
-    m_filter = video_filter_method == 0
-        ? FilterType::Nearest
-        : FilterType::Linear;
 
     QString shaderPath(video_shader);
 


### PR DESCRIPTION
Summary
=======
When exiting OpenGL 3 Core renderer options applying changes, the filter method reverts to nearest.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
