### PR TITLE
Fix gcc warning with use of strncpy

### DIFF
--- a/src/disk/zip.c
+++ b/src/disk/zip.c
@@ -532,6 +532,11 @@ zip_load(zip_t *dev, char *fn)
         fatal("zip_load(): Error seeking to the beginning of the file\n");
 
     strncpy(dev->drv->image_path, fn, sizeof(dev->drv->image_path) - 1);
+    // After using strncpy, dev->drv->image_path needs to be explicitly null terminated to make gcc happy.
+    // In the event strlen(dev->drv->image_path) == sizeof(dev->drv->image_path) (no null terminator)
+    // it is placed at the very end. Otherwise, it is placed right after the string.
+    const size_t term = strlen(dev->drv->image_path) == sizeof(dev->drv->image_path) ? sizeof(dev->drv->image_path) - 1 : strlen(dev->drv->image_path);
+    dev->drv->image_path[term] = '\0';
 
     return 1;
 }


### PR DESCRIPTION
Summary
=======
Thanks to `-Wstringop-truncation` gcc is very particular about the use of `strncpy`.

It seems to be particularly concerned that 
* The destination string could, prior to the copy, potentially have no null terminator present
* The length copied from the source string could potentially have no null terminator (because the length being copied is less than the source size)
* If both of the above are true, the final dest string, after copy, could therefore have no null terminator

The fix for this is to explicitly set the null terminator which makes gcc happy.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
A previous attempt to fix this accidentally broke zip loading and had to be undone in #4298 
