### PR TITLE
Raise minimum RAM for MSI MS-4144 to 5 MBs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,6 @@ cmake_dependent_option(PAS16          "Pro Audio Spectrum 16"                   
 cmake_dependent_option(SIO_DETECT     "Super I/O Detection Helper"                  ON      "DEV_BRANCH"    OFF)
 cmake_dependent_option(VGAWONDER      "ATI VGA Wonder (ATI-18800)"                  ON      "DEV_BRANCH"    OFF)
 cmake_dependent_option(XL24           "ATI VGA Wonder XL24 (ATI-28800-6)"           ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(MS4144         "MSI MS-4144"                                 ON      "DEV_BRANCH"    OFF)
 
 # Ditto but for Qt
 if(QT)

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -536,9 +536,7 @@ extern int machine_at_greenb_init(const machine_t *);
 extern int machine_at_r418_init(const machine_t *);
 extern int machine_at_ls486e_init(const machine_t *);
 extern int machine_at_4dps_init(const machine_t *);
-#if defined(DEV_BRANCH) && defined(USE_MS4144)
 extern int machine_at_ms4144_init(const machine_t *);
-#endif
 extern int machine_at_4saw2_init(const machine_t *);
 extern int machine_at_m4li_init(const machine_t *);
 extern int machine_at_alfredo_init(const machine_t *);

--- a/src/machine/CMakeLists.txt
+++ b/src/machine/CMakeLists.txt
@@ -40,7 +40,3 @@ endif()
 if(OPEN_AT)
     target_compile_definitions(mch PRIVATE USE_OPEN_AT)
 endif()
-
-if(MS4144)
-    target_compile_definitions(mch PRIVATE USE_MS4144)
-endif()

--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -1045,7 +1045,7 @@ machine_at_4dps_init(const machine_t *model)
 
     return ret;
 }
-#if defined(DEV_BRANCH) && defined(USE_MS4144)
+
 int
 machine_at_ms4144_init(const machine_t *model)
 {
@@ -1072,7 +1072,7 @@ machine_at_ms4144_init(const machine_t *model)
 
     return ret;
 }
-#endif
+
 int
 machine_at_486sp3c_init(const machine_t *model)
 {

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -7783,7 +7783,6 @@ const machine_t machines[] = {
         .snd_device = NULL,
         .net_device = NULL
     },
-#if defined(DEV_BRANCH) && defined(USE_MS4144)
     /* AMIKEY-2 */
     {
         .name = "[SiS 496] MSI MS-4144",
@@ -7824,7 +7823,6 @@ const machine_t machines[] = {
         .snd_device = NULL,
         .net_device = NULL
     },
-#endif
     /* This has the UMC 88xx on-chip KBC. */
     {
         .name = "[UMC 8881] A-Trend ATC-1415",

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -7807,7 +7807,7 @@ const machine_t machines[] = {
         .bus_flags = MACHINE_PCI,
         .flags = MACHINE_SUPER_IO | MACHINE_IDE_DUAL | MACHINE_APM,
         .ram = {
-            .min = 1024,
+            .min = 5120, /* Hack: machine seems to break with less than 5 MBs of RAM */
             .max = 131072,
             .step = 1024
         },


### PR DESCRIPTION
Summary
=======
Turns out the breakage is caused by the amount of RAM.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
