### PR TITLE
Initial support for the 8-bit NE2000 compatible boards.

### DIFF
--- a/src/include/86box/net_ne2000.h
+++ b/src/include/86box/net_ne2000.h
@@ -37,15 +37,17 @@
 #define NET_NE2000_H
 
 enum {
-    NE2K_NONE          = 0,
-    NE2K_NE1000        = 1, /* 8-bit ISA NE1000 */
-    NE2K_NE1000_COMPAT = 2, /* 8-bit ISA NE1000-Compatible */
-    NE2K_NE2000        = 3, /* 16-bit ISA NE2000 */
-    NE2K_NE2000_COMPAT = 4, /* 16-bit ISA NE2000-Compatible */
-    NE2K_ETHERNEXT_MC  = 5, /* 16-bit MCA EtherNext/MC */
-    NE2K_RTL8019AS     = 6, /* 16-bit ISA PnP Realtek 8019AS */
-    NE2K_DE220P        = 7, /* 16-bit ISA PnP D-Link DE-220P */
-    NE2K_RTL8029AS     = 8  /* 32-bit PCI Realtek 8029AS */
+    NE2K_NONE               = 0,
+    NE2K_NE1000             = 1, /* 8-bit ISA NE1000 */
+    NE2K_NE1000_COMPAT      = 2, /* 8-bit ISA NE1000-Compatible */
+    NE2K_NE2000             = 3, /* 16-bit ISA NE2000 */
+    NE2K_NE2000_COMPAT      = 4, /* 16-bit ISA NE2000-Compatible */
+    NE2K_NE2000_COMPAT_8BIT = 5, /* 8-bit ISA NE2000-Compatible, like: https://github.com/skiselev/isa8_eth */
+    NE2K_ETHERNEXT_MC       = 6, /* 16-bit MCA EtherNext/MC */
+    NE2K_RTL8019AS          = 7, /* 16-bit ISA PnP Realtek 8019AS */
+    NE2K_DE220P             = 8, /* 16-bit ISA PnP D-Link DE-220P */
+    NE2K_RTL8029AS          = 9, /* 32-bit PCI Realtek 8029AS */
+    /* Check nic_init() if adding items after this point. */
 };
 
 #endif /*NET_NE2000_H*/

--- a/src/include/86box/network.h
+++ b/src/include/86box/network.h
@@ -211,6 +211,7 @@ extern const device_t ne1000_device;
 extern const device_t ne1000_compat_device;
 extern const device_t ne2000_device;
 extern const device_t ne2000_compat_device;
+extern const device_t ne2000_compat_8bit_device;
 extern const device_t ethernext_mc_device;
 extern const device_t rtl8019as_device;
 extern const device_t de220p_device;

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -115,6 +115,7 @@ static const device_t *net_cards[] = {
     &de220p_device,
     &ne1000_compat_device,
     &ne2000_compat_device,
+    &ne2000_compat_8bit_device,
     &ne1000_device,
     &ne2000_device,
     &pcnet_am79c960_eb_device,


### PR DESCRIPTION
Summary
=======
Currently, the emulator allows only NE1000-like ethernet boards for the XT-class machines. However, a relatively popular modern 8-bit NE2000-compliant board exists[^OBP] https://github.com/skiselev/isa8_eth. 

[^OBP]: And, possibly, if not 8-bit, then 16-bit but 8-bit ISA-compatible NE2000-like boards existed -- I used at last one such board, which worked with more or less general packet driver named ne2000\.com. 

So I attempted to add ability to add 8-bit NE2000-compatible boards to the XT machines. It is a rather straightforward clone with minimal modifications of the NE2K_NE2000_COMPAT. I am using the board on the real hardware, in fact this code appeared due to recreating the Amstrad 1640 PC with this board in emulation. 

Tested basically in the SLiRP and PCap modes, using MTCP ftp, ftpsrv (transferred 50 Mb by small files), telnet, and ping utilities. 

![image](https://github.com/user-attachments/assets/3d588395-0c94-4da3-9394-79ba91db06dc)

It is my first attempt to contribute to the 86Box, so if it is feasible, please direct me to improve my pull to the project standards.

Checklist
=========

* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
Modern NE2000 compatible [ISA 8-Bit Ethernet Controller](https://github.com/skiselev/isa8_eth) implementation. Requires customized packet driver adapted to work with 8-bit ISA, [provided by the author](https://github.com/skiselev/isa8_eth/blob/main/software/driver).
