### PR TITLE
qt: Reload renderer of main monitor when multiple monitors are shown

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -723,6 +723,7 @@ MainWindow::destroyRendererMonitorSlot(int monitor_index)
         }
         config_save();
         this->renderers[monitor_index].release()->deleteLater();
+        ui->stackedWidget->switchRenderer((RendererStack::Renderer) vid_api);
     }
 }
 
@@ -2378,6 +2379,7 @@ MainWindow::on_actionShow_non_primary_monitors_triggered()
                                                monitor_settings[monitor_index].mon_window_h > 2048 ? 2048 : monitor_settings[monitor_index].mon_window_h);
             }
             secondaryRenderer->switchRenderer((RendererStack::Renderer) vid_api);
+            ui->stackedWidget->switchRenderer((RendererStack::Renderer) vid_api);
         }
     } else {
         for (int monitor_index = 1; monitor_index < MONITORS_NUM; monitor_index++) {


### PR DESCRIPTION
Summary
=======
qt: Reload renderer of main monitor when multiple monitors are shown

Fixes broken screen on hard resets when multiple monitors are used.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
