### PR TITLE
UUID updates

### DIFF
--- a/src/qt/qt_util.hpp
+++ b/src/qt/qt_util.hpp
@@ -17,6 +17,7 @@ QString currentUuid();
 void storeCurrentUuid();
 bool compareUuid();
 void generateNewMacAdresses();
+bool hasConfiguredNICs();
 };
 
 #endif


### PR DESCRIPTION
Summary
=======
A few updates to the UUID system:

* Ensure relative paths are properly resolved to the canonical dir
* Do not display a mismatch prompt unless the system has configured NICs. If there are no configured NICs, just update the UUID on mismatch because there is no action to be taken.

Checklist
=========
* [X] I have discussed this with core contributors already

References
==========
N/A