### PR TITLE
Ability to build with CLANG and Regular builds

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -28,6 +28,9 @@ jobs:
       fail-fast: true
       matrix:
         build:
+#          - name: Regular
+#            debug: n
+#            dev: n
           - name: Debug
             debug: y
             dev: n
@@ -44,14 +47,28 @@ jobs:
             new: y
             slug: -NDR
         environment:
+#          - msystem: MSYS
+#            clang: n
+#            x64: y
           - msystem: MINGW32
             prefix: mingw-w64-i686
+            clang: n
             x64: n
           - msystem: MINGW64
             prefix: mingw-w64-x86_64
+            clang: n
             x64: y
+#          - msystem: CLANG32
+#            prefix: mingw-w64-clang-i686
+#            clang: y
+#            x64: n
+#          - msystem: CLANG64
+#            prefix: mingw-w64-clang-x86_64
+#            clang: y
+#            x64: y
           - msystem: UCRT64
             prefix: mingw-w64-ucrt-x86_64
+            clang: n
             x64: y
 
     steps:
@@ -65,6 +82,7 @@ jobs:
             make
           pacboy: >-
             gcc:p
+            clang:p
             pkg-config:p
             freetype:p
             SDL2:p
@@ -80,6 +98,7 @@ jobs:
           DEV_BUILD=${{ matrix.build.dev }}
           DEBUG=${{ matrix.build.debug }}
           NEW_DYNAREC=${{ matrix.dynarec.new }}
+          CLANG=${{ matrix.environment.clang }}
           X64=${{ matrix.environment.x64 }}
         working-directory: ./src
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -37,6 +37,8 @@ jobs:
       fail-fast: true
       matrix:
         build:
+#          - name: Regular
+#            preset: regular
           - name: Debug
             preset: debug
             slug: -Debug
@@ -62,12 +64,20 @@ jobs:
               qt5-base:p
               qt5-tools:p
         environment:
+#          - msystem: MSYS
+#            toolchain: ./cmake/flags-gcc-x86_64.cmake
           - msystem: MINGW32
             prefix: mingw-w64-i686
             toolchain: ./cmake/flags-gcc-i686.cmake
           - msystem: MINGW64
             prefix: mingw-w64-x86_64
             toolchain: ./cmake/flags-gcc-x86_64.cmake
+#          - msystem: CLANG32
+#            prefix: mingw-w64-clang-i686
+#            toolchain: ./cmake/llvm-win32-i686.cmake
+#          - msystem: CLANG64
+#            prefix: mingw-w64-clang-x86_64
+#            toolchain: ./cmake/llvm-win32-x86_64.cmake
           - msystem: UCRT64
             prefix: mingw-w64-ucrt-x86_64
             toolchain: ./cmake/flags-gcc-x86_64.cmake
@@ -122,6 +132,8 @@ jobs:
       fail-fast: true
       matrix:
         build:
+#          - name: Regular
+#            preset: regular
           - name: Debug
             preset: debug
             slug: -Debug
@@ -219,6 +231,8 @@ jobs:
       fail-fast: true
       matrix:
         build:
+#          - name: Regular
+#            preset: regular
           - name: Debug
             preset: debug
             slug: -Debug
@@ -280,6 +294,8 @@ jobs:
       fail-fast: true
       matrix:
         build:
+#          - name: Regular
+#            preset: regular
           - name: Debug
             preset: debug
             slug: -Debug


### PR DESCRIPTION
Summary
=======
Ability to build with CLANG and Regular builds
This is ofcourse disabled by default, and primarily to make my life easier on branches

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
