### PR TITLE
Revert "Rename "AMI XT clone" as the machine has been identified"

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -437,7 +437,7 @@ const machine_t machines[] = {
         .net_device = NULL
     },
     {
-        .name = "[8088] Micoms XL-7 Turbo",
+        .name = "[8088] AMI XT clone",
         .internal_name = "amixt",
         .type = MACHINE_TYPE_8088,
         .chipset = MACHINE_CHIPSET_DISCRETE,


### PR DESCRIPTION
Turns out this was an error on The Retro Web's part.

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [xI have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
