### PR TITLE
Rename "AMI XT clone" as the machine has been identified

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -437,7 +437,7 @@ const machine_t machines[] = {
         .net_device = NULL
     },
     {
-        .name = "[8088] AMI XT clone",
+        .name = "[8088] Micoms XL-7 Turbo",
         .internal_name = "amixt",
         .type = MACHINE_TYPE_8088,
         .chipset = MACHINE_CHIPSET_DISCRETE,


### PR DESCRIPTION
Summary
=======
The machine appears to be a Micoms XL-7 Turbo. Thanks @mfmcosta for finding this out.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://theretroweb.com/motherboards/s/micoms-system-pt-xl-7-turbo
