### PR TITLE
Detect TigerVNC pointer

### DIFF
--- a/src/qt/xinput2_mouse.cpp
+++ b/src/qt/xinput2_mouse.cpp
@@ -81,9 +81,17 @@ xinput2_get_xtest_pointer()
 {
     /* The XTEST pointer events injected by VNC servers to move the cursor always report
        absolute coordinates, despite XTEST declaring relative axes (related: SDL issue 1836).
-       This looks for the XTEST pointer so that we can assume it's absolute as a workaround. */
+       This looks for the XTEST pointer so that we can assume it's absolute as a workaround.
+
+       TigerVNC publishes both the XTEST pointer and a TigerVNC pointer, but actual
+       RawMotion events are published using the TigerVNC pointer */
     int           devs;
     XIDeviceInfo *info = XIQueryDevice(disp, XIAllDevices, &devs), *dev;
+    for (int i = 0; i < devs; i++) {
+        dev = &info[i];
+        if ((dev->use == XISlavePointer) && !strcmp(dev->name, "TigerVNC pointer"))
+            return dev->deviceid;
+    }
     for (int i = 0; i < devs; i++) {
         dev = &info[i];
         if ((dev->use == XISlavePointer) && !strcmp(dev->name, "Virtual core XTEST pointer"))


### PR DESCRIPTION
Summary
=======
TigerVNC pointer needs the same workaround as previously added for another VNC server, but it's pointer is named differently. In addition, it also publishes a pointer using the XTEST pointer name already added as a workaround. So, if a TigerVNC pointer is detected, it should be selected first.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
Man page XIQueryDevice(3), and the existing workaround in xinput2_input