### PR TITLE
Modify the PCAP filter to allow multicast packets

### DIFF
--- a/src/network/net_pcap.c
+++ b/src/network/net_pcap.c
@@ -500,7 +500,7 @@ net_pcap_init(const netcard_t *card, const uint8_t *mac_addr, void *priv, char *
     pcap_log("PCAP: installing filter for MAC=%02x:%02x:%02x:%02x:%02x:%02x\n",
              mac_addr[0], mac_addr[1], mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
     sprintf(filter_exp,
-            "( ((ether dst ff:ff:ff:ff:ff:ff) or (ether dst %02x:%02x:%02x:%02x:%02x:%02x)) and not (ether src %02x:%02x:%02x:%02x:%02x:%02x) )",
+            "( ((ether broadcast) or (ether multicast) or (ether dst %02x:%02x:%02x:%02x:%02x:%02x)) and not (ether src %02x:%02x:%02x:%02x:%02x:%02x) )",
             mac_addr[0], mac_addr[1], mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5],
             mac_addr[0], mac_addr[1], mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
     if (f_pcap_compile(pcap->pcap, &fp, filter_exp, 0, 0xffffffff) != -1) {


### PR DESCRIPTION
Summary
=======
This PR modifies the PCAP filter accordingly:
* Multicast packets are now passed through
* The `broadcast` keyword is used instead of `ff:ff:ff:ff:ff:ff`

The biggest effect is fixing NetBEUI / NetBIOS which was not working before: NetBEUI uses a multicast address (`03:00:00:00:00:01`) instead of a standard ethernet broadcast which was not passing the PCAP filter.

Anything that uses NetBEUI / NetBIOS should now work with PCAP, including LAN Manager. Any other L3 that uses multicast should also now work.

Screenshot of win98 with no TCP/IP installed, using only NetBEUI to communicate with another win98 host configured the same:

![netbeui](https://github.com/86Box/86Box/assets/47337035/ad70e659-6932-4376-a2e3-d958d5d106ec)

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A