### PR TITLE
Compile and linker fixes for OpenBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,10 @@ else()
     option(CPPTHREADS "C++11 threads" ON)
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+    SET(CMAKE_EXE_LINKER_FLAGS "-Wl,-z,wxneeded")
+endif()
+
 # Development branch features
 #
 #                      Option         Description                                Def.  Condition     Otherwise

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -54,6 +54,10 @@
 #    include <sys/mman.h>
 #endif
 
+#ifdef Q_OS_OPENBSD
+#    include <pthread_np.h>
+#endif
+
 #if 0
 static QByteArray buf;
 #endif
@@ -804,8 +808,10 @@ plat_set_thread_name(void *thread, const char *name)
     char truncated[16];
 #    endif
     strncpy(truncated, name, sizeof(truncated) - 1);
-#    ifdef Q_OS_DARWIN
+#    if defined(Q_OS_DARWIN)
     pthread_setname_np(truncated);
+#    elif defined(Q_OS_OPENBSD)
+    pthread_set_name_np(thread ? *((pthread_t *) thread) : pthread_self(), truncated);
 #    else
     pthread_setname_np(thread ? *((pthread_t *) thread) : pthread_self(), truncated);
 #    endif


### PR DESCRIPTION
Summary
=======
* link with wxneeded is required for DYNAREC, in addition to being installed onto a filesystem with the wxallowed flag (like /usr/local on a default installation)
* pthread_setname_np is pthread_set_name_np on OpenBSD

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://man.openbsd.org/ld#wxneeded
https://man.openbsd.org/man8/mount.8#wxallowed

https://man.openbsd.org/pthread_set_name_np
