### PR TITLE
Microtouch: add controller type selection and start adding legacy modes for them

### DIFF
--- a/src/device/mouse_microtouch_touchscreen.c
+++ b/src/device/mouse_microtouch_touchscreen.c
@@ -108,7 +108,7 @@ microtouch_process_commands(mouse_microtouch_t *mtouch)
     }
     if (mtouch->cmd[0] == 'O' && mtouch->cmd[1] == 'I') { /* Output Identity */
         fifo8_push(&mtouch->resp, 1);
-        fifo8_push_all(&mtouch->resp, (uint8_t *) "P50200\r", sizeof("P50200\r") - 1);
+        fifo8_push_all(&mtouch->resp, (uint8_t *) "A30600\r", sizeof("A30600\r") - 1);
     }
     if (mtouch->cmd[0] == 'F' && mtouch->cmd[1] == 'T') { /* Format Tablet */
         mtouch->mode = MODE_TABLET;
@@ -176,8 +176,10 @@ microtouch_process_commands(mouse_microtouch_t *mtouch)
         fifo8_push(&mtouch->resp, 1);
         fifo8_push_all(&mtouch->resp, (uint8_t *) "A\r", 2);
     }
-    if (fifo8_num_used(&mtouch->resp) != fifo_used) {
-        pclog("Command received: %s\n", mtouch->cmd);
+    if (fifo8_num_used(&mtouch->resp) != fifo_used || mtouch->in_reset) {
+        pclog("Command handled: %s\n", mtouch->cmd);
+    } else {
+        pclog("Command ignored: %s\n", mtouch->cmd);
     }
 }
 
@@ -216,6 +218,7 @@ mtouch_write(serial_t *serial, void *priv, uint8_t data)
             dev->cmd[dev->cmd_pos++] = data;
         } else {
             dev->cmd[dev->cmd_pos++] = data;
+            dev->soh = 0;
             microtouch_process_commands(dev);
         }
     }

--- a/src/device/mouse_microtouch_touchscreen.c
+++ b/src/device/mouse_microtouch_touchscreen.c
@@ -48,8 +48,8 @@ enum mtouch_formats {
 
 const char* mtouch_identity[] = {
     "A30100", /* SMT2 Serial / SMT3(R)V */
-    "A40100", /* PC Bus SMT2 */
-    "P50100", /* TouchPen 4 (+) */
+    "A40100", /* SMT2 PCBus */
+    "P50100", /* TouchPen 4(+) */
     "Q10100", /* SMT3(R) Serial */
 };
 
@@ -176,7 +176,7 @@ microtouch_process_commands(mouse_microtouch_t *mtouch)
     }
     if (mtouch->cmd[0] == 'G' && mtouch->cmd[1] == 'P' && mtouch->cmd[2] == '1') { /* Get Parameter Block 1 */
         mt_fifo8_puts(&mtouch->resp, "A");
-        mt_fifo8_puts(&mtouch->resp, "0000000000000000000000000");
+        fifo8_push_all(&mtouch->resp, (uint8_t *) "0000000000000000000000000\r", sizeof("0000000000000000000000000\r") - 1);
         mt_fifo8_puts(&mtouch->resp, "0");
     }
     if (mtouch->cmd[0] == 'S' && mtouch->cmd[1] == 'P' && mtouch->cmd[2] == '1') { /* Set Parameter Block 1 */
@@ -282,7 +282,7 @@ mtouch_poll(void *priv)
         if (!b && dev->b) {
             microtouch_calibrate_timer(dev);
         }
-        dev->b = b; /* Save lack of buttonpress */
+        dev->b = b; /* Save buttonpress */
         return 0;
     }
     

--- a/src/device/mouse_microtouch_touchscreen.c
+++ b/src/device/mouse_microtouch_touchscreen.c
@@ -330,11 +330,6 @@ mtouch_poll(void *priv)
             fifo8_push(&dev->resp, abs_y_int & 0b1111111);
             fifo8_push(&dev->resp, (abs_y_int >> 7) & 0b1111111);
         } else if (dev->b) { /* Liftoff */
-            fifo8_push(&dev->resp, 0b11000000 | ((dev->pen_mode == 2) ? ((1 << 5)) : 0));
-            fifo8_push(&dev->resp, abs_x_int & 0b1111111);
-            fifo8_push(&dev->resp, (abs_x_int >> 7) & 0b1111111);
-            fifo8_push(&dev->resp, abs_y_int & 0b1111111);
-            fifo8_push(&dev->resp, (abs_y_int >> 7) & 0b1111111);
             fifo8_push(&dev->resp, 0b10000000 | ((dev->pen_mode == 2) ? ((1 << 5)) : 0));
             fifo8_push(&dev->resp, abs_x_int & 0b1111111);
             fifo8_push(&dev->resp, (abs_x_int >> 7) & 0b1111111);

--- a/src/device/mouse_microtouch_touchscreen.c
+++ b/src/device/mouse_microtouch_touchscreen.c
@@ -20,7 +20,8 @@
 /* TODO:
     - Properly implement GP/SP commands (formats are not documented at all, like anywhere; no dumps yet).
     - Dynamic baud rate selection from software following this.
-    - Add additional SMT2/3 commands plus config option for controller type.
+    - Add additional SMT2/3 formats as we currently only support Tablet, Hex and Dec.
+    - Add additional SMT2/3 modes as we currently hardcode Mode Stream + Mode Status.
 */
 #include <ctype.h>
 #include <stdint.h>


### PR DESCRIPTION
Summary
=======
Microtouch:
- Add menu option to select between the four available Microtouch controller identities.
- Add format Decimal.
- Have identities boot up in the right default modes.
- Fix SOH flag not being reset after packets.
- Optimize format Hexadecimal.
- Update TODO and rename variables for format to build a foundation to implement modes later.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
www.touchwindow.com/mm5/drivers/mtsctlrm.pdf
