### PR TITLE
Temporary solution to a 24bpp issue and hblank.

### DIFF
--- a/src/video/vid_s3_virge.c
+++ b/src/video/vid_s3_virge.c
@@ -959,7 +959,7 @@ s3_virge_recalctimings(svga_t *svga)
         svga->vram_display_mask = virge->vram_mask;
     }
 
-    svga->hoverride = 1
+    svga->hoverride = 1;
 }
 
 static void

--- a/src/video/vid_s3_virge.c
+++ b/src/video/vid_s3_virge.c
@@ -958,13 +958,15 @@ s3_virge_recalctimings(svga_t *svga)
         }
         svga->vram_display_mask = virge->vram_mask;
     }
+
+    svga->hoverride = 1
 }
 
 static void
 s3_virge_update_buffer(virge_t *virge)
 {
     svga_t *svga = &virge->svga;
-    
+
     if ((svga->crtc[0x67] & 0xc) != 0xc)
         return;
 
@@ -977,7 +979,7 @@ s3_virge_update_buffer(virge_t *virge)
         svga->overlay.addr = virge->streams.sec_fb1;
     else
         svga->overlay.addr = virge->streams.sec_fb0;
-    
+
     svga->rowoffset = virge->streams.pri_stride >> 3;
 }
 


### PR DESCRIPTION
Summary
=======
So that 24bpp color is not discolored anymore as well as hblank bugs being nulled.

Checklist
=========
* [x] Closes #4203
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
