### PR TITLE
Voodoo: vertical display programming fix.

### DIFF
--- a/src/video/vid_voodoo.c
+++ b/src/video/vid_voodoo.c
@@ -505,6 +505,9 @@ voodoo_writel(uint32_t addr, uint32_t val, void *priv)
                 voodoo->videoDimensions = val;
                 voodoo->h_disp          = (val & 0xfff) + 1;
                 voodoo->v_disp          = (val >> 16) & 0xfff;
+                if ((voodoo->v_disp == 386) || (voodoo->v_disp == 402) ||
+                    (voodoo->v_disp == 482) || (voodoo->v_disp == 602))
+                    voodoo->v_disp     -= 2;
                 break;
             case SST_fbiInit0:
                 if (voodoo->initEnable & 0x01) {


### PR DESCRIPTION
Summary
=======
Apparently some software reprograms the vertical display wrong sometimes (in this case, vdisp + 2). This should fix software titles that use such techniques...


Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
