### PR TITLE
vid_tvp3026_ramdac: Implement warp-around for hardware cursor buffer32 drawing

### DIFF
--- a/src/video/vid_tvp3026_ramdac.c
+++ b/src/video/vid_tvp3026_ramdac.c
@@ -649,7 +649,7 @@ tvp3026_hwcursor_draw(svga_t *svga, int displine)
             comb = (b0 | (b1 << 1));
 
             y_pos = displine;
-            x_pos = offset + svga->x_add;
+            x_pos = (offset + svga->x_add) & 2047;
             p     = svga->monitor->target_buffer->line[y_pos];
 
             if (offset >= svga->dac_hwcursor_latch.x) {


### PR DESCRIPTION
Summary
=======
vid_tvp3026_ramdac: Implement warp-around for hardware cursor buffer32 drawing

Fixes crashes on Windows 2000

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
