### PR TITLE
Use defines instead of hardcodes for drive limits

### DIFF
--- a/src/cdrom/cdrom.c
+++ b/src/cdrom/cdrom.c
@@ -25,6 +25,7 @@
 #include <86box/cdrom.h>
 #include <86box/cdrom_image.h>
 #include <86box/plat.h>
+#include <86box/scsi.h>
 #include <86box/scsi_device.h>
 #include <86box/sound.h>
 

--- a/src/disk/mo.c
+++ b/src/disk/mo.c
@@ -31,6 +31,7 @@
 #include <86box/config.h>
 #include <86box/timer.h>
 #include <86box/device.h>
+#include <86box/scsi.h>
 #include <86box/scsi_device.h>
 #include <86box/nvr.h>
 #include <86box/path.h>

--- a/src/disk/zip.c
+++ b/src/disk/zip.c
@@ -27,6 +27,7 @@
 #include <86box/config.h>
 #include <86box/timer.h>
 #include <86box/device.h>
+#include <86box/scsi.h>
 #include <86box/scsi_device.h>
 #include <86box/nvr.h>
 #include <86box/plat.h>

--- a/src/include/86box/hdc_ide.h
+++ b/src/include/86box/hdc_ide.h
@@ -19,6 +19,9 @@
 #ifndef EMU_IDE_H
 # define EMU_IDE_H
 
+#define IDE_BUS_MAX 4
+#define IDE_CHAN_MAX 2
+
 #define HDC_PRIMARY_BASE    0x01F0
 #define HDC_PRIMARY_SIDE    0x03F6
 #define HDC_PRIMARY_IRQ	    14

--- a/src/include/86box/scsi.h
+++ b/src/include/86box/scsi.h
@@ -21,7 +21,7 @@
 #ifndef EMU_SCSI_H
 # define EMU_SCSI_H
 
-extern int	scsi_card_current[4];
+extern int	scsi_card_current[SCSI_BUS_MAX];
 
 extern int	scsi_card_available(int card);
 #ifdef EMU_DEVICE_H

--- a/src/include/86box/scsi.h
+++ b/src/include/86box/scsi.h
@@ -21,6 +21,12 @@
 #ifndef EMU_SCSI_H
 # define EMU_SCSI_H
 
+/* Configuration. */
+#define SCSI_BUS_MAX    4  /* currently we support up to 4 controllers */
+
+#define SCSI_ID_MAX	    16 /* 16 on wide buses */
+#define SCSI_LUN_MAX    8  /* always 8 */
+
 extern int	scsi_card_current[SCSI_BUS_MAX];
 
 extern int	scsi_card_available(int card);

--- a/src/include/86box/scsi_device.h
+++ b/src/include/86box/scsi_device.h
@@ -21,10 +21,6 @@
 # define SCSI_DEVICE_H
 
 /* Configuration. */
-#define SCSI_BUS_MAX		4		/* currently we support up to 4 controllers */
-
-#define SCSI_ID_MAX		16		/* 16 on wide buses */
-#define SCSI_LUN_MAX		8		/* always 8 */
 
 #define SCSI_LUN_USE_CDB	0xff
 
@@ -361,8 +357,9 @@ typedef struct {
 #define SCSI_REMOVABLE_DISK 0x8000
 #define SCSI_REMOVABLE_CDROM 0x8005
 
+#ifdef EMU_SCSI_H
 extern scsi_device_t	scsi_devices[SCSI_BUS_MAX][SCSI_ID_MAX];
-
+#endif /* EMU_SCSI_H */
 
 extern int	cdrom_add_error_and_subchannel(uint8_t *b, int real_sector_type);
 extern int	cdrom_LBAtoMSF_accurate(void);

--- a/src/scsi/scsi_cdrom.c
+++ b/src/scsi/scsi_cdrom.c
@@ -27,6 +27,7 @@
 #include <86box/config.h>
 #include <86box/timer.h>
 #include <86box/device.h>
+#include <86box/scsi.h>
 #include <86box/scsi_device.h>
 #include <86box/nvr.h>
 #include <86box/hdc.h>

--- a/src/scsi/scsi_disk.c
+++ b/src/scsi/scsi_disk.c
@@ -25,6 +25,7 @@
 #include <86box/nvr.h>
 #include <86box/hdd.h>
 #include <86box/hdc.h>
+#include <86box/scsi.h>
 #include <86box/scsi_device.h>
 #include <86box/hdc_ide.h>
 #include <86box/plat.h>

--- a/src/win/win_settings.c
+++ b/src/win/win_settings.c
@@ -365,7 +365,7 @@ win_settings_init(void)
     temp_cassette = cassette_enable;
 
     mfm_tracking = xta_tracking = esdi_tracking = ide_tracking = 0;
-    for (i = 0; i < 8; i++)
+    for (i = 0; i < SCSI_LUN_MAX; i++)
         scsi_tracking[i] = 0;
 
     /* Hard disks category */
@@ -1958,12 +1958,12 @@ add_locations(HWND hdlg)
         settings_add_string(hdlg, IDC_COMBO_HD_CHANNEL, (LPARAM) lptsTemp);
     }
 
-    for (i = 0; i < 64; i++) {
+    for (i = 0; i < (SCSI_BUS_MAX * SCSI_ID_MAX); i++) {
         wsprintf(lptsTemp, plat_get_string(IDS_4135), i >> 4, i & 15);
         settings_add_string(hdlg, IDC_COMBO_HD_ID, (LPARAM) lptsTemp);
     }
 
-    for (i = 0; i < 8; i++) {
+    for (i = 0; i < (IDE_BUS_MAX * IDE_CHAN_MAX); i++) {
         wsprintf(lptsTemp, plat_get_string(IDS_4097), i >> 1, i & 1);
         settings_add_string(hdlg, IDC_COMBO_HD_CHANNEL_IDE, (LPARAM) lptsTemp);
     }
@@ -1989,7 +1989,7 @@ next_free_ide_channel(void)
 {
     int64_t i;
 
-    for (i = 0; i < 8; i++) {
+    for (i = 0; i < (IDE_BUS_MAX * IDE_CHAN_MAX); i++) {
         if (!(ide_tracking & (0xffLL << (i << 3LL))))
             return i;
     }
@@ -2002,7 +2002,7 @@ next_free_scsi_id(uint8_t *id)
 {
     int64_t i;
 
-    for (i = 0; i < 64; i++) {
+    for (i = 0; i < (SCSI_BUS_MAX * SCSI_ID_MAX); i++) {
         if (!(scsi_tracking[i >> 3] & (0xffLL << ((i & 0x07) << 3LL)))) {
             *id = i;
             return;
@@ -2138,7 +2138,7 @@ recalc_next_free_id(HWND hdlg)
     enable_add = enable_add && !bus_full(&mfm_tracking, 2);
     enable_add = enable_add && !bus_full(&esdi_tracking, 2);
     enable_add = enable_add && !bus_full(&xta_tracking, 2);
-    enable_add = enable_add && !bus_full(&ide_tracking, 8);
+    enable_add = enable_add && !bus_full(&ide_tracking, IDE_CHAN_MAX);
     for (i = 0; i < 2; i++)
         enable_add = enable_add && !bus_full(&(scsi_tracking[i]), 8);
 
@@ -3554,7 +3554,7 @@ win_settings_floppy_drives_recalc_list(HWND hdlg)
     lvI.mask      = LVIF_TEXT | LVIF_IMAGE | LVIF_STATE;
     lvI.stateMask = lvI.state = 0;
 
-    for (i = 0; i < 4; i++) {
+    for (i = 0; i < FDD_NUM; i++) {
         lvI.iSubItem = 0;
         if (temp_fdd_types[i] > 0) {
             t = fdd_getname(temp_fdd_types[i]);
@@ -3600,7 +3600,7 @@ win_settings_cdrom_drives_recalc_list(HWND hdlg)
     lvI.mask      = LVIF_TEXT | LVIF_IMAGE | LVIF_STATE;
     lvI.stateMask = lvI.iSubItem = lvI.state = 0;
 
-    for (i = 0; i < 4; i++) {
+    for (i = 0; i < CDROM_NUM; i++) {
         fsid = combo_id_to_format_string_id(temp_cdrom[i].bus_type);
 
         lvI.iSubItem = 0;
@@ -3947,13 +3947,13 @@ win_settings_zip_drives_init_columns(HWND hdlg)
 }
 
 static int
-get_selected_drive(HWND hdlg, int id)
+get_selected_drive(HWND hdlg, int id, int max)
 {
     int  drive = -1;
     int  i, j = 0;
     HWND h;
 
-    for (i = 0; i < 4; i++) {
+    for (i = 0; i < max; i++) {
         h = GetDlgItem(hdlg, id);
         j = ListView_GetItemState(h, i, LVIS_SELECTED);
         if (j)
@@ -4179,12 +4179,12 @@ cdrom_add_locations(HWND hdlg)
         settings_add_string(hdlg, IDC_COMBO_CD_SPEED, (LPARAM) lptsTemp);
     }
 
-    for (i = 0; i < 64; i++) {
+    for (i = 0; i < (SCSI_BUS_MAX * SCSI_ID_MAX); i++) {
         wsprintf(lptsTemp, plat_get_string(IDS_4135), i >> 4, i & 15);
         settings_add_string(hdlg, IDC_COMBO_CD_ID, (LPARAM) lptsTemp);
     }
 
-    for (i = 0; i < 8; i++) {
+    for (i = 0; i < (IDE_BUS_MAX * IDE_CHAN_MAX); i++) {
         wsprintf(lptsTemp, plat_get_string(IDS_4097), i >> 1, i & 1);
         settings_add_string(hdlg, IDC_COMBO_CD_CHANNEL_IDE, (LPARAM) lptsTemp);
     }
@@ -4245,12 +4245,12 @@ mo_add_locations(HWND hdlg)
             settings_add_string(hdlg, IDC_COMBO_MO_BUS, win_get_string(combo_id_to_string_id(i)));
     }
 
-    for (i = 0; i < 64; i++) {
+    for (i = 0; i < (SCSI_BUS_MAX * SCSI_ID_MAX); i++) {
         wsprintf(lptsTemp, plat_get_string(IDS_4135), i >> 4, i & 15);
         settings_add_string(hdlg, IDC_COMBO_MO_ID, (LPARAM) lptsTemp);
     }
 
-    for (i = 0; i < 8; i++) {
+    for (i = 0; i < (IDE_BUS_MAX * IDE_CHAN_MAX); i++) {
         wsprintf(lptsTemp, plat_get_string(IDS_4097), i >> 1, i & 1);
         settings_add_string(hdlg, IDC_COMBO_MO_CHANNEL_IDE, (LPARAM) lptsTemp);
     }
@@ -4322,12 +4322,12 @@ zip_add_locations(HWND hdlg)
             settings_add_string(hdlg, IDC_COMBO_ZIP_BUS, win_get_string(combo_id_to_string_id(i)));
     }
 
-    for (i = 0; i < 64; i++) {
+    for (i = 0; i < (SCSI_BUS_MAX * SCSI_LUN_MAX) ; i++) {
         wsprintf(lptsTemp, plat_get_string(IDS_4135), i >> 4, i & 15);
         settings_add_string(hdlg, IDC_COMBO_ZIP_ID, (LPARAM) lptsTemp);
     }
 
-    for (i = 0; i < 8; i++) {
+    for (i = 0; i < (IDE_BUS_MAX * IDE_CHAN_MAX); i++) {
         wsprintf(lptsTemp, plat_get_string(IDS_4097), i >> 1, i & 1);
         settings_add_string(hdlg, IDC_COMBO_ZIP_CHANNEL_IDE, (LPARAM) lptsTemp);
     }
@@ -4497,7 +4497,7 @@ win_settings_floppy_and_cdrom_drives_proc(HWND hdlg, UINT message, WPARAM wParam
 
             if ((((LPNMHDR) lParam)->code == LVN_ITEMCHANGED) && (((LPNMHDR) lParam)->idFrom == IDC_LIST_FLOPPY_DRIVES)) {
                 old_sel         = lv1_current_sel;
-                lv1_current_sel = get_selected_drive(hdlg, IDC_LIST_FLOPPY_DRIVES);
+                lv1_current_sel = get_selected_drive(hdlg, IDC_LIST_FLOPPY_DRIVES, FDD_NUM);
                 if (lv1_current_sel == old_sel)
                     return FALSE;
                 ignore_change = 1;
@@ -4507,7 +4507,7 @@ win_settings_floppy_and_cdrom_drives_proc(HWND hdlg, UINT message, WPARAM wParam
                 ignore_change = 0;
             } else if ((((LPNMHDR) lParam)->code == LVN_ITEMCHANGED) && (((LPNMHDR) lParam)->idFrom == IDC_LIST_CDROM_DRIVES)) {
                 old_sel         = lv2_current_sel;
-                lv2_current_sel = get_selected_drive(hdlg, IDC_LIST_CDROM_DRIVES);
+                lv2_current_sel = get_selected_drive(hdlg, IDC_LIST_CDROM_DRIVES, CDROM_NUM);
                 if (lv2_current_sel == old_sel)
                     return FALSE;
                 ignore_change = 1;
@@ -4684,7 +4684,7 @@ win_settings_other_removable_devices_proc(HWND hdlg, UINT message, WPARAM wParam
 
             if ((((LPNMHDR) lParam)->code == LVN_ITEMCHANGED) && (((LPNMHDR) lParam)->idFrom == IDC_LIST_MO_DRIVES)) {
                 old_sel         = lv1_current_sel;
-                lv1_current_sel = get_selected_drive(hdlg, IDC_LIST_MO_DRIVES);
+                lv1_current_sel = get_selected_drive(hdlg, IDC_LIST_MO_DRIVES, MO_NUM);
                 if (lv1_current_sel == old_sel)
                     return FALSE;
                 ignore_change = 1;
@@ -4707,7 +4707,7 @@ win_settings_other_removable_devices_proc(HWND hdlg, UINT message, WPARAM wParam
                 ignore_change = 0;
             } else if ((((LPNMHDR) lParam)->code == LVN_ITEMCHANGED) && (((LPNMHDR) lParam)->idFrom == IDC_LIST_ZIP_DRIVES)) {
                 old_sel         = lv2_current_sel;
-                lv2_current_sel = get_selected_drive(hdlg, IDC_LIST_ZIP_DRIVES);
+                lv2_current_sel = get_selected_drive(hdlg, IDC_LIST_ZIP_DRIVES, ZIP_NUM);
                 if (lv2_current_sel == old_sel)
                     return FALSE;
                 ignore_change = 1;


### PR DESCRIPTION
Summary
=======
Use defines instead of hardcodes for drive limits
This only updates the win32 ui, and core code at the moment, I have limited time today, but QT-UI should remain how it was before functionally. (Infact, everything should in reality)


Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
