### PR TITLE
residfp: Fix unused variable warnings with Clang

### DIFF
--- a/src/sound/resid-fp/WaveformGenerator.cpp
+++ b/src/sound/resid-fp/WaveformGenerator.cpp
@@ -43,7 +43,7 @@ namespace reSIDfp
 const unsigned int FLOATING_OUTPUT_TTL_6581R3  =   54000;
 const unsigned int FLOATING_OUTPUT_FADE_6581R3 =    1400;
 // ~1s
-const unsigned int FLOATING_OUTPUT_TTL_6581R4  = 1000000;
+//const unsigned int FLOATING_OUTPUT_TTL_6581R4  = 1000000;
 // ~1s
 const unsigned int FLOATING_OUTPUT_TTL_8580R5  =  800000;
 const unsigned int FLOATING_OUTPUT_FADE_8580R5 =   50000;
@@ -61,7 +61,7 @@ const unsigned int FLOATING_OUTPUT_FADE_8580R5 =   50000;
 const unsigned int SHIFT_REGISTER_RESET_6581R3 =   50000;
 const unsigned int SHIFT_REGISTER_FADE_6581R3  =   15000;
 // ~2.15s
-const unsigned int SHIFT_REGISTER_RESET_6581R4 = 2150000;
+//const unsigned int SHIFT_REGISTER_RESET_6581R4 = 2150000;
 // ~2.8s
 const unsigned int SHIFT_REGISTER_RESET_8580R5 =  986000;
 const unsigned int SHIFT_REGISTER_FADE_8580R5  =  314300;


### PR DESCRIPTION
Summary
=======
Title.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A