### PR TITLE
SCSI and disk fixes (July 14th, 2024)

### DIFF
--- a/src/disk/mo.c
+++ b/src/disk/mo.c
@@ -701,7 +701,6 @@ mo_command_common(mo_t *dev)
 static void
 mo_command_complete(mo_t *dev)
 {
-    ui_sb_update_icon(SB_MO | dev->id, 0);
     dev->packet_status = PHASE_COMPLETE;
     mo_command_common(dev);
 }

--- a/src/disk/zip.c
+++ b/src/disk/zip.c
@@ -875,7 +875,6 @@ zip_command_common(zip_t *dev)
 static void
 zip_command_complete(zip_t *dev)
 {
-    ui_sb_update_icon(SB_ZIP | dev->id, 0);
     dev->packet_status = PHASE_COMPLETE;
     zip_command_common(dev);
 }

--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -393,14 +393,23 @@ MachineStatus::refreshIcons()
     }
     for (size_t i = 0; i < CDROM_NUM; ++i) {
         d->cdrom[i].setActive(machine_status.cdrom[i].active);
+        if (machine_status.cdrom[i].active)
+            ui_sb_update_icon(SB_CDROM | i, 0);
+
         d->cdrom[i].setEmpty(machine_status.cdrom[i].empty);
     }
     for (size_t i = 0; i < ZIP_NUM; i++) {
         d->zip[i].setActive(machine_status.zip[i].active);
+        if (machine_status.zip[i].active)
+            ui_sb_update_icon(SB_ZIP | i, 0);
+
         d->zip[i].setEmpty(machine_status.zip[i].empty);
     }
     for (size_t i = 0; i < MO_NUM; i++) {
         d->mo[i].setActive(machine_status.mo[i].active);
+        if (machine_status.mo[i].active)
+            ui_sb_update_icon(SB_MO | i, 0);
+
         d->mo[i].setEmpty(machine_status.mo[i].empty);
     }
 
@@ -408,6 +417,8 @@ MachineStatus::refreshIcons()
 
     for (size_t i = 0; i < HDD_BUS_USB; i++) {
         d->hdds[i].setActive(machine_status.hdd[i].active);
+        if (machine_status.hdd[i].active)
+            ui_sb_update_icon(SB_HDD | i, 0);
     }
 
     for (size_t i = 0; i < NET_CARD_MAX; i++) {

--- a/src/scsi/scsi_disk.c
+++ b/src/scsi/scsi_disk.c
@@ -461,7 +461,7 @@ scsi_disk_command_common(scsi_disk_t *dev)
                               (uint64_t) period);
                 dev->callback += period;
                 break;
-            default:    
+            default:
                 dev->callback = 0;
                 break;
         }
@@ -511,7 +511,6 @@ scsi_disk_command_common(scsi_disk_t *dev)
 static void
 scsi_disk_command_complete(scsi_disk_t *dev)
 {
-    ui_sb_update_icon(SB_HDD | dev->drv->bus, 0);
     dev->packet_status = PHASE_COMPLETE;
     scsi_disk_command_common(dev);
 }
@@ -1647,7 +1646,7 @@ scsi_disk_identify(ide_t *ide, int ide_has_dma)
     scsi_disk_log("ATAPI Identify: %s\n", device_identify);
 
     /* ATAPI device, direct-access device, non-removable media, accelerated DRQ */
-    ide->buffer[0] = 0x8000 | (0 << 8) | 0x00 | (2 << 5); 
+    ide->buffer[0] = 0x8000 | (0 << 8) | 0x00 | (2 << 5);
     ide_padstr((char *) (ide->buffer + 10), "", 20);          /* Serial Number */
 
     ide_padstr((char *) (ide->buffer + 23), EMU_VERSION_EX, 8);   /* Firmware */


### PR DESCRIPTION
Summary
=======
All: the icon refresh for the respective storage now works properly across all adapters that use it (especially the aha154x compatibles and spock/tribble).
SCSI CD-ROM: The Sony/Texel/DEC SCSI command 0xC0 (Set Address Format) isn't a command that checks for ready status, however, it is for other vendors like NEC, Matsushita, etc. and I am not wishing to create a duplicate command_flags array duplicate just for vendor unique commands. This fixes the MSF bit of Sony/Texel/DEC CD-ROM drives which don't use the Mode Page equivalent.
Toshiba only: attempt to mark the 3201B as a SCSI-1 only CD-ROM drive properly.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[Texel SCSI CD-ROM drive manual (same commands as Sony + 0xC0)](http://www.bitsavers.org/pdf/texel/Texel_DMxx28_CDROM_SCSI_V1_23_June_1993.pdf)
