### PR TITLE
Corrected (more or less) the IBM PS/2 model 60 POS ID

### DIFF
--- a/src/machine/m_ps2_mca.c
+++ b/src/machine/m_ps2_mca.c
@@ -1385,7 +1385,7 @@ machine_ps2_model_60_init(const machine_t *model)
 
     machine_ps2_common_init(model);
 
-    ps2.planar_id = 0xf7ff;
+    ps2.planar_id = 0xfbff;
     ps2_mca_board_model_50_init(8);
 
     return ret;


### PR DESCRIPTION
Summary
=======
Looks like the model 50 bios expects the 50 POS id and given the 60 shares its stuff with 50 (being a larger 8-slot version of the 50), I believe the id is identical then until a I find a proper 60-specific bios.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
