### PR TITLE
qt: force update to happen after hardware renderer is created

### DIFF
--- a/src/qt/qt_hardwarerenderer.hpp
+++ b/src/qt/qt_hardwarerenderer.hpp
@@ -75,6 +75,7 @@ public:
         m_context = new QOpenGLContext();
         m_context->setFormat(format());
         m_context->create();
+        update();
     }
     ~HardwareRenderer()
     {


### PR DESCRIPTION
Summary
=======
qt: force update to happen after hardware renderer is created

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
