### PR TITLE
Fix SDL UI failing to build when C++11 threads are disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,6 @@ option(RTMIDI       "RtMidi"                                                    
 option(FLUIDSYNTH   "FluidSynth"                                                    ON)
 option(MUNT         "MUNT"                                                          ON)
 option(VNC          "VNC renderer"                                                  OFF)
-option(CPPTHREADS   "C++11 threads"                                                 ON)
 option(NEW_DYNAREC  "Use the PCem v15 (\"new\") dynamic recompiler"                 OFF)
 option(MINITRACE    "Enable Chrome tracing using the modified minitrace library"    OFF)
 option(GDBSTUB      "Enable GDB stub server for debugging"                          OFF)
@@ -141,8 +140,10 @@ option(DEBUGREGS486 "Enable debug register opeartion on 486+ CPUs"              
 
 if(WIN32)
     set(QT ON)
+    option(CPPTHREADS "C++11 threads" OFF)
 else()
     option(QT "Qt GUI" ON)
+    option(CPPTHREADS "C++11 threads" ON)
 endif()
 
 # Development branch features

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,9 +27,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     add_compile_definitions(_FILE_OFFSET_BITS=64 _LARGEFILE_SOURCE=1 _LARGEFILE64_SOURCE=1)
 endif()
 
-if(WIN32)
-    target_sources(86Box PRIVATE qt/win_thread.c)
-else()
+if(CPPTHREADS)
     target_sources(86Box PRIVATE thread.cpp)
 endif()
 

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -227,6 +227,10 @@ if(WIN32 AND NOT MINGW)
     target_sources(plat PRIVATE win_opendir.c)
 endif()
 
+if(WIN32 AND NOT CPPTHREADS)
+    target_sources(plat PRIVATE win_thread.c)
+endif()
+
 if(WIN32)
     target_sources(plat PRIVATE win_serial_passthrough.c win_netsocket.c)
 else()

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -5,7 +5,7 @@
 #include <86box/plat.h>
 #include <86box/thread.h>
 
-struct event_cpp11_ex_t {
+struct event_cpp11_t {
     std::condition_variable cond;
     std::mutex              mutex;
     bool                    state = false;
@@ -82,14 +82,14 @@ thread_close_mutex(mutex_t *_mutex)
 event_t *
 thread_create_event()
 {
-    auto ev = new event_cpp11_ex_t;
+    auto ev = new event_cpp11_t;
     return ev;
 }
 
 int
 thread_wait_event(event_t *handle, int timeout)
 {
-    auto event = reinterpret_cast<event_cpp11_ex_t *>(handle);
+    auto event = reinterpret_cast<event_cpp11_t *>(handle);
     auto lock  = std::unique_lock<std::mutex>(event->mutex);
 
     if (timeout < 0) {
@@ -112,7 +112,7 @@ thread_wait_event(event_t *handle, int timeout)
 void
 thread_set_event(event_t *handle)
 {
-    auto event = reinterpret_cast<event_cpp11_ex_t *>(handle);
+    auto event = reinterpret_cast<event_cpp11_t *>(handle);
     {
         auto lock    = std::unique_lock<std::mutex>(event->mutex);
         event->state = true;
@@ -123,7 +123,7 @@ thread_set_event(event_t *handle)
 void
 thread_reset_event(event_t *handle)
 {
-    auto event   = reinterpret_cast<event_cpp11_ex_t *>(handle);
+    auto event   = reinterpret_cast<event_cpp11_t *>(handle);
     auto lock    = std::unique_lock<std::mutex>(event->mutex);
     event->state = false;
 }
@@ -131,7 +131,7 @@ thread_reset_event(event_t *handle)
 void
 thread_destroy_event(event_t *handle)
 {
-    auto event = reinterpret_cast<event_cpp11_ex_t *>(handle);
+    auto event = reinterpret_cast<event_cpp11_t *>(handle);
     delete event;
 }
 }


### PR DESCRIPTION
Summary
=======
Fix the SDL UI failing to build with duplicate symbol errors when C++11 threads are disabled in favor of pthreads - the `CPPTHREADS` CMake options is functional again. Also revert previous failed fix attempts.

Checklist
=========
* [x] Closes #4753 (for real)
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A
