### PR TITLE
Fix the initialization of the color cursor regs (ATI Mach32)

### DIFF
--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -5213,7 +5213,6 @@ mach32_hwcursor_draw(svga_t *svga, int displine)
             color0 = ((mach->ext_cur_col_0_r << 16) | (mach->ext_cur_col_0_g << 8) | mach->cursor_col_0);
             color1 = ((mach->ext_cur_col_1_r << 16) | (mach->ext_cur_col_1_g << 8) | mach->cursor_col_1);
             break;
-            break;
     }
 
     if (dev->interlace && dev->hwcursor_oddeven)

--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -5195,6 +5195,7 @@ mach32_hwcursor_draw(svga_t *svga, int displine)
 
     mach_log("BPP=%d.\n", dev->accel_bpp);
     switch (dev->accel_bpp) {
+        default:
         case 8:
             color0 = dev->pallook[mach->cursor_col_0];
             color1 = dev->pallook[mach->cursor_col_1];
@@ -5212,7 +5213,6 @@ mach32_hwcursor_draw(svga_t *svga, int displine)
             color0 = ((mach->ext_cur_col_0_r << 16) | (mach->ext_cur_col_0_g << 8) | mach->cursor_col_0);
             color1 = ((mach->ext_cur_col_1_r << 16) | (mach->ext_cur_col_1_g << 8) | mach->cursor_col_1);
             break;
-        default:
             break;
     }
 


### PR DESCRIPTION
Summary
=======
See title.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
