### PR TITLE
Use ftruncate on Unix to create hard disk images quickly

### DIFF
--- a/src/disk/hdd_image.c
+++ b/src/disk/hdd_image.c
@@ -26,6 +26,9 @@
 #include <time.h>
 #include <wchar.h>
 #include <errno.h>
+#ifdef __unix__
+#include <unistd.h>
+#endif
 #define HAVE_STDARG_H
 #include <86box/86box.h>
 #include <86box/path.h>
@@ -183,6 +186,7 @@ prepare_new_hard_disk(uint8_t id, uint64_t full_size)
 {
     uint64_t target_size = (full_size + hdd_images[id].base) - ftello64(hdd_images[id].file);
 
+#ifndef __unix__
     uint32_t size;
     uint32_t t;
 
@@ -217,7 +221,16 @@ prepare_new_hard_disk(uint8_t id, uint64_t full_size)
     pclog_toggle_suppr();
 
     free(empty_sector_1mb);
+#else
+    pclog("Creating hard disk image: ");
+    int ret = ftruncate(fileno(hdd_images[id].file), (size_t) target_size);
 
+    if (ret) {
+        pclog("failed\n");
+        fatal("Could not create hard disk image\n");
+    }
+    pclog("OK!\n");
+#endif
     hdd_images[id].last_sector = (uint32_t) (full_size >> 9) - 1;
 
     hdd_images[id].loaded = 1;

--- a/src/qt/qt_harddiskdialog.cpp
+++ b/src/qt/qt_harddiskdialog.cpp
@@ -20,6 +20,9 @@
 #include "ui_qt_harddiskdialog.h"
 
 extern "C" {
+#ifdef __unix__
+#include <unistd.h>
+#endif
 #include <86box/86box.h>
 #include <86box/hdd.h>
 #include "../disk/minivhd/minivhd.h"
@@ -447,6 +450,7 @@ HarddiskDialog::onCreateNewFile()
     }
 
     // formats 0, 1 and 2
+#ifndef __unix__
     connect(this, &HarddiskDialog::fileProgress, this, [this](int value) { ui->progressBar->setValue(value); QApplication::processEvents(); });
     ui->progressBar->setVisible(true);
     [size, &file, this] {
@@ -469,6 +473,13 @@ HarddiskDialog::onCreateNewFile()
         }
         emit fileProgress(100);
     }();
+#else
+    int ret = ftruncate(file.handle(), (size_t) size);
+
+    if (ret) {
+        QMessageBox::critical(this, tr("Unable to write file"), tr("Make sure the file is being saved to a writable directory."));
+    }
+#endif
 
     QMessageBox::information(this, tr("Disk image created"), tr("Remember to partition and format the newly-created drive."));
     setResult(QDialog::Accepted);


### PR DESCRIPTION
Summary
=======
Instead of writing out disk blocks slowly across the entire volume, just use the ftruncate function to create a file instantly at the desired size.

Depending on file system, this can either result in identical results to the old code just faster (eg: ZFS and btrfs with compression enabled), sparse files (most native Unix file systems without compression, eg ext4 and UFS), or a full non-sparse file like before (creating an image on FAT and exFAT).

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/