### PR TITLE
Implement media history manager and recently used images

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1829,6 +1829,15 @@ load_floppy_and_cdrom_drives(void)
 
         sprintf(temp, "cdrom_%02i_iso_path", c + 1);
         config_delete_var(cat, temp);
+
+        for (int i = 0; i < MAX_PREV_IMAGES; i++) {
+            cdrom[c].image_history[i] = (char *) calloc(MAX_IMAGE_PATH_LEN + 1, sizeof(char));
+            sprintf(temp, "cdrom_%02i_image_history_%02i", c + 1, i + 1);
+            p = config_get_string(cat, temp, NULL);
+            if(p) {
+                sprintf(cdrom[c].image_history[i], "%s", p);
+            }
+        }
     }
 }
 
@@ -3136,6 +3145,15 @@ save_floppy_and_cdrom_drives(void)
             config_delete_var(cat, temp);
         } else {
             config_set_string(cat, temp, cdrom[c].image_path);
+        }
+
+        for (int i = 0; i < MAX_PREV_IMAGES; i++) {
+            sprintf(temp, "cdrom_%02i_image_history_%02i", c + 1, i + 1);
+            if(strlen(cdrom[c].image_history[i]) == 0) {
+                config_delete_var(cat, temp);
+            } else {
+                config_set_string(cat, temp, cdrom[c].image_history[i]);
+            }
         }
     }
 

--- a/src/config.c
+++ b/src/config.c
@@ -3149,7 +3149,7 @@ save_floppy_and_cdrom_drives(void)
 
         for (int i = 0; i < MAX_PREV_IMAGES; i++) {
             sprintf(temp, "cdrom_%02i_image_history_%02i", c + 1, i + 1);
-            if(strlen(cdrom[c].image_history[i]) == 0) {
+            if((cdrom[c].image_history[i] == 0) || strlen(cdrom[c].image_history[i]) == 0) {
                 config_delete_var(cat, temp);
             } else {
                 config_set_string(cat, temp, cdrom[c].image_history[i]);

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -31,6 +31,10 @@
 #define NVR_PATH        "nvr"
 #define SCREENSHOT_PATH "screenshots"
 
+/* Recently used images */
+#define MAX_PREV_IMAGES 4
+#define MAX_IMAGE_PATH_LEN 256
+
 /* Default language 0xFFFF = from system, 0x409 = en-US */
 #define DEFAULT_LANGUAGE 0x0409
 

--- a/src/include/86box/cdrom.h
+++ b/src/include/86box/cdrom.h
@@ -39,6 +39,8 @@
 #define CD_TOC_SESSION			1
 #define CD_TOC_RAW			2
 
+#define CD_IMAGE_HISTORY                4
+
 #define BUF_SIZE 32768
 
 #define CDROM_IMAGE 200
@@ -109,6 +111,8 @@ typedef struct cdrom {
 
     char image_path[1024],
          prev_image_path[1024];
+
+    char *image_history[CD_IMAGE_HISTORY];
 
     uint32_t sound_on, cdrom_capacity,
              pad, seek_pos,

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -166,6 +166,9 @@ add_library(ui STATIC
     qt_mcadevicelist.cpp
     qt_mcadevicelist.ui
 
+    qt_mediahistorymanager.cpp
+    qt_mediahistorymanager.hpp
+
     ../qt_resources.qrc
 )
 

--- a/src/qt/qt_mediahistorymanager.cpp
+++ b/src/qt/qt_mediahistorymanager.cpp
@@ -1,0 +1,326 @@
+/*
+* 86Box	A hypervisor and IBM PC system emulator that specializes in
+*		running old operating systems and software designed for IBM
+*		PC systems and compatibles from 1981 through fairly recent
+*		system designs based on the PCI bus.
+*
+*		This file is part of the 86Box distribution.
+*
+*		Media history management module
+*
+*
+*
+* Authors:	cold-brewed
+*
+*		Copyright 2022 The 86Box development team
+*/
+
+
+#include <QApplication>
+#include <QFileInfo>
+#include <QMetaEnum>
+#include <QStringBuilder>
+#include <utility>
+
+#include "86box/cdrom.h"
+#include "qt_mediahistorymanager.hpp"
+
+namespace ui {
+
+MediaHistoryManager::MediaHistoryManager() {
+    initializeImageHistory();
+    deserializeAllImageHistory();
+    initialDeduplication();
+
+}
+
+MediaHistoryManager::~MediaHistoryManager()
+= default;
+
+master_list_t &
+MediaHistoryManager::blankImageHistory(master_list_t &initialized_master_list) const
+{
+    for ( const auto device_type : ui::AllSupportedMediaHistoryTypes ) {
+        device_media_history_t device_media_history;
+        // Loop for all possible media devices
+        for (int device_index = 0 ; device_index < maxDevicesSupported(device_type); device_index++) {
+            device_index_list_t indexing_list;
+            device_media_history[device_index] = indexing_list;
+            // Loop for each history slot
+            for (int slot_index = 0; slot_index < max_images; slot_index++) {
+                device_media_history[device_index].append(QString());
+            }
+        }
+        initialized_master_list.insert(device_type, device_media_history);
+    }
+    return initialized_master_list;
+}
+
+
+const device_index_list_t&
+MediaHistoryManager::getHistoryListForDeviceIndex(int index, ui::MediaType type)
+{
+    if (master_list.contains(type)) {
+        if ((index >= 0 ) && (index < master_list[type].size())) {
+            return master_list[type][index];
+        } else {
+            qWarning("Media device index %i for device type %s was requested but index %i is out of range (valid range: >= 0 && < %i)",
+                     index, mediaTypeToString(type).toUtf8().constData(), index, master_list[type].size());
+        }
+    }
+    // Failure gets an empty list
+    return empty_device_index_list;
+}
+
+void MediaHistoryManager::setHistoryListForDeviceIndex(int index, ui::MediaType type, device_index_list_t history_list)
+{
+    master_list[type][index] = std::move(history_list);
+}
+
+QString
+MediaHistoryManager::getImageForSlot(int index, int slot, ui::MediaType type)
+{
+    QString image_name;
+    device_index_list_t device_history = getHistoryListForDeviceIndex(index, type);
+    if ((slot >= 0) && (slot < device_history.size())) {
+        image_name = device_history[slot];
+    } else {
+        qWarning("Media history slot %i, index %i for device type %s was requested but slot %i is out of range (valid range: >= 0 && < %i, device_history.size() is %i)",
+                 slot, index, mediaTypeToString(type).toUtf8().constData(), slot, maxDevicesSupported(type), device_history.size());
+    }
+    return image_name;
+}
+
+// These are hardcoded since we can't include the various
+// header files where they are defined (e.g., fdd.h, mo.h).
+// However, all in ui::MediaType support 4 except cassette.
+int MediaHistoryManager::maxDevicesSupported(ui::MediaType type)
+{
+    return type == ui::MediaType::Cassette ? 1 : 4;
+
+}
+
+void MediaHistoryManager::deserializeImageHistoryType(ui::MediaType type)
+{
+    for (int device = 0; device < maxDevicesSupported(type); device++) {
+        char **device_history_ptr = getEmuHistoryVarForType(type, device);
+        if(device_history_ptr == nullptr) {
+            // Device not supported, return and do not deserialize.
+            // This will leave the image listing at the default initialization state
+            // from the ui side (this class)
+            continue;
+        }
+        for ( int slot = 0; slot < MAX_PREV_IMAGES; slot++) {
+            master_list[type][device][slot] = device_history_ptr[slot];
+        }
+    }
+}
+void MediaHistoryManager::deserializeAllImageHistory()
+{
+    for ( const auto device_type : ui::AllSupportedMediaHistoryTypes ) {
+        deserializeImageHistoryType(device_type);
+    }
+}
+void MediaHistoryManager::serializeImageHistoryType(ui::MediaType type)
+{
+    for (int device = 0; device < maxDevicesSupported(type); device++) {
+        char **device_history_ptr = getEmuHistoryVarForType(type, device);
+        if(device_history_ptr == nullptr) {
+            // Device not supported, return and do not serialize.
+            // This will leave the image listing at the current state,
+            // and it will not be saved on the emu side
+            continue;
+        }
+        for ( int slot = 0; slot < MAX_PREV_IMAGES; slot++) {
+            strncpy(device_history_ptr[slot], master_list[type][device][slot].toUtf8().constData(), MAX_IMAGE_PATH_LEN);
+
+        }
+    }
+}
+
+void MediaHistoryManager::serializeAllImageHistory()
+{
+    for ( const auto device_type : ui::AllSupportedMediaHistoryTypes ) {
+        serializeImageHistoryType(device_type);
+    }
+}
+
+void MediaHistoryManager::initialDeduplication()
+{
+
+    QString current_image;
+    // Perform initial dedup if an image is loaded
+    for ( const auto device_type : ui::AllSupportedMediaHistoryTypes ) {
+        for (int device_index = 0; device_index < maxDevicesSupported(device_type); device_index++) {
+            device_index_list_t device_history = getHistoryListForDeviceIndex(device_index, device_type);
+            switch (device_type) {
+                case ui::MediaType::Optical:
+                    current_image = cdrom[device_index].image_path;
+                    break;
+                default:
+                    continue;
+                    break;
+            }
+            deduplicateList(device_history, QVector<QString> (1, current_image));
+            // Fill in missing, if any
+            int missing = MAX_PREV_IMAGES - device_history.size();
+            if(missing) {
+                for (int i = 0; i < missing; i++) {
+                    device_history.push_back(QString());
+                }
+            }
+            setHistoryListForDeviceIndex(device_index, device_type, device_history);
+        }
+    }
+}
+
+char ** MediaHistoryManager::getEmuHistoryVarForType(ui::MediaType type, int index)
+{
+    switch (type) {
+        case ui::MediaType::Optical:
+            return &cdrom[index].image_history[0];
+        default:
+            return nullptr;
+
+    }
+}
+
+device_index_list_t &
+MediaHistoryManager::deduplicateList(device_index_list_t &device_history, const QVector<QString>& filenames)
+{
+    QVector<QString> items_to_delete;
+    for (auto &list_item_path : device_history) {
+        if(list_item_path.isEmpty()) {
+            continue ;
+        }
+        for (const auto& path_to_check : filenames) {
+            if(path_to_check.isEmpty()) {
+                continue ;
+            }
+            QString adjusted_path = pathAdjustSingle(path_to_check);
+            int match = QString::localeAwareCompare(list_item_path, adjusted_path);
+            if (match == 0) {
+                items_to_delete.append(list_item_path);
+            }
+        }
+    }
+    // Remove by name rather than index because the index would change
+    // after each removal
+    for (const auto& path: items_to_delete) {
+        device_history.removeAll(path);
+    }
+    return device_history;
+}
+
+void MediaHistoryManager::addImageToHistory(int index, ui::MediaType type, const QString& image_name, const QString& new_image_name)
+{
+    device_index_list_t device_history = getHistoryListForDeviceIndex(index, type);
+    QVector<QString> files_to_check;
+
+    files_to_check.append(image_name);
+    files_to_check.append(new_image_name);
+    device_history = deduplicateList(device_history, files_to_check);
+
+
+    if (!image_name.isEmpty()) {
+        device_history.push_front(image_name);
+    }
+
+    // Pop any extras
+    if ((device_history.size() > MAX_PREV_IMAGES)) {
+        device_history.pop_back();
+    }
+
+    // Fill in missing, if any
+    int missing = MAX_PREV_IMAGES - device_history.size();
+    if(missing) {
+        for (int i = 0; i < missing; i++) {
+            device_history.push_back(QString());
+        }
+    }
+
+    device_history = removeMissingImages(device_history);
+    device_history = pathAdjustFull(device_history);
+
+    setHistoryListForDeviceIndex(index, type, device_history);
+    serializeImageHistoryType(type);
+}
+
+QString MediaHistoryManager::mediaTypeToString(ui::MediaType type)
+{
+    QMetaEnum qme = QMetaEnum::fromType<ui::MediaType>();
+    return qme.valueToKey(static_cast<int>(type));
+}
+
+QString
+MediaHistoryManager::pathAdjustSingle(QString checked_path)
+{
+    QString current_usr_path = getUsrPath();
+    QFileInfo file_info(checked_path);
+    if (file_info.filePath().isEmpty() || current_usr_path.isEmpty() || file_info.isRelative()) {
+        return checked_path;
+    }
+    if (file_info.filePath().startsWith(current_usr_path)) {
+        checked_path = file_info.filePath().remove(current_usr_path);
+    }
+    return checked_path;
+}
+
+device_index_list_t &
+MediaHistoryManager::pathAdjustFull(device_index_list_t &device_history)
+{
+    for (auto &checked_path : device_history) {
+        checked_path = pathAdjustSingle(checked_path);
+    }
+    return device_history;
+}
+QString MediaHistoryManager::getUsrPath()
+{
+    QString current_usr_path(usr_path);
+    // Ensure `usr_path` has a trailing slash
+    return current_usr_path.endsWith("/") ? current_usr_path : current_usr_path.append("/");
+}
+device_index_list_t &
+MediaHistoryManager::removeMissingImages(device_index_list_t &device_history)
+{
+    for (auto &checked_path : device_history) {
+        QFileInfo file_info(checked_path);
+        if (file_info.filePath().isEmpty()) {
+            continue;
+        }
+        // For this check, explicitly prepend `usr_path` to relative paths to account for $CWD platform variances
+        QFileInfo absolute_path = file_info.isRelative() ? getUsrPath().append(file_info.filePath()) : file_info;
+        if(!absolute_path.exists()) {
+            qWarning("Image file %s does not exist - removing from history", qPrintable(file_info.filePath()));
+            checked_path = "";
+        }
+    }
+    return device_history;
+}
+
+void MediaHistoryManager::initializeImageHistory()
+{
+    auto initial_master_list = getMasterList();
+    setMasterList(blankImageHistory(initial_master_list));
+}
+
+const master_list_t &
+MediaHistoryManager::getMasterList() const
+{
+    return master_list;
+}
+
+void
+MediaHistoryManager::setMasterList(const master_list_t &masterList)
+{
+    master_list = masterList;
+}
+
+void
+MediaHistoryManager::clearImageHistory()
+{
+    initializeImageHistory();
+    serializeAllImageHistory();
+}
+
+} // ui

--- a/src/qt/qt_mediahistorymanager.hpp
+++ b/src/qt/qt_mediahistorymanager.hpp
@@ -1,0 +1,139 @@
+/*
+* 86Box	A hypervisor and IBM PC system emulator that specializes in
+*		running old operating systems and software designed for IBM
+*		PC systems and compatibles from 1981 through fairly recent
+*		system designs based on the PCI bus.
+*
+*		This file is part of the 86Box distribution.
+*
+*		Header for the media history management module
+*
+*
+*
+* Authors:	cold-brewed
+*
+*		Copyright 2022 The 86Box development team
+*/
+
+#ifndef QT_MEDIAHISTORYMANAGER_HPP
+#define QT_MEDIAHISTORYMANAGER_HPP
+
+#include <QString>
+#include <QWidget>
+#include <QVector>
+
+#include <initializer_list>
+
+extern "C" {
+#include <86box/86box.h>
+}
+
+// This macro helps give us the required `qHash()` function in order to use the
+// enum as a hash key
+#define QHASH_FOR_CLASS_ENUM(T) \
+inline uint qHash(const T &t, uint seed) { \
+    return ::qHash(static_cast<typename std::underlying_type<T>::type>(t), seed); \
+}
+
+typedef QVector<QString>             device_index_list_t;
+typedef QHash<int, QVector<QString>> device_media_history_t;
+
+
+namespace ui {
+    Q_NAMESPACE
+    
+    enum class MediaType {
+        Floppy,
+        Optical,
+        Zip,
+        Mo,
+        Cassette
+    };
+    // This macro allows us to do a reverse lookup of the enum with `QMetaEnum`
+    Q_ENUM_NS(MediaType)
+    
+    QHASH_FOR_CLASS_ENUM(MediaType)
+
+    typedef QHash<ui::MediaType, device_media_history_t> master_list_t;
+
+    // Used to iterate over all supported types when preparing data structures
+    // Also useful to indicate which types support history
+    static const MediaType AllSupportedMediaHistoryTypes[] = {
+        MediaType::Optical
+    };
+
+    class MediaHistoryManager {
+
+    public:
+        MediaHistoryManager();
+        virtual ~MediaHistoryManager();
+
+        // Get the image name for a particular slot,
+        // index, and type combination
+        QString getImageForSlot(int index, int slot, ui::MediaType type);
+
+        // Add an image to history
+        void addImageToHistory(int index, ui::MediaType type, const QString& image_name, const QString& new_image_name);
+
+        // Convert the enum value to a string
+        static QString mediaTypeToString(ui::MediaType type);
+
+        // Clear out the image history
+        void clearImageHistory();
+
+
+    private:
+        int max_images = MAX_PREV_IMAGES;
+
+        // Main hash of hash of vector of strings
+        master_list_t       master_list;
+        const master_list_t &getMasterList() const;
+        void                 setMasterList(const master_list_t &masterList);
+
+        device_index_list_t index_list, empty_device_index_list;
+
+        // Return a blank, initialized image history list
+        master_list_t &blankImageHistory(master_list_t &initialized_master_list) const;
+
+        // Initialize the image history
+        void initializeImageHistory();
+
+        // Max number of devices supported by media type
+        static int maxDevicesSupported(ui::MediaType type);
+
+        // Serialize the data back into the C array
+        // on the emu side
+        void serializeImageHistoryType(ui::MediaType type);
+        void serializeAllImageHistory();
+
+        // Deserialize the data from C array on the emu side
+        // for the ui side
+        void deserializeImageHistoryType(ui::MediaType type);
+        void deserializeAllImageHistory();
+
+        // Get emu history variable for a device type
+        static char** getEmuHistoryVarForType(ui::MediaType type, int index);
+
+        // Get or set the history for a specific device/index combo
+        const device_index_list_t &getHistoryListForDeviceIndex(int index, ui::MediaType type);
+        void setHistoryListForDeviceIndex(int index, ui::MediaType type, device_index_list_t history_list);
+
+        // Remove missing image files from history list
+        static device_index_list_t &removeMissingImages(device_index_list_t &device_history);
+
+        // If an absolute path is contained within `usr_path`, convert to a relative path
+        static device_index_list_t &pathAdjustFull(device_index_list_t &device_history);
+        static QString pathAdjustSingle(QString checked_path);
+
+        // Deduplicate history entries
+        static device_index_list_t &deduplicateList(device_index_list_t &device_history, const QVector<QString>& filenames);
+        void initialDeduplication();
+
+        // Gets the `usr_path` from the emu side and appends a
+        // trailing slash if necessary
+        static QString getUsrPath();
+    };
+
+} // ui
+
+#endif // QT_MEDIAHISTORYMANAGER_HPP

--- a/src/qt/qt_mediamenu.hpp
+++ b/src/qt/qt_mediamenu.hpp
@@ -3,7 +3,11 @@
 #include <memory>
 #include <QObject>
 #include <QMap>
+#include "qt_mediahistorymanager.hpp"
 
+extern "C" {
+#include <86box/86box.h>
+}
 class QMenu;
 
 class MediaMenu : QObject
@@ -40,7 +44,9 @@ public:
     void cdromMount(int i);
     void cdromMount(int i, const QString& filename);
     void cdromEject(int i);
-    void cdromReload(int i);
+    void cdromReload(int index, int slot);
+    void updateImageHistory(int index, int slot, ui::MediaType type);
+    void clearImageHistory();
     void cdromUpdateMenu(int i);
 
     void zipNewImage(int i);
@@ -72,6 +78,7 @@ private:
     QMap<int, QMenu*> netMenus;
 
     QString getMediaOpenDirectory();
+    ui::MediaHistoryManager mhm;
 
     int cassetteRecordPos;
     int cassettePlayPos;
@@ -87,6 +94,8 @@ private:
     int cdromMutePos;
     int cdromReloadPos;
     int cdromImagePos;
+    int cdromImageHistoryPos[MAX_PREV_IMAGES];
+    int floppyImageHistoryPos[MAX_PREV_IMAGES];
 
     int zipEjectPos;
     int zipReloadPos;

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -167,7 +167,7 @@ plat_fopen(const char *path, const char *mode)
 FILE *
 plat_fopen64(const char *path, const char *mode)
 {
-#ifdef Q_OS_MACOS
+#if defined(Q_OS_MACOS) or defined(Q_OS_LINUX)
     QFileInfo fi(path);
     QString filename = fi.isRelative() ? usr_path + fi.filePath() : fi.filePath();
     return fopen(filename.toUtf8().constData(), mode);

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -167,7 +167,13 @@ plat_fopen(const char *path, const char *mode)
 FILE *
 plat_fopen64(const char *path, const char *mode)
 {
+#ifdef Q_OS_MACOS
+    QFileInfo fi(path);
+    QString filename = fi.isRelative() ? usr_path + fi.filePath() : fi.filePath();
+    return fopen(filename.toUtf8().constData(), mode);
+#else
     return fopen(QString::fromUtf8(path).toLocal8Bit(), mode);
+#endif
 }
 
 int


### PR DESCRIPTION
Summary
=======

This PR implements a new media history manager on the UI side and associated storage on the emu side for persistence. Up to 4 recent images are stored in this list.

I created a new class for this because I wanted to make it generic / robust enough to apply to any of the supported media types in 86Box. While it may look a bit complicated, I discovered there are a lot of sharp edges and corner cases when it comes to implementing something as seemingly simple as media history. This is further complicated by the different types of media, multiple devices, etc. that are supported in 86Box. I found it was easier to put all of this into a class rather than hard-coding a mess into the existing media menu structure.

Right now, however, only optical is currently implemented. The code and structure is all there for other media types which can be added incrementally once this PR is in. As an example, you'll see several places where only `ui::MediaType::Optical` is addressed. The other types can be added in later.

On the discord there was interest in having the image files stored as *relative* paths when persisted in the config. The theory being a given image could be stored in the same directory as the `86Box.cfg` (`usr_path`) and therefore slightly "portable" in the sense that the config directory (and associated files) could be moved around.

When I checked, the existing code stores all paths as absolute. On some platforms (windows) you can manually modify the config file and change the image to relative and it does work, but again it is stored absolute by default. Because of `$CWD` funkiness with macOS, relative will *not* work without this PR, even with the path manually changed as above. I addressed that issue in this PR with the `plat_fopen64()` change noted below. I also found that linux needed the same fix to work with relative paths: basically, without the fix, if you start with `-P` from a different `$CWD` the relative paths can't be found.

This PR attempts to convert absolute paths (initially obtained from qt file selection dialog) to relative paths when they are placed in the history: Each item is checked againt `usr_path` and if the item exists in that directory, `usr_path` is stripped off and only the relative path stored. All other paths remain the same.

Items are also deduplicated as they are added. For example, if you load an image that is currently in the history list, it is removed from the history list to prevent it from taking up multiple history slots. It will then be placed in the most recent list when ejected or replaced.

Additionally, images are checked for existence and any items that do not exist on the filesystem are automatically removed.

I tested with non-latin filenames and dirs to be safe on the platforms that needed the `plat_fopen64()` change (mac, linux).

The main media menu (not the pop-up) has an option to clear the history.

On the QT side, the media menu is created and pre-populated with blank entries due to some issues with dynamically adding entries to an already-existing menu. Basically: The menu items are created and hidden by default. If there is an image history for that listing, the menu item is displayed (unhidden) when the menu is updated.

I'd appreciate some reviews as my cpp is a bit rusty.

### Screenshots

![Menu example with 3](https://user-images.githubusercontent.com/47337035/187710985-9149104f-45d4-4184-845e-9a578ec99d16.png)

![Menu example](https://user-images.githubusercontent.com/47337035/187710997-672b4bb6-695c-4ea1-a89a-007a1e476a5e.png)

![Main menu](https://user-images.githubusercontent.com/47337035/187711052-662645a9-170c-48a8-9cf5-cbf75e67f65b.png)

### Summary of file changes

`src/include/86box/cdrom.h`:

`cdrom_t` gets `char *image_history[CD_IMAGE_HISTORY]` to store image history on emu side. This value is not directly persisted in config, but rather serialzed to individual entries.

`src/config.c`:

Updated to add initialization and store / retrieve for image history. At runtime it is stored in the array of `*char` and is serialized to individial items for storage. Saved entry example: `cdrom_01_image_history_01=image_file`

`src/include/86box/86box.h`: some constants like `MAX_PREV_IMAGES`

`src/qt/CMakeLists.txt`: Added new files

`src/qt/qt_mediamenu.cpp` and `src/qt/qt_mediamenu.hpp`

Added a new main menu option to clear image history.

Several modifications and some new functions to support image history in the media menu.

`src/qt/qt_platform.cpp`:

I needed to modify the `plat_fopen64()` to support opening stored *relative* paths. This is mainly because `$CWD` can be undefined *or* just about anything all the way up to `/` on macOS depending on how it is lauched. This modification simply applies `usr_path` to any relative paths encountered for open. Absolute paths are not touched. The same fix is also applied to linux because relative paths won't work with `-P` when `$CWD` differs from `usr_path`.

It is gated behind `Q_OS_MACOS` and `Q_OS_LINUX`.

`src/qt/qt_mediahistorymanager.cpp` and `src/qt/qt_mediahistorymanager.hpp`: The new `MediaHistoryManager` class


Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
