### PR TITLE
mpu401: Extend MPU401_QUEUE to 1024 bytes

### DIFF
--- a/src/include/86box/snd_mpu401.h
+++ b/src/include/86box/snd_mpu401.h
@@ -26,7 +26,7 @@
 
 #define MPU401_VERSION      0x15
 #define MPU401_REVISION     0x01
-#define MPU401_QUEUE        64
+#define MPU401_QUEUE        1024
 #define MPU401_INPUT_QUEUE  1024
 #define MPU401_TIMECONSTANT (60000000 / 1000.0f)
 #define MPU401_RESETBUSY    27.0f


### PR DESCRIPTION
Summary
=======
mpu401: Extend MPU401_QUEUE to 1024 bytes.

Allows SysEx messages larger than 64 bytes to be received correctly.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
