### PR TITLE
Magic numbers for sound freq changed to defines

### DIFF
--- a/src/include/86box/sound.h
+++ b/src/include/86box/sound.h
@@ -24,9 +24,16 @@
 
 extern int sound_gain;
 
-#define SOUNDBUFLEN (48000 / 50)
+#define FREQ_44100 44100
+#define FREQ_48000 48000
+#define FREQ_49716 49716
+#define FREQ_88200 88200
+#define FREQ_96000 96000
 
-#define CD_FREQ     44100
+#define SOUND_FREQ FREQ_48000
+#define SOUNDBUFLEN (SOUND_FREQ / 50)
+
+#define CD_FREQ     FREQ_44100
 #define CD_BUFLEN   (CD_FREQ / 10)
 
 enum {

--- a/src/sound/midi_fluidsynth.c
+++ b/src/sound/midi_fluidsynth.c
@@ -130,7 +130,7 @@ fluidsynth_poll(void)
 {
     fluidsynth_t *data = &fsdev;
     data->midi_pos++;
-    if (data->midi_pos == 48000 / RENDER_RATE) {
+    if (data->midi_pos == SOUND_FREQ / RENDER_RATE) {
         data->midi_pos = 0;
         thread_set_event(data->event);
     }

--- a/src/sound/midi_mt32.c
+++ b/src/sound/midi_mt32.c
@@ -202,7 +202,7 @@ void
 mt32_poll(void)
 {
     midi_pos++;
-    if (midi_pos == 48000 / RENDER_RATE) {
+    if (midi_pos == SOUND_FREQ / RENDER_RATE) {
         midi_pos = 0;
         thread_set_event(event);
     }

--- a/src/sound/openal.c
+++ b/src/sound/openal.c
@@ -34,7 +34,7 @@
 #include <86box/midi.h>
 #include <86box/sound.h>
 
-#define FREQ   48000
+#define FREQ   SOUND_FREQ
 #define BUFLEN SOUNDBUFLEN
 
 ALuint        buffers[4];      /* front and back buffers */

--- a/src/sound/snd_ac97_via.c
+++ b/src/sound/snd_ac97_via.c
@@ -746,7 +746,7 @@ ac97_via_speed_changed(void *priv)
     if (dev->vsr_enabled && dev->codec[0][0])
         freq = ac97_codec_getrate(dev->codec[0][0], 0x2c);
     else
-        freq = 48000.0;
+        freq = (double) SOUND_FREQ;
 
     dev->sgd[0].timer_latch = (uint64_t) ((double) TIMER_USEC * (1000000.0 / freq));
     dev->sgd[2].timer_latch = (uint64_t) ((double) TIMER_USEC * (1000000.0 / 24000.0));

--- a/src/sound/snd_audiopci.c
+++ b/src/sound/snd_audiopci.c
@@ -2045,7 +2045,7 @@ es1371_speed_changed(void *p)
 {
     es1371_t *dev = (es1371_t *) p;
 
-    dev->dac[1].latch = (uint64_t) ((double) TIMER_USEC * (1000000.0 / 48000.0));
+    dev->dac[1].latch = (uint64_t) ((double) TIMER_USEC * (1000000.0 / (double) SOUND_FREQ));
 }
 
 static const device_config_t es1371_config[] = {

--- a/src/sound/snd_emu8k.c
+++ b/src/sound/snd_emu8k.c
@@ -1659,7 +1659,7 @@ emu8k_vol_slide(emu8k_slide_t *slide, int32_t target)
 void
 emu8k_update(emu8k_t *emu8k)
 {
-    int new_pos = (sound_pos_global * 44100) / 48000;
+    int new_pos = (sound_pos_global * FREQ_44100) / SOUND_FREQ;
     if (emu8k->pos >= new_pos)
         return;
 

--- a/src/sound/snd_opl_nuked.c
+++ b/src/sound/snd_opl_nuked.c
@@ -55,6 +55,8 @@
 #define WRBUF_DELAY 1
 #define RSM_FRAC    10
 
+#define OPL_FREQ FREQ_48000
+
 // Channel types
 enum {
     ch_2op  = 0,
@@ -1481,7 +1483,7 @@ nuked_drv_init(const device_t *info)
         dev->status = 0x06;
 
     /* Initialize the NukedOPL object. */
-    nuked_init(&dev->opl, 48000);
+    nuked_init(&dev->opl, OPL_FREQ);
 
     timer_add(&dev->timers[0], nuked_timer_1, dev, 0);
     timer_add(&dev->timers[1], nuked_timer_2, dev, 0);

--- a/src/sound/snd_opl_ymfm.cpp
+++ b/src/sound/snd_opl_ymfm.cpp
@@ -42,6 +42,8 @@ extern "C" {
 
 #define RSM_FRAC 10
 
+#define OPL_FREQ FREQ_48000
+
 enum {
     FLAG_CYCLES = (1 << 0)
 };
@@ -294,15 +296,15 @@ ymfm_drv_init(const device_t *info)
     switch (info->local) {
         case FM_YM3812:
         default:
-            fm = (YMFMChipBase *) new YMFMChip<ymfm::ym3812>(3579545, FM_YM3812, 48000);
+            fm = (YMFMChipBase *) new YMFMChip<ymfm::ym3812>(3579545, FM_YM3812, OPL_FREQ);
             break;
 
         case FM_YMF262:
-            fm = (YMFMChipBase *) new YMFMChip<ymfm::ymf262>(14318181, FM_YMF262, 48000);
+            fm = (YMFMChipBase *) new YMFMChip<ymfm::ymf262>(14318181, FM_YMF262, OPL_FREQ);
             break;
 
         case FM_YMF289B:
-            fm = (YMFMChipBase *) new YMFMChip<ymfm::ymf289b>(33868800, FM_YMF289B, 48000);
+            fm = (YMFMChipBase *) new YMFMChip<ymfm::ymf289b>(33868800, FM_YMF289B, OPL_FREQ);
             break;
 
         case FM_YMF278B:

--- a/src/sound/snd_resid.cc
+++ b/src/sound/snd_resid.cc
@@ -7,6 +7,8 @@
 #include <86box/plat.h>
 #include <86box/snd_resid.h>
 
+#define RESID_FREQ 48000
+
 typedef struct psid_t {
     /* resid sid implementation */
     SIDFP  *sid;
@@ -42,7 +44,7 @@ sid_init(void)
         psid->sid->write(c, 0);
 
     if (!psid->sid->set_sampling_parameters((float) cycles_per_sec, method,
-                                            (float) 48000, 0.9 * 48000.0 / 2.0)) {
+                                            (float) RESID_FREQ, 0.9 * (float) RESID_FREQ / 2.0)) {
         //        printf("reSID failed!\n");
     }
 
@@ -93,7 +95,7 @@ sid_write(uint16_t addr, uint8_t val, UNUSED(void *p))
     psid->sid->write(addr & 0x1f, val);
 }
 
-#define CLOCK_DELTA(n) (int) (((14318180.0 * n) / 16.0) / 48000.0)
+#define CLOCK_DELTA(n) (int) (((14318180.0 * n) / 16.0) / (float) RESID_FREQ)
 
 static void
 fillbuf2(int &count, int16_t *buf, int len)

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -364,7 +364,7 @@ sb_get_buffer_sb16_awe32(int32_t *buffer, int len, void *p)
         out_l = 0.0, out_r = 0.0;
 
         if (sb->dsp.sb_type > SB16)
-            c_emu8k = ((((c / 2) * 44100) / 48000) * 2);
+            c_emu8k = ((((c / 2) * FREQ_44100) / SOUND_FREQ) * 2);
 
         if (sb->opl_enabled) {
             out_l = ((double) opl_buf[c]) * mixer->fm_l * 0.7171630859375;
@@ -433,7 +433,7 @@ sb_get_buffer_sb16_awe32(int32_t *buffer, int len, void *p)
         }
 
         if (sb->dsp.sb_enable_i) {
-            c_record = dsp_rec_pos + ((c * sb->dsp.sb_freq) / 48000);
+            c_record = dsp_rec_pos + ((c * sb->dsp.sb_freq) / SOUND_FREQ);
             in_l <<= mixer->input_gain_L;
             in_r <<= mixer->input_gain_R;
 

--- a/src/sound/snd_sb_dsp.c
+++ b/src/sound/snd_sb_dsp.c
@@ -145,7 +145,7 @@ recalc_sb16_filter(int c, int playback_freq)
     /* Cutoff frequency = playback / 2 */
     int    n;
     double w, h;
-    double fC = ((double) playback_freq) / 96000.0;
+    double fC = ((double) playback_freq) / (double) FREQ_96000;
     double gain;
 
     for (n = 0; n < SB16_NCoef; n++) {
@@ -1139,7 +1139,7 @@ sb_dsp_init(sb_dsp_t *dsp, int type, int subtype, void *parent)
     /* Initialise SB16 filter to same cutoff as 8-bit SBs (3.2 kHz). This will be recalculated when
        a set frequency command is sent. */
     recalc_sb16_filter(0, 3200 * 2);
-    recalc_sb16_filter(1, 44100);
+    recalc_sb16_filter(1, FREQ_44100);
 
     /* Initialize SB16 8051 RAM and ASP internal RAM */
     memset(dsp->sb_8051_ram, 0x00, sizeof(dsp->sb_8051_ram));

--- a/src/sound/snd_sn76489.c
+++ b/src/sound/snd_sn76489.c
@@ -192,7 +192,7 @@ sn76489_init(sn76489_t *sn76489, uint16_t base, uint16_t size, int type, int fre
     sn76489->noise    = 3;
     sn76489->shift    = 0x4000;
     sn76489->type     = type;
-    sn76489->psgconst = (((double) freq / 64.0) / 48000.0);
+    sn76489->psgconst = (((double) freq / 64.0) / (double) FREQ_48000);
 
     sn76489_mute = 0;
 

--- a/src/sound/sound.c
+++ b/src/sound/sound.c
@@ -475,7 +475,7 @@ sound_poll(void *priv)
         if (cd_thread_enable) {
             cd_buf_update--;
             if (!cd_buf_update) {
-                cd_buf_update = (48000 / SOUNDBUFLEN) / (CD_FREQ / CD_BUFLEN);
+                cd_buf_update = (SOUND_FREQ / SOUNDBUFLEN) / (CD_FREQ / CD_BUFLEN);
                 thread_set_event(sound_cd_event);
             }
         }
@@ -487,7 +487,7 @@ sound_poll(void *priv)
 void
 sound_speed_changed(void)
 {
-    sound_poll_latch = (uint64_t) ((double) TIMER_USEC * (1000000.0 / 48000.0));
+    sound_poll_latch = (uint64_t) ((double) TIMER_USEC * (1000000.0 / (double) SOUND_FREQ));
 }
 
 void

--- a/src/sound/xaudio2.c
+++ b/src/sound/xaudio2.c
@@ -44,7 +44,7 @@ static dllimp_t xaudio2_imports[] = {
 #    define XAudio2Create pXAudio2Create
 #endif
 
-static int                     midi_freq     = 44100;
+static int                     midi_freq     = FREQ_44100;
 static int                     midi_buf_size = 4410;
 static int                     initialized   = 0;
 static IXAudio2               *xaudio2       = NULL;
@@ -53,7 +53,7 @@ static IXAudio2SourceVoice    *srcvoice      = NULL;
 static IXAudio2SourceVoice    *srcvoicemidi  = NULL;
 static IXAudio2SourceVoice    *srcvoicecd    = NULL;
 
-#define FREQ   48000
+#define FREQ   SOUND_FREQ
 #define BUFLEN SOUNDBUFLEN
 
 static void WINAPI


### PR DESCRIPTION
Summary
=======
Magic numbers for sound freq changed to defines, initial work for frequency customization

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
