### PR TITLE
PVGA 256 col+ fixes (July 14th, 2024)

### DIFF
--- a/src/video/vid_paradise.c
+++ b/src/video/vid_paradise.c
@@ -364,7 +364,7 @@ paradise_write(uint32_t addr, uint8_t val, void *priv)
     addr = (addr & 0x7fff) + paradise->write_bank[(addr >> 15) & 3];
 
     /*Could be done in a better way but it works.*/
-    if (svga->gdcreg[0x0e] & 0x01) {
+    if ((svga->gdcreg[0x0e] & 0x01) || (svga->gdcreg[5] & 0x40)) {
         if (((svga->gdcreg[6] & 0x0c) == 0x04) && (svga->crtc[0x14] & 0x40) && ((svga->gdcreg[0x0b] & 0xc0) == 0xc0) && !svga->chain4) {
             prev_addr  = addr & 3;
             prev_addr2 = addr & 0xfffc;
@@ -401,7 +401,7 @@ paradise_writew(uint32_t addr, uint16_t val, void *priv)
     addr = (addr & 0x7fff) + paradise->write_bank[(addr >> 15) & 3];
 
     /*Could be done in a better way but it works.*/
-    if (svga->gdcreg[0x0e] & 0x01) {
+    if ((svga->gdcreg[0x0e] & 0x01) || (svga->gdcreg[5] & 0x40)) {
         if (((svga->gdcreg[6] & 0x0c) == 0x04) && (svga->crtc[0x14] & 0x40) && ((svga->gdcreg[0x0b] & 0xc0) == 0xc0) && !svga->chain4) {
             prev_addr  = addr & 3;
             prev_addr2 = addr & 0xfffc;
@@ -437,7 +437,7 @@ paradise_read(uint32_t addr, void *priv)
     addr = (addr & 0x7fff) + paradise->read_bank[(addr >> 15) & 3];
 
     /*Could be done in a better way but it works.*/
-    if (svga->gdcreg[0x0e] & 0x01) {
+    if ((svga->gdcreg[0x0e] & 0x01) || (svga->gdcreg[5] & 0x40)) {
         if (((svga->gdcreg[6] & 0x0c) == 0x04) && (svga->crtc[0x14] & 0x40) && ((svga->gdcreg[0x0b] & 0xc0) == 0xc0) && !svga->chain4) {
             prev_addr  = addr & 3;
             prev_addr2 = addr & 0xfffc;
@@ -472,7 +472,7 @@ paradise_readw(uint32_t addr, void *priv)
     addr = (addr & 0x7fff) + paradise->read_bank[(addr >> 15) & 3];
 
     /*Could be done in a better way but it works.*/
-    if (svga->gdcreg[0x0e] & 0x01) {
+    if ((svga->gdcreg[0x0e] & 0x01) || (svga->gdcreg[5] & 0x40)) { {
         if (((svga->gdcreg[6] & 0x0c) == 0x04) && (svga->crtc[0x14] & 0x40) && ((svga->gdcreg[0x0b] & 0xc0) == 0xc0) && !svga->chain4) {
             prev_addr  = addr & 3;
             prev_addr2 = addr & 0xfffc;


### PR DESCRIPTION
Summary
=======
Sometimes 256 color+ would still glitch because the generic way of enabling 8bpp mode is triggered instead. This fixes some stuff that relies on it.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
