### PR TITLE
qt: Media menu updates

### DIFF
--- a/src/qt/qt_mediamenu.hpp
+++ b/src/qt/qt_mediamenu.hpp
@@ -80,7 +80,6 @@ private:
     int floppyEjectPos;
 
     int cdromMutePos;
-    int cdromEmptyPos;
     int cdromReloadPos;
     int cdromImagePos;
 


### PR DESCRIPTION
Summary
=======
The CD-ROM menu was a bit inconsistent with the floppy media menu. For example, to eject an image it's listed as `Eject` in floppy but `Empty` in cd. To load an image you click `Image`, but in a different location than that of the floppy menu.

In addition, the `Reload previous image` had no effect while an image was loaded.

This PR tries to clean that up a little:
* `Empty` is now called `Eject` like the floppy and moved to the bottom. 
* `Reload previous image` is only visible when the conditions are met: 1) no image mounted and 2) a previous image was used.
* To load an image, you now select `Image...` in a similar location to the floppy menu

This also adds the currently mounted image name to the floppy and CD-ROM menu while an image is mounted. See pictures below. Tested on mac/linux/win.

![no images loaded](https://user-images.githubusercontent.com/47337035/182481707-0cd4a10f-ebb9-42c3-9a3e-62c673ee79b7.png)
No image loaded, no previous image

![image loaded](https://user-images.githubusercontent.com/47337035/182481729-3bc3b4a9-5cc2-4090-afae-2726d4867aca.png)
Image loaded, image name displayed

![reload image](https://user-images.githubusercontent.com/47337035/182481751-bd08e9d1-e6d5-42ee-9ad7-b761ab96e67a.png)
No image loaded, reload image displaying previous image name

![floppy menu](https://user-images.githubusercontent.com/47337035/182481772-1ed0cb1c-c190-425b-9ba4-cc2544b02dc9.png)
Floppy menu with image name

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
