### PR TITLE
Add an option to control SBMIDI input receiving on SB Pro MCV

### DIFF
--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -2749,6 +2749,17 @@ static const device_config_t sb_pro_config[] = {
     { .name = "", .description = "", .type = CONFIG_END }
 };
 
+static const device_config_t sb_pro_mcv_config[] = {
+    {
+        .name = "receive_input",
+        .description = "Receive input (SB MIDI)",
+        .type = CONFIG_BINARY,
+        .default_string = "",
+        .default_int = 1
+    },
+    { .name = "", .description = "", .type = CONFIG_END }
+};
+
 static const device_config_t sb_16_config[] = {
     {
         .name = "base",
@@ -3523,7 +3534,7 @@ const device_t sb_pro_mcv_device = {
     { .available = NULL },
     .speed_changed = sb_speed_changed,
     .force_redraw  = NULL,
-    .config        = NULL
+    .config        = sb_pro_mcv_config
 };
 
 const device_t sb_pro_compat_device = {


### PR DESCRIPTION
Summary
=======

Adds an option to control MIDI input that was missing from the Sound Blaster Pro MCV despite having been added to other Sound Blasters.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
