### PR TITLE
macos: Add special mapping for insert key

### DIFF
--- a/src/qt/cocoa_keyboard.hpp
+++ b/src/qt/cocoa_keyboard.hpp
@@ -127,3 +127,9 @@ static std::array<uint32_t, 127> cocoa_keycodes = { /* key names in parentheses 
     0x150, /* DownArrow */
     0x148, /* UpArrow */
 };
+
+// https://developer.apple.com/documentation/appkit/nseventmodifierflags/
+qint32 NSEventModifierFlagCommand = 1 << 20;
+
+qint32 nvk_Delete = 0x75;
+qint32 nvk_Insert = 0x72;

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -1092,6 +1092,11 @@ MainWindow::processMacKeyboardInput(bool down, const QKeyEvent *event)
             if (mac_iso_swap)
                 nvk = (nvk == 0x0a) ? 0x32 : 0x0a;
         }
+        // Special case for command + forward delete to send insert.
+        if ((event->nativeModifiers() & NSEventModifierFlagCommand) &&
+            ((event->nativeVirtualKey() == nvk_Delete) || event->key() == Qt::Key_Delete)) {
+            nvk = nvk_Insert; // Qt::Key_Help according to event->key()
+        }
 
         processKeyboardInput(down, nvk);
     }


### PR DESCRIPTION
Summary
=======
macOS doesn't really have a concept of the insert key, but guests do. On modern macOS keyboards (at least en-us) what would be close to the insert key is now the `Fn` or "Globe" key. However, that key is owned by macOS and will not pass through to guests.

This adds a special case for `Command + Delete` which will send `Insert` to the guest. 

**Note:** The delete key being referred to here is "forward delete" on a mac keyboard, not the delete key where the backspace key would be on some keyboards.

**Note 2:** An external keyboard that has a regular insert key still works fine.

Checklist
=========
* [X] Closes #3410
* [X] I have discussed this with core contributors already

References
==========
N/A
