### PR TITLE
Accept raw input from non-primary monitor windows on Qt

### DIFF
--- a/src/qt/qt_winrawinputfilter.cpp
+++ b/src/qt/qt_winrawinputfilter.cpp
@@ -45,9 +45,11 @@
 #include <array>
 #include <memory>
 
+#include "qt_rendererstack.hpp"
+
 extern "C" void win_joystick_handle(PRAWINPUT);
 std::unique_ptr<WindowsRawInputFilter>
-WindowsRawInputFilter::Register(QMainWindow *window)
+WindowsRawInputFilter::Register(MainWindow *window)
 {
     HWND wnd = (HWND) window->winId();
 
@@ -70,7 +72,7 @@ WindowsRawInputFilter::Register(QMainWindow *window)
     return inputfilter;
 }
 
-WindowsRawInputFilter::WindowsRawInputFilter(QMainWindow *window)
+WindowsRawInputFilter::WindowsRawInputFilter(MainWindow *window)
 {
     this->window = window;
 
@@ -108,8 +110,18 @@ WindowsRawInputFilter::nativeEventFilter(const QByteArray &eventType, void *mess
         MSG *msg = static_cast<MSG *>(message);
 
         if (msg->message == WM_INPUT) {
+
             if (window->isActiveWindow() && menus_open == 0)
                 handle_input((HRAWINPUT) msg->lParam);
+            else
+            {
+                for (auto &w : window->renderers) {
+                    if (w && w->isActiveWindow()) {
+                        handle_input((HRAWINPUT) msg->lParam);
+                        break;
+                    }
+                }
+            }
 
             return true;
         }

--- a/src/qt/qt_winrawinputfilter.hpp
+++ b/src/qt/qt_winrawinputfilter.hpp
@@ -41,6 +41,8 @@
 
 #include <memory>
 
+#include "qt_mainwindow.hpp"
+
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #    define result_t qintptr
 #else
@@ -51,7 +53,7 @@ class WindowsRawInputFilter : public QObject, public QAbstractNativeEventFilter 
     Q_OBJECT
 
 public:
-    static std::unique_ptr<WindowsRawInputFilter> Register(QMainWindow *window);
+    static std::unique_ptr<WindowsRawInputFilter> Register(MainWindow *window);
 
     bool nativeEventFilter(const QByteArray &eventType, void *message, result_t *result) override;
 
@@ -61,7 +63,7 @@ public slots:
     void mousePoll();
 
 private:
-    QMainWindow *window;
+    MainWindow *window;
     uint16_t     scancode_map[768];
     int          buttons    = 0;
     int          dx         = 0;
@@ -69,7 +71,7 @@ private:
     int          dwheel     = 0;
     int          menus_open = 0;
 
-    WindowsRawInputFilter(QMainWindow *window);
+    WindowsRawInputFilter(MainWindow *window);
 
     void          handle_input(HRAWINPUT input);
     void          keyboard_handle(PRAWINPUT raw);


### PR DESCRIPTION
Summary
=======
Raw input was processed only when main window is active. Now we have 2nd monitor window that can also be active. If the main window isn't active, non-primary monitor windows are checked for activity too and raw input processed for them also.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
