### PR TITLE
GHA: Disable win32 in CodeQL

### DIFF
--- a/.github/workflows/codeql_windows_msys2.yml
+++ b/.github/workflows/codeql_windows_msys2.yml
@@ -61,9 +61,6 @@ jobs:
             new: on
             slug: -NDR
         ui:
-          - name: Win32 GUI
-            qt: off
-            static: on
           - name: Qt GUI
             qt: on
             static: off


### PR DESCRIPTION
Summary
=======
The win32 builds were disabled in #4093 but due to a slight oversight still remained in the CodeQL builds. 

This PR removes the win32 build from the stanza in the CodeQL action file to stop win32 from building.

Sending this to `master` instead of `4.2` since it is only related to CI (GHA) with no code changes.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
#4093 
