### PR TITLE
Fix Qt 6.4 builds

### DIFF
--- a/src/disk/hdd.c
+++ b/src/disk/hdd.c
@@ -442,16 +442,16 @@ hdd_preset_get_num()
     return sizeof(hdd_speed_presets) / sizeof(hdd_preset_t);
 }
 
-char *
+const char *
 hdd_preset_getname(int preset)
 {
-    return (char *) hdd_speed_presets[preset].name;
+    return hdd_speed_presets[preset].name;
 }
 
-char *
+const char *
 hdd_preset_get_internal_name(int preset)
 {
-    return (char *) hdd_speed_presets[preset].internal_name;
+    return hdd_speed_presets[preset].internal_name;
 }
 
 int

--- a/src/include/86box/hdd.h
+++ b/src/include/86box/hdd.h
@@ -203,13 +203,13 @@ extern int image_is_hdi(const char *s);
 extern int image_is_hdx(const char *s, int check_signature);
 extern int image_is_vhd(const char *s, int check_signature);
 
-extern double hdd_timing_write(hard_disk_t *hdd, uint32_t addr, uint32_t len);
-extern double hdd_timing_read(hard_disk_t *hdd, uint32_t addr, uint32_t len);
-extern double hdd_seek_get_time(hard_disk_t *hdd, uint32_t dst_addr, uint8_t operation, uint8_t continuous, double max_seek_time);
-int           hdd_preset_get_num();
-char         *hdd_preset_getname(int preset);
-extern char  *hdd_preset_get_internal_name(int preset);
-extern int    hdd_preset_get_from_internal_name(char *s);
-extern void   hdd_preset_apply(int hdd_id);
+extern double      hdd_timing_write(hard_disk_t *hdd, uint32_t addr, uint32_t len);
+extern double      hdd_timing_read(hard_disk_t *hdd, uint32_t addr, uint32_t len);
+extern double      hdd_seek_get_time(hard_disk_t *hdd, uint32_t dst_addr, uint8_t operation, uint8_t continuous, double max_seek_time);
+int                hdd_preset_get_num();
+const char        *hdd_preset_getname(int preset);
+extern const char *hdd_preset_get_internal_name(int preset);
+extern int         hdd_preset_get_from_internal_name(char *s);
+extern void        hdd_preset_apply(int hdd_id);
 
 #endif /*EMU_HDD_H*/


### PR DESCRIPTION
Summary
=======
Cast from `char*` to `QVariant` was removed in Qt 6.4 and caused builds to fail. Fix by using `const char*` instead.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
