### PR TITLE
OPTiMC: Don't factor in the SB mixer OPL volumes

### DIFF
--- a/src/sound/snd_optimc.c
+++ b/src/sound/snd_optimc.c
@@ -76,6 +76,8 @@ optimc_filter_opl(void* priv, double* out_l, double* out_r)
     optimc_t *optimc = (optimc_t *) priv;
 
     if (optimc->cur_wss_enabled) {
+        *out_l /= optimc->sb->mixer_sbpro.fm_l;
+        *out_r /= optimc->sb->mixer_sbpro.fm_r;
         ad1848_filter_aux2((void*)&optimc->ad1848, out_l, out_r);
     }
 }


### PR DESCRIPTION
Summary
=======
OPTiMC: Don't factor in the SB mixer OPL volumes

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
