### PR TITLE
snd_optimc, snd_opl_ymfm: Fix warnings

### DIFF
--- a/src/sound/snd_opl_ymfm.cpp
+++ b/src/sound/snd_opl_ymfm.cpp
@@ -80,8 +80,8 @@ public:
         : YMFMChipBase(clock, type, samplerate)
         , m_chip(*this)
         , m_clock(clock)
-        , m_samplecnt(0)
         , m_samplerate(samplerate)
+        , m_samplecnt(0)
     {
         memset(m_samples, 0, sizeof(m_samples));
         memset(m_oldsamples, 0, sizeof(m_oldsamples));

--- a/src/sound/snd_optimc.c
+++ b/src/sound/snd_optimc.c
@@ -131,13 +131,6 @@ optimc_add_opl(optimc_t *optimc)
 }
 
 static void
-optimc_reload_opl(optimc_t *optimc)
-{
-    optimc_remove_opl(optimc);
-    optimc_add_opl(optimc);
-}
-
-static void
 optimc_reg_write(uint16_t addr, uint8_t val, void *p)
 {
     optimc_t      *optimc           = (optimc_t *) p;


### PR DESCRIPTION
Summary
=======
Fixes the following warnings:
```
src/sound/snd_optimc.c:134:1: warning: 'optimc_reload_opl' defined but not used [-Wunused-function]
  134 | optimc_reload_opl(optimc_t *optimc)
      | ^~~~~~~~~~~~~~~~~
```

```
src/sound/snd_opl_ymfm.cpp: In instantiation of 'YMFMChip<ChipType>::YMFMChip(uint32_t, fm_type, uint32_t) [with ChipType = ymfm::ym3812; uint32_t = unsigned int]':
src/sound/snd_opl_ymfm.cpp:288:87:   required from here
src/sound/snd_opl_ymfm.cpp:243:13: warning: 'YMFMChip<ymfm::ym3812>::m_samplecnt' will be initialized after [-Wreorder]
  243 |     int32_t m_samplecnt;
      |             ^~~~~~~~~~~
src/sound/snd_opl_ymfm.cpp:236:36: warning:   'uint32_t YMFMChip<ymfm::ym3812>::m_samplerate' [-Wreorder]
  236 |     uint32_t                       m_samplerate;
      |                                    ^~~~~~~~~~~~
src/sound/snd_opl_ymfm.cpp:79:5: warning:   when initialized here [-Wreorder]
   79 |     YMFMChip(uint32_t clock, fm_type type, uint32_t samplerate)
      |     ^~~~~~~~
src/sound/snd_opl_ymfm.cpp: In instantiation of 'YMFMChip<ChipType>::YMFMChip(uint32_t, fm_type, uint32_t) [with ChipType = ymfm::ymf262; uint32_t = unsigned int]':
src/sound/snd_opl_ymfm.cpp:292:88:   required from here
src/sound/snd_opl_ymfm.cpp:243:13: warning: 'YMFMChip<ymfm::ymf262>::m_samplecnt' will be initialized after [-Wreorder]
  243 |     int32_t m_samplecnt;
      |             ^~~~~~~~~~~
src/sound/snd_opl_ymfm.cpp:236:36: warning:   'uint32_t YMFMChip<ymfm::ymf262>::m_samplerate' [-Wreorder]
  236 |     uint32_t                       m_samplerate;
      |                                    ^~~~~~~~~~~~
src/sound/snd_opl_ymfm.cpp:79:5: warning:   when initialized here [-Wreorder]
   79 |     YMFMChip(uint32_t clock, fm_type type, uint32_t samplerate)
      |     ^~~~~~~~
src/sound/snd_opl_ymfm.cpp: In instantiation of 'YMFMChip<ChipType>::YMFMChip(uint32_t, fm_type, uint32_t) [with ChipType = ymfm::ymf289b; uint32_t = unsigned int]':
src/sound/snd_opl_ymfm.cpp:296:90:   required from here
src/sound/snd_opl_ymfm.cpp:243:13: warning: 'YMFMChip<ymfm::ymf289b>::m_samplecnt' will be initialized after [-Wreorder]
  243 |     int32_t m_samplecnt;
      |             ^~~~~~~~~~~
src/sound/snd_opl_ymfm.cpp:236:36: warning:   'uint32_t YMFMChip<ymfm::ymf289b>::m_samplerate' [-Wreorder]
  236 |     uint32_t                       m_samplerate;
      |                                    ^~~~~~~~~~~~
src/sound/snd_opl_ymfm.cpp:79:5: warning:   when initialized here [-Wreorder]
   79 |     YMFMChip(uint32_t clock, fm_type type, uint32_t samplerate)
      |     ^~~~~~~~
src/sound/snd_opl_ymfm.cpp: In instantiation of 'YMFMChip<ChipType>::YMFMChip(uint32_t, fm_type, uint32_t) [with ChipType = ymfm::ymf278b; uint32_t = unsigned int]':
src/sound/snd_opl_ymfm.cpp:300:90:   required from here
src/sound/snd_opl_ymfm.cpp:243:13: warning: 'YMFMChip<ymfm::ymf278b>::m_samplecnt' will be initialized after [-Wreorder]
  243 |     int32_t m_samplecnt;
      |             ^~~~~~~~~~~
src/sound/snd_opl_ymfm.cpp:236:36: warning:   'uint32_t YMFMChip<ymfm::ymf278b>::m_samplerate' [-Wreorder]
  236 |     uint32_t                       m_samplerate;
      |                                    ^~~~~~~~~~~~
src/sound/snd_opl_ymfm.cpp:79:5: warning:   when initialized here [-Wreorder]
   79 |     YMFMChip(uint32_t clock, fm_type type, uint32_t samplerate)
      |     ^~~~~~~~
```

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
