### PR TITLE
Made reg 0x53 (read only) default temp val to 0x70 to satisfy xgaaidos.sys' detection.

### DIFF
--- a/src/dma.c
+++ b/src/dma.c
@@ -1448,7 +1448,7 @@ dma_channel_read(int channel)
 		dma_sg_next_addr(dma_c);
 	else {
 		tc = 1;
-		if (dma_c->mode & 0x10) { /*Auto-init*/
+		if ((dma_c->mode & 0x10) || dma_ps2.is_ps2) { /*Auto-init*/
 			dma_c->cc = dma_c->cb;
 			dma_c->ac = dma_c->ab;
 		} else
@@ -1536,7 +1536,7 @@ dma_channel_write(int channel, uint16_t val)
 	if (dma_advanced && (dma_c->sg_status & 1) && !(dma_c->sg_status & 6))
 		dma_sg_next_addr(dma_c);
 	else {
-		if (dma_c->mode & 0x10) { /*Auto-init*/
+		if ((dma_c->mode & 0x10) || dma_ps2.is_ps2) { /*Auto-init*/
 			dma_c->cc = dma_c->cb;
 			dma_c->ac = dma_c->ab;
 		} else

--- a/src/video/vid_xga.c
+++ b/src/video/vid_xga.c
@@ -577,7 +577,7 @@ xga_ext_inb(uint16_t addr, void *p)
                     ret = 0x0b;
                     break;
                 case 0x53:
-                    ret = 0xb0;
+                    ret = 0x70;
                     break;
                 case 0x54:
                     ret = xga->clk_sel_1;


### PR DESCRIPTION
Summary
=======
Apparently MCA Audio cards always want auto-init enabled.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
