### PR TITLE
Add DECchip 24110 NIC emulation

### DIFF
--- a/src/include/86box/net_tulip.h
+++ b/src/include/86box/net_tulip.h
@@ -1,1 +1,2 @@
 extern const device_t dec_tulip_device;
+extern const device_t dec_tulip_21140_device;

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -15,7 +15,7 @@
 set(net_sources)
 list(APPEND net_sources network.c net_pcap.c net_slirp.c net_dp8390.c net_3c501.c
     net_3c503.c net_ne2000.c net_pcnet.c net_wd8003.c net_plip.c net_event.c net_null.c
-    net_eeprom_nmc93cxx.c net_tulip.c net_rtl8139.c)
+    net_eeprom_nmc93cxx.c net_tulip.c net_rtl8139.c net_l80225.c)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(SLIRP REQUIRED IMPORTED_TARGET slirp)

--- a/src/network/net_l80225.c
+++ b/src/network/net_l80225.c
@@ -1,0 +1,42 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <86box/86box.h>
+#include <86box/timer.h>
+#include <86box/pci.h>
+#include <86box/io.h>
+#include <86box/mem.h>
+#include <86box/dma.h>
+#include <86box/device.h>
+#include <86box/thread.h>
+#include <86box/network.h>
+
+uint16_t
+l80225_mii_readw(uint16_t* regs, uint16_t addr)
+{
+    switch (addr)
+    {
+        case 0x1:
+            return 0x782D;
+        case 0x2:
+            return 0b10110;
+        case 0x3:
+            return 0xF830;
+        case 0x5:
+            return 0x41E1;
+        case 0x18:
+            return 0xC0;
+        default:
+            return regs[addr];
+    }
+    return 0;
+}
+
+void
+l80225_mii_writew(uint16_t* regs, uint16_t addr, uint16_t val)
+{
+    regs[addr] = val;
+}

--- a/src/network/net_tulip.c
+++ b/src/network/net_tulip.c
@@ -1579,6 +1579,7 @@ nic_init(const device_t *info)
     memcpy(s->mii_regs, tulip_mdi_default, sizeof(tulip_mdi_default));
     s->nic = network_attach(s, (uint8_t *) &nmc93cxx_eeprom_data(s->eeprom)[10], tulip_receive, NULL);
     s->dev = pci_add_card(PCI_ADD_NETWORK, tulip_pci_read, tulip_pci_write, s);
+    mem_mapping_add(&s->memory, 0, 0, NULL, NULL, tulip_read, NULL, NULL, tulip_write, NULL, MEM_MAPPING_EXTERNAL, s);
     tulip_reset(s);
     return s;
 }

--- a/src/network/net_tulip.c
+++ b/src/network/net_tulip.c
@@ -1067,6 +1067,7 @@ tulip_write(uint32_t addr, uint32_t data, void *opaque)
                 tulip_xmit_list_update(s);
             } else {
                 tulip_update_ts(s, CSR5_TS_STOPPED);
+                s->csr[5] |= CSR5_TPS;
             }
             break;
 

--- a/src/network/net_tulip.c
+++ b/src/network/net_tulip.c
@@ -660,7 +660,7 @@ static const uint16_t tulip_mdi_default[] = {
     0x0000,
     0x0000,
     0x0000,
-    0x0000,
+    0x3800,
     0x0000,
     /* MDI Registers 16 - 31 */
     0x0003,
@@ -683,6 +683,7 @@ static const uint16_t tulip_mdi_default[] = {
 
 /* Readonly mask for MDI (PHY) registers */
 static const uint16_t tulip_mdi_mask[] = {
+    /* MDI Registers 0 - 6, 7 */
     0x0000,
     0xffff,
     0xffff,
@@ -691,6 +692,7 @@ static const uint16_t tulip_mdi_mask[] = {
     0xffff,
     0xffff,
     0x0000,
+    /* MDI Registers 8 - 15 */
     0x0000,
     0x0000,
     0x0000,
@@ -699,6 +701,7 @@ static const uint16_t tulip_mdi_mask[] = {
     0x0000,
     0x0000,
     0x0000,
+    /* MDI Registers 16 - 31 */
     0x0fff,
     0x0000,
     0xffff,
@@ -717,12 +720,15 @@ static const uint16_t tulip_mdi_mask[] = {
     0x0000,
 };
 
+extern uint16_t l80225_mii_readw(uint16_t* regs, uint16_t addr);
+extern void l80225_mii_writew(uint16_t* regs, uint16_t addr, uint16_t val);
+
 static uint16_t
 tulip_mii_read(TULIPState *s, int phy, int reg)
 {
     uint16_t ret = 0;
     if (phy == 1) {
-        ret = s->mii_regs[reg];
+        ret = l80225_mii_readw(s->mii_regs, reg);
     }
     return ret;
 }
@@ -734,8 +740,7 @@ tulip_mii_write(TULIPState *s, int phy, int reg, uint16_t data)
         return;
     }
 
-    s->mii_regs[reg] &= ~tulip_mdi_mask[reg];
-    s->mii_regs[reg] |= (data & tulip_mdi_mask[reg]);
+    return l80225_mii_writew(s->mii_regs, reg, data);
 }
 
 static void

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -120,6 +120,7 @@ static const device_t *net_cards[] = {
     &pcnet_am79c960_vlb_device,
     &dec_tulip_device,
     &rtl8139c_plus_device,
+    &dec_tulip_21140_device,
     NULL
 };
 


### PR DESCRIPTION
Summary
=======
Add DECchip 24110 NIC emulation.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
