### PR TITLE
Temporary disable of serial passthrough

### DIFF
--- a/src/qt/qt_settingsports.cpp
+++ b/src/qt/qt_settingsports.cpp
@@ -76,6 +76,16 @@ SettingsPorts::SettingsPorts(QWidget *parent)
     ui->pushButtonSerialPassThru3->setEnabled(serial_passthrough_enabled[2]);
     ui->checkBoxSerialPassThru4->setChecked(serial_passthrough_enabled[3]);
     ui->pushButtonSerialPassThru4->setEnabled(serial_passthrough_enabled[3]);
+
+    // Temporarily disabled
+    ui->checkBoxSerialPassThru1->setVisible(false);
+    ui->pushButtonSerialPassThru1->setVisible(false);
+    ui->checkBoxSerialPassThru2->setVisible(false);
+    ui->pushButtonSerialPassThru2->setVisible(false);
+    ui->checkBoxSerialPassThru3->setVisible(false);
+    ui->pushButtonSerialPassThru3->setVisible(false);
+    ui->checkBoxSerialPassThru4->setVisible(false);
+    ui->pushButtonSerialPassThru4->setVisible(false);
 }
 
 SettingsPorts::~SettingsPorts()


### PR DESCRIPTION
Summary
=======
Removes the passthrough options from the UI, temporarily.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A