### PR TITLE
Qt: Application icon fixes

### DIFF
--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -194,6 +194,17 @@ main(int argc, char *argv[])
     QApplication::setFont(QFont(font_name, font_size.toInt()));
     SetCurrentProcessExplicitAppUserModelID(L"86Box.86Box");
 #endif
+
+#ifdef RELEASE_BUILD
+    app.setWindowIcon(QIcon(":/settings/win/icons/86Box-green.ico"));
+#elif defined ALPHA_BUILD
+    app.setWindowIcon(QIcon(":/settings/win/icons/86Box-red.ico"));
+#elif defined BETA_BUILD
+    app.setWindowIcon(QIcon(":/settings/win/icons/86Box-yellow.ico"));
+#else
+    app.setWindowIcon(QIcon(":/settings/win/icons/86Box-gray.ico"));
+#endif
+
     if (!pc_init_modules()) {
         ui_msgbox_header(MBX_FATAL, (void *) IDS_2121, (void *) IDS_2056);
         return 6;

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -205,6 +205,10 @@ main(int argc, char *argv[])
     app.setWindowIcon(QIcon(":/settings/win/icons/86Box-gray.ico"));
 #endif
 
+#if (!defined(Q_OS_WINDOWS) && !defined(__APPLE__))
+    app.setDesktopFileName("net.86box.86Box");
+#endif
+
     if (!pc_init_modules()) {
         ui_msgbox_header(MBX_FATAL, (void *) IDS_2121, (void *) IDS_2056);
         return 6;

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -196,15 +196,6 @@ MainWindow::MainWindow(QWidget *parent)
     auto toolbar_label = new QLabel();
     ui->toolBar->addWidget(toolbar_label);
 
-#ifdef RELEASE_BUILD
-    this->setWindowIcon(QIcon(":/settings/win/icons/86Box-green.ico"));
-#elif defined ALPHA_BUILD
-    this->setWindowIcon(QIcon(":/settings/win/icons/86Box-red.ico"));
-#elif defined BETA_BUILD
-    this->setWindowIcon(QIcon(":/settings/win/icons/86Box-yellow.ico"));
-#else
-    this->setWindowIcon(QIcon(":/settings/win/icons/86Box-gray.ico"));
-#endif
     this->setWindowFlag(Qt::MSWindowsFixedSizeDialogHint, vid_resize != 1);
     this->setWindowFlag(Qt::WindowMaximizeButtonHint, vid_resize == 1);
 


### PR DESCRIPTION
Summary
=======
* Set the window icon for the entire application, instead of just the main window; fixes dialog windows having a generic icon when the main window isn't initialized (like the standalone Settings dialog)
* Set the .desktop file name on \*nix; may possibly fix the generic icon showing up instead of 86Box's icon on Wayland

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
<https://community.kde.org/Guidelines_and_HOWTOs/Wayland_Porting_Notes#Application_Icon>