### PR TITLE
qt: Add a warning when cpu_override is enabled

### DIFF
--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -28,6 +28,8 @@
 #include <QLibraryInfo>
 #include <QString>
 #include <QFont>
+#include <QDialog>
+#include <QMessageBox>
 
 #ifdef QT_STATIC
 /* Static builds need plugin imports */
@@ -274,6 +276,21 @@ main(int argc, char *argv[])
         main_window->installEventFilter(&socket);
         socket.connectToServer(qgetenv("86BOX_MANAGER_SOCKET"));
     }
+
+    /* Warn the user about unsupported configs */
+    if (cpu_override) {
+        QMessageBox warningbox(QMessageBox::Icon::Warning, QObject::tr("You are loading an unsupported configuration"),
+                               QObject::tr("CPU type filtering based on selected machine is disabled for this emulated machine.\n\nThis makes it possible to choose a CPU that is otherwise incompatible with the selected machine. However, you may run into incompatibilities with the machine BIOS or other software.\n\nEnabling this setting is not officially supported and any bug reports filed may be closed as invalid."),
+                               QMessageBox::NoButton, main_window);
+        warningbox.addButton(QObject::tr("Continue"), QMessageBox::AcceptRole);
+        warningbox.addButton(QObject::tr("Exit"), QMessageBox::RejectRole);
+        warningbox.exec();
+        if (warningbox.result() == QDialog::Accepted) {
+              confirm_exit_cmdl = 0; /* skip the confirmation prompt without touching the config */
+              emit main_window->close();
+        }
+    }
+
     // pc_reset_hard_init();
 
     /* Set the PAUSE mode depending on the renderer. */

--- a/src/qt/qt_settingsmachine.cpp
+++ b/src/qt/qt_settingsmachine.cpp
@@ -278,7 +278,7 @@ SettingsMachine::on_comboBoxSpeed_currentIndexChanged(int index)
         if (!(flags & CPU_SUPPORTS_DYNAREC)) {
             ui->checkBoxDynamicRecompiler->setChecked(false);
             ui->checkBoxDynamicRecompiler->setEnabled(false);
-        } else if (flags & CPU_REQUIRES_DYNAREC) {
+        } else if ((flags & CPU_REQUIRES_DYNAREC) && !cpu_override) {
             ui->checkBoxDynamicRecompiler->setChecked(true);
             ui->checkBoxDynamicRecompiler->setEnabled(false);
         } else {

--- a/src/win/win_settings.c
+++ b/src/win/win_settings.c
@@ -748,7 +748,7 @@ win_settings_machine_recalc_cpu(HWND hdlg)
     cpu_flags = temp_cpu_f->cpus[temp_cpu].cpu_flags;
     if (!(cpu_flags & CPU_SUPPORTS_DYNAREC) && (cpu_flags & CPU_REQUIRES_DYNAREC))
         fatal("Attempting to select a CPU that requires the recompiler and does not support it at the same time\n");
-    if (!(cpu_flags & CPU_SUPPORTS_DYNAREC) || (cpu_flags & CPU_REQUIRES_DYNAREC)) {
+    if (!(cpu_flags & CPU_SUPPORTS_DYNAREC) || ((cpu_flags & CPU_REQUIRES_DYNAREC) && !cpu_override))) {
         if (!(cpu_flags & CPU_SUPPORTS_DYNAREC))
             temp_dynarec = 0;
         if (cpu_flags & CPU_REQUIRES_DYNAREC)


### PR DESCRIPTION
Summary
=======
Reintroduce a warning message on startup when cpu_override is enabled that was present in the Win32 UI. Also allow dynarec to be disabled on dynarec-only CPUs (falling back to interpeter) in the UI when cpu_override is on.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A