### PR TITLE
slirp: fix port forwarding and handle configuration with multiple nics

### DIFF
--- a/src/include/86box/network.h
+++ b/src/include/86box/network.h
@@ -127,6 +127,7 @@ struct _netcard_t {
     mutex_t        *tx_mutex;
     mutex_t        *rx_mutex;
     pc_timer_t      timer;
+    int             card_num;
 };
 
 typedef struct {

--- a/src/network/net_slirp.c
+++ b/src/network/net_slirp.c
@@ -415,7 +415,7 @@ net_slirp_init(const netcard_t *card, const uint8_t *mac_addr, void *priv)
     struct in_addr  host       = { .s_addr = htonl(0x0a000002 | (slirp_card_num << 8)) }; /* 10.0.x.2 */
     struct in_addr  dhcp       = { .s_addr = htonl(0x0a00000f | (slirp_card_num << 8)) }; /* 10.0.x.15 */
     struct in_addr  dns        = { .s_addr = htonl(0x0a000003 | (slirp_card_num << 8)) }; /* 10.0.x.3 */
-    struct in_addr  bind       = { .s_addr = htonl(0x00000000 | (slirp_card_num << 8)) }; /* 0.0.0.0 */
+    struct in_addr  bind       = { .s_addr = htonl(0x00000000) }; /* 0.0.0.0 */
     struct in6_addr ipv6_dummy = { 0 };                                                   /* contents don't matter; we're not using IPv6 */
 
     /* Initialize SLiRP. */
@@ -428,7 +428,8 @@ net_slirp_init(const netcard_t *card, const uint8_t *mac_addr, void *priv)
 
     /* Set up port forwarding. */
     int   udp, external, internal, i = 0;
-    char *category = "SLiRP Port Forwarding";
+    char category[32];
+    snprintf(category, sizeof(category), "SLiRP Port Forwarding #%i", card->card_num + 1);
     char  key[20];
     while (1) {
         sprintf(key, "%d_protocol", i);

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -388,6 +388,7 @@ network_attach(void *card_drv, uint8_t *mac, NETRXCB rx, NETWAITCB wait, NETSETL
     card->set_link_state = set_link_state;
     card->tx_mutex = thread_create_mutex();
     card->rx_mutex = thread_create_mutex();
+    card->card_num = net_card_current;
 
     for (int i=0; i<3; i++) {
         network_queue_init(&card->queues[i]);


### PR DESCRIPTION
Summary
=======
slirp: fix port forwarding and handle configuration with multiple nics
The forwarding configuration should now be set under the category [SLiRP Port Forwarding #1] for the first nic, etc..

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
