### PR TITLE
Remove the C/C++ standard flags from the toolchain files

### DIFF
--- a/cmake/flags-gcc.cmake
+++ b/cmake/flags-gcc.cmake
@@ -14,8 +14,8 @@
 #
 
 # Define our flags
-string(APPEND CMAKE_C_FLAGS_INIT                " -std=c99 -fomit-frame-pointer -Wall -fno-strict-aliasing -Werror=implicit-int -Werror=implicit-function-declaration -Werror=int-conversion -Werror=strict-prototypes -Werror=old-style-definition")
-string(APPEND CMAKE_CXX_FLAGS_INIT              " -std=c++11 -fomit-frame-pointer -Wall -fno-strict-aliasing")
+string(APPEND CMAKE_C_FLAGS_INIT                " -fomit-frame-pointer -Wall -fno-strict-aliasing -Werror=implicit-int -Werror=implicit-function-declaration -Werror=int-conversion -Werror=strict-prototypes -Werror=old-style-definition")
+string(APPEND CMAKE_CXX_FLAGS_INIT              " -fomit-frame-pointer -Wall -fno-strict-aliasing")
 string(APPEND CMAKE_C_FLAGS_RELEASE_INIT        " -g0 -O3")
 string(APPEND CMAKE_CXX_FLAGS_RELEASE_INIT      " -g0 -O3")
 string(APPEND CMAKE_C_FLAGS_DEBUG_INIT          " -ggdb -Og")


### PR DESCRIPTION
Summary
=======
Remove the C/C++ standard flags from the toolchain files that never worked anyway due to `CMAKE_(C|CXX)_STANDARD` overriding them and were potentially compilation-breaking due to disabling compiler extensions.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A
