### PR TITLE
Get rid of VLA's in voodoo_banshee.c and voodoo_display.c

### DIFF
--- a/src/video/vid_voodoo_banshee.c
+++ b/src/video/vid_voodoo_banshee.c
@@ -2350,7 +2350,7 @@ banshee_overlay_draw(svga_t *svga, int displine)
                     uint8_t *samp3 = malloc(64 * 3);
                     uint8_t *samp4 = malloc((svga->overlay_latch.cur_xsize) * 3);
 
-                    assert(svga->overlay_latch.xsize <= 64);
+                    assert(svga->overlay_latch.cur_xsize <= 64);
                     src = &svga->vram[src_addr2 & svga->vram_mask];
                     OVERLAY_SAMPLE(banshee->overlay_buffer[1]);
                     for (x = 0; x < svga->overlay_latch.cur_xsize; x++) {

--- a/src/video/vid_voodoo_banshee.c
+++ b/src/video/vid_voodoo_banshee.c
@@ -2348,7 +2348,7 @@ banshee_overlay_draw(svga_t *svga, int displine)
                     uint8_t *samp1 = malloc(64 * 3);
                     uint8_t *samp2 = malloc(64 * 3);
                     uint8_t *samp3 = malloc(64 * 3);
-                    uint8_t *samp4 = malloc((svga->overlay_latch.cur_xsize) * 3);
+                    uint8_t *samp4 = malloc(64 * 3);
 
                     assert(svga->overlay_latch.cur_xsize <= 64);
                     src = &svga->vram[src_addr2 & svga->vram_mask];

--- a/src/video/vid_voodoo_banshee.c
+++ b/src/video/vid_voodoo_banshee.c
@@ -14,6 +14,7 @@
  *
  *          Copyright 2008-2020 Sarah Walker.
  */
+#include <assert.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdint.h>
@@ -2267,9 +2268,10 @@ banshee_overlay_draw(svga_t *svga, int displine)
 
             case VIDPROCCFG_FILTER_MODE_DITHER_4X4:
                 if (banshee->voodoo->scrfilter && banshee->voodoo->scrfilterEnabled) {
-                    uint8_t *fil  = malloc((svga->overlay_latch.cur_xsize) * 3);
-                    uint8_t *fil3 = malloc((svga->overlay_latch.cur_xsize) * 3);
+                    uint8_t *fil  = malloc(64 * 3);
+                    uint8_t *fil3 = malloc(64 * 3);
 
+                    assert(svga->overlay_latch.xsize <= 64)
                     if (banshee->vidProcCfg & VIDPROCCFG_H_SCALE_ENABLE) /* leilei HACK - don't know of real 4x1 hscaled behavior yet, double for now */
                     {
                         for (x = 0; x < svga->overlay_latch.cur_xsize; x++) {
@@ -2339,15 +2341,16 @@ banshee_overlay_draw(svga_t *svga, int displine)
 
             case VIDPROCCFG_FILTER_MODE_DITHER_2X2:
                 if (banshee->voodoo->scrfilter && banshee->voodoo->scrfilterEnabled) {
-                    uint8_t *fil   = malloc((svga->overlay_latch.cur_xsize) * 3);
-                    uint8_t *soak  = malloc((svga->overlay_latch.cur_xsize) * 3);
-                    uint8_t *soak2 = malloc((svga->overlay_latch.cur_xsize) * 3);
+                    uint8_t *fil   = malloc(64 * 3);
+                    uint8_t *soak  = malloc(64 * 3);
+                    uint8_t *soak2 = malloc(64 * 3);
 
-                    uint8_t *samp1 = malloc((svga->overlay_latch.cur_xsize) * 3);
-                    uint8_t *samp2 = malloc((svga->overlay_latch.cur_xsize) * 3);
-                    uint8_t *samp3 = malloc((svga->overlay_latch.cur_xsize) * 3);
+                    uint8_t *samp1 = malloc(64 * 3);
+                    uint8_t *samp2 = malloc(64 * 3);
+                    uint8_t *samp3 = malloc(64 * 3);
                     uint8_t *samp4 = malloc((svga->overlay_latch.cur_xsize) * 3);
 
+                    assert(svga->overlay_latch.xsize <= 64);
                     src = &svga->vram[src_addr2 & svga->vram_mask];
                     OVERLAY_SAMPLE(banshee->overlay_buffer[1]);
                     for (x = 0; x < svga->overlay_latch.cur_xsize; x++) {

--- a/src/video/vid_voodoo_banshee.c
+++ b/src/video/vid_voodoo_banshee.c
@@ -2271,7 +2271,7 @@ banshee_overlay_draw(svga_t *svga, int displine)
                     uint8_t *fil  = malloc(64 * 3);
                     uint8_t *fil3 = malloc(64 * 3);
 
-                    assert(svga->overlay_latch.xsize <= 64);
+                    assert(svga->overlay_latch.cur_xsize <= 64);
                     if (banshee->vidProcCfg & VIDPROCCFG_H_SCALE_ENABLE) /* leilei HACK - don't know of real 4x1 hscaled behavior yet, double for now */
                     {
                         for (x = 0; x < svga->overlay_latch.cur_xsize; x++) {

--- a/src/video/vid_voodoo_banshee.c
+++ b/src/video/vid_voodoo_banshee.c
@@ -2271,7 +2271,7 @@ banshee_overlay_draw(svga_t *svga, int displine)
                     uint8_t *fil  = malloc(64 * 3);
                     uint8_t *fil3 = malloc(64 * 3);
 
-                    assert(svga->overlay_latch.xsize <= 64)
+                    assert(svga->overlay_latch.xsize <= 64);
                     if (banshee->vidProcCfg & VIDPROCCFG_H_SCALE_ENABLE) /* leilei HACK - don't know of real 4x1 hscaled behavior yet, double for now */
                     {
                         for (x = 0; x < svga->overlay_latch.cur_xsize; x++) {

--- a/src/video/vid_voodoo_display.c
+++ b/src/video/vid_voodoo_display.c
@@ -374,7 +374,7 @@ voodoo_filterline_v1(voodoo_t *voodoo, uint8_t *fil, int column, uint16_t *src, 
     int x;
 
     // Scratchpad for avoiding feedback streaks
-    uint8_t *fil3[4096 * 3];
+    uint8_t *fil3 = malloc(4096 * 3);
 
     assert(voodoo->h_disp <= 4096);
 
@@ -435,7 +435,7 @@ voodoo_filterline_v2(voodoo_t *voodoo, uint8_t *fil, int column, uint16_t *src, 
     int x;
 
     // Scratchpad for blending filter
-    uint8_t *fil3[4096 * 3];
+    uint8_t *fil3= malloc(4096 * 3);
 
     assert(voodoo->h_disp <= 4096);
 
@@ -542,7 +542,7 @@ voodoo_callback(void *p)
                     monitor->target_buffer->line[voodoo->line + 8][x] = 0x00000000;
 
                 if (voodoo->scrfilter && voodoo->scrfilterEnabled) {
-                    uint8_t *fil[4096 * 3]; /* interleaved 24-bit RGB */
+                    uint8_t *fil = malloc(4096 * 3); /* interleaved 24-bit RGB */
 
                     assert(voodoo->h_disp <= 4096);
 

--- a/src/video/vid_voodoo_display.c
+++ b/src/video/vid_voodoo_display.c
@@ -14,6 +14,7 @@
  *
  *          Copyright 2008-2020 Sarah Walker.
  */
+#include <assert.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdint.h>
@@ -373,7 +374,9 @@ voodoo_filterline_v1(voodoo_t *voodoo, uint8_t *fil, int column, uint16_t *src, 
     int x;
 
     // Scratchpad for avoiding feedback streaks
-    uint8_t *fil3 = malloc((voodoo->h_disp) * 3);
+    uint8_t fil3[4096 * 3];
+
+    assert(voodoo->h_disp <= 4096);
 
     /* 16 to 32-bit */
     for (x = 0; x < column; x++) {
@@ -432,7 +435,9 @@ voodoo_filterline_v2(voodoo_t *voodoo, uint8_t *fil, int column, uint16_t *src, 
     int x;
 
     // Scratchpad for blending filter
-    uint8_t *fil3 = malloc((voodoo->h_disp) * 3);
+    uint8_t fil3[4096 * 3];
+
+    assert(voodoo->h_disp <= 4096);
 
     /* 16 to 32-bit */
     for (x = 0; x < column; x++) {
@@ -537,7 +542,9 @@ voodoo_callback(void *p)
                     monitor->target_buffer->line[voodoo->line + 8][x] = 0x00000000;
 
                 if (voodoo->scrfilter && voodoo->scrfilterEnabled) {
-                    uint8_t *fil = malloc((voodoo->h_disp) * 3); /* interleaved 24-bit RGB */
+                    uint8_t fil[4096 * 3]; /* interleaved 24-bit RGB */
+
+                    assert(voodoo->h_disp <= 4096);
 
                     if (voodoo->type == VOODOO_2)
                         voodoo_filterline_v2(voodoo, fil, voodoo->h_disp, src, voodoo->line);

--- a/src/video/vid_voodoo_display.c
+++ b/src/video/vid_voodoo_display.c
@@ -374,7 +374,7 @@ voodoo_filterline_v1(voodoo_t *voodoo, uint8_t *fil, int column, uint16_t *src, 
     int x;
 
     // Scratchpad for avoiding feedback streaks
-    uint8_t fil3[4096 * 3];
+    uint8_t *fil3[4096 * 3];
 
     assert(voodoo->h_disp <= 4096);
 
@@ -435,7 +435,7 @@ voodoo_filterline_v2(voodoo_t *voodoo, uint8_t *fil, int column, uint16_t *src, 
     int x;
 
     // Scratchpad for blending filter
-    uint8_t fil3[4096 * 3];
+    uint8_t *fil3[4096 * 3];
 
     assert(voodoo->h_disp <= 4096);
 
@@ -542,7 +542,7 @@ voodoo_callback(void *p)
                     monitor->target_buffer->line[voodoo->line + 8][x] = 0x00000000;
 
                 if (voodoo->scrfilter && voodoo->scrfilterEnabled) {
-                    uint8_t fil[4096 * 3]; /* interleaved 24-bit RGB */
+                    uint8_t *fil[4096 * 3]; /* interleaved 24-bit RGB */
 
                     assert(voodoo->h_disp <= 4096);
 


### PR DESCRIPTION
Summary
=======
Get rid of VLA's in voodoo_banshee.c and voodoo_display.c

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[pcem PR#199](https://github.com/sarah-walker-pcem/pcem/pull/199)
