### PR TITLE
workflows: Remove libvncserver from deps

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -94,7 +94,6 @@ jobs:
             rtmidi:p
             libslirp:p
             fluidsynth:p
-            libvncserver:p
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/cmake_linux.yml
+++ b/.github/workflows/cmake_linux.yml
@@ -80,7 +80,6 @@ jobs:
           libopenal-dev
           libslirp-dev
           libfluidsynth-dev
-          libvncserver-dev
           ${{ matrix.ui.packages }}
 
       - name: Checkout repository

--- a/.github/workflows/cmake_macos.yml
+++ b/.github/workflows/cmake_macos.yml
@@ -82,7 +82,6 @@ jobs:
           rtmidi
           openal-soft
           fluidsynth
-          libvncserver
           ${{ matrix.ui.packages }}
 
       - name: Checkout repository

--- a/.github/workflows/cmake_windows_msys2.yml
+++ b/.github/workflows/cmake_windows_msys2.yml
@@ -104,7 +104,6 @@ jobs:
             rtmidi:p
             libslirp:p
             fluidsynth:p
-            libvncserver:p
             ${{ matrix.ui.packages }}
 
       - name: Checkout repository

--- a/.github/workflows/codeql_linux.yml
+++ b/.github/workflows/codeql_linux.yml
@@ -83,7 +83,6 @@ jobs:
           libopenal-dev
           libslirp-dev
           libfluidsynth-dev
-          libvncserver-dev
           ${{ matrix.ui.packages }}
 
       - name: Checkout repository

--- a/.github/workflows/codeql_macos.yml
+++ b/.github/workflows/codeql_macos.yml
@@ -76,7 +76,6 @@ jobs:
           rtmidi
           openal-soft
           fluidsynth
-          libvncserver
           ${{ matrix.ui.packages }}
 
       - name: Checkout repository

--- a/.github/workflows/codeql_windows_msys2.yml
+++ b/.github/workflows/codeql_windows_msys2.yml
@@ -110,7 +110,6 @@ jobs:
             rtmidi:p
             libslirp:p
             fluidsynth:p
-            libvncserver:p
             ${{ matrix.ui.packages }}
 
       - name: Checkout repository


### PR DESCRIPTION
Summary
=======
Remove libvncserver from dependencies from Github Actions workflows; since they're built with VNC renderer disabled, it's effectively useless.

Fixes Windows workflows breakage.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
