### PR TITLE
CPU with softfloat features (below).

### DIFF
--- a/src/cpu/x87.h
+++ b/src/cpu/x87.h
@@ -141,6 +141,8 @@ void FPU_stack_underflow(uint32_t fetchdat, int stnr, int pop_stack);
 int FPU_handle_NaN32(floatx80 a, float32 b, floatx80 *r, struct float_status_t *status);
 int FPU_handle_NaN64(floatx80 a, float64 b, floatx80 *r, struct float_status_t *status);
 int FPU_tagof(const floatx80 reg);
+uint8_t pack_FPU_TW(uint16_t twd);
+uint16_t unpack_FPU_TW(uint16_t tag_byte);
 
 static __inline uint16_t
 i387_get_control_word(void)


### PR DESCRIPTION
Summary
=======
CPU with softfloat: Added softfloat versions of the i686 FX opcodes while preserving the existing non-softfloat ones.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
