### PR TITLE
386_common: Handle IOPB segment limit corner case more like the old code

### DIFF
--- a/src/cpu/386_common.c
+++ b/src/cpu/386_common.c
@@ -1053,13 +1053,13 @@ enter_smm(int in_hlt)
 
     memset(saved_state, 0x00, SMM_SAVE_STATE_MAP_SIZE * sizeof(uint32_t));
 
-    if (is_cxsmm) /* Cx6x86 */
+    if (is_cxsmm)                    /* Cx6x86 */
         smram_save_state_cyrix(saved_state, in_hlt);
     else if (is_pentium || is_am486) /* Am486 / 5x86 / Intel P5 (Pentium) */
         smram_save_state_p5(saved_state, in_hlt);
-    else if (is_k5 || is_k6) /* AMD K5 and K6 */
+    else if (is_k5 || is_k6)         /* AMD K5 and K6 */
         smram_save_state_amd_k(saved_state, in_hlt);
-    else if (is_p6) /* Intel P6 (Pentium Pro, Pentium II, Celeron) */
+    else if (is_p6)                  /* Intel P6 (Pentium Pro, Pentium II, Celeron) */
         smram_save_state_p6(saved_state, in_hlt);
 
     cr0 &= ~0x8000000d;
@@ -1224,13 +1224,13 @@ leave_smm(void)
     }
 
     x386_common_log("New SMBASE: %08X (%08X)\n", saved_state[SMRAM_FIELD_P5_SMBASE_OFFSET], saved_state[66]);
-    if (is_cxsmm) /* Cx6x86 */
+    if (is_cxsmm)                    /* Cx6x86 */
         smram_restore_state_cyrix(saved_state);
     else if (is_pentium || is_am486) /* Am486 / 5x86 / Intel P5 (Pentium) */
         smram_restore_state_p5(saved_state);
-    else if (is_k5 || is_k6) /* AMD K5 and K6 */
+    else if (is_k5 || is_k6)         /* AMD K5 and K6 */
         smram_restore_state_amd_k(saved_state);
-    else if (is_p6) /* Intel P6 (Pentium Pro, Pentium II, Celeron) */
+    else if (is_p6)                  /* Intel P6 (Pentium Pro, Pentium II, Celeron) */
         smram_restore_state_p6(saved_state);
 
     in_smm = 0;
@@ -1429,24 +1429,27 @@ x86illegal(void)
 int
 checkio(uint32_t port, int mask)
 {
-    uint16_t t;
+    uint32_t t;
 
     cpl_override = 1;
     t            = readmemw(tr.base, 0x66);
 
-    if (cpu_state.abrt) {
+    if (UNLIKELY(cpu_state.abrt)) {
         cpl_override = 0;
         return 0;
     }
 
-    if ((t + (port >> 3UL) + 1) > tr.limit) {
-        cpl_override = 0;
-        return mask;
+    t += (port >> 3UL);
+    mask <<= (port & 7);
+    if (UNLIKELY(mask & 0xff00)) {
+        if (LIKELY(t < tr.limit))
+            mask &= readmemwl(tr.base + t);
+    } else {
+        if (LIKELY(t <= tr.limit))
+            mask &= readmembl(tr.base + t);
     }
-
-    t            = readmemwl(tr.base + t + (port >> 3));
     cpl_override = 0;
-    return (t >> (port & 7)) & mask;
+    return mask;
 }
 
 #ifdef OLD_DIVEXCP

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -55,6 +55,14 @@
 #define BCD16(x)  ((((x) / 1000) << 12) | (((x) / 100) << 8) | BCD8(x))
 #define BCD32(x)  ((((x) / 10000000) << 28) | (((x) / 1000000) << 24) | (((x) / 100000) << 20) | (((x) / 10000) << 16) | BCD16(x))
 
+#if defined(__GNUC__) || defined(__clang__)
+#    define UNLIKELY(x) __builtin_expect((x), 0)
+#    define LIKELY(x)   __builtin_expect((x), 1)
+#else
+#    define UNLIKELY(x) (x)
+#    define LIKELY(x)   (x)
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Summary
=======
The qemu code always checks task segment limits for and reads a word, which creates a corner case if an I/O port is in the last IOPB byte allowed by the segment limit. This new code is based on v86 and should behave more like the old byte-by-byte check.

The behavior of a real CPU remains unknown.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://github.com/copy/v86/blob/38a103c56b0ef83cca4e1723bd723b3ffe471dbe/src/rust/cpu/cpu.rs#L2762