### PR TITLE
DMA: Implemented autoinit mode in the PS/2 MCA side (although the bit…

### DIFF
--- a/src/dma.c
+++ b/src/dma.c
@@ -62,6 +62,7 @@ static struct {
 
 
 #define DMA_PS2_IOA		(1 << 0)
+#define DMA_PS2_AUTOINIT    (1 << 1)
 #define DMA_PS2_XFER_MEM_TO_IO	(1 << 2)
 #define DMA_PS2_XFER_IO_TO_MEM	(3 << 2)
 #define DMA_PS2_XFER_MASK	(3 << 2)
@@ -729,6 +730,8 @@ dma_ps2_write(uint16_t addr, uint8_t val, void *priv)
                 else if ((val & DMA_PS2_XFER_MASK) == DMA_PS2_XFER_IO_TO_MEM)
 					mode |= 4;
 				dma_c->mode = (dma_c->mode & ~0x2c) | mode;
+				if (val & DMA_PS2_AUTOINIT)
+                    dma_c->mode |= 0x10;
 				dma_c->ps2_mode = val;
 				dma_c->size = val & DMA_PS2_SIZE16;
 				break;

--- a/src/include/86box/net_wd8003.h
+++ b/src/include/86box/net_wd8003.h
@@ -50,7 +50,8 @@ enum {
     WD8003EB,			/* WD8003EB  :  8-bit ISA, 5x3 interface chip */
     WD8013EBT,			/* WD8013EBT : 16-bit ISA, no  interface chip */
     WD8003ETA,			/* WD8003ET/A: 16-bit MCA, no  interface chip */
-    WD8003EA			/* WD8003E/A : 16-bit MCA, 5x3 interface chip */
+    WD8003EA,			/* WD8003E/A : 16-bit MCA, 5x3 interface chip */
+    WD8013EPA
 };
 
 extern const device_t 	wd8003e_device;
@@ -58,5 +59,6 @@ extern const device_t 	wd8003eb_device;
 extern const device_t 	wd8013ebt_device;
 extern const device_t 	wd8003eta_device;
 extern const device_t 	wd8003ea_device;
+extern const device_t 	wd8013epa_device;
 
 #endif	/*NET_WD8003_H*/

--- a/src/include/86box/sound.h
+++ b/src/include/86box/sound.h
@@ -120,6 +120,7 @@ extern const device_t sb_16_device;
 extern const device_t sb_16_pnp_device;
 extern const device_t sb_16_compat_device;
 extern const device_t sb_16_compat_nompu_device;
+extern const device_t sb_16_reply_mca_device;
 extern const device_t sb_32_pnp_device;
 extern const device_t sb_awe32_device;
 extern const device_t sb_awe32_pnp_device;

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -103,6 +103,7 @@ static netcard_t net_cards[] = {
     { &ethernext_mc_device,       NULL },
     { &wd8003eta_device,          NULL },
     { &wd8003ea_device,           NULL },
+    { &wd8013epa_device,          NULL },
     { &pcnet_am79c973_device,     NULL },
     { &pcnet_am79c970a_device,    NULL },
     { &rtl8029as_device,          NULL },

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -1198,6 +1198,148 @@ sb_pro_mcv_write(int port, uint8_t val, void *p)
     sb_dsp_setdma8(&sb->dsp, sb->pos_regs[4] & 3);
 }
 
+static uint8_t
+sb_16_reply_mca_read(int port, void *p)
+{
+    sb_t   *sb  = (sb_t *) p;
+    uint8_t ret = sb->pos_regs[port & 7];
+
+    sb_log("sb_16_reply_mca_read: port=%04x ret=%02x\n", port, ret);
+
+    return ret;
+}
+
+static void
+sb_16_reply_mca_write(int port, uint8_t val, void *p)
+{
+    uint16_t addr, mpu401_addr;
+    int low_dma, high_dma;
+    sb_t *sb = (sb_t *) p;
+
+    if (port < 0x102)
+        return;
+
+    sb_log("sb_16_reply_mca_write: port=%04x val=%02x\n", port, val);
+
+    switch (sb->pos_regs[2] & 0xc4) {
+        case 4:
+            addr = 0x220;
+            break;
+        case 0x44:
+            addr = 0x240;
+            break;
+        case 0x84:
+            addr = 0x260;
+            break;
+        case 0xc4:
+            addr = 0x280;
+            break;
+        case 0:
+            addr = 0;
+            break;
+    }
+
+    if (addr) {
+        io_removehandler(addr, 0x0004,
+                      opl3_read, NULL, NULL,
+                      opl3_write, NULL, NULL,
+                      &sb->opl);
+        io_removehandler(addr + 8, 0x0002,
+                      opl3_read, NULL, NULL,
+                      opl3_write, NULL, NULL,
+                      &sb->opl);
+        io_removehandler(0x0388, 0x0004,
+                      opl3_read, NULL, NULL,
+                      opl3_write, NULL, NULL,
+                      &sb->opl);
+        io_removehandler(addr + 4, 0x0002,
+                     sb_ct1745_mixer_read, NULL, NULL,
+                     sb_ct1745_mixer_write, NULL, NULL,
+                     sb);
+    }
+
+    /* DSP I/O handler is activated in sb_dsp_setaddr */
+    sb_dsp_setaddr(&sb->dsp, 0);
+    mpu401_change_addr(sb->mpu, 0);
+    gameport_remap(sb->gameport, 0);
+
+    sb->pos_regs[port & 7] = val;
+
+    if (sb->pos_regs[2] & 1) {
+        switch (sb->pos_regs[2] & 0xc4) {
+            case 4:
+                addr = 0x220;
+                break;
+            case 0x44:
+                addr = 0x240;
+                break;
+            case 0x84:
+                addr = 0x260;
+                break;
+            case 0xc4:
+                addr = 0x280;
+                break;
+            case 0:
+                addr = 0;
+                break;
+        }
+        switch (sb->pos_regs[2] & 0x18) {
+            case 8:
+                mpu401_addr = 0x330;
+                break;
+            case 0x18:
+                mpu401_addr = 0x300;
+                break;
+            case 0:
+                mpu401_addr = 0;
+                break;
+        }
+
+        if (addr) {
+            io_sethandler(addr, 0x0004,
+                          opl3_read, NULL, NULL,
+                          opl3_write, NULL, NULL,
+                          &sb->opl);
+            io_sethandler(addr + 8, 0x0002,
+                          opl3_read, NULL, NULL,
+                          opl3_write, NULL, NULL,
+                          &sb->opl);
+            io_sethandler(0x0388, 0x0004,
+                          opl3_read, NULL, NULL,
+                          opl3_write, NULL, NULL, &sb->opl);
+            io_sethandler(addr + 4, 0x0002,
+                          sb_ct1745_mixer_read, NULL, NULL,
+                          sb_ct1745_mixer_write, NULL, NULL,
+                          sb);
+        }
+
+        /* DSP I/O handler is activated in sb_dsp_setaddr */
+        sb_dsp_setaddr(&sb->dsp, addr);
+        mpu401_change_addr(sb->mpu, mpu401_addr);
+        gameport_remap(sb->gameport, (sb->pos_regs[2] & 0x20) ? 0x200 : 0);
+    }
+
+    switch (sb->pos_regs[4] & 0x60) {
+        case 0x20:
+            sb_dsp_setirq(&sb->dsp, 5);
+            break;
+        case 0x40:
+            sb_dsp_setirq(&sb->dsp, 7);
+            break;
+        case 0x60:
+            sb_dsp_setirq(&sb->dsp, 10);
+            break;
+    }
+
+    low_dma = sb->pos_regs[3] & 3;
+    high_dma = (sb->pos_regs[3] >> 4) & 7;
+    if (!high_dma)
+        high_dma = low_dma;
+
+    sb_dsp_setdma8(&sb->dsp, low_dma);
+    sb_dsp_setdma16(&sb->dsp, high_dma);
+}
+
 static void
 sb_16_pnp_config_changed(uint8_t ld, isapnp_device_config_t *config, void *priv)
 {
@@ -1781,6 +1923,41 @@ sb_16_init(const device_t *info)
 
     if (device_get_config_int("receive_input"))
         midi_in_handler(1, sb_dsp_input_msg, sb_dsp_input_sysex, &sb->dsp);
+
+    return sb;
+}
+
+static void *
+sb_16_reply_mca_init(const device_t *info)
+{
+    sb_t *sb = malloc(sizeof(sb_t));
+    memset(sb, 0x00, sizeof(sb_t));
+
+    sb->opl_enabled = 1;
+    opl3_init(&sb->opl);
+
+    sb_dsp_init(&sb->dsp, SB16, SB_SUBTYPE_DEFAULT, sb);
+    sb_ct1745_mixer_reset(sb);
+
+    sb->mixer_enabled = 1;
+    sb->mixer_sb16.output_filter = 1;
+    sound_add_handler(sb_get_buffer_sb16_awe32, sb);
+    sound_set_cd_audio_filter(sb16_awe32_filter_cd_audio, sb);
+
+    sb->mpu = (mpu_t *) malloc(sizeof(mpu_t));
+    memset(sb->mpu, 0, sizeof(mpu_t));
+    mpu401_init(sb->mpu, 0, 0, M_UART, device_get_config_int("receive_input401"));
+    sb_dsp_set_mpu(&sb->dsp, sb->mpu);
+
+    if (device_get_config_int("receive_input"))
+        midi_in_handler(1, sb_dsp_input_msg, sb_dsp_input_sysex, &sb->dsp);
+
+    sb->gameport = gameport_add(&gameport_device);
+
+    /* I/O handlers activated in sb_pro_mcv_write */
+    mca_add(sb_16_reply_mca_read, sb_16_reply_mca_write, sb_mcv_feedb, NULL, sb);
+    sb->pos_regs[0] = 0x38;
+    sb->pos_regs[1] = 0x51;
 
     return sb;
 }
@@ -3369,6 +3546,20 @@ const device_t sb_16_device = {
     .speed_changed = sb_speed_changed,
     .force_redraw  = NULL,
     .config        = sb_16_config
+};
+
+const device_t sb_16_reply_mca_device = {
+    .name          = "Sound Blaster 16 Reply MCA",
+    .internal_name = "sb16_reply_mca",
+    .flags         = DEVICE_MCA,
+    .local         = 0,
+    .init          = sb_16_reply_mca_init,
+    .close         = sb_close,
+    .reset         = NULL,
+    { .available = NULL },
+    .speed_changed = sb_speed_changed,
+    .force_redraw  = NULL,
+    .config        = sb_16_pnp_config
 };
 
 const device_t sb_16_pnp_device = {

--- a/src/sound/sound.c
+++ b/src/sound/sound.c
@@ -140,6 +140,7 @@ static const SOUND_CARD sound_cards[] = {
     { &ncr_business_audio_device },
     { &sb_mcv_device             },
     { &sb_pro_mcv_device         },
+    { &sb_16_reply_mca_device    },
     { &cmi8338_device            },
     { &cmi8738_device            },
     { &es1371_device             },


### PR DESCRIPTION
… is undocumented in said side, but documented in the ISA/PCI side).

Summary
=======
Networking: Added the WD8013EP/A MCA nic, which is more supported than the WD80x3ET/A plus an initial ram size configuration before POS configuration.
Sound: Added the Reply MCA OEM of SB16 with its own MCA POS ID and properly implemented the IRQ's and DMA's of the AdLib Gold in its EEPROM plus an initial configurable setting for them and an initial DRQ implementation into said card.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
