### PR TITLE
vid_voodoo_banshee: Extend screen filter buffers to 2048 * 3 bytes

### DIFF
--- a/src/video/vid_voodoo_banshee.c
+++ b/src/video/vid_voodoo_banshee.c
@@ -2265,10 +2265,9 @@ banshee_overlay_draw(svga_t *svga, int displine)
 
             case VIDPROCCFG_FILTER_MODE_DITHER_4X4:
                 if (banshee->voodoo->scrfilter && banshee->voodoo->scrfilterEnabled) {
-                    uint8_t fil[64 * 3];
-                    uint8_t fil3[64 * 3];
+                    uint8_t fil[2048 * 3];
+                    uint8_t fil3[2048 * 3];
 
-                    assert(svga->overlay_latch.cur_xsize <= 64);
                     if (banshee->vidProcCfg & VIDPROCCFG_H_SCALE_ENABLE) /* leilei HACK - don't know of real 4x1 hscaled behavior yet, double for now */
                     {
                         for (x = 0; x < svga->overlay_latch.cur_xsize; x++) {
@@ -2335,16 +2334,15 @@ banshee_overlay_draw(svga_t *svga, int displine)
 
             case VIDPROCCFG_FILTER_MODE_DITHER_2X2:
                 if (banshee->voodoo->scrfilter && banshee->voodoo->scrfilterEnabled) {
-                    uint8_t fil[64 * 3];
-                    uint8_t soak[64 * 3];
-                    uint8_t soak2[64 * 3];
+                    uint8_t fil[2048 * 3];
+                    uint8_t soak[2048 * 3];
+                    uint8_t soak2[2048 * 3];
 
-                    uint8_t samp1[64 * 3];
-                    uint8_t samp2[64 * 3];
-                    uint8_t samp3[64 * 3];
-                    uint8_t samp4[64 * 3];
+                    uint8_t samp1[2048 * 3];
+                    uint8_t samp2[2048 * 3];
+                    uint8_t samp3[2048 * 3];
+                    uint8_t samp4[2048 * 3];
 
-                    assert(svga->overlay_latch.cur_xsize <= 64);
                     src = &svga->vram[src_addr2 & svga->vram_mask];
                     OVERLAY_SAMPLE(banshee->overlay_buffer[1]);
                     for (x = 0; x < svga->overlay_latch.cur_xsize; x++) {


### PR DESCRIPTION
Summary
=======
vid_voodoo_banshee: Extend screen filter buffers to 2048 * 3 bytes.

Fixes crashes when screen filtering is enabled and AmigaSport V3.0 drivers for Windows XP are used.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
