### PR TITLE
Add a machine flag for machines with a cassette port

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1008,9 +1008,11 @@ load_storage_controllers(void)
     ide_ter_enabled = !!ini_section_get_int(cat, "ide_ter", 0);
     ide_qua_enabled = !!ini_section_get_int(cat, "ide_qua", 0);
 
-    /* TODO: Re-enable by default after we actually have a proper machine flag for this. */
-    cassette_enable = !!ini_section_get_int(cat, "cassette_enabled", 0);
-    p               = ini_section_get_string(cat, "cassette_file", "");
+    if (machine_has_bus(machine, MACHINE_BUS_CASSETTE))
+        cassette_enable = !!ini_section_get_int(cat, "cassette_enabled", 0);
+    else
+        cassette_enable = 0;
+    p = ini_section_get_string(cat, "cassette_file", "");
     if (strlen(p) > 511)
         fatal("load_storage_controllers(): strlen(p) > 511\n");
     else
@@ -1971,8 +1973,7 @@ config_load(void)
         for (i = 0; i < ISAMEM_MAX; i++)
             isamem_type[i] = 0;
 
-        /* TODO: Re-enable by default when we have a proper machine flag for this. */
-        cassette_enable = 0;
+        cassette_enable = 1;
         memset(cassette_fname, 0x00, sizeof(cassette_fname));
         memcpy(cassette_mode, "load", strlen("load") + 1);
         cassette_pos          = 0;

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -26,18 +26,20 @@
 #define MACHINE_BUS_NONE 0x00000000 /* sys has no bus */
 /* Feature flags for BUS'es. */
 #define MACHINE_BUS_ISA       0x00000001 /* sys has ISA bus */
-#define MACHINE_BUS_CARTRIDGE 0x00000002 /* sys has two cartridge bays */
-#define MACHINE_BUS_ISA16     0x00000004 /* sys has ISA16 bus - PC/AT architecture */
-#define MACHINE_BUS_CBUS      0x00000008 /* sys has C-BUS bus */
-#define MACHINE_BUS_PS2       0x00000010 /* system has PS/2 keyboard and mouse ports */
-#define MACHINE_BUS_EISA      0x00000020 /* sys has EISA bus */
-#define MACHINE_BUS_VLB       0x00000040 /* sys has VL bus */
-#define MACHINE_BUS_MCA       0x00000080 /* sys has MCA bus */
-#define MACHINE_BUS_PCI       0x00000100 /* sys has PCI bus */
-#define MACHINE_BUS_PCMCIA    0x00000200 /* sys has PCMCIA bus */
-#define MACHINE_BUS_AGP       0x00000400 /* sys has AGP bus */
-#define MACHINE_BUS_AC97      0x00000800 /* sys has AC97 bus (ACR/AMR/CNR slot) */
+#define MACHINE_BUS_CASSETTE  0x00000002 /* sys has cassette port */
+#define MACHINE_BUS_CARTRIDGE 0x00000004 /* sys has two cartridge bays */
+#define MACHINE_BUS_ISA16     0x00000008 /* sys has ISA16 bus - PC/AT architecture */
+#define MACHINE_BUS_CBUS      0x00000010 /* sys has C-BUS bus */
+#define MACHINE_BUS_PS2       0x00000020 /* system has PS/2 keyboard and mouse ports */
+#define MACHINE_BUS_EISA      0x00000040 /* sys has EISA bus */
+#define MACHINE_BUS_VLB       0x00000080 /* sys has VL bus */
+#define MACHINE_BUS_MCA       0x00000100 /* sys has MCA bus */
+#define MACHINE_BUS_PCI       0x00000200 /* sys has PCI bus */
+#define MACHINE_BUS_PCMCIA    0x00000400 /* sys has PCMCIA bus */
+#define MACHINE_BUS_AGP       0x00000800 /* sys has AGP bus */
+#define MACHINE_BUS_AC97      0x00001000 /* sys has AC97 bus (ACR/AMR/CNR slot) */
 /* Aliases. */
+#define MACHINE_CASSETTE  (MACHINE_BUS_CASSETTE)  /* sys has cassette port */
 #define MACHINE_CARTRIDGE (MACHINE_BUS_CARTRIDGE) /* sys has two cartridge bays */
 /* Combined flags. */
 #define MACHINE_PC        (MACHINE_BUS_ISA)                     /* sys is PC/XT-compatible (ISA) */
@@ -57,16 +59,17 @@
 #define MACHINE_AGP       (MACHINE_BUS_AGP | MACHINE_PCI)       /* sys is AT-compatible with AGP  */
 #define MACHINE_AGP98     (MACHINE_BUS_AGP | MACHINE_PCI98)     /* sys is NEC PC-98x1 series with AGP (did that even exist?) */
 
-#define MACHINE_PCJR      (MACHINE_PC | MACHINE_CARTRIDGE)     /* sys is PCjr */
-#define MACHINE_PS2       (MACHINE_AT | MACHINE_BUS_PS2)       /* sys is PS/2 */
-#define MACHINE_PS2_MCA   (MACHINE_MCA | MACHINE_BUS_PS2)      /* sys is MCA PS/2 */
-#define MACHINE_PS2_VLB   (MACHINE_VLB | MACHINE_BUS_PS2)      /* sys is VLB PS/2 */
-#define MACHINE_PS2_PCI   (MACHINE_PCI | MACHINE_BUS_PS2)      /* sys is PCI PS/2 */
-#define MACHINE_PS2_PCIV  (MACHINE_PCIV | MACHINE_BUS_PS2)     /* sys is VLB/PCI PS/2 */
-#define MACHINE_PS2_AGP   (MACHINE_AGP | MACHINE_BUS_PS2)      /* sys is AGP PS/2 */
-#define MACHINE_PS2_A97   (MACHINE_PS2_AGP | MACHINE_BUS_AC97) /* sys is AGP/AC97 PS/2 */
-#define MACHINE_PS2_NOISA (MACHINE_PS2_AGP & ~MACHINE_AT)      /* sys is AGP PS/2 without ISA */
-#define MACHINE_PS2_NOI97 (MACHINE_PS2_A97 & ~MACHINE_AT)      /* sys is AGP/AC97 PS/2 without ISA */
+#define MACHINE_PC5150    (MACHINE_PC | MACHINE_CASSETTE)                     /* sys is IBM PC 5150 */
+#define MACHINE_PCJR      (MACHINE_PC | MACHINE_CASSETTE | MACHINE_CARTRIDGE) /* sys is PCjr */
+#define MACHINE_PS2       (MACHINE_AT | MACHINE_BUS_PS2)                      /* sys is PS/2 */
+#define MACHINE_PS2_MCA   (MACHINE_MCA | MACHINE_BUS_PS2)                     /* sys is MCA PS/2 */
+#define MACHINE_PS2_VLB   (MACHINE_VLB | MACHINE_BUS_PS2)                     /* sys is VLB PS/2 */
+#define MACHINE_PS2_PCI   (MACHINE_PCI | MACHINE_BUS_PS2)                     /* sys is PCI PS/2 */
+#define MACHINE_PS2_PCIV  (MACHINE_PCIV | MACHINE_BUS_PS2)                    /* sys is VLB/PCI PS/2 */
+#define MACHINE_PS2_AGP   (MACHINE_AGP | MACHINE_BUS_PS2)                     /* sys is AGP PS/2 */
+#define MACHINE_PS2_A97   (MACHINE_PS2_AGP | MACHINE_BUS_AC97)                /* sys is AGP/AC97 PS/2 */
+#define MACHINE_PS2_NOISA (MACHINE_PS2_AGP & ~MACHINE_AT)                     /* sys is AGP PS/2 without ISA */
+#define MACHINE_PS2_NOI97 (MACHINE_PS2_A97 & ~MACHINE_AT)                     /* sys is AGP/AC97 PS/2 without ISA */
 /* Feature flags for miscellaneous internal devices. */
 #define MACHINE_FLAGS_NONE 0x00000000 /* sys has no int devices */
 #define MACHINE_VIDEO      0x00000001 /* sys has int video */

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -222,7 +222,7 @@ const machine_t machines[] = {
             .min_multi = 0,
             .max_multi = 0
         },
-        .bus_flags = MACHINE_PC,
+        .bus_flags = MACHINE_PC5150,
         .flags = MACHINE_FLAGS_NONE,
         .ram = {
             .min = 16,
@@ -260,7 +260,7 @@ const machine_t machines[] = {
             .min_multi = 0,
             .max_multi = 0
         },
-        .bus_flags = MACHINE_PC,
+        .bus_flags = MACHINE_PC5150,
         .flags = MACHINE_FLAGS_NONE,
         .ram = {
             .min = 64,

--- a/src/qt/qt_settingsstoragecontrollers.cpp
+++ b/src/qt/qt_settingsstoragecontrollers.cpp
@@ -56,12 +56,12 @@ SettingsStorageControllers::save()
         auto *cbox           = findChild<QComboBox *>(QString("comboBoxSCSI%1").arg(i + 1));
         scsi_card_current[i] = cbox->currentData().toInt();
     }
-    hdc_current     		= ui->comboBoxHD->currentData().toInt();
-    fdc_type        		= ui->comboBoxFD->currentData().toInt();
-	cdrom_interface_current = ui->comboBoxCDInterface->currentData().toInt();
-    ide_ter_enabled 		= ui->checkBoxTertiaryIDE->isChecked() ? 1 : 0;
-    ide_qua_enabled 		= ui->checkBoxQuaternaryIDE->isChecked() ? 1 : 0;
-    cassette_enable 		= ui->checkBoxCassette->isChecked() ? 1 : 0;
+    hdc_current             = ui->comboBoxHD->currentData().toInt();
+    fdc_type                = ui->comboBoxFD->currentData().toInt();
+    cdrom_interface_current = ui->comboBoxCDInterface->currentData().toInt();
+    ide_ter_enabled         = ui->checkBoxTertiaryIDE->isChecked() ? 1 : 0;
+    ide_qua_enabled         = ui->checkBoxQuaternaryIDE->isChecked() ? 1 : 0;
+    cassette_enable         = ui->checkBoxCassette->isChecked() ? 1 : 0;
 }
 
 void
@@ -132,9 +132,9 @@ SettingsStorageControllers::onCurrentMachineChanged(int machineId)
     ui->comboBoxFD->setCurrentIndex(selectedRow);
 
     /*CD interface controller config*/
-    model 		= ui->comboBoxCDInterface->model();
-    removeRows 	= model->rowCount();
-    c 			= 0;
+    model      = ui->comboBoxCDInterface->model();
+    removeRows = model->rowCount();
+    c          = 0;
     selectedRow = 0;
     while (true) {
         /* Skip "internal" if machine doesn't have it. */

--- a/src/qt/qt_settingsstoragecontrollers.cpp
+++ b/src/qt/qt_settingsstoragecontrollers.cpp
@@ -40,8 +40,6 @@ SettingsStorageControllers::SettingsStorageControllers(QWidget *parent)
 {
     ui->setupUi(this);
 
-    ui->checkBoxCassette->setChecked(cassette_enable > 0);
-
     onCurrentMachineChanged(machine);
 }
 
@@ -198,6 +196,14 @@ SettingsStorageControllers::onCurrentMachineChanged(int machineId)
     ui->checkBoxQuaternaryIDE->setEnabled(is_at > 0);
     ui->checkBoxTertiaryIDE->setChecked(ui->checkBoxTertiaryIDE->isEnabled() && ide_ter_enabled);
     ui->checkBoxQuaternaryIDE->setChecked(ui->checkBoxQuaternaryIDE->isEnabled() && ide_qua_enabled);
+
+    if (machine_has_bus(machineId, MACHINE_BUS_CASSETTE)) {
+        ui->checkBoxCassette->setChecked(cassette_enable > 0);
+        ui->checkBoxCassette->setEnabled(true);
+    } else {
+        ui->checkBoxCassette->setChecked(false);
+        ui->checkBoxCassette->setEnabled(false);
+    }
 }
 
 void

--- a/src/win/win_settings.c
+++ b/src/win/win_settings.c
@@ -2002,9 +2002,10 @@ win_settings_storage_proc(HWND hdlg, UINT message, WPARAM wParam, LPARAM lParam)
             settings_enable_window(hdlg, IDC_BUTTON_IDE_TER, is_at && temp_ide_ter);
             settings_enable_window(hdlg, IDC_CHECK_IDE_QUA, is_at);
             settings_enable_window(hdlg, IDC_BUTTON_IDE_QUA, is_at && temp_ide_qua);
+            settings_enable_window(hdlg, IDC_CHECK_CASSETTE, machine_has_bus(temp_machine, MACHINE_BUS_CASSETTE));
             settings_set_check(hdlg, IDC_CHECK_IDE_TER, temp_ide_ter);
             settings_set_check(hdlg, IDC_CHECK_IDE_QUA, temp_ide_qua);
-            settings_set_check(hdlg, IDC_CHECK_CASSETTE, temp_cassette);
+            settings_set_check(hdlg, IDC_CHECK_CASSETTE, (temp_cassette && machine_has_bus(temp_machine, MACHINE_BUS_CASSETTE)));
 
             free(stransi);
             free(lptsTemp);


### PR DESCRIPTION
Summary
=======
Introduce a new machine feature flag for machines with a cassette port (IBM PC 1981 and 1982, and PCjr) and disables the cassette option (including graying out the checkbox in Qt and Win32 UIs) on machines without the flag. Cassette is now added to the default IBM PC (1981) configuration that is loaded when starting without a .cfg file.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
