### PR TITLE
qt_hardwarerenderer: Don't update the entire texture on blits

### DIFF
--- a/src/qt/qt_hardwarerenderer.cpp
+++ b/src/qt/qt_hardwarerenderer.cpp
@@ -21,6 +21,8 @@
 #include "qt_hardwarerenderer.hpp"
 #include <QApplication>
 #include <QVector2D>
+#include <QOpenGLPixelTransferOptions>
+
 #include <atomic>
 #include <vector>
 
@@ -196,7 +198,7 @@ void HardwareRenderer::onBlit(int buf_idx, int x, int y, int w, int h) {
         return;
     }
     m_context->makeCurrent(this);
-    m_texture->setData(QOpenGLTexture::PixelFormat::RGBA, QOpenGLTexture::PixelType::UInt8, (const void*)imagebufs[buf_idx].get());
+    m_texture->setData(0, 0, 0, w + x, h + y, 0, QOpenGLTexture::PixelFormat::RGBA, QOpenGLTexture::PixelType::UInt8, (const void*)imagebufs[buf_idx].get(), &m_transferOptions);
     buf_usage[buf_idx].clear();
     source.setRect(x, y, w, h);
     if (origSource != source) onResize(this->width(), this->height());

--- a/src/qt/qt_hardwarerenderer.hpp
+++ b/src/qt/qt_hardwarerenderer.hpp
@@ -8,6 +8,7 @@
 #include <QOpenGLShader>
 #include <QOpenGLShaderProgram>
 #include <QOpenGLTextureBlitter>
+#include <QOpenGLPixelTransferOptions>
 #include <QPainter>
 #include <QEvent>
 #include <QKeyEvent>
@@ -38,6 +39,8 @@ private:
     QOpenGLTextureBlitter* m_blt{nullptr};
     QOpenGLBuffer m_vbo[2];
     QOpenGLVertexArrayObject m_vao;
+    QOpenGLPixelTransferOptions m_transferOptions;
+
 public:
     enum class RenderType {
         OpenGL,
@@ -66,6 +69,8 @@ public:
         setFlags(Qt::FramelessWindowHint);
         parentWidget = parent;
         setRenderType(rtype);
+
+        m_transferOptions.setRowLength(2048);
 
         m_context = new QOpenGLContext();
         m_context->setFormat(format());


### PR DESCRIPTION
Summary
=======
qt_hardwarerenderer: Don't update the entire texture on blits

Improves performance by a lot (especially in the intro of Jazz Jackrabbit 1).

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
