### PR TITLE
Matrox MGA fixes:

### DIFF
--- a/src/include/86box/video.h
+++ b/src/include/86box/video.h
@@ -439,8 +439,8 @@ extern const device_t pgc_device;
 extern const device_t millennium_device;
 extern const device_t mystique_device;
 extern const device_t mystique_220_device;
-#    if defined(DEV_BRANCH) && defined(USE_MGA2)
 extern const device_t millennium_ii_device;
+#    if defined(DEV_BRANCH) && defined(USE_MGA2)
 extern const device_t productiva_g100_device;
 #    endif
 

--- a/src/video/vid_table.c
+++ b/src/video/vid_table.c
@@ -209,9 +209,7 @@ video_cards[] = {
     { &s3_trio3d2x_pci_device                          },
     { &chips_69000_device                              },
     { &millennium_device                               },
-#if defined(DEV_BRANCH) && defined(USE_MGA2)
     { &millennium_ii_device                            },
-#endif
     { &mystique_device                                 },
     { &mystique_220_device                             },
     { &tgui9440_pci_device                             },


### PR DESCRIPTION
Summary
=======
1. When the 128K banking is activated, use a mask of 0xffff instead of 0x1ffff.
2. Debian uses standard VGA mapping when in chain4 mode and its lfb is adapted accordingly.
3. Fixed the decode VRAM mask on the Millennium II so that the vram is detected correctly and no more glitches.
4. Undev the Millennium II as well.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
