### PR TITLE
Report correct cache info in CPUID on P6-family CPUs

### DIFF
--- a/src/cpu/cpu.c
+++ b/src/cpu/cpu.c
@@ -2373,9 +2373,14 @@ cpu_CPUID(void)
                 EBX = ECX = 0;
                 EDX       = CPUID_FPU | CPUID_VME | CPUID_PSE | CPUID_TSC | CPUID_MSR | CPUID_PAE | CPUID_MCE | CPUID_CMPXCHG8B | CPUID_MTRR | CPUID_PGE | CPUID_MCA | CPUID_SEP | CPUID_CMOV;
             } else if (EAX == 2) {
-                EAX = 0x00000001;
+                EAX = 0x03020101; /* Instruction TLB: 4 KB pages, 4-way set fully associative, 32 entries
+                                     Instruction TLB: 4 MB pages, fully associative, 2 entries
+                                     Data TLB: 4 KB pages, 4-way set associative, 64 entries */
                 EBX = ECX = 0;
-                EDX       = 0x00000000;
+                EDX       = 0x0C040842; /* Data TLB: 4 MB pages, 4-way set associative, 8 entries
+                                           Level 1 instruction cache: 16 KB, 4-way set associative, 32 byte line size
+                                           Level 1 data cache: 16 KB, 4-way set associative, 32 byte line size
+                                           Level 2 cache: 256 KB, 4-way set associative, 32 byte line size */
             } else
                 EAX = EBX = ECX = EDX = 0;
             break;
@@ -2391,9 +2396,14 @@ cpu_CPUID(void)
                 EBX = ECX = 0;
                 EDX       = CPUID_FPU | CPUID_VME | CPUID_PSE | CPUID_TSC | CPUID_MSR | CPUID_PAE | CPUID_MCE | CPUID_CMPXCHG8B | CPUID_MMX | CPUID_MTRR | CPUID_PGE | CPUID_MCA | CPUID_SEP | CPUID_CMOV;
             } else if (EAX == 2) {
-                EAX = 0x00000001;
+                EAX = 0x03020101; /* Instruction TLB: 4 KB pages, 4-way set fully associative, 32 entries
+                                     Instruction TLB: 4 MB pages, fully associative, 2 entries
+                                     Data TLB: 4 KB pages, 4-way set associative, 64 entries */
                 EBX = ECX = 0;
-                EDX       = 0x00000000;
+                EDX       = 0x0C040843; /* Data TLB: 4 MB pages, 4-way set associative, 8 entries
+                                           Level 1 instruction cache: 16 KB, 4-way set associative, 32 byte line size
+                                           Level 1 data cache: 16 KB, 4-way set associative, 32 byte line size
+                                           Level 2 cache: 512 KB, 4-way set associative, 32 byte line size */
             } else
                 EAX = EBX = ECX = EDX = 0;
             break;
@@ -2409,9 +2419,22 @@ cpu_CPUID(void)
                 EBX = ECX = 0;
                 EDX       = CPUID_FPU | CPUID_VME | CPUID_PSE | CPUID_TSC | CPUID_MSR | CPUID_PAE | CPUID_MCE | CPUID_CMPXCHG8B | CPUID_MMX | CPUID_MTRR | CPUID_PGE | CPUID_MCA | CPUID_SEP | CPUID_FXSR | CPUID_CMOV;
             } else if (EAX == 2) {
-                EAX = 0x00000001;
+                EAX = 0x03020101; /* Instruction TLB: 4 KB pages, 4-way set fully associative, 32 entries
+                                     Instruction TLB: 4 MB pages, fully associative, 2 entries
+                                     Data TLB: 4 KB pages, 4-way set associative, 64 entries */
                 EBX = ECX = 0;
-                EDX       = 0x00000000;
+                if (cpu_f->package == CPU_PKG_SLOT2) /* Pentium II Xeon Drake */
+                    EDX = 0x0C040844; /* Data TLB: 4 MB pages, 4-way set associative, 8 entries
+                                         Level 1 instruction cache: 16 KB, 4-way set associative, 32 byte line size
+                                         Level 1 data cache: 16 KB, 4-way set associative, 32 byte line size
+                                         Level 2 cache: 1 MB, 4-way set associative, 32 byte line size */
+                else if (!strncmp(cpu_f->internal_name, "celeron", 7)) { /* Celeron */
+                    if (CPUID >= 0x660) /* Mendocino */
+                        EDX = 0x0C040841; /* Level 2 cache: 128 KB, 4-way set associative, 32 byte line size */
+                    else /* Covington */
+                        EDX = 0x0C040840; /* No Level 2 cache */
+                } else /* Pentium II Deschutes and OverDrive */
+                    EDX = 0x0C040843; /* Level 2 cache: 512 KB, 4-way set associative, 32 byte line size */
             } else
                 EAX = EBX = ECX = EDX = 0;
             break;


### PR DESCRIPTION
Summary
=======
Makes Pentium Pro and Pentium II (incl. Celerons) report accurate cache and TLB information in the output of CPUID with EAX=2.

Checklist
=========
* [x] Closes #3785
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
[Intel Processor Identification and the CPUID Instruction](http://datasheets.chipdb.org/Intel/x86/CPUID/24161821.pdf) - information on the cache descriptor values
<https://www.cpu-world.com/> (too many pages to list) - CPUID dumps of real CPUs