### PR TITLE
(mostly) Fix EGA split screen - fix done by @cons-cinnabar

### DIFF
--- a/src/video/vid_ega.c
+++ b/src/video/vid_ega.c
@@ -582,10 +582,11 @@ ega_poll(void *p)
         ega->vc++;
         ega->vc &= 511;
         if (ega->vc == ega->split) {
+            // TODO: Implement the hardware bug where the first scanline is drawn twice when the split happens
             if (ega->interlace && ega->oddeven)
-                ega->ma = ega->maback = ega->ma_latch + (ega->rowoffset << 1);
+                ega->ma = ega->maback = ega->rowoffset << 1;
             else
-                ega->ma = ega->maback = ega->ma_latch;
+                ega->ma = ega->maback = 0;
             ega->ma <<= 2;
             ega->maback <<= 2;
             ega->sc = 0;


### PR DESCRIPTION
Closes: #3386

Summary
=======
Fixes the EGA split screen restart address being incorrect.

Note that this does NOT implement the hardware bug which makes the first line of the lower split render twice - that can be fixed later once there's a good test case for it.

Checklist
=========
* [x] Closes #3386
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
C&T 82C434 datasheet; IBM EGA docs; Michael Abrash's Graphics Programming Black Book.
