### PR TITLE
Add Gemlight GMB-P54SPS (SiS 501, Socket 5)

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -568,6 +568,7 @@ extern int machine_at_hot543_init(const machine_t *);
 
 extern int machine_at_p54sp4_init(const machine_t *);
 extern int machine_at_sq588_init(const machine_t *);
+extern int machine_at_p54sps_init(const machine_t *);
 
 /* m_at_socket7_3v.c */
 extern int machine_at_p54tp4xe_init(const machine_t *);

--- a/src/machine/m_at_socket5.c
+++ b/src/machine/m_at_socket5.c
@@ -344,3 +344,32 @@ machine_at_sq588_init(const machine_t *model)
 
     return ret;
 }
+
+int
+machine_at_p54sps_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/p54sps/35s106.bin",
+                           0x000e0000, 131072, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_common_init(model);
+
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x01, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x06, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x07, PCI_CARD_NORMAL, 2, 3, 4, 1);
+    pci_register_slot(0x08, PCI_CARD_NORMAL, 3, 4, 1, 2);
+    pci_register_slot(0x09, PCI_CARD_NORMAL, 4, 1, 2, 3);
+    device_add(&sis_85c50x_device);
+    device_add(&ide_pci_2ch_device);
+    device_add(&keyboard_at_ami_device);
+    device_add(&w83787f_device);
+    device_add(&sst_flash_29ee010_device);
+
+    return ret;
+}

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -8040,6 +8040,43 @@ const machine_t machines[] = {
         .snd_device = NULL,
         .net_device = NULL
     },
+    /* This machine has a Winbond W83C842 KBC */
+    {
+        .name = "[SiS 501] Gemlight GMB-P54SPS",
+        .internal_name = "p54sps",
+        .type = MACHINE_TYPE_SOCKET5,
+        .chipset = MACHINE_CHIPSET_SIS_501,
+        .init = machine_at_p54sps_init,
+        .pad = 0,
+        .pad0 = 0,
+        .pad1 = MACHINE_AVAILABLE,
+        .pad2 = 0,
+        .cpu = {
+            .package = CPU_PKG_SOCKET5_7,
+        CPU_BLOCK(CPU_PENTIUMMMX),
+            .min_bus = 50000000,
+            .max_bus = 66666667,
+            .min_voltage = 3520,
+            .max_voltage = 3520,
+            .min_multi = 1.5,
+            .max_multi = 1.5
+        },
+        .bus_flags = MACHINE_PCI,
+        .flags = MACHINE_IDE_DUAL,
+        .ram = {
+            .min = 8192,
+            .max = 131072,
+            .step = 8192
+        },
+        .nvrmask = 127,
+        .kbc = KBC_JETKEY_5_W83C42,
+        .kbc_p1 = 0,
+        .gpio = 0,
+        .device = NULL,
+        .vid_device = NULL,
+        .snd_device = NULL,
+        .net_device = NULL
+    },
 
     /* Socket 7 (Single Voltage) machines */
     /* 430FX */


### PR DESCRIPTION
Summary
=======
Added Gemlight GMB-P54SPS (SiS 501, Socket 5)
NOTE: The Winbond W83769F IDE controller is not emulated yet, although a datasheet is available [here](https://pdf.datasheetcatalog.com/datasheet_pdf/winbond-electronics/W83769F.pdf).

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [X] This pull request requires changes to the ROM set
  * [X] I have opened a roms pull request - https://github.com/86Box/roms/pull/196

References
==========
https://theretroweb.com/motherboards/s/gemlight-gmb-p54sps
