### PR TITLE
cmake: Include freetype directory properly on FreeBSD

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,6 +109,9 @@ endif()
 
 find_package(Freetype REQUIRED)
 include_directories(${FREETYPE_INCLUDE_DIRS})
+if(FREETYPE_INCLUDE_DIR_ft2build)
+    include_directories(${FREETYPE_INCLUDE_DIR_ft2build})
+endif()
 if(APPLE)
     # Freetype is dynamically loaded by the emulator, however, we link it
     # on macOS so it gets copied to the bundle by the installation process


### PR DESCRIPTION
Summary
=======
cmake: Include freetype directory properly on FreeBSD

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
