### PR TITLE
Add onboard C&T 69000 video to the ADLink NuPRO-592

### DIFF
--- a/src/machine/m_at_socket7.c
+++ b/src/machine/m_at_socket7.c
@@ -869,13 +869,17 @@ machine_at_nupro592_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x0B, PCI_CARD_VIDEO,       3, 4, 1, 2); /* C&T B69000 */
+    pci_register_slot(0x0C, PCI_CARD_NETWORK,     4, 1, 2, 3); /* Intel 82559 */
     pci_register_slot(0x11, PCI_CARD_NORMAL,      1, 2, 3, 4);
     pci_register_slot(0x12, PCI_CARD_NORMAL,      4, 1, 2, 3);
     pci_register_slot(0x13, PCI_CARD_NORMAL,      3, 4, 1, 2);
     pci_register_slot(0x14, PCI_CARD_NORMAL,      2, 3, 4, 1);
-    pci_register_slot(0x0B, PCI_CARD_NORMAL,      3, 4, 1, 2); /*Strongly suspect these are on-board slots*/
-    pci_register_slot(0x0C, PCI_CARD_NORMAL,      4, 1, 2, 3);
     pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 4); /* PIIX4 */
+
+    if (gfxcard[0] == VID_INTERNAL)
+        device_add(&chips_69000_onboard_device);
+
     device_add(&i430tx_device);
     device_add(&piix4_device);
     device_add(&keyboard_ps2_ami_pci_device);

--- a/src/machine/m_at_socket7.c
+++ b/src/machine/m_at_socket7.c
@@ -878,7 +878,7 @@ machine_at_nupro592_init(const machine_t *model)
     pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 4); /* PIIX4 */
 
     if (gfxcard[0] == VID_INTERNAL)
-        device_add(&chips_69000_onboard_device);
+        device_add(machine_get_vid_device(machine));
 
     device_add(&i430tx_device);
     device_add(&piix4_device);

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -11922,7 +11922,7 @@ const machine_t machines[] = {
     /* 430TX */
     /* The BIOS sends KBC command B8, CA, and CB, so it has an AMI KBC firmware. */
     {
-        .name = "[i430TX] ADLink NuPRO-592",
+        .name = "[i430TX] ADLink NuPRO-591/592",
         .internal_name = "nupro592",
         .type = MACHINE_TYPE_SOCKET7,
         .chipset = MACHINE_CHIPSET_INTEL_430TX,
@@ -11942,7 +11942,7 @@ const machine_t machines[] = {
             .max_multi = 5.5
         },
         .bus_flags = MACHINE_PS2_PCI,
-        .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI, /* Has internal video: C&T B69000 */
+        .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_VIDEO,
         .ram = {
             .min = 8192,
             .max = 262144,
@@ -11956,7 +11956,7 @@ const machine_t machines[] = {
         .device = NULL,
         .fdc_device = NULL,
         .sio_device = NULL,
-        .vid_device = NULL,
+        .vid_device = &chips_69000_onboard_device,
         .snd_device = NULL,
         .net_device = NULL
     },


### PR DESCRIPTION
Summary
=======
Add optional onboard C&T 69000 video to the ADLink NuPRO-592, allowing it to be turned into the NuPRO-591 model, since the BIOS supports all three (590 with onboard video and not-yet-emulated NIC, 591 and 592). The machine name has been altered accordingly.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
<https://theretroweb.com/motherboards/s/adlink-nupro-590-series>