### PR TITLE
add command 0xea - set stream mode

### DIFF
--- a/src/device/mouse_ps2.c
+++ b/src/device/mouse_ps2.c
@@ -191,6 +191,12 @@ ps2_write(uint8_t val, void *priv)
                 keyboard_at_adddata_mouse(dev->sample_rate);
                 break;
 
+            case 0xea: /* set stream */
+                dev->flags &= ~FLAG_CTRLDAT;
+                mouse_scan = 1;
+                keyboard_at_adddata_mouse(0xfa); /* ACK for command byte */
+                break;
+
             case 0xeb: /* Get mouse data */
                 keyboard_at_adddata_mouse(0xfa);
 


### PR DESCRIPTION
Summary
=======
This commits adds support for the command 0xea - set stream for PS2 mice. I was messing with OpenServer, and PS2 mice is not detected before this patch.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://wiki.osdev.org/PS/2_Mouse
