### PR TITLE
Small 5380 SCSI improvements.

### DIFF
--- a/src/scsi/scsi_ncr5380.c
+++ b/src/scsi/scsi_ncr5380.c
@@ -185,7 +185,7 @@ typedef struct ncr5380_t {
 #define DMA_SEND              1
 #define DMA_INITIATOR_RECEIVE 2
 
-static int cmd_len[8] = { 6, 10, 10, 6, 16, 12, 6, 6 };
+static int cmd_len[8] = { 6, 10, 10, 6, 16, 12, 10, 6 };
 
 #ifdef ENABLE_NCR5380_LOG
 int ncr5380_do_log = ENABLE_NCR5380_LOG;
@@ -278,7 +278,7 @@ ncr_timer_on(ncr5380_t *ncr_dev, ncr_t *ncr, int callback)
         if (ncr_dev->type == 3)
             p *= 512.0;
         else
-            p *= 128.0;
+            p *= 144.0;
     }
 
     p += 1.0;


### PR DESCRIPTION
Summary
=======
1. The chip in question now supports the right command length for vendor unique commands, fixes crashes that use said commands.
2. Made the CD speed of said chip even closer to the real thing.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
