### PR TITLE
Rename dtk 386 clone to DTK PM-1630C

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -4416,7 +4416,7 @@ const machine_t machines[] = {
     },
     /* Has IBM AT KBC firmware. */
     {
-        .name = "[NEAT] DTK 386SX clone",
+        .name = "[NEAT] DTK PM-1630C",
         .internal_name = "dtk386",
         .type = MACHINE_TYPE_386SX,
         .chipset = MACHINE_CHIPSET_NEAT,


### PR DESCRIPTION
was used for DTK Peer-2030
Summary
=======
machine identified 

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
post screen pictures
https://forum.vcfed.org/index.php?threads/getting-a-dtk-peer-2030-computer-running.1238827/post-1276666

the motherboard is listed  in trw
https://theretroweb.com/motherboards/s/dtk-pm-1630c 
manual
https://archive.org/details/dtk-ppm-2030-c/DTK%20BIOS%2026-20N%2C%2026-20NR%2C%2026-90N%20User%27s%20Manual/
https://theretroweb.com/motherboard/manual/peer-2030-5fd299cdcffc1060932266.pdf