### PR TITLE
Add a version of the XTIDE Universal BIOS for V20/V30 CPUs

### DIFF
--- a/src/disk/hdc.c
+++ b/src/disk/hdc.c
@@ -103,6 +103,7 @@ static const struct {
     { &xta_wdxt150_device          },
     { &xtide_acculogic_device      },
     { &xtide_device                },
+    { &xtide_plus_device           },
     { &esdi_ps2_device             },
     { &ide_pci_device              },
     { &ide_pci_2ch_device          },

--- a/src/disk/hdc_xtide.c
+++ b/src/disk/hdc_xtide.c
@@ -45,6 +45,7 @@
 #include <86box/hdc_ide.h>
 
 #define ROM_PATH_XT     "roms/hdd/xtide/ide_xt.bin"
+#define ROM_PATH_XTP    "roms/hdd/xtide/ide_xtp.bin"
 #define ROM_PATH_AT     "roms/hdd/xtide/ide_at.bin"
 #define ROM_PATH_PS2    "roms/hdd/xtide/SIDE1V12.BIN"
 #define ROM_PATH_PS2AT  "roms/hdd/xtide/ide_at_1_1_5.bin"
@@ -130,8 +131,13 @@ xtide_init(const device_t *info)
 
     memset(xtide, 0x00, sizeof(xtide_t));
 
-    rom_init(&xtide->bios_rom, ROM_PATH_XT,
-             0xc8000, 0x2000, 0x1fff, 0, MEM_MAPPING_EXTERNAL);
+    if (info->local == 1) {
+        rom_init(&xtide->bios_rom, ROM_PATH_XTP,
+                 0xc8000, 0x2000, 0x1fff, 0, MEM_MAPPING_EXTERNAL);
+    } else {
+        rom_init(&xtide->bios_rom, ROM_PATH_XT,
+                 0xc8000, 0x2000, 0x1fff, 0, MEM_MAPPING_EXTERNAL);
+    }
 
     xtide->ide_board = ide_xtide_init();
 
@@ -146,6 +152,12 @@ static int
 xtide_available(void)
 {
     return (rom_present(ROM_PATH_XT));
+}
+
+static int
+xtide_plus_available(void)
+{
+    return (rom_present(ROM_PATH_XTP));
 }
 
 static void *
@@ -253,6 +265,20 @@ const device_t xtide_device = {
     .close         = xtide_close,
     .reset         = NULL,
     { .available = xtide_available },
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = NULL
+};
+
+const device_t xtide_plus_device = {
+    .name          = "PC/XT XTIDE (V20/V30/8018x)",
+    .internal_name = "xtide_plus",
+    .flags         = DEVICE_ISA,
+    .local         = 1,
+    .init          = xtide_init,
+    .close         = xtide_close,
+    .reset         = NULL,
+    { .available = xtide_plus_available },
     .speed_changed = NULL,
     .force_redraw  = NULL,
     .config        = NULL

--- a/src/include/86box/hdc.h
+++ b/src/include/86box/hdc.h
@@ -79,6 +79,7 @@ extern const device_t xta_wdxt150_device; /* xta_wdxt150 */
 extern const device_t xta_hd20_device;    /* EuroPC internal */
 
 extern const device_t xtide_device;           /* xtide_xt */
+extern const device_t xtide_plus_device;      /* xtide_xt_plus */
 extern const device_t xtide_at_device;        /* xtide_at */
 extern const device_t xtide_at_386_device;    /* xtide_at_386 */
 extern const device_t xtide_acculogic_device; /* xtide_ps2 */


### PR DESCRIPTION
Summary
=======
Adds a new "XT+" version of the XTIDE Universal BIOS for V20/V30/186/188 compatible CPUs.
Note that booting from hard drives will fail due to #2939. Other functions work fine.

![image](https://user-images.githubusercontent.com/2708460/205506141-a83aa810-76e0-4451-a889-92678fc6aa9d.png)

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/191/
