### PR TITLE
Correct many file headers to show 86box

### DIFF
--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -1,20 +1,20 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Definitions for the code generator.
+ *          Definitions for the code generator.
  *
  *
  *
- * Authors:	Sarah Walker, <tommowalker@tommowalker.co.uk>
- *		Miran Grca, <mgrca8@gmail.com>
+ * Authors: Sarah Walker, <tommowalker@tommowalker.co.uk>
+ *          Miran Grca, <mgrca8@gmail.com>
  *
- *		Copyright 2008-2018 Sarah Walker.
- *		Copyright 2016-2018 Miran Grca.
+ *          Copyright 2008-2018 Sarah Walker.
+ *          Copyright 2016-2018 Miran Grca.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -92,7 +92,7 @@ typedef struct codeblock_t
         int pnt;
         int ins;
 
-	int valid;
+    int valid;
 
         int was_recompiled;
         int TOP;
@@ -353,7 +353,7 @@ static inline void addbyte(uint8_t val)
 
 static inline void addword(uint16_t val)
 {
-	uint16_t *p = (uint16_t *) &codeblock[block_current].data[block_pos];
+    uint16_t *p = (uint16_t *) &codeblock[block_current].data[block_pos];
         *p = val;
         block_pos += 2;
         if (block_pos >= BLOCK_MAX)
@@ -364,7 +364,7 @@ static inline void addword(uint16_t val)
 
 static inline void addlong(uint32_t val)
 {
-	uint32_t *p = (uint32_t *) &codeblock[block_current].data[block_pos];
+    uint32_t *p = (uint32_t *) &codeblock[block_current].data[block_pos];
         *p = val;
         block_pos += 4;
         if (block_pos >= BLOCK_MAX)
@@ -375,7 +375,7 @@ static inline void addlong(uint32_t val)
 
 static inline void addquad(uint64_t val)
 {
-	uint64_t *p = (uint64_t *) &codeblock[block_current].data[block_pos];
+    uint64_t *p = (uint64_t *) &codeblock[block_current].data[block_pos];
         *p = val;
         block_pos += 8;
         if (block_pos >= BLOCK_MAX)

--- a/src/codegen/codegen_x86.c
+++ b/src/codegen/codegen_x86.c
@@ -1,22 +1,22 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Dynamic Recompiler for Intel 32-bit systems.
+ *          Dynamic Recompiler for Intel 32-bit systems.
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
- *		Miran Grca, <mgrca8@gmail.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
+ *          Miran Grca, <mgrca8@gmail.com>
  *
- *		Copyright 2018 Fred N. van Kempen.
- *		Copyright 2008-2018 Sarah Walker.
- *		Copyright 2016-2018 Miran Grca.
+ *          Copyright 2018 Fred N. van Kempen.
+ *          Copyright 2008-2018 Sarah Walker.
+ *          Copyright 2016-2018 Miran Grca.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1402,7 +1402,7 @@ void codegen_block_init(uint32_t phys_addr)
         block_num = HASH(phys_addr);
         codeblock_hash[block_num] = &codeblock[block_current];
 
-	block->valid = 1;
+    block->valid = 1;
         block->ins = 0;
         block->pc = cs + cpu_state.pc;
         block->_cs = cs;
@@ -1452,14 +1452,14 @@ void codegen_block_start_recompile(codeblock_t *block)
         addbyte(0xe8); /*CALL x86gpf*/
         addlong((uint32_t)x86gpf - (uint32_t)(&codeblock[block_current].data[block_pos + 4]));
 #else
-	addbyte(0xc6);	/* mov byte ptr[&(cpu_state.abrt)],ABRT_GPF */
-	addbyte(0x05);
-	addlong((uint32_t) (uintptr_t) &(cpu_state.abrt));
-	addbyte(ABRT_GPF);
-	addbyte(0x31);	/* xor eax,eax */
-	addbyte(0xc0);
-	addbyte(0xa3);	/* mov [&(abrt_error)],eax */
-	addlong((uint32_t) (uintptr_t) &(abrt_error));
+    addbyte(0xc6);    /* mov byte ptr[&(cpu_state.abrt)],ABRT_GPF */
+    addbyte(0x05);
+    addlong((uint32_t) (uintptr_t) &(cpu_state.abrt));
+    addbyte(ABRT_GPF);
+    addbyte(0x31);    /* xor eax,eax */
+    addbyte(0xc0);
+    addbyte(0xa3);    /* mov [&(abrt_error)],eax */
+    addlong((uint32_t) (uintptr_t) &(abrt_error));
 #endif
         block_pos = BLOCK_EXIT_OFFSET; /*Exit code*/
         addbyte(0x83); /*ADDL $16,%esp*/
@@ -2036,8 +2036,8 @@ generate_call:
                   then reverse it for subsequent instructions if the jump is not taken*/
                 int jump_cycles = 0;
 
-		if (codegen_timing_jump_cycles != NULL)
-			jump_cycles = codegen_timing_jump_cycles();
+        if (codegen_timing_jump_cycles != NULL)
+            jump_cycles = codegen_timing_jump_cycles();
 
                 if (jump_cycles)
                         codegen_accumulate(ACCREG_cycles, -jump_cycles);
@@ -2066,13 +2066,13 @@ generate_call:
                         codegen_endpc = (cs + cpu_state.pc) + 8;
 
 #ifdef CHECK_INT
-			/* Check for interrupts. */
-			addbyte(0xf6);	/* test byte ptr[&pic_pending],1 */
-			addbyte(0x05);
-			addlong((uint32_t) (uintptr_t) &pic_pending);
-			addbyte(0x01);
-			addbyte(0x0F); addbyte(0x85); /*JNZ 0*/
-			addlong((uint32_t)&block->data[BLOCK_EXIT_OFFSET] - (uint32_t)(&block->data[block_pos + 4]));
+            /* Check for interrupts. */
+            addbyte(0xf6);    /* test byte ptr[&pic_pending],1 */
+            addbyte(0x05);
+            addlong((uint32_t) (uintptr_t) &pic_pending);
+            addbyte(0x01);
+            addbyte(0x0F); addbyte(0x85); /*JNZ 0*/
+            addlong((uint32_t)&block->data[BLOCK_EXIT_OFFSET] - (uint32_t)(&block->data[block_pos + 4]));
 #endif
 
                         return;
@@ -2087,7 +2087,7 @@ generate_call:
                 addbyte(0xC6); /*MOVB [ssegs],op_ssegs*/
                 addbyte(0x45);
                 addbyte((uint8_t)cpu_state_offset(ssegs));
-               	addbyte(op_pc + pc_off);
+                   addbyte(op_pc + pc_off);
         }
 
         if (!test_modrm ||
@@ -2130,7 +2130,7 @@ generate_call:
         addbyte(0xC7); /*MOVL pc,new_pc*/
         addbyte(0x45);
         addbyte((uint8_t)cpu_state_offset(pc));
-	addlong(op_pc + pc_off);
+    addlong(op_pc + pc_off);
 
         addbyte(0xC7); /*MOVL $old_pc,(oldpc)*/
         addbyte(0x45);
@@ -2159,10 +2159,10 @@ generate_call:
         block->ins++;
 
 #ifdef CHECK_INT
-	/* Check for interrupts. */
-	addbyte(0x0a);	/* or  al,byte ptr[&pic_pending] */
-	addbyte(0x05);
-	addlong((uint32_t) (uintptr_t) &pic_pending);
+    /* Check for interrupts. */
+    addbyte(0x0a);    /* or  al,byte ptr[&pic_pending] */
+    addbyte(0x05);
+    addlong((uint32_t) (uintptr_t) &pic_pending);
 #endif
 
         addbyte(0x09); /*OR %eax, %eax*/

--- a/src/cpu/codegen_public.h
+++ b/src/cpu/codegen_public.h
@@ -1,18 +1,18 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Definitions for the code generator.
+ *          Definitions for the code generator.
  *
  *
  *
- * Authors:	Miran Grca, <mgrca8@gmail.com>
+ * Authors: Miran Grca, <mgrca8@gmail.com>
  *
- *		Copyright 2020 Miran Grca.
+ *          Copyright 2020 Miran Grca.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -50,15 +50,15 @@
 #endif
 
 
-extern void	codegen_init();
+extern void    codegen_init();
 #ifdef USE_NEW_DYNAREC
-extern void	codegen_close();
+extern void    codegen_close();
 #endif
-extern void	codegen_flush();
+extern void    codegen_flush();
 
 
 /*Current physical page of block being recompiled. -1 if no recompilation taking place */
-extern uint32_t	recomp_page;
+extern uint32_t    recomp_page;
 extern int codegen_in_recompile;
 
 #endif

--- a/src/cpu/x86_ops.h
+++ b/src/cpu/x86_ops.h
@@ -1,22 +1,22 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Miscellaneous x86 CPU Instructions.
+ *          Miscellaneous x86 CPU Instructions.
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
- *		Miran Grca, <mgrca8@gmail.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
+ *          Miran Grca, <mgrca8@gmail.com>
  *
- *		Copyright 2018 Fred N. van Kempen.
- *		Copyright 2008-2018 Sarah Walker.
- *		Copyright 2016-2018 Miran Grca.
+ *          Copyright 2018 Fred N. van Kempen.
+ *          Copyright 2008-2018 Sarah Walker.
+ *          Copyright 2016-2018 Miran Grca.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -40,15 +40,15 @@
 #define _X86_OPS_H
 
 
-#define UN_USED(x)	(void)(x)
+#define UN_USED(x)    (void)(x)
 
 
 typedef int (*OpFn)(uint32_t fetchdat);
 
 #ifdef USE_DYNAREC
 void x86_setopcodes(const OpFn *opcodes, const OpFn *opcodes_0f,
-		    const OpFn *dynarec_opcodes,
-		    const OpFn *dynarec_opcodes_0f);
+            const OpFn *dynarec_opcodes,
+            const OpFn *dynarec_opcodes_0f);
 
 extern const OpFn *x86_dynarec_opcodes;
 extern const OpFn *x86_dynarec_opcodes_0f;

--- a/src/device.c
+++ b/src/device.c
@@ -1,23 +1,23 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implementation of the generic device interface to handle
- *		all devices attached to the emulator.
+ *          Implementation of the generic device interface to handle
+ *          all devices attached to the emulator.
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
- *		Miran Grca, <mgrca8@gmail.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
+ *          Miran Grca, <mgrca8@gmail.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2017-2019 Fred N. van Kempen.
- *		Copyright 2016-2019 Miran Grca.
- *		Copyright 2008-2019 Sarah Walker.
+ *          Copyright 2017-2019 Fred N. van Kempen.
+ *          Copyright 2016-2019 Miran Grca.
+ *          Copyright 2008-2019 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/device/isamem.c
+++ b/src/device/isamem.c
@@ -1,60 +1,60 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implementation of a memory expansion board for the ISA Bus.
+ *          Implementation of a memory expansion board for the ISA Bus.
  *
- *		Although modern systems use direct-connect local buses to
- *		connect the CPU with its memory, originally the main system
- *		bus(es) were used for that. Memory expension cards could add
- *		memory to the system through the ISA bus, using a variety of
- *		techniques.
+ *          Although modern systems use direct-connect local buses to
+ *          connect the CPU with its memory, originally the main system
+ *          bus(es) were used for that. Memory expension cards could add
+ *          memory to the system through the ISA bus, using a variety of
+ *          techniques.
  *
- *		The majority of these boards could provide some (additional)
- *		conventional (low) memory, extended (high) memory on 80286
- *		and higher systems, as well as EMS bank-switched memory.
+ *          The majority of these boards could provide some (additional)
+ *          conventional (low) memory, extended (high) memory on 80286
+ *          and higher systems, as well as EMS bank-switched memory.
  *
- *		This implementation uses the LIM 3.2 specifications for EMS.
+ *          This implementation uses the LIM 3.2 specifications for EMS.
  *
- *		With the EMS method, the system's standard memory is expanded
- *		by means of bank-switching. One or more 'frames' in the upper
- *		memory area (640K-1024K) are used as viewports into an array
- *		of RAM pages numbered 0 to N. Each page is defined to be 16KB
- *		in size, so, for a 1024KB board, 64 such pages are available.
- *		I/O control registers are used to set up the mappings. More
- *		modern boards even have multiple 'copies' of those registers,
- *		which can be switched very fast, to allow for multitasking.
+ *          With the EMS method, the system's standard memory is expanded
+ *          by means of bank-switching. One or more 'frames' in the upper
+ *          memory area (640K-1024K) are used as viewports into an array
+ *          of RAM pages numbered 0 to N. Each page is defined to be 16KB
+ *          in size, so, for a 1024KB board, 64 such pages are available.
+ *          I/O control registers are used to set up the mappings. More
+ *          modern boards even have multiple 'copies' of those registers,
+ *          which can be switched very fast, to allow for multitasking.
  *
- * TODO:	The EV159 is supposed to support 16b EMS transfers, but the
- *		EMM.sys driver for it doesn't seem to want to do that..
+ * TODO:    The EV159 is supposed to support 16b EMS transfers, but the
+ *          EMM.sys driver for it doesn't seem to want to do that..
  *
  *
  *
- * Author:	Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
  *
- *		Copyright 2018 Fred N. van Kempen.
+ *          Copyright 2018 Fred N. van Kempen.
  *
- *		Redistribution and  use  in source  and binary forms, with
- *		or  without modification, are permitted  provided that the
- *		following conditions are met:
+ *          Redistribution and  use  in source  and binary forms, with
+ *          or  without modification, are permitted  provided that the
+ *          following conditions are met:
  *
- *		1. Redistributions of  source  code must retain the entire
- *		   above notice, this list of conditions and the following
- *		   disclaimer.
+ *          1. Redistributions of  source  code must retain the entire
+ *             above notice, this list of conditions and the following
+ *             disclaimer.
  *
- *		2. Redistributions in binary form must reproduce the above
- *		   copyright  notice,  this list  of  conditions  and  the
- *		   following disclaimer in  the documentation and/or other
- *		   materials provided with the distribution.
+ *          2. Redistributions in binary form must reproduce the above
+ *             copyright  notice,  this list  of  conditions  and  the
+ *             following disclaimer in  the documentation and/or other
+ *             materials provided with the distribution.
  *
- *		3. Neither the  name of the copyright holder nor the names
- *		   of  its  contributors may be used to endorse or promote
- *		   products  derived from  this  software without specific
- *		   prior written permission.
+ *          3. Neither the  name of the copyright holder nor the names
+ *             of  its  contributors may be used to endorse or promote
+ *             products  derived from  this  software without specific
+ *             prior written permission.
  *
  * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
  * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT

--- a/src/device/isamem.c
+++ b/src/device/isamem.c
@@ -1,10 +1,8 @@
 /*
- * 86Box    A hypervisor and IBM PC system emulator that specializes in
- *          running old operating systems and software designed for IBM
- *          PC systems and compatibles from 1981 through fairly recent
- *          system designs based on the PCI bus.
- *
- *          This file is part of the 86Box distribution.
+ * VARCem   Virtual ARchaeological Computer EMulator.
+ *          An emulator of (mostly) x86-based PC systems and devices,
+ *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *          spanning the era between 1981 and 1995.
  *
  *          Implementation of a memory expansion board for the ISA Bus.
  *

--- a/src/device/isartc.c
+++ b/src/device/isartc.c
@@ -1,56 +1,56 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implementation of a Clock/RTC Card for the ISA PC/XT.
+ *          Implementation of a Clock/RTC Card for the ISA PC/XT.
  *
- *		Systems starting with the PC/XT had, by default, a realtime
- *		clock and NVR chip on the mainboard. The BIOS stored config
- *		data in the NVR, and the system could maintain time and date
- *		using the RTC.
+ *          Systems starting with the PC/XT had, by default, a realtime
+ *          clock and NVR chip on the mainboard. The BIOS stored config
+ *          data in the NVR, and the system could maintain time and date
+ *          using the RTC.
  *
- *		Originally, PC systems did not have this, and they first did
- *		show up in non-IBM clone systems. Shortly after, expansion
- *		cards with this function became available for the PC's (ISA)
- *		bus, and they came in many forms and designs.
+ *          Originally, PC systems did not have this, and they first did
+ *          show up in non-IBM clone systems. Shortly after, expansion
+ *          cards with this function became available for the PC's (ISA)
+ *          bus, and they came in many forms and designs.
  *
- *		This implementation offers some of those boards:
+ *          This implementation offers some of those boards:
  *
- *		  Everex EV-170 (using NatSemi MM58167 chip)
- *		  DTK PII-147 Hexa I/O Plus (using UMC 82C8167 chip)
+ *            Everex EV-170 (using NatSemi MM58167 chip)
+ *            DTK PII-147 Hexa I/O Plus (using UMC 82C8167 chip)
  *
- *		and more will follow as time permits.
+ *          and more will follow as time permits.
  *
- * NOTE:	The IRQ functionalities have been implemented, but not yet
- *		tested, as I need to write test software for them first :)
+ * NOTE:    The IRQ functionalities have been implemented, but not yet
+ *          tested, as I need to write test software for them first :)
  *
  *
  *
- * Author:	Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
  *
- *		Copyright 2018 Fred N. van Kempen.
+ *          Copyright 2018 Fred N. van Kempen.
  *
- *		Redistribution and  use  in source  and binary forms, with
- *		or  without modification, are permitted  provided that the
- *		following conditions are met:
+ *          Redistribution and  use  in source  and binary forms, with
+ *          or  without modification, are permitted  provided that the
+ *          following conditions are met:
  *
- *		1. Redistributions of  source  code must retain the entire
- *		   above notice, this list of conditions and the following
- *		   disclaimer.
+ *          1. Redistributions of  source  code must retain the entire
+ *             above notice, this list of conditions and the following
+ *             disclaimer.
  *
- *		2. Redistributions in binary form must reproduce the above
- *		   copyright  notice,  this list  of  conditions  and  the
- *		   following disclaimer in  the documentation and/or other
- *		   materials provided with the distribution.
+ *          2. Redistributions in binary form must reproduce the above
+ *             copyright  notice,  this list  of  conditions  and  the
+ *             following disclaimer in  the documentation and/or other
+ *             materials provided with the distribution.
  *
- *		3. Neither the  name of the copyright holder nor the names
- *		   of  its  contributors may be used to endorse or promote
- *		   products  derived from  this  software without specific
- *		   prior written permission.
+ *          3. Neither the  name of the copyright holder nor the names
+ *             of  its  contributors may be used to endorse or promote
+ *             products  derived from  this  software without specific
+ *             prior written permission.
  *
  * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
  * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT
@@ -113,9 +113,9 @@ typedef struct {
 } rtcdev_t;
 
 /************************************************************************
- *									*
- *		    Driver for the NatSemi MM58167 chip.		*
- *									*
+ *                                    *
+ *            Driver for the NatSemi MM58167 chip.        *
+ *                                    *
  ************************************************************************/
 #define MM67_REGS 32
 
@@ -482,9 +482,9 @@ mm67_write(uint16_t port, uint8_t val, void *priv)
 }
 
 /************************************************************************
- *									*
- *		    Generic code for all supported chips.		*
- *									*
+ *                                    *
+ *            Generic code for all supported chips.        *
+ *                                    *
  ************************************************************************/
 
 /* Initialize the device for use. */

--- a/src/device/isartc.c
+++ b/src/device/isartc.c
@@ -1,10 +1,8 @@
 /*
- * 86Box    A hypervisor and IBM PC system emulator that specializes in
- *          running old operating systems and software designed for IBM
- *          PC systems and compatibles from 1981 through fairly recent
- *          system designs based on the PCI bus.
- *
- *          This file is part of the 86Box distribution.
+ * VARCem   Virtual ARchaeological Computer EMulator.
+ *          An emulator of (mostly) x86-based PC systems and devices,
+ *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *          spanning the era between 1981 and 1995.
  *
  *          Implementation of a Clock/RTC Card for the ISA PC/XT.
  *

--- a/src/disk/hdc_xta.c
+++ b/src/disk/hdc_xta.c
@@ -1,76 +1,76 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implementation of a generic IDE-XTA disk controller.
+ *          Implementation of a generic IDE-XTA disk controller.
  *
- *		XTA is the acronym for 'XT-Attached', which was basically
- *		the XT-counterpart to what we know now as IDE (which is
- *		also named ATA - AT Attachment.)  The basic ideas was to
- *		put the actual drive controller electronics onto the drive
- *		itself, and have the host machine just talk to that using
- *		a simpe, standardized I/O path- hence the name IDE, for
- *		Integrated Drive Electronics.
+ *          XTA is the acronym for 'XT-Attached', which was basically
+ *          the XT-counterpart to what we know now as IDE (which is
+ *          also named ATA - AT Attachment.)  The basic ideas was to
+ *          put the actual drive controller electronics onto the drive
+ *          itself, and have the host machine just talk to that using
+ *          a simpe, standardized I/O path- hence the name IDE, for
+ *          Integrated Drive Electronics.
  *
- *		In the ATA version of IDE, the programming interface of
- *		the IBM PC/AT (which used the Western Digitial 1002/1003
- *		controllers) was kept, and, so, ATA-IDE assumes a 16bit
- *		data path: it reads and writes 16bit words of data. The
- *		disk drives for this bus commonly have an 'A' suffix to
- *		identify them as 'ATBUS'.
+ *          In the ATA version of IDE, the programming interface of
+ *          the IBM PC/AT (which used the Western Digitial 1002/1003
+ *          controllers) was kept, and, so, ATA-IDE assumes a 16bit
+ *          data path: it reads and writes 16bit words of data. The
+ *          disk drives for this bus commonly have an 'A' suffix to
+ *          identify them as 'ATBUS'.
  *
- *		In XTA-IDE, which is slightly older, the programming
- *		interface of the IBM PC/XT (which used the MFM controller
- *		from Xebec) was kept, and, so, it uses an 8bit data path.
- *		Disk drives for this bus commonly have the 'X' suffix to
- *		mark them as being for this XTBUS variant.
+ *          In XTA-IDE, which is slightly older, the programming
+ *          interface of the IBM PC/XT (which used the MFM controller
+ *          from Xebec) was kept, and, so, it uses an 8bit data path.
+ *          Disk drives for this bus commonly have the 'X' suffix to
+ *          mark them as being for this XTBUS variant.
  *
- *		So, XTA and ATA try to do the same thing, but they use
- *		different ways to achive their goal.
+ *          So, XTA and ATA try to do the same thing, but they use
+ *          different ways to achive their goal.
  *
- *		Also, XTA is **not** the same as XTIDE.  XTIDE is a modern
- *		variant of ATA-IDE, but retro-fitted for use on 8bit XT
- *		systems: an extra register is used to deal with the extra
- *		data byte per transfer.  XTIDE uses regular IDE drives,
- *		and uses the regular ATA/IDE programming interface, just
- *		with the extra register.
+ *          Also, XTA is **not** the same as XTIDE.  XTIDE is a modern
+ *          variant of ATA-IDE, but retro-fitted for use on 8bit XT
+ *          systems: an extra register is used to deal with the extra
+ *          data byte per transfer.  XTIDE uses regular IDE drives,
+ *          and uses the regular ATA/IDE programming interface, just
+ *          with the extra register.
  *
- * NOTE:	This driver implements both the 'standard' XTA interface,
- *		sold by Western Digital as the WDXT-140 (no BIOS) and the
- *		WDXT-150 (with BIOS), as well as some variants customized
- *		for specific machines.
+ * NOTE:    This driver implements both the 'standard' XTA interface,
+ *          sold by Western Digital as the WDXT-140 (no BIOS) and the
+ *          WDXT-150 (with BIOS), as well as some variants customized
+ *          for specific machines.
  *
- * NOTE:	The XTA interface is 0-based for sector numbers !!
+ * NOTE:    The XTA interface is 0-based for sector numbers !!
  *
  *
  *
- * Author:	Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
  *
- *		Based on my earlier HD20 driver for the EuroPC.
+ *          Based on my earlier HD20 driver for the EuroPC.
  *
- *		Copyright 2017,2018 Fred N. van Kempen.
+ *          Copyright 2017,2018 Fred N. van Kempen.
  *
- *		Redistribution and  use  in source  and binary forms, with
- *		or  without modification, are permitted  provided that the
- *		following conditions are met:
+ *          Redistribution and  use  in source  and binary forms, with
+ *          or  without modification, are permitted  provided that the
+ *          following conditions are met:
  *
- *		1. Redistributions of  source  code must retain the entire
- *		   above notice, this list of conditions and the following
- *		   disclaimer.
+ *          1. Redistributions of  source  code must retain the entire
+ *             above notice, this list of conditions and the following
+ *             disclaimer.
  *
- *		2. Redistributions in binary form must reproduce the above
- *		   copyright  notice,  this list  of  conditions  and  the
- *		   following disclaimer in  the documentation and/or other
- *		   materials provided with the distribution.
+ *          2. Redistributions in binary form must reproduce the above
+ *             copyright  notice,  this list  of  conditions  and  the
+ *             following disclaimer in  the documentation and/or other
+ *             materials provided with the distribution.
  *
- *		3. Neither the  name of the copyright holder nor the names
- *		   of  its  contributors may be used to endorse or promote
- *		   products  derived from  this  software without specific
- *		   prior written permission.
+ *          3. Neither the  name of the copyright holder nor the names
+ *             of  its  contributors may be used to endorse or promote
+ *             products  derived from  this  software without specific
+ *             prior written permission.
  *
  * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
  * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT
@@ -122,14 +122,14 @@ enum {
 /* Command values. */
 #define CMD_TEST_READY  0x00
 #define CMD_RECALIBRATE 0x01
-/* unused 	0x02 */
+/* unused     0x02 */
 #define CMD_READ_SENSE       0x03
 #define CMD_FORMAT_DRIVE     0x04
 #define CMD_READ_VERIFY      0x05
 #define CMD_FORMAT_TRACK     0x06
 #define CMD_FORMAT_BAD_TRACK 0x07
 #define CMD_READ_SECTORS     0x08
-/* unused	0x09 */
+/* unused    0x09 */
 #define CMD_WRITE_SECTORS       0x0a
 #define CMD_SEEK                0x0b
 #define CMD_SET_DRIVE_PARAMS    0x0c
@@ -137,8 +137,8 @@ enum {
 #define CMD_READ_SECTOR_BUFFER  0x0e
 #define CMD_WRITE_SECTOR_BUFFER 0x0f
 #define CMD_RAM_DIAGS           0xe0
-/* unused	0xe1 */
-/* unused	0xe2 */
+/* unused    0xe1 */
+/* unused    0xe2 */
 #define CMD_DRIVE_DIAGS 0xe3
 #define CMD_CTRL_DIAGS  0xe4
 #define CMD_READ_LONG   0xe5
@@ -184,20 +184,20 @@ enum {
 /* The device control block (6 bytes) */
 #pragma pack(push, 1)
 typedef struct {
-    uint8_t cmd; /* [7:5] class, [4:0] opcode	*/
+    uint8_t cmd; /* [7:5] class, [4:0] opcode    */
 
-    uint8_t head   : 5, /* [4:0] head number		*/
-        drvsel     : 1, /* [5] drive select		*/
-        mbz        : 2; /* [7:6] 00			*/
+    uint8_t head   : 5, /* [4:0] head number        */
+        drvsel     : 1, /* [5] drive select        */
+        mbz        : 2; /* [7:6] 00            */
 
-    uint8_t sector : 6, /* [5:0] sector number 0-63	*/
-        cyl_high   : 2; /* [7:6] cylinder [9:8] bits	*/
+    uint8_t sector : 6, /* [5:0] sector number 0-63    */
+        cyl_high   : 2; /* [7:6] cylinder [9:8] bits    */
 
-    uint8_t cyl_low; /* [7:0] cylinder [7:0] bits	*/
+    uint8_t cyl_low; /* [7:0] cylinder [7:0] bits    */
 
-    uint8_t count; /* [7:0] blk count / interleave	*/
+    uint8_t count; /* [7:0] blk count / interleave    */
 
-    uint8_t ctrl; /* [7:0] control field		*/
+    uint8_t ctrl; /* [7:0] control field        */
 } dcb_t;
 #pragma pack(pop)
 
@@ -246,8 +246,8 @@ typedef struct {
 
     /* Controller state. */
     int8_t     state;  /* controller state */
-    uint8_t    sense;  /* current SENSE ERROR value	*/
-    uint8_t    status; /* current operational status	*/
+    uint8_t    sense;  /* current SENSE ERROR value    */
+    uint8_t    status; /* current operational status    */
     uint8_t    intr;
     uint64_t   callback;
     pc_timer_t timer;

--- a/src/disk/hdc_xta.c
+++ b/src/disk/hdc_xta.c
@@ -1,10 +1,8 @@
 /*
- * 86Box    A hypervisor and IBM PC system emulator that specializes in
- *          running old operating systems and software designed for IBM
- *          PC systems and compatibles from 1981 through fairly recent
- *          system designs based on the PCI bus.
- *
- *          This file is part of the 86Box distribution.
+ * VARCem   Virtual ARchaeological Computer EMulator.
+ *          An emulator of (mostly) x86-based PC systems and devices,
+ *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *          spanning the era between 1981 and 1995.
  *
  *          Implementation of a generic IDE-XTA disk controller.
  *

--- a/src/floppy/fdc_pii15xb.c
+++ b/src/floppy/fdc_pii15xb.c
@@ -1,48 +1,48 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *	  Implementation of the DTK MiniMicro series of Floppy Disk Controllers.
- *    Original code from VARCem. Fully rewritten, fixed and improved for 86Box.
+ *          Implementation of the DTK MiniMicro series of Floppy Disk Controllers.
+ *          Original code from VARCem. Fully rewritten, fixed and improved for 86Box.
  *
- * Author:	Fred N. van Kempen, <decwiz@yahoo.com>,
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>,
  *          Tiseno100
  *
- *		Copyright 2019 Fred N. van Kempen.
- *      Copyright 2021 Tiseno100
+ *          Copyright 2019 Fred N. van Kempen.
+ *          Copyright 2021 Tiseno100
  *
- *		Redistribution and use in source and binary forms, with
- *		or without modification, are permitted provided that the
- *		following conditions are met:
+ *          Redistribution and  use  in source  and binary forms, with
+ *          or  without modification, are permitted  provided that the
+ *          following conditions are met:
  *
- *		1. Redistributions of source code must retain the entire
- *		  above notice, this list of conditions and the following
- *		  disclaimer.
+ *          1. Redistributions of  source  code must retain the entire
+ *             above notice, this list of conditions and the following
+ *             disclaimer.
  *
- *		2. Redistributions in binary form must reproduce the above
- *		  copyright notice, this list of conditions and the
- *		  following disclaimer in the documentation and/or other
- *		  materials provided with the distribution.
+ *          2. Redistributions in binary form must reproduce the above
+ *             copyright  notice,  this list  of  conditions  and  the
+ *             following disclaimer in  the documentation and/or other
+ *             materials provided with the distribution.
  *
- *		3. Neither the name of the copyright holder nor the names
- *		  of its contributors may be used to endorse or promote
- *		  products derived from this software without specific
- *		  prior written permission.
+ *          3. Neither the  name of the copyright holder nor the names
+ *             of  its  contributors may be used to endorse or promote
+ *             products  derived from  this  software without specific
+ *             prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
- * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * PARTICULAR PURPOSE  ARE  DISCLAIMED. IN  NO  EVENT  SHALL THE COPYRIGHT
+ * HOLDER OR  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL,  EXEMPLARY,  OR  CONSEQUENTIAL  DAMAGES  (INCLUDING,  BUT  NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES;  LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED  AND ON  ANY
+ * THEORY OF  LIABILITY, WHETHER IN  CONTRACT, STRICT  LIABILITY, OR  TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING  IN ANY  WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 

--- a/src/floppy/fdc_pii15xb.c
+++ b/src/floppy/fdc_pii15xb.c
@@ -1,10 +1,8 @@
 /*
- * 86Box    A hypervisor and IBM PC system emulator that specializes in
- *          running old operating systems and software designed for IBM
- *          PC systems and compatibles from 1981 through fairly recent
- *          system designs based on the PCI bus.
- *
- *          This file is part of the 86Box distribution.
+ * VARCem   Virtual ARchaeological Computer EMulator.
+ *          An emulator of (mostly) x86-based PC systems and devices,
+ *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *          spanning the era between 1981 and 1995.
  *
  *          Implementation of the DTK MiniMicro series of Floppy Disk Controllers.
  *          Original code from VARCem. Fully rewritten, fixed and improved for 86Box.

--- a/src/floppy/fdd_json.c
+++ b/src/floppy/fdd_json.c
@@ -1,36 +1,36 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implementation of the PCjs JSON floppy image format.
+ *          Implementation of the PCjs JSON floppy image format.
  *
  *
  *
- * Author:	Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
  *
- *		Copyright 2017-2019 Fred N. van Kempen.
+ *          Copyright 2017-2019 Fred N. van Kempen.
  *
- *		Redistribution and  use  in source  and binary forms, with
- *		or  without modification, are permitted  provided that the
- *		following conditions are met:
+ *          Redistribution and  use  in source  and binary forms, with
+ *          or  without modification, are permitted  provided that the
+ *          following conditions are met:
  *
- *		1. Redistributions of  source  code must retain the entire
- *		   above notice, this list of conditions and the following
- *		   disclaimer.
+ *          1. Redistributions of  source  code must retain the entire
+ *             above notice, this list of conditions and the following
+ *             disclaimer.
  *
- *		2. Redistributions in binary form must reproduce the above
- *		   copyright  notice,  this list  of  conditions  and  the
- *		   following disclaimer in  the documentation and/or other
- *		   materials provided with the distribution.
+ *          2. Redistributions in binary form must reproduce the above
+ *             copyright  notice,  this list  of  conditions  and  the
+ *             following disclaimer in  the documentation and/or other
+ *             materials provided with the distribution.
  *
- *		3. Neither the  name of the copyright holder nor the names
- *		   of  its  contributors may be used to endorse or promote
- *		   products  derived from  this  software without specific
- *		   prior written permission.
+ *          3. Neither the  name of the copyright holder nor the names
+ *             of  its  contributors may be used to endorse or promote
+ *             products  derived from  this  software without specific
+ *             prior written permission.
  *
  * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
  * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT
@@ -88,7 +88,7 @@ typedef struct {
     uint8_t dmf; /* disk is DMF format */
     uint8_t interleave;
 #if 0
-    uint8_t	skew;
+    uint8_t    skew;
 #endif
     uint8_t gap2_len;
     uint8_t gap3_len;

--- a/src/floppy/fdd_json.c
+++ b/src/floppy/fdd_json.c
@@ -1,10 +1,8 @@
 /*
- * 86Box    A hypervisor and IBM PC system emulator that specializes in
- *          running old operating systems and software designed for IBM
- *          PC systems and compatibles from 1981 through fairly recent
- *          system designs based on the PCI bus.
- *
- *          This file is part of the 86Box distribution.
+ * VARCem   Virtual ARchaeological Computer EMulator.
+ *          An emulator of (mostly) x86-based PC systems and devices,
+ *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *          spanning the era between 1981 and 1995.
  *
  *          Implementation of the PCjs JSON floppy image format.
  *

--- a/src/game/joystick_ch_flightstick_pro.c
+++ b/src/game/joystick_ch_flightstick_pro.c
@@ -1,20 +1,20 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implementation of the Flight Stick Pro.
+ *          Implementation of the Flight Stick Pro.
  *
  *
  *
- * Authors:	Miran Grca, <mgrca8@gmail.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Miran Grca, <mgrca8@gmail.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2016-2018 Miran Grca.
- *		Copyright 2008-2018 Sarah Walker.
+ *          Copyright 2016-2018 Miran Grca.
+ *          Copyright 2008-2018 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/game/joystick_standard.c
+++ b/src/game/joystick_standard.c
@@ -1,20 +1,20 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implementation of a standard joystick.
+ *          Implementation of a standard joystick.
  *
  *
  *
- * Authors:	Miran Grca, <mgrca8@gmail.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Miran Grca, <mgrca8@gmail.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2016-2018 Miran Grca.
- *		Copyright 2008-2018 Sarah Walker.
+ *          Copyright 2016-2018 Miran Grca.
+ *          Copyright 2008-2018 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/game/joystick_sw_pad.c
+++ b/src/game/joystick_sw_pad.c
@@ -1,41 +1,41 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implementation of a Side Winder GamePad.
+ *          Implementation of a Side Winder GamePad.
  *
- * Notes:	- Write to 0x201 starts packet transfer (5*N or 15*N bits)
- *		- Currently alternates between Mode A and Mode B (is there
- *		  any way of actually controlling which is used?)
- *		- Windows 9x drivers require Mode B when more than 1 pad
- *		  connected
- *		- Packet preceeded by high data (currently 50us), and
- *		  followed by low data (currently 160us) - timings are
- *		  probably wrong, but good enough for everything I've tried
- *		- Analog inputs are only used to time ID packet request.
- *		  If A0 timing out is followed after ~64us by another 0x201
- *		  write then an ID packet is triggered
- *		- Sidewinder game pad ID is 'H0003'
- *		- ID is sent in Mode A (1 bit per clock), but data bit 2
- *		  must change during ID packet transfer, or Windows 9x
- *		  drivers won't use Mode B. I don't know if it oscillates,
- *		  mirrors the data transfer, or something else - the drivers
- *		  only check that it changes at least 10 times during the
- *		  transfer
- *		- Some DOS stuff will write to 0x201 while a packet is
- *		  being transferred. This seems to be ignored.
+ * Notes:   - Write to 0x201 starts packet transfer (5*N or 15*N bits)
+ *          - Currently alternates between Mode A and Mode B (is there
+ *            any way of actually controlling which is used?)
+ *          - Windows 9x drivers require Mode B when more than 1 pad
+ *            connected
+ *          - Packet preceeded by high data (currently 50us), and
+ *            followed by low data (currently 160us) - timings are
+ *            probably wrong, but good enough for everything I've tried
+ *          - Analog inputs are only used to time ID packet request.
+ *            If A0 timing out is followed after ~64us by another 0x201
+ *            write then an ID packet is triggered
+ *          - Sidewinder game pad ID is 'H0003'
+ *          - ID is sent in Mode A (1 bit per clock), but data bit 2
+ *            must change during ID packet transfer, or Windows 9x
+ *            drivers won't use Mode B. I don't know if it oscillates,
+ *            mirrors the data transfer, or something else - the drivers
+ *            only check that it changes at least 10 times during the
+ *            transfer
+ *          - Some DOS stuff will write to 0x201 while a packet is
+ *            being transferred. This seems to be ignored.
  *
  *
  *
- * Authors:	Miran Grca, <mgrca8@gmail.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Miran Grca, <mgrca8@gmail.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2016-2018 Miran Grca.
- *		Copyright 2008-2018 Sarah Walker.
+ *          Copyright 2016-2018 Miran Grca.
+ *          Copyright 2008-2018 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/game/joystick_tm_fcs.c
+++ b/src/game/joystick_tm_fcs.c
@@ -1,20 +1,20 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implementation of Thrust Master Flight Control System.
+ *          Implementation of Thrust Master Flight Control System.
  *
  *
  *
- * Authors:	Miran Grca, <mgrca8@gmail.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Miran Grca, <mgrca8@gmail.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2016-2018 Miran Grca.
- *		Copyright 2008-2018 Sarah Walker.
+ *          Copyright 2016-2018 Miran Grca.
+ *          Copyright 2008-2018 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/include/86box/bswap.h
+++ b/src/include/86box/bswap.h
@@ -1,20 +1,20 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Various definitions for portable byte-swapping.
+ *          Various definitions for portable byte-swapping.
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
- *		neozeed,
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
+ *          neozeed,
  *
- *		Copyright 2017,2018 Fred N. van Kempen.
- *		Copyright 2016-2018 neozeed.
+ *          Copyright 2017,2018 Fred N. van Kempen.
+ *          Copyright 2016-2018 neozeed.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -44,34 +44,34 @@
 #include <byteswap.h>
 #else
 # define bswap_16(x) \
-	( \
-	    ((uint16_t)( \
-		(((uint16_t)(x) & (uint16_t)0x00ffU) << 8) | \
-		(((uint16_t)(x) & (uint16_t)0xff00U) >> 8) )) \
-	)
+    ( \
+        ((uint16_t)( \
+        (((uint16_t)(x) & (uint16_t)0x00ffU) << 8) | \
+        (((uint16_t)(x) & (uint16_t)0xff00U) >> 8) )) \
+    )
 
 # define bswap_32(x) \
-	( \
-	    ((uint32_t)( \
-		(((uint32_t)(x) & (uint32_t)0x000000ffUL) << 24) | \
-		(((uint32_t)(x) & (uint32_t)0x0000ff00UL) <<  8) | \
-		(((uint32_t)(x) & (uint32_t)0x00ff0000UL) >>  8) | \
-		(((uint32_t)(x) & (uint32_t)0xff000000UL) >> 24) )) \
-	)
+    ( \
+        ((uint32_t)( \
+        (((uint32_t)(x) & (uint32_t)0x000000ffUL) << 24) | \
+        (((uint32_t)(x) & (uint32_t)0x0000ff00UL) <<  8) | \
+        (((uint32_t)(x) & (uint32_t)0x00ff0000UL) >>  8) | \
+        (((uint32_t)(x) & (uint32_t)0xff000000UL) >> 24) )) \
+    )
 
 # define bswap_64(x) \
-	( \
-	    ((uint64_t)( \
-		(uint64_t)(((uint64_t)(x) & (uint64_t)0x00000000000000ffULL) << 56) | \
-		(uint64_t)(((uint64_t)(x) & (uint64_t)0x000000000000ff00ULL) << 40) | \
-		(uint64_t)(((uint64_t)(x) & (uint64_t)0x0000000000ff0000ULL) << 24) | \
-		(uint64_t)(((uint64_t)(x) & (uint64_t)0x00000000ff000000ULL) <<  8) | \
-	        (uint64_t)(((uint64_t)(x) & (uint64_t)0x000000ff00000000ULL) >>  8) | \
-		(uint64_t)(((uint64_t)(x) & (uint64_t)0x0000ff0000000000ULL) >> 24) | \
-		(uint64_t)(((uint64_t)(x) & (uint64_t)0x00ff000000000000ULL) >> 40) | \
-		(uint64_t)(((uint64_t)(x) & (uint64_t)0xff00000000000000ULL) >> 56) )) \
-	)
-#endif	/*HAVE_BYTESWAP_H*/
+    ( \
+        ((uint64_t)( \
+        (uint64_t)(((uint64_t)(x) & (uint64_t)0x00000000000000ffULL) << 56) | \
+        (uint64_t)(((uint64_t)(x) & (uint64_t)0x000000000000ff00ULL) << 40) | \
+        (uint64_t)(((uint64_t)(x) & (uint64_t)0x0000000000ff0000ULL) << 24) | \
+        (uint64_t)(((uint64_t)(x) & (uint64_t)0x00000000ff000000ULL) <<  8) | \
+            (uint64_t)(((uint64_t)(x) & (uint64_t)0x000000ff00000000ULL) >>  8) | \
+        (uint64_t)(((uint64_t)(x) & (uint64_t)0x0000ff0000000000ULL) >> 24) | \
+        (uint64_t)(((uint64_t)(x) & (uint64_t)0x00ff000000000000ULL) >> 40) | \
+        (uint64_t)(((uint64_t)(x) & (uint64_t)0xff00000000000000ULL) >> 56) )) \
+    )
+#endif    /*HAVE_BYTESWAP_H*/
 
 #if defined __has_builtin && __has_builtin(__builtin_bswap16)
 #define bswap16(x) __builtin_bswap16(x)

--- a/src/include/86box/device.h
+++ b/src/include/86box/device.h
@@ -1,22 +1,22 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Definitions for the device handler.
+ *          Definitions for the device handler.
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
- *		Miran Grca, <mgrca8@gmail.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
+ *          Miran Grca, <mgrca8@gmail.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2017-2019 Fred N. van Kempen.
- *		Copyright 2016-2019 Miran Grca.
- *		Copyright 2008-2019 Sarah Walker.
+ *          Copyright 2017-2019 Fred N. van Kempen.
+ *          Copyright 2016-2019 Miran Grca.
+ *          Copyright 2008-2019 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/include/86box/dma.h
+++ b/src/include/86box/dma.h
@@ -1,22 +1,22 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Definitions for the Intel DMA controller.
+ *          Definitions for the Intel DMA controller.
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
- *		Miran Grca, <mgrca8@gmail.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
+ *          Miran Grca, <mgrca8@gmail.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2017-2020 Fred N. van Kempen.
- *		Copyright 2016-2020 Miran Grca.
- *		Copyright 2008-2020 Sarah Walker.
+ *          Copyright 2017-2020 Fred N. van Kempen.
+ *          Copyright 2016-2020 Miran Grca.
+ *          Copyright 2008-2020 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/include/86box/fdd_json.h
+++ b/src/include/86box/fdd_json.h
@@ -1,10 +1,8 @@
 /*
- * 86Box    A hypervisor and IBM PC system emulator that specializes in
- *          running old operating systems and software designed for IBM
- *          PC systems and compatibles from 1981 through fairly recent
- *          system designs based on the PCI bus.
- *
- *          This file is part of the 86Box distribution.
+ * VARCem   Virtual ARchaeological Computer EMulator.
+ *          An emulator of (mostly) x86-based PC systems and devices,
+ *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *          spanning the era between 1981 and 1995.
  *
  *          Definitions for the PCjs JSON floppy image format.
  *

--- a/src/include/86box/fdd_json.h
+++ b/src/include/86box/fdd_json.h
@@ -1,36 +1,36 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Definitions for the PCjs JSON floppy image format.
+ *          Definitions for the PCjs JSON floppy image format.
  *
  *
  *
- * Author:	Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
  *
- *		Copyright 2017,2018 Fred N. van Kempen.
+ *          Copyright 2017,2018 Fred N. van Kempen.
  *
- *		Redistribution and  use  in source  and binary forms, with
- *		or  without modification, are permitted  provided that the
- *		following conditions are met:
+ *          Redistribution and  use  in source  and binary forms, with
+ *          or  without modification, are permitted  provided that the
+ *          following conditions are met:
  *
- *		1. Redistributions of  source  code must retain the entire
- *		   above notice, this list of conditions and the following
- *		   disclaimer.
+ *          1. Redistributions of  source  code must retain the entire
+ *             above notice, this list of conditions and the following
+ *             disclaimer.
  *
- *		2. Redistributions in binary form must reproduce the above
- *		   copyright  notice,  this list  of  conditions  and  the
- *		   following disclaimer in  the documentation and/or other
- *		   materials provided with the distribution.
+ *          2. Redistributions in binary form must reproduce the above
+ *             copyright  notice,  this list  of  conditions  and  the
+ *             following disclaimer in  the documentation and/or other
+ *             materials provided with the distribution.
  *
- *		3. Neither the  name of the copyright holder nor the names
- *		   of  its  contributors may be used to endorse or promote
- *		   products  derived from  this  software without specific
- *		   prior written permission.
+ *          3. Neither the  name of the copyright holder nor the names
+ *             of  its  contributors may be used to endorse or promote
+ *             products  derived from  this  software without specific
+ *             prior written permission.
  *
  * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
  * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT

--- a/src/include/86box/isamem.h
+++ b/src/include/86box/isamem.h
@@ -1,10 +1,8 @@
 /*
- * 86Box    A hypervisor and IBM PC system emulator that specializes in
- *          running old operating systems and software designed for IBM
- *          PC systems and compatibles from 1981 through fairly recent
- *          system designs based on the PCI bus.
- *
- *          This file is part of the 86Box distribution.
+ * VARCem   Virtual ARchaeological Computer EMulator.
+ *          An emulator of (mostly) x86-based PC systems and devices,
+ *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *          spanning the era between 1981 and 1995.
  *
  *          Definitions for the ISAMEM cards.
  *

--- a/src/include/86box/isamem.h
+++ b/src/include/86box/isamem.h
@@ -1,36 +1,36 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Definitions for the ISAMEM cards.
+ *          Definitions for the ISAMEM cards.
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
  *
- *		Copyright 2018 Fred N. van Kempen.
+ *          Copyright 2018 Fred N. van Kempen.
  *
- *		Redistribution and  use  in source  and binary forms, with
- *		or  without modification, are permitted  provided that the
- *		following conditions are met:
+ *          Redistribution and  use  in source  and binary forms, with
+ *          or  without modification, are permitted  provided that the
+ *          following conditions are met:
  *
- *		1. Redistributions of  source  code must retain the entire
- *		   above notice, this list of conditions and the following
- *		   disclaimer.
+ *          1. Redistributions of  source  code must retain the entire
+ *             above notice, this list of conditions and the following
+ *             disclaimer.
  *
- *		2. Redistributions in binary form must reproduce the above
- *		   copyright  notice,  this list  of  conditions  and  the
- *		   following disclaimer in  the documentation and/or other
- *		   materials provided with the distribution.
+ *          2. Redistributions in binary form must reproduce the above
+ *             copyright  notice,  this list  of  conditions  and  the
+ *             following disclaimer in  the documentation and/or other
+ *             materials provided with the distribution.
  *
- *		3. Neither the  name of the copyright holder nor the names
- *		   of  its  contributors may be used to endorse or promote
- *		   products  derived from  this  software without specific
- *		   prior written permission.
+ *          3. Neither the  name of the copyright holder nor the names
+ *             of  its  contributors may be used to endorse or promote
+ *             products  derived from  this  software without specific
+ *             prior written permission.
  *
  * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
  * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT

--- a/src/include/86box/isartc.h
+++ b/src/include/86box/isartc.h
@@ -1,36 +1,36 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Definitions for the ISARTC cards.
+ *          Definitions for the ISARTC cards.
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
  *
- *		Copyright 2018 Fred N. van Kempen.
+ *          Copyright 2018 Fred N. van Kempen.
  *
- *		Redistribution and  use  in source  and binary forms, with
- *		or  without modification, are permitted  provided that the
- *		following conditions are met:
+ *          Redistribution and  use  in source  and binary forms, with
+ *          or  without modification, are permitted  provided that the
+ *          following conditions are met:
  *
- *		1. Redistributions of  source  code must retain the entire
- *		   above notice, this list of conditions and the following
- *		   disclaimer.
+ *          1. Redistributions of  source  code must retain the entire
+ *             above notice, this list of conditions and the following
+ *             disclaimer.
  *
- *		2. Redistributions in binary form must reproduce the above
- *		   copyright  notice,  this list  of  conditions  and  the
- *		   following disclaimer in  the documentation and/or other
- *		   materials provided with the distribution.
+ *          2. Redistributions in binary form must reproduce the above
+ *             copyright  notice,  this list  of  conditions  and  the
+ *             following disclaimer in  the documentation and/or other
+ *             materials provided with the distribution.
  *
- *		3. Neither the  name of the copyright holder nor the names
- *		   of  its  contributors may be used to endorse or promote
- *		   products  derived from  this  software without specific
- *		   prior written permission.
+ *          3. Neither the  name of the copyright holder nor the names
+ *             of  its  contributors may be used to endorse or promote
+ *             products  derived from  this  software without specific
+ *             prior written permission.
  *
  * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
  * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT

--- a/src/include/86box/isartc.h
+++ b/src/include/86box/isartc.h
@@ -1,10 +1,8 @@
 /*
- * 86Box    A hypervisor and IBM PC system emulator that specializes in
- *          running old operating systems and software designed for IBM
- *          PC systems and compatibles from 1981 through fairly recent
- *          system designs based on the PCI bus.
- *
- *          This file is part of the 86Box distribution.
+ * VARCem   Virtual ARchaeological Computer EMulator.
+ *          An emulator of (mostly) x86-based PC systems and devices,
+ *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *          spanning the era between 1981 and 1995.
  *
  *          Definitions for the ISARTC cards.
  *

--- a/src/include/86box/joystick_standard.h
+++ b/src/include/86box/joystick_standard.h
@@ -1,20 +1,20 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Definitions for the joystick driver.
+ *          Definitions for the joystick driver.
  *
  *
  *
- * Authors:	Miran Grca, <mgrca8@gmail.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Miran Grca, <mgrca8@gmail.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2016-2018 Miran Grca.
- *		Copyright 2008-2018 Sarah Walker.
+ *          Copyright 2016-2018 Miran Grca.
+ *          Copyright 2008-2018 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/include/86box/joystick_sw_pad.h
+++ b/src/include/86box/joystick_sw_pad.h
@@ -1,20 +1,20 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Definitions for the Sidewinder Pro driver.
+ *        Definitions for the Sidewinder Pro driver.
  *
  *
  *
- * Authors:	Miran Grca, <mgrca8@gmail.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Miran Grca, <mgrca8@gmail.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2016-2018 Miran Grca.
- *		Copyright 2008-2018 Sarah Walker.
+ *          Copyright 2016-2018 Miran Grca.
+ *          Copyright 2008-2018 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/include/86box/joystick_tm_fcs.h
+++ b/src/include/86box/joystick_tm_fcs.h
@@ -1,20 +1,20 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Definitions for the Flight Control System driver.
+ *        Definitions for the Flight Control System driver.
  *
  *
  *
- * Authors:	Miran Grca, <mgrca8@gmail.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Miran Grca, <mgrca8@gmail.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2016-2018 Miran Grca.
- *		Copyright 2008-2018 Sarah Walker.
+ *          Copyright 2016-2018 Miran Grca.
+ *          Copyright 2008-2018 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/include/86box/keyboard.h
+++ b/src/include/86box/keyboard.h
@@ -1,22 +1,22 @@
 /*
- * 86Box	A hypervisor and IBM PC system emulator that specializes in
- *		running old operating systems and software designed for IBM
- *		PC systems and compatibles from 1981 through fairly recent
- *		system designs based on the PCI bus.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the 86Box distribution.
+ *          This file is part of the 86Box distribution.
  *
- *		Definitions for the keyboard interface.
+ *          Definitions for the keyboard interface.
  *
  *
  *
- * Authors:	Sarah Walker, <http://pcem-emulator.co.uk/>
- *		Miran Grca, <mgrca8@gmail.com>
- *		Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors: Sarah Walker, <http://pcem-emulator.co.uk/>
+ *          Miran Grca, <mgrca8@gmail.com>
+ *          Fred N. van Kempen, <decwiz@yahoo.com>
  *
- *		Copyright 2008-2019 Sarah Walker.
- *		Copyright 2016-2019 Miran Grca.
- *		Copyright 2017-2019 Fred N. van Kempen.
+ *          Copyright 2008-2019 Sarah Walker.
+ *          Copyright 2016-2019 Miran Grca.
+ *          Copyright 2017-2019 Fred N. van Kempen.
  */
 
 #ifndef EMU_KEYBOARD_H

--- a/src/include/86box/m_at_t3100e.h
+++ b/src/include/86box/m_at_t3100e.h
@@ -1,22 +1,22 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Definitions for the Toshiba T3100e system.
+ *          Definitions for the Toshiba T3100e system.
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
- *		Miran Grca, <mgrca8@gmail.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
+ *          Miran Grca, <mgrca8@gmail.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2017,2018 Fred N. van Kempen.
- *		Copyright 2016-2018 Miran Grca.
- *		Copyright 2008-2018 Sarah Walker.
+ *          Copyright 2017,2018 Fred N. van Kempen.
+ *          Copyright 2016-2018 Miran Grca.
+ *          Copyright 2008-2018 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/include/86box/m_xt_t1000.h
+++ b/src/include/86box/m_xt_t1000.h
@@ -1,22 +1,22 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Definitions for the Toshiba T1000/T1200 machines.
+ *          Definitions for the Toshiba T1000/T1200 machines.
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
- *		Miran Grca, <mgrca8@gmail.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
+ *          Miran Grca, <mgrca8@gmail.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2017,2018 Fred N. van Kempen.
- *		Copyright 2016-2018 Miran Grca.
- *		Copyright 2008-2018 Sarah Walker.
+ *          Copyright 2017,2018 Fred N. van Kempen.
+ *          Copyright 2016-2018 Miran Grca.
+ *          Copyright 2008-2018 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/include/86box/net_ne2000.h
+++ b/src/include/86box/net_ne2000.h
@@ -1,18 +1,18 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Definitions for the NE2000 ethernet controller.
+ *          Definitions for the NE2000 ethernet controller.
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
  *
- *		Copyright 2017,2018 Fred N. van Kempen.
+ *          Copyright 2017,2018 Fred N. van Kempen.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/include/86box/network.h
+++ b/src/include/86box/network.h
@@ -1,36 +1,36 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Definitions for the network module.
+ *          Definitions for the network module.
  *
  *
  *
- * Author:	Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
  *
- *		Copyright 2017-2019 Fred N. van Kempen.
+ *          Copyright 2017-2019 Fred N. van Kempen.
  *
- *		Redistribution and  use  in source  and binary forms, with
- *		or  without modification, are permitted  provided that the
- *		following conditions are met:
+ *          Redistribution and  use  in source  and binary forms, with
+ *          or  without modification, are permitted  provided that the
+ *          following conditions are met:
  *
- *		1. Redistributions of  source  code must retain the entire
- *		   above notice, this list of conditions and the following
- *		   disclaimer.
+ *          1. Redistributions of  source  code must retain the entire
+ *             above notice, this list of conditions and the following
+ *             disclaimer.
  *
- *		2. Redistributions in binary form must reproduce the above
- *		   copyright  notice,  this list  of  conditions  and  the
- *		   following disclaimer in  the documentation and/or other
- *		   materials provided with the distribution.
+ *          2. Redistributions in binary form must reproduce the above
+ *             copyright  notice,  this list  of  conditions  and  the
+ *             following disclaimer in  the documentation and/or other
+ *             materials provided with the distribution.
  *
- *		3. Neither the  name of the copyright holder nor the names
- *		   of  its  contributors may be used to endorse or promote
- *		   products  derived from  this  software without specific
- *		   prior written permission.
+ *          3. Neither the  name of the copyright holder nor the names
+ *             of  its  contributors may be used to endorse or promote
+ *             products  derived from  this  software without specific
+ *             prior written permission.
  *
  * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
  * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT

--- a/src/include/86box/network.h
+++ b/src/include/86box/network.h
@@ -1,10 +1,8 @@
 /*
- * 86Box    A hypervisor and IBM PC system emulator that specializes in
- *          running old operating systems and software designed for IBM
- *          PC systems and compatibles from 1981 through fairly recent
- *          system designs based on the PCI bus.
- *
- *          This file is part of the 86Box distribution.
+ * VARCem   Virtual ARchaeological Computer EMulator.
+ *          An emulator of (mostly) x86-based PC systems and devices,
+ *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *          spanning the era between 1981 and 1995.
  *
  *          Definitions for the network module.
  *

--- a/src/include/86box/nvr.h
+++ b/src/include/86box/nvr.h
@@ -1,10 +1,8 @@
 /*
- * 86Box    A hypervisor and IBM PC system emulator that specializes in
- *          running old operating systems and software designed for IBM
- *          PC systems and compatibles from 1981 through fairly recent
- *          system designs based on the PCI bus.
- *
- *          This file is part of the 86Box distribution.
+ * VARCem   Virtual ARchaeological Computer EMulator.
+ *          An emulator of (mostly) x86-based PC systems and devices,
+ *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *          spanning the era between 1981 and 1995.
  *
  *          Definitions for the generic NVRAM/CMOS driver.
  *

--- a/src/include/86box/nvr.h
+++ b/src/include/86box/nvr.h
@@ -1,38 +1,38 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Definitions for the generic NVRAM/CMOS driver.
+ *          Definitions for the generic NVRAM/CMOS driver.
  *
  *
  *
- * Author:	Fred N. van Kempen, <decwiz@yahoo.com>,
- * 		David Hrdlička, <hrdlickadavid@outlook.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>,
+ *          David Hrdlička, <hrdlickadavid@outlook.com>
  *
- *		Copyright 2017-2020 Fred N. van Kempen.
- *		Copyright 2018-2020 David Hrdlička.
+ *          Copyright 2017-2020 Fred N. van Kempen.
+ *          Copyright 2018-2020 David Hrdlička.
  *
- *		Redistribution and  use  in source  and binary forms, with
- *		or  without modification, are permitted  provided that the
- *		following conditions are met:
+ *          Redistribution and  use  in source  and binary forms, with
+ *          or  without modification, are permitted  provided that the
+ *          following conditions are met:
  *
- *		1. Redistributions of  source  code must retain the entire
- *		   above notice, this list of conditions and the following
- *		   disclaimer.
+ *          1. Redistributions of  source  code must retain the entire
+ *             above notice, this list of conditions and the following
+ *             disclaimer.
  *
- *		2. Redistributions in binary form must reproduce the above
- *		   copyright  notice,  this list  of  conditions  and  the
- *		   following disclaimer in  the documentation and/or other
- *		   materials provided with the distribution.
+ *          2. Redistributions in binary form must reproduce the above
+ *             copyright  notice,  this list  of  conditions  and  the
+ *             following disclaimer in  the documentation and/or other
+ *             materials provided with the distribution.
  *
- *		3. Neither the  name of the copyright holder nor the names
- *		   of  its  contributors may be used to endorse or promote
- *		   products  derived from  this  software without specific
- *		   prior written permission.
+ *          3. Neither the  name of the copyright holder nor the names
+ *             of  its  contributors may be used to endorse or promote
+ *             products  derived from  this  software without specific
+ *             prior written permission.
  *
  * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
  * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT

--- a/src/include/86box/nvr_ps2.h
+++ b/src/include/86box/nvr_ps2.h
@@ -1,20 +1,20 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Definitions for the PS/2 cmos/nvr device.
+ *          Definitions for the PS/2 cmos/nvr device.
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2017,2018 Fred N. van Kempen.
- *		Copyright 2008-2018 Sarah Walker.
+ *          Copyright 2017,2018 Fred N. van Kempen.
+ *          Copyright 2008-2018 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/include/86box/png_struct.h
+++ b/src/include/86box/png_struct.h
@@ -1,36 +1,36 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Definitions for the centralized PNG image handler.
+ *          Definitions for the centralized PNG image handler.
  *
  *
  *
- * Author:	Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
  *
- *		Copyright 2018 Fred N. van Kempen.
+ *          Copyright 2018 Fred N. van Kempen.
  *
- *		Redistribution and  use  in source  and binary forms, with
- *		or  without modification, are permitted  provided that the
- *		following conditions are met:
+ *          Redistribution and  use  in source  and binary forms, with
+ *          or  without modification, are permitted  provided that the
+ *          following conditions are met:
  *
- *		1. Redistributions of  source  code must retain the entire
- *		   above notice, this list of conditions and the following
- *		   disclaimer.
+ *          1. Redistributions of  source  code must retain the entire
+ *             above notice, this list of conditions and the following
+ *             disclaimer.
  *
- *		2. Redistributions in binary form must reproduce the above
- *		   copyright  notice,  this list  of  conditions  and  the
- *		   following disclaimer in  the documentation and/or other
- *		   materials provided with the distribution.
+ *          2. Redistributions in binary form must reproduce the above
+ *             copyright  notice,  this list  of  conditions  and  the
+ *             following disclaimer in  the documentation and/or other
+ *             materials provided with the distribution.
  *
- *		3. Neither the  name of the copyright holder nor the names
- *		   of  its  contributors may be used to endorse or promote
- *		   products  derived from  this  software without specific
- *		   prior written permission.
+ *          3. Neither the  name of the copyright holder nor the names
+ *             of  its  contributors may be used to endorse or promote
+ *             products  derived from  this  software without specific
+ *             prior written permission.
  *
  * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
  * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT

--- a/src/include/86box/png_struct.h
+++ b/src/include/86box/png_struct.h
@@ -1,10 +1,8 @@
 /*
- * 86Box    A hypervisor and IBM PC system emulator that specializes in
- *          running old operating systems and software designed for IBM
- *          PC systems and compatibles from 1981 through fairly recent
- *          system designs based on the PCI bus.
- *
- *          This file is part of the 86Box distribution.
+ * VARCem   Virtual ARchaeological Computer EMulator.
+ *          An emulator of (mostly) x86-based PC systems and devices,
+ *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *          spanning the era between 1981 and 1995.
  *
  *          Definitions for the centralized PNG image handler.
  *

--- a/src/include/86box/printer.h
+++ b/src/include/86box/printer.h
@@ -1,36 +1,36 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Definitions for the printers module.
+ *          Definitions for the printers module.
  *
  *
  *
- * Author:	Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
  *
- *		Copyright 2018 Fred N. van Kempen.
+ *          Copyright 2018 Fred N. van Kempen.
  *
- *		Redistribution and  use  in source  and binary forms, with
- *		or  without modification, are permitted  provided that the
- *		following conditions are met:
+ *          Redistribution and  use  in source  and binary forms, with
+ *          or  without modification, are permitted  provided that the
+ *          following conditions are met:
  *
- *		1. Redistributions of  source  code must retain the entire
- *		   above notice, this list of conditions and the following
- *		   disclaimer.
+ *          1. Redistributions of  source  code must retain the entire
+ *             above notice, this list of conditions and the following
+ *             disclaimer.
  *
- *		2. Redistributions in binary form must reproduce the above
- *		   copyright  notice,  this list  of  conditions  and  the
- *		   following disclaimer in  the documentation and/or other
- *		   materials provided with the distribution.
+ *          2. Redistributions in binary form must reproduce the above
+ *             copyright  notice,  this list  of  conditions  and  the
+ *             following disclaimer in  the documentation and/or other
+ *             materials provided with the distribution.
  *
- *		3. Neither the  name of the copyright holder nor the names
- *		   of  its  contributors may be used to endorse or promote
- *		   products  derived from  this  software without specific
- *		   prior written permission.
+ *          3. Neither the  name of the copyright holder nor the names
+ *             of  its  contributors may be used to endorse or promote
+ *             products  derived from  this  software without specific
+ *             prior written permission.
  *
  * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
  * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT

--- a/src/include/86box/printer.h
+++ b/src/include/86box/printer.h
@@ -1,10 +1,8 @@
 /*
- * 86Box    A hypervisor and IBM PC system emulator that specializes in
- *          running old operating systems and software designed for IBM
- *          PC systems and compatibles from 1981 through fairly recent
- *          system designs based on the PCI bus.
- *
- *          This file is part of the 86Box distribution.
+ * VARCem   Virtual ARchaeological Computer EMulator.
+ *          An emulator of (mostly) x86-based PC systems and devices,
+ *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *          spanning the era between 1981 and 1995.
  *
  *          Definitions for the printers module.
  *

--- a/src/include/86box/video.h
+++ b/src/include/86box/video.h
@@ -1,22 +1,22 @@
 /*
  * 86Box	A hypervisor and IBM PC system emulator that specializes in
- *		running old operating systems and software designed for IBM
- *		PC systems and compatibles from 1981 through fairly recent
- *		system designs based on the PCI bus.
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the 86Box distribution.
+ *          This file is part of the 86Box distribution.
  *
- *		Definitions for the video controller module.
+ *          Definitions for the video controller module.
  *
  *
  *
- * Authors:	Sarah Walker, <http://pcem-emulator.co.uk/>
- *		Miran Grca, <mgrca8@gmail.com>
- *		Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors: Sarah Walker, <http://pcem-emulator.co.uk/>
+ *          Miran Grca, <mgrca8@gmail.com>
+ *          Fred N. van Kempen, <decwiz@yahoo.com>
  *
- *		Copyright 2008-2019 Sarah Walker.
- *		Copyright 2016-2019 Miran Grca.
- *		Copyright 2017-2019 Fred N. van Kempen.
+ *          Copyright 2008-2019 Sarah Walker.
+ *          Copyright 2016-2019 Miran Grca.
+ *          Copyright 2017-2019 Fred N. van Kempen.
  */
 
 #ifndef EMU_VIDEO_H

--- a/src/machine/m_at.c
+++ b/src/machine/m_at.c
@@ -1,22 +1,22 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Standard PC/AT implementation.
+ *          Standard PC/AT implementation.
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
- *		Miran Grca, <mgrca8@gmail.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
+ *          Miran Grca, <mgrca8@gmail.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2017-2020 Fred N. van Kempen.
- *		Copyright 2016-2020 Miran Grca.
- *		Copyright 2008-2020 Sarah Walker.
+ *          Copyright 2017-2020 Fred N. van Kempen.
+ *          Copyright 2016-2020 Miran Grca.
+ *          Copyright 2008-2020 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/machine/m_at_commodore.c
+++ b/src/machine/m_at_commodore.c
@@ -1,22 +1,22 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implementation of the Commodore PC3 system.
+ *          Implementation of the Commodore PC3 system.
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
- *		Miran Grca, <mgrca8@gmail.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
+ *          Miran Grca, <mgrca8@gmail.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2017,2018 Fred N. van Kempen.
- *		Copyright 2016-2018 Miran Grca.
- *		Copyright 2008-2018 Sarah Walker.
+ *          Copyright 2017,2018 Fred N. van Kempen.
+ *          Copyright 2016-2018 Miran Grca.
+ *          Copyright 2008-2018 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/machine/m_at_t3100e.c
+++ b/src/machine/m_at_t3100e.c
@@ -1,131 +1,131 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implementation of the Toshiba T3100e.
+ *          Implementation of the Toshiba T3100e.
  *
- *		The Toshiba 3100e is a 286-based portable.
+ *          The Toshiba 3100e is a 286-based portable.
  *
- *		To bring up the BIOS setup screen hold down the 'Fn' key
- *		on booting.
+ *          To bring up the BIOS setup screen hold down the 'Fn' key
+ *          on booting.
  *
- *		Memory management
- *		~~~~~~~~~~~~~~~~~
+ *          Memory management
+ *          ~~~~~~~~~~~~~~~~~
  *
- *		Motherboard memory is divided into:
- *		- Conventional memory: Either 512k or 640k
- *		- Upper memory:        Either 512k or 384k, depending on
- *				       amount of conventional memory.
- *				       Upper memory can be used as EMS or XMS.
- *		- High memory:         0-4Mb, depending on RAM installed.
- *				       The BIOS setup screen allows some or
- *				       all of this to be used as EMS; the
- *				       remainder is XMS.
+ *          Motherboard memory is divided into:
+ *          - Conventional memory: Either 512k or 640k
+ *          - Upper memory:        Either 512k or 384k, depending on
+ *                         amount of conventional memory.
+ *                         Upper memory can be used as EMS or XMS.
+ *          - High memory:         0-4Mb, depending on RAM installed.
+ *                         The BIOS setup screen allows some or
+ *                         all of this to be used as EMS; the
+ *                         remainder is XMS.
  *
- *		Additional memory (either EMS or XMS) can also be provided
- *		by ISA expansion cards.
+ *          Additional memory (either EMS or XMS) can also be provided
+ *          by ISA expansion cards.
  *
- *		Under test in PCem, the BIOS will boot with up to 65368Kb
- *		of memory in total (16Mb less 16k). However it will give
- *		an error with RAM sizes above 8Mb, if any of the high
- *		memory is allocated as EMS, because the builtin EMS page
- *		registers can only access up to 8Mb.
+ *          Under test in PCem, the BIOS will boot with up to 65368Kb
+ *          of memory in total (16Mb less 16k). However it will give
+ *          an error with RAM sizes above 8Mb, if any of the high
+ *          memory is allocated as EMS, because the builtin EMS page
+ *          registers can only access up to 8Mb.
  *
- *		Memory is controlled by writes to I/O port 8084h:
- *		  Bit 7: Always 0  }
- *		  Bit 6: Always 1  } These bits select which motherboard
- *		  Bit 5: Always 0  } function to access.
- *		  Bit 4: Set to treat upper RAM as XMS
- *		  Bit 3: Enable external RAM boards?
- *		  Bit 2: Set for 640k conventional memory, clear for 512k
- *		  Bit 1: Enable RAM beyond 1Mb.
- *		  Bit 0: Enable EMS.
+ *          Memory is controlled by writes to I/O port 8084h:
+ *            Bit 7: Always 0  }
+ *            Bit 6: Always 1  } These bits select which motherboard
+ *            Bit 5: Always 0  } function to access.
+ *            Bit 4: Set to treat upper RAM as XMS
+ *            Bit 3: Enable external RAM boards?
+ *            Bit 2: Set for 640k conventional memory, clear for 512k
+ *            Bit 1: Enable RAM beyond 1Mb.
+ *            Bit 0: Enable EMS.
  *
- *		The last value written to this port is saved at 0040:0093h,
- *		and in CMOS memory at offset 0x37. If the top bit of the
- *		CMOS byte is set, then high memory is being provided by
- *		an add-on card rather than the mainboard; accordingly,
- *		the BIOS will not allow high memory to be used as EMS.
+ *          The last value written to this port is saved at 0040:0093h,
+ *          and in CMOS memory at offset 0x37. If the top bit of the
+ *          CMOS byte is set, then high memory is being provided by
+ *          an add-on card rather than the mainboard; accordingly,
+ *          the BIOS will not allow high memory to be used as EMS.
  *
- *		EMS is controlled by 16 page registers:
+ *          EMS is controlled by 16 page registers:
  *
- *		Page mapped at		0xD000	0xD400	0xD800	0xDC00
- *		------------------------------------------------------
- *		Pages 0x00-0x7F		 0x208	0x4208	0x8208	0xc208
- *		Pages 0x80-0xFF		 0x218	0x4218	0x8218	0xc218
- *		Pages 0x100-0x17F	 0x258	0x4258	0x8258	0xc258
- *		Pages 0x180-0x1FF	 0x268	0x4268	0x8268	0xc268
+ *          Page mapped at        0xD000    0xD400    0xD800    0xDC00
+ *          ------------------------------------------------------
+ *          Pages 0x00-0x7F         0x208    0x4208    0x8208    0xc208
+ *          Pages 0x80-0xFF         0x218    0x4218    0x8218    0xc218
+ *          Pages 0x100-0x17F     0x258    0x4258    0x8258    0xc258
+ *          Pages 0x180-0x1FF     0x268    0x4268    0x8268    0xc268
  *
- *		The value written has bit 7 set to enable EMS, reset to
- *		disable it.
+ *          The value written has bit 7 set to enable EMS, reset to
+ *          disable it.
  *
- *		So:
- *		OUT 0x208,  0x80  will page in the first 16k page at 0xD0000.
- *		OUT 0x208,  0x00  will page out EMS, leaving nothing at 0xD0000.
- *		OUT 0x4208, 0x80  will page in the first 16k page at 0xD4000.
- *		OUT 0x218,  0x80  will page in the 129th 16k page at 0xD0000.
- *		etc.
+ *          So:
+ *          OUT 0x208,  0x80  will page in the first 16k page at 0xD0000.
+ *          OUT 0x208,  0x00  will page out EMS, leaving nothing at 0xD0000.
+ *          OUT 0x4208, 0x80  will page in the first 16k page at 0xD4000.
+ *          OUT 0x218,  0x80  will page in the 129th 16k page at 0xD0000.
+ *          etc.
  *
- *		To use EMS from DOS, you will need the Toshiba EMS driver
- *		(TOSHEMM.ZIP). This supports the above system, plus further
- *		ranges of ports at 0x_2A8, 0x_2B8, 0x_2C8.
+ *          To use EMS from DOS, you will need the Toshiba EMS driver
+ *          (TOSHEMM.ZIP). This supports the above system, plus further
+ *          ranges of ports at 0x_2A8, 0x_2B8, 0x_2C8.
  *
- *		Features not implemented:
- *		> Four video fonts.
- *		> BIOS-controlled mapping of serial ports to IRQs.
- *		> Custom keyboard controller. This has a number of extra
- *		  commands in the 0xB0-0xBC range, for such things as turbo
- *		  on/off, and switching the keyboard between AT and PS/2
- *		  modes. Currently I have only implemented command 0xBB,
- *		  so that self-test completes successfully. Commands include:
+ *          Features not implemented:
+ *          > Four video fonts.
+ *          > BIOS-controlled mapping of serial ports to IRQs.
+ *          > Custom keyboard controller. This has a number of extra
+ *            commands in the 0xB0-0xBC range, for such things as turbo
+ *            on/off, and switching the keyboard between AT and PS/2
+ *            modes. Currently I have only implemented command 0xBB,
+ *            so that self-test completes successfully. Commands include:
  *
- *		  0xB0:   Turbo on
- *		  0xB1:   Turbo off
- *		  0xB2:   Internal display on?
- *		  0xB3:   Internal display off?
- *		  0xB5:   Get settings byte (bottom bit is color/mono setting)
- *		  0xB6:   Set settings byte
- *		  0xB7:   Behave as 101-key PS/2 keyboard
- *		  0xB8:   Behave as 84-key AT keyboard
- *		  0xBB:   Return a byte, bit 2 is Fn key state, other bits unknown.
+ *            0xB0:   Turbo on
+ *            0xB1:   Turbo off
+ *            0xB2:   Internal display on?
+ *            0xB3:   Internal display off?
+ *            0xB5:   Get settings byte (bottom bit is color/mono setting)
+ *            0xB6:   Set settings byte
+ *            0xB7:   Behave as 101-key PS/2 keyboard
+ *            0xB8:   Behave as 84-key AT keyboard
+ *            0xBB:   Return a byte, bit 2 is Fn key state, other bits unknown.
  *
- *		The other main I/O port needed to POST is:
- *		  0x8084: System control.
- *		  Top 3 bits give command, bottom 5 bits give parameters.
- *		  000 => set serial port IRQ / addresses
- *		  bit 4:    IRQ5 serial port base: 1 => 0x338, 0 => 0x3E8
- *		  bits 3, 2, 0 specify serial IRQs for COM1, COM2, COM3:
- *			    00 0 => 4, 3, 5
+ *          The other main I/O port needed to POST is:
+ *            0x8084: System control.
+ *            Top 3 bits give command, bottom 5 bits give parameters.
+ *            000 => set serial port IRQ / addresses
+ *            bit 4:    IRQ5 serial port base: 1 => 0x338, 0 => 0x3E8
+ *            bits 3, 2, 0 specify serial IRQs for COM1, COM2, COM3:
+ *                          00 0 => 4, 3, 5
  *                          00 1 => 4, 5, 3
  *                          01 0 => 3, 4, 5
  *                          01 1 => 3, 5, 4
  *                          10 0 => 4, -, 3
  *                          10 1 => 3, -, 4
- *		  010 => set memory mappings
- *			 bit 4 set if upper RAM is XMS
- *			 bit 3 enable add-on memory boards beyond 5Mb?
- *                       bit 2 set for 640k sysram, clear for 512k sysram
- *                       bit 1 enable mainboard XMS
- *                       bit 0 enable mainboard EMS
- *		  100 => set parallel mode / LCD settings
- *                       bit 4 set for bidirectional parallel port
- *                       bit 3 set to disable internal CGA
- *                       bit 2 set for single-pixel LCD font
- *                       bits 0,1 for display font
+ *            010 => set memory mappings
+ *               bit 4 set if upper RAM is XMS
+ *               bit 3 enable add-on memory boards beyond 5Mb?
+ *                         bit 2 set for 640k sysram, clear for 512k sysram
+ *                         bit 1 enable mainboard XMS
+ *                         bit 0 enable mainboard EMS
+ *            100 => set parallel mode / LCD settings
+ *                         bit 4 set for bidirectional parallel port
+ *                         bit 3 set to disable internal CGA
+ *                         bit 2 set for single-pixel LCD font
+ *                         bits 0,1 for display font
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
- *		Miran Grca, <mgrca8@gmail.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
+ *          Miran Grca, <mgrca8@gmail.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2017,2018 Fred N. van Kempen.
- *		Copyright 2016-2018 Miran Grca.
- *		Copyright 2008-2018 Sarah Walker.
+ *          Copyright 2017,2018 Fred N. van Kempen.
+ *          Copyright 2016-2018 Miran Grca.
+ *          Copyright 2008-2018 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -486,7 +486,7 @@ t3100e_sys_in(uint16_t addr, void *p)
 void
 t3100e_sys_out(uint16_t addr, uint8_t val, void *p)
 {
-    //	struct t3100e_ems_regs *regs = (struct t3100e_ems_regs *)p;
+    //    struct t3100e_ems_regs *regs = (struct t3100e_ems_regs *)p;
 
     switch (val & 0xE0) {
         case 0x00: /* Set serial port IRQs. Not implemented */

--- a/src/machine/m_at_t3100e_vid.c
+++ b/src/machine/m_at_t3100e_vid.c
@@ -1,36 +1,36 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implementation of the Toshiba 3100e plasma display.
- *		This display has a fixed 640x400 resolution.
+ *          Implementation of the Toshiba 3100e plasma display.
+ *          This display has a fixed 640x400 resolution.
  *
- *		T3100e CRTC regs (from the ROM):
+ *          T3100e CRTC regs (from the ROM):
  *
- *		Selecting a character height of 3 seems to be sufficient to
- *		convert the 640x200 graphics mode to 640x400 (and, by
- *		analogy, 320x200 to 320x400).
+ *          Selecting a character height of 3 seems to be sufficient to
+ *          convert the 640x200 graphics mode to 640x400 (and, by
+ *          analogy, 320x200 to 320x400).
  *
- *		Horiz-----> Vert------>  I ch
- *		38 28 2D 0A 1F 06 19 1C 02 07 06 07   CO40
- *		71 50 5A 0A 1F 06 19 1C 02 07 06 07   CO80
- *		38 28 2D 0A 7F 06 64 70 02 01 06 07   Graphics
- *		61 50 52 0F 19 06 19 19 02 0D 0B 0C   MONO
- *		2D 28 22 0A 67 00 64 67 02 03 06 07   640x400
+ *          Horiz-----> Vert------>  I ch
+ *          38 28 2D 0A 1F 06 19 1C 02 07 06 07   CO40
+ *          71 50 5A 0A 1F 06 19 1C 02 07 06 07   CO80
+ *          38 28 2D 0A 7F 06 64 70 02 01 06 07   Graphics
+ *          61 50 52 0F 19 06 19 19 02 0D 0B 0C   MONO
+ *          2D 28 22 0A 67 00 64 67 02 03 06 07   640x400
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
- *		Miran Grca, <mgrca8@gmail.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
+ *          Miran Grca, <mgrca8@gmail.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2017-2019 Fred N. van Kempen.
- *		Copyright 2016-2019 Miran Grca.
- *		Copyright 2008-2019 Sarah Walker.
+ *          Copyright 2017-2019 Fred N. van Kempen.
+ *          Copyright 2016-2019 Miran Grca.
+ *          Copyright 2008-2019 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -561,9 +561,9 @@ t3100e_recalcattrs(t3100e_t *t3100e)
      *     Bit 0: Attributes 01-06, 08-0E are inverse video
      *     Bit 1: Attributes 01-06, 08-0E are bold
      *     Bit 2: Attributes 11-16, 18-1F, 21-26, 28-2F ... F1-F6, F8-FF
-     * 	      are inverse video
+     *           are inverse video
      *     Bit 3: Attributes 11-16, 18-1F, 21-26, 28-2F ... F1-F6, F8-FF
-     * 	      are bold */
+     *           are bold */
 
     /* Set up colours */
     amber = makecol(0xf7, 0x7C, 0x34);

--- a/src/machine/m_ps1_hdc.c
+++ b/src/machine/m_ps1_hdc.c
@@ -1,10 +1,8 @@
 /*
- * 86Box    A hypervisor and IBM PC system emulator that specializes in
- *          running old operating systems and software designed for IBM
- *          PC systems and compatibles from 1981 through fairly recent
- *          system designs based on the PCI bus.
- *
- *          This file is part of the 86Box distribution.
+ * VARCem   Virtual ARchaeological Computer EMulator.
+ *          An emulator of (mostly) x86-based PC systems and devices,
+ *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *          spanning the era between 1981 and 1995.
  *
  *          Implementation of the PS/1 Model 2011 disk controller.
  *

--- a/src/machine/m_ps1_hdc.c
+++ b/src/machine/m_ps1_hdc.c
@@ -1,74 +1,74 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implementation of the PS/1 Model 2011 disk controller.
+ *          Implementation of the PS/1 Model 2011 disk controller.
  *
- *		XTA is the acronym for 'XT-Attached', which was basically
- *		the XT-counterpart to what we know now as IDE (which is
- *		also named ATA - AT Attachment.)  The basic ideas was to
- *		put the actual drive controller electronics onto the drive
- *		itself, and have the host machine just talk to that using
- *		a simpe, standardized I/O path- hence the name IDE, for
- *		Integrated Drive Electronics.
+ *          XTA is the acronym for 'XT-Attached', which was basically
+ *          the XT-counterpart to what we know now as IDE (which is
+ *          also named ATA - AT Attachment.)  The basic ideas was to
+ *          put the actual drive controller electronics onto the drive
+ *          itself, and have the host machine just talk to that using
+ *          a simpe, standardized I/O path- hence the name IDE, for
+ *          Integrated Drive Electronics.
  *
- *		In the ATA version of IDE, the programming interface of
- *		the IBM PC/AT (which used the Western Digitial 1002/1003
- *		controllers) was kept, and, so, ATA-IDE assumes a 16bit
- *		data path: it reads and writes 16bit words of data. The
- *		disk drives for this bus commonly have an 'A' suffix to
- *		identify them as 'ATBUS'.
+ *          In the ATA version of IDE, the programming interface of
+ *          the IBM PC/AT (which used the Western Digitial 1002/1003
+ *          controllers) was kept, and, so, ATA-IDE assumes a 16bit
+ *          data path: it reads and writes 16bit words of data. The
+ *          disk drives for this bus commonly have an 'A' suffix to
+ *          identify them as 'ATBUS'.
  *
- *		In XTA-IDE, which is slightly older, the programming
- *		interface of the IBM PC/XT (which used the MFM controller
- *		from Xebec) was kept, and, so, it uses an 8bit data path.
- *		Disk drives for this bus commonly have the 'X' suffix to
- *		mark them as being for this XTBUS variant.
+ *          In XTA-IDE, which is slightly older, the programming
+ *          interface of the IBM PC/XT (which used the MFM controller
+ *          from Xebec) was kept, and, so, it uses an 8bit data path.
+ *          Disk drives for this bus commonly have the 'X' suffix to
+ *          mark them as being for this XTBUS variant.
  *
- *		So, XTA and ATA try to do the same thing, but they use
- *		different ways to achive their goal.
+ *          So, XTA and ATA try to do the same thing, but they use
+ *          different ways to achive their goal.
  *
- *		Also, XTA is **not** the same as XTIDE.  XTIDE is a modern
- *		variant of ATA-IDE, but retro-fitted for use on 8bit XT
- *		systems: an extra register is used to deal with the extra
- *		data byte per transfer.  XTIDE uses regular IDE drives,
- *		and uses the regular ATA/IDE programming interface, just
- *		with the extra register.
+ *          Also, XTA is **not** the same as XTIDE.  XTIDE is a modern
+ *          variant of ATA-IDE, but retro-fitted for use on 8bit XT
+ *          systems: an extra register is used to deal with the extra
+ *          data byte per transfer.  XTIDE uses regular IDE drives,
+ *          and uses the regular ATA/IDE programming interface, just
+ *          with the extra register.
  *
- * NOTE:	We should probably find a nicer way to integrate our Disk
- *		Type table with the main code, so the user can only select
- *		items from that list...
+ * NOTE:    We should probably find a nicer way to integrate our Disk
+ *          Type table with the main code, so the user can only select
+ *          items from that list...
  *
  *
  *
- * Author:	Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
  *
- *		Based on my earlier HD20 driver for the EuroPC.
- *		Thanks to Marco Bortolin for the help and feedback !!
+ *          Based on my earlier HD20 driver for the EuroPC.
+ *          Thanks to Marco Bortolin for the help and feedback !!
  *
- *		Copyright 2017-2019 Fred N. van Kempen.
+ *          Copyright 2017-2019 Fred N. van Kempen.
  *
- *		Redistribution and  use  in source  and binary forms, with
- *		or  without modification, are permitted  provided that the
- *		following conditions are met:
+ *          Redistribution and  use  in source  and binary forms, with
+ *          or  without modification, are permitted  provided that the
+ *          following conditions are met:
  *
- *		1. Redistributions of  source  code must retain the entire
- *		   above notice, this list of conditions and the following
- *		   disclaimer.
+ *          1. Redistributions of  source  code must retain the entire
+ *             above notice, this list of conditions and the following
+ *             disclaimer.
  *
- *		2. Redistributions in binary form must reproduce the above
- *		   copyright  notice,  this list  of  conditions  and  the
- *		   following disclaimer in  the documentation and/or other
- *		   materials provided with the distribution.
+ *          2. Redistributions in binary form must reproduce the above
+ *             copyright  notice,  this list  of  conditions  and  the
+ *             following disclaimer in  the documentation and/or other
+ *             materials provided with the distribution.
  *
- *		3. Neither the  name of the copyright holder nor the names
- *		   of  its  contributors may be used to endorse or promote
- *		   products  derived from  this  software without specific
- *		   prior written permission.
+ *          3. Neither the  name of the copyright holder nor the names
+ *             of  its  contributors may be used to endorse or promote
+ *             products  derived from  this  software without specific
+ *             prior written permission.
  *
  * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
  * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT
@@ -165,56 +165,56 @@ enum {
 #pragma pack(push, 1)
 typedef struct {
     /* Status byte 0. */
-    uint8_t track_0  : 1, /* T0			*/
-        mbz1         : 1, /* 0			*/
-        mbz2         : 1, /* 0			*/
-        cylinder_err : 1, /* CE			*/
-        write_fault  : 1, /* WF			*/
-        mbz3         : 1, /* 0			*/
-        seek_end     : 1, /* SE			*/
-        not_ready    : 1; /* NR			*/
+    uint8_t track_0  : 1, /* T0            */
+        mbz1         : 1, /* 0            */
+        mbz2         : 1, /* 0            */
+        cylinder_err : 1, /* CE            */
+        write_fault  : 1, /* WF            */
+        mbz3         : 1, /* 0            */
+        seek_end     : 1, /* SE            */
+        not_ready    : 1; /* NR            */
 
     /* Status byte 1. */
-    uint8_t id_not_found : 1, /* ID			*/
-        mbz4             : 1, /* 0			*/
-        mbz5             : 1, /* 0			*/
-        wrong_cyl        : 1, /* WC			*/
-        all_bit_set      : 1, /* BT			*/
-        mark_not_found   : 1, /* AM			*/
-        ecc_crc_err      : 1, /* ET			*/
-        ecc_crc_field    : 1; /* EF			*/
+    uint8_t id_not_found : 1, /* ID            */
+        mbz4             : 1, /* 0            */
+        mbz5             : 1, /* 0            */
+        wrong_cyl        : 1, /* WC            */
+        all_bit_set      : 1, /* BT            */
+        mark_not_found   : 1, /* AM            */
+        ecc_crc_err      : 1, /* ET            */
+        ecc_crc_field    : 1; /* EF            */
 
     /* Status byte 2. */
-    uint8_t headsel_state : 4, /* headsel state[4]	*/
-        defective_sector  : 1, /* DS			*/
-        retried_ok        : 1, /* RG			*/
-        need_reset        : 1, /* RR			*/
+    uint8_t headsel_state : 4, /* headsel state[4]    */
+        defective_sector  : 1, /* DS            */
+        retried_ok        : 1, /* RG            */
+        need_reset        : 1, /* RR            */
 #if 1
-        valid : 1; /* 0 (abused as VALID)	*/
+        valid : 1; /* 0 (abused as VALID)    */
 #else
-        mbz6 : 1; /* 0			*/
+        mbz6 : 1; /* 0            */
 #endif
 
     /* Most recent ID field seen. */
-    uint8_t last_cyl_low;  /* Cyl_Low[8]		*/
-    uint8_t last_head : 4, /* HD[4]		*/
-        mbz7          : 1, /* 0			*/
-        last_cyl_high : 2, /* Cyl_high[2]		*/
-        last_def_sect : 1; /* DS			*/
-    uint8_t last_sect;     /* Sect[8]		*/
+    uint8_t last_cyl_low;  /* Cyl_Low[8]        */
+    uint8_t last_head : 4, /* HD[4]        */
+        mbz7          : 1, /* 0            */
+        last_cyl_high : 2, /* Cyl_high[2]        */
+        last_def_sect : 1; /* DS            */
+    uint8_t last_sect;     /* Sect[8]        */
 
-    uint8_t sect_size; /* Size[8] = 02		*/
+    uint8_t sect_size; /* Size[8] = 02        */
 
     /* Current position. */
-    uint8_t curr_cyl_high : 2, /* Cyl_High_[2]		*/
-        mbz8              : 1, /* 0			*/
-        mbz9              : 1, /* 0			*/
-        curr_head         : 4; /* HD_2[4]		*/
-    uint8_t curr_cyl_low;      /* Cyl_Low_2[8]		*/
+    uint8_t curr_cyl_high : 2, /* Cyl_High_[2]        */
+        mbz8              : 1, /* 0            */
+        mbz9              : 1, /* 0            */
+        curr_head         : 4; /* HD_2[4]        */
+    uint8_t curr_cyl_low;      /* Cyl_Low_2[8]        */
 
-    uint8_t sect_corr; /* sectors corrected	*/
+    uint8_t sect_corr; /* sectors corrected    */
 
-    uint8_t retries; /* retries		*/
+    uint8_t retries; /* retries        */
 
     /*
      * This byte shows the progress of the controller through the
@@ -235,7 +235,7 @@ typedef struct {
      *     transfer:
      *
      *     Bit 7    A sector was transferred between the system
-     *	            and the sector buffer.
+     *                and the sector buffer.
      *
      *     Bit 6    A sector was transferred between the controller
      *              and the sector buffer.
@@ -249,11 +249,11 @@ typedef struct {
      * 4.  When the transfer is complete, the low nibble equals hex 4
      *     and the high nibble is unchanged.
      */
-    uint8_t cmd_syndrome; /* command syndrome	*/
+    uint8_t cmd_syndrome; /* command syndrome    */
 
-    uint8_t drive_type; /* drive type		*/
+    uint8_t drive_type; /* drive type        */
 
-    uint8_t rsvd; /* reserved byte	*/
+    uint8_t rsvd; /* reserved byte    */
 } ssb_t;
 #pragma pack(pop)
 
@@ -293,20 +293,20 @@ typedef struct {
  */
 #pragma pack(push, 1)
 typedef struct {
-    uint8_t cyl_high     : 2, /* cylinder [9:8] bits	*/
-        defective_sector : 1, /* DS			*/
-        mbz1             : 1, /* 0			*/
-        head             : 4; /* head number		*/
+    uint8_t cyl_high     : 2, /* cylinder [9:8] bits    */
+        defective_sector : 1, /* DS            */
+        mbz1             : 1, /* 0            */
+        head             : 4; /* head number        */
 
-    uint8_t cyl_low; /* cylinder [7:0] bits	*/
+    uint8_t cyl_low; /* cylinder [7:0] bits    */
 
-    uint8_t sector; /* sector number	*/
+    uint8_t sector; /* sector number    */
 
-    uint8_t mbz2 : 1, /* 0			*/
-        mbo      : 1, /* 1			*/
-        mbz3     : 6; /* 000000		*/
+    uint8_t mbz2 : 1, /* 0            */
+        mbo      : 1, /* 1            */
+        mbz3     : 6; /* 000000        */
 
-    uint8_t fill; /* filler byte		*/
+    uint8_t fill; /* filler byte        */
 } fcb_t;
 #pragma pack(pop)
 
@@ -319,25 +319,25 @@ typedef struct {
  */
 #pragma pack(push, 1)
 typedef struct {
-    uint8_t ec_p     : 1, /* EC/P (ecc/park)	*/
-        mbz1         : 1, /* 0			*/
-        auto_seek    : 1, /* AS (auto-seek)	*/
-        no_data      : 1, /* ND (no data)		*/
-        cmd          : 4; /* command code[4]	*/
+    uint8_t ec_p     : 1, /* EC/P (ecc/park)    */
+        mbz1         : 1, /* 0            */
+        auto_seek    : 1, /* AS (auto-seek)    */
+        no_data      : 1, /* ND (no data)        */
+        cmd          : 4; /* command code[4]    */
 
-    uint8_t cyl_high : 2, /* cylinder [9:8] bits	*/
-        mbz2         : 2, /* 00			*/
-        head         : 4; /* head number		*/
+    uint8_t cyl_high : 2, /* cylinder [9:8] bits    */
+        mbz2         : 2, /* 00            */
+        head         : 4; /* head number        */
 
-    uint8_t cyl_low; /* cylinder [7:0] bits	*/
+    uint8_t cyl_low; /* cylinder [7:0] bits    */
 
-    uint8_t sector; /* sector number	*/
+    uint8_t sector; /* sector number    */
 
-    uint8_t mbz3 : 1, /* 0			*/
-        mbo1     : 1, /* 1			*/
-        mbz4     : 6; /* 000000		*/
+    uint8_t mbz3 : 1, /* 0            */
+        mbo1     : 1, /* 1            */
+        mbz4     : 6; /* 000000        */
 
-    uint8_t count; /* blk count/interleave	*/
+    uint8_t count; /* blk count/interleave    */
 } ccb_t;
 #pragma pack(pop)
 
@@ -417,51 +417,51 @@ typedef struct {
  */
 static const geom_t ibm_type_table[] = {
   // clang-format off
-    {    0,     0,       0,          0,      0	},	/*  0	(none)	*/
-    {  306,     4,      17,        128,    305	},	/*  1	10 MB	*/
-    {  615,     4,      17,        300,    615	},	/*  2	20 MB	*/
-    {  615,     6,      17,        300,    615	},	/*  3	31 MB	*/
-    {  940,     8,      17,        512,    940	},	/*  4	62 MB	*/
-    {  940,     6,      17,        512,    940	},	/*  5	47 MB	*/
-    {  615,     4,      17,         -1,    615	},	/*  6	20 MB	*/
-    {  462,     8,      17,        256,    511	},	/*  7	31 MB	*/
-    {  733,     5,      17,         -1,    733	},	/*  8	30 MB	*/
-    {  900,    15,      17,         -1,    901	},	/*  9	112 MB	*/
-    {  820,     3,      17,         -1,    820	},	/* 10	20 MB	*/
-    {  855,     5,      17,         -1,    855	},	/* 11	35 MB	*/
-    {  855,     7,      17,         -1,    855	},	/* 12	50 MB	*/
-    {  306,     8,      17,        128,    319	},	/* 13	20 MB	*/
-    {  733,     7,      17,         -1,    733	},	/* 14	43 MB	*/
-    {    0,     0,       0,          0,      0	},	/* 15	(rsvd)	*/
-    {  612,     4,      17,          0,    663	},	/* 16	20 MB	*/
-    {  977,     5,      17,        300,    977	},	/* 17	41 MB	*/
-    {  977,     7,      17,         -1,    977	},	/* 18	57 MB	*/
-    { 1024,     7,      17,        512,   1023	},	/* 19	59 MB	*/
-    {  733,     5,      17,        300,    732	},	/* 20	30 MB	*/
-    {  733,     7,      17,        300,    732	},	/* 21	43 MB	*/
-    {  733,     5,      17,        300,    733	},	/* 22	30 MB	*/
-    {  306,     4,      17,          0,    336	},	/* 23	10 MB	*/
-    {  612,     4,      17,        305,    663	},	/* 24	20 MB	*/
-    {  306,     4,      17,         -1,    340	},	/* 25	10 MB	*/
-    {  612,     4,      17,         -1,    670	},	/* 26	20 MB	*/
-    {  698,     7,      17,        300,    732	},	/* 27	41 MB	*/
-    {  976,     5,      17,        488,    977	},	/* 28	40 MB	*/
-    {  306,     4,      17,          0,    340	},	/* 29	10 MB	*/
-    {  611,     4,      17,        306,    663	},	/* 30	20 MB	*/
-    {  732,     7,      17,        300,    732	},	/* 31	43 MB	*/
-    { 1023,     5,      17,         -1,   1023	},	/* 32	42 MB	*/
-    {  614,     4,      25,         -1,    663	},	/* 33	30 MB	*/
-    {  775,     2,      27,         -1,    900	},	/* 34	20 MB	*/
-    {  921,     2,      33,         -1,   1000	},	/* 35	30 MB *	*/
-    {  402,     4,      26,         -1,    460	},	/* 36	20 MB	*/
-    {  580,     6,      26,         -1,    640	},	/* 37	44 MB	*/
-    {  845,     2,      36,         -1,   1023	},	/* 38	30 MB *	*/
-    {  769,     3,      36,         -1,   1023	},	/* 39	41 MB *	*/
-    {  531,     4,      39,         -1,    532	},	/* 40	40 MB	*/
-    {  577,     2,      36,         -1,   1023	},	/* 41	20 MB	*/
-    {  654,     2,      32,         -1,    674	},	/* 42	20 MB	*/
-    {  923,     5,      36,         -1,   1023	},	/* 43	81 MB	*/
-    {  531,     8,      39,         -1,    532	}	/* 44	81 MB	*/
+    {    0,     0,       0,          0,      0    },    /*  0    (none)    */
+    {  306,     4,      17,        128,    305    },    /*  1    10 MB    */
+    {  615,     4,      17,        300,    615    },    /*  2    20 MB    */
+    {  615,     6,      17,        300,    615    },    /*  3    31 MB    */
+    {  940,     8,      17,        512,    940    },    /*  4    62 MB    */
+    {  940,     6,      17,        512,    940    },    /*  5    47 MB    */
+    {  615,     4,      17,         -1,    615    },    /*  6    20 MB    */
+    {  462,     8,      17,        256,    511    },    /*  7    31 MB    */
+    {  733,     5,      17,         -1,    733    },    /*  8    30 MB    */
+    {  900,    15,      17,         -1,    901    },    /*  9    112 MB    */
+    {  820,     3,      17,         -1,    820    },    /* 10    20 MB    */
+    {  855,     5,      17,         -1,    855    },    /* 11    35 MB    */
+    {  855,     7,      17,         -1,    855    },    /* 12    50 MB    */
+    {  306,     8,      17,        128,    319    },    /* 13    20 MB    */
+    {  733,     7,      17,         -1,    733    },    /* 14    43 MB    */
+    {    0,     0,       0,          0,      0    },    /* 15    (rsvd)    */
+    {  612,     4,      17,          0,    663    },    /* 16    20 MB    */
+    {  977,     5,      17,        300,    977    },    /* 17    41 MB    */
+    {  977,     7,      17,         -1,    977    },    /* 18    57 MB    */
+    { 1024,     7,      17,        512,   1023    },    /* 19    59 MB    */
+    {  733,     5,      17,        300,    732    },    /* 20    30 MB    */
+    {  733,     7,      17,        300,    732    },    /* 21    43 MB    */
+    {  733,     5,      17,        300,    733    },    /* 22    30 MB    */
+    {  306,     4,      17,          0,    336    },    /* 23    10 MB    */
+    {  612,     4,      17,        305,    663    },    /* 24    20 MB    */
+    {  306,     4,      17,         -1,    340    },    /* 25    10 MB    */
+    {  612,     4,      17,         -1,    670    },    /* 26    20 MB    */
+    {  698,     7,      17,        300,    732    },    /* 27    41 MB    */
+    {  976,     5,      17,        488,    977    },    /* 28    40 MB    */
+    {  306,     4,      17,          0,    340    },    /* 29    10 MB    */
+    {  611,     4,      17,        306,    663    },    /* 30    20 MB    */
+    {  732,     7,      17,        300,    732    },    /* 31    43 MB    */
+    { 1023,     5,      17,         -1,   1023    },    /* 32    42 MB    */
+    {  614,     4,      25,         -1,    663    },    /* 33    30 MB    */
+    {  775,     2,      27,         -1,    900    },    /* 34    20 MB    */
+    {  921,     2,      33,         -1,   1000    },    /* 35    30 MB *    */
+    {  402,     4,      26,         -1,    460    },    /* 36    20 MB    */
+    {  580,     6,      26,         -1,    640    },    /* 37    44 MB    */
+    {  845,     2,      36,         -1,   1023    },    /* 38    30 MB *    */
+    {  769,     3,      36,         -1,   1023    },    /* 39    41 MB *    */
+    {  531,     4,      39,         -1,    532    },    /* 40    40 MB    */
+    {  577,     2,      36,         -1,   1023    },    /* 41    20 MB    */
+    {  654,     2,      32,         -1,    674    },    /* 42    20 MB    */
+    {  923,     5,      36,         -1,   1023    },    /* 43    81 MB    */
+    {  531,     8,      39,         -1,    532    }    /* 44    81 MB    */
   // clang-format on
 };
 
@@ -663,7 +663,7 @@ do_format(hdc_t *dev, drive_t *drive, ccb_t *ccb)
 
                 /* Point to the FCB we got. */
 #if 0
-		fcb = (fcb_t *)dev->data;
+        fcb = (fcb_t *)dev->data;
 #endif
             dev->state = STATE_FINIT;
             /*FALLTHROUGH*/
@@ -693,7 +693,7 @@ do_fmt:
              * use it's "filler byte" value...
              */
 #if 0
-		hdd_image_zero_ex(drive->hdd_num, addr, fcb->fill, drive->spt);
+        hdd_image_zero_ex(drive->hdd_num, addr, fcb->fill, drive->spt);
 #else
             hdd_image_zero(drive->hdd_num, addr, drive->spt);
 #endif

--- a/src/machine/m_ps2_mca.c
+++ b/src/machine/m_ps2_mca.c
@@ -1,22 +1,22 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implementation of MCA-based PS/2 machines.
+ *          Implementation of MCA-based PS/2 machines.
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
- *		Miran Grca, <mgrca8@gmail.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
+ *          Miran Grca, <mgrca8@gmail.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2017-2019 Fred N. van Kempen.
- *		Copyright 2016-2019 Miran Grca.
- *		Copyright 2008-2019 Sarah Walker.
+ *          Copyright 2017-2019 Fred N. van Kempen.
+ *          Copyright 2016-2019 Miran Grca.
+ *          Copyright 2008-2019 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/machine/m_xt_t1000.c
+++ b/src/machine/m_xt_t1000.c
@@ -1,65 +1,65 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implementation of the Toshiba T1000 and T1200 portables.
+ *          Implementation of the Toshiba T1000 and T1200 portables.
  *
- *		The T1000 is the T3100e's little brother -- a real laptop
- *		with a rechargeable battery.
+ *          The T1000 is the T3100e's little brother -- a real laptop
+ *          with a rechargeable battery.
  *
- *		Features: 80C88 at 4.77MHz
- *		- 512k system RAM
- *		- 640x200 monochrome LCD
- *		- 82-key keyboard
- *		- Real-time clock. Not the normal 146818, but a TC8521,
- *		   which is a 4-bit chip.
- *		- A ROM drive (128k, 256k or 512k) which acts as a mini
- *		  hard drive and contains a copy of DOS 2.11.
- *		- 160 bytes of non-volatile RAM for the CONFIG.SYS used
- *		  when booting from the ROM drive. Possibly physically
- *		  located in the keyboard controller RAM.
+ *          Features: 80C88 at 4.77MHz
+ *          - 512k system RAM
+ *          - 640x200 monochrome LCD
+ *          - 82-key keyboard
+ *          - Real-time clock. Not the normal 146818, but a TC8521,
+ *             which is a 4-bit chip.
+ *          - A ROM drive (128k, 256k or 512k) which acts as a mini
+ *            hard drive and contains a copy of DOS 2.11.
+ *          - 160 bytes of non-volatile RAM for the CONFIG.SYS used
+ *            when booting from the ROM drive. Possibly physically
+ *            located in the keyboard controller RAM.
  *
- *		An optional memory expansion board can be fitted. This adds
- *		768k of RAM, which can be used for up to three purposes:
- *		> Conventional memory -- 128k between 512k and 640k
- *		> HardRAM -- a battery-backed RAM drive.
- *		> EMS
+ *          An optional memory expansion board can be fitted. This adds
+ *          768k of RAM, which can be used for up to three purposes:
+ *          > Conventional memory -- 128k between 512k and 640k
+ *          > HardRAM -- a battery-backed RAM drive.
+ *          > EMS
  *
- *		This means that there are up to three different
- *		implementations of non-volatile RAM in the same computer
- *		(52 nibbles in the TC8521, 160 bytes of CONFIG.SYS, and
- *		up to 768k of HardRAM).
+ *          This means that there are up to three different
+ *          implementations of non-volatile RAM in the same computer
+ *          (52 nibbles in the TC8521, 160 bytes of CONFIG.SYS, and
+ *          up to 768k of HardRAM).
  *
- *		The T1200 is a slightly upgraded version with a turbo mode
- *		(double CPU clock, 9.54MHz) and an optional hard drive.
- *		The interface for this is proprietary both at the physical
- *		and programming level.
+ *          The T1200 is a slightly upgraded version with a turbo mode
+ *          (double CPU clock, 9.54MHz) and an optional hard drive.
+ *          The interface for this is proprietary both at the physical
+ *          and programming level.
  *
- *		01F2h: If hard drive is present, low 4 bits are 0Ch [20Mb]
- *			or 0Dh [10Mb].
+ *          01F2h: If hard drive is present, low 4 bits are 0Ch [20Mb]
+ *          or 0Dh [10Mb].
  *
- *		The hard drive is a 20MB (615/2/26) RLL 3.5" drive.
+ *          The hard drive is a 20MB (615/2/26) RLL 3.5" drive.
  *
- *		The TC8521 is a 4-bit RTC, so each memory location can only
- *		hold a single BCD digit. Hence everything has 'ones' and
- *		'tens' digits.
+ *          The TC8521 is a 4-bit RTC, so each memory location can only
+ *          hold a single BCD digit. Hence everything has 'ones' and
+ *          'tens' digits.
  *
- * NOTE:	Still need to figure out a way to load/save ConfigSys and
- *		HardRAM stuff. Needs to be linked in to the NVR code.
+ * NOTE:    Still need to figure out a way to load/save ConfigSys and
+ *          HardRAM stuff. Needs to be linked in to the NVR code.
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
- *		Miran Grca, <mgrca8@gmail.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
+ *          Miran Grca, <mgrca8@gmail.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2018,2019 Fred N. van Kempen.
- *		Copyright 2018,2019 Miran Grca.
- *		Copyright 2018,2019 Sarah Walker.
+ *          Copyright 2018,2019 Fred N. van Kempen.
+ *          Copyright 2018,2019 Miran Grca.
+ *          Copyright 2018,2019 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/machine/m_xt_t1000_vid.c
+++ b/src/machine/m_xt_t1000_vid.c
@@ -1,23 +1,23 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implementation of the Toshiba T1000 plasma display, which
- *		has a fixed resolution of 640x200 pixels.
+ *          Implementation of the Toshiba T1000 plasma display, which
+ *          has a fixed resolution of 640x200 pixels.
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
- *		Miran Grca, <mgrca8@gmail.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
+ *          Miran Grca, <mgrca8@gmail.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2018,2019 Fred N. van Kempen.
- *		Copyright 2018,2019 Miran Grca.
- *		Copyright 2018,2019 Sarah Walker.
+ *          Copyright 2018,2019 Fred N. van Kempen.
+ *          Copyright 2018,2019 Miran Grca.
+ *          Copyright 2018,2019 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -546,9 +546,9 @@ t1000_recalcattrs(t1000_t *t1000)
      *     Bit 0: Attributes 01-06, 08-0E are inverse video
      *     Bit 1: Attributes 01-06, 08-0E are bold
      *     Bit 2: Attributes 11-16, 18-1F, 21-26, 28-2F ... F1-F6, F8-FF
-     * 	      are inverse video
+     *           are inverse video
      *     Bit 3: Attributes 11-16, 18-1F, 21-26, 28-2F ... F1-F6, F8-FF
-     * 	      are bold */
+     *           are bold */
 
     /* Set up colours */
     if (t1000->invert) {

--- a/src/network/net_ne2000.c
+++ b/src/network/net_ne2000.c
@@ -1,30 +1,30 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implementation of the following network controllers:
- *			- Novell NE1000 (ISA 8-bit);
- *			- Novell NE2000 (ISA 16-bit);
- *			- Novell NE/2 compatible (NetWorth Inc. Ethernext/MC) (MCA 16-bit);
- *			- Realtek RTL8019AS (ISA 16-bit, PnP);
- *			- Realtek RTL8029AS (PCI).
+ *          Implementation of the following network controllers:
+ *              - Novell NE1000 (ISA 8-bit);
+ *              - Novell NE2000 (ISA 16-bit);
+ *              - Novell NE/2 compatible (NetWorth Inc. Ethernext/MC) (MCA 16-bit);
+ *              - Realtek RTL8019AS (ISA 16-bit, PnP);
+ *              - Realtek RTL8029AS (PCI).
  *
  *
  *
- * Based on	@(#)ne2k.cc v1.56.2.1 2004/02/02 22:37:22 cbothamy
+ * Based on    @(#)ne2k.cc v1.56.2.1 2004/02/02 22:37:22 cbothamy
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
- *		TheCollector1995, <mariogplayer@gmail.com>
- *		Miran Grca, <mgrca8@gmail.com>
- *		Peter Grehan, <grehan@iprg.nokia.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
+ *          TheCollector1995, <mariogplayer@gmail.com>
+ *          Miran Grca, <mgrca8@gmail.com>
+ *          Peter Grehan, <grehan@iprg.nokia.com>
  *
- *		Copyright 2017,2018 Fred N. van Kempen.
- *		Copyright 2016-2018 Miran Grca.
- *		Portions Copyright (C) 2002  MandrakeSoft S.A.
+ *          Copyright 2017,2018 Fred N. van Kempen.
+ *          Copyright 2016-2018 Miran Grca.
+ *          Portions Copyright (C) 2002  MandrakeSoft S.A.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/network/net_pcap.c
+++ b/src/network/net_pcap.c
@@ -1,36 +1,36 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Handle WinPcap library processing.
+ *          Handle WinPcap library processing.
  *
  *
  *
- * Author:	Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
  *
- *		Copyright 2017-2019 Fred N. van Kempen.
+ *          Copyright 2017-2019 Fred N. van Kempen.
  *
- *		Redistribution and  use  in source  and binary forms, with
- *		or  without modification, are permitted  provided that the
- *		following conditions are met:
+ *          Redistribution and  use  in source  and binary forms, with
+ *          or  without modification, are permitted  provided that the
+ *          following conditions are met:
  *
- *		1. Redistributions of  source  code must retain the entire
- *		   above notice, this list of conditions and the following
- *		   disclaimer.
+ *          1. Redistributions of  source  code must retain the entire
+ *             above notice, this list of conditions and the following
+ *             disclaimer.
  *
- *		2. Redistributions in binary form must reproduce the above
- *		   copyright  notice,  this list  of  conditions  and  the
- *		   following disclaimer in  the documentation and/or other
- *		   materials provided with the distribution.
+ *          2. Redistributions in binary form must reproduce the above
+ *             copyright  notice,  this list  of  conditions  and  the
+ *             following disclaimer in  the documentation and/or other
+ *             materials provided with the distribution.
  *
- *		3. Neither the  name of the copyright holder nor the names
- *		   of  its  contributors may be used to endorse or promote
- *		   products  derived from  this  software without specific
- *		   prior written permission.
+ *          3. Neither the  name of the copyright holder nor the names
+ *             of  its  contributors may be used to endorse or promote
+ *             products  derived from  this  software without specific
+ *             prior written permission.
  *
  * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
  * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT

--- a/src/network/net_pcap.c
+++ b/src/network/net_pcap.c
@@ -1,10 +1,8 @@
 /*
- * 86Box    A hypervisor and IBM PC system emulator that specializes in
- *          running old operating systems and software designed for IBM
- *          PC systems and compatibles from 1981 through fairly recent
- *          system designs based on the PCI bus.
- *
- *          This file is part of the 86Box distribution.
+ * VARCem   Virtual ARchaeological Computer EMulator.
+ *          An emulator of (mostly) x86-based PC systems and devices,
+ *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *          spanning the era between 1981 and 1995.
  *
  *          Handle WinPcap library processing.
  *

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -1,10 +1,8 @@
 /*
- * 86Box    A hypervisor and IBM PC system emulator that specializes in
- *          running old operating systems and software designed for IBM
- *          PC systems and compatibles from 1981 through fairly recent
- *          system designs based on the PCI bus.
- *
- *          This file is part of the 86Box distribution.
+ * VARCem   Virtual ARchaeological Computer EMulator.
+ *          An emulator of (mostly) x86-based PC systems and devices,
+ *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *          spanning the era between 1981 and 1995.
  *
  *          Implementation of the network module.
  *

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -1,40 +1,40 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implementation of the network module.
+ *          Implementation of the network module.
  *
- * NOTE		The definition of the netcard_t is currently not optimal;
- *		it should be malloc'ed and then linked to the NETCARD def.
- *		Will be done later.
+ * NOTE     The definition of the netcard_t is currently not optimal;
+ *          it should be malloc'ed and then linked to the NETCARD def.
+ *          Will be done later.
  *
  *
  *
- * Author:	Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
  *
- *		Copyright 2017-2019 Fred N. van Kempen.
+ *          Copyright 2017-2019 Fred N. van Kempen.
  *
- *		Redistribution and  use  in source  and binary forms, with
- *		or  without modification, are permitted  provided that the
- *		following conditions are met:
+ *          Redistribution and  use  in source  and binary forms, with
+ *          or  without modification, are permitted  provided that the
+ *          following conditions are met:
  *
- *		1. Redistributions of  source  code must retain the entire
- *		   above notice, this list of conditions and the following
- *		   disclaimer.
+ *          1. Redistributions of  source  code must retain the entire
+ *             above notice, this list of conditions and the following
+ *             disclaimer.
  *
- *		2. Redistributions in binary form must reproduce the above
- *		   copyright  notice,  this list  of  conditions  and  the
- *		   following disclaimer in  the documentation and/or other
- *		   materials provided with the distribution.
+ *          2. Redistributions in binary form must reproduce the above
+ *             copyright  notice,  this list  of  conditions  and  the
+ *             following disclaimer in  the documentation and/or other
+ *             materials provided with the distribution.
  *
- *		3. Neither the  name of the copyright holder nor the names
- *		   of  its  contributors may be used to endorse or promote
- *		   products  derived from  this  software without specific
- *		   prior written permission.
+ *          3. Neither the  name of the copyright holder nor the names
+ *             of  its  contributors may be used to endorse or promote
+ *             products  derived from  this  software without specific
+ *             prior written permission.
  *
  * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
  * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT

--- a/src/network/pcap_if.c
+++ b/src/network/pcap_if.c
@@ -1,10 +1,8 @@
 /*
- * 86Box    A hypervisor and IBM PC system emulator that specializes in
- *          running old operating systems and software designed for IBM
- *          PC systems and compatibles from 1981 through fairly recent
- *          system designs based on the PCI bus.
- *
- *          This file is part of the 86Box distribution.
+ * VARCem   Virtual ARchaeological Computer EMulator.
+ *          An emulator of (mostly) x86-based PC systems and devices,
+ *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *          spanning the era between 1981 and 1995.
  *
  *          Simple program to show usage of (Win)Pcap.
  *

--- a/src/network/pcap_if.c
+++ b/src/network/pcap_if.c
@@ -1,38 +1,38 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Simple program to show usage of (Win)Pcap.
+ *          Simple program to show usage of (Win)Pcap.
  *
- *		Based on the "libpcap" examples.
+ *          Based on the "libpcap" examples.
  *
  *
  *
- * Author:	Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
  *
- *		Copyright 2017,2018 Fred N. van Kempen.
+ *          Copyright 2017,2018 Fred N. van Kempen.
  *
- *		Redistribution and  use  in source  and binary forms, with
- *		or  without modification, are permitted  provided that the
- *		following conditions are met:
+ *          Redistribution and  use  in source  and binary forms, with
+ *          or  without modification, are permitted  provided that the
+ *          following conditions are met:
  *
- *		1. Redistributions of  source  code must retain the entire
- *		   above notice, this list of conditions and the following
- *		   disclaimer.
+ *          1. Redistributions of  source  code must retain the entire
+ *             above notice, this list of conditions and the following
+ *             disclaimer.
  *
- *		2. Redistributions in binary form must reproduce the above
- *		   copyright  notice,  this list  of  conditions  and  the
- *		   following disclaimer in  the documentation and/or other
- *		   materials provided with the distribution.
+ *          2. Redistributions in binary form must reproduce the above
+ *             copyright  notice,  this list  of  conditions  and  the
+ *             following disclaimer in  the documentation and/or other
+ *             materials provided with the distribution.
  *
- *		3. Neither the  name of the copyright holder nor the names
- *		   of  its  contributors may be used to endorse or promote
- *		   products  derived from  this  software without specific
- *		   prior written permission.
+ *          3. Neither the  name of the copyright holder nor the names
+ *             of  its  contributors may be used to endorse or promote
+ *             products  derived from  this  software without specific
+ *             prior written permission.
  *
  * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
  * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT

--- a/src/nvr.c
+++ b/src/nvr.c
@@ -1,38 +1,38 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implement a generic NVRAM/CMOS/RTC device.
+ *          Implement a generic NVRAM/CMOS/RTC device.
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>,
- * 		David Hrdlička, <hrdlickadavid@outlook.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>,
+ *          David Hrdlička, <hrdlickadavid@outlook.com>
  *
- *		Copyright 2017-2019 Fred N. van Kempen.
- *		Copyright 2018,2019 David Hrdlička.
+ *          Copyright 2017-2019 Fred N. van Kempen.
+ *          Copyright 2018,2019 David Hrdlička.
  *
- *		Redistribution and  use  in source  and binary forms, with
- *		or  without modification, are permitted  provided that the
- *		following conditions are met:
+ *          Redistribution and  use  in source  and binary forms, with
+ *          or  without modification, are permitted  provided that the
+ *          following conditions are met:
  *
- *		1. Redistributions of  source  code must retain the entire
- *		   above notice, this list of conditions and the following
- *		   disclaimer.
+ *          1. Redistributions of  source  code must retain the entire
+ *             above notice, this list of conditions and the following
+ *             disclaimer.
  *
- *		2. Redistributions in binary form must reproduce the above
- *		   copyright  notice,  this list  of  conditions  and  the
- *		   following disclaimer in  the documentation and/or other
- *		   materials provided with the distribution.
+ *          2. Redistributions in binary form must reproduce the above
+ *             copyright  notice,  this list  of  conditions  and  the
+ *             following disclaimer in  the documentation and/or other
+ *             materials provided with the distribution.
  *
- *		3. Neither the  name of the copyright holder nor the names
- *		   of  its  contributors may be used to endorse or promote
- *		   products  derived from  this  software without specific
- *		   prior written permission.
+ *          3. Neither the  name of the copyright holder nor the names
+ *             of  its  contributors may be used to endorse or promote
+ *             products  derived from  this  software without specific
+ *             prior written permission.
  *
  * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
  * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT

--- a/src/nvr.c
+++ b/src/nvr.c
@@ -1,10 +1,8 @@
 /*
- * 86Box    A hypervisor and IBM PC system emulator that specializes in
- *          running old operating systems and software designed for IBM
- *          PC systems and compatibles from 1981 through fairly recent
- *          system designs based on the PCI bus.
- *
- *          This file is part of the 86Box distribution.
+ * VARCem   Virtual ARchaeological Computer EMulator.
+ *          An emulator of (mostly) x86-based PC systems and devices,
+ *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *          spanning the era between 1981 and 1995.
  *
  *          Implement a generic NVRAM/CMOS/RTC device.
  *

--- a/src/nvr_at.c
+++ b/src/nvr_at.c
@@ -1,204 +1,204 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implement a more-or-less defacto-standard RTC/NVRAM.
+ *          Implement a more-or-less defacto-standard RTC/NVRAM.
  *
- *		When IBM released the PC/AT machine, it came standard with a
- *		battery-backed RTC chip to keep the time of day, something
- *		that was optional on standard PC's with a myriad variants
- *		being put on the market, often on cheap multi-I/O cards.
+ *          When IBM released the PC/AT machine, it came standard with a
+ *          battery-backed RTC chip to keep the time of day, something
+ *          that was optional on standard PC's with a myriad variants
+ *          being put on the market, often on cheap multi-I/O cards.
  *
- *		The PC/AT had an on-board DS12885-series chip ("the black
- *		block") which was an RTC/clock chip with onboard oscillator
- *		and a backup battery (hence the big size.) The chip also had
- *		a small amount of RAM bytes available to the user, which was
- *		used by IBM's ROM BIOS to store machine configuration data.
- *		Later versions and clones used the 12886 and/or 1288(C)7
- *		series, or the MC146818 series, all with an external battery.
- *		Many of those batteries would create corrosion issues later
- *		on in mainboard life...
+ *          The PC/AT had an on-board DS12885-series chip ("the black
+ *          block") which was an RTC/clock chip with onboard oscillator
+ *          and a backup battery (hence the big size.) The chip also had
+ *          a small amount of RAM bytes available to the user, which was
+ *          used by IBM's ROM BIOS to store machine configuration data.
+ *          Later versions and clones used the 12886 and/or 1288(C)7
+ *          series, or the MC146818 series, all with an external battery.
+ *          Many of those batteries would create corrosion issues later
+ *          on in mainboard life...
  *
- *		Since then, pretty much any PC has an implementation of that
- *		device, which became known as the "nvr" or "cmos".
+ *          Since then, pretty much any PC has an implementation of that
+ *          device, which became known as the "nvr" or "cmos".
  *
- * NOTES	Info extracted from the data sheets:
+ * NOTES    Info extracted from the data sheets:
  *
- *		* The century register at location 32h is a BCD register
- *		  designed to automatically load the BCD value 20 as the
- *		  year register changes from 99 to 00.  The MSB of this
- *		  register is not affected when the load of 20 occurs,
- *		  and remains at the value written by the user.
+ *          * The century register at location 32h is a BCD register
+ *            designed to automatically load the BCD value 20 as the
+ *            year register changes from 99 to 00.  The MSB of this
+ *            register is not affected when the load of 20 occurs,
+ *            and remains at the value written by the user.
  *
- *		* Rate Selector (RS3:RS0)
- *		  These four rate-selection bits select one of the 13
- *		  taps on the 15-stage divider or disable the divider
- *		  output.  The tap selected can be used to generate an
- *		  output square wave (SQW pin) and/or a periodic interrupt.
+ *          * Rate Selector (RS3:RS0)
+ *            These four rate-selection bits select one of the 13
+ *            taps on the 15-stage divider or disable the divider
+ *            output.  The tap selected can be used to generate an
+ *            output square wave (SQW pin) and/or a periodic interrupt.
  *
- *		  The user can do one of the following:
- *		   - enable the interrupt with the PIE bit;
- *		   - enable the SQW output pin with the SQWE bit;
- *		   - enable both at the same time and the same rate; or
- *		   - enable neither.
+ *            The user can do one of the following:
+ *             - enable the interrupt with the PIE bit;
+ *             - enable the SQW output pin with the SQWE bit;
+ *             - enable both at the same time and the same rate; or
+ *             - enable neither.
  *
- *		  Table 3 lists the periodic interrupt rates and the square
- *		  wave frequencies that can be chosen with the RS bits.
- *		  These four read/write bits are not affected by !RESET.
+ *            Table 3 lists the periodic interrupt rates and the square
+ *            wave frequencies that can be chosen with the RS bits.
+ *            These four read/write bits are not affected by !RESET.
  *
- *		* Oscillator (DV2:DV0)
- *		  These three bits are used to turn the oscillator on or
- *		  off and to reset the countdown chain.  A pattern of 010
- *		  is the only combination of bits that turn the oscillator
- *		  on and allow the RTC to keep time.  A pattern of 11x
- *		  enables the oscillator but holds the countdown chain in
- *		  reset.  The next update occurs at 500ms after a pattern
- *		  of 010 is written to DV0, DV1, and DV2.
+ *          * Oscillator (DV2:DV0)
+ *            These three bits are used to turn the oscillator on or
+ *            off and to reset the countdown chain.  A pattern of 010
+ *            is the only combination of bits that turn the oscillator
+ *            on and allow the RTC to keep time.  A pattern of 11x
+ *            enables the oscillator but holds the countdown chain in
+ *            reset.  The next update occurs at 500ms after a pattern
+ *            of 010 is written to DV0, DV1, and DV2.
  *
- *		* Update-In-Progress (UIP)
- *		  This bit is a status flag that can be monitored. When the
- *		  UIP bit is a 1, the update transfer occurs soon.  When
- *		  UIP is a 0, the update transfer does not occur for at
- *		  least 244us.  The time, calendar, and alarm information
- *		  in RAM is fully available for access when the UIP bit
- *		  is 0.  The UIP bit is read-only and is not affected by
- *		  !RESET.  Writing the SET bit in Register B to a 1
- *		  inhibits any update transfer and clears the UIP status bit.
+ *          * Update-In-Progress (UIP)
+ *            This bit is a status flag that can be monitored. When the
+ *            UIP bit is a 1, the update transfer occurs soon.  When
+ *            UIP is a 0, the update transfer does not occur for at
+ *            least 244us.  The time, calendar, and alarm information
+ *            in RAM is fully available for access when the UIP bit
+ *            is 0.  The UIP bit is read-only and is not affected by
+ *            !RESET.  Writing the SET bit in Register B to a 1
+ *            inhibits any update transfer and clears the UIP status bit.
  *
- *		* Daylight Saving Enable (DSE)
- *		  This bit is a read/write bit that enables two daylight
- *		  saving adjustments when DSE is set to 1.  On the first
- *		  Sunday in April (or the last Sunday in April in the
- *		  MC146818A), the time increments from 1:59:59 AM to
- *		  3:00:00 AM.  On the last Sunday in October when the time
- *		  first reaches 1:59:59 AM, it changes to 1:00:00 AM.
+ *          * Daylight Saving Enable (DSE)
+ *            This bit is a read/write bit that enables two daylight
+ *            saving adjustments when DSE is set to 1.  On the first
+ *            Sunday in April (or the last Sunday in April in the
+ *            MC146818A), the time increments from 1:59:59 AM to
+ *            3:00:00 AM.  On the last Sunday in October when the time
+ *            first reaches 1:59:59 AM, it changes to 1:00:00 AM.
  *
- *		  When DSE is enabled, the internal logic test for the
- *		  first/last Sunday condition at midnight.  If the DSE bit
- *		  is not set when the test occurs, the daylight saving
- *		  function does not operate correctly.  These adjustments
- *		  do not occur when the DSE bit is 0. This bit is not
- *		  affected by internal functions or !RESET.
+ *            When DSE is enabled, the internal logic test for the
+ *            first/last Sunday condition at midnight.  If the DSE bit
+ *            is not set when the test occurs, the daylight saving
+ *            function does not operate correctly.  These adjustments
+ *            do not occur when the DSE bit is 0. This bit is not
+ *            affected by internal functions or !RESET.
  *
- *		* 24/12
- *		  The 24/12 control bit establishes the format of the hours
- *		  byte. A 1 indicates the 24-hour mode and a 0 indicates
- *		  the 12-hour mode.  This bit is read/write and is not
- *		  affected by internal functions or !RESET.
+ *          * 24/12
+ *            The 24/12 control bit establishes the format of the hours
+ *            byte. A 1 indicates the 24-hour mode and a 0 indicates
+ *            the 12-hour mode.  This bit is read/write and is not
+ *            affected by internal functions or !RESET.
  *
- *		* Data Mode (DM)
- *		  This bit indicates whether time and calendar information
- *		  is in binary or BCD format.  The DM bit is set by the
- *		  program to the appropriate format and can be read as
- *		  required.  This bit is not modified by internal functions
- *		  or !RESET. A 1 in DM signifies binary data, while a 0 in
- *		  DM specifies BCD data.
+ *          * Data Mode (DM)
+ *            This bit indicates whether time and calendar information
+ *            is in binary or BCD format.  The DM bit is set by the
+ *            program to the appropriate format and can be read as
+ *            required.  This bit is not modified by internal functions
+ *            or !RESET. A 1 in DM signifies binary data, while a 0 in
+ *            DM specifies BCD data.
  *
- *		* Square-Wave Enable (SQWE)
- *		  When this bit is set to 1, a square-wave signal at the
- *		  frequency set by the rate-selection bits RS3-RS0 is driven
- *		  out on the SQW pin.  When the SQWE bit is set to 0, the
- *		  SQW pin is held low. SQWE is a read/write bit and is
- *		  cleared by !RESET.  SQWE is low if disabled, and is high
- *		  impedance when VCC is below VPF. SQWE is cleared to 0 on
- *		  !RESET.
+ *          * Square-Wave Enable (SQWE)
+ *            When this bit is set to 1, a square-wave signal at the
+ *            frequency set by the rate-selection bits RS3-RS0 is driven
+ *            out on the SQW pin.  When the SQWE bit is set to 0, the
+ *            SQW pin is held low. SQWE is a read/write bit and is
+ *            cleared by !RESET.  SQWE is low if disabled, and is high
+ *            impedance when VCC is below VPF. SQWE is cleared to 0 on
+ *            !RESET.
  *
- *		* Update-Ended Interrupt Enable (UIE)
- *		  This bit is a read/write bit that enables the update-end
- *		  flag (UF) bit in Register C to assert !IRQ.  The !RESET
- *		  pin going low or the SET bit going high clears the UIE bit.
- *		  The internal functions of the device do not affect the UIE
- *		  bit, but is cleared to 0 on !RESET.
+ *          * Update-Ended Interrupt Enable (UIE)
+ *            This bit is a read/write bit that enables the update-end
+ *            flag (UF) bit in Register C to assert !IRQ.  The !RESET
+ *            pin going low or the SET bit going high clears the UIE bit.
+ *            The internal functions of the device do not affect the UIE
+ *            bit, but is cleared to 0 on !RESET.
  *
- *		* Alarm Interrupt Enable (AIE)
- *		  This bit is a read/write bit that, when set to 1, permits
- *		  the alarm flag (AF) bit in Register C to assert !IRQ.  An
- *		  alarm interrupt occurs for each second that the three time
- *		  bytes equal the three alarm bytes, including a don't-care
- *		  alarm code of binary 11XXXXXX.  The AF bit does not
- *		  initiate the !IRQ signal when the AIE bit is set to 0.
- *		  The internal functions of the device do not affect the AIE
- *		  bit, but is cleared to 0 on !RESET.
+ *          * Alarm Interrupt Enable (AIE)
+ *            This bit is a read/write bit that, when set to 1, permits
+ *            the alarm flag (AF) bit in Register C to assert !IRQ.  An
+ *            alarm interrupt occurs for each second that the three time
+ *            bytes equal the three alarm bytes, including a don't-care
+ *            alarm code of binary 11XXXXXX.  The AF bit does not
+ *            initiate the !IRQ signal when the AIE bit is set to 0.
+ *            The internal functions of the device do not affect the AIE
+ *            bit, but is cleared to 0 on !RESET.
  *
- *		* Periodic Interrupt Enable (PIE)
- *		  The PIE bit is a read/write bit that allows the periodic
- *		  interrupt flag (PF) bit in Register C to drive the !IRQ pin
- *		  low.  When the PIE bit is set to 1, periodic interrupts are
- *		  generated by driving the !IRQ pin low at a rate specified
- *		  by the RS3-RS0 bits of Register A.  A 0 in the PIE bit
- *		  blocks the !IRQ output from being driven by a periodic
- *		  interrupt, but the PF bit is still set at the periodic
- *		  rate.  PIE is not modified b any internal device functions,
- *		  but is cleared to 0 on !RESET.
+ *          * Periodic Interrupt Enable (PIE)
+ *            The PIE bit is a read/write bit that allows the periodic
+ *            interrupt flag (PF) bit in Register C to drive the !IRQ pin
+ *            low.  When the PIE bit is set to 1, periodic interrupts are
+ *            generated by driving the !IRQ pin low at a rate specified
+ *            by the RS3-RS0 bits of Register A.  A 0 in the PIE bit
+ *            blocks the !IRQ output from being driven by a periodic
+ *            interrupt, but the PF bit is still set at the periodic
+ *            rate.  PIE is not modified b any internal device functions,
+ *            but is cleared to 0 on !RESET.
  *
- *		* SET
- *		  When the SET bit is 0, the update transfer functions
- *		  normally by advancing the counts once per second.  When
- *		  the SET bit is written to 1, any update transfer is
- *		  inhibited, and the program can initialize the time and
- *		  calendar bytes without an update occurring in the midst of
- *		  initializing. Read cycles can be executed in a similar
- *		  manner. SET is a read/write bit and is not affected by
- *		  !RESET or internal functions of the device.
+ *          * SET
+ *            When the SET bit is 0, the update transfer functions
+ *            normally by advancing the counts once per second.  When
+ *            the SET bit is written to 1, any update transfer is
+ *            inhibited, and the program can initialize the time and
+ *            calendar bytes without an update occurring in the midst of
+ *            initializing. Read cycles can be executed in a similar
+ *            manner. SET is a read/write bit and is not affected by
+ *            !RESET or internal functions of the device.
  *
- *		* Update-Ended Interrupt Flag (UF)
- *		  This bit is set after each update cycle. When the UIE
- *		  bit is set to 1, the 1 in UF causes the IRQF bit to be
- *		  a 1, which asserts the !IRQ pin.  This bit can be
- *		  cleared by reading Register C or with a !RESET.
+ *          * Update-Ended Interrupt Flag (UF)
+ *            This bit is set after each update cycle. When the UIE
+ *            bit is set to 1, the 1 in UF causes the IRQF bit to be
+ *            a 1, which asserts the !IRQ pin.  This bit can be
+ *            cleared by reading Register C or with a !RESET.
  *
- *		* Alarm Interrupt Flag (AF)
- *		  A 1 in the AF bit indicates that the current time has
- *		  matched the alarm time.  If the AIE bit is also 1, the
- *		  !IRQ pin goes low and a 1 appears in the IRQF bit. This
- *		  bit can be cleared by reading Register C or with a
- *		  !RESET.
+ *          * Alarm Interrupt Flag (AF)
+ *            A 1 in the AF bit indicates that the current time has
+ *            matched the alarm time.  If the AIE bit is also 1, the
+ *            !IRQ pin goes low and a 1 appears in the IRQF bit. This
+ *            bit can be cleared by reading Register C or with a
+ *            !RESET.
  *
- *		* Periodic Interrupt Flag (PF)
- *		  This bit is read-only and is set to 1 when an edge is
- *		  detected on the selected tap of the divider chain.  The
- *		  RS3 through RS0 bits establish the periodic rate. PF is
- *		  set to 1 independent of the state of the PIE bit.  When
- *		  both PF and PIE are 1s, the !IRQ signal is active and
- *		  sets the IRQF bit. This bit can be cleared by reading
- *		  Register C or with a !RESET.
+ *          * Periodic Interrupt Flag (PF)
+ *            This bit is read-only and is set to 1 when an edge is
+ *            detected on the selected tap of the divider chain.  The
+ *            RS3 through RS0 bits establish the periodic rate. PF is
+ *            set to 1 independent of the state of the PIE bit.  When
+ *            both PF and PIE are 1s, the !IRQ signal is active and
+ *            sets the IRQF bit. This bit can be cleared by reading
+ *            Register C or with a !RESET.
  *
- *		* Interrupt Request Flag (IRQF)
- *		  The interrupt request flag (IRQF) is set to a 1 when one
- *		  or more of the following are true:
- *		   - PF == PIE == 1
- *		   - AF == AIE == 1
- *		   - UF == UIE == 1
- *		  Any time the IRQF bit is a 1, the !IRQ pin is driven low.
- *		  All flag bits are cleared after Register C is read by the
- *		  program or when the !RESET pin is low.
+ *          * Interrupt Request Flag (IRQF)
+ *            The interrupt request flag (IRQF) is set to a 1 when one
+ *            or more of the following are true:
+ *             - PF == PIE == 1
+ *             - AF == AIE == 1
+ *             - UF == UIE == 1
+ *            Any time the IRQF bit is a 1, the !IRQ pin is driven low.
+ *            All flag bits are cleared after Register C is read by the
+ *            program or when the !RESET pin is low.
  *
- *		* Valid RAM and Time (VRT)
- *		  This bit indicates the condition of the battery connected
- *		  to the VBAT pin. This bit is not writeable and should
- *		  always be 1 when read.  If a 0 is ever present, an
- *		  exhausted internal lithium energy source is indicated and
- *		  both the contents of the RTC data and RAM data are
- *		  questionable.  This bit is unaffected by !RESET.
+ *          * Valid RAM and Time (VRT)
+ *            This bit indicates the condition of the battery connected
+ *            to the VBAT pin. This bit is not writeable and should
+ *            always be 1 when read.  If a 0 is ever present, an
+ *            exhausted internal lithium energy source is indicated and
+ *            both the contents of the RTC data and RAM data are
+ *            questionable.  This bit is unaffected by !RESET.
  *
- *		This file implements a generic version of the RTC/NVRAM chip,
- *		including the later update (DS12887A) which implemented a
- *		"century" register to be compatible with Y2K.
+ *          This file implements a generic version of the RTC/NVRAM chip,
+ *          including the later update (DS12887A) which implemented a
+ *          "century" register to be compatible with Y2K.
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
- *		Miran Grca, <mgrca8@gmail.com>
- *		Mahod,
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
+ *          Miran Grca, <mgrca8@gmail.com>
+ *          Mahod,
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2017-2020 Fred N. van Kempen.
- *		Copyright 2016-2020 Miran Grca.
- *		Copyright 2008-2020 Sarah Walker.
+ *          Copyright 2017-2020 Fred N. van Kempen.
+ *          Copyright 2016-2020 Miran Grca.
+ *          Copyright 2008-2020 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/nvr_ps2.c
+++ b/src/nvr_ps2.c
@@ -1,20 +1,20 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Handling of the PS/2 series CMOS devices.
+ *        Handling of the PS/2 series CMOS devices.
  *
  *
  *
- * Authors:	Fred N. van Kempen, <decwiz@yahoo.com>
- *		Sarah Walker, <tommowalker@tommowalker.co.uk>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
+ *          Sarah Walker, <tommowalker@tommowalker.co.uk>
  *
- *		Copyright 2017,2018 Fred N. van Kempen.
- *		Copyright 2008-2018 Sarah Walker.
+ *          Copyright 2017,2018 Fred N. van Kempen.
+ *          Copyright 2008-2018 Sarah Walker.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/printer/png.c
+++ b/src/printer/png.c
@@ -1,36 +1,36 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Provide centralized access to the PNG image handler.
+ *          Provide centralized access to the PNG image handler.
  *
  *
  *
- * Author:	Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
  *
- *		Copyright 2018 Fred N. van Kempen.
+ *          Copyright 2018 Fred N. van Kempen.
  *
- *		Redistribution and  use  in source  and binary forms, with
- *		or  without modification, are permitted  provided that the
- *		following conditions are met:
+ *          Redistribution and  use  in source  and binary forms, with
+ *          or  without modification, are permitted  provided that the
+ *          following conditions are met:
  *
- *		1. Redistributions of  source  code must retain the entire
- *		   above notice, this list of conditions and the following
- *		   disclaimer.
+ *          1. Redistributions of  source  code must retain the entire
+ *             above notice, this list of conditions and the following
+ *             disclaimer.
  *
- *		2. Redistributions in binary form must reproduce the above
- *		   copyright  notice,  this list  of  conditions  and  the
- *		   following disclaimer in  the documentation and/or other
- *		   materials provided with the distribution.
+ *          2. Redistributions in binary form must reproduce the above
+ *             copyright  notice,  this list  of  conditions  and  the
+ *             following disclaimer in  the documentation and/or other
+ *             materials provided with the distribution.
  *
- *		3. Neither the  name of the copyright holder nor the names
- *		   of  its  contributors may be used to endorse or promote
- *		   products  derived from  this  software without specific
- *		   prior written permission.
+ *          3. Neither the  name of the copyright holder nor the names
+ *             of  its  contributors may be used to endorse or promote
+ *             products  derived from  this  software without specific
+ *             prior written permission.
  *
  * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
  * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT

--- a/src/printer/png.c
+++ b/src/printer/png.c
@@ -1,10 +1,8 @@
 /*
- * 86Box    A hypervisor and IBM PC system emulator that specializes in
- *          running old operating systems and software designed for IBM
- *          PC systems and compatibles from 1981 through fairly recent
- *          system designs based on the PCI bus.
- *
- *          This file is part of the 86Box distribution.
+ * VARCem   Virtual ARchaeological Computer EMulator.
+ *          An emulator of (mostly) x86-based PC systems and devices,
+ *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *          spanning the era between 1981 and 1995.
  *
  *          Provide centralized access to the PNG image handler.
  *

--- a/src/printer/prt_cpmap.c
+++ b/src/printer/prt_cpmap.c
@@ -1,40 +1,40 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Various ASCII to Unicode maps, for the various codepages.
+ *          Various ASCII to Unicode maps, for the various codepages.
  *
  *
  *
- * Authors:	Michael Drüing, <michael@drueing.de>
- *		Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors: Michael Drüing, <michael@drueing.de>
+ *          Fred N. van Kempen, <decwiz@yahoo.com>
  *
- *		Based on code by Frederic Weymann (originally for DosBox.)
+ *          Based on code by Frederic Weymann (originally for DosBox.)
  *
- *		Copyright 2018 Michael Drüing.
- *		Copyright 2018 Fred N. van Kempen.
+ *          Copyright 2018 Michael Drüing.
+ *          Copyright 2018 Fred N. van Kempen.
  *
- *		Redistribution and  use  in source  and binary forms, with
- *		or  without modification, are permitted  provided that the
- *		following conditions are met:
+ *          Redistribution and  use  in source  and binary forms, with
+ *          or  without modification, are permitted  provided that the
+ *          following conditions are met:
  *
- *		1. Redistributions of  source  code must retain the entire
- *		   above notice, this list of conditions and the following
- *		   disclaimer.
+ *          1. Redistributions of  source  code must retain the entire
+ *             above notice, this list of conditions and the following
+ *             disclaimer.
  *
- *		2. Redistributions in binary form must reproduce the above
- *		   copyright  notice,  this list  of  conditions  and  the
- *		   following disclaimer in  the documentation and/or other
- *		   materials provided with the distribution.
+ *          2. Redistributions in binary form must reproduce the above
+ *             copyright  notice,  this list  of  conditions  and  the
+ *             following disclaimer in  the documentation and/or other
+ *             materials provided with the distribution.
  *
- *		3. Neither the  name of the copyright holder nor the names
- *		   of  its  contributors may be used to endorse or promote
- *		   products  derived from  this  software without specific
- *		   prior written permission.
+ *          3. Neither the  name of the copyright holder nor the names
+ *             of  its  contributors may be used to endorse or promote
+ *             products  derived from  this  software without specific
+ *             prior written permission.
  *
  * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
  * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT

--- a/src/printer/prt_cpmap.c
+++ b/src/printer/prt_cpmap.c
@@ -1,10 +1,8 @@
 /*
- * 86Box    A hypervisor and IBM PC system emulator that specializes in
- *          running old operating systems and software designed for IBM
- *          PC systems and compatibles from 1981 through fairly recent
- *          system designs based on the PCI bus.
- *
- *          This file is part of the 86Box distribution.
+ * VARCem   Virtual ARchaeological Computer EMulator.
+ *          An emulator of (mostly) x86-based PC systems and devices,
+ *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *          spanning the era between 1981 and 1995.
  *
  *          Various ASCII to Unicode maps, for the various codepages.
  *

--- a/src/printer/prt_escp.c
+++ b/src/printer/prt_escp.c
@@ -1,10 +1,8 @@
 /*
- * 86Box    A hypervisor and IBM PC system emulator that specializes in
- *          running old operating systems and software designed for IBM
- *          PC systems and compatibles from 1981 through fairly recent
- *          system designs based on the PCI bus.
- *
- *          This file is part of the 86Box distribution.
+ * VARCem   Virtual ARchaeological Computer EMulator.
+ *          An emulator of (mostly) x86-based PC systems and devices,
+ *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *          spanning the era between 1981 and 1995.
  *
  *          Implementation of the Generic ESC/P Dot-Matrix printer.
  *

--- a/src/printer/prt_escp.c
+++ b/src/printer/prt_escp.c
@@ -1,40 +1,40 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implementation of the Generic ESC/P Dot-Matrix printer.
+ *          Implementation of the Generic ESC/P Dot-Matrix printer.
  *
  *
  *
- * Authors:	Michael Drüing, <michael@drueing.de>
- *		Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors: Michael Drüing, <michael@drueing.de>
+ *          Fred N. van Kempen, <decwiz@yahoo.com>
  *
- *		Based on code by Frederic Weymann (originally for DosBox.)
+ *          Based on code by Frederic Weymann (originally for DosBox.)
  *
- *		Copyright 2018,2019 Michael Drüing.
- *		Copyright 2019,2019 Fred N. van Kempen.
+ *          Copyright 2018,2019 Michael Drüing.
+ *          Copyright 2019,2019 Fred N. van Kempen.
  *
- *		Redistribution and  use  in source  and binary forms, with
- *		or  without modification, are permitted  provided that the
- *		following conditions are met:
+ *          Redistribution and  use  in source  and binary forms, with
+ *          or  without modification, are permitted  provided that the
+ *          following conditions are met:
  *
- *		1. Redistributions of  source  code must retain the entire
- *		   above notice, this list of conditions and the following
- *		   disclaimer.
+ *          1. Redistributions of  source  code must retain the entire
+ *             above notice, this list of conditions and the following
+ *             disclaimer.
  *
- *		2. Redistributions in binary form must reproduce the above
- *		   copyright  notice,  this list  of  conditions  and  the
- *		   following disclaimer in  the documentation and/or other
- *		   materials provided with the distribution.
+ *          2. Redistributions in binary form must reproduce the above
+ *             copyright  notice,  this list  of  conditions  and  the
+ *             following disclaimer in  the documentation and/or other
+ *             materials provided with the distribution.
  *
- *		3. Neither the  name of the copyright holder nor the names
- *		   of  its  contributors may be used to endorse or promote
- *		   products  derived from  this  software without specific
- *		   prior written permission.
+ *          3. Neither the  name of the copyright holder nor the names
+ *             of  its  contributors may be used to endorse or promote
+ *             products  derived from  this  software without specific
+ *             prior written permission.
  *
  * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
  * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT
@@ -697,8 +697,8 @@ process_char(escp_t *dev, uint8_t ch)
             case 0x5e: // Enable printing of all character codes on next character
             case 0x67: // Select 10.5-point, 15-cpi (ESC g)
 
-            case 0x834: // Select italic font (FS 4)	(= ESC 4)
-            case 0x835: // Cancel italic font (FS 5)	(= ESC 5)
+            case 0x834: // Select italic font (FS 4)    (= ESC 4)
+            case 0x835: // Cancel italic font (FS 5)    (= ESC 5)
             case 0x846: // Select forward feed mode (FS F)
             case 0x852: // Select reverse feed mode (FS R)
                 dev->esc_parms_req = 0;
@@ -735,14 +735,14 @@ process_char(escp_t *dev, uint8_t ch)
             case 0x77:  // Turn double-height printing on/off (ESC w)
             case 0x78:  // Select LQ or draft (ESC x)
             case 0x7e:  // Select/Deselect slash zero (ESC ~)
-            case 0x832: // Select 1/6-inch line spacing (FS 2)	(= ESC 2)
-            case 0x833: // Set n/360-inch line spacing (FS 3)	(= ESC +)
-            case 0x841: // Set n/60-inch line spacing (FS A)	(= ESC A)
-            case 0x843: // Select LQ type style (FS C)	(= ESC k)
+            case 0x832: // Select 1/6-inch line spacing (FS 2)    (= ESC 2)
+            case 0x833: // Set n/360-inch line spacing (FS 3)    (= ESC +)
+            case 0x841: // Set n/60-inch line spacing (FS A)    (= ESC A)
+            case 0x843: // Select LQ type style (FS C)    (= ESC k)
             case 0x845: // Select character width (FS E)
-            case 0x849: // Select character table (FS I)	(= ESC t)
+            case 0x849: // Select character table (FS I)    (= ESC t)
             case 0x853: // Select High Speed/High Density elite pitch (FS S)
-            case 0x856: // Turn double-height printing on/off (FS V)	(= ESC w)
+            case 0x856: // Turn double-height printing on/off (FS V)    (= ESC w)
                 dev->esc_parms_req = 1;
                 break;
 

--- a/src/printer/prt_text.c
+++ b/src/printer/prt_text.c
@@ -1,10 +1,8 @@
 /*
- * 86Box    A hypervisor and IBM PC system emulator that specializes in
- *          running old operating systems and software designed for IBM
- *          PC systems and compatibles from 1981 through fairly recent
- *          system designs based on the PCI bus.
- *
- *          This file is part of the 86Box distribution.
+ * VARCem   Virtual ARchaeological Computer EMulator.
+ *          An emulator of (mostly) x86-based PC systems and devices,
+ *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
+ *          spanning the era between 1981 and 1995.
  *
  *          Implementation of a generic text printer.
  *

--- a/src/printer/prt_text.c
+++ b/src/printer/prt_text.c
@@ -1,43 +1,43 @@
 /*
- * VARCem	Virtual ARchaeological Computer EMulator.
- *		An emulator of (mostly) x86-based PC systems and devices,
- *		using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
- *		spanning the era between 1981 and 1995.
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
  *
- *		This file is part of the VARCem Project.
+ *          This file is part of the 86Box distribution.
  *
- *		Implementation of a generic text printer.
+ *          Implementation of a generic text printer.
  *
- *		Simple old text printers were unable to do any formatting
- *		of the text. They were just sheets of paper with a fixed
- *		size (in the U.S., this would be Letter, 8.5"x11") with a
- *		set of fixed margings to allow for proper operation of the
- *		printer mechanics. This would lead to a page being 66 lines
- *		of 80 characters each.
+ *          Simple old text printers were unable to do any formatting
+ *          of the text. They were just sheets of paper with a fixed
+ *          size (in the U.S., this would be Letter, 8.5"x11") with a
+ *          set of fixed margings to allow for proper operation of the
+ *          printer mechanics. This would lead to a page being 66 lines
+ *          of 80 characters each.
  *
  *
  *
- * Author:	Fred N. van Kempen, <decwiz@yahoo.com>
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
  *
- *		Copyright 2018,2019 Fred N. van Kempen.
+ *          Copyright 2018,2019 Fred N. van Kempen.
  *
- *		Redistribution and  use  in source  and binary forms, with
- *		or  without modification, are permitted  provided that the
- *		following conditions are met:
+ *          Redistribution and  use  in source  and binary forms, with
+ *          or  without modification, are permitted  provided that the
+ *          following conditions are met:
  *
- *		1. Redistributions of  source  code must retain the entire
- *		   above notice, this list of conditions and the following
- *		   disclaimer.
+ *          1. Redistributions of  source  code must retain the entire
+ *             above notice, this list of conditions and the following
+ *             disclaimer.
  *
- *		2. Redistributions in binary form must reproduce the above
- *		   copyright  notice,  this list  of  conditions  and  the
- *		   following disclaimer in  the documentation and/or other
- *		   materials provided with the distribution.
+ *          2. Redistributions in binary form must reproduce the above
+ *             copyright  notice,  this list  of  conditions  and  the
+ *             following disclaimer in  the documentation and/or other
+ *             materials provided with the distribution.
  *
- *		3. Neither the  name of the copyright holder nor the names
- *		   of  its  contributors may be used to endorse or promote
- *		   products  derived from  this  software without specific
- *		   prior written permission.
+ *          3. Neither the  name of the copyright holder nor the names
+ *             of  its  contributors may be used to endorse or promote
+ *             products  derived from  this  software without specific
+ *             prior written permission.
  *
  * THIS SOFTWARE  IS  PROVIDED BY THE  COPYRIGHT  HOLDERS AND CONTRIBUTORS
  * "AS IS" AND  ANY EXPRESS  OR  IMPLIED  WARRANTIES,  INCLUDING, BUT  NOT


### PR DESCRIPTION
Summary
=======
Correct many file headers to show 86box
Also fixes tabs to spaces in said headers (More to come in another PR)

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
