### PR TITLE
Cirrus, ATI Mach8/32 and XGA fixes.

### DIFF
--- a/src/include/86box/vid_8514a.h
+++ b/src/include/86box/vid_8514a.h
@@ -137,7 +137,7 @@ typedef struct ibm8514_t {
     } accel;
 
     uint16_t test;
-    int      ibm_mode;
+    int      vendor_mode[2];
 
     int      v_total;
     int      dispend;

--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -2009,7 +2009,7 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
                 if (dev->accel.cur_y >= 0x600)
                     dev->accel.cy |= ~0x5ff;
 
-                if ((dev->local >= 2) && dev->accel.ge_offset && (dev->accel_bpp == 24))
+                if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && (dev->accel_bpp == 24))
                     dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
                 else
                     dev->accel.dest = dev->accel.cy * dev->pitch;
@@ -2061,7 +2061,7 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
                         if (!(dev->accel.cmd & 0x40) && (frgd_mix == 2) && (bkgd_mix == 2) && (pixcntl == 0) && (cmd == 2)) {
                             if (!(dev->accel.sx & 1)) {
                                 dev->accel.output = 1;
-                                if ((dev->local >= 2) && dev->accel.ge_offset && (dev->accel_bpp == 24))
+                                if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && (dev->accel_bpp == 24))
                                     dev->accel.newdest_out = (dev->accel.ge_offset << 2) + ((dev->accel.cy + 1) * dev->pitch);
                                 else
                                     dev->accel.newdest_out = (dev->accel.cy + 1) * dev->pitch;
@@ -2075,7 +2075,7 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
                     if (!(dev->accel.cmd & 2) && (frgd_mix == 2) && (pixcntl == 0) && (cmd == 2)) {
                         if (!(dev->accel.sx & 1)) {
                             dev->accel.input      = 1;
-                            if ((dev->local >= 2) && dev->accel.ge_offset && (dev->accel_bpp == 24))
+                            if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && (dev->accel_bpp == 24))
                                 dev->accel.newdest_in = (dev->accel.ge_offset << 2) + ((dev->accel.cy + 1) * dev->pitch);
                             else
                                 dev->accel.newdest_in = (dev->accel.cy + 1) * dev->pitch;
@@ -2258,7 +2258,7 @@ rect_fill_pix:
                                         break;
                                 }
 
-                                if ((dev->local >= 2) && dev->accel.ge_offset && (dev->accel_bpp == 24))
+                                if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && (dev->accel_bpp == 24))
                                     dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
                                 else
                                     dev->accel.dest = dev->accel.cy * dev->pitch;
@@ -2343,7 +2343,7 @@ rect_fill_pix:
                                 else
                                     dev->accel.cy--;
 
-                                if ((dev->local >= 2) && dev->accel.ge_offset && (dev->accel_bpp == 24))
+                                if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && (dev->accel_bpp == 24))
                                     dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
                                 else
                                     dev->accel.dest = dev->accel.cy * dev->pitch;
@@ -2435,7 +2435,7 @@ rect_fill_pix:
                                 else
                                     dev->accel.cy--;
 
-                                if ((dev->local >= 2) && dev->accel.ge_offset && (dev->accel_bpp == 24))
+                                if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && (dev->accel_bpp == 24))
                                     dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
                                 else
                                     dev->accel.dest = dev->accel.cy * dev->pitch;
@@ -2494,7 +2494,7 @@ rect_fill_pix:
                                         else
                                             dev->accel.cy--;
 
-                                        if ((dev->local >= 2) && dev->accel.ge_offset && (dev->accel_bpp == 24)) {
+                                        if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && (dev->accel_bpp == 24)) {
                                             dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
                                             dev->accel.newdest_in = (dev->accel.ge_offset << 2) + ((dev->accel.cy + 1) * dev->pitch);
                                         } else {
@@ -2519,7 +2519,7 @@ rect_fill_pix:
                                         else
                                             dev->accel.cy--;
 
-                                        if ((dev->local >= 2) && dev->accel.ge_offset && (dev->accel_bpp == 24)) {
+                                        if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && (dev->accel_bpp == 24)) {
                                             dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
                                             dev->accel.newdest_in = (dev->accel.ge_offset << 2) + ((dev->accel.cy + 1) * dev->pitch);
                                         } else {
@@ -2575,7 +2575,7 @@ rect_fill_pix:
                                         else
                                             dev->accel.cy--;
 
-                                        if ((dev->local >= 2) && dev->accel.ge_offset && (dev->accel_bpp == 24)) {
+                                        if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && (dev->accel_bpp == 24)) {
                                             dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
                                             dev->accel.newdest_out = (dev->accel.ge_offset << 2) + ((dev->accel.cy + 1) * dev->pitch);
                                         } else {
@@ -2600,7 +2600,7 @@ rect_fill_pix:
                                         else
                                             dev->accel.cy--;
 
-                                        if ((dev->local >= 2) && dev->accel.ge_offset && (dev->accel_bpp == 24)) {
+                                        if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && (dev->accel_bpp == 24)) {
                                             dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
                                             dev->accel.newdest_out = (dev->accel.ge_offset << 2) + ((dev->accel.cy + 1) * dev->pitch);
                                         } else {
@@ -2690,7 +2690,7 @@ rect_fill_pix:
                                     else
                                         dev->accel.cy--;
 
-                                    if ((dev->local >= 2) && dev->accel.ge_offset && (dev->accel_bpp == 24))
+                                    if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && (dev->accel_bpp == 24))
                                         dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
                                     else
                                         dev->accel.dest = dev->accel.cy * dev->pitch;
@@ -2767,7 +2767,7 @@ rect_fill:
                                     else
                                         dev->accel.cy--;
 
-                                    if ((dev->local >= 2) && dev->accel.ge_offset && (dev->accel_bpp == 24))
+                                    if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && (dev->accel_bpp == 24))
                                         dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
                                     else
                                         dev->accel.dest = dev->accel.cy * dev->pitch;
@@ -2838,7 +2838,7 @@ rect_fill:
                                     else
                                         dev->accel.cy--;
 
-                                    if ((dev->local >= 2) && dev->accel.ge_offset && (dev->accel_bpp == 24))
+                                    if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && (dev->accel_bpp == 24))
                                         dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
                                     else
                                         dev->accel.dest = dev->accel.cy * dev->pitch;
@@ -2923,7 +2923,7 @@ rect_fill:
                                     else
                                         dev->accel.cy--;
 
-                                    if ((dev->local >= 2) && dev->accel.ge_offset && (dev->accel_bpp == 24))
+                                    if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && (dev->accel_bpp == 24))
                                         dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
                                     else
                                         dev->accel.dest = dev->accel.cy * dev->pitch;
@@ -2990,7 +2990,7 @@ rect_fill:
                                     else
                                         dev->accel.cy--;
 
-                                    if ((dev->local >= 2) && dev->accel.ge_offset && (dev->accel_bpp == 24))
+                                    if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && (dev->accel_bpp == 24))
                                         dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
                                     else
                                         dev->accel.dest = dev->accel.cy * dev->pitch;
@@ -3685,7 +3685,7 @@ bitblt:
                             }
                         }
                     } else {
-                        if ((dev->accel_bpp == 24) && (dev->local >= 2) && (dev->accel.cmd == 0xc2b5)) {
+                        if ((dev->accel_bpp == 24) && ((dev->local & 0xff) >= 0x02) && (dev->accel.cmd == 0xc2b5)) {
                             int64_t cx;
                             int64_t dx;
 

--- a/src/video/vid_cl54xx.c
+++ b/src/video/vid_cl54xx.c
@@ -651,6 +651,23 @@ gd54xx_is_5434(svga_t *svga)
 }
 
 static void
+gd54xx_set_svga_fast(gd54xx_t *gd54xx)
+{
+    svga_t   *svga   = &gd54xx->svga;
+
+    if ((svga->crtc[0x27] == CIRRUS_ID_CLGD5422) || (svga->crtc[0x27] == CIRRUS_ID_CLGD5424))
+        svga->fast = ((svga->gdcreg[8] == 0xff) && !(svga->gdcreg[3] & 0x18) &&
+                      !svga->gdcreg[1]) &&
+                      ((svga->chain4 && svga->packed_chain4) || svga->fb_only) &&
+                      !(svga->adv_flags & FLAG_ADDR_BY8);
+                      /* TODO: needs verification on other Cirrus chips */
+    else
+        svga->fast = ((svga->gdcreg[8] == 0xff) && !(svga->gdcreg[3] & 0x18) &&
+                     !svga->gdcreg[1]) && ((svga->chain4 && svga->packed_chain4) ||
+                     svga->fb_only);
+}
+
+static void
 gd54xx_out(uint16_t addr, uint8_t val, void *priv)
 {
     gd54xx_t *gd54xx = (gd54xx_t *) priv;
@@ -793,13 +810,14 @@ gd54xx_out(uint16_t addr, uint8_t val, void *priv)
                         break;
                     case 0x07:
                         svga->packed_chain4 = svga->seqregs[7] & 1;
-                        svga_recalctimings(svga);
                         if (gd54xx_is_5422(svga))
                             gd543x_recalc_mapping(gd54xx);
                         else
                             svga->seqregs[svga->seqaddr] &= 0x0f;
                         if (svga->crtc[0x27] >= CIRRUS_ID_CLGD5429)
                             svga->set_reset_disabled = svga->seqregs[7] & 1;
+                        gd54xx_set_svga_fast(gd54xx);
+                        svga_recalctimings(svga);
                         break;
                     case 0x17:
                         if (gd54xx_is_5422(svga))
@@ -919,10 +937,8 @@ gd54xx_out(uint16_t addr, uint8_t val, void *priv)
                         break;
                 }
 
-                if ((svga->crtc[0x27] == CIRRUS_ID_CLGD5422) || (svga->crtc[0x27] == CIRRUS_ID_CLGD5424))
-                    svga->fast = (svga->gdcreg[8] == 0xff && !(svga->gdcreg[3] & 0x18) && !svga->gdcreg[1]) && ((svga->chain4 && svga->packed_chain4) || svga->fb_only) && !(svga->adv_flags & FLAG_ADDR_BY8); /*TODO: needs verification on other Cirrus chips*/
-                else
-                    svga->fast = (svga->gdcreg[8] == 0xff && !(svga->gdcreg[3] & 0x18) && !svga->gdcreg[1]) && ((svga->chain4 && svga->packed_chain4) || svga->fb_only);
+                gd54xx_set_svga_fast(gd54xx);
+
                 if (((svga->gdcaddr == 5) && ((val ^ o) & 0x70)) || ((svga->gdcaddr == 6) && ((val ^ o) & 1)))
                     svga_recalctimings(svga);
             } else {

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -219,7 +219,7 @@ svga_out(uint16_t addr, uint8_t val, void *priv)
                 dev->on[1] = dev->on[0];
             }
 
-            svga_log("3C3: XGA ON = %d.\n", xga->on);
+            svga_log("3C3: VGA ON = %d.\n", val & 0x01);
             vga_on = val & 0x01;
             break;
         case 0x3c4:
@@ -611,7 +611,7 @@ svga_recalctimings(svga_t *svga)
 
     svga->clock = (svga->vidclock) ? VGACONST2 : VGACONST1;
 
-    svga->lowres = svga->attrregs[0x10] & 0x40;
+    svga->lowres = !!(svga->attrregs[0x10] & 0x40);
 
     svga->interlace = 0;
 
@@ -742,7 +742,7 @@ svga_recalctimings(svga_t *svga)
     }
 
     if (ibm8514_active && (svga->dev8514 != NULL)) {
-        if (!dev->local)
+        if ((dev->local & 0xff) == 0x00)
             ibm8514_recalctimings(svga);
     }
 


### PR DESCRIPTION
Summary
=======
1. Update svga->fast to account for packed chain mode toggles, fixes issues on Descent II for DOS using the Cirrus cards.
2. Re-organized ATI Mach8/32 LFB access as well as 8514/A/ATI mode toggles, should end the video mode issues once and for all.
3. Fixed a small but major pattern issue with IBM OS/2 1.30.1's XGA driver (not .2, which is fine as is).


Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
