### PR TITLE
qt: Add Drag And Drop support for removable media icons

### DIFF
--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -392,7 +392,11 @@ void MachineStatus::refresh(QStatusBar* sbar) {
         connect((ClickableLabel*)d->fdd[i].label.get(), &ClickableLabel::clicked, [i](QPoint pos) {
             MediaMenu::ptr->floppyMenus[i]->popup(pos - QPoint(0, MediaMenu::ptr->floppyMenus[i]->sizeHint().height()));
         });
+        connect((ClickableLabel*)d->fdd[i].label.get(), &ClickableLabel::dropped, [i](QString str) {
+            MediaMenu::ptr->floppyMount(i, str, false);
+        });
         d->fdd[i].label->setToolTip(MediaMenu::ptr->floppyMenus[i]->title());
+        d->fdd[i].label->setAcceptDrops(true);
         sbar->addWidget(d->fdd[i].label.get());
     });
 
@@ -403,7 +407,11 @@ void MachineStatus::refresh(QStatusBar* sbar) {
         connect((ClickableLabel*)d->cdrom[i].label.get(), &ClickableLabel::clicked, [i](QPoint pos) {
             MediaMenu::ptr->cdromMenus[i]->popup(pos - QPoint(0, MediaMenu::ptr->cdromMenus[i]->sizeHint().height()));
         });
+        connect((ClickableLabel*)d->cdrom[i].label.get(), &ClickableLabel::dropped, [i](QString str) {
+            MediaMenu::ptr->cdromMount(i, str);
+        });
         d->cdrom[i].label->setToolTip(MediaMenu::ptr->cdromMenus[i]->title());
+        d->cdrom[i].label->setAcceptDrops(true);
         sbar->addWidget(d->cdrom[i].label.get());
     });
 
@@ -414,7 +422,11 @@ void MachineStatus::refresh(QStatusBar* sbar) {
         connect((ClickableLabel*)d->zip[i].label.get(), &ClickableLabel::clicked, [i](QPoint pos) {
             MediaMenu::ptr->zipMenus[i]->popup(pos - QPoint(0, MediaMenu::ptr->zipMenus[i]->sizeHint().height()));
         });
+        connect((ClickableLabel*)d->zip[i].label.get(), &ClickableLabel::dropped, [i](QString str) {
+            MediaMenu::ptr->zipMount(i, str, false);
+        });
         d->zip[i].label->setToolTip(MediaMenu::ptr->zipMenus[i]->title());
+        d->zip[i].label->setAcceptDrops(true);
         sbar->addWidget(d->zip[i].label.get());
     });
 
@@ -425,7 +437,11 @@ void MachineStatus::refresh(QStatusBar* sbar) {
         connect((ClickableLabel*)d->mo[i].label.get(), &ClickableLabel::clicked, [i](QPoint pos) {
             MediaMenu::ptr->moMenus[i]->popup(pos - QPoint(0, MediaMenu::ptr->moMenus[i]->sizeHint().height()));
         });
+        connect((ClickableLabel*)d->mo[i].label.get(), &ClickableLabel::dropped, [i](QString str) {
+            MediaMenu::ptr->moMount(i, str, false);
+        });
         d->mo[i].label->setToolTip(MediaMenu::ptr->moMenus[i]->title());
+        d->mo[i].label->setAcceptDrops(true);
         sbar->addWidget(d->mo[i].label.get());
     });
 

--- a/src/qt/qt_machinestatus.hpp
+++ b/src/qt/qt_machinestatus.hpp
@@ -4,6 +4,7 @@
 #include <QWidget>
 #include <QLabel>
 #include <QMouseEvent>
+#include <QMimeData>
 
 #include <memory>
 
@@ -19,10 +20,35 @@ class ClickableLabel : public QLabel {
     signals:
         void clicked(QPoint);
         void doubleClicked(QPoint);
+        void dropped(QString);
 
     protected:
         void mousePressEvent(QMouseEvent* event) override { emit clicked(event->globalPos()); }
         void mouseDoubleClickEvent(QMouseEvent* event) override { emit doubleClicked(event->globalPos()); }
+        void dragEnterEvent(QDragEnterEvent* event) override
+        {
+            if (event->mimeData()->hasUrls() && event->mimeData()->urls().size() == 1) {
+                event->setDropAction(Qt::CopyAction);
+                event->acceptProposedAction();
+            }
+            else event->ignore();
+        }
+        void dragMoveEvent(QDragMoveEvent* event) override
+        {
+            if (event->mimeData()->hasUrls() && event->mimeData()->urls().size() == 1) {
+                event->setDropAction(Qt::CopyAction);
+                event->acceptProposedAction();
+            }
+            else event->ignore();
+        }
+        void dropEvent(QDropEvent* event) override
+        {
+            if (event->dropAction() == Qt::CopyAction)
+            {
+                emit dropped(event->mimeData()->urls()[0].toLocalFile());
+            }
+            else event->ignore();
+        }
 };
 
 class MachineStatus : public QObject

--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -361,22 +361,8 @@ void MediaMenu::cdromMute(int i) {
     sound_cd_thread_reset();
 }
 
-void MediaMenu::cdromMount(int i) {
-    QString dir;
-    QFileInfo fi(cdrom[i].image_path);
-
-    auto filename = QFileDialog::getOpenFileName(
-        parentWidget,
-        QString(),
-        QString(),
-        tr("CD-ROM images") %
-        util::DlgFilter({ "iso","cue" }) %
-        tr("All files") %
-        util::DlgFilter({ "*" }, true));
-
-    if (filename.isEmpty()) {
-        return;
-    }
+void MediaMenu::cdromMount(int i, const QString &filename)
+{
     QByteArray fn = filename.toUtf8().data();
 
     cdrom[i].prev_host_drive = cdrom[i].host_drive;
@@ -399,6 +385,26 @@ void MediaMenu::cdromMount(int i) {
     cdromUpdateMenu(i);
     ui_sb_update_tip(SB_CDROM | i);
     config_save();
+}
+
+void MediaMenu::cdromMount(int i) {
+    QString dir;
+    QFileInfo fi(cdrom[i].image_path);
+
+    auto filename = QFileDialog::getOpenFileName(
+        parentWidget,
+        QString(),
+        QString(),
+        tr("CD-ROM images") %
+        util::DlgFilter({ "iso","cue" }) %
+        tr("All files") %
+        util::DlgFilter({ "*" }, true));
+
+    if (filename.isEmpty()) {
+        return;
+    }
+
+    cdromMount(i, filename);
 }
 
 void MediaMenu::cdromEject(int i) {

--- a/src/qt/qt_mediamenu.hpp
+++ b/src/qt/qt_mediamenu.hpp
@@ -37,6 +37,7 @@ public:
 
     void cdromMute(int i);
     void cdromMount(int i);
+    void cdromMount(int i, const QString& filename);
     void cdromEject(int i);
     void cdromReload(int i);
     void cdromUpdateMenu(int i);


### PR DESCRIPTION
Summary
=======
qt: Add Drag And Drop support for removable media icons.

Dragging a CD-ROM/floppy/ZIP/MO image into their respective status bar icons should cause said image to be mounted into said slot respectively.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
