### PR TITLE
Update unix.c to add a missing semicolon for Apple build

### DIFF
--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -814,7 +814,7 @@ void
 plat_get_global_config_dir(char *strptr)
 {
 #ifdef __APPLE__
-    char *prefPath = SDL_GetPrefPath(NULL, "net.86Box.86Box")
+    char *prefPath = SDL_GetPrefPath(NULL, "net.86Box.86Box");
 #else
     char *prefPath = SDL_GetPrefPath(NULL, "86Box");
 #endif


### PR DESCRIPTION
Summary
=======
Add missing semicolon for Apple build

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
