### PR TITLE
MGA fixes 2:

### DIFF
--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -721,12 +721,6 @@ mystique_out(uint16_t addr, uint8_t val, void *priv)
                 mystique->crtcext_regs[mystique->crtcext_idx] = val;
             if (mystique->crtcext_idx == 1)
                 svga->dpms = !!(val & 0x30);
-            if (mystique->crtcext_idx < 4) {
-                if (mystique->crtcext_idx != 3) {
-                    svga->fullchange = changeframecount;
-                    svga_recalctimings(svga);
-                }
-            }
             if (mystique->crtcext_idx == 4) {
                 if (svga->gdcreg[6] & 0xc) {
                     /*64k banks*/
@@ -947,8 +941,8 @@ mystique_recalctimings(svga_t *svga)
                     break;
             }
         }
+        svga->packed_chain4 = 1;
         svga->line_compare = mystique_line_compare;
-        svga->packed_chain4 = !svga->chain4;
     } else {
         svga->packed_chain4 = 0;
         svga->line_compare  = NULL;
@@ -958,8 +952,8 @@ mystique_recalctimings(svga_t *svga)
 
     svga->fb_only       = svga->packed_chain4;
     svga->disable_blink = (svga->bpp > 4);
-#if 0
-    pclog("PackedChain4=%d, chain4=%x, fast=%x, bit6 attrreg10=%02x, bits 5-6 gdcreg5=%02x.\n", svga->packed_chain4, svga->chain4, svga->fast, svga->attrregs[0x10] & 0x40, svga->gdcreg[5] & 0x60);
+#if 1
+    pclog("PackedChain4=%d, chain4=%x, fast=%x, bit6 attrreg10=%02x, bits 5-6 gdcreg5=%02x, extmode=%02x.\n", svga->packed_chain4, svga->chain4, svga->fast, svga->attrregs[0x10] & 0x40, svga->gdcreg[5] & 0x60, mystique->pci_regs[0x41] & 1, mystique->crtcext_regs[3] & CRTCX_R3_MGAMODE);
 #endif
 }
 

--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -952,7 +952,7 @@ mystique_recalctimings(svga_t *svga)
 
     svga->fb_only       = svga->packed_chain4;
     svga->disable_blink = (svga->bpp > 4);
-#if 1
+#if 0
     pclog("PackedChain4=%d, chain4=%x, fast=%x, bit6 attrreg10=%02x, bits 5-6 gdcreg5=%02x, extmode=%02x.\n", svga->packed_chain4, svga->chain4, svga->fast, svga->attrregs[0x10] & 0x40, svga->gdcreg[5] & 0x60, mystique->pci_regs[0x41] & 1, mystique->crtcext_regs[3] & CRTCX_R3_MGAMODE);
 #endif
 }


### PR DESCRIPTION
Summary
=======
1. Reverted the packed chain4 and fb_only sides to 1 when extended mode is set, but with the call to svga_recalctimings removed from port 0x3df due to mode issues, this should fix all the MGA mode issues I know.
2. Cleaned up the rendering order in svga_recalctimings, especially 4bpp and 8bpp.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
