### PR TITLE
Some temporary video changes regarding the horizontal display.

### DIFF
--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -3214,7 +3214,6 @@ s3_recalctimings(svga_t *svga)
     }
 
     svga->hdisp = svga->hdisp_old;
-
     svga->ma_latch |= (s3->ma_ext << 16);
 
     if (s3->chip >= S3_86C928) {
@@ -3222,7 +3221,7 @@ s3_recalctimings(svga_t *svga)
             svga->htotal |= 0x100;
         if (svga->crtc[0x5d] & 0x02) {
             svga->hdisp_time |= 0x100;
-            svga->hdisp |= 0x100 * svga->dots_per_clock;
+            svga->hdisp |= (0x100 * svga->dots_per_clock);
         }
         if (svga->crtc[0x5e] & 0x01)
             svga->vtotal |= 0x400;
@@ -3442,8 +3441,13 @@ s3_recalctimings(svga_t *svga)
                         break;
                     case S3_VISION968:
                         switch (s3->card_type) {
-                            case S3_PHOENIX_VISION968:
+                            case S3_MIROVIDEO40SV_ERGO_968:
+                                if (svga->hdisp == 832)
+                                    svga->hdisp -= 32;
+                                break;
                             case S3_NUMBER9_9FX_771:
+                            case S3_PHOENIX_VISION968:
+                            case S3_SPEA_MERCURY_P64V:
                                 svga->hdisp <<= 1;
                                 svga->dots_per_clock <<= 1;
                                 if (svga->hdisp == 832)
@@ -3619,8 +3623,13 @@ s3_recalctimings(svga_t *svga)
                         break;
                     case S3_VISION968:
                         switch (s3->card_type) {
+                            case S3_MIROVIDEO40SV_ERGO_968:
+                                if (svga->hdisp == 832)
+                                    svga->hdisp -= 32;
+                                break;
                             case S3_NUMBER9_9FX_771:
                             case S3_PHOENIX_VISION968:
+                            case S3_SPEA_MERCURY_P64V:
                                 svga->hdisp <<= 1;
                                 svga->dots_per_clock <<= 1;
                                 /* TODO: Is this still needed? */
@@ -3801,8 +3810,13 @@ s3_recalctimings(svga_t *svga)
                         break;
                     case S3_VISION968:
                         switch (s3->card_type) {
+                            case S3_MIROVIDEO40SV_ERGO_968:
+                                if (svga->hdisp == 832)
+                                    svga->hdisp -= 32;
+                                break;
                             case S3_NUMBER9_9FX_771:
                             case S3_PHOENIX_VISION968:
+                            case S3_SPEA_MERCURY_P64V:
                                 svga->hdisp <<= 1;
                                 svga->dots_per_clock <<= 1;
                                 /* TODO: Is this still needed? */
@@ -4003,8 +4017,13 @@ s3_recalctimings(svga_t *svga)
                         break;
                     case S3_VISION968:
                         switch (s3->card_type) {
+                            case S3_MIROVIDEO40SV_ERGO_968:
+                                if (svga->hdisp == 832)
+                                    svga->hdisp -= 32;
+                                break;
                             case S3_NUMBER9_9FX_771:
                             case S3_PHOENIX_VISION968:
+                            case S3_SPEA_MERCURY_P64V:
                                 svga->hdisp <<= 1;
                                 svga->dots_per_clock <<= 1;
                                 /* TODO: Is this still needed? */
@@ -4165,7 +4184,7 @@ s3_trio64v_recalctimings(svga_t *svga)
     if ((svga->crtc[0x33] & 0x20) || ((svga->crtc[0x67] & 0xc) == 0xc)) {
         /* The S3 version of the Cirrus' special blanking mode, with identical behavior. */
         svga->hblankstart = (((svga->crtc[0x5d] & 0x02) >> 1) << 8) + svga->crtc[1]/* +
-                            ((svga->crtc[3] >> 5) & 3) + 1*/;
+                            ((svga->crtc[3] >> 5) & 3)*/;
         svga->hblank_end_val = svga->htotal - 1 /* + ((svga->crtc[3] >> 5) & 3)*/;
 
         svga->monitor->mon_overscan_y = 0;

--- a/src/video/vid_tvp3026_ramdac.c
+++ b/src/video/vid_tvp3026_ramdac.c
@@ -65,7 +65,7 @@ typedef struct tvp3026_ramdac_t {
 static void
 tvp3026_set_bpp(tvp3026_ramdac_t *ramdac, svga_t *svga)
 {
-    if ((ramdac->true_color & 0x80) == 0x80) {
+    if (ramdac->true_color & 0x80) {
         if (ramdac->mcr & 0x08)
             svga->bpp = 8;
         else
@@ -514,67 +514,16 @@ tvp3026_recalctimings(void *priv, svga_t *svga)
 {
     const tvp3026_ramdac_t *ramdac = (tvp3026_ramdac_t *) priv;
 
-    svga->interlace = (ramdac->ccr & 0x40);
+    svga->interlace = !!(ramdac->ccr & 0x40);
     /* TODO: Figure out gamma correction for 15/16 bpp color. */
     svga->lut_map = !!(svga->bpp >= 15 && (ramdac->true_color & 0xf0) != 0x00);
 
-    switch (ramdac->mcr) {
-        case 0x41:
-        case 0x4a:
-        case 0x61:
+    pclog("MCR=0x%02x, truecolor=0x%02x, crtc1=0x%02x, MCLK=0x%02x, ClockSel=%x.\n", ramdac->mcr, ramdac->true_color, svga->crtc[1] + 1, ramdac->mclk & 0x7f, ramdac->clock_sel);
+    if (!(ramdac->clock_sel & 0x70)) {
+        if (ramdac->mcr != 0x98) {
             svga->hdisp <<= 1;
             svga->dots_per_clock <<= 1;
-            break;
-        case 0x42:
-        case 0x4b:
-        case 0x62:
-            svga->hdisp <<= 2;
-            svga->dots_per_clock <<= 2;
-            break;
-        case 0x43:
-        case 0x4c:
-        case 0x63:
-            svga->hdisp <<= 3;
-            svga->dots_per_clock <<= 3;
-            break;
-        case 0x44:
-        case 0x64:
-            svga->hdisp <<= 4;
-            svga->dots_per_clock <<= 4;
-            break;
-        case 0x5b:
-            switch (ramdac->true_color) {
-                case 0x16:
-                case 0x17:
-                    svga->hdisp = (svga->hdisp << 2) / 3;
-                    svga->dots_per_clock = (svga->dots_per_clock << 2) / 3;
-                    break;
-                case 0x1e:
-                case 0x1f:
-                    svga->hdisp = (svga->hdisp * 5) >> 2;
-                    svga->dots_per_clock = (svga->dots_per_clock * 5) >> 2;
-                    break;
-            }
-            break;
-        case 0x5c:
-            switch (ramdac->true_color) {
-                case 0x06:
-                case 0x07:
-                    svga->hdisp <<= 1;
-                    svga->dots_per_clock <<= 1;
-                    break;
-                case 0x16:
-                case 0x17:
-                    svga->hdisp = (svga->hdisp << 3) / 3;
-                    svga->dots_per_clock = (svga->dots_per_clock << 3) / 3;
-                    break;
-                case 0x1e:
-                case 0x1f:
-                    svga->hdisp = (svga->hdisp * 5) >> 1;
-                    svga->dots_per_clock = (svga->dots_per_clock * 5) >> 1;
-                    break;
-            }
-            break;
+        }
     }
 }
 


### PR DESCRIPTION
Summary
=======
S3 side:
Temporary changes to match the release (due to tomorrow) of 86box. Said changes are about the horizontal display of the tvp3026-based S3 chips.

IBM/ATI 8514-based:
Temporarily commented out the hblank side of it due to htotal bugs.

TVP3026 side:
When the upper clock selection bits are 0 and when extended VGA modes are set, double the hdisp.


Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
