### PR TITLE
qt: fix busy looping with evdev mouse

### DIFF
--- a/src/qt/evdev_mouse.cpp
+++ b/src/qt/evdev_mouse.cpp
@@ -69,8 +69,7 @@ void evdev_thread_func()
         {
             struct input_event ev;
             if (pfds[i].revents & POLLIN) {
-                int rc;
-                while ((rc = libevdev_next_event(evdev_mice[i].second, LIBEVDEV_READ_FLAG_NORMAL, &ev)) == 0)
+                while (libevdev_next_event(evdev_mice[i].second, LIBEVDEV_READ_FLAG_NORMAL, &ev) == 0)
                 {
                     if (ev.type == EV_REL && mouse_capture)
                     {

--- a/src/qt/evdev_mouse.cpp
+++ b/src/qt/evdev_mouse.cpp
@@ -31,6 +31,7 @@ extern "C"
 #include <86box/86box.h>
 #include <86box/plat.h>
 #include <86box/mouse.h>
+#include <poll.h>
 }
 
 static std::vector<std::pair<int, libevdev*>> evdev_mice;
@@ -54,25 +55,40 @@ void evdev_mouse_poll()
 
 void evdev_thread_func()
 {
+    struct pollfd *pfds = (struct pollfd*)calloc(evdev_mice.size(), sizeof(struct pollfd));
+    for (unsigned int i = 0; i < evdev_mice.size(); i++)
+    {
+        pfds[i].fd = libevdev_get_fd(evdev_mice[i].second);
+        pfds[i].events = POLLIN;
+    }
+
     while (!stopped)
     {
+        poll(pfds, evdev_mice.size(), 500);
         for (unsigned int i = 0; i < evdev_mice.size(); i++)
         {
             struct input_event ev;
-            int rc = libevdev_next_event(evdev_mice[i].second, LIBEVDEV_READ_FLAG_NORMAL, &ev);
-            if (rc == 0 && ev.type == EV_REL && mouse_capture)
-            {
-                if (ev.code == REL_X) evdev_mouse_rel_x += ev.value;
-                if (ev.code == REL_Y) evdev_mouse_rel_y += ev.value;
+            if (pfds[i].revents & POLLIN) {
+                int rc;
+                while ((rc = libevdev_next_event(evdev_mice[i].second, LIBEVDEV_READ_FLAG_NORMAL, &ev)) == 0)
+                {
+                    if (ev.type == EV_REL && mouse_capture)
+                    {
+                        if (ev.code == REL_X) evdev_mouse_rel_x += ev.value;
+                        if (ev.code == REL_Y) evdev_mouse_rel_y += ev.value;
+                    }
+                }
             }
         }
     }
+
     for (unsigned int i = 0; i < evdev_mice.size(); i++)
     {
         libevdev_free(evdev_mice[i].second);
         evdev_mice[i].second = nullptr;
         close(evdev_mice[i].first);
     }
+    free(pfds);
     evdev_mice.clear();
 }
 


### PR DESCRIPTION
Summary
=======
Replace busy looping which was using 100% cpu with poll()

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
