### PR TITLE
viso: Make sure to close file descriptors 

### DIFF
--- a/src/cdrom/cdrom_image_backend.c
+++ b/src/cdrom/cdrom_image_backend.c
@@ -159,7 +159,15 @@ bin_init(const char *filename, int *error)
         tf->get_length = bin_get_length;
         tf->close      = bin_close;
     } else {
-        free(tf);
+        /* From the check above, error may still be non-zero if opening a directory.
+         * The error is set for viso to try and open the directory following this function.
+         * However, we need to make sure the descriptor is closed. */
+        if ((tf->file != NULL) && ((stats.st_mode & S_IFMT) == S_IFDIR)) {
+            /* tf is freed by bin_close */
+            bin_close(tf);
+        } else {
+            free(tf);
+        }
         tf = NULL;
     }
 


### PR DESCRIPTION
Summary
=======
tldr: `bin_init` (`cdrom_image_backend.c`) calls `plat_fopen64` and doesn't close the handle when it detects a directory.

Some more details:

```c
tf->file = plat_fopen64(tf->fn, "rb");
```

`tf->fn` is the directory name for the viso mount. This open succeeds even though it is a directory (Opening a directory is a valid operation). 

However, the next part includes a check to see if it is a directory. If so, it sets `error` to 1. The problem here is that `error` is 1 because of the dir check (this is normal operation and causes viso to kick in following this function). But the error action taken in the `else` assumes a more serious error. It wipes out `tf` and just returns.

This leaves the directory open that was opened in `plat_fopen64` above - at least until 86box closes.

The fix just makes sure to close the descriptor in this case (target is a directory *and* exists).

cc @richardg867 for review re: viso 

Checklist
=========
* [X] Closes #3194


References
==========
N/A
