### PR TITLE
qt: Avoid reading absolute mouse input from cross-platform Qt code on Windows

### DIFF
--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -174,7 +174,7 @@ RendererStack::mouseMoveEvent(QMouseEvent *event)
         event->ignore();
         return;
     }
-#ifdef __APPLE__
+#if defined __APPLE__ || defined _WIN32
     event->accept();
     return;
 #else


### PR DESCRIPTION
Summary
=======
qt: Avoid reading absolute mouse input from cross-platform Qt code on Windows

This ensures only RAWINPUT sends mouse input to the emulated machine on Windows.


Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
