### PR TITLE
Fix yet another null dereference in lpt.c

### DIFF
--- a/src/lpt.c
+++ b/src/lpt.c
@@ -103,7 +103,7 @@ lpt_devices_close(void)
     for (i = 0; i < PARALLEL_MAX; i++) {
 	dev = &lpt_ports[i];
 
-	if (dev->dt)
+	if (lpt_ports[i].dt && lpt_ports[i].dt->init)
 		dev->dt->close(dev->priv);
 
         dev->dt = NULL;


### PR DESCRIPTION
Summary
=======
Fix yet another null dereference in lpt.c

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
