### PR TITLE
Small Mach32/SVGA font mapping fix.

### DIFF
--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -2427,16 +2427,6 @@ mach_out(uint16_t addr, uint8_t val, void *priv)
                 svga_out(addr, val, svga);
             return;
 
-        case 0x3CF:
-            if (svga->gdcaddr == 6) {
-                uint8_t old_val = svga->gdcreg[6];
-                svga->gdcreg[6] = val;
-                if ((svga->gdcreg[6] & 0xc) != (old_val & 0xc))
-                    mach32_updatemapping(mach);
-                return;
-            }
-            break;
-
         case 0x3D4:
             svga->crtcreg = val & 0x3f;
             return;


### PR DESCRIPTION

Summary
=======
Small mach32/svga mapping fix (actually fixes font rendering on win3.1x using the Mach32 2.6 drivers)

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
