### PR TITLE
PASPlus fix for PoP1

### DIFF
--- a/src/sound/snd_pas16.c
+++ b/src/sound/snd_pas16.c
@@ -309,7 +309,7 @@ pas16_in(uint16_t port, void *priv)
             ret = pas16->audiofilt;
             break;
         case 0x0803:
-            ret = pas16->irq_ena | (pas16->type ? 0x20 : 0x00);
+            ret = pas16->irq_ena | 0x20;
             pas16_log("IRQ Mask read=%02x.\n", ret);
             break;
 


### PR DESCRIPTION
Summary
=======
Okay, turns out bit 5 (for the board revision) is for all PAS2-based cards, which includes both Plus and 16.
This should fix the PCM IRQ on PoP1 and board detection on Plus DOS drivers.

Checklist
=========
* [x] Closes #4334
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
