### PR TITLE
qt: Account for empty path in plat_fopen

### DIFF
--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -163,7 +163,7 @@ plat_fopen(const char *path, const char *mode)
 {
 #if defined(Q_OS_MACOS) or defined(Q_OS_LINUX)
     QFileInfo fi(path);
-    QString filename = fi.isRelative() ? usr_path + fi.filePath() : fi.filePath();
+    QString filename = (fi.isRelative() && !fi.filePath().isEmpty()) ? usr_path + fi.filePath() : fi.filePath();
     return fopen(filename.toUtf8().constData(), mode);
 #else
     return fopen(QString::fromUtf8(path).toLocal8Bit(), mode);
@@ -175,7 +175,7 @@ plat_fopen64(const char *path, const char *mode)
 {
 #if defined(Q_OS_MACOS) or defined(Q_OS_LINUX)
     QFileInfo fi(path);
-    QString filename = fi.isRelative() ? usr_path + fi.filePath() : fi.filePath();
+    QString filename = (fi.isRelative() && !fi.filePath().isEmpty()) ? usr_path + fi.filePath() : fi.filePath();
     return fopen(filename.toUtf8().constData(), mode);
 #else
     return fopen(QString::fromUtf8(path).toLocal8Bit(), mode);


### PR DESCRIPTION
Summary
=======
In #2703 I had to update `plat_fopen()` to allow relative paths for mac and linux. It doesn't, however, account for blank / null paths. 

Apparently floppy and cassette drives blindly load image paths, including null ones (because they aren't set in the config). This wasn't a problem before, but the new logic was still appending the `usr_path` to the blanks paths because apparently blank / null paths evaluate to relative paths. Ultimately it was causing it to try and load a directory.

The blind loading of null images should probably also be fixed in a separate PR, but this one will at least account for blank / null paths using the new `plat_fopen()` logic and fix the immediate issue. I also updated the `plat_fopen64()` as well.

Thanks to @telanus for helping me locate the issue.

Checklist
=========
N/A

References
==========
Previous PR #2703
