### PR TITLE
Fix Error initializing Hard Disk Controller in Siemens Nixdorf D824

### DIFF
--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -400,7 +400,8 @@ machine_at_d824_init(const machine_t *model)
 
     device_add(&keyboard_ps2_device);
     device_add(&fdc37c651_device);
-
+    device_add(&ide_isa_device);
+    
     return ret;
 }
 


### PR DESCRIPTION
Summary
=======
this should fix the issues.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
Provide links to datasheets or other documentation that helped you implement this pull request.
according to theretro web has 1x ide interface 
https://theretroweb.com/motherboards/s/siemens-nixdorf-system-board-d824
uses FDC37C651 SUPER 1/0 FLOPPY DISK CONTROLLERS 
http://www.bitsavers.org/components/standardMicrosystems/_dataSheets/SMC_37C651.pdf
mainboard pictures : https://www.ebay.it/itm/256012385136
Technical Manual See Page 6
https://theretroweb.com/motherboard/manual/fts-systemboardd824technicalmanualen-10-1083427.pdf-5f6661e2be9b0918876552.pdf
