### PR TITLE
EGA, (S)VGA: Fix vertical fine scroll behaviour

### DIFF
--- a/src/video/vid_ega.c
+++ b/src/video/vid_ega.c
@@ -555,7 +555,7 @@ ega_recalctimings(ega_t *ega)
     if (ega->seqregs[1] & 8)
         overscan_x <<= 1;
 
-    ega->y_add = (overscan_y >> 1) - (ega->crtc[8] & 0x1f);
+    ega->y_add = (overscan_y >> 1);
     ega->x_add = (overscan_x >> 1);
 
     if (ega->seqregs[1] & 8) {
@@ -769,6 +769,7 @@ ega_poll(void *priv)
         if ((ega->sc == (ega->crtc[11] & 31)) || (ega->sc == ega->rowcount))
             ega->con = 0;
         if (ega->dispon) {
+            /* TODO: Verify real hardware behaviour for out-of-range fine vertical scroll */
             if (ega->linedbl && !ega->linecountff) {
                 ega->linecountff = 1;
                 ega->ma          = ega->maback;
@@ -881,7 +882,7 @@ ega_poll(void *priv)
         }
         if (ega->vc == ega->vtotal) {
             ega->vc       = 0;
-            ega->sc       = 0;
+            ega->sc       = (ega->crtc[0x8] & 0x1f);
             ega->dispon   = 1;
             ega->displine = (ega->interlace && ega->oddeven) ? 1 : 0;
 
@@ -916,7 +917,7 @@ ega_doblit(int wx, int wy, ega_t *ega)
     int       x_add   = enable_overscan ? overscan_x : 0;
     int       y_start = enable_overscan ? 0 : (overscan_y >> 1);
     int       x_start = enable_overscan ? 0 : (overscan_x >> 1);
-    int       bottom  = (overscan_y >> 1) + (ega->crtc[8] & 0x1f);
+    int       bottom  = (overscan_y >> 1);
     uint32_t *p;
     int       i;
     int       j;

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -741,7 +741,7 @@ svga_recalctimings(svga_t *svga)
     if (svga->hdisp >= 2048)
         svga->monitor->mon_overscan_x = 0;
 
-    svga->y_add = (svga->monitor->mon_overscan_y >> 1) - (svga->crtc[8] & 0x1f);
+    svga->y_add = (svga->monitor->mon_overscan_y >> 1);
     svga->x_add = (svga->monitor->mon_overscan_x >> 1);
 
     if (svga->vblankstart < svga->dispend)
@@ -942,6 +942,8 @@ svga_poll(void *priv)
         if ((svga->sc == (svga->crtc[11] & 31)) || (svga->sc == svga->rowcount))
             svga->con = 0;
         if (svga->dispon) {
+            /* TODO: Verify real hardware behaviour for out-of-range fine vertical scroll
+               - S3 Trio64V2/DX: sc == rowcount, wrapping 5-bit counter. */
             if (svga->linedbl && !svga->linecountff) {
                 svga->linecountff = 1;
                 svga->ma          = svga->maback;
@@ -1065,7 +1067,7 @@ svga_poll(void *priv)
         }
         if (svga->vc == svga->vtotal) {
             svga->vc       = 0;
-            svga->sc       = 0;
+            svga->sc       = (svga->crtc[0x8] & 0x1f);
             svga->dispon   = 1;
             svga->displine = (svga->interlace && svga->oddeven) ? 1 : 0;
 
@@ -1642,7 +1644,7 @@ svga_doblit(int wx, int wy, svga_t *svga)
     x_add   = enable_overscan ? svga->monitor->mon_overscan_x : 0;
     y_start = enable_overscan ? 0 : (svga->monitor->mon_overscan_y >> 1);
     x_start = enable_overscan ? 0 : (svga->monitor->mon_overscan_x >> 1);
-    bottom  = (svga->monitor->mon_overscan_y >> 1) + (svga->crtc[8] & 0x1f);
+    bottom  = (svga->monitor->mon_overscan_y >> 1);
 
     if (svga->vertical_linedbl) {
         y_add <<= 1;


### PR DESCRIPTION
Summary
=======
This fixes the CRTC-based fine vertical scroll behaviour on the EGA render and the (S)VGA renderer.

The code was effectively offsetting the row counter and hiding the top few rows in the overscan. This messes up a lot of things, resulting in blank rows at the bottom and split screen activating on the wrong row.

Also, after this fix, if you set an out-of-range fine scroll value and you see some garbage at the top of your screen... that's normal for at least one real chipset.

Checklist
=========
* [x] Closes #4001
* [ ] I have discussed this with core contributors already

References
==========
vgadoc, that bug report, and my trusty onboard S3 Trio64V2/DX for comparison.
