### PR TITLE
Video related changes:

### DIFF
--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -4454,7 +4454,7 @@ ibm8514_init(const device_t *info)
     }
 #endif
 
-    timer_add(&svga->timer8514, ibm8514_poll, svga, 0);
+    timer_add(&svga->timer8514, ibm8514_poll, svga, 1);
 
     return svga;
 }

--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -6057,7 +6057,7 @@ mach8_init(const device_t *info)
     } else
         ati_eeprom_load_mach8(&mach->eeprom, "mach8.nvr");
 
-    timer_add(&svga->timer8514, ibm8514_poll, svga, 0);
+    timer_add(&svga->timer8514, ibm8514_poll, svga, 1);
 
     return mach;
 }

--- a/src/video/vid_et4000.c
+++ b/src/video/vid_et4000.c
@@ -650,22 +650,22 @@ et4000_recalctimings(svga_t *svga)
 
     svga->ma_latch |= (svga->crtc[0x33] & 3) << 16;
 
-    svga->hblankstart    = (((svga->crtc[0x3f] & 0x10) >> 4) << 8) + svga->crtc[2];
+    svga->hblankstart    = (((svga->crtc[0x3f] & 0x4) >> 2) << 8) + svga->crtc[2];
 
     if (svga->crtc[0x35] & 1)
-        svga->vblankstart += 0x400;
+        svga->vblankstart |= 0x400;
     if (svga->crtc[0x35] & 2)
-        svga->vtotal += 0x400;
+        svga->vtotal |= 0x400;
     if (svga->crtc[0x35] & 4)
-        svga->dispend += 0x400;
+        svga->dispend |= 0x400;
     if (svga->crtc[0x35] & 8)
-        svga->vsyncstart += 0x400;
+        svga->vsyncstart |= 0x400;
     if (svga->crtc[0x35] & 0x10)
-        svga->split += 0x400;
+        svga->split |= 0x400;
     if (!svga->rowoffset)
         svga->rowoffset = 0x100;
     if (svga->crtc[0x3f] & 1)
-        svga->htotal += 256;
+        svga->htotal |= 0x100;
     if (svga->attrregs[0x16] & 0x20) {
         svga->hdisp <<= 1;
         svga->dots_per_clock <<= 1;

--- a/src/video/vid_et4000w32.c
+++ b/src/video/vid_et4000w32.c
@@ -432,22 +432,22 @@ et4000w32p_recalctimings(svga_t *svga)
 
     svga->ma_latch |= (svga->crtc[0x33] & 0x7) << 16;
 
-    svga->hblankstart    = (((svga->crtc[0x3f] & 0x10) >> 4) << 8) + svga->crtc[2];
+    svga->hblankstart    = (((svga->crtc[0x3f] & 0x4) >> 2) << 8) + svga->crtc[2];
 
     if (svga->crtc[0x35] & 0x01)
-        svga->vblankstart += 0x400;
+        svga->vblankstart |= 0x400;
     if (svga->crtc[0x35] & 0x02)
-        svga->vtotal += 0x400;
+        svga->vtotal |= 0x400;
     if (svga->crtc[0x35] & 0x04)
-        svga->dispend += 0x400;
+        svga->dispend |= 0x400;
     if (svga->crtc[0x35] & 0x08)
-        svga->vsyncstart += 0x400;
+        svga->vsyncstart |= 0x400;
     if (svga->crtc[0x35] & 0x10)
-        svga->split += 0x400;
+        svga->split |= 0x400;
     if (svga->crtc[0x3F] & 0x80)
-        svga->rowoffset += 0x100;
+        svga->rowoffset |= 0x100;
     if (svga->crtc[0x3F] & 0x01)
-        svga->htotal += 256;
+        svga->htotal |= 0x100;
     if (svga->attrregs[0x16] & 0x20) {
         svga->hdisp <<= 1;
         svga->dots_per_clock <<= 1;
@@ -535,9 +535,6 @@ et4000w32p_recalctimings(svga_t *svga)
         } else {
             switch (svga->gdcreg[5] & 0x60) {
                 case 0x00:
-                    if (et4000->rev == 5)
-                        svga->ma_latch++;
-
                     if (svga->seqregs[1] & 8) /* Low res (320) */
                         svga->render = svga_render_4bpp_lowres;
                     else

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -899,7 +899,7 @@ svga_recalctimings(svga_t *svga)
 
     if (ibm8514_active && (svga->dev8514 != NULL)) {
         if (dev->on[0] || dev->on[1]) {
-            disptime8514 = dev->htotal;
+            disptime8514 = dev->h_total ? dev->h_total : TIMER_USEC;
             _dispontime8514 = dev->hdisped;
         }
     }
@@ -934,10 +934,10 @@ svga_recalctimings(svga_t *svga)
                 dev->dispofftime = TIMER_USEC;
 
             timer_disable(&svga->timer);
-            timer_enable(&svga->timer8514);
+            timer_set_delay_u64(&svga->timer8514, TIMER_USEC);
         } else {
             timer_disable(&svga->timer8514);
-            timer_enable(&svga->timer);
+            timer_set_delay_u64(&svga->timer, TIMER_USEC);
         }
     }
 


### PR DESCRIPTION
Summary
=======
IBM/ATI 8514/A side:
Made mode switches more immediate when actually switching from VGA to 8514/A and viceversa.

Tseng ET4000AX/W32 series side:
Actually use bit 2 of index 0x3f for the horizontal blank start bit 8 instead of bit 4 (horizontal retrace start), fixes skew issues with the et4000w32i rev B. card with resolutions like 1024x768 at 15 or 16bpp and others.


Checklist
=========
* [x] Closes #4188 (mach32 side).
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
