### PR TITLE
use zip for roms to prevent clobbering

### DIFF
--- a/bumpversion.sh
+++ b/bumpversion.sh
@@ -17,9 +17,11 @@
 
 # Parse arguments.
 newversion="$1"
+romversion="$2"
+
 if [ -z "$(echo "$newversion" | grep '\.')" ]
 then
-	echo '[!] Usage: bumpversion.sh x.y[.z]'
+	echo '[!] Usage: bumpversion.sh x.y[.z] [romversion]'
 	exit 1
 fi
 shift
@@ -30,6 +32,12 @@ newversion_min=$(echo "$newversion" | cut -d. -f2)
 newversion_patch=$(echo "$newversion" | cut -d. -f3)
 [ -z "$newversion_patch" ] && newversion_patch=0
 
+if [ -z "${romversion}" ]; then
+	# Get the latest ROM release from the GitHub API.
+	romversion=$(curl --silent "https://api.github.com/repos/86Box/roms/releases/latest" |
+		grep '"tag_name":' |
+		sed -E 's/.*"([^"]+)".*/\1/')
+fi
 
 # Switch to the repository root directory.
 cd "$(dirname "$0")" || exit
@@ -61,6 +69,7 @@ patch_file src/include_make/*/version.h EMU_VERSION_PATCH 's/(#\s*define\s+EMU_V
 patch_file src/include_make/*/version.h COPYRIGHT_YEAR 's/(#\s*define\s+COPYRIGHT_YEAR\s+)[0-9]+/\1'"$(date +%Y)"'/'
 patch_file src/include_make/*/version.h EMU_DOCS_URL 's/(#\s*define\s+EMU_DOCS_URL\s+"https:\/\/[^\/]+\/en\/v)[^\/]+/\1'"$newversion_maj.$newversion_min"'/'
 patch_file src/unix/assets/*.spec Version 's/(Version:\s+)[0-9].+/\1'"$newversion"'/'
+patch_file src/unix/assets/*.spec '%global romver' 's/(^%global\ romver\s+)[0-9]{8}/\1'"$romversion"'/'
 patch_file src/unix/assets/*.spec 'changelog version' 's/(^[*]\s.*>\s+)[0-9].+/\1'"$newversion"-1'/'
 patch_file src/unix/assets/*.spec 'changelog date' 's/(^[*]\s)[a-zA-Z]{3}\s[a-zA-Z]{3}\s[0-9]{2}\s[0-9]{4}/\1'"$(pretty_date)"'/'
 patch_file src/unix/assets/*.metainfo.xml release 's/(<release version=")[^"]+(" date=")[^"]+/\1'"$newversion"'\2'"$(date +%Y-%m-%d)"'/'

--- a/src/unix/assets/86Box.spec
+++ b/src/unix/assets/86Box.spec
@@ -20,7 +20,7 @@ License:	GPLv2+
 URL:		https://86box.net
 
 Source0:	https://github.com/86Box/86Box/archive/refs/tags/v%%{version}.tar.gz
-Source1:	https://github.com/86Box/roms/archive/refs/tags/%{version}.tar.gz
+Source1:	https://github.com/86Box/roms/archive/refs/tags/v%{version}.zip
 
 BuildRequires: cmake
 BuildRequires: desktop-file-utils

--- a/src/unix/assets/86Box.spec
+++ b/src/unix/assets/86Box.spec
@@ -12,6 +12,8 @@
 # After a successful build, you can install the RPMs as follows:
 #  sudo dnf install RPMS/$(uname -m)/86Box-3* RPMS/noarch/86Box-roms*
 
+%global romver v3.7
+
 Name:		86Box
 Version:	3.7.1
 Release:	1%{?dist}
@@ -20,7 +22,7 @@ License:	GPLv2+
 URL:		https://86box.net
 
 Source0:	https://github.com/86Box/86Box/archive/refs/tags/v%%{version}.tar.gz
-Source1:	https://github.com/86Box/roms/archive/refs/tags/v%{version}.zip
+Source1:	https://github.com/86Box/roms/archive/refs/tags/%{romver}.zip
 
 BuildRequires: cmake
 BuildRequires: desktop-file-utils
@@ -55,7 +57,7 @@ It supports various models of PCs, graphics and sound cards, and CPUs.
 
 %package	roms
 Summary:	ROMs for use with 86Box
-Version:	%{version}
+Version:	%{romver}
 License:	Proprietary
 BuildArch:	noarch
 
@@ -111,7 +113,7 @@ popd
 
 # files part of the rom package
 %files roms
-%license  roms-%{version}/LICENSE
+%license  roms-%{romver}/LICENSE
 %{_datadir}/%{name}/roms
 
 %changelog


### PR DESCRIPTION
Summary
=======
With both the main and roms package having the exact same source package filenames, one clobbers the other and the build fails. Prevent this by using the zip package instead for the ROMs.
