### PR TITLE
Fix crash at exit due to a unreleased mutex

### DIFF
--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -54,6 +54,7 @@ QElapsedTimer elapsed_timer;
 
 static std::atomic_int blitmx_contention = 0;
 static std::recursive_mutex blitmx;
+static thread_local std::unique_lock blit_lock { blitmx, std::defer_lock };
 
 class CharPointer {
 public:
@@ -468,17 +469,17 @@ void dynld_close(void *handle)
 void startblit()
 {
     blitmx_contention++;
-    if (blitmx.try_lock()) {
+    if (blit_lock.try_lock()) {
         return;
     }
 
-    blitmx.lock();
+    blit_lock.lock();
 }
 
 void endblit()
 {
     blitmx_contention--;
-    blitmx.unlock();
+    blit_lock.unlock();
     if (blitmx_contention > 0) {
         // a deadlock has been observed on linux when toggling via video_toggle_option
         // because the mutex is typically unfair on linux


### PR DESCRIPTION
Summary
=======

Qt startblit() and endblit() use a mutex that can remain locked at exit.
A thread static wrapper makes sure that each thread using the mutex will also release it before terminating.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
