### PR TITLE
TVP3026: Implement gamma correction for 15/16 bpp modes

### DIFF
--- a/src/include/86box/vid_svga.h
+++ b/src/include/86box/vid_svga.h
@@ -404,12 +404,13 @@ extern float   stg_getclock(int clock, void *priv);
 extern void    tkd8001_ramdac_out(uint16_t addr, uint8_t val, void *priv, svga_t *svga);
 extern uint8_t tkd8001_ramdac_in(uint16_t addr, void *priv, svga_t *svga);
 
-extern void    tvp3026_ramdac_out(uint16_t addr, int rs2, int rs3, uint8_t val, void *priv, svga_t *svga);
-extern uint8_t tvp3026_ramdac_in(uint16_t addr, int rs2, int rs3, void *priv, svga_t *svga);
-extern void    tvp3026_recalctimings(void *priv, svga_t *svga);
-extern void    tvp3026_hwcursor_draw(svga_t *svga, int displine);
-extern float   tvp3026_getclock(int clock, void *priv);
-extern void    tvp3026_gpio(uint8_t (*read)(uint8_t cntl, void *priv), void (*write)(uint8_t cntl, uint8_t data, void *priv), void *cb_priv, void *priv);
+extern void     tvp3026_ramdac_out(uint16_t addr, int rs2, int rs3, uint8_t val, void *priv, svga_t *svga);
+extern uint8_t  tvp3026_ramdac_in(uint16_t addr, int rs2, int rs3, void *priv, svga_t *svga);
+extern uint32_t tvp3026_conv_16to32(svga_t* svga, uint16_t color, uint8_t bpp);
+extern void     tvp3026_recalctimings(void *priv, svga_t *svga);
+extern void     tvp3026_hwcursor_draw(svga_t *svga, int displine);
+extern float    tvp3026_getclock(int clock, void *priv);
+extern void     tvp3026_gpio(uint8_t (*read)(uint8_t cntl, void *priv), void (*write)(uint8_t cntl, uint8_t data, void *priv), void *cb_priv, void *priv);
 
 #    ifdef EMU_DEVICE_H
 extern const device_t ati68860_ramdac_device;

--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -6038,6 +6038,7 @@ mystique_init(const device_t *info)
         mystique->svga.ramdac            = device_add(&tvp3026_ramdac_device);
         mystique->svga.clock_gen         = mystique->svga.ramdac;
         mystique->svga.getclock          = tvp3026_getclock;
+        mystique->svga.conv_16to32       = tvp3026_conv_16to32;
         if (mystique->vram_size >= 16)
             mystique->svga.decode_mask = mystique->svga.vram_mask;
         tvp3026_gpio(mystique_tvp3026_gpio_read, mystique_tvp3026_gpio_write, mystique, mystique->svga.ramdac);
@@ -6126,7 +6127,9 @@ mystique_init(const device_t *info)
     mystique->softrap_status_read = 1;
 
     mystique->svga.vsync_callback = mystique_vsync_callback;
-    mystique->svga.conv_16to32    = mystique_conv_16to32;
+
+    if (mystique->type != MGA_2064W && mystique->type != MGA_2164W)
+        mystique->svga.conv_16to32    = mystique_conv_16to32;
 
     mystique->i2c     = i2c_gpio_init("i2c_mga");
     mystique->i2c_ddc = i2c_gpio_init("ddc_mga");

--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -8491,9 +8491,10 @@ s3_init(const device_t *info)
                 svga->clock_gen = device_add(&icd2061_device);
                 svga->getclock  = icd2061_getclock;
             } else {
-                svga->ramdac    = device_add(&tvp3026_ramdac_device);
-                svga->clock_gen = svga->ramdac;
-                svga->getclock  = tvp3026_getclock;
+                svga->ramdac      = device_add(&tvp3026_ramdac_device);
+                svga->clock_gen   = svga->ramdac;
+                svga->getclock    = tvp3026_getclock;
+                svga->conv_16to32 = tvp3026_conv_16to32;
             }
             break;
 


### PR DESCRIPTION
Summary
=======
TVP3026: Implement gamma correction for 15/16 bpp modes

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
