### PR TITLE
rtc: Fix crash when closing device

### DIFF
--- a/src/device/isartc.c
+++ b/src/device/isartc.c
@@ -608,9 +608,6 @@ isartc_close(void *priv)
     io_removehandler(dev->base_addr, dev->base_addrsz,
                      dev->f_rd, NULL, NULL, dev->f_wr, NULL, NULL, dev);
 
-    if (dev->nvr.fn != NULL)
-        free(dev->nvr.fn);
-
     free(dev);
 }
 


### PR DESCRIPTION
Summary
=======
`isartc_close()` tries to `free` a pointer that isn't allocated (`nvr.fn`). The `char *` is actually pointed to an existing string in `isartc_init()`. This causes a crash when the rtc device is closed.

This PR removes the unneeded `free`.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
