### PR TITLE
qt: Change default disk image type to dynamic vhd

### DIFF
--- a/src/qt/qt_filefield.cpp
+++ b/src/qt/qt_filefield.cpp
@@ -31,6 +31,12 @@ FileField::FileField(QWidget *parent)
         fileName_ = ui->label->text();
         emit fileSelected(ui->label->text(), true);
     });
+
+    connect(ui->label, &QLineEdit::textChanged, this, [this]() {
+        fileName_ = ui->label->text();
+        emit fileTextEntered(ui->label->text(), true);
+    });
+
     this->setFixedWidth(this->sizeHint().width() + ui->pushButton->sizeHint().width());
 }
 

--- a/src/qt/qt_filefield.hpp
+++ b/src/qt/qt_filefield.hpp
@@ -19,12 +19,14 @@ public:
 
     void    setFilter(const QString &filter) { filter_ = filter; }
     QString selectedFilter() const { return selectedFilter_; }
+    void    setselectedFilter(const QString &selectedFilter) { selectedFilter_ = selectedFilter; }
 
     void setCreateFile(bool createFile) { createFile_ = createFile; }
     bool createFile() { return createFile_; }
 
 signals:
     void fileSelected(const QString &fileName, bool precheck = false);
+    void fileTextEntered(const QString &fileName, bool precheck = false);
 
 private slots:
     void on_pushButton_clicked();

--- a/src/qt/qt_harddiskdialog.cpp
+++ b/src/qt/qt_harddiskdialog.cpp
@@ -84,6 +84,13 @@ HarddiskDialog::HarddiskDialog(bool existing, QWidget *parent)
     ui->lineEditSize->setValidator(new QIntValidator());
     ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
 
+    filters = QStringList({ tr("Raw image") % util::DlgFilter({ "img" }, true),
+                          tr("HDI image") % util::DlgFilter({ "hdi" }, true),
+                          tr("HDX image") % util::DlgFilter({ "hdx" }, true),
+                          tr("Fixed-size VHD") % util::DlgFilter({ "vhd" }, true),
+                          tr("Dynamic-size VHD") % util::DlgFilter({ "vhd" }, true),
+                          tr("Differencing VHD") % util::DlgFilter({ "vhd" }, true) });
+
     if (existing) {
         ui->fileField->setFilter(tr("Hard disk images") % util::DlgFilter({ "hd?", "im?", "vhd" }) % tr("All files") % util::DlgFilter({ "*" }, true));
 
@@ -99,24 +106,26 @@ HarddiskDialog::HarddiskDialog(bool existing, QWidget *parent)
 
         connect(ui->fileField, &FileField::fileSelected, this, &HarddiskDialog::onExistingFileSelected);
     } else {
-        QStringList filters({ tr("Raw image") % util::DlgFilter({ "img" }, true),
-                              tr("HDI image") % util::DlgFilter({ "hdi" }, true),
-                              tr("HDX image") % util::DlgFilter({ "hdx" }, true),
-                              tr("Fixed-size VHD") % util::DlgFilter({ "vhd" }, true),
-                              tr("Dynamic-size VHD") % util::DlgFilter({ "vhd" }, true),
-                              tr("Differencing VHD") % util::DlgFilter({ "vhd" }, true) });
-
         ui->fileField->setFilter(filters.join(";;"));
 
         setWindowTitle(tr("Add New Hard Disk"));
         ui->fileField->setCreateFile(true);
 
-        connect(ui->fileField, &FileField::fileSelected, this, [this, filters] {
+        // Enable the OK button as long as the filename length is non-zero
+        connect(ui->fileField, &FileField::fileTextEntered, this, [this] {
+            ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled((this->fileName().length() > 0));
+        });
+
+        connect(ui->fileField, &FileField::fileSelected, this, [this] {
             int filter = filters.indexOf(ui->fileField->selectedFilter());
             if (filter > -1)
                 ui->comboBoxFormat->setCurrentIndex(filter);
             ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
         });
+        // Set the default format to Dynamic-size VHD. Do it last after everything is set up
+        // so the currentIndexChanged signal can do what is needed
+        ui->comboBoxFormat->setCurrentIndex(DEFAULT_DISK_FORMAT);
+        ui->fileField->setselectedFilter(filters.value(DEFAULT_DISK_FORMAT));
     }
 }
 
@@ -179,6 +188,7 @@ HarddiskDialog::on_comboBoxFormat_currentIndexChanged(int index)
         ui->comboBoxBlockSize->show();
         ui->labelBlockSize->show();
     }
+    ui->fileField->setselectedFilter(filters.value(index));
 }
 
 /* If the disk geometry requested in the 86Box GUI is not compatible with the internal VHD geometry,

--- a/src/qt/qt_harddiskdialog.hpp
+++ b/src/qt/qt_harddiskdialog.hpp
@@ -52,6 +52,11 @@ private:
 
     bool disallowSizeModifications = false;
 
+    QStringList filters;
+    // "Dynamic-size VHD" is number 4 in the `filters` list and the
+    // comboBoxFormat model
+    const uint8_t DEFAULT_DISK_FORMAT = 4;
+
     bool checkAndAdjustCylinders();
     bool checkAndAdjustHeads();
     bool checkAndAdjustSectors();


### PR DESCRIPTION
Summary
=======
This PR changes the default disk image type to dynamic vhd. All of the other options still remain.

There are some other small fixes in here. `qt_filefield` had some unfinished functionality which caused some things in `qt_harddiskdialog` to not work at all. Such as

* Not selecting the proper file filter in the open dialog based on the selected type
* Not properly enabling the OK button once a filename is entered
* No setter for `selectedFilter`

All things considered, `qt_filefield` should probably be rewritten but that is for another day.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
