### PR TITLE
network: ne2k / dp8390 fixes for netware

### DIFF
--- a/src/include/86box/net_dp8390.h
+++ b/src/include/86box/net_dp8390.h
@@ -178,7 +178,10 @@ typedef struct {
                              0xFF. */
         id1;              /* 0x70 for the RTL8019AS, 0x43 for the
                              RTL8029AS, otherwise 0xFF. */
-    int mem_size, mem_start, mem_end;
+    uint32_t mem_size;
+    uint32_t mem_start;
+    uint32_t mem_end;
+    uint32_t mem_wrap;
 
     int tx_timer_index;
     int tx_timer_active;


### PR DESCRIPTION
Summary
=======
Novell Netware 3.12 would always appear to send out packets to the network but could never actually establish any form of communication. Digging deeper into the issue I found that the packets would either be all zeroes or random data from memory.

Turns out the the netware drivers seem to rely on a memory wraparound functionality that wasn't fully implemented (at least, not for tx).

This PR implements the wraparound for all dp8390 devices based on the configured memory size. I've tested it with netware 3.12 and vde for networking but I suspect it will fix all versions of netware that had this problem. The tests were performed with pure IPX, no TCP. 

The issues reported in #2389 should be fixed with this PR as well.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
* [ne2k at osdev](https://wiki.osdev.org/Ne2000)
* DP8390 datasheet
