### PR TITLE
Make plat_fallthrough and plat_unused headers less fragile

### DIFF
--- a/src/include/86box/plat_fallthrough.h
+++ b/src/include/86box/plat_fallthrough.h
@@ -18,6 +18,7 @@
 #ifndef EMU_PLAT_FALLTHROUGH_H
 #define EMU_PLAT_FALLTHROUGH_H
 
+#ifndef EMU_PLAT_H
 #ifdef _MSC_VER
 # define fallthrough do {} while (0) /* fallthrough */
 #else
@@ -29,6 +30,7 @@
 #  endif
 #  define fallthrough do {} while (0) /* fallthrough */
 # endif
+#endif
 #endif
 
 #endif /*EMU_PLAT_FALLTHROUGH_H*/

--- a/src/include/86box/plat_unused.h
+++ b/src/include/86box/plat_unused.h
@@ -21,11 +21,13 @@
 #ifndef EMU_PLAT_UNUSED_H
 #define EMU_PLAT_UNUSED_H
 
+#ifndef EMU_PLAT_H
 #ifdef _MSC_VER
 #    define UNUSED(arg) arg
 #else
 /* A hack (GCC-specific?) to allow us to ignore unused parameters. */
 #    define UNUSED(arg) __attribute__((unused)) arg
+#endif
 #endif
 
 #endif /*EMU_PLAT_UNUSED_H*/


### PR DESCRIPTION
Summary
=======
Make plat_fallthrough and plat_unused headers less fragile

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
