### PR TITLE
cleanup: remove "not" operator whenever it's not needed

### DIFF
--- a/src/device/cartridge.c
+++ b/src/device/cartridge.c
@@ -108,12 +108,12 @@ cart_image_load(int drive, char *fn)
     if (size & 0x00000fff) {
         size -= 0x00000200;
         fseek(fp, 0x000001ce, SEEK_SET);
-        (void) !fread(&base, 1, 2, fp);
+        fread(&base, 1, 2, fp);
         base <<= 4;
         fseek(fp, 0x00000200, SEEK_SET);
         carts[drive].buf = (uint8_t *) malloc(size);
         memset(carts[drive].buf, 0x00, size);
-        (void) !fread(carts[drive].buf, 1, size, fp);
+        fread(carts[drive].buf, 1, size, fp);
         fclose(fp);
     } else {
         base = drive ? 0xe0000 : 0xd0000;
@@ -122,7 +122,7 @@ cart_image_load(int drive, char *fn)
         fseek(fp, 0x00000000, SEEK_SET);
         carts[drive].buf = (uint8_t *) malloc(size);
         memset(carts[drive].buf, 0x00, size);
-        (void) !fread(carts[drive].buf, 1, size, fp);
+        fread(carts[drive].buf, 1, size, fp);
         fclose(fp);
     }
 

--- a/src/device/hwm_lm78.c
+++ b/src/device/hwm_lm78.c
@@ -111,7 +111,7 @@ lm78_nvram(lm78_t *dev, uint8_t save)
         if (save)
             fwrite(&dev->as99127f.nvram, sizeof(dev->as99127f.nvram), 1, fp);
         else
-            (void) !fread(&dev->as99127f.nvram, sizeof(dev->as99127f.nvram), 1, fp);
+            fread(&dev->as99127f.nvram, sizeof(dev->as99127f.nvram), 1, fp);
         fclose(fp);
     }
 

--- a/src/disk/minivhd/convert.c
+++ b/src/disk/minivhd/convert.c
@@ -124,7 +124,7 @@ mvhd_convert_to_vhd_sparse(const char* utf8_raw_path, const char* utf8_vhd_path,
             copy_sect = total_sectors - i;
             memset(buff, 0, sizeof buff);
         }
-        (void) !fread(buff, MVHD_SECTOR_SIZE, copy_sect, raw_img);
+        fread(buff, MVHD_SECTOR_SIZE, copy_sect, raw_img);
 
         /* Only write data if there's data to write, to take advantage of the sparse VHD format */
         if (memcmp(buff, empty_buff, sizeof buff) != 0) {

--- a/src/disk/minivhd/create.c
+++ b/src/disk/minivhd/create.c
@@ -268,7 +268,7 @@ mvhd_create_fixed_raw(const char* path, FILE* raw_img, uint64_t size_in_bytes, M
         gen_footer(&vhdm->footer, raw_size, geom, MVHD_TYPE_FIXED, 0);
         mvhd_fseeko64(raw_img, 0, SEEK_SET);
         for (s = 0; s < size_sectors; s++) {
-            (void) !fread(img_data, sizeof img_data, 1, raw_img);
+            fread(img_data, sizeof img_data, 1, raw_img);
             fwrite(img_data, sizeof img_data, 1, fp);
             if (progress_callback)
                 progress_callback(s + 1, size_sectors);

--- a/src/disk/minivhd/manage.c
+++ b/src/disk/minivhd/manage.c
@@ -79,7 +79,7 @@ read_footer(MVHDMeta* vhdm)
     uint8_t buffer[MVHD_FOOTER_SIZE];
 
     mvhd_fseeko64(vhdm->f, -MVHD_FOOTER_SIZE, SEEK_END);
-    (void) !fread(buffer, sizeof buffer, 1, vhdm->f);
+    fread(buffer, sizeof buffer, 1, vhdm->f);
     mvhd_buffer_to_footer(&vhdm->footer, buffer);
 }
 
@@ -95,7 +95,7 @@ read_sparse_header(MVHDMeta* vhdm)
     uint8_t buffer[MVHD_SPARSE_SIZE];
 
     mvhd_fseeko64(vhdm->f, vhdm->footer.data_offset, SEEK_SET);
-    (void) !fread(buffer, sizeof buffer, 1, vhdm->f);
+    fread(buffer, sizeof buffer, 1, vhdm->f);
     mvhd_buffer_to_header(&vhdm->sparse, buffer);
 }
 
@@ -153,7 +153,7 @@ read_bat(MVHDMeta *vhdm, MVHDError* err)
     mvhd_fseeko64(vhdm->f, vhdm->sparse.bat_offset, SEEK_SET);
 
     for (uint32_t i = 0; i < vhdm->sparse.max_bat_ent; i++) {
-        (void) !fread(&vhdm->block_offset[i], sizeof *vhdm->block_offset, 1, vhdm->f);
+        fread(&vhdm->block_offset[i], sizeof *vhdm->block_offset, 1, vhdm->f);
         vhdm->block_offset[i] = mvhd_from_be32(vhdm->block_offset[i]);
     }
     return 0;
@@ -330,7 +330,7 @@ get_diff_parent_path(MVHDMeta* vhdm, int* err)
             goto paths_cleanup;
         }
         mvhd_fseeko64(vhdm->f, vhdm->sparse.par_loc_entry[i].plat_data_offset, SEEK_SET);
-        (void) !fread(paths->tmp_src_path, sizeof (uint8_t), utf_inlen, vhdm->f);
+        fread(paths->tmp_src_path, sizeof (uint8_t), utf_inlen, vhdm->f);
 
         /* Note, the W2*u parent locators are UTF-16LE, unlike the filename field previously obtained,
            which is UTF-16BE */
@@ -445,7 +445,7 @@ mvhd_file_is_vhd(FILE* f)
     }
 
     mvhd_fseeko64(f, -MVHD_FOOTER_SIZE, SEEK_END);
-    (void) !fread(con_str, sizeof con_str, 1, f);
+    fread(con_str, sizeof con_str, 1, f);
     if (mvhd_is_conectix_str(con_str)) {
         return 1;
     }

--- a/src/disk/minivhd/minivhd_io.c
+++ b/src/disk/minivhd/minivhd_io.c
@@ -105,7 +105,7 @@ read_sect_bitmap(MVHDMeta* vhdm, int blk)
 {
     if (vhdm->block_offset[blk] != MVHD_SPARSE_BLK) {
         mvhd_fseeko64(vhdm->f, (uint64_t)vhdm->block_offset[blk] * MVHD_SECTOR_SIZE, SEEK_SET);
-        (void) !fread(vhdm->bitmap.curr_bitmap, vhdm->bitmap.sector_count * MVHD_SECTOR_SIZE, 1, vhdm->f);
+        fread(vhdm->bitmap.curr_bitmap, vhdm->bitmap.sector_count * MVHD_SECTOR_SIZE, 1, vhdm->f);
     } else {
         memset(vhdm->bitmap.curr_bitmap, 0, vhdm->bitmap.sector_count * MVHD_SECTOR_SIZE);
     }
@@ -168,13 +168,13 @@ create_block(MVHDMeta* vhdm, int blk)
 
     /* Seek to where the footer SHOULD be */
     mvhd_fseeko64(vhdm->f, -MVHD_FOOTER_SIZE, SEEK_END);
-    (void) !fread(footer, sizeof footer, 1, vhdm->f);
+    fread(footer, sizeof footer, 1, vhdm->f);
     mvhd_fseeko64(vhdm->f, -MVHD_FOOTER_SIZE, SEEK_END);
 
     if (!mvhd_is_conectix_str(footer)) {
         /* Oh dear. We use the header instead, since something has gone wrong at the footer */
         mvhd_fseeko64(vhdm->f, 0, SEEK_SET);
-        (void) !fread(footer, sizeof footer, 1, vhdm->f);
+        fread(footer, sizeof footer, 1, vhdm->f);
         mvhd_fseeko64(vhdm->f, 0, SEEK_END);
     }
 
@@ -215,7 +215,7 @@ mvhd_fixed_read(MVHDMeta* vhdm, uint32_t offset, int num_sectors, void* out_buff
 
     addr = (int64_t)offset * MVHD_SECTOR_SIZE;
     mvhd_fseeko64(vhdm->f, addr, SEEK_SET);
-    (void) !fread(out_buff, transfer_sectors*MVHD_SECTOR_SIZE, 1, vhdm->f);
+    fread(out_buff, transfer_sectors*MVHD_SECTOR_SIZE, 1, vhdm->f);
 
     return truncated_sectors;
 }
@@ -251,7 +251,7 @@ mvhd_sparse_read(MVHDMeta* vhdm, uint32_t offset, int num_sectors, void* out_buf
         }
 
         if (VHD_TESTBIT(vhdm->bitmap.curr_bitmap, sib)) {
-            (void) !fread(buff, MVHD_SECTOR_SIZE, 1, vhdm->f);
+            fread(buff, MVHD_SECTOR_SIZE, 1, vhdm->f);
         } else {
             memset(buff, 0, MVHD_SECTOR_SIZE);
             mvhd_fseeko64(vhdm->f, MVHD_SECTOR_SIZE, SEEK_CUR);

--- a/src/floppy/fdd_86f.c
+++ b/src/floppy/fdd_86f.c
@@ -2945,13 +2945,13 @@ d86f_read_track(int drive, int track, int thin_track, int side, uint16_t *da, ui
                 }
             } else
                 dev->extra_bit_cells[side] = 0;
-            (void) !fread(&(dev->index_hole_pos[side]), 4, 1, dev->fp);
+            fread(&(dev->index_hole_pos[side]), 4, 1, dev->fp);
         } else
             fseek(dev->fp, dev->track_offset[logical_track] + d86f_track_header_size(drive), SEEK_SET);
         array_size = d86f_get_array_size(drive, side, 0);
-        (void) !fread(da, 1, array_size, dev->fp);
+        fread(da, 1, array_size, dev->fp);
         if (d86f_has_surface_desc(drive))
-            (void) !fread(sa, 1, array_size, dev->fp);
+            fread(sa, 1, array_size, dev->fp);
     } else {
         if (!thin_track) {
             switch ((dev->disk_flags >> 1) & 3) {
@@ -3533,9 +3533,9 @@ d86f_load(int drive, char *fn)
 
     fseek(dev->fp, 0, SEEK_END);
     len = ftell(dev->fp);
-    fseek(dev->fp, 0, SEEK_SET);
 
-    (void) !fread(&magic, 4, 1, dev->fp);
+    fseek(dev->fp, 0, SEEK_SET);
+    fread(&magic, 4, 1, dev->fp);
 
     if (len < 16) {
         /* File is WAY too small, abort. */
@@ -3576,7 +3576,7 @@ d86f_load(int drive, char *fn)
         d86f_log("86F: Recognized file version: %i.%02i\n", dev->version >> 8, dev->version & 0xff);
     }
 
-    (void) !fread(&(dev->disk_flags), 2, 1, dev->fp);
+    fread(&(dev->disk_flags), 2, 1, dev->fp);
 
     if (d86f_has_surface_desc(drive)) {
         for (uint8_t i = 0; i < 2; i++)
@@ -3724,8 +3724,7 @@ d86f_load(int drive, char *fn)
     d86f[drive] = dev;
 
     fseek(dev->fp, 8, SEEK_SET);
-
-    (void) !fread(dev->track_offset, 1, d86f_get_track_table_size(drive), dev->fp);
+    fread(dev->track_offset, 1, d86f_get_track_table_size(drive), dev->fp);
 
     if (!(dev->track_offset[0])) {
         /* File has no track 0 side 0, abort. */

--- a/src/floppy/fdd_img.c
+++ b/src/floppy/fdd_img.c
@@ -711,12 +711,12 @@ img_load(int drive, char *fn)
         /* This is a Japanese FDI image, so let's read the header */
         img_log("img_load(): File is a Japanese FDI image...\n");
         fseek(dev->fp, 0x10, SEEK_SET);
-        (void) !fread(&bpb_bps, 1, 2, dev->fp);
+        fread(&bpb_bps, 1, 2, dev->fp);
         fseek(dev->fp, 0x0C, SEEK_SET);
-        (void) !fread(&size, 1, 4, dev->fp);
+        fread(&size, 1, 4, dev->fp);
         bpb_total = size / bpb_bps;
         fseek(dev->fp, 0x08, SEEK_SET);
-        (void) !fread(&(dev->base), 1, 4, dev->fp);
+        fread(&(dev->base), 1, 4, dev->fp);
         fseek(dev->fp, dev->base + 0x15, SEEK_SET);
         bpb_mid = fgetc(dev->fp);
         if (bpb_mid < 0xF0)
@@ -755,7 +755,7 @@ img_load(int drive, char *fn)
             dev->disk_at_once = 1;
 
             fseek(dev->fp, 0x50, SEEK_SET);
-            (void) !fread(&dev->tracks, 1, 4, dev->fp);
+            fread(&dev->tracks, 1, 4, dev->fp);
 
             /* Decode the entire file - pass 1, no write to buffer, determine length. */
             fseek(dev->fp, 0x80, SEEK_SET);
@@ -766,10 +766,10 @@ img_load(int drive, char *fn)
                 if (!track_bytes) {
                     /* Skip first 3 bytes - their meaning is unknown to us but could be a checksum. */
                     first_byte = fgetc(dev->fp);
-                    (void) !fread(&track_bytes, 1, 2, dev->fp);
+                    fread(&track_bytes, 1, 2, dev->fp);
                     img_log("Block header: %02X %04X ", first_byte, track_bytes);
                     /* Read the length of encoded data block. */
-                    (void) !fread(&track_bytes, 1, 2, dev->fp);
+                    fread(&track_bytes, 1, 2, dev->fp);
                     img_log("%04X\n", track_bytes);
                 }
 
@@ -793,7 +793,7 @@ img_load(int drive, char *fn)
                         /* Literal. */
                         track_bytes -= (run & 0x7f);
                         literal = (uint8_t *) malloc(run & 0x7f);
-                        (void) !fread(literal, 1, (run & 0x7f), dev->fp);
+                        fread(literal, 1, (run & 0x7f), dev->fp);
                         free(literal);
                     }
                     size += (run & 0x7f);
@@ -803,7 +803,7 @@ img_load(int drive, char *fn)
                     /* Literal block. */
                     size += (track_bytes - fdf_suppress_final_byte);
                     literal = (uint8_t *) malloc(track_bytes);
-                    (void) !fread(literal, 1, track_bytes, dev->fp);
+                    fread(literal, 1, track_bytes, dev->fp);
                     free(literal);
                     track_bytes = 0;
                 }
@@ -823,10 +823,10 @@ img_load(int drive, char *fn)
                 if (!track_bytes) {
                     /* Skip first 3 bytes - their meaning is unknown to us but could be a checksum. */
                     first_byte = fgetc(dev->fp);
-                    (void) !fread(&track_bytes, 1, 2, dev->fp);
+                    fread(&track_bytes, 1, 2, dev->fp);
                     img_log("Block header: %02X %04X ", first_byte, track_bytes);
                     /* Read the length of encoded data block. */
-                    (void) !fread(&track_bytes, 1, 2, dev->fp);
+                    fread(&track_bytes, 1, 2, dev->fp);
                     img_log("%04X\n", track_bytes);
                 }
 
@@ -855,7 +855,7 @@ img_load(int drive, char *fn)
                         /* Literal. */
                         track_bytes -= real_run;
                         literal = (uint8_t *) malloc(real_run);
-                        (void) !fread(literal, 1, real_run, dev->fp);
+                        fread(literal, 1, real_run, dev->fp);
                         if (!track_bytes)
                             real_run -= fdf_suppress_final_byte;
                         if (run & 0x7f)
@@ -866,7 +866,7 @@ img_load(int drive, char *fn)
                 } else {
                     /* Literal block. */
                     literal = (uint8_t *) malloc(track_bytes);
-                    (void) !fread(literal, 1, track_bytes, dev->fp);
+                    fread(literal, 1, track_bytes, dev->fp);
                     memcpy(bpos, literal, track_bytes - fdf_suppress_final_byte);
                     free(literal);
                     bpos += (track_bytes - fdf_suppress_final_byte);
@@ -896,10 +896,10 @@ img_load(int drive, char *fn)
             dev->fp = plat_fopen(fn, "rb");
 
             fseek(dev->fp, 0x03, SEEK_SET);
-            (void) !fread(&bpb_bps, 1, 2, dev->fp);
+            fread(&bpb_bps, 1, 2, dev->fp);
 #if 0
             fseek(dev->fp, 0x0B, SEEK_SET);
-            (void) !fread(&bpb_total, 1, 2, dev->fp);
+            fread(&bpb_total, 1, 2, dev->fp);
 #endif
             fseek(dev->fp, 0x10, SEEK_SET);
             bpb_sectors = fgetc(dev->fp);
@@ -919,7 +919,7 @@ img_load(int drive, char *fn)
             memset(dev->disk_data, 0xf6, ((uint32_t) bpb_total) * ((uint32_t) bpb_bps));
 
             fseek(dev->fp, 0x6F, SEEK_SET);
-            (void) !fread(&comment_len, 1, 2, dev->fp);
+            fread(&comment_len, 1, 2, dev->fp);
 
             fseek(dev->fp, -1, SEEK_END);
             size = ftell(dev->fp) + 1;
@@ -929,7 +929,7 @@ img_load(int drive, char *fn)
             cur_pos = 0;
 
             while (!feof(dev->fp)) {
-                (void) !fread(&block_len, 1, 2, dev->fp);
+                fread(&block_len, 1, 2, dev->fp);
 
                 if (!feof(dev->fp)) {
                     if (block_len < 0) {
@@ -946,10 +946,10 @@ img_load(int drive, char *fn)
                     } else if (block_len > 0) {
                         if ((cur_pos + block_len) > ((uint32_t) bpb_total) * ((uint32_t) bpb_bps)) {
                             block_len = ((uint32_t) bpb_total) * ((uint32_t) bpb_bps) - cur_pos;
-                            (void) !fread(dev->disk_data + cur_pos, 1, block_len, dev->fp);
+                            fread(dev->disk_data + cur_pos, 1, block_len, dev->fp);
                             break;
                         } else {
-                            (void) !fread(dev->disk_data + cur_pos, 1, block_len, dev->fp);
+                            fread(dev->disk_data + cur_pos, 1, block_len, dev->fp);
                             cur_pos += block_len;
                         }
                     }
@@ -970,9 +970,9 @@ img_load(int drive, char *fn)
             } else
                 img_log("img_load(): File is a raw image...\n");
             fseek(dev->fp, dev->base + 0x0B, SEEK_SET);
-            (void) !fread(&bpb_bps, 1, 2, dev->fp);
+            fread(&bpb_bps, 1, 2, dev->fp);
             fseek(dev->fp, dev->base + 0x13, SEEK_SET);
-            (void) !fread(&bpb_total, 1, 2, dev->fp);
+            fread(&bpb_total, 1, 2, dev->fp);
             fseek(dev->fp, dev->base + 0x15, SEEK_SET);
             bpb_mid = fgetc(dev->fp);
             fseek(dev->fp, dev->base + 0x18, SEEK_SET);
@@ -1140,7 +1140,7 @@ jump_if_fdf:
             /* The image is a Japanese FDI, therefore we read the number of tracks from the header. */
             if (fseek(dev->fp, 0x1C, SEEK_SET) == -1)
                 fatal("Japanese FDI: Failed when seeking to 0x1C\n");
-            (void) !fread(&(dev->tracks), 1, 4, dev->fp);
+            fread(&(dev->tracks), 1, 4, dev->fp);
         } else {
             if (!cqm && !fdf) {
                 /* Number of tracks = number of total sectors divided by sides times sectors per track. */

--- a/src/floppy/fdd_td0.c
+++ b/src/floppy/fdd_td0.c
@@ -646,7 +646,7 @@ td0_initialize(int drive)
     }
 
     fseek(dev->fp, 0, SEEK_SET);
-    (void) !fread(header, 1, 12, dev->fp);
+    fread(header, 1, 12, dev->fp);
     head_count = header[9];
 
     if (header[0] == 't') {

--- a/src/ini.c
+++ b/src/ini.c
@@ -276,7 +276,7 @@ ini_detect_bom(const char *fn)
 #endif
     if (fp == NULL)
         return 0;
-    (void) !fread(bom, 1, 3, fp);
+    fread(bom, 1, 3, fp);
     if (bom[0] == 0xEF && bom[1] == 0xBB && bom[2] == 0xBF) {
         fclose(fp);
         return 1;
@@ -350,7 +350,7 @@ ini_read(const char *fn)
 #ifdef __HAIKU__
         ini_fgetws(buff, sizeof_w(buff), fp);
 #else
-        (void) !fgetws(buff, sizeof_w(buff), fp);
+        fgetws(buff, sizeof_w(buff), fp);
 #endif
         if (feof(fp))
             break;
@@ -380,7 +380,7 @@ ini_read(const char *fn)
             c++;
             d = 0;
             while (buff[c] != L']' && buff[c])
-                (void) !wctomb(&(sname[d++]), buff[c++]);
+		    wctomb(&(sname[d++]), buff[c++]);
             sname[d] = L'\0';
 
             /* Is the section name properly terminated? */
@@ -390,7 +390,7 @@ ini_read(const char *fn)
             /* Create a new section and insert it. */
             ns = malloc(sizeof(section_t));
             memset(ns, 0x00, sizeof(section_t));
-            memcpy(ns->name, sname, 128);
+            memcpy(ns->name, sname, sizeof(sname));
             list_add(&ns->list, head);
 
             /* New section is now the current one. */
@@ -401,7 +401,7 @@ ini_read(const char *fn)
         /* Get the variable name. */
         d = 0;
         while ((buff[c] != L'=') && (buff[c] != L' ') && buff[c])
-            (void) !wctomb(&(ename[d++]), buff[c++]);
+		wctomb(&(ename[d++]), buff[c++]);
         ename[d] = L'\0';
 
         /* Skip incomplete lines. */
@@ -422,7 +422,7 @@ ini_read(const char *fn)
         /* Allocate a new variable entry.. */
         ne = malloc(sizeof(entry_t));
         memset(ne, 0x00, sizeof(entry_t));
-        memcpy(ne->name, ename, 128);
+        memcpy(ne->name, ename, sizeof(ename));
         wcsncpy(ne->wdata, &buff[d], sizeof_w(ne->wdata) - 1);
         ne->wdata[sizeof_w(ne->wdata) - 1] = L'\0';
 #ifdef _WIN32 /* Make sure the string is converted to UTF-8 rather than a legacy codepage */

--- a/src/machine/m_xt_t1000.c
+++ b/src/machine/m_xt_t1000.c
@@ -1054,7 +1054,7 @@ t1000_emsboard_load(void)
     if (mem_size > 512) {
         fp = plat_fopen(nvr_path("t1000_ems.nvr"), "rb");
         if (fp != NULL) {
-            (void) !fread(&ram[512 * 1024], 1024, (mem_size - 512), fp);
+            fread(&ram[512 * 1024], 1024, (mem_size - 512), fp);
             fclose(fp);
         }
     }

--- a/src/mem/catalyst_flash.c
+++ b/src/mem/catalyst_flash.c
@@ -209,7 +209,7 @@ catalyst_flash_init(UNUSED(const device_t *info))
 
     fp = nvr_fopen(flash_path, "rb");
     if (fp) {
-        (void) !fread(dev->array, 0x20000, 1, fp);
+        fread(dev->array, 0x20000, 1, fp);
         fclose(fp);
     }
 

--- a/src/mem/intel_flash.c
+++ b/src/mem/intel_flash.c
@@ -514,16 +514,16 @@ intel_flash_init(const device_t *info)
 
     fp = nvr_fopen(flash_path, "rb");
     if (fp) {
-        (void) !fread(&(dev->array[dev->block_start[BLOCK_MAIN1]]), dev->block_len[BLOCK_MAIN1], 1, fp);
+        fread(&(dev->array[dev->block_start[BLOCK_MAIN1]]), dev->block_len[BLOCK_MAIN1], 1, fp);
         if (dev->block_len[BLOCK_MAIN2])
-            (void) !fread(&(dev->array[dev->block_start[BLOCK_MAIN2]]), dev->block_len[BLOCK_MAIN2], 1, fp);
+            fread(&(dev->array[dev->block_start[BLOCK_MAIN2]]), dev->block_len[BLOCK_MAIN2], 1, fp);
         if (dev->block_len[BLOCK_MAIN3])
-            (void) !fread(&(dev->array[dev->block_start[BLOCK_MAIN3]]), dev->block_len[BLOCK_MAIN3], 1, fp);
+            fread(&(dev->array[dev->block_start[BLOCK_MAIN3]]), dev->block_len[BLOCK_MAIN3], 1, fp);
         if (dev->block_len[BLOCK_MAIN4])
-            (void) !fread(&(dev->array[dev->block_start[BLOCK_MAIN4]]), dev->block_len[BLOCK_MAIN4], 1, fp);
+            fread(&(dev->array[dev->block_start[BLOCK_MAIN4]]), dev->block_len[BLOCK_MAIN4], 1, fp);
 
-        (void) !fread(&(dev->array[dev->block_start[BLOCK_DATA1]]), dev->block_len[BLOCK_DATA1], 1, fp);
-        (void) !fread(&(dev->array[dev->block_start[BLOCK_DATA2]]), dev->block_len[BLOCK_DATA2], 1, fp);
+        fread(&(dev->array[dev->block_start[BLOCK_DATA1]]), dev->block_len[BLOCK_DATA1], 1, fp);
+        fread(&(dev->array[dev->block_start[BLOCK_DATA2]]), dev->block_len[BLOCK_DATA2], 1, fp);
         fclose(fp);
     }
 

--- a/src/network/net_event.c
+++ b/src/network/net_event.c
@@ -24,7 +24,7 @@ net_event_init(net_evt_t *event)
 #ifdef _WIN32
     event->handle = CreateEvent(NULL, FALSE, FALSE, NULL);
 #else
-    (void) !pipe(event->fds);
+    pipe(event->fds);
     setup_fd(event->fds[0]);
     setup_fd(event->fds[1]);
 #endif
@@ -36,7 +36,7 @@ net_event_set(net_evt_t *event)
 #ifdef _WIN32
     SetEvent(event->handle);
 #else
-    (void) !write(event->fds[1], "a", 1);
+    write(event->fds[1], "a", 1);
 #endif
 }
 
@@ -47,7 +47,7 @@ net_event_clear(UNUSED(net_evt_t *event))
     /* Do nothing on WIN32 since we use an auto-reset event */
 #else
     char dummy[1];
-    (void) !read(event->fds[0], &dummy, sizeof(dummy));
+    read(event->fds[0], &dummy, sizeof(dummy));
 #endif
 }
 

--- a/src/scsi/scsi_aha154x.c
+++ b/src/scsi/scsi_aha154x.c
@@ -740,11 +740,11 @@ aha_setbios(x54x_t *dev)
 
     /* Load first chunk of BIOS (which is the main BIOS, aka ROM1.) */
     dev->rom1 = malloc(ROM_SIZE);
-    (void) !fread(dev->rom1, ROM_SIZE, 1, fp);
+    fread(dev->rom1, ROM_SIZE, 1, fp);
     temp -= ROM_SIZE;
     if (temp > 0) {
         dev->rom2 = malloc(ROM_SIZE);
-        (void) !fread(dev->rom2, ROM_SIZE, 1, fp);
+        fread(dev->rom2, ROM_SIZE, 1, fp);
         temp -= ROM_SIZE;
     } else {
         dev->rom2 = NULL;
@@ -858,10 +858,10 @@ aha_setmcode(x54x_t *dev)
     }
     aha1542cp_pnp_rom = (uint8_t *) malloc(dev->pnp_len + 7);
     fseek(fp, dev->pnp_offset, SEEK_SET);
-    (void) !fread(aha1542cp_pnp_rom, dev->pnp_len, 1, fp);
+    fread(aha1542cp_pnp_rom, dev->pnp_len, 1, fp);
     memset(&(aha1542cp_pnp_rom[4]), 0x00, 5);
     fseek(fp, dev->pnp_offset + 4, SEEK_SET);
-    (void) !fread(&(aha1542cp_pnp_rom[9]), dev->pnp_len - 4, 1, fp);
+    fread(&(aha1542cp_pnp_rom[9]), dev->pnp_len - 4, 1, fp);
     /* Even the real AHA-1542CP microcode seem to be flipping bit
        4 to not erroneously indicate there is a range length. */
     aha1542cp_pnp_rom[0x87] |= 0x04;
@@ -872,7 +872,7 @@ aha_setmcode(x54x_t *dev)
 
     /* Load the SCSISelect decompression code. */
     fseek(fp, dev->cmd_33_offset, SEEK_SET);
-    (void) !fread(dev->cmd_33_buf, dev->cmd_33_len, 1, fp);
+    fread(dev->cmd_33_buf, dev->cmd_33_len, 1, fp);
 
     (void) fclose(fp);
 }

--- a/src/scsi/scsi_buslogic.c
+++ b/src/scsi/scsi_buslogic.c
@@ -1725,7 +1725,7 @@ buslogic_init(const device_t *info)
         if (has_autoscsi_rom) {
             fp = rom_fopen(autoscsi_rom_name, "rb");
             if (fp) {
-                (void) !fread(bl->AutoSCSIROM, 1, autoscsi_rom_size, fp);
+                fread(bl->AutoSCSIROM, 1, autoscsi_rom_size, fp);
                 fclose(fp);
                 fp = NULL;
             }
@@ -1734,7 +1734,7 @@ buslogic_init(const device_t *info)
         if (has_scam_rom) {
             fp = rom_fopen(scam_rom_name, "rb");
             if (fp) {
-                (void) !fread(bl->SCAMData, 1, scam_rom_size, fp);
+                fread(bl->SCAMData, 1, scam_rom_size, fp);
                 fclose(fp);
                 fp = NULL;
             }

--- a/src/scsi/scsi_ncr53c8xx.c
+++ b/src/scsi/scsi_ncr53c8xx.c
@@ -1452,7 +1452,7 @@ ncr53c8xx_eeprom(ncr53c8xx_t *dev, uint8_t save)
         if (save)
             fwrite(&dev->nvram, sizeof(dev->nvram), 1, fp);
         else
-            (void) !fread(&dev->nvram, sizeof(dev->nvram), 1, fp);
+            fread(&dev->nvram, sizeof(dev->nvram), 1, fp);
         fclose(fp);
     }
 }

--- a/src/sound/snd_cs423x.c
+++ b/src/sound/snd_cs423x.c
@@ -176,7 +176,7 @@ cs423x_nvram(cs423x_t *dev, uint8_t save)
         if (save)
             fwrite(dev->eeprom_data, sizeof(dev->eeprom_data), 1, fp);
         else
-            (void) !fread(dev->eeprom_data, sizeof(dev->eeprom_data), 1, fp);
+            fread(dev->eeprom_data, sizeof(dev->eeprom_data), 1, fp);
         fclose(fp);
     }
 }

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -921,7 +921,7 @@ monitor_thread(void *param)
             else {
 #endif
                 printf("(86Box) ");
-                (void) !getline(&line, &n, stdin);
+                getline(&line, &n, stdin);
 #ifdef ENABLE_READLINE
             }
 #endif

--- a/src/video/vid_xga.c
+++ b/src/video/vid_xga.c
@@ -3353,7 +3353,7 @@ xga_init(const device_t *info)
 
     rom = malloc(xga->bios_rom.sz);
     memset(rom, 0xff, xga->bios_rom.sz);
-    (void) !fread(rom, xga->bios_rom.sz, 1, fp);
+    fread(rom, xga->bios_rom.sz, 1, fp);
     (void) fclose(fp);
 
     xga->bios_rom.rom  = rom;

--- a/src/video/video.c
+++ b/src/video/video.c
@@ -1029,9 +1029,9 @@ loadfont_common(FILE *f, int format)
             for (d = 0; d < 4; d++) {
                 /* There are 4 fonts in the ROM */
                 for (c = 0; c < 256; c++) /* 8x14 MDA in 8x16 cell */
-                    (void) !fread(&fontdatm[256 * d + c][0], 1, 16, f);
+                    fread(&fontdatm[256 * d + c][0], 1, 16, f);
                 for (c = 0; c < 256; c++) { /* 8x8 CGA in 8x16 cell */
-                    (void) !fread(&fontdat[256 * d + c][0], 1, 8, f);
+                    fread(&fontdat[256 * d + c][0], 1, 8, f);
                     fseek(f, 8, SEEK_CUR);
                 }
             }
@@ -1059,23 +1059,23 @@ loadfont_common(FILE *f, int format)
         case 5:                               /* Toshiba 3100e */
             for (d = 0; d < 2048; d += 512) { /* Four languages... */
                 for (c = d; c < d + 256; c++) {
-                    (void) !fread(&fontdatm[c][8], 1, 8, f);
+                    fread(&fontdatm[c][8], 1, 8, f);
                 }
                 for (c = d + 256; c < d + 512; c++) {
-                    (void) !fread(&fontdatm[c][8], 1, 8, f);
+                    fread(&fontdatm[c][8], 1, 8, f);
                 }
                 for (c = d; c < d + 256; c++) {
-                    (void) !fread(&fontdatm[c][0], 1, 8, f);
+                    fread(&fontdatm[c][0], 1, 8, f);
                 }
                 for (c = d + 256; c < d + 512; c++) {
-                    (void) !fread(&fontdatm[c][0], 1, 8, f);
+                    fread(&fontdatm[c][0], 1, 8, f);
                 }
                 fseek(f, 4096, SEEK_CUR); /* Skip blank section */
                 for (c = d; c < d + 256; c++) {
-                    (void) !fread(&fontdat[c][0], 1, 8, f);
+                    fread(&fontdat[c][0], 1, 8, f);
                 }
                 for (c = d + 256; c < d + 512; c++) {
-                    (void) !fread(&fontdat[c][0], 1, 8, f);
+                    fread(&fontdat[c][0], 1, 8, f);
                 }
             }
             break;
@@ -1096,7 +1096,7 @@ loadfont_common(FILE *f, int format)
         case 7: /* Sigma Color 400 */
             /* The first 4k of the character ROM holds an 8x8 font */
             for (c = 0; c < 256; c++) {
-                (void) !fread(&fontdat[c][0], 1, 8, f);
+                fread(&fontdat[c][0], 1, 8, f);
                 fseek(f, 8, SEEK_CUR);
             }
             /* The second 4k holds an 8x16 font */
@@ -1114,7 +1114,7 @@ loadfont_common(FILE *f, int format)
 
         case 9: /* Image Manager 1024 native font */
             for (c = 0; c < 256; c++)
-                (void) !fread(&fontdat12x18[c][0], 1, 36, f);
+                fread(&fontdat12x18[c][0], 1, 36, f);
             break;
 
         case 10:                       /* Pravetz */
@@ -1128,9 +1128,9 @@ loadfont_common(FILE *f, int format)
             for (d = 0; d < 4; d++) {
                 /* There are 4 fonts in the ROM */
                 for (c = 0; c < 256; c++) /* 8x14 MDA in 8x16 cell */
-                    (void) !fread(&fontdatm2[256 * d + c][0], 1, 16, f);
+                    fread(&fontdatm2[256 * d + c][0], 1, 16, f);
                 for (c = 0; c < 256; c++) { /* 8x8 CGA in 8x16 cell */
-                    (void) !fread(&fontdat2[256 * d + c][0], 1, 8, f);
+                    fread(&fontdat2[256 * d + c][0], 1, 8, f);
                     fseek(f, 8, SEEK_CUR);
                 }
             }


### PR DESCRIPTION
Summary
=======
1. In a lot of places logical not operator is used before a function (mostly around fread()), and then casting them to void. But this result practically nothing as the compiler will ignore them anyway.

e.g. (void) !fread()
will represent as only fread(). It's only making it harder to read, so removing the extra "(void) !" seems reasonable.

2. ini.c - use sizeof() instead of directly specifying the size when calling memcpy().

Tested with GCC and Clang

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/