### PR TITLE
Make sure timers don't go completely out of sync upon altering TSC vi…

### DIFF
--- a/src/cpu/cpu.c
+++ b/src/cpu/cpu.c
@@ -40,6 +40,7 @@
 #include <86box/nmi.h>
 #include <86box/pic.h>
 #include <86box/pci.h>
+#include <86box/timer.h>
 #include <86box/gdbstub.h>
 #include <86box/plat_fallthrough.h>
 #include <86box/plat_unused.h>
@@ -3492,7 +3493,7 @@ cpu_WRMSR(void)
                     break;
                 /* Time Stamp Counter */
                 case 0x10:
-                    tsc = EAX | ((uint64_t) EDX << 32);
+                    timer_set_new_tsc(EAX | ((uint64_t) EDX << 32));
                     break;
                 /* Performance Monitor - Control and Event Select */
                 case 0x11:
@@ -3568,7 +3569,7 @@ cpu_WRMSR(void)
                     break;
                 /* Time Stamp Counter */
                 case 0x10:
-                    tsc = EAX | ((uint64_t) EDX << 32);
+                    timer_set_new_tsc(EAX | ((uint64_t) EDX << 32));
                     break;
                 /* PERFCTR0 - Performance Counter Register 0 - aliased to TSC */
                 case 0xc1:
@@ -3664,7 +3665,7 @@ cpu_WRMSR(void)
                     break;
                 /* Time Stamp Counter */
                 case 0x00000010:
-                    tsc = EAX | ((uint64_t) EDX << 32);
+                    timer_set_new_tsc(EAX | ((uint64_t) EDX << 32));
                     break;
                 /* Array Access Register */
                 case 0x00000082:
@@ -3834,7 +3835,7 @@ amd_k_invalid_wrmsr:
                 /* Time Stamp Counter */
                 case 0x00000010:
                 case 0x80000010:
-                    tsc = EAX | ((uint64_t) EDX << 32);
+                    timer_set_new_tsc(EAX | ((uint64_t) EDX << 32));
                     break;
                 /* Performance Monitor - Control and Event Select */
                 case 0x00000011:
@@ -3919,7 +3920,7 @@ pentium_invalid_wrmsr:
                     msr.tr5 = EAX & 0x008f0f3b;
                 /* Time Stamp Counter */
                 case 0x10:
-                    tsc = EAX | ((uint64_t) EDX << 32);
+                    timer_set_new_tsc(EAX | ((uint64_t) EDX << 32));
                     break;
                 /* Performance Monitor - Control and Event Select */
                 case 0x11:
@@ -3952,7 +3953,7 @@ pentium_invalid_wrmsr:
                     break;
                 /* Time Stamp Counter */
                 case 0x10:
-                    tsc = EAX | ((uint64_t) EDX << 32);
+                    timer_set_new_tsc(EAX | ((uint64_t) EDX << 32));
                     break;
                 /* Unknown */
                 case 0x18:

--- a/src/include/86box/timer.h
+++ b/src/include/86box/timer.h
@@ -185,6 +185,9 @@ timer_set_p(pc_timer_t *timer, void *priv)
 extern void timer_stop(pc_timer_t *timer);
 extern void timer_on_auto(pc_timer_t *timer, double period);
 
+/* Change TSC, taking into account the timers. */
+extern void timer_set_new_tsc(uint64_t new_tsc);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
…a WRMSR

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
