### PR TITLE
Fix two warnings in Qt code

### DIFF
--- a/src/qt/qt_openglrenderer.cpp
+++ b/src/qt/qt_openglrenderer.cpp
@@ -254,7 +254,7 @@ OpenGLRenderer::initializeExtensions()
 
         glBufferStorage = (PFNGLBUFFERSTORAGEEXTPROC_LOCAL) context->getProcAddress(context->hasExtension("GL_EXT_buffer_storage") ? "glBufferStorageEXT" : "glBufferStorage");
         if (!glBufferStorage)
-            glBufferStorage = glBufferStorage = (PFNGLBUFFERSTORAGEEXTPROC_LOCAL) context->getProcAddress("glBufferStorage");
+            glBufferStorage = (PFNGLBUFFERSTORAGEEXTPROC_LOCAL) context->getProcAddress("glBufferStorage");
     }
 #endif
 }

--- a/src/qt/qt_openglrenderer.hpp
+++ b/src/qt/qt_openglrenderer.hpp
@@ -77,8 +77,8 @@ private:
     static constexpr int BUFFERBYTES  = 16777216; /* Pixel is 4 bytes. */
     static constexpr int BUFFERCOUNT  = 3;        /* How many buffers to use for pixel transfer (2-3 is commonly recommended). */
 
-    OpenGLOptions *options;
     QTimer        *renderTimer;
+    OpenGLOptions *options;
 
     QString glslVersion;
 


### PR DESCRIPTION
Summary
=======
Fixes the following warnings:
```
In file included from C:/Jenkins/agent/workspace/86Box@9/src/qt/qt_openglrenderer.cpp:27:
C:/Jenkins/agent/workspace/86Box@9/src/qt/qt_openglrenderer.hpp: In constructor 'OpenGLRenderer::OpenGLRenderer(QWidget*)':
C:/Jenkins/agent/workspace/86Box@9/src/qt/qt_openglrenderer.hpp:81:20: warning: 'OpenGLRenderer::renderTimer' will be initialized after [-Wreorder]
   81 |     QTimer        *renderTimer;
      |                    ^~~~~~~~~~~
C:/Jenkins/agent/workspace/86Box@9/src/qt/qt_openglrenderer.hpp:80:20: warning:   'OpenGLOptions* OpenGLRenderer::options' [-Wreorder]
   80 |     OpenGLOptions *options;
      |                    ^~~~~~~
C:/Jenkins/agent/workspace/86Box@9/src/qt/qt_openglrenderer.cpp:37:1: warning:   when initialized here [-Wreorder]
   37 | OpenGLRenderer::OpenGLRenderer(QWidget *parent)
      | ^~~~~~~~~~~~~~
```

```
C:/Jenkins/agent/workspace/86Box@9/src/qt/qt_openglrenderer.cpp: In member function 'void OpenGLRenderer::initializeExtensions()':
C:/Jenkins/agent/workspace/86Box@9/src/qt/qt_openglrenderer.cpp:257:29: warning: operation on '((OpenGLRenderer*)this)->OpenGLRenderer::glBufferStorage' may be undefined [-Wsequence-point]
  257 |             glBufferStorage = glBufferStorage = (PFNGLBUFFERSTORAGEEXTPROC_LOCAL) context->getProcAddress("glBufferStorage");
      |             ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Note: no action was taken on the unused `int combo_to_struct[256];` in qt_deviceconfig.cpp because this seems to be reserved for future use; paging @jriwanek for clarifcation.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
