### PR TITLE
Allow connection to a VDE switch run by the same user

### DIFF
--- a/src/network/net_vde.c
+++ b/src/network/net_vde.c
@@ -274,7 +274,7 @@ void *net_vde_init(const netcard_t *card, const uint8_t *mac_addr, void *priv, c
 
     vde_args.group = 0;
     vde_args.port  = 0;
-    vde_args.mode  = 0;
+    vde_args.mode  = 0700;  // Allow the switch to connect back to our socket if it is run by the same user
 
     // We are calling vde_open_real(), not the vde_open() macro...
     if ((vde->vdeconn = f_vde_open(socket_name, VDE_DESCRIPTION, 


### PR DESCRIPTION
Summary
=======
Allow connection to a VDE switch run by the same user because `libvdeplug` will only change the mode if the switch is run by another user that isn't root.
If the switch is run by the same user as 86Box the socket will be chmoded to 000 and the switch, unable to connect back, will drop the connection.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://github.com/rd235/vdeplug4/blob/187256c528137036cc4e3228728b3f70a3342fa5/libvdeplug4/libvdeplug_vde.c#L261-L275
