### PR TITLE
Fix several instances of uninitialized variables.

### DIFF
--- a/src/cpu/386_ops.h
+++ b/src/cpu/386_ops.h
@@ -223,10 +223,11 @@ extern void x386_dynarec_log(const char *fmt, ...);
 static int
 opVPCEXT(uint32_t fetchdat)
 {
-    uint8_t    b1, b2;
+    uint8_t    b1;
+    uint8_t    b2;
     uint16_t   cent;
     time_t     now;
-    struct tm *tm;
+    struct tm *tm = NULL;
 
     if (!is_vpc) /* only emulate this on Virtual PC machines */
         return ILLEGAL(fetchdat);

--- a/src/cpu/x86_ops_misc.h
+++ b/src/cpu/x86_ops_misc.h
@@ -51,8 +51,10 @@ opSETALC(uint32_t fetchdat)
 static int
 opF6_a16(uint32_t fetchdat)
 {
-    int      tempws, tempws2 = 0;
-    uint16_t tempw, src16;
+    int      tempws  = 0;
+    int      tempws2 = 0;
+    uint16_t tempw   = 0;
+    uint16_t src16;
     uint8_t  src, dst;
     int8_t   temps;
 
@@ -167,8 +169,10 @@ opF6_a16(uint32_t fetchdat)
 static int
 opF6_a32(uint32_t fetchdat)
 {
-    int      tempws, tempws2 = 0;
-    uint16_t tempw, src16;
+    int      tempws  = 0;
+    int      tempws2 = 0;
+    uint16_t tempw   = 0;
+    uint16_t src16;
     uint8_t  src, dst;
     int8_t   temps;
 
@@ -282,10 +286,13 @@ opF6_a32(uint32_t fetchdat)
 static int
 opF7_w_a16(uint32_t fetchdat)
 {
-    uint32_t templ, templ2   = 0;
-    int      tempws, tempws2 = 0;
+    uint32_t templ;
+    uint32_t templ2  = 0;
+    int      tempws;
+    int      tempws2 = 0;
     int16_t  temps16;
-    uint16_t src, dst;
+    uint16_t src;
+    uint16_t dst;
 
     fetch_ea_16(fetchdat);
     if (cpu_mod != 3)
@@ -392,8 +399,10 @@ opF7_w_a16(uint32_t fetchdat)
 static int
 opF7_w_a32(uint32_t fetchdat)
 {
-    uint32_t templ, templ2   = 0;
-    int      tempws, tempws2 = 1;
+    uint32_t templ;
+    uint32_t templ2  = 0;
+    int      tempws;
+    int      tempws2 = 1;
     int16_t  temps16;
     uint16_t src, dst;
 

--- a/src/floppy/fdd_img.c
+++ b/src/floppy/fdd_img.c
@@ -668,8 +668,8 @@ img_load(int drive, char *fn)
     uint16_t track_bytes = 0;
     uint8_t *literal;
     img_t   *dev;
-    int      temp_rate;
-    int      guess = 0;
+    int      temp_rate = 0;
+    int      guess     = 0;
     int      size;
 
     ext = path_get_extension(fn);

--- a/src/scsi/scsi_buslogic.c
+++ b/src/scsi/scsi_buslogic.c
@@ -1513,14 +1513,14 @@ buslogic_init(const device_t *info)
 {
     x54x_t          *dev;
     char            *bios_rom_name;
-    uint16_t         bios_rom_size;
-    uint16_t         bios_rom_mask;
+    uint16_t         bios_rom_size = 0;
+    uint16_t         bios_rom_mask = 0;
     uint8_t          has_autoscsi_rom;
-    char            *autoscsi_rom_name;
-    uint16_t         autoscsi_rom_size;
+    char            *autoscsi_rom_name = NULL;
+    uint16_t         autoscsi_rom_size = 0;
     uint8_t          has_scam_rom;
-    char            *scam_rom_name;
-    uint16_t         scam_rom_size;
+    char            *scam_rom_name = NULL;
+    uint16_t         scam_rom_size = 0;
     FILE            *f;
     buslogic_data_t *bl;
     uint32_t         bios_rom_addr;

--- a/src/sio/sio_82091aa.c
+++ b/src/sio/sio_82091aa.c
@@ -142,7 +142,7 @@ i82091aa_write(uint16_t port, uint8_t val, void *priv)
 {
     i82091aa_t *dev = (i82091aa_t *) priv;
     uint8_t     index;
-    uint8_t     valxor;
+    uint8_t     valxor = 0;
     uint8_t     uart = (dev->cur_reg >> 4) - 0x03;
     uint8_t    *reg  = &(dev->regs[dev->cur_reg]);
 

--- a/src/sound/snd_ad1848.c
+++ b/src/sound/snd_ad1848.c
@@ -65,7 +65,7 @@ ad1848_updatevolmask(ad1848_t *ad1848)
 static void
 ad1848_updatefreq(ad1848_t *ad1848)
 {
-    double  freq = 0;
+    double  freq = 0.0;
     uint8_t set  = 0;
 
     if (ad1848->type >= AD1848_TYPE_CS4235) {

--- a/src/sound/snd_ad1848.c
+++ b/src/sound/snd_ad1848.c
@@ -65,8 +65,8 @@ ad1848_updatevolmask(ad1848_t *ad1848)
 static void
 ad1848_updatefreq(ad1848_t *ad1848)
 {
-    double  freq;
-    uint8_t set = 0;
+    double  freq = 0;
+    uint8_t set  = 0;
 
     if (ad1848->type >= AD1848_TYPE_CS4235) {
         if (ad1848->xregs[11] & 0x20) {

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -348,7 +348,7 @@ sb_get_buffer_sb16_awe32(int32_t *buffer, int len, void *p)
     sb_t              *sb    = (sb_t *) p;
     sb_ct1745_mixer_t *mixer = &sb->mixer_sb16;
     int                dsp_rec_pos = sb->dsp.record_pos_write;
-    int                c_emu8k;
+    int                c_emu8k = 0;
     int                c_record;
     int32_t            in_l;
     int32_t            in_r;

--- a/src/video/vid_ati_mach64.c
+++ b/src/video/vid_ati_mach64.c
@@ -3223,7 +3223,7 @@ uint8_t
 mach64_ext_inb(uint16_t port, void *p)
 {
     mach64_t *mach64 = (mach64_t *) p;
-    uint8_t   ret;
+    uint8_t   ret = 0xff;
 
     switch (port) {
         case 0x02ec:

--- a/src/video/vid_et4000w32.c
+++ b/src/video/vid_et4000w32.c
@@ -2084,7 +2084,7 @@ et4000w32_blit(int count, int cpu_input, uint32_t src_dat, uint32_t mix_dat, et4
     uint8_t source;
     uint8_t dest;
     uint8_t rop;
-    uint8_t out;
+    uint8_t out = 0;
     int     mixmap;
 
     if (!(et4000->acl.status & ACL_XYST) && !et4000->acl.mmu_start) {

--- a/src/video/vid_xga.c
+++ b/src/video/vid_xga.c
@@ -504,7 +504,7 @@ xga_ext_inb(uint16_t addr, void *p)
 {
     svga_t *svga = (svga_t *) p;
     xga_t  *xga  = &svga->xga;
-    uint8_t ret;
+    uint8_t ret  = 0xff;
     uint8_t index;
 
     switch (addr & 0x0f) {


### PR DESCRIPTION
Summary
=======
Fix several instances of uninitialized variables.
Solves about 24 of the codeql reports

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[codeql](https://github.com/86Box/86Box/security/code-scanning)
