### PR TITLE
vid_tvp3026_ramdac: Don't ignore CCR2 and CCR3 bits for Cursor RAM reads/writes.

### DIFF
--- a/src/video/vid_tvp3026_ramdac.c
+++ b/src/video/vid_tvp3026_ramdac.c
@@ -163,11 +163,19 @@ tvp3026_ramdac_out(uint16_t addr, int rs2, int rs3, uint8_t val, void *p, svga_t
             switch (ramdac->ind_idx) {
                 case 0x06: /* Indirect Cursor Control */
                     ramdac->ccr                  = val;
-                    svga->dac_hwcursor.cur_xsize = svga->dac_hwcursor.cur_ysize = 64;
-                    svga->dac_hwcursor.x                                        = ramdac->hwc_x - svga->dac_hwcursor.cur_xsize;
-                    svga->dac_hwcursor.y                                        = ramdac->hwc_y - svga->dac_hwcursor.cur_ysize;
-                    svga->dac_hwcursor.ena                                      = !!(val & 0x03);
-                    ramdac->mode                                                = val & 0x03;
+                    if (!(ramdac->ccr & 0x80)) {
+                        svga->dac_hwcursor.cur_xsize = svga->dac_hwcursor.cur_ysize = 64;
+                        svga->dac_hwcursor.x                                        = ramdac->hwc_x - svga->dac_hwcursor.cur_xsize;
+                        svga->dac_hwcursor.y                                        = ramdac->hwc_y - svga->dac_hwcursor.cur_ysize;
+                        svga->dac_hwcursor.ena                                      = !!(val & 0x03);
+                        ramdac->mode                                                = val & 0x03;
+                    } else {
+                        svga->dac_hwcursor.cur_xsize = svga->dac_hwcursor.cur_ysize = 64;
+                        svga->dac_hwcursor.x                                        = ramdac->hwc_x - svga->dac_hwcursor.cur_xsize;
+                        svga->dac_hwcursor.y                                        = ramdac->hwc_y - svga->dac_hwcursor.cur_ysize;
+                        svga->dac_hwcursor.ena                                      = !!(ramdac->dcc & 0x03);
+                        ramdac->mode                                                = ramdac->dcc & 0x03;
+                    }
                     break;
                 case 0x0f: /* Latch Control */
                     ramdac->latch_cntl = val;
@@ -244,7 +252,7 @@ tvp3026_ramdac_out(uint16_t addr, int rs2, int rs3, uint8_t val, void *p, svga_t
             }
             break;
         case 0x0b: /* Cursor RAM Data Register (RS value = 1011) */
-            index          = svga->dac_addr & da_mask;
+            index          = (svga->dac_addr & da_mask) | ((ramdac->ccr & 0x0c) << 6);
             cd             = (uint8_t *) ramdac->cursor64_data;
             cd[index]      = val;
             svga->dac_addr = (svga->dac_addr + 1) & da_mask;
@@ -410,7 +418,7 @@ tvp3026_ramdac_in(uint16_t addr, int rs2, int rs3, void *p, svga_t *svga)
             }
             break;
         case 0x0b: /* Cursor RAM Data Register (RS value = 1011) */
-            index = (svga->dac_addr - 1) & da_mask;
+            index = ((svga->dac_addr - 1) & da_mask) | ((ramdac->ccr & 0x0c) << 6);
             cd    = (uint8_t *) ramdac->cursor64_data;
             temp  = cd[index];
 


### PR DESCRIPTION
Summary
=======
vid_tvp3026_ramdac: Don't ignore CCR2 and CCR3 bits for Cursor RAM reads/writes.

Fixes hardware cursor under Windows 95 (and potentially others).

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
