### PR TITLE
Add some defines to build succesfully on FreeBSD

### DIFF
--- a/src/include/86box/plat_dir.h
+++ b/src/include/86box/plat_dir.h
@@ -66,6 +66,9 @@ extern void           seekdir(DIR *, long);
 extern int            closedir(DIR *);
 
 #    define rewinddir(dirp) seekdir(dirp, 0L)
+#elif defined(__FreeBSD__)
+/* FreeBSD uses dirent.h instead of sys/dir.h */
+#    include <dirent.h>
 #else
 /* On linux and macOS, use the standard functions and types */
 #    include <sys/dir.h>

--- a/src/unix/unix_serial_passthrough.c
+++ b/src/unix/unix_serial_passthrough.c
@@ -21,6 +21,9 @@
 #    define _DEFAULT_SOURCE 1
 #    define _BSD_SOURCE     1
 #endif
+#ifdef __FreeBSD__
+#    define __BSD_VISIBLE   1
+#endif
 #include <stdio.h>
 #include <fcntl.h>
 #include <stdlib.h>
@@ -165,7 +168,7 @@ plat_serpt_set_params(void *p)
         term_attr.c_cflag &= CSTOPB;
         if (dev->serial->lcr & 0x04)
             term_attr.c_cflag |= CSTOPB;
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__FreeBSD__)
         term_attr.c_cflag &= PARENB | PARODD;
 #else
         term_attr.c_cflag &= PARENB | PARODD | CMSPAR;
@@ -174,7 +177,7 @@ plat_serpt_set_params(void *p)
             term_attr.c_cflag |= PARENB;
             if (!(dev->serial->lcr & 0x10))
                 term_attr.c_cflag |= PARODD;
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
             if ((dev->serial->lcr & 0x20))
                 term_attr.c_cflag |= CMSPAR;
 #endif


### PR DESCRIPTION
Tested on FreeBSD 13.2 only.  FreeBSD is more similar to Mac OS X in system-level library support than it is to Linux.

So far as I know, need to use `CFLAGS=-I/usr/local/include/freetype2 cmake ...` to get cmake to include the proper FreeType 2 headers. If there's a cmake expert that could fix it, that'd be great.