### PR TITLE
(S)VGA paletted renderer rewrite

### DIFF
--- a/src/include/86box/vid_svga_render.h
+++ b/src/include/86box/vid_svga_render.h
@@ -53,6 +53,8 @@ void svga_render_4bpp_lowres(svga_t *svga);
 void svga_render_4bpp_highres(svga_t *svga);
 void svga_render_8bpp_lowres(svga_t *svga);
 void svga_render_8bpp_highres(svga_t *svga);
+void svga_render_8bpp_s3_lowres(svga_t *svga);
+void svga_render_8bpp_s3_highres(svga_t *svga);
 void svga_render_8bpp_tseng_lowres(svga_t *svga);
 void svga_render_8bpp_tseng_highres(svga_t *svga);
 void svga_render_8bpp_gs_lowres(svga_t *svga);

--- a/src/include/86box/vid_svga_render.h
+++ b/src/include/86box/vid_svga_render.h
@@ -34,6 +34,7 @@ extern int      cgablink;
 extern int scrollcache;
 
 extern uint8_t edatlookup[4][4];
+extern uint8_t egaremap2bpp[256];
 
 void svga_recalc_remap_func(svga_t *svga);
 

--- a/src/include/86box/vid_svga_render.h
+++ b/src/include/86box/vid_svga_render.h
@@ -53,8 +53,6 @@ void svga_render_4bpp_lowres(svga_t *svga);
 void svga_render_4bpp_highres(svga_t *svga);
 void svga_render_8bpp_lowres(svga_t *svga);
 void svga_render_8bpp_highres(svga_t *svga);
-void svga_render_8bpp_s3_lowres(svga_t *svga);
-void svga_render_8bpp_s3_highres(svga_t *svga);
 void svga_render_8bpp_tseng_lowres(svga_t *svga);
 void svga_render_8bpp_tseng_highres(svga_t *svga);
 void svga_render_8bpp_gs_lowres(svga_t *svga);

--- a/src/video/vid_ega.c
+++ b/src/video/vid_ega.c
@@ -61,8 +61,6 @@ static uint32_t        pallook64[256];
 static int             ega_type           = 0;
 static int             old_overscan_color = 0;
 
-uint8_t egaremap2bpp[256];
-
 /* 3C2 controls default mode on EGA. On VGA, it determines monitor type (mono or colour):
     7=CGA mode (200 lines), 9=EGA mode (350 lines), 8=EGA mode (200 lines). */
 int egaswitchread;
@@ -1280,32 +1278,6 @@ ega_init(ega_t *ega, int monitor_type, int is_mono)
             ega_rotate[d][c] = e;
             e                = (e >> 1) | ((e & 1) ? 0x80 : 0);
         }
-    }
-
-    for (c = 0; c < 4; c++) {
-        for (d = 0; d < 4; d++) {
-            edatlookup[c][d] = 0;
-            if (c & 1)
-                edatlookup[c][d] |= 1;
-            if (d & 1)
-                edatlookup[c][d] |= 2;
-            if (c & 2)
-                edatlookup[c][d] |= 0x10;
-            if (d & 2)
-                edatlookup[c][d] |= 0x20;
-        }
-    }
-
-    for (c = 0; c < 256; c++) {
-        egaremap2bpp[c] = 0;
-        if (c & 0x01)
-            egaremap2bpp[c] |= 0x01;
-        if (c & 0x04)
-            egaremap2bpp[c] |= 0x02;
-        if (c & 0x10)
-            egaremap2bpp[c] |= 0x04;
-        if (c & 0x40)
-            egaremap2bpp[c] |= 0x08;
     }
 
     if (is_mono) {

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -1001,7 +1001,7 @@ svga_poll(void *priv)
             else
                 svga->cursoron = svga->blink & (16 + (16 * blink_delay));
 
-            if (!(svga->gdcreg[6] & 1) && !(svga->blink & 15))
+            if (!(svga->blink & 15))
                 svga->fullchange = 2;
 
             svga->blink = (svga->blink + 1) & 0x7f;

--- a/src/video/vid_svga_render.c
+++ b/src/video/vid_svga_render.c
@@ -569,14 +569,12 @@ svga_render_indexed_gfx(svga_t *svga, bool highres, bool combine8bits)
             load_counter = 0;
         }
 
-        if (incr_counter == 0) {
-            svga->ma += 4;
-            // DISCREPANCY TODO FIXME 2/4bpp used vram_mask, 8bpp used vram_display_mask --GM
-            svga->ma &= svga->vram_display_mask;
-        }
         incr_counter += 1;
         if (incr_counter >= incevery) {
             incr_counter = 0;
+            svga->ma += 4;
+            // DISCREPANCY TODO FIXME 2/4bpp used vram_mask, 8bpp used vram_display_mask --GM
+            svga->ma &= svga->vram_display_mask;
         }
 
         //

--- a/src/video/video.c
+++ b/src/video/video.c
@@ -78,6 +78,7 @@
 
 volatile int screenshots = 0;
 uint8_t      edatlookup[4][4];
+uint8_t      egaremap2bpp[256];
 uint8_t      fontdat[2048][8];            /* IBM CGA font */
 uint8_t      fontdatm[2048][16];          /* IBM MDA font */
 uint8_t      fontdat2[2048][8];           /* IBM CGA 2nd instance font */
@@ -913,6 +914,18 @@ video_init(void)
             if (d & 2)
                 edatlookup[c][d] |= 0x20;
         }
+    }
+
+    for (uint16_t c = 0; c < 256; c++) {
+        egaremap2bpp[c] = 0;
+        if (c & 0x01)
+            egaremap2bpp[c] |= 0x01;
+        if (c & 0x04)
+            egaremap2bpp[c] |= 0x02;
+        if (c & 0x10)
+            egaremap2bpp[c] |= 0x04;
+        if (c & 0x40)
+            egaremap2bpp[c] |= 0x08;
     }
 
     video_6to8 = malloc(4 * 256);


### PR DESCRIPTION
Summary
=======
This replaces the generic (S)VGA 2bpp, 4bpp, and 8bpp renderers with a single renderer which supports more of what the VGA at least theoretically does.

I am aware that this almost certainly will break a lot of things. I've tried to *not* break things, but, well... a lot of stuff depends on the (S)VGA renderer.

Features:

* Loading (Sequencer) and address incrementing (CRTC) are now independent
  * You can read the same value twice or four times and it does what you'd think it would
* Planes are chained in a ring
  * No idea if it's actually a ring or if it needs to shift in some 0s or some 1s, so this will need testing on quite a few pieces of hardware.
* Byte/Word/Doubleword mode are now handled theoretically properly
* The CGA 2bpp flag no longer ignores the 2 upper bit planes (fixes #3836)
  * I would go as far to say that if something *doesn't* support this properly, it's an emulator.
* 8bpp rendering is now based on the 4bpp renderer, and the 8bpp shift mode is implemented
  * The normal way of implementing the 8bpp shift mode is non-universal, and probably worth researching on a per-chipset level. (Neither of my two tested laptops implement it in the way it's implemented here, and one implements it in a way which is useless for 4bpp graphics.)
* Blink is implemented in graphics mode (worth testing this for #3447)
  * I can confirm that an Intel GMA 4500MHD (2008) can even do this in Mode 13h and it works in the most obvious way, which is how I've implemented it here... but this isn't universal and an AMD Stoney Ridge (2016) ignores blink in Mode 13h.

I will need to go back through the EGA renderer and get a lot of this stuff backported to it as, after scratching my head throughout this, bugs and missing features have been revealed.

The main thing I've learnt from all this? Odd/Even mode is a configuration nightmare, and VGA makes it even worse.

Checklist
=========
* [x] Closes #3836
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
The Chips & Technologies 82C451 datasheet was the most valuable authoritative reference.
I ensured that Pinball Fantasies still worked on IBM VGA and a VLB S3 Trio64. (The virtual machine I was using, a MR BIOS SX495, does not use PCI so I was unable to compare a V+ card, but I could get something set up for that.)
I also ensured that all QBASIC graphics modes usable on a VGA in MS-DOS 6.20 still worked on both as well - that is, 1,2,7,8,9,10,11,12,13.