### PR TITLE
Fix EGA fine scrolling in text modes

### DIFF
--- a/src/device/unittester.c
+++ b/src/device/unittester.c
@@ -170,7 +170,7 @@ unittester_write(uint16_t port, uint8_t val, UNUSED(void *priv))
 {
     if (port == unittester.iobase_port + 0x00) {
         /* Command port */
-        unittester_log("[UT] W %02X Command\n", val);
+        /* unittester_log("[UT] W %02X Command\n", val); */
 
         unittester.write_offs = 0;
         unittester.write_len  = 0;
@@ -221,7 +221,7 @@ unittester_write(uint16_t port, uint8_t val, UNUSED(void *priv))
 
     } else if (port == unittester.iobase_port + 0x01) {
         /* Data port */
-        unittester_log("[UT] W %02X Data\n", val);
+        /* unittester_log("[UT] W %02X Data\n", val); */
 
         /* Skip if not awaiting */
         if ((unittester.status & UT_STATUS_AWAITING_WRITE) == 0)
@@ -369,6 +369,12 @@ unittester_write(uint16_t port, uint8_t val, UNUSED(void *priv))
                     unittester.read_len      = ((uint64_t) unittester.read_snap_width) * ((uint64_t) unittester.read_snap_height) * 4;
                     unittester.read_snap_crc = 0xFFFFFFFF;
 
+                    unittester_log("[UT] Screen rectangle analysis - %d x %d @ (%d, %d)\n",
+                                   unittester.read_snap_width,
+                                   unittester.read_snap_height,
+                                   unittester.read_snap_xoffs - (int16_t) unittester.snap_img_xoffs,
+                                   unittester.read_snap_yoffs - (int16_t) unittester.snap_img_yoffs);
+
                     if (unittester.cmd_id == UT_CMD_VERIFY_SCREEN_SNAPSHOT_RECTANGLE) {
                         /* Read everything and compute CRC */
                         uint32_t crc = 0xFFFFFFFF;
@@ -380,6 +386,9 @@ unittester_write(uint16_t port, uint8_t val, UNUSED(void *priv))
                             }
                         }
                         unittester.read_snap_crc = crc ^ 0xFFFFFFFF;
+
+                        unittester_log("[UT] Screen rectangle analysis CRC = %08X\n",
+                                       unittester.read_snap_crc);
 
                         /* Set actual read length for CRC result */
                         unittester.read_len = 4;
@@ -418,7 +427,7 @@ unittester_read(uint16_t port, UNUSED(void *priv))
 
     if (port == unittester.iobase_port + 0x00) {
         /* Status port */
-        unittester_log("[UT] R -- Status = %02X\n", unittester.status);
+        /* unittester_log("[UT] R -- Status = %02X\n", unittester.status); */
         return unittester.status;
     } else if (port == unittester.iobase_port + 0x01) {
         /* Data port */

--- a/src/video/vid_ega.c
+++ b/src/video/vid_ega.c
@@ -552,11 +552,17 @@ ega_recalctimings(ega_t *ega)
 
     overscan_x = (ega->seqregs[1] & 1) ? 16 : 18;
 
+    if (ega->vres)
+        overscan_y <<= 1;
+
     if (ega->seqregs[1] & 8)
         overscan_x <<= 1;
 
     ega->y_add = (overscan_y >> 1);
     ega->x_add = (overscan_x >> 1);
+
+    if (ega->vres)
+        ega->y_add >>= 1;
 
     if (ega->seqregs[1] & 8) {
         disptime    = (double) ((ega->crtc[0] + 2) << 1);
@@ -896,11 +902,12 @@ ega_poll(void *priv)
 void
 ega_doblit(int wx, int wy, ega_t *ega)
 {
-    int       y_add   = enable_overscan ? overscan_y : 0;
+    int       unscaled_overscan_y = ega->vres ? overscan_y >> 1 : overscan_y;
+    int       y_add   = enable_overscan ? unscaled_overscan_y : 0;
     int       x_add   = enable_overscan ? overscan_x : 0;
-    int       y_start = enable_overscan ? 0 : (overscan_y >> 1);
+    int       y_start = enable_overscan ? 0 : (unscaled_overscan_y >> 1);
     int       x_start = enable_overscan ? 0 : (overscan_x >> 1);
-    int       bottom  = (overscan_y >> 1);
+    int       bottom  = (unscaled_overscan_y >> 1);
     uint32_t *p;
     int       i;
     int       j;

--- a/src/video/vid_ega.c
+++ b/src/video/vid_ega.c
@@ -684,7 +684,7 @@ void
 ega_poll(void *priv)
 {
     ega_t   *ega = (ega_t *) priv;
-    int      x;
+    int      x, y;
     int      old_ma;
     int      wx = 640;
     int      wy = 350;
@@ -704,37 +704,26 @@ ega_poll(void *priv)
                 video_wait_for_buffer();
             }
 
-            if (ega->vres) {
-                old_ma = ega->ma;
-
-                ega->displine <<= 1;
-                ega->y_add <<= 1;
-
+            old_ma = ega->ma;
+            ega->displine *= ega->vres + 1;
+            ega->y_add *= ega->vres + 1;
+            for (y = 0; y <= ega->vres; y++) {
+                /* Render scanline */
                 ega->render(ega);
 
+                /* Render overscan */
                 ega->x_add = (overscan_x >> 1);
                 ega_render_overscan_left(ega);
                 ega_render_overscan_right(ega);
                 ega->x_add = (overscan_x >> 1) - ega->scrollcache;
 
-                ega->displine++;
-
-                ega->ma = old_ma;
-
-                ega->render(ega);
-
-                ega->x_add = (overscan_x >> 1);
-                ega_render_overscan_left(ega);
-                ega_render_overscan_right(ega);
-                ega->x_add = (overscan_x >> 1) - ega->scrollcache;
-
-                ega->y_add >>= 1;
-                ega->displine >>= 1;
-            } else {
-                ega_render_overscan_left(ega);
-                ega->render(ega);
-                ega_render_overscan_right(ega);
+                if (y != ega->vres) {
+                    ega->ma = old_ma;
+                    ega->displine++;
+                }
             }
+            ega->displine /= ega->vres + 1;
+            ega->y_add /= ega->vres + 1;
 
             if (ega->lastline < ega->displine)
                 ega->lastline = ega->displine;
@@ -887,16 +876,10 @@ ega_poll(void *priv)
             ega->displine = (ega->interlace && ega->oddeven) ? 1 : 0;
 
             ega->scrollcache = (ega->attrregs[0x13] & 0x0f);
-            if (!(ega->gdcreg[6] & 1) && !(ega->attrregs[0x10] & 1)) { /*Text mode*/
-                if (ega->seqregs[1] & 1)
-                    ega->scrollcache &= 0x07;
-                else {
-                    ega->scrollcache++;
-                    if (ega->scrollcache > 8)
-                        ega->scrollcache = 0;
-                }
-            } else
-                ega->scrollcache &= 0x07;
+            if (ega->scrollcache >= 0x8)
+                ega->scrollcache = 0;
+            else
+                ega->scrollcache++;
 
             if (ega->seqregs[1] & 8)
                 ega->scrollcache <<= 1;

--- a/src/video/vid_ega_render.c
+++ b/src/video/vid_ega_render.c
@@ -126,6 +126,14 @@ ega_render_text(ega_t *ega)
         const bool blinked       = ega->blink & 0x10;
         uint32_t  *p             = &buffer32->line[ega->displine + ega->y_add][ega->x_add];
 
+        /* Compensate for 8dot scroll */
+        if (!seq9dot) {
+            for (int x = 0; x < dotwidth; x++) {
+                p[x] = ega->overscan_color;
+            }
+            p += dotwidth;
+        }
+
         for (int x = 0; x < (ega->hdisp + ega->scrollcache); x += charwidth) {
             uint32_t addr = ega->remap_func(ega, ega->ma) & ega->vrammask;
 


### PR DESCRIPTION
Summary
=======
This fixes the fine scroll in the EGA text modes, including 8-dot and 9-dot modes, also providing a fallback for the "shift left by 1" effect in lieu of a correct implementation of the character skew counter.

This *also* does some changes to the unit tester - firstly, the debug log is a lot more useful, and secondly, it's now compatible with EGA double-scanned rendering (yep, that was a bug).

Checklist
=========
* [x] Closes #4001 (for real this time!)
* [ ] I have discussed this with core contributors already

References
==========
IBM EGA reference; vgadoc; remembering something about various SVGA datasheets explaining the horizontal panning pretty much identically to each other; testing on my S3 Trio64V2/DX for feasible behaviour.
