### PR TITLE
vnc: Pause always when switching to VNC renderer

### DIFF
--- a/src/vnc.c
+++ b/src/vnc.c
@@ -212,6 +212,7 @@ vnc_init(UNUSED(void *arg))
 	32, 32, 0, 1, 255,255,255, 16, 8, 0, 0, 0
     };
 
+    plat_pause(1);
     cgapal_rebuild_monitor(0);
 
     if (rfb == NULL) {


### PR DESCRIPTION
Summary
=======
vnc: Pause always when switching to VNC renderer.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
