### PR TITLE
Add support for wave files in cue sheets using libsnd

### DIFF
--- a/src/cdrom/CMakeLists.txt
+++ b/src/cdrom/CMakeLists.txt
@@ -13,4 +13,13 @@
 #          Copyright 2020-2021 David Hrdlička.
 #
 
+find_package(PkgConfig REQUIRED)
+
+pkg_check_modules(SNDFILE REQUIRED IMPORTED_TARGET sndfile)
+
 add_library(cdrom OBJECT cdrom.c cdrom_image_backend.c cdrom_image_viso.c cdrom_image.c cdrom_ioctl.c cdrom_mitsumi.c)
+target_link_libraries(86Box PkgConfig::SNDFILE)
+if (WIN32)
+    # MSYS2
+    target_link_libraries(86Box -static ${SNDFILE_STATIC_LIBRARIES})
+endif()

--- a/src/cdrom/cdrom_image.c
+++ b/src/cdrom/cdrom_image.c
@@ -294,7 +294,6 @@ cdrom_image_open(cdrom_t *dev, const char *fn)
         dev->cd_status = CD_STATUS_DATA_ONLY;
     else
         dev->cd_status = CD_STATUS_STOPPED;
-    dev->is_dir         = (i == 3);
     dev->seek_pos       = 0;
     dev->cd_buflen      = 0;
     dev->cdrom_capacity = image_get_capacity(dev);

--- a/src/cdrom/cdrom_image_backend.c
+++ b/src/cdrom/cdrom_image_backend.c
@@ -14,10 +14,12 @@
  * Authors: Miran Grca, <mgrca8@gmail.com>
  *          Fred N. van Kempen, <decwiz@yahoo.com>
  *          The DOSBox Team, <unknown>
+ *          Cacodemon345
  *
  *          Copyright 2016-2020 Miran Grca.
  *          Copyright 2017-2020 Fred N. van Kempen.
  *          Copyright 2002-2020 The DOSBox Team.
+ *          Copyright 2024 Cacodemon345.
  */
 #define __STDC_FORMAT_MACROS
 #include <ctype.h>
@@ -39,6 +41,8 @@
 #include <86box/path.h>
 #include <86box/plat.h>
 #include <86box/cdrom_image_backend.h>
+
+#include <sndfile.h>
 
 #define CDROM_BCD(x)        (((x) % 10) | (((x) / 10) << 4))
 
@@ -66,13 +70,109 @@ cdrom_image_backend_log(const char *fmt, ...)
 #    define cdrom_image_backend_log(fmt, ...)
 #endif
 
+typedef struct audio_file_t {
+    SNDFILE *file;
+    SF_INFO  info;
+} audio_file_t;
+
+/* Audio file functions */
+static int
+audio_read(void *priv, uint8_t *buffer, uint64_t seek, size_t count)
+{
+    track_file_t *tf            = (track_file_t *) priv;
+    audio_file_t *audio         = (audio_file_t *) tf->priv;
+    uint64_t      samples_seek  = seek / 4;
+    uint64_t      samples_count = count / 4;
+
+    if ((seek & 3) || (count & 3)) {
+        cdrom_image_backend_log("CD Audio file: Reading on non-4-aligned boundaries.\n");
+    }
+
+    sf_count_t res = sf_seek(audio->file, samples_seek, SEEK_SET);
+
+    if (res == -1)
+        return 0;
+
+    return !!sf_readf_short(audio->file, (short *) buffer, samples_count);
+}
+
+static uint64_t
+audio_get_length(void *priv)
+{
+    track_file_t *tf    = (track_file_t *) priv;
+    audio_file_t *audio = (audio_file_t *) tf->priv;
+
+    /* Assume 16-bit audio, 2 channel. */
+    return audio->info.frames * 4ull;
+}
+
+static void
+audio_close(void *priv)
+{
+    track_file_t *tf    = (track_file_t *) priv;
+    audio_file_t *audio = (audio_file_t *) tf->priv;
+
+    memset(tf->fn, 0x00, sizeof(tf->fn));
+    if (audio && audio->file)
+        sf_close(audio->file);
+    free(audio);
+    free(tf);
+}
+
+static track_file_t *
+audio_init(const char *filename, int *error)
+{
+    track_file_t *tf    = (track_file_t *) calloc(sizeof(track_file_t), 1);
+    audio_file_t *audio = (audio_file_t *) calloc(sizeof(audio_file_t), 1);
+#ifdef _WIN32
+    wchar_t filename_w[4096];
+#endif
+
+    if (tf == NULL || audio == NULL) {
+        goto cleanup_error;
+    }
+
+    memset(tf->fn, 0x00, sizeof(tf->fn));
+    strncpy(tf->fn, filename, sizeof(tf->fn) - 1);
+#ifdef _WIN32
+    mbstowcs(filename_w, filename, 4096);
+    audio->file = sf_wchar_open(filename_w, SFM_READ, &audio->info);
+#else
+    audio->file = sf_open(filename, SFM_READ, &audio->info);
+#endif
+
+    if (!audio->file) {
+        cdrom_image_backend_log("Audio file open error!");
+        goto cleanup_error;
+    }
+
+    if (audio->info.channels != 2 || audio->info.samplerate != 44100 || !audio->info.seekable) {
+        cdrom_image_backend_log("Audio file not seekable or in non-CD format!");
+        sf_close(audio->file);
+        goto cleanup_error;
+    }
+
+    *error         = 0;
+    tf->priv       = audio;
+    tf->fp         = NULL;
+    tf->close      = audio_close;
+    tf->get_length = audio_get_length;
+    tf->read       = audio_read;
+    return tf;
+cleanup_error:
+    free(tf);
+    free(audio);
+    *error = 1;
+    return NULL;
+}
+
 /* Binary file functions. */
 static int
 bin_read(void *priv, uint8_t *buffer, uint64_t seek, size_t count)
 {
     track_file_t *tf;
 
-    cdrom_image_backend_log("CDROM: binary_read(%08lx, pos=%" PRIu64 " count=%lu\n",
+    cdrom_image_backend_log("CDROM: binary_read(%08lx, pos=%" PRIu64 " count=%lu)\n",
                             tf->fp, seek, count);
 
     if ((tf = (track_file_t *) priv)->fp == NULL)
@@ -90,6 +190,15 @@ bin_read(void *priv, uint8_t *buffer, uint64_t seek, size_t count)
         cdrom_image_backend_log("CDROM: binary_read failed during read!\n");
 #endif
         return 0;
+    }
+
+    if (UNLIKELY(tf->motorola)) {
+        for (uint64_t i = 0; i < count; i += 2) {
+            uint8_t buffer0 = buffer[i];
+            uint8_t buffer1 = buffer[i + 1];
+            buffer[i] = buffer1;
+            buffer[i + 1] = buffer0;
+        }
     }
 
     return 1;
@@ -279,11 +388,10 @@ int
 cdi_get_audio_track_info(cd_img_t *cdi, UNUSED(int end), int track, int *track_num, TMSF *start, uint8_t *attr)
 {
     const track_t *trk = &cdi->tracks[track - 1];
+    const int      pos = trk->start + 150;
 
     if ((track < 1) || (track > cdi->tracks_num))
         return 0;
-
-    const int pos      = trk->start + 150;
 
     FRAMES_TO_MSF(pos, &start->min, &start->sec, &start->fr);
 
@@ -360,20 +468,20 @@ cdi_read_sector(cd_img_t *cdi, uint8_t *buffer, int raw, uint32_t sector)
 {
     const int      track = cdi_get_track(cdi, sector) - 1;
     const uint64_t sect  = (uint64_t) sector;
-    int      raw_size;
-    int      cooked_size;
-    uint64_t offset;
-    int      m = 0;
-    int      s = 0;
-    int      f = 0;
+    int            raw_size;
+    int            cooked_size;
+    uint64_t       offset;
+    int            m = 0;
+    int            s = 0;
+    int            f = 0;
 
     if (track < 0)
         return 0;
 
-    const track_t *trk     = &cdi->tracks[track];
-    const int track_is_raw = ((trk->sector_size == RAW_SECTOR_SIZE) || (trk->sector_size == 2448));
+    const track_t *trk          = &cdi->tracks[track];
+    const int      track_is_raw = ((trk->sector_size == RAW_SECTOR_SIZE) || (trk->sector_size == 2448));
 
-    const uint64_t seek    = trk->skip + ((sect - trk->start) * trk->sector_size);
+    const uint64_t seek         = trk->skip + ((sect - trk->start) * trk->sector_size);
 
     if (track_is_raw)
         raw_size = trk->sector_size;
@@ -420,13 +528,13 @@ cdi_read_sector(cd_img_t *cdi, uint8_t *buffer, int raw, uint32_t sector)
 int
 cdi_read_sectors(cd_img_t *cdi, uint8_t *buffer, int raw, uint32_t sector, uint32_t num)
 {
-    int      success = 1;
+    int success = 1;
 
     /* TODO: This fails to account for Mode 2. Shouldn't we have a function
              to get sector size? */
-    const int       sector_size = raw ? RAW_SECTOR_SIZE : COOKED_SECTOR_SIZE;
-    const uint32_t  buf_len     = num * sector_size;
-    uint8_t        *buf         = (uint8_t *) malloc(buf_len * sizeof(uint8_t));
+    const int      sector_size = raw ? RAW_SECTOR_SIZE : COOKED_SECTOR_SIZE;
+    const uint32_t buf_len     = num * sector_size;
+    uint8_t       *buf         = (uint8_t *) malloc(buf_len * sizeof(uint8_t));
 
     for (uint32_t i = 0; i < num; i++) {
         success = cdi_read_sector(cdi, &buf[i * sector_size], raw, sector + i);
@@ -434,9 +542,7 @@ cdi_read_sectors(cd_img_t *cdi, uint8_t *buffer, int raw, uint32_t sector, uint3
             break;
         /* Based on the DOSBox patch, but check all 8 bytes and makes sure it's not an
            audio track. */
-        if (raw && (sector < cdi->tracks[0].length) &&
-            !cdi->tracks[0].mode2 && (cdi->tracks[0].attr != AUDIO_TRACK) &&
-            *(uint64_t *) &(buf[(i * sector_size) + 2068]))
+        if (raw && (sector < cdi->tracks[0].length) && !cdi->tracks[0].mode2 && (cdi->tracks[0].attr != AUDIO_TRACK) && *(uint64_t *) &(buf[(i * sector_size) + 2068]))
             return 0;
     }
 
@@ -538,80 +644,93 @@ cdi_track_push_back(cd_img_t *cdi, track_t *trk)
 }
 
 int
+cdi_get_iso_track(cd_img_t *cdi, track_t *trk, const char *filename)
+{
+    int error;
+    int ret = 2;
+    memset(trk, 0, sizeof(track_t));
+
+    /* Data track (shouldn't there be a lead in track?). */
+    trk->file = bin_init(filename, &error);
+    if (error) {
+        if ((trk->file != NULL) && (trk->file->close != NULL))
+            trk->file->close(trk->file);
+        ret       = 3;
+        trk->file = viso_init(filename, &error);
+        if (error) {
+            if ((trk->file != NULL) && (trk->file->close != NULL))
+                trk->file->close(trk->file);
+            return 0;
+        }
+    }
+    trk->number       = 1;
+    trk->track_number = 1;
+    trk->attr         = DATA_TRACK;
+
+    /* Try to detect ISO type. */
+    trk->form  = 0;
+    trk->mode2 = 0;
+
+    if (cdi_can_read_pvd(trk->file, RAW_SECTOR_SIZE, 0, 0))
+        trk->sector_size = RAW_SECTOR_SIZE;
+    else if (cdi_can_read_pvd(trk->file, 2336, 1, 0)) {
+        trk->sector_size = 2336;
+        trk->mode2       = 1;
+    } else if (cdi_can_read_pvd(trk->file, 2324, 1, 2)) {
+        trk->sector_size = 2324;
+        trk->mode2       = 1;
+        trk->form        = 2;
+        trk->noskip      = 1;
+    } else if (cdi_can_read_pvd(trk->file, 2328, 1, 2)) {
+        trk->sector_size = 2328;
+        trk->mode2       = 1;
+        trk->form        = 2;
+        trk->noskip      = 1;
+    } else if (cdi_can_read_pvd(trk->file, 2336, 1, 1)) {
+        trk->sector_size = 2336;
+        trk->mode2       = 1;
+        trk->form        = 1;
+        trk->skip        = 8;
+    } else if (cdi_can_read_pvd(trk->file, RAW_SECTOR_SIZE, 1, 0)) {
+        trk->sector_size = RAW_SECTOR_SIZE;
+        trk->mode2       = 1;
+    } else if (cdi_can_read_pvd(trk->file, RAW_SECTOR_SIZE, 1, 1)) {
+        trk->sector_size = RAW_SECTOR_SIZE;
+        trk->mode2       = 1;
+        trk->form        = 1;
+    } else {
+        /* We use 2048 mode 1 as the default. */
+        trk->sector_size = COOKED_SECTOR_SIZE;
+    }
+
+    trk->length = trk->file->get_length(trk->file) / trk->sector_size;
+    cdrom_image_backend_log("ISO: Data track: length = %" PRIu64 ", sector_size = %i\n", trk->length, trk->sector_size);
+    return ret;
+}
+
+int
 cdi_load_iso(cd_img_t *cdi, const char *filename)
 {
-    int     error;
     int     ret = 2;
     track_t trk;
 
     cdi->tracks     = NULL;
     cdi->tracks_num = 0;
 
-    memset(&trk, 0, sizeof(track_t));
+    ret = cdi_get_iso_track(cdi, &trk, filename);
 
-    /* Data track (shouldn't there be a lead in track?). */
-    trk.file = bin_init(filename, &error);
-    if (error) {
-        if ((trk.file != NULL) && (trk.file->close != NULL))
-            trk.file->close(trk.file);
-        ret      = 3;
-        trk.file = viso_init(filename, &error);
-        if (error) {
-            if ((trk.file != NULL) && (trk.file->close != NULL))
-                trk.file->close(trk.file);
-            return 0;
-        }
+    if (ret >= 1) {
+        cdi_track_push_back(cdi, &trk);
+
+        /* Lead out track. */
+        trk.number       = 2;
+        trk.track_number = 0xAA;
+        trk.attr         = 0x16; /* Was originally 0x00, but I believe 0x16 is appropriate. */
+        trk.start        = trk.length;
+        trk.length       = 0;
+        trk.file         = NULL;
+        cdi_track_push_back(cdi, &trk);
     }
-    trk.number       = 1;
-    trk.track_number = 1;
-    trk.attr         = DATA_TRACK;
-
-    /* Try to detect ISO type. */
-    trk.form  = 0;
-    trk.mode2 = 0;
-
-    if (cdi_can_read_pvd(trk.file, RAW_SECTOR_SIZE, 0, 0))
-        trk.sector_size = RAW_SECTOR_SIZE;
-    else if (cdi_can_read_pvd(trk.file, 2336, 1, 0)) {
-        trk.sector_size = 2336;
-        trk.mode2       = 1;
-    } else if (cdi_can_read_pvd(trk.file, 2324, 1, 2)) {
-        trk.sector_size = 2324;
-        trk.mode2       = 1;
-        trk.form        = 2;
-    } else if (cdi_can_read_pvd(trk.file, 2328, 1, 2)) {
-        trk.sector_size = 2328;
-        trk.mode2       = 1;
-        trk.form        = 2;
-    } else if (cdi_can_read_pvd(trk.file, 2336, 1, 1)) {
-        trk.sector_size = 2336;
-        trk.mode2       = 1;
-        trk.form        = 1;
-        trk.skip        = 8;
-    } else if (cdi_can_read_pvd(trk.file, RAW_SECTOR_SIZE, 1, 0)) {
-        trk.sector_size = RAW_SECTOR_SIZE;
-        trk.mode2       = 1;
-    } else if (cdi_can_read_pvd(trk.file, RAW_SECTOR_SIZE, 1, 1)) {
-        trk.sector_size = RAW_SECTOR_SIZE;
-        trk.mode2       = 1;
-        trk.form        = 1;
-    } else {
-        /* We use 2048 mode 1 as the default. */
-        trk.sector_size = COOKED_SECTOR_SIZE;
-    }
-
-    trk.length = trk.file->get_length(trk.file) / trk.sector_size;
-    cdrom_image_backend_log("ISO: Data track: length = %" PRIu64 ", sector_size = %i\n", trk.length, trk.sector_size);
-    cdi_track_push_back(cdi, &trk);
-
-    /* Lead out track. */
-    trk.number       = 2;
-    trk.track_number = 0xAA;
-    trk.attr         = 0x16; /* Was originally 0x00, but I believe 0x16 is appropriate. */
-    trk.start        = trk.length;
-    trk.length       = 0;
-    trk.file         = NULL;
-    cdi_track_push_back(cdi, &trk);
 
     return ret;
 }
@@ -704,7 +823,7 @@ cdi_cue_get_frame(uint64_t *frames, char **line)
     char temp[128];
     int  min = 0;
     int  sec = 0;
-    int  fr = 0;
+    int  fr  = 0;
     int  success;
 
     success = cdi_cue_get_buffer(temp, line, 0);
@@ -765,7 +884,7 @@ cdi_add_track(cd_img_t *cdi, track_t *cur, uint64_t *shift, uint64_t prestart, u
         if (cur->number != 1)
             return 0;
         cur->skip = skip * cur->sector_size;
-        if ((cur->sector_size != RAW_SECTOR_SIZE) && (cur->form > 0))
+        if ((cur->sector_size != RAW_SECTOR_SIZE) && (cur->form > 0) && !cur->noskip)
             cur->skip += 8;
         cur->start += cur_pregap;
         *total_pregap = cur_pregap;
@@ -782,14 +901,14 @@ cdi_add_track(cd_img_t *cdi, track_t *cur, uint64_t *shift, uint64_t prestart, u
         cur->start += *total_pregap;
     } else {
         const uint64_t temp = prev->file->get_length(prev->file) - (prev->skip);
-        prev->length = temp / ((uint64_t) prev->sector_size);
+        prev->length        = temp / ((uint64_t) prev->sector_size);
         if ((temp % prev->sector_size) != 0)
             prev->length++;
         /* Padding. */
 
         cur->start += prev->start + prev->length + cur_pregap;
         cur->skip = skip * cur->sector_size;
-        if ((cur->sector_size != RAW_SECTOR_SIZE) && (cur->form > 0))
+        if ((cur->sector_size != RAW_SECTOR_SIZE) && (cur->form > 0) && !cur->noskip)
             cur->skip += 8;
         *shift += prev->start + prev->length;
         *total_pregap = cur_pregap;
@@ -813,12 +932,13 @@ cdi_load_cue(cd_img_t *cdi, const char *cuefile)
 {
     track_t  trk;
     char     pathname[MAX_FILENAME_LENGTH];
-    uint64_t shift = 0ULL;
-    uint64_t prestart = 0ULL;
-    uint64_t cur_pregap = 0ULL;
+    uint64_t shift        = 0ULL;
+    uint64_t prestart     = 0ULL;
+    uint64_t cur_pregap   = 0ULL;
     uint64_t total_pregap = 0ULL;
-    uint64_t frame = 0ULL;
+    uint64_t frame        = 0ULL;
     uint64_t index;
+    int      iso_file_used = 0;
     int      success;
     int      error;
     int      can_add_track = 0;
@@ -874,82 +994,97 @@ cdi_load_cue(cd_img_t *cdi, const char *cuefile)
             if (!success)
                 break;
 
-            trk.start  = 0;
-            trk.skip   = 0;
-            cur_pregap = 0;
-            prestart   = 0;
+            if (iso_file_used) {
+                /* We don't alter anything of the detected track type with the one specified in the CUE file, except its numbers. */
+                cur_pregap = 0;
+                prestart   = 0;
 
-            trk.number       = cdi_cue_get_number(&line);
-            trk.track_number = trk.number;
-            success          = cdi_cue_get_keyword(&type, &line);
-            if (!success)
-                break;
+                trk.number       = cdi_cue_get_number(&line);
+                trk.track_number = trk.number;
+                success          = cdi_cue_get_keyword(&type, &line);
+                if (!success)
+                    break;
+                can_add_track = 1;
 
-            trk.form  = 0;
-            trk.mode2 = 0;
+                iso_file_used = 0;
+            } else {
+                trk.start  = 0;
+                trk.skip   = 0;
+                cur_pregap = 0;
+                prestart   = 0;
 
-            trk.pre = 0;
+                trk.number       = cdi_cue_get_number(&line);
+                trk.track_number = trk.number;
+                success          = cdi_cue_get_keyword(&type, &line);
+                if (!success)
+                    break;
 
-            if (!strcmp(type, "AUDIO")) {
-                trk.sector_size = RAW_SECTOR_SIZE;
-                trk.attr        = AUDIO_TRACK;
-            } else if (!strcmp(type, "MODE1/2048")) {
-                trk.sector_size = COOKED_SECTOR_SIZE;
-                trk.attr        = DATA_TRACK;
-            } else if (!strcmp(type, "MODE1/2352")) {
-                trk.sector_size = RAW_SECTOR_SIZE;
-                trk.attr        = DATA_TRACK;
-            } else if (!strcmp(type, "MODE1/2448")) {
-                trk.sector_size = 2448;
-                trk.attr        = DATA_TRACK;
-            } else if (!strcmp(type, "MODE2/2048")) {
-                trk.form        = 1;
-                trk.sector_size = COOKED_SECTOR_SIZE;
-                trk.attr        = DATA_TRACK;
-                trk.mode2       = 1;
-            } else if (!strcmp(type, "MODE2/2324")) {
-                trk.form        = 2;
-                trk.sector_size = 2324;
-                trk.attr        = DATA_TRACK;
-                trk.mode2       = 1;
-            } else if (!strcmp(type, "MODE2/2328")) {
-                trk.form        = 2;
-                trk.sector_size = 2328;
-                trk.attr        = DATA_TRACK;
-                trk.mode2       = 1;
-            } else if (!strcmp(type, "MODE2/2336")) {
-                trk.form        = 1;
-                trk.sector_size = 2336;
-                trk.attr        = DATA_TRACK;
-                trk.mode2       = 1;
-            } else if (!strcmp(type, "MODE2/2352")) {
-                /* Assume this is XA Mode 2 Form 1. */
-                trk.form        = 1;
-                trk.sector_size = RAW_SECTOR_SIZE;
-                trk.attr        = DATA_TRACK;
-                trk.mode2       = 1;
-            } else if (!strcmp(type, "MODE2/2448")) {
-                /* Assume this is XA Mode 2 Form 1. */
-                trk.form        = 1;
-                trk.sector_size = 2448;
-                trk.attr        = DATA_TRACK;
-                trk.mode2       = 1;
-            } else if (!strcmp(type, "CDG/2448")) {
-                trk.sector_size = 2448;
-                trk.attr        = DATA_TRACK;
-                trk.mode2       = 1;
-            } else if (!strcmp(type, "CDI/2336")) {
-                trk.sector_size = 2336;
-                trk.attr        = DATA_TRACK;
-                trk.mode2       = 1;
-            } else if (!strcmp(type, "CDI/2352")) {
-                trk.sector_size = RAW_SECTOR_SIZE;
-                trk.attr        = DATA_TRACK;
-                trk.mode2       = 1;
-            } else
-                success = 0;
+                trk.form  = 0;
+                trk.mode2 = 0;
 
-            can_add_track = 1;
+                trk.pre = 0;
+
+                if (!strcmp(type, "AUDIO")) {
+                    trk.sector_size = RAW_SECTOR_SIZE;
+                    trk.attr        = AUDIO_TRACK;
+                } else if (!strcmp(type, "MODE1/2048")) {
+                    trk.sector_size = COOKED_SECTOR_SIZE;
+                    trk.attr        = DATA_TRACK;
+                } else if (!strcmp(type, "MODE1/2352")) {
+                    trk.sector_size = RAW_SECTOR_SIZE;
+                    trk.attr        = DATA_TRACK;
+                } else if (!strcmp(type, "MODE1/2448")) {
+                    trk.sector_size = 2448;
+                    trk.attr        = DATA_TRACK;
+                } else if (!strcmp(type, "MODE2/2048")) {
+                    trk.form        = 1;
+                    trk.sector_size = COOKED_SECTOR_SIZE;
+                    trk.attr        = DATA_TRACK;
+                    trk.mode2       = 1;
+                } else if (!strcmp(type, "MODE2/2324")) {
+                    trk.form        = 2;
+                    trk.sector_size = 2324;
+                    trk.attr        = DATA_TRACK;
+                    trk.mode2       = 1;
+                } else if (!strcmp(type, "MODE2/2328")) {
+                    trk.form        = 2;
+                    trk.sector_size = 2328;
+                    trk.attr        = DATA_TRACK;
+                    trk.mode2       = 1;
+                } else if (!strcmp(type, "MODE2/2336")) {
+                    trk.form        = 1;
+                    trk.sector_size = 2336;
+                    trk.attr        = DATA_TRACK;
+                    trk.mode2       = 1;
+                } else if (!strcmp(type, "MODE2/2352")) {
+                    /* Assume this is XA Mode 2 Form 1. */
+                    trk.form        = 1;
+                    trk.sector_size = RAW_SECTOR_SIZE;
+                    trk.attr        = DATA_TRACK;
+                    trk.mode2       = 1;
+                } else if (!strcmp(type, "MODE2/2448")) {
+                    /* Assume this is XA Mode 2 Form 1. */
+                    trk.form        = 1;
+                    trk.sector_size = 2448;
+                    trk.attr        = DATA_TRACK;
+                    trk.mode2       = 1;
+                } else if (!strcmp(type, "CDG/2448")) {
+                    trk.sector_size = 2448;
+                    trk.attr        = DATA_TRACK;
+                    trk.mode2       = 1;
+                } else if (!strcmp(type, "CDI/2336")) {
+                    trk.sector_size = 2336;
+                    trk.attr        = DATA_TRACK;
+                    trk.mode2       = 1;
+                } else if (!strcmp(type, "CDI/2352")) {
+                    trk.sector_size = RAW_SECTOR_SIZE;
+                    trk.attr        = DATA_TRACK;
+                    trk.mode2       = 1;
+                } else
+                    success = 0;
+
+                can_add_track = 1;
+            }
         } else if (!strcmp(command, "INDEX")) {
             index   = cdi_cue_get_number(&line);
             success = cdi_cue_get_frame(&frame, &line);
@@ -968,8 +1103,8 @@ cdi_load_cue(cd_img_t *cdi, const char *cuefile)
                     break;
             }
         } else if (!strcmp(command, "FILE")) {
-            char     filename[MAX_FILENAME_LENGTH];
-            char     ansi[MAX_FILENAME_LENGTH];
+            char filename[MAX_FILENAME_LENGTH];
+            char ansi[MAX_FILENAME_LENGTH];
 
             if (can_add_track)
                 success = cdi_add_track(cdi, &trk, &shift, prestart, &total_pregap, cur_pregap);
@@ -992,13 +1127,40 @@ cdi_load_cue(cd_img_t *cdi, const char *cuefile)
             trk.file = NULL;
             error    = 1;
 
-            if (!strcmp(type, "BINARY")) {
-                path_append_filename(filename, pathname, ansi);
-                trk.file = track_file_init(filename, &error);
+            if (!strcmp(type, "BINARY") || !strcmp(type, "MOTOROLA")) {
+                int fn_len = 0;
+                if (!path_abs(ansi)) {
+                    path_append_filename(filename, pathname, ansi);
+                } else {
+                    strcpy(filename, ansi);
+                }
+                fn_len = strlen(filename);
+                if ((tolower((int) filename[fn_len - 1]) == 'o'
+                    && tolower((int) filename[fn_len - 2]) == 's'
+                    && tolower((int) filename[fn_len - 3]) == 'i'
+                    && filename[fn_len - 4] == '.')
+                    || plat_dir_check(filename)) {
+                    error = !cdi_get_iso_track(cdi, &trk, filename);
+                    if (!error) {
+                        iso_file_used = 1;
+                    }
+                } else
+                    trk.file = track_file_init(filename, &error);
+                
+                if (trk.file) {
+                    trk.file->motorola = !strcmp(type, "MOTOROLA");
+                }
+            } else if (!strcmp(type, "WAVE") || !strcmp(type, "AIFF") || !strcmp(type, "MP3")) {
+                if (!path_abs(ansi)) {
+                    path_append_filename(filename, pathname, ansi);
+                } else {
+                    strcpy(filename, ansi);
+                }
+                trk.file = audio_init(filename, &error);
             }
             if (error) {
 #ifdef ENABLE_CDROM_IMAGE_BACKEND_LOG
-                cdrom_image_backend_log("CUE: cannot open fille '%s' in cue sheet!\n",
+                cdrom_image_backend_log("CUE: cannot open file '%s' in cue sheet!\n",
                                         filename);
 #endif
                 if (trk.file != NULL) {
@@ -1067,7 +1229,7 @@ cdi_has_audio_track(cd_img_t *cdi)
     if ((cdi == NULL) || (cdi->tracks == NULL))
         return 0;
 
-    /* Audio track has attribute 0x14. */
+    /* Audio track has attribute 0x10. */
     for (int i = 0; i < cdi->tracks_num; i++) {
         if (cdi->tracks[i].attr == AUDIO_TRACK)
             return 1;

--- a/src/cdrom/cdrom_ioctl.c
+++ b/src/cdrom/cdrom_ioctl.c
@@ -254,7 +254,6 @@ cdrom_ioctl_open(cdrom_t *dev, const char *drv)
 
     /* All good, reset state. */
     dev->cd_status      = CD_STATUS_STOPPED;
-    dev->is_dir         = 0;
     dev->seek_pos       = 0;
     dev->cd_buflen      = 0;
     dev->cdrom_capacity = ioctl_get_capacity(dev);

--- a/src/include/86box/cdrom.h
+++ b/src/include/86box/cdrom.h
@@ -226,7 +226,6 @@ typedef struct cdrom {
     uint8_t speed;
     uint8_t cur_speed;
 
-    int   is_dir;
     void *priv;
 
     char image_path[1024];

--- a/src/include/86box/cdrom_image_backend.h
+++ b/src/include/86box/cdrom_image_backend.h
@@ -53,6 +53,8 @@ typedef struct track_file_t {
     char  fn[260];
     FILE *fp;
     void *priv;
+
+    int motorola;
 } track_file_t;
 
 typedef struct track_t {
@@ -63,7 +65,7 @@ typedef struct track_t {
     int           mode2;
     int           form;
     int           pre;
-    int           pad;
+    int           noskip; /* Do not skip by 8 bytes.*/
     uint64_t      start;
     uint64_t      length;
     uint64_t      skip;

--- a/src/qt/qt_settingsfloppycdrom.cpp
+++ b/src/qt/qt_settingsfloppycdrom.cpp
@@ -218,7 +218,6 @@ SettingsFloppyCDROM::save()
     /* Removable devices category */
     model = ui->tableViewCDROM->model();
     for (int i = 0; i < CDROM_NUM; i++) {
-        cdrom[i].is_dir = 0;
         cdrom[i].priv = NULL;
         cdrom[i].ops = NULL;
         cdrom[i].image = NULL;


### PR DESCRIPTION
Summary
=======
Add support for wave files in cue sheets using libsnd.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
