### PR TITLE
ATI Mach8/32 fixes regarding 1992 ATI Ultra drivers for Windows 3.1x:

### DIFF
--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -2940,9 +2940,11 @@ rect_fill:
                         } else {
                             while (count-- && dev->accel.sy >= 0) {
                                 if (dev->accel.cx >= dev->accel.clip_left && dev->accel.cx <= clip_r && dev->accel.cy >= dev->accel.clip_top && dev->accel.cy <= clip_b) {
-                                    switch ((mix_dat & mix_mask) ? frgd_mix : bkgd_mix) {
+                                    switch (frgd_mix) {
                                         case 0:
                                             src_dat = bkgd_color;
+                                            if (!bkgd_mix && (dev->accel.cmd & 0x40) && ((dev->accel.frgd_mix & 0x1f) == 7) && ((dev->accel.bkgd_mix & 0x1f) == 3) && !dev->bpp && (bkgd_color == 0x00)) /*For some reason, the September 1992 Mach8/32 drivers for Win3.x don't set the background colors properly.*/
+                                                src_dat = frgd_color;
                                             break;
                                         case 1:
                                             src_dat = frgd_color;
@@ -2962,7 +2964,7 @@ rect_fill:
 
                                     if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
                                         old_dest_dat = dest_dat;
-                                        MIX(mix_dat & mix_mask, dest_dat, src_dat);
+                                        MIX(1, dest_dat, src_dat);
                                         dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
                                         WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
                                     }
@@ -3740,7 +3742,7 @@ bitblt:
                                     case 3:
                                         READ(dev->accel.src + dev->accel.cx, src_dat);
                                         if (pixcntl == 3) {
-                                            if (dev->accel.cmd & 0x10) {
+                                            if ((dev->accel.cmd & 0x10) && !(dev->accel.cmd & 0x40)) {
                                                 src_dat = ((src_dat & rd_mask) == rd_mask);
                                             }
                                         }

--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -3628,7 +3628,9 @@ mach_accel_out(uint16_t port, uint8_t val, mach_t *mach)
         case 0x6e8:
         case 0x6e9:
             if (!(port & 1)) {
-                dev->hdisp = val;
+                if (!dev->on[0] || !dev->on[1])
+                    dev->hdisp = val;
+
                 mach_log("ATI 8514/A: H_DISP write 06E8 = %d\n", dev->hdisp + 1);
             }
             svga_recalctimings(svga);
@@ -3653,8 +3655,10 @@ mach_accel_out(uint16_t port, uint8_t val, mach_t *mach)
 
         case 0x16e8:
         case 0x16e9:
-            WRITE8(port, dev->vdisp, val);
-            dev->vdisp &= 0x1fff;
+            if (!dev->on[0] || !dev->on[1]) {
+                WRITE8(port, dev->vdisp, val);
+                dev->vdisp &= 0x1fff;
+            }
             svga_recalctimings(svga);
             break;
 


### PR DESCRIPTION
Summary
=======
1. For some reason, background colors were always black under those drivers in 8bpp mode, added a tweak to fix it (as well as Clock colors).
2. Likewise for the red scrolling in pbrush or write, added a tweak to its bitblt read mask.
3. Don't call svga_recalctimings in the hdisp/vdisp ports directly, fixes screen size on said drivers without affecting other stuff.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
