### PR TITLE
Modem fixes

### DIFF
--- a/src/network/net_modem.c
+++ b/src/network/net_modem.c
@@ -391,6 +391,7 @@ modem_data_mode_process_byte(modem_t* modem, uint8_t data)
             modem->plusinc = 0;
         }
     }
+    modem->cmdpause = 0;
 
     if (modem->tx_count < 0x10000 && modem->connected) {
         modem->tx_pkt_ser_line[modem->tx_count++] = data;
@@ -597,6 +598,7 @@ modem_reset(modem_t* modem)
 	modem->cmdpos = 0;
 	modem->cmdbuf[0] = 0;
 	modem->flowcontrol = 0;
+	modem->cmdpause = 0;
 	modem->plusinc = 0;
     modem->dtrmode = 2;
 

--- a/src/network/net_modem.c
+++ b/src/network/net_modem.c
@@ -795,7 +795,7 @@ modem_do_command(modem_t* modem)
                     }
                 }
                 modem_dial(modem, foundstr);
-                break;
+                return;
             }
             case 'I': // Some strings about firmware
                 switch (modem_scan_number(&scanbuf)) {


### PR DESCRIPTION
Summary
=======
* Increase phone book size to 200 entries from 20, while decreasing the entry size from 1023 to 127 (anything longer wouldn't work anyway)
* Make certain string operations, including phonebook parsing, safer
* Fix escape sequence guard timer counter never resetting, effectively making the guard timer non-functional
* Stop command line processing after dialing; dialed number no longer gets interpreted as a command, affected primarily hostnames

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A
