### PR TITLE
qt: Add earlier drive checkbox in CD-ROM settings

### DIFF
--- a/src/qt/qt_settingsfloppycdrom.hpp
+++ b/src/qt/qt_settingsfloppycdrom.hpp
@@ -28,6 +28,8 @@ private slots:
     void onFloppyRowChanged(const QModelIndex &current);
     void onCDROMRowChanged(const QModelIndex &current);
 
+    void on_checkBoxEarlierDrive_stateChanged(int arg1);
+
 private:
     Ui::SettingsFloppyCDROM *ui;
 };

--- a/src/qt/qt_settingsfloppycdrom.ui
+++ b/src/qt/qt_settingsfloppycdrom.ui
@@ -145,6 +145,13 @@
      <item row="1" column="1">
       <widget class="QComboBox" name="comboBoxSpeed"/>
      </item>
+     <item row="1" column="2">
+      <widget class="QCheckBox" name="checkBoxEarlierDrive">
+       <property name="text">
+        <string>Earlier drive</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>


### PR DESCRIPTION
Summary
=======
qt: Add earlier drive checkbox in CD-ROM settings

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
