### PR TITLE
Devbranch non-onboard Chips & Technologies B69000

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,25 +142,26 @@ option(DISCORD      "Discord Rich Presence support"                             
 
 # Development branch features
 #
-#                      Option         Description                                   Def.    Condition       Otherwise
-#                      ------         -----------                                   ----    ---------       ---------
-cmake_dependent_option(AMD_K5         "AMD K5"                                      ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(AN430TX        "Intel AN430TX"                               ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(CYRIX_6X86     "Cyrix 6x86"                                  ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(DESKPRO386     "Compaq Deskpro 386"                          ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(GUSMAX         "Gravis UltraSound MAX"                       ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(ISAMEM_RAMPAGE "AST Rampage"                                 ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(ISAMEM_IAB     "Intel Above Board"                           ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(ISAMEM_BRAT    "BocaRAM/AT"                                  ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(LASERXT        "VTech Laser XT"                              ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(MGA2           "Matrox Millennium II and Productiva G100"    ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(OLIVETTI       "Olivetti M290"                               ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(OPEN_AT        "OpenAT"                                      ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(OPL4ML         "OPL4-ML daughterboard"                       ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(PAS16          "Pro Audio Spectrum 16"                       ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(SIO_DETECT     "Super I/O Detection Helper"                  ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(VGAWONDER      "ATI VGA Wonder (ATI-18800)"                  ON      "DEV_BRANCH"    OFF)
-cmake_dependent_option(XL24           "ATI VGA Wonder XL24 (ATI-28800-6)"           ON      "DEV_BRANCH"    OFF)
+#                      Option                  Description                                   Def.    Condition       Otherwise
+#                      ------                  -----------                                   ----    ---------       ---------
+cmake_dependent_option(AMD_K5                  "AMD K5"                                      ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(AN430TX                 "Intel AN430TX"                               ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(CYRIX_6X86              "Cyrix 6x86"                                  ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(DESKPRO386              "Compaq Deskpro 386"                          ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(GUSMAX                  "Gravis UltraSound MAX"                       ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(ISAMEM_RAMPAGE          "AST Rampage"                                 ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(ISAMEM_IAB              "Intel Above Board"                           ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(ISAMEM_BRAT             "BocaRAM/AT"                                  ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(LASERXT                 "VTech Laser XT"                              ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(MGA2                    "Matrox Millennium II and Productiva G100"    ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(OLIVETTI                "Olivetti M290"                               ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(OPEN_AT                 "OpenAT"                                      ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(OPL4ML                  "OPL4-ML daughterboard"                       ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(PAS16                   "Pro Audio Spectrum 16"                       ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(SIO_DETECT              "Super I/O Detection Helper"                  ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(VGAWONDER               "ATI VGA Wonder (ATI-18800)"                  ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(XL24                    "ATI VGA Wonder XL24 (ATI-28800-6)"           ON      "DEV_BRANCH"    OFF)
+cmake_dependent_option(CHIPS_69000_NON_ONBOARD "Non-onboard Chips & Technologies B69000"     ON      "DEV_BRANCH"    OFF)
 
 # Ditto but for Qt
 if(QT)

--- a/src/include/86box/video.h
+++ b/src/include/86box/video.h
@@ -580,7 +580,9 @@ extern const device_t velocity_200_agp_device;
 extern const device_t wy700_device;
 
 /* Chips & Technologies */
+#if defined(DEV_BRANCH) && defined(USE_CHIPS_69000_NON_ONBOARD)
 extern const device_t chips_69000_device;
+#endif
 extern const device_t chips_69000_onboard_device;
 
 #endif

--- a/src/video/CMakeLists.txt
+++ b/src/video/CMakeLists.txt
@@ -40,6 +40,10 @@ if(XL24)
     target_compile_definitions(vid PRIVATE USE_XL24)
 endif()
 
+if(CHIPS_69000_NON_ONBOARD)
+    target_compile_definitions(vid PRIVATE USE_CHIPS_69000_NON_ONBOARD)
+endif()
+
 add_library(voodoo OBJECT vid_voodoo.c vid_voodoo_banshee.c
     vid_voodoo_banshee_blitter.c vid_voodoo_blitter.c vid_voodoo_display.c
     vid_voodoo_fb.c vid_voodoo_fifo.c vid_voodoo_reg.c vid_voodoo_render.c

--- a/src/video/vid_chips_69000.c
+++ b/src/video/vid_chips_69000.c
@@ -2334,10 +2334,12 @@ chips_69000_init(const device_t *info)
     chips_69000_t *chips = calloc(1, sizeof(chips_69000_t));
 
     /* Appears to have an odd VBIOS size. */
+#if defined(DEV_BRANCH) && defined(USE_CHIPS_69000_NON_ONBOARD)
     if (!info->local) {
         rom_init(&chips->bios_rom, "roms/video/chips/69000.ROM", 0xc0000, 0x40000, 0x3ffff, 0x0000, MEM_MAPPING_EXTERNAL);
         mem_mapping_disable(&chips->bios_rom.mapping);
     }
+#endif
 
     video_inform(VIDEO_FLAG_TYPE_SPECIAL, &timing_chips);
 
@@ -2371,7 +2373,7 @@ chips_69000_init(const device_t *info)
     timer_add(&chips->decrement_timer, chips_69000_decrement_timer, chips, 0);
     timer_on_auto(&chips->decrement_timer, 1000000. / 2000.);
 
-    chips->i2c_ddc = i2c_gpio_init("c&t_69000_mga");
+    chips->i2c_ddc = i2c_gpio_init("c&t_69000_ddc");
     chips->ddc     = ddc_init(i2c_gpio_get_bus(chips->i2c_ddc));
     
     chips->flat_panel_regs[0x01] = 1;
@@ -2416,6 +2418,7 @@ chips_69000_force_redraw(void *p)
     chips->svga.fullchange = changeframecount;
 }
 
+#if defined(DEV_BRANCH) && defined(USE_CHIPS_69000_NON_ONBOARD)
 const device_t chips_69000_device = {
     .name          = "Chips & Technologies B69000",
     .internal_name = "c&t_69000",
@@ -2429,6 +2432,7 @@ const device_t chips_69000_device = {
     .force_redraw  = chips_69000_force_redraw,
     .config        = NULL
 };
+#endif
 
 const device_t chips_69000_onboard_device = {
     .name          = "Chips & Technologies B69000 (onboard)",

--- a/src/video/vid_table.c
+++ b/src/video/vid_table.c
@@ -207,7 +207,9 @@ video_cards[] = {
     { &s3_virge_357_pci_device                         },
     { &s3_diamond_stealth_4000_pci_device              },
     { &s3_trio3d2x_pci_device                          },
+#if defined(DEV_BRANCH) && defined(USE_CHIPS_69000_NON_ONBOARD)
     { &chips_69000_device                              },
+#endif
     { &millennium_device                               },
 #if defined(DEV_BRANCH) && defined(USE_MGA2)
     { &millennium_ii_device                            },


### PR DESCRIPTION
Summary
=======
Devbranch non-onboard Chips & Technologies B69000

The standalone VBIOS is defective, as it returns incorrect linear addresses.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
