### PR TITLE
mouse_wacom_tablet: Point mode is disabled when suppressed mode is enabled

### DIFF
--- a/src/device/mouse_wacom_tablet.c
+++ b/src/device/mouse_wacom_tablet.c
@@ -330,6 +330,8 @@ wacom_report_timer(void *priv)
 
             case WACOM_MODE_POINT:
                 {
+                    if (wacom->suppressed_increment)
+                        break;
                     if (!(wacom_switch_off_to_on(wacom->b, wacom->oldb)))
                         return;
                     break;


### PR DESCRIPTION
Summary
=======
mouse_wacom_tablet: Point mode is disabled when suppressed mode is enabled

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
