### PR TITLE
usb: Hook up USB interrupts to rest of the chipsets

### DIFF
--- a/src/chipset/intel_piix.c
+++ b/src/chipset/intel_piix.c
@@ -77,6 +77,7 @@ typedef struct _piix_ {
     piix_io_trap_t io_traps[26];
     port_92_t     *port_92;
     pc_timer_t     fast_off_timer;
+    usb_params_t   usb_params;
 } piix_t;
 
 #ifdef ENABLE_PIIX_LOG
@@ -1426,6 +1427,14 @@ piix_fast_off_count(void *priv)
 }
 
 static void
+piix_usb_raise_interrupt(usb_t* usb, void *priv)
+{
+    piix_t *dev = (piix_t *) priv;
+
+    pci_set_irq(dev->pci_slot, PCI_INTD);
+}
+
+static void
 piix_reset(void *p)
 {
     piix_t *dev = (piix_t *) p;
@@ -1569,8 +1578,12 @@ piix_init(const device_t *info)
         sff_set_irq_mode(dev->bm[1], 1, 2);
     }
 
-    if (dev->type >= 3)
-        dev->usb = device_add(&usb_device);
+    if (dev->type >= 3) {
+        dev->usb_params.parent_priv     = dev;
+        dev->usb_params.smi_handle      = NULL;
+        dev->usb_params.raise_interrupt = piix_usb_raise_interrupt;
+        dev->usb                        = device_add_parameters(&usb_device, &dev->usb_params);
+    }
 
     if (dev->type > 3) {
         dev->nvr   = device_add(&piix4_nvr_device);

--- a/src/chipset/stpc.c
+++ b/src/chipset/stpc.c
@@ -65,7 +65,11 @@ typedef struct stpc_t {
     smram_t    *smram;
     usb_t      *usb;
     int         ide_slot;
+    int         usb_slot;
     sff8038i_t *bm[2];
+
+    /* Miscellaneous */
+    usb_params_t usb_params;
 } stpc_t;
 
 typedef struct stpc_serial_t {
@@ -871,6 +875,14 @@ stpc_setup(stpc_t *dev)
 }
 
 static void
+stpc_usb_raise_interrupt(usb_t* usb, void* priv)
+{
+    stpc_t *dev = (stpc_t *) priv;
+
+    pci_set_irq(dev->usb_slot, PCI_INTA);
+}
+
+static void
 stpc_close(void *priv)
 {
     stpc_t *dev = (stpc_t *) priv;
@@ -895,9 +907,13 @@ stpc_init(const device_t *info)
     pci_add_card(PCI_ADD_NORTHBRIDGE, stpc_nb_read, stpc_nb_write, dev);
     dev->ide_slot = pci_add_card(PCI_ADD_SOUTHBRIDGE, stpc_isab_read, stpc_isab_write, dev);
     if (dev->local == STPC_ATLAS) {
+        dev->usb_params.smi_handle      = NULL;
+        dev->usb_params.raise_interrupt = stpc_usb_raise_interrupt;
+        dev->usb_params.parent_priv     = dev;
+
         dev->ide_slot = pci_add_card(PCI_ADD_SOUTHBRIDGE, stpc_ide_read, stpc_ide_write, dev);
-        dev->usb      = device_add(&usb_device);
-        pci_add_card(PCI_ADD_SOUTHBRIDGE, stpc_usb_read, stpc_usb_write, dev);
+        dev->usb      = device_add_parameters(&usb_device, &dev->usb_params);
+        dev->usb_slot = pci_add_card(PCI_ADD_SOUTHBRIDGE, stpc_usb_read, stpc_usb_write, dev);
     }
 
     dev->bm[0] = device_add_inst(&sff8038i_device, 1);

--- a/src/include/86box/usb.h
+++ b/src/include/86box/usb.h
@@ -82,6 +82,8 @@ typedef struct
     uint8_t (*device_out)(void* priv, uint8_t* data, uint32_t len);
     /* Process setup packets. */
     uint8_t (*device_setup)(void* priv, uint8_t* data);
+    /* Device reset */
+    void (*device_reset)(void* priv);
 
     void* priv;
 } usb_device_t;


### PR DESCRIPTION
Summary
=======
usb: Hook up USB interrupts to rest of the chipsets

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
