### PR TITLE
Time sync now works correctly with Vendex RTC

### DIFF
--- a/src/device/isartc.c
+++ b/src/device/isartc.c
@@ -546,7 +546,7 @@ isartc_init(const device_t *info)
             break;
 
         case ISARTC_VENDEX: /* Vendex HeadStart Turbo 888-XT RTC */
-            dev->flags |= FLAG_YEAR80;
+            dev->flags |= FLAG_YEAR80 | FLAG_YEARBCD;
             dev->base_addr   = 0x0300;
             dev->base_addrsz = 32;
             dev->f_rd        = mm67_read;


### PR DESCRIPTION
Summary
=======
Time sync now works correctly with Vendex RTC.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
