### PR TITLE
voodoo: Fix misleading pixel format error message

### DIFF
--- a/src/video/vid_voodoo_banshee.c
+++ b/src/video/vid_voodoo_banshee.c
@@ -527,7 +527,7 @@ banshee_recalctimings(svga_t *svga)
                 svga->bpp    = 32;
                 break;
             default:
-                fatal("Unknown pixel format %08x\n", banshee->vgaInit0);
+                fatal("Unknown pixel format %08x (vgaInit0=%08x)\n", VIDPROCCFG_DESKTOP_PIX_FORMAT, banshee->vgaInit0);
         }
         if (!(banshee->vidProcCfg & VIDPROCCFG_DESKTOP_TILE) && (banshee->vidProcCfg & VIDPROCCFG_HALF_MODE))
             svga->rowcount = 1;


### PR DESCRIPTION
Summary
=======
voodoo: Fix misleading pixel format error message

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
