### PR TITLE
qt: Make renderer widget resizable only once

### DIFF
--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -141,6 +141,7 @@ private:
     /* If main window should send keyboard input */
     bool send_keyboard_input = true;
     bool shownonce = false;
+    bool resizableonce = false;
 
     friend class SpecifyDimensions;
     friend class ProgSettings;

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -34,6 +34,7 @@
 
 #include "evdev_mouse.hpp"
 
+#include <atomic>
 #include <stdexcept>
 
 #include <QScreen>
@@ -53,8 +54,8 @@ double mouse_sensitivity = 1.0;
 }
 
 struct mouseinputdata {
-    int deltax, deltay, deltaz;
-    int mousebuttons;
+    atomic_int deltax, deltay, deltaz;
+    atomic_int mousebuttons;
 };
 static mouseinputdata mousedata;
 
@@ -145,7 +146,7 @@ int ignoreNextMouseEvent = 1;
 void
 RendererStack::mouseReleaseEvent(QMouseEvent *event)
 {
-    if (this->geometry().contains(event->pos()) && event->button() == Qt::LeftButton && !mouse_capture && (isMouseDown & 1)) {
+    if (this->geometry().contains(event->pos()) && event->button() == Qt::LeftButton && !mouse_capture && (isMouseDown & 1) && mouse_get_buttons() != 0) {
         plat_mouse_capture(1);
         this->setCursor(Qt::BlankCursor);
         if (!ignoreNextMouseEvent)
@@ -164,6 +165,7 @@ RendererStack::mouseReleaseEvent(QMouseEvent *event)
     }
     isMouseDown &= ~1;
 }
+
 void
 RendererStack::mousePressEvent(QMouseEvent *event)
 {
@@ -173,6 +175,7 @@ RendererStack::mousePressEvent(QMouseEvent *event)
     }
     event->accept();
 }
+
 void
 RendererStack::wheelEvent(QWheelEvent *event)
 {


### PR DESCRIPTION
Summary
=======
[qt: Make renderer widget resizable only once](https://github.com/86Box/86Box/commit/548e8b360abe43bee3169fc21c35b4c2377034b3)
[qt: Fix mouse polling](https://github.com/86Box/86Box/commit/7beec38ed3624c4bf0a00caa8b7bc22b00efa5f1)

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
