### PR TITLE
Miscellaneous UI fixes

### DIFF
--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -741,6 +741,9 @@ msgstr "T"
 msgid "S"
 msgstr "S"
 
+msgid "MiB"
+msgstr "Mio"
+
 msgid "KB"
 msgstr "Ko"
 

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -831,6 +831,9 @@ msgstr "H"
 msgid "S"
 msgstr "S"
 
+msgid "MiB"
+msgstr "МиБ"
+
 msgid "KB"
 msgstr "КБ"
 

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -741,6 +741,9 @@ msgstr "H"
 msgid "S"
 msgstr "S"
 
+msgid "MiB"
+msgstr "МіБ"
+
 msgid "KB"
 msgstr "КБ"
 

--- a/src/qt/qt_deviceconfig.cpp
+++ b/src/qt/qt_deviceconfig.cpp
@@ -298,7 +298,7 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                 int   currentIndex  = 0;
                 auto  serialDevices = EnumerateSerialDevices();
 
-                Models::AddEntry(model, "None", -1);
+                Models::AddEntry(model, tr("None"), -1);
                 for (int i = 0; i < serialDevices.size(); i++) {
                     const int row = Models::AddEntry(model, serialDevices[i], i);
                     if (selected == serialDevices[i])
@@ -401,7 +401,7 @@ DeviceConfig::ConfigureDevice(const _device_ *device, int instance, Settings *se
                     {
                         auto *cbox = dc.findChild<QComboBox *>(config->name);
                         auto  path = cbox->currentText().toUtf8();
-                        if (path == "None")
+                        if (cbox->currentData().toInt() == -1)
                             path = "";
                         config_set_string(device_context.name, const_cast<char *>(config->name), path);
                         break;

--- a/src/qt/qt_joystickconfiguration.cpp
+++ b/src/qt/qt_joystickconfiguration.cpp
@@ -36,7 +36,7 @@ JoystickConfiguration::JoystickConfiguration(int type, int joystick_nr, QWidget 
     ui->setupUi(this);
 
     auto model = ui->comboBoxDevice->model();
-    Models::AddEntry(model, "None", 0);
+    Models::AddEntry(model, tr("None"), 0);
     for (int c = 0; c < joysticks_present; c++) {
         Models::AddEntry(model, plat_joystick_state[c].name, c + 1);
     }
@@ -114,8 +114,8 @@ JoystickConfiguration::on_comboBoxDevice_currentIndexChanged(int index)
         }
 
         for (int d = 0; d < plat_joystick_state[joystick].nr_povs; d++) {
-            Models::AddEntry(model, QString("%1 (X axis)").arg(plat_joystick_state[joystick].pov[d].name), 0);
-            Models::AddEntry(model, QString("%1 (Y axis)").arg(plat_joystick_state[joystick].pov[d].name), 0);
+            Models::AddEntry(model, tr("%1 (X axis)").arg(plat_joystick_state[joystick].pov[d].name), 0);
+            Models::AddEntry(model, tr("%1 (Y axis)").arg(plat_joystick_state[joystick].pov[d].name), 0);
         }
 
         int nr_axes = plat_joystick_state[joystick].nr_axes;
@@ -161,9 +161,9 @@ JoystickConfiguration::on_comboBoxDevice_currentIndexChanged(int index)
     for (int c = 0; c < joystick_get_pov_count(type) * 2; c++) {
         QLabel *label;
         if (c & 1) {
-            label = new QLabel(QString("%1 (Y axis)").arg(joystick_get_pov_name(type, c / 2)), this);
+            label = new QLabel(tr("%1 (Y axis)").arg(joystick_get_pov_name(type, c / 2)), this);
         } else {
-            label = new QLabel(QString("%1 (X axis)").arg(joystick_get_pov_name(type, c / 2)), this);
+            label = new QLabel(tr("%1 (X axis)").arg(joystick_get_pov_name(type, c / 2)), this);
         }
         auto cbox = new QComboBox(this);
         cbox->setObjectName(QString("cboxPov%1").arg(QString::number(c)));
@@ -171,8 +171,8 @@ JoystickConfiguration::on_comboBoxDevice_currentIndexChanged(int index)
         auto model = cbox->model();
 
         for (int d = 0; d < plat_joystick_state[joystick].nr_povs; d++) {
-            Models::AddEntry(model, QString("%1 (X axis)").arg(plat_joystick_state[joystick].pov[d].name), 0);
-            Models::AddEntry(model, QString("%1 (Y axis)").arg(plat_joystick_state[joystick].pov[d].name), 0);
+            Models::AddEntry(model, tr("%1 (X axis)").arg(plat_joystick_state[joystick].pov[d].name), 0);
+            Models::AddEntry(model, tr("%1 (Y axis)").arg(plat_joystick_state[joystick].pov[d].name), 0);
         }
 
         for (int d = 0; d < plat_joystick_state[joystick].nr_axes; d++) {

--- a/src/qt/qt_progsettings.cpp
+++ b/src/qt/qt_progsettings.cpp
@@ -159,16 +159,18 @@ ProgSettings::on_pushButton_released()
 QString
 ProgSettings::getFontName(uint32_t lcid)
 {
-        if (lcid == 0x0804) /* zh-CN */
-            return "Microsoft YaHei";
-        else if (lcid == 0x0404) /* zh-TW */
+    switch (lcid) {
+        case 0x0404: /* zh-TW */
             return "Microsoft JhengHei";
-        else if (lcid == 0x0411) /* ja-JP */
+        case 0x0411: /* ja-JP */
             return "Meiryo UI";
-        else if (lcid == 0x0412) /* ko-KR */
+        case 0x0412: /* ko-KR */
             return "Malgun Gothic";
-        else
+        case 0x0804: /* zh-CN */
+            return "Microsoft YaHei";
+        default:
             return "Segoe UI";
+    }
 }
 #endif
 

--- a/src/qt/qt_settingsmachine.cpp
+++ b/src/qt/qt_settingsmachine.cpp
@@ -301,7 +301,7 @@ SettingsMachine::on_comboBoxSpeed_currentIndexChanged(int index)
         for (const char *fpuName = fpu_get_name_from_index(cpuFamily, cpuId, i);
              fpuName != nullptr; fpuName = fpu_get_name_from_index(cpuFamily, cpuId, ++i)) {
             auto fpuType = fpu_get_type_from_index(cpuFamily, cpuId, i);
-            Models::AddEntry(modelFpu, QString("%1").arg(fpuName), fpuType);
+            Models::AddEntry(modelFpu, tr(QString("%1").arg(fpuName).toUtf8().data()), fpuType);
             if (fpu_type == fpuType)
                 selectedFpuRow = i;
         }


### PR DESCRIPTION
Summary
=======
- Fix the "None" option not being translated in several places (FPU selection, host joystick selection, host serial port selection for serial passthrough)
- Make "POV # (X/Y axis)" translatable
- Add translations for "MiB" in the HDD table header for languages that require it

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A