### PR TITLE
qt: Give the user the option to extract ROM set from a zip file if no ROMs are found

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -31,6 +31,8 @@ if(APPLE AND USE_QT6)
     find_package(Qt6Gui/Qt6QICNSPlugin REQUIRED)
 endif()
 
+find_package(libzip REQUIRED)
+
 add_library(plat STATIC
     qt.c
     qt_main.cpp
@@ -153,6 +155,7 @@ if(RTMIDI)
     target_compile_definitions(ui PRIVATE USE_RTMIDI)
 endif()
 
+target_link_libraries(ui PUBLIC libzip::zip)
 
 if(WIN32)
     enable_language(RC)

--- a/src/qt/languages/en-US.po
+++ b/src/qt/languages/en-US.po
@@ -1183,3 +1183,5 @@ msgstr "2% below perfect RPM"
 msgid "(System Default)"
 msgstr "(System Default)"
 
+msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory. If you have already downloaded it, press OK to select the downloaded ROM set to extract."
+msgstr "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory. If you have already downloaded it, press OK to select the downloaded ROM set to extract."


### PR DESCRIPTION
Summary
=======
qt: Give the user the option to extract ROM set from a zip file if no ROMs are found.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
