### PR TITLE
qt: Fix separators not showing up on macOS

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -525,6 +525,23 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(this, &MainWindow::initRendererMonitorForNonQtThread, this, &MainWindow::initRendererMonitorSlot, Qt::BlockingQueuedConnection);
     connect(this, &MainWindow::destroyRendererMonitor, this, &MainWindow::destroyRendererMonitorSlot);
     connect(this, &MainWindow::destroyRendererMonitorForNonQtThread, this, &MainWindow::destroyRendererMonitorSlot, Qt::BlockingQueuedConnection);
+
+#ifdef Q_OS_MACOS
+	QTimer::singleShot(0, this, [this] () {
+		for (auto curObj : this->menuBar()->children()) {
+			if (qobject_cast<QMenu*>(curObj)) {
+				auto menu = qobject_cast<QMenu*>(curObj);
+				menu->setSeparatorsCollapsible(false);
+				for (auto curObj2 : menu->children()) {
+					if (qobject_cast<QMenu*>(curObj2)) {
+						auto menu2 = qobject_cast<QMenu*>(curObj2);
+						menu2->setSeparatorsCollapsible(false);
+					}
+				}
+			}
+		}
+	});
+#endif
 }
 
 void MainWindow::closeEvent(QCloseEvent *event) {


### PR DESCRIPTION
Summary
=======
qt: Fix separators not showing up on macOS

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://bugreports.qt.io/browse/QTBUG-94802?gerritIssueType=IssueOnly
