### PR TITLE
IBM ESDI MCA, 8514/A, XGA and Rancho changes:

### DIFF
--- a/src/include/86box/scsi_ncr5380.h
+++ b/src/include/86box/scsi_ncr5380.h
@@ -26,6 +26,7 @@
 
 extern const device_t scsi_lcs6821n_device;
 extern const device_t scsi_rt1000b_device;
+extern const device_t scsi_rt1000mc_device;
 extern const device_t scsi_t128_device;
 extern const device_t scsi_t130b_device;
 extern const device_t scsi_ls2000_device;

--- a/src/include/86box/vid_8514a.h
+++ b/src/include/86box/vid_8514a.h
@@ -62,7 +62,7 @@ typedef struct ibm8514_t
         int x1, x2, y1, y2;
         int sys_cnt, sys_cnt2;
         int temp_cnt;
-        int16_t cx, cy;
+        int16_t cx, cy, oldcy;
         int16_t sx, sy;
         int16_t dx, dy;
         int16_t err;
@@ -80,7 +80,7 @@ typedef struct ibm8514_t
         int odd_in, odd_out;
 
         uint16_t scratch;
-        int fill_state, fill_drop;
+        int fill_state, xdir, ydir;
     } accel;
 
     uint16_t test;

--- a/src/scsi/scsi.c
+++ b/src/scsi/scsi.c
@@ -86,6 +86,7 @@ static SCSI_CARD scsi_cards[] = {
     { &scsi_ls2000_device,       },
     { &scsi_lcs6821n_device,     },
     { &scsi_rt1000b_device,      },
+    { &scsi_rt1000mc_device,     },
     { &scsi_t128_device,         },
     { &scsi_t130b_device,        },
 #ifdef WALTJE

--- a/src/video/vid_xga.c
+++ b/src/video/vid_xga.c
@@ -2704,7 +2704,7 @@ static void
     xga->on = 0;
     xga->hwcursor.xsize = 64;
     xga->hwcursor.ysize = 64;
-    xga->bios_rom.sz = 0x2000;
+    xga->bios_rom.sz = 0x8000;
 
     f = rom_fopen(xga->type ? XGA2_BIOS_PATH : XGA_BIOS_PATH, "rb");
     (void)fseek(f, 0L, SEEK_END);
@@ -2729,7 +2729,7 @@ static void
         xga->instance = 0;
         xga->rom_addr = 0;
         mem_mapping_add(&xga->bios_rom.mapping,
-                0xdc000, xga->bios_rom.sz,
+                0xd8000, xga->bios_rom.sz,
                 rom_read, rom_readw, rom_readl,
                 NULL, NULL, NULL,
                 xga->bios_rom.rom, MEM_MAPPING_EXTERNAL, &xga->bios_rom);


### PR DESCRIPTION
Summary
=======
ESDI MCA: Increased esdi_time from 200 to 512, should fix the timeout that caused the bad attention 03 fatal.
Rancho: Added the Rancho RT1000B-MC MCA SCSI controller, it uses the 8.20R BIOS.
8514/A: Reworked the Outline command to satisfy the manual and the win2.10 (286/386) driver.
XGA: Initial rom len is set to 0x8000 (which, after being configured, is set back to 0x2000) just to not make it hang with POST code 40 25 on most MCA configurations.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/169/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
