### PR TITLE
OHCI: HcHCCA's lower 8 bits are always zero

### DIFF
--- a/src/include/86box/usb.h
+++ b/src/include/86box/usb.h
@@ -22,6 +22,7 @@
 extern "C" {
 #endif
 
+/* USB Host Controller device struct */
 typedef struct
 {
     uint8_t       uhci_io[32], ohci_mmio[4096];
@@ -30,6 +31,13 @@ typedef struct
     uint32_t      ohci_mem_base;
     mem_mapping_t ohci_mmio_mapping;
 } usb_t;
+
+/* USB endpoint device struct. Incomplete and unused. */
+typedef struct
+{
+    uint16_t vendor_id;
+    uint16_t device_id;
+} usb_device_t;
 
 /* Global variables. */
 extern const device_t usb_device;

--- a/src/usb.c
+++ b/src/usb.c
@@ -208,6 +208,8 @@ ohci_mmio_write(uint32_t addr, uint8_t val, void *p)
                 val &= ~0x01;
             }
             break;
+        case OHCI_HcHCCA:
+            return;
         case OHCI_HcInterruptStatus:
             dev->ohci_mmio[addr] &= ~(val & 0x7f);
             return;


### PR DESCRIPTION
Summary
=======
OHCI: HcHCCA's lower 8 bits are always zero

Start of work on USB endpoint device infrastructure

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
