### PR TITLE
Microtouch: add option to turn off visible mouse crosshair

### DIFF
--- a/src/device/mouse_microtouch_touchscreen.c
+++ b/src/device/mouse_microtouch_touchscreen.c
@@ -341,7 +341,7 @@ mtouch_init(const device_t *info)
     timer_on_auto(&dev->host_to_serial_timer, (1000000. / dev->baud_rate) * 10);
     dev->mode        = MODE_TABLET;
     dev->pen_mode    = 3;
-    mouse_input_mode = 1;
+    mouse_input_mode = device_get_config_int("crosshair") + 1;
     mouse_set_buttons(2);
     mouse_set_poll_ex(mtouch_poll_global);
 
@@ -397,6 +397,13 @@ static const device_config_t mtouch_config[] = {
             { .description =   "2400", .value =   2400 },
             { .description =   "1200", .value =   1200 }
         }
+    },
+    {
+        .name = "crosshair",
+        .description = "Show Crosshair",
+        .type = CONFIG_BINARY,
+        .default_string = "",
+        .default_int = 1
     },
     { .name = "", .description = "", .type = CONFIG_END }
   // clang-format on

--- a/src/include/86box/mouse.h
+++ b/src/include/86box/mouse.h
@@ -50,7 +50,7 @@ extern "C" {
 #endif
 
 extern int    mouse_type;
-extern int    mouse_input_mode; /* 1 = Absolute, 0 = Relative */
+extern int    mouse_input_mode; /* 2 = Absolute (Visible Crosshair), 1 = Absolute, 0 = Relative */
 extern int    mouse_timed; /* 1 = Timed, 0 = Constant */
 extern int    mouse_tablet_in_proximity;
 extern double mouse_x_abs;

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -251,6 +251,8 @@ RendererStack::enterEvent(QEvent *event)
     mousedata.mouse_tablet_in_proximity = m_monitor_index + 1;
 
     if (mouse_input_mode == 1)
+        QApplication::setOverrideCursor(Qt::BlankCursor);
+    else if (mouse_input_mode == 2)
         QApplication::setOverrideCursor(Qt::CrossCursor);
 }
 


### PR DESCRIPTION
Summary
=======
In 86Box 4.1, the mouse cursor was disabled in relative input mode, then used by wacom_tablet device only. Cacodemon345 changed this to a crosshair cursor for the Microtouch driver. This PR restores the old default behavior, but adds an option for the Microtouch device to enable or disable the crosshair.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
