### PR TITLE
When linear framebuffer base is mapped, it's fb_only time.

### DIFF
--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -3128,6 +3128,10 @@ static void s3_recalctimings(svga_t *svga)
 			if (s3->width == 1280 || s3->width == 1600 || (s3->card_type == S3_SPEA_MERCURY_P64V ||
 				s3->card_type == S3_NUMBER9_9FX_771))
 				svga->hdisp <<= 1;
+            if (s3->card_type == S3_NUMBER9_9FX_771) {
+                if (svga->hdisp == 832)
+                    svga->hdisp -= 32;
+            }
 			if (s3->card_type == S3_MIROVIDEO40SV_ERGO_968 || s3->card_type == S3_MIROCRYSTAL20SV_964 ||
 				s3->card_type == S3_MIROCRYSTAL20SD_864 || s3->card_type == S3_PHOENIX_VISION968 ||
 				s3->card_type == S3_SPEA_MERCURY_P64V) {
@@ -3378,12 +3382,9 @@ s3_updatemapping(s3_t *s3)
 
 				mem_mapping_set_addr(&s3->linear_mapping, s3->linear_base, s3->linear_size);
 			}
-			if (s3->chip >= S3_TRIO64V)
-				svga->fb_only = 1;
+			svga->fb_only = 1;
 		} else {
-			if (s3->chip >= S3_TRIO64V)
-				svga->fb_only = 0;
-
+			svga->fb_only = 0;
 			mem_mapping_disable(&s3->linear_mapping);
 		}
 

--- a/src/video/vid_s3_virge.c
+++ b/src/video/vid_s3_virge.c
@@ -777,7 +777,6 @@ static void s3_virge_recalctimings(svga_t *svga)
 
         if ((svga->crtc[0x67] & 0xc) != 0xc) /*VGA mode*/
         {
-				svga->fb_only = 0;
                 svga->ma_latch |= (virge->ma_ext << 16);
                 if (svga->crtc[0x51] & 0x30)      svga->rowoffset += (svga->crtc[0x51] & 0x30) << 4;
                 else if (svga->crtc[0x43] & 0x04) svga->rowoffset += 0x100;
@@ -820,8 +819,6 @@ static void s3_virge_recalctimings(svga_t *svga)
         }
         else /*Streams mode*/
         {
-				svga->fb_only = 1;
-
                 if (virge->streams.buffer_ctrl & 1)
                         svga->ma_latch = virge->streams.pri_fb1 >> 2;
                 else


### PR DESCRIPTION
Summary
=======
Fixes gibberish fonts and corrupt mouse cursor on BeOS releases using the S3 Trio/Virge cards.
Slight cleanup of the XGA card and fixed more possible cursor issues.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
