### PR TITLE
8-bit renderer fix about the Tseng cards:

### DIFF
--- a/src/video/vid_svga_render.c
+++ b/src/video/vid_svga_render.c
@@ -470,9 +470,9 @@ svga_render_indexed_gfx(svga_t *svga, bool highres, bool combine8bits)
     const bool    dwordincr   = ((svga->crtc[0x14] & 0x20) != 0) && !wordincr;
     const bool    dwordshift  = ((svga->crtc[0x14] & 0x40) != 0);
     const bool    wordshift   = ((svga->crtc[0x17] & 0x40) == 0) && !dwordshift;
-    const uint32_t incbypow2  = combine8bits && svga->force_old_addr ? 0 : (dwordshift ? 2 : wordshift ? 1 : 0);
-    const uint32_t incevery   = combine8bits && svga->force_old_addr ? 1 : (dwordincr  ? 4 : wordincr  ? 2 : 1);
-    const uint32_t loadevery  = combine8bits && svga->force_old_addr ? 1 : (dwordload  ? 4 : wordload  ? 2 : 1);
+    const uint32_t incbypow2  = (combine8bits && (svga->force_old_addr || svga->packed_chain4)) ? 0 : (dwordshift ? 2 : wordshift ? 1 : 0);
+    const uint32_t incevery   = (combine8bits && (svga->force_old_addr || svga->packed_chain4)) ? 1 : (dwordincr  ? 4 : wordincr  ? 2 : 1);
+    const uint32_t loadevery  = (combine8bits && (svga->force_old_addr || svga->packed_chain4)) ? 1 : (dwordload  ? 4 : wordload  ? 2 : 1);
 
     const bool    shift2bit   = ((svga->gdcreg[0x05] & 0x60) == 0x20 );
     const bool    shift4bit   = ((svga->gdcreg[0x05] & 0x40) == 0x40 );


### PR DESCRIPTION
Summary
=======
Seems the Tseng cards are as incompatible as the S3 cards in terms of pure IBM VGA emulation, especially the chain4 stuff, so accomodate the fix to the renderer. Fixes 8bpp rendering on Tseng cards when invoked.


Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
