### PR TITLE
ISA PS/2: Clean-ups and converted into a typedef struct.

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -777,7 +777,9 @@ extern int	machine_ps2_m30_286_init(const machine_t *);
 
 /* m_ps2_mca.c */
 extern int	machine_ps2_model_50_init(const machine_t *);
+extern int  machine_ps2_model_60_init(const machine_t *);
 extern int	machine_ps2_model_55sx_init(const machine_t *);
+extern int	machine_ps2_model_65sx_init(const machine_t *);
 extern int	machine_ps2_model_70_type3_init(const machine_t *);
 extern int	machine_ps2_model_80_init(const machine_t *);
 extern int	machine_ps2_model_80_axx_init(const machine_t *);

--- a/src/include/86box/nvr_ps2.h
+++ b/src/include/86box/nvr_ps2.h
@@ -40,6 +40,7 @@
 
 
 extern const device_t	ps2_nvr_device;
+extern const device_t   ps2_nvr_55ls_device;
 
 
 #endif	/*EMU_NVRPS2_H*/

--- a/src/machine/m_ps2_isa.c
+++ b/src/machine/m_ps2_isa.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 #include <wchar.h>
 #include <86box/86box.h>
@@ -25,145 +26,175 @@
 #include <86box/machine.h>
 
 
-static uint8_t ps2_91, ps2_94, ps2_102, ps2_103, ps2_104, ps2_105, ps2_190;
-static serial_t *ps2_uart;
+typedef struct {
+    int	model;
+    int cpu_type;
+
+    uint8_t	ps2_91,
+		ps2_92,
+		ps2_94,
+		ps2_102,
+		ps2_103,
+		ps2_104,
+		ps2_105,
+		ps2_190;
+
+    serial_t *uart;
+} ps2_isa_t;
 
 
-static struct
+static void
+ps2_write(uint16_t port, uint8_t val, void *priv)
 {
-        uint8_t status, int_status;
-        uint8_t attention, ctrl;
-} ps2_hd;
+    ps2_isa_t *ps2 = (ps2_isa_t *)priv;
 
+    switch (port) {
+        case 0x0094:
+            ps2->ps2_94 = val;
+            break;
 
-static uint8_t ps2_read(uint16_t port, void *p)
-{
-        uint8_t temp;
+        case 0x0102:
+            if (!(ps2->ps2_94 & 0x80)) {
+                lpt1_remove();
+                serial_remove(ps2->uart);
+                if (val & 0x04) {
+                    if (val & 0x08)
+                        serial_setup(ps2->uart, COM1_ADDR, COM1_IRQ);
+                    else
+                        serial_setup(ps2->uart, COM2_ADDR, COM2_IRQ);
+                }
+                if (val & 0x10) {
+                    switch ((val >> 5) & 3) {
+                        case 0:
+                            lpt1_init(LPT_MDA_ADDR);
+                            break;
+                        case 1:
+                            lpt1_init(LPT1_ADDR);
+                            break;
+                        case 2:
+                            lpt1_init(LPT2_ADDR);
+                            break;
+                    }
+                }
+                ps2->ps2_102 = val;
+            }
+            break;
 
-        switch (port)
-        {
-                case 0x91:
-		temp = ps2_91;
-		ps2_91 = 0;
-                return temp;
-                case 0x94:
-                return ps2_94;
-                case 0x102:
-                return ps2_102 | 8;
-                case 0x103:
-                return ps2_103;
-                case 0x104:
-                return ps2_104;
-                case 0x105:
-                return ps2_105;
-                case 0x190:
-                return ps2_190;
+        case 0x0103:
+            ps2->ps2_103 = val;
+            break;
 
-#ifdef FIXME
-                case 0x322:
-                temp = ps2_hd.status;
-                break;
-                case 0x324:
-                temp = ps2_hd.int_status;
-                ps2_hd.int_status &= ~0x02;
-                break;
-#endif
+        case 0x0104:
+            ps2->ps2_104 = val;
+            break;
 
-                default:
-                temp = 0xff;
-                break;
-        }
+        case 0x0105:
+            ps2->ps2_105 = val;
+            break;
 
-        return temp;
+        case 0x0190:
+            ps2->ps2_190 = val;
+            break;
+    }
 }
 
-static void ps2_write(uint16_t port, uint8_t val, void *p)
+static uint8_t
+ps2_read(uint16_t port, void *priv)
 {
-        switch (port)
-        {
-                case 0x94:
-                ps2_94 = val;
-                break;
-                case 0x102:
-				if (!(ps2_94 & 0x80)) {
-					lpt1_remove();
-					serial_remove(ps2_uart);
-					if (val & 0x04) {
-						if (val & 0x08)
-							serial_setup(ps2_uart, COM1_ADDR, COM1_IRQ);
-						else
-							serial_setup(ps2_uart, COM2_ADDR, COM2_IRQ);
-					}
-					if (val & 0x10) {
-						switch ((val >> 5) & 3)
-						{
-							case 0:
-							lpt1_init(LPT_MDA_ADDR);
-							break;
-							case 1:
-							lpt1_init(LPT1_ADDR);
-							break;
-							case 2:
-							lpt1_init(LPT2_ADDR);
-							break;
-						}
-					}
-					ps2_102 = val;
-				}
-				break;
+    ps2_isa_t *ps2 = (ps2_isa_t *)priv;
+    uint8_t temp = 0xff;
 
-                case 0x103:
-                ps2_103 = val;
-                break;
-                case 0x104:
-                ps2_104 = val;
-                break;
-                case 0x105:
-                ps2_105 = val;
-                break;
-                case 0x190:
-                ps2_190 = val;
-                break;
+    switch (port) {
+        case 0x0091:
+            temp = ps2->ps2_91;
+            ps2->ps2_91 = 0;
+            break;
 
-#ifdef FIXME
-                case 0x322:
-                ps2_hd.ctrl = val;
-                if (val & 0x80)
-                        ps2_hd.status |= 0x02;
-                break;
-                case 0x324:
-                ps2_hd.attention = val & 0xf0;
-                if (ps2_hd.attention)
-                        ps2_hd.status = 0x14;
-                break;
-#endif
-        }
+        case 0x0094:
+            temp = ps2->ps2_94;
+            break;
+
+        case 0x0102:
+            temp = ps2->ps2_102 | 0x08;
+            break;
+
+        case 0x0103:
+            temp = ps2->ps2_103;
+            break;
+
+        case 0x0104:
+            temp = ps2->ps2_104;
+            break;
+
+        case 0x0105:
+            temp = ps2->ps2_105;
+            break;
+
+        case 0x0190:
+            temp = ps2->ps2_190;
+            break;
+    }
+
+    return temp;
 }
 
-
-static void ps2board_init(void)
+static void
+ps2_isa_setup(int model, int cpu_type)
 {
-        io_sethandler(0x0091, 0x0001, ps2_read, NULL, NULL, ps2_write, NULL, NULL, NULL);
-        io_sethandler(0x0094, 0x0001, ps2_read, NULL, NULL, ps2_write, NULL, NULL, NULL);
-        io_sethandler(0x0102, 0x0004, ps2_read, NULL, NULL, ps2_write, NULL, NULL, NULL);
-        io_sethandler(0x0190, 0x0001, ps2_read, NULL, NULL, ps2_write, NULL, NULL, NULL);
-#ifdef FIXME
-        io_sethandler(0x0320, 0x0001, ps2_read, NULL, NULL, ps2_write, NULL, NULL, NULL);
-        io_sethandler(0x0322, 0x0001, ps2_read, NULL, NULL, ps2_write, NULL, NULL, NULL);
-        io_sethandler(0x0324, 0x0001, ps2_read, NULL, NULL, ps2_write, NULL, NULL, NULL);
-#endif
+    ps2_isa_t *ps2;
+    void *priv;
+
+    ps2 = (ps2_isa_t *)malloc(sizeof(ps2_isa_t));
+    memset(ps2, 0x00, sizeof(ps2_isa_t));
+    ps2->model = model;
+    ps2->cpu_type = cpu_type;
+
+
+    io_sethandler(0x0091, 1,
+		  ps2_read, NULL, NULL, ps2_write, NULL, NULL, ps2);
+    io_sethandler(0x0094, 1,
+		  ps2_read, NULL, NULL, ps2_write, NULL, NULL, ps2);
+    io_sethandler(0x0102, 4,
+		  ps2_read, NULL, NULL, ps2_write, NULL, NULL, ps2);
+    io_sethandler(0x0190, 1,
+		  ps2_read, NULL, NULL, ps2_write, NULL, NULL, ps2);
+
+    ps2->uart = device_add_inst(&ns16450_device, 1);
+
+    lpt1_remove();
+    lpt1_init(LPT_MDA_ADDR);
 
 	device_add(&port_92_device);
 
-        ps2_190 = 0;
+    mem_remap_top(384);
 
-	ps2_uart = device_add_inst(&ns16450_device, 1);
+    device_add(&ps_nvr_device);
 
-        lpt1_init(LPT_MDA_ADDR);
+    device_add(&fdc_at_ps1_device);
 
-        memset(&ps2_hd, 0, sizeof(ps2_hd));
+    /* Enable the builtin HDC. */
+    if (hdc_current == 1) {
+        priv = device_add(&ps1_hdc_device);
+        ps1_hdc_inform(priv, &ps2->ps2_91);
+    }
+
+    device_add(&ps1vga_device);
 }
 
+static void
+ps2_isa_common_init(const machine_t *model)
+{
+    machine_common_init(model);
+
+    refresh_at_enable = 1;
+    pit_ctr_set_out_func(&pit->counters[1], pit_refresh_timer_at);
+
+    dma16_init();
+    pic2_init();
+
+	device_add(&keyboard_ps2_device);
+	device_add(&port_6x_ps2_device);
+}
 
 int
 machine_ps2_m30_286_init(const machine_t *model)
@@ -178,28 +209,10 @@ machine_ps2_m30_286_init(const machine_t *model)
 	if (bios_only || !ret)
 		return ret;
 
-        machine_common_init(model);
+    ps2_isa_common_init(model);
 
-	mem_remap_top(384);
-
-	device_add(&fdc_at_ps1_device);
-
-	refresh_at_enable = 1;
-        pit_ctr_set_out_func(&pit->counters[1], pit_refresh_timer_at);
-        dma16_init();
-	device_add(&keyboard_ps2_device);
-	device_add(&port_6x_ps2_device);
-	device_add(&ps_nvr_device);
-        pic2_init();
-        ps2board_init();
-	device_add(&ps1vga_device);
-
- 	/* Enable the builtin HDC. */
-	if (hdc_current == 1) {
-		priv = device_add(&ps1_hdc_device);
-
-		ps1_hdc_inform(priv, &ps2_91);
-	}
+    ps2_isa_setup(30, 286);
 
 	return ret;
 }
+

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -312,6 +312,8 @@ const machine_t machines[] = {
     /* 286 machines that utilize the MCA bus */
     /* Has IBM PS/2 Type 2 KBC firmware. */
     { "[MCA] IBM PS/2 model 50",                       "ibmps2_m50",       MACHINE_TYPE_286,        MACHINE_CHIPSET_PROPRIETARY,         machine_ps2_model_50_init,        0, 0, MACHINE_AVAILABLE, 0 , CPU_PKG_286 | CPU_PKG_486SLC_IBM,                CPU_BLOCK_NONE, 10000000, 0, 0, 0, 0, 0, MACHINE_PS2_MCA, MACHINE_VIDEO, 1024, 10240, 1024,   63, NULL, NULL },
+    /* Has IBM PS/2 Type 2 KBC firmware. */
+    { "[MCA] IBM PS/2 model 60",                       "ibmps2_m60",       MACHINE_TYPE_286,        MACHINE_CHIPSET_PROPRIETARY,         machine_ps2_model_60_init,        0, 0, MACHINE_AVAILABLE, 0 , CPU_PKG_286 | CPU_PKG_486SLC_IBM,                CPU_BLOCK_NONE, 10000000, 0, 0, 0, 0, 0, MACHINE_PS2_MCA, MACHINE_VIDEO, 1024, 10240, 1024,   63, NULL, NULL },
 
     /* 386SX machines */
     /* ISA slots available because an official IBM expansion for that existed. */
@@ -373,6 +375,8 @@ const machine_t machines[] = {
     /* 386SX machines which utilize the MCA bus */
     /* Has IBM PS/2 Type 1 KBC firmware. */
     { "[MCA] IBM PS/2 model 55SX",                     "ibmps2_m55sx",     MACHINE_TYPE_386SX,      MACHINE_CHIPSET_PROPRIETARY,         machine_ps2_model_55sx_init,      0, 0, MACHINE_AVAILABLE, 0 , CPU_PKG_386SX,                                   CPU_BLOCK_NONE, 0, 0, 0, 0, 0, 0, MACHINE_PS2_MCA, MACHINE_VIDEO, 1024,  8192, 1024,  63, NULL, NULL },
+    /* Has IBM PS/2 Type 1 KBC firmware. */
+    { "[MCA] IBM PS/2 model 65SX",                     "ibmps2_m65sx",     MACHINE_TYPE_386SX,      MACHINE_CHIPSET_PROPRIETARY,         machine_ps2_model_65sx_init,      0, 0, MACHINE_AVAILABLE, 0 , CPU_PKG_386SX,                                   CPU_BLOCK_NONE, 0, 0, 0, 0, 0, 0, MACHINE_PS2_MCA, MACHINE_VIDEO, 1024,  8192, 1024,  63, NULL, NULL },
 
     /* 486SLC machines */
     /* 486SLC machines with just the ISA slot */
@@ -397,11 +401,7 @@ const machine_t machines[] = {
 
     /* 386DX machines which utilize the MCA bus */
     /* Has IBM PS/2 Type 1 KBC firmware. */
-    { "[MCA] IBM PS/2 model 70 (type 3)",              "ibmps2_m70_type3", MACHINE_TYPE_386DX,      MACHINE_CHIPSET_PROPRIETARY,         machine_ps2_model_70_type3_init,  0, 0, MACHINE_AVAILABLE, 0 , CPU_PKG_386DX | CPU_PKG_486BL,                   CPU_BLOCK_NONE, 0, 0, 0, 0, 0, 0, MACHINE_PS2_MCA, MACHINE_VIDEO, 2048, 65536, 2048,  63, NULL, NULL },
-    /* Has IBM PS/2 Type 1 KBC firmware. */
-    { "[MCA] IBM PS/2 model 80 (type 2)",              "ibmps2_m80",       MACHINE_TYPE_386DX,      MACHINE_CHIPSET_PROPRIETARY,         machine_ps2_model_80_init,        0, 0, MACHINE_AVAILABLE, 0 , CPU_PKG_386DX | CPU_PKG_486BL | CPU_PKG_SOCKET1, CPU_BLOCK_NONE, 0, 0, 0, 0, 0, 0, MACHINE_PS2_MCA, MACHINE_VIDEO, 1024, 65536, 1024,  63, NULL, NULL },
-    /* Has IBM PS/2 Type 1 KBC firmware. */
-    { "[MCA] IBM PS/2 model 80 (type 3)",              "ibmps2_m80_type3", MACHINE_TYPE_386DX,      MACHINE_CHIPSET_PROPRIETARY,         machine_ps2_model_80_axx_init,    0, 0, MACHINE_AVAILABLE, 0 , CPU_PKG_386DX | CPU_PKG_486BL | CPU_PKG_SOCKET1, CPU_BLOCK_NONE, 0, 0, 0, 0, 0, 0, MACHINE_PS2_MCA, MACHINE_VIDEO, 2048, 65536, 2048,  63, NULL, NULL },
+    { "[MCA] IBM PS/2 model 80 (type 2)",              "ibmps2_m80",       MACHINE_TYPE_386DX,      MACHINE_CHIPSET_PROPRIETARY,         machine_ps2_model_80_init,        0, 0, MACHINE_AVAILABLE, 0 , CPU_PKG_386DX | CPU_PKG_486BL,                   CPU_BLOCK_NONE, 0, 0, 0, 0, 0, 0, MACHINE_PS2_MCA, MACHINE_VIDEO, 1024, 65536, 1024,  63, NULL, NULL },
 
     /* 386DX/486 machines */
     /* The BIOS sends commands C9 without a parameter and D5, both of which are
@@ -411,6 +411,10 @@ const machine_t machines[] = {
     { "[OPTi 495] DataExpert SX495",                   "ami495",           MACHINE_TYPE_386DX_486,  MACHINE_CHIPSET_OPTI_495,            machine_at_opti495_ami_init,      0, 0, MACHINE_AVAILABLE, 0 , CPU_PKG_386DX | CPU_PKG_SOCKET1,                 CPU_BLOCK_NONE, 0, 0, 0, 0, 0, 0, MACHINE_VLB, MACHINE_IDE, 1024, 32768, 1024, 127, NULL, NULL },
     /* Has AMIKey F KBC firmware (it's just the MR BIOS for the above machine). */
     { "[OPTi 495] DataExpert SX495 (MR BIOS)",         "mr495",            MACHINE_TYPE_386DX_486,  MACHINE_CHIPSET_OPTI_495,            machine_at_opti495_mr_init,       0, 0, MACHINE_AVAILABLE, 0 , CPU_PKG_386DX | CPU_PKG_SOCKET1,                 CPU_BLOCK_NONE, 0, 0, 0, 0, 0, 0, MACHINE_VLB, MACHINE_IDE, 1024, 32768, 1024, 127, NULL, NULL },
+    /* Has IBM PS/2 Type 1 KBC firmware. */
+    { "[MCA] IBM PS/2 model 70 (type 3)",              "ibmps2_m70_type3", MACHINE_TYPE_386DX_486,  MACHINE_CHIPSET_PROPRIETARY,         machine_ps2_model_70_type3_init,  0, 0, MACHINE_AVAILABLE, 0 , CPU_PKG_386DX | CPU_PKG_486BL | CPU_PKG_SOCKET1, CPU_BLOCK_NONE, 0, 0, 0, 0, 0, 0, MACHINE_PS2_MCA, MACHINE_VIDEO, 2048, 65536, 2048,  63, NULL, NULL },
+    /* Has IBM PS/2 Type 1 KBC firmware. */
+    { "[MCA] IBM PS/2 model 80 (type 3)",              "ibmps2_m80_type3", MACHINE_TYPE_386DX_486,  MACHINE_CHIPSET_PROPRIETARY,         machine_ps2_model_80_axx_init,    0, 0, MACHINE_AVAILABLE, 0 , CPU_PKG_386DX | CPU_PKG_486BL | CPU_PKG_SOCKET1, CPU_BLOCK_NONE, 0, 0, 0, 0, 0, 0, MACHINE_PS2_MCA, MACHINE_VIDEO, 2048, 65536, 2048,  63, NULL, NULL },
 
     /* 486 machines - Socket 1 */
     /* Has JetKey 5 KBC Firmware which looks like it is a clone of AMIKey type F.


### PR DESCRIPTION
Summary
=======
MCA PS/2: Added Model 60 (8-slot version of 50 with the same bios) and Model 65sx (essentially the same as 55sx but with a new bios and a secondary nvram a la 70-80 but limited to 2KB of size instead of 8KB).
MCA PS/2: Made the i486 cpu selection on only on Type 3 MCA models (70-80) and not Type 2 anymore, therefore the latter is limited to 386DX cpu's only.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/171/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
