### PR TITLE
Correct IBM 5170 memory size, more IBM ISA memory cards

### DIFF
--- a/src/device/isamem.c
+++ b/src/device/isamem.c
@@ -851,6 +851,54 @@ isamem_close(void *priv)
     free(dev);
 }
 
+static const device_config_t ibmxt_32k_config[] = {
+  // clang-format off
+    {
+        .name = "size",
+        .description = "Memory Size",
+        .type = CONFIG_SPINNER,
+        .default_string = "",
+        .default_int = 32,
+        .file_filter = "",
+        .spinner = {
+            .min = 32,
+            .max = 576,
+            .step = 32
+        },
+        .selection = { { 0 } }
+    },
+    {
+        .name = "start",
+        .description = "Start Address",
+        .type = CONFIG_SPINNER,
+        .default_string = "",
+        .default_int = 64,
+        .file_filter = "",
+        .spinner = {
+            .min = 0,
+            .max = 608,
+            .step = 32
+        },
+        .selection = { { 0 } }
+    },
+    { .name = "", .description = "", .type = CONFIG_END }
+  // clang-format on
+};
+
+static const device_t ibmxt_32k_device = {
+    .name          = "IBM PC/XT 32K Memory Expansion Option",
+    .internal_name = "ibmxt_32k",
+    .flags         = DEVICE_ISA,
+    .local         = ISAMEM_IBMXT_CARD,
+    .init          = isamem_init,
+    .close         = isamem_close,
+    .reset         = NULL,
+    { .available = NULL },
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = ibmxt_32k_config
+};
+
 static const device_config_t ibmxt_config[] = {
   // clang-format off
     {
@@ -1962,6 +2010,7 @@ static const struct {
     // clang-format off
     { &isa_none_device     },
     // XT Ram Expansion Cards
+    { &ibmxt_32k_device    },
     { &ibmxt_device        },
     { &genericxt_device    },
     { &msramcard_device    },

--- a/src/device/isamem.c
+++ b/src/device/isamem.c
@@ -899,6 +899,54 @@ static const device_t ibmxt_32k_device = {
     .config        = ibmxt_32k_config
 };
 
+static const device_config_t ibmxt_64k_config[] = {
+  // clang-format off
+    {
+        .name = "size",
+        .description = "Memory Size",
+        .type = CONFIG_SPINNER,
+        .default_string = "",
+        .default_int = 64,
+        .file_filter = "",
+        .spinner = {
+            .min = 64,
+            .max = 576,
+            .step = 64
+        },
+        .selection = { { 0 } }
+    },
+    {
+        .name = "start",
+        .description = "Start Address",
+        .type = CONFIG_SPINNER,
+        .default_string = "",
+        .default_int = 64,
+        .file_filter = "",
+        .spinner = {
+            .min = 0,
+            .max = 576,
+            .step = 64
+        },
+        .selection = { { 0 } }
+    },
+    { .name = "", .description = "", .type = CONFIG_END }
+  // clang-format on
+};
+
+static const device_t ibmxt_64k_device = {
+    .name          = "IBM PC/XT 64K Memory Expansion Option",
+    .internal_name = "ibmxt_64k",
+    .flags         = DEVICE_ISA,
+    .local         = ISAMEM_IBMXT_CARD,
+    .init          = isamem_init,
+    .close         = isamem_close,
+    .reset         = NULL,
+    { .available = NULL },
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = ibmxt_64k_config
+};
+
 static const device_config_t ibmxt_config[] = {
   // clang-format off
     {
@@ -2011,6 +2059,7 @@ static const struct {
     { &isa_none_device     },
     // XT Ram Expansion Cards
     { &ibmxt_32k_device    },
+    { &ibmxt_64k_device    },
     { &ibmxt_device        },
     { &genericxt_device    },
     { &msramcard_device    },

--- a/src/device/isamem.c
+++ b/src/device/isamem.c
@@ -90,11 +90,12 @@
 #define ISAMEM_GENXT_CARD      1
 #define ISAMEM_RAMCARD_CARD    2
 #define ISAMEM_SYSTEMCARD_CARD 3
-#define ISAMEM_IBMAT_CARD      4
-#define ISAMEM_GENAT_CARD      5
-#define ISAMEM_P5PAK_CARD      6
-#define ISAMEM_A6PAK_CARD      7
-#define ISAMEM_EMS5150_CARD    8
+#define ISAMEM_IBMAT_128K_CARD 4
+#define ISAMEM_IBMAT_CARD      5
+#define ISAMEM_GENAT_CARD      6
+#define ISAMEM_P5PAK_CARD      7
+#define ISAMEM_A6PAK_CARD      8
+#define ISAMEM_EMS5150_CARD    9
 #define ISAMEM_EV159_CARD      10
 #define ISAMEM_RAMPAGEXT_CARD  11
 #define ISAMEM_ABOVEBOARD_CARD 12
@@ -500,6 +501,13 @@ isamem_init(const device_t *info)
             dev->total_size = device_get_config_int("size");
             dev->start_addr = device_get_config_int("start");
             tot             = dev->total_size;
+            break;
+
+        case ISAMEM_IBMAT_128K_CARD: /* IBM PC/AT 128K Memory Expansion Option */
+            dev->total_size = 128;
+            dev->start_addr = 512;
+            tot             = dev->total_size;
+            dev->flags |= FLAG_WIDE;
             break;
 
         case ISAMEM_IBMAT_CARD: /* IBM PC/AT Memory Expansion Card */
@@ -1033,6 +1041,20 @@ static const device_t mssystemcard_device = {
     .speed_changed = NULL,
     .force_redraw  = NULL,
     .config        = mssystemcard_config
+};
+
+static const device_t ibmat_128k_device = {
+    .name          = "IBM PC/AT 128KB Memory Expansion Option",
+    .internal_name = "ibmat_128k",
+    .flags         = DEVICE_ISA,
+    .local         = ISAMEM_IBMAT_128K_CARD,
+    .init          = isamem_init,
+    .close         = isamem_close,
+    .reset         = NULL,
+    { .available = NULL },
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = NULL
 };
 
 static const device_config_t ibmat_config[] = {
@@ -1939,12 +1961,16 @@ static const struct {
 } boards[] = {
     // clang-format off
     { &isa_none_device     },
+    // XT Ram Expansion Cards
     { &ibmxt_device        },
     { &genericxt_device    },
     { &msramcard_device    },
     { &mssystemcard_device },
+    // AT RAM Expansion Cards
+    { &ibmat_128k_device   },
     { &ibmat_device        },
     { &genericat_device    },
+    // EMS Cards
     { &p5pak_device        },
     { &a6pak_device        },
     { &ems5150_device      },

--- a/src/device/isamem.c
+++ b/src/device/isamem.c
@@ -957,9 +957,9 @@ static const device_config_t ibmxt_config[] = {
         .default_int = 128,
         .file_filter = "",
         .spinner = {
-            .min = 0,
-            .max = 512,
-            .step = 16
+            .min = 64,
+            .max = 576,
+            .step = 64
         },
         .selection = { { 0 } }
     },
@@ -982,7 +982,7 @@ static const device_config_t ibmxt_config[] = {
 };
 
 static const device_t ibmxt_device = {
-    .name          = "IBM PC/XT Memory Expansion",
+    .name          = "IBM PC/XT 64/256K Memory Expansion Option",
     .internal_name = "ibmxt",
     .flags         = DEVICE_ISA,
     .local         = ISAMEM_IBMXT_CARD,

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -2545,8 +2545,8 @@ const machine_t machines[] = {
         .flags = MACHINE_FLAGS_NONE,
         .ram = {
             .min = 256,
-            .max = 15872,
-            .step = 128
+            .max = 512,
+            .step = 256
         },
         .nvrmask = 63,
         .kbc_device = NULL,


### PR DESCRIPTION
Summary
=======
* Fix IBM 5170's memory size choices
* Add the IBM 32k Memory Expansion Option
* Add the IBM 64K Memory Expansion Option
* Correct existing IBM Memory to match the 64/256K Memory Expansion option
* Add the IBM PC/AT 128KB Memory Expansion Option

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
