### PR TITLE
qt: Fix unresponsive progress bar when creating floppy images

### DIFF
--- a/src/qt/qt_newfloppydialog.cpp
+++ b/src/qt/qt_newfloppydialog.cpp
@@ -187,6 +187,7 @@ void NewFloppyDialog::onCreate() {
 
     QProgressDialog progress("Creating floppy image", QString(), 0, 100, this);
     connect(this, &NewFloppyDialog::fileProgress, &progress, &QProgressDialog::setValue);
+    connect(this, &NewFloppyDialog::fileProgress, [] { QApplication::processEvents(); });
     switch (mediaType_) {
     case MediaType::Floppy:
         if (fi.suffix().toLower() == QStringLiteral("86f")) {


### PR DESCRIPTION
Summary
=======
qt: Fix unresponsive progress bar when creating floppy images

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
