### PR TITLE
qt: Add MCA device list to Tools

### DIFF
--- a/src/include/86box/mca.h
+++ b/src/include/86box/mca.h
@@ -5,8 +5,10 @@ extern void mca_init(int nr_cards);
 extern void mca_add(uint8_t (*read)(int addr, void *priv), void (*write)(int addr, uint8_t val, void *priv), uint8_t (*feedb)(void *priv), void (*reset)(void *priv), void *priv);
 extern void mca_set_index(int index);
 extern uint8_t mca_read(uint16_t port);
+extern uint8_t mca_read_index(uint16_t port, int index);
 extern void mca_write(uint16_t port, uint8_t val);
 extern uint8_t mca_feedb(void);
+extern int mca_get_nr_cards(void);
 extern void mca_reset(void);
 
 extern void ps2_cache_clean(void);

--- a/src/mca.c
+++ b/src/mca.c
@@ -45,6 +45,20 @@ uint8_t mca_read(uint16_t port)
 	return mca_card_read[mca_index](port, mca_priv[mca_index]);
 }
 
+uint8_t mca_read_index(uint16_t port, int index)
+{
+	if (mca_index >= mca_nr_cards)
+		return 0xff;
+	if (!mca_card_read[index])
+		return 0xff;
+	return mca_card_read[index](port, mca_priv[index]);
+}
+
+int mca_get_nr_cards(void)
+{
+	return mca_nr_cards;
+}
+
 void mca_write(uint16_t port, uint8_t val)
 {
 	if (mca_index >= mca_nr_cards)

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -151,6 +151,10 @@ add_library(ui STATIC
     qt_vulkanrenderer.hpp
     qt_vulkanrenderer.cpp
 
+    qt_mcadevicelist.hpp
+    qt_mcadevicelist.cpp
+    qt_mcadevicelist.ui
+
     ../qt_resources.qrc
 )
 

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -26,6 +26,7 @@
 #include "qt_specifydimensions.h"
 #include "qt_soundgain.hpp"
 #include "qt_progsettings.hpp"
+#include "qt_mcadevicelist.hpp"
 
 #include "qt_rendererstack.hpp"
 #include "qt_renderercommon.hpp"
@@ -1875,3 +1876,12 @@ void MainWindow::on_actionRenderer_options_triggered()
     if (dlg)
         dlg->exec();
 }
+
+void MainWindow::on_actionMCA_devices_triggered()
+{
+    auto dlg = new MCADeviceList(this);
+
+    if (dlg)
+        dlg->exec();
+}
+

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -103,6 +103,8 @@ private slots:
     void showMessage_(const QString& header, const QString& message);
     void getTitle_(wchar_t* title);
 
+    void on_actionMCA_devices_triggered();
+
 protected:
     void keyPressEvent(QKeyEvent* event) override;
     void keyReleaseEvent(QKeyEvent* event) override;

--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -89,6 +89,8 @@
     <addaction name="separator"/>
     <addaction name="actionBegin_trace"/>
     <addaction name="actionEnd_trace"/>
+    <addaction name="separator"/>
+    <addaction name="actionMCA_devices"/>
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
@@ -736,6 +738,11 @@
    </property>
    <property name="vid_api" stdset="0">
     <number>4</number>
+   </property>
+  </action>
+  <action name="actionMCA_devices">
+   <property name="text">
+    <string>MCA devices...</string>
    </property>
   </action>
  </widget>

--- a/src/qt/qt_mcadevicelist.cpp
+++ b/src/qt/qt_mcadevicelist.cpp
@@ -1,0 +1,42 @@
+#include "qt_mcadevicelist.hpp"
+#include "ui_qt_mcadevicelist.h"
+
+extern "C"
+{
+#include <86box/86box.h>
+#include <86box/video.h>
+#include <86box/mca.h>
+#include <86box/plat.h>
+}
+
+MCADeviceList::MCADeviceList(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::MCADeviceList)
+{
+    ui->setupUi(this);
+
+    startblit();
+    if (mca_get_nr_cards() == 0)
+    {
+        ui->listWidget->addItem(QObject::tr("No MCA devices."));
+        ui->listWidget->setDisabled(true);
+    }
+    else
+    {
+        for (int i = 0; i < mca_get_nr_cards(); i++)
+        {
+            uint32_t deviceId = (mca_read_index(0x00, i) | (mca_read_index(0x01, i) << 8));
+            if (deviceId != 0xFFFF)
+            {
+                QString hexRepresentation = QString::number(deviceId, 16).toUpper();
+                ui->listWidget->addItem(QString("Slot %1: 0x%2 (@%3.ADF)").arg(i).arg(hexRepresentation, hexRepresentation));
+            }
+        }
+    }
+    endblit();
+}
+
+MCADeviceList::~MCADeviceList()
+{
+    delete ui;
+}

--- a/src/qt/qt_mcadevicelist.cpp
+++ b/src/qt/qt_mcadevicelist.cpp
@@ -29,7 +29,7 @@ MCADeviceList::MCADeviceList(QWidget *parent) :
             if (deviceId != 0xFFFF)
             {
                 QString hexRepresentation = QString::number(deviceId, 16).toUpper();
-                ui->listWidget->addItem(QString("Slot %1: 0x%2 (@%3.ADF)").arg(i).arg(hexRepresentation, hexRepresentation));
+                ui->listWidget->addItem(QString("Slot %1: 0x%2 (@%3.ADF)").arg(i + 1).arg(hexRepresentation, hexRepresentation));
             }
         }
     }

--- a/src/qt/qt_mcadevicelist.hpp
+++ b/src/qt/qt_mcadevicelist.hpp
@@ -1,0 +1,22 @@
+#ifndef QT_MCADEVICELIST_HPP
+#define QT_MCADEVICELIST_HPP
+
+#include <QDialog>
+
+namespace Ui {
+class MCADeviceList;
+}
+
+class MCADeviceList : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit MCADeviceList(QWidget *parent = nullptr);
+    ~MCADeviceList();
+
+private:
+    Ui::MCADeviceList *ui;
+};
+
+#endif // QT_MCADEVICELIST_HPP

--- a/src/qt/qt_mcadevicelist.ui
+++ b/src/qt/qt_mcadevicelist.ui
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MCADeviceList</class>
+ <widget class="QDialog" name="MCADeviceList">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>List of MCA devices:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QListWidget" name="listWidget"/>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>MCADeviceList</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>MCADeviceList</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/qt/qt_mcadevicelist.ui
+++ b/src/qt/qt_mcadevicelist.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>MCA devices</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -30,7 +30,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Summary
=======
This PR adds a dialog that lists all MCA devices that currently exist in the emulated machine, with the MCA IDs of said devices. The dialog can be accessed from the Tools menu.

Note that this doesn't include the friendly name of the devices.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
