### PR TITLE
Machine features and fixes:

### DIFF
--- a/src/include/86box/keyboard.h
+++ b/src/include/86box/keyboard.h
@@ -234,6 +234,7 @@ extern const device_t keyboard_at_tg_ami_device;
 extern const device_t keyboard_at_toshiba_device;
 extern const device_t keyboard_at_olivetti_device;
 extern const device_t keyboard_at_ncr_device;
+extern const device_t keyboard_at_compaq_device;
 extern const device_t keyboard_ps2_device;
 extern const device_t keyboard_ps2_ps1_device;
 extern const device_t keyboard_ps2_ps1_pci_device;

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -544,9 +544,8 @@ extern int machine_at_cmdpc_init(const machine_t *);
 extern int machine_at_portableii_init(const machine_t *);
 extern int machine_at_portableiii_init(const machine_t *);
 extern int machine_at_portableiii386_init(const machine_t *);
-#if defined(DEV_BRANCH) && defined(USE_DESKPRO386)
 extern int machine_at_deskpro386_init(const machine_t *);
-#endif
+extern int machine_at_deskpro386_01_1988_init(const machine_t *);
 
 /* m_at_socket4.c */
 extern void machine_at_premiere_common_init(const machine_t *, int);

--- a/src/machine/m_at_compaq.c
+++ b/src/machine/m_at_compaq.c
@@ -31,6 +31,7 @@
 #include <86box/mem.h>
 #include <86box/rom.h>
 #include <86box/device.h>
+#include <86box/keyboard.h>
 #include <86box/fdd.h>
 #include <86box/fdc.h>
 #include <86box/fdc_ext.h>
@@ -41,21 +42,27 @@
 #include <86box/vid_cga.h>
 #include <86box/vid_cga_comp.h>
 
+
+static video_timings_t timing_compaq_plasma = { .type = VIDEO_ISA, .write_b = 8, .write_w = 16, .write_l = 32, .read_b = 8, .read_w = 16, .read_l = 32 };
+
 enum {
     COMPAQ_PORTABLEII = 0,
     COMPAQ_PORTABLEIII,
     COMPAQ_PORTABLEIII386,
-    COMPAQ_DESKPRO386
+    COMPAQ_DESKPRO386,
+    COMPAQ_DESKPRO386_01_1988
 };
 
 #define CGA_RGB       0
 #define CGA_COMPOSITE 1
 
-#define COMPOSITE_OLD 0
-#define COMPOSITE_NEW 1
-
 /*Very rough estimate*/
 #define VID_CLOCK (double) (651 * 416 * 60)
+
+static uint8_t cga_crtcmask[32] = {
+    0xff, 0xff, 0xff, 0xff, 0x7f, 0x1f, 0x7f, 0x7f, 0xf3, 0x1f, 0x7f, 0x1f, 0x3f, 0xff, 0x3f, 0xff,
+    0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
 
 /* Mapping of attributes to colours */
 static uint32_t amber;
@@ -72,6 +79,8 @@ static uint32_t normcols[256][2];
  */
 static int8_t cpq_st_display_internal = -1;
 
+static uint8_t mdaattr[256][2][2];
+
 static void
 compaq_plasma_display_set(uint8_t internal)
 {
@@ -85,21 +94,13 @@ compaq_plasma_display_get(void)
 }
 
 typedef struct compaq_plasma_t {
-    mem_mapping_t plasma_mapping;
     cga_t         cga;
     uint8_t       port_23c6;
     uint8_t       internal_monitor;
-    uint8_t       attrmap; /* Attribute mapping register */
-    int           linepos, displine;
-    uint8_t      *vram;
-    uint64_t      dispontime, dispofftime;
-    int           dispon, fullchange;
+    uint8_t       attrmap;
 } compaq_plasma_t;
 
-static uint8_t cga_crtcmask[32] = {
-    0xff, 0xff, 0xff, 0xff, 0x7f, 0x1f, 0x7f, 0x7f, 0xf3, 0x1f, 0x7f, 0x1f, 0x3f, 0xff, 0x3f, 0xff,
-    0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
-};
+static int compaq_machine_type = 0;
 
 /* Compaq Deskpro 386 remaps RAM from 0xA0000-0xFFFFF to 0xFA0000-0xFFFFFF */
 static mem_mapping_t ram_mapping;
@@ -121,8 +122,18 @@ compaq_plasma_recalctimings(compaq_plasma_t *self)
     disptime          = 651;
     _dispontime       = 640;
     _dispofftime      = disptime - _dispontime;
-    self->dispontime  = (uint64_t) (_dispontime * (cpuclock / VID_CLOCK) * (double) (1ULL << 32));
-    self->dispofftime = (uint64_t) (_dispofftime * (cpuclock / VID_CLOCK) * (double) (1ULL << 32));
+    self->cga.dispontime  = (uint64_t) (_dispontime * (cpuclock / VID_CLOCK) * (double) (1ULL << 32));
+    self->cga.dispofftime = (uint64_t) (_dispofftime * (cpuclock / VID_CLOCK) * (double) (1ULL << 32));
+}
+
+static void
+compaq_plasma_waitstates(void *p)
+{
+    int ws_array[16] = { 3, 4, 5, 6, 7, 8, 4, 5, 6, 7, 8, 4, 5, 6, 7, 8 };
+    int ws;
+
+    ws = ws_array[cycles & 0xf];
+    sub_cycles(ws);
 }
 
 static void
@@ -130,7 +141,8 @@ compaq_plasma_write(uint32_t addr, uint8_t val, void *priv)
 {
     compaq_plasma_t *self = (compaq_plasma_t *) priv;
 
-    self->vram[addr & 0x7fff] = val;
+    self->cga.vram[addr & 0x7fff] = val;
+    compaq_plasma_waitstates(&self->cga);
 }
 
 static uint8_t
@@ -139,204 +151,10 @@ compaq_plasma_read(uint32_t addr, void *priv)
     compaq_plasma_t *self = (compaq_plasma_t *) priv;
     uint8_t          ret;
 
-    ret = (self->vram[addr & 0x7fff]);
+    compaq_plasma_waitstates(&self->cga);
+    ret = (self->cga.vram[addr & 0x7fff]);
 
     return ret;
-}
-
-/* Draw a row of text in 80-column mode */
-static void
-compaq_plasma_text80(compaq_plasma_t *self)
-{
-    uint32_t cols[2];
-    int      c;
-    uint8_t  chr;
-    uint8_t  attr;
-    int      drawcursor;
-    int      cursorline;
-    int      blink;
-    uint16_t addr;
-    uint8_t  sc;
-    uint16_t ma = (self->cga.crtc[13] | (self->cga.crtc[12] << 8)) & 0x7fff;
-    uint16_t ca = (self->cga.crtc[15] | (self->cga.crtc[14] << 8)) & 0x7fff;
-
-    sc   = (self->displine) & 15;
-    addr = ((ma & ~1) + (self->displine >> 4) * 80) * 2;
-    ma += (self->displine >> 4) * 80;
-
-    if ((self->cga.crtc[10] & 0x60) == 0x20)
-        cursorline = 0;
-    else
-        cursorline = ((self->cga.crtc[10] & 0x0F) * 2 <= sc) && ((self->cga.crtc[11] & 0x0F) * 2 >= sc);
-
-    for (uint8_t x = 0; x < 80; x++) {
-        chr        = self->vram[(addr + 2 * x) & 0x7FFF];
-        attr       = self->vram[(addr + 2 * x + 1) & 0x7FFF];
-        drawcursor = ((ma == ca) && cursorline && (self->cga.cgamode & 8) && (self->cga.cgablink & 16));
-
-        blink = ((self->cga.cgablink & 16) && (self->cga.cgamode & 0x20) && (attr & 0x80) && !drawcursor);
-
-        if (self->cga.cgamode & 0x20) { /* Blink */
-            cols[1] = blinkcols[attr][1];
-            cols[0] = blinkcols[attr][0];
-            if (blink)
-                cols[1] = cols[0];
-        } else {
-            cols[1] = normcols[attr][1];
-            cols[0] = normcols[attr][0];
-        }
-        if (drawcursor) {
-            for (c = 0; c < 8; c++)
-                ((uint32_t *) buffer32->line[self->displine])[(x << 3) + c] = cols[(fontdatm[chr][sc] & (1 << (c ^ 7))) ? 1 : 0] ^ (amber ^ black);
-        } else {
-            for (c = 0; c < 8; c++)
-                ((uint32_t *) buffer32->line[self->displine])[(x << 3) + c] = cols[(fontdatm[chr][sc] & (1 << (c ^ 7))) ? 1 : 0];
-        }
-        ++ma;
-    }
-}
-
-/* Draw a row of text in 40-column mode */
-static void
-compaq_plasma_text40(compaq_plasma_t *self)
-{
-    uint32_t cols[2];
-    int      c;
-    uint8_t  chr;
-    uint8_t  attr;
-    int      drawcursor;
-    int      cursorline;
-    int      blink;
-    uint16_t addr;
-    uint8_t  sc;
-    uint16_t ma = (self->cga.crtc[13] | (self->cga.crtc[12] << 8)) & 0x7fff;
-    uint16_t ca = (self->cga.crtc[15] | (self->cga.crtc[14] << 8)) & 0x7fff;
-
-    sc   = (self->displine) & 15;
-    addr = ((ma & ~1) + (self->displine >> 4) * 40) * 2;
-    ma += (self->displine >> 4) * 40;
-
-    if ((self->cga.crtc[10] & 0x60) == 0x20)
-        cursorline = 0;
-    else
-        cursorline = ((self->cga.crtc[10] & 0x0F) * 2 <= sc) && ((self->cga.crtc[11] & 0x0F) * 2 >= sc);
-
-    for (uint8_t x = 0; x < 40; x++) {
-        chr        = self->vram[(addr + 2 * x) & 0x7FFF];
-        attr       = self->vram[(addr + 2 * x + 1) & 0x7FFF];
-        drawcursor = ((ma == ca) && cursorline && (self->cga.cgamode & 8) && (self->cga.cgablink & 16));
-
-        blink = ((self->cga.cgablink & 16) && (self->cga.cgamode & 0x20) && (attr & 0x80) && !drawcursor);
-
-        if (self->cga.cgamode & 0x20) { /* Blink */
-            cols[1] = blinkcols[attr][1];
-            cols[0] = blinkcols[attr][0];
-            if (blink)
-                cols[1] = cols[0];
-        } else {
-            cols[1] = normcols[attr][1];
-            cols[0] = normcols[attr][0];
-        }
-        if (drawcursor) {
-            for (c = 0; c < 8; c++) {
-                ((uint32_t *) buffer32->line[self->displine])[(x << 4) + c * 2] = ((uint32_t *) buffer32->line[self->displine])[(x << 4) + c * 2 + 1] = cols[(fontdatm[chr][sc] & (1 << (c ^ 7))) ? 1 : 0] ^ (amber ^ black);
-            }
-        } else {
-            for (c = 0; c < 8; c++) {
-                ((uint32_t *) buffer32->line[self->displine])[(x << 4) + c * 2] = ((uint32_t *) buffer32->line[self->displine])[(x << 4) + c * 2 + 1] = cols[(fontdatm[chr][sc] & (1 << (c ^ 7))) ? 1 : 0];
-            }
-        }
-        ++ma;
-    }
-}
-
-/* Draw a line in CGA 640x200 or Compaq Plasma 640x400 mode */
-static void
-compaq_plasma_cgaline6(compaq_plasma_t *self)
-{
-    uint8_t  dat;
-    uint32_t ink = 0;
-    uint16_t addr;
-    uint32_t fg = (self->cga.cgacol & 0x0F) ? amber : black;
-    uint32_t bg = black;
-
-    uint16_t ma = (self->cga.crtc[13] | (self->cga.crtc[12] << 8)) & 0x7fff;
-
-    if ((self->cga.crtc[9] == 3) || (self->port_23c6 & 1)) /* 640*400 */ {
-        addr = ((self->displine) & 1) * 0x2000 + ((self->displine >> 1) & 1) * 0x4000 + (self->displine >> 2) * 80 + ((ma & ~1) << 1);
-    } else {
-        addr = ((self->displine >> 1) & 1) * 0x2000 + (self->displine >> 2) * 80 + ((ma & ~1) << 1);
-    }
-    for (uint8_t x = 0; x < 80; x++) {
-        dat = self->vram[addr & 0x7FFF];
-        addr++;
-
-        for (uint8_t c = 0; c < 8; c++) {
-            ink = (dat & 0x80) ? fg : bg;
-            if (!(self->cga.cgamode & 8))
-                ink = black;
-            ((uint32_t *) buffer32->line[self->displine])[x * 8 + c] = ink;
-            dat <<= 1;
-        }
-    }
-}
-
-/* Draw a line in CGA 320x200 mode. Here the CGA colours are converted to
- * dither patterns: colour 1 to 25% grey, colour 2 to 50% grey */
-static void
-compaq_plasma_cgaline4(compaq_plasma_t *self)
-{
-    uint8_t  dat;
-    uint8_t  pattern;
-    uint32_t ink0 = 0;
-    uint32_t ink1 = 0;
-    uint16_t addr;
-
-    uint16_t ma = (self->cga.crtc[13] | (self->cga.crtc[12] << 8)) & 0x7fff;
-
-    /* 320*200 */
-    addr = ((self->displine >> 1) & 1) * 0x2000 + (self->displine >> 2) * 80 + ((ma & ~1) << 1);
-
-    for (uint8_t x = 0; x < 80; x++) {
-        dat = self->vram[addr & 0x7FFF];
-        addr++;
-
-        for (uint8_t c = 0; c < 4; c++) {
-            pattern = (dat & 0xC0) >> 6;
-            if (!(self->cga.cgamode & 8))
-                pattern = 0;
-
-            switch (pattern & 3) {
-                case 0:
-                    ink0 = ink1 = black;
-                    break;
-                case 1:
-                    if (self->displine & 1) {
-                        ink0 = black;
-                        ink1 = black;
-                    } else {
-                        ink0 = amber;
-                        ink1 = black;
-                    }
-                    break;
-                case 2:
-                    if (self->displine & 1) {
-                        ink0 = black;
-                        ink1 = amber;
-                    } else {
-                        ink0 = amber;
-                        ink1 = black;
-                    }
-                    break;
-                case 3:
-                    ink0 = ink1 = amber;
-                    break;
-            }
-            ((uint32_t *) buffer32->line[self->displine])[x * 8 + 2 * c]     = ink0;
-            ((uint32_t *) buffer32->line[self->displine])[x * 8 + 2 * c + 1] = ink1;
-            dat <<= 2;
-        }
-    }
 }
 
 static void
@@ -348,7 +166,7 @@ compaq_plasma_out(uint16_t addr, uint8_t val, void *priv)
     switch (addr) {
         /* Emulated CRTC, register select */
         case 0x3d4:
-            self->cga.crtcreg = val & 31;
+            cga_out(addr, val, &self->cga);
             break;
 
         /* Emulated CRTC, value */
@@ -366,33 +184,26 @@ compaq_plasma_out(uint16_t addr, uint8_t val, void *priv)
 
             if (old != val) {
                 if (self->cga.crtcreg < 0xe || self->cga.crtcreg > 0x10) {
-                    self->fullchange = changeframecount;
+                    self->cga.fullchange = changeframecount;
                     compaq_plasma_recalctimings(self);
                 }
             }
             break;
-
         case 0x3d8:
-            self->cga.cgamode = val;
-            break;
-
         case 0x3d9:
-            self->cga.cgacol = val;
+            cga_out(addr, val, &self->cga);
             break;
 
         case 0x13c6:
-            if (val & 8)
-                compaq_plasma_display_set(1);
-            else
-                compaq_plasma_display_set(0);
+            compaq_plasma_display_set((val & 8) ? 1 : 0);
             break;
 
         case 0x23c6:
             self->port_23c6 = val;
             if (val & 8) /* Disable internal CGA */
-                mem_mapping_disable(&self->plasma_mapping);
+                mem_mapping_disable(&self->cga.mapping);
             else
-                mem_mapping_enable(&self->plasma_mapping);
+                mem_mapping_enable(&self->cga.mapping);
             break;
     }
 }
@@ -405,31 +216,38 @@ compaq_plasma_in(uint16_t addr, void *priv)
 
     switch (addr) {
         case 0x3d4:
-            ret = self->cga.crtcreg;
+        case 0x3da:
+            ret = cga_in(addr, &self->cga);
             break;
 
         case 0x3d5:
             if (self->cga.crtcreg == 0x12) {
-                ret = self->attrmap & 0x0F;
+                ret = self->attrmap & 0x0f;
                 if (self->internal_monitor)
                     ret |= 0x30; /* Plasma / CRT */
             } else
-                ret = self->cga.crtc[self->cga.crtcreg];
-            break;
-
-        case 0x3da:
-            ret = self->cga.cgastat;
+                ret = cga_in(addr, &self->cga);
             break;
 
         case 0x13c6:
-            if (compaq_plasma_display_get())
-                ret = 8;
-            else
-                ret = 0;
+            ret = compaq_plasma_display_get() ? 8 : 0;
+            ret |= 4;
+            break;
+
+        case 0x1bc6:
+            ret = 0;
+            if (compaq_plasma_display_get()) {
+                if ((self->cga.cgamode & 0x12) == 0x12) {
+                    if (self->port_23c6 & 8)
+                        ret |= 0x40;
+                    else
+                        ret |= 0x20;
+                }
+            }
             break;
 
         case 0x23c6:
-            ret = self->port_23c6;
+            ret = 0;
             break;
     }
 
@@ -440,56 +258,243 @@ static void
 compaq_plasma_poll(void *p)
 {
     compaq_plasma_t *self = (compaq_plasma_t *) p;
+    uint8_t  chr, attr;
+    uint8_t  sc;
+    uint16_t ma  = (self->cga.crtc[13] | (self->cga.crtc[12] << 8)) & 0x7fff;
+    uint16_t ca  = (self->cga.crtc[15] | (self->cga.crtc[14] << 8)) & 0x7fff;
+    uint16_t dat;
+    uint16_t addr;
+    int      drawcursor;
+    int      x, c;
+    int      cursorline;
+    int      blink     = 0;
+    int      underline = 0;
+    uint32_t ink = 0;
+    uint32_t fg = (self->cga.cgacol & 0x0f) ? amber : black;
+    uint32_t bg = black;
+    uint32_t cols[2];
+    uint8_t  dat2, pattern;
+    uint32_t ink0 = 0, ink1 = 0;
 
     /* Switch between internal plasma and external CRT display. */
-    if (cpq_st_display_internal != -1 && cpq_st_display_internal != self->internal_monitor) {
+    if ((cpq_st_display_internal != -1) && (cpq_st_display_internal != self->internal_monitor)) {
         self->internal_monitor = cpq_st_display_internal;
         compaq_plasma_recalctimings(self);
     }
 
+    /* graphic mode and not mode 40h */
     if (!self->internal_monitor && !(self->port_23c6 & 1)) {
         cga_poll(&self->cga);
         return;
     }
 
-    if (!self->linepos) {
-        timer_advance_u64(&self->cga.timer, self->dispofftime);
+    /* mode 40h or text mode */
+    if (!self->cga.linepos) {
+        timer_advance_u64(&self->cga.timer, self->cga.dispofftime);
         self->cga.cgastat |= 1;
-        self->linepos = 1;
-        if (self->dispon) {
-            if (self->displine == 0)
+        self->cga.linepos = 1;
+        if (self->cga.cgadispon) {
+            if (self->cga.displine == 0) {
                 video_wait_for_buffer();
+            }
+            if (self->cga.cgamode & 2) {
+                if (self->cga.cgamode & 0x10) {
+                    /* 640x400 mode */
+                    if (self->port_23c6 & 1) /* 640*400 */ {
+                        addr = ((self->cga.displine) & 1) * 0x2000 + ((self->cga.displine >> 1) & 1) * 0x4000 + (self->cga.displine >> 2) * 80 + ((ma & ~1) << 1);
+                    } else {
+                        addr = ((self->cga.displine >> 1) & 1) * 0x2000 + (self->cga.displine >> 2) * 80 + ((ma & ~1) << 1);
+                    }
+                    for (x = 0; x < 80; x++) {
+                        dat2 = self->cga.vram[(addr & 0x7FFF)];
+                        addr++;
 
-            /* Graphics */
-            if (self->cga.cgamode & 0x02) {
-                if (self->cga.cgamode & 0x10)
-                    compaq_plasma_cgaline6(self);
+                        for (c = 0; c < 8; c++) {
+                            ink = (dat2 & 0x80) ? fg : bg;
+                            if (!(self->cga.cgamode & 8))
+                                ink = black;
+                            ((uint32_t *) buffer32->line[self->cga.displine])[x * 8 + c] = ink;
+                            dat2 <<= 1;
+                        }
+                    }
+                } else {
+                    addr = ((self->cga.displine >> 1) & 1) * 0x2000 + (self->cga.displine >> 2) * 80 + ((ma & ~1) << 1);
+                    for (x = 0; x < 80; x++) {
+                        dat2 = self->cga.vram[(addr & 0x7fff)];
+                        addr++;
+
+                        for (c = 0; c < 4; c++) {
+                            pattern = (dat2 & 0xC0) >> 6;
+                            if (!(self->cga.cgamode & 8))
+                                pattern = 0;
+
+                            switch (pattern & 3) {
+                                case 0:
+                                    ink0 = ink1 = black;
+                                    break;
+                                case 1:
+                                    if (self->cga.displine & 1) {
+                                        ink0 = black;
+                                        ink1 = black;
+                                    } else {
+                                        ink0 = amber;
+                                        ink1 = black;
+                                    }
+                                    break;
+                                case 2:
+                                    if (self->cga.displine & 1) {
+                                        ink0 = black;
+                                        ink1 = amber;
+                                    } else {
+                                        ink0 = amber;
+                                        ink1 = black;
+                                    }
+                                    break;
+                                case 3:
+                                    ink0 = ink1 = amber;
+                                    break;
+                            }
+                            buffer32->line[self->cga.displine][x * 8 + 2 * c]     = ink0;
+                            buffer32->line[self->cga.displine][x * 8 + 2 * c + 1] = ink1;
+                            dat2 <<= 2;
+                        }
+                    }
+                }
+            } else if (self->cga.cgamode & 1) {
+                /* 80-col */
+                sc = self->cga.displine & 0x0f;
+                addr = ((ma & ~1) + (self->cga.displine >> 4) * 80) * 2;
+                ma += (self->cga.displine >> 4) * 80;
+
+                if ((self->cga.crtc[0x0a] & 0x60) == 0x20)
+                    cursorline = 0;
                 else
-                    compaq_plasma_cgaline4(self);
-            } else if (self->cga.cgamode & 0x01) /* High-res text */
-                compaq_plasma_text80(self);
-            else
-                compaq_plasma_text40(self);
+                    cursorline = ((self->cga.crtc[0x0a] & 0x0f) * 2 <= sc) && ((self->cga.crtc[0x0b] & 0x0F) * 2 >= sc);
+
+                /* for each text column */
+                for (x = 0; x < 80; x++) {
+                    /* video output enabled */
+                    if (self->cga.cgamode & 8) {
+                        chr        = self->cga.vram[(addr + 2 * x) & 0x7fff];
+                        attr       = self->cga.vram[(addr + 2 * x + 1) & 0x7fff];
+                    } else
+                        chr = attr = 0;
+                    /* check if cursor has to be drawn */
+                    drawcursor = ((ma == ca) && cursorline && self->cga.cursoron);
+                    underline = ((self->port_23c6 & 0x40) && (attr & 0x1) && !(attr & 0x6));
+                    if (underline) {
+                        /* set forecolor to white */
+                        attr |= 7;
+                    }
+                    blink = 0;
+                    /* blink active */
+                    if (self->cga.cgamode & 0x20) {
+                        cols[1] = blinkcols[attr][1];
+                        cols[0] = blinkcols[attr][0];
+                        /* attribute 7 active and not cursor */
+                        if ((self->cga.cgablink & 8) && (attr & 0x80) && !self->cga.drawcursor) {
+                            /* set blinking */
+                            cols[1] = cols[0];
+                            blink   = 1;
+                        }
+                    } else {
+                        /* Set intensity bit */
+                        cols[1] = normcols[attr][1];
+                        cols[0] = normcols[attr][0];
+                        blink   = (attr & 0x80) * 8 + 7 + 16;
+                    }
+                    /* character underline active and 7th row of pixels in character height being drawn */
+                    if (underline && (sc == 7)) {
+                        /* for each pixel in character width */
+                        for (c = 0; c < 8; c++)
+                            buffer32->line[self->cga.displine][(x << 3) + c] = mdaattr[attr][blink][1];
+                    } else if (drawcursor) {
+                        for (c = 0; c < 8; c++)
+                            buffer32->line[self->cga.displine][(x << 3) + c] = cols[(fontdatm[chr + self->cga.fontbase][sc] & (1 << (c ^ 7))) ? 1 : 0] ^ (amber ^ black);
+                    } else {
+                        for (c = 0; c < 8; c++)
+                            buffer32->line[self->cga.displine][(x << 3) + c] = cols[(fontdatm[chr + self->cga.fontbase][sc] & (1 << (c ^ 7))) ? 1 : 0];
+                    }
+
+                    ++ma;
+                }
+            } else { /* 40-col */
+                sc = self->cga.displine & 0x0f;
+                addr = ((ma & ~1) + (self->cga.displine >> 4) * 40) * 2;
+                ma += (self->cga.displine >> 4) * 40;
+
+                if ((self->cga.crtc[0x0a] & 0x60) == 0x20)
+                    cursorline = 0;
+                else
+                    cursorline = ((self->cga.crtc[0x0a] & 0x0f) * 2 <= sc) && ((self->cga.crtc[0x0b] & 0x0F) * 2 >= sc);
+
+                for (x = 0; x < 40; x++) {
+                    if (self->cga.cgamode & 8) {
+                        chr        = self->cga.vram[(addr + 2 * x) & 0x7fff];
+                        attr       = self->cga.vram[(addr + 2 * x + 1) & 0x7fff];
+                    } else {
+                        chr = attr = 0;
+                    }
+                    drawcursor = ((ma == ca) && cursorline && self->cga.cursoron);
+                    underline = ((self->port_23c6 & 0x40) && (attr & 0x1) && !(attr & 0x6));
+                    if (underline) {
+                        /* set forecolor to white */
+                        attr |= 7;
+                    }
+                    blink = 0;
+                    /* blink active */
+                    if (self->cga.cgamode & 0x20) {
+                        cols[1] = blinkcols[attr][1];
+                        cols[0] = blinkcols[attr][0];
+                        /* attribute 7 active and not cursor */
+                        if ((self->cga.cgablink & 8) && (attr & 0x80) && !self->cga.drawcursor) {
+                            /* set blinking */
+                            cols[1] = cols[0];
+                            blink   = 1;
+                        }
+                    } else {
+                        /* Set intensity bit */
+                        cols[1] = normcols[attr][1];
+                        cols[0] = normcols[attr][0];
+                        blink   = (attr & 0x80) * 8 + 7 + 16;
+                    }
+                    /* character underline active and 7th row of pixels in character height being drawn */
+                    if (underline && (sc == 7)) {
+                        /* for each pixel in character width */
+                        for (c = 0; c < 8; c++)
+                            buffer32->line[self->cga.displine][(x << 4) + (c * 2)] = buffer32->line[self->cga.displine][(x << 4) + (c * 2) + 1] = mdaattr[attr][blink][1];
+                    } else if (drawcursor) {
+                        for (c = 0; c < 8; c++) {
+                            buffer32->line[self->cga.displine][(x << 4) + c * 2] = buffer32->line[self->cga.displine][(x << 4) + c * 2 + 1] = cols[(fontdatm[chr][sc] & (1 << (c ^ 7))) ? 1 : 0] ^ (amber ^ black);
+                        }
+                    } else {
+                        for (c = 0; c < 8; c++) {
+                            buffer32->line[self->cga.displine][(x << 4) + c * 2] = buffer32->line[self->cga.displine][(x << 4) + c * 2 + 1] = cols[(fontdatm[chr][sc] & (1 << (c ^ 7))) ? 1 : 0];
+                        }
+                    }
+                    ++ma;
+                }
+            }
         }
-        self->displine++;
+        self->cga.displine++;
         /* Hardcode a fixed refresh rate and VSYNC timing */
-        if (self->displine == 400) { /* Start of VSYNC */
+        if (self->cga.displine == 400) { /* Start of VSYNC */
             self->cga.cgastat |= 8;
-            self->dispon = 0;
+            self->cga.cgadispon = 0;
         }
-        if (self->displine == 416) { /* End of VSYNC */
-            self->displine = 0;
+        if (self->cga.displine == 416) { /* End of VSYNC */
+            self->cga.displine = 0;
             self->cga.cgastat &= ~8;
-            self->dispon = 1;
+            self->cga.cgadispon = 1;
         }
     } else {
-        if (self->dispon)
+        if (self->cga.cgadispon)
             self->cga.cgastat &= ~1;
 
-        timer_advance_u64(&self->cga.timer, self->dispontime);
-        self->linepos = 0;
+        timer_advance_u64(&self->cga.timer, self->cga.dispontime);
+        self->cga.linepos = 0;
 
-        if (self->displine == 400) {
+        if (self->cga.displine == 400) {
             /* Hardcode 640x400 window size */
             if ((640 != xsize) || (400 != ysize) || video_force_resize_get()) {
                 xsize = 640;
@@ -515,12 +520,39 @@ compaq_plasma_poll(void *p)
                     video_bpp = 1;
                 else
                     video_bpp = 2;
-
             } else
                 video_bpp = 0;
+
             self->cga.cgablink++;
         }
     }
+}
+
+static void
+compaq_plasma_mdaattr_rebuild(void)
+{
+    int c;
+
+    for (c = 0; c < 256; c++) {
+        mdaattr[c][0][0] = mdaattr[c][1][0] = mdaattr[c][1][1] = 16;
+        if (c & 8)
+            mdaattr[c][0][1] = 15 + 16;
+        else
+            mdaattr[c][0][1] = 7 + 16;
+    }
+
+    mdaattr[0x70][0][1] = 16;
+    mdaattr[0x70][0][0] = mdaattr[0x70][1][0] = mdaattr[0x70][1][1] = 16 + 15;
+    mdaattr[0xF0][0][1]                                             = 16;
+    mdaattr[0xF0][0][0] = mdaattr[0xF0][1][0] = mdaattr[0xF0][1][1] = 16 + 15;
+    mdaattr[0x78][0][1]                                             = 16 + 7;
+    mdaattr[0x78][0][0] = mdaattr[0x78][1][0] = mdaattr[0x78][1][1] = 16 + 15;
+    mdaattr[0xF8][0][1]                                             = 16 + 7;
+    mdaattr[0xF8][0][0] = mdaattr[0xF8][1][0] = mdaattr[0xF8][1][1] = 16 + 15;
+    mdaattr[0x00][0][1] = mdaattr[0x00][1][1] = 16;
+    mdaattr[0x08][0][1] = mdaattr[0x08][1][1] = 16;
+    mdaattr[0x80][0][1] = mdaattr[0x80][1][1] = 16;
+    mdaattr[0x88][0][1] = mdaattr[0x88][1][1] = 16;
 }
 
 static void
@@ -537,10 +569,10 @@ compaq_plasma_recalcattrs(compaq_plasma_t *self)
      *            are bold */
 
     /* Set up colours */
-    amber = makecol(0xff, 0x7D, 0x00);
-    black = makecol(0x64, 0x19, 0x00);
+    amber = makecol(0xff, 0x7d, 0x00);
+    black = makecol(0x64, 0x0c, 0x00);
 
-    /* Initialise the attribute mapping. Start by defaulting everything
+    /* Initialize the attribute mapping. Start by defaulting everything
      * to black on amber, and with bold set by bit 3 */
     for (n = 0; n < 256; n++) {
         blinkcols[n][0] = normcols[n][0] = amber;
@@ -607,36 +639,37 @@ compaq_plasma_recalcattrs(compaq_plasma_t *self)
 static void *
 compaq_plasma_init(const device_t *info)
 {
-    int              display_type;
     compaq_plasma_t *self = malloc(sizeof(compaq_plasma_t));
     memset(self, 0, sizeof(compaq_plasma_t));
 
-    display_type        = device_get_config_int("display_type");
-    self->cga.composite = (display_type != CGA_RGB);
-    self->cga.revision  = device_get_config_int("composite_type");
+    video_inform(VIDEO_FLAG_TYPE_CGA, &timing_compaq_plasma);
+    loadfont_ex("roms/machines/portableiii/K Combined.bin", 1, 0x4bb2);
 
-    self->vram             = malloc(0x8000);
+    self->cga.composite = 0;
+    self->cga.revision  = 0;
+
+    self->cga.vram             = malloc(0x8000);
     self->internal_monitor = 1;
 
     cga_comp_init(self->cga.revision);
     timer_add(&self->cga.timer, compaq_plasma_poll, self, 1);
-    mem_mapping_add(&self->plasma_mapping, 0xb8000, 0x08000, compaq_plasma_read, NULL, NULL, compaq_plasma_write, NULL, NULL, NULL /*self->cga.vram*/, MEM_MAPPING_EXTERNAL, self);
+    mem_mapping_add(&self->cga.mapping, 0xb8000, 0x08000, compaq_plasma_read, NULL, NULL, compaq_plasma_write, NULL, NULL, NULL /*self->cga.vram*/, MEM_MAPPING_EXTERNAL, self);
     io_sethandler(0x03d0, 0x0010, compaq_plasma_in, NULL, NULL, compaq_plasma_out, NULL, NULL, self);
     io_sethandler(0x13c6, 0x0001, compaq_plasma_in, NULL, NULL, compaq_plasma_out, NULL, NULL, self);
+    io_sethandler(0x1bc6, 0x0001, compaq_plasma_in, NULL, NULL, compaq_plasma_out, NULL, NULL, self);
     io_sethandler(0x23c6, 0x0001, compaq_plasma_in, NULL, NULL, compaq_plasma_out, NULL, NULL, self);
 
     /* Default attribute mapping is 4 */
     self->attrmap = 4;
     compaq_plasma_recalcattrs(self);
 
-    self->cga.cgastat = 0xF4;
-    self->cga.vram    = self->vram;
-
+    self->cga.cgastat = 0xf4;
     overscan_x = overscan_y = 16;
 
     self->cga.rgb_type = device_get_config_int("rgb_type");
     cga_palette        = (self->cga.rgb_type << 1);
     cgapal_rebuild();
+    compaq_plasma_mdaattr_rebuild();
 
     return self;
 }
@@ -646,8 +679,7 @@ compaq_plasma_close(void *p)
 {
     compaq_plasma_t *self = (compaq_plasma_t *) p;
 
-    free(self->vram);
-
+    free(self->cga.vram);
     free(self);
 }
 
@@ -662,37 +694,9 @@ compaq_plasma_speed_changed(void *p)
 const device_config_t compaq_plasma_config[] = {
   // clang-format off
     {
-        .name = "display_type",
-        .description = "Display type",
-        .type = CONFIG_SELECTION,
-        .default_string = "",
-        .default_int = CGA_RGB,
-        .file_filter = "",
-        .spinner = { 0 },
-        .selection = {
-            { .description = "RGB",       .value = CGA_RGB       },
-            { .description = "Composite", .value = CGA_COMPOSITE },
-            { .description = ""                                  }
-        }
-    },
-    {
-        .name = "composite_type",
-        .description = "Composite type",
-        .type = CONFIG_SELECTION,
-        .default_string = "",
-        .default_int = COMPOSITE_OLD,
-        .file_filter = "",
-        .spinner = { 0 },
-        {
-            { .description = "Old", .value = COMPOSITE_OLD },
-            { .description = "New", .value = COMPOSITE_NEW },
-            { .description = ""                            }
-        }
-    },
-    {
         .name = "rgb_type",
-        .description = "RGB type",
-        .type = CONFIG_SELECTION,
+		.description = "RGB type",
+		.type = CONFIG_SELECTION,
         .default_string = "",
         .default_int = 0,
         .file_filter = "",
@@ -702,7 +706,6 @@ const device_config_t compaq_plasma_config[] = {
             { .description = "Green Monochrome", .value = 1 },
             { .description = "Amber Monochrome", .value = 2 },
             { .description = "Gray Monochrome",  .value = 3 },
-            { .description = "Color (no brown)", .value = 4 },
             { .description = ""                             }
         }
     },
@@ -781,26 +784,36 @@ write_raml(uint32_t addr, uint32_t val, void *priv)
 static void
 machine_at_compaq_init(const machine_t *model, int type)
 {
-    if (type != COMPAQ_DESKPRO386)
+    compaq_machine_type = type;
+
+    if ((type != COMPAQ_DESKPRO386) && (type != COMPAQ_DESKPRO386_01_1988))
         mem_remap_top(384);
 
     if (fdc_type == FDC_INTERNAL)
         device_add(&fdc_at_device);
 
-    mem_mapping_add(&ram_mapping, 0xfa0000, 0x60000,
-                    read_ram, read_ramw, read_raml,
-                    write_ram, write_ramw, write_raml,
-                    0xa0000 + ram, MEM_MAPPING_INTERNAL, NULL);
+    if ((type == COMPAQ_DESKPRO386) || (type == COMPAQ_DESKPRO386_01_1988) || (type == COMPAQ_PORTABLEIII386))
+        mem_mapping_add(&ram_mapping, 0xfa0000, 0x60000,
+                        read_ram, read_ramw, read_raml,
+                        write_ram, write_ramw, write_raml,
+                        0xa0000 + ram, MEM_MAPPING_EXTERNAL, NULL);
+    else
+        mem_mapping_add(&ram_mapping, 0xfa0000, 0x60000,
+                        read_ram, read_ramw, read_raml,
+                        write_ram, write_ramw, write_raml,
+                        0xa0000 + ram, MEM_MAPPING_INTERNAL, NULL);
 
     video_reset(gfxcard[0]);
 
     switch (type) {
         case COMPAQ_PORTABLEII:
+			machine_at_init(model);
             break;
 
         case COMPAQ_PORTABLEIII:
             if (gfxcard[0] == VID_INTERNAL)
                 device_add(&compaq_plasma_device);
+			machine_at_init(model);
             break;
 
         case COMPAQ_PORTABLEIII386:
@@ -808,15 +821,17 @@ machine_at_compaq_init(const machine_t *model, int type)
                 device_add(&ide_isa_device);
             if (gfxcard[0] == VID_INTERNAL)
                 device_add(&compaq_plasma_device);
+			machine_at_init(model);
             break;
 
         case COMPAQ_DESKPRO386:
+        case COMPAQ_DESKPRO386_01_1988:
             if (hdc_current == 1)
                 device_add(&ide_isa_device);
+            machine_at_common_init(model);
+            device_add(&keyboard_at_compaq_device);
             break;
     }
-
-    machine_at_init(model);
 }
 
 int
@@ -841,9 +856,9 @@ machine_at_portableiii_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleavedr("roms/machines/portableiii/Compaq Portable III - BIOS - 106779-002 - Even.bin",
-                                 "roms/machines/portableiii/Compaq Portable III - BIOS - 106778-002 - Odd.bin",
-                                 0x000f8000, 65536, 0);
+    ret = bios_load_linearr("roms/machines/portableiii/K Combined.bin",
+                                0x000f8000, 65536, 0);
+
 
     if (bios_only || !ret)
         return ret;
@@ -858,9 +873,8 @@ machine_at_portableiii386_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleavedr("roms/machines/portableiii/Compaq Portable III - BIOS - 106779-002 - Even.bin",
-                                 "roms/machines/portableiii/Compaq Portable III - BIOS - 106778-002 - Odd.bin",
-                                 0x000f8000, 65536, 0);
+    ret = bios_load_linearr("roms/machines/portableiii/K Combined.bin",
+                                0x000f8000, 65536, 0);
 
     if (bios_only || !ret)
         return ret;
@@ -870,14 +884,13 @@ machine_at_portableiii386_init(const machine_t *model)
     return ret;
 }
 
-#if defined(DEV_BRANCH) && defined(USE_DESKPRO386)
 int
 machine_at_deskpro386_init(const machine_t *model)
 {
     int ret;
 
     ret = bios_load_linearr("roms/machines/deskpro386/1986-09-04-HI.json.bin",
-                            0x000fc000, 65536, 0);
+                            0x000f8000, 65536, 0);
 
     if (bios_only || !ret)
         return ret;
@@ -886,4 +899,19 @@ machine_at_deskpro386_init(const machine_t *model)
 
     return ret;
 }
-#endif
+
+int
+machine_at_deskpro386_01_1988_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linearr("roms/machines/deskpro386/1988-01-28.json.bin",
+                            0x000f8000, 65536, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_compaq_init(model, COMPAQ_DESKPRO386_01_1988);
+
+    return ret;
+}

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -2587,8 +2587,8 @@ const machine_t machines[] = {
         .cpu = {
             .package = CPU_PKG_286,
             .block = CPU_BLOCK_NONE,
-            .min_bus = 6000000,
-            .max_bus = 8000000,
+            .min_bus = 0,
+            .max_bus = 0,
             .min_voltage = 0,
             .max_voltage = 0,
             .min_multi = 0,
@@ -2904,8 +2904,8 @@ const machine_t machines[] = {
         .cpu = {
             .package = CPU_PKG_286,
             .block = CPU_BLOCK_NONE,
-            .min_bus = 6000000,
-            .max_bus = 8000000,
+            .min_bus = 0,
+            .max_bus = 0,
             .min_voltage = 0,
             .max_voltage = 0,
             .min_multi = 0,
@@ -2943,8 +2943,8 @@ const machine_t machines[] = {
         .cpu = {
             .package = CPU_PKG_286,
             .block = CPU_BLOCK_NONE,
-            .min_bus = 6000000,
-            .max_bus = 8000000,
+            .min_bus = 0,
+            .max_bus = 0,
             .min_voltage = 0,
             .max_voltage = 0,
             .min_multi = 0,
@@ -4670,9 +4670,8 @@ const machine_t machines[] = {
         .net_device = NULL
     },
     /* Uses Compaq KBC firmware. */
-#if defined(DEV_BRANCH) && defined(USE_DESKPRO386)
     {
-        .name = "[ISA] Compaq Deskpro 386",
+        .name = "[ISA] Compaq Deskpro 386 (September 1986)",
         .internal_name = "deskpro386",
         .type = MACHINE_TYPE_386DX,
         .chipset = MACHINE_CHIPSET_DISCRETE,
@@ -4692,13 +4691,13 @@ const machine_t machines[] = {
             .max_multi = 0
         },
         .bus_flags = MACHINE_AT,
-        .flags = MACHINE_IDE | MACHINE_APM,
+        .flags = MACHINE_IDE,
         .ram = {
-            .min = 1024,
-            .max = 14336,
-            .step = 1024
+            .min = 640,
+            .max = 16384,
+            .step = 128
         },
-        .nvrmask = 127,
+        .nvrmask = 63,
         .kbc_device = NULL,
         .kbc_p1 = 0,
         .gpio = 0,
@@ -4709,7 +4708,44 @@ const machine_t machines[] = {
         .snd_device = NULL,
         .net_device = NULL
     },
-#endif /* defined(DEV_BRANCH) && defined(USE_DESKPRO386) */
+    {
+        .name = "[ISA] Compaq Deskpro 386 (January 1988)",
+        .internal_name = "deskpro386_01_1988",
+        .type = MACHINE_TYPE_386DX,
+        .chipset = MACHINE_CHIPSET_DISCRETE,
+        .init = machine_at_deskpro386_01_1988_init,
+        .pad = 0,
+        .pad0 = 0,
+        .pad1 = MACHINE_AVAILABLE,
+        .pad2 = 0,
+        .cpu = {
+            .package = CPU_PKG_386DX,
+            .block = CPU_BLOCK_NONE,
+            .min_bus = 0,
+            .max_bus = 0,
+            .min_voltage = 0,
+            .max_voltage = 0,
+            .min_multi = 0,
+            .max_multi = 0
+        },
+        .bus_flags = MACHINE_AT,
+        .flags = MACHINE_IDE,
+        .ram = {
+            .min = 640,
+            .max = 16384,
+            .step = 128
+        },
+        .nvrmask = 63,
+        .kbc_device = NULL,
+        .kbc_p1 = 0,
+        .gpio = 0,
+        .device = NULL,
+        .fdc_device = NULL,
+        .sio_device = NULL,
+        .vid_device = NULL,
+        .snd_device = NULL,
+        .net_device = NULL
+    },
     {
         .name = "[ISA] Compaq Portable III (386)",
         .internal_name = "portableiii386",
@@ -4731,7 +4767,7 @@ const machine_t machines[] = {
             .max_multi = 0
         },
         .bus_flags = MACHINE_AT,
-        .flags = MACHINE_IDE | MACHINE_VIDEO | MACHINE_APM,
+        .flags = MACHINE_IDE | MACHINE_VIDEO,
         .ram = {
             .min = 1024,
             .max = 14336,


### PR DESCRIPTION
Summary
=======
Revamped and refactored the Compaq AT clone code, including a more correct Plasma emulation and undev branch the Deskpro 386 while adding the September 1986 and January 1988 bioses. Added Compaq AT KBC strictly for the Deskpro 386 with the right settings, including the FPU bit. The generic AMI/Quadtel/Phoenix IBM AT's don't issue the speed problems of the pure IBM AT beyond 8Mhz, so don't limit them to 8Mhz.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/203/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
