### PR TITLE
GDB stub small fixes: out-of-bounds and wrong packet reply in 'qfThreadInfo'

### DIFF
--- a/src/gdbstub.c
+++ b/src/gdbstub.c
@@ -631,10 +631,10 @@ gdbstub_client_respond(gdbstub_client_t *client)
     /* Send response packet. */
     client->response[client->response_pos] = '\0';
 #ifdef ENABLE_GDBSTUB_LOG
-    i                     = client->response[995]; /* pclog_ex buffer too small */
-    client->response[995] = '\0';
+    i                     = client->response[994]; /* pclog_ex buffer too small */
+    client->response[994] = '\0';
     gdbstub_log("GDB Stub: Sending response: %s\n", client->response);
-    client->response[995] = i;
+    client->response[994] = i;
 #endif
     send(client->socket, "$", 1, 0);
     send(client->socket, client->response, client->response_pos, 0);

--- a/src/gdbstub.c
+++ b/src/gdbstub.c
@@ -1100,7 +1100,7 @@ e00:
             } else if (!strcmp(client->response, "C")) {
                 FAST_RESPONSE("QC1");
             } else if (!strcmp(client->response, "fThreadInfo")) {
-                FAST_RESPONSE("m 1");
+                FAST_RESPONSE("m1");
             } else if (!strcmp(client->response, "sThreadInfo")) {
                 FAST_RESPONSE("l");
             } else if (!strcmp(client->response, "Rcmd")) {


### PR DESCRIPTION
Summary
=======
This PR brings two small fixes that prevents from using GDB stub normally:

1. Fixes an out-of-bounds issue when the `ENABLE_GDBSTUB_LOG` flag is set.

2. Remove an additional space in the response of the 'qfThreadInfo' package that prevents GDB from recognizing the current thread.

With these fixes, GDB now works like a charm here.

(There is a more detailed explanation of each fix in the commit messages)

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://sourceware.org/gdb/onlinedocs/gdb/General-Query-Packets.html
