### PR TITLE
vde: Don't fatal() in network driver

### DIFF
--- a/src/network/net_vde.c
+++ b/src/network/net_vde.c
@@ -280,7 +280,7 @@ void *net_vde_init(const netcard_t *card, const uint8_t *mac_addr, void *priv) {
         // TODO: Once there is a solution for the mentioned crash, this should be removed
         // and/or replaced by proper error handling code.
         //-
-        fatal("Could not open the specified VDE socket (%s). Please fix your networking configuration.", socket_name);
+        // fatal("Could not open the specified VDE socket (%s). Please fix your networking configuration.", socket_name);
         // It makes no sense to issue this warning since the program will crash anyway...
         // ui_msgbox_header(MBX_WARNING, (wchar_t *) IDS_2167, (wchar_t *) IDS_2168);
         return NULL;


### PR DESCRIPTION
Summary
=======
Network drivers shouldn't `fatal` during init. Instead, they are supposed to return `NULL` and let the caller take appropriate action.

Once #3326 is merged a vde init failure will automatically fall back to null driver.

Checklist
=========
* [X] I have discussed this with core contributors already


References
==========
N/A
