### PR TITLE
qt: Display architecture information in About box

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -75,6 +75,7 @@ extern int qt_nvr_save(void);
 #include <QScreen>
 #include <QString>
 #include <QDir>
+#include <QSysInfo>
 #if QT_CONFIG(vulkan)
 #    include <QVulkanInstance>
 #    include <QVulkanFunctions>
@@ -2098,6 +2099,7 @@ MainWindow::on_actionAbout_86Box_triggered()
 #ifdef EMU_GIT_HASH
     githash = QString(" [%1]").arg(EMU_GIT_HASH);
 #endif
+    githash.append(QString(" [%1]").arg(QSysInfo::buildCpuArchitecture());
     msgBox.setText(QString("<b>%3%1%2</b>").arg(EMU_VERSION_FULL, githash, tr("86Box v")));
     msgBox.setInformativeText(tr("An emulator of old computers\n\nAuthors: Sarah Walker, Miran Grca, Fred N. van Kempen (waltje), SA1988, Tiseno100, reenigne, leilei, JohnElliott, greatpsycho, and others.\n\nReleased under the GNU General Public License version 2 or later. See LICENSE for more information."));
     msgBox.setWindowTitle("About 86Box");

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -2099,7 +2099,7 @@ MainWindow::on_actionAbout_86Box_triggered()
 #ifdef EMU_GIT_HASH
     githash = QString(" [%1]").arg(EMU_GIT_HASH);
 #endif
-    githash.append(QString(" [%1]").arg(QSysInfo::buildCpuArchitecture());
+    githash.append(QString(" [%1]").arg(QSysInfo::buildCpuArchitecture()));
     msgBox.setText(QString("<b>%3%1%2</b>").arg(EMU_VERSION_FULL, githash, tr("86Box v")));
     msgBox.setInformativeText(tr("An emulator of old computers\n\nAuthors: Sarah Walker, Miran Grca, Fred N. van Kempen (waltje), SA1988, Tiseno100, reenigne, leilei, JohnElliott, greatpsycho, and others.\n\nReleased under the GNU General Public License version 2 or later. See LICENSE for more information."));
     msgBox.setWindowTitle("About 86Box");


### PR DESCRIPTION
Summary
=======
qt: Display architecture information in About box

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
