### PR TITLE
Add a machine flag for machines requiring softfloat FPU and improve the related UI behavior

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -515,13 +515,8 @@ load_machine(void)
 
     cpu_use_dynarec = !!ini_section_get_int(cat, "cpu_use_dynarec", 0);
     fpu_softfloat = !!ini_section_get_int(cat, "fpu_softfloat", 0);
-    /*The IBM PS/2 model 70 type 4 BIOS does heavy tests to the FPU in 80-bit precision mode, requiring softfloat 
-      otherwise it would always throw error 12903 on POST, so always disable dynarec and enable softfloat for this
-      machine only.*/
-    if (!strcmp(machines[machine].internal_name, "ibmps2_m70_type4")) {
-        cpu_use_dynarec = 0;
+    if (machine_has_flags(machine, MACHINE_SOFTFLOAT_ONLY))
         fpu_softfloat = 1;
-    }
 
     p = ini_section_get_string(cat, "time_sync", NULL);
     if (p != NULL) {

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -98,19 +98,20 @@
 #define MACHINE_AV            (MACHINE_VIDEO | MACHINE_SOUND)    /* sys has video and sound */
 #define MACHINE_AG            (MACHINE_SOUND | MACHINE_GAMEPORT) /* sys has sound and game port */
 /* Feature flags for internal storage controllers. */
-#define MACHINE_HDC      0x03FE0000 /* sys has int HDC */
-#define MACHINE_MFM      0x00020000 /* sys has int MFM/RLL */
-#define MACHINE_XTA      0x00040000 /* sys has int XTA */
-#define MACHINE_ESDI     0x00080000 /* sys has int ESDI */
-#define MACHINE_IDE_PRI  0x00100000 /* sys has int pri IDE/ATAPI */
-#define MACHINE_IDE_SEC  0x00200000 /* sys has int sec IDE/ATAPI */
-#define MACHINE_IDE_TER  0x00400000 /* sys has int ter IDE/ATAPI */
-#define MACHINE_IDE_QUA  0x00800000 /* sys has int qua IDE/ATAPI */
-#define MACHINE_SCSI_PRI 0x01000000 /* sys has int pri SCSI */
-#define MACHINE_SCSI_SEC 0x02000000 /* sys has int sec SCSI */
-#define MACHINE_USB_PRI  0x04000000 /* sys has int pri USB */
-#define MACHINE_USB_SEC  0x08000000 /* sys has int sec USB */
-#define MACHINE_COREBOOT 0x10000000 /* sys has coreboot BIOS */
+#define MACHINE_HDC            0x03FE0000 /* sys has int HDC */
+#define MACHINE_MFM            0x00020000 /* sys has int MFM/RLL */
+#define MACHINE_XTA            0x00040000 /* sys has int XTA */
+#define MACHINE_ESDI           0x00080000 /* sys has int ESDI */
+#define MACHINE_IDE_PRI        0x00100000 /* sys has int pri IDE/ATAPI */
+#define MACHINE_IDE_SEC        0x00200000 /* sys has int sec IDE/ATAPI */
+#define MACHINE_IDE_TER        0x00400000 /* sys has int ter IDE/ATAPI */
+#define MACHINE_IDE_QUA        0x00800000 /* sys has int qua IDE/ATAPI */
+#define MACHINE_SCSI_PRI       0x01000000 /* sys has int pri SCSI */
+#define MACHINE_SCSI_SEC       0x02000000 /* sys has int sec SCSI */
+#define MACHINE_USB_PRI        0x04000000 /* sys has int pri USB */
+#define MACHINE_USB_SEC        0x08000000 /* sys has int sec USB */
+#define MACHINE_COREBOOT       0x10000000 /* sys has coreboot BIOS */
+#define MACHINE_SOFTFLOAT_ONLY 0x20000000 /* sys requires softfloat FPU */
 /* Combined flags. */
 #define MACHINE_IDE        (MACHINE_IDE_PRI)                   /* sys has int single IDE/ATAPI - mark as pri IDE/ATAPI */
 #define MACHINE_IDE_DUAL   (MACHINE_IDE_PRI | MACHINE_IDE_SEC) /* sys has int dual IDE/ATAPI - mark as both pri and sec IDE/ATAPI */

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -5492,7 +5492,7 @@ const machine_t machines[] = {
             .max_multi = 0
         },
         .bus_flags = MACHINE_PS2_MCA,
-        .flags = MACHINE_VIDEO,
+        .flags = MACHINE_VIDEO | MACHINE_SOFTFLOAT_ONLY,
         .ram = {
             .min = 2048,
             .max = 65536,

--- a/src/qt/qt_settingsmachine.cpp
+++ b/src/qt/qt_settingsmachine.cpp
@@ -110,11 +110,7 @@ SettingsMachine::save()
     cpu             = ui->comboBoxSpeed->currentData().toInt();
     fpu_type        = ui->comboBoxFPU->currentData().toInt();
     cpu_use_dynarec = ui->checkBoxDynamicRecompiler->isChecked() ? 1 : 0;
-    fpu_softfloat   = (ui->checkBoxFPUSoftfloat->isChecked() && !cpu_use_dynarec) ? 1 : 0;
-    if (!strcmp(machines[machine].internal_name, "ibmps2_m70_type4")) {
-        cpu_use_dynarec = 0;
-        fpu_softfloat = 1;
-    }
+    fpu_softfloat   = ui->checkBoxFPUSoftfloat->isChecked() ? 1 : 0;
 
     int64_t temp_mem_size;
     if (machine_get_ram_granularity(machine) < 1024) {
@@ -281,25 +277,17 @@ SettingsMachine::on_comboBoxSpeed_currentIndexChanged(int index)
     if (!(flags & CPU_SUPPORTS_DYNAREC)) {
         ui->checkBoxDynamicRecompiler->setChecked(false);
         ui->checkBoxDynamicRecompiler->setEnabled(false);
-        ui->checkBoxFPUSoftfloat->setChecked(fpu_softfloat);
-        ui->checkBoxFPUSoftfloat->setEnabled(cpu_use_dynarec ? false : true);
     } else if (flags & CPU_REQUIRES_DYNAREC) {
         ui->checkBoxDynamicRecompiler->setChecked(true);
         ui->checkBoxDynamicRecompiler->setEnabled(false);
-        ui->checkBoxFPUSoftfloat->setChecked(false);
-        ui->checkBoxFPUSoftfloat->setEnabled(false);
     } else {
         ui->checkBoxDynamicRecompiler->setChecked(cpu_use_dynarec);
         ui->checkBoxDynamicRecompiler->setEnabled(true);
-        ui->checkBoxFPUSoftfloat->setChecked(fpu_softfloat);
-        ui->checkBoxFPUSoftfloat->setEnabled(cpu_use_dynarec ? false : true);
     }
-#else
-    ui->checkBoxFPUSoftfloat->setChecked(fpu_softfloat);
-    ui->checkBoxFPUSoftfloat->setEnabled(true);
 #endif
 
     // win_settings_machine_recalc_fpu
+    int   machineId  = ui->comboBoxMachine->currentData().toInt();
     auto *modelFpu   = ui->comboBoxFPU->model();
     int   removeRows = modelFpu->rowCount();
 
@@ -317,6 +305,10 @@ SettingsMachine::on_comboBoxSpeed_currentIndexChanged(int index)
     ui->comboBoxFPU->setEnabled(modelFpu->rowCount() > 1);
     ui->comboBoxFPU->setCurrentIndex(-1);
     ui->comboBoxFPU->setCurrentIndex(selectedFpuRow);
+
+    ui->checkBoxFPUSoftfloat->setChecked(machine_has_flags(machineId, MACHINE_SOFTFLOAT_ONLY) ? true : fpu_softfloat);
+    ui->checkBoxFPUSoftfloat->setEnabled(machine_has_flags(machineId, MACHINE_SOFTFLOAT_ONLY) ? false : true);
+
 }
 
 void

--- a/src/win/win_settings.c
+++ b/src/win/win_settings.c
@@ -714,7 +714,8 @@ win_settings_machine_recalc_fpu(HWND hdlg)
         c++;
     }
 
-    settings_set_check(hdlg, IDC_CHECK_SOFTFLOAT, temp_fpu_softfloat);
+    settings_set_check(hdlg, IDC_CHECK_SOFTFLOAT, (machine_has_flags(temp_machine, MACHINE_SOFTFLOAT_ONLY) ? TRUE : temp_fpu_softfloat));
+    settings_enable_window(hdlg, IDC_CHECK_SOFTFLOAT, (machine_has_flags(temp_machine, MACHINE_SOFTFLOAT_ONLY) ? FALSE : TRUE));
 
     settings_enable_window(hdlg, IDC_COMBO_FPU, c > 1);
 


### PR DESCRIPTION
Summary
=======
* Introduce a new machine feature flag for machines that require softfloat FPU emulation to work, and replace existing hacks for the IBM PS/2 Model 70 type 4 with checks for this flag;
* Disable the softfloat checkbox in the Qt and Win32 UIs when a machine with this flag is selected;
* Remove the existing restrictions on having softfloat and dynarec enabled simultaneously.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
