### PR TITLE
Apply blanking extensions to more SVGA cards.

### DIFF
--- a/src/video/vid_cl54xx.c
+++ b/src/video/vid_cl54xx.c
@@ -1950,7 +1950,7 @@ gd54xx_recalctimings(svga_t *svga)
 				  and the actual blanking comes from the display enable signal. */
 	/* Start blanking at the first character clock after the last active one. */
 	svga->hblankstart = svga->crtc[1] + 1;
-	svga->hblank_end_val = (svga->htotal + 6) & 0x3f;
+	svga->hblank_end_val = (svga->htotal + 5) & 0xff;
 	/* In this mode, the dots per clock are always 8 or 16, never 9 or 18. */
 	if (!svga->scrblank && svga->attr_palette_enable)
 		svga->dots_per_clock = (svga->seqregs[1] & 8) ? 16 : 8;
@@ -1958,6 +1958,10 @@ gd54xx_recalctimings(svga_t *svga)
 	svga->hblank_overscan = 0;
 	/* Also make sure vertical blanking starts on display end. */
 	svga->vblankstart = svga->dispend;
+
+    /* Account for horizontal overflow bits. */
+    svga->hblank_end_val += (svga->crtc[0x1a] & 0x30) << 2;
+    svga->hblank_end_len = 0x100;
     }
 
     if (!(svga->gdcreg[6] & 1) && !(svga->attrregs[0x10] & 1)) { /*Text mode*/

--- a/src/video/vid_et4000.c
+++ b/src/video/vid_et4000.c
@@ -613,6 +613,8 @@ et4000_recalctimings(svga_t *svga)
         svga->rowoffset = 0x100;
     if (svga->crtc[0x3f] & 1)
         svga->htotal += 256;
+    if (svga->crtc[0x3f] & 0x04)
+        svga->hblankstart += 0x100;
     if (svga->attrregs[0x16] & 0x20)
         svga->hdisp <<= 1;
 

--- a/src/video/vid_et4000w32.c
+++ b/src/video/vid_et4000w32.c
@@ -445,6 +445,8 @@ et4000w32p_recalctimings(svga_t *svga)
         svga->rowoffset += 0x100;
     if (svga->crtc[0x3F] & 0x01)
         svga->htotal += 256;
+    if (svga->crtc[0x3F] & 0x04)
+        svga->hblankstart += 0x100;
     if (svga->attrregs[0x16] & 0x20)
         svga->hdisp <<= 1;
 

--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -192,6 +192,8 @@
 #define CRTCX_R0_OFFSET_MASK          (3 << 4)
 
 #define CRTCX_R1_HTOTAL8              (1 << 0)
+#define CRTCX_R1_HBLKSTRT8            (1 << 1)
+#define CRTCX_R1_HBLKEND6             (1 << 6)
 
 #define CRTCX_R2_VTOTAL10             (1 << 0)
 #define CRTCX_R2_VTOTAL11             (1 << 1)
@@ -941,6 +943,8 @@ mystique_recalctimings(svga_t *svga)
 
     if (mystique->crtcext_regs[1] & CRTCX_R1_HTOTAL8)
         svga->htotal |= 0x100;
+    if (mystique->crtcext_regs[1] & CRTCX_R1_HBLKSTRT8)
+        svga->hblankstart += 0x100;
     if (mystique->crtcext_regs[2] & CRTCX_R2_VTOTAL10)
         svga->vtotal |= 0x400;
     if (mystique->crtcext_regs[2] & CRTCX_R2_VTOTAL11)
@@ -970,6 +974,11 @@ mystique_recalctimings(svga_t *svga)
         svga->hdisp         = (svga->crtc[1] + 1) << 3;
         svga->hdisp_time    = svga->hdisp;
         svga->rowoffset     = svga->crtc[0x13] | ((mystique->crtcext_regs[0] & CRTCX_R0_OFFSET_MASK) << 4);
+
+        svga->hblank_end_len = 0x80;
+        svga->hblank_end_val += mystique->crtcext_regs[1] & CRTCX_R1_HBLKEND6;
+
+        svga->hblank_overscan = 0;
 
         if (mystique->type != MGA_2164W && mystique->type != MGA_2064W)
             svga->lut_map = !!(mystique->xmiscctrl & XMISCCTRL_RAMCS);

--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -4013,6 +4013,11 @@ s3_trio64v_recalctimings(svga_t *svga)
     s3_t *s3            = (s3_t *) svga->priv;
     int         clk_sel = (svga->miscout >> 2) & 3;
 
+    if (!svga->scrblank && svga->attr_palette_enable && (svga->crtc[0x43] & 0x80)) {
+        /* TODO: In case of bug reports, disable 9-dots-wide character clocks in graphics modes. */
+        svga->dots_per_clock = ((svga->seqregs[1] & 1) ? 16 : 18);
+    }
+
     svga->hdisp = svga->hdisp_old;
     if (svga->crtc[0x5d] & 0x01)
         svga->htotal |= 0x100;
@@ -4145,11 +4150,6 @@ s3_trio64v_recalctimings(svga_t *svga)
             default:
                 break;
         }
-    }
-
-    if (!svga->scrblank && svga->attr_palette_enable && (svga->crtc[0x43] & 0x80)) {
-        /* TODO: In case of bug reports, disable 9-dots-wide character clocks in graphics modes. */
-        svga->dots_per_clock = ((svga->seqregs[1] & 1) ? 16 : 18);
     }
 
     if (svga->crtc[0x5d] & 0x04)

--- a/src/video/vid_s3_virge.c
+++ b/src/video/vid_s3_virge.c
@@ -778,11 +778,16 @@ s3_virge_recalctimings(svga_t *svga)
 
     svga->hdisp = svga->hdisp_old;
 
+    if (!svga->scrblank && svga->attr_palette_enable && (svga->crtc[0x43] & 0x80)) {
+        /* TODO: In case of bug reports, disable 9-dots-wide character clocks in graphics modes. */
+        svga->dots_per_clock = ((svga->seqregs[1] & 1) ? 16 : 18);
+    }
+
     if (svga->crtc[0x5d] & 0x01)
         svga->htotal += 0x100;
     if (svga->crtc[0x5d] & 0x02) {
         svga->hdisp_time += 0x100;
-        svga->hdisp += 0x100 * ((svga->seqregs[1] & 8) ? 16 : 8);
+        svga->hdisp += 0x100 * svga->dots_per_clock;
     }
     if (svga->crtc[0x5e] & 0x01)
         svga->vtotal += 0x400;
@@ -906,6 +911,15 @@ s3_virge_recalctimings(svga_t *svga)
         }
         svga->vram_display_mask = virge->vram_mask;
     }
+    
+    if (svga->crtc[0x5d] & 0x04)
+        svga->hblankstart += 0x100;
+    
+    if (svga->crtc[0x5d] & 0x08)
+        svga->hblank_ext = 0x40;
+    svga->hblank_end_len = 0x00000040;
+
+    svga->hblank_overscan = !(svga->crtc[0x33] & 0x20);
 }
 
 static void

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -738,7 +738,6 @@ svga_recalctimings(svga_t *svga)
     } else
         svga->monitor->mon_overscan_x = 16;
 
-    svga->htotal         = svga->crtc[0];
     svga->hblankstart    = svga->crtc[4] + 1;
     svga->hblank_end_val = (svga->crtc[3] & 0x1f) | ((svga->crtc[5] & 0x80) ? 0x20 : 0x00);
 #if 0
@@ -767,7 +766,6 @@ svga_recalctimings(svga_t *svga)
     if (xga_active && (svga->xga != NULL))
         xga_recalctimings(svga);
 
-    svga->htotal += 6; /*+6 is required for Tyrian*/
     svga->hblankend = (svga->hblankstart & ~(svga->hblank_end_len - 1)) | svga->hblank_end_val;
     if (svga->hblankend <= svga->hblankstart)
         svga->hblankend += svga->hblank_end_len;

--- a/src/video/vid_voodoo_banshee.c
+++ b/src/video/vid_voodoo_banshee.c
@@ -552,6 +552,10 @@ banshee_recalctimings(svga_t *svga)
         svga->htotal += 0x100;
     if (svga->crtc[0x1a] & 0x04)
         svga->hdisp += 0x100;
+    if (svga->crtc[0x1a] & 0x10)
+        svga->hblankstart += 0x100;
+    if (svga->crtc[0x1a] & 0x20)
+        svga->hblank_end_val += 0x40;
     /*6 R/W Vertical Retrace Start bit 10 0x10
       5 R/W Reserved. -
       4 R/W Vertical Blank Start bit 10. 0x15
@@ -610,6 +614,8 @@ banshee_recalctimings(svga_t *svga)
 
         svga->char_width = 8;
         svga->split      = 99999;
+
+        svga->hblank_end_len = 0x80;
 
         if (banshee->vidProcCfg & VIDPROCCFG_2X_MODE) {
             svga->hdisp *= 2;


### PR DESCRIPTION
Summary
=======
Apply blanking extensions to more SVGA cards.

* Fix duplicated logic in vid_svga.c
* Voodoo 3/Banshee emulation now has blanking extensions applied
* S3 ViRGE and Matrox video cards as well
* Tseng ET4000-series cards as well
* Fix off-by-one error in vid_cl54xx.c

Trident cards are yet to be investigated. XGA and 8514/A are yet to be made blanking extensions compliant. Mach64, Paradise/WDC and OAK OTI cards remain as-is for now.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
Datasheets/databooks of respective cards whenever possible.
