### PR TITLE
qt: fix multiple compiler warnings

### DIFF
--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -358,7 +358,7 @@ void MachineStatus::refresh(QStatusBar* sbar) {
     if (cassette_enable) {
         d->cassette.label = std::make_unique<ClickableLabel>();
         d->cassette.setEmpty(QString(cassette_fname).isEmpty());
-        connect((ClickableLabel*)d->cassette.label.get(), &ClickableLabel::clicked, [this](QPoint pos) {
+        connect((ClickableLabel*)d->cassette.label.get(), &ClickableLabel::clicked, [](QPoint pos) {
             MediaMenu::ptr->cassetteMenu->popup(pos - QPoint(0, MediaMenu::ptr->cassetteMenu->sizeHint().height()));
         });
         d->cassette.label->setToolTip(MediaMenu::ptr->cassetteMenu->title());
@@ -369,7 +369,7 @@ void MachineStatus::refresh(QStatusBar* sbar) {
         for (int i = 0; i < 2; ++i) {
             d->cartridge[i].label = std::make_unique<ClickableLabel>();
             d->cartridge[i].setEmpty(QString(cart_fns[i]).isEmpty());
-            connect((ClickableLabel*)d->cartridge[i].label.get(), &ClickableLabel::clicked, [this, i](QPoint pos) {
+            connect((ClickableLabel*)d->cartridge[i].label.get(), &ClickableLabel::clicked, [i](QPoint pos) {
                 MediaMenu::ptr->cartridgeMenus[i]->popup(pos - QPoint(0, MediaMenu::ptr->cartridgeMenus[i]->sizeHint().height()));
             });
             d->cartridge[i].label->setToolTip(MediaMenu::ptr->cartridgeMenus[i]->title());
@@ -389,7 +389,7 @@ void MachineStatus::refresh(QStatusBar* sbar) {
         d->fdd[i].label = std::make_unique<ClickableLabel>();
         d->fdd[i].setEmpty(QString(floppyfns[i]).isEmpty());
         d->fdd[i].setActive(false);
-        connect((ClickableLabel*)d->fdd[i].label.get(), &ClickableLabel::clicked, [this, i](QPoint pos) {
+        connect((ClickableLabel*)d->fdd[i].label.get(), &ClickableLabel::clicked, [i](QPoint pos) {
             MediaMenu::ptr->floppyMenus[i]->popup(pos - QPoint(0, MediaMenu::ptr->floppyMenus[i]->sizeHint().height()));
         });
         d->fdd[i].label->setToolTip(MediaMenu::ptr->floppyMenus[i]->title());
@@ -400,7 +400,7 @@ void MachineStatus::refresh(QStatusBar* sbar) {
         d->cdrom[i].label = std::make_unique<ClickableLabel>();
         d->cdrom[i].setEmpty(cdrom[i].host_drive != 200 || QString(cdrom[i].image_path).isEmpty());
         d->cdrom[i].setActive(false);
-        connect((ClickableLabel*)d->cdrom[i].label.get(), &ClickableLabel::clicked, [this, i](QPoint pos) {
+        connect((ClickableLabel*)d->cdrom[i].label.get(), &ClickableLabel::clicked, [i](QPoint pos) {
             MediaMenu::ptr->cdromMenus[i]->popup(pos - QPoint(0, MediaMenu::ptr->cdromMenus[i]->sizeHint().height()));
         });
         d->cdrom[i].label->setToolTip(MediaMenu::ptr->cdromMenus[i]->title());
@@ -411,7 +411,7 @@ void MachineStatus::refresh(QStatusBar* sbar) {
         d->zip[i].label = std::make_unique<ClickableLabel>();
         d->zip[i].setEmpty(QString(zip_drives[i].image_path).isEmpty());
         d->zip[i].setActive(false);
-        connect((ClickableLabel*)d->zip[i].label.get(), &ClickableLabel::clicked, [this, i](QPoint pos) {
+        connect((ClickableLabel*)d->zip[i].label.get(), &ClickableLabel::clicked, [i](QPoint pos) {
             MediaMenu::ptr->zipMenus[i]->popup(pos - QPoint(0, MediaMenu::ptr->zipMenus[i]->sizeHint().height()));
         });
         d->zip[i].label->setToolTip(MediaMenu::ptr->zipMenus[i]->title());
@@ -422,7 +422,7 @@ void MachineStatus::refresh(QStatusBar* sbar) {
         d->mo[i].label = std::make_unique<ClickableLabel>();
         d->mo[i].setEmpty(QString(mo_drives[i].image_path).isEmpty());
         d->mo[i].setActive(false);
-        connect((ClickableLabel*)d->mo[i].label.get(), &ClickableLabel::clicked, [this, i](QPoint pos) {
+        connect((ClickableLabel*)d->mo[i].label.get(), &ClickableLabel::clicked, [i](QPoint pos) {
             MediaMenu::ptr->moMenus[i]->popup(pos - QPoint(0, MediaMenu::ptr->moMenus[i]->sizeHint().height()));
         });
         d->mo[i].label->setToolTip(MediaMenu::ptr->moMenus[i]->title());
@@ -471,7 +471,7 @@ void MachineStatus::refresh(QStatusBar* sbar) {
     d->sound = std::make_unique<ClickableLabel>();
     d->sound->setPixmap(d->pixmaps.sound);
 
-    connect(d->sound.get(), &ClickableLabel::doubleClicked, d->sound.get(), [this](QPoint pos) {
+    connect(d->sound.get(), &ClickableLabel::doubleClicked, d->sound.get(), [](QPoint pos) {
         SoundGain gain(main_window);
         gain.exec();
     });

--- a/src/qt/qt_newfloppydialog.cpp
+++ b/src/qt/qt_newfloppydialog.cpp
@@ -340,7 +340,7 @@ bool NewFloppyDialog::create86f(const QString& filename, const disk_size_t& disk
 }
 
 /* Ignore false positive warning caused by a bug on gcc */
-#ifdef __GNUC__
+#if __GNUC__ >= 11
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif
 

--- a/src/qt/qt_newfloppydialog.cpp
+++ b/src/qt/qt_newfloppydialog.cpp
@@ -339,6 +339,11 @@ bool NewFloppyDialog::create86f(const QString& filename, const disk_size_t& disk
     return true;
 }
 
+/* Ignore false positive warning caused by a bug on gcc */
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+
 bool NewFloppyDialog::createSectorImage(const QString &filename, const disk_size_t& disk_size, FileType type)
 {
     uint32_t total_size = 0;

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -74,11 +74,13 @@ private:
 
 extern "C" {
 #ifdef Q_OS_WINDOWS
-#define NOMINMAX
-#include <windows.h>
-#include <86box/win.h>
+#    ifndef NOMINMAX
+#        define NOMINMAX
+#    endif
+#    include <windows.h>
+#    include <86box/win.h>
 #else
-#include <strings.h>
+#    include <strings.h>
 #endif
 #include <86box/86box.h>
 #include <86box/device.h>

--- a/src/qt/qt_settings_bus_tracking.cpp
+++ b/src/qt/qt_settings_bus_tracking.cpp
@@ -218,7 +218,7 @@ SettingsBusTracking::scsi_bus_full()
 void
 SettingsBusTracking::device_track(int set, uint8_t dev_type, int bus, int channel)
 {
-    int i, element;
+    int element;
     uint64_t mask;
     uint8_t count = 0;
 

--- a/src/qt/qt_settings_bus_tracking.cpp
+++ b/src/qt/qt_settings_bus_tracking.cpp
@@ -220,7 +220,6 @@ SettingsBusTracking::device_track(int set, uint8_t dev_type, int bus, int channe
 {
     int element;
     uint64_t mask;
-    uint8_t count = 0;
 
     switch (bus) {
         case HDD_BUS_MFM:

--- a/src/qt/qt_settingsinput.cpp
+++ b/src/qt/qt_settingsinput.cpp
@@ -54,7 +54,6 @@ void SettingsInput::onCurrentMachineChanged(int machineId) {
     // win_settings_video_proc, WM_INITDIALOG
     this->machineId = machineId;
 
-    const auto* machine = &machines[machineId];
     auto* mouseModel = ui->comboBoxMouse->model();
     auto removeRows = mouseModel->rowCount();
 

--- a/src/qt/qt_settingsnetwork.cpp
+++ b/src/qt/qt_settingsnetwork.cpp
@@ -80,7 +80,6 @@ void SettingsNetwork::save() {
 
 void SettingsNetwork::onCurrentMachineChanged(int machineId) {
     this->machineId = machineId;
-    auto* machine = &machines[machineId];
 
     auto* model = ui->comboBoxAdapter->model();
     auto removeRows = model->rowCount();

--- a/src/qt/qt_settingsstoragecontrollers.cpp
+++ b/src/qt/qt_settingsstoragecontrollers.cpp
@@ -64,7 +64,6 @@ void SettingsStorageControllers::save() {
 
 void SettingsStorageControllers::onCurrentMachineChanged(int machineId) {
     this->machineId = machineId;
-    auto* machine = &machines[machineId];
 
     /*HD controller config*/
     auto* model = ui->comboBoxHD->model();


### PR DESCRIPTION
Summary
=======
Fix some of the compiler warnings (mainly gcc/mingw) from Qt code.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
