### PR TITLE
MGA: For Millennium II and later, force VRAM amount to 16MB on non-dev-branch builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,23 +142,24 @@ option(DISCORD      "Discord Rich Presence support"                             
 
 # Development branch features
 #
-#                      Option         Description                                   Def.    Condition       Otherwise
-#                      ------         -----------                                   ----    ---------       ---------
-cmake_dependent_option(AMD_K5         "AMD K5"                                      ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(AN430TX        "Intel AN430TX"                               ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(CYRIX_6X86     "Cyrix 6x86"                                  ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(DESKPRO386     "Compaq Deskpro 386"                          ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(GUSMAX         "Gravis UltraSound MAX"                       ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(ISAMEM_RAMPAGE "AST Rampage"                                 ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(ISAMEM_IAB     "Intel Above Board"                           ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(ISAMEM_BRAT    "BocaRAM/AT"                                  ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(LASERXT        "VTech Laser XT"                              ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(OLIVETTI       "Olivetti M290"                               ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(OPEN_AT        "OpenAT"                                      ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(PAS16          "Pro Audio Spectrum 16"                       ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(SIO_DETECT     "Super I/O Detection Helper"                  ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(VGAWONDER      "ATI VGA Wonder (ATI-18800)"                  ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(XL24           "ATI VGA Wonder XL24 (ATI-28800-6)"           ON      "DEV_BRANCH"    OFF)
+#                      Option         Description                                                      Def.    Condition       Otherwise
+#                      ------         -----------                                                      ----    ---------       ---------
+cmake_dependent_option(AMD_K5          "AMD K5"                                                         ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(AN430TX         "Intel AN430TX"                                                  ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(CYRIX_6X86      "Cyrix 6x86"                                                     ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(DESKPRO386      "Compaq Deskpro 386"                                             ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(GUSMAX          "Gravis UltraSound MAX"                                          ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(ISAMEM_RAMPAGE  "AST Rampage"                                                    ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(ISAMEM_IAB      "Intel Above Board"                                              ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(ISAMEM_BRAT     "BocaRAM/AT"                                                     ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(LASERXT         "VTech Laser XT"                                                 ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(OLIVETTI        "Olivetti M290"                                                  ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(OPEN_AT         "OpenAT"                                                         ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(PAS16           "Pro Audio Spectrum 16"                                          ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(SIO_DETECT      "Super I/O Detection Helper"                                     ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(VGAWONDER       "ATI VGA Wonder (ATI-18800)"                                     ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(XL24            "ATI VGA Wonder XL24 (ATI-28800-6)"                              ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(MGA2_VMEM_SIZES "Configurable VRAM amount for Millennium II and Productiva G100" ON      "DEV_BRANCH"    OFF)
 
 # Ditto but for Qt
 if(QT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,6 @@ cmake_dependent_option(ISAMEM_RAMPAGE "AST Rampage"                             
 cmake_dependent_option(ISAMEM_IAB     "Intel Above Board"                           ON      "DEV_BRANCH"    OFF)
 cmake_dependent_option(ISAMEM_BRAT    "BocaRAM/AT"                                  ON      "DEV_BRANCH"    OFF)
 cmake_dependent_option(LASERXT        "VTech Laser XT"                              ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(MGA2           "Matrox Millennium II and Productiva G100"    ON      "DEV_BRANCH"    OFF)
 cmake_dependent_option(OLIVETTI       "Olivetti M290"                               ON      "DEV_BRANCH"    OFF)
 cmake_dependent_option(OPEN_AT        "OpenAT"                                      ON      "DEV_BRANCH"    OFF)
 cmake_dependent_option(PAS16          "Pro Audio Spectrum 16"                       ON      "DEV_BRANCH"    OFF)

--- a/src/include/86box/video.h
+++ b/src/include/86box/video.h
@@ -439,10 +439,8 @@ extern const device_t pgc_device;
 extern const device_t millennium_device;
 extern const device_t mystique_device;
 extern const device_t mystique_220_device;
-#    if defined(DEV_BRANCH) && defined(USE_MGA2)
 extern const device_t millennium_ii_device;
 extern const device_t productiva_g100_device;
-#    endif
 
 /* Oak OTI-0x7 */
 extern const device_t oti037c_device;

--- a/src/video/CMakeLists.txt
+++ b/src/video/CMakeLists.txt
@@ -28,10 +28,6 @@ add_library(vid OBJECT agpgart.c video.c vid_table.c vid_cga.c vid_cga_comp.c
     vid_ibm_rgb528_ramdac.c vid_sdac_ramdac.c vid_ogc.c vid_mga.c vid_nga.c
     vid_tvp3026_ramdac.c vid_att2xc498_ramdac.c vid_xga.c)
 
-if(MGA2)
-    target_compile_definitions(vid PRIVATE USE_MGA2)
-endif()
-
 if(VGAWONDER)
     target_compile_definitions(vid PRIVATE USE_VGAWONDER)
 endif()

--- a/src/video/CMakeLists.txt
+++ b/src/video/CMakeLists.txt
@@ -36,6 +36,10 @@ if(XL24)
     target_compile_definitions(vid PRIVATE USE_XL24)
 endif()
 
+if(MGA2_VMEM_SIZES)
+    target_compile_definitions(vid PRIVATE USE_MGA2_VMEM_SIZES)
+endif()
+
 add_library(voodoo OBJECT vid_voodoo.c vid_voodoo_banshee.c
     vid_voodoo_banshee_blitter.c vid_voodoo_blitter.c vid_voodoo_display.c
     vid_voodoo_fb.c vid_voodoo_fifo.c vid_voodoo_reg.c vid_voodoo_render.c

--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -6541,7 +6541,6 @@ mystique_220_available(void)
     return rom_present(ROM_MYSTIQUE_220);
 }
 
-#if defined(DEV_BRANCH) && defined(USE_MGA2)
 static int
 millennium_ii_available(void)
 {
@@ -6553,7 +6552,6 @@ matrox_g100_available(void)
 {
     return rom_present(ROM_G100);
 }
-#endif
 
 static void
 mystique_speed_changed(void *priv)
@@ -6603,7 +6601,6 @@ static const device_config_t mystique_config[] = {
   // clang-format on
 };
 
-#if defined(DEV_BRANCH) && defined(USE_MGA2)
 static const device_config_t millennium_ii_config[] = {
   // clang-format off
     {
@@ -6635,7 +6632,6 @@ static const device_config_t millennium_ii_config[] = {
     }
   // clang-format on
 };
-#endif
 
 const device_t millennium_device = {
     .name          = "Matrox Millennium",
@@ -6679,7 +6675,6 @@ const device_t mystique_220_device = {
     .config        = mystique_config
 };
 
-#if defined(DEV_BRANCH) && defined(USE_MGA2)
 const device_t millennium_ii_device = {
     .name          = "Matrox Millennium II",
     .internal_name = "millennium_ii",
@@ -6707,4 +6702,3 @@ const device_t productiva_g100_device = {
     .force_redraw  = mystique_force_redraw,
     .config        = millennium_ii_config
 };
-#endif

--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -6382,7 +6382,15 @@ mystique_init(const device_t *info)
         rom_init(&mystique->bios_rom, romfn, 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
     mem_mapping_disable(&mystique->bios_rom.mapping);
 
-    mystique->vram_size   = device_get_config_int("memory");
+#if defined(DEV_BRANCH) && defined(USE_MGA2_VMEM_SIZES)
+    mystique->vram_size = device_get_config_int("memory");
+#else
+    if (mystique->type >= MGA_2164W)
+        mystique->vram_size = 16;
+    else
+        mystique->vram_size = device_get_config_int("memory");
+#endif
+
     mystique->vram_mask   = (mystique->vram_size << 20) - 1;
     mystique->vram_mask_w = mystique->vram_mask >> 1;
     mystique->vram_mask_l = mystique->vram_mask >> 2;
@@ -6601,6 +6609,7 @@ static const device_config_t mystique_config[] = {
   // clang-format on
 };
 
+#if defined(DEV_BRANCH) && defined(USE_MGA2_VMEM_SIZES)
 static const device_config_t millennium_ii_config[] = {
   // clang-format off
     {
@@ -6632,6 +6641,7 @@ static const device_config_t millennium_ii_config[] = {
     }
   // clang-format on
 };
+#endif
 
 const device_t millennium_device = {
     .name          = "Matrox Millennium",
@@ -6686,7 +6696,11 @@ const device_t millennium_ii_device = {
     { .available = millennium_ii_available },
     .speed_changed = mystique_speed_changed,
     .force_redraw  = mystique_force_redraw,
+#if defined(DEV_BRANCH) && defined(USE_MGA2_VMEM_SIZES)
     .config        = millennium_ii_config
+#else
+    .config        = NULL
+#endif
 };
 
 const device_t productiva_g100_device = {
@@ -6700,5 +6714,9 @@ const device_t productiva_g100_device = {
     { .available = matrox_g100_available },
     .speed_changed = mystique_speed_changed,
     .force_redraw  = mystique_force_redraw,
+#if defined(DEV_BRANCH) && defined(USE_MGA2_VMEM_SIZES)
     .config        = millennium_ii_config
+#else
+    .config        = NULL
+#endif
 };

--- a/src/video/vid_table.c
+++ b/src/video/vid_table.c
@@ -208,9 +208,7 @@ video_cards[] = {
     { &s3_diamond_stealth_4000_pci_device              },
     { &s3_trio3d2x_pci_device                          },
     { &millennium_device                               },
-#if defined(DEV_BRANCH) && defined(USE_MGA2)
     { &millennium_ii_device                            },
-#endif
     { &mystique_device                                 },
     { &mystique_220_device                             },
     { &tgui9440_pci_device                             },
@@ -261,9 +259,7 @@ video_cards[] = {
     { &s3_virge_357_agp_device                         },
     { &s3_diamond_stealth_4000_agp_device              },
     { &s3_trio3d2x_agp_device                          },
-#if defined(DEV_BRANCH) && defined(USE_MGA2)
     { &productiva_g100_device, VIDEO_FLAG_TYPE_SPECIAL },
-#endif
     { &velocity_100_agp_device                         },
     { &velocity_200_agp_device                         },
     { &voodoo_3_1000_agp_device                        },

--- a/src/win/Makefile.mingw
+++ b/src/win/Makefile.mingw
@@ -64,9 +64,6 @@ ifeq ($(DEV_BUILD), y)
  ifndef LASERXT
   LASERXT := y
  endif
- ifndef MGA2
-  MGA2 := y
- endif
  ifndef OLIVETTI
   OLIVETTI := y
  endif
@@ -127,9 +124,6 @@ else
  endif
  ifndef LASERXT
   LASERXT := n
- endif
- ifndef MGA2
-  MGA2 := n
  endif
  ifndef OLIVETTI
   OLIVETTI := n
@@ -494,10 +488,6 @@ ifeq ($(DEV_BRANCH), y)
  ifeq ($(LASERXT), y)
   OPTS     += -DUSE_LASERXT
   DEVBROBJ += m_xt_laserxt.o
- endif
-
- ifeq ($(MGA2), y)
-  OPTS += -DUSE_MGA2
  endif
 
  ifeq ($(OPEN_AT), y)


### PR DESCRIPTION
Summary
=======
MGA: For Millennium II and later, force VRAM amount to 16MB on non-dev-branch builds.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
