### PR TITLE
nvr_at: Re-add a forgotten check for VIA NVR

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -681,6 +681,7 @@ extern int machine_at_p6sba_init(const machine_t *);
 extern int machine_at_ficka6130_init(const machine_t *);
 extern int machine_at_p3v133_init(const machine_t *);
 extern int machine_at_p3v4x_init(const machine_t *);
+extern int machine_at_gt694va_init(const machine_t *);
 
 extern int machine_at_vei8_init(const machine_t *);
 
@@ -702,7 +703,6 @@ extern int machine_at_awo671r_init(const machine_t *);
 extern int machine_at_63a1_init(const machine_t *);
 extern int machine_at_s370sba_init(const machine_t *);
 extern int machine_at_apas3_init(const machine_t *);
-extern int machine_at_gt694va_init(const machine_t *);
 extern int machine_at_cuv4xls_init(const machine_t *);
 extern int machine_at_6via90ap_init(const machine_t *);
 extern int machine_at_s1857_init(const machine_t *);

--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -573,6 +573,48 @@ machine_at_p3v4x_init(const machine_t *model)
 }
 
 int
+machine_at_gt694va_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/gt694va/21071100.bin",
+                           0x000c0000, 262144, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_common_init_ex(model, 2);
+
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 0, 0, 3, 4);
+    pci_register_slot(0x0D, PCI_CARD_SOUND,       4, 1, 2, 3); /* assumed */
+    pci_register_slot(0x0F, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x11, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x13, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x01, PCI_CARD_AGPBRIDGE,   1, 2, 3, 4);
+    device_add(&via_apro133a_device);
+    device_add(&via_vt82c596b_device);
+    device_add(&w83977ef_device);
+    device_add(&keyboard_ps2_ami_pci_device);
+    device_add(&sst_flash_39sf020_device);
+    spd_register(SPD_TYPE_SDRAM, 0x7, 1024);
+    device_add(&w83782d_device);       /* fans: CPU, unused, unused; temperatures: System, CPU1, unused */
+    hwm_values.voltages[1]     = 1500; /* IN1 (unknown purpose, assumed Vtt) */
+    hwm_values.fans[0]         = 4500; /* BIOS does not display <4411 RPM */
+    hwm_values.fans[1]         = 0;    /* unused */
+    hwm_values.fans[2]         = 0;    /* unused */
+    hwm_values.temperatures[2] = 0;    /* unused */
+
+    if (sound_card_current == SOUND_INTERNAL) {
+        device_add(&es1371_onboard_device);
+        device_add(&cs4297_device); /* assumed */
+    }
+
+    return ret;
+}
+
+int
 machine_at_vei8_init(const machine_t *model)
 {
     int ret;

--- a/src/machine/m_at_socket370.c
+++ b/src/machine/m_at_socket370.c
@@ -345,48 +345,6 @@ machine_at_apas3_init(const machine_t *model)
 }
 
 int
-machine_at_gt694va_init(const machine_t *model)
-{
-    int ret;
-
-    ret = bios_load_linear("roms/machines/gt694va/21071100.bin",
-                           0x000c0000, 262144, 0);
-
-    if (bios_only || !ret)
-        return ret;
-
-    machine_at_common_init_ex(model, 2);
-
-    pci_init(PCI_CONFIG_TYPE_1);
-    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 0, 0, 3, 4);
-    pci_register_slot(0x0D, PCI_CARD_SOUND,       4, 1, 2, 3); /* assumed */
-    pci_register_slot(0x0F, PCI_CARD_NORMAL,      3, 4, 1, 2);
-    pci_register_slot(0x11, PCI_CARD_NORMAL,      2, 3, 4, 1);
-    pci_register_slot(0x13, PCI_CARD_NORMAL,      1, 2, 3, 4);
-    pci_register_slot(0x01, PCI_CARD_AGPBRIDGE,   1, 2, 3, 4);
-    device_add(&via_apro133a_device);
-    device_add(&via_vt82c596b_device);
-    device_add(&w83977ef_device);
-    device_add(&keyboard_ps2_ami_pci_device);
-    device_add(&sst_flash_39sf020_device);
-    spd_register(SPD_TYPE_SDRAM, 0x7, 1024);
-    device_add(&w83782d_device);       /* fans: CPU, unused, unused; temperatures: System, CPU1, unused */
-    hwm_values.voltages[1]     = 1500; /* IN1 (unknown purpose, assumed Vtt) */
-    hwm_values.fans[0]         = 4500; /* BIOS does not display <4411 RPM */
-    hwm_values.fans[1]         = 0;    /* unused */
-    hwm_values.fans[2]         = 0;    /* unused */
-    hwm_values.temperatures[2] = 0;    /* unused */
-
-    if (sound_card_current == SOUND_INTERNAL) {
-        device_add(&es1371_onboard_device);
-        device_add(&cs4297_device); /* assumed */
-    }
-
-    return ret;
-}
-
-int
 machine_at_cuv4xls_init(const machine_t *model)
 {
     int ret;

--- a/src/nvr_at.c
+++ b/src/nvr_at.c
@@ -1096,7 +1096,7 @@ nvr_at_init(const device_t *info)
             io_sethandler(0x0070, 2,
                           nvr_read, NULL, NULL, nvr_write, NULL, NULL, nvr);
         }
-        if ((info->local & 0x1f) == 0x11) {
+        if (((info->local & 0x1f) == 0x11) || ((info->local & 0x1f) == 0x17)) {
             io_sethandler(0x0072, 2,
                           nvr_read, NULL, NULL, nvr_write, NULL, NULL, nvr);
         }


### PR DESCRIPTION
Summary
=======
Restores a removed case in nvr_at.c, the absence of which made the BCM GT694VA and ASUS CUV4X-LS hang at POST C1 C0.

Also moves the GT694VA code to the proper file.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
