### PR TITLE
Compile fix.

### DIFF
--- a/src/video/vid_ati68860_ramdac.c
+++ b/src/video/vid_ati68860_ramdac.c
@@ -68,19 +68,20 @@ void
 ati68860_ramdac_out(uint16_t addr, uint8_t val, void *priv, svga_t *svga)
 {
     ati68860_ramdac_t *ramdac = (ati68860_ramdac_t *) priv;
+    ibm8514_t 		  *dev    = &svga->dev8514;
 
     switch (addr) {
         case 0:
-            svga_out(ibm8514_on ? 0x2ec : 0x3c8, val, svga);
+            svga_out(dev->on ? 0x2ec : 0x3c8, val, svga);
             break;
         case 1:
-            svga_out(ibm8514_on ? 0x2ed : 0x3c9, val, svga);
+            svga_out(dev->on ? 0x2ed : 0x3c9, val, svga);
             break;
         case 2:
-            svga_out(ibm8514_on ? 0x2ea : 0x3c6, val, svga);
+            svga_out(dev->on ? 0x2ea : 0x3c6, val, svga);
             break;
         case 3:
-            svga_out(ibm8514_on ? 0x2eb : 0x3c7, val, svga);
+            svga_out(dev->on ? 0x2eb : 0x3c7, val, svga);
             break;
         default:
             ramdac->regs[addr & 0xf] = val;
@@ -171,20 +172,21 @@ uint8_t
 ati68860_ramdac_in(uint16_t addr, void *priv, svga_t *svga)
 {
     const ati68860_ramdac_t *ramdac = (ati68860_ramdac_t *) priv;
+    ibm8514_t 		  *dev    = &svga->dev8514;
     uint8_t                  temp   = 0;
 
     switch (addr) {
         case 0:
-            temp = svga_in(ibm8514_on ? 0x2ec : 0x3c8, svga);
+            temp = svga_in(dev->on ? 0x2ec : 0x3c8, svga);
             break;
         case 1:
-            temp = svga_in(ibm8514_on ? 0x2ed : 0x3c9, svga);
+            temp = svga_in(dev->on ? 0x2ed : 0x3c9, svga);
             break;
         case 2:
-            temp = svga_in(ibm8514_on ? 0x2ea : 0x3c6, svga);
+            temp = svga_in(dev->on ? 0x2ea : 0x3c6, svga);
             break;
         case 3:
-            temp = svga_in(ibm8514_on ? 0x2eb : 0x3c7, svga);
+            temp = svga_in(dev->on ? 0x2eb : 0x3c7, svga);
             break;
         case 4:
         case 8:


### PR DESCRIPTION
Summary
=======
Now the ATI 68860 RAMDAC is using the proper 8514/A ON flag when needed.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
