### PR TITLE
Qt: Remove leftovers of the "Reload previous image" option

### DIFF
--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -877,9 +877,7 @@ MediaMenu::zipUpdateMenu(int i)
     auto  childs = menu->children();
 
     auto *ejectMenu  = dynamic_cast<QAction *>(childs[zipEjectPos]);
-    auto *reloadMenu = dynamic_cast<QAction *>(childs[zipReloadPos]);
     ejectMenu->setEnabled(!name.isEmpty());
-    reloadMenu->setEnabled(!prev_name.isEmpty());
 
     QString busName = tr("Unknown Bus");
     switch (zip_drives[i].bus_type) {
@@ -1008,9 +1006,7 @@ MediaMenu::moUpdateMenu(int i)
     auto  childs = menu->children();
 
     auto *ejectMenu  = dynamic_cast<QAction *>(childs[moEjectPos]);
-    auto *reloadMenu = dynamic_cast<QAction *>(childs[moReloadPos]);
     ejectMenu->setEnabled(!name.isEmpty());
-    reloadMenu->setEnabled(!prev_name.isEmpty());
 
     QString busName = tr("Unknown Bus");
     switch (mo_drives[i].bus_type) {

--- a/src/qt/qt_mediamenu.hpp
+++ b/src/qt/qt_mediamenu.hpp
@@ -108,17 +108,14 @@ private:
     int floppyImageHistoryPos[MAX_PREV_IMAGES];
 
     int cdromMutePos;
-    int cdromReloadPos;
     int cdromImagePos;
     int cdromDirPos;
     int cdromImageHistoryPos[MAX_PREV_IMAGES];
 
     int zipEjectPos;
-    int zipReloadPos;
     int zipImageHistoryPos[MAX_PREV_IMAGES];
 
     int moEjectPos;
-    int moReloadPos;
     int moImageHistoryPos[MAX_PREV_IMAGES];
 
     int netDisconnPos;


### PR DESCRIPTION
Summary
=======
Fixes 86Box crashing on start after adding a ZIP drive.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
N/A