### PR TITLE
mystique_line_compare: Re-enable line compare behaviour

### DIFF
--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -805,7 +805,7 @@ mystique_line_compare(svga_t *svga)
     mystique->status |= STATUS_VLINEPEN;
     mystique_update_irqs(mystique);
 
-    return 0;
+    return 1;
 }
 
 static void


### PR DESCRIPTION
Summary
=======
mystique_line_compare: Re-enable line compare behaviour

Reduces glitches on M3D, although it doesn't eliminate it completely

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
