### PR TITLE
qt: Update ui pause state in plat_pause

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -754,10 +754,6 @@ void MainWindow::on_actionCtrl_Alt_Esc_triggered() {
 
 void MainWindow::on_actionPause_triggered() {
     plat_pause(dopause ^ 1);
-    auto pause_icon   = dopause ? QIcon(":/menuicons/win/icons/run.ico") : QIcon(":/menuicons/win/icons/pause.ico");
-    auto tooltip_text = dopause ? QString(tr("Resume execution")) : QString(tr("Pause execution"));
-    ui->actionPause->setIcon(pause_icon);
-    ui->actionPause->setToolTip(tooltip_text);
 }
 
 void MainWindow::on_actionExit_triggered() {
@@ -2054,6 +2050,13 @@ void MainWindow::on_actionSound_gain_triggered()
 void MainWindow::setSendKeyboardInput(bool enabled)
 {
     send_keyboard_input = enabled;
+}
+
+void MainWindow::setUiPauseState(bool paused) {
+    auto pause_icon   = paused ? QIcon(":/menuicons/win/icons/run.ico") : QIcon(":/menuicons/win/icons/pause.ico");
+    auto tooltip_text = paused ? QString(tr("Resume execution")) : QString(tr("Pause execution"));
+    ui->actionPause->setIcon(pause_icon);
+    ui->actionPause->setToolTip(tooltip_text);
 }
 
 void MainWindow::on_actionPreferences_triggered()

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -33,6 +33,7 @@ public:
     void blitToWidget(int x, int y, int w, int h, int monitor_index);
     QSize getRenderWidgetSize();
     void setSendKeyboardInput(bool enabled);
+    void setUiPauseState(bool paused);
 
     std::array<std::unique_ptr<RendererStack>, 8> renderers;
 signals:

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -366,6 +366,7 @@ plat_pause(int p)
         ui_window_title(oldtitle);
     }
     discord_update_activity(dopause);
+    main_window->setUiPauseState(p);
 
 #ifdef Q_OS_WINDOWS
     if (source_hwnd)


### PR DESCRIPTION
Summary
=======
This moves the ui pause button updates into `plat_pause`. A new function had to be added in `qt_mainwindow.cpp` to actually place the logic and updates due to `MainWindow:ui` being private.

This allows it to catch all `plat_pause` calls instead of just ones triggered from ui actions.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
