### PR TITLE
qt: Fix multiple issues with hdd image creation

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -999,7 +999,7 @@ load_hard_disks(void)
 
             case HDD_BUS_IDE:
                 max_spt    = 63;
-                max_hpc    = 16;
+                max_hpc    = 255;
                 max_tracks = 266305;
                 break;
 

--- a/src/qt/qt_harddiskdialog.cpp
+++ b/src/qt/qt_harddiskdialog.cpp
@@ -293,7 +293,7 @@ void HarddiskDialog::onCreateNewFile() {
 
     ui->progressBar->setEnabled(true);
     setResult(QDialog::Rejected);
-    qint64 size = ui->lineEditSize->text().toUInt() << 20U;
+    quint64 size = ui->lineEditSize->text().toULongLong() << 20U;
     if (size > 0x1FFFFFFE00ll) {
         QMessageBox::critical(this, tr("Disk image too large"), tr("Disk images cannot be larger than 127 GB."));
         return;
@@ -326,6 +326,8 @@ void HarddiskDialog::onCreateNewFile() {
             ui->fileField->setFileName(fileName);
         }
     }
+    QFileInfo fi(fileName);
+    fileName = (fi.isRelative() && !fi.filePath().isEmpty()) ? usr_path + fi.filePath() : fi.filePath();
 
     QFile file(fileName);
     if (! file.open(QIODevice::WriteOnly)) {


### PR DESCRIPTION
Summary
=======
When creating a new hdd image in qt, there were a few issues:

* If the image to be created was greater than a certain size, bit 32 and above would get lopped off resulting in the wrong size created.
* Once an image with > 16 heads was written to config, the image config would be changed and head count clamped to 16.
* If you type in an image file (as opposed to using the file picker) in the new HD image dialog, the resulting file would get placed in `$CWD` instead of `usr_path`. The image file would be created, but in the wrong location. As soon as the settings were confirmed the image file would then be created in `usr_path` resulting in two image files.

To fix:
* The image size logic was happening as a 32-bit unsigned int due to `toUInt()` grabbing the calculated number. Changed the qt type to `unsigned long long` via `toULongLong()`. Changed the size var to `quint64`.
* Updated `config.c` max settings to match `win_settings.c`.
* Added a section in `qt_harddiskdialog.cpp` to add `usr_path` to the filename if the path is relative

**Note:** `config.c` should be updated to use constants for `max_spt`, `max_hpc`, etc. for each bus. I figured it would be better to add those in a separate PR.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
