### PR TITLE
Fix broken translation for Voodoo Graphics

### DIFF
--- a/src/qt/qt_settingsdisplay.ui
+++ b/src/qt/qt_settingsdisplay.ui
@@ -102,7 +102,7 @@
    <item row="4" column="0" colspan="2">
     <widget class="QCheckBox" name="checkBoxVoodoo">
      <property name="text">
-      <string>Voodoo 1 or 2 Graphics</string>
+      <string>Voodoo Graphics</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Summary
=======
Fixed broken translation of "Voodoo Graphics" for all languages. Since the list of possible video cards includes Voodoo 1, Obsidian, Voodoo 2, then “Voodoo Graphics” is better suited for all these video cards, as it was originally in 86Box.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
