### PR TITLE
The IBM 386/486 cpu's are based on modified Intel 386 designs and, as…

### DIFF
--- a/src/cpu/x86_ops_flag.h
+++ b/src/cpu/x86_ops_flag.h
@@ -266,11 +266,11 @@ static int opPOPFD(uint32_t fetchdat)
         else if (IOPLp)           cpu_state.flags = (cpu_state.flags & 0x3000) | (templ & 0x4fd5) | 2;
         else                      cpu_state.flags = (cpu_state.flags & 0x3200) | (templ & 0x4dd5) | 2;
 
-        templ &= (is486 || isibm486) ? 0x3c0000 : 0;
+        templ &= (is486) ? 0x3c0000 : 0;
         templ |= ((cpu_state.eflags&3) << 16);
         if (cpu_CR4_mask & CR4_VME) cpu_state.eflags = (templ >> 16) & 0x3f;
         else if (CPUID)             cpu_state.eflags = (templ >> 16) & 0x27;
-        else if (is486 || isibm486) cpu_state.eflags = (templ >> 16) & 7;
+        else if (is486) cpu_state.eflags = (templ >> 16) & 7;
         else                        cpu_state.eflags = (templ >> 16) & 3;
 
         flags_extract();


### PR DESCRIPTION
Summary
=======
… such, should behave like the them on the x86 flag ops.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
