### PR TITLE
Fix a crash with Sound Blaster Pro v2

### DIFF
--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -314,7 +314,7 @@ sb_get_buffer_sbpro(int32_t *buffer, int len, void *p)
 
     if (sb->opl_enabled) {
         sb->opl.reset_buffer(sb->opl.priv);
-        if (sb->dsp.sb_type != SBPRO)
+        if (sb->dsp.sb_type == SBPRO)
             sb->opl2.reset_buffer(sb->opl2.priv);
     }
 


### PR DESCRIPTION
Summary
=======
Fixes a segfault at startup when the Sound Blaster Pro v2 or Pro MCV are selected. Additionally, seems to fix OPL playback on Sound Blaster Pro v1 outputting only on the left channel.

Checklist
=========
* [x] Closes #2382
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
