### PR TITLE
fix flags for serial passthrough on unix

### DIFF
--- a/src/unix/unix_serial_passthrough.c
+++ b/src/unix/unix_serial_passthrough.c
@@ -182,7 +182,6 @@ plat_serpt_set_params(void *priv)
                 term_attr.c_cflag |= CMSPAR;
 #endif
         }
-        printf("c_cflag=%08x\n", term_attr.c_cflag);
         tcsetattr(dev->master_fd, TCSANOW, &term_attr);
 #undef BAUDRATE_RANGE
     }

--- a/src/unix/unix_serial_passthrough.c
+++ b/src/unix/unix_serial_passthrough.c
@@ -149,7 +149,7 @@ plat_serpt_set_params(void *priv)
         BAUDRATE_RANGE(dev->baudrate, 57600, 115200, B57600);
         BAUDRATE_RANGE(dev->baudrate, 115200, 0xFFFFFFFF, B115200);
 
-        term_attr.c_cflag &= CSIZE;
+        term_attr.c_cflag &= ~CSIZE;
         switch (dev->data_bits) {
             case 8:
             default:
@@ -165,13 +165,13 @@ plat_serpt_set_params(void *priv)
                 term_attr.c_cflag |= CS5;
                 break;
         }
-        term_attr.c_cflag &= CSTOPB;
+        term_attr.c_cflag &= ~CSTOPB;
         if (dev->serial->lcr & 0x04)
             term_attr.c_cflag |= CSTOPB;
 #if !defined(__linux__)
-        term_attr.c_cflag &= PARENB | PARODD;
+        term_attr.c_cflag &= ~(PARENB | PARODD);
 #else
-        term_attr.c_cflag &= PARENB | PARODD | CMSPAR;
+        term_attr.c_cflag &= ~(PARENB | PARODD | CMSPAR);
 #endif
         if (dev->serial->lcr & 0x08) {
             term_attr.c_cflag |= PARENB;
@@ -182,6 +182,7 @@ plat_serpt_set_params(void *priv)
                 term_attr.c_cflag |= CMSPAR;
 #endif
         }
+        printf("c_cflag=%08x\n", term_attr.c_cflag);
         tcsetattr(dev->master_fd, TCSANOW, &term_attr);
 #undef BAUDRATE_RANGE
     }


### PR DESCRIPTION
Summary
=======
The logic for clearing bits in termios.c_flag was reversed. That caused clearing of all the other flags than which were intended to be cleared, which in turn caused the host serial port to be stuck at random and unusable configuration (5 data bits on macOS).

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
