### PR TITLE
Optimize IO in

### DIFF
--- a/src/include/86box/m_amstrad.h
+++ b/src/include/86box/m_amstrad.h
@@ -20,7 +20,7 @@
 #ifndef MACHINE_AMSTRAD_H
 #define MACHINE_AMSTRAD_H
 
-extern int amstrad_latch;
+extern uint32_t amstrad_latch;
 
 enum {
     AMSTRAD_NOLATCH,

--- a/src/io.c
+++ b/src/io.c
@@ -312,12 +312,14 @@ inb(uint16_t port)
 	p = q;
     }
 
-    if (port & 0x80)
-	amstrad_latch = AMSTRAD_NOLATCH;
-    else if (port & 0x4000)
-	amstrad_latch = AMSTRAD_SW10;
-    else
-	amstrad_latch = AMSTRAD_SW9;
+    if (amstrad_latch & 0x80000000) {
+        if (port & 0x80)
+            amstrad_latch = AMSTRAD_NOLATCH | 0x80000000;
+        else if (port & 0x4000)
+            amstrad_latch = AMSTRAD_SW10 | 0x80000000;
+        else
+            amstrad_latch = AMSTRAD_SW9 | 0x80000000;
+    }
 
     if (!found)
 	cycles -= io_delay;
@@ -401,12 +403,14 @@ inw(uint16_t port)
     }
     ret = (ret8[1] << 8) | ret8[0];
 
-    if (port & 0x80)
-	amstrad_latch = AMSTRAD_NOLATCH;
-    else if (port & 0x4000)
-	amstrad_latch = AMSTRAD_SW10;
-    else
-	amstrad_latch = AMSTRAD_SW9;
+    if (amstrad_latch & 0x80000000) {
+        if (port & 0x80)
+            amstrad_latch = AMSTRAD_NOLATCH | 0x80000000;
+        else if (port & 0x4000)
+            amstrad_latch = AMSTRAD_SW10 | 0x80000000;
+        else
+            amstrad_latch = AMSTRAD_SW9 | 0x80000000;
+    }
 
     if (!found)
 	cycles -= io_delay;
@@ -487,17 +491,26 @@ inl(uint16_t port)
 
     ret16[0] = ret & 0xffff;
     ret16[1] = (ret >> 16) & 0xffff;
-    for (i = 0; i < 4; i += 2) {
-	p = io[(port + i) & 0xffff];
-	while(p) {
-		q = p->next;
-		if (p->inw && !p->inl) {
-			ret16[i >> 1] &= p->inw(port + i, p->priv);
-			found |= 2;
-			qfound++;
-		}
-		p = q;
-	}
+    p = io[port & 0xffff];
+    while (p) {
+        q = p->next;
+        if (p->inw && !p->inl) {
+            ret16[0] &= p->inw(port, p->priv);
+            found |= 2;
+            qfound++;
+        }
+        p = q;
+    }
+
+    p = io[(port + 2) & 0xffff];
+    while (p) {
+        q = p->next;
+        if (p->inw && !p->inl) {
+            ret16[1] &= p->inw(port + 2, p->priv);
+            found |= 2;
+            qfound++;
+        }
+        p = q;
     }
     ret = (ret16[1] << 16) | ret16[0];
 
@@ -519,12 +532,14 @@ inl(uint16_t port)
     }
     ret = (ret8[3] << 24) | (ret8[2] << 16) | (ret8[1] << 8) | ret8[0];
 
-    if (port & 0x80)
-	amstrad_latch = AMSTRAD_NOLATCH;
-    else if (port & 0x4000)
-	amstrad_latch = AMSTRAD_SW10;
-    else
-	amstrad_latch = AMSTRAD_SW9;
+    if (amstrad_latch & 0x80000000) {
+        if (port & 0x80)
+            amstrad_latch = AMSTRAD_NOLATCH | 0x80000000;
+        else if (port & 0x4000)
+            amstrad_latch = AMSTRAD_SW10 | 0x80000000;
+        else
+            amstrad_latch = AMSTRAD_SW9 | 0x80000000;
+    }
 
     if (!found)
 	cycles -= io_delay;

--- a/src/machine/m_amstrad.c
+++ b/src/machine/m_amstrad.c
@@ -156,7 +156,7 @@ typedef struct {
     fdc_t    *fdc;
 } amstrad_t;
 
-int amstrad_latch;
+uint32_t amstrad_latch;
 
 static uint8_t key_queue[16];
 static int     key_queue_start = 0,
@@ -2255,7 +2255,7 @@ ams_read(uint16_t port, void *priv)
                     else if (video_is_mda())
                         ret |= 0xc0;
 
-                    switch (amstrad_latch) {
+                    switch (amstrad_latch & 0x7fffffff) {
                         case AMSTRAD_NOLATCH:
                             ret &= ~0x20;
                             break;
@@ -2293,6 +2293,7 @@ machine_amstrad_init(const machine_t *model, int type)
     ams = (amstrad_t *) malloc(sizeof(amstrad_t));
     memset(ams, 0x00, sizeof(amstrad_t));
     ams->type = type;
+    amstrad_latch = 0x80000000;
 
     switch (type) {
         case AMS_PC200:


### PR DESCRIPTION
Summary
=======
Around 36% faster IO in

References
==========
CPU time
_Before_:
<img width="384" alt="in_before" src="https://user-images.githubusercontent.com/1732242/183715532-3fc2bc02-cefb-4594-bfd5-91953bc0f2be.png">

_After_:
<img width="384" alt="in_after" src="https://user-images.githubusercontent.com/1732242/183715573-4c9ba236-f429-4d14-91d1-106607ec7050.png">

