### PR TITLE
Adding missing translation strings in RU, en-US, en-GB

### DIFF
--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -49,8 +49,8 @@ msgstr "SDL (&Hardware)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (&OpenGL)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "Open&GL (3.0 Core)"
+msgid "Open&GL 3.0"
+msgstr "Open&GL 3.0"
 
 msgid "&VNC"
 msgstr "&VNC"
@@ -385,8 +385,8 @@ msgstr "Recopilador Dinàmic"
 msgid "Video:"
 msgstr "Vídeo:"
 
-msgid "Voodoo Graphics"
-msgstr "Gràfics Voodoo"
+msgid "3Dfx Voodoo Graphics"
+msgstr "Gràfics 3Dfx Voodoo"
 
 msgid "IBM 8514/A Graphics"
 msgstr "Gràfics IBM 8514/A"
@@ -940,8 +940,8 @@ msgstr "Imatges de cartutx"
 msgid "Error initializing renderer"
 msgstr "Error en inicialitzar el renderitzador"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "No has estat possible inicialitzar el renderitzador OpenGL (3.0 Core). Utilitzar un altre renderitzador."
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "No has estat possible inicialitzar el renderitzador OpenGL 3.0. Utilitzar un altre renderitzador."
 
 msgid "Resume execution"
 msgstr "Reprendre l'execució"

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -49,8 +49,8 @@ msgstr "SDL (&Hardware)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (&OpenGL)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "Open&GL (3.0 Core)"
+msgid "Open&GL 3.0"
+msgstr "Open&GL 3.0"
 
 msgid "&VNC"
 msgstr "&VNC"
@@ -385,8 +385,8 @@ msgstr "Dynamický překladač"
 msgid "Video:"
 msgstr "Grafika:"
 
-msgid "Voodoo Graphics"
-msgstr "Použít grafický akcelerátor Voodoo"
+msgid "3Dfx Voodoo Graphics"
+msgstr "Použít grafický akcelerátor 3Dfx Voodoo"
 
 msgid "IBM 8514/A Graphics"
 msgstr "Grafika IBM 8514/A"
@@ -940,8 +940,8 @@ msgstr "Obrazy cartridge"
 msgid "Error initializing renderer"
 msgstr "Chyba při inicializaci vykreslovače"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "Vykreslovač OpenGL (3.0 Core) se nepodařilo inicializovat. Použijte jiný renderer."
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "Vykreslovač OpenGL 3.0 se nepodařilo inicializovat. Použijte jiný renderer."
 
 msgid "Resume execution"
 msgstr "Obnovit"

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -49,8 +49,8 @@ msgstr "SDL (&Hardware)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (&OpenGL)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "Open&GL (3.0-Kern)"
+msgid "Open&GL 3.0"
+msgstr "Open&GL 3.0"
 
 msgid "&VNC"
 msgstr "&VNC"
@@ -385,8 +385,8 @@ msgstr "Dynamischer Recompiler"
 msgid "Video:"
 msgstr "Videokarte:"
 
-msgid "Voodoo Graphics"
-msgstr "Voodoo-Grafik"
+msgid "3Dfx Voodoo Graphics"
+msgstr "3Dfx Voodoo-Grafik"
 
 msgid "IBM 8514/A Graphics"
 msgstr "IBM 8514/A-Grafik"
@@ -940,8 +940,8 @@ msgstr "Cartridgeimages"
 msgid "Error initializing renderer"
 msgstr "Fehler bei der Rendererinitialisierung"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "Der OpenGL (3.0-Kern)-Renderer konnte nicht initialisiert werden. Bitte benutzen Sie einen anderen Renderer."
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "Der OpenGL 3.0-Renderer konnte nicht initialisiert werden. Bitte benutzen Sie einen anderen Renderer."
 
 msgid "Resume execution"
 msgstr "Fortsetzen"

--- a/src/qt/languages/en-GB.po
+++ b/src/qt/languages/en-GB.po
@@ -31,6 +31,12 @@ msgstr "&Hide status bar"
 msgid "Hide &toolbar"
 msgstr "Hide &toolbar"
 
+msgid "Show status icons in fullscreen"
+msgstr "Show status icons in fullscreen"
+
+msgid "Show non-primary monitors"
+msgstr "Show non-primary monitors"
+
 msgid "&Resizeable window"
 msgstr "&Resizeable window"
 
@@ -49,11 +55,35 @@ msgstr "SDL (&Hardware)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (&OpenGL)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "Open&GL (3.0 Core)"
+msgid "Open&GL 3.0"
+msgstr "Open&GL 3.0"
 
 msgid "&VNC"
 msgstr "&VNC"
+
+msgid "Renderer options..."
+msgstr "Renderer options..."
+
+msgid "OpenGL 3.0 renderer options"
+msgstr "OpenGL 3.0 renderer options"
+
+msgid "Render behavior"
+msgstr "Render behavior"
+
+msgid "Synchronize with video"
+msgstr "Synchronize with video"
+
+msgid "Use target framerate:"
+msgstr "Use target framerate:"
+
+msgid "VSync"
+msgstr "VSync"
+
+msgid "Shaders"
+msgstr "Shaders"
+
+msgid "No shader selected"
+msgstr "No shader selected"
 
 msgid "Specify dimensions..."
 msgstr "Specify dimensions..."
@@ -127,6 +157,9 @@ msgstr "&Integer scale"
 msgid "4:&3 Integer scale"
 msgstr "4:&3 Integer scale"
 
+msgid "Apply fullscreen stretch mode when maximized"
+msgstr "Apply fullscreen stretch mode when maximized"
+
 msgid "E&GA/(S)VGA settings"
 msgstr "E&GA/(S)VGA settings"
 
@@ -193,6 +226,9 @@ msgstr "Enable &Discord integration"
 msgid "Sound &gain..."
 msgstr "Sound &gain..."
 
+msgid "Open screenshots folder..."
+msgstr "Open screenshots folder..."
+
 msgid "Begin trace\tCtrl+T"
 msgstr "Begin trace\tCtrl+T"
 
@@ -232,6 +268,9 @@ msgstr "&Fast forward to the end"
 msgid "E&ject"
 msgstr "E&ject"
 
+msgid "Eject %s"
+msgstr "Eject %s"
+
 msgid "&Image..."
 msgstr "&Image..."
 
@@ -240,6 +279,9 @@ msgstr "E&xport to 86F..."
 
 msgid "&Mute"
 msgstr "&Mute"
+
+msgid "&Unmute"
+msgstr "&Unmute"
 
 msgid "E&mpty"
 msgstr "E&mpty"
@@ -361,6 +403,9 @@ msgstr "FPU:"
 msgid "Wait states:"
 msgstr "Wait states:"
 
+msgid "PIT Mode:"
+msgstr "PIT Mode:"
+
 msgid "MB"
 msgstr "MB"
 
@@ -383,10 +428,13 @@ msgid "Dynamic Recompiler"
 msgstr "Dynamic Recompiler"
 
 msgid "Video:"
-msgstr "Video:"
+msgstr "Video card 1:"
 
-msgid "Voodoo Graphics"
-msgstr "Voodoo Graphics"
+msgid "Video #2:"
+msgstr "Video card 2:"
+
+msgid "3Dfx Voodoo Graphics"
+msgstr "3Dfx Voodoo Graphics"
 
 msgid "IBM 8514/A Graphics"
 msgstr "IBM 8514/A Graphics"
@@ -413,16 +461,16 @@ msgid "Joystick 4..."
 msgstr "Joystick 4..."
 
 msgid "Sound card #1:"
-msgstr "Sound card #1:"
+msgstr "Sound card 1:"
 
 msgid "Sound card #2:"
-msgstr "Sound card #2:"
+msgstr "Sound card 2:"
 
 msgid "Sound card #3:"
-msgstr "Sound card #3:"
+msgstr "Sound card 3:"
 
 msgid "Sound card #4:"
-msgstr "Sound card #4:"
+msgstr "Sound card 4:"
 
 msgid "MIDI Out Device:"
 msgstr "MIDI Out Device:"
@@ -453,6 +501,30 @@ msgstr "PCap device:"
 
 msgid "Network adapter:"
 msgstr "Network adapter:"
+
+msgid "Network Card #1"
+msgstr "Network card 1:"
+
+msgid "Network Card #2"
+msgstr "Network card 2:"
+
+msgid "Network Card #3"
+msgstr "Network card 3:"
+
+msgid "Network Card #4"
+msgstr "Network card 4:"
+
+msgid "Mode"
+msgstr "Mode:"
+
+msgid "Interface"
+msgstr "Interface:"
+
+msgid "Adapter"
+msgstr "Adapter:"
+
+msgid "VDE Socket"
+msgstr "VDE Socket:"
 
 msgid "COM1 Device:"
 msgstr "COM1 Device:"
@@ -489,6 +561,18 @@ msgstr "Serial port 3"
 
 msgid "Serial port 4"
 msgstr "Serial port 4"
+
+msgid "Serial port passthrough 1"
+msgstr "Serial port passthrough 1"
+
+msgid "Serial port passthrough 2"
+msgstr "Serial port passthrough 2"
+
+msgid "Serial port passthrough 3"
+msgstr "Serial port passthrough 3"
+
+msgid "Serial port passthrough 4"
+msgstr "Serial port passthrough 4"
 
 msgid "Parallel port 1"
 msgstr "Parallel port 1"
@@ -541,8 +625,14 @@ msgstr "&New..."
 msgid "&Existing..."
 msgstr "&Existing..."
 
+msgid "Browse..."
+msgstr "Browse..."
+
 msgid "&Remove"
 msgstr "&Remove"
+
+msgid "Remove"
+msgstr "Remove"
 
 msgid "Bus:"
 msgstr "Bus:"
@@ -625,6 +715,9 @@ msgstr "ISABugger device"
 msgid "POST card"
 msgstr "POST card"
 
+msgid "86Box Unit Tester"
+msgstr "86Box Unit Tester"
+
 msgid "FONT_SIZE"
 msgstr "9"
 
@@ -660,6 +753,9 @@ msgstr "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://
 
 msgid "(empty)"
 msgstr "(empty)"
+
+msgid "Clear image history"
+msgstr "Clear image history"
 
 msgid "All files"
 msgstr "All files"
@@ -940,8 +1036,8 @@ msgstr "Cartridge images"
 msgid "Error initializing renderer"
 msgstr "Error initializing renderer"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "OpenGL 3.0 renderer could not be initialized. Use another renderer."
 
 msgid "Resume execution"
 msgstr "Resume execution"

--- a/src/qt/languages/en-US.po
+++ b/src/qt/languages/en-US.po
@@ -31,6 +31,12 @@ msgstr "&Hide status bar"
 msgid "Hide &toolbar"
 msgstr "Hide &toolbar"
 
+msgid "Show status icons in fullscreen"
+msgstr "Show status icons in fullscreen"
+
+msgid "Show non-primary monitors"
+msgstr "Show non-primary monitors"
+
 msgid "&Resizeable window"
 msgstr "&Resizeable window"
 
@@ -49,11 +55,35 @@ msgstr "SDL (&Hardware)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (&OpenGL)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "Open&GL (3.0 Core)"
+msgid "Open&GL 3.0"
+msgstr "Open&GL 3.0"
 
 msgid "&VNC"
 msgstr "&VNC"
+
+msgid "Renderer options..."
+msgstr "Renderer options..."
+
+msgid "OpenGL 3.0 renderer options"
+msgstr "OpenGL 3.0 renderer options"
+
+msgid "Render behavior"
+msgstr "Render behavior"
+
+msgid "Synchronize with video"
+msgstr "Synchronize with video"
+
+msgid "Use target framerate:"
+msgstr "Use target framerate:"
+
+msgid "VSync"
+msgstr "VSync"
+
+msgid "Shaders"
+msgstr "Shaders"
+
+msgid "No shader selected"
+msgstr "No shader selected"
 
 msgid "Specify dimensions..."
 msgstr "Specify dimensions..."
@@ -127,6 +157,9 @@ msgstr "&Integer scale"
 msgid "4:&3 Integer scale"
 msgstr "4:&3 Integer scale"
 
+msgid "Apply fullscreen stretch mode when maximized"
+msgstr "Apply fullscreen stretch mode when maximized"
+
 msgid "E&GA/(S)VGA settings"
 msgstr "E&GA/(S)VGA settings"
 
@@ -193,6 +226,9 @@ msgstr "Enable &Discord integration"
 msgid "Sound &gain..."
 msgstr "Sound &gain..."
 
+msgid "Open screenshots folder..."
+msgstr "Open screenshots folder..."
+
 msgid "Begin trace\tCtrl+T"
 msgstr "Begin trace\tCtrl+T"
 
@@ -232,6 +268,9 @@ msgstr "&Fast forward to the end"
 msgid "E&ject"
 msgstr "E&ject"
 
+msgid "Eject %s"
+msgstr "Eject %s"
+
 msgid "&Image..."
 msgstr "&Image..."
 
@@ -240,6 +279,9 @@ msgstr "E&xport to 86F..."
 
 msgid "&Mute"
 msgstr "&Mute"
+
+msgid "&Unmute"
+msgstr "&Unmute"
 
 msgid "E&mpty"
 msgstr "E&mpty"
@@ -361,6 +403,9 @@ msgstr "FPU:"
 msgid "Wait states:"
 msgstr "Wait states:"
 
+msgid "PIT Mode:"
+msgstr "PIT Mode:"
+
 msgid "MB"
 msgstr "MB"
 
@@ -383,10 +428,13 @@ msgid "Dynamic Recompiler"
 msgstr "Dynamic Recompiler"
 
 msgid "Video:"
-msgstr "Video:"
+msgstr "Video card 1:"
 
-msgid "Voodoo Graphics"
-msgstr "Voodoo Graphics"
+msgid "Video #2:"
+msgstr "Video card 2:"
+
+msgid "3Dfx Voodoo Graphics"
+msgstr "3Dfx Voodoo Graphics"
 
 msgid "IBM 8514/A Graphics"
 msgstr "IBM 8514/A Graphics"
@@ -413,16 +461,16 @@ msgid "Joystick 4..."
 msgstr "Joystick 4..."
 
 msgid "Sound card #1:"
-msgstr "Sound card #1:"
+msgstr "Sound card 1:"
 
 msgid "Sound card #2:"
-msgstr "Sound card #2:"
+msgstr "Sound card 2:"
 
 msgid "Sound card #3:"
-msgstr "Sound card #3:"
+msgstr "Sound card 3:"
 
 msgid "Sound card #4:"
-msgstr "Sound card #4:"
+msgstr "Sound card 4:"
 
 msgid "MIDI Out Device:"
 msgstr "MIDI Out Device:"
@@ -453,6 +501,30 @@ msgstr "PCap device:"
 
 msgid "Network adapter:"
 msgstr "Network adapter:"
+
+msgid "Network Card #1"
+msgstr "Network card 1:"
+
+msgid "Network Card #2"
+msgstr "Network card 2:"
+
+msgid "Network Card #3"
+msgstr "Network card 3:"
+
+msgid "Network Card #4"
+msgstr "Network card 4:"
+
+msgid "Mode"
+msgstr "Mode:"
+
+msgid "Interface"
+msgstr "Interface:"
+
+msgid "Adapter"
+msgstr "Adapter:"
+
+msgid "VDE Socket"
+msgstr "VDE Socket:"
 
 msgid "COM1 Device:"
 msgstr "COM1 Device:"
@@ -489,6 +561,18 @@ msgstr "Serial port 3"
 
 msgid "Serial port 4"
 msgstr "Serial port 4"
+
+msgid "Serial port passthrough 1"
+msgstr "Serial port passthrough 1"
+
+msgid "Serial port passthrough 2"
+msgstr "Serial port passthrough 2"
+
+msgid "Serial port passthrough 3"
+msgstr "Serial port passthrough 3"
+
+msgid "Serial port passthrough 4"
+msgstr "Serial port passthrough 4"
 
 msgid "Parallel port 1"
 msgstr "Parallel port 1"
@@ -541,8 +625,14 @@ msgstr "&New..."
 msgid "&Existing..."
 msgstr "&Existing..."
 
+msgid "Browse..."
+msgstr "Browse..."
+
 msgid "&Remove"
 msgstr "&Remove"
+
+msgid "Remove"
+msgstr "Remove"
 
 msgid "Bus:"
 msgstr "Bus:"
@@ -625,6 +715,9 @@ msgstr "ISABugger device"
 msgid "POST card"
 msgstr "POST card"
 
+msgid "86Box Unit Tester"
+msgstr "86Box Unit Tester"
+
 msgid "FONT_SIZE"
 msgstr "9"
 
@@ -660,6 +753,9 @@ msgstr "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://
 
 msgid "(empty)"
 msgstr "(empty)"
+
+msgid "Clear image history"
+msgstr "Clear image history"
 
 msgid "All files"
 msgstr "All files"
@@ -940,8 +1036,8 @@ msgstr "Cartridge images"
 msgid "Error initializing renderer"
 msgstr "Error initializing renderer"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "OpenGL 3.0 renderer could not be initialized. Use another renderer."
 
 msgid "Resume execution"
 msgstr "Resume execution"

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -49,8 +49,8 @@ msgstr "SDL (&Hardware)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (&OpenGL)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "Open&GL (3.0 Core)"
+msgid "Open&GL 3.0"
+msgstr "Open&GL 3.0"
 
 msgid "&VNC"
 msgstr "&VNC"
@@ -385,8 +385,8 @@ msgstr "Recompilador Dinámico"
 msgid "Video:"
 msgstr "Vídeo:"
 
-msgid "Voodoo Graphics"
-msgstr "Voodoo Graphics"
+msgid "3Dfx Voodoo Graphics"
+msgstr "3Dfx Voodoo Graphics"
 
 msgid "IBM 8514/A Graphics"
 msgstr "IBM 8514/A Graphics"
@@ -940,8 +940,8 @@ msgstr "Imágenes de Cartucho"
 msgid "Error initializing renderer"
 msgstr "Error al inicializar el renderizador"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "No fué posible inicializar el renderizador OpenGL (3.0 Core). Utilice otro renderizador."
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "No fué posible inicializar el renderizador OpenGL 3.0. Utilice otro renderizador."
 
 msgid "Resume execution"
 msgstr "Retomar la ejecución"

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -49,8 +49,8 @@ msgstr "SDL (&laitteistokiihdytetty)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (&OpenGL)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "Open&GL (3.0 Core)"
+msgid "Open&GL 3.0"
+msgstr "Open&GL 3.0"
 
 msgid "&VNC"
 msgstr "&VNC"
@@ -385,8 +385,8 @@ msgstr "Dynaaminen uudelleenkääntäjä"
 msgid "Video:"
 msgstr "Näytönohjain:"
 
-msgid "Voodoo Graphics"
-msgstr "Voodoo-grafiikkasuoritin"
+msgid "3Dfx Voodoo Graphics"
+msgstr "3Dfx Voodoo-grafiikkasuoritin"
 
 msgid "IBM 8514/A Graphics"
 msgstr "IBM 8514/A-grafiikkasuoritin"
@@ -940,8 +940,8 @@ msgstr "ROM-moduulikuvat"
 msgid "Error initializing renderer"
 msgstr "Virhe renderöijän alustuksessa"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "OpenGL (3.0 Core) -renderöijän alustus epäonnistui. Käytä toista renderöijää."
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "OpenGL 3.0 -renderöijän alustus epäonnistui. Käytä toista renderöijää."
 
 msgid "Resume execution"
 msgstr "Jatka suoritusta"

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -49,8 +49,8 @@ msgstr "SDL (&Materiel)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (&OpenGL)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "Open&GL (3.0 Core)"
+msgid "Open&GL 3.0"
+msgstr "Open&GL 3.0"
 
 msgid "&VNC"
 msgstr "&VNC"
@@ -385,8 +385,8 @@ msgstr "Recompilateur dynamique"
 msgid "Video:"
 msgstr "Vidéo:"
 
-msgid "Voodoo Graphics"
-msgstr "Graphique Voodoo"
+msgid "3Dfx Voodoo Graphics"
+msgstr "Graphique 3Dfx Voodoo"
 
 msgid "IBM 8514/A Graphics"
 msgstr "Graphique IBM 8514/A"
@@ -940,8 +940,8 @@ msgstr "Images cartouche"
 msgid "Error initializing renderer"
 msgstr "Erreur d'initialisation du moteur de rendu"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "Le moteur de rendu OpenGL (3.0 Core) n'a pas pu être initialisé. Utilisez un autre moteur de rendu."
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "Le moteur de rendu OpenGL 3.0 n'a pas pu être initialisé. Utilisez un autre moteur de rendu."
 
 msgid "Resume execution"
 msgstr "Reprendre l'exécution"

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -49,8 +49,8 @@ msgstr "SDL (&Hardver)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (&OpenGL)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "Open&GL (3.0 jezgra)"
+msgid "Open&GL 3.0"
+msgstr "Open&GL 3.0"
 
 msgid "&VNC"
 msgstr "&VNC"
@@ -385,8 +385,8 @@ msgstr "Dinamički rekompilator"
 msgid "Video:"
 msgstr "Video:"
 
-msgid "Voodoo Graphics"
-msgstr "Voodoo grafika"
+msgid "3Dfx Voodoo Graphics"
+msgstr "3Dfx Voodoo grafika"
 
 msgid "IBM 8514/A Graphics"
 msgstr "IBM 8514/A grafika"
@@ -940,8 +940,8 @@ msgstr "Slike kasete"
 msgid "Error initializing renderer"
 msgstr "Nije moguće inicijalizirati renderer"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "Nije moguće inicijalizirati OpenGL (3.0 jezgra) renderer. Molimte koristite drugi renderer."
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "Nije moguće inicijalizirati OpenGL 3.0 renderer. Molimte koristite drugi renderer."
 
 msgid "Resume execution"
 msgstr "Nastavi"

--- a/src/qt/languages/hu-HU.po
+++ b/src/qt/languages/hu-HU.po
@@ -49,8 +49,8 @@ msgstr "SDL (&Hardveres)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (&OpenGL)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "Open&GL (3.0 Core)"
+msgid "Open&GL 3.0"
+msgstr "Open&GL 3.0"
 
 msgid "&VNC"
 msgstr "&VNC"
@@ -385,8 +385,8 @@ msgstr "Dinamikus újrafordítás"
 msgid "Video:"
 msgstr "Videokártya:"
 
-msgid "Voodoo Graphics"
-msgstr "Voodoo-gyorsítókártya"
+msgid "3Dfx Voodoo Graphics"
+msgstr "3Dfx Voodoo-gyorsítókártya"
 
 msgid "IBM 8514/A Graphics"
 msgstr "IBM 8514/A-gyorsítókártya"
@@ -940,8 +940,8 @@ msgstr "ROM-kazetta képek"
 msgid "Error initializing renderer"
 msgstr "Hiba történt a renderelő inicializálásakor"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "Az OpenGL (3.0 Core) megjelenítő-motort nem sikerült inicializálni. Kérem használjon másik renderelőt."
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "Az OpenGL 3.0 megjelenítő-motort nem sikerült inicializálni. Kérem használjon másik renderelőt."
 
 msgid "Resume execution"
 msgstr "Folytassa a végrehajtást"

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -49,8 +49,8 @@ msgstr "SDL (&Hardware)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (&OpenGL)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "Open&GL (3.0 Core)"
+msgid "Open&GL 3.0"
+msgstr "Open&GL 3.0"
 
 msgid "&VNC"
 msgstr "&VNC"
@@ -385,8 +385,8 @@ msgstr "Ricompilatore dinamico"
 msgid "Video:"
 msgstr "Video:"
 
-msgid "Voodoo Graphics"
-msgstr "Grafica Voodoo"
+msgid "3Dfx Voodoo Graphics"
+msgstr "Grafica 3Dfx Voodoo"
 
 msgid "IBM 8514/A Graphics"
 msgstr "Grafica IBM 8514/A"
@@ -940,8 +940,8 @@ msgstr "Immagini cartuccia"
 msgid "Error initializing renderer"
 msgstr "Errore nell'inizializzazione del renderer"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "Non è stato possibile inizializzare il renderer OpenGL (3.0 Core). Utilizzare un altro renderer."
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "Non è stato possibile inizializzare il renderer OpenGL 3.0. Utilizzare un altro renderer."
 
 msgid "Resume execution"
 msgstr "Riprendere l'esecuzione"

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -49,8 +49,8 @@ msgstr "SDL (ハードウェア)(&H)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (OpenGL)(&O)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "OpenGL (3.0コア)(&G)"
+msgid "Open&GL 3.0"
+msgstr "OpenGL 3.0(&G)"
 
 msgid "&VNC"
 msgstr "VNC(&V)"
@@ -385,8 +385,8 @@ msgstr "動的再コンパイル"
 msgid "Video:"
 msgstr "ビデオカード:"
 
-msgid "Voodoo Graphics"
-msgstr "Voodooグラフィック"
+msgid "3Dfx Voodoo Graphics"
+msgstr "3Dfx Voodooグラフィック"
 
 msgid "IBM 8514/A Graphics"
 msgstr "IBM 8514/Aグラフィック"
@@ -940,8 +940,8 @@ msgstr "カートリッジイメージ"
 msgid "Error initializing renderer"
 msgstr "レンダラーの初期化エラー"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "OpenGL (3.0コア) レンダラーが初期化できません。別のレンダラーを使用してください。"
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "OpenGL 3.0 レンダラーが初期化できません。別のレンダラーを使用してください。"
 
 msgid "Resume execution"
 msgstr "実行を再開"

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -49,8 +49,8 @@ msgstr "SDL (하드웨어)(&H)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (OpenGL)(&O)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "OpenGL (3.0 코어)(&G)"
+msgid "Open&GL 3.0"
+msgstr "OpenGL 3.0(&G)"
 
 msgid "&VNC"
 msgstr "VNC(&V)"
@@ -385,8 +385,8 @@ msgstr "동적 재컴파일"
 msgid "Video:"
 msgstr "비디오 카드:"
 
-msgid "Voodoo Graphics"
-msgstr "Voodoo 그래픽"
+msgid "3Dfx Voodoo Graphics"
+msgstr "3Dfx Voodoo 그래픽"
 
 msgid "IBM 8514/A Graphics"
 msgstr "IBM 8514/A 그래픽"
@@ -940,8 +940,8 @@ msgstr "카트리지 이미지"
 msgid "Error initializing renderer"
 msgstr "렌더러 초기화 오류"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "OpenGL (3.0 Core) 렌더러를 초기화할 수 없습니다. 다른 렌더러를 사용하십시오."
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "OpenGL 3.0 렌더러를 초기화할 수 없습니다. 다른 렌더러를 사용하십시오."
 
 msgid "Resume execution"
 msgstr "실행 재개"

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -49,8 +49,8 @@ msgstr "SDL (&Hardware)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (&OpenGL)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "Open&GL (3.0 Core)"
+msgid "Open&GL 3.0"
+msgstr "Open&GL 3.0"
 
 msgid "&VNC"
 msgstr "&VNC"
@@ -385,8 +385,8 @@ msgstr "Dynamiczny rekompilator"
 msgid "Video:"
 msgstr "Wideo:"
 
-msgid "Voodoo Graphics"
-msgstr "Grafika Voodoo"
+msgid "3Dfx Voodoo Graphics"
+msgstr "Grafika 3Dfx Voodoo"
 
 msgid "IBM 8514/A Graphics"
 msgstr "Grafika IBM 8514/A"
@@ -940,8 +940,8 @@ msgstr "Obrazy kartrydżu"
 msgid "Error initializing renderer"
 msgstr "Błąd inicjalizacji renderera"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "Nie można zainicjować renderera OpenGL (3.0 Core). Użyj innego."
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "Nie można zainicjować renderera OpenGL 3.0. Użyj innego."
 
 msgid "Resume execution"
 msgstr "Wznów wykonywanie"

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -49,8 +49,8 @@ msgstr "SDL (&Hardware)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (&OpenGL)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "Open&GL (Núcleo 3.0)"
+msgid "Open&GL 3.0"
+msgstr "Open&GL 3.0"
 
 msgid "&VNC"
 msgstr "&VNC"
@@ -350,7 +350,7 @@ msgid "CPU type:"
 msgstr "Tipo de CPU:"
 
 msgid "Speed:"
-msgstr "Veloc.:"
+msgstr "Velocidade:"
 
 msgid "Frequency:"
 msgstr "Frequência:"
@@ -385,8 +385,8 @@ msgstr "Recompilador dinâmico"
 msgid "Video:"
 msgstr "Vídeo:"
 
-msgid "Voodoo Graphics"
-msgstr "3DFX Voodoo"
+msgid "3Dfx Voodoo Graphics"
+msgstr "Gráficos 3Dfx Voodoo"
 
 msgid "IBM 8514/A Graphics"
 msgstr "Gráficos IBM 8514/A"
@@ -940,8 +940,8 @@ msgstr "Imagens de cartucho"
 msgid "Error initializing renderer"
 msgstr "Erro ao inicializar o renderizador"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "O renderizador OpenGL (Núcleo 3.0) não pôde ser inicializado. Use outro renderizador."
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "O renderizador OpenGL 3.0 não pôde ser inicializado. Use outro renderizador."
 
 msgid "Resume execution"
 msgstr "Continuar a execução"

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -49,8 +49,8 @@ msgstr "SDL (&Hardware)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (&OpenGL)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "Open&GL (Núcleo 3.0)"
+msgid "Open&GL 3.0"
+msgstr "Open&GL 3.0"
 
 msgid "&VNC"
 msgstr "&VNC"
@@ -385,8 +385,8 @@ msgstr "Recompilador dinâmico"
 msgid "Video:"
 msgstr "Vídeo:"
 
-msgid "Voodoo Graphics"
-msgstr "Gráficos Voodoo"
+msgid "3Dfx Voodoo Graphics"
+msgstr "Gráficos 3Dfx Voodoo"
 
 msgid "IBM 8514/A Graphics"
 msgstr "Gráficos IBM 8514/A"
@@ -940,8 +940,8 @@ msgstr "Imagens de cartucho"
 msgid "Error initializing renderer"
 msgstr "Erro na inicialização do renderizador"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "Não foi possível inicializar o renderizador OpenGL (3.0 Core). Utilize outro renderizador."
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "Não foi possível inicializar o renderizador OpenGL 3.0. Utilize outro renderizador."
 
 msgid "Resume execution"
 msgstr "Retomar execução"

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -55,8 +55,8 @@ msgstr "SDL (&Hardware)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (&OpenGL)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "Open&GL (3.0)"
+msgid "Open&GL 3.0"
+msgstr "Open&GL 3.0"
 
 msgid "&VNC"
 msgstr "&VNC"
@@ -403,6 +403,9 @@ msgstr "FPU:"
 msgid "Wait states:"
 msgstr "Циклы ожидания:"
 
+msgid "PIT Mode:"
+msgstr "Режим PIT:"
+
 msgid "MB"
 msgstr "МБ"
 
@@ -430,14 +433,14 @@ msgstr "Видеокарта 1:"
 msgid "Video #2:"
 msgstr "Видеокарта 2:"
 
-msgid "Voodoo Graphics"
-msgstr "Ускоритель Voodoo"
+msgid "3Dfx Voodoo Graphics"
+msgstr "3Dfx Voodoo Graphics"
 
 msgid "IBM 8514/A Graphics"
-msgstr "Ускоритель IBM 8514/A"
+msgstr "IBM 8514/A Graphics"
 
 msgid "XGA Graphics"
-msgstr "Ускоритель XGA"
+msgstr "XGA Graphics"
 
 msgid "Mouse:"
 msgstr "Мышь:"
@@ -712,6 +715,9 @@ msgstr "Устройство ISABugger"
 msgid "POST card"
 msgstr "Карта POST"
 
+msgid "86Box Unit Tester"
+msgstr "Модульный Тестер 86Box"
+
 msgid "FONT_SIZE"
 msgstr "9"
 
@@ -947,7 +953,7 @@ msgid "About 86Box"
 msgstr "О 86Box"
 
 msgid "86Box v"
-msgstr "86Box v."
+msgstr "86Box v"
 
 msgid "An emulator of old computers\n\nAuthors: Miran Grča (OBattler), RichardG867, Jasmine Iwanek, TC1995, coldbrewed, Teemu Korhonen (Manaatti), Joakim L. Gilje, Adrien Moulin (elyosh), Daniel Balsom (gloriouscow), Cacodemon345, Fred N. van Kempen (waltje), Tiseno100, reenigne, and others.\n\nWith previous core contributions from Sarah Walker, leilei, JohnElliott, greatpsycho, and others.\n\nReleased under the GNU General Public License version 2 or later. See LICENSE for more information."
 msgstr "Эмулятор старых компьютеров\n\nАвторы: Miran Grča (OBattler), RichardG867, Jasmine Iwanek, TC1995, coldbrewed, Teemu Korhonen (Manaatti), Joakim L. Gilje, Adrien Moulin (elyosh), Daniel Balsom (gloriouscow), Cacodemon345, Fred N. van Kempen (waltje), Tiseno100, reenigne, and others.\n\nWith previous core contributions from Sarah Walker, leilei, JohnElliott, greatpsycho, and others.\n\nВыпускается под лицензией GNU General Public License версии 2 или более поздней. Дополнительную информацию см. в файле LICENSE."
@@ -1030,8 +1036,8 @@ msgstr "Образы картриджей"
 msgid "Error initializing renderer"
 msgstr "Ошибка инициализации рендерера"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "Невозможно инициализировать рендерер OpenGL (3.0). Пожалуйста, используйте другой рендерер."
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "Невозможно инициализировать рендерер OpenGL 3.0. Пожалуйста, используйте другой рендерер."
 
 msgid "Resume execution"
 msgstr "Возобновить выполнение"

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -49,8 +49,8 @@ msgstr "SDL (&Hardware)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (&OpenGL)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "Open&GL (3.0 Core)"
+msgid "Open&GL 3.0"
+msgstr "Open&GL 3.0"
 
 msgid "&VNC"
 msgstr "&VNC"
@@ -385,8 +385,8 @@ msgstr "Dynamický prekladač"
 msgid "Video:"
 msgstr "Grafika:"
 
-msgid "Voodoo Graphics"
-msgstr "Použiť grafický akcelerátor Voodoo"
+msgid "3Dfx Voodoo Graphics"
+msgstr "Použiť grafický akcelerátor 3Dfx Voodoo"
 
 msgid "IBM 8514/A Graphics"
 msgstr "Grafika IBM 8514/A"
@@ -940,8 +940,8 @@ msgstr "Obrazy cartridge"
 msgid "Error initializing renderer"
 msgstr "Chyba pri inicializácii vykresľovača"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "Vykresľovač OpenGL (3.0 Core) sa nepodarilo inicializovať. Použite iný renderer."
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "Vykresľovač OpenGL 3.0 sa nepodarilo inicializovať. Použite iný renderer."
 
 msgid "Resume execution"
 msgstr "Obnoviť"

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -49,8 +49,8 @@ msgstr "SDL (s&trojno)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (&OpenGL)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "Open&GL (Jedro 3.0)"
+msgid "Open&GL 3.0"
+msgstr "Open&GL 3.0"
 
 msgid "&VNC"
 msgstr "&VNC"
@@ -385,8 +385,8 @@ msgstr "Dinamični prevajalnik"
 msgid "Video:"
 msgstr "Video:"
 
-msgid "Voodoo Graphics"
-msgstr "Voodoo grafika"
+msgid "3Dfx Voodoo Graphics"
+msgstr "3Dfx Voodoo grafika"
 
 msgid "IBM 8514/A Graphics"
 msgstr "IBM 8514/A grafika"
@@ -940,8 +940,8 @@ msgstr "Slike spominskega vložka"
 msgid "Error initializing renderer"
 msgstr "Napaka pri zagonu sistema za upodabljanje"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "Sistema za upodabljanje OpenGL (3.0 Core) ni bilo mogoče zagnati. Uporabite drug sistem za upodabljanje."
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "Sistema za upodabljanje OpenGL 3.0 ni bilo mogoče zagnati. Uporabite drug sistem za upodabljanje."
 
 msgid "Resume execution"
 msgstr "Nadaljuj izvajanje"

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -49,8 +49,8 @@ msgstr "SDL (&Donanım)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (&OpenGL)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "Open&GL (3.0 Core)"
+msgid "Open&GL 3.0"
+msgstr "Open&GL 3.0"
 
 msgid "&VNC"
 msgstr "&VNC"
@@ -385,8 +385,8 @@ msgstr "Dinamik Derleyici"
 msgid "Video:"
 msgstr "Ekran kartı:"
 
-msgid "Voodoo Graphics"
-msgstr "Voodoo Grafikleri"
+msgid "3Dfx Voodoo Graphics"
+msgstr "3Dfx Voodoo Grafikleri"
 
 msgid "IBM 8514/A Graphics"
 msgstr "IBM 8514/A Grafikleri"
@@ -940,8 +940,8 @@ msgstr "Kartuş imajları"
 msgid "Error initializing renderer"
 msgstr "Oluşturucu başlatılırken hata oluştu"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "OpenGL (3.0 Core) görüntüleyici başlatılamadı. Başka bir görüntüleyici kullanın."
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "OpenGL 3.0 görüntüleyici başlatılamadı. Başka bir görüntüleyici kullanın."
 
 msgid "Resume execution"
 msgstr "Yürütmeye devam et"

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -49,8 +49,8 @@ msgstr "SDL (&Hardware)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (&OpenGL)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "Open&GL (3.0)"
+msgid "Open&GL 3.0"
+msgstr "Open&GL 3.0"
 
 msgid "&VNC"
 msgstr "&VNC"
@@ -385,8 +385,8 @@ msgstr "Динамічний рекомпілятор"
 msgid "Video:"
 msgstr "Відеокарта:"
 
-msgid "Voodoo Graphics"
-msgstr "Прискорювач Voodoo"
+msgid "3Dfx Voodoo Graphics"
+msgstr "Прискорювач 3Dfx Voodoo"
 
 msgid "IBM 8514/A Graphics"
 msgstr "Прискорювач IBM 8514/A"
@@ -857,7 +857,7 @@ msgid "About 86Box"
 msgstr "Про 86Box"
 
 msgid "86Box v"
-msgstr "86Box v."
+msgstr "86Box v"
 
 msgid "An emulator of old computers\n\nAuthors: Miran Grča (OBattler), RichardG867, Jasmine Iwanek, TC1995, coldbrewed, Teemu Korhonen (Manaatti), Joakim L. Gilje, Adrien Moulin (elyosh), Daniel Balsom (gloriouscow), Cacodemon345, Fred N. van Kempen (waltje), Tiseno100, reenigne, and others.\n\nWith previous core contributions from Sarah Walker, leilei, JohnElliott, greatpsycho, and others.\n\nReleased under the GNU General Public License version 2 or later. See LICENSE for more information."
 msgstr "Емулятор старих комп'ютерів\n\nАвтори: Miran Grča (OBattler), RichardG867, Jasmine Iwanek, TC1995, coldbrewed, Teemu Korhonen (Manaatti), Joakim L. Gilje, Adrien Moulin (elyosh), Daniel Balsom (gloriouscow), Cacodemon345, Fred N. van Kempen (waltje), Tiseno100, reenigne, and others.\n\nWith previous core contributions from Sarah Walker, leilei, JohnElliott, greatpsycho, and others.\n\nВипускаєтся під ліцензією GNU General Public License версії 2 або більше пізніше. Додадкову інформацію см. у файлі LICENSE."
@@ -940,8 +940,8 @@ msgstr "Образи картриджів"
 msgid "Error initializing renderer"
 msgstr "Помилка ініціалізації рендерера"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "Неможливо ініціалізувати рендерер OpenGL (3.0). Будь ласка, використовуйте інший рендерер."
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "Неможливо ініціалізувати рендерер OpenGL 3.0. Будь ласка, використовуйте інший рендерер."
 
 msgid "Resume execution"
 msgstr "Відновити виконання"

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -49,8 +49,8 @@ msgstr "SDL (硬件)(&H)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (OpenGL)(&O)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "OpenGL (3.0 核心)(&G)"
+msgid "Open&GL 3.0"
+msgstr "OpenGL 3.0(&G)"
 
 msgid "&VNC"
 msgstr "VNC(&V)"
@@ -385,8 +385,8 @@ msgstr "动态重编译器"
 msgid "Video:"
 msgstr "显卡:"
 
-msgid "Voodoo Graphics"
-msgstr "Voodoo Graphics"
+msgid "3Dfx Voodoo Graphics"
+msgstr "3Dfx Voodoo Graphics"
 
 msgid "IBM 8514/A Graphics"
 msgstr "IBM 8514/A Graphics"
@@ -940,8 +940,8 @@ msgstr "卡带映像"
 msgid "Error initializing renderer"
 msgstr "初始化渲染器时出错"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "无法初始化 OpenGL (3.0 核心) 渲染器。请使用其他渲染器。"
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "无法初始化 OpenGL 3.0 渲染器。请使用其他渲染器。"
 
 msgid "Resume execution"
 msgstr "恢复执行"

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -49,8 +49,8 @@ msgstr "SDL (硬體)(&H)"
 msgid "SDL (&OpenGL)"
 msgstr "SDL (OpenGL)(&O)"
 
-msgid "Open&GL (3.0 Core)"
-msgstr "OpenGL (3.0 核心)(&G)"
+msgid "Open&GL 3.0"
+msgstr "OpenGL 3.0(&G)"
 
 msgid "&VNC"
 msgstr "VNC(&V)"
@@ -385,8 +385,8 @@ msgstr "動態重編譯器"
 msgid "Video:"
 msgstr "顯示卡:"
 
-msgid "Voodoo Graphics"
-msgstr "Voodoo Graphics"
+msgid "3Dfx Voodoo Graphics"
+msgstr "3Dfx Voodoo Graphics"
 
 msgid "IBM 8514/A Graphics"
 msgstr "IBM 8514/A Graphics"
@@ -940,8 +940,8 @@ msgstr "卡帶映像"
 msgid "Error initializing renderer"
 msgstr "初始化渲染器時出錯"
 
-msgid "OpenGL (3.0 Core) renderer could not be initialized. Use another renderer."
-msgstr "無法初始化 OpenGL (3.0 核心) 渲染器。請使用其他渲染器。"
+msgid "OpenGL 3.0 renderer could not be initialized. Use another renderer."
+msgstr "無法初始化 OpenGL 3.0 渲染器。請使用其他渲染器。"
 
 msgid "Resume execution"
 msgstr "恢復執行"

--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -731,7 +731,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Open&amp;GL (3.0 Core)</string>
+    <string>Open&amp;GL 3.0</string>
    </property>
    <property name="vid_api" stdset="0">
     <number>3</number>

--- a/src/qt/qt_settingsdisplay.ui
+++ b/src/qt/qt_settingsdisplay.ui
@@ -62,7 +62,7 @@
    <item row="1" column="0" colspan="2">
     <widget class="QComboBox" name="comboBoxVideo">
      <property name="maxVisibleItems">
-      <number>35</number>
+      <number>30</number>
      </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">

--- a/src/qt/qt_settingsdisplay.ui
+++ b/src/qt/qt_settingsdisplay.ui
@@ -62,7 +62,7 @@
    <item row="1" column="0" colspan="2">
     <widget class="QComboBox" name="comboBoxVideo">
      <property name="maxVisibleItems">
-      <number>30</number>
+      <number>35</number>
      </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -102,7 +102,7 @@
    <item row="4" column="0" colspan="2">
     <widget class="QCheckBox" name="checkBoxVoodoo">
      <property name="text">
-      <string>Voodoo Graphics</string>
+      <string>3Dfx Voodoo Graphics</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Summary
=======
1. Adding missing translation strings to RU, en-US, en-GB. Based on en-US, it is now easier to translate for other languages.
2. For all languages, "OpenGL (3.0 Core)" has been corrected to "OpenGL 3.0", since this looks more preferable (in most programs, for example AIDA64, OpenGL 3.0 is written without parentheses)
3. For RU, en-US, en-GB corrected to “Video card 1:”, “Sound card 1:” (etc).
4. For RU and uk-UA corrected "v." to "v", since in other languages "v" is written without a dot and in most programs "v" is written without a dot.
5. For most languages, “3Dfx Voodoo Graphics”, “IBM 8514/A Graphics”, “XGA Graphics” are left without translation, since these are the original names of video cards.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
