### PR TITLE
Media history: fix buffer overflow

### DIFF
--- a/src/qt/qt_mediahistorymanager.cpp
+++ b/src/qt/qt_mediahistorymanager.cpp
@@ -337,7 +337,7 @@ MediaHistoryManager::removeMissingImages(device_index_list_t &device_history)
         }
 
         char *p = checked_path.toUtf8().data();
-        char temp[1024] = { 0 };
+        char temp[MAX_IMAGE_PATH_LEN -1] = { 0 };
 
         if (path_abs(p)) {
             if (strlen(p) > (MAX_IMAGE_PATH_LEN - 1))


### PR DESCRIPTION
Summary
=======
This fixes a crash (introduced in 208b213aac) when inserting/ejecting a disk image.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
