### PR TITLE
mouse_wacom_tablet: Resets now set the mode properly

### DIFF
--- a/src/device/mouse_wacom_tablet.c
+++ b/src/device/mouse_wacom_tablet.c
@@ -81,7 +81,6 @@ wacom_reset(mouse_wacom_t *wacom)
     wacom->mode                 = WACOM_MODE_POINT;
     wacom->data_pos             = 0;
     wacom->transmission_ongoing = 0;
-    wacom->mode                 = 0;
     wacom->transmission_stopped = 0;
     wacom->interval             = 0;
     wacom->transmit_id          = 0;


### PR DESCRIPTION
Summary
=======
mouse_wacom_tablet: Resets now set the mode properly

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
