### PR TITLE
Microtouch: Fix compiler warning

### DIFF
--- a/src/device/mouse_microtouch_touchscreen.c
+++ b/src/device/mouse_microtouch_touchscreen.c
@@ -240,7 +240,7 @@ mtouch_write(serial_t *serial, void *priv, uint8_t data)
 static int
 mtouch_prepare_transmit(void *priv)    
 {
-    char buffer[10];
+    char buffer[16];
     mouse_microtouch_t *dev = (mouse_microtouch_t *) priv;
     
     double abs_x = dev->abs_x;


### PR DESCRIPTION
Summary
=======
Noticed there were a bunch of sprintf truncation warnings in the buildbot. This should squash most if not all of them.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
