### PR TITLE
ymfm: Clean up numerous warnings

### DIFF
--- a/src/sound/snd_opl_ymfm.cpp
+++ b/src/sound/snd_opl_ymfm.cpp
@@ -150,12 +150,15 @@ public:
     {
         for (uint32_t i = 0; i < num_samples; i++) {
             m_chip.generate(&m_output);
-            if (ChipType::OUTPUTS == 1) {
-                *data++ = m_output.data[(m_type == FM_YMF278B) ? 4 : 0];
-                *data++ = m_output.data[(m_type == FM_YMF278B) ? 4 : 0];
+            if(m_type == FM_YMF278B) {
+                *data++ += m_output.data[4 % ChipType::OUTPUTS];
+                *data++ += m_output.data[5 % ChipType::OUTPUTS];
+            } else if (ChipType::OUTPUTS == 1) {
+                *data++ = m_output.data[0];
+                *data++ = m_output.data[0];
             } else {
-                *data++ = m_output.data[(m_type == FM_YMF278B) ? 4 : 0];
-                *data++ = m_output.data[(m_type == FM_YMF278B) ? 5 : (1 % ChipType::OUTPUTS)];
+                *data++ = m_output.data[0];
+                *data++ = m_output.data[1 % ChipType::OUTPUTS];
             }
         }
     }
@@ -167,12 +170,15 @@ public:
                 m_oldsamples[0] = m_samples[0];
                 m_oldsamples[1] = m_samples[1];
                 m_chip.generate(&m_output);
-                if (ChipType::OUTPUTS == 1) {
-                    m_samples[0] = m_output.data[(m_type == FM_YMF278B) ? 4 : 0];
-                    m_samples[1] = m_output.data[(m_type == FM_YMF278B) ? 4 : 0];
+                if(m_type == FM_YMF278B) {
+                    m_samples[0] += m_output.data[4 % ChipType::OUTPUTS];
+                    m_samples[1] += m_output.data[5 % ChipType::OUTPUTS];
+                } else if (ChipType::OUTPUTS == 1) {
+                    m_samples[0] = m_output.data[0];
+                    m_samples[1] = m_output.data[0];
                 } else {
-                    m_samples[0] = m_output.data[(m_type == FM_YMF278B) ? 4 : 0];
-                    m_samples[1] = m_output.data[(m_type == FM_YMF278B) ? 5 : (1 % ChipType::OUTPUTS)];
+                    m_samples[0] = m_output.data[0];
+                    m_samples[1] = m_output.data[1 % ChipType::OUTPUTS];
                 }
                 m_samplecnt -= m_rateratio;
             }

--- a/src/sound/ymfm/ymfm.h
+++ b/src/sound/ymfm/ymfm.h
@@ -46,6 +46,8 @@
 #include <string>
 #include <vector>
 
+#define SNPRINTF_BUFFER_SIZE_CALC (256 - (end - &buffer[0]))
+
 namespace ymfm
 {
 
@@ -350,7 +352,7 @@ public:
 		{
 			// create file
 			char name[20];
-			sprintf(name, "wavlog-%02d.wav", m_index);
+                        snprintf(name, sizeof(name), "wavlog-%02d.wav", m_index);
 			FILE *out = fopen(name, "wb");
 
 			// make the wav file header

--- a/src/sound/ymfm/ymfm_fm.ipp
+++ b/src/sound/ymfm/ymfm_fm.ipp
@@ -1522,8 +1522,11 @@ void fm_engine_base<RegisterType>::engine_timer_expired(uint32_t tnum)
 				m_modified_channels |= 1 << chnum;
 			}
 
-	// reset
-	m_timer_running[tnum] = false;
+        // Make sure the array does not go out of bounds to keep gcc happy
+        if(tnum < 2) {
+            // reset
+            m_timer_running[tnum] = false;
+        }
 	update_timer(tnum, 1, 0);
 }
 

--- a/src/sound/ymfm/ymfm_opl.cpp
+++ b/src/sound/ymfm/ymfm_opl.cpp
@@ -388,7 +388,7 @@ std::string opl_registers_base<Revision>::log_keyon(uint32_t choffs, uint32_t op
 	char buffer[256];
 	char *end = &buffer[0];
 
-	end += sprintf(end, "%2u.%02u freq=%04X fb=%u alg=%X mul=%X tl=%02X ksr=%u ns=%u ksl=%u adr=%X/%X/%X sl=%X sus=%u",
+	end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, "%2u.%02u freq=%04X fb=%u alg=%X mul=%X tl=%02X ksr=%u ns=%u ksl=%u adr=%X/%X/%X sl=%X sus=%u",
 		chnum, opnum,
 		ch_block_freq(choffs),
 		ch_feedback(choffs),
@@ -405,25 +405,25 @@ std::string opl_registers_base<Revision>::log_keyon(uint32_t choffs, uint32_t op
 		op_eg_sustain(opoffs));
 
 	if (OUTPUTS > 1)
-		end += sprintf(end, " out=%c%c%c%c",
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " out=%c%c%c%c",
 			ch_output_0(choffs) ? 'L' : '-',
 			ch_output_1(choffs) ? 'R' : '-',
 			ch_output_2(choffs) ? '0' : '-',
 			ch_output_3(choffs) ? '1' : '-');
 	if (op_lfo_am_enable(opoffs) != 0)
-		end += sprintf(end, " am=%u", lfo_am_depth());
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " am=%u", lfo_am_depth());
 	if (op_lfo_pm_enable(opoffs) != 0)
-		end += sprintf(end, " pm=%u", lfo_pm_depth());
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " pm=%u", lfo_pm_depth());
 	if (waveform_enable() && op_waveform(opoffs) != 0)
-		end += sprintf(end, " wf=%u", op_waveform(opoffs));
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " wf=%u", op_waveform(opoffs));
 	if (is_rhythm(choffs))
-		end += sprintf(end, " rhy=1");
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " rhy=1");
 	if (DYNAMIC_OPS)
 	{
 		operator_mapping map;
 		operator_map(map);
 		if (bitfield(map.chan[chnum], 16, 8) != 0xff)
-			end += sprintf(end, " 4op");
+			end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " 4op");
 	}
 
 	return buffer;
@@ -687,7 +687,7 @@ std::string opll_registers::log_keyon(uint32_t choffs, uint32_t opoffs)
 	char buffer[256];
 	char *end = &buffer[0];
 
-	end += sprintf(end, "%u.%02u freq=%04X inst=%X fb=%u mul=%X",
+	end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, "%u.%02u freq=%04X inst=%X fb=%u mul=%X",
 		chnum, opnum,
 		ch_block_freq(choffs),
 		ch_instrument(choffs),
@@ -695,11 +695,11 @@ std::string opll_registers::log_keyon(uint32_t choffs, uint32_t opoffs)
 		op_multiple(opoffs));
 
 	if (bitfield(opoffs, 0) == 1 || (is_rhythm(choffs) && choffs >= 6))
-		end += sprintf(end, " vol=%X", op_volume(opoffs));
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " vol=%X", op_volume(opoffs));
 	else
-		end += sprintf(end, " tl=%02X", ch_total_level(choffs));
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " tl=%02X", ch_total_level(choffs));
 
-	end += sprintf(end, " ksr=%u ksl=%u adr=%X/%X/%X sl=%X sus=%u/%u",
+	end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " ksr=%u ksl=%u adr=%X/%X/%X sl=%X sus=%u/%u",
 		op_ksr(opoffs),
 		op_ksl(opoffs),
 		op_attack_rate(opoffs),
@@ -710,13 +710,13 @@ std::string opll_registers::log_keyon(uint32_t choffs, uint32_t opoffs)
 		ch_sustain(choffs));
 
 	if (op_lfo_am_enable(opoffs))
-		end += sprintf(end, " am=1");
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " am=1");
 	if (op_lfo_pm_enable(opoffs))
-		end += sprintf(end, " pm=1");
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " pm=1");
 	if (op_waveform(opoffs) != 0)
-		end += sprintf(end, " wf=1");
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " wf=1");
 	if (is_rhythm(choffs))
-		end += sprintf(end, " rhy=1");
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " rhy=1");
 
 	return buffer;
 }

--- a/src/sound/ymfm/ymfm_opm.cpp
+++ b/src/sound/ymfm/ymfm_opm.cpp
@@ -356,7 +356,7 @@ std::string opm_registers::log_keyon(uint32_t choffs, uint32_t opoffs)
 	char buffer[256];
 	char *end = &buffer[0];
 
-	end += sprintf(end, "%u.%02u freq=%04X dt2=%u dt=%u fb=%u alg=%X mul=%X tl=%02X ksr=%u adsr=%02X/%02X/%02X/%X sl=%X out=%c%c",
+	end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, "%u.%02u freq=%04X dt2=%u dt=%u fb=%u alg=%X mul=%X tl=%02X ksr=%u adsr=%02X/%02X/%02X/%X sl=%X out=%c%c",
 		chnum, opnum,
 		ch_block_freq(choffs),
 		op_detune2(opoffs),
@@ -376,14 +376,14 @@ std::string opm_registers::log_keyon(uint32_t choffs, uint32_t opoffs)
 
 	bool am = (lfo_am_depth() != 0 && ch_lfo_am_sens(choffs) != 0 && op_lfo_am_enable(opoffs) != 0);
 	if (am)
-		end += sprintf(end, " am=%u/%02X", ch_lfo_am_sens(choffs), lfo_am_depth());
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " am=%u/%02X", ch_lfo_am_sens(choffs), lfo_am_depth());
 	bool pm = (lfo_pm_depth() != 0 && ch_lfo_pm_sens(choffs) != 0);
 	if (pm)
-		end += sprintf(end, " pm=%u/%02X", ch_lfo_pm_sens(choffs), lfo_pm_depth());
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " pm=%u/%02X", ch_lfo_pm_sens(choffs), lfo_pm_depth());
 	if (am || pm)
-		end += sprintf(end, " lfo=%02X/%c", lfo_rate(), "WQTN"[lfo_waveform()]);
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " lfo=%02X/%c", lfo_rate(), "WQTN"[lfo_waveform()]);
 	if (noise_enable() && opoffs == 31)
-		end += sprintf(end, " noise=1");
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " noise=1");
 
 	return buffer;
 }

--- a/src/sound/ymfm/ymfm_opn.cpp
+++ b/src/sound/ymfm/ymfm_opn.cpp
@@ -411,7 +411,7 @@ std::string opn_registers_base<IsOpnA>::log_keyon(uint32_t choffs, uint32_t opof
 	char buffer[256];
 	char *end = &buffer[0];
 
-	end += sprintf(end, "%u.%02u freq=%04X dt=%u fb=%u alg=%X mul=%X tl=%02X ksr=%u adsr=%02X/%02X/%02X/%X sl=%X",
+	end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, "%u.%02u freq=%04X dt=%u fb=%u alg=%X mul=%X tl=%02X ksr=%u adsr=%02X/%02X/%02X/%X sl=%X",
 		chnum, opnum,
 		block_freq,
 		op_detune(opoffs),
@@ -427,21 +427,21 @@ std::string opn_registers_base<IsOpnA>::log_keyon(uint32_t choffs, uint32_t opof
 		op_sustain_level(opoffs));
 
 	if (OUTPUTS > 1)
-		end += sprintf(end, " out=%c%c",
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " out=%c%c",
 			ch_output_0(choffs) ? 'L' : '-',
 			ch_output_1(choffs) ? 'R' : '-');
 	if (op_ssg_eg_enable(opoffs))
-		end += sprintf(end, " ssg=%X", op_ssg_eg_mode(opoffs));
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " ssg=%X", op_ssg_eg_mode(opoffs));
 	bool am = (op_lfo_am_enable(opoffs) && ch_lfo_am_sens(choffs) != 0);
 	if (am)
-		end += sprintf(end, " am=%u", ch_lfo_am_sens(choffs));
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " am=%u", ch_lfo_am_sens(choffs));
 	bool pm = (ch_lfo_pm_sens(choffs) != 0);
 	if (pm)
-		end += sprintf(end, " pm=%u", ch_lfo_pm_sens(choffs));
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " pm=%u", ch_lfo_pm_sens(choffs));
 	if (am || pm)
-		end += sprintf(end, " lfo=%02X", lfo_rate());
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " lfo=%02X", lfo_rate());
 	if (multi_freq() && choffs == 2)
-		end += sprintf(end, " multi=1");
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " multi=1");
 
 	return buffer;
 }

--- a/src/sound/ymfm/ymfm_opq.cpp
+++ b/src/sound/ymfm/ymfm_opq.cpp
@@ -341,7 +341,7 @@ std::string opq_registers::log_keyon(uint32_t choffs, uint32_t opoffs)
 	char buffer[256];
 	char *end = &buffer[0];
 
-	end += sprintf(end, "%u.%02u freq=%04X dt=%+2d fb=%u alg=%X mul=%X tl=%02X ksr=%u adsr=%02X/%02X/%02X/%X sl=%X out=%c%c",
+	end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, "%u.%02u freq=%04X dt=%+2d fb=%u alg=%X mul=%X tl=%02X ksr=%u adsr=%02X/%02X/%02X/%X sl=%X out=%c%c",
 		chnum, opnum,
 		(opoffs & 1) ? ch_block_freq_24(choffs) : ch_block_freq_13(choffs),
 		int32_t(op_detune(opoffs)) - 0x20,
@@ -360,14 +360,14 @@ std::string opq_registers::log_keyon(uint32_t choffs, uint32_t opoffs)
 
 	bool am = (lfo_enable() && op_lfo_am_enable(opoffs) && ch_lfo_am_sens(choffs) != 0);
 	if (am)
-		end += sprintf(end, " am=%u", ch_lfo_am_sens(choffs));
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " am=%u", ch_lfo_am_sens(choffs));
 	bool pm = (lfo_enable() && ch_lfo_pm_sens(choffs) != 0);
 	if (pm)
-		end += sprintf(end, " pm=%u", ch_lfo_pm_sens(choffs));
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " pm=%u", ch_lfo_pm_sens(choffs));
 	if (am || pm)
-		end += sprintf(end, " lfo=%02X", lfo_rate());
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " lfo=%02X", lfo_rate());
 	if (ch_reverb(choffs))
-		end += sprintf(end, " reverb");
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " reverb");
 
 	return buffer;
 }

--- a/src/sound/ymfm/ymfm_opz.cpp
+++ b/src/sound/ymfm/ymfm_opz.cpp
@@ -557,14 +557,14 @@ std::string opz_registers::log_keyon(uint32_t choffs, uint32_t opoffs)
 	char buffer[256];
 	char *end = &buffer[0];
 
-	end += sprintf(end, "%u.%02u", chnum, opnum);
+	end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, "%u.%02u", chnum, opnum);
 
 	if (op_fix_mode(opoffs))
-		end += sprintf(end, " fixfreq=%X fine=%X shift=%X", op_fix_frequency(opoffs), op_fine(opoffs), op_fix_range(opoffs));
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " fixfreq=%X fine=%X shift=%X", op_fix_frequency(opoffs), op_fine(opoffs), op_fix_range(opoffs));
 	else
-		end += sprintf(end, " freq=%04X dt2=%u fine=%X", ch_block_freq(choffs), op_detune2(opoffs), op_fine(opoffs));
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " freq=%04X dt2=%u fine=%X", ch_block_freq(choffs), op_detune2(opoffs), op_fine(opoffs));
 
-	end += sprintf(end, " dt=%u fb=%u alg=%X mul=%X tl=%02X ksr=%u adsr=%02X/%02X/%02X/%X sl=%X out=%c%c",
+	end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " dt=%u fb=%u alg=%X mul=%X tl=%02X ksr=%u adsr=%02X/%02X/%02X/%X sl=%X out=%c%c",
 		op_detune(opoffs),
 		ch_feedback(choffs),
 		ch_algorithm(choffs),
@@ -580,32 +580,32 @@ std::string opz_registers::log_keyon(uint32_t choffs, uint32_t opoffs)
 		ch_output_1(choffs) ? 'R' : '-');
 
 	if (op_eg_shift(opoffs) != 0)
-		end += sprintf(end, " egshift=%u", op_eg_shift(opoffs));
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " egshift=%u", op_eg_shift(opoffs));
 
 	bool am = (lfo_am_depth() != 0 && ch_lfo_am_sens(choffs) != 0 && op_lfo_am_enable(opoffs) != 0);
 	if (am)
-		end += sprintf(end, " am=%u/%02X", ch_lfo_am_sens(choffs), lfo_am_depth());
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " am=%u/%02X", ch_lfo_am_sens(choffs), lfo_am_depth());
 	bool pm = (lfo_pm_depth() != 0 && ch_lfo_pm_sens(choffs) != 0);
 	if (pm)
-		end += sprintf(end, " pm=%u/%02X", ch_lfo_pm_sens(choffs), lfo_pm_depth());
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " pm=%u/%02X", ch_lfo_pm_sens(choffs), lfo_pm_depth());
 	if (am || pm)
-		end += sprintf(end, " lfo=%02X/%c", lfo_rate(), "WQTN"[lfo_waveform()]);
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " lfo=%02X/%c", lfo_rate(), "WQTN"[lfo_waveform()]);
 
 	bool am2 = (lfo2_am_depth() != 0 && ch_lfo2_am_sens(choffs) != 0 && op_lfo_am_enable(opoffs) != 0);
 	if (am2)
-		end += sprintf(end, " am2=%u/%02X", ch_lfo2_am_sens(choffs), lfo2_am_depth());
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " am2=%u/%02X", ch_lfo2_am_sens(choffs), lfo2_am_depth());
 	bool pm2 = (lfo2_pm_depth() != 0 && ch_lfo2_pm_sens(choffs) != 0);
 	if (pm2)
-		end += sprintf(end, " pm2=%u/%02X", ch_lfo2_pm_sens(choffs), lfo2_pm_depth());
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " pm2=%u/%02X", ch_lfo2_pm_sens(choffs), lfo2_pm_depth());
 	if (am2 || pm2)
-		end += sprintf(end, " lfo2=%02X/%c", lfo2_rate(), "WQTN"[lfo2_waveform()]);
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " lfo2=%02X/%c", lfo2_rate(), "WQTN"[lfo2_waveform()]);
 
 	if (op_reverb_rate(opoffs) != 0)
-		end += sprintf(end, " rev=%u", op_reverb_rate(opoffs));
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " rev=%u", op_reverb_rate(opoffs));
 	if (op_waveform(opoffs) != 0)
-		end += sprintf(end, " wf=%u", op_waveform(opoffs));
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " wf=%u", op_waveform(opoffs));
 	if (noise_enable() && opoffs == 31)
-		end += sprintf(end, " noise=1");
+		end += snprintf(end, SNPRINTF_BUFFER_SIZE_CALC, " noise=1");
 
 	return buffer;
 }


### PR DESCRIPTION
Summary
=======
Cleaning up a bunch of ymfm warnings:

* One such warning revolved around the YMF278B implementation. The index was based around a ternary which made gcc unhappy. Cleaned up by matching the official example (existing code did not match)
* Another issue was cleaned up by adding a conditional to make gcc happy (this one resulted in several warnings)

In addition, all `sprintf`s were cleaned up to `snprintf`s to make clang happy. Since ymfm uses pointer arithmetic to write to the buffer a special macro had to be created to be passed to `snprintf` and properly calculate the remaining size. You'll see the macro as `SNPRINTF_BUFFER_SIZE_CALC`.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
