### PR TITLE
Updated description of Microtouch Emulation

### DIFF
--- a/src/device/mouse_microtouch_touchscreen.c
+++ b/src/device/mouse_microtouch_touchscreen.c
@@ -10,7 +10,7 @@
  *
  *
  *
- * Authors: Cacodemon345
+ * Authors: Cacodemon345, mourix
  *
  *          Copyright 2024 Cacodemon345
  */
@@ -415,7 +415,7 @@ static const device_config_t mtouch_config[] = {
 };
 
 const device_t mouse_mtouch_device = {
-    .name          = "3M MicroTouch TouchPen 4",
+    .name          = "3M MicroTouch (Serial)",
     .internal_name = "microtouch_touchpen",
     .flags         = DEVICE_COM,
     .local         = 0,


### PR DESCRIPTION
Summary
=======
As it now emulates more protocols than the TouchPen, I figured it'd be better defined as just 3M Microtouch (as it now does part of SMT3(V) and TouchPen 4

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========

