### PR TITLE
Force 'page_in_evict_list' to be always inlined

### DIFF
--- a/src/include/86box/mem.h
+++ b/src/include/86box/mem.h
@@ -229,7 +229,7 @@ typedef struct page_t {
 
 extern uint32_t purgable_page_list_head;
 static inline int
-page_in_evict_list(page_t *p)
+page_in_evict_list(page_t *p) __attribute__((always_inline))  
 {
     return (p->evict_prev != EVICT_NOT_IN_LIST);
 }


### PR DESCRIPTION
Summary
=======
mem: Force 'page_in_evict_list' to be always inlined

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
