### PR TITLE
Update Olivetti M240 BIOS to 2.11

### DIFF
--- a/src/machine/m_xt_olivetti.c
+++ b/src/machine/m_xt_olivetti.c
@@ -1853,8 +1853,8 @@ machine_xt_m240_init(const machine_t *model)
     m24_kbd_t *m24_kbd;
     nvr_t     *nvr;
 
-    ret = bios_load_interleaved("roms/machines/m240/olivetti_m240_pch6_2.04_low.bin",
-                                "roms/machines/m240/olivetti_m240_pch5_2.04_high.bin",
+    ret = bios_load_interleaved("roms/machines/m240/olivetti_m240_pchj_2.11_low.bin",
+                                "roms/machines/m240/olivetti_m240_pchk_2.11_high.bin",
                                 0x000f8000, 32768, 0);
 
     if (bios_only || !ret)


### PR DESCRIPTION
Dumped BIOS 2.11
Updating the BIOS from 2.04 to 2.11 fixes several bugs:

- "Format Failure" message during hard disk formatting under MS DOS
- WANGTEK 40 MB streaming tape unit management
- I/O errors in floppy disk after an ON/OFF sequence
- Clock problems after using "GOSLOW"
- Possibility of testing system from a remote work station
- Possibility of programming in RTCC
- Solves FUJITSU 8284 problem

Summary
=======
Add Olivetti M240 BIOS version 2.11

Checklist
=========

* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/259/


