### PR TITLE
Compile fixes for Qt6 on Windows

### DIFF
--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -17,6 +17,10 @@
  *          Copyright 2021-2022 Cacodemon345
  *          Copyright 2021-2022 Teemu Korhonen
  */
+
+#ifdef _WIN32
+#define UNICODE 1
+#endif
 #include <QApplication>
 #include <QSurfaceFormat>
 #include <QDebug>
@@ -220,13 +224,13 @@ main(int argc, char *argv[])
 
 #ifdef Q_OS_WINDOWS
 #    if !defined(EMU_BUILD_NUM) || (EMU_BUILD_NUM != 5624)
-    HWND winbox = FindWindow("TWinBoxMain", NULL);
+    HWND winbox = FindWindow(L"TWinBoxMain", NULL);
     if (winbox &&
-        FindWindowEx(winbox, NULL, "TToolBar", NULL) &&
-        FindWindowEx(winbox, NULL, "TListBox", NULL) &&
-        FindWindowEx(winbox, NULL, "TStatusBar", NULL) &&
-        (winbox = FindWindowEx(winbox, NULL, "TPageControl", NULL)) && /* holds a TTabSheet even on VM pages */
-        FindWindowEx(winbox, NULL, "TTabSheet", NULL))
+        FindWindowEx(winbox, NULL, L"TToolBar", NULL) &&
+        FindWindowEx(winbox, NULL, L"TListBox", NULL) &&
+        FindWindowEx(winbox, NULL, L"TStatusBar", NULL) &&
+        (winbox = FindWindowEx(winbox, NULL, L"TPageControl", NULL)) && /* holds a TTabSheet even on VM pages */
+        FindWindowEx(winbox, NULL, L"TTabSheet", NULL))
 #    endif
     {
         QMessageBox warningbox(QMessageBox::Icon::Warning, QObject::tr("WinBox is no longer supported"),

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -17,10 +17,6 @@
  *          Copyright 2021-2022 Cacodemon345
  *          Copyright 2021-2022 Teemu Korhonen
  */
-
-#ifdef _WIN32
-#define UNICODE 1
-#endif
 #include <QApplication>
 #include <QSurfaceFormat>
 #include <QDebug>
@@ -224,13 +220,13 @@ main(int argc, char *argv[])
 
 #ifdef Q_OS_WINDOWS
 #    if !defined(EMU_BUILD_NUM) || (EMU_BUILD_NUM != 5624)
-    HWND winbox = FindWindow(L"TWinBoxMain", NULL);
+    HWND winbox = FindWindowW(L"TWinBoxMain", NULL);
     if (winbox &&
-        FindWindowEx(winbox, NULL, L"TToolBar", NULL) &&
-        FindWindowEx(winbox, NULL, L"TListBox", NULL) &&
-        FindWindowEx(winbox, NULL, L"TStatusBar", NULL) &&
-        (winbox = FindWindowEx(winbox, NULL, L"TPageControl", NULL)) && /* holds a TTabSheet even on VM pages */
-        FindWindowEx(winbox, NULL, L"TTabSheet", NULL))
+        FindWindowExW(winbox, NULL, L"TToolBar", NULL) &&
+        FindWindowExW(winbox, NULL, L"TListBox", NULL) &&
+        FindWindowExW(winbox, NULL, L"TStatusBar", NULL) &&
+        (winbox = FindWindowExW(winbox, NULL, L"TPageControl", NULL)) && /* holds a TTabSheet even on VM pages */
+        FindWindowExW(winbox, NULL, L"TTabSheet", NULL))
 #    endif
     {
         QMessageBox warningbox(QMessageBox::Icon::Warning, QObject::tr("WinBox is no longer supported"),


### PR DESCRIPTION
Summary
=======
Qt6 on Windows defines the UNICODE macro by default unlike Qt5. This PR fixes compilation with Qt6 on Windows by forcing it and changing the WinBox manager checks to use Unicode strings.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
