### PR TITLE
opti499.c: Remove an unneeded call to free()

### DIFF
--- a/src/chipset/opti499.c
+++ b/src/chipset/opti499.c
@@ -226,8 +226,6 @@ opti499_reset(void *priv)
     cpu_update_waitstates();
 
     opti499_recalc(dev);
-
-    free(dev);
 }
 
 static void


### PR DESCRIPTION
Summary
=======
Title. Fixes an use after free() warning.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A
