### PR TITLE
Revert "qt: Always resize"

### DIFF
--- a/src/qt/qt_ui.cpp
+++ b/src/qt/qt_ui.cpp
@@ -85,7 +85,7 @@ void mouse_poll() {
 extern "C" int vid_resize;
 void plat_resize_request(int w, int h, int monitor_index)
 {
-    if (is_quit) return;
+    if (video_fullscreen || is_quit) return;
     if (vid_resize & 2) {
         plat_resize_monitor(fixed_size_x, fixed_size_y, monitor_index);
     }


### PR DESCRIPTION
Summary
=======
This reverts commit 6ac2faf2f87544e42043c8536a52b14b94909780.

Breaks fullscreen scaling.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
