### PR TITLE
Create SECURITY.md - adding Security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Supported Versions
+
+The [`main` branch](https://github.com/86Box/86Box/tree/master) and [latest release](https://github.com/86Box/86Box/releases) are both supported with security updates.
+
+## Reporting a Vulnerability
+
+Please inform the team by reporting security issues via Discord:
+
+Contact: https://discord.gg/QXK9XTv


### PR DESCRIPTION
Summary
=======
Adding Security policy (based on the one of DOSBox Staging). 
It was one of three missing items in [Community standards](https://github.com/86Box/86Box/community), thus improving the community standards rating of the project.

The other two are:
- Code of conduct
- Repository admins accept content reports

![image](https://github.com/86Box/86Box/assets/97228894/05d19713-8ecb-42e3-ad16-b0b84cde4917)


Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
