### PR TITLE
Always include dirent.h on non-Windows

### DIFF
--- a/src/include/86box/plat_dir.h
+++ b/src/include/86box/plat_dir.h
@@ -66,12 +66,9 @@ extern void           seekdir(DIR *, long);
 extern int            closedir(DIR *);
 
 #    define rewinddir(dirp) seekdir(dirp, 0L)
-#elif defined(__FreeBSD__)
-/* FreeBSD uses dirent.h instead of sys/dir.h */
-#    include <dirent.h>
 #else
 /* On linux and macOS, use the standard functions and types */
-#    include <sys/dir.h>
+#    include <dirent.h>
 #endif
 
 #endif /*PLAT_DIR_H*/


### PR DESCRIPTION
Summary
=======
Always include dirent.h on non-Windows

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
