### PR TITLE
Fix warnings on the XGA, 8514/A and EGA Render map files.

### DIFF
--- a/src/include/86box/vid_ega_render_remap.h
+++ b/src/include/86box/vid_ega_render_remap.h
@@ -88,24 +88,24 @@ static uint32_t (*address_remap_funcs[16])(ega_t *ega, uint32_t in_addr) =
 
 void ega_recalc_remap_func(ega_t *ega)
 {
-        int func_nr;
+    int func_nr;
 
-        if (ega->crtc[0x14] & 0x40)
-                func_nr = VAR_DWORD_MODE;
-        else if (ega->crtc[0x17] & 0x40)
-                func_nr = VAR_BYTE_MODE;
-        else if (ega->crtc[0x17] & 0x20)
-                func_nr = VAR_WORD_MODE_MA15;
-        else
-                func_nr = VAR_WORD_MODE_MA13;
+    if (ega->crtc[0x14] & 0x40)
+        func_nr = VAR_DWORD_MODE;
+    else if (ega->crtc[0x17] & 0x40)
+        func_nr = VAR_BYTE_MODE;
+    else if (ega->crtc[0x17] & 0x20)
+        func_nr = VAR_WORD_MODE_MA15;
+    else
+        func_nr = VAR_WORD_MODE_MA13;
 
-        if (!(ega->crtc[0x17] & 0x01))
-                func_nr |= VAR_ROW0_MA13;
-        if (!(ega->crtc[0x17] & 0x02))
-                func_nr |= VAR_ROW1_MA14;
+    if (!(ega->crtc[0x17] & 0x01))
+        func_nr |= VAR_ROW0_MA13;
+    if (!(ega->crtc[0x17] & 0x02))
+        func_nr |= VAR_ROW1_MA14;
 
-		ega->remap_required = (func_nr != 0);
-        ega->remap_func = address_remap_funcs[func_nr];
+    ega->remap_required = (func_nr != 0);
+    ega->remap_func = address_remap_funcs[func_nr];
 }
 
 #endif /*VIDEO_RENDER_REMAP_H*/

--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -662,7 +662,6 @@ static void
 ibm8514_ramdac_out(uint16_t port, uint8_t val, void *p)
 {
     svga_t *svga = (svga_t *)p;
-    uint8_t index;
 
     switch (port) {
         case 0x2ea:
@@ -1038,8 +1037,6 @@ ibm8514_short_stroke_start(int count, int cpu_input, uint32_t mix_dat, uint32_t 
     ibm8514_accel_start(count, cpu_input, mix_dat, cpu_dat, dev, len);
 }
 
-#define SWAP(a,b) { tmpswap = a; a = b; b = tmpswap; }
-
 static void
 ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, ibm8514_t *dev, int len)
 {
@@ -1060,7 +1057,6 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
 	uint32_t old_mix_dat;
 	int and3 = dev->accel.cur_x & 3;
 	uint8_t poly_src = 0;
-	int16_t tmpswap = 0;
 
 	if (dev->accel.cmd & 0x100) {
 		dev->force_busy = 1;

--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -37,22 +37,6 @@
 #include <86box/vid_svga_render.h>
 #include "cpu.h"
 
-#define INT_VSY (1 << 0)
-#define INT_GE_BSY (1 << 1)
-#define INT_FIFO_OVR (1 << 2)
-#define INT_FIFO_EMP (1 << 3)
-#define INT_MASK 0xf
-
-#define FIFO_MASK (FIFO_SIZE - 1)
-#define FIFO_ENTRY_SIZE (1 << 31)
-
-#define FIFO_ENTRIES_8514 (dev->fifo_write_idx - dev->fifo_read_idx)
-#define FIFO_FULL_8514 ((dev->fifo_write_idx - dev->fifo_read_idx) >= FIFO_SIZE)
-#define FIFO_EMPTY_8514 (dev->fifo_read_idx == dev->fifo_write_idx)
-
-#define FIFO_TYPE_8514 0xff000000
-#define FIFO_ADDR_8514 0x00ffffff
-
 static void ibm8514_accel_out_fifo(ibm8514_t *dev, uint16_t port, uint32_t val, int len);
 static void ibm8514_accel_outb(uint16_t port, uint8_t val, void *p);
 static void ibm8514_accel_outw(uint16_t port, uint16_t val, void *p);
@@ -368,17 +352,14 @@ ibm8514_accel_out_fifo(ibm8514_t *dev, uint16_t port, uint32_t val, int len)
         case 0x82e8:
         case 0xc2e8:
             if (len == 1) {
-                dev->accel.cur_y_bit12 = (dev->accel.cur_y_bit12 & 0xf00) | val;
                 dev->accel.cur_y = (dev->accel.cur_y & 0x700) | val;
             } else {
-                dev->accel.cur_y_bit12 = val & 0xfff;
                 dev->accel.cur_y = val & 0x7ff;
             }
             break;
         case 0x82e9:
         case 0xc2e9:
             if (len == 1) {
-                dev->accel.cur_y_bit12 = (dev->accel.cur_y_bit12 & 0xff) | ((val & 0x0f) << 8);
                 dev->accel.cur_y = (dev->accel.cur_y & 0xff) | ((val & 0x07) << 8);
             }
             break;
@@ -386,17 +367,14 @@ ibm8514_accel_out_fifo(ibm8514_t *dev, uint16_t port, uint32_t val, int len)
         case 0x86e8:
         case 0xc6e8:
             if (len == 1) {
-                dev->accel.cur_x_bit12 = (dev->accel.cur_x_bit12 & 0xf00) | val;
                 dev->accel.cur_x = (dev->accel.cur_x & 0x700) | val;
             } else {
-                dev->accel.cur_x_bit12 = val & 0xfff;
                 dev->accel.cur_x = val & 0x7ff;
             }
             break;
         case 0x86e9:
         case 0xc6e9:
             if (len == 1) {
-                dev->accel.cur_x_bit12 = (dev->accel.cur_x_bit12 & 0xff) | ((val & 0x0f) << 8);
                 dev->accel.cur_x = (dev->accel.cur_x & 0xff) | ((val & 0x07) << 8);
             }
             break;
@@ -448,7 +426,7 @@ ibm8514_accel_out_fifo(ibm8514_t *dev, uint16_t port, uint32_t val, int len)
             else {
                 dev->accel.err_term = val & 0x3fff;
                 if (val & 0x2000)
-                    dev->accel.err_term |= ~0x3fff;
+                    dev->accel.err_term |= ~0x1fff;
             }
             break;
         case 0x92e9:
@@ -456,7 +434,7 @@ ibm8514_accel_out_fifo(ibm8514_t *dev, uint16_t port, uint32_t val, int len)
             if (len == 1) {
                 dev->accel.err_term = (dev->accel.err_term & 0xff) | ((val & 0x3f) << 8);
                 if (val & 0x20)
-                    dev->accel.err_term |= ~0x3fff;
+                    dev->accel.err_term |= ~0x1fff;
             }
             break;
 
@@ -707,7 +685,6 @@ ibm8514_ramdac_in(uint16_t port, void *p)
 {
     svga_t *svga = (svga_t *)p;
     uint8_t ret = 0xff;
-    uint8_t index;
 
     switch (port) {
         case 0x2ea:
@@ -725,62 +702,6 @@ ibm8514_ramdac_in(uint16_t port, void *p)
 
     }
     return ret;
-}
-
-static void
-ibm8514_io_remove(svga_t *svga)
-{
-    io_removehandler(0x2e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x2ea, 0x0004, ibm8514_ramdac_in, NULL, NULL, ibm8514_ramdac_out, NULL, NULL, svga);
-    io_removehandler(0x6e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xae8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xee8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x12e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x16e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x1ae8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x1ee8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x22e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x26e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x2ee8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x42e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x4ae8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x52e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x56e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x5ae8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x5ee8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x82e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x86e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x8ae8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x8ee8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x92e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x96e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x9ae8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0x9ee8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xa2e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xa6e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xaae8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xaee8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xb2e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xb6e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xbae8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xbee8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xe2e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-
-    io_removehandler(0xc2e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xc6e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xcae8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xcee8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xd2e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xd6e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xdae8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xdee8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xe6e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xeae8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xeee8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xf2e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xf6e8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xfae8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
-    io_removehandler(0xfee8, 0x0002, ibm8514_accel_inb, ibm8514_accel_inw, NULL, ibm8514_accel_outb, ibm8514_accel_outw, NULL, svga);
 }
 
 static void
@@ -1139,7 +1060,7 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
 	uint32_t old_mix_dat;
 	int and3 = dev->accel.cur_x & 3;
 	uint8_t poly_src = 0;
-	int16_t tmpswap;
+	int16_t tmpswap = 0;
 
 	if (dev->accel.cmd & 0x100) {
 		dev->force_busy = 1;
@@ -2717,7 +2638,7 @@ bitblt_pix:
                                     break;
                             }
 
-                            READ(dev->accel.dest + dev->accel.cx, dest_dat);
+                            READ(dev->accel.dest + dev->accel.dx, dest_dat);
 
                             if ((compare_mode == 0) ||
                                 ((compare_mode == 0x10) && (dest_dat >= compare)) ||
@@ -2729,7 +2650,7 @@ bitblt_pix:
                                 old_dest_dat = dest_dat;
                                 MIX(mix_dat & mix_mask, dest_dat, src_dat);
                                 dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
-                                WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
+                                WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
                             }
                         }
 

--- a/src/video/vid_xga.c
+++ b/src/video/vid_xga.c
@@ -2210,8 +2210,6 @@ xga_write(uint32_t addr, uint8_t val, void *p)
 static void
 xga_writeb(uint32_t addr, uint8_t val, void *p)
 {
-    svga_t *svga = (svga_t *)p;
-
     //pclog("[%04X:%08X]: WriteB\n", CS, cpu_state.pc);
     xga_write(addr, val, p);
 }
@@ -2219,8 +2217,6 @@ xga_writeb(uint32_t addr, uint8_t val, void *p)
 static void
 xga_writew(uint32_t addr, uint16_t val, void *p)
 {
-    svga_t *svga = (svga_t *)p;
-
     //pclog("[%04X:%08X]: WriteW\n", CS, cpu_state.pc);
     xga_write(addr, val, p);
     xga_write(addr + 1, val >> 8, p);
@@ -2229,8 +2225,6 @@ xga_writew(uint32_t addr, uint16_t val, void *p)
 static void
 xga_writel(uint32_t addr, uint32_t val, void *p)
 {
-    svga_t *svga = (svga_t *)p;
-
     //pclog("[%04X:%08X]: WriteL\n", CS, cpu_state.pc);
     xga_write(addr, val, p);
     xga_write(addr + 1, val >> 8, p);
@@ -2336,7 +2330,6 @@ xga_read(uint32_t addr, void *p)
 static uint8_t
 xga_readb(uint32_t addr, void *p)
 {
-    svga_t *svga = (svga_t *)p;
     uint8_t ret;
 
     ret = xga_read(addr, p);
@@ -2347,7 +2340,6 @@ xga_readb(uint32_t addr, void *p)
 static uint16_t
 xga_readw(uint32_t addr, void *p)
 {
-    svga_t *svga = (svga_t *)p;
     uint16_t ret;
 
     ret = xga_read(addr, p);
@@ -2359,7 +2351,6 @@ xga_readw(uint32_t addr, void *p)
 static uint32_t
 xga_readl(uint32_t addr, void *p)
 {
-    svga_t *svga = (svga_t *)p;
     uint32_t ret;
 
     ret = xga_read(addr, p);

--- a/src/video/vid_xga.c
+++ b/src/video/vid_xga.c
@@ -445,7 +445,6 @@ xga_ext_inb(uint16_t addr, void *p)
     svga_t *svga = (svga_t *)p;
     xga_t *xga = &svga->xga;
     uint8_t ret, index;
-    uint16_t sprite_idx;
 
     switch (addr & 0x0f) {
         case 0:
@@ -898,7 +897,7 @@ xga_short_stroke(svga_t *svga, uint8_t ssv)
     uint32_t srcbase = xga->accel.px_map_base[xga->accel.src_map];
     int y = ssv & 0x0f;
     int x = 0;
-    int dx, dy, dirx, diry;
+    int dx, dy, dirx = 0, diry = 0;
 
     dx = xga->accel.dst_map_x & 0x1fff;
     if (xga->accel.dst_map_x & 0x1800)
@@ -1916,7 +1915,7 @@ xga_memio_writel(uint32_t addr, uint32_t val, void *p)
 static uint8_t
 xga_mem_read(uint32_t addr, xga_t *xga, svga_t *svga)
 {
-    uint8_t temp;
+    uint8_t temp = 0xff;
 
     addr &= 0x1fff;
 
@@ -2031,18 +2030,15 @@ static void
 xga_hwcursor_draw(svga_t *svga, int displine)
 {
     xga_t *xga = &svga->xga;
-    uint8_t dat;
+    uint8_t dat = 0;
     int offset = xga->hwcursor_latch.x - xga->hwcursor_latch.xoff;
     int x, x_pos, y_pos;
-    int comb;
+    int comb = 0;
     uint32_t *p;
-    uint8_t *cd;
     int idx = (xga->cursor_data_on) ? 32 : 0;
 
     if (xga->interlace && xga->hwcursor_oddeven)
 	xga->hwcursor_latch.addr += 16;
-
-    cd = (uint8_t *) xga->sprite_data;
 
     y_pos = displine;
     x_pos = offset + svga->x_add;
@@ -2155,7 +2151,6 @@ xga_render_16bpp(xga_t *xga, svga_t *svga)
     int x;
     uint32_t *p;
 	uint32_t dat;
-	uint32_t addr;
 
     if ((xga->displine + svga->y_add) < 0)
 		return;
@@ -2169,7 +2164,7 @@ xga_render_16bpp(xga_t *xga, svga_t *svga)
 
         for (x = 0; x <= (xga->h_disp); x += 8) {
             dat = *(uint32_t *)(&xga->vram[(xga->ma + (x << 1)) & xga->vram_mask]);
-            p[x]     = video_16to32[dat & 0xffff];
+            p[x] = video_16to32[dat & 0xffff];
             p[x + 1] = video_16to32[dat >> 16];
 
             dat = *(uint32_t *)(&xga->vram[(xga->ma + (x << 1) + 4) & xga->vram_mask]);
@@ -2216,7 +2211,6 @@ static void
 xga_writeb(uint32_t addr, uint8_t val, void *p)
 {
     svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
 
     //pclog("[%04X:%08X]: WriteB\n", CS, cpu_state.pc);
     xga_write(addr, val, p);
@@ -2226,7 +2220,6 @@ static void
 xga_writew(uint32_t addr, uint16_t val, void *p)
 {
     svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
 
     //pclog("[%04X:%08X]: WriteW\n", CS, cpu_state.pc);
     xga_write(addr, val, p);
@@ -2237,7 +2230,6 @@ static void
 xga_writel(uint32_t addr, uint32_t val, void *p)
 {
     svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
 
     //pclog("[%04X:%08X]: WriteL\n", CS, cpu_state.pc);
     xga_write(addr, val, p);
@@ -2345,7 +2337,6 @@ static uint8_t
 xga_readb(uint32_t addr, void *p)
 {
     svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
     uint8_t ret;
 
     ret = xga_read(addr, p);
@@ -2357,7 +2348,6 @@ static uint16_t
 xga_readw(uint32_t addr, void *p)
 {
     svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
     uint16_t ret;
 
     ret = xga_read(addr, p);
@@ -2370,7 +2360,6 @@ static uint32_t
 xga_readl(uint32_t addr, void *p)
 {
     svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
     uint32_t ret;
 
     ret = xga_read(addr, p);
@@ -2665,16 +2654,11 @@ xga_mca_feedb(void *priv)
 }
 
 static void
-xga_pos_out(uint16_t addr, uint8_t val, void *priv)
+xga_mca_reset(void *p)
 {
-    svga_t *svga = (svga_t *)priv;
-    xga_t *xga = &svga->xga;
+    svga_t *svga = (svga_t *)p;
 
-    mem_mapping_disable(&svga->mapping);
-    if (val & 0x08) {
-        mem_mapping_enable(&svga->mapping);
-        xga_updatemapping(svga);
-    }
+    xga_mca_write(0x102, 0, svga);
 }
 
 static uint8_t
@@ -2692,6 +2676,7 @@ static void
     xga_t *xga = &svga->xga;
     FILE *f;
     uint32_t temp;
+    uint32_t initial_bios_addr = device_get_config_hex20("init_bios_addr");
     uint8_t *rom = NULL;
 
     xga->type = device_get_config_int("type");
@@ -2704,7 +2689,7 @@ static void
     xga->on = 0;
     xga->hwcursor.cur_xsize = 64;
     xga->hwcursor.cur_ysize = 64;
-    xga->bios_rom.sz = 0x8000;
+    xga->bios_rom.sz = 0x2000;
 
     f = rom_fopen(xga->type ? XGA2_BIOS_PATH : XGA_BIOS_PATH, "rb");
     (void)fseek(f, 0L, SEEK_END);
@@ -2729,7 +2714,7 @@ static void
         xga->instance = 0;
         xga->rom_addr = 0;
         mem_mapping_add(&xga->bios_rom.mapping,
-                0xd8000, xga->bios_rom.sz,
+                initial_bios_addr, xga->bios_rom.sz,
                 rom_read, rom_readw, rom_readl,
                 NULL, NULL, NULL,
                 xga->bios_rom.rom, MEM_MAPPING_EXTERNAL, &xga->bios_rom);
@@ -2759,7 +2744,7 @@ static void
     xga->pos_regs[1] = 0x8f;
 
     if (xga->bus & DEVICE_MCA) {
-        mca_add(xga_mca_read, xga_mca_write, xga_mca_feedb, NULL, svga);
+        mca_add(xga_mca_read, xga_mca_write, xga_mca_feedb, xga_mca_reset, svga);
     } else {
         io_sethandler(0x0100, 0x0008, xga_pos_in, NULL, NULL, NULL, NULL, NULL, svga);
         io_sethandler(0x2100 + (xga->instance << 4), 0x0010, xga_ext_inb, NULL, NULL, xga_ext_outb, NULL, NULL, svga);
@@ -2805,6 +2790,25 @@ xga_force_redraw(void *p)
 
 static const device_config_t xga_configuration[] = {
     // clang-format off
+    {
+        .name = "init_bios_addr",
+        .description = "Initial MCA BIOS Address (before POS configuration)",
+        .type = CONFIG_HEX20,
+        .default_string = "",
+        .default_int = 0xc0000,
+        .file_filter = "",
+        .spinner = { 0 },
+        .selection = {
+            { .description = "C000H", .value = 0xc0000 },
+            { .description = "C800H", .value = 0xc8000 },
+            { .description = "CC00H", .value = 0xcc000 },
+            { .description = "D000H", .value = 0xd0000 },
+            { .description = "D400H", .value = 0xd4000 },
+            { .description = "D800H", .value = 0xd8000 },
+            { .description = "DC00H", .value = 0xdc000 },
+            { .description = ""                        }
+        },
+    },
     {
         .name = "type",
         .description = "XGA type",


### PR DESCRIPTION
Summary
=======
Revert initial XGA rom length back to 0x2000 to prevent error 114 in the MCA bioses.
Note: if you encounter a 40 25 hang again with the XGA-2 roms, just close and re-open the emulator, this typically affects hard resets.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
