### PR TITLE
cmake: Enable 64-bit file support on 32-bit Linux

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,10 @@ add_executable(86Box 86box.c config.c log.c random.c timer.c io.c acpi.c apm.c
     dma.c ddma.c discord.c nmi.c pic.c pit.c port_6x.c port_92.c ppi.c pci.c
     mca.c usb.c fifo8.c device.c nvr.c nvr_at.c nvr_ps2.c)
 
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+    add_compile_definitions(_FILE_OFFSET_BITS=64 _LARGEFILE_SOURCE=1 _LARGEFILE64_SOURCE=1)
+endif()
+
 if(CPPTHREADS)
     target_sources(86Box PRIVATE thread.cpp)
 endif()


### PR DESCRIPTION
Summary
=======
cmake: Enable 64-bit file support on 32-bit Linux

This is to allow proper support for large files on 32-bit Linux.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
