### PR TITLE
Fix Mach64 LFB in some cases.

### DIFF
--- a/src/video/vid_ati_mach64.c
+++ b/src/video/vid_ati_mach64.c
@@ -4253,13 +4253,6 @@ mach64_read_linear(uint32_t addr, void *priv)
 
     cycles -= svga->monitor->mon_video_timing_read_b;
 
-    if (!svga->fast) {
-        if (svga->chain2_read) {
-            addr &= ~1;
-            addr <<= 2;
-        }
-    }
-
     addr &= svga->decode_mask;
     if (addr >= svga->vram_max)
         return 0xff;
@@ -4301,13 +4294,6 @@ mach64_write_linear(uint32_t addr, uint8_t val, void *priv)
     svga_t *svga = (svga_t *) priv;
 
     cycles -= svga->monitor->mon_video_timing_write_b;
-
-    if (!svga->fast) {
-        if (svga->chain2_write) {
-            addr &= ~1;
-            addr <<= 2;
-        }
-    }
 
     addr &= svga->decode_mask;
     if (addr >= svga->vram_max)


### PR DESCRIPTION
Summary
=======
These few cases where it gets corrupt fonts like in some builds of NT 4.0 and mode changes in Win95's driver. Hopefully this keeps everything else intact.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
