### PR TITLE
qt: Reenable and make functional ACPI shutdown button

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -97,6 +97,8 @@
 #include <86box/version.h>
 #include <86box/gdbstub.h>
 #include <86box/machine_status.h>
+#include <86box/apm.h>
+#include <86box/acpi.h>
 
 // Disable c99-designator to avoid the warnings about int ng
 #ifdef __clang__
@@ -1015,6 +1017,9 @@ pc_reset_hard_init(void)
      * the actual machine, but which support some of the
      * modules that are.
      */
+
+    /* Mark ACPI as unavailable */
+    acpi_enabled = 0;
 
     /* Reset the general machine support modules. */
     io_init();

--- a/src/include/86box/acpi.h
+++ b/src/include/86box/acpi.h
@@ -18,7 +18,11 @@
 #define ACPI_H
 
 #ifdef __cplusplus
+#include <atomic>
+using atomic_int = std::atomic_int;
 extern "C" {
+#else
+#include <stdatomic.h>
 #endif
 
 #define ACPI_TIMER_FREQ 3579545
@@ -90,7 +94,7 @@ typedef struct
         slot, irq_mode,
         irq_pin, irq_line,
         mirq_is_level;
-    pc_timer_t timer, resume_timer;
+    pc_timer_t timer, resume_timer, pwrbtn_timer;
     nvr_t     *nvr;
     apm_t     *apm;
     void      *i2c,
@@ -98,7 +102,9 @@ typedef struct
 } acpi_t;
 
 /* Global variables. */
-extern int acpi_rtc_status;
+extern int        acpi_rtc_status;
+extern atomic_int acpi_pwrbut_pressed;
+extern int        acpi_enabled;
 
 extern const device_t acpi_ali_device;
 extern const device_t acpi_intel_device;

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -47,6 +47,9 @@ extern "C" {
 #include <86box/machine.h>
 #include <86box/vid_ega.h>
 #include <86box/version.h>
+//#include <86box/acpi.h> /* Requires timer.h include, which conflicts with Qt headers */
+extern atomic_int acpi_pwrbut_pressed;
+extern int acpi_enabled;
 
 #ifdef USE_VNC
 #    include <86box/vnc.h>
@@ -1679,6 +1682,7 @@ MainWindow::refreshMediaMenu()
     mm->refresh(ui->menuMedia);
     status->refresh(ui->statusbar);
     ui->actionMCA_devices->setVisible(machine_has_bus(machine, MACHINE_BUS_MCA));
+    ui->actionACPI_Shutdown->setEnabled(!!acpi_enabled);
 }
 
 void
@@ -2430,3 +2434,9 @@ MainWindow::on_actionApply_fullscreen_stretch_mode_when_maximized_triggered(bool
     device_force_redraw();
     config_save();
 }
+
+void MainWindow::on_actionACPI_Shutdown_triggered()
+{
+    acpi_pwrbut_pressed = 1;
+}
+

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -135,6 +135,9 @@ protected:
     void changeEvent(QEvent *event) override;
 
 private slots:
+    void on_actionACPI_Shutdown_triggered();
+
+private slots:
     void on_actionShow_non_primary_monitors_triggered();
 
     void on_actionOpen_screenshots_folder_triggered();

--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -743,7 +743,7 @@
   </action>
   <action name="actionACPI_Shutdown">
    <property name="enabled">
-    <bool>false</bool>
+    <bool>true</bool>
    </property>
    <property name="icon">
     <iconset resource="../qt_resources.qrc">
@@ -756,7 +756,7 @@
     <string>ACPI Shutdown</string>
    </property>
    <property name="visible">
-    <bool>false</bool>
+    <bool>true</bool>
    </property>
   </action>
   <action name="actionBegin_trace">


### PR DESCRIPTION
Summary
=======
qt: Reenable and make functional ACPI shutdown button

Checklist
=========
* [X] Closes #973
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
