### PR TITLE
qt: Status bar timers no longer keep running forever

### DIFF
--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -102,6 +102,7 @@ namespace {
                 return;
             }
             label->setPixmap(active ? pixmaps->active : pixmaps->normal);
+            timer.setSingleShot(true);
             timer.start(75);
         }
     };
@@ -128,6 +129,7 @@ namespace {
         void setActive(bool b) {
             active = b;
             refresh();
+            timer.setSingleShot(true);
             timer.start(75);
         }
         void setEmpty(bool b) {


### PR DESCRIPTION
Summary
=======
qt: Status bar timers no longer keep running forever

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
