### PR TITLE
qt: Rework ui pause update into a slot

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -2052,9 +2052,9 @@ void MainWindow::setSendKeyboardInput(bool enabled)
     send_keyboard_input = enabled;
 }
 
-void MainWindow::setUiPauseState(bool paused) {
-    auto pause_icon   = paused ? QIcon(":/menuicons/win/icons/run.ico") : QIcon(":/menuicons/win/icons/pause.ico");
-    auto tooltip_text = paused ? QString(tr("Resume execution")) : QString(tr("Pause execution"));
+void MainWindow::updateUiPauseState() {
+    auto pause_icon   = dopause ? QIcon(":/menuicons/win/icons/run.ico") : QIcon(":/menuicons/win/icons/pause.ico");
+    auto tooltip_text = dopause ? QString(tr("Resume execution")) : QString(tr("Pause execution"));
     ui->actionPause->setIcon(pause_icon);
     ui->actionPause->setToolTip(tooltip_text);
 }

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -33,7 +33,6 @@ public:
     void blitToWidget(int x, int y, int w, int h, int monitor_index);
     QSize getRenderWidgetSize();
     void setSendKeyboardInput(bool enabled);
-    void setUiPauseState(bool paused);
 
     std::array<std::unique_ptr<RendererStack>, 8> renderers;
 signals:
@@ -65,6 +64,7 @@ public slots:
     void togglePause();
     void initRendererMonitorSlot(int monitor_index);
     void destroyRendererMonitorSlot(int monitor_index);
+    void updateUiPauseState();
 private slots:
     void on_actionFullscreen_triggered();
     void on_actionSettings_triggered();

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -366,7 +366,7 @@ plat_pause(int p)
         ui_window_title(oldtitle);
     }
     discord_update_activity(dopause);
-    main_window->setUiPauseState(p);
+    QTimer::singleShot(0, main_window, &MainWindow::updateUiPauseState);
 
 #ifdef Q_OS_WINDOWS
     if (source_hwnd)


### PR DESCRIPTION
Summary
=======
Hopefully this is the last one on the pause icon.

In #2758 I moved pause icon updates into `plat_pause`. However, `plat_pause` can be called from non-UI threads. Because of that I moved the update function to a slot, to be called from `plat_pause`. This is because in general UIs shouldn't be updated from a non-UI thread.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
#2758
