### PR TITLE
More video fixes:

### DIFF
--- a/src/video/vid_ati_mach64.c
+++ b/src/video/vid_ati_mach64.c
@@ -420,7 +420,7 @@ mach64_out(uint16_t addr, uint8_t val, void *priv)
         case 0x3C8:
         case 0x3C9:
             if (mach64->type == MACH64_GX)
-                ati68860_ramdac_out((addr & 3) | ((mach64->dac_cntl & 3) << 2), val, mach64->svga.ramdac, svga);
+                ati68860_ramdac_out((addr & 3) | ((mach64->dac_cntl & 3) << 2), val, svga->ramdac, svga);
             else
                 svga_out(addr, val, svga);
             return;
@@ -487,7 +487,7 @@ mach64_in(uint16_t addr, void *priv)
         case 0x3C8:
         case 0x3C9:
             if (mach64->type == MACH64_GX)
-                return ati68860_ramdac_in((addr & 3) | ((mach64->dac_cntl & 3) << 2), mach64->svga.ramdac, svga);
+                return ati68860_ramdac_in((addr & 3) | ((mach64->dac_cntl & 3) << 2), svga->ramdac, svga);
             return svga_in(addr, svga);
 
         case 0x3D4:
@@ -654,6 +654,7 @@ mach64_update_irqs(mach64_t *mach64)
         pci_clear_irq(mach64->pci_slot, PCI_INTA, &mach64->irq_state);
 }
 
+#if 0
 static __inline void
 wake_fifo_thread(mach64_t *mach64)
 {
@@ -668,6 +669,7 @@ mach64_wait_fifo_idle(mach64_t *mach64)
         thread_wait_event(mach64->fifo_not_full_event, 1);
     }
 }
+#endif
 
 #define READ8(addr, var)                \
     switch ((addr) &3) {                \
@@ -1167,6 +1169,7 @@ mach64_accel_write_fifo_l(mach64_t *mach64, uint32_t addr, uint32_t val)
     }
 }
 
+#if 0
 static void
 fifo_thread(void *param)
 {
@@ -1230,6 +1233,7 @@ mach64_queue(mach64_t *mach64, uint32_t addr, uint32_t val, uint32_t type)
     if (FIFO_ENTRIES > 0xe000 || FIFO_ENTRIES < 8)
         wake_fifo_thread(mach64);
 }
+#endif
 
 void
 mach64_start_fill(mach64_t *mach64)
@@ -2517,26 +2521,26 @@ mach64_ext_readb(uint32_t addr, void *priv)
             case 0x101:
             case 0x102:
             case 0x103:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->dst_off_pitch);
                 break;
             case 0x104:
             case 0x105:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->dst_y_x);
                 break;
             case 0x108:
             case 0x109:
             case 0x11c:
             case 0x11d:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr + 2, mach64->dst_y_x);
                 break;
             case 0x10c:
             case 0x10d:
             case 0x10e:
             case 0x10f:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->dst_y_x);
                 break;
             case 0x110:
@@ -2551,7 +2555,7 @@ mach64_ext_readb(uint32_t addr, void *priv)
             case 0x11b:
             case 0x11e:
             case 0x11f:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->dst_height_width);
                 break;
 
@@ -2559,28 +2563,28 @@ mach64_ext_readb(uint32_t addr, void *priv)
             case 0x121:
             case 0x122:
             case 0x123:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->dst_bres_lnth);
                 break;
             case 0x124:
             case 0x125:
             case 0x126:
             case 0x127:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->dst_bres_err);
                 break;
             case 0x128:
             case 0x129:
             case 0x12a:
             case 0x12b:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->dst_bres_inc);
                 break;
             case 0x12c:
             case 0x12d:
             case 0x12e:
             case 0x12f:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->dst_bres_dec);
                 break;
 
@@ -2588,7 +2592,7 @@ mach64_ext_readb(uint32_t addr, void *priv)
             case 0x131:
             case 0x132:
             case 0x133:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->dst_cntl);
                 break;
 
@@ -2596,75 +2600,75 @@ mach64_ext_readb(uint32_t addr, void *priv)
             case 0x181:
             case 0x182:
             case 0x183:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->src_off_pitch);
                 break;
             case 0x184:
             case 0x185:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->src_y_x);
                 break;
             case 0x188:
             case 0x189:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr + 2, mach64->src_y_x);
                 break;
             case 0x18c:
             case 0x18d:
             case 0x18e:
             case 0x18f:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->src_y_x);
                 break;
             case 0x190:
             case 0x191:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr + 2, mach64->src_height1_width1);
                 break;
             case 0x194:
             case 0x195:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->src_height1_width1);
                 break;
             case 0x198:
             case 0x199:
             case 0x19a:
             case 0x19b:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->src_height1_width1);
                 break;
             case 0x19c:
             case 0x19d:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->src_y_x_start);
                 break;
             case 0x1a0:
             case 0x1a1:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr + 2, mach64->src_y_x_start);
                 break;
             case 0x1a4:
             case 0x1a5:
             case 0x1a6:
             case 0x1a7:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->src_y_x_start);
                 break;
             case 0x1a8:
             case 0x1a9:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr + 2, mach64->src_height2_width2);
                 break;
             case 0x1ac:
             case 0x1ad:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->src_height2_width2);
                 break;
             case 0x1b0:
             case 0x1b1:
             case 0x1b2:
             case 0x1b3:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->src_height2_width2);
                 break;
 
@@ -2672,7 +2676,7 @@ mach64_ext_readb(uint32_t addr, void *priv)
             case 0x1b5:
             case 0x1b6:
             case 0x1b7:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->src_cntl);
                 break;
 
@@ -2680,7 +2684,7 @@ mach64_ext_readb(uint32_t addr, void *priv)
             case 0x241:
             case 0x242:
             case 0x243:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->host_cntl);
                 break;
 
@@ -2688,14 +2692,14 @@ mach64_ext_readb(uint32_t addr, void *priv)
             case 0x281:
             case 0x282:
             case 0x283:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->pat_reg0);
                 break;
             case 0x284:
             case 0x285:
             case 0x286:
             case 0x287:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->pat_reg1);
                 break;
 
@@ -2703,7 +2707,7 @@ mach64_ext_readb(uint32_t addr, void *priv)
             case 0x289:
             case 0x28a:
             case 0x28b:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->pat_cntl);
                 break;
 
@@ -2711,7 +2715,7 @@ mach64_ext_readb(uint32_t addr, void *priv)
             case 0x2a1:
             case 0x2a8:
             case 0x2a9:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->sc_left_right);
                 break;
             case 0x2a4:
@@ -2720,7 +2724,7 @@ mach64_ext_readb(uint32_t addr, void *priv)
                 fallthrough;
             case 0x2aa:
             case 0x2ab:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->sc_left_right);
                 break;
 
@@ -2728,7 +2732,7 @@ mach64_ext_readb(uint32_t addr, void *priv)
             case 0x2ad:
             case 0x2b4:
             case 0x2b5:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->sc_top_bottom);
                 break;
             case 0x2b0:
@@ -2737,7 +2741,7 @@ mach64_ext_readb(uint32_t addr, void *priv)
                 fallthrough;
             case 0x2b6:
             case 0x2b7:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->sc_top_bottom);
                 break;
 
@@ -2745,14 +2749,14 @@ mach64_ext_readb(uint32_t addr, void *priv)
             case 0x2c1:
             case 0x2c2:
             case 0x2c3:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->dp_bkgd_clr);
                 break;
             case 0x2c4:
             case 0x2c5:
             case 0x2c6:
             case 0x2c7:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->dp_frgd_clr);
                 break;
 
@@ -2760,7 +2764,7 @@ mach64_ext_readb(uint32_t addr, void *priv)
             case 0x2c9:
             case 0x2ca:
             case 0x2cb:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->write_mask);
                 break;
 
@@ -2768,7 +2772,7 @@ mach64_ext_readb(uint32_t addr, void *priv)
             case 0x2cd:
             case 0x2ce:
             case 0x2cf:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->chain_mask);
                 break;
 
@@ -2776,21 +2780,21 @@ mach64_ext_readb(uint32_t addr, void *priv)
             case 0x2d1:
             case 0x2d2:
             case 0x2d3:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->dp_pix_width);
                 break;
             case 0x2d4:
             case 0x2d5:
             case 0x2d6:
             case 0x2d7:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->dp_mix);
                 break;
             case 0x2d8:
             case 0x2d9:
             case 0x2da:
             case 0x2db:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->dp_src);
                 break;
 
@@ -2798,64 +2802,53 @@ mach64_ext_readb(uint32_t addr, void *priv)
             case 0x301:
             case 0x302:
             case 0x303:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->clr_cmp_clr);
                 break;
             case 0x304:
             case 0x305:
             case 0x306:
             case 0x307:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->clr_cmp_mask);
                 break;
             case 0x308:
             case 0x309:
             case 0x30a:
             case 0x30b:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->clr_cmp_cntl);
                 break;
 
             case 0x310:
             case 0x311:
-                if (((mach64->crtc_gen_cntl >> 8) & 7) == BPP_24) {
-                    ret = 0;
-                } else {
-                    if (!FIFO_EMPTY)
-                        wake_fifo_thread(mach64);
-                    ret = 0;
-                    if (FIFO_FULL)
-                        ret = 0xff;
-                }
+                ret = 0;
                 break;
 
             case 0x320:
             case 0x321:
             case 0x322:
             case 0x323:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->context_mask);
                 break;
 
             case 0x330:
             case 0x331:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr, mach64->dst_cntl);
                 break;
             case 0x332:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr - 2, mach64->src_cntl);
                 break;
             case 0x333:
-                mach64_wait_fifo_idle(mach64);
+                //mach64_wait_fifo_idle(mach64);
                 READ8(addr - 3, mach64->pat_cntl);
                 break;
 
             case 0x338:
-                if (((mach64->crtc_gen_cntl >> 8) & 7) == BPP_24)
-                    ret = 0;
-                else
-                    ret = FIFO_EMPTY ? 0 : 1;
+                ret = 0;
                 break;
 
             default:
@@ -3039,10 +3032,7 @@ mach64_ext_writeb(uint32_t addr, uint8_t val, void *priv)
 
         mach64_log("nmach64_ext_writeb: addr=%04x val=%02x\n", addr, val);
     } else if (addr & 0x300) {
-        if (((mach64->crtc_gen_cntl >> 8) & 7) == BPP_24)
-            mach64_accel_write_fifo(mach64, addr & 0x3ff, val);
-        else
-            mach64_queue(mach64, addr & 0x3ff, val, FIFO_WRITE_BYTE);
+        mach64_accel_write_fifo(mach64, addr & 0x3ff, val);
     } else
         switch (addr & 0x3ff) {
             case 0x00:
@@ -3051,6 +3041,7 @@ mach64_ext_writeb(uint32_t addr, uint8_t val, void *priv)
             case 0x03:
                 WRITE8(addr, mach64->crtc_h_total_disp, val);
                 svga_recalctimings(&mach64->svga);
+                svga->fullchange = svga->monitor->mon_changeframecount;
                 break;
             case 0x08:
             case 0x09:
@@ -3058,6 +3049,7 @@ mach64_ext_writeb(uint32_t addr, uint8_t val, void *priv)
             case 0x0b:
                 WRITE8(addr, mach64->crtc_v_total_disp, val);
                 svga_recalctimings(&mach64->svga);
+                svga->fullchange = svga->monitor->mon_changeframecount;
                 break;
             case 0x0c:
             case 0x0d:
@@ -3065,6 +3057,7 @@ mach64_ext_writeb(uint32_t addr, uint8_t val, void *priv)
             case 0x0f:
                 WRITE8(addr, mach64->crtc_v_sync_strt_wid, val);
                 svga_recalctimings(&mach64->svga);
+                svga->fullchange = svga->monitor->mon_changeframecount;
                 break;
 
             case 0x14:
@@ -3094,6 +3087,7 @@ mach64_ext_writeb(uint32_t addr, uint8_t val, void *priv)
                     svga->fb_only = 0;
                 svga->dpms = !!(mach64->crtc_gen_cntl & 0x0c);
                 svga_recalctimings(&mach64->svga);
+                svga->fullchange = svga->monitor->mon_changeframecount;
                 break;
 
             case 0x40:
@@ -3268,10 +3262,7 @@ mach64_ext_writew(uint32_t addr, uint16_t val, void *priv)
         mach64_ext_writeb(addr, val, priv);
         mach64_ext_writeb(addr + 1, val >> 8, priv);
     } else if (addr & 0x300) {
-        if (((mach64->crtc_gen_cntl >> 8) & 7) == BPP_24)
-            mach64_accel_write_fifo_w(mach64, addr & 0x3fe, val);
-        else
-            mach64_queue(mach64, addr & 0x3fe, val, FIFO_WRITE_WORD);
+        mach64_accel_write_fifo_w(mach64, addr & 0x3fe, val);
     } else
         switch (addr & 0x3fe) {
             default:
@@ -3292,10 +3283,7 @@ mach64_ext_writel(uint32_t addr, uint32_t val, void *priv)
         mach64_ext_writew(addr, val, priv);
         mach64_ext_writew(addr + 2, val >> 16, priv);
     } else if (addr & 0x300) {
-        if (((mach64->crtc_gen_cntl >> 8) & 7) == BPP_24)
-            mach64_accel_write_fifo_l(mach64, addr & 0x3fc, val);
-        else
-            mach64_queue(mach64, addr & 0x3fc, val, FIFO_WRITE_DWORD);
+        mach64_accel_write_fifo_l(mach64, addr & 0x3fc, val);
     } else
         switch (addr & 0x3fc) {
             default:
@@ -4382,20 +4370,23 @@ mach64_pci_write(UNUSED(int func), int addr, uint8_t val, void *priv)
 static void *
 mach64_common_init(const device_t *info)
 {
+    svga_t   *svga;
     mach64_t *mach64 = malloc(sizeof(mach64_t));
     memset(mach64, 0, sizeof(mach64_t));
+
+    svga = &mach64->svga;
 
     mach64->vram_size = device_get_config_int("memory");
     mach64->vram_mask = (mach64->vram_size << 20) - 1;
 
-    svga_init(info, &mach64->svga, mach64, mach64->vram_size << 20,
+    svga_init(info, svga, mach64, mach64->vram_size << 20,
               mach64_recalctimings,
               mach64_in, mach64_out,
               NULL,
               mach64_overlay_draw);
-    mach64->svga.dac_hwcursor.cur_ysize = 64;
+    svga->dac_hwcursor.cur_ysize = 64;
 
-    mem_mapping_add(&mach64->linear_mapping, 0, 0, svga_read_linear, svga_readw_linear, svga_readl_linear, svga_write_linear, svga_writew_linear, svga_writel_linear, NULL, MEM_MAPPING_EXTERNAL, &mach64->svga);
+    mem_mapping_add(&mach64->linear_mapping, 0, 0, svga_read_linear, svga_readw_linear, svga_readl_linear, svga_write_linear, svga_writew_linear, svga_writel_linear, NULL, MEM_MAPPING_EXTERNAL, svga);
     mem_mapping_add(&mach64->mmio_linear_mapping, 0, 0, mach64_ext_readb, mach64_ext_readw, mach64_ext_readl, mach64_ext_writeb, mach64_ext_writew, mach64_ext_writel, NULL, MEM_MAPPING_EXTERNAL, mach64);
     mem_mapping_add(&mach64->mmio_linear_mapping_2, 0, 0, mach64_ext_readb, mach64_ext_readw, mach64_ext_readl, mach64_ext_writeb, mach64_ext_writew, mach64_ext_writel, NULL, MEM_MAPPING_EXTERNAL, mach64);
     mem_mapping_add(&mach64->mmio_mapping, 0xbc000, 0x04000, mach64_ext_readb, mach64_ext_readw, mach64_ext_readl, mach64_ext_writeb, mach64_ext_writew, mach64_ext_writel, NULL, MEM_MAPPING_EXTERNAL, mach64);
@@ -4411,20 +4402,15 @@ mach64_common_init(const device_t *info)
     mach64->pci_regs[0x32]            = 0x0c;
     mach64->pci_regs[0x33]            = 0x00;
 
-    mach64->svga.ramdac            = device_add(&ati68860_ramdac_device);
-    mach64->svga.dac_hwcursor_draw = ati68860_hwcursor_draw;
+    svga->ramdac            = device_add(&ati68860_ramdac_device);
+    svga->dac_hwcursor_draw = ati68860_hwcursor_draw;
 
-    mach64->svga.clock_gen = device_add(&ics2595_device);
+    svga->clock_gen = device_add(&ics2595_device);
 
     mach64->dst_cntl = 3;
 
     mach64->i2c = i2c_gpio_init("ddc_ati_mach64");
     mach64->ddc = ddc_init(i2c_gpio_get_bus(mach64->i2c));
-
-    mach64->wake_fifo_thread    = thread_create_event();
-    mach64->fifo_not_full_event = thread_create_event();
-    mach64->thread_run          = 1;
-    mach64->fifo_thread         = thread_create(fifo_thread, mach64);
 
     return mach64;
 }
@@ -4520,12 +4506,6 @@ void
 mach64_close(void *priv)
 {
     mach64_t *mach64 = (mach64_t *) priv;
-
-    mach64->thread_run = 0;
-    thread_set_event(mach64->wake_fifo_thread);
-    thread_wait(mach64->fifo_thread);
-    thread_destroy_event(mach64->fifo_not_full_event);
-    thread_destroy_event(mach64->wake_fifo_thread);
 
     svga_close(&mach64->svga);
 

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -117,6 +117,9 @@ svga_out(uint16_t addr, uint8_t val, void *priv)
     uint8_t    o;
     uint8_t    index;
 
+    if (!dev && (addr >= 0x2ea) && (addr <= 0x2ed))
+        return;
+
     switch (addr) {
         case 0x2ea:
             dev->dac_mask = val;
@@ -362,6 +365,9 @@ svga_in(uint16_t addr, void *priv)
     ibm8514_t *dev = (ibm8514_t *) svga->dev8514;
     uint8_t    index;
     uint8_t    ret = 0xff;
+
+    if (!dev && (addr >= 0x2ea) && (addr <= 0x2ed))
+        return ret;
 
     switch (addr) {
         case 0x2ea:
@@ -827,14 +833,16 @@ svga_poll(void *priv)
     int        ret;
     int        old_ma;
 
-    if (ibm8514_active && dev->on) {
-        ibm8514_poll(dev, svga);
-        return;
-    }
-    if (xga_active && xga->on) {
-        if ((xga->disp_cntl_2 & 7) >= 2) {
-            xga_poll(xga, svga);
+    if (!svga->override) {
+        if (ibm8514_active && dev->on) {
+            ibm8514_poll(dev, svga);
             return;
+        }
+        if (xga_active && xga->on) {
+            if ((xga->disp_cntl_2 & 7) >= 2) {
+                xga_poll(xga, svga);
+                return;
+            }
         }
     }
 

--- a/src/video/vid_tgui9440.c
+++ b/src/video/vid_tgui9440.c
@@ -760,10 +760,18 @@ tgui_recalctimings(svga_t *svga)
             case 8:
                 svga->render = svga_render_8bpp_highres;
                 if (tgui->type >= TGUI_9660) {
-                    if ((svga->dispend == 510) || (svga->dispend == 512))
-                        svga->hdisp = 1280;
-                    else if ((svga->dispend == 600) && (svga->hdisp == 800) && svga->interlace)
-                        svga->hdisp = 1600;
+                    if (svga->dispend == ((1024 >> 1) - 2))
+                        svga->dispend += 2;
+                    if (svga->dispend == (1024 >> 1))
+                        svga->hdisp <<= 1;
+                    else if ((svga->hdisp == (1600 >> 1)) && (svga->dispend == (1200 >> 1)) && svga->interlace)
+                        svga->hdisp <<= 1;
+                    else if (svga->hdisp == (1024 >> 1)) {
+                        if (svga->interlace && (svga->dispend == (768 >> 1)))
+                            svga->hdisp <<= 1;
+                        else if (!svga->interlace && (svga->dispend == 768))
+                            svga->hdisp <<= 1;
+                    }
 
                     if (ger22upper & 0x80) {
                         svga->htotal <<= 1;
@@ -799,7 +807,7 @@ tgui_recalctimings(svga_t *svga)
             case 32:
                 svga->render = svga_render_32bpp_highres;
                 if (tgui->type >= TGUI_9660) {
-                    if (svga->hdisp == 1024)
+                    if (!ger22upper)
                         svga->rowoffset <<= 1;
                 }
                 break;
@@ -1455,15 +1463,21 @@ tgui_accel_command(int count, uint32_t cpu_dat, tgui_t *tgui)
         }
     }
 
-    /*For delayed mode switches.*/
-    if (tgui->type == TGUI_9440) {
-        if (tgui->accel.pitch == 800)
-            tgui->accel.pitch += 32;
+    /*See this: https://android.googlesource.com/kernel/tegra/+/android-tegra-flounder-3.10-lollipop-release/drivers/video/tridentfb.c for the pitch*/
+    tgui->accel.pitch = svga->rowoffset;
 
-        if (tgui->accel.bpp == 1) {
-            if (!ger22upper)
-                tgui->accel.pitch = svga->rowoffset << 2;
-        }
+    switch (svga->bpp) {
+        case 8:
+        case 24:
+            tgui->accel.pitch <<= 3;
+            break;
+        case 15:
+        case 16:
+            tgui->accel.pitch <<= 2;
+            break;
+        case 32:
+            tgui->accel.pitch <<= 1;
+            break;
     }
 #if 0
     pclog("TGUI accel command = %x, ger22 = %04x, hdisp = %d, dispend = %d, vtotal = %d, rowoffset = %d, svgabpp = %d, interlace = %d, accelbpp = %d, pitch = %d.\n", tgui->accel.command, tgui->accel.ger22, svga->hdisp, svga->dispend, svga->vtotal, svga->rowoffset, svga->bpp, svga->interlace, tgui->accel.bpp, tgui->accel.pitch);
@@ -2056,7 +2070,6 @@ tgui_accel_out(uint16_t addr, uint8_t val, void *priv)
     switch (addr) {
         case 0x2122:
             tgui->accel.ger22 = (tgui->accel.ger22 & 0xff00) | val;
-            tgui->accel.pitch = 0x200 << ((val >> 2) & 3);
             switch (svga->bpp) {
                 case 8:
                 case 24:
@@ -2076,7 +2089,8 @@ tgui_accel_out(uint16_t addr, uint8_t val, void *priv)
             break;
 
         case 0x2123:
-            //pclog("Pitch IO23: val = %02x, rowoffset = %x, pitch = %d.\n", val, svga->rowoffset, tgui->accel.pitch);
+            tgui->accel.ger22 = (tgui->accel.ger22 & 0xff) | (val << 8);
+            //pclog("Pitch IO23: val = %02x, rowoffset = %x.\n", tgui->accel.ger22, svga->crtc[0x13]);
             switch (svga->bpp) {
                 case 8:
                 case 24:
@@ -2090,24 +2104,6 @@ tgui_accel_out(uint16_t addr, uint8_t val, void *priv)
                     tgui->accel.bpp = 3;
                     break;
             }
-            tgui->accel.ger22 = (tgui->accel.ger22 & 0xff) | (val << 8);
-            if ((val & 0x80) || ((val & 0xc0) == 0x40))
-                tgui->accel.pitch = svga->rowoffset << 3;
-            else if (tgui->accel.pitch <= 1024) {
-                tgui->accel.pitch = svga->rowoffset << 3;
-                if (!val)
-                    tgui->accel.pitch = 1024;
-            }
-
-            if (tgui->accel.pitch == 800)
-                tgui->accel.pitch += 32;
-
-            if (tgui->accel.bpp == 1)
-                tgui->accel.pitch >>= 1;
-            else if (tgui->accel.bpp == 3)
-                tgui->accel.pitch >>= 2;
-
-            svga_recalctimings(svga);
             break;
 
         case 0x2124: /*Command*/
@@ -2724,59 +2720,11 @@ tgui_accel_write(uint32_t addr, uint8_t val, void *priv)
 
     switch (addr & 0xff) {
         case 0x22:
-            tgui->accel.ger22 = (tgui->accel.ger22 & 0xff00) | val;
-            tgui->accel.pitch = 0x200 << ((val >> 2) & 3);
-            switch (svga->bpp) {
-                case 8:
-                case 24:
-                    tgui->accel.bpp = 0;
-                    break;
-                case 15:
-                case 16:
-                    tgui->accel.bpp = 1;
-                    break;
-                case 32:
-                    tgui->accel.bpp = 3;
-                    break;
-
-                default:
-                    break;
-            }
+            tgui_accel_out(0x2122, val, tgui);
             break;
 
         case 0x23:
-            switch (svga->bpp) {
-                case 8:
-                case 24:
-                    tgui->accel.bpp = 0;
-                    break;
-                case 15:
-                case 16:
-                    tgui->accel.bpp = 1;
-                    break;
-                case 32:
-                    tgui->accel.bpp = 3;
-                    break;
-            }
-            tgui->accel.ger22 = (tgui->accel.ger22 & 0xff) | (val << 8);
-            if ((val & 0x80) || ((val & 0xc0) == 0x40))
-                tgui->accel.pitch = svga->rowoffset << 3;
-            else if (tgui->accel.pitch <= 1024) {
-                tgui->accel.pitch = svga->rowoffset << 3;
-                if (!val)
-                    tgui->accel.pitch = 1024;
-            }
-
-            if (tgui->accel.pitch == 800)
-                tgui->accel.pitch += 32;
-
-            if (tgui->accel.bpp == 1)
-                tgui->accel.pitch >>= 1;
-            else if (tgui->accel.bpp == 3)
-                tgui->accel.pitch >>= 2;
-
-            //pclog("Pitch MM23: fullval = %04x, rowoffset = %x, pitch = %d.\n", tgui->accel.ger22, svga->rowoffset, tgui->accel.pitch);
-            svga_recalctimings(svga);
+            tgui_accel_out(0x2123, val, tgui);
             break;
 
         case 0x24: /*Command*/


### PR DESCRIPTION
Summary
=======
ATI Mach64 is temporarily unthreaded because of blitter desyncing.
ATI Mach32 now returns to ATI mode from IBM mode and vice versa more correctly.
Make the IBM 8514/A compatible poll not run if a 3D add-on card (Voodoo1/2) takes precedence (seen on a Mach32 PCI and Voodoo2 3D combo).
Finally ended the mess ups of the TGUI9440/96x0 pitch, it actually was the CRTC offset reg (SVGA CRTC 0x13) that defined it with some shifting based on the BPP.

Checklist
=========
* [x] Closes #3728
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
TGUI9440/96x0.
[Only thing regarding about said chipset](https://android.googlesource.com/kernel/tegra/+/android-tegra-flounder-3.10-lollipop-release/drivers/video/tridentfb.c)
