### PR TITLE
qt_d3d9renderer: Make screenshots work

### DIFF
--- a/src/qt/qt_d3d9renderer.cpp
+++ b/src/qt/qt_d3d9renderer.cpp
@@ -152,7 +152,7 @@ void D3D9Renderer::blit(int x, int y, int w, int h)
     srcRect.left = source.left();
     srcRect.right = source.right();
 
-    if (screenshots) {
+    if (monitors[m_monitor_index].mon_screenshots) {
         video_screenshot_monitor((uint32_t *) &(monitors[m_monitor_index].target_buffer->line[y][x]), 0, 0, 2048, m_monitor_index);
     }
     if (SUCCEEDED(d3d9surface->LockRect(&lockRect, &srcRect, 0))) {


### PR DESCRIPTION
Summary
=======
qt_d3d9renderer: Make screenshots work.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
