### PR TITLE
update WM_CLASS instance name from vm_name

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -371,6 +371,8 @@ if (APPLE AND CMAKE_MACOSX_BUNDLE)
 endif()
 
 if (UNIX AND NOT APPLE AND NOT HAIKU)
+    target_sources(ui PRIVATE x11_util.c)
+
     find_package(X11 REQUIRED)
     target_link_libraries(ui PRIVATE X11::X11 X11::Xi)
     target_sources(ui PRIVATE evdev_keyboard.cpp xinput2_mouse.cpp)

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -718,7 +718,7 @@ MainWindow::MainWindow(QWidget *parent)
     {}
 #endif
 
-#if !defined Q_OS_MACOS && !defined Q_OS_HAIKU
+#if defined Q_OS_UNIX && !defined Q_OS_MACOS && !defined Q_OS_HAIKU
     if (QApplication::platformName().contains("xcb")) {
         QTimer::singleShot(0, this, [this] {
             auto whandle = windowHandle();

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -117,6 +117,11 @@ extern int qt_nvr_save(void);
 #    undef KeyRelease
 #endif
 
+#if defined Q_OS_UNIX && !defined Q_OS_HAIKU && !defined Q_OS_MACOS
+#include <qpa/qplatformwindow.h>
+#include "x11_util.h"
+#endif
+
 #ifdef Q_OS_MACOS
 #    include "cocoa_keyboard.hpp"
 // The namespace is required to avoid clashing typedefs; we only use this
@@ -711,6 +716,20 @@ MainWindow::MainWindow(QWidget *parent)
     else
 #    endif
     {}
+#endif
+
+#if !defined Q_OS_MACOS && !defined Q_OS_HAIKU
+    if (QApplication::platformName().contains("xcb")) {
+        QTimer::singleShot(0, this, [this] {
+            auto whandle = windowHandle();
+            if (! whandle) {
+                qWarning() << "No window handle";
+            } else {
+                QPlatformWindow *window = whandle->handle();
+                set_wm_class(window->winId(), vm_name);
+            }
+        });
+    }
 #endif
 }
 

--- a/src/qt/x11_util.c
+++ b/src/qt/x11_util.c
@@ -1,0 +1,22 @@
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <stdio.h>
+
+#include "x11_util.h"
+
+void set_wm_class(unsigned long window, char *res_name) {
+    Display* display = XOpenDisplay(NULL);
+    if (display == NULL) {
+        return;
+    }
+
+    XClassHint hint;
+    XGetClassHint(display, window, &hint);
+
+    hint.res_name = res_name;
+    XSetClassHint(display, window, &hint);
+
+    // During testing, I've had to issue XGetClassHint after XSetClassHint
+    // to get the window manager to recognize the change.
+    XGetClassHint(display, window, &hint);
+}

--- a/src/qt/x11_util.h
+++ b/src/qt/x11_util.h
@@ -1,0 +1,9 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void set_wm_class(unsigned long window, char *res_name);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Summary
=======
From a request in #86box-support on Discord.

This updates the WM_CLASS instance name from 86box' vm_name variable after the mainwindow has opened. I haven't done extensive testing so far, as I only have a machine running Xwayland readily available.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://www.x.org/docs/ICCCM/icccm.pdf
