### PR TITLE
Intel Premiere/PCI ED: update bios to 1013AF2

### DIFF
--- a/src/machine/m_at_socket4.c
+++ b/src/machine/m_at_socket4.c
@@ -290,8 +290,8 @@ machine_at_revenge_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined("roms/machines/revenge/1009af2_.bio",
-                                    "roms/machines/revenge/1009af2_.bi1",
+    ret = bios_load_linear_combined("roms/machines/revenge/1013af2_.bio",
+                                    "roms/machines/revenge/1013af2_.bi1",
                                     0x1c000, 128);
 
     if (bios_only || !ret)


### PR DESCRIPTION
This updates the filename to match the newer 1013AF2 BIOS.

Summary
=======
Currently, the Intel Premiere/PCI ED uses ```1009AF2``` as BIOS. But there is a newer BIOS ```1013AF2```. This commit updates the used filename and a PR for updating the ROM is filled at https://github.com/86Box/roms/pull/223.

I did run a Test with Windows 95 OSR 2.5 and I haven't noticed any issues for me. I do also own the Intel Premiere/PCI ED, if there is something you would like to test.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [X] This pull request requires changes to the ROM set
  * [X] I have opened a roms pull request - https://github.com/86Box/roms/pull/223

References
==========
BIOS History: https://theretroweb.com/motherboards/s/intel-premiere-pci-ed-batman-s-revenge#bios