### PR TITLE
Add GDBStub to win32 makefile

### DIFF
--- a/src/win/Makefile.mingw
+++ b/src/win/Makefile.mingw
@@ -31,6 +31,9 @@ ifeq ($(DEV_BUILD), y)
  ifndef DEBUG
   DEBUG		:= y
  endif
+ ifndef GDBSTUB
+  GDBSTUB	:= n
+ endif
  ifndef DEV_BRANCH
   DEV_BRANCH	:= y
  endif
@@ -91,6 +94,9 @@ ifeq ($(DEV_BUILD), y)
 else
  ifndef DEBUG
   DEBUG		:= n
+ endif
+ ifndef GDBSTUB
+  GDBSTUB	:= n
  endif
  ifndef DEV_BRANCH
   DEV_BRANCH	:= n
@@ -506,6 +512,10 @@ OPTS		+= -DUSE_OLIVETTI
 DEVBROBJ	+= olivetti_eva.o
 endif
 
+ifeq ($(GDBSTUB), y)
+OPTS		+= -DUSE_GDBSTUB
+DEVBROBJ	+= gdbstub.o
+endif
 
 endif
 


### PR DESCRIPTION
Summary
=======
Add GDBStub to win32 makefile, it was missing

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
