### PR TITLE
OPTiMC: Fix OPL volume mixing

### DIFF
--- a/src/include/86box/snd_ad1848.h
+++ b/src/include/86box/snd_ad1848.h
@@ -66,6 +66,7 @@ extern void    ad1848_write(uint16_t addr, uint8_t val, void *priv);
 extern void ad1848_update(ad1848_t *ad1848);
 extern void ad1848_speed_changed(ad1848_t *ad1848);
 extern void ad1848_filter_cd_audio(int channel, double *buffer, void *priv);
+extern void ad1848_filter_aux2(void* priv, double* out_l, double* out_r);
 
 extern void ad1848_init(ad1848_t *ad1848, uint8_t type);
 

--- a/src/include/86box/snd_sb.h
+++ b/src/include/86box/snd_sb.h
@@ -147,6 +147,9 @@ typedef struct sb_t {
         pnp_rom[512];
 
     uint16_t opl_pnp_addr;
+
+    void   *opl_mixer;
+    void  (*opl_mix)(void*, double*, double*);
 } sb_t;
 
 extern void    sb_ct1345_mixer_write(uint16_t addr, uint8_t val, void *p);

--- a/src/sound/snd_ad1848.c
+++ b/src/sound/snd_ad1848.c
@@ -600,6 +600,24 @@ ad1848_filter_cd_audio(int channel, double *buffer, void *priv)
 }
 
 void
+ad1848_filter_aux2(void* priv, double* out_l, double* out_r)
+{
+    ad1848_t *ad1848 = (ad1848_t *) priv;
+
+    if (ad1848->regs[4] & 0x80) {
+        *out_l = 0.0;
+    } else {
+        *out_l = ((*out_l) * ad1848_vols_5bits_aux_gain[ad1848->regs[4] & 0x1f]) / 65536.0;
+    }
+
+    if (ad1848->regs[5] & 0x80) {
+        *out_r = 0.0;
+    } else {
+        *out_r = ((*out_r) * ad1848_vols_5bits_aux_gain[ad1848->regs[5] & 0x1f]) / 65536.0;
+    }
+}
+
+void
 ad1848_init(ad1848_t *ad1848, uint8_t type)
 {
     uint8_t c;

--- a/src/sound/snd_optimc.c
+++ b/src/sound/snd_optimc.c
@@ -70,6 +70,16 @@ typedef struct optimc_t {
     uint8_t regs[6];
 } optimc_t, opti_82c929_t;
 
+static void
+optimc_filter_opl(void* priv, double* out_l, double* out_r)
+{
+    optimc_t *optimc = (optimc_t *) priv;
+
+    if (optimc->cur_wss_enabled) {
+        ad1848_filter_aux2((void*)&optimc->ad1848, out_l, out_r);
+    }
+}
+
 static uint8_t
 optimc_wss_read(uint16_t addr, void *priv)
 {
@@ -371,6 +381,9 @@ optimc_init(const device_t *info)
     sb_dsp_setirq(&optimc->sb->dsp, optimc->cur_irq);
     sb_dsp_setdma8(&optimc->sb->dsp, optimc->cur_dma);
     sb_ct1345_mixer_reset(optimc->sb);
+
+    optimc->sb->opl_mixer = optimc;
+    optimc->sb->opl_mix = optimc_filter_opl;
 
     optimc->fm_type = (info->local & OPTIMC_OPL4) ? FM_YMF278B : FM_YMF262;
     fm_driver_get(optimc->fm_type, &optimc->sb->opl);

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -290,6 +290,9 @@ sb_get_buffer_sbpro(int32_t *buffer, int len, void *p)
             } else {
                 out_l = (((double) opl_buf[c]) * mixer->fm_l) * 0.7171630859375;
                 out_r = (((double) opl_buf[c + 1]) * mixer->fm_r) * 0.7171630859375;
+                if (sb->opl_mix && sb->opl_mixer) {
+                    sb->opl_mix(sb->opl_mixer, &out_l, &out_r);
+                }
             }
         }
 


### PR DESCRIPTION
Summary
=======
OPTiMC: Fix OPL volume mixing

Windows driver operates the chip in WSS mode so AUX2 volume filtering for OPL playback is required


Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
