### PR TITLE
[v4.2] Check for pcap DLL in Npcap's installation directory on Windows

### DIFF
--- a/src/network/net_pcap.c
+++ b/src/network/net_pcap.c
@@ -365,7 +365,13 @@ net_pcap_prepare(netdev_t *list)
 
     /* Try loading the DLL. */
 #ifdef _WIN32
+    /* Add the Npcap directory to the DLL search path. */
+    char npcap_dir[512];
+    GetSystemDirectoryA(npcap_dir, 480);
+    strcat(npcap_dir, "\\Npcap");
+    SetDllDirectoryA(npcap_dir);
     libpcap_handle = dynld_module("wpcap.dll", pcap_imports);
+    SetDllDirectoryA(NULL); /* reset the DLL search path */
 #elif defined __APPLE__
     libpcap_handle = dynld_module("libpcap.dylib", pcap_imports);
 #else


### PR DESCRIPTION
Summary
=======
On windows, add the directory where Npcap always installs its libraries to the DLL search path when looking for libpcap. This makes PCap networking usable if Npcap is not installed in WinPcap-compatible mode.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
<https://npcap.com/guide/npcap-devguide.html#npcap-feature-native>