### PR TITLE
the DEC 21143-based NIC expects a SROM Format version of 3

### DIFF
--- a/src/network/net_tulip.c
+++ b/src/network/net_tulip.c
@@ -1530,6 +1530,9 @@ nic_init(const device_t *info)
             s->eeprom_data[40] = 0x00;
             s->eeprom_data[41] = 0x00;
         } else {
+            /*SROM Format Version 3*/
+            s->eeprom_data[18] = 0x03;
+
             /*Block Count*/
             s->eeprom_data[32] = 0x01;
 
@@ -1677,7 +1680,7 @@ static const device_config_t dec_tulip_21140_config[] = {
 // clang-format on
 
 const device_t dec_tulip_device = {
-    .name          = "DE500A Fast Ethernet (DECchip 21143 \"Tulip\")",
+    .name          = "DEC DE-500A Fast Ethernet (DECchip 21143 \"Tulip\")",
     .internal_name = "dec_21143_tulip",
     .flags         = DEVICE_PCI,
     .local         = 0,


### PR DESCRIPTION
Summary
=======
This fixes detection under various operating systems, including NT-based ones.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
