### PR TITLE
Forgot to apply the correction to the ATI 68860 ramdac, should clear the compile warnings

### DIFF
--- a/src/video/vid_ati68860_ramdac.c
+++ b/src/video/vid_ati68860_ramdac.c
@@ -73,16 +73,16 @@ ati68860_ramdac_out(uint16_t addr, uint8_t val, void *priv, svga_t *svga)
 
     switch (addr) {
         case 0:
-            svga_out((dev && dev->on) ? 0x2ec : 0x3c8, val, svga);
+            svga_out((dev && (dev->on[0] || dev->on[1])) ? 0x2ec : 0x3c8, val, svga);
             break;
         case 1:
-            svga_out((dev && dev->on) ? 0x2ed : 0x3c9, val, svga);
+            svga_out((dev && (dev->on[0] || dev->on[1])) ? 0x2ed : 0x3c9, val, svga);
             break;
         case 2:
-            svga_out((dev && dev->on) ? 0x2ea : 0x3c6, val, svga);
+            svga_out((dev && (dev->on[0] || dev->on[1])) ? 0x2ea : 0x3c6, val, svga);
             break;
         case 3:
-            svga_out((dev && dev->on) ? 0x2eb : 0x3c7, val, svga);
+            svga_out((dev && (dev->on[0] || dev->on[1])) ? 0x2eb : 0x3c7, val, svga);
             break;
         default:
             ramdac->regs[addr & 0xf] = val;
@@ -178,16 +178,16 @@ ati68860_ramdac_in(uint16_t addr, void *priv, svga_t *svga)
 
     switch (addr) {
         case 0:
-            temp = svga_in((dev && dev->on) ? 0x2ec : 0x3c8, svga);
+            temp = svga_in((dev && (dev->on[0] || dev->on[1])) ? 0x2ec : 0x3c8, svga);
             break;
         case 1:
-            temp = svga_in((dev && dev->on) ? 0x2ed : 0x3c9, svga);
+            temp = svga_in((dev && (dev->on[0] || dev->on[1])) ? 0x2ed : 0x3c9, svga);
             break;
         case 2:
-            temp = svga_in((dev && dev->on) ? 0x2ea : 0x3c6, svga);
+            temp = svga_in((dev && (dev->on[0] || dev->on[1])) ? 0x2ea : 0x3c6, svga);
             break;
         case 3:
-            temp = svga_in((dev && dev->on) ? 0x2eb : 0x3c7, svga);
+            temp = svga_in((dev && (dev->on[0] || dev->on[1])) ? 0x2eb : 0x3c7, svga);
             break;
         case 4:
         case 8:


### PR DESCRIPTION
Summary
=======
Forgot to apply the correction to the ATI 68860 ramdac, should clear the compile warnings.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
