### PR TITLE
Add new platform function to get cpu string

### DIFF
--- a/src/include/86box/plat.h
+++ b/src/include/86box/plat.h
@@ -137,6 +137,7 @@ extern void     plat_vidapi_reload(void);
 extern void     plat_vid_reload_options(void);
 extern uint32_t plat_language_code(char *langcode);
 extern void     plat_language_code_r(uint32_t lcid, char *outbuf, int len);
+extern void     plat_get_cpu_string(char *outbuf, uint8_t len);
 
 /* Resource management. */
 extern void     set_language(uint32_t id);

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -36,6 +36,7 @@
 #include <QDateTime>
 #include <QLocalSocket>
 #include <QTimer>
+#include <QProcess>
 
 #include <QLibrary>
 #include <QElapsedTimer>
@@ -659,4 +660,70 @@ plat_init_rom_paths()
         rom_add_path(QDir(path).filePath("86Box/roms").toUtf8().constData());
 #endif
     }
+}
+
+void
+plat_get_cpu_string(char *outbuf, uint8_t len) {
+    auto cpu_string = QString("Unknown");
+    /* Write the default string now in case we have to exit early from an error */
+    qstrncpy(outbuf, cpu_string.toUtf8().constData(), len);
+
+#if defined(Q_OS_MACOS)
+    auto *process = new QProcess(nullptr);
+    QStringList arguments;
+    QString program = "/usr/sbin/sysctl";
+    arguments << "machdep.cpu.brand_string";
+    process->start(program, arguments);
+    if (!process->waitForStarted()) {
+        return;
+    }
+    if (!process->waitForFinished()) {
+        return;
+    }
+    QByteArray result = process->readAll();
+    auto command_result = QString(result).split(": ").last();
+    if(!command_result.isEmpty()) {
+        cpu_string = command_result;
+    }
+#elif defined(Q_OS_WINDOWS)
+    const LPCSTR  keyName   = "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0";
+    const LPCSTR  valueName = "ProcessorNameString";
+    unsigned char buf[32768];
+    DWORD         bufSize;
+    HKEY          hKey;
+    bufSize = 32768;
+    if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, keyName, 0, 1, &hKey) == ERROR_SUCCESS) {
+        if (RegQueryValueExA(hKey, valueName, NULL, NULL, buf, &bufSize) == ERROR_SUCCESS) {
+            cpu_string = reinterpret_cast<const char*>(buf);
+        }
+        RegCloseKey(hKey);
+    }
+#elif defined(Q_OS_LINUX)
+    auto cpuinfo = QString("/proc/cpuinfo");
+    auto cpuinfo_fi = QFileInfo(cpuinfo);
+    if(!cpuinfo_fi.isReadable()) {
+        return;
+    }
+    QFile file(cpuinfo);
+    if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QTextStream textStream(&file);
+        while(true) {
+            QString line = textStream.readLine();
+            if (line.isNull()) {
+                break;
+            }
+            if(line.contains(QRegExp("model name.*:"))) {
+                auto list = line.split(": ");
+                if(!list.last().isEmpty()) {
+                    cpu_string = list.last();
+                    break;
+                }
+            }
+
+        }
+    }
+#endif
+
+    qstrncpy(outbuf, cpu_string.toUtf8().constData(), len);
+
 }

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -1309,6 +1309,12 @@ plat_language_code(char *langcode)
     return 0;
 }
 
+void
+plat_get_cpu_string(char *outbuf, uint8_t len) {
+    char cpu_string[] = "Unknown";
+    strncpy(outbuf, cpu_string, len);
+}
+
 /* Converts back the language code to LCID */
 void
 plat_language_code_r(uint32_t lcid, char *outbuf, int len)

--- a/src/win/win.c
+++ b/src/win/win.c
@@ -1251,6 +1251,12 @@ plat_language_code_r(uint32_t lcid, char *outbuf, int len)
 }
 
 void
+plat_get_cpu_string(char *outbuf, uint8_t len) {
+    char cpu_string[] = "Unknown";
+    strncpy(outbuf, cpu_string, len);
+}
+
+void
 take_screenshot(void)
 {
     startblit();


### PR DESCRIPTION
Summary
=======
`plat_get_cpu_string` uses different methods to try and get the cpu string. These methods vary by OS. If it can't be determined it simply returns `Unknown`.

It is only really implemented in qt. There are stubs in unix and win that also return `Unknown`.

* Mac: `sysctl`
* Windows: registry key
* Linux: `/proc/cpuinfo`

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
