### PR TITLE
MGA: Add Matrox Millennium II video adapter

### DIFF
--- a/src/include/86box/video.h
+++ b/src/include/86box/video.h
@@ -438,6 +438,7 @@ extern const device_t pgc_device;
 extern const device_t millennium_device;
 extern const device_t mystique_device;
 extern const device_t mystique_220_device;
+extern const device_t millennium_ii_device;
 
 /* Oak OTI-0x7 */
 extern const device_t oti037c_device;

--- a/src/video/vid_table.c
+++ b/src/video/vid_table.c
@@ -205,6 +205,7 @@ video_cards[] = {
     { &s3_diamond_stealth_4000_pci_device            },
     { &s3_trio3d2x_pci_device                        },
     { &millennium_device                             },
+    { &millennium_ii_device                          },
     { &mystique_device                               },
     { &mystique_220_device                           },
     { &tgui9440_pci_device                           },


### PR DESCRIPTION
Summary
=======
This PR adds the Matrox Millennium II video adapter.

Latest Windows 98 SE drivers are tested and working OK. Transparency under Direct3D is broken but Vintage3D website also reports broken transparency.

Note: 1920x1080 with 24 bits-per-pixel mode is very broken, and all signs point to being a driver bug, not an emulation bug.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [X] This pull request requires changes to the ROM set
  * [X] I have opened a roms pull request - https://github.com/86Box/roms/pull/221

References
==========
None.
