### PR TITLE
Revert "Rework Voodoo texture precalc to support non-split trilinear …

### DIFF
--- a/src/include/86box/vid_voodoo_texture.h
+++ b/src/include/86box/vid_voodoo_texture.h
@@ -33,7 +33,8 @@ static const uint32_t texture_offset[LOD_MAX + 3] = {
     256 * 256 + 128 * 128 + 64 * 64 + 32 * 32 + 16 * 16 + 8 * 8 + 4 * 4 + 2 * 2 + 1 * 1 + 1
 };
 
-void voodoo_recalc_tex(voodoo_t *voodoo, int tmu);
+void voodoo_recalc_tex12(voodoo_t *voodoo, int tmu);
+void voodoo_recalc_tex3(voodoo_t *voodoo, int tmu);
 void voodoo_use_texture(voodoo_t *voodoo, voodoo_params_t *params, int tmu);
 void voodoo_tex_writel(uint32_t addr, uint32_t val, void *p);
 void flush_texture_cache(voodoo_t *voodoo, uint32_t dirty_addr, int tmu);

--- a/src/video/vid_voodoo_reg.c
+++ b/src/video/vid_voodoo_reg.c
@@ -73,6 +73,7 @@ void
 voodoo_reg_writel(uint32_t addr, uint32_t val, void *p)
 {
     voodoo_t *voodoo = (voodoo_t *) p;
+    void (*voodoo_recalc_tex)(voodoo_t *voodoo, int tmu) = NULL;
     union {
         uint32_t i;
         float    f;
@@ -81,6 +82,11 @@ voodoo_reg_writel(uint32_t addr, uint32_t val, void *p)
     int chip = (addr >> 10) & 0xf;
     if (!chip)
         chip = 0xf;
+
+    if (voodoo->type == VOODOO_3)
+        voodoo_recalc_tex = voodoo_recalc_tex3;
+    else
+        voodoo_recalc_tex = voodoo_recalc_tex12;
 
     tempif.i = val;
     // voodoo_reg_log("voodoo_reg_write_l: addr=%08x val=%08x(%f) chip=%x\n", addr, val, tempif.f, chip);


### PR DESCRIPTION
…textures" for voodoo1/2 Fixes #1137

Summary
=======
Revert "Rework Voodoo texture precalc to support non-split trilinear textures" for voodoo1/2 Fixes #1137

Checklist
=========
* [X] Closes #1137
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
