### PR TITLE
MAC address configuration, machine move detection

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -206,6 +206,7 @@ int      video_fullscreen_scale_maximized       = 0;              /* (C) Whether
                                                                          also apply when maximized. */
 int      do_auto_pause                          = 0;              /* (C) Auto-pause the emulator on focus
                                                                          loss */
+char     uuid[MAX_UUID_LEN]                     = { '\0' };       /* (C) UUID or machine identifier */
 
 /* Statistics. */
 extern int mmuflush;

--- a/src/config.c
+++ b/src/config.c
@@ -209,6 +209,12 @@ load_general(void)
     ini_section_delete_var(cat, "window_coordinates");
 
     do_auto_pause = ini_section_get_int(cat, "do_auto_pause", 0);
+
+    p = ini_section_get_string(cat, "uuid", NULL);
+    if (p != NULL)
+        strncpy(uuid, p, sizeof(uuid) - 1);
+    else
+        strncpy(uuid, "", sizeof(uuid) - 1);
 }
 
 /* Load monitor section. */
@@ -1877,6 +1883,11 @@ save_general(void)
         ini_section_set_int(cat, "do_auto_pause", do_auto_pause);
     else
         ini_section_delete_var(cat, "do_auto_pause");
+
+    if (strnlen(uuid, sizeof(uuid) - 1) > 0)
+        ini_section_set_string(cat, "uuid", uuid);
+    else
+        ini_section_delete_var(cat, "uuid");
 
     ini_delete_section_if_empty(config, cat);
 }

--- a/src/device.c
+++ b/src/device.c
@@ -467,8 +467,7 @@ device_has_config(const device_t *dev)
     config = dev->config;
 
     while (config->type != -1) {
-        if (config->type != CONFIG_MAC)
-            c++;
+        c++;
         config++;
     }
 

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -35,6 +35,9 @@
 #define MAX_PREV_IMAGES    4
 #define MAX_IMAGE_PATH_LEN 2048
 
+/* Max UUID Length */
+#define MAX_UUID_LEN 64
+
 /* Default language 0xFFFF = from system, 0x409 = en-US */
 #define DEFAULT_LANGUAGE 0x0409
 
@@ -167,10 +170,11 @@ extern uint16_t key_prefix_2_2;
 extern uint16_t key_uncapture_1;
 extern uint16_t key_uncapture_2;
 
-extern char exe_path[2048];    /* path (dir) of executable */
-extern char usr_path[1024];    /* path (dir) of user data */
-extern char cfg_path[1024];    /* full path of config file */
-extern int  open_dir_usr_path; /* default file open dialog directory of usr_path */
+extern char exe_path[2048];     /* path (dir) of executable */
+extern char usr_path[1024];     /* path (dir) of user data */
+extern char cfg_path[1024];     /* full path of config file */
+extern int  open_dir_usr_path;  /* default file open dialog directory of usr_path */
+extern char uuid[MAX_UUID_LEN]; /* UUID or machine identifier */
 #ifndef USE_NEW_DYNAREC
 extern FILE *stdlog; /* file to log output to */
 #endif

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -30,6 +30,7 @@
 #include <QFont>
 #include <QDialog>
 #include <QMessageBox>
+#include <QPushButton>
 
 #ifdef QT_STATIC
 /* Static builds need plugin imports */
@@ -71,6 +72,7 @@ extern "C" {
 #include "cocoa_mouse.hpp"
 #include "qt_styleoverride.hpp"
 #include "qt_unixmanagerfilter.hpp"
+#include "qt_util.hpp"
 
 // Void Cast
 #define VC(x) const_cast<wchar_t *>(x)
@@ -218,6 +220,25 @@ main(int argc, char *argv[])
         fatalbox.setTextFormat(Qt::TextFormat::RichText);
         fatalbox.exec();
         return 6;
+    }
+
+    // UUID / copy / move detection
+    if(!util::compareUuid()) {
+        QMessageBox movewarnbox;
+        movewarnbox.setIcon(QMessageBox::Icon::Warning);
+        movewarnbox.setText("This machine might have been moved or copied.");
+        movewarnbox.setInformativeText("In order to ensure proper networking functionality, 86Box needs to know if this machine was moved or copied.\n\nSelect \"I Copied It\" if you are not sure.");
+        const QPushButton *movedButton  = movewarnbox.addButton(QObject::tr("I Moved It"), QMessageBox::AcceptRole);
+        const QPushButton *copiedButton = movewarnbox.addButton(QObject::tr("I Copied It"), QMessageBox::DestructiveRole);
+        QPushButton       *cancelButton = movewarnbox.addButton(QObject::tr("Cancel"), QMessageBox::RejectRole);
+        movewarnbox.setDefaultButton(cancelButton);
+        movewarnbox.exec();
+        if (movewarnbox.clickedButton() == copiedButton) {
+            util::storeCurrentUuid();
+            util::generateNewMacAdresses();
+        } else if (movewarnbox.clickedButton() == movedButton) {
+            util::storeCurrentUuid();
+        }
     }
 
 #ifdef Q_OS_WINDOWS

--- a/src/qt/qt_util.cpp
+++ b/src/qt/qt_util.cpp
@@ -21,7 +21,19 @@
 #if QT_VERSION <= QT_VERSION_CHECK(5, 14, 0)
 #    include <QDesktopWidget>
 #endif
+#include <QUuid>
 #include "qt_util.hpp"
+
+extern "C" {
+#include <86box/86box.h>
+#include <86box/config.h>
+#include <86box/device.h>
+#include <86box/ini.h>
+#include <86box/random.h>
+#include <86box/thread.h>
+#include <86box/timer.h>
+#include <86box/network.h>
+}
 
 namespace util {
 QScreen *
@@ -54,6 +66,47 @@ DlgFilter(std::initializer_list<QString> extensions, bool last)
     temp.removeDuplicates();
 #endif
     return " (" % temp.join(' ') % ")" % (!last ? ";;" : "");
+}
+
+QString currentUuid()
+{
+    return QUuid::createUuidV5(QUuid{}, QString(usr_path)).toString(QUuid::WithoutBraces);
+}
+
+bool compareUuid()
+{
+    // A uuid not set in the config file will have a zero length.
+    // Any uuid that is lower than the minimum length will be considered invalid
+    // and a new one will be generated
+    if (const auto currentUuidLength = QString(uuid).length(); currentUuidLength < UUID_MIN_LENGTH) {
+        storeCurrentUuid();
+        return true;
+    }
+    // The uuid appears to be a valid, at least by length.
+    // Compare with a simple string match
+    return uuid == currentUuid();
+}
+
+void
+storeCurrentUuid()
+{
+    strncpy(uuid, currentUuid().toUtf8().constData(), sizeof(uuid) - 1);
+}
+
+void
+generateNewMacAdresses()
+{
+    for (int i = 0; i < NET_CARD_MAX; ++i) {
+        auto net_card = net_cards_conf[i];
+        if (net_card.device_num != 0) {
+            const auto network_device = network_card_getdevice(net_card.device_num);
+            device_context_t device_context;
+
+            device_set_context(&device_context, network_device, i+1);
+            auto generatedMac = QString::asprintf("%02X:%02X:%02X", random_generate(), random_generate(), random_generate()).toLower();
+            config_set_string(device_context.name, "mac", generatedMac.toUtf8().constData());
+        }
+    }
 }
 
 }

--- a/src/qt/qt_util.hpp
+++ b/src/qt/qt_util.hpp
@@ -8,10 +8,15 @@
 
 class QScreen;
 namespace util {
+static constexpr auto UUID_MIN_LENGTH = 36;
 /* Creates extension list for qt filedialog */
 QString DlgFilter(std::initializer_list<QString> extensions, bool last = false);
 /* Returns screen the widget is on */
 QScreen *screenOfWidget(QWidget *widget);
+QString currentUuid();
+void storeCurrentUuid();
+bool compareUuid();
+void generateNewMacAdresses();
 };
 
 #endif


### PR DESCRIPTION
Summary
=======
### Highlights:
* MAC Address configuration
* UUID generation based on vm path
* Detection when a vm is moved or copied
* Regeneration of configured MAC addresses when a vm is copied
* Centered device name in configuration dialog

### Details

MAC addresses can now be configured in device settings. A `Generate` button is provided to generate a random MAC. Previously this could only be done by manually editing the config file.

Note: The input dialog is filtered and limited to only hex characters.

Screenshot:

![macconfig](https://github.com/86Box/86Box/assets/47337035/cb8e33c4-8475-4931-887f-7a12a782a18e)

Note that the device name is now centered. It was previously left justified.

A UUID is now generated during vm start. The UUID is based on the filesystem path of the current vm and is stored in the `General` section. This is used to detect when a vm has moved from its original location.

The primary reason to detect this event is to allow MAC addresses to be regenerated. If you clone / copy a vm and try to network them you will likely have issues due to the identical MAC addresses.

Example dialog when a move is detected:

![movewarning](https://github.com/86Box/86Box/assets/47337035/aad962a6-5aa4-40ba-8f84-0948c2aa79e2)

* If you indicate that it was copied, a new UUID is generated and new MAC addresses are generated for each configured NIC.
* If you indicate that it was moved, a new UUID is generated and no further action is taken.
* If you hit cancel, no action is taken



Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A
