### PR TITLE
Make codeql check more of the code

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,5 @@
+name: "86Box CodeQL config"
+
+queries:
+  - uses: security-extended
+#  - uses: security-and-quality

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -91,7 +91,10 @@ jobs:
             openal:p
             rtmidi:p
             libvncserver:p
-      - uses: actions/checkout@v3
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: make
         run: >-
           make -fwin/Makefile.mingw -j
@@ -101,7 +104,9 @@ jobs:
           CLANG=${{ matrix.environment.clang }}
           X64=${{ matrix.environment.x64 }}
         working-directory: ./src
-      - uses: actions/upload-artifact@v3
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
         with:
           name: '86Box${{ matrix.dynarec.slug }}${{ matrix.build.slug }}-Windows-${{ matrix.environment.msystem }}-gha${{ github.run_number }}'
           path: src/86Box.exe

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,6 +24,7 @@ on:
       - "!**/Makefile*"
 
 jobs:
+
   msys2:
     name: "Windows MSYS2 (${{ matrix.ui.name }}, ${{ matrix.build.name }}, ${{ matrix.dynarec.name }}, ${{ matrix.environment.msystem }})"
 
@@ -102,7 +103,10 @@ jobs:
             rtmidi:p
             libvncserver:p
             ${{ matrix.ui.packages }}
-      - uses: actions/checkout@v3
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Configure CMake
         run: >-
           cmake -G Ninja -S . -B build --preset ${{ matrix.build.preset }}
@@ -111,11 +115,15 @@ jobs:
           -D CMAKE_INSTALL_PREFIX=./build/artifacts
           -D QT=${{ matrix.ui.qt }}
           -D STATIC_BUILD=${{ matrix.ui.static }}
+
       - name: Build
         run: cmake --build build
+
       - name: Generate package
         run: cmake --install build
-      - uses: actions/upload-artifact@v3
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
         with:
           name: '86Box${{ matrix.ui.slug }}${{ matrix.dynarec.slug }}${{ matrix.build.slug }}-Windows-${{ matrix.environment.msystem }}-gha${{ github.run_number }}'
           path: build/artifacts/**
@@ -177,12 +185,15 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{ matrix.target.vcvars }}
+
       - name: Add LLVM to path
         run: echo "C:/Program Files/LLVM/bin" >> $env:GITHUB_PATH
+
       - name: Download Ninja
         run: >
           Invoke-WebRequest https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-win.zip -OutFile ninja-win.zip && 
           Expand-Archive ninja-win.zip -DestinationPath .
+
       - name: Setup NuGet Credentials
         run: >
           & (C:/vcpkg/vcpkg fetch nuget | tail -n 2)
@@ -192,9 +203,13 @@ jobs:
           -name "GitHub"
           -username "86Box"
           -password "${{ secrets.GITHUB_TOKEN }}"
+
       - name: Fix MSVC atomic headers
         run: dir "C:/Program Files/Microsoft Visual Studio/2022/*/VC/Tools/MSVC/*/include" -include stdatomic.h -recurse | del
-      - uses: actions/checkout@v3
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Configure CMake
         run: >
           cmake -G Ninja -S . -B build --preset ${{ matrix.build.preset }}
@@ -205,19 +220,25 @@ jobs:
           -D VCPKG_TARGET_TRIPLET=${{ matrix.target.triplet }}
           -D VCPKG_HOST_TRIPLET=x64-windows
           -D VCPKG_USE_HOST_TOOLS=ON
+
       - name: Fix Qt
         if: matrix.ui.qt == 'on'
         run: |
          $qtTargetsPath = "${{ github.workspace }}/build/vcpkg_installed/${{ matrix.target.triplet }}/share/Qt6/Qt6Targets.cmake"
          (Get-Content $qtTargetsPath) -replace "^.*-Zc:__cplusplus;-permissive-.*$","#$&" | Set-Content $qtTargetsPath
+
       - name: Reconfigure CMake
         if: matrix.ui.qt == 'on'
         run: cmake clean build
+
       - name: Build
         run: cmake --build build
+
       - name: Generate package
         run: cmake --install build
-      - uses: actions/upload-artifact@v3
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
         with:
           name: '86Box${{ matrix.ui.slug }}${{ matrix.dynarec.slug }}${{ matrix.build.slug }}-Windows-LLVM-${{ matrix.target.name }}-gha${{ github.run_number }}'
           path: build/artifacts/**
@@ -271,7 +292,10 @@ jobs:
           libopenal-dev
           libvncserver-dev
           ${{ matrix.ui.packages }}
-      - uses: actions/checkout@v3
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Configure CMake
         run: >-
           cmake -G Ninja -S . -B build --preset ${{ matrix.build.preset }}
@@ -279,11 +303,15 @@ jobs:
           -D NEW_DYNAREC=${{ matrix.dynarec.new }}
           -D CMAKE_INSTALL_PREFIX=./build/artifacts
           -D QT=${{ matrix.ui.qt }}
+
       - name: Build
         run: cmake --build build
+
       - name: Generate package
         run: cmake --install build
-      - uses: actions/upload-artifact@v3
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
         with:
           name: '86Box${{ matrix.ui.slug }}${{ matrix.dynarec.slug }}${{ matrix.build.slug }}-UbuntuJammy-x86_64-gha${{ github.run_number }}'
           path: build/artifacts/**
@@ -331,7 +359,10 @@ jobs:
           openal-soft
           libvncserver
           ${{ matrix.ui.packages }}
-      - uses: actions/checkout@v3
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Configure CMake
         run: >-
           cmake -G Ninja -S . -B build --preset ${{ matrix.build.preset }}
@@ -342,11 +373,15 @@ jobs:
           -D Qt5_ROOT=$(brew --prefix qt@5)
           -D Qt5LinguistTools_ROOT=$(brew --prefix qt@5)
           -D OpenAL_ROOT=$(brew --prefix openal-soft)
+
       - name: Build
         run: cmake --build build
+
       - name: Generate package
         run: cmake --install build
-      - uses: actions/upload-artifact@v3
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
         with:
           name: '86Box${{ matrix.ui.slug }}${{ matrix.dynarec.slug }}${{ matrix.build.slug }}-macOS-x86_64-gha${{ github.run_number }}'
           path: build/artifacts/**

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-name: "CodeQL"
+name: CodeQL
 
 on:
 
@@ -24,10 +24,124 @@ on:
       - "!**/Makefile*"
 
 jobs:
-  analyze:
-    name: Analyze
 
-    runs-on: ubuntu-latest
+  analyze-msys2:
+    name: "Analyze Windows MSYS2 (${{ matrix.ui.name }}, ${{ matrix.build.name }}, ${{ matrix.dynarec.name }}, ${{ matrix.environment.msystem }})"
+
+    runs-on: windows-2022
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    strategy:
+      fail-fast: true
+      matrix:
+        language: [ 'cpp' ]
+        build:
+#          - name: Regular
+#            preset: regular
+#          - name: Debug
+#            preset: debug
+#            slug: -Debug
+          - name: Dev
+            preset: experimental
+            slug: -Dev
+        dynarec:
+          - name: ODR
+            new: off
+            slug: -ODR
+          - name: NDR
+            new: on
+            slug: -NDR
+        ui:
+          - name: Win32 GUI
+            qt: off
+            static: on
+          - name: Qt GUI
+            qt: on
+            static: off
+            slug: -Qt
+            packages: >-
+              qt5-base:p
+              qt5-tools:p
+        environment:
+#          - msystem: MSYS
+#            toolchain: ./cmake/flags-gcc-x86_64.cmake
+          - msystem: MINGW32
+            prefix: mingw-w64-i686
+            toolchain: ./cmake/flags-gcc-i686.cmake
+          - msystem: MINGW64
+            prefix: mingw-w64-x86_64
+            toolchain: ./cmake/flags-gcc-x86_64.cmake
+#          - msystem: CLANG32
+#            prefix: mingw-w64-clang-i686
+#            toolchain: ./cmake/llvm-win32-i686.cmake
+#          - msystem: CLANG64
+#            prefix: mingw-w64-clang-x86_64
+#            toolchain: ./cmake/llvm-win32-x86_64.cmake
+          - msystem: UCRT64
+            prefix: mingw-w64-ucrt-x86_64
+            toolchain: ./cmake/flags-gcc-x86_64.cmake
+
+    steps:
+      - name: Prepare MSYS2 environment
+        uses: msys2/setup-msys2@v2
+        with:
+          release: false
+          update: true
+          msystem: ${{ matrix.environment.msystem }}
+          pacboy: >-
+            ninja:p
+            cmake:p
+            gcc:p
+            pkgconf:p
+            freetype:p
+            SDL2:p
+            zlib:p
+            libpng:p
+            openal:p
+            rtmidi:p
+            libvncserver:p
+            ${{ matrix.ui.packages }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Configure CMake
+        run: >-
+          cmake -G Ninja -S . -B build --preset ${{ matrix.build.preset }}
+          --toolchain ${{ matrix.environment.toolchain }}
+          -D NEW_DYNAREC=${{ matrix.dynarec.new }}
+          -D CMAKE_INSTALL_PREFIX=./build/artifacts
+          -D QT=${{ matrix.ui.qt }}
+          -D STATIC_BUILD=${{ matrix.ui.static }}
+
+      - name: Build
+        run: cmake --build build
+
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{matrix.language}}"
+
+  analyze-linux:
+
+    name: "Analyze Linux GCC 11 (${{ matrix.ui.name }}, ${{ matrix.build.name }}, ${{ matrix.dynarec.name }}, x86_64)"
+
+    runs-on: ubuntu-22.04
 
     permissions:
       actions: read
@@ -35,9 +149,35 @@ jobs:
       security-events: write
 
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         language: [ 'cpp' ]
+        build:
+#          - name: Regular
+#            preset: regular
+#          - name: Debug
+#            preset: debug
+#            slug: -Debug
+          - name: Dev
+            preset: experimental
+            slug: -Dev
+        dynarec:
+          - name: ODR
+            new: off
+            slug: -ODR
+          - name: NDR
+            new: on
+            slug: -NDR
+        ui:
+          - name: Qt GUI
+            qt: on
+            slug: -Qt
+            packages: >-
+              qtbase5-dev
+              qtbase5-private-dev
+              qttools5-dev
+              libevdev-dev
+              libxkbcommon-x11-dev
 
     steps:
       - name: Install dependencies
@@ -50,10 +190,9 @@ jobs:
           libpng-dev
           libc6-dev
           librtmidi-dev
-          qtbase5-dev
-          qttools5-dev
           libopenal-dev
           libvncserver-dev
+          ${{ matrix.ui.packages }}
 
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -62,9 +201,96 @@ jobs:
         uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+      - name: Configure CMake
+        run: >-
+          cmake -G Ninja -S . -B build --preset ${{ matrix.build.preset }}
+          --toolchain ./cmake/flags-gcc-x86_64.cmake
+          -D NEW_DYNAREC=${{ matrix.dynarec.new }}
+          -D CMAKE_INSTALL_PREFIX=./build/artifacts
+          -D QT=${{ matrix.ui.qt }}
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{matrix.language}}"
+
+  analyze-macos11:
+    name: "Analyze macOS 11 (${{ matrix.ui.name }}, ${{ matrix.build.name }}, ${{ matrix.dynarec.name }}, x86_64)"
+
+    runs-on: macos-11
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: true
+      matrix:
+        language: [ 'cpp' ]
+        build:
+#          - name: Regular
+#            preset: regular
+#          - name: Debug
+#            preset: debug
+#            slug: -Debug
+          - name: Dev
+            preset: experimental
+            slug: -Dev
+        dynarec:
+          - name: ODR
+            new: off
+            slug: -ODR
+          - name: NDR
+            new: on
+            slug: -NDR
+        ui:
+          - name: Qt GUI
+            qt: on
+            slug: -Qt
+            packages: >-
+              qt@5
+
+    steps:
+      - name: Install dependencies
+        run: >-
+          brew install
+          ninja
+          freetype
+          sdl2
+          libpng
+          rtmidi
+          openal-soft
+          libvncserver
+          ${{ matrix.ui.packages }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Configure CMake
+        run: >-
+          cmake -G Ninja -S . -B build --preset ${{ matrix.build.preset }}
+          --toolchain ./cmake/flags-gcc-x86_64.cmake
+          -D NEW_DYNAREC=${{ matrix.dynarec.new }}
+          -D CMAKE_INSTALL_PREFIX=./build/artifacts
+          -D QT=${{ matrix.ui.qt }}
+          -D Qt5_ROOT=$(brew --prefix qt@5)
+          -D Qt5LinguistTools_ROOT=$(brew --prefix qt@5)
+          -D OpenAL_ROOT=$(brew --prefix openal-soft)
+
+      - name: Build
+        run: cmake --build build
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Summary
=======
Expands codeql checks to security-extended
Also checks win32 and macos builds
checks dev instead of regular builds for more complete coverage

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
