### PR TITLE
Correct version in vcpkg.json

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "86box",
-    "version-string": "3.1",
+    "version-string": "3.3",
     "homepage": "https://86box.net/",
     "documentation": "http://86box.readthedocs.io/",
     "license": "GPL-2.0-or-later",


### PR DESCRIPTION
Summary
=======
86box i as 3.3, not 3.1

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
