### PR TITLE
Fix speeds other than RAM disk not being selectable for SCSI or ATAPI HDDs

### DIFF
--- a/src/qt/qt_harddrive_common.cpp
+++ b/src/qt/qt_harddrive_common.cpp
@@ -75,8 +75,10 @@ Harddrives::populateSpeeds(QAbstractItemModel *model, int bus)
     int num_preset;
 
     switch (bus) {
-        case HDD_BUS_IDE:
         case HDD_BUS_ESDI:
+        case HDD_BUS_IDE:
+        case HDD_BUS_ATAPI:
+        case HDD_BUS_SCSI:
             num_preset = hdd_preset_get_num();
             break;
 


### PR DESCRIPTION
Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A
