### PR TITLE
Fix NVR size for Olivetti M24

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -1999,7 +1999,7 @@ const machine_t machines[] = {
             .max = 640,
             .step = 128
         },
-        .nvrmask = 0,
+        .nvrmask = 15,
         .kbc = KBC_OLIVETTI_XT,
         .kbc_p1 = 0xff00,
         .gpio = 0xffffffff,


### PR DESCRIPTION
Summary
=======
Set an NVR of 16 bytes. Fixes save date/time on Olivetti M24 restart.