### PR TITLE
Add host_cpu and emu_build_num to config

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -77,6 +77,7 @@
 #include <86box/plat_dir.h>
 #include <86box/ui.h>
 #include <86box/snd_opl.h>
+#include <86box/version.h>
 
 static int   cx;
 static int   cy;
@@ -1877,6 +1878,15 @@ save_general(void)
         ini_section_set_int(cat, "do_auto_pause", do_auto_pause);
     else
         ini_section_delete_var(cat, "do_auto_pause");
+
+    char cpu_buf[128] = { 0 };
+    plat_get_cpu_string(cpu_buf, 128);
+    ini_section_set_string(cat, "host_cpu", cpu_buf);
+
+    if (EMU_BUILD_NUM != 0)
+        ini_section_set_int(cat, "emu_build_num", EMU_BUILD_NUM);
+    else
+        ini_section_delete_var(cat, "emu_build_num");
 
     ini_delete_section_if_empty(config, cat);
 }

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -686,7 +686,7 @@ plat_get_cpu_string(char *outbuf, uint8_t len) {
         return;
     }
     QByteArray result = process->readAll();
-    auto command_result = QString(result).split(": ").last();
+    auto command_result = QString(result).split(": ").last().trimmed();
     if(!command_result.isEmpty()) {
         cpu_string = command_result;
     }


### PR DESCRIPTION
Summary
=======
The `plat_get_cpu_string` function was added a while back (#3533) in order to try and detect the host cpu string. This takes the function and adds the output to the `General` section in the config as `host_cpu`.

Additionally, this will also add `EMU_BUILD_NUM` into `General` as `emu_build_num` if it is set to anything other than the default `0`.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
#3533 
