### PR TITLE
linux pcap fix

### DIFF
--- a/src/network/net_pcap.c
+++ b/src/network/net_pcap.c
@@ -122,7 +122,7 @@ static const unsigned char
 			*(*f_pcap_next)(void *,void *);
 static int		(*f_pcap_sendpacket)(void *,const unsigned char *,int);
 static void		(*f_pcap_close)(void *);
-#ifdef __linux__
+#ifndef _WIN32
 static int              (*f_pcap_setnonblock)(void*, int, char*);
 #endif
 static dllimp_t pcap_imports[] = {
@@ -135,7 +135,7 @@ static dllimp_t pcap_imports[] = {
   { "pcap_next",	&f_pcap_next		},
   { "pcap_sendpacket",	&f_pcap_sendpacket	},
   { "pcap_close",	&f_pcap_close		},
-#ifdef __linux__
+#ifndef _WIN32
   { "pcap_setnonblock",	&f_pcap_setnonblock	},
 #endif
   { NULL,		NULL			},
@@ -388,7 +388,7 @@ net_pcap_reset(const netcard_t *card, uint8_t *mac)
 	pcap_log(" Unable to open device: %s!\n", network_host);
 	return(-1);
     }
-#ifdef __linux__
+#ifndef _WIN32
     if (f_pcap_setnonblock((void*)pcap, 1, errbuf) != 0)
         pcap_log("PCAP: failed nonblock %s\n", errbuf);
 #endif

--- a/src/network/net_pcap.c
+++ b/src/network/net_pcap.c
@@ -122,6 +122,9 @@ static const unsigned char
 			*(*f_pcap_next)(void *,void *);
 static int		(*f_pcap_sendpacket)(void *,const unsigned char *,int);
 static void		(*f_pcap_close)(void *);
+#ifdef __linux__
+static int              (*f_pcap_setnonblock)(void*, int, char*);
+#endif
 static dllimp_t pcap_imports[] = {
   { "pcap_lib_version",	&f_pcap_lib_version	},
   { "pcap_findalldevs",	&f_pcap_findalldevs	},
@@ -132,6 +135,9 @@ static dllimp_t pcap_imports[] = {
   { "pcap_next",	&f_pcap_next		},
   { "pcap_sendpacket",	&f_pcap_sendpacket	},
   { "pcap_close",	&f_pcap_close		},
+#ifdef __linux__
+  { "pcap_setnonblock",	&f_pcap_setnonblock	},
+#endif
   { NULL,		NULL			},
 };
 
@@ -382,6 +388,11 @@ net_pcap_reset(const netcard_t *card, uint8_t *mac)
 	pcap_log(" Unable to open device: %s!\n", network_host);
 	return(-1);
     }
+#ifdef __linux__
+    if (f_pcap_setnonblock((void*)pcap, 1, errbuf) != 0)
+        pcap_log("PCAP: failed nonblock %s\n", errbuf);
+#endif
+
     pcap_log("PCAP: interface: %s\n", network_host);
 
     /* Create a MAC address based packet filter. */


### PR DESCRIPTION
Summary
=======
This change fixes a difference between pcap on windows and pcap on linux where pcap_next blocks until a new packet arrives.
It may also improve mac OS although this patch uses `ifdef __linux__` because I cannot test on Mac OS.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
PCAP linux manual page, specifically the section about "packet buffer timeout"
[This github issue goes into more detail](https://github.com/the-tcpdump-group/libpcap/issues/572)
