### PR TITLE
snd_sb.c: Fix compilation error

### DIFF
--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -1292,6 +1292,7 @@ sb_ct1745_mixer_read(uint16_t addr, void *priv)
                 break;
 
             case 0x82:
+                ; /* Empty statement to make compilers happy about the following variable declaration. */
                 /* The Interrupt status register, addressed as register 82h on the Mixer register map,
                    is used by the ISR to determine whether the interrupt is meant for it or for some
                    other ISR, in which case it should chain to the previous routine. */


### PR DESCRIPTION
Summary
=======
Variable declarations, unlike statements, aren't allowed after labels (including case labels) according to the C standard, so insert a semicolon to make an empty statement that satisfies the requirement.

Oddly, MSYS2/MinGW-w64 GCC, unlike other compilers, including GCC on other systems, seemed to accept them without errors...


Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A