### PR TITLE
S3 ViRGE: Respect blend control compose modes on pre-GX2 ViRGE

### DIFF
--- a/src/video/vid_s3_virge.c
+++ b/src/video/vid_s3_virge.c
@@ -918,6 +918,10 @@ s3_virge_recalctimings(svga_t *svga)
         svga->overlay.v_acc = virge->streams.dda_vert_accumulator;
         svga->rowoffset     = virge->streams.pri_stride >> 3;
 
+        if (virge->chip <= S3_VIRGEDX && svga->overlay.ena) {
+            svga->overlay.ena = (((virge->streams.blend_ctrl >> 24) & 7) == 0b000) || (((virge->streams.blend_ctrl >> 24) & 7) == 0b101);
+        }
+
         switch ((virge->streams.pri_ctrl >> 24) & 0x7) {
             case 0: /*RGB-8 (CLUT)*/
                 svga->render = svga_render_8bpp_highres;
@@ -1963,6 +1967,7 @@ s3_virge_mmio_write_l(uint32_t addr, uint32_t val, void *priv)
                 break;
             case 0x81a0:
                 virge->streams.blend_ctrl = val;
+                svga_recalctimings(svga);
                 break;
             case 0x81c0:
                 virge->streams.pri_fb0 = val & 0x7fffff;


### PR DESCRIPTION
Summary
=======
S3 ViRGE: Respect blend control compose modes on pre-GX2 ViRGE

Fixes video overlay staying on-screen on Linux.

Checklist
=========
* [X] Closes #4164
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
