### PR TITLE
Fix AppStream metainfo file

### DIFF
--- a/src/unix/assets/net.86box.86Box.metainfo.xml
+++ b/src/unix/assets/net.86box.86Box.metainfo.xml
@@ -4,9 +4,10 @@
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-2.0-or-later</project_license>
     <name>86Box</name>
+    <developer_name>86Box developers</developer_name>
     <summary>An emulator for classic IBM PC clones</summary>
     <categories>
-      <category>Emulation</category>
+      <category>Emulator</category>
     </categories>
     <launchable type="desktop-id">net.86box.86Box.desktop</launchable>
     <releases>


### PR DESCRIPTION
From the [Flathub](https://flathub.org) AppStream validator:

```
{
    "errors": [
        "appstream-failed-validation",
        "appstream-missing-developer-name"
    ],
    "warnings": [
        "appstream-summary-too-long",
        "appstream-screenshot-missing-caption"
    ],
    "appstream": [
        "E: net._86box._86Box:~: category-invalid Emulation",
        "E: net._86box._86Box:~: all-categories-ignored"
    ],
    "message": "Please consult the documentation at https://docs.flathub.org/docs/for-app-authors/linter"
}
```

This PR:
- Fixes the "Emulation" category that should be "Emulator" (same as the desktop file one).
- Adds developer name that is required by multiple AppStream validators nowadays.