### PR TITLE
ESC/P: make the dot matrix font optional

### DIFF
--- a/src/printer/prt_escp.c
+++ b/src/printer/prt_escp.c
@@ -545,6 +545,17 @@ update_font(escp_t *dev)
     if (FT_New_Face(ft_lib, path, 0, &dev->fontface)) {
         escp_log("ESC/P: unable to load font '%s'\n", path);
         dev->fontface = NULL;
+
+        /* Try to fall back to Courier in case the dot matrix font is absent. */
+        if (!strcmp(fn, FONT_FILE_DOTMATRIX)) {
+            strcpy(path, dev->fontpath);
+            path_slash(path);
+            strcat(path, FONT_FILE_COURIER);
+            if (FT_New_Face(ft_lib, path, 0, &dev->fontface)) {
+                escp_log("ESC/P: unable to load font '%s'\n", path);
+                dev->fontface = NULL;
+            }
+        }
     }
 
     if (!dev->multipoint_mode) {

--- a/src/printer/prt_escp.c
+++ b/src/printer/prt_escp.c
@@ -531,7 +531,7 @@ update_font(escp_t *dev)
                 fn = FONT_FILE_OCRB;
                 break;
             default:
-                fn = FONT_FILE_DOTMATRIX;
+                fn = FONT_FILE_ROMAN;
         }
 
     /* Create a full pathname for the ROM file. */


### PR DESCRIPTION
Summary
=======
Allow ESC/P printer emulation to operate without the dot matrix font, which has unclear license status, by substituting it with Courier for draft-quality printing if dotmatrix.ttf is not found, and using Roman instead as a fallback for unsupported LQ typefaces.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

