### PR TITLE
voodoo_codegen_x86*: Remove bounds checking for block_pos

### DIFF
--- a/src/include/86box/vid_voodoo_codegen_x86-64.h
+++ b/src/include/86box/vid_voodoo_codegen_x86-64.h
@@ -46,32 +46,24 @@ static int next_block_to_write[4] = { 0, 0 };
 #define addbyte(val)                   \
     do {                               \
         code_block[block_pos++] = val; \
-        if (block_pos >= BLOCK_SIZE)   \
-            fatal("Over!\n");          \
     } while (0)
 
 #define addword(val)                                \
     do {                                            \
         *(uint16_t *) &code_block[block_pos] = val; \
         block_pos += 2;                             \
-        if (block_pos >= BLOCK_SIZE)                \
-            fatal("Over!\n");                       \
     } while (0)
 
 #define addlong(val)                                \
     do {                                            \
         *(uint32_t *) &code_block[block_pos] = val; \
         block_pos += 4;                             \
-        if (block_pos >= BLOCK_SIZE)                \
-            fatal("Over!\n");                       \
     } while (0)
 
 #define addquad(val)                                \
     do {                                            \
         *(uint64_t *) &code_block[block_pos] = val; \
         block_pos += 8;                             \
-        if (block_pos >= BLOCK_SIZE)                \
-            fatal("Over!\n");                       \
     } while (0)
 
 static __m128i xmm_01_w; // = 0x0001000100010001ull;

--- a/src/include/86box/vid_voodoo_codegen_x86.h
+++ b/src/include/86box/vid_voodoo_codegen_x86.h
@@ -44,32 +44,24 @@ static int next_block_to_write[4] = { 0, 0 };
 #define addbyte(val)                   \
     do {                               \
         code_block[block_pos++] = val; \
-        if (block_pos >= BLOCK_SIZE)   \
-            fatal("Over!\n");          \
     } while (0)
 
 #define addword(val)                                \
     do {                                            \
         *(uint16_t *) &code_block[block_pos] = val; \
         block_pos += 2;                             \
-        if (block_pos >= BLOCK_SIZE)                \
-            fatal("Over!\n");                       \
     } while (0)
 
 #define addlong(val)                                \
     do {                                            \
         *(uint32_t *) &code_block[block_pos] = val; \
         block_pos += 4;                             \
-        if (block_pos >= BLOCK_SIZE)                \
-            fatal("Over!\n");                       \
     } while (0)
 
 #define addquad(val)                                \
     do {                                            \
         *(uint64_t *) &code_block[block_pos] = val; \
         block_pos += 8;                             \
-        if (block_pos >= BLOCK_SIZE)                \
-            fatal("Over!\n");                       \
     } while (0)
 
 static __m128i xmm_01_w; // = 0x0001000100010001ull;


### PR DESCRIPTION
Summary
=======
voodoo_codegen_x86*: Remove bounds checking for block_pos

Block sizes are sufficiently large enough to ensure no buffer overrun as block_pos is initialized to 0 every time a block is generated. It should cause a good Voodoo performance increase on x86 and x86-64 when the recompiler of it is enabled.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
