### PR TITLE
Fix: Load the interface list even if PCAP is not selected

### DIFF
--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -857,6 +857,9 @@ MediaMenu::nicUpdateMenu(int i)
         case NET_TYPE_PCAP:
             netType = "PCAP";
             break;
+        case NET_TYPE_VDE:
+            netType = "VDE";
+            break;
     }
 
     QString devName = DeviceConfig::DeviceName(network_card_getdevice(net_cards_conf[i].device_num), network_card_get_internal_name(net_cards_conf[i].device_num), 1);

--- a/src/qt/qt_settingsnetwork.cpp
+++ b/src/qt/qt_settingsnetwork.cpp
@@ -148,7 +148,7 @@ SettingsNetwork::onCurrentMachineChanged(int machineId)
 
         selectedRow = 0;
 
-        if (net_cards_conf[i].net_type == NET_TYPE_PCAP) {
+        if (network_ndev > 0) {
             QString currentPcapDevice = net_cards_conf[i].host_dev_name;
             cbox                      = findChild<QComboBox *>(QString("comboBoxIntf%1").arg(i + 1));
             model                     = cbox->model();
@@ -161,7 +161,8 @@ SettingsNetwork::onCurrentMachineChanged(int machineId)
             }
             model->removeRows(0, removeRows);
             cbox->setCurrentIndex(selectedRow);
-        } else if (net_cards_conf[i].net_type == NET_TYPE_VDE) {
+        }  
+        if (net_cards_conf[i].net_type == NET_TYPE_VDE) {
             QString currentVdeSocket = net_cards_conf[i].host_dev_name;
             auto editline = findChild<QLineEdit *>(QString("socketVDENIC%1").arg(i+1));
             editline->setText(currentVdeSocket);


### PR DESCRIPTION
Summary
=======
Fix: Show the interface list in the network settings dialog when PCAP is not selected at VM startup.
Fix: Show "VDE" when hovering over the status icon for a VDE connected NIC

The vde implementation was bugged. It did not load the interface combo unless NIC was selected at startup. This has been fixed. Also, a cosmetic bug which showed "none" in the status icon when VDE was selected has been addeessed.


Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
