### PR TITLE
Update the default copyright year

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,7 @@ if(NOT EMU_BUILD_NUM)
     set(EMU_BUILD_NUM 0)
 endif()
 if(NOT EMU_COPYRIGHT_YEAR)
-    set(EMU_COPYRIGHT_YEAR 2023)
+    set(EMU_COPYRIGHT_YEAR 2024)
 endif()
 
 add_subdirectory(src)

--- a/src/device/mouse_serial.c
+++ b/src/device/mouse_serial.c
@@ -28,6 +28,7 @@
 #include <86box/serial.h>
 #include <86box/mouse.h>
 #include <86box/plat.h>
+#include <86box/version.h>
 
 #define SERMOUSE_PORT 0 /* attach to Serial0 */
 
@@ -537,7 +538,7 @@ ltsermouse_process_command(mouse_t *dev)
                         [FORMAT_HEX]       = 0x04,
                         [FORMAT_MS_4BYTE]  = 0x08,         /* Guess */
                         [FORMAT_MS_WHEEL]  = 0x08 };       /* Guess */
-    const char *copr = "\r\n(C) 2023 86Box, Revision 3.0";
+    const char *copr = "\r\n(C) " COPYRIGHT_YEAR " 86Box, Revision 3.0";
 
     mouse_serial_log("ltsermouse_process_command(): %02X\n", dev->ib);
     dev->command = dev->ib;

--- a/src/include_make/86box/version.h
+++ b/src/include_make/86box/version.h
@@ -34,7 +34,7 @@
 #define EMU_VERSION_FULL   EMU_VERSION
 #define EMU_VERSION_FULL_W EMU_VERSION_W
 
-#define COPYRIGHT_YEAR "2022"
+#define COPYRIGHT_YEAR "2024"
 
 /* Web URL info. */
 #define EMU_SITE       "86box.net"


### PR DESCRIPTION
Summary
=======
It's 2024.

Also replaces the hardcoded copyright year with the COPYRIGHT_YEAR macro in the emulated Logitech serial mouse's self-report string.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
<https://www.timeanddate.com/>
