### PR TITLE
qt_hardwarerenderer: Use setData on Qt 5.14 and later

### DIFF
--- a/src/qt/qt_hardwarerenderer.cpp
+++ b/src/qt/qt_hardwarerenderer.cpp
@@ -199,10 +199,14 @@ void HardwareRenderer::onBlit(int buf_idx, int x, int y, int w, int h) {
         return;
     }
     m_context->makeCurrent(this);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    m_texture->setData(x, y, 0, w, h, 0, QOpenGLTexture::PixelFormat::RGBA, QOpenGLTexture::PixelType::UInt8, (const void*)((uintptr_t)imagebufs[buf_idx].get() + (uintptr_t)(2048 * 4 * y + x * 4)), &m_transferOptions);
+#else
     m_texture->bind();
     glPixelStorei(GL_UNPACK_ROW_LENGTH, 2048);
     glTexSubImage2D(GL_TEXTURE_2D, 0, x, y, w, h, QOpenGLTexture::PixelFormat::RGBA, QOpenGLTexture::PixelType::UInt8, (const void*)((uintptr_t)imagebufs[buf_idx].get() + (uintptr_t)(2048 * 4 * y + x * 4)));
     m_texture->release();
+#endif
     buf_usage[buf_idx].clear();
     source.setRect(x, y, w, h);
     if (origSource != source) onResize(this->width(), this->height());


### PR DESCRIPTION
Summary
=======
qt_hardwarerenderer: Use setData on Qt 5.14 and later

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
