### PR TITLE
Fix CPU-Z on IBM 486

### DIFF
--- a/src/cpu/x86_ops_flag.h
+++ b/src/cpu/x86_ops_flag.h
@@ -293,11 +293,11 @@ static int opPOPFD(uint32_t fetchdat)
         else if (IOPLp)           cpu_state.flags = (cpu_state.flags & 0x3000) | (templ & 0x4fd5) | 2;
         else                      cpu_state.flags = (cpu_state.flags & 0x3200) | (templ & 0x4dd5) | 2;
 
-        templ &= (is486) ? 0x3c0000 : 0;
+        templ &= (is486 || isibm486) ? 0x3c0000 : 0;
         templ |= ((cpu_state.eflags&3) << 16);
         if (cpu_CR4_mask & CR4_VME) cpu_state.eflags = (templ >> 16) & 0x3f;
         else if (CPUID)             cpu_state.eflags = (templ >> 16) & 0x27;
-        else if (is486) cpu_state.eflags = (templ >> 16) & 7;
+        else if (is486 || isibm486) cpu_state.eflags = (templ >> 16) & 7;
         else                        cpu_state.eflags = (templ >> 16) & 3;
 
         flags_extract();

--- a/src/mem/mem.c
+++ b/src/mem/mem.c
@@ -302,7 +302,7 @@ mmutranslatereal_normal(uint32_t addr, int rw)
 
     if ((temp & 0x80) && (cr4 & CR4_PSE)) {
         /*4MB page*/
-        if (((CPL == 3) && !(temp & 4) && !cpl_override) || (rw && !(temp & 2) && (((CPL == 3) && !cpl_override) || (is486 && (cr0 & WP_FLAG))))) {
+        if (((CPL == 3) && !(temp & 4) && !cpl_override) || (rw && !(temp & 2) && (((CPL == 3) && !cpl_override) || ((is486 || isibm486) && (cr0 & WP_FLAG))))) {
             cr2 = addr;
             temp &= 1;
             if (CPL == 3)
@@ -323,7 +323,7 @@ mmutranslatereal_normal(uint32_t addr, int rw)
 
     temp  = rammap((temp & ~0xfff) + ((addr >> 10) & 0xffc));
     temp3 = temp & temp2;
-    if (!(temp & 1) || ((CPL == 3) && !(temp3 & 4) && !cpl_override) || (rw && !(temp3 & 2) && (((CPL == 3) && !cpl_override) || (is486 && (cr0 & WP_FLAG))))) {
+    if (!(temp & 1) || ((CPL == 3) && !(temp3 & 4) && !cpl_override) || (rw && !(temp3 & 2) && (((CPL == 3) && !cpl_override) || ((is486 || isibm486) && (cr0 & WP_FLAG))))) {
         cr2 = addr;
         temp &= 1;
         if (CPL == 3)


### PR DESCRIPTION
Summary
=======
Fixes CPU-Z detection on IBM 486 by restoring 486 behavior to EFLAGS without breaking NT 3.1

Checklist
=========
* [x] I have discussed this with core contributors already

References
==========
CPU-Z Vintage Edition CPU detection.
