### PR TITLE
Fix build by adding pic.h include in sis_85c50x.c

### DIFF
--- a/src/chipset/sis_85c50x.c
+++ b/src/chipset/sis_85c50x.c
@@ -30,6 +30,7 @@
 
 #include <86box/apm.h>
 #include <86box/machine.h>
+#include <86box/pic.h>
 #include <86box/mem.h>
 #include <86box/smram.h>
 #include <86box/pci.h>


### PR DESCRIPTION
Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
