### PR TITLE
Add PS/2 mouse support for TriGem 486G and bump Gigabyte GA-586IP's RAM limit to 256MB

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -5786,7 +5786,7 @@ const machine_t machines[] = {
             .min_multi = 0,
             .max_multi = 0
         },
-        .bus_flags = MACHINE_VLB,
+        .bus_flags = MACHINE_PS2_VLB,
         .flags = MACHINE_IDE,
         .ram = {
             .min = 1024,
@@ -7684,7 +7684,7 @@ const machine_t machines[] = {
         .flags = MACHINE_IDE_DUAL,
         .ram = {
             .min = 2048,
-            .max = 131072,
+            .max = 262144,
             .step = 2048
         },
         .nvrmask = 127,


### PR DESCRIPTION
Summary
=======
Added PS/2 mouse support for TriGem 486G (which I forgot to add) and bumped Gigabyte GA-586IP's RAM limit to 256MB (tested, works perfectly, although the user manual states a 768MB RAM limit)

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[TriGem 486G page on The Retro Web](https://theretroweb.com/motherboards/s/trigem-486gm)
[Gigabyte GA-586IP User Manual](https://theretroweb.com/motherboard/manual/5ip-9412-5f93528866e94941858988.pdf)
