### PR TITLE
S3 ViRGE/GX2: Fix screen overlay staying on Windows XP

### DIFF
--- a/src/video/vid_s3_virge.c
+++ b/src/video/vid_s3_virge.c
@@ -920,6 +920,10 @@ s3_virge_recalctimings(svga_t *svga)
 
         if (virge->chip <= S3_VIRGEDX && svga->overlay.ena) {
             svga->overlay.ena = (((virge->streams.blend_ctrl >> 24) & 7) == 0b000) || (((virge->streams.blend_ctrl >> 24) & 7) == 0b101);
+        } else if (virge->chip == S3_VIRGEGX2 && svga->overlay.ena) {
+            /* 0x20 = Secondary Stream enabled */
+            /* 0x2000 = Primary Stream enabled */
+            svga->overlay.ena = !!(virge->streams.blend_ctrl & 0x20) && (svga->crtc[0x67] & 0xC);
         }
 
         switch ((virge->streams.pri_ctrl >> 24) & 0x7) {


### PR DESCRIPTION
Summary
=======
S3 ViRGE/GX2: Fix screen overlay staying on Windows XP.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
