### PR TITLE
Bumped the RAM min to 8MB on ASUS P5A

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -12265,7 +12265,7 @@ const machine_t machines[] = {
         .bus_flags = MACHINE_PS2_AGP,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_GAMEPORT | MACHINE_USB,
         .ram = {
-            .min = 1024,
+            .min = 8192,
             .max = 1572864,
             .step = 8192
         },


### PR DESCRIPTION
Summary
=======
Change the Minimum RAM to 8MB on ASUS P5A machine
It would cause a hang in the BIOS if it's lower than 8MB (screenshot below)
![86Box_2024-02-12_15-41-04](https://github.com/86Box/86Box/assets/46503276/de8ca4b4-bc43-4382-a2cc-c0f3498f904d)


Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
N/A
