### PR TITLE
Add the CR4 Page Global Enable bit support to Pentium Pro and Pentium II CPUs

### DIFF
--- a/src/cpu/cpu.c
+++ b/src/cpu/cpu.c
@@ -61,6 +61,7 @@ enum {
     CPUID_AMDSEP    = (1 << 10),
     CPUID_SEP       = (1 << 11),
     CPUID_MTRR      = (1 << 12),
+    CPUID_PGE       = (1 << 13),
     CPUID_MCA       = (1 << 14),
     CPUID_CMOV      = (1 << 15),
     CPUID_MMX       = (1 << 23),
@@ -1298,7 +1299,7 @@ cpu_set(void)
             if (cpu_s->cpu_type >= CPU_PENTIUM2)
                 cpu_features |= CPU_FEATURE_MMX;
             msr.fcr      = (1 << 8) | (1 << 9) | (1 << 12) | (1 << 16) | (1 << 19) | (1 << 21);
-            cpu_CR4_mask = CR4_VME | CR4_PVI | CR4_TSD | CR4_DE | CR4_PSE | CR4_MCE | CR4_PAE | CR4_PCE;
+            cpu_CR4_mask = CR4_VME | CR4_PVI | CR4_TSD | CR4_DE | CR4_PSE | CR4_MCE | CR4_PAE | CR4_PCE | CR4_PGE;
             if (cpu_s->cpu_type == CPU_PENTIUM2D)
                 cpu_CR4_mask |= CR4_OSFXSR;
 
@@ -1959,7 +1960,7 @@ cpu_CPUID(void)
             } else if (EAX == 1) {
                 EAX = CPUID;
                 EBX = ECX = 0;
-                EDX       = CPUID_FPU | CPUID_VME | CPUID_PSE | CPUID_TSC | CPUID_MSR | CPUID_PAE | CPUID_MCE | CPUID_CMPXCHG8B | CPUID_MTRR | CPUID_MCA | CPUID_SEP | CPUID_CMOV;
+                EDX       = CPUID_FPU | CPUID_VME | CPUID_PSE | CPUID_TSC | CPUID_MSR | CPUID_PAE | CPUID_MCE | CPUID_CMPXCHG8B | CPUID_MTRR | CPUID_PGE | CPUID_MCA | CPUID_SEP | CPUID_CMOV;
             } else if (EAX == 2) {
                 EAX = 0x00000001;
                 EBX = ECX = 0;
@@ -1977,7 +1978,7 @@ cpu_CPUID(void)
             } else if (EAX == 1) {
                 EAX = CPUID;
                 EBX = ECX = 0;
-                EDX       = CPUID_FPU | CPUID_VME | CPUID_PSE | CPUID_TSC | CPUID_MSR | CPUID_PAE | CPUID_MCE | CPUID_CMPXCHG8B | CPUID_MMX | CPUID_MTRR | CPUID_MCA | CPUID_SEP | CPUID_CMOV;
+                EDX       = CPUID_FPU | CPUID_VME | CPUID_PSE | CPUID_TSC | CPUID_MSR | CPUID_PAE | CPUID_MCE | CPUID_CMPXCHG8B | CPUID_MMX | CPUID_MTRR | CPUID_PGE | CPUID_MCA | CPUID_SEP | CPUID_CMOV;
             } else if (EAX == 2) {
                 EAX = 0x00000001;
                 EBX = ECX = 0;
@@ -1995,7 +1996,7 @@ cpu_CPUID(void)
             } else if (EAX == 1) {
                 EAX = CPUID;
                 EBX = ECX = 0;
-                EDX       = CPUID_FPU | CPUID_VME | CPUID_PSE | CPUID_TSC | CPUID_MSR | CPUID_PAE | CPUID_MCE | CPUID_CMPXCHG8B | CPUID_MMX | CPUID_MTRR | CPUID_MCA | CPUID_SEP | CPUID_FXSR | CPUID_CMOV;
+                EDX       = CPUID_FPU | CPUID_VME | CPUID_PSE | CPUID_TSC | CPUID_MSR | CPUID_PAE | CPUID_MCE | CPUID_CMPXCHG8B | CPUID_MMX | CPUID_MTRR | CPUID_PGE | CPUID_MCA | CPUID_SEP | CPUID_FXSR | CPUID_CMOV;
             } else if (EAX == 2) {
                 EAX = 0x00000001;
                 EBX = ECX = 0;

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -195,6 +195,7 @@ typedef struct {
 #define CR4_PVI  (1 << 1)
 #define CR4_PSE  (1 << 4)
 #define CR4_PAE  (1 << 5)
+#define CR4_PGE  (1 << 7)
 
 #define CPL      ((cpu_state.seg_cs.access >> 5) & 3)
 

--- a/src/cpu/x86_ops_mov_ctrl.h
+++ b/src/cpu/x86_ops_mov_ctrl.h
@@ -148,7 +148,7 @@ opMOV_CRx_r_a16(uint32_t fetchdat)
             break;
         case 4:
             if (cpu_has_feature(CPU_FEATURE_CR4)) {
-                if (((cpu_state.regs[cpu_rm].l ^ cr4) & cpu_CR4_mask) & CR4_PAE)
+                if (((cpu_state.regs[cpu_rm].l ^ cr4) & cpu_CR4_mask) & (CR4_PAE | CR4_PGE))
                     flushmmucache();
                 cr4 = cpu_state.regs[cpu_rm].l & cpu_CR4_mask;
                 break;
@@ -205,7 +205,7 @@ opMOV_CRx_r_a32(uint32_t fetchdat)
             break;
         case 4:
             if (cpu_has_feature(CPU_FEATURE_CR4)) {
-                if (((cpu_state.regs[cpu_rm].l ^ cr4) & cpu_CR4_mask) & CR4_PAE)
+                if (((cpu_state.regs[cpu_rm].l ^ cr4) & cpu_CR4_mask) & (CR4_PAE | CR4_PGE))
                     flushmmucache();
                 cr4 = cpu_state.regs[cpu_rm].l & cpu_CR4_mask;
                 break;


### PR DESCRIPTION
Summary
=======
Title.

Should fix certain operating systems expecting it to be present and refusing to boot.

Code ported from PCBox.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
