### PR TITLE
vde: Properly initialize a variable and fix sizing

### DIFF
--- a/src/include/86box/network.h
+++ b/src/include/86box/network.h
@@ -150,9 +150,9 @@ typedef struct {
 } netdev_t;
 
 typedef struct {
-    int has_slirp: 1;
-    int has_pcap: 1;
-    int has_vde:  1;
+    int has_slirp;
+    int has_pcap;
+    int has_vde;
 } network_devmap_t;
 
 

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -123,7 +123,7 @@ netcard_conf_t net_cards_conf[NET_CARD_MAX];
 uint16_t       net_card_current = 0;
 
 /* Global variables. */
-network_devmap_t network_devmap;
+network_devmap_t network_devmap = {0};
 int  network_ndev;
 netdev_t network_devs[NET_HOST_INTF_MAX];
 


### PR DESCRIPTION
Summary
=======
`network_devmap` wasn't being properly initialized to zero. `network_devmap_t` also seems like it was initially supposed to be a bit field but is assigned ints in the code. 

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
