### PR TITLE
Fix build with -DENABLE_PC_LOG=1

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -761,7 +761,7 @@ void
 pc_full_speed(void)
 {
     if (!atfullspeed) {
-        pc_log("Set fullspeed - %i %i\n", is386, AT);
+        pc_log("Set fullspeed - %i %i\n", is386, is486);
         pc_speed_changed();
     }
     atfullspeed = 1;


### PR DESCRIPTION
Summary
=======

Global "AT" is not there since commit bc90f993503f ('Finally got rid of the AT and PCI global variables.').

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
