### PR TITLE
Fix a few bugs pertaining to EGA fine horizontal scrolling

### DIFF
--- a/src/video/vid_ega.c
+++ b/src/video/vid_ega.c
@@ -557,7 +557,7 @@ ega_recalctimings(ega_t *ega)
         overscan_x <<= 1;
 
     ega->y_add = (overscan_y >> 1);
-    ega->x_add = (overscan_x >> 1);
+    ega->x_add = (overscan_x >> 1) - ega->scrollcache;
 
     if (ega->vres)
         ega->y_add >>= 1;

--- a/src/video/vid_ega.c
+++ b/src/video/vid_ega.c
@@ -804,10 +804,6 @@ ega_poll(void *priv)
             ega->cca = ega->ma;
             ega->maback <<= 2;
             ega->sc = 0;
-            if (ega->attrregs[0x10] & 0x20) {
-                ega->scrollcache = 0;
-                ega->x_add       = (overscan_x >> 1);
-            }
         }
         if (ega->vc == ega->dispend) {
             ega->dispon = 0;

--- a/src/video/vid_ega_render.c
+++ b/src/video/vid_ega_render.c
@@ -199,6 +199,7 @@ ega_render_graphics(ega_t *ega)
     const bool    attrblink   = ((ega->attrregs[0x10] & 8) != 0);
     const bool    blinked     = ega->blink & 0x10;
     const bool    crtcreset   = ((ega->crtc[0x17] & 0x80) == 0);
+    const bool    seq9dot       = ((ega->seqregs[1] & 1) == 0);
     const bool    seqoddeven  = ((ega->seqregs[1] & 4) != 0);
     const uint8_t blinkmask   = (attrblink && blinked ? 0x8 : 0x0);
     uint32_t     *p           = &buffer32->line[ega->displine + ega->y_add][ega->x_add];
@@ -206,6 +207,15 @@ ega_render_graphics(ega_t *ega)
     const int     dotwidth    = 1 << dwshift;
     const int     charwidth   = dotwidth * 8;
     int           secondcclk  = 0;
+
+    /* Compensate for 8dot scroll */
+    if (!seq9dot) {
+        for (int x = 0; x < dotwidth; x++) {
+            p[x] = ega->overscan_color;
+        }
+        p += dotwidth;
+    }
+
     for (int x = 0; x <= (ega->hdisp + ega->scrollcache); x += charwidth) {
         uint32_t addr = ega->remap_func(ega, ega->ma) & ega->vrammask;
 


### PR DESCRIPTION
Summary
=======
A few bugs are fixed here.
* One was my fault for forgetting to adjust the graphics renderer to handle the 8/9-dot workaround in the text renderer.
* Another was exposed by my changes: The wobbling that happens in one of the BIOSes, which was triggered by the cursor settings constantly being written repeatedly, which spammed calls to `ega_recalctimings()`.
* Lastly, there's a bit that only exists in VGA which was in the EGA renderer for some reason. This wasn't the cause of any of the bugs I was trying to fix, but it's still worth getting rid of it.

Checklist
=========
* [x] Closes #4072
* [ ] I have discussed this with core contributors already

References
==========
Mostly boiled down to original research based on available documentation and logical deduction.