### PR TITLE
C&T 69000: Fix ROP 0xFF `WHITENESS` on 16+ bpp modes

### DIFF
--- a/src/video/vid_chips_69000.c
+++ b/src/video/vid_chips_69000.c
@@ -775,9 +775,6 @@ chips_69000_recalctimings(svga_t *svga)
         svga->hblank_end_val = ((svga->crtc[3] & 0x1f) | ((svga->crtc[5] & 0x80) ? 0x20 : 0x00)) | (svga->crtc[0x3c] & 0b11000000);
         svga->hblank_end_mask = 0xff;
 
-        if (svga->hblank_end_val >= svga->htotal)
-            svga->hblank_end_val = svga->htotal - 1;
-
         svga->ma_latch |= (svga->crtc[0x40] & 0xF) << 16;
         svga->rowoffset |= (svga->crtc[0x41] & 0xF) << 8;
 

--- a/src/video/vid_chips_69000.c
+++ b/src/video/vid_chips_69000.c
@@ -351,7 +351,7 @@ chips_69000_do_rop_16bpp(uint16_t *dst, uint16_t src, uint8_t rop)
             *dst |= src;
             break;
         case 0xFF:
-            *dst = 0xFF;
+            *dst = 0xFFFF;
             break;
     }
 }
@@ -405,7 +405,7 @@ chips_69000_do_rop_24bpp(uint32_t *dst, uint32_t src, uint8_t rop)
             *dst |= src;
             break;
         case 0xFF:
-            *dst = 0xFF;
+            *dst = 0xFFFFFF;
             break;
     }
 }

--- a/src/video/vid_chips_69000.c
+++ b/src/video/vid_chips_69000.c
@@ -775,6 +775,9 @@ chips_69000_recalctimings(svga_t *svga)
         svga->hblank_end_val = ((svga->crtc[3] & 0x1f) | ((svga->crtc[5] & 0x80) ? 0x20 : 0x00)) | (svga->crtc[0x3c] & 0b11000000);
         svga->hblank_end_mask = 0xff;
 
+        if (svga->hblank_end_val >= svga->htotal)
+            svga->hblank_end_val = svga->htotal - 1;
+
         svga->ma_latch |= (svga->crtc[0x40] & 0xF) << 16;
         svga->rowoffset |= (svga->crtc[0x41] & 0xF) << 8;
 


### PR DESCRIPTION
Summary
=======
C&T 69000: Fix ROP 0xFF `WHITENESS` on 16+ bpp modes

Fixes blue background on Write in Windows 3.11 drivers.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
