### PR TITLE
qt: Expand the number of items displayed in comboboxes to 30

### DIFF
--- a/src/qt/qt_deviceconfig.cpp
+++ b/src/qt/qt_deviceconfig.cpp
@@ -138,6 +138,7 @@ DeviceConfig::ConfigureDevice(const _device_ *device, int instance, Settings *se
                 {
                     auto *cbox = new QComboBox();
                     cbox->setObjectName(config->name);
+                    cbox->setMaxVisibleItems(30);
                     auto *model        = cbox->model();
                     int   currentIndex = -1;
                     int   selected     = config_get_int(device_context.name, const_cast<char *>(config->name), config->default_int);
@@ -158,6 +159,7 @@ DeviceConfig::ConfigureDevice(const _device_ *device, int instance, Settings *se
                 {
                     auto *cbox = new QComboBox();
                     cbox->setObjectName(config->name);
+                    cbox->setMaxVisibleItems(30);
                     auto *model        = cbox->model();
                     int   currentIndex = -1;
                     int   selected     = config_get_int(device_context.name, const_cast<char *>(config->name), config->default_int);
@@ -181,6 +183,7 @@ DeviceConfig::ConfigureDevice(const _device_ *device, int instance, Settings *se
                 {
                     auto *cbox = new QComboBox();
                     cbox->setObjectName(config->name);
+                    cbox->setMaxVisibleItems(30);
                     auto *model        = cbox->model();
                     int   currentIndex = -1;
                     int   selected     = 0;
@@ -210,6 +213,7 @@ DeviceConfig::ConfigureDevice(const _device_ *device, int instance, Settings *se
                 {
                     auto *cbox = new QComboBox();
                     cbox->setObjectName(config->name);
+                    cbox->setMaxVisibleItems(30);
                     auto *model        = cbox->model();
                     int   currentIndex = -1;
                     char *selected;
@@ -269,6 +273,7 @@ DeviceConfig::ConfigureDevice(const _device_ *device, int instance, Settings *se
                 {
                     auto *cbox = new QComboBox();
                     cbox->setObjectName(config->name);
+                    cbox->setMaxVisibleItems(30);
                     auto *model         = cbox->model();
                     int   currentIndex  = 0;
                     auto  serialDevices = EnumerateSerialDevices();

--- a/src/qt/qt_harddiskdialog.ui
+++ b/src/qt/qt_harddiskdialog.ui
@@ -50,7 +50,11 @@
     </widget>
    </item>
    <item row="6" column="5">
-    <widget class="QComboBox" name="comboBoxSpeed"/>
+    <widget class="QComboBox" name="comboBoxSpeed">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
+    </widget>
    </item>
    <item row="3" column="4">
     <widget class="QLabel" name="label_5">
@@ -106,7 +110,11 @@
     </widget>
    </item>
    <item row="5" column="5">
-    <widget class="QComboBox" name="comboBoxChannel"/>
+    <widget class="QComboBox" name="comboBoxChannel">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
+    </widget>
    </item>
    <item row="11" column="0" colspan="6">
     <widget class="QDialogButtonBox" name="buttonBox">
@@ -172,7 +180,11 @@
     </widget>
    </item>
    <item row="4" column="3" colspan="3">
-    <widget class="QComboBox" name="comboBoxType"/>
+    <widget class="QComboBox" name="comboBoxType">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
+    </widget>
    </item>
    <item row="5" column="0">
     <widget class="QLabel" name="label_8">
@@ -182,10 +194,18 @@
     </widget>
    </item>
    <item row="6" column="1" colspan="3">
-    <widget class="QComboBox" name="comboBoxFormat"/>
+    <widget class="QComboBox" name="comboBoxFormat">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
+    </widget>
    </item>
    <item row="7" column="1" colspan="3">
-    <widget class="QComboBox" name="comboBoxBlockSize"/>
+    <widget class="QComboBox" name="comboBoxBlockSize">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
+    </widget>
    </item>
    <item row="3" column="3">
     <widget class="QLineEdit" name="lineEditHeads">
@@ -207,7 +227,11 @@
     </widget>
    </item>
    <item row="5" column="1" colspan="3">
-    <widget class="QComboBox" name="comboBoxBus"/>
+    <widget class="QComboBox" name="comboBoxBus">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
+    </widget>
    </item>
    <item row="7" column="0">
     <widget class="QLabel" name="labelBlockSize">

--- a/src/qt/qt_joystickconfiguration.cpp
+++ b/src/qt/qt_joystickconfiguration.cpp
@@ -106,6 +106,7 @@ JoystickConfiguration::on_comboBoxDevice_currentIndexChanged(int index)
         auto label = new QLabel(joystick_get_axis_name(type, c), this);
         auto cbox  = new QComboBox(this);
         cbox->setObjectName(QString("cboxAxis%1").arg(QString::number(c)));
+        cbox->setMaxVisibleItems(30);
         auto model = cbox->model();
 
         for (int d = 0; d < plat_joystick_state[joystick].nr_axes; d++) {
@@ -146,6 +147,7 @@ JoystickConfiguration::on_comboBoxDevice_currentIndexChanged(int index)
         auto label = new QLabel(joystick_get_button_name(type, c), this);
         auto cbox  = new QComboBox(this);
         cbox->setObjectName(QString("cboxButton%1").arg(QString::number(c)));
+        cbox->setMaxVisibleItems(30);
         auto model = cbox->model();
 
         for (int d = 0; d < plat_joystick_state[joystick].nr_buttons; d++) {
@@ -172,6 +174,7 @@ JoystickConfiguration::on_comboBoxDevice_currentIndexChanged(int index)
         }
         auto cbox = new QComboBox(this);
         cbox->setObjectName(QString("cboxPov%1").arg(QString::number(c)));
+        cbox->setMaxVisibleItems(30);
         auto model = cbox->model();
 
         for (int d = 0; d < plat_joystick_state[joystick].nr_povs; d++) {

--- a/src/qt/qt_joystickconfiguration.ui
+++ b/src/qt/qt_joystickconfiguration.ui
@@ -25,7 +25,11 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QComboBox" name="comboBoxDevice"/>
+    <widget class="QComboBox" name="comboBoxDevice">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
+    </widget>
    </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label_2">

--- a/src/qt/qt_newfloppydialog.ui
+++ b/src/qt/qt_newfloppydialog.ui
@@ -52,6 +52,9 @@
    </item>
    <item row="1" column="1">
     <widget class="QComboBox" name="comboBoxSize">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
@@ -69,6 +72,9 @@
    </item>
    <item row="2" column="1">
     <widget class="QComboBox" name="comboBoxRpm">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
        <horstretch>0</horstretch>

--- a/src/qt/qt_progsettings.ui
+++ b/src/qt/qt_progsettings.ui
@@ -34,6 +34,9 @@
      <property name="editable">
       <bool>false</bool>
      </property>
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
      <item>
       <property name="text">
        <string>(Default)</string>
@@ -109,6 +112,9 @@
    </item>
    <item row="4" column="0" colspan="2">
     <widget class="QComboBox" name="comboBoxLanguage">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
      <item>
       <property name="text">
        <string>(System Default)</string>

--- a/src/qt/qt_settingsdisplay.ui
+++ b/src/qt/qt_settingsdisplay.ui
@@ -61,6 +61,9 @@
    </item>
    <item row="1" column="0" colspan="2">
     <widget class="QComboBox" name="comboBoxVideo">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -119,6 +122,9 @@
    </item>
    <item row="3" column="0" colspan="2">
     <widget class="QComboBox" name="comboBoxVideoSecondary">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>

--- a/src/qt/qt_settingsfloppycdrom.ui
+++ b/src/qt/qt_settingsfloppycdrom.ui
@@ -62,7 +62,11 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="comboBoxFloppyType"/>
+      <widget class="QComboBox" name="comboBoxFloppyType">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QCheckBox" name="checkBoxTurboTimings">
@@ -150,16 +154,32 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QComboBox" name="comboBoxBus"/>
+      <widget class="QComboBox" name="comboBoxBus">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+      </widget>
      </item>
      <item row="0" column="3">
-      <widget class="QComboBox" name="comboBoxChannel"/>
+      <widget class="QComboBox" name="comboBoxChannel">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+      </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QComboBox" name="comboBoxSpeed"/>
+      <widget class="QComboBox" name="comboBoxSpeed">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+      </widget>
      </item>
      <item row="2" column="1" colspan="3">
-      <widget class="QComboBox" name="comboBoxCDROMType"/>
+      <widget class="QComboBox" name="comboBoxCDROMType">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/src/qt/qt_settingsharddisks.ui
+++ b/src/qt/qt_settingsharddisks.ui
@@ -55,7 +55,11 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="comboBoxBus"/>
+      <widget class="QComboBox" name="comboBoxBus">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QLabel" name="labelChannel">
@@ -65,7 +69,11 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="comboBoxChannel"/>
+      <widget class="QComboBox" name="comboBoxChannel">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QLabel" name="labelSpeed">
@@ -75,7 +83,11 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="comboBoxSpeed"/>
+      <widget class="QComboBox" name="comboBoxSpeed">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/src/qt/qt_settingsinput.ui
+++ b/src/qt/qt_settingsinput.ui
@@ -96,6 +96,9 @@
    </item>
    <item row="0" column="1" colspan="2">
     <widget class="QComboBox" name="comboBoxMouse">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -105,7 +108,11 @@
     </widget>
    </item>
    <item row="1" column="1" colspan="2">
-    <widget class="QComboBox" name="comboBoxJoystick"/>
+    <widget class="QComboBox" name="comboBoxJoystick">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/qt/qt_settingsmachine.ui
+++ b/src/qt/qt_settingsmachine.ui
@@ -49,7 +49,11 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QComboBox" name="comboBoxMachineType"/>
+       <widget class="QComboBox" name="comboBoxMachineType">
+        <property name="maxVisibleItems">
+         <number>30</number>
+        </property>
+       </widget>
       </item>
       <item row="5" column="0">
        <widget class="QLabel" name="label_6">
@@ -59,7 +63,11 @@
        </widget>
       </item>
       <item row="3" column="1">
-       <widget class="QComboBox" name="comboBoxFPU"/>
+       <widget class="QComboBox" name="comboBoxFPU">
+        <property name="maxVisibleItems">
+         <number>30</number>
+        </property>
+       </widget>
       </item>
       <item row="4" column="1">
        <widget class="QWidget" name="widget_4" native="true">
@@ -78,6 +86,9 @@
          </property>
          <item>
           <widget class="QComboBox" name="comboBoxWaitStates">
+           <property name="maxVisibleItems">
+            <number>30</number>
+           </property>
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -95,6 +106,9 @@
          </item>
          <item>
           <widget class="QComboBox" name="comboBoxPitMode">
+           <property name="maxVisibleItems">
+            <number>30</number>
+           </property>
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -130,6 +144,9 @@
          </property>
          <item>
           <widget class="QComboBox" name="comboBoxCPU">
+           <property name="maxVisibleItems">
+            <number>30</number>
+           </property>
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -150,6 +167,9 @@
          </item>
          <item>
           <widget class="QComboBox" name="comboBoxSpeed">
+           <property name="maxVisibleItems">
+            <number>30</number>
+           </property>
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -187,7 +207,11 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QComboBox" name="comboBoxMachine"/>
+          <widget class="QComboBox" name="comboBoxMachine">
+           <property name="maxVisibleItems">
+            <number>30</number>
+           </property>
+          </widget>
          </item>
          <item>
           <widget class="QPushButton" name="pushButtonConfigure">

--- a/src/qt/qt_settingsnetwork.ui
+++ b/src/qt/qt_settingsnetwork.ui
@@ -51,6 +51,9 @@
        </item>
        <item row="0" column="1" colspan="2">
         <widget class="QComboBox" name="comboBoxNet1">
+         <property name="maxVisibleItems">
+          <number>30</number>
+         </property>
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -74,6 +77,9 @@
        </item>
        <item row="1" column="1" colspan="2">
         <widget class="QComboBox" name="comboBoxIntf1">
+         <property name="maxVisibleItems">
+          <number>30</number>
+         </property>
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -97,6 +103,9 @@
        </item>
        <item row="2" column="1">
         <widget class="QComboBox" name="comboBoxNIC1">
+         <property name="maxVisibleItems">
+          <number>30</number>
+         </property>
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -170,6 +179,9 @@
        </item>
        <item row="0" column="1" colspan="2">
         <widget class="QComboBox" name="comboBoxNet2">
+         <property name="maxVisibleItems">
+          <number>30</number>
+         </property>
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -193,6 +205,9 @@
        </item>
        <item row="1" column="1" colspan="2">
         <widget class="QComboBox" name="comboBoxIntf2">
+         <property name="maxVisibleItems">
+          <number>30</number>
+         </property>
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -216,6 +231,9 @@
        </item>
        <item row="2" column="1">
         <widget class="QComboBox" name="comboBoxNIC2">
+         <property name="maxVisibleItems">
+          <number>30</number>
+         </property>
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -283,6 +301,9 @@
        </item>
        <item row="0" column="1" colspan="2">
         <widget class="QComboBox" name="comboBoxNet3">
+         <property name="maxVisibleItems">
+          <number>30</number>
+         </property>
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -306,6 +327,9 @@
        </item>
        <item row="1" column="1" colspan="2">
         <widget class="QComboBox" name="comboBoxIntf3">
+         <property name="maxVisibleItems">
+          <number>30</number>
+         </property>
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -329,6 +353,9 @@
        </item>
        <item row="2" column="1">
         <widget class="QComboBox" name="comboBoxNIC3">
+         <property name="maxVisibleItems">
+          <number>30</number>
+         </property>
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -402,6 +429,9 @@
        </item>
        <item row="0" column="1" colspan="2">
         <widget class="QComboBox" name="comboBoxNet4">
+         <property name="maxVisibleItems">
+          <number>30</number>
+         </property>
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -425,6 +455,9 @@
        </item>
        <item row="1" column="1" colspan="2">
         <widget class="QComboBox" name="comboBoxIntf4">
+         <property name="maxVisibleItems">
+          <number>30</number>
+         </property>
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -448,6 +481,9 @@
        </item>
        <item row="2" column="1">
         <widget class="QComboBox" name="comboBoxNIC4">
+         <property name="maxVisibleItems">
+          <number>30</number>
+         </property>
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>

--- a/src/qt/qt_settingsotherperipherals.ui
+++ b/src/qt/qt_settingsotherperipherals.ui
@@ -37,6 +37,9 @@
      </item>
      <item>
       <widget class="QComboBox" name="comboBoxRTC">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
        <property name="sizePolicy">
         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -68,7 +71,17 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QComboBox" name="comboBoxCard2"/>
+       <widget class="QComboBox" name="comboBoxCard2">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
       </item>
       <item row="2" column="2">
        <widget class="QPushButton" name="pushButtonConfigureCard3">
@@ -100,6 +113,9 @@
       </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="comboBoxCard1">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -116,10 +132,30 @@
        </widget>
       </item>
       <item row="2" column="1">
-       <widget class="QComboBox" name="comboBoxCard3"/>
+       <widget class="QComboBox" name="comboBoxCard3">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
       </item>
       <item row="3" column="1">
-       <widget class="QComboBox" name="comboBoxCard4"/>
+       <widget class="QComboBox" name="comboBoxCard4">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
       </item>
       <item row="3" column="2">
        <widget class="QPushButton" name="pushButtonConfigureCard4">

--- a/src/qt/qt_settingsotherremovable.ui
+++ b/src/qt/qt_settingsotherremovable.ui
@@ -69,10 +69,18 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QComboBox" name="comboBoxMOBus"/>
+      <widget class="QComboBox" name="comboBoxMOBus">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+      </widget>
      </item>
      <item row="0" column="3">
-      <widget class="QComboBox" name="comboBoxMOChannel"/>
+      <widget class="QComboBox" name="comboBoxMOChannel">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+      </widget>
      </item>
      <item row="1" column="0">
       <widget class="QLabel" name="label_4">
@@ -82,7 +90,11 @@
       </widget>
      </item>
      <item row="1" column="1" colspan="3">
-      <widget class="QComboBox" name="comboBoxMOType"/>
+      <widget class="QComboBox" name="comboBoxMOType">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
@@ -135,7 +147,11 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="comboBoxZIPBus"/>
+      <widget class="QComboBox" name="comboBoxZIPBus">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QLabel" name="label_5">
@@ -145,7 +161,11 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="comboBoxZIPChannel"/>
+      <widget class="QComboBox" name="comboBoxZIPChannel">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QCheckBox" name="checkBoxZIP250">

--- a/src/qt/qt_settingsports.ui
+++ b/src/qt/qt_settingsports.ui
@@ -36,7 +36,11 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QComboBox" name="comboBoxLpt1"/>
+      <widget class="QComboBox" name="comboBoxLpt1">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+      </widget>
      </item>
      <item row="1" column="0">
       <widget class="QLabel" name="label_2">
@@ -46,7 +50,11 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QComboBox" name="comboBoxLpt2"/>
+      <widget class="QComboBox" name="comboBoxLpt2">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+      </widget>
      </item>
      <item row="2" column="0">
       <widget class="QLabel" name="label_3">
@@ -56,7 +64,11 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QComboBox" name="comboBoxLpt3"/>
+      <widget class="QComboBox" name="comboBoxLpt3">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+      </widget>
      </item>
      <item row="3" column="0">
       <widget class="QLabel" name="label_4">
@@ -66,7 +78,11 @@
       </widget>
      </item>
      <item row="3" column="1">
-      <widget class="QComboBox" name="comboBoxLpt4"/>
+      <widget class="QComboBox" name="comboBoxLpt4">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/src/qt/qt_settingssound.ui
+++ b/src/qt/qt_settingssound.ui
@@ -94,6 +94,9 @@
 
    <item row="5" column="1">
     <widget class="QComboBox" name="comboBoxMidiIn">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -132,6 +135,9 @@
    </item>
    <item row="4" column="1">
     <widget class="QComboBox" name="comboBoxMidiOut">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -198,6 +204,9 @@
    </item>
    <item row="0" column="1">
     <widget class="QComboBox" name="comboBoxSoundCard1">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -208,6 +217,9 @@
    </item>
    <item row="1" column="1">
     <widget class="QComboBox" name="comboBoxSoundCard2">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -218,6 +230,9 @@
    </item>
    <item row="2" column="1">
     <widget class="QComboBox" name="comboBoxSoundCard3">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -228,6 +243,9 @@
    </item>
    <item row="3" column="1">
     <widget class="QComboBox" name="comboBoxSoundCard4">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
        <horstretch>0</horstretch>

--- a/src/qt/qt_settingsstoragecontrollers.ui
+++ b/src/qt/qt_settingsstoragecontrollers.ui
@@ -61,6 +61,9 @@
      </item>
      <item row="2" column="1">
       <widget class="QComboBox" name="comboBoxCDInterface">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
        <property name="visible">
         <bool>false</bool>
        </property>
@@ -78,6 +81,9 @@
      </item>
      <item row="0" column="1">
       <widget class="QComboBox" name="comboBoxHD">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -94,7 +100,11 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QComboBox" name="comboBoxFD"/>
+      <widget class="QComboBox" name="comboBoxFD">
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+      </widget>
      </item>
      <item row="3" column="0">
       <widget class="QCheckBox" name="checkBoxTertiaryIDE">
@@ -161,6 +171,9 @@
       </item>
       <item row="0" column="2">
        <widget class="QComboBox" name="comboBoxSCSI1">
+        <property name="maxVisibleItems">
+         <number>30</number>
+        </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -177,13 +190,43 @@
        </widget>
       </item>
       <item row="1" column="2">
-       <widget class="QComboBox" name="comboBoxSCSI2"/>
+       <widget class="QComboBox" name="comboBoxSCSI2">
+        <property name="maxVisibleItems">
+         <number>30</number>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
       </item>
       <item row="2" column="2">
-       <widget class="QComboBox" name="comboBoxSCSI3"/>
+       <widget class="QComboBox" name="comboBoxSCSI3">
+        <property name="maxVisibleItems">
+         <number>30</number>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
       </item>
       <item row="3" column="2">
-       <widget class="QComboBox" name="comboBoxSCSI4"/>
+       <widget class="QComboBox" name="comboBoxSCSI4">
+        <property name="maxVisibleItems">
+         <number>30</number>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
       </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label_3">


### PR DESCRIPTION
Summary
=======
Expand the number of items visible in expanded comboboxes to 30 from the default 10.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A
