### PR TITLE
Rename "Phoenix 286 clone" as the machine has been identified

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -3361,7 +3361,7 @@ const machine_t machines[] = {
     },
     /* Has IBM AT KBC firmware. */
     {
-        .name = "[NEAT] Phoenix 286 clone",
+        .name = "[NEAT] Arche AMA-2010",
         .internal_name = "px286",
         .type = MACHINE_TYPE_286,
         .chipset = MACHINE_CHIPSET_NEAT,

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -12693,7 +12693,7 @@ const machine_t machines[] = {
         .snd_device = NULL,
         .net_device = NULL
     },
-    /* The base board hasa Holtek HT6542B with AMIKey-2 (updated 'H') KBC firmware. */
+    /* The base board has a Holtek HT6542B with AMIKey-2 (updated 'H') KBC firmware. */
     {
         .name = "[i440FX] ASUS P/I-P65UP5 (C-P6ND)",
         .internal_name = "p65up5_cp6nd",


### PR DESCRIPTION
Summary
=======
The machine appears to be the Arche AMA-2010 (Kenitec 286/16). Thanks @mfmcosta for bringing this up.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://theretroweb.com/motherboards/s/arche-ama-2010
