### PR TITLE
Improvements to `plat_tempfile()`-generated file names

### DIFF
--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -316,7 +316,7 @@ plat_tempfile(char *bufp, char *prefix, char *suffix)
         name.append(QString("%1-").arg(prefix));
     }
 
-    name.append(QDateTime::currentDateTime().toString("yyyyMMdd-hhmmss-zzzz"));
+    name.append(QDateTime::currentDateTime().toString("yyyyMMdd-hhmmss-zzz"));
     if (suffix)
         name.append(suffix);
     strcpy(bufp, name.toUtf8().data());

--- a/src/win/win.c
+++ b/src/win/win.c
@@ -626,7 +626,7 @@ plat_tempfile(char *bufp, char *prefix, char *suffix)
     else
         strcpy(bufp, "");
 
-    GetSystemTime(&SystemTime);
+    GetLocalTime(&SystemTime);
     sprintf(&bufp[strlen(bufp)], "%d%02d%02d-%02d%02d%02d-%03d%s",
             SystemTime.wYear, SystemTime.wMonth, SystemTime.wDay,
             SystemTime.wHour, SystemTime.wMinute, SystemTime.wSecond,


### PR DESCRIPTION
Summary
=======
Improvements to `plat_tempfile()`-generated file names:
- Fix milliseconds being appended twice (e.g. "Monitor_1_20230701-172615-**71**071") in the Qt UI's implementation;
- Change the Win32 UI's implementation to use local time instead of UTC - makes more sense for screenshots or printer output, shouldn't affect any other uses.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
