### PR TITLE
qt: Fix mute icon in CD-ROM menus

### DIFF
--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -572,7 +572,8 @@ MediaMenu::cdromUpdateMenu(int i)
     auto  childs = menu->children();
 
     auto *muteMenu = dynamic_cast<QAction *>(childs[cdromMutePos]);
-    muteMenu->setChecked(cdrom[i].sound_on == 0);
+    muteMenu->setIcon(QApplication::style()->standardIcon((cdrom[i].sound_on == 0) ? QStyle::SP_MediaVolume : QStyle::SP_MediaVolumeMuted));
+    muteMenu->setText((cdrom[i].sound_on == 0) ? tr("&Unmute") : tr("&Mute"));
 
     auto *imageMenu = dynamic_cast<QAction *>(childs[cdromImagePos]);
     imageMenu->setEnabled(!name.isEmpty());


### PR DESCRIPTION
Summary
=======
qt: Fix mute icon in CD-ROM menus

Checklist
=========
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
