### PR TITLE
qt: cdrom loading fixes on Windows

### DIFF
--- a/src/cdrom/cdrom_image.c
+++ b/src/cdrom/cdrom_image.c
@@ -257,6 +257,7 @@ image_open_abort(cdrom_t *dev)
     cdrom_image_close(dev);
     dev->ops = NULL;
     dev->host_drive = 0;
+    dev->image_path[0] = 0;
     return 1;
 }
 

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -167,7 +167,7 @@ plat_fopen(const char *path, const char *mode)
 FILE *
 plat_fopen64(const char *path, const char *mode)
 {
-    return fopen(path, mode);
+    return fopen(QString::fromUtf8(path).toLocal8Bit(), mode);
 }
 
 int


### PR DESCRIPTION
Summary
=======
[cdrom: Properly empty the path of image if it can't be loaded](https://github.com/86Box/86Box/commit/740108c37c84f22ae2cca1c8145d85a12b2de2b0)
[qt: Fix usage of unconverted path in plat_fopen64](https://github.com/86Box/86Box/commit/97242168ded8a5f1fbd289512056961952784d15)

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
