### PR TITLE
Disable the softfloat checkbox when no FPU is selected

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -510,6 +510,7 @@ load_machine(void)
 
     cpu_use_dynarec = !!ini_section_get_int(cat, "cpu_use_dynarec", 0);
     fpu_softfloat = !!ini_section_get_int(cat, "fpu_softfloat", 0);
+    if ((fpu_type != FPU_NONE) && machine_has_flags(machine, MACHINE_SOFTFLOAT_ONLY))
     if (machine_has_flags(machine, MACHINE_SOFTFLOAT_ONLY))
         fpu_softfloat = 1;
 

--- a/src/qt/qt_settingsmachine.cpp
+++ b/src/qt/qt_settingsmachine.cpp
@@ -288,7 +288,6 @@ SettingsMachine::on_comboBoxSpeed_currentIndexChanged(int index)
 #endif
 
         // win_settings_machine_recalc_fpu
-        int   machineId  = ui->comboBoxMachine->currentData().toInt();
         auto *modelFpu   = ui->comboBoxFPU->model();
         int   removeRows = modelFpu->rowCount();
 
@@ -306,11 +305,27 @@ SettingsMachine::on_comboBoxSpeed_currentIndexChanged(int index)
         ui->comboBoxFPU->setEnabled(modelFpu->rowCount() > 1);
         ui->comboBoxFPU->setCurrentIndex(-1);
         ui->comboBoxFPU->setCurrentIndex(selectedFpuRow);
+    }
+}
 
-        ui->checkBoxFPUSoftfloat->setChecked(machine_has_flags(machineId, MACHINE_SOFTFLOAT_ONLY) ?
-                                             true : fpu_softfloat);
-        ui->checkBoxFPUSoftfloat->setEnabled(machine_has_flags(machineId, MACHINE_SOFTFLOAT_ONLY) ?
-                                             false : true);
+void
+SettingsMachine::on_comboBoxFPU_currentIndexChanged(int index)
+{
+    if (index >= 0) {
+        int         cpuFamilyId = ui->comboBoxCPU->currentData().toInt();
+        const auto *cpuFamily   = &cpu_families[cpuFamilyId];
+        int         cpuId       = ui->comboBoxSpeed->currentData().toInt();
+        int         machineId   = ui->comboBoxMachine->currentData().toInt();
+
+        if (fpu_get_type_from_index(cpuFamily, cpuId, index) == FPU_NONE) {
+            ui->checkBoxFPUSoftfloat->setChecked(false);
+            ui->checkBoxFPUSoftfloat->setEnabled(false);
+        } else {
+            ui->checkBoxFPUSoftfloat->setChecked(machine_has_flags(machineId, MACHINE_SOFTFLOAT_ONLY) ?
+                                                 true : fpu_softfloat);
+            ui->checkBoxFPUSoftfloat->setEnabled(machine_has_flags(machineId, MACHINE_SOFTFLOAT_ONLY) ?
+                                                 false : true);
+        }
     }
 }
 

--- a/src/qt/qt_settingsmachine.hpp
+++ b/src/qt/qt_settingsmachine.hpp
@@ -22,6 +22,9 @@ private slots:
     void on_pushButtonConfigure_clicked();
 
 private slots:
+    void on_comboBoxFPU_currentIndexChanged(int index);
+
+private slots:
     void on_comboBoxSpeed_currentIndexChanged(int index);
 
 private slots:

--- a/src/win/win_settings.c
+++ b/src/win/win_settings.c
@@ -689,6 +689,18 @@ win_settings_save(void)
 }
 
 static void
+win_settings_machine_recalc_softfloat(HWND hdlg)
+{
+    if (temp_fpu == FPU_NONE) {
+        settings_set_check(hdlg, IDC_CHECK_SOFTFLOAT, FALSE);
+        settings_enable_window(hdlg, IDC_CHECK_SOFTFLOAT, FALSE);
+    } else {
+        settings_set_check(hdlg, IDC_CHECK_SOFTFLOAT, (machine_has_flags(temp_machine, MACHINE_SOFTFLOAT_ONLY) ? TRUE : temp_fpu_softfloat));
+        settings_enable_window(hdlg, IDC_CHECK_SOFTFLOAT, (machine_has_flags(temp_machine, MACHINE_SOFTFLOAT_ONLY) ? FALSE : TRUE));
+    }
+}
+
+static void
 win_settings_machine_recalc_fpu(HWND hdlg)
 {
     int         c;
@@ -714,12 +726,11 @@ win_settings_machine_recalc_fpu(HWND hdlg)
         c++;
     }
 
-    settings_set_check(hdlg, IDC_CHECK_SOFTFLOAT, (machine_has_flags(temp_machine, MACHINE_SOFTFLOAT_ONLY) ? TRUE : temp_fpu_softfloat));
-    settings_enable_window(hdlg, IDC_CHECK_SOFTFLOAT, (machine_has_flags(temp_machine, MACHINE_SOFTFLOAT_ONLY) ? FALSE : TRUE));
-
     settings_enable_window(hdlg, IDC_COMBO_FPU, c > 1);
 
     temp_fpu = fpu_get_type_from_index(temp_cpu_f, temp_cpu, settings_get_cur_sel(hdlg, IDC_COMBO_FPU));
+
+    win_settings_machine_recalc_softfloat(hdlg);
 }
 
 static void
@@ -1046,6 +1057,7 @@ win_settings_machine_proc(HWND hdlg, UINT message, WPARAM wParam, UNUSED(LPARAM 
                         temp_fpu = fpu_get_type_from_index(temp_cpu_f, temp_cpu,
                                                            settings_get_cur_sel(hdlg, IDC_COMBO_FPU));
                     }
+                    win_settings_machine_recalc_softfloat(hdlg);
                     break;
                 case IDC_CONFIGURE_MACHINE:
                     temp_machine = listtomachine[settings_get_cur_sel(hdlg, IDC_COMBO_MACHINE)];


### PR DESCRIPTION
Summary
=======
Disable the SoftFloat FPU option if no FPU (including internal) is present

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
N/A
