### PR TITLE
Pravetz-16 / IMKO-4

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -784,6 +784,7 @@ extern int machine_xt_sansx16_init(const machine_t *);
 extern int machine_xt_bw230_init(const machine_t *);
 
 extern int machine_xt_iskra3104_init(const machine_t *);
+extern int machine_xt_pravetz16_imko4_init(const machine_t *);
 
 /* m_xt_compaq.c */
 extern int machine_xt_compaq_deskpro_init(const machine_t *);

--- a/src/machine/m_xt.c
+++ b/src/machine/m_xt.c
@@ -329,6 +329,21 @@ machine_xt_iskra3104_init(const machine_t *model)
 }
 
 int
+machine_xt_pravetz16_imko4_init(const machine_t *model)
+{
+	int ret;
+    
+    ret = bios_load_linear("roms/machines/pravetz16/BIOS_IMKO4_FE00.bin",
+			   0x000fe000, 8192, 0);
+
+    if (bios_only || !ret)
+	    return ret;
+
+    machine_xt_init_ex(model);
+    return ret;
+}
+
+int
 machine_xt_pc4i_init(const machine_t *model)
 {
     int ret;

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -1610,6 +1610,42 @@ const machine_t machines[] = {
         .snd_device = NULL,
         .net_device = NULL
     },
+    {
+        .name = "[8088] Pravetz 16 / IMKO-4",
+        .internal_name = "pravetz16",
+        .type = MACHINE_TYPE_8088,
+        .chipset = MACHINE_CHIPSET_DISCRETE,
+        .init = machine_xt_pravetz16_imko4_init,
+        .pad = 0,
+        .pad0 = 0,
+        .pad1 = MACHINE_AVAILABLE,
+        .pad2 = 0,
+        .cpu = {
+            .package = CPU_PKG_8088,
+            .block = CPU_BLOCK_NONE,
+            .min_bus = 0,
+            .max_bus = 0,
+            .min_voltage = 0,
+            .max_voltage = 0,
+            .min_multi = 0,
+            .max_multi = 0
+        },
+        .bus_flags = MACHINE_PC,
+        .flags = MACHINE_FLAGS_NONE,
+        .ram = {
+            .min = 64,
+            .max = 640,
+            .step = 64
+        },
+        .nvrmask = 0,
+        .kbc = KBC_IBM_PC_XT,
+        .kbc_p1 = 0xff00,
+        .gpio = 0xffffffff,
+        .device = NULL,
+        .vid_device = NULL,
+        .snd_device = NULL,
+        .net_device = NULL
+    },
 
     /* 8086 Machines */
     {


### PR DESCRIPTION
Summary
=======
Adding Pravetz-16 (IMKO-4), an IBM PC/XT compatible made in Bulgaria in the 80s that featured Intel 8088 at 4.77 MHz.

Checklist
=========
* [x] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/180

References
==========
https://www.old-computers.com/museum/computer.asp?st=2&c=615
https://www.sandacite.com/forum/index.php?topic=10864.0
https://paskov.vmsoft-bg.com/tag/pravetz-16/
https://sandacite.com/biblio/files/original/8/132/_%D0%BA%D0%BE%D0%BC%D0%BF%D1%8E%D1%82%D1%8A%D1%80_%D0%9F%D1%80%D0%B0%D0%B2%D0%B5%D1%86-16,_%D0%BF%D0%B0%D1%81%D0%BF%D0%BE%D1%80%D1%82,_%D0%98%D0%A2%D0%9A%D0%A0_%D0%91%D0%90%D0%9D,_1982_[2].pdf
