### PR TITLE
qt: Fixes to the process for selecting an existing hdd image

### DIFF
--- a/src/qt/qt_filefield.cpp
+++ b/src/qt/qt_filefield.cpp
@@ -29,7 +29,7 @@ FileField::FileField(QWidget *parent)
 
     connect(ui->label, &QLineEdit::editingFinished, this, [this]() {
         fileName_ = ui->label->text();
-        emit fileSelected(ui->label->text());
+        emit fileSelected(ui->label->text(), true);
     });
     this->setFixedWidth(this->sizeHint().width() + ui->pushButton->sizeHint().width());
 }

--- a/src/qt/qt_filefield.hpp
+++ b/src/qt/qt_filefield.hpp
@@ -24,7 +24,7 @@ public:
     bool createFile() { return createFile_; }
 
 signals:
-    void fileSelected(const QString &fileName);
+    void fileSelected(const QString &fileName, bool precheck = false);
 
 private slots:
     void on_pushButton_clicked();

--- a/src/qt/qt_harddiskdialog.cpp
+++ b/src/qt/qt_harddiskdialog.cpp
@@ -51,6 +51,40 @@ HarddiskDialog::HarddiskDialog(bool existing, QWidget *parent)
 {
     ui->setupUi(this);
 
+    auto *model = ui->comboBoxFormat->model();
+    model->insertRows(0, 6);
+    model->setData(model->index(0, 0), tr("Raw image (.img)"));
+    model->setData(model->index(1, 0), tr("HDI image (.hdi)"));
+    model->setData(model->index(2, 0), tr("HDX image (.hdx)"));
+    model->setData(model->index(3, 0), tr("Fixed-size VHD (.vhd)"));
+    model->setData(model->index(4, 0), tr("Dynamic-size VHD (.vhd)"));
+    model->setData(model->index(5, 0), tr("Differencing VHD (.vhd)"));
+
+    model = ui->comboBoxBlockSize->model();
+    model->insertRows(0, 2);
+    model->setData(model->index(0, 0), tr("Large blocks (2 MB)"));
+    model->setData(model->index(1, 0), tr("Small blocks (512 KB)"));
+
+    ui->comboBoxBlockSize->hide();
+    ui->labelBlockSize->hide();
+
+    Harddrives::populateBuses(ui->comboBoxBus->model());
+    ui->comboBoxBus->setCurrentIndex(3);
+
+    model = ui->comboBoxType->model();
+    for (int i = 0; i < 127; i++) {
+        uint64_t size    = ((uint64_t) hdd_table[i][0]) * hdd_table[i][1] * hdd_table[i][2];
+        uint32_t size_mb = size >> 11LL;
+        // QString text = QString("%1 MiB (CHS: %2, %3, %4)").arg(size_mb).arg(hdd_table[i][0]).arg(hdd_table[i][1]).arg(hdd_table[i][2]);
+        QString text = QString::asprintf(tr("%u MB (CHS: %i, %i, %i)").toUtf8().constData(), (size_mb), (hdd_table[i][0]), (hdd_table[i][1]), (hdd_table[i][2]));
+        Models::AddEntry(model, text, i);
+    }
+    Models::AddEntry(model, tr("Custom..."), 127);
+    Models::AddEntry(model, tr("Custom (large)..."), 128);
+
+    ui->lineEditSize->setValidator(new QIntValidator());
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+
     if (existing) {
         ui->fileField->setFilter(tr("Hard disk images") % util::DlgFilter({ "hd?", "im?", "vhd" }) % tr("All files") % util::DlgFilter({ "*" }, true));
 
@@ -85,40 +119,6 @@ HarddiskDialog::HarddiskDialog(bool existing, QWidget *parent)
             ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
         });
     }
-
-    auto *model = ui->comboBoxFormat->model();
-    model->insertRows(0, 6);
-    model->setData(model->index(0, 0), tr("Raw image (.img)"));
-    model->setData(model->index(1, 0), tr("HDI image (.hdi)"));
-    model->setData(model->index(2, 0), tr("HDX image (.hdx)"));
-    model->setData(model->index(3, 0), tr("Fixed-size VHD (.vhd)"));
-    model->setData(model->index(4, 0), tr("Dynamic-size VHD (.vhd)"));
-    model->setData(model->index(5, 0), tr("Differencing VHD (.vhd)"));
-
-    model = ui->comboBoxBlockSize->model();
-    model->insertRows(0, 2);
-    model->setData(model->index(0, 0), tr("Large blocks (2 MB)"));
-    model->setData(model->index(1, 0), tr("Small blocks (512 KB)"));
-
-    ui->comboBoxBlockSize->hide();
-    ui->labelBlockSize->hide();
-
-    Harddrives::populateBuses(ui->comboBoxBus->model());
-    ui->comboBoxBus->setCurrentIndex(3);
-
-    model = ui->comboBoxType->model();
-    for (int i = 0; i < 127; i++) {
-        uint64_t size    = ((uint64_t) hdd_table[i][0]) * hdd_table[i][1] * hdd_table[i][2];
-        uint32_t size_mb = size >> 11LL;
-        // QString text = QString("%1 MiB (CHS: %2, %3, %4)").arg(size_mb).arg(hdd_table[i][0]).arg(hdd_table[i][1]).arg(hdd_table[i][2]);
-        QString text = QString::asprintf(tr("%u MB (CHS: %i, %i, %i)").toUtf8().constData(), (size_mb), (hdd_table[i][0]), (hdd_table[i][1]), (hdd_table[i][2]));
-        Models::AddEntry(model, text, i);
-    }
-    Models::AddEntry(model, tr("Custom..."), 127);
-    Models::AddEntry(model, tr("Custom (large)..."), 128);
-
-    ui->lineEditSize->setValidator(new QIntValidator());
-    ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
 }
 
 HarddiskDialog::~HarddiskDialog()
@@ -499,7 +499,7 @@ HarddiskDialog::recalcSelection()
 }
 
 void
-HarddiskDialog::onExistingFileSelected(const QString &fileName)
+HarddiskDialog::onExistingFileSelected(const QString &fileName, bool precheck)
 {
     // TODO : Over to non-existing file selected
     /*
@@ -531,7 +531,11 @@ HarddiskDialog::onExistingFileSelected(const QString &fileName)
     ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
     QFile file(fileName);
     if (!file.open(QIODevice::ReadOnly)) {
-        QMessageBox::critical(this, tr("Unable to read file"), tr("Make sure the file exists and is readable."));
+        // No message box during precheck (performed when the file input loses focus and this function is called)
+        // If precheck is false, the file has been chosen from a file dialog and the alert should display.
+        if(!precheck) {
+            QMessageBox::critical(this, tr("Unable to read file"), tr("Make sure the file exists and is readable."));
+        }
         return;
     }
     QByteArray fileNameUtf8 = fileName.toUtf8();

--- a/src/qt/qt_harddiskdialog.hpp
+++ b/src/qt/qt_harddiskdialog.hpp
@@ -37,7 +37,7 @@ private slots:
     void on_comboBoxBus_currentIndexChanged(int index);
     void on_comboBoxFormat_currentIndexChanged(int index);
     void onCreateNewFile();
-    void onExistingFileSelected(const QString &fileName);
+    void onExistingFileSelected(const QString &fileName, bool precheck);
 
 private:
     Ui::HarddiskDialog *ui;


### PR DESCRIPTION
Summary
=======
In settings -> hdd selection -> existing disk, when you type a filename *then* select specify, you'll get an error about the file not existing. Sometimes the dialog will still appear for selection, but this seems to vary a little by OS.

The message is mainly because once the file entry loses focus (`editingFinished` signal) it's connected to `fileSelected` which then connects to `onExistingFileSelected`. The file *does* need to be checked once selected and I believe that was the intent. However, the way the signals are wired up you can actually wind up with the check happening twice: once before selection and once after selection.

I tried to go for a minimal fix without too much impact to the existing logic (which could use some updating, really). I did this by allowing the function to differentiate between the signal received when focus is lost (`editingFinished`) and when a file is actually selected from a dialog (`fileSelected`). Now, if you type in an existing image name and then tab out or otherwise remove focus, the CHS / size fields are correctly auto-populated. If the image name does not exist, there is no error dialog displayed. However, the OK button is not enabled, requiring a manual selection.

Additionally, there was another bug where the CHS selection was supposed to be disabled when selecting an existing image.  Another event (`on_comboBoxFormat_currentIndexChanged`) caused it to get re-enabled. This was fixed by moving the section in the constructor to after that event fires (combo box being populated).

Checklist
=========
* [ ] I have discussed this with core contributors already

References
==========
N/A
