### PR TITLE
Add Vision Systems LBA Enhancer

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -181,6 +181,7 @@ int      gfxcard[2]                             = { 0, 0 };       /* (C) graphic
 int      show_second_monitors                   = 1;              /* (C) show non-primary monitors */
 int      sound_is_float                         = 1;              /* (C) sound uses FP values */
 int      voodoo_enabled                         = 0;              /* (C) video option */
+int      lba_enhancer_enabled                   = 0;              /* (C) enable Vision Systems LBA Enhancer */
 int      ibm8514_standalone_enabled             = 0;              /* (C) video option */
 int      xga_standalone_enabled                 = 0;              /* (C) video option */
 uint32_t mem_size                               = 0;              /* (C) memory size (Installed on
@@ -1226,6 +1227,9 @@ pc_reset_hard_init(void)
         device_add(&postcard_device);
     if (unittester_enabled)
         device_add(&unittester_device);
+    
+    if (lba_enhancer_enabled)
+        device_add(&lba_enhancer_device);
 
     if (IS_ARCH(machine, MACHINE_BUS_PCI)) {
         pci_register_cards();

--- a/src/config.c
+++ b/src/config.c
@@ -876,6 +876,8 @@ load_storage_controllers(void)
             path_normalize(cart_fns[c]);
         }
     }
+
+    lba_enhancer_enabled = !!ini_section_get_int(cat, "lba_enhancer_enabled", 0);
 }
 
 /* Load "Hard Disks" section. */
@@ -2341,6 +2343,11 @@ save_storage_controllers(void)
         else
             ini_section_set_string(cat, temp, cart_fns[c]);
     }
+
+    if (lba_enhancer_enabled == 0)
+        ini_section_delete_var(cat, "lba_enhancer_enabled");
+    else
+        ini_section_set_int(cat, "lba_enhancer_enabled", 1);
 }
 
 /* Save "Other Peripherals" section. */

--- a/src/disk/CMakeLists.txt
+++ b/src/disk/CMakeLists.txt
@@ -16,7 +16,7 @@
 add_library(hdd OBJECT hdd.c hdd_image.c hdd_table.c hdc.c hdc_st506_xt.c
     hdc_st506_at.c hdc_xta.c hdc_esdi_at.c hdc_esdi_mca.c hdc_xtide.c
     hdc_ide.c hdc_ide_ali5213.c hdc_ide_opti611.c hdc_ide_cmd640.c hdc_ide_cmd646.c
-    hdc_ide_sff8038i.c hdc_ide_um8673f.c hdc_ide_w83769f.c)
+    hdc_ide_sff8038i.c hdc_ide_um8673f.c hdc_ide_w83769f.c lba_enhancer.c)
 
 add_library(zip OBJECT zip.c)
 

--- a/src/disk/lba_enhancer.c
+++ b/src/disk/lba_enhancer.c
@@ -1,0 +1,97 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          Vision Systems LBA Enhancer emulation.
+ *
+ *
+ *
+ * Authors: Cacodemon345
+ *
+ *          Copyright 2024 Cacodemon345
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#define HAVE_STDARG_H
+#include <86box/86box.h>
+#include <86box/io.h>
+#include <86box/device.h>
+#include <86box/mem.h>
+#include <86box/rom.h>
+#include <86box/plat_unused.h>
+
+typedef struct lba_enhancer_t
+{
+    rom_t rom;
+} lba_enhancer_t;
+
+#define BIOS_LBA_ENHANCER "roms/hdd/misc/lbaenhancer.bin"
+
+void* lba_enhancer_init(const device_t* info)
+{
+    lba_enhancer_t* lba_enhancer = (lba_enhancer_t*)calloc(1, sizeof(lba_enhancer_t));
+
+    rom_init(&lba_enhancer->rom, BIOS_LBA_ENHANCER, device_get_config_hex20("bios_addr"), 0x4000, 0x3fff, 0, MEM_MAPPING_EXTERNAL);
+    return lba_enhancer;
+}
+
+void lba_enhancer_close(void* priv)
+{
+    lba_enhancer_t* lba_enhancer = (lba_enhancer_t*)priv;
+
+    free(lba_enhancer->rom.rom);
+    free(priv);
+    return;
+}
+
+static int
+lba_enhancer_available(void)
+{
+    return rom_present(BIOS_LBA_ENHANCER);
+}
+
+// clang-format off
+static const device_config_t lba_enhancer_config[] = {
+    {
+        .name = "bios_addr",
+        .description = "BIOS Address",
+        .type = CONFIG_HEX20,
+        .default_string = "",
+        .default_int = 0xc8000,
+        .file_filter = "",
+        .spinner = { 0 },
+        .selection = {
+            { .description = "C800H",    .value = 0xc8000 },
+            { .description = "CC00H",    .value = 0xcc000 },
+            { .description = "D000H",    .value = 0xd0000 },
+            { .description = "D400H",    .value = 0xd4000 },
+            { .description = "D800H",    .value = 0xd8000 },
+            { .description = "DC00H",    .value = 0xdc000 },
+            { .description = ""                           }
+        },
+    },
+    { .name = "", .description = "", .type = CONFIG_END }
+};
+// clang-format on
+
+const device_t lba_enhancer_device = {
+    .name          = "Vision Systems LBA Enhancer",
+    .internal_name = "lba_enhancer",
+    .flags         = DEVICE_AT,
+    .local         = 0,
+    .init          = lba_enhancer_init,
+    .close         = lba_enhancer_close,
+    .reset         = NULL,
+    { .available = lba_enhancer_available },
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = lba_enhancer_config
+};

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -140,6 +140,7 @@ extern int      fpu_type;                   /* (C) fpu type */
 extern int      fpu_softfloat;              /* (C) fpu uses softfloat */
 extern int      time_sync;                  /* (C) enable time sync */
 extern int      hdd_format_type;            /* (C) hard disk file format */
+extern int      lba_enhancer_enabled;       /* (C) enable Vision Systems LBA Enhancer */
 extern int      confirm_reset;              /* (C) enable reset confirmation */
 extern int      confirm_exit;               /* (C) enable exit confirmation */
 extern int      confirm_save;               /* (C) enable save confirmation */

--- a/src/include/86box/hdc.h
+++ b/src/include/86box/hdc.h
@@ -103,6 +103,9 @@ extern const device_t xtide_at_device;        /* xtide_at */
 extern const device_t xtide_acculogic_device; /* xtide_ps2 */
 extern const device_t xtide_at_ps2_device;    /* xtide_at_ps2 */
 
+/* Miscellaneous */
+extern const device_t lba_enhancer_device;
+
 extern void hdc_init(void);
 extern void hdc_reset(void);
 

--- a/src/qt/qt_settingsstoragecontrollers.cpp
+++ b/src/qt/qt_settingsstoragecontrollers.cpp
@@ -62,6 +62,7 @@ SettingsStorageControllers::save()
     ide_ter_enabled         = ui->checkBoxTertiaryIDE->isChecked() ? 1 : 0;
     ide_qua_enabled         = ui->checkBoxQuaternaryIDE->isChecked() ? 1 : 0;
     cassette_enable         = ui->checkBoxCassette->isChecked() ? 1 : 0;
+    lba_enhancer_enabled    = ui->checkBoxLbaEnhancer->isChecked() ? 1 : 0;
 }
 
 void
@@ -204,6 +205,9 @@ SettingsStorageControllers::onCurrentMachineChanged(int machineId)
         ui->checkBoxCassette->setChecked(false);
         ui->checkBoxCassette->setEnabled(false);
     }
+
+    ui->checkBoxLbaEnhancer->setChecked(lba_enhancer_enabled > 0 && device_available(&lba_enhancer_device));
+    ui->pushButtonConfigureLbaEnhancer->setEnabled(ui->checkBoxLbaEnhancer->isChecked());
 }
 
 void
@@ -333,3 +337,15 @@ SettingsStorageControllers::on_pushButtonSCSI4_clicked()
 {
     DeviceConfig::ConfigureDevice(scsi_card_getdevice(ui->comboBoxSCSI4->currentData().toInt()), 4, qobject_cast<Settings *>(Settings::settings));
 }
+
+void SettingsStorageControllers::on_checkBoxLbaEnhancer_stateChanged(int arg1)
+{
+    ui->pushButtonConfigureLbaEnhancer->setEnabled(arg1 != 0);
+}
+
+
+void SettingsStorageControllers::on_pushButtonConfigureLbaEnhancer_clicked()
+{
+    DeviceConfig::ConfigureDevice(&lba_enhancer_device);
+}
+

--- a/src/qt/qt_settingsstoragecontrollers.hpp
+++ b/src/qt/qt_settingsstoragecontrollers.hpp
@@ -39,6 +39,10 @@ private slots:
     void on_comboBoxHD_currentIndexChanged(int index);
     void on_comboBoxCDInterface_currentIndexChanged(int index);
 
+    void on_checkBoxLbaEnhancer_stateChanged(int arg1);
+
+    void on_pushButtonConfigureLbaEnhancer_clicked();
+
 private:
     Ui::SettingsStorageControllers *ui;
     int                             machineId = 0;

--- a/src/qt/qt_settingsstoragecontrollers.ui
+++ b/src/qt/qt_settingsstoragecontrollers.ui
@@ -51,44 +51,44 @@
      </item>
      <item row="2" column="0">
       <widget class="QLabel" name="label_7">
-       <property name="text">
-        <string>CD-ROM Controller:</string>
-       </property>
        <property name="visible">
         <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>CD-ROM Controller:</string>
        </property>
       </widget>
      </item>
      <item row="2" column="1">
       <widget class="QComboBox" name="comboBoxCDInterface">
-       <property name="maxVisibleItems">
-        <number>30</number>
-       </property>
        <property name="visible">
         <bool>false</bool>
+       </property>
+       <property name="maxVisibleItems">
+        <number>30</number>
        </property>
       </widget>
      </item>
      <item row="2" column="2">
       <widget class="QPushButton" name="pushButtonCDInterface">
-       <property name="text">
-        <string>Configure</string>
-       </property>
        <property name="visible">
         <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Configure</string>
        </property>
       </widget>
      </item>
      <item row="0" column="1">
       <widget class="QComboBox" name="comboBoxHD">
-       <property name="maxVisibleItems">
-        <number>30</number>
-       </property>
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
+       </property>
+       <property name="maxVisibleItems">
+        <number>30</number>
        </property>
       </widget>
      </item>
@@ -171,14 +171,14 @@
       </item>
       <item row="0" column="2">
        <widget class="QComboBox" name="comboBoxSCSI1">
-        <property name="maxVisibleItems">
-         <number>30</number>
-        </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="maxVisibleItems">
+         <number>30</number>
         </property>
        </widget>
       </item>
@@ -191,40 +191,40 @@
       </item>
       <item row="1" column="2">
        <widget class="QComboBox" name="comboBoxSCSI2">
-        <property name="maxVisibleItems">
-         <number>30</number>
-        </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="maxVisibleItems">
+         <number>30</number>
         </property>
        </widget>
       </item>
       <item row="2" column="2">
        <widget class="QComboBox" name="comboBoxSCSI3">
-        <property name="maxVisibleItems">
-         <number>30</number>
-        </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="maxVisibleItems">
+         <number>30</number>
         </property>
        </widget>
       </item>
       <item row="3" column="2">
        <widget class="QComboBox" name="comboBoxSCSI4">
-        <property name="maxVisibleItems">
-         <number>30</number>
-        </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="maxVisibleItems">
+         <number>30</number>
         </property>
        </widget>
       </item>
@@ -265,6 +265,43 @@
       <string>Cassette</string>
      </property>
     </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QCheckBox" name="checkBoxLbaEnhancer">
+       <property name="text">
+        <string>Vision Systems LBA Enhancer</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButtonConfigureLbaEnhancer">
+       <property name="text">
+        <string>Configure</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <spacer name="verticalSpacer">


### PR DESCRIPTION
Summary
=======
This PR adds Vision Systems LBA Enhancer.

It adds 28-bit LBA addressing to machines with BIOSes that do not support it.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [X] This pull request requires changes to the ROM set
  * [X] I have opened a roms pull request - https://github.com/86Box/roms/pull/249/

References
==========
None.
