### PR TITLE
serial_passthrough: Allow configuration of named pipe parameter

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2472,11 +2472,12 @@ save_ports(void)
                               (char *) com_device_get_internal_name(com_ports[c].device));
                 */
 
-        if (com_ports[c].enabled)
-            if (serial_passthrough_enabled[c]) {
-                sprintf(temp, "serial%d_passthrough_enabled", c + 1);
-                ini_section_set_int(cat, temp, 1);
-            }
+        sprintf(temp, "serial%d_passthrough_enabled", c + 1);
+        if (serial_passthrough_enabled[c]) {
+            ini_section_set_int(cat, temp, 1);
+        } else {
+            ini_section_delete_var(cat, temp);
+        }
     }
 
     for (c = 0; c < PARALLEL_MAX; c++) {

--- a/src/device/serial_passthrough.c
+++ b/src/device/serial_passthrough.c
@@ -177,6 +177,9 @@ serial_passthrough_dev_init(const device_t *info)
                                    serial_passthrough_write, serial_passthrough_transmit_period, serial_passthrough_lcr_callback, dev);
 
     strncpy(dev->host_serial_path, device_get_config_string("host_serial_path"), 1023);
+#ifdef _WIN32
+    strncpy(dev->named_pipe, device_get_config_string("named_pipe"), 1023);
+#endif
 
     serial_passthrough_log("%s: port=COM%d\n", info->name, dev->port + 1);
     serial_passthrough_log("%s: baud=%f\n", info->name, dev->baudrate);
@@ -264,6 +267,17 @@ static const device_config_t serial_passthrough_config[] = {
         .spinner = {},
         .selection = {}
     },
+#ifdef _WIN32
+    {
+        .name = "named_pipe",
+        .description = "Name of pipe",
+        .type = CONFIG_STRING,
+        .default_string = "\\\\.\\pipe\\86Box\\test",
+        .file_filter = NULL,
+        .spinner = {},
+        .selection = {}
+    },
+#endif
     {
         .name = "data_bits",
         .description = "Data bits",

--- a/src/include/86box/serial_passthrough.h
+++ b/src/include/86box/serial_passthrough.h
@@ -50,6 +50,7 @@ typedef struct serial_passthrough_s {
     intptr_t                     master_fd;    /* file desc for master pseudo terminal or
                                                 * socket or alike */
     char  host_serial_path[1024];              /* Path to TTY/host serial port on the host */
+    char  named_pipe[1024];                    /* (Windows only) Name of the pipe. */
     void *backend_priv;                        /* Private platform backend data */
 } serial_passthrough_t;
 

--- a/src/qt/qt_deviceconfig.cpp
+++ b/src/qt/qt_deviceconfig.cpp
@@ -26,6 +26,7 @@
 #include <QSpinBox>
 #include <QCheckBox>
 #include <QFrame>
+#include <QLineEdit>
 #include <QLabel>
 #include <QDir>
 #include <QSettings>
@@ -254,6 +255,15 @@ DeviceConfig::ConfigureDevice(const _device_ *device, int instance, Settings *se
                     dc.ui->formLayout->addRow(config->description, fileField);
                     break;
                 }
+            case CONFIG_STRING:
+                {
+                    auto lineEdit = new QLineEdit;
+                    lineEdit->setObjectName(config->name);
+                    lineEdit->setCursor(Qt::IBeamCursor);
+                    lineEdit->setText(config_get_string(device_context.name, const_cast<char *>(config->name), const_cast<char *>(config->default_string)));
+                    dc.ui->formLayout->addRow(config->description, lineEdit);
+                    break;
+                }
             case CONFIG_SERPORT:
                 {
                     auto *cbox = new QComboBox();
@@ -313,6 +323,12 @@ DeviceConfig::ConfigureDevice(const _device_ *device, int instance, Settings *se
                         if (path == "None")
                             path = "";
                         config_set_string(device_context.name, const_cast<char *>(config->name), path);
+                        break;
+                    }
+                case CONFIG_STRING:
+                    {
+                        auto *lineEdit = dc.findChild<QLineEdit *>(config->name);
+                        config_set_string(device_context.name, const_cast<char *>(config->name), lineEdit->text().toUtf8());
                         break;
                     }
                 case CONFIG_HEX16:

--- a/src/win/win_devconf.c
+++ b/src/win/win_devconf.c
@@ -168,6 +168,7 @@ deviceconfig_dlgproc(HWND hdlg, UINT message, WPARAM wParam, LPARAM lParam)
                         id += 2;
                         break;
                     case CONFIG_FNAME:
+                    case CONFIG_STRING:
                         wstr = config_get_wstring((char *) config_device.name,
                                                   (char *) config->name, 0);
                         if (wstr)
@@ -288,6 +289,7 @@ deviceconfig_dlgproc(HWND hdlg, UINT message, WPARAM wParam, LPARAM lParam)
                             id += 2;
                             break;
                         case CONFIG_FNAME:
+                        case CONFIG_STRING:
                             str = config_get_string((char *) config_device.name,
                                                     (char *) config->name, (char *) "");
                             SendMessage(h, WM_GETTEXT, 511, (LPARAM) s);
@@ -397,6 +399,7 @@ deviceconfig_dlgproc(HWND hdlg, UINT message, WPARAM wParam, LPARAM lParam)
                             id += 2;
                             break;
                         case CONFIG_FNAME:
+                        case CONFIG_STRING:
                             SendMessage(h, WM_GETTEXT, 511, (LPARAM) ws);
                             config_set_wstring((char *) config_device.name, (char *) config->name, ws);
 
@@ -455,6 +458,7 @@ deviceconfig_dlgproc(HWND hdlg, UINT message, WPARAM wParam, LPARAM lParam)
                         case CONFIG_MIDI_OUT:
                         case CONFIG_MIDI_IN:
                         case CONFIG_SPINNER:
+                        case CONFIG_STRING:
                             id += 2;
                             break;
                         case CONFIG_FNAME:
@@ -622,6 +626,52 @@ deviceconfig_inst_open(HWND hwnd, const device_t *device, int inst)
                     data++;
 
                 /* TODO: add up down class */
+                /*Static text*/
+                item     = (DLGITEMTEMPLATE *) data;
+                item->x  = 10;
+                item->y  = y + 2;
+                item->id = id++;
+
+                item->cx = 60;
+                item->cy = 20;
+
+                item->style = WS_CHILD | WS_VISIBLE;
+
+                data    = (uint16_t *) (item + 1);
+                *data++ = 0xFFFF;
+                *data++ = 0x0082; /* static class */
+
+                data += MultiByteToWideChar(CP_ACP, 0, config->description, -1, data, 256);
+                *data++ = 0; /* no creation data */
+
+                if (((uintptr_t) data) & 2)
+                    data++;
+
+                y += 20;
+                break;
+            case CONFIG_STRING:
+                /*Editable Text*/
+                item     = (DLGITEMTEMPLATE *) data;
+                item->x  = 70;
+                item->y  = y;
+                item->id = id++;
+
+                item->cx = 140;
+                item->cy = 14;
+
+                item->style           = WS_CHILD | WS_VISIBLE | ES_READONLY;
+                item->dwExtendedStyle = WS_EX_CLIENTEDGE;
+
+                data    = (uint16_t *) (item + 1);
+                *data++ = 0xFFFF;
+                *data++ = 0x0081; /* edit text class */
+
+                data += MultiByteToWideChar(CP_ACP, 0, "", -1, data, 256);
+                *data++ = 0; /* no creation data */
+
+                if (((uintptr_t) data) & 2)
+                    data++;
+
                 /*Static text*/
                 item     = (DLGITEMTEMPLATE *) data;
                 item->x  = 10;

--- a/src/win/win_serial_passthrough.c
+++ b/src/win/win_serial_passthrough.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include <wchar.h>
 
 #include <86box/86box.h>
 #include <86box/log.h>
@@ -30,6 +31,7 @@
 #include <86box/device.h>
 #include <86box/serial_passthrough.h>
 #include <86box/plat_serial_passthrough.h>
+#include <86box/ui.h>
 
 #include <windows.h>
 
@@ -161,9 +163,15 @@ static int
 open_pseudo_terminal(serial_passthrough_t *dev)
 {
     char ascii_pipe_name[1024] = { 0 };
-    snprintf(ascii_pipe_name, sizeof(ascii_pipe_name), "\\\\.\\pipe\\86Box\\%s", vm_name);
+    strncpy(ascii_pipe_name, dev->named_pipe, 1023);
     dev->master_fd = (intptr_t) CreateNamedPipeA(ascii_pipe_name, PIPE_ACCESS_DUPLEX, PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_NOWAIT, 32, 65536, 65536, NMPWAIT_USE_DEFAULT_WAIT, NULL);
     if (dev->master_fd == (intptr_t) INVALID_HANDLE_VALUE) {
+        wchar_t errorMsg[1024] = { 0 };
+        wchar_t finalMsg[1024] = { 0 };
+        DWORD error = GetLastError();
+        FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM, NULL, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), errorMsg, 1024, NULL);
+        swprintf(finalMsg, 1024, L"Named Pipe (server, named_pipe=\"%hs\", port=COM%d): %ls\n", ascii_pipe_name, dev->port + 1, errorMsg);
+        ui_msgbox(MBX_ERROR | MBX_FATAL, finalMsg);
         return 0;
     }
     pclog("Named Pipe @ %s\n", ascii_pipe_name);


### PR DESCRIPTION
Summary
=======
serial_passthrough: Allow configuration of named pipe parameter

Windows-only.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
