### PR TITLE
Display dynarec information in the About box

### DIFF
--- a/src/include/86box/language.h
+++ b/src/include/86box/language.h
@@ -150,6 +150,18 @@
 #define IDS_2160      2160 // "ACPI shutdown"
 #define IDS_2161      2161 // "Settings"
 #define IDS_2162      2162 // "Early drive"
+#define IDS_2163      2163 // "no dynarec"
+#define IDS_2164      2164 // "old dynarec"
+#define IDS_2165      2165 // "new dynarec"
+#ifdef USE_DYNAREC
+#    ifdef USE_NEW_DYNAREC
+#        define IDS_DYNAREC IDS_2165
+#    else
+#        define IDS_DYNAREC IDS_2164
+#    endif
+#else
+#    define IDS_DYNAREC IDS_2163
+#endif
 
 #define IDS_4096      4096 // "Hard disk (%s)"
 #define IDS_4097      4097 // "%01i:%01i"
@@ -258,7 +270,7 @@
 
 #define IDS_LANG_ENUS IDS_7168
 
-#define STR_NUM_2048  115
+#define STR_NUM_2048  118
 // UNUSED: #define STR_NUM_3072  11
 #define STR_NUM_4096 40
 #define STR_NUM_4352 6

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -2095,12 +2095,21 @@ MainWindow::on_actionAbout_86Box_triggered()
 {
     QMessageBox msgBox;
     msgBox.setTextFormat(Qt::RichText);
-    QString githash;
+    QString versioninfo;
 #ifdef EMU_GIT_HASH
-    githash = QString(" [%1]").arg(EMU_GIT_HASH);
+    versioninfo = QString(" [%1]").arg(EMU_GIT_HASH);
 #endif
-    githash.append(QString(" [%1]").arg(QSysInfo::buildCpuArchitecture()));
-    msgBox.setText(QString("<b>%3%1%2</b>").arg(EMU_VERSION_FULL, githash, tr("86Box v")));
+#ifdef USE_DYNAREC
+#    ifdef USE_NEW_DYNAREC
+#        define DYNAREC_STR "new dynarec"
+#    else
+#        define DYNAREC_STR "old dynarec"
+#    endif
+#else
+#    define DYNAREC_STR "no dynarec"
+#endif
+    versioninfo.append(QString(" [%1, %2]").arg(QSysInfo::buildCpuArchitecture(), tr(DYNAREC_STR)));
+    msgBox.setText(QString("<b>%3%1%2</b>").arg(EMU_VERSION_FULL, versioninfo, tr("86Box v")));
     msgBox.setInformativeText(tr("An emulator of old computers\n\nAuthors: Sarah Walker, Miran Grca, Fred N. van Kempen (waltje), SA1988, Tiseno100, reenigne, leilei, JohnElliott, greatpsycho, and others.\n\nReleased under the GNU General Public License version 2 or later. See LICENSE for more information."));
     msgBox.setWindowTitle("About 86Box");
     msgBox.addButton("OK", QMessageBox::ButtonRole::AcceptRole);

--- a/src/win/languages/cs-CZ.rc
+++ b/src/win/languages/cs-CZ.rc
@@ -522,6 +522,9 @@ BEGIN
     IDS_2160	"Vypnout skrze rozhraní ACPI"
     IDS_2161	"Nastavení"
     IDS_2162    "Časná mechanika"
+    IDS_2163    "no dynarec"
+    IDS_2164    "old dynarec"
+    IDS_2165    "new dynarec"
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/de-DE.rc
+++ b/src/win/languages/de-DE.rc
@@ -522,6 +522,9 @@ BEGIN
     IDS_2160	"ACPI-basiertes Herunterfahren"
     IDS_2161	"Optionen"
     IDS_2162    "Früheres Laufwerk"
+    IDS_2163    "no dynarec"
+    IDS_2164    "old dynarec"
+    IDS_2165    "new dynarec"
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/en-GB.rc
+++ b/src/win/languages/en-GB.rc
@@ -522,6 +522,9 @@ BEGIN
     IDS_2160	"ACPI shutdown"
     IDS_2161	"Settings"
     IDS_2162    "Earlier drive"
+    IDS_2163    "no dynarec"
+    IDS_2164    "old dynarec"
+    IDS_2165    "new dynarec"
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/en-US.rc
+++ b/src/win/languages/en-US.rc
@@ -522,6 +522,9 @@ BEGIN
     IDS_2160	"ACPI shutdown"
     IDS_2161	"Settings"
     IDS_2162    "Earlier drive"
+    IDS_2163    "no dynarec"
+    IDS_2164    "old dynarec"
+    IDS_2165    "new dynarec"
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/es-ES.rc
+++ b/src/win/languages/es-ES.rc
@@ -522,6 +522,9 @@ BEGIN
     IDS_2160	"ACPI shutdown"
     IDS_2161	"Settings"
     IDS_2162    "Unidad anterior"
+    IDS_2163    "no dynarec"
+    IDS_2164    "old dynarec"
+    IDS_2165    "new dynarec"
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/fi-FI.rc
+++ b/src/win/languages/fi-FI.rc
@@ -522,6 +522,9 @@ BEGIN
     IDS_2160	"ACPI-sammutus"
     IDS_2161	"Asetukset"
     IDS_2162    "Aiemmat asemat"
+    IDS_2163    "no dynarec"
+    IDS_2164    "old dynarec"
+    IDS_2165    "new dynarec"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/fr-FR.rc
+++ b/src/win/languages/fr-FR.rc
@@ -522,6 +522,9 @@ BEGIN
     IDS_2160	"ACPI shutdown"
     IDS_2161	"Settings"
     IDS_2162    "Lecteur plus tôt"
+    IDS_2163    "no dynarec"
+    IDS_2164    "old dynarec"
+    IDS_2165    "new dynarec"
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/hr-HR.rc
+++ b/src/win/languages/hr-HR.rc
@@ -522,6 +522,9 @@ BEGIN
     IDS_2160	"ACPI bazirano gašenje"
     IDS_2161	"Postavke"
     IDS_2162    "Raniji pogon"
+    IDS_2163    "no dynarec"
+    IDS_2164    "old dynarec"
+    IDS_2165    "new dynarec"
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/hu-HU.rc
+++ b/src/win/languages/hu-HU.rc
@@ -526,6 +526,9 @@ BEGIN
     IDS_2160	"ACPI shutdown"
     IDS_2161	"Settings"
     IDS_2162    "Korábbi meghajtó"
+    IDS_2163    "no dynarec"
+    IDS_2164    "old dynarec"
+    IDS_2165    "new dynarec"
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/it-IT.rc
+++ b/src/win/languages/it-IT.rc
@@ -523,6 +523,9 @@ BEGIN
     IDS_2160	"ACPI shutdown"
     IDS_2161	"Settings"
     IDS_2162    "Unità anteriore"
+    IDS_2163    "no dynarec"
+    IDS_2164    "old dynarec"
+    IDS_2165    "new dynarec"
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/ja-JP.rc
+++ b/src/win/languages/ja-JP.rc
@@ -522,6 +522,9 @@ BEGIN
     IDS_2160	"ACPIシャットダウン"
     IDS_2161	"設定"
     IDS_2162    "アーリードライブ"
+    IDS_2163    "no dynarec"
+    IDS_2164    "old dynarec"
+    IDS_2165    "new dynarec"
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/ko-KR.rc
+++ b/src/win/languages/ko-KR.rc
@@ -522,6 +522,9 @@ BEGIN
     IDS_2160	"ACPI 종료"
     IDS_2161	"설정"
     IDS_2162    "이전 드라이브"
+    IDS_2163    "no dynarec"
+    IDS_2164    "old dynarec"
+    IDS_2165    "new dynarec"
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/pl-PL.rc
+++ b/src/win/languages/pl-PL.rc
@@ -522,6 +522,9 @@ BEGIN
     IDS_2160	"Wyłączenie ACPI"
     IDS_2161	"Ustawienia"
     IDS_2162    "Wcześniejszy napęd"
+    IDS_2163    "no dynarec"
+    IDS_2164    "old dynarec"
+    IDS_2165    "new dynarec"
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/pt-BR.rc
+++ b/src/win/languages/pt-BR.rc
@@ -525,6 +525,9 @@ BEGIN
     IDS_2160	"Desligamento por ACPI"
     IDS_2161	"Configurações"
     IDS_2162    "Unidade anterior"
+    IDS_2163    "no dynarec"
+    IDS_2164    "old dynarec"
+    IDS_2165    "new dynarec"
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/pt-PT.rc
+++ b/src/win/languages/pt-PT.rc
@@ -522,6 +522,9 @@ BEGIN
     IDS_2160	"Encerramento ACPI"
     IDS_2161	"Definições"
     IDS_2162    "Unidade anterior"
+    IDS_2163    "no dynarec"
+    IDS_2164    "old dynarec"
+    IDS_2165    "new dynarec"
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/ru-RU.rc
+++ b/src/win/languages/ru-RU.rc
@@ -522,6 +522,9 @@ BEGIN
     IDS_2160	"Сигнал завершения ACPI"
     IDS_2161	"Настройки машины"
     IDS_2162    "Предыдущий дисковод"
+    IDS_2163    "no dynarec"
+    IDS_2164    "old dynarec"
+    IDS_2165    "new dynarec"
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/sl-SI.rc
+++ b/src/win/languages/sl-SI.rc
@@ -522,6 +522,9 @@ BEGIN
     IDS_2160	"Zaustavitev ACPI"
     IDS_2161	"Nastavitve"
     IDS_2162    "Zgodnejši pogon"
+    IDS_2163    "no dynarec"
+    IDS_2164    "old dynarec"
+    IDS_2165    "new dynarec"
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/tr-TR.rc
+++ b/src/win/languages/tr-TR.rc
@@ -522,6 +522,9 @@ BEGIN
     IDS_2160	"ACPI kapatma"
     IDS_2161	"Ayarlar"
     IDS_2162    "Daha erken sürüş"
+    IDS_2163    "no dynarec"
+    IDS_2164    "old dynarec"
+    IDS_2165    "new dynarec"
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/uk-UA.rc
+++ b/src/win/languages/uk-UA.rc
@@ -522,6 +522,9 @@ BEGIN
     IDS_2160 "Сигнал завершення ACPI"
     IDS_2161 "Налаштування машини"
     IDS_2162    "Більш ранній дисковод"
+    IDS_2163    "no dynarec"
+    IDS_2164    "old dynarec"
+    IDS_2165    "new dynarec"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/zh-CN.rc
+++ b/src/win/languages/zh-CN.rc
@@ -522,6 +522,9 @@ BEGIN
     IDS_2160	"ACPI 关机"
     IDS_2161	"设置"
     IDS_2162    "早先的驱动器"
+    IDS_2163    "no dynarec"
+    IDS_2164    "old dynarec"
+    IDS_2165    "new dynarec"
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/languages/zh-TW.rc
+++ b/src/win/languages/zh-TW.rc
@@ -522,6 +522,9 @@ BEGIN
     IDS_2160	"ACPI 關機"
     IDS_2161	"設定"
     IDS_2162    "早先的光碟機"
+    IDS_2163    "no dynarec"
+    IDS_2164    "old dynarec"
+    IDS_2165    "new dynarec"
 END
 
 STRINGTABLE DISCARDABLE 

--- a/src/win/win_about.c
+++ b/src/win/win_about.c
@@ -45,8 +45,21 @@ AboutDialogCreate(HWND hwnd)
     wchar_t emu_version[256];
     i = swprintf(emu_version, sizeof(emu_version), L"%ls v%ls", EMU_NAME_W, EMU_VERSION_FULL_W);
 #ifdef EMU_GIT_HASH
-    swprintf(&emu_version[i], sizeof(emu_version) - i, L" [%ls]", EMU_GIT_HASH_W);
+    i += swprintf(&emu_version[i], sizeof(emu_version) - i, L" [%ls]", EMU_GIT_HASH_W);
 #endif
+
+#if defined(__arm__) || defined(__TARGET_ARCH_ARM)
+#    define ARCH_STR L"arm"
+#elif defined(__aarch64__) || defined(_M_ARM64)
+#    define ARCH_STR L"arm64"
+#elif defined(__i386) || defined(__i386__) || defined(_M_IX86)
+#    define ARCH_STR L"i386"
+#elif defined(__x86_64) || defined(__x86_64__) || defined(__amd64) || defined(_M_X64)
+#    define ARCH_STR L"x86_64"
+#else
+#    define ARCH_STR L"unknown"
+#endif
+    swprintf(&emu_version[i], sizeof(emu_version) - i, L" [%ls, %ls]", ARCH_STR, plat_get_string(IDS_DYNAREC));
 
     tdconfig.cbSize             = sizeof(tdconfig);
     tdconfig.hwndParent         = hwnd;


### PR DESCRIPTION
Summary
=======
Adds information on what dynarec 86Box was compiled with (old, new or none) in the About box.

Done for both Qt and Win32 UIs; for the latter, architecture info was added as well.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
