### PR TITLE
Modem (and related) cleanups

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,34 +5,11 @@ indent_style = space
 indent_size = 4
 tab_width = 4
 
-# Disabled for now since not all editors support setting a tab_width value different from indent_size
-# Relevant VSCode extension issue: https://github.com/editorconfig/editorconfig-vscode/issues/190
-# [*.rc]
-# indent_style = space
-# indent_size = 4
-# tab_width = 4
-
-# [Makefile.*]
-# indent_style = space
-# indent_size = 4
-# tab_width = 4
-
 [*.manifest]
-indent_style = space
 indent_size = 2
 
 [*.yml]
-indent_style = space
 indent_size = 2
 
-[**/CMakeLists.txt]
-indent_style = space
-indent_size = 4
-
-[*.cmake]
-indent_style = space
-indent_size = 4
-
-[*.json]
-indent_style = space
-indent_size = 4
+[*.ui]
+indent_size = 1

--- a/src/device/serial_passthrough.c
+++ b/src/device/serial_passthrough.c
@@ -370,12 +370,12 @@ static const device_config_t serial_passthrough_config[] = {
 // clang-format on
 
 const device_t serial_passthrough_device = {
-    .name          = "Serial Passthrough Device",
-    .flags         = 0,
-    .local         = 0,
-    .init          = serial_passthrough_dev_init,
-    .close         = serial_passthrough_dev_close,
-    .reset         = NULL,
+    .name  = "Serial Passthrough Device",
+    .flags = 0,
+    .local = 0,
+    .init  = serial_passthrough_dev_init,
+    .close = serial_passthrough_dev_close,
+    .reset = NULL,
     { .poll = NULL },
     .speed_changed = serial_passthrough_speed_changed,
     .force_redraw  = NULL,

--- a/src/include/86box/plat_netsocket.h
+++ b/src/include/86box/plat_netsocket.h
@@ -1,24 +1,23 @@
 #ifndef _WIN32
-#define SOCKET int
+#    define SOCKET int
 #else
-#include <winsock2.h>
-#include <ws2tcpip.h>
+#    include <winsock2.h>
+#    include <ws2tcpip.h>
 #endif
 
-enum net_socket_types
-{
+enum net_socket_types {
     /* Only TCP is supported for now. */
     NET_SOCKET_TCP
 };
 
 SOCKET plat_netsocket_create(int type);
 SOCKET plat_netsocket_create_server(int type, unsigned short port);
-void plat_netsocket_close(SOCKET socket);
+void   plat_netsocket_close(SOCKET socket);
 
 SOCKET plat_netsocket_accept(SOCKET socket);
-int plat_netsocket_connected(SOCKET socket); /* Returns -1 on trouble. */
-int plat_netsocket_connect(SOCKET socket, const char* hostname, unsigned short port);
+int    plat_netsocket_connected(SOCKET socket); /* Returns -1 on trouble. */
+int    plat_netsocket_connect(SOCKET socket, const char *hostname, unsigned short port);
 
 /* Returns 0 in case of inability to send. -1 in case of errors. */
-int plat_netsocket_send(SOCKET socket, const unsigned char* data, unsigned int size, int *wouldblock);
-int plat_netsocket_receive(SOCKET socket, unsigned char* data, unsigned int size, int *wouldblock);
+int plat_netsocket_send(SOCKET socket, const unsigned char *data, unsigned int size, int *wouldblock);
+int plat_netsocket_receive(SOCKET socket, unsigned char *data, unsigned int size, int *wouldblock);

--- a/src/network/net_modem.c
+++ b/src/network/net_modem.c
@@ -58,89 +58,84 @@ modem_log(const char *fmt, ...)
 #endif
 
 /* From RFC 1055. */
-#define END             0300    /* indicates end of packet */
-#define ESC             0333    /* indicates byte stuffing */
-#define ESC_END         0334    /* ESC ESC_END means END data byte */
-#define ESC_ESC         0335    /* ESC ESC_ESC means ESC data byte */
+#define END     0300 /* indicates end of packet */
+#define ESC     0333 /* indicates byte stuffing */
+#define ESC_END 0334 /* ESC ESC_END means END data byte */
+#define ESC_ESC 0335 /* ESC ESC_ESC means ESC data byte */
 
 typedef enum ResTypes {
-	ResNONE,
-	ResOK,
-	ResERROR,
-	ResCONNECT,
-	ResRING,
-	ResBUSY,
-	ResNODIALTONE,
-	ResNOCARRIER,
-	ResNOANSWER
+    ResNONE,
+    ResOK,
+    ResERROR,
+    ResCONNECT,
+    ResRING,
+    ResBUSY,
+    ResNODIALTONE,
+    ResNOCARRIER,
+    ResNOANSWER
 } ResTypes;
 
-enum modem_types
-{
+enum modem_types {
     MODEM_TYPE_SLIP  = 1,
     MODEM_TYPE_PPP   = 2,
     MODEM_TYPE_TCPIP = 3
 };
 
-typedef enum modem_mode_t
-{
+typedef enum modem_mode_t {
     MODEM_MODE_COMMAND = 0,
-    MODEM_MODE_DATA = 1
+    MODEM_MODE_DATA    = 1
 } modem_mode_t;
 
-typedef enum modem_slip_stage_t
-{
+typedef enum modem_slip_stage_t {
     MODEM_SLIP_STAGE_USERNAME,
     MODEM_SLIP_STAGE_PASSWORD
 } modem_slip_stage_t;
 
 #define COMMAND_BUFFER_SIZE 512
-#define NUMBER_BUFFER_SIZE 128
-#define PHONEBOOK_SIZE 200
+#define NUMBER_BUFFER_SIZE  128
+#define PHONEBOOK_SIZE      200
 
-typedef struct modem_phonebook_entry_t
-{
+typedef struct modem_phonebook_entry_t {
     char phone[NUMBER_BUFFER_SIZE];
     char address[NUMBER_BUFFER_SIZE];
 } modem_phonebook_entry_t;
 
-typedef struct modem_t
-{
+typedef struct modem_t {
     uint8_t   mac[6];
     serial_t *serial;
     uint32_t  baudrate;
 
     modem_mode_t mode;
 
-    uint8_t esc_character_expected;
+    uint8_t    esc_character_expected;
     pc_timer_t host_to_serial_timer;
     pc_timer_t dtr_timer;
     pc_timer_t cmdpause_timer;
 
-    uint8_t tx_pkt_ser_line[0x10000]; /* SLIP-encoded. */
+    uint8_t  tx_pkt_ser_line[0x10000]; /* SLIP-encoded. */
     uint32_t tx_count;
 
-    Fifo8 rx_data; /* Data received from the network. */
-	uint8_t reg[100];
+    Fifo8   rx_data; /* Data received from the network. */
+    uint8_t reg[100];
 
     Fifo8 data_pending; /* Data yet to be sent to the host. */
 
-    char cmdbuf[COMMAND_BUFFER_SIZE];
-    char prevcmdbuf[COMMAND_BUFFER_SIZE];
-    char numberinprogress[NUMBER_BUFFER_SIZE];
-    char lastnumber[NUMBER_BUFFER_SIZE];
-	uint32_t cmdpos;
+    char     cmdbuf[COMMAND_BUFFER_SIZE];
+    char     prevcmdbuf[COMMAND_BUFFER_SIZE];
+    char     numberinprogress[NUMBER_BUFFER_SIZE];
+    char     lastnumber[NUMBER_BUFFER_SIZE];
+    uint32_t cmdpos;
     uint32_t port;
-    int plusinc, flowcontrol;
-    int in_warmup, dtrmode;
-    int dcdmode;
+    int      plusinc, flowcontrol;
+    int      in_warmup, dtrmode;
+    int      dcdmode;
 
-    bool connected, ringing;
-    bool echo, numericresponse;
-    bool tcpIpMode, tcpIpConnInProgress;
-    bool cooldown;
-    bool telnet_mode;
-    bool dtrstate;
+    bool     connected, ringing;
+    bool     echo, numericresponse;
+    bool     tcpIpMode, tcpIpConnInProgress;
+    bool     cooldown;
+    bool     telnet_mode;
+    bool     dtrstate;
     uint32_t tcpIpConnCounter;
 
     int doresponse;
@@ -153,82 +148,89 @@ typedef struct modem_t
     SOCKET waitingclientsocket;
 
     struct {
-		bool binary[2];
-		bool echo[2];
-		bool supressGA[2];
-		bool timingMark[2];
-		bool inIAC;
-		bool recCommand;
-		uint8_t command;
-	} telClient;
+        bool    binary[2];
+        bool    echo[2];
+        bool    supressGA[2];
+        bool    timingMark[2];
+        bool    inIAC;
+        bool    recCommand;
+        uint8_t command;
+    } telClient;
 
     modem_phonebook_entry_t entries[PHONEBOOK_SIZE];
-    uint32_t entries_num;
-    
+    uint32_t                entries_num;
+
     netcard_t *card;
 } modem_t;
 
 #define MREG_AUTOANSWER_COUNT 0
-#define MREG_RING_COUNT 1
-#define MREG_ESCAPE_CHAR 2
-#define MREG_CR_CHAR 3
-#define MREG_LF_CHAR 4
-#define MREG_BACKSPACE_CHAR 5
-#define MREG_GUARD_TIME 12
-#define MREG_DTR_DELAY 25
+#define MREG_RING_COUNT       1
+#define MREG_ESCAPE_CHAR      2
+#define MREG_CR_CHAR          3
+#define MREG_LF_CHAR          4
+#define MREG_BACKSPACE_CHAR   5
+#define MREG_GUARD_TIME       12
+#define MREG_DTR_DELAY        25
 
-static void modem_do_command(modem_t* modem, int repeat);
-static void modem_accept_incoming_call(modem_t* modem);
+static void modem_do_command(modem_t *modem, int repeat);
+static void modem_accept_incoming_call(modem_t *modem);
 
 extern ssize_t local_getline(char **buf, size_t *bufsiz, FILE *fp);
 
 // https://stackoverflow.com/a/122974
-char *trim(char *str)
+char *
+trim(char *str)
 {
-    size_t len = 0;
-    char *frontp = str;
-    char *endp = NULL;
+    size_t len    = 0;
+    char  *frontp = str;
+    char  *endp   = NULL;
 
-    if( str == NULL ) { return NULL; }
-    if( str[0] == '\0' ) { return str; }
+    if (str == NULL) {
+        return NULL;
+    }
+    if (str[0] == '\0') {
+        return str;
+    }
 
-    len = strlen(str);
+    len  = strlen(str);
     endp = str + len;
 
     /* Move the front and back pointers to address the first non-whitespace
      * characters from each end.
      */
-    while( isspace((unsigned char) *frontp) ) { ++frontp; }
-    if( endp != frontp )
-    {
-        while( isspace((unsigned char) *(--endp)) && endp != frontp ) {}
+    while (isspace((unsigned char) *frontp)) {
+        ++frontp;
+    }
+    if (endp != frontp) {
+        while (isspace((unsigned char) *(--endp)) && endp != frontp) { }
     }
 
-    if( frontp != str && endp == frontp )
-            *str = '\0';
-    else if( str + len - 1 != endp )
-            *(endp + 1) = '\0';
+    if (frontp != str && endp == frontp)
+        *str = '\0';
+    else if (str + len - 1 != endp)
+        *(endp + 1) = '\0';
 
     /* Shift the string so that it starts at str so that if it's dynamically
      * allocated, we can still free it on the returned pointer.  Note the reuse
      * of endp to mean the front of the string buffer now.
      */
     endp = str;
-    if( frontp != str )
-    {
-            while( *frontp ) { *endp++ = *frontp++; }
-            *endp = '\0';
+    if (frontp != str) {
+        while (*frontp) {
+            *endp++ = *frontp++;
+        }
+        *endp = '\0';
     }
 
     return str;
 }
 
 static void
-modem_read_phonebook_file(modem_t* modem, const char* path)
+modem_read_phonebook_file(modem_t *modem, const char *path)
 {
-    FILE* file = plat_fopen(path, "r");
-    char* buf  = NULL;
-    char* buf2 = NULL;
+    FILE  *file = plat_fopen(path, "r");
+    char  *buf  = NULL;
+    char  *buf2 = NULL;
     size_t size = 0;
     if (!file)
         return;
@@ -238,14 +240,14 @@ modem_read_phonebook_file(modem_t* modem, const char* path)
     modem_log("Modem: Reading phone book file %s...\n", path);
     while (local_getline(&buf, &size, file) != -1) {
         modem_phonebook_entry_t entry = { { 0 }, { 0 } };
-        buf[strcspn(buf, "\r\n")] = '\0';
+        buf[strcspn(buf, "\r\n")]     = '\0';
 
         /* Remove surrounding whitespace from the input line and find the address part. */
-        buf = trim(buf);
+        buf  = trim(buf);
         buf2 = &buf[strcspn(buf, " \t")];
 
         /* Remove surrounding whitespace and any extra text from the address part, then store it. */
-        buf2 = trim(buf2);
+        buf2                       = trim(buf2);
         buf2[strcspn(buf2, " \t")] = '\0';
         strncpy(entry.address, buf2, sizeof(entry.address) - 1);
 
@@ -264,7 +266,7 @@ modem_read_phonebook_file(modem_t* modem, const char* path)
             modem_log("Modem: Invalid character in phone number %s\n", entry.phone);
             continue;
         }
-        
+
         modem_log("Modem: Mapped phone number %s to address %s\n", entry.phone, entry.address);
         modem->entries[modem->entries_num++] = entry;
         if (modem->entries_num >= PHONEBOOK_SIZE)
@@ -274,36 +276,37 @@ modem_read_phonebook_file(modem_t* modem, const char* path)
 }
 
 static void
-modem_echo(modem_t* modem, uint8_t c)
+modem_echo(modem_t *modem, uint8_t c)
 {
-    if (modem->echo && fifo8_num_free(&modem->data_pending)) fifo8_push(&modem->data_pending, c);
+    if (modem->echo && fifo8_num_free(&modem->data_pending))
+        fifo8_push(&modem->data_pending, c);
 }
 
 static uint32_t
 modem_scan_number(char **scan)
 {
-    char c = 0;
-	uint32_t ret = 0;
-	while (1) {
+    char     c   = 0;
+    uint32_t ret = 0;
+    while (1) {
         c = **scan;
         if (c == 0)
             break;
-		if (c >= '0' && c <= '9') {
-			ret*=10;
-			ret+=c-'0';
-			*scan = *scan + 1;
-		} else
-			break;
-	}
-	return ret;
+        if (c >= '0' && c <= '9') {
+            ret *= 10;
+            ret += c - '0';
+            *scan = *scan + 1;
+        } else
+            break;
+    }
+    return ret;
 }
 
 static uint8_t
 modem_fetch_character(char **scan)
 {
     uint8_t c = **scan;
-	*scan = *scan + 1;
-	return c;
+    *scan     = *scan + 1;
+    return c;
 }
 
 static void
@@ -315,37 +318,36 @@ modem_speed_changed(void *priv)
 
     timer_stop(&dev->host_to_serial_timer);
     /* FIXME: do something to dev->baudrate */
-    timer_on_auto(&dev->host_to_serial_timer, (1000000.0 / (double)dev->baudrate) * 9);
+    timer_on_auto(&dev->host_to_serial_timer, (1000000.0 / (double) dev->baudrate) * 9);
 #if 0
     serial_clear_fifo(dev->serial);
 #endif
 }
 
 static void
-modem_send_line(modem_t* modem, const char* line)
+modem_send_line(modem_t *modem, const char *line)
 {
     fifo8_push(&modem->data_pending, modem->reg[MREG_CR_CHAR]);
     fifo8_push(&modem->data_pending, modem->reg[MREG_LF_CHAR]);
-    fifo8_push_all(&modem->data_pending, (uint8_t*)line, strlen(line));
+    fifo8_push_all(&modem->data_pending, (uint8_t *) line, strlen(line));
     fifo8_push(&modem->data_pending, modem->reg[MREG_CR_CHAR]);
     fifo8_push(&modem->data_pending, modem->reg[MREG_LF_CHAR]);
 }
 
-
 static void
-modem_send_number(modem_t* modem, uint32_t val)
+modem_send_number(modem_t *modem, uint32_t val)
 {
-	fifo8_push(&modem->data_pending, modem->reg[MREG_CR_CHAR]);
-	fifo8_push(&modem->data_pending, modem->reg[MREG_LF_CHAR]);
+    fifo8_push(&modem->data_pending, modem->reg[MREG_CR_CHAR]);
+    fifo8_push(&modem->data_pending, modem->reg[MREG_LF_CHAR]);
 
-	fifo8_push(&modem->data_pending, val / 100 + '0');
-	val = val%100;
-	fifo8_push(&modem->data_pending, val / 10 + '0');
-	val = val%10;
-	fifo8_push(&modem->data_pending, val + '0');
+    fifo8_push(&modem->data_pending, val / 100 + '0');
+    val = val % 100;
+    fifo8_push(&modem->data_pending, val / 10 + '0');
+    val = val % 10;
+    fifo8_push(&modem->data_pending, val + '0');
 
-	fifo8_push(&modem->data_pending, modem->reg[MREG_CR_CHAR]);
-	fifo8_push(&modem->data_pending, modem->reg[MREG_LF_CHAR]);
+    fifo8_push(&modem->data_pending, modem->reg[MREG_CR_CHAR]);
+    fifo8_push(&modem->data_pending, modem->reg[MREG_LF_CHAR]);
 }
 
 static void
@@ -391,13 +393,12 @@ process_tx_packet(modem_t *modem, uint8_t *p, uint32_t len)
     }
 
 send_tx_packet:
-    if (received)
-    {
-        uint8_t* buf = calloc(received + 14, 1);
+    if (received) {
+        uint8_t *buf = calloc(received + 14, 1);
         buf[0] = buf[1] = buf[2] = buf[3] = buf[4] = buf[5] = 0xFF;
         buf[6] = buf[7] = buf[8] = buf[9] = buf[10] = buf[11] = 0xFC;
-        buf[12] = 0x08;
-        buf[13] = 0x00;
+        buf[12]                                               = 0x08;
+        buf[13]                                               = 0x00;
         memcpy(buf + 14, processed_tx_packet, received);
         network_tx(modem->card, buf, received + 14);
         free(buf);
@@ -407,7 +408,7 @@ send_tx_packet:
 }
 
 static void
-modem_data_mode_process_byte(modem_t* modem, uint8_t data)
+modem_data_mode_process_byte(modem_t *modem, uint8_t data)
 {
     if (modem->reg[MREG_ESCAPE_CHAR] <= 127) {
         if (modem->plusinc >= 1 && modem->plusinc <= 3 && modem->reg[MREG_ESCAPE_CHAR] == data) {
@@ -421,7 +422,7 @@ modem_data_mode_process_byte(modem_t* modem, uint8_t data)
     if (modem->tx_count < 0x10000 && modem->connected) {
         modem->tx_pkt_ser_line[modem->tx_count++] = data;
         if (data == END && !modem->tcpIpMode) {
-            process_tx_packet(modem, modem->tx_pkt_ser_line, (uint32_t)modem->tx_count);
+            process_tx_packet(modem, modem->tx_pkt_ser_line, (uint32_t) modem->tx_count);
             modem->tx_count = 0;
         }
     }
@@ -430,7 +431,7 @@ modem_data_mode_process_byte(modem_t* modem, uint8_t data)
 static void
 host_to_modem_cb(void *priv)
 {
-    modem_t* modem = (modem_t*)priv;
+    modem_t *modem = (modem_t *) priv;
 
     if (modem->in_warmup)
         goto no_write_to_machine;
@@ -460,143 +461,169 @@ host_to_modem_cb(void *priv)
     }
 
 no_write_to_machine:
-    timer_on_auto(&modem->host_to_serial_timer, (1000000.0 / (double)modem->baudrate) * (double)9);
+    timer_on_auto(&modem->host_to_serial_timer, (1000000.0 / (double) modem->baudrate) * (double) 9);
 }
 
 static void
 modem_write(UNUSED(serial_t *s), void *priv, uint8_t txval)
 {
-    modem_t* modem = (modem_t*)priv;
+    modem_t *modem = (modem_t *) priv;
 
     if (modem->mode == MODEM_MODE_COMMAND) {
         if (modem->cmdpos < 2) {
-			// Ignore everything until we see "AT" sequence.
-			if (modem->cmdpos == 0 && toupper(txval) != 'A') {
-				return;
-			}
+            // Ignore everything until we see "AT" sequence.
+            if (modem->cmdpos == 0 && toupper(txval) != 'A') {
+                return;
+            }
 
-			if (modem->cmdpos == 1 && toupper(txval) != 'T') {
-				if (txval == '/') {
-					// Repeat the last command.
-					modem_echo(modem, txval);
-					modem_log("Repeat last command (%s)\n", modem->prevcmdbuf);
-					modem_do_command(modem, 1);
-				} else {
-					modem_echo(modem, modem->reg[MREG_BACKSPACE_CHAR]);
-					modem->cmdpos = 0;
-				}
-				return;
-			}
+            if (modem->cmdpos == 1 && toupper(txval) != 'T') {
+                if (txval == '/') {
+                    // Repeat the last command.
+                    modem_echo(modem, txval);
+                    modem_log("Repeat last command (%s)\n", modem->prevcmdbuf);
+                    modem_do_command(modem, 1);
+                } else {
+                    modem_echo(modem, modem->reg[MREG_BACKSPACE_CHAR]);
+                    modem->cmdpos = 0;
+                }
+                return;
+            }
         } else {
-			// Now entering command.
-			if (txval == modem->reg[MREG_BACKSPACE_CHAR]) {
-				if (modem->cmdpos > 2) {
-					modem_echo(modem, txval);
-					modem->cmdpos--;
-				}
-				return;
-			}
+            // Now entering command.
+            if (txval == modem->reg[MREG_BACKSPACE_CHAR]) {
+                if (modem->cmdpos > 2) {
+                    modem_echo(modem, txval);
+                    modem->cmdpos--;
+                }
+                return;
+            }
 
-			if (txval == modem->reg[MREG_LF_CHAR]) {
-				return; // Real modem doesn't seem to skip this?
-			}
+            if (txval == modem->reg[MREG_LF_CHAR]) {
+                return; // Real modem doesn't seem to skip this?
+            }
 
-			if (txval == modem->reg[MREG_CR_CHAR]) {
-				modem_echo(modem, txval);
-				modem_do_command(modem, 0);
-				return;
-			}
-		}
+            if (txval == modem->reg[MREG_CR_CHAR]) {
+                modem_echo(modem, txval);
+                modem_do_command(modem, 0);
+                return;
+            }
+        }
 
         if (modem->cmdpos < 99) {
-			modem_echo(modem, txval);
-			modem->cmdbuf[modem->cmdpos] = txval;
-			modem->cmdpos++;
-		}
+            modem_echo(modem, txval);
+            modem->cmdbuf[modem->cmdpos] = txval;
+            modem->cmdpos++;
+        }
     } else {
         modem_data_mode_process_byte(modem, txval);
     }
 }
 
-void modem_send_res(modem_t* modem, const ResTypes response) {
-    char response_str_connect[256] = { 0 };
-	const char* response_str = NULL;
-	uint32_t code = -1;
+void
+modem_send_res(modem_t *modem, const ResTypes response)
+{
+    char        response_str_connect[256] = { 0 };
+    const char *response_str              = NULL;
+    uint32_t    code                      = -1;
 
     snprintf(response_str_connect, sizeof(response_str_connect), "CONNECT %u", modem->baudrate);
 
-	switch (response) {
-	case ResOK:         code = 0; response_str = "OK"; break;
-	case ResCONNECT:    code = 1; response_str = response_str_connect; break;
-	case ResRING:       code = 2; response_str = "RING"; break;
-	case ResNOCARRIER:  code = 3; response_str = "NO CARRIER"; break;
-	case ResERROR:      code = 4; response_str = "ERROR"; break;
-	case ResNODIALTONE: code = 6; response_str = "NO DIALTONE"; break;
-	case ResBUSY:       code = 7; response_str = "BUSY"; break;
-	case ResNOANSWER:   code = 8; response_str = "NO ANSWER"; break;
-	case ResNONE: return;
-	}
+    switch (response) {
+        case ResOK:
+            code         = 0;
+            response_str = "OK";
+            break;
+        case ResCONNECT:
+            code         = 1;
+            response_str = response_str_connect;
+            break;
+        case ResRING:
+            code         = 2;
+            response_str = "RING";
+            break;
+        case ResNOCARRIER:
+            code         = 3;
+            response_str = "NO CARRIER";
+            break;
+        case ResERROR:
+            code         = 4;
+            response_str = "ERROR";
+            break;
+        case ResNODIALTONE:
+            code         = 6;
+            response_str = "NO DIALTONE";
+            break;
+        case ResBUSY:
+            code         = 7;
+            response_str = "BUSY";
+            break;
+        case ResNOANSWER:
+            code         = 8;
+            response_str = "NO ANSWER";
+            break;
+        case ResNONE:
+            return;
+    }
 
-	if (modem->doresponse != 1) {
-		if (modem->doresponse == 2 && (response == ResRING ||
-			response == ResCONNECT || response == ResNOCARRIER)) {
-			return;
-		}
-		modem_log("Modem response: %s\n", response_str);
-		if (modem->numericresponse && code != ~0) {
-			modem_send_number(modem, code);
-		} else if (response_str != NULL) {
-			modem_send_line(modem, response_str);
-		}
+    if (modem->doresponse != 1) {
+        if (modem->doresponse == 2 && (response == ResRING || response == ResCONNECT || response == ResNOCARRIER)) {
+            return;
+        }
+        modem_log("Modem response: %s\n", response_str);
+        if (modem->numericresponse && code != ~0) {
+            modem_send_number(modem, code);
+        } else if (response_str != NULL) {
+            modem_send_line(modem, response_str);
+        }
 
-		// if(CSerial::CanReceiveByte())	// very fast response
-		//	if(rqueue->inuse() && CSerial::getRTS())
-		//	{ uint8_t rbyte =rqueue->getb();
-		//		CSerial::receiveByte(rbyte);
-		//	LOG_MSG("SERIAL: Port %" PRIu8 " modem sending byte %2x back to UART2",
-		//	        GetPortNumber(), rbyte);
-		//	}
-	}
+        // if(CSerial::CanReceiveByte())	// very fast response
+        //	if(rqueue->inuse() && CSerial::getRTS())
+        //	{ uint8_t rbyte =rqueue->getb();
+        //		CSerial::receiveByte(rbyte);
+        //	LOG_MSG("SERIAL: Port %" PRIu8 " modem sending byte %2x back to UART2",
+        //	        GetPortNumber(), rbyte);
+        //	}
+    }
 }
 
 void
-modem_enter_idle_state(modem_t* modem)
+modem_enter_idle_state(modem_t *modem)
 {
     timer_disable(&modem->dtr_timer);
-    modem->connected = false;
-    modem->ringing = false;
-    modem->mode = MODEM_MODE_COMMAND;
-    modem->in_warmup = 0;
+    modem->connected           = false;
+    modem->ringing             = false;
+    modem->mode                = MODEM_MODE_COMMAND;
+    modem->in_warmup           = 0;
     modem->tcpIpConnInProgress = 0;
-    modem->tcpIpConnCounter = 0;
+    modem->tcpIpConnCounter    = 0;
 
-    if (modem->waitingclientsocket != (SOCKET)-1)
+    if (modem->waitingclientsocket != (SOCKET) -1)
         plat_netsocket_close(modem->waitingclientsocket);
-    
-    if (modem->clientsocket != (SOCKET)-1)
+
+    if (modem->clientsocket != (SOCKET) -1)
         plat_netsocket_close(modem->clientsocket);
 
-    modem->clientsocket = modem->waitingclientsocket = (SOCKET)-1;
-    if (modem->serversocket != (SOCKET)-1) {
+    modem->clientsocket = modem->waitingclientsocket = (SOCKET) -1;
+    if (modem->serversocket != (SOCKET) -1) {
         modem->waitingclientsocket = plat_netsocket_accept(modem->serversocket);
-        while (modem->waitingclientsocket != (SOCKET)-1) {
+        while (modem->waitingclientsocket != (SOCKET) -1) {
             plat_netsocket_close(modem->waitingclientsocket);
             modem->waitingclientsocket = plat_netsocket_accept(modem->serversocket);
         }
         plat_netsocket_close(modem->serversocket);
-        modem->serversocket = (SOCKET)-1;
+        modem->serversocket = (SOCKET) -1;
     }
 
-    if (modem->waitingclientsocket != (SOCKET)-1)
+    if (modem->waitingclientsocket != (SOCKET) -1)
         plat_netsocket_close(modem->waitingclientsocket);
 
-    modem->waitingclientsocket = (SOCKET)-1;
-    modem->tcpIpMode = false;
+    modem->waitingclientsocket = (SOCKET) -1;
+    modem->tcpIpMode           = false;
     modem->tcpIpConnInProgress = false;
 
     if (modem->listen_port) {
         modem->serversocket = plat_netsocket_create_server(NET_SOCKET_TCP, modem->listen_port);
-        if (modem->serversocket == (SOCKET)-1) {
+        if (modem->serversocket == (SOCKET) -1) {
             pclog("Failed to set up server on port %d\n", modem->listen_port);
         }
     }
@@ -608,15 +635,15 @@ modem_enter_idle_state(modem_t* modem)
 }
 
 void
-modem_enter_connected_state(modem_t* modem)
+modem_enter_connected_state(modem_t *modem)
 {
     modem_send_res(modem, ResCONNECT);
-    modem->mode = MODEM_MODE_DATA;
-    modem->ringing = false;
+    modem->mode      = MODEM_MODE_DATA;
+    modem->ringing   = false;
     modem->connected = true;
     modem->tcpIpMode = true;
-    modem->cooldown = true;
-    modem->tx_count = 0;
+    modem->cooldown  = true;
+    modem->tx_count  = 0;
     plat_netsocket_close(modem->serversocket);
     modem->serversocket = -1;
     memset(&modem->telClient, 0, sizeof(modem->telClient));
@@ -625,49 +652,46 @@ modem_enter_connected_state(modem_t* modem)
 }
 
 void
-modem_reset(modem_t* modem)
+modem_reset(modem_t *modem)
 {
     modem->dcdmode = 1;
     modem_enter_idle_state(modem);
-	modem->cmdpos = 0;
-	modem->cmdbuf[0] = 0;
-	modem->prevcmdbuf[0] = 0;
-    modem->lastnumber[0] = 0;
+    modem->cmdpos              = 0;
+    modem->cmdbuf[0]           = 0;
+    modem->prevcmdbuf[0]       = 0;
+    modem->lastnumber[0]       = 0;
     modem->numberinprogress[0] = 0;
-	modem->flowcontrol = 0;
-	modem->cmdpause = 0;
-	modem->plusinc = 0;
-    modem->dtrmode = 2;
+    modem->flowcontrol         = 0;
+    modem->cmdpause            = 0;
+    modem->plusinc             = 0;
+    modem->dtrmode             = 2;
 
-	memset(&modem->reg,0,sizeof(modem->reg));
-	modem->reg[MREG_AUTOANSWER_COUNT] = 0;  // no autoanswer
-	modem->reg[MREG_RING_COUNT]       = 1;
-	modem->reg[MREG_ESCAPE_CHAR]      = '+';
-	modem->reg[MREG_CR_CHAR]          = '\r';
-	modem->reg[MREG_LF_CHAR]          = '\n';
-	modem->reg[MREG_BACKSPACE_CHAR]   = '\b';
-	modem->reg[MREG_GUARD_TIME]       = 50;
-	modem->reg[MREG_DTR_DELAY]        = 5;
+    memset(&modem->reg, 0, sizeof(modem->reg));
+    modem->reg[MREG_AUTOANSWER_COUNT] = 0; // no autoanswer
+    modem->reg[MREG_RING_COUNT]       = 1;
+    modem->reg[MREG_ESCAPE_CHAR]      = '+';
+    modem->reg[MREG_CR_CHAR]          = '\r';
+    modem->reg[MREG_LF_CHAR]          = '\n';
+    modem->reg[MREG_BACKSPACE_CHAR]   = '\b';
+    modem->reg[MREG_GUARD_TIME]       = 50;
+    modem->reg[MREG_DTR_DELAY]        = 5;
 
-	modem->echo = true;
-	modem->doresponse = 0;
-	modem->numericresponse = false;
+    modem->echo            = true;
+    modem->doresponse      = 0;
+    modem->numericresponse = false;
 }
 
 void
-modem_dial(modem_t* modem, const char* str)
+modem_dial(modem_t *modem, const char *str)
 {
     modem->tcpIpConnCounter = 0;
-    modem->tcpIpMode = false;
-    if (!strncmp(str, "0.0.0.0", sizeof("0.0.0.0") - 1))
-    {
+    modem->tcpIpMode        = false;
+    if (!strncmp(str, "0.0.0.0", sizeof("0.0.0.0") - 1)) {
         modem_log("Turning on SLIP\n");
         modem_enter_connected_state(modem);
         modem->numberinprogress[0] = 0;
-        modem->tcpIpMode = false;
-    }
-    else
-    {
+        modem->tcpIpMode           = false;
+    } else {
         char buf[NUMBER_BUFFER_SIZE] = "";
         strncpy(buf, str, sizeof(buf) - 1);
         strncpy(modem->lastnumber, str, sizeof(modem->lastnumber) - 1);
@@ -675,59 +699,60 @@ modem_dial(modem_t* modem, const char* str)
 
         // Scan host for port
         uint16_t port;
-        char * hasport = strrchr(buf,':');
+        char    *hasport = strrchr(buf, ':');
         if (hasport) {
             *hasport++ = 0;
-            port = (uint16_t)atoi(hasport);
-        }
-        else {
+            port       = (uint16_t) atoi(hasport);
+        } else {
             port = 23;
         }
 
         modem->numberinprogress[0] = 0;
-        modem->clientsocket = plat_netsocket_create(NET_SOCKET_TCP);
+        modem->clientsocket        = plat_netsocket_create(NET_SOCKET_TCP);
         if (modem->clientsocket == -1) {
             pclog("Failed to create client socket\n");
-		    modem_send_res(modem, ResNOCARRIER);
-		    modem_enter_idle_state(modem);
+            modem_send_res(modem, ResNOCARRIER);
+            modem_enter_idle_state(modem);
             return;
         }
 
         if (-1 == plat_netsocket_connect(modem->clientsocket, buf, port)) {
             pclog("Failed to connect to %s\n", buf);
-		    modem_send_res(modem, ResNOCARRIER);
-		    modem_enter_idle_state(modem);
+            modem_send_res(modem, ResNOCARRIER);
+            modem_enter_idle_state(modem);
             return;
         }
         modem->tcpIpConnInProgress = 1;
-        modem->tcpIpConnCounter = 0;
+        modem->tcpIpConnCounter    = 0;
     }
 }
 
 static bool
-is_next_token(const char* a, size_t N, const char *b)
+is_next_token(const char *a, size_t N, const char *b)
 {
-	// Is 'b' at least as long as 'a'?
-	size_t N_without_null = N - 1;
-	if (strnlen(b, N) < N_without_null)
-		return false;
-	return (strncmp(a, b, N_without_null) == 0);
+    // Is 'b' at least as long as 'a'?
+    size_t N_without_null = N - 1;
+    if (strnlen(b, N) < N_without_null)
+        return false;
+    return (strncmp(a, b, N_without_null) == 0);
 }
 
-static const char *modem_get_address_from_phonebook(modem_t* modem, const char *input) {
+static const char *
+modem_get_address_from_phonebook(modem_t *modem, const char *input)
+{
     int i = 0;
-	for (i = 0; i < modem->entries_num; i++) {
-		if (strcmp(input, modem->entries[i].phone) == 0)
-			return modem->entries[i].address;
-	}
+    for (i = 0; i < modem->entries_num; i++) {
+        if (strcmp(input, modem->entries[i].phone) == 0)
+            return modem->entries[i].address;
+    }
 
-	return NULL;
+    return NULL;
 }
 
 static void
-modem_do_command(modem_t* modem, int repeat)
+modem_do_command(modem_t *modem, int repeat)
 {
-    int i = 0;
+    int   i       = 0;
     char *scanbuf = NULL;
 
     if (repeat) {
@@ -750,11 +775,11 @@ modem_do_command(modem_t* modem, int repeat)
         modem->cmdbuf[i] = toupper(modem->cmdbuf[i]);
     }
 
-	/* AT command set interpretation */
-	if ((modem->cmdbuf[0] != 'A') || (modem->cmdbuf[1] != 'T')) {
-		modem_send_res(modem, ResERROR);
-		return;
-	}
+    /* AT command set interpretation */
+    if ((modem->cmdbuf[0] != 'A') || (modem->cmdbuf[1] != 'T')) {
+        modem_send_res(modem, ResERROR);
+        return;
+    }
 
     modem_log("Command received: %s (doresponse = %d)\n", modem->cmdbuf, modem->doresponse);
 
@@ -782,142 +807,159 @@ modem_do_command(modem_t* modem, int repeat)
                 }
                 modem_send_res(modem, ResERROR);
                 return;
-            case 'D': { // Dial.
-                char buffer[NUMBER_BUFFER_SIZE];
-                char obuffer[NUMBER_BUFFER_SIZE];
-                char * foundstr = &scanbuf[0];
-                const char *mappedaddr = NULL;
-                size_t i = 0;
+            case 'D':
+                { // Dial.
+                    char        buffer[NUMBER_BUFFER_SIZE];
+                    char        obuffer[NUMBER_BUFFER_SIZE];
+                    char       *foundstr   = &scanbuf[0];
+                    const char *mappedaddr = NULL;
+                    size_t      i          = 0;
 
-                if (*foundstr == 'T' || *foundstr == 'P') // Tone/pulse dialing
-                    foundstr++;
-                else if (*foundstr == 'L') { // Redial last number
-                    if (modem->lastnumber[0] == 0)
-                        modem_send_res(modem, ResERROR);
-                    else {
-                        modem_log("Redialing number %s\n", modem->lastnumber);
-                        modem_dial(modem, modem->lastnumber);
+                    if (*foundstr == 'T' || *foundstr == 'P') // Tone/pulse dialing
+                        foundstr++;
+                    else if (*foundstr == 'L') { // Redial last number
+                        if (modem->lastnumber[0] == 0)
+                            modem_send_res(modem, ResERROR);
+                        else {
+                            modem_log("Redialing number %s\n", modem->lastnumber);
+                            modem_dial(modem, modem->lastnumber);
+                        }
+                        return;
                     }
-                    return;
-                }
 
-                if ((!foundstr[0] && !modem->numberinprogress[0]) || ((strlen(modem->numberinprogress) + strlen(foundstr)) > (NUMBER_BUFFER_SIZE - 1))) {
-                    // Check for empty or too long strings
-                    modem_send_res(modem, ResERROR);
-                    modem->numberinprogress[0] = 0;
-                    return;
-                }
-
-                foundstr = trim(foundstr);
-
-                // Check for ; and return to command mode if found
-                char *semicolon = strchr(foundstr, ';');
-                if (semicolon != NULL) {
-                    modem_log("Semicolon found in number, returning to command mode\n");
-                    strncat(modem->numberinprogress, foundstr, strcspn(foundstr, ";"));
-                    scanbuf = semicolon + 1;
-                    break;
-                } else {
-                    strcat(modem->numberinprogress, foundstr);
-                    foundstr = modem->numberinprogress;
-                }
-
-                modem_log("Dialing number %s\n", foundstr);
-                mappedaddr = modem_get_address_from_phonebook(modem, foundstr);
-                if (mappedaddr) {
-                    modem_dial(modem, mappedaddr);
-                    return;
-                }
-
-                if (strlen(foundstr) >= 12) {
-                    // Check if supplied parameter only consists of digits
-                    bool isNum = true;
-                    size_t fl = strlen(foundstr);
-                    for (i = 0; i < fl; i++)
-                        if (foundstr[i] < '0' || foundstr[i] > '9')
-                            isNum = false;
-                    if (isNum && (fl > (NUMBER_BUFFER_SIZE - 5))) {
-                        // Check if the number is long enough to cause buffer
-                        // overflows during the number => IP transformation
+                    if ((!foundstr[0] && !modem->numberinprogress[0]) || ((strlen(modem->numberinprogress) + strlen(foundstr)) > (NUMBER_BUFFER_SIZE - 1))) {
+                        // Check for empty or too long strings
                         modem_send_res(modem, ResERROR);
                         modem->numberinprogress[0] = 0;
                         return;
-                    } else if (isNum) {
-                        // Parameter is a number with at least 12 digits => this cannot
-                        // be a valid IP/name
-                        // Transform by adding dots
-                        size_t j = 0;
-                        const size_t foundlen = strlen(foundstr);
-                        for (i = 0; i < foundlen; i++) {
-                            buffer[j++] = foundstr[i];
-                            // Add a dot after the third, sixth and ninth number
-                            if (i == 2 || i == 5 || i == 8)
-                                buffer[j++] = '.';
-                            // If the string is longer than 12 digits,
-                            // interpret the rest as port
-                            if (i == 11 && foundlen > 12)
-                                buffer[j++] = ':';
-                        }
-                        buffer[j] = 0;
-                        foundstr = buffer;
-
-                        // Remove Zeros from beginning of octets
-                        size_t k = 0;
-                        size_t foundlen2 = strlen(foundstr);
-                        for (i = 0; i < foundlen2; i++) {
-                            if (i == 0 && foundstr[0] == '0') continue;
-                            if (i == 1 && foundstr[0] == '0' && foundstr[1] == '0') continue;
-                            if (foundstr[i] == '0' && foundstr[i-1] == '.') continue;
-                            if (foundstr[i] == '0' && foundstr[i-1] == '0' && foundstr[i-2] == '.') continue;
-                            obuffer[k++] = foundstr[i];
-                            }
-                        obuffer[k] = 0;
-                        foundstr = obuffer;
                     }
+
+                    foundstr = trim(foundstr);
+
+                    // Check for ; and return to command mode if found
+                    char *semicolon = strchr(foundstr, ';');
+                    if (semicolon != NULL) {
+                        modem_log("Semicolon found in number, returning to command mode\n");
+                        strncat(modem->numberinprogress, foundstr, strcspn(foundstr, ";"));
+                        scanbuf = semicolon + 1;
+                        break;
+                    } else {
+                        strcat(modem->numberinprogress, foundstr);
+                        foundstr = modem->numberinprogress;
+                    }
+
+                    modem_log("Dialing number %s\n", foundstr);
+                    mappedaddr = modem_get_address_from_phonebook(modem, foundstr);
+                    if (mappedaddr) {
+                        modem_dial(modem, mappedaddr);
+                        return;
+                    }
+
+                    if (strlen(foundstr) >= 12) {
+                        // Check if supplied parameter only consists of digits
+                        bool   isNum = true;
+                        size_t fl    = strlen(foundstr);
+                        for (i = 0; i < fl; i++)
+                            if (foundstr[i] < '0' || foundstr[i] > '9')
+                                isNum = false;
+                        if (isNum && (fl > (NUMBER_BUFFER_SIZE - 5))) {
+                            // Check if the number is long enough to cause buffer
+                            // overflows during the number => IP transformation
+                            modem_send_res(modem, ResERROR);
+                            modem->numberinprogress[0] = 0;
+                            return;
+                        } else if (isNum) {
+                            // Parameter is a number with at least 12 digits => this cannot
+                            // be a valid IP/name
+                            // Transform by adding dots
+                            size_t       j        = 0;
+                            const size_t foundlen = strlen(foundstr);
+                            for (i = 0; i < foundlen; i++) {
+                                buffer[j++] = foundstr[i];
+                                // Add a dot after the third, sixth and ninth number
+                                if (i == 2 || i == 5 || i == 8)
+                                    buffer[j++] = '.';
+                                // If the string is longer than 12 digits,
+                                // interpret the rest as port
+                                if (i == 11 && foundlen > 12)
+                                    buffer[j++] = ':';
+                            }
+                            buffer[j] = 0;
+                            foundstr  = buffer;
+
+                            // Remove Zeros from beginning of octets
+                            size_t k         = 0;
+                            size_t foundlen2 = strlen(foundstr);
+                            for (i = 0; i < foundlen2; i++) {
+                                if (i == 0 && foundstr[0] == '0')
+                                    continue;
+                                if (i == 1 && foundstr[0] == '0' && foundstr[1] == '0')
+                                    continue;
+                                if (foundstr[i] == '0' && foundstr[i - 1] == '.')
+                                    continue;
+                                if (foundstr[i] == '0' && foundstr[i - 1] == '0' && foundstr[i - 2] == '.')
+                                    continue;
+                                obuffer[k++] = foundstr[i];
+                            }
+                            obuffer[k] = 0;
+                            foundstr   = obuffer;
+                        }
+                    }
+                    modem_dial(modem, foundstr);
+                    return;
                 }
-                modem_dial(modem, foundstr);
-                return;
-            }
             case 'I': // Some strings about firmware
                 switch (modem_scan_number(&scanbuf)) {
-                case 3: modem_send_line(modem, "86Box Emulated Modem Firmware V1.00"); break;
-                case 4: modem_send_line(modem, "Modem compiled for 86Box version " EMU_VERSION); break;
+                    case 3:
+                        modem_send_line(modem, "86Box Emulated Modem Firmware V1.00");
+                        break;
+                    case 4:
+                        modem_send_line(modem, "Modem compiled for 86Box version " EMU_VERSION);
+                        break;
                 }
                 break;
             case 'E': // Echo on/off
                 switch (modem_scan_number(&scanbuf)) {
-                case 0: modem->echo = false; break;
-                case 1: modem->echo = true; break;
+                    case 0:
+                        modem->echo = false;
+                        break;
+                    case 1:
+                        modem->echo = true;
+                        break;
                 }
                 break;
             case 'V':
                 switch (modem_scan_number(&scanbuf)) {
-                case 0: modem->numericresponse = true; break;
-                case 1: modem->numericresponse = false; break;
+                    case 0:
+                        modem->numericresponse = true;
+                        break;
+                    case 1:
+                        modem->numericresponse = false;
+                        break;
                 }
                 break;
             case 'H': // Hang up
                 switch (modem_scan_number(&scanbuf)) {
-                case 0:
-                    modem->numberinprogress[0] = 0;
-                    if (modem->connected) {
-                        modem_send_res(modem, ResNOCARRIER);
-                        modem_enter_idle_state(modem);
-                        return;
-                    }
-                    // else return ok
+                    case 0:
+                        modem->numberinprogress[0] = 0;
+                        if (modem->connected) {
+                            modem_send_res(modem, ResNOCARRIER);
+                            modem_enter_idle_state(modem);
+                            return;
+                        }
+                        // else return ok
                 }
                 break;
             case 'O': // Return to data mode
                 switch (modem_scan_number(&scanbuf)) {
-                case 0:
-                    if (modem->connected) {
-                        modem->mode = MODEM_MODE_DATA;
-                        return;
-                    } else {
-                        modem_send_res(modem, ResERROR);
-                        return;
-                    }
+                    case 0:
+                        if (modem->connected) {
+                            modem->mode = MODEM_MODE_DATA;
+                            return;
+                        } else {
+                            modem_send_res(modem, ResERROR);
+                            return;
+                        }
                 }
                 break;
             case 'T': // Tone Dial
@@ -939,130 +981,137 @@ modem_do_command(modem_t* modem, int repeat)
                     break;
                 }
                 return;
-            case 'Z': { // Reset and load profiles
-                // scan the number away, if any
-                modem_scan_number(&scanbuf);
-                if (modem->connected)
-                    modem_send_res(modem, ResNOCARRIER);
-                modem_reset(modem);
-                break;
-            }
+            case 'Z':
+                { // Reset and load profiles
+                    // scan the number away, if any
+                    modem_scan_number(&scanbuf);
+                    if (modem->connected)
+                        modem_send_res(modem, ResNOCARRIER);
+                    modem_reset(modem);
+                    break;
+                }
             case ' ': // skip space
                 break;
-            case 'Q': {
-                // Response options
-                // 0 = all on, 1 = all off,
-                // 2 = no ring and no connect/carrier in answermode
-                const uint32_t val = modem_scan_number(&scanbuf);
-                if (!(val > 2)) {
-                    modem->doresponse = val;
-                    break;
-                } else {
-                    modem_send_res(modem, ResERROR);
-                    return;
+            case 'Q':
+                {
+                    // Response options
+                    // 0 = all on, 1 = all off,
+                    // 2 = no ring and no connect/carrier in answermode
+                    const uint32_t val = modem_scan_number(&scanbuf);
+                    if (!(val > 2)) {
+                        modem->doresponse = val;
+                        break;
+                    } else {
+                        modem_send_res(modem, ResERROR);
+                        return;
+                    }
                 }
-            }
 
-		    case 'S': { // Registers
-		    	const uint32_t index = modem_scan_number(&scanbuf);
-		    	if (index >= 100) {
-		    		modem_send_res(modem, ResERROR);
-		    		return; //goto ret_none;
-		    	}
+            case 'S':
+                { // Registers
+                    const uint32_t index = modem_scan_number(&scanbuf);
+                    if (index >= 100) {
+                        modem_send_res(modem, ResERROR);
+                        return; // goto ret_none;
+                    }
 
-		    	while (scanbuf[0] == ' ')
-		    		scanbuf++; // skip spaces
+                    while (scanbuf[0] == ' ')
+                        scanbuf++; // skip spaces
 
-		    	if (scanbuf[0] == '=') { // set register
-		    		scanbuf++;
-		    		while (scanbuf[0] == ' ')
-		    			scanbuf++; // skip spaces
-		    		const uint32_t val = modem_scan_number(&scanbuf);
-		    		modem->reg[index] = val;
-		    		break;
-		    	}
-		    	else if (scanbuf[0] == '?') { // get register
-		    		modem_send_number(modem, modem->reg[index]);
-		    		scanbuf++;
-		    		break;
-		    	}
-		    	// else
-		    		// LOG_MSG("SERIAL: Port %" PRIu8 " print reg %" PRIu32
-		    		//         " with %" PRIu8 ".",
-		    		//         GetPortNumber(), index, reg[index]);
-		    }
-		    break;
-		    case '&': { // & escaped commands
-		    	char cmdchar = modem_fetch_character(&scanbuf);
-		    	switch(cmdchar) {
-		    		case 'C': {
-		    		        const uint32_t val = modem_scan_number(&scanbuf);
-		    		        if (val < 2)
-		    			        modem->dcdmode = val;
-		    		        else {
-		    			        modem_send_res(modem, ResERROR);
-		    			        return;
-		    		        }
-		    		        break;
-		    	    }
-		    		case 'K': {
-		    		        const uint32_t val = modem_scan_number(&scanbuf);
-		    		        if (val < 5)
-		    			        modem->flowcontrol = val;
-		    		        else {
-		    			        modem_send_res(modem, ResERROR);
-		    			        return;
-		    		        }
-		    		        break;
-		    	        }
-		    	        case 'D': {
-		    		        const uint32_t val = modem_scan_number(&scanbuf);
-		    		        if (val < 4)
-		    			        modem->dtrmode = val;
-		    		        else {
-		    			        modem_send_res(modem, ResERROR);
-		    			        return;
-		    		        }
-		    		        break;
-		    	        }
-		    	        case '\0':
-		    		        // end of string
-		    		        modem_send_res(modem, ResERROR);
-		    		        return;
-		    	        }
-		    	        break;
-		    }
-            break;
-		    case '\\': { // \ escaped commands
-		    	char cmdchar = modem_fetch_character(&scanbuf);
-		    	switch (cmdchar) {
-		    		case 'N':
-		    			// error correction stuff - not emulated
-		    			if (modem_scan_number(&scanbuf) > 5) {
-		    				modem_send_res(modem, ResERROR);
-		    				return;
-		    			}
-		    			break;
-		    		case '\0':
-		    			// end of string
-		    			modem_send_res(modem, ResERROR);
-		    			return;
-		    	}
-		    	break;
-		    }
-		    case '\0':
-		    	modem_send_res(modem, ResOK);
-		    	return;
-            }
+                    if (scanbuf[0] == '=') { // set register
+                        scanbuf++;
+                        while (scanbuf[0] == ' ')
+                            scanbuf++; // skip spaces
+                        const uint32_t val = modem_scan_number(&scanbuf);
+                        modem->reg[index]  = val;
+                        break;
+                    } else if (scanbuf[0] == '?') { // get register
+                        modem_send_number(modem, modem->reg[index]);
+                        scanbuf++;
+                        break;
+                    }
+                    // else
+                    // LOG_MSG("SERIAL: Port %" PRIu8 " print reg %" PRIu32
+                    //         " with %" PRIu8 ".",
+                    //         GetPortNumber(), index, reg[index]);
+                }
+                break;
+            case '&':
+                { // & escaped commands
+                    char cmdchar = modem_fetch_character(&scanbuf);
+                    switch (cmdchar) {
+                        case 'C':
+                            {
+                                const uint32_t val = modem_scan_number(&scanbuf);
+                                if (val < 2)
+                                    modem->dcdmode = val;
+                                else {
+                                    modem_send_res(modem, ResERROR);
+                                    return;
+                                }
+                                break;
+                            }
+                        case 'K':
+                            {
+                                const uint32_t val = modem_scan_number(&scanbuf);
+                                if (val < 5)
+                                    modem->flowcontrol = val;
+                                else {
+                                    modem_send_res(modem, ResERROR);
+                                    return;
+                                }
+                                break;
+                            }
+                        case 'D':
+                            {
+                                const uint32_t val = modem_scan_number(&scanbuf);
+                                if (val < 4)
+                                    modem->dtrmode = val;
+                                else {
+                                    modem_send_res(modem, ResERROR);
+                                    return;
+                                }
+                                break;
+                            }
+                        case '\0':
+                            // end of string
+                            modem_send_res(modem, ResERROR);
+                            return;
+                    }
+                    break;
+                }
+                break;
+            case '\\':
+                { // \ escaped commands
+                    char cmdchar = modem_fetch_character(&scanbuf);
+                    switch (cmdchar) {
+                        case 'N':
+                            // error correction stuff - not emulated
+                            if (modem_scan_number(&scanbuf) > 5) {
+                                modem_send_res(modem, ResERROR);
+                                return;
+                            }
+                            break;
+                        case '\0':
+                            // end of string
+                            modem_send_res(modem, ResERROR);
+                            return;
+                    }
+                    break;
+                }
+            case '\0':
+                modem_send_res(modem, ResOK);
+                return;
+        }
     }
 }
 
 void
-modem_dtr_callback_timer(void* priv)
+modem_dtr_callback_timer(void *priv)
 {
     modem_t *dev = (modem_t *) priv;
     if (dev->connected) {
-		switch (dev->dtrmode) {
+        switch (dev->dtrmode) {
             case 1:
                 modem_log("DTR dropped, returning to command mode (dtrmode = %i)\n", dev->dtrmode);
                 dev->mode = MODEM_MODE_COMMAND;
@@ -1082,9 +1131,9 @@ modem_dtr_callback_timer(void* priv)
 }
 
 void
-modem_dtr_callback(serial_t* serial, int status, void *priv)
+modem_dtr_callback(serial_t *serial, int status, void *priv)
 {
-    modem_t *dev = (modem_t *) priv;
+    modem_t *dev  = (modem_t *) priv;
     dev->dtrstate = !!status;
     if (status == 1)
         timer_disable(&dev->dtr_timer);
@@ -1093,15 +1142,15 @@ modem_dtr_callback(serial_t* serial, int status, void *priv)
 }
 
 static void
-fifo8_resize_2x(Fifo8* fifo)
+fifo8_resize_2x(Fifo8 *fifo)
 {
-    uint32_t pos = 0;
+    uint32_t pos  = 0;
     uint32_t size = fifo->capacity * 2;
     uint32_t used = fifo8_num_used(fifo);
     if (!used)
         return;
 
-    uint8_t* temp_buf = calloc(fifo->capacity * 2, 1);
+    uint8_t *temp_buf = calloc(fifo->capacity * 2, 1);
     if (!temp_buf) {
         fatal("net_modem: Out Of Memory!\n");
     }
@@ -1118,111 +1167,117 @@ fifo8_resize_2x(Fifo8* fifo)
 
 #define TEL_CLIENT 0
 #define TEL_SERVER 1
-void modem_process_telnet(modem_t* modem, uint8_t *data, uint32_t size)
+void
+modem_process_telnet(modem_t *modem, uint8_t *data, uint32_t size)
 {
     uint32_t i = 0;
-	for (i = 0; i < size; i++) {
-		uint8_t c = data[i];
-		if (modem->telClient.inIAC) {
-			if (modem->telClient.recCommand) {
-				if ((c != 0) && (c != 1) && (c != 3)) {
-					if (modem->telClient.command > 250) {
-						/* Reject anything we don't recognize */
-						modem_data_mode_process_byte(modem, 0xff);
-						modem_data_mode_process_byte(modem, 252);
-						modem_data_mode_process_byte(modem, c); /* We won't do crap! */
-					}
-			}
-			switch (modem->telClient.command) {
-				case 251: /* Will */
-					if (c == 0) modem->telClient.binary[TEL_SERVER] = true;
-					if (c == 1) modem->telClient.echo[TEL_SERVER] = true;
-					if (c == 3) modem->telClient.supressGA[TEL_SERVER] = true;
-					break;
-				case 252: /* Won't */
-					if (c == 0) modem->telClient.binary[TEL_SERVER] = false;
-					if (c == 1) modem->telClient.echo[TEL_SERVER] = false;
-					if (c == 3) modem->telClient.supressGA[TEL_SERVER] = false;
-					break;
-				case 253: /* Do */
-					if (c == 0) {
-						modem->telClient.binary[TEL_CLIENT] = true;
-							modem_data_mode_process_byte(modem, 0xff);
-							modem_data_mode_process_byte(modem, 251);
-							modem_data_mode_process_byte(modem, 0); /* Will do binary transfer */
-					}
-					if (c == 1) {
-						modem->telClient.echo[TEL_CLIENT] = false;
-							modem_data_mode_process_byte(modem, 0xff);
-							modem_data_mode_process_byte(modem, 252);
-							modem_data_mode_process_byte(modem, 1); /* Won't echo (too lazy) */
-					}
-					if (c == 3) {
-						modem->telClient.supressGA[TEL_CLIENT] = true;
-							modem_data_mode_process_byte(modem, 0xff);
-							modem_data_mode_process_byte(modem, 251);
-							modem_data_mode_process_byte(modem, 3); /* Will Suppress GA */
-					}
-					break;
-				case 254: /* Don't */
-					if (c == 0) {
-						modem->telClient.binary[TEL_CLIENT] = false;
-							modem_data_mode_process_byte(modem, 0xff);
-							modem_data_mode_process_byte(modem, 252);
-							modem_data_mode_process_byte(modem, 0); /* Won't do binary transfer */
-					}
-					if (c == 1) {
-						modem->telClient.echo[TEL_CLIENT] = false;
-							modem_data_mode_process_byte(modem, 0xff);
-							modem_data_mode_process_byte(modem, 252);
-							modem_data_mode_process_byte(modem, 1); /* Won't echo (fine by me) */
-					}
-					if (c == 3) {
-						modem->telClient.supressGA[TEL_CLIENT] = true;
-							modem_data_mode_process_byte(modem, 0xff);
-							modem_data_mode_process_byte(modem, 251);
-							modem_data_mode_process_byte(modem, 3); /* Will Suppress GA (too lazy) */
-					}
-					break;
-				default:
-					break;
-			}
-			modem->telClient.inIAC = false;
-			modem->telClient.recCommand = false;
-			continue;
-		} else {
-			if (c == 249) {
-				/* Go Ahead received */
-				modem->telClient.inIAC = false;
-				continue;
-			}
-			modem->telClient.command = c;
-			modem->telClient.recCommand = true;
+    for (i = 0; i < size; i++) {
+        uint8_t c = data[i];
+        if (modem->telClient.inIAC) {
+            if (modem->telClient.recCommand) {
+                if ((c != 0) && (c != 1) && (c != 3)) {
+                    if (modem->telClient.command > 250) {
+                        /* Reject anything we don't recognize */
+                        modem_data_mode_process_byte(modem, 0xff);
+                        modem_data_mode_process_byte(modem, 252);
+                        modem_data_mode_process_byte(modem, c); /* We won't do crap! */
+                    }
+                }
+                switch (modem->telClient.command) {
+                    case 251: /* Will */
+                        if (c == 0)
+                            modem->telClient.binary[TEL_SERVER] = true;
+                        if (c == 1)
+                            modem->telClient.echo[TEL_SERVER] = true;
+                        if (c == 3)
+                            modem->telClient.supressGA[TEL_SERVER] = true;
+                        break;
+                    case 252: /* Won't */
+                        if (c == 0)
+                            modem->telClient.binary[TEL_SERVER] = false;
+                        if (c == 1)
+                            modem->telClient.echo[TEL_SERVER] = false;
+                        if (c == 3)
+                            modem->telClient.supressGA[TEL_SERVER] = false;
+                        break;
+                    case 253: /* Do */
+                        if (c == 0) {
+                            modem->telClient.binary[TEL_CLIENT] = true;
+                            modem_data_mode_process_byte(modem, 0xff);
+                            modem_data_mode_process_byte(modem, 251);
+                            modem_data_mode_process_byte(modem, 0); /* Will do binary transfer */
+                        }
+                        if (c == 1) {
+                            modem->telClient.echo[TEL_CLIENT] = false;
+                            modem_data_mode_process_byte(modem, 0xff);
+                            modem_data_mode_process_byte(modem, 252);
+                            modem_data_mode_process_byte(modem, 1); /* Won't echo (too lazy) */
+                        }
+                        if (c == 3) {
+                            modem->telClient.supressGA[TEL_CLIENT] = true;
+                            modem_data_mode_process_byte(modem, 0xff);
+                            modem_data_mode_process_byte(modem, 251);
+                            modem_data_mode_process_byte(modem, 3); /* Will Suppress GA */
+                        }
+                        break;
+                    case 254: /* Don't */
+                        if (c == 0) {
+                            modem->telClient.binary[TEL_CLIENT] = false;
+                            modem_data_mode_process_byte(modem, 0xff);
+                            modem_data_mode_process_byte(modem, 252);
+                            modem_data_mode_process_byte(modem, 0); /* Won't do binary transfer */
+                        }
+                        if (c == 1) {
+                            modem->telClient.echo[TEL_CLIENT] = false;
+                            modem_data_mode_process_byte(modem, 0xff);
+                            modem_data_mode_process_byte(modem, 252);
+                            modem_data_mode_process_byte(modem, 1); /* Won't echo (fine by me) */
+                        }
+                        if (c == 3) {
+                            modem->telClient.supressGA[TEL_CLIENT] = true;
+                            modem_data_mode_process_byte(modem, 0xff);
+                            modem_data_mode_process_byte(modem, 251);
+                            modem_data_mode_process_byte(modem, 3); /* Will Suppress GA (too lazy) */
+                        }
+                        break;
+                    default:
+                        break;
+                }
+                modem->telClient.inIAC      = false;
+                modem->telClient.recCommand = false;
+                continue;
+            } else {
+                if (c == 249) {
+                    /* Go Ahead received */
+                    modem->telClient.inIAC = false;
+                    continue;
+                }
+                modem->telClient.command    = c;
+                modem->telClient.recCommand = true;
 
-			if ((modem->telClient.binary[TEL_SERVER]) && (c == 0xff)) {
-				/* Binary data with value of 255 */
-				modem->telClient.inIAC = false;
-				modem->telClient.recCommand = false;
-                fifo8_push(&modem->rx_data, 0xff);
-				continue;
-			}
-		}
-		} else {
-			if (c == 0xff) {
-				modem->telClient.inIAC = true;
-				continue;
-			}
-			fifo8_push(&modem->rx_data, c);
-		}
-	}
+                if ((modem->telClient.binary[TEL_SERVER]) && (c == 0xff)) {
+                    /* Binary data with value of 255 */
+                    modem->telClient.inIAC      = false;
+                    modem->telClient.recCommand = false;
+                    fifo8_push(&modem->rx_data, 0xff);
+                    continue;
+                }
+            }
+        } else {
+            if (c == 0xff) {
+                modem->telClient.inIAC = true;
+                continue;
+            }
+            fifo8_push(&modem->rx_data, c);
+        }
+    }
 }
 
 static int
 modem_rx(void *priv, uint8_t *buf, int io_len)
 {
-#if 1
-    modem_t* modem = (modem_t*)priv;
-    uint32_t i = 0;
+    modem_t *modem = (modem_t *) priv;
+    uint32_t i     = 0;
 
     if (modem->tcpIpMode)
         return 0;
@@ -1265,7 +1320,6 @@ modem_rx(void *priv, uint8_t *buf, int io_len)
     }
     fifo8_push(&modem->rx_data, END);
     return 1;
-#endif
 }
 
 static void
@@ -1275,17 +1329,17 @@ modem_rcr_cb(UNUSED(struct serial_s *serial), void *priv)
 
     timer_stop(&dev->host_to_serial_timer);
     /* FIXME: do something to dev->baudrate */
-    timer_on_auto(&dev->host_to_serial_timer, (1000000.0 / (double)dev->baudrate) * (double) 9);
+    timer_on_auto(&dev->host_to_serial_timer, (1000000.0 / (double) dev->baudrate) * (double) 9);
 #if 0
     serial_clear_fifo(dev->serial);
 #endif
 }
 
 static void
-modem_accept_incoming_call(modem_t* modem)
+modem_accept_incoming_call(modem_t *modem)
 {
     if (modem->waitingclientsocket != -1) {
-        modem->clientsocket = modem->waitingclientsocket;
+        modem->clientsocket        = modem->waitingclientsocket;
         modem->waitingclientsocket = -1;
         modem_enter_connected_state(modem);
         modem->in_warmup = 250;
@@ -1297,8 +1351,8 @@ modem_accept_incoming_call(modem_t* modem)
 static void
 modem_cmdpause_timer_callback(void *priv)
 {
-    modem_t *modem = (modem_t *) priv;
-	uint32_t guard_threashold = 0;
+    modem_t *modem            = (modem_t *) priv;
+    uint32_t guard_threshold = 0;
     timer_on_auto(&modem->cmdpause_timer, 1000);
 
     if (modem->tcpIpConnInProgress) {
@@ -1326,7 +1380,7 @@ modem_cmdpause_timer_callback(void *priv)
                 modem_enter_idle_state(modem);
                 modem_send_res(modem, ResNOANSWER);
                 modem->tcpIpConnInProgress = 0;
-                modem->tcpIpMode = 0;
+                modem->tcpIpMode           = 0;
                 break;
             }
         } while (0);
@@ -1341,26 +1395,25 @@ modem_cmdpause_timer_callback(void *priv)
                 modem->ringing = true;
                 modem_send_res(modem, ResRING);
                 serial_set_ri(modem->serial, !serial_get_ri(modem->serial));
-                modem->ringtimer = 3000;
+                modem->ringtimer            = 3000;
                 modem->reg[MREG_RING_COUNT] = 0;
             }
         }
     }
-	if (modem->ringing) {
-		if (modem->ringtimer <= 0) {
-			modem->reg[MREG_RING_COUNT]++;
-			if ((modem->reg[MREG_AUTOANSWER_COUNT] > 0) &&
-				(modem->reg[MREG_RING_COUNT] >= modem->reg[MREG_AUTOANSWER_COUNT])) {
-				modem_accept_incoming_call(modem);
-				return;
-			}
-			modem_send_res(modem, ResRING);
+    if (modem->ringing) {
+        if (modem->ringtimer <= 0) {
+            modem->reg[MREG_RING_COUNT]++;
+            if ((modem->reg[MREG_AUTOANSWER_COUNT] > 0) && (modem->reg[MREG_RING_COUNT] >= modem->reg[MREG_AUTOANSWER_COUNT])) {
+                modem_accept_incoming_call(modem);
+                return;
+            }
+            modem_send_res(modem, ResRING);
             serial_set_ri(modem->serial, !serial_get_ri(modem->serial));
 
-			modem->ringtimer = 3000;
-		}
-		--modem->ringtimer;
-	}
+            modem->ringtimer = 3000;
+        }
+        --modem->ringtimer;
+    }
 
     if (modem->in_warmup) {
         modem->in_warmup--;
@@ -1368,12 +1421,11 @@ modem_cmdpause_timer_callback(void *priv)
             modem->tx_count = 0;
             fifo8_reset(&modem->rx_data);
         }
-    }
-    else if (modem->connected && modem->tcpIpMode) {
+    } else if (modem->connected && modem->tcpIpMode) {
         if (modem->tx_count) {
             int wouldblock = 0;
-            int res = plat_netsocket_send(modem->clientsocket, modem->tx_pkt_ser_line, modem->tx_count, &wouldblock);
-            
+            int res        = plat_netsocket_send(modem->clientsocket, modem->tx_pkt_ser_line, modem->tx_count, &wouldblock);
+
             if (res <= 0 && !wouldblock) {
                 /* No bytes sent or error. */
                 modem->tx_count = 0;
@@ -1390,8 +1442,8 @@ modem_cmdpause_timer_callback(void *priv)
         }
         if (modem->connected) {
             uint8_t buffer[16];
-            int wouldblock = 0;
-            int res = plat_netsocket_receive(modem->clientsocket, buffer, sizeof(buffer), &wouldblock);
+            int     wouldblock = 0;
+            int     res        = plat_netsocket_receive(modem->clientsocket, buffer, sizeof(buffer), &wouldblock);
 
             if (res > 0) {
                 if (modem->telnet_mode)
@@ -1410,31 +1462,30 @@ modem_cmdpause_timer_callback(void *priv)
         }
     }
 
-	modem->cmdpause++;
-    guard_threashold = (uint32_t)(modem->reg[MREG_GUARD_TIME] * 20);
-	if (modem->cmdpause > guard_threashold) {
-		if (modem->plusinc == 0) {
-			modem->plusinc = 1;
-		} else if (modem->plusinc == 4) {
-			modem_log("Escape sequence triggered, returning to command mode\n");
-			modem->mode = MODEM_MODE_COMMAND;
-			modem_send_res(modem, ResOK);
-			modem->plusinc = 0;
-		}
-	}
+    modem->cmdpause++;
+    guard_threshold = (uint32_t) (modem->reg[MREG_GUARD_TIME] * 20);
+    if (modem->cmdpause > guard_threshold) {
+        if (modem->plusinc == 0) {
+            modem->plusinc = 1;
+        } else if (modem->plusinc == 4) {
+            modem_log("Escape sequence triggered, returning to command mode\n");
+            modem->mode = MODEM_MODE_COMMAND;
+            modem_send_res(modem, ResOK);
+            modem->plusinc = 0;
+        }
+    }
 }
 
 /* Initialize the device for use by the user. */
 static void *
 modem_init(const device_t *info)
 {
-    modem_t* modem = (modem_t*)calloc(1, sizeof(modem_t));
-    const char* phonebook_file = NULL;
+    modem_t    *modem          = (modem_t *) calloc(1, sizeof(modem_t));
+    const char *phonebook_file = NULL;
     memset(modem->mac, 0xfc, 6);
 
-    
-    modem->port = device_get_config_int("port");
-    modem->baudrate = device_get_config_int("baudrate");
+    modem->port        = device_get_config_int("port");
+    modem->baudrate    = device_get_config_int("baudrate");
     modem->listen_port = device_get_config_int("listen_port");
     modem->telnet_mode = device_get_config_int("telnet_mode");
 
@@ -1456,13 +1507,14 @@ modem_init(const device_t *info)
     if (phonebook_file && phonebook_file[0] != 0) {
         modem_read_phonebook_file(modem, phonebook_file);
     }
-    
+
     return modem;
 }
 
-void modem_close(void *priv)
+void
+modem_close(void *priv)
 {
-    modem_t* modem = (modem_t*)priv;
+    modem_t *modem     = (modem_t *) priv;
     modem->listen_port = 0;
     modem_reset(modem);
     fifo8_destroy(&modem->data_pending);

--- a/src/qt/win_serial_passthrough.c
+++ b/src/qt/win_serial_passthrough.c
@@ -173,7 +173,7 @@ open_pseudo_terminal(serial_passthrough_t *dev)
     char ascii_pipe_name[1024] = { 0 };
     strncpy(ascii_pipe_name, dev->named_pipe, sizeof(ascii_pipe_name));
     ascii_pipe_name[1023] = '\0';
-    dev->master_fd = (intptr_t) CreateNamedPipeA(ascii_pipe_name, PIPE_ACCESS_DUPLEX, PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_NOWAIT, 1, 65536, 65536, NMPWAIT_USE_DEFAULT_WAIT, NULL);
+    dev->master_fd        = (intptr_t) CreateNamedPipeA(ascii_pipe_name, PIPE_ACCESS_DUPLEX, PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_NOWAIT, 1, 65536, 65536, NMPWAIT_USE_DEFAULT_WAIT, NULL);
     if (dev->master_fd == (intptr_t) INVALID_HANDLE_VALUE) {
         wchar_t errorMsg[1024] = { 0 };
         wchar_t finalMsg[1024] = { 0 };

--- a/src/unix/unix_netsocket.c
+++ b/src/unix/unix_netsocket.c
@@ -19,91 +19,92 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <netdb.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <string.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/select.h>
 #include <unistd.h>
 
-SOCKET plat_netsocket_create(int type)
+SOCKET
+plat_netsocket_create(int type)
 {
-    SOCKET fd = -1;
-    int yes = 1;
+    SOCKET fd  = -1;
+    int    yes = 1;
 
     if (type != NET_SOCKET_TCP)
         return -1;
-    
+
     fd = socket(AF_INET, SOCK_STREAM, 0);
     if (fd == -1)
         return -1;
 
     fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK);
-    setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (char*)&yes, sizeof(yes));
-    
+    setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (char *) &yes, sizeof(yes));
+
     return fd;
 }
 
-SOCKET plat_netsocket_create_server(int type, unsigned short port)
+SOCKET
+plat_netsocket_create_server(int type, unsigned short port)
 {
     struct sockaddr_in sock_addr;
-    SOCKET fd = -1;
-    int yes = 1;
+    SOCKET             fd  = -1;
+    int                yes = 1;
 
     if (type != NET_SOCKET_TCP)
         return -1;
-    
+
     fd = socket(AF_INET, SOCK_STREAM, 0);
     if (fd == -1)
         return -1;
-    
-    memset(&sock_addr, 0, sizeof(struct sockaddr_in));
-    
-    sock_addr.sin_family = AF_INET;
-    sock_addr.sin_addr.s_addr = INADDR_ANY;
-    sock_addr.sin_port = htons(port);
 
-    if (bind(fd, (struct sockaddr *)&sock_addr, sizeof(struct sockaddr_in)) == -1) {
+    memset(&sock_addr, 0, sizeof(struct sockaddr_in));
+
+    sock_addr.sin_family      = AF_INET;
+    sock_addr.sin_addr.s_addr = INADDR_ANY;
+    sock_addr.sin_port        = htons(port);
+
+    if (bind(fd, (struct sockaddr *) &sock_addr, sizeof(struct sockaddr_in)) == -1) {
         plat_netsocket_close(fd);
-        return (SOCKET)-1;
+        return (SOCKET) -1;
     }
 
     if (listen(fd, 5) == -1) {
         plat_netsocket_close(fd);
-        return (SOCKET)-1;
+        return (SOCKET) -1;
     }
 
     fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK);
-    setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (char*)&yes, sizeof(yes));
+    setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (char *) &yes, sizeof(yes));
 
     return fd;
 }
 
-void plat_netsocket_close(SOCKET socket)
+void
+plat_netsocket_close(SOCKET socket)
 {
-    close((SOCKET)socket);
+    close((SOCKET) socket);
 }
 
-SOCKET plat_netsocket_accept(SOCKET socket)
+SOCKET
+plat_netsocket_accept(SOCKET socket)
 {
     SOCKET clientsocket = accept(socket, NULL, NULL);
 
     if (clientsocket == -1)
         return -1;
-    
+
     return clientsocket;
 }
 
-int plat_netsocket_connected(SOCKET socket)
+int
+plat_netsocket_connected(SOCKET socket)
 {
     struct sockaddr addr;
     socklen_t       len = sizeof(struct sockaddr);
     fd_set          wrfds;
     struct timeval  tv;
-    int             res = -1;
+    int             res    = -1;
     int             status = 0;
     socklen_t       optlen = 4;
 
@@ -117,15 +118,15 @@ int plat_netsocket_connected(SOCKET socket)
 
     if (res == -1)
         return -1;
-    
+
     if (res == 0 || !(res >= 1 && FD_ISSET(socket, &wrfds)))
         return 0;
-    
-    res = getsockopt(socket, SOL_SOCKET, SO_ERROR, (char*)&status, &optlen);
+
+    res = getsockopt(socket, SOL_SOCKET, SO_ERROR, (char *) &status, &optlen);
 
     if (res == -1)
         return -1;
-    
+
     if (status != 0)
         return -1;
 
@@ -135,16 +136,17 @@ int plat_netsocket_connected(SOCKET socket)
     return 1;
 }
 
-int plat_netsocket_connect(SOCKET socket, const char* hostname, unsigned short port)
+int
+plat_netsocket_connect(SOCKET socket, const char *hostname, unsigned short port)
 {
     struct sockaddr_in sock_addr;
-    int res = -1;
+    int                res = -1;
 
-    sock_addr.sin_family = AF_INET;
+    sock_addr.sin_family      = AF_INET;
     sock_addr.sin_addr.s_addr = inet_addr(hostname);
-    sock_addr.sin_port = htons(port);
+    sock_addr.sin_port        = htons(port);
 
-    if (sock_addr.sin_addr.s_addr == ((in_addr_t)-1) || sock_addr.sin_addr.s_addr == 0) {
+    if (sock_addr.sin_addr.s_addr == ((in_addr_t) -1) || sock_addr.sin_addr.s_addr == 0) {
         struct hostent *hp;
 
         hp = gethostbyname(hostname);
@@ -155,22 +157,23 @@ int plat_netsocket_connect(SOCKET socket, const char* hostname, unsigned short p
             return -1;
     }
 
-    res = connect(socket, (struct sockaddr *)&sock_addr, sizeof(struct sockaddr_in));
+    res = connect(socket, (struct sockaddr *) &sock_addr, sizeof(struct sockaddr_in));
 
     if (res == -1) {
         int error = errno;
 
         if (error == EISCONN || error == EWOULDBLOCK || error == EAGAIN || error == EINPROGRESS)
             return 0;
-        
+
         res = -1;
     }
     return res;
 }
 
-int plat_netsocket_send(SOCKET socket, const unsigned char* data, unsigned int size, int *wouldblock)
+int
+plat_netsocket_send(SOCKET socket, const unsigned char *data, unsigned int size, int *wouldblock)
 {
-    int res = send(socket, (const char*)data, size, 0);
+    int res = send(socket, (const char *) data, size, 0);
 
     if (res == -1) {
         int error = errno;
@@ -183,9 +186,10 @@ int plat_netsocket_send(SOCKET socket, const unsigned char* data, unsigned int s
     return res;
 }
 
-int plat_netsocket_receive(SOCKET socket, unsigned char* data, unsigned int size, int *wouldblock)
+int
+plat_netsocket_receive(SOCKET socket, unsigned char *data, unsigned int size, int *wouldblock)
 {
-    int res = recv(socket, (char*)data, size, 0);
+    int res = recv(socket, (char *) data, size, 0);
 
     if (res == -1) {
         int error = errno;

--- a/src/unix/unix_serial_passthrough.c
+++ b/src/unix/unix_serial_passthrough.c
@@ -22,7 +22,7 @@
 #    define _BSD_SOURCE     1
 #endif
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
-#    define __BSD_VISIBLE   1
+#    define __BSD_VISIBLE 1
 #endif
 #include <stdio.h>
 #include <fcntl.h>


### PR DESCRIPTION
Summary
=======
* Disable most modem logging
* Run `clang-format` on modem, netsocket and serial passthrough code
* Clean up .editorconfig: remove specific entries made redundant after the new indent style was introduced, add definition for Qt .ui files 

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A