### PR TITLE
Mark plat_vidapi() argument as const and remove the NULL

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1720,7 +1720,7 @@ save_general(void)
     char          temp[512];
     char          buffer[512] = { 0 };
 
-    const char *va_name = NULL;
+    const char *va_name;
 
     ini_section_set_int(cat, "vid_resize", vid_resize);
     if (vid_resize == 0)

--- a/src/include/86box/plat.h
+++ b/src/include/86box/plat.h
@@ -153,7 +153,7 @@ extern uint32_t plat_get_ticks(void);
 extern void     plat_delay_ms(uint32_t count);
 extern void     plat_pause(int p);
 extern void     plat_mouse_capture(int on);
-extern int      plat_vidapi(char *name);
+extern int      plat_vidapi(const char *name);
 extern char    *plat_vidapi_name(int api);
 extern void     plat_resize(int x, int y, int monitor_index);
 extern void     plat_resize_request(int x, int y, int monitor_index);

--- a/src/qt/qt.c
+++ b/src/qt/qt.c
@@ -38,7 +38,7 @@ qt_nvr_save(void)
 char icon_set[256] = ""; /* name of the iconset to be used */
 
 int
-plat_vidapi(char *api)
+plat_vidapi(const char *api)
 {
     if (!strcasecmp(api, "default") || !strcasecmp(api, "system")) {
         return 0;

--- a/src/unix/unix_sdl.c
+++ b/src/unix/unix_sdl.c
@@ -392,7 +392,7 @@ sdl_reload(void)
 }
 
 int
-plat_vidapi(char *api)
+plat_vidapi(UNUSED(const char *api))
 {
     return 0;
 }


### PR DESCRIPTION
## Summary
* plat_vidapi() accepts char pointer, which never gets modifed later on. Mark it as const.

* In src/config.c, va_name is initialized as NULL, however, plat_vidapi_name() never returns a NULL pointer, nor it was initialized under a condition branch. Removing NULL, might save one instruction, which requires zeroing the register before setting its initial value.

## Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/