### PR TITLE
unix_serial_passthrough.c: check errno for EWOULDBLOCK

### DIFF
--- a/src/unix/unix_serial_passthrough.c
+++ b/src/unix/unix_serial_passthrough.c
@@ -112,7 +112,7 @@ plat_serpt_write_vcon(serial_passthrough_t *dev, uint8_t data)
     if (dev->mode == SERPT_MODE_HOSTSER) {
         do {
             res = write(dev->master_fd, &data, 1);
-        } while (res == 0 || (res == -1 && (errno == EAGAIN || res == EWOULDBLOCK)));
+        } while (res == 0 || (res == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)));
     } else
         res = write(dev->master_fd, &data, 1);
 }


### PR DESCRIPTION
Summary
=======
plat_serpt_write_vcon(): write() returns how much data it has written to the file descriptor, and in case an error, it returns -1. So the EWOULDBLOCK never really triggers, as in the following condition we're not checking the errno, but the return value of the write() function.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/