### PR TITLE
Fix broken VHD handling

### DIFF
--- a/src/disk/minivhd/manage.c
+++ b/src/disk/minivhd/manage.c
@@ -445,6 +445,7 @@ mvhd_file_is_vhd(FILE* f)
     }
 
     mvhd_fseeko64(f, -MVHD_FOOTER_SIZE, SEEK_END);
+    (void) !fread(con_str, sizeof con_str, 1, f);
     if (mvhd_is_conectix_str(con_str)) {
         return 1;
     }


### PR DESCRIPTION
Summary
=======
Restore an `fread()` that was accidentally removed during a cleanup in https://github.com/86Box/86Box/commit/375f69ed611a404765034547353f3b639ef39805#diff-d72bfe3a78e6ceb45ad18538746a43d7a89dd5bdea6958276ed0c2760086cef7L449, causing VHD support to break.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
