### PR TITLE
More sprintf and warning cleanup

### DIFF
--- a/src/qt/qt_vulkanrenderer.cpp
+++ b/src/qt/qt_vulkanrenderer.cpp
@@ -938,9 +938,6 @@ VulkanRenderer2::startNextFrame()
     if (err != VK_SUCCESS)
         qFatal("Failed to map memory: %d", err);
     QMatrix4x4 m = m_proj;
-#if 0
-    m.rotate(m_rotation, 0, 0, 1);
-#endif
     memcpy(p, m.constData(), 16 * sizeof(float));
     m_devFuncs->vkUnmapMemory(dev, m_bufMem);
     p = nullptr;

--- a/src/qt/qt_vulkanrenderer.hpp
+++ b/src/qt/qt_vulkanrenderer.hpp
@@ -89,6 +89,5 @@ private:
     VkFormat       m_texFormat;
 
     QMatrix4x4 m_proj;
-    float      m_rotation = 0.0f;
 };
 #endif

--- a/src/qt/sdl_joystick.cpp
+++ b/src/qt/sdl_joystick.cpp
@@ -41,15 +41,15 @@ joystick_init()
             plat_joystick_state[c].nr_povs    = SDL_JoystickNumHats(sdl_joy[c]);
 
             for (d = 0; d < std::min(plat_joystick_state[c].nr_axes, 8); d++) {
-                sprintf(plat_joystick_state[c].axis[d].name, "Axis %i", d);
+                snprintf(plat_joystick_state[c].axis[d].name, sizeof(plat_joystick_state[c].axis[d].name), "Axis %i", d);
                 plat_joystick_state[c].axis[d].id = d;
             }
             for (d = 0; d < std::min(plat_joystick_state[c].nr_buttons, 8); d++) {
-                sprintf(plat_joystick_state[c].button[d].name, "Button %i", d);
+                snprintf(plat_joystick_state[c].button[d].name, sizeof(plat_joystick_state[c].button[d].name), "Button %i", d);
                 plat_joystick_state[c].button[d].id = d;
             }
             for (d = 0; d < std::min(plat_joystick_state[c].nr_povs, 4); d++) {
-                sprintf(plat_joystick_state[c].pov[d].name, "POV %i", d);
+                snprintf(plat_joystick_state[c].pov[d].name, sizeof(plat_joystick_state[c].pov[d].name), "POV %i", d);
                 plat_joystick_state[c].pov[d].id = d;
             }
         }

--- a/src/sound/munt/MidiStreamParser.cpp
+++ b/src/sound/munt/MidiStreamParser.cpp
@@ -191,7 +191,7 @@ Bit32u MidiStreamParserImpl::parseShortMessageDataBytes(const Bit8u stream[], Bi
 		} else if (dataByte < 0xF8) {
 			// Discard invalid bytes and start over
 			char s[128];
-			sprintf(s, "parseShortMessageDataBytes: Invalid short message: status %02x, expected length %i, actual %i -> ignored", *streamBuffer, shortMessageLength, streamBufferSize);
+			snprintf(s, sizeof(s), "parseShortMessageDataBytes: Invalid short message: status %02x, expected length %i, actual %i -> ignored", *streamBuffer, shortMessageLength, streamBufferSize);
 			midiReporter.printDebug(s);
 			streamBufferSize = 0; // Clear streamBuffer
 			return parsedLength;

--- a/src/sound/munt/Part.cpp
+++ b/src/sound/munt/Part.cpp
@@ -54,7 +54,7 @@ Part::Part(Synth *useSynth, unsigned int usePartNum) {
 		// Nasty hack for rhythm
 		timbreTemp = NULL;
 	} else {
-		sprintf(name, "Part %d", partNum + 1);
+                snprintf(name, sizeof(name), "Part %d", partNum + 1);
 		timbreTemp = &synth->mt32ram.timbreTemp[partNum];
 	}
 	currentInstr[0] = 0;


### PR DESCRIPTION
Summary
=======
Some more warning cleanups. `sprintf` and unused vars.

I think `qt_vulkanrenderer.hpp` got converted from CRLF->LF when I modified it.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
