### PR TITLE
Mach64VT class 8bpp render fix.

### DIFF
--- a/src/video/vid_ati_mach64.c
+++ b/src/video/vid_ati_mach64.c
@@ -539,7 +539,7 @@ mach64_recalctimings(svga_t *svga)
                 break;
             case BPP_8:
                 if (mach64->type != MACH64_GX)
-                    svga->render = svga_render_8bpp_highres;
+                    svga->render = svga_render_8bpp_clone_highres;
                 svga->hdisp <<= 3;
                 svga->rowoffset >>= 1;
                 break;


### PR DESCRIPTION
Summary
=======
Make it sure the alternative 8bpp renderer to avoid any palette flickering.

Checklist
=========
* [x] Closes #4833
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
