### PR TITLE
Clear the MT-32 LCD message on reset

### DIFF
--- a/src/sound/midi_mt32.c
+++ b/src/sound/midi_mt32.c
@@ -320,6 +320,8 @@ mt32_close(void *p)
     }
     context = NULL;
 
+    ui_sb_mt32lcd("");
+
     if (buffer)
         free(buffer);
     buffer = NULL;


### PR DESCRIPTION
Summary
=======
Makes the last MT-32 LCD message in the status bar disappear upon a hard reset instead of persisting until the emulator is closed, to avoid interfering with the POST card. 

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
