### PR TITLE
ESDI MCA: No longer fatal on default reads, fixes Win3.0 MME installation to hard disk using ESDI MCA.

### DIFF
--- a/src/disk/hdc_esdi_mca.c
+++ b/src/disk/hdc_esdi_mca.c
@@ -863,7 +863,8 @@ esdi_read(uint16_t port, void *priv)
             break;
 
         default:
-            fatal("esdi_read port=%04x\n", port);
+            esdi_mca_log("esdi_read port=%04x\n", port);
+            break;
     }
 
     return (ret);


### PR DESCRIPTION
Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
