### PR TITLE
qt: Improve hard disk create file selection

### DIFF
--- a/src/qt/qt_harddiskdialog.cpp
+++ b/src/qt/qt_harddiskdialog.cpp
@@ -38,6 +38,7 @@ extern "C" {
 #include <QProgressDialog>
 #include <QPushButton>
 #include <QStringBuilder>
+#include <QStringList>
 
 #include "qt_harddrive_common.hpp"
 #include "qt_settings_bus_tracking.hpp"
@@ -50,8 +51,9 @@ HarddiskDialog::HarddiskDialog(bool existing, QWidget *parent) :
 {
     ui->setupUi(this);
 
-    ui->fileField->setFilter(tr("Hard disk images") % util::DlgFilter({ "hd?","im?","vhd" }) % tr("All files") % util::DlgFilter({ "*" }, true));
     if (existing) {
+        ui->fileField->setFilter(tr("Hard disk images") % util::DlgFilter({ "hd?", "im?", "vhd" }) % tr("All files") % util::DlgFilter({ "*" }, true));
+
         setWindowTitle(tr("Add Existing Hard Disk"));
         ui->lineEditCylinders->setEnabled(false);
         ui->lineEditHeads->setEnabled(false);
@@ -64,8 +66,24 @@ HarddiskDialog::HarddiskDialog(bool existing, QWidget *parent) :
 
         connect(ui->fileField, &FileField::fileSelected, this, &HarddiskDialog::onExistingFileSelected);
     } else {
+        QStringList filters({ tr("Raw image") % util::DlgFilter({ "img" }, true),
+                              tr("HDI image") % util::DlgFilter({ "hdi" }, true),
+                              tr("HDX image") % util::DlgFilter({ "hdx" }, true),
+                              tr("Fixed-size VHD") % util::DlgFilter({ "vhd" }, true),
+                              tr("Dynamic-size VHD") % util::DlgFilter({ "vhd" }, true),
+                              tr("Differencing VHD") % util::DlgFilter({ "vhd" }, true) });
+
+        ui->fileField->setFilter(filters.join(";;"));
+
         setWindowTitle(tr("Add New Hard Disk"));
         ui->fileField->setCreateFile(true);
+
+        connect(ui->fileField, &FileField::fileSelected, this, [this, filters] {
+            int filter = filters.indexOf(ui->fileField->selectedFilter());
+            if (filter > -1)
+                ui->comboBoxFormat->setCurrentIndex(filter);
+            ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
+        });
     }
 
     auto* model = ui->comboBoxFormat->model();
@@ -101,9 +119,6 @@ HarddiskDialog::HarddiskDialog(bool existing, QWidget *parent) :
 
     ui->lineEditSize->setValidator(new QIntValidator());
     ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
-    if (!existing) connect(ui->fileField, &FileField::fileSelected, this, [this] {
-        ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
-    });
 }
 
 HarddiskDialog::~HarddiskDialog()


### PR DESCRIPTION
Summary
=======
Adds the available formats and corresponding extensions to file dialog filter when creating a hard disk. The format combo box is set to the same selection. This also fixes the error when not adding the extension on the file dialog and automatically adds the extension if necessary. 

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
