### PR TITLE
qt: Match toolbar background with Win32 backend

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -160,6 +160,9 @@ MainWindow::MainWindow(QWidget *parent) :
     statusBar()->setStyleSheet("QStatusBar::item {border: None; } QStatusBar QLabel { margin-right: 2px; margin-bottom: 1px; }");
     this->centralWidget()->setStyleSheet("background-color: black;");
     ui->toolBar->setVisible(!hide_tool_bar);
+#ifdef _WIN32
+    ui->toolBar->setBackgroundRole(QPalette::Light);
+#endif
     renderers[0].reset(nullptr);
     auto toolbar_spacer = new QWidget();
     toolbar_spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);

--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -218,6 +218,9 @@
    <property name="windowTitle">
     <string notr="true">toolBar</string>
    </property>
+   <property name="autoFillBackground">
+    <bool>true</bool>
+   </property>
    <property name="movable">
     <bool>false</bool>
    </property>


### PR DESCRIPTION
Summary
=======
qt: Match toolbar background with Win32 backend

Checklist
=========
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
