### PR TITLE
qt_winrawinputfilter: Poll for 4th and 5th mouse buttons

### DIFF
--- a/src/qt/qt_winrawinputfilter.cpp
+++ b/src/qt/qt_winrawinputfilter.cpp
@@ -340,6 +340,16 @@ WindowsRawInputFilter::mouse_handle(PRAWINPUT raw)
     else if (state.usButtonFlags & RI_MOUSE_RIGHT_BUTTON_UP)
         buttons &= ~2;
 
+    if (state.usButtonFlags & RI_MOUSE_BUTTON_4_DOWN)
+        mousestate.buttons |= 8;
+    else if (state.usButtonFlags & RI_MOUSE_BUTTON_4_UP)
+        mousestate.buttons &= ~8;
+
+    if (state.usButtonFlags & RI_MOUSE_BUTTON_5_DOWN)
+        mousestate.buttons |= 16;
+    else if (state.usButtonFlags & RI_MOUSE_BUTTON_5_UP)
+        mousestate.buttons &= ~16;
+    
     if (state.usButtonFlags & RI_MOUSE_WHEEL) {
         dwheel += (SHORT) state.usButtonData / 120;
     }


### PR DESCRIPTION
Summary
=======
qt_winrawinputfilter: Poll for 4th and 5th mouse buttons

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
