### PR TITLE
qt: New hdd image creation path

### DIFF
--- a/src/qt/qt_harddiskdialog.cpp
+++ b/src/qt/qt_harddiskdialog.cpp
@@ -328,6 +328,7 @@ void HarddiskDialog::onCreateNewFile() {
     }
     QFileInfo fi(fileName);
     fileName = (fi.isRelative() && !fi.filePath().isEmpty()) ? usr_path + fi.filePath() : fi.filePath();
+    ui->fileField->setFileName(fileName);
 
     QFile file(fileName);
     if (! file.open(QIODevice::WriteOnly)) {


### PR DESCRIPTION
Summary
=======
This is a follow-up to #2859. The fix did work, but the updated (full path) filename also needs to be manually updated in the ui field. Without it, there would be an error after saving the settings (though it would work fine after the error). This fix updates the ui field.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
#2859
