### PR TITLE
More ATI changes plus one IBM 8514/A fix:

### DIFF
--- a/src/include/86box/vid_svga.h
+++ b/src/include/86box/vid_svga.h
@@ -289,7 +289,7 @@ extern uint8_t ibm8514_ramdac_in(uint16_t port, void *priv);
 extern void    ibm8514_ramdac_out(uint16_t port, uint8_t val, void *priv);
 extern int     ibm8514_cpu_src(svga_t *svga);
 extern int     ibm8514_cpu_dest(svga_t *svga);
-extern void    ibm8514_accel_out_pixtrans(svga_t *svga, uint16_t port, uint16_t val, int len);
+extern void    ibm8514_accel_out_pixtrans(svga_t *svga, uint16_t port, uint32_t val, int len);
 extern void    ibm8514_short_stroke_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, svga_t *svga, uint8_t ssv, int len);
 extern void    ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, svga_t *svga, int len);
 

--- a/src/include/86box/vid_svga.h
+++ b/src/include/86box/vid_svga.h
@@ -128,6 +128,8 @@ typedef struct svga_t {
     int hblank_sub;
     int hblank_end_val;
     int hblank_end_len;
+    int packed_4bpp;
+    int ati_4color;
 
     /*The three variables below allow us to implement memory maps like that seen on a 1MB Trio64 :
       0MB-1MB - VRAM

--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -221,7 +221,7 @@ ibm8514_cpu_dest(svga_t *svga)
 }
 
 void
-ibm8514_accel_out_pixtrans(svga_t *svga, UNUSED(uint16_t port), uint16_t val, int len)
+ibm8514_accel_out_pixtrans(svga_t *svga, UNUSED(uint16_t port), uint32_t val, int len)
 {
     ibm8514_t *dev       = (ibm8514_t *) svga->dev8514;
     uint8_t    nibble    = 0;
@@ -1298,8 +1298,9 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
     /*Bit 4 of the Command register is the draw yes bit, which enables writing to memory/reading from memory when enabled.
       When this bit is disabled, no writing to memory/reading from memory is allowed. (This bit is almost meaningless on
       the NOP command)*/
-    if (dev->accel.cmd == 0x53b1 && !cpu_dat)
-        ibm8514_log("CMD8514: CMD=%d, full=%04x, pixcntl=%x, count=%d, frgdmix = %02x, bkgdmix = %02x, polygon=%x, cpu=%08x, frgdmix=%02x, bkgdmix=%02x.\n", cmd, dev->accel.cmd, pixcntl, count, frgd_mix, bkgd_mix, dev->accel.multifunc[0x0a] & 6, cpu_dat, dev->accel.frgd_mix, dev->accel.bkgd_mix);
+    if (dev->accel.cmd == 0x43b3) {
+        ibm8514_log("CMD8514: CMD=%d, full=%04x, pixcntl=%x, count=%d, frcolor=%02x, bkcolor=%02x, polygon=%x, cpu=%08x, frgdmix=%02x, bkgdmix=%02x.\n", cmd, dev->accel.cmd, pixcntl, count, frgd_color, bkgd_color, dev->accel.multifunc[0x0a] & 6, cpu_dat, dev->accel.frgd_mix, dev->accel.bkgd_mix);
+    }
 
     switch (cmd) {
         case 0: /*NOP (Short Stroke Vectors)*/
@@ -3758,7 +3759,6 @@ bitblt:
                                     old_dest_dat = dest_dat;
                                     MIX(mix_dat & mix_mask, dest_dat, src_dat);
                                     dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
-
                                     if (dev->accel.cmd & 4) {
                                         if (dev->accel.sx > 0) {
                                             WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
@@ -4356,6 +4356,7 @@ ibm8514_init(const device_t *info)
     dev->changedvram = calloc(dev->vram_size >> 12, 1);
     dev->vram_mask   = dev->vram_size - 1;
     dev->map8        = dev->pallook;
+    dev->local       = 0;
 
     dev->type     = info->flags;
     dev->bpp      = 0;

--- a/src/video/vid_ati18800.c
+++ b/src/video/vid_ati18800.c
@@ -186,8 +186,22 @@ ati18800_recalctimings(svga_t *svga)
         svga->gdcreg[5] &= ~0x40;
     }
 
-    if (ati18800->regs[0xb0] & 6)
+    if (ati18800->regs[0xb0] & 6) {
         svga->gdcreg[5] |= 0x40;
+        if ((ati18800->regs[0xb6] & 0x18) >= 0x10)
+            svga->packed_4bpp = 1;
+        else
+            svga->packed_4bpp = 0;
+    } else
+        svga->packed_4bpp = 0;
+
+    if ((ati18800->regs[0xb6] & 0x18) == 8) {
+        svga->hdisp <<= 1;
+        svga->htotal <<= 1;
+        svga->ati_4color = 1;
+    } else
+        svga->ati_4color = 0;
+
 
     if (!svga->scrblank && (svga->crtc[0x17] & 0x80) && svga->attr_palette_enable) {
          if ((svga->gdcreg[6] & 1) || (svga->attrregs[0x10] & 1)) {
@@ -215,8 +229,10 @@ ati18800_recalctimings(svga_t *svga)
                                 svga->render = svga_render_8bpp_lowres;
                             else {
                                 svga->render = svga_render_8bpp_highres;
-                                svga->ma_latch <<= 1;
-                                svga->rowoffset <<= 1;
+                                if (!svga->packed_4bpp) {
+                                    svga->ma_latch <<= 1;
+                                    svga->rowoffset <<= 1;
+                                }
                             }
                             break;
                     }

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -116,6 +116,7 @@ svga_out(uint16_t addr, uint8_t val, void *priv)
     xga_t     *xga = (xga_t *) svga->xga;
     uint8_t    o;
     uint8_t    index;
+    uint8_t    pal4to16[16] = { 0, 7, 0x38, 0x3f, 0, 3, 4, 0x3f, 0, 2, 4, 0x3e, 0, 3, 5, 0x3f };
 
     if (!dev && (addr >= 0x2ea) && (addr <= 0x2ed))
         return;
@@ -163,7 +164,7 @@ svga_out(uint16_t addr, uint8_t val, void *priv)
         case 0x3c0:
         case 0x3c1:
             if (!svga->attrff) {
-                svga->attraddr = val & 31;
+                svga->attraddr = val & 0x1f;
                 if ((val & 0x20) != svga->attr_palette_enable) {
                     svga->fullchange          = 3;
                     svga->attr_palette_enable = val & 0x20;
@@ -172,19 +173,19 @@ svga_out(uint16_t addr, uint8_t val, void *priv)
             } else {
                 if ((svga->attraddr == 0x13) && (svga->attrregs[0x13] != val))
                     svga->fullchange = svga->monitor->mon_changeframecount;
-                o                                   = svga->attrregs[svga->attraddr & 31];
-                svga->attrregs[svga->attraddr & 31] = val;
-                if (svga->attraddr < 16) {
-                    svga->color_2bpp = (val >> 4) & 0x03;
+                o                                   = svga->attrregs[svga->attraddr & 0x1f];
+                svga->attrregs[svga->attraddr & 0x1f] = val;
+                if (svga->attraddr < 0x10)
                     svga->fullchange = svga->monitor->mon_changeframecount;
-                }
-                if (svga->attraddr == 0x10 || svga->attraddr == 0x14 || svga->attraddr < 0x10) {
-                    for (int c = 0; c < 16; c++) {
-                        if (svga->attrregs[0x10] & 0x80) {
+
+                if ((svga->attraddr == 0x10) || (svga->attraddr == 0x14) || (svga->attraddr < 0x10)) {
+                    for (int c = 0; c < 0x10; c++) {
+                        if (svga->attrregs[0x10] & 0x80)
                             svga->egapal[c] = (svga->attrregs[c] & 0xf) | ((svga->attrregs[0x14] & 0xf) << 4);
-                        } else {
+                        else if (svga->ati_4color)
+                            svga->egapal[c] = pal4to16[(c & 0x03) | ((val >> 2) & 0xc)];
+                        else
                             svga->egapal[c] = (svga->attrregs[c] & 0x3f) | ((svga->attrregs[0x14] & 0xc) << 4);
-                        }
                     }
                     svga->fullchange = svga->monitor->mon_changeframecount;
                 }


### PR DESCRIPTION
Summary
=======
1. Made the 4 color mode (67h) work properly now, including its 4 schemes on all ATI cards that support said mode.
2. Shadow set now has a true purpose for 8514/A compatibility on ATI Mach8/32.
3. Non-ATI 8514/A used to not work before because of the dev->local variable was not being set to 0 in the ibm8514_init() function, now it's fixed.

Checklist
=========
* [x] Closes #3941
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
