### PR TITLE
qt: Global option in preferences to use usr_path as the file image open directory

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -183,6 +183,7 @@ int confirm_save = 1;				/* (C) enable save confirmation */
 int	enable_discord = 0;			/* (C) enable Discord integration */
 int pit_mode = -1;				/* (C) force setting PIT mode */
 int fm_driver = 0;				/* (C) select FM sound driver */
+int open_dir_usr_path = 0;                      /* default file open dialog directory of usr_path */
 
 /* Statistics. */
 extern int mmuflush;

--- a/src/config.c
+++ b/src/config.c
@@ -611,6 +611,8 @@ load_general(void)
 
     enable_discord = !!config_get_int(cat, "enable_discord", 0);
 
+    open_dir_usr_path = config_get_int(cat, "open_dir_usr_path", 0);
+
     video_framerate = config_get_int(cat, "video_gl_framerate", -1);
     video_vsync     = config_get_int(cat, "video_gl_vsync", 0);
     strncpy(video_shader, config_get_string(cat, "video_gl_shader", ""), sizeof(video_shader));
@@ -2379,6 +2381,11 @@ save_general(void)
         config_set_int(cat, "enable_discord", enable_discord);
     else
         config_delete_var(cat, "enable_discord");
+
+    if (open_dir_usr_path)
+        config_set_int(cat, "open_dir_usr_path", open_dir_usr_path);
+    else
+        config_delete_var(cat, "open_dir_usr_path");
 
     if (video_framerate != -1)
         config_set_int(cat, "video_gl_framerate", video_framerate);

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -137,6 +137,7 @@ extern int    fm_driver;         /* (C) select FM sound driver */
 extern char exe_path[2048]; /* path (dir) of executable */
 extern char usr_path[1024]; /* path (dir) of user data */
 extern char cfg_path[1024]; /* full path of config file */
+extern int  open_dir_usr_path;    /* default file open dialog directory of usr_path */
 #ifndef USE_NEW_DYNAREC
 extern FILE *stdlog; /* file to log output to */
 #endif

--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -28,6 +28,7 @@
 #include <QStringBuilder>
 
 extern "C" {
+#include <86box/86box.h>
 #include <86box/config.h>
 #include <86box/device.h>
 #include <86box/timer.h>
@@ -173,7 +174,7 @@ void MediaMenu::cassetteNewImage() {
 void MediaMenu::cassetteSelectImage(bool wp) {
     auto filename = QFileDialog::getOpenFileName(parentWidget,
         QString(),
-        QString(),
+        getMediaOpenDirectory(),
         tr("Cassette images") %
         util::DlgFilter({ "pcm","raw","wav","cas" }) %
         tr("All files") %
@@ -247,7 +248,7 @@ void MediaMenu::cartridgeSelectImage(int i) {
     auto filename = QFileDialog::getOpenFileName(
         parentWidget,
         QString(),
-        QString(),
+        getMediaOpenDirectory(),
         tr("Cartridge images") %
         util::DlgFilter({ "a","b","jrc" }) %
         tr("All files") %
@@ -291,7 +292,7 @@ void MediaMenu::floppySelectImage(int i, bool wp) {
     auto filename = QFileDialog::getOpenFileName(
         parentWidget,
         QString(),
-        QString(),
+        getMediaOpenDirectory(),
         tr("All images") %
         util::DlgFilter({ "0??","1??","??0","86f","bin","cq?","d??","flp","hdm","im?","json","td0","*fd?","mfm","xdf" }) %
         tr("Advanced sector images") %
@@ -400,7 +401,7 @@ void MediaMenu::cdromMount(int i) {
     auto filename = QFileDialog::getOpenFileName(
         parentWidget,
         QString(),
-        QString(),
+        getMediaOpenDirectory(),
         tr("CD-ROM images") %
         util::DlgFilter({ "iso","cue" }) %
         tr("All files") %
@@ -571,7 +572,7 @@ void MediaMenu::moSelectImage(int i, bool wp) {
     auto filename = QFileDialog::getOpenFileName(
         parentWidget,
         QString(),
-        QString(),
+        getMediaOpenDirectory(),
         tr("MO images") %
         util::DlgFilter({ "im?", "mdi" }) %
         tr("All files") %
@@ -656,6 +657,13 @@ void MediaMenu::moUpdateMenu(int i) {
     menu->setTitle(QString::asprintf(tr("MO %i (%ls): %ls").toUtf8().constData(), i + 1, busName.toStdU16String().data(), name.isEmpty() ? tr("(empty)").toStdU16String().data() : name.toStdU16String().data()));
 }
 
+QString MediaMenu::getMediaOpenDirectory() {
+    QString openDirectory;
+    if (open_dir_usr_path > 0) {
+        openDirectory = QString::fromUtf8(usr_path);
+    }
+    return openDirectory;
+}
 
 // callbacks from 86box C code
 extern "C" {

--- a/src/qt/qt_mediamenu.hpp
+++ b/src/qt/qt_mediamenu.hpp
@@ -66,6 +66,8 @@ private:
     QMap<int, QMenu*> zipMenus;
     QMap<int, QMenu*> moMenus;
 
+    QString getMediaOpenDirectory();
+
     int cassetteRecordPos;
     int cassettePlayPos;
     int cassetteRewindPos;

--- a/src/qt/qt_progsettings.cpp
+++ b/src/qt/qt_progsettings.cpp
@@ -113,12 +113,14 @@ ProgSettings::ProgSettings(QWidget *parent) :
 
     mouseSensitivity = mouse_sensitivity;
     ui->horizontalSlider->setValue(mouseSensitivity * 100.);
+    ui->openDirUsrPath->setChecked(open_dir_usr_path > 0);
 }
 
 void ProgSettings::accept()
 {
     strcpy(icon_set, ui->comboBox->currentData().toString().toUtf8().data());
     lang_id = ui->comboBoxLanguage->currentData().toUInt();
+    open_dir_usr_path = ui->openDirUsrPath->isChecked() ? 1 : 0;
 
     loadTranslators(QCoreApplication::instance());
     reloadStrings();

--- a/src/qt/qt_progsettings.ui
+++ b/src/qt/qt_progsettings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>458</width>
-    <height>303</height>
+    <height>374</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -29,24 +29,14 @@
    <property name="sizeConstraint">
     <enum>QLayout::SetFixedSize</enum>
    </property>
-   <item row="2" column="0">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="1" column="0" colspan="2">
+    <widget class="QComboBox" name="comboBox">
+     <property name="editable">
+      <bool>false</bool>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QComboBox" name="comboBoxLanguage">
      <item>
       <property name="text">
-       <string>(System Default)</string>
+       <string>(Default)</string>
       </property>
      </item>
     </widget>
@@ -58,30 +48,6 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QPushButton" name="pushButton">
-     <property name="text">
-      <string>Default</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QPushButton" name="pushButtonLanguage">
-     <property name="text">
-      <string>Default</string>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0" colspan="2">
     <widget class="QLabel" name="label">
      <property name="text">
@@ -89,8 +55,8 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
-    <widget class="QPushButton" name="pushButton_2">
+   <item row="2" column="1">
+    <widget class="QPushButton" name="pushButton">
      <property name="text">
       <string>Default</string>
      </property>
@@ -109,25 +75,15 @@
      </property>
     </spacer>
    </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Language:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <spacer name="horizontalSpacer_2">
+   <item row="12" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
-    </spacer>
+    </widget>
    </item>
    <item row="7" column="0" colspan="2">
     <widget class="QSlider" name="horizontalSlider">
@@ -151,16 +107,70 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QComboBox" name="comboBox">
-     <property name="editable">
-      <bool>false</bool>
-     </property>
+   <item row="4" column="0" colspan="2">
+    <widget class="QComboBox" name="comboBoxLanguage">
      <item>
       <property name="text">
-       <string>(Default)</string>
+       <string>(System Default)</string>
       </property>
      </item>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Language:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QPushButton" name="pushButtonLanguage">
+     <property name="text">
+      <string>Default</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="QPushButton" name="pushButton_2">
+     <property name="text">
+      <string>Default</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="0">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="9" column="0">
+    <widget class="QCheckBox" name="openDirUsrPath">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Select media images from program working directory</string>
+     </property>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
Summary
=======
On macOS, after launching 86Box from finder the image file selection directory defaults to `/`. On Windows and Linux, qt defaults to what is essentially the `$CWD` of the application. There are a few reasons for the macOS difference, mostly just the way application bundles are structured and the way they are launched.

This PR adds an option to try and mimic the Windows / Linux behavior on macOS . When this option is selected any media selection dialog will default to the `usr_path` directory.

The option appears to have no effect on Windows or Linux because open dialogs are in `$CWD` by default. Additionally, current behavior can be maintained by not selecting the option.

Tested on: macOS, linux, windows 10

**Note:** A side effect of this PR is making the preferences dialog wider to display the text for the option (handled automatically by qt). I believe at least one person on discord was requesting something to that effect in order to accommodate longer strings in various translations. 

I think a review by @Cacodemon345 would be good for the qt aspect. Since I had to add another config option and make changes to various files to accommodate I'd like @OBattler to give it a look as well.

### Example

Preferences window

![windows prefs](https://user-images.githubusercontent.com/47337035/181994486-fc58e741-c1a7-43cc-b757-16e00f46527a.png)

![macos prefs](https://user-images.githubusercontent.com/47337035/181994494-133eb21e-2985-49f5-8f4c-5250bc957e10.png)

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
