### PR TITLE
network.c: fix log statement

### DIFF
--- a/src/network/network.c
+++ b/src/network/network.c
@@ -541,12 +541,12 @@ network_reset(void)
 
     network_log("NETWORK: set up for %s, card='%s'\n",
 	(network_type==NET_TYPE_SLIRP)?"SLiRP":"Pcap",
-			net_cards[network_card].name);
+			net_cards[network_card].device->name);
 
     /* Add the (new?) card to the I/O system. */
     if (net_cards[network_card].device) {
 	network_log("NETWORK: adding device '%s'\n",
-		net_cards[network_card].name);
+		net_cards[network_card].device->name);
 	device_add(net_cards[network_card].device);
     }
 }


### PR DESCRIPTION
Summary
=======
Log statements broke somewhere in development.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
