### PR TITLE
Matrox Mystique: Fix display flickering issues for real

### DIFF
--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -722,6 +722,28 @@ mystique_out(uint16_t addr, uint8_t val, void *priv)
             if (mystique->crtcext_idx < 6)
                 mystique->crtcext_regs[mystique->crtcext_idx] = val;
 
+            if (mystique->crtcext_idx == 0 && (mystique->crtcext_regs[3] & CRTCX_R3_MGAMODE))
+            {
+                svga->rowoffset     = svga->crtc[0x13] | ((mystique->crtcext_regs[0] & CRTCX_R0_OFFSET_MASK) << 4);
+                if (mystique->type >= MGA_1064SG)
+                    svga->rowoffset <<= 1;
+                svga->ma_latch      = ((mystique->crtcext_regs[0] & CRTCX_R0_STARTADD_MASK) << 16) | (svga->crtc[0xc] << 8) | svga->crtc[0xd];
+                if (mystique->pci_regs[0x41] & (OPTION_INTERLEAVE >> 8)) {
+                    svga->rowoffset <<= 1;
+                    svga->ma_latch <<= 1;
+                }
+                if (mystique->type >= MGA_1064SG) {
+                    svga->ma_latch <<= 1;
+                    if (svga->ma_latch != mystique->ma_latch_old) {
+                        if (svga->interlace && svga->oddeven)
+                            svga->maback = (svga->maback - (mystique->ma_latch_old << 2)) + (svga->ma_latch << 2) + (svga->rowoffset << 1);
+                        else
+                            svga->maback = (svga->maback - (mystique->ma_latch_old << 2)) + (svga->ma_latch << 2);
+                        mystique->ma_latch_old = svga->ma_latch;
+                    }
+                }
+            }
+
             if (mystique->crtcext_idx == 4) {
                 if (svga->gdcreg[6] & 0xc) {
                     /*64k banks*/
@@ -886,6 +908,7 @@ mystique_recalctimings(svga_t *svga)
         if (mystique->type >= MGA_1064SG) {
             /*Mystique, unlike most SVGA cards, allows display start to take
               effect mid-screen*/
+            svga->ma_latch <<= 1;
 #ifdef CHANGE_MA
             if (svga->ma_latch != mystique->ma_latch_old) {
                 if (svga->interlace && svga->oddeven)
@@ -2767,7 +2790,7 @@ run_dma(mystique_t *mystique)
             case DMA_STATE_SEC:
                 switch (mystique->dma.secaddress & DMA_MODE_MASK) {
                     case DMA_MODE_REG:
-                        if ((mystique->dma.secaddress & DMA_ADDR_MASK) == (mystique->dma.secend & DMA_ADDR_MASK)) {
+                        if ((mystique->dma.secaddress & DMA_ADDR_MASK) >= (mystique->dma.secend & DMA_ADDR_MASK)) {
                             if ((mystique->dma.primaddress & DMA_ADDR_MASK) == (mystique->dma.primend & DMA_ADDR_MASK)) {
                                 mystique->endprdmasts_pending = 1;
                                 mystique->dma.state           = DMA_STATE_IDLE;
@@ -2786,7 +2809,7 @@ run_dma(mystique_t *mystique)
                             words_transferred++;
                         }
 
-                        if ((mystique->dma.secaddress & DMA_ADDR_MASK) == (mystique->dma.secend & DMA_ADDR_MASK)) {
+                        if ((mystique->dma.secaddress & DMA_ADDR_MASK) >= (mystique->dma.secend & DMA_ADDR_MASK)) {
                             if ((mystique->dma.primaddress & DMA_ADDR_MASK) == (mystique->dma.primend & DMA_ADDR_MASK)) {
                                 mystique->endprdmasts_pending = 1;
                                 mystique->dma.state           = DMA_STATE_IDLE;
@@ -2820,7 +2843,7 @@ run_dma(mystique_t *mystique)
                         mystique->dma.sec_state = (mystique->dma.sec_state + 1) & 3;
 
                         words_transferred++;
-                        if ((mystique->dma.secaddress & DMA_ADDR_MASK) == (mystique->dma.secend & DMA_ADDR_MASK)) {
+                        if ((mystique->dma.secaddress & DMA_ADDR_MASK) >= (mystique->dma.secend & DMA_ADDR_MASK)) {
                             if ((mystique->dma.primaddress & DMA_ADDR_MASK) == (mystique->dma.primend & DMA_ADDR_MASK)) {
                                 mystique->endprdmasts_pending = 1;
                                 mystique->dma.state           = DMA_STATE_IDLE;
@@ -2837,7 +2860,7 @@ run_dma(mystique_t *mystique)
                     case DMA_MODE_BLIT:
                         {
                             uint32_t val;
-                            if ((mystique->dma.secaddress & DMA_ADDR_MASK) == (mystique->dma.secend & DMA_ADDR_MASK)) {
+                            if ((mystique->dma.secaddress & DMA_ADDR_MASK) >= (mystique->dma.secend & DMA_ADDR_MASK)) {
                                 if ((mystique->dma.primaddress & DMA_ADDR_MASK) == (mystique->dma.primend & DMA_ADDR_MASK)) {
                                     mystique->endprdmasts_pending = 1;
                                     mystique->dma.state           = DMA_STATE_IDLE;
@@ -2857,7 +2880,7 @@ run_dma(mystique_t *mystique)
                                 blit_iload_write(mystique, val, 32);
 
                             words_transferred++;
-                            if ((mystique->dma.secaddress & DMA_ADDR_MASK) == (mystique->dma.secend & DMA_ADDR_MASK)) {
+                            if ((mystique->dma.secaddress & DMA_ADDR_MASK) >= (mystique->dma.secend & DMA_ADDR_MASK)) {
                                 if ((mystique->dma.primaddress & DMA_ADDR_MASK) == (mystique->dma.primend & DMA_ADDR_MASK)) {
                                     mystique->endprdmasts_pending = 1;
                                     mystique->dma.state           = DMA_STATE_IDLE;

--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -725,8 +725,7 @@ mystique_out(uint16_t addr, uint8_t val, void *priv)
             if (mystique->crtcext_idx == 0 && (mystique->crtcext_regs[3] & CRTCX_R3_MGAMODE))
             {
                 svga->rowoffset     = svga->crtc[0x13] | ((mystique->crtcext_regs[0] & CRTCX_R0_OFFSET_MASK) << 4);
-                if (mystique->type >= MGA_1064SG)
-                    svga->rowoffset <<= 1;
+                svga->rowoffset <<= 1;
                 svga->ma_latch      = ((mystique->crtcext_regs[0] & CRTCX_R0_STARTADD_MASK) << 16) | (svga->crtc[0xc] << 8) | svga->crtc[0xd];
                 if (mystique->pci_regs[0x41] & (OPTION_INTERLEAVE >> 8)) {
                     svga->rowoffset <<= 1;


### PR DESCRIPTION
Summary
=======
Matrox Mystique: Fix display flickering issues for real

Direct3D tests under Windows 95 do not flicker anymore, and the MSICUBE sample program renders correctly.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
