### PR TITLE
Fix GitHub Actions failing

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -90,6 +90,7 @@ jobs:
             libpng:p
             openal:p
             rtmidi:p
+            fluidsynth:p
             libvncserver:p
 
       - name: Checkout repository

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -90,6 +90,7 @@ jobs:
             libpng:p
             openal:p
             rtmidi:p
+            libslirp:p
             fluidsynth:p
             libvncserver:p
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -105,6 +105,7 @@ jobs:
             openal:p
             rtmidi:p
             libslirp:p
+            fluidsynth:p
             libvncserver:p
             ${{ matrix.ui.packages }}
 
@@ -329,8 +330,9 @@ jobs:
           libc6-dev
           librtmidi-dev
           libopenal-dev
-          libvncserver-dev
           libslirp-dev
+          libfluidsynth-dev
+          libvncserver-dev
           ${{ matrix.ui.packages }}
 
       - name: Checkout repository
@@ -415,6 +417,7 @@ jobs:
           libpng
           rtmidi
           openal-soft
+          fluidsynth
           libvncserver
           ${{ matrix.ui.packages }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -108,6 +108,7 @@ jobs:
             openal:p
             rtmidi:p
             libslirp:p
+            fluidsynth:p
             libvncserver:p
             ${{ matrix.ui.packages }}
 
@@ -193,6 +194,7 @@ jobs:
           librtmidi-dev
           libopenal-dev
           libslirp-dev
+          libfluidsynth-dev
           libvncserver-dev
           ${{ matrix.ui.packages }}
 
@@ -268,6 +270,7 @@ jobs:
           libpng
           rtmidi
           openal-soft
+          fluidsynth
           libvncserver
           ${{ matrix.ui.packages }}
 


### PR DESCRIPTION
Summary
=======
Fixes CI builds failing due to missing FluidSynth (and for Makefile actions, libslirp).

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
