### PR TITLE
Fix granularity of Generic AT RAM expansion card

### DIFF
--- a/src/device/isamem.c
+++ b/src/device/isamem.c
@@ -1215,7 +1215,7 @@ static const device_config_t genericat_config[] = {
         .spinner = {
             .min = 0,
             .max = 16384,
-            .step = 512
+            .step = 128
         },
         .selection = { { 0 } }
     },


### PR DESCRIPTION
Summary
=======
Fix granularity of Generic AT RAM expansion card

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
