### PR TITLE
C&T 69000: avoid stale linear mappings

### DIFF
--- a/src/video/vid_chips_69000.c
+++ b/src/video/vid_chips_69000.c
@@ -1886,10 +1886,10 @@ chips_69000_pci_write(int func, int addr, uint8_t val, void *p)
                 }
             case 0x13:
                 {
-                    // if (!(chips->pci_conf_status & PCI_COMMAND_MEM)) {
-                        // chips->linear_mapping.base = val << 24;
-                        // break;
-                    // }
+                    if (!chips->linear_mapping.enable) {
+                        chips->linear_mapping.base = val << 24;
+                        break;
+                    }
                     mem_mapping_set_addr(&chips->linear_mapping, val << 24, (1 << 24));
                     break;
                 }

--- a/src/video/vid_chips_69000.c
+++ b/src/video/vid_chips_69000.c
@@ -1887,7 +1887,7 @@ chips_69000_pci_write(int func, int addr, uint8_t val, void *p)
             case 0x13:
                 {
                     // if (!(chips->pci_conf_status & PCI_COMMAND_MEM)) {
-                        chips->linear_mapping.base = val << 24;
+                        // chips->linear_mapping.base = val << 24;
                         // break;
                     // }
                     mem_mapping_set_addr(&chips->linear_mapping, val << 24, (1 << 24));


### PR DESCRIPTION
Summary
=======
C&T 69000: avoid stale linear mappings

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
