### PR TITLE
QT: Fix crash in the first sound card selection.

### DIFF
--- a/src/qt/qt_settingssound.cpp
+++ b/src/qt/qt_settingssound.cpp
@@ -237,7 +237,7 @@ SettingsSound::on_comboBoxSoundCard4_currentIndexChanged(int index)
     if (index < 0) {
         return;
     }
-    ui->pushButtonConfigureSoundCard1->setEnabled(sound_card_has_config(ui->comboBoxSoundCard4->currentData().toInt()));
+    ui->pushButtonConfigureSoundCard4->setEnabled(sound_card_has_config(ui->comboBoxSoundCard4->currentData().toInt()));
 }
 
 void


### PR DESCRIPTION
Summary
=======
QT: Fix crash in the first sound card selection.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
