### PR TITLE
Remove the PS/2 mouse flag from the Gigabyte GA-586IP

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -7389,7 +7389,7 @@ const machine_t machines[] = {
             .min_multi = 1.5,
             .max_multi = 1.5
         },
-        .bus_flags = MACHINE_PS2_PCI,
+        .bus_flags = MACHINE_PCI,
         .flags = MACHINE_IDE_DUAL,
         .ram = {
             .min = 2048,


### PR DESCRIPTION
Summary
=======
The Gigabyte GA-586IP motherboard has no PS/2 mouse header, yet 86Box allows to select the PS/2 mouse.

Checklist
=========
* [x] Closes #2614
* [ ] I have discussed this with core contributors already

References
==========
https://www.ultimateretro.net/en/motherboards/2741
