### PR TITLE
qt: Display device name separately in device configuration

### DIFF
--- a/src/qt/qt_deviceconfig.cpp
+++ b/src/qt/qt_deviceconfig.cpp
@@ -25,6 +25,8 @@
 #include <QFormLayout>
 #include <QSpinBox>
 #include <QCheckBox>
+#include <QFrame>
+#include <QLabel>
 
 extern "C" {
 #include <86box/86box.h>
@@ -61,6 +63,12 @@ DeviceConfig::ConfigureDevice(const _device_ *device, int instance, Settings *se
     device_context_t device_context;
     device_set_context(&device_context, device, instance);
 
+    auto device_label = new QLabel(device->name);
+    dc.ui->formLayout->addRow(device_label);
+    auto line = new QFrame;
+    line->setFrameShape(QFrame::HLine);
+    line->setFrameShadow(QFrame::Sunken);
+    dc.ui->formLayout->addRow(line);
     const auto *config = device->config;
     while (config->type != -1) {
         switch (config->type) {


### PR DESCRIPTION
Summary
=======
qt: Display device name separately in device configuration

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
