### PR TITLE
qt: Fix crashes and freezes when switching to/from Direct3D 9

### DIFF
--- a/src/qt/qt_d3d9renderer.cpp
+++ b/src/qt/qt_d3d9renderer.cpp
@@ -142,6 +142,7 @@ void D3D9Renderer::blit(int x, int y, int w, int h)
         video_blit_complete();
         return;
     }
+    surfaceInUse = true;
     source.setRect(x, y, w, h);
     RECT srcRect;
     D3DLOCKED_RECT lockRect;
@@ -150,7 +151,6 @@ void D3D9Renderer::blit(int x, int y, int w, int h)
     srcRect.left = source.left();
     srcRect.right = source.right();
 
-    surfaceInUse = true;
     if (screenshots) {
         video_screenshot((uint32_t *) &(buffer32->line[y][x]), 0, 0, 2048);
     }

--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -583,24 +583,25 @@ void MachineStatus::updateTip(int tag)
 {
     int category = tag & 0xfffffff0;
     int item = tag & 0xf;
+    if (!MediaMenu::ptr) return;
     switch (category) {
     case SB_CASSETTE:
-        d->cassette.label->setToolTip(MediaMenu::ptr->cassetteMenu->title());
+        if (d->cassette.label && MediaMenu::ptr->cassetteMenu) d->cassette.label->setToolTip(MediaMenu::ptr->cassetteMenu->title());
         break;
     case SB_CARTRIDGE:
-        d->cartridge[item].label->setToolTip(MediaMenu::ptr->cartridgeMenus[item]->title());
+        if (d->cartridge[item].label && MediaMenu::ptr->cartridgeMenus[item]) d->cartridge[item].label->setToolTip(MediaMenu::ptr->cartridgeMenus[item]->title());
         break;
     case SB_FLOPPY:
-        d->fdd[item].label->setToolTip(MediaMenu::ptr->floppyMenus[item]->title());
+        if (d->fdd[item].label && MediaMenu::ptr->floppyMenus[item]) d->fdd[item].label->setToolTip(MediaMenu::ptr->floppyMenus[item]->title());
         break;
     case SB_CDROM:
-        d->cdrom[item].label->setToolTip(MediaMenu::ptr->cdromMenus[item]->title());
+        if (d->cdrom[item].label && MediaMenu::ptr->cdromMenus[item]) d->cdrom[item].label->setToolTip(MediaMenu::ptr->cdromMenus[item]->title());
         break;
     case SB_ZIP:
-        d->zip[item].label->setToolTip(MediaMenu::ptr->zipMenus[item]->title());
+        if (d->zip[item].label && MediaMenu::ptr->zipMenus[item]) d->zip[item].label->setToolTip(MediaMenu::ptr->zipMenus[item]->title());
         break;
     case SB_MO:
-        d->mo[item].label->setToolTip(MediaMenu::ptr->moMenus[item]->title());
+        if (d->mo[item].label && MediaMenu::ptr->moMenus[item]) d->mo[item].label->setToolTip(MediaMenu::ptr->moMenus[item]->title());
         break;
     case SB_HDD:
         break;

--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -501,6 +501,7 @@ void MediaMenu::zipEject(int i) {
     zip_t *dev = (zip_t *) zip_drives[i].priv;
 
     zip_disk_close(dev);
+    zip_drives[i].image_path[0] = 0;
     if (zip_drives[i].bus_type) {
         /* Signal disk change to the emulated machine. */
         zip_insert(dev);
@@ -600,6 +601,7 @@ void MediaMenu::moEject(int i) {
     mo_t *dev = (mo_t *) mo_drives[i].priv;
 
     mo_disk_close(dev);
+    mo_drives[i].image_path[0] = 0;
     if (mo_drives[i].bus_type) {
         /* Signal disk change to the emulated machine. */
         mo_insert(dev);

--- a/src/qt/qt_rendererstack.hpp
+++ b/src/qt/qt_rendererstack.hpp
@@ -79,6 +79,7 @@ signals:
 public slots:
     void blitCommon(int x, int y, int w, int h);
     void blitRenderer(int x, int y, int w, int h);
+    void blitDummy(int x, int y, int w, int h);
     void mousePoll();
 
 private:
@@ -101,7 +102,7 @@ private:
 
     RendererCommon          *rendererWindow { nullptr };
     std::unique_ptr<QWidget> current;
-    std::atomic<bool> directBlitting{false};
+    std::atomic<bool> directBlitting{false}, blitDummied{false};
 };
 
 #endif // QT_RENDERERCONTAINER_HPP


### PR DESCRIPTION
Summary
=======
qt: Fix crashes and freezes when switching to/from Direct3D 9

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
