### PR TITLE
More warning cleanups

### DIFF
--- a/src/cdrom/cdrom_image_viso.c
+++ b/src/cdrom/cdrom_image_viso.c
@@ -331,7 +331,7 @@ viso_fill_fn_short(char *data, const viso_entry_t *entry, viso_entry_t **entries
     }
 
     /* Check if this filename is unique, and add a tail if required, while also adding the extension. */
-    char tail[8];
+    char tail[16];
     for (int i = force_tail; i <= 999999; i++) {
         /* Add tail to the filename if this is not the first run. */
         int tail_len = -1;

--- a/src/codegen_new/codegen_backend_arm64_ops.c
+++ b/src/codegen_new/codegen_backend_arm64_ops.c
@@ -341,7 +341,7 @@ host_arm64_ADDX_IMM(codeblock_t *block, int dst_reg, int src_n_reg, uint64_t imm
         } else if (imm_data & 0xfff000)
             codegen_addlong(block, OPCODE_ADDX_IMM | Rd(dst_reg) | Rn(src_n_reg) | IMM12((imm_data >> 12) & 0xfff) | DATPROC_IMM_SHIFT(1));
     } else
-        fatal("ADD_IMM_X %016llx\n", imm_data);
+        fatal("ADD_IMM_X %016" PRIu64 "\n", imm_data);
 }
 void
 host_arm64_ADD_REG(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_reg, int shift)
@@ -684,7 +684,7 @@ host_arm64_CMPX_IMM(codeblock_t *block, int src_n_reg, uint64_t imm_data)
     } else if (!(imm_data & 0xfffffffffffff000ull)) {
         codegen_addlong(block, OPCODE_CMPX_IMM | Rd(REG_XZR) | Rn(src_n_reg) | IMM12(imm_data & 0xfff) | DATPROC_IMM_SHIFT(0));
     } else
-        fatal("CMPX_IMM %08llx\n", imm_data);
+        fatal("CMPX_IMM %08" PRIu64 "\n", imm_data);
 }
 
 void

--- a/src/cpu/codegen_timing_pentium.c
+++ b/src/cpu/codegen_timing_pentium.c
@@ -17,6 +17,7 @@
 #include "cpu.h"
 #include <86box/mem.h>
 #include <86box/plat_unused.h>
+#include <inttypes.h>
 
 #include "x86.h"
 #include "x86_ops.h"
@@ -850,7 +851,7 @@ COUNT(uint64_t timings, uint64_t deps, int op_32)
             return cpu_has_feature(CPU_FEATURE_MMX) ? 1 : 2;
     }
 
-    fatal("Illegal COUNT %016llx\n", timings);
+    fatal("Illegal COUNT %016" PRIu64 "\n", timings);
 
     return timings;
 }

--- a/src/disk/minivhd/manage.c
+++ b/src/disk/minivhd/manage.c
@@ -439,13 +439,14 @@ MVHDAPI int
 mvhd_file_is_vhd(FILE* f)
 {
     uint8_t con_str[8];
+    size_t res;
 
     if (f == NULL) {
         return 0;
     }
 
     mvhd_fseeko64(f, -MVHD_FOOTER_SIZE, SEEK_END);
-    fread(con_str, sizeof con_str, 1, f);
+    res = fread(con_str, sizeof con_str, 1, f);
     if (mvhd_is_conectix_str(con_str)) {
         return 1;
     }

--- a/src/unix/unix_serial_passthrough.c
+++ b/src/unix/unix_serial_passthrough.c
@@ -94,6 +94,7 @@ plat_serpt_write_vcon(serial_passthrough_t *dev, uint8_t data)
     fd_set wrfds;
     int    res;
 #endif
+    size_t res;
 
     /* We cannot use select here, this would block the hypervisor! */
 #if 0
@@ -109,12 +110,11 @@ plat_serpt_write_vcon(serial_passthrough_t *dev, uint8_t data)
 
     /* just write it out */
     if (dev->mode == SERPT_MODE_HOSTSER) {
-        int res = 0;
         do {
             res = write(dev->master_fd, &data, 1);
         } while (res == 0 || (res == -1 && (errno == EAGAIN || res == EWOULDBLOCK)));
     } else
-        write(dev->master_fd, &data, 1);
+        res = write(dev->master_fd, &data, 1);
 }
 
 void

--- a/src/video/vid_xga.c
+++ b/src/video/vid_xga.c
@@ -3079,6 +3079,7 @@ xga_init(const device_t *info)
     xga_t   *xga  = &svga->xga;
     FILE    *f;
     uint8_t *rom = NULL;
+    size_t   res;
 
     xga->ext_mem_addr = device_get_config_hex16("ext_mem_addr");
     xga->instance_isa = device_get_config_int("instance");
@@ -3103,7 +3104,7 @@ xga_init(const device_t *info)
 
     rom = malloc(xga->bios_rom.sz);
     memset(rom, 0xff, xga->bios_rom.sz);
-    (void) fread(rom, xga->bios_rom.sz, 1, f);
+    res = fread(rom, xga->bios_rom.sz, 1, f);
     (void) fclose(f);
 
     xga->bios_rom.rom  = rom;


### PR DESCRIPTION
Summary
=======
These are primarily for gcc on linux.

* Fix up some buffer sizes to where gcc won't be upset about possible truncation
* Move some printf formatters to `PRIu64` which will work across all platforms
* Assign a return variable to some `fread`s and `write`s. These were triggering `-Wunused-result` because the functions have the attribute `warn_unused_result`.
  * Note that the return value isn't checked or acted upon, just assigned to make gcc happy.

Tested the changes for warnings on mac (clang), linux (gcc) and windows (gcc). 

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A