### PR TITLE
Disable GHA win32 and makefile jobs

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   msys2:
+    # Negative condition disables the job
+    if: false
     name: "Win32 GUI, ${{ matrix.build.name }}, ${{ matrix.dynarec.name }}, ${{ matrix.environment.msystem }}"
 
     runs-on: windows-2022

--- a/.github/workflows/cmake_windows_msys2.yml
+++ b/.github/workflows/cmake_windows_msys2.yml
@@ -57,9 +57,6 @@ jobs:
             new: on
             slug: -NDR
         ui:
-          - name: Win32 GUI
-            qt: off
-            static: on
           - name: Qt GUI
             qt: on
             static: on


### PR DESCRIPTION
Summary
=======
This will disable the GHA:
* `makefile` job (consists entirely of deprecated win32 builds)
* Deprecated win32 builds in the windows cmake job

The makefile job yaml file remains in place but is disabled with a conditional. Once merged the job can also be disabled in the repo settings.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
[GitHub docs link](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution) for disabling a job using a conditional.
