### PR TITLE
386_dynarec: Fix cycle counting behaviour

### DIFF
--- a/src/cpu/386_dynarec.c
+++ b/src/cpu/386_dynarec.c
@@ -297,7 +297,7 @@ prefetch_flush(void)
 #ifdef USE_DYNAREC
 int             cycles_main = 0;
 static int      cycles_old  = 0;
-static uint64_t tsc_old     = 0;
+uint64_t tsc_old            = 0; /* Only intended for usage in cpu.c to set tsc_old to the correct value, when the TSC value is overwritten by software. */
 
 #    ifdef USE_ACYCS
 int acycs = 0;
@@ -329,6 +329,8 @@ update_tsc(void)
         if (TIMER_VAL_LESS_THAN_VAL(timer_target, (uint32_t) tsc))
             timer_process_inline();
     }
+    tsc_old = tsc;
+    cycles_old = cycles;
 }
 
 static __inline void
@@ -744,7 +746,6 @@ exec386_dynarec(int cycs)
 {
     int      vector, tempi;
     int      cycdiff;
-    int      oldcyc, oldcyc2;
     uint64_t oldtsc, delta;
 
     int cyc_period = cycs / 2000; /*5us*/
@@ -768,7 +769,6 @@ exec386_dynarec(int cycs)
 
             cycdiff = 0;
 #    endif
-            oldcyc = oldcyc2 = cycles;
             cycles_old       = cycles;
             oldtsc           = tsc;
             tsc_old          = tsc;
@@ -830,8 +830,8 @@ exec386_dynarec(int cycs)
                 }
             }
 
-            cycdiff = oldcyc - cycles;
-            delta   = tsc - oldtsc;
+            cycdiff = cycles_old - cycles;
+            delta   = tsc - tsc_old;
             if (delta > 0) {
                 /* TSC has changed, this means interim timer processing has happened,
                    see how much we still need to add. */

--- a/src/cpu/cpu.c
+++ b/src/cpu/cpu.c
@@ -72,6 +72,8 @@ enum {
 #define CPUID_3DNOW  (1UL << 31UL)
 #define CPUID_3DNOWE (1UL << 30UL)
 
+extern uint64_t tsc_old;
+
 /* Make sure this is as low as possible. */
 cpu_state_t cpu_state;
 
@@ -2628,7 +2630,12 @@ cpu_WRMSR(void)
                     msr.tr12 = EAX & 0x228;
                     break;
                 case 0x10:
-                    tsc = EAX | ((uint64_t) EDX << 32);
+#ifdef USE_DYNAREC
+                    if (cpu_use_dynarec) {
+                        update_tsc();
+                    }
+#endif
+                    tsc = tsc_old = EAX | ((uint64_t) EDX << 32);
                     break;
                 case 0x11:
                     msr.cesr = EAX & 0xff00ff;
@@ -2667,7 +2674,12 @@ cpu_WRMSR(void)
                 case 0x01:
                     break;
                 case 0x10:
-                    tsc = EAX | ((uint64_t) EDX << 32);
+#ifdef USE_DYNAREC
+                    if (cpu_use_dynarec) {
+                        update_tsc();
+                    }
+#endif
+                    tsc = tsc_old = EAX | ((uint64_t) EDX << 32);
                     break;
                 case 0x1107:
                     msr.fcr = EAX;
@@ -2746,7 +2758,12 @@ cpu_WRMSR(void)
                     msr.tr12 = EAX & 0x228;
                     break;
                 case 0x10:
-                    tsc = EAX | ((uint64_t) EDX << 32);
+#ifdef USE_DYNAREC
+                    if (cpu_use_dynarec) {
+                        update_tsc();
+                    }
+#endif
+                    tsc = tsc_old = EAX | ((uint64_t) EDX << 32);
                     break;
                 case 0x83:
                     msr.ecx83 = EAX | ((uint64_t) EDX << 32);
@@ -2819,7 +2836,12 @@ amd_k_invalid_wrmsr:
                 case 0x01:
                     break;
                 case 0x10:
-                    tsc = EAX | ((uint64_t) EDX << 32);
+#ifdef USE_DYNAREC
+                    if (cpu_use_dynarec) {
+                        update_tsc();
+                    }
+#endif
+                    tsc = tsc_old = EAX | ((uint64_t) EDX << 32);
                     break;
                 case 0x8b:
 #if defined(DEV_BRANCH) && defined(USE_CYRIX_6X86)
@@ -2844,7 +2866,12 @@ amd_k_invalid_wrmsr:
                         x86gpf(NULL, 0);
                     break;
                 case 0x10:
-                    tsc = EAX | ((uint64_t) EDX << 32);
+#ifdef USE_DYNAREC
+                    if (cpu_use_dynarec) {
+                        update_tsc();
+                    }
+#endif
+                    tsc = tsc_old = EAX | ((uint64_t) EDX << 32);
                     break;
                 case 0x1b:
                     cpu_log("APIC_BASE write: %08X%08X\n", EDX, EAX);


### PR DESCRIPTION
Summary
=======
386_dynarec: Fix cycle counting behaviour when update_tsc is called

Don't count more cycles than what actually elapsed.

Checklist
=========
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
