### PR TITLE
S3 changes (and TVP3026) of the day (August 15th, 2024)

### DIFF
--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -3965,6 +3965,17 @@ s3_recalctimings(svga_t *svga)
                         svga->dots_per_clock = (svga->dots_per_clock << 1) / 3;
                         break;
 
+                    case S3_VISION968:
+                        switch (s3->card_type) {
+                            case S3_MIROVIDEO40SV_ERGO_968:
+                                svga->hdisp = (svga->hdisp / 3) << 2;
+                                svga->dots_per_clock = (svga->hdisp / 3) << 2;
+                                break;
+                            default:
+                                break;
+                        }
+                        break;
+
                     case S3_TRIO64:
                     case S3_TRIO32:
                         svga->hdisp /= 3;

--- a/src/video/vid_tvp3026_ramdac.c
+++ b/src/video/vid_tvp3026_ramdac.c
@@ -516,7 +516,7 @@ tvp3026_recalctimings(void *priv, svga_t *svga)
 
     svga->interlace = !!(ramdac->ccr & 0x40);
     /* TODO: Figure out gamma correction for 15/16 bpp color. */
-    svga->lut_map = !!(svga->bpp >= 15 && (ramdac->true_color & 0xf0) != 0x00);
+    svga->lut_map = !!((svga->bpp >= 15 && (svga->bpp != 24)) && (ramdac->true_color & 0xf0) != 0x00);
 
     if (!(ramdac->clock_sel & 0x70)) {
         if (ramdac->mcr != 0x98) {


### PR DESCRIPTION
Summary
=======
1. TVP3026: disable lut mapping on 24bpp modes (mainly the S3 Vision968 drivers which use the TVP3026 ramdac).
2. S3 Vision968 (MiroVideo 40SV Ergo): Corrected 1280x1024 24bpp resolution.
3. ViRGE class: limit the FIFO entries in the bitblt regs to less than 16 entries and make the Image Transfers FIFO writes not wraparound to 1 and reads to 0 (to allow at least a read to a write in the thread without hanging the entire emulator elsewhere). Fixes Win3.1 PBRUSH colors while keeping performance on par with PCem.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
