### PR TITLE
Fix Debian Woody's matroxfb's test again.

### DIFF
--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -719,10 +719,9 @@ mystique_out(uint16_t addr, uint8_t val, void *priv)
         case 0x3df:
             if (mystique->crtcext_idx == 1)
                 svga->dpms = !!(val & 0x30);
-            if (mystique->crtcext_idx < 6) {
+            if (mystique->crtcext_idx < 6)
                 mystique->crtcext_regs[mystique->crtcext_idx] = val;
-                svga_recalctimings(&mystique->svga);
-            }
+
             if (mystique->crtcext_idx == 4) {
                 if (svga->gdcreg[6] & 0xc) {
                     /*64k banks*/


### PR DESCRIPTION
Summary
=======
Don't call svga_recalctimings() on MGA's port 0x3df, fixes Debian Woody's matroxfb screen test.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
