### PR TITLE
FluidSynth code improvements

### DIFF
--- a/src/sound/midi_fluidsynth.c
+++ b/src/sound/midi_fluidsynth.c
@@ -216,7 +216,7 @@ fluidsynth_init(const device_t *info)
 
         double reverb_room_size = device_get_config_int("reverb_room_size") / 100.0;
         double reverb_damping   = device_get_config_int("reverb_damping") / 100.0;
-        int    reverb_width     = device_get_config_int("reverb_width");
+        double reverb_width     = device_get_config_int("reverb_width") / 10.0;
         double reverb_level     = device_get_config_int("reverb_level") / 100.0;
 
 #    ifndef USE_OLD_FLUIDSYNTH_API
@@ -342,7 +342,7 @@ static const device_config_t fluidsynth_config[] = {
         .name = "chorus",
         .description = "Chorus",
         .type = CONFIG_BINARY,
-        .default_int = 0
+        .default_int = 1
     },
     {
         .name = "chorus_voices",
@@ -364,7 +364,7 @@ static const device_config_t fluidsynth_config[] = {
             .min = 0,
             .max = 100
         },
-        .default_int = 100
+        .default_int = 20
     },
     {
         .name = "chorus_speed",
@@ -372,7 +372,7 @@ static const device_config_t fluidsynth_config[] = {
         .type = CONFIG_SPINNER,
         .spinner =
         {
-            .min = 30,
+            .min = 10,
             .max = 500
         },
         .default_int = 30
@@ -384,7 +384,7 @@ static const device_config_t fluidsynth_config[] = {
         .spinner =
         {
             .min = 0,
-            .max = 210
+            .max = 2560
         },
         .default_int = 80
     },
@@ -409,7 +409,7 @@ static const device_config_t fluidsynth_config[] = {
         .name = "reverb",
         .description = "Reverb",
         .type = CONFIG_BINARY,
-        .default_int = 0
+        .default_int = 1
     },
     {
         .name = "reverb_room_size",
@@ -418,7 +418,7 @@ static const device_config_t fluidsynth_config[] = {
         .spinner =
         {
             .min = 0,
-            .max = 120
+            .max = 100
         },
         .default_int = 20
     },
@@ -440,9 +440,9 @@ static const device_config_t fluidsynth_config[] = {
         .spinner =
         {
             .min = 0,
-            .max = 100
+            .max = 1000
         },
-        .default_int = 1
+        .default_int = 5
     },
     {
         .name = "reverb_level",

--- a/src/sound/midi_fluidsynth.c
+++ b/src/sound/midi_fluidsynth.c
@@ -15,17 +15,8 @@
 #    include <86box/config.h>
 #    include <86box/device.h>
 #    include <86box/midi.h>
-#    include <86box/plat.h>
-#    include <86box/plat_dynld.h>
 #    include <86box/thread.h>
 #    include <86box/sound.h>
-#    include <86box/ui.h>
-
-#    define FLUID_CHORUS_DEFAULT_N     3
-#    define FLUID_CHORUS_DEFAULT_LEVEL 2.0f
-#    define FLUID_CHORUS_DEFAULT_SPEED 0.3f
-#    define FLUID_CHORUS_DEFAULT_DEPTH 8.0f
-#    define FLUID_CHORUS_DEFAULT_TYPE  FLUID_CHORUS_MOD_SINE
 
 #    define RENDER_RATE                100
 #    define BUFFER_SEGMENTS            10
@@ -34,10 +25,10 @@ extern void givealbuffer_midi(void *buf, uint32_t size);
 extern void al_set_midi(int freq, int buf_size);
 
 typedef struct fluidsynth {
-    void *settings;
-    void *synth;
-    int   samplerate;
-    int   sound_font;
+    fluid_settings_t *settings;
+    fluid_synth_t    *synth;
+    int               samplerate;
+    int               sound_font;
 
     thread_t *thread_h;
     event_t  *event, *start_event;


### PR DESCRIPTION
Summary
=======
* Cleanup of stuff left over after the removal of FluidSynth dynloading: remove #defines that were never used and #includes that are no longer needed, use actual types for pointers to FluidSynth-specific structs instead of `void *`
* Use the new reverb/chorus control API functions added in FluidSynth v2.2.0 if linking to v2.2.0 or later, and keep using the older now-deprecated functions otherwise 
* Bring default configuration values and their limits in line with the latest FluidSynth version

Thing to note: due to 86Box device configuration system only supporting integer numbers for options, reverb width on the config side is now multiplied by 10 to accommodate the new default value of 0.5 (5).


Checklist
=========
* [x] Closes #3049
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
