### PR TITLE
MGA: More Mystique busmastering fixes

### DIFF
--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -1032,6 +1032,8 @@ mystique_update_irqs(mystique_t *mystique)
 
     if ((mystique->status & mystique->ien) & STATUS_SOFTRAPEN)
         irq = 1;
+    if ((mystique->status & mystique->ien) & STATUS_VLINEPEN)
+        irq = 1;
     if ((mystique->status & STATUS_VSYNCPEN) && (svga->crtc[0x11] & 0x30) == 0x10)
         irq = 1;
 
@@ -1442,7 +1444,7 @@ mystique_ctrl_read_b(uint32_t addr, void *priv)
                 break;
 
             case REG_IEN:
-                ret = mystique->ien & 0x64;
+                ret = mystique->ien & 0x65;
                 break;
             case REG_IEN + 1:
             case REG_IEN + 2:
@@ -1985,6 +1987,7 @@ mystique_ctrl_write_b(uint32_t addr, uint8_t val, void *priv)
     switch (addr & 0x3fff) {
         case REG_ICLEAR:
             if (val & ICLEAR_SOFTRAPICLR) {
+                //pclog("softrapiclr\n");
                 mystique->status &= ~STATUS_SOFTRAPEN;
                 mystique_update_irqs(mystique);
             }
@@ -2401,7 +2404,7 @@ mystique_accel_ctrl_write_l(uint32_t addr, uint32_t val, void *priv)
             mystique->dma.words_expected  = 0;
             mystique->endprdmasts_pending = 1;
             mystique->softrap_pending_val = val;
-            mystique->softrap_pending     = 1;
+            mystique->softrap_pending     += 1;
             break;
 
         default:
@@ -2959,16 +2962,21 @@ mystique_softrap_pending_timer(void *priv)
 
     timer_advance_u64(&mystique->softrap_pending_timer, TIMER_USEC * 100);
 
-    if (mystique->endprdmasts_pending) {
-        mystique->endprdmasts_pending = 0;
-        mystique->status |= STATUS_ENDPRDMASTS;
-    }
-    if (mystique->softrap_pending) {
-        mystique->softrap_pending = 0;
+    if (thread_test_mutex(mystique->dma.lock))
+    {
+        if (mystique->endprdmasts_pending) {
+            mystique->endprdmasts_pending = 0;
+            mystique->status |= STATUS_ENDPRDMASTS;
+        }
+        if (mystique->softrap_pending) {
+            mystique->softrap_pending--;
 
-        mystique->dma.secaddress = mystique->softrap_pending_val;
-        mystique->status |= STATUS_SOFTRAPEN;
-        mystique_update_irqs(mystique);
+            mystique->dma.secaddress = mystique->softrap_pending_val;
+            mystique->status |= STATUS_SOFTRAPEN;
+            //pclog("softrapen\n");
+            mystique_update_irqs(mystique);
+        }
+        thread_release_mutex(mystique->dma.lock);
     }
 }
 


### PR DESCRIPTION
Summary
=======
MGA: More Mystique busmastering fixes

* ~~Use mutex locking when reporting SOFTRAPEN~~
* IEN register now correctly returns values it currently holds
* Restore VLINEPEN interrupt

~~NT 4.0's OpenGL screensavers now can render around 20-40 frames before freezing.~~

Edit: 3D busmastering now works, but it is slow.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
