### PR TITLE
Pravetz-16 proper naming of BIOS files

### DIFF
--- a/src/machine/m_xt.c
+++ b/src/machine/m_xt.c
@@ -334,25 +334,24 @@ machine_xt_pravetz16_imko4_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear("roms/machines/pravetz16/BIOS_IMKO4_FE00.bin",
+    ret = bios_load_linear("roms/machines/pravetz16/BIOS_IMKO4_FE00.BIN",
                            0x000fe000, 65536, 0);
-    if (ret) {
-        ret = bios_load_aux_linear("roms/machines/pravetz16/IMKO4-D34_SGS-M2764ADIP28.BIN",
-                                   0x000f4000, 8192, 0);
+    if (ret) 
+    {
+        bios_load_aux_linear("roms/machines/pravetz16/BIOS_IMKO4_F400.BIN",
+                                 0x000f4000, 8192, 0);
 
-        if (ret) {
-            bios_load_aux_linear("roms/machines/pravetz16/1.bin",
+        bios_load_aux_linear("roms/machines/pravetz16/BIOS_IMKO4_F600.BIN",
                                  0x000f6000, 8192, 0);
 
-            bios_load_aux_linear("roms/machines/pravetz16/2.bin",
+        bios_load_aux_linear("roms/machines/pravetz16/BIOS_IMKO4_FA00.BIN",
                                  0x000fa000, 8192, 0);
 
-            bios_load_aux_linear("roms/machines/pravetz16/5.bin",
+        bios_load_aux_linear("roms/machines/pravetz16/BIOS_IMKO4_F800.BIN",
                                  0x000f8000, 8192, 0);
 
-            bios_load_aux_linear("roms/machines/pravetz16/6.bin",
+        bios_load_aux_linear("roms/machines/pravetz16/BIOS_IMKO4_FC00.BIN",
                                  0x000fc000, 8192, 0);
-        }
     }
 
     if (bios_only || !ret)

--- a/src/video/vid_cga.c
+++ b/src/video/vid_cga.c
@@ -540,7 +540,7 @@ cga_pravetz_init(const device_t *info)
 {
     cga_t *cga = cga_standalone_init(info);
 
-    loadfont("roms/video/cga/CGA - PRAVETZ.BIN", 10);
+    loadfont("roms/video/cga/PRAVETZ-VDC2.BIN", 10);
 
     io_removehandler(0x03dd, 0x0001, cga_in, NULL, NULL, cga_out, NULL, NULL, cga);
     io_sethandler(0x03dd, 0x0001, cga_pravetz_in, NULL, NULL, cga_pravetz_out, NULL, NULL, cga);


### PR DESCRIPTION
Summary
=======
Change of Pravetz-16 BIOS filenames to include the addresses. 
Renamed the CGA BIOS file as well to include VDC-2 info.

Checklist
=========
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/186

References
==========
The naming matches the starting memory address as depicted here:
https://www.sandacite.com/forum/index.php?action=dlattach;topic=2702.0;attach=133236;image
