### PR TITLE
C&T 69000: Monochrome patterns are no longer horizontally reversed

### DIFF
--- a/src/video/vid_chips_69000.c
+++ b/src/video/vid_chips_69000.c
@@ -910,7 +910,7 @@ chips_69000_process_pixel(chips_69000_t* chips, uint32_t pixel)
         else
             pattern_data = chips_69000_readb_linear(chips->bitblt_running.bitblt.pat_addr + ((vert_pat_alignment + (chips->bitblt_running.y & 7)) & 7), chips);
 
-        is_true = !!(pattern_data & (1 << (((chips->bitblt_running.bitblt.destination_addr & 7) + chips->bitblt_running.x) & 7)));
+        is_true = !!(pattern_data & (1 << (7 - ((chips->bitblt_running.bitblt.destination_addr + chips->bitblt_running.x) & 7))));
 
         if (!is_true && (chips->bitblt_running.bitblt.bitblt_control & (1 << 17))) {
             return;

--- a/src/video/vid_chips_69000.c
+++ b/src/video/vid_chips_69000.c
@@ -817,6 +817,7 @@ chips_69000_recalctimings(svga_t *svga)
                 svga->hdisp = ((chips->flat_panel_regs[0x20] | ((chips->flat_panel_regs[0x25] & 0xF) << 8)) + 1) << 3;
                 //svga->htotal = ((chips->flat_panel_regs[0x23] | ((chips->flat_panel_regs[0x26] & 0xF) << 8)) + 5) << 3;
                 //svga->hblank_end_val = svga->htotal - 1;
+                svga->hoverride = 1;
             }
             if (svga->dispend > (((chips->flat_panel_regs[0x30] | ((chips->flat_panel_regs[0x35] & 0xF) << 8)) + 1))) {
                 svga->dispend = svga->vsyncstart = svga->vblankstart = ((chips->flat_panel_regs[0x30] | ((chips->flat_panel_regs[0x35] & 0xF) << 8)) + 1);
@@ -828,7 +829,6 @@ chips_69000_recalctimings(svga_t *svga)
             //svga->vsyncstart = ((chips->flat_panel_regs[0x31] | ((chips->flat_panel_regs[0x35] & 0xF0) << 4)) + 1);
             //svga->vtotal = ((chips->flat_panel_regs[0x33] | ((chips->flat_panel_regs[0x36] & 0xF) << 8)) + 2);
             svga->clock = (cpuclock * (double) (1ULL << 32)) / svga->getclock((chips->flat_panel_regs[0x03] >> 2) & 3, svga->priv);
-            svga->hoverride = 1;
         } else {
             svga->hoverride = 0;
         }

--- a/src/video/vid_chips_69000.c
+++ b/src/video/vid_chips_69000.c
@@ -818,7 +818,9 @@ chips_69000_recalctimings(svga_t *svga)
                 //svga->htotal = ((chips->flat_panel_regs[0x23] | ((chips->flat_panel_regs[0x26] & 0xF) << 8)) + 5) << 3;
                 //svga->hblank_end_val = svga->htotal - 1;
                 svga->hoverride = 1;
-            }
+            } else
+                svga->hoverride = 0;
+
             if (svga->dispend > (((chips->flat_panel_regs[0x30] | ((chips->flat_panel_regs[0x35] & 0xF) << 8)) + 1))) {
                 svga->dispend = svga->vsyncstart = svga->vblankstart = ((chips->flat_panel_regs[0x30] | ((chips->flat_panel_regs[0x35] & 0xF) << 8)) + 1);
             }


### PR DESCRIPTION
Summary
=======
C&T 69000: Monochrome patterns are no longer horizontally reversed

Fixes mouse dragging glitches under Windows 2000 on 16+ bpp.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
