### PR TITLE
wl_mouse: Don't uncapture mouse if is already uncaptured

### DIFF
--- a/src/qt/wl_mouse.cpp
+++ b/src/qt/wl_mouse.cpp
@@ -98,8 +98,8 @@ void wl_mouse_capture(QWindow *window)
 
 void wl_mouse_uncapture()
 {
-    zwp_locked_pointer_v1_destroy(conf_pointer);
-    zwp_relative_pointer_v1_destroy(rel_pointer);
+    if (conf_pointer) zwp_locked_pointer_v1_destroy(conf_pointer);
+    if (rel_pointer) zwp_relative_pointer_v1_destroy(rel_pointer);
     rel_pointer = nullptr;
     conf_pointer = nullptr;
 }


### PR DESCRIPTION
Summary
=======
wl_mouse: Don't uncapture mouse if is already uncaptured

Checklist
=========
* [X] Closes #2234
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
