### PR TITLE
XGA: Cursor no longer gets black parts when returning from Mystify screensaver to GUI and, at the same time, keeping the Win95 cursor intact.

### DIFF
--- a/src/include/86box/vid_xga.h
+++ b/src/include/86box/vid_xga.h
@@ -92,7 +92,7 @@ typedef struct xga_t {
     int on;
     int op_mode_reset, linear_endian_reverse;
     int sprite_pos, sprite_pos_prefetch, cursor_data_on;
-    int pal_test;
+    int pal_test, a5_test;
     int type, bus;
 
     uint32_t linear_base, linear_size, banked_mask;

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -1079,6 +1079,7 @@ svga_write_common(uint32_t addr, uint8_t val, uint8_t linear, void *p)
         if (((svga->xga.op_mode & 7) >= 4) && (svga->xga.aperture_cntl == 1)) {
             if (val == 0xa5) { /*Memory size test of XGA*/
                 svga->xga.test = val;
+                svga->xga.a5_test = 1;
                 return;
             } else if (val == 0x5a) {
                 svga->xga.test = val;


### PR DESCRIPTION
Mono blits no longer cause transparency issues in some programs (e.g.: Creative utilities such as MIDI and CD on Win3.1x).

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
