### PR TITLE
Change NEC CD-ROM DRIVE:74 to 75.

### DIFF
--- a/src/include/86box/cdrom.h
+++ b/src/include/86box/cdrom.h
@@ -99,7 +99,7 @@ static const struct
     { "CHINON",   "CD-ROM CDS-431",     "H42 ", "(SCSI) CHINON CD-ROM CDS-431 H42",      "CHINON_CD-ROM_CDS-431_H42",     BUS_TYPE_SCSI }, /*22*/
     { "DEC",      "RRD45   (C) DEC",    "0436", "(SCSI) DEC RRD45 0436",                 "DEC_RRD45_0436",                BUS_TYPE_SCSI }, /*23*/
     { "MATSHITA", "CD-ROM CR-501",      "1.0b", "(SCSI) MATSHITA CD-ROM CR-501 1.0b",    "MATSHITA_CD-ROM_CR-501_1.0b",   BUS_TYPE_SCSI }, /*24*/
-    { "NEC",      "CD-ROM DRIVE:74",    "1.00", "(SCSI) NEC CD-ROM DRIVE:74 1.00",       "NEC_CD-ROM_DRIVE74_1.00",       BUS_TYPE_SCSI }, /*25*/
+    { "NEC",      "CD-ROM DRIVE:75",    "1.00", "(SCSI) NEC CD-ROM DRIVE:75 1.00",       "NEC_CD-ROM_DRIVE75_1.00",       BUS_TYPE_SCSI }, /*25*/
     { "NEC",      "CD-ROM DRIVE:464",   "1.05", "(SCSI) NEC CD-ROM DRIVE:464 1.05",      "NEC_CD-ROM_DRIVE464_1.05",      BUS_TYPE_SCSI }, /*26*/
     { "SONY",     "CD-ROM CDU-541",     "1.0i", "(SCSI) SONY CD-ROM CDU-541 1.0i",       "SONY_CD-ROM_CDU-541_1.0i",      BUS_TYPE_SCSI }, /*27*/
     { "SONY",     "CD-ROM CDU-76S",     "1.00", "(SCSI) SONY CD-ROM CDU-76S 1.00",       "SONY_CD-ROM_CDU-76S_1.00",      BUS_TYPE_SCSI }, /*28*/

--- a/src/scsi/scsi_cdrom.c
+++ b/src/scsi/scsi_cdrom.c
@@ -1011,7 +1011,7 @@ scsi_cdrom_command_common(scsi_cdrom_t *dev)
                 }
                 break;
             case 0xde:
-                if (!strcmp(cdrom_drive_types[dev->drv->type].internal_name, "NEC_CD-ROM_DRIVE74_1.00") ||
+                if (!strcmp(cdrom_drive_types[dev->drv->type].internal_name, "NEC_CD-ROM_DRIVE75_1.00") ||
                     !strcmp(cdrom_drive_types[dev->drv->type].internal_name, "NEC_CD-ROM_DRIVE464_1.05")) {
                     bytes_per_second = 176.0 * 1024.0;
                     bytes_per_second *= (double) dev->drv->cur_speed;
@@ -1809,7 +1809,7 @@ begin:
             break;
 
         case 0xDA: /*GPCMD_SPEED_ALT*/
-            if (!strcmp(cdrom_drive_types[dev->drv->type].internal_name, "NEC_CD-ROM_DRIVE74_1.00") ||
+            if (!strcmp(cdrom_drive_types[dev->drv->type].internal_name, "NEC_CD-ROM_DRIVE75_1.00") ||
                 !strcmp(cdrom_drive_types[dev->drv->type].internal_name, "NEC_CD-ROM_DRIVE464_1.05")) { /*GPCMD_STILL_NEC*/
                 scsi_cdrom_set_phase(dev, SCSI_PHASE_STATUS);
                 cdrom_audio_pause_resume(dev->drv, 0x00);
@@ -2037,7 +2037,7 @@ begin:
             dev->drv->seek_diff = ABS((int) (pos - dev->sector_pos));
 
             if ((cdb[0] == GPCMD_READ_10) || (cdb[0] == GPCMD_READ_12)) {
-                if (!strcmp(cdrom_drive_types[dev->drv->type].internal_name, "NEC_CD-ROM_DRIVE74_1.00") ||
+                if (!strcmp(cdrom_drive_types[dev->drv->type].internal_name, "NEC_CD-ROM_DRIVE75_1.00") ||
                     !strcmp(cdrom_drive_types[dev->drv->type].internal_name, "NEC_CD-ROM_DRIVE464_1.05") ||
                     !strcmp(cdrom_drive_types[dev->drv->type].internal_name, "TOSHIBA_CD-ROM_DRIVEXM_3433") ||
                     !strcmp(cdrom_drive_types[dev->drv->type].internal_name, "TOSHIBA_CD-ROM_XM-3301TA_0272") ||
@@ -2921,7 +2921,7 @@ begin:
                     } else if (!strcmp(cdrom_drive_types[dev->drv->type].internal_name, "MATSHITA_CD-ROM_CR-501_1.0b")) {
                         dev->buffer[3] = 0x01;
                         dev->buffer[2] = 0x02;
-                    } else if (!strcmp(cdrom_drive_types[dev->drv->type].internal_name, "NEC_CD-ROM_DRIVE74_1.00")) {
+                    } else if (!strcmp(cdrom_drive_types[dev->drv->type].internal_name, "NEC_CD-ROM_DRIVE75_1.00")) {
                         dev->buffer[3] = 0x01;
                         dev->buffer[2] = 0x02;
                     } else if (!strcmp(cdrom_drive_types[dev->drv->type].internal_name, "DEC_RRD45_0436")) {
@@ -3117,7 +3117,7 @@ atapi_out:
             }
             dev->drv->seek_diff = ABS((int) (pos - dev->drv->seek_pos));
             if (cdb[0] == GPCMD_SEEK_10) {
-                if (!strcmp(cdrom_drive_types[dev->drv->type].internal_name, "NEC_CD-ROM_DRIVE74_1.00") ||
+                if (!strcmp(cdrom_drive_types[dev->drv->type].internal_name, "NEC_CD-ROM_DRIVE75_1.00") ||
                     !strcmp(cdrom_drive_types[dev->drv->type].internal_name, "NEC_CD-ROM_DRIVE464_1.05") ||
                     !strcmp(cdrom_drive_types[dev->drv->type].internal_name, "TOSHIBA_CD-ROM_DRIVEXM_3433") ||
                     !strcmp(cdrom_drive_types[dev->drv->type].internal_name, "TOSHIBA_CD-ROM_XM-3301TA_0272") ||


### PR DESCRIPTION
Summary
=======
Change the NEC CD-ROM DRIVE:74 to 75 due to the former being buggy on NT.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
