### PR TITLE
Simplify and reuse code in m_at_286_386sx.c

### DIFF
--- a/src/machine/m_at_286_386sx.c
+++ b/src/machine/m_at_286_386sx.c
@@ -254,10 +254,14 @@ machine_at_micronics386_init(const machine_t *model)
 }
 
 static void
-machine_at_scat_init(const machine_t *model, int is_v4)
+machine_at_scat_init(const machine_t *model, int is_v4, int is_ami)
 {
     machine_at_common_init(model);
-    device_add(&keyboard_at_ami_device);
+
+    if (is_ami)
+        device_add(&keyboard_at_ami_device);
+    else
+        device_add(&keyboard_at_device);
 
     if (is_v4)
         device_add(&scat_4_device);
@@ -289,7 +293,7 @@ machine_at_award286_init(const machine_t *model)
     if (bios_only || !ret)
         return ret;
 
-    machine_at_scat_init(model, 0);
+    machine_at_scat_init(model, 0, 1);
 
     if (fdc_type == FDC_INTERNAL)
         device_add(&fdc_at_device);
@@ -308,7 +312,7 @@ machine_at_gdc212m_init(const machine_t *model)
     if (bios_only || !ret)
         return ret;
 
-    machine_at_scat_init(model, 0);
+    machine_at_scat_init(model, 0, 1);
 
     if (fdc_type == FDC_INTERNAL)
         device_add(&fdc_at_device);
@@ -331,10 +335,7 @@ machine_at_gw286ct_init(const machine_t *model)
 
     device_add(&f82c710_device);
 
-    machine_at_common_init(model);
-    device_add(&keyboard_at_device);
-
-    device_add(&scat_4_device);
+    machine_at_scat_init(model, 1, 0);
 
     device_add(&ide_isa_device);
 
@@ -352,7 +353,7 @@ machine_at_super286tr_init(const machine_t *model)
     if (bios_only || !ret)
         return ret;
 
-    machine_at_scat_init(model, 0);
+    machine_at_scat_init(model, 0, 1);
 
     if (fdc_type == FDC_INTERNAL)
         device_add(&fdc_at_device);
@@ -371,7 +372,7 @@ machine_at_spc4200p_init(const machine_t *model)
     if (bios_only || !ret)
         return ret;
 
-    machine_at_scat_init(model, 0);
+    machine_at_scat_init(model, 0, 1);
 
     if (fdc_type == FDC_INTERNAL)
         device_add(&fdc_at_device);
@@ -391,7 +392,7 @@ machine_at_spc4216p_init(const machine_t *model)
     if (bios_only || !ret)
         return ret;
 
-    machine_at_scat_init(model, 1);
+    machine_at_scat_init(model, 1, 1);
 
     if (fdc_type == FDC_INTERNAL)
         device_add(&fdc_at_device);
@@ -414,7 +415,7 @@ machine_at_spc4620p_init(const machine_t *model)
     if (gfxcard == VID_INTERNAL)
         device_add(&ati28800k_spc4620p_device);
 
-    machine_at_scat_init(model, 1);
+    machine_at_scat_init(model, 1, 1);
 
     if (fdc_type == FDC_INTERNAL)
         device_add(&fdc_at_device);
@@ -449,7 +450,7 @@ machine_at_deskmaster286_init(const machine_t *model)
     if (bios_only || !ret)
         return ret;
 
-    machine_at_scat_init(model, 0);
+    machine_at_scat_init(model, 0, 1);
 
     if (fdc_type == FDC_INTERNAL)
         device_add(&fdc_at_device);
@@ -720,11 +721,10 @@ machine_at_mr1217_init(const machine_t *model)
     if (bios_only || !ret)
         return ret;
 
-    machine_at_common_init(model);
+    machine_at_common_ide_init(model);
 
     device_add(&ali1217_device);
     device_add(&fdc_at_device);
-    device_add(&ide_isa_device);
     device_add(&keyboard_ps2_device);
 
     return ret;


### PR DESCRIPTION
Summary
=======
Simplify and reuse code in m_at_286_386sx.c, makes the code flow a little bit easier to follow

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
