### PR TITLE
Update network drivers to provide error message

### DIFF
--- a/src/include/86box/language.h
+++ b/src/include/86box/language.h
@@ -163,6 +163,8 @@
 #    define IDS_DYNAREC IDS_2163
 #endif
 #define IDS_2166      2166 // "Video card #2 ""%hs"" is not..."
+#define IDS_2167      2167 // "Network driver initialization failed"
+#define IDS_2168      2168 // "The network configuration will be switched to the null driver"
 
 #define IDS_4096      4096 // "Hard disk (%s)"
 #define IDS_4097      4097 // "%01i:%01i"
@@ -271,7 +273,7 @@
 
 #define IDS_LANG_ENUS IDS_7168
 
-#define STR_NUM_2048  118
+#define STR_NUM_2048  120
 // UNUSED: #define STR_NUM_3072  11
 #define STR_NUM_4096 40
 #define STR_NUM_4352 6

--- a/src/include/86box/network.h
+++ b/src/include/86box/network.h
@@ -64,6 +64,9 @@
 #define NET_PERIOD_10M     0.8
 #define NET_PERIOD_100M    0.08
 
+/* Error buffers for network driver init */
+#define NET_DRV_ERRBUF_SIZE 384
+
 enum {
     NET_LINK_DOWN      = (1 << 1),
     NET_LINK_TEMP_DOWN = (1 << 2),
@@ -118,7 +121,7 @@ typedef struct _netcard_t netcard_t;
 
 typedef struct netdrv_t {
     void (*notify_in)(void *priv);
-    void *(*init)(const netcard_t *card, const uint8_t *mac_addr, void *priv);
+    void *(*init)(const netcard_t *card, const uint8_t *mac_addr, void *priv, char *netdrv_errbuf);
     void (*close)(void *priv);
     void *priv;
 } netdrv_t;

--- a/src/network/net_null.c
+++ b/src/network/net_null.c
@@ -158,7 +158,7 @@ net_null_thread(void *priv)
 #endif
 
 void *
-net_null_init(const netcard_t *card, const uint8_t *mac_addr, void *priv)
+net_null_init(const netcard_t *card, const uint8_t *mac_addr, void *priv, char *netdrv_errbuf)
 {
     net_null_log("Null Network: Init\n");
 

--- a/src/network/net_pcap.c
+++ b/src/network/net_pcap.c
@@ -409,6 +409,15 @@ net_pcap_prepare(netdev_t *list)
 }
 
 /*
+ * Copy error message to the error buffer
+ * and log if enabled.
+ */
+void net_pcap_error(char *errbuf, const char *message) {
+    strncpy(errbuf, message, NET_DRV_ERRBUF_SIZE);
+    pcap_log("PCAP: %s\n", message);
+}
+
+/*
  * Initialize (Win)Pcap for use.
  *
  * We already know we have PCAP available, as this
@@ -416,18 +425,19 @@ net_pcap_prepare(netdev_t *list)
  * tries to attach to the network module.
  */
 void *
-net_pcap_init(const netcard_t *card, const uint8_t *mac_addr, void *priv)
+net_pcap_init(const netcard_t *card, const uint8_t *mac_addr, void *priv, char *netdrv_errbuf)
 {
     char               errbuf[PCAP_ERRBUF_SIZE];
     char              *str;
     char               filter_exp[255];
     struct bpf_program fp;
+    char errbuf_prep[NET_DRV_ERRBUF_SIZE];
 
     char *intf_name = (char *) priv;
 
     /* Did we already load the library? */
     if (libpcap_handle == NULL) {
-        pcap_log("PCAP: net_pcap_init without handle.\n");
+        net_pcap_error(netdrv_errbuf, "net_pcap_init without handle");
         return NULL;
     }
 
@@ -440,7 +450,7 @@ net_pcap_init(const netcard_t *card, const uint8_t *mac_addr, void *priv)
 
     /* Get the value of our capture interface. */
     if ((intf_name[0] == '\0') || !strcmp(intf_name, "none")) {
-        pcap_log("PCAP: no interface configured!\n");
+        net_pcap_error(netdrv_errbuf, "No interface configured");
         return NULL;
     }
 
@@ -451,7 +461,8 @@ net_pcap_init(const netcard_t *card, const uint8_t *mac_addr, void *priv)
     memcpy(pcap->mac_addr, mac_addr, sizeof(pcap->mac_addr));
 
     if ((pcap->pcap = f_pcap_create(intf_name, errbuf)) == NULL) {
-        pcap_log(" Unable to open device: %s!\n", intf_name);
+        snprintf(errbuf_prep, NET_DRV_ERRBUF_SIZE, " Unable to open device: %s!\n", intf_name);
+        net_pcap_error(netdrv_errbuf, errbuf_prep);
         free(pcap);
         return NULL;
     }
@@ -469,7 +480,8 @@ net_pcap_init(const netcard_t *card, const uint8_t *mac_addr, void *priv)
         pcap_log("PCAP: error setting snaplen\n");
 
     if (f_pcap_activate((void *) pcap->pcap) != 0) {
-        pcap_log("PCAP: failed pcap_activate");
+        snprintf(errbuf_prep, NET_DRV_ERRBUF_SIZE, "%s", (char *)f_pcap_geterr(pcap->pcap));
+        net_pcap_error(netdrv_errbuf, errbuf_prep);
         f_pcap_close((void *) pcap->pcap);
         free(pcap);
         return NULL;
@@ -484,13 +496,15 @@ net_pcap_init(const netcard_t *card, const uint8_t *mac_addr, void *priv)
             mac_addr[0], mac_addr[1], mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
     if (f_pcap_compile((void *) pcap->pcap, &fp, filter_exp, 0, 0xffffffff) != -1) {
         if (f_pcap_setfilter((void *) pcap->pcap, &fp) != 0) {
-            pcap_log("PCAP: error installing filter (%s) !\n", filter_exp);
+            snprintf(errbuf_prep, NET_DRV_ERRBUF_SIZE, "Error installing filter (%s)\n", filter_exp);
+            net_pcap_error(netdrv_errbuf, errbuf_prep);
             f_pcap_close((void *) pcap->pcap);
             free(pcap);
             return NULL;
         }
     } else {
-        pcap_log("PCAP: could not compile filter (%s) : %s!\n", filter_exp, f_pcap_geterr((void *) pcap->pcap));
+        snprintf(errbuf_prep, NET_DRV_ERRBUF_SIZE, "Could not compile filter (%s) : %s!\n", filter_exp, (char *)f_pcap_geterr((void *) pcap->pcap));
+        net_pcap_error(netdrv_errbuf, errbuf_prep);
         f_pcap_close((void *) pcap->pcap);
         free(pcap);
         return NULL;

--- a/src/network/net_slirp.c
+++ b/src/network/net_slirp.c
@@ -384,7 +384,7 @@ static int slirp_card_num = 2;
 
 /* Initialize SLiRP for use. */
 void *
-net_slirp_init(const netcard_t *card, const uint8_t *mac_addr, void *priv)
+net_slirp_init(const netcard_t *card, const uint8_t *mac_addr, void *priv, char *netdrv_errbuf)
 {
     slirp_log("SLiRP: initializing...\n");
     net_slirp_t *slirp = calloc(1, sizeof(net_slirp_t));
@@ -410,6 +410,7 @@ net_slirp_init(const netcard_t *card, const uint8_t *mac_addr, void *priv)
     slirp->slirp = slirp_init(0, 1, net, mask, host, 0, ipv6_dummy, 0, ipv6_dummy, NULL, NULL, NULL, NULL, dhcp, dns, ipv6_dummy, NULL, NULL, &slirp_cb, slirp);
     if (!slirp->slirp) {
         slirp_log("SLiRP: initialization failed\n");
+        snprintf(netdrv_errbuf, NET_DRV_ERRBUF_SIZE, "SLiRP initialization failed");
         free(slirp);
         return NULL;
     }

--- a/src/network/net_vde.c
+++ b/src/network/net_vde.c
@@ -236,25 +236,34 @@ void net_vde_in_available(void *priv) {
 }
 
 //+
+// Copy error message to the error buffer
+// and log if enabled.
+//-
+void net_vde_error(char *errbuf, const char *message) {
+    strncpy(errbuf, message, NET_DRV_ERRBUF_SIZE);
+    vde_log("VDE: %s\n", message);
+}
+
+//+
 // Initialize VDE for use
 // At this point the vdeplug library is already loaded
 // card: network card we are attaching
 // mac_addr: MAC address we are using
 // priv: Name of the VDE contol socket directory
 //-
-void *net_vde_init(const netcard_t *card, const uint8_t *mac_addr, void *priv) {
+void *net_vde_init(const netcard_t *card, const uint8_t *mac_addr, void *priv, char *netdrv_errbuf) {
     struct vde_open_args vde_args;
     int i;
 
     char *socket_name = (char *) priv;
 
     if (libvde_handle == NULL) {
-        vde_log("VDE: net_vde_init without library handle!\n");
+        net_vde_error(netdrv_errbuf, "net_vde_init without library handle");
         return NULL;
     }
 
     if ((socket_name[0] == '\0') || !strcmp(socket_name, "none")) {
-        vde_log("VDE: No socket name configured!\n");
+        net_vde_error(netdrv_errbuf, "No socket name configured");
         return NULL;
     }
 
@@ -271,18 +280,10 @@ void *net_vde_init(const netcard_t *card, const uint8_t *mac_addr, void *priv) {
     // We are calling vde_open_real(), not the vde_open() macro...
     if ((vde->vdeconn = f_vde_open(socket_name, VDE_DESCRIPTION, 
                                         LIBVDEPLUG_INTERFACE_VERSION, &vde_args)) == NULL) {
-        vde_log("VDE: Unable to open socket %s (%s)!\n", socket_name, strerror(errno));
+        char buf[NET_DRV_ERRBUF_SIZE];
+        snprintf(buf, NET_DRV_ERRBUF_SIZE, "Unable to open socket %s (%s)", socket_name, strerror(errno));
+        net_vde_error(netdrv_errbuf, buf);
         free(vde);
-        //+
-        // There is a bug upstream that causes an uncontrolled crash if the network is not
-        // properly initialized. 
-        // To avoid that crash, we tell the user we cannot continue and exit the program.
-        // TODO: Once there is a solution for the mentioned crash, this should be removed
-        // and/or replaced by proper error handling code.
-        //-
-        // fatal("Could not open the specified VDE socket (%s). Please fix your networking configuration.", socket_name);
-        // It makes no sense to issue this warning since the program will crash anyway...
-        // ui_msgbox_header(MBX_WARNING, (wchar_t *) IDS_2167, (wchar_t *) IDS_2168);
         return NULL;
     }
     vde_log("VDE: Socket opened (%s).\n", socket_name);

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -1219,3 +1219,9 @@ msgstr "2% pod dokonalými ot./m"
 msgid "(System Default)"
 msgstr "(Výchozí nastavení systému)"
 
+msgid "Failed to initialize network driver"
+msgstr "Failed to initialize network driver"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "The network configuration will be switched to the null driver"
+

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -1219,3 +1219,9 @@ msgstr "2% unterhalb der perfekten Drehzahl"
 msgid "(System Default)"
 msgstr "(Systemstandard)"
 
+msgid "Failed to initialize network driver"
+msgstr "Failed to initialize network driver"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "The network configuration will be switched to the null driver"
+

--- a/src/qt/languages/en-GB.po
+++ b/src/qt/languages/en-GB.po
@@ -1219,3 +1219,9 @@ msgstr "2% below perfect RPM"
 msgid "(System Default)"
 msgstr "(System Default)"
 
+msgid "Failed to initialize network driver"
+msgstr "Failed to initialize network driver"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "The network configuration will be switched to the null driver"
+

--- a/src/qt/languages/en-US.po
+++ b/src/qt/languages/en-US.po
@@ -1219,3 +1219,9 @@ msgstr "2% below perfect RPM"
 msgid "(System Default)"
 msgstr "(System Default)"
 
+msgid "Failed to initialize network driver"
+msgstr "Failed to initialize network driver"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "The network configuration will be switched to the null driver"
+

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -1219,3 +1219,9 @@ msgstr "2% por debajo de RPM perfectas"
 msgid "(System Default)"
 msgstr "(Por defecto del sistema)"
 
+msgid "Failed to initialize network driver"
+msgstr "Failed to initialize network driver"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "The network configuration will be switched to the null driver"
+

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -1219,3 +1219,10 @@ msgstr "2% alle täydellisen RPM:n"
 msgid "(System Default)"
 msgstr "(Järjestelmän oletus)"
 
+msgid "Failed to initialize network driver"
+msgstr "Failed to initialize network driver"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "The network configuration will be switched to the null driver"
+
+

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -1219,3 +1219,9 @@ msgstr "Précision RPM de moins 2%"
 msgid "(System Default)"
 msgstr "(Défaut du système)"
 
+msgid "Failed to initialize network driver"
+msgstr "Failed to initialize network driver"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "The network configuration will be switched to the null driver"
+

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -1219,3 +1219,9 @@ msgstr "2% ispod savršenog broja okretaja"
 msgid "(System Default)"
 msgstr "(Zadana postavka operativnog sustava)"
 
+msgid "Failed to initialize network driver"
+msgstr "Failed to initialize network driver"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "The network configuration will be switched to the null driver"
+

--- a/src/qt/languages/hu-HU.po
+++ b/src/qt/languages/hu-HU.po
@@ -1219,3 +1219,9 @@ msgstr "2%-kal a tökéletes RPM alatt"
 msgid "(System Default)"
 msgstr "(A rendszer nyelve)"
 
+msgid "Failed to initialize network driver"
+msgstr "Failed to initialize network driver"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "The network configuration will be switched to the null driver"
+

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -1219,3 +1219,9 @@ msgstr "RPM 2% sotto perfezione"
 msgid "(System Default)"
 msgstr "(Predefinito del sistema)"
 
+msgid "Failed to initialize network driver"
+msgstr "Failed to initialize network driver"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "The network configuration will be switched to the null driver"
+

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -1219,3 +1219,9 @@ msgstr "2%低い回転数"
 msgid "(System Default)"
 msgstr "(システム既定値)"
 
+msgid "Failed to initialize network driver"
+msgstr "Failed to initialize network driver"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "The network configuration will be switched to the null driver"
+

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -1219,3 +1219,9 @@ msgstr "2% 낮은 회전수"
 msgid "(System Default)"
 msgstr "(시스템 기본값)"
 
+msgid "Failed to initialize network driver"
+msgstr "Failed to initialize network driver"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "The network configuration will be switched to the null driver"
+

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -1219,3 +1219,9 @@ msgstr "2% poniżej idealnych obrotów"
 msgid "(System Default)"
 msgstr "(Domyślne ustawienie systemowe)"
 
+msgid "Failed to initialize network driver"
+msgstr "Failed to initialize network driver"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "The network configuration will be switched to the null driver"
+

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -1219,3 +1219,9 @@ msgstr "2% abaixo das RPM perfeita"
 msgid "(System Default)"
 msgstr "(Padrão do sistema)"
 
+msgid "Failed to initialize network driver"
+msgstr "Failed to initialize network driver"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "The network configuration will be switched to the null driver"
+

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -1219,3 +1219,9 @@ msgstr "RPM 2% abaixo do RPM perfeito"
 msgid "(System Default)"
 msgstr "(Padrão do sistema)"
 
+msgid "Failed to initialize network driver"
+msgstr "Failed to initialize network driver"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "The network configuration will be switched to the null driver"
+

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -1219,3 +1219,9 @@ msgstr "На 2% медленнее точного RPM"
 msgid "(System Default)"
 msgstr "(Системный)"
 
+msgid "Failed to initialize network driver"
+msgstr "Failed to initialize network driver"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "The network configuration will be switched to the null driver"
+

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -1219,3 +1219,9 @@ msgstr "2% pod popolnimi obrati"
 msgid "(System Default)"
 msgstr "(Sistemsko privzeto)"
 
+msgid "Failed to initialize network driver"
+msgstr "Failed to initialize network driver"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "The network configuration will be switched to the null driver"
+

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -1219,3 +1219,9 @@ msgstr "mükemmel RPM değerinin 2% altı"
 msgid "(System Default)"
 msgstr "(Sistem Varsayılanı)"
 
+msgid "Failed to initialize network driver"
+msgstr "Failed to initialize network driver"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "The network configuration will be switched to the null driver"
+

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -1219,3 +1219,9 @@ msgstr "На 2% повільніше точного RPM"
 msgid "(System Default)"
 msgstr "(Системний)"
 
+msgid "Failed to initialize network driver"
+msgstr "Failed to initialize network driver"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "The network configuration will be switched to the null driver"
+

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -1219,3 +1219,9 @@ msgstr "低于标准转速的 2%"
 msgid "(System Default)"
 msgstr "(系统默认)"
 
+msgid "Failed to initialize network driver"
+msgstr "Failed to initialize network driver"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "The network configuration will be switched to the null driver"
+

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -1218,3 +1218,10 @@ msgstr "低於標準轉速的 2%"
 
 msgid "(System Default)"
 msgstr "(系統預設)"
+
+msgid "Failed to initialize network driver"
+msgstr "Failed to initialize network driver"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "The network configuration will be switched to the null driver"
+

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -602,6 +602,8 @@ ProgSettings::reloadStrings()
     translatedstrings[IDS_2143] = QCoreApplication::translate("", "Monitor in sleep mode").toStdWString();
     translatedstrings[IDS_2121] = QCoreApplication::translate("", "No ROMs found").toStdWString();
     translatedstrings[IDS_2056] = QCoreApplication::translate("", "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory.").toStdWString();
+    translatedstrings[IDS_2167] = QCoreApplication::translate("", "Failed to initialize network driver").toStdWString();
+    translatedstrings[IDS_2168] = QCoreApplication::translate("", "The network configuration will be switched to the null driver").toStdWString();
 
     auto flsynthstr = QCoreApplication::translate("", " is required for FluidSynth MIDI output.");
     if (flsynthstr.contains("libfluidsynth")) {

--- a/src/qt/qt_settingsnetwork.cpp
+++ b/src/qt/qt_settingsnetwork.cpp
@@ -90,8 +90,7 @@ SettingsNetwork::save()
         if (net_cards_conf[i].net_type == NET_TYPE_PCAP) {
             strncpy(net_cards_conf[i].host_dev_name, network_devs[cbox->currentData().toInt()].device, sizeof(net_cards_conf[i].host_dev_name) - 1);
         } else if (net_cards_conf[i].net_type == NET_TYPE_VDE) {
-            const char *str_socket = socket_line->text().toStdString().c_str();
-            strncpy(net_cards_conf[i].host_dev_name, str_socket, strlen(str_socket));
+            strncpy(net_cards_conf[i].host_dev_name, socket_line->text().toUtf8().constData(), sizeof(net_cards_conf[i].host_dev_name));
         }
     }
 }

--- a/src/win/languages/cs-CZ.rc
+++ b/src/win/languages/cs-CZ.rc
@@ -542,6 +542,8 @@ BEGIN
     IDS_2164    "Old Dynarec"
     IDS_2165    "New Dynarec"
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+    IDS_2167    "Failed to initialize network driver"
+    IDS_2168    "The network configuration will be switched to the null driver"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/de-DE.rc
+++ b/src/win/languages/de-DE.rc
@@ -542,6 +542,8 @@ BEGIN
     IDS_2164    "Old Dynarec"
     IDS_2165    "New Dynarec"
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+    IDS_2167    "Failed to initialize network driver"
+    IDS_2168    "The network configuration will be switched to the null driver"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/en-GB.rc
+++ b/src/win/languages/en-GB.rc
@@ -542,6 +542,8 @@ BEGIN
     IDS_2164    "Old Dynarec"
     IDS_2165    "New Dynarec"
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+    IDS_2167    "Failed to initialize network driver"
+    IDS_2168    "The network configuration will be switched to the null driver"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/en-US.rc
+++ b/src/win/languages/en-US.rc
@@ -542,6 +542,8 @@ BEGIN
     IDS_2164    "Old Dynarec"
     IDS_2165    "New Dynarec"
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+    IDS_2167    "Failed to initialize network driver"
+    IDS_2168    "The network configuration will be switched to the null driver"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/es-ES.rc
+++ b/src/win/languages/es-ES.rc
@@ -542,6 +542,8 @@ BEGIN
     IDS_2164    "Old Dynarec"
     IDS_2165    "New Dynarec"
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+    IDS_2167    "Failed to initialize network driver"
+    IDS_2168    "The network configuration will be switched to the null driver"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/fi-FI.rc
+++ b/src/win/languages/fi-FI.rc
@@ -542,6 +542,8 @@ BEGIN
     IDS_2164    "Old Dynarec"
     IDS_2165    "New Dynarec"
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+    IDS_2167    "Failed to initialize network driver"
+    IDS_2168    "The network configuration will be switched to the null driver"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/fr-FR.rc
+++ b/src/win/languages/fr-FR.rc
@@ -542,6 +542,8 @@ BEGIN
     IDS_2164    "Old Dynarec"
     IDS_2165    "New Dynarec"
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+    IDS_2167    "Failed to initialize network driver"
+    IDS_2168    "The network configuration will be switched to the null driver"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/hr-HR.rc
+++ b/src/win/languages/hr-HR.rc
@@ -542,6 +542,8 @@ BEGIN
     IDS_2164    "Old Dynarec"
     IDS_2165    "New Dynarec"
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+    IDS_2167    "Failed to initialize network driver"
+    IDS_2168    "The network configuration will be switched to the null driver"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/hu-HU.rc
+++ b/src/win/languages/hu-HU.rc
@@ -546,6 +546,8 @@ BEGIN
     IDS_2164    "Old Dynarec"
     IDS_2165    "New Dynarec"
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+    IDS_2167    "Failed to initialize network driver"
+    IDS_2168    "The network configuration will be switched to the null driver"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/it-IT.rc
+++ b/src/win/languages/it-IT.rc
@@ -543,6 +543,8 @@ BEGIN
     IDS_2164    "Old Dynarec"
     IDS_2165    "New Dynarec"
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+    IDS_2167    "Failed to initialize network driver"
+    IDS_2168    "The network configuration will be switched to the null driver"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/ja-JP.rc
+++ b/src/win/languages/ja-JP.rc
@@ -542,6 +542,8 @@ BEGIN
     IDS_2164    "Old Dynarec"
     IDS_2165    "New Dynarec"
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+    IDS_2167    "Failed to initialize network driver"
+    IDS_2168    "The network configuration will be switched to the null driver"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/ko-KR.rc
+++ b/src/win/languages/ko-KR.rc
@@ -542,6 +542,8 @@ BEGIN
     IDS_2164    "Old Dynarec"
     IDS_2165    "New Dynarec"
     IDS_2166    "두번째 비디오카드 ""%hs""는 roms/video 디렉토리에서 ROM이 누락되어 사용할 수 없습니다. 두번째 비디오 카드를 비활성화 합니다."
+    IDS_2167    "Failed to initialize network driver"
+    IDS_2168    "The network configuration will be switched to the null driver"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/pl-PL.rc
+++ b/src/win/languages/pl-PL.rc
@@ -542,6 +542,8 @@ BEGIN
     IDS_2164    "Old Dynarec"
     IDS_2165    "New Dynarec"
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+    IDS_2167    "Failed to initialize network driver"
+    IDS_2168    "The network configuration will be switched to the null driver"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/pt-BR.rc
+++ b/src/win/languages/pt-BR.rc
@@ -545,6 +545,8 @@ BEGIN
     IDS_2164    "Old Dynarec"
     IDS_2165    "New Dynarec"
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+    IDS_2167    "Failed to initialize network driver"
+    IDS_2168    "The network configuration will be switched to the null driver"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/pt-PT.rc
+++ b/src/win/languages/pt-PT.rc
@@ -542,6 +542,8 @@ BEGIN
     IDS_2164    "Old Dynarec"
     IDS_2165    "New Dynarec"
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+    IDS_2167    "Failed to initialize network driver"
+    IDS_2168    "The network configuration will be switched to the null driver"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/ru-RU.rc
+++ b/src/win/languages/ru-RU.rc
@@ -542,6 +542,8 @@ BEGIN
     IDS_2164    "Old Dynarec"
     IDS_2165    "New Dynarec"
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+    IDS_2167    "Failed to initialize network driver"
+    IDS_2168    "The network configuration will be switched to the null driver"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/sl-SI.rc
+++ b/src/win/languages/sl-SI.rc
@@ -542,6 +542,8 @@ BEGIN
     IDS_2164    "Old Dynarec"
     IDS_2165    "New Dynarec"
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+    IDS_2167    "Failed to initialize network driver"
+    IDS_2168    "The network configuration will be switched to the null driver"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/tr-TR.rc
+++ b/src/win/languages/tr-TR.rc
@@ -542,6 +542,8 @@ BEGIN
     IDS_2164    "Old Dynarec"
     IDS_2165    "New Dynarec"
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+    IDS_2167    "Failed to initialize network driver"
+    IDS_2168    "The network configuration will be switched to the null driver"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/uk-UA.rc
+++ b/src/win/languages/uk-UA.rc
@@ -542,6 +542,8 @@ BEGIN
     IDS_2164    "Old Dynarec"
     IDS_2165    "New Dynarec"
     IDS_2166    "Відеокарта #2 ""%hs"" недоступна через відсутність файлу її ПЗУ в каталозі roms/video. Відключення другої відеокарти."
+    IDS_2167    "Failed to initialize network driver"
+    IDS_2168    "The network configuration will be switched to the null driver"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/zh-CN.rc
+++ b/src/win/languages/zh-CN.rc
@@ -542,6 +542,8 @@ BEGIN
     IDS_2164    "Old Dynarec"
     IDS_2165    "New Dynarec"
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+    IDS_2167    "Failed to initialize network driver"
+    IDS_2168    "The network configuration will be switched to the null driver"
 END
 
 STRINGTABLE DISCARDABLE

--- a/src/win/languages/zh-TW.rc
+++ b/src/win/languages/zh-TW.rc
@@ -542,6 +542,8 @@ BEGIN
     IDS_2164    "Old Dynarec"
     IDS_2165    "New Dynarec"
     IDS_2166    "Video card #2 ""%hs"" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+    IDS_2167    "Failed to initialize network driver"
+    IDS_2168    "The network configuration will be switched to the null driver"
 END
 
 STRINGTABLE DISCARDABLE


### PR DESCRIPTION
Summary
=======
Continuation of some work done in #3326 

This PR modifies the network drivers to have `netdrv_errbuf` as part of the init. As part of normal operation, when the init fails it returns `NULL` and there is no way to understand *why* the init failed. Now, when an init fails an error message with more information is copied to `netdrv_errbuf` so the UI can provide some information to the user.

All of the existing drivers were updated to use this new functionality and provide the error message (slirp, pcap, vde).

New translation strings were added to qt and win32 as well. Upon failure, the error is displayed and network falls back to the null driver. @jriwanek might want to review and make sure I didn't break win32 (though it does compile and run fine in my testing).

A separate issue was fixed in the network configuration dialog with VDE where it was grabbing config data incorrectly and getting corrupt data.

Tested on mac, windows and linux. 

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
#3326 