### PR TITLE
XGA: Revert to the rom_init routine to load the XGA-1/XGA-2 bios

### DIFF
--- a/src/video/vid_xga.c
+++ b/src/video/vid_xga.c
@@ -14,26 +14,26 @@
  *
  *		Copyright 2022 TheCollector1995.
  */
-#include "cpu.h"
-#include <86box/86box.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <wchar.h>
 #include <86box/bswap.h>
-#include <86box/device.h>
-#include <86box/dma.h>
+#include <86box/86box.h>
 #include <86box/io.h>
 #include <86box/machine.h>
-#include <86box/mca.h>
 #include <86box/mem.h>
+#include <86box/dma.h>
 #include <86box/rom.h>
+#include <86box/mca.h>
+#include <86box/device.h>
 #include <86box/timer.h>
+#include <86box/video.h>
 #include <86box/vid_svga.h>
 #include <86box/vid_svga_render.h>
 #include <86box/vid_xga_device.h>
-#include <86box/video.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <wchar.h>
+#include "cpu.h"
 
 #define XGA_BIOS_PATH  "roms/video/xga/XGA_37F9576_Ver200.BIN"
 #define XGA2_BIOS_PATH "roms/video/xga/xga2_v300.bin"

--- a/src/video/vid_xga.c
+++ b/src/video/vid_xga.c
@@ -35,10 +35,10 @@
 #include <86box/vid_xga_device.h>
 #include "cpu.h"
 
-#define XGA_BIOS_PATH  "roms/video/xga/XGA_37F9576_Ver200.BIN"
+#define XGA_BIOS_PATH "roms/video/xga/XGA_37F9576_Ver200.BIN"
 #define XGA2_BIOS_PATH "roms/video/xga/xga2_v300.bin"
 
-static void    xga_ext_outb(uint16_t addr, uint8_t val, void *p);
+static void xga_ext_outb(uint16_t addr, uint8_t val, void *p);
 static uint8_t xga_ext_inb(uint16_t addr, void *p);
 
 static void
@@ -46,7 +46,7 @@ xga_updatemapping(svga_t *svga)
 {
     xga_t *xga = &svga->xga;
 
-    // pclog("OpMode = %x, linear base = %08x, aperture cntl = %d, opmodereset1 = %d, access mode = %x, map = %x.\n", xga->op_mode, xga->linear_base, xga->aperture_cntl, xga->op_mode_reset, xga->access_mode, svga->gdcreg[6] & 0x0c);
+    //pclog("OpMode = %x, linear base = %08x, aperture cntl = %d, opmodereset1 = %d, access mode = %x, map = %x.\n", xga->op_mode, xga->linear_base, xga->aperture_cntl, xga->op_mode_reset, xga->access_mode, svga->gdcreg[6] & 0x0c);
     if ((xga->op_mode & 7) >= 4) {
         if (xga->aperture_cntl == 1) {
             mem_mapping_disable(&svga->mapping);
@@ -72,7 +72,7 @@ linear:
                     mem_mapping_disable(&xga->linear_mapping);
             }
             xga->on = 0;
-            vga_on  = 1;
+            vga_on = 1;
             if (((xga->op_mode & 7) == 4) && ((svga->gdcreg[6] & 0x0c) == 0x0c) && !xga->a5_test)
                 xga->linear_endian_reverse = 1;
         } else {
@@ -99,7 +99,7 @@ linear:
         }
         mem_mapping_disable(&xga->linear_mapping);
         xga->on = 0;
-        vga_on  = 1;
+        vga_on = 1;
     }
 }
 
@@ -109,10 +109,10 @@ xga_recalctimings(svga_t *svga)
     xga_t *xga = &svga->xga;
 
     if (xga->on) {
-        xga->v_total      = xga->vtotal + 1;
-        xga->dispend      = xga->vdispend + 1;
-        xga->v_syncstart  = xga->vsyncstart + 1;
-        xga->split        = xga->linecmp + 1;
+        xga->v_total = xga->vtotal + 1;
+        xga->dispend = xga->vdispend + 1;
+        xga->v_syncstart = xga->vsyncstart + 1;
+        xga->split = xga->linecmp + 1;
         xga->v_blankstart = xga->vblankstart + 1;
 
         xga->h_disp = (xga->hdisp + 1) << 3;
@@ -120,7 +120,7 @@ xga_recalctimings(svga_t *svga)
         xga->rowoffset = (xga->hdisp + 1);
 
         xga->interlace = !!(xga->disp_cntl_1 & 0x08);
-        xga->rowcount  = (xga->disp_cntl_2 & 0xc0) >> 6;
+        xga->rowcount = (xga->disp_cntl_2 & 0xc0) >> 6;
 
         if (xga->interlace) {
             xga->v_total >>= 1;
@@ -135,16 +135,16 @@ xga_recalctimings(svga_t *svga)
         switch (xga->clk_sel_1 & 0x0c) {
             case 0:
                 if (xga->clk_sel_2 & 0x80) {
-                    svga->clock = (cpuclock * (double) (1ull << 32)) / 41539000.0;
+                    svga->clock = (cpuclock * (double)(1ull << 32)) / 41539000.0;
                 } else {
-                    svga->clock = (cpuclock * (double) (1ull << 32)) / 25175000.0;
+                    svga->clock = (cpuclock * (double)(1ull << 32)) / 25175000.0;
                 }
                 break;
             case 4:
-                svga->clock = (cpuclock * (double) (1ull << 32)) / 28322000.0;
+                svga->clock = (cpuclock * (double)(1ull << 32)) / 28322000.0;
                 break;
             case 0x0c:
-                svga->clock = (cpuclock * (double) (1ull << 32)) / 44900000.0;
+                svga->clock = (cpuclock * (double)(1ull << 32)) / 44900000.0;
                 break;
         }
     } else {
@@ -215,11 +215,11 @@ xga_ext_out_reg(xga_t *xga, svga_t *svga, uint8_t idx, uint8_t val)
             break;
 
         case 0x30:
-            xga->hwc_pos_x  = (xga->hwc_pos_x & 0x0700) | val;
+            xga->hwc_pos_x = (xga->hwc_pos_x & 0x0700) | val;
             xga->hwcursor.x = xga->hwc_pos_x;
             break;
         case 0x31:
-            xga->hwc_pos_x  = (xga->hwc_pos_x & 0xff) | ((val & 0x07) << 8);
+            xga->hwc_pos_x = (xga->hwc_pos_x & 0xff) | ((val & 0x07) << 8);
             xga->hwcursor.x = xga->hwc_pos_x;
             break;
 
@@ -229,11 +229,11 @@ xga_ext_out_reg(xga_t *xga, svga_t *svga, uint8_t idx, uint8_t val)
             break;
 
         case 0x33:
-            xga->hwc_pos_y  = (xga->hwc_pos_y & 0x0700) | val;
+            xga->hwc_pos_y = (xga->hwc_pos_y & 0x0700) | val;
             xga->hwcursor.y = xga->hwc_pos_y;
             break;
         case 0x34:
-            xga->hwc_pos_y  = (xga->hwc_pos_y & 0xff) | ((val & 0x07) << 8);
+            xga->hwc_pos_y = (xga->hwc_pos_y & 0xff) | ((val & 0x07) << 8);
             xga->hwcursor.y = xga->hwc_pos_y;
             break;
 
@@ -243,7 +243,7 @@ xga_ext_out_reg(xga_t *xga, svga_t *svga, uint8_t idx, uint8_t val)
             break;
 
         case 0x36:
-            xga->hwc_control  = val;
+            xga->hwc_control = val;
             xga->hwcursor.ena = xga->hwc_control & 1;
             break;
 
@@ -306,12 +306,12 @@ xga_ext_out_reg(xga_t *xga, svga_t *svga, uint8_t idx, uint8_t val)
 
         case 0x60:
             xga->sprite_pal_addr_idx = (xga->sprite_pal_addr_idx & 0x3f00) | val;
-            svga->dac_pos            = 0;
-            svga->dac_addr           = val & 0xff;
+            svga->dac_pos = 0;
+            svga->dac_addr = val & 0xff;
             break;
         case 0x61:
             xga->sprite_pal_addr_idx = (xga->sprite_pal_addr_idx & 0xff) | ((val & 0x3f) << 8);
-            xga->sprite_pos          = xga->sprite_pal_addr_idx & 0x1ff;
+            xga->sprite_pos = xga->sprite_pal_addr_idx & 0x1ff;
             if ((xga->sprite_pos >= 0) && (xga->sprite_pos <= 16)) {
                 if ((xga->op_mode & 7) >= 5)
                     xga->cursor_data_on = 1;
@@ -333,17 +333,17 @@ xga_ext_out_reg(xga_t *xga, svga_t *svga, uint8_t idx, uint8_t val)
                     xga->cursor_data_on = 0;
                 }
             }
-            // pclog("Sprite POS = %d, data on = %d, idx = %d, apcntl = %d\n", xga->sprite_pos, xga->cursor_data_on, xga->sprite_pal_addr_idx, xga->aperture_cntl);
+            //pclog("Sprite POS = %d, data on = %d, idx = %d, apcntl = %d\n", xga->sprite_pos, xga->cursor_data_on, xga->sprite_pal_addr_idx, xga->aperture_cntl);
             break;
 
         case 0x62:
             xga->sprite_pal_addr_idx_prefetch = (xga->sprite_pal_addr_idx_prefetch & 0x3f00) | val;
-            svga->dac_pos                     = 0;
-            svga->dac_addr                    = val & 0xff;
+            svga->dac_pos = 0;
+            svga->dac_addr = val & 0xff;
             break;
         case 0x63:
             xga->sprite_pal_addr_idx_prefetch = (xga->sprite_pal_addr_idx_prefetch & 0xff) | ((val & 0x3f) << 8);
-            xga->sprite_pos_prefetch          = xga->sprite_pal_addr_idx_prefetch & 0x1ff;
+            xga->sprite_pos_prefetch = xga->sprite_pal_addr_idx_prefetch & 0x1ff;
             break;
 
         case 0x64:
@@ -362,14 +362,14 @@ xga_ext_out_reg(xga_t *xga, svga_t *svga, uint8_t idx, uint8_t val)
                     svga->dac_pos++;
                     break;
                 case 2:
-                    xga->pal_b            = val;
-                    index                 = svga->dac_addr & 0xff;
+                    xga->pal_b = val;
+                    index = svga->dac_addr & 0xff;
                     svga->vgapal[index].r = svga->dac_r;
                     svga->vgapal[index].g = svga->dac_g;
                     svga->vgapal[index].b = xga->pal_b;
-                    svga->pallook[index]  = makecol32(svga->vgapal[index].r, svga->vgapal[index].g, svga->vgapal[index].b);
-                    svga->dac_pos         = 0;
-                    svga->dac_addr        = (svga->dac_addr + 1) & 0xff;
+                    svga->pallook[index] = makecol32(svga->vgapal[index].r, svga->vgapal[index].g, svga->vgapal[index].b);
+                    svga->dac_pos = 0;
+                    svga->dac_addr = (svga->dac_addr + 1) & 0xff;
                     break;
             }
             break;
@@ -390,7 +390,7 @@ xga_ext_out_reg(xga_t *xga, svga_t *svga, uint8_t idx, uint8_t val)
 
         case 0x6a:
             xga->sprite_data[xga->sprite_pos] = val;
-            xga->sprite_pos                   = (xga->sprite_pos + 1) & 0x3ff;
+            xga->sprite_pos = (xga->sprite_pos + 1) & 0x3ff;
             break;
 
         case 0x70:
@@ -403,10 +403,10 @@ xga_ext_out_reg(xga_t *xga, svga_t *svga, uint8_t idx, uint8_t val)
 static void
 xga_ext_outb(uint16_t addr, uint8_t val, void *p)
 {
-    svga_t *svga = (svga_t *) p;
-    xga_t  *xga  = &svga->xga;
+    svga_t *svga = (svga_t *)p;
+    xga_t *xga = &svga->xga;
 
-    // pclog("[%04X:%08X]: EXT OUTB = %02x, val = %02x\n", CS, cpu_state.pc, addr, val);
+    //pclog("[%04X:%08X]: EXT OUTB = %02x, val = %02x\n", CS, cpu_state.pc, addr, val);
     switch (addr & 0x0f) {
         case 0:
             xga->op_mode = val;
@@ -421,17 +421,17 @@ xga_ext_outb(uint16_t addr, uint8_t val, void *p)
                 xga->aperture_cntl = 0;
             break;
         case 6:
-            vga_on  = 0;
+            vga_on = 0;
             xga->on = 1;
             break;
         case 8:
             xga->ap_idx = val;
-            // pclog("Aperture CNTL = %d, val = %02x, up to bit6 = %02x\n", xga->aperture_cntl, val, val & 0x3f);
+            //pclog("Aperture CNTL = %d, val = %02x, up to bit6 = %02x\n", xga->aperture_cntl, val, val & 0x3f);
             if ((xga->op_mode & 7) < 4) {
                 xga->write_bank = xga->read_bank = 0;
             } else {
                 xga->write_bank = (xga->ap_idx & 0x3f) << 16;
-                xga->read_bank  = xga->write_bank;
+                xga->read_bank = xga->write_bank;
             }
             break;
         case 9:
@@ -454,8 +454,8 @@ xga_ext_outb(uint16_t addr, uint8_t val, void *p)
 static uint8_t
 xga_ext_inb(uint16_t addr, void *p)
 {
-    svga_t *svga = (svga_t *) p;
-    xga_t  *xga  = &svga->xga;
+    svga_t *svga = (svga_t *)p;
+    xga_t *xga = &svga->xga;
     uint8_t ret, index;
 
     switch (addr & 0x0f) {
@@ -629,9 +629,9 @@ xga_ext_inb(uint16_t addr, void *p)
                             ret = svga->vgapal[index].g;
                             break;
                         case 2:
-                            svga->dac_pos  = 0;
+                            svga->dac_pos = 0;
                             svga->dac_addr = (svga->dac_addr + 1) & 0xff;
-                            ret            = svga->vgapal[index].b;
+                            ret = svga->vgapal[index].b;
                             break;
                     }
                     break;
@@ -651,8 +651,8 @@ xga_ext_inb(uint16_t addr, void *p)
                     break;
 
                 case 0x6a:
-                    // pclog("Sprite POS Read = %d, addr idx = %04x\n", xga->sprite_pos, xga->sprite_pal_addr_idx_prefetch);
-                    ret                      = xga->sprite_data[xga->sprite_pos_prefetch];
+                    //pclog("Sprite POS Read = %d, addr idx = %04x\n", xga->sprite_pos, xga->sprite_pal_addr_idx_prefetch);
+                    ret = xga->sprite_data[xga->sprite_pos_prefetch];
                     xga->sprite_pos_prefetch = (xga->sprite_pos_prefetch + 1) & 0x3ff;
                     break;
 
@@ -667,114 +667,70 @@ xga_ext_inb(uint16_t addr, void *p)
             break;
     }
 
-    // pclog("[%04X:%08X]: EXT INB = %02x, ret = %02x\n", CS, cpu_state.pc, addr, ret);
+    //pclog("[%04X:%08X]: EXT INB = %02x, ret = %02x\n", CS, cpu_state.pc, addr, ret);
     return ret;
 }
+
 
 #define READ(addr, dat) \
     dat = xga->vram[(addr) & (xga->vram_mask)];
 
-#define WRITE(addr, dat)                                         \
-    xga->vram[((addr)) & (xga->vram_mask)]                = dat; \
+#define WRITE(addr, dat) \
+    xga->vram[((addr)) & (xga->vram_mask)] = dat; \
     xga->changedvram[(((addr)) & (xga->vram_mask)) >> 12] = changeframecount;
 
 #define READW(addr, dat) \
-    dat = *(uint16_t *) &xga->vram[(addr) & (xga->vram_mask)];
+    dat = *(uint16_t *)&xga->vram[(addr) & (xga->vram_mask)];
 
-#define READW_REVERSE(addr, dat)                               \
+#define READW_REVERSE(addr, dat) \
     dat = xga->vram[(addr + 1) & (xga->vram_mask - 1)] & 0xff; \
     dat |= (xga->vram[(addr) & (xga->vram_mask - 1)] << 8);
 
-#define WRITEW(addr, dat)                                        \
-    *(uint16_t *) &xga->vram[((addr)) & (xga->vram_mask)] = dat; \
+#define WRITEW(addr, dat) \
+    *(uint16_t *)&xga->vram[((addr)) & (xga->vram_mask)] = dat; \
     xga->changedvram[(((addr)) & (xga->vram_mask)) >> 12] = changeframecount;
 
-#define WRITEW_REVERSE(addr, dat)                                       \
-    xga->vram[((addr + 1)) & (xga->vram_mask - 1)]        = dat & 0xff; \
-    xga->vram[((addr)) & (xga->vram_mask - 1)]            = dat >> 8;   \
+#define WRITEW_REVERSE(addr, dat) \
+    xga->vram[((addr + 1)) & (xga->vram_mask - 1)] = dat & 0xff; \
+    xga->vram[((addr)) & (xga->vram_mask - 1)] = dat >> 8; \
     xga->changedvram[(((addr)) & (xga->vram_mask)) >> 12] = changeframecount;
 
-#define ROP(mix, d, s)                                                                 \
-    {                                                                                  \
-        switch ((mix) ? (xga->accel.frgd_mix & 0x1f) : (xga->accel.bkgd_mix & 0x1f)) { \
-            case 0x00:                                                                 \
-                d = 0;                                                                 \
-                break;                                                                 \
-            case 0x01:                                                                 \
-                d = s & d;                                                             \
-                break;                                                                 \
-            case 0x02:                                                                 \
-                d = s & ~d;                                                            \
-                break;                                                                 \
-            case 0x03:                                                                 \
-                d = s;                                                                 \
-                break;                                                                 \
-            case 0x04:                                                                 \
-                d = ~s & d;                                                            \
-                break;                                                                 \
-            case 0x05:                                                                 \
-                d = d;                                                                 \
-                break;                                                                 \
-            case 0x06:                                                                 \
-                d = s ^ d;                                                             \
-                break;                                                                 \
-            case 0x07:                                                                 \
-                d = s | d;                                                             \
-                break;                                                                 \
-            case 0x08:                                                                 \
-                d = ~s & ~d;                                                           \
-                break;                                                                 \
-            case 0x09:                                                                 \
-                d = s ^ ~d;                                                            \
-                break;                                                                 \
-            case 0x0a:                                                                 \
-                d = ~d;                                                                \
-                break;                                                                 \
-            case 0x0b:                                                                 \
-                d = s | ~d;                                                            \
-                break;                                                                 \
-            case 0x0c:                                                                 \
-                d = ~s;                                                                \
-                break;                                                                 \
-            case 0x0d:                                                                 \
-                d = ~s | d;                                                            \
-                break;                                                                 \
-            case 0x0e:                                                                 \
-                d = ~s | ~d;                                                           \
-                break;                                                                 \
-            case 0x0f:                                                                 \
-                d = ~0;                                                                \
-                break;                                                                 \
-            case 0x10:                                                                 \
-                d = MAX(s, d);                                                         \
-                break;                                                                 \
-            case 0x11:                                                                 \
-                d = MIN(s, d);                                                         \
-                break;                                                                 \
-            case 0x12:                                                                 \
-                d = MIN(0xff, s + d);                                                  \
-                break;                                                                 \
-            case 0x13:                                                                 \
-                d = MAX(0, d - s);                                                     \
-                break;                                                                 \
-            case 0x14:                                                                 \
-                d = MAX(0, s - d);                                                     \
-                break;                                                                 \
-            case 0x15:                                                                 \
-                d = (s + d) >> 1;                                                      \
-                break;                                                                 \
-        }                                                                              \
-    }
+#define ROP(mix, d, s) { \
+    switch ((mix) ? (xga->accel.frgd_mix & 0x1f) : (xga->accel.bkgd_mix & 0x1f)) {	\
+        case 0x00: d = 0; break; \
+        case 0x01: d = s & d; break; \
+        case 0x02: d = s & ~d; break; \
+        case 0x03: d = s; break; \
+        case 0x04: d = ~s & d; break; \
+        case 0x05: d = d; break; \
+        case 0x06: d = s ^ d; break; \
+        case 0x07: d = s | d; break; \
+        case 0x08: d = ~s & ~d; break; \
+        case 0x09: d = s ^ ~d; break; \
+        case 0x0a: d = ~d; break; \
+        case 0x0b: d = s | ~d; break; \
+        case 0x0c: d = ~s; break; \
+        case 0x0d: d = ~s | d; break; \
+        case 0x0e: d = ~s | ~d; break; \
+        case 0x0f: d = ~0; break; \
+        case 0x10: d = MAX(s, d); break; \
+        case 0x11: d = MIN(s, d); break; \
+        case 0x12: d = MIN(0xff, s + d); break; \
+        case 0x13: d = MAX(0, d - s); break; \
+        case 0x14: d = MAX(0, s - d); break; \
+        case 0x15: d = (s + d) >> 1; break; \
+    } \
+ }
 
 static uint32_t
 xga_accel_read_pattern_map_pixel(svga_t *svga, int x, int y, int map, uint32_t base, int width)
 {
-    xga_t   *xga  = &svga->xga;
+    xga_t *xga = &svga->xga;
     uint32_t addr = base;
-    int      bits;
+    int bits;
     uint32_t byte;
-    uint8_t  px;
-    int      skip = 0;
+    uint8_t px;
+    int skip = 0;
 
     if (xga->base_addr_1mb) {
         if (addr < xga->base_addr_1mb || (addr > (xga->base_addr_1mb + 0xfffff)))
@@ -803,15 +759,16 @@ xga_accel_read_pattern_map_pixel(svga_t *svga, int x, int y, int map, uint32_t b
     return px;
 }
 
+
 static uint32_t
 xga_accel_read_map_pixel(svga_t *svga, int x, int y, int map, uint32_t base, int width)
 {
-    xga_t   *xga  = &svga->xga;
+    xga_t *xga = &svga->xga;
     uint32_t addr = base;
-    int      bits;
+    int bits;
     uint32_t byte;
-    uint8_t  px;
-    int      skip = 0;
+    uint8_t px;
+    int skip = 0;
 
     if (xga->base_addr_1mb) {
         if (addr < xga->base_addr_1mb || (addr > (xga->base_addr_1mb + 0xfffff)))
@@ -874,10 +831,10 @@ xga_accel_read_map_pixel(svga_t *svga, int x, int y, int map, uint32_t base, int
 static void
 xga_accel_write_map_pixel(svga_t *svga, int x, int y, int map, uint32_t base, uint32_t pixel, int width)
 {
-    xga_t   *xga  = &svga->xga;
+    xga_t *xga = &svga->xga;
     uint32_t addr = base;
-    uint8_t  byte, mask;
-    int      skip = 0;
+    uint8_t byte, mask;
+    int skip = 0;
 
     if (xga->base_addr_1mb) {
         if (addr < xga->base_addr_1mb || (addr > (xga->base_addr_1mb + 0xfffff)))
@@ -891,11 +848,11 @@ xga_accel_write_map_pixel(svga_t *svga, int x, int y, int map, uint32_t base, ui
         case 0: /*1-bit*/
             addr += (y * (width) >> 3);
             addr += (x >> 3);
-            if (!skip) {
+			if (!skip) {
                 READ(addr, byte);
-            } else {
+			} else {
                 byte = mem_readb_phys(addr);
-            }
+			}
             if ((xga->accel.px_map_format[map] & 8) && !(xga->access_mode & 8)) {
                 if (xga->linear_endian_reverse)
                     mask = 1 << (7 - (x & 7));
@@ -948,15 +905,15 @@ xga_accel_write_map_pixel(svga_t *svga, int x, int y, int map, uint32_t base, ui
 static void
 xga_short_stroke(svga_t *svga, uint8_t ssv)
 {
-    xga_t   *xga = &svga->xga;
+    xga_t *xga = &svga->xga;
     uint32_t src_dat, dest_dat, old_dest_dat;
-    uint32_t color_cmp  = xga->accel.color_cmp;
+    uint32_t color_cmp = xga->accel.color_cmp;
     uint32_t plane_mask = xga->accel.plane_mask;
-    uint32_t dstbase    = xga->accel.px_map_base[xga->accel.dst_map];
-    uint32_t srcbase    = xga->accel.px_map_base[xga->accel.src_map];
-    int      y          = ssv & 0x0f;
-    int      x          = 0;
-    int      dx, dy, dirx = 0, diry = 0;
+    uint32_t dstbase = xga->accel.px_map_base[xga->accel.dst_map];
+    uint32_t srcbase = xga->accel.px_map_base[xga->accel.src_map];
+    int y = ssv & 0x0f;
+    int x = 0;
+    int dx, dy, dirx = 0, diry = 0;
 
     dx = xga->accel.dst_map_x & 0x1fff;
     if (xga->accel.dst_map_x & 0x1800)
@@ -1004,11 +961,18 @@ xga_short_stroke(svga_t *svga, uint8_t ssv)
     if (xga->accel.pat_src == 8) {
         while (y >= 0) {
             if (xga->accel.command & 0xc0) {
-                if ((dx >= xga->accel.mask_map_origin_x_off) && (dx <= ((xga->accel.px_map_width[0] & 0xfff) + xga->accel.mask_map_origin_x_off)) && (dy >= xga->accel.mask_map_origin_y_off) && (dy <= ((xga->accel.px_map_height[0] & 0xfff) + xga->accel.mask_map_origin_y_off))) {
-                    src_dat  = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
+                if ((dx >= xga->accel.mask_map_origin_x_off) && (dx <= ((xga->accel.px_map_width[0] & 0xfff) + xga->accel.mask_map_origin_x_off)) &&
+                    (dy >= xga->accel.mask_map_origin_y_off) && (dy <= ((xga->accel.px_map_height[0] & 0xfff) + xga->accel.mask_map_origin_y_off))) {
+                    src_dat = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
                     dest_dat = xga_accel_read_map_pixel(svga, dx, dy, xga->accel.dst_map, dstbase, xga->accel.px_map_width[xga->accel.dst_map] + 1);
 
-                    if ((xga->accel.cc_cond == 4) || ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) || ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) || ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) || ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) || ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) || ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
+                    if ((xga->accel.cc_cond == 4) ||
+                        ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) ||
+                        ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) ||
+                        ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) ||
+                        ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) ||
+                        ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) ||
+                        ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
                         old_dest_dat = dest_dat;
                         ROP(1, dest_dat, src_dat);
                         dest_dat = (dest_dat & plane_mask) | (old_dest_dat & ~plane_mask);
@@ -1025,10 +989,16 @@ xga_short_stroke(svga_t *svga, uint8_t ssv)
                     }
                 }
             } else {
-                src_dat  = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
+                src_dat = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
                 dest_dat = xga_accel_read_map_pixel(svga, dx, dy, xga->accel.dst_map, dstbase, xga->accel.px_map_width[xga->accel.dst_map] + 1);
 
-                if ((xga->accel.cc_cond == 4) || ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) || ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) || ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) || ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) || ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) || ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
+                if ((xga->accel.cc_cond == 4) ||
+                    ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) ||
+                    ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) ||
+                    ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) ||
+                    ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) ||
+                    ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) ||
+                    ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
                     old_dest_dat = dest_dat;
                     ROP(1, dest_dat, src_dat);
                     dest_dat = (dest_dat & plane_mask) | (old_dest_dat & ~plane_mask);
@@ -1061,40 +1031,37 @@ xga_short_stroke(svga_t *svga, uint8_t ssv)
     xga->accel.dst_map_y = dy;
 }
 
-#define SWAP(a, b) \
-    tmpswap = a;   \
-    a       = b;   \
-    b       = tmpswap;
+#define SWAP(a,b) tmpswap = a; a = b; b = tmpswap;
 
 static void
 xga_line_draw_write(svga_t *svga)
 {
-    xga_t   *xga = &svga->xga;
+    xga_t *xga = &svga->xga;
     uint32_t src_dat, dest_dat, old_dest_dat;
-    uint32_t color_cmp  = xga->accel.color_cmp;
+    uint32_t color_cmp = xga->accel.color_cmp;
     uint32_t plane_mask = xga->accel.plane_mask;
-    uint32_t dstbase    = xga->accel.px_map_base[xga->accel.dst_map];
-    uint32_t srcbase    = xga->accel.px_map_base[xga->accel.src_map];
-    int      dminor, destxtmp, dmajor, err, tmpswap;
-    int      steep = 1;
-    int      xdir, ydir;
-    int      y = xga->accel.blt_width;
-    int      x = 0;
-    int      dx, dy;
+    uint32_t dstbase = xga->accel.px_map_base[xga->accel.dst_map];
+    uint32_t srcbase = xga->accel.px_map_base[xga->accel.src_map];
+    int dminor, destxtmp, dmajor, err, tmpswap;
+    int steep = 1;
+    int xdir, ydir;
+    int y = xga->accel.blt_width;
+    int x = 0;
+    int dx, dy;
 
-    dminor = ((int16_t) xga->accel.bres_k1);
-    if (xga->accel.bres_k1 & 0x2000)
+	dminor = ((int16_t)xga->accel.bres_k1);
+	if (xga->accel.bres_k1 & 0x2000)
         dminor |= ~0x1fff;
-    dminor >>= 1;
+	dminor >>= 1;
 
-    destxtmp = ((int16_t) xga->accel.bres_k2);
-    if (xga->accel.bres_k2 & 0x2000)
+	destxtmp = ((int16_t)xga->accel.bres_k2);
+	if (xga->accel.bres_k2 & 0x2000)
         destxtmp |= ~0x1fff;
 
     dmajor = -(destxtmp - (dminor << 1)) >> 1;
 
-    err = ((int16_t) xga->accel.bres_err_term);
-    if (xga->accel.bres_err_term & 0x2000)
+	err = ((int16_t)xga->accel.bres_err_term);
+	if (xga->accel.bres_err_term & 0x2000)
         destxtmp |= ~0x1fff;
 
     if (xga->accel.octant & 0x02) {
@@ -1118,20 +1085,27 @@ xga_line_draw_write(svga_t *svga)
         dy |= ~0x17ff;
 
     if (xga->accel.octant & 0x01) {
-        steep = 0;
-        SWAP(dx, dy);
-        SWAP(xdir, ydir);
+		steep = 0;
+		SWAP(dx, dy);
+		SWAP(xdir, ydir);
     }
 
     if (xga->accel.pat_src == 8) {
         while (y >= 0) {
             if (xga->accel.command & 0xc0) {
                 if (steep) {
-                    if ((dx >= xga->accel.mask_map_origin_x_off) && (dx <= ((xga->accel.px_map_width[0] & 0xfff) + xga->accel.mask_map_origin_x_off)) && (dy >= xga->accel.mask_map_origin_y_off) && (dy <= ((xga->accel.px_map_height[0] & 0xfff) + xga->accel.mask_map_origin_y_off))) {
-                        src_dat  = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
+                    if ((dx >= xga->accel.mask_map_origin_x_off) && (dx <= ((xga->accel.px_map_width[0] & 0xfff) + xga->accel.mask_map_origin_x_off)) &&
+                        (dy >= xga->accel.mask_map_origin_y_off) && (dy <= ((xga->accel.px_map_height[0] & 0xfff) + xga->accel.mask_map_origin_y_off))) {
+                        src_dat = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
                         dest_dat = xga_accel_read_map_pixel(svga, dx, dy, xga->accel.dst_map, dstbase, xga->accel.px_map_width[xga->accel.dst_map] + 1);
 
-                        if ((xga->accel.cc_cond == 4) || ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) || ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) || ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) || ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) || ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) || ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
+                        if ((xga->accel.cc_cond == 4) ||
+                            ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) ||
+                            ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) ||
+                            ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) ||
+                            ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) ||
+                            ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) ||
+                            ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
                             old_dest_dat = dest_dat;
                             ROP(1, dest_dat, src_dat);
                             dest_dat = (dest_dat & plane_mask) | (old_dest_dat & ~plane_mask);
@@ -1144,11 +1118,18 @@ xga_line_draw_write(svga_t *svga)
                         }
                     }
                 } else {
-                    if ((dy >= xga->accel.mask_map_origin_x_off) && (dy <= ((xga->accel.px_map_width[0] & 0xfff) + xga->accel.mask_map_origin_x_off)) && (dx >= xga->accel.mask_map_origin_y_off) && (dx <= ((xga->accel.px_map_height[0] & 0xfff) + xga->accel.mask_map_origin_y_off))) {
-                        src_dat  = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
+                    if ((dy >= xga->accel.mask_map_origin_x_off) && (dy <= ((xga->accel.px_map_width[0] & 0xfff) + xga->accel.mask_map_origin_x_off)) &&
+                        (dx >= xga->accel.mask_map_origin_y_off) && (dx <= ((xga->accel.px_map_height[0] & 0xfff) + xga->accel.mask_map_origin_y_off))) {
+                        src_dat = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
                         dest_dat = xga_accel_read_map_pixel(svga, dy, dx, xga->accel.dst_map, dstbase, xga->accel.px_map_width[xga->accel.dst_map] + 1);
 
-                        if ((xga->accel.cc_cond == 4) || ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) || ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) || ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) || ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) || ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) || ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
+                        if ((xga->accel.cc_cond == 4) ||
+                            ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) ||
+                            ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) ||
+                            ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) ||
+                            ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) ||
+                            ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) ||
+                            ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
                             old_dest_dat = dest_dat;
                             ROP(1, dest_dat, src_dat);
                             dest_dat = (dest_dat & plane_mask) | (old_dest_dat & ~plane_mask);
@@ -1163,10 +1144,16 @@ xga_line_draw_write(svga_t *svga)
                 }
             } else {
                 if (steep) {
-                    src_dat  = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
+                    src_dat = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
                     dest_dat = xga_accel_read_map_pixel(svga, dx, dy, xga->accel.dst_map, dstbase, xga->accel.px_map_width[xga->accel.dst_map] + 1);
 
-                    if ((xga->accel.cc_cond == 4) || ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) || ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) || ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) || ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) || ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) || ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
+                    if ((xga->accel.cc_cond == 4) ||
+                        ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) ||
+                        ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) ||
+                        ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) ||
+                        ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) ||
+                        ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) ||
+                        ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
                         old_dest_dat = dest_dat;
                         ROP(1, dest_dat, src_dat);
                         dest_dat = (dest_dat & plane_mask) | (old_dest_dat & ~plane_mask);
@@ -1178,10 +1165,16 @@ xga_line_draw_write(svga_t *svga)
                             xga_accel_write_map_pixel(svga, dx, dy, xga->accel.dst_map, dstbase, dest_dat, xga->accel.px_map_width[xga->accel.dst_map] + 1);
                     }
                 } else {
-                    src_dat  = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
+                    src_dat = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
                     dest_dat = xga_accel_read_map_pixel(svga, dy, dx, xga->accel.dst_map, dstbase, xga->accel.px_map_width[xga->accel.dst_map] + 1);
 
-                    if ((xga->accel.cc_cond == 4) || ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) || ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) || ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) || ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) || ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) || ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
+                    if ((xga->accel.cc_cond == 4) ||
+                        ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) ||
+                        ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) ||
+                        ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) ||
+                        ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) ||
+                        ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) ||
+                        ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
                         old_dest_dat = dest_dat;
                         ROP(1, dest_dat, src_dat);
                         dest_dat = (dest_dat & plane_mask) | (old_dest_dat & ~plane_mask);
@@ -1221,6 +1214,7 @@ xga_line_draw_write(svga_t *svga)
     }
 }
 
+
 static int16_t
 xga_dst_wrap(int16_t addr)
 {
@@ -1231,20 +1225,20 @@ xga_dst_wrap(int16_t addr)
 static void
 xga_bitblt(svga_t *svga)
 {
-    xga_t   *xga = &svga->xga;
+    xga_t *xga = &svga->xga;
     uint32_t src_dat, dest_dat, old_dest_dat;
-    uint32_t color_cmp  = xga->accel.color_cmp;
+    uint32_t color_cmp = xga->accel.color_cmp;
     uint32_t plane_mask = xga->accel.plane_mask;
-    uint32_t patbase    = xga->accel.px_map_base[xga->accel.pat_src];
-    uint32_t dstbase    = xga->accel.px_map_base[xga->accel.dst_map];
-    uint32_t srcbase    = xga->accel.px_map_base[xga->accel.src_map];
-    uint32_t patwidth   = xga->accel.px_map_width[xga->accel.pat_src];
-    uint32_t dstwidth   = xga->accel.px_map_width[xga->accel.dst_map];
-    uint32_t srcwidth   = xga->accel.px_map_width[xga->accel.src_map];
-    uint32_t patheight  = xga->accel.px_map_height[xga->accel.pat_src];
-    uint32_t srcheight  = xga->accel.px_map_height[xga->accel.src_map];
-    int      mix        = 0;
-    int      xdir, ydir;
+    uint32_t patbase = xga->accel.px_map_base[xga->accel.pat_src];
+    uint32_t dstbase = xga->accel.px_map_base[xga->accel.dst_map];
+    uint32_t srcbase = xga->accel.px_map_base[xga->accel.src_map];
+    uint32_t patwidth = xga->accel.px_map_width[xga->accel.pat_src];
+    uint32_t dstwidth = xga->accel.px_map_width[xga->accel.dst_map];
+    uint32_t srcwidth = xga->accel.px_map_width[xga->accel.src_map];
+    uint32_t patheight = xga->accel.px_map_height[xga->accel.pat_src];
+    uint32_t srcheight = xga->accel.px_map_height[xga->accel.src_map];
+    int mix = 0;
+    int xdir, ydir;
 
     if (xga->accel.octant & 0x02) {
         ydir = -1;
@@ -1283,15 +1277,22 @@ xga_bitblt(svga_t *svga)
             }
         }
 
-        // pclog("Pattern Map = 8: CMD = %08x: SRCBase = %08x, DSTBase = %08x, from/to vram dir = %d, cmd dir = %06x\n", xga->accel.command, srcbase, dstbase, xga->from_to_vram, xga->accel.dir_cmd);
-        // pclog("CMD = %08x: Y = %d, X = %d, patsrc = %02x, srcmap = %d, dstmap = %d, py = %d, sy = %d, dy = %d, width0 = %d, width1 = %d, width2 = %d, width3 = %d\n", xga->accel.command, xga->accel.y, xga->accel.x, xga->accel.pat_src, xga->accel.src_map, xga->accel.dst_map, xga->accel.py, xga->accel.sy, xga->accel.dy, xga->accel.px_map_width[0], xga->accel.px_map_width[1], xga->accel.px_map_width[2], xga->accel.px_map_width[3]);
+        //pclog("Pattern Map = 8: CMD = %08x: SRCBase = %08x, DSTBase = %08x, from/to vram dir = %d, cmd dir = %06x\n", xga->accel.command, srcbase, dstbase, xga->from_to_vram, xga->accel.dir_cmd);
+        //pclog("CMD = %08x: Y = %d, X = %d, patsrc = %02x, srcmap = %d, dstmap = %d, py = %d, sy = %d, dy = %d, width0 = %d, width1 = %d, width2 = %d, width3 = %d\n", xga->accel.command, xga->accel.y, xga->accel.x, xga->accel.pat_src, xga->accel.src_map, xga->accel.dst_map, xga->accel.py, xga->accel.sy, xga->accel.dy, xga->accel.px_map_width[0], xga->accel.px_map_width[1], xga->accel.px_map_width[2], xga->accel.px_map_width[3]);
         while (xga->accel.y >= 0) {
             if (xga->accel.command & 0xc0) {
-                if ((xga->accel.dx >= xga->accel.mask_map_origin_x_off) && (xga->accel.dx <= ((xga->accel.px_map_width[0] & 0xfff) + xga->accel.mask_map_origin_x_off)) && (xga->accel.dy >= xga->accel.mask_map_origin_y_off) && (xga->accel.dy <= ((xga->accel.px_map_height[0] & 0xfff) + xga->accel.mask_map_origin_y_off))) {
-                    src_dat  = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.sx, xga->accel.sy, xga->accel.src_map, srcbase, srcwidth + 1) : xga->accel.frgd_color;
+                if ((xga->accel.dx >= xga->accel.mask_map_origin_x_off) && (xga->accel.dx <= ((xga->accel.px_map_width[0] & 0xfff) + xga->accel.mask_map_origin_x_off)) &&
+                    (xga->accel.dy >= xga->accel.mask_map_origin_y_off) && (xga->accel.dy <= ((xga->accel.px_map_height[0] & 0xfff) + xga->accel.mask_map_origin_y_off))) {
+                    src_dat = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.sx, xga->accel.sy, xga->accel.src_map, srcbase, srcwidth + 1) : xga->accel.frgd_color;
                     dest_dat = xga_accel_read_map_pixel(svga, xga->accel.dx, xga->accel.dy, xga->accel.dst_map, dstbase, dstwidth + 1);
 
-                    if ((xga->accel.cc_cond == 4) || ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) || ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) || ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) || ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) || ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) || ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
+                    if ((xga->accel.cc_cond == 4) ||
+                        ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) ||
+                        ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) ||
+                        ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) ||
+                        ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) ||
+                        ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) ||
+                        ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
                         old_dest_dat = dest_dat;
                         ROP(1, dest_dat, src_dat);
                         dest_dat = (dest_dat & plane_mask) | (old_dest_dat & ~plane_mask);
@@ -1299,10 +1300,16 @@ xga_bitblt(svga_t *svga)
                     }
                 }
             } else {
-                src_dat  = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.sx, xga->accel.sy, xga->accel.src_map, srcbase, srcwidth + 1) : xga->accel.frgd_color;
+                src_dat = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.sx, xga->accel.sy, xga->accel.src_map, srcbase, srcwidth + 1) : xga->accel.frgd_color;
                 dest_dat = xga_accel_read_map_pixel(svga, xga->accel.dx, xga->accel.dy, xga->accel.dst_map, dstbase, dstwidth + 1);
 
-                if ((xga->accel.cc_cond == 4) || ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) || ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) || ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) || ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) || ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) || ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
+                if ((xga->accel.cc_cond == 4) ||
+                    ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) ||
+                    ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) ||
+                    ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) ||
+                    ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) ||
+                    ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) ||
+                    ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
                     old_dest_dat = dest_dat;
                     ROP(1, dest_dat, src_dat);
                     dest_dat = (dest_dat & plane_mask) | (old_dest_dat & ~plane_mask);
@@ -1361,13 +1368,14 @@ xga_bitblt(svga_t *svga)
             }
         }
 
-        // pclog("Pattern Map = %d: CMD = %08x: PATBase = %08x, SRCBase = %08x, DSTBase = %08x\n", xga->accel.pat_src, xga->accel.command, patbase, srcbase, dstbase);
-        // pclog("CMD = %08x: Y = %d, X = %d, patsrc = %02x, srcmap = %d, dstmap = %d, py = %d, sy = %d, dy = %d, width0 = %d, width1 = %d, width2 = %d, width3 = %d\n", xga->accel.command, xga->accel.y, xga->accel.x, xga->accel.pat_src, xga->accel.src_map, xga->accel.dst_map, xga->accel.py, xga->accel.sy, xga->accel.dy, xga->accel.px_map_width[0], xga->accel.px_map_width[1], xga->accel.px_map_width[2], xga->accel.px_map_width[3]);
+        //pclog("Pattern Map = %d: CMD = %08x: PATBase = %08x, SRCBase = %08x, DSTBase = %08x\n", xga->accel.pat_src, xga->accel.command, patbase, srcbase, dstbase);
+        //pclog("CMD = %08x: Y = %d, X = %d, patsrc = %02x, srcmap = %d, dstmap = %d, py = %d, sy = %d, dy = %d, width0 = %d, width1 = %d, width2 = %d, width3 = %d\n", xga->accel.command, xga->accel.y, xga->accel.x, xga->accel.pat_src, xga->accel.src_map, xga->accel.dst_map, xga->accel.py, xga->accel.sy, xga->accel.dy, xga->accel.px_map_width[0], xga->accel.px_map_width[1], xga->accel.px_map_width[2], xga->accel.px_map_width[3]);
         while (xga->accel.y >= 0) {
             mix = xga_accel_read_pattern_map_pixel(svga, xga->accel.px, xga->accel.py, xga->accel.pat_src, patbase, patwidth + 1);
 
             if (xga->accel.command & 0xc0) {
-                if ((xga->accel.dx >= xga->accel.mask_map_origin_x_off) && (xga->accel.dx <= ((xga->accel.px_map_width[0] & 0xfff) + xga->accel.mask_map_origin_x_off)) && (xga->accel.dy >= xga->accel.mask_map_origin_y_off) && (xga->accel.dy <= ((xga->accel.px_map_height[0] & 0xfff) + xga->accel.mask_map_origin_y_off))) {
+                if ((xga->accel.dx >= xga->accel.mask_map_origin_x_off) && (xga->accel.dx <= ((xga->accel.px_map_width[0] & 0xfff) + xga->accel.mask_map_origin_x_off)) &&
+                    (xga->accel.dy >= xga->accel.mask_map_origin_y_off) && (xga->accel.dy <= ((xga->accel.px_map_height[0] & 0xfff) + xga->accel.mask_map_origin_y_off))) {
                     if (mix)
                         src_dat = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.sx, xga->accel.sy, xga->accel.src_map, srcbase, srcwidth + 1) : xga->accel.frgd_color;
                     else
@@ -1375,7 +1383,13 @@ xga_bitblt(svga_t *svga)
 
                     dest_dat = xga_accel_read_map_pixel(svga, xga->accel.dx, xga->accel.dy, xga->accel.dst_map, dstbase, dstwidth + 1);
 
-                    if ((xga->accel.cc_cond == 4) || ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) || ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) || ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) || ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) || ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) || ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
+                    if ((xga->accel.cc_cond == 4) ||
+                        ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) ||
+                        ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) ||
+                        ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) ||
+                        ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) ||
+                        ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) ||
+                        ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
                         old_dest_dat = dest_dat;
                         ROP(mix, dest_dat, src_dat);
                         dest_dat = (dest_dat & plane_mask) | (old_dest_dat & ~plane_mask);
@@ -1390,13 +1404,20 @@ xga_bitblt(svga_t *svga)
 
                 dest_dat = xga_accel_read_map_pixel(svga, xga->accel.dx, xga->accel.dy, xga->accel.dst_map, dstbase, dstwidth + 1);
 
-                if ((xga->accel.cc_cond == 4) || ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) || ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) || ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) || ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) || ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) || ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
+                if ((xga->accel.cc_cond == 4) ||
+                    ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) ||
+                    ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) ||
+                    ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) ||
+                    ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) ||
+                    ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) ||
+                    ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
                     old_dest_dat = dest_dat;
                     ROP(mix, dest_dat, src_dat);
                     dest_dat = (dest_dat & plane_mask) | (old_dest_dat & ~plane_mask);
                     xga_accel_write_map_pixel(svga, xga->accel.dx, xga->accel.dy, xga->accel.dst_map, dstbase, dest_dat, dstwidth + 1);
                 }
             }
+
 
             xga->accel.sx += xdir;
             if (xga->accel.pattern)
@@ -1466,7 +1487,7 @@ xga_mem_write(uint32_t addr, uint32_t val, xga_t *xga, svga_t *svga, int len)
 
             case 0x18:
                 if (len == 4) {
-                    xga->accel.px_map_width[xga->accel.px_map_idx]  = val & 0xffff;
+                    xga->accel.px_map_width[xga->accel.px_map_idx] = val & 0xffff;
                     xga->accel.px_map_height[xga->accel.px_map_idx] = (val >> 16) & 0xffff;
                 } else if (len == 2) {
                     xga->accel.px_map_width[xga->accel.px_map_idx] = val & 0xffff;
@@ -1543,13 +1564,13 @@ xga_mem_write(uint32_t addr, uint32_t val, xga_t *xga, svga_t *svga, int len)
 
             case 0x2c:
                 if (len == 4) {
-                    xga->accel.short_stroke         = val;
+                    xga->accel.short_stroke = val;
                     xga->accel.short_stroke_vector1 = xga->accel.short_stroke & 0xff;
                     xga->accel.short_stroke_vector2 = (xga->accel.short_stroke >> 8) & 0xff;
                     xga->accel.short_stroke_vector3 = (xga->accel.short_stroke >> 16) & 0xff;
                     xga->accel.short_stroke_vector4 = (xga->accel.short_stroke >> 24) & 0xff;
 
-                    // pclog("1Vector = %02x, 2Vector = %02x, 3Vector = %02x, 4Vector = %02x\n", xga->accel.short_stroke_vector1, xga->accel.short_stroke_vector2, xga->accel.short_stroke_vector3, xga->accel.short_stroke_vector4);
+                    //pclog("1Vector = %02x, 2Vector = %02x, 3Vector = %02x, 4Vector = %02x\n", xga->accel.short_stroke_vector1, xga->accel.short_stroke_vector2, xga->accel.short_stroke_vector3, xga->accel.short_stroke_vector4);
                     xga_short_stroke(svga, xga->accel.short_stroke_vector1);
                     xga_short_stroke(svga, xga->accel.short_stroke_vector2);
                     xga_short_stroke(svga, xga->accel.short_stroke_vector3);
@@ -1579,7 +1600,7 @@ xga_mem_write(uint32_t addr, uint32_t val, xga_t *xga, svga_t *svga, int len)
                 xga->accel.frgd_mix = val & 0xff;
                 if (len == 4) {
                     xga->accel.bkgd_mix = (val >> 8) & 0xff;
-                    xga->accel.cc_cond  = (val >> 16) & 0x07;
+                    xga->accel.cc_cond = (val >> 16) & 0x07;
                 } else if (len == 2) {
                     xga->accel.bkgd_mix = (val >> 8) & 0xff;
                 }
@@ -1687,7 +1708,7 @@ xga_mem_write(uint32_t addr, uint32_t val, xga_t *xga, svga_t *svga, int len)
 
             case 0x60:
                 if (len == 4) {
-                    xga->accel.blt_width  = val & 0xffff;
+                    xga->accel.blt_width = val & 0xffff;
                     xga->accel.blt_height = (val >> 16) & 0xffff;
                 } else if (len == 2) {
                     xga->accel.blt_width = val;
@@ -1814,30 +1835,30 @@ xga_mem_write(uint32_t addr, uint32_t val, xga_t *xga, svga_t *svga, int len)
                 if (len == 4) {
                     xga->accel.command = val;
 exec_command:
-                    xga->accel.octant    = xga->accel.command & 0x07;
+                    xga->accel.octant = xga->accel.command & 0x07;
                     xga->accel.draw_mode = xga->accel.command & 0x30;
                     xga->accel.mask_mode = xga->accel.command & 0xc0;
-                    xga->accel.pat_src   = ((xga->accel.command >> 12) & 0x0f);
-                    xga->accel.dst_map   = ((xga->accel.command >> 16) & 0x0f);
-                    xga->accel.src_map   = ((xga->accel.command >> 20) & 0x0f);
+                    xga->accel.pat_src = ((xga->accel.command >> 12) & 0x0f);
+                    xga->accel.dst_map = ((xga->accel.command >> 16) & 0x0f);
+                    xga->accel.src_map = ((xga->accel.command >> 20) & 0x0f);
 
-                    // if (xga->accel.pat_src) {
-                    //     pclog("[%04X:%08X]: Accel Command = %02x, full = %08x, patwidth = %d, dstwidth = %d, srcwidth = %d, patheight = %d, dstheight = %d, srcheight = %d, px = %d, py = %d, dx = %d, dy = %d, sx = %d, sy = %d, patsrc = %d, dstmap = %d, srcmap = %d, dstbase = %08x, srcbase = %08x, patbase = %08x, dstformat = %x, srcformat = %x, planemask = %08x\n",
-                    //       CS, cpu_state.pc, ((xga->accel.command >> 24) & 0x0f), xga->accel.command, xga->accel.px_map_width[xga->accel.pat_src],
-                    //       xga->accel.px_map_width[xga->accel.dst_map], xga->accel.px_map_width[xga->accel.src_map],
-                    //       xga->accel.px_map_height[xga->accel.pat_src], xga->accel.px_map_height[xga->accel.dst_map],
-                    //       xga->accel.px_map_height[xga->accel.src_map],
-                    //       xga->accel.pat_map_x, xga->accel.pat_map_y,
-                    //       xga->accel.dst_map_x, xga->accel.dst_map_y,
-                    //       xga->accel.src_map_x, xga->accel.src_map_y,
-                    //       xga->accel.pat_src, xga->accel.dst_map, xga->accel.src_map,
-                    //       xga->accel.px_map_base[xga->accel.dst_map], xga->accel.px_map_base[xga->accel.src_map], xga->accel.px_map_base[xga->accel.pat_src],
-                    //       xga->accel.px_map_format[xga->accel.dst_map] & 0x0f, xga->accel.px_map_format[xga->accel.src_map] & 0x0f, xga->accel.plane_mask);
-                    //     //pclog("\n");
-                    // }
+                    //if (xga->accel.pat_src) {
+                    //    pclog("[%04X:%08X]: Accel Command = %02x, full = %08x, patwidth = %d, dstwidth = %d, srcwidth = %d, patheight = %d, dstheight = %d, srcheight = %d, px = %d, py = %d, dx = %d, dy = %d, sx = %d, sy = %d, patsrc = %d, dstmap = %d, srcmap = %d, dstbase = %08x, srcbase = %08x, patbase = %08x, dstformat = %x, srcformat = %x, planemask = %08x\n",
+                    //      CS, cpu_state.pc, ((xga->accel.command >> 24) & 0x0f), xga->accel.command, xga->accel.px_map_width[xga->accel.pat_src],
+                    //      xga->accel.px_map_width[xga->accel.dst_map], xga->accel.px_map_width[xga->accel.src_map],
+                    //      xga->accel.px_map_height[xga->accel.pat_src], xga->accel.px_map_height[xga->accel.dst_map],
+                    //      xga->accel.px_map_height[xga->accel.src_map],
+                    //      xga->accel.pat_map_x, xga->accel.pat_map_y,
+                    //      xga->accel.dst_map_x, xga->accel.dst_map_y,
+                    //      xga->accel.src_map_x, xga->accel.src_map_y,
+                    //      xga->accel.pat_src, xga->accel.dst_map, xga->accel.src_map,
+                    //      xga->accel.px_map_base[xga->accel.dst_map], xga->accel.px_map_base[xga->accel.src_map], xga->accel.px_map_base[xga->accel.pat_src],
+                    //      xga->accel.px_map_format[xga->accel.dst_map] & 0x0f, xga->accel.px_map_format[xga->accel.src_map] & 0x0f, xga->accel.plane_mask);
+                    //    //pclog("\n");
+                    //}
                     switch ((xga->accel.command >> 24) & 0x0f) {
                         case 3: /*Bresenham Line Draw Read*/
-                            // pclog("Line Draw Read\n");
+                            //pclog("Line Draw Read\n");
                             break;
                         case 4: /*Short Stroke Vectors*/
                             break;
@@ -1848,7 +1869,7 @@ exec_command:
                             xga_bitblt(svga);
                             break;
                         case 9: /*Inverting BitBLT*/
-                            // pclog("Inverting BitBLT\n");
+                            //pclog("Inverting BitBLT\n");
                             break;
                     }
                 } else if (len == 2) {
@@ -1880,31 +1901,31 @@ exec_command:
 static void
 xga_memio_writeb(uint32_t addr, uint8_t val, void *p)
 {
-    svga_t *svga = (svga_t *) p;
-    xga_t  *xga  = &svga->xga;
+    svga_t *svga = (svga_t *)p;
+    xga_t *xga = &svga->xga;
 
     xga_mem_write(addr, val, xga, svga, 1);
-    // pclog("Write MEMIOB = %04x, val = %02x\n", addr & 0x7f, val);
+    //pclog("Write MEMIOB = %04x, val = %02x\n", addr & 0x7f, val);
 }
 
 static void
 xga_memio_writew(uint32_t addr, uint16_t val, void *p)
 {
-    svga_t *svga = (svga_t *) p;
-    xga_t  *xga  = &svga->xga;
+    svga_t *svga = (svga_t *)p;
+    xga_t *xga = &svga->xga;
 
     xga_mem_write(addr, val, xga, svga, 2);
-    // pclog("Write MEMIOW = %04x, val = %04x\n", addr & 0x7f, val);
+    //pclog("Write MEMIOW = %04x, val = %04x\n", addr & 0x7f, val);
 }
 
 static void
 xga_memio_writel(uint32_t addr, uint32_t val, void *p)
 {
-    svga_t *svga = (svga_t *) p;
-    xga_t  *xga  = &svga->xga;
+    svga_t *svga = (svga_t *)p;
+    xga_t *xga = &svga->xga;
 
     xga_mem_write(addr, val, xga, svga, 4);
-    // pclog("Write MEMIOL = %04x, val = %08x\n", addr & 0x7f, val);
+    //pclog("Write MEMIOL = %04x, val = %08x\n", addr & 0x7f, val);
 }
 
 static uint8_t
@@ -1981,35 +2002,35 @@ xga_mem_read(uint32_t addr, xga_t *xga, svga_t *svga)
 static uint8_t
 xga_memio_readb(uint32_t addr, void *p)
 {
-    svga_t *svga = (svga_t *) p;
-    xga_t  *xga  = &svga->xga;
+    svga_t *svga = (svga_t *)p;
+    xga_t *xga = &svga->xga;
     uint8_t temp;
 
     temp = xga_mem_read(addr, xga, svga);
 
-    // pclog("[%04X:%08X]: Read MEMIOB = %04x, temp = %02x\n", CS, cpu_state.pc, addr, temp);
+    //pclog("[%04X:%08X]: Read MEMIOB = %04x, temp = %02x\n", CS, cpu_state.pc, addr, temp);
     return temp;
 }
 
 static uint16_t
 xga_memio_readw(uint32_t addr, void *p)
 {
-    svga_t  *svga = (svga_t *) p;
-    xga_t   *xga  = &svga->xga;
+    svga_t *svga = (svga_t *)p;
+    xga_t *xga = &svga->xga;
     uint16_t temp;
 
     temp = xga_mem_read(addr, xga, svga);
     temp |= (xga_mem_read(addr + 1, xga, svga) << 8);
 
-    // pclog("[%04X:%08X]: Read MEMIOW = %04x, temp = %04x\n", CS, cpu_state.pc, addr, temp);
+    //pclog("[%04X:%08X]: Read MEMIOW = %04x, temp = %04x\n", CS, cpu_state.pc, addr, temp);
     return temp;
 }
 
 static uint32_t
 xga_memio_readl(uint32_t addr, void *p)
 {
-    svga_t  *svga = (svga_t *) p;
-    xga_t   *xga  = &svga->xga;
+    svga_t *svga = (svga_t *)p;
+    xga_t *xga = &svga->xga;
     uint32_t temp;
 
     temp = xga_mem_read(addr, xga, svga);
@@ -2017,59 +2038,59 @@ xga_memio_readl(uint32_t addr, void *p)
     temp |= (xga_mem_read(addr + 2, xga, svga) << 16);
     temp |= (xga_mem_read(addr + 3, xga, svga) << 24);
 
-    // pclog("Read MEMIOL = %04x, temp = %08x\n", addr, temp);
+    //pclog("Read MEMIOL = %04x, temp = %08x\n", addr, temp);
     return temp;
 }
 
 static void
 xga_hwcursor_draw(svga_t *svga, int displine)
 {
-    xga_t    *xga    = &svga->xga;
-    uint8_t   dat    = 0;
-    int       offset = xga->hwcursor_latch.x - xga->hwcursor_latch.xoff;
-    int       x, x_pos, y_pos;
-    int       comb = 0;
+    xga_t *xga = &svga->xga;
+    uint8_t dat = 0;
+    int offset = xga->hwcursor_latch.x - xga->hwcursor_latch.xoff;
+    int x, x_pos, y_pos;
+    int comb = 0;
     uint32_t *p;
-    int       idx = (xga->cursor_data_on) ? 32 : 0;
+    int idx = (xga->cursor_data_on) ? 32 : 0;
 
     if (xga->interlace && xga->hwcursor_oddeven)
-        xga->hwcursor_latch.addr += 16;
+	xga->hwcursor_latch.addr += 16;
 
     y_pos = displine;
     x_pos = offset + svga->x_add;
-    p     = buffer32->line[y_pos];
+    p = buffer32->line[y_pos];
 
     for (x = 0; x < xga->hwcursor_latch.cur_xsize; x++) {
-        if (x >= idx) {
-            if (!(x & 0x03))
-                dat = xga->sprite_data[xga->hwcursor_latch.addr & 0x3ff];
+    if (x >= idx) {
+        if (!(x & 0x03))
+            dat = xga->sprite_data[xga->hwcursor_latch.addr & 0x3ff];
 
-            comb = (dat >> ((x & 0x03) << 1)) & 0x03;
+        comb = (dat >> ((x & 0x03) << 1)) & 0x03;
 
-            x_pos = offset + svga->x_add + x;
+        x_pos = offset + svga->x_add + x;
 
-            switch (comb) {
-                case 0x00:
-                    /* Cursor Color 1 */
-                    p[x_pos] = xga->hwc_color0;
-                    break;
-                case 0x01:
-                    /* Cursor Color 2 */
-                    p[x_pos] = xga->hwc_color1;
-                    break;
-                case 0x03:
-                    /* Complement */
-                    p[x_pos] ^= 0xffffff;
-                    break;
-            }
+        switch (comb) {
+            case 0x00:
+                /* Cursor Color 1 */
+                p[x_pos] = xga->hwc_color0;
+                break;
+            case 0x01:
+                /* Cursor Color 2 */
+                p[x_pos] = xga->hwc_color1;
+                break;
+            case 0x03:
+                /* Complement */
+                p[x_pos] ^= 0xffffff;
+                break;
         }
+    }
 
-        if ((x & 0x03) == 0x03)
-            xga->hwcursor_latch.addr++;
+	if ((x & 0x03) == 0x03)
+		xga->hwcursor_latch.addr++;
     }
 
     if (xga->interlace && !xga->hwcursor_oddeven)
-        xga->hwcursor_latch.addr += 16;
+	xga->hwcursor_latch.addr += 16;
 }
 
 static void
@@ -2078,13 +2099,13 @@ xga_render_overscan_left(xga_t *xga, svga_t *svga)
     int i;
 
     if ((xga->displine + svga->y_add) < 0)
-        return;
+	return;
 
     if (svga->scrblank || (xga->h_disp == 0))
-        return;
+	return;
 
     for (i = 0; i < svga->x_add; i++)
-        buffer32->line[xga->displine + svga->y_add][i] = svga->overscan_color;
+	buffer32->line[xga->displine + svga->y_add][i] = svga->overscan_color;
 }
 
 static void
@@ -2093,62 +2114,62 @@ xga_render_overscan_right(xga_t *xga, svga_t *svga)
     int i, right;
 
     if ((xga->displine + svga->y_add) < 0)
-        return;
+	return;
 
     if (svga->scrblank || (xga->h_disp == 0))
-        return;
+	return;
 
     right = (overscan_x >> 1);
     for (i = 0; i < right; i++)
-        buffer32->line[xga->displine + svga->y_add][svga->x_add + xga->h_disp + i] = svga->overscan_color;
+	buffer32->line[xga->displine + svga->y_add][svga->x_add + xga->h_disp + i] = svga->overscan_color;
 }
 
 static void
 xga_render_8bpp(xga_t *xga, svga_t *svga)
 {
-    int       x;
+    int x;
     uint32_t *p;
-    uint32_t  dat;
+    uint32_t dat;
 
     if ((xga->displine + svga->y_add) < 0)
-        return;
+		return;
 
     if (xga->changedvram[xga->ma >> 12] || xga->changedvram[(xga->ma >> 12) + 1] || svga->fullchange) {
-        p = &buffer32->line[xga->displine + svga->y_add][svga->x_add];
+		p = &buffer32->line[xga->displine + svga->y_add][svga->x_add];
 
-        if (xga->firstline_draw == 2000)
-            xga->firstline_draw = xga->displine;
-        xga->lastline_draw = xga->displine;
+		if (xga->firstline_draw == 2000)
+			xga->firstline_draw = xga->displine;
+		xga->lastline_draw = xga->displine;
 
-        for (x = 0; x <= xga->h_disp; x += 8) {
-            dat  = *(uint32_t *) (&xga->vram[xga->ma & xga->vram_mask]);
-            p[0] = svga->pallook[dat & 0xff];
-            p[1] = svga->pallook[(dat >> 8) & 0xff];
-            p[2] = svga->pallook[(dat >> 16) & 0xff];
-            p[3] = svga->pallook[(dat >> 24) & 0xff];
+		for (x = 0; x <= xga->h_disp; x += 8) {
+			dat = *(uint32_t *)(&xga->vram[xga->ma & xga->vram_mask]);
+			p[0] = svga->pallook[dat & 0xff];
+			p[1] = svga->pallook[(dat >> 8) & 0xff];
+			p[2] = svga->pallook[(dat >> 16) & 0xff];
+			p[3] = svga->pallook[(dat >> 24) & 0xff];
 
-            dat  = *(uint32_t *) (&xga->vram[(xga->ma + 4) & xga->vram_mask]);
-            p[4] = svga->pallook[dat & 0xff];
-            p[5] = svga->pallook[(dat >> 8) & 0xff];
-            p[6] = svga->pallook[(dat >> 16) & 0xff];
-            p[7] = svga->pallook[(dat >> 24) & 0xff];
+            dat = *(uint32_t *)(&xga->vram[(xga->ma + 4) & xga->vram_mask]);
+			p[4] = svga->pallook[dat & 0xff];
+			p[5] = svga->pallook[(dat >> 8) & 0xff];
+			p[6] = svga->pallook[(dat >> 16) & 0xff];
+			p[7] = svga->pallook[(dat >> 24) & 0xff];
 
-            xga->ma += 8;
-            p += 8;
-        }
-        xga->ma &= xga->vram_mask;
+			xga->ma += 8;
+			p += 8;
+		}
+		xga->ma &= xga->vram_mask;
     }
 }
 
 static void
 xga_render_16bpp(xga_t *xga, svga_t *svga)
 {
-    int       x;
+    int x;
     uint32_t *p;
-    uint32_t  dat;
+	uint32_t dat;
 
     if ((xga->displine + svga->y_add) < 0)
-        return;
+		return;
 
     if (xga->changedvram[xga->ma >> 12] || xga->changedvram[(xga->ma >> 12) + 1] || svga->fullchange) {
         p = &buffer32->line[xga->displine + svga->y_add][svga->x_add];
@@ -2158,19 +2179,19 @@ xga_render_16bpp(xga_t *xga, svga_t *svga)
         xga->lastline_draw = xga->displine;
 
         for (x = 0; x <= (xga->h_disp); x += 8) {
-            dat      = *(uint32_t *) (&xga->vram[(xga->ma + (x << 1)) & xga->vram_mask]);
-            p[x]     = video_16to32[dat & 0xffff];
+            dat = *(uint32_t *)(&xga->vram[(xga->ma + (x << 1)) & xga->vram_mask]);
+            p[x] = video_16to32[dat & 0xffff];
             p[x + 1] = video_16to32[dat >> 16];
 
-            dat      = *(uint32_t *) (&xga->vram[(xga->ma + (x << 1) + 4) & xga->vram_mask]);
+            dat = *(uint32_t *)(&xga->vram[(xga->ma + (x << 1) + 4) & xga->vram_mask]);
             p[x + 2] = video_16to32[dat & 0xffff];
             p[x + 3] = video_16to32[dat >> 16];
 
-            dat      = *(uint32_t *) (&xga->vram[(xga->ma + (x << 1) + 8) & xga->vram_mask]);
+            dat = *(uint32_t *)(&xga->vram[(xga->ma + (x << 1) + 8) & xga->vram_mask]);
             p[x + 4] = video_16to32[dat & 0xffff];
             p[x + 5] = video_16to32[dat >> 16];
 
-            dat      = *(uint32_t *) (&xga->vram[(xga->ma + (x << 1) + 12) & xga->vram_mask]);
+            dat = *(uint32_t *)(&xga->vram[(xga->ma + (x << 1) + 12) & xga->vram_mask]);
             p[x + 6] = video_16to32[dat & 0xffff];
             p[x + 7] = video_16to32[dat >> 16];
         }
@@ -2182,8 +2203,8 @@ xga_render_16bpp(xga_t *xga, svga_t *svga)
 static void
 xga_write(uint32_t addr, uint8_t val, void *p)
 {
-    svga_t *svga = (svga_t *) p;
-    xga_t  *xga  = &svga->xga;
+    svga_t *svga = (svga_t *)p;
+    xga_t *xga = &svga->xga;
 
     if (!xga->on) {
         svga_write(addr, val, svga);
@@ -2199,20 +2220,20 @@ xga_write(uint32_t addr, uint8_t val, void *p)
     cycles -= video_timing_write_b;
 
     xga->changedvram[(addr & xga->vram_mask) >> 12] = changeframecount;
-    xga->vram[addr & xga->vram_mask]                = val;
+    xga->vram[addr & xga->vram_mask] = val;
 }
 
 static void
 xga_writeb(uint32_t addr, uint8_t val, void *p)
 {
-    // pclog("[%04X:%08X]: WriteB\n", CS, cpu_state.pc);
+    //pclog("[%04X:%08X]: WriteB\n", CS, cpu_state.pc);
     xga_write(addr, val, p);
 }
 
 static void
 xga_writew(uint32_t addr, uint16_t val, void *p)
 {
-    // pclog("[%04X:%08X]: WriteW\n", CS, cpu_state.pc);
+    //pclog("[%04X:%08X]: WriteW\n", CS, cpu_state.pc);
     xga_write(addr, val, p);
     xga_write(addr + 1, val >> 8, p);
 }
@@ -2220,7 +2241,7 @@ xga_writew(uint32_t addr, uint16_t val, void *p)
 static void
 xga_writel(uint32_t addr, uint32_t val, void *p)
 {
-    // pclog("[%04X:%08X]: WriteL\n", CS, cpu_state.pc);
+    //pclog("[%04X:%08X]: WriteL\n", CS, cpu_state.pc);
     xga_write(addr, val, p);
     xga_write(addr + 1, val >> 8, p);
     xga_write(addr + 2, val >> 16, p);
@@ -2230,8 +2251,8 @@ xga_writel(uint32_t addr, uint32_t val, void *p)
 static void
 xga_write_linear(uint32_t addr, uint8_t val, void *p)
 {
-    svga_t *svga = (svga_t *) p;
-    xga_t  *xga  = &svga->xga;
+    svga_t *svga = (svga_t *)p;
+    xga_t *xga = &svga->xga;
 
     if (!xga->on) {
         svga_write_linear(addr, val, svga);
@@ -2246,14 +2267,14 @@ xga_write_linear(uint32_t addr, uint8_t val, void *p)
     cycles -= video_timing_write_b;
 
     xga->changedvram[(addr & xga->vram_mask) >> 12] = changeframecount;
-    xga->vram[addr & xga->vram_mask]                = val;
+    xga->vram[addr & xga->vram_mask] = val;
 }
 
 static void
 xga_writew_linear(uint32_t addr, uint16_t val, void *p)
 {
-    svga_t *svga = (svga_t *) p;
-    xga_t  *xga  = &svga->xga;
+    svga_t *svga = (svga_t *)p;
+    xga_t *xga = &svga->xga;
 
     if (!xga->on) {
         svga_writew_linear(addr, val, svga);
@@ -2288,8 +2309,8 @@ xga_writew_linear(uint32_t addr, uint16_t val, void *p)
 static void
 xga_writel_linear(uint32_t addr, uint32_t val, void *p)
 {
-    svga_t *svga = (svga_t *) p;
-    xga_t  *xga  = &svga->xga;
+    svga_t *svga = (svga_t *)p;
+    xga_t *xga = &svga->xga;
 
     if (!xga->on) {
         svga_writel_linear(addr, val, svga);
@@ -2305,8 +2326,8 @@ xga_writel_linear(uint32_t addr, uint32_t val, void *p)
 static uint8_t
 xga_read(uint32_t addr, void *p)
 {
-    svga_t *svga = (svga_t *) p;
-    xga_t  *xga  = &svga->xga;
+    svga_t *svga = (svga_t *)p;
+    xga_t *xga = &svga->xga;
 
     if (!xga->on)
         return svga_read(addr, svga);
@@ -2359,8 +2380,8 @@ xga_readl(uint32_t addr, void *p)
 static uint8_t
 xga_read_linear(uint32_t addr, void *p)
 {
-    svga_t *svga = (svga_t *) p;
-    xga_t  *xga  = &svga->xga;
+    svga_t *svga = (svga_t *)p;
+    xga_t *xga = &svga->xga;
 
     if (!xga->on)
         return svga_read_linear(addr, svga);
@@ -2378,8 +2399,8 @@ xga_read_linear(uint32_t addr, void *p)
 static uint16_t
 xga_readw_linear(uint32_t addr, void *p)
 {
-    svga_t  *svga = (svga_t *) p;
-    xga_t   *xga  = &svga->xga;
+    svga_t *svga = (svga_t *)p;
+    xga_t *xga = &svga->xga;
     uint16_t ret;
 
     if (!xga->on)
@@ -2406,13 +2427,14 @@ xga_readw_linear(uint32_t addr, void *p)
 static uint32_t
 xga_readl_linear(uint32_t addr, void *p)
 {
-    svga_t *svga = (svga_t *) p;
-    xga_t  *xga  = &svga->xga;
+    svga_t *svga = (svga_t *)p;
+    xga_t *xga = &svga->xga;
 
     if (!xga->on)
         return svga_readl_linear(addr, svga);
 
-    return xga_read_linear(addr, p) | (xga_read_linear(addr + 1, p) << 8) | (xga_read_linear(addr + 2, p) << 16) | (xga_read_linear(addr + 3, p) << 24);
+    return xga_read_linear(addr, p) | (xga_read_linear(addr + 1, p) << 8) |
+        (xga_read_linear(addr + 2, p) << 16) | (xga_read_linear(addr + 3, p) << 24);
 }
 
 static void
@@ -2429,16 +2451,16 @@ xga_do_render(svga_t *svga)
             break;
     }
 
-    svga->x_add = (overscan_x >> 1);
-    xga_render_overscan_left(xga, svga);
-    xga_render_overscan_right(xga, svga);
-    svga->x_add = (overscan_x >> 1);
+	svga->x_add = (overscan_x >> 1);
+	xga_render_overscan_left(xga, svga);
+	xga_render_overscan_right(xga, svga);
+	svga->x_add = (overscan_x >> 1);
 
     if (xga->hwcursor_on) {
-        xga_hwcursor_draw(svga, xga->displine + svga->y_add);
-        xga->hwcursor_on--;
-        if (xga->hwcursor_on && xga->interlace)
-            xga->hwcursor_on--;
+    xga_hwcursor_draw(svga, xga->displine + svga->y_add);
+	xga->hwcursor_on--;
+	if (xga->hwcursor_on && xga->interlace)
+		xga->hwcursor_on--;
     }
 }
 
@@ -2446,158 +2468,160 @@ void
 xga_poll(xga_t *xga, svga_t *svga)
 {
     uint32_t x;
-    int      wx, wy;
+    int wx, wy;
 
     if (!xga->linepos) {
-        if (xga->displine == xga->hwcursor_latch.y && xga->hwcursor_latch.ena) {
-            xga->hwcursor_on      = xga->hwcursor_latch.cur_ysize - (xga->cursor_data_on ? 32 : 0);
-            xga->hwcursor_oddeven = 0;
+    if (xga->displine == xga->hwcursor_latch.y && xga->hwcursor_latch.ena) {
+        xga->hwcursor_on = xga->hwcursor_latch.cur_ysize - (xga->cursor_data_on ? 32 : 0);
+        xga->hwcursor_oddeven = 0;
+    }
+
+    if (xga->displine == (xga->hwcursor_latch.y + 1) && xga->hwcursor_latch.ena &&
+                   xga->interlace) {
+        xga->hwcursor_on = xga->hwcursor_latch.cur_ysize - (xga->cursor_data_on ? 33 : 1);
+        xga->hwcursor_oddeven = 1;
+    }
+
+    timer_advance_u64(&svga->timer, svga->dispofftime);
+    xga->linepos = 1;
+
+    if (xga->dispon) {
+        xga->h_disp_on = 1;
+
+        xga->ma &= xga->vram_mask;
+
+        if (xga->firstline == 2000) {
+            xga->firstline = xga->displine;
+            video_wait_for_buffer();
         }
 
-        if (xga->displine == (xga->hwcursor_latch.y + 1) && xga->hwcursor_latch.ena && xga->interlace) {
-            xga->hwcursor_on      = xga->hwcursor_latch.cur_ysize - (xga->cursor_data_on ? 33 : 1);
-            xga->hwcursor_oddeven = 1;
+        if (xga->hwcursor_on) {
+            xga->changedvram[xga->ma >> 12] = xga->changedvram[(xga->ma >> 12) + 1] =
+                                xga->interlace ? 3 : 2;
         }
 
-        timer_advance_u64(&svga->timer, svga->dispofftime);
-        xga->linepos = 1;
+        xga_do_render(svga);
 
-        if (xga->dispon) {
-            xga->h_disp_on = 1;
+        if (xga->lastline < xga->displine)
+            xga->lastline = xga->displine;
+    }
 
-            xga->ma &= xga->vram_mask;
-
-            if (xga->firstline == 2000) {
-                xga->firstline = xga->displine;
-                video_wait_for_buffer();
-            }
-
-            if (xga->hwcursor_on) {
-                xga->changedvram[xga->ma >> 12] = xga->changedvram[(xga->ma >> 12) + 1] = xga->interlace ? 3 : 2;
-            }
-
-            xga_do_render(svga);
-
-            if (xga->lastline < xga->displine)
-                xga->lastline = xga->displine;
-        }
-
+    xga->displine++;
+    if (xga->interlace)
         xga->displine++;
-        if (xga->interlace)
-            xga->displine++;
-        if (xga->displine > 1500)
-            xga->displine = 0;
+    if (xga->displine > 1500)
+        xga->displine = 0;
     } else {
-        timer_advance_u64(&svga->timer, svga->dispontime);
-        xga->h_disp_on = 0;
+    timer_advance_u64(&svga->timer, svga->dispontime);
+    xga->h_disp_on = 0;
 
-        xga->linepos = 0;
-        if (xga->dispon) {
-            if (xga->sc == xga->rowcount) {
-                xga->sc = 0;
-
-                if ((xga->disp_cntl_2 & 7) == 4) {
-                    xga->maback += (xga->rowoffset << 4);
-                    if (xga->interlace)
-                        xga->maback += (xga->rowoffset << 4);
-                } else {
-                    xga->maback += (xga->rowoffset << 3);
-                    if (xga->interlace)
-                        xga->maback += (xga->rowoffset << 3);
-                }
-                xga->maback &= xga->vram_mask;
-                xga->ma = xga->maback;
-            } else {
-                xga->sc++;
-                xga->sc &= 0x1f;
-                xga->ma = xga->maback;
-            }
-        }
-
-        xga->vc++;
-        xga->vc &= 2047;
-
-        if (xga->vc == xga->split) {
-            if (xga->interlace && xga->oddeven)
-                xga->ma = xga->maback = (xga->rowoffset << 1);
-            else
-                xga->ma = xga->maback = 0;
-            xga->ma     = (xga->ma << 2);
-            xga->maback = (xga->maback << 2);
-
+    xga->linepos = 0;
+    if (xga->dispon) {
+        if (xga->sc == xga->rowcount) {
             xga->sc = 0;
-        }
-        if (xga->vc == xga->dispend) {
-            xga->dispon = 0;
 
-            for (x = 0; x < ((xga->vram_mask + 1) >> 12); x++) {
-                if (xga->changedvram[x])
-                    xga->changedvram[x]--;
+            if ((xga->disp_cntl_2 & 7) == 4) {
+                xga->maback += (xga->rowoffset << 4);
+                if (xga->interlace)
+                    xga->maback += (xga->rowoffset << 4);
+            } else {
+                xga->maback += (xga->rowoffset << 3);
+                if (xga->interlace)
+                    xga->maback += (xga->rowoffset << 3);
             }
-            if (svga->fullchange)
-                svga->fullchange--;
+            xga->maback &= xga->vram_mask;
+            xga->ma = xga->maback;
+        } else {
+            xga->sc++;
+            xga->sc &= 0x1f;
+            xga->ma = xga->maback;
         }
-        if (xga->vc == xga->v_syncstart) {
-            xga->dispon = 0;
-            x           = xga->h_disp;
+    }
 
-            if (xga->interlace && !xga->oddeven)
-                xga->lastline++;
-            if (xga->interlace && xga->oddeven)
-                xga->firstline--;
+    xga->vc++;
+    xga->vc &= 2047;
 
-            wx = x;
+    if (xga->vc == xga->split) {
+        if (xga->interlace && xga->oddeven)
+            xga->ma = xga->maback = (xga->rowoffset << 1);
+        else
+            xga->ma = xga->maback = 0;
+        xga->ma = (xga->ma << 2);
+        xga->maback = (xga->maback << 2);
 
-            wy = xga->lastline - xga->firstline;
-            svga_doblit(wx, wy, svga);
+        xga->sc = 0;
+    }
+    if (xga->vc == xga->dispend) {
+        xga->dispon = 0;
 
-            xga->firstline = 2000;
-            xga->lastline  = 0;
-
-            xga->firstline_draw = 2000;
-            xga->lastline_draw  = 0;
-
-            xga->oddeven ^= 1;
-
-            changeframecount = xga->interlace ? 3 : 2;
-
-            if (xga->interlace && xga->oddeven)
-                xga->ma = xga->maback = xga->ma_latch + (xga->rowoffset << 1);
-            else
-                xga->ma = xga->maback = xga->ma_latch;
-
-            xga->ma     = (xga->ma << 2);
-            xga->maback = (xga->maback << 2);
+        for (x = 0; x < ((xga->vram_mask + 1) >> 12); x++) {
+            if (xga->changedvram[x])
+                xga->changedvram[x]--;
         }
-        if (xga->vc == xga->v_total) {
-            xga->vc       = 0;
-            xga->sc       = 0;
-            xga->dispon   = 1;
-            xga->displine = (xga->interlace && xga->oddeven) ? 1 : 0;
+        if (svga->fullchange)
+            svga->fullchange--;
+    }
+    if (xga->vc == xga->v_syncstart) {
+        xga->dispon = 0;
+        x = xga->h_disp;
 
-            svga->x_add = (overscan_x >> 1);
+        if (xga->interlace && !xga->oddeven)
+            xga->lastline++;
+        if (xga->interlace && xga->oddeven)
+            xga->firstline--;
 
-            xga->hwcursor_on    = 0;
-            xga->hwcursor_latch = xga->hwcursor;
-        }
+        wx = x;
+
+        wy = xga->lastline - xga->firstline;
+        svga_doblit(wx, wy, svga);
+
+        xga->firstline = 2000;
+        xga->lastline = 0;
+
+        xga->firstline_draw = 2000;
+        xga->lastline_draw = 0;
+
+        xga->oddeven ^= 1;
+
+        changeframecount = xga->interlace ? 3 : 2;
+
+        if (xga->interlace && xga->oddeven)
+            xga->ma = xga->maback = xga->ma_latch + (xga->rowoffset << 1);
+        else
+            xga->ma = xga->maback = xga->ma_latch;
+
+        xga->ma = (xga->ma << 2);
+        xga->maback = (xga->maback << 2);
+    }
+    if (xga->vc == xga->v_total) {
+        xga->vc = 0;
+        xga->sc = 0;
+        xga->dispon = 1;
+        xga->displine = (xga->interlace && xga->oddeven) ? 1 : 0;
+
+        svga->x_add = (overscan_x >> 1);
+
+        xga->hwcursor_on = 0;
+        xga->hwcursor_latch = xga->hwcursor;
+    }
     }
 }
 
 static uint8_t
 xga_mca_read(int port, void *priv)
 {
-    svga_t *svga = (svga_t *) priv;
-    xga_t  *xga  = &svga->xga;
+    svga_t *svga = (svga_t *)priv;
+    xga_t *xga = &svga->xga;
 
-    // pclog("[%04X:%08X]: POS Read Port = %x, val = %02x\n", CS, cpu_state.pc, port & 7, xga->pos_regs[port & 7]);
+    //pclog("[%04X:%08X]: POS Read Port = %x, val = %02x\n", CS, cpu_state.pc, port & 7, xga->pos_regs[port & 7]);
     return (xga->pos_regs[port & 7]);
 }
 
 static void
 xga_mca_write(int port, uint8_t val, void *priv)
 {
-    svga_t *svga = (svga_t *) priv;
-    xga_t  *xga  = &svga->xga;
+    svga_t *svga = (svga_t *)priv;
+    xga_t *xga = &svga->xga;
 
     /* MCA does not write registers below 0x0100. */
     if (port < 0x0102)
@@ -2607,22 +2631,23 @@ xga_mca_write(int port, uint8_t val, void *priv)
     mem_mapping_disable(&xga->bios_rom.mapping);
     mem_mapping_disable(&xga->memio_mapping);
     xga->on = 0;
-    vga_on  = 1;
+    vga_on = 1;
 
     /* Save the MCA register value. */
     xga->pos_regs[port & 7] = val;
     if (!(xga->pos_regs[4] & 1)) /*MCA 4MB addressing on systems with more than 16MB of memory*/
         xga->pos_regs[4] |= 1;
 
-    // pclog("[%04X:%08X]: POS Write Port = %x, val = %02x, linear base = %08x, instance = %d, rom addr = %05x\n", CS, cpu_state.pc, port & 7, val, xga->linear_base, xga->instance, xga->rom_addr);
+    //pclog("[%04X:%08X]: POS Write Port = %x, val = %02x, linear base = %08x, instance = %d, rom addr = %05x\n", CS, cpu_state.pc, port & 7, val, xga->linear_base, xga->instance, xga->rom_addr);
     if (xga->pos_regs[2] & 1) {
-        xga->instance      = (xga->pos_regs[2] & 0x0e) >> 1;
+        xga->instance = (xga->pos_regs[2] & 0x0e) >> 1;
         xga->base_addr_1mb = (xga->pos_regs[5] & 0x0f) << 20;
-        xga->linear_base   = ((xga->pos_regs[4] & 0xfe) * 0x1000000) + (xga->instance << 22);
-        xga->rom_addr      = 0xc0000 + (((xga->pos_regs[2] & 0xf0) >> 4) * 0x2000);
+        xga->linear_base = ((xga->pos_regs[4] & 0xfe) * 0x1000000) + (xga->instance << 22);
+        xga->rom_addr = 0xc0000 + (((xga->pos_regs[2] & 0xf0) >> 4) * 0x2000);
 
         io_sethandler(0x2100 + (xga->instance << 4), 0x0010, xga_ext_inb, NULL, NULL, xga_ext_outb, NULL, NULL, svga);
-        mem_mapping_set_addr(&xga->bios_rom.mapping, xga->rom_addr, 0x2000);
+        if ((port & 7) == 2)
+            mem_mapping_set_addr(&xga->bios_rom.mapping, xga->rom_addr, 0x2000);
         mem_mapping_set_addr(&xga->memio_mapping, xga->rom_addr + 0x1c00 + (xga->instance * 0x80), 0x80);
     }
 }
@@ -2630,8 +2655,8 @@ xga_mca_write(int port, uint8_t val, void *priv)
 static uint8_t
 xga_mca_feedb(void *priv)
 {
-    svga_t *svga = (svga_t *) priv;
-    xga_t  *xga  = &svga->xga;
+    svga_t *svga = (svga_t *)priv;
+    xga_t *xga = &svga->xga;
 
     return xga->pos_regs[2] & 1;
 }
@@ -2639,7 +2664,7 @@ xga_mca_feedb(void *priv)
 static void
 xga_mca_reset(void *p)
 {
-    svga_t *svga = (svga_t *) p;
+    svga_t *svga = (svga_t *)p;
 
     xga_mca_write(0x102, 0, svga);
 }
@@ -2647,48 +2672,47 @@ xga_mca_reset(void *p)
 static uint8_t
 xga_pos_in(uint16_t addr, void *priv)
 {
-    svga_t *svga = (svga_t *) priv;
+    svga_t *svga = (svga_t *)priv;
 
     return (xga_mca_read(addr, svga));
 }
 
 static void
-    *
-    xga_init(const device_t *info)
+*xga_init(const device_t *info)
 {
-    svga_t  *svga = svga_get_pri();
-    xga_t   *xga  = &svga->xga;
-    FILE    *f;
+    svga_t *svga = svga_get_pri();
+    xga_t *xga = &svga->xga;
+    FILE *f;
     uint32_t temp;
     uint32_t initial_bios_addr = device_get_config_hex20("init_bios_addr");
-    uint8_t *rom               = NULL;
+    uint8_t *rom = NULL;
 
     xga->type = device_get_config_int("type");
-    xga->bus  = info->flags;
+    xga->bus = info->flags;
 
-    xga->vram_size             = (1024 << 10);
-    xga->vram_mask             = xga->vram_size - 1;
-    xga->vram                  = calloc(xga->vram_size, 1);
-    xga->changedvram           = calloc(xga->vram_size >> 12, 1);
-    xga->on                    = 0;
-    xga->hwcursor.cur_xsize    = 64;
-    xga->hwcursor.cur_ysize    = 64;
-    xga->bios_rom.sz           = 0x2000;
+    xga->vram_size = (1024 << 10);
+    xga->vram_mask = xga->vram_size - 1;
+    xga->vram = calloc(xga->vram_size, 1);
+    xga->changedvram = calloc(xga->vram_size >> 12, 1);
+    xga->on = 0;
+    xga->hwcursor.cur_xsize = 64;
+    xga->hwcursor.cur_ysize = 64;
+    xga->bios_rom.sz = 0x2000;
     xga->linear_endian_reverse = 0;
-    xga->a5_test               = 0;
+    xga->a5_test = 0;
 
     f = rom_fopen(xga->type ? XGA2_BIOS_PATH : XGA_BIOS_PATH, "rb");
-    (void) fseek(f, 0L, SEEK_END);
+    (void)fseek(f, 0L, SEEK_END);
     temp = ftell(f);
-    (void) fseek(f, 0L, SEEK_SET);
+    (void)fseek(f, 0L, SEEK_SET);
 
     rom = malloc(xga->bios_rom.sz);
     memset(rom, 0xff, xga->bios_rom.sz);
-    (void) !fread(rom, xga->bios_rom.sz, 1, f);
+    (void)fread(rom, xga->bios_rom.sz, 1, f);
     temp -= xga->bios_rom.sz;
-    (void) fclose(f);
+    (void)fclose(f);
 
-    xga->bios_rom.rom  = rom;
+    xga->bios_rom.rom = rom;
     xga->bios_rom.mask = xga->bios_rom.sz - 1;
     if (f != NULL) {
         free(rom);
@@ -2697,29 +2721,25 @@ static void
     xga->base_addr_1mb = 0;
     if (info->flags & DEVICE_MCA) {
         xga->linear_base = 0;
-        xga->instance    = 0;
-        xga->rom_addr    = 0;
-        mem_mapping_add(&xga->bios_rom.mapping,
-                        initial_bios_addr, xga->bios_rom.sz,
-                        rom_read, rom_readw, rom_readl,
-                        NULL, NULL, NULL,
-                        xga->bios_rom.rom, MEM_MAPPING_EXTERNAL, &xga->bios_rom);
+        xga->instance = 0;
+        xga->rom_addr = 0;
+        rom_init(&xga->bios_rom, xga->type ? XGA2_BIOS_PATH : XGA_BIOS_PATH, initial_bios_addr, 0x2000, 0x1fff, 0, MEM_MAPPING_EXTERNAL);
     } else {
         xga->pos_regs[2] = 1 | 0x0c | 0xf0;
-        xga->instance    = (xga->pos_regs[2] & 0x0e) >> 1;
+        xga->instance = (xga->pos_regs[2] & 0x0e) >> 1;
         xga->pos_regs[4] = 1 | 2;
         xga->linear_base = ((xga->pos_regs[4] & 0xfe) * 0x1000000) + (xga->instance << 22);
-        xga->rom_addr    = 0xc0000 + (((xga->pos_regs[2] & 0xf0) >> 4) * 0x2000);
+        xga->rom_addr = 0xc0000 + (((xga->pos_regs[2] & 0xf0) >> 4) * 0x2000);
     }
 
     mem_mapping_add(&xga->video_mapping, 0, 0, xga_readb, xga_readw, xga_readl,
                     xga_writeb, xga_writew, xga_writel,
                     NULL, MEM_MAPPING_EXTERNAL, svga);
-    mem_mapping_add(&xga->linear_mapping, 0, 0, xga_read_linear, xga_readw_linear, xga_readl_linear,
+	mem_mapping_add(&xga->linear_mapping, 0, 0, xga_read_linear, xga_readw_linear, xga_readl_linear,
                     xga_write_linear, xga_writew_linear, xga_writel_linear,
-                    NULL, MEM_MAPPING_EXTERNAL, svga);
+                    NULL, MEM_MAPPING_EXTERNAL,	svga);
     mem_mapping_add(&xga->memio_mapping, 0, 0, xga_memio_readb, xga_memio_readw, xga_memio_readl,
-                    xga_memio_writeb, xga_memio_writew, xga_memio_writel,
+                    xga_memio_writeb, xga_memio_writew,	xga_memio_writel,
                     xga->bios_rom.rom, MEM_MAPPING_EXTERNAL, svga);
 
     mem_mapping_disable(&xga->video_mapping);
@@ -2743,8 +2763,8 @@ static void
 static void
 xga_close(void *p)
 {
-    svga_t *svga = (svga_t *) p;
-    xga_t  *xga  = &svga->xga;
+    svga_t *svga = (svga_t *)p;
+    xga_t *xga = &svga->xga;
 
     if (svga) {
         free(xga->vram);
@@ -2761,7 +2781,7 @@ xga_available(void)
 static void
 xga_speed_changed(void *p)
 {
-    svga_t *svga = (svga_t *) p;
+    svga_t *svga = (svga_t *)p;
 
     svga_recalctimings(svga);
 }
@@ -2769,13 +2789,13 @@ xga_speed_changed(void *p)
 static void
 xga_force_redraw(void *p)
 {
-    svga_t *svga = (svga_t *) p;
+    svga_t *svga = (svga_t *)p;
 
     svga->fullchange = changeframecount;
 }
 
 static const device_config_t xga_configuration[] = {
-  // clang-format off
+    // clang-format off
     {
         .name = "init_bios_addr",
         .description = "Initial MCA BIOS Address (before POS configuration)",
@@ -2816,35 +2836,35 @@ static const device_config_t xga_configuration[] = {
         }
     },
     { .name = "", .description = "", .type = CONFIG_END }
-// clang-format on
+    // clang-format on
 };
 
 const device_t xga_device = {
-    .name          = "XGA (MCA)",
+    .name = "XGA (MCA)",
     .internal_name = "xga_mca",
-    .flags         = DEVICE_MCA,
-    .local         = 0,
-    .init          = xga_init,
-    .close         = xga_close,
-    .reset         = NULL,
+    .flags = DEVICE_MCA,
+    .local = 0,
+    .init = xga_init,
+    .close = xga_close,
+    .reset = NULL,
     { .available = xga_available },
     .speed_changed = xga_speed_changed,
-    .force_redraw  = xga_force_redraw,
-    .config        = xga_configuration
+    .force_redraw = xga_force_redraw,
+    .config = xga_configuration
 };
 
 const device_t xga_isa_device = {
-    .name          = "XGA (ISA)",
+    .name = "XGA (ISA)",
     .internal_name = "xga_isa",
-    .flags         = DEVICE_ISA | DEVICE_AT,
-    .local         = 0,
-    .init          = xga_init,
-    .close         = xga_close,
-    .reset         = NULL,
+    .flags = DEVICE_ISA | DEVICE_AT,
+    .local = 0,
+    .init = xga_init,
+    .close = xga_close,
+    .reset = NULL,
     { .available = xga_available },
     .speed_changed = xga_speed_changed,
-    .force_redraw  = xga_force_redraw,
-    .config        = xga_configuration
+    .force_redraw = xga_force_redraw,
+    .config = xga_configuration
 };
 
 void

--- a/src/video/vid_xga.c
+++ b/src/video/vid_xga.c
@@ -14,31 +14,31 @@
  *
  *		Copyright 2022 TheCollector1995.
  */
-#include <stdio.h>
-#include <stdint.h>
-#include <string.h>
-#include <stdlib.h>
-#include <wchar.h>
-#include <86box/bswap.h>
+#include "cpu.h"
 #include <86box/86box.h>
+#include <86box/bswap.h>
+#include <86box/device.h>
+#include <86box/dma.h>
 #include <86box/io.h>
 #include <86box/machine.h>
-#include <86box/mem.h>
-#include <86box/dma.h>
-#include <86box/rom.h>
 #include <86box/mca.h>
-#include <86box/device.h>
+#include <86box/mem.h>
+#include <86box/rom.h>
 #include <86box/timer.h>
-#include <86box/video.h>
 #include <86box/vid_svga.h>
 #include <86box/vid_svga_render.h>
 #include <86box/vid_xga_device.h>
-#include "cpu.h"
+#include <86box/video.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
 
-#define XGA_BIOS_PATH "roms/video/xga/XGA_37F9576_Ver200.BIN"
+#define XGA_BIOS_PATH  "roms/video/xga/XGA_37F9576_Ver200.BIN"
 #define XGA2_BIOS_PATH "roms/video/xga/xga2_v300.bin"
 
-static void xga_ext_outb(uint16_t addr, uint8_t val, void *p);
+static void    xga_ext_outb(uint16_t addr, uint8_t val, void *p);
 static uint8_t xga_ext_inb(uint16_t addr, void *p);
 
 static void
@@ -46,7 +46,7 @@ xga_updatemapping(svga_t *svga)
 {
     xga_t *xga = &svga->xga;
 
-    //pclog("OpMode = %x, linear base = %08x, aperture cntl = %d, opmodereset1 = %d, access mode = %x, map = %x.\n", xga->op_mode, xga->linear_base, xga->aperture_cntl, xga->op_mode_reset, xga->access_mode, svga->gdcreg[6] & 0x0c);
+    // pclog("OpMode = %x, linear base = %08x, aperture cntl = %d, opmodereset1 = %d, access mode = %x, map = %x.\n", xga->op_mode, xga->linear_base, xga->aperture_cntl, xga->op_mode_reset, xga->access_mode, svga->gdcreg[6] & 0x0c);
     if ((xga->op_mode & 7) >= 4) {
         if (xga->aperture_cntl == 1) {
             mem_mapping_disable(&svga->mapping);
@@ -72,7 +72,7 @@ linear:
                     mem_mapping_disable(&xga->linear_mapping);
             }
             xga->on = 0;
-            vga_on = 1;
+            vga_on  = 1;
             if (((xga->op_mode & 7) == 4) && ((svga->gdcreg[6] & 0x0c) == 0x0c) && !xga->a5_test)
                 xga->linear_endian_reverse = 1;
         } else {
@@ -99,7 +99,7 @@ linear:
         }
         mem_mapping_disable(&xga->linear_mapping);
         xga->on = 0;
-        vga_on = 1;
+        vga_on  = 1;
     }
 }
 
@@ -109,10 +109,10 @@ xga_recalctimings(svga_t *svga)
     xga_t *xga = &svga->xga;
 
     if (xga->on) {
-        xga->v_total = xga->vtotal + 1;
-        xga->dispend = xga->vdispend + 1;
-        xga->v_syncstart = xga->vsyncstart + 1;
-        xga->split = xga->linecmp + 1;
+        xga->v_total      = xga->vtotal + 1;
+        xga->dispend      = xga->vdispend + 1;
+        xga->v_syncstart  = xga->vsyncstart + 1;
+        xga->split        = xga->linecmp + 1;
         xga->v_blankstart = xga->vblankstart + 1;
 
         xga->h_disp = (xga->hdisp + 1) << 3;
@@ -120,7 +120,7 @@ xga_recalctimings(svga_t *svga)
         xga->rowoffset = (xga->hdisp + 1);
 
         xga->interlace = !!(xga->disp_cntl_1 & 0x08);
-        xga->rowcount = (xga->disp_cntl_2 & 0xc0) >> 6;
+        xga->rowcount  = (xga->disp_cntl_2 & 0xc0) >> 6;
 
         if (xga->interlace) {
             xga->v_total >>= 1;
@@ -135,16 +135,16 @@ xga_recalctimings(svga_t *svga)
         switch (xga->clk_sel_1 & 0x0c) {
             case 0:
                 if (xga->clk_sel_2 & 0x80) {
-                    svga->clock = (cpuclock * (double)(1ull << 32)) / 41539000.0;
+                    svga->clock = (cpuclock * (double) (1ull << 32)) / 41539000.0;
                 } else {
-                    svga->clock = (cpuclock * (double)(1ull << 32)) / 25175000.0;
+                    svga->clock = (cpuclock * (double) (1ull << 32)) / 25175000.0;
                 }
                 break;
             case 4:
-                svga->clock = (cpuclock * (double)(1ull << 32)) / 28322000.0;
+                svga->clock = (cpuclock * (double) (1ull << 32)) / 28322000.0;
                 break;
             case 0x0c:
-                svga->clock = (cpuclock * (double)(1ull << 32)) / 44900000.0;
+                svga->clock = (cpuclock * (double) (1ull << 32)) / 44900000.0;
                 break;
         }
     } else {
@@ -215,11 +215,11 @@ xga_ext_out_reg(xga_t *xga, svga_t *svga, uint8_t idx, uint8_t val)
             break;
 
         case 0x30:
-            xga->hwc_pos_x = (xga->hwc_pos_x & 0x0700) | val;
+            xga->hwc_pos_x  = (xga->hwc_pos_x & 0x0700) | val;
             xga->hwcursor.x = xga->hwc_pos_x;
             break;
         case 0x31:
-            xga->hwc_pos_x = (xga->hwc_pos_x & 0xff) | ((val & 0x07) << 8);
+            xga->hwc_pos_x  = (xga->hwc_pos_x & 0xff) | ((val & 0x07) << 8);
             xga->hwcursor.x = xga->hwc_pos_x;
             break;
 
@@ -229,11 +229,11 @@ xga_ext_out_reg(xga_t *xga, svga_t *svga, uint8_t idx, uint8_t val)
             break;
 
         case 0x33:
-            xga->hwc_pos_y = (xga->hwc_pos_y & 0x0700) | val;
+            xga->hwc_pos_y  = (xga->hwc_pos_y & 0x0700) | val;
             xga->hwcursor.y = xga->hwc_pos_y;
             break;
         case 0x34:
-            xga->hwc_pos_y = (xga->hwc_pos_y & 0xff) | ((val & 0x07) << 8);
+            xga->hwc_pos_y  = (xga->hwc_pos_y & 0xff) | ((val & 0x07) << 8);
             xga->hwcursor.y = xga->hwc_pos_y;
             break;
 
@@ -243,7 +243,7 @@ xga_ext_out_reg(xga_t *xga, svga_t *svga, uint8_t idx, uint8_t val)
             break;
 
         case 0x36:
-            xga->hwc_control = val;
+            xga->hwc_control  = val;
             xga->hwcursor.ena = xga->hwc_control & 1;
             break;
 
@@ -306,12 +306,12 @@ xga_ext_out_reg(xga_t *xga, svga_t *svga, uint8_t idx, uint8_t val)
 
         case 0x60:
             xga->sprite_pal_addr_idx = (xga->sprite_pal_addr_idx & 0x3f00) | val;
-            svga->dac_pos = 0;
-            svga->dac_addr = val & 0xff;
+            svga->dac_pos            = 0;
+            svga->dac_addr           = val & 0xff;
             break;
         case 0x61:
             xga->sprite_pal_addr_idx = (xga->sprite_pal_addr_idx & 0xff) | ((val & 0x3f) << 8);
-            xga->sprite_pos = xga->sprite_pal_addr_idx & 0x1ff;
+            xga->sprite_pos          = xga->sprite_pal_addr_idx & 0x1ff;
             if ((xga->sprite_pos >= 0) && (xga->sprite_pos <= 16)) {
                 if ((xga->op_mode & 7) >= 5)
                     xga->cursor_data_on = 1;
@@ -333,17 +333,17 @@ xga_ext_out_reg(xga_t *xga, svga_t *svga, uint8_t idx, uint8_t val)
                     xga->cursor_data_on = 0;
                 }
             }
-            //pclog("Sprite POS = %d, data on = %d, idx = %d, apcntl = %d\n", xga->sprite_pos, xga->cursor_data_on, xga->sprite_pal_addr_idx, xga->aperture_cntl);
+            // pclog("Sprite POS = %d, data on = %d, idx = %d, apcntl = %d\n", xga->sprite_pos, xga->cursor_data_on, xga->sprite_pal_addr_idx, xga->aperture_cntl);
             break;
 
         case 0x62:
             xga->sprite_pal_addr_idx_prefetch = (xga->sprite_pal_addr_idx_prefetch & 0x3f00) | val;
-            svga->dac_pos = 0;
-            svga->dac_addr = val & 0xff;
+            svga->dac_pos                     = 0;
+            svga->dac_addr                    = val & 0xff;
             break;
         case 0x63:
             xga->sprite_pal_addr_idx_prefetch = (xga->sprite_pal_addr_idx_prefetch & 0xff) | ((val & 0x3f) << 8);
-            xga->sprite_pos_prefetch = xga->sprite_pal_addr_idx_prefetch & 0x1ff;
+            xga->sprite_pos_prefetch          = xga->sprite_pal_addr_idx_prefetch & 0x1ff;
             break;
 
         case 0x64:
@@ -362,14 +362,14 @@ xga_ext_out_reg(xga_t *xga, svga_t *svga, uint8_t idx, uint8_t val)
                     svga->dac_pos++;
                     break;
                 case 2:
-                    xga->pal_b = val;
-                    index = svga->dac_addr & 0xff;
+                    xga->pal_b            = val;
+                    index                 = svga->dac_addr & 0xff;
                     svga->vgapal[index].r = svga->dac_r;
                     svga->vgapal[index].g = svga->dac_g;
                     svga->vgapal[index].b = xga->pal_b;
-                    svga->pallook[index] = makecol32(svga->vgapal[index].r, svga->vgapal[index].g, svga->vgapal[index].b);
-                    svga->dac_pos = 0;
-                    svga->dac_addr = (svga->dac_addr + 1) & 0xff;
+                    svga->pallook[index]  = makecol32(svga->vgapal[index].r, svga->vgapal[index].g, svga->vgapal[index].b);
+                    svga->dac_pos         = 0;
+                    svga->dac_addr        = (svga->dac_addr + 1) & 0xff;
                     break;
             }
             break;
@@ -390,7 +390,7 @@ xga_ext_out_reg(xga_t *xga, svga_t *svga, uint8_t idx, uint8_t val)
 
         case 0x6a:
             xga->sprite_data[xga->sprite_pos] = val;
-            xga->sprite_pos = (xga->sprite_pos + 1) & 0x3ff;
+            xga->sprite_pos                   = (xga->sprite_pos + 1) & 0x3ff;
             break;
 
         case 0x70:
@@ -403,10 +403,10 @@ xga_ext_out_reg(xga_t *xga, svga_t *svga, uint8_t idx, uint8_t val)
 static void
 xga_ext_outb(uint16_t addr, uint8_t val, void *p)
 {
-    svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
+    svga_t *svga = (svga_t *) p;
+    xga_t  *xga  = &svga->xga;
 
-    //pclog("[%04X:%08X]: EXT OUTB = %02x, val = %02x\n", CS, cpu_state.pc, addr, val);
+    // pclog("[%04X:%08X]: EXT OUTB = %02x, val = %02x\n", CS, cpu_state.pc, addr, val);
     switch (addr & 0x0f) {
         case 0:
             xga->op_mode = val;
@@ -421,17 +421,17 @@ xga_ext_outb(uint16_t addr, uint8_t val, void *p)
                 xga->aperture_cntl = 0;
             break;
         case 6:
-            vga_on = 0;
+            vga_on  = 0;
             xga->on = 1;
             break;
         case 8:
             xga->ap_idx = val;
-            //pclog("Aperture CNTL = %d, val = %02x, up to bit6 = %02x\n", xga->aperture_cntl, val, val & 0x3f);
+            // pclog("Aperture CNTL = %d, val = %02x, up to bit6 = %02x\n", xga->aperture_cntl, val, val & 0x3f);
             if ((xga->op_mode & 7) < 4) {
                 xga->write_bank = xga->read_bank = 0;
             } else {
                 xga->write_bank = (xga->ap_idx & 0x3f) << 16;
-                xga->read_bank = xga->write_bank;
+                xga->read_bank  = xga->write_bank;
             }
             break;
         case 9:
@@ -454,8 +454,8 @@ xga_ext_outb(uint16_t addr, uint8_t val, void *p)
 static uint8_t
 xga_ext_inb(uint16_t addr, void *p)
 {
-    svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
+    svga_t *svga = (svga_t *) p;
+    xga_t  *xga  = &svga->xga;
     uint8_t ret, index;
 
     switch (addr & 0x0f) {
@@ -629,9 +629,9 @@ xga_ext_inb(uint16_t addr, void *p)
                             ret = svga->vgapal[index].g;
                             break;
                         case 2:
-                            svga->dac_pos = 0;
+                            svga->dac_pos  = 0;
                             svga->dac_addr = (svga->dac_addr + 1) & 0xff;
-                            ret = svga->vgapal[index].b;
+                            ret            = svga->vgapal[index].b;
                             break;
                     }
                     break;
@@ -651,8 +651,8 @@ xga_ext_inb(uint16_t addr, void *p)
                     break;
 
                 case 0x6a:
-                    //pclog("Sprite POS Read = %d, addr idx = %04x\n", xga->sprite_pos, xga->sprite_pal_addr_idx_prefetch);
-                    ret = xga->sprite_data[xga->sprite_pos_prefetch];
+                    // pclog("Sprite POS Read = %d, addr idx = %04x\n", xga->sprite_pos, xga->sprite_pal_addr_idx_prefetch);
+                    ret                      = xga->sprite_data[xga->sprite_pos_prefetch];
                     xga->sprite_pos_prefetch = (xga->sprite_pos_prefetch + 1) & 0x3ff;
                     break;
 
@@ -667,70 +667,114 @@ xga_ext_inb(uint16_t addr, void *p)
             break;
     }
 
-    //pclog("[%04X:%08X]: EXT INB = %02x, ret = %02x\n", CS, cpu_state.pc, addr, ret);
+    // pclog("[%04X:%08X]: EXT INB = %02x, ret = %02x\n", CS, cpu_state.pc, addr, ret);
     return ret;
 }
-
 
 #define READ(addr, dat) \
     dat = xga->vram[(addr) & (xga->vram_mask)];
 
-#define WRITE(addr, dat) \
-    xga->vram[((addr)) & (xga->vram_mask)] = dat; \
+#define WRITE(addr, dat)                                         \
+    xga->vram[((addr)) & (xga->vram_mask)]                = dat; \
     xga->changedvram[(((addr)) & (xga->vram_mask)) >> 12] = changeframecount;
 
 #define READW(addr, dat) \
-    dat = *(uint16_t *)&xga->vram[(addr) & (xga->vram_mask)];
+    dat = *(uint16_t *) &xga->vram[(addr) & (xga->vram_mask)];
 
-#define READW_REVERSE(addr, dat) \
+#define READW_REVERSE(addr, dat)                               \
     dat = xga->vram[(addr + 1) & (xga->vram_mask - 1)] & 0xff; \
     dat |= (xga->vram[(addr) & (xga->vram_mask - 1)] << 8);
 
-#define WRITEW(addr, dat) \
-    *(uint16_t *)&xga->vram[((addr)) & (xga->vram_mask)] = dat; \
+#define WRITEW(addr, dat)                                        \
+    *(uint16_t *) &xga->vram[((addr)) & (xga->vram_mask)] = dat; \
     xga->changedvram[(((addr)) & (xga->vram_mask)) >> 12] = changeframecount;
 
-#define WRITEW_REVERSE(addr, dat) \
-    xga->vram[((addr + 1)) & (xga->vram_mask - 1)] = dat & 0xff; \
-    xga->vram[((addr)) & (xga->vram_mask - 1)] = dat >> 8; \
+#define WRITEW_REVERSE(addr, dat)                                       \
+    xga->vram[((addr + 1)) & (xga->vram_mask - 1)]        = dat & 0xff; \
+    xga->vram[((addr)) & (xga->vram_mask - 1)]            = dat >> 8;   \
     xga->changedvram[(((addr)) & (xga->vram_mask)) >> 12] = changeframecount;
 
-#define ROP(mix, d, s) { \
-    switch ((mix) ? (xga->accel.frgd_mix & 0x1f) : (xga->accel.bkgd_mix & 0x1f)) {	\
-        case 0x00: d = 0; break; \
-        case 0x01: d = s & d; break; \
-        case 0x02: d = s & ~d; break; \
-        case 0x03: d = s; break; \
-        case 0x04: d = ~s & d; break; \
-        case 0x05: d = d; break; \
-        case 0x06: d = s ^ d; break; \
-        case 0x07: d = s | d; break; \
-        case 0x08: d = ~s & ~d; break; \
-        case 0x09: d = s ^ ~d; break; \
-        case 0x0a: d = ~d; break; \
-        case 0x0b: d = s | ~d; break; \
-        case 0x0c: d = ~s; break; \
-        case 0x0d: d = ~s | d; break; \
-        case 0x0e: d = ~s | ~d; break; \
-        case 0x0f: d = ~0; break; \
-        case 0x10: d = MAX(s, d); break; \
-        case 0x11: d = MIN(s, d); break; \
-        case 0x12: d = MIN(0xff, s + d); break; \
-        case 0x13: d = MAX(0, d - s); break; \
-        case 0x14: d = MAX(0, s - d); break; \
-        case 0x15: d = (s + d) >> 1; break; \
-    } \
- }
+#define ROP(mix, d, s)                                                                 \
+    {                                                                                  \
+        switch ((mix) ? (xga->accel.frgd_mix & 0x1f) : (xga->accel.bkgd_mix & 0x1f)) { \
+            case 0x00:                                                                 \
+                d = 0;                                                                 \
+                break;                                                                 \
+            case 0x01:                                                                 \
+                d = s & d;                                                             \
+                break;                                                                 \
+            case 0x02:                                                                 \
+                d = s & ~d;                                                            \
+                break;                                                                 \
+            case 0x03:                                                                 \
+                d = s;                                                                 \
+                break;                                                                 \
+            case 0x04:                                                                 \
+                d = ~s & d;                                                            \
+                break;                                                                 \
+            case 0x05:                                                                 \
+                d = d;                                                                 \
+                break;                                                                 \
+            case 0x06:                                                                 \
+                d = s ^ d;                                                             \
+                break;                                                                 \
+            case 0x07:                                                                 \
+                d = s | d;                                                             \
+                break;                                                                 \
+            case 0x08:                                                                 \
+                d = ~s & ~d;                                                           \
+                break;                                                                 \
+            case 0x09:                                                                 \
+                d = s ^ ~d;                                                            \
+                break;                                                                 \
+            case 0x0a:                                                                 \
+                d = ~d;                                                                \
+                break;                                                                 \
+            case 0x0b:                                                                 \
+                d = s | ~d;                                                            \
+                break;                                                                 \
+            case 0x0c:                                                                 \
+                d = ~s;                                                                \
+                break;                                                                 \
+            case 0x0d:                                                                 \
+                d = ~s | d;                                                            \
+                break;                                                                 \
+            case 0x0e:                                                                 \
+                d = ~s | ~d;                                                           \
+                break;                                                                 \
+            case 0x0f:                                                                 \
+                d = ~0;                                                                \
+                break;                                                                 \
+            case 0x10:                                                                 \
+                d = MAX(s, d);                                                         \
+                break;                                                                 \
+            case 0x11:                                                                 \
+                d = MIN(s, d);                                                         \
+                break;                                                                 \
+            case 0x12:                                                                 \
+                d = MIN(0xff, s + d);                                                  \
+                break;                                                                 \
+            case 0x13:                                                                 \
+                d = MAX(0, d - s);                                                     \
+                break;                                                                 \
+            case 0x14:                                                                 \
+                d = MAX(0, s - d);                                                     \
+                break;                                                                 \
+            case 0x15:                                                                 \
+                d = (s + d) >> 1;                                                      \
+                break;                                                                 \
+        }                                                                              \
+    }
 
 static uint32_t
 xga_accel_read_pattern_map_pixel(svga_t *svga, int x, int y, int map, uint32_t base, int width)
 {
-    xga_t *xga = &svga->xga;
+    xga_t   *xga  = &svga->xga;
     uint32_t addr = base;
-    int bits;
+    int      bits;
     uint32_t byte;
-    uint8_t px;
-    int skip = 0;
+    uint8_t  px;
+    int      skip = 0;
 
     if (xga->base_addr_1mb) {
         if (addr < xga->base_addr_1mb || (addr > (xga->base_addr_1mb + 0xfffff)))
@@ -759,16 +803,15 @@ xga_accel_read_pattern_map_pixel(svga_t *svga, int x, int y, int map, uint32_t b
     return px;
 }
 
-
 static uint32_t
 xga_accel_read_map_pixel(svga_t *svga, int x, int y, int map, uint32_t base, int width)
 {
-    xga_t *xga = &svga->xga;
+    xga_t   *xga  = &svga->xga;
     uint32_t addr = base;
-    int bits;
+    int      bits;
     uint32_t byte;
-    uint8_t px;
-    int skip = 0;
+    uint8_t  px;
+    int      skip = 0;
 
     if (xga->base_addr_1mb) {
         if (addr < xga->base_addr_1mb || (addr > (xga->base_addr_1mb + 0xfffff)))
@@ -831,10 +874,10 @@ xga_accel_read_map_pixel(svga_t *svga, int x, int y, int map, uint32_t base, int
 static void
 xga_accel_write_map_pixel(svga_t *svga, int x, int y, int map, uint32_t base, uint32_t pixel, int width)
 {
-    xga_t *xga = &svga->xga;
+    xga_t   *xga  = &svga->xga;
     uint32_t addr = base;
-    uint8_t byte, mask;
-    int skip = 0;
+    uint8_t  byte, mask;
+    int      skip = 0;
 
     if (xga->base_addr_1mb) {
         if (addr < xga->base_addr_1mb || (addr > (xga->base_addr_1mb + 0xfffff)))
@@ -848,11 +891,11 @@ xga_accel_write_map_pixel(svga_t *svga, int x, int y, int map, uint32_t base, ui
         case 0: /*1-bit*/
             addr += (y * (width) >> 3);
             addr += (x >> 3);
-			if (!skip) {
+            if (!skip) {
                 READ(addr, byte);
-			} else {
+            } else {
                 byte = mem_readb_phys(addr);
-			}
+            }
             if ((xga->accel.px_map_format[map] & 8) && !(xga->access_mode & 8)) {
                 if (xga->linear_endian_reverse)
                     mask = 1 << (7 - (x & 7));
@@ -905,15 +948,15 @@ xga_accel_write_map_pixel(svga_t *svga, int x, int y, int map, uint32_t base, ui
 static void
 xga_short_stroke(svga_t *svga, uint8_t ssv)
 {
-    xga_t *xga = &svga->xga;
+    xga_t   *xga = &svga->xga;
     uint32_t src_dat, dest_dat, old_dest_dat;
-    uint32_t color_cmp = xga->accel.color_cmp;
+    uint32_t color_cmp  = xga->accel.color_cmp;
     uint32_t plane_mask = xga->accel.plane_mask;
-    uint32_t dstbase = xga->accel.px_map_base[xga->accel.dst_map];
-    uint32_t srcbase = xga->accel.px_map_base[xga->accel.src_map];
-    int y = ssv & 0x0f;
-    int x = 0;
-    int dx, dy, dirx = 0, diry = 0;
+    uint32_t dstbase    = xga->accel.px_map_base[xga->accel.dst_map];
+    uint32_t srcbase    = xga->accel.px_map_base[xga->accel.src_map];
+    int      y          = ssv & 0x0f;
+    int      x          = 0;
+    int      dx, dy, dirx = 0, diry = 0;
 
     dx = xga->accel.dst_map_x & 0x1fff;
     if (xga->accel.dst_map_x & 0x1800)
@@ -961,18 +1004,11 @@ xga_short_stroke(svga_t *svga, uint8_t ssv)
     if (xga->accel.pat_src == 8) {
         while (y >= 0) {
             if (xga->accel.command & 0xc0) {
-                if ((dx >= xga->accel.mask_map_origin_x_off) && (dx <= ((xga->accel.px_map_width[0] & 0xfff) + xga->accel.mask_map_origin_x_off)) &&
-                    (dy >= xga->accel.mask_map_origin_y_off) && (dy <= ((xga->accel.px_map_height[0] & 0xfff) + xga->accel.mask_map_origin_y_off))) {
-                    src_dat = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
+                if ((dx >= xga->accel.mask_map_origin_x_off) && (dx <= ((xga->accel.px_map_width[0] & 0xfff) + xga->accel.mask_map_origin_x_off)) && (dy >= xga->accel.mask_map_origin_y_off) && (dy <= ((xga->accel.px_map_height[0] & 0xfff) + xga->accel.mask_map_origin_y_off))) {
+                    src_dat  = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
                     dest_dat = xga_accel_read_map_pixel(svga, dx, dy, xga->accel.dst_map, dstbase, xga->accel.px_map_width[xga->accel.dst_map] + 1);
 
-                    if ((xga->accel.cc_cond == 4) ||
-                        ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) ||
-                        ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) ||
-                        ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) ||
-                        ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) ||
-                        ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) ||
-                        ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
+                    if ((xga->accel.cc_cond == 4) || ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) || ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) || ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) || ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) || ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) || ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
                         old_dest_dat = dest_dat;
                         ROP(1, dest_dat, src_dat);
                         dest_dat = (dest_dat & plane_mask) | (old_dest_dat & ~plane_mask);
@@ -989,16 +1025,10 @@ xga_short_stroke(svga_t *svga, uint8_t ssv)
                     }
                 }
             } else {
-                src_dat = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
+                src_dat  = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
                 dest_dat = xga_accel_read_map_pixel(svga, dx, dy, xga->accel.dst_map, dstbase, xga->accel.px_map_width[xga->accel.dst_map] + 1);
 
-                if ((xga->accel.cc_cond == 4) ||
-                    ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) ||
-                    ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) ||
-                    ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) ||
-                    ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) ||
-                    ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) ||
-                    ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
+                if ((xga->accel.cc_cond == 4) || ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) || ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) || ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) || ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) || ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) || ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
                     old_dest_dat = dest_dat;
                     ROP(1, dest_dat, src_dat);
                     dest_dat = (dest_dat & plane_mask) | (old_dest_dat & ~plane_mask);
@@ -1031,37 +1061,40 @@ xga_short_stroke(svga_t *svga, uint8_t ssv)
     xga->accel.dst_map_y = dy;
 }
 
-#define SWAP(a,b) tmpswap = a; a = b; b = tmpswap;
+#define SWAP(a, b) \
+    tmpswap = a;   \
+    a       = b;   \
+    b       = tmpswap;
 
 static void
 xga_line_draw_write(svga_t *svga)
 {
-    xga_t *xga = &svga->xga;
+    xga_t   *xga = &svga->xga;
     uint32_t src_dat, dest_dat, old_dest_dat;
-    uint32_t color_cmp = xga->accel.color_cmp;
+    uint32_t color_cmp  = xga->accel.color_cmp;
     uint32_t plane_mask = xga->accel.plane_mask;
-    uint32_t dstbase = xga->accel.px_map_base[xga->accel.dst_map];
-    uint32_t srcbase = xga->accel.px_map_base[xga->accel.src_map];
-    int dminor, destxtmp, dmajor, err, tmpswap;
-    int steep = 1;
-    int xdir, ydir;
-    int y = xga->accel.blt_width;
-    int x = 0;
-    int dx, dy;
+    uint32_t dstbase    = xga->accel.px_map_base[xga->accel.dst_map];
+    uint32_t srcbase    = xga->accel.px_map_base[xga->accel.src_map];
+    int      dminor, destxtmp, dmajor, err, tmpswap;
+    int      steep = 1;
+    int      xdir, ydir;
+    int      y = xga->accel.blt_width;
+    int      x = 0;
+    int      dx, dy;
 
-	dminor = ((int16_t)xga->accel.bres_k1);
-	if (xga->accel.bres_k1 & 0x2000)
+    dminor = ((int16_t) xga->accel.bres_k1);
+    if (xga->accel.bres_k1 & 0x2000)
         dminor |= ~0x1fff;
-	dminor >>= 1;
+    dminor >>= 1;
 
-	destxtmp = ((int16_t)xga->accel.bres_k2);
-	if (xga->accel.bres_k2 & 0x2000)
+    destxtmp = ((int16_t) xga->accel.bres_k2);
+    if (xga->accel.bres_k2 & 0x2000)
         destxtmp |= ~0x1fff;
 
     dmajor = -(destxtmp - (dminor << 1)) >> 1;
 
-	err = ((int16_t)xga->accel.bres_err_term);
-	if (xga->accel.bres_err_term & 0x2000)
+    err = ((int16_t) xga->accel.bres_err_term);
+    if (xga->accel.bres_err_term & 0x2000)
         destxtmp |= ~0x1fff;
 
     if (xga->accel.octant & 0x02) {
@@ -1085,27 +1118,20 @@ xga_line_draw_write(svga_t *svga)
         dy |= ~0x17ff;
 
     if (xga->accel.octant & 0x01) {
-		steep = 0;
-		SWAP(dx, dy);
-		SWAP(xdir, ydir);
+        steep = 0;
+        SWAP(dx, dy);
+        SWAP(xdir, ydir);
     }
 
     if (xga->accel.pat_src == 8) {
         while (y >= 0) {
             if (xga->accel.command & 0xc0) {
                 if (steep) {
-                    if ((dx >= xga->accel.mask_map_origin_x_off) && (dx <= ((xga->accel.px_map_width[0] & 0xfff) + xga->accel.mask_map_origin_x_off)) &&
-                        (dy >= xga->accel.mask_map_origin_y_off) && (dy <= ((xga->accel.px_map_height[0] & 0xfff) + xga->accel.mask_map_origin_y_off))) {
-                        src_dat = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
+                    if ((dx >= xga->accel.mask_map_origin_x_off) && (dx <= ((xga->accel.px_map_width[0] & 0xfff) + xga->accel.mask_map_origin_x_off)) && (dy >= xga->accel.mask_map_origin_y_off) && (dy <= ((xga->accel.px_map_height[0] & 0xfff) + xga->accel.mask_map_origin_y_off))) {
+                        src_dat  = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
                         dest_dat = xga_accel_read_map_pixel(svga, dx, dy, xga->accel.dst_map, dstbase, xga->accel.px_map_width[xga->accel.dst_map] + 1);
 
-                        if ((xga->accel.cc_cond == 4) ||
-                            ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) ||
-                            ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) ||
-                            ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) ||
-                            ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) ||
-                            ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) ||
-                            ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
+                        if ((xga->accel.cc_cond == 4) || ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) || ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) || ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) || ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) || ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) || ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
                             old_dest_dat = dest_dat;
                             ROP(1, dest_dat, src_dat);
                             dest_dat = (dest_dat & plane_mask) | (old_dest_dat & ~plane_mask);
@@ -1118,18 +1144,11 @@ xga_line_draw_write(svga_t *svga)
                         }
                     }
                 } else {
-                    if ((dy >= xga->accel.mask_map_origin_x_off) && (dy <= ((xga->accel.px_map_width[0] & 0xfff) + xga->accel.mask_map_origin_x_off)) &&
-                        (dx >= xga->accel.mask_map_origin_y_off) && (dx <= ((xga->accel.px_map_height[0] & 0xfff) + xga->accel.mask_map_origin_y_off))) {
-                        src_dat = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
+                    if ((dy >= xga->accel.mask_map_origin_x_off) && (dy <= ((xga->accel.px_map_width[0] & 0xfff) + xga->accel.mask_map_origin_x_off)) && (dx >= xga->accel.mask_map_origin_y_off) && (dx <= ((xga->accel.px_map_height[0] & 0xfff) + xga->accel.mask_map_origin_y_off))) {
+                        src_dat  = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
                         dest_dat = xga_accel_read_map_pixel(svga, dy, dx, xga->accel.dst_map, dstbase, xga->accel.px_map_width[xga->accel.dst_map] + 1);
 
-                        if ((xga->accel.cc_cond == 4) ||
-                            ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) ||
-                            ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) ||
-                            ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) ||
-                            ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) ||
-                            ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) ||
-                            ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
+                        if ((xga->accel.cc_cond == 4) || ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) || ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) || ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) || ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) || ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) || ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
                             old_dest_dat = dest_dat;
                             ROP(1, dest_dat, src_dat);
                             dest_dat = (dest_dat & plane_mask) | (old_dest_dat & ~plane_mask);
@@ -1144,16 +1163,10 @@ xga_line_draw_write(svga_t *svga)
                 }
             } else {
                 if (steep) {
-                    src_dat = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
+                    src_dat  = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
                     dest_dat = xga_accel_read_map_pixel(svga, dx, dy, xga->accel.dst_map, dstbase, xga->accel.px_map_width[xga->accel.dst_map] + 1);
 
-                    if ((xga->accel.cc_cond == 4) ||
-                        ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) ||
-                        ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) ||
-                        ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) ||
-                        ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) ||
-                        ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) ||
-                        ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
+                    if ((xga->accel.cc_cond == 4) || ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) || ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) || ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) || ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) || ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) || ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
                         old_dest_dat = dest_dat;
                         ROP(1, dest_dat, src_dat);
                         dest_dat = (dest_dat & plane_mask) | (old_dest_dat & ~plane_mask);
@@ -1165,16 +1178,10 @@ xga_line_draw_write(svga_t *svga)
                             xga_accel_write_map_pixel(svga, dx, dy, xga->accel.dst_map, dstbase, dest_dat, xga->accel.px_map_width[xga->accel.dst_map] + 1);
                     }
                 } else {
-                    src_dat = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
+                    src_dat  = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.src_map_x & 0xfff, xga->accel.src_map_y & 0xfff, xga->accel.src_map, srcbase, xga->accel.px_map_width[xga->accel.src_map] + 1) : xga->accel.frgd_color;
                     dest_dat = xga_accel_read_map_pixel(svga, dy, dx, xga->accel.dst_map, dstbase, xga->accel.px_map_width[xga->accel.dst_map] + 1);
 
-                    if ((xga->accel.cc_cond == 4) ||
-                        ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) ||
-                        ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) ||
-                        ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) ||
-                        ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) ||
-                        ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) ||
-                        ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
+                    if ((xga->accel.cc_cond == 4) || ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) || ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) || ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) || ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) || ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) || ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
                         old_dest_dat = dest_dat;
                         ROP(1, dest_dat, src_dat);
                         dest_dat = (dest_dat & plane_mask) | (old_dest_dat & ~plane_mask);
@@ -1214,7 +1221,6 @@ xga_line_draw_write(svga_t *svga)
     }
 }
 
-
 static int16_t
 xga_dst_wrap(int16_t addr)
 {
@@ -1225,20 +1231,20 @@ xga_dst_wrap(int16_t addr)
 static void
 xga_bitblt(svga_t *svga)
 {
-    xga_t *xga = &svga->xga;
+    xga_t   *xga = &svga->xga;
     uint32_t src_dat, dest_dat, old_dest_dat;
-    uint32_t color_cmp = xga->accel.color_cmp;
+    uint32_t color_cmp  = xga->accel.color_cmp;
     uint32_t plane_mask = xga->accel.plane_mask;
-    uint32_t patbase = xga->accel.px_map_base[xga->accel.pat_src];
-    uint32_t dstbase = xga->accel.px_map_base[xga->accel.dst_map];
-    uint32_t srcbase = xga->accel.px_map_base[xga->accel.src_map];
-    uint32_t patwidth = xga->accel.px_map_width[xga->accel.pat_src];
-    uint32_t dstwidth = xga->accel.px_map_width[xga->accel.dst_map];
-    uint32_t srcwidth = xga->accel.px_map_width[xga->accel.src_map];
-    uint32_t patheight = xga->accel.px_map_height[xga->accel.pat_src];
-    uint32_t srcheight = xga->accel.px_map_height[xga->accel.src_map];
-    int mix = 0;
-    int xdir, ydir;
+    uint32_t patbase    = xga->accel.px_map_base[xga->accel.pat_src];
+    uint32_t dstbase    = xga->accel.px_map_base[xga->accel.dst_map];
+    uint32_t srcbase    = xga->accel.px_map_base[xga->accel.src_map];
+    uint32_t patwidth   = xga->accel.px_map_width[xga->accel.pat_src];
+    uint32_t dstwidth   = xga->accel.px_map_width[xga->accel.dst_map];
+    uint32_t srcwidth   = xga->accel.px_map_width[xga->accel.src_map];
+    uint32_t patheight  = xga->accel.px_map_height[xga->accel.pat_src];
+    uint32_t srcheight  = xga->accel.px_map_height[xga->accel.src_map];
+    int      mix        = 0;
+    int      xdir, ydir;
 
     if (xga->accel.octant & 0x02) {
         ydir = -1;
@@ -1277,22 +1283,15 @@ xga_bitblt(svga_t *svga)
             }
         }
 
-        //pclog("Pattern Map = 8: CMD = %08x: SRCBase = %08x, DSTBase = %08x, from/to vram dir = %d, cmd dir = %06x\n", xga->accel.command, srcbase, dstbase, xga->from_to_vram, xga->accel.dir_cmd);
-        //pclog("CMD = %08x: Y = %d, X = %d, patsrc = %02x, srcmap = %d, dstmap = %d, py = %d, sy = %d, dy = %d, width0 = %d, width1 = %d, width2 = %d, width3 = %d\n", xga->accel.command, xga->accel.y, xga->accel.x, xga->accel.pat_src, xga->accel.src_map, xga->accel.dst_map, xga->accel.py, xga->accel.sy, xga->accel.dy, xga->accel.px_map_width[0], xga->accel.px_map_width[1], xga->accel.px_map_width[2], xga->accel.px_map_width[3]);
+        // pclog("Pattern Map = 8: CMD = %08x: SRCBase = %08x, DSTBase = %08x, from/to vram dir = %d, cmd dir = %06x\n", xga->accel.command, srcbase, dstbase, xga->from_to_vram, xga->accel.dir_cmd);
+        // pclog("CMD = %08x: Y = %d, X = %d, patsrc = %02x, srcmap = %d, dstmap = %d, py = %d, sy = %d, dy = %d, width0 = %d, width1 = %d, width2 = %d, width3 = %d\n", xga->accel.command, xga->accel.y, xga->accel.x, xga->accel.pat_src, xga->accel.src_map, xga->accel.dst_map, xga->accel.py, xga->accel.sy, xga->accel.dy, xga->accel.px_map_width[0], xga->accel.px_map_width[1], xga->accel.px_map_width[2], xga->accel.px_map_width[3]);
         while (xga->accel.y >= 0) {
             if (xga->accel.command & 0xc0) {
-                if ((xga->accel.dx >= xga->accel.mask_map_origin_x_off) && (xga->accel.dx <= ((xga->accel.px_map_width[0] & 0xfff) + xga->accel.mask_map_origin_x_off)) &&
-                    (xga->accel.dy >= xga->accel.mask_map_origin_y_off) && (xga->accel.dy <= ((xga->accel.px_map_height[0] & 0xfff) + xga->accel.mask_map_origin_y_off))) {
-                    src_dat = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.sx, xga->accel.sy, xga->accel.src_map, srcbase, srcwidth + 1) : xga->accel.frgd_color;
+                if ((xga->accel.dx >= xga->accel.mask_map_origin_x_off) && (xga->accel.dx <= ((xga->accel.px_map_width[0] & 0xfff) + xga->accel.mask_map_origin_x_off)) && (xga->accel.dy >= xga->accel.mask_map_origin_y_off) && (xga->accel.dy <= ((xga->accel.px_map_height[0] & 0xfff) + xga->accel.mask_map_origin_y_off))) {
+                    src_dat  = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.sx, xga->accel.sy, xga->accel.src_map, srcbase, srcwidth + 1) : xga->accel.frgd_color;
                     dest_dat = xga_accel_read_map_pixel(svga, xga->accel.dx, xga->accel.dy, xga->accel.dst_map, dstbase, dstwidth + 1);
 
-                    if ((xga->accel.cc_cond == 4) ||
-                        ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) ||
-                        ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) ||
-                        ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) ||
-                        ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) ||
-                        ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) ||
-                        ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
+                    if ((xga->accel.cc_cond == 4) || ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) || ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) || ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) || ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) || ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) || ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
                         old_dest_dat = dest_dat;
                         ROP(1, dest_dat, src_dat);
                         dest_dat = (dest_dat & plane_mask) | (old_dest_dat & ~plane_mask);
@@ -1300,16 +1299,10 @@ xga_bitblt(svga_t *svga)
                     }
                 }
             } else {
-                src_dat = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.sx, xga->accel.sy, xga->accel.src_map, srcbase, srcwidth + 1) : xga->accel.frgd_color;
+                src_dat  = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.sx, xga->accel.sy, xga->accel.src_map, srcbase, srcwidth + 1) : xga->accel.frgd_color;
                 dest_dat = xga_accel_read_map_pixel(svga, xga->accel.dx, xga->accel.dy, xga->accel.dst_map, dstbase, dstwidth + 1);
 
-                if ((xga->accel.cc_cond == 4) ||
-                    ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) ||
-                    ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) ||
-                    ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) ||
-                    ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) ||
-                    ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) ||
-                    ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
+                if ((xga->accel.cc_cond == 4) || ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) || ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) || ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) || ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) || ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) || ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
                     old_dest_dat = dest_dat;
                     ROP(1, dest_dat, src_dat);
                     dest_dat = (dest_dat & plane_mask) | (old_dest_dat & ~plane_mask);
@@ -1368,14 +1361,13 @@ xga_bitblt(svga_t *svga)
             }
         }
 
-        //pclog("Pattern Map = %d: CMD = %08x: PATBase = %08x, SRCBase = %08x, DSTBase = %08x\n", xga->accel.pat_src, xga->accel.command, patbase, srcbase, dstbase);
-        //pclog("CMD = %08x: Y = %d, X = %d, patsrc = %02x, srcmap = %d, dstmap = %d, py = %d, sy = %d, dy = %d, width0 = %d, width1 = %d, width2 = %d, width3 = %d\n", xga->accel.command, xga->accel.y, xga->accel.x, xga->accel.pat_src, xga->accel.src_map, xga->accel.dst_map, xga->accel.py, xga->accel.sy, xga->accel.dy, xga->accel.px_map_width[0], xga->accel.px_map_width[1], xga->accel.px_map_width[2], xga->accel.px_map_width[3]);
+        // pclog("Pattern Map = %d: CMD = %08x: PATBase = %08x, SRCBase = %08x, DSTBase = %08x\n", xga->accel.pat_src, xga->accel.command, patbase, srcbase, dstbase);
+        // pclog("CMD = %08x: Y = %d, X = %d, patsrc = %02x, srcmap = %d, dstmap = %d, py = %d, sy = %d, dy = %d, width0 = %d, width1 = %d, width2 = %d, width3 = %d\n", xga->accel.command, xga->accel.y, xga->accel.x, xga->accel.pat_src, xga->accel.src_map, xga->accel.dst_map, xga->accel.py, xga->accel.sy, xga->accel.dy, xga->accel.px_map_width[0], xga->accel.px_map_width[1], xga->accel.px_map_width[2], xga->accel.px_map_width[3]);
         while (xga->accel.y >= 0) {
             mix = xga_accel_read_pattern_map_pixel(svga, xga->accel.px, xga->accel.py, xga->accel.pat_src, patbase, patwidth + 1);
 
             if (xga->accel.command & 0xc0) {
-                if ((xga->accel.dx >= xga->accel.mask_map_origin_x_off) && (xga->accel.dx <= ((xga->accel.px_map_width[0] & 0xfff) + xga->accel.mask_map_origin_x_off)) &&
-                    (xga->accel.dy >= xga->accel.mask_map_origin_y_off) && (xga->accel.dy <= ((xga->accel.px_map_height[0] & 0xfff) + xga->accel.mask_map_origin_y_off))) {
+                if ((xga->accel.dx >= xga->accel.mask_map_origin_x_off) && (xga->accel.dx <= ((xga->accel.px_map_width[0] & 0xfff) + xga->accel.mask_map_origin_x_off)) && (xga->accel.dy >= xga->accel.mask_map_origin_y_off) && (xga->accel.dy <= ((xga->accel.px_map_height[0] & 0xfff) + xga->accel.mask_map_origin_y_off))) {
                     if (mix)
                         src_dat = (((xga->accel.command >> 28) & 3) == 2) ? xga_accel_read_map_pixel(svga, xga->accel.sx, xga->accel.sy, xga->accel.src_map, srcbase, srcwidth + 1) : xga->accel.frgd_color;
                     else
@@ -1383,13 +1375,7 @@ xga_bitblt(svga_t *svga)
 
                     dest_dat = xga_accel_read_map_pixel(svga, xga->accel.dx, xga->accel.dy, xga->accel.dst_map, dstbase, dstwidth + 1);
 
-                    if ((xga->accel.cc_cond == 4) ||
-                        ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) ||
-                        ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) ||
-                        ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) ||
-                        ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) ||
-                        ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) ||
-                        ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
+                    if ((xga->accel.cc_cond == 4) || ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) || ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) || ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) || ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) || ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) || ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
                         old_dest_dat = dest_dat;
                         ROP(mix, dest_dat, src_dat);
                         dest_dat = (dest_dat & plane_mask) | (old_dest_dat & ~plane_mask);
@@ -1404,20 +1390,13 @@ xga_bitblt(svga_t *svga)
 
                 dest_dat = xga_accel_read_map_pixel(svga, xga->accel.dx, xga->accel.dy, xga->accel.dst_map, dstbase, dstwidth + 1);
 
-                if ((xga->accel.cc_cond == 4) ||
-                    ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) ||
-                    ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) ||
-                    ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) ||
-                    ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) ||
-                    ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) ||
-                    ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
+                if ((xga->accel.cc_cond == 4) || ((xga->accel.cc_cond == 1) && (dest_dat > color_cmp)) || ((xga->accel.cc_cond == 2) && (dest_dat == color_cmp)) || ((xga->accel.cc_cond == 3) && (dest_dat < color_cmp)) || ((xga->accel.cc_cond == 5) && (dest_dat >= color_cmp)) || ((xga->accel.cc_cond == 6) && (dest_dat != color_cmp)) || ((xga->accel.cc_cond == 7) && (dest_dat <= color_cmp))) {
                     old_dest_dat = dest_dat;
                     ROP(mix, dest_dat, src_dat);
                     dest_dat = (dest_dat & plane_mask) | (old_dest_dat & ~plane_mask);
                     xga_accel_write_map_pixel(svga, xga->accel.dx, xga->accel.dy, xga->accel.dst_map, dstbase, dest_dat, dstwidth + 1);
                 }
             }
-
 
             xga->accel.sx += xdir;
             if (xga->accel.pattern)
@@ -1487,7 +1466,7 @@ xga_mem_write(uint32_t addr, uint32_t val, xga_t *xga, svga_t *svga, int len)
 
             case 0x18:
                 if (len == 4) {
-                    xga->accel.px_map_width[xga->accel.px_map_idx] = val & 0xffff;
+                    xga->accel.px_map_width[xga->accel.px_map_idx]  = val & 0xffff;
                     xga->accel.px_map_height[xga->accel.px_map_idx] = (val >> 16) & 0xffff;
                 } else if (len == 2) {
                     xga->accel.px_map_width[xga->accel.px_map_idx] = val & 0xffff;
@@ -1564,13 +1543,13 @@ xga_mem_write(uint32_t addr, uint32_t val, xga_t *xga, svga_t *svga, int len)
 
             case 0x2c:
                 if (len == 4) {
-                    xga->accel.short_stroke = val;
+                    xga->accel.short_stroke         = val;
                     xga->accel.short_stroke_vector1 = xga->accel.short_stroke & 0xff;
                     xga->accel.short_stroke_vector2 = (xga->accel.short_stroke >> 8) & 0xff;
                     xga->accel.short_stroke_vector3 = (xga->accel.short_stroke >> 16) & 0xff;
                     xga->accel.short_stroke_vector4 = (xga->accel.short_stroke >> 24) & 0xff;
 
-                    //pclog("1Vector = %02x, 2Vector = %02x, 3Vector = %02x, 4Vector = %02x\n", xga->accel.short_stroke_vector1, xga->accel.short_stroke_vector2, xga->accel.short_stroke_vector3, xga->accel.short_stroke_vector4);
+                    // pclog("1Vector = %02x, 2Vector = %02x, 3Vector = %02x, 4Vector = %02x\n", xga->accel.short_stroke_vector1, xga->accel.short_stroke_vector2, xga->accel.short_stroke_vector3, xga->accel.short_stroke_vector4);
                     xga_short_stroke(svga, xga->accel.short_stroke_vector1);
                     xga_short_stroke(svga, xga->accel.short_stroke_vector2);
                     xga_short_stroke(svga, xga->accel.short_stroke_vector3);
@@ -1600,7 +1579,7 @@ xga_mem_write(uint32_t addr, uint32_t val, xga_t *xga, svga_t *svga, int len)
                 xga->accel.frgd_mix = val & 0xff;
                 if (len == 4) {
                     xga->accel.bkgd_mix = (val >> 8) & 0xff;
-                    xga->accel.cc_cond = (val >> 16) & 0x07;
+                    xga->accel.cc_cond  = (val >> 16) & 0x07;
                 } else if (len == 2) {
                     xga->accel.bkgd_mix = (val >> 8) & 0xff;
                 }
@@ -1708,7 +1687,7 @@ xga_mem_write(uint32_t addr, uint32_t val, xga_t *xga, svga_t *svga, int len)
 
             case 0x60:
                 if (len == 4) {
-                    xga->accel.blt_width = val & 0xffff;
+                    xga->accel.blt_width  = val & 0xffff;
                     xga->accel.blt_height = (val >> 16) & 0xffff;
                 } else if (len == 2) {
                     xga->accel.blt_width = val;
@@ -1835,30 +1814,30 @@ xga_mem_write(uint32_t addr, uint32_t val, xga_t *xga, svga_t *svga, int len)
                 if (len == 4) {
                     xga->accel.command = val;
 exec_command:
-                    xga->accel.octant = xga->accel.command & 0x07;
+                    xga->accel.octant    = xga->accel.command & 0x07;
                     xga->accel.draw_mode = xga->accel.command & 0x30;
                     xga->accel.mask_mode = xga->accel.command & 0xc0;
-                    xga->accel.pat_src = ((xga->accel.command >> 12) & 0x0f);
-                    xga->accel.dst_map = ((xga->accel.command >> 16) & 0x0f);
-                    xga->accel.src_map = ((xga->accel.command >> 20) & 0x0f);
+                    xga->accel.pat_src   = ((xga->accel.command >> 12) & 0x0f);
+                    xga->accel.dst_map   = ((xga->accel.command >> 16) & 0x0f);
+                    xga->accel.src_map   = ((xga->accel.command >> 20) & 0x0f);
 
-                    //if (xga->accel.pat_src) {
-                    //    pclog("[%04X:%08X]: Accel Command = %02x, full = %08x, patwidth = %d, dstwidth = %d, srcwidth = %d, patheight = %d, dstheight = %d, srcheight = %d, px = %d, py = %d, dx = %d, dy = %d, sx = %d, sy = %d, patsrc = %d, dstmap = %d, srcmap = %d, dstbase = %08x, srcbase = %08x, patbase = %08x, dstformat = %x, srcformat = %x, planemask = %08x\n",
-                    //      CS, cpu_state.pc, ((xga->accel.command >> 24) & 0x0f), xga->accel.command, xga->accel.px_map_width[xga->accel.pat_src],
-                    //      xga->accel.px_map_width[xga->accel.dst_map], xga->accel.px_map_width[xga->accel.src_map],
-                    //      xga->accel.px_map_height[xga->accel.pat_src], xga->accel.px_map_height[xga->accel.dst_map],
-                    //      xga->accel.px_map_height[xga->accel.src_map],
-                    //      xga->accel.pat_map_x, xga->accel.pat_map_y,
-                    //      xga->accel.dst_map_x, xga->accel.dst_map_y,
-                    //      xga->accel.src_map_x, xga->accel.src_map_y,
-                    //      xga->accel.pat_src, xga->accel.dst_map, xga->accel.src_map,
-                    //      xga->accel.px_map_base[xga->accel.dst_map], xga->accel.px_map_base[xga->accel.src_map], xga->accel.px_map_base[xga->accel.pat_src],
-                    //      xga->accel.px_map_format[xga->accel.dst_map] & 0x0f, xga->accel.px_map_format[xga->accel.src_map] & 0x0f, xga->accel.plane_mask);
-                    //    //pclog("\n");
-                    //}
+                    // if (xga->accel.pat_src) {
+                    //     pclog("[%04X:%08X]: Accel Command = %02x, full = %08x, patwidth = %d, dstwidth = %d, srcwidth = %d, patheight = %d, dstheight = %d, srcheight = %d, px = %d, py = %d, dx = %d, dy = %d, sx = %d, sy = %d, patsrc = %d, dstmap = %d, srcmap = %d, dstbase = %08x, srcbase = %08x, patbase = %08x, dstformat = %x, srcformat = %x, planemask = %08x\n",
+                    //       CS, cpu_state.pc, ((xga->accel.command >> 24) & 0x0f), xga->accel.command, xga->accel.px_map_width[xga->accel.pat_src],
+                    //       xga->accel.px_map_width[xga->accel.dst_map], xga->accel.px_map_width[xga->accel.src_map],
+                    //       xga->accel.px_map_height[xga->accel.pat_src], xga->accel.px_map_height[xga->accel.dst_map],
+                    //       xga->accel.px_map_height[xga->accel.src_map],
+                    //       xga->accel.pat_map_x, xga->accel.pat_map_y,
+                    //       xga->accel.dst_map_x, xga->accel.dst_map_y,
+                    //       xga->accel.src_map_x, xga->accel.src_map_y,
+                    //       xga->accel.pat_src, xga->accel.dst_map, xga->accel.src_map,
+                    //       xga->accel.px_map_base[xga->accel.dst_map], xga->accel.px_map_base[xga->accel.src_map], xga->accel.px_map_base[xga->accel.pat_src],
+                    //       xga->accel.px_map_format[xga->accel.dst_map] & 0x0f, xga->accel.px_map_format[xga->accel.src_map] & 0x0f, xga->accel.plane_mask);
+                    //     //pclog("\n");
+                    // }
                     switch ((xga->accel.command >> 24) & 0x0f) {
                         case 3: /*Bresenham Line Draw Read*/
-                            //pclog("Line Draw Read\n");
+                            // pclog("Line Draw Read\n");
                             break;
                         case 4: /*Short Stroke Vectors*/
                             break;
@@ -1869,7 +1848,7 @@ exec_command:
                             xga_bitblt(svga);
                             break;
                         case 9: /*Inverting BitBLT*/
-                            //pclog("Inverting BitBLT\n");
+                            // pclog("Inverting BitBLT\n");
                             break;
                     }
                 } else if (len == 2) {
@@ -1901,31 +1880,31 @@ exec_command:
 static void
 xga_memio_writeb(uint32_t addr, uint8_t val, void *p)
 {
-    svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
+    svga_t *svga = (svga_t *) p;
+    xga_t  *xga  = &svga->xga;
 
     xga_mem_write(addr, val, xga, svga, 1);
-    //pclog("Write MEMIOB = %04x, val = %02x\n", addr & 0x7f, val);
+    // pclog("Write MEMIOB = %04x, val = %02x\n", addr & 0x7f, val);
 }
 
 static void
 xga_memio_writew(uint32_t addr, uint16_t val, void *p)
 {
-    svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
+    svga_t *svga = (svga_t *) p;
+    xga_t  *xga  = &svga->xga;
 
     xga_mem_write(addr, val, xga, svga, 2);
-    //pclog("Write MEMIOW = %04x, val = %04x\n", addr & 0x7f, val);
+    // pclog("Write MEMIOW = %04x, val = %04x\n", addr & 0x7f, val);
 }
 
 static void
 xga_memio_writel(uint32_t addr, uint32_t val, void *p)
 {
-    svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
+    svga_t *svga = (svga_t *) p;
+    xga_t  *xga  = &svga->xga;
 
     xga_mem_write(addr, val, xga, svga, 4);
-    //pclog("Write MEMIOL = %04x, val = %08x\n", addr & 0x7f, val);
+    // pclog("Write MEMIOL = %04x, val = %08x\n", addr & 0x7f, val);
 }
 
 static uint8_t
@@ -2002,35 +1981,35 @@ xga_mem_read(uint32_t addr, xga_t *xga, svga_t *svga)
 static uint8_t
 xga_memio_readb(uint32_t addr, void *p)
 {
-    svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
+    svga_t *svga = (svga_t *) p;
+    xga_t  *xga  = &svga->xga;
     uint8_t temp;
 
     temp = xga_mem_read(addr, xga, svga);
 
-    //pclog("[%04X:%08X]: Read MEMIOB = %04x, temp = %02x\n", CS, cpu_state.pc, addr, temp);
+    // pclog("[%04X:%08X]: Read MEMIOB = %04x, temp = %02x\n", CS, cpu_state.pc, addr, temp);
     return temp;
 }
 
 static uint16_t
 xga_memio_readw(uint32_t addr, void *p)
 {
-    svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
+    svga_t  *svga = (svga_t *) p;
+    xga_t   *xga  = &svga->xga;
     uint16_t temp;
 
     temp = xga_mem_read(addr, xga, svga);
     temp |= (xga_mem_read(addr + 1, xga, svga) << 8);
 
-    //pclog("[%04X:%08X]: Read MEMIOW = %04x, temp = %04x\n", CS, cpu_state.pc, addr, temp);
+    // pclog("[%04X:%08X]: Read MEMIOW = %04x, temp = %04x\n", CS, cpu_state.pc, addr, temp);
     return temp;
 }
 
 static uint32_t
 xga_memio_readl(uint32_t addr, void *p)
 {
-    svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
+    svga_t  *svga = (svga_t *) p;
+    xga_t   *xga  = &svga->xga;
     uint32_t temp;
 
     temp = xga_mem_read(addr, xga, svga);
@@ -2038,59 +2017,59 @@ xga_memio_readl(uint32_t addr, void *p)
     temp |= (xga_mem_read(addr + 2, xga, svga) << 16);
     temp |= (xga_mem_read(addr + 3, xga, svga) << 24);
 
-    //pclog("Read MEMIOL = %04x, temp = %08x\n", addr, temp);
+    // pclog("Read MEMIOL = %04x, temp = %08x\n", addr, temp);
     return temp;
 }
 
 static void
 xga_hwcursor_draw(svga_t *svga, int displine)
 {
-    xga_t *xga = &svga->xga;
-    uint8_t dat = 0;
-    int offset = xga->hwcursor_latch.x - xga->hwcursor_latch.xoff;
-    int x, x_pos, y_pos;
-    int comb = 0;
+    xga_t    *xga    = &svga->xga;
+    uint8_t   dat    = 0;
+    int       offset = xga->hwcursor_latch.x - xga->hwcursor_latch.xoff;
+    int       x, x_pos, y_pos;
+    int       comb = 0;
     uint32_t *p;
-    int idx = (xga->cursor_data_on) ? 32 : 0;
+    int       idx = (xga->cursor_data_on) ? 32 : 0;
 
     if (xga->interlace && xga->hwcursor_oddeven)
-	xga->hwcursor_latch.addr += 16;
+        xga->hwcursor_latch.addr += 16;
 
     y_pos = displine;
     x_pos = offset + svga->x_add;
-    p = buffer32->line[y_pos];
+    p     = buffer32->line[y_pos];
 
     for (x = 0; x < xga->hwcursor_latch.cur_xsize; x++) {
-    if (x >= idx) {
-        if (!(x & 0x03))
-            dat = xga->sprite_data[xga->hwcursor_latch.addr & 0x3ff];
+        if (x >= idx) {
+            if (!(x & 0x03))
+                dat = xga->sprite_data[xga->hwcursor_latch.addr & 0x3ff];
 
-        comb = (dat >> ((x & 0x03) << 1)) & 0x03;
+            comb = (dat >> ((x & 0x03) << 1)) & 0x03;
 
-        x_pos = offset + svga->x_add + x;
+            x_pos = offset + svga->x_add + x;
 
-        switch (comb) {
-            case 0x00:
-                /* Cursor Color 1 */
-                p[x_pos] = xga->hwc_color0;
-                break;
-            case 0x01:
-                /* Cursor Color 2 */
-                p[x_pos] = xga->hwc_color1;
-                break;
-            case 0x03:
-                /* Complement */
-                p[x_pos] ^= 0xffffff;
-                break;
+            switch (comb) {
+                case 0x00:
+                    /* Cursor Color 1 */
+                    p[x_pos] = xga->hwc_color0;
+                    break;
+                case 0x01:
+                    /* Cursor Color 2 */
+                    p[x_pos] = xga->hwc_color1;
+                    break;
+                case 0x03:
+                    /* Complement */
+                    p[x_pos] ^= 0xffffff;
+                    break;
+            }
         }
-    }
 
-	if ((x & 0x03) == 0x03)
-		xga->hwcursor_latch.addr++;
+        if ((x & 0x03) == 0x03)
+            xga->hwcursor_latch.addr++;
     }
 
     if (xga->interlace && !xga->hwcursor_oddeven)
-	xga->hwcursor_latch.addr += 16;
+        xga->hwcursor_latch.addr += 16;
 }
 
 static void
@@ -2099,13 +2078,13 @@ xga_render_overscan_left(xga_t *xga, svga_t *svga)
     int i;
 
     if ((xga->displine + svga->y_add) < 0)
-	return;
+        return;
 
     if (svga->scrblank || (xga->h_disp == 0))
-	return;
+        return;
 
     for (i = 0; i < svga->x_add; i++)
-	buffer32->line[xga->displine + svga->y_add][i] = svga->overscan_color;
+        buffer32->line[xga->displine + svga->y_add][i] = svga->overscan_color;
 }
 
 static void
@@ -2114,62 +2093,62 @@ xga_render_overscan_right(xga_t *xga, svga_t *svga)
     int i, right;
 
     if ((xga->displine + svga->y_add) < 0)
-	return;
+        return;
 
     if (svga->scrblank || (xga->h_disp == 0))
-	return;
+        return;
 
     right = (overscan_x >> 1);
     for (i = 0; i < right; i++)
-	buffer32->line[xga->displine + svga->y_add][svga->x_add + xga->h_disp + i] = svga->overscan_color;
+        buffer32->line[xga->displine + svga->y_add][svga->x_add + xga->h_disp + i] = svga->overscan_color;
 }
 
 static void
 xga_render_8bpp(xga_t *xga, svga_t *svga)
 {
-    int x;
+    int       x;
     uint32_t *p;
-    uint32_t dat;
+    uint32_t  dat;
 
     if ((xga->displine + svga->y_add) < 0)
-		return;
+        return;
 
     if (xga->changedvram[xga->ma >> 12] || xga->changedvram[(xga->ma >> 12) + 1] || svga->fullchange) {
-		p = &buffer32->line[xga->displine + svga->y_add][svga->x_add];
+        p = &buffer32->line[xga->displine + svga->y_add][svga->x_add];
 
-		if (xga->firstline_draw == 2000)
-			xga->firstline_draw = xga->displine;
-		xga->lastline_draw = xga->displine;
+        if (xga->firstline_draw == 2000)
+            xga->firstline_draw = xga->displine;
+        xga->lastline_draw = xga->displine;
 
-		for (x = 0; x <= xga->h_disp; x += 8) {
-			dat = *(uint32_t *)(&xga->vram[xga->ma & xga->vram_mask]);
-			p[0] = svga->pallook[dat & 0xff];
-			p[1] = svga->pallook[(dat >> 8) & 0xff];
-			p[2] = svga->pallook[(dat >> 16) & 0xff];
-			p[3] = svga->pallook[(dat >> 24) & 0xff];
+        for (x = 0; x <= xga->h_disp; x += 8) {
+            dat  = *(uint32_t *) (&xga->vram[xga->ma & xga->vram_mask]);
+            p[0] = svga->pallook[dat & 0xff];
+            p[1] = svga->pallook[(dat >> 8) & 0xff];
+            p[2] = svga->pallook[(dat >> 16) & 0xff];
+            p[3] = svga->pallook[(dat >> 24) & 0xff];
 
-            dat = *(uint32_t *)(&xga->vram[(xga->ma + 4) & xga->vram_mask]);
-			p[4] = svga->pallook[dat & 0xff];
-			p[5] = svga->pallook[(dat >> 8) & 0xff];
-			p[6] = svga->pallook[(dat >> 16) & 0xff];
-			p[7] = svga->pallook[(dat >> 24) & 0xff];
+            dat  = *(uint32_t *) (&xga->vram[(xga->ma + 4) & xga->vram_mask]);
+            p[4] = svga->pallook[dat & 0xff];
+            p[5] = svga->pallook[(dat >> 8) & 0xff];
+            p[6] = svga->pallook[(dat >> 16) & 0xff];
+            p[7] = svga->pallook[(dat >> 24) & 0xff];
 
-			xga->ma += 8;
-			p += 8;
-		}
-		xga->ma &= xga->vram_mask;
+            xga->ma += 8;
+            p += 8;
+        }
+        xga->ma &= xga->vram_mask;
     }
 }
 
 static void
 xga_render_16bpp(xga_t *xga, svga_t *svga)
 {
-    int x;
+    int       x;
     uint32_t *p;
-	uint32_t dat;
+    uint32_t  dat;
 
     if ((xga->displine + svga->y_add) < 0)
-		return;
+        return;
 
     if (xga->changedvram[xga->ma >> 12] || xga->changedvram[(xga->ma >> 12) + 1] || svga->fullchange) {
         p = &buffer32->line[xga->displine + svga->y_add][svga->x_add];
@@ -2179,19 +2158,19 @@ xga_render_16bpp(xga_t *xga, svga_t *svga)
         xga->lastline_draw = xga->displine;
 
         for (x = 0; x <= (xga->h_disp); x += 8) {
-            dat = *(uint32_t *)(&xga->vram[(xga->ma + (x << 1)) & xga->vram_mask]);
-            p[x] = video_16to32[dat & 0xffff];
+            dat      = *(uint32_t *) (&xga->vram[(xga->ma + (x << 1)) & xga->vram_mask]);
+            p[x]     = video_16to32[dat & 0xffff];
             p[x + 1] = video_16to32[dat >> 16];
 
-            dat = *(uint32_t *)(&xga->vram[(xga->ma + (x << 1) + 4) & xga->vram_mask]);
+            dat      = *(uint32_t *) (&xga->vram[(xga->ma + (x << 1) + 4) & xga->vram_mask]);
             p[x + 2] = video_16to32[dat & 0xffff];
             p[x + 3] = video_16to32[dat >> 16];
 
-            dat = *(uint32_t *)(&xga->vram[(xga->ma + (x << 1) + 8) & xga->vram_mask]);
+            dat      = *(uint32_t *) (&xga->vram[(xga->ma + (x << 1) + 8) & xga->vram_mask]);
             p[x + 4] = video_16to32[dat & 0xffff];
             p[x + 5] = video_16to32[dat >> 16];
 
-            dat = *(uint32_t *)(&xga->vram[(xga->ma + (x << 1) + 12) & xga->vram_mask]);
+            dat      = *(uint32_t *) (&xga->vram[(xga->ma + (x << 1) + 12) & xga->vram_mask]);
             p[x + 6] = video_16to32[dat & 0xffff];
             p[x + 7] = video_16to32[dat >> 16];
         }
@@ -2203,8 +2182,8 @@ xga_render_16bpp(xga_t *xga, svga_t *svga)
 static void
 xga_write(uint32_t addr, uint8_t val, void *p)
 {
-    svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
+    svga_t *svga = (svga_t *) p;
+    xga_t  *xga  = &svga->xga;
 
     if (!xga->on) {
         svga_write(addr, val, svga);
@@ -2220,20 +2199,20 @@ xga_write(uint32_t addr, uint8_t val, void *p)
     cycles -= video_timing_write_b;
 
     xga->changedvram[(addr & xga->vram_mask) >> 12] = changeframecount;
-    xga->vram[addr & xga->vram_mask] = val;
+    xga->vram[addr & xga->vram_mask]                = val;
 }
 
 static void
 xga_writeb(uint32_t addr, uint8_t val, void *p)
 {
-    //pclog("[%04X:%08X]: WriteB\n", CS, cpu_state.pc);
+    // pclog("[%04X:%08X]: WriteB\n", CS, cpu_state.pc);
     xga_write(addr, val, p);
 }
 
 static void
 xga_writew(uint32_t addr, uint16_t val, void *p)
 {
-    //pclog("[%04X:%08X]: WriteW\n", CS, cpu_state.pc);
+    // pclog("[%04X:%08X]: WriteW\n", CS, cpu_state.pc);
     xga_write(addr, val, p);
     xga_write(addr + 1, val >> 8, p);
 }
@@ -2241,7 +2220,7 @@ xga_writew(uint32_t addr, uint16_t val, void *p)
 static void
 xga_writel(uint32_t addr, uint32_t val, void *p)
 {
-    //pclog("[%04X:%08X]: WriteL\n", CS, cpu_state.pc);
+    // pclog("[%04X:%08X]: WriteL\n", CS, cpu_state.pc);
     xga_write(addr, val, p);
     xga_write(addr + 1, val >> 8, p);
     xga_write(addr + 2, val >> 16, p);
@@ -2251,8 +2230,8 @@ xga_writel(uint32_t addr, uint32_t val, void *p)
 static void
 xga_write_linear(uint32_t addr, uint8_t val, void *p)
 {
-    svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
+    svga_t *svga = (svga_t *) p;
+    xga_t  *xga  = &svga->xga;
 
     if (!xga->on) {
         svga_write_linear(addr, val, svga);
@@ -2267,14 +2246,14 @@ xga_write_linear(uint32_t addr, uint8_t val, void *p)
     cycles -= video_timing_write_b;
 
     xga->changedvram[(addr & xga->vram_mask) >> 12] = changeframecount;
-    xga->vram[addr & xga->vram_mask] = val;
+    xga->vram[addr & xga->vram_mask]                = val;
 }
 
 static void
 xga_writew_linear(uint32_t addr, uint16_t val, void *p)
 {
-    svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
+    svga_t *svga = (svga_t *) p;
+    xga_t  *xga  = &svga->xga;
 
     if (!xga->on) {
         svga_writew_linear(addr, val, svga);
@@ -2309,8 +2288,8 @@ xga_writew_linear(uint32_t addr, uint16_t val, void *p)
 static void
 xga_writel_linear(uint32_t addr, uint32_t val, void *p)
 {
-    svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
+    svga_t *svga = (svga_t *) p;
+    xga_t  *xga  = &svga->xga;
 
     if (!xga->on) {
         svga_writel_linear(addr, val, svga);
@@ -2326,8 +2305,8 @@ xga_writel_linear(uint32_t addr, uint32_t val, void *p)
 static uint8_t
 xga_read(uint32_t addr, void *p)
 {
-    svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
+    svga_t *svga = (svga_t *) p;
+    xga_t  *xga  = &svga->xga;
 
     if (!xga->on)
         return svga_read(addr, svga);
@@ -2380,8 +2359,8 @@ xga_readl(uint32_t addr, void *p)
 static uint8_t
 xga_read_linear(uint32_t addr, void *p)
 {
-    svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
+    svga_t *svga = (svga_t *) p;
+    xga_t  *xga  = &svga->xga;
 
     if (!xga->on)
         return svga_read_linear(addr, svga);
@@ -2399,8 +2378,8 @@ xga_read_linear(uint32_t addr, void *p)
 static uint16_t
 xga_readw_linear(uint32_t addr, void *p)
 {
-    svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
+    svga_t  *svga = (svga_t *) p;
+    xga_t   *xga  = &svga->xga;
     uint16_t ret;
 
     if (!xga->on)
@@ -2427,14 +2406,13 @@ xga_readw_linear(uint32_t addr, void *p)
 static uint32_t
 xga_readl_linear(uint32_t addr, void *p)
 {
-    svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
+    svga_t *svga = (svga_t *) p;
+    xga_t  *xga  = &svga->xga;
 
     if (!xga->on)
         return svga_readl_linear(addr, svga);
 
-    return xga_read_linear(addr, p) | (xga_read_linear(addr + 1, p) << 8) |
-        (xga_read_linear(addr + 2, p) << 16) | (xga_read_linear(addr + 3, p) << 24);
+    return xga_read_linear(addr, p) | (xga_read_linear(addr + 1, p) << 8) | (xga_read_linear(addr + 2, p) << 16) | (xga_read_linear(addr + 3, p) << 24);
 }
 
 static void
@@ -2451,16 +2429,16 @@ xga_do_render(svga_t *svga)
             break;
     }
 
-	svga->x_add = (overscan_x >> 1);
-	xga_render_overscan_left(xga, svga);
-	xga_render_overscan_right(xga, svga);
-	svga->x_add = (overscan_x >> 1);
+    svga->x_add = (overscan_x >> 1);
+    xga_render_overscan_left(xga, svga);
+    xga_render_overscan_right(xga, svga);
+    svga->x_add = (overscan_x >> 1);
 
     if (xga->hwcursor_on) {
-    xga_hwcursor_draw(svga, xga->displine + svga->y_add);
-	xga->hwcursor_on--;
-	if (xga->hwcursor_on && xga->interlace)
-		xga->hwcursor_on--;
+        xga_hwcursor_draw(svga, xga->displine + svga->y_add);
+        xga->hwcursor_on--;
+        if (xga->hwcursor_on && xga->interlace)
+            xga->hwcursor_on--;
     }
 }
 
@@ -2468,160 +2446,158 @@ void
 xga_poll(xga_t *xga, svga_t *svga)
 {
     uint32_t x;
-    int wx, wy;
+    int      wx, wy;
 
     if (!xga->linepos) {
-    if (xga->displine == xga->hwcursor_latch.y && xga->hwcursor_latch.ena) {
-        xga->hwcursor_on = xga->hwcursor_latch.cur_ysize - (xga->cursor_data_on ? 32 : 0);
-        xga->hwcursor_oddeven = 0;
-    }
-
-    if (xga->displine == (xga->hwcursor_latch.y + 1) && xga->hwcursor_latch.ena &&
-                   xga->interlace) {
-        xga->hwcursor_on = xga->hwcursor_latch.cur_ysize - (xga->cursor_data_on ? 33 : 1);
-        xga->hwcursor_oddeven = 1;
-    }
-
-    timer_advance_u64(&svga->timer, svga->dispofftime);
-    xga->linepos = 1;
-
-    if (xga->dispon) {
-        xga->h_disp_on = 1;
-
-        xga->ma &= xga->vram_mask;
-
-        if (xga->firstline == 2000) {
-            xga->firstline = xga->displine;
-            video_wait_for_buffer();
+        if (xga->displine == xga->hwcursor_latch.y && xga->hwcursor_latch.ena) {
+            xga->hwcursor_on      = xga->hwcursor_latch.cur_ysize - (xga->cursor_data_on ? 32 : 0);
+            xga->hwcursor_oddeven = 0;
         }
 
-        if (xga->hwcursor_on) {
-            xga->changedvram[xga->ma >> 12] = xga->changedvram[(xga->ma >> 12) + 1] =
-                                xga->interlace ? 3 : 2;
+        if (xga->displine == (xga->hwcursor_latch.y + 1) && xga->hwcursor_latch.ena && xga->interlace) {
+            xga->hwcursor_on      = xga->hwcursor_latch.cur_ysize - (xga->cursor_data_on ? 33 : 1);
+            xga->hwcursor_oddeven = 1;
         }
 
-        xga_do_render(svga);
+        timer_advance_u64(&svga->timer, svga->dispofftime);
+        xga->linepos = 1;
 
-        if (xga->lastline < xga->displine)
-            xga->lastline = xga->displine;
-    }
+        if (xga->dispon) {
+            xga->h_disp_on = 1;
 
-    xga->displine++;
-    if (xga->interlace)
-        xga->displine++;
-    if (xga->displine > 1500)
-        xga->displine = 0;
-    } else {
-    timer_advance_u64(&svga->timer, svga->dispontime);
-    xga->h_disp_on = 0;
+            xga->ma &= xga->vram_mask;
 
-    xga->linepos = 0;
-    if (xga->dispon) {
-        if (xga->sc == xga->rowcount) {
-            xga->sc = 0;
-
-            if ((xga->disp_cntl_2 & 7) == 4) {
-                xga->maback += (xga->rowoffset << 4);
-                if (xga->interlace)
-                    xga->maback += (xga->rowoffset << 4);
-            } else {
-                xga->maback += (xga->rowoffset << 3);
-                if (xga->interlace)
-                    xga->maback += (xga->rowoffset << 3);
+            if (xga->firstline == 2000) {
+                xga->firstline = xga->displine;
+                video_wait_for_buffer();
             }
-            xga->maback &= xga->vram_mask;
-            xga->ma = xga->maback;
-        } else {
-            xga->sc++;
-            xga->sc &= 0x1f;
-            xga->ma = xga->maback;
+
+            if (xga->hwcursor_on) {
+                xga->changedvram[xga->ma >> 12] = xga->changedvram[(xga->ma >> 12) + 1] = xga->interlace ? 3 : 2;
+            }
+
+            xga_do_render(svga);
+
+            if (xga->lastline < xga->displine)
+                xga->lastline = xga->displine;
         }
-    }
 
-    xga->vc++;
-    xga->vc &= 2047;
+        xga->displine++;
+        if (xga->interlace)
+            xga->displine++;
+        if (xga->displine > 1500)
+            xga->displine = 0;
+    } else {
+        timer_advance_u64(&svga->timer, svga->dispontime);
+        xga->h_disp_on = 0;
 
-    if (xga->vc == xga->split) {
-        if (xga->interlace && xga->oddeven)
-            xga->ma = xga->maback = (xga->rowoffset << 1);
-        else
-            xga->ma = xga->maback = 0;
-        xga->ma = (xga->ma << 2);
-        xga->maback = (xga->maback << 2);
+        xga->linepos = 0;
+        if (xga->dispon) {
+            if (xga->sc == xga->rowcount) {
+                xga->sc = 0;
 
-        xga->sc = 0;
-    }
-    if (xga->vc == xga->dispend) {
-        xga->dispon = 0;
-
-        for (x = 0; x < ((xga->vram_mask + 1) >> 12); x++) {
-            if (xga->changedvram[x])
-                xga->changedvram[x]--;
+                if ((xga->disp_cntl_2 & 7) == 4) {
+                    xga->maback += (xga->rowoffset << 4);
+                    if (xga->interlace)
+                        xga->maback += (xga->rowoffset << 4);
+                } else {
+                    xga->maback += (xga->rowoffset << 3);
+                    if (xga->interlace)
+                        xga->maback += (xga->rowoffset << 3);
+                }
+                xga->maback &= xga->vram_mask;
+                xga->ma = xga->maback;
+            } else {
+                xga->sc++;
+                xga->sc &= 0x1f;
+                xga->ma = xga->maback;
+            }
         }
-        if (svga->fullchange)
-            svga->fullchange--;
-    }
-    if (xga->vc == xga->v_syncstart) {
-        xga->dispon = 0;
-        x = xga->h_disp;
 
-        if (xga->interlace && !xga->oddeven)
-            xga->lastline++;
-        if (xga->interlace && xga->oddeven)
-            xga->firstline--;
+        xga->vc++;
+        xga->vc &= 2047;
 
-        wx = x;
+        if (xga->vc == xga->split) {
+            if (xga->interlace && xga->oddeven)
+                xga->ma = xga->maback = (xga->rowoffset << 1);
+            else
+                xga->ma = xga->maback = 0;
+            xga->ma     = (xga->ma << 2);
+            xga->maback = (xga->maback << 2);
 
-        wy = xga->lastline - xga->firstline;
-        svga_doblit(wx, wy, svga);
+            xga->sc = 0;
+        }
+        if (xga->vc == xga->dispend) {
+            xga->dispon = 0;
 
-        xga->firstline = 2000;
-        xga->lastline = 0;
+            for (x = 0; x < ((xga->vram_mask + 1) >> 12); x++) {
+                if (xga->changedvram[x])
+                    xga->changedvram[x]--;
+            }
+            if (svga->fullchange)
+                svga->fullchange--;
+        }
+        if (xga->vc == xga->v_syncstart) {
+            xga->dispon = 0;
+            x           = xga->h_disp;
 
-        xga->firstline_draw = 2000;
-        xga->lastline_draw = 0;
+            if (xga->interlace && !xga->oddeven)
+                xga->lastline++;
+            if (xga->interlace && xga->oddeven)
+                xga->firstline--;
 
-        xga->oddeven ^= 1;
+            wx = x;
 
-        changeframecount = xga->interlace ? 3 : 2;
+            wy = xga->lastline - xga->firstline;
+            svga_doblit(wx, wy, svga);
 
-        if (xga->interlace && xga->oddeven)
-            xga->ma = xga->maback = xga->ma_latch + (xga->rowoffset << 1);
-        else
-            xga->ma = xga->maback = xga->ma_latch;
+            xga->firstline = 2000;
+            xga->lastline  = 0;
 
-        xga->ma = (xga->ma << 2);
-        xga->maback = (xga->maback << 2);
-    }
-    if (xga->vc == xga->v_total) {
-        xga->vc = 0;
-        xga->sc = 0;
-        xga->dispon = 1;
-        xga->displine = (xga->interlace && xga->oddeven) ? 1 : 0;
+            xga->firstline_draw = 2000;
+            xga->lastline_draw  = 0;
 
-        svga->x_add = (overscan_x >> 1);
+            xga->oddeven ^= 1;
 
-        xga->hwcursor_on = 0;
-        xga->hwcursor_latch = xga->hwcursor;
-    }
+            changeframecount = xga->interlace ? 3 : 2;
+
+            if (xga->interlace && xga->oddeven)
+                xga->ma = xga->maback = xga->ma_latch + (xga->rowoffset << 1);
+            else
+                xga->ma = xga->maback = xga->ma_latch;
+
+            xga->ma     = (xga->ma << 2);
+            xga->maback = (xga->maback << 2);
+        }
+        if (xga->vc == xga->v_total) {
+            xga->vc       = 0;
+            xga->sc       = 0;
+            xga->dispon   = 1;
+            xga->displine = (xga->interlace && xga->oddeven) ? 1 : 0;
+
+            svga->x_add = (overscan_x >> 1);
+
+            xga->hwcursor_on    = 0;
+            xga->hwcursor_latch = xga->hwcursor;
+        }
     }
 }
 
 static uint8_t
 xga_mca_read(int port, void *priv)
 {
-    svga_t *svga = (svga_t *)priv;
-    xga_t *xga = &svga->xga;
+    svga_t *svga = (svga_t *) priv;
+    xga_t  *xga  = &svga->xga;
 
-    //pclog("[%04X:%08X]: POS Read Port = %x, val = %02x\n", CS, cpu_state.pc, port & 7, xga->pos_regs[port & 7]);
+    // pclog("[%04X:%08X]: POS Read Port = %x, val = %02x\n", CS, cpu_state.pc, port & 7, xga->pos_regs[port & 7]);
     return (xga->pos_regs[port & 7]);
 }
 
 static void
 xga_mca_write(int port, uint8_t val, void *priv)
 {
-    svga_t *svga = (svga_t *)priv;
-    xga_t *xga = &svga->xga;
+    svga_t *svga = (svga_t *) priv;
+    xga_t  *xga  = &svga->xga;
 
     /* MCA does not write registers below 0x0100. */
     if (port < 0x0102)
@@ -2631,32 +2607,35 @@ xga_mca_write(int port, uint8_t val, void *priv)
     mem_mapping_disable(&xga->bios_rom.mapping);
     mem_mapping_disable(&xga->memio_mapping);
     xga->on = 0;
-    vga_on = 1;
+    vga_on  = 1;
 
     /* Save the MCA register value. */
     xga->pos_regs[port & 7] = val;
     if (!(xga->pos_regs[4] & 1)) /*MCA 4MB addressing on systems with more than 16MB of memory*/
         xga->pos_regs[4] |= 1;
 
-    //pclog("[%04X:%08X]: POS Write Port = %x, val = %02x, linear base = %08x, instance = %d, rom addr = %05x\n", CS, cpu_state.pc, port & 7, val, xga->linear_base, xga->instance, xga->rom_addr);
     if (xga->pos_regs[2] & 1) {
-        xga->instance = (xga->pos_regs[2] & 0x0e) >> 1;
+        xga->instance      = (xga->pos_regs[2] & 0x0e) >> 1;
         xga->base_addr_1mb = (xga->pos_regs[5] & 0x0f) << 20;
-        xga->linear_base = ((xga->pos_regs[4] & 0xfe) * 0x1000000) + (xga->instance << 22);
-        xga->rom_addr = 0xc0000 + (((xga->pos_regs[2] & 0xf0) >> 4) * 0x2000);
+        xga->linear_base   = ((xga->pos_regs[4] & 0xfe) * 0x1000000) + (xga->instance << 22);
+        xga->rom_addr      = 0xc0000 + (((xga->pos_regs[2] & 0xf0) >> 4) * 0x2000);
 
         io_sethandler(0x2100 + (xga->instance << 4), 0x0010, xga_ext_inb, NULL, NULL, xga_ext_outb, NULL, NULL, svga);
-        if ((port & 7) == 2)
+
+        if (xga->pos_regs[3] & 1) {
             mem_mapping_set_addr(&xga->bios_rom.mapping, xga->rom_addr, 0x2000);
-        mem_mapping_set_addr(&xga->memio_mapping, xga->rom_addr + 0x1c00 + (xga->instance * 0x80), 0x80);
+        } else {
+            mem_mapping_set_addr(&xga->memio_mapping, xga->rom_addr + 0x1c00 + (xga->instance * 0x80), 0x80);
+        }
     }
+    // pclog("[%04X:%08X]: POS Write Port = %x, val = %02x, linear base = %08x, instance = %d, rom addr = %05x\n", CS, cpu_state.pc, port & 7, val, xga->linear_base, xga->instance, xga->rom_addr);
 }
 
 static uint8_t
 xga_mca_feedb(void *priv)
 {
-    svga_t *svga = (svga_t *)priv;
-    xga_t *xga = &svga->xga;
+    svga_t *svga = (svga_t *) priv;
+    xga_t  *xga  = &svga->xga;
 
     return xga->pos_regs[2] & 1;
 }
@@ -2664,7 +2643,7 @@ xga_mca_feedb(void *priv)
 static void
 xga_mca_reset(void *p)
 {
-    svga_t *svga = (svga_t *)p;
+    svga_t *svga = (svga_t *) p;
 
     xga_mca_write(0x102, 0, svga);
 }
@@ -2672,47 +2651,48 @@ xga_mca_reset(void *p)
 static uint8_t
 xga_pos_in(uint16_t addr, void *priv)
 {
-    svga_t *svga = (svga_t *)priv;
+    svga_t *svga = (svga_t *) priv;
 
     return (xga_mca_read(addr, svga));
 }
 
 static void
-*xga_init(const device_t *info)
+    *
+    xga_init(const device_t *info)
 {
-    svga_t *svga = svga_get_pri();
-    xga_t *xga = &svga->xga;
-    FILE *f;
+    svga_t  *svga = svga_get_pri();
+    xga_t   *xga  = &svga->xga;
+    FILE    *f;
     uint32_t temp;
     uint32_t initial_bios_addr = device_get_config_hex20("init_bios_addr");
-    uint8_t *rom = NULL;
+    uint8_t *rom               = NULL;
 
     xga->type = device_get_config_int("type");
-    xga->bus = info->flags;
+    xga->bus  = info->flags;
 
-    xga->vram_size = (1024 << 10);
-    xga->vram_mask = xga->vram_size - 1;
-    xga->vram = calloc(xga->vram_size, 1);
-    xga->changedvram = calloc(xga->vram_size >> 12, 1);
-    xga->on = 0;
-    xga->hwcursor.cur_xsize = 64;
-    xga->hwcursor.cur_ysize = 64;
-    xga->bios_rom.sz = 0x2000;
+    xga->vram_size             = (1024 << 10);
+    xga->vram_mask             = xga->vram_size - 1;
+    xga->vram                  = calloc(xga->vram_size, 1);
+    xga->changedvram           = calloc(xga->vram_size >> 12, 1);
+    xga->on                    = 0;
+    xga->hwcursor.cur_xsize    = 64;
+    xga->hwcursor.cur_ysize    = 64;
+    xga->bios_rom.sz           = 0x2000;
     xga->linear_endian_reverse = 0;
-    xga->a5_test = 0;
+    xga->a5_test               = 0;
 
     f = rom_fopen(xga->type ? XGA2_BIOS_PATH : XGA_BIOS_PATH, "rb");
-    (void)fseek(f, 0L, SEEK_END);
+    (void) fseek(f, 0L, SEEK_END);
     temp = ftell(f);
-    (void)fseek(f, 0L, SEEK_SET);
+    (void) fseek(f, 0L, SEEK_SET);
 
     rom = malloc(xga->bios_rom.sz);
     memset(rom, 0xff, xga->bios_rom.sz);
-    (void)fread(rom, xga->bios_rom.sz, 1, f);
+    (void) fread(rom, xga->bios_rom.sz, 1, f);
     temp -= xga->bios_rom.sz;
-    (void)fclose(f);
+    (void) fclose(f);
 
-    xga->bios_rom.rom = rom;
+    xga->bios_rom.rom  = rom;
     xga->bios_rom.mask = xga->bios_rom.sz - 1;
     if (f != NULL) {
         free(rom);
@@ -2721,25 +2701,25 @@ static void
     xga->base_addr_1mb = 0;
     if (info->flags & DEVICE_MCA) {
         xga->linear_base = 0;
-        xga->instance = 0;
-        xga->rom_addr = 0;
+        xga->instance    = 0;
+        xga->rom_addr    = 0;
         rom_init(&xga->bios_rom, xga->type ? XGA2_BIOS_PATH : XGA_BIOS_PATH, initial_bios_addr, 0x2000, 0x1fff, 0, MEM_MAPPING_EXTERNAL);
     } else {
         xga->pos_regs[2] = 1 | 0x0c | 0xf0;
-        xga->instance = (xga->pos_regs[2] & 0x0e) >> 1;
+        xga->instance    = (xga->pos_regs[2] & 0x0e) >> 1;
         xga->pos_regs[4] = 1 | 2;
         xga->linear_base = ((xga->pos_regs[4] & 0xfe) * 0x1000000) + (xga->instance << 22);
-        xga->rom_addr = 0xc0000 + (((xga->pos_regs[2] & 0xf0) >> 4) * 0x2000);
+        xga->rom_addr    = 0xc0000 + (((xga->pos_regs[2] & 0xf0) >> 4) * 0x2000);
     }
 
     mem_mapping_add(&xga->video_mapping, 0, 0, xga_readb, xga_readw, xga_readl,
                     xga_writeb, xga_writew, xga_writel,
                     NULL, MEM_MAPPING_EXTERNAL, svga);
-	mem_mapping_add(&xga->linear_mapping, 0, 0, xga_read_linear, xga_readw_linear, xga_readl_linear,
+    mem_mapping_add(&xga->linear_mapping, 0, 0, xga_read_linear, xga_readw_linear, xga_readl_linear,
                     xga_write_linear, xga_writew_linear, xga_writel_linear,
-                    NULL, MEM_MAPPING_EXTERNAL,	svga);
+                    NULL, MEM_MAPPING_EXTERNAL, svga);
     mem_mapping_add(&xga->memio_mapping, 0, 0, xga_memio_readb, xga_memio_readw, xga_memio_readl,
-                    xga_memio_writeb, xga_memio_writew,	xga_memio_writel,
+                    xga_memio_writeb, xga_memio_writew, xga_memio_writel,
                     xga->bios_rom.rom, MEM_MAPPING_EXTERNAL, svga);
 
     mem_mapping_disable(&xga->video_mapping);
@@ -2763,8 +2743,8 @@ static void
 static void
 xga_close(void *p)
 {
-    svga_t *svga = (svga_t *)p;
-    xga_t *xga = &svga->xga;
+    svga_t *svga = (svga_t *) p;
+    xga_t  *xga  = &svga->xga;
 
     if (svga) {
         free(xga->vram);
@@ -2781,7 +2761,7 @@ xga_available(void)
 static void
 xga_speed_changed(void *p)
 {
-    svga_t *svga = (svga_t *)p;
+    svga_t *svga = (svga_t *) p;
 
     svga_recalctimings(svga);
 }
@@ -2789,13 +2769,13 @@ xga_speed_changed(void *p)
 static void
 xga_force_redraw(void *p)
 {
-    svga_t *svga = (svga_t *)p;
+    svga_t *svga = (svga_t *) p;
 
     svga->fullchange = changeframecount;
 }
 
 static const device_config_t xga_configuration[] = {
-    // clang-format off
+  // clang-format off
     {
         .name = "init_bios_addr",
         .description = "Initial MCA BIOS Address (before POS configuration)",
@@ -2836,35 +2816,35 @@ static const device_config_t xga_configuration[] = {
         }
     },
     { .name = "", .description = "", .type = CONFIG_END }
-    // clang-format on
+// clang-format on
 };
 
 const device_t xga_device = {
-    .name = "XGA (MCA)",
+    .name          = "XGA (MCA)",
     .internal_name = "xga_mca",
-    .flags = DEVICE_MCA,
-    .local = 0,
-    .init = xga_init,
-    .close = xga_close,
-    .reset = NULL,
+    .flags         = DEVICE_MCA,
+    .local         = 0,
+    .init          = xga_init,
+    .close         = xga_close,
+    .reset         = NULL,
     { .available = xga_available },
     .speed_changed = xga_speed_changed,
-    .force_redraw = xga_force_redraw,
-    .config = xga_configuration
+    .force_redraw  = xga_force_redraw,
+    .config        = xga_configuration
 };
 
 const device_t xga_isa_device = {
-    .name = "XGA (ISA)",
+    .name          = "XGA (ISA)",
     .internal_name = "xga_isa",
-    .flags = DEVICE_ISA | DEVICE_AT,
-    .local = 0,
-    .init = xga_init,
-    .close = xga_close,
-    .reset = NULL,
+    .flags         = DEVICE_ISA | DEVICE_AT,
+    .local         = 0,
+    .init          = xga_init,
+    .close         = xga_close,
+    .reset         = NULL,
     { .available = xga_available },
     .speed_changed = xga_speed_changed,
-    .force_redraw = xga_force_redraw,
-    .config = xga_configuration
+    .force_redraw  = xga_force_redraw,
+    .config        = xga_configuration
 };
 
 void


### PR DESCRIPTION
Summary
=======
This fixes intermittent hangs on the XGA-2 end (MCA only, ISA version is intact).
Also includes indenting fixes.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
