### PR TITLE
Fix 95/98FE protection errors on emulated P6

### DIFF
--- a/src/cpu/codegen_timing_p6.c
+++ b/src/cpu/codegen_timing_p6.c
@@ -158,10 +158,13 @@ static const macro_op_t lods_op =
 };
 static const macro_op_t loop_op =
 {
-        .nr_uops = 2,
+        .nr_uops = 5,
         .decode_type = DECODE_COMPLEX,
         .uop[0] = {.type = UOP_ALU,    .latency = 1},
-        .uop[1] = {.type = UOP_BRANCH, .latency = 2}
+        .uop[1] = {.type = UOP_ALU,    .latency = 1},
+        .uop[2] = {.type = UOP_ALU,    .latency = 1},	
+        .uop[3] = {.type = UOP_ALU,    .latency = 1},			
+        .uop[4] = {.type = UOP_BRANCH, .latency = 1}
 };
 static const macro_op_t mov_reg_seg_op =
 {


### PR DESCRIPTION

Summary
=======
Hopefully fix Windows Protection Errors in Windows 95 and 98 First Edition on faster-clocked Intel P6-architecture CPUs.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
[https://archive.org/details/bitsavers_intelpentimIIIntelArchitecureOptimization1999_1886592](url)