### PR TITLE
Fix broken translation of "ACPI shutdown" tooltip for all languages

### DIFF
--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -776,7 +776,7 @@
     <string>ACPI Shutdown</string>
    </property>
    <property name="toolTip">
-    <string>ACPI Shutdown</string>
+    <string>ACPI shutdown</string>
    </property>
    <property name="visible">
     <bool>true</bool>

--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -773,7 +773,7 @@
      <normaloff>:/menuicons/win/icons/acpi_shutdown.ico</normaloff>:/menuicons/win/icons/acpi_shutdown.ico</iconset>
    </property>
    <property name="text">
-    <string>ACPI Shutdown</string>
+    <string>ACPI shutdown</string>
    </property>
    <property name="toolTip">
     <string>ACPI shutdown</string>


### PR DESCRIPTION
Fix broken translation of "ACPI shutdown" tooltip for all languages

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
