### PR TITLE
qt: display at initialization time (update() call doesn't work there)

### DIFF
--- a/src/qt/qt_hardwarerenderer.cpp
+++ b/src/qt/qt_hardwarerenderer.cpp
@@ -140,7 +140,8 @@ void HardwareRenderer::initializeGL()
     pclog("OpenGL shader language version: %s\n", glGetString(GL_SHADING_LANGUAGE_VERSION));
     glClearColor(0, 0, 0, 1);
     m_texture->setWrapMode(QOpenGLTexture::ClampToEdge);
-    update();
+    glClear(GL_COLOR_BUFFER_BIT);
+    m_context->swapBuffers(this);
 }
 
 void HardwareRenderer::paintGL() {


### PR DESCRIPTION
Summary
=======
qt: display at initialization time (update() call doesn't work there)

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
