### PR TITLE
qt: Update machine settings layout for consistency

### DIFF
--- a/src/qt/qt_settingsmachine.ui
+++ b/src/qt/qt_settingsmachine.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>458</width>
-    <height>390</height>
+    <height>391</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -28,7 +28,7 @@
    </property>
    <item>
     <widget class="QWidget" name="widget" native="true">
-     <layout class="QFormLayout" name="formLayout">
+     <layout class="QGridLayout" name="gridLayout">
       <property name="leftMargin">
        <number>0</number>
       </property>
@@ -51,58 +51,55 @@
       <item row="0" column="1">
        <widget class="QComboBox" name="comboBoxMachineType"/>
       </item>
-      <item row="2" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
          <string>Machine:</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="1" column="1">
+       <widget class="QWidget" name="widget_3" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QComboBox" name="comboBoxMachine"/>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButtonConfigure">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Configure</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="2" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
          <string>CPU type:</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>FPU:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Wait states:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Memory:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QComboBox" name="comboBoxFPU"/>
-      </item>
-      <item row="5" column="1">
-       <widget class="QComboBox" name="comboBoxWaitStates"/>
-      </item>
-      <item row="6" column="1">
-       <widget class="QSpinBox" name="spinBoxRAM">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
+      <item row="2" column="1">
        <widget class="QWidget" name="widget_2" native="true">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <property name="leftMargin">
@@ -150,38 +147,41 @@
         </layout>
        </widget>
       </item>
-      <item row="2" column="1">
-       <widget class="QWidget" name="widget_3" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QComboBox" name="comboBoxMachine"/>
-         </item>
-         <item>
-          <widget class="QPushButton" name="pushButtonConfigure">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Configure</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>FPU:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="comboBoxFPU"/>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Wait states:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QComboBox" name="comboBoxWaitStates"/>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Memory:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QSpinBox" name="spinBoxRAM">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
        </widget>
       </item>
      </layout>


### PR DESCRIPTION
Summary
=======
This updates the machine settings layout in order to make mac and linux consistent with the windows version. Even though they use the same code, it appears that qt on windows makes some assumptions on the layout that the others do not.

The widget that is the container for the other widgets was set to a form layout (`QFormLayout`). I had to change the form layout to a grid layout (`QGridLayout`) in order for the combo boxes to fully honor their `sizePolicy` of `Preferred`(`QSizePolicy::Policy`). With `Preferred` it would normally expand to fill up the space, but qt seems to require a grid to make that happen.

This fixes the issue on mac and linux but has no effect on windows. Windows apparently automatically converts to a grid layout so making it explicit has no effect. See screenshots below for examples. The spacing still isn't quite perfect on mac, but I'll tweak that in a separate PR.

![machine settings old](https://user-images.githubusercontent.com/47337035/182663879-69f045f3-edbe-421c-997c-0a41515c0534.png)
mac machine settings before PR

![machine settings new](https://user-images.githubusercontent.com/47337035/182663918-5cf7ab32-80ea-4e55-a0e4-b006c41e3e74.png)
mac machine settings after PR

![machine settings linux](https://user-images.githubusercontent.com/47337035/182663972-5f5ecc29-5607-47e5-9d3d-de0948accad2.png)
linux machine settings after PR

![machine settings win](https://user-images.githubusercontent.com/47337035/182664012-44aeba39-ea85-48e7-ba5d-bdd743c7b873.png)
windows settings after PR (no effect)

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A