### PR TITLE
vid_ega: Make the read-write CRTC registers readable

### DIFF
--- a/src/video/vid_ega.c
+++ b/src/video/vid_ega.c
@@ -312,8 +312,25 @@ ega_in(uint16_t addr, void *p)
             break;
         case 0x3d1:
         case 0x3d5:
-            if (ega_type)
-                ret = ega->crtc[ega->crtcreg];
+            switch(ega->crtcreg) {
+                case 0xc:
+                case 0xd:
+                case 0xe:
+                case 0xf:
+                    ret = ega->crtc[ega->crtcreg];
+                    break;
+
+                case 0x10:
+                case 0x11:
+                    // TODO: Return light pen address once implemented
+                    if (ega_type)
+                        ret = ega->crtc[ega->crtcreg];
+                    break;
+
+                default:
+                    if (ega_type)
+                        ret = ega->crtc[ega->crtcreg];
+            }
             break;
         case 0x3da:
             ega->attrff = 0;


### PR DESCRIPTION
Summary
=======
This makes the read-write CRTC registers readable.
For completeness, this also provides a stub for anyone wanting to implement the read-only light pen address registers, but until someone fills it out, the behaviour should remain unchanged.

This fixes a lockup that happens when returning from QBASIC under many screen modes, including SCREEN 0. It probably fixes other things too.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
IBM EGA reference.
