### PR TITLE
Fixed the 8514/A to VGA soft reset and made the vga_on variable a global one

### DIFF
--- a/src/cpu/x86.c
+++ b/src/cpu/x86.c
@@ -36,6 +36,8 @@
 #include <86box/pci.h>
 #include <86box/ppi.h>
 #include <86box/timer.h>
+#include <86box/video.h>
+#include <86box/vid_svga.h>
 
 /* The opcode of the instruction currently being executed. */
 uint8_t opcode;
@@ -340,6 +342,9 @@ softresetx86(void)
 {
     if (soft_reset_mask)
 	return;
+
+    if (ibm8514_enabled)
+        vga_on = 1;
 
     reset_common(0);
 }

--- a/src/include/86box/vid_svga.h
+++ b/src/include/86box/vid_svga.h
@@ -165,8 +165,6 @@ typedef struct svga_t
 
 	int force_old_addr;
 
-    int vga_on;
-
 	int remap_required;
 	uint32_t (*remap_func)(struct svga_t *svga, uint32_t in_addr);
 
@@ -174,6 +172,7 @@ typedef struct svga_t
 } svga_t;
 
 extern svga_t *svga_8514;
+extern int vga_on;
 
 extern void ibm8514_poll(ibm8514_t *dev, svga_t *svga);
 extern void ibm8514_recalctimings(svga_t *svga);

--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -958,8 +958,8 @@ ibm8514_accel_out(uint16_t port, uint32_t val, svga_t *svga, int len)
 
             case 0x4ae8:
                 dev->accel.advfunc_cntl = val & 7;
-                svga->vga_on = ((dev->accel.advfunc_cntl & 1) == 0) ? 1 : 0;
-                //pclog("IBM 8514/A: VGA ON = %i, val = %02x\n", svga->vga_on, val);
+                vga_on = ((dev->accel.advfunc_cntl & 1) == 0) ? 1 : 0;
+                //pclog("IBM 8514/A: VGA ON = %i, val = %02x\n", vga_on, val);
                 svga_recalctimings(svga);
                 break;
         }

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -53,7 +53,7 @@ uint8_t		svga_rotate[8][256];
 /*Primary SVGA device. As multiple video cards are not yet supported this is the
   only SVGA device.*/
 static svga_t	*svga_pri;
-
+int vga_on;
 
 svga_t
 *svga_get_pri()
@@ -554,7 +554,7 @@ svga_recalctimings(svga_t *svga)
     } else
 	overscan_x  = 16;
 
-    if (svga->vga_on) {
+    if (vga_on) {
         if (svga->recalctimings_ex) {
             svga->recalctimings_ex(svga);
         }
@@ -657,7 +657,7 @@ svga_poll(void *p)
     int wx, wy;
     int ret, old_ma;
 
-    if (!svga->vga_on) {
+    if (!vga_on) {
         ibm8514_poll(&svga->dev8514, svga);
         return;
     }
@@ -968,7 +968,7 @@ svga_init(const device_t *info, svga_t *svga, void *p, int memsize,
     svga->translate_address = NULL;
     svga->ksc5601_english_font_type = 0;
 
-    svga->vga_on = 1;
+    vga_on = 1;
 
     if ((info->flags & DEVICE_PCI) || (info->flags & DEVICE_VLB) || (info->flags & DEVICE_MCA)) {
 	    mem_mapping_add(&svga->mapping, 0xa0000, 0x20000,


### PR DESCRIPTION
to make sure it's used by the soft reset.

Updated copyright holder that was accidentally reverted while committing the IBM 8514/A source files.

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
