### PR TITLE
qt: Keyboard input now works properly when mouse is uncaptured

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -1313,7 +1313,14 @@ void MainWindow::getTitle(wchar_t *title)
 
 bool MainWindow::eventFilter(QObject* receiver, QEvent* event)
 {
-    if (this->keyboardGrabber() == this) {
+    if (!dopause && (mouse_capture || !kbd_req_capture)) {
+        if (event->type() == QEvent::Shortcut) {
+            auto shortcutEvent = (QShortcutEvent*)event;
+            if (shortcutEvent->key() == ui->actionExit->shortcut()) {
+                event->accept();
+                return true;
+            }
+        }
         if (event->type() == QEvent::KeyPress) {
             event->accept();
             this->keyPressEvent((QKeyEvent *) event);


### PR DESCRIPTION
Summary
=======
qt: Keyboard input now works properly when mouse is uncaptured.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
