### PR TITLE
qt: Fix status bar icons ignoring update activity setting

### DIFF
--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -366,6 +366,10 @@ hdd_count(int bus)
 void
 MachineStatus::refreshIcons()
 {
+    /* Check if icons should show activity. */
+    if (!update_icons)
+        return;
+
     for (size_t i = 0; i < FDD_NUM; ++i) {
         d->fdd[i].setActive(machine_status.fdd[i].active);
         d->fdd[i].setEmpty(machine_status.fdd[i].empty);
@@ -397,6 +401,23 @@ MachineStatus::refreshIcons()
     for (int i = 0; i < 2; ++i) {
         d->cartridge[i].setEmpty(machine_status.cartridge[i].empty);
     }
+}
+
+void
+MachineStatus::clearActivity()
+{
+    for (auto &fdd : d->fdd)
+        fdd.setActive(false);
+    for (auto &cdrom : d->cdrom)
+        cdrom.setActive(false);
+    for (auto &zip : d->zip)
+        zip.setActive(false);
+    for (auto &mo : d->mo)
+        mo.setActive(false);
+    for (auto &hdd : d->hdds)
+        hdd.setActive(false);
+    for (auto &net : d->net)
+        net.setActive(false);
 }
 
 void

--- a/src/qt/qt_machinestatus.hpp
+++ b/src/qt/qt_machinestatus.hpp
@@ -70,6 +70,7 @@ public:
     static void iterateNIC(const std::function<void(int i)> &cb);
 
     QString getMessage();
+    void    clearActivity();
 public slots:
     void refresh(QStatusBar *sbar);
     void message(const QString &msg);

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -2231,6 +2231,9 @@ MainWindow::on_actionUpdate_status_bar_icons_triggered()
 {
     update_icons ^= 1;
     ui->actionUpdate_status_bar_icons->setChecked(update_icons);
+
+    /* Prevent icons staying when disabled during activity. */
+    status->clearActivity();
 }
 
 void


### PR DESCRIPTION
Summary
=======
Disabling status bar icons activity was left unimplemented on qt. Prevent refreshing the icons and clear their activity status on setting change.

Checklist
=========
* [x] Closes #2953
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
