### PR TITLE
qt: Destroy existing Direct3D 9 devices if it exists

### DIFF
--- a/src/qt/qt_d3d9renderer.cpp
+++ b/src/qt/qt_d3d9renderer.cpp
@@ -24,11 +24,16 @@ D3D9Renderer::D3D9Renderer(QWidget *parent, int monitor_index)
 
     windowHandle = (HWND) winId();
     surfaceInUse = true;
+    finalized = true;
 
     RendererCommon::parentWidget = parent;
 
     this->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     this->m_monitor_index = monitor_index;
+
+    d3d9surface = nullptr;
+    d3d9dev = nullptr;
+    d3d9 = nullptr;
 }
 
 D3D9Renderer::~D3D9Renderer()
@@ -67,6 +72,7 @@ D3D9Renderer::hideEvent(QHideEvent *event)
 void
 D3D9Renderer::showEvent(QShowEvent *event)
 {
+    if (d3d9) finalize();
     params = {};
 
     if (FAILED(Direct3DCreate9Ex(D3D_SDK_VERSION, &d3d9))) {


### PR DESCRIPTION
Summary
=======
qt: Destroy existing Direct3D 9 devices if it exists

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
