### PR TITLE
Fix PCjr memory steps

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -303,7 +303,7 @@ const machine_t machines[] = {
         .ram = {
             .min = 128,
             .max = 640,
-            .step = 128
+            .step = 64
         },
         .nvrmask = 0,
         .kbc_device = NULL, /* TODO: No specific kbd_device yet */


### PR DESCRIPTION
Summary
=======
Changes memory step on the pcjr from 128k to 64k.

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
