### PR TITLE
More and more video changes and fixes (8514/A and compatibles):

### DIFF
--- a/src/include/86box/vid_8514a.h
+++ b/src/include/86box/vid_8514a.h
@@ -41,7 +41,7 @@ typedef struct ibm8514_t {
     int type;
     int local;
     int bpp;
-    int on;
+    int on[2];
     int accel_bpp;
 
     uint32_t vram_size;
@@ -64,7 +64,7 @@ typedef struct ibm8514_t {
     struct {
         uint16_t subsys_cntl;
         uint16_t setup_md;
-        uint8_t  advfunc_cntl;
+        uint16_t advfunc_cntl;
         uint8_t  ext_advfunc_cntl;
         uint16_t cur_y;
         uint16_t cur_y_bitres;


### PR DESCRIPTION
Summary
=======
1. Made the 8514/A mode switch to VGA and viceversa (including ATI mode) actually usable and eliminating the last bugs related to them. Fixes 8514/A mode in OS/2 1.x/2.x (both IBM and Microsoft).
2. More sanity checks to the 8514/A and XGA pointers. Should fix emulator crashes on hard resets.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
