### PR TITLE
Qt: Rawinput now follows keyboard focus properly

### DIFF
--- a/src/qt/qt_winrawinputfilter.cpp
+++ b/src/qt/qt_winrawinputfilter.cpp
@@ -53,17 +53,15 @@ extern "C" void win_joystick_handle(PRAWINPUT);
 std::unique_ptr<WindowsRawInputFilter>
 WindowsRawInputFilter::Register(MainWindow *window)
 {
-    HWND wnd = (HWND) window->winId();
-
     RAWINPUTDEVICE rid[2] = {
         {.usUsagePage = 0x01,
          .usUsage     = 0x06,
          .dwFlags     = RIDEV_NOHOTKEYS,
-         .hwndTarget  = wnd},
+         .hwndTarget  = nullptr},
         { .usUsagePage = 0x01,
          .usUsage     = 0x02,
          .dwFlags     = 0,
-         .hwndTarget  = wnd}
+         .hwndTarget  = nullptr}
     };
 
     if (RegisterRawInputDevices(rid, 2, sizeof(rid[0])) == FALSE)


### PR DESCRIPTION
Summary
=======
Qt: Rawinput now follows keyboard focus properly

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
