### PR TITLE
qt: Fix double free when multi-monitor is enabled and evdev is used

### DIFF
--- a/src/qt/evdev_mouse.cpp
+++ b/src/qt/evdev_mouse.cpp
@@ -70,6 +70,7 @@ void evdev_thread_func()
     for (unsigned int i = 0; i < evdev_mice.size(); i++)
     {
         libevdev_free(evdev_mice[i].second);
+        evdev_mice[i].second = nullptr;
         close(evdev_mice[i].first);
     }
     evdev_mice.clear();
@@ -77,12 +78,16 @@ void evdev_thread_func()
 
 void evdev_stop()
 {
-    stopped = true;
-    evdev_thread->wait();
+    if (evdev_thread) {
+        stopped = true;
+        evdev_thread->wait();
+        evdev_thread = nullptr;
+    }
 }
 
 void evdev_init()
 {
+    if (evdev_thread) return;
     for (int i = 0; i < 256; i++)
     {
         std::string evdev_device_path = "/dev/input/event" + std::to_string(i);


### PR DESCRIPTION
Summary
=======
qt: Fix double free when multi-monitor is enabled and evdev is used

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
