### PR TITLE
qt: Fix shaders on HD4000/4400

### DIFF
--- a/src/qt/qt_opengloptions.cpp
+++ b/src/qt/qt_opengloptions.cpp
@@ -145,6 +145,9 @@ OpenGLOptions::addShader(const QString &path)
 
     shader_file.close();
 
+    /* Remove parameter lines */
+    shader_text.remove(QRegularExpression("^\\s*#pragma parameter.*?\\n", QRegularExpression::MultilineOption));
+
     QRegularExpression version("^\\s*(#version\\s+\\w+)", QRegularExpression::MultilineOption);
 
     auto match = version.match(shader_text);

--- a/src/qt/qt_opengloptions.cpp
+++ b/src/qt/qt_opengloptions.cpp
@@ -14,6 +14,7 @@
  *      Copyright 2022 Teemu Korhonen
  */
 
+#include <QByteArray>
 #include <QFile>
 #include <QRegularExpression>
 #include <QStringBuilder>
@@ -89,7 +90,7 @@ OpenGLOptions::save() const
     auto path = m_shaders.first().path().toLocal8Bit();
 
     if (!path.isEmpty())
-        strcpy(video_shader, path.constData());
+        qstrncpy(video_shader, path.constData(), sizeof(video_shader));
     else
         video_shader[0] = '\0';
 }


### PR DESCRIPTION
Summary
=======
This fixes shader crashing with Intel HD4000 on Windows with latest drivers. Probably also fixes the errors with HD4400.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
