### PR TITLE
Minor changes to OPTi 82C929A emulation

### DIFF
--- a/src/sound/snd_optimc.c
+++ b/src/sound/snd_optimc.c
@@ -40,7 +40,7 @@
 #include <86box/rom.h>
 
 static int optimc_wss_dma[4] = { 0, 0, 1, 3 };
-static int optimc_wss_irq[4] = { 7, 9, 10, 11, };
+static int optimc_wss_irq[4] = { 7, 9, 10, 11 };
 
 enum optimc_local_flags {
     OPTIMC_CS4231 = 0x100,


### PR DESCRIPTION
Summary
=======
Corrected typographical error in code at line 43

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://www.philscomputerlab.com/82c929a.html
https://www.philscomputerlab.com/uploads/3/7/2/3/37231621/optcs00036-1.pdf
https://www.philscomputerlab.com/uploads/3/7/2/3/37231621/82c929_mad16_pro.pdf