### PR TITLE
usb: Port reset logic is now on a timer

### DIFF
--- a/src/include/86box/usb.h
+++ b/src/include/86box/usb.h
@@ -39,6 +39,8 @@ typedef struct usb_t
     int           uhci_enable, ohci_enable;
     uint32_t      ohci_mem_base;
     mem_mapping_t ohci_mmio_mapping;
+    pc_timer_t    ohci_frame_timer;
+    pc_timer_t    ohci_port_reset_timer[2];
 
     usb_params_t* usb_params;
 } usb_t;


### PR DESCRIPTION
Summary
=======
usb: Port reset logic is now on a timer

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
