### PR TITLE
qt: Multimonitor and absolute mouse input fixes

### DIFF
--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -138,7 +138,11 @@ main_thread_fn()
     }
 
     is_quit = 1;
-    QTimer::singleShot(0, QApplication::instance(), []() { QApplication::instance()->quit(); });
+    if (gfxcard[1]) {
+        ui_deinit_monitor(1);
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+    QTimer::singleShot(0, QApplication::instance(), []() { QApplication::processEvents(); QApplication::instance()->quit(); });
 }
 
 static std::thread *main_thread;

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -733,7 +733,9 @@ MainWindow::initRendererMonitorSlot(int monitor_index)
                 secondaryRenderer->showMaximized();
             }
             secondaryRenderer->switchRenderer((RendererStack::Renderer) vid_api);
+            secondaryRenderer->setMouseTracking(true);
         }
+        connect(this, &MainWindow::pollMouse, secondaryRenderer.get(), &RendererStack::mousePoll, Qt::DirectConnection);
     }
 }
 

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -151,6 +151,9 @@ RendererStack::mousePoll()
             if (!mouse_tablet_in_proximity) {
                 mouse_tablet_in_proximity = mousedata.mouse_tablet_in_proximity;
             }
+            if (mousedata.mouse_tablet_in_proximity) {
+                mouse_buttons = mousedata.mousebuttons;
+            }
         }
         return;
     }


### PR DESCRIPTION
Summary
=======
[Fix crashes when exiting emulator in multimonitor modes](https://github.com/86Box/86Box/commit/e650ec75052132bb811fdf164538d6182e8e8630)
[Absolute mouse input now works on secondary monitors](https://github.com/86Box/86Box/commit/7de41b383c2f0d4925b433fb7250aa8d7aebae80)

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
