### PR TITLE
change m24 BIOS rom to newer 1.44 version

### DIFF
--- a/src/machine/m_xt_olivetti.c
+++ b/src/machine/m_xt_olivetti.c
@@ -752,8 +752,8 @@ machine_xt_m24_init(const machine_t *model)
     int ret;
     m24_kbd_t *m24_kbd;
 
-    ret = bios_load_interleaved("roms/machines/m24/olivetti_m24_version_1.43_low.bin",
-				"roms/machines/m24/olivetti_m24_version_1.43_high.bin",
+    ret = bios_load_interleaved("roms/machines/m24/olivetti_m24_bios_version_1.44_low_even.bin",
+				"roms/machines/m24/olivetti_m24_bios_version_1.44_high_odd.bin",
 				0x000fc000, 16384, 0);
 
     if (bios_only || !ret)


### PR DESCRIPTION
https://forum.vcfed.org/index.php?threads/olivetti-m21-m24-with-bios-version-1-44.72815/

Summary
=======
change BIOS rom from 1.43 to 1.44

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ X] This pull request requires changes to the ROM set
  * [ X] I have opened a roms pull request - https://github.com/86Box/roms/pull/165

References
==========
https://forum.vcfed.org/index.php?threads/olivetti-m21-m24-with-bios-version-1-44.72815/
