### PR TITLE
qt: fix hard freeze on hidden second windows

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -1594,7 +1594,7 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
 void MainWindow::blitToWidget(int x, int y, int w, int h, int monitor_index)
 {
     if (monitor_index >= 1) {
-        if (renderers[monitor_index] && renderers[monitor_index].isVisible()) renderers[monitor_index]->blit(x, y, w, h);
+        if (renderers[monitor_index] && renderers[monitor_index]->isVisible()) renderers[monitor_index]->blit(x, y, w, h);
         else video_blit_complete_monitor(monitor_index);
     }
     else ui->stackedWidget->blit(x, y, w, h);

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -1594,7 +1594,7 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
 void MainWindow::blitToWidget(int x, int y, int w, int h, int monitor_index)
 {
     if (monitor_index >= 1) {
-        if (renderers[monitor_index]) renderers[monitor_index]->blit(x, y, w, h);
+        if (renderers[monitor_index] && renderers[monitor_index].isVisible()) renderers[monitor_index]->blit(x, y, w, h);
         else video_blit_complete_monitor(monitor_index);
     }
     else ui->stackedWidget->blit(x, y, w, h);


### PR DESCRIPTION
Summary
=======
qt: fix hard freeze on hidden second windows

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
