### PR TITLE
qt: Temporarily hide the Mitsumi CD-ROM bus in dropdowns

### DIFF
--- a/src/qt/qt_harddrive_common.cpp
+++ b/src/qt/qt_harddrive_common.cpp
@@ -49,16 +49,24 @@ void
 Harddrives::populateRemovableBuses(QAbstractItemModel *model)
 {
     model->removeRows(0, model->rowCount());
+#if 0
     model->insertRows(0, 4);
+#else
+    model->insertRows(0, 3);
+#endif
     model->setData(model->index(0, 0), QObject::tr("Disabled"));
     model->setData(model->index(1, 0), QObject::tr("ATAPI"));
     model->setData(model->index(2, 0), QObject::tr("SCSI"));
+#if 0
     model->setData(model->index(3, 0), QObject::tr("Mitsumi"));
+#endif
 
     model->setData(model->index(0, 0), HDD_BUS_DISABLED, Qt::UserRole);
     model->setData(model->index(1, 0), HDD_BUS_ATAPI, Qt::UserRole);
     model->setData(model->index(2, 0), HDD_BUS_SCSI, Qt::UserRole);
+#if 0
     model->setData(model->index(3, 0), CDROM_BUS_MITSUMI, Qt::UserRole);
+#endif
 }
 
 void


### PR DESCRIPTION
Summary
=======
Temporarily hide the Mitsumi CD-ROM bus in the bus dropdown on the floppy/CD-ROM settings page for the 4.0 release

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A