### PR TITLE
Remove dead code in scsi_ncr5380.h

### DIFF
--- a/src/include/86box/scsi_ncr5380.h
+++ b/src/include/86box/scsi_ncr5380.h
@@ -138,9 +138,6 @@ extern const device_t scsi_t128_device;
 extern const device_t scsi_t228_device;
 extern const device_t scsi_t130b_device;
 extern const device_t scsi_ls2000_device;
-#if defined(DEV_BRANCH) && defined(USE_SUMO)
-extern const device_t scsi_scsiat_device;
-#endif
 #endif
 
 #endif /*SCSI_NCR5380_H*/


### PR DESCRIPTION
Summary
=======
Remove dead code in scsi_ncr5380.h

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
