### PR TITLE
GHA changes

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -458,10 +458,12 @@ jobs:
           sonar-scanner --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
 
       - name: Generate package
+        if: 0
         run: |
           cmake --install build
 
       - name: Upload artifact
+        if: 0
         uses: actions/upload-artifact@v3
         with:
           name: '86Box${{ matrix.ui.slug }}${{ matrix.dynarec.slug }}${{ matrix.build.slug }}-macOS-x86_64-gha${{ github.run_number }}'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -62,11 +62,12 @@ jobs:
             static: on
           - name: Qt GUI
             qt: on
-            static: off
+            static: on
             slug: -Qt
             packages: >-
-              qt5-base:p
-              qt5-tools:p
+              qt5-static:p
+#              qt5-base:p
+#              qt5-tools:p
         environment:
 #          - msystem: MSYS
 #            toolchain: ./cmake/flags-gcc-x86_64.cmake


### PR DESCRIPTION
Summary
=======
Make the windows QT packages static and avoid bundling needless libraries.
Disable the macos artifact creation for now as it's broken and I don't know the right solution. (Avoid needless build failure reports)

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
