### PR TITLE
Add macbox to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ It is also recommended to use a manager application with 86Box for easier handli
 * [86Box Manager](https://github.com/86Box/86BoxManager) by [Overdoze](https://github.com/daviunic) (Windows only)
 * [86Box Manager Lite](https://github.com/insanemal/86box_manager_py) by [Insanemal](https://github.com/insanemal)
 * [WinBox for 86Box](https://github.com/86Box/WinBox-for-86Box) by Laci bá' (Windows only)
+* [MacBox for 86Box](https://github.com/Moonif/MacBox) by [Moonif](https://github.com/Moonif) (MacOs only)
 
 It is also possible to use 86Box on its own with the `--vmpath`/`-P` command line option.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It is also recommended to use a manager application with 86Box for easier handli
 * [86Box Manager](https://github.com/86Box/86BoxManager) by [Overdoze](https://github.com/daviunic) (Windows only)
 * [86Box Manager Lite](https://github.com/insanemal/86box_manager_py) by [Insanemal](https://github.com/insanemal)
 * [WinBox for 86Box](https://github.com/86Box/WinBox-for-86Box) by Laci bá' (Windows only)
-* [MacBox for 86Box](https://github.com/Moonif/MacBox) by [Moonif](https://github.com/Moonif) (MacOs only)
+* [MacBox for 86Box](https://github.com/Moonif/MacBox) by [Moonif](https://github.com/Moonif) (MacOS only)
 
 It is also possible to use 86Box on its own with the `--vmpath`/`-P` command line option.
 


### PR DESCRIPTION
Summary
=======
Update README.md to add info about MacBox - for 86Box users who use MacOS.
