### PR TITLE
qt: Disable bus channels that are currently in use

### DIFF
--- a/src/qt/qt_harddiskdialog.cpp
+++ b/src/qt/qt_harddiskdialog.cpp
@@ -746,7 +746,7 @@ HarddiskDialog::on_comboBoxBus_currentIndexChanged(int index)
     ui->lineEditHeads->setValidator(new QIntValidator(1, max_heads, this));
     ui->lineEditSectors->setValidator(new QIntValidator(1, max_sectors, this));
 
-    Harddrives::populateBusChannels(ui->comboBoxChannel->model(), ui->comboBoxBus->currentData().toInt());
+    Harddrives::populateBusChannels(ui->comboBoxChannel->model(), ui->comboBoxBus->currentData().toInt(), Harddrives::busTrackClass);
     Harddrives::populateSpeeds(ui->comboBoxSpeed->model(), ui->comboBoxBus->currentData().toInt());
 
     switch (ui->comboBoxBus->currentData().toInt()) {

--- a/src/qt/qt_harddrive_common.cpp
+++ b/src/qt/qt_harddrive_common.cpp
@@ -24,6 +24,7 @@ extern "C" {
 }
 
 #include <QAbstractItemModel>
+#include <QStandardItemModel>
 
 void
 Harddrives::populateBuses(QAbstractItemModel *model)
@@ -96,7 +97,7 @@ Harddrives::populateSpeeds(QAbstractItemModel *model, int bus)
 }
 
 void
-Harddrives::populateBusChannels(QAbstractItemModel *model, int bus)
+Harddrives::populateBusChannels(QAbstractItemModel *model, int bus, SettingsBusTracking *sbt)
 {
     model->removeRows(0, model->rowCount());
 
@@ -104,6 +105,8 @@ Harddrives::populateBusChannels(QAbstractItemModel *model, int bus)
     int shifter         = 1;
     int orer            = 1;
     int subChannelWidth = 1;
+    QList<int> busesToCheck;
+    QList<int> channelsInUse;
     switch (bus) {
         case HDD_BUS_MFM:
         case HDD_BUS_XTA:
@@ -111,15 +114,29 @@ Harddrives::populateBusChannels(QAbstractItemModel *model, int bus)
             busRows = 2;
             break;
         case HDD_BUS_IDE:
+            busRows = 8;
+            busesToCheck.append(HDD_BUS_ATAPI);
+            busesToCheck.append(HDD_BUS_IDE);
+            break;
         case HDD_BUS_ATAPI:
             busRows = 8;
+            busesToCheck.append(HDD_BUS_IDE);
+            busesToCheck.append(HDD_BUS_ATAPI);
             break;
         case HDD_BUS_SCSI:
             shifter         = 4;
             orer            = 15;
             busRows         = 64;
             subChannelWidth = 2;
+            busesToCheck.append(HDD_BUS_SCSI);
             break;
+        default:
+            break;
+    }
+    if(sbt != nullptr && !busesToCheck.empty()) {
+        for (auto const &checkBus : busesToCheck) {
+            channelsInUse.append(sbt->busChannelsInUse(checkBus));
+        }
     }
 
     model->insertRows(0, busRows);
@@ -127,6 +144,11 @@ Harddrives::populateBusChannels(QAbstractItemModel *model, int bus)
         auto idx = model->index(i, 0);
         model->setData(idx, QString("%1:%2").arg(i >> shifter).arg(i & orer, subChannelWidth, 10, QChar('0')));
         model->setData(idx, ((i >> shifter) << shifter) | (i & orer), Qt::UserRole);
+        const auto *channelModel = qobject_cast<QStandardItemModel*>(model);
+        auto *channelItem = channelModel->item(i);
+        if(channelItem) {
+            channelItem->setEnabled(!channelsInUse.contains(i));
+        }
     }
 }
 

--- a/src/qt/qt_harddrive_common.hpp
+++ b/src/qt/qt_harddrive_common.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include "qt_settings_bus_tracking.hpp"
 
 class QString;
 class QAbstractItemModel;
@@ -9,7 +10,7 @@ class SettingsBusTracking;
 namespace Harddrives {
 void                        populateBuses(QAbstractItemModel *model);
 void                        populateRemovableBuses(QAbstractItemModel *model);
-void                        populateBusChannels(QAbstractItemModel *model, int bus);
+void                        populateBusChannels(QAbstractItemModel *model, int bus, SettingsBusTracking *sbt = nullptr);
 void                        populateSpeeds(QAbstractItemModel *model, int bus);
 QString                     BusChannelName(uint8_t bus, uint8_t channel);
 inline SettingsBusTracking *busTrackClass = nullptr;

--- a/src/qt/qt_settings.cpp
+++ b/src/qt/qt_settings.cpp
@@ -153,6 +153,10 @@ Settings::Settings(QWidget *parent)
             &SettingsStorageControllers::onCurrentMachineChanged);
     connect(machine, &SettingsMachine::currentMachineChanged, otherPeripherals,
             &SettingsOtherPeripherals::onCurrentMachineChanged);
+    connect(floppyCdrom, &SettingsFloppyCDROM::cdromChannelChanged, harddisks,
+            &SettingsHarddisks::reloadBusChannels);
+    connect(harddisks, &SettingsHarddisks::driveChannelChanged, floppyCdrom,
+            &SettingsFloppyCDROM::reloadBusChannels);
 
     connect(ui->listView->selectionModel(), &QItemSelectionModel::currentChanged, this,
            [this](const QModelIndex &current, const QModelIndex &previous) {

--- a/src/qt/qt_settings_bus_tracking.cpp
+++ b/src/qt/qt_settings_bus_tracking.cpp
@@ -198,6 +198,45 @@ SettingsBusTracking::scsi_bus_full()
     return (count == 64);
 }
 
+QList<int> SettingsBusTracking::busChannelsInUse(const int bus) {
+
+    QList<int> channelsInUse;
+    int        element;
+    uint64_t   mask;
+    switch (bus) {
+        case HDD_BUS_IDE:
+            for (uint8_t i = 0; i < 32; i++) {
+                element = ((i << 3) >> 6);
+                mask = ((uint64_t) DEV_HDD) << ((uint64_t) ((i << 3) & 0x3f));
+                if (ide_tracking[element] & mask) {
+                    channelsInUse.append(i);
+                }
+            }
+            break;
+        case HDD_BUS_ATAPI:
+            for (uint8_t i = 0; i < 32; i++) {
+                element = ((i << 3) >> 6);
+                mask = ((uint64_t) DEV_CDROM) << ((uint64_t) ((i << 3) & 0x3f));
+                if (ide_tracking[element] & mask) {
+                    channelsInUse.append(i);
+                }
+            }
+            break;
+        case HDD_BUS_SCSI:
+            for (uint8_t i = 0; i < 64; i++) {
+                element = ((i << 3) >> 6);
+                mask    = 0xffULL << ((uint64_t) ((i << 3) & 0x3f));
+                if (scsi_tracking[element] & mask)
+                    channelsInUse.append(i);
+            }
+            break;
+        default:
+            break;
+    }
+
+    return channelsInUse;
+}
+
 void
 SettingsBusTracking::device_track(int set, uint8_t dev_type, int bus, int channel)
 {

--- a/src/qt/qt_settings_bus_tracking.hpp
+++ b/src/qt/qt_settings_bus_tracking.hpp
@@ -28,6 +28,8 @@ public:
     explicit SettingsBusTracking();
     ~SettingsBusTracking() = default;
 
+    QList<int> busChannelsInUse(int bus);
+
     /* These return 0xff is none is free. */
     uint8_t next_free_mfm_channel();
     uint8_t next_free_esdi_channel();

--- a/src/qt/qt_settingsfloppycdrom.cpp
+++ b/src/qt/qt_settingsfloppycdrom.cpp
@@ -263,6 +263,7 @@ SettingsFloppyCDROM::onCDROMRowChanged(const QModelIndex &current)
 
     ui->comboBoxSpeed->setCurrentIndex(speed == 0 ? 7 : speed - 1);
     ui->comboBoxCDROMType->setCurrentIndex(type);
+    enableCurrentlySelectedChannel();
 }
 
 void
@@ -288,6 +289,13 @@ SettingsFloppyCDROM::on_comboBoxFloppyType_activated(int index)
                   ui->tableViewFloppy->selectionModel()->currentIndex(), index);
 }
 
+void SettingsFloppyCDROM::reloadBusChannels() {
+    auto selected = ui->comboBoxChannel->currentIndex();
+    Harddrives::populateBusChannels(ui->comboBoxChannel->model(), ui->comboBoxBus->currentData().toInt(), Harddrives::busTrackClass);
+    ui->comboBoxChannel->setCurrentIndex(selected);
+    enableCurrentlySelectedChannel();
+}
+
 void
 SettingsFloppyCDROM::on_comboBoxBus_currentIndexChanged(int index)
 {
@@ -298,7 +306,7 @@ SettingsFloppyCDROM::on_comboBoxBus_currentIndexChanged(int index)
         ui->comboBoxSpeed->setEnabled((bus == CDROM_BUS_MITSUMI) ? 0 : enabled);
         ui->comboBoxCDROMType->setEnabled((bus == CDROM_BUS_MITSUMI) ? 0 : enabled);
 
-        Harddrives::populateBusChannels(ui->comboBoxChannel->model(), bus);
+        Harddrives::populateBusChannels(ui->comboBoxChannel->model(), bus, Harddrives::busTrackClass);
     }
 }
 
@@ -363,6 +371,17 @@ SettingsFloppyCDROM::on_comboBoxBus_activated(int)
 }
 
 void
+SettingsFloppyCDROM::enableCurrentlySelectedChannel()
+{
+    const auto *item_model = qobject_cast<QStandardItemModel*>(ui->comboBoxChannel->model());
+    const auto index = ui->comboBoxChannel->currentIndex();
+    auto *item = item_model->item(index);
+    if(item) {
+        item->setEnabled(true);
+    }
+}
+
+void
 SettingsFloppyCDROM::on_comboBoxChannel_activated(int)
 {
     auto i = ui->tableViewCDROM->selectionModel()->currentIndex().siblingAtColumn(0);
@@ -376,6 +395,7 @@ SettingsFloppyCDROM::on_comboBoxChannel_activated(int)
     Harddrives::busTrackClass->device_track(1, DEV_CDROM, ui->tableViewCDROM->model()->data(i,
                                             Qt::UserRole).toInt(), ui->tableViewCDROM->model()->data(i,
                                             Qt::UserRole + 1).toInt());
+    emit cdromChannelChanged();
 }
 
 void

--- a/src/qt/qt_settingsfloppycdrom.hpp
+++ b/src/qt/qt_settingsfloppycdrom.hpp
@@ -13,9 +13,12 @@ class SettingsFloppyCDROM : public QWidget {
 public:
     explicit SettingsFloppyCDROM(QWidget *parent = nullptr);
     ~SettingsFloppyCDROM();
+    void reloadBusChannels();
 
     void save();
 
+signals:
+    void cdromChannelChanged();
 private slots:
     void on_comboBoxCDROMType_activated(int index);
     void on_comboBoxChannel_activated(int index);
@@ -30,6 +33,7 @@ private slots:
 
 private:
     Ui::SettingsFloppyCDROM *ui;
+    void enableCurrentlySelectedChannel();
 };
 
 #endif // QT_SETTINGSFLOPPYCDROM_HPP

--- a/src/qt/qt_settingsharddisks.hpp
+++ b/src/qt/qt_settingsharddisks.hpp
@@ -13,8 +13,12 @@ class SettingsHarddisks : public QWidget {
 public:
     explicit SettingsHarddisks(QWidget *parent = nullptr);
     ~SettingsHarddisks();
+    void reloadBusChannels();
 
     void save();
+
+signals:
+    void driveChannelChanged();
 
 private slots:
     void on_comboBoxChannel_currentIndexChanged(int index);
@@ -30,6 +34,7 @@ private slots:
 
 private:
     Ui::SettingsHarddisks *ui;
+    void                   enableCurrentlySelectedChannel();
     bool                   buschangeinprogress = false;
 };
 


### PR DESCRIPTION
Summary
=======
This PR adds a new internal bus tracking feature for IDE, ATAPI and SCSI buses. Essentially, channels that are in use by other devices are disabled in the UI and therefore unable to be selected. It also fixes an issue where the channel suggestion doesn't properly select the lowest one after a drive removal.

Checklist
=========
* [X] Closes #4367
* [X] I have discussed this with core contributors already

References
==========
N/A