### PR TITLE
More MGA fixes.

### DIFF
--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -636,14 +636,12 @@ static void wake_fifo_thread(mystique_t *mystique);
 static void wait_fifo_idle(mystique_t *mystique);
 static void mystique_queue(mystique_t *mystique, uint32_t addr, uint32_t val, uint32_t type);
 
-#if 0
 static uint8_t  mystique_readb_linear(uint32_t addr, void *priv);
 static uint16_t mystique_readw_linear(uint32_t addr, void *priv);
 static uint32_t mystique_readl_linear(uint32_t addr, void *priv);
 static void     mystique_writeb_linear(uint32_t addr, uint8_t val, void *priv);
 static void     mystique_writew_linear(uint32_t addr, uint16_t val, void *priv);
 static void     mystique_writel_linear(uint32_t addr, uint32_t val, void *priv);
-#endif
 
 static void mystique_recalc_mapping(mystique_t *mystique);
 static int  mystique_line_compare(svga_t *svga);
@@ -994,7 +992,7 @@ mystique_recalc_mapping(mystique_t *mystique)
     if (mystique->pci_regs[0x41] & 1) {
         switch (svga->gdcreg[6] & 0x0C) {
             case 0x0: /*128k at A0000*/
-                mem_mapping_set_addr(&svga->mapping, 0xa0000, 0x10000);
+                mem_mapping_set_addr(&svga->mapping, 0xa0000, 0x20000);
                 svga->banked_mask = 0x1ffff;
                 break;
             case 0x4: /*64k at A0000*/
@@ -2560,11 +2558,13 @@ mystique_accel_iload_write_l(UNUSED(uint32_t addr), uint32_t val, void *priv)
     }
 }
 
-#if 0
 static uint8_t
 mystique_readb_linear(uint32_t addr, void *priv)
 {
     const svga_t *svga = (svga_t *) priv;
+
+    if (!svga->fast)
+        return svga_read_linear(addr, priv);
 
     cycles -= video_timing_read_b;
 
@@ -2608,6 +2608,11 @@ mystique_writeb_linear(uint32_t addr, uint8_t val, void *priv)
 {
     svga_t *svga = (svga_t *) priv;
 
+    if (!svga->fast) {
+        svga_write_linear(addr, val, priv);
+        return;
+    }
+
     cycles -= video_timing_write_b;
 
     addr &= svga->decode_mask;
@@ -2647,7 +2652,6 @@ mystique_writel_linear(uint32_t addr, uint32_t val, void *priv)
     svga->changedvram[addr >> 12]   = svga->monitor->mon_changeframecount;
     *(uint32_t *) &svga->vram[addr] = val;
 }
-#endif
 
 static void
 run_dma(mystique_t *mystique)
@@ -2711,7 +2715,7 @@ run_dma(mystique_t *mystique)
                         mystique->dma.pri_state = (mystique->dma.pri_state + 1) & 3;
 
                         if (mystique->dma.state == DMA_STATE_SEC) {
-                            mystique->dma.pri_state = 0;                            
+                            mystique->dma.pri_state = 0;
                             mystique->dma.words_expected = 0;
                         }
                         else if ((mystique->dma.primaddress & DMA_ADDR_MASK) >= (mystique->dma.primend & DMA_ADDR_MASK)) {
@@ -5652,8 +5656,8 @@ mystique_init(const device_t *info)
     mem_mapping_disable(&mystique->ctrl_mapping);
 
     mem_mapping_add(&mystique->lfb_mapping, 0, 0,
-                    svga_read_linear, svga_readw_linear, svga_readl_linear,
-                    svga_write_linear, svga_writew_linear, svga_writel_linear,
+                    mystique_readb_linear, mystique_readw_linear, mystique_readl_linear,
+                    mystique_writeb_linear, mystique_writew_linear, mystique_writel_linear,
                     NULL, 0, &mystique->svga);
     mem_mapping_disable(&mystique->lfb_mapping);
 


### PR DESCRIPTION
Summary
=======
Re-introduced the mystique read/write linear functions but with a check (!svga->fast) in the byte ones to make sure the generic svga linear functions are enabled when needed, this should keep compatibility stable while also fixing the amount of memory of NT 4.0's MGA Millennium drivers.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
