### PR TITLE
qt: Fix compile on ARM64 with GLES2 headers

### DIFF
--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -289,6 +289,7 @@ int main(int argc, char* argv[]) {
     cpu_thread_run = 0;
     main_thread->join();
     pc_close(nullptr);
+    endblit();
 
     socket.close();
     return ret;

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -650,6 +650,11 @@ MainWindow::~MainWindow() {
 void MainWindow::showEvent(QShowEvent *event) {
     if (shownonce) return;
     shownonce = true;
+    if (window_remember) {
+        if (window_w < 320) window_w = 320;
+        if (window_h < 200) window_h = 200;
+    }
+
     if (window_remember && !QApplication::platformName().contains("wayland")) {
         setGeometry(window_x, window_y, window_w, window_h + menuBar()->height() + (hide_status_bar ? 0 : statusBar()->height()) + (hide_tool_bar ? 0 : ui->toolBar->height()));
     }

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -651,8 +651,8 @@ void MainWindow::showEvent(QShowEvent *event) {
     if (shownonce) return;
     shownonce = true;
     if (window_remember) {
-        if (window_w < 320) window_w = 320;
-        if (window_h < 200) window_h = 200;
+        if (window_w == 0) window_w = 320;
+        if (window_h == 0) window_h = 200;
     }
 
     if (window_remember && !QApplication::platformName().contains("wayland")) {

--- a/src/qt/qt_openglrenderer.cpp
+++ b/src/qt/qt_openglrenderer.cpp
@@ -26,6 +26,14 @@
 #include "qt_opengloptionsdialog.hpp"
 #include "qt_openglrenderer.hpp"
 
+#ifndef GL_MAP_PERSISTENT_BIT
+#define GL_MAP_PERSISTENT_BIT 0x0040
+#endif
+
+#ifndef GL_MAP_COHERENT_BIT
+#define GL_MAP_COHERENT_BIT 0x0080
+#endif
+
 OpenGLRenderer::OpenGLRenderer(QWidget *parent)
     : QWindow(parent->windowHandle())
     , renderTimer(new QTimer(this))
@@ -239,10 +247,12 @@ void
 OpenGLRenderer::initializeExtensions()
 {
 #ifndef NO_BUFFER_STORAGE
-    if (context->hasExtension("GL_ARB_buffer_storage")) {
+    if (context->hasExtension("GL_ARB_buffer_storage") || context->hasExtension("GL_EXT_buffer_storage")) {
         hasBufferStorage = true;
 
-        glBufferStorage = (PFNGLBUFFERSTORAGEPROC) context->getProcAddress("glBufferStorage");
+        glBufferStorage = (PFNGLBUFFERSTORAGEEXTPROC_LOCAL) context->getProcAddress(context->hasExtension("GL_EXT_buffer_storage") ? "glBufferStorageEXT" : "glBufferStorage");
+        if (!glBufferStorage)
+            glBufferStorage = glBufferStorage = (PFNGLBUFFERSTORAGEEXTPROC_LOCAL) context->getProcAddress("glBufferStorage");
     }
 #endif
 }

--- a/src/qt/qt_openglrenderer.hpp
+++ b/src/qt/qt_openglrenderer.hpp
@@ -39,6 +39,8 @@
 #include "qt_opengloptions.hpp"
 #include "qt_renderercommon.hpp"
 
+typedef void (QOPENGLF_APIENTRYP PFNGLBUFFERSTORAGEEXTPROC_LOCAL) (GLenum target, GLsizeiptr size, const void *data, GLbitfield flags);
+
 class OpenGLRenderer : public QWindow, protected QOpenGLExtraFunctions, public RendererCommon {
     Q_OBJECT
 
@@ -103,7 +105,7 @@ private:
     /* GL_ARB_buffer_storage */
     bool hasBufferStorage = false;
 #ifndef NO_BUFFER_STORAGE
-    PFNGLBUFFERSTORAGEPROC glBufferStorage = nullptr;
+    PFNGLBUFFERSTORAGEEXTPROC_LOCAL glBufferStorage = nullptr;
 #endif
 
 private slots:

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -54,7 +54,6 @@ QElapsedTimer elapsed_timer;
 
 static std::atomic_int blitmx_contention = 0;
 static std::recursive_mutex blitmx;
-static thread_local std::unique_lock blit_lock { blitmx, std::defer_lock };
 
 class CharPointer {
 public:
@@ -469,17 +468,17 @@ void dynld_close(void *handle)
 void startblit()
 {
     blitmx_contention++;
-    if (blit_lock.try_lock()) {
+    if (blitmx.try_lock()) {
         return;
     }
 
-    blit_lock.lock();
+    blitmx.lock();
 }
 
 void endblit()
 {
     blitmx_contention--;
-    blit_lock.unlock();
+    blitmx.unlock();
     if (blitmx_contention > 0) {
         // a deadlock has been observed on linux when toggling via video_toggle_option
         // because the mutex is typically unfair on linux


### PR DESCRIPTION
Summary
=======
qt: Fix compile on ARM64 with GLES2 headers

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
