### PR TITLE
Correct BCM GT694VA

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -11080,6 +11080,44 @@ const machine_t machines[] = {
         .snd_device = NULL,
         .net_device = NULL
     },
+    /* Has a Winbond W83977EF Super I/O chip with on-chip KBC with AMIKey-2 KBC
+       firmware. */
+    {
+        .name = "[VIA Apollo Pro 133A] BCM GT694VA",
+        .internal_name = "gt694va",
+        .type = MACHINE_TYPE_SLOT1,
+        .chipset = MACHINE_CHIPSET_VIA_APOLLO_PRO_133A,
+        .init = machine_at_gt694va_init,
+        .pad = 0,
+        .pad0 = 0,
+        .pad1 = MACHINE_AVAILABLE,
+        .pad2 = 0,
+        .cpu = {
+            .package = CPU_PKG_SLOT1,
+            .block = CPU_BLOCK_NONE,
+            .min_bus = 66666667,
+            .max_bus = 133333333,
+            .min_voltage = 1300,
+            .max_voltage = 3500,
+            .min_multi = 1.5,
+            .max_multi = 8.0
+        },
+        .bus_flags = MACHINE_PS2_AGP,
+        .flags = MACHINE_IDE_DUAL | MACHINE_SOUND,
+        .ram = {
+            .min = 8192,
+            .max = 3145728,
+            .step = 8192
+        },
+        .nvrmask = 255,
+        .kbc = KBC_UNKNOWN,
+        .kbc_p1 = 0,
+        .gpio = 0,
+        .device = &es1371_onboard_device,
+        .vid_device = NULL,
+        .snd_device = NULL,
+        .net_device = NULL
+    },
 
     /* Slot 1/2 machines */
     /* 440GX */
@@ -11628,44 +11666,6 @@ const machine_t machines[] = {
         .kbc_p1 = 0,
         .gpio = 0,
         .device = &cmi8738_onboard_device,
-        .vid_device = NULL,
-        .snd_device = NULL,
-        .net_device = NULL
-    },
-    /* Has a Winbond W83977EF Super I/O chip with on-chip KBC with AMIKey-2 KBC
-       firmware. */
-    {
-        .name = "[VIA Apollo Pro 133A] BCM GT694VA",
-        .internal_name = "gt694va",
-        .type = MACHINE_TYPE_SOCKET370,
-        .chipset = MACHINE_CHIPSET_VIA_APOLLO_PRO_133A,
-        .init = machine_at_gt694va_init,
-        .pad = 0,
-        .pad0 = 0,
-        .pad1 = MACHINE_AVAILABLE,
-        .pad2 = 0,
-        .cpu = {
-            .package = CPU_PKG_SOCKET370,
-            .block = CPU_BLOCK_NONE,
-            .min_bus = 66666667,
-            .max_bus = 133333333,
-            .min_voltage = 1300,
-            .max_voltage = 3500,
-            .min_multi = 1.5,
-            .max_multi = 8.0
-        },
-        .bus_flags = MACHINE_PS2_AGP,
-        .flags = MACHINE_IDE_DUAL | MACHINE_SOUND,
-        .ram = {
-            .min = 16384,
-            .max = 3145728,
-            .step = 8192
-        },
-        .nvrmask = 255,
-        .kbc = KBC_UNKNOWN,
-        .kbc_p1 = 0,
-        .gpio = 0,
-        .device = &es1371_onboard_device,
         .vid_device = NULL,
         .snd_device = NULL,
         .net_device = NULL


### PR DESCRIPTION
Summary
=======
Correct the BCM GT694VA, it's a Slot 1 board, not a Socket 370 board, and according to the manual (and testing the BIOS), supports a minimum of 8MB, installed, as opposed to 16MB.

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None