### PR TITLE
qt: Fix searching for icon packs in roms dir

### DIFF
--- a/src/qt/qt_progsettings.cpp
+++ b/src/qt/qt_progsettings.cpp
@@ -46,16 +46,12 @@ QTranslator* ProgSettings::qtTranslator = nullptr;
 QString ProgSettings::getIconSetPath()
 {
     if (iconset_to_qt.isEmpty()) {
-        QVector<QFileInfo> roms_dirs;
-        // Walk rom_paths to get the candidates
-        for (rom_path_t *emu_rom_path = &rom_paths; emu_rom_path != nullptr; emu_rom_path = emu_rom_path->next) {
-            roms_dirs.append(QFileInfo(emu_rom_path->path));
-        }
         // Always include default bundled icons
         iconset_to_qt.insert("", ":/settings/win/icons");
-        for (auto &checked_dir : roms_dirs) {
+        // Walk rom_paths to get the candidates
+        for (rom_path_t *emu_rom_path = &rom_paths; emu_rom_path != nullptr; emu_rom_path = emu_rom_path->next) {
             // Check for icons subdir in each candidate
-            QDir roms_icons_dir(checked_dir.filePath() + "/icons");
+            QDir roms_icons_dir(QString(emu_rom_path->path) + "/icons");
             if (roms_icons_dir.isReadable()) {
                 auto dirList = roms_icons_dir.entryList(QDir::AllDirs | QDir::Executable | QDir::Readable);
                 for (auto &curIconSet : dirList) {

--- a/src/qt/qt_progsettings.cpp
+++ b/src/qt/qt_progsettings.cpp
@@ -33,6 +33,8 @@ extern "C"
 #include <86box/version.h>
 #include <86box/config.h>
 #include <86box/plat.h>
+#include <86box/mem.h>
+#include <86box/rom.h>
 }
 
 
@@ -43,24 +45,25 @@ ProgSettings::CustomTranslator* ProgSettings::translator = nullptr;
 QTranslator* ProgSettings::qtTranslator = nullptr;
 QString ProgSettings::getIconSetPath()
 {
-    QString roms_root;
-    if (rom_path[0])
-        roms_root = rom_path;
-    else {
-        roms_root = QString("%1/roms").arg(exe_path);
-    }
-
-    if (iconset_to_qt.isEmpty())
-    {
+    if (iconset_to_qt.isEmpty()) {
+        QVector<QFileInfo> roms_dirs;
+        // Walk rom_paths to get the candidates
+        for (rom_path_t *emu_rom_path = &rom_paths; emu_rom_path != nullptr; emu_rom_path = emu_rom_path->next) {
+            roms_dirs.append(QFileInfo(emu_rom_path->path));
+        }
+        // Always include default bundled icons
         iconset_to_qt.insert("", ":/settings/win/icons");
-        QDir dir(roms_root + "/icons/");
-        if (dir.isReadable())
-        {
-            auto dirList = dir.entryList(QDir::AllDirs | QDir::Executable | QDir::Readable);
-            for (auto &curIconSet : dirList)
-            {
-                if (curIconSet == "." || curIconSet == "..") continue;
-                iconset_to_qt.insert(curIconSet, (dir.canonicalPath() + '/') + curIconSet);
+        for (auto &checked_dir : roms_dirs) {
+            // Check for icons subdir in each candidate
+            QDir roms_icons_dir(checked_dir.filePath() + "/icons");
+            if (roms_icons_dir.isReadable()) {
+                auto dirList = roms_icons_dir.entryList(QDir::AllDirs | QDir::Executable | QDir::Readable);
+                for (auto &curIconSet : dirList) {
+                    if (curIconSet == "." || curIconSet == "..") {
+                        continue;
+                    }
+                    iconset_to_qt.insert(curIconSet, (roms_icons_dir.canonicalPath() + '/') + curIconSet);
+                }
             }
         }
     }


### PR DESCRIPTION
Summary
=======
The existing code essentially hardcodes the icons path to `exe_path/roms`. Therefore the icon packs will only display in settings *if* the roms dir is in the same dir as the executable. With any other configuration (such as roms installed to global dir) the icon packs won't display.

This PR changes it to walk `rom_paths` and search each directory for `icons/` to find packs. Tested on mac, windows, linux and makes the icons appear for me in preferences.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
