### PR TITLE
Fix ACPI poweroffs disabling exit confirmations

### DIFF
--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -413,7 +413,7 @@ void
 plat_power_off(void)
 {
     plat_mouse_capture(0);
-    confirm_exit = 0;
+    confirm_exit_cmdl = 0;
     nvr_save();
     config_save();
 

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -697,7 +697,7 @@ plat_get_exe_name(char *s, int size)
 void
 plat_power_off(void)
 {
-    confirm_exit = 0;
+    confirm_exit_cmdl = 0;
     nvr_save();
     config_save();
 

--- a/src/win/win_ui.c
+++ b/src/win/win_ui.c
@@ -383,7 +383,7 @@ win_notify_dlg_closed(void)
 void
 plat_power_off(void)
 {
-    confirm_exit = 0;
+    confirm_exit_cmdl = 0;
     nvr_save();
     config_save();
 


### PR DESCRIPTION
Summary
=======
Fix ACPI poweroffs saving the exit confirmation dialog disable option to the config file.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A
