### PR TITLE
Correct undevbranching of the Matrox Millenium

### DIFF
--- a/src/include/86box/video.h
+++ b/src/include/86box/video.h
@@ -433,7 +433,7 @@ extern const device_t pgc_device;
 
 /* Matrox MGA */
 extern const device_t millennium_device;
-#    if defined(DEV_BRANCH)
+#    if defined(DEV_BRANCH) && defined(USE_MGA)
 extern const device_t mystique_device;
 extern const device_t mystique_220_device;
 #    endif

--- a/src/video/CMakeLists.txt
+++ b/src/video/CMakeLists.txt
@@ -28,6 +28,10 @@ add_library(vid OBJECT agpgart.c video.c vid_table.c vid_cga.c vid_cga_comp.c
     vid_ibm_rgb528_ramdac.c vid_sdac_ramdac.c vid_ogc.c vid_mga.c vid_nga.c
     vid_tvp3026_ramdac.c vid_att2xc498_ramdac.c vid_xga.c)
 
+if(MGA)
+    target_compile_definitions(vid PRIVATE USE_MGA)
+endif()
+
 if(VGAWONDER)
     target_compile_definitions(vid PRIVATE USE_VGAWONDER)
 endif()

--- a/src/video/vid_table.c
+++ b/src/video/vid_table.c
@@ -205,7 +205,7 @@ video_cards[] = {
     { &s3_diamond_stealth_4000_pci_device            },
     { &s3_trio3d2x_pci_device                        },
     { &millennium_device                             },
-#if defined(DEV_BRANCH)
+#if defined(DEV_BRANCH) && defined(USE_MGA)
     { &mystique_device                               },
     { &mystique_220_device                           },
 #endif

--- a/src/win/Makefile.mingw
+++ b/src/win/Makefile.mingw
@@ -498,7 +498,6 @@ ifeq ($(DEV_BRANCH), y)
 
  ifeq ($(MGA), y)
   OPTS     += -DUSE_MGA
-  DEVBROBJ += vid_mga.o
  endif
 
  ifeq ($(OPEN_AT), y)
@@ -765,6 +764,7 @@ VIDOBJ := agpgart.o video.o \
           vid_s3.o vid_s3_virge.o \
           vid_ibm_rgb528_ramdac.o vid_sdac_ramdac.o \
           vid_ogc.o \
+          vid_mga.o \
           vid_nga.o \
           vid_tvp3026_ramdac.o \
           vid_xga.o


### PR DESCRIPTION
Summary
=======
Correct undevbranching of the Matrox Millenium

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
