### PR TITLE
Fix QDI EXCELLENT II to have an AGP slot as it's supposed to.

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -10852,7 +10852,7 @@ const machine_t machines[] = {
             .min_multi = 3.0,
             .max_multi = 8.0
         },
-        .bus_flags = MACHINE_PS2_PCI,
+        .bus_flags = MACHINE_PS2_AGP,
         .flags = MACHINE_IDE_DUAL,
         .ram = {
             .min = 8192,


### PR DESCRIPTION
Summary
=======
Fixed the QDI EXCELLENT II (Slot 1, i440EX) to have an AGP slot, as the actual board itself also has one [as can be seen in it's user manual](https://www.manualslib.com/manual/2297520/Qdi-P6i440ex-Matx-Excellent-Ii.html?page=23).

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://www.manualslib.com/manual/2297520/Qdi-P6i440ex-Matx-Excellent-Ii.html?page=23
https://www.osta.ee/en/legend-qdi-p61440exmatx-excellent-ii-celeron-300a-143346542.html
