### PR TITLE
qt: Fix potential null pointer access in media history

### DIFF
--- a/src/qt/qt_mediahistorymanager.cpp
+++ b/src/qt/qt_mediahistorymanager.cpp
@@ -132,8 +132,9 @@ void MediaHistoryManager::serializeImageHistoryType(ui::MediaType type)
             continue;
         }
         for ( int slot = 0; slot < MAX_PREV_IMAGES; slot++) {
-            strncpy(device_history_ptr[slot], master_list[type][device][slot].toUtf8().constData(), MAX_IMAGE_PATH_LEN);
-
+            if (device_history_ptr[slot] != nullptr) {
+                strncpy(device_history_ptr[slot], master_list[type][device][slot].toUtf8().constData(), MAX_IMAGE_PATH_LEN);
+            }
         }
     }
 }


### PR DESCRIPTION
Summary
=======
There is a potential null pointer access if the image history doesn't yet exist, as in the first run of a new system. The main pointer (already checked) is valid but the first pointer in the array will not be. This adds a check.

Checklist
=========
* [ ] I have discussed this with core contributors already

References
==========
N/A
