### PR TITLE
Fix 8514/A and GUS checkboxes not being grayed out with 8-bit ISA-only machines as intended

### DIFF
--- a/src/qt/qt_settingsdisplay.cpp
+++ b/src/qt/qt_settingsdisplay.cpp
@@ -115,7 +115,7 @@ void SettingsDisplay::on_comboBoxVideo_currentIndexChanged(int index) {
     }
     ui->pushButtonConfigureVoodoo->setEnabled(machineHasPci && ui->checkBoxVoodoo->isChecked());
 
-    bool hasIsa16 = machine_has_bus(machineId, MACHINE_BUS_ISA | MACHINE_AT) > 0;
+    bool hasIsa16 = machine_has_bus(machineId, MACHINE_BUS_ISA16) > 0;
     bool has_MCA = machine_has_bus(machineId, MACHINE_BUS_MCA) > 0;
     ui->checkBox8514->setEnabled(hasIsa16 || has_MCA);
     if (hasIsa16 || has_MCA) {

--- a/src/qt/qt_settingssound.cpp
+++ b/src/qt/qt_settingssound.cpp
@@ -144,7 +144,7 @@ void SettingsSound::onCurrentMachineChanged(int machineId) {
     ui->checkBoxFloat32->setChecked(sound_is_float > 0);
 
     bool hasIsa = machine_has_bus(machineId, MACHINE_BUS_ISA) > 0;
-    bool hasIsa16 = machine_has_bus(machineId, MACHINE_BUS_ISA) > 0;
+    bool hasIsa16 = machine_has_bus(machineId, MACHINE_BUS_ISA16) > 0;
     ui->checkBoxCMS->setEnabled(hasIsa);
     ui->pushButtonConfigureCMS->setEnabled((GAMEBLASTER > 0) && hasIsa);
     ui->checkBoxGUS->setEnabled(hasIsa16);


### PR DESCRIPTION
Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
