### PR TITLE
Fix SB 2.0 OPL crash

### DIFF
--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -1654,16 +1654,16 @@ sb_2_init(const device_t *info)
             io_sethandler(addr, 0x0002,
                           sb->opl.read, NULL, NULL,
                           sb->opl.write, NULL, NULL,
-                          sb->opl.write);
+                          sb->opl.priv);
         }
         io_sethandler(addr + 8, 0x0002,
                       sb->opl.read, NULL, NULL,
                       sb->opl.write, NULL, NULL,
-                      sb->opl.write);
+                      sb->opl.priv);
         io_sethandler(0x0388, 0x0002,
                       sb->opl.read, NULL, NULL,
                       sb->opl.write, NULL, NULL,
-                      sb->opl.write);
+                      sb->opl.priv);
     }
 
     if (sb->cms_enabled) {


### PR DESCRIPTION
Summary
=======
Fix SB 2.0 OPL crash
Thanks to TC1995 for reporting.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
