### PR TITLE
Fix Qt joystick dialog

### DIFF
--- a/src/qt/qt_joystickconfiguration.cpp
+++ b/src/qt/qt_joystickconfiguration.cpp
@@ -43,7 +43,7 @@ JoystickConfiguration::JoystickConfiguration(int type, int joystick_nr, QWidget 
     }
 
     ui->comboBoxDevice->setCurrentIndex(joystick_state[joystick_nr].plat_joystick_nr);
-    setFixedSize(minimumSizeHint());
+    layout()->setSizeConstraint(QLayout::SetFixedSize);
 }
 
 JoystickConfiguration::~JoystickConfiguration()
@@ -197,6 +197,4 @@ void JoystickConfiguration::on_comboBoxDevice_currentIndexChanged(int index) {
 
         ++row;
     }
-
-    setFixedSize(minimumSizeHint());
 }

--- a/src/qt/qt_joystickconfiguration.ui
+++ b/src/qt/qt_joystickconfiguration.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Joystick configuration</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="1" column="0" colspan="2">


### PR DESCRIPTION
Summary
=======
The joystick dialog was set to fixed size while it's widgets are added dynamically per device selection.

Set fixed size as a constraint to allow the dialog conform to selections instead of staying the initial minimum size.

Also set the dialog title "Dialog" -> "Joystick configuration".

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
