### PR TITLE
Apparently a default temp val of 0xff in the read makes XGA-1/2 panic…

### DIFF
--- a/src/video/vid_xga.c
+++ b/src/video/vid_xga.c
@@ -1915,7 +1915,7 @@ xga_memio_writel(uint32_t addr, uint32_t val, void *p)
 static uint8_t
 xga_mem_read(uint32_t addr, xga_t *xga, svga_t *svga)
 {
-    uint8_t temp = 0xff;
+    uint8_t temp = 0;
 
     addr &= 0x1fff;
 


### PR DESCRIPTION
… on GUI's...

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
