### PR TITLE
vid_mga: Fix opaque pattern blits

### DIFF
--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -2177,7 +2177,7 @@ mystique_accel_ctrl_write_l(uint32_t addr, uint32_t val, void *p)
                 int x, y;
 
                 for (y = 0; y < 8; y++) {
-                    for (x = 0; x < 8; x++)
+                    for (x = 0; x < 16; x++)
                         mystique->dwgreg.pattern[y][x] = 1;
                 }
                 mystique->dwgreg.src[0] = 0xffffffff;


### PR DESCRIPTION
Summary
=======
vid_mga: Fix opaque pattern blits

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
