### PR TITLE
Various machine table fixes for Slot 1 machines

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -13953,7 +13953,7 @@ const machine_t machines[] = {
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_GAMEPORT | MACHINE_USB, /* Machine has internal sound: C-Media CMI8330 */
         .ram = {
             .min = 1024,
-            .max = 1572864,
+            .max = 393216,
             .step = 8192
         },
         .nvrmask = 255,
@@ -13995,7 +13995,7 @@ const machine_t machines[] = {
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_USB,
         .ram = {
             .min = 8192,
-            .max = 1048576,
+            .max = 524288,
             .step = 8192
         },
         .nvrmask = 127,
@@ -14036,7 +14036,7 @@ const machine_t machines[] = {
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_USB,
         .ram = {
             .min = 8192,
-            .max = 786432,
+            .max = 393216,
             .step = 8192
         },
         .nvrmask = 127,
@@ -14069,7 +14069,7 @@ const machine_t machines[] = {
             .package = CPU_PKG_SLOT1,
             .block = CPU_BLOCK_NONE,
             .min_bus = 60000000,
-            .max_bus = 100000000,
+            .max_bus = 83333333,
             .min_voltage = 1500,
             .max_voltage = 3500,
             .min_multi = 2.0,
@@ -14161,7 +14161,7 @@ const machine_t machines[] = {
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
         .ram = {
             .min = 8192,
-            .max = 786432,
+            .max = 393216,
             .step = 8192
         },
         .nvrmask = 255,
@@ -14448,11 +14448,11 @@ const machine_t machines[] = {
             .min_multi = 1.5,
             .max_multi = 8.0
         },
-        .bus_flags = MACHINE_PS2_AGP | MACHINE_BUS_USB,
+        .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_GAMEPORT | MACHINE_USB, /* Machine has internal video: Matrox MGA-G200 and sound: Crystal CS4820 */
         .ram = {
             .min = 8192,
-            .max = 1048576,
+            .max = 524288,
             .step = 8192
         },
         .nvrmask = 255,
@@ -14533,7 +14533,7 @@ const machine_t machines[] = {
         .flags = MACHINE_IDE_DUAL | MACHINE_SOUND | MACHINE_APM | MACHINE_ACPI | MACHINE_USB, /* Machine has internal sound: Ensoniq ES1371 */
         .ram = {
             .min = 8192,
-            .max = 1048576,
+            .max = 786432,
             .step = 8192
         },
         .nvrmask = 255,
@@ -14648,7 +14648,7 @@ const machine_t machines[] = {
             .package = CPU_PKG_SLOT1,
             .block = CPU_BLOCK_NONE,
             .min_bus = 66666667,
-            .max_bus = 66666667,
+            .max_bus = 100000000,
             .min_voltage = 1800,
             .max_voltage = 3500,
             .min_multi = 1.5,
@@ -14867,7 +14867,7 @@ const machine_t machines[] = {
         .flags = MACHINE_IDE_DUAL | MACHINE_SOUND | MACHINE_APM | MACHINE_ACPI | MACHINE_GAMEPORT | MACHINE_USB, /* Machine has internal sound: Ensoniq ES1373 */
         .ram = {
             .min = 8192,
-            .max = 3145728,
+            .max = 1572864,
             .step = 8192
         },
         .nvrmask = 255,
@@ -14909,7 +14909,7 @@ const machine_t machines[] = {
         .flags = MACHINE_IDE_DUAL | MACHINE_SOUND | MACHINE_APM | MACHINE_ACPI | MACHINE_GAMEPORT | MACHINE_USB, /* Machine has internal sound: Ensoniq ES1373 */
         .ram = {
             .min = 8192,
-            .max = 1572864,
+            .max = 786432,
             .step = 1024
         },
         .nvrmask = 255,
@@ -14949,7 +14949,7 @@ const machine_t machines[] = {
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_GAMEPORT | MACHINE_USB,
         .ram = {
             .min = 8192,
-            .max = 1572864,
+            .max = 393216,
             .step = 1024
         },
         .nvrmask = 255,


### PR DESCRIPTION
Summary
=======
I have fixed various mistakes (such as incorrect maximum RAM sizes, maximum FSB speeds, supported expansion slots etc.) present on some emulated Slot 1 machines, so they more accurately reflect the limitations that exist on the actual ones.

Here is a full list of all the fixes:

- **PC Chips M729:** *Reduced the maximum RAM size from 1.5 GB to 384 MB*
- **ASUS P/I-P65UP5 (C-PKND):** *Reduced the maximum RAM size from 1 GB to 512 MB*
- **ASUS KN97:** *Reduced the maximum RAM size from 768 MB to 384 MB*
- **ABIT LX6:** *Reduced the maximum FSB speed from 100 MHz to 83 MHz*
- **NEC Mate NX MA30D/23D:** *Reduced the maximum RAM size from 768 MB to 384 MB*
- **HP Vectra VEi 8:** *Reduced the maximum RAM size from 1 GB to 512 MB and removed the AGP graphics slot*
- **Tyan Tsunami ATX:** *Reduced the maximum RAM size from 1 GB to 768 MB*
- **Packard Bell Bora Pro:** *Increased the maximum FSB speed from 66 MHz to 100 MHz*
- **BCM GT694VA:** *Reduced the maximum RAM size from 3 GB to 1.5 GB*
- **Freetech/Flexus P6F99:** *Reduced the maximum RAM size from 1.5 GB to 768 MB*
- **PC Chips M747:** *Reduced the maximum RAM size from 1.5 GB to 384 MB*

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://theretroweb.com/motherboard/manual/m729-user-manual-ver-1.2-5f4d7e3102fab664464186.pdf
https://theretroweb.com/motherboard/manual/p65up5-204-5f14abc8464ed646430544.pdf
https://theretroweb.com/motherboard/manual/lx6e-5f07803a7908c881661452.pdf
https://www.inversenet.co.jp/pclist/product/NEC-desk/PC%252DMA30DMZAAA41.html
https://theretroweb.com/motherboard/manual/6110-615761484c108485972448.pdf
https://theretroweb.com/motherboard/manual/m-s1846-160-630bbabfbcff2325349299.pdf
https://theretroweb.com/motherboard/manual/ms6168v2-5f07787654ff9686533698.pdf
https://theretroweb.com/motherboards/s/bcm-gt694va
https://theretroweb.com/motherboard/manual/f99-60c2280313ed1904195891.pdf
https://theretroweb.com/motherboard/manual/m747v15n-634e5cae4ab0f970665245.pdf
