### PR TITLE
qt: Fixes for removable image files

### DIFF
--- a/src/qt/qt_newfloppydialog.cpp
+++ b/src/qt/qt_newfloppydialog.cpp
@@ -186,7 +186,7 @@ NewFloppyDialog::onCreate()
 {
     auto      filename = ui->fileField->fileName();
     QFileInfo fi(filename);
-    filename = (fi.isRelative() && !fi.filePath().isEmpty()) ? usr_path + fi.filePath() : fi.filePath();
+    filename = (fi.isRelative() && !fi.filePath().isEmpty()) ? (usr_path + fi.filePath()) : fi.filePath();
     ui->fileField->setFileName(filename);
     FileType  fileType;
 

--- a/src/qt/qt_newfloppydialog.cpp
+++ b/src/qt/qt_newfloppydialog.cpp
@@ -25,6 +25,7 @@
 #include "qt_util.hpp"
 
 extern "C" {
+#include <86box/86box.h>
 #include <86box/plat.h>
 #include <86box/random.h>
 #include <86box/scsi_device.h>
@@ -130,20 +131,20 @@ NewFloppyDialog::NewFloppyDialog(MediaType type, QWidget *parent)
                 Models::AddEntry(model, tr(floppyTypes[i].toUtf8().data()), i);
             }
             ui->fileField->setFilter(
-                tr("All images") % util::DlgFilter({ "86f", "dsk", "flp", "im?", "*fd?" }) % tr("Basic sector images") % util::DlgFilter({ "dsk", "flp", "im?", "img", "*fd?" }) % tr("Surface images") % util::DlgFilter({ "86f" }, true));
+                tr("All images") % util::DlgFilter({ "86f", "dsk", "flp", "im?", "img", "*fd?" }) % tr("Basic sector images") % util::DlgFilter({ "dsk", "flp", "im?", "img", "*fd?" }) % tr("Surface images") % util::DlgFilter({ "86f" }, true));
 
             break;
         case MediaType::Zip:
             for (int i = 0; i < zipTypes.size(); ++i) {
                 Models::AddEntry(model, tr(zipTypes[i].toUtf8().data()), i);
             }
-            ui->fileField->setFilter(tr("ZIP images") % util::DlgFilter({ "im?", "zdi" }, true));
+            ui->fileField->setFilter(tr("ZIP images") % util::DlgFilter({ "im?", "img", "zdi" }, true));
             break;
         case MediaType::Mo:
             for (int i = 0; i < moTypes.size(); ++i) {
                 Models::AddEntry(model, tr(moTypes[i].toUtf8().data()), i);
             }
-            ui->fileField->setFilter(tr("MO images") % util::DlgFilter({ "im?", "mdi" }) % tr("All files") % util::DlgFilter({ "*" }, true));
+            ui->fileField->setFilter(tr("MO images") % util::DlgFilter({ "im?", "img", "mdi" }) % tr("All files") % util::DlgFilter({ "*" }, true));
             break;
     }
 
@@ -185,6 +186,8 @@ NewFloppyDialog::onCreate()
 {
     auto      filename = ui->fileField->fileName();
     QFileInfo fi(filename);
+    filename = (fi.isRelative() && !fi.filePath().isEmpty()) ? usr_path + fi.filePath() : fi.filePath();
+    ui->fileField->setFileName(filename);
     FileType  fileType;
 
     QProgressDialog progress("Creating floppy image", QString(), 0, 100, this);


### PR DESCRIPTION
Summary
=======
On macOS the new file dialog was forcing the use of the `.mdi` suffix on files for MO disks (and likely all removable types). This PR updates the filter to allow one to specify `.img` files for the suffix on all of the removable drive types where supported (currently: floppy, zip, mo).

There was another issue where the newly-created image would appear in the incorrect place when manually typing in the filename to be used (similar to #2859 and #2868 it would just dump into `$CWD`). This PR also applies the same fix for the removable image types.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
#2859 and #2868
