### PR TITLE
qt: Remove a trailing space in a label in qt_settingsnetwork.ui

### DIFF
--- a/src/qt/qt_settingsnetwork.ui
+++ b/src/qt/qt_settingsnetwork.ui
@@ -356,7 +356,7 @@
        <item row="3" column="0">
         <widget class="QLabel" name="label_5">
          <property name="text">
-          <string>VDE Socket </string>
+          <string>VDE Socket</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Checklist
=========
* [x] Closes #3627, #3484
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A
