### PR TITLE
qt: HDD icons no longer stays lit "forever"

### DIFF
--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -354,6 +354,7 @@ void MachineStatus::refreshIcons() {
 
     for (size_t i = 0; i < HDD_BUS_USB; i++) {
         d->hdds[i].setActive(machine_status.hdd[i].active);
+        machine_status.hdd[i].active = false;
     }
 
     d->net.setActive(machine_status.net.active);


### PR DESCRIPTION
Summary
=======
qt: HDD icons no longer stays lit "forever".

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
