### PR TITLE
Fix loading of PCAP network device

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -866,6 +866,8 @@ load_network(void)
                         ui_msgbox_header(MBX_ERROR, (wchar_t *) IDS_2096, (wchar_t *) IDS_2130);
                     }
                     strcpy(net_cards_conf[c].host_dev_name, "none");
+                } else {
+                    strncpy(net_cards_conf[c].host_dev_name, p, sizeof(net_cards_conf[c].host_dev_name) - 1);
                 }
             } else {
                 strncpy(net_cards_conf[c].host_dev_name, p, sizeof(net_cards_conf[c].host_dev_name) - 1);


### PR DESCRIPTION
Summary
=======
When VDE support was added some parts of `config.c` had to be reworked to allow `net_XX_host_device` to be used for the VDE socket. A missing `else` clause caused the pcap network device to not get loaded properly.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
