### PR TITLE
Optimize timer processing

### DIFF
--- a/src/include/86box/timer.h
+++ b/src/include/86box/timer.h
@@ -199,29 +199,11 @@ extern int		timer_inited;
 
 
 static __inline void
-timer_remove_head_inline(void)
-{
-    pc_timer_t *timer;
-
-    if (timer_inited && timer_head) {
-	timer = timer_head;
-	timer_head = timer->next;
-	if (timer_head) {
-		timer_head->prev = NULL;
-		timer->next->prev = NULL;
-	}
-	timer->next = timer->prev = NULL;
-	timer->flags &= ~TIMER_ENABLED;
-    }
-}
-
-
-static __inline void
 timer_process_inline(void)
 {
     pc_timer_t *timer;
 
-    if (!timer_inited || !timer_head)
+    if (!timer_head)
 	return;
 
     while(1) {
@@ -230,7 +212,12 @@ timer_process_inline(void)
 	if (!TIMER_LESS_THAN_VAL(timer, (uint32_t)tsc))
 		break;
 
-	timer_remove_head_inline();
+    timer_head = timer->next;
+    if (timer_head)
+        timer_head->prev = NULL;
+
+    timer->next = timer->prev = NULL;
+    timer->flags &= ~TIMER_ENABLED;
 
 	if (timer->flags & TIMER_SPLIT)
 		timer_advance_ex(timer, 0);	/* We're splitting a > 1 s period into multiple <= 1 s periods. */


### PR DESCRIPTION
Summary
=======
Around 25% faster timer processing

References
==========
CPU time
_Before_:
<img width="384" alt="timer_before" src="https://user-images.githubusercontent.com/1732242/183703768-219e7953-3296-4495-abad-9eca1cdf1bfd.png">

_After_:
<img width="384" alt="t_after" src="https://user-images.githubusercontent.com/1732242/183704888-f8c0afbe-ee62-4720-8dfd-4c1ff8ed02ee.png">

