### PR TITLE
Fix resid warnings, and also explicitly set the C++ version

### DIFF
--- a/src/sound/resid-fp/FilterModelConfig6581.cpp
+++ b/src/sound/resid-fp/FilterModelConfig6581.cpp
@@ -131,9 +131,9 @@ FilterModelConfig6581::FilterModelConfig6581() :
         vmax);
 #endif
 
-    #pragma omp parallel sections
+//    #pragma omp parallel sections
     {
-        #pragma omp section
+//        #pragma omp section
         {
 #ifdef _OPENMP
             OpAmp opampModel(
@@ -167,7 +167,7 @@ FilterModelConfig6581::FilterModelConfig6581() :
             }
         }
 
-        #pragma omp section
+//        #pragma omp section
         {
 #ifdef _OPENMP
             OpAmp opampModel(
@@ -199,7 +199,7 @@ FilterModelConfig6581::FilterModelConfig6581() :
             }
         }
 
-        #pragma omp section
+//        #pragma omp section
         {
 #ifdef _OPENMP
             OpAmp opampModel(
@@ -230,7 +230,7 @@ FilterModelConfig6581::FilterModelConfig6581() :
             }
         }
 
-        #pragma omp section
+//        #pragma omp section
         {
 #ifdef _OPENMP
             OpAmp opampModel(
@@ -261,7 +261,7 @@ FilterModelConfig6581::FilterModelConfig6581() :
             }
         }
 
-        #pragma omp section
+//        #pragma omp section
         {
             const double nVddt = N16 * (Vddt - vmin);
 
@@ -275,7 +275,7 @@ FilterModelConfig6581::FilterModelConfig6581() :
             }
         }
 
-        #pragma omp section
+//        #pragma omp section
         {
             //  EKV model:
             //

--- a/src/sound/resid-fp/FilterModelConfig8580.cpp
+++ b/src/sound/resid-fp/FilterModelConfig8580.cpp
@@ -143,9 +143,9 @@ FilterModelConfig8580::FilterModelConfig8580() :
         vmax);
 #endif
 
-    #pragma omp parallel sections
+//    #pragma omp parallel sections
     {
-        #pragma omp section
+//        #pragma omp section
         {
 #ifdef _OPENMP
             OpAmp opampModel(
@@ -179,7 +179,7 @@ FilterModelConfig8580::FilterModelConfig8580() :
             }
         }
 
-        #pragma omp section
+//        #pragma omp section
         {
 #ifdef _OPENMP
             OpAmp opampModel(
@@ -211,7 +211,7 @@ FilterModelConfig8580::FilterModelConfig8580() :
             }
         }
 
-        #pragma omp section
+//        #pragma omp section
         {
 #ifdef _OPENMP
             OpAmp opampModel(
@@ -242,7 +242,7 @@ FilterModelConfig8580::FilterModelConfig8580() :
             }
         }
 
-        #pragma omp section
+//        #pragma omp section
         {
 #ifdef _OPENMP
             OpAmp opampModel(

--- a/src/sound/resid-fp/WaveformCalculator.cpp
+++ b/src/sound/resid-fp/WaveformCalculator.cpp
@@ -68,15 +68,19 @@ static float exponentialDistance(float distance, int i)
     return pow(distance, -i);
 }
 
+#if 0
 MAYBE_UNUSED static float linearDistance(float distance, int i)
 {
     return 1.f / (1.f + i * distance);
 }
+#endif
 
+#if 0
 MAYBE_UNUSED static float quadraticDistance(float distance, int i)
 {
     return 1.f / (1.f + (i*i) * distance);
 }
+#endif
 
 /// Calculate triangle waveform
 static unsigned int triXor(unsigned int val)

--- a/src/sound/resid-fp/config.h
+++ b/src/sound/resid-fp/config.h
@@ -1,0 +1,1 @@
+#define HAVE_CXX14


### PR DESCRIPTION
Summary
=======
Fix resid warnings, and also explicitly set the C++ version

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
