### PR TITLE
qt: Don't resize renderer screen beyond window size

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -261,7 +261,7 @@ MainWindow::MainWindow(QWidget *parent)
                 + (statusBar()->height() * !hide_status_bar)
                 + (ui->toolBar->height() * !hide_tool_bar);
 
-            ui->stackedWidget->resize(w, h);
+            ui->stackedWidget->resize(w, (h / (!dpi_scale ? util::screenOfWidget(this)->devicePixelRatio() : 1.)));
             setFixedSize(w, modifiedHeight);
         }
     });


### PR DESCRIPTION
Summary
=======
qt: Don't resize renderer screen beyond window size

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
