### PR TITLE
pcap: do bounds checking in net_pcap_prepare

### DIFF
--- a/src/include/86box/network.h
+++ b/src/include/86box/network.h
@@ -58,6 +58,7 @@
 #define NET_MAX_FRAME 1518
 #define NET_QUEUE_LEN 8
 #define NET_CARD_MAX 4
+#define NET_HOST_INTF_MAX 64
 
 /* Supported network cards. */
 enum {
@@ -141,7 +142,7 @@ extern "C" {
 /* Global variables. */
 extern int	nic_do_log;				/* config */
 extern int      network_ndev;
-extern netdev_t network_devs[32];
+extern netdev_t network_devs[NET_HOST_INTF_MAX];
 
 
 /* Function prototypes. */

--- a/src/network/net_pcap.c
+++ b/src/network/net_pcap.c
@@ -354,6 +354,9 @@ net_pcap_prepare(netdev_t *list)
     }
 
     for (dev=devlist; dev!=NULL; dev=dev->next) {
+		if (i >= (NET_HOST_INTF_MAX - 1))
+			break;
+
 		/**
 		 * we initialize the strings to NULL first for strncpy
 		 */

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -122,7 +122,7 @@ int net_card_current = 0;
 
 /* Global variables. */
 int		network_ndev;
-netdev_t	network_devs[32];
+netdev_t	network_devs[NET_HOST_INTF_MAX];
 
 
 /* Local variables. */


### PR DESCRIPTION
Summary
=======
This fixes a crash when the host has a lot of network interfaces

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
