### PR TITLE
Miscellaneous fixes and improvements for v4.1.1

### DIFF
--- a/src/qt/qt_harddiskdialog.cpp
+++ b/src/qt/qt_harddiskdialog.cpp
@@ -567,7 +567,7 @@ HarddiskDialog::onExistingFileSelected(const QString &fileName, bool precheck)
     } else if (image_is_vhd(fileNameUtf8.data(), 1)) {
         MVHDMeta *vhd = mvhd_open(fileNameUtf8.data(), 0, &vhd_error);
         if (vhd == nullptr) {
-            QMessageBox::critical(this, tr("Unable to read file"), tr("Make sure the file exists and is readable"));
+            QMessageBox::critical(this, tr("Unable to read file"), tr("Make sure the file exists and is readable."));
             return;
         } else if (vhd_error == MVHD_ERR_TIMESTAMP) {
             QMessageBox::StandardButton btn = QMessageBox::warning(this, tr("Parent and child disk timestamps do not match"), tr("This could mean that the parent image was modified after the differencing image was created.\n\nIt can also happen if the image files were moved or copied, or by a bug in the program that created this disk.\n\nDo you want to fix the timestamps?"), QMessageBox::Yes | QMessageBox::No);
@@ -618,7 +618,7 @@ HarddiskDialog::onExistingFileSelected(const QString &fileName, bool precheck)
     }
 
     if ((sectors > max_sectors) || (heads > max_heads) || (cylinders > max_cylinders)) {
-        QMessageBox::critical(this, tr("Unable to read file"), tr("Make sure the file exists and is readable"));
+        QMessageBox::critical(this, tr("Unable to read file"), tr("Make sure the file exists and is readable."));
         return;
     }
 

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -581,11 +581,11 @@ c16stombs(char dst[], const uint16_t src[], int len)
 #endif
 
 #ifdef _WIN32
-#    if defined(__x86_64) || defined(__x86_64__) || defined(__amd64) || defined(_M_X64)
+#    if defined(__amd64__) || defined(_M_X64) || defined(__aarch64__) || defined(_M_ARM64)
 #        define LIB_NAME_GS          "gsdll64.dll"
 #    else
 #        define LIB_NAME_GS          "gsdll32.dll"
-#endif
+#    endif
 #    define MOUSE_CAPTURE_KEYSEQ "F8+F12"
 #else
 #    define LIB_NAME_GS          "libgs"

--- a/src/qt/qt_progsettings.cpp
+++ b/src/qt/qt_progsettings.cpp
@@ -110,6 +110,7 @@ ProgSettings::ProgSettings(QWidget *parent)
             ui->comboBoxLanguage->setCurrentIndex(ui->comboBoxLanguage->findData(i.key()));
         }
     }
+    ui->comboBoxLanguage->model()->sort(Qt::AscendingOrder);
 
     mouseSensitivity = mouse_sensitivity;
     ui->horizontalSlider->setValue(mouseSensitivity * 100.);


### PR DESCRIPTION
Summary
=======
* Fix up the architecture check #ifdef from [the previous PR](https://github.com/86Box/86Box/pull/4275) to match what is used to determine the DLL filename to try loading;
* Add a missing period at the end of certain error messages, fixes translations of them not appearing under certain circumstances;
* Sort the language list alphabetically instead of by LCID.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A