### PR TITLE
macOS: Fix dynamic loading of bundled libraries

### DIFF
--- a/src/printer/prt_escp.c
+++ b/src/printer/prt_escp.c
@@ -90,7 +90,7 @@
 #ifdef _WIN32
 # define PATH_FREETYPE_DLL	"freetype.dll"
 #elif defined __APPLE__
-# define PATH_FREETYPE_DLL	"libfreetype.dylib"
+# define PATH_FREETYPE_DLL	"libfreetype.6.dylib"
 #else
 # define PATH_FREETYPE_DLL	"libfreetype.so.6"
 #endif

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -309,7 +309,11 @@ if (APPLE AND CMAKE_MACOSX_BUNDLE)
     install(CODE "
         include(BundleUtilities)
         get_filename_component(CMAKE_INSTALL_PREFIX_ABSOLUTE \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX} ABSOLUTE)
-        fixup_bundle(\"\${CMAKE_INSTALL_PREFIX_ABSOLUTE}/86Box.app\" \"${QT_PLUGINS}\" \"${DIRS}\")")
+        fixup_bundle(\"\${CMAKE_INSTALL_PREFIX_ABSOLUTE}/86Box.app\" \"${QT_PLUGINS}\" \"${DIRS}\")
+        execute_process(
+            COMMAND ${CMAKE_INSTALL_NAME_TOOL} -add_rpath \"@executable_path/../Frameworks/\"
+            \"\${CMAKE_INSTALL_PREFIX_ABSOLUTE}/${INSTALL_RUNTIME_DIR}/86Box\")
+        ")
 endif()
 
 if (UNIX AND NOT APPLE AND NOT HAIKU)


### PR DESCRIPTION
Summary
=======
Dynamic loading of bundled libraries appears to have been broken for a while. This affects anything that is loaded through `dynld_module()` (ultimately handled by `QLibrary` on this version). 

The libraries were bundled appropriately, however the executable didn't know where to look for them. This is normally handled with `RPATH` but that was being stripped off by cmake during the install section.

This PR adds an additional step during the install process to add `@executable_path/../Frameworks/` as an `RPATH` to the final binary.

This also fixes the freetype library name to `libfreetype.6.dylib` on macOS as well. It was trying to load the wrong name, but without this fix it still would not have worked even with the correct name.

This should also fix the discord integration on macOS since it is also dynamically loaded at runtime.

Correct `RPATH` verified with `otool`:

```
otool -l 86Box.app/Contents/MacOS/86Box | grep -A3 LC_R
          cmd LC_RPATH
      cmdsize 48
         path @executable_path/../Frameworks/ (offset 12)
```

Checklist
=========
* [X] Closes #2516
* [X] I have discussed this with core contributors already

References
==========
N/A
