### PR TITLE
Voodoo fix for NFS2SE

### DIFF
--- a/src/video/vid_voodoo_fifo.c
+++ b/src/video/vid_voodoo_fifo.c
@@ -494,6 +494,7 @@ void voodoo_fifo_thread(void *param)
                                 switch (header >> 30)
                                 {
                                         case 0: /*Linear framebuffer (Banshee)*/
+                                        case 1: /*Planar YUV*/
                                         if (voodoo->texture_present[0][(addr & voodoo->texture_mask) >> TEX_DIRTY_SHIFT])
                                         {
 //                                                voodoo_fifo_log("texture_present at %08x %i\n", addr, (addr & voodoo->texture_mask) >> TEX_DIRTY_SHIFT);


### PR DESCRIPTION
Summary
=======
fixes a lot of graphical corruption on the menu of NFS2SE when render threads = 4, seems to fix all corruption in game too, according to @Dizzy611 it also improves performance.

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
