### PR TITLE
Add new 4.0 dependencies to RPM spec file

### DIFF
--- a/src/unix/assets/86Box.spec
+++ b/src/unix/assets/86Box.spec
@@ -12,7 +12,7 @@
 # After a successful build, you can install the RPMs as follows:
 #  sudo dnf install RPMS/$(uname -m)/86Box-3* RPMS/noarch/86Box-roms*
 
-%global romver 3.11
+%global romver 4.0
 
 Name:		86Box
 Version:	4.0
@@ -27,11 +27,14 @@ Source1:	https://github.com/86Box/roms/archive/refs/tags/v%{romver}.zip
 BuildRequires: cmake
 BuildRequires: desktop-file-utils
 BuildRequires: extra-cmake-modules
+BuildRequires: fluidsynth-devel
 BuildRequires: freetype-devel
 BuildRequires: gcc-c++
 BuildRequires: libFAudio-devel
 BuildRequires: libappstream-glib
+BuildRequires: libatomic
 BuildRequires: libevdev-devel
+BuildRequires: libslirp-devel
 BuildRequires: libxkbcommon-x11-devel
 BuildRequires: libXi-devel
 BuildRequires: ninja-build
@@ -118,5 +121,5 @@ popd
 %{_datadir}/%{name}/roms
 
 %changelog
-* Tue Feb 28 2023 Robert de Rooy <robert.de.rooy[AT]gmail.com> 4.0-1
+* Sat Aug 26 2023 Robert de Rooy <robert.de.rooy[AT]gmail.com> 4.0-1
 - Bump release


### PR DESCRIPTION
Summary
=======
86Box 4.0 has additional dependencies which were missing from the RPM spec file

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

