### PR TITLE
qt: Various fields should not be editable in settings view

### DIFF
--- a/src/qt/qt_settingsfloppycdrom.ui
+++ b/src/qt/qt_settingsfloppycdrom.ui
@@ -35,6 +35,9 @@
    </item>
    <item>
     <widget class="QTableView" name="tableViewFloppy">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
      <property name="selectionMode">
       <enum>QAbstractItemView::SingleSelection</enum>
      </property>
@@ -99,6 +102,9 @@
    </item>
    <item>
     <widget class="QTableView" name="tableViewCDROM">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
      <property name="selectionMode">
       <enum>QAbstractItemView::SingleSelection</enum>
      </property>

--- a/src/qt/qt_settingsharddisks.ui
+++ b/src/qt/qt_settingsharddisks.ui
@@ -28,6 +28,9 @@
    </property>
    <item>
     <widget class="QTableView" name="tableView">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
      <property name="selectionMode">
       <enum>QAbstractItemView::SingleSelection</enum>
      </property>

--- a/src/qt/qt_settingsotherremovable.ui
+++ b/src/qt/qt_settingsotherremovable.ui
@@ -35,6 +35,9 @@
    </item>
    <item>
     <widget class="QTableView" name="tableViewMO">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
      <property name="selectionMode">
       <enum>QAbstractItemView::SingleSelection</enum>
      </property>
@@ -105,6 +108,9 @@
    </item>
    <item>
     <widget class="QTableView" name="tableViewZIP">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
      <property name="selectionMode">
       <enum>QAbstractItemView::SingleSelection</enum>
      </property>


### PR DESCRIPTION
Summary
=======
When viewing the hard drive listing in the settings view, you can double click some of the fields and edit them. This disables the editable aspect of those fields (they shouldn't be editable).

Edit: Added the same fix for floppy, cd-rom, and other devices after @lemondrops brought it to my attention.

Checklist
=========
* [ ] I have discussed this with core contributors already

References
==========
N/A
