### PR TITLE
Make joysticks work with the PCjr

### DIFF
--- a/src/machine/m_pcjr.c
+++ b/src/machine/m_pcjr.c
@@ -37,6 +37,7 @@
 #include <86box/pit.h>
 #include <86box/mem.h>
 #include <86box/device.h>
+#include <86box/gameport.h>
 #include <86box/serial.h>
 #include <86box/keyboard.h>
 #include <86box/rom.h>
@@ -814,6 +815,9 @@ machine_pcjr_init(const machine_t *model)
 
     device_add(&ns8250_pcjr_device);
     serial_set_next_inst(SERIAL_MAX); /* So that serial_standalone_init() won't do anything. */
+
+    /* "All the inputs are 'read' with one 'IN' from address hex 201." - PCjr Technical Reference (Nov. 83), p.2-119 */
+    standalone_gameport_type = &gameport_201_device;
 
     return ret;
 }


### PR DESCRIPTION
Summary
=======
The PCjr Technical Reference says that all joystick inputs go through 0x201, and at least Imagic's Demon Attack seems to expect this. I've tested this and it does let the game work fine.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[PCjr Technical Reference, p.2-119](http://bitsavers.org/pdf/ibm/pc/pc_jr/PCjr_Technical_Reference_Nov83.pdf#page=145)
