### PR TITLE
net_modem: process '&' escaped commands properly

### DIFF
--- a/src/network/net_modem.c
+++ b/src/network/net_modem.c
@@ -919,6 +919,7 @@ modem_do_command(modem_t* modem)
 		    	        }
 		    	        break;
 		    }
+            break;
 		    case '\\': { // \ escaped commands
 		    	char cmdchar = modem_fetch_character(&scanbuf);
 		    	switch (cmdchar) {


### PR DESCRIPTION
Summary
=======
net_modem: process '&' escaped commands properly

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
