### PR TITLE
IDE/ATAPI: Don't overwrite data in packet writes during Phase Data In.

### DIFF
--- a/src/disk/hdc_ide.c
+++ b/src/disk/hdc_ide.c
@@ -1150,6 +1150,9 @@ ide_atapi_packet_write(ide_t *ide, uint32_t val, int length)
     bufferw = (uint16_t *) bufferb;
     bufferl = (uint32_t *) bufferb;
 
+    if (dev->packet_status == PHASE_DATA_IN)
+        return;
+
     switch (length) {
         case 1:
             bufferb[dev->pos] = val & 0xff;


### PR DESCRIPTION

Summary
=======
Fixes Solaris 2.6 CD installation on ide/atapi.

Checklist
=========
* [x] Closes #2901 
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
