### PR TITLE
add cpl_override in pmodeiret() when cpu_state.flags has NT_FLAG

### DIFF
--- a/src/cpu/x86seg.c
+++ b/src/cpu/x86seg.c
@@ -1796,7 +1796,9 @@ pmodeiret(int is32)
     }
 
     if (cpu_state.flags & NT_FLAG) {
+        cpl_override = 1;
         seg  = readmemw(tr.base, 0);
+        cpl_override = 0;
         addr = seg & 0xfff8;
         if (seg & 0x0004) {
             x86seg_log("TS LDT %04X %04X IRET\n", seg, gdt.limit);

--- a/src/cpu/x86seg.c
+++ b/src/cpu/x86seg.c
@@ -1811,8 +1811,8 @@ pmodeiret(int is32)
             }
             addr += gdt.base;
         }
-        cpl_override = 1;
         read_descriptor(addr, segdat, segdat32, 1);
+        cpl_override = 1;
         op_taskswitch286(seg, segdat, segdat[2] & 0x0800);
         cpl_override = 0;
         return;


### PR DESCRIPTION
Summary
=======
I've been hit by #1951 myself, and debugging the issue led me to guess cpl_override should be set for this read. With this patch, the warnings disappear, but OpenServer still doesn't go graphical unless a very small subset of video cards has been selected.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
Debugging the same CPU state in QEMU helped me verify the expected value for the `seg` assignment.