### PR TITLE
usb: More work on frame timing and events

### DIFF
--- a/src/chipset/ali1543.c
+++ b/src/chipset/ali1543.c
@@ -1430,7 +1430,7 @@ ali7101_read(int func, int addr, void *priv)
 }
 
 static void
-ali5237_usb_raise_interrupt(void *priv)
+ali5237_usb_raise_interrupt(usb_t* usb, void *priv)
 {
     ali1543_t *dev = (ali1543_t *) priv;
 

--- a/src/include/86box/usb.h
+++ b/src/include/86box/usb.h
@@ -36,7 +36,13 @@ typedef struct
 /* USB Host Controller device struct */
 typedef struct usb_t
 {
-    uint8_t       uhci_io[32], ohci_mmio[4096];
+    union
+    {
+        uint8_t  ohci_mmio[4096];
+        uint16_t ohci_mmio_w[2048];
+        uint32_t ohci_mmio_l[1024];
+    };
+    uint8_t       uhci_io[32];
     uint16_t      uhci_io_base;
     int           uhci_enable, ohci_enable;
     uint32_t      ohci_mem_base;


### PR DESCRIPTION
Summary
=======
usb: More work on frame timing and events

I should be getting close to implementing HCCA read/write and transfer/endpoint descriptor parsing.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
