### PR TITLE
qt_openglrenderer: fix fullscreen rendering on mac

### DIFF
--- a/src/qt/qt_openglrenderer.cpp
+++ b/src/qt/qt_openglrenderer.cpp
@@ -95,8 +95,8 @@ OpenGLRenderer::resizeEvent(QResizeEvent *event)
     context->makeCurrent(this);
 
     glViewport(
-        destination.x(),
-        destination.y(),
+        destination.x() * devicePixelRatio(),
+        destination.y() * devicePixelRatio(),
         destination.width() * devicePixelRatio(),
         destination.height() * devicePixelRatio());
 }
@@ -179,8 +179,8 @@ OpenGLRenderer::initialize()
         glClearColor(0.f, 0.f, 0.f, 1.f);
 
         glViewport(
-            destination.x(),
-            destination.y(),
+            destination.x() * devicePixelRatio(),
+            destination.y() * devicePixelRatio(),
             destination.width() * devicePixelRatio(),
             destination.height() * devicePixelRatio());
 
@@ -424,6 +424,14 @@ OpenGLRenderer::onBlit(int buf_idx, int x, int y, int w, int h)
         return;
 
     context->makeCurrent(this);
+
+#ifdef Q_OS_MACOS
+    glViewport(
+        destination.x() * devicePixelRatio(),
+        destination.y() * devicePixelRatio(),
+        destination.width() * devicePixelRatio(),
+        destination.height() * devicePixelRatio());
+#endif
 
     if (source.width() != w || source.height() != h) {
         source.setRect(0, 0, w, h);


### PR DESCRIPTION
Summary
=======
Fix fullscreen rendering on mac.
glViewport needs to be called inside onBlit on mac or the viewport transformation will be reset at some point.
Also correct the x/y offset scaling for retina displays.

Checklist
=========
* [X] Closes #2340
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
