### PR TITLE
Fix building on macOS without Qt

### DIFF
--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -806,7 +806,7 @@ plat_init_rom_paths()
 #else
     char default_rom_path[1024] = { '\0 '};
     getDefaultROMPath(default_rom_path);
-    rom_path_add(default_rom_path);
+    rom_add_path(default_rom_path);
 #endif
 }
 


### PR DESCRIPTION
Summary
=======
Fix typo in unix.c preventing build on macOS with Qt disabled

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
