### PR TITLE
Fix Qt 6 build and modifier key handling on macOS

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -22,6 +22,14 @@ endif()
 find_package(Threads REQUIRED)
 find_package(Qt${QT_MAJOR} COMPONENTS Core Widgets Network OpenGL REQUIRED)
 find_package(Qt${QT_MAJOR}LinguistTools REQUIRED)
+# TODO: Is this the correct way to do this, and is it required on any
+# other platforms or with Qt 5?
+if(APPLE AND USE_QT6)
+    find_package(Qt6Gui/Qt6QCocoaIntegrationPlugin REQUIRED)
+    find_package(Qt6Widgets/Qt6QMacStylePlugin REQUIRED)
+    find_package(Qt6Gui/Qt6QICOPlugin REQUIRED)
+    find_package(Qt6Gui/Qt6QICNSPlugin REQUIRED)
+endif()
 
 add_library(plat STATIC
     qt.c
@@ -232,17 +240,13 @@ if (APPLE AND CMAKE_MACOSX_BUNDLE)
     set(INSTALL_CMAKE_DIR "${prefix}/Resources")
 
     # using the install_qt5_plugin to add Qt plugins into the macOS app bundle
-    if (USE_QT6)
-        install_qt5_plugin("Qt6::QCocoaIntegrationPlugin" QT_PLUGINS ${prefix})
-    else()
-        install_qt5_plugin("Qt5::QCocoaIntegrationPlugin" QT_PLUGINS ${prefix})
-        install_qt5_plugin("Qt5::QMacStylePlugin" QT_PLUGINS ${prefix})
-        install_qt5_plugin("Qt5::QICOPlugin" QT_PLUGINS ${prefix})
-        install_qt5_plugin("Qt5::QICNSPlugin" QT_PLUGINS ${prefix})
-    endif()
+    install_qt5_plugin("Qt${QT_MAJOR}::QCocoaIntegrationPlugin" QT_PLUGINS ${prefix})
+    install_qt5_plugin("Qt${QT_MAJOR}::QMacStylePlugin" QT_PLUGINS ${prefix})
+    install_qt5_plugin("Qt${QT_MAJOR}::QICOPlugin" QT_PLUGINS ${prefix})
+    install_qt5_plugin("Qt${QT_MAJOR}::QICNSPlugin" QT_PLUGINS ${prefix})
     
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/qt.conf"
-        "[Paths]\nPlugins = ${_qt_plugin_dir}\n")
+        "[Paths]\nPlugins = PlugIns\n")
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/qt.conf"
         DESTINATION "${INSTALL_CMAKE_DIR}")
 
@@ -253,8 +257,8 @@ if (APPLE AND CMAKE_MACOSX_BUNDLE)
         endforeach()
     endif()
 
-    # Append Qt's lib folder which is two levels above Qt5Widgets_DIR
-    list(APPEND DIRS "${Qt5Widgets_DIR}/../..")
+    # Append Qt's lib folder which is two levels above Qt*Widgets_DIR
+    list(APPEND DIRS "${Qt${QT_MAJOR}Widgets_DIR}/../..")
 
     include(InstallRequiredSystemLibraries)
 

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -118,6 +118,11 @@ private:
     std::unique_ptr<MachineStatus> status;
     std::shared_ptr<MediaMenu> mm;
 
+#ifdef Q_OS_MACOS
+    uint32_t last_modifiers = 0;
+    void processMacKeyboardInput(bool down, const QKeyEvent* event);
+#endif
+
     /* If main window should send keyboard input */
     bool send_keyboard_input = true;
     bool shownonce = false;


### PR DESCRIPTION
Summary
=======
Fix some build system issues with Qt 6 on macOS and work around a modifier key input handling bug on the same configuration. See the commit messages for the gory details.

I've tested these changes on macOS 12.3 (on Apple Silicon, but using an x86-64 build of 86Box).

A possible alternative to consider would be to switch input handling to something like [qkeycode](https://github.com/nyanpasu64/qkeycode), which abstracts away the platform differences using code based on Qt WebEngine and would obviate the need for platform-specific input handling and tables.  Since it would involve dealing with adding another potentially-vendored dependency and qkeycode isn't currently as effective as this manual handling (it doesn't distinguish left and right modifiers on macOS and I'd need to send a patch upstream to fix that), I haven't pursued that option currently. Given the flakiness of Qt's input handling and the amount of code the per-platform tables and hacks take, though, it might be worth considering for the future.

I have some additional work-in-progress patches to address some additional macOS infelicities and in particular to fix issues with Apple Silicon builds and allow universal AArch64 + x86-64 app bundles to be created, but they need some extra polishing and testing so I'm just getting these quick fixes sent off now.

Checklist
=========
* [x] Closes #2211
* [ ] I have discussed this with core contributors already
   Hopefully not necessary as these are just relatively straightforward fixes; is the IRC channel or the Discord the better place to discuss any further changes?
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
* [QTBUG-69608](https://bugreports.qt.io/browse/QTBUG-69608)