### PR TITLE
vid_mga: Fix Matrox Mystique MGA modes

### DIFF
--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -848,7 +848,7 @@ mystique_recalctimings(svga_t *svga)
     mystique_t *mystique = (mystique_t *) svga->p;
     int         clk_sel  = (svga->miscout >> 2) & 3;
 
-    svga->clock = (cpuclock * (float) (1ull << 32)) / svga->getclock(clk_sel & 2, svga->clock_gen);
+    svga->clock = (cpuclock * (float) (1ull << 32)) / svga->getclock(clk_sel & 3, svga->clock_gen);
 
     if (mystique->crtcext_regs[1] & CRTCX_R1_HTOTAL8)
         svga->htotal += 0x100;
@@ -896,7 +896,9 @@ mystique_recalctimings(svga_t *svga)
                     svga->ma = svga->maback = (svga->maback - (mystique->ma_latch_old << 2)) + (svga->ma_latch << 2);
                 mystique->ma_latch_old = svga->ma_latch;
             }
-
+            
+            svga->rowoffset <<= 1;
+            
             switch (mystique->xmulctrl & XMULCTRL_DEPTH_MASK) {
                 case XMULCTRL_DEPTH_8:
                 case XMULCTRL_DEPTH_2G8V16:


### PR DESCRIPTION
Summary
=======
vid_mga: Fix Matrox Mystique MGA modes

Clock selection now works properly

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
