### PR TITLE
qt: Disable 8514/A selection for all S3 video cards

### DIFF
--- a/src/qt/qt_settingsdisplay.cpp
+++ b/src/qt/qt_settingsdisplay.cpp
@@ -117,10 +117,12 @@ void SettingsDisplay::on_comboBoxVideo_currentIndexChanged(int index) {
 
     bool hasIsa16 = machine_has_bus(machineId, MACHINE_BUS_ISA | MACHINE_AT) > 0;
     bool has_MCA = machine_has_bus(machineId, MACHINE_BUS_MCA) > 0;
-    ui->checkBox8514->setEnabled(hasIsa16 || has_MCA);
-    if (hasIsa16 || has_MCA) {
+    bool isS3 = ui->comboBoxVideo->currentText().contains("S3");
+    ui->checkBox8514->setEnabled((hasIsa16 || has_MCA) && !isS3);
+    if ((hasIsa16 || has_MCA) && !isS3) {
         ui->checkBox8514->setChecked(ibm8514_enabled > 0);
     }
+    else ui->checkBox8514->setChecked(0);
 }
 
 void SettingsDisplay::on_checkBoxVoodoo_stateChanged(int state) {


### PR DESCRIPTION
Summary
=======
qt: Disable 8514/A selection for all S3 video cards.

S3 cards make use of IO ports that are also used by the 8514/A. Disable 8514/A selections when a S3 card is selected.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
