### PR TITLE
Fix zip disk image load crash

### DIFF
--- a/src/disk/zip.c
+++ b/src/disk/zip.c
@@ -531,7 +531,7 @@ zip_load(zip_t *dev, char *fn)
     if (fseek(dev->drv->fp, dev->drv->base, SEEK_SET) == -1)
         fatal("zip_load(): Error seeking to the beginning of the file\n");
 
-    strncpy(dev->drv->image_path, fn, strlen(dev->drv->image_path) + 1);
+    strncpy(dev->drv->image_path, fn, sizeof(dev->drv->image_path) - 1);
 
     return 1;
 }


### PR DESCRIPTION
Summary
=======
Revert the changes in e7f15d87. Fixes a crash when 86box loads a zip image.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
e7f15d87 was the original commit for this
