### PR TITLE
And finally, more fixes to the XGA implementation including:

### DIFF
--- a/src/cpu/x86.c
+++ b/src/cpu/x86.c
@@ -343,7 +343,7 @@ softresetx86(void)
     if (soft_reset_mask)
 	return;
 
-    if (ibm8514_enabled)
+    if (ibm8514_enabled || xga_enabled)
         vga_on = 1;
 
     reset_common(0);

--- a/src/include/86box/vid_xga.h
+++ b/src/include/86box/vid_xga.h
@@ -63,6 +63,7 @@ typedef struct xga_t
     uint8_t pal_g, pal_g_prefetch;
     uint8_t pal_b, pal_b_prefetch;
     uint8_t sprite_data[1024];
+    uint8_t scrollcache;
     uint8_t *vram, *changedvram;
 
     int16_t hwc_pos_x;
@@ -88,11 +89,9 @@ typedef struct xga_t
         char_width, hwcursor_on;
     int pal_pos, pal_pos_prefetch;
     int on;
-    int op_mode_reset;
+    int op_mode_reset, linear_endian_reverse;
     int sprite_pos, sprite_pos_prefetch, cursor_data_on;
     int pal_test;
-    int dma_channel;
-    int from_to_vram;
 
     uint32_t linear_base, linear_size, banked_mask;
     uint32_t base_addr_1mb;


### PR DESCRIPTION
Summary
=======
Cursor and mapping on Windows 2.x' 286/808x XGA driver.
Pattern and DMA bus master fixes to OS/2 2.x/Warp's XGA driver.
Software reset no longer causes glitches to the screen using XGA (x86.c)

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
