### PR TITLE
SCSI CD-ROM fixes of the day.

### DIFF
--- a/src/cdrom/cdrom.c
+++ b/src/cdrom/cdrom.c
@@ -442,7 +442,7 @@ cdrom_audio_callback(cdrom_t *dev, int16_t *output, int len)
 {
     int ret = 1;
 
-    if (!dev->sound_on || (dev->cd_status != CD_STATUS_PLAYING)) {
+    if (!dev->sound_on || (dev->cd_status != CD_STATUS_PLAYING) || dev->audio_muted_soft) {
         cdrom_log("CD-ROM %i: Audio callback while not playing\n", dev->id);
         if (dev->cd_status == CD_STATUS_PLAYING)
             dev->seek_pos += (len >> 11);
@@ -557,6 +557,7 @@ cdrom_audio_play(cdrom_t *dev, uint32_t pos, uint32_t len, int ismsf)
         len += pos;
     }
 
+    dev->audio_muted_soft = 0;
     /* Do this at this point, since it's at this point that we know the
        actual LBA position to start playing from. */
     if (!(dev->ops->track_type(dev, pos) & CD_TRACK_AUDIO)) {
@@ -578,6 +579,7 @@ cdrom_audio_track_search(cdrom_t *dev, uint32_t pos, int type, uint8_t playbit)
     int m = 0;
     int s = 0;
     int f = 0;
+    uint32_t pos2 = 0;
 
     if (dev->cd_status == CD_STATUS_DATA_ONLY)
         return 0;
@@ -614,14 +616,21 @@ cdrom_audio_track_search(cdrom_t *dev, uint32_t pos, int type, uint8_t playbit)
             break;
     }
 
+    pos2 = pos - 1;
+    if (pos2 == 0xffffffff)
+        pos2 = pos + 1;
+
     /* Do this at this point, since it's at this point that we know the
        actual LBA position to start playing from. */
-    if (!(dev->ops->track_type(dev, pos) & CD_TRACK_AUDIO)) {
-        cdrom_log("CD-ROM %i: LBA %08X not on an audio track\n", dev->id, pos);
-        cdrom_stop(dev);
-        return 0;
-    }
+    if (!(dev->ops->track_type(dev, pos2) & CD_TRACK_AUDIO)) {
+        cdrom_log("CD-ROM %i: Track Search: LBA %08X not on an audio track\n", dev->id, pos);
+        dev->audio_muted_soft = 1;
+        if (dev->ops->track_type(dev, pos) & CD_TRACK_AUDIO)
+            dev->audio_muted_soft = 0;
+    } else
+        dev->audio_muted_soft = 0;
 
+    cdrom_log("Track Search Toshiba: Muted?=%d, LBA=%08X.\n", dev->audio_muted_soft, pos);
     dev->cd_buflen = 0;
     dev->cd_status = playbit ? CD_STATUS_PLAYING : CD_STATUS_PAUSED;
     return 1;
@@ -647,6 +656,7 @@ cdrom_audio_track_search_pioneer(cdrom_t *dev, uint32_t pos, uint8_t playbit)
 
     dev->seek_pos = pos;
 
+    dev->audio_muted_soft = 0;
     /* Do this at this point, since it's at this point that we know the
        actual LBA position to start playing from. */
     if (!(dev->ops->track_type(dev, pos) & CD_TRACK_AUDIO)) {
@@ -676,6 +686,7 @@ cdrom_audio_play_pioneer(cdrom_t *dev, uint32_t pos)
     pos = MSFtoLBA(m, s, f) - 150;
     dev->cd_end = pos;
 
+    dev->audio_muted_soft = 0;
     dev->cd_buflen = 0;
     dev->cd_status = CD_STATUS_PLAYING;
     return 1;
@@ -717,16 +728,7 @@ cdrom_audio_play_toshiba(cdrom_t *dev, uint32_t pos, int type)
             break;
     }
 
-    cdrom_log("Toshiba/NEC Play Audio: MSF = %06x, type = %02x, cdstatus = %02x\n", pos, type, dev->cd_status);
-
-    /* Do this at this point, since it's at this point that we know the
-       actual LBA position to start playing from. */
-    if (!(dev->ops->track_type(dev, pos) & CD_TRACK_AUDIO)) {
-        cdrom_log("CD-ROM %i: LBA %08X not on an audio track\n", dev->id, pos);
-        cdrom_stop(dev);
-        return 0;
-    }
-
+    cdrom_log("Toshiba Play Audio: Muted?=%d, LBA=%08X.\n", dev->audio_muted_soft, pos);
     dev->cd_buflen = 0;
     dev->cd_status = CD_STATUS_PLAYING;
     return 1;
@@ -770,6 +772,7 @@ cdrom_audio_scan(cdrom_t *dev, uint32_t pos, int type)
             break;
     }
 
+    dev->audio_muted_soft = 0;
     /* Do this at this point, since it's at this point that we know the
        actual LBA position to start playing from. */
     if (!(dev->ops->track_type(dev, pos) & CD_TRACK_AUDIO)) {
@@ -1007,6 +1010,11 @@ cdrom_get_current_subcodeq_playstatus(cdrom_t *dev, uint8_t *b)
     else
         ret = (dev->cd_status == CD_STATUS_PLAYING) ? 0x00 : dev->audio_op;
 
+    /*If a valid audio track is detected with audio on, unmute it.*/
+    if (dev->ops->track_type(dev, dev->seek_pos) & CD_TRACK_AUDIO)
+        dev->audio_muted_soft = 0;
+
+    cdrom_log("SubCodeQ: Play Status: Seek LBA=%08x, CDEND=%08x, mute=%d.\n", dev->seek_pos, dev->cd_end, dev->audio_muted_soft);
     b[0] = subc.attr;
     b[1] = bin2bcd(subc.track);
     b[2] = bin2bcd(subc.index);

--- a/src/include/86box/cdrom.h
+++ b/src/include/86box/cdrom.h
@@ -244,6 +244,7 @@ typedef struct cdrom {
     int prev_host_drive;
     int cd_buflen;
     int audio_op;
+    int audio_muted_soft;
     int sony_msf;
 
     const cdrom_ops_t *ops;

--- a/src/scsi/scsi_cdrom.c
+++ b/src/scsi/scsi_cdrom.c
@@ -3613,6 +3613,14 @@ atapi_out:
                     dev->sony_vendor = 1;
 
                     len = (cdb[7] << 8) | cdb[8];
+                    if (!len) {
+                        scsi_cdrom_set_phase(dev, SCSI_PHASE_STATUS);
+                        scsi_cdrom_log("CD-ROM %i: PlayBack Control Sony All done - callback set\n", dev->id);
+                        dev->packet_status = PHASE_COMPLETE;
+                        dev->callback      = 20.0 * CDROM_TIME;
+                        scsi_cdrom_set_callback(dev);
+                        break;
+                    }
                     scsi_cdrom_buf_alloc(dev, 65536);
 
                     scsi_cdrom_set_buf_len(dev, BufLen, &len);


### PR DESCRIPTION
Summary
=======
1. Re-implemented in the best way possible the muted part of the Toshiba/NEC Play Audio commands and related, per spec.
2. Forgot to add a check to a Sony Vendor Data Out command  when the len is 0 it should become a Status command, fixes emulator crashes when len is 0 using some CD software.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
