### PR TITLE
Build fixes on Clang

### DIFF
--- a/src/include/86box/win.h
+++ b/src/include/86box/win.h
@@ -23,7 +23,9 @@
 #ifndef PLAT_WIN_H
 #define PLAT_WIN_H
 
+#ifndef UNICODE
 #define UNICODE
+#endif
 #define BITMAP WINDOWS_BITMAP
 #if 0
 #    ifdef _WIN32_WINNT

--- a/src/network/net_slirp.c
+++ b/src/network/net_slirp.c
@@ -329,9 +329,11 @@ net_slirp_thread(void *priv)
                 break;
 
             case NET_EVENT_TX:
-                int packets = network_tx_popv(slirp->card, slirp->pkt_tx_v, SLIRP_PKT_BATCH);
-                for (int i = 0; i < packets; i++) {
-                    net_slirp_in(slirp, slirp->pkt_tx_v[i].data, slirp->pkt_tx_v[i].len);
+                {
+                    int packets = network_tx_popv(slirp->card, slirp->pkt_tx_v, SLIRP_PKT_BATCH);
+                    for (int i = 0; i < packets; i++) {
+                        net_slirp_in(slirp, slirp->pkt_tx_v[i].data, slirp->pkt_tx_v[i].len);
+                    }
                 }
                 break;
 

--- a/src/qt/win_joystick_rawinput.c
+++ b/src/qt/win_joystick_rawinput.c
@@ -205,15 +205,15 @@ void joystick_get_capabilities(raw_joystick_t* rawjoy, plat_joystick_t* joy) {
 
 void joystick_get_device_name(raw_joystick_t* rawjoy, plat_joystick_t* joy, PRID_DEVICE_INFO info) {
 	UINT size = 0;
-	char *device_name = NULL;
+	WCHAR *device_name = NULL;
 	WCHAR device_desc_wide[200] = {0};
 
-	GetRawInputDeviceInfoA(rawjoy->hdevice, RIDI_DEVICENAME, device_name, &size);
-	device_name = calloc(size, sizeof(char));
-	if (GetRawInputDeviceInfoA(rawjoy->hdevice, RIDI_DEVICENAME, device_name, &size) <= 0)
+	GetRawInputDeviceInfoW(rawjoy->hdevice, RIDI_DEVICENAME, device_name, &size);
+	device_name = calloc(size, sizeof(WCHAR));
+	if (GetRawInputDeviceInfoW(rawjoy->hdevice, RIDI_DEVICENAME, device_name, &size) <= 0)
 		fatal("joystick_get_capabilities: Failed to get device name.\n");
 
-	HANDLE hDevObj = CreateFile(device_name, GENERIC_READ | GENERIC_WRITE,
+	HANDLE hDevObj = CreateFileW(device_name, GENERIC_READ | GENERIC_WRITE,
 		FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL);
 	if (hDevObj) {
 		HidD_GetProductString(hDevObj, device_desc_wide, sizeof(WCHAR) * 200);

--- a/src/win/win_joystick_rawinput.c
+++ b/src/win/win_joystick_rawinput.c
@@ -220,15 +220,15 @@ void
 joystick_get_device_name(raw_joystick_t *rawjoy, plat_joystick_t *joy, PRID_DEVICE_INFO info)
 {
     UINT  size                  = 0;
-    char *device_name           = NULL;
+    WCHAR *device_name           = NULL;
     WCHAR device_desc_wide[200] = { 0 };
 
-    GetRawInputDeviceInfoA(rawjoy->hdevice, RIDI_DEVICENAME, device_name, &size);
-    device_name = calloc(size, sizeof(char));
-    if (GetRawInputDeviceInfoA(rawjoy->hdevice, RIDI_DEVICENAME, device_name, &size) <= 0)
+    GetRawInputDeviceInfoW(rawjoy->hdevice, RIDI_DEVICENAME, device_name, &size);
+    device_name = calloc(size, sizeof(WCHAR));
+    if (GetRawInputDeviceInfoW(rawjoy->hdevice, RIDI_DEVICENAME, device_name, &size) <= 0)
         fatal("joystick_get_capabilities: Failed to get device name.\n");
 
-    HANDLE hDevObj = CreateFile(device_name, GENERIC_READ | GENERIC_WRITE,
+    HANDLE hDevObj = CreateFileW(device_name, GENERIC_READ | GENERIC_WRITE,
                                 FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL);
     if (hDevObj) {
         HidD_GetProductString(hDevObj, device_desc_wide, sizeof(WCHAR) * 200);


### PR DESCRIPTION
Summary
=======
_Briefly describe what you are submitting._

Clang 14 does not like defining new variables in a switch label, which errors with:
```
D:\msys64\clang64\bin\cc.exe -DCMAKE -DUSE_DYNAREC -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS -ID:/msys64/clang64/include/freetype2 -ID:/msys64/clang64/include/SDL2 -ID:/86Box/build/src/include -ID:/86Box/src/include -ID:/86Box/src/cpu -ID:/86Box/src/codegen -std=gnu11 -MD -MT src/network/CMakeFiles/net.dir/net_slirp.c.obj -MF src\network\CMakeFiles\net.dir\net_slirp.c.obj.d -o src/network/CMakeFiles/net.dir/net_slirp.c.obj -c D:/86Box/src/network/net_slirp.c
D:/86Box/src/network/net_slirp.c:333:21: error: expected expression
                    int packets = network_tx_popv(slirp->card, slirp->pkt_tx_v, SLIRP_PKT_BATCH);
                    ^
D:/86Box/src/network/net_slirp.c:334:41: error: use of undeclared identifier 'packets'; did you mean 'socket'?
                    for (int i = 0; i < packets; i++) {
                                        ^~~~~~~
                                        socket
D:/msys64/clang64/include/winsock2.h:1037:37: note: 'socket' declared here
  WINSOCK_API_LINKAGE SOCKET WSAAPI socket(int af,int type,int protocol);
                                    ^
2 errors generated.
ninja: build stopped: subcommand failed.
```

Also fixed a CHAR/WCHAR mismatch in win_joystick_rawinput.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
