### PR TITLE
qt: Hide the VDE socket textbox on Windows

### DIFF
--- a/src/qt/qt_settingsnetwork.cpp
+++ b/src/qt/qt_settingsnetwork.cpp
@@ -64,7 +64,12 @@ SettingsNetwork::SettingsNetwork(QWidget *parent)
         auto *nic_cbox      = findChild<QComboBox *>(QString("comboBoxNIC%1").arg(i + 1));
         auto *net_type_cbox = findChild<QComboBox *>(QString("comboBoxNet%1").arg(i + 1));
         auto *intf_cbox     = findChild<QComboBox *>(QString("comboBoxIntf%1").arg(i + 1));
+#ifdef Q_OS_WINDOWS
         auto *socket_line   = findChild<QLineEdit *>(QString("socketVDENIC%1").arg(i + 1));
+        auto *socket_label  = findChild<QLabel *>(QString("labelVDESocket%1").arg(i + 1));
+        socket_line->setVisible(false);
+        socket_label->setVisible(false);
+#endif
         connect(nic_cbox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SettingsNetwork::on_comboIndexChanged);
         connect(net_type_cbox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SettingsNetwork::on_comboIndexChanged);
         connect(intf_cbox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SettingsNetwork::on_comboIndexChanged);

--- a/src/qt/qt_settingsnetwork.ui
+++ b/src/qt/qt_settingsnetwork.ui
@@ -142,7 +142,7 @@
         </widget>
        </item>
        <item row="3" column="0">
-        <widget class="QLabel" name="label_3">
+        <widget class="QLabel" name="labelVDESocket1">
          <property name="text">
           <string>VDE Socket</string>
          </property>
@@ -248,7 +248,7 @@
         </widget>
        </item>
        <item row="3" column="0">
-        <widget class="QLabel" name="label_4">
+        <widget class="QLabel" name="labelVDESocket2">
          <property name="text">
           <string>VDE Socket</string>
          </property>
@@ -353,9 +353,9 @@
         </widget>
        </item>
        <item row="3" column="0">
-        <widget class="QLabel" name="label_5">
+        <widget class="QLabel" name="labelVDESocket3">
          <property name="text">
-          <string>VDE Socket </string>
+          <string>VDE Socket</string>
          </property>
         </widget>
        </item>
@@ -481,7 +481,7 @@
         <widget class="QLineEdit" name="socketVDENIC4"/>
        </item>
        <item row="3" column="0">
-        <widget class="QLabel" name="label_6">
+        <widget class="QLabel" name="labelVDESocket4">
          <property name="text">
           <string>VDE Socket</string>
          </property>


### PR DESCRIPTION
Summary
=======
Title.
Also fixes an unused variable warning as a side effect.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
