### PR TITLE
Make screenshots thread-safe

### DIFF
--- a/src/include/86box/video.h
+++ b/src/include/86box/video.h
@@ -25,6 +25,7 @@
 #ifdef __cplusplus
 #include <atomic>
 using atomic_bool = std::atomic_bool;
+using atomic_int = std::atomic_int;
 #else
 #include <stdatomic.h>
 #endif
@@ -112,7 +113,7 @@ typedef struct monitor_t
     int mon_force_resize;
     int mon_fullchange;
     int mon_changeframecount;
-    int mon_screenshots;
+    atomic_int mon_screenshots;
     uint32_t* mon_pal_lookup;
     int* mon_cga_palette;
     int mon_pal_lookup_static; /* Whether it should not be freed by the API. */

--- a/src/video/video.c
+++ b/src/video/video.c
@@ -442,7 +442,7 @@ video_screenshot_monitor(uint32_t *buf, int start_x, int start_y, int row_len, i
     video_take_screenshot_monitor((const char *) path, buf, start_x, start_y, row_len, monitor_index);
     png_destroy_write_struct(&png_ptr[monitor_index], &info_ptr[monitor_index]);
 
-    monitors[monitor_index].mon_screenshots--;
+    atomic_fetch_sub(&monitors[monitor_index].mon_screenshots, 1);
 }
 
 void
@@ -942,6 +942,7 @@ video_monitor_init(int index)
     monitors[index].mon_force_resize = 1;
     monitors[index].mon_vid_type = VIDEO_FLAG_TYPE_NONE;
     atomic_init(&doresize_monitors[index], 0);
+    atomic_init(&monitors[index].mon_screenshots, 0);
     if (index >= 1) ui_init_monitor(index);
     monitors[index].mon_blit_data_ptr->blit_thread = thread_create(blit_thread, monitors[index].mon_blit_data_ptr);
 }


### PR DESCRIPTION
Summary
=======
Make screenshots thread-safe.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
