### PR TITLE
mpu401: Add MPU-401AT I/O address ranges

### DIFF
--- a/src/sound/snd_mpu401.c
+++ b/src/sound/snd_mpu401.c
@@ -1845,6 +1845,18 @@ static const device_config_t mpu401_standalone_config[] = {
                 .value = 0x330
             },
             {
+                .description = "0x332",
+                .value = 0x332
+            },
+            {
+                .description = "0x334",
+                .value = 0x334
+            },
+            {
+                .description = "0x336",
+                .value = 0x336
+            },
+            {
                 .description = "0x340",
                 .value = 0x340
             },


### PR DESCRIPTION
Summary
=======
mpu401: Add MPU-401AT I/O address ranges

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://wiki.preterhuman.net/Roland_MPU-401AT
