### PR TITLE
Add A-Trend 4GPV5 machine

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -533,6 +533,7 @@ extern int machine_at_win471_init(const machine_t *);
 extern int machine_at_pci400ca_init(const machine_t *);
 extern int machine_at_vi15g_init(const machine_t *);
 extern int machine_at_greenb_init(const machine_t *);
+extern int machine_at_4gpv5_init(const machine_t *);
 
 extern int machine_at_r418_init(const machine_t *);
 extern int machine_at_ls486e_init(const machine_t *);

--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -921,6 +921,29 @@ machine_at_greenb_init(const machine_t *model)
     return ret;
 }
 
+int
+machine_at_4gpv5_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/4gpv5/4GPV5.bin",
+                           0x000f0000, 65536, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_common_init(model);
+
+    if (fdc_type == FDC_INTERNAL)
+        device_add(&fdc_at_device);
+
+    device_add(&contaq_82c596a_device);
+
+    device_add(&keyboard_at_device);
+
+    return ret;
+}
+
 static void
 machine_at_sis_85c496_common_init(UNUSED(const machine_t *model))
 {

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -6204,6 +6204,46 @@ const machine_t machines[] = {
 
     /* 486 machines - Socket 3 */
     /* 486 machines with just the ISA slot */
+    /* Has a Fujitsu MBL8042H KBC. */
+    {
+        .name = "[Contaq 82C596A] A-Trend 4GPV5",
+        .internal_name = "4gpv5",
+        .type = MACHINE_TYPE_486_S3,
+        .chipset = MACHINE_CHIPSET_CONTAQ_82C596,
+        .init = machine_at_4gpv5_init,
+        .p1_handler = NULL,
+        .gpio_handler = NULL,
+        .available_flag = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu = {
+            .package = CPU_PKG_SOCKET3,
+            .block = CPU_BLOCK_NONE,
+            .min_bus = 0,
+            .max_bus = 0,
+            .min_voltage = 0,
+            .max_voltage = 0,
+            .min_multi = 0,
+            .max_multi = 0
+        },
+        .bus_flags = MACHINE_VLB,
+        .flags = MACHINE_APM,
+        .ram = {
+            .min = 1024,
+            .max = 65536,
+            .step = 1024
+        },
+        .nvrmask = 127,
+        .kbc_device = NULL,
+        .kbc_p1 = 0xff,
+        .gpio = 0xffffffff,
+        .gpio_acpi = 0xffffffff,
+        .device = NULL,
+        .fdc_device = NULL,
+        .sio_device = NULL,
+        .vid_device = NULL,
+        .snd_device = NULL,
+        .net_device = NULL
+    },
     /* Has AMI MegaKey KBC firmware. */
     {
         .name = "[Contaq 82C597] Visionex Green-B",


### PR DESCRIPTION
Summary
=======
This PR adds the A-Trend 4GPV5 machine, which is based on the Contaq 82C596A chipset and has an Award 4.99G BIOS.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/242/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
