### PR TITLE
Fix Hard Reset dialog button order

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -579,8 +579,8 @@ void MainWindow::on_actionHard_Reset_triggered() {
     if (confirm_reset)
     {
         QMessageBox questionbox(QMessageBox::Icon::Question, "86Box", tr("Are you sure you want to hard reset the emulated machine?"), QMessageBox::NoButton, this);
-        questionbox.addButton(tr("Don't reset"), QMessageBox::AcceptRole);
         questionbox.addButton(tr("Reset"), QMessageBox::RejectRole);
+        questionbox.addButton(tr("Don't reset"), QMessageBox::AcceptRole);
         QCheckBox *chkbox = new QCheckBox(tr("Don't show this message again"));
         questionbox.setCheckBox(chkbox);
         chkbox->setChecked(!confirm_reset);


### PR DESCRIPTION
Summary
=======
qt: Fix Hard Reset dialog button order

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
