### PR TITLE
Fix ISABugger not being actually disabled on machines without ISA

### DIFF
--- a/src/qt/qt_settingsotherperipherals.cpp
+++ b/src/qt/qt_settingsotherperipherals.cpp
@@ -41,11 +41,12 @@ SettingsOtherPeripherals::onCurrentMachineChanged(int machineId)
 {
     this->machineId = machineId;
 
-    ui->checkBoxISABugger->setChecked(bugger_enabled > 0 ? true : false);
+    bool machineHasIsa = (machine_has_bus(machineId, MACHINE_BUS_ISA) > 0);
+    ui->checkBoxISABugger->setChecked((machineHasIsa && (bugger_enabled > 0)) ? true : false);
     ui->checkBoxPOSTCard->setChecked(postcard_enabled > 0 ? true : false);
-    ui->checkBoxISABugger->setEnabled(machine_has_bus(machineId, MACHINE_BUS_ISA));
-    ui->comboBoxRTC->setEnabled(machine_has_bus(machineId, MACHINE_BUS_ISA));
-    ui->pushButtonConfigureRTC->setEnabled(machine_has_bus(machineId, MACHINE_BUS_ISA));
+    ui->checkBoxISABugger->setEnabled(machineHasIsa);
+    ui->comboBoxRTC->setEnabled(machineHasIsa);
+    ui->pushButtonConfigureRTC->setEnabled(machineHasIsa);
 
     ui->comboBoxCard1->clear();
     ui->comboBoxCard2->clear();
@@ -97,8 +98,8 @@ SettingsOtherPeripherals::onCurrentMachineChanged(int machineId)
         }
         cbox->setCurrentIndex(-1);
         cbox->setCurrentIndex(selectedRow);
-        cbox->setEnabled(machine_has_bus(machineId, MACHINE_BUS_ISA));
-        findChild<QPushButton *>(QString("pushButtonConfigureCard%1").arg(c + 1))->setEnabled(isamem_type[c] != 0 && machine_has_bus(machineId, MACHINE_BUS_ISA));
+        cbox->setEnabled(machineHasIsa);
+        findChild<QPushButton *>(QString("pushButtonConfigureCard%1").arg(c + 1))->setEnabled(isamem_type[c] != 0 && machineHasIsa);
     }
 }
 

--- a/src/win/win_settings.c
+++ b/src/win/win_settings.c
@@ -5415,7 +5415,7 @@ win_settings_peripherals_proc(HWND hdlg, UINT message, WPARAM wParam, LPARAM lPa
             }
 
             settings_enable_window(hdlg, IDC_CHECK_BUGGER, machine_has_bus(temp_machine, MACHINE_BUS_ISA));
-            settings_set_check(hdlg, IDC_CHECK_BUGGER, temp_bugger);
+            settings_set_check(hdlg, IDC_CHECK_BUGGER, (temp_bugger && machine_has_bus(temp_machine, MACHINE_BUS_ISA)));
             settings_set_check(hdlg, IDC_CHECK_POSTCARD, temp_postcard);
 
             free(stransi);


### PR DESCRIPTION
Summary
=======
Fix an oversight in Qt and Win32 UIs when the ISABugger device would not be removed after switching to a machine without ISA slots.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
