### PR TITLE
MGA updates for the vram detection and stuff.

### DIFF
--- a/src/include/86box/video.h
+++ b/src/include/86box/video.h
@@ -440,9 +440,7 @@ extern const device_t millennium_device;
 extern const device_t mystique_device;
 extern const device_t mystique_220_device;
 extern const device_t millennium_ii_device;
-#    if defined(DEV_BRANCH) && defined(USE_MGA2)
 extern const device_t productiva_g100_device;
-#    endif
 
 /* Oak OTI-0x7 */
 extern const device_t oti037c_device;

--- a/src/video/vid_table.c
+++ b/src/video/vid_table.c
@@ -260,9 +260,7 @@ video_cards[] = {
     { &s3_virge_357_agp_device                         },
     { &s3_diamond_stealth_4000_agp_device              },
     { &s3_trio3d2x_agp_device                          },
-#if defined(DEV_BRANCH) && defined(USE_MGA2)
     { &productiva_g100_device, VIDEO_FLAG_TYPE_SPECIAL },
-#endif
     { &velocity_100_agp_device                         },
     { &velocity_200_agp_device                         },
     { &voodoo_3_1000_agp_device                        },


### PR DESCRIPTION
Summary
=======
1. The Debian issue mystery lies around chain2_read/write being required when the LFB mapping is enabled too when MGA modes are set without blitting, however, when it is blitting, immediately tell chain2 to not interfere with the mapping. Fixes Debian once and for all as well as VRAM detection correctly while keeping existing compatibility fine.
2. Undev branch the G100 per above. (Revert if more bugs are revealed).
3. An AND with 0 is not tolerable as it nulls the LFB, fixes hang ups with Win2000 using the Millennium II and possibly the G100.
4. the Extended CRTCs now have a call for timing recalculation, fixes mode changes when blitting is going on.


Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
