### PR TITLE
voodoo: CMDFIFO type 2 is available starting with Voodoo 2

### DIFF
--- a/src/video/vid_voodoo_fifo.c
+++ b/src/video/vid_voodoo_fifo.c
@@ -359,8 +359,8 @@ voodoo_fifo_thread(void *param)
                     break;
 
                 case 2:
-                    if (voodoo->type < VOODOO_BANSHEE)
-                        fatal("CMDFIFO2: Not Banshee\n");
+                    if (voodoo->type < VOODOO_2)
+                        fatal("CMDFIFO2: Not Voodoo 2\n");
                     mask = (header >> 3);
                     addr = 8;
                     while (mask) {


### PR DESCRIPTION
Summary
=======
voodoo: CMDFIFO type 2 is available starting with Voodoo 2

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
http://vgamuseum.info/images/doc/3dfx/voodoo2.pdf
