### PR TITLE
Fix RPM spec file

### DIFF
--- a/bumpversion.sh
+++ b/bumpversion.sh
@@ -36,7 +36,7 @@ if [ -z "${romversion}" ]; then
 	# Get the latest ROM release from the GitHub API.
 	romversion=$(curl --silent "https://api.github.com/repos/86Box/roms/releases/latest" |
 		grep '"tag_name":' |
-		sed -E 's/.*"([^"]+)".*/\1/')
+		sed -E 's/.*"v([^"]+)".*/\1/')
 fi
 
 # Switch to the repository root directory.

--- a/src/unix/assets/86Box.spec
+++ b/src/unix/assets/86Box.spec
@@ -12,7 +12,7 @@
 # After a successful build, you can install the RPMs as follows:
 #  sudo dnf install RPMS/$(uname -m)/86Box-3* RPMS/noarch/86Box-roms*
 
-%global romver v3.11
+%global romver 3.11
 
 Name:		86Box
 Version:	4.0
@@ -21,8 +21,8 @@ Summary:	Classic PC emulator
 License:	GPLv2+
 URL:		https://86box.net
 
-Source0:	https://github.com/86Box/86Box/archive/refs/tags/v%%{version}.tar.gz
-Source1:	https://github.com/86Box/roms/archive/refs/tags/%{romver}.zip
+Source0:	https://github.com/86Box/86Box/archive/refs/tags/v%{version}.tar.gz
+Source1:	https://github.com/86Box/roms/archive/refs/tags/v%{romver}.zip
 
 BuildRequires: cmake
 BuildRequires: desktop-file-utils
@@ -32,6 +32,7 @@ BuildRequires: gcc-c++
 BuildRequires: libFAudio-devel
 BuildRequires: libappstream-glib
 BuildRequires: libevdev-devel
+BuildRequires: libxkbcommon-x11-devel
 BuildRequires: libXi-devel
 BuildRequires: ninja-build
 BuildRequires: openal-soft-devel
@@ -98,7 +99,7 @@ cp src/unix/assets/net.86box.86Box.metainfo.xml %{buildroot}%{_metainfodir}
 appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/net.86box.86Box.metainfo.xml
 
 # install roms
-pushd roms-%{version}
+pushd roms-%{romver}
   mkdir -p %{buildroot}%{_datadir}/%{name}/roms
   cp -a * %{buildroot}%{_datadir}/%{name}/roms/
 popd


### PR DESCRIPTION
Summary
=======
- Handle changed source filenames, which now include a 'v' at the beginning
- Add libxkbcommon-x11-devel to the build requirements

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
My local builds started failing due to a missing xkbcommon-x11 header file. e.g.
```
[23/45] Building CXX object src/qt/CMakeFiles/ui.dir/xkbcommon_keyboard.cpp.o
FAILED: src/qt/CMakeFiles/ui.dir/xkbcommon_keyboard.cpp.o 
/usr/lib64/ccache/c++ -DCMAKE -DDISCORD -DEVDEV_INPUT -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DRELEASE_BUILD -DUSE_DYNAREC -DUSE_NEW_DYNAREC -DUSE_RTMIDI -DWAYLAND -DXKBCOMMON -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE=1 -D_LARGEFILE_SOURCE=1 -I/home/rderooy/src/github/86Box/build/src/qt -I/home/rderooy/src/github/86Box/src/qt -I/home/rderooy/src/github/86Box/build/src/qt/ui_autogen/include -I/usr/include/freetype2 -I/usr/include/SDL2 -I/home/rderooy/src/github/86Box/build/src/include -I/home/rderooy/src/github/86Box/src/include -I/home/rderooy/src/github/86Box/src/cpu -I/home/rderooy/src/github/86Box/src/codegen_new -I/usr/include/qt5/QtGui/5.15.8 -I/usr/include/qt5/QtGui/5.15.8/QtGui -I/usr/include/qt5/QtCore/5.15.8 -I/usr/include/qt5/QtCore/5.15.8/QtCore -isystem /usr/include/qt5 -isystem /usr/include/qt5/QtWidgets -isystem /usr/include/qt5/QtGui -isystem /usr/include/qt5/QtCore -isystem /usr/lib64/qt5/mkspecs/linux-g++ -isystem /usr/include/qt5/QtOpenGL -isystem /usr/include/qt5/QtNetwork -isystem /usr/include/libevdev-1.0 -O3 -DNDEBUG -std=c++17 -fPIC -MD -MT src/qt/CMakeFiles/ui.dir/xkbcommon_keyboard.cpp.o -MF src/qt/CMakeFiles/ui.dir/xkbcommon_keyboard.cpp.o.d -o src/qt/CMakeFiles/ui.dir/xkbcommon_keyboard.cpp.o -c /home/rderooy/src/github/86Box/src/qt/xkbcommon_keyboard.cpp
/home/rderooy/src/github/86Box/src/qt/xkbcommon_keyboard.cpp:18:10: fatal error: xkbcommon/xkbcommon-x11.h: No such file or directory
   18 | #include <xkbcommon/xkbcommon-x11.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.

```
