### PR TITLE
Fix Ghostscript DLL filename in an error message on 64-bit Windows

### DIFF
--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -581,7 +581,11 @@ c16stombs(char dst[], const uint16_t src[], int len)
 #endif
 
 #ifdef _WIN32
-#    define LIB_NAME_GS          "gsdll32.dll"
+#    if defined(__x86_64) || defined(__x86_64__) || defined(__amd64) || defined(_M_X64)
+#        define LIB_NAME_GS          "gsdll64.dll"
+#    else
+#        define LIB_NAME_GS          "gsdll32.dll"
+#endif
 #    define MOUSE_CAPTURE_KEYSEQ "F8+F12"
 #else
 #    define LIB_NAME_GS          "libgs"


### PR DESCRIPTION
Summary
=======
Correct the Ghostscript DLL filename that's used in an error message on 64-bit Windows from "gsdll32.dll" to "gsdll64.dll".

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A