### PR TITLE
Don't shut down when second display is closed

### DIFF
--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -447,7 +447,11 @@ RendererStack::blitCommon(int x, int y, int w, int h)
 
 void RendererStack::closeEvent(QCloseEvent* event)
 {
-    if (cpu_thread_run == 0 || is_quit == 1) { event->accept(); return; }
+    if (cpu_thread_run == 0 || is_quit == 0) {
+        event->accept();
+        show_second_monitors = 0; // TODO: This isn't actually the right fix, so fix this properly.
+        return;
+    }
     event->ignore();
     main_window->close();
 }


### PR DESCRIPTION
Summary
=======
Fixes closing 86box *entirely* when second display window is closed
KNOWN BUG (Cosmetic only): Inverts the setting on the menu if you close the window manually

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
