### PR TITLE
fix build for non-dynarec platforms

### DIFF
--- a/src/cpu/cpu.c
+++ b/src/cpu/cpu.c
@@ -1170,7 +1170,9 @@ cpu_set(void)
 
             if ((cpu_s->cpu_type == CPU_K6_2P) || (cpu_s->cpu_type == CPU_K6_3P)) {
                 x86_opcodes_3DNOW         = ops_3DNOWE;
+#ifdef USE_DYNAREC
                 x86_dynarec_opcodes_3DNOW = dynarec_ops_3DNOWE;
+#endif
             }
 
             timing_rr  = 1; /* register dest - register src */


### PR DESCRIPTION
Summary
=======
Do not set a member that doesn't exist on platforms without dynarec support. Currently it fails to build with
````
/builddir/build/BUILD/86Box-3.11/src/cpu/cpu.c: In function 'cpu_set':
/builddir/build/BUILD/86Box-3.11/src/cpu/cpu.c:1173:17: error: 'x86_dynarec_opcodes_3DNOW' undeclared (first use in this function); did you mean 'x86_opcodes_3DNOW'?
 1173 |                 x86_dynarec_opcodes_3DNOW = dynarec_ops_3DNOWE;
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~
      |                 x86_opcodes_3DNOW
/builddir/build/BUILD/86Box-3.11/src/cpu/cpu.c:1173:17: note: each undeclared identifier is reported only once for each function it appears in
builddir/build/BUILD/86Box-3.11/src/cpu/cpu.c:1173:45: error: 'dynarec_ops_3DNOWE' undeclared (first use in this function)
 1173 |                 x86_dynarec_opcodes_3DNOW = dynarec_ops_3DNOWE;
      |                                             ^~~~~~~~~~~~~~~~~~

````

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
