### PR TITLE
Fix GDB stub builds due to undeclared symbol

### DIFF
--- a/src/gdbstub.c
+++ b/src/gdbstub.c
@@ -222,8 +222,10 @@ static char      target_xml[]   = /* QEMU gdb-xml/i386-32bit.xml with modificati
             "<reg name=\"fs\" bitsize=\"16\" type=\"int32\"/>"
             "<reg name=\"gs\" bitsize=\"16\" type=\"int32\"/>"
             ""
+#if 0
             "<reg name=\"fs_base\" bitsize=\"32\" type=\"int32\"/>"
             "<reg name=\"gs_base\" bitsize=\"32\" type=\"int32\"/>"
+#endif
             ""
             "<flags id=\"i386_cr0\" size=\"4\">"
                 "<field name=\"PG\" start=\"31\" end=\"31\"/>"
@@ -548,10 +550,12 @@ gdbstub_client_write_reg(int index, uint8_t *buf)
             flushmmucache();
             break;
 
+#if 0
         case GDB_REG_FS_BASE ... GDB_REG_GS_BASE:
             /* Do what qemu does and just load the base. */
             segment_regs[(index - 16) + (GDB_REG_FS - GDB_REG_CS)]->base = *((uint32_t *) buf);
             break;
+#endif
 
         case GDB_REG_CR0 ... GDB_REG_CR4:
             *cr_regs[index - GDB_REG_CR0] = *((uint32_t *) buf);


### PR DESCRIPTION
Summary
=======
This PR fixes a build issue that occurred while building with GDB stub support (`-DGDBSTUB=ON`) enabled, as can be seen in:
```text
$ cmake -DGDBSTUB=ON ..
...
$ make
...
/home/david/86Box/src/gdbstub.c: In function ‘gdbstub_client_write_reg’:
/home/david/86Box/src/gdbstub.c:551:14: error: ‘GDB_REG_FS_BASE’ undeclared (first use in this function); did you mean ‘GDB_REG_FSTAT’?
  551 |         case GDB_REG_FS_BASE ... GDB_REG_GS_BASE:
      |              ^~~~~~~~~~~~~~~
      |              GDB_REG_FSTAT

```

The issue was introduced in commit 565421a, which commented out the `GDB_REG_FS_BASE` and `GDB_REG_GS_BASE` registers, but did not remove the code snippets that referenced them in `gdbstub_client_write_reg()`. This PR comments out those code snippets as well.

Additionally, I've removed the `fs_base` and `gs_base` registers from the XML file, to ensure the correct numbering of the registers for the GDB.

---

**Note:** I have three other small patches for `gdbstub.c`, should I submit them in separate PRs or is one enough?

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========

