### PR TITLE
Add nine new Machines

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -259,6 +259,8 @@ extern int	machine_at_ama932j_init(const machine_t *);
 extern int	machine_at_px286_init(const machine_t *);
 extern int	machine_at_quadt286_init(const machine_t *);
 extern int	machine_at_mr286_init(const machine_t *);
+extern int	machine_at_ca286_init(const machine_t *);
+extern int	machine_at_cat102_init(const machine_t *);
 
 extern int	machine_at_neat_init(const machine_t *);
 extern int	machine_at_neat_ami_init(const machine_t *);
@@ -390,6 +392,7 @@ extern int	machine_at_atc1415_init(const machine_t *);
 extern int	machine_at_actionpc2600_init(const machine_t *);
 extern int	machine_at_m919_init(const machine_t *);
 extern int	machine_at_spc7700plw_init(const machine_t *);
+extern int	machine_at_apc9486_init(const machine_t *);
 
 #ifdef EMU_DEVICE_H
 extern const device_t 	*at_acera1g_get_device(void);
@@ -709,6 +712,12 @@ extern int	machine_xt_pc700_init(const machine_t *);
 extern int	machine_xt_pc500_init(const machine_t *);
 extern int	machine_xt_vendex_init(const machine_t *);
 extern int	machine_xt_znic_init(const machine_t *);
+extern int	machine_xt_super16t_init(const machine_t *);
+extern int	machine_xt_super16te_init(const machine_t *);
+extern int	machine_xt_top88_init(const machine_t *);
+extern int	machine_xt_kaypropc_init(const machine_t *);
+extern int	machine_xt_sansx16_init(const machine_t *);
+extern int	machine_xt_bw230_init(const machine_t *);
 
 extern int	machine_xt_iskra3104_init(const machine_t *);
 

--- a/src/machine/m_at.c
+++ b/src/machine/m_at.c
@@ -211,6 +211,42 @@ machine_at_ibmatami_init(const machine_t *model)
 
     return ret;
 }
+ 
+ 
+int
+machine_at_ca286_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_interleaved("roms/machines/ca286/mb-low.BIN",
+				"roms/machines/ca286/mb-high.BIN",
+				0x000f0000, 65536, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_at_ibm_common_init(model);
+
+    return ret;
+}
+
+
+int
+machine_at_cat102_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_interleaved("roms/machines/cat102/CAT102_U23.BIN",
+				"roms/machines/cat102/CAT102_U24.BIN",
+				0x000f0000, 65536, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_at_ibm_common_init(model);
+
+    return ret;
+}
 
 
 int

--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -1817,3 +1817,33 @@ machine_at_spc7700plw_init(const machine_t *model)
 
     return ret;
 }
+
+
+int
+machine_at_apc9486_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/apc9486/Amstrad_PC9486.BIN",
+			   0x000e0000, 131072, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_at_common_init(model);
+
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x10, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x12, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
+    pci_register_slot(0x0C, PCI_CARD_NORMAL, 2, 3, 4, 1);
+    pci_register_slot(0x0D, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x0E, PCI_CARD_NORMAL, 3, 4, 1, 2);
+
+    device_add(&umc_hb4_device);
+    device_add(&umc_8886af_device);
+    device_add(&fdc37c665_device);
+    device_add(&intel_flash_bxt_device);
+    device_add(&keyboard_at_ami_device);
+
+    return ret;
+}

--- a/src/machine/m_xt.c
+++ b/src/machine/m_xt.c
@@ -456,3 +456,111 @@ machine_xt_vendex_init(const machine_t *model)
 
     return ret;
 }
+
+int
+machine_xt_super16t_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/super16t/Hyundai SUPER-16T - System BIOS HEA v1.12Ta (16k)(MBM27128)(1986).BIN",
+			   0x000fc000, 16384, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_xt_clone_init(model);
+
+    /* On-board FDC cannot be disabled */
+	device_add(&fdc_xt_device);
+
+    return ret;
+}
+
+int
+machine_xt_super16te_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/super16te/Hyundai SUPER-16TE - System BIOS v2.00Id (16k)(D27128A)(1989).BIN",
+			   0x000fc000, 16384, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_xt_clone_init(model);
+
+    /* On-board FDC cannot be disabled */
+	device_add(&fdc_xt_device);
+
+    return ret;
+}
+
+int
+machine_xt_top88_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/top88/Hyosung Topstar 88T - BIOS version 3.0.bin",
+			   0x000fc000, 16384, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_xt_clone_init(model);
+
+    /* On-board FDC cannot be disabled */
+	device_add(&fdc_xt_device);
+
+    return ret;
+}
+
+int
+machine_xt_kaypropc_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/kaypropc/Kaypro_v2.03K.bin",
+			   0x000fe000, 8192, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_xt_clone_init(model);
+
+    return ret;
+}
+
+int
+machine_xt_sansx16_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/sansx16/tmm27128ad.bin.bin",
+			   0x000fc000, 16384, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_xt_clone_init(model);
+
+    /* On-board FDC cannot be disabled */
+	device_add(&fdc_xt_device);
+
+    return ret;
+}
+
+int
+machine_xt_bw230_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/bw230/bondwell.bin",
+			   0x000fe000, 8192, 0);
+
+    if (bios_only || !ret)
+	return ret;
+
+    machine_xt_clone_init(model);
+
+    return ret;
+}

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -111,12 +111,17 @@ const machine_t machines[] = {
     { "[8088] IBM XT (1986)",			"ibmxt86",		MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PC,									  256,   640,  64,    0,		    machine_xt86_init, NULL			},
     { "[8088] American XT Computer",		"americxt",		MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PC,									   64,   640,  64,    0,	     machine_xt_americxt_init, NULL			},
     { "[8088] AMI XT clone",			"amixt",		MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PC,									   64,   640,  64,    0,		machine_xt_amixt_init, NULL			},
+    { "[8088] Bondwell BW230",		"bw230",		MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PC,									   64,   640,  64,    0,	     machine_xt_bw230_init, NULL			},
     { "[8088] Columbia Data Products MPC-1600", "mpc1600",		MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PC,									  128,   512,  64,    0,	      machine_xt_mpc1600_init, NULL			},
     { "[8088] Compaq Portable",			"portable",		MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PC,									  128,   640, 128,    0,      machine_xt_compaq_portable_init, NULL			},
     { "[8088] DTK PIM-TB10-Z",			"dtk",			MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PC,									   64,   640,  64,    0,		  machine_xt_dtk_init, NULL			},
     { "[8088] Eagle PC Spirit",			"pcspirit",		MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PC,									  128,   640,  64,    0,	     machine_xt_pcspirit_init, NULL			},
     { "[8088] Generic XT clone",		"genxt",		MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PC,									   64,   640,  64,    0,		   machine_genxt_init, NULL			},
+    { "[8088] Hyosung Topstar 88T",		"top88",		MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 0, 0, 0, 0, 0, 0,						             	MACHINE_PC,     							  128,   640,  64,    0,		machine_xt_top88_init, NULL			},
+    { "[8088] Hyundai SUPER-16T",		"super16t",		MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 4772728, 7159092, 0, 0, 0, 0,							MACHINE_PC,     							  128,   640,  64,    0,		machine_xt_super16t_init, NULL			},
+    { "[8088] Hyundai SUPER-16TE",		"super16te",		MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 10000000, 0, 0, 0, 0, 0,							MACHINE_PC,     							  128,   640,  64,    0,		machine_xt_super16te_init, NULL			},
     { "[8088] Juko ST",				"jukopc",		MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PC,									   64,   640,  64,    0,	       machine_xt_jukopc_init, NULL			},
+    { "[8088] Kaypro PC",			"kaypropc",		MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PC,									   64,   640,  64,    0,	     machine_xt_kaypropc_init, NULL			},
     { "[8088] Multitech PC-500",		"pc500",		MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PC,									  128,   640,  64,    0,		machine_xt_pc500_init, NULL			},
     { "[8088] Multitech PC-700",		"pc700",		MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PC,									  128,   640,  64,    0,		machine_xt_pc700_init, NULL			},
     { "[8088] NCR PC4i",			"pc4i",			MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PC,									  256,   640, 256,    0,		 machine_xt_pc4i_init, NULL			},
@@ -124,6 +129,7 @@ const machine_t machines[] = {
     { "[8088] OpenXT",				"openxt",		MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PC,									   64,   640,  64,    0,	       machine_xt_openxt_init, NULL			},
     { "[8088] Philips P3105/NMS9100",		"p3105",		MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PC | MACHINE_XTA,							  256,   768, 256,    0,		machine_xt_p3105_init, NULL			},
     { "[8088] Phoenix XT clone",		"pxxt",			MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PC,									   64,   640,  64,    0,		 machine_xt_pxxt_init, NULL			},
+    { "[8088] Sanyo SX-16",				"sansx16",			MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PC,									   256,   768, 256,    0,		machine_xt_sansx16_init, NULL			},
     { "[8088] Schneider EuroPC",		"europc",		MACHINE_TYPE_8088,		CPU_PKG_8088_EUROPC, 0, 0, 0, 0, 0, 0, 0,									MACHINE_PC | MACHINE_XTA | MACHINE_MOUSE,					  512,   640, 128,   15,		  machine_europc_init, NULL			},
     { "[8088] Super PC/Turbo XT",		"pcxt",			MACHINE_TYPE_8088,		CPU_PKG_8088, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PC,									   64,   640,  64,    0,		 machine_xt_pcxt_init, NULL			},
     { "[8088] Tandy 1000",			"tandy",		MACHINE_TYPE_8088,		CPU_PKG_8088_EUROPC, 0, 0, 0, 0, 0, 0, 0,									MACHINE_PC | MACHINE_VIDEO_FIXED,						  128,   640, 128,    0,		   machine_tandy_init, tandy1k_get_device	},
@@ -172,7 +178,11 @@ const machine_t machines[] = {
     { "[ISA] IBM XT Model 286",			"ibmxt286",		MACHINE_TYPE_286,		CPU_PKG_286, 0, 6000000, 6000000, 0, 0, 0, 0,									MACHINE_AT,									  256, 15872, 128,  127,	     machine_at_ibmxt286_init, NULL			},
     /* AMI BIOS for a chipset-less machine, most likely has AMI 'F' KBC firmware. */
     { "[ISA] AMI IBM AT",			"ibmatami",		MACHINE_TYPE_286,		CPU_PKG_286, 0, 6000000, 8000000, 0, 0, 0, 0,									MACHINE_AT,									  256, 15872, 128,   63,	     machine_at_ibmatami_init, NULL			},
-    /* Uses Commodore (CBM) KBC firmware, to be implemented as identical to the
+    /* */
+    { "[ISA] California Access 286",			"ca286",		MACHINE_TYPE_286,		CPU_PKG_286, 0, 0, 0, 0, 0, 0, 0,									MACHINE_AT,									  256, 15872, 128,   63,		machine_at_ca286_init, NULL			},
+    /* */
+    { "[ISA] CAT102 Clone",			"cat102",		MACHINE_TYPE_286,		CPU_PKG_286, 0, 0, 0, 0, 0, 0, 0,									MACHINE_AT,									  256, 15872, 128,   63,		machine_at_cat102_init, NULL			},
+     /* Uses Commodore (CBM) KBC firmware, to be implemented as identical to the
        IBM AT KBC firmware unless evidence emerges of any proprietary commands. */
     { "[ISA] Commodore PC 30 III",		"cmdpc30",		MACHINE_TYPE_286,		CPU_PKG_286, 0, 0, 0, 0, 0, 0, 0,										MACHINE_AT,									  640, 16384, 128,  127,		machine_at_cmdpc_init, NULL			},
     /* Uses Compaq KBC firmware. */
@@ -455,6 +465,8 @@ const machine_t machines[] = {
     { "[SiS 496] Zida Tomato 4DP",		"4dps",			MACHINE_TYPE_486_S3,		CPU_PKG_SOCKET3, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PCI | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,				 1024, 261120, 1024, 255,		 machine_at_4dps_init, NULL			},
     /* This has the UMC 88xx on-chip KBC. */
     { "[UMC 8881] A-Trend ATC-1415",		"atc1415",		MACHINE_TYPE_486_S3,		CPU_PKG_SOCKET3, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PCI | MACHINE_IDE_DUAL,							 1024,  65536, 1024, 255,	      machine_at_atc1415_init, NULL			},
+    /* */
+    { "[UMC 8881] Amstrad PC9486",		"apc9486",		MACHINE_TYPE_486_S3,		CPU_PKG_SOCKET3, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PCI | MACHINE_BUS_PS2 | MACHINE_IDE_DUAL,				 1024, 131072, 1024, 255,	   machine_at_apc9486_init, NULL			},
     /* This has an AMIKey-2, which is an updated version of type 'H'. */
     { "[UMC 8881] ECS Elite UM8810PAIO",	"ecs486",		MACHINE_TYPE_486_S3,		CPU_PKG_SOCKET3, 0, 0, 0, 0, 0, 0, 0,										MACHINE_PCI | MACHINE_IDE_DUAL,							 1024, 131072, 1024, 255,	       machine_at_ecs486_init, NULL			},
     /* Has AMIKey Z(!) KBC firmware. */


### PR DESCRIPTION
Summary
=======
Add support for the following PCs:
1) Bondwell BW230
2) Hyosung Topstar 88T
3) Hyundai SUPER-16T
4) Hyundai SUPER-16TE
5) Kaypro PC
6) Sanyo SX-16
7) Amstrad PC9486
8) California Access 286
9) CAT102 Based Clone

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/159

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
