### PR TITLE
qt: Do not display removed viso directories in media history

### DIFF
--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -511,6 +511,7 @@ void MediaMenu::updateImageHistory(int index, int slot, ui::MediaType type) {
     QString menu_item_name = fi.fileName().isEmpty() ? tr("previous image").toUtf8().constData() : fi.fileName().toUtf8().constData();
     imageHistoryUpdatePos->setText(QString::asprintf(tr("%s").toUtf8().constData(), menu_item_name.toUtf8().constData()));
     imageHistoryUpdatePos->setVisible(!fi.fileName().isEmpty());
+    imageHistoryUpdatePos->setVisible(fi.exists());
 }
 
 void MediaMenu::clearImageHistory() {


### PR DESCRIPTION
Summary
=======
The media history menu is updated on certain events such as mount and unmount. During that time, files or directories that no longer exist will be removed from the menu. 

However, if a directory or file is removed prior to that event, they will still be temporarily displayed in the menu. This PR will remove (hide) them from the menu until they can be properly processed in the next event.

Checklist
=========
N/A

References
==========
N/A
