### PR TITLE
qt: Raise minimum Xi2 version requirement to 2.1

### DIFF
--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -75,15 +75,10 @@ RendererStack::RendererStack(QWidget *parent, int monitor_index)
     if (!mouse_type || (mouse_type[0] == '\0') || !stricmp(mouse_type, "auto")) {
         if (QApplication::platformName().contains("wayland"))
             strcpy(auto_mouse_type, "wayland");
-#   if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
         else if (QApplication::platformName() == "eglfs")
             strcpy(auto_mouse_type, "evdev");
         else if (QApplication::platformName() == "xcb")
             strcpy(auto_mouse_type, "xinput2");
-#   else
-        else if (QApplication::platformName() == "eglfs" || QApplication::platformName() == "xcb")
-            strcpy(auto_mouse_type, "evdev");
-#   endif
         else
             auto_mouse_type[0] = '\0';
         mouse_type = auto_mouse_type;

--- a/src/qt/xinput2_mouse.cpp
+++ b/src/qt/xinput2_mouse.cpp
@@ -81,8 +81,7 @@ void xinput2_proc()
     Window win;
     win = DefaultRootWindow(disp);
 
-    // XIAllMasterDevices doesn't work for click-and-drag operations.
-    ximask.deviceid = XIAllDevices;
+    ximask.deviceid = XIAllMasterDevices;
     ximask.mask_len = XIMaskLen(XI_LASTEVENT);
     ximask.mask = (unsigned char*)calloc(ximask.mask_len, sizeof(unsigned char));
 
@@ -166,7 +165,7 @@ void xinput2_init()
         qWarning() << "Cannot open current X11 display";
         return;
     }
-    auto event = 0, err = 0, minor = 0, major = 2;
+    auto event = 0, err = 0, minor = 1, major = 2;
     if (XQueryExtension(disp, "XInputExtension", &xi2opcode, &event, &err))
     {
         if (XIQueryVersion(disp, &major, &minor) == Success)


### PR DESCRIPTION
Summary
=======
qt: Raise minimum Xi2 version requirement to 2.1

This is needed for click-and-drag to work with both Qt5 and Qt6, especially the latter which was previously broken, without any hacks.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
