### PR TITLE
qt: properly update "Show non-primary monitors" settings when they are closed

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -2058,7 +2058,7 @@ void MainWindow::on_actionMCA_devices_triggered()
 
 void MainWindow::on_actionShow_non_primary_monitors_triggered()
 {
-    show_second_monitors ^= 1;
+    show_second_monitors = (int)ui->actionShow_non_primary_monitors->isChecked();
 
     blitDummied = true;
 

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -148,6 +148,7 @@ private:
     friend class SpecifyDimensions;
     friend class ProgSettings;
     friend class RendererCommon;
+    friend class RendererStack; // For UI variable access by non-primary renderer windows.
 };
 
 #endif // QT_MAINWINDOW_HPP

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -32,6 +32,8 @@
 #include "qt_mainwindow.hpp"
 #include "qt_util.hpp"
 
+#include "ui_qt_mainwindow.h"
+
 #include "evdev_mouse.hpp"
 
 #include <atomic>
@@ -459,9 +461,9 @@ RendererStack::blitCommon(int x, int y, int w, int h)
 
 void RendererStack::closeEvent(QCloseEvent* event)
 {
-    if (cpu_thread_run == 0 || is_quit == 0) {
+    if (cpu_thread_run == 1 || is_quit == 0) {
         event->accept();
-        show_second_monitors = 0; // TODO: This isn't actually the right fix, so fix this properly.
+        main_window->ui->actionShow_non_primary_monitors->setChecked(false);
         return;
     }
     event->ignore();


### PR DESCRIPTION
Summary
=======
qt: properly update "Show non-primary monitors" settings when they are closed

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
