### PR TITLE
qt: Make the About dialog closeable with Esc key

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -1725,7 +1725,8 @@ MainWindow::on_actionAbout_86Box_triggered()
     msgBox.setText(QString("<b>%3%1%2</b>").arg(EMU_VERSION_FULL, versioninfo, tr("86Box v")));
     msgBox.setInformativeText(tr("An emulator of old computers\n\nAuthors: Miran Grča (OBattler), RichardG867, Jasmine Iwanek, TC1995, coldbrewed, Teemu Korhonen (Manaatti), Joakim L. Gilje, Adrien Moulin (elyosh), Daniel Balsom (gloriouscow), Cacodemon345, Fred N. van Kempen (waltje), Tiseno100, reenigne, and others.\n\nWith previous core contributions from Sarah Walker, leilei, JohnElliott, greatpsycho, and others.\n\nReleased under the GNU General Public License version 2 or later. See LICENSE for more information."));
     msgBox.setWindowTitle("About 86Box");
-    msgBox.addButton("OK", QMessageBox::ButtonRole::AcceptRole);
+    const auto closeButton = msgBox.addButton("OK", QMessageBox::ButtonRole::AcceptRole);
+    msgBox.setEscapeButton(closeButton);
     const auto webSiteButton = msgBox.addButton(EMU_SITE, QMessageBox::ButtonRole::HelpRole);
     webSiteButton->connect(webSiteButton, &QPushButton::released, []() {
         QDesktopServices::openUrl(QUrl("https://" EMU_SITE));


### PR DESCRIPTION
Summary
=======
Makes the About dialog closeable with the Esc key or the window manager's close button.

Checklist
=========
* [x] Closes #4911
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A