### PR TITLE
Fix incorrect position of CD speed

### DIFF
--- a/src/win/languages/dialogs.rc
+++ b/src/win/languages/dialogs.rc
@@ -733,7 +733,7 @@ BEGIN
     LTEXT           STR_CD_SPEED, IDT_CD_SPEED,
                     CFG_HMARGIN, 207, 34, CFG_PANE_LTEXT_HEIGHT
     COMBOBOX        IDC_COMBO_CD_SPEED,
-                    43, 205, 328, 12,
+                    33, 205, 328, 12,
                     CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
 END
 


### PR DESCRIPTION
Summary
=======
Fix incorrect position of CD speed combobox

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
