### PR TITLE
unix: Fix missing include

### DIFF
--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -18,6 +18,7 @@
 #include <inttypes.h>
 #include <dlfcn.h>
 #include <wchar.h>
+#include <pwd.h>
 #include <stdatomic.h>
 
 #include <86box/86box.h>


### PR DESCRIPTION
Summary
=======
unix: Fix missing include needed for ROM paths code.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
