### PR TITLE
Fix detection of MGA G100 video RAM when 16MB

### DIFF
--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -6371,6 +6371,8 @@ mystique_init(const device_t *info)
                   NULL);
         mystique->svga.clock_gen = mystique;
         mystique->svga.getclock  = mystique_getclock;
+        if (mystique->vram_size >= 16)
+            mystique->svga.decode_mask = mystique->svga.vram_mask;
     }
 
     io_sethandler(0x03c0, 0x0020, mystique_in, NULL, NULL, mystique_out, NULL, NULL, mystique);


### PR DESCRIPTION
Summary
=======
Fix detection of MGA G100 video RAM when 16MB

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
