### PR TITLE
network: always link to ws2_32 on win32

### DIFF
--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -35,3 +35,7 @@ endif()
 if (HAIKU)
     target_link_libraries(86Box network)
 endif()
+
+if(WIN32)
+    target_link_libraries(86Box ws2_32)
+endif()


### PR DESCRIPTION
Summary
=======
network: always link to ws2_32 on win32

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
