### PR TITLE
GHA: Enable mac builds, homebrew fixes

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -417,7 +417,7 @@ jobs:
     steps:
       - name: Install source dependencies
         run: >-
-          brew install -s
+          brew reinstall -s
           ${{ matrix.ui.src-packages }}
 
       - name: Install dependencies

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -411,8 +411,15 @@ jobs:
             slug: -Qt
             packages: >-
               qt@5
+            src-packages: >-
+              libsndfile
 
     steps:
+      - name: Install source dependencies
+        run: >-
+          brew install -s
+          ${{ matrix.ui.src-packages }}
+
       - name: Install dependencies
         run: >-
           brew install
@@ -458,12 +465,10 @@ jobs:
           sonar-scanner --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
 
       - name: Generate package
-        if: 0
         run: |
           cmake --install build
 
       - name: Upload artifact
-        if: 0
         uses: actions/upload-artifact@v3
         with:
           name: '86Box${{ matrix.ui.slug }}${{ matrix.dynarec.slug }}${{ matrix.build.slug }}-macOS-x86_64-gha${{ github.run_number }}'


### PR DESCRIPTION
Summary
=======
Fix a homebrew issue with `libsndfile` and enable the build again in GHA.

There's a library / packaging issue with the `libsndfile` bottle in homebrew which causes the bundling to fail. Until that issue is addressed we need to have GHA build `libsndfile` from source.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
