### PR TITLE
qt: Another joystick dialog fix

### DIFF
--- a/src/qt/qt_joystickconfiguration.cpp
+++ b/src/qt/qt_joystickconfiguration.cpp
@@ -82,7 +82,9 @@ int JoystickConfiguration::selectedPov(int pov) {
 void JoystickConfiguration::on_comboBoxDevice_currentIndexChanged(int index) {
     for (auto w : widgets) {
         ui->ct->removeWidget(w);
+        w->deleteLater();
     }
+    widgets.clear();
 
     if (index == 0) {
         return;


### PR DESCRIPTION
Summary
=======
The dynamically added widgets in joystick dialog weren't removed properly.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
