### PR TITLE
 Whitespace in win32 lang files (2/2)

### DIFF
--- a/src/win/languages/cs-CZ.rc
+++ b/src/win/languages/cs-CZ.rc
@@ -13,7 +13,7 @@ LANGUAGE LANG_CZECH, SUBLANG_DEFAULT
 // Menu
 //
 
-MainMenu MENU DISCARDABLE 
+MainMenu MENU DISCARDABLE
 BEGIN
     POPUP "&Akce"
     BEGIN
@@ -34,7 +34,7 @@ BEGIN
         MENUITEM "&Schovat stavový řádek", IDM_VID_HIDE_STATUS_BAR
         MENUITEM "Schovat panel &nástrojů", IDM_VID_HIDE_TOOLBAR
         MENUITEM SEPARATOR
-        MENUITEM "&Show non-primary monitors",   IDM_VID_MONITORS
+        MENUITEM "&Show non-primary monitors", IDM_VID_MONITORS
         MENUITEM "&Měnitelná velikost okna", IDM_VID_RESIZE
         MENUITEM "&Pamatovat velikost a pozici", IDM_VID_REMEMBER
         MENUITEM SEPARATOR
@@ -128,7 +128,7 @@ BEGIN
     END
 END
 
-StatusBarMenu MENU DISCARDABLE 
+StatusBarMenu MENU DISCARDABLE
 BEGIN
     MENUITEM SEPARATOR
 END
@@ -392,7 +392,7 @@ END
 // String Table
 //
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     2048        "86Box"
     IDS_2049    "Chyba"
@@ -412,7 +412,7 @@ BEGIN
     IDS_2063    "Počítač ""%hs"" není dostupný, jelikož chybí obraz jeho paměti ROM ve složce ""roms/machines"". Konfigurace se přepne na jiný dostupný počítač."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2064    "Video adaptér ""%hs"" není dostupný, jelikož chybí obraz jeho paměti ROM ve složce ""roms/video"". Konfigurace se přepne na jiný dostupný adaptér."
     IDS_2065    "Počítač"
@@ -432,7 +432,7 @@ BEGIN
     IDS_2079    "Stiskněte F8+F12 nebo prostřední tlačítko pro uvolnění myši"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2080    "Nastala chyba při inicializaci knihovny FluidSynth."
     IDS_2081    "Sběrnice"
@@ -544,7 +544,7 @@ BEGIN
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_4096    "Pevný disk (%s)"
     IDS_4097    "%01i:%01i"

--- a/src/win/languages/de-DE.rc
+++ b/src/win/languages/de-DE.rc
@@ -13,7 +13,7 @@ LANGUAGE LANG_GERMAN, SUBLANG_DEFAULT
 // Menu
 //
 
-MainMenu MENU DISCARDABLE 
+MainMenu MENU DISCARDABLE
 BEGIN
     POPUP "&Aktionen"
     BEGIN
@@ -128,7 +128,7 @@ BEGIN
     END
 END
 
-StatusBarMenu MENU DISCARDABLE 
+StatusBarMenu MENU DISCARDABLE
 BEGIN
     MENUITEM SEPARATOR
 END
@@ -392,7 +392,7 @@ END
 // String Table
 //
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     2048        "86Box"
     IDS_2049    "Fehler"
@@ -412,7 +412,7 @@ BEGIN
     IDS_2063    "Das System ""%hs"" ist aufgrund von fehlenden ROMs im Verzeichnis roms/machines nicht verfügbar. Es wird auf ein verfügbares System gewechselt."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2064    "Die Videokarte ""%hs"" ist aufgrund von fehlenden ROMs im Verzeichnis roms/video nicht verfügbar. Es wird auf eine verfügbare Videokarte gewechselt."
     IDS_2065    "System"
@@ -432,7 +432,7 @@ BEGIN
     IDS_2079    "Bitte F8+F12 oder die mittlere Maustaste zur Mausfreigabe drücken"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2080    "FluidSynth konnte nicht initialisiert werden"
     IDS_2081    "Bus"
@@ -544,7 +544,7 @@ BEGIN
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_4096    "Festplatte (%s)"
     IDS_4097    "%01i:%01i"
@@ -643,7 +643,7 @@ BEGIN
 
     IDS_7168    "(Systemstandard)"
 END
-#define IDS_LANG_ENUS    IDS_7168
+#define IDS_LANG_ENUS IDS_7168
 
 // German (de-DE) resources
 /////////////////////////////////////////////////////////////////////////////

--- a/src/win/languages/en-GB.rc
+++ b/src/win/languages/en-GB.rc
@@ -13,7 +13,7 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_UK
 // Menu
 //
 
-MainMenu MENU DISCARDABLE 
+MainMenu MENU DISCARDABLE
 BEGIN
     POPUP "&Action"
     BEGIN
@@ -40,12 +40,12 @@ BEGIN
         MENUITEM SEPARATOR
         POPUP "Re&nderer"
         BEGIN
-            MENUITEM "&SDL (Software)",    IDM_VID_SDL_SW
-            MENUITEM "SDL (&Hardware)",    IDM_VID_SDL_HW
-            MENUITEM "SDL (&OpenGL)",      IDM_VID_SDL_OPENGL
+            MENUITEM "&SDL (Software)", IDM_VID_SDL_SW
+            MENUITEM "SDL (&Hardware)", IDM_VID_SDL_HW
+            MENUITEM "SDL (&OpenGL)", IDM_VID_SDL_OPENGL
             MENUITEM "Open&GL (3.0 Core)", IDM_VID_OPENGL_CORE
 #ifdef USE_VNC
-            MENUITEM "&VNC",               IDM_VID_VNC
+            MENUITEM "&VNC", IDM_VID_VNC
 #endif
         END
         MENUITEM SEPARATOR
@@ -53,16 +53,16 @@ BEGIN
         MENUITEM "F&orce 4:3 display ratio", IDM_VID_FORCE43
         POPUP "&Window scale factor"
         BEGIN
-            MENUITEM "&0.5x",                   IDM_VID_SCALE_1X
-            MENUITEM "&1x",                     IDM_VID_SCALE_2X
-            MENUITEM "1.&5x",                   IDM_VID_SCALE_3X
-            MENUITEM "&2x",                     IDM_VID_SCALE_4X
-            MENUITEM "&3x",                     IDM_VID_SCALE_5X
-            MENUITEM "&4x",                     IDM_VID_SCALE_6X
-            MENUITEM "&5x",                     IDM_VID_SCALE_7X
-            MENUITEM "&6x",                     IDM_VID_SCALE_8X
-            MENUITEM "&7x",                     IDM_VID_SCALE_9X
-            MENUITEM "&8x",                     IDM_VID_SCALE_10X
+            MENUITEM "&0.5x", IDM_VID_SCALE_1X
+            MENUITEM "&1x", IDM_VID_SCALE_2X
+            MENUITEM "1.&5x", IDM_VID_SCALE_3X
+            MENUITEM "&2x", IDM_VID_SCALE_4X
+            MENUITEM "&3x", IDM_VID_SCALE_5X
+            MENUITEM "&4x", IDM_VID_SCALE_6X
+            MENUITEM "&5x", IDM_VID_SCALE_7X
+            MENUITEM "&6x", IDM_VID_SCALE_8X
+            MENUITEM "&7x", IDM_VID_SCALE_9X
+            MENUITEM "&8x", IDM_VID_SCALE_10X
         END
         POPUP "Filter method"
         BEGIN
@@ -109,7 +109,7 @@ BEGIN
         MENUITEM SEPARATOR
         MENUITEM "Take s&creenshot\tCtrl+F11", IDM_ACTION_SCREENSHOT
         MENUITEM SEPARATOR
-        MENUITEM "&Preferences...",        IDM_PREFERENCES
+        MENUITEM "&Preferences...", IDM_PREFERENCES
 #ifdef DISCORD
         MENUITEM "Enable &Discord integration", IDM_DISCORD
 #endif
@@ -128,7 +128,7 @@ BEGIN
     END
 END
 
-StatusBarMenu MENU DISCARDABLE 
+StatusBarMenu MENU DISCARDABLE
 BEGIN
     MENUITEM SEPARATOR
 END
@@ -296,42 +296,42 @@ END
 #define STR_SOUND2        "Sound card 2:"
 #define STR_SOUND3        "Sound card 3:"
 #define STR_SOUND4        "Sound card 4:"
-#define STR_MIDI_OUT    "MIDI Out Device:"
-#define STR_MIDI_IN        "MIDI In Device:"
+#define STR_MIDI_OUT      "MIDI Out Device:"
+#define STR_MIDI_IN       "MIDI In Device:"
 #define STR_MPU401        "Standalone MPU-401"
-#define STR_FLOAT        "Use FLOAT32 sound"
-#define STR_FM_DRIVER        "FM synth driver"
-#define STR_FM_DRV_NUKED    "Nuked (more accurate)"
-#define STR_FM_DRV_YMFM        "YMFM (faster)"
+#define STR_FLOAT         "Use FLOAT32 sound"
+#define STR_FM_DRIVER     "FM synth driver"
+#define STR_FM_DRV_NUKED  "Nuked (more accurate)"
+#define STR_FM_DRV_YMFM   "YMFM (faster)"
 
-#define STR_NET_TYPE    "Network type:"
-#define STR_PCAP        "PCap device:"
-#define STR_NET            "Network adapter:"
-#define STR_NET1        "Network card 1:"
-#define STR_NET2        "Network card 2:"
-#define STR_NET3        "Network card 3:"
-#define STR_NET4        "Network card 4:"
+#define STR_NET_TYPE      "Network type:"
+#define STR_PCAP          "PCap device:"
+#define STR_NET           "Network adapter:"
+#define STR_NET1          "Network card 1:"
+#define STR_NET2          "Network card 2:"
+#define STR_NET3          "Network card 3:"
+#define STR_NET4          "Network card 4:"
 
-#define STR_COM1        "COM1 Device:"
-#define STR_COM2        "COM2 Device:"
-#define STR_COM3        "COM3 Device:"
-#define STR_COM4        "COM4 Device:"
-#define STR_LPT1        "LPT1 Device:"
-#define STR_LPT2        "LPT2 Device:"
-#define STR_LPT3        "LPT3 Device:"
-#define STR_LPT4        "LPT4 Device:"
-#define STR_SERIAL1        "Serial port 1"
-#define STR_SERIAL2        "Serial port 2"
-#define STR_SERIAL3        "Serial port 3"
-#define STR_SERIAL4        "Serial port 4"
-#define STR_PARALLEL1        "Parallel port 1"
-#define STR_PARALLEL2        "Parallel port 2"
-#define STR_PARALLEL3        "Parallel port 3"
-#define STR_PARALLEL4        "Parallel port 4"
-#define STR_SERIAL_PASS1    "Serial port passthrough 1"
-#define STR_SERIAL_PASS2    "Serial port passthrough 2"
-#define STR_SERIAL_PASS3    "Serial port passthrough 3"
-#define STR_SERIAL_PASS4    "Serial port passthrough 4"
+#define STR_COM1          "COM1 Device:"
+#define STR_COM2          "COM2 Device:"
+#define STR_COM3          "COM3 Device:"
+#define STR_COM4          "COM4 Device:"
+#define STR_LPT1          "LPT1 Device:"
+#define STR_LPT2          "LPT2 Device:"
+#define STR_LPT3          "LPT3 Device:"
+#define STR_LPT4          "LPT4 Device:"
+#define STR_SERIAL1       "Serial port 1"
+#define STR_SERIAL2       "Serial port 2"
+#define STR_SERIAL3       "Serial port 3"
+#define STR_SERIAL4       "Serial port 4"
+#define STR_PARALLEL1     "Parallel port 1"
+#define STR_PARALLEL2     "Parallel port 2"
+#define STR_PARALLEL3     "Parallel port 3"
+#define STR_PARALLEL4     "Parallel port 4"
+#define STR_SERIAL_PASS1  "Serial port passthrough 1"
+#define STR_SERIAL_PASS2  "Serial port passthrough 2"
+#define STR_SERIAL_PASS3  "Serial port passthrough 3"
+#define STR_SERIAL_PASS4  "Serial port passthrough 4"
 
 #define STR_HDC           "HD Controller:"
 #define STR_FDC           "FD Controller:"
@@ -392,7 +392,7 @@ END
 // String Table
 //
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     2048        "86Box"
     IDS_2049    "Error"
@@ -412,7 +412,7 @@ BEGIN
     IDS_2063    "Machine ""%hs"" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2064    "Video card ""%hs"" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
     IDS_2065    "Machine"
@@ -432,7 +432,7 @@ BEGIN
     IDS_2079    "Press F8+F12 or middle button to release mouse"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2080    "Unable to initialize FluidSynth"
     IDS_2081    "Bus"
@@ -544,7 +544,7 @@ BEGIN
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_4096    "Hard disk (%s)"
     IDS_4097    "%01i:%01i"

--- a/src/win/languages/en-US.rc
+++ b/src/win/languages/en-US.rc
@@ -13,78 +13,78 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 // Menu
 //
 
-MainMenu MENU DISCARDABLE 
+MainMenu MENU DISCARDABLE
 BEGIN
     POPUP "&Action"
     BEGIN
         MENUITEM "&Keyboard requires capture", IDM_ACTION_KBD_REQ_CAPTURE
-        MENUITEM "&Right CTRL is left ALT",    IDM_ACTION_RCTRL_IS_LALT
+        MENUITEM "&Right CTRL is left ALT", IDM_ACTION_RCTRL_IS_LALT
         MENUITEM SEPARATOR
-        MENUITEM "&Hard Reset...",             IDM_ACTION_HRESET
-        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12",    IDM_ACTION_RESET_CAD
+        MENUITEM "&Hard Reset...", IDM_ACTION_HRESET
+        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12", IDM_ACTION_RESET_CAD
         MENUITEM SEPARATOR
-        MENUITEM "Ctrl+Alt+&Esc",              IDM_ACTION_CTRL_ALT_ESC
+        MENUITEM "Ctrl+Alt+&Esc", IDM_ACTION_CTRL_ALT_ESC
         MENUITEM SEPARATOR
-        MENUITEM "&Pause",                     IDM_ACTION_PAUSE
+        MENUITEM "&Pause", IDM_ACTION_PAUSE
         MENUITEM SEPARATOR
-        MENUITEM "E&xit...",                   IDM_ACTION_EXIT
+        MENUITEM "E&xit...", IDM_ACTION_EXIT
     END
     POPUP "&View"
     BEGIN
-        MENUITEM "&Hide status bar",           IDM_VID_HIDE_STATUS_BAR
-        MENUITEM "Hide &toolbar",              IDM_VID_HIDE_TOOLBAR
+        MENUITEM "&Hide status bar", IDM_VID_HIDE_STATUS_BAR
+        MENUITEM "Hide &toolbar", IDM_VID_HIDE_TOOLBAR
         MENUITEM SEPARATOR
         MENUITEM "&Show non-primary monitors", IDM_VID_MONITORS
-        MENUITEM "&Resizeable window",         IDM_VID_RESIZE
+        MENUITEM "&Resizeable window", IDM_VID_RESIZE
         MENUITEM "R&emember size && position", IDM_VID_REMEMBER
         MENUITEM SEPARATOR
         POPUP "Re&nderer"
         BEGIN
-            MENUITEM "&SDL (Software)",    IDM_VID_SDL_SW
-            MENUITEM "SDL (&Hardware)",    IDM_VID_SDL_HW
-            MENUITEM "SDL (&OpenGL)",      IDM_VID_SDL_OPENGL
+            MENUITEM "&SDL (Software)", IDM_VID_SDL_SW
+            MENUITEM "SDL (&Hardware)", IDM_VID_SDL_HW
+            MENUITEM "SDL (&OpenGL)", IDM_VID_SDL_OPENGL
             MENUITEM "Open&GL (3.0 Core)", IDM_VID_OPENGL_CORE
 #ifdef USE_VNC
-            MENUITEM "&VNC",               IDM_VID_VNC
+            MENUITEM "&VNC", IDM_VID_VNC
 #endif
         END
         MENUITEM SEPARATOR
-        MENUITEM "Specify dimensions...",    IDM_VID_SPECIFY_DIM
+        MENUITEM "Specify dimensions...", IDM_VID_SPECIFY_DIM
         MENUITEM "F&orce 4:3 display ratio", IDM_VID_FORCE43
         POPUP "&Window scale factor"
         BEGIN
-            MENUITEM "&0.5x",                   IDM_VID_SCALE_1X
-            MENUITEM "&1x",                     IDM_VID_SCALE_2X
-            MENUITEM "1.&5x",                   IDM_VID_SCALE_3X
-            MENUITEM "&2x",                     IDM_VID_SCALE_4X
-            MENUITEM "&3x",                     IDM_VID_SCALE_5X
-            MENUITEM "&4x",                     IDM_VID_SCALE_6X
-            MENUITEM "&5x",                     IDM_VID_SCALE_7X
-            MENUITEM "&6x",                     IDM_VID_SCALE_8X
-            MENUITEM "&7x",                     IDM_VID_SCALE_9X
-            MENUITEM "&8x",                     IDM_VID_SCALE_10X
+            MENUITEM "&0.5x", IDM_VID_SCALE_1X
+            MENUITEM "&1x", IDM_VID_SCALE_2X
+            MENUITEM "1.&5x", IDM_VID_SCALE_3X
+            MENUITEM "&2x", IDM_VID_SCALE_4X
+            MENUITEM "&3x", IDM_VID_SCALE_5X
+            MENUITEM "&4x", IDM_VID_SCALE_6X
+            MENUITEM "&5x", IDM_VID_SCALE_7X
+            MENUITEM "&6x", IDM_VID_SCALE_8X
+            MENUITEM "&7x", IDM_VID_SCALE_9X
+            MENUITEM "&8x", IDM_VID_SCALE_10X
         END
         POPUP "Filter method"
         BEGIN
             MENUITEM "&Nearest", IDM_VID_FILTER_NEAREST
-            MENUITEM "&Linear",  IDM_VID_FILTER_LINEAR
+            MENUITEM "&Linear", IDM_VID_FILTER_LINEAR
         END
-        MENUITEM "Hi&DPI scaling",             IDM_VID_HIDPI
+        MENUITEM "Hi&DPI scaling", IDM_VID_HIDPI
         MENUITEM SEPARATOR
         MENUITEM "&Fullscreen\tCtrl+Alt+PgUp", IDM_VID_FULLSCREEN
         POPUP "Fullscreen &stretch mode"
         BEGIN
-            MENUITEM "&Full screen stretch",        IDM_VID_FS_FULL
-            MENUITEM "&4:3",                        IDM_VID_FS_43
+            MENUITEM "&Full screen stretch", IDM_VID_FS_FULL
+            MENUITEM "&4:3", IDM_VID_FS_43
             MENUITEM "&Square pixels (Keep ratio)", IDM_VID_FS_KEEPRATIO
-            MENUITEM "&Integer scale",              IDM_VID_FS_INT
+            MENUITEM "&Integer scale", IDM_VID_FS_INT
         END
         POPUP "E&GA/(S)VGA settings"
         BEGIN
             MENUITEM "&Inverted VGA monitor", IDM_VID_INVERT
             POPUP "VGA screen &type"
             BEGIN
-                MENUITEM "RGB &Color",     IDM_VID_GRAY_RGB
+                MENUITEM "RGB &Color", IDM_VID_GRAY_RGB
                 MENUITEM "&RGB Grayscale", IDM_VID_GRAY_MONO
                 MENUITEM "&Amber monitor", IDM_VID_GRAY_AMBER
                 MENUITEM "&Green monitor", IDM_VID_GRAY_GREEN
@@ -93,42 +93,42 @@ BEGIN
             POPUP "Grayscale &conversion type"
             BEGIN
                 MENUITEM "BT&601 (NTSC/PAL)", IDM_VID_GRAYCT_601
-                MENUITEM "BT&709 (HDTV)",     IDM_VID_GRAYCT_709
-                MENUITEM "&Average",          IDM_VID_GRAYCT_AVE
+                MENUITEM "BT&709 (HDTV)", IDM_VID_GRAYCT_709
+                MENUITEM "&Average", IDM_VID_GRAYCT_AVE
             END
         END
         MENUITEM SEPARATOR
-        MENUITEM "CGA/PCjr/Tandy/E&GA/(S)VGA overscan",     IDM_VID_OVERSCAN
+        MENUITEM "CGA/PCjr/Tandy/E&GA/(S)VGA overscan", IDM_VID_OVERSCAN
         MENUITEM "Change contrast for &monochrome display", IDM_VID_CGACON
     END
     MENUITEM "&Media", IDM_MEDIA
     POPUP "&Tools"
     BEGIN
-        MENUITEM "&Settings...",                IDM_CONFIG
-        MENUITEM "&Update status bar icons",    IDM_UPDATE_ICONS
+        MENUITEM "&Settings...", IDM_CONFIG
+        MENUITEM "&Update status bar icons", IDM_UPDATE_ICONS
         MENUITEM SEPARATOR
-        MENUITEM "Take s&creenshot\tCtrl+F11",  IDM_ACTION_SCREENSHOT
+        MENUITEM "Take s&creenshot\tCtrl+F11", IDM_ACTION_SCREENSHOT
         MENUITEM SEPARATOR
-        MENUITEM "&Preferences...",        IDM_PREFERENCES
+        MENUITEM "&Preferences...", IDM_PREFERENCES
 #ifdef DISCORD
         MENUITEM "Enable &Discord integration", IDM_DISCORD
 #endif
         MENUITEM SEPARATOR
-        MENUITEM "Sound &gain...",              IDM_SND_GAIN
+        MENUITEM "Sound &gain...", IDM_SND_GAIN
 #ifdef MTR_ENABLED
         MENUITEM SEPARATOR
-        MENUITEM "Begin trace\tCtrl+T",         IDM_ACTION_BEGIN_TRACE
-        MENUITEM "End trace\tCtrl+T",           IDM_ACTION_END_TRACE
+        MENUITEM "Begin trace\tCtrl+T", IDM_ACTION_BEGIN_TRACE
+        MENUITEM "End trace\tCtrl+T", IDM_ACTION_END_TRACE
 #endif
     END
     POPUP "&Help"
     BEGIN
         MENUITEM "&Documentation...", IDM_DOCS
-        MENUITEM "&About 86Box...",   IDM_ABOUT
+        MENUITEM "&About 86Box...", IDM_ABOUT
     END
 END
 
-StatusBarMenu MENU DISCARDABLE 
+StatusBarMenu MENU DISCARDABLE
 BEGIN
     MENUITEM SEPARATOR
 END
@@ -137,17 +137,17 @@ CassetteSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&New image...",                        IDM_CASSETTE_IMAGE_NEW
+        MENUITEM "&New image...", IDM_CASSETTE_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Existing image...",                   IDM_CASSETTE_IMAGE_EXISTING
+        MENUITEM "&Existing image...", IDM_CASSETTE_IMAGE_EXISTING
         MENUITEM "Existing image (&Write-protected)...", IDM_CASSETTE_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Record",                              IDM_CASSETTE_RECORD
-        MENUITEM "&Play",                                IDM_CASSETTE_PLAY
-        MENUITEM "&Rewind to the beginning",             IDM_CASSETTE_REWIND
-        MENUITEM "&Fast forward to the end",             IDM_CASSETTE_FAST_FORWARD
+        MENUITEM "&Record", IDM_CASSETTE_RECORD
+        MENUITEM "&Play", IDM_CASSETTE_PLAY
+        MENUITEM "&Rewind to the beginning", IDM_CASSETTE_REWIND
+        MENUITEM "&Fast forward to the end", IDM_CASSETTE_FAST_FORWARD
         MENUITEM SEPARATOR
-        MENUITEM "E&ject",                               IDM_CASSETTE_EJECT
+        MENUITEM "E&ject", IDM_CASSETTE_EJECT
     END
 END
 
@@ -157,7 +157,7 @@ BEGIN
     BEGIN
         MENUITEM "&Image...", IDM_CARTRIDGE_IMAGE
         MENUITEM SEPARATOR
-        MENUITEM "E&ject",    IDM_CARTRIDGE_EJECT
+        MENUITEM "E&ject", IDM_CARTRIDGE_EJECT
     END
 END
 
@@ -165,14 +165,14 @@ FloppySubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&New image...",                        IDM_FLOPPY_IMAGE_NEW
+        MENUITEM "&New image...", IDM_FLOPPY_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Existing image...",                   IDM_FLOPPY_IMAGE_EXISTING
+        MENUITEM "&Existing image...", IDM_FLOPPY_IMAGE_EXISTING
         MENUITEM "Existing image (&Write-protected)...", IDM_FLOPPY_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "E&xport to 86F...",                    IDM_FLOPPY_EXPORT_TO_86F
+        MENUITEM "E&xport to 86F...", IDM_FLOPPY_EXPORT_TO_86F
         MENUITEM SEPARATOR
-        MENUITEM "E&ject",                               IDM_FLOPPY_EJECT
+        MENUITEM "E&ject", IDM_FLOPPY_EJECT
     END
 END
 
@@ -180,13 +180,13 @@ CdromSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Mute",                  IDM_CDROM_MUTE
+        MENUITEM "&Mute", IDM_CDROM_MUTE
         MENUITEM SEPARATOR
-        MENUITEM "E&mpty",                 IDM_CDROM_EMPTY
+        MENUITEM "E&mpty", IDM_CDROM_EMPTY
         MENUITEM "&Reload previous image", IDM_CDROM_RELOAD
         MENUITEM SEPARATOR
-        MENUITEM "&Image...",              IDM_CDROM_IMAGE
-        MENUITEM "&Folder...",             IDM_CDROM_DIR
+        MENUITEM "&Image...", IDM_CDROM_IMAGE
+        MENUITEM "&Folder...", IDM_CDROM_DIR
     END
 END
 
@@ -194,13 +194,13 @@ ZIPSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&New image...",                        IDM_ZIP_IMAGE_NEW
+        MENUITEM "&New image...", IDM_ZIP_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Existing image...",                   IDM_ZIP_IMAGE_EXISTING
+        MENUITEM "&Existing image...", IDM_ZIP_IMAGE_EXISTING
         MENUITEM "Existing image (&Write-protected)...", IDM_ZIP_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "E&ject",                               IDM_ZIP_EJECT
-        MENUITEM "&Reload previous image",               IDM_ZIP_RELOAD
+        MENUITEM "E&ject", IDM_ZIP_EJECT
+        MENUITEM "&Reload previous image", IDM_ZIP_RELOAD
     END
 END
 
@@ -208,13 +208,13 @@ MOSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&New image...",                        IDM_MO_IMAGE_NEW
+        MENUITEM "&New image...", IDM_MO_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Existing image...",                   IDM_MO_IMAGE_EXISTING
+        MENUITEM "&Existing image...", IDM_MO_IMAGE_EXISTING
         MENUITEM "Existing image (&Write-protected)...", IDM_MO_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "E&ject",                               IDM_MO_EJECT
-        MENUITEM "&Reload previous image",               IDM_MO_RELOAD
+        MENUITEM "E&ject", IDM_MO_EJECT
+        MENUITEM "&Reload previous image", IDM_MO_RELOAD
     END
 END
 
@@ -223,15 +223,15 @@ BEGIN
     POPUP "Target &framerate"
     BEGIN
         MENUITEM "&Sync with video", IDM_VID_GL_FPS_BLITTER
-        MENUITEM "&25 fps",          IDM_VID_GL_FPS_25
-        MENUITEM "&30 fps",          IDM_VID_GL_FPS_30
-        MENUITEM "&50 fps",          IDM_VID_GL_FPS_50
-        MENUITEM "&60 fps",          IDM_VID_GL_FPS_60
-        MENUITEM "&75 fps",          IDM_VID_GL_FPS_75
+        MENUITEM "&25 fps", IDM_VID_GL_FPS_25
+        MENUITEM "&30 fps", IDM_VID_GL_FPS_30
+        MENUITEM "&50 fps", IDM_VID_GL_FPS_50
+        MENUITEM "&60 fps", IDM_VID_GL_FPS_60
+        MENUITEM "&75 fps", IDM_VID_GL_FPS_75
     END
-    MENUITEM "&VSync",            IDM_VID_GL_VSYNC
+    MENUITEM "&VSync", IDM_VID_GL_VSYNC
     MENUITEM "&Select shader...", IDM_VID_GL_SHADER
-    MENUITEM "&Remove shader",    IDM_VID_GL_NOSHADER
+    MENUITEM "&Remove shader", IDM_VID_GL_NOSHADER
 END
 
 
@@ -296,42 +296,42 @@ END
 #define STR_SOUND2        "Sound card 2:"
 #define STR_SOUND3        "Sound card 3:"
 #define STR_SOUND4        "Sound card 4:"
-#define STR_MIDI_OUT    "MIDI Out Device:"
-#define STR_MIDI_IN        "MIDI In Device:"
+#define STR_MIDI_OUT      "MIDI Out Device:"
+#define STR_MIDI_IN       "MIDI In Device:"
 #define STR_MPU401        "Standalone MPU-401"
-#define STR_FLOAT        "Use FLOAT32 sound"
-#define STR_FM_DRIVER        "FM synth driver"
-#define STR_FM_DRV_NUKED    "Nuked (more accurate)"
-#define STR_FM_DRV_YMFM        "YMFM (faster)"
+#define STR_FLOAT         "Use FLOAT32 sound"
+#define STR_FM_DRIVER     "FM synth driver"
+#define STR_FM_DRV_NUKED  "Nuked (more accurate)"
+#define STR_FM_DRV_YMFM   "YMFM (faster)"
 
-#define STR_NET_TYPE    "Network type:"
-#define STR_PCAP        "PCap device:"
-#define STR_NET            "Network adapter:"
-#define STR_NET1        "Network card 1:"
-#define STR_NET2        "Network card 2:"
-#define STR_NET3        "Network card 3:"
-#define STR_NET4        "Network card 4:"
+#define STR_NET_TYPE      "Network type:"
+#define STR_PCAP          "PCap device:"
+#define STR_NET           "Network adapter:"
+#define STR_NET1          "Network card 1:"
+#define STR_NET2          "Network card 2:"
+#define STR_NET3          "Network card 3:"
+#define STR_NET4          "Network card 4:"
 
-#define STR_COM1        "COM1 Device:"
-#define STR_COM2        "COM2 Device:"
-#define STR_COM3        "COM3 Device:"
-#define STR_COM4        "COM4 Device:"
-#define STR_LPT1        "LPT1 Device:"
-#define STR_LPT2        "LPT2 Device:"
-#define STR_LPT3        "LPT3 Device:"
-#define STR_LPT4        "LPT4 Device:"
-#define STR_SERIAL1        "Serial port 1"
-#define STR_SERIAL2        "Serial port 2"
-#define STR_SERIAL3        "Serial port 3"
-#define STR_SERIAL4        "Serial port 4"
-#define STR_PARALLEL1        "Parallel port 1"
-#define STR_PARALLEL2        "Parallel port 2"
-#define STR_PARALLEL3        "Parallel port 3"
-#define STR_PARALLEL4        "Parallel port 4"
-#define STR_SERIAL_PASS1    "Serial port passthrough 1"
-#define STR_SERIAL_PASS2    "Serial port passthrough 2"
-#define STR_SERIAL_PASS3    "Serial port passthrough 3"
-#define STR_SERIAL_PASS4    "Serial port passthrough 4"
+#define STR_COM1          "COM1 Device:"
+#define STR_COM2          "COM2 Device:"
+#define STR_COM3          "COM3 Device:"
+#define STR_COM4          "COM4 Device:"
+#define STR_LPT1          "LPT1 Device:"
+#define STR_LPT2          "LPT2 Device:"
+#define STR_LPT3          "LPT3 Device:"
+#define STR_LPT4          "LPT4 Device:"
+#define STR_SERIAL1       "Serial port 1"
+#define STR_SERIAL2       "Serial port 2"
+#define STR_SERIAL3       "Serial port 3"
+#define STR_SERIAL4       "Serial port 4"
+#define STR_PARALLEL1     "Parallel port 1"
+#define STR_PARALLEL2     "Parallel port 2"
+#define STR_PARALLEL3     "Parallel port 3"
+#define STR_PARALLEL4     "Parallel port 4"
+#define STR_SERIAL_PASS1  "Serial port passthrough 1"
+#define STR_SERIAL_PASS2  "Serial port passthrough 2"
+#define STR_SERIAL_PASS3  "Serial port passthrough 3"
+#define STR_SERIAL_PASS4  "Serial port passthrough 4"
 
 #define STR_HDC           "HD Controller:"
 #define STR_FDC           "FD Controller:"
@@ -392,7 +392,7 @@ END
 // String Table
 //
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     2048        "86Box"
     IDS_2049    "Error"
@@ -412,7 +412,7 @@ BEGIN
     IDS_2063    "Machine ""%hs"" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2064    "Video card ""%hs"" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
     IDS_2065    "Machine"
@@ -432,7 +432,7 @@ BEGIN
     IDS_2079    "Press F8+F12 or middle button to release mouse"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2080    "Unable to initialize FluidSynth"
     IDS_2081    "Bus"
@@ -544,7 +544,7 @@ BEGIN
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_4096    "Hard disk (%s)"
     IDS_4097    "%01i:%01i"

--- a/src/win/languages/es-ES.rc
+++ b/src/win/languages/es-ES.rc
@@ -13,122 +13,122 @@ LANGUAGE LANG_SPANISH, SUBLANG_SPANISH
 // Menu
 //
 
-MainMenu MENU DISCARDABLE 
+MainMenu MENU DISCARDABLE
 BEGIN
     POPUP "&Acción"
     BEGIN
-        MENUITEM "&Teclado requiere captura",    IDM_ACTION_KBD_REQ_CAPTURE
-        MENUITEM "CTRL &derecho es ALT izquierdo",    IDM_ACTION_RCTRL_IS_LALT
+        MENUITEM "&Teclado requiere captura", IDM_ACTION_KBD_REQ_CAPTURE
+        MENUITEM "CTRL &derecho es ALT izquierdo", IDM_ACTION_RCTRL_IS_LALT
         MENUITEM SEPARATOR
-        MENUITEM "&Hard Reset...",                 IDM_ACTION_HRESET
-        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12",     IDM_ACTION_RESET_CAD
+        MENUITEM "&Hard Reset...", IDM_ACTION_HRESET
+        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12", IDM_ACTION_RESET_CAD
         MENUITEM SEPARATOR
-    MENUITEM "Ctrl+Alt+&Esc",        IDM_ACTION_CTRL_ALT_ESC
+    MENUITEM "Ctrl+Alt+&Esc", IDM_ACTION_CTRL_ALT_ESC
         MENUITEM SEPARATOR
-        MENUITEM "&Pausa",                      IDM_ACTION_PAUSE
+        MENUITEM "&Pausa", IDM_ACTION_PAUSE
         MENUITEM SEPARATOR
-        MENUITEM "&Salir...",                       IDM_ACTION_EXIT
+        MENUITEM "&Salir...", IDM_ACTION_EXIT
     END
     POPUP "&Vista"
     BEGIN
-        MENUITEM "&Ocultar barra de estado",        IDM_VID_HIDE_STATUS_BAR
-        MENUITEM "Hide &toolbar",        IDM_VID_HIDE_TOOLBAR
+        MENUITEM "&Ocultar barra de estado", IDM_VID_HIDE_STATUS_BAR
+        MENUITEM "Hide &toolbar", IDM_VID_HIDE_TOOLBAR
         MENUITEM SEPARATOR
-        MENUITEM "&Show non-primary monitors",  IDM_VID_MONITORS
-        MENUITEM "&Ventana redimensionable",          IDM_VID_RESIZE
-        MENUITEM "&Recordar tamaño y posición",  IDM_VID_REMEMBER
+        MENUITEM "&Show non-primary monitors", IDM_VID_MONITORS
+        MENUITEM "&Ventana redimensionable", IDM_VID_RESIZE
+        MENUITEM "&Recordar tamaño y posición", IDM_VID_REMEMBER
         MENUITEM SEPARATOR
         POPUP "Re&nderizador"
         BEGIN
-            MENUITEM "&SDL (Software)",         IDM_VID_SDL_SW
-            MENUITEM "SDL (&Hardware)",         IDM_VID_SDL_HW
-            MENUITEM "SDL (&OpenGL)",           IDM_VID_SDL_OPENGL
-            MENUITEM "Open&GL (3.0 Core)",      IDM_VID_OPENGL_CORE
+            MENUITEM "&SDL (Software)", IDM_VID_SDL_SW
+            MENUITEM "SDL (&Hardware)", IDM_VID_SDL_HW
+            MENUITEM "SDL (&OpenGL)", IDM_VID_SDL_OPENGL
+            MENUITEM "Open&GL (3.0 Core)", IDM_VID_OPENGL_CORE
 #ifdef USE_VNC
-            MENUITEM "&VNC",                    IDM_VID_VNC
+            MENUITEM "&VNC", IDM_VID_VNC
 #endif
         END
         MENUITEM SEPARATOR
-        MENUITEM "E&specificar dimensiones...",          IDM_VID_SPECIFY_DIM
-        MENUITEM "F&orzar ratio 4:3",    IDM_VID_FORCE43
+        MENUITEM "E&specificar dimensiones...", IDM_VID_SPECIFY_DIM
+        MENUITEM "F&orzar ratio 4:3", IDM_VID_FORCE43
         POPUP "&Factor de escalado de ventana"
         BEGIN
-            MENUITEM "&0.5x",                   IDM_VID_SCALE_1X
-            MENUITEM "&1x",                     IDM_VID_SCALE_2X
-            MENUITEM "1.&5x",                   IDM_VID_SCALE_3X
-            MENUITEM "&2x",                     IDM_VID_SCALE_4X
-            MENUITEM "&3x",                     IDM_VID_SCALE_5X
-            MENUITEM "&4x",                     IDM_VID_SCALE_6X
-            MENUITEM "&5x",                     IDM_VID_SCALE_7X
-            MENUITEM "&6x",                     IDM_VID_SCALE_8X
-            MENUITEM "&7x",                     IDM_VID_SCALE_9X
-            MENUITEM "&8x",                     IDM_VID_SCALE_10X
+            MENUITEM "&0.5x", IDM_VID_SCALE_1X
+            MENUITEM "&1x", IDM_VID_SCALE_2X
+            MENUITEM "1.&5x", IDM_VID_SCALE_3X
+            MENUITEM "&2x", IDM_VID_SCALE_4X
+            MENUITEM "&3x", IDM_VID_SCALE_5X
+            MENUITEM "&4x", IDM_VID_SCALE_6X
+            MENUITEM "&5x", IDM_VID_SCALE_7X
+            MENUITEM "&6x", IDM_VID_SCALE_8X
+            MENUITEM "&7x", IDM_VID_SCALE_9X
+            MENUITEM "&8x", IDM_VID_SCALE_10X
         END
         POPUP "&Método de filtrado"
         BEGIN
-            MENUITEM "&Más cercano",                 IDM_VID_FILTER_NEAREST
-            MENUITEM "&Lineal",                  IDM_VID_FILTER_LINEAR
+            MENUITEM "&Más cercano", IDM_VID_FILTER_NEAREST
+            MENUITEM "&Lineal", IDM_VID_FILTER_LINEAR
         END
-        MENUITEM "&Escalado alta densidad",              IDM_VID_HIDPI
+        MENUITEM "&Escalado alta densidad", IDM_VID_HIDPI
         MENUITEM SEPARATOR
-        MENUITEM "&Pantalla completa\tCtrl+Alt+PgUp",    IDM_VID_FULLSCREEN
+        MENUITEM "&Pantalla completa\tCtrl+Alt+PgUp", IDM_VID_FULLSCREEN
         POPUP "Escalado pantalla completa"
         BEGIN
-            MENUITEM "&Estirar",        IDM_VID_FS_FULL
-            MENUITEM "&4:3",                        IDM_VID_FS_43
+            MENUITEM "&Estirar", IDM_VID_FS_FULL
+            MENUITEM "&4:3", IDM_VID_FS_43
             MENUITEM "&Píxeles cuadrados (Mant. aspecto)", IDM_VID_FS_KEEPRATIO
-            MENUITEM "&Escalado valor entero",              IDM_VID_FS_INT
+            MENUITEM "&Escalado valor entero", IDM_VID_FS_INT
         END
         POPUP "&Ajustes EGA/(S)VGA"
         BEGIN
-            MENUITEM "&Monitor VGA invertido",   IDM_VID_INVERT
+            MENUITEM "&Monitor VGA invertido", IDM_VID_INVERT
             POPUP "&Tipo de pantalla VGA"
             BEGIN
-                MENUITEM "RGB &Color",          IDM_VID_GRAY_RGB
-                MENUITEM "RGB &Grises",      IDM_VID_GRAY_MONO
-                MENUITEM "Monitor &Ámbar",      IDM_VID_GRAY_AMBER
-                MENUITEM "Monitor &Verde",      IDM_VID_GRAY_GREEN
-                MENUITEM "Monitor &Blanco",      IDM_VID_GRAY_WHITE
+                MENUITEM "RGB &Color", IDM_VID_GRAY_RGB
+                MENUITEM "RGB &Grises", IDM_VID_GRAY_MONO
+                MENUITEM "Monitor &Ámbar", IDM_VID_GRAY_AMBER
+                MENUITEM "Monitor &Verde", IDM_VID_GRAY_GREEN
+                MENUITEM "Monitor &Blanco", IDM_VID_GRAY_WHITE
             END
             POPUP "&Conversión a grises"
             BEGIN
-                MENUITEM "BT&601 (NTSC/PAL)",   IDM_VID_GRAYCT_601
-                MENUITEM "BT&709 (HDTV)",       IDM_VID_GRAYCT_709
-                MENUITEM "&Media",            IDM_VID_GRAYCT_AVE
+                MENUITEM "BT&601 (NTSC/PAL)", IDM_VID_GRAYCT_601
+                MENUITEM "BT&709 (HDTV)", IDM_VID_GRAYCT_709
+                MENUITEM "&Media", IDM_VID_GRAYCT_AVE
             END
         END
         MENUITEM SEPARATOR
-        MENUITEM "&Overscan CGA/PCjr/Tandy/EGA/(S)VGA",     IDM_VID_OVERSCAN
+        MENUITEM "&Overscan CGA/PCjr/Tandy/EGA/(S)VGA", IDM_VID_OVERSCAN
         MENUITEM "Cambiar contraste para pantalla &monocroma", IDM_VID_CGACON
     END
-    MENUITEM "&Medios",                IDM_MEDIA
+    MENUITEM "&Medios", IDM_MEDIA
     POPUP "&Herramientas"
     BEGIN
-        MENUITEM "&Ajustes...",                IDM_CONFIG
-        MENUITEM "&Actualizar iconos en barra de estado",    IDM_UPDATE_ICONS
+        MENUITEM "&Ajustes...", IDM_CONFIG
+        MENUITEM "&Actualizar iconos en barra de estado", IDM_UPDATE_ICONS
         MENUITEM SEPARATOR
-        MENUITEM "Tomar c&aptura\tCtrl+F11",  IDM_ACTION_SCREENSHOT
+        MENUITEM "Tomar c&aptura\tCtrl+F11", IDM_ACTION_SCREENSHOT
         MENUITEM SEPARATOR
-        MENUITEM "&Preferencias...",        IDM_PREFERENCES
+        MENUITEM "&Preferencias...", IDM_PREFERENCES
 #ifdef DISCORD
         MENUITEM "Habilitar integración con &Discord", IDM_DISCORD
 #endif
         MENUITEM SEPARATOR
-        MENUITEM "&Ganancia de sonido...",              IDM_SND_GAIN
+        MENUITEM "&Ganancia de sonido...", IDM_SND_GAIN
 #ifdef MTR_ENABLED
         MENUITEM SEPARATOR
-        MENUITEM "Comenzar traza\tCtrl+T",         IDM_ACTION_BEGIN_TRACE
-        MENUITEM "Terminar traza\tCtrl+T",           IDM_ACTION_END_TRACE
+        MENUITEM "Comenzar traza\tCtrl+T", IDM_ACTION_BEGIN_TRACE
+        MENUITEM "Terminar traza\tCtrl+T", IDM_ACTION_END_TRACE
 #endif
     END
     POPUP "&Ayuda"
     BEGIN
-        MENUITEM "&Documentación...",           IDM_DOCS
-        MENUITEM "&Acerca de 86Box...",             IDM_ABOUT
+        MENUITEM "&Documentación...", IDM_DOCS
+        MENUITEM "&Acerca de 86Box...", IDM_ABOUT
     END
 END
 
-StatusBarMenu MENU DISCARDABLE 
+StatusBarMenu MENU DISCARDABLE
 BEGIN
     MENUITEM SEPARATOR
 END
@@ -137,17 +137,17 @@ CassetteSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nueva imagen...",                IDM_CASSETTE_IMAGE_NEW
+        MENUITEM "&Nueva imagen...", IDM_CASSETTE_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "Imagen &Existente...",                IDM_CASSETTE_IMAGE_EXISTING
-        MENUITEM "Imagen Existente (&Sólo-lectura)...",    IDM_CASSETTE_IMAGE_EXISTING_WP
+        MENUITEM "Imagen &Existente...", IDM_CASSETTE_IMAGE_EXISTING
+        MENUITEM "Imagen Existente (&Sólo-lectura)...", IDM_CASSETTE_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Grabar",                    IDM_CASSETTE_RECORD
-        MENUITEM "&Reproducir",                    IDM_CASSETTE_PLAY
-        MENUITEM "&Rebobinar al inicio",            IDM_CASSETTE_REWIND
-        MENUITEM "&Avance rápido al final",            IDM_CASSETTE_FAST_FORWARD
+        MENUITEM "&Grabar", IDM_CASSETTE_RECORD
+        MENUITEM "&Reproducir", IDM_CASSETTE_PLAY
+        MENUITEM "&Rebobinar al inicio", IDM_CASSETTE_REWIND
+        MENUITEM "&Avance rápido al final", IDM_CASSETTE_FAST_FORWARD
         MENUITEM SEPARATOR
-        MENUITEM "E&xtraer",                    IDM_CASSETTE_EJECT
+        MENUITEM "E&xtraer", IDM_CASSETTE_EJECT
     END
 END
 
@@ -155,9 +155,9 @@ CartridgeSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Imagen...",                    IDM_CARTRIDGE_IMAGE
+        MENUITEM "&Imagen...", IDM_CARTRIDGE_IMAGE
         MENUITEM SEPARATOR
-        MENUITEM "E&xtraer",                    IDM_CARTRIDGE_EJECT
+        MENUITEM "E&xtraer", IDM_CARTRIDGE_EJECT
     END
 END
 
@@ -165,14 +165,14 @@ FloppySubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nueva imagen...",                IDM_FLOPPY_IMAGE_NEW
+        MENUITEM "&Nueva imagen...", IDM_FLOPPY_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "Imagen &existente...",                IDM_FLOPPY_IMAGE_EXISTING
-        MENUITEM "Imagen existente (&sólo-lectura)...",    IDM_FLOPPY_IMAGE_EXISTING_WP
+        MENUITEM "Imagen &existente...", IDM_FLOPPY_IMAGE_EXISTING
+        MENUITEM "Imagen existente (&sólo-lectura)...", IDM_FLOPPY_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "E&xportar a 86F...",                IDM_FLOPPY_EXPORT_TO_86F
+        MENUITEM "E&xportar a 86F...", IDM_FLOPPY_EXPORT_TO_86F
         MENUITEM SEPARATOR
-        MENUITEM "E&xtraer",                    IDM_FLOPPY_EJECT
+        MENUITEM "E&xtraer", IDM_FLOPPY_EJECT
     END
 END
 
@@ -180,13 +180,13 @@ CdromSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Silenciar",                    IDM_CDROM_MUTE
+        MENUITEM "&Silenciar", IDM_CDROM_MUTE
         MENUITEM SEPARATOR
-        MENUITEM "E&xtraer disco",                    IDM_CDROM_EMPTY
-        MENUITEM "&Recargar imagen previa",            IDM_CDROM_RELOAD
+        MENUITEM "E&xtraer disco", IDM_CDROM_EMPTY
+        MENUITEM "&Recargar imagen previa", IDM_CDROM_RELOAD
         MENUITEM SEPARATOR
-        MENUITEM "&Imagen...",                    IDM_CDROM_IMAGE
-        MENUITEM "&Carpeta...",                    IDM_CDROM_DIR
+        MENUITEM "&Imagen...", IDM_CDROM_IMAGE
+        MENUITEM "&Carpeta...", IDM_CDROM_DIR
     END
 END
 
@@ -194,13 +194,13 @@ ZIPSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nueva imagen...",                IDM_ZIP_IMAGE_NEW
+        MENUITEM "&Nueva imagen...", IDM_ZIP_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "Imagen &existente...",                IDM_ZIP_IMAGE_EXISTING
-        MENUITEM "Imagen existente (&sólo-lectura)...",    IDM_ZIP_IMAGE_EXISTING_WP
+        MENUITEM "Imagen &existente...", IDM_ZIP_IMAGE_EXISTING
+        MENUITEM "Imagen existente (&sólo-lectura)...", IDM_ZIP_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "E&xtraer",                    IDM_ZIP_EJECT
-        MENUITEM "&Recargar imagen previa",            IDM_ZIP_RELOAD
+        MENUITEM "E&xtraer", IDM_ZIP_EJECT
+        MENUITEM "&Recargar imagen previa", IDM_ZIP_RELOAD
     END
 END
 
@@ -208,13 +208,13 @@ MOSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nueva imagen...",                IDM_MO_IMAGE_NEW
+        MENUITEM "&Nueva imagen...", IDM_MO_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "Imagen &existente...",                IDM_MO_IMAGE_EXISTING
-        MENUITEM "Imagen existente (&sólo-lectura)...",    IDM_MO_IMAGE_EXISTING_WP
+        MENUITEM "Imagen &existente...", IDM_MO_IMAGE_EXISTING
+        MENUITEM "Imagen existente (&sólo-lectura)...", IDM_MO_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "E&xtraer",                    IDM_MO_EJECT
-        MENUITEM "&Recargar imagen previa",            IDM_MO_RELOAD
+        MENUITEM "E&xtraer", IDM_MO_EJECT
+        MENUITEM "&Recargar imagen previa", IDM_MO_RELOAD
     END
 END
 
@@ -240,150 +240,150 @@ END
 // Dialog
 //
 
-#define STR_PREFERENCES        "Preferencias"
-#define STR_SND_GAIN        "Ganancia de Sonido"
-#define STR_NEW_FLOPPY        "Nueva Imagen"
+#define STR_PREFERENCES   "Preferencias"
+#define STR_SND_GAIN      "Ganancia de Sonido"
+#define STR_NEW_FLOPPY    "Nueva Imagen"
 #define STR_CONFIG        "Ajustes"
-#define STR_SPECIFY_DIM        "Especificar Dimensiones de la Ventana Principal"
+#define STR_SPECIFY_DIM   "Especificar Dimensiones de la Ventana Principal"
 
 #define STR_OK            "Aceptar"
 #define STR_CANCEL        "Cancelar"
 #define STR_GLOBAL        "Salvar estos ajustes como por &defecto globalmente"
-#define STR_DEFAULT        "&Por defecto"
-#define STR_LANGUAGE        "Idioma:"
-#define STR_ICONSET        "Juego de iconos:"
+#define STR_DEFAULT       "&Por defecto"
+#define STR_LANGUAGE      "Idioma:"
+#define STR_ICONSET       "Juego de iconos:"
 
-#define STR_GAIN        "Ganancia"
+#define STR_GAIN          "Ganancia"
 
-#define STR_FILE_NAME        "Nombre de archivo:"
-#define STR_DISK_SIZE        "Tamaño de disco:"
-#define STR_RPM_MODE        "Modo RPM:"
-#define STR_PROGRESS        "Progreso:"
+#define STR_FILE_NAME     "Nombre de archivo:"
+#define STR_DISK_SIZE     "Tamaño de disco:"
+#define STR_RPM_MODE      "Modo RPM:"
+#define STR_PROGRESS      "Progreso:"
 
-#define STR_WIDTH        "Ancho:"
+#define STR_WIDTH         "Ancho:"
 #define STR_HEIGHT        "Alto:"
-#define STR_LOCK_TO_SIZE    "Bloquear a este tamaño"
+#define STR_LOCK_TO_SIZE  "Bloquear a este tamaño"
 
-#define STR_MACHINE_TYPE    "Tipo de máquina:"
-#define STR_MACHINE        "Máquina:"
-#define STR_CONFIGURE        "Configurar"
-#define STR_CPU_TYPE        "Tipo de CPU:"
-#define STR_CPU_SPEED        "Velocidad:"
-#define STR_FPU            "FPU:"
-#define STR_WAIT_STATES        "Estados en espera:"
+#define STR_MACHINE_TYPE  "Tipo de máquina:"
+#define STR_MACHINE       "Máquina:"
+#define STR_CONFIGURE     "Configurar"
+#define STR_CPU_TYPE      "Tipo de CPU:"
+#define STR_CPU_SPEED     "Velocidad:"
+#define STR_FPU           "FPU:"
+#define STR_WAIT_STATES   "Estados en espera:"
 #define STR_MB            "MB"
 #define STR_MEMORY        "Memoria:"
-#define STR_TIME_SYNC        "Sincronización horaria"
-#define STR_DISABLED        "Deshabilitado"
-#define STR_ENABLED_LOCAL    "Habilitado (hora local)"
-#define STR_ENABLED_UTC        "Habilitado (UTC)"
-#define STR_DYNAREC        "Recompilador Dinámico"
+#define STR_TIME_SYNC     "Sincronización horaria"
+#define STR_DISABLED      "Deshabilitado"
+#define STR_ENABLED_LOCAL "Habilitado (hora local)"
+#define STR_ENABLED_UTC   "Habilitado (UTC)"
+#define STR_DYNAREC       "Recompilador Dinámico"
 
-#define STR_VIDEO        "Vídeo:"
-#define STR_VIDEO_2        "Vídeo 2:"
+#define STR_VIDEO         "Vídeo:"
+#define STR_VIDEO_2       "Vídeo 2:"
 #define STR_VOODOO        "Voodoo Graphics"
-#define STR_IBM8514        "IBM 8514/a Graphics"
-#define STR_XGA            "XGA Graphics"
+#define STR_IBM8514       "IBM 8514/a Graphics"
+#define STR_XGA           "XGA Graphics"
 
-#define STR_MOUSE        "Ratón:"
-#define STR_JOYSTICK        "Mando:"
-#define STR_JOY1        "Mando 1..."
-#define STR_JOY2        "Mando 2..."
-#define STR_JOY3        "Mando 3..."
-#define STR_JOY4        "Mando 4..."
+#define STR_MOUSE         "Ratón:"
+#define STR_JOYSTICK      "Mando:"
+#define STR_JOY1          "Mando 1..."
+#define STR_JOY2          "Mando 2..."
+#define STR_JOY3          "Mando 3..."
+#define STR_JOY4          "Mando 4..."
 
 #define STR_SOUND1        "Tarjeta de sonido 1:"
 #define STR_SOUND2        "Tarjeta de sonido 2:"
 #define STR_SOUND3        "Tarjeta de sonido 3:"
 #define STR_SOUND4        "Tarjeta de sonido 4:"
-#define STR_MIDI_OUT        "Dispositivo MIDI de salida:"
-#define STR_MIDI_IN        "Dispositivo MIDI de entrada:"
+#define STR_MIDI_OUT      "Dispositivo MIDI de salida:"
+#define STR_MIDI_IN       "Dispositivo MIDI de entrada:"
 #define STR_MPU401        "MPU-401 independiente"
-#define STR_FLOAT        "Usar sonido FLOAT32"
-#define STR_FM_DRIVER        "Controlador de sintet. FM"
-#define STR_FM_DRV_NUKED    "Nuked (más preciso)"
-#define STR_FM_DRV_YMFM        "YMFM (más rápido)"
+#define STR_FLOAT         "Usar sonido FLOAT32"
+#define STR_FM_DRIVER     "Controlador de sintet. FM"
+#define STR_FM_DRV_NUKED  "Nuked (más preciso)"
+#define STR_FM_DRV_YMFM   "YMFM (más rápido)"
 
-#define STR_NET_TYPE    "Tipo de red:"
-#define STR_PCAP        "Dispositivo PCap:"
-#define STR_NET            "Adaptador de red:"
-#define STR_NET1        "Network card 1:"
-#define STR_NET2        "Network card 2:"
-#define STR_NET3        "Network card 3:"
-#define STR_NET4        "Network card 4:"
+#define STR_NET_TYPE      "Tipo de red:"
+#define STR_PCAP          "Dispositivo PCap:"
+#define STR_NET           "Adaptador de red:"
+#define STR_NET1          "Network card 1:"
+#define STR_NET2          "Network card 2:"
+#define STR_NET3          "Network card 3:"
+#define STR_NET4          "Network card 4:"
 
-#define STR_COM1        "Dispositivo COM1:"
-#define STR_COM2        "Dispositivo COM2:"
-#define STR_COM3        "Dispositivo COM3:"
-#define STR_COM4        "Dispositivo COM4:"
-#define STR_LPT1        "Dispositivo LPT1:"
-#define STR_LPT2        "Dispositivo LPT2:"
-#define STR_LPT3        "Dispositivo LPT3:"
-#define STR_LPT4        "Dispositivo LPT4:"
-#define STR_SERIAL1        "Puerto serie 1"
-#define STR_SERIAL2        "Puerto serie 2"
-#define STR_SERIAL3        "Puerto serie 3"
-#define STR_SERIAL4        "Puerto serie 4"
-#define STR_PARALLEL1        "Puerto paralelo 1"
-#define STR_PARALLEL2        "Puerto paralelo 2"
-#define STR_PARALLEL3        "Puerto paralelo 3"
-#define STR_PARALLEL4        "Puerto paralelo 4"
-#define STR_SERIAL_PASS1    "Serial port passthrough 1"
-#define STR_SERIAL_PASS2    "Serial port passthrough 2"
-#define STR_SERIAL_PASS3    "Serial port passthrough 3"
-#define STR_SERIAL_PASS4    "Serial port passthrough 4"
+#define STR_COM1          "Dispositivo COM1:"
+#define STR_COM2          "Dispositivo COM2:"
+#define STR_COM3          "Dispositivo COM3:"
+#define STR_COM4          "Dispositivo COM4:"
+#define STR_LPT1          "Dispositivo LPT1:"
+#define STR_LPT2          "Dispositivo LPT2:"
+#define STR_LPT3          "Dispositivo LPT3:"
+#define STR_LPT4          "Dispositivo LPT4:"
+#define STR_SERIAL1       "Puerto serie 1"
+#define STR_SERIAL2       "Puerto serie 2"
+#define STR_SERIAL3       "Puerto serie 3"
+#define STR_SERIAL4       "Puerto serie 4"
+#define STR_PARALLEL1     "Puerto paralelo 1"
+#define STR_PARALLEL2     "Puerto paralelo 2"
+#define STR_PARALLEL3     "Puerto paralelo 3"
+#define STR_PARALLEL4     "Puerto paralelo 4"
+#define STR_SERIAL_PASS1  "Serial port passthrough 1"
+#define STR_SERIAL_PASS2  "Serial port passthrough 2"
+#define STR_SERIAL_PASS3  "Serial port passthrough 3"
+#define STR_SERIAL_PASS4  "Serial port passthrough 4"
 
-#define STR_HDC            "Controladora HD:"
-#define STR_FDC            "Controladora FD:"
-#define STR_IDE_TER        "Tercera controladora IDE"
-#define STR_IDE_QUA        "Cuarta controladora IDE"
-#define STR_SCSI        "SCSI"
+#define STR_HDC           "Controladora HD:"
+#define STR_FDC           "Controladora FD:"
+#define STR_IDE_TER       "Tercera controladora IDE"
+#define STR_IDE_QUA       "Cuarta controladora IDE"
+#define STR_SCSI          "SCSI"
 #define STR_SCSI_1        "Controladora 1:"
 #define STR_SCSI_2        "Controladora 2:"
 #define STR_SCSI_3        "Controladora 3:"
 #define STR_SCSI_4        "Controladora 4:"
-#define STR_CASSETTE        "Cassette"
+#define STR_CASSETTE      "Cassette"
 
-#define STR_HDD            "Discos duros:"
-#define STR_NEW            "&Nuevo..."
-#define STR_EXISTING        "&Existente..."
+#define STR_HDD           "Discos duros:"
+#define STR_NEW           "&Nuevo..."
+#define STR_EXISTING      "&Existente..."
 #define STR_REMOVE        "E&liminar"
-#define STR_BUS            "Bus:"
-#define STR_CHANNEL        "Canal:"
+#define STR_BUS           "Bus:"
+#define STR_CHANNEL       "Canal:"
 #define STR_ID            "ID:"
-#define STR_SPEED        "Speed:"
+#define STR_SPEED         "Speed:"
 
-#define STR_SPECIFY        "E&specificar..."
-#define STR_SECTORS        "Sectores:"
-#define STR_HEADS        "Cabezas:"
-#define STR_CYLS        "Cilindros:"
-#define STR_SIZE_MB        "Tamaño (MB):"
-#define STR_TYPE        "Tipo:"
-#define STR_IMG_FORMAT        "Formato de imagen:"
-#define STR_BLOCK_SIZE        "Tamaño de bloque:"
+#define STR_SPECIFY       "E&specificar..."
+#define STR_SECTORS       "Sectores:"
+#define STR_HEADS         "Cabezas:"
+#define STR_CYLS          "Cilindros:"
+#define STR_SIZE_MB       "Tamaño (MB):"
+#define STR_TYPE          "Tipo:"
+#define STR_IMG_FORMAT    "Formato de imagen:"
+#define STR_BLOCK_SIZE    "Tamaño de bloque:"
 
-#define STR_FLOPPY_DRIVES    "Unidades de disquete:"
-#define STR_TURBO        "Temporizaciones Turbo"
-#define STR_CHECKBPB        "Chequear BPB"
-#define STR_CDROM_DRIVES    "Unidades de CD-ROM:"
-#define STR_CD_SPEED        "Velocidad:"
-#define STR_EARLY        "Unidad anterior"
+#define STR_FLOPPY_DRIVES "Unidades de disquete:"
+#define STR_TURBO         "Temporizaciones Turbo"
+#define STR_CHECKBPB      "Chequear BPB"
+#define STR_CDROM_DRIVES  "Unidades de CD-ROM:"
+#define STR_CD_SPEED      "Velocidad:"
+#define STR_EARLY         "Unidad anterior"
 
-#define STR_MO_DRIVES        "Unidades MO:"
-#define STR_ZIP_DRIVES        "Unidades ZIP:"
-#define STR_250            "ZIP 250"
+#define STR_MO_DRIVES     "Unidades MO:"
+#define STR_ZIP_DRIVES    "Unidades ZIP:"
+#define STR_250           "ZIP 250"
 
 #define STR_ISARTC        "ISA RTC:"
 #define STR_ISAMEM        "Expansión de Memoria ISA"
-#define STR_ISAMEM_1        "Tarjeta 1:"
-#define STR_ISAMEM_2        "Tarjeta 2:"
-#define STR_ISAMEM_3        "Tarjeta 3:"
-#define STR_ISAMEM_4        "Tarjeta 4:"
+#define STR_ISAMEM_1      "Tarjeta 1:"
+#define STR_ISAMEM_2      "Tarjeta 2:"
+#define STR_ISAMEM_3      "Tarjeta 3:"
+#define STR_ISAMEM_4      "Tarjeta 4:"
 #define STR_BUGGER        "Dispositivo ISABugger"
-#define STR_POSTCARD        "Tarjeta POST"
+#define STR_POSTCARD      "Tarjeta POST"
 
-#define FONT_SIZE        9
-#define FONT_NAME        "Segoe UI"
+#define FONT_SIZE         9
+#define FONT_NAME         "Segoe UI"
 
 #include "dialogs.rc"
 
@@ -392,9 +392,9 @@ END
 // String Table
 //
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
-    2048    "86Box"
+    2048        "86Box"
     IDS_2049    "Error"
     IDS_2050    "Error fatal"
     IDS_2051    " - PAUSED"
@@ -412,7 +412,7 @@ BEGIN
     IDS_2063    "La máquina ""%hs"" no está disponible debido a ROMs faltantes en el directorio roms/machines. Cambiando a una máquina disponible."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2064    "La tarjeta de vídeo ""%hs"" no está disponible debido a ROMs faltantes en el directorio roms/machines. Cambiando a una tarjeta de vídeo disponible."
     IDS_2065    "Máquina"
@@ -432,7 +432,7 @@ BEGIN
     IDS_2079    "Pulsa F8+F12 o el botón central para liberar el ratón"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2080    "Incapaz de inicializar FluidSynth"
     IDS_2081    "Bus"
@@ -544,7 +544,7 @@ BEGIN
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_4096    "Disco duro (%s)"
     IDS_4097    "%01i:%01i"
@@ -643,7 +643,7 @@ BEGIN
 
     IDS_7168    "(Por defecto del sistema)"
 END
-#define IDS_LANG_ESES    IDS_7168
+#define IDS_LANG_ESES IDS_7168
 
 // Spanish (Spain) resources
 /////////////////////////////////////////////////////////////////////////////

--- a/src/win/languages/fi-FI.rc
+++ b/src/win/languages/fi-FI.rc
@@ -17,114 +17,114 @@ MainMenu MENU DISCARDABLE
 BEGIN
     POPUP "&Toiminto"
     BEGIN
-        MENUITEM "&Vaadi näppäimistön kaappaus",                        IDM_ACTION_KBD_REQ_CAPTURE
-        MENUITEM "&Oikea CTRL on vasen ALT",                            IDM_ACTION_RCTRL_IS_LALT
+        MENUITEM "&Vaadi näppäimistön kaappaus", IDM_ACTION_KBD_REQ_CAPTURE
+        MENUITEM "&Oikea CTRL on vasen ALT", IDM_ACTION_RCTRL_IS_LALT
         MENUITEM SEPARATOR
-        MENUITEM "&Uudelleenkäynnistys (kylmä)...",                     IDM_ACTION_HRESET
-        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12",                             IDM_ACTION_RESET_CAD
+        MENUITEM "&Uudelleenkäynnistys (kylmä)...", IDM_ACTION_HRESET
+        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12", IDM_ACTION_RESET_CAD
         MENUITEM SEPARATOR
-    MENUITEM "Ctrl+Alt+&Esc",                                           IDM_ACTION_CTRL_ALT_ESC
+    MENUITEM "Ctrl+Alt+&Esc", IDM_ACTION_CTRL_ALT_ESC
         MENUITEM SEPARATOR
-        MENUITEM "&Tauko",                                              IDM_ACTION_PAUSE
+        MENUITEM "&Tauko", IDM_ACTION_PAUSE
         MENUITEM SEPARATOR
-        MENUITEM "&Poistu...",                                          IDM_ACTION_EXIT
+        MENUITEM "&Poistu...", IDM_ACTION_EXIT
     END
     POPUP "&Näytä"
     BEGIN
-        MENUITEM "&Piilota tilapalkki",                                 IDM_VID_HIDE_STATUS_BAR
-        MENUITEM "Piilota &työkalupalkki",                              IDM_VID_HIDE_TOOLBAR
+        MENUITEM "&Piilota tilapalkki", IDM_VID_HIDE_STATUS_BAR
+        MENUITEM "Piilota &työkalupalkki", IDM_VID_HIDE_TOOLBAR
         MENUITEM SEPARATOR
-        MENUITEM "&Show non-primary monitors",  IDM_VID_MONITORS
-        MENUITEM "&Salli koon muuttaminen",                             IDM_VID_RESIZE
-        MENUITEM "&Muista koko ja sijainti",                            IDM_VID_REMEMBER
+        MENUITEM "&Show non-primary monitors", IDM_VID_MONITORS
+        MENUITEM "&Salli koon muuttaminen", IDM_VID_RESIZE
+        MENUITEM "&Muista koko ja sijainti", IDM_VID_REMEMBER
         MENUITEM SEPARATOR
         POPUP "&Renderöijä"
         BEGIN
-            MENUITEM "&SDL (ohjelmistopohjainen)",                      IDM_VID_SDL_SW
-            MENUITEM "SDL (&laitteistokiihdytetty)",                    IDM_VID_SDL_HW
-            MENUITEM "SDL (&OpenGL)",                                   IDM_VID_SDL_OPENGL
-            MENUITEM "Open&GL (3.0 Core)",                              IDM_VID_OPENGL_CORE
+            MENUITEM "&SDL (ohjelmistopohjainen)", IDM_VID_SDL_SW
+            MENUITEM "SDL (&laitteistokiihdytetty)", IDM_VID_SDL_HW
+            MENUITEM "SDL (&OpenGL)", IDM_VID_SDL_OPENGL
+            MENUITEM "Open&GL (3.0 Core)", IDM_VID_OPENGL_CORE
 #ifdef USE_VNC
-            MENUITEM "&VNC",                                            IDM_VID_VNC
+            MENUITEM "&VNC", IDM_VID_VNC
 #endif
         END
         MENUITEM SEPARATOR
-        MENUITEM "&Määritä koko...",                                    IDM_VID_SPECIFY_DIM
-        MENUITEM "Pakota 4:3-näyttösuhde",                              IDM_VID_FORCE43
+        MENUITEM "&Määritä koko...", IDM_VID_SPECIFY_DIM
+        MENUITEM "Pakota 4:3-näyttösuhde", IDM_VID_FORCE43
         POPUP "&Ikkunan kokokerroin"
         BEGIN
-            MENUITEM "&0.5x",                                           IDM_VID_SCALE_1X
-            MENUITEM "&1x",                                             IDM_VID_SCALE_2X
-            MENUITEM "1.&5x",                                           IDM_VID_SCALE_3X
-            MENUITEM "&2x",                                             IDM_VID_SCALE_4X
-            MENUITEM "&3x",                                             IDM_VID_SCALE_5X
-            MENUITEM "&4x",                                             IDM_VID_SCALE_6X
-            MENUITEM "&5x",                                             IDM_VID_SCALE_7X
-            MENUITEM "&6x",                                             IDM_VID_SCALE_8X
-            MENUITEM "&7x",                                             IDM_VID_SCALE_9X
-            MENUITEM "&8x",                                             IDM_VID_SCALE_10X
+            MENUITEM "&0.5x", IDM_VID_SCALE_1X
+            MENUITEM "&1x", IDM_VID_SCALE_2X
+            MENUITEM "1.&5x", IDM_VID_SCALE_3X
+            MENUITEM "&2x", IDM_VID_SCALE_4X
+            MENUITEM "&3x", IDM_VID_SCALE_5X
+            MENUITEM "&4x", IDM_VID_SCALE_6X
+            MENUITEM "&5x", IDM_VID_SCALE_7X
+            MENUITEM "&6x", IDM_VID_SCALE_8X
+            MENUITEM "&7x", IDM_VID_SCALE_9X
+            MENUITEM "&8x", IDM_VID_SCALE_10X
         END
         POPUP "&Suodatusmetodi"
         BEGIN
-            MENUITEM "&Lähin naapuri",                                  IDM_VID_FILTER_NEAREST
-            MENUITEM "Li&neaarinen interpolaatio",                      IDM_VID_FILTER_LINEAR
+            MENUITEM "&Lähin naapuri", IDM_VID_FILTER_NEAREST
+            MENUITEM "Li&neaarinen interpolaatio", IDM_VID_FILTER_LINEAR
         END
-        MENUITEM "&Suuri DPI-skaalaus",                                 IDM_VID_HIDPI
+        MENUITEM "&Suuri DPI-skaalaus", IDM_VID_HIDPI
         MENUITEM SEPARATOR
-        MENUITEM "&Koko näytön tila\tCtrl+Alt+PgUp",                  IDM_VID_FULLSCREEN
+        MENUITEM "&Koko näytön tila\tCtrl+Alt+PgUp", IDM_VID_FULLSCREEN
         POPUP "Koko näytön &skaalaustila"
         BEGIN
-            MENUITEM "&Venytä koko näyttöön",                           IDM_VID_FS_FULL
-            MENUITEM "&4:3",                                            IDM_VID_FS_43
-            MENUITEM "&Tasasivuiset kuvapisteet (säilytä kuvasuhde)",   IDM_VID_FS_KEEPRATIO
-            MENUITEM "&Kokonaislukuskaalaus",                           IDM_VID_FS_INT
+            MENUITEM "&Venytä koko näyttöön", IDM_VID_FS_FULL
+            MENUITEM "&4:3", IDM_VID_FS_43
+            MENUITEM "&Tasasivuiset kuvapisteet (säilytä kuvasuhde)", IDM_VID_FS_KEEPRATIO
+            MENUITEM "&Kokonaislukuskaalaus", IDM_VID_FS_INT
         END
         POPUP "&EGA/(S)VGA-asetukset"
         BEGIN
-            MENUITEM "&VGA-näyttö käänteisillä väreillä",               IDM_VID_INVERT
+            MENUITEM "&VGA-näyttö käänteisillä väreillä", IDM_VID_INVERT
             POPUP "VGA-näytön &tyyppi"
             BEGIN
-                MENUITEM "RGB, &värit",                                 IDM_VID_GRAY_RGB
-                MENUITEM "&RGB, harmaasävy",                            IDM_VID_GRAY_MONO
-                MENUITEM "&Meripihkanvärinen",                          IDM_VID_GRAY_AMBER
-                MENUITEM "V&ihreä",                                     IDM_VID_GRAY_GREEN
-                MENUITEM "V&alkoinen",                                  IDM_VID_GRAY_WHITE
+                MENUITEM "RGB, &värit", IDM_VID_GRAY_RGB
+                MENUITEM "&RGB, harmaasävy", IDM_VID_GRAY_MONO
+                MENUITEM "&Meripihkanvärinen", IDM_VID_GRAY_AMBER
+                MENUITEM "V&ihreä", IDM_VID_GRAY_GREEN
+                MENUITEM "V&alkoinen", IDM_VID_GRAY_WHITE
             END
             POPUP "&Harmaasävymuunnoksen tyyppi"
             BEGIN
-                MENUITEM "BT&601 (NTSC/PAL)",                           IDM_VID_GRAYCT_601
-                MENUITEM "BT&709 (HDTV)",                               IDM_VID_GRAYCT_709
-                MENUITEM "&Keskiarvo",                                  IDM_VID_GRAYCT_AVE
+                MENUITEM "BT&601 (NTSC/PAL)", IDM_VID_GRAYCT_601
+                MENUITEM "BT&709 (HDTV)", IDM_VID_GRAYCT_709
+                MENUITEM "&Keskiarvo", IDM_VID_GRAYCT_AVE
             END
         END
         MENUITEM SEPARATOR
-        MENUITEM "CGA/PCjr/Tandy/E&GA/(S)VGA &yliskannaus",             IDM_VID_OVERSCAN
-        MENUITEM "&Muuta harmaavärinäytön kontrastia",                  IDM_VID_CGACON
+        MENUITEM "CGA/PCjr/Tandy/E&GA/(S)VGA &yliskannaus", IDM_VID_OVERSCAN
+        MENUITEM "&Muuta harmaavärinäytön kontrastia", IDM_VID_CGACON
     END
-    MENUITEM "&Media",                                                  IDM_MEDIA
+    MENUITEM "&Media", IDM_MEDIA
     POPUP "Työ&kalut"
     BEGIN
-        MENUITEM "&Kokoonpano...",                                      IDM_CONFIG
-        MENUITEM "&Päivitä tilapalkin kuvakkeita",                      IDM_UPDATE_ICONS
+        MENUITEM "&Kokoonpano...", IDM_CONFIG
+        MENUITEM "&Päivitä tilapalkin kuvakkeita", IDM_UPDATE_ICONS
         MENUITEM SEPARATOR
-        MENUITEM "Ota &kuvakaappaus\tCtrl+F11",                         IDM_ACTION_SCREENSHOT
+        MENUITEM "Ota &kuvakaappaus\tCtrl+F11", IDM_ACTION_SCREENSHOT
         MENUITEM SEPARATOR
-        MENUITEM "&Sovellusasetukset...",                               IDM_PREFERENCES
+        MENUITEM "&Sovellusasetukset...", IDM_PREFERENCES
 #ifdef DISCORD
-        MENUITEM "Käytä &Discord-integraatiota",                        IDM_DISCORD
+        MENUITEM "Käytä &Discord-integraatiota", IDM_DISCORD
 #endif
         MENUITEM SEPARATOR
-        MENUITEM "&Äänitasot...",                                       IDM_SND_GAIN
+        MENUITEM "&Äänitasot...", IDM_SND_GAIN
 #ifdef MTR_ENABLED
         MENUITEM SEPARATOR
-        MENUITEM "Aloita jäljitys\tCtrl+T",                             IDM_ACTION_BEGIN_TRACE
-        MENUITEM "Lopeta jäljitys\tCtrl+T",                             IDM_ACTION_END_TRACE
+        MENUITEM "Aloita jäljitys\tCtrl+T", IDM_ACTION_BEGIN_TRACE
+        MENUITEM "Lopeta jäljitys\tCtrl+T", IDM_ACTION_END_TRACE
 #endif
     END
     POPUP "&Ohje"
     BEGIN
-        MENUITEM "&Ohjekirja...",                                       IDM_DOCS
-        MENUITEM "&Tietoja 86Boxista...",                               IDM_ABOUT
+        MENUITEM "&Ohjekirja...", IDM_DOCS
+        MENUITEM "&Tietoja 86Boxista...", IDM_ABOUT
     END
 END
 
@@ -137,17 +137,17 @@ CassetteSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Uusi kasettikuva...",                                IDM_CASSETTE_IMAGE_NEW
+        MENUITEM "&Uusi kasettikuva...", IDM_CASSETTE_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Olemassaoleva kasettikuva...",                       IDM_CASSETTE_IMAGE_EXISTING
-        MENUITEM "Olemassaoleva kasettikuva (&kirjoitussuojattu)...",   IDM_CASSETTE_IMAGE_EXISTING_WP
+        MENUITEM "&Olemassaoleva kasettikuva...", IDM_CASSETTE_IMAGE_EXISTING
+        MENUITEM "Olemassaoleva kasettikuva (&kirjoitussuojattu)...", IDM_CASSETTE_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Nauhoita",                                           IDM_CASSETTE_RECORD
-        MENUITEM "&Toista",                                             IDM_CASSETTE_PLAY
-        MENUITEM "Kelaa &alkuun",                                       IDM_CASSETTE_REWIND
-        MENUITEM "Kelaa &loppuun",                                      IDM_CASSETTE_FAST_FORWARD
+        MENUITEM "&Nauhoita", IDM_CASSETTE_RECORD
+        MENUITEM "&Toista", IDM_CASSETTE_PLAY
+        MENUITEM "Kelaa &alkuun", IDM_CASSETTE_REWIND
+        MENUITEM "Kelaa &loppuun", IDM_CASSETTE_FAST_FORWARD
         MENUITEM SEPARATOR
-        MENUITEM "&Poista kasettipesästä",                              IDM_CASSETTE_EJECT
+        MENUITEM "&Poista kasettipesästä", IDM_CASSETTE_EJECT
     END
 END
 
@@ -155,9 +155,9 @@ CartridgeSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&ROM-moduulikuva...",                                 IDM_CARTRIDGE_IMAGE
+        MENUITEM "&ROM-moduulikuva...", IDM_CARTRIDGE_IMAGE
         MENUITEM SEPARATOR
-        MENUITEM "&Irrota",                                             IDM_CARTRIDGE_EJECT
+        MENUITEM "&Irrota", IDM_CARTRIDGE_EJECT
     END
 END
 
@@ -165,14 +165,14 @@ FloppySubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Uusi levykekuva...",                                 IDM_FLOPPY_IMAGE_NEW
+        MENUITEM "&Uusi levykekuva...", IDM_FLOPPY_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Olemassaoleva levykekuva...",                        IDM_FLOPPY_IMAGE_EXISTING
-        MENUITEM "Olemassaoleva levykekuva (&kirjoitussuojattu)...",    IDM_FLOPPY_IMAGE_EXISTING_WP
+        MENUITEM "&Olemassaoleva levykekuva...", IDM_FLOPPY_IMAGE_EXISTING
+        MENUITEM "Olemassaoleva levykekuva (&kirjoitussuojattu)...", IDM_FLOPPY_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Vie 86F-tiedostoon...",                              IDM_FLOPPY_EXPORT_TO_86F
+        MENUITEM "&Vie 86F-tiedostoon...", IDM_FLOPPY_EXPORT_TO_86F
         MENUITEM SEPARATOR
-        MENUITEM "&Poista asemasta",                                    IDM_FLOPPY_EJECT
+        MENUITEM "&Poista asemasta", IDM_FLOPPY_EJECT
     END
 END
 
@@ -180,13 +180,13 @@ CdromSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Mykistä",                                            IDM_CDROM_MUTE
+        MENUITEM "&Mykistä", IDM_CDROM_MUTE
         MENUITEM SEPARATOR
-        MENUITEM "&Tyhjä",                                              IDM_CDROM_EMPTY
-        MENUITEM "&Lataa edellinen levykuva uudelleen",                 IDM_CDROM_RELOAD
+        MENUITEM "&Tyhjä", IDM_CDROM_EMPTY
+        MENUITEM "&Lataa edellinen levykuva uudelleen", IDM_CDROM_RELOAD
         MENUITEM SEPARATOR
-        MENUITEM "L&evykuva...",                                           IDM_CDROM_IMAGE
-        MENUITEM "&Kansio...",                        IDM_CDROM_DIR
+        MENUITEM "L&evykuva...", IDM_CDROM_IMAGE
+        MENUITEM "&Kansio...", IDM_CDROM_DIR
     END
 END
 
@@ -194,13 +194,13 @@ ZIPSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Uusi levykuva...",                                   IDM_ZIP_IMAGE_NEW
+        MENUITEM "&Uusi levykuva...", IDM_ZIP_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Olemassaoleva levykuva...",                          IDM_ZIP_IMAGE_EXISTING
-        MENUITEM "Olemassaoleva levykuva (&kirjoitussuojattu)...",      IDM_ZIP_IMAGE_EXISTING_WP
+        MENUITEM "&Olemassaoleva levykuva...", IDM_ZIP_IMAGE_EXISTING
+        MENUITEM "Olemassaoleva levykuva (&kirjoitussuojattu)...", IDM_ZIP_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Poista asemasta",                                    IDM_ZIP_EJECT
-        MENUITEM "&Lataa edellinen levykuva uudelleen",                 IDM_ZIP_RELOAD
+        MENUITEM "&Poista asemasta", IDM_ZIP_EJECT
+        MENUITEM "&Lataa edellinen levykuva uudelleen", IDM_ZIP_RELOAD
     END
 END
 
@@ -208,13 +208,13 @@ MOSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Uusi levykuva...",                                   IDM_MO_IMAGE_NEW
+        MENUITEM "&Uusi levykuva...", IDM_MO_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Olemassaoleva levykuva...",                          IDM_MO_IMAGE_EXISTING
-        MENUITEM "Olemassaoleva levykuva (&kirjoitussuojattu)...",      IDM_MO_IMAGE_EXISTING_WP
+        MENUITEM "&Olemassaoleva levykuva...", IDM_MO_IMAGE_EXISTING
+        MENUITEM "Olemassaoleva levykuva (&kirjoitussuojattu)...", IDM_MO_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Poista asemasta",                                    IDM_MO_EJECT
-        MENUITEM "&Lataa edellinen levykuva uudelleen",                 IDM_MO_RELOAD
+        MENUITEM "&Poista asemasta", IDM_MO_EJECT
+        MENUITEM "&Lataa edellinen levykuva uudelleen", IDM_MO_RELOAD
     END
 END
 
@@ -222,16 +222,16 @@ VidGLSubMenu MENU DISCARDABLE
 BEGIN
     POPUP "&Kuvataajuustavoite"
     BEGIN
-        MENUITEM "&Synkronisoi videoon",        IDM_VID_GL_FPS_BLITTER
-        MENUITEM "&25 ruutua/s",                IDM_VID_GL_FPS_25
-        MENUITEM "&30 ruutua/s",                IDM_VID_GL_FPS_30
-        MENUITEM "&50 ruutua/s",                IDM_VID_GL_FPS_50
-        MENUITEM "&60 ruutua/s",                IDM_VID_GL_FPS_60
-        MENUITEM "&75 ruutua/s",                IDM_VID_GL_FPS_75
+        MENUITEM "&Synkronisoi videoon", IDM_VID_GL_FPS_BLITTER
+        MENUITEM "&25 ruutua/s", IDM_VID_GL_FPS_25
+        MENUITEM "&30 ruutua/s", IDM_VID_GL_FPS_30
+        MENUITEM "&50 ruutua/s", IDM_VID_GL_FPS_50
+        MENUITEM "&60 ruutua/s", IDM_VID_GL_FPS_60
+        MENUITEM "&75 ruutua/s", IDM_VID_GL_FPS_75
     END
-    MENUITEM "&VSync",                          IDM_VID_GL_VSYNC
-    MENUITEM "Valitse varjostin&ohjelma...",    IDM_VID_GL_SHADER
-    MENUITEM "&Poista varjostinohjelma",        IDM_VID_GL_NOSHADER
+    MENUITEM "&VSync", IDM_VID_GL_VSYNC
+    MENUITEM "Valitse varjostin&ohjelma...", IDM_VID_GL_SHADER
+    MENUITEM "&Poista varjostinohjelma", IDM_VID_GL_NOSHADER
 END
 
 
@@ -240,150 +240,150 @@ END
 // Dialog
 //
 
-#define STR_PREFERENCES     "Sovellusasetukset"
-#define STR_SND_GAIN        "Äänen taso"
-#define STR_NEW_FLOPPY      "Uusi levykuva"
-#define STR_CONFIG          "Kokoonpano"
-#define STR_SPECIFY_DIM     "Määritä pääikkunan koko"
+#define STR_PREFERENCES   "Sovellusasetukset"
+#define STR_SND_GAIN      "Äänen taso"
+#define STR_NEW_FLOPPY    "Uusi levykuva"
+#define STR_CONFIG        "Kokoonpano"
+#define STR_SPECIFY_DIM   "Määritä pääikkunan koko"
 
-#define STR_OK              "OK"
-#define STR_CANCEL          "Peruuta"
-#define STR_GLOBAL          "Tallenna nämä asetukset &globaaleiksi oletuksiksi"
-#define STR_DEFAULT         "&Oletus"
-#define STR_LANGUAGE        "Kieli:"
-#define STR_ICONSET         "Kuvakkeet:"
+#define STR_OK            "OK"
+#define STR_CANCEL        "Peruuta"
+#define STR_GLOBAL        "Tallenna nämä asetukset &globaaleiksi oletuksiksi"
+#define STR_DEFAULT       "&Oletus"
+#define STR_LANGUAGE      "Kieli:"
+#define STR_ICONSET       "Kuvakkeet:"
 
-#define STR_GAIN            "Taso"
+#define STR_GAIN          "Taso"
 
-#define STR_FILE_NAME       "Tiedostonimi:"
-#define STR_DISK_SIZE       "Levyn koko:"
-#define STR_RPM_MODE        "Kierroslukutila:"
-#define STR_PROGRESS        "Edistyminen:"
+#define STR_FILE_NAME     "Tiedostonimi:"
+#define STR_DISK_SIZE     "Levyn koko:"
+#define STR_RPM_MODE      "Kierroslukutila:"
+#define STR_PROGRESS      "Edistyminen:"
 
-#define STR_WIDTH           "Leveys:"
-#define STR_HEIGHT          "Korkeus:"
-#define STR_LOCK_TO_SIZE    "Lukitse tähän kokoon"
+#define STR_WIDTH         "Leveys:"
+#define STR_HEIGHT        "Korkeus:"
+#define STR_LOCK_TO_SIZE  "Lukitse tähän kokoon"
 
-#define STR_MACHINE_TYPE    "Tietokoneen tyyppi:"
-#define STR_MACHINE         "Tietokone:"
-#define STR_CONFIGURE       "Määritys"
-#define STR_CPU_TYPE        "Suorittimen tyyppi:"
-#define STR_CPU_SPEED       "Nopeus:"
-#define STR_FPU             "Apusuoritin:"
-#define STR_WAIT_STATES     "Odotustilat:"
-#define STR_MB              "Mt"
-#define STR_MEMORY          "Muisti:"
-#define STR_TIME_SYNC       "Kellon synkronointi"
-#define STR_DISABLED        "Ei käytössä"
-#define STR_ENABLED_LOCAL   "Käytössä (paikallinen)"
-#define STR_ENABLED_UTC     "Käytössä (UTC)"
-#define STR_DYNAREC         "Dynaaminen uudelleenkääntäjä"
+#define STR_MACHINE_TYPE  "Tietokoneen tyyppi:"
+#define STR_MACHINE       "Tietokone:"
+#define STR_CONFIGURE     "Määritys"
+#define STR_CPU_TYPE      "Suorittimen tyyppi:"
+#define STR_CPU_SPEED     "Nopeus:"
+#define STR_FPU           "Apusuoritin:"
+#define STR_WAIT_STATES   "Odotustilat:"
+#define STR_MB            "Mt"
+#define STR_MEMORY        "Muisti:"
+#define STR_TIME_SYNC     "Kellon synkronointi"
+#define STR_DISABLED      "Ei käytössä"
+#define STR_ENABLED_LOCAL "Käytössä (paikallinen)"
+#define STR_ENABLED_UTC   "Käytössä (UTC)"
+#define STR_DYNAREC       "Dynaaminen uudelleenkääntäjä"
 
-#define STR_VIDEO           "Näytönohjain:"
-#define STR_VIDEO_2         "Näytönohjain 2:"
-#define STR_VOODOO          "Voodoo-grafiikkasuoritin"
-#define STR_IBM8514        "IBM 8514/a-grafiikkasuoritin"
-#define STR_XGA             "XGA-grafiikkasuoritin"
+#define STR_VIDEO         "Näytönohjain:"
+#define STR_VIDEO_2       "Näytönohjain 2:"
+#define STR_VOODOO        "Voodoo-grafiikkasuoritin"
+#define STR_IBM8514       "IBM 8514/a-grafiikkasuoritin"
+#define STR_XGA           "XGA-grafiikkasuoritin"
 
-#define STR_MOUSE           "Hiiri:"
-#define STR_JOYSTICK        "Peliohjain:"
-#define STR_JOY1            "Peliohjain 1..."
-#define STR_JOY2            "Peliohjain 2..."
-#define STR_JOY3            "Peliohjain 3..."
-#define STR_JOY4            "Peliohjain 4..."
+#define STR_MOUSE         "Hiiri:"
+#define STR_JOYSTICK      "Peliohjain:"
+#define STR_JOY1          "Peliohjain 1..."
+#define STR_JOY2          "Peliohjain 2..."
+#define STR_JOY3          "Peliohjain 3..."
+#define STR_JOY4          "Peliohjain 4..."
 
-#define STR_SOUND1           "Äänikortti 1:"
-#define STR_SOUND2           "Äänikortti 2:"
-#define STR_SOUND3           "Äänikortti 3:"
-#define STR_SOUND4           "Äänikortti 4:"
-#define STR_MIDI_OUT        "MIDI-ulostulo:"
-#define STR_MIDI_IN         "MIDI-sisääntulo:"
-#define STR_MPU401          "Erillinen MPU-401"
-#define STR_FLOAT           "Käytä FLOAT32-ääntä"
-#define STR_FM_DRIVER       "FM-syntetisaattoriohjain"
-#define STR_FM_DRV_NUKED    "Nuked (tarkempi)"
-#define STR_FM_DRV_YMFM     "YMFM (nopeampi)"
+#define STR_SOUND1        "Äänikortti 1:"
+#define STR_SOUND2        "Äänikortti 2:"
+#define STR_SOUND3        "Äänikortti 3:"
+#define STR_SOUND4        "Äänikortti 4:"
+#define STR_MIDI_OUT      "MIDI-ulostulo:"
+#define STR_MIDI_IN       "MIDI-sisääntulo:"
+#define STR_MPU401        "Erillinen MPU-401"
+#define STR_FLOAT         "Käytä FLOAT32-ääntä"
+#define STR_FM_DRIVER     "FM-syntetisaattoriohjain"
+#define STR_FM_DRV_NUKED  "Nuked (tarkempi)"
+#define STR_FM_DRV_YMFM   "YMFM (nopeampi)"
 
-#define STR_NET_TYPE        "Verkon tyyppi:"
-#define STR_PCAP            "PCap-laite:"
-#define STR_NET             "Verkkokortti:"
-#define STR_NET1            "Network card 1:"
-#define STR_NET2            "Network card 2:"
-#define STR_NET3            "Network card 3:"
-#define STR_NET4            "Network card 4:"
+#define STR_NET_TYPE      "Verkon tyyppi:"
+#define STR_PCAP          "PCap-laite:"
+#define STR_NET           "Verkkokortti:"
+#define STR_NET1          "Network card 1:"
+#define STR_NET2          "Network card 2:"
+#define STR_NET3          "Network card 3:"
+#define STR_NET4          "Network card 4:"
 
-#define STR_COM1            "COM1-laite:"
-#define STR_COM2            "COM2-laite:"
-#define STR_COM3            "COM3-laite:"
-#define STR_COM4            "COM4-laite:"
-#define STR_LPT1            "LPT1-laite:"
-#define STR_LPT2            "LPT2-laite:"
-#define STR_LPT3            "LPT3-laite:"
-#define STR_LPT4            "LPT4-laite:"
-#define STR_SERIAL1         "Sarjaportti 1"
-#define STR_SERIAL2         "Sarjaportti 2"
-#define STR_SERIAL3         "Sarjaportti 3"
-#define STR_SERIAL4         "Sarjaportti 4"
-#define STR_PARALLEL1       "Rinnakkaisportti 1"
-#define STR_PARALLEL2       "Rinnakkaisportti 2"
-#define STR_PARALLEL3       "Rinnakkaisportti 3"
-#define STR_PARALLEL4       "Rinnakkaisportti 4"
-#define STR_SERIAL_PASS1    "Serial port passthrough 1"
-#define STR_SERIAL_PASS2    "Serial port passthrough 2"
-#define STR_SERIAL_PASS3    "Serial port passthrough 3"
-#define STR_SERIAL_PASS4    "Serial port passthrough 4"
+#define STR_COM1          "COM1-laite:"
+#define STR_COM2          "COM2-laite:"
+#define STR_COM3          "COM3-laite:"
+#define STR_COM4          "COM4-laite:"
+#define STR_LPT1          "LPT1-laite:"
+#define STR_LPT2          "LPT2-laite:"
+#define STR_LPT3          "LPT3-laite:"
+#define STR_LPT4          "LPT4-laite:"
+#define STR_SERIAL1       "Sarjaportti 1"
+#define STR_SERIAL2       "Sarjaportti 2"
+#define STR_SERIAL3       "Sarjaportti 3"
+#define STR_SERIAL4       "Sarjaportti 4"
+#define STR_PARALLEL1     "Rinnakkaisportti 1"
+#define STR_PARALLEL2     "Rinnakkaisportti 2"
+#define STR_PARALLEL3     "Rinnakkaisportti 3"
+#define STR_PARALLEL4     "Rinnakkaisportti 4"
+#define STR_SERIAL_PASS1  "Serial port passthrough 1"
+#define STR_SERIAL_PASS2  "Serial port passthrough 2"
+#define STR_SERIAL_PASS3  "Serial port passthrough 3"
+#define STR_SERIAL_PASS4  "Serial port passthrough 4"
 
-#define STR_HDC             "Kiintolevyohjain:"
-#define STR_FDC             "Levykeohjain:"
-#define STR_IDE_TER         "Kolmas IDE-ohjain"
-#define STR_IDE_QUA         "Neljäs IDE-ohjain"
-#define STR_SCSI            "SCSI"
-#define STR_SCSI_1          "Ohjain 1:"
-#define STR_SCSI_2          "Ohjain 2:"
-#define STR_SCSI_3          "Ohjain 3:"
-#define STR_SCSI_4          "Ohjain 4:"
-#define STR_CASSETTE        "Kasettiasema"
+#define STR_HDC           "Kiintolevyohjain:"
+#define STR_FDC           "Levykeohjain:"
+#define STR_IDE_TER       "Kolmas IDE-ohjain"
+#define STR_IDE_QUA       "Neljäs IDE-ohjain"
+#define STR_SCSI          "SCSI"
+#define STR_SCSI_1        "Ohjain 1:"
+#define STR_SCSI_2        "Ohjain 2:"
+#define STR_SCSI_3        "Ohjain 3:"
+#define STR_SCSI_4        "Ohjain 4:"
+#define STR_CASSETTE      "Kasettiasema"
 
-#define STR_HDD             "Kiintolevyt:"
-#define STR_NEW             "&Uusi..."
-#define STR_EXISTING        "&Olemassaoleva..."
-#define STR_REMOVE          "&Poista"
-#define STR_BUS             "Väylä:"
-#define STR_CHANNEL         "Kanava:"
-#define STR_ID              "ID:"
-#define STR_SPEED        "Speed:"
+#define STR_HDD           "Kiintolevyt:"
+#define STR_NEW           "&Uusi..."
+#define STR_EXISTING      "&Olemassaoleva..."
+#define STR_REMOVE        "&Poista"
+#define STR_BUS           "Väylä:"
+#define STR_CHANNEL       "Kanava:"
+#define STR_ID            "ID:"
+#define STR_SPEED         "Speed:"
 
-#define STR_SPECIFY         "&Määritä..."
-#define STR_SECTORS         "Sektorit:"
-#define STR_HEADS           "Lukupäät:"
-#define STR_CYLS            "Sylinterit:"
-#define STR_SIZE_MB         "Koko (Mt):"
-#define STR_TYPE            "Tyyppi:"
-#define STR_IMG_FORMAT      "Tiedostomuoto:"
-#define STR_BLOCK_SIZE      "Lohkon koko:"
+#define STR_SPECIFY       "&Määritä..."
+#define STR_SECTORS       "Sektorit:"
+#define STR_HEADS         "Lukupäät:"
+#define STR_CYLS          "Sylinterit:"
+#define STR_SIZE_MB       "Koko (Mt):"
+#define STR_TYPE          "Tyyppi:"
+#define STR_IMG_FORMAT    "Tiedostomuoto:"
+#define STR_BLOCK_SIZE    "Lohkon koko:"
 
-#define STR_FLOPPY_DRIVES   "Levykeasemat:"
-#define STR_TURBO           "Turbo-ajoitukset"
-#define STR_CHECKBPB        "Tarkista BPB"
-#define STR_CDROM_DRIVES    "CD-ROM-asemat:"
-#define STR_CD_SPEED        "Nopeus:"
-#define STR_EARLY           "Aiemmat asemat"
+#define STR_FLOPPY_DRIVES "Levykeasemat:"
+#define STR_TURBO         "Turbo-ajoitukset"
+#define STR_CHECKBPB      "Tarkista BPB"
+#define STR_CDROM_DRIVES  "CD-ROM-asemat:"
+#define STR_CD_SPEED      "Nopeus:"
+#define STR_EARLY         "Aiemmat asemat"
 
-#define STR_MO_DRIVES       "Magneettisoptiset asemat (MO):"
-#define STR_ZIP_DRIVES      "ZIP-asemat:"
-#define STR_250             "ZIP 250"
+#define STR_MO_DRIVES     "Magneettisoptiset asemat (MO):"
+#define STR_ZIP_DRIVES    "ZIP-asemat:"
+#define STR_250           "ZIP 250"
 
-#define STR_ISARTC          "ISA-RTC (kello):"
-#define STR_ISAMEM          "ISA-muistilaajennus"
-#define STR_ISAMEM_1        "Kortti 1:"
-#define STR_ISAMEM_2        "Kortti 2:"
-#define STR_ISAMEM_3        "Kortti 3:"
-#define STR_ISAMEM_4        "Kortti 4:"
-#define STR_BUGGER          "ISABugger-laite"
-#define STR_POSTCARD        "POST-kortti"
+#define STR_ISARTC        "ISA-RTC (kello):"
+#define STR_ISAMEM        "ISA-muistilaajennus"
+#define STR_ISAMEM_1      "Kortti 1:"
+#define STR_ISAMEM_2      "Kortti 2:"
+#define STR_ISAMEM_3      "Kortti 3:"
+#define STR_ISAMEM_4      "Kortti 4:"
+#define STR_BUGGER        "ISABugger-laite"
+#define STR_POSTCARD      "POST-kortti"
 
-#define FONT_SIZE        9
-#define FONT_NAME        "Segoe UI"
+#define FONT_SIZE         9
+#define FONT_NAME         "Segoe UI"
 
 #include "dialogs.rc"
 
@@ -394,7 +394,7 @@ END
 
 STRINGTABLE DISCARDABLE
 BEGIN
-    2048    "86Box"
+    2048        "86Box"
     IDS_2049    "Virhe"
     IDS_2050    "Vakava virhe"
     IDS_2051    " - TAUKO"
@@ -643,7 +643,7 @@ BEGIN
 
     IDS_7168    "(Järjestelmän oletus)"
 END
-#define IDS_LANG_ENUS    IDS_7168
+#define IDS_LANG_ENUS IDS_7168
 
 // English (U.S.) resources
 /////////////////////////////////////////////////////////////////////////////

--- a/src/win/languages/fr-FR.rc
+++ b/src/win/languages/fr-FR.rc
@@ -13,122 +13,122 @@ LANGUAGE LANG_FRENCH, SUBLANG_FRENCH
 // Menu
 //
 
-MainMenu MENU DISCARDABLE 
+MainMenu MENU DISCARDABLE
 BEGIN
     POPUP "&Action"
     BEGIN
-        MENUITEM "&Capturer le clavier",    IDM_ACTION_KBD_REQ_CAPTURE
-        MENUITEM "CTRL &Droite devient ALT Gauche",    IDM_ACTION_RCTRL_IS_LALT
+        MENUITEM "&Capturer le clavier", IDM_ACTION_KBD_REQ_CAPTURE
+        MENUITEM "CTRL &Droite devient ALT Gauche", IDM_ACTION_RCTRL_IS_LALT
         MENUITEM SEPARATOR
-        MENUITEM "&Hard Reset...",              IDM_ACTION_HRESET
-        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12",     IDM_ACTION_RESET_CAD
+        MENUITEM "&Hard Reset...", IDM_ACTION_HRESET
+        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12", IDM_ACTION_RESET_CAD
         MENUITEM SEPARATOR
-    MENUITEM "Ctrl+Alt+&Esc",        IDM_ACTION_CTRL_ALT_ESC
+    MENUITEM "Ctrl+Alt+&Esc", IDM_ACTION_CTRL_ALT_ESC
         MENUITEM SEPARATOR
-        MENUITEM "&Pause",                      IDM_ACTION_PAUSE
+        MENUITEM "&Pause", IDM_ACTION_PAUSE
         MENUITEM SEPARATOR
-        MENUITEM "&Quitter...",                       IDM_ACTION_EXIT
+        MENUITEM "&Quitter...", IDM_ACTION_EXIT
     END
     POPUP "&Vue"
     BEGIN
-        MENUITEM "&Masquer la barre de status",        IDM_VID_HIDE_STATUS_BAR
-        MENUITEM "Hide &toolbar",        IDM_VID_HIDE_TOOLBAR
+        MENUITEM "&Masquer la barre de status", IDM_VID_HIDE_STATUS_BAR
+        MENUITEM "Hide &toolbar", IDM_VID_HIDE_TOOLBAR
         MENUITEM SEPARATOR
-        MENUITEM "&Show non-primary monitors",  IDM_VID_MONITORS
-        MENUITEM "Fenètre &Retaillable",          IDM_VID_RESIZE
-        MENUITEM "S&auvegarder taille && position",  IDM_VID_REMEMBER
+        MENUITEM "&Show non-primary monitors", IDM_VID_MONITORS
+        MENUITEM "Fenètre &Retaillable", IDM_VID_RESIZE
+        MENUITEM "S&auvegarder taille && position", IDM_VID_REMEMBER
         MENUITEM SEPARATOR
         POPUP "Moteur de &rendu vidéo"
         BEGIN
-            MENUITEM "&SDL (Logiciel)",         IDM_VID_SDL_SW
-            MENUITEM "SDL (&Materiel)",         IDM_VID_SDL_HW
-            MENUITEM "SDL (&OpenGL)",           IDM_VID_SDL_OPENGL
-            MENUITEM "Open&GL (3.0 Core)",      IDM_VID_OPENGL_CORE
+            MENUITEM "&SDL (Logiciel)", IDM_VID_SDL_SW
+            MENUITEM "SDL (&Materiel)", IDM_VID_SDL_HW
+            MENUITEM "SDL (&OpenGL)", IDM_VID_SDL_OPENGL
+            MENUITEM "Open&GL (3.0 Core)", IDM_VID_OPENGL_CORE
 #ifdef USE_VNC
-            MENUITEM "&VNC",                    IDM_VID_VNC
+            MENUITEM "&VNC", IDM_VID_VNC
 #endif
         END
         MENUITEM SEPARATOR
-        MENUITEM "Specifier dimensions...",          IDM_VID_SPECIFY_DIM
-        MENUITEM "F&orcer 4:3",    IDM_VID_FORCE43
+        MENUITEM "Specifier dimensions...", IDM_VID_SPECIFY_DIM
+        MENUITEM "F&orcer 4:3", IDM_VID_FORCE43
         POPUP "&Echelle facteur"
         BEGIN
-            MENUITEM "&0.5x",                   IDM_VID_SCALE_1X
-            MENUITEM "&1x",                     IDM_VID_SCALE_2X
-            MENUITEM "1.&5x",                   IDM_VID_SCALE_3X
-            MENUITEM "&2x",                     IDM_VID_SCALE_4X
-            MENUITEM "&3x",                     IDM_VID_SCALE_5X
-            MENUITEM "&4x",                     IDM_VID_SCALE_6X
-            MENUITEM "&5x",                     IDM_VID_SCALE_7X
-            MENUITEM "&6x",                     IDM_VID_SCALE_8X
-            MENUITEM "&7x",                     IDM_VID_SCALE_9X
-            MENUITEM "&8x",                     IDM_VID_SCALE_10X
+            MENUITEM "&0.5x", IDM_VID_SCALE_1X
+            MENUITEM "&1x", IDM_VID_SCALE_2X
+            MENUITEM "1.&5x", IDM_VID_SCALE_3X
+            MENUITEM "&2x", IDM_VID_SCALE_4X
+            MENUITEM "&3x", IDM_VID_SCALE_5X
+            MENUITEM "&4x", IDM_VID_SCALE_6X
+            MENUITEM "&5x", IDM_VID_SCALE_7X
+            MENUITEM "&6x", IDM_VID_SCALE_8X
+            MENUITEM "&7x", IDM_VID_SCALE_9X
+            MENUITEM "&8x", IDM_VID_SCALE_10X
         END
         POPUP "Methode Filtre"
         BEGIN
-            MENUITEM "&Plus proche",                 IDM_VID_FILTER_NEAREST
-            MENUITEM "&Lineaire",                  IDM_VID_FILTER_LINEAR
+            MENUITEM "&Plus proche", IDM_VID_FILTER_NEAREST
+            MENUITEM "&Lineaire", IDM_VID_FILTER_LINEAR
         END
-        MENUITEM "Mise à l'échelle Hi&DPI",              IDM_VID_HIDPI
+        MENUITEM "Mise à l'échelle Hi&DPI", IDM_VID_HIDPI
         MENUITEM SEPARATOR
-        MENUITEM "&Plein Ecran\tCtrl+Alt+PgUp",    IDM_VID_FULLSCREEN
+        MENUITEM "&Plein Ecran\tCtrl+Alt+PgUp", IDM_VID_FULLSCREEN
         POPUP "Mode &Elargi plein écran"
         BEGIN
-            MENUITEM "&Plein écran étiré",        IDM_VID_FS_FULL
-            MENUITEM "&4:3",                        IDM_VID_FS_43
+            MENUITEM "&Plein écran étiré", IDM_VID_FS_FULL
+            MENUITEM "&4:3", IDM_VID_FS_43
             MENUITEM "pixels &Carrés(Keep ratio)", IDM_VID_FS_KEEPRATIO
-            MENUITEM "Echelle &Entière",              IDM_VID_FS_INT
+            MENUITEM "Echelle &Entière", IDM_VID_FS_INT
         END
         POPUP "Réglages E&GA/(S)VGA"
         BEGIN
-            MENUITEM "Moniteur VGA &Inversé",   IDM_VID_INVERT
+            MENUITEM "Moniteur VGA &Inversé", IDM_VID_INVERT
             POPUP "&Type Ecran VGA"
             BEGIN
-                MENUITEM "RGB &Couleur",          IDM_VID_GRAY_RGB
-                MENUITEM "&RGB Ton de Gris",      IDM_VID_GRAY_MONO
-                MENUITEM "Moniteur &Ambre",      IDM_VID_GRAY_AMBER
-                MENUITEM "Moniteur &Vert",      IDM_VID_GRAY_GREEN
-                MENUITEM "Moniteur &Blanc",      IDM_VID_GRAY_WHITE
+                MENUITEM "RGB &Couleur", IDM_VID_GRAY_RGB
+                MENUITEM "&RGB Ton de Gris", IDM_VID_GRAY_MONO
+                MENUITEM "Moniteur &Ambre", IDM_VID_GRAY_AMBER
+                MENUITEM "Moniteur &Vert", IDM_VID_GRAY_GREEN
+                MENUITEM "Moniteur &Blanc", IDM_VID_GRAY_WHITE
             END
             POPUP "Grayscale &conversion type"
             BEGIN
-                MENUITEM "BT&601 (NTSC/PAL)",   IDM_VID_GRAYCT_601
-                MENUITEM "BT&709 (HDTV)",       IDM_VID_GRAYCT_709
-                MENUITEM "&Moyenne",            IDM_VID_GRAYCT_AVE
+                MENUITEM "BT&601 (NTSC/PAL)", IDM_VID_GRAYCT_601
+                MENUITEM "BT&709 (HDTV)", IDM_VID_GRAYCT_709
+                MENUITEM "&Moyenne", IDM_VID_GRAYCT_AVE
             END
         END
         MENUITEM SEPARATOR
-        MENUITEM "CGA/PCjr/Tandy/E&GA/(S)VGA overscan",     IDM_VID_OVERSCAN
+        MENUITEM "CGA/PCjr/Tandy/E&GA/(S)VGA overscan", IDM_VID_OVERSCAN
         MENUITEM "Modifier contraste affichage  &monochrome", IDM_VID_CGACON
     END
-    MENUITEM "&Media",                IDM_MEDIA
+    MENUITEM "&Media", IDM_MEDIA
     POPUP "Ou&tils"
     BEGIN
-        MENUITEM "&Réglages...",                IDM_CONFIG
-        MENUITEM "Mettre à jour la barre de stat&us",    IDM_UPDATE_ICONS
+        MENUITEM "&Réglages...", IDM_CONFIG
+        MENUITEM "Mettre à jour la barre de stat&us", IDM_UPDATE_ICONS
         MENUITEM SEPARATOR
-        MENUITEM "Copie &Ecran\tCtrl+F11",  IDM_ACTION_SCREENSHOT
+        MENUITEM "Copie &Ecran\tCtrl+F11", IDM_ACTION_SCREENSHOT
         MENUITEM SEPARATOR
-        MENUITEM "&Préférences...",    IDM_PREFERENCES
+        MENUITEM "&Préférences...", IDM_PREFERENCES
 #ifdef DISCORD
         MENUITEM "Activer intégration &Discord", IDM_DISCORD
 #endif
         MENUITEM SEPARATOR
-        MENUITEM "&Gain Son...",              IDM_SND_GAIN
+        MENUITEM "&Gain Son...", IDM_SND_GAIN
 #ifdef MTR_ENABLED
         MENUITEM SEPARATOR
-        MENUITEM "Démarrer traces\tCtrl+T",         IDM_ACTION_BEGIN_TRACE
-        MENUITEM "Finir traces\tCtrl+T",           IDM_ACTION_END_TRACE
+        MENUITEM "Démarrer traces\tCtrl+T", IDM_ACTION_BEGIN_TRACE
+        MENUITEM "Finir traces\tCtrl+T", IDM_ACTION_END_TRACE
 #endif
     END
     POPUP "&Aide"
     BEGIN
-        MENUITEM "&Documentation...",           IDM_DOCS
-        MENUITEM "&A Propos de 86Box...",             IDM_ABOUT
+        MENUITEM "&Documentation...", IDM_DOCS
+        MENUITEM "&A Propos de 86Box...", IDM_ABOUT
     END
 END
 
-StatusBarMenu MENU DISCARDABLE 
+StatusBarMenu MENU DISCARDABLE
 BEGIN
     MENUITEM SEPARATOR
 END
@@ -137,17 +137,17 @@ CassetteSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nouvelle image...",                IDM_CASSETTE_IMAGE_NEW
+        MENUITEM "&Nouvelle image...", IDM_CASSETTE_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "Image &Existante...",                IDM_CASSETTE_IMAGE_EXISTING
-        MENUITEM "Image Existante(&Lecture seule)...",    IDM_CASSETTE_IMAGE_EXISTING_WP
+        MENUITEM "Image &Existante...", IDM_CASSETTE_IMAGE_EXISTING
+        MENUITEM "Image Existante(&Lecture seule)...", IDM_CASSETTE_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "En&registrer",                    IDM_CASSETTE_RECORD
-        MENUITEM "&Jouer",                    IDM_CASSETTE_PLAY
-        MENUITEM "&Revenir au debut",            IDM_CASSETTE_REWIND
-        MENUITEM "Aller à la &Fin",            IDM_CASSETTE_FAST_FORWARD
+        MENUITEM "En&registrer", IDM_CASSETTE_RECORD
+        MENUITEM "&Jouer", IDM_CASSETTE_PLAY
+        MENUITEM "&Revenir au debut", IDM_CASSETTE_REWIND
+        MENUITEM "Aller à la &Fin", IDM_CASSETTE_FAST_FORWARD
         MENUITEM SEPARATOR
-        MENUITEM "E&jecter",                    IDM_CASSETTE_EJECT
+        MENUITEM "E&jecter", IDM_CASSETTE_EJECT
     END
 END
 
@@ -155,9 +155,9 @@ CartridgeSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Image...",                    IDM_CARTRIDGE_IMAGE
+        MENUITEM "&Image...", IDM_CARTRIDGE_IMAGE
         MENUITEM SEPARATOR
-        MENUITEM "E&jecter",                    IDM_CARTRIDGE_EJECT
+        MENUITEM "E&jecter", IDM_CARTRIDGE_EJECT
     END
 END
 
@@ -165,14 +165,14 @@ FloppySubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nouvelle image...",                IDM_FLOPPY_IMAGE_NEW
+        MENUITEM "&Nouvelle image...", IDM_FLOPPY_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "Image &Existante...",                IDM_FLOPPY_IMAGE_EXISTING
-        MENUITEM "Image Existante(&Lecture seule)...",    IDM_FLOPPY_IMAGE_EXISTING_WP
+        MENUITEM "Image &Existante...", IDM_FLOPPY_IMAGE_EXISTING
+        MENUITEM "Image Existante(&Lecture seule)...", IDM_FLOPPY_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "E&xport vers 86F...",                IDM_FLOPPY_EXPORT_TO_86F
+        MENUITEM "E&xport vers 86F...", IDM_FLOPPY_EXPORT_TO_86F
         MENUITEM SEPARATOR
-        MENUITEM "E&jecter",                    IDM_FLOPPY_EJECT
+        MENUITEM "E&jecter", IDM_FLOPPY_EJECT
     END
 END
 
@@ -180,13 +180,13 @@ CdromSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Couper",                    IDM_CDROM_MUTE
+        MENUITEM "&Couper", IDM_CDROM_MUTE
         MENUITEM SEPARATOR
-        MENUITEM "E&jecter",                    IDM_CDROM_EMPTY
-        MENUITEM "&Recharger image précedente",            IDM_CDROM_RELOAD
+        MENUITEM "E&jecter", IDM_CDROM_EMPTY
+        MENUITEM "&Recharger image précedente", IDM_CDROM_RELOAD
         MENUITEM SEPARATOR
-        MENUITEM "&Image...",                    IDM_CDROM_IMAGE
-        MENUITEM "&Dossier...",                    IDM_CDROM_DIR
+        MENUITEM "&Image...", IDM_CDROM_IMAGE
+        MENUITEM "&Dossier...", IDM_CDROM_DIR
     END
 END
 
@@ -194,13 +194,13 @@ ZIPSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nouvelle image...",                IDM_ZIP_IMAGE_NEW
+        MENUITEM "&Nouvelle image...", IDM_ZIP_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "Image &Existante...",                IDM_ZIP_IMAGE_EXISTING
-        MENUITEM "Image Existante (&Lecture Seule)...",    IDM_ZIP_IMAGE_EXISTING_WP
+        MENUITEM "Image &Existante...", IDM_ZIP_IMAGE_EXISTING
+        MENUITEM "Image Existante (&Lecture Seule)...", IDM_ZIP_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "E&jecter",                    IDM_ZIP_EJECT
-        MENUITEM "&Recharger image précédente",            IDM_ZIP_RELOAD
+        MENUITEM "E&jecter", IDM_ZIP_EJECT
+        MENUITEM "&Recharger image précédente", IDM_ZIP_RELOAD
     END
 END
 
@@ -208,13 +208,13 @@ MOSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nouvelle image...",            IDM_MO_IMAGE_NEW
+        MENUITEM "&Nouvelle image...", IDM_MO_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "Image &Existante...",                IDM_MO_IMAGE_EXISTING
-        MENUITEM "Image Existante (&Lecture Seule)...",    IDM_MO_IMAGE_EXISTING_WP
+        MENUITEM "Image &Existante...", IDM_MO_IMAGE_EXISTING
+        MENUITEM "Image Existante (&Lecture Seule)...", IDM_MO_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "E&jecter",                    IDM_MO_EJECT
-        MENUITEM "&Recharger image précédente",            IDM_MO_RELOAD
+        MENUITEM "E&jecter", IDM_MO_EJECT
+        MENUITEM "&Recharger image précédente", IDM_MO_RELOAD
     END
 END
 
@@ -240,150 +240,150 @@ END
 // Dialog
 //
 
-#define STR_PREFERENCES        "Préférences"
-#define STR_SND_GAIN        "Gain son"
-#define STR_NEW_FLOPPY        "Nouvelle image"
+#define STR_PREFERENCES   "Préférences"
+#define STR_SND_GAIN      "Gain son"
+#define STR_NEW_FLOPPY    "Nouvelle image"
 #define STR_CONFIG        "Réglages"
-#define STR_SPECIFY_DIM        "Spécifier le détournement de la fenêtre principale"
+#define STR_SPECIFY_DIM   "Spécifier le détournement de la fenêtre principale"
 
 #define STR_OK            "OK"
 #define STR_CANCEL        "Annuler"
 #define STR_GLOBAL        "Sauvegarder ces paramètres comme valeurs par défaut &globales"
-#define STR_DEFAULT        "&Défaut"
-#define STR_LANGUAGE        "Langue:"
-#define STR_ICONSET        "Ensemble d'icônes:"
+#define STR_DEFAULT       "&Défaut"
+#define STR_LANGUAGE      "Langue:"
+#define STR_ICONSET       "Ensemble d'icônes:"
 
-#define STR_GAIN        "Gain"
+#define STR_GAIN          "Gain"
 
-#define STR_FILE_NAME        "Nom fichier:"
-#define STR_DISK_SIZE        "Taille disque:"
-#define STR_RPM_MODE        "Mode RPM:"
-#define STR_PROGRESS        "Progrès:"
+#define STR_FILE_NAME     "Nom fichier:"
+#define STR_DISK_SIZE     "Taille disque:"
+#define STR_RPM_MODE      "Mode RPM:"
+#define STR_PROGRESS      "Progrès:"
 
-#define STR_WIDTH        "Largeur:"
+#define STR_WIDTH         "Largeur:"
 #define STR_HEIGHT        "Hauteur:"
-#define STR_LOCK_TO_SIZE    "Verrouiller à cette taille"
+#define STR_LOCK_TO_SIZE  "Verrouiller à cette taille"
 
-#define STR_MACHINE_TYPE    "Type de machine:"
-#define STR_MACHINE        "Machine:"
-#define STR_CONFIGURE        "Configurer"
-#define STR_CPU_TYPE        "Type du processeur:"
-#define STR_CPU_SPEED        "Vitesse:"
-#define STR_FPU            "FPU:"
-#define STR_WAIT_STATES        "États d'attente:"
+#define STR_MACHINE_TYPE  "Type de machine:"
+#define STR_MACHINE       "Machine:"
+#define STR_CONFIGURE     "Configurer"
+#define STR_CPU_TYPE      "Type du processeur:"
+#define STR_CPU_SPEED     "Vitesse:"
+#define STR_FPU           "FPU:"
+#define STR_WAIT_STATES   "États d'attente:"
 #define STR_MB            "Mo"
 #define STR_MEMORY        "Mémoire:"
-#define STR_TIME_SYNC        "Synchronisation du temps"
-#define STR_DISABLED        "Désactivé"
-#define STR_ENABLED_LOCAL    "Activé (heure locale)"
-#define STR_ENABLED_UTC        "Activé (UTC)"
-#define STR_DYNAREC        "Recompilateur dynamique"
+#define STR_TIME_SYNC     "Synchronisation du temps"
+#define STR_DISABLED      "Désactivé"
+#define STR_ENABLED_LOCAL "Activé (heure locale)"
+#define STR_ENABLED_UTC   "Activé (UTC)"
+#define STR_DYNAREC       "Recompilateur dynamique"
 
-#define STR_VIDEO        "Vidéo:"
-#define STR_VIDEO_2        "Vidéo 2:"
+#define STR_VIDEO         "Vidéo:"
+#define STR_VIDEO_2       "Vidéo 2:"
 #define STR_VOODOO        "Graphique Voodoo"
-#define STR_IBM8514        "Graphique IBM 8514/a"
-#define STR_XGA            "Graphique XGA"
+#define STR_IBM8514       "Graphique IBM 8514/a"
+#define STR_XGA           "Graphique XGA"
 
-#define STR_MOUSE        "Souris:"
-#define STR_JOYSTICK        "Manette de commande:"
-#define STR_JOY1        "Manette 1..."
-#define STR_JOY2        "Manette 2..."
-#define STR_JOY3        "Manette 3..."
-#define STR_JOY4        "Manette 4..."
+#define STR_MOUSE         "Souris:"
+#define STR_JOYSTICK      "Manette de commande:"
+#define STR_JOY1          "Manette 1..."
+#define STR_JOY2          "Manette 2..."
+#define STR_JOY3          "Manette 3..."
+#define STR_JOY4          "Manette 4..."
 
 #define STR_SOUND1        "Carte son 1:"
 #define STR_SOUND2        "Carte son 2:"
 #define STR_SOUND3        "Carte son 3:"
 #define STR_SOUND4        "Carte son 4:"
-#define STR_MIDI_OUT        "Sortie MIDI:"
-#define STR_MIDI_IN        "Entrée MIDI:"
+#define STR_MIDI_OUT      "Sortie MIDI:"
+#define STR_MIDI_IN       "Entrée MIDI:"
 #define STR_MPU401        "MPU-401 autonome"
-#define STR_FLOAT        "Utiliser le son FLOAT32"
-#define STR_FM_DRIVER        "Pilote de synthétiseur FM"
-#define STR_FM_DRV_NUKED    "Nuked (plus précis)"
-#define STR_FM_DRV_YMFM        "YMFM (plus rapide)"
+#define STR_FLOAT         "Utiliser le son FLOAT32"
+#define STR_FM_DRIVER     "Pilote de synthétiseur FM"
+#define STR_FM_DRV_NUKED  "Nuked (plus précis)"
+#define STR_FM_DRV_YMFM   "YMFM (plus rapide)"
 
-#define STR_NET_TYPE    "Type de réseau:"
-#define STR_PCAP        "Dispositif PCap:"
-#define STR_NET            "Adaptateur de réseau:"
-#define STR_NET1        "Network card 1:"
-#define STR_NET2        "Network card 2:"
-#define STR_NET3        "Network card 3:"
-#define STR_NET4        "Network card 4:"
+#define STR_NET_TYPE      "Type de réseau:"
+#define STR_PCAP          "Dispositif PCap:"
+#define STR_NET           "Adaptateur de réseau:"
+#define STR_NET1          "Network card 1:"
+#define STR_NET2          "Network card 2:"
+#define STR_NET3          "Network card 3:"
+#define STR_NET4          "Network card 4:"
 
-#define STR_COM1        "Dispositif COM1:"
-#define STR_COM2        "Dispositif COM2:"
-#define STR_COM3        "Dispositif COM3:"
-#define STR_COM4        "Dispositif COM4:"
-#define STR_LPT1        "Dispositif LPT1:"
-#define STR_LPT2        "Dispositif LPT2:"
-#define STR_LPT3        "Dispositif LPT3:"
-#define STR_LPT4        "Dispositif LPT4:"
-#define STR_SERIAL1        "Port série 1"
-#define STR_SERIAL2        "Port série 2"
-#define STR_SERIAL3        "Port série 3"
-#define STR_SERIAL4        "Port série 4"
-#define STR_PARALLEL1        "Port parallèle 1"
-#define STR_PARALLEL2        "Port parallèle 2"
-#define STR_PARALLEL3        "Port parallèle 3"
-#define STR_PARALLEL4        "Port parallèle 4"
-#define STR_SERIAL_PASS1    "Serial port passthrough 1"
-#define STR_SERIAL_PASS2    "Serial port passthrough 2"
-#define STR_SERIAL_PASS3    "Serial port passthrough 3"
-#define STR_SERIAL_PASS4    "Serial port passthrough 4"
+#define STR_COM1          "Dispositif COM1:"
+#define STR_COM2          "Dispositif COM2:"
+#define STR_COM3          "Dispositif COM3:"
+#define STR_COM4          "Dispositif COM4:"
+#define STR_LPT1          "Dispositif LPT1:"
+#define STR_LPT2          "Dispositif LPT2:"
+#define STR_LPT3          "Dispositif LPT3:"
+#define STR_LPT4          "Dispositif LPT4:"
+#define STR_SERIAL1       "Port série 1"
+#define STR_SERIAL2       "Port série 2"
+#define STR_SERIAL3       "Port série 3"
+#define STR_SERIAL4       "Port série 4"
+#define STR_PARALLEL1     "Port parallèle 1"
+#define STR_PARALLEL2     "Port parallèle 2"
+#define STR_PARALLEL3     "Port parallèle 3"
+#define STR_PARALLEL4     "Port parallèle 4"
+#define STR_SERIAL_PASS1  "Serial port passthrough 1"
+#define STR_SERIAL_PASS2  "Serial port passthrough 2"
+#define STR_SERIAL_PASS3  "Serial port passthrough 3"
+#define STR_SERIAL_PASS4  "Serial port passthrough 4"
 
-#define STR_HDC            "Contrôleur HD:"
-#define STR_FDC            "Contrôleur FD:"
-#define STR_IDE_TER        "Contrôleur IDE tertiaire"
-#define STR_IDE_QUA        "Contrôleur IDE quaternair"
-#define STR_SCSI        "SCSI"
+#define STR_HDC           "Contrôleur HD:"
+#define STR_FDC           "Contrôleur FD:"
+#define STR_IDE_TER       "Contrôleur IDE tertiaire"
+#define STR_IDE_QUA       "Contrôleur IDE quaternair"
+#define STR_SCSI          "SCSI"
 #define STR_SCSI_1        "Contrôleur 1:"
 #define STR_SCSI_2        "Contrôleur 2:"
 #define STR_SCSI_3        "Contrôleur 3:"
 #define STR_SCSI_4        "Contrôleur 4:"
-#define STR_CASSETTE        "Cassette"
+#define STR_CASSETTE      "Cassette"
 
-#define STR_HDD            "Disques durs:"
-#define STR_NEW            "&Nouveau..."
-#define STR_EXISTING        "&Existant..."
+#define STR_HDD           "Disques durs:"
+#define STR_NEW           "&Nouveau..."
+#define STR_EXISTING      "&Existant..."
 #define STR_REMOVE        "&Supprimer"
-#define STR_BUS            "Bus:"
-#define STR_CHANNEL        "Canal:"
+#define STR_BUS           "Bus:"
+#define STR_CHANNEL       "Canal:"
 #define STR_ID            "ID:"
-#define STR_SPEED        "Speed:"
+#define STR_SPEED         "Speed:"
 
-#define STR_SPECIFY        "&Spécifier..."
-#define STR_SECTORS        "Secteurs:"
-#define STR_HEADS        "Têtes:"
-#define STR_CYLS        "Cylindres:"
-#define STR_SIZE_MB        "Taille (Mo):"
-#define STR_TYPE        "Type:"
-#define STR_IMG_FORMAT        "Format Image:"
-#define STR_BLOCK_SIZE        "Taille du bloc:"
+#define STR_SPECIFY       "&Spécifier..."
+#define STR_SECTORS       "Secteurs:"
+#define STR_HEADS         "Têtes:"
+#define STR_CYLS          "Cylindres:"
+#define STR_SIZE_MB       "Taille (Mo):"
+#define STR_TYPE          "Type:"
+#define STR_IMG_FORMAT    "Format Image:"
+#define STR_BLOCK_SIZE    "Taille du bloc:"
 
-#define STR_FLOPPY_DRIVES    "Lecteurs de disquettes:"
-#define STR_TURBO        "Turbo"
-#define STR_CHECKBPB        "Vérifier BPB"
-#define STR_CDROM_DRIVES    "Lecterus CD-ROM:"
-#define STR_CD_SPEED        "Vitesse:"
-#define STR_EARLY        "Lecteur plus tôt"
+#define STR_FLOPPY_DRIVES "Lecteurs de disquettes:"
+#define STR_TURBO         "Turbo"
+#define STR_CHECKBPB      "Vérifier BPB"
+#define STR_CDROM_DRIVES  "Lecterus CD-ROM:"
+#define STR_CD_SPEED      "Vitesse:"
+#define STR_EARLY         "Lecteur plus tôt"
 
-#define STR_MO_DRIVES        "Lecteurs magnéto-optiques:"
-#define STR_ZIP_DRIVES        "Lecteurs ZIP:"
-#define STR_250            "ZIP 250"
+#define STR_MO_DRIVES     "Lecteurs magnéto-optiques:"
+#define STR_ZIP_DRIVES    "Lecteurs ZIP:"
+#define STR_250           "ZIP 250"
 
 #define STR_ISARTC        "Horloge temps réel ISA:"
 #define STR_ISAMEM        "Expansion de la mémoire ISA"
-#define STR_ISAMEM_1        "Carte 1:"
-#define STR_ISAMEM_2        "Carte 2:"
-#define STR_ISAMEM_3        "Carte 3:"
-#define STR_ISAMEM_4        "Carte 4:"
+#define STR_ISAMEM_1      "Carte 1:"
+#define STR_ISAMEM_2      "Carte 2:"
+#define STR_ISAMEM_3      "Carte 3:"
+#define STR_ISAMEM_4      "Carte 4:"
 #define STR_BUGGER        "Dispositif ISABugger"
-#define STR_POSTCARD        "Carte POST"
+#define STR_POSTCARD      "Carte POST"
 
-#define FONT_SIZE        9
-#define FONT_NAME        "Segoe UI"
+#define FONT_SIZE         9
+#define FONT_NAME         "Segoe UI"
 
 #include "dialogs.rc"
 
@@ -392,9 +392,9 @@ END
 // String Table
 //
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
-    2048    "86Box"
+    2048        "86Box"
     IDS_2049    "Erreur"
     IDS_2050    "Erreur fatale"
     IDS_2051    " - PAUSED"
@@ -412,7 +412,7 @@ BEGIN
     IDS_2063    "La machine ""%hs"" n'est pas disponible en raison de l'absence de ROMs dans le répertoire roms/machines. Basculer vers une machine disponible."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2064    "La carte vidéo ""%hs"" n'est pas disponible en raison de l'absence de ROMs dans le répertoire roms/video. Basculer vers une carte vidéo disponible."
     IDS_2065    "Machine"
@@ -432,7 +432,7 @@ BEGIN
     IDS_2079    "Appuyer sur F8+F12 ou le bouton central pour libérer la souris"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2080    "Impossible d'initialiser FluidSynth"
     IDS_2081    "Bus"
@@ -544,7 +544,7 @@ BEGIN
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_4096    "Disque dur (%s)"
     IDS_4097    "%01i:%01i"
@@ -643,7 +643,7 @@ BEGIN
 
     IDS_7168    "(Défaut du système)"
 END
-#define IDS_LANG_ENUS    IDS_7168
+#define IDS_LANG_ENUS IDS_7168
 
 // French (F.R.) resources
 /////////////////////////////////////////////////////////////////////////////

--- a/src/win/languages/hr-HR.rc
+++ b/src/win/languages/hr-HR.rc
@@ -13,122 +13,122 @@ LANGUAGE LANG_CROATIAN, SUBLANG_DEFAULT
 // Menu
 //
 
-MainMenu MENU DISCARDABLE 
+MainMenu MENU DISCARDABLE
 BEGIN
     POPUP "&Radnje"
     BEGIN
-        MENUITEM "&Tipkovnica zahtijeva hvatanje miša",    IDM_ACTION_KBD_REQ_CAPTURE
-        MENUITEM "&Desni CTRL je lijevi ALT",    IDM_ACTION_RCTRL_IS_LALT
+        MENUITEM "&Tipkovnica zahtijeva hvatanje miša", IDM_ACTION_KBD_REQ_CAPTURE
+        MENUITEM "&Desni CTRL je lijevi ALT", IDM_ACTION_RCTRL_IS_LALT
         MENUITEM SEPARATOR
-        MENUITEM "&Ponovno pokretanje...",                 IDM_ACTION_HRESET
-        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12",     IDM_ACTION_RESET_CAD
+        MENUITEM "&Ponovno pokretanje...", IDM_ACTION_HRESET
+        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12", IDM_ACTION_RESET_CAD
         MENUITEM SEPARATOR
-    MENUITEM "Ctrl+Alt+&Esc",        IDM_ACTION_CTRL_ALT_ESC
+    MENUITEM "Ctrl+Alt+&Esc", IDM_ACTION_CTRL_ALT_ESC
         MENUITEM SEPARATOR
-        MENUITEM "&Pauza",                      IDM_ACTION_PAUSE
+        MENUITEM "&Pauza", IDM_ACTION_PAUSE
         MENUITEM SEPARATOR
-        MENUITEM "Iz&laz...",                       IDM_ACTION_EXIT
+        MENUITEM "Iz&laz...", IDM_ACTION_EXIT
     END
     POPUP "&Pogled"
     BEGIN
-        MENUITEM "&Sakrij statusni redak",        IDM_VID_HIDE_STATUS_BAR
-        MENUITEM "&Sakrij alatni redak",        IDM_VID_HIDE_TOOLBAR
+        MENUITEM "&Sakrij statusni redak", IDM_VID_HIDE_STATUS_BAR
+        MENUITEM "&Sakrij alatni redak", IDM_VID_HIDE_TOOLBAR
         MENUITEM SEPARATOR
-        MENUITEM "&Show non-primary monitors",  IDM_VID_MONITORS
-        MENUITEM "&Prozor s promjenjivim veličinama",          IDM_VID_RESIZE
-        MENUITEM "&Zapamtite veličinu i položaj",  IDM_VID_REMEMBER
+        MENUITEM "&Show non-primary monitors", IDM_VID_MONITORS
+        MENUITEM "&Prozor s promjenjivim veličinama", IDM_VID_RESIZE
+        MENUITEM "&Zapamtite veličinu i položaj", IDM_VID_REMEMBER
         MENUITEM SEPARATOR
         POPUP "&Renderer"
         BEGIN
-            MENUITEM "&SDL (Softver)",         IDM_VID_SDL_SW
-            MENUITEM "SDL (&Hardver)",         IDM_VID_SDL_HW
-            MENUITEM "SDL (&OpenGL)",           IDM_VID_SDL_OPENGL
-            MENUITEM "Open&GL (3.0 jezgra)",      IDM_VID_OPENGL_CORE
+            MENUITEM "&SDL (Softver)", IDM_VID_SDL_SW
+            MENUITEM "SDL (&Hardver)", IDM_VID_SDL_HW
+            MENUITEM "SDL (&OpenGL)", IDM_VID_SDL_OPENGL
+            MENUITEM "Open&GL (3.0 jezgra)", IDM_VID_OPENGL_CORE
 #ifdef USE_VNC
-            MENUITEM "&VNC",                    IDM_VID_VNC
+            MENUITEM "&VNC", IDM_VID_VNC
 #endif
         END
         MENUITEM SEPARATOR
-        MENUITEM "Odrediti veličinu...",          IDM_VID_SPECIFY_DIM
-        MENUITEM "&4:3 omjer prikaza",    IDM_VID_FORCE43
+        MENUITEM "Odrediti veličinu...", IDM_VID_SPECIFY_DIM
+        MENUITEM "&4:3 omjer prikaza", IDM_VID_FORCE43
         POPUP "&Faktor skaliranja prozora"
         BEGIN
-            MENUITEM "&0,5x",                   IDM_VID_SCALE_1X
-            MENUITEM "&1x",                     IDM_VID_SCALE_2X
-            MENUITEM "1,&5x",                   IDM_VID_SCALE_3X
-            MENUITEM "&2x",                     IDM_VID_SCALE_4X
-            MENUITEM "&3x",                     IDM_VID_SCALE_5X
-            MENUITEM "&4x",                     IDM_VID_SCALE_6X
-            MENUITEM "&5x",                     IDM_VID_SCALE_7X
-            MENUITEM "&6x",                     IDM_VID_SCALE_8X
-            MENUITEM "&7x",                     IDM_VID_SCALE_9X
-            MENUITEM "&8x",                     IDM_VID_SCALE_10X
+            MENUITEM "&0,5x", IDM_VID_SCALE_1X
+            MENUITEM "&1x", IDM_VID_SCALE_2X
+            MENUITEM "1,&5x", IDM_VID_SCALE_3X
+            MENUITEM "&2x", IDM_VID_SCALE_4X
+            MENUITEM "&3x", IDM_VID_SCALE_5X
+            MENUITEM "&4x", IDM_VID_SCALE_6X
+            MENUITEM "&5x", IDM_VID_SCALE_7X
+            MENUITEM "&6x", IDM_VID_SCALE_8X
+            MENUITEM "&7x", IDM_VID_SCALE_9X
+            MENUITEM "&8x", IDM_VID_SCALE_10X
         END
         POPUP "Metoda filtriranja"
         BEGIN
-            MENUITEM "&Najbliža",                 IDM_VID_FILTER_NEAREST
-            MENUITEM "&Linearna",                  IDM_VID_FILTER_LINEAR
+            MENUITEM "&Najbliža", IDM_VID_FILTER_NEAREST
+            MENUITEM "&Linearna", IDM_VID_FILTER_LINEAR
         END
-        MENUITEM "&HiDPI skaliranje",              IDM_VID_HIDPI
+        MENUITEM "&HiDPI skaliranje", IDM_VID_HIDPI
         MENUITEM SEPARATOR
-        MENUITEM "&Cijelozaslonski način\tCtrl+Alt+PgUp",    IDM_VID_FULLSCREEN
+        MENUITEM "&Cijelozaslonski način\tCtrl+Alt+PgUp", IDM_VID_FULLSCREEN
         POPUP "&Način cijelozaslonskog rastezanja"
         BEGIN
-            MENUITEM "&Razvuci na cijeli zaslona",        IDM_VID_FS_FULL
-            MENUITEM "&4:3",                        IDM_VID_FS_43
+            MENUITEM "&Razvuci na cijeli zaslona", IDM_VID_FS_FULL
+            MENUITEM "&4:3", IDM_VID_FS_43
             MENUITEM "&Kvadratni pikseli (zadrži omjer)", IDM_VID_FS_KEEPRATIO
-            MENUITEM "&Cijelobrojno skaliranje",              IDM_VID_FS_INT
+            MENUITEM "&Cijelobrojno skaliranje", IDM_VID_FS_INT
         END
         POPUP "E&GA/(S)VGA postavke"
         BEGIN
-            MENUITEM "&Obrni boje zaslona VGA",   IDM_VID_INVERT
+            MENUITEM "&Obrni boje zaslona VGA", IDM_VID_INVERT
             POPUP "&Tip zaslona VGA"
             BEGIN
-                MENUITEM "RGB u &boji",          IDM_VID_GRAY_RGB
-                MENUITEM "&RGB u nijansama sive boje",      IDM_VID_GRAY_MONO
-                MENUITEM "&Jantarni zaslon",      IDM_VID_GRAY_AMBER
-                MENUITEM "&Zeleni zaslon",      IDM_VID_GRAY_GREEN
-                MENUITEM "&Bijeli zaslon",      IDM_VID_GRAY_WHITE
+                MENUITEM "RGB u &boji", IDM_VID_GRAY_RGB
+                MENUITEM "&RGB u nijansama sive boje", IDM_VID_GRAY_MONO
+                MENUITEM "&Jantarni zaslon", IDM_VID_GRAY_AMBER
+                MENUITEM "&Zeleni zaslon", IDM_VID_GRAY_GREEN
+                MENUITEM "&Bijeli zaslon", IDM_VID_GRAY_WHITE
             END
             POPUP "&Vrsta konverzije nijansa sive boje"
             BEGIN
-                MENUITEM "BT&601 (NTSC/PAL)",   IDM_VID_GRAYCT_601
-                MENUITEM "BT&709 (HDTV)",       IDM_VID_GRAYCT_709
-                MENUITEM "&Prosjek",            IDM_VID_GRAYCT_AVE
+                MENUITEM "BT&601 (NTSC/PAL)", IDM_VID_GRAYCT_601
+                MENUITEM "BT&709 (HDTV)", IDM_VID_GRAYCT_709
+                MENUITEM "&Prosjek", IDM_VID_GRAYCT_AVE
             END
         END
         MENUITEM SEPARATOR
-        MENUITEM "&Višak slike CGA/PCjr/Tandy/EGA/(S)VGA",     IDM_VID_OVERSCAN
+        MENUITEM "&Višak slike CGA/PCjr/Tandy/EGA/(S)VGA", IDM_VID_OVERSCAN
         MENUITEM "&Promjeni kontrast za crno-bijeli zaslon", IDM_VID_CGACON
     END
-    MENUITEM "&Mediji",                IDM_MEDIA
+    MENUITEM "&Mediji", IDM_MEDIA
     POPUP "&Alati"
     BEGIN
-        MENUITEM "&Opcije...",                IDM_CONFIG
-        MENUITEM "&Ažuriraj ikone statusnog redka",    IDM_UPDATE_ICONS
+        MENUITEM "&Opcije...", IDM_CONFIG
+        MENUITEM "&Ažuriraj ikone statusnog redka", IDM_UPDATE_ICONS
         MENUITEM SEPARATOR
-        MENUITEM "Napravi &snimku zaslona\tCtrl+F11",  IDM_ACTION_SCREENSHOT
+        MENUITEM "Napravi &snimku zaslona\tCtrl+F11", IDM_ACTION_SCREENSHOT
         MENUITEM SEPARATOR
-        MENUITEM "&Postavke...",    IDM_PREFERENCES
+        MENUITEM "&Postavke...", IDM_PREFERENCES
 #ifdef DISCORD
         MENUITEM "Omogući integraciju sa programom &Discord", IDM_DISCORD
 #endif
         MENUITEM SEPARATOR
-        MENUITEM "&Pojačanje zvuka...",              IDM_SND_GAIN
+        MENUITEM "&Pojačanje zvuka...", IDM_SND_GAIN
 #ifdef MTR_ENABLED
         MENUITEM SEPARATOR
-        MENUITEM "Z&apočni praćenje\tCtrl+T",         IDM_ACTION_BEGIN_TRACE
-        MENUITEM "&Svrši praćenje\tCtrl+T",           IDM_ACTION_END_TRACE
+        MENUITEM "Z&apočni praćenje\tCtrl+T", IDM_ACTION_BEGIN_TRACE
+        MENUITEM "&Svrši praćenje\tCtrl+T", IDM_ACTION_END_TRACE
 #endif
     END
     POPUP "&Pomoć"
     BEGIN
-        MENUITEM "&Dokumentacija...",           IDM_DOCS
-        MENUITEM "&O programu 86Box...",             IDM_ABOUT
+        MENUITEM "&Dokumentacija...", IDM_DOCS
+        MENUITEM "&O programu 86Box...", IDM_ABOUT
     END
 END
 
-StatusBarMenu MENU DISCARDABLE 
+StatusBarMenu MENU DISCARDABLE
 BEGIN
     MENUITEM SEPARATOR
 END
@@ -137,17 +137,17 @@ CassetteSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nova slika...",                IDM_CASSETTE_IMAGE_NEW
+        MENUITEM "&Nova slika...", IDM_CASSETTE_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Postojeća slika...",                IDM_CASSETTE_IMAGE_EXISTING
-        MENUITEM "Postojeća slika (&zaštićena od pisanja)...",    IDM_CASSETTE_IMAGE_EXISTING_WP
+        MENUITEM "&Postojeća slika...", IDM_CASSETTE_IMAGE_EXISTING
+        MENUITEM "Postojeća slika (&zaštićena od pisanja)...", IDM_CASSETTE_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Snimi",                    IDM_CASSETTE_RECORD
-        MENUITEM "&Pokreni",                    IDM_CASSETTE_PLAY
-        MENUITEM "P&remotaj na početak",            IDM_CASSETTE_REWIND
-        MENUITEM "&Preskoči do kraja",            IDM_CASSETTE_FAST_FORWARD
+        MENUITEM "&Snimi", IDM_CASSETTE_RECORD
+        MENUITEM "&Pokreni", IDM_CASSETTE_PLAY
+        MENUITEM "P&remotaj na početak", IDM_CASSETTE_REWIND
+        MENUITEM "&Preskoči do kraja", IDM_CASSETTE_FAST_FORWARD
         MENUITEM SEPARATOR
-        MENUITEM "&Izbaci",                    IDM_CASSETTE_EJECT
+        MENUITEM "&Izbaci", IDM_CASSETTE_EJECT
     END
 END
 
@@ -155,9 +155,9 @@ CartridgeSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Slika...",                    IDM_CARTRIDGE_IMAGE
+        MENUITEM "&Slika...", IDM_CARTRIDGE_IMAGE
         MENUITEM SEPARATOR
-        MENUITEM "&Izbaci",                    IDM_CARTRIDGE_EJECT
+        MENUITEM "&Izbaci", IDM_CARTRIDGE_EJECT
     END
 END
 
@@ -165,14 +165,14 @@ FloppySubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nova slika...",                IDM_FLOPPY_IMAGE_NEW
+        MENUITEM "&Nova slika...", IDM_FLOPPY_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Postojeća slika...",                IDM_FLOPPY_IMAGE_EXISTING
-        MENUITEM "Postojeća slika (&zaštićena od pisanja)...",    IDM_FLOPPY_IMAGE_EXISTING_WP
+        MENUITEM "&Postojeća slika...", IDM_FLOPPY_IMAGE_EXISTING
+        MENUITEM "Postojeća slika (&zaštićena od pisanja)...", IDM_FLOPPY_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Izvozi u 86F...",                IDM_FLOPPY_EXPORT_TO_86F
+        MENUITEM "&Izvozi u 86F...", IDM_FLOPPY_EXPORT_TO_86F
         MENUITEM SEPARATOR
-        MENUITEM "&Izbaci",                    IDM_FLOPPY_EJECT
+        MENUITEM "&Izbaci", IDM_FLOPPY_EJECT
     END
 END
 
@@ -180,13 +180,13 @@ CdromSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Isključi zvuk",                    IDM_CDROM_MUTE
+        MENUITEM "&Isključi zvuk", IDM_CDROM_MUTE
         MENUITEM SEPARATOR
-        MENUITEM "&Prazno",                    IDM_CDROM_EMPTY
-        MENUITEM "&Ponovo učitaj prethodnu sliku",            IDM_CDROM_RELOAD
+        MENUITEM "&Prazno", IDM_CDROM_EMPTY
+        MENUITEM "&Ponovo učitaj prethodnu sliku", IDM_CDROM_RELOAD
         MENUITEM SEPARATOR
-        MENUITEM "&Slika...",                    IDM_CDROM_IMAGE
-        MENUITEM "&Mapa...",                    IDM_CDROM_DIR
+        MENUITEM "&Slika...", IDM_CDROM_IMAGE
+        MENUITEM "&Mapa...", IDM_CDROM_DIR
     END
 END
 
@@ -194,13 +194,13 @@ ZIPSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nova slika...",                IDM_ZIP_IMAGE_NEW
+        MENUITEM "&Nova slika...", IDM_ZIP_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Postojeća slika...",                IDM_ZIP_IMAGE_EXISTING
-        MENUITEM "Postojeća slika (&zaštićena od pisanja)...",    IDM_ZIP_IMAGE_EXISTING_WP
+        MENUITEM "&Postojeća slika...", IDM_ZIP_IMAGE_EXISTING
+        MENUITEM "Postojeća slika (&zaštićena od pisanja)...", IDM_ZIP_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Izbaci",                    IDM_ZIP_EJECT
-        MENUITEM "&Ponovo učitaj prethodnu sliku",            IDM_ZIP_RELOAD
+        MENUITEM "&Izbaci", IDM_ZIP_EJECT
+        MENUITEM "&Ponovo učitaj prethodnu sliku", IDM_ZIP_RELOAD
     END
 END
 
@@ -208,13 +208,13 @@ MOSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nova slika...",                IDM_MO_IMAGE_NEW
+        MENUITEM "&Nova slika...", IDM_MO_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Postojeća slika...",                IDM_MO_IMAGE_EXISTING
-        MENUITEM "Postojeća slika (&zaštićena od pisanja)...",    IDM_MO_IMAGE_EXISTING_WP
+        MENUITEM "&Postojeća slika...", IDM_MO_IMAGE_EXISTING
+        MENUITEM "Postojeća slika (&zaštićena od pisanja)...", IDM_MO_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Izbaci",                    IDM_MO_EJECT
-        MENUITEM "&Ponovo učitaj prethodnu sliku",            IDM_MO_RELOAD
+        MENUITEM "&Izbaci", IDM_MO_EJECT
+        MENUITEM "&Ponovo učitaj prethodnu sliku", IDM_MO_RELOAD
     END
 END
 
@@ -240,150 +240,150 @@ END
 // Dialog
 //
 
-#define STR_PREFERENCES        "Postavke"
-#define STR_SND_GAIN        "Pojačavanje zvuka"
-#define STR_NEW_FLOPPY        "Nova slika"
+#define STR_PREFERENCES   "Postavke"
+#define STR_SND_GAIN      "Pojačavanje zvuka"
+#define STR_NEW_FLOPPY    "Nova slika"
 #define STR_CONFIG        "Opcije"
-#define STR_SPECIFY_DIM        "Odredite glavne dimenzije prozora"
+#define STR_SPECIFY_DIM   "Odredite glavne dimenzije prozora"
 
 #define STR_OK            "U redu"
 #define STR_CANCEL        "Otkaži"
 #define STR_GLOBAL        "Spremite ove postavke kao &globalne zadane postavke"
-#define STR_DEFAULT        "Zadano"
-#define STR_LANGUAGE        "Jezik:"
-#define STR_ICONSET        "Paket ikona:"
+#define STR_DEFAULT       "Zadano"
+#define STR_LANGUAGE      "Jezik:"
+#define STR_ICONSET       "Paket ikona:"
 
-#define STR_GAIN        "Pojačavanje"
+#define STR_GAIN          "Pojačavanje"
 
-#define STR_FILE_NAME        "Ime datoteke:"
-#define STR_DISK_SIZE        "Veličina diska:"
-#define STR_RPM_MODE        "Način broja okretaja:"
-#define STR_PROGRESS        "Napredak:"
+#define STR_FILE_NAME     "Ime datoteke:"
+#define STR_DISK_SIZE     "Veličina diska:"
+#define STR_RPM_MODE      "Način broja okretaja:"
+#define STR_PROGRESS      "Napredak:"
 
-#define STR_WIDTH        "Širina:"
+#define STR_WIDTH         "Širina:"
 #define STR_HEIGHT        "Visina:"
-#define STR_LOCK_TO_SIZE    "Zaključajte na ovu veličinu"
+#define STR_LOCK_TO_SIZE  "Zaključajte na ovu veličinu"
 
-#define STR_MACHINE_TYPE    "Tip sistema:"
-#define STR_MACHINE        "Sistem:"
-#define STR_CONFIGURE        "Namjesti"
-#define STR_CPU_TYPE        "Tip procesora:"
-#define STR_CPU_SPEED        "Brzina:"
-#define STR_FPU            "FPU uređaj:"
-#define STR_WAIT_STATES        "Stanja čekanja:"
+#define STR_MACHINE_TYPE  "Tip sistema:"
+#define STR_MACHINE       "Sistem:"
+#define STR_CONFIGURE     "Namjesti"
+#define STR_CPU_TYPE      "Tip procesora:"
+#define STR_CPU_SPEED     "Brzina:"
+#define STR_FPU           "FPU uređaj:"
+#define STR_WAIT_STATES   "Stanja čekanja:"
 #define STR_MB            "MB"
 #define STR_MEMORY        "Memorija:"
-#define STR_TIME_SYNC        "Sinkronizacija vremena"
-#define STR_DISABLED        "Isključeno"
-#define STR_ENABLED_LOCAL    "Uključeno (lokalno vrijeme)"
-#define STR_ENABLED_UTC        "Uključeno (UTC)"
-#define STR_DYNAREC        "Dinamički rekompilator"
+#define STR_TIME_SYNC     "Sinkronizacija vremena"
+#define STR_DISABLED      "Isključeno"
+#define STR_ENABLED_LOCAL "Uključeno (lokalno vrijeme)"
+#define STR_ENABLED_UTC   "Uključeno (UTC)"
+#define STR_DYNAREC       "Dinamički rekompilator"
 
-#define STR_VIDEO        "Video:"
-#define STR_VIDEO_2        "Video 2:"
+#define STR_VIDEO         "Video:"
+#define STR_VIDEO_2       "Video 2:"
 #define STR_VOODOO        "Voodoo grafika"
-#define STR_IBM8514        "IBM 8514/a grafika"
-#define STR_XGA            "XGA grafika"
+#define STR_IBM8514       "IBM 8514/a grafika"
+#define STR_XGA           "XGA grafika"
 
-#define STR_MOUSE        "Miš:"
-#define STR_JOYSTICK        "Palica za igru:"
-#define STR_JOY1        "Palica za igru 1..."
-#define STR_JOY2        "Palica za igru 2..."
-#define STR_JOY3        "Palica za igru 3..."
-#define STR_JOY4        "Palica za igru 4..."
+#define STR_MOUSE         "Miš:"
+#define STR_JOYSTICK      "Palica za igru:"
+#define STR_JOY1          "Palica za igru 1..."
+#define STR_JOY2          "Palica za igru 2..."
+#define STR_JOY3          "Palica za igru 3..."
+#define STR_JOY4          "Palica za igru 4..."
 
 #define STR_SOUND1        "Zvučna kartica 1:"
 #define STR_SOUND2        "Zvučna kartica 2:"
 #define STR_SOUND3        "Zvučna kartica 3:"
 #define STR_SOUND4        "Zvučna kartica 4:"
-#define STR_MIDI_OUT        "Izlazni uređaj MIDI:"
-#define STR_MIDI_IN        "Ulazni uređaj MIDI:"
+#define STR_MIDI_OUT      "Izlazni uređaj MIDI:"
+#define STR_MIDI_IN       "Ulazni uređaj MIDI:"
 #define STR_MPU401        "Samostalni MPU-401"
-#define STR_FLOAT        "Koristi FLOAT32 za zvuk"
-#define STR_FM_DRIVER        "Drajver za FM sintisajzer"
-#define STR_FM_DRV_NUKED    "Nuked (precizniji)"
-#define STR_FM_DRV_YMFM        "YMFM (brži)"
+#define STR_FLOAT         "Koristi FLOAT32 za zvuk"
+#define STR_FM_DRIVER     "Drajver za FM sintisajzer"
+#define STR_FM_DRV_NUKED  "Nuked (precizniji)"
+#define STR_FM_DRV_YMFM   "YMFM (brži)"
 
-#define STR_NET_TYPE    "Tip mreže:"
-#define STR_PCAP        "Uređaj PCap:"
-#define STR_NET            "Mrežna kartica:"
-#define STR_NET1        "Network card 1:"
-#define STR_NET2        "Network card 2:"
-#define STR_NET3        "Network card 3:"
-#define STR_NET4        "Network card 4:"
+#define STR_NET_TYPE      "Tip mreže:"
+#define STR_PCAP          "Uređaj PCap:"
+#define STR_NET           "Mrežna kartica:"
+#define STR_NET1          "Network card 1:"
+#define STR_NET2          "Network card 2:"
+#define STR_NET3          "Network card 3:"
+#define STR_NET4          "Network card 4:"
 
-#define STR_COM1        "Uređaj COM1:"
-#define STR_COM2        "Uređaj COM2:"
-#define STR_COM3        "Uređaj COM3:"
-#define STR_COM4        "Uređaj COM4:"
-#define STR_LPT1        "Uređaj LPT1:"
-#define STR_LPT2        "Uređaj LPT2:"
-#define STR_LPT3        "Uređaj LPT3:"
-#define STR_LPT4        "Uređaj LPT4:"
-#define STR_SERIAL1        "Serijska vrata 1"
-#define STR_SERIAL2        "Serijska vrata 2"
-#define STR_SERIAL3        "Serijska vrata 3"
-#define STR_SERIAL4        "Serijska vrata 4"
-#define STR_PARALLEL1        "Paralelna vrata 1"
-#define STR_PARALLEL2        "Paralelna vrata 2"
-#define STR_PARALLEL3        "Paralelna vrata 3"
-#define STR_PARALLEL4        "Paralelna vrata 4"
-#define STR_SERIAL_PASS1    "Serial port passthrough 1"
-#define STR_SERIAL_PASS2    "Serial port passthrough 2"
-#define STR_SERIAL_PASS3    "Serial port passthrough 3"
-#define STR_SERIAL_PASS4    "Serial port passthrough 4"
+#define STR_COM1          "Uređaj COM1:"
+#define STR_COM2          "Uređaj COM2:"
+#define STR_COM3          "Uređaj COM3:"
+#define STR_COM4          "Uređaj COM4:"
+#define STR_LPT1          "Uređaj LPT1:"
+#define STR_LPT2          "Uređaj LPT2:"
+#define STR_LPT3          "Uređaj LPT3:"
+#define STR_LPT4          "Uređaj LPT4:"
+#define STR_SERIAL1       "Serijska vrata 1"
+#define STR_SERIAL2       "Serijska vrata 2"
+#define STR_SERIAL3       "Serijska vrata 3"
+#define STR_SERIAL4       "Serijska vrata 4"
+#define STR_PARALLEL1     "Paralelna vrata 1"
+#define STR_PARALLEL2     "Paralelna vrata 2"
+#define STR_PARALLEL3     "Paralelna vrata 3"
+#define STR_PARALLEL4     "Paralelna vrata 4"
+#define STR_SERIAL_PASS1  "Serial port passthrough 1"
+#define STR_SERIAL_PASS2  "Serial port passthrough 2"
+#define STR_SERIAL_PASS3  "Serial port passthrough 3"
+#define STR_SERIAL_PASS4  "Serial port passthrough 4"
 
-#define STR_HDC            "Kontroler tvrdog diska:"
-#define STR_FDC            "Kontroler diskete:"
-#define STR_IDE_TER        "Tercijarni IDE kontroler"
-#define STR_IDE_QUA        "Kvaternarni IDE kontroler"
-#define STR_SCSI        "SCSI"
+#define STR_HDC           "Kontroler tvrdog diska:"
+#define STR_FDC           "Kontroler diskete:"
+#define STR_IDE_TER       "Tercijarni IDE kontroler"
+#define STR_IDE_QUA       "Kvaternarni IDE kontroler"
+#define STR_SCSI          "SCSI"
 #define STR_SCSI_1        "Kontroler 1:"
 #define STR_SCSI_2        "Kontroler 2:"
 #define STR_SCSI_3        "Kontroler 3:"
 #define STR_SCSI_4        "Kontroler 4:"
-#define STR_CASSETTE        "Audio kaseta"
+#define STR_CASSETTE      "Audio kaseta"
 
-#define STR_HDD            "Tvrdi diskovi:"
-#define STR_NEW            "&Novi..."
-#define STR_EXISTING        "&Postojeći..."
+#define STR_HDD           "Tvrdi diskovi:"
+#define STR_NEW           "&Novi..."
+#define STR_EXISTING      "&Postojeći..."
 #define STR_REMOVE        "&Ukloni"
-#define STR_BUS            "Sabirnica:"
-#define STR_CHANNEL        "Kanal:"
+#define STR_BUS           "Sabirnica:"
+#define STR_CHANNEL       "Kanal:"
 #define STR_ID            "ID:"
-#define STR_SPEED        "Speed:"
+#define STR_SPEED         "Speed:"
 
-#define STR_SPECIFY        "&Odredi..."
-#define STR_SECTORS        "Sektori:"
-#define STR_HEADS        "Glave:"
-#define STR_CYLS        "Cilindri:"
-#define STR_SIZE_MB        "Veličina (MB):"
-#define STR_TYPE        "Tip:"
-#define STR_IMG_FORMAT        "Format slike:"
-#define STR_BLOCK_SIZE        "Veličina slike:"
+#define STR_SPECIFY       "&Odredi..."
+#define STR_SECTORS       "Sektori:"
+#define STR_HEADS         "Glave:"
+#define STR_CYLS          "Cilindri:"
+#define STR_SIZE_MB       "Veličina (MB):"
+#define STR_TYPE          "Tip:"
+#define STR_IMG_FORMAT    "Format slike:"
+#define STR_BLOCK_SIZE    "Veličina slike:"
 
-#define STR_FLOPPY_DRIVES    "Disketni pogoni:"
-#define STR_TURBO        "Turbo vrijemena"
-#define STR_CHECKBPB        "Provjeraj BPB"
-#define STR_CDROM_DRIVES    "CD-ROM pogoni:"
-#define STR_CD_SPEED        "Brzina:"
-#define STR_EARLY        "Raniji pogon"
+#define STR_FLOPPY_DRIVES "Disketni pogoni:"
+#define STR_TURBO         "Turbo vrijemena"
+#define STR_CHECKBPB      "Provjeraj BPB"
+#define STR_CDROM_DRIVES  "CD-ROM pogoni:"
+#define STR_CD_SPEED      "Brzina:"
+#define STR_EARLY         "Raniji pogon"
 
-#define STR_MO_DRIVES        "MO pogoni:"
-#define STR_ZIP_DRIVES        "ZIP pogoni:"
-#define STR_250            "ZIP 250"
+#define STR_MO_DRIVES     "MO pogoni:"
+#define STR_ZIP_DRIVES    "ZIP pogoni:"
+#define STR_250           "ZIP 250"
 
 #define STR_ISARTC        "Sat stvarnog vremena (RTC):"
 #define STR_ISAMEM        "Proširenje memorije ISA"
-#define STR_ISAMEM_1        "Kartica 1:"
-#define STR_ISAMEM_2        "Kartica 2:"
-#define STR_ISAMEM_3        "Kartica 3:"
-#define STR_ISAMEM_4        "Kartica 4:"
+#define STR_ISAMEM_1      "Kartica 1:"
+#define STR_ISAMEM_2      "Kartica 2:"
+#define STR_ISAMEM_3      "Kartica 3:"
+#define STR_ISAMEM_4      "Kartica 4:"
 #define STR_BUGGER        "Uređaj ISABugger"
-#define STR_POSTCARD        "Kartica POST"
+#define STR_POSTCARD      "Kartica POST"
 
-#define FONT_SIZE        9
-#define FONT_NAME        "Segoe UI"
+#define FONT_SIZE         9
+#define FONT_NAME         "Segoe UI"
 
 #include "dialogs.rc"
 
@@ -392,9 +392,9 @@ END
 // String Table
 //
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
-    2048    "86Box"
+    2048        "86Box"
     IDS_2049    "Greška"
     IDS_2050    "Fatalna greška"
     IDS_2051    " - PAUSED"
@@ -412,7 +412,7 @@ BEGIN
     IDS_2063    "Sistem ""%hs"" nije dostupan jer ne postoje potrebni ROM-ovi u mapu roms/machines. Prebacivanje na dostupno računalo."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2064    "Video kartica ""%hs"" nije dostupna jer ne postoje potrebni ROM-ovi u mapu roms/video. Prebacivanje na dostupnu video karticu."
     IDS_2065    "Sistem"
@@ -432,7 +432,7 @@ BEGIN
     IDS_2079    "Pritisnite F8+F12 ili srednji gumb miša za otpuštanje miša"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2080    "Nije moguće inicijalizirati FluidSynth"
     IDS_2081    "Bus"
@@ -544,7 +544,7 @@ BEGIN
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_4096    "Tvrdi disk (%s)"
     IDS_4097    "%01i:%01i"
@@ -643,7 +643,7 @@ BEGIN
 
     IDS_7168    "(Zadana postavka operativnog sustava)"
 END
-#define IDS_LANG_ENUS    IDS_7168
+#define IDS_LANG_ENUS IDS_7168
 
 // Croatian (hr-HR) resources
 /////////////////////////////////////////////////////////////////////////////

--- a/src/win/languages/hu-HU.rc
+++ b/src/win/languages/hu-HU.rc
@@ -18,122 +18,122 @@ LANGUAGE LANG_HUNGARIAN, SUBLANG_DEFAULT
 // Menu
 //
 
-MainMenu MENU DISCARDABLE 
+MainMenu MENU DISCARDABLE
 BEGIN
     POPUP "&Művelet"
     BEGIN
-        MENUITEM "A &billentyűzet elfogást igényel",    IDM_ACTION_KBD_REQ_CAPTURE
-        MENUITEM "A &jobb oldali CTRL a bal ALT",    IDM_ACTION_RCTRL_IS_LALT
+        MENUITEM "A &billentyűzet elfogást igényel", IDM_ACTION_KBD_REQ_CAPTURE
+        MENUITEM "A &jobb oldali CTRL a bal ALT", IDM_ACTION_RCTRL_IS_LALT
         MENUITEM SEPARATOR
-        MENUITEM "Hardveres &újraindítás...",                 IDM_ACTION_HRESET
-        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12",     IDM_ACTION_RESET_CAD
+        MENUITEM "Hardveres &újraindítás...", IDM_ACTION_HRESET
+        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12", IDM_ACTION_RESET_CAD
         MENUITEM SEPARATOR
-    MENUITEM "Ctrl+Alt+&Esc",        IDM_ACTION_CTRL_ALT_ESC
+    MENUITEM "Ctrl+Alt+&Esc", IDM_ACTION_CTRL_ALT_ESC
         MENUITEM SEPARATOR
-        MENUITEM "&Szüneteltetés",                      IDM_ACTION_PAUSE
+        MENUITEM "&Szüneteltetés", IDM_ACTION_PAUSE
         MENUITEM SEPARATOR
-        MENUITEM "&Kilépés...",                       IDM_ACTION_EXIT
+        MENUITEM "&Kilépés...", IDM_ACTION_EXIT
     END
     POPUP "&Nézet"
     BEGIN
-        MENUITEM "Állapotsor &elrejtése",        IDM_VID_HIDE_STATUS_BAR
-        MENUITEM "Hide &toolbar",        IDM_VID_HIDE_TOOLBAR
+        MENUITEM "Állapotsor &elrejtése", IDM_VID_HIDE_STATUS_BAR
+        MENUITEM "Hide &toolbar", IDM_VID_HIDE_TOOLBAR
         MENUITEM SEPARATOR
-        MENUITEM "&Show non-primary monitors",  IDM_VID_MONITORS
-        MENUITEM "&Átméretezhető ablak",          IDM_VID_RESIZE
-        MENUITEM "Méret és pozíció &megjegyzése",  IDM_VID_REMEMBER
+        MENUITEM "&Show non-primary monitors", IDM_VID_MONITORS
+        MENUITEM "&Átméretezhető ablak", IDM_VID_RESIZE
+        MENUITEM "Méret és pozíció &megjegyzése", IDM_VID_REMEMBER
         MENUITEM SEPARATOR
         POPUP "&Megjelenítő"
         BEGIN
-            MENUITEM "&SDL (Szoftveres)",         IDM_VID_SDL_SW
-            MENUITEM "SDL (&Hardveres)",         IDM_VID_SDL_HW
-            MENUITEM "SDL (&OpenGL)",           IDM_VID_SDL_OPENGL
-            MENUITEM "Open&GL (3.0 Core)",      IDM_VID_OPENGL_CORE
+            MENUITEM "&SDL (Szoftveres)", IDM_VID_SDL_SW
+            MENUITEM "SDL (&Hardveres)", IDM_VID_SDL_HW
+            MENUITEM "SDL (&OpenGL)", IDM_VID_SDL_OPENGL
+            MENUITEM "Open&GL (3.0 Core)", IDM_VID_OPENGL_CORE
 #ifdef USE_VNC
-            MENUITEM "&VNC",                    IDM_VID_VNC
+            MENUITEM "&VNC", IDM_VID_VNC
 #endif
         END
         MENUITEM SEPARATOR
-        MENUITEM "Méretek kézi megadása...",          IDM_VID_SPECIFY_DIM
-        MENUITEM "&Rögzített 4:3 képarány",    IDM_VID_FORCE43
+        MENUITEM "Méretek kézi megadása...", IDM_VID_SPECIFY_DIM
+        MENUITEM "&Rögzített 4:3 képarány", IDM_VID_FORCE43
         POPUP "&Ablak méretezési tényező"
         BEGIN
-            MENUITEM "&0,5x",                   IDM_VID_SCALE_1X
-            MENUITEM "&1x",                     IDM_VID_SCALE_2X
-            MENUITEM "1,&5x",                   IDM_VID_SCALE_3X
-            MENUITEM "&2x",                     IDM_VID_SCALE_4X
-            MENUITEM "&3x",                     IDM_VID_SCALE_5X
-            MENUITEM "&4x",                     IDM_VID_SCALE_6X
-            MENUITEM "&5x",                     IDM_VID_SCALE_7X
-            MENUITEM "&6x",                     IDM_VID_SCALE_8X
-            MENUITEM "&7x",                     IDM_VID_SCALE_9X
-            MENUITEM "&8x",                     IDM_VID_SCALE_10X
+            MENUITEM "&0,5x", IDM_VID_SCALE_1X
+            MENUITEM "&1x", IDM_VID_SCALE_2X
+            MENUITEM "1,&5x", IDM_VID_SCALE_3X
+            MENUITEM "&2x", IDM_VID_SCALE_4X
+            MENUITEM "&3x", IDM_VID_SCALE_5X
+            MENUITEM "&4x", IDM_VID_SCALE_6X
+            MENUITEM "&5x", IDM_VID_SCALE_7X
+            MENUITEM "&6x", IDM_VID_SCALE_8X
+            MENUITEM "&7x", IDM_VID_SCALE_9X
+            MENUITEM "&8x", IDM_VID_SCALE_10X
         END
         POPUP "Szűrési mód"
         BEGIN
-            MENUITEM "&Szomszédos",                 IDM_VID_FILTER_NEAREST
-            MENUITEM "&Lineáris",                  IDM_VID_FILTER_LINEAR
+            MENUITEM "&Szomszédos", IDM_VID_FILTER_NEAREST
+            MENUITEM "&Lineáris", IDM_VID_FILTER_LINEAR
         END
-        MENUITEM "Hi&DPI méretezés",              IDM_VID_HIDPI
+        MENUITEM "Hi&DPI méretezés", IDM_VID_HIDPI
         MENUITEM SEPARATOR
-        MENUITEM "&Teljes képernyő\tCtrl+Alt+PgUp",    IDM_VID_FULLSCREEN
+        MENUITEM "&Teljes képernyő\tCtrl+Alt+PgUp", IDM_VID_FULLSCREEN
         POPUP "Teljes képernyős &méretezés"
         BEGIN
-            MENUITEM "&Nyújtás a teljes képernyőre",        IDM_VID_FS_FULL
-            MENUITEM "&4:3",                        IDM_VID_FS_43
+            MENUITEM "&Nyújtás a teljes képernyőre", IDM_VID_FS_FULL
+            MENUITEM "&4:3", IDM_VID_FS_43
             MENUITEM "&Négyzetes képpontok (aránytartás)", IDM_VID_FS_KEEPRATIO
-            MENUITEM "&Egész tényezős nagyítás",              IDM_VID_FS_INT
+            MENUITEM "&Egész tényezős nagyítás", IDM_VID_FS_INT
         END
         POPUP "E&GA/(S)VGA beállítások"
         BEGIN
-            MENUITEM "&Invertált VGA kijelző",   IDM_VID_INVERT
+            MENUITEM "&Invertált VGA kijelző", IDM_VID_INVERT
             POPUP "VGA képernyő &típusa"
             BEGIN
-                MENUITEM "RGB &színes",          IDM_VID_GRAY_RGB
-                MENUITEM "&RGB szürkeárnyalatos",      IDM_VID_GRAY_MONO
-                MENUITEM "&Gyömbér kijelző",      IDM_VID_GRAY_AMBER
-                MENUITEM "&Zöld kijelző",      IDM_VID_GRAY_GREEN
-                MENUITEM "&Fehér kijelző",      IDM_VID_GRAY_WHITE
+                MENUITEM "RGB &színes", IDM_VID_GRAY_RGB
+                MENUITEM "&RGB szürkeárnyalatos", IDM_VID_GRAY_MONO
+                MENUITEM "&Gyömbér kijelző", IDM_VID_GRAY_AMBER
+                MENUITEM "&Zöld kijelző", IDM_VID_GRAY_GREEN
+                MENUITEM "&Fehér kijelző", IDM_VID_GRAY_WHITE
             END
             POPUP "Szürkéskála &konzerziós eljárás"
             BEGIN
-                MENUITEM "BT&601 (NTSC/PAL)",   IDM_VID_GRAYCT_601
-                MENUITEM "BT&709 (HDTV)",       IDM_VID_GRAYCT_709
-                MENUITEM "&Átlag szerint",            IDM_VID_GRAYCT_AVE
+                MENUITEM "BT&601 (NTSC/PAL)", IDM_VID_GRAYCT_601
+                MENUITEM "BT&709 (HDTV)", IDM_VID_GRAYCT_709
+                MENUITEM "&Átlag szerint", IDM_VID_GRAYCT_AVE
             END
         END
         MENUITEM SEPARATOR
-        MENUITEM "CGA/PCjr/Tandy/E&GA/(S)VGA túlpásztázás",     IDM_VID_OVERSCAN
+        MENUITEM "CGA/PCjr/Tandy/E&GA/(S)VGA túlpásztázás", IDM_VID_OVERSCAN
         MENUITEM "Kontraszt illesztése &monokróm kijelzőhöz", IDM_VID_CGACON
     END
-    MENUITEM "&Média",                IDM_MEDIA
+    MENUITEM "&Média", IDM_MEDIA
     POPUP "&Eszközök"
     BEGIN
-        MENUITEM "&Konfigurálás...",                IDM_CONFIG
-        MENUITEM "Állapotsori ikonok &frissítése",    IDM_UPDATE_ICONS
+        MENUITEM "&Konfigurálás...", IDM_CONFIG
+        MENUITEM "Állapotsori ikonok &frissítése", IDM_UPDATE_ICONS
         MENUITEM SEPARATOR
-        MENUITEM "&Képernyőkép készítése\tCtrl+F11",  IDM_ACTION_SCREENSHOT
+        MENUITEM "&Képernyőkép készítése\tCtrl+F11", IDM_ACTION_SCREENSHOT
         MENUITEM SEPARATOR
-        MENUITEM "&Beállítások...",    IDM_PREFERENCES
+        MENUITEM "&Beállítások...", IDM_PREFERENCES
 #ifdef DISCORD
         MENUITEM "&Discord integráció engedélyezése", IDM_DISCORD
 #endif
         MENUITEM SEPARATOR
-        MENUITEM "&Hangerőszabályzó...",              IDM_SND_GAIN
+        MENUITEM "&Hangerőszabályzó...", IDM_SND_GAIN
 #ifdef MTR_ENABLED
         MENUITEM SEPARATOR
-        MENUITEM "Nyomkövetés megkezdése\tCtrl+T",         IDM_ACTION_BEGIN_TRACE
-        MENUITEM "Nyomkövetés befejezése\tCtrl+T",           IDM_ACTION_END_TRACE
+        MENUITEM "Nyomkövetés megkezdése\tCtrl+T", IDM_ACTION_BEGIN_TRACE
+        MENUITEM "Nyomkövetés befejezése\tCtrl+T", IDM_ACTION_END_TRACE
 #endif
     END
     POPUP "&Súgó"
     BEGIN
-        MENUITEM "&Dokumentáció...",           IDM_DOCS
-        MENUITEM "A 86Box &névjegye...",             IDM_ABOUT
+        MENUITEM "&Dokumentáció...", IDM_DOCS
+        MENUITEM "A 86Box &névjegye...", IDM_ABOUT
     END
 END
 
-StatusBarMenu MENU DISCARDABLE 
+StatusBarMenu MENU DISCARDABLE
 BEGIN
     MENUITEM SEPARATOR
 END
@@ -142,17 +142,17 @@ CassetteSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Új képfájl létrehozása...",                IDM_CASSETTE_IMAGE_NEW
+        MENUITEM "&Új képfájl létrehozása...", IDM_CASSETTE_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "Meglévő képfájl &megnyitása...",                IDM_CASSETTE_IMAGE_EXISTING
-        MENUITEM "Meglévő képfájl megnyitása (&írásvédett)...",    IDM_CASSETTE_IMAGE_EXISTING_WP
+        MENUITEM "Meglévő képfájl &megnyitása...", IDM_CASSETTE_IMAGE_EXISTING
+        MENUITEM "Meglévő képfájl megnyitása (&írásvédett)...", IDM_CASSETTE_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Felvétel",                    IDM_CASSETTE_RECORD
-        MENUITEM "&Lejátszás",                    IDM_CASSETTE_PLAY
-        MENUITEM "&Visszatekerés az elejére",            IDM_CASSETTE_REWIND
-        MENUITEM "&Előretekerés a végére",            IDM_CASSETTE_FAST_FORWARD
+        MENUITEM "&Felvétel", IDM_CASSETTE_RECORD
+        MENUITEM "&Lejátszás", IDM_CASSETTE_PLAY
+        MENUITEM "&Visszatekerés az elejére", IDM_CASSETTE_REWIND
+        MENUITEM "&Előretekerés a végére", IDM_CASSETTE_FAST_FORWARD
         MENUITEM SEPARATOR
-        MENUITEM "&Kiadás",                    IDM_CASSETTE_EJECT
+        MENUITEM "&Kiadás", IDM_CASSETTE_EJECT
     END
 END
 
@@ -160,9 +160,9 @@ CartridgeSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "Kép&fájl...",                    IDM_CARTRIDGE_IMAGE
+        MENUITEM "Kép&fájl...", IDM_CARTRIDGE_IMAGE
         MENUITEM SEPARATOR
-        MENUITEM "&Kiadás",                    IDM_CARTRIDGE_EJECT
+        MENUITEM "&Kiadás", IDM_CARTRIDGE_EJECT
     END
 END
 
@@ -170,14 +170,14 @@ FloppySubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Új képfájl létrehozása...",                IDM_FLOPPY_IMAGE_NEW
+        MENUITEM "&Új képfájl létrehozása...", IDM_FLOPPY_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "Meglévő képfájl &megnyitása...",                IDM_FLOPPY_IMAGE_EXISTING
-        MENUITEM "Meglévő képfájl megnyitása (&írásvédett)...",    IDM_FLOPPY_IMAGE_EXISTING_WP
+        MENUITEM "Meglévő képfájl &megnyitása...", IDM_FLOPPY_IMAGE_EXISTING
+        MENUITEM "Meglévő képfájl megnyitása (&írásvédett)...", IDM_FLOPPY_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "E&xportálás 86F formátumba...",                IDM_FLOPPY_EXPORT_TO_86F
+        MENUITEM "E&xportálás 86F formátumba...", IDM_FLOPPY_EXPORT_TO_86F
         MENUITEM SEPARATOR
-        MENUITEM "&Kiadás",                    IDM_FLOPPY_EJECT
+        MENUITEM "&Kiadás", IDM_FLOPPY_EJECT
     END
 END
 
@@ -185,13 +185,13 @@ CdromSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Némítás",                    IDM_CDROM_MUTE
+        MENUITEM "&Némítás", IDM_CDROM_MUTE
         MENUITEM SEPARATOR
-        MENUITEM "&Kiadás",                    IDM_CDROM_EMPTY
-        MENUITEM "Előző képfájl &újratöltése",            IDM_CDROM_RELOAD
+        MENUITEM "&Kiadás", IDM_CDROM_EMPTY
+        MENUITEM "Előző képfájl &újratöltése", IDM_CDROM_RELOAD
         MENUITEM SEPARATOR
-        MENUITEM "&Meglévő képfájl &megnyitása...",                    IDM_CDROM_IMAGE
-        MENUITEM "&Mappa...",                    IDM_CDROM_DIR
+        MENUITEM "&Meglévő képfájl &megnyitása...", IDM_CDROM_IMAGE
+        MENUITEM "&Mappa...", IDM_CDROM_DIR
     END
 END
 
@@ -199,13 +199,13 @@ ZIPSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Új képfájl létrehozása...",                IDM_ZIP_IMAGE_NEW
+        MENUITEM "&Új képfájl létrehozása...", IDM_ZIP_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Meglévő képfájl &megnyitása...",                IDM_ZIP_IMAGE_EXISTING
-        MENUITEM "Meglévő képfájl megnyitása (&írásvédett)...",    IDM_ZIP_IMAGE_EXISTING_WP
+        MENUITEM "&Meglévő képfájl &megnyitása...", IDM_ZIP_IMAGE_EXISTING
+        MENUITEM "Meglévő képfájl megnyitása (&írásvédett)...", IDM_ZIP_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "Kiadás",                    IDM_ZIP_EJECT
-        MENUITEM "Előző képfájl &újratöltése",            IDM_ZIP_RELOAD
+        MENUITEM "Kiadás", IDM_ZIP_EJECT
+        MENUITEM "Előző képfájl &újratöltése", IDM_ZIP_RELOAD
     END
 END
 
@@ -213,13 +213,13 @@ MOSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Új képfájl létrehozása...",                IDM_MO_IMAGE_NEW
+        MENUITEM "&Új képfájl létrehozása...", IDM_MO_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Meglévő képfájl &megnyitása...",                IDM_MO_IMAGE_EXISTING
-        MENUITEM "Meglévő képfájl megnyitása (&írásvédett)...",    IDM_MO_IMAGE_EXISTING_WP
+        MENUITEM "&Meglévő képfájl &megnyitása...", IDM_MO_IMAGE_EXISTING
+        MENUITEM "Meglévő képfájl megnyitása (&írásvédett)...", IDM_MO_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "Kiadás",                    IDM_MO_EJECT
-        MENUITEM "Előző képfájl &újratöltése",            IDM_MO_RELOAD
+        MENUITEM "Kiadás", IDM_MO_EJECT
+        MENUITEM "Előző képfájl &újratöltése", IDM_MO_RELOAD
     END
 END
 
@@ -245,150 +245,150 @@ END
 // Dialog
 //
 
-#define STR_PREFERENCES        "Beállítások"
-#define STR_SND_GAIN        "Hangerőszabályzó"
-#define STR_NEW_FLOPPY        "Új képfájl létrehozása"
+#define STR_PREFERENCES   "Beállítások"
+#define STR_SND_GAIN      "Hangerőszabályzó"
+#define STR_NEW_FLOPPY    "Új képfájl létrehozása"
 #define STR_CONFIG        "Konfigurálás"
-#define STR_SPECIFY_DIM        "Főablak méreteinek megadása"
+#define STR_SPECIFY_DIM   "Főablak méreteinek megadása"
 
 #define STR_OK            "OK"
 #define STR_CANCEL        "Mégse"
 #define STR_GLOBAL        "Beállítások mentése &globális alapértékként"
-#define STR_DEFAULT        "&Alapértelmezett"
-#define STR_LANGUAGE        "Nyelv:"
-#define STR_ICONSET        "Ikonkészlet:"
+#define STR_DEFAULT       "&Alapértelmezett"
+#define STR_LANGUAGE      "Nyelv:"
+#define STR_ICONSET       "Ikonkészlet:"
 
-#define STR_GAIN        "Hangerő"
+#define STR_GAIN          "Hangerő"
 
-#define STR_FILE_NAME        "Fájlnév:"
-#define STR_DISK_SIZE        "Méret:"
-#define STR_RPM_MODE        "RPM-mód:"
-#define STR_PROGRESS        "Folyamat:"
+#define STR_FILE_NAME     "Fájlnév:"
+#define STR_DISK_SIZE     "Méret:"
+#define STR_RPM_MODE      "RPM-mód:"
+#define STR_PROGRESS      "Folyamat:"
 
-#define STR_WIDTH        "Szélesség:"
+#define STR_WIDTH         "Szélesség:"
 #define STR_HEIGHT        "Magasság:"
-#define STR_LOCK_TO_SIZE    "Rögzítés a megadott méretre"
+#define STR_LOCK_TO_SIZE  "Rögzítés a megadott méretre"
 
-#define STR_MACHINE_TYPE    "Géptípus:"
-#define STR_MACHINE        "Számítógép:"
-#define STR_CONFIGURE        "Beállítások..."
-#define STR_CPU_TYPE        "Processzor:"
-#define STR_CPU_SPEED        "Seb.:"
-#define STR_FPU            "FPU-egység:"
-#define STR_WAIT_STATES        "Várak. ciklusok:"
+#define STR_MACHINE_TYPE  "Géptípus:"
+#define STR_MACHINE       "Számítógép:"
+#define STR_CONFIGURE     "Beállítások..."
+#define STR_CPU_TYPE      "Processzor:"
+#define STR_CPU_SPEED     "Seb.:"
+#define STR_FPU           "FPU-egység:"
+#define STR_WAIT_STATES   "Várak. ciklusok:"
 #define STR_MB            "MB"
 #define STR_MEMORY        "Memória:"
-#define STR_TIME_SYNC        "Idő szinkronizáció"
-#define STR_DISABLED        "Letiltva"
-#define STR_ENABLED_LOCAL    "Engedélyezve (helyi idő)"
-#define STR_ENABLED_UTC        "Engedélyezve (UTC)"
-#define STR_DYNAREC        "Dinamikus újrafordítás"
+#define STR_TIME_SYNC     "Idő szinkronizáció"
+#define STR_DISABLED      "Letiltva"
+#define STR_ENABLED_LOCAL "Engedélyezve (helyi idő)"
+#define STR_ENABLED_UTC   "Engedélyezve (UTC)"
+#define STR_DYNAREC       "Dinamikus újrafordítás"
 
-#define STR_VIDEO        "Videokártya:"
-#define STR_VIDEO_2        "Videokártya 2:"
+#define STR_VIDEO         "Videokártya:"
+#define STR_VIDEO_2       "Videokártya 2:"
 #define STR_VOODOO        "Voodoo-gyorsítókártya"
-#define STR_IBM8514        "IBM 8514/a-gyorsítókártya"
-#define STR_XGA            "XGA-gyorsítókártya"
+#define STR_IBM8514       "IBM 8514/a-gyorsítókártya"
+#define STR_XGA           "XGA-gyorsítókártya"
 
-#define STR_MOUSE        "Egér:"
-#define STR_JOYSTICK        "Játékvezérlő:"
-#define STR_JOY1        "Játékvez. 1..."
-#define STR_JOY2        "Játékvez. 2..."
-#define STR_JOY3        "Játékvez. 3..."
-#define STR_JOY4        "Játékvez. 4..."
+#define STR_MOUSE         "Egér:"
+#define STR_JOYSTICK      "Játékvezérlő:"
+#define STR_JOY1          "Játékvez. 1..."
+#define STR_JOY2          "Játékvez. 2..."
+#define STR_JOY3          "Játékvez. 3..."
+#define STR_JOY4          "Játékvez. 4..."
 
 #define STR_SOUND1        "Hangkártya 1:"
 #define STR_SOUND2        "Hangkártya 2:"
 #define STR_SOUND3        "Hangkártya 3:"
 #define STR_SOUND4        "Hangkártya 4:"
-#define STR_MIDI_OUT        "MIDI-kimenet:"
-#define STR_MIDI_IN        "MIDI-bemenet:"
+#define STR_MIDI_OUT      "MIDI-kimenet:"
+#define STR_MIDI_IN       "MIDI-bemenet:"
 #define STR_MPU401        "Különálló MPU-401"
-#define STR_FLOAT        "FLOAT32 használata"
-#define STR_FM_DRIVER        "FM szintetizátor meghajtó"
-#define STR_FM_DRV_NUKED    "Nuked (pontosabb)"
-#define STR_FM_DRV_YMFM        "YMFM (gyorsabb)"
+#define STR_FLOAT         "FLOAT32 használata"
+#define STR_FM_DRIVER     "FM szintetizátor meghajtó"
+#define STR_FM_DRV_NUKED  "Nuked (pontosabb)"
+#define STR_FM_DRV_YMFM   "YMFM (gyorsabb)"
 
-#define STR_NET_TYPE    "Hálózati típusa:"
-#define STR_PCAP        "PCap eszköz:"
-#define STR_NET            "Hálózati kártya:"
-#define STR_NET1        "Network card 1:"
-#define STR_NET2        "Network card 2:"
-#define STR_NET3        "Network card 3:"
-#define STR_NET4        "Network card 4:"
+#define STR_NET_TYPE      "Hálózati típusa:"
+#define STR_PCAP          "PCap eszköz:"
+#define STR_NET           "Hálózati kártya:"
+#define STR_NET1          "Network card 1:"
+#define STR_NET2          "Network card 2:"
+#define STR_NET3          "Network card 3:"
+#define STR_NET4          "Network card 4:"
 
-#define STR_COM1        "COM1 eszköz:"
-#define STR_COM2        "COM2 eszköz:"
-#define STR_COM3        "COM3 eszköz:"
-#define STR_COM4        "COM4 eszköz:"
-#define STR_LPT1        "LPT1 eszköz:"
-#define STR_LPT2        "LPT2 eszköz:"
-#define STR_LPT3        "LPT3 eszköz:"
-#define STR_LPT4        "LPT4 eszköz:"
-#define STR_SERIAL1        "Soros port 1"
-#define STR_SERIAL2        "Soros port 2"
-#define STR_SERIAL3        "Soros port 3"
-#define STR_SERIAL4        "Soros port 4"
-#define STR_PARALLEL1        "Párhuzamos port 1"
-#define STR_PARALLEL2        "Párhuzamos port 2"
-#define STR_PARALLEL3        "Párhuzamos port 3"
-#define STR_PARALLEL4        "Párhuzamos port 4"
-#define STR_SERIAL_PASS1    "Serial port passthrough 1"
-#define STR_SERIAL_PASS2    "Serial port passthrough 2"
-#define STR_SERIAL_PASS3    "Serial port passthrough 3"
-#define STR_SERIAL_PASS4    "Serial port passthrough 4"
+#define STR_COM1          "COM1 eszköz:"
+#define STR_COM2          "COM2 eszköz:"
+#define STR_COM3          "COM3 eszköz:"
+#define STR_COM4          "COM4 eszköz:"
+#define STR_LPT1          "LPT1 eszköz:"
+#define STR_LPT2          "LPT2 eszköz:"
+#define STR_LPT3          "LPT3 eszköz:"
+#define STR_LPT4          "LPT4 eszköz:"
+#define STR_SERIAL1       "Soros port 1"
+#define STR_SERIAL2       "Soros port 2"
+#define STR_SERIAL3       "Soros port 3"
+#define STR_SERIAL4       "Soros port 4"
+#define STR_PARALLEL1     "Párhuzamos port 1"
+#define STR_PARALLEL2     "Párhuzamos port 2"
+#define STR_PARALLEL3     "Párhuzamos port 3"
+#define STR_PARALLEL4     "Párhuzamos port 4"
+#define STR_SERIAL_PASS1  "Serial port passthrough 1"
+#define STR_SERIAL_PASS2  "Serial port passthrough 2"
+#define STR_SERIAL_PASS3  "Serial port passthrough 3"
+#define STR_SERIAL_PASS4  "Serial port passthrough 4"
 
-#define STR_HDC            "Merevl.-vezérlő:"
-#define STR_FDC            "Floppy-vezérlő:"
-#define STR_IDE_TER        "Harmadlagos IDE-vezérlő"
-#define STR_IDE_QUA        "Negyedleges IDE-vezérlő"
-#define STR_SCSI        "SCSI"
+#define STR_HDC           "Merevl.-vezérlő:"
+#define STR_FDC           "Floppy-vezérlő:"
+#define STR_IDE_TER       "Harmadlagos IDE-vezérlő"
+#define STR_IDE_QUA       "Negyedleges IDE-vezérlő"
+#define STR_SCSI          "SCSI"
 #define STR_SCSI_1        "Gazdaadapt. 1:"
 #define STR_SCSI_2        "Gazdaadapt. 2:"
 #define STR_SCSI_3        "Gazdaadapt. 3:"
 #define STR_SCSI_4        "Gazdaadapt. 4:"
-#define STR_CASSETTE        "Magnókazetta"
+#define STR_CASSETTE      "Magnókazetta"
 
-#define STR_HDD            "Merevlemezek:"
-#define STR_NEW            "&Új..."
-#define STR_EXISTING        "&Megnyitás..."
+#define STR_HDD           "Merevlemezek:"
+#define STR_NEW           "&Új..."
+#define STR_EXISTING      "&Megnyitás..."
 #define STR_REMOVE        "&Eltávolítás"
-#define STR_BUS            "Busz:"
-#define STR_CHANNEL        "Csatorna:"
+#define STR_BUS           "Busz:"
+#define STR_CHANNEL       "Csatorna:"
 #define STR_ID            "ID:"
-#define STR_SPEED        "Speed:"
+#define STR_SPEED         "Speed:"
 
-#define STR_SPECIFY        "&Kiválasztás..."
-#define STR_SECTORS        "Szektor:"
-#define STR_HEADS        "Fej:"
-#define STR_CYLS        "Cilinder:"
-#define STR_SIZE_MB        "Méret (MB):"
-#define STR_TYPE        "Típus:"
-#define STR_IMG_FORMAT        "Formátum:"
-#define STR_BLOCK_SIZE        "Blokkméret:"
+#define STR_SPECIFY       "&Kiválasztás..."
+#define STR_SECTORS       "Szektor:"
+#define STR_HEADS         "Fej:"
+#define STR_CYLS          "Cilinder:"
+#define STR_SIZE_MB       "Méret (MB):"
+#define STR_TYPE          "Típus:"
+#define STR_IMG_FORMAT    "Formátum:"
+#define STR_BLOCK_SIZE    "Blokkméret:"
 
-#define STR_FLOPPY_DRIVES    "Floppy-meghajtók:"
-#define STR_TURBO        "Turbó időzítés"
-#define STR_CHECKBPB        "BPB ellenőrzés"
-#define STR_CDROM_DRIVES    "CD-ROM meghajtók:"
-#define STR_CD_SPEED        "Seb.:"
-#define STR_EARLY        "Korábbi meghajtó"
+#define STR_FLOPPY_DRIVES "Floppy-meghajtók:"
+#define STR_TURBO         "Turbó időzítés"
+#define STR_CHECKBPB      "BPB ellenőrzés"
+#define STR_CDROM_DRIVES  "CD-ROM meghajtók:"
+#define STR_CD_SPEED      "Seb.:"
+#define STR_EARLY         "Korábbi meghajtó"
 
-#define STR_MO_DRIVES        "MO-meghajtók:"
-#define STR_ZIP_DRIVES        "ZIP-meghajtók:"
-#define STR_250            "ZIP 250"
+#define STR_MO_DRIVES     "MO-meghajtók:"
+#define STR_ZIP_DRIVES    "ZIP-meghajtók:"
+#define STR_250           "ZIP 250"
 
 #define STR_ISARTC        "ISA RTC (óra):"
 #define STR_ISAMEM        "ISA memóriabővítők"
-#define STR_ISAMEM_1        "Kártya 1:"
-#define STR_ISAMEM_2        "Kártya 2:"
-#define STR_ISAMEM_3        "Kártya 3:"
-#define STR_ISAMEM_4        "Kártya 4:"
+#define STR_ISAMEM_1      "Kártya 1:"
+#define STR_ISAMEM_2      "Kártya 2:"
+#define STR_ISAMEM_3      "Kártya 3:"
+#define STR_ISAMEM_4      "Kártya 4:"
 #define STR_BUGGER        "ISABugger eszköz"
-#define STR_POSTCARD        "POST kártya"
+#define STR_POSTCARD      "POST kártya"
 
-#define FONT_SIZE        9
-#define FONT_NAME        "Segoe UI"
+#define FONT_SIZE         9
+#define FONT_NAME         "Segoe UI"
 
 #include "dialogs.rc"
 
@@ -397,9 +397,9 @@ END
 // String Table
 //
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
-    2048    "86Box"
+    2048        "86Box"
     IDS_2049    "Hiba"
     IDS_2050    "Végzetes hiba"
     IDS_2051    " - PAUSED"
@@ -417,7 +417,7 @@ BEGIN
     IDS_2063    "A számítógép ""%hs"" nem elérhető a ""roms/machines"" mappából hiányzó ROM-képek miatt. Ehelyett egy másik gép kerül futtatásra."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2064    "A videokártya ""%hs"" nem elérhető a ""roms/video"" mappából hiányzó ROM-képek miatt. Ehelyett egy másik kártya kerül futtatásra."
     IDS_2065    "Számítógép"
@@ -437,7 +437,7 @@ BEGIN
     IDS_2079    "Nyomja meg az F8+F12-t vagy a középső gombot az egér elengédéséhez"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2080    "Nem sikerült a FluidSynth inicializálása"
     IDS_2081    "Busz"
@@ -548,7 +548,7 @@ BEGIN
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_4096    "Merevlemez (%s)"
     IDS_4097    "%01i:%01i"
@@ -647,7 +647,7 @@ BEGIN
 
     IDS_7168    "(A rendszer nyelve)"
 END
-#define IDS_LANG_ENUS    IDS_7168
+#define IDS_LANG_ENUS IDS_7168
 
 // Hungarian resources
 /////////////////////////////////////////////////////////////////////////////

--- a/src/win/languages/it-IT.rc
+++ b/src/win/languages/it-IT.rc
@@ -14,122 +14,122 @@ LANGUAGE LANG_ITALIAN, SUBLANG_ITALIAN
 // Menu
 //
 
-MainMenu MENU DISCARDABLE 
+MainMenu MENU DISCARDABLE
 BEGIN
     POPUP "&Azione"
     BEGIN
-        MENUITEM "&Tastiera richiede la cattura",    IDM_ACTION_KBD_REQ_CAPTURE
-        MENUITEM "&CTRL destro è ALT sinistro",    IDM_ACTION_RCTRL_IS_LALT
+        MENUITEM "&Tastiera richiede la cattura", IDM_ACTION_KBD_REQ_CAPTURE
+        MENUITEM "&CTRL destro è ALT sinistro", IDM_ACTION_RCTRL_IS_LALT
         MENUITEM SEPARATOR
-        MENUITEM "&Riavvia...",                 IDM_ACTION_HRESET
-        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12",     IDM_ACTION_RESET_CAD
+        MENUITEM "&Riavvia...", IDM_ACTION_HRESET
+        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12", IDM_ACTION_RESET_CAD
         MENUITEM SEPARATOR
-    MENUITEM "Ctrl+Alt+&Esc",        IDM_ACTION_CTRL_ALT_ESC
+    MENUITEM "Ctrl+Alt+&Esc", IDM_ACTION_CTRL_ALT_ESC
         MENUITEM SEPARATOR
-        MENUITEM "&Pausa",                      IDM_ACTION_PAUSE
+        MENUITEM "&Pausa", IDM_ACTION_PAUSE
         MENUITEM SEPARATOR
-        MENUITEM "E&sci...",                       IDM_ACTION_EXIT
+        MENUITEM "E&sci...", IDM_ACTION_EXIT
     END
     POPUP "&Visualizza"
     BEGIN
-        MENUITEM "&Nascondi barra di stato",        IDM_VID_HIDE_STATUS_BAR
-        MENUITEM "Hide &toolbar",        IDM_VID_HIDE_TOOLBAR
+        MENUITEM "&Nascondi barra di stato", IDM_VID_HIDE_STATUS_BAR
+        MENUITEM "Hide &toolbar", IDM_VID_HIDE_TOOLBAR
         MENUITEM SEPARATOR
-        MENUITEM "&Show non-primary monitors",  IDM_VID_MONITORS
-        MENUITEM "&Finestra ridimensionabile",          IDM_VID_RESIZE
-        MENUITEM "R&icorda dimensioni e posizione",  IDM_VID_REMEMBER
+        MENUITEM "&Show non-primary monitors", IDM_VID_MONITORS
+        MENUITEM "&Finestra ridimensionabile", IDM_VID_RESIZE
+        MENUITEM "R&icorda dimensioni e posizione", IDM_VID_REMEMBER
         MENUITEM SEPARATOR
         POPUP "Re&nderer"
         BEGIN
-            MENUITEM "&SDL (Software)",         IDM_VID_SDL_SW
-            MENUITEM "SDL (&Hardware)",         IDM_VID_SDL_HW
-            MENUITEM "SDL (&OpenGL)",           IDM_VID_SDL_OPENGL
-            MENUITEM "Open&GL (3.0 Core)",      IDM_VID_OPENGL_CORE
+            MENUITEM "&SDL (Software)", IDM_VID_SDL_SW
+            MENUITEM "SDL (&Hardware)", IDM_VID_SDL_HW
+            MENUITEM "SDL (&OpenGL)", IDM_VID_SDL_OPENGL
+            MENUITEM "Open&GL (3.0 Core)", IDM_VID_OPENGL_CORE
 #ifdef USE_VNC
-            MENUITEM "&VNC",                    IDM_VID_VNC
+            MENUITEM "&VNC", IDM_VID_VNC
 #endif
         END
         MENUITEM SEPARATOR
-        MENUITEM "Specifica dimensioni...",          IDM_VID_SPECIFY_DIM
-        MENUITEM "F&orza display 4:3",    IDM_VID_FORCE43
+        MENUITEM "Specifica dimensioni...", IDM_VID_SPECIFY_DIM
+        MENUITEM "F&orza display 4:3", IDM_VID_FORCE43
         POPUP "&Fattore scalare della finestra"
         BEGIN
-            MENUITEM "&0.5x",                   IDM_VID_SCALE_1X
-            MENUITEM "&1x",                     IDM_VID_SCALE_2X
-            MENUITEM "1.&5x",                   IDM_VID_SCALE_3X
-            MENUITEM "&2x",                     IDM_VID_SCALE_4X
-            MENUITEM "&3x",                     IDM_VID_SCALE_5X
-            MENUITEM "&4x",                     IDM_VID_SCALE_6X
-            MENUITEM "&5x",                     IDM_VID_SCALE_7X
-            MENUITEM "&6x",                     IDM_VID_SCALE_8X
-            MENUITEM "&7x",                     IDM_VID_SCALE_9X
-            MENUITEM "&8x",                     IDM_VID_SCALE_10X
+            MENUITEM "&0.5x", IDM_VID_SCALE_1X
+            MENUITEM "&1x", IDM_VID_SCALE_2X
+            MENUITEM "1.&5x", IDM_VID_SCALE_3X
+            MENUITEM "&2x", IDM_VID_SCALE_4X
+            MENUITEM "&3x", IDM_VID_SCALE_5X
+            MENUITEM "&4x", IDM_VID_SCALE_6X
+            MENUITEM "&5x", IDM_VID_SCALE_7X
+            MENUITEM "&6x", IDM_VID_SCALE_8X
+            MENUITEM "&7x", IDM_VID_SCALE_9X
+            MENUITEM "&8x", IDM_VID_SCALE_10X
         END
         POPUP "Metodo filtro"
         BEGIN
-            MENUITEM "&Dal più vicino",                 IDM_VID_FILTER_NEAREST
-            MENUITEM "&Lineare",                  IDM_VID_FILTER_LINEAR
+            MENUITEM "&Dal più vicino", IDM_VID_FILTER_NEAREST
+            MENUITEM "&Lineare", IDM_VID_FILTER_LINEAR
         END
-        MENUITEM "Scala Hi&DPI",              IDM_VID_HIDPI
+        MENUITEM "Scala Hi&DPI", IDM_VID_HIDPI
         MENUITEM SEPARATOR
-        MENUITEM "&Schermo intero\tCtrl+Alt+PgUp",    IDM_VID_FULLSCREEN
+        MENUITEM "&Schermo intero\tCtrl+Alt+PgUp", IDM_VID_FULLSCREEN
         POPUP "Modalità adattamento &schermo intero"
         BEGIN
-            MENUITEM "&Adatta a schermo intero",        IDM_VID_FS_FULL
-            MENUITEM "&4:3",                        IDM_VID_FS_43
+            MENUITEM "&Adatta a schermo intero", IDM_VID_FS_FULL
+            MENUITEM "&4:3", IDM_VID_FS_43
             MENUITEM "&Pixel quadrati (mantiene l'aspetto)", IDM_VID_FS_KEEPRATIO
-            MENUITEM "&Scala intera",              IDM_VID_FS_INT
+            MENUITEM "&Scala intera", IDM_VID_FS_INT
         END
         POPUP "Impostazioni E&GA/(S)VGA"
         BEGIN
-            MENUITEM "&Invertire monitor VGA",   IDM_VID_INVERT
+            MENUITEM "&Invertire monitor VGA", IDM_VID_INVERT
             POPUP "Schermi VGA &"
             BEGIN
-                MENUITEM "RGB &Color",          IDM_VID_GRAY_RGB
-                MENUITEM "&RGB Monocroma",      IDM_VID_GRAY_MONO
-                MENUITEM "&Monitor ambra",      IDM_VID_GRAY_AMBER
-                MENUITEM "&Monitor verde",      IDM_VID_GRAY_GREEN
-                MENUITEM "&Monitor bianco",      IDM_VID_GRAY_WHITE
+                MENUITEM "RGB &Color", IDM_VID_GRAY_RGB
+                MENUITEM "&RGB Monocroma", IDM_VID_GRAY_MONO
+                MENUITEM "&Monitor ambra", IDM_VID_GRAY_AMBER
+                MENUITEM "&Monitor verde", IDM_VID_GRAY_GREEN
+                MENUITEM "&Monitor bianco", IDM_VID_GRAY_WHITE
             END
             POPUP "Conversione &scala grigia"
             BEGIN
-                MENUITEM "BT&601 (NTSC/PAL)",   IDM_VID_GRAYCT_601
-                MENUITEM "BT&709 (HDTV)",       IDM_VID_GRAYCT_709
-                MENUITEM "&AMedia",            IDM_VID_GRAYCT_AVE
+                MENUITEM "BT&601 (NTSC/PAL)", IDM_VID_GRAYCT_601
+                MENUITEM "BT&709 (HDTV)", IDM_VID_GRAYCT_709
+                MENUITEM "&AMedia", IDM_VID_GRAYCT_AVE
             END
         END
         MENUITEM SEPARATOR
-        MENUITEM "Sovrascansione CGA/PCjr/Tandy/E&GA/(S)VGA",     IDM_VID_OVERSCAN
+        MENUITEM "Sovrascansione CGA/PCjr/Tandy/E&GA/(S)VGA", IDM_VID_OVERSCAN
         MENUITEM "Cambia il contrasto per &display monocromatici", IDM_VID_CGACON
     END
-    MENUITEM "&Dispositivi",                IDM_MEDIA
+    MENUITEM "&Dispositivi", IDM_MEDIA
     POPUP "&Strumenti"
     BEGIN
-        MENUITEM "&Impostazioni...",                IDM_CONFIG
-        MENUITEM "&Aggiorna icone della barra di stato",    IDM_UPDATE_ICONS
+        MENUITEM "&Impostazioni...", IDM_CONFIG
+        MENUITEM "&Aggiorna icone della barra di stato", IDM_UPDATE_ICONS
         MENUITEM SEPARATOR
-        MENUITEM "Cattura schermata\tCtrl+F11",  IDM_ACTION_SCREENSHOT
+        MENUITEM "Cattura schermata\tCtrl+F11", IDM_ACTION_SCREENSHOT
         MENUITEM SEPARATOR
-        MENUITEM "&Preferenze...",    IDM_PREFERENCES
+        MENUITEM "&Preferenze...", IDM_PREFERENCES
 #ifdef DISCORD
         MENUITEM "Abilita &integrazione Discord", IDM_DISCORD
 #endif
         MENUITEM SEPARATOR
-        MENUITEM "Guadagno &suono...",              IDM_SND_GAIN
+        MENUITEM "Guadagno &suono...", IDM_SND_GAIN
 #ifdef MTR_ENABLED
         MENUITEM SEPARATOR
-        MENUITEM "Inizia traccia\tCtrl+T",         IDM_ACTION_BEGIN_TRACE
-        MENUITEM "Ferma traccia\tCtrl+T",           IDM_ACTION_END_TRACE
+        MENUITEM "Inizia traccia\tCtrl+T", IDM_ACTION_BEGIN_TRACE
+        MENUITEM "Ferma traccia\tCtrl+T", IDM_ACTION_END_TRACE
 #endif
     END
     POPUP "&?"
     BEGIN
-        MENUITEM "&Documentazione...",           IDM_DOCS
-        MENUITEM "&Informazioni su 86Box...",             IDM_ABOUT
+        MENUITEM "&Documentazione...", IDM_DOCS
+        MENUITEM "&Informazioni su 86Box...", IDM_ABOUT
     END
 END
 
-StatusBarMenu MENU DISCARDABLE 
+StatusBarMenu MENU DISCARDABLE
 BEGIN
     MENUITEM SEPARATOR
 END
@@ -138,17 +138,17 @@ CassetteSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nuova immagine...",                IDM_CASSETTE_IMAGE_NEW
+        MENUITEM "&Nuova immagine...", IDM_CASSETTE_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Immagine esistente...",                IDM_CASSETTE_IMAGE_EXISTING
-        MENUITEM "Immagine esistente (&protezione contro scrittura)...",    IDM_CASSETTE_IMAGE_EXISTING_WP
+        MENUITEM "&Immagine esistente...", IDM_CASSETTE_IMAGE_EXISTING
+        MENUITEM "Immagine esistente (&protezione contro scrittura)...", IDM_CASSETTE_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Registra",                    IDM_CASSETTE_RECORD
-        MENUITEM "R&iproduci",                    IDM_CASSETTE_PLAY
-        MENUITEM "Ri&avvolgi all'inizio",            IDM_CASSETTE_REWIND
-        MENUITEM "A&vanti veloce alla fine",            IDM_CASSETTE_FAST_FORWARD
+        MENUITEM "&Registra", IDM_CASSETTE_RECORD
+        MENUITEM "R&iproduci", IDM_CASSETTE_PLAY
+        MENUITEM "Ri&avvolgi all'inizio", IDM_CASSETTE_REWIND
+        MENUITEM "A&vanti veloce alla fine", IDM_CASSETTE_FAST_FORWARD
         MENUITEM SEPARATOR
-        MENUITEM "&Espelli",                    IDM_CASSETTE_EJECT
+        MENUITEM "&Espelli", IDM_CASSETTE_EJECT
     END
 END
 
@@ -156,9 +156,9 @@ CartridgeSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Immagine...",                    IDM_CARTRIDGE_IMAGE
+        MENUITEM "&Immagine...", IDM_CARTRIDGE_IMAGE
         MENUITEM SEPARATOR
-        MENUITEM "&Espelli",                    IDM_CARTRIDGE_EJECT
+        MENUITEM "&Espelli", IDM_CARTRIDGE_EJECT
     END
 END
 
@@ -166,14 +166,14 @@ FloppySubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nuova immagine...",                IDM_FLOPPY_IMAGE_NEW
+        MENUITEM "&Nuova immagine...", IDM_FLOPPY_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Immagine esistente...",                IDM_FLOPPY_IMAGE_EXISTING
-        MENUITEM "Immagine esistente (&protezione contro scrittura)...",    IDM_FLOPPY_IMAGE_EXISTING_WP
+        MENUITEM "&Immagine esistente...", IDM_FLOPPY_IMAGE_EXISTING
+        MENUITEM "Immagine esistente (&protezione contro scrittura)...", IDM_FLOPPY_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "E&sporta in 86F...",                IDM_FLOPPY_EXPORT_TO_86F
+        MENUITEM "E&sporta in 86F...", IDM_FLOPPY_EXPORT_TO_86F
         MENUITEM SEPARATOR
-        MENUITEM "&Espelli",                    IDM_FLOPPY_EJECT
+        MENUITEM "&Espelli", IDM_FLOPPY_EJECT
     END
 END
 
@@ -181,13 +181,13 @@ CdromSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Muto",                    IDM_CDROM_MUTE
+        MENUITEM "&Muto", IDM_CDROM_MUTE
         MENUITEM SEPARATOR
-        MENUITEM "&Espelli",                    IDM_CDROM_EMPTY
-        MENUITEM "&Ricarica l'immagine precedente",            IDM_CDROM_RELOAD
+        MENUITEM "&Espelli", IDM_CDROM_EMPTY
+        MENUITEM "&Ricarica l'immagine precedente", IDM_CDROM_RELOAD
         MENUITEM SEPARATOR
-        MENUITEM "&Immagine...",                    IDM_CDROM_IMAGE
-        MENUITEM "&Cartella...",                    IDM_CDROM_DIR
+        MENUITEM "&Immagine...", IDM_CDROM_IMAGE
+        MENUITEM "&Cartella...", IDM_CDROM_DIR
     END
 END
 
@@ -195,13 +195,13 @@ ZIPSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nuova immagine...",                IDM_ZIP_IMAGE_NEW
+        MENUITEM "&Nuova immagine...", IDM_ZIP_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Immagine esistente...",                IDM_ZIP_IMAGE_EXISTING
-        MENUITEM "Immagine esistente (&protezione contro scrittura)...",    IDM_ZIP_IMAGE_EXISTING_WP
+        MENUITEM "&Immagine esistente...", IDM_ZIP_IMAGE_EXISTING
+        MENUITEM "Immagine esistente (&protezione contro scrittura)...", IDM_ZIP_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Espelli",                    IDM_ZIP_EJECT
-        MENUITEM "&Ricarica l'immagine precedente",            IDM_ZIP_RELOAD
+        MENUITEM "&Espelli", IDM_ZIP_EJECT
+        MENUITEM "&Ricarica l'immagine precedente", IDM_ZIP_RELOAD
     END
 END
 
@@ -209,13 +209,13 @@ MOSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nuova immagine...",                IDM_MO_IMAGE_NEW
+        MENUITEM "&Nuova immagine...", IDM_MO_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Immagine esistente...",                IDM_MO_IMAGE_EXISTING
-        MENUITEM "Immagine esistente (&protezione contro scrittura)...",    IDM_MO_IMAGE_EXISTING_WP
+        MENUITEM "&Immagine esistente...", IDM_MO_IMAGE_EXISTING
+        MENUITEM "Immagine esistente (&protezione contro scrittura)...", IDM_MO_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Espelli",                    IDM_MO_EJECT
-        MENUITEM "&Ricarica l'immagine precedente",            IDM_MO_RELOAD
+        MENUITEM "&Espelli", IDM_MO_EJECT
+        MENUITEM "&Ricarica l'immagine precedente", IDM_MO_RELOAD
     END
 END
 
@@ -241,150 +241,150 @@ END
 // Dialog
 //
 
-#define STR_PREFERENCES        "Preferenze"
-#define STR_SND_GAIN        "Guadagno del suono"
-#define STR_NEW_FLOPPY        "Nuova immagine"
+#define STR_PREFERENCES   "Preferenze"
+#define STR_SND_GAIN      "Guadagno del suono"
+#define STR_NEW_FLOPPY    "Nuova immagine"
 #define STR_CONFIG        "Impostazioni"
-#define STR_SPECIFY_DIM        "Specifica dimensioni della finestra principale"
+#define STR_SPECIFY_DIM   "Specifica dimensioni della finestra principale"
 
 #define STR_OK            "OK"
 #define STR_CANCEL        "Annulla"
 #define STR_GLOBAL        "Salva queste impostazioni come &predefinite globali"
-#define STR_DEFAULT        "&Predefinito"
-#define STR_LANGUAGE        "Lingua:"
-#define STR_ICONSET        "Pacchetto di icone:"
+#define STR_DEFAULT       "&Predefinito"
+#define STR_LANGUAGE      "Lingua:"
+#define STR_ICONSET       "Pacchetto di icone:"
 
-#define STR_GAIN        "Guadagno"
+#define STR_GAIN          "Guadagno"
 
-#define STR_FILE_NAME        "Nome file:"
-#define STR_DISK_SIZE        "Dimensioni disco:"
-#define STR_RPM_MODE        "Modalità RPM:"
-#define STR_PROGRESS        "Progresso:"
+#define STR_FILE_NAME     "Nome file:"
+#define STR_DISK_SIZE     "Dimensioni disco:"
+#define STR_RPM_MODE      "Modalità RPM:"
+#define STR_PROGRESS      "Progresso:"
 
-#define STR_WIDTH        "Larghezza:"
+#define STR_WIDTH         "Larghezza:"
 #define STR_HEIGHT        "Altezza:"
-#define STR_LOCK_TO_SIZE    "Blocca in queste dimensioni"
+#define STR_LOCK_TO_SIZE  "Blocca in queste dimensioni"
 
-#define STR_MACHINE_TYPE    "Tipo di piastra madre:"
-#define STR_MACHINE        "Piastra madre:"
-#define STR_CONFIGURE        "Configura"
-#define STR_CPU_TYPE        "Tipo del CPU:"
-#define STR_CPU_SPEED        "Veloc.:"
-#define STR_FPU            "FPU:"
-#define STR_WAIT_STATES        "Stati di attesa:"
+#define STR_MACHINE_TYPE  "Tipo di piastra madre:"
+#define STR_MACHINE       "Piastra madre:"
+#define STR_CONFIGURE     "Configura"
+#define STR_CPU_TYPE      "Tipo del CPU:"
+#define STR_CPU_SPEED     "Veloc.:"
+#define STR_FPU           "FPU:"
+#define STR_WAIT_STATES   "Stati di attesa:"
 #define STR_MB            "MB"
 #define STR_MEMORY        "Memoria:"
-#define STR_TIME_SYNC        "Sincronizzazione dell'ora"
-#define STR_DISABLED        "Disabilitata"
-#define STR_ENABLED_LOCAL    "Abilitata (ora locale)"
-#define STR_ENABLED_UTC        "Abilitata (UTC)"
-#define STR_DYNAREC        "Ricompilatore dinamico"
+#define STR_TIME_SYNC     "Sincronizzazione dell'ora"
+#define STR_DISABLED      "Disabilitata"
+#define STR_ENABLED_LOCAL "Abilitata (ora locale)"
+#define STR_ENABLED_UTC   "Abilitata (UTC)"
+#define STR_DYNAREC       "Ricompilatore dinamico"
 
-#define STR_VIDEO        "Video:"
-#define STR_VIDEO_2        "Video 2:"
+#define STR_VIDEO         "Video:"
+#define STR_VIDEO_2       "Video 2:"
 #define STR_VOODOO        "Grafica Voodoo"
-#define STR_IBM8514        "Grafica IBM 8514/a"
-#define STR_XGA            "Grafica XGA"
+#define STR_IBM8514       "Grafica IBM 8514/a"
+#define STR_XGA           "Grafica XGA"
 
-#define STR_MOUSE        "Mouse:"
-#define STR_JOYSTICK        "Joystick:"
-#define STR_JOY1        "Joystick 1..."
-#define STR_JOY2        "Joystick 2..."
-#define STR_JOY3        "Joystick 3..."
-#define STR_JOY4        "Joystick 4..."
+#define STR_MOUSE         "Mouse:"
+#define STR_JOYSTICK      "Joystick:"
+#define STR_JOY1          "Joystick 1..."
+#define STR_JOY2          "Joystick 2..."
+#define STR_JOY3          "Joystick 3..."
+#define STR_JOY4          "Joystick 4..."
 
 #define STR_SOUND1        "Scheda audio 1:"
 #define STR_SOUND2        "Scheda audio 2:"
 #define STR_SOUND3        "Scheda audio 3:"
 #define STR_SOUND4        "Scheda audio 4:"
-#define STR_MIDI_OUT        "Uscita MIDI:"
-#define STR_MIDI_IN        "Entrata MIDI:"
+#define STR_MIDI_OUT      "Uscita MIDI:"
+#define STR_MIDI_IN       "Entrata MIDI:"
 #define STR_MPU401        "MPU-401 autonomo"
-#define STR_FLOAT        "Usa suono FLOAT32"
-#define STR_FM_DRIVER        "Driver sint. FM"
-#define STR_FM_DRV_NUKED    "Nuked (più accurato)"
-#define STR_FM_DRV_YMFM        "YMFM (più veloce)"
+#define STR_FLOAT         "Usa suono FLOAT32"
+#define STR_FM_DRIVER     "Driver sint. FM"
+#define STR_FM_DRV_NUKED  "Nuked (più accurato)"
+#define STR_FM_DRV_YMFM   "YMFM (più veloce)"
 
-#define STR_NET_TYPE    "Tipo di rete:"
-#define STR_PCAP        "Dispositivo PCap:"
-#define STR_NET            "Scheda di rete:"
-#define STR_NET1        "Network card 1:"
-#define STR_NET2        "Network card 2:"
-#define STR_NET3        "Network card 3:"
-#define STR_NET4        "Network card 4:"
+#define STR_NET_TYPE      "Tipo di rete:"
+#define STR_PCAP          "Dispositivo PCap:"
+#define STR_NET           "Scheda di rete:"
+#define STR_NET1          "Network card 1:"
+#define STR_NET2          "Network card 2:"
+#define STR_NET3          "Network card 3:"
+#define STR_NET4          "Network card 4:"
 
-#define STR_COM1        "Dispositivo COM1:"
-#define STR_COM2        "Dispositivo COM2:"
-#define STR_COM3        "Dispositivo COM3:"
-#define STR_COM4        "Dispositivo COM4:"
-#define STR_LPT1        "Dispositivo LPT1:"
-#define STR_LPT2        "Dispositivo LPT2:"
-#define STR_LPT3        "Dispositivo LPT3:"
-#define STR_LPT4        "Dispositivo LPT4:"
-#define STR_SERIAL1        "Porta seriale 1"
-#define STR_SERIAL2        "Porta seriale 2"
-#define STR_SERIAL3        "Porta seriale 3"
-#define STR_SERIAL4        "Porta seriale 4"
-#define STR_PARALLEL1        "Porta parallela 1"
-#define STR_PARALLEL2        "Porta parallela 2"
-#define STR_PARALLEL3        "Porta parallela 3"
-#define STR_PARALLEL4        "Porta parallela 4"
-#define STR_SERIAL_PASS1    "Serial port passthrough 1"
-#define STR_SERIAL_PASS2    "Serial port passthrough 2"
-#define STR_SERIAL_PASS3    "Serial port passthrough 3"
-#define STR_SERIAL_PASS4    "Serial port passthrough 4"
+#define STR_COM1          "Dispositivo COM1:"
+#define STR_COM2          "Dispositivo COM2:"
+#define STR_COM3          "Dispositivo COM3:"
+#define STR_COM4          "Dispositivo COM4:"
+#define STR_LPT1          "Dispositivo LPT1:"
+#define STR_LPT2          "Dispositivo LPT2:"
+#define STR_LPT3          "Dispositivo LPT3:"
+#define STR_LPT4          "Dispositivo LPT4:"
+#define STR_SERIAL1       "Porta seriale 1"
+#define STR_SERIAL2       "Porta seriale 2"
+#define STR_SERIAL3       "Porta seriale 3"
+#define STR_SERIAL4       "Porta seriale 4"
+#define STR_PARALLEL1     "Porta parallela 1"
+#define STR_PARALLEL2     "Porta parallela 2"
+#define STR_PARALLEL3     "Porta parallela 3"
+#define STR_PARALLEL4     "Porta parallela 4"
+#define STR_SERIAL_PASS1  "Serial port passthrough 1"
+#define STR_SERIAL_PASS2  "Serial port passthrough 2"
+#define STR_SERIAL_PASS3  "Serial port passthrough 3"
+#define STR_SERIAL_PASS4  "Serial port passthrough 4"
 
-#define STR_HDC            "Controller HD:"
-#define STR_FDC            "Controller FD:"
-#define STR_IDE_TER        "Controller IDE terziario"
-#define STR_IDE_QUA        "Controller IDE quaternario"
-#define STR_SCSI        "SCSI"
+#define STR_HDC           "Controller HD:"
+#define STR_FDC           "Controller FD:"
+#define STR_IDE_TER       "Controller IDE terziario"
+#define STR_IDE_QUA       "Controller IDE quaternario"
+#define STR_SCSI          "SCSI"
 #define STR_SCSI_1        "Controller 1:"
 #define STR_SCSI_2        "Controller 2:"
 #define STR_SCSI_3        "Controller 3:"
 #define STR_SCSI_4        "Controller 4:"
-#define STR_CASSETTE        "Cassetta"
+#define STR_CASSETTE      "Cassetta"
 
-#define STR_HDD            "Hard disk:"
-#define STR_NEW            "&Nuovo..."
-#define STR_EXISTING        "&Esistente..."
+#define STR_HDD           "Hard disk:"
+#define STR_NEW           "&Nuovo..."
+#define STR_EXISTING      "&Esistente..."
 #define STR_REMOVE        "&Rimouvi"
-#define STR_BUS            "Bus:"
-#define STR_CHANNEL        "Canale:"
+#define STR_BUS           "Bus:"
+#define STR_CHANNEL       "Canale:"
 #define STR_ID            "ID:"
-#define STR_SPEED        "Speed:"
+#define STR_SPEED         "Speed:"
 
-#define STR_SPECIFY        "&Specifica..."
-#define STR_SECTORS        "Settori:"
-#define STR_HEADS        "Testine:"
-#define STR_CYLS        "Cilindri:"
-#define STR_SIZE_MB        "Dimensioni (MB):"
-#define STR_TYPE        "Tipo:"
-#define STR_IMG_FORMAT        "Formato immagine:"
-#define STR_BLOCK_SIZE        "Dimensioni blocco:"
+#define STR_SPECIFY       "&Specifica..."
+#define STR_SECTORS       "Settori:"
+#define STR_HEADS         "Testine:"
+#define STR_CYLS          "Cilindri:"
+#define STR_SIZE_MB       "Dimensioni (MB):"
+#define STR_TYPE          "Tipo:"
+#define STR_IMG_FORMAT    "Formato immagine:"
+#define STR_BLOCK_SIZE    "Dimensioni blocco:"
 
-#define STR_FLOPPY_DRIVES    "Unità floppy:"
-#define STR_TURBO        "Turbo"
-#define STR_CHECKBPB        "Verifica BPB"
-#define STR_CDROM_DRIVES    "Unità CD-ROM:"
-#define STR_CD_SPEED        "Veloc.:"
-#define STR_EARLY        "Unità anteriore"
+#define STR_FLOPPY_DRIVES "Unità floppy:"
+#define STR_TURBO         "Turbo"
+#define STR_CHECKBPB      "Verifica BPB"
+#define STR_CDROM_DRIVES  "Unità CD-ROM:"
+#define STR_CD_SPEED      "Veloc.:"
+#define STR_EARLY         "Unità anteriore"
 
-#define STR_MO_DRIVES        "Unità magneto-ottiche:"
-#define STR_ZIP_DRIVES        "Unità ZIP:"
-#define STR_250            "ZIP 250"
+#define STR_MO_DRIVES     "Unità magneto-ottiche:"
+#define STR_ZIP_DRIVES    "Unità ZIP:"
+#define STR_250           "ZIP 250"
 
 #define STR_ISARTC        "RTC ISA:"
 #define STR_ISAMEM        "Espansione memoria ISA"
-#define STR_ISAMEM_1        "Scheda 1:"
-#define STR_ISAMEM_2        "Scheda 2:"
-#define STR_ISAMEM_3        "Scheda 3:"
-#define STR_ISAMEM_4        "Scheda 4:"
+#define STR_ISAMEM_1      "Scheda 1:"
+#define STR_ISAMEM_2      "Scheda 2:"
+#define STR_ISAMEM_3      "Scheda 3:"
+#define STR_ISAMEM_4      "Scheda 4:"
 #define STR_BUGGER        "Dispositivo ISABugger"
-#define STR_POSTCARD        "Scheda POST"
+#define STR_POSTCARD      "Scheda POST"
 
-#define FONT_SIZE        9
-#define FONT_NAME        "Segoe UI"
+#define FONT_SIZE         9
+#define FONT_NAME         "Segoe UI"
 
 #include "dialogs.rc"
 
@@ -393,9 +393,9 @@ END
 // String Table
 //
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
-    2048    "86Box"
+    2048        "86Box"
     IDS_2049    "Errore"
     IDS_2050    "Errore fatale"
     IDS_2051    " - PAUSED"
@@ -413,7 +413,7 @@ BEGIN
     IDS_2063    "La macchina ""%hs"" non è disponibile a causa di immagini ROM mancanti nella directory roms/machines. Cambiando ad una macchina disponibile."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2064    "La scheda video ""%hs"" non è disponibile a causa di immagini ROM mancanti nella directory roms/video. Cambiando ad una scheda video disponibile."
     IDS_2065    "Piastra madre"
@@ -433,7 +433,7 @@ BEGIN
     IDS_2079    "Premi F8+F12 o pulsante centrale per rilasciare il mouse"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2080    "Impossibile inizializzare FluidSynth"
     IDS_2081    "Bus"
@@ -545,7 +545,7 @@ BEGIN
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_4096    "Hard disk (%s)"
     IDS_4097    "%01i:%01i"
@@ -644,7 +644,7 @@ BEGIN
 
     IDS_7168    "(Predefinito del sistema)"
 END
-#define IDS_LANG_ENUS    IDS_7168
+#define IDS_LANG_ENUS IDS_7168
 
 // Italian (IT-it) resources
 /////////////////////////////////////////////////////////////////////////////

--- a/src/win/languages/ja-JP.rc
+++ b/src/win/languages/ja-JP.rc
@@ -13,122 +13,122 @@ LANGUAGE LANG_JAPANESE, SUBLANG_DEFAULT
 // Menu
 //
 
-MainMenu MENU DISCARDABLE 
+MainMenu MENU DISCARDABLE
 BEGIN
     POPUP "動作(&A)"
     BEGIN
-        MENUITEM "キーボードはキャプチャが必要(&K)",    IDM_ACTION_KBD_REQ_CAPTURE
-        MENUITEM "右CTRLを左ALTへ(&R)",    IDM_ACTION_RCTRL_IS_LALT
+        MENUITEM "キーボードはキャプチャが必要(&K)", IDM_ACTION_KBD_REQ_CAPTURE
+        MENUITEM "右CTRLを左ALTへ(&R)", IDM_ACTION_RCTRL_IS_LALT
         MENUITEM SEPARATOR
-        MENUITEM "ハードリセット(&H)...",                 IDM_ACTION_HRESET
-        MENUITEM "Ctrl+Alt+Del(&C)\tCtrl+F12",     IDM_ACTION_RESET_CAD
+        MENUITEM "ハードリセット(&H)...", IDM_ACTION_HRESET
+        MENUITEM "Ctrl+Alt+Del(&C)\tCtrl+F12", IDM_ACTION_RESET_CAD
         MENUITEM SEPARATOR
-    MENUITEM "Ctrl+Alt+Esc(&E)",        IDM_ACTION_CTRL_ALT_ESC
+    MENUITEM "Ctrl+Alt+Esc(&E)", IDM_ACTION_CTRL_ALT_ESC
         MENUITEM SEPARATOR
-        MENUITEM "一時停止(&P)",                      IDM_ACTION_PAUSE
+        MENUITEM "一時停止(&P)", IDM_ACTION_PAUSE
         MENUITEM SEPARATOR
-        MENUITEM "終了(&X)...",                       IDM_ACTION_EXIT
+        MENUITEM "終了(&X)...", IDM_ACTION_EXIT
     END
     POPUP "表示(&V)"
     BEGIN
-        MENUITEM "ステータスバーを隠す(&H)",        IDM_VID_HIDE_STATUS_BAR
-        MENUITEM "ツールバーを隠す(&T)",        IDM_VID_HIDE_TOOLBAR
+        MENUITEM "ステータスバーを隠す(&H)", IDM_VID_HIDE_STATUS_BAR
+        MENUITEM "ツールバーを隠す(&T)", IDM_VID_HIDE_TOOLBAR
         MENUITEM SEPARATOR
-        MENUITEM "&Show non-primary monitors",  IDM_VID_MONITORS
-        MENUITEM "ウィンドウのサイズをリサイズ可能(&R)",          IDM_VID_RESIZE
-        MENUITEM "ウィンドウのサイズと位置を記憶(&E)",  IDM_VID_REMEMBER
+        MENUITEM "&Show non-primary monitors", IDM_VID_MONITORS
+        MENUITEM "ウィンドウのサイズをリサイズ可能(&R)", IDM_VID_RESIZE
+        MENUITEM "ウィンドウのサイズと位置を記憶(&E)", IDM_VID_REMEMBER
         MENUITEM SEPARATOR
         POPUP "レンダラー(&N)"
         BEGIN
-            MENUITEM "SDL (ソフトウェア)(&S)",         IDM_VID_SDL_SW
-            MENUITEM "SDL (ハードウェア)(&H)",         IDM_VID_SDL_HW
-            MENUITEM "SDL (OpenGL)(&O)",           IDM_VID_SDL_OPENGL
-            MENUITEM "OpenGL (3.0コア)(&G)",      IDM_VID_OPENGL_CORE
+            MENUITEM "SDL (ソフトウェア)(&S)", IDM_VID_SDL_SW
+            MENUITEM "SDL (ハードウェア)(&H)", IDM_VID_SDL_HW
+            MENUITEM "SDL (OpenGL)(&O)", IDM_VID_SDL_OPENGL
+            MENUITEM "OpenGL (3.0コア)(&G)", IDM_VID_OPENGL_CORE
 #ifdef USE_VNC
-            MENUITEM "VNC(&V)",                    IDM_VID_VNC
+            MENUITEM "VNC(&V)", IDM_VID_VNC
 #endif
         END
         MENUITEM SEPARATOR
-        MENUITEM "ウィンドウのサイズを指定...",          IDM_VID_SPECIFY_DIM
-        MENUITEM "4:3アスペクト比を固定(&O)",    IDM_VID_FORCE43
+        MENUITEM "ウィンドウのサイズを指定...", IDM_VID_SPECIFY_DIM
+        MENUITEM "4:3アスペクト比を固定(&O)", IDM_VID_FORCE43
         POPUP "ウィンドウの表示倍率(&W)"
         BEGIN
-            MENUITEM "0.5x(&0)",                   IDM_VID_SCALE_1X
-            MENUITEM "1x(&1)",                     IDM_VID_SCALE_2X
-            MENUITEM "1.5x(&5)",                   IDM_VID_SCALE_3X
-            MENUITEM "2x(&2)",                     IDM_VID_SCALE_4X
-            MENUITEM "&3x",                        IDM_VID_SCALE_5X
-            MENUITEM "&4x",                        IDM_VID_SCALE_6X
-            MENUITEM "&5x",                        IDM_VID_SCALE_7X
-            MENUITEM "&6x",                        IDM_VID_SCALE_8X
-            MENUITEM "&7x",                        IDM_VID_SCALE_9X
-            MENUITEM "&8x",                        IDM_VID_SCALE_10X
+            MENUITEM "0.5x(&0)", IDM_VID_SCALE_1X
+            MENUITEM "1x(&1)", IDM_VID_SCALE_2X
+            MENUITEM "1.5x(&5)", IDM_VID_SCALE_3X
+            MENUITEM "2x(&2)", IDM_VID_SCALE_4X
+            MENUITEM "&3x", IDM_VID_SCALE_5X
+            MENUITEM "&4x", IDM_VID_SCALE_6X
+            MENUITEM "&5x", IDM_VID_SCALE_7X
+            MENUITEM "&6x", IDM_VID_SCALE_8X
+            MENUITEM "&7x", IDM_VID_SCALE_9X
+            MENUITEM "&8x", IDM_VID_SCALE_10X
         END
         POPUP "フィルター方式"
         BEGIN
-            MENUITEM "最近傍補間(&N)",                 IDM_VID_FILTER_NEAREST
-            MENUITEM "線形補間(&L)",                  IDM_VID_FILTER_LINEAR
+            MENUITEM "最近傍補間(&N)", IDM_VID_FILTER_NEAREST
+            MENUITEM "線形補間(&L)", IDM_VID_FILTER_LINEAR
         END
-        MENUITEM "HiDPIスケーリング(&D)",              IDM_VID_HIDPI
+        MENUITEM "HiDPIスケーリング(&D)", IDM_VID_HIDPI
         MENUITEM SEPARATOR
-        MENUITEM "フルスクリーン(&F)\tCtrl+Alt+PgUp",    IDM_VID_FULLSCREEN
+        MENUITEM "フルスクリーン(&F)\tCtrl+Alt+PgUp", IDM_VID_FULLSCREEN
         POPUP "フルスクリーンのスケール(&S)"
         BEGIN
-            MENUITEM "フルスクリーンに拡大(&F)",        IDM_VID_FS_FULL
-            MENUITEM "4:3(&4)",                        IDM_VID_FS_43
+            MENUITEM "フルスクリーンに拡大(&F)", IDM_VID_FS_FULL
+            MENUITEM "4:3(&4)", IDM_VID_FS_43
             MENUITEM "正方形ピクセル(アスペクト比を維持)(&S)", IDM_VID_FS_KEEPRATIO
-            MENUITEM "整数倍(&I)",              IDM_VID_FS_INT
+            MENUITEM "整数倍(&I)", IDM_VID_FS_INT
         END
         POPUP "E&GA/(S)VGAの設定"
         BEGIN
-            MENUITEM "色を反転(&I)",   IDM_VID_INVERT
+            MENUITEM "色を反転(&I)", IDM_VID_INVERT
             POPUP "画面タイプ(&T)"
             BEGIN
-                MENUITEM "RGB(カラー)(&C)",         IDM_VID_GRAY_RGB
-                MENUITEM "RGB(グレースケール)(&R)",   IDM_VID_GRAY_MONO
-                MENUITEM "モニター(琥珀色)(&A)",       IDM_VID_GRAY_AMBER
-                MENUITEM "モニター(緑色)(&G)",       IDM_VID_GRAY_GREEN
-                MENUITEM "モニター(白色)(&W)",       IDM_VID_GRAY_WHITE
+                MENUITEM "RGB(カラー)(&C)", IDM_VID_GRAY_RGB
+                MENUITEM "RGB(グレースケール)(&R)", IDM_VID_GRAY_MONO
+                MENUITEM "モニター(琥珀色)(&A)", IDM_VID_GRAY_AMBER
+                MENUITEM "モニター(緑色)(&G)", IDM_VID_GRAY_GREEN
+                MENUITEM "モニター(白色)(&W)", IDM_VID_GRAY_WHITE
             END
             POPUP "グレースケール変換タイプ(&C)"
             BEGIN
-                MENUITEM "BT601 (NTSC/PAL)(&6)",   IDM_VID_GRAYCT_601
-                MENUITEM "BT709 (HDTV)(&7)",       IDM_VID_GRAYCT_709
-                MENUITEM "平均(&A)",            IDM_VID_GRAYCT_AVE
+                MENUITEM "BT601 (NTSC/PAL)(&6)", IDM_VID_GRAYCT_601
+                MENUITEM "BT709 (HDTV)(&7)", IDM_VID_GRAYCT_709
+                MENUITEM "平均(&A)", IDM_VID_GRAYCT_AVE
             END
         END
         MENUITEM SEPARATOR
-        MENUITEM "CGA/PCjr/Tandy/EGA/(S)VGAオーバースキャン(&G)",     IDM_VID_OVERSCAN
+        MENUITEM "CGA/PCjr/Tandy/EGA/(S)VGAオーバースキャン(&G)", IDM_VID_OVERSCAN
         MENUITEM "単色モニター用コントラストを変更(&M)", IDM_VID_CGACON
     END
-    MENUITEM "メディア(&M)",                IDM_MEDIA
+    MENUITEM "メディア(&M)", IDM_MEDIA
     POPUP "ツール(&T)"
     BEGIN
-        MENUITEM "設定(&S)...",                IDM_CONFIG
-        MENUITEM "ステータスバーのアイコンを更新(&U)",    IDM_UPDATE_ICONS
+        MENUITEM "設定(&S)...", IDM_CONFIG
+        MENUITEM "ステータスバーのアイコンを更新(&U)", IDM_UPDATE_ICONS
         MENUITEM SEPARATOR
-        MENUITEM "スクリーンショットを撮る(&C)\tCtrl+F11",  IDM_ACTION_SCREENSHOT
+        MENUITEM "スクリーンショットを撮る(&C)\tCtrl+F11", IDM_ACTION_SCREENSHOT
         MENUITEM SEPARATOR
-        MENUITEM "環境設定(&P)...",    IDM_PREFERENCES
+        MENUITEM "環境設定(&P)...", IDM_PREFERENCES
 #ifdef DISCORD
         MENUITEM "Discordとの連携機能(&D)", IDM_DISCORD
 #endif
         MENUITEM SEPARATOR
-        MENUITEM "音量を調節(&G)...",              IDM_SND_GAIN
+        MENUITEM "音量を調節(&G)...", IDM_SND_GAIN
 #ifdef MTR_ENABLED
         MENUITEM SEPARATOR
-        MENUITEM "トレース開始\tCtrl+T",         IDM_ACTION_BEGIN_TRACE
-        MENUITEM "トレース終了\tCtrl+T",           IDM_ACTION_END_TRACE
+        MENUITEM "トレース開始\tCtrl+T", IDM_ACTION_BEGIN_TRACE
+        MENUITEM "トレース終了\tCtrl+T", IDM_ACTION_END_TRACE
 #endif
     END
     POPUP "ヘルプ(&H)"
     BEGIN
-        MENUITEM "ドキュメント(&D)...",           IDM_DOCS
-        MENUITEM "86Boxのバージョン情報(&A)...",        IDM_ABOUT
+        MENUITEM "ドキュメント(&D)...", IDM_DOCS
+        MENUITEM "86Boxのバージョン情報(&A)...", IDM_ABOUT
     END
 END
 
-StatusBarMenu MENU DISCARDABLE 
+StatusBarMenu MENU DISCARDABLE
 BEGIN
     MENUITEM SEPARATOR
 END
@@ -137,17 +137,17 @@ CassetteSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "新規イメージ(&N)...",                IDM_CASSETTE_IMAGE_NEW
+        MENUITEM "新規イメージ(&N)...", IDM_CASSETTE_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "既存のイメージを開く(&E)...",                IDM_CASSETTE_IMAGE_EXISTING
-        MENUITEM "既存のイメージを開く(書き込み保護)(&W)...",        IDM_CASSETTE_IMAGE_EXISTING_WP
+        MENUITEM "既存のイメージを開く(&E)...", IDM_CASSETTE_IMAGE_EXISTING
+        MENUITEM "既存のイメージを開く(書き込み保護)(&W)...", IDM_CASSETTE_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "録音(&R)",                    IDM_CASSETTE_RECORD
-        MENUITEM "再生(&P)",                    IDM_CASSETTE_PLAY
-        MENUITEM "冒頭に巻き戻す(&R)",                IDM_CASSETTE_REWIND
-        MENUITEM "最後まで早送り(&F)",                IDM_CASSETTE_FAST_FORWARD
+        MENUITEM "録音(&R)", IDM_CASSETTE_RECORD
+        MENUITEM "再生(&P)", IDM_CASSETTE_PLAY
+        MENUITEM "冒頭に巻き戻す(&R)", IDM_CASSETTE_REWIND
+        MENUITEM "最後まで早送り(&F)", IDM_CASSETTE_FAST_FORWARD
         MENUITEM SEPARATOR
-        MENUITEM "取り出す(&J)",                    IDM_CASSETTE_EJECT
+        MENUITEM "取り出す(&J)", IDM_CASSETTE_EJECT
     END
 END
 
@@ -155,9 +155,9 @@ CartridgeSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "イメージ(&I)...",                IDM_CARTRIDGE_IMAGE
+        MENUITEM "イメージ(&I)...", IDM_CARTRIDGE_IMAGE
         MENUITEM SEPARATOR
-        MENUITEM "取り出す(&J)",                    IDM_CARTRIDGE_EJECT
+        MENUITEM "取り出す(&J)", IDM_CARTRIDGE_EJECT
     END
 END
 
@@ -165,14 +165,14 @@ FloppySubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "新規イメージ(&N)...",                IDM_FLOPPY_IMAGE_NEW
+        MENUITEM "新規イメージ(&N)...", IDM_FLOPPY_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "既存のイメージを開く(&E)...",                IDM_FLOPPY_IMAGE_EXISTING
-        MENUITEM "既存のイメージを開く(書き込み保護)(&W)...",        IDM_FLOPPY_IMAGE_EXISTING_WP
+        MENUITEM "既存のイメージを開く(&E)...", IDM_FLOPPY_IMAGE_EXISTING
+        MENUITEM "既存のイメージを開く(書き込み保護)(&W)...", IDM_FLOPPY_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "86Fイメージにエクスポート(&X)...",            IDM_FLOPPY_EXPORT_TO_86F
+        MENUITEM "86Fイメージにエクスポート(&X)...", IDM_FLOPPY_EXPORT_TO_86F
         MENUITEM SEPARATOR
-        MENUITEM "取り出す(&J)",                    IDM_FLOPPY_EJECT
+        MENUITEM "取り出す(&J)", IDM_FLOPPY_EJECT
     END
 END
 
@@ -180,13 +180,13 @@ CdromSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "ミュート(&M)",                    IDM_CDROM_MUTE
+        MENUITEM "ミュート(&M)", IDM_CDROM_MUTE
         MENUITEM SEPARATOR
-        MENUITEM "空(&M)",                    IDM_CDROM_EMPTY
-        MENUITEM "前のイメージを再読み込み(&R)",            IDM_CDROM_RELOAD
+        MENUITEM "空(&M)", IDM_CDROM_EMPTY
+        MENUITEM "前のイメージを再読み込み(&R)", IDM_CDROM_RELOAD
         MENUITEM SEPARATOR
-        MENUITEM "イメージ(&I)...",                    IDM_CDROM_IMAGE
-        MENUITEM "フォルダ(&F)...",                    IDM_CDROM_DIR
+        MENUITEM "イメージ(&I)...", IDM_CDROM_IMAGE
+        MENUITEM "フォルダ(&F)...", IDM_CDROM_DIR
     END
 END
 
@@ -194,13 +194,13 @@ ZIPSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "新規イメージ(&N)...",                IDM_ZIP_IMAGE_NEW
+        MENUITEM "新規イメージ(&N)...", IDM_ZIP_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "既存のイメージを開く(&E)...",                IDM_ZIP_IMAGE_EXISTING
-        MENUITEM "既存のイメージを開く(書き込み保護)(&W)...",        IDM_ZIP_IMAGE_EXISTING_WP
+        MENUITEM "既存のイメージを開く(&E)...", IDM_ZIP_IMAGE_EXISTING
+        MENUITEM "既存のイメージを開く(書き込み保護)(&W)...", IDM_ZIP_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "取り出す(&J)",                    IDM_ZIP_EJECT
-        MENUITEM "前のイメージを再読み込み(&R)",            IDM_ZIP_RELOAD
+        MENUITEM "取り出す(&J)", IDM_ZIP_EJECT
+        MENUITEM "前のイメージを再読み込み(&R)", IDM_ZIP_RELOAD
     END
 END
 
@@ -208,13 +208,13 @@ MOSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "新規イメージ(&N)...",                IDM_MO_IMAGE_NEW
+        MENUITEM "新規イメージ(&N)...", IDM_MO_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "既存のイメージを開く(&E)...",                IDM_MO_IMAGE_EXISTING
-        MENUITEM "既存のイメージを開く(書き込み保護)(&W)...",        IDM_MO_IMAGE_EXISTING_WP
+        MENUITEM "既存のイメージを開く(&E)...", IDM_MO_IMAGE_EXISTING
+        MENUITEM "既存のイメージを開く(書き込み保護)(&W)...", IDM_MO_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "取り出す(&J)",                    IDM_MO_EJECT
-        MENUITEM "前のイメージを再読み込み(&R)",            IDM_MO_RELOAD
+        MENUITEM "取り出す(&J)", IDM_MO_EJECT
+        MENUITEM "前のイメージを再読み込み(&R)", IDM_MO_RELOAD
     END
 END
 
@@ -240,150 +240,150 @@ END
 // Dialog
 //
 
-#define STR_PREFERENCES        "環境設定"
-#define STR_SND_GAIN        "音量ゲイン"
-#define STR_NEW_FLOPPY        "新規のイメージ"
+#define STR_PREFERENCES   "環境設定"
+#define STR_SND_GAIN      "音量ゲイン"
+#define STR_NEW_FLOPPY    "新規のイメージ"
 #define STR_CONFIG        "設定"
-#define STR_SPECIFY_DIM        "メインウィンドウのサイズ指定"
+#define STR_SPECIFY_DIM   "メインウィンドウのサイズ指定"
 
 #define STR_OK            "OK"
 #define STR_CANCEL        "キャンセル"
 #define STR_GLOBAL        "これらの設定をグローバル既定値として保存する(&G)"
-#define STR_DEFAULT        "既定値(&D)"
-#define STR_LANGUAGE        "言語:"
-#define STR_ICONSET        "アイコンセット:"
+#define STR_DEFAULT       "既定値(&D)"
+#define STR_LANGUAGE      "言語:"
+#define STR_ICONSET       "アイコンセット:"
 
-#define STR_GAIN        "ゲイン値"
+#define STR_GAIN          "ゲイン値"
 
-#define STR_FILE_NAME        "ファイル名:"
-#define STR_DISK_SIZE        "ディスクサイズ:"
-#define STR_RPM_MODE        "回転数モード:"
-#define STR_PROGRESS        "進行状況:"
+#define STR_FILE_NAME     "ファイル名:"
+#define STR_DISK_SIZE     "ディスクサイズ:"
+#define STR_RPM_MODE      "回転数モード:"
+#define STR_PROGRESS      "進行状況:"
 
-#define STR_WIDTH        "幅:"
+#define STR_WIDTH         "幅:"
 #define STR_HEIGHT        "高さ:"
-#define STR_LOCK_TO_SIZE    "このサイズをロックする"
+#define STR_LOCK_TO_SIZE  "このサイズをロックする"
 
-#define STR_MACHINE_TYPE    "マシンタイプ:"
-#define STR_MACHINE        "マシン:"
-#define STR_CONFIGURE        "設定"
-#define STR_CPU_TYPE        "CPUタイプ:"
-#define STR_CPU_SPEED        "速度:"
-#define STR_FPU            "FPU:"
-#define STR_WAIT_STATES        "待機状態:"
+#define STR_MACHINE_TYPE  "マシンタイプ:"
+#define STR_MACHINE       "マシン:"
+#define STR_CONFIGURE     "設定"
+#define STR_CPU_TYPE      "CPUタイプ:"
+#define STR_CPU_SPEED     "速度:"
+#define STR_FPU           "FPU:"
+#define STR_WAIT_STATES   "待機状態:"
 #define STR_MB            "MB"
 #define STR_MEMORY        "メモリ:"
-#define STR_TIME_SYNC        "時刻同期機能"
-#define STR_DISABLED        "無効にする"
-#define STR_ENABLED_LOCAL    "有効にする (現地時間)"
-#define STR_ENABLED_UTC        "有効にする (UTC)"
-#define STR_DYNAREC        "動的リコンパイラ"
+#define STR_TIME_SYNC     "時刻同期機能"
+#define STR_DISABLED      "無効にする"
+#define STR_ENABLED_LOCAL "有効にする (現地時間)"
+#define STR_ENABLED_UTC   "有効にする (UTC)"
+#define STR_DYNAREC       "動的リコンパイラ"
 
-#define STR_VIDEO        "ビデオカード:"
-#define STR_VIDEO_2        "ビデオカード 2:"
+#define STR_VIDEO         "ビデオカード:"
+#define STR_VIDEO_2       "ビデオカード 2:"
 #define STR_VOODOO        "Voodooグラフィック"
-#define STR_IBM8514        "IBM 8514/aグラフィック"
-#define STR_XGA            "XGAグラフィック"
+#define STR_IBM8514       "IBM 8514/aグラフィック"
+#define STR_XGA           "XGAグラフィック"
 
-#define STR_MOUSE        "マウス:"
-#define STR_JOYSTICK        "ジョイスティック:"
-#define STR_JOY1        "ジョイスティック1..."
-#define STR_JOY2        "ジョイスティック2..."
-#define STR_JOY3        "ジョイスティック3..."
-#define STR_JOY4        "ジョイスティック4..."
+#define STR_MOUSE         "マウス:"
+#define STR_JOYSTICK      "ジョイスティック:"
+#define STR_JOY1          "ジョイスティック1..."
+#define STR_JOY2          "ジョイスティック2..."
+#define STR_JOY3          "ジョイスティック3..."
+#define STR_JOY4          "ジョイスティック4..."
 
 #define STR_SOUND1        "サウンドカード 1:"
 #define STR_SOUND2        "サウンドカード 2:"
 #define STR_SOUND3        "サウンドカード 3:"
 #define STR_SOUND4        "サウンドカード 4:"
-#define STR_MIDI_OUT        "MIDI出力デバイス:"
-#define STR_MIDI_IN        "MIDI入力デバイス:"
+#define STR_MIDI_OUT      "MIDI出力デバイス:"
+#define STR_MIDI_IN       "MIDI入力デバイス:"
 #define STR_MPU401        "独立型MPU-401"
-#define STR_FLOAT        "FLOAT32サウンドを使用する"
-#define STR_FM_DRIVER        "FMシンセドライバー"
-#define STR_FM_DRV_NUKED    "Nuked (高精度化)"
-#define STR_FM_DRV_YMFM        "YMFM (より速く)"
+#define STR_FLOAT         "FLOAT32サウンドを使用する"
+#define STR_FM_DRIVER     "FMシンセドライバー"
+#define STR_FM_DRV_NUKED  "Nuked (高精度化)"
+#define STR_FM_DRV_YMFM   "YMFM (より速く)"
 
-#define STR_NET_TYPE    "ネットワークタイプ:"
-#define STR_PCAP        "PCapデバイス:"
-#define STR_NET            "ネットワークアダプター:"
-#define STR_NET1        "Network card 1:"
-#define STR_NET2        "Network card 2:"
-#define STR_NET3        "Network card 3:"
-#define STR_NET4        "Network card 4:"
+#define STR_NET_TYPE      "ネットワークタイプ:"
+#define STR_PCAP          "PCapデバイス:"
+#define STR_NET           "ネットワークアダプター:"
+#define STR_NET1          "Network card 1:"
+#define STR_NET2          "Network card 2:"
+#define STR_NET3          "Network card 3:"
+#define STR_NET4          "Network card 4:"
 
-#define STR_COM1        "COM1デバイス:"
-#define STR_COM2        "COM2デバイス:"
-#define STR_COM3        "COM3デバイス:"
-#define STR_COM4        "COM4デバイス:"
-#define STR_LPT1        "LPT1デバイス:"
-#define STR_LPT2        "LPT2デバイス:"
-#define STR_LPT3        "LPT3デバイス:"
-#define STR_LPT4        "LPT4デバイス:"
-#define STR_SERIAL1        "シリアルポート1"
-#define STR_SERIAL2        "シリアルポート2"
-#define STR_SERIAL3        "シリアルポート3"
-#define STR_SERIAL4        "シリアルポート4"
-#define STR_PARALLEL1        "パラレルポート1"
-#define STR_PARALLEL2        "パラレルポート2"
-#define STR_PARALLEL3        "パラレルポート3"
-#define STR_PARALLEL4        "パラレルポート4"
-#define STR_SERIAL_PASS1    "Serial port passthrough 1"
-#define STR_SERIAL_PASS2    "Serial port passthrough 2"
-#define STR_SERIAL_PASS3    "Serial port passthrough 3"
-#define STR_SERIAL_PASS4    "Serial port passthrough 4"
+#define STR_COM1          "COM1デバイス:"
+#define STR_COM2          "COM2デバイス:"
+#define STR_COM3          "COM3デバイス:"
+#define STR_COM4          "COM4デバイス:"
+#define STR_LPT1          "LPT1デバイス:"
+#define STR_LPT2          "LPT2デバイス:"
+#define STR_LPT3          "LPT3デバイス:"
+#define STR_LPT4          "LPT4デバイス:"
+#define STR_SERIAL1       "シリアルポート1"
+#define STR_SERIAL2       "シリアルポート2"
+#define STR_SERIAL3       "シリアルポート3"
+#define STR_SERIAL4       "シリアルポート4"
+#define STR_PARALLEL1     "パラレルポート1"
+#define STR_PARALLEL2     "パラレルポート2"
+#define STR_PARALLEL3     "パラレルポート3"
+#define STR_PARALLEL4     "パラレルポート4"
+#define STR_SERIAL_PASS1  "Serial port passthrough 1"
+#define STR_SERIAL_PASS2  "Serial port passthrough 2"
+#define STR_SERIAL_PASS3  "Serial port passthrough 3"
+#define STR_SERIAL_PASS4  "Serial port passthrough 4"
 
-#define STR_HDC            "HDコントローラー:"
-#define STR_FDC            "FDコントローラー:"
-#define STR_IDE_TER        "第三のIDEコントローラー"
-#define STR_IDE_QUA        "第四のIDEコントローラー"
-#define STR_SCSI        "SCSI"
+#define STR_HDC           "HDコントローラー:"
+#define STR_FDC           "FDコントローラー:"
+#define STR_IDE_TER       "第三のIDEコントローラー"
+#define STR_IDE_QUA       "第四のIDEコントローラー"
+#define STR_SCSI          "SCSI"
 #define STR_SCSI_1        "コントローラー1:"
 #define STR_SCSI_2        "コントローラー2:"
 #define STR_SCSI_3        "コントローラー3:"
 #define STR_SCSI_4        "コントローラー4:"
-#define STR_CASSETTE        "カセット"
+#define STR_CASSETTE      "カセット"
 
-#define STR_HDD            "ハードディスク:"
-#define STR_NEW            "新規(&N)..."
-#define STR_EXISTING        "既定(&E)..."
+#define STR_HDD           "ハードディスク:"
+#define STR_NEW           "新規(&N)..."
+#define STR_EXISTING      "既定(&E)..."
 #define STR_REMOVE        "除去(&R)"
-#define STR_BUS            "バス:"
-#define STR_CHANNEL        "チャンネル:"
+#define STR_BUS           "バス:"
+#define STR_CHANNEL       "チャンネル:"
 #define STR_ID            "ID:"
-#define STR_SPEED        "Speed:"
+#define STR_SPEED         "Speed:"
 
-#define STR_SPECIFY        "参照(&S)..."
-#define STR_SECTORS        "セクター:"
-#define STR_HEADS        "ヘッド:"
-#define STR_CYLS        "シリンダー:"
-#define STR_SIZE_MB        "サイズ(MB):"
-#define STR_TYPE        "タイプ:"
-#define STR_IMG_FORMAT        "イメージ形式:"
-#define STR_BLOCK_SIZE        "ブロックサイズ:"
+#define STR_SPECIFY       "参照(&S)..."
+#define STR_SECTORS       "セクター:"
+#define STR_HEADS         "ヘッド:"
+#define STR_CYLS          "シリンダー:"
+#define STR_SIZE_MB       "サイズ(MB):"
+#define STR_TYPE          "タイプ:"
+#define STR_IMG_FORMAT    "イメージ形式:"
+#define STR_BLOCK_SIZE    "ブロックサイズ:"
 
-#define STR_FLOPPY_DRIVES    "フロッピードライブ:"
-#define STR_TURBO        "高速タイミング"
-#define STR_CHECKBPB        "BPBをチェック"
-#define STR_CDROM_DRIVES    "CD-ROMドライブ:"
-#define STR_CD_SPEED        "速度:"
-#define STR_EARLY        "アーリードライブ"
+#define STR_FLOPPY_DRIVES "フロッピードライブ:"
+#define STR_TURBO         "高速タイミング"
+#define STR_CHECKBPB      "BPBをチェック"
+#define STR_CDROM_DRIVES  "CD-ROMドライブ:"
+#define STR_CD_SPEED      "速度:"
+#define STR_EARLY         "アーリードライブ"
 
-#define STR_MO_DRIVES        "光磁気ドライブ:"
-#define STR_ZIP_DRIVES        "ZIPドライブ:"
-#define STR_250            "ZIP 250"
+#define STR_MO_DRIVES     "光磁気ドライブ:"
+#define STR_ZIP_DRIVES    "ZIPドライブ:"
+#define STR_250           "ZIP 250"
 
 #define STR_ISARTC        "ISA RTCカード:"
 #define STR_ISAMEM        "ISAメモリー拡張カード"
-#define STR_ISAMEM_1        "カード1:"
-#define STR_ISAMEM_2        "カード2:"
-#define STR_ISAMEM_3        "カード3:"
-#define STR_ISAMEM_4        "カード4:"
+#define STR_ISAMEM_1      "カード1:"
+#define STR_ISAMEM_2      "カード2:"
+#define STR_ISAMEM_3      "カード3:"
+#define STR_ISAMEM_4      "カード4:"
 #define STR_BUGGER        "ISABuggerデバイス"
-#define STR_POSTCARD        "POSTカード"
+#define STR_POSTCARD      "POSTカード"
 
-#define FONT_SIZE        9
-#define FONT_NAME        "Meiryo UI"
+#define FONT_SIZE         9
+#define FONT_NAME         "Meiryo UI"
 
 #include "dialogs.rc"
 
@@ -392,9 +392,9 @@ END
 // String Table
 //
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
-    2048    "86Box"
+    2048        "86Box"
     IDS_2049    "エラー"
     IDS_2050    "致命的なエラー"
     IDS_2051    " - 一時停止"
@@ -412,7 +412,7 @@ BEGIN
     IDS_2063    "roms/machinesディレクトリにROMがないため、マシン「%hs」は使用できません。使用可能なマシンに切り替えます。"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2064    "roms/videoディレクトリにROMがないため、ビデオカード「%hs」は使用できません。使用可能なビデオカードに切り替えます。"
     IDS_2065    "マシン"
@@ -432,7 +432,7 @@ BEGIN
     IDS_2079    "F8+F12キーまたは中ボタンでマウスを解放します"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2080    "FluidSynthが初期化できません"
     IDS_2081    "バス"
@@ -544,7 +544,7 @@ BEGIN
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_4096    "ハードディスク (%s)"
     IDS_4097    "%01i:%01i"
@@ -643,7 +643,7 @@ BEGIN
 
     IDS_7168    "(システム既定値)"
 END
-#define IDS_LANG_ENUS    IDS_7168
+#define IDS_LANG_ENUS IDS_7168
 
 // Japanese resources
 /////////////////////////////////////////////////////////////////////////////

--- a/src/win/languages/ko-KR.rc
+++ b/src/win/languages/ko-KR.rc
@@ -13,122 +13,122 @@ LANGUAGE LANG_KOREAN, SUBLANG_DEFAULT
 // Menu
 //
 
-MainMenu MENU DISCARDABLE 
+MainMenu MENU DISCARDABLE
 BEGIN
     POPUP "동작(&A)"
     BEGIN
-        MENUITEM "키보드는 캡쳐가 필요함(&K)",    IDM_ACTION_KBD_REQ_CAPTURE
-        MENUITEM "우측CTRL로 좌측ALT 입력(&R)",    IDM_ACTION_RCTRL_IS_LALT
+        MENUITEM "키보드는 캡쳐가 필요함(&K)", IDM_ACTION_KBD_REQ_CAPTURE
+        MENUITEM "우측CTRL로 좌측ALT 입력(&R)", IDM_ACTION_RCTRL_IS_LALT
         MENUITEM SEPARATOR
-        MENUITEM "재시작(&H)...",                 IDM_ACTION_HRESET
-        MENUITEM "Ctrl+Alt+Del(&C)\tCtrl+F12",     IDM_ACTION_RESET_CAD
+        MENUITEM "재시작(&H)...", IDM_ACTION_HRESET
+        MENUITEM "Ctrl+Alt+Del(&C)\tCtrl+F12", IDM_ACTION_RESET_CAD
         MENUITEM SEPARATOR
-    MENUITEM "Ctrl+Alt+Esc(&E)",        IDM_ACTION_CTRL_ALT_ESC
+    MENUITEM "Ctrl+Alt+Esc(&E)", IDM_ACTION_CTRL_ALT_ESC
         MENUITEM SEPARATOR
-        MENUITEM "일시정지(&P)",                      IDM_ACTION_PAUSE
+        MENUITEM "일시정지(&P)", IDM_ACTION_PAUSE
         MENUITEM SEPARATOR
-        MENUITEM "끝내기(&X)...",                       IDM_ACTION_EXIT
+        MENUITEM "끝내기(&X)...", IDM_ACTION_EXIT
     END
     POPUP "표시(&V)"
     BEGIN
-        MENUITEM "상태 바 숨기기(&H)",        IDM_VID_HIDE_STATUS_BAR
-        MENUITEM "Hide &toolbar",        IDM_VID_HIDE_TOOLBAR
+        MENUITEM "상태 바 숨기기(&H)", IDM_VID_HIDE_STATUS_BAR
+        MENUITEM "Hide &toolbar", IDM_VID_HIDE_TOOLBAR
         MENUITEM SEPARATOR
-        MENUITEM "&Show non-primary monitors",  IDM_VID_MONITORS
-        MENUITEM "창 크기 조절 가능하게 하기(&R)",          IDM_VID_RESIZE
-        MENUITEM "창 크기와 위치를 기억하기(&E)",  IDM_VID_REMEMBER
+        MENUITEM "&Show non-primary monitors", IDM_VID_MONITORS
+        MENUITEM "창 크기 조절 가능하게 하기(&R)", IDM_VID_RESIZE
+        MENUITEM "창 크기와 위치를 기억하기(&E)", IDM_VID_REMEMBER
         MENUITEM SEPARATOR
         POPUP "렌더러(&N)"
         BEGIN
-            MENUITEM "SDL (소프트웨어)(&S)",         IDM_VID_SDL_SW
-            MENUITEM "SDL (하드웨어)(&H)",         IDM_VID_SDL_HW
-            MENUITEM "SDL (OpenGL)(&O)",           IDM_VID_SDL_OPENGL
-            MENUITEM "OpenGL (3.0 코어)(&G)",      IDM_VID_OPENGL_CORE
+            MENUITEM "SDL (소프트웨어)(&S)", IDM_VID_SDL_SW
+            MENUITEM "SDL (하드웨어)(&H)", IDM_VID_SDL_HW
+            MENUITEM "SDL (OpenGL)(&O)", IDM_VID_SDL_OPENGL
+            MENUITEM "OpenGL (3.0 코어)(&G)", IDM_VID_OPENGL_CORE
 #ifdef USE_VNC
-            MENUITEM "VNC(&V)",                    IDM_VID_VNC
+            MENUITEM "VNC(&V)", IDM_VID_VNC
 #endif
         END
         MENUITEM SEPARATOR
-        MENUITEM "창 크기 지정하기...",          IDM_VID_SPECIFY_DIM
-        MENUITEM "화면 비율을 4:3으로 맞추기(&O)",    IDM_VID_FORCE43
+        MENUITEM "창 크기 지정하기...", IDM_VID_SPECIFY_DIM
+        MENUITEM "화면 비율을 4:3으로 맞추기(&O)", IDM_VID_FORCE43
         POPUP "창 표시 배율(&W)"
         BEGIN
-            MENUITEM "0.5배(&0)",                   IDM_VID_SCALE_1X
-            MENUITEM "1배(&1)",                     IDM_VID_SCALE_2X
-            MENUITEM "1.5배(&5)",                   IDM_VID_SCALE_3X
-            MENUITEM "2배(&2)",                     IDM_VID_SCALE_4X
-            MENUITEM "&3배",                        IDM_VID_SCALE_5X
-            MENUITEM "&4배",                        IDM_VID_SCALE_6X
-            MENUITEM "&5배",                        IDM_VID_SCALE_7X
-            MENUITEM "&6배",                        IDM_VID_SCALE_8X
-            MENUITEM "&7배",                        IDM_VID_SCALE_9X
-            MENUITEM "&8배",                        IDM_VID_SCALE_10X
+            MENUITEM "0.5배(&0)", IDM_VID_SCALE_1X
+            MENUITEM "1배(&1)", IDM_VID_SCALE_2X
+            MENUITEM "1.5배(&5)", IDM_VID_SCALE_3X
+            MENUITEM "2배(&2)", IDM_VID_SCALE_4X
+            MENUITEM "&3배", IDM_VID_SCALE_5X
+            MENUITEM "&4배", IDM_VID_SCALE_6X
+            MENUITEM "&5배", IDM_VID_SCALE_7X
+            MENUITEM "&6배", IDM_VID_SCALE_8X
+            MENUITEM "&7배", IDM_VID_SCALE_9X
+            MENUITEM "&8배", IDM_VID_SCALE_10X
         END
         POPUP "필터 형식"
         BEGIN
-            MENUITEM "최근방 이웃 보간법(&N)",                 IDM_VID_FILTER_NEAREST
-            MENUITEM "선형 보간법(&L)",                  IDM_VID_FILTER_LINEAR
+            MENUITEM "최근방 이웃 보간법(&N)", IDM_VID_FILTER_NEAREST
+            MENUITEM "선형 보간법(&L)", IDM_VID_FILTER_LINEAR
         END
-        MENUITEM "HiDPI 스케일링(&D)",              IDM_VID_HIDPI
+        MENUITEM "HiDPI 스케일링(&D)", IDM_VID_HIDPI
         MENUITEM SEPARATOR
-        MENUITEM "전체 화면(&F)\tCtrl+Alt+PgUp",    IDM_VID_FULLSCREEN
+        MENUITEM "전체 화면(&F)\tCtrl+Alt+PgUp", IDM_VID_FULLSCREEN
         POPUP "전체 화면 비율(&S)"
         BEGIN
-            MENUITEM "전체 화면으로 확대(&F)",        IDM_VID_FS_FULL
-            MENUITEM "4:3(&4)",                        IDM_VID_FS_43
+            MENUITEM "전체 화면으로 확대(&F)", IDM_VID_FS_FULL
+            MENUITEM "4:3(&4)", IDM_VID_FS_43
             MENUITEM "정사각형 픽셀 (비율 유지)(&S)", IDM_VID_FS_KEEPRATIO
-            MENUITEM "정수배 확대(&I)",              IDM_VID_FS_INT
+            MENUITEM "정수배 확대(&I)", IDM_VID_FS_INT
         END
         POPUP "E&GA/(S)VGA 설정"
         BEGIN
-            MENUITEM "색상 반전된 VGA 모니터(&I)",   IDM_VID_INVERT
+            MENUITEM "색상 반전된 VGA 모니터(&I)", IDM_VID_INVERT
             POPUP "VGA 화면 종류(&T)"
             BEGIN
-                MENUITEM "RGB 천연색(&C)",         IDM_VID_GRAY_RGB
-                MENUITEM "RGB 회색조(&R)",   IDM_VID_GRAY_MONO
-                MENUITEM "주황색 모니터(&A)",       IDM_VID_GRAY_AMBER
-                MENUITEM "녹색 모니터(&G)",       IDM_VID_GRAY_GREEN
-                MENUITEM "흰색 모니터(&W)",       IDM_VID_GRAY_WHITE
+                MENUITEM "RGB 천연색(&C)", IDM_VID_GRAY_RGB
+                MENUITEM "RGB 회색조(&R)", IDM_VID_GRAY_MONO
+                MENUITEM "주황색 모니터(&A)", IDM_VID_GRAY_AMBER
+                MENUITEM "녹색 모니터(&G)", IDM_VID_GRAY_GREEN
+                MENUITEM "흰색 모니터(&W)", IDM_VID_GRAY_WHITE
             END
             POPUP "회색조 표현방식(&C)"
             BEGIN
-                MENUITEM "BT601 (NTSC/PAL)(&6)",   IDM_VID_GRAYCT_601
-                MENUITEM "BT709 (HDTV)(&7)",       IDM_VID_GRAYCT_709
-                MENUITEM "평균값(&A)",            IDM_VID_GRAYCT_AVE
+                MENUITEM "BT601 (NTSC/PAL)(&6)", IDM_VID_GRAYCT_601
+                MENUITEM "BT709 (HDTV)(&7)", IDM_VID_GRAYCT_709
+                MENUITEM "평균값(&A)", IDM_VID_GRAYCT_AVE
             END
         END
         MENUITEM SEPARATOR
-        MENUITEM "CGA/PCjr/Tandy/EGA/(S)VGA 오버스캔(&G)",     IDM_VID_OVERSCAN
+        MENUITEM "CGA/PCjr/Tandy/EGA/(S)VGA 오버스캔(&G)", IDM_VID_OVERSCAN
         MENUITEM "흑백 표시를 위한 밝기 조정(&M)", IDM_VID_CGACON
     END
-    MENUITEM "미디어(&M)",                IDM_MEDIA
+    MENUITEM "미디어(&M)", IDM_MEDIA
     POPUP "도구(&T)"
     BEGIN
-        MENUITEM "설정(&S)...",                IDM_CONFIG
-        MENUITEM "상태 바 아이콘 갱신하기(&U)",    IDM_UPDATE_ICONS
+        MENUITEM "설정(&S)...", IDM_CONFIG
+        MENUITEM "상태 바 아이콘 갱신하기(&U)", IDM_UPDATE_ICONS
         MENUITEM SEPARATOR
-        MENUITEM "스크린샷 찍기(&C)\tCtrl+F11",  IDM_ACTION_SCREENSHOT
+        MENUITEM "스크린샷 찍기(&C)\tCtrl+F11", IDM_ACTION_SCREENSHOT
         MENUITEM SEPARATOR
-        MENUITEM "환경설정(&P)...",    IDM_PREFERENCES
+        MENUITEM "환경설정(&P)...", IDM_PREFERENCES
 #ifdef DISCORD
         MENUITEM "디스코드 연동 활성화하기(&D)", IDM_DISCORD
 #endif
         MENUITEM SEPARATOR
-        MENUITEM "음량 증폭(&G)...",              IDM_SND_GAIN
+        MENUITEM "음량 증폭(&G)...", IDM_SND_GAIN
 #ifdef MTR_ENABLED
         MENUITEM SEPARATOR
-        MENUITEM "추적 시작하기\tCtrl+T",         IDM_ACTION_BEGIN_TRACE
-        MENUITEM "추적 끝내기\tCtrl+T",           IDM_ACTION_END_TRACE
+        MENUITEM "추적 시작하기\tCtrl+T", IDM_ACTION_BEGIN_TRACE
+        MENUITEM "추적 끝내기\tCtrl+T", IDM_ACTION_END_TRACE
 #endif
     END
     POPUP "도움말(&H)"
     BEGIN
-        MENUITEM "문서(&D)...",           IDM_DOCS
-        MENUITEM "86Box에 대해(&A)...",        IDM_ABOUT
+        MENUITEM "문서(&D)...", IDM_DOCS
+        MENUITEM "86Box에 대해(&A)...", IDM_ABOUT
     END
 END
 
-StatusBarMenu MENU DISCARDABLE 
+StatusBarMenu MENU DISCARDABLE
 BEGIN
     MENUITEM SEPARATOR
 END
@@ -137,17 +137,17 @@ CassetteSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "새 이미지(&N)...",                IDM_CASSETTE_IMAGE_NEW
+        MENUITEM "새 이미지(&N)...", IDM_CASSETTE_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "이미지 불러오기(&E)...",                IDM_CASSETTE_IMAGE_EXISTING
-        MENUITEM "이미지 불러오기 (쓰기방지)(&W)...",        IDM_CASSETTE_IMAGE_EXISTING_WP
+        MENUITEM "이미지 불러오기(&E)...", IDM_CASSETTE_IMAGE_EXISTING
+        MENUITEM "이미지 불러오기 (쓰기방지)(&W)...", IDM_CASSETTE_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "녹음하기(&R)",                    IDM_CASSETTE_RECORD
-        MENUITEM "재생하기(&P)",                    IDM_CASSETTE_PLAY
-        MENUITEM "맨앞으로 되감기(&R)",                IDM_CASSETTE_REWIND
-        MENUITEM "맨끝으로 빨리감기(&F)",                IDM_CASSETTE_FAST_FORWARD
+        MENUITEM "녹음하기(&R)", IDM_CASSETTE_RECORD
+        MENUITEM "재생하기(&P)", IDM_CASSETTE_PLAY
+        MENUITEM "맨앞으로 되감기(&R)", IDM_CASSETTE_REWIND
+        MENUITEM "맨끝으로 빨리감기(&F)", IDM_CASSETTE_FAST_FORWARD
         MENUITEM SEPARATOR
-        MENUITEM "꺼내기(&J)",                    IDM_CASSETTE_EJECT
+        MENUITEM "꺼내기(&J)", IDM_CASSETTE_EJECT
     END
 END
 
@@ -155,9 +155,9 @@ CartridgeSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "이미지(&I)...",                IDM_CARTRIDGE_IMAGE
+        MENUITEM "이미지(&I)...", IDM_CARTRIDGE_IMAGE
         MENUITEM SEPARATOR
-        MENUITEM "꺼내기(&J)",                    IDM_CARTRIDGE_EJECT
+        MENUITEM "꺼내기(&J)", IDM_CARTRIDGE_EJECT
     END
 END
 
@@ -165,14 +165,14 @@ FloppySubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "새 이미지(&N)...",                IDM_FLOPPY_IMAGE_NEW
+        MENUITEM "새 이미지(&N)...", IDM_FLOPPY_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "이미지 불러오기(&E)...",                IDM_FLOPPY_IMAGE_EXISTING
-        MENUITEM "이미지 불러오기 (쓰기방지)(&W)...",        IDM_FLOPPY_IMAGE_EXISTING_WP
+        MENUITEM "이미지 불러오기(&E)...", IDM_FLOPPY_IMAGE_EXISTING
+        MENUITEM "이미지 불러오기 (쓰기방지)(&W)...", IDM_FLOPPY_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "86F로 보내기(&X)...",            IDM_FLOPPY_EXPORT_TO_86F
+        MENUITEM "86F로 보내기(&X)...", IDM_FLOPPY_EXPORT_TO_86F
         MENUITEM SEPARATOR
-        MENUITEM "꺼내기(&J)",                    IDM_FLOPPY_EJECT
+        MENUITEM "꺼내기(&J)", IDM_FLOPPY_EJECT
     END
 END
 
@@ -180,13 +180,13 @@ CdromSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "음소거(&M)",                    IDM_CDROM_MUTE
+        MENUITEM "음소거(&M)", IDM_CDROM_MUTE
         MENUITEM SEPARATOR
-        MENUITEM "비었음(&M)",                    IDM_CDROM_EMPTY
-        MENUITEM "이전 이미지 다시 불러오기(&R)",            IDM_CDROM_RELOAD
+        MENUITEM "비었음(&M)", IDM_CDROM_EMPTY
+        MENUITEM "이전 이미지 다시 불러오기(&R)", IDM_CDROM_RELOAD
         MENUITEM SEPARATOR
-        MENUITEM "이미지(&I)...",                    IDM_CDROM_IMAGE
-        MENUITEM "폴더(&F)...",                    IDM_CDROM_DIR
+        MENUITEM "이미지(&I)...", IDM_CDROM_IMAGE
+        MENUITEM "폴더(&F)...", IDM_CDROM_DIR
     END
 END
 
@@ -194,13 +194,13 @@ ZIPSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "새 이미지(&N)...",                IDM_ZIP_IMAGE_NEW
+        MENUITEM "새 이미지(&N)...", IDM_ZIP_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "이미지 불러오기(&E)...",                IDM_ZIP_IMAGE_EXISTING
-        MENUITEM "이미지 불러오기 (쓰기방지)(&W)...",        IDM_ZIP_IMAGE_EXISTING_WP
+        MENUITEM "이미지 불러오기(&E)...", IDM_ZIP_IMAGE_EXISTING
+        MENUITEM "이미지 불러오기 (쓰기방지)(&W)...", IDM_ZIP_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "꺼내기(&J)",                    IDM_ZIP_EJECT
-        MENUITEM "이전 이미지 다시 불러오기(&R)",            IDM_ZIP_RELOAD
+        MENUITEM "꺼내기(&J)", IDM_ZIP_EJECT
+        MENUITEM "이전 이미지 다시 불러오기(&R)", IDM_ZIP_RELOAD
     END
 END
 
@@ -208,13 +208,13 @@ MOSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "새 이미지(&N)...",                IDM_MO_IMAGE_NEW
+        MENUITEM "새 이미지(&N)...", IDM_MO_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "이미지 불러오기(&E)...",                IDM_MO_IMAGE_EXISTING
-        MENUITEM "이미지 불러오기 (쓰기방지)(&W)...",        IDM_MO_IMAGE_EXISTING_WP
+        MENUITEM "이미지 불러오기(&E)...", IDM_MO_IMAGE_EXISTING
+        MENUITEM "이미지 불러오기 (쓰기방지)(&W)...", IDM_MO_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "꺼내기(&J)",                    IDM_MO_EJECT
-        MENUITEM "이전 이미지 다시 불러오기(&R)",            IDM_MO_RELOAD
+        MENUITEM "꺼내기(&J)", IDM_MO_EJECT
+        MENUITEM "이전 이미지 다시 불러오기(&R)", IDM_MO_RELOAD
     END
 END
 
@@ -240,150 +240,150 @@ END
 // Dialog
 //
 
-#define STR_PREFERENCES        "환경설정"
-#define STR_SND_GAIN        "음량 증폭"
-#define STR_NEW_FLOPPY        "새 이미지"
+#define STR_PREFERENCES   "환경설정"
+#define STR_SND_GAIN      "음량 증폭"
+#define STR_NEW_FLOPPY    "새 이미지"
 #define STR_CONFIG        "설정"
-#define STR_SPECIFY_DIM        "창 크기 지정"
+#define STR_SPECIFY_DIM   "창 크기 지정"
 
 #define STR_OK            "확인"
 #define STR_CANCEL        "취소"
 #define STR_GLOBAL        "이 설정들을 전역 기본값으로 저장하기(&G)"
-#define STR_DEFAULT        "기본값(&D)"
-#define STR_LANGUAGE        "언어:"
-#define STR_ICONSET        "아이콘셋:"
+#define STR_DEFAULT       "기본값(&D)"
+#define STR_LANGUAGE      "언어:"
+#define STR_ICONSET       "아이콘셋:"
 
-#define STR_GAIN        "증가값"
+#define STR_GAIN          "증가값"
 
-#define STR_FILE_NAME        "파일명:"
-#define STR_DISK_SIZE        "디스크 용량:"
-#define STR_RPM_MODE        "RPM 모드:"
-#define STR_PROGRESS        "진행:"
+#define STR_FILE_NAME     "파일명:"
+#define STR_DISK_SIZE     "디스크 용량:"
+#define STR_RPM_MODE      "RPM 모드:"
+#define STR_PROGRESS      "진행:"
 
-#define STR_WIDTH        "가로:"
+#define STR_WIDTH         "가로:"
 #define STR_HEIGHT        "세로:"
-#define STR_LOCK_TO_SIZE    "크기 고정"
+#define STR_LOCK_TO_SIZE  "크기 고정"
 
-#define STR_MACHINE_TYPE    "머신 종류:"
-#define STR_MACHINE        "기종:"
-#define STR_CONFIGURE        "설정"
-#define STR_CPU_TYPE        "CPU 종류:"
-#define STR_CPU_SPEED        "속도:"
-#define STR_FPU            "FPU:"
-#define STR_WAIT_STATES        "대기 상태:"
+#define STR_MACHINE_TYPE  "머신 종류:"
+#define STR_MACHINE       "기종:"
+#define STR_CONFIGURE     "설정"
+#define STR_CPU_TYPE      "CPU 종류:"
+#define STR_CPU_SPEED     "속도:"
+#define STR_FPU           "FPU:"
+#define STR_WAIT_STATES   "대기 상태:"
 #define STR_MB            "MB"
 #define STR_MEMORY        "메모리:"
-#define STR_TIME_SYNC        "시간 동기화"
-#define STR_DISABLED        "사용하지 않음"
-#define STR_ENABLED_LOCAL    "사용 (현지 시간)"
-#define STR_ENABLED_UTC        "사용 (UTC)"
-#define STR_DYNAREC        "동적 재컴파일"
+#define STR_TIME_SYNC     "시간 동기화"
+#define STR_DISABLED      "사용하지 않음"
+#define STR_ENABLED_LOCAL "사용 (현지 시간)"
+#define STR_ENABLED_UTC   "사용 (UTC)"
+#define STR_DYNAREC       "동적 재컴파일"
 
-#define STR_VIDEO        "비디오 카드:"
-#define STR_VIDEO_2        "비디오 카드 2:"
+#define STR_VIDEO         "비디오 카드:"
+#define STR_VIDEO_2       "비디오 카드 2:"
 #define STR_VOODOO        "Voodoo 그래픽"
-#define STR_IBM8514        "IBM 8514/a 그래픽"
-#define STR_XGA            "XGA 그래픽"
+#define STR_IBM8514       "IBM 8514/a 그래픽"
+#define STR_XGA           "XGA 그래픽"
 
-#define STR_MOUSE        "마우스:"
-#define STR_JOYSTICK        "조이스틱:"
-#define STR_JOY1        "조이스틱 1..."
-#define STR_JOY2        "조이스틱 2..."
-#define STR_JOY3        "조이스틱 3..."
-#define STR_JOY4        "조이스틱 4..."
+#define STR_MOUSE         "마우스:"
+#define STR_JOYSTICK      "조이스틱:"
+#define STR_JOY1          "조이스틱 1..."
+#define STR_JOY2          "조이스틱 2..."
+#define STR_JOY3          "조이스틱 3..."
+#define STR_JOY4          "조이스틱 4..."
 
 #define STR_SOUND1        "사운드 카드 1:"
 #define STR_SOUND2        "사운드 카드 2:"
 #define STR_SOUND3        "사운드 카드 3:"
 #define STR_SOUND4        "사운드 카드 4:"
-#define STR_MIDI_OUT        "MIDI 출력 장치:"
-#define STR_MIDI_IN        "MIDI 입력 장치:"
+#define STR_MIDI_OUT      "MIDI 출력 장치:"
+#define STR_MIDI_IN       "MIDI 입력 장치:"
 #define STR_MPU401        "MPU-401 단독 사용"
-#define STR_FLOAT        "FLOAT32 사운드 사용"
-#define STR_FM_DRIVER        "FM 신디사이저 드라이버"
-#define STR_FM_DRV_NUKED    "Nuked (더 정확한)"
-#define STR_FM_DRV_YMFM        "YMFM (더 빠르게)"
+#define STR_FLOAT         "FLOAT32 사운드 사용"
+#define STR_FM_DRIVER     "FM 신디사이저 드라이버"
+#define STR_FM_DRV_NUKED  "Nuked (더 정확한)"
+#define STR_FM_DRV_YMFM   "YMFM (더 빠르게)"
 
-#define STR_NET_TYPE    "네트워크 종류:"
-#define STR_PCAP        "PCap 장치:"
-#define STR_NET            "네트워크 어댑터:"
-#define STR_NET1        "Network card 1:"
-#define STR_NET2        "Network card 2:"
-#define STR_NET3        "Network card 3:"
-#define STR_NET4        "Network card 4:"
+#define STR_NET_TYPE      "네트워크 종류:"
+#define STR_PCAP          "PCap 장치:"
+#define STR_NET           "네트워크 어댑터:"
+#define STR_NET1          "Network card 1:"
+#define STR_NET2          "Network card 2:"
+#define STR_NET3          "Network card 3:"
+#define STR_NET4          "Network card 4:"
 
-#define STR_COM1        "COM1 장치:"
-#define STR_COM2        "COM2 장치:"
-#define STR_COM3        "COM3 장치:"
-#define STR_COM4        "COM4 장치:"
-#define STR_LPT1        "LPT1 장치:"
-#define STR_LPT2        "LPT2 장치:"
-#define STR_LPT3        "LPT3 장치:"
-#define STR_LPT4        "LPT4 장치:"
-#define STR_SERIAL1        "직렬 포트 1"
-#define STR_SERIAL2        "직렬 포트 2"
-#define STR_SERIAL3        "직렬 포트 3"
-#define STR_SERIAL4        "직렬 포트 4"
-#define STR_PARALLEL1        "병렬 포트 1"
-#define STR_PARALLEL2        "병렬 포트 2"
-#define STR_PARALLEL3        "병렬 포트 3"
-#define STR_PARALLEL4        "병렬 포트 4"
-#define STR_SERIAL_PASS1    "Serial port passthrough 1"
-#define STR_SERIAL_PASS2    "Serial port passthrough 2"
-#define STR_SERIAL_PASS3    "Serial port passthrough 3"
-#define STR_SERIAL_PASS4    "Serial port passthrough 4"
+#define STR_COM1          "COM1 장치:"
+#define STR_COM2          "COM2 장치:"
+#define STR_COM3          "COM3 장치:"
+#define STR_COM4          "COM4 장치:"
+#define STR_LPT1          "LPT1 장치:"
+#define STR_LPT2          "LPT2 장치:"
+#define STR_LPT3          "LPT3 장치:"
+#define STR_LPT4          "LPT4 장치:"
+#define STR_SERIAL1       "직렬 포트 1"
+#define STR_SERIAL2       "직렬 포트 2"
+#define STR_SERIAL3       "직렬 포트 3"
+#define STR_SERIAL4       "직렬 포트 4"
+#define STR_PARALLEL1     "병렬 포트 1"
+#define STR_PARALLEL2     "병렬 포트 2"
+#define STR_PARALLEL3     "병렬 포트 3"
+#define STR_PARALLEL4     "병렬 포트 4"
+#define STR_SERIAL_PASS1  "Serial port passthrough 1"
+#define STR_SERIAL_PASS2  "Serial port passthrough 2"
+#define STR_SERIAL_PASS3  "Serial port passthrough 3"
+#define STR_SERIAL_PASS4  "Serial port passthrough 4"
 
-#define STR_HDC            "HD 컨트롤러:"
-#define STR_FDC            "FD 컨트롤러:"
-#define STR_IDE_TER        "제3의 IDE 컨트롤러"
-#define STR_IDE_QUA        "제4의 IDE 컨트롤러"
-#define STR_SCSI        "SCSI"
+#define STR_HDC           "HD 컨트롤러:"
+#define STR_FDC           "FD 컨트롤러:"
+#define STR_IDE_TER       "제3의 IDE 컨트롤러"
+#define STR_IDE_QUA       "제4의 IDE 컨트롤러"
+#define STR_SCSI          "SCSI"
 #define STR_SCSI_1        "컨트롤러 1:"
 #define STR_SCSI_2        "컨트롤러 2:"
 #define STR_SCSI_3        "컨트롤러 3:"
 #define STR_SCSI_4        "컨트롤러 4:"
-#define STR_CASSETTE        "카세트 테이프"
+#define STR_CASSETTE      "카세트 테이프"
 
-#define STR_HDD            "하드 디스크:"
-#define STR_NEW            "새로 만들기(&N)..."
-#define STR_EXISTING        "불러오기(&E)..."
+#define STR_HDD           "하드 디스크:"
+#define STR_NEW           "새로 만들기(&N)..."
+#define STR_EXISTING      "불러오기(&E)..."
 #define STR_REMOVE        "목록에서 제거(&R)"
-#define STR_BUS            "버스:"
-#define STR_CHANNEL        "채널:"
+#define STR_BUS           "버스:"
+#define STR_CHANNEL       "채널:"
 #define STR_ID            "ID:"
-#define STR_SPEED        "Speed:"
+#define STR_SPEED         "Speed:"
 
-#define STR_SPECIFY        "열기(&S)..."
-#define STR_SECTORS        "섹터:"
-#define STR_HEADS        "헤드:"
-#define STR_CYLS        "실린더:"
-#define STR_SIZE_MB        "용량(MB):"
-#define STR_TYPE        "형식:"
-#define STR_IMG_FORMAT        "이미지 포맷:"
-#define STR_BLOCK_SIZE        "블록 크기:"
+#define STR_SPECIFY       "열기(&S)..."
+#define STR_SECTORS       "섹터:"
+#define STR_HEADS         "헤드:"
+#define STR_CYLS          "실린더:"
+#define STR_SIZE_MB       "용량(MB):"
+#define STR_TYPE          "형식:"
+#define STR_IMG_FORMAT    "이미지 포맷:"
+#define STR_BLOCK_SIZE    "블록 크기:"
 
-#define STR_FLOPPY_DRIVES    "플로피 드라이브:"
-#define STR_TURBO        "고속 동작"
-#define STR_CHECKBPB        "BPB 확인"
-#define STR_CDROM_DRIVES    "CD-ROM 드라이브:"
-#define STR_CD_SPEED        "속도:"
-#define STR_EARLY        "이전 드라이브"
+#define STR_FLOPPY_DRIVES "플로피 드라이브:"
+#define STR_TURBO         "고속 동작"
+#define STR_CHECKBPB      "BPB 확인"
+#define STR_CDROM_DRIVES  "CD-ROM 드라이브:"
+#define STR_CD_SPEED      "속도:"
+#define STR_EARLY         "이전 드라이브"
 
-#define STR_MO_DRIVES        "광자기 드라이브:"
-#define STR_ZIP_DRIVES        "ZIP 드라이브:"
-#define STR_250            "ZIP 250"
+#define STR_MO_DRIVES     "광자기 드라이브:"
+#define STR_ZIP_DRIVES    "ZIP 드라이브:"
+#define STR_250           "ZIP 250"
 
 #define STR_ISARTC        "ISA RTC 카드:"
 #define STR_ISAMEM        "ISA 메모리 확장 카드"
-#define STR_ISAMEM_1        "카드 1:"
-#define STR_ISAMEM_2        "카드 2:"
-#define STR_ISAMEM_3        "카드 3:"
-#define STR_ISAMEM_4        "카드 4:"
+#define STR_ISAMEM_1      "카드 1:"
+#define STR_ISAMEM_2      "카드 2:"
+#define STR_ISAMEM_3      "카드 3:"
+#define STR_ISAMEM_4      "카드 4:"
 #define STR_BUGGER        "ISABugger 장치"
-#define STR_POSTCARD        "POST 카드"
+#define STR_POSTCARD      "POST 카드"
 
-#define FONT_SIZE        9
-#define FONT_NAME        "Malgun Gothic"
+#define FONT_SIZE         9
+#define FONT_NAME         "Malgun Gothic"
 
 #include "dialogs.rc"
 
@@ -392,9 +392,9 @@ END
 // String Table
 //
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
-    2048    "86Box"
+    2048        "86Box"
     IDS_2049    "오류"
     IDS_2050    "치명적인 오류"
     IDS_2051    " - PAUSED"
@@ -412,7 +412,7 @@ BEGIN
     IDS_2063    "roms/machines 디렉토리에 필요한 롬파일이 없어 기종 ""%hs""을(를) 사용할 수 없습니다. 사용 가능한 기종으로 변경합니다."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2064    "roms/video 디렉토리에 필요한 롬파일이 없어 비디오 카드 ""%hs""을(를) 사용할 수 없습니다. 사용 가능한 기종으로 변경합니다."
     IDS_2065    "기종"
@@ -432,7 +432,7 @@ BEGIN
     IDS_2079    "F12+F8키 또는 가운데 버튼을 클릭하면 마우스를 해제합니다"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2080    "FluidSynth를 초기화할 수 없습니다"
     IDS_2081    "버스"
@@ -544,7 +544,7 @@ BEGIN
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_4096    "하드 디스크 (%s)"
     IDS_4097    "%01i:%01i"
@@ -643,7 +643,7 @@ BEGIN
 
     IDS_7168    "(시스템 기본값)"
 END
-#define IDS_LANG_ENUS    IDS_7168
+#define IDS_LANG_ENUS IDS_7168
 
 // Korean resources
 /////////////////////////////////////////////////////////////////////////////

--- a/src/win/languages/pl-PL.rc
+++ b/src/win/languages/pl-PL.rc
@@ -13,122 +13,122 @@ LANGUAGE LANG_POLISH, SUBLANG_DEFAULT
 // Menu
 //
 
-MainMenu MENU DISCARDABLE 
+MainMenu MENU DISCARDABLE
 BEGIN
     POPUP "&Akcje"
     BEGIN
-        MENUITEM "&Klawaitura wymaga przechwytu myszy",    IDM_ACTION_KBD_REQ_CAPTURE
-        MENUITEM "&Prawy CTRL to lewy Alt",    IDM_ACTION_RCTRL_IS_LALT
+        MENUITEM "&Klawaitura wymaga przechwytu myszy", IDM_ACTION_KBD_REQ_CAPTURE
+        MENUITEM "&Prawy CTRL to lewy Alt", IDM_ACTION_RCTRL_IS_LALT
         MENUITEM SEPARATOR
-        MENUITEM "&Twardy reset...",                 IDM_ACTION_HRESET
-        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12",     IDM_ACTION_RESET_CAD
+        MENUITEM "&Twardy reset...", IDM_ACTION_HRESET
+        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12", IDM_ACTION_RESET_CAD
         MENUITEM SEPARATOR
-    MENUITEM "Ctrl+Alt+&Esc",        IDM_ACTION_CTRL_ALT_ESC
+    MENUITEM "Ctrl+Alt+&Esc", IDM_ACTION_CTRL_ALT_ESC
         MENUITEM SEPARATOR
-        MENUITEM "&Pauza",                      IDM_ACTION_PAUSE
+        MENUITEM "&Pauza", IDM_ACTION_PAUSE
         MENUITEM SEPARATOR
-        MENUITEM "W&yjdź...",                       IDM_ACTION_EXIT
+        MENUITEM "W&yjdź...", IDM_ACTION_EXIT
     END
     POPUP "&Widok"
     BEGIN
-        MENUITEM "&Ukryj pasek statusu",        IDM_VID_HIDE_STATUS_BAR
-        MENUITEM "Ukryj &pasek narzędzi",        IDM_VID_HIDE_TOOLBAR
+        MENUITEM "&Ukryj pasek statusu", IDM_VID_HIDE_STATUS_BAR
+        MENUITEM "Ukryj &pasek narzędzi", IDM_VID_HIDE_TOOLBAR
         MENUITEM SEPARATOR
-        MENUITEM "&Show non-primary monitors",  IDM_VID_MONITORS
-        MENUITEM "&Okno o zmiennym rozmiarze",          IDM_VID_RESIZE
-        MENUITEM "P&amiętaj rozmiar &i pozycję",  IDM_VID_REMEMBER
+        MENUITEM "&Show non-primary monitors", IDM_VID_MONITORS
+        MENUITEM "&Okno o zmiennym rozmiarze", IDM_VID_RESIZE
+        MENUITEM "P&amiętaj rozmiar &i pozycję", IDM_VID_REMEMBER
         MENUITEM SEPARATOR
         POPUP "Re&nderer"
         BEGIN
-            MENUITEM "&SDL (Software)",         IDM_VID_SDL_SW
-            MENUITEM "SDL (&Hardware)",         IDM_VID_SDL_HW
-            MENUITEM "SDL (&OpenGL)",           IDM_VID_SDL_OPENGL
-            MENUITEM "Open&GL (3.0 Core)",      IDM_VID_OPENGL_CORE
+            MENUITEM "&SDL (Software)", IDM_VID_SDL_SW
+            MENUITEM "SDL (&Hardware)", IDM_VID_SDL_HW
+            MENUITEM "SDL (&OpenGL)", IDM_VID_SDL_OPENGL
+            MENUITEM "Open&GL (3.0 Core)", IDM_VID_OPENGL_CORE
 #ifdef USE_VNC
-            MENUITEM "&VNC",                    IDM_VID_VNC
+            MENUITEM "&VNC", IDM_VID_VNC
 #endif
         END
         MENUITEM SEPARATOR
-        MENUITEM "Określ rozmiary...",          IDM_VID_SPECIFY_DIM
-        MENUITEM "&Wymuś proporcje wyświetlania 4:3",    IDM_VID_FORCE43
+        MENUITEM "Określ rozmiary...", IDM_VID_SPECIFY_DIM
+        MENUITEM "&Wymuś proporcje wyświetlania 4:3", IDM_VID_FORCE43
         POPUP "&Czynnik skalowania okna"
         BEGIN
-            MENUITEM "&0.5x",                   IDM_VID_SCALE_1X
-            MENUITEM "&1x",                     IDM_VID_SCALE_2X
-            MENUITEM "1.&5x",                   IDM_VID_SCALE_3X
-            MENUITEM "&2x",                     IDM_VID_SCALE_4X
-            MENUITEM "&3x",                     IDM_VID_SCALE_5X
-            MENUITEM "&4x",                     IDM_VID_SCALE_6X
-            MENUITEM "&5x",                     IDM_VID_SCALE_7X
-            MENUITEM "&6x",                     IDM_VID_SCALE_8X
-            MENUITEM "&7x",                     IDM_VID_SCALE_9X
-            MENUITEM "&8x",                     IDM_VID_SCALE_10X
+            MENUITEM "&0.5x", IDM_VID_SCALE_1X
+            MENUITEM "&1x", IDM_VID_SCALE_2X
+            MENUITEM "1.&5x", IDM_VID_SCALE_3X
+            MENUITEM "&2x", IDM_VID_SCALE_4X
+            MENUITEM "&3x", IDM_VID_SCALE_5X
+            MENUITEM "&4x", IDM_VID_SCALE_6X
+            MENUITEM "&5x", IDM_VID_SCALE_7X
+            MENUITEM "&6x", IDM_VID_SCALE_8X
+            MENUITEM "&7x", IDM_VID_SCALE_9X
+            MENUITEM "&8x", IDM_VID_SCALE_10X
         END
         POPUP "Metoda filtrowania"
         BEGIN
-            MENUITEM "&Nearest",                 IDM_VID_FILTER_NEAREST
-            MENUITEM "&Linear",                  IDM_VID_FILTER_LINEAR
+            MENUITEM "&Nearest", IDM_VID_FILTER_NEAREST
+            MENUITEM "&Linear", IDM_VID_FILTER_LINEAR
         END
-        MENUITEM "Skalowanie Hi&DPI",              IDM_VID_HIDPI
+        MENUITEM "Skalowanie Hi&DPI", IDM_VID_HIDPI
         MENUITEM SEPARATOR
-        MENUITEM "&Pełny ekran\tCtrl+Alt+PgUp",    IDM_VID_FULLSCREEN
+        MENUITEM "&Pełny ekran\tCtrl+Alt+PgUp", IDM_VID_FULLSCREEN
         POPUP "Fullscreen &stretch mode"
         BEGIN
-            MENUITEM "&Tryb rozciągania na pełnym ekranie",        IDM_VID_FS_FULL
-            MENUITEM "&4:3",                        IDM_VID_FS_43
+            MENUITEM "&Tryb rozciągania na pełnym ekranie", IDM_VID_FS_FULL
+            MENUITEM "&4:3", IDM_VID_FS_43
             MENUITEM "&Kwadratowe piksele (Zachowaj proporcje)", IDM_VID_FS_KEEPRATIO
-            MENUITEM "&Skalowanie całkowite",              IDM_VID_FS_INT
+            MENUITEM "&Skalowanie całkowite", IDM_VID_FS_INT
         END
         POPUP "Ustawienia E&GA/(S)VGA"
         BEGIN
-            MENUITEM "&Odwrócony monitor VGA",   IDM_VID_INVERT
+            MENUITEM "&Odwrócony monitor VGA", IDM_VID_INVERT
             POPUP "Rodzaj ekranu &VGA"
             BEGIN
-                MENUITEM "RGB - &Kolorowy",          IDM_VID_GRAY_RGB
-                MENUITEM "&RGB - Skala szarości",      IDM_VID_GRAY_MONO
-                MENUITEM "&Bursztynowy monitor",      IDM_VID_GRAY_AMBER
-                MENUITEM "&Zielony monitor",      IDM_VID_GRAY_GREEN
-                MENUITEM "&Biały monitor",      IDM_VID_GRAY_WHITE
+                MENUITEM "RGB - &Kolorowy", IDM_VID_GRAY_RGB
+                MENUITEM "&RGB - Skala szarości", IDM_VID_GRAY_MONO
+                MENUITEM "&Bursztynowy monitor", IDM_VID_GRAY_AMBER
+                MENUITEM "&Zielony monitor", IDM_VID_GRAY_GREEN
+                MENUITEM "&Biały monitor", IDM_VID_GRAY_WHITE
             END
             POPUP "Typ konwersji &w skali szarości"
             BEGIN
-                MENUITEM "BT&601 (NTSC/PAL)",   IDM_VID_GRAYCT_601
-                MENUITEM "BT&709 (HDTV)",       IDM_VID_GRAYCT_709
-                MENUITEM "&Średni",            IDM_VID_GRAYCT_AVE
+                MENUITEM "BT&601 (NTSC/PAL)", IDM_VID_GRAYCT_601
+                MENUITEM "BT&709 (HDTV)", IDM_VID_GRAYCT_709
+                MENUITEM "&Średni", IDM_VID_GRAYCT_AVE
             END
         END
         MENUITEM SEPARATOR
-        MENUITEM "Overscan dla CGA/PCjr/Tandy/E&GA/(S)VGA",     IDM_VID_OVERSCAN
+        MENUITEM "Overscan dla CGA/PCjr/Tandy/E&GA/(S)VGA", IDM_VID_OVERSCAN
         MENUITEM "Zmień kontrast dla &monochromatycznego ekranu", IDM_VID_CGACON
     END
-    MENUITEM "&Nośnik",                IDM_MEDIA
+    MENUITEM "&Nośnik", IDM_MEDIA
     POPUP "&Narzędzia"
     BEGIN
-        MENUITEM "&Ustawienia...",                IDM_CONFIG
-        MENUITEM "&Aktualizuj ikony na pasku statusu",    IDM_UPDATE_ICONS
+        MENUITEM "&Ustawienia...", IDM_CONFIG
+        MENUITEM "&Aktualizuj ikony na pasku statusu", IDM_UPDATE_ICONS
         MENUITEM SEPARATOR
-        MENUITEM "Zrób &zrzut ekranu\tCtrl+F11",  IDM_ACTION_SCREENSHOT
+        MENUITEM "Zrób &zrzut ekranu\tCtrl+F11", IDM_ACTION_SCREENSHOT
         MENUITEM SEPARATOR
-        MENUITEM "&Preferencje...",        IDM_PREFERENCES
+        MENUITEM "&Preferencje...", IDM_PREFERENCES
 #ifdef DISCORD
         MENUITEM "Włącz integrację z &Discord", IDM_DISCORD
 #endif
         MENUITEM SEPARATOR
-        MENUITEM "Wzmocnienie &dźwięku...",              IDM_SND_GAIN
+        MENUITEM "Wzmocnienie &dźwięku...", IDM_SND_GAIN
 #ifdef MTR_ENABLED
         MENUITEM SEPARATOR
-        MENUITEM "Rozpocznij śledzenie\tCtrl+T",         IDM_ACTION_BEGIN_TRACE
-        MENUITEM "Zakończ śledzenie\tCtrl+T",           IDM_ACTION_END_TRACE
+        MENUITEM "Rozpocznij śledzenie\tCtrl+T", IDM_ACTION_BEGIN_TRACE
+        MENUITEM "Zakończ śledzenie\tCtrl+T", IDM_ACTION_END_TRACE
 #endif
     END
     POPUP "&Pomoc"
     BEGIN
-        MENUITEM "&Dokumentacja...",           IDM_DOCS
-        MENUITEM "&O 86Box...",             IDM_ABOUT
+        MENUITEM "&Dokumentacja...", IDM_DOCS
+        MENUITEM "&O 86Box...", IDM_ABOUT
     END
 END
 
-StatusBarMenu MENU DISCARDABLE 
+StatusBarMenu MENU DISCARDABLE
 BEGIN
     MENUITEM SEPARATOR
 END
@@ -137,17 +137,17 @@ CassetteSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nowy obraz...",                IDM_CASSETTE_IMAGE_NEW
+        MENUITEM "&Nowy obraz...", IDM_CASSETTE_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Istniejący obraz...",                IDM_CASSETTE_IMAGE_EXISTING
-        MENUITEM "Istniejący obraz (&Chroniony przed zapisem)...",    IDM_CASSETTE_IMAGE_EXISTING_WP
+        MENUITEM "&Istniejący obraz...", IDM_CASSETTE_IMAGE_EXISTING
+        MENUITEM "Istniejący obraz (&Chroniony przed zapisem)...", IDM_CASSETTE_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Nagraj",                    IDM_CASSETTE_RECORD
-        MENUITEM "&Odtwórz",                    IDM_CASSETTE_PLAY
-        MENUITEM "&Przewiń do początku",            IDM_CASSETTE_REWIND
-        MENUITEM "&Przewiń do końca",            IDM_CASSETTE_FAST_FORWARD
+        MENUITEM "&Nagraj", IDM_CASSETTE_RECORD
+        MENUITEM "&Odtwórz", IDM_CASSETTE_PLAY
+        MENUITEM "&Przewiń do początku", IDM_CASSETTE_REWIND
+        MENUITEM "&Przewiń do końca", IDM_CASSETTE_FAST_FORWARD
         MENUITEM SEPARATOR
-        MENUITEM "W&yjmij",                    IDM_CASSETTE_EJECT
+        MENUITEM "W&yjmij", IDM_CASSETTE_EJECT
     END
 END
 
@@ -155,9 +155,9 @@ CartridgeSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Obraz...",                    IDM_CARTRIDGE_IMAGE
+        MENUITEM "&Obraz...", IDM_CARTRIDGE_IMAGE
         MENUITEM SEPARATOR
-        MENUITEM "W&yjmij",                    IDM_CARTRIDGE_EJECT
+        MENUITEM "W&yjmij", IDM_CARTRIDGE_EJECT
     END
 END
 
@@ -165,14 +165,14 @@ FloppySubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nowy obraz...",                IDM_FLOPPY_IMAGE_NEW
+        MENUITEM "&Nowy obraz...", IDM_FLOPPY_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Istniejący obraz...",                IDM_FLOPPY_IMAGE_EXISTING
-        MENUITEM "Istniejący obraz (&Chroniony przed zapisem)...",    IDM_FLOPPY_IMAGE_EXISTING_WP
+        MENUITEM "&Istniejący obraz...", IDM_FLOPPY_IMAGE_EXISTING
+        MENUITEM "Istniejący obraz (&Chroniony przed zapisem)...", IDM_FLOPPY_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "E&ksportuj do 86F...",                IDM_FLOPPY_EXPORT_TO_86F
+        MENUITEM "E&ksportuj do 86F...", IDM_FLOPPY_EXPORT_TO_86F
         MENUITEM SEPARATOR
-        MENUITEM "W&yjmij",                    IDM_FLOPPY_EJECT
+        MENUITEM "W&yjmij", IDM_FLOPPY_EJECT
     END
 END
 
@@ -180,13 +180,13 @@ CdromSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Ścisz",                    IDM_CDROM_MUTE
+        MENUITEM "&Ścisz", IDM_CDROM_MUTE
         MENUITEM SEPARATOR
-        MENUITEM "P&usty",                    IDM_CDROM_EMPTY
-        MENUITEM "&Przeładuj poprzedni obraz",            IDM_CDROM_RELOAD
+        MENUITEM "P&usty", IDM_CDROM_EMPTY
+        MENUITEM "&Przeładuj poprzedni obraz", IDM_CDROM_RELOAD
         MENUITEM SEPARATOR
-        MENUITEM "&Obraz...",                    IDM_CDROM_IMAGE
-        MENUITEM "&Teczka...",                    IDM_CDROM_DIR
+        MENUITEM "&Obraz...", IDM_CDROM_IMAGE
+        MENUITEM "&Teczka...", IDM_CDROM_DIR
     END
 END
 
@@ -194,13 +194,13 @@ ZIPSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nowy obraz...",                IDM_ZIP_IMAGE_NEW
+        MENUITEM "&Nowy obraz...", IDM_ZIP_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Istniejący obraz...",                IDM_ZIP_IMAGE_EXISTING
-        MENUITEM "Istniejący obraz (&Chroniony przed zapisem)...",    IDM_ZIP_IMAGE_EXISTING_WP
+        MENUITEM "&Istniejący obraz...", IDM_ZIP_IMAGE_EXISTING
+        MENUITEM "Istniejący obraz (&Chroniony przed zapisem)...", IDM_ZIP_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "W&yjmij",                    IDM_ZIP_EJECT
-        MENUITEM "&Przeładuj poprzedni obraz",            IDM_ZIP_RELOAD
+        MENUITEM "W&yjmij", IDM_ZIP_EJECT
+        MENUITEM "&Przeładuj poprzedni obraz", IDM_ZIP_RELOAD
     END
 END
 
@@ -208,13 +208,13 @@ MOSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nowy obraz...",                IDM_MO_IMAGE_NEW
+        MENUITEM "&Nowy obraz...", IDM_MO_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Istniejący obraz...",                IDM_MO_IMAGE_EXISTING
-        MENUITEM "Istniejący obraz (&Chroniony przed zapisem)...",    IDM_MO_IMAGE_EXISTING_WP
+        MENUITEM "&Istniejący obraz...", IDM_MO_IMAGE_EXISTING
+        MENUITEM "Istniejący obraz (&Chroniony przed zapisem)...", IDM_MO_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "W&yjmij",                    IDM_MO_EJECT
-        MENUITEM "&Przeładuj poprzedni obraz",            IDM_MO_RELOAD
+        MENUITEM "W&yjmij", IDM_MO_EJECT
+        MENUITEM "&Przeładuj poprzedni obraz", IDM_MO_RELOAD
     END
 END
 
@@ -240,150 +240,150 @@ END
 // Dialog
 //
 
-#define STR_PREFERENCES        "Preferencje"
-#define STR_SND_GAIN        "Wzmocnienie dźwięku"
-#define STR_NEW_FLOPPY        "Nowy obraz"
+#define STR_PREFERENCES   "Preferencje"
+#define STR_SND_GAIN      "Wzmocnienie dźwięku"
+#define STR_NEW_FLOPPY    "Nowy obraz"
 #define STR_CONFIG        "Ustawienia"
-#define STR_SPECIFY_DIM        "Określ rozmiary okna"
+#define STR_SPECIFY_DIM   "Określ rozmiary okna"
 
 #define STR_OK            "OK"
 #define STR_CANCEL        "Anuluj"
 #define STR_GLOBAL        "Zapisz ustawienia jako &globalne ustawienia domyślne"
-#define STR_DEFAULT        "&Domyślny"
-#define STR_LANGUAGE        "Język:"
-#define STR_ICONSET        "Zestaw ikon:"
+#define STR_DEFAULT       "&Domyślny"
+#define STR_LANGUAGE      "Język:"
+#define STR_ICONSET       "Zestaw ikon:"
 
-#define STR_GAIN        "Wzmacniacz"
+#define STR_GAIN          "Wzmacniacz"
 
-#define STR_FILE_NAME        "Nazwa pliku:"
-#define STR_DISK_SIZE        "Rozmiar dysku:"
-#define STR_RPM_MODE        "Tryb RPM:"
-#define STR_PROGRESS        "Postęp:"
+#define STR_FILE_NAME     "Nazwa pliku:"
+#define STR_DISK_SIZE     "Rozmiar dysku:"
+#define STR_RPM_MODE      "Tryb RPM:"
+#define STR_PROGRESS      "Postęp:"
 
-#define STR_WIDTH        "Szerokość:"
+#define STR_WIDTH         "Szerokość:"
 #define STR_HEIGHT        "Wysokość:"
-#define STR_LOCK_TO_SIZE    "Stały rozmiar"
+#define STR_LOCK_TO_SIZE  "Stały rozmiar"
 
-#define STR_MACHINE_TYPE    "Rodzaj maszyny:"
-#define STR_MACHINE        "Maszyna:"
-#define STR_CONFIGURE        "Konfiguruj"
-#define STR_CPU_TYPE        "Rodzaj procesora:"
-#define STR_CPU_SPEED        "Szybkość:"
-#define STR_FPU            "Jednostka FPU:"
-#define STR_WAIT_STATES        "Stany oczekiwania:"
+#define STR_MACHINE_TYPE  "Rodzaj maszyny:"
+#define STR_MACHINE       "Maszyna:"
+#define STR_CONFIGURE     "Konfiguruj"
+#define STR_CPU_TYPE      "Rodzaj procesora:"
+#define STR_CPU_SPEED     "Szybkość:"
+#define STR_FPU           "Jednostka FPU:"
+#define STR_WAIT_STATES   "Stany oczekiwania:"
 #define STR_MB            "MB"
 #define STR_MEMORY        "Pamięć:"
-#define STR_TIME_SYNC        "Synchronizacja czasu"
-#define STR_DISABLED        "Wyłączona"
-#define STR_ENABLED_LOCAL    "Włączona (czas lokalny)"
-#define STR_ENABLED_UTC        "Włączona (UTC)"
-#define STR_DYNAREC        "Dynamiczny rekompilator"
+#define STR_TIME_SYNC     "Synchronizacja czasu"
+#define STR_DISABLED      "Wyłączona"
+#define STR_ENABLED_LOCAL "Włączona (czas lokalny)"
+#define STR_ENABLED_UTC   "Włączona (UTC)"
+#define STR_DYNAREC       "Dynamiczny rekompilator"
 
-#define STR_VIDEO        "Wideo:"
-#define STR_VIDEO_2        "Wideo 2:"
+#define STR_VIDEO         "Wideo:"
+#define STR_VIDEO_2       "Wideo 2:"
 #define STR_VOODOO        "Grafika Voodoo"
-#define STR_IBM8514        "Grafika IBM 8514/a"
-#define STR_XGA            "Grafika XGA"
+#define STR_IBM8514       "Grafika IBM 8514/a"
+#define STR_XGA           "Grafika XGA"
 
-#define STR_MOUSE        "Mysz:"
-#define STR_JOYSTICK        "Joystick:"
-#define STR_JOY1        "Joystick 1..."
-#define STR_JOY2        "Joystick 2..."
-#define STR_JOY3        "Joystick 3..."
-#define STR_JOY4        "Joystick 4..."
+#define STR_MOUSE         "Mysz:"
+#define STR_JOYSTICK      "Joystick:"
+#define STR_JOY1          "Joystick 1..."
+#define STR_JOY2          "Joystick 2..."
+#define STR_JOY3          "Joystick 3..."
+#define STR_JOY4          "Joystick 4..."
 
 #define STR_SOUND1        "Karta dźwiękowa 1:"
 #define STR_SOUND2        "Karta dźwiękowa 2:"
 #define STR_SOUND3        "Karta dźwiękowa 3:"
 #define STR_SOUND4        "Karta dźwiękowa 4:"
-#define STR_MIDI_OUT        "Urządzenie wyjściowe MIDI:"
-#define STR_MIDI_IN        "Urządzenie wejściowe MIDI:"
+#define STR_MIDI_OUT      "Urządzenie wyjściowe MIDI:"
+#define STR_MIDI_IN       "Urządzenie wejściowe MIDI:"
 #define STR_MPU401        "Samodzielne urządzenie MPU-401"
-#define STR_FLOAT        "Użyj dźwięku FLOAT32"
-#define STR_FM_DRIVER        "Sterownik syntezy FM"
-#define STR_FM_DRV_NUKED    "Nuked (dokładniejszy)"
-#define STR_FM_DRV_YMFM        "YMFM (szybszy)"
+#define STR_FLOAT         "Użyj dźwięku FLOAT32"
+#define STR_FM_DRIVER     "Sterownik syntezy FM"
+#define STR_FM_DRV_NUKED  "Nuked (dokładniejszy)"
+#define STR_FM_DRV_YMFM   "YMFM (szybszy)"
 
-#define STR_NET_TYPE    "Rodzaj sieci:"
-#define STR_PCAP        "Urządzenie PCap:"
-#define STR_NET            "Karta sieciowa:"
-#define STR_NET1        "Network card 1:"
-#define STR_NET2        "Network card 2:"
-#define STR_NET3        "Network card 3:"
-#define STR_NET4        "Network card 4:"
+#define STR_NET_TYPE      "Rodzaj sieci:"
+#define STR_PCAP          "Urządzenie PCap:"
+#define STR_NET           "Karta sieciowa:"
+#define STR_NET1          "Network card 1:"
+#define STR_NET2          "Network card 2:"
+#define STR_NET3          "Network card 3:"
+#define STR_NET4          "Network card 4:"
 
-#define STR_COM1        "Urządzenie COM1:"
-#define STR_COM2        "Urządzenie COM2:"
-#define STR_COM3        "Urządzenie COM3:"
-#define STR_COM4        "Urządzenie COM4:"
-#define STR_LPT1        "Urządzenie LPT1:"
-#define STR_LPT2        "Urządzenie LPT2:"
-#define STR_LPT3        "Urządzenie LPT3:"
-#define STR_LPT4        "Urządzenie LPT4:"
-#define STR_SERIAL1        "Port szeregowy 1"
-#define STR_SERIAL2        "Port szeregowy 2"
-#define STR_SERIAL3        "Port szeregowy 3"
-#define STR_SERIAL4        "Port Szeregowy 4"
-#define STR_PARALLEL1        "Port równoległy 1"
-#define STR_PARALLEL2        "Port równoległy 2"
-#define STR_PARALLEL3        "Port równoległy 3"
-#define STR_PARALLEL4        "Port równoległy 4"
-#define STR_SERIAL_PASS1    "Serial port passthrough 1"
-#define STR_SERIAL_PASS2    "Serial port passthrough 2"
-#define STR_SERIAL_PASS3    "Serial port passthrough 3"
-#define STR_SERIAL_PASS4    "Serial port passthrough 4"
+#define STR_COM1          "Urządzenie COM1:"
+#define STR_COM2          "Urządzenie COM2:"
+#define STR_COM3          "Urządzenie COM3:"
+#define STR_COM4          "Urządzenie COM4:"
+#define STR_LPT1          "Urządzenie LPT1:"
+#define STR_LPT2          "Urządzenie LPT2:"
+#define STR_LPT3          "Urządzenie LPT3:"
+#define STR_LPT4          "Urządzenie LPT4:"
+#define STR_SERIAL1       "Port szeregowy 1"
+#define STR_SERIAL2       "Port szeregowy 2"
+#define STR_SERIAL3       "Port szeregowy 3"
+#define STR_SERIAL4       "Port Szeregowy 4"
+#define STR_PARALLEL1     "Port równoległy 1"
+#define STR_PARALLEL2     "Port równoległy 2"
+#define STR_PARALLEL3     "Port równoległy 3"
+#define STR_PARALLEL4     "Port równoległy 4"
+#define STR_SERIAL_PASS1  "Serial port passthrough 1"
+#define STR_SERIAL_PASS2  "Serial port passthrough 2"
+#define STR_SERIAL_PASS3  "Serial port passthrough 3"
+#define STR_SERIAL_PASS4  "Serial port passthrough 4"
 
-#define STR_HDC            "Kontroler dysku twardego:"
-#define STR_FDC            "Kontroler dyskietek:"
-#define STR_IDE_TER        "Trzeciorzędowy kontroler IDE"
-#define STR_IDE_QUA        "Czwartorzędowy kontroler IDE"
-#define STR_SCSI        "SCSI"
+#define STR_HDC           "Kontroler dysku twardego:"
+#define STR_FDC           "Kontroler dyskietek:"
+#define STR_IDE_TER       "Trzeciorzędowy kontroler IDE"
+#define STR_IDE_QUA       "Czwartorzędowy kontroler IDE"
+#define STR_SCSI          "SCSI"
 #define STR_SCSI_1        "Kontroler 1:"
 #define STR_SCSI_2        "Kontroler 2:"
 #define STR_SCSI_3        "Kontroler 3:"
 #define STR_SCSI_4        "Kontroler 4:"
 #define STR_CASSETTE        "Kaseta"
 
-#define STR_HDD            "Dyski twarde:"
-#define STR_NEW            "&Nowy..."
-#define STR_EXISTING        "&Istniejący..."
+#define STR_HDD           "Dyski twarde:"
+#define STR_NEW           "&Nowy..."
+#define STR_EXISTING      "&Istniejący..."
 #define STR_REMOVE        "&Usuń"
-#define STR_BUS            "Magistrala:"
-#define STR_CHANNEL        "Kanał:"
+#define STR_BUS           "Magistrala:"
+#define STR_CHANNEL       "Kanał:"
 #define STR_ID            "ID:"
-#define STR_SPEED        "Speed:"
+#define STR_SPEED         "Speed:"
 
-#define STR_SPECIFY        "&Określ..."
-#define STR_SECTORS        "Sektory:"
-#define STR_HEADS        "Głowice:"
-#define STR_CYLS        "Cylindry:"
-#define STR_SIZE_MB        "Rozmiar (MB):"
-#define STR_TYPE        "Rodzaj:"
-#define STR_IMG_FORMAT        "Format obrazu:"
-#define STR_BLOCK_SIZE        "Rozmiar bloku:"
+#define STR_SPECIFY       "&Określ..."
+#define STR_SECTORS       "Sektory:"
+#define STR_HEADS         "Głowice:"
+#define STR_CYLS          "Cylindry:"
+#define STR_SIZE_MB       "Rozmiar (MB):"
+#define STR_TYPE          "Rodzaj:"
+#define STR_IMG_FORMAT    "Format obrazu:"
+#define STR_BLOCK_SIZE    "Rozmiar bloku:"
 
-#define STR_FLOPPY_DRIVES    "Napędy dyskietek:"
-#define STR_TURBO        "Rozrządy Turbo"
-#define STR_CHECKBPB        "Sprawdzaj BPB"
-#define STR_CDROM_DRIVES    "Napędy CD-ROM:"
-#define STR_CD_SPEED        "Szybkość:"
-#define STR_EARLY        "Wcześniejszy napęd"
+#define STR_FLOPPY_DRIVES "Napędy dyskietek:"
+#define STR_TURBO         "Rozrządy Turbo"
+#define STR_CHECKBPB      "Sprawdzaj BPB"
+#define STR_CDROM_DRIVES  "Napędy CD-ROM:"
+#define STR_CD_SPEED      "Szybkość:"
+#define STR_EARLY         "Wcześniejszy napęd"
 
-#define STR_MO_DRIVES        "Napędy MO:"
-#define STR_ZIP_DRIVES        "Napędy ZIP:"
-#define STR_250            "ZIP 250"
+#define STR_MO_DRIVES     "Napędy MO:"
+#define STR_ZIP_DRIVES    "Napędy ZIP:"
+#define STR_250           "ZIP 250"
 
 #define STR_ISARTC        "ISA RTC:"
 #define STR_ISAMEM        "Rozszerzenie pamięci ISA"
-#define STR_ISAMEM_1        "Karta 1:"
-#define STR_ISAMEM_2        "Karta 2:"
-#define STR_ISAMEM_3        "Karta 3:"
-#define STR_ISAMEM_4        "Karta 4:"
+#define STR_ISAMEM_1      "Karta 1:"
+#define STR_ISAMEM_2      "Karta 2:"
+#define STR_ISAMEM_3      "Karta 3:"
+#define STR_ISAMEM_4      "Karta 4:"
 #define STR_BUGGER        "Urządzenie ISABugger"
-#define STR_POSTCARD        "Karta POST"
+#define STR_POSTCARD      "Karta POST"
 
-#define FONT_SIZE        9
-#define FONT_NAME        "Segoe UI"
+#define FONT_SIZE         9
+#define FONT_NAME         "Segoe UI"
 
 #include "dialogs.rc"
 
@@ -392,9 +392,9 @@ END
 // String Table
 //
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
-    2048    "86Box"
+    2048        "86Box"
     IDS_2049    "Błąd"
     IDS_2050    "Fatalny błąd"
     IDS_2051    " - PAUSED"
@@ -412,7 +412,7 @@ BEGIN
     IDS_2063    "Maszyna ""%hs"" nie jest dostępna, ponieważ brakuje obrazów ROM w katalogu roms/machines. Przełączanie na dostępną maszynę."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2064    "Karta wideo ""%hs"" nie jest dostępna, ponieważ brakuje obrazów ROM w katalogu roms/video. Przełączanie na dostępną kartę wideo."
     IDS_2065    "Maszyna"
@@ -432,7 +432,7 @@ BEGIN
     IDS_2079    "Naciśnij klawisze F8+F12 lub środkowy przycisk w celu uwolnienia myszy"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2080    "Nie można zainicjować FluidSynth"
     IDS_2081    "Magistrala"
@@ -544,7 +544,7 @@ BEGIN
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_4096    "Dysk twardy (%s)"
     IDS_4097    "%01i:%01i"
@@ -643,7 +643,7 @@ BEGIN
 
     IDS_7168    "(Domyślne ustawienie systemowe)"
 END
-#define IDS_LANG_ENUS    IDS_7168
+#define IDS_LANG_ENUS IDS_7168
 
 // Polish (pl-PL) resources
 /////////////////////////////////////////////////////////////////////////////

--- a/src/win/languages/pt-BR.rc
+++ b/src/win/languages/pt-BR.rc
@@ -16,122 +16,122 @@ LANGUAGE LANG_PORTUGUESE, SUBLANG_PORTUGUESE_BRAZILIAN
 // Menu
 //
 
-MainMenu MENU DISCARDABLE 
+MainMenu MENU DISCARDABLE
 BEGIN
     POPUP "&Ação"
     BEGIN
-        MENUITEM "&Teclado requer captura",    IDM_ACTION_KBD_REQ_CAPTURE
-        MENUITEM "CTRL &direito é o ALT esquerdo",    IDM_ACTION_RCTRL_IS_LALT
+        MENUITEM "&Teclado requer captura", IDM_ACTION_KBD_REQ_CAPTURE
+        MENUITEM "CTRL &direito é o ALT esquerdo", IDM_ACTION_RCTRL_IS_LALT
         MENUITEM SEPARATOR
-        MENUITEM "&Reinicialização completa...",                 IDM_ACTION_HRESET
-        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12",     IDM_ACTION_RESET_CAD
+        MENUITEM "&Reinicialização completa...", IDM_ACTION_HRESET
+        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12", IDM_ACTION_RESET_CAD
         MENUITEM SEPARATOR
-    MENUITEM "Ctrl+Alt+&Esc",        IDM_ACTION_CTRL_ALT_ESC
+    MENUITEM "Ctrl+Alt+&Esc", IDM_ACTION_CTRL_ALT_ESC
         MENUITEM SEPARATOR
-        MENUITEM "&Pausar",                      IDM_ACTION_PAUSE
+        MENUITEM "&Pausar", IDM_ACTION_PAUSE
         MENUITEM SEPARATOR
-        MENUITEM "&Sair...",                       IDM_ACTION_EXIT
+        MENUITEM "&Sair...", IDM_ACTION_EXIT
     END
     POPUP "&Exibir"
     BEGIN
-        MENUITEM "&Ocultar barra de status",        IDM_VID_HIDE_STATUS_BAR
-        MENUITEM "Ocultar &barra de ferramenta",        IDM_VID_HIDE_TOOLBAR
+        MENUITEM "&Ocultar barra de status", IDM_VID_HIDE_STATUS_BAR
+        MENUITEM "Ocultar &barra de ferramenta", IDM_VID_HIDE_TOOLBAR
         MENUITEM SEPARATOR
-        MENUITEM "&Mostrar monitores não-primários",  IDM_VID_MONITORS
-        MENUITEM "&Janela redimensionável",          IDM_VID_RESIZE
-        MENUITEM "&Lembrar tamanho e posição",  IDM_VID_REMEMBER
+        MENUITEM "&Mostrar monitores não-primários", IDM_VID_MONITORS
+        MENUITEM "&Janela redimensionável", IDM_VID_RESIZE
+        MENUITEM "&Lembrar tamanho e posição", IDM_VID_REMEMBER
         MENUITEM SEPARATOR
         POPUP "&Renderizador"
         BEGIN
-            MENUITEM "&SDL (Software)",         IDM_VID_SDL_SW
-            MENUITEM "SDL (&Hardware)",         IDM_VID_SDL_HW
-            MENUITEM "SDL (&OpenGL)",           IDM_VID_SDL_OPENGL
-            MENUITEM "Open&GL (Núcleo 3.0)",      IDM_VID_OPENGL_CORE
+            MENUITEM "&SDL (Software)", IDM_VID_SDL_SW
+            MENUITEM "SDL (&Hardware)", IDM_VID_SDL_HW
+            MENUITEM "SDL (&OpenGL)", IDM_VID_SDL_OPENGL
+            MENUITEM "Open&GL (Núcleo 3.0)", IDM_VID_OPENGL_CORE
 #ifdef USE_VNC
-            MENUITEM "&VNC",                    IDM_VID_VNC
+            MENUITEM "&VNC", IDM_VID_VNC
 #endif
         END
         MENUITEM SEPARATOR
-        MENUITEM "Especificar as dimensões...",          IDM_VID_SPECIFY_DIM
-        MENUITEM "F&orçar proporção de tela em 4:3",    IDM_VID_FORCE43
+        MENUITEM "Especificar as dimensões...", IDM_VID_SPECIFY_DIM
+        MENUITEM "F&orçar proporção de tela em 4:3", IDM_VID_FORCE43
         POPUP "&Fator de redimensionamento da janela"
         BEGIN
-            MENUITEM "&0,5x",                   IDM_VID_SCALE_1X
-            MENUITEM "&1x",                     IDM_VID_SCALE_2X
-            MENUITEM "1,&5x",                   IDM_VID_SCALE_3X
-            MENUITEM "&2x",                     IDM_VID_SCALE_4X
-            MENUITEM "&3x",                     IDM_VID_SCALE_5X
-            MENUITEM "&4x",                     IDM_VID_SCALE_6X
-            MENUITEM "&5x",                     IDM_VID_SCALE_7X
-            MENUITEM "&6x",                     IDM_VID_SCALE_8X
-            MENUITEM "&7x",                     IDM_VID_SCALE_9X
-            MENUITEM "&8x",                     IDM_VID_SCALE_10X
+            MENUITEM "&0,5x", IDM_VID_SCALE_1X
+            MENUITEM "&1x", IDM_VID_SCALE_2X
+            MENUITEM "1,&5x", IDM_VID_SCALE_3X
+            MENUITEM "&2x", IDM_VID_SCALE_4X
+            MENUITEM "&3x", IDM_VID_SCALE_5X
+            MENUITEM "&4x", IDM_VID_SCALE_6X
+            MENUITEM "&5x", IDM_VID_SCALE_7X
+            MENUITEM "&6x", IDM_VID_SCALE_8X
+            MENUITEM "&7x", IDM_VID_SCALE_9X
+            MENUITEM "&8x", IDM_VID_SCALE_10X
         END
         POPUP "Método de filtragem"
         BEGIN
-            MENUITEM "&Mais próximo",                 IDM_VID_FILTER_NEAREST
-            MENUITEM "&Linear",                  IDM_VID_FILTER_LINEAR
+            MENUITEM "&Mais próximo", IDM_VID_FILTER_NEAREST
+            MENUITEM "&Linear", IDM_VID_FILTER_LINEAR
         END
-        MENUITEM "Escala Hi&DPI",              IDM_VID_HIDPI
+        MENUITEM "Escala Hi&DPI", IDM_VID_HIDPI
         MENUITEM SEPARATOR
-        MENUITEM "&Tela cheia\tCtrl+Alt+PgUp",    IDM_VID_FULLSCREEN
+        MENUITEM "&Tela cheia\tCtrl+Alt+PgUp", IDM_VID_FULLSCREEN
         POPUP "Modo de &redimensionamento da tela cheia"
         BEGIN
-            MENUITEM "&Tela cheia esticada",        IDM_VID_FS_FULL
-            MENUITEM "&4:3",                        IDM_VID_FS_43
+            MENUITEM "&Tela cheia esticada", IDM_VID_FS_FULL
+            MENUITEM "&4:3", IDM_VID_FS_43
             MENUITEM "Pixel&s quadrados (manter proporção)", IDM_VID_FS_KEEPRATIO
-            MENUITEM "&Redimensionamento com valores inteiros",              IDM_VID_FS_INT
+            MENUITEM "&Redimensionamento com valores inteiros", IDM_VID_FS_INT
         END
         POPUP "Configurações E&GA/(S)VGA"
         BEGIN
-            MENUITEM "Monitor VGA &invertido",   IDM_VID_INVERT
+            MENUITEM "Monitor VGA &invertido", IDM_VID_INVERT
             POPUP "&Tipo de tela VGA"
             BEGIN
-                MENUITEM "&Cores RGB",          IDM_VID_GRAY_RGB
-                MENUITEM "Tons de cinza &RGB",      IDM_VID_GRAY_MONO
-                MENUITEM "Monitor &âmbar",      IDM_VID_GRAY_AMBER
-                MENUITEM "Monitor &verde",      IDM_VID_GRAY_GREEN
-                MENUITEM "Monitor &branco",      IDM_VID_GRAY_WHITE
+                MENUITEM "&Cores RGB", IDM_VID_GRAY_RGB
+                MENUITEM "Tons de cinza &RGB", IDM_VID_GRAY_MONO
+                MENUITEM "Monitor &âmbar", IDM_VID_GRAY_AMBER
+                MENUITEM "Monitor &verde", IDM_VID_GRAY_GREEN
+                MENUITEM "Monitor &branco", IDM_VID_GRAY_WHITE
             END
             POPUP "Tipo de &conversão de tons de cinza"
             BEGIN
-                MENUITEM "BT&601 (NTSC/PAL)",   IDM_VID_GRAYCT_601
-                MENUITEM "BT&709 (HDTV)",       IDM_VID_GRAYCT_709
-                MENUITEM "&Média",            IDM_VID_GRAYCT_AVE
+                MENUITEM "BT&601 (NTSC/PAL)", IDM_VID_GRAYCT_601
+                MENUITEM "BT&709 (HDTV)", IDM_VID_GRAYCT_709
+                MENUITEM "&Média", IDM_VID_GRAYCT_AVE
             END
         END
         MENUITEM SEPARATOR
-        MENUITEM "Overscan do CGA/PCjr/Tandy/E&GA/(S)VGA",     IDM_VID_OVERSCAN
+        MENUITEM "Overscan do CGA/PCjr/Tandy/E&GA/(S)VGA", IDM_VID_OVERSCAN
         MENUITEM "Alterar contraste para exibição &monocromática", IDM_VID_CGACON
     END
-    MENUITEM "&Mídia",                IDM_MEDIA
+    MENUITEM "&Mídia", IDM_MEDIA
     POPUP "&Ferramentas"
     BEGIN
-        MENUITEM "&Configurações...",                IDM_CONFIG
-        MENUITEM "&Atualizar ícones da barra de status",    IDM_UPDATE_ICONS
+        MENUITEM "&Configurações...", IDM_CONFIG
+        MENUITEM "&Atualizar ícones da barra de status", IDM_UPDATE_ICONS
         MENUITEM SEPARATOR
-        MENUITEM "Capturar &tela\tCtrl+F11",  IDM_ACTION_SCREENSHOT
+        MENUITEM "Capturar &tela\tCtrl+F11", IDM_ACTION_SCREENSHOT
         MENUITEM SEPARATOR
-        MENUITEM "&Preferências...",    IDM_PREFERENCES
+        MENUITEM "&Preferências...", IDM_PREFERENCES
 #ifdef DISCORD
         MENUITEM "Ativar integração com o &Discord", IDM_DISCORD
 #endif
         MENUITEM SEPARATOR
-        MENUITEM "&Ganho de som...",              IDM_SND_GAIN
+        MENUITEM "&Ganho de som...", IDM_SND_GAIN
 #ifdef MTR_ENABLED
         MENUITEM SEPARATOR
-        MENUITEM "Inicio do rastreamento\tCtrl+T",         IDM_ACTION_BEGIN_TRACE
-        MENUITEM "Fim do rastreamento\tCtrl+T",           IDM_ACTION_END_TRACE
+        MENUITEM "Inicio do rastreamento\tCtrl+T", IDM_ACTION_BEGIN_TRACE
+        MENUITEM "Fim do rastreamento\tCtrl+T", IDM_ACTION_END_TRACE
 #endif
     END
     POPUP "&Ajuda"
     BEGIN
-        MENUITEM "&Documentação...",           IDM_DOCS
-        MENUITEM "&Sobre o 86Box...",             IDM_ABOUT
+        MENUITEM "&Documentação...", IDM_DOCS
+        MENUITEM "&Sobre o 86Box...", IDM_ABOUT
     END
 END
 
-StatusBarMenu MENU DISCARDABLE 
+StatusBarMenu MENU DISCARDABLE
 BEGIN
     MENUITEM SEPARATOR
 END
@@ -140,17 +140,17 @@ CassetteSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nova imagem...",                IDM_CASSETTE_IMAGE_NEW
+        MENUITEM "&Nova imagem...", IDM_CASSETTE_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Imagem existente...",                IDM_CASSETTE_IMAGE_EXISTING
-        MENUITEM "Imagem existente (&protegida contra escrita)...",    IDM_CASSETTE_IMAGE_EXISTING_WP
+        MENUITEM "&Imagem existente...", IDM_CASSETTE_IMAGE_EXISTING
+        MENUITEM "Imagem existente (&protegida contra escrita)...", IDM_CASSETTE_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Gravar",                    IDM_CASSETTE_RECORD
-        MENUITEM "&Reproduzir",                    IDM_CASSETTE_PLAY
-        MENUITEM "&Rebobinar até o começo",            IDM_CASSETTE_REWIND
-        MENUITEM "&Avançar até o fim",            IDM_CASSETTE_FAST_FORWARD
+        MENUITEM "&Gravar", IDM_CASSETTE_RECORD
+        MENUITEM "&Reproduzir", IDM_CASSETTE_PLAY
+        MENUITEM "&Rebobinar até o começo", IDM_CASSETTE_REWIND
+        MENUITEM "&Avançar até o fim", IDM_CASSETTE_FAST_FORWARD
         MENUITEM SEPARATOR
-        MENUITEM "E&jetar",                    IDM_CASSETTE_EJECT
+        MENUITEM "E&jetar", IDM_CASSETTE_EJECT
     END
 END
 
@@ -158,9 +158,9 @@ CartridgeSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Imagem...",                    IDM_CARTRIDGE_IMAGE
+        MENUITEM "&Imagem...", IDM_CARTRIDGE_IMAGE
         MENUITEM SEPARATOR
-        MENUITEM "E&jetar",                    IDM_CARTRIDGE_EJECT
+        MENUITEM "E&jetar", IDM_CARTRIDGE_EJECT
     END
 END
 
@@ -168,14 +168,14 @@ FloppySubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nova imagem...",                IDM_FLOPPY_IMAGE_NEW
+        MENUITEM "&Nova imagem...", IDM_FLOPPY_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Imagem existente...",                IDM_FLOPPY_IMAGE_EXISTING
-        MENUITEM "Imagem existente (&protegida contra escrita)...",    IDM_FLOPPY_IMAGE_EXISTING_WP
+        MENUITEM "&Imagem existente...", IDM_FLOPPY_IMAGE_EXISTING
+        MENUITEM "Imagem existente (&protegida contra escrita)...", IDM_FLOPPY_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "E&xportar para 86F...",                IDM_FLOPPY_EXPORT_TO_86F
+        MENUITEM "E&xportar para 86F...", IDM_FLOPPY_EXPORT_TO_86F
         MENUITEM SEPARATOR
-        MENUITEM "E&jetar",                    IDM_FLOPPY_EJECT
+        MENUITEM "E&jetar", IDM_FLOPPY_EJECT
     END
 END
 
@@ -183,13 +183,13 @@ CdromSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Sem som",                    IDM_CDROM_MUTE
+        MENUITEM "&Sem som", IDM_CDROM_MUTE
         MENUITEM SEPARATOR
-        MENUITEM "&Vazio",                    IDM_CDROM_EMPTY
-        MENUITEM "&Recarregar imagem anterior",            IDM_CDROM_RELOAD
+        MENUITEM "&Vazio", IDM_CDROM_EMPTY
+        MENUITEM "&Recarregar imagem anterior", IDM_CDROM_RELOAD
         MENUITEM SEPARATOR
-        MENUITEM "&Imagem...",                    IDM_CDROM_IMAGE
-        MENUITEM "&Pasta...",                    IDM_CDROM_DIR
+        MENUITEM "&Imagem...", IDM_CDROM_IMAGE
+        MENUITEM "&Pasta...", IDM_CDROM_DIR
     END
 END
 
@@ -197,13 +197,13 @@ ZIPSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nova imagem...",                IDM_ZIP_IMAGE_NEW
+        MENUITEM "&Nova imagem...", IDM_ZIP_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Imagem existente...",                IDM_ZIP_IMAGE_EXISTING
-        MENUITEM "Imagem existente (&protegida contra escrita)...",    IDM_ZIP_IMAGE_EXISTING_WP
+        MENUITEM "&Imagem existente...", IDM_ZIP_IMAGE_EXISTING
+        MENUITEM "Imagem existente (&protegida contra escrita)...", IDM_ZIP_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "E&jetar",                    IDM_ZIP_EJECT
-        MENUITEM "&Recarregar imagem anterior",            IDM_ZIP_RELOAD
+        MENUITEM "E&jetar", IDM_ZIP_EJECT
+        MENUITEM "&Recarregar imagem anterior", IDM_ZIP_RELOAD
     END
 END
 
@@ -211,13 +211,13 @@ MOSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nova imagem...",                IDM_MO_IMAGE_NEW
+        MENUITEM "&Nova imagem...", IDM_MO_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Imagem existente...",                IDM_MO_IMAGE_EXISTING
-        MENUITEM "Imagem existente (&protegida contra escrita)...",    IDM_MO_IMAGE_EXISTING_WP
+        MENUITEM "&Imagem existente...", IDM_MO_IMAGE_EXISTING
+        MENUITEM "Imagem existente (&protegida contra escrita)...", IDM_MO_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "E&jetar",                    IDM_MO_EJECT
-        MENUITEM "&Recarregar imagem anterior",            IDM_MO_RELOAD
+        MENUITEM "E&jetar", IDM_MO_EJECT
+        MENUITEM "&Recarregar imagem anterior", IDM_MO_RELOAD
     END
 END
 
@@ -243,150 +243,150 @@ END
 // Dialog
 //
 
-#define STR_PREFERENCES        "Preferências"
-#define STR_SND_GAIN        "Ganho de som"
-#define STR_NEW_FLOPPY        "Nova imagem de disquete"
+#define STR_PREFERENCES   "Preferências"
+#define STR_SND_GAIN      "Ganho de som"
+#define STR_NEW_FLOPPY    "Nova imagem de disquete"
 #define STR_CONFIG        "Configurações"
-#define STR_SPECIFY_DIM        "Especifique as dimensões da janela principal"
+#define STR_SPECIFY_DIM   "Especifique as dimensões da janela principal"
 
 #define STR_OK            "OK"
 #define STR_CANCEL        "Cancelar"
 #define STR_GLOBAL        "Usar estas configurações como &padrões globais"
-#define STR_DEFAULT        "&Padrão"
-#define STR_LANGUAGE        "Idioma:"
-#define STR_ICONSET        "Pacote de ícones:"
+#define STR_DEFAULT       "&Padrão"
+#define STR_LANGUAGE      "Idioma:"
+#define STR_ICONSET       "Pacote de ícones:"
 
-#define STR_GAIN        "Ganho"
+#define STR_GAIN          "Ganho"
 
-#define STR_FILE_NAME        "Nome:"
-#define STR_DISK_SIZE        "Tamanho:"
-#define STR_RPM_MODE        "Modo RPM:"
-#define STR_PROGRESS        "Progresso:"
+#define STR_FILE_NAME     "Nome:"
+#define STR_DISK_SIZE     "Tamanho:"
+#define STR_RPM_MODE      "Modo RPM:"
+#define STR_PROGRESS      "Progresso:"
 
-#define STR_WIDTH        "Largura:"
+#define STR_WIDTH         "Largura:"
 #define STR_HEIGHT        "Altura:"
-#define STR_LOCK_TO_SIZE    "Travar nesse tamanho"
+#define STR_LOCK_TO_SIZE  "Travar nesse tamanho"
 
-#define STR_MACHINE_TYPE    "Tipo de máquina:"
-#define STR_MACHINE        "Máquina:"
-#define STR_CONFIGURE        "Configurar"
-#define STR_CPU_TYPE        "Tipo de CPU:"
-#define STR_CPU_SPEED        "Veloc.:"
-#define STR_FPU            "FPU:"
-#define STR_WAIT_STATES        "Estados de espera:"
+#define STR_MACHINE_TYPE  "Tipo de máquina:"
+#define STR_MACHINE       "Máquina:"
+#define STR_CONFIGURE     "Configurar"
+#define STR_CPU_TYPE      "Tipo de CPU:"
+#define STR_CPU_SPEED     "Veloc.:"
+#define STR_FPU           "FPU:"
+#define STR_WAIT_STATES   "Estados de espera:"
 #define STR_MB            "MB"
 #define STR_MEMORY        "Memória:"
-#define STR_TIME_SYNC        "Sincronização da hora"
-#define STR_DISABLED        "Desativar"
-#define STR_ENABLED_LOCAL    "Ativar (hora local)"
-#define STR_ENABLED_UTC        "Ativar (UTC)"
-#define STR_DYNAREC        "Recompilador dinâmico"
+#define STR_TIME_SYNC     "Sincronização da hora"
+#define STR_DISABLED      "Desativar"
+#define STR_ENABLED_LOCAL "Ativar (hora local)"
+#define STR_ENABLED_UTC   "Ativar (UTC)"
+#define STR_DYNAREC       "Recompilador dinâmico"
 
-#define STR_VIDEO        "Vídeo:"
-#define STR_VIDEO_2        "Vídeo 2:"
+#define STR_VIDEO         "Vídeo:"
+#define STR_VIDEO_2       "Vídeo 2:"
 #define STR_VOODOO        "3DFX Voodoo"
-#define STR_IBM8514        "Gráficos IBM 8514/a"
-#define STR_XGA            "Gráficos XGA"
+#define STR_IBM8514       "Gráficos IBM 8514/a"
+#define STR_XGA           "Gráficos XGA"
 
-#define STR_MOUSE        "Mouse:"
-#define STR_JOYSTICK        "Joystick:"
-#define STR_JOY1        "Joystick 1..."
-#define STR_JOY2        "Joystick 2..."
-#define STR_JOY3        "Joystick 3..."
-#define STR_JOY4        "Joystick 4..."
+#define STR_MOUSE         "Mouse:"
+#define STR_JOYSTICK      "Joystick:"
+#define STR_JOY1          "Joystick 1..."
+#define STR_JOY2          "Joystick 2..."
+#define STR_JOY3          "Joystick 3..."
+#define STR_JOY4          "Joystick 4..."
 
 #define STR_SOUND1        "Placa de som 1:"
 #define STR_SOUND2        "Placa de som 2:"
 #define STR_SOUND3        "Placa de som 3:"
 #define STR_SOUND4        "Placa de som 4:"
-#define STR_MIDI_OUT        "Disp. saída MIDI:"
-#define STR_MIDI_IN        "Disp. entrada MIDI:"
+#define STR_MIDI_OUT      "Disp. saída MIDI:"
+#define STR_MIDI_IN       "Disp. entrada MIDI:"
 #define STR_MPU401        "MPU-401 autônomo"
-#define STR_FLOAT        "Usar som FLOAT32"
-#define STR_FM_DRIVER        "Controlador de sint. FM"
-#define STR_FM_DRV_NUKED    "Nuked (mais preciso)"
-#define STR_FM_DRV_YMFM        "YMFM (mais rápido)"
+#define STR_FLOAT         "Usar som FLOAT32"
+#define STR_FM_DRIVER     "Controlador de sint. FM"
+#define STR_FM_DRV_NUKED  "Nuked (mais preciso)"
+#define STR_FM_DRV_YMFM   "YMFM (mais rápido)"
 
-#define STR_NET_TYPE        "Tipo de rede:"
-#define STR_PCAP        "Dispositivo PCap:"
-#define STR_NET            "Adaptador de rede:"
-#define STR_NET1        "Network card 1:"
-#define STR_NET2        "Network card 2:"
-#define STR_NET3        "Network card 3:"
-#define STR_NET4        "Network card 4:"
+#define STR_NET_TYPE      "Tipo de rede:"
+#define STR_PCAP          "Dispositivo PCap:"
+#define STR_NET           "Adaptador de rede:"
+#define STR_NET1          "Network card 1:"
+#define STR_NET2          "Network card 2:"
+#define STR_NET3          "Network card 3:"
+#define STR_NET4          "Network card 4:"
 
-#define STR_COM1        "Dispositivo COM1:"
-#define STR_COM2        "Dispositivo COM2:"
-#define STR_COM3        "Dispositivo COM3:"
-#define STR_COM4        "Dispositivo COM4:"
-#define STR_LPT1        "Dispositivo LPT1:"
-#define STR_LPT2        "Dispositivo LPT2:"
-#define STR_LPT3        "Dispositivo LPT3:"
-#define STR_LPT4        "Dispositivo LPT4:"
-#define STR_SERIAL1        "Porta serial 1"
-#define STR_SERIAL2        "Porta serial 2"
-#define STR_SERIAL3        "Porta serial 3"
-#define STR_SERIAL4        "Porta serial 4"
-#define STR_PARALLEL1        "Porta paralela 1"
-#define STR_PARALLEL2        "Porta paralela 2"
-#define STR_PARALLEL3        "Porta paralela 3"
-#define STR_PARALLEL4        "Porta paralela 4"
-#define STR_SERIAL_PASS1    "Serial port passthrough 1"
-#define STR_SERIAL_PASS2    "Serial port passthrough 2"
-#define STR_SERIAL_PASS3    "Serial port passthrough 3"
-#define STR_SERIAL_PASS4    "Serial port passthrough 4"
+#define STR_COM1          "Dispositivo COM1:"
+#define STR_COM2          "Dispositivo COM2:"
+#define STR_COM3          "Dispositivo COM3:"
+#define STR_COM4          "Dispositivo COM4:"
+#define STR_LPT1          "Dispositivo LPT1:"
+#define STR_LPT2          "Dispositivo LPT2:"
+#define STR_LPT3          "Dispositivo LPT3:"
+#define STR_LPT4          "Dispositivo LPT4:"
+#define STR_SERIAL1       "Porta serial 1"
+#define STR_SERIAL2       "Porta serial 2"
+#define STR_SERIAL3       "Porta serial 3"
+#define STR_SERIAL4       "Porta serial 4"
+#define STR_PARALLEL1     "Porta paralela 1"
+#define STR_PARALLEL2     "Porta paralela 2"
+#define STR_PARALLEL3     "Porta paralela 3"
+#define STR_PARALLEL4     "Porta paralela 4"
+#define STR_SERIAL_PASS1  "Serial port passthrough 1"
+#define STR_SERIAL_PASS2  "Serial port passthrough 2"
+#define STR_SERIAL_PASS3  "Serial port passthrough 3"
+#define STR_SERIAL_PASS4  "Serial port passthrough 4"
 
-#define STR_HDC            "Controlador HD:"
-#define STR_FDC            "Controlador FD:"
-#define STR_IDE_TER        "Controlador IDE terciário"
-#define STR_IDE_QUA        "Controlador IDE quaternário"
-#define STR_SCSI        "SCSI"
+#define STR_HDC           "Controlador HD:"
+#define STR_FDC           "Controlador FD:"
+#define STR_IDE_TER       "Controlador IDE terciário"
+#define STR_IDE_QUA       "Controlador IDE quaternário"
+#define STR_SCSI          "SCSI"
 #define STR_SCSI_1        "Controlador 1:"
 #define STR_SCSI_2        "Controlador 2:"
 #define STR_SCSI_3        "Controlador 3:"
 #define STR_SCSI_4        "Controlador 4:"
-#define STR_CASSETTE        "Cassete"
+#define STR_CASSETTE      "Cassete"
 
-#define STR_HDD            "Discos rígidos:"
-#define STR_NEW            "&Novo..."
-#define STR_EXISTING        "&Existente..."
+#define STR_HDD           "Discos rígidos:"
+#define STR_NEW           "&Novo..."
+#define STR_EXISTING      "&Existente..."
 #define STR_REMOVE        "&Remover"
-#define STR_BUS            "Bar.:"
-#define STR_CHANNEL        "Canal:"
+#define STR_BUS           "Bar.:"
+#define STR_CHANNEL       "Canal:"
 #define STR_ID            "ID:"
-#define STR_SPEED        "Velocidade:"
+#define STR_SPEED         "Velocidade:"
 
-#define STR_SPECIFY        "&Especificar..."
-#define STR_SECTORS        "Setores:"
-#define STR_HEADS        "Cabeças:"
-#define STR_CYLS        "Cilindros:"
-#define STR_SIZE_MB        "Tamanho (MB):"
-#define STR_TYPE        "Tipo:"
-#define STR_IMG_FORMAT        "Formato:"
-#define STR_BLOCK_SIZE        "Blocos:"
+#define STR_SPECIFY       "&Especificar..."
+#define STR_SECTORS       "Setores:"
+#define STR_HEADS         "Cabeças:"
+#define STR_CYLS          "Cilindros:"
+#define STR_SIZE_MB       "Tamanho (MB):"
+#define STR_TYPE          "Tipo:"
+#define STR_IMG_FORMAT    "Formato:"
+#define STR_BLOCK_SIZE    "Blocos:"
 
-#define STR_FLOPPY_DRIVES    "Unidades de disquete:"
-#define STR_TURBO        "Turbo"
-#define STR_CHECKBPB        "Verificar BPB"
-#define STR_CDROM_DRIVES    "Unidades de CD-ROM:"
-#define STR_CD_SPEED        "Veloc.:"
-#define STR_EARLY        "Unidade anterior"
+#define STR_FLOPPY_DRIVES "Unidades de disquete:"
+#define STR_TURBO         "Turbo"
+#define STR_CHECKBPB      "Verificar BPB"
+#define STR_CDROM_DRIVES  "Unidades de CD-ROM:"
+#define STR_CD_SPEED      "Veloc.:"
+#define STR_EARLY         "Unidade anterior"
 
-#define STR_MO_DRIVES        "Unidades magneto-ópticas:"
-#define STR_ZIP_DRIVES        "Unidades ZIP:"
-#define STR_250            "ZIP 250"
+#define STR_MO_DRIVES     "Unidades magneto-ópticas:"
+#define STR_ZIP_DRIVES    "Unidades ZIP:"
+#define STR_250           "ZIP 250"
 
 #define STR_ISARTC        "RTC ISA:"
 #define STR_ISAMEM        "Expansão de memória ISA"
-#define STR_ISAMEM_1        "Placa 1:"
-#define STR_ISAMEM_2        "Placa 2:"
-#define STR_ISAMEM_3        "Placa 3:"
-#define STR_ISAMEM_4        "Placa 4:"
+#define STR_ISAMEM_1      "Placa 1:"
+#define STR_ISAMEM_2      "Placa 2:"
+#define STR_ISAMEM_3      "Placa 3:"
+#define STR_ISAMEM_4      "Placa 4:"
 #define STR_BUGGER        "Dispositivo ISABugger"
-#define STR_POSTCARD        "Placa de diagnóstico"
+#define STR_POSTCARD      "Placa de diagnóstico"
 
-#define FONT_SIZE        9
-#define FONT_NAME        "Segoe UI"
+#define FONT_SIZE         9
+#define FONT_NAME         "Segoe UI"
 
 #include "dialogs.rc"
 
@@ -395,9 +395,9 @@ END
 // String Table
 //
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
-    2048    "86Box"
+    2048        "86Box"
     IDS_2049    "Erro"
     IDS_2050    "Erro fatal"
     IDS_2051    " - PAUSADO"
@@ -415,7 +415,7 @@ BEGIN
     IDS_2063    "A máquina ""%hs"" não está disponível devido à falta de ROMs no diretório roms/machines. Mudando para uma máquina disponível."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2064    "A placa de vídeo ""%hs"" não está disponível devido à falta de ROMs no diretório roms/video. Mudando para uma placa de vídeo disponível."
     IDS_2065    "Máquina"
@@ -435,7 +435,7 @@ BEGIN
     IDS_2079    "Aperte F8+F12 ou botão do meio para liberar o mouse"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2080    "Não foi possível inicializar o FluidSynth"
     IDS_2081    "Barramento"
@@ -547,7 +547,7 @@ BEGIN
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_4096    "Disco rígido (%s)"
     IDS_4097    "%01i:%01i"
@@ -646,7 +646,7 @@ BEGIN
 
     IDS_7168    "(Padrão do sistema)"
 END
-#define IDS_LANG_ENUS    IDS_7168
+#define IDS_LANG_ENUS IDS_7168
 
 // Portuguese (pt-BR) resources
 /////////////////////////////////////////////////////////////////////////////

--- a/src/win/languages/pt-PT.rc
+++ b/src/win/languages/pt-PT.rc
@@ -13,122 +13,122 @@ LANGUAGE LANG_PORTUGUESE, SUBLANG_PORTUGUESE
 // Menu
 //
 
-MainMenu MENU DISCARDABLE 
+MainMenu MENU DISCARDABLE
 BEGIN
     POPUP "&Ação"
     BEGIN
-        MENUITEM "&Teclado requere captura",    IDM_ACTION_KBD_REQ_CAPTURE
+        MENUITEM "&Teclado requere captura", IDM_ACTION_KBD_REQ_CAPTURE
         MENUITEM "&CTRL direito é ALT esquerdo",IDM_ACTION_RCTRL_IS_LALT
         MENUITEM SEPARATOR
         MENUITEM "&Reinicialização completa...",IDM_ACTION_HRESET
-        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12",     IDM_ACTION_RESET_CAD
+        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12", IDM_ACTION_RESET_CAD
         MENUITEM SEPARATOR
-    MENUITEM "Ctrl+Alt+&Esc",        IDM_ACTION_CTRL_ALT_ESC
+    MENUITEM "Ctrl+Alt+&Esc", IDM_ACTION_CTRL_ALT_ESC
         MENUITEM SEPARATOR
-        MENUITEM "&Pausa",                      IDM_ACTION_PAUSE
+        MENUITEM "&Pausa", IDM_ACTION_PAUSE
         MENUITEM SEPARATOR
-        MENUITEM "&Sair...",                    IDM_ACTION_EXIT
+        MENUITEM "&Sair...", IDM_ACTION_EXIT
     END
     POPUP "&Ver"
     BEGIN
-        MENUITEM "&Ocultar barra de estado",    IDM_VID_HIDE_STATUS_BAR
-        MENUITEM "Hide &toolbar",        IDM_VID_HIDE_TOOLBAR
+        MENUITEM "&Ocultar barra de estado", IDM_VID_HIDE_STATUS_BAR
+        MENUITEM "Hide &toolbar", IDM_VID_HIDE_TOOLBAR
         MENUITEM SEPARATOR
-        MENUITEM "&Show non-primary monitors",  IDM_VID_MONITORS
-        MENUITEM "&Janela redimensionável",     IDM_VID_RESIZE
-        MENUITEM "&Lembrar tamanho e posição",  IDM_VID_REMEMBER
+        MENUITEM "&Show non-primary monitors", IDM_VID_MONITORS
+        MENUITEM "&Janela redimensionável", IDM_VID_RESIZE
+        MENUITEM "&Lembrar tamanho e posição", IDM_VID_REMEMBER
         MENUITEM SEPARATOR
         POPUP "&Renderizador"
         BEGIN
-            MENUITEM "&SDL (Software)",         IDM_VID_SDL_SW
-            MENUITEM "SDL (&Hardware)",         IDM_VID_SDL_HW
-            MENUITEM "SDL (&OpenGL)",           IDM_VID_SDL_OPENGL
-            MENUITEM "Open&GL (Núcleo 3.0)",    IDM_VID_OPENGL_CORE
+            MENUITEM "&SDL (Software)", IDM_VID_SDL_SW
+            MENUITEM "SDL (&Hardware)", IDM_VID_SDL_HW
+            MENUITEM "SDL (&OpenGL)", IDM_VID_SDL_OPENGL
+            MENUITEM "Open&GL (Núcleo 3.0)", IDM_VID_OPENGL_CORE
 #ifdef USE_VNC
-            MENUITEM "&VNC",                    IDM_VID_VNC
+            MENUITEM "&VNC", IDM_VID_VNC
 #endif
         END
         MENUITEM SEPARATOR
-        MENUITEM "&Especificar dimensões...",   IDM_VID_SPECIFY_DIM
-        MENUITEM "&Forçar rácio de visualização 4:3",    IDM_VID_FORCE43
+        MENUITEM "&Especificar dimensões...", IDM_VID_SPECIFY_DIM
+        MENUITEM "&Forçar rácio de visualização 4:3", IDM_VID_FORCE43
         POPUP "F&actor de escala de janela"
         BEGIN
-            MENUITEM "&0.5x",                   IDM_VID_SCALE_1X
-            MENUITEM "&1x",                     IDM_VID_SCALE_2X
-            MENUITEM "1.&5x",                   IDM_VID_SCALE_3X
-            MENUITEM "&2x",                     IDM_VID_SCALE_4X
-            MENUITEM "&3x",                     IDM_VID_SCALE_5X
-            MENUITEM "&4x",                     IDM_VID_SCALE_6X
-            MENUITEM "&5x",                     IDM_VID_SCALE_7X
-            MENUITEM "&6x",                     IDM_VID_SCALE_8X
-            MENUITEM "&7x",                     IDM_VID_SCALE_9X
-            MENUITEM "&8x",                     IDM_VID_SCALE_10X
+            MENUITEM "&0.5x", IDM_VID_SCALE_1X
+            MENUITEM "&1x", IDM_VID_SCALE_2X
+            MENUITEM "1.&5x", IDM_VID_SCALE_3X
+            MENUITEM "&2x", IDM_VID_SCALE_4X
+            MENUITEM "&3x", IDM_VID_SCALE_5X
+            MENUITEM "&4x", IDM_VID_SCALE_6X
+            MENUITEM "&5x", IDM_VID_SCALE_7X
+            MENUITEM "&6x", IDM_VID_SCALE_8X
+            MENUITEM "&7x", IDM_VID_SCALE_9X
+            MENUITEM "&8x", IDM_VID_SCALE_10X
         END
         POPUP "Método de filtragem"
         BEGIN
-            MENUITEM "&Mais próximo",            IDM_VID_FILTER_NEAREST
-            MENUITEM "&Linear",                  IDM_VID_FILTER_LINEAR
+            MENUITEM "&Mais próximo", IDM_VID_FILTER_NEAREST
+            MENUITEM "&Linear", IDM_VID_FILTER_LINEAR
         END
-        MENUITEM "Escala Hi&DPI",                IDM_VID_HIDPI
+        MENUITEM "Escala Hi&DPI", IDM_VID_HIDPI
         MENUITEM SEPARATOR
-        MENUITEM "E&crã cheio\tCtrl+Alt+PgUp",    IDM_VID_FULLSCREEN
+        MENUITEM "E&crã cheio\tCtrl+Alt+PgUp", IDM_VID_FULLSCREEN
         POPUP "Modo &de estiramento em ecrã cheio"
         BEGIN
-            MENUITEM "&Estiramento em ecrã cheio",  IDM_VID_FS_FULL
-            MENUITEM "&4:3",                        IDM_VID_FS_43
+            MENUITEM "&Estiramento em ecrã cheio", IDM_VID_FS_FULL
+            MENUITEM "&4:3", IDM_VID_FS_43
             MENUITEM "Pixels &quadrados (Manter rácio)", IDM_VID_FS_KEEPRATIO
-            MENUITEM "Escala &inteira",              IDM_VID_FS_INT
+            MENUITEM "Escala &inteira", IDM_VID_FS_INT
         END
         POPUP "Definições E&GA/(S)VGA"
         BEGIN
-            MENUITEM "Monitor VGA &invertido",   IDM_VID_INVERT
+            MENUITEM "Monitor VGA &invertido", IDM_VID_INVERT
             POPUP "&Tipo de ecrã VGA"
             BEGIN
-                MENUITEM "&Cores RGB",          IDM_VID_GRAY_RGB
-                MENUITEM "&RGB em escala de cinzentos",      IDM_VID_GRAY_MONO
-                MENUITEM "Monitor âmb&ar",      IDM_VID_GRAY_AMBER
-                MENUITEM "Monitor &verde",      IDM_VID_GRAY_GREEN
-                MENUITEM "Monitor &branco",     IDM_VID_GRAY_WHITE
+                MENUITEM "&Cores RGB", IDM_VID_GRAY_RGB
+                MENUITEM "&RGB em escala de cinzentos", IDM_VID_GRAY_MONO
+                MENUITEM "Monitor âmb&ar", IDM_VID_GRAY_AMBER
+                MENUITEM "Monitor &verde", IDM_VID_GRAY_GREEN
+                MENUITEM "Monitor &branco", IDM_VID_GRAY_WHITE
             END
             POPUP "Tipo de &conversão para escala de cinzentos"
             BEGIN
-                MENUITEM "BT&601 (NTSC/PAL)",   IDM_VID_GRAYCT_601
-                MENUITEM "BT&709 (HDTV)",       IDM_VID_GRAYCT_709
-                MENUITEM "&Media",              IDM_VID_GRAYCT_AVE
+                MENUITEM "BT&601 (NTSC/PAL)", IDM_VID_GRAYCT_601
+                MENUITEM "BT&709 (HDTV)", IDM_VID_GRAYCT_709
+                MENUITEM "&Media", IDM_VID_GRAYCT_AVE
             END
         END
         MENUITEM SEPARATOR
-        MENUITEM "Overscan de CGA/PCjr/Tandy/E&GA/(S)VGA",  IDM_VID_OVERSCAN
+        MENUITEM "Overscan de CGA/PCjr/Tandy/E&GA/(S)VGA", IDM_VID_OVERSCAN
         MENUITEM "Mudar &contraste para ecrã monocromático", IDM_VID_CGACON
     END
-    MENUITEM "&Media",                IDM_MEDIA
+    MENUITEM "&Media", IDM_MEDIA
     POPUP "&Ferramentas"
     BEGIN
-        MENUITEM "&Definições...",              IDM_CONFIG
-        MENUITEM "&Atualizar ícones da barra de estado",    IDM_UPDATE_ICONS
+        MENUITEM "&Definições...", IDM_CONFIG
+        MENUITEM "&Atualizar ícones da barra de estado", IDM_UPDATE_ICONS
         MENUITEM SEPARATOR
-        MENUITEM "Gravar imagem de ecrã\tCtrl+F11",  IDM_ACTION_SCREENSHOT
+        MENUITEM "Gravar imagem de ecrã\tCtrl+F11", IDM_ACTION_SCREENSHOT
         MENUITEM SEPARATOR
-        MENUITEM "&Preferências...",    IDM_PREFERENCES
+        MENUITEM "&Preferências...", IDM_PREFERENCES
 #ifdef DISCORD
         MENUITEM "Ativar integração com &Discord", IDM_DISCORD
 #endif
         MENUITEM SEPARATOR
-        MENUITEM "&Ganho de som...",              IDM_SND_GAIN
+        MENUITEM "&Ganho de som...", IDM_SND_GAIN
 #ifdef MTR_ENABLED
         MENUITEM SEPARATOR
-        MENUITEM "Iniciar o rastreio\tCtrl+T",         IDM_ACTION_BEGIN_TRACE
-        MENUITEM "Terminar o rastreio\tCtrl+T",           IDM_ACTION_END_TRACE
+        MENUITEM "Iniciar o rastreio\tCtrl+T", IDM_ACTION_BEGIN_TRACE
+        MENUITEM "Terminar o rastreio\tCtrl+T", IDM_ACTION_END_TRACE
 #endif
     END
     POPUP "&Ajuda"
     BEGIN
-        MENUITEM "&Documentação...",           IDM_DOCS
-        MENUITEM "&Acerca do 86Box...",        IDM_ABOUT
+        MENUITEM "&Documentação...", IDM_DOCS
+        MENUITEM "&Acerca do 86Box...", IDM_ABOUT
     END
 END
 
-StatusBarMenu MENU DISCARDABLE 
+StatusBarMenu MENU DISCARDABLE
 BEGIN
     MENUITEM SEPARATOR
 END
@@ -137,17 +137,17 @@ CassetteSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nova imagem...",                IDM_CASSETTE_IMAGE_NEW
+        MENUITEM "&Nova imagem...", IDM_CASSETTE_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "Imagem &existente...",            IDM_CASSETTE_IMAGE_EXISTING
-        MENUITEM "Imagem existente (&Proteção contra escrita)...",    IDM_CASSETTE_IMAGE_EXISTING_WP
+        MENUITEM "Imagem &existente...", IDM_CASSETTE_IMAGE_EXISTING
+        MENUITEM "Imagem existente (&Proteção contra escrita)...", IDM_CASSETTE_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Gravar",                    IDM_CASSETTE_RECORD
-        MENUITEM "&Reproduzir",                    IDM_CASSETTE_PLAY
-        MENUITEM "Re&bobinar para o início",            IDM_CASSETTE_REWIND
-        MENUITEM "&Avanço rápido para o fim",            IDM_CASSETTE_FAST_FORWARD
+        MENUITEM "&Gravar", IDM_CASSETTE_RECORD
+        MENUITEM "&Reproduzir", IDM_CASSETTE_PLAY
+        MENUITEM "Re&bobinar para o início", IDM_CASSETTE_REWIND
+        MENUITEM "&Avanço rápido para o fim", IDM_CASSETTE_FAST_FORWARD
         MENUITEM SEPARATOR
-        MENUITEM "E&jetar",                    IDM_CASSETTE_EJECT
+        MENUITEM "E&jetar", IDM_CASSETTE_EJECT
     END
 END
 
@@ -155,9 +155,9 @@ CartridgeSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Imagem...",                    IDM_CARTRIDGE_IMAGE
+        MENUITEM "&Imagem...", IDM_CARTRIDGE_IMAGE
         MENUITEM SEPARATOR
-        MENUITEM "E&jetar",                    IDM_CARTRIDGE_EJECT
+        MENUITEM "E&jetar", IDM_CARTRIDGE_EJECT
     END
 END
 
@@ -165,14 +165,14 @@ FloppySubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nova imagem...",                IDM_FLOPPY_IMAGE_NEW
+        MENUITEM "&Nova imagem...", IDM_FLOPPY_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "Imagem &existente...",            IDM_FLOPPY_IMAGE_EXISTING
-        MENUITEM "Imagem existente (&Proteção contra escrita)...",    IDM_FLOPPY_IMAGE_EXISTING_WP
+        MENUITEM "Imagem &existente...", IDM_FLOPPY_IMAGE_EXISTING
+        MENUITEM "Imagem existente (&Proteção contra escrita)...", IDM_FLOPPY_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "E&xportar para 86F...",            IDM_FLOPPY_EXPORT_TO_86F
+        MENUITEM "E&xportar para 86F...", IDM_FLOPPY_EXPORT_TO_86F
         MENUITEM SEPARATOR
-        MENUITEM "E&jetar",                    IDM_FLOPPY_EJECT
+        MENUITEM "E&jetar", IDM_FLOPPY_EJECT
     END
 END
 
@@ -180,13 +180,13 @@ CdromSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Mute",                    IDM_CDROM_MUTE
+        MENUITEM "&Mute", IDM_CDROM_MUTE
         MENUITEM SEPARATOR
-        MENUITEM "&CDROM vazio",                IDM_CDROM_EMPTY
-        MENUITEM "&Recarregar imagem anterior",            IDM_CDROM_RELOAD
+        MENUITEM "&CDROM vazio", IDM_CDROM_EMPTY
+        MENUITEM "&Recarregar imagem anterior", IDM_CDROM_RELOAD
         MENUITEM SEPARATOR
-        MENUITEM "&Imagem...",                    IDM_CDROM_IMAGE
-        MENUITEM "&Pasta...",                    IDM_CDROM_DIR
+        MENUITEM "&Imagem...", IDM_CDROM_IMAGE
+        MENUITEM "&Pasta...", IDM_CDROM_DIR
     END
 END
 
@@ -194,13 +194,13 @@ ZIPSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nova imagem...",                IDM_ZIP_IMAGE_NEW
+        MENUITEM "&Nova imagem...", IDM_ZIP_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "Imagem &existente...",            IDM_ZIP_IMAGE_EXISTING
-        MENUITEM "Imagem existente (&Proteção contra escrita)...",    IDM_ZIP_IMAGE_EXISTING_WP
+        MENUITEM "Imagem &existente...", IDM_ZIP_IMAGE_EXISTING
+        MENUITEM "Imagem existente (&Proteção contra escrita)...", IDM_ZIP_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "E&jetar",                    IDM_ZIP_EJECT
-        MENUITEM "&Recarregar imagem anterior",            IDM_ZIP_RELOAD
+        MENUITEM "E&jetar", IDM_ZIP_EJECT
+        MENUITEM "&Recarregar imagem anterior", IDM_ZIP_RELOAD
     END
 END
 
@@ -208,13 +208,13 @@ MOSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nova imagem...",                IDM_MO_IMAGE_NEW
+        MENUITEM "&Nova imagem...", IDM_MO_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "Imagem &existente...",            IDM_MO_IMAGE_EXISTING
-        MENUITEM "Imagem existente (&Proteção contra escrita)...",    IDM_MO_IMAGE_EXISTING_WP
+        MENUITEM "Imagem &existente...", IDM_MO_IMAGE_EXISTING
+        MENUITEM "Imagem existente (&Proteção contra escrita)...", IDM_MO_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "E&jetar",                    IDM_MO_EJECT
-        MENUITEM "&Recarregar imagem anterior",            IDM_MO_RELOAD
+        MENUITEM "E&jetar", IDM_MO_EJECT
+        MENUITEM "&Recarregar imagem anterior", IDM_MO_RELOAD
     END
 END
 
@@ -240,150 +240,150 @@ END
 // Dialog
 //
 
-#define STR_PREFERENCES        "Preferências"
-#define STR_SND_GAIN        "Ganho de som"
-#define STR_NEW_FLOPPY        "Nova imagem"
+#define STR_PREFERENCES   "Preferências"
+#define STR_SND_GAIN      "Ganho de som"
+#define STR_NEW_FLOPPY    "Nova imagem"
 #define STR_CONFIG        "Definições"
-#define STR_SPECIFY_DIM        "Especificar dimensões da janela principal"
+#define STR_SPECIFY_DIM   "Especificar dimensões da janela principal"
 
 #define STR_OK            "OK"
 #define STR_CANCEL        "Cancelar"
 #define STR_GLOBAL        "Guardar estas definições como padrões &globais"
-#define STR_DEFAULT        "&Padrão"
-#define STR_LANGUAGE        "Idioma:"
-#define STR_ICONSET        "Pacote de ícones:"
+#define STR_DEFAULT       "&Padrão"
+#define STR_LANGUAGE      "Idioma:"
+#define STR_ICONSET       "Pacote de ícones:"
 
-#define STR_GAIN        "Ganho"
+#define STR_GAIN          "Ganho"
 
-#define STR_FILE_NAME        "Nome:"
-#define STR_DISK_SIZE        "Tamanho:"
-#define STR_RPM_MODE        "Modo RPM:"
-#define STR_PROGRESS        "Progresso:"
+#define STR_FILE_NAME     "Nome:"
+#define STR_DISK_SIZE     "Tamanho:"
+#define STR_RPM_MODE      "Modo RPM:"
+#define STR_PROGRESS      "Progresso:"
 
-#define STR_WIDTH        "Largura:"
+#define STR_WIDTH         "Largura:"
 #define STR_HEIGHT        "Altura:"
-#define STR_LOCK_TO_SIZE    "Fixar neste tamanho"
+#define STR_LOCK_TO_SIZE  "Fixar neste tamanho"
 
-#define STR_MACHINE_TYPE    "Tipo de máquina:"
-#define STR_MACHINE        "Máquina:"
-#define STR_CONFIGURE        "Configurar"
-#define STR_CPU_TYPE        "Tipo do CPU:"
-#define STR_CPU_SPEED        "Velocidade:"
-#define STR_FPU            "FPU:"
-#define STR_WAIT_STATES        "Estados de espera:"
+#define STR_MACHINE_TYPE  "Tipo de máquina:"
+#define STR_MACHINE       "Máquina:"
+#define STR_CONFIGURE     "Configurar"
+#define STR_CPU_TYPE      "Tipo do CPU:"
+#define STR_CPU_SPEED     "Velocidade:"
+#define STR_FPU           "FPU:"
+#define STR_WAIT_STATES   "Estados de espera:"
 #define STR_MB            "MB"
 #define STR_MEMORY        "Memória:"
-#define STR_TIME_SYNC        "Sincronização da hora"
-#define STR_DISABLED        "Desativada"
-#define STR_ENABLED_LOCAL    "Ativada (hora local)"
-#define STR_ENABLED_UTC        "Ativada (UTC)"
-#define STR_DYNAREC        "Recompilador dinâmico"
+#define STR_TIME_SYNC     "Sincronização da hora"
+#define STR_DISABLED      "Desativada"
+#define STR_ENABLED_LOCAL "Ativada (hora local)"
+#define STR_ENABLED_UTC   "Ativada (UTC)"
+#define STR_DYNAREC       "Recompilador dinâmico"
 
-#define STR_VIDEO        "Vídeo:"
-#define STR_VIDEO_2        "Vídeo 2:"
+#define STR_VIDEO         "Vídeo:"
+#define STR_VIDEO_2       "Vídeo 2:"
 #define STR_VOODOO        "Gráficos Voodoo"
-#define STR_IBM8514        "Gráficos IBM 8514/a"
-#define STR_XGA            "Gráficos XGA"
+#define STR_IBM8514       "Gráficos IBM 8514/a"
+#define STR_XGA           "Gráficos XGA"
 
-#define STR_MOUSE        "Rato:"
-#define STR_JOYSTICK        "Joystick:"
-#define STR_JOY1        "Joystick 1..."
-#define STR_JOY2        "Joystick 2..."
-#define STR_JOY3        "Joystick 3..."
-#define STR_JOY4        "Joystick 4..."
+#define STR_MOUSE         "Rato:"
+#define STR_JOYSTICK      "Joystick:"
+#define STR_JOY1          "Joystick 1..."
+#define STR_JOY2          "Joystick 2..."
+#define STR_JOY3          "Joystick 3..."
+#define STR_JOY4          "Joystick 4..."
 
 #define STR_SOUND1        "Placa de som 1:"
 #define STR_SOUND2        "Placa de som 2:"
 #define STR_SOUND3        "Placa de som 3:"
 #define STR_SOUND4        "Placa de som 4:"
-#define STR_MIDI_OUT        "Disp. saída MIDI:"
-#define STR_MIDI_IN        "Disp. entrada MIDI:"
+#define STR_MIDI_OUT      "Disp. saída MIDI:"
+#define STR_MIDI_IN       "Disp. entrada MIDI:"
 #define STR_MPU401        "MPU-401 autónomo"
-#define STR_FLOAT        "Utilizar som FLOAT32"
-#define STR_FM_DRIVER        "Controlador de sint. FM"
-#define STR_FM_DRV_NUKED    "Nuked (mais exacto)"
-#define STR_FM_DRV_YMFM        "YMFM (mais rápido)"
+#define STR_FLOAT         "Utilizar som FLOAT32"
+#define STR_FM_DRIVER     "Controlador de sint. FM"
+#define STR_FM_DRV_NUKED  "Nuked (mais exacto)"
+#define STR_FM_DRV_YMFM   "YMFM (mais rápido)"
 
-#define STR_NET_TYPE    "Tipo de rede:"
-#define STR_PCAP        "Dispositivo PCap:"
-#define STR_NET            "Placa de rede:"
-#define STR_NET1        "Network card 1:"
-#define STR_NET2        "Network card 2:"
-#define STR_NET3        "Network card 3:"
-#define STR_NET4        "Network card 4:"
+#define STR_NET_TYPE      "Tipo de rede:"
+#define STR_PCAP          "Dispositivo PCap:"
+#define STR_NET           "Placa de rede:"
+#define STR_NET1          "Network card 1:"
+#define STR_NET2          "Network card 2:"
+#define STR_NET3          "Network card 3:"
+#define STR_NET4          "Network card 4:"
 
-#define STR_COM1        "Dispositivo COM1:"
-#define STR_COM2        "Dispositivo COM2:"
-#define STR_COM3        "Dispositivo COM3:"
-#define STR_COM4        "Dispositivo COM4:"
-#define STR_LPT1        "Dispositivo LPT1:"
-#define STR_LPT2        "Dispositivo LPT2:"
-#define STR_LPT3        "Dispositivo LPT3:"
-#define STR_LPT4        "Dispositivo LPT4:"
-#define STR_SERIAL1        "Porta de série 1"
-#define STR_SERIAL2        "Porta de série 2"
-#define STR_SERIAL3        "Porta de série 3"
-#define STR_SERIAL4        "Porta de série 4"
-#define STR_PARALLEL1        "Porta paralela 1"
-#define STR_PARALLEL2        "Porta paralela 2"
-#define STR_PARALLEL3        "Porta paralela 3"
-#define STR_PARALLEL4        "Porta paralela 4"
-#define STR_SERIAL_PASS1    "Serial port passthrough 1"
-#define STR_SERIAL_PASS2    "Serial port passthrough 2"
-#define STR_SERIAL_PASS3    "Serial port passthrough 3"
-#define STR_SERIAL_PASS4    "Serial port passthrough 4"
+#define STR_COM1          "Dispositivo COM1:"
+#define STR_COM2          "Dispositivo COM2:"
+#define STR_COM3          "Dispositivo COM3:"
+#define STR_COM4          "Dispositivo COM4:"
+#define STR_LPT1          "Dispositivo LPT1:"
+#define STR_LPT2          "Dispositivo LPT2:"
+#define STR_LPT3          "Dispositivo LPT3:"
+#define STR_LPT4          "Dispositivo LPT4:"
+#define STR_SERIAL1       "Porta de série 1"
+#define STR_SERIAL2       "Porta de série 2"
+#define STR_SERIAL3       "Porta de série 3"
+#define STR_SERIAL4       "Porta de série 4"
+#define STR_PARALLEL1     "Porta paralela 1"
+#define STR_PARALLEL2     "Porta paralela 2"
+#define STR_PARALLEL3     "Porta paralela 3"
+#define STR_PARALLEL4     "Porta paralela 4"
+#define STR_SERIAL_PASS1  "Serial port passthrough 1"
+#define STR_SERIAL_PASS2  "Serial port passthrough 2"
+#define STR_SERIAL_PASS3  "Serial port passthrough 3"
+#define STR_SERIAL_PASS4  "Serial port passthrough 4"
 
-#define STR_HDC            "Controlador HD:"
-#define STR_FDC            "Controlador FD:"
-#define STR_IDE_TER        "Controlador IDE terciário"
-#define STR_IDE_QUA        "Controlador IDE quaternário"
-#define STR_SCSI        "SCSI"
+#define STR_HDC           "Controlador HD:"
+#define STR_FDC           "Controlador FD:"
+#define STR_IDE_TER       "Controlador IDE terciário"
+#define STR_IDE_QUA       "Controlador IDE quaternário"
+#define STR_SCSI          "SCSI"
 #define STR_SCSI_1        "Controlador 1:"
 #define STR_SCSI_2        "Controlador 2:"
 #define STR_SCSI_3        "Controlador 3:"
 #define STR_SCSI_4        "Controlador 4:"
-#define STR_CASSETTE        "Cassete"
+#define STR_CASSETTE      "Cassete"
 
-#define STR_HDD            "Discos rígidos:"
-#define STR_NEW            "&Novo..."
-#define STR_EXISTING        "&Existente..."
+#define STR_HDD           "Discos rígidos:"
+#define STR_NEW           "&Novo..."
+#define STR_EXISTING      "&Existente..."
 #define STR_REMOVE        "&Remover"
-#define STR_BUS            "Barram.:"
-#define STR_CHANNEL        "Canal:"
+#define STR_BUS           "Barram.:"
+#define STR_CHANNEL       "Canal:"
 #define STR_ID            "ID:"
-#define STR_SPEED        "Speed:"
+#define STR_SPEED         "Speed:"
 
-#define STR_SPECIFY        "&Especificar..."
-#define STR_SECTORS        "Sectores:"
-#define STR_HEADS        "Cabeças:"
-#define STR_CYLS        "Cilindros:"
-#define STR_SIZE_MB        "Tamanho (MB):"
-#define STR_TYPE        "Tipo:"
-#define STR_IMG_FORMAT        "Formato de imagem:"
-#define STR_BLOCK_SIZE        "Tamanho de bloco:"
+#define STR_SPECIFY       "&Especificar..."
+#define STR_SECTORS       "Sectores:"
+#define STR_HEADS         "Cabeças:"
+#define STR_CYLS          "Cilindros:"
+#define STR_SIZE_MB       "Tamanho (MB):"
+#define STR_TYPE          "Tipo:"
+#define STR_IMG_FORMAT    "Formato de imagem:"
+#define STR_BLOCK_SIZE    "Tamanho de bloco:"
 
-#define STR_FLOPPY_DRIVES    "Unidades de disquete:"
-#define STR_TURBO        "Velocidade turbo"
-#define STR_CHECKBPB        "Verificar BPB"
-#define STR_CDROM_DRIVES    "Unidades CD-ROM:"
-#define STR_CD_SPEED        "Velocidade:"
-#define STR_EARLY        "Unidade anterior"
+#define STR_FLOPPY_DRIVES "Unidades de disquete:"
+#define STR_TURBO         "Velocidade turbo"
+#define STR_CHECKBPB      "Verificar BPB"
+#define STR_CDROM_DRIVES  "Unidades CD-ROM:"
+#define STR_CD_SPEED      "Velocidade:"
+#define STR_EARLY         "Unidade anterior"
 
-#define STR_MO_DRIVES        "Unidades magneto-ópticas:"
-#define STR_ZIP_DRIVES        "Unidades ZIP:"
-#define STR_250            "ZIP 250"
+#define STR_MO_DRIVES     "Unidades magneto-ópticas:"
+#define STR_ZIP_DRIVES    "Unidades ZIP:"
+#define STR_250           "ZIP 250"
 
 #define STR_ISARTC        "ISA RTC:"
 #define STR_ISAMEM        "Expansão de memória ISA"
-#define STR_ISAMEM_1        "Placa 1:"
-#define STR_ISAMEM_2        "Placa 2:"
-#define STR_ISAMEM_3        "Placa 3:"
-#define STR_ISAMEM_4        "Placa 4:"
+#define STR_ISAMEM_1      "Placa 1:"
+#define STR_ISAMEM_2      "Placa 2:"
+#define STR_ISAMEM_3      "Placa 3:"
+#define STR_ISAMEM_4      "Placa 4:"
 #define STR_BUGGER        "Dispositivo ISABugger"
-#define STR_POSTCARD        "Placa POST"
+#define STR_POSTCARD      "Placa POST"
 
-#define FONT_SIZE        9
-#define FONT_NAME        "Segoe UI"
+#define FONT_SIZE         9
+#define FONT_NAME         "Segoe UI"
 
 #include "dialogs.rc"
 
@@ -392,9 +392,9 @@ END
 // String Table
 //
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
-    2048    "86Box"
+    2048        "86Box"
     IDS_2049    "Erro"
     IDS_2050    "Erro fatal"
     IDS_2051    " - PAUSED"
@@ -412,7 +412,7 @@ BEGIN
     IDS_2063    "A máquina ""%hs"" não está disponível devido à falta de ROMs na pasta roms/machines. A mudar para uma máquina disponível."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2064    "A placa vídeo ""%hs"" não está disponível devido à falta de ROMs na pasta roms/video. A mudar para uma placa vídeo disponível."
     IDS_2065    "Máquina"
@@ -432,7 +432,7 @@ BEGIN
     IDS_2079    "Pressione F8+F12 ou tecla média para soltar o rato"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2080    "Não foi possível inicializar o FluidSynth"
     IDS_2081    "Barramento"
@@ -544,7 +544,7 @@ BEGIN
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_4096    "Disco rígido (%s)"
     IDS_4097    "%01i:%01i"

--- a/src/win/languages/ru-RU.rc
+++ b/src/win/languages/ru-RU.rc
@@ -13,122 +13,122 @@ LANGUAGE LANG_RUSSIAN, SUBLANG_DEFAULT
 // Menu
 //
 
-MainMenu MENU DISCARDABLE 
+MainMenu MENU DISCARDABLE
 BEGIN
     POPUP "&Действие"
     BEGIN
-        MENUITEM "&Клавиатура требует захвата",    IDM_ACTION_KBD_REQ_CAPTURE
-        MENUITEM "&Правый CTRL - это левый ALT",    IDM_ACTION_RCTRL_IS_LALT
+        MENUITEM "&Клавиатура требует захвата", IDM_ACTION_KBD_REQ_CAPTURE
+        MENUITEM "&Правый CTRL - это левый ALT", IDM_ACTION_RCTRL_IS_LALT
         MENUITEM SEPARATOR
-        MENUITEM "&Холодная перезагрузка...",                 IDM_ACTION_HRESET
-        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12",     IDM_ACTION_RESET_CAD
+        MENUITEM "&Холодная перезагрузка...", IDM_ACTION_HRESET
+        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12", IDM_ACTION_RESET_CAD
         MENUITEM SEPARATOR
-    MENUITEM "Ctrl+Alt+&Esc",        IDM_ACTION_CTRL_ALT_ESC
+    MENUITEM "Ctrl+Alt+&Esc", IDM_ACTION_CTRL_ALT_ESC
         MENUITEM SEPARATOR
-        MENUITEM "&Пауза",                      IDM_ACTION_PAUSE
+        MENUITEM "&Пауза", IDM_ACTION_PAUSE
         MENUITEM SEPARATOR
-        MENUITEM "&Выход...",                       IDM_ACTION_EXIT
+        MENUITEM "&Выход...", IDM_ACTION_EXIT
     END
     POPUP "&Вид"
     BEGIN
-        MENUITEM "&Скрыть строку состояния",        IDM_VID_HIDE_STATUS_BAR
-        MENUITEM "С&крыть панель инструментов",        IDM_VID_HIDE_TOOLBAR
+        MENUITEM "&Скрыть строку состояния", IDM_VID_HIDE_STATUS_BAR
+        MENUITEM "С&крыть панель инструментов", IDM_VID_HIDE_TOOLBAR
         MENUITEM SEPARATOR
-        MENUITEM "&Show non-primary monitors",  IDM_VID_MONITORS
-        MENUITEM "&Изменяемый размер окна",          IDM_VID_RESIZE
-        MENUITEM "&Запомнить размер и положение",  IDM_VID_REMEMBER
+        MENUITEM "&Show non-primary monitors", IDM_VID_MONITORS
+        MENUITEM "&Изменяемый размер окна", IDM_VID_RESIZE
+        MENUITEM "&Запомнить размер и положение", IDM_VID_REMEMBER
         MENUITEM SEPARATOR
         POPUP "&Рендеринг"
         BEGIN
-            MENUITEM "&SDL (Software)",         IDM_VID_SDL_SW
-            MENUITEM "SDL (&Hardware)",         IDM_VID_SDL_HW
-            MENUITEM "SDL (&OpenGL)",           IDM_VID_SDL_OPENGL
-            MENUITEM "Open&GL (3.0)",      IDM_VID_OPENGL_CORE
+            MENUITEM "&SDL (Software)", IDM_VID_SDL_SW
+            MENUITEM "SDL (&Hardware)", IDM_VID_SDL_HW
+            MENUITEM "SDL (&OpenGL)", IDM_VID_SDL_OPENGL
+            MENUITEM "Open&GL (3.0)", IDM_VID_OPENGL_CORE
 #ifdef USE_VNC
-            MENUITEM "&VNC",                    IDM_VID_VNC
+            MENUITEM "&VNC", IDM_VID_VNC
 #endif
         END
         MENUITEM SEPARATOR
-        MENUITEM "&Указать размеры...",          IDM_VID_SPECIFY_DIM
-        MENUITEM "У&становить соотношение сторон 4:3",    IDM_VID_FORCE43
+        MENUITEM "&Указать размеры...", IDM_VID_SPECIFY_DIM
+        MENUITEM "У&становить соотношение сторон 4:3", IDM_VID_FORCE43
         POPUP "&Масштаб окна"
         BEGIN
-            MENUITEM "&0.5x",                   IDM_VID_SCALE_1X
-            MENUITEM "&1x",                     IDM_VID_SCALE_2X
-            MENUITEM "1.&5x",                   IDM_VID_SCALE_3X
-            MENUITEM "&2x",                     IDM_VID_SCALE_4X
-            MENUITEM "&3x",                     IDM_VID_SCALE_5X
-            MENUITEM "&4x",                     IDM_VID_SCALE_6X
-            MENUITEM "&5x",                     IDM_VID_SCALE_7X
-            MENUITEM "&6x",                     IDM_VID_SCALE_8X
-            MENUITEM "&7x",                     IDM_VID_SCALE_9X
-            MENUITEM "&8x",                     IDM_VID_SCALE_10X
+            MENUITEM "&0.5x", IDM_VID_SCALE_1X
+            MENUITEM "&1x", IDM_VID_SCALE_2X
+            MENUITEM "1.&5x", IDM_VID_SCALE_3X
+            MENUITEM "&2x", IDM_VID_SCALE_4X
+            MENUITEM "&3x", IDM_VID_SCALE_5X
+            MENUITEM "&4x", IDM_VID_SCALE_6X
+            MENUITEM "&5x", IDM_VID_SCALE_7X
+            MENUITEM "&6x", IDM_VID_SCALE_8X
+            MENUITEM "&7x", IDM_VID_SCALE_9X
+            MENUITEM "&8x", IDM_VID_SCALE_10X
         END
         POPUP "Метод фильтрации"
         BEGIN
-            MENUITEM "&Ближайший",                 IDM_VID_FILTER_NEAREST
-            MENUITEM "&Линейный",                  IDM_VID_FILTER_LINEAR
+            MENUITEM "&Ближайший", IDM_VID_FILTER_NEAREST
+            MENUITEM "&Линейный", IDM_VID_FILTER_LINEAR
         END
-        MENUITEM "Масштабирование Hi&DPI",              IDM_VID_HIDPI
+        MENUITEM "Масштабирование Hi&DPI", IDM_VID_HIDPI
         MENUITEM SEPARATOR
-        MENUITEM "&Полноэкранный режим\tCtrl+Alt+PgUp",    IDM_VID_FULLSCREEN
+        MENUITEM "&Полноэкранный режим\tCtrl+Alt+PgUp", IDM_VID_FULLSCREEN
         POPUP "&Растягивание в полноэкранном режиме"
         BEGIN
-            MENUITEM "&На весь экран",        IDM_VID_FS_FULL
-            MENUITEM "&4:3",                        IDM_VID_FS_43
+            MENUITEM "&На весь экран", IDM_VID_FS_FULL
+            MENUITEM "&4:3", IDM_VID_FS_43
             MENUITEM "&Квадратные пиксели (сохранить соотношение)", IDM_VID_FS_KEEPRATIO
-            MENUITEM "&Целочисленное масштабирование",              IDM_VID_FS_INT
+            MENUITEM "&Целочисленное масштабирование", IDM_VID_FS_INT
         END
         POPUP "Настройки E&GA/(S)VGA"
         BEGIN
-            MENUITEM "&Инвертировать цвета VGA",   IDM_VID_INVERT
+            MENUITEM "&Инвертировать цвета VGA", IDM_VID_INVERT
             POPUP "&Тип экрана VGA"
             BEGIN
-                MENUITEM "RGB &цветной",          IDM_VID_GRAY_RGB
-                MENUITEM "&RGB монохромный",      IDM_VID_GRAY_MONO
-                MENUITEM "&Янтарный оттенок",      IDM_VID_GRAY_AMBER
-                MENUITEM "&Зелёный оттенок",      IDM_VID_GRAY_GREEN
-                MENUITEM "&Белый оттенок",      IDM_VID_GRAY_WHITE
+                MENUITEM "RGB &цветной", IDM_VID_GRAY_RGB
+                MENUITEM "&RGB монохромный", IDM_VID_GRAY_MONO
+                MENUITEM "&Янтарный оттенок", IDM_VID_GRAY_AMBER
+                MENUITEM "&Зелёный оттенок", IDM_VID_GRAY_GREEN
+                MENUITEM "&Белый оттенок", IDM_VID_GRAY_WHITE
             END
             POPUP "Тип монохромного &конвертирования"
             BEGIN
-                MENUITEM "BT&601 (NTSC/PAL)",   IDM_VID_GRAYCT_601
-                MENUITEM "BT&709 (HDTV)",       IDM_VID_GRAYCT_709
-                MENUITEM "&Усреднённый",            IDM_VID_GRAYCT_AVE
+                MENUITEM "BT&601 (NTSC/PAL)", IDM_VID_GRAYCT_601
+                MENUITEM "BT&709 (HDTV)", IDM_VID_GRAYCT_709
+                MENUITEM "&Усреднённый", IDM_VID_GRAYCT_AVE
             END
         END
         MENUITEM SEPARATOR
-        MENUITEM "Вылеты развёртки CGA/PCjr/Tandy/E&GA/(S)VGA",     IDM_VID_OVERSCAN
+        MENUITEM "Вылеты развёртки CGA/PCjr/Tandy/E&GA/(S)VGA", IDM_VID_OVERSCAN
         MENUITEM "Изменить контрастность &монохромного дисплея", IDM_VID_CGACON
     END
-    MENUITEM "&Носители",                IDM_MEDIA
+    MENUITEM "&Носители", IDM_MEDIA
     POPUP "&Инструменты"
     BEGIN
-        MENUITEM "&Настройки машины...",                IDM_CONFIG
-        MENUITEM "&Обновление значков строки состояния",    IDM_UPDATE_ICONS
+        MENUITEM "&Настройки машины...", IDM_CONFIG
+        MENUITEM "&Обновление значков строки состояния", IDM_UPDATE_ICONS
         MENUITEM SEPARATOR
-        MENUITEM "Сделать с&криншот\tCtrl+F11",  IDM_ACTION_SCREENSHOT
+        MENUITEM "Сделать с&криншот\tCtrl+F11", IDM_ACTION_SCREENSHOT
         MENUITEM SEPARATOR
-        MENUITEM "&Параметры...",        IDM_PREFERENCES
+        MENUITEM "&Параметры...", IDM_PREFERENCES
 #ifdef DISCORD
         MENUITEM "Включить интеграцию &Discord", IDM_DISCORD
 #endif
         MENUITEM SEPARATOR
-        MENUITEM "&Усиление звука...",              IDM_SND_GAIN
+        MENUITEM "&Усиление звука...", IDM_SND_GAIN
 #ifdef MTR_ENABLED
         MENUITEM SEPARATOR
-        MENUITEM "Начать трассировку\tCtrl+T",         IDM_ACTION_BEGIN_TRACE
-        MENUITEM "Завершить трассировку\tCtrl+T",           IDM_ACTION_END_TRACE
+        MENUITEM "Начать трассировку\tCtrl+T", IDM_ACTION_BEGIN_TRACE
+        MENUITEM "Завершить трассировку\tCtrl+T", IDM_ACTION_END_TRACE
 #endif
     END
     POPUP "&Помощь"
     BEGIN
-        MENUITEM "&Документация...",           IDM_DOCS
-        MENUITEM "&О программе 86Box...",             IDM_ABOUT
+        MENUITEM "&Документация...", IDM_DOCS
+        MENUITEM "&О программе 86Box...", IDM_ABOUT
     END
 END
 
-StatusBarMenu MENU DISCARDABLE 
+StatusBarMenu MENU DISCARDABLE
 BEGIN
     MENUITEM SEPARATOR
 END
@@ -137,17 +137,17 @@ CassetteSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Новый образ...",                IDM_CASSETTE_IMAGE_NEW
+        MENUITEM "&Новый образ...", IDM_CASSETTE_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Выбрать образ...",                IDM_CASSETTE_IMAGE_EXISTING
-        MENUITEM "Выбрать образ (&Защита от записи)...",    IDM_CASSETTE_IMAGE_EXISTING_WP
+        MENUITEM "&Выбрать образ...", IDM_CASSETTE_IMAGE_EXISTING
+        MENUITEM "Выбрать образ (&Защита от записи)...", IDM_CASSETTE_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Запись",                    IDM_CASSETTE_RECORD
-        MENUITEM "&Воспроизведение",                    IDM_CASSETTE_PLAY
-        MENUITEM "&Перемотка на начало",            IDM_CASSETTE_REWIND
-        MENUITEM "&Перемотка в конец",            IDM_CASSETTE_FAST_FORWARD
+        MENUITEM "&Запись", IDM_CASSETTE_RECORD
+        MENUITEM "&Воспроизведение", IDM_CASSETTE_PLAY
+        MENUITEM "&Перемотка на начало", IDM_CASSETTE_REWIND
+        MENUITEM "&Перемотка в конец", IDM_CASSETTE_FAST_FORWARD
         MENUITEM SEPARATOR
-        MENUITEM "И&звлечь",                    IDM_CASSETTE_EJECT
+        MENUITEM "И&звлечь", IDM_CASSETTE_EJECT
     END
 END
 
@@ -155,9 +155,9 @@ CartridgeSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Образ...",                    IDM_CARTRIDGE_IMAGE
+        MENUITEM "&Образ...", IDM_CARTRIDGE_IMAGE
         MENUITEM SEPARATOR
-        MENUITEM "И&звлечь",                    IDM_CARTRIDGE_EJECT
+        MENUITEM "И&звлечь", IDM_CARTRIDGE_EJECT
     END
 END
 
@@ -165,14 +165,14 @@ FloppySubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Новый образ...",                IDM_FLOPPY_IMAGE_NEW
+        MENUITEM "&Новый образ...", IDM_FLOPPY_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Выбрать образ...",                IDM_FLOPPY_IMAGE_EXISTING
-        MENUITEM "Выбрать образ (&Защита от записи)...",    IDM_FLOPPY_IMAGE_EXISTING_WP
+        MENUITEM "&Выбрать образ...", IDM_FLOPPY_IMAGE_EXISTING
+        MENUITEM "Выбрать образ (&Защита от записи)...", IDM_FLOPPY_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "Э&кспорт в 86F...",                IDM_FLOPPY_EXPORT_TO_86F
+        MENUITEM "Э&кспорт в 86F...", IDM_FLOPPY_EXPORT_TO_86F
         MENUITEM SEPARATOR
-        MENUITEM "И&звлечь",                    IDM_FLOPPY_EJECT
+        MENUITEM "И&звлечь", IDM_FLOPPY_EJECT
     END
 END
 
@@ -180,13 +180,13 @@ CdromSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "О&тключить звук",                    IDM_CDROM_MUTE
+        MENUITEM "О&тключить звук", IDM_CDROM_MUTE
         MENUITEM SEPARATOR
-        MENUITEM "П&устой",                    IDM_CDROM_EMPTY
-        MENUITEM "&Снова загрузить предыдущий образ",            IDM_CDROM_RELOAD
+        MENUITEM "П&устой", IDM_CDROM_EMPTY
+        MENUITEM "&Снова загрузить предыдущий образ", IDM_CDROM_RELOAD
         MENUITEM SEPARATOR
-        MENUITEM "&Образ...",                    IDM_CDROM_IMAGE
-        MENUITEM "&Папка...",                    IDM_CDROM_DIR
+        MENUITEM "&Образ...", IDM_CDROM_IMAGE
+        MENUITEM "&Папка...", IDM_CDROM_DIR
     END
 END
 
@@ -194,13 +194,13 @@ ZIPSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Новый образ...",                IDM_ZIP_IMAGE_NEW
+        MENUITEM "&Новый образ...", IDM_ZIP_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Выбрать образ...",                IDM_ZIP_IMAGE_EXISTING
-        MENUITEM "Выбрать образ (&Защита от записи)...",    IDM_ZIP_IMAGE_EXISTING_WP
+        MENUITEM "&Выбрать образ...", IDM_ZIP_IMAGE_EXISTING
+        MENUITEM "Выбрать образ (&Защита от записи)...", IDM_ZIP_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "И&звлечь",                    IDM_ZIP_EJECT
-        MENUITEM "&Снова загрузить предыдущий образ",            IDM_ZIP_RELOAD
+        MENUITEM "И&звлечь", IDM_ZIP_EJECT
+        MENUITEM "&Снова загрузить предыдущий образ", IDM_ZIP_RELOAD
     END
 END
 
@@ -208,13 +208,13 @@ MOSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Новый образ...",                IDM_MO_IMAGE_NEW
+        MENUITEM "&Новый образ...", IDM_MO_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Выбрать образ...",                IDM_MO_IMAGE_EXISTING
-        MENUITEM "Выбрать образ (&Защита от записи)...",    IDM_MO_IMAGE_EXISTING_WP
+        MENUITEM "&Выбрать образ...", IDM_MO_IMAGE_EXISTING
+        MENUITEM "Выбрать образ (&Защита от записи)...", IDM_MO_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "И&звлечь",                    IDM_MO_EJECT
-        MENUITEM "&Снова загрузить предыдущий образ",            IDM_MO_RELOAD
+        MENUITEM "И&звлечь", IDM_MO_EJECT
+        MENUITEM "&Снова загрузить предыдущий образ", IDM_MO_RELOAD
     END
 END
 
@@ -240,150 +240,150 @@ END
 // Dialog
 //
 
-#define STR_PREFERENCES        "Параметры"
-#define STR_SND_GAIN        "Усиление звука"
-#define STR_NEW_FLOPPY        "Новый образ"
+#define STR_PREFERENCES   "Параметры"
+#define STR_SND_GAIN      "Усиление звука"
+#define STR_NEW_FLOPPY    "Новый образ"
 #define STR_CONFIG        "Настройки"
-#define STR_SPECIFY_DIM        "Указать размеры главного окна"
+#define STR_SPECIFY_DIM   "Указать размеры главного окна"
 
 #define STR_OK            "OK"
 #define STR_CANCEL        "Отмена"
 #define STR_GLOBAL        "Сохранить эти параметры как &глобальные по умолчанию"
-#define STR_DEFAULT        "&По умолчанию"
-#define STR_LANGUAGE        "Язык:"
-#define STR_ICONSET        "Набор иконок:"
+#define STR_DEFAULT       "&По умолчанию"
+#define STR_LANGUAGE      "Язык:"
+#define STR_ICONSET       "Набор иконок:"
 
-#define STR_GAIN        "Усиление"
+#define STR_GAIN          "Усиление"
 
-#define STR_FILE_NAME        "Имя файла:"
-#define STR_DISK_SIZE        "Размер диска:"
-#define STR_RPM_MODE        "RPM режим:"
-#define STR_PROGRESS        "Прогресс:"
+#define STR_FILE_NAME     "Имя файла:"
+#define STR_DISK_SIZE     "Размер диска:"
+#define STR_RPM_MODE      "RPM режим:"
+#define STR_PROGRESS      "Прогресс:"
 
-#define STR_WIDTH        "Ширина:"
+#define STR_WIDTH         "Ширина:"
 #define STR_HEIGHT        "Высота:"
-#define STR_LOCK_TO_SIZE    "Зафиксировать размер"
+#define STR_LOCK_TO_SIZE  "Зафиксировать размер"
 
-#define STR_MACHINE_TYPE    "Тип машины:"
-#define STR_MACHINE        "Системная плата:"
-#define STR_CONFIGURE        "Настройка"
-#define STR_CPU_TYPE        "Тип ЦП:"
-#define STR_CPU_SPEED        "Скорость:"
-#define STR_FPU            "FPU:"
-#define STR_WAIT_STATES        "Циклы ожидания:"
+#define STR_MACHINE_TYPE  "Тип машины:"
+#define STR_MACHINE       "Системная плата:"
+#define STR_CONFIGURE     "Настройка"
+#define STR_CPU_TYPE      "Тип ЦП:"
+#define STR_CPU_SPEED     "Скорость:"
+#define STR_FPU           "FPU:"
+#define STR_WAIT_STATES   "Циклы ожидания:"
 #define STR_MB            "МБ"
 #define STR_MEMORY        "Память:"
-#define STR_TIME_SYNC        "Синхронизация времени"
-#define STR_DISABLED        "Отключить"
-#define STR_ENABLED_LOCAL    "Включить (местное)"
-#define STR_ENABLED_UTC        "Включить (UTC)"
-#define STR_DYNAREC        "Динамический рекомпилятор"
+#define STR_TIME_SYNC     "Синхронизация времени"
+#define STR_DISABLED      "Отключить"
+#define STR_ENABLED_LOCAL "Включить (местное)"
+#define STR_ENABLED_UTC   "Включить (UTC)"
+#define STR_DYNAREC       "Динамический рекомпилятор"
 
-#define STR_VIDEO        "Видеокарта:"
-#define STR_VIDEO_2        "Видеокарта 2:"
+#define STR_VIDEO         "Видеокарта:"
+#define STR_VIDEO_2       "Видеокарта 2:"
 #define STR_VOODOO        "Ускоритель Voodoo"
-#define STR_IBM8514        "Ускоритель IBM 8514/a"
-#define STR_XGA            "Ускоритель XGA"
+#define STR_IBM8514       "Ускоритель IBM 8514/a"
+#define STR_XGA           "Ускоритель XGA"
 
-#define STR_MOUSE        "Мышь:"
-#define STR_JOYSTICK        "Джойстик:"
-#define STR_JOY1        "Джойстик 1..."
-#define STR_JOY2        "Джойстик 2..."
-#define STR_JOY3        "Джойстик 3..."
-#define STR_JOY4        "Джойстик 4..."
+#define STR_MOUSE         "Мышь:"
+#define STR_JOYSTICK      "Джойстик:"
+#define STR_JOY1          "Джойстик 1..."
+#define STR_JOY2          "Джойстик 2..."
+#define STR_JOY3          "Джойстик 3..."
+#define STR_JOY4          "Джойстик 4..."
 
 #define STR_SOUND1        "Звуковая карта 1:"
 #define STR_SOUND2        "Звуковая карта 2:"
 #define STR_SOUND3        "Звуковая карта 3:"
 #define STR_SOUND4        "Звуковая карта 4:"
-#define STR_MIDI_OUT        "MIDI Out устр-во:"
-#define STR_MIDI_IN        "MIDI In устр-во:"
+#define STR_MIDI_OUT      "MIDI Out устр-во:"
+#define STR_MIDI_IN       "MIDI In устр-во:"
 #define STR_MPU401        "Отдельный MPU-401"
-#define STR_FLOAT        "FLOAT32 звук"
-#define STR_FM_DRIVER        "Драйвер FM-синтезатора"
-#define STR_FM_DRV_NUKED    "Nuked (более точный)"
-#define STR_FM_DRV_YMFM        "YMFM (быстрей)"
+#define STR_FLOAT         "FLOAT32 звук"
+#define STR_FM_DRIVER     "Драйвер FM-синтезатора"
+#define STR_FM_DRV_NUKED  "Nuked (более точный)"
+#define STR_FM_DRV_YMFM   "YMFM (быстрей)"
 
-#define STR_NET_TYPE    "Тип сети:"
-#define STR_PCAP        "Устройство PCap:"
-#define STR_NET            "Сетевая карта:"
-#define STR_NET1        "Network card 1:"
-#define STR_NET2        "Network card 2:"
-#define STR_NET3        "Network card 3:"
-#define STR_NET4        "Network card 4:"
+#define STR_NET_TYPE      "Тип сети:"
+#define STR_PCAP          "Устройство PCap:"
+#define STR_NET           "Сетевая карта:"
+#define STR_NET1          "Network card 1:"
+#define STR_NET2          "Network card 2:"
+#define STR_NET3          "Network card 3:"
+#define STR_NET4          "Network card 4:"
 
-#define STR_COM1        "Устройство COM1:"
-#define STR_COM2        "Устройство COM2:"
-#define STR_COM3        "Устройство COM3:"
-#define STR_COM4        "Устройство COM4:"
-#define STR_LPT1        "Устройство LPT1:"
-#define STR_LPT2        "Устройство LPT2:"
-#define STR_LPT3        "Устройство LPT3:"
-#define STR_LPT4        "Устройство LPT4:"
-#define STR_SERIAL1        "Последов. порт COM1"
-#define STR_SERIAL2        "Последов. порт COM2"
-#define STR_SERIAL3        "Последов. порт COM3"
-#define STR_SERIAL4        "Последов. порт COM4"
-#define STR_PARALLEL1        "Параллельный порт LPT1"
-#define STR_PARALLEL2        "Параллельный порт LPT2"
-#define STR_PARALLEL3        "Параллельный порт LPT3"
-#define STR_PARALLEL4        "Параллельный порт LPT4"
-#define STR_SERIAL_PASS1    "Serial port passthrough 1"
-#define STR_SERIAL_PASS2    "Serial port passthrough 2"
-#define STR_SERIAL_PASS3    "Serial port passthrough 3"
-#define STR_SERIAL_PASS4    "Serial port passthrough 4"
+#define STR_COM1          "Устройство COM1:"
+#define STR_COM2          "Устройство COM2:"
+#define STR_COM3          "Устройство COM3:"
+#define STR_COM4          "Устройство COM4:"
+#define STR_LPT1          "Устройство LPT1:"
+#define STR_LPT2          "Устройство LPT2:"
+#define STR_LPT3          "Устройство LPT3:"
+#define STR_LPT4          "Устройство LPT4:"
+#define STR_SERIAL1       "Последов. порт COM1"
+#define STR_SERIAL2       "Последов. порт COM2"
+#define STR_SERIAL3       "Последов. порт COM3"
+#define STR_SERIAL4       "Последов. порт COM4"
+#define STR_PARALLEL1     "Параллельный порт LPT1"
+#define STR_PARALLEL2     "Параллельный порт LPT2"
+#define STR_PARALLEL3     "Параллельный порт LPT3"
+#define STR_PARALLEL4     "Параллельный порт LPT4"
+#define STR_SERIAL_PASS1  "Serial port passthrough 1"
+#define STR_SERIAL_PASS2  "Serial port passthrough 2"
+#define STR_SERIAL_PASS3  "Serial port passthrough 3"
+#define STR_SERIAL_PASS4  "Serial port passthrough 4"
 
-#define STR_HDC            "Контроллер HD:"
-#define STR_FDC            "Контроллер FD:"
-#define STR_IDE_TER        "Третичный IDE контроллер"
-#define STR_IDE_QUA        "Четвертичный IDE контроллер"
-#define STR_SCSI        "SCSI"
+#define STR_HDC           "Контроллер HD:"
+#define STR_FDC           "Контроллер FD:"
+#define STR_IDE_TER       "Третичный IDE контроллер"
+#define STR_IDE_QUA       "Четвертичный IDE контроллер"
+#define STR_SCSI          "SCSI"
 #define STR_SCSI_1        "Контроллер 1:"
 #define STR_SCSI_2        "Контроллер 2:"
 #define STR_SCSI_3        "Контроллер 3:"
 #define STR_SCSI_4        "Контроллер 4:"
-#define STR_CASSETTE        "Кассета"
+#define STR_CASSETTE      "Кассета"
 
-#define STR_HDD            "Жёсткие диски:"
-#define STR_NEW            "&Создать..."
-#define STR_EXISTING        "&Выбрать..."
+#define STR_HDD           "Жёсткие диски:"
+#define STR_NEW           "&Создать..."
+#define STR_EXISTING      "&Выбрать..."
 #define STR_REMOVE        "&Убрать"
-#define STR_BUS            "Шина:"
-#define STR_CHANNEL        "Канал:"
+#define STR_BUS           "Шина:"
+#define STR_CHANNEL       "Канал:"
 #define STR_ID            "ID:"
-#define STR_SPEED        "Speed:"
+#define STR_SPEED         "Speed:"
 
-#define STR_SPECIFY        "&Указать..."
-#define STR_SECTORS        "Сектора:"
-#define STR_HEADS        "Головки:"
-#define STR_CYLS        "Цилиндры:"
-#define STR_SIZE_MB        "Размер (МБ):"
-#define STR_TYPE        "Тип:"
-#define STR_IMG_FORMAT        "Тип образа:"
-#define STR_BLOCK_SIZE        "Размер блока:"
+#define STR_SPECIFY       "&Указать..."
+#define STR_SECTORS       "Сектора:"
+#define STR_HEADS         "Головки:"
+#define STR_CYLS          "Цилиндры:"
+#define STR_SIZE_MB       "Размер (МБ):"
+#define STR_TYPE          "Тип:"
+#define STR_IMG_FORMAT    "Тип образа:"
+#define STR_BLOCK_SIZE    "Размер блока:"
 
-#define STR_FLOPPY_DRIVES    "Гибкие диски:"
-#define STR_TURBO        "Турбо тайминги"
-#define STR_CHECKBPB        "Проверять BPB"
-#define STR_CDROM_DRIVES    "Дисководы CD-ROM:"
-#define STR_CD_SPEED        "Скорость:"
-#define STR_EARLY        "Предыдущий дисковод"
+#define STR_FLOPPY_DRIVES "Гибкие диски:"
+#define STR_TURBO         "Турбо тайминги"
+#define STR_CHECKBPB      "Проверять BPB"
+#define STR_CDROM_DRIVES  "Дисководы CD-ROM:"
+#define STR_CD_SPEED      "Скорость:"
+#define STR_EARLY         "Предыдущий дисковод"
 
-#define STR_MO_DRIVES        "Магнитооптические дисководы:"
-#define STR_ZIP_DRIVES        "ZIP дисководы:"
-#define STR_250            "ZIP 250"
+#define STR_MO_DRIVES     "Магнитооптические дисководы:"
+#define STR_ZIP_DRIVES    "ZIP дисководы:"
+#define STR_250           "ZIP 250"
 
 #define STR_ISARTC        "ISA RTC:"
 #define STR_ISAMEM        "Карта расширения памяти (ISA)"
-#define STR_ISAMEM_1        "Карта 1:"
-#define STR_ISAMEM_2        "Карта 2:"
-#define STR_ISAMEM_3        "Карта 3:"
-#define STR_ISAMEM_4        "Карта 4:"
+#define STR_ISAMEM_1      "Карта 1:"
+#define STR_ISAMEM_2      "Карта 2:"
+#define STR_ISAMEM_3      "Карта 3:"
+#define STR_ISAMEM_4      "Карта 4:"
 #define STR_BUGGER        "Устройство ISABugger"
-#define STR_POSTCARD        "Карта POST"
+#define STR_POSTCARD      "Карта POST"
 
-#define FONT_SIZE        9
-#define FONT_NAME        "Segoe UI"
+#define FONT_SIZE         9
+#define FONT_NAME         "Segoe UI"
 
 #include "dialogs.rc"
 
@@ -392,9 +392,9 @@ END
 // String Table
 //
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
-    2048    "86Box"
+    2048        "86Box"
     IDS_2049    "Ошибка"
     IDS_2050    "Неустранимая ошибка"
     IDS_2051    " - ПАУЗА"
@@ -412,7 +412,7 @@ BEGIN
     IDS_2063    "Системная плата ""%hs"" недоступна из-за отсутствия файла её ПЗУ в каталоге roms/machines. Переключение на доступную системную плату."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2064    "Видеокарта ""%hs"" недоступна из-за отсутствия файла её ПЗУ в каталоге roms/video. Переключение на доступную видеокарту."
     IDS_2065    "Компьютер"
@@ -432,7 +432,7 @@ BEGIN
     IDS_2079    "Нажмите F8+F12 или среднюю кнопку мыши чтобы освободить курсор"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2080    "Невозможно инициализировать FluidSynth"
     IDS_2081    "Шина"
@@ -544,7 +544,7 @@ BEGIN
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_4096    "Жёсткий диск (%s)"
     IDS_4097    "%01i:%01i"
@@ -643,7 +643,7 @@ BEGIN
 
     IDS_7168    "(Системный)"
 END
-#define IDS_LANG_ENUS    IDS_7168
+#define IDS_LANG_ENUS IDS_7168
 
 // Russian resources
 /////////////////////////////////////////////////////////////////////////////

--- a/src/win/languages/sl-SI.rc
+++ b/src/win/languages/sl-SI.rc
@@ -13,122 +13,122 @@ LANGUAGE LANG_SLOVENIAN, SUBLANG_DEFAULT
 // Menu
 //
 
-MainMenu MENU DISCARDABLE 
+MainMenu MENU DISCARDABLE
 BEGIN
     POPUP "&Dejanja"
     BEGIN
-        MENUITEM "&Tipkovnica potrebuje zajem",    IDM_ACTION_KBD_REQ_CAPTURE
-        MENUITEM "&Desni CTRL je levi ALT",    IDM_ACTION_RCTRL_IS_LALT
+        MENUITEM "&Tipkovnica potrebuje zajem", IDM_ACTION_KBD_REQ_CAPTURE
+        MENUITEM "&Desni CTRL je levi ALT", IDM_ACTION_RCTRL_IS_LALT
         MENUITEM SEPARATOR
-        MENUITEM "&Ponovni zagon...",                 IDM_ACTION_HRESET
-        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12",     IDM_ACTION_RESET_CAD
+        MENUITEM "&Ponovni zagon...", IDM_ACTION_HRESET
+        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12", IDM_ACTION_RESET_CAD
         MENUITEM SEPARATOR
-    MENUITEM "Ctrl+Alt+&Esc",        IDM_ACTION_CTRL_ALT_ESC
+    MENUITEM "Ctrl+Alt+&Esc", IDM_ACTION_CTRL_ALT_ESC
         MENUITEM SEPARATOR
-        MENUITEM "&Premor",                      IDM_ACTION_PAUSE
+        MENUITEM "&Premor", IDM_ACTION_PAUSE
         MENUITEM SEPARATOR
-        MENUITEM "Iz&hod...",                       IDM_ACTION_EXIT
+        MENUITEM "Iz&hod...", IDM_ACTION_EXIT
     END
     POPUP "&Pogled"
     BEGIN
-        MENUITEM "&Skrij statusno vrstico",        IDM_VID_HIDE_STATUS_BAR
-        MENUITEM "Hide &toolbar",        IDM_VID_HIDE_TOOLBAR
+        MENUITEM "&Skrij statusno vrstico", IDM_VID_HIDE_STATUS_BAR
+        MENUITEM "Hide &toolbar", IDM_VID_HIDE_TOOLBAR
         MENUITEM SEPARATOR
-        MENUITEM "&Show non-primary monitors",  IDM_VID_MONITORS
-        MENUITEM "S&premenljiva velikost okna",          IDM_VID_RESIZE
-        MENUITEM "&Zapomni si velikost in položaj",  IDM_VID_REMEMBER
+        MENUITEM "&Show non-primary monitors", IDM_VID_MONITORS
+        MENUITEM "S&premenljiva velikost okna", IDM_VID_RESIZE
+        MENUITEM "&Zapomni si velikost in položaj", IDM_VID_REMEMBER
         MENUITEM SEPARATOR
         POPUP "&Upodabljanje"
         BEGIN
-            MENUITEM "&SDL (programsko)",         IDM_VID_SDL_SW
-            MENUITEM "SDL (s&trojno)",         IDM_VID_SDL_HW
-            MENUITEM "SDL (&OpenGL)",           IDM_VID_SDL_OPENGL
-            MENUITEM "Open&GL (Jedro 3.0)",      IDM_VID_OPENGL_CORE
+            MENUITEM "&SDL (programsko)", IDM_VID_SDL_SW
+            MENUITEM "SDL (s&trojno)", IDM_VID_SDL_HW
+            MENUITEM "SDL (&OpenGL)", IDM_VID_SDL_OPENGL
+            MENUITEM "Open&GL (Jedro 3.0)", IDM_VID_OPENGL_CORE
 #ifdef USE_VNC
-            MENUITEM "&VNC",                    IDM_VID_VNC
+            MENUITEM "&VNC", IDM_VID_VNC
 #endif
         END
         MENUITEM SEPARATOR
-        MENUITEM "&Določi velikost...",          IDM_VID_SPECIFY_DIM
-        MENUITEM "&Vsili 4:3 razmerje zaslona",    IDM_VID_FORCE43
+        MENUITEM "&Določi velikost...", IDM_VID_SPECIFY_DIM
+        MENUITEM "&Vsili 4:3 razmerje zaslona", IDM_VID_FORCE43
         POPUP "&Faktor velikosti okna"
         BEGIN
-            MENUITEM "&0.5x",                   IDM_VID_SCALE_1X
-            MENUITEM "&1x",                     IDM_VID_SCALE_2X
-            MENUITEM "1.&5x",                   IDM_VID_SCALE_3X
-            MENUITEM "&2x",                     IDM_VID_SCALE_4X
-            MENUITEM "&3x",                     IDM_VID_SCALE_5X
-            MENUITEM "&4x",                     IDM_VID_SCALE_6X
-            MENUITEM "&5x",                     IDM_VID_SCALE_7X
-            MENUITEM "&6x",                     IDM_VID_SCALE_8X
-            MENUITEM "&7x",                     IDM_VID_SCALE_9X
-            MENUITEM "&8x",                     IDM_VID_SCALE_10X
+            MENUITEM "&0.5x", IDM_VID_SCALE_1X
+            MENUITEM "&1x", IDM_VID_SCALE_2X
+            MENUITEM "1.&5x", IDM_VID_SCALE_3X
+            MENUITEM "&2x", IDM_VID_SCALE_4X
+            MENUITEM "&3x", IDM_VID_SCALE_5X
+            MENUITEM "&4x", IDM_VID_SCALE_6X
+            MENUITEM "&5x", IDM_VID_SCALE_7X
+            MENUITEM "&6x", IDM_VID_SCALE_8X
+            MENUITEM "&7x", IDM_VID_SCALE_9X
+            MENUITEM "&8x", IDM_VID_SCALE_10X
         END
         POPUP "&Metoda filtriranja"
         BEGIN
-            MENUITEM "&Najbližja",                 IDM_VID_FILTER_NEAREST
-            MENUITEM "&Linearna",                  IDM_VID_FILTER_LINEAR
+            MENUITEM "&Najbližja", IDM_VID_FILTER_NEAREST
+            MENUITEM "&Linearna", IDM_VID_FILTER_LINEAR
         END
-        MENUITEM "&Raztezanje za visok DPI",              IDM_VID_HIDPI
+        MENUITEM "&Raztezanje za visok DPI", IDM_VID_HIDPI
         MENUITEM SEPARATOR
-        MENUITEM "&Celozaslonski način\tCtrl+Alt+PgUp",    IDM_VID_FULLSCREEN
+        MENUITEM "&Celozaslonski način\tCtrl+Alt+PgUp", IDM_VID_FULLSCREEN
         POPUP "&Način celozaslonskega raztezanja"
         BEGIN
-            MENUITEM "&Raztegni na celoten zaslon",        IDM_VID_FS_FULL
-            MENUITEM "&4:3",                        IDM_VID_FS_43
+            MENUITEM "&Raztegni na celoten zaslon", IDM_VID_FS_FULL
+            MENUITEM "&4:3", IDM_VID_FS_43
             MENUITEM "&Kvadratni piksli (ohrani razmerje)", IDM_VID_FS_KEEPRATIO
-            MENUITEM "&Celoštevilsko raztezanje",              IDM_VID_FS_INT
+            MENUITEM "&Celoštevilsko raztezanje", IDM_VID_FS_INT
         END
         POPUP "Nastavitve E&GA/(S)VGA"
         BEGIN
-            MENUITEM "&Obrni barve zaslona VGA",   IDM_VID_INVERT
+            MENUITEM "&Obrni barve zaslona VGA", IDM_VID_INVERT
             POPUP "&Vrsta zaslona VGA"
             BEGIN
-                MENUITEM "&Barvni RGB",          IDM_VID_GRAY_RGB
-                MENUITEM "&Sivinski RGB",      IDM_VID_GRAY_MONO
-                MENUITEM "&Rumeni zaslon",      IDM_VID_GRAY_AMBER
-                MENUITEM "&Zeleni zaslon",      IDM_VID_GRAY_GREEN
-                MENUITEM "B&eli zaslon",      IDM_VID_GRAY_WHITE
+                MENUITEM "&Barvni RGB", IDM_VID_GRAY_RGB
+                MENUITEM "&Sivinski RGB", IDM_VID_GRAY_MONO
+                MENUITEM "&Rumeni zaslon", IDM_VID_GRAY_AMBER
+                MENUITEM "&Zeleni zaslon", IDM_VID_GRAY_GREEN
+                MENUITEM "B&eli zaslon", IDM_VID_GRAY_WHITE
             END
             POPUP "V&rsta pretvorbe sivin"
             BEGIN
-                MENUITEM "BT&601 (NTSC/PAL)",   IDM_VID_GRAYCT_601
-                MENUITEM "BT&709 (HDTV)",       IDM_VID_GRAYCT_709
-                MENUITEM "&Povprečje",            IDM_VID_GRAYCT_AVE
+                MENUITEM "BT&601 (NTSC/PAL)", IDM_VID_GRAYCT_601
+                MENUITEM "BT&709 (HDTV)", IDM_VID_GRAYCT_709
+                MENUITEM "&Povprečje", IDM_VID_GRAYCT_AVE
             END
         END
         MENUITEM SEPARATOR
-        MENUITEM "&Presežek slike CGA/PCjr/Tandy/EGA/(S)VGA",     IDM_VID_OVERSCAN
+        MENUITEM "&Presežek slike CGA/PCjr/Tandy/EGA/(S)VGA", IDM_VID_OVERSCAN
         MENUITEM "&Spremeni contrast za črno-beli zaslon", IDM_VID_CGACON
     END
-    MENUITEM "&Mediji",                IDM_MEDIA
+    MENUITEM "&Mediji", IDM_MEDIA
     POPUP "&Orodja"
     BEGIN
-        MENUITEM "&Nastavitve...",                IDM_CONFIG
-        MENUITEM "&Posodabljaj ikone statusne vrstice",    IDM_UPDATE_ICONS
+        MENUITEM "&Nastavitve...", IDM_CONFIG
+        MENUITEM "&Posodabljaj ikone statusne vrstice", IDM_UPDATE_ICONS
         MENUITEM SEPARATOR
-        MENUITEM "&Zajemi posnetek zaslona\tCtrl+F11",  IDM_ACTION_SCREENSHOT
+        MENUITEM "&Zajemi posnetek zaslona\tCtrl+F11", IDM_ACTION_SCREENSHOT
         MENUITEM SEPARATOR
-        MENUITEM "&Možnosti...",    IDM_PREFERENCES
+        MENUITEM "&Možnosti...", IDM_PREFERENCES
 #ifdef DISCORD
         MENUITEM "Omogoči integracijo s programom &Discord", IDM_DISCORD
 #endif
         MENUITEM SEPARATOR
-        MENUITEM "&Ojačanje zvoka...",              IDM_SND_GAIN
+        MENUITEM "&Ojačanje zvoka...", IDM_SND_GAIN
 #ifdef MTR_ENABLED
         MENUITEM SEPARATOR
-        MENUITEM "Z&ačni sledenje\tCtrl+T",         IDM_ACTION_BEGIN_TRACE
-        MENUITEM "&Končaj sledenje\tCtrl+T",           IDM_ACTION_END_TRACE
+        MENUITEM "Z&ačni sledenje\tCtrl+T", IDM_ACTION_BEGIN_TRACE
+        MENUITEM "&Končaj sledenje\tCtrl+T", IDM_ACTION_END_TRACE
 #endif
     END
     POPUP "&Pomoč"
     BEGIN
-        MENUITEM "&Dokumentacija...",           IDM_DOCS
-        MENUITEM "&O programu 86Box...",             IDM_ABOUT
+        MENUITEM "&Dokumentacija...", IDM_DOCS
+        MENUITEM "&O programu 86Box...", IDM_ABOUT
     END
 END
 
-StatusBarMenu MENU DISCARDABLE 
+StatusBarMenu MENU DISCARDABLE
 BEGIN
     MENUITEM SEPARATOR
 END
@@ -137,17 +137,17 @@ CassetteSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nova slika...",                IDM_CASSETTE_IMAGE_NEW
+        MENUITEM "&Nova slika...", IDM_CASSETTE_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Obstoječa slika...",                IDM_CASSETTE_IMAGE_EXISTING
-        MENUITEM "Obstoječa slika (&samo za branje)...",    IDM_CASSETTE_IMAGE_EXISTING_WP
+        MENUITEM "&Obstoječa slika...", IDM_CASSETTE_IMAGE_EXISTING
+        MENUITEM "Obstoječa slika (&samo za branje)...", IDM_CASSETTE_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "Snemaj",                    IDM_CASSETTE_RECORD
-        MENUITEM "Predvajaj",                    IDM_CASSETTE_PLAY
-        MENUITEM "Previj na začetek",            IDM_CASSETTE_REWIND
-        MENUITEM "Preskoči na konec",            IDM_CASSETTE_FAST_FORWARD
+        MENUITEM "Snemaj", IDM_CASSETTE_RECORD
+        MENUITEM "Predvajaj", IDM_CASSETTE_PLAY
+        MENUITEM "Previj na začetek", IDM_CASSETTE_REWIND
+        MENUITEM "Preskoči na konec", IDM_CASSETTE_FAST_FORWARD
         MENUITEM SEPARATOR
-        MENUITEM "Izvrzi",                    IDM_CASSETTE_EJECT
+        MENUITEM "Izvrzi", IDM_CASSETTE_EJECT
     END
 END
 
@@ -155,9 +155,9 @@ CartridgeSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "Slika...",                    IDM_CARTRIDGE_IMAGE
+        MENUITEM "Slika...", IDM_CARTRIDGE_IMAGE
         MENUITEM SEPARATOR
-        MENUITEM "Izvrzi",                    IDM_CARTRIDGE_EJECT
+        MENUITEM "Izvrzi", IDM_CARTRIDGE_EJECT
     END
 END
 
@@ -165,14 +165,14 @@ FloppySubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nova slika...",                IDM_FLOPPY_IMAGE_NEW
+        MENUITEM "&Nova slika...", IDM_FLOPPY_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Obstoječa slika...",                IDM_FLOPPY_IMAGE_EXISTING
-        MENUITEM "Obstoječa slika (&samo za branje)...",    IDM_FLOPPY_IMAGE_EXISTING_WP
+        MENUITEM "&Obstoječa slika...", IDM_FLOPPY_IMAGE_EXISTING
+        MENUITEM "Obstoječa slika (&samo za branje)...", IDM_FLOPPY_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Izvozi v 86F...",                IDM_FLOPPY_EXPORT_TO_86F
+        MENUITEM "&Izvozi v 86F...", IDM_FLOPPY_EXPORT_TO_86F
         MENUITEM SEPARATOR
-        MENUITEM "I&zvrzi",                    IDM_FLOPPY_EJECT
+        MENUITEM "I&zvrzi", IDM_FLOPPY_EJECT
     END
 END
 
@@ -180,13 +180,13 @@ CdromSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Utišaj",                    IDM_CDROM_MUTE
+        MENUITEM "&Utišaj", IDM_CDROM_MUTE
         MENUITEM SEPARATOR
-        MENUITEM "&Prazen",                    IDM_CDROM_EMPTY
-        MENUITEM "&Naloži zadnjo sliko",            IDM_CDROM_RELOAD
+        MENUITEM "&Prazen", IDM_CDROM_EMPTY
+        MENUITEM "&Naloži zadnjo sliko", IDM_CDROM_RELOAD
         MENUITEM SEPARATOR
-        MENUITEM "&Slika...",                    IDM_CDROM_IMAGE
-        MENUITEM "&Mapa...",                    IDM_CDROM_DIR
+        MENUITEM "&Slika...", IDM_CDROM_IMAGE
+        MENUITEM "&Mapa...", IDM_CDROM_DIR
     END
 END
 
@@ -194,13 +194,13 @@ ZIPSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nova slika...",                IDM_ZIP_IMAGE_NEW
+        MENUITEM "&Nova slika...", IDM_ZIP_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Obstoječa slika...",                IDM_ZIP_IMAGE_EXISTING
-        MENUITEM "Obstoječa slika (&samo za branje)...",    IDM_ZIP_IMAGE_EXISTING_WP
+        MENUITEM "&Obstoječa slika...", IDM_ZIP_IMAGE_EXISTING
+        MENUITEM "Obstoječa slika (&samo za branje)...", IDM_ZIP_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "I&zvrzi",                    IDM_ZIP_EJECT
-        MENUITEM "&Naloži zadnjo sliko",            IDM_ZIP_RELOAD
+        MENUITEM "I&zvrzi", IDM_ZIP_EJECT
+        MENUITEM "&Naloži zadnjo sliko", IDM_ZIP_RELOAD
     END
 END
 
@@ -208,13 +208,13 @@ MOSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Nova slika...",                IDM_MO_IMAGE_NEW
+        MENUITEM "&Nova slika...", IDM_MO_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Obstoječa slika...",                IDM_MO_IMAGE_EXISTING
-        MENUITEM "Obstoječa slika (&samo za branje)...",    IDM_MO_IMAGE_EXISTING_WP
+        MENUITEM "&Obstoječa slika...", IDM_MO_IMAGE_EXISTING
+        MENUITEM "Obstoječa slika (&samo za branje)...", IDM_MO_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "I&zvrzi",                    IDM_MO_EJECT
-        MENUITEM "&Naloži zadnjo sliko",            IDM_MO_RELOAD
+        MENUITEM "I&zvrzi", IDM_MO_EJECT
+        MENUITEM "&Naloži zadnjo sliko", IDM_MO_RELOAD
     END
 END
 
@@ -240,150 +240,150 @@ END
 // Dialog
 //
 
-#define STR_PREFERENCES        "Možnosti"
-#define STR_SND_GAIN        "Ojačanje zvoka"
-#define STR_NEW_FLOPPY        "Nova slika"
+#define STR_PREFERENCES   "Možnosti"
+#define STR_SND_GAIN      "Ojačanje zvoka"
+#define STR_NEW_FLOPPY    "Nova slika"
 #define STR_CONFIG        "Nastavitve"
-#define STR_SPECIFY_DIM        "Določi velikost glavnega okna"
+#define STR_SPECIFY_DIM   "Določi velikost glavnega okna"
 
 #define STR_OK            "V redu"
 #define STR_CANCEL        "Prekliči"
 #define STR_GLOBAL        "Shrani te nastavitve kot globalne privzete"
-#define STR_DEFAULT        "Privzeto"
-#define STR_LANGUAGE        "Jezik:"
-#define STR_ICONSET        "Komplet ikon:"
+#define STR_DEFAULT       "Privzeto"
+#define STR_LANGUAGE      "Jezik:"
+#define STR_ICONSET       "Komplet ikon:"
 
-#define STR_GAIN        "Ojačanje"
+#define STR_GAIN          "Ojačanje"
 
-#define STR_FILE_NAME        "Ime datoteke:"
-#define STR_DISK_SIZE        "Velikost diska:"
-#define STR_RPM_MODE        "Način števila obratov:"
-#define STR_PROGRESS        "Napredek:"
+#define STR_FILE_NAME     "Ime datoteke:"
+#define STR_DISK_SIZE     "Velikost diska:"
+#define STR_RPM_MODE      "Način števila obratov:"
+#define STR_PROGRESS      "Napredek:"
 
-#define STR_WIDTH        "Širina:"
+#define STR_WIDTH         "Širina:"
 #define STR_HEIGHT        "Višina:"
-#define STR_LOCK_TO_SIZE    "Zakleni na to velikost"
+#define STR_LOCK_TO_SIZE  "Zakleni na to velikost"
 
-#define STR_MACHINE_TYPE    "Vrsta sistema:"
-#define STR_MACHINE        "Sistem:"
-#define STR_CONFIGURE        "Nastavi"
-#define STR_CPU_TYPE        "Vrsta procesorja:"
-#define STR_CPU_SPEED        "Hitrost:"
-#define STR_FPU            "Procesor plavajoče vejice:"
-#define STR_WAIT_STATES        "Čakalna stanja:"
+#define STR_MACHINE_TYPE  "Vrsta sistema:"
+#define STR_MACHINE       "Sistem:"
+#define STR_CONFIGURE     "Nastavi"
+#define STR_CPU_TYPE      "Vrsta procesorja:"
+#define STR_CPU_SPEED     "Hitrost:"
+#define STR_FPU           "Procesor plavajoče vejice:"
+#define STR_WAIT_STATES   "Čakalna stanja:"
 #define STR_MB            "MB"
 #define STR_MEMORY        "Spomin:"
-#define STR_TIME_SYNC        "Sinhronizacija časa"
-#define STR_DISABLED        "Onemogočeno"
-#define STR_ENABLED_LOCAL    "Omogočeno (lokalni čas)"
-#define STR_ENABLED_UTC        "Omogočeno (UTC)"
-#define STR_DYNAREC        "Dinamični prevajalnik"
+#define STR_TIME_SYNC     "Sinhronizacija časa"
+#define STR_DISABLED      "Onemogočeno"
+#define STR_ENABLED_LOCAL "Omogočeno (lokalni čas)"
+#define STR_ENABLED_UTC   "Omogočeno (UTC)"
+#define STR_DYNAREC       "Dinamični prevajalnik"
 
-#define STR_VIDEO        "Video:"
-#define STR_VIDEO_2        "Video 2:"
+#define STR_VIDEO         "Video:"
+#define STR_VIDEO_2       "Video 2:"
 #define STR_VOODOO        "Voodoo grafika"
-#define STR_IBM8514        "IBM 8514/a grafika"
-#define STR_XGA            "XGA grafika"
+#define STR_IBM8514       "IBM 8514/a grafika"
+#define STR_XGA           "XGA grafika"
 
-#define STR_MOUSE        "Miška:"
-#define STR_JOYSTICK        "Igralna palica:"
-#define STR_JOY1        "Igralna palica 1..."
-#define STR_JOY2        "Igralna palica 2..."
-#define STR_JOY3        "Igralna palica 3..."
-#define STR_JOY4        "Igralna palica 4..."
+#define STR_MOUSE         "Miška:"
+#define STR_JOYSTICK      "Igralna palica:"
+#define STR_JOY1          "Igralna palica 1..."
+#define STR_JOY2          "Igralna palica 2..."
+#define STR_JOY3          "Igralna palica 3..."
+#define STR_JOY4          "Igralna palica 4..."
 
 #define STR_SOUND1        "Zvočna kartica 1:"
 #define STR_SOUND2        "Zvočna kartica 2:"
 #define STR_SOUND3        "Zvočna kartica 3:"
 #define STR_SOUND4        "Zvočna kartica 4:"
-#define STR_MIDI_OUT        "Izhodna naprava MIDI:"
-#define STR_MIDI_IN        "Vhodna naprava MIDI:"
+#define STR_MIDI_OUT      "Izhodna naprava MIDI:"
+#define STR_MIDI_IN       "Vhodna naprava MIDI:"
 #define STR_MPU401        "Samostojen MPU-401"
-#define STR_FLOAT        "Uporabi FLOAT32 za zvok"
-#define STR_FM_DRIVER        "Gonilnik sintetizacije FM"
-#define STR_FM_DRV_NUKED    "Nuked (točnejši)"
-#define STR_FM_DRV_YMFM        "YMFM (hitrejši)"
+#define STR_FLOAT         "Uporabi FLOAT32 za zvok"
+#define STR_FM_DRIVER     "Gonilnik sintetizacije FM"
+#define STR_FM_DRV_NUKED  "Nuked (točnejši)"
+#define STR_FM_DRV_YMFM   "YMFM (hitrejši)"
 
-#define STR_NET_TYPE    "Vrsta omrežja:"
-#define STR_PCAP        "Naprava PCap:"
-#define STR_NET            "Omrežna kartica:"
-#define STR_NET1        "Network card 1:"
-#define STR_NET2        "Network card 2:"
-#define STR_NET3        "Network card 3:"
-#define STR_NET4        "Network card 4:"
+#define STR_NET_TYPE      "Vrsta omrežja:"
+#define STR_PCAP          "Naprava PCap:"
+#define STR_NET           "Omrežna kartica:"
+#define STR_NET1          "Network card 1:"
+#define STR_NET2          "Network card 2:"
+#define STR_NET3          "Network card 3:"
+#define STR_NET4          "Network card 4:"
 
-#define STR_COM1        "Naprava COM1:"
-#define STR_COM2        "Naprava COM2:"
-#define STR_COM3        "Naprava COM3:"
-#define STR_COM4        "Naprava COM4:"
-#define STR_LPT1        "Naprava LPT1:"
-#define STR_LPT2        "Naprava LPT2:"
-#define STR_LPT3        "Naprava LPT3:"
-#define STR_LPT4        "Naprava LPT4:"
-#define STR_SERIAL1        "Serijska vrata 1"
-#define STR_SERIAL2        "Serijska vrata 2"
-#define STR_SERIAL3        "Serijska vrata 3"
-#define STR_SERIAL4        "Serijska vrata 4"
-#define STR_PARALLEL1        "Paralelna vrata 1"
-#define STR_PARALLEL2        "Paralelna vrata 2"
-#define STR_PARALLEL3        "Paralelna vrata 3"
-#define STR_PARALLEL4        "Paralelna vrata 4"
-#define STR_SERIAL_PASS1    "Serial port passthrough 1"
-#define STR_SERIAL_PASS2    "Serial port passthrough 2"
-#define STR_SERIAL_PASS3    "Serial port passthrough 3"
-#define STR_SERIAL_PASS4    "Serial port passthrough 4"
+#define STR_COM1          "Naprava COM1:"
+#define STR_COM2          "Naprava COM2:"
+#define STR_COM3          "Naprava COM3:"
+#define STR_COM4          "Naprava COM4:"
+#define STR_LPT1          "Naprava LPT1:"
+#define STR_LPT2          "Naprava LPT2:"
+#define STR_LPT3          "Naprava LPT3:"
+#define STR_LPT4          "Naprava LPT4:"
+#define STR_SERIAL1       "Serijska vrata 1"
+#define STR_SERIAL2       "Serijska vrata 2"
+#define STR_SERIAL3       "Serijska vrata 3"
+#define STR_SERIAL4       "Serijska vrata 4"
+#define STR_PARALLEL1     "Paralelna vrata 1"
+#define STR_PARALLEL2     "Paralelna vrata 2"
+#define STR_PARALLEL3     "Paralelna vrata 3"
+#define STR_PARALLEL4     "Paralelna vrata 4"
+#define STR_SERIAL_PASS1  "Serial port passthrough 1"
+#define STR_SERIAL_PASS2  "Serial port passthrough 2"
+#define STR_SERIAL_PASS3  "Serial port passthrough 3"
+#define STR_SERIAL_PASS4  "Serial port passthrough 4"
 
-#define STR_HDC            "Krmilnik trdega diska:"
-#define STR_FDC            "Krmilnik disketnika:"
-#define STR_IDE_TER        "Terciarni krmilnik IDE"
-#define STR_IDE_QUA        "Kvartarni krmilnik IDE"
-#define STR_SCSI        "SCSI"
+#define STR_HDC           "Krmilnik trdega diska:"
+#define STR_FDC           "Krmilnik disketnika:"
+#define STR_IDE_TER       "Terciarni krmilnik IDE"
+#define STR_IDE_QUA       "Kvartarni krmilnik IDE"
+#define STR_SCSI          "SCSI"
 #define STR_SCSI_1        "Krmilnik 1:"
 #define STR_SCSI_2        "Krmilnik 2:"
 #define STR_SCSI_3        "Krmilnik 3:"
 #define STR_SCSI_4        "Krmilnik 4:"
-#define STR_CASSETTE        "Kasetnik"
+#define STR_CASSETTE      "Kasetnik"
 
-#define STR_HDD            "Trdi diski:"
-#define STR_NEW            "Nov..."
-#define STR_EXISTING        "Obstoječ..."
+#define STR_HDD           "Trdi diski:"
+#define STR_NEW           "Nov..."
+#define STR_EXISTING      "Obstoječ..."
 #define STR_REMOVE        "Odstrani"
-#define STR_BUS            "Vodilo:"
-#define STR_CHANNEL        "Kanal:"
+#define STR_BUS           "Vodilo:"
+#define STR_CHANNEL       "Kanal:"
 #define STR_ID            "ID:"
-#define STR_SPEED        "Speed:"
+#define STR_SPEED         "Speed:"
 
-#define STR_SPECIFY        "Določi..."
-#define STR_SECTORS        "Sektorji:"
-#define STR_HEADS        "Glave:"
-#define STR_CYLS        "Cilindri:"
-#define STR_SIZE_MB        "Velikost (MB):"
-#define STR_TYPE        "Vrsta:"
-#define STR_IMG_FORMAT        "Format slike:"
-#define STR_BLOCK_SIZE        "Velikost bloka:"
+#define STR_SPECIFY       "Določi..."
+#define STR_SECTORS       "Sektorji:"
+#define STR_HEADS         "Glave:"
+#define STR_CYLS          "Cilindri:"
+#define STR_SIZE_MB       "Velikost (MB):"
+#define STR_TYPE          "Vrsta:"
+#define STR_IMG_FORMAT    "Format slike:"
+#define STR_BLOCK_SIZE    "Velikost bloka:"
 
-#define STR_FLOPPY_DRIVES    "Disketni pogoni:"
-#define STR_TURBO        "Turbo časovniki"
-#define STR_CHECKBPB        "Preverjaj BPB"
-#define STR_CDROM_DRIVES    "Pogoni CD-ROM:"
-#define STR_CD_SPEED        "Hitrost:"
-#define STR_EARLY        "Zgodnejši pogon"
+#define STR_FLOPPY_DRIVES "Disketni pogoni:"
+#define STR_TURBO         "Turbo časovniki"
+#define STR_CHECKBPB      "Preverjaj BPB"
+#define STR_CDROM_DRIVES  "Pogoni CD-ROM:"
+#define STR_CD_SPEED      "Hitrost:"
+#define STR_EARLY         "Zgodnejši pogon"
 
-#define STR_MO_DRIVES        "Magnetno-optični pogoni:"
-#define STR_ZIP_DRIVES        "Pogoni ZIP:"
-#define STR_250            "ZIP 250"
+#define STR_MO_DRIVES     "Magnetno-optični pogoni:"
+#define STR_ZIP_DRIVES    "Pogoni ZIP:"
+#define STR_250           "ZIP 250"
 
 #define STR_ISARTC        "Ura v realnem času ISA:"
 #define STR_ISAMEM        "Razširitev spomina ISA"
-#define STR_ISAMEM_1        "Kartica 1:"
-#define STR_ISAMEM_2        "Kartica 2:"
-#define STR_ISAMEM_3        "Kartica 3:"
-#define STR_ISAMEM_4        "Kartica 4:"
+#define STR_ISAMEM_1      "Kartica 1:"
+#define STR_ISAMEM_2      "Kartica 2:"
+#define STR_ISAMEM_3      "Kartica 3:"
+#define STR_ISAMEM_4      "Kartica 4:"
 #define STR_BUGGER        "Naprava ISABugger"
-#define STR_POSTCARD        "Kartica POST"
+#define STR_POSTCARD      "Kartica POST"
 
-#define FONT_SIZE        9
-#define FONT_NAME        "Segoe UI"
+#define FONT_SIZE         9
+#define FONT_NAME         "Segoe UI"
 
 #include "dialogs.rc"
 
@@ -392,9 +392,9 @@ END
 // String Table
 //
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
-    2048    "86Box"
+    2048        "86Box"
     IDS_2049    "Napaka"
     IDS_2050    "Kritična napaka"
     IDS_2051    " - PAUSED"
@@ -412,7 +412,7 @@ BEGIN
     IDS_2063    "Sistem ""%hs"" ni na voljo zaradi manjkajočih ROM-ov v mapi roms/machines. Preklapljam na drug sistem, ki je na voljo."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2064    "Grafična kartica ""%hs"" ni na voljo zaradi manjkajočih ROM-ov v mapi roms/video. Preklapljam na drugo grafično kartico, ki je na voljo.."
     IDS_2065    "Sistem"
@@ -432,7 +432,7 @@ BEGIN
     IDS_2079    "Pritisnite F8+F12 ali srednji gumb za izpust miške"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2080    "Ne morem inicializirati FluidSynth"
     IDS_2081    "Vodilo"
@@ -544,7 +544,7 @@ BEGIN
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_4096    "Trdi disk (%s)"
     IDS_4097    "%01i:%01i"
@@ -643,7 +643,7 @@ BEGIN
 
     IDS_7168    "(Sistemsko privzeto)"
 END
-#define IDS_LANG_ENUS    IDS_7168
+#define IDS_LANG_ENUS IDS_7168
 
 // Slovenian resources
 /////////////////////////////////////////////////////////////////////////////

--- a/src/win/languages/tr-TR.rc
+++ b/src/win/languages/tr-TR.rc
@@ -13,122 +13,122 @@ LANGUAGE LANG_TURKISH, SUBLANG_DEFAULT
 // Menu
 //
 
-MainMenu MENU DISCARDABLE 
+MainMenu MENU DISCARDABLE
 BEGIN
     POPUP "&Komutlar"
     BEGIN
-        MENUITEM "&Klavye sadece fare yakalandığında çalışsın",    IDM_ACTION_KBD_REQ_CAPTURE
-        MENUITEM "&Sağ CTRL tuşunu sol ALT tuşu olarak ayarla",    IDM_ACTION_RCTRL_IS_LALT
+        MENUITEM "&Klavye sadece fare yakalandığında çalışsın", IDM_ACTION_KBD_REQ_CAPTURE
+        MENUITEM "&Sağ CTRL tuşunu sol ALT tuşu olarak ayarla", IDM_ACTION_RCTRL_IS_LALT
         MENUITEM SEPARATOR
-        MENUITEM "&Makineyi yeniden başlat...",                 IDM_ACTION_HRESET
-        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12",     IDM_ACTION_RESET_CAD
+        MENUITEM "&Makineyi yeniden başlat...", IDM_ACTION_HRESET
+        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12", IDM_ACTION_RESET_CAD
         MENUITEM SEPARATOR
-    MENUITEM "Ctrl+Alt+&Esc",        IDM_ACTION_CTRL_ALT_ESC
+    MENUITEM "Ctrl+Alt+&Esc", IDM_ACTION_CTRL_ALT_ESC
         MENUITEM SEPARATOR
-        MENUITEM "&Duraklat",                      IDM_ACTION_PAUSE
+        MENUITEM "&Duraklat", IDM_ACTION_PAUSE
         MENUITEM SEPARATOR
-        MENUITEM "Emülatörden &çık...",                       IDM_ACTION_EXIT
+        MENUITEM "Emülatörden &çık...", IDM_ACTION_EXIT
     END
     POPUP "&Görüntüleme"
     BEGIN
-        MENUITEM "&Durum çubuğunu gizle",        IDM_VID_HIDE_STATUS_BAR
-        MENUITEM "Hide &toolbar",        IDM_VID_HIDE_TOOLBAR
+        MENUITEM "&Durum çubuğunu gizle", IDM_VID_HIDE_STATUS_BAR
+        MENUITEM "Hide &toolbar", IDM_VID_HIDE_TOOLBAR
         MENUITEM SEPARATOR
-        MENUITEM "&Show non-primary monitors",  IDM_VID_MONITORS
-        MENUITEM "&Yeniden boyutlandırılabilir pencere",          IDM_VID_RESIZE
-        MENUITEM "&Pencere boyut ve pozisyonunu hatırla",  IDM_VID_REMEMBER
+        MENUITEM "&Show non-primary monitors", IDM_VID_MONITORS
+        MENUITEM "&Yeniden boyutlandırılabilir pencere", IDM_VID_RESIZE
+        MENUITEM "&Pencere boyut ve pozisyonunu hatırla", IDM_VID_REMEMBER
         MENUITEM SEPARATOR
         POPUP "&İşleyici"
         BEGIN
-            MENUITEM "&SDL (Yazılım)",         IDM_VID_SDL_SW
-            MENUITEM "SDL (&Donanım)",         IDM_VID_SDL_HW
-            MENUITEM "SDL (&OpenGL)",           IDM_VID_SDL_OPENGL
-            MENUITEM "Open&GL (3.0 Core)",      IDM_VID_OPENGL_CORE
+            MENUITEM "&SDL (Yazılım)", IDM_VID_SDL_SW
+            MENUITEM "SDL (&Donanım)", IDM_VID_SDL_HW
+            MENUITEM "SDL (&OpenGL)", IDM_VID_SDL_OPENGL
+            MENUITEM "Open&GL (3.0 Core)", IDM_VID_OPENGL_CORE
 #ifdef USE_VNC
-            MENUITEM "&VNC",                    IDM_VID_VNC
+            MENUITEM "&VNC", IDM_VID_VNC
 #endif
         END
         MENUITEM SEPARATOR
-        MENUITEM "Pencere &boyutunu belirle...",          IDM_VID_SPECIFY_DIM
-        MENUITEM "&4:3 görüntüleme oranına zorla",    IDM_VID_FORCE43
+        MENUITEM "Pencere &boyutunu belirle...", IDM_VID_SPECIFY_DIM
+        MENUITEM "&4:3 görüntüleme oranına zorla", IDM_VID_FORCE43
         POPUP "Pencere &ölçek çarpanı"
         BEGIN
-            MENUITEM "&0.5x",                   IDM_VID_SCALE_1X
-            MENUITEM "&1x",                     IDM_VID_SCALE_2X
-            MENUITEM "1.&5x",                   IDM_VID_SCALE_3X
-            MENUITEM "&2x",                     IDM_VID_SCALE_4X
-            MENUITEM "&3x",                     IDM_VID_SCALE_5X
-            MENUITEM "&4x",                     IDM_VID_SCALE_6X
-            MENUITEM "&5x",                     IDM_VID_SCALE_7X
-            MENUITEM "&6x",                     IDM_VID_SCALE_8X
-            MENUITEM "&7x",                     IDM_VID_SCALE_9X
-            MENUITEM "&8x",                     IDM_VID_SCALE_10X
+            MENUITEM "&0.5x", IDM_VID_SCALE_1X
+            MENUITEM "&1x", IDM_VID_SCALE_2X
+            MENUITEM "1.&5x", IDM_VID_SCALE_3X
+            MENUITEM "&2x", IDM_VID_SCALE_4X
+            MENUITEM "&3x", IDM_VID_SCALE_5X
+            MENUITEM "&4x", IDM_VID_SCALE_6X
+            MENUITEM "&5x", IDM_VID_SCALE_7X
+            MENUITEM "&6x", IDM_VID_SCALE_8X
+            MENUITEM "&7x", IDM_VID_SCALE_9X
+            MENUITEM "&8x", IDM_VID_SCALE_10X
         END
         POPUP "&Filtre metodu"
         BEGIN
-            MENUITEM "&Nearest (En yakın)",                 IDM_VID_FILTER_NEAREST
-            MENUITEM "&Linear (Doğrusal)",                  IDM_VID_FILTER_LINEAR
+            MENUITEM "&Nearest (En yakın)", IDM_VID_FILTER_NEAREST
+            MENUITEM "&Linear (Doğrusal)", IDM_VID_FILTER_LINEAR
         END
-        MENUITEM "Hi&DPI ölçeklemesi",              IDM_VID_HIDPI
+        MENUITEM "Hi&DPI ölçeklemesi", IDM_VID_HIDPI
         MENUITEM SEPARATOR
-        MENUITEM "&Tam ekran\tCtrl+Alt+PgUp",    IDM_VID_FULLSCREEN
+        MENUITEM "&Tam ekran\tCtrl+Alt+PgUp", IDM_VID_FULLSCREEN
         POPUP "Tam ekran &germe modu"
         BEGIN
-            MENUITEM "&Tam ekrana ger",        IDM_VID_FS_FULL
-            MENUITEM "&4:3",                        IDM_VID_FS_43
+            MENUITEM "&Tam ekrana ger", IDM_VID_FS_FULL
+            MENUITEM "&4:3", IDM_VID_FS_43
             MENUITEM "&Kare piksel (ölçeği koru)", IDM_VID_FS_KEEPRATIO
-            MENUITEM "Tam &sayı ölçeklemesi",              IDM_VID_FS_INT
+            MENUITEM "Tam &sayı ölçeklemesi", IDM_VID_FS_INT
         END
         POPUP "EGA/&(S)VGA ayarları"
         BEGIN
-            MENUITEM "Ters &renk VGA monitör",   IDM_VID_INVERT
+            MENUITEM "Ters &renk VGA monitör", IDM_VID_INVERT
             POPUP "VGA ekran &tipi"
             BEGIN
-                MENUITEM "RGB (&renkli)",          IDM_VID_GRAY_RGB
-                MENUITEM "RGB (&gri tonlama)",      IDM_VID_GRAY_MONO
-                MENUITEM "&Kehribar rengi monitör",      IDM_VID_GRAY_AMBER
-                MENUITEM "&Yeşil renk monitör",      IDM_VID_GRAY_GREEN
-                MENUITEM "&Beyaz renk monitör",      IDM_VID_GRAY_WHITE
+                MENUITEM "RGB (&renkli)", IDM_VID_GRAY_RGB
+                MENUITEM "RGB (&gri tonlama)", IDM_VID_GRAY_MONO
+                MENUITEM "&Kehribar rengi monitör", IDM_VID_GRAY_AMBER
+                MENUITEM "&Yeşil renk monitör", IDM_VID_GRAY_GREEN
+                MENUITEM "&Beyaz renk monitör", IDM_VID_GRAY_WHITE
             END
             POPUP "&Gri tonlama dönüştürme tipi"
             BEGIN
-                MENUITEM "BT&601 (NTSC/PAL)",   IDM_VID_GRAYCT_601
-                MENUITEM "BT&709 (HDTV)",       IDM_VID_GRAYCT_709
-                MENUITEM "&Ortalama",            IDM_VID_GRAYCT_AVE
+                MENUITEM "BT&601 (NTSC/PAL)", IDM_VID_GRAYCT_601
+                MENUITEM "BT&709 (HDTV)", IDM_VID_GRAYCT_709
+                MENUITEM "&Ortalama", IDM_VID_GRAYCT_AVE
             END
         END
         MENUITEM SEPARATOR
-        MENUITEM "CGA/PCjr/Tandy/E&GA/(S)VGA aşırı taraması",     IDM_VID_OVERSCAN
+        MENUITEM "CGA/PCjr/Tandy/E&GA/(S)VGA aşırı taraması", IDM_VID_OVERSCAN
         MENUITEM "Gri to&nlamalı görüntü için kontrastı değiştir", IDM_VID_CGACON
     END
-    MENUITEM "&Medya",                IDM_MEDIA
+    MENUITEM "&Medya", IDM_MEDIA
     POPUP "&Araçlar"
     BEGIN
-        MENUITEM "&Ayarlar...",                IDM_CONFIG
-        MENUITEM "Durum &çubuğu ikonlarını güncelle",    IDM_UPDATE_ICONS
+        MENUITEM "&Ayarlar...", IDM_CONFIG
+        MENUITEM "Durum &çubuğu ikonlarını güncelle", IDM_UPDATE_ICONS
         MENUITEM SEPARATOR
-        MENUITEM "&Ekran görüntüsü al\tCtrl+F11",  IDM_ACTION_SCREENSHOT
+        MENUITEM "&Ekran görüntüsü al\tCtrl+F11", IDM_ACTION_SCREENSHOT
         MENUITEM SEPARATOR
-        MENUITEM "&Tercihler...",    IDM_PREFERENCES
+        MENUITEM "&Tercihler...", IDM_PREFERENCES
 #ifdef DISCORD
         MENUITEM "&Discord entegrasyonunu etkinleştir", IDM_DISCORD
 #endif
         MENUITEM SEPARATOR
-        MENUITEM "&Ses yükseltici...",              IDM_SND_GAIN
+        MENUITEM "&Ses yükseltici...", IDM_SND_GAIN
 #ifdef MTR_ENABLED
         MENUITEM SEPARATOR
-        MENUITEM "Begin trace\tCtrl+T",         IDM_ACTION_BEGIN_TRACE
-        MENUITEM "End trace\tCtrl+T",           IDM_ACTION_END_TRACE
+        MENUITEM "Begin trace\tCtrl+T", IDM_ACTION_BEGIN_TRACE
+        MENUITEM "End trace\tCtrl+T", IDM_ACTION_END_TRACE
 #endif
     END
     POPUP "&Yardım"
     BEGIN
-        MENUITEM "&Dökümanlar...",           IDM_DOCS
-        MENUITEM "&86Box Hakkında...",             IDM_ABOUT
+        MENUITEM "&Dökümanlar...", IDM_DOCS
+        MENUITEM "&86Box Hakkında...", IDM_ABOUT
     END
 END
 
-StatusBarMenu MENU DISCARDABLE 
+StatusBarMenu MENU DISCARDABLE
 BEGIN
     MENUITEM SEPARATOR
 END
@@ -137,17 +137,17 @@ CassetteSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Yeni imaj oluştur...",                IDM_CASSETTE_IMAGE_NEW
+        MENUITEM "&Yeni imaj oluştur...", IDM_CASSETTE_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&İmaj seç...",                IDM_CASSETTE_IMAGE_EXISTING
-        MENUITEM "İmaj &seç (Yazma-korumalı)...",    IDM_CASSETTE_IMAGE_EXISTING_WP
+        MENUITEM "&İmaj seç...", IDM_CASSETTE_IMAGE_EXISTING
+        MENUITEM "İmaj &seç (Yazma-korumalı)...", IDM_CASSETTE_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Kaydet",                    IDM_CASSETTE_RECORD
-        MENUITEM "&Oynat",                    IDM_CASSETTE_PLAY
-        MENUITEM "&Başlangıca geri sar",            IDM_CASSETTE_REWIND
-        MENUITEM "Sona doğru &ileri sar",            IDM_CASSETTE_FAST_FORWARD
+        MENUITEM "&Kaydet", IDM_CASSETTE_RECORD
+        MENUITEM "&Oynat", IDM_CASSETTE_PLAY
+        MENUITEM "&Başlangıca geri sar", IDM_CASSETTE_REWIND
+        MENUITEM "Sona doğru &ileri sar", IDM_CASSETTE_FAST_FORWARD
         MENUITEM SEPARATOR
-        MENUITEM "&Çıkar",                    IDM_CASSETTE_EJECT
+        MENUITEM "&Çıkar", IDM_CASSETTE_EJECT
     END
 END
 
@@ -155,9 +155,9 @@ CartridgeSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&İmaj...",                    IDM_CARTRIDGE_IMAGE
+        MENUITEM "&İmaj...", IDM_CARTRIDGE_IMAGE
         MENUITEM SEPARATOR
-        MENUITEM "&Çıkar",                    IDM_CARTRIDGE_EJECT
+        MENUITEM "&Çıkar", IDM_CARTRIDGE_EJECT
     END
 END
 
@@ -165,14 +165,14 @@ FloppySubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Yeni imaj oluştur...",                IDM_FLOPPY_IMAGE_NEW
+        MENUITEM "&Yeni imaj oluştur...", IDM_FLOPPY_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&İmaj seç...",                IDM_FLOPPY_IMAGE_EXISTING
-        MENUITEM "İmaj &seç (Yazma-korumalı)...",    IDM_FLOPPY_IMAGE_EXISTING_WP
+        MENUITEM "&İmaj seç...", IDM_FLOPPY_IMAGE_EXISTING
+        MENUITEM "İmaj &seç (Yazma-korumalı)...", IDM_FLOPPY_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&86F dosyası olarak aktar...",                IDM_FLOPPY_EXPORT_TO_86F
+        MENUITEM "&86F dosyası olarak aktar...", IDM_FLOPPY_EXPORT_TO_86F
         MENUITEM SEPARATOR
-        MENUITEM "&Çıkar",                    IDM_FLOPPY_EJECT
+        MENUITEM "&Çıkar", IDM_FLOPPY_EJECT
     END
 END
 
@@ -180,13 +180,13 @@ CdromSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Sesi kapat",                    IDM_CDROM_MUTE
+        MENUITEM "&Sesi kapat", IDM_CDROM_MUTE
         MENUITEM SEPARATOR
-        MENUITEM "İmajı &çıkar",                    IDM_CDROM_EMPTY
-        MENUITEM "&Önceki imajı seç",            IDM_CDROM_RELOAD
+        MENUITEM "İmajı &çıkar", IDM_CDROM_EMPTY
+        MENUITEM "&Önceki imajı seç", IDM_CDROM_RELOAD
         MENUITEM SEPARATOR
-        MENUITEM "&İmaj seç...",                    IDM_CDROM_IMAGE
-        MENUITEM "&Klasör...",                    IDM_CDROM_DIR
+        MENUITEM "&İmaj seç...", IDM_CDROM_IMAGE
+        MENUITEM "&Klasör...", IDM_CDROM_DIR
     END
 END
 
@@ -194,13 +194,13 @@ ZIPSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Yeni imaj...",                IDM_ZIP_IMAGE_NEW
+        MENUITEM "&Yeni imaj...", IDM_ZIP_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&İmaj seç...",                IDM_ZIP_IMAGE_EXISTING
-        MENUITEM "İmaj &seç (Yazma-korumalı)...",    IDM_ZIP_IMAGE_EXISTING_WP
+        MENUITEM "&İmaj seç...", IDM_ZIP_IMAGE_EXISTING
+        MENUITEM "İmaj &seç (Yazma-korumalı)...", IDM_ZIP_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Çıkar",                    IDM_ZIP_EJECT
-        MENUITEM "&Önceki imajı seç",            IDM_ZIP_RELOAD
+        MENUITEM "&Çıkar", IDM_ZIP_EJECT
+        MENUITEM "&Önceki imajı seç", IDM_ZIP_RELOAD
     END
 END
 
@@ -208,13 +208,13 @@ MOSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Yeni imaj...",                IDM_MO_IMAGE_NEW
+        MENUITEM "&Yeni imaj...", IDM_MO_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&İmaj seç...",                IDM_MO_IMAGE_EXISTING
-        MENUITEM "İmaj &seç (Yazma-korumalı)...",    IDM_MO_IMAGE_EXISTING_WP
+        MENUITEM "&İmaj seç...", IDM_MO_IMAGE_EXISTING
+        MENUITEM "İmaj &seç (Yazma-korumalı)...", IDM_MO_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Çıkar",                    IDM_MO_EJECT
-        MENUITEM "&Önceki imajı seç",            IDM_MO_RELOAD
+        MENUITEM "&Çıkar", IDM_MO_EJECT
+        MENUITEM "&Önceki imajı seç", IDM_MO_RELOAD
     END
 END
 
@@ -240,150 +240,150 @@ END
 // Dialog
 //
 
-#define STR_PREFERENCES        "Tercihler"
-#define STR_SND_GAIN        "Ses Artırma"
-#define STR_NEW_FLOPPY        "Yeni İmaj"
+#define STR_PREFERENCES   "Tercihler"
+#define STR_SND_GAIN      "Ses Artırma"
+#define STR_NEW_FLOPPY    "Yeni İmaj"
 #define STR_CONFIG        "Ayarlar"
-#define STR_SPECIFY_DIM        "Ana Pencere Boyutunu Belirle"
+#define STR_SPECIFY_DIM   "Ana Pencere Boyutunu Belirle"
 
 #define STR_OK            "Tamam"
 #define STR_CANCEL        "İptal et"
 #define STR_GLOBAL        "Bu ayarları &varsayılan olarak kaydet"
-#define STR_DEFAULT        "&Varsayılan"
-#define STR_LANGUAGE        "Dil:"
-#define STR_ICONSET        "Simge seti:"
+#define STR_DEFAULT       "&Varsayılan"
+#define STR_LANGUAGE      "Dil:"
+#define STR_ICONSET       "Simge seti:"
 
-#define STR_GAIN        "Artırma"
+#define STR_GAIN          "Artırma"
 
-#define STR_FILE_NAME        "Dosya adı:"
-#define STR_DISK_SIZE        "Disk boyutu:"
-#define STR_RPM_MODE        "RPM modu:"
-#define STR_PROGRESS        "İşlem:"
+#define STR_FILE_NAME     "Dosya adı:"
+#define STR_DISK_SIZE     "Disk boyutu:"
+#define STR_RPM_MODE      "RPM modu:"
+#define STR_PROGRESS      "İşlem:"
 
-#define STR_WIDTH        "Genişlik:"
+#define STR_WIDTH         "Genişlik:"
 #define STR_HEIGHT        "Yükseklik:"
-#define STR_LOCK_TO_SIZE    "Bu boyuta kilitle"
+#define STR_LOCK_TO_SIZE  "Bu boyuta kilitle"
 
-#define STR_MACHINE_TYPE    "Makine türü:"
-#define STR_MACHINE        "Makine:"
-#define STR_CONFIGURE        "Ayarla"
-#define STR_CPU_TYPE        "CPU türü:"
-#define STR_CPU_SPEED        "Hız:"
-#define STR_FPU            "FPU:"
-#define STR_WAIT_STATES        "Bekleme süreleri:"
+#define STR_MACHINE_TYPE  "Makine türü:"
+#define STR_MACHINE       "Makine:"
+#define STR_CONFIGURE     "Ayarla"
+#define STR_CPU_TYPE      "CPU türü:"
+#define STR_CPU_SPEED     "Hız:"
+#define STR_FPU           "FPU:"
+#define STR_WAIT_STATES   "Bekleme süreleri:"
 #define STR_MB            "MB"
 #define STR_MEMORY        "Bellek:"
-#define STR_TIME_SYNC        "Zaman senkronizasyonu"
-#define STR_DISABLED        "Devre dışı"
-#define STR_ENABLED_LOCAL    "Etkin (yerel zaman)"
-#define STR_ENABLED_UTC        "Etkin (UTC)"
-#define STR_DYNAREC        "Dinamik Derleyici"
+#define STR_TIME_SYNC     "Zaman senkronizasyonu"
+#define STR_DISABLED      "Devre dışı"
+#define STR_ENABLED_LOCAL "Etkin (yerel zaman)"
+#define STR_ENABLED_UTC   "Etkin (UTC)"
+#define STR_DYNAREC       "Dinamik Derleyici"
 
-#define STR_VIDEO        "Ekran kartı:"
-#define STR_VIDEO_2        "Ekran kartı 2:"
+#define STR_VIDEO         "Ekran kartı:"
+#define STR_VIDEO_2       "Ekran kartı 2:"
 #define STR_VOODOO        "Voodoo Grafikleri"
-#define STR_IBM8514        "IBM 8514/a Grafikleri"
-#define STR_XGA            "XGA Grafikleri"
+#define STR_IBM8514       "IBM 8514/a Grafikleri"
+#define STR_XGA           "XGA Grafikleri"
 
-#define STR_MOUSE        "Fare:"
-#define STR_JOYSTICK        "Oyun kolu:"
-#define STR_JOY1        "Oyun kolu 1..."
-#define STR_JOY2        "Oyun kolu 2..."
-#define STR_JOY3        "Oyun kolu 3..."
-#define STR_JOY4        "Oyun kolu 4..."
+#define STR_MOUSE         "Fare:"
+#define STR_JOYSTICK      "Oyun kolu:"
+#define STR_JOY1          "Oyun kolu 1..."
+#define STR_JOY2          "Oyun kolu 2..."
+#define STR_JOY3          "Oyun kolu 3..."
+#define STR_JOY4          "Oyun kolu 4..."
 
 #define STR_SOUND1        "Ses kartı 1:"
 #define STR_SOUND2        "Ses kartı 2:"
 #define STR_SOUND3        "Ses kartı 3:"
 #define STR_SOUND4        "Ses kartı 4:"
-#define STR_MIDI_OUT        "MIDI Çıkış Cihazı:"
-#define STR_MIDI_IN        "MIDI Giriş Cihazı:"
+#define STR_MIDI_OUT      "MIDI Çıkış Cihazı:"
+#define STR_MIDI_IN       "MIDI Giriş Cihazı:"
 #define STR_MPU401        "Bağımsız MPU-401"
-#define STR_FLOAT        "FLOAT32 ses kullan"
-#define STR_FM_DRIVER        "FM sentez sürücüsü"
-#define STR_FM_DRV_NUKED    "Nuked (daha doğru)"
-#define STR_FM_DRV_YMFM        "YMFM (daha hızlı)"
+#define STR_FLOAT         "FLOAT32 ses kullan"
+#define STR_FM_DRIVER     "FM sentez sürücüsü"
+#define STR_FM_DRV_NUKED  "Nuked (daha doğru)"
+#define STR_FM_DRV_YMFM   "YMFM (daha hızlı)"
 
-#define STR_NET_TYPE    "Ağ tipi:"
-#define STR_PCAP        "PCap cihazı:"
-#define STR_NET            "Ağ cihazı:"
-#define STR_NET1        "Network card 1:"
-#define STR_NET2        "Network card 2:"
-#define STR_NET3        "Network card 3:"
-#define STR_NET4        "Network card 4:"
+#define STR_NET_TYPE      "Ağ tipi:"
+#define STR_PCAP          "PCap cihazı:"
+#define STR_NET           "Ağ cihazı:"
+#define STR_NET1          "Network card 1:"
+#define STR_NET2          "Network card 2:"
+#define STR_NET3          "Network card 3:"
+#define STR_NET4          "Network card 4:"
 
-#define STR_COM1        "COM1 Cihazı:"
-#define STR_COM2        "COM2 Cihazı:"
-#define STR_COM3        "COM3 Cihazı:"
-#define STR_COM4        "COM4 Cihazı:"
-#define STR_LPT1        "LPT1 Cihazı:"
-#define STR_LPT2        "LPT2 Cihazı:"
-#define STR_LPT3        "LPT3 Cihazı:"
-#define STR_LPT4        "LPT4 Cihazı:"
-#define STR_SERIAL1        "Seri port 1"
-#define STR_SERIAL2        "Seri port 2"
-#define STR_SERIAL3        "Seri port 3"
-#define STR_SERIAL4        "Seri port 4"
-#define STR_PARALLEL1        "Paralel port 1"
-#define STR_PARALLEL2        "Paralel port 2"
-#define STR_PARALLEL3        "Paralel port 3"
-#define STR_PARALLEL4        "Paralel port 4"
-#define STR_SERIAL_PASS1    "Serial port passthrough 1"
-#define STR_SERIAL_PASS2    "Serial port passthrough 2"
-#define STR_SERIAL_PASS3    "Serial port passthrough 3"
-#define STR_SERIAL_PASS4    "Serial port passthrough 4"
+#define STR_COM1          "COM1 Cihazı:"
+#define STR_COM2          "COM2 Cihazı:"
+#define STR_COM3          "COM3 Cihazı:"
+#define STR_COM4          "COM4 Cihazı:"
+#define STR_LPT1          "LPT1 Cihazı:"
+#define STR_LPT2          "LPT2 Cihazı:"
+#define STR_LPT3          "LPT3 Cihazı:"
+#define STR_LPT4          "LPT4 Cihazı:"
+#define STR_SERIAL1       "Seri port 1"
+#define STR_SERIAL2       "Seri port 2"
+#define STR_SERIAL3       "Seri port 3"
+#define STR_SERIAL4       "Seri port 4"
+#define STR_PARALLEL1     "Paralel port 1"
+#define STR_PARALLEL2     "Paralel port 2"
+#define STR_PARALLEL3     "Paralel port 3"
+#define STR_PARALLEL4     "Paralel port 4"
+#define STR_SERIAL_PASS1  "Serial port passthrough 1"
+#define STR_SERIAL_PASS2  "Serial port passthrough 2"
+#define STR_SERIAL_PASS3  "Serial port passthrough 3"
+#define STR_SERIAL_PASS4  "Serial port passthrough 4"
 
-#define STR_HDC            "HD Kontrolcüsü:"
-#define STR_FDC            "FD Kontrolcüsü:"
-#define STR_IDE_TER        "Üçlü IDE Kontrolcüsü"
-#define STR_IDE_QUA        "Dörtlü IDE Kontrolcüsü"
-#define STR_SCSI        "SCSI"
+#define STR_HDC           "HD Kontrolcüsü:"
+#define STR_FDC           "FD Kontrolcüsü:"
+#define STR_IDE_TER       "Üçlü IDE Kontrolcüsü"
+#define STR_IDE_QUA       "Dörtlü IDE Kontrolcüsü"
+#define STR_SCSI          "SCSI"
 #define STR_SCSI_1        "Kontrolcü 1:"
 #define STR_SCSI_2        "Kontrolcü 2:"
 #define STR_SCSI_3        "Kontrolcü 3:"
 #define STR_SCSI_4        "Kontrolcü 4:"
-#define STR_CASSETTE        "Kaset"
+#define STR_CASSETTE      "Kaset"
 
-#define STR_HDD            "Hard diskler:"
-#define STR_NEW            "&Yeni..."
-#define STR_EXISTING        "&Var olan..."
+#define STR_HDD           "Hard diskler:"
+#define STR_NEW           "&Yeni..."
+#define STR_EXISTING      "&Var olan..."
 #define STR_REMOVE        "&Kaldır"
-#define STR_BUS            "Veri yolu:"
-#define STR_CHANNEL        "Kanal:"
+#define STR_BUS           "Veri yolu:"
+#define STR_CHANNEL       "Kanal:"
 #define STR_ID            "ID:"
-#define STR_SPEED        "Speed:"
+#define STR_SPEED         "Speed:"
 
-#define STR_SPECIFY        "&Belirle..."
-#define STR_SECTORS        "Sektörler:"
-#define STR_HEADS        "Veri Kafaları:"
-#define STR_CYLS        "Silindirler:"
-#define STR_SIZE_MB        "Boyut (MB):"
-#define STR_TYPE        "Tip:"
-#define STR_IMG_FORMAT        "İmaj Düzeni:"
-#define STR_BLOCK_SIZE        "Blok Boyutu:"
+#define STR_SPECIFY       "&Belirle..."
+#define STR_SECTORS       "Sektörler:"
+#define STR_HEADS         "Veri Kafaları:"
+#define STR_CYLS          "Silindirler:"
+#define STR_SIZE_MB       "Boyut (MB):"
+#define STR_TYPE          "Tip:"
+#define STR_IMG_FORMAT    "İmaj Düzeni:"
+#define STR_BLOCK_SIZE    "Blok Boyutu:"
 
-#define STR_FLOPPY_DRIVES    "Disket sürücüleri:"
-#define STR_TURBO        "Turbo zamanlamaları"
-#define STR_CHECKBPB        "BPB'yi denetle"
-#define STR_CDROM_DRIVES    "CD-ROM sürücüleri:"
-#define STR_CD_SPEED        "Hız:"
-#define STR_EARLY        "Daha erken sürüş"
+#define STR_FLOPPY_DRIVES "Disket sürücüleri:"
+#define STR_TURBO         "Turbo zamanlamaları"
+#define STR_CHECKBPB      "BPB'yi denetle"
+#define STR_CDROM_DRIVES  "CD-ROM sürücüleri:"
+#define STR_CD_SPEED      "Hız:"
+#define STR_EARLY         "Daha erken sürüş"
 
-#define STR_MO_DRIVES        "MO sürücüleri:"
-#define STR_ZIP_DRIVES        "ZIP sürücüleri:"
-#define STR_250            "ZIP 250"
+#define STR_MO_DRIVES     "MO sürücüleri:"
+#define STR_ZIP_DRIVES    "ZIP sürücüleri:"
+#define STR_250           "ZIP 250"
 
 #define STR_ISARTC        "ISA RTC:"
 #define STR_ISAMEM        "ISA Bellek Artırma"
-#define STR_ISAMEM_1        "Kart 1:"
-#define STR_ISAMEM_2        "Kart 2:"
-#define STR_ISAMEM_3        "Kart 3:"
-#define STR_ISAMEM_4        "Kart 4:"
+#define STR_ISAMEM_1      "Kart 1:"
+#define STR_ISAMEM_2      "Kart 2:"
+#define STR_ISAMEM_3      "Kart 3:"
+#define STR_ISAMEM_4      "Kart 4:"
 #define STR_BUGGER        "ISABugger cihazı"
-#define STR_POSTCARD        "POST kartı"
+#define STR_POSTCARD      "POST kartı"
 
-#define FONT_SIZE        9
-#define FONT_NAME        "Segoe UI"
+#define FONT_SIZE         9
+#define FONT_NAME         "Segoe UI"
 
 #include "dialogs.rc"
 
@@ -392,9 +392,9 @@ END
 // String Table
 //
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
-    2048    "86Box"
+    2048        "86Box"
     IDS_2049    "Hata"
     IDS_2050    "Kritik hata"
     IDS_2051    " - PAUSED"
@@ -412,7 +412,7 @@ BEGIN
     IDS_2063    """%hs"" makinesi roms/machines klasöründe mevcut olmayan ROM imajı yüzünden mevcut değil. Mevcut olan bir makineye geçiş yapılıyor."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2064    """%hs"" ekran kartı roms/video klasöründe mevcut olmayan ROM imajı yüzünden mevcut değil. Mevcut olan bir ekran kartına geçiş yapılıyor."
     IDS_2065    "Makine"
@@ -432,7 +432,7 @@ BEGIN
     IDS_2079    "Farenin bırakılması için F8+F12 veya farenin orta tuşuna basın"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2080    "FluidSynth başlatılamadı"
     IDS_2081    "Veri yolu"
@@ -544,7 +544,7 @@ BEGIN
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_4096    "Hard disk (%s)"
     IDS_4097    "%01i:%01i"
@@ -643,7 +643,7 @@ BEGIN
 
     IDS_7168    "(Sistem Varsayılanı)"
 END
-#define IDS_LANG_TRTR    IDS_7168
+#define IDS_LANG_TRTR IDS_7168
 
 // Turkish (TR) resources
 /////////////////////////////////////////////////////////////////////////////

--- a/src/win/languages/uk-UA.rc
+++ b/src/win/languages/uk-UA.rc
@@ -13,122 +13,122 @@ LANGUAGE LANG_UKRAINIAN, SUBLANG_DEFAULT
 // Menu
 //
 
-MainMenu MENU DISCARDABLE 
+MainMenu MENU DISCARDABLE
 BEGIN
     POPUP "&Дія"
     BEGIN
-        MENUITEM "&Клавіатура потребує захвату",    IDM_ACTION_KBD_REQ_CAPTURE
-        MENUITEM "&Правий CTRL - це лівий ALT",    IDM_ACTION_RCTRL_IS_LALT
+        MENUITEM "&Клавіатура потребує захвату", IDM_ACTION_KBD_REQ_CAPTURE
+        MENUITEM "&Правий CTRL - це лівий ALT", IDM_ACTION_RCTRL_IS_LALT
         MENUITEM SEPARATOR
-        MENUITEM "&Холодне перезавантаження...",                 IDM_ACTION_HRESET
-        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12",     IDM_ACTION_RESET_CAD
+        MENUITEM "&Холодне перезавантаження...", IDM_ACTION_HRESET
+        MENUITEM "&Ctrl+Alt+Del\tCtrl+F12", IDM_ACTION_RESET_CAD
         MENUITEM SEPARATOR
-    MENUITEM "Ctrl+Alt+&Esc",        IDM_ACTION_CTRL_ALT_ESC
+    MENUITEM "Ctrl+Alt+&Esc", IDM_ACTION_CTRL_ALT_ESC
         MENUITEM SEPARATOR
-        MENUITEM "&Пауза",                      IDM_ACTION_PAUSE
+        MENUITEM "&Пауза", IDM_ACTION_PAUSE
         MENUITEM SEPARATOR
-        MENUITEM "&Вихід...",                       IDM_ACTION_EXIT
+        MENUITEM "&Вихід...", IDM_ACTION_EXIT
     END
     POPUP "&Вигляд"
     BEGIN
-        MENUITEM "&Приховати рядок стану",        IDM_VID_HIDE_STATUS_BAR
-        MENUITEM "&Приховати панель інструментів",        IDM_VID_HIDE_TOOLBAR
+        MENUITEM "&Приховати рядок стану", IDM_VID_HIDE_STATUS_BAR
+        MENUITEM "&Приховати панель інструментів", IDM_VID_HIDE_TOOLBAR
         MENUITEM SEPARATOR
-        MENUITEM "&Show non-primary monitors",  IDM_VID_MONITORS
-        MENUITEM "&Змінний розмір вікна",          IDM_VID_RESIZE
-        MENUITEM "&Запам'ятати розмір і становище",  IDM_VID_REMEMBER
+        MENUITEM "&Show non-primary monitors", IDM_VID_MONITORS
+        MENUITEM "&Змінний розмір вікна", IDM_VID_RESIZE
+        MENUITEM "&Запам'ятати розмір і становище", IDM_VID_REMEMBER
         MENUITEM SEPARATOR
         POPUP "&Рендеринг"
         BEGIN
-            MENUITEM "&SDL (Software)",         IDM_VID_SDL_SW
-            MENUITEM "SDL (&Hardware)",         IDM_VID_SDL_HW
-            MENUITEM "SDL (&OpenGL)",           IDM_VID_SDL_OPENGL
-            MENUITEM "Open&GL (3.0)",      IDM_VID_OPENGL_CORE
+            MENUITEM "&SDL (Software)", IDM_VID_SDL_SW
+            MENUITEM "SDL (&Hardware)", IDM_VID_SDL_HW
+            MENUITEM "SDL (&OpenGL)", IDM_VID_SDL_OPENGL
+            MENUITEM "Open&GL (3.0)", IDM_VID_OPENGL_CORE
 #ifdef USE_VNC
-            MENUITEM "&VNC",                    IDM_VID_VNC
+            MENUITEM "&VNC", IDM_VID_VNC
 #endif
         END
         MENUITEM SEPARATOR
-        MENUITEM "&Вказати розміри...",          IDM_VID_SPECIFY_DIM
-        MENUITEM "&Встановити відношення сторін 4:3",    IDM_VID_FORCE43
+        MENUITEM "&Вказати розміри...", IDM_VID_SPECIFY_DIM
+        MENUITEM "&Встановити відношення сторін 4:3", IDM_VID_FORCE43
         POPUP "&Масштаб вікна"
         BEGIN
-            MENUITEM "&0.5x",                   IDM_VID_SCALE_1X
-            MENUITEM "&1x",                     IDM_VID_SCALE_2X
-            MENUITEM "1.&5x",                   IDM_VID_SCALE_3X
-            MENUITEM "&2x",                     IDM_VID_SCALE_4X
-            MENUITEM "&3x",                     IDM_VID_SCALE_5X
-            MENUITEM "&4x",                     IDM_VID_SCALE_6X
-            MENUITEM "&5x",                     IDM_VID_SCALE_7X
-            MENUITEM "&6x",                     IDM_VID_SCALE_8X
-            MENUITEM "&7x",                     IDM_VID_SCALE_9X
-            MENUITEM "&8x",                     IDM_VID_SCALE_10X
+            MENUITEM "&0.5x", IDM_VID_SCALE_1X
+            MENUITEM "&1x", IDM_VID_SCALE_2X
+            MENUITEM "1.&5x", IDM_VID_SCALE_3X
+            MENUITEM "&2x", IDM_VID_SCALE_4X
+            MENUITEM "&3x", IDM_VID_SCALE_5X
+            MENUITEM "&4x", IDM_VID_SCALE_6X
+            MENUITEM "&5x", IDM_VID_SCALE_7X
+            MENUITEM "&6x", IDM_VID_SCALE_8X
+            MENUITEM "&7x", IDM_VID_SCALE_9X
+            MENUITEM "&8x", IDM_VID_SCALE_10X
         END
         POPUP "Метод фільтрації"
         BEGIN
-            MENUITEM "&Найближчий",                 IDM_VID_FILTER_NEAREST
-            MENUITEM "&Лінійний",                  IDM_VID_FILTER_LINEAR
+            MENUITEM "&Найближчий", IDM_VID_FILTER_NEAREST
+            MENUITEM "&Лінійний", IDM_VID_FILTER_LINEAR
         END
-        MENUITEM "Масштабування Hi&DPI",              IDM_VID_HIDPI
+        MENUITEM "Масштабування Hi&DPI", IDM_VID_HIDPI
         MENUITEM SEPARATOR
-        MENUITEM "&Повноекранний режим\tCtrl+Alt+PgUp",    IDM_VID_FULLSCREEN
+        MENUITEM "&Повноекранний режим\tCtrl+Alt+PgUp", IDM_VID_FULLSCREEN
         POPUP "&Розстягування у повноекранному режимі"
         BEGIN
-            MENUITEM "&На весь екран",        IDM_VID_FS_FULL
-            MENUITEM "&4:3",                        IDM_VID_FS_43
+            MENUITEM "&На весь екран", IDM_VID_FS_FULL
+            MENUITEM "&4:3", IDM_VID_FS_43
             MENUITEM "&Квадратні пікселі (зберегти відношення)", IDM_VID_FS_KEEPRATIO
-            MENUITEM "&Цілісночисленне масштабування",              IDM_VID_FS_INT
+            MENUITEM "&Цілісночисленне масштабування", IDM_VID_FS_INT
         END
         POPUP "Налаштування E&GA/(S)VGA"
         BEGIN
-            MENUITEM "&Інвертувати кольори VGA",   IDM_VID_INVERT
+            MENUITEM "&Інвертувати кольори VGA", IDM_VID_INVERT
             POPUP "&Тип екрана VGA"
             BEGIN
-                MENUITEM "RGB &кольоровий",          IDM_VID_GRAY_RGB
-                MENUITEM "&RGB монохромний",      IDM_VID_GRAY_MONO
-                MENUITEM "&Бурштиновий відтінок",      IDM_VID_GRAY_AMBER
-                MENUITEM "&Зелений відтінок",      IDM_VID_GRAY_GREEN
-                MENUITEM "&Білий відтінок",      IDM_VID_GRAY_WHITE
+                MENUITEM "RGB &кольоровий", IDM_VID_GRAY_RGB
+                MENUITEM "&RGB монохромний", IDM_VID_GRAY_MONO
+                MENUITEM "&Бурштиновий відтінок", IDM_VID_GRAY_AMBER
+                MENUITEM "&Зелений відтінок", IDM_VID_GRAY_GREEN
+                MENUITEM "&Білий відтінок", IDM_VID_GRAY_WHITE
             END
             POPUP "Тип монохромного &конвертування"
             BEGIN
-                MENUITEM "BT&601 (NTSC/PAL)",   IDM_VID_GRAYCT_601
-                MENUITEM "BT&709 (HDTV)",       IDM_VID_GRAYCT_709
-                MENUITEM "&Усереднений",            IDM_VID_GRAYCT_AVE
+                MENUITEM "BT&601 (NTSC/PAL)", IDM_VID_GRAYCT_601
+                MENUITEM "BT&709 (HDTV)", IDM_VID_GRAYCT_709
+                MENUITEM "&Усереднений", IDM_VID_GRAYCT_AVE
             END
         END
         MENUITEM SEPARATOR
-        MENUITEM "Вильоти розгортки CGA/PCjr/Tandy/E&GA/(S)VGA",     IDM_VID_OVERSCAN
+        MENUITEM "Вильоти розгортки CGA/PCjr/Tandy/E&GA/(S)VGA", IDM_VID_OVERSCAN
         MENUITEM "Змінити контрастність &монохромного дисплея", IDM_VID_CGACON
     END
-    MENUITEM "&Носії",                IDM_MEDIA
+    MENUITEM "&Носії", IDM_MEDIA
     POPUP "&Інструменти"
     BEGIN
-        MENUITEM "&Налаштування машини...",                IDM_CONFIG
-        MENUITEM "&Обновлення значків рядка стану",    IDM_UPDATE_ICONS
+        MENUITEM "&Налаштування машини...", IDM_CONFIG
+        MENUITEM "&Обновлення значків рядка стану", IDM_UPDATE_ICONS
         MENUITEM SEPARATOR
-        MENUITEM "Зробити &знімок\tCtrl+F11",  IDM_ACTION_SCREENSHOT
+        MENUITEM "Зробити &знімок\tCtrl+F11", IDM_ACTION_SCREENSHOT
         MENUITEM SEPARATOR
-        MENUITEM "&Параметри...",        IDM_PREFERENCES
+        MENUITEM "&Параметри...", IDM_PREFERENCES
 #ifdef DISCORD
         MENUITEM "Увімкнути інтеграцію &Discord", IDM_DISCORD
 #endif
         MENUITEM SEPARATOR
-        MENUITEM "&Посилення звуку...",              IDM_SND_GAIN
+        MENUITEM "&Посилення звуку...", IDM_SND_GAIN
 #ifdef MTR_ENABLED
         MENUITEM SEPARATOR
-        MENUITEM "Почати трасування\tCtrl+T",         IDM_ACTION_BEGIN_TRACE
-        MENUITEM "Завершити трасування\tCtrl+T",           IDM_ACTION_END_TRACE
+        MENUITEM "Почати трасування\tCtrl+T", IDM_ACTION_BEGIN_TRACE
+        MENUITEM "Завершити трасування\tCtrl+T", IDM_ACTION_END_TRACE
 #endif
     END
     POPUP "&Допомога"
     BEGIN
-        MENUITEM "&Документація...",           IDM_DOCS
-        MENUITEM "&Про програму 86Box...",             IDM_ABOUT
+        MENUITEM "&Документація...", IDM_DOCS
+        MENUITEM "&Про програму 86Box...", IDM_ABOUT
     END
 END
 
-StatusBarMenu MENU DISCARDABLE 
+StatusBarMenu MENU DISCARDABLE
 BEGIN
     MENUITEM SEPARATOR
 END
@@ -137,17 +137,17 @@ CassetteSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Новий образ...",                IDM_CASSETTE_IMAGE_NEW
+        MENUITEM "&Новий образ...", IDM_CASSETTE_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Вибрати образ...",                IDM_CASSETTE_IMAGE_EXISTING
-        MENUITEM "Вибрати образ (&Захист від запису)...",    IDM_CASSETTE_IMAGE_EXISTING_WP
+        MENUITEM "&Вибрати образ...", IDM_CASSETTE_IMAGE_EXISTING
+        MENUITEM "Вибрати образ (&Захист від запису)...", IDM_CASSETTE_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Запис",                    IDM_CASSETTE_RECORD
-        MENUITEM "&Відтворення",                    IDM_CASSETTE_PLAY
-        MENUITEM "&Перемотування на початок",            IDM_CASSETTE_REWIND
-        MENUITEM "&Перемотування у кінець",            IDM_CASSETTE_FAST_FORWARD
+        MENUITEM "&Запис", IDM_CASSETTE_RECORD
+        MENUITEM "&Відтворення", IDM_CASSETTE_PLAY
+        MENUITEM "&Перемотування на початок", IDM_CASSETTE_REWIND
+        MENUITEM "&Перемотування у кінець", IDM_CASSETTE_FAST_FORWARD
         MENUITEM SEPARATOR
-        MENUITEM "&Вилучити",                    IDM_CASSETTE_EJECT
+        MENUITEM "&Вилучити", IDM_CASSETTE_EJECT
     END
 END
 
@@ -155,9 +155,9 @@ CartridgeSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Образ...",                    IDM_CARTRIDGE_IMAGE
+        MENUITEM "&Образ...", IDM_CARTRIDGE_IMAGE
         MENUITEM SEPARATOR
-        MENUITEM "&Вилучити",                    IDM_CARTRIDGE_EJECT
+        MENUITEM "&Вилучити", IDM_CARTRIDGE_EJECT
     END
 END
 
@@ -165,14 +165,14 @@ FloppySubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Новий образ...",                IDM_FLOPPY_IMAGE_NEW
+        MENUITEM "&Новий образ...", IDM_FLOPPY_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Вибрати образ...",                IDM_FLOPPY_IMAGE_EXISTING
-        MENUITEM "Вибрати образ (&Захист від запису)...",    IDM_FLOPPY_IMAGE_EXISTING_WP
+        MENUITEM "&Вибрати образ...", IDM_FLOPPY_IMAGE_EXISTING
+        MENUITEM "Вибрати образ (&Захист від запису)...", IDM_FLOPPY_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Експорт в 86F...",                IDM_FLOPPY_EXPORT_TO_86F
+        MENUITEM "&Експорт в 86F...", IDM_FLOPPY_EXPORT_TO_86F
         MENUITEM SEPARATOR
-        MENUITEM "&Вилучити",                    IDM_FLOPPY_EJECT
+        MENUITEM "&Вилучити", IDM_FLOPPY_EJECT
     END
 END
 
@@ -180,13 +180,13 @@ CdromSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Відключити звук",                    IDM_CDROM_MUTE
+        MENUITEM "&Відключити звук", IDM_CDROM_MUTE
         MENUITEM SEPARATOR
-        MENUITEM "&Пустий",                    IDM_CDROM_EMPTY
-        MENUITEM "&Знову завантажити попередній образ",            IDM_CDROM_RELOAD
+        MENUITEM "&Пустий", IDM_CDROM_EMPTY
+        MENUITEM "&Знову завантажити попередній образ", IDM_CDROM_RELOAD
         MENUITEM SEPARATOR
-        MENUITEM "&Образ...",                    IDM_CDROM_IMAGE
-        MENUITEM "&Тека...",                    IDM_CDROM_DIR
+        MENUITEM "&Образ...", IDM_CDROM_IMAGE
+        MENUITEM "&Тека...", IDM_CDROM_DIR
     END
 END
 
@@ -194,13 +194,13 @@ ZIPSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Новий образ...",                IDM_ZIP_IMAGE_NEW
+        MENUITEM "&Новий образ...", IDM_ZIP_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Вибрати образ...",                IDM_ZIP_IMAGE_EXISTING
-        MENUITEM "Вибрати образ (&Захист від запису)...",    IDM_ZIP_IMAGE_EXISTING_WP
+        MENUITEM "&Вибрати образ...", IDM_ZIP_IMAGE_EXISTING
+        MENUITEM "Вибрати образ (&Захист від запису)...", IDM_ZIP_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Вилучити",                    IDM_ZIP_EJECT
-        MENUITEM "&Знову завантажити попередній образ",            IDM_ZIP_RELOAD
+        MENUITEM "&Вилучити", IDM_ZIP_EJECT
+        MENUITEM "&Знову завантажити попередній образ", IDM_ZIP_RELOAD
     END
 END
 
@@ -208,13 +208,13 @@ MOSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "&Новий образ...",                IDM_MO_IMAGE_NEW
+        MENUITEM "&Новий образ...", IDM_MO_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "&Вибрати образ...",                IDM_MO_IMAGE_EXISTING
-        MENUITEM "Вибрати образ (&Захист від запису)...",    IDM_MO_IMAGE_EXISTING_WP
+        MENUITEM "&Вибрати образ...", IDM_MO_IMAGE_EXISTING
+        MENUITEM "Вибрати образ (&Захист від запису)...", IDM_MO_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "&Вилучити",                    IDM_MO_EJECT
-        MENUITEM "&Знову завантажити попередній образ",            IDM_MO_RELOAD
+        MENUITEM "&Вилучити", IDM_MO_EJECT
+        MENUITEM "&Знову завантажити попередній образ", IDM_MO_RELOAD
     END
 END
 
@@ -240,150 +240,150 @@ END
 // Dialog
 //
 
-#define STR_PREFERENCES        "Параметри"
-#define STR_SND_GAIN        "Посилення звуку"
-#define STR_NEW_FLOPPY        "Новий образ"
+#define STR_PREFERENCES   "Параметри"
+#define STR_SND_GAIN      "Посилення звуку"
+#define STR_NEW_FLOPPY    "Новий образ"
 #define STR_CONFIG        "Налаштування"
-#define STR_SPECIFY_DIM        "Вказати розміри головного вікна"
+#define STR_SPECIFY_DIM   "Вказати розміри головного вікна"
 
 #define STR_OK            "OK"
 #define STR_CANCEL        "Відміна"
 #define STR_GLOBAL        "Зберегти ці параметри як &глобальні за замовчуванням"
-#define STR_DEFAULT        "&За замовчуванням"
-#define STR_LANGUAGE        "Язык:"
-#define STR_ICONSET        "Набір іконок:"
+#define STR_DEFAULT       "&За замовчуванням"
+#define STR_LANGUAGE      "Язык:"
+#define STR_ICONSET       "Набір іконок:"
 
-#define STR_GAIN        "Посилення"
+#define STR_GAIN          "Посилення"
 
-#define STR_FILE_NAME        "Ім'я файлу:"
-#define STR_DISK_SIZE        "Розмір диска:"
-#define STR_RPM_MODE        "RPM режим:"
-#define STR_PROGRESS        "Прогрес:"
+#define STR_FILE_NAME     "Ім'я файлу:"
+#define STR_DISK_SIZE     "Розмір диска:"
+#define STR_RPM_MODE      "RPM режим:"
+#define STR_PROGRESS      "Прогрес:"
 
-#define STR_WIDTH        "Ширина:"
+#define STR_WIDTH         "Ширина:"
 #define STR_HEIGHT        "Висота:"
-#define STR_LOCK_TO_SIZE    "Зафіксувати розмір"
+#define STR_LOCK_TO_SIZE  "Зафіксувати розмір"
 
-#define STR_MACHINE_TYPE    "Тип машини:"
-#define STR_MACHINE        "Системна плата:"
-#define STR_CONFIGURE        "Налаштування"
-#define STR_CPU_TYPE        "Тип ЦП:"
-#define STR_CPU_SPEED        "Швидкість:"
-#define STR_FPU            "FPU:"
-#define STR_WAIT_STATES        "Цикли очікування:"
+#define STR_MACHINE_TYPE  "Тип машини:"
+#define STR_MACHINE       "Системна плата:"
+#define STR_CONFIGURE     "Налаштування"
+#define STR_CPU_TYPE      "Тип ЦП:"
+#define STR_CPU_SPEED     "Швидкість:"
+#define STR_FPU           "FPU:"
+#define STR_WAIT_STATES   "Цикли очікування:"
 #define STR_MB            "МБ"
 #define STR_MEMORY        "Пам'ять:"
-#define STR_TIME_SYNC        "Синхронізація часу"
-#define STR_DISABLED        "Відключити"
-#define STR_ENABLED_LOCAL    "Увімкнути (місцеве)"
-#define STR_ENABLED_UTC        "Увімкнути (UTC)"
-#define STR_DYNAREC        "Динамічний рекомпілятор"
+#define STR_TIME_SYNC     "Синхронізація часу"
+#define STR_DISABLED      "Відключити"
+#define STR_ENABLED_LOCAL "Увімкнути (місцеве)"
+#define STR_ENABLED_UTC   "Увімкнути (UTC)"
+#define STR_DYNAREC       "Динамічний рекомпілятор"
 
-#define STR_VIDEO        "Відеокарта:"
-#define STR_VIDEO_2        "Відеокарта 2:"
+#define STR_VIDEO         "Відеокарта:"
+#define STR_VIDEO_2       "Відеокарта 2:"
 #define STR_VOODOO        "Прискорювач Voodoo"
-#define STR_IBM8514        "Прискорювач IBM 8514/a"
-#define STR_XGA            "Прискорювач XGA"
+#define STR_IBM8514       "Прискорювач IBM 8514/a"
+#define STR_XGA           "Прискорювач XGA"
 
-#define STR_MOUSE        "Миша:"
-#define STR_JOYSTICK        "Джойстик:"
-#define STR_JOY1        "Джойстик 1..."
-#define STR_JOY2        "Джойстик 2..."
-#define STR_JOY3        "Джойстик 3..."
-#define STR_JOY4        "Джойстик 4..."
+#define STR_MOUSE         "Миша:"
+#define STR_JOYSTICK      "Джойстик:"
+#define STR_JOY1          "Джойстик 1..."
+#define STR_JOY2          "Джойстик 2..."
+#define STR_JOY3          "Джойстик 3..."
+#define STR_JOY4          "Джойстик 4..."
 
 #define STR_SOUND1        "Звукова карта 1:"
 #define STR_SOUND2        "Звукова карта 2:"
 #define STR_SOUND3        "Звукова карта 3:"
 #define STR_SOUND4        "Звукова карта 4:"
-#define STR_MIDI_OUT        "MIDI Out при-ій:"
-#define STR_MIDI_IN        "MIDI In при-ій:"
+#define STR_MIDI_OUT      "MIDI Out при-ій:"
+#define STR_MIDI_IN       "MIDI In при-ій:"
 #define STR_MPU401        "Окремий MPU-401"
-#define STR_FLOAT        "FLOAT32 звук"
-#define STR_FM_DRIVER        "Драйвер FM-синтезатора"
-#define STR_FM_DRV_NUKED    "Nuked (більш точний)"
-#define STR_FM_DRV_YMFM        "YMFM (швидший)"
+#define STR_FLOAT         "FLOAT32 звук"
+#define STR_FM_DRIVER     "Драйвер FM-синтезатора"
+#define STR_FM_DRV_NUKED  "Nuked (більш точний)"
+#define STR_FM_DRV_YMFM   "YMFM (швидший)"
 
-#define STR_NET_TYPE    "Тип мережі:"
-#define STR_PCAP        "Пристрій PCap:"
-#define STR_NET            "Мережева карта:"
-#define STR_NET1        "Network card 1:"
-#define STR_NET2        "Network card 2:"
-#define STR_NET3        "Network card 3:"
-#define STR_NET4        "Network card 4:"
+#define STR_NET_TYPE      "Тип мережі:"
+#define STR_PCAP          "Пристрій PCap:"
+#define STR_NET           "Мережева карта:"
+#define STR_NET1          "Network card 1:"
+#define STR_NET2          "Network card 2:"
+#define STR_NET3          "Network card 3:"
+#define STR_NET4          "Network card 4:"
 
-#define STR_COM1        "Пристрій COM1:"
-#define STR_COM2        "Пристрій COM2:"
-#define STR_COM3        "Пристрій COM3:"
-#define STR_COM4        "Пристрій COM4:"
-#define STR_LPT1        "Пристрій LPT1:"
-#define STR_LPT2        "Пристрій LPT2:"
-#define STR_LPT3        "Пристрій LPT3:"
-#define STR_LPT4        "Пристрій LPT4:"
-#define STR_SERIAL1        "Послідов. порт COM1"
-#define STR_SERIAL2        "Послідов. порт COM2"
-#define STR_SERIAL3        "Послідов. порт COM3"
-#define STR_SERIAL4        "Послідов. порт COM4"
-#define STR_PARALLEL1        "Паралельний порт LPT1"
-#define STR_PARALLEL2        "Паралельний порт LPT2"
-#define STR_PARALLEL3        "Паралельний порт LPT3"
-#define STR_PARALLEL4        "Паралельний порт LPT4"
-#define STR_SERIAL_PASS1    "Serial port passthrough 1"
-#define STR_SERIAL_PASS2    "Serial port passthrough 2"
-#define STR_SERIAL_PASS3    "Serial port passthrough 3"
-#define STR_SERIAL_PASS4    "Serial port passthrough 4"
+#define STR_COM1          "Пристрій COM1:"
+#define STR_COM2          "Пристрій COM2:"
+#define STR_COM3          "Пристрій COM3:"
+#define STR_COM4          "Пристрій COM4:"
+#define STR_LPT1          "Пристрій LPT1:"
+#define STR_LPT2          "Пристрій LPT2:"
+#define STR_LPT3          "Пристрій LPT3:"
+#define STR_LPT4          "Пристрій LPT4:"
+#define STR_SERIAL1       "Послідов. порт COM1"
+#define STR_SERIAL2       "Послідов. порт COM2"
+#define STR_SERIAL3       "Послідов. порт COM3"
+#define STR_SERIAL4       "Послідов. порт COM4"
+#define STR_PARALLEL1     "Паралельний порт LPT1"
+#define STR_PARALLEL2     "Паралельний порт LPT2"
+#define STR_PARALLEL3     "Паралельний порт LPT3"
+#define STR_PARALLEL4     "Паралельний порт LPT4"
+#define STR_SERIAL_PASS1  "Serial port passthrough 1"
+#define STR_SERIAL_PASS2  "Serial port passthrough 2"
+#define STR_SERIAL_PASS3  "Serial port passthrough 3"
+#define STR_SERIAL_PASS4  "Serial port passthrough 4"
 
-#define STR_HDC            "Контролер HD:"
-#define STR_FDC            "Контролер FD:"
-#define STR_IDE_TER        "Третинний IDE контролер"
-#define STR_IDE_QUA        "Четвертинний IDE контролер"
-#define STR_SCSI        "SCSI"
+#define STR_HDC           "Контролер HD:"
+#define STR_FDC           "Контролер FD:"
+#define STR_IDE_TER       "Третинний IDE контролер"
+#define STR_IDE_QUA       "Четвертинний IDE контролер"
+#define STR_SCSI          "SCSI"
 #define STR_SCSI_1        "Контролер 1:"
 #define STR_SCSI_2        "Контролер 2:"
 #define STR_SCSI_3        "Контролер 3:"
 #define STR_SCSI_4        "Контролер 4:"
-#define STR_CASSETTE        "Касета"
+#define STR_CASSETTE      "Касета"
 
-#define STR_HDD            "Жорсткі диски:"
-#define STR_NEW            "&Створити..."
-#define STR_EXISTING        "&Вибрати..."
+#define STR_HDD           "Жорсткі диски:"
+#define STR_NEW           "&Створити..."
+#define STR_EXISTING      "&Вибрати..."
 #define STR_REMOVE        "&Прибрати"
-#define STR_BUS            "Шина:"
-#define STR_CHANNEL        "Канал:"
+#define STR_BUS           "Шина:"
+#define STR_CHANNEL       "Канал:"
 #define STR_ID            "ID:"
-#define STR_SPEED        "Speed:"
+#define STR_SPEED         "Speed:"
 
-#define STR_SPECIFY        "&Вказати..."
-#define STR_SECTORS        "Сектора:"
-#define STR_HEADS        "Головки:"
-#define STR_CYLS        "Циліндри:"
-#define STR_SIZE_MB        "Розмір (МБ):"
-#define STR_TYPE        "Тип:"
-#define STR_IMG_FORMAT        "Тип образу:"
-#define STR_BLOCK_SIZE        "Розмір блоку:"
+#define STR_SPECIFY       "&Вказати..."
+#define STR_SECTORS       "Сектора:"
+#define STR_HEADS         "Головки:"
+#define STR_CYLS          "Циліндри:"
+#define STR_SIZE_MB       "Розмір (МБ):"
+#define STR_TYPE          "Тип:"
+#define STR_IMG_FORMAT    "Тип образу:"
+#define STR_BLOCK_SIZE    "Розмір блоку:"
 
-#define STR_FLOPPY_DRIVES    "Гнучкі диски:"
-#define STR_TURBO        "Турбо таймінги"
-#define STR_CHECKBPB        "Перевіряти BPB"
-#define STR_CDROM_DRIVES    "Дисководи CD-ROM:"
-#define STR_CD_SPEED        "Швидкість:"
-#define STR_EARLY        "Більш ранній дисковод"
+#define STR_FLOPPY_DRIVES "Гнучкі диски:"
+#define STR_TURBO         "Турбо таймінги"
+#define STR_CHECKBPB      "Перевіряти BPB"
+#define STR_CDROM_DRIVES  "Дисководи CD-ROM:"
+#define STR_CD_SPEED      "Швидкість:"
+#define STR_EARLY         "Більш ранній дисковод"
 
-#define STR_MO_DRIVES        "Магнітооптичні дисководи:"
-#define STR_ZIP_DRIVES        "ZIP дисководи:"
-#define STR_250            "ZIP 250"
+#define STR_MO_DRIVES     "Магнітооптичні дисководи:"
+#define STR_ZIP_DRIVES    "ZIP дисководи:"
+#define STR_250           "ZIP 250"
 
 #define STR_ISARTC        "ISA RTC:"
 #define STR_ISAMEM        "Карта розширення пам'яті (ISA)"
-#define STR_ISAMEM_1        "Карта 1:"
-#define STR_ISAMEM_2        "Карта 2:"
-#define STR_ISAMEM_3        "Карта 3:"
-#define STR_ISAMEM_4        "Карта 4:"
+#define STR_ISAMEM_1      "Карта 1:"
+#define STR_ISAMEM_2      "Карта 2:"
+#define STR_ISAMEM_3      "Карта 3:"
+#define STR_ISAMEM_4      "Карта 4:"
 #define STR_BUGGER        "Пристрій ISABugger"
-#define STR_POSTCARD        "Карта POST"
+#define STR_POSTCARD      "Карта POST"
 
-#define FONT_SIZE        9
-#define FONT_NAME        "Segoe UI"
+#define FONT_SIZE         9
+#define FONT_NAME         "Segoe UI"
 
 #include "dialogs.rc"
 
@@ -392,9 +392,9 @@ END
 // String Table
 //
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
-    2048    "86Box"
+    2048        "86Box"
     IDS_2049    "Помилка"
     IDS_2050    "Непереробна помилка"
     IDS_2051    " - PAUSED"
@@ -412,7 +412,7 @@ BEGIN
     IDS_2063    "Системна плата ""%hs"" недоступна через відсутність файлу її ПЗУ в каталозі roms/machines. Переключення на доступну системну плату."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2064    "Відеокарта ""%hs"" недоступна через відсутність файлу її ПЗУ в каталозі roms/video. Переключення на доступну відеокарту."
     IDS_2065    "Комп'ютер"
@@ -432,7 +432,7 @@ BEGIN
     IDS_2079    "Натисніть F8+F12 або середню кнопку миші, щоб звільнити курсор"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2080    "Неможливо ініціалізувати FluidSynth"
     IDS_2081    "Шина"
@@ -524,19 +524,19 @@ BEGIN
     IDS_2146    "Ви завантажуєте непідтримувану конфігурацію"
     IDS_2147    "Вибір типів ЦП для цієї системної плати на даній емульованій машині відключено.\n\nЦе дозволяє вибрати процесор, який в іншому випадку не сумісний з вибраною материнською платою. Однак, ви можете зіткнутися з несумісністю з BIOS материнської плати або іншим ПО.\n\nВключення цього параметра офіційно не підтримується, і всі подані звіти про помилки можуть бути закриті як недійсні."
     IDS_2148    "Продовжити"
-    IDS_2149 "Касета: %s"
-    IDS_2150 "Образи касет (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0Усі файли (*.*)\0*. *\0"
-    IDS_2151 "Картридж %i: %ls"
-    IDS_2152 "Образи картриджів (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0Всі файли (*.*)\0*.*\0"
-    IDS_2153 "Помилка ініціалізації рендерера"
-    IDS_2154 "Неможливо ініціалізувати рендерер OpenGL (3.0). Будь ласка, використовуйте інший рендерер."
-    IDS_2155 "Відновити виконання"
-    IDS_2156 "Призупинити виконання"
-    IDS_2157 "Натиснути Ctrl+Alt+Del"
-    IDS_2158 "Натиснути Ctrl+Alt+Esc"
-    IDS_2159 "Холодне перезавантаження"
-    IDS_2160 "Сигнал завершення ACPI"
-    IDS_2161 "Налаштування машини"
+    IDS_2149    "Касета: %s"
+    IDS_2150    "Образи касет (*.PCM;*.RAW;*.WAV;*.CAS)\0*.PCM;*.RAW;*.WAV;*.CAS\0Усі файли (*.*)\0*. *\0"
+    IDS_2151    "Картридж %i: %ls"
+    IDS_2152    "Образи картриджів (*.A;*.B;*.JRC)\0*.A;*.B;*.JRC\0Всі файли (*.*)\0*.*\0"
+    IDS_2153    "Помилка ініціалізації рендерера"
+    IDS_2154    "Неможливо ініціалізувати рендерер OpenGL (3.0). Будь ласка, використовуйте інший рендерер."
+    IDS_2155    "Відновити виконання"
+    IDS_2156    "Призупинити виконання"
+    IDS_2157    "Натиснути Ctrl+Alt+Del"
+    IDS_2158    "Натиснути Ctrl+Alt+Esc"
+    IDS_2159    "Холодне перезавантаження"
+    IDS_2160    "Сигнал завершення ACPI"
+    IDS_2161    "Налаштування машини"
     IDS_2162    "Більш ранній дисковод"
     IDS_2163    "No Dynarec"
     IDS_2164    "Old Dynarec"
@@ -546,102 +546,102 @@ END
 
 STRINGTABLE DISCARDABLE
 BEGIN
-    IDS_4096 "Жорсткий диск (%s)"
-    IDS_4097 "%01i:%01i"
-    IDS_4098 "%01i"
-    IDS_4099 "MFM/RLL або ESDI дисководів CD-ROM ніколи не існувало"
-    IDS_4100 "Задати вручну..."
-    IDS_4101 "Задати вручну (large)..."
-    IDS_4102 "Створити новий жорсткий диск"
-    IDS_4103 "Вибрати існуючий жорсткий диск"
-    IDS_4104 "Розмір образів дисків HDI не може перевищувати 4 ГБ."
-    IDS_4105 "Розмір образів дисків не може перевищувати 127 ГБ."
-    IDS_4106 "Образи жорстких дисків (*.HD?;*.IM?;*.VHD)\0*.HD?;*.IM?;*.VHD\0Всі файли (*.*)\0*.*\0 "
-    IDS_4107 "Неможливо прочитати файл"
-    IDS_4108 "Неможливо записати файл"
-    IDS_4109 "Образи HDI або HDX з розміром сектора, відмінним від 512, не підтримуються."
-    IDS_4110 "USB поки не підтримується"
-    IDS_4111 "Файл образу диска вже існує"
-    IDS_4112 "Вкажіть правильне ім'я файлу."
-    IDS_4113 "Образ диску створено"
-    IDS_4114 "Переконайтеся, що файл є доступним для читання."
-    IDS_4115 "Переконайтеся, що файл зберігається в каталог, який є доступним для запису."
-    IDS_4116 "Занадто великий образ диска"
-    IDS_4117 "Не забудьте розмітити та відформатувати новостворений диск."
-    IDS_4118 "Вибраний файл буде перезаписано. Ви впевнені, що хочете використовувати його?"
-    IDS_4119 "Образ диска, що не підтримується"
-    IDS_4120 "Перезаписати"
-    IDS_4121 "Не перезаписувати"
-    IDS_4122 "RAW образ (.img)"
-    IDS_4123 "Образ HDI (.hdi)"
-    IDS_4124 "Образ HDX (.hdx)"
-    IDS_4125 "VHD фіксованого розміру (.vhd)"
-    IDS_4126 "VHD динамічного розміру (.vhd)"
-    IDS_4127 "Диференційований образ VHD (.vhd)"
-    IDS_4128 "Великі блоки (2 МБ)"
-    IDS_4129 "Маленькі блоки (512 КБ)"
-    IDS_4130 "Файли VHD (*.VHD)\0*.VHD\0Всі файли (*.*)\0*.*\0"
-    IDS_4131 "Виберіть батьківський VHD"
-    IDS_4132 "Це може означати, що батьківський образ був змінений після того, як було створено диференційований образ.\n\nЦе також може статися, якщо файли зображення були переміщені або скопійовані, або через помилку в програмі, що створила цей диск.\n \nВи хочете виправити тимчасові позначки?"
-    IDS_4133 "Тимчасові мітки батьківського та дочірнього дисків не співпадають"
-    IDS_4134 "Не вдалося виправити тимчасову позначку VHD."
-    IDS_4135 "%01i:%02i"
+    IDS_4096    "Жорсткий диск (%s)"
+    IDS_4097    "%01i:%01i"
+    IDS_4098    "%01i"
+    IDS_4099    "MFM/RLL або ESDI дисководів CD-ROM ніколи не існувало"
+    IDS_4100    "Задати вручну..."
+    IDS_4101    "Задати вручну (large)..."
+    IDS_4102    "Створити новий жорсткий диск"
+    IDS_4103    "Вибрати існуючий жорсткий диск"
+    IDS_4104    "Розмір образів дисків HDI не може перевищувати 4 ГБ."
+    IDS_4105    "Розмір образів дисків не може перевищувати 127 ГБ."
+    IDS_4106    "Образи жорстких дисків (*.HD?;*.IM?;*.VHD)\0*.HD?;*.IM?;*.VHD\0Всі файли (*.*)\0*.*\0 "
+    IDS_4107    "Неможливо прочитати файл"
+    IDS_4108    "Неможливо записати файл"
+    IDS_4109    "Образи HDI або HDX з розміром сектора, відмінним від 512, не підтримуються."
+    IDS_4110    "USB поки не підтримується"
+    IDS_4111    "Файл образу диска вже існує"
+    IDS_4112    "Вкажіть правильне ім'я файлу."
+    IDS_4113    "Образ диску створено"
+    IDS_4114    "Переконайтеся, що файл є доступним для читання."
+    IDS_4115    "Переконайтеся, що файл зберігається в каталог, який є доступним для запису."
+    IDS_4116    "Занадто великий образ диска"
+    IDS_4117    "Не забудьте розмітити та відформатувати новостворений диск."
+    IDS_4118    "Вибраний файл буде перезаписано. Ви впевнені, що хочете використовувати його?"
+    IDS_4119    "Образ диска, що не підтримується"
+    IDS_4120    "Перезаписати"
+    IDS_4121    "Не перезаписувати"
+    IDS_4122    "RAW образ (.img)"
+    IDS_4123    "Образ HDI (.hdi)"
+    IDS_4124    "Образ HDX (.hdx)"
+    IDS_4125    "VHD фіксованого розміру (.vhd)"
+    IDS_4126    "VHD динамічного розміру (.vhd)"
+    IDS_4127    "Диференційований образ VHD (.vhd)"
+    IDS_4128    "Великі блоки (2 МБ)"
+    IDS_4129    "Маленькі блоки (512 КБ)"
+    IDS_4130    "Файли VHD (*.VHD)\0*.VHD\0Всі файли (*.*)\0*.*\0"
+    IDS_4131    "Виберіть батьківський VHD"
+    IDS_4132    "Це може означати, що батьківський образ був змінений після того, як було створено диференційований образ.\n\nЦе також може статися, якщо файли зображення були переміщені або скопійовані, або через помилку в програмі, що створила цей диск.\n \nВи хочете виправити тимчасові позначки?"
+    IDS_4133    "Тимчасові мітки батьківського та дочірнього дисків не співпадають"
+    IDS_4134    "Не вдалося виправити тимчасову позначку VHD."
+    IDS_4135    "%01i:%02i"
 
-    IDS_4352 "MFM/RLL"
-    IDS_4353 "XTA"
-    IDS_4354 "ESDI"
-    IDS_4355 "IDE"
-    IDS_4356 "ATAPI"
-    IDS_4357 "SCSI"
+    IDS_4352    "MFM/RLL"
+    IDS_4353    "XTA"
+    IDS_4354    "ESDI"
+    IDS_4355    "IDE"
+    IDS_4356    "ATAPI"
+    IDS_4357    "SCSI"
 
-    IDS_4608 "MFM/RLL (%01i:%01i)"
-    IDS_4609 "XTA (%01i:%01i)"
-    IDS_4610 "ESDI (%01i:%01i)"
-    IDS_4611 "IDE (%01i:%01i)"
-    IDS_4612 "ATAPI (%01i:%01i)"
-    IDS_4613 "SCSI (%01i:%02i)"
+    IDS_4608    "MFM/RLL (%01i:%01i)"
+    IDS_4609    "XTA (%01i:%01i)"
+    IDS_4610    "ESDI (%01i:%01i)"
+    IDS_4611    "IDE (%01i:%01i)"
+    IDS_4612    "ATAPI (%01i:%01i)"
+    IDS_4613    "SCSI (%01i:%02i)"
 
-    IDS_5120 "CD-ROM %i (%s): %s"
+    IDS_5120    "CD-ROM %i (%s): %s"
 
-    IDS_5376 "Відключено"
-    IDS_5381 "ATAPI"
-    IDS_5382 "SCSI"
+    IDS_5376    "Відключено"
+    IDS_5381    "ATAPI"
+    IDS_5382    "SCSI"
 
-    IDS_5632 "Відключено"
-    IDS_5637 "ATAPI (%01i:%01i)"
-    IDS_5638 "SCSI (%01i:%02i)"
+    IDS_5632    "Відключено"
+    IDS_5637    "ATAPI (%01i:%01i)"
+    IDS_5638    "SCSI (%01i:%02i)"
 
-    IDS_5888 "160 кБ"
-    IDS_5889 "180 кБ"
-    IDS_5890 "320 кБ"
-    IDS_5891 "360 кБ"
-    IDS_5892 "640 кБ"
-    IDS_5893 "720 кБ"
-    IDS_5894 "1.2 МБ"
-    IDS_5895 "1.25 МБ"
-    IDS_5896 "1.44 МБ"
-    IDS_5897 "DMF (кластер 1024)"
-    IDS_5898 "DMF (кластер 2048)"
-    IDS_5899 "2.88 МБ"
-    IDS_5900 "ZIP 100"
-    IDS_5901 "ZIP 250"
-    IDS_5902 "3.5"" 128 МБ (ISO 10090)"
-    IDS_5903 "3.5"" 230 МБ (ISO 13963)"
-    IDS_5904 "3.5"" 540 МБ (ISO 15498)"
-    IDS_5905 "3.5"" 640 МБ (ISO 15498)"
-    IDS_5906 "3.5"" 1.3 ГБ (GigaMO)"
-    IDS_5907 "3.5"" 2.3 ГБ (GigaMO 2)"
-    IDS_5908 "5.25"" 600 МБ"
-    IDS_5909 "5.25"" 650 МБ"
-    IDS_5910 "5.25"" 1 ГБ"
-    IDS_5911 "5.25"" 1.3 ГБ"
+    IDS_5888    "160 кБ"
+    IDS_5889    "180 кБ"
+    IDS_5890    "320 кБ"
+    IDS_5891    "360 кБ"
+    IDS_5892    "640 кБ"
+    IDS_5893    "720 кБ"
+    IDS_5894    "1.2 МБ"
+    IDS_5895    "1.25 МБ"
+    IDS_5896    "1.44 МБ"
+    IDS_5897    "DMF (кластер 1024)"
+    IDS_5898    "DMF (кластер 2048)"
+    IDS_5899    "2.88 МБ"
+    IDS_5900    "ZIP 100"
+    IDS_5901    "ZIP 250"
+    IDS_5902    "3.5"" 128 МБ (ISO 10090)"
+    IDS_5903    "3.5"" 230 МБ (ISO 13963)"
+    IDS_5904    "3.5"" 540 МБ (ISO 15498)"
+    IDS_5905    "3.5"" 640 МБ (ISO 15498)"
+    IDS_5906    "3.5"" 1.3 ГБ (GigaMO)"
+    IDS_5907    "3.5"" 2.3 ГБ (GigaMO 2)"
+    IDS_5908    "5.25"" 600 МБ"
+    IDS_5909    "5.25"" 650 МБ"
+    IDS_5910    "5.25"" 1 ГБ"
+    IDS_5911    "5.25"" 1.3 ГБ"
 
-    IDS_6144 "Точний RPM"
-    IDS_6145 "На 1% повільніше точного RPM"
-    IDS_6146 "На 1.5% повільніше точного RPM"
-    IDS_6147 "На 2% повільніше точного RPM"
+    IDS_6144    "Точний RPM"
+    IDS_6145    "На 1% повільніше точного RPM"
+    IDS_6146    "На 1.5% повільніше точного RPM"
+    IDS_6147    "На 2% повільніше точного RPM"
 
-    IDS_7168 "(Системний)"
+    IDS_7168    "(Системний)"
 END
 #define IDS_LANG_ENUS IDS_7168
 

--- a/src/win/languages/zh-CN.rc
+++ b/src/win/languages/zh-CN.rc
@@ -13,122 +13,122 @@ LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED
 // Menu
 //
 
-MainMenu MENU DISCARDABLE 
+MainMenu MENU DISCARDABLE
 BEGIN
     POPUP "操作(&A)"
     BEGIN
-        MENUITEM "键盘需要捕捉(&K)",    IDM_ACTION_KBD_REQ_CAPTURE
-        MENUITEM "将右 CTRL 键映射为左 ALT 键(&R)",    IDM_ACTION_RCTRL_IS_LALT
+        MENUITEM "键盘需要捕捉(&K)", IDM_ACTION_KBD_REQ_CAPTURE
+        MENUITEM "将右 CTRL 键映射为左 ALT 键(&R)", IDM_ACTION_RCTRL_IS_LALT
         MENUITEM SEPARATOR
-        MENUITEM "硬重置(&H)...",                 IDM_ACTION_HRESET
-        MENUITEM "Ctrl+Alt+Del(&C)\tCtrl+F12",     IDM_ACTION_RESET_CAD
+        MENUITEM "硬重置(&H)...", IDM_ACTION_HRESET
+        MENUITEM "Ctrl+Alt+Del(&C)\tCtrl+F12", IDM_ACTION_RESET_CAD
         MENUITEM SEPARATOR
-    MENUITEM "Ctrl+Alt+Esc(&E)",        IDM_ACTION_CTRL_ALT_ESC
+        MENUITEM "Ctrl+Alt+Esc(&E)", IDM_ACTION_CTRL_ALT_ESC
         MENUITEM SEPARATOR
-        MENUITEM "暂停(&P)",                      IDM_ACTION_PAUSE
+        MENUITEM "暂停(&P)", IDM_ACTION_PAUSE
         MENUITEM SEPARATOR
-        MENUITEM "退出(&X)...",                       IDM_ACTION_EXIT
+        MENUITEM "退出(&X)...", IDM_ACTION_EXIT
     END
     POPUP "查看(&V)"
     BEGIN
-        MENUITEM "隐藏状态栏(&H)",        IDM_VID_HIDE_STATUS_BAR
-        MENUITEM "隐藏工具栏(&T)",        IDM_VID_HIDE_TOOLBAR
+        MENUITEM "隐藏状态栏(&H)", IDM_VID_HIDE_STATUS_BAR
+        MENUITEM "隐藏工具栏(&T)", IDM_VID_HIDE_TOOLBAR
         MENUITEM SEPARATOR
-        MENUITEM "Show non-primary monitors(&S)",  IDM_VID_MONITORS
-        MENUITEM "窗口大小可调(&R)",          IDM_VID_RESIZE
-        MENUITEM "记住窗口大小和位置(&E)",  IDM_VID_REMEMBER
+        MENUITEM "Show non-primary monitors(&S)", IDM_VID_MONITORS
+        MENUITEM "窗口大小可调(&R)", IDM_VID_RESIZE
+        MENUITEM "记住窗口大小和位置(&E)", IDM_VID_REMEMBER
         MENUITEM SEPARATOR
         POPUP "渲染器(&N)"
         BEGIN
-            MENUITEM "SDL (软件)(&S)",         IDM_VID_SDL_SW
-            MENUITEM "SDL (硬件)(&H)",         IDM_VID_SDL_HW
-            MENUITEM "SDL (OpenGL)(&O)",           IDM_VID_SDL_OPENGL
-            MENUITEM "OpenGL (3.0 核心)(&G)",      IDM_VID_OPENGL_CORE
+            MENUITEM "SDL (软件)(&S)", IDM_VID_SDL_SW
+            MENUITEM "SDL (硬件)(&H)", IDM_VID_SDL_HW
+            MENUITEM "SDL (OpenGL)(&O)", IDM_VID_SDL_OPENGL
+            MENUITEM "OpenGL (3.0 核心)(&G)", IDM_VID_OPENGL_CORE
 #ifdef USE_VNC
-            MENUITEM "VNC(&V)",                    IDM_VID_VNC
+            MENUITEM "VNC(&V)", IDM_VID_VNC
 #endif
         END
         MENUITEM SEPARATOR
-        MENUITEM "指定窗口大小...",          IDM_VID_SPECIFY_DIM
-        MENUITEM "强制 4:3 显示比例(&O)",    IDM_VID_FORCE43
+        MENUITEM "指定窗口大小...", IDM_VID_SPECIFY_DIM
+        MENUITEM "强制 4:3 显示比例(&O)", IDM_VID_FORCE43
         POPUP "窗口缩放系数(&W)"
         BEGIN
-            MENUITEM "0.5x(&0)",                   IDM_VID_SCALE_1X
-            MENUITEM "1x(&1)",                     IDM_VID_SCALE_2X
-            MENUITEM "1.5x(&5)",                   IDM_VID_SCALE_3X
-            MENUITEM "2x(&2)",                     IDM_VID_SCALE_4X
-            MENUITEM "&3x",                        IDM_VID_SCALE_5X
-            MENUITEM "&4x",                        IDM_VID_SCALE_6X
-            MENUITEM "&5x",                        IDM_VID_SCALE_7X
-            MENUITEM "&6x",                        IDM_VID_SCALE_8X
-            MENUITEM "&7x",                        IDM_VID_SCALE_9X
-            MENUITEM "&8x",                        IDM_VID_SCALE_10X
+            MENUITEM "0.5x(&0)", IDM_VID_SCALE_1X
+            MENUITEM "1x(&1)", IDM_VID_SCALE_2X
+            MENUITEM "1.5x(&5)", IDM_VID_SCALE_3X
+            MENUITEM "2x(&2)", IDM_VID_SCALE_4X
+            MENUITEM "&3x", IDM_VID_SCALE_5X
+            MENUITEM "&4x", IDM_VID_SCALE_6X
+            MENUITEM "&5x", IDM_VID_SCALE_7X
+            MENUITEM "&6x", IDM_VID_SCALE_8X
+            MENUITEM "&7x", IDM_VID_SCALE_9X
+            MENUITEM "&8x", IDM_VID_SCALE_10X
         END
         POPUP "过滤方式"
         BEGIN
-            MENUITEM "邻近(&N)",                 IDM_VID_FILTER_NEAREST
-            MENUITEM "线性(&L)",                  IDM_VID_FILTER_LINEAR
+            MENUITEM "邻近(&N)", IDM_VID_FILTER_NEAREST
+            MENUITEM "线性(&L)", IDM_VID_FILTER_LINEAR
         END
-        MENUITEM "HiDPI 缩放(&D)",              IDM_VID_HIDPI
+        MENUITEM "HiDPI 缩放(&D)", IDM_VID_HIDPI
         MENUITEM SEPARATOR
-        MENUITEM "全屏(&F)\tCtrl+Alt+PgUp",    IDM_VID_FULLSCREEN
+        MENUITEM "全屏(&F)\tCtrl+Alt+PgUp", IDM_VID_FULLSCREEN
         POPUP "全屏拉伸模式(&S)"
         BEGIN
-            MENUITEM "全屏拉伸(&F)",        IDM_VID_FS_FULL
-            MENUITEM "4:3(&4)",                        IDM_VID_FS_43
+            MENUITEM "全屏拉伸(&F)", IDM_VID_FS_FULL
+            MENUITEM "4:3(&4)", IDM_VID_FS_43
             MENUITEM "保持比例(&S)", IDM_VID_FS_KEEPRATIO
-            MENUITEM "整数比例(&I)",              IDM_VID_FS_INT
+            MENUITEM "整数比例(&I)", IDM_VID_FS_INT
         END
         POPUP "EGA/(S)VGA 设置(&G)"
         BEGIN
-            MENUITEM "VGA 显示器反色显示(&I)",   IDM_VID_INVERT
+            MENUITEM "VGA 显示器反色显示(&I)", IDM_VID_INVERT
             POPUP "VGA 屏幕类型(&T)"
             BEGIN
-                MENUITEM "RGB 彩色(&C)",          IDM_VID_GRAY_RGB
-                MENUITEM "RGB 灰度(&R)",      IDM_VID_GRAY_MONO
-                MENUITEM "琥珀色单色显示器(&A)",      IDM_VID_GRAY_AMBER
-                MENUITEM "绿色单色显示器(&G)",      IDM_VID_GRAY_GREEN
-                MENUITEM "白色单色显示器(&W)",      IDM_VID_GRAY_WHITE
+                MENUITEM "RGB 彩色(&C)", IDM_VID_GRAY_RGB
+                MENUITEM "RGB 灰度(&R)", IDM_VID_GRAY_MONO
+                MENUITEM "琥珀色单色显示器(&A)", IDM_VID_GRAY_AMBER
+                MENUITEM "绿色单色显示器(&G)", IDM_VID_GRAY_GREEN
+                MENUITEM "白色单色显示器(&W)", IDM_VID_GRAY_WHITE
             END
             POPUP "灰度转换类型(&C)"
             BEGIN
-                MENUITEM "BT601 (NTSC/PAL)(&6)",   IDM_VID_GRAYCT_601
-                MENUITEM "BT709 (HDTV)(&7)",       IDM_VID_GRAYCT_709
-                MENUITEM "平均(&A)",            IDM_VID_GRAYCT_AVE
+                MENUITEM "BT601 (NTSC/PAL)(&6)", IDM_VID_GRAYCT_601
+                MENUITEM "BT709 (HDTV)(&7)", IDM_VID_GRAYCT_709
+                MENUITEM "平均(&A)", IDM_VID_GRAYCT_AVE
             END
         END
         MENUITEM SEPARATOR
-        MENUITEM "CGA/PCjr/Tandy/EGA/(S)VGA 过扫描(&G)",     IDM_VID_OVERSCAN
+        MENUITEM "CGA/PCjr/Tandy/EGA/(S)VGA 过扫描(&G)", IDM_VID_OVERSCAN
         MENUITEM "更改单色显示对比度(&M)", IDM_VID_CGACON
     END
-    MENUITEM "介质(&M)",                IDM_MEDIA
+    MENUITEM "介质(&M)", IDM_MEDIA
     POPUP "工具(&T)"
     BEGIN
-        MENUITEM "设置(&S)...",                IDM_CONFIG
-        MENUITEM "更新状态栏图标(&U)",    IDM_UPDATE_ICONS
+        MENUITEM "设置(&S)...", IDM_CONFIG
+        MENUITEM "更新状态栏图标(&U)", IDM_UPDATE_ICONS
         MENUITEM SEPARATOR
-        MENUITEM "截图(&C)\tCtrl+F11",  IDM_ACTION_SCREENSHOT
+        MENUITEM "截图(&C)\tCtrl+F11", IDM_ACTION_SCREENSHOT
         MENUITEM SEPARATOR
-        MENUITEM "首选项(&P)...",    IDM_PREFERENCES
+        MENUITEM "首选项(&P)...", IDM_PREFERENCES
 #ifdef DISCORD
         MENUITEM "启用 Discord 集成(&D)", IDM_DISCORD
 #endif
         MENUITEM SEPARATOR
-        MENUITEM "音量增益(&G)...",              IDM_SND_GAIN
+        MENUITEM "音量增益(&G)...", IDM_SND_GAIN
 #ifdef MTR_ENABLED
         MENUITEM SEPARATOR
-        MENUITEM "开始追踪\tCtrl+T",         IDM_ACTION_BEGIN_TRACE
-        MENUITEM "结束追踪\tCtrl+T",           IDM_ACTION_END_TRACE
+        MENUITEM "开始追踪\tCtrl+T", IDM_ACTION_BEGIN_TRACE
+        MENUITEM "结束追踪\tCtrl+T", IDM_ACTION_END_TRACE
 #endif
     END
     POPUP "帮助(&H)"
     BEGIN
-        MENUITEM "文档(&D)...",           IDM_DOCS
-        MENUITEM "关于 86Box(&A)...",             IDM_ABOUT
+        MENUITEM "文档(&D)...", IDM_DOCS
+        MENUITEM "关于 86Box(&A)...", IDM_ABOUT
     END
 END
 
-StatusBarMenu MENU DISCARDABLE 
+StatusBarMenu MENU DISCARDABLE
 BEGIN
     MENUITEM SEPARATOR
 END
@@ -137,17 +137,17 @@ CassetteSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "新建镜像(&N)...",                IDM_CASSETTE_IMAGE_NEW
+        MENUITEM "新建镜像(&N)...", IDM_CASSETTE_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "打开已存在的镜像(&E)...",                IDM_CASSETTE_IMAGE_EXISTING
-        MENUITEM "打开已存在的镜像并写保护(&W)...",    IDM_CASSETTE_IMAGE_EXISTING_WP
+        MENUITEM "打开已存在的镜像(&E)...", IDM_CASSETTE_IMAGE_EXISTING
+        MENUITEM "打开已存在的镜像并写保护(&W)...", IDM_CASSETTE_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "录制(&R)",                    IDM_CASSETTE_RECORD
-        MENUITEM "播放(&P)",                    IDM_CASSETTE_PLAY
-        MENUITEM "倒带至起点(&R)",            IDM_CASSETTE_REWIND
-        MENUITEM "快进至终点(&F)",            IDM_CASSETTE_FAST_FORWARD
+        MENUITEM "录制(&R)", IDM_CASSETTE_RECORD
+        MENUITEM "播放(&P)", IDM_CASSETTE_PLAY
+        MENUITEM "倒带至起点(&R)", IDM_CASSETTE_REWIND
+        MENUITEM "快进至终点(&F)", IDM_CASSETTE_FAST_FORWARD
         MENUITEM SEPARATOR
-        MENUITEM "弹出(&J)",                    IDM_CASSETTE_EJECT
+        MENUITEM "弹出(&J)", IDM_CASSETTE_EJECT
     END
 END
 
@@ -155,9 +155,9 @@ CartridgeSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "镜像(&I)...",                    IDM_CARTRIDGE_IMAGE
+        MENUITEM "镜像(&I)...", IDM_CARTRIDGE_IMAGE
         MENUITEM SEPARATOR
-        MENUITEM "弹出(&J)",                    IDM_CARTRIDGE_EJECT
+        MENUITEM "弹出(&J)", IDM_CARTRIDGE_EJECT
     END
 END
 
@@ -165,14 +165,14 @@ FloppySubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "新建镜像(&N)...",                IDM_FLOPPY_IMAGE_NEW
+        MENUITEM "新建镜像(&N)...", IDM_FLOPPY_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "打开已存在的镜像(&E)...",                IDM_FLOPPY_IMAGE_EXISTING
-        MENUITEM "打开已存在的镜像并写保护(&W)...",    IDM_FLOPPY_IMAGE_EXISTING_WP
+        MENUITEM "打开已存在的镜像(&E)...", IDM_FLOPPY_IMAGE_EXISTING
+        MENUITEM "打开已存在的镜像并写保护(&W)...", IDM_FLOPPY_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "导出为 86F 格式(&x)...",                IDM_FLOPPY_EXPORT_TO_86F
+        MENUITEM "导出为 86F 格式(&x)...", IDM_FLOPPY_EXPORT_TO_86F
         MENUITEM SEPARATOR
-        MENUITEM "弹出(&J)",                    IDM_FLOPPY_EJECT
+        MENUITEM "弹出(&J)", IDM_FLOPPY_EJECT
     END
 END
 
@@ -180,13 +180,13 @@ CdromSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "静音(&M)",                    IDM_CDROM_MUTE
+        MENUITEM "静音(&M)", IDM_CDROM_MUTE
         MENUITEM SEPARATOR
-        MENUITEM "空置驱动器(&M)",                    IDM_CDROM_EMPTY
-        MENUITEM "载入上一个镜像(&R)",            IDM_CDROM_RELOAD
+        MENUITEM "空置驱动器(&M)", IDM_CDROM_EMPTY
+        MENUITEM "载入上一个镜像(&R)", IDM_CDROM_RELOAD
         MENUITEM SEPARATOR
-        MENUITEM "镜像(&I)...",                    IDM_CDROM_IMAGE
-        MENUITEM "文件夹(&F)...",                    IDM_CDROM_DIR
+        MENUITEM "镜像(&I)...", IDM_CDROM_IMAGE
+        MENUITEM "文件夹(&F)...", IDM_CDROM_DIR
     END
 END
 
@@ -194,13 +194,13 @@ ZIPSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "新建镜像(&N)...",                IDM_ZIP_IMAGE_NEW
+        MENUITEM "新建镜像(&N)...", IDM_ZIP_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "打开已存在的镜像(&E)...",                IDM_ZIP_IMAGE_EXISTING
-        MENUITEM "打开已存在的镜像并写保护(&W)...",    IDM_ZIP_IMAGE_EXISTING_WP
+        MENUITEM "打开已存在的镜像(&E)...", IDM_ZIP_IMAGE_EXISTING
+        MENUITEM "打开已存在的镜像并写保护(&W)...", IDM_ZIP_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "弹出(&J)",                    IDM_ZIP_EJECT
-        MENUITEM "载入上一个镜像(&R)",            IDM_ZIP_RELOAD
+        MENUITEM "弹出(&J)", IDM_ZIP_EJECT
+        MENUITEM "载入上一个镜像(&R)", IDM_ZIP_RELOAD
     END
 END
 
@@ -208,13 +208,13 @@ MOSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "新建镜像(&N)...",                IDM_MO_IMAGE_NEW
+        MENUITEM "新建镜像(&N)...", IDM_MO_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "打开已存在的镜像(&E)...",                IDM_MO_IMAGE_EXISTING
-        MENUITEM "打开已存在的镜像并写保护(&W)...",    IDM_MO_IMAGE_EXISTING_WP
+        MENUITEM "打开已存在的镜像(&E)...", IDM_MO_IMAGE_EXISTING
+        MENUITEM "打开已存在的镜像并写保护(&W)...", IDM_MO_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "弹出(&J)",                    IDM_MO_EJECT
-        MENUITEM "载入上一个镜像(&R)",            IDM_MO_RELOAD
+        MENUITEM "弹出(&J)", IDM_MO_EJECT
+        MENUITEM "载入上一个镜像(&R)", IDM_MO_RELOAD
     END
 END
 
@@ -240,147 +240,147 @@ END
 // Dialog
 //
 
-#define STR_PREFERENCES        "首选项"
-#define STR_SND_GAIN        "音量增益"
-#define STR_NEW_FLOPPY        "新建镜像"
+#define STR_PREFERENCES   "首选项"
+#define STR_SND_GAIN      "音量增益"
+#define STR_NEW_FLOPPY    "新建镜像"
 #define STR_CONFIG        "设置"
-#define STR_SPECIFY_DIM        "指定主窗口大小"
+#define STR_SPECIFY_DIM   "指定主窗口大小"
 
 #define STR_OK            "确定"
 #define STR_CANCEL        "取消"
 #define STR_GLOBAL        "将以上设置存储为全局默认值(&G)"
-#define STR_DEFAULT        "默认(&D)"
-#define STR_LANGUAGE        "语言:"
-#define STR_ICONSET        "图标集:"
+#define STR_DEFAULT       "默认(&D)"
+#define STR_LANGUAGE      "语言:"
+#define STR_ICONSET       "图标集:"
 
-#define STR_GAIN        "增益"
+#define STR_GAIN          "增益"
 
-#define STR_FILE_NAME        "文件名:"
-#define STR_DISK_SIZE        "磁盘大小:"
-#define STR_RPM_MODE        "转速 (RPM) 模式:"
-#define STR_PROGRESS        "进度:"
+#define STR_FILE_NAME     "文件名:"
+#define STR_DISK_SIZE     "磁盘大小:"
+#define STR_RPM_MODE      "转速 (RPM) 模式:"
+#define STR_PROGRESS      "进度:"
 
-#define STR_WIDTH        "宽度:"
+#define STR_WIDTH         "宽度:"
 #define STR_HEIGHT        "高度:"
-#define STR_LOCK_TO_SIZE    "锁定此大小"
+#define STR_LOCK_TO_SIZE  "锁定此大小"
 
-#define STR_MACHINE_TYPE    "机器类型:"
-#define STR_MACHINE        "机型:"
-#define STR_CONFIGURE        "配置"
-#define STR_CPU_TYPE        "CPU 类型:"
-#define STR_CPU_SPEED        "速度:"
-#define STR_FPU            "浮点处理器 (FPU):"
-#define STR_WAIT_STATES        "等待状态 (WS):"
+#define STR_MACHINE_TYPE  "机器类型:"
+#define STR_MACHINE       "机型:"
+#define STR_CONFIGURE     "配置"
+#define STR_CPU_TYPE      "CPU 类型:"
+#define STR_CPU_SPEED     "速度:"
+#define STR_FPU           "浮点处理器 (FPU):"
+#define STR_WAIT_STATES   "等待状态 (WS):"
 #define STR_MB            "MB"
 #define STR_MEMORY        "内存:"
-#define STR_TIME_SYNC        "时间同步"
-#define STR_DISABLED        "禁用"
-#define STR_ENABLED_LOCAL    "启用 (本地时间)"
-#define STR_ENABLED_UTC        "启用 (UTC)"
-#define STR_DYNAREC        "动态重编译器"
+#define STR_TIME_SYNC     "时间同步"
+#define STR_DISABLED      "禁用"
+#define STR_ENABLED_LOCAL "启用 (本地时间)"
+#define STR_ENABLED_UTC   "启用 (UTC)"
+#define STR_DYNAREC       "动态重编译器"
 
-#define STR_VIDEO        "显卡:"
-#define STR_VIDEO_2        "显卡 2:"
+#define STR_VIDEO         "显卡:"
+#define STR_VIDEO_2       "显卡 2:"
 #define STR_VOODOO        "Voodoo Graphics"
-#define STR_IBM8514        "IBM 8514/a Graphics"
-#define STR_XGA            "XGA Graphics"
+#define STR_IBM8514       "IBM 8514/a Graphics"
+#define STR_XGA           "XGA Graphics"
 
-#define STR_MOUSE        "鼠标:"
-#define STR_JOYSTICK        "操纵杆:"
-#define STR_JOY1        "操纵杆 1..."
-#define STR_JOY2        "操纵杆 2..."
-#define STR_JOY3        "操纵杆 3..."
-#define STR_JOY4        "操纵杆 4..."
+#define STR_MOUSE         "鼠标:"
+#define STR_JOYSTICK      "操纵杆:"
+#define STR_JOY1          "操纵杆 1..."
+#define STR_JOY2          "操纵杆 2..."
+#define STR_JOY3          "操纵杆 3..."
+#define STR_JOY4          "操纵杆 4..."
 
 #define STR_SOUND1        "声卡 1:"
 #define STR_SOUND2        "声卡 2:"
 #define STR_SOUND3        "声卡 3:"
 #define STR_SOUND4        "声卡 4:"
-#define STR_MIDI_OUT        "MIDI 输出设备:"
-#define STR_MIDI_IN        "MIDI 输入设备:"
+#define STR_MIDI_OUT      "MIDI 输出设备:"
+#define STR_MIDI_IN       "MIDI 输入设备:"
 #define STR_MPU401        "独立 MPU-401"
-#define STR_FLOAT        "使用单精度浮点 (FLOAT32)"
-#define STR_FM_DRIVER        "调频合成器驱动器"
-#define STR_FM_DRV_NUKED    "Nuked (更准确)"
-#define STR_FM_DRV_YMFM        "YMFM (更快)"
+#define STR_FLOAT         "使用单精度浮点 (FLOAT32)"
+#define STR_FM_DRIVER     "调频合成器驱动器"
+#define STR_FM_DRV_NUKED  "Nuked (更准确)"
+#define STR_FM_DRV_YMFM   "YMFM (更快)"
 
-#define STR_NET_TYPE    "网络类型:"
-#define STR_PCAP        "PCap 设备:"
-#define STR_NET            "网络适配器:"
-#define STR_NET1        "Network card 1:"
-#define STR_NET2        "Network card 2:"
-#define STR_NET3        "Network card 3:"
-#define STR_NET4        "Network card 4:"
+#define STR_NET_TYPE      "网络类型:"
+#define STR_PCAP          "PCap 设备:"
+#define STR_NET           "网络适配器:"
+#define STR_NET1          "Network card 1:"
+#define STR_NET2          "Network card 2:"
+#define STR_NET3          "Network card 3:"
+#define STR_NET4          "Network card 4:"
 
-#define STR_COM1        "COM1 设备:"
-#define STR_COM2        "COM2 设备:"
-#define STR_COM3        "COM3 设备:"
-#define STR_COM4        "COM4 设备:"
-#define STR_LPT1        "LPT1 设备:"
-#define STR_LPT2        "LPT2 设备:"
-#define STR_LPT3        "LPT3 设备:"
-#define STR_LPT4        "LPT4 设备:"
-#define STR_SERIAL1        "串口 1"
-#define STR_SERIAL2        "串口 2"
-#define STR_SERIAL3        "串口 3"
-#define STR_SERIAL4        "串口 4"
-#define STR_PARALLEL1        "并口 1"
-#define STR_PARALLEL2        "并口 2"
-#define STR_PARALLEL3        "并口 3"
-#define STR_PARALLEL4        "并口 4"
-#define STR_SERIAL_PASS1    "Serial port passthrough 1"
-#define STR_SERIAL_PASS2    "Serial port passthrough 2"
-#define STR_SERIAL_PASS3    "Serial port passthrough 3"
-#define STR_SERIAL_PASS4    "Serial port passthrough 4"
+#define STR_COM1          "COM1 设备:"
+#define STR_COM2          "COM2 设备:"
+#define STR_COM3          "COM3 设备:"
+#define STR_COM4          "COM4 设备:"
+#define STR_LPT1          "LPT1 设备:"
+#define STR_LPT2          "LPT2 设备:"
+#define STR_LPT3          "LPT3 设备:"
+#define STR_LPT4          "LPT4 设备:"
+#define STR_SERIAL1       "串口 1"
+#define STR_SERIAL2       "串口 2"
+#define STR_SERIAL3       "串口 3"
+#define STR_SERIAL4       "串口 4"
+#define STR_PARALLEL1     "并口 1"
+#define STR_PARALLEL2     "并口 2"
+#define STR_PARALLEL3     "并口 3"
+#define STR_PARALLEL4     "并口 4"
+#define STR_SERIAL_PASS1  "Serial port passthrough 1"
+#define STR_SERIAL_PASS2  "Serial port passthrough 2"
+#define STR_SERIAL_PASS3  "Serial port passthrough 3"
+#define STR_SERIAL_PASS4  "Serial port passthrough 4"
 
-#define STR_HDC            "硬盘控制器:"
-#define STR_FDC            "软盘控制器:"
-#define STR_IDE_TER        "第三 IDE 控制器"
-#define STR_IDE_QUA        "第四 IDE 控制器"
-#define STR_SCSI        "SCSI"
+#define STR_HDC           "硬盘控制器:"
+#define STR_FDC           "软盘控制器:"
+#define STR_IDE_TER       "第三 IDE 控制器"
+#define STR_IDE_QUA       "第四 IDE 控制器"
+#define STR_SCSI          "SCSI"
 #define STR_SCSI_1        "控制器 1:"
 #define STR_SCSI_2        "控制器 2:"
 #define STR_SCSI_3        "控制器 3:"
 #define STR_SCSI_4        "控制器 4:"
-#define STR_CASSETTE        "磁带"
+#define STR_CASSETTE      "磁带"
 
-#define STR_HDD            "硬盘:"
-#define STR_NEW            "新建(&N)..."
-#define STR_EXISTING        "已有镜像(&E)..."
+#define STR_HDD           "硬盘:"
+#define STR_NEW           "新建(&N)..."
+#define STR_EXISTING      "已有镜像(&E)..."
 #define STR_REMOVE        "移除(&R)"
-#define STR_BUS            "总线:"
-#define STR_CHANNEL        "通道:"
+#define STR_BUS           "总线:"
+#define STR_CHANNEL       "通道:"
 #define STR_ID            "ID:"
-#define STR_SPEED        "Speed:"
+#define STR_SPEED         "Speed:"
 
-#define STR_SPECIFY        "指定(&S)..."
-#define STR_SECTORS        "扇区(S):"
-#define STR_HEADS        "磁头(H):"
-#define STR_CYLS        "柱面(C):"
-#define STR_SIZE_MB        "大小 (MB):"
-#define STR_TYPE        "类型:"
-#define STR_IMG_FORMAT        "镜像格式:"
-#define STR_BLOCK_SIZE        "块大小:"
+#define STR_SPECIFY       "指定(&S)..."
+#define STR_SECTORS       "扇区(S):"
+#define STR_HEADS         "磁头(H):"
+#define STR_CYLS          "柱面(C):"
+#define STR_SIZE_MB       "大小 (MB):"
+#define STR_TYPE          "类型:"
+#define STR_IMG_FORMAT    "镜像格式:"
+#define STR_BLOCK_SIZE    "块大小:"
 
-#define STR_FLOPPY_DRIVES    "软盘驱动器:"
-#define STR_TURBO        "加速时序"
-#define STR_CHECKBPB        "检查 BPB"
-#define STR_CDROM_DRIVES    "光盘驱动器:"
-#define STR_CD_SPEED        "速度:"
-#define STR_EARLY        "早先的驱动器"
+#define STR_FLOPPY_DRIVES "软盘驱动器:"
+#define STR_TURBO         "加速时序"
+#define STR_CHECKBPB      "检查 BPB"
+#define STR_CDROM_DRIVES  "光盘驱动器:"
+#define STR_CD_SPEED      "速度:"
+#define STR_EARLY         "早先的驱动器"
 
-#define STR_MO_DRIVES        "磁光盘驱动器:"
-#define STR_ZIP_DRIVES        "ZIP 驱动器:"
-#define STR_250            "ZIP 250"
+#define STR_MO_DRIVES     "磁光盘驱动器:"
+#define STR_ZIP_DRIVES    "ZIP 驱动器:"
+#define STR_250           "ZIP 250"
 
 #define STR_ISARTC        "ISA 实时时钟:"
 #define STR_ISAMEM        "ISA 内存扩充"
-#define STR_ISAMEM_1        "扩展卡 1:"
-#define STR_ISAMEM_2        "扩展卡 2:"
-#define STR_ISAMEM_3        "扩展卡 3:"
-#define STR_ISAMEM_4        "扩展卡 4:"
+#define STR_ISAMEM_1      "扩展卡 1:"
+#define STR_ISAMEM_2      "扩展卡 2:"
+#define STR_ISAMEM_3      "扩展卡 3:"
+#define STR_ISAMEM_4      "扩展卡 4:"
 #define STR_BUGGER        "ISABugger 设备"
-#define STR_POSTCARD        "自检 (POST) 卡"
+#define STR_POSTCARD      "自检 (POST) 卡"
 
 #define FONT_SIZE        9
 #define FONT_NAME        "Microsoft YaHei"
@@ -392,9 +392,9 @@ END
 // String Table
 //
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
-    2048    "86Box"
+    2048        "86Box"
     IDS_2049    "错误"
     IDS_2050    "致命错误"
     IDS_2051    " - 已暂停"
@@ -412,7 +412,7 @@ BEGIN
     IDS_2063    "由于 roms/machines 文件夹中缺少合适的 ROM，机型 ""%hs"" 不可用。将切换到其他可用机型。"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2064    "由于 roms/video 文件夹中缺少合适的 ROM，显卡 ""%hs"" 不可用。将切换到其他可用显卡。"
     IDS_2065    "机型"
@@ -432,7 +432,7 @@ BEGIN
     IDS_2079    "按下 F8+F12 或鼠标中键释放鼠标"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2080    "无法初始化 FluidSynth"
     IDS_2081    "总线"
@@ -544,7 +544,7 @@ BEGIN
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_4096    "硬盘 (%s)"
     IDS_4097    "%01i:%01i"
@@ -643,7 +643,7 @@ BEGIN
 
     IDS_7168    "(系统默认)"
 END
-#define IDS_LANG_ENUS    IDS_7168
+#define IDS_LANG_ENUS IDS_7168
 
 // Simplified Chinese resources
 /////////////////////////////////////////////////////////////////////////////

--- a/src/win/languages/zh-TW.rc
+++ b/src/win/languages/zh-TW.rc
@@ -13,122 +13,122 @@ LANGUAGE LANG_CHINESE, SUBLANG_CHINESE_TRADITIONAL
 // Menu
 //
 
-MainMenu MENU DISCARDABLE 
+MainMenu MENU DISCARDABLE
 BEGIN
     POPUP "動作(&A)"
     BEGIN
-        MENUITEM "鍵盤需要捕捉(&K)",    IDM_ACTION_KBD_REQ_CAPTURE
-        MENUITEM "將右 CTRL 鍵映射為左 ALT 鍵(&R)",    IDM_ACTION_RCTRL_IS_LALT
+        MENUITEM "鍵盤需要捕捉(&K)", IDM_ACTION_KBD_REQ_CAPTURE
+        MENUITEM "將右 CTRL 鍵映射為左 ALT 鍵(&R)", IDM_ACTION_RCTRL_IS_LALT
         MENUITEM SEPARATOR
-        MENUITEM "硬重設(&H)...",                 IDM_ACTION_HRESET
-        MENUITEM "Ctrl+Alt+Del(&C)\tCtrl+F12",     IDM_ACTION_RESET_CAD
+        MENUITEM "硬重設(&H)...", IDM_ACTION_HRESET
+        MENUITEM "Ctrl+Alt+Del(&C)\tCtrl+F12", IDM_ACTION_RESET_CAD
         MENUITEM SEPARATOR
-    MENUITEM "Ctrl+Alt+Esc(&E)",        IDM_ACTION_CTRL_ALT_ESC
+        MENUITEM "Ctrl+Alt+Esc(&E)", IDM_ACTION_CTRL_ALT_ESC
         MENUITEM SEPARATOR
-        MENUITEM "暫停(&P)",                      IDM_ACTION_PAUSE
+        MENUITEM "暫停(&P)", IDM_ACTION_PAUSE
         MENUITEM SEPARATOR
-        MENUITEM "退出(&X)...",                       IDM_ACTION_EXIT
+        MENUITEM "退出(&X)...", IDM_ACTION_EXIT
     END
     POPUP "檢視(&V)"
     BEGIN
-        MENUITEM "隱藏狀態列(&H)",        IDM_VID_HIDE_STATUS_BAR
-        MENUITEM "隱藏工具列(&T)",        IDM_VID_HIDE_TOOLBAR
+        MENUITEM "隱藏狀態列(&H)", IDM_VID_HIDE_STATUS_BAR
+        MENUITEM "隱藏工具列(&T)", IDM_VID_HIDE_TOOLBAR
         MENUITEM SEPARATOR
-        MENUITEM "Show non-primary monitors(&S)",  IDM_VID_MONITORS
-        MENUITEM "視窗大小可調(&R)",          IDM_VID_RESIZE
-        MENUITEM "記住視窗大小和位置(&E)",  IDM_VID_REMEMBER
+        MENUITEM "Show non-primary monitors(&S)", IDM_VID_MONITORS
+        MENUITEM "視窗大小可調(&R)", IDM_VID_RESIZE
+        MENUITEM "記住視窗大小和位置(&E)", IDM_VID_REMEMBER
         MENUITEM SEPARATOR
         POPUP "渲染器(&N)"
         BEGIN
-            MENUITEM "SDL (軟體)(&S)",         IDM_VID_SDL_SW
-            MENUITEM "SDL (硬體)(&H)",         IDM_VID_SDL_HW
-            MENUITEM "SDL (OpenGL)(&O)",           IDM_VID_SDL_OPENGL
-            MENUITEM "OpenGL (3.0 核心)(&G)",      IDM_VID_OPENGL_CORE
+            MENUITEM "SDL (軟體)(&S)", IDM_VID_SDL_SW
+            MENUITEM "SDL (硬體)(&H)", IDM_VID_SDL_HW
+            MENUITEM "SDL (OpenGL)(&O)", IDM_VID_SDL_OPENGL
+            MENUITEM "OpenGL (3.0 核心)(&G)", IDM_VID_OPENGL_CORE
 #ifdef USE_VNC
-            MENUITEM "VNC(&V)",                    IDM_VID_VNC
+            MENUITEM "VNC(&V)", IDM_VID_VNC
 #endif
         END
         MENUITEM SEPARATOR
-        MENUITEM "指定視窗大小...",          IDM_VID_SPECIFY_DIM
-        MENUITEM "強制 4:3 顯示比例(&O)",    IDM_VID_FORCE43
+        MENUITEM "指定視窗大小...", IDM_VID_SPECIFY_DIM
+        MENUITEM "強制 4:3 顯示比例(&O)", IDM_VID_FORCE43
         POPUP "視窗縮放係數(&W)"
         BEGIN
-            MENUITEM "0.5x(&0)",                   IDM_VID_SCALE_1X
-            MENUITEM "1x(&1)",                     IDM_VID_SCALE_2X
-            MENUITEM "1.5x(&5)",                   IDM_VID_SCALE_3X
-            MENUITEM "2x(&2)",                     IDM_VID_SCALE_4X
-            MENUITEM "&3x",                        IDM_VID_SCALE_5X
-            MENUITEM "&4x",                        IDM_VID_SCALE_6X
-            MENUITEM "&5x",                        IDM_VID_SCALE_7X
-            MENUITEM "&6x",                        IDM_VID_SCALE_8X
-            MENUITEM "&7x",                        IDM_VID_SCALE_9X
-            MENUITEM "&8x",                        IDM_VID_SCALE_10X
+            MENUITEM "0.5x(&0)", IDM_VID_SCALE_1X
+            MENUITEM "1x(&1)", IDM_VID_SCALE_2X
+            MENUITEM "1.5x(&5)", IDM_VID_SCALE_3X
+            MENUITEM "2x(&2)", IDM_VID_SCALE_4X
+            MENUITEM "&3x", IDM_VID_SCALE_5X
+            MENUITEM "&4x", IDM_VID_SCALE_6X
+            MENUITEM "&5x", IDM_VID_SCALE_7X
+            MENUITEM "&6x", IDM_VID_SCALE_8X
+            MENUITEM "&7x", IDM_VID_SCALE_9X
+            MENUITEM "&8x", IDM_VID_SCALE_10X
         END
         POPUP "過濾方式"
         BEGIN
-            MENUITEM "鄰近(&N)",                 IDM_VID_FILTER_NEAREST
-            MENUITEM "線性(&L)",                  IDM_VID_FILTER_LINEAR
+            MENUITEM "鄰近(&N)", IDM_VID_FILTER_NEAREST
+            MENUITEM "線性(&L)", IDM_VID_FILTER_LINEAR
         END
-        MENUITEM "HiDPI 縮放(&D)",              IDM_VID_HIDPI
+        MENUITEM "HiDPI 縮放(&D)", IDM_VID_HIDPI
         MENUITEM SEPARATOR
-        MENUITEM "全螢幕(&F)\tCtrl+Alt+PgUp",    IDM_VID_FULLSCREEN
+        MENUITEM "全螢幕(&F)\tCtrl+Alt+PgUp", IDM_VID_FULLSCREEN
         POPUP "全螢幕拉伸模式(&S)"
         BEGIN
-            MENUITEM "全螢幕拉伸(&F)",        IDM_VID_FS_FULL
-            MENUITEM "4:3(&4)",                        IDM_VID_FS_43
+            MENUITEM "全螢幕拉伸(&F)", IDM_VID_FS_FULL
+            MENUITEM "4:3(&4)", IDM_VID_FS_43
             MENUITEM "保持比例(&S)", IDM_VID_FS_KEEPRATIO
-            MENUITEM "整數比例(&I)",              IDM_VID_FS_INT
+            MENUITEM "整數比例(&I)", IDM_VID_FS_INT
         END
         POPUP "EGA/(S)VGA 設定(&G)"
         BEGIN
-            MENUITEM "VGA 顯示器反色顯示(&I)",   IDM_VID_INVERT
+            MENUITEM "VGA 顯示器反色顯示(&I)", IDM_VID_INVERT
             POPUP "VGA 螢幕類型(&T)"
             BEGIN
-                MENUITEM "RGB 彩色(&C)",          IDM_VID_GRAY_RGB
-                MENUITEM "RGB 灰度(&R)",      IDM_VID_GRAY_MONO
-                MENUITEM "琥珀色單色顯示器(&A)",      IDM_VID_GRAY_AMBER
-                MENUITEM "綠色單色顯示器(&G)",      IDM_VID_GRAY_GREEN
-                MENUITEM "白色單色顯示器(&W)",      IDM_VID_GRAY_WHITE
+                MENUITEM "RGB 彩色(&C)", IDM_VID_GRAY_RGB
+                MENUITEM "RGB 灰度(&R)", IDM_VID_GRAY_MONO
+                MENUITEM "琥珀色單色顯示器(&A)", IDM_VID_GRAY_AMBER
+                MENUITEM "綠色單色顯示器(&G)", IDM_VID_GRAY_GREEN
+                MENUITEM "白色單色顯示器(&W)", IDM_VID_GRAY_WHITE
             END
             POPUP "灰度轉換類型(&C)"
             BEGIN
-                MENUITEM "BT601 (NTSC/PAL)(&6)",   IDM_VID_GRAYCT_601
-                MENUITEM "BT709 (HDTV)(&7)",       IDM_VID_GRAYCT_709
-                MENUITEM "平均(&A)",            IDM_VID_GRAYCT_AVE
+                MENUITEM "BT601 (NTSC/PAL)(&6)", IDM_VID_GRAYCT_601
+                MENUITEM "BT709 (HDTV)(&7)", IDM_VID_GRAYCT_709
+                MENUITEM "平均(&A)", IDM_VID_GRAYCT_AVE
             END
         END
         MENUITEM SEPARATOR
-        MENUITEM "CGA/PCjr/Tandy/EGA/(S)VGA 過掃描(&G)",     IDM_VID_OVERSCAN
+        MENUITEM "CGA/PCjr/Tandy/EGA/(S)VGA 過掃描(&G)", IDM_VID_OVERSCAN
         MENUITEM "變更單色顯示對比度(&M)", IDM_VID_CGACON
     END
-    MENUITEM "介質(&M)",                IDM_MEDIA
+    MENUITEM "介質(&M)", IDM_MEDIA
     POPUP "工具(&T)"
     BEGIN
-        MENUITEM "設定(&S)...",                IDM_CONFIG
-        MENUITEM "更新狀態列圖示(&U)",    IDM_UPDATE_ICONS
+        MENUITEM "設定(&S)...", IDM_CONFIG
+        MENUITEM "更新狀態列圖示(&U)", IDM_UPDATE_ICONS
         MENUITEM SEPARATOR
-        MENUITEM "擷圖(&C)\tCtrl+F11",  IDM_ACTION_SCREENSHOT
+        MENUITEM "擷圖(&C)\tCtrl+F11", IDM_ACTION_SCREENSHOT
         MENUITEM SEPARATOR
-        MENUITEM "首選項(&P)...",    IDM_PREFERENCES
+        MENUITEM "首選項(&P)...", IDM_PREFERENCES
 #ifdef DISCORD
         MENUITEM "啟用 Discord 整合(&D)", IDM_DISCORD
 #endif
         MENUITEM SEPARATOR
-        MENUITEM "音量增益(&G)...",              IDM_SND_GAIN
+        MENUITEM "音量增益(&G)...", IDM_SND_GAIN
 #ifdef MTR_ENABLED
         MENUITEM SEPARATOR
-        MENUITEM "開始追踪\tCtrl+T",         IDM_ACTION_BEGIN_TRACE
-        MENUITEM "結束追踪\tCtrl+T",           IDM_ACTION_END_TRACE
+        MENUITEM "開始追踪\tCtrl+T", IDM_ACTION_BEGIN_TRACE
+        MENUITEM "結束追踪\tCtrl+T", IDM_ACTION_END_TRACE
 #endif
     END
     POPUP "說明(&H)"
     BEGIN
-        MENUITEM "文件(&D)...",           IDM_DOCS
-        MENUITEM "關於 86Box(&A)...",             IDM_ABOUT
+        MENUITEM "文件(&D)...", IDM_DOCS
+        MENUITEM "關於 86Box(&A)...", IDM_ABOUT
     END
 END
 
-StatusBarMenu MENU DISCARDABLE 
+StatusBarMenu MENU DISCARDABLE
 BEGIN
     MENUITEM SEPARATOR
 END
@@ -137,17 +137,17 @@ CassetteSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "新增映像(&N)...",                IDM_CASSETTE_IMAGE_NEW
+        MENUITEM "新增映像(&N)...", IDM_CASSETTE_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "開啟已存在的映像(&E)...",                IDM_CASSETTE_IMAGE_EXISTING
-        MENUITEM "開啟已存在的映像並寫保護(&W)...",    IDM_CASSETTE_IMAGE_EXISTING_WP
+        MENUITEM "開啟已存在的映像(&E)...", IDM_CASSETTE_IMAGE_EXISTING
+        MENUITEM "開啟已存在的映像並寫保護(&W)...", IDM_CASSETTE_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "錄製(&R)",                    IDM_CASSETTE_RECORD
-        MENUITEM "播放(&P)",                    IDM_CASSETTE_PLAY
-        MENUITEM "倒帶至起點(&R)",            IDM_CASSETTE_REWIND
-        MENUITEM "快進至終點(&F)",            IDM_CASSETTE_FAST_FORWARD
+        MENUITEM "錄製(&R)", IDM_CASSETTE_RECORD
+        MENUITEM "播放(&P)", IDM_CASSETTE_PLAY
+        MENUITEM "倒帶至起點(&R)", IDM_CASSETTE_REWIND
+        MENUITEM "快進至終點(&F)", IDM_CASSETTE_FAST_FORWARD
         MENUITEM SEPARATOR
-        MENUITEM "退出(&J)",                    IDM_CASSETTE_EJECT
+        MENUITEM "退出(&J)", IDM_CASSETTE_EJECT
     END
 END
 
@@ -155,9 +155,9 @@ CartridgeSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "映像(&I)...",                    IDM_CARTRIDGE_IMAGE
+        MENUITEM "映像(&I)...", IDM_CARTRIDGE_IMAGE
         MENUITEM SEPARATOR
-        MENUITEM "退出(&J)",                    IDM_CARTRIDGE_EJECT
+        MENUITEM "退出(&J)", IDM_CARTRIDGE_EJECT
     END
 END
 
@@ -165,14 +165,14 @@ FloppySubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "新增映像(&N)...",                IDM_FLOPPY_IMAGE_NEW
+        MENUITEM "新增映像(&N)...", IDM_FLOPPY_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "開啟已存在的映像(&E)...",                IDM_FLOPPY_IMAGE_EXISTING
-        MENUITEM "開啟已存在的映像並寫保護(&W)...",    IDM_FLOPPY_IMAGE_EXISTING_WP
+        MENUITEM "開啟已存在的映像(&E)...", IDM_FLOPPY_IMAGE_EXISTING
+        MENUITEM "開啟已存在的映像並寫保護(&W)...", IDM_FLOPPY_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "匯出為 86F 格式(&x)...",                IDM_FLOPPY_EXPORT_TO_86F
+        MENUITEM "匯出為 86F 格式(&x)...", IDM_FLOPPY_EXPORT_TO_86F
         MENUITEM SEPARATOR
-        MENUITEM "退出(&J)",                    IDM_FLOPPY_EJECT
+        MENUITEM "退出(&J)", IDM_FLOPPY_EJECT
     END
 END
 
@@ -180,13 +180,13 @@ CdromSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "靜音(&M)",                    IDM_CDROM_MUTE
+        MENUITEM "靜音(&M)", IDM_CDROM_MUTE
         MENUITEM SEPARATOR
-        MENUITEM "空置光碟機(&M)",                    IDM_CDROM_EMPTY
-        MENUITEM "載入上一個映像(&R)",            IDM_CDROM_RELOAD
+        MENUITEM "空置光碟機(&M)", IDM_CDROM_EMPTY
+        MENUITEM "載入上一個映像(&R)", IDM_CDROM_RELOAD
         MENUITEM SEPARATOR
-        MENUITEM "映像(&I)...",                    IDM_CDROM_IMAGE
-        MENUITEM "資料夾(&F)...",                    IDM_CDROM_DIR
+        MENUITEM "映像(&I)...", IDM_CDROM_IMAGE
+        MENUITEM "資料夾(&F)...", IDM_CDROM_DIR
     END
 END
 
@@ -194,13 +194,13 @@ ZIPSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "新增映像(&N)...",                IDM_ZIP_IMAGE_NEW
+        MENUITEM "新增映像(&N)...", IDM_ZIP_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "開啟已存在的映像(&E)...",                IDM_ZIP_IMAGE_EXISTING
-        MENUITEM "開啟已存在的映像並寫保護(&W)...",    IDM_ZIP_IMAGE_EXISTING_WP
+        MENUITEM "開啟已存在的映像(&E)...", IDM_ZIP_IMAGE_EXISTING
+        MENUITEM "開啟已存在的映像並寫保護(&W)...", IDM_ZIP_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "退出(&J)",                    IDM_ZIP_EJECT
-        MENUITEM "載入上一個映像(&R)",            IDM_ZIP_RELOAD
+        MENUITEM "退出(&J)", IDM_ZIP_EJECT
+        MENUITEM "載入上一個映像(&R)", IDM_ZIP_RELOAD
     END
 END
 
@@ -208,13 +208,13 @@ MOSubmenu MENU DISCARDABLE
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "新增映像(&N)...",                IDM_MO_IMAGE_NEW
+        MENUITEM "新增映像(&N)...", IDM_MO_IMAGE_NEW
         MENUITEM SEPARATOR
-        MENUITEM "開啟已存在的映像(&E)...",                IDM_MO_IMAGE_EXISTING
-        MENUITEM "開啟已存在的映像並寫保護(&W)...",    IDM_MO_IMAGE_EXISTING_WP
+        MENUITEM "開啟已存在的映像(&E)...", IDM_MO_IMAGE_EXISTING
+        MENUITEM "開啟已存在的映像並寫保護(&W)...", IDM_MO_IMAGE_EXISTING_WP
         MENUITEM SEPARATOR
-        MENUITEM "退出(&J)",                    IDM_MO_EJECT
-        MENUITEM "載入上一個映像(&R)",            IDM_MO_RELOAD
+        MENUITEM "退出(&J)", IDM_MO_EJECT
+        MENUITEM "載入上一個映像(&R)", IDM_MO_RELOAD
     END
 END
 
@@ -240,147 +240,147 @@ END
 // Dialog
 //
 
-#define STR_PREFERENCES        "首選項"
-#define STR_SND_GAIN        "音量增益"
-#define STR_NEW_FLOPPY        "新增映像"
+#define STR_PREFERENCES   "首選項"
+#define STR_SND_GAIN      "音量增益"
+#define STR_NEW_FLOPPY    "新增映像"
 #define STR_CONFIG        "設定"
-#define STR_SPECIFY_DIM        "指定主視窗大小"
+#define STR_SPECIFY_DIM   "指定主視窗大小"
 
 #define STR_OK            "確定"
 #define STR_CANCEL        "取消"
 #define STR_GLOBAL        "將以上設定存儲為全局預設值(&G)"
-#define STR_DEFAULT        "預設(&D)"
-#define STR_LANGUAGE        "語言:"
-#define STR_ICONSET        "圖示集:"
+#define STR_DEFAULT       "預設(&D)"
+#define STR_LANGUAGE      "語言:"
+#define STR_ICONSET       "圖示集:"
 
-#define STR_GAIN        "增益"
+#define STR_GAIN          "增益"
 
-#define STR_FILE_NAME        "檔案名:"
-#define STR_DISK_SIZE        "磁碟大小:"
-#define STR_RPM_MODE        "轉速 (RPM) 模式:"
-#define STR_PROGRESS        "進度:"
+#define STR_FILE_NAME     "檔案名:"
+#define STR_DISK_SIZE     "磁碟大小:"
+#define STR_RPM_MODE      "轉速 (RPM) 模式:"
+#define STR_PROGRESS      "進度:"
 
-#define STR_WIDTH        "寬度:"
+#define STR_WIDTH         "寬度:"
 #define STR_HEIGHT        "高度:"
-#define STR_LOCK_TO_SIZE    "鎖定此大小"
+#define STR_LOCK_TO_SIZE  "鎖定此大小"
 
-#define STR_MACHINE_TYPE    "機器類型:"
-#define STR_MACHINE        "機型:"
-#define STR_CONFIGURE        "配置"
-#define STR_CPU_TYPE        "CPU 類型:"
-#define STR_CPU_SPEED        "速度:"
-#define STR_FPU            "浮點處理器 (FPU):"
-#define STR_WAIT_STATES        "等待狀態 (WS):"
+#define STR_MACHINE_TYPE  "機器類型:"
+#define STR_MACHINE       "機型:"
+#define STR_CONFIGURE     "配置"
+#define STR_CPU_TYPE      "CPU 類型:"
+#define STR_CPU_SPEED     "速度:"
+#define STR_FPU           "浮點處理器 (FPU):"
+#define STR_WAIT_STATES   "等待狀態 (WS):"
 #define STR_MB            "MB"
 #define STR_MEMORY        "記憶體:"
-#define STR_TIME_SYNC        "時間同步"
-#define STR_DISABLED        "禁用"
-#define STR_ENABLED_LOCAL    "啟用 (本地時間)"
-#define STR_ENABLED_UTC        "啟用 (UTC)"
-#define STR_DYNAREC        "動態重編譯器"
+#define STR_TIME_SYNC     "時間同步"
+#define STR_DISABLED      "禁用"
+#define STR_ENABLED_LOCAL "啟用 (本地時間)"
+#define STR_ENABLED_UTC   "啟用 (UTC)"
+#define STR_DYNAREC       "動態重編譯器"
 
-#define STR_VIDEO        "顯示卡:"
-#define STR_VIDEO_2        "顯示卡 2:"
+#define STR_VIDEO         "顯示卡:"
+#define STR_VIDEO_2       "顯示卡 2:"
 #define STR_VOODOO        "Voodoo Graphics"
-#define STR_IBM8514        "IBM 8514/a Graphics"
-#define STR_XGA            "XGA Graphics"
+#define STR_IBM8514       "IBM 8514/a Graphics"
+#define STR_XGA           "XGA Graphics"
 
-#define STR_MOUSE        "滑鼠:"
-#define STR_JOYSTICK        "搖桿:"
-#define STR_JOY1        "搖桿 1..."
-#define STR_JOY2        "搖桿 2..."
-#define STR_JOY3        "搖桿 3..."
-#define STR_JOY4        "搖桿 4..."
+#define STR_MOUSE         "滑鼠:"
+#define STR_JOYSTICK      "搖桿:"
+#define STR_JOY1          "搖桿 1..."
+#define STR_JOY2          "搖桿 2..."
+#define STR_JOY3          "搖桿 3..."
+#define STR_JOY4          "搖桿 4..."
 
 #define STR_SOUND1        "音訊卡 1:"
 #define STR_SOUND2        "音訊卡 2:"
 #define STR_SOUND3        "音訊卡 3:"
 #define STR_SOUND4        "音訊卡 4:"
-#define STR_MIDI_OUT        "MIDI 輸出裝置:"
-#define STR_MIDI_IN        "MIDI 輸入裝置:"
+#define STR_MIDI_OUT      "MIDI 輸出裝置:"
+#define STR_MIDI_IN       "MIDI 輸入裝置:"
 #define STR_MPU401        "獨立 MPU-401"
-#define STR_FLOAT        "使用單精度浮點 (FLOAT32)"
-#define STR_FM_DRIVER        "調頻合成器驅動器"
-#define STR_FM_DRV_NUKED    "Nuked (更準確)"
-#define STR_FM_DRV_YMFM        "YMFM (更快)"
+#define STR_FLOAT         "使用單精度浮點 (FLOAT32)"
+#define STR_FM_DRIVER     "調頻合成器驅動器"
+#define STR_FM_DRV_NUKED  "Nuked (更準確)"
+#define STR_FM_DRV_YMFM   "YMFM (更快)"
 
-#define STR_NET_TYPE    "網路類型:"
-#define STR_PCAP        "PCap 裝置:"
-#define STR_NET            "網路配接器:"
-#define STR_NET1        "Network card 1:"
-#define STR_NET2        "Network card 2:"
-#define STR_NET3        "Network card 3:"
-#define STR_NET4        "Network card 4:"
+#define STR_NET_TYPE      "網路類型:"
+#define STR_PCAP          "PCap 裝置:"
+#define STR_NET           "網路配接器:"
+#define STR_NET1          "Network card 1:"
+#define STR_NET2          "Network card 2:"
+#define STR_NET3          "Network card 3:"
+#define STR_NET4          "Network card 4:"
 
-#define STR_COM1        "COM1 裝置:"
-#define STR_COM2        "COM2 裝置:"
-#define STR_COM3        "COM3 裝置:"
-#define STR_COM4        "COM4 裝置:"
-#define STR_LPT1        "LPT1 裝置:"
-#define STR_LPT2        "LPT2 裝置:"
-#define STR_LPT3        "LPT3 裝置:"
-#define STR_LPT4        "LPT4 裝置:"
-#define STR_SERIAL1        "序列埠 1"
-#define STR_SERIAL2        "序列埠 2"
-#define STR_SERIAL3        "序列埠 3"
-#define STR_SERIAL4        "序列埠 4"
-#define STR_PARALLEL1        "並列埠 1"
-#define STR_PARALLEL2        "並列埠 2"
-#define STR_PARALLEL3        "並列埠 3"
-#define STR_PARALLEL4        "並列埠 4"
-#define STR_SERIAL_PASS1    "Serial port passthrough 1"
-#define STR_SERIAL_PASS2    "Serial port passthrough 2"
-#define STR_SERIAL_PASS3    "Serial port passthrough 3"
-#define STR_SERIAL_PASS4    "Serial port passthrough 4"
+#define STR_COM1          "COM1 裝置:"
+#define STR_COM2          "COM2 裝置:"
+#define STR_COM3          "COM3 裝置:"
+#define STR_COM4          "COM4 裝置:"
+#define STR_LPT1          "LPT1 裝置:"
+#define STR_LPT2          "LPT2 裝置:"
+#define STR_LPT3          "LPT3 裝置:"
+#define STR_LPT4          "LPT4 裝置:"
+#define STR_SERIAL1       "序列埠 1"
+#define STR_SERIAL2       "序列埠 2"
+#define STR_SERIAL3       "序列埠 3"
+#define STR_SERIAL4       "序列埠 4"
+#define STR_PARALLEL1     "並列埠 1"
+#define STR_PARALLEL2     "並列埠 2"
+#define STR_PARALLEL3     "並列埠 3"
+#define STR_PARALLEL4     "並列埠 4"
+#define STR_SERIAL_PASS1  "Serial port passthrough 1"
+#define STR_SERIAL_PASS2  "Serial port passthrough 2"
+#define STR_SERIAL_PASS3  "Serial port passthrough 3"
+#define STR_SERIAL_PASS4  "Serial port passthrough 4"
 
-#define STR_HDC            "硬碟控制器:"
-#define STR_FDC            "軟碟控制器:"
-#define STR_IDE_TER        "第三 IDE 控制器"
-#define STR_IDE_QUA        "第四 IDE 控制器"
-#define STR_SCSI        "SCSI"
+#define STR_HDC           "硬碟控制器:"
+#define STR_FDC           "軟碟控制器:"
+#define STR_IDE_TER       "第三 IDE 控制器"
+#define STR_IDE_QUA       "第四 IDE 控制器"
+#define STR_SCSI          "SCSI"
 #define STR_SCSI_1        "控制器 1:"
 #define STR_SCSI_2        "控制器 2:"
 #define STR_SCSI_3        "控制器 3:"
 #define STR_SCSI_4        "控制器 4:"
-#define STR_CASSETTE        "磁帶"
+#define STR_CASSETTE      "磁帶"
 
-#define STR_HDD            "硬碟:"
-#define STR_NEW            "新增(&N)..."
-#define STR_EXISTING        "已有映像(&E)..."
+#define STR_HDD           "硬碟:"
+#define STR_NEW           "新增(&N)..."
+#define STR_EXISTING      "已有映像(&E)..."
 #define STR_REMOVE        "移除(&R)"
-#define STR_BUS            "匯流排:"
-#define STR_CHANNEL        "通道:"
+#define STR_BUS           "匯流排:"
+#define STR_CHANNEL       "通道:"
 #define STR_ID            "ID:"
-#define STR_SPEED        "Speed:"
+#define STR_SPEED         "Speed:"
 
-#define STR_SPECIFY        "指定(&S)..."
-#define STR_SECTORS        "磁區(S):"
-#define STR_HEADS        "磁頭(H):"
-#define STR_CYLS        "柱面(C):"
-#define STR_SIZE_MB        "大小 (MB):"
-#define STR_TYPE        "類型:"
-#define STR_IMG_FORMAT        "映像格式:"
-#define STR_BLOCK_SIZE        "區塊大小:"
+#define STR_SPECIFY       "指定(&S)..."
+#define STR_SECTORS       "磁區(S):"
+#define STR_HEADS         "磁頭(H):"
+#define STR_CYLS          "柱面(C):"
+#define STR_SIZE_MB       "大小 (MB):"
+#define STR_TYPE          "類型:"
+#define STR_IMG_FORMAT    "映像格式:"
+#define STR_BLOCK_SIZE    "區塊大小:"
 
-#define STR_FLOPPY_DRIVES    "軟碟機:"
-#define STR_TURBO        "加速時序"
-#define STR_CHECKBPB        "檢查 BPB"
-#define STR_CDROM_DRIVES    "光碟機:"
-#define STR_CD_SPEED        "速度:"
-#define STR_EARLY        "早先的光碟機"
+#define STR_FLOPPY_DRIVES "軟碟機:"
+#define STR_TURBO         "加速時序"
+#define STR_CHECKBPB      "檢查 BPB"
+#define STR_CDROM_DRIVES  "光碟機:"
+#define STR_CD_SPEED      "速度:"
+#define STR_EARLY         "早先的光碟機"
 
-#define STR_MO_DRIVES        "磁光碟機:"
-#define STR_ZIP_DRIVES        "ZIP 磁碟機:"
-#define STR_250            "ZIP 250"
+#define STR_MO_DRIVES     "磁光碟機:"
+#define STR_ZIP_DRIVES    "ZIP 磁碟機:"
+#define STR_250           "ZIP 250"
 
 #define STR_ISARTC        "ISA 實時時鐘:"
 #define STR_ISAMEM        "ISA 記憶體擴充"
-#define STR_ISAMEM_1        "擴充卡 1:"
-#define STR_ISAMEM_2        "擴充卡 2:"
-#define STR_ISAMEM_3        "擴充卡 3:"
-#define STR_ISAMEM_4        "擴充卡 4:"
+#define STR_ISAMEM_1      "擴充卡 1:"
+#define STR_ISAMEM_2      "擴充卡 2:"
+#define STR_ISAMEM_3      "擴充卡 3:"
+#define STR_ISAMEM_4      "擴充卡 4:"
 #define STR_BUGGER        "ISABugger 裝置"
-#define STR_POSTCARD        "自檢 (POST) 卡"
+#define STR_POSTCARD      "自檢 (POST) 卡"
 
 #define FONT_SIZE        9
 #define FONT_NAME        "Microsoft JhengHei"
@@ -392,9 +392,9 @@ END
 // String Table
 //
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
-    2048    "86Box"
+    2048        "86Box"
     IDS_2049    "錯誤"
     IDS_2050    "致命錯誤"
     IDS_2051    " - 已暫停"
@@ -412,7 +412,7 @@ BEGIN
     IDS_2063    "由於 roms/machines 資料夾中缺少合適的 ROM，機型 ""%hs"" 不可用。將切換到其他可用機型。"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2064    "由於 roms/video 資料夾中缺少合適的 ROM，顯示卡 ""%hs"" 不可用。將切換到其他可用顯示卡。"
     IDS_2065    "機型"
@@ -432,7 +432,7 @@ BEGIN
     IDS_2079    "按下 F8+F12 或滑鼠中鍵釋放滑鼠"
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_2080    "無法初始化 FluidSynth"
     IDS_2081    "匯流排"
@@ -544,7 +544,7 @@ BEGIN
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
 END
 
-STRINGTABLE DISCARDABLE 
+STRINGTABLE DISCARDABLE
 BEGIN
     IDS_4096    "硬碟 (%s)"
     IDS_4097    "%01i:%01i"
@@ -643,7 +643,7 @@ BEGIN
 
     IDS_7168    "(系統預設)"
 END
-#define IDS_LANG_ENUS    IDS_7168
+#define IDS_LANG_ENUS IDS_7168
 
 // Traditional Chinese resources
 /////////////////////////////////////////////////////////////////////////////

--- a/src/win/win_settings.c
+++ b/src/win/win_settings.c
@@ -2492,7 +2492,7 @@ static BOOL
 win_settings_hard_disks_recalc_list(HWND hdlg)
 {
     LVITEM lvI;
-    int    i, j = 0;
+    int    j = 0;
     WCHAR  szText[256], usr_path_w[1024];
     HWND   hwndList = GetDlgItem(hdlg, IDC_LIST_HARD_DISKS);
 


### PR DESCRIPTION
Summary
=======
[Whitespace in win32 lang files (2/2)](https://github.com/86Box/86Box/commit/93a1f2d2f980b769bf1ced76307839e380b90387)
[Fix a compile warn in win_settings.c](https://github.com/86Box/86Box/commit/bfcc11c5126ce25f1ca65307eceb22a5890a23ba)

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
