### PR TITLE
Fix QListView width in the settings window

### DIFF
--- a/src/qt/qt_settings.cpp
+++ b/src/qt/qt_settings.cpp
@@ -143,7 +143,7 @@ Settings::Settings(QWidget *parent) :
         ui->stackedWidget->setCurrentIndex(current.row());
     });
 
-    ui->listView->setMaximumWidth(ui->listView->sizeHintForColumn(0) + qApp->style()->pixelMetric(QStyle::PM_ScrollBarExtent));
+    ui->listView->setMinimumWidth(ui->listView->sizeHintForColumn(0) + qApp->style()->pixelMetric(QStyle::PM_ScrollBarExtent));
 
     Settings::settings = this;
 }


### PR DESCRIPTION
Summary
=======
On macOS and linux the `QListView` in the settings window is too narrow and not resized properly after being populated. 

This is a very small fix. The current code uses `setMaximumWidth()` based on the size hint for the column. For some reason qt seems to prefer `setMinimumWidth()` instead in order to properly size the list view.

I tested this on both macOS and linux and it seems to fix the issue. For some reason it was already displaying properly on windows (qt) and this change seems to have no effect there.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
