### PR TITLE
Serial passthrough fixes on Windows

### DIFF
--- a/src/win/win_serial_passthrough.c
+++ b/src/win/win_serial_passthrough.c
@@ -73,9 +73,6 @@ plat_serpt_write_vcon(serial_passthrough_t *dev, uint8_t data)
     // fwrite(dev->master_fd, &data, 1);
     DWORD bytesWritten = 0;
     WriteFile((HANDLE) dev->master_fd, &data, 1, &bytesWritten, NULL);
-    if (bytesWritten == 0) {
-        fatal("serial_passthrough: WriteFile pipe write-buffer full!");
-    }
 }
 
 void


### PR DESCRIPTION
Summary
=======
[qt: Fix serial ports enumeration on Windows](https://github.com/86Box/86Box/commit/ed6f7a6f8e3529b956992056d4d36f01682b0258)
[win_serial_passthrough: Don't error on 0-byte writes](https://github.com/86Box/86Box/commit/e6156022cfcabbe82d6b12c1c735633edcd249fa)

References
==========
None.
