### PR TITLE
Assorted fixes

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -3067,7 +3067,7 @@ const machine_t machines[] = {
             .max_multi = 0
         },
         .bus_flags = MACHINE_AT,
-        .flags = MACHINE_FLAGS_NONE,
+        .flags = MACHINE_SOFTFLOAT_ONLY,
         .ram = {
             .min = 512,
             .max = 16384,

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -333,6 +333,8 @@ MainWindow::MainWindow(QWidget *parent)
 
 #ifndef DISCORD
     ui->actionEnable_Discord_integration->setVisible(false);
+#else
+    ui->actionEnable_Discord_integration->setEnabled(discord_loaded);
 #endif
 
 #if defined Q_OS_WINDOWS || defined Q_OS_MACOS


### PR DESCRIPTION
Summary
=======
1. Disable the "Enable Discord integration" menu item if the Discord library fails to load
2. Mark the Quadtel 286 clone as requiring SoftFloat FPU to make the "80287 internal register error" go away
3. Dev branch only: Fix the GUS MAX's CS4231 codec using the incorrect DMA channel for playback; add support for the correct (GF1's record) channel

Checklist
=========
* [x] Closes #2274
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
For item 3: [UltraSound Lowlevel ToolKit, Revision 2.22](http://dk.toastednet.org/GUS/docs/UltraSound%20Lowlevel%20ToolKit%20v2.22%20(21%20December%201994).pdf), page 123 (129) - "Note that the DMA channels appear flipped between the GF1 and the codec. This is to allow us to DMA to dram to load patches while the codec is busy playing back .WAV data."
