### PR TITLE
ET4000 RAMDAC break fix.

### DIFF
--- a/src/video/vid_et4000.c
+++ b/src/video/vid_et4000.c
@@ -145,6 +145,7 @@ et4000_in(uint16_t addr, void *priv)
         case 0x3c9:
             if (dev->type >= ET4000_TYPE_ISA)
                 return sc1502x_ramdac_in(addr, svga->ramdac, svga);
+            break;
 
         case 0x3cd: /*Banking*/
             return dev->banking;


### PR DESCRIPTION
Summary
=======
This should fix the black screens when returning to text mode after the GUI.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
