### PR TITLE
SCSI fixes of the day (August 8th, 2024)

### DIFF
--- a/src/scsi/scsi_cdrom.c
+++ b/src/scsi/scsi_cdrom.c
@@ -1724,9 +1724,6 @@ scsi_cdrom_request_sense(scsi_cdrom_t *dev, uint8_t *buffer, uint8_t alloc_lengt
            that condition. */
         dev->unit_attention = 0;
     }
-
-    /* Clear the sense stuff as per the spec. */
-    scsi_cdrom_sense_clear(dev, GPCMD_REQUEST_SENSE);
 }
 
 void
@@ -1841,6 +1838,10 @@ scsi_cdrom_command(scsi_common_t *sc, uint8_t *cdb)
         return;
 
 begin:
+    if (cdb[0] != GPCMD_REQUEST_SENSE) {
+        /* Clear the sense stuff as per the spec. */
+        scsi_cdrom_sense_clear(dev, cdb[0]);
+    }
     switch (cdb[0]) {
         case GPCMD_TEST_UNIT_READY:
             scsi_cdrom_set_phase(dev, SCSI_PHASE_STATUS);

--- a/src/scsi/scsi_pcscsi.c
+++ b/src/scsi/scsi_pcscsi.c
@@ -545,10 +545,6 @@ esp_do_command_phase(esp_t *dev)
         esp_log("ESP SCSI Start reading/writing\n");
         esp_do_dma(dev);
     } else {
-        if (dev->mca && (buf[0] == 0x43) && (sd->phase == SCSI_PHASE_STATUS)) {
-            esp_set_phase(dev, STAT_DI);
-            scsi_device_command_phase1(sd);
-        }
         esp_log("ESP SCSI Command with no length\n");
         esp_command_complete(dev, sd->status);
     }


### PR DESCRIPTION
Summary
=======
SCSI CD-ROM: request sense command should preserve its sense data unless a different command is issued, fixes DOS hanging with a blinking cursor using CDSCSI-2.sys for the 53c9x MCA card when there's no CD inside, making its no length Data In hack no longer needed.


Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[SCSI-2 specification, page 112 of the PDF](http://www.bitsavers.org/components/ncr_symbios/scsi/SCSI-2_Standard_1994.pdf)
