### PR TITLE
MGA: Don't reset screen size every recalctimings

### DIFF
--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -953,7 +953,6 @@ mystique_recalctimings(svga_t *svga)
 
     svga->fb_only       = svga->packed_chain4;
     svga->disable_blink = (svga->bpp > 4);
-    reset_screen_size();
     video_force_resize_set_monitor(1, svga->monitor_index);
 #if 0
     pclog("PackedChain4=%d, chain4=%x, fast=%x, bit6 attrreg10=%02x, bits 5-6 gdcreg5=%02x, extmode=%02x.\n", svga->packed_chain4, svga->chain4, svga->fast, svga->attrregs[0x10] & 0x40, svga->gdcreg[5] & 0x60, mystique->pci_regs[0x41] & 1, mystique->crtcext_regs[3] & CRTCX_R3_MGAMODE);


### PR DESCRIPTION
Summary
=======
MGA: Don't reset screen size every recalctimings

Fixes intense resizing.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
