### PR TITLE
qt: Disable processing of alt-f4 in windows.

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -437,6 +437,11 @@ MainWindow::MainWindow(QWidget *parent) :
 }
 
 void MainWindow::closeEvent(QCloseEvent *event) {
+    if (mouse_capture) {
+        event->ignore();
+        return;
+    }
+
     if (confirm_exit && confirm_exit_cmdl && cpu_thread_run)
     {
         QMessageBox questionbox(QMessageBox::Icon::Question, "86Box", tr("Are you sure you want to exit 86Box?"), QMessageBox::Yes | QMessageBox::No, this);

--- a/src/qt/qt_winrawinputfilter.cpp
+++ b/src/qt/qt_winrawinputfilter.cpp
@@ -116,12 +116,18 @@ bool WindowsRawInputFilter::nativeEventFilter(const QByteArray &eventType, void 
     {
         MSG *msg = static_cast<MSG *>(message);
 
-        if (msg->message == WM_INPUT)
-        {
+        if (msg->message == WM_INPUT) {
             if (window->isActiveWindow() && menus_open == 0)
-                handle_input((HRAWINPUT)msg->lParam);
+                handle_input((HRAWINPUT) msg->lParam);
 
             return true;
+        }
+
+        /* Stop processing of Alt-F4 */
+        if (msg->message == WM_SYSKEYDOWN) {
+            if (msg->wParam == 0x73) {
+                return true;
+            }
         }
     }
 


### PR DESCRIPTION
Summary
=======
Prevents Alt-F4 from quitting 86Box by stopping the message handling on windows raw input filter.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
