### PR TITLE
Build / CI: Add dependencies for VDE

### DIFF
--- a/.ci/AppImageBuilder.yml
+++ b/.ci/AppImageBuilder.yml
@@ -59,6 +59,7 @@ AppDir:
     - libsixel1 # if CLI:BOOL=ON
     - libslirp0 # if SLIRP_EXTERNAL:BOOL=ON
     - libsndio7.0 # if OPENAL:BOOL=ON
+    - libvdeplug-dev # -dev also pulls in libvdeplug2. -dev is required to get the proper .so symlink to the library
     - libwayland-client0 # if QT:BOOL=ON
     - libx11-6 # if QT:BOOL=ON
     - libx11-xcb1 # if QT:BOOL=ON

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -587,7 +587,7 @@ else
 	# ...and the ones we do want listed. Non-dev packages fill missing spots on the list.
 	libpkgs=""
 	longest_libpkg=0
-	for pkg in libc6-dev libstdc++6 libopenal-dev libfreetype6-dev libx11-dev libsdl2-dev libpng-dev librtmidi-dev qtdeclarative5-dev libwayland-dev libevdev-dev libxkbcommon-x11-dev libglib2.0-dev libslirp-dev libfaudio-dev libaudio-dev libjack-jackd2-dev libpipewire-0.3-dev libsamplerate0-dev libsndio-dev
+	for pkg in libc6-dev libstdc++6 libopenal-dev libfreetype6-dev libx11-dev libsdl2-dev libpng-dev librtmidi-dev qtdeclarative5-dev libwayland-dev libevdev-dev libxkbcommon-x11-dev libglib2.0-dev libslirp-dev libfaudio-dev libaudio-dev libjack-jackd2-dev libpipewire-0.3-dev libsamplerate0-dev libsndio-dev libvdeplug-dev
 	do
 		libpkgs="$libpkgs $pkg:$arch_deb"
 		length=$(echo -n $pkg | sed 's/-dev$//' | sed "s/qtdeclarative/qt/" | wc -c)
@@ -678,7 +678,7 @@ case $arch in
 	32 | x86)	cmake_flags_extra="$cmake_flags_extra -D ARCH=i386";;
 	64 | x86_64*)	cmake_flags_extra="$cmake_flags_extra -D ARCH=x86_64";;
 	ARM32 | arm32)	cmake_flags_extra="$cmake_flags_extra -D ARCH=arm";;
-	ARM64 | arm64)	cmake_flags_extra="$cmake_flags_extra -D ARCH=arm64";;
+	ARM64 | arm64)	cmake_flags_extra="$cmake_flags_extra -D ARCH=arm64 -D NEW_DYNAREC=ON";;
 	*)		cmake_flags_extra="$cmake_flags_extra -D \"ARCH=$arch\"";;
 esac
 

--- a/.ci/dependencies_macports.txt
+++ b/.ci/dependencies_macports.txt
@@ -13,3 +13,4 @@ qt5
 wget
 fluidsynth
 ghostscript
+vde2


### PR DESCRIPTION
Summary
=======
This adds VDE dependencies to the build process for both macOS and linux.

There's an additional minor update to `build.sh` where `-D NEW_DYNAREC=ON` gets added automatically to all arm64 builds.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
