### PR TITLE
Disable blink in 8bpp modes on MGA; Re-instate main 8bpp hires renderer

### DIFF
--- a/src/include/86box/vid_svga.h
+++ b/src/include/86box/vid_svga.h
@@ -246,6 +246,11 @@ typedef struct svga_t {
       addresses are shifted to match*/
     int packed_chain4;
 
+    /*Disable 8bpp blink mode - some cards support it, some don't, it's a weird mode
+      If mode 13h appears in a reddish-brown background (0x88) with dark green text (0x8F),
+      you should set this flag when entering that mode*/
+    int disable_blink;
+
     /*Force CRTC to dword mode, regardless of CR14/CR17. Required for S3 enhanced mode*/
     int force_dword_mode;
 

--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -935,7 +935,7 @@ mystique_recalctimings(svga_t *svga)
         } else {
             switch (svga->bpp) {
                 case 8:
-                    svga->render = svga_render_8bpp_incompatible_highres;
+                    svga->render = svga_render_8bpp_highres;
                     break;
                 case 15:
                     svga->render = svga_render_15bpp_highres;
@@ -958,6 +958,8 @@ mystique_recalctimings(svga_t *svga)
         if (mystique->type >= MGA_1064SG)
             svga->bpp = 8;
     }
+
+    svga->disable_blink = (svga->bpp > 4);
 }
 
 static void

--- a/src/video/vid_svga_render.c
+++ b/src/video/vid_svga_render.c
@@ -457,7 +457,7 @@ svga_render_indexed_gfx(svga_t *svga, bool highres, bool combine8bits)
     uint32_t  changed_offset;
 
     const bool blinked   = svga->blink & 0x10;
-    const bool attrblink = ((svga->attrregs[0x10] & 0x08) != 0);
+    const bool attrblink = (!svga->disable_blink) && ((svga->attrregs[0x10] & 0x08) != 0);
 
     /*
        The following is likely how it works on an IBM VGA - that is, it works with its BIOS.


### PR DESCRIPTION
Summary
=======
This should fix the blinking in 8bpp modes on the Matrix Millennium.

What I've been using to test this:

In a non-CJK MS-DOS 6.2x, run `debug`, then:
```
a100
mov ax, 13
int 10
int 3

g=100
q
```

Now you're in mode 13h, run `qbasic` and then exit it. (esc, alt, f, x - all separate keys)

The background should be black. If it's reddish-brown, then you've ended up in the weird thing that is 8bpp blink mode, which is supported by some VGA clones but not all. The Matrox Millennium card sets the blink bit, so what this PR does is it tells the renderer to ignore the blink bit when bpp > 4 on a Matrox card.

Checklist
=========
* [x] I have discussed this with core contributors already

References
==========
None