### PR TITLE
qt: Hide the dynarec checkbox if built without a dynarec

### DIFF
--- a/src/qt/qt_settingsmachine.cpp
+++ b/src/qt/qt_settingsmachine.cpp
@@ -90,6 +90,11 @@ SettingsMachine::SettingsMachine(QWidget *parent)
 
     ui->comboBoxMachineType->setCurrentIndex(-1);
     ui->comboBoxMachineType->setCurrentIndex(selectedMachineType);
+
+#ifndef USE_DYNAREC
+    ui->checkBoxDynamicRecompiler->setEnabled(false);
+    ui->checkBoxDynamicRecompiler->setVisible(false);
+#endif
 }
 
 SettingsMachine::~SettingsMachine()


### PR DESCRIPTION
Summary
=======
Hide the dynamic recompiler checkbox in the settings dialog of the Qt UI when 86Box is built without a dynarec.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
