### PR TITLE
Use F8+F12 to release mouse on all platforms

### DIFF
--- a/src/device/keyboard.c
+++ b/src/device/keyboard.c
@@ -31,23 +31,13 @@
 
 int keyboard_scan;
 
-#ifdef _WIN32
-/* Windows: F8+F12 */
+/* F8+F12 */
 uint16_t key_prefix_1_1 = 0x042;     /* F8 */
 uint16_t key_prefix_1_2 = 0x000;     /* Invalid */
 uint16_t key_prefix_2_1 = 0x000;     /* Invalid */
 uint16_t key_prefix_2_2 = 0x000;     /* Invalid */
 uint16_t key_uncapture_1 = 0x058;    /* F12 */
 uint16_t key_uncapture_2 = 0x000;    /* Invalid */
-#else
-/* WxWidgets cannot do two regular keys.. CTRL+END */
-uint16_t key_prefix_1_1 = 0x01d;     /* Left Ctrl */
-uint16_t key_prefix_1_2 = 0x11d;     /* Right Ctrl */
-uint16_t key_prefix_2_1 = 0x000;     /* Invalid */
-uint16_t key_prefix_2_2 = 0x000;     /* Invalid */
-uint16_t key_uncapture_1 = 0x04f;    /* Numpad End */
-uint16_t key_uncapture_2 = 0x14f;    /* End */
-#endif
 
 void (*keyboard_send)(uint16_t val);
 

--- a/src/include/86box/plat.h
+++ b/src/include/86box/plat.h
@@ -32,8 +32,8 @@
 /* String ID numbers. */
 enum {
     STRING_MOUSE_CAPTURE,             /* "Click to capture mouse" */
-    STRING_MOUSE_RELEASE,             /* "Press F8+F12/Ctrl+End to release mouse" */
-    STRING_MOUSE_RELEASE_MMB,         /* "Press F8+F12/Ctrl+End or middle button to release mouse" */
+    STRING_MOUSE_RELEASE,             /* "Press F8+F12 to release mouse" */
+    STRING_MOUSE_RELEASE_MMB,         /* "Press F8+F12 or middle button to release mouse" */
     STRING_INVALID_CONFIG,            /* "Invalid configuration" */
     STRING_NO_ST506_ESDI_CDROM,       /* "MFM/RLL or ESDI CD-ROM drives never existed" */
     STRING_NET_ERROR,                 /* "Failed to initialize network driver" */

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -583,6 +583,8 @@ c16stombs(char dst[], const uint16_t src[], int len)
 }
 #endif
 
+#    define MOUSE_CAPTURE_KEYSEQ "F8+F12"
+
 #ifdef _WIN32
 #    if defined(__amd64__) || defined(_M_X64) || defined(__aarch64__) || defined(_M_ARM64)
 #        define LIB_NAME_GS   "gsdll64.dll"
@@ -592,12 +594,10 @@ c16stombs(char dst[], const uint16_t src[], int len)
 #        define LIB_NAME_GPCL "gpcl6dll32.dll"
 #    endif
 #    define LIB_NAME_PCAP        "Npcap"
-#    define MOUSE_CAPTURE_KEYSEQ "F8+F12"
 #else
 #    define LIB_NAME_GS          "libgs"
 #    define LIB_NAME_GPCL        "libgpcl6"
 #    define LIB_NAME_PCAP        "libpcap"
-#    define MOUSE_CAPTURE_KEYSEQ "Ctrl+End"
 #endif
 
 QMap<int, std::wstring> ProgSettings::translatedstrings;


### PR DESCRIPTION
Summary
=======
It seems that Ctrl+End was used on non-Win32 platforms because WxWidgets couldn’t use non-modifier keys as a keyboard sequence.  Qt can, and F8+F12 interferes with the operation of software a lot less than Ctrl+End does (try doing some text editing!).

86Box hasn’t used WxWidgets for quite some time and this platform limitation hack has long outlived its necessity.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/