### PR TITLE
Remove a useless AND to 0x7f in the SB DSP reset routine in its port 0x0e (Read)

### DIFF
--- a/src/sound/snd_sb_dsp.c
+++ b/src/sound/snd_sb_dsp.c
@@ -1983,10 +1983,8 @@ sb_read(uint16_t a, void *priv)
                 else
                     ret = (dsp->sb_read_rp == dsp->sb_read_wp) ? 0x7f : 0xff;
             }
-            if (dsp->state == DSP_S_RESET_WAIT) {
-                ret &= 0x7f;
+            if (dsp->state == DSP_S_RESET_WAIT)
                 dsp->state = DSP_S_NORMAL;
-            }
             break;
         case 0xF: /* 16-bit ack */
             if (IS_NOT_ESS(dsp)) {


### PR DESCRIPTION
Summary
=======
This fixes the audio issue on Zool 2.

Checklist
=========
* [x] Closes #4822 
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
