### PR TITLE
qt: Remember maximized state of monitor windows if enabled

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -649,10 +649,14 @@ load_monitor(int monitor_index)
     if (p == NULL)
 	p = temp;
 
-    if (window_remember)
+    if (window_remember) {
         sscanf(p, "%i, %i, %i, %i",
                &monitor_settings[monitor_index].mon_window_x, &monitor_settings[monitor_index].mon_window_y,
                &monitor_settings[monitor_index].mon_window_w, &monitor_settings[monitor_index].mon_window_h);
+        monitor_settings[monitor_index].mon_window_maximized = !!config_get_int(cat, "window_maximized", 0);
+    } else {
+        monitor_settings[monitor_index].mon_window_maximized = 0;
+    }
 }
 
 /* Load "Machine" section. */
@@ -2415,8 +2419,15 @@ save_monitor(int monitor_index)
 		monitor_settings[monitor_index].mon_window_w, monitor_settings[monitor_index].mon_window_h);
 
         config_set_string(cat, "window_coordinates", temp);
-    } else
+        if (monitor_settings[monitor_index].mon_window_maximized != 0) {
+            config_set_int(cat, "window_maximized", monitor_settings[monitor_index].mon_window_maximized);
+        } else {
+            config_delete_var(cat, "window_maximized");
+        }
+    } else {
         config_delete_var(cat, "window_coordinates");
+        config_delete_var(cat, "window_maximized");
+    }
 }
 
 /* Save "Machine" section. */

--- a/src/include/86box/video.h
+++ b/src/include/86box/video.h
@@ -124,6 +124,7 @@ typedef struct monitor_settings_t {
     int mon_window_y;
     int mon_window_w;
     int mon_window_h;
+    int mon_window_maximized;
 } monitor_settings_t;
 
 #define MONITORS_NUM 2

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -173,6 +173,7 @@ int main(int argc, char* argv[]) {
         return 0;
     }
 
+    bool startMaximized = window_remember && monitor_settings[0].mon_window_maximized;
     fprintf(stderr, "Qt: version %s, platform \"%s\"\n", qVersion(), QApplication::platformName().toUtf8().data());
     ProgSettings::loadTranslators(&app);
 #ifdef Q_OS_WINDOWS
@@ -200,7 +201,12 @@ int main(int argc, char* argv[]) {
     discord_load();
 
     main_window = new MainWindow();
-    main_window->show();
+    if (startMaximized) {
+        main_window->showMaximized();
+    } else {
+        main_window->show();
+    }
+
     app.installEventFilter(main_window);
 
 #ifdef Q_OS_WINDOWS

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -657,6 +657,9 @@ void MainWindow::initRendererMonitorSlot(int monitor_index)
                 monitor_settings[monitor_index].mon_window_w > 2048 ? 2048 : monitor_settings[monitor_index].mon_window_w,
                 monitor_settings[monitor_index].mon_window_h > 2048 ? 2048 : monitor_settings[monitor_index].mon_window_h);
             }
+            if (monitor_settings[monitor_index].mon_window_maximized) {
+                secondaryRenderer->showMaximized();
+            }
             secondaryRenderer->switchRenderer((RendererStack::Renderer)vid_api);
         }
 
@@ -2070,6 +2073,10 @@ void MainWindow::changeEvent(QEvent* event)
     }
 #endif
     QWidget::changeEvent(event);
+    if (isVisible()) {
+        monitor_settings[0].mon_window_maximized = isMaximized();
+        config_save();
+    }
 }
 
 void MainWindow::on_actionRenderer_options_triggered()

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -48,6 +48,7 @@
 
 extern "C" {
 #include <86box/86box.h>
+#include <86box/config.h>
 #include <86box/mouse.h>
 #include <86box/plat.h>
 #include <86box/video.h>
@@ -481,3 +482,10 @@ void RendererStack::closeEvent(QCloseEvent* event)
     main_window->close();
 }
 
+void RendererStack::changeEvent(QEvent *event)
+{
+    if (m_monitor_index != 0 && isVisible()) {
+        monitor_settings[m_monitor_index].mon_window_maximized = isMaximized();
+        config_save();
+    }
+}

--- a/src/qt/qt_rendererstack.hpp
+++ b/src/qt/qt_rendererstack.hpp
@@ -32,6 +32,7 @@ public:
     void wheelEvent(QWheelEvent *event) override;
     void leaveEvent(QEvent *event) override;
     void closeEvent(QCloseEvent *event) override;
+    void changeEvent(QEvent* event) override;
     void resizeEvent(QResizeEvent *event) override
     {
         onResize(event->size().width(), event->size().height());


### PR DESCRIPTION
Summary
=======
qt: Remember maximized state of monitor windows if enabled

This is rolled into the same "Remember size and position" toggle.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None,
