### PR TITLE
VISO fixes for mac / linux

### DIFF
--- a/src/cdrom/cdrom_image_backend.c
+++ b/src/cdrom/cdrom_image_backend.c
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #ifdef _WIN32
 #    include <string.h>
 #else
@@ -131,6 +132,7 @@ static track_file_t *
 bin_init(const char *filename, int *error)
 {
     track_file_t *tf = (track_file_t *) malloc(sizeof(track_file_t));
+    struct stat stats;
 
     if (tf == NULL) {
         *error = 1;
@@ -142,7 +144,11 @@ bin_init(const char *filename, int *error)
     tf->file = plat_fopen64(tf->fn, "rb");
     cdrom_image_backend_log("CDROM: binary_open(%s) = %08lx\n", tf->fn, tf->file);
 
-    *error = (tf->file == NULL);
+    if (stat(tf->fn, &stats) != 0) {
+        /* Use a blank structure if stat failed. */
+        memset(&stats, 0, sizeof(struct stat));
+    }
+    *error = ((tf->file == NULL) || (S_ISDIR(stats.st_mode)));
 
     /* Set the function pointers. */
     if (!*error) {

--- a/src/cdrom/cdrom_image_backend.c
+++ b/src/cdrom/cdrom_image_backend.c
@@ -148,7 +148,7 @@ bin_init(const char *filename, int *error)
         /* Use a blank structure if stat failed. */
         memset(&stats, 0, sizeof(struct stat));
     }
-    *error = ((tf->file == NULL) || (S_ISDIR(stats.st_mode)));
+    *error = ((tf->file == NULL) || ((stats.st_mode & S_IFMT) == S_IFDIR));
 
     /* Set the function pointers. */
     if (!*error) {

--- a/src/include/86box/plat_dir.h
+++ b/src/include/86box/plat_dir.h
@@ -17,6 +17,8 @@
 #ifndef PLAT_DIR_H
 #define PLAT_DIR_H
 
+/* Windows needs the POSIX re-implementations */
+#if defined(_WIN32)
 #ifdef _MAX_FNAME
 #    define MAXNAMLEN _MAX_FNAME
 #else
@@ -63,5 +65,10 @@ extern void           seekdir(DIR *, long);
 extern int            closedir(DIR *);
 
 #define rewinddir(dirp) seekdir(dirp, 0L)
+#else
+/* On linux and macOS, use the standard functions and types */
+#include <sys/dir.h>
+#endif
+
 
 #endif /*PLAT_DIR_H*/


### PR DESCRIPTION
Summary
=======
The code was relying on `fopen()` to return null when a directory is opened in order to take the correct path for viso support. But since opening a directory is undefined (unless requesting write perms), it succeeds on mac / linux. This updates `bin_init()` to `stat()` the requested file / dir and follow the appropriate path for viso to work.

There were also some issues with the POSIX re-implementation of various `dir.h` structures that are used on windows. I updated `plat_dir.h` to use `sys/dir.h` on mac and linux because the structures returned by those platforms did not line up with the existing re-implementations. 

As far as I can tell, with this fix VISO works now on all platforms. Tested on windows (msys2), mac, linux. 

cc @richardg867 for review

Edit: Note that the build failures will be solved by #2722

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A