### PR TITLE
x86: mov r, DR6 now always writes bits 4-11 and bits 16-31 as 1

### DIFF
--- a/src/cpu/386.c
+++ b/src/cpu/386.c
@@ -196,6 +196,7 @@ exec386(int cycs)
 			enter_smm_check(0);
 		else if (trap) {
 			flags_rebuild();
+			dr[6] |= 0x4000;
 			if (msw&1)
 				pmodeint(1,0);
 			else {

--- a/src/cpu/386_dynarec.c
+++ b/src/cpu/386_dynarec.c
@@ -404,6 +404,7 @@ exec386_dynarec_int(void)
 	oldcs = CS;
 #endif
 	cpu_state.oldpc = cpu_state.pc;
+	dr[6] |= 0x4000;
 	x86_int(1);
     }
 

--- a/src/cpu/x86_ops_mov_ctrl.h
+++ b/src/cpu/x86_ops_mov_ctrl.h
@@ -91,7 +91,7 @@ static int opMOV_r_DRx_a16(uint32_t fetchdat)
                 return 1;
         }
         fetch_ea_16(fetchdat);
-        cpu_state.regs[cpu_rm].l = dr[cpu_reg];
+        cpu_state.regs[cpu_rm].l = dr[cpu_reg] | (cpu_reg == 6 ? 0xffff0ff0u : 0);
         CLOCK_CYCLES(6);
         PREFETCH_RUN(6, 2, rmdat, 0,0,0,0, 0);
         return 0;
@@ -104,7 +104,7 @@ static int opMOV_r_DRx_a32(uint32_t fetchdat)
                 return 1;
         }
         fetch_ea_32(fetchdat);
-        cpu_state.regs[cpu_rm].l = dr[cpu_reg];
+        cpu_state.regs[cpu_rm].l = dr[cpu_reg] | (cpu_reg == 6 ? 0xffff0ff0u : 0);
         CLOCK_CYCLES(6);
         PREFETCH_RUN(6, 2, rmdat, 0,0,0,0, 1);
         return 0;


### PR DESCRIPTION
Summary
=======
x86: mov r, DR6 now always writes bits 4-11 and bits 16-31 as 1

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
