### PR TITLE
Millennium and Millennium 2: Enable gamma correction only for 24+ bpp

### DIFF
--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -947,9 +947,12 @@ mystique_recalctimings(svga_t *svga)
         svga->hdisp         = (svga->crtc[1] + 1) << 3;
         svga->hdisp_time    = svga->hdisp;
         svga->rowoffset     = svga->crtc[0x13] | ((mystique->crtcext_regs[0] & CRTCX_R0_OFFSET_MASK) << 4);
-        svga->lut_map       = !!(mystique->xmiscctrl & XMISCCTRL_RAMCS);
+
+        if (mystique->type != MGA_2164W && mystique->type != MGA_2064W)
+            svga->lut_map = !!(mystique->xmiscctrl & XMISCCTRL_RAMCS);
+
         if (mystique->type >= MGA_1064SG)
-            svga->ma_latch      = ((mystique->crtcext_regs[0] & CRTCX_R0_STARTADD_MASK) << 16) | (svga->crtc[0xc] << 8) | svga->crtc[0xd];
+            svga->ma_latch = ((mystique->crtcext_regs[0] & CRTCX_R0_STARTADD_MASK) << 16) | (svga->crtc[0xc] << 8) | svga->crtc[0xd];
 
         if ((mystique->pci_regs[0x41] & (OPTION_INTERLEAVE >> 8))) {
             svga->rowoffset <<= 1;

--- a/src/video/vid_tvp3026_ramdac.c
+++ b/src/video/vid_tvp3026_ramdac.c
@@ -515,6 +515,8 @@ tvp3026_recalctimings(void *priv, svga_t *svga)
     const tvp3026_ramdac_t *ramdac = (tvp3026_ramdac_t *) priv;
 
     svga->interlace = (ramdac->ccr & 0x40);
+    /* TODO: Figure out gamma correction for 15/16 bpp color. */
+    svga->lut_map = !!(svga->bpp >= 24 && (ramdac->true_color & 0xf0) != 0x00);
 }
 
 void


### PR DESCRIPTION
Summary
=======
Millennium and Millennium 2: Enable gamma correction only for 24+ bpp

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
