### PR TITLE
fixes typo on mac icon fix

### DIFF
--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -195,7 +195,7 @@ main(int argc, char *argv[])
     SetCurrentProcessExplicitAppUserModelID(L"86Box.86Box");
 #endif
 
-#ifndef __APPLE__
+#ifndef Q_OS_MACOS
 #    ifdef RELEASE_BUILD
     app.setWindowIcon(QIcon(":/settings/win/icons/86Box-green.ico"));
 #    elif defined ALPHA_BUILD

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -195,7 +195,7 @@ main(int argc, char *argv[])
     SetCurrentProcessExplicitAppUserModelID(L"86Box.86Box");
 #endif
 
-#ifndef Q_OS_APPLE
+#ifndef __APPLE__
 #    ifdef RELEASE_BUILD
     app.setWindowIcon(QIcon(":/settings/win/icons/86Box-green.ico"));
 #    elif defined ALPHA_BUILD


### PR DESCRIPTION
Summary
=======
This fixes a typo on a mac icon fix submitted by lemondrops.
The original code uses 
`#ifndef Q_OS_APPLE `
instead of 
`#ifndef __APPLE__`

After changing this line, the correct icon appears on MacOS Dock, for both app window and settings window.

Checklist
=========
* [X] Closes #3973 
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
OBattler
