### PR TITLE
Add handling for several missing strings to plat_get_string on Qt and legacy Unix UIs

### DIFF
--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -533,9 +533,11 @@ void ProgSettings::reloadStrings()
     translatedstrings[IDS_2078] = QCoreApplication::translate("", "Press F8+F12 to release mouse").replace("F8+F12", MOUSE_CAPTURE_KEYSEQ).replace("CTRL-END", QLocale::system().name() == "de_DE" ? "Strg+Ende" : "CTRL-END").toStdWString();
     translatedstrings[IDS_2079] = QCoreApplication::translate("", "Press F8+F12 or middle button to release mouse").replace("F8+F12", MOUSE_CAPTURE_KEYSEQ).replace("CTRL-END", QLocale::system().name() == "de_DE" ? "Strg+Ende" : "CTRL-END").toStdWString();
     translatedstrings[IDS_2080] = QCoreApplication::translate("", "Failed to initialize FluidSynth").toStdWString();
+    translatedstrings[IDS_2130] = QCoreApplication::translate("", "Invalid configuration").toStdWString();
     translatedstrings[IDS_4099] = QCoreApplication::translate("", "MFM/RLL or ESDI CD-ROM drives never existed").toStdWString();
     translatedstrings[IDS_2093] = QCoreApplication::translate("", "Failed to set up PCap").toStdWString();
     translatedstrings[IDS_2094] = QCoreApplication::translate("", "No PCap devices found").toStdWString();
+    translatedstrings[IDS_2095] = QCoreApplication::translate("", "Invalid PCap device").toStdWString();
     translatedstrings[IDS_2110] = QCoreApplication::translate("", "Unable to initialize FreeType").toStdWString();
     translatedstrings[IDS_2111] = QCoreApplication::translate("", "Unable to initialize SDL, libsdl2 is required").toStdWString();
     translatedstrings[IDS_2129] = QCoreApplication::translate("", "Make sure libpcap is installed and that you are on a libpcap-compatible network connection.").toStdWString();
@@ -543,6 +545,7 @@ void ProgSettings::reloadStrings()
     translatedstrings[IDS_2063] = QCoreApplication::translate("", "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine.").toStdWString();
     translatedstrings[IDS_2064] = QCoreApplication::translate("", "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card.").toStdWString();
     translatedstrings[IDS_2128] = QCoreApplication::translate("", "Hardware not available").toStdWString();
+    translatedstrings[IDS_2142] = QCoreApplication::translate("", "Monitor in sleep mode").toStdWString();
     translatedstrings[IDS_2120] = QCoreApplication::translate("", "No ROMs found").toStdWString();
     translatedstrings[IDS_2056] = QCoreApplication::translate("", "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory.").replace("roms", ROMDIR).toStdWString();
 

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -229,19 +229,23 @@ wchar_t* plat_get_string(int i)
     switch (i)
     {
         case IDS_2077:
-            return L"Click to capture mouse.";
+            return L"Click to capture mouse";
         case IDS_2078:
             return L"Press CTRL-END to release mouse";
         case IDS_2079:
             return L"Press CTRL-END or middle button to release mouse";
         case IDS_2080:
             return L"Failed to initialize FluidSynth";
+        case IDS_2130:
+            return L"Invalid configuration";
         case IDS_4099:
             return L"MFM/RLL or ESDI CD-ROM drives never existed";
         case IDS_2093:
             return L"Failed to set up PCap";
         case IDS_2094:
             return L"No PCap devices found";
+        case IDS_2095:
+            return L"Invalid PCap device";
         case IDS_2110:
             return L"Unable to initialize FreeType";
         case IDS_2111:
@@ -250,6 +254,8 @@ wchar_t* plat_get_string(int i)
             return L"libfreetype is required for ESC/P printer emulation.";
         case IDS_2132:
             return L"libgs is required for automatic conversion of PostScript files to PDF.\n\nAny documents sent to the generic PostScript printer will be saved as PostScript (.ps) files.";
+        case IDS_2133:
+            return L"libfluidsynth is required for FluidSynth MIDI output.";
         case IDS_2129:
             return L"Make sure libpcap is installed and that you are on a libpcap-compatible network connection.";
         case IDS_2114:
@@ -260,6 +266,8 @@ wchar_t* plat_get_string(int i)
             return L"Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card.";
         case IDS_2128:
             return L"Hardware not available";
+        case IDS_2142:
+            return L"Monitor in sleep mode";
     }
     return L"";
 }


### PR DESCRIPTION
Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
