### PR TITLE
Clean up some qt warnings

### DIFF
--- a/src/qt/qt_deviceconfig.cpp
+++ b/src/qt/qt_deviceconfig.cpp
@@ -109,7 +109,6 @@ DeviceConfig::ConfigureDevice(const _device_ *device, int instance, Settings *se
 {
     DeviceConfig dc(settings);
     dc.setWindowTitle(QString("%1 Device Configuration").arg(device->name));
-    int c;
     int p;
     int q;
 
@@ -216,7 +215,7 @@ DeviceConfig::ConfigureDevice(const _device_ *device, int instance, Settings *se
                     char *selected;
                     selected = config_get_string(device_context.name, const_cast<char *>(config->name), const_cast<char *>(config->default_string));
 
-                    c = q = 0;
+                    q = 0;
                     for (auto *bios = config->bios; (bios != nullptr) && (bios->name != nullptr) && (strlen(bios->name) > 0); ++bios) {
                         p = 0;
                         for (int d = 0; d < bios->files_no; d++)
@@ -226,7 +225,6 @@ DeviceConfig::ConfigureDevice(const _device_ *device, int instance, Settings *se
                             if (!strcmp(selected, bios->internal_name)) {
                                 currentIndex = row;
                             }
-                            c++;
                         }
                         q++;
                     }

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -327,7 +327,7 @@ RendererStack::switchRenderer(Renderer renderer)
                 createRenderer(renderer);
                 disconnect(this, &RendererStack::blit, this, &RendererStack::blitDummy);
                 blitDummied = false;
-                QTimer::singleShot(1000, this, [this]() { blitDummied = false; });
+                QTimer::singleShot(1000, this, []() { blitDummied = false; });
             });
 
             rendererWindow->hasBlitFunc() ? current.reset() : current.release()->deleteLater();

--- a/src/qt/qt_settingsnetwork.cpp
+++ b/src/qt/qt_settingsnetwork.cpp
@@ -64,7 +64,6 @@ SettingsNetwork::SettingsNetwork(QWidget *parent)
         auto *nic_cbox      = findChild<QComboBox *>(QString("comboBoxNIC%1").arg(i + 1));
         auto *net_type_cbox = findChild<QComboBox *>(QString("comboBoxNet%1").arg(i + 1));
         auto *intf_cbox     = findChild<QComboBox *>(QString("comboBoxIntf%1").arg(i + 1));
-        auto *socket_line   = findChild<QLineEdit *>(QString("socketVDENIC%1").arg(i + 1));
         connect(nic_cbox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SettingsNetwork::on_comboIndexChanged);
         connect(net_type_cbox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SettingsNetwork::on_comboIndexChanged);
         connect(intf_cbox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SettingsNetwork::on_comboIndexChanged);


### PR DESCRIPTION
Summary
=======
Cleans up a few qt warnings. There should not be any others (in qt) once this is merged.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
