### PR TITLE
Don't set the application icon in qt_main.c on Mac

### DIFF
--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -195,18 +195,19 @@ main(int argc, char *argv[])
     SetCurrentProcessExplicitAppUserModelID(L"86Box.86Box");
 #endif
 
-#ifdef RELEASE_BUILD
+#ifndef Q_OS_APPLE
+#    ifdef RELEASE_BUILD
     app.setWindowIcon(QIcon(":/settings/win/icons/86Box-green.ico"));
-#elif defined ALPHA_BUILD
+#    elif defined ALPHA_BUILD
     app.setWindowIcon(QIcon(":/settings/win/icons/86Box-red.ico"));
-#elif defined BETA_BUILD
+#    elif defined BETA_BUILD
     app.setWindowIcon(QIcon(":/settings/win/icons/86Box-yellow.ico"));
-#else
+#    else
     app.setWindowIcon(QIcon(":/settings/win/icons/86Box-gray.ico"));
-#endif
 
-#if (!defined(Q_OS_WINDOWS) && !defined(__APPLE__))
+#    ifdef Q_OS_UNIX
     app.setDesktopFileName("net.86box.86Box");
+#    endif
 #endif
 
     if (!pc_init_modules()) {


### PR DESCRIPTION
Summary
=======
Don't set the application icon in qt_main.c on Mac so it won't override the bundle's icon.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A