### PR TITLE
Add Slot1 to Socket 8 slotket

### DIFF
--- a/src/cpu/cpu.c
+++ b/src/cpu/cpu.c
@@ -235,7 +235,7 @@ cpu_is_eligible(const cpu_family_t *cpu_family, int cpu, int machine)
     if (packages & CPU_PKG_SOCKET3)
         packages |= CPU_PKG_SOCKET1;
     else if (packages & CPU_PKG_SLOT1)
-        packages |= CPU_PKG_SOCKET370;
+        packages |= CPU_PKG_SOCKET370 | CPU_PKG_SOCKET8;
 
     /* Package type. */
     if (!(cpu_family->package & packages))


### PR DESCRIPTION

Summary
=======
Add Slot1 to Socket 8 slotket
One such example is the ASUS C-P6S1

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://www.cpushack.com/2020/09/09/finding-the-limits-of-the-socket-8/
https://arstechnica.com/civis/threads/looking-for-a-socket-8-to-slot-1-converter-riser-card-asus-c-p6s1.1118291/