### PR TITLE
qt: fix mouse getting captured even if VM has no mouse

### DIFF
--- a/src/qt/qt_ui.cpp
+++ b/src/qt/qt_ui.cpp
@@ -34,6 +34,7 @@ extern "C" {
 
 #include <86box/plat.h>
 #include <86box/ui.h>
+#include <86box/mouse.h>
 
 void
 plat_delay_ms(uint32_t count)
@@ -72,6 +73,9 @@ void plat_setfullscreen(int on) {
 }
 
 void plat_mouse_capture(int on) {
+    if (!kbd_req_capture && (mouse_type == MOUSE_TYPE_NONE))
+        return;
+
     main_window->setMouseCapture(on > 0 ? true : false);
 }
 


### PR DESCRIPTION
Summary
=======
Make the same check as in Win32 UI; if keyboard doesn't require capture and VM has no mouse selected, then don't capture mouse on click.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
