### PR TITLE
qt: Media history part II: Floppy

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1291,6 +1291,14 @@ load_floppy_and_cdrom_drives(void)
             sprintf(temp, "fdd_%02i_check_bpb", c + 1);
             ini_section_delete_var(cat, temp);
         }
+        for (int i = 0; i < MAX_PREV_IMAGES; i++) {
+            fdd_image_history[c][i] = (char *) calloc(MAX_IMAGE_PATH_LEN + 1, sizeof(char));
+            sprintf(temp, "fdd_%02i_image_history_%02i", c + 1, i + 1);
+            p = ini_section_get_string(cat, temp, NULL);
+            if (p) {
+                sprintf(fdd_image_history[c][i], "%s", p);
+            }
+        }
     }
 
     memset(temp, 0x00, sizeof(temp));
@@ -2680,6 +2688,15 @@ save_floppy_and_cdrom_drives(void)
             ini_section_delete_var(cat, temp);
         else
             ini_section_set_int(cat, temp, fdd_get_check_bpb(c));
+
+        for (int i = 0; i < MAX_PREV_IMAGES; i++) {
+            sprintf(temp, "fdd_%02i_image_history_%02i", c + 1, i + 1);
+            if ((fdd_image_history[c][i] == 0) || strlen(fdd_image_history[c][i]) == 0) {
+                ini_section_delete_var(cat, temp);
+            } else {
+                ini_section_set_string(cat, temp, fdd_image_history[c][i]);
+            }
+        }
     }
 
     for (c = 0; c < CDROM_NUM; c++) {

--- a/src/floppy/fdd.c
+++ b/src/floppy/fdd.c
@@ -76,6 +76,7 @@ typedef struct {
 fdd_t fdd[FDD_NUM];
 
 char floppyfns[FDD_NUM][512];
+char *fdd_image_history[FDD_NUM][FLOPPY_IMAGE_HISTORY];
 
 pc_timer_t fdd_poll_time[FDD_NUM];
 

--- a/src/include/86box/fdd.h
+++ b/src/include/86box/fdd.h
@@ -22,6 +22,7 @@
 #define EMU_FDD_H
 
 #define FDD_NUM          4
+#define FLOPPY_IMAGE_HISTORY         4
 #define SEEK_RECALIBRATE -999
 
 #ifdef __cplusplus
@@ -83,6 +84,7 @@ typedef struct {
 
 extern DRIVE      drives[FDD_NUM];
 extern char       floppyfns[FDD_NUM][512];
+extern char       *fdd_image_history[FDD_NUM][FLOPPY_IMAGE_HISTORY];
 extern pc_timer_t fdd_poll_time[FDD_NUM];
 extern int        ui_writeprot[FDD_NUM];
 

--- a/src/qt/qt_mediahistorymanager.cpp
+++ b/src/qt/qt_mediahistorymanager.cpp
@@ -21,9 +21,14 @@
 #include <QMetaEnum>
 #include <QStringBuilder>
 #include <utility>
-
-#include "86box/cdrom.h"
 #include "qt_mediahistorymanager.hpp"
+
+extern "C"
+{
+#include <86box/timer.h>
+#include <86box/cdrom.h>
+#include <86box/fdd.h>
+}
 
 namespace ui {
 
@@ -158,6 +163,9 @@ void MediaHistoryManager::initialDeduplication()
                 case ui::MediaType::Optical:
                     current_image = cdrom[device_index].image_path;
                     break;
+                case ui::MediaType::Floppy:
+                    current_image = floppyfns[device_index];
+                    break;
                 default:
                     continue;
                     break;
@@ -180,6 +188,8 @@ char ** MediaHistoryManager::getEmuHistoryVarForType(ui::MediaType type, int ind
     switch (type) {
         case ui::MediaType::Optical:
             return &cdrom[index].image_history[0];
+        case ui::MediaType::Floppy:
+            return &fdd_image_history[index][0];
         default:
             return nullptr;
 

--- a/src/qt/qt_mediahistorymanager.hpp
+++ b/src/qt/qt_mediahistorymanager.hpp
@@ -59,7 +59,8 @@ namespace ui {
     // Used to iterate over all supported types when preparing data structures
     // Also useful to indicate which types support history
     static const MediaType AllSupportedMediaHistoryTypes[] = {
-        MediaType::Optical
+        MediaType::Optical,
+        MediaType::Floppy,
     };
 
     class MediaHistoryManager {
@@ -87,7 +88,7 @@ namespace ui {
 
         // Main hash of hash of vector of strings
         master_list_t       master_list;
-        const master_list_t &getMasterList() const;
+        [[nodiscard]] const master_list_t &getMasterList() const;
         void                 setMasterList(const master_list_t &masterList);
 
         device_index_list_t index_list, empty_device_index_list;

--- a/src/qt/qt_mediamenu.hpp
+++ b/src/qt/qt_mediamenu.hpp
@@ -37,6 +37,7 @@ public:
     void floppySelectImage(int i, bool wp);
     void floppyMount(int i, const QString& filename, bool wp);
     void floppyEject(int i);
+    void floppyMenuSelect(int index, int slot);
     void floppyExportTo86f(int i);
     void floppyUpdateMenu(int i);
 

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -161,7 +161,13 @@ plat_timer_read(void)
 FILE *
 plat_fopen(const char *path, const char *mode)
 {
+#if defined(Q_OS_MACOS) or defined(Q_OS_LINUX)
+    QFileInfo fi(path);
+    QString filename = fi.isRelative() ? usr_path + fi.filePath() : fi.filePath();
+    return fopen(filename.toUtf8().constData(), mode);
+#else
     return fopen(QString::fromUtf8(path).toLocal8Bit(), mode);
+#endif
 }
 
 FILE *


### PR DESCRIPTION
Summary
=======
This is a continuation of #2656. In the first PR only CD-ROM support was initially added to media history. This one adds the same support for floppy images.

Just about everything applies from the original PR, except floppy instead of CD. Some variable names differ due to the different subsystem of floppy vs. cd, but the same form of serialization / deserialization, persistence in the config file, etc. all apply here. A lot of the groundwork for supporting other media types was already put in with the previous PR.

In the original PR I had to update in `plat_fopen64()` in `qt_platform.cpp` in order to have mac and linux properly support relative paths. More specifically: paths relative to `usr_path`. 

In this PR I had to do the same but for `plat_fopen()` instead. The exact same changes were made as in the previous PR: If a relative path is opened, append `usr_path` to the path. Absolute paths aren't modified at all. This only applies to mac and linux, windows still performs the same as before (gated behind `#ifdef`s).

Tested on all platforms.

## Screenshot
![floppy menu](https://user-images.githubusercontent.com/47337035/193430191-78779b0a-d2fc-4de3-9c64-5c509e15cdc4.png)

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
Previous PR: #2656