### PR TITLE
Add a Victor V86P disk driver

### DIFF
--- a/src/disk/hdc.c
+++ b/src/disk/hdc.c
@@ -115,6 +115,7 @@ static const struct {
     { &st506_xt_wd1002a_27x_device },
     { &st506_xt_wd1004_27x_device  },
     { &st506_xt_wd1004a_27x_device },
+    { &st506_xt_victor_v86p_device },
     { &esdi_at_wd1007vse1_device   },
     { &ide_isa_device              },
     { &ide_isa_2ch_device          },

--- a/src/include/86box/hdc.h
+++ b/src/include/86box/hdc.h
@@ -40,6 +40,7 @@ extern const device_t st506_at_wd1003_device;      /* st506_at_wd1003 */
 extern const device_t st506_xt_wd1004a_wx1_device; /* st506_xt_wd1004a_wx1 */
 extern const device_t st506_xt_wd1004_27x_device;  /* st506_xt_wd1004_27x */
 extern const device_t st506_xt_wd1004a_27x_device; /* st506_xt_wd1004a_27x */
+extern const device_t st506_xt_victor_v86p_device; /* st506_xt_victor_v86p */
 
 extern const device_t esdi_at_wd1007vse1_device; /* esdi_at */
 extern const device_t esdi_ps2_device;           /* esdi_mca */


### PR DESCRIPTION
Summary
=======
This emulates a JVC-branded controller/drive pair, using RLL encoding, connected via a small connector electrically compatible with ST-506.

The controller is ST-506 compatible with an extra command for self-power-off. The option ROM is made by SMS. Commented disassembly is available for study [1].

The disk is a 3.5" 20MiB "made by Victor", labeled JD3824T100 on the outer protective casing, JD3824T00-1 on the actual drive. It's 615/2/34 physically, pretends to be a 614/4/17 so that it's type 3 compatible.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/182

References
==========
[1] https://archive.org/details/v86p-hd