### PR TITLE
vid_mga: Make Matrox Millennium multi-monitor compatible

### DIFF
--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -5126,9 +5126,9 @@ mystique_hwcursor_draw(svga_t *svga, int displine)
         case XCURCTRL_CURMODE_XGA:
             for (x = 0; x < 64; x++) {
                 if (!(dat[1] & (1ull << 63)))
-                    buffer32->line[displine][offset + svga->x_add] = (dat[0] & (1ull << 63)) ? mystique->cursor.col[1] : mystique->cursor.col[0];
+                    svga->monitor->target_buffer->line[displine][offset + svga->x_add] = (dat[0] & (1ull << 63)) ? mystique->cursor.col[1] : mystique->cursor.col[0];
                 else if (dat[0] & (1ull << 63))
-                    buffer32->line[displine][offset + svga->x_add] ^= 0xffffff;
+                    svga->monitor->target_buffer->line[displine][offset + svga->x_add] ^= 0xffffff;
 
                 offset++;
                 dat[0] <<= 1;

--- a/src/video/vid_table.c
+++ b/src/video/vid_table.c
@@ -199,7 +199,7 @@ video_cards[] = {
     { &s3_diamond_stealth_4000_pci_device            },
     { &s3_trio3d2x_pci_device                        },
 #if defined(DEV_BRANCH) && defined(USE_MGA)
-    { &millennium_device                             },
+    { &millennium_device,    VIDEO_FLAG_TYPE_SPECIAL },
     { &mystique_device                               },
     { &mystique_220_device                           },
 #endif

--- a/src/video/vid_tvp3026_ramdac.c
+++ b/src/video/vid_tvp3026_ramdac.c
@@ -489,7 +489,7 @@ tvp3026_hwcursor_draw(svga_t *svga, int displine)
 
             y_pos = displine;
             x_pos = offset + svga->x_add;
-            p     = buffer32->line[y_pos];
+            p     = svga->monitor->target_buffer->line[y_pos];
 
             if (offset >= svga->dac_hwcursor_latch.x) {
                 switch (mode) {


### PR DESCRIPTION
Summary
=======
vid_mga: Make Matrox Millennium multi-monitor compatible.

Tested working under Windows XP with AGP Voodoo 3 AmigaSport v3.0 drivers and built-in Matrox Millennium drivers. The latter is to be selected as primary in BIOS settings if feasible for Windows XP's multi-monitor to work properly.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
