### PR TITLE
Clang warning cleanup

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -918,11 +918,15 @@ pc_init_modules(void)
 
 #ifdef USE_DYNAREC
 #    if defined(__APPLE__) && defined(__aarch64__)
-    pthread_jit_write_protect_np(0);
+    if (__builtin_available(macOS 11.0, *)) {
+        pthread_jit_write_protect_np(0);
+    }
 #    endif
     codegen_init();
 #    if defined(__APPLE__) && defined(__aarch64__)
-    pthread_jit_write_protect_np(1);
+    if (__builtin_available(macOS 11.0, *)) {
+        pthread_jit_write_protect_np(1);
+    }
 #    endif
 #endif
 

--- a/src/codegen_new/codegen_backend_arm64_ops.c
+++ b/src/codegen_new/codegen_backend_arm64_ops.c
@@ -684,7 +684,7 @@ host_arm64_CMPX_IMM(codeblock_t *block, int src_n_reg, uint64_t imm_data)
     } else if (!(imm_data & 0xfffffffffffff000ull)) {
         codegen_addlong(block, OPCODE_CMPX_IMM | Rd(REG_XZR) | Rn(src_n_reg) | IMM12(imm_data & 0xfff) | DATPROC_IMM_SHIFT(0));
     } else
-        fatal("CMPX_IMM %08x\n", imm_data);
+        fatal("CMPX_IMM %08llx\n", imm_data);
 }
 
 void

--- a/src/cpu/386_dynarec.c
+++ b/src/cpu/386_dynarec.c
@@ -484,7 +484,9 @@ exec386_dynarec_dyn(void)
         x86_was_reset = 0;
 
 #    if defined(__APPLE__) && defined(__aarch64__)
-        pthread_jit_write_protect_np(0);
+        if (__builtin_available(macOS 11.0, *)) {
+            pthread_jit_write_protect_np(0);
+        }
 #    endif
         codegen_block_start_recompile(block);
         codegen_in_recompile = 1;
@@ -568,7 +570,9 @@ exec386_dynarec_dyn(void)
 
         codegen_in_recompile = 0;
 #    if defined(__APPLE__) && defined(__aarch64__)
-        pthread_jit_write_protect_np(1);
+        if (__builtin_available(macOS 11.0, *)) {
+            pthread_jit_write_protect_np(1);
+        }
 #    endif
     } else if (!cpu_state.abrt) {
         /* Mark block but do not recompile */

--- a/src/cpu/808x/queue.c
+++ b/src/cpu/808x/queue.c
@@ -78,7 +78,7 @@ queue_set_size(size_t size)
 {
     if (size > QUEUE_MAX)
 #if (defined __amd64__ || defined _M_X64 || defined __aarch64__ || defined _M_ARM64)
-        fatal("Requested prefetch queue of %" PRIi64 " bytes is too big\n", size);
+        fatal("Requested prefetch queue of %zu bytes is too big\n", size);
 #else
         fatal("Requested prefetch queue of %i bytes is too big\n", size);
 #endif

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -394,8 +394,13 @@ typedef struct {
     MMX_REG MM[8];
 
 #ifdef USE_NEW_DYNAREC
+#    if defined(__APPLE__) && defined(__aarch64__)
+    uint64_t old_fp_control;
+    uint64_t new_fp_control;
+#    else
     uint32_t old_fp_control;
     uint32_t new_fp_control;
+#    endif
 #    if defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86
     uint16_t old_fp_control2;
     uint16_t new_fp_control2;


### PR DESCRIPTION
Summary
=======
Cleaning up some clang warnings. A few are specific to arm64 macOS and gated appropriately.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
