### PR TITLE
Fix some variant type comparisons

### DIFF
--- a/src/cpu/808x.c
+++ b/src/cpu/808x.c
@@ -440,10 +440,10 @@ pfq_write(void)
 static uint8_t
 pfq_read(void)
 {
-    uint8_t temp, i;
+    uint8_t temp;
 
     temp = pfq[0];
-    for (i = 0; i < (pfq_size - 1); i++)
+    for (int i = 0; i < (pfq_size - 1); i++)
         pfq[i] = pfq[i + 1];
     pfq_pos--;
     cpu_state.pc = (cpu_state.pc + 1) & 0xffff;

--- a/src/floppy/fdd_86f.c
+++ b/src/floppy/fdd_86f.c
@@ -2550,7 +2550,7 @@ uint16_t
 d86f_prepare_pretrack(int drive, int side, int iso)
 {
     d86f_t  *dev = d86f[drive];
-    uint16_t i, pos;
+    uint16_t pos;
     int      mfm;
     int      real_gap0_len;
     int      sync_len;
@@ -2575,22 +2575,22 @@ d86f_prepare_pretrack(int drive, int side, int iso)
 
     d86f_destroy_linked_lists(drive, side);
 
-    for (i = 0; i < raw_size; i++)
+    for (uint32_t i = 0; i < raw_size; i++)
         d86f_write_direct_common(drive, side, gap_fill, 0, i);
 
     pos = 0;
 
     if (!iso) {
-        for (i = 0; i < real_gap0_len; i++) {
+        for (int i = 0; i < real_gap0_len; i++) {
             d86f_write_direct_common(drive, side, gap_fill, 0, pos);
             pos = (pos + 1) % raw_size;
         }
-        for (i = 0; i < sync_len; i++) {
+        for (int i = 0; i < sync_len; i++) {
             d86f_write_direct_common(drive, side, 0, 0, pos);
             pos = (pos + 1) % raw_size;
         }
         if (mfm) {
-            for (i = 0; i < 3; i++) {
+            for (uint8_t i = 0; i < 3; i++) {
                 d86f_write_direct_common(drive, side, 0x2452, 1, pos);
                 pos = (pos + 1) % raw_size;
             }
@@ -2600,7 +2600,7 @@ d86f_prepare_pretrack(int drive, int side, int iso)
         pos = (pos + 1) % raw_size;
     }
 
-    for (i = 0; i < real_gap1_len; i++) {
+    for (int i = 0; i < real_gap1_len; i++) {
         d86f_write_direct_common(drive, side, gap_fill, 0, pos);
         pos = (pos + 1) % raw_size;
     }

--- a/src/sound/snd_adlibgold.c
+++ b/src/sound/snd_adlibgold.c
@@ -842,7 +842,6 @@ static void
 adgold_input_msg(void *p, uint8_t *msg, uint32_t len)
 {
     adgold_t *adgold = (adgold_t *) p;
-    uint8_t   i;
 
     if (adgold->sysex)
         return;
@@ -850,7 +849,7 @@ adgold_input_msg(void *p, uint8_t *msg, uint32_t len)
     if (adgold->uart_in) {
         adgold->adgold_mma_status |= 0x04;
 
-        for (i = 0; i < len; i++) {
+        for (uint32_t i = 0; i < len; i++) {
             adgold->midi_queue[adgold->midi_w++] = msg[i];
             adgold->midi_w &= 0x0f;
         }

--- a/src/sound/snd_audiopci.c
+++ b/src/sound/snd_audiopci.c
@@ -1969,9 +1969,8 @@ static void
 es1371_input_msg(void *p, uint8_t *msg, uint32_t len)
 {
     es1371_t *dev = (es1371_t *) p;
-    uint8_t   i;
 
-    for (i = 0; i < len; i++)
+    for (uint32_t i = 0; i < len; i++)
         es1371_write_fifo(dev, msg[i]);
 }
 

--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -1085,7 +1085,6 @@ static void
 gus_input_msg(void *p, uint8_t *msg, uint32_t len)
 {
     gus_t  *gus = (gus_t *) p;
-    uint8_t i;
 
     if (gus->sysex)
         return;
@@ -1093,7 +1092,7 @@ gus_input_msg(void *p, uint8_t *msg, uint32_t len)
     if (gus->uart_in) {
         gus->midi_status |= MIDI_INT_RECEIVE;
 
-        for (i = 0; i < len; i++) {
+        for (uint32_t i = 0; i < len; i++) {
             gus->midi_queue[gus->midi_w++] = msg[i];
             gus->midi_w &= 63;
         }

--- a/src/sound/snd_sb_dsp.c
+++ b/src/sound/snd_sb_dsp.c
@@ -1055,7 +1055,6 @@ void
 sb_dsp_input_msg(void *p, uint8_t *msg, uint32_t len)
 {
     sb_dsp_t *dsp = (sb_dsp_t *) p;
-    uint8_t   i   = 0;
 
     sb_dsp_log("MIDI in sysex = %d, uart irq = %d, msg = %d\n", dsp->midi_in_sysex, dsp->uart_irq, len);
 
@@ -1068,11 +1067,11 @@ sb_dsp_input_msg(void *p, uint8_t *msg, uint32_t len)
         return;
 
     if (dsp->uart_irq) {
-        for (i = 0; i < len; i++)
+        for (uint32_t i = 0; i < len; i++)
             sb_add_data(dsp, msg[i]);
         sb_irq(dsp, 1);
     } else if (dsp->midi_in_poll) {
-        for (i = 0; i < len; i++)
+        for (uint32_t i = 0; i < len; i++)
             sb_add_data(dsp, msg[i]);
     }
 }

--- a/src/video/vid_ht216.c
+++ b/src/video/vid_ht216.c
@@ -1347,7 +1347,7 @@ ht216_read_common(ht216_t *ht216, uint32_t addr)
         temp = 0xff;
 
         for (pixel = 0; pixel < 8; pixel++) {
-            for (plane = 0; plane < (1 << count); plane++) {
+            for (plane = 0; plane < (uint8_t)(1 << count); plane++) {
                 if (svga->colournocare & (1 << plane)) {
                     /* If we care about a plane, and the pixel has a mismatch on it, clear its bit. */
                     if (((svga->latch.b[plane] >> pixel) & 1) != ((svga->colourcompare >> plane) & 1))


### PR DESCRIPTION
Summary
=======
Several loops compared narrow with wide types, this is usually a bad idea.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
