### PR TITLE
Rename 586MC1 to GA-586IS

### DIFF
--- a/src/machine/m_at_socket4.c
+++ b/src/machine/m_at_socket4.c
@@ -317,7 +317,6 @@ machine_at_586mc1_init(const machine_t *model)
 
     machine_at_award_common_init(model);
 
-    device_add(&sio_device);
     device_add(&intel_flash_bxt_device);
     device_add(&i430lx_device);
 

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -8725,7 +8725,7 @@ const machine_t machines[] = {
     },
     /* Has AMI MegaKey KBC firmware. */
     {
-        .name = "[i430LX] Micro Star 586MC1",
+        .name = "[i430LX] Gigabyte GA-586IS",
         .internal_name = "586mc1",
         .type = MACHINE_TYPE_SOCKET4,
         .chipset = MACHINE_CHIPSET_INTEL_430LX,
@@ -8744,8 +8744,8 @@ const machine_t machines[] = {
             .min_multi = MACHINE_MULTIPLIER_FIXED,
             .max_multi = MACHINE_MULTIPLIER_FIXED
         },
-        .bus_flags = MACHINE_PS2_PCI,
-        .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI,
+        .bus_flags = MACHINE_PCI,
+        .flags = MACHINE_APM | MACHINE_ACPI,
         .ram = {
             .min = 2048,
             .max = 131072,


### PR DESCRIPTION
Summary
=======
According to TRW the BIOS string belongs to this machine. The machine also does not have internal IDE or PS/2 mouse support.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://theretroweb.com/motherboards/s/gigabyte-ga-586is
