### PR TITLE
qt: Fix discord update timer to run at one second interval

### DIFF
--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -293,7 +293,7 @@ int main(int argc, char* argv[]) {
         QObject::connect(&discordupdate, &QTimer::timeout, &app, [] {
             discord_run_callbacks();
         });
-        discordupdate.start(0);
+        discordupdate.start(1000);
     }
 
     /* Initialize the rendering window, or fullscreen. */


### PR DESCRIPTION
Summary
=======
The discord timer in `qt_main` seems to be running at full speed (timeout of zero) when the library is loaded, eating up the main qt thread. This PR changes it to an appropriate interval of one second.

The performance penalty happens even if discord is disabled. The whole section should probably be cleaned up, but this at should at least address the immediate performance problem. All qt platforms that have the discord library loaded are likely affected by this.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
