### PR TITLE
qt: Make fatal messageboxes have the correct icons

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -36,6 +36,7 @@ extern "C" {
 #include <86box/config.h>
 #include <86box/keyboard.h>
 #include <86box/plat.h>
+#include <86box/ui.h>
 #include <86box/discord.h>
 #include <86box/video.h>
 #include <86box/machine.h>
@@ -1448,18 +1449,25 @@ void MainWindow::refreshMediaMenu() {
     ui->actionMCA_devices->setVisible(machine_has_bus(machine, MACHINE_BUS_MCA));
 }
 
-void MainWindow::showMessage(const QString& header, const QString& message) {
+void MainWindow::showMessage(int flags, const QString& header, const QString& message) {
     if (QThread::currentThread() == this->thread()) {
-        showMessage_(header, message);
+        showMessage_(flags, header, message);
     } else {
-        emit showMessageForNonQtThread(header, message);
+        emit showMessageForNonQtThread(flags, header, message);
     }
 }
 
-void MainWindow::showMessage_(const QString &header, const QString &message) {
+void MainWindow::showMessage_(int flags, const QString &header, const QString &message) {
     QMessageBox box(QMessageBox::Warning, header, message, QMessageBox::NoButton, this);
+    if (flags & (MBX_FATAL)) {
+        box.setIcon(QMessageBox::Critical);
+    }
+    else if (!(flags & (MBX_ERROR | MBX_WARNING))) {
+        box.setIcon(QMessageBox::Warning);
+    }
     box.setTextFormat(Qt::TextFormat::RichText);
     box.exec();
+    if (cpu_thread_run == 0) QApplication::exit(-1);
 }
 
 void MainWindow::keyPressEvent(QKeyEvent* event)

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -24,7 +24,7 @@ public:
     explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
 
-    void showMessage(const QString& header, const QString& message);
+    void showMessage(int flags, const QString& header, const QString& message);
     void getTitle(wchar_t* title);
     void blitToWidget(int x, int y, int w, int h);
     QSize getRenderWidgetSize();
@@ -45,7 +45,7 @@ signals:
     void setFullscreen(bool state);
     void setMouseCapture(bool state);
 
-    void showMessageForNonQtThread(const QString& header, const QString& message);
+    void showMessageForNonQtThread(int flags, const QString& header, const QString& message);
     void getTitleForNonQtThread(wchar_t* title);
 public slots:
     void showSettings();
@@ -100,7 +100,7 @@ private slots:
     void on_actionRenderer_options_triggered();
 
     void refreshMediaMenu();
-    void showMessage_(const QString& header, const QString& message);
+    void showMessage_(int flags, const QString& header, const QString& message);
     void getTitle_(wchar_t* title);
 
     void on_actionMCA_devices_triggered();

--- a/src/qt/qt_ui.cpp
+++ b/src/qt/qt_ui.cpp
@@ -93,7 +93,7 @@ int	ui_msgbox_header(int flags, void *header, void* message) {
         msgBox.exec();
     } else {
         // else scope it to main_window
-        main_window->showMessage(hdr, msg);
+        main_window->showMessage(flags, hdr, msg);
     }
     return 0;
 }


### PR DESCRIPTION
Summary
=======
qt: Make fatal messageboxes have the correct icons

Fatals now exit the emulator properly

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
