### PR TITLE
Allow HDD Speed to be set in win32 ui (1/2)

### DIFF
--- a/src/include/86box/resource.h
+++ b/src/include/86box/resource.h
@@ -280,7 +280,7 @@
 #define IDC_COMBO_HD_BUS          1135
 #define IDC_COMBO_HD_CHANNEL      1136
 #define IDC_COMBO_HD_ID           1137
-#define IDC_COMBO_HD_LUN          1138
+#define IDC_COMBO_HD_SPEED        1138
 #define IDC_COMBO_HD_CHANNEL_IDE  1139
 
 #define IDC_EDIT_HD_FILE_NAME     1140 /* add hard disk dialog */

--- a/src/win/languages/dialogs.rc
+++ b/src/win/languages/dialogs.rc
@@ -665,22 +665,28 @@ BEGIN
     LTEXT           STR_BUS,IDT_BUS,
                     CFG_HMARGIN, 188, 24, CFG_PANE_LTEXT_HEIGHT
     COMBOBOX        IDC_COMBO_HD_BUS,
-                    33, 186, 130, 12,CBS_DROPDOWNLIST | 
+                    33, 186, 40, 12,CBS_DROPDOWNLIST | 
                     WS_VSCROLL | WS_TABSTOP
 
     LTEXT           STR_CHANNEL, IDT_CHANNEL,
-                    181, 188, 38, CFG_PANE_LTEXT_HEIGHT
+                    91, 188, 38, CFG_PANE_LTEXT_HEIGHT
     COMBOBOX        IDC_COMBO_HD_CHANNEL,
-                    221, 186, 140, 12,
+                    131, 186, 40, 12,
                     CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     COMBOBOX        IDC_COMBO_HD_CHANNEL_IDE,
-                    221, 186, 140, 12,
+                    131, 186, 40, 12,
                     CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
 
     LTEXT           STR_ID, IDT_ID,
-                    181, 188, 38, CFG_PANE_LTEXT_HEIGHT
+                    91, 188, 38, CFG_PANE_LTEXT_HEIGHT
     COMBOBOX        IDC_COMBO_HD_ID,
-                    221, 186, 140, 12,
+                    131, 186, 70, 12,
+                    CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+
+    LTEXT           STR_SPEED, IDT_SPEED,
+                    201, 188, 38, CFG_PANE_LTEXT_HEIGHT
+    COMBOBOX        IDC_COMBO_HD_SPEED,
+                    241, 186, 70, 12,
                     CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
 
     PUSHBUTTON      STR_NEW, IDC_BUTTON_HDD_ADD_NEW,


### PR DESCRIPTION
Summary
=======
Allow HDD Speed to be set in win32 ui, this is the initial part to add the visible UI elements

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
