### PR TITLE
qt: Fix play / pause icon to reflect current state

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -202,7 +202,8 @@ MainWindow::MainWindow(QWidget *parent) :
             }
         }
 #endif
-        ui->actionPause->setChecked(dopause);
+        ui->actionPause->setChecked(false);
+        ui->actionPause->setCheckable(false);
     });
     connect(this, &MainWindow::getTitleForNonQtThread, this, &MainWindow::getTitle_, Qt::BlockingQueuedConnection);
 
@@ -753,6 +754,10 @@ void MainWindow::on_actionCtrl_Alt_Esc_triggered() {
 
 void MainWindow::on_actionPause_triggered() {
     plat_pause(dopause ^ 1);
+    auto pause_icon   = dopause ? QIcon(":/menuicons/win/icons/run.ico") : QIcon(":/menuicons/win/icons/pause.ico");
+    auto tooltip_text = dopause ? QString(tr("Resume execution")) : QString(tr("Pause execution"));
+    ui->actionPause->setIcon(pause_icon);
+    ui->actionPause->setToolTip(tooltip_text);
 }
 
 void MainWindow::on_actionExit_triggered() {


### PR DESCRIPTION
Summary
=======
The main toolbar pause button always displays the pause icon, even when the system is paused. When paused, the button goes into the checked state (but remains a pause icon).

This PR changes it to:

* Switch back and forth between play and pause icon depending on pause / run state
* Update the tooltip based on the current state
* Make the pause action button uncheckable so it will never appear checked or recessed (previous behavior, not necessary with the icon change)

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
