### PR TITLE
Don't accept a directory as config file parameter

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -507,7 +507,7 @@ usage:
 			rom_add_path(rpath);
 		} else if (!strcasecmp(argv[c], "--config") ||
 			   !strcasecmp(argv[c], "-C")) {
-			if ((c+1) == argc) goto usage;
+			if ((c+1) == argc || plat_dir_check(argv[c + 1])) goto usage;
 
 			cfg = argv[++c];
 		} else if (!strcasecmp(argv[c], "--vmname") ||


### PR DESCRIPTION
Summary
=======
Don't accept a directory as config file parameter.

Fixes startup freeze if the config file specified on the command line turns out to be a directory.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
