### PR TITLE
qt: Fix dangling pointers on Vulkan init failure

### DIFF
--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -301,6 +301,7 @@ RendererStack::createRenderer(Renderer renderer)
                 imagebufs = {};
                 endblit();
                 QTimer::singleShot(0, this, [this]() { switchRenderer(Renderer::Software); });
+                current.reset(nullptr);
                 break;
             };
             rendererWindow = hw;
@@ -325,7 +326,7 @@ RendererStack::createRenderer(Renderer renderer)
         }
 #endif
     }
-
+    if (current.get() == nullptr) return;
     current->setFocusPolicy(Qt::NoFocus);
     current->setFocusProxy(this);
     addWidget(current.get());

--- a/src/qt/qt_settings.cpp
+++ b/src/qt/qt_settings.cpp
@@ -105,6 +105,11 @@ Settings::Settings(QWidget *parent) :
     ui->setupUi(this);
 
     ui->listView->setModel(new SettingsModel(this));
+    ui->listView->setFlow(QListView::TopToBottom);
+    ui->listView->setWrapping(false);
+    ui->listView->setWordWrap(true);
+    ui->listView->setItemAlignment(Qt::AlignmentFlag::AlignHCenter);
+    ui->listView->setUniformItemSizes(true);
 
     Harddrives::busTrackClass = new SettingsBusTracking;
     machine = new SettingsMachine(this);
@@ -130,8 +135,6 @@ Settings::Settings(QWidget *parent) :
     ui->stackedWidget->addWidget(floppyCdrom);
     ui->stackedWidget->addWidget(otherRemovable);
     ui->stackedWidget->addWidget(otherPeripherals);
-
-    ui->listView->setFixedWidth(ui->listView->sizeHintForColumn(0) + 5);
 
     connect(machine, &SettingsMachine::currentMachineChanged, display, &SettingsDisplay::onCurrentMachineChanged);
     connect(machine, &SettingsMachine::currentMachineChanged, input, &SettingsInput::onCurrentMachineChanged);

--- a/src/qt/qt_settings.ui
+++ b/src/qt/qt_settings.ui
@@ -30,7 +30,11 @@
     <widget class="QWidget" name="widget" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,3">
       <item>
-       <widget class="QListView" name="listView"/>
+       <widget class="QListView" name="listView">
+        <property name="viewMode">
+         <enum>QListView::IconMode</enum>
+        </property>
+       </widget>
       </item>
       <item>
        <widget class="QStackedWidget" name="stackedWidget">


### PR DESCRIPTION
Summary
=======
qt: Fix dangling pointers on Vulkan init failure

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
