### PR TITLE
macOS: Add Vulkan support via MoltenVK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,9 @@ cmake_dependent_option(XL24           "ATI VGA Wonder XL24 (ATI-28800-6)"       
 # Ditto but for Qt
 if(QT)
     option(USE_QT6 "Use Qt6 instead of Qt5" OFF)
+    if(APPLE)
+        option(MOLTENVK "Use MoltenVK libraries for Vulkan support on macOS. Requires a Vulkan-enabled QT." OFF)
+    endif()
 endif()
 
 # Determine the build type

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,9 @@
 #           Copyright 2020-2022 David Hrdlička.
 #           Copyright 2021 dob205.
 #
+if(APPLE)
+    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+endif()
 
 add_executable(86Box 86box.c config.c log.c random.c timer.c io.c acpi.c apm.c
     dma.c ddma.c discord.c nmi.c pic.c pit.c pit_fast.c port_6x.c port_92.c ppi.c pci.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,11 +86,16 @@ if(APPLE)
     # Force using the newest library if it's installed by homebrew
     set(CMAKE_FIND_FRAMEWORK LAST)
 
-    # setting our compilation target to macOS 10.15 Catalina if targetting Qt6, macOS 10.13 High Sierra otherwise
+    # setting our compilation target to macOS 10.15 Catalina if targeting Qt6,
+    # macOS 10.14 Mojave for vulkan support, 10.13 High Sierra otherwise
     if (USE_QT6)
         set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15")
     else()
-        set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
+        if(MOLTENVK)
+            set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14")
+        else()
+            set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
+        endif()
     endif()
 endif()
 

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -206,6 +206,18 @@ endif()
 
 if (APPLE)
     target_sources(ui PRIVATE macos_event_filter.mm)
+    if(MOLTENVK)
+        find_path(MOLTENVK_INCLUDE "vulkan/vulkan.h" PATHS "/opt/homebrew/opt/molten-vk/libexec/include" "/usr/local/opt/molten-vk/libexec/include" ${MOLTENVK_INCLUDE_DIR})
+        if (NOT MOLTENVK_INCLUDE)
+            message(FATAL_ERROR "Could not find vulkan/vulkan.h. If the headers are installed please use -DMOLTENVK_INCLUDE_DIR=/path/to/headers")
+        endif()
+        target_include_directories(ui PRIVATE ${MOLTENVK_INCLUDE})
+        find_library(MOLTENVK_LIB MoltenVK)
+        if (NOT MOLTENVK_LIB)
+            message(FATAL_ERROR "Could not find MoltenVK library")
+        endif()
+        target_link_libraries(ui PRIVATE "${MOLTENVK_LIB}")
+    endif()
 endif()
 
 if (WIN32)
@@ -282,6 +294,7 @@ if (APPLE AND CMAKE_MACOSX_BUNDLE)
     set(prefix "86Box.app/Contents")
     set(INSTALL_RUNTIME_DIR "${prefix}/MacOS")
     set(INSTALL_CMAKE_DIR "${prefix}/Resources")
+    set(INSTALL_LIB_DIR "${prefix}/Frameworks")
 
     # using the install_qt5_plugin to add Qt plugins into the macOS app bundle
     install_qt5_plugin("Qt${QT_MAJOR}::QCocoaIntegrationPlugin" QT_PLUGINS ${prefix})
@@ -314,6 +327,16 @@ if (APPLE AND CMAKE_MACOSX_BUNDLE)
             COMMAND ${CMAKE_INSTALL_NAME_TOOL} -add_rpath \"@executable_path/../Frameworks/\"
             \"\${CMAKE_INSTALL_PREFIX_ABSOLUTE}/${INSTALL_RUNTIME_DIR}/86Box\")
         ")
+    if(MOLTENVK)
+        install(CODE "
+        execute_process(
+            COMMAND bash -c \"set -e
+            echo \\\"-- Creating vulkan dylib symlink for QT (libVulkan.dylib -> libMoltenVK.dylib)\\\"
+            cd \${CMAKE_INSTALL_PREFIX_ABSOLUTE}/${INSTALL_LIB_DIR}
+            ln -sf libMoltenVK.dylib libVulkan.dylib
+            \")
+        ")
+    endif()
 endif()
 
 if (UNIX AND NOT APPLE AND NOT HAIKU)


### PR DESCRIPTION
Summary
=======
This PR adds the ability to enable Vulkan support on macOS via MoltenVK.

### Requirements

* MoltenVK headers and library. Can be installed with `brew install molten-vk`. Cmake will automatically search the necessary homebrew paths for headers and standard library path for the library. If the headers are in a different location it can be specified with `-DMOLTENVK_INCLUDE_DIR`.
* Vulkan-enabled QT. If you wish to use this, you must first build QT with vulkan support (via MoltenVK) and have it available locally. You'll also need to adjust `Qt5_DIR` and other associated variables to point to that specific QT.

To enable, build with `-DMOLTENVK`. The default is off.

The installation process was also updated to create a symlink (`libVulkan.dylib` -> `libMoltenVK.dylib`) in the installation bundle. QT by default looks for `libVulkan.dylib` and will not find `libMoltenVK.dylib` on its own. The  only way to override the library name is by setting the `QT_VULKAN_LIB` environment variable with the name. There aren't any easy ways to do that in an app bundle that I could find.

However, the symlink seems to solve that problem, giving it the default filename it is looking for.

**Note:** This PR specifically does **not** use the built-in cmake `FindVulkan` function. `FindVulkan` is looking for the full SDK and also requires additional environment variables to be set. The full SDK is not needed here, just the headers and a library which are easily satisfied with the homebrew package.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
