### PR TITLE
Microtouch: serial fixes, poll rate increases, mode status, cleanups

### DIFF
--- a/src/device/mouse_microtouch_touchscreen.c
+++ b/src/device/mouse_microtouch_touchscreen.c
@@ -109,7 +109,7 @@ microtouch_process_commands(mouse_microtouch_t *mtouch)
     if (mtouch->cmd[0] == 'A' && (mtouch->cmd[1] == 'D' || mtouch->cmd[1] == 'E')) { /* Autobaud Enable/Disable */
         mt_fifo8_puts(&mtouch->resp, "0");
     }
-	if (mtouch->cmd[0] == 'C' && (mtouch->cmd[1] == 'N' || mtouch->cmd[1] == 'X')) { /* Calibrate New/Extended */
+    if (mtouch->cmd[0] == 'C' && (mtouch->cmd[1] == 'N' || mtouch->cmd[1] == 'X')) { /* Calibrate New/Extended */
         mt_fifo8_puts(&mtouch->resp, "0");
         mtouch->cal_cntr = 2;
     }
@@ -118,7 +118,7 @@ microtouch_process_commands(mouse_microtouch_t *mtouch)
         mtouch->format = FORMAT_DEC;
         mt_fifo8_puts(&mtouch->resp, "0");
     }
-	if (mtouch->cmd[0] == 'F' && mtouch->cmd[1] == 'N') { /* Filter Number */
+    if (mtouch->cmd[0] == 'F' && mtouch->cmd[1] == 'N') { /* Filter Number */
         mt_fifo8_puts(&mtouch->resp, "0");
     }
     if (mtouch->cmd[0] == 'F' && mtouch->cmd[1] == 'O') { /* Finger Only */
@@ -196,10 +196,10 @@ microtouch_process_commands(mouse_microtouch_t *mtouch)
     if (mtouch->cmd[0] == 'S' && mtouch->cmd[1] == 'P' && mtouch->cmd[2] == '1') { /* Set Parameter Block 1 */
         mt_fifo8_puts(&mtouch->resp, "A");
     }
-	if (mtouch->cmd[0] == 'U' && mtouch->cmd[1] == 'T') { /* Unit Type */
+    if (mtouch->cmd[0] == 'U' && mtouch->cmd[1] == 'T') { /* Unit Type */
         mt_fifo8_puts(&mtouch->resp, "TP****00");
     }
-	if (mtouch->cmd[0] == 'Z') { /* Null */
+    if (mtouch->cmd[0] == 'Z') { /* Null */
         mt_fifo8_puts(&mtouch->resp, "0");
     }
     if (fifo8_num_used(&mtouch->resp) != fifo_used || mtouch->in_reset) {
@@ -230,7 +230,7 @@ mtouch_write_to_host(void *priv)
     }
 
 no_write_to_machine:
-    timer_on_auto(&dev->host_to_serial_timer, (1000000.0 / (double) 9600.0) * (double) (1 + 8 + 1));
+    timer_on_auto(&dev->host_to_serial_timer, (1000000.0 / (double) dev->baud_rate) * (double) (1 + 8 + 1));
 }
 
 void
@@ -415,9 +415,9 @@ mtouch_init(const device_t *info)
     mouse_input_mode = device_get_config_int("crosshair") + 1;
     mouse_set_buttons(2);
     mouse_set_poll_ex(mtouch_poll_global);
-
+    
     mtouch_inst = dev;
-
+    
     return dev;
 }
 
@@ -430,7 +430,7 @@ mtouch_close(void *priv)
     /* Detach serial port from the mouse. */
     if (dev && dev->serial && dev->serial->sd)
         memset(dev->serial->sd, 0, sizeof(serial_device_t));
-
+    
     free(dev);
     mtouch_inst = NULL;
 }

--- a/src/device/mouse_microtouch_touchscreen.c
+++ b/src/device/mouse_microtouch_touchscreen.c
@@ -356,6 +356,10 @@ mtouch_init(const device_t *info)
 
     dev->serial = serial_attach(device_get_config_int("port"), NULL, mtouch_write, dev);
     dev->baud_rate = device_get_config_int("baudrate");
+    serial_set_cts(dev->serial, 1);
+    serial_set_dsr(dev->serial, 1);
+    serial_set_dcd(dev->serial, 1);
+    
     fifo8_create(&dev->resp, 512);
     timer_add(&dev->host_to_serial_timer, mtouch_write_to_host, dev, 0);
     timer_add(&dev->reset_timer, microtouch_reset_complete, dev, 0);


### PR DESCRIPTION
Summary
=======
- Set CTS/DSR/DCD high like a real Microtouch so linux drivers don't hang anymore.
- Implement Mode Status for Format Hex/Dec, making the default modes like the real thing.
- Change fifo sizes and behavior to not feed a serial port that just opened with 500 bytes of click data.
- Add a few more empty command responses. Set unknown commands to reply back with 0 instead of 1. Sort alphabetically.
- Currently, the mouse poll interrupt creates serial packets. The old code did so at 100Hz. The real Microtouch sends data as fast as it can do over the serial port, making the rate different per mode. The future solution is to decouple the data generation from the mouse polling, but for now I've set the poll rate to the approximate speed the different modes need as a workaround.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/