### PR TITLE
qt: Shortcut fixes

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -1615,7 +1615,18 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
     if (send_keyboard_input && !(kbd_req_capture && !mouse_capture && !video_fullscreen))
     {
         // Windows keys in Qt have one-to-one mapping.
-        if (event->key() == Qt::Key_Super_L || event->key() == Qt::Key_Super_R) {
+        if (event->key() == Qt::Key_Pause && !keyboard_recv(0x38) && !keyboard_recv(0x138)) {
+            if ((keyboard_recv(0x1D) || keyboard_recv(0x11D)) {
+                keyboard_input(1, 0x46);
+            } else {
+                keyboard_input(0, 0xE1);
+                keyboard_input(0, 0x1D);
+                keyboard_input(0, 0x45);
+                keyboard_input(0, 0xE1);
+                keyboard_input(1, 0x1D);
+                keyboard_input(1, 0x45);
+            }
+        } else if (event->key() == Qt::Key_Super_L || event->key() == Qt::Key_Super_R) {
             keyboard_input(1, event->key() == Qt::Key_Super_L ? 0x15B : 0x15C);
         } else
 #ifdef Q_OS_MACOS
@@ -1653,7 +1664,9 @@ void MainWindow::blitToWidget(int x, int y, int w, int h, int monitor_index)
 void MainWindow::keyReleaseEvent(QKeyEvent* event)
 {
     if (event->key() == Qt::Key_Pause) {
-        plat_pause(dopause ^ 1);
+        if (keyboard_recv(0x38) && keyboard_recv(0x138)) {
+            plat_pause(dopause ^ 1);
+        }
     }
     if (!send_keyboard_input)
         return;

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -1632,6 +1632,12 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
     if (keyboard_ismsexit()) {
         plat_mouse_capture(0);
     }
+
+    if ((video_fullscreen > 0) && (keyboard_recv(0x1D) || keyboard_recv(0x11D))) {
+        if (keyboard_recv(0x57)) ui->actionTake_screenshot->trigger();
+        else if (keyboard_recv(0x58)) pc_send_cad();
+    }
+
     event->accept();
 }
 
@@ -1646,6 +1652,9 @@ void MainWindow::blitToWidget(int x, int y, int w, int h, int monitor_index)
 
 void MainWindow::keyReleaseEvent(QKeyEvent* event)
 {
+    if (event->key() == Qt::Key_Pause) {
+        plat_pause(dopause ^ 1);
+    }
     if (!send_keyboard_input)
         return;
 

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -1616,7 +1616,7 @@ void MainWindow::keyPressEvent(QKeyEvent* event)
     {
         // Windows keys in Qt have one-to-one mapping.
         if (event->key() == Qt::Key_Pause && !keyboard_recv(0x38) && !keyboard_recv(0x138)) {
-            if ((keyboard_recv(0x1D) || keyboard_recv(0x11D)) {
+            if ((keyboard_recv(0x1D) || keyboard_recv(0x11D))) {
                 keyboard_input(1, 0x46);
             } else {
                 keyboard_input(0, 0xE1);


### PR DESCRIPTION
Summary
=======
qt: Shortcut fixes

* Make Pause key pause/resume the emulator when both Alts are held, passthrough to emulated machine otherwise.
* Make screenshot taking and C+A+D shortcuts work on fullscreen

Checklist
=========
* [X] Closes #2626
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
