### PR TITLE
Add missing semicolon to desktop file

### DIFF
--- a/src/unix/assets/net.86box.86Box.desktop
+++ b/src/unix/assets/net.86box.86Box.desktop
@@ -6,4 +6,4 @@ Exec=86Box
 Icon=net.86box.86Box
 Terminal=false
 Type=Application
-Categories=System;Emulator
+Categories=System;Emulator;


### PR DESCRIPTION
It should be there according to the desktop file specification.