### PR TITLE
add Wells American A*Star AT clone

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -439,7 +439,7 @@ extern int machine_at_ibmatquadtel_init(const machine_t *); // IBM AT with Quadt
 extern int machine_at_ibmxt286_init(const machine_t *);
 
 extern int machine_at_siemens_init(const machine_t *); // Siemens PCD-2L. N82330 discrete machine. It segfaults in some places
-
+extern int machine_at_wellamerastar_init(const machine_t *); // Wells American A*Star with custom award BIOS 
 #if defined(DEV_BRANCH) && defined(USE_OPEN_AT)
 extern int machine_at_openat_init(const machine_t *);
 #endif

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -439,6 +439,7 @@ extern int machine_at_ibmatquadtel_init(const machine_t *); // IBM AT with Quadt
 extern int machine_at_ibmxt286_init(const machine_t *);
 
 extern int machine_at_siemens_init(const machine_t *); // Siemens PCD-2L. N82330 discrete machine. It segfaults in some places
+
 extern int machine_at_wellamerastar_init(const machine_t *); // Wells American A*Star with custom award BIOS 
 #if defined(DEV_BRANCH) && defined(USE_OPEN_AT)
 extern int machine_at_openat_init(const machine_t *);

--- a/src/machine/m_at.c
+++ b/src/machine/m_at.c
@@ -263,14 +263,14 @@ machine_at_wellamerastar_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved("roms/machines/wellamerastar/W_3.031_L",
-                                "roms/machines/wellamerastar/W_3.031_H",
+    ret = bios_load_interleaved("roms/machines/wellamerastar/W_3.031_L.BIN",
+                                "roms/machines/wellamerastar/W_3.031_H.BIN",
                                 0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
         return ret;
 
-    machine_at_wellamerastar_init(model);
+    machine_at_ibm_common_init(model);
 
     return ret;
 }

--- a/src/machine/m_at.c
+++ b/src/machine/m_at.c
@@ -258,6 +258,23 @@ machine_at_siemens_init(const machine_t *model)
     return ret;
 }
 
+int
+machine_at_wellamerastar_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_interleaved("roms/machines/wellamerastar/W_3.031_L",
+                                "roms/machines/wellamerastar/W_3.031_H",
+                                0x000f0000, 65536, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_wellamerastar_init(model);
+
+    return ret;
+}
+
 #if defined(DEV_BRANCH) && defined(USE_OPEN_AT)
 int
 machine_at_openat_init(const machine_t *model)

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -2994,6 +2994,48 @@ const machine_t machines[] = {
         .snd_device = NULL,
         .net_device = NULL
     },
+    /*Has custom Award firmware for Wells American*/
+{
+        .name = "[ISA] Wells American A*Star ",
+        .internal_name = "wellamerastar",
+        .type = MACHINE_TYPE_286,
+        .chipset = MACHINE_CHIPSET_DISCRETE,
+        .init = machine_at_wellamerastar_init,
+        .p1_handler = machine_generic_p1_handler,
+        .gpio_handler = NULL,
+        .available_flag = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu = {
+            .package = CPU_PKG_286,
+            .block = CPU_BLOCK_NONE,
+            .min_bus = 6000000,
+            .max_bus = 14000000,
+            .min_voltage = 0,
+            .max_voltage = 0,
+            .min_multi = 0,
+            .max_multi = 0
+        },
+        .bus_flags = MACHINE_AT,
+        .flags = MACHINE_FLAGS_NONE,
+        .ram = {
+            .min = 512,
+            .max = 1024,
+            .step = 512
+        },
+        .nvrmask = 63,
+        .kbc_device = &keyboard_at_device,
+        .kbc_params = 0x00000000,
+        .kbc_p1 = 0x000004f0,
+        .gpio = 0xffffffff,
+        .gpio_acpi = 0xffffffff,
+        .device = NULL,
+        .fdc_device = NULL,
+        .sio_device = NULL,
+        .vid_device = NULL,
+        .snd_device = NULL,
+        .net_device = NULL
+    },
+
 #if defined(DEV_BRANCH) && defined(USE_OLIVETTI)
     /* Has Olivetti KBC firmware. */
     {

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -2994,7 +2994,7 @@ const machine_t machines[] = {
         .snd_device = NULL,
         .net_device = NULL
     },
-    /*Has custom Award firmware for Wells American*/
+    
 {
         .name = "[ISA] Wells American A*Star ",
         .internal_name = "wellamerastar",


### PR DESCRIPTION
Summary
=======
Wells American A*Star 286 IBM PC AT clone 6-14mhz w/ BIOS

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [X] This pull request requires changes to the ROM set
  * [X] I have opened a roms pull request - https://github.com/86Box/roms/pull/265

References
==========
my physical machine and a bunch of magazines on google books.

https://theretroweb.com/motherboards/s/wells-american-corporation-a-star-14mhz
