### PR TITLE
Fixing up path_get_slash return value

### DIFF
--- a/src/include/86box/path.h
+++ b/src/include/86box/path.h
@@ -3,6 +3,6 @@ extern char *path_get_filename(char *s);
 extern char *path_get_extension(char *s);
 extern void  path_append_filename(char *dest, const char *s1, const char *s2);
 extern void  path_slash(char *path);
-extern char *path_get_slash(char *path);
+extern const char *path_get_slash(char *path);
 extern void  path_normalize(char *path);
 extern int   path_abs(char *path);

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -304,16 +304,10 @@ path_slash(char *path)
     path_normalize(path);
 }
 
-char *
+const char *
 path_get_slash(char *path)
 {
-    auto        len = strlen(path);
-    std::string ret = "";
-
-    if (path[len - 1] != '/')
-        ret = "/";
-
-    return (char *) ret.c_str();
+    return QString(path).endsWith("/") ? "" : "/";
 }
 
 void

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -310,7 +310,7 @@ path_slash(char *path)
     path_normalize(path);
 }
 
-char *
+const char *
 path_get_slash(char *path)
 {
     char *ret = "";

--- a/src/win/win.c
+++ b/src/win/win.c
@@ -739,7 +739,7 @@ path_slash(char *path)
 }
 
 /* Return a trailing (back)slash if necessary. */
-char *
+const char *
 path_get_slash(char *path)
 {
     char *ret = "";


### PR DESCRIPTION
Summary
=======
The qt version of `path_get_slash` was returning a pointer to a string defined locally in the function. This was causing garbage to be returned from whatever memory location after it went out of scope.

I simplified the function based on what it was performing. I also changed the return type from `char *` to `const char*` to make things more simple. Header, QT, win, unix files were updated with the new signature.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
