### PR TITLE
mem.c: Remove (conditionally) duplicate definitions

### DIFF
--- a/src/mem/mem.c
+++ b/src/mem/mem.c
@@ -164,46 +164,6 @@ mem_log(const char *fmt, ...)
 #    define mem_log(fmt, ...)
 #endif
 
-#ifdef USE_DEBUG_REGS_486
-/* As below, 1 = exec, 4 = read. */
-int    read_type = 4;
-
-/* Set trap for data address breakpoints - 1 = exec, 2 = write, 4 = read. */
-void
-mem_debug_check_addr(uint32_t addr, int flags)
-{
-    uint32_t bp_addr;
-    uint32_t bp_mask;
-    uint32_t len_type_pair;
-    int bp_enabled;
-    uint8_t match_flags[4] = { 0, 2, 0, 6 };
-
-    if (cpu_state.abrt || ((flags == 1) && (cpu_state.eflags & RF_FLAG)))
-        return;
-
-    if (dr[7] & 0x000000ff)  for (uint8_t i = 0; i < 4; i++) {
-        bp_addr = dr[i];
-        bp_enabled = (dr[7] >> (i << 1)) & 0x03;
-        len_type_pair = (dr[7] >> (16 + (i << 2))) & 0x0f;
-        bp_mask = ~((len_type_pair >> 2) & 0x03);
-
-        if ((flags & match_flags[len_type_pair & 0x03]) && ((bp_addr & bp_mask) == (addr & bp_mask))) {
-            /*
-               From the Intel i386 documemntation:
-
-               (Note that the processor sets Bn regardless of whether Gn or
-               Ln is set. If more than one breakpoint condition occurs at one time and if
-               the breakpoint trap occurs due to an enabled condition other than n, Bn may
-               be set, even though neither Gn nor Ln is set.)
-             */
-            dr[6] |= (1 << i);
-            if (bp_enabled)
-                trap |= (read_type == 1) ? 8 : 4;
-        }
-    }
-}
-#endif
-
 int
 mem_addr_is_ram(uint32_t addr)
 {


### PR DESCRIPTION
Summary
=======
Fixes building with debug registers for 486+ enabled

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A
