### PR TITLE
Add Micronics M5Pi

### DIFF
--- a/src/disk/hdc_ide_w83769f.c
+++ b/src/disk/hdc_ide_w83769f.c
@@ -458,3 +458,16 @@ const device_t ide_w83769f_pci_34_device = {
     .config        = NULL
 };
 
+const device_t ide_w83769f_pci_single_channel_device = {
+    .name          = "Winbond W83769F PCI",
+    .internal_name = "ide_w83769f_pci",
+    .flags         = DEVICE_PCI,
+    .local         = 0x200b4,
+    .init          = w83769f_init,
+    .close         = w83769f_close,
+    .reset         = w83769f_reset,
+    { .available = NULL },
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = NULL
+};

--- a/src/include/86box/hdc.h
+++ b/src/include/86box/hdc.h
@@ -87,6 +87,7 @@ extern const device_t ide_w83769f_vlb_device;                   /* Winbond W8376
 extern const device_t ide_w83769f_vlb_34_device;                /* Winbond W83769F VLB (Port 34h) */
 extern const device_t ide_w83769f_pci_device;                   /* Winbond W83769F PCI */
 extern const device_t ide_w83769f_pci_34_device;                /* Winbond W83769F PCI (Port 34h) */
+extern const device_t ide_w83769f_pci_single_channel_device;    /* Winbond W83769F PCI (Only primary channel) */
 
 extern const device_t ide_ter_device;
 extern const device_t ide_ter_pnp_device;

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -625,6 +625,7 @@ extern int machine_at_valuepointp60_init(const machine_t *);
 extern int machine_at_revenge_init(const machine_t *);
 extern int machine_at_586is_init(const machine_t *);
 extern int machine_at_pb520r_init(const machine_t *);
+extern int machine_at_m5pi_init(const machine_t *);
 
 extern int machine_at_excalibur_init(const machine_t *);
 

--- a/src/machine/m_at_socket4.c
+++ b/src/machine/m_at_socket4.c
@@ -356,6 +356,36 @@ machine_at_pb520r_init(const machine_t *model)
 }
 
 int
+machine_at_m5pi_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear_inverted("roms/machines/m5pi/M5PI10R.BIN",
+                           0x000e0000, 131072, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_common_init(model);
+
+    pci_init(PCI_CONFIG_TYPE_2 | PCI_NO_IRQ_STEERING);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x01, PCI_CARD_IDE,         0, 0, 0, 0);
+    pci_register_slot(0x0f, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x0c, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x0b, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x02, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 0);
+    device_add(&i430lx_device);	
+    device_add(&sio_zb_device);	
+    device_add_params(machine_get_kbc_device(machine), (void *) model->kbc_params);
+    device_add(&ide_w83769f_pci_single_channel_device);	
+    device_add(&fdc37c665_device);
+    device_add(&intel_flash_bxt_ami_device);
+
+    return ret;
+}
+
+int
 machine_at_excalibur_init(const machine_t *model)
 {
     int ret;

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -9258,7 +9258,46 @@ const machine_t machines[] = {
         .snd_device = NULL,
         .net_device = NULL
     },
-
+    /* The M5Pi appears to have a Phoenix MultiKey KBC firmware according to photos. */	
+    {
+        .name = "[i430LX] Micronics M5Pi",
+        .internal_name = "m5pi",
+        .type = MACHINE_TYPE_SOCKET4,
+        .chipset = MACHINE_CHIPSET_INTEL_430LX,
+        .init = machine_at_m5pi_init,
+        .p1_handler = NULL,
+        .gpio_handler = NULL,
+        .available_flag = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu = {
+            .package = CPU_PKG_SOCKET4,
+            .block = CPU_BLOCK_NONE,
+            .min_bus = 60000000,
+            .max_bus = 66666667,
+            .min_voltage = 5000,
+            .max_voltage = 5000,
+            .min_multi = MACHINE_MULTIPLIER_FIXED,
+            .max_multi = MACHINE_MULTIPLIER_FIXED
+        },
+        .bus_flags = MACHINE_PS2_PCI,
+        .flags = MACHINE_IDE_DUAL | MACHINE_APM,
+        .ram = {
+            .min = 2048,
+            .max = 131072,
+            .step = 2048
+        },
+        .nvrmask = 127,
+        .kbc_device = &keyboard_ps2_phoenix_device,
+        .kbc_p1 = 0xff,
+        .gpio = 0xffffffff,
+        .gpio_acpi = 0xffffffff,
+        .device = NULL,
+        .fdc_device = NULL,
+        .sio_device = NULL,
+        .vid_device = NULL,
+        .snd_device = NULL,
+        .net_device = NULL
+    },
     /* OPTi 596/597 */
     /* This uses an AMI KBC firmware in PS/2 mode (it sends command A5 with the
        PS/2 "Load Security" meaning), most likely MegaKey as it sends command AF


### PR DESCRIPTION
Summary
=======
The Micronics M5Pi is a Socket 4 430LX machine that uses a version of the "PhoenixBIOS Ax86" BIOS. Possibly one of the last machines to use a relatively-stock version of the old Phoenix BIOS.


Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [X] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/ - this is not to the main branch yet?

References
==========
https://theretroweb.com/motherboard/manual/m5pi-5f691a3f73f3a600802954.pdf
