### PR TITLE
Improve handling of High-DPI mice

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -180,8 +180,8 @@ load_general(void)
         lang_id = plat_language_code(p);
 
     mouse_sensitivity = ini_section_get_double(cat, "mouse_sensitivity", 1.0);
-    if (mouse_sensitivity < 0.5)
-        mouse_sensitivity = 0.5;
+    if (mouse_sensitivity < 0.1)
+        mouse_sensitivity = 0.1;
     else if (mouse_sensitivity > 2.0)
         mouse_sensitivity = 2.0;
 

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -136,6 +136,7 @@ extern int is_pentium; /* TODO: Move back to cpu/cpu.h when it's figured out,
                                 how to remove that hack from the ET4000/W32p. */
 extern int    fixed_size_x, fixed_size_y;
 extern double mouse_sensitivity; /* (C) Mouse sensitivity scale */
+extern double mouse_x_error, mouse_y_error;    /* Mouse error accumulators */
 extern int    pit_mode;          /* (C) force setting PIT mode */
 extern int    fm_driver;         /* (C) select FM sound driver */
 

--- a/src/qt/qt_progsettings.ui
+++ b/src/qt/qt_progsettings.ui
@@ -88,7 +88,7 @@
    <item row="7" column="0" colspan="2">
     <widget class="QSlider" name="horizontalSlider">
      <property name="minimum">
-      <number>50</number>
+      <number>10</number>
      </property>
      <property name="maximum">
       <number>200</number>

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -54,6 +54,7 @@ extern "C" {
 #include <86box/video.h>
 
 double mouse_sensitivity = 1.0;
+double mouse_x_error = 0.0, mouse_y_error = 0.0;
 }
 
 struct mouseinputdata {
@@ -151,8 +152,14 @@ RendererStack::mousePoll()
 #endif
         this->mouse_poll_func();
 
-    mouse_x *= mouse_sensitivity;
-    mouse_y *= mouse_sensitivity;
+    double scaled_x = mouse_x * mouse_sensitivity + mouse_x_error;
+    double scaled_y = mouse_y * mouse_sensitivity + mouse_y_error;
+
+    mouse_x = static_cast<int>(scaled_x);
+    mouse_y = static_cast<int>(scaled_y);
+
+    mouse_x_error = scaled_x - mouse_x;
+    mouse_y_error = scaled_y - mouse_y;
 }
 
 int ignoreNextMouseEvent = 1;

--- a/src/unix/unix_sdl.c
+++ b/src/unix/unix_sdl.c
@@ -44,6 +44,7 @@ int resize_pending = 0;
 int resize_w = 0;
 int resize_h = 0;
 double mouse_sensitivity = 1.0; /* Unused. */
+double mouse_x_error = 0.0, mouse_y_error = 0.0; /* Unused. */
 static uint8_t interpixels[17842176];
 
 extern void RenderImGui();

--- a/src/win/win_mouse.c
+++ b/src/win/win_mouse.c
@@ -29,6 +29,7 @@
 
 int    mouse_capture;
 double mouse_sensitivity = 1.0; /* Unused. */
+double mouse_x_error = 0.0, mouse_y_error = 0.0; /* Unused. */
 
 typedef struct {
     int buttons;


### PR DESCRIPTION
Summary
=======
After reducing the mouse sensitivity to compensate for my high-dpi mouse, I noticed that something felt odd about mouse motion, particularly when moving the cursor at low speed. It would feel as if the cursor would "catch" or "stick" sometimes. I had a hunch as to what was wrong, so I investigated.
Mouse sensitivity is applied as a simple scalar multiplication. This is fine for values >= 1, but for small values as I was using, the constant double-to-int conversions for the deltas were rounding off the small motions, and if you moved the mouse slowly enough, the cursor would never move at all. To fix this, I added two error terms that store the fractional motion after rounding, and re-apply it on the next iteration. Now the cursor always moves no matter how slowly you drag, and cursor motion overall just "feels" more natural.
I also reduced minimum sensitivity to 10% instead of 50, since for some mice even 50 isn't slow enough.

I'm new to this codebase, so let me know if there's anything I should adjust. I put the error terms with the sensitivity variable, since they only have meaning when sensitivity scaling is applied, but perhaps there's a better place.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
