### PR TITLE
Fix accidental reversion from Socket 7 to socket 5 in two machines

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -8584,7 +8584,7 @@ const machine_t machines[] = {
     {
         .name = "[i430FX] DataExpert EXP8551",
         .internal_name = "exp8551",
-        .type = MACHINE_TYPE_SOCKET5,
+        .type = MACHINE_TYPE_SOCKET7_3V,
         .chipset = MACHINE_CHIPSET_INTEL_430FX,
         .init = machine_at_exp8551_init,
         .pad = 0,
@@ -8906,7 +8906,7 @@ const machine_t machines[] = {
     {
         .name = "[i430FX] PC Partner MB500N",
         .internal_name = "mb500n",
-        .type = MACHINE_TYPE_SOCKET5,
+        .type = MACHINE_TYPE_SOCKET7_3V,
         .chipset = MACHINE_CHIPSET_INTEL_430FX,
         .init = machine_at_mb500n_init,
         .pad = 0,


### PR DESCRIPTION
Summary
=======
Fix accidental reversion from Socket 7 to socket 5 in two machines

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
