### PR TITLE
Add the Tandy 4000 AT compatible and SCAT-286-003 machines

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -451,6 +451,7 @@ extern int machine_at_quadt386sx_init(const machine_t *);
 extern int machine_at_award286_init(const machine_t *);
 extern int machine_at_gdc212m_init(const machine_t *);
 extern int machine_at_gw286ct_init(const machine_t *);
+extern int machine_at_senor_scat286_init(const machine_t *);
 extern int machine_at_super286c_init(const machine_t *);
 extern int machine_at_super286tr_init(const machine_t *);
 extern int machine_at_spc4200p_init(const machine_t *);
@@ -492,6 +493,7 @@ extern int machine_at_ecs386_init(const machine_t *);
 extern int machine_at_spc6000a_init(const machine_t *);
 extern int machine_at_micronics386_init(const machine_t *);
 extern int machine_at_ecs386v_init(const machine_t *);
+extern int machine_at_tandy4000_init(const machine_t *);
 
 extern int machine_at_rycleopardlx_init(const machine_t *);
 

--- a/src/machine/m_at_286_386sx.c
+++ b/src/machine/m_at_286_386sx.c
@@ -351,6 +351,25 @@ machine_at_gw286ct_init(const machine_t *model)
 }
 
 int
+machine_at_senor_scat286_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/senor286/AMI-DSC2-1115-061390-K8.rom",
+                           0x000f0000, 65536, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_scat_init(model, 0, 1);
+
+    if (fdc_type == FDC_INTERNAL)
+        device_add(&fdc_at_device);
+
+    return ret;
+}
+
+int
 machine_at_super286c_init(const machine_t *model)
 {
     int ret;

--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -90,6 +90,26 @@ machine_at_asus386_init(const machine_t *model)
     return ret;
 }
 
+int
+machine_at_tandy4000_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/tandy4000/BIOS Tandy 4000 v1.03.01.bin",
+                           0x000f8000, 32768, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_common_init(model);
+    device_add(&keyboard_at_device);
+
+    if (fdc_type == FDC_INTERNAL)
+        device_add(&fdc_at_device);
+
+    return ret;
+}
+
 static void
 machine_at_sis401_common_init(const machine_t *model)
 {

--- a/src/machine/m_at_compaq.c
+++ b/src/machine/m_at_compaq.c
@@ -633,7 +633,10 @@ compaq_plasma_init(UNUSED(const device_t *info))
     memset(self, 0, sizeof(compaq_plasma_t));
 
     video_inform(VIDEO_FLAG_TYPE_CGA, &timing_compaq_plasma);
-    loadfont_ex("roms/machines/portableiii/K Combined.bin", 11, 0x4bb2);
+    if (compaq_machine_type == COMPAQ_PORTABLEIII)
+        loadfont_ex("roms/machines/portableiii/K Combined.bin", 11, 0x4bb2);
+    else
+        loadfont_ex("roms/machines/portableiii/P.2 Combined.bin", 11, 0x4b49);
 
     self->cga.composite = 0;
     self->cga.revision  = 0;
@@ -863,8 +866,8 @@ machine_at_portableiii386_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linearr("roms/machines/portableiii/K Combined.bin",
-                                0x000f8000, 65536, 0);
+    ret = bios_load_linearr("roms/machines/portableiii/P.2 Combined.bin",
+                                0x000f0000, 131072, 0);
 
     if (bios_only || !ret)
         return ret;

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -3726,6 +3726,45 @@ const machine_t machines[] = {
         .net_device = NULL
     },
 
+    {
+        .name = "[SCAT] Senor Science Co. SCAT-286-003",
+        .internal_name = "senorscat286",
+        .type = MACHINE_TYPE_286,
+        .chipset = MACHINE_CHIPSET_SCAT,
+        .init = machine_at_senor_scat286_init,
+        .p1_handler = NULL,
+        .gpio_handler = NULL,
+        .available_flag = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu = {
+            .package = CPU_PKG_286,
+            .block = CPU_BLOCK_NONE,
+            .min_bus = 0,
+            .max_bus = 0,
+            .min_voltage = 0,
+            .max_voltage = 0,
+            .min_multi = 0,
+            .max_multi = 0
+        },
+        .bus_flags = MACHINE_AT,
+        .flags = MACHINE_IDE,
+        .ram = {
+            .min = 1024,
+            .max = 4096,
+            .step = 1024
+        },
+        .nvrmask = 127,
+        .kbc_device = NULL,
+        .kbc_p1 = 0xff,
+        .gpio = 0xffffffff,
+        .gpio_acpi = 0xffffffff,
+        .device = NULL,
+        .fdc_device = NULL,
+        .sio_device = NULL,
+        .vid_device = NULL,
+        .snd_device = NULL,
+        .net_device = NULL
+    },
     /* 286 machines that utilize the MCA bus */
     /* Has IBM PS/2 Type 2 KBC firmware. */
     {
@@ -5013,7 +5052,7 @@ const machine_t machines[] = {
             .max = 14336,
             .step = 1024
         },
-        .nvrmask = 127,
+        .nvrmask = 63,
         .kbc_device = NULL,
         .kbc_p1 = 0xff,
         .gpio = 0xffffffff,
@@ -5054,6 +5093,46 @@ const machine_t machines[] = {
             .step = 128
         },
         .nvrmask = 127,
+        .kbc_device = NULL,
+        .kbc_p1 = 0xff,
+        .gpio = 0xffffffff,
+        .gpio_acpi = 0xffffffff,
+        .device = NULL,
+        .fdc_device = NULL,
+        .sio_device = NULL,
+        .vid_device = NULL,
+        .snd_device = NULL,
+        .net_device = NULL
+    },
+    /* Has IBM AT KBC firmware. */
+    {
+        .name = "[ISA] Tandy 4000",
+        .internal_name = "tandy4000",
+        .type = MACHINE_TYPE_386DX,
+        .chipset = MACHINE_CHIPSET_DISCRETE,
+        .init = machine_at_tandy4000_init,
+        .p1_handler = NULL,
+        .gpio_handler = NULL,
+        .available_flag = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu = {
+            .package = CPU_PKG_386DX,
+            .block = CPU_BLOCK_NONE,
+            .min_bus = 0,
+            .max_bus = 0,
+            .min_voltage = 0,
+            .max_voltage = 0,
+            .min_multi = 0,
+            .max_multi = 0
+        },
+        .bus_flags = MACHINE_AT,
+        .flags = MACHINE_APM,
+        .ram = {
+            .min = 1024,
+            .max = 16384,
+            .step = 1024
+        },
+        .nvrmask = 63,
         .kbc_device = NULL,
         .kbc_p1 = 0xff,
         .gpio = 0xffffffff,


### PR DESCRIPTION
Summary
=======
And a proper Compaq Portable III 386 BIOS.
Note: The SCAT 286 003 machine is a SCAT-based AMI 286 machine.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/254/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
