### PR TITLE
Add an instrumentation option for performance profiling

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -138,6 +138,10 @@ char	rom_path[1024] = { '\0'};		/* (O) full path to ROMs */
 rom_path_t rom_paths = { "", NULL };    /* (O) full paths to ROMs */
 char	log_path[1024] = { '\0'};		/* (O) full path of logfile */
 char	vm_name[1024]  = { '\0'};		/* (O) display name of the VM */
+#ifdef USE_INSTRUMENT
+uint8_t instru_enabled = 0;
+uint64_t instru_run_ms = 0;
+#endif
 
 /* Configuration values. */
 int window_remember;
@@ -567,6 +571,12 @@ usage:
 
 			/* .. and then exit. */
 			return(0);
+#ifdef USE_INSTRUMENT
+		} else if (!strcasecmp(argv[c], "--instrument")) {
+			if ((c+1) == argc) goto usage;
+			instru_enabled = 1;
+			sscanf(argv[++c], "%llu", &instru_run_ms);
+#endif
 		}
 
 		/* Uhm... out of options here.. */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,10 @@ if(VNC)
     endif()
 endif()
 
+if(INSTRUMENT)
+    add_compile_definitions(USE_INSTRUMENT)
+endif()
+
 target_link_libraries(86Box cpu chipset mch dev mem fdd game cdrom zip mo hdd
     net print scsi sio snd vid voodoo plat ui)
 

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -76,6 +76,10 @@ extern uint64_t source_hwnd;
 extern char rom_path[1024]; /* (O) full path to ROMs */
 extern char log_path[1024]; /* (O) full path of logfile */
 extern char vm_name[1024];  /* (O) display name of the VM */
+#ifdef USE_INSTRUMENT
+extern uint8_t instru_enabled;
+extern uint64_t instru_run_ms;
+#endif
 
 #define window_x monitor_settings[0].mon_window_x
 #define window_y monitor_settings[0].mon_window_y

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -118,9 +118,9 @@ main_thread_fn()
 #ifdef USE_INSTRUMENT
             if (instru_enabled) {
                 uint64_t elapsed_us = (elapsed_timer.nsecsElapsed() - start_time) / 1000;
-                uint64_t total_elapsed_us = (uint64_t)((double)tsc / cpu_s->rspeed * 1000);
-                printf("[instrument] %llu, %llu\n", total_elapsed_us, elapsed_us);
-                if (instru_run_ms && total_elapsed_us >= instru_run_ms)
+                uint64_t total_elapsed_ms = (uint64_t)((double)tsc / cpu_s->rspeed * 1000);
+                printf("[instrument] %llu, %llu\n", total_elapsed_ms, elapsed_us);
+                if (instru_run_ms && total_elapsed_ms >= instru_run_ms)
                     break;
             }
 #endif

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -109,9 +109,21 @@ main_thread_fn()
             if (drawits > 50)
                 drawits = 0;
 
+#ifdef USE_INSTRUMENT
+            uint64_t start_time = elapsed_timer.nsecsElapsed();
+#endif
             /* Run a block of code. */
             pc_run();
 
+#ifdef USE_INSTRUMENT
+            if (instru_enabled) {
+                uint64_t elapsed_us = (elapsed_timer.nsecsElapsed() - start_time) / 1000;
+                uint64_t total_elapsed_us = (uint64_t)((double)tsc / cpu_s->rspeed * 1000);
+                printf("[instrument] %llu, %llu\n", total_elapsed_us, elapsed_us);
+                if (instru_run_ms && total_elapsed_us >= instru_run_ms)
+                    break;
+            }
+#endif
             /* Every 200 frames we save the machine status. */
             if (++frames >= 200 && nvr_dosave) {
                 qt_nvr_save();


### PR DESCRIPTION
Summary
=======
Not built by default, this allows printing the emulation speed on stdout and exiting after a certain emulation time.
Useful for automated performance profiling.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
