### PR TITLE
vid_ega: Merge renderers and fix a few extra bugs

### DIFF
--- a/src/include/86box/vid_ega.h
+++ b/src/include/86box/vid_ega.h
@@ -121,9 +121,7 @@ void ega_render_blank(ega_t *ega);
 void ega_render_overscan_left(ega_t *ega);
 void ega_render_overscan_right(ega_t *ega);
 
-void ega_render_text_40(ega_t *ega);
-void ega_render_text_80(ega_t *ega);
-
+void ega_render_text(ega_t *ega);
 void ega_render_graphics(ega_t *ega);
 #endif
 

--- a/src/include/86box/vid_ega.h
+++ b/src/include/86box/vid_ega.h
@@ -126,8 +126,7 @@ void ega_render_text_80(ega_t *ega);
 void ega_render_2bpp_lowres(ega_t *ega);
 void ega_render_2bpp_highres(ega_t *ega);
 
-void ega_render_4bpp_lowres(ega_t *ega);
-void ega_render_4bpp_highres(ega_t *ega);
+void ega_render_4bpp(ega_t *ega);
 #endif
 
 #endif /*VIDEO_EGA_H*/

--- a/src/include/86box/vid_ega.h
+++ b/src/include/86box/vid_ega.h
@@ -113,6 +113,7 @@ extern int      con, cursoron, cgablink;
 extern int scrollcache;
 
 extern uint8_t edatlookup[4][4];
+extern uint8_t egaremap2bpp[256];
 
 #if defined(EMU_MEM_H) && defined(EMU_ROM_H)
 void ega_render_blank(ega_t *ega);
@@ -123,10 +124,7 @@ void ega_render_overscan_right(ega_t *ega);
 void ega_render_text_40(ega_t *ega);
 void ega_render_text_80(ega_t *ega);
 
-void ega_render_2bpp_lowres(ega_t *ega);
-void ega_render_2bpp_highres(ega_t *ega);
-
-void ega_render_4bpp(ega_t *ega);
+void ega_render_graphics(ega_t *ega);
 #endif
 
 #endif /*VIDEO_EGA_H*/

--- a/src/video/vid_ega.c
+++ b/src/video/vid_ega.c
@@ -57,7 +57,7 @@ static uint8_t         ega_rotate[8][256];
 static uint32_t        pallook16[256], pallook64[256];
 static int             ega_type = 0, old_overscan_color = 0;
 
-extern uint8_t edatlookup[4][4];
+uint8_t egaremap2bpp[256];
 
 /* 3C2 controls default mode on EGA. On VGA, it determines monitor type (mono or colour):
     7=CGA mode (200 lines), 9=EGA mode (350 lines), 8=EGA mode (200 lines). */
@@ -419,19 +419,8 @@ ega_recalctimings(ega_t *ega)
             ega->hdisp_old = ega->hdisp;
         } else {
             ega->hdisp *= (ega->seqregs[1] & 8) ? 16 : 8;
+            ega->render = ega_render_graphics;
             ega->hdisp_old = ega->hdisp;
-
-            switch (ega->gdcreg[5] & 0x20) {
-                case 0x00:
-                    ega->render = ega_render_4bpp;
-                    break;
-                case 0x20:
-                    if (ega->seqregs[1] & 8)
-                        ega->render = ega_render_2bpp_lowres;
-                    else
-                        ega->render = ega_render_2bpp_highres;
-                    break;
-            }
         }
     }
 
@@ -1058,6 +1047,18 @@ ega_init(ega_t *ega, int monitor_type, int is_mono)
             if (d & 2)
                 edatlookup[c][d] |= 0x20;
         }
+    }
+
+    for (c = 0; c < 256; c++) {
+        egaremap2bpp[c] = 0;
+        if (c & 0x01)
+            egaremap2bpp[c] |= 0x01;
+        if (c & 0x04)
+            egaremap2bpp[c] |= 0x02;
+        if (c & 0x10)
+            egaremap2bpp[c] |= 0x04;
+        if (c & 0x40)
+            egaremap2bpp[c] |= 0x08;
     }
 
     if (is_mono) {

--- a/src/video/vid_ega.c
+++ b/src/video/vid_ega.c
@@ -423,10 +423,7 @@ ega_recalctimings(ega_t *ega)
 
             switch (ega->gdcreg[5] & 0x20) {
                 case 0x00:
-                    if (ega->seqregs[1] & 8)
-                        ega->render = ega_render_4bpp_lowres;
-                    else
-                        ega->render = ega_render_4bpp_highres;
+                    ega->render = ega_render_4bpp;
                     break;
                 case 0x20:
                     if (ega->seqregs[1] & 8)

--- a/src/video/vid_ega.c
+++ b/src/video/vid_ega.c
@@ -409,13 +409,11 @@ ega_recalctimings(ega_t *ega)
     ega->render = ega_render_blank;
     if (!ega->scrblank && ega->attr_palette_enable) {
         if (!(ega->gdcreg[6] & 1)) {
-            if (ega->seqregs[1] & 8) {
-                ega->render = ega_render_text_40;
+            if (ega->seqregs[1] & 8)
                 ega->hdisp *= (ega->seqregs[1] & 1) ? 16 : 18;
-            } else {
-                ega->render = ega_render_text_80;
+            else
                 ega->hdisp *= (ega->seqregs[1] & 1) ? 8 : 9;
-            }
+            ega->render = ega_render_text;
             ega->hdisp_old = ega->hdisp;
         } else {
             ega->hdisp *= (ega->seqregs[1] & 8) ? 16 : 8;

--- a/src/video/vid_ega_render.c
+++ b/src/video/vid_ega_render.c
@@ -165,7 +165,7 @@ ega_render_text(ega_t *ega)
             ega->ma += 4;
             p += charwidth;
         }
-        ega->ma &= ega->vrammask;
+        ega->ma &= 0x3ffff;
     }
 }
 


### PR DESCRIPTION
Summary
=======
This merges the 4 graphics renderers together (2bpp vs 4bpp x lowres vs highres) and the 2 text renderers together (40 wide vs 80 wide). This makes it easier to implement correct behaviour without having to do it in up to 6 different places.

This also contains a few bugfixes. These are:
- The CGA compatibility 2-bit-chunky rendering now actually factors in the upper 2 planes.
- The CRTC memory address is now wrapped correctly in 2-bit-chunky modes and text modes. (Had to fix this in 2 places already; now this fixes it in the remaining 4 places, partly by merging them all together.)
- Graphics modes now support blinking, as required by the 640x350 2bpp monochrome mode from the BIOS. (How I forgot this was a thing when I was working on getting the 64KB 640x350x2bpp modes working, I don't know, but this has always been a thing even on SVGA cards.)

My plan is to eventually have one renderer for both graphics and text modes, considering it's possible to get a mixture of both modes by setting some registers one way and the rest the other way. But this should at least make stuff easier in the meantime.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
IBM EGA reference manual (especially the schematic and the BIOS mode tables) and Chips & Technologies 82C43x datasheet. You have to read between the lines on both of these as they tend to be wrong in places, although the schematic seems pretty accurate.
