### PR TITLE
MGA: Do not reset DWORD expected counter while SOFTRAP read is still pending

### DIFF
--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -2186,7 +2186,10 @@ mystique_ctrl_write_b(uint32_t addr, uint8_t val, void *priv)
             thread_wait_mutex(mystique->dma.lock);
             WRITE8(addr, mystique->dma.primaddress, val);
             mystique->dma.pri_state = 0;
-            mystique->dma.words_expected = 0;
+            if (mystique->dma.state == DMA_STATE_IDLE && !(mystique->softrap_pending || mystique->endprdmasts_pending || !mystique->softrap_status_read)) {
+                mystique->dma.words_expected = 0;
+            }
+            mystique->dma.state = DMA_STATE_IDLE;
             thread_release_mutex(mystique->dma.lock);
             break;
 


### PR DESCRIPTION
Summary
=======
MGA: Do not reset DWORD expected counter while SOFTRAP read is still pending

Fixes Matrox Simple Interface games without breaking Windows 2000 drivers.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
