### PR TITLE
OPTiMC: MC6 register is readable, despite what the datasheet says

### DIFF
--- a/src/sound/snd_optimc.c
+++ b/src/sound/snd_optimc.c
@@ -312,7 +312,8 @@ optimc_reg_read(uint16_t addr, void *p)
             case 3: /* MC4 */
             case 4: /* MC5 */
                 temp = optimc->regs[addr - 0xF8D];
-            case 5: /* MC6 (not readable) */
+            case 5: /* MC6 */
+                temp = optimc->regs[5];
                 break;
             case 2: /* MC3 */
                 temp = (optimc->regs[2] & ~0x3) | 0x2;


### PR DESCRIPTION
Summary
=======
OPTiMC: MC6 register is readable, despite what the datasheet says

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
