### PR TITLE
vid_svga: engage DPMS when sync signals are disabled on standard modes

### DIFF
--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -944,6 +944,9 @@ svga_recalctimings(svga_t *svga)
     if (!svga->force_old_addr)
         svga_recalc_remap_func(svga);
 
+    if (svga->render == svga_render_blank && !(svga->crtc[0x17] & 0x80))
+        svga->dpms = 1;
+
     /* Inform the user interface of any DPMS mode changes. */
     if (svga->dpms) {
         if (!svga->dpms_ui) {

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -586,6 +586,7 @@ svga_recalctimings(svga_t *svga)
     int              hsyncend;
 #endif
 
+    svga->dpms        = 0;
     svga->vtotal      = svga->crtc[6];
     svga->dispend     = svga->crtc[0x12];
     svga->vsyncstart  = svga->crtc[0x10];


### PR DESCRIPTION
Summary
=======
vid_svga: engage DPMS when sync signals are disabled on standard modes

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
http://www.osdever.net/FreeVGA/vga/crtcreg.htm
