### PR TITLE
usb: Add infrastructure for interrupt descriptor polling

### DIFF
--- a/src/include/86box/usb.h
+++ b/src/include/86box/usb.h
@@ -40,7 +40,9 @@ typedef struct usb_t
     uint32_t      ohci_mem_base;
     mem_mapping_t ohci_mmio_mapping;
     pc_timer_t    ohci_frame_timer;
+    pc_timer_t    ohci_interrupt_desc_poll_timer;
     pc_timer_t    ohci_port_reset_timer[2];
+    uint8_t       ohci_interrupt_counter : 5;
 
     usb_params_t* usb_params;
 } usb_t;

--- a/src/usb.c
+++ b/src/usb.c
@@ -196,6 +196,17 @@ ohci_update_frame_counter(void* priv)
 }
 
 void
+ohci_poll_interrupt_descriptors(void* priv)
+{
+    usb_t *dev = (usb_t *) priv;
+
+    /* TODO: Actually poll the interrupt descriptors. */
+
+    dev->ohci_interrupt_counter++;
+    timer_on_auto(&dev->ohci_interrupt_desc_poll_timer, 1000.);
+}
+
+void
 ohci_port_reset_callback(void* priv)
 {
     usb_t *dev = (usb_t *) priv;
@@ -470,6 +481,7 @@ usb_init_ext(const device_t *info, void* params)
     timer_add(&dev->ohci_frame_timer, ohci_update_frame_counter, dev, 0); /* Unused for now, to be used for frame counting. */
     timer_add(&dev->ohci_port_reset_timer[0], ohci_port_reset_callback, dev, 0);
     timer_add(&dev->ohci_port_reset_timer[1], ohci_port_reset_callback_2, dev, 0);
+    timer_add(&dev->ohci_interrupt_desc_poll_timer, ohci_poll_interrupt_descriptors, dev, 0);
     usb_reset(dev);
 
     return dev;


### PR DESCRIPTION
Summary
=======
usb: Add infrastructure for interrupt descriptor polling

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
