### PR TITLE
SCSI/CD-ROM fixes: Properly implemented the Toshiba specific SCSI commands

### DIFF
--- a/src/include/86box/cdrom.h
+++ b/src/include/86box/cdrom.h
@@ -116,7 +116,7 @@ typedef struct cdrom {
         seek_diff, cd_end;
 
     int host_drive, prev_host_drive,
-        cd_buflen, noplay;
+        cd_buflen, audio_op;
 
     const cdrom_ops_t *ops;
 


### PR DESCRIPTION
Summary
=======
SCSI/CD-ROM fixes: Properly implemented the Toshiba specific SCSI commands including the Audio side per the Toshiba CD-ROM SCSI-2 manual from 1990 (they were previously implemented with some hacks). These were required for proper Audio handling in OS/2 and other stuff.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[_Provide links to datasheets or other documentation that helped you implement this pull request._](http://bitsavers.informatik.uni-stuttgart.de/pdf/toshiba/cdrom/Toshiba_CD-ROM_SCSI-2_Interface_Specifications_Version_5.0_Sep90.pdf)
