### PR TITLE
Fix accidental removal of rtmidi on msys2 builds

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -77,6 +77,7 @@ jobs:
             ${{ matrix.environment.prefix }}-libpng
             ${{ matrix.environment.prefix }}-libvncserver
             ${{ matrix.environment.prefix }}-openal
+            ${{ matrix.environment.prefix }}-rtmidi
       - uses: actions/checkout@v2
       - name: Configure CMake
         run: >-


### PR DESCRIPTION
Summary
=======
Fix accidental removal of rtmidi on msys2 builds

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
