### PR TITLE
Minor changes to OPTi 82C929A emulation

### DIFF
--- a/src/sound/snd_optimc.c
+++ b/src/sound/snd_optimc.c
@@ -101,7 +101,7 @@ optimc_wss_write(uint16_t addr, uint8_t val, void *priv)
         return;
     optimc->wss_config = val;
     ad1848_setdma(&optimc->ad1848, optimc_wss_dma[val & 3]);
-    ad1848_setirq(&optimc->ad1848, optimc_wss_irq[(val >> 3) & 7]);
+    ad1848_setirq(&optimc->ad1848, optimc_wss_irq[val & 3]);
 }
 
 static void


### PR DESCRIPTION
Summary
=======
Corrected bug introduced by earlier pull request which broke WSS audio in Windows.

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
