### PR TITLE
Mach64 temporary updates:

### DIFF
--- a/src/include/86box/vid_svga_render.h
+++ b/src/include/86box/vid_svga_render.h
@@ -53,7 +53,7 @@ extern void svga_render_4bpp_lowres(svga_t *svga);
 extern void svga_render_4bpp_highres(svga_t *svga);
 extern void svga_render_8bpp_lowres(svga_t *svga);
 extern void svga_render_8bpp_highres(svga_t *svga);
-extern void svga_render_8bpp_incompatible_highres(svga_t *svga);
+extern void svga_render_8bpp_clone_highres(svga_t *svga);
 extern void svga_render_8bpp_tseng_lowres(svga_t *svga);
 extern void svga_render_8bpp_tseng_highres(svga_t *svga);
 extern void svga_render_8bpp_gs_lowres(svga_t *svga);

--- a/src/video/vid_ati68860_ramdac.c
+++ b/src/video/vid_ati68860_ramdac.c
@@ -130,7 +130,8 @@ ati68860_ramdac_out(uint16_t addr, uint8_t val, void *priv, svga_t *svga)
                             ramdac->render = svga_render_4bpp_highres;
                             break;
                         case 0x83:
-                            ramdac->render = svga_render_8bpp_highres;
+                            /*FIXME*/
+                            ramdac->render = svga_render_8bpp_clone_highres;
                             break;
                         case 0xa0:
                         case 0xb0:
@@ -155,7 +156,8 @@ ati68860_ramdac_out(uint16_t addr, uint8_t val, void *priv, svga_t *svga)
                             ramdac->render = svga_render_RGBA8888_highres;
                             break;
                         default:
-                            ramdac->render = svga_render_8bpp_highres;
+                            /*FIXME*/
+                            ramdac->render = svga_render_8bpp_clone_highres;
                             break;
                     }
                     break;
@@ -235,7 +237,8 @@ ati68860_ramdac_init(UNUSED(const device_t *info))
     ati68860_ramdac_t *ramdac = (ati68860_ramdac_t *) malloc(sizeof(ati68860_ramdac_t));
     memset(ramdac, 0, sizeof(ati68860_ramdac_t));
 
-    ramdac->render = svga_render_8bpp_highres;
+    /*FIXME*/
+    ramdac->render = svga_render_8bpp_clone_highres;
 
     return ramdac;
 }

--- a/src/video/vid_svga_render.c
+++ b/src/video/vid_svga_render.c
@@ -717,7 +717,7 @@ void svga_render_8bpp_lowres(svga_t *svga) { svga_render_indexed_gfx(svga, false
 void svga_render_8bpp_highres(svga_t *svga) { svga_render_indexed_gfx(svga, true, true); }
 
 void
-svga_render_8bpp_incompatible_highres(svga_t *svga)
+svga_render_8bpp_clone_highres(svga_t *svga)
 {
     int       x;
     uint32_t *p;


### PR DESCRIPTION
Summary
=======
Temporarily replace the ATI68860 8bpp renderer with a clone one while the current renderer (8bpp) is being fixed for proper colors on the Mach64.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
