### PR TITLE
Fix regex bug

### DIFF
--- a/bumpversion.sh
+++ b/bumpversion.sh
@@ -17,23 +17,28 @@
 
 # Parse arguments.
 newversion="$1"
-if [ -z "$(echo $newversion | grep '\.')" ]
+romversion="$2"
+if [ -z "$(echo "$newversion" | grep '\.')" ]
 then
-	echo '[!] Usage: bumpversion.sh x.y[.z]'
+	echo '[!] Usage: bumpversion.sh x.y[.z] [romversion]'
 	exit 1
 fi
 shift
 
 # Extract version components.
-newversion_maj=$(echo $newversion | cut -d. -f1)
-newversion_min=$(echo $newversion | cut -d. -f2)
-newversion_patch=$(echo $newversion | cut -d. -f3)
+newversion_maj=$(echo "$newversion" | cut -d. -f1)
+newversion_min=$(echo "$newversion" | cut -d. -f2)
+newversion_patch=$(echo "$newversion" | cut -d. -f3)
 [ -z "$newversion_patch" ] && newversion_patch=0
 
 # Switch to the repository root directory.
-cd "$(dirname "$0")"
+cd "$(dirname "$0")" || exit
 
 get_latest_rom_release() {
+	if [ -n "${romversion}" ]; then
+		echo "${romversion}"
+		return
+	fi
 	# Get the latest ROM release from the GitHub API.
 	curl --silent "https://api.github.com/repos/86Box/roms/releases/latest" |
 		grep '"tag_name":' |
@@ -67,7 +72,7 @@ patch_file src/include_make/*/version.h EMU_VERSION_PATCH 's/(#\s*define\s+EMU_V
 patch_file src/include_make/*/version.h COPYRIGHT_YEAR 's/(#\s*define\s+COPYRIGHT_YEAR\s+)[0-9]+/\1'"$(date +%Y)"'/'
 patch_file src/include_make/*/version.h EMU_DOCS_URL 's/(#\s*define\s+EMU_DOCS_URL\s+"https:\/\/[^\/]+\/en\/v)[^\/]+/\1'"$newversion_maj.$newversion_min"'/'
 patch_file src/unix/assets/*.spec Version 's/(Version:\s+)[0-9].+/\1'"$newversion"'/'
-patch_file src/unix/assets/*.spec '%global romver' 's/(^%global\ romver\s+)[0-9]{8}/'"$(get_latest_rom_release)"'/'
+patch_file src/unix/assets/*.spec '%global romver' 's/(^%global\ romver\s+)[0-9]{8}/\1'"$(get_latest_rom_release)"'/'
 patch_file src/unix/assets/*.spec 'changelog version' 's/(^[*]\s.*>\s+)[0-9].+/\1'"$newversion"-1'/'
 patch_file src/unix/assets/*.spec 'changelog date' 's/(^[*]\s)[a-zA-Z]{3}\s[a-zA-Z]{3}\s[0-9]{2}\s[0-9]{4}/\1'"$(pretty_date)"'/'
 patch_file src/unix/assets/*.metainfo.xml release 's/(<release version=")[^"]+(" date=")[^"]+/\1'"$newversion"'\2'"$(date +%Y-%m-%d)"'/'

--- a/bumpversion.sh
+++ b/bumpversion.sh
@@ -31,19 +31,16 @@ newversion_min=$(echo "$newversion" | cut -d. -f2)
 newversion_patch=$(echo "$newversion" | cut -d. -f3)
 [ -z "$newversion_patch" ] && newversion_patch=0
 
+
+if [ -z "${romversion}" ]; then
+	# Get the latest ROM release from the GitHub API.
+	romversion=$(curl --silent "https://api.github.com/repos/86Box/roms/releases/latest" |
+		grep '"tag_name":' |
+		sed -E 's/.*"([^"]+)".*/\1/')
+fi
+
 # Switch to the repository root directory.
 cd "$(dirname "$0")" || exit
-
-get_latest_rom_release() {
-	if [ -n "${romversion}" ]; then
-		echo "${romversion}"
-		return
-	fi
-	# Get the latest ROM release from the GitHub API.
-	curl --silent "https://api.github.com/repos/86Box/roms/releases/latest" |
-		grep '"tag_name":' |
-		sed -E 's/.*"([^"]+)".*/\1/'
-}
 
 pretty_date() {
 	# Ensure we get the date in English.
@@ -72,7 +69,7 @@ patch_file src/include_make/*/version.h EMU_VERSION_PATCH 's/(#\s*define\s+EMU_V
 patch_file src/include_make/*/version.h COPYRIGHT_YEAR 's/(#\s*define\s+COPYRIGHT_YEAR\s+)[0-9]+/\1'"$(date +%Y)"'/'
 patch_file src/include_make/*/version.h EMU_DOCS_URL 's/(#\s*define\s+EMU_DOCS_URL\s+"https:\/\/[^\/]+\/en\/v)[^\/]+/\1'"$newversion_maj.$newversion_min"'/'
 patch_file src/unix/assets/*.spec Version 's/(Version:\s+)[0-9].+/\1'"$newversion"'/'
-patch_file src/unix/assets/*.spec '%global romver' 's/(^%global\ romver\s+)[0-9]{8}/\1'"$(get_latest_rom_release)"'/'
+patch_file src/unix/assets/*.spec '%global romver' 's/(^%global\ romver\s+)[0-9]{8}/\1'"$romversion"'/'
 patch_file src/unix/assets/*.spec 'changelog version' 's/(^[*]\s.*>\s+)[0-9].+/\1'"$newversion"-1'/'
 patch_file src/unix/assets/*.spec 'changelog date' 's/(^[*]\s)[a-zA-Z]{3}\s[a-zA-Z]{3}\s[0-9]{2}\s[0-9]{4}/\1'"$(pretty_date)"'/'
 patch_file src/unix/assets/*.metainfo.xml release 's/(<release version=")[^"]+(" date=")[^"]+/\1'"$newversion"'\2'"$(date +%Y-%m-%d)"'/'

--- a/src/unix/assets/86Box.spec
+++ b/src/unix/assets/86Box.spec
@@ -12,7 +12,7 @@
 # After a successful build, you can install the RPMs as follows:
 #  sudo dnf install RPMS/$(uname -m)/86Box-3* RPMS/noarch/86Box-roms*
 
-20220523
+%global romver 20220701
 
 Name:		86Box
 Version:	3.6
@@ -120,5 +120,5 @@ popd
 %{_bindir}/roms
 
 %changelog
-* Mon Jun 27 2022 Robert de Rooy <robert.de.rooy[AT]gmail.com> 3.6-1
+* Fri Jul 01 2022 Robert de Rooy <robert.de.rooy[AT]gmail.com> 3.6-1
 - Bump release


### PR DESCRIPTION
Summary
=======
Fix the regex bug I introduced with the last commit, it caused an invalid update to the RPM spec file which is also fixed.

I also added support for an optional second argument to `bumpversion.sh` to allow the ROM release version to be manually specified. This way if you know you will be releasing a new ROM version just after the new 86Box release, you can already update it to the next ROM release version, instead of the current version.

Lastly, I ran ShellCheck against the script and cleaned up some minor warnings.