### PR TITLE
With bumpversion.sh my hack to update metainfo.xml is obsolete

### DIFF
--- a/bumpversion.sh
+++ b/bumpversion.sh
@@ -67,6 +67,5 @@ patch_file src/include_make/*/version.h EMU_VERSION_MIN 's/(#\s*define\s+EMU_VER
 patch_file src/include_make/*/version.h EMU_VERSION_PATCH 's/(#\s*define\s+EMU_VERSION_PATCH\s+)[0-9]+/\1'"$newversion_patch"'/'
 patch_file src/include_make/*/version.h COPYRIGHT_YEAR 's/(#\s*define\s+COPYRIGHT_YEAR\s+)[0-9]+/\1'"$(date +%Y)"'/'
 patch_file src/include_make/*/version.h EMU_DOCS_URL 's/(#\s*define\s+EMU_DOCS_URL\s+"https:\/\/[^\/]+\/en\/v)[^\/]+/\1'"$newversion_maj.$newversion_min"'/'
-patch_file src/unix/assets/*.spec date 's/(%global\s+date\s+).+/\1'"$(date +%Y-%m-%d)"'/'
 patch_file src/unix/assets/*.spec Version 's/(Version:\s+)[0-9].+/\1'"$newversion"'/'
 patch_file src/unix/assets/*.metainfo.xml release 's/(<release version=")[^"]+(" date=")[^"]+/\1'"$newversion"'\2'"$(date +%Y-%m-%d)"'/'

--- a/src/unix/assets/86Box.spec
+++ b/src/unix/assets/86Box.spec
@@ -12,7 +12,6 @@
 # After a successful build, you can install the RPMs as follows:
 #  sudo dnf install RPMS/$(uname -m)/86Box-3* RPMS/noarch/86Box-roms*
 
-%global date 2022-04-26
 %global romver 20220319
 
 Name:		86Box
@@ -95,7 +94,6 @@ desktop-file-install --dir=%{buildroot}%{_datadir}/applications src/unix/assets/
 # install metadata
 mkdir -p %{buildroot}%{_metainfodir}
 cp src/unix/assets/net.86box.86Box.metainfo.xml %{buildroot}%{_metainfodir}
-sed -i 's/<release version.*/<release version="%{version}" date="%{date}"\/>/' %{buildroot}%{_metainfodir}/net.86box.86Box.metainfo.xml
 appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/net.86box.86Box.metainfo.xml
 
 # install roms


### PR DESCRIPTION
Summary
=======
I had put a hack in place to update the metainfo.xml file in the RPM spec file, this is no longer needed with bumpversion.sh

The only thing missing from `bumpversion.sh` that I can quickly see, is updating the roms date in the spec file.