### PR TITLE
qt: force the screen output widget to be resizable

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -1544,6 +1544,7 @@ void MainWindow::on_actionFullscreen_triggered() {
         ui->menubar->hide();
         ui->statusbar->hide();
         ui->toolBar->hide();
+        ui->stackedWidget->setFixedSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
         showFullScreen();
         if (vid_api == 5) QTimer::singleShot(0, this, [this] () { ui->stackedWidget->switchRenderer(RendererStack::Renderer::Direct3D9); });
     }


### PR DESCRIPTION
Summary
=======
qt: force the screen output widget to be resizable

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
