### PR TITLE
Video changes of the day (July 8th, 2024)

### DIFF
--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -1004,9 +1004,9 @@ ibm8514_accel_out(uint16_t port, uint32_t val, svga_t *svga, int len)
             case 0x4ae8:
             case 0x4ae9:
                 WRITE8(port, dev->accel.advfunc_cntl, val);
-                dev->on[port & 1] = dev->accel.advfunc_cntl & 0x01;
-                vga_on = !dev->on[port & 1];
-                dev->vendor_mode[port & 1] = 0;
+                dev->on[0] = dev->accel.advfunc_cntl & 0x01;
+                vga_on = !dev->on[0];
+                dev->vendor_mode[0] = 0;
                 ibm8514_log("[%04X:%08X]: IBM 8514/A: (0x%04x): ON=%d, shadow crt=%x, hdisp=%d, vdisp=%d.\n", CS, cpu_state.pc, port, dev->on[port & 1], dev->accel.advfunc_cntl & 0x04, dev->hdisp, dev->vdisp);
                 ibm8514_log("IBM mode set %s resolution.\n", (dev->accel.advfunc_cntl & 0x04) ? "2: 1024x768" : "1: 640x480");
                 svga_recalctimings(svga);
@@ -4311,7 +4311,7 @@ ibm8514_recalctimings(svga_t *svga)
     } else
 #endif
     {
-        if (dev->on[0] || dev->on[1]) {
+        if (dev->on[0]) {
             dev->h_total = dev->htotal + 1;
             dev->rowcount = !!(dev->disp_cntl & 0x08);
 
@@ -4416,7 +4416,7 @@ ibm8514_init(const device_t *info)
 
     dev->vram_size   = 1024 << 10;
     dev->vram        = calloc(dev->vram_size, 1);
-    dev->changedvram = calloc(dev->vram_size >> 12, 1);
+    dev->changedvram = calloc((dev->vram_size >> 12) + 1, 1);
     dev->vram_mask   = dev->vram_size - 1;
     dev->map8        = dev->pallook;
     dev->local       = 0;

--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -2596,13 +2596,16 @@ mach_recalctimings(svga_t *svga)
         if (dev->interlace)
             dev->dispend >>= 1;
 
-        if (dev->dispend == 766)
+        if (dev->dispend == 478)
             dev->dispend += 2;
 
         if (dev->dispend == 598)
             dev->dispend += 2;
 
-        if (dev->dispend == 478)
+        if (dev->dispend == 766)
+            dev->dispend += 2;
+
+        if (dev->dispend == 1022)
             dev->dispend += 2;
 
         if ((dev->local & 0xff) >= 0x02) {
@@ -5870,7 +5873,7 @@ mach8_init(const device_t *info)
                       NULL);
         dev->vram_size   = mach->memory << 10;
         dev->vram        = calloc(dev->vram_size, 1);
-        dev->changedvram = calloc(dev->vram_size >> 12, 1);
+        dev->changedvram = calloc((dev->vram_size >> 12) + 1, 1);
         dev->vram_mask   = dev->vram_size - 1;
         dev->hwcursor.cur_ysize = 64;
         mach->config1 = 0x20;
@@ -5918,7 +5921,7 @@ mach8_init(const device_t *info)
                       NULL);
         dev->vram_size   = (1024 << 10);
         dev->vram        = calloc(dev->vram_size, 1);
-        dev->changedvram = calloc(dev->vram_size >> 12, 1);
+        dev->changedvram = calloc((dev->vram_size >> 12) + 1, 1);
         dev->vram_mask   = dev->vram_size - 1;
         video_inform(VIDEO_FLAG_TYPE_8514, &timing_gfxultra_isa);
         mach->config1 = 0x01 | 0x02 | 0x20 | 0x08 | 0x80;

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -223,7 +223,8 @@ svga_out(uint16_t addr, uint8_t val, void *priv)
                 xga->on = (val & 0x01) ? 0 : 1;
             if (ibm8514_active && dev) {
                 dev->on[0] = (val & 0x01) ? 0 : 1;
-                dev->on[1] = dev->on[0];
+                if (dev->local & 0xff)
+                    dev->on[1] = dev->on[0];
             }
 
             svga_log("3C3: VGA ON = %d.\n", val & 0x01);

--- a/src/video/vid_xga.c
+++ b/src/video/vid_xga.c
@@ -3346,7 +3346,7 @@ xga_init(const device_t *info)
     xga->vram_size             = (1024 << 10);
     xga->vram_mask             = xga->vram_size - 1;
     xga->vram                  = calloc(xga->vram_size, 1);
-    xga->changedvram           = calloc(xga->vram_size >> 12, 1);
+    xga->changedvram           = calloc((xga->vram_size >> 12) + 1, 1);
     xga->on                    = 0;
     xga->hwcursor.cur_xsize    = 64;
     xga->hwcursor.cur_ysize    = 64;


### PR DESCRIPTION
Summary
=======
IBM 8514/A set:
Fixed a one off video bug that was causing the VGA video to not be restored after quitting a 8514/A GUI session (namely on Win2.x' 8514/A's driver). ATI Mach32:
Fixed another vertical display issue when activated (in 1280x1024 mode, when 1024 was 1022). All involved:
Apply RG's changedvram fix to 8514/A, Mach8/32 and XGA's changedvram pointers.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
