### PR TITLE
cpu_busspeed is now a double

### DIFF
--- a/src/cpu/cpu.c
+++ b/src/cpu/cpu.c
@@ -114,7 +114,7 @@ int isa_cycles, cpu_inited,
     cpu_waitstates, cpu_cache_int_enabled, cpu_cache_ext_enabled,
     cpu_isa_speed, cpu_pci_speed, cpu_isa_pci_div, cpu_agp_speed, cpu_alt_reset,
 
-    cpu_override, cpu_effective, cpu_multi, cpu_16bitbus, cpu_64bitbus, cpu_busspeed,
+    cpu_override, cpu_effective, cpu_multi, cpu_16bitbus, cpu_64bitbus,
     cpu_cyrix_alignment, CPUID,
 
     is186, is_nec,
@@ -138,7 +138,7 @@ uint8_t  _cache[2048];
 uint64_t cpu_CR4_mask, tsc = 0;
 uint64_t pmc[2] = { 0, 0 };
 
-double cpu_dmulti;
+double cpu_dmulti, cpu_busspeed;
 
 msr_t msr;
 

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -490,10 +490,11 @@ extern int                        cpu_override;
 extern int    cpu_isintel;
 extern int    cpu_iscyrix;
 extern int    cpu_16bitbus, cpu_64bitbus;
-extern int    cpu_busspeed, cpu_pci_speed;
+extern int    cpu_pci_speed;
 extern int    cpu_multi;
 extern double cpu_dmulti;
 extern double fpu_multi;
+extern double cpu_busspeed;
 extern int    cpu_cyrix_alignment; /*Cyrix 5x86/6x86 only has data misalignment
                                      penalties when crossing 8-byte boundaries*/
 


### PR DESCRIPTION
Summary
=======
cpu_busspeed is now a double

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
