### PR TITLE
Fix missing devices and machines on Linux (and probably MacOS/*nix in general)

### DIFF
--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -687,7 +687,7 @@ machine_at_pb450_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear("roms/machines/pb450/OPTI802.BIN",
+    ret = bios_load_linear("roms/machines/pb450/OPTI802.bin",
                            0x000e0000, 131072, 0);
 
     if (bios_only || !ret)
@@ -1367,7 +1367,7 @@ machine_at_amis76_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_inverted("roms/machines/s76p/s76p.rom", 
+    ret = bios_load_linear_inverted("roms/machines/s76p/S76P.ROM", 
                                     0x000e0000, 131072, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_socket5.c
+++ b/src/machine/m_at_socket5.c
@@ -64,8 +64,8 @@ machine_at_dellplato_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined("roms/machines/dellplato/1016AX1J.bio",
-                                    "roms/machines/dellplato/1016AX1J.bi1",
+    ret = bios_load_linear_combined("roms/machines/dellplato/1016AX1J.BIO",
+                                    "roms/machines/dellplato/1016AX1J.BI1",
                                     0x1d000, 128);
 
     if (bios_only || !ret)

--- a/src/machine/m_xt.c
+++ b/src/machine/m_xt.c
@@ -339,7 +339,7 @@ machine_xt_pravetz16_imko4_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear("roms/machines/pravetz16/BIOS_IMKO4_FE00.BIN",
+    ret = bios_load_linear("roms/machines/pravetz16/BIOS_IMKO4_FE00.bin",
                            0x000fe000, 65536, 0);
     if (ret) {
         bios_load_aux_linear("roms/machines/pravetz16/BIOS_IMKO4_F400.BIN",

--- a/src/video/vid_et4000w32.c
+++ b/src/video/vid_et4000w32.c
@@ -42,7 +42,7 @@
 #define BIOS_ROM_PATH_W32                      "roms/video/et4000w32/ET4000W32VLB_bios_MX27C512.BIN"
 #define BIOS_ROM_PATH_W32I_ISA                 "roms/video/et4000w32/ET4KW32I.VBI"
 #define BIOS_ROM_PATH_W32I_VLB                 "roms/video/et4000w32/tseng.u41.bin"
-#define BIOS_ROM_PATH_W32P_VIDEOMAGIC_REVB_VLB "roms/video/et4000w32/VideoMagic-BioS-HXIRTW32PWSRL.BIN"
+#define BIOS_ROM_PATH_W32P_VIDEOMAGIC_REVB_VLB "roms/video/et4000w32/VideoMagic-BioS-HXIRTW32PWSRL.bin"
 #define BIOS_ROM_PATH_W32P                     "roms/video/et4000w32/ET4K_W32.BIN"
 #define BIOS_ROM_PATH_W32P_REVC                "roms/video/et4000w32/et4000w32pcardex.BIN"
 


### PR DESCRIPTION
This pull request makes changes for the following 4 machines:
-pravetz16: capitalization of `BIOS_IMKO4_FE00.BIN` corrected to `BIOS_IMKO4_FE00.bin`
-s76p: capitalization of `s76p.rom` corrected to `S76P.ROM`
-dellplato: capitalization of `1016AX1J.bio` and `1016AX1J.bi1` file extensions corrected to `.BIO` and `.BI1` respectively
-pb450: capitalization of `OPTI802.BIN` corrected to `OPTI802.bin`

This pull request makes changes for the following 2 video cards:
Tseng Labs ET4000/w32p Rev. B PCI (VideoMagic)
Tseng Labs ET4000/w32p Rev. B VLB (VideoMagic) (these both share a ROM, and its extension needed to be lower-cased)

Summary
=======
Due to case-sensitive filesystems on *nix systems, these machines and video cards were not showing up. I was told it's preferred to edit the source code over changing the names of the ROMs, so here it is.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
