### PR TITLE
Joystick: Fix emulated POV hat configuration

### DIFF
--- a/src/qt/qt_joystickconfiguration.cpp
+++ b/src/qt/qt_joystickconfiguration.cpp
@@ -186,16 +186,8 @@ JoystickConfiguration::on_comboBoxDevice_currentIndexChanged(int index)
             Models::AddEntry(model, plat_joystick_state[joystick].axis[d].name, 0);
         }
 
-        int mapping = joystick_state[joystick_nr].pov_mapping[c][0];
+        int mapping = joystick_state[joystick_nr].pov_mapping[c / 2][c & 1];
         int nr_povs = plat_joystick_state[joystick].nr_povs;
-        if (mapping & POV_X)
-            cbox->setCurrentIndex((mapping & 3) * 2);
-        else if (mapping & POV_Y)
-            cbox->setCurrentIndex((mapping & 3) * 2 + 1);
-        else
-            cbox->setCurrentIndex(mapping + nr_povs * 2);
-
-        mapping = joystick_state[joystick_nr].pov_mapping[c][1];
         if (mapping & POV_X)
             cbox->setCurrentIndex((mapping & 3) * 2);
         else if (mapping & POV_Y)

--- a/src/qt/qt_settingsinput.cpp
+++ b/src/qt/qt_settingsinput.cpp
@@ -190,9 +190,9 @@ updateJoystickConfig(int type, int joystick_nr, QWidget *parent)
         for (int c = 0; c < joystick_get_button_count(type); c++) {
             joystick_state[joystick_nr].button_mapping[c] = jc.selectedButton(c);
         }
-        for (int c = 0; c < joystick_get_button_count(type); c++) {
+        for (int c = 0; c < joystick_get_pov_count(type) * 2; c += 2) {
             joystick_state[joystick_nr].pov_mapping[c][0] = get_pov(jc, c, joystick_nr);
-            joystick_state[joystick_nr].pov_mapping[c][1] = get_pov(jc, c, joystick_nr);
+            joystick_state[joystick_nr].pov_mapping[c][1] = get_pov(jc, c + 1, joystick_nr);
         }
     }
 }

--- a/src/win/win_jsconf.c
+++ b/src/win/win_jsconf.c
@@ -247,7 +247,7 @@ joystickconfig_dlgproc(HWND hdlg, UINT message, WPARAM wParam, UNUSED(LPARAM lPa
                                 joystick_state[joystick_nr].button_mapping[c] = SendMessage(h, CB_GETCURSEL, 0, 0);
                                 id += 2;
                             }
-                            for (c = 0; c < joystick_get_button_count(joystick_config_type); c++) {
+                            for (c = 0; c < joystick_get_pov_count(joystick_config_type); c++) {
                                 h                                             = GetDlgItem(hdlg, id);
                                 joystick_state[joystick_nr].pov_mapping[c][0] = get_pov(hdlg, id);
                                 id += 2;


### PR DESCRIPTION
Summary
=======
Fixes issues preventing successful emulated joystick POV hat configuration, such as hat's Y axis being set to the same host axis as the X axis, axes being reset to the stick's Y axis or another seemingly random host axis, etc.

Checklist
=========
* [x] Partially addresses #3825 (only the hat related issues)
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A
