### PR TITLE
UI updates: softfloat and voodoo

### DIFF
--- a/src/qt/qt_settingsdisplay.cpp
+++ b/src/qt/qt_settingsdisplay.cpp
@@ -139,6 +139,7 @@ SettingsDisplay::on_comboBoxVideo_currentIndexChanged(int index)
     if (index < 0) {
         return;
     }
+    static QRegularExpression voodooRegex("3dfx|voodoo|banshee", QRegularExpression::CaseInsensitiveOption);
     auto curVideoCard_2 = videoCard[1];
     videoCard[0] = ui->comboBoxVideo->currentData().toInt();
     if (videoCard[0] == VID_INTERNAL)
@@ -206,6 +207,25 @@ SettingsDisplay::on_comboBoxVideo_currentIndexChanged(int index)
     if ((videoCard[1] == 0) || (machine_has_flags(machineId, MACHINE_VIDEO_ONLY) > 0)) {
         ui->comboBoxVideoSecondary->setCurrentIndex(0);
         ui->pushButtonConfigureSecondary->setEnabled(false);
+    }
+
+    // Is the currently selected video card a voodoo?
+    if (ui->comboBoxVideo->currentText().contains(voodooRegex)) {
+        // Get the name of the video card currently in use
+        const device_t *video_dev        = video_card_getdevice(gfxcard[0]);
+        const QString   currentVideoName = DeviceConfig::DeviceName(video_dev, video_get_internal_name(gfxcard[0]), 1);
+        // Is it a voodoo?
+        const bool currentCardIsVoodoo = currentVideoName.contains(voodooRegex);
+        // Don't uncheck if
+        // * Current card is voodoo
+        // * Add-on voodoo was manually overridden in config
+        if (ui->checkBoxVoodoo->isChecked() && !currentCardIsVoodoo) {
+            // Otherwise, uncheck the add-on voodoo when a main voodoo is selected
+            ui->checkBoxVoodoo->setCheckState(Qt::Unchecked);
+        }
+        ui->checkBoxVoodoo->setDisabled(true);
+    } else {
+        ui->checkBoxVoodoo->setDisabled(false);
     }
 }
 

--- a/src/qt/qt_settingsdisplay.ui
+++ b/src/qt/qt_settingsdisplay.ui
@@ -61,14 +61,14 @@
    </item>
    <item row="1" column="0" colspan="2">
     <widget class="QComboBox" name="comboBoxVideo">
-     <property name="maxVisibleItems">
-      <number>30</number>
-     </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
+     </property>
+     <property name="maxVisibleItems">
+      <number>30</number>
      </property>
     </widget>
    </item>
@@ -102,7 +102,7 @@
    <item row="4" column="0" colspan="2">
     <widget class="QCheckBox" name="checkBoxVoodoo">
      <property name="text">
-      <string>Voodoo Graphics</string>
+      <string>Voodoo 1 or 2 Graphics</string>
      </property>
     </widget>
    </item>
@@ -122,14 +122,14 @@
    </item>
    <item row="3" column="0" colspan="2">
     <widget class="QComboBox" name="comboBoxVideoSecondary">
-     <property name="maxVisibleItems">
-      <number>30</number>
-     </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
+     </property>
+     <property name="maxVisibleItems">
+      <number>30</number>
      </property>
     </widget>
    </item>

--- a/src/qt/qt_settingsmachine.cpp
+++ b/src/qt/qt_settingsmachine.cpp
@@ -61,6 +61,11 @@ SettingsMachine::SettingsMachine(QWidget *parent)
             break;
     }
 
+    auto warning_icon = ui->softFloatWarningIcon->style()->standardIcon(QStyle::SP_MessageBoxWarning);
+    ui->softFloatWarningIcon->setPixmap(warning_icon.pixmap(warning_icon.actualSize(QSize(16, 16))));
+    ui->softFloatWarningIcon->setVisible(false);
+    ui->softFloatWarningText->setVisible(false);
+
     auto *waitStatesModel = ui->comboBoxWaitStates->model();
     waitStatesModel->insertRows(0, 9);
     auto idx = waitStatesModel->index(0, 0);
@@ -336,4 +341,14 @@ SettingsMachine::on_pushButtonConfigure_clicked()
     int         machineId = ui->comboBoxMachine->currentData().toInt();
     const auto *device    = machine_get_device(machineId);
     DeviceConfig::ConfigureDevice(device, 0, qobject_cast<Settings *>(Settings::settings));
+}
+
+void SettingsMachine::on_checkBoxFPUSoftfloat_stateChanged(int state) {
+    if(state == Qt::Checked) {
+        ui->softFloatWarningIcon->setVisible(true);
+        ui->softFloatWarningText->setVisible(true);
+    } else {
+        ui->softFloatWarningIcon->setVisible(false);
+        ui->softFloatWarningText->setVisible(false);
+    }
 }

--- a/src/qt/qt_settingsmachine.hpp
+++ b/src/qt/qt_settingsmachine.hpp
@@ -35,6 +35,7 @@ private slots:
 
 private slots:
     void on_comboBoxMachineType_currentIndexChanged(int index);
+    void on_checkBoxFPUSoftfloat_stateChanged(int state);
 
 private:
     Ui::SettingsMachine *ui;

--- a/src/qt/qt_settingsmachine.ui
+++ b/src/qt/qt_settingsmachine.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>458</width>
-    <height>434</height>
+    <height>459</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -41,17 +41,17 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Wait states:</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="comboBoxMachineType">
         <property name="maxVisibleItems">
          <number>30</number>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>FPU:</string>
         </property>
        </widget>
       </item>
@@ -69,55 +69,21 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
-       <widget class="QWidget" name="widget_4" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QComboBox" name="comboBoxWaitStates">
-           <property name="maxVisibleItems">
-            <number>30</number>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_8">
-           <property name="text">
-            <string>PIT mode:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="comboBoxPitMode">
-           <property name="maxVisibleItems">
-            <number>30</number>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-        </layout>
+      <item row="5" column="1">
+       <widget class="QSpinBox" name="spinBoxRAM">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Machine type:</string>
+        </property>
        </widget>
       </item>
       <item row="2" column="0">
@@ -144,14 +110,14 @@
          </property>
          <item>
           <widget class="QComboBox" name="comboBoxCPU">
-           <property name="maxVisibleItems">
-            <number>30</number>
-           </property>
            <property name="sizePolicy">
             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
+           </property>
+           <property name="maxVisibleItems">
+            <number>30</number>
            </property>
           </widget>
          </item>
@@ -167,27 +133,31 @@
          </item>
          <item>
           <widget class="QComboBox" name="comboBoxSpeed">
-           <property name="maxVisibleItems">
-            <number>30</number>
-           </property>
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
+           <property name="maxVisibleItems">
+            <number>30</number>
+           </property>
           </widget>
          </item>
         </layout>
        </widget>
       </item>
-      <item row="5" column="1">
-       <widget class="QSpinBox" name="spinBoxRAM">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Wait states:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Machine:</string>
         </property>
        </widget>
       </item>
@@ -229,55 +199,120 @@
         </layout>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Machine type:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Machine:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>FPU:</string>
-        </property>
+      <item row="4" column="1">
+       <widget class="QWidget" name="widget_4" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QComboBox" name="comboBoxWaitStates">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="maxVisibleItems">
+            <number>30</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_8">
+           <property name="text">
+            <string>PIT mode:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="comboBoxPitMode">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="maxVisibleItems">
+            <number>30</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkBoxDynamicRecompiler">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-       <horstretch>2</horstretch>
-       <verstretch>2</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Dynamic Recompiler</string>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="dynamicRecompilerLayout">
+     <item>
+      <widget class="QCheckBox" name="checkBoxDynamicRecompiler">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>2</horstretch>
+         <verstretch>2</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Dynamic Recompiler</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkBoxFPUSoftfloat">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-       <horstretch>3</horstretch>
-       <verstretch>3</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Softfloat FPU</string>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="softFloatLayout">
+     <item>
+      <widget class="QCheckBox" name="checkBoxFPUSoftfloat">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>3</horstretch>
+         <verstretch>3</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Softfloat FPU</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="softFloatWarningIcon">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="softFloatWarningText">
+       <property name="text">
+        <string>High performance impact</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="softFloatHorizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QGroupBox" name="groupBox">


### PR DESCRIPTION
Summary
=======
This adds a few UI updates.

First, a warning was added about the performance impact of softfloat if enabled. Screenshot:

![fpuwarn](https://github.com/86Box/86Box/assets/47337035/8666251b-bfe1-4e17-bd2b-5c9cb6cf8a91)

Second, some voodoo updates.

If a voodoo is selected as the *primary* display card, the UI disables the option to add a voodoo 1 or 2. Note that this can be overridden in the config file and will be respected.

To make things a little more clear, `Voodoo Graphics` was replaced with `Voodoo 1 or 2 Graphics`.

Screenshot:

![voodoo_disable_1](https://github.com/86Box/86Box/assets/47337035/036cedf5-74ae-4762-864f-27cc895be3cc)

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
