### PR TITLE
qt_d3d9renderer: Clear screen backbuffer at each render

### DIFF
--- a/src/qt/qt_d3d9renderer.cpp
+++ b/src/qt/qt_d3d9renderer.cpp
@@ -108,6 +108,7 @@ void D3D9Renderer::paintEvent(QPaintEvent *event)
     dstRect.left = destination.left();
     dstRect.right = destination.right();
     d3d9dev->BeginScene();
+    d3d9dev->Clear(0, nullptr, D3DCLEAR_TARGET, 0xFF000000, 0, 0);
     while (surfaceInUse) {}
     surfaceInUse = true;
     d3d9dev->StretchRect(d3d9surface, &srcRect, backbuffer, &dstRect, video_filter_method == 0 ? D3DTEXF_POINT : D3DTEXF_LINEAR);


### PR DESCRIPTION
Summary
=======
qt_d3d9renderer: Clear screen backbuffer at each render

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
