### PR TITLE
Fix a typo in qt_platform.cpp

### DIFF
--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -571,7 +571,7 @@ void ProgSettings::reloadStrings()
         gssynthstr.replace("libgs", LIB_NAME_GS);
     }
     else gssynthstr.prepend(LIB_NAME_GS);
-    translatedstrings[IDS_2132] = flsynthstr.toStdWString();
+    translatedstrings[IDS_2132] = gssynthstr.toStdWString();
     auto ftsynthstr = QCoreApplication::translate("", " is required for ESC/P printer emulation.");
     if (ftsynthstr.contains("libfreetype"))
     {


### PR DESCRIPTION
Summary
=======
Fixes a typo that made the dialog box shown upon failing to load the Ghostscript library display the wrong message.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
