### PR TITLE
Compaq Deskpro 386 1988 BIOS ROM change:

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -560,7 +560,7 @@ extern int machine_at_portableii_init(const machine_t *);
 extern int machine_at_portableiii_init(const machine_t *);
 extern int machine_at_portableiii386_init(const machine_t *);
 extern int machine_at_deskpro386_init(const machine_t *);
-extern int machine_at_deskpro386_01_1988_init(const machine_t *);
+extern int machine_at_deskpro386_05_1988_init(const machine_t *);
 
 /* m_at_socket4.c */
 extern void machine_at_premiere_common_init(const machine_t *, int);

--- a/src/machine/m_at_compaq.c
+++ b/src/machine/m_at_compaq.c
@@ -52,7 +52,7 @@ enum {
     COMPAQ_PORTABLEIII,
     COMPAQ_PORTABLEIII386,
     COMPAQ_DESKPRO386,
-    COMPAQ_DESKPRO386_01_1988
+    COMPAQ_DESKPRO386_05_1988
 };
 
 #define CGA_RGB       0
@@ -829,7 +829,7 @@ machine_at_compaq_init(const machine_t *model, int type)
             break;
 
         case COMPAQ_DESKPRO386:
-        case COMPAQ_DESKPRO386_01_1988:
+        case COMPAQ_DESKPRO386_05_1988:
             if (hdc_current == 1)
                 device_add(&ide_isa_device);
             device_add(&compaq_386_device);
@@ -909,17 +909,17 @@ machine_at_deskpro386_init(const machine_t *model)
 }
 
 int
-machine_at_deskpro386_01_1988_init(const machine_t *model)
+machine_at_deskpro386_05_1988_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linearr("roms/machines/deskpro386/1988-01-28.json.bin",
+    ret = bios_load_linearr("roms/machines/deskpro386/1988-05-10.json.bin",
                             0x000f8000, 65536, 0);
 
     if (bios_only || !ret)
         return ret;
 
-    machine_at_compaq_init(model, COMPAQ_DESKPRO386_01_1988);
+    machine_at_compaq_init(model, COMPAQ_DESKPRO386_05_1988);
 
     return ret;
 }

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -4708,11 +4708,11 @@ const machine_t machines[] = {
         .net_device = NULL
     },
     {
-        .name = "[ISA] Compaq Deskpro 386 (January 1988)",
-        .internal_name = "deskpro386_01_1988",
+        .name = "[ISA] Compaq Deskpro 386 (May 1988)",
+        .internal_name = "deskpro386_05_1988",
         .type = MACHINE_TYPE_386DX,
         .chipset = MACHINE_CHIPSET_DISCRETE,
-        .init = machine_at_deskpro386_01_1988_init,
+        .init = machine_at_deskpro386_05_1988_init,
         .pad = 0,
         .pad0 = 0,
         .pad1 = MACHINE_AVAILABLE,


### PR DESCRIPTION
Summary
=======
Changed to the May 1988 due to malformed status of the January 1988 one.

Checklist
=========
* [x] Closes #3606
* [x] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/210/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
