### PR TITLE
Adding SMT3 Format Hexadecimal to Microtouch driver

### DIFF
--- a/src/device/mouse_microtouch_touchscreen.c
+++ b/src/device/mouse_microtouch_touchscreen.c
@@ -40,7 +40,7 @@
 enum mtouch_modes {
     MODE_TABLET = 1,
     MODE_RAW    = 2,
-	MODE_HEX    = 3
+    MODE_HEX    = 3
 };
 
 typedef struct mouse_microtouch_t {
@@ -94,69 +94,69 @@ microtouch_process_commands(mouse_microtouch_t *mtouch)
     for (i = 0; i < strlen(mtouch->cmd); i++) {
         mtouch->cmd[i] = toupper(mtouch->cmd[i]);
     }
-    if (mtouch->cmd[0] == 'Z') { // Null
+    if (mtouch->cmd[0] == 'Z') { /* Null */
         fifo8_push(&mtouch->resp, 1);
         fifo8_push_all(&mtouch->resp, (uint8_t *) "0\r", 2);
     }
-    if (mtouch->cmd[0] == 'F' && mtouch->cmd[1] == 'O') { // Finger Only
+    if (mtouch->cmd[0] == 'F' && mtouch->cmd[1] == 'O') { /* Finger Only */
         mtouch->pen_mode = 1;
         fifo8_push(&mtouch->resp, 1);
         fifo8_push_all(&mtouch->resp, (uint8_t *) "0\r", 2);
     }
-    if (mtouch->cmd[0] == 'U' && mtouch->cmd[1] == 'T') { // Unit Type
+    if (mtouch->cmd[0] == 'U' && mtouch->cmd[1] == 'T') { /* Unit Type */
         fifo8_push(&mtouch->resp, 1);
         fifo8_push_all(&mtouch->resp, (uint8_t *) "TP****00\r", sizeof("TP****00\r") - 1);
     }
-    if (mtouch->cmd[0] == 'O' && mtouch->cmd[1] == 'I') { // Output Identity
+    if (mtouch->cmd[0] == 'O' && mtouch->cmd[1] == 'I') { /* Output Identity */
         fifo8_push(&mtouch->resp, 1);
         fifo8_push_all(&mtouch->resp, (uint8_t *) "P50200\r", sizeof("P50200\r") - 1);
     }
-    if (mtouch->cmd[0] == 'F' && mtouch->cmd[1] == 'T') { // Format Tablet
+    if (mtouch->cmd[0] == 'F' && mtouch->cmd[1] == 'T') { /* Format Tablet */
         mtouch->mode = MODE_TABLET;
         fifo8_push(&mtouch->resp, 1);
         fifo8_push_all(&mtouch->resp, (uint8_t *) "0\r", 2);
     }
-	if (mtouch->cmd[0] == 'F' && mtouch->cmd[1] == 'H') { // Format Hexadecimal
-		mtouch->mode = MODE_HEX;
+    if (mtouch->cmd[0] == 'F' && mtouch->cmd[1] == 'H') { /* Format Hexadecimal */
+        mtouch->mode = MODE_HEX;
         fifo8_push(&mtouch->resp, 1);
         fifo8_push_all(&mtouch->resp, (uint8_t *)"0\r", 2);
     }
-    if (mtouch->cmd[0] == 'F' && mtouch->cmd[1] == 'R') { // Format Raw
+    if (mtouch->cmd[0] == 'F' && mtouch->cmd[1] == 'R') { /* Format Raw */
         mtouch->mode     = MODE_RAW;
         mtouch->cal_cntr = 0;
         fifo8_push(&mtouch->resp, 1);
         fifo8_push_all(&mtouch->resp, (uint8_t *) "0\r", 2);
     }
-    if (mtouch->cmd[0] == 'M' && mtouch->cmd[1] == 'S') { // Mode Stream
+    if (mtouch->cmd[0] == 'M' && mtouch->cmd[1] == 'S') { /* Mode Stream */
         fifo8_push(&mtouch->resp, 1);
         fifo8_push_all(&mtouch->resp, (uint8_t *) "0\r", 2);
     }
-    if (mtouch->cmd[0] == 'R') { // Reset
+    if (mtouch->cmd[0] == 'R') { /* Reset */
         mtouch->in_reset = true;
         mtouch->mode     = MODE_TABLET;
         mtouch->cal_cntr = 0;
         mtouch->pen_mode = 3;
         timer_on_auto(&mtouch->reset_timer, 500. * 1000.);
     }
-    if (mtouch->cmd[0] == 'A' && (mtouch->cmd[1] == 'D' || mtouch->cmd[1] == 'E')) { // Autobaud Enable/Disable
+    if (mtouch->cmd[0] == 'A' && (mtouch->cmd[1] == 'D' || mtouch->cmd[1] == 'E')) { /* Autobaud Enable/Disable */
         fifo8_push(&mtouch->resp, 1);
         fifo8_push_all(&mtouch->resp, (uint8_t *) "0\r", 2);
     }
-    if (mtouch->cmd[0] == 'N' && mtouch->cmd[1] == 'M') { // ??
+    if (mtouch->cmd[0] == 'N' && mtouch->cmd[1] == 'M') { /* ?? */
         fifo8_push(&mtouch->resp, 1);
         fifo8_push_all(&mtouch->resp, (uint8_t *) "1\r", 2);
     }
-    if (mtouch->cmd[0] == 'F' && mtouch->cmd[1] == 'Q') { // ??
+    if (mtouch->cmd[0] == 'F' && mtouch->cmd[1] == 'Q') { /* ?? */
         fifo8_push(&mtouch->resp, 1);
         fifo8_push_all(&mtouch->resp, (uint8_t *) "1\r", 2);
     }
-    if (mtouch->cmd[0] == 'G' && mtouch->cmd[1] == 'F') { // ??
+    if (mtouch->cmd[0] == 'G' && mtouch->cmd[1] == 'F') { /* ?? */
         fifo8_push(&mtouch->resp, 1);
         fifo8_push_all(&mtouch->resp, (uint8_t *) "1\r", 2);
     }
     if (mtouch->cmd[0] == 'P') {
-        if (mtouch->cmd[1] == 'F') mtouch->pen_mode = 3;      // Pen or Finger
-        else if (mtouch->cmd[1] == 'O') mtouch->pen_mode = 2; // Pen Only
+        if (mtouch->cmd[1] == 'F') mtouch->pen_mode = 3;      /* Pen or Finger */
+        else if (mtouch->cmd[1] == 'O') mtouch->pen_mode = 2; /* Pen Only */
         fifo8_push(&mtouch->resp, 1);
         fifo8_push_all(&mtouch->resp, (uint8_t *) "0\r", 2);
     }
@@ -225,18 +225,18 @@ static int
 mtouch_poll(void *priv)
 {
     mouse_microtouch_t *dev = (mouse_microtouch_t *) priv;
-	
-	if (fifo8_num_free(&dev->resp) <= 10 || dev->mode == MODE_RAW) {
-		return 0;
-	}
-	
-	unsigned int abs_x_int = 0, abs_y_int = 0;
+    
+    if (fifo8_num_free(&dev->resp) <= 10 || dev->mode == MODE_RAW) {
+        return 0;
+    }
+    
+    unsigned int abs_x_int = 0, abs_y_int = 0;
     double       abs_x;
     double       abs_y;
     int          b = mouse_get_buttons_ex();
 
     mouse_get_abs_coords(&abs_x, &abs_y);
-    dev->b |= !!(b & 3); // any button pressed
+    dev->b |= !!(b & 3); /* any button pressed */
     
     if (abs_x >= 1.0)
         abs_x = 1.0;
@@ -280,7 +280,7 @@ mtouch_poll(void *priv)
         if (dev->cal_cntr) {
             return 0;
         }
-        if (!!(b & 3)) { // Hover
+        if (!!(b & 3)) { /* Hover */
             dev->abs_x = abs_x;
             dev->abs_y = abs_y;
             dev->b |= 1;
@@ -293,7 +293,7 @@ mtouch_poll(void *priv)
             fifo8_push(&dev->resp, (abs_x_int >> 7) & 0b1111111);
             fifo8_push(&dev->resp, abs_y_int & 0b1111111);
             fifo8_push(&dev->resp, (abs_y_int >> 7) & 0b1111111);
-        } else if ((dev->b & 1) && !(b & 3)) { // Touch
+        } else if ((dev->b & 1) && !(b & 3)) { /* Touch */
             dev->b &= ~1;
             abs_x_int = dev->abs_x * 16383;
             abs_y_int = 16383 - dev->abs_y * 16383;
@@ -309,27 +309,27 @@ mtouch_poll(void *priv)
             fifo8_push(&dev->resp, (abs_y_int >> 7) & 0b1111111);
         }
     }
-	
+    
     else if (dev->mode == MODE_HEX) {
         abs_x_int = abs_x * 1023;
         abs_y_int = 1023 - (abs_y * 1023);
         char buffer[20];
         
-		if (dev->cal_cntr && !b && dev->prev_b) { 
+        if (dev->cal_cntr && !b && dev->prev_b) { 
             microtouch_calibrate_timer(dev);
-        }		
+        }
         else if (b & 1) {
-            if (dev->prev_b == 0) { // Touchdown
+            if (dev->prev_b == 0) { /* Touchdown */
                 snprintf(buffer, sizeof(buffer), "\x19%03X,%03X\r", abs_x_int, abs_y_int);
-            } else { // Touch Continuation
+            } else { /* Touch Continuation */
                 snprintf(buffer, sizeof(buffer), "\x1c%03X,%03X\r", abs_x_int, abs_y_int);
             }
             fifo8_push_all(&dev->resp, (uint8_t *)buffer, strlen(buffer));
-        } else if (dev->prev_b == 1) { // Liftoff
+        } else if (dev->prev_b == 1) { /* Liftoff */
             snprintf(buffer, sizeof(buffer), "\x18%03X,%03X\r", abs_x_int, abs_y_int);
             fifo8_push_all(&dev->resp, (uint8_t *)buffer, strlen(buffer));
         }
-		dev->prev_b = b & 1;
+        dev->prev_b = b & 1;
     }
     return 0;
 }


### PR DESCRIPTION
Summary
=======
This driver was originally started as SMT3 by Cacodemon345, but later changed to Touchpen 4 as that variant dropped most legacy output formats so less had to be implemented. This PR implements SMT3 legacy Format Hexadecimal, which is needed to play Funworld Photo Play 2000 software.

The original Format Tablet code does some interesting bit checking with b and dev->b, which makes the calibration routine give replies so fast after CX, that it confuses the Photo Play software. For format hex I have added simpler mouse button check, and let the calibration routine run after a mouse button release. Maybe Cacodemon345 can tell if the original behavior was intended, or we can simplify Format Tablet the same way?

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
Reference: https://www.touchwindow.com/mm5/drivers/mtsctlrm.pdf
