### PR TITLE
Mach8/32 fixes (again):

### DIFF
--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -4036,7 +4036,7 @@ ibm8514_render_ABGR8888(svga_t *svga)
 }
 
 void
-ibm8514_render_RGBA8888(svga_t *svga)
+ibm8514_render_32bpp(svga_t *svga)
 {
     ibm8514_t *dev = (ibm8514_t *) svga->dev8514;
     int        x;
@@ -4046,7 +4046,7 @@ ibm8514_render_RGBA8888(svga_t *svga)
     if ((dev->displine + svga->y_add) < 0)
         return;
 
-    if (dev->changedvram[dev->ma >> 12] || dev->changedvram[(dev->ma >> 12) + 1] || svga->fullchange) {
+    if (dev->changedvram[dev->ma >> 12] || dev->changedvram[(dev->ma >> 12) + 1] || dev->changedvram[(dev->ma >> 12) + 2] || svga->fullchange) {
         p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
 
         if (dev->firstline_draw == 2000)
@@ -4055,7 +4055,7 @@ ibm8514_render_RGBA8888(svga_t *svga)
 
         for (x = 0; x <= dev->h_disp; x++) {
             dat  = *(uint32_t *) (&dev->vram[(dev->ma + (x << 2)) & dev->vram_mask]);
-            *p++ = dat >> 8;
+            p[x] = dat & 0xffffff;
         }
         dev->ma += (x * 4);
         dev->ma &= dev->vram_mask;


### PR DESCRIPTION
Summary
=======
1. Fixed wrong setting of highres and lowres mode of 8bpp, makes Transport Tycoon run properly on these ATI cards again.
2. 32-bit (RGBA) True Color is actually supported on the Mach32, but barely used, and the original code was wrong. This fix makes 32-bit True Color render the right colors.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
