### PR TITLE
AD1848: Writes to register 27 are rejected on Crystal

### DIFF
--- a/src/sound/snd_ad1848.c
+++ b/src/sound/snd_ad1848.c
@@ -378,6 +378,10 @@ ad1848_write(uint16_t addr, uint8_t val, void *priv)
 
                 case 25:
                     return;
+                case 27:
+                    if (ad1848->type != AD1848_TYPE_DEFAULT)
+                        return;
+                    break;
             }
             ad1848->regs[ad1848->index] = val;
 


### PR DESCRIPTION
Summary
=======
AD1848: Writes to register 27 are rejected on Crystal codecs

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
