### PR TITLE
Dont add the fdc twice to the vendex

### DIFF
--- a/src/machine/m_xt.c
+++ b/src/machine/m_xt.c
@@ -451,9 +451,6 @@ machine_xt_vendex_init(const machine_t *model)
 
     machine_xt_clone_init(model);
 
-    /* On-board FDC cannot be disabled */
-	device_add(&fdc_xt_device);
-
     return ret;
 }
 


### PR DESCRIPTION
Summary
=======
Prevents the vendex adding the FDC twice. (Doesn't fix the HDD at drive E bug, that's elsewhere and harder to resolve)

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
