### PR TITLE
Disable UCRT64 in msys2 workflow

### DIFF
--- a/.github/workflows/cmake_windows_msys2.yml
+++ b/.github/workflows/cmake_windows_msys2.yml
@@ -79,9 +79,9 @@ jobs:
 #          - msystem: CLANG64
 #            prefix: mingw-w64-clang-x86_64
 #            toolchain: ./cmake/llvm-win32-x86_64.cmake
-          - msystem: UCRT64
-            prefix: mingw-w64-ucrt-x86_64
-            toolchain: ./cmake/flags-gcc-x86_64.cmake
+#          - msystem: UCRT64
+#            prefix: mingw-w64-ucrt-x86_64
+#            toolchain: ./cmake/flags-gcc-x86_64.cmake
 
     steps:
       - name: Prepare MSYS2 environment


### PR DESCRIPTION
Summary
=======
UCRT64 isn't used in any official capacity or for release builds. Disabling in GHA to try and trim down the workflow times.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
