### PR TITLE
GHA: Disable 32-bit windows builds

### DIFF
--- a/.github/workflows/cmake_windows_msys2.yml
+++ b/.github/workflows/cmake_windows_msys2.yml
@@ -67,9 +67,9 @@ jobs:
         environment:
 #          - msystem: MSYS
 #            toolchain: ./cmake/flags-gcc-x86_64.cmake
-          - msystem: MINGW32
-            prefix: mingw-w64-i686
-            toolchain: ./cmake/flags-gcc-i686.cmake
+#          - msystem: MINGW32
+#            prefix: mingw-w64-i686
+#            toolchain: ./cmake/flags-gcc-i686.cmake
           - msystem: MINGW64
             prefix: mingw-w64-x86_64
             toolchain: ./cmake/flags-gcc-x86_64.cmake


### PR DESCRIPTION
Summary
=======
This PR disables the 32-bit windows builds in GitHub Actions.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A