### PR TITLE
qt: Fix crashes on failed loads of media images

### DIFF
--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -338,6 +338,9 @@ void MediaMenu::floppyExportTo86f(int i) {
 void MediaMenu::floppyUpdateMenu(int i) {
     QString name = floppyfns[i];
 
+    if (!floppyMenus.contains(i))
+        return;
+
     auto* menu = floppyMenus[i];
     auto childs = menu->children();
 
@@ -412,6 +415,8 @@ void MediaMenu::cdromReload(int i) {
 
 void MediaMenu::cdromUpdateMenu(int i) {
     QString name = cdrom[i].image_path;
+    if (!cdromMenus.contains(i))
+        return;
     auto* menu = cdromMenus[i];
     auto childs = menu->children();
 
@@ -515,6 +520,8 @@ void MediaMenu::zipReload(int i) {
 void MediaMenu::zipUpdateMenu(int i) {
     QString name = zip_drives[i].image_path;
     QString prev_name = zip_drives[i].prev_image_path;
+    if (!zipMenus.contains(i))
+        return;
     auto* menu = zipMenus[i];
     auto childs = menu->children();
 
@@ -612,6 +619,8 @@ void MediaMenu::moReload(int i) {
 void MediaMenu::moUpdateMenu(int i) {
     QString name = mo_drives[i].image_path;
     QString prev_name = mo_drives[i].prev_image_path;
+    if (!moMenus.contains(i))
+        return;
     auto* menu = moMenus[i];
     auto childs = menu->children();
 


### PR DESCRIPTION
Summary
=======
qt: Fix crashes on failed loads of media images

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
