### PR TITLE
Big video changes of the day (October 26th, 2024)

### DIFF
--- a/src/include/86box/vid_8514a.h
+++ b/src/include/86box/vid_8514a.h
@@ -52,7 +52,7 @@ typedef struct ibm8514_t {
     int type;
     int local;
     int bpp;
-    int on[2];
+    int on;
     int accel_bpp;
 
     uint32_t vram_size;
@@ -102,6 +102,8 @@ typedef struct ibm8514_t {
         uint16_t frgd_mix;
         uint16_t multifunc_cntl;
         uint16_t multifunc[16];
+        uint16_t clip_right;
+        uint16_t clip_bottom;
         int16_t  clip_left;
         int16_t  clip_top;
         uint8_t  pix_trans[2];
@@ -112,8 +114,6 @@ typedef struct ibm8514_t {
         int      x3;
         int      y1;
         int      y2;
-        int      sys_cnt;
-        int      sys_cnt2;
         int      temp_cnt;
         int16_t  cx;
         int16_t  cx_back;
@@ -127,20 +127,14 @@ typedef struct ibm8514_t {
         int16_t  err;
         uint32_t src;
         uint32_t dest;
-        uint32_t newsrc_blt;
-        uint32_t newdest_blt;
-        uint32_t newdest_in;
-        uint32_t newdest_out;
-        uint8_t *writemono;
-        uint8_t *nibbleset;
         int      x_count;
         int      xx_count;
         int      y_count;
         int      input;
+        int      input2;
         int      output;
+        int      output2;
 
-        uint16_t cur_x_bit12;
-        uint16_t cur_y_bit12;
         int      ssv_len;
         uint8_t  ssv_dir;
         uint8_t  ssv_draw;
@@ -156,7 +150,6 @@ typedef struct ibm8514_t {
     } accel;
 
     uint16_t test;
-    int      vendor_mode[2];
     int      h_blankstart;
     int      h_blank_end_val;
     int      hblankstart;
@@ -227,6 +220,11 @@ typedef struct ibm8514_t {
     int      ext_pitch;
     int      ext_crt_pitch;
     int      extensions;
+    int      linear;
+    int      _4bpp;
+    uint32_t vram_amount;
+    int      vram_512k_8514;
+    PALETTE  _8514pal;
 
     latch8514_t latch;
 } ibm8514_t;

--- a/src/include/86box/vid_ati_mach8.h
+++ b/src/include/86box/vid_ati_mach8.h
@@ -41,8 +41,6 @@ typedef struct mach_t {
     int ramdac_type;
     int old_mode;
 
-    uint32_t memory;
-
     uint16_t config1;
     uint16_t config2;
 
@@ -73,9 +71,7 @@ typedef struct mach_t {
     uint8_t  bank_r;
     uint16_t shadow_set;
     uint16_t shadow_cntl;
-    int ext_on[2];
-    int extended_mode;
-    int compat_mode;
+    int override_resolution;
 
     struct {
         uint8_t  line_idx;
@@ -84,6 +80,12 @@ typedef struct mach_t {
         uint8_t  patt_len;
         uint8_t  pix_trans[2];
         uint8_t  eeprom_control;
+        uint8_t  alu_bg_fn;
+        uint8_t  alu_fg_fn;
+        uint16_t clip_left;
+        uint16_t clip_right;
+        uint16_t clip_top;
+        uint16_t clip_bottom;
         uint16_t dest_x_end;
         uint16_t dest_x_start;
         uint16_t dest_y_end;
@@ -102,14 +104,14 @@ typedef struct mach_t {
         uint16_t ge_offset_hi;
         uint16_t linedraw_opt;
         uint16_t max_waitstates;
-        uint8_t  patt_data_idx;
-        uint8_t  patt_data[0x18];
         uint16_t scan_to_x;
         uint16_t scratch0;
         uint16_t scratch1;
         uint16_t test;
         uint16_t pattern;
         uint16_t test2;
+        int      patt_data_idx_reg;
+        int      patt_data_idx;
         int      src_y_dir;
         int      cmd_type;
         int      block_write_mono_pattern_enable;
@@ -144,9 +146,8 @@ typedef struct mach_t {
         int      stepx;
         int      stepy;
         int      src_stepx;
-        uint8_t  color_pattern[16];
-        uint8_t  color_pattern_full[32];
-        uint16_t color_pattern_word[8];
+        uint8_t  mono_pattern_normal[16];
+        uint8_t  color_pattern[32];
         int      mono_pattern[8][8];
         uint32_t ge_offset;
         uint32_t crt_offset;

--- a/src/include/86box/vid_svga.h
+++ b/src/include/86box/vid_svga.h
@@ -369,6 +369,7 @@ uint32_t svga_mask_addr(uint32_t addr, svga_t *svga);
 uint32_t svga_mask_changedaddr(uint32_t addr, svga_t *svga);
 
 void svga_doblit(int wx, int wy, svga_t *svga);
+void svga_poll(void *priv);
 
 enum {
     RAMDAC_6BIT = 0,
@@ -395,6 +396,9 @@ extern uint8_t att49x_ramdac_in(uint16_t addr, int rs2, void *priv, svga_t *svga
 extern void    att498_ramdac_out(uint16_t addr, int rs2, uint8_t val, void *priv, svga_t *svga);
 extern uint8_t att498_ramdac_in(uint16_t addr, int rs2, void *priv, svga_t *svga);
 extern float   av9194_getclock(int clock, void *priv);
+
+extern void    bt481_ramdac_out(uint16_t addr, int rs2, uint8_t val, void *priv, svga_t *svga);
+extern uint8_t bt481_ramdac_in(uint16_t addr, int rs2, void *priv, svga_t *svga);
 
 extern void    bt48x_ramdac_out(uint16_t addr, int rs2, int rs3, uint8_t val, void *priv, svga_t *svga);
 extern uint8_t bt48x_ramdac_in(uint16_t addr, int rs2, int rs3, void *priv, svga_t *svga);
@@ -452,6 +456,7 @@ extern const device_t att491_ramdac_device;
 extern const device_t att492_ramdac_device;
 extern const device_t att498_ramdac_device;
 extern const device_t av9194_device;
+extern const device_t bt481_ramdac_device;
 extern const device_t bt484_ramdac_device;
 extern const device_t att20c504_ramdac_device;
 extern const device_t bt485_ramdac_device;

--- a/src/include/86box/vid_xga.h
+++ b/src/include/86box/vid_xga.h
@@ -31,13 +31,11 @@ typedef struct xga_hwcursor_t {
 } xga_hwcursor_t;
 
 typedef struct xga_t {
-    mem_mapping_t  membios_mapping;
     mem_mapping_t  memio_mapping;
     mem_mapping_t  linear_mapping;
     mem_mapping_t  video_mapping;
     rom_t          bios_rom;
-    rom_t          membios_rom;
-    rom_t          vga_bios_rom;
+    rom_t          bios_rom2;
     xga_hwcursor_t hwcursor;
     xga_hwcursor_t hwcursor_latch;
     PALETTE        extpal;
@@ -153,6 +151,7 @@ typedef struct xga_t {
     int a5_test;
     int type;
     int bus;
+    int busy;
 
     uint32_t linear_base;
     uint32_t linear_size;

--- a/src/video/CMakeLists.txt
+++ b/src/video/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(vid OBJECT agpgart.c video.c vid_table.c vid_cga.c vid_cga_comp.c
     vid_sigma.c vid_wy700.c vid_ega.c vid_ega_render.c vid_svga.c vid_8514a.c
     vid_svga_render.c vid_ddc.c vid_vga.c vid_ati_eeprom.c vid_ati18800.c
     vid_ati28800.c vid_ati_mach8.c vid_ati_mach64.c vid_ati68875_ramdac.c
-    vid_ati68860_ramdac.c vid_bt48x_ramdac.c vid_chips_69000.c
+    vid_ati68860_ramdac.c vid_bt481_ramdac.c vid_bt48x_ramdac.c vid_chips_69000.c
     vid_av9194.c vid_icd2061.c vid_ics2494.c vid_ics2595.c vid_cl54xx.c
     vid_et3000.c vid_et4000.c vid_sc1148x_ramdac.c vid_sc1502x_ramdac.c
     vid_et4000w32.c vid_stg_ramdac.c vid_ht216.c vid_oak_oti.c vid_paradise.c

--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -106,6 +106,9 @@ ibm8514_log(const char *fmt, ...)
         dat = (dev->vram[(addr) & (dev->vram_mask)]); \
     }
 
+#define READ_HIGH(addr, dat) \
+    dat |= (dev->vram[(addr) & (dev->vram_mask)] << 8);
+
 #define MIX(mixmode, dest_dat, src_dat)                                                       \
     {                                                                                         \
         switch ((mixmode) ? (dev->accel.frgd_mix & 0x1f) : (dev->accel.bkgd_mix & 0x1f)) {    \
@@ -191,7 +194,10 @@ ibm8514_log(const char *fmt, ...)
                 dest_dat = MAX(0, (src_dat - dest_dat));                                      \
                 break;                                                                        \
             case 0x1b:                                                                        \
-                dest_dat = MIN(~0, (dest_dat + src_dat));                                     \
+                if (dev->bpp)                                                                 \
+                    dest_dat = MIN(0xffff, (dest_dat + src_dat));                             \
+                else                                                                          \
+                    dest_dat = MIN(0xff, (dest_dat + src_dat));                               \
                 break;                                                                        \
             case 0x1c:                                                                        \
                 dest_dat = MAX(0, (dest_dat - src_dat)) / 2;                                  \
@@ -203,7 +209,10 @@ ibm8514_log(const char *fmt, ...)
                 dest_dat = MAX(0, (src_dat - dest_dat)) / 2;                                  \
                 break;                                                                        \
             case 0x1f:                                                                        \
-                dest_dat = (~0 < (src_dat + dest_dat)) ? ~0 : ((src_dat + dest_dat) >> 1); 	  \
+                if (dev->bpp)                                                                 \
+                    dest_dat = (0xffff < (src_dat + dest_dat)) ? 0xffff : ((src_dat + dest_dat) / 2); \
+                else                                                                          \
+                    dest_dat = (0xff < (src_dat + dest_dat)) ? 0xff : ((src_dat + dest_dat) / 2); \
                 break;                                                                        \
         }                                                                                     \
     }
@@ -259,10 +268,9 @@ ibm8514_accel_out_pixtrans(svga_t *svga, UNUSED(uint16_t port), uint32_t val, in
     int        frgd_mix  = (dev->accel.frgd_mix >> 5) & 3;
     int        bkgd_mix  = (dev->accel.bkgd_mix >> 5) & 3;
     int        cmd       = dev->accel.cmd >> 13;
-    int        and3      = dev->accel.cur_x & 3;
 
     if (dev->accel.cmd & 0x100) {
-        if (len != 1) {
+        if (len == 2) {
             /*Bus size*/
             if (dev->accel.cmd & 0x200) /*16-bit*/
                 pixcnt = 16;
@@ -271,200 +279,49 @@ ibm8514_accel_out_pixtrans(svga_t *svga, UNUSED(uint16_t port), uint32_t val, in
 
             /*Pixel transfer data mode, can't be the same as Foreground/Background CPU data*/
             if (pixcntl == 2) {
-                if ((frgd_mix == 2) || (bkgd_mix == 2)) {
+                if ((frgd_mix == 2) || (bkgd_mix == 2))
                     pixelxfer = val;
-                } else {
-                    if (dev->accel.cmd & 2) {
+                else {
+                    if (dev->accel.cmd & 0x02) {
                         if (pixcnt == 16) {
                             if ((cmd >= 2) && (dev->accel.cmd & 0x1000))
                                 val = (val >> 8) | (val << 8);
                         }
-                        if (and3 == 3) {
-                            if (dev->accel.cmd & 0x1000)
-                                goto regular_nibble;
-                            if (val & 0x02)
-                                nibble |= 0x10;
-                            if (val & 0x04)
-                                nibble |= 0x08;
-                            if (val & 0x08)
-                                nibble |= 0x04;
-                            if (val & 0x10)
-                                nibble |= 0x02;
-                            if (val & 0x200)
-                                nibble |= 0x01;
-                            if (val & 0x400)
-                                nibble |= 0x80;
-                            if (val & 0x800)
-                                nibble |= 0x40;
-                            if (val & 0x1000)
-                                nibble |= 0x20;
-                        } else if (and3 == 2) {
-                            if (dev->accel.cmd & 0x1000)
-                                goto regular_nibble;
-                            if (val & 0x02)
-                                nibble |= 0x20;
-                            if (val & 0x04)
-                                nibble |= 0x10;
-                            if (val & 0x08)
-                                nibble |= 0x08;
-                            if (val & 0x10)
-                                nibble |= 0x04;
-                            if (val & 0x200)
-                                nibble |= 0x02;
-                            if (val & 0x400)
-                                nibble |= 0x01;
-                            if (val & 0x800)
-                                nibble |= 0x80;
-                            if (val & 0x1000)
-                                nibble |= 0x40;
-                        } else if (and3 == 1) {
-                            if (dev->accel.cmd & 0x1000)
-                                goto regular_nibble;
-                            if (val & 0x02)
-                                nibble |= 0x40;
-                            if (val & 0x04)
-                                nibble |= 0x20;
-                            if (val & 0x08)
-                                nibble |= 0x10;
-                            if (val & 0x10)
-                                nibble |= 0x08;
-                            if (val & 0x200)
-                                nibble |= 0x04;
-                            if (val & 0x400)
-                                nibble |= 0x02;
-                            if (val & 0x800)
-                                nibble |= 0x01;
-                            if (val & 0x1000)
-                                nibble |= 0x80;
-                        } else {
-regular_nibble:
-                            if (val & 0x02)
-                                nibble |= 0x80;
-                            if (val & 0x04)
-                                nibble |= 0x40;
-                            if (val & 0x08)
-                                nibble |= 0x20;
-                            if (val & 0x10)
-                                nibble |= 0x10;
-                            if (val & 0x200)
-                                nibble |= 0x08;
-                            if (val & 0x400)
-                                nibble |= 0x04;
-                            if (val & 0x800)
-                                nibble |= 0x02;
-                            if (val & 0x1000)
-                                nibble |= 0x01;
-                        }
-
-                        if ((and3 == 0) || (dev->accel.cmd & 0x1000) || ((dev->accel.cmd & 8) && ibm8514_cpu_src(svga))) {
-                            if ((dev->accel.cmd & 8) && ibm8514_cpu_src(svga)) {
+                        if ((cmd <= 2) || (cmd == 4)) {
+                            if ((dev->accel.cmd & 0x08) && (cmd >= 2))
                                 monoxfer = val;
-                            } else
-                                monoxfer = nibble;
-                            ibm8514_accel_start(pixcnt, 1, monoxfer, pixelxfer, svga, len);
-                            if (dev->accel.nibbleset != NULL) {
-                                free(dev->accel.nibbleset);
-                                dev->accel.nibbleset = NULL;
-                            }
-                            if (dev->accel.writemono != NULL) {
-                                free(dev->accel.writemono);
-                                dev->accel.writemono = NULL;
-                            }
-                            return;
-                        }
-
-                        dev->accel.writemono[dev->accel.x_count] = nibble;
-                        if (val & 0x1c00) {
-                            if (and3 == 1) {
+                            else {
+                                if (val & 0x02)
+                                    nibble |= 0x80;
+                                if (val & 0x04)
+                                    nibble |= 0x40;
+                                if (val & 0x08)
+                                    nibble |= 0x20;
+                                if (val & 0x10)
+                                    nibble |= 0x10;
+                                if (val & 0x200)
+                                    nibble |= 0x08;
+                                if (val & 0x400)
+                                    nibble |= 0x04;
+                                if (val & 0x800)
+                                    nibble |= 0x02;
                                 if (val & 0x1000)
-                                    dev->accel.nibbleset[dev->accel.x_count] = 0x80;
-                                else
-                                    dev->accel.nibbleset[dev->accel.x_count] = 0;
-                            } else if (and3 == 2) {
-                                if (val & 0x1000) {
-                                    if (val & 0x800)
-                                        dev->accel.nibbleset[dev->accel.x_count] = 0xc0;
-                                    else
-                                        dev->accel.nibbleset[dev->accel.x_count] = 0x40;
-                                } else if (val & 0x800) {
-                                    if (val & 0x1000)
-                                        dev->accel.nibbleset[dev->accel.x_count] = 0xc0;
-                                    else
-                                        dev->accel.nibbleset[dev->accel.x_count] = 0x80;
-                                } else
-                                    dev->accel.nibbleset[dev->accel.x_count] = 0;
-                            } else if (and3 == 3) {
-                                if (val & 0x1000) {
-                                    if (val & 0x800) {
-                                        if (val & 0x400)
-                                            dev->accel.nibbleset[dev->accel.x_count] = 0xe0;
-                                        else
-                                            dev->accel.nibbleset[dev->accel.x_count] = 0x60;
-                                    } else if (val & 0x400) {
-                                        if (val & 0x800)
-                                            dev->accel.nibbleset[dev->accel.x_count] = 0xe0;
-                                        else
-                                            dev->accel.nibbleset[dev->accel.x_count] = 0xa0;
-                                    } else
-                                        dev->accel.nibbleset[dev->accel.x_count] = 0x20;
-                                } else if (val & 0x800) {
-                                    if (val & 0x400) {
-                                        if (val & 0x1000)
-                                            dev->accel.nibbleset[dev->accel.x_count] = 0xe0;
-                                        else
-                                            dev->accel.nibbleset[dev->accel.x_count] = 0xc0;
-                                    } else if (val & 0x1000) {
-                                        if (val & 0x400)
-                                            dev->accel.nibbleset[dev->accel.x_count] = 0xe0;
-                                        else
-                                            dev->accel.nibbleset[dev->accel.x_count] = 0x60;
-                                    } else
-                                        dev->accel.nibbleset[dev->accel.x_count] = 0x40;
-                                } else if (val & 0x400) {
-                                    if (val & 0x800) {
-                                        if (val & 0x1000)
-                                            dev->accel.nibbleset[dev->accel.x_count] = 0xe0;
-                                        else
-                                            dev->accel.nibbleset[dev->accel.x_count] = 0xc0;
-                                    } else if (val & 0x1000) {
-                                        if (val & 0x800)
-                                            dev->accel.nibbleset[dev->accel.x_count] = 0xe0;
-                                        else
-                                            dev->accel.nibbleset[dev->accel.x_count] = 0xa0;
-                                    } else
-                                        dev->accel.nibbleset[dev->accel.x_count] = 0x80;
-                                } else
-                                    dev->accel.nibbleset[dev->accel.x_count] = 0;
+                                    nibble |= 0x01;
+
+                                monoxfer = nibble;
                             }
                         } else
-                            dev->accel.nibbleset[dev->accel.x_count] = 0;
-
-                        dev->accel.x_count++;
-                        if (dev->accel.x_count == dev->accel.sys_cnt) {
-                            for (int i = 0; i < dev->accel.x_count; i++) {
-                                dev->accel.writemono[i] &= ~dev->accel.nibbleset[i];
-                                dev->accel.writemono[i] |= dev->accel.nibbleset[i + 1];
-                                ibm8514_accel_start(pixcnt, 1, dev->accel.writemono[i], pixelxfer, svga, len);
-                            }
-
-                            dev->accel.x_count = 0;
-                            if (dev->accel.nibbleset != NULL) {
-                                free(dev->accel.nibbleset);
-                                dev->accel.nibbleset = NULL;
-                            }
-                            if (dev->accel.writemono != NULL) {
-                                free(dev->accel.writemono);
-                                dev->accel.writemono = NULL;
-                            }
-                        }
-                        return;
-                    }
-                    monoxfer = val;
+                            monoxfer = val;
+                    } else
+                        monoxfer = val;
                 }
-            } else {
+            } else
                 pixelxfer = val;
-            }
-            ibm8514_accel_start(pixcnt, 1, monoxfer, pixelxfer, svga, len);
+
+            if (dev->accel.input)
+                ibm8514_accel_start(pixcnt >> 1, 1, monoxfer & 0xff, pixelxfer & 0xff, svga, len);
+            else
+                ibm8514_accel_start(pixcnt, 1, monoxfer & 0xffff, pixelxfer & 0xffff, svga, len);
         }
     }
 }
@@ -480,115 +337,61 @@ ibm8514_accel_out_fifo(svga_t *svga, uint16_t port, uint32_t val, int len)
     switch (port) {
         case 0x82e8:
         case 0xc2e8:
-            if (len == 1)
-                dev->accel.cur_y = (dev->accel.cur_y & 0x700) | val;
-            else
+            if (len == 2)
                 dev->accel.cur_y = val & 0x7ff;
-            break;
-        case 0x82e9:
-        case 0xc2e9:
-            if (len == 1)
-                dev->accel.cur_y = (dev->accel.cur_y & 0xff) | ((val & 0x07) << 8);
             break;
 
         case 0x86e8:
         case 0xc6e8:
-            if (len == 1)
-                dev->accel.cur_x = (dev->accel.cur_x & 0x700) | val;
-            else
+            if (len == 2)
                 dev->accel.cur_x = val & 0x7ff;
-            break;
-        case 0x86e9:
-        case 0xc6e9:
-            if (len == 1) {
-                dev->accel.cur_x = (dev->accel.cur_x & 0xff) | ((val & 0x07) << 8);
-            }
             break;
 
         case 0x8ae8:
         case 0xcae8:
-            if (len == 1)
-                dev->accel.desty_axstp = (dev->accel.desty_axstp & 0x3f00) | val;
-            else {
-                dev->accel.desty       = val & 0x07ff;
+            if (len == 2) {
+                dev->accel.desty       = val & 0x7ff;
                 dev->accel.desty_axstp = val & 0x3fff;
                 if (val & 0x2000)
-                    dev->accel.desty_axstp |= ~0x1fff;
-            }
-            break;
-        case 0x8ae9:
-        case 0xcae9:
-            if (len == 1) {
-                dev->accel.desty_axstp = (dev->accel.desty_axstp & 0xff) | ((val & 0x3f) << 8);
-                if (val & 0x20)
                     dev->accel.desty_axstp |= ~0x1fff;
             }
             break;
 
         case 0x8ee8:
         case 0xcee8:
-            if (len == 1)
-                dev->accel.destx_distp = (dev->accel.destx_distp & 0x3f00) | val;
-            else {
-                dev->accel.destx       = val & 0x07ff;
+            if (len == 2) {
+                dev->accel.destx       = val & 0x7ff;
                 dev->accel.destx_distp = val & 0x3fff;
                 if (val & 0x2000)
                     dev->accel.destx_distp |= ~0x1fff;
             }
             break;
-        case 0x8ee9:
-        case 0xcee9:
-            if (len == 1) {
-                dev->accel.destx_distp = (dev->accel.destx_distp & 0xff) | ((val & 0x3f) << 8);
-                if (val & 0x20)
-                    dev->accel.destx_distp |= ~0x1fff;
-            }
-            break;
 
         case 0x92e8:
-            if (len != 1)
+            if (len == 2)
                 dev->test = val;
             fallthrough;
 
         case 0xd2e8:
-            if (len == 1)
-                dev->accel.err_term = (dev->accel.err_term & 0x3f00) | val;
-            else {
+            if (len == 2) {
                 dev->accel.err_term = val & 0x3fff;
                 if (val & 0x2000)
-                    dev->accel.err_term |= ~0x1fff;
-            }
-            break;
-        case 0x92e9:
-        case 0xd2e9:
-            if (len == 1) {
-                dev->accel.err_term = (dev->accel.err_term & 0xff) | ((val & 0x3f) << 8);
-                if (val & 0x20)
                     dev->accel.err_term |= ~0x1fff;
             }
             break;
 
         case 0x96e8:
         case 0xd6e8:
-            if (len == 1)
-                dev->accel.maj_axis_pcnt = (dev->accel.maj_axis_pcnt & 0x700) | val;
-            else {
+            if (len == 2) {
                 dev->accel.maj_axis_pcnt = val & 0x7ff;
                 dev->accel.maj_axis_pcnt_no_limit = val;
             }
-            break;
-        case 0x96e9:
-        case 0xd6e9:
-            if (len == 1)
-                dev->accel.maj_axis_pcnt = (dev->accel.maj_axis_pcnt & 0xff) | ((val & 0x07) << 8);
             break;
 
         case 0x9ae8:
         case 0xdae8:
             dev->accel.ssv_state = 0;
-            if (len == 1)
-                dev->accel.cmd = (dev->accel.cmd & 0xff00) | val;
-            else {
+            if (len == 2) {
                 dev->data_available  = 0;
                 dev->data_available2 = 0;
                 dev->accel.cmd       = val;
@@ -596,20 +399,7 @@ ibm8514_accel_out_fifo(svga_t *svga, uint16_t port, uint32_t val, int len)
                     if (dev->accel.cmd & 0x100)
                         dev->accel.cmd_back = 0;
                 }
-                ibm8514_log("8514/A CMD=%04x.\n", dev->accel.cmd);
-                ibm8514_accel_start(-1, 0, -1, 0, svga, len);
-            }
-            break;
-        case 0x9ae9:
-        case 0xdae9:
-            if (len == 1) {
-                dev->data_available  = 0;
-                dev->data_available2 = 0;
-                dev->accel.cmd       = (dev->accel.cmd & 0xff) | (val << 8);
-                if (port == 0xdae9) {
-                    if (dev->accel.cmd & 0x100)
-                        dev->accel.cmd_back = 0;
-                }
+                ibm8514_log("8514/A CMD=%04x, back=%d.\n", dev->accel.cmd, dev->accel.cmd_back);
                 ibm8514_accel_start(-1, 0, -1, 0, svga, len);
             }
             break;
@@ -617,35 +407,14 @@ ibm8514_accel_out_fifo(svga_t *svga, uint16_t port, uint32_t val, int len)
         case 0x9ee8:
         case 0xdee8:
             dev->accel.ssv_state = 1;
-            if (len == 1)
-                dev->accel.short_stroke = (dev->accel.short_stroke & 0xff00) | val;
-            else {
+            if (len == 2) {
                 dev->accel.short_stroke = val;
-                dev->accel.cx           = dev->accel.cur_x;
-                dev->accel.cy           = dev->accel.cur_y;
-                if (dev->accel.cur_x >= 0x600)
-                    dev->accel.cx |= ~0x5ff;
-                if (dev->accel.cur_y >= 0x600)
-                    dev->accel.cy |= ~0x5ff;
 
-                if (dev->accel.cmd & 0x1000) {
-                    ibm8514_short_stroke_start(-1, 0, -1, 0, svga, dev->accel.short_stroke & 0xff, len);
-                    ibm8514_short_stroke_start(-1, 0, -1, 0, svga, dev->accel.short_stroke >> 8, len);
-                } else {
-                    ibm8514_short_stroke_start(-1, 0, -1, 0, svga, dev->accel.short_stroke >> 8, len);
-                    ibm8514_short_stroke_start(-1, 0, -1, 0, svga, dev->accel.short_stroke & 0xff, len);
-                }
-            }
-            break;
-        case 0x9ee9:
-        case 0xdee9:
-            dev->accel.ssv_state = 1;
-            if (len == 1) {
-                dev->accel.short_stroke = (dev->accel.short_stroke & 0xff) | (val << 8);
-                dev->accel.cx           = dev->accel.cur_x;
-                dev->accel.cy           = dev->accel.cur_y;
+                dev->accel.cx = dev->accel.cur_x;
                 if (dev->accel.cur_x >= 0x600)
                     dev->accel.cx |= ~0x5ff;
+
+                dev->accel.cy = dev->accel.cur_y;
                 if (dev->accel.cur_y >= 0x600)
                     dev->accel.cy |= ~0x5ff;
 
@@ -662,92 +431,55 @@ ibm8514_accel_out_fifo(svga_t *svga, uint16_t port, uint32_t val, int len)
         case 0xa2e8:
         case 0xe2e8:
             if (port == 0xe2e8) {
-                if (dev->accel.cmd_back) {
-                    if (len == 1)
-                        dev->accel.bkgd_color = (dev->accel.bkgd_color & 0x00ff) | val;
-                    else
+                if (len == 2) {
+                    if (dev->accel.cmd_back)
                         dev->accel.bkgd_color = val;
-                } else {
-                    if (ibm8514_cpu_dest(svga))
-                        break;
-                    ibm8514_accel_out_pixtrans(svga, port, val, len);
+                    else {
+                        if (ibm8514_cpu_dest(svga))
+                            break;
+                        ibm8514_accel_out_pixtrans(svga, port, val, len);
+                    }
                 }
             } else {
-                if (len == 1)
-                    dev->accel.bkgd_color = (dev->accel.bkgd_color & 0x00ff) | val;
-                else
+                if (len == 2)
                     dev->accel.bkgd_color = val;
             }
-            break;
-        case 0xa2e9:
-        case 0xe2e9:
-            if (len == 1)
-                dev->accel.bkgd_color = (dev->accel.bkgd_color & 0xff00) | (val << 8);
             break;
 
         case 0xa6e8:
         case 0xe6e8:
             if (port == 0xe6e8) {
-                if (dev->accel.cmd_back) {
-                    if (len == 1)
-                        dev->accel.frgd_color = (dev->accel.frgd_color & 0x00ff) | val;
-                    else
+                if (len == 2) {
+                    if (dev->accel.cmd_back)
                         dev->accel.frgd_color = val;
-                } else {
-                    if (ibm8514_cpu_dest(svga))
-                        break;
-                    ibm8514_accel_out_pixtrans(svga, port, val, len);
+                    else {
+                        if (ibm8514_cpu_dest(svga))
+                            break;
+                        ibm8514_accel_out_pixtrans(svga, port, val, len);
+                    }
                 }
             } else {
-                if (len == 1)
-                    dev->accel.frgd_color = (dev->accel.frgd_color & 0x00ff) | val;
-                else
+                if (len == 2)
                     dev->accel.frgd_color = val;
             }
-            break;
-        case 0xa6e9:
-        case 0xe6e9:
-            if (len == 1)
-                dev->accel.frgd_color = (dev->accel.frgd_color & 0xff00) | (val << 8);
             break;
 
         case 0xaae8:
         case 0xeae8:
-            if (len == 1)
-                dev->accel.wrt_mask = (dev->accel.wrt_mask & 0x00ff) | val;
-            else
+            if (len == 2)
                 dev->accel.wrt_mask = val;
-            break;
-        case 0xaae9:
-        case 0xeae9:
-            if (len == 1)
-                dev->accel.wrt_mask = (dev->accel.wrt_mask & 0xff00) | (val << 8);
             break;
 
         case 0xaee8:
         case 0xeee8:
-            if (len == 1)
-                dev->accel.rd_mask = (dev->accel.rd_mask & 0x00ff) | val;
-            else
+            if (len == 2)
                 dev->accel.rd_mask = val;
-            break;
-        case 0xaee9:
-        case 0xeee9:
-            if (len == 1)
-                dev->accel.rd_mask = (dev->accel.rd_mask & 0xff00) | (val << 8);
             break;
 
         case 0xb2e8:
         case 0xf2e8:
-            if (len == 1)
-                dev->accel.color_cmp = (dev->accel.color_cmp & 0x00ff) | val;
-            else
+            if (len == 2)
                 dev->accel.color_cmp = val;
-            break;
-        case 0xb2e9:
-        case 0xf2e9:
-            if (len == 1)
-                dev->accel.color_cmp = (dev->accel.color_cmp & 0xff00) | (val << 8);
             break;
 
         case 0xb6e8:
@@ -762,45 +494,10 @@ ibm8514_accel_out_fifo(svga_t *svga, uint16_t port, uint32_t val, int len)
 
         case 0xbee8:
         case 0xfee8:
-            if (len == 1)
-                dev->accel.multifunc_cntl = (dev->accel.multifunc_cntl & 0xff00) | val;
-            else {
+            if (len == 2) {
                 dev->accel.multifunc_cntl                             = val;
                 dev->accel.multifunc[dev->accel.multifunc_cntl >> 12] = dev->accel.multifunc_cntl & 0xfff;
-                if ((dev->accel.multifunc_cntl >> 12) == 1)
-                    dev->accel.clip_top = val & 0x7ff;
-
-                if ((dev->accel.multifunc_cntl >> 12) == 2)
-                    dev->accel.clip_left = val & 0x7ff;
-
-                if ((dev->accel.multifunc_cntl >> 12) == 3)
-                    dev->accel.multifunc[3] = val & 0x7ff;
-
-                if ((dev->accel.multifunc_cntl >> 12) == 4)
-                    dev->accel.multifunc[4] = val & 0x7ff;
-
-                ibm8514_log("CLIPBOTTOM=%d, CLIPRIGHT=%d, bpp=%d, pitch=%d.\n", dev->accel.multifunc[3], dev->accel.multifunc[4], dev->accel_bpp, dev->pitch);
-                if (port == 0xfee8)
-                    dev->accel.cmd_back = 1;
-                else
-                    dev->accel.cmd_back = 0;
-            }
-            break;
-        case 0xbee9:
-        case 0xfee9:
-            if (len == 1) {
-                dev->accel.multifunc_cntl                             = (dev->accel.multifunc_cntl & 0xff) | (val << 8);
-                dev->accel.multifunc[dev->accel.multifunc_cntl >> 12] = dev->accel.multifunc_cntl & 0xfff;
-                if ((dev->accel.multifunc_cntl >> 12) == 1)
-                    dev->accel.clip_top = dev->accel.multifunc_cntl & 0x7ff;
-
-                if ((dev->accel.multifunc_cntl >> 12) == 2)
-                    dev->accel.clip_left = dev->accel.multifunc_cntl & 0x7ff;
-
-                if (port == 0xfee9)
-                    dev->accel.cmd_back = 1;
-                else
-                    dev->accel.cmd_back = 0;
+                dev->accel.cmd_back = !!(port == 0xfee8);
             }
             break;
 
@@ -902,10 +599,8 @@ ibm8514_accel_out(uint16_t port, uint32_t val, svga_t *svga, int len)
 
             case 0x6e8:
                 /*In preparation to switch from VGA to 8514/A mode*/
-                if (!dev->on[0] || !dev->on[1]) {
-                    dev->hdisped = val;
-                    dev->hdisp = (dev->hdisped + 1) << 3;
-                }
+                dev->hdisped = val;
+                dev->hdisp = (dev->hdisped + 1) << 3;
                 ibm8514_log("[%04X:%08X]: IBM 8514/A: (0x%04x): hdisp=0x%02x.\n", CS, cpu_state.pc, port, val);
                 svga_recalctimings(svga);
                 break;
@@ -938,11 +633,9 @@ ibm8514_accel_out(uint16_t port, uint32_t val, svga_t *svga, int len)
             case 0x16e8:
             case 0x16e9:
                 /*In preparation to switch from VGA to 8514/A mode*/
-                if (!dev->on[0] || !dev->on[1]) {
-                    WRITE8(port, dev->v_disp, val);
-                    dev->v_disp &= 0x1fff;
-                    dev->vdisp = (dev->v_disp + 1) >> 1;
-                }
+                WRITE8(port, dev->v_disp, val);
+                dev->v_disp &= 0x1fff;
+                dev->vdisp = (dev->v_disp + 1) >> 1;
                 ibm8514_log("IBM 8514/A: V_DISP write 16E8 = %d\n", dev->v_disp);
                 ibm8514_log("IBM 8514/A: (0x%04x): vdisp=0x%02x.\n", port, val);
                 svga_recalctimings(svga);
@@ -1000,12 +693,10 @@ ibm8514_accel_out(uint16_t port, uint32_t val, svga_t *svga, int len)
                 break;
 
             case 0x4ae8:
-            case 0x4ae9:
                 WRITE8(port, dev->accel.advfunc_cntl, val);
-                dev->on[0] = dev->accel.advfunc_cntl & 0x01;
-                vga_on = !dev->on[0];
-                dev->vendor_mode[0] = 0;
-                ibm8514_log("[%04X:%08X]: IBM 8514/A: (0x%04x): ON=%d, shadow crt=%x, hdisp=%d, vdisp=%d.\n", CS, cpu_state.pc, port, dev->on[port & 1], dev->accel.advfunc_cntl & 0x04, dev->hdisp, dev->vdisp);
+                dev->on = dev->accel.advfunc_cntl & 0x01;
+                vga_on = !dev->on;
+                ibm8514_log("[%04X:%08X]: IBM 8514/A: (0x%04x): ON=%d, shadow crt=%x, hdisp=%d, vdisp=%d.\n", CS, cpu_state.pc, port, dev->on, dev->accel.advfunc_cntl & 0x04, dev->hdisp, dev->vdisp);
                 ibm8514_log("IBM mode set %s resolution.\n", (dev->accel.advfunc_cntl & 0x04) ? "2: 1024x768" : "1: 640x480");
                 svga_recalctimings(svga);
                 break;
@@ -1042,29 +733,29 @@ ibm8514_accel_in_fifo(svga_t *svga, uint16_t port, int len)
     switch (port) {
         case 0x82e8:
         case 0xc2e8:
-            if (len != 1)
+            if (len == 2)
                 temp = dev->accel.cur_y;
             break;
 
         case 0x86e8:
         case 0xc6e8:
-            if (len != 1)
+            if (len == 2)
                 temp = dev->accel.cur_x;
             break;
 
         case 0x92e8:
-            if (len != 1)
+            if (len == 2)
                 temp = dev->test;
             break;
 
         case 0x96e8:
-            if (len != 1)
+            if (len == 2)
                 temp = dev->accel.maj_axis_pcnt;
             break;
 
         case 0x9ae8:
         case 0xdae8:
-            if (len != 1) {
+            if (len == 2) {
                 if (dev->force_busy)
                     temp |= 0x200; /*Hardware busy*/
                 dev->force_busy = 0;
@@ -1090,14 +781,19 @@ ibm8514_accel_in_fifo(svga_t *svga, uint16_t port, int len)
         case 0xe2e8:
         case 0xe6e8:
             if (ibm8514_cpu_dest(svga)) {
-                if (len != 1) {
+                if (len == 2) {
                     cmd = (dev->accel.cmd >> 13);
                     READ_PIXTRANS_WORD(dev->accel.cx, 0);
-                    if (dev->accel.input && !dev->accel.odd_in && !dev->accel.sx) {
-                        temp &= ~0xff00;
-                        temp |= (dev->vram[(dev->accel.newdest_in + dev->accel.cur_x) & dev->vram_mask] << 8);
-                    }
-                    ibm8514_accel_out_pixtrans(svga, port, temp, len);
+                    if (dev->accel.input) {
+                        ibm8514_accel_out_pixtrans(svga, port, temp & 0xff, len);
+                        if (dev->accel.odd_in) { /*WORDs on odd destination scan lengths.*/
+                            dev->accel.odd_in = 0;
+                            temp &= ~0xff00;
+                            READ_HIGH(dev->accel.dest + dev->accel.cx, temp);
+                        }
+                        ibm8514_accel_out_pixtrans(svga, port, (temp >> 8) & 0xff, len);
+                    } else
+                        ibm8514_accel_out_pixtrans(svga, port, temp, len);
                 }
             }
             break;
@@ -1113,9 +809,6 @@ ibm8514_accel_in(uint16_t port, svga_t *svga)
 {
     ibm8514_t *dev       = (ibm8514_t *) svga->dev8514;
     uint8_t   temp       = 0;
-    uint16_t  clip_b_ibm = dev->accel.multifunc[3];
-    uint16_t  clip_r_ibm = dev->accel.multifunc[4];
-    int       cmd        = (dev->accel.cmd >> 13);
 
     switch (port) {
         case 0x2e8:
@@ -1150,19 +843,8 @@ ibm8514_accel_in(uint16_t port, svga_t *svga)
             if (dev->vc == dev->v_syncstart)
                 dev->subsys_stat |= 1;
 
-            if (cmd == 6) {
-                if (((dev->accel.dx) >= dev->accel.clip_left) && ((dev->accel.dx) <= clip_r_ibm) && ((dev->accel.dy) >= dev->accel.clip_top) && ((dev->accel.dy) <= clip_b_ibm))
-                    temp |= 2;
-            } else {
-                if (((dev->accel.cx) >= dev->accel.clip_left) && ((dev->accel.dx) <= clip_r_ibm) && ((dev->accel.cy) >= dev->accel.clip_top) && ((dev->accel.cy) <= clip_b_ibm))
-                    temp |= 2;
-            }
-
-            if (!dev->force_busy)
-                temp |= 8;
-
             if (port & 1)
-                temp = 0x80;
+                temp = dev->vram_512k_8514 ? 0x00 : 0x80;
             else {
                 temp |= (dev->subsys_stat | 0x80);
                 temp |= 0x20;
@@ -1232,8 +914,10 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
     uint16_t   old_dest_dat;
     int        frgd_mix;
     int        bkgd_mix;
-    uint16_t   clip_b          = dev->accel.multifunc[3];
-    uint16_t   clip_r          = dev->accel.multifunc[4];
+    int16_t    clip_t          = dev->accel.multifunc[1] & 0x7ff;
+    int16_t    clip_l          = dev->accel.multifunc[2] & 0x7ff;
+    uint16_t   clip_b          = dev->accel.multifunc[3] & 0x7ff;
+    uint16_t   clip_r          = dev->accel.multifunc[4] & 0x7ff;
     int        pixcntl         = (dev->accel.multifunc[0x0a] >> 6) & 3;
     uint16_t   mix_mask        = dev->bpp ? 0x8000 : 0x80;
     uint16_t   compare         = dev->accel.color_cmp;
@@ -1265,11 +949,11 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
     bkgd_mix = (dev->accel.bkgd_mix >> 5) & 3;
 
     if (cpu_input) {
-        if ((dev->accel.cmd & 2) || (pixcntl == 2)) {
+        if ((dev->accel.cmd & 0x02) || (pixcntl == 2)) {
             if ((frgd_mix == 2) || (bkgd_mix == 2))
                 count >>= 3;
             else if (pixcntl == 2) {
-                if (dev->accel.cmd & 2)
+                if (dev->accel.cmd & 0x02)
                     count >>= 1;
                 else
                     count >>= 3;
@@ -1369,9 +1053,12 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
             if (dev->accel.ssv_state == 0)
                 break;
 
-            if (dev->accel.cmd & 8) {
+            if (dev->accel.cmd & 0x08) {
                 while (count-- && dev->accel.ssv_len >= 0) {
-                    if (dev->accel.cx >= dev->accel.clip_left && dev->accel.cx <= clip_r && dev->accel.cy >= dev->accel.clip_top && dev->accel.cy <= clip_b) {
+                    if ((dev->accel.cx >= clip_l) &&
+                        (dev->accel.cx <= clip_r) &&
+                        (dev->accel.cy >= clip_t) &&
+                        (dev->accel.cy <= clip_b)) {
                         switch ((mix_dat & mix_mask) ? frgd_mix : bkgd_mix) {
                             case 0:
                                 src_dat = bkgd_color;
@@ -1389,17 +1076,24 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
                             default:
                                 break;
                         }
+
                         READ((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
 
-                        if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
+                        if ((compare_mode == 0) ||
+                            ((compare_mode == 0x10) && (dest_dat >= compare)) ||
+                            ((compare_mode == 0x18) && (dest_dat < compare)) ||
+                            ((compare_mode == 0x20) && (dest_dat != compare)) ||
+                            ((compare_mode == 0x28) && (dest_dat == compare)) ||
+                            ((compare_mode == 0x30) && (dest_dat <= compare)) ||
+                            ((compare_mode == 0x38) && (dest_dat > compare))) {
                             old_dest_dat = dest_dat;
                             MIX(mix_dat & mix_mask, dest_dat, src_dat);
                             dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
 
                             if (dev->accel.ssv_draw) {
-                                if ((dev->accel.cmd & 4) && dev->accel.ssv_len) {
+                                if ((dev->accel.cmd & 0x04) && dev->accel.ssv_len) {
                                     WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
-                                } else if (!(dev->accel.cmd & 4)) {
+                                } else if (!(dev->accel.cmd & 0x04)) {
                                     WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
                                 }
                             }
@@ -1454,8 +1148,10 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
                 }
             } else {
                 while (count-- && (dev->accel.ssv_len >= 0)) {
-                    if ((dev->accel.cx >= dev->accel.clip_left) && (dev->accel.cx <= clip_r) &&
-                        (dev->accel.cy >= dev->accel.clip_top) && (dev->accel.cy <= clip_b)) {
+                    if ((dev->accel.cx >= clip_l) &&
+                        (dev->accel.cx <= clip_r) &&
+                        (dev->accel.cy >= clip_t) &&
+                        (dev->accel.cy <= clip_b)) {
                         switch ((mix_dat & mix_mask) ? frgd_mix : bkgd_mix) {
                             case 0:
                                 src_dat = bkgd_color;
@@ -1476,15 +1172,21 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
 
                         READ((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
 
-                        if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
+                        if ((compare_mode == 0) ||
+                            ((compare_mode == 0x10) && (dest_dat >= compare)) ||
+                            ((compare_mode == 0x18) && (dest_dat < compare)) ||
+                            ((compare_mode == 0x20) && (dest_dat != compare)) ||
+                            ((compare_mode == 0x28) && (dest_dat == compare)) ||
+                            ((compare_mode == 0x30) && (dest_dat <= compare)) ||
+                            ((compare_mode == 0x38) && (dest_dat > compare))) {
                             old_dest_dat = dest_dat;
                             MIX(mix_dat & mix_mask, dest_dat, src_dat);
                             dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
 
                             if (dev->accel.ssv_draw) {
-                                if ((dev->accel.cmd & 4) && dev->accel.ssv_len) {
+                                if ((dev->accel.cmd & 0x04) && dev->accel.ssv_len) {
                                     WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
-                                } else if (!(dev->accel.cmd & 4)) {
+                                } else if (!(dev->accel.cmd & 0x04)) {
                                     WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
                                 }
                             }
@@ -1576,47 +1278,25 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
 
         case 1: /*Draw line*/
             if (!cpu_input) {
-                dev->accel.xx_count = 0;
-                dev->accel.cx       = dev->accel.cur_x;
-                dev->accel.cy       = dev->accel.cur_y;
+                dev->accel.output = 0;
+                dev->accel.x_count = 0;
 
+                dev->accel.cx = dev->accel.cur_x;
                 if (dev->accel.cur_x >= 0x600)
                     dev->accel.cx |= ~0x5ff;
 
+                dev->accel.cy = dev->accel.cur_y;
                 if (dev->accel.cur_y >= 0x600)
                     dev->accel.cy |= ~0x5ff;
 
                 dev->accel.sy = dev->accel.maj_axis_pcnt;
 
-                ibm8514_log("Line Draw 8514/A, frgdmix=%d, bkgdmix=%d, c(%d,%d), pixcntl=%d, sy=%d, polyfill=%x, selfrmix=%02x, selbkmix=%02x, bkgdcol=%02x, frgdcol=%02x, clipt=%d, clipb=%d.\n", frgd_mix, bkgd_mix, dev->accel.cx, dev->accel.cy, pixcntl, dev->accel.sy, dev->accel.multifunc[0x0a] & 6, dev->accel.frgd_mix & 0x1f, dev->accel.bkgd_mix & 0x1f, bkgd_color, frgd_color, dev->accel.clip_top, clip_b);
+                ibm8514_log("Line Draw 8514/A CMD=%04x, frgdmix=%d, bkgdmix=%d, c(%d,%d), pixcntl=%d, sy=%d, polyfill=%x, selfrmix=%02x, selbkmix=%02x, bkgdcol=%02x, frgdcol=%02x, clipt=%d, clipb=%d.\n", dev->accel.cmd, frgd_mix, bkgd_mix, dev->accel.cx, dev->accel.cy, pixcntl, dev->accel.sy, dev->accel.multifunc[0x0a] & 6, dev->accel.frgd_mix & 0x1f, dev->accel.bkgd_mix & 0x1f, bkgd_color, frgd_color, dev->accel.clip_top, clip_b);
                 if (ibm8514_cpu_src(svga)) {
-                    if (dev->accel.cmd & 2) {
-                        if (dev->accel.cmd & 8) {
-                            if (and3 == 1) {
-                                dev->accel.sy += 4;
-                                if (dev->accel.cmd & 0x20)
-                                    dev->accel.cx += 4;
-                                else
-                                    dev->accel.cx -= 4;
-                            } else if (and3 == 2) {
-                                dev->accel.sy += 5;
-                                if (dev->accel.cmd & 0x20)
-                                    dev->accel.cx += 5;
-                                else
-                                    dev->accel.cx -= 5;
-                            } else if (and3 == 3) {
-                                dev->accel.sy += 6;
-                                if (dev->accel.cmd & 0x20)
-                                    dev->accel.cx += 6;
-                                else
-                                    dev->accel.cx -= 6;
-                            } else {
-                                dev->accel.sy += 3;
-                                if (dev->accel.cmd & 0x20)
-                                    dev->accel.cx += 3;
-                                else
-                                    dev->accel.cx -= 3;
-                            }
+                    if (dev->accel.cmd & 0x02) {
+                        if (!(dev->accel.cmd & 0x1000)) {
+                            if (dev->accel.cmd & 0x08)
+                                dev->accel.output = 1;
                         }
                     }
                     dev->data_available  = 0;
@@ -1629,12 +1309,18 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
                 }
             }
 
-            if (dev->accel.cmd & 8) { /*Vector Line*/
-                if (ibm8514_cpu_dest(svga) && cpu_input && (dev->accel.cmd & 2))
+            if (dev->accel.cmd & 0x08) { /*Vector Line*/
+                if (ibm8514_cpu_dest(svga) && cpu_input && (dev->accel.cmd & 0x02))
                     count >>= 1;
-                dev->accel.xx_count++;
+
+                if (dev->accel.cmd & 0x02)
+                    ibm8514_log("Line Draw Vector Single pixtrans=%04x, count=%d.\n", mix_dat, count);
+
                 while (count-- && (dev->accel.sy >= 0)) {
-                    if (dev->accel.cx >= dev->accel.clip_left && dev->accel.cx <= clip_r && dev->accel.cy >= dev->accel.clip_top && dev->accel.cy <= clip_b) {
+                    if ((dev->accel.cx >= clip_l) &&
+                        (dev->accel.cx <= clip_r) &&
+                        (dev->accel.cy >= clip_t) &&
+                        (dev->accel.cy <= clip_b)) {
                         if (ibm8514_cpu_dest(svga) && (pixcntl == 0)) {
                             mix_dat = mix_mask; /* Mix data = forced to foreground register. */
                         } else if (ibm8514_cpu_dest(svga) && (pixcntl == 3)) {
@@ -1649,94 +1335,72 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
                             if (pixcntl == 3)
                                 src_dat = ((src_dat & rd_mask) == rd_mask);
                         } else {
-                            switch ((mix_dat & mix_mask) ? frgd_mix : bkgd_mix) {
-                                case 0:
-                                    src_dat = bkgd_color;
-                                    break;
-                                case 1:
-                                    src_dat = frgd_color;
-                                    break;
-                                case 2:
-                                    src_dat = cpu_dat;
-                                    break;
-                                case 3:
-                                    src_dat = 0;
-                                    break;
+                            if (dev->accel.output) {
+                                switch ((mix_dat & 0x01) ? frgd_mix : bkgd_mix) {
+                                    case 0:
+                                        src_dat = bkgd_color;
+                                        break;
+                                    case 1:
+                                        src_dat = frgd_color;
+                                        break;
+                                    case 2:
+                                        src_dat = cpu_dat;
+                                        break;
+                                    case 3:
+                                        src_dat = 0;
+                                        break;
 
-                                default:
-                                    break;
+                                    default:
+                                        break;
+                                }
+                            } else {
+                                switch ((mix_dat & mix_mask) ? frgd_mix : bkgd_mix) {
+                                    case 0:
+                                        src_dat = bkgd_color;
+                                        break;
+                                    case 1:
+                                        src_dat = frgd_color;
+                                        break;
+                                    case 2:
+                                        src_dat = cpu_dat;
+                                        break;
+                                    case 3:
+                                        src_dat = 0;
+                                        break;
+
+                                    default:
+                                        break;
+                                }
                             }
                         }
 
                         READ((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
 
-                        if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
+                        if ((compare_mode == 0) ||
+                            ((compare_mode == 0x10) && (dest_dat >= compare)) ||
+                            ((compare_mode == 0x18) && (dest_dat < compare)) ||
+                            ((compare_mode == 0x20) && (dest_dat != compare)) ||
+                            ((compare_mode == 0x28) && (dest_dat == compare)) ||
+                            ((compare_mode == 0x30) && (dest_dat <= compare)) ||
+                            ((compare_mode == 0x38) && (dest_dat > compare))) {
                             old_dest_dat = dest_dat;
-                            MIX(mix_dat & mix_mask, dest_dat, src_dat);
+                            if (dev->accel.output) {
+                                MIX(mix_dat & 0x01, dest_dat, src_dat);
+                            } else {
+                                MIX(mix_dat & mix_mask, dest_dat, src_dat);
+                            }
                             dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
-                            if ((dev->accel.cmd & 2) && ibm8514_cpu_src(svga)) {
-                                if (and3 == 1) {
-                                    if (dev->accel.xx_count >= 2) {
-                                        if ((dev->accel.cmd & 4) && dev->accel.sy) {
-                                            WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
-                                        } else if (!(dev->accel.cmd & 4)) {
-                                            WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
-                                        }
-                                    }
-                                } else if (and3 == 2) {
-                                    if (dev->accel.xx_count == 2) {
-                                        if (count <= 2) {
-                                            if ((dev->accel.cmd & 4) && dev->accel.sy) {
-                                                WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
-                                            } else if (!(dev->accel.cmd & 4)) {
-                                                WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
-                                            }
-                                        }
-                                    } else if (dev->accel.xx_count >= 3) {
-                                        if ((dev->accel.cmd & 4) && dev->accel.sy) {
-                                            WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
-                                        } else if (!(dev->accel.cmd & 4)) {
-                                            WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
-                                        }
-                                    }
-                                } else if (and3 == 3) {
-                                    if (dev->accel.xx_count == 2) {
-                                        if (count <= 1) {
-                                            if ((dev->accel.cmd & 4) && dev->accel.sy) {
-                                                WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
-                                            } else if (!(dev->accel.cmd & 4)) {
-                                                WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
-                                            }
-                                        }
-                                    } else if (dev->accel.xx_count >= 3) {
-                                        if ((dev->accel.cmd & 4) && dev->accel.sy) {
-                                            WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
-                                        } else if (!(dev->accel.cmd & 4)) {
-                                            WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
-                                        }
-                                    }
-                                } else {
-                                    if (dev->accel.xx_count == 1) {
-                                        if (!count) {
-                                            if ((dev->accel.cmd & 4) && dev->accel.sy) {
-                                                WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
-                                            } else if (!(dev->accel.cmd & 4)) {
-                                                WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
-                                            }
-                                        }
-                                    } else if (dev->accel.xx_count >= 2) {
-                                        if ((dev->accel.cmd & 4) && dev->accel.sy) {
-                                            WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
-                                        } else if (!(dev->accel.cmd & 4)) {
-                                            WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
-                                        }
-                                    }
+                            if ((dev->accel.cmd & 0x02) && ibm8514_cpu_src(svga)) {
+                                if ((dev->accel.cmd & 0x04) && dev->accel.sy) {
+                                    WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
+                                } else if (!(dev->accel.cmd & 0x04)) {
+                                    WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
                                 }
                             } else {
                                 if (ibm8514_cpu_src(svga) || !cpu_input) {
-                                    if ((dev->accel.cmd & 4) && dev->accel.sy) {
+                                    if ((dev->accel.cmd & 0x04) && dev->accel.sy) {
                                         WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
-                                    } else if (!(dev->accel.cmd & 4)) {
+                                    } else if (!(dev->accel.cmd & 0x04)) {
                                         WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
                                     }
                                 }
@@ -1744,16 +1408,20 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
                         }
                     }
 
-                    mix_dat <<= 1;
-                    mix_dat |= 1;
+                    if (!dev->accel.sy)
+                        break;
+
+                    if (dev->accel.output)
+                        mix_dat >>= 1;
+                    else {
+                        mix_dat <<= 1;
+                        mix_dat |= 1;
+                    }
+
                     if (dev->bpp)
                         cpu_dat >>= 16;
                     else
                         cpu_dat >>= 8;
-
-                    if (dev->accel.sy == 0) {
-                        break;
-                    }
 
                     switch (dev->accel.cmd & 0xe0) {
                         case 0x00:
@@ -1793,19 +1461,24 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
                 }
                 dev->accel.cur_x = dev->accel.cx;
                 dev->accel.cur_y = dev->accel.cy;
-            } else { /*Bresenham*/
+                dev->accel.x_count = 0;
+                dev->accel.output = 0;
+            } else { /*Bresenham Line*/
                 if (pixcntl == 1) {
                     dev->accel.temp_cnt = 8;
                     while (count-- && (dev->accel.sy >= 0)) {
-                        if (dev->accel.temp_cnt == 0) {
+                        if (!dev->accel.temp_cnt) {
                             dev->accel.temp_cnt = 8;
-                            mix_dat             = old_mix_dat;
+                            mix_dat = old_mix_dat;
                         }
-                        if (dev->accel.cx >= dev->accel.clip_left && dev->accel.cx <= clip_r && dev->accel.cy >= dev->accel.clip_top && dev->accel.cy <= clip_b) {
+                        if ((dev->accel.cx >= clip_l) &&
+                            (dev->accel.cx <= clip_r) &&
+                            (dev->accel.cy >= clip_t) &&
+                            (dev->accel.cy <= clip_b)) {
                             if (ibm8514_cpu_dest(svga)) {
                                 READ((dev->accel.cy * dev->pitch) + dev->accel.cx, src_dat);
                             } else
-                                switch ((mix_dat & 1) ? frgd_mix : bkgd_mix) {
+                                switch ((mix_dat & 0x01) ? frgd_mix : bkgd_mix) {
                                     case 0:
                                         src_dat = bkgd_color;
                                         break;
@@ -1825,13 +1498,19 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
 
                             READ((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
 
-                            if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
+                            if ((compare_mode == 0) ||
+                                ((compare_mode == 0x10) && (dest_dat >= compare)) ||
+                                ((compare_mode == 0x18) && (dest_dat < compare)) ||
+                                ((compare_mode == 0x20) && (dest_dat != compare)) ||
+                                ((compare_mode == 0x28) && (dest_dat == compare)) ||
+                                ((compare_mode == 0x30) && (dest_dat <= compare)) ||
+                                ((compare_mode == 0x38) && (dest_dat > compare))) {
                                 old_dest_dat = dest_dat;
-                                MIX(mix_dat & 1, dest_dat, src_dat);
+                                MIX(mix_dat & 0x01, dest_dat, src_dat);
                                 dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
-                                if ((dev->accel.cmd & 4) && dev->accel.sy) {
+                                if ((dev->accel.cmd & 0x04) && dev->accel.sy) {
                                     WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
-                                } else if (!(dev->accel.cmd & 4)) {
+                                } else if (!(dev->accel.cmd & 0x04)) {
                                     WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
                                 }
                             }
@@ -1844,9 +1523,8 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
                         else
                             cpu_dat >>= 8;
 
-                        if (dev->accel.sy == 0) {
+                        if (dev->accel.sy == 0)
                             break;
-                        }
 
                         if (dev->accel.cmd & 0x40) {
                             if (dev->accel.cmd & 0x80)
@@ -1882,7 +1560,10 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
                     }
                 } else {
                     while (count-- && (dev->accel.sy >= 0)) {
-                        if ((dev->accel.cx) >= dev->accel.clip_left && (dev->accel.cx) <= clip_r && (dev->accel.cy) >= dev->accel.clip_top && (dev->accel.cy) <= clip_b) {
+                        if ((dev->accel.cx >= clip_l) &&
+                            (dev->accel.cx <= clip_r) &&
+                            (dev->accel.cy >= clip_t) &&
+                            (dev->accel.cy <= clip_b)) {
                             if (ibm8514_cpu_dest(svga) && (pixcntl == 0)) {
                                 mix_dat = mix_mask; /* Mix data = forced to foreground register. */
                             } else if (ibm8514_cpu_dest(svga) && (pixcntl == 3)) {
@@ -1917,13 +1598,19 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
 
                             READ((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
 
-                            if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
+                            if ((compare_mode == 0) ||
+                                ((compare_mode == 0x10) && (dest_dat >= compare)) ||
+                                ((compare_mode == 0x18) && (dest_dat < compare)) ||
+                                ((compare_mode == 0x20) && (dest_dat != compare)) ||
+                                ((compare_mode == 0x28) && (dest_dat == compare)) ||
+                                ((compare_mode == 0x30) && (dest_dat <= compare)) ||
+                                ((compare_mode == 0x38) && (dest_dat > compare))) {
                                 old_dest_dat = dest_dat;
                                 MIX(mix_dat & mix_mask, dest_dat, src_dat);
                                 dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
-                                if ((dev->accel.cmd & 4) && dev->accel.sy) {
+                                if ((dev->accel.cmd & 0x04) && dev->accel.sy) {
                                     WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
-                                } else if (!(dev->accel.cmd & 4)) {
+                                } else if (!(dev->accel.cmd & 0x04)) {
                                     WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
                                 }
                             }
@@ -1981,79 +1668,60 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
         case 3: /*Rectangle fill (Y direction)*/
         case 4: /*Rectangle fill (Y direction using nibbles)*/
             if (!cpu_input) {
-                dev->accel.x_count     = 0;
-                dev->accel.xx_count    = 0;
-                dev->accel.odd_out     = 0;
-                dev->accel.odd_in      = 0;
-                dev->accel.input       = 0;
-                dev->accel.output      = 0;
-                dev->accel.newdest_out = 0;
-                dev->accel.newdest_in  = 0;
-
-                dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
-                dev->accel.sy = dev->accel.multifunc[0] & 0x7ff;
+                dev->accel.x_count = 0;
+                dev->accel.output = 0;
+                dev->accel.input = 0;
+                dev->accel.input2 = 0;
+                dev->accel.odd_in = 0;
 
                 dev->accel.cx = dev->accel.cur_x;
                 if (dev->accel.cur_x >= 0x600)
                     dev->accel.cx |= ~0x5ff;
+
                 dev->accel.cy = dev->accel.cur_y;
                 if (dev->accel.cur_y >= 0x600)
                     dev->accel.cy |= ~0x5ff;
 
-                if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && ((dev->accel_bpp == 24) || (dev->accel_bpp == 8)))
+                dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
+                dev->accel.sy = dev->accel.multifunc[0] & 0x7ff;
+
+                if ((dev->accel_bpp == 24) || (dev->accel_bpp <= 8))
                     dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
+                else if (dev->bpp)
+                    dev->accel.dest = (dev->accel.ge_offset << 1) + (dev->accel.cy * dev->pitch);
                 else
-                    dev->accel.dest = dev->accel.cy * dev->pitch;
+                    dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
 
                 if (cmd == 4)
-                    dev->accel.cmd |= 2;
+                    dev->accel.cmd |= 0x02;
                 else if (cmd == 3)
-                    dev->accel.cmd &= ~2;
+                    dev->accel.cmd &= ~0x02;
 
                 if (ibm8514_cpu_src(svga)) {
-                    if (dev->accel.cmd & 2) {
+                    if (dev->accel.cmd & 0x02) {
                         if (!(dev->accel.cmd & 0x1000)) {
-                            if (!(dev->accel.cmd & 8)) {
-                                dev->accel.sx += and3;
-                                dev->accel.nibbleset = (uint8_t *) calloc(1, (dev->accel.sx >> 3) + 1);
-                                dev->accel.writemono = (uint8_t *) calloc(1, (dev->accel.sx >> 3) + 1);
-                                dev->accel.sys_cnt   = (dev->accel.sx >> 3) + 1;
+                            if (dev->accel.cmd & 0x08) {
+                                dev->accel.x_count = dev->accel.cx - (and3 + 3);
+                                dev->accel.sx += (and3 + 3);
                             } else {
-                                if (and3 == 1) {
-                                    dev->accel.sx += 4;
+                                dev->accel.x_count = dev->accel.cx;
+                                if (and3) {
                                     if (dev->accel.cmd & 0x20)
-                                        dev->accel.cx += 4;
+                                        dev->accel.x_count -= and3;
                                     else
-                                        dev->accel.cx -= 4;
-                                } else if (and3 == 2) {
-                                    dev->accel.sx += 5;
-                                    if (dev->accel.cmd & 0x20)
-                                        dev->accel.cx += 5;
-                                    else
-                                        dev->accel.cx -= 5;
-                                } else if (and3 == 3) {
-                                    dev->accel.sx += 6;
-                                    if (dev->accel.cmd & 0x20)
-                                        dev->accel.cx += 6;
-                                    else
-                                        dev->accel.cx -= 6;
-                                } else {
-                                    dev->accel.sx += 3;
-                                    if (dev->accel.cmd & 0x20)
-                                        dev->accel.cx += 3;
-                                    else
-                                        dev->accel.cx -= 3;
+                                        dev->accel.x_count += and3;
+
+                                    dev->accel.sx += 8;
                                 }
                             }
                         }
                     } else {
-                        if (!(dev->accel.cmd & 0x40) && (frgd_mix == 2) && (bkgd_mix == 2) && (pixcntl == 0) && (cmd == 2)) {
-                            if (!(dev->accel.sx & 1)) {
-                                dev->accel.output = 1;
-                                if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && ((dev->accel_bpp == 24) || (dev->accel_bpp == 8)))
-                                    dev->accel.newdest_out = (dev->accel.ge_offset << 2) + ((dev->accel.cy + 1) * dev->pitch);
-                                else
-                                    dev->accel.newdest_out = (dev->accel.cy + 1) * dev->pitch;
+                        if (dev->accel.cmd & 0x1000) {
+                            if (dev->accel.cmd & 0x200) {
+                                if (dev->accel.cmd & 0x04) {
+                                    dev->accel.output = 1;
+                                    dev->accel.sx -= 2;
+                                }
                             }
                         }
                     }
@@ -2061,35 +1729,35 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
                     dev->data_available2 = 0;
                     return; /*Wait for data from CPU*/
                 } else if (ibm8514_cpu_dest(svga)) {
-                    if (!(dev->accel.cmd & 2) && (frgd_mix == 2) && (pixcntl == 0) && (cmd == 2)) {
-                        if (!(dev->accel.sx & 1)) {
-                            dev->accel.input      = 1;
-                            if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && ((dev->accel_bpp == 24) || (dev->accel_bpp == 8)))
-                                dev->accel.newdest_in = (dev->accel.ge_offset << 2) + ((dev->accel.cy + 1) * dev->pitch);
-                            else
-                                dev->accel.newdest_in = (dev->accel.cy + 1) * dev->pitch;
-                        }
-                    } else if (dev->accel.cmd & 2) {
-                        if (dev->accel.cmd & 8) {
-                            dev->accel.sx += and3;
-                            dev->accel.nibbleset = (uint8_t *) calloc(1, (dev->accel.sx >> 3) + 1);
-                            dev->accel.writemono = (uint8_t *) calloc(1, (dev->accel.sx >> 3) + 1);
-                            dev->accel.sys_cnt   = (dev->accel.sx >> 3) + 1;
+                    if (!(dev->accel.cmd & 0x02)) {
+                        if (dev->accel.cmd & 0x1000) {
+                            if (dev->accel.cmd & 0x200) {
+                                if (!(dev->accel.sx & 1) && !(dev->accel.cmd & 0x04)) {
+                                    dev->accel.input = 1;
+                                } else if (dev->accel.cmd & 0x04) {
+                                    dev->accel.input2 = 1;
+                                    dev->accel.sx -= 2;
+                                }
+                            }
                         }
                     }
+                    ibm8514_log("INPUT=%d.\n", dev->accel.input);
                     dev->data_available  = 1;
                     dev->data_available2 = 1;
                     return; /*Wait for data from CPU*/
                 }
             }
 
-            if (dev->accel.cmd & 2) {
+            ibm8514_log("Rectangle %d: full=%04x, odd=%d, c(%d,%d), frgdmix=%d, bkgdmix=%d, xcount=%d, and3=%d, len(%d,%d), CURX=%d, Width=%d, pixcntl=%d, mix_dat=%08x, count=%d, cpu_data=%08x, cpu_input=%d.\n", cmd, dev->accel.cmd, dev->accel.input, dev->accel.cx, dev->accel.cy, frgd_mix, bkgd_mix, dev->accel.x_count, and3, dev->accel.sx, dev->accel.sy, dev->accel.cur_x, dev->accel.maj_axis_pcnt, pixcntl, mix_dat, count, cpu_dat, cpu_input);
+
+            if (dev->accel.cmd & 0x08) { /*Vectored Rectangle*/
                 if (cpu_input) {
-rect_fill_pix:
-                    if ((dev->accel.cmd & 8) && ibm8514_cpu_src(svga)) {
-                        dev->accel.xx_count++;
+                    if (ibm8514_cpu_src(svga)) {
                         while (count-- && (dev->accel.sy >= 0)) {
-                            if (dev->accel.cx >= dev->accel.clip_left && dev->accel.cx <= clip_r && dev->accel.cy >= dev->accel.clip_top && dev->accel.cy <= clip_b) {
+                            if ((dev->accel.cx >= clip_l) &&
+                                (dev->accel.cx <= clip_r) &&
+                                (dev->accel.cy >= clip_t) &&
+                                (dev->accel.cy <= clip_b)) {
                                 switch ((mix_dat & mix_mask) ? frgd_mix : bkgd_mix) {
                                     case 0:
                                         src_dat = bkgd_color;
@@ -2110,76 +1778,26 @@ rect_fill_pix:
 
                                 READ(dev->accel.dest + dev->accel.cx, dest_dat);
 
-                                if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
+                                if ((compare_mode == 0) ||
+                                    ((compare_mode == 0x10) && (dest_dat >= compare)) ||
+                                    ((compare_mode == 0x18) && (dest_dat < compare)) ||
+                                    ((compare_mode == 0x20) && (dest_dat != compare)) ||
+                                    ((compare_mode == 0x28) && (dest_dat == compare)) ||
+                                    ((compare_mode == 0x30) && (dest_dat <= compare)) ||
+                                    ((compare_mode == 0x38) && (dest_dat > compare))) {
                                     old_dest_dat = dest_dat;
                                     MIX(mix_dat & mix_mask, dest_dat, src_dat);
                                     dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
-                                    if (and3 == 1) {
-                                        if (dev->accel.xx_count >= 2) {
-                                            if ((dev->accel.cmd & 4) && dev->accel.sx) {
-                                                WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
-                                            } else if (!(dev->accel.cmd & 4)) {
-                                                WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
-                                            }
-                                        }
-                                    } else if (and3 == 2) {
-                                        if (dev->accel.xx_count == 2) {
-                                            if (count <= 2) {
-                                                if ((dev->accel.cmd & 4) && dev->accel.sx) {
-                                                    WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
-                                                } else if (!(dev->accel.cmd & 4)) {
-                                                    WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
-                                                }
-                                            }
-                                        } else if (dev->accel.xx_count >= 3) {
-                                            if ((dev->accel.cmd & 4) && dev->accel.sx) {
-                                                WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
-                                            } else if (!(dev->accel.cmd & 4)) {
-                                                WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
-                                            }
-                                        }
-                                    } else if (and3 == 3) {
-                                        if (dev->accel.xx_count == 2) {
-                                            if (count <= 1) {
-                                                if ((dev->accel.cmd & 4) && dev->accel.sx) {
-                                                    WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
-                                                } else if (!(dev->accel.cmd & 4)) {
-                                                    WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
-                                                }
-                                            }
-                                        } else if (dev->accel.xx_count >= 3) {
-                                            if ((dev->accel.cmd & 4) && dev->accel.sx) {
-                                                WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
-                                            } else if (!(dev->accel.cmd & 4)) {
-                                                WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
-                                            }
-                                        }
-                                    } else {
-                                        if (dev->accel.xx_count == 1) {
-                                            if (!count) {
-                                                if ((dev->accel.cmd & 4) && dev->accel.sx) {
-                                                    WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
-                                                } else if (!(dev->accel.cmd & 4)) {
-                                                    WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
-                                                }
-                                            }
-                                        } else if (dev->accel.xx_count >= 2) {
-                                            if ((dev->accel.cmd & 4) && dev->accel.sx) {
-                                                WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
-                                            } else if (!(dev->accel.cmd & 4)) {
-                                                WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
-                                            }
-                                        }
+                                    if ((dev->accel.cmd & 0x02) && (dev->accel.x_count != dev->accel.cx))
+                                        goto skip_vector_rect_write;
+
+                                    if ((dev->accel.cmd & 0x04) && dev->accel.sx) {
+                                        WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
+                                    } else if (!(dev->accel.cmd & 0x04)) {
+                                        WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
                                     }
                                 }
                             }
-
-                            mix_dat <<= 1;
-                            mix_dat |= 1;
-                            if (dev->bpp)
-                                cpu_dat >>= 16;
-                            else
-                                cpu_dat >>= 8;
 
                             switch (dev->accel.cmd & 0xe0) {
                                 case 0x00:
@@ -2205,17 +1823,42 @@ rect_fill_pix:
                                     break;
                             }
 
+skip_vector_rect_write:
+                            switch (dev->accel.cmd & 0xe0) {
+                                case 0x00:
+                                    dev->accel.x_count++;
+                                    break;
+                                case 0x20:
+                                    dev->accel.x_count++;
+                                    break;
+                                case 0x60:
+                                    dev->accel.x_count--;
+                                    break;
+                                case 0x80:
+                                    dev->accel.x_count--;
+                                    break;
+                                case 0xa0:
+                                    dev->accel.x_count--;
+                                    break;
+                                case 0xe0:
+                                    dev->accel.x_count++;
+                                    break;
+
+                                default:
+                                    break;
+                            }
+
+                            if (dev->bpp)
+                                cpu_dat >>= 16;
+                            else
+                                cpu_dat >>= 8;
+
+                            mix_dat <<= 1;
+                            mix_dat |= 1;
+
                             dev->accel.sx--;
                             if (dev->accel.sx < 0) {
                                 dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
-                                if (and3 == 1)
-                                    dev->accel.sx += 4;
-                                else if (and3 == 2)
-                                    dev->accel.sx += 5;
-                                else if (and3 == 3)
-                                    dev->accel.sx += 6;
-                                else
-                                    dev->accel.sx += 3;
 
                                 if (dev->accel.cmd & 0x20)
                                     dev->accel.cx -= (dev->accel.sx + 1);
@@ -2246,34 +1889,62 @@ rect_fill_pix:
                                         break;
                                 }
 
-                                if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && ((dev->accel_bpp == 24) || (dev->accel_bpp == 8)))
+                                if ((dev->accel_bpp == 24) || (dev->accel_bpp <= 8))
                                     dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
+                                else if (dev->bpp)
+                                    dev->accel.dest = (dev->accel.ge_offset << 1) + (dev->accel.cy * dev->pitch);
                                 else
-                                    dev->accel.dest = dev->accel.cy * dev->pitch;
+                                    dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
 
                                 dev->accel.sy--;
+                                dev->accel.x_count = 0;
                                 return;
                             }
                         }
-                        break;
-                    }
-                    if (count < 8) {
-                        while (count-- && (dev->accel.sy >= 0)) {
-                            if (dev->accel.cx >= dev->accel.clip_left && dev->accel.cx <= clip_r && dev->accel.cy >= dev->accel.clip_top && dev->accel.cy <= clip_b) {
-                                if (ibm8514_cpu_dest(svga) && (pixcntl == 0)) {
-                                    mix_dat = mix_mask; /* Mix data = forced to foreground register. */
-                                } else if (ibm8514_cpu_dest(svga) && (pixcntl == 3)) {
-                                    /* Mix data = current video memory value. */
-                                    READ(dev->accel.dest + dev->accel.cx, mix_dat);
-                                    mix_dat = ((mix_dat & rd_mask) == rd_mask);
-                                    mix_dat = mix_dat ? mix_mask : 0;
-                                }
+                    } else
+                        ibm8514_log("Vectored Rectangle with destination reads (TODO).\n");
+                } else
+                    ibm8514_log("Vectored Rectangle with normal processing (TODO).\n");
+            } else { /*Normal Rectangle*/
+                if (cpu_input) {
+                    while (count-- && (dev->accel.sy >= 0)) {
+                        if ((dev->accel.cx >= clip_l) &&
+                            (dev->accel.cx <= clip_r) &&
+                            (dev->accel.cy >= clip_t) &&
+                            (dev->accel.cy <= clip_b)) {
+                            if (ibm8514_cpu_dest(svga) && (pixcntl == 0)) {
+                                mix_dat = mix_mask; /* Mix data = forced to foreground register. */
+                            } else if (ibm8514_cpu_dest(svga) && (pixcntl == 3)) {
+                                /* Mix data = current video memory value. */
+                                READ(dev->accel.dest + dev->accel.cx, mix_dat);
+                                mix_dat = ((mix_dat & rd_mask) == rd_mask);
+                                mix_dat = mix_dat ? mix_mask : 0;
+                            }
 
-                                if (ibm8514_cpu_dest(svga)) {
-                                    READ(dev->accel.dest + dev->accel.cx, src_dat);
-                                    if (pixcntl == 3)
-                                        src_dat = ((src_dat & rd_mask) == rd_mask);
-                                } else
+                            if (ibm8514_cpu_dest(svga)) {
+                                READ(dev->accel.dest + dev->accel.cx, src_dat);
+                                if (pixcntl == 3)
+                                    src_dat = ((src_dat & rd_mask) == rd_mask);
+                            } else {
+                                if (dev->accel.cmd & 0x02) {
+                                    switch ((mix_dat & 0x01) ? frgd_mix : bkgd_mix) {
+                                        case 0:
+                                            src_dat = bkgd_color;
+                                            break;
+                                        case 1:
+                                            src_dat = frgd_color;
+                                            break;
+                                        case 2:
+                                            src_dat = cpu_dat;
+                                            break;
+                                        case 3:
+                                            src_dat = 0;
+                                            break;
+
+                                        default:
+                                            break;
+                                    }
+                                } else {
                                     switch ((mix_dat & mix_mask) ? frgd_mix : bkgd_mix) {
                                         case 0:
                                             src_dat = bkgd_color;
@@ -2291,418 +1962,114 @@ rect_fill_pix:
                                         default:
                                             break;
                                     }
+                                }
+                            }
 
-                                READ(dev->accel.dest + dev->accel.cx, dest_dat);
+                            READ(dev->accel.dest + dev->accel.cx, dest_dat);
 
-                                if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
-                                    old_dest_dat = dest_dat;
-                                    MIX(mix_dat & mix_mask, dest_dat, src_dat);
+                            if ((compare_mode == 0) ||
+                                ((compare_mode == 0x10) && (dest_dat >= compare)) ||
+                                ((compare_mode == 0x18) && (dest_dat < compare)) ||
+                                ((compare_mode == 0x20) && (dest_dat != compare)) ||
+                                ((compare_mode == 0x28) && (dest_dat == compare)) ||
+                                ((compare_mode == 0x30) && (dest_dat <= compare)) ||
+                                ((compare_mode == 0x38) && (dest_dat > compare))) {
+                                old_dest_dat = dest_dat;
+                                if (dev->accel.cmd & 0x02) {
+                                    MIX(mix_dat & 0x01, dest_dat, src_dat);
+                                    if ((dev->accel.x_count != dev->accel.cx) && !(dev->accel.cmd & 0x1000) && and3)
+                                        goto skip_nibble_rect_write;
+
                                     dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
-                                    WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
-                                }
-                            }
-                            mix_dat <<= 1;
-                            mix_dat |= 1;
-                            if (dev->bpp)
-                                cpu_dat >>= 16;
-                            else
-                                cpu_dat >>= 8;
-
-                            if (dev->accel.cmd & 0x20)
-                                dev->accel.cx++;
-                            else
-                                dev->accel.cx--;
-
-                            dev->accel.sx--;
-                            if (dev->accel.sx < 0) {
-                                dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
-
-                                if (dev->accel.cmd & 2) {
-                                    dev->accel.sx += (dev->accel.cur_x & 3);
-                                }
-
-                                if (dev->accel.cmd & 0x20) {
-                                    dev->accel.cx -= (dev->accel.sx) + 1;
-                                } else
-                                    dev->accel.cx += (dev->accel.sx) + 1;
-
-                                if (dev->accel.cmd & 0x80)
-                                    dev->accel.cy++;
-                                else
-                                    dev->accel.cy--;
-
-                                if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && ((dev->accel_bpp == 24) || (dev->accel_bpp == 8)))
-                                    dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
-                                else
-                                    dev->accel.dest = dev->accel.cy * dev->pitch;
-
-                                dev->accel.sy--;
-                                return;
-                            }
-                        }
-                    } else {
-                        while (count-- && (dev->accel.sy >= 0)) {
-                            if (dev->accel.cx >= dev->accel.clip_left && dev->accel.cx <= clip_r && dev->accel.cy >= dev->accel.clip_top && dev->accel.cy <= clip_b) {
-                                if (ibm8514_cpu_dest(svga) && (pixcntl == 0)) {
-                                    mix_dat = 1; /* Mix data = forced to foreground register. */
-                                } else if (ibm8514_cpu_dest(svga) && (pixcntl == 3)) {
-                                    /* Mix data = current video memory value. */
-                                    READ(dev->accel.dest + dev->accel.cx, mix_dat);
-                                    mix_dat = ((mix_dat & rd_mask) == rd_mask);
-                                    mix_dat = mix_dat ? 1 : 0;
-                                }
-
-                                if (ibm8514_cpu_dest(svga)) {
-                                    READ(dev->accel.dest + dev->accel.cx, src_dat);
-                                    if (pixcntl == 3)
-                                        src_dat = ((src_dat & rd_mask) == rd_mask);
-                                } else {
-                                    switch ((mix_dat & 1) ? frgd_mix : bkgd_mix) {
-                                        case 0:
-                                            src_dat = bkgd_color;
-                                            break;
-                                        case 1:
-                                            src_dat = frgd_color;
-                                            break;
-                                        case 2:
-                                            src_dat = cpu_dat;
-                                            break;
-                                        case 3:
-                                            src_dat = 0;
-                                            break;
-
-                                        default:
-                                            break;
-                                    }
-                                }
-
-                                READ(dev->accel.dest + dev->accel.cx, dest_dat);
-
-                                if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
-                                    old_dest_dat = dest_dat;
-                                    MIX(mix_dat & 1, dest_dat, src_dat);
-                                    dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
-                                    WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
-                                }
-                            }
-                            mix_dat >>= 1;
-                            if (dev->bpp)
-                                cpu_dat >>= 16;
-                            else
-                                cpu_dat >>= 8;
-
-                            if (dev->accel.cmd & 0x20)
-                                dev->accel.cx++;
-                            else
-                                dev->accel.cx--;
-
-                            dev->accel.sx--;
-                            if (dev->accel.sx < 0) {
-                                dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
-
-                                if (dev->accel.cmd & 2) {
-                                    if (!(dev->accel.cmd & 0x1000))
-                                        dev->accel.sx += (dev->accel.cur_x & 3);
-                                }
-
-                                if (dev->accel.cmd & 0x20)
-                                    dev->accel.cx -= (dev->accel.sx) + 1;
-                                else
-                                    dev->accel.cx += (dev->accel.sx) + 1;
-
-                                if (dev->accel.cmd & 2) {
-                                    if (dev->accel.cmd & 0x1000) {
-                                        dev->accel.cx = dev->accel.cur_x;
-                                        if (dev->accel.cur_x >= 0x600)
-                                            dev->accel.cx |= ~0x5ff;
-                                    }
-                                }
-
-                                if (dev->accel.cmd & 0x80)
-                                    dev->accel.cy++;
-                                else
-                                    dev->accel.cy--;
-
-                                if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && ((dev->accel_bpp == 24) || (dev->accel_bpp == 8)))
-                                    dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
-                                else
-                                    dev->accel.dest = dev->accel.cy * dev->pitch;
-
-                                dev->accel.sy--;
-                                return;
-                            }
-                        }
-                    }
-                } else {
-                    goto rect_fill;
-                }
-            } else {
-                if (cpu_input) {
-                    if (pixcntl == 2) {
-                        goto rect_fill_pix;
-                    } else {
-                        if (dev->accel.input && !dev->accel.output) {
-                            while (count-- && (dev->accel.sy >= 0)) {
-                                if (dev->accel.cx >= dev->accel.clip_left && dev->accel.cx <= clip_r && dev->accel.cy >= dev->accel.clip_top && dev->accel.cy <= clip_b) {
-                                    mix_dat = mix_mask; /* Mix data = forced to foreground register. */
-                                    if (!dev->accel.odd_in && !dev->accel.sx) {
-                                        READ(dev->accel.newdest_in + dev->accel.cur_x, src_dat);
-                                        READ(dev->accel.newdest_in + dev->accel.cur_x, dest_dat);
-                                    } else {
-                                        READ(dev->accel.dest + dev->accel.cx, src_dat);
-                                        READ(dev->accel.dest + dev->accel.cx, dest_dat);
-                                    }
-                                    if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
-                                        old_dest_dat = dest_dat;
-                                        MIX(mix_dat & mix_mask, dest_dat, src_dat);
-                                        dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
-                                        if (!dev->accel.odd_in && !dev->accel.sx) {
-                                            WRITE(dev->accel.newdest_in + dev->accel.cur_x, dest_dat);
-                                        } else {
-                                            WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
-                                        }
-                                    }
-                                }
-
-                                mix_dat <<= 1;
-                                mix_dat |= 1;
-
-                                if (dev->accel.cmd & 0x20)
-                                    dev->accel.cx++;
-                                else
-                                    dev->accel.cx--;
-
-                                dev->accel.sx--;
-                                if (dev->accel.odd_in) {
-                                    if (dev->accel.sx < 0) {
-                                        dev->accel.sx     = dev->accel.maj_axis_pcnt & 0x7ff;
-                                        dev->accel.odd_in = 0;
-                                        dev->accel.cx     = dev->accel.cur_x;
-                                        if (dev->accel.cmd & 0x80)
-                                            dev->accel.cy++;
-                                        else
-                                            dev->accel.cy--;
-
-                                        if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && ((dev->accel_bpp == 24) || (dev->accel_bpp == 8))) {
-                                            dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
-                                            dev->accel.newdest_in = (dev->accel.ge_offset << 2) + ((dev->accel.cy + 1) * dev->pitch);
-                                        } else {
-                                            dev->accel.dest       = dev->accel.cy * dev->pitch;
-                                            dev->accel.newdest_in = (dev->accel.cy + 1) * dev->pitch;
-                                        }
-                                        dev->accel.sy--;
-                                        return;
+                                    if ((dev->accel.cmd & 0x04) && dev->accel.sx) {
+                                        WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
+                                    } else if (!(dev->accel.cmd & 0x04)) {
+                                        WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
                                     }
                                 } else {
-                                    if (dev->accel.sx < 0) {
-                                        dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
-                                        dev->accel.sx--;
-                                        dev->accel.cx     = dev->accel.cur_x;
-                                        dev->accel.odd_in = 1;
-                                        if (dev->accel.cmd & 0x20)
-                                            dev->accel.cx++;
-                                        else
-                                            dev->accel.cx--;
-                                        if (dev->accel.cmd & 0x80)
-                                            dev->accel.cy++;
-                                        else
-                                            dev->accel.cy--;
-
-                                        if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && ((dev->accel_bpp == 24) || (dev->accel_bpp == 8))) {
-                                            dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
-                                            dev->accel.newdest_in = (dev->accel.ge_offset << 2) + ((dev->accel.cy + 1) * dev->pitch);
-                                        } else {
-                                            dev->accel.dest       = dev->accel.cy * dev->pitch;
-                                            dev->accel.newdest_in = (dev->accel.cy + 1) * dev->pitch;
-                                        }
-                                        dev->accel.sy--;
-                                        return;
-                                    }
-                                }
-                            }
-                        } else if (dev->accel.output && !dev->accel.input) {
-                            while (count-- && (dev->accel.sy >= 0)) {
-                                if (dev->accel.cx >= dev->accel.clip_left && dev->accel.cx <= clip_r && dev->accel.cy >= dev->accel.clip_top && dev->accel.cy <= clip_b) {
-                                    src_dat = cpu_dat;
-                                    if (!dev->accel.odd_out && !dev->accel.sx) {
-                                        READ(dev->accel.newdest_out + dev->accel.cur_x, dest_dat);
-                                    } else {
-                                        READ(dev->accel.dest + dev->accel.cx, dest_dat);
-                                    }
-
-                                    if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
-                                        old_dest_dat = dest_dat;
-                                        MIX(mix_dat & mix_mask, dest_dat, src_dat);
-                                        dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
-                                        if (!dev->accel.odd_out && !dev->accel.sx) {
-                                            WRITE(dev->accel.newdest_out + dev->accel.cur_x, dest_dat);
-                                        } else {
-                                            WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
-                                        }
-                                    }
-                                }
-
-                                mix_dat <<= 1;
-                                mix_dat |= 1;
-                                if (dev->bpp)
-                                    cpu_dat >>= 16;
-                                else
-                                    cpu_dat >>= 8;
-
-                                if (dev->accel.cmd & 0x20)
-                                    dev->accel.cx++;
-                                else
-                                    dev->accel.cx--;
-
-                                dev->accel.sx--;
-                                if (dev->accel.odd_out) {
-                                    if (dev->accel.sx < 0) {
-                                        dev->accel.sx      = dev->accel.maj_axis_pcnt & 0x7ff;
-                                        dev->accel.odd_out = 0;
-                                        dev->accel.cx      = dev->accel.cur_x;
-                                        if (dev->accel.cmd & 0x80)
-                                            dev->accel.cy++;
-                                        else
-                                            dev->accel.cy--;
-
-                                        if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && ((dev->accel_bpp == 24) || (dev->accel_bpp == 8))) {
-                                            dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
-                                            dev->accel.newdest_out = (dev->accel.ge_offset << 2) + ((dev->accel.cy + 1) * dev->pitch);
-                                        } else {
-                                            dev->accel.dest        = dev->accel.cy * dev->pitch;
-                                            dev->accel.newdest_out = (dev->accel.cy + 1) * dev->pitch;
-                                        }
-                                        dev->accel.sy--;
-                                        return;
-                                    }
-                                } else {
-                                    if (dev->accel.sx < 0) {
-                                        dev->accel.sx      = dev->accel.maj_axis_pcnt & 0x7ff;
-                                        dev->accel.odd_out = 1;
-                                        dev->accel.sx--;
-                                        dev->accel.cx = dev->accel.cur_x;
-                                        if (dev->accel.cmd & 0x20)
-                                            dev->accel.cx++;
-                                        else
-                                            dev->accel.cx--;
-                                        if (dev->accel.cmd & 0x80)
-                                            dev->accel.cy++;
-                                        else
-                                            dev->accel.cy--;
-
-                                        if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && ((dev->accel_bpp == 24) || (dev->accel_bpp == 8))) {
-                                            dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
-                                            dev->accel.newdest_out = (dev->accel.ge_offset << 2) + ((dev->accel.cy + 1) * dev->pitch);
-                                        } else {
-                                            dev->accel.dest        = dev->accel.cy * dev->pitch;
-                                            dev->accel.newdest_out = (dev->accel.cy + 1) * dev->pitch;
-                                        }
-                                        dev->accel.sy--;
-                                        return;
-                                    }
-                                }
-                            }
-                        } else {
-                            while (count-- && (dev->accel.sy >= 0)) {
-                                if (dev->accel.cx >= dev->accel.clip_left && dev->accel.cx <= clip_r && dev->accel.cy >= dev->accel.clip_top && dev->accel.cy <= clip_b) {
-                                    if (ibm8514_cpu_dest(svga) && (pixcntl == 0)) {
-                                        mix_dat = mix_mask; /* Mix data = forced to foreground register. */
-                                    } else if (ibm8514_cpu_dest(svga) && (pixcntl == 3)) {
-                                        /* Mix data = current video memory value. */
-                                        READ(dev->accel.dest + dev->accel.cx, mix_dat);
-                                        mix_dat = ((mix_dat & rd_mask) == rd_mask);
-                                        mix_dat = mix_dat ? mix_mask : 0;
-                                    }
-
-                                    if (ibm8514_cpu_dest(svga)) {
-                                        READ(dev->accel.dest + dev->accel.cx, src_dat);
+                                    if (ibm8514_cpu_dest(svga) && (cmd == 2)) {
                                         if (pixcntl == 3) {
-                                            src_dat = ((src_dat & rd_mask) == rd_mask);
-                                        }
-                                    } else
-                                        switch ((mix_dat & mix_mask) ? frgd_mix : bkgd_mix) {
-                                            case 0:
-                                                src_dat = bkgd_color;
-                                                break;
-                                            case 1:
-                                                src_dat = frgd_color;
-                                                break;
-                                            case 2:
-                                                src_dat = cpu_dat;
-                                                break;
-                                            case 3:
-                                                src_dat = 0;
-                                                break;
-
-                                            default:
-                                                break;
-                                        }
-
-                                    READ(dev->accel.dest + dev->accel.cx, dest_dat);
-
-                                    if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
-                                        old_dest_dat = dest_dat;
-                                        if (ibm8514_cpu_dest(svga)) {
-                                            if (pixcntl == 3) {
-                                                MIX(mix_dat & mix_mask, dest_dat, src_dat);
-                                            }
-                                        } else {
                                             MIX(mix_dat & mix_mask, dest_dat, src_dat);
                                         }
-                                        dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
+                                    } else {
+                                        MIX(mix_dat & mix_mask, dest_dat, src_dat);
+                                    }
+                                    dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
+                                    if ((dev->accel.cmd & 0x04) && dev->accel.sx) {
+                                        WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
+                                    } else if (!(dev->accel.cmd & 0x04)) {
                                         WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
                                     }
                                 }
-
-                                mix_dat <<= 1;
-                                mix_dat |= 1;
-                                if (dev->bpp)
-                                    cpu_dat >>= 16;
-                                else
-                                    cpu_dat >>= 8;
-
-                                if (dev->accel.cmd & 0x20)
-                                    dev->accel.cx++;
-                                else
-                                    dev->accel.cx--;
-
-                                dev->accel.sx--;
-                                if (dev->accel.sx < 0) {
-                                    dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
-
-                                    if (dev->accel.cmd & 0x20) {
-                                        dev->accel.cx -= (dev->accel.sx) + 1;
-                                    } else
-                                        dev->accel.cx += (dev->accel.sx) + 1;
-
-                                    if (dev->accel.cmd & 0x80)
-                                        dev->accel.cy++;
-                                    else
-                                        dev->accel.cy--;
-
-                                    if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && ((dev->accel_bpp == 24) || (dev->accel_bpp == 8)))
-                                        dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
-                                    else
-                                        dev->accel.dest = dev->accel.cy * dev->pitch;
-
-                                    dev->accel.sy--;
-                                    return;
-                                }
                             }
+                        }
+                        if (dev->accel.cmd & 0x20)
+                            dev->accel.cx++;
+                        else
+                            dev->accel.cx--;
+
+skip_nibble_rect_write:
+                        if (dev->accel.cmd & 0x20)
+                            dev->accel.x_count++;
+                        else
+                            dev->accel.x_count--;
+
+                        if (dev->accel.cmd & 0x02)
+                            mix_dat >>= 1;
+                        else {
+                            mix_dat <<= 1;
+                            mix_dat |= 1;
+                        }
+
+                        if (dev->bpp)
+                            cpu_dat >>= 16;
+                        else
+                            cpu_dat >>= 8;
+
+                        dev->accel.sx--;
+                        if (dev->accel.sx < 0) {
+                            dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
+                            if (dev->accel.input)
+                                dev->accel.odd_in = 1;
+                            if (dev->accel.output || dev->accel.input2)
+                                dev->accel.sx -= 2;
+
+                            if (dev->accel.cmd & 0x20)
+                                dev->accel.cx -= (dev->accel.sx + 1);
+                            else
+                                dev->accel.cx += (dev->accel.sx + 1);
+
+                            if (dev->accel.cmd & 0x80)
+                                dev->accel.cy++;
+                            else
+                                dev->accel.cy--;
+
+                            if ((dev->accel_bpp == 24) || (dev->accel_bpp <= 8))
+                                dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
+                            else if (dev->bpp)
+                                dev->accel.dest = (dev->accel.ge_offset << 1) + (dev->accel.cy * dev->pitch);
+                            else
+                                dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
+
+                            dev->accel.sy--;
+                            dev->accel.x_count = 0;
+                            return;
                         }
                     }
                 } else {
-rect_fill:
                     if (pixcntl == 1) {
                         if (dev->accel.cmd & 0x40) {
-                            count               = dev->accel.maj_axis_pcnt + 1;
+                            count = (dev->accel.maj_axis_pcnt & 0x7ff) + 1;
                             dev->accel.temp_cnt = 8;
                             while (count-- && dev->accel.sy >= 0) {
-                                if (dev->accel.temp_cnt == 0) {
+                                if (!dev->accel.temp_cnt) {
                                     mix_dat >>= 8;
                                     dev->accel.temp_cnt = 8;
                                 }
-                                if (dev->accel.cx >= dev->accel.clip_left && dev->accel.cx <= clip_r && dev->accel.cy >= dev->accel.clip_top && dev->accel.cy <= clip_b) {
+                                if ((dev->accel.cx >= clip_l) &&
+                                    (dev->accel.cx <= clip_r) &&
+                                    (dev->accel.cy >= clip_t) &&
+                                    (dev->accel.cy <= clip_b)) {
                                     switch ((mix_dat & mix_mask) ? frgd_mix : bkgd_mix) {
                                         case 0:
                                             src_dat = bkgd_color;
@@ -2711,8 +2078,6 @@ rect_fill:
                                             src_dat = frgd_color;
                                             break;
                                         case 2:
-                                            src_dat = 0;
-                                            break;
                                         case 3:
                                             src_dat = 0;
                                             break;
@@ -2723,11 +2088,16 @@ rect_fill:
 
                                     READ(dev->accel.dest + dev->accel.cx, dest_dat);
 
-                                    if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
+                                    if ((compare_mode == 0) ||
+                                        ((compare_mode == 0x10) && (dest_dat >= compare)) ||
+                                        ((compare_mode == 0x18) && (dest_dat < compare)) ||
+                                        ((compare_mode == 0x20) && (dest_dat != compare)) ||
+                                        ((compare_mode == 0x28) && (dest_dat == compare)) ||
+                                        ((compare_mode == 0x30) && (dest_dat <= compare)) ||
+                                        ((compare_mode == 0x38) && (dest_dat > compare))) {
                                         old_dest_dat = dest_dat;
                                         MIX(mix_dat & mix_mask, dest_dat, src_dat);
                                         dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
-
                                         WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
                                     }
                                 }
@@ -2748,36 +2118,38 @@ rect_fill:
                                     dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
 
                                     if (dev->accel.cmd & 0x20) {
-                                        dev->accel.cx -= (dev->accel.sx) + 1;
+                                        dev->accel.cx -= (dev->accel.sx + 1);
                                     } else
-                                        dev->accel.cx += (dev->accel.sx) + 1;
+                                        dev->accel.cx += (dev->accel.sx + 1);
 
                                     if (dev->accel.cmd & 0x80)
                                         dev->accel.cy++;
                                     else
                                         dev->accel.cy--;
 
-                                    if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && ((dev->accel_bpp == 24) || (dev->accel_bpp == 8)))
+                                    if ((dev->accel_bpp == 24) || (dev->accel_bpp <= 8))
                                         dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
+                                    else if (dev->bpp)
+                                        dev->accel.dest = (dev->accel.ge_offset << 1) + (dev->accel.cy * dev->pitch);
                                     else
-                                        dev->accel.dest = dev->accel.cy * dev->pitch;
+                                        dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
 
                                     dev->accel.sy--;
-
-                                    dev->accel.cur_x = dev->accel.cx;
-                                    dev->accel.cur_y = dev->accel.cy;
                                     return;
                                 }
                             }
                         } else {
                             dev->accel.temp_cnt = 8;
-                            while (count-- && dev->accel.sy >= 0) {
+                            while (count-- && (dev->accel.sy >= 0)) {
                                 if (!dev->accel.temp_cnt) {
                                     dev->accel.temp_cnt = 8;
-                                    mix_dat             = old_mix_dat;
+                                    mix_dat = old_mix_dat;
                                 }
-                                if (dev->accel.cx >= dev->accel.clip_left && dev->accel.cx <= clip_r && dev->accel.cy >= dev->accel.clip_top && dev->accel.cy <= clip_b) {
-                                    switch ((mix_dat & 1) ? frgd_mix : bkgd_mix) {
+                                if ((dev->accel.cx >= clip_l) &&
+                                    (dev->accel.cx <= clip_r) &&
+                                    (dev->accel.cy >= clip_t) &&
+                                    (dev->accel.cy <= clip_b)) {
+                                    switch ((mix_dat & 0x01) ? frgd_mix : bkgd_mix) {
                                         case 0:
                                             src_dat = bkgd_color;
                                             break;
@@ -2785,8 +2157,6 @@ rect_fill:
                                             src_dat = frgd_color;
                                             break;
                                         case 2:
-                                            src_dat = 0;
-                                            break;
                                         case 3:
                                             src_dat = 0;
                                             break;
@@ -2797,11 +2167,16 @@ rect_fill:
 
                                     READ(dev->accel.dest + dev->accel.cx, dest_dat);
 
-                                    if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
+                                    if ((compare_mode == 0) ||
+                                        ((compare_mode == 0x10) && (dest_dat >= compare)) ||
+                                        ((compare_mode == 0x18) && (dest_dat < compare)) ||
+                                        ((compare_mode == 0x20) && (dest_dat != compare)) ||
+                                        ((compare_mode == 0x28) && (dest_dat == compare)) ||
+                                        ((compare_mode == 0x30) && (dest_dat <= compare)) ||
+                                        ((compare_mode == 0x38) && (dest_dat > compare))) {
                                         old_dest_dat = dest_dat;
-                                        MIX(mix_dat & 1, dest_dat, src_dat);
+                                        MIX(mix_dat & 0x01, dest_dat, src_dat);
                                         dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
-
                                         WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
                                     }
                                 }
@@ -2819,167 +2194,193 @@ rect_fill:
                                     dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
 
                                     if (dev->accel.cmd & 0x20) {
-                                        dev->accel.cx -= (dev->accel.sx) + 1;
+                                        dev->accel.cx -= (dev->accel.sx + 1);
                                     } else
-                                        dev->accel.cx += (dev->accel.sx) + 1;
+                                        dev->accel.cx += (dev->accel.sx + 1);
 
                                     if (dev->accel.cmd & 0x80)
                                         dev->accel.cy++;
                                     else
                                         dev->accel.cy--;
 
-                                    if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && ((dev->accel_bpp == 24) || (dev->accel_bpp == 8)))
+                                    if ((dev->accel_bpp == 24) || (dev->accel_bpp <= 8))
                                         dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
+                                    else if (dev->bpp)
+                                        dev->accel.dest = (dev->accel.ge_offset << 1) + (dev->accel.cy * dev->pitch);
                                     else
-                                        dev->accel.dest = dev->accel.cy * dev->pitch;
+                                        dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
 
                                     dev->accel.sy--;
 
                                     if (dev->accel.sy < 0) {
-                                        dev->accel.cur_x = dev->accel.cx;
-                                        dev->accel.cur_y = dev->accel.cy;
+                                        if (cmd != 4) {
+                                            dev->accel.cur_x = dev->accel.cx;
+                                            dev->accel.cur_y = dev->accel.cy;
+                                        }
                                         return;
                                     }
                                 }
                             }
                         }
-                    } else {
-                        if ((dev->accel.multifunc[0x0a] & 6) == 4) {
-                            while (count-- && (dev->accel.sy >= 0)) {
-                                if (dev->accel.cx >= dev->accel.clip_left && dev->accel.cx <= clip_r && dev->accel.cy >= dev->accel.clip_top && dev->accel.cy <= clip_b) {
-                                    READ(dev->accel.dest + dev->accel.cx, mix_dat);
-                                    if ((mix_dat & rd_mask_polygon) == rd_mask_polygon)
-                                        dev->accel.fill_state = !dev->accel.fill_state;
+                    } else if ((dev->accel.multifunc[0x0a] & 0x06) == 0x04) { /*Polygon Draw Type A*/
+                        while (count-- && (dev->accel.sy >= 0)) {
+                            if ((dev->accel.cx >= clip_l) &&
+                                (dev->accel.cx <= clip_r) &&
+                                (dev->accel.cy >= clip_t) &&
+                                (dev->accel.cy <= clip_b)) {
+                                READ(dev->accel.dest + dev->accel.cx, mix_dat);
+                                if ((mix_dat & rd_mask_polygon) == rd_mask_polygon)
+                                    dev->accel.fill_state ^= 1;
 
-                                    READ(dev->accel.dest + dev->accel.cx, dest_dat);
-                                    old_dest_dat = dest_dat;
-                                    if (dev->accel.fill_state) {
-                                        if (!(rd_mask_polygon & 1) && (wrt_mask & 1)) {
-                                            MIX(mix_dat ^ rd_mask_polygon, dest_dat, mix_dat);
-                                            ibm8514_log("Filling c(%d,%d) without bit 0 of rdmask=%02x, wrtmask=%02x, mixdat=%02x, dest=%02x, old=%02x.\n", dev->accel.cx, dev->accel.cy, rd_mask_polygon, wrt_mask, mix_dat, dest_dat, old_dest_dat);
-                                            dest_dat &= ~rd_mask_polygon;
-                                        } else if ((rd_mask_polygon & 1) && (wrt_mask & 1)) {
-                                            ibm8514_log("Filling c(%d,%d) with bit 0 of rdmask=%02x, wrtmask=%02x.\n", dev->accel.cx, dev->accel.cy, rd_mask_polygon, wrt_mask);
-                                            dest_dat &= ~(rd_mask_polygon & wrt_mask);
-                                        }
-                                    } else {
-                                        if (!(rd_mask_polygon & 1) && (wrt_mask & 1))
-                                            dest_dat &= ~rd_mask_polygon;
-                                        else if ((rd_mask_polygon & 1) && (wrt_mask & 1))
-                                            dest_dat &= ~(rd_mask_polygon & wrt_mask);
+                                READ(dev->accel.dest + dev->accel.cx, dest_dat);
+                                old_dest_dat = dest_dat;
+                                if (dev->accel.fill_state) {
+                                    if (!(rd_mask_polygon & 0x01) && (wrt_mask & 0x01)) {
+                                        MIX(mix_dat ^ rd_mask_polygon, dest_dat, mix_dat);
+                                        ibm8514_log("Filling c(%d,%d) without bit 0 of rdmask=%02x, wrtmask=%02x, mixdat=%02x, dest=%02x, old=%02x.\n", dev->accel.cx, dev->accel.cy, rd_mask_polygon, wrt_mask, mix_dat, dest_dat, old_dest_dat);
+                                        dest_dat &= ~rd_mask_polygon;
+                                    } else if ((rd_mask_polygon & 0x01) && (wrt_mask & 0x01)) {
+                                        ibm8514_log("Filling c(%d,%d) with bit 0 of rdmask=%02x, wrtmask=%02x.\n", dev->accel.cx, dev->accel.cy, rd_mask_polygon, wrt_mask);
+                                        dest_dat &= ~(rd_mask_polygon & wrt_mask);
                                     }
+                                } else {
+                                    if (!(rd_mask_polygon & 0x01) && (wrt_mask & 0x01))
+                                        dest_dat &= ~rd_mask_polygon;
+                                    else if ((rd_mask_polygon & 0x01) && (wrt_mask & 0x01))
+                                        dest_dat &= ~(rd_mask_polygon & wrt_mask);
+                                }
 
+                                dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
+
+                                if ((compare_mode == 0) ||
+                                    ((compare_mode == 0x10) && (dest_dat >= compare)) ||
+                                    ((compare_mode == 0x18) && (dest_dat < compare)) ||
+                                    ((compare_mode == 0x20) && (dest_dat != compare)) ||
+                                    ((compare_mode == 0x28) && (dest_dat == compare)) ||
+                                    ((compare_mode == 0x30) && (dest_dat <= compare)) ||
+                                    ((compare_mode == 0x38) && (dest_dat > compare))) {
+                                    ibm8514_log("Results c(%d,%d):rdmask=%02x, wrtmask=%02x, mix=%02x, destdat=%02x, nowrite=%d.\n", dev->accel.cx, dev->accel.cy, rd_mask_polygon, wrt_mask, mix_dat, dest_dat, dev->accel.cx_back);
+                                    WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
+                                }
+                            }
+
+                            if (dev->accel.cmd & 0x20)
+                                dev->accel.cx++;
+                            else
+                                dev->accel.cx--;
+
+                            dev->accel.sx--;
+                            if (dev->accel.sx < 0) {
+                                dev->accel.fill_state = 0;
+                                dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
+
+                                if (dev->accel.cmd & 0x20)
+                                    dev->accel.cx -= (dev->accel.sx + 1);
+                                else
+                                    dev->accel.cx += (dev->accel.sx + 1);
+
+                                if (dev->accel.cmd & 0x80)
+                                    dev->accel.cy++;
+                                else
+                                    dev->accel.cy--;
+
+                                if ((dev->accel_bpp == 24) || (dev->accel_bpp <= 8))
+                                    dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
+                                else if (dev->bpp)
+                                    dev->accel.dest = (dev->accel.ge_offset << 1) + (dev->accel.cy * dev->pitch);
+                                else
+                                    dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
+
+                                dev->accel.sy--;
+
+                                if (dev->accel.sy < 0) {
+                                    ibm8514_log(".\n");
+                                    return;
+                                }
+                            }
+                        }
+                    } else {
+                        ibm8514_log("Polygon Draw Type=%02x, CL=%d, CR=%d.\n", dev->accel.multifunc[0x0a] & 0x06, clip_l, clip_r);
+                        while (count-- && dev->accel.sy >= 0) {
+                            if ((dev->accel.cx >= clip_l) &&
+                                (dev->accel.cx <= clip_r) &&
+                                (dev->accel.cy >= clip_t) &&
+                                (dev->accel.cy <= clip_b)) {
+                                switch ((mix_dat & mix_mask) ? frgd_mix : bkgd_mix) {
+                                    case 0:
+                                        src_dat = bkgd_color;
+                                        if (!bkgd_mix && (dev->accel.cmd & 0x40) && ((dev->accel.frgd_mix & 0x1f) == 7) && ((dev->accel.bkgd_mix & 0x1f) == 3) && !dev->bpp && (bkgd_color == 0x00)) /*For some reason, the September 1992 Mach8/32 drivers for Win3.x don't set the background colors properly.*/
+                                            src_dat = frgd_color;
+                                        break;
+                                    case 1:
+                                        src_dat = frgd_color;
+                                        break;
+                                    case 2:
+                                    case 3:
+                                        src_dat = 0;
+                                        break;
+
+                                    default:
+                                        break;
+                                }
+
+                                READ(dev->accel.dest + dev->accel.cx, dest_dat);
+
+                                if ((compare_mode == 0) ||
+                                    ((compare_mode == 0x10) && (dest_dat >= compare)) ||
+                                    ((compare_mode == 0x18) && (dest_dat < compare)) ||
+                                    ((compare_mode == 0x20) && (dest_dat != compare)) ||
+                                    ((compare_mode == 0x28) && (dest_dat == compare)) ||
+                                    ((compare_mode == 0x30) && (dest_dat <= compare)) ||
+                                    ((compare_mode == 0x38) && (dest_dat > compare))) {
+                                    old_dest_dat = dest_dat;
+                                    MIX(mix_dat & mix_mask, dest_dat, src_dat);
                                     dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
 
-                                    if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
-                                        ibm8514_log("Results c(%d,%d):rdmask=%02x, wrtmask=%02x, mix=%02x, destdat=%02x, nowrite=%d.\n", dev->accel.cx, dev->accel.cy, rd_mask_polygon, wrt_mask, mix_dat, dest_dat, dev->accel.cx_back);
+                                    if (dev->accel.cmd & 0x10) {
                                         WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
                                     }
                                 }
+                            } else
+                                ibm8514_log("Outside clipping.\n");
+
+                            mix_dat <<= 1;
+                            mix_dat |= 1;
+
+                            if (dev->accel.cmd & 0x20)
+                                dev->accel.cx++;
+                            else
+                                dev->accel.cx--;
+
+                            dev->accel.sx--;
+                            if (dev->accel.sx < 0) {
+                                dev->accel.fill_state = 0;
+                                dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
 
                                 if (dev->accel.cmd & 0x20)
-                                    dev->accel.cx++;
+                                    dev->accel.cx -= (dev->accel.sx + 1);
                                 else
-                                    dev->accel.cx--;
+                                    dev->accel.cx += (dev->accel.sx + 1);
 
-                                dev->accel.sx--;
-                                if (dev->accel.sx < 0) {
-                                    dev->accel.fill_state = 0;
-                                    dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
-
-                                    if (dev->accel.cmd & 0x20)
-                                        dev->accel.cx -= (dev->accel.sx) + 1;
-                                    else
-                                        dev->accel.cx += (dev->accel.sx) + 1;
-
-                                    if (dev->accel.cmd & 0x80)
-                                        dev->accel.cy++;
-                                    else
-                                        dev->accel.cy--;
-
-                                    dev->accel.dest = dev->accel.cy * dev->pitch;
-
-                                    dev->accel.sy--;
-
-                                    if (dev->accel.sy < 0) {
-                                        ibm8514_log(".\n");
-                                        return;
-                                    }
-                                }
-                            }
-                        } else {
-                            ibm8514_log("Rectangle Fill Normal CMD=%04x, CURRENT(%d,%d), sx=%d, FR(%02x), linedraw=%d.\n", dev->accel.cmd, dev->accel.cx, dev->accel.cy, dev->accel.sx, frgd_color, dev->accel.linedraw);
-                            while (count-- && dev->accel.sy >= 0) {
-                                if (dev->accel.cx >= dev->accel.clip_left && dev->accel.cx <= clip_r && dev->accel.cy >= dev->accel.clip_top && dev->accel.cy <= clip_b) {
-                                    switch ((mix_dat & mix_mask) ? frgd_mix : bkgd_mix) {
-                                        case 0:
-                                            src_dat = bkgd_color;
-                                            if (!bkgd_mix && (dev->accel.cmd & 0x40) && ((dev->accel.frgd_mix & 0x1f) == 7) && ((dev->accel.bkgd_mix & 0x1f) == 3) && !dev->bpp && (bkgd_color == 0x00)) /*For some reason, the September 1992 Mach8/32 drivers for Win3.x don't set the background colors properly.*/
-                                                src_dat = frgd_color;
-                                            break;
-                                        case 1:
-                                            src_dat = frgd_color;
-                                            break;
-                                        case 2:
-                                            src_dat = 0;
-                                            break;
-                                        case 3:
-                                            src_dat = 0;
-                                            break;
-
-                                        default:
-                                            break;
-                                    }
-
-
-                                    READ(dev->accel.dest + dev->accel.cx, dest_dat);
-
-                                    if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
-                                        old_dest_dat = dest_dat;
-                                        MIX(mix_dat & mix_mask, dest_dat, src_dat);
-                                        dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
-
-                                        if (dev->accel.cmd & 0x10) {
-                                            WRITE(dev->accel.dest + dev->accel.cx, dest_dat);
-                                        }
-                                    }
-                                }
-
-                                mix_dat <<= 1;
-                                mix_dat |= 1;
-
-                                if (dev->accel.cmd & 0x20)
-                                    dev->accel.cx++;
+                                if (dev->accel.cmd & 0x80)
+                                    dev->accel.cy++;
                                 else
-                                    dev->accel.cx--;
+                                    dev->accel.cy--;
 
-                                dev->accel.sx--;
-                                if (dev->accel.sx < 0) {
-                                    dev->accel.fill_state = 0;
-                                    dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
+                                if ((dev->accel_bpp == 24) || (dev->accel_bpp <= 8))
+                                    dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
+                                else if (dev->bpp)
+                                    dev->accel.dest = (dev->accel.ge_offset << 1) + (dev->accel.cy * dev->pitch);
+                                else
+                                    dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
 
-                                    if (dev->accel.cmd & 0x20)
-                                        dev->accel.cx -= (dev->accel.sx) + 1;
-                                    else
-                                        dev->accel.cx += (dev->accel.sx) + 1;
-
-                                    if (dev->accel.cmd & 0x80)
-                                        dev->accel.cy++;
-                                    else
-                                        dev->accel.cy--;
-
-                                    if (((dev->local & 0xff) >= 0x02) && dev->accel.ge_offset && ((dev->accel_bpp == 24) || (dev->accel_bpp == 8)))
-                                        dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
-                                    else
-                                        dev->accel.dest = dev->accel.cy * dev->pitch;
-
-                                    dev->accel.sy--;
-
-                                    if (dev->accel.sy < 0) {
+                                dev->accel.sy--;
+                                if (dev->accel.sy < 0) {
+                                    if (cmd != 4) {
                                         dev->accel.cur_x = dev->accel.cx;
                                         dev->accel.cur_y = dev->accel.cy;
-                                        return;
                                     }
+                                    return;
                                 }
                             }
                         }
@@ -2990,14 +2391,15 @@ rect_fill:
 
         case 5: /*Draw Polygon Boundary Line*/ {
             if (!cpu_input) {
+                dev->accel.sy = dev->accel.maj_axis_pcnt_no_limit;
+
                 dev->accel.cx = dev->accel.cur_x;
                 if (dev->accel.cur_x >= 0x600)
                     dev->accel.cx |= ~0x5ff;
+
                 dev->accel.cy = dev->accel.cur_y;
                 if (dev->accel.cur_y >= 0x600)
                     dev->accel.cy |= ~0x5ff;
-
-                dev->accel.sy = dev->accel.maj_axis_pcnt_no_limit;
 
                 if (dev->accel.cmd & 0x80)
                     dev->accel.oldcy = dev->accel.cy + 1;
@@ -3017,14 +2419,15 @@ rect_fill:
                 }
             }
 
-            if (dev->accel.cmd & 8) {
+            if (dev->accel.cmd & 0x08) { /*Vectored Boundary Line*/
                 while (count-- && (dev->accel.sy >= 0)) {
-                    if (dev->accel.cx < 0)
-                        dev->accel.cx = 0;
-                    if (dev->accel.cy < 0)
-                        dev->accel.cy = 0;
+                    if (dev->accel.cx < clip_l)
+                        dev->accel.cx = clip_l;
 
-                    if (dev->accel.cx >= dev->accel.clip_left && dev->accel.cx <= clip_r && dev->accel.cy >= dev->accel.clip_top && dev->accel.cy <= clip_b) {
+                    if ((dev->accel.cx >= clip_l) &&
+                        (dev->accel.cx <= clip_r) &&
+                        (dev->accel.cy >= clip_t) &&
+                        (dev->accel.cy <= clip_b)) {
                         switch ((mix_dat & mix_mask) ? frgd_mix : bkgd_mix) {
                             case 0:
                                 src_dat = bkgd_color;
@@ -3046,16 +2449,22 @@ rect_fill:
 
                         READ((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
 
-                        if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
+                        if ((compare_mode == 0) ||
+                            ((compare_mode == 0x10) && (dest_dat >= compare)) ||
+                            ((compare_mode == 0x18) && (dest_dat < compare)) ||
+                            ((compare_mode == 0x20) && (dest_dat != compare)) ||
+                            ((compare_mode == 0x28) && (dest_dat == compare)) ||
+                            ((compare_mode == 0x30) && (dest_dat <= compare)) ||
+                            ((compare_mode == 0x38) && (dest_dat > compare))) {
                             old_dest_dat = dest_dat;
                             MIX(mix_dat & mix_mask, dest_dat, src_dat);
                             dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
                             if (dev->accel.cmd & 0x10) {
-                                if (dev->accel.sy && (dev->accel.cmd & 4)) {
+                                if (dev->accel.sy && (dev->accel.cmd & 0x04)) {
                                     if (dev->accel.oldcy != dev->accel.cy) {
                                         WRITE((dev->accel.cy * dev->pitch) + (dev->accel.cx), dest_dat);
                                     }
-                                } else if (!(dev->accel.cmd & 4)) {
+                                } else if (!(dev->accel.cmd & 0x04)) {
                                     if (dev->accel.oldcy != dev->accel.cy) {
                                         WRITE((dev->accel.cy * dev->pitch) + (dev->accel.cx), dest_dat);
                                     }
@@ -3116,12 +2525,15 @@ rect_fill:
 
                     dev->accel.sy--;
                 }
-            } else {
+            } else { /*Vectored Bresenham*/
                 while (count-- && (dev->accel.sy >= 0)) {
-                    if (dev->accel.cx < dev->accel.clip_left)
-                        dev->accel.cx = dev->accel.clip_left;
+                    if (dev->accel.cx < clip_l)
+                        dev->accel.cx = clip_l;
 
-                    if (dev->accel.cx >= dev->accel.clip_left && dev->accel.cx <= clip_r && dev->accel.cy >= dev->accel.clip_top && dev->accel.cy <= clip_b) {
+                    if ((dev->accel.cx >= clip_l) &&
+                        (dev->accel.cx <= clip_r) &&
+                        (dev->accel.cy >= clip_t) &&
+                        (dev->accel.cy <= clip_b)) {
                         switch ((mix_dat & mix_mask) ? frgd_mix : bkgd_mix) {
                             case 0:
                                 src_dat = bkgd_color;
@@ -3142,7 +2554,13 @@ rect_fill:
 
                         READ((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
 
-                        if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
+                        if ((compare_mode == 0) ||
+                            ((compare_mode == 0x10) && (dest_dat >= compare)) ||
+                            ((compare_mode == 0x18) && (dest_dat < compare)) ||
+                            ((compare_mode == 0x20) && (dest_dat != compare)) ||
+                            ((compare_mode == 0x28) && (dest_dat == compare)) ||
+                            ((compare_mode == 0x30) && (dest_dat <= compare)) ||
+                            ((compare_mode == 0x38) && (dest_dat > compare))) {
                             old_dest_dat = dest_dat;
                             MIX(mix_dat & mix_mask, dest_dat, src_dat);
                             dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
@@ -3209,38 +2627,50 @@ rect_fill:
             if (!cpu_input) /*!cpu_input is trigger to start operation*/
             {
                 dev->accel.x_count = 0;
-                dev->accel.output  = 0;
-
-                dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
-                dev->accel.sy = dev->accel.multifunc[0] & 0x7ff;
 
                 dev->accel.dx = dev->accel.destx;
-                dev->accel.dy = dev->accel.desty;
-
                 if (dev->accel.destx >= 0x600)
                     dev->accel.dx |= ~0x5ff;
+
+                dev->accel.dy = dev->accel.desty;
                 if (dev->accel.desty >= 0x600)
                     dev->accel.dy |= ~0x5ff;
 
                 dev->accel.cx = dev->accel.cur_x;
-                dev->accel.cy = dev->accel.cur_y;
-
                 if (dev->accel.cur_x >= 0x600)
                     dev->accel.cx |= ~0x5ff;
+
+                dev->accel.cy = dev->accel.cur_y;
                 if (dev->accel.cur_y >= 0x600)
                     dev->accel.cy |= ~0x5ff;
 
-                dev->accel.src  = dev->accel.cy * dev->pitch;
-                dev->accel.dest = dev->accel.dy * dev->pitch;
+                dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
+                dev->accel.sy = dev->accel.multifunc[0] & 0x7ff;
+
+                if ((dev->accel_bpp == 24) || (dev->accel_bpp <= 8)) {
+                    dev->accel.src  = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
+                    dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.dy * dev->pitch);
+                } else if (dev->bpp) {
+                    dev->accel.src  = (dev->accel.ge_offset << 1) + (dev->accel.cy * dev->pitch);
+                    dev->accel.dest = (dev->accel.ge_offset << 1) + (dev->accel.dy * dev->pitch);
+                } else {
+                    dev->accel.src  = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
+                    dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.dy * dev->pitch);
+                }
                 dev->accel.fill_state = 0;
 
                 if (ibm8514_cpu_src(svga)) {
-                    if (dev->accel.cmd & 2) {
+                    if (dev->accel.cmd & 0x02) {
                         if (!(dev->accel.cmd & 0x1000)) {
-                            dev->accel.sx += (dev->accel.cur_x & 3);
-                            dev->accel.nibbleset = (uint8_t *) calloc(1, (dev->accel.sx >> 3) + 1);
-                            dev->accel.writemono = (uint8_t *) calloc(1, (dev->accel.sx >> 3) + 1);
-                            dev->accel.sys_cnt   = (dev->accel.sx >> 3) + 1;
+                            dev->accel.x_count = dev->accel.cx;
+                            if (and3) {
+                                if (dev->accel.cmd & 0x20)
+                                    dev->accel.x_count -= and3;
+                                else
+                                    dev->accel.x_count += and3;
+
+                                dev->accel.sx += 8;
+                            }
                         }
                     }
                     dev->data_available  = 0;
@@ -3253,495 +2683,389 @@ rect_fill:
                 }
             }
 
-            if (dev->accel.cmd & 2) {
-                if (cpu_input) {
-bitblt_pix:
-                    if (count < 8) {
-                        while (count-- && (dev->accel.sy >= 0)) {
-                            if (dev->accel.dx >= dev->accel.clip_left && dev->accel.dx <= clip_r && dev->accel.dy >= dev->accel.clip_top && dev->accel.dy <= clip_b) {
-                                if (pixcntl == 3) {
-                                    if (!(dev->accel.cmd & 0x10) && ((frgd_mix != 3) || (bkgd_mix != 3))) {
-                                        READ(dev->accel.src + dev->accel.cx, mix_dat);
-                                        mix_dat = ((mix_dat & rd_mask) == rd_mask);
-                                        mix_dat = mix_dat ? mix_mask : 0;
-                                    } else if (dev->accel.cmd & 0x10) {
-                                        READ(dev->accel.src + dev->accel.cx, mix_dat);
-                                        mix_dat = ((mix_dat & rd_mask) == rd_mask);
-                                        mix_dat = mix_dat ? mix_mask : 0;
-                                    }
-                                }
-                                switch ((mix_dat & mix_mask) ? frgd_mix : bkgd_mix) {
-                                    case 0:
-                                        src_dat = bkgd_color;
-                                        break;
-                                    case 1:
-                                        src_dat = frgd_color;
-                                        break;
-                                    case 2:
-                                        src_dat = cpu_dat;
-                                        break;
-                                    case 3:
-                                        READ(dev->accel.src + dev->accel.cx, src_dat);
-                                        if (pixcntl == 3) {
-                                            if (dev->accel.cmd & 0x10) {
-                                                src_dat = ((src_dat & rd_mask) == rd_mask);
-                                            }
-                                        }
-                                        break;
-
-                                    default:
-                                        break;
-                                }
-
-                                READ(dev->accel.dest + dev->accel.dx, dest_dat);
-
-                                if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
-                                    old_dest_dat = dest_dat;
-
-                                    MIX(mix_dat & mix_mask, dest_dat, src_dat);
-                                    dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
-                                    WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
-                                }
-                            }
-
-                            mix_dat <<= 1;
-                            mix_dat |= 1;
-                            if (dev->bpp)
-                                cpu_dat >>= 16;
-                            else
-                                cpu_dat >>= 8;
-
-                            if (dev->accel.cmd & 0x20) {
-                                dev->accel.dx++;
-                                dev->accel.cx++;
-                            } else {
-                                dev->accel.dx--;
-                                dev->accel.cx--;
-                            }
-
-                            dev->accel.sx--;
-                            if (dev->accel.sx < 0) {
-                                dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
-
-                                if (dev->accel.cmd & 2) {
-                                    dev->accel.sx += (dev->accel.cur_x & 3);
-                                }
-
-                                if (dev->accel.cmd & 0x20) {
-                                    dev->accel.dx -= (dev->accel.sx) + 1;
-                                    dev->accel.cx -= (dev->accel.sx) + 1;
-                                } else {
-                                    dev->accel.dx += (dev->accel.sx) + 1;
-                                    dev->accel.cx += (dev->accel.sx) + 1;
-                                }
-
-                                if (dev->accel.cmd & 0x80) {
-                                    dev->accel.dy++;
-                                    dev->accel.cy++;
-                                } else {
-                                    dev->accel.dy--;
-                                    dev->accel.cy--;
-                                }
-
-                                dev->accel.src  = dev->accel.cy * dev->pitch;
-                                dev->accel.dest = dev->accel.dy * dev->pitch;
-                                dev->accel.sy--;
-                                return;
+            ibm8514_log("BitBLT: full=%04x, odd=%d, c(%d,%d), d(%d,%d), xcount=%d, and3=%d, len(%d,%d), CURX=%d, Width=%d, pixcntl=%d, mix_dat=%08x, count=%d, cpu_data=%08x, cpu_input=%d.\n", dev->accel.cmd, dev->accel.input, dev->accel.cx, dev->accel.cy, dev->accel.dx, dev->accel.dy, dev->accel.x_count, and3, dev->accel.sx, dev->accel.sy, dev->accel.cur_x, dev->accel.maj_axis_pcnt, pixcntl, mix_dat, count, cpu_dat, cpu_input);
+            if (cpu_input) {
+                while (count-- && (dev->accel.sy >= 0)) {
+                    if ((dev->accel.dx >= clip_l) &&
+                        (dev->accel.dx <= clip_r) &&
+                        (dev->accel.dy >= clip_t) &&
+                        (dev->accel.dy <= clip_b)) {
+                        if (pixcntl == 3) {
+                            if (!(dev->accel.cmd & 0x10) && ((frgd_mix != 3) || (bkgd_mix != 3))) {
+                                READ(dev->accel.src + dev->accel.cx, mix_dat);
+                                mix_dat = ((mix_dat & rd_mask) == rd_mask);
+                                if (dev->accel.cmd & 0x02)
+                                    mix_dat = mix_dat ? 0x01 : 0x00;
+                                else
+                                    mix_dat = mix_dat ? mix_mask : 0x00;
+                            } else if (dev->accel.cmd & 0x10) {
+                                READ(dev->accel.src + dev->accel.cx, mix_dat);
+                                mix_dat = ((mix_dat & rd_mask) == rd_mask);
+                                if (dev->accel.cmd & 0x02)
+                                    mix_dat = mix_dat ? 0x01 : 0x00;
+                                else
+                                    mix_dat = mix_dat ? mix_mask : 0x00;
                             }
                         }
-                    } else {
-                        while (count-- && (dev->accel.sy >= 0)) {
-                            if (dev->accel.dx >= dev->accel.clip_left && dev->accel.dx <= clip_r && dev->accel.dy >= dev->accel.clip_top && dev->accel.dy <= clip_b) {
-                                if (pixcntl == 3) {
-                                    if (!(dev->accel.cmd & 0x10) && ((frgd_mix != 3) || (bkgd_mix != 3))) {
-                                        READ(dev->accel.src + dev->accel.cx, mix_dat);
-                                        mix_dat = ((mix_dat & rd_mask) == rd_mask);
-                                        mix_dat = mix_dat ? 1 : 0;
-                                    } else if (dev->accel.cmd & 0x10) {
-                                        READ(dev->accel.src + dev->accel.cx, mix_dat);
-                                        mix_dat = ((mix_dat & rd_mask) == rd_mask);
-                                        mix_dat = mix_dat ? 1 : 0;
+                        if (dev->accel.cmd & 0x02) {
+                            switch ((mix_dat & 0x01) ? frgd_mix : bkgd_mix) {
+                                case 0:
+                                    src_dat = bkgd_color;
+                                    break;
+                                case 1:
+                                    src_dat = frgd_color;
+                                    break;
+                                case 2:
+                                    src_dat = cpu_dat;
+                                    break;
+                                case 3:
+                                    READ(dev->accel.src + dev->accel.cx, src_dat);
+                                    if (pixcntl == 3) {
+                                        if (dev->accel.cmd & 0x10)
+                                            src_dat = ((src_dat & rd_mask) == rd_mask);
                                     }
-                                }
-                                switch ((mix_dat & 1) ? frgd_mix : bkgd_mix) {
-                                    case 0:
-                                        src_dat = bkgd_color;
-                                        break;
-                                    case 1:
-                                        src_dat = frgd_color;
-                                        break;
-                                    case 2:
-                                        src_dat = cpu_dat;
-                                        break;
-                                    case 3:
-                                        READ(dev->accel.src + dev->accel.cx, src_dat);
-                                        if (pixcntl == 3) {
-                                            if (dev->accel.cmd & 0x10) {
-                                                src_dat = ((src_dat & rd_mask) == rd_mask);
-                                            }
-                                        }
-                                        break;
+                                    break;
 
-                                    default:
-                                        break;
-                                }
-
-                                READ(dev->accel.dest + dev->accel.dx, dest_dat);
-
-                                if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
-                                    old_dest_dat = dest_dat;
-                                    MIX(mix_dat & 1, dest_dat, src_dat);
-                                    dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
-                                    WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
-                                }
-                            }
-
-                            mix_dat >>= 1;
-                            if (dev->bpp)
-                                cpu_dat >>= 16;
-                            else
-                                cpu_dat >>= 8;
-
-                            if (dev->accel.cmd & 0x20) {
-                                dev->accel.dx++;
-                                dev->accel.cx++;
-                            } else {
-                                dev->accel.dx--;
-                                dev->accel.cx--;
-                            }
-
-                            dev->accel.sx--;
-                            if (dev->accel.sx < 0) {
-                                dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
-
-                                if (dev->accel.cmd & 2) {
-                                    if (!(dev->accel.cmd & 0x1000))
-                                        dev->accel.sx += (dev->accel.cur_x & 3);
-                                }
-
-                                if (dev->accel.cmd & 0x20) {
-                                    dev->accel.dx -= (dev->accel.sx) + 1;
-                                    dev->accel.cx -= (dev->accel.sx) + 1;
-                                } else {
-                                    dev->accel.dx += (dev->accel.sx) + 1;
-                                    dev->accel.cx += (dev->accel.sx) + 1;
-                                }
-
-                                if (dev->accel.cmd & 2) {
-                                    if (dev->accel.cmd & 0x1000) {
-                                        dev->accel.cx = dev->accel.cur_x;
-                                        if (dev->accel.cur_x >= 0x600)
-                                            dev->accel.cx |= ~0x5ff;
-                                        dev->accel.dx = dev->accel.destx;
-                                        if (dev->accel.destx >= 0x600)
-                                            dev->accel.dx |= ~0x5ff;
-                                    }
-                                }
-
-                                if (dev->accel.cmd & 0x80) {
-                                    dev->accel.dy++;
-                                    dev->accel.cy++;
-                                } else {
-                                    dev->accel.dy--;
-                                    dev->accel.cy--;
-                                }
-
-                                dev->accel.dest = dev->accel.dy * dev->pitch;
-                                dev->accel.src  = dev->accel.cy * dev->pitch;
-                                dev->accel.sy--;
-                                return;
-                            }
-                        }
-                    }
-                } else {
-                    goto bitblt;
-                }
-            } else {
-                if (cpu_input) {
-                    if (pixcntl == 2) {
-                        goto bitblt_pix;
-                    } else {
-                        while (count-- && (dev->accel.sy >= 0)) {
-                            if (dev->accel.dx >= dev->accel.clip_left && dev->accel.dx <= clip_r && dev->accel.dy >= dev->accel.clip_top && dev->accel.dy <= clip_b) {
-                                if (pixcntl == 3) {
-                                    if (!(dev->accel.cmd & 0x10) && ((frgd_mix != 3) || (bkgd_mix != 3))) {
-                                        READ(dev->accel.src + dev->accel.cx, mix_dat);
-                                        mix_dat = ((mix_dat & rd_mask) == rd_mask);
-                                        mix_dat = mix_dat ? mix_mask : 0;
-                                    } else if (dev->accel.cmd & 0x10) {
-                                        READ(dev->accel.src + dev->accel.cx, mix_dat);
-                                        mix_dat = ((mix_dat & rd_mask) == rd_mask);
-                                        mix_dat = mix_dat ? mix_mask : 0;
-                                    }
-                                }
-                                switch ((mix_dat & mix_mask) ? frgd_mix : bkgd_mix) {
-                                    case 0:
-                                        src_dat = bkgd_color;
-                                        break;
-                                    case 1:
-                                        src_dat = frgd_color;
-                                        break;
-                                    case 2:
-                                        src_dat = cpu_dat;
-                                        break;
-                                    case 3:
-                                        READ(dev->accel.src + dev->accel.cx, src_dat);
-                                        if (pixcntl == 3) {
-                                            if (dev->accel.cmd & 0x10) {
-                                                src_dat = ((src_dat & rd_mask) == rd_mask);
-                                            }
-                                        }
-                                        break;
-
-                                    default:
-                                        break;
-                                }
-
-                                READ(dev->accel.dest + dev->accel.dx, dest_dat);
-
-                                if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
-                                    old_dest_dat = dest_dat;
-                                    MIX(mix_dat & mix_mask, dest_dat, src_dat);
-                                    dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
-                                    WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
-                                }
-                            }
-
-                            mix_dat <<= 1;
-                            mix_dat |= 1;
-                            if (dev->bpp)
-                                cpu_dat >>= 16;
-                            else
-                                cpu_dat >>= 8;
-
-                            if (dev->accel.cmd & 0x20) {
-                                dev->accel.dx++;
-                                dev->accel.cx++;
-                            } else {
-                                dev->accel.dx--;
-                                dev->accel.cx--;
-                            }
-
-                            dev->accel.sx--;
-                            if (dev->accel.sx < 0) {
-                                dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
-
-                                if (dev->accel.cmd & 0x20) {
-                                    dev->accel.dx -= (dev->accel.sx) + 1;
-                                    dev->accel.cx -= (dev->accel.sx) + 1;
-                                } else {
-                                    dev->accel.dx += (dev->accel.sx) + 1;
-                                    dev->accel.cx += (dev->accel.sx) + 1;
-                                }
-
-                                if (dev->accel.cmd & 0x80) {
-                                    dev->accel.dy++;
-                                    dev->accel.cy++;
-                                } else {
-                                    dev->accel.dy--;
-                                    dev->accel.cy--;
-                                }
-
-                                dev->accel.dest = dev->accel.dy * dev->pitch;
-                                dev->accel.src  = dev->accel.cy * dev->pitch;
-                                dev->accel.sy--;
-                                return;
-                            }
-                        }
-                    }
-                } else {
-bitblt:
-                    if (pixcntl == 1) {
-                        if (dev->accel.cmd & 0x40) {
-                            count               = dev->accel.maj_axis_pcnt + 1;
-                            dev->accel.temp_cnt = 8;
-                            while (count-- && dev->accel.sy >= 0) {
-                                if (!dev->accel.temp_cnt) {
-                                    mix_dat >>= 8;
-                                    dev->accel.temp_cnt = 8;
-                                }
-                                if (dev->accel.dx >= dev->accel.clip_left && dev->accel.dx <= clip_r && dev->accel.dy >= dev->accel.clip_top && dev->accel.dy <= clip_b) {
-                                    switch ((mix_dat & mix_mask) ? frgd_mix : bkgd_mix) {
-                                        case 0:
-                                            src_dat = bkgd_color;
-                                            break;
-                                        case 1:
-                                            src_dat = frgd_color;
-                                            break;
-                                        case 2:
-                                            src_dat = 0;
-                                            break;
-                                        case 3:
-                                            READ(dev->accel.src + dev->accel.cx, src_dat);
-                                            break;
-
-                                        default:
-                                            break;
-                                    }
-
-                                    READ(dev->accel.dest + dev->accel.dx, dest_dat);
-
-                                    if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
-                                        old_dest_dat = dest_dat;
-                                        MIX(mix_dat & mix_mask, dest_dat, src_dat);
-                                        dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
-
-                                        WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
-                                    }
-                                }
-
-                                if (dev->accel.temp_cnt > 0) {
-                                    dev->accel.temp_cnt--;
-                                    mix_dat <<= 1;
-                                    mix_dat |= 1;
-                                }
-
-                                if (dev->accel.cmd & 0x20) {
-                                    dev->accel.dx++;
-                                    dev->accel.cx++;
-                                } else {
-                                    dev->accel.dx--;
-                                    dev->accel.cx--;
-                                }
-
-                                dev->accel.sx--;
-                                if (dev->accel.sx < 0) {
-                                    dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
-
-                                    if (dev->accel.cmd & 0x20) {
-                                        dev->accel.dx -= (dev->accel.sx) + 1;
-                                        dev->accel.cx -= (dev->accel.sx) + 1;
-                                    } else {
-                                        dev->accel.dx += (dev->accel.sx) + 1;
-                                        dev->accel.cx += (dev->accel.sx) + 1;
-                                    }
-
-                                    if (dev->accel.cmd & 0x80) {
-                                        dev->accel.dy++;
-                                        dev->accel.cy++;
-                                    } else {
-                                        dev->accel.dy--;
-                                        dev->accel.cy--;
-                                    }
-
-                                    dev->accel.dest = dev->accel.dy * dev->pitch;
-                                    dev->accel.src  = dev->accel.cy * dev->pitch;
-                                    dev->accel.sy--;
-                                    return;
-                                }
+                                default:
+                                    break;
                             }
                         } else {
-                            dev->accel.temp_cnt = 8;
-                            while (count-- && dev->accel.sy >= 0) {
-                                if (!dev->accel.temp_cnt) {
-                                    dev->accel.temp_cnt = 8;
-                                    mix_dat             = old_mix_dat;
-                                }
-                                if (dev->accel.dx >= dev->accel.clip_left && dev->accel.dx <= clip_r && dev->accel.dy >= dev->accel.clip_top && dev->accel.dy <= clip_b) {
-                                    switch ((mix_dat & 1) ? frgd_mix : bkgd_mix) {
-                                        case 0:
-                                            src_dat = bkgd_color;
-                                            break;
-                                        case 1:
-                                            src_dat = frgd_color;
-                                            break;
-                                        case 2:
-                                            src_dat = 0;
-                                            break;
-                                        case 3:
-                                            READ(dev->accel.src + dev->accel.cx, src_dat);
-                                            break;
-
-                                        default:
-                                            break;
+                            switch ((mix_dat & mix_mask) ? frgd_mix : bkgd_mix) {
+                                case 0:
+                                    src_dat = bkgd_color;
+                                    break;
+                                case 1:
+                                    src_dat = frgd_color;
+                                    break;
+                                case 2:
+                                    src_dat = cpu_dat;
+                                    break;
+                                case 3:
+                                    READ(dev->accel.src + dev->accel.cx, src_dat);
+                                    if (pixcntl == 3) {
+                                        if (dev->accel.cmd & 0x10)
+                                            src_dat = ((src_dat & rd_mask) == rd_mask);
                                     }
+                                    break;
 
-                                    READ(dev->accel.dest + dev->accel.dx, dest_dat);
+                                default:
+                                    break;
+                            }
+                        }
 
-                                    if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
-                                        old_dest_dat = dest_dat;
-                                        MIX(mix_dat & 1, dest_dat, src_dat);
-                                        dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
+                        READ(dev->accel.dest + dev->accel.dx, dest_dat);
 
-                                        WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
-                                    }
+                        if ((compare_mode == 0) ||
+                            ((compare_mode == 0x10) && (dest_dat >= compare)) ||
+                            ((compare_mode == 0x18) && (dest_dat < compare)) ||
+                            ((compare_mode == 0x20) && (dest_dat != compare)) ||
+                            ((compare_mode == 0x28) && (dest_dat == compare)) ||
+                            ((compare_mode == 0x30) && (dest_dat <= compare)) ||
+                            ((compare_mode == 0x38) && (dest_dat > compare))) {
+                            old_dest_dat = dest_dat;
+                            if (dev->accel.cmd & 0x02) {
+                                MIX(mix_dat & 0x01, dest_dat, src_dat);
+                                if ((dev->accel.x_count != dev->accel.cx) && !(dev->accel.cmd & 0x1000) && and3)
+                                    goto skip_nibble_bitblt_write;
+
+                                dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
+                                WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
+                            } else {
+                                MIX(mix_dat & mix_mask, dest_dat, src_dat);
+                                dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
+                                WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
+                            }
+                        }
+                    }
+
+                    if (dev->accel.cmd & 0x20) {
+                        dev->accel.dx++;
+                        dev->accel.cx++;
+                    } else {
+                        dev->accel.dx--;
+                        dev->accel.cx--;
+                    }
+
+skip_nibble_bitblt_write:
+                    if (dev->accel.cmd & 0x20)
+                        dev->accel.x_count++;
+                    else
+                        dev->accel.x_count--;
+
+                    if (dev->accel.cmd & 0x02)
+                        mix_dat >>= 1;
+                    else {
+                        mix_dat <<= 1;
+                        mix_dat |= 1;
+                    }
+
+                    if (dev->bpp)
+                        cpu_dat >>= 16;
+                    else
+                        cpu_dat >>= 8;
+
+                    dev->accel.sx--;
+                    if (dev->accel.sx < 0) {
+                        dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
+
+                        if (dev->accel.cmd & 0x20) {
+                            dev->accel.dx -= (dev->accel.sx + 1);
+                            dev->accel.cx -= (dev->accel.sx + 1);
+                        } else {
+                            dev->accel.dx += (dev->accel.sx + 1);
+                            dev->accel.cx += (dev->accel.sx + 1);
+                        }
+
+                        if (dev->accel.cmd & 0x80) {
+                            dev->accel.dy++;
+                            dev->accel.cy++;
+                        } else {
+                            dev->accel.dy--;
+                            dev->accel.cy--;
+                        }
+
+                        if ((dev->accel_bpp == 24) || (dev->accel_bpp <= 8)) {
+                            dev->accel.src  = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
+                            dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.dy * dev->pitch);
+                        } else if (dev->bpp) {
+                            dev->accel.src  = (dev->accel.ge_offset << 1) + (dev->accel.cy * dev->pitch);
+                            dev->accel.dest = (dev->accel.ge_offset << 1) + (dev->accel.dy * dev->pitch);
+                        } else {
+                            dev->accel.src  = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
+                            dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.dy * dev->pitch);
+                        }
+
+                        dev->accel.sy--;
+                        dev->accel.x_count = 0;
+                        return;
+                    }
+                }
+            } else {
+                if (pixcntl == 1) {
+                    if (dev->accel.cmd & 0x40) {
+                        count = (dev->accel.maj_axis_pcnt & 0x7ff) + 1;
+                        dev->accel.temp_cnt = 8;
+                        while (count-- && (dev->accel.sy >= 0)) {
+                            if (!dev->accel.temp_cnt) {
+                                mix_dat >>= 8;
+                                dev->accel.temp_cnt = 8;
+                            }
+                            if ((dev->accel.dx >= clip_l) &&
+                                (dev->accel.dx <= clip_r) &&
+                                (dev->accel.dy >= clip_t) &&
+                                (dev->accel.dy <= clip_b)) {
+                                switch ((mix_dat & mix_mask) ? frgd_mix : bkgd_mix) {
+                                    case 0:
+                                        src_dat = bkgd_color;
+                                        break;
+                                    case 1:
+                                        src_dat = frgd_color;
+                                        break;
+                                    case 2:
+                                        src_dat = 0;
+                                        break;
+                                    case 3:
+                                        READ(dev->accel.src + dev->accel.cx, src_dat);
+                                        break;
+
+                                    default:
+                                        break;
                                 }
 
+                                READ(dev->accel.dest + dev->accel.dx, dest_dat);
+
+                                if ((compare_mode == 0) ||
+                                    ((compare_mode == 0x10) && (dest_dat >= compare)) ||
+                                    ((compare_mode == 0x18) && (dest_dat < compare)) ||
+                                    ((compare_mode == 0x20) && (dest_dat != compare)) ||
+                                    ((compare_mode == 0x28) && (dest_dat == compare)) ||
+                                    ((compare_mode == 0x30) && (dest_dat <= compare)) ||
+                                    ((compare_mode == 0x38) && (dest_dat > compare))) {
+                                    old_dest_dat = dest_dat;
+                                    MIX(mix_dat & mix_mask, dest_dat, src_dat);
+                                    dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
+                                    WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
+                                }
+                            }
+
+                            if (dev->accel.temp_cnt > 0) {
                                 dev->accel.temp_cnt--;
-                                mix_dat >>= 1;
+                                mix_dat <<= 1;
+                                mix_dat |= 1;
+                            }
+
+                            if (dev->accel.cmd & 0x20) {
+                                dev->accel.dx++;
+                                dev->accel.cx++;
+                            } else {
+                                dev->accel.dx--;
+                                dev->accel.cx--;
+                            }
+
+                            dev->accel.sx--;
+                            if (dev->accel.sx < 0) {
+                                dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
 
                                 if (dev->accel.cmd & 0x20) {
-                                    dev->accel.dx++;
-                                    dev->accel.cx++;
+                                    dev->accel.dx -= (dev->accel.sx + 1);
+                                    dev->accel.cx -= (dev->accel.sx + 1);
                                 } else {
-                                    dev->accel.dx--;
-                                    dev->accel.cx--;
+                                    dev->accel.dx += (dev->accel.sx + 1);
+                                    dev->accel.cx += (dev->accel.sx + 1);
                                 }
 
-                                dev->accel.sx--;
-                                if (dev->accel.sx < 0) {
-                                    dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
-
-                                    if (dev->accel.cmd & 0x20) {
-                                        dev->accel.dx -= (dev->accel.sx) + 1;
-                                        dev->accel.cx -= (dev->accel.sx) + 1;
-                                    } else {
-                                        dev->accel.dx += (dev->accel.sx) + 1;
-                                        dev->accel.cx += (dev->accel.sx) + 1;
-                                    }
-
-                                    if (dev->accel.cmd & 0x80) {
-                                        dev->accel.dy++;
-                                        dev->accel.cy++;
-                                    } else {
-                                        dev->accel.dy--;
-                                        dev->accel.cy--;
-                                    }
-
-                                    dev->accel.dest = dev->accel.dy * dev->pitch;
-                                    dev->accel.src  = dev->accel.cy * dev->pitch;
-                                    dev->accel.sy--;
-
-                                    if (dev->accel.sy < 0) {
-                                        return;
-                                    }
+                                if (dev->accel.cmd & 0x80) {
+                                    dev->accel.dy++;
+                                    dev->accel.cy++;
+                                } else {
+                                    dev->accel.dy--;
+                                    dev->accel.cy--;
                                 }
+
+                                if ((dev->accel_bpp == 24) || (dev->accel_bpp <= 8)) {
+                                    dev->accel.src  = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
+                                    dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.dy * dev->pitch);
+                                } else if (dev->bpp) {
+                                    dev->accel.src  = (dev->accel.ge_offset << 1) + (dev->accel.cy * dev->pitch);
+                                    dev->accel.dest = (dev->accel.ge_offset << 1) + (dev->accel.dy * dev->pitch);
+                                } else {
+                                    dev->accel.src  = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
+                                    dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.dy * dev->pitch);
+                                }
+
+                                dev->accel.sy--;
+                                return;
                             }
                         }
                     } else {
-                        if ((dev->accel_bpp == 24) && ((dev->local & 0xff) >= 0x02) && (dev->accel.cmd == 0xc2b5)) {
-                            int64_t cx;
-                            int64_t dx;
+                        dev->accel.temp_cnt = 8;
+                        while (count-- && (dev->accel.sy >= 0)) {
+                            if (!dev->accel.temp_cnt) {
+                                dev->accel.temp_cnt = 8;
+                                mix_dat = old_mix_dat;
+                            }
+                            if ((dev->accel.dx >= clip_l) &&
+                                (dev->accel.dx <= clip_r) &&
+                                (dev->accel.dy >= clip_t) &&
+                                (dev->accel.dy <= clip_b)) {
+                                switch ((mix_dat & 0x01) ? frgd_mix : bkgd_mix) {
+                                    case 0:
+                                        src_dat = bkgd_color;
+                                        break;
+                                    case 1:
+                                        src_dat = frgd_color;
+                                        break;
+                                    case 2:
+                                        src_dat = 0;
+                                        break;
+                                    case 3:
+                                        READ(dev->accel.src + dev->accel.cx, src_dat);
+                                        break;
 
-                            cx = (int64_t) dev->accel.cx;
-                            dx = (int64_t) dev->accel.dx;
-
-                            while (1) {
-                                if ((dx >= (((int64_t)dev->accel.clip_left) * 3)) && (dx <= (((uint64_t)clip_r) * 3)) &&
-                                    (dev->accel.dy >= (dev->accel.clip_top << 1)) && (dev->accel.dy <= (clip_b << 1))) {
-
-                                    READ(dev->accel.src + (dev->accel.ge_offset << 2) + cx, src_dat);
-                                    READ(dev->accel.dest + (dev->accel.ge_offset << 2) + dx, dest_dat);
-
-                                    dest_dat = (src_dat & wrt_mask) | (dest_dat & ~wrt_mask);
-
-                                    WRITE(dev->accel.dest + (dev->accel.ge_offset << 2) + dx, dest_dat);
+                                    default:
+                                        break;
                                 }
 
-                                cx++;
-                                dx++;
+                                READ(dev->accel.dest + dev->accel.dx, dest_dat);
 
-                                dev->accel.sx--;
-                                if (dev->accel.sx < 0)
-                                    return;
+                                if ((compare_mode == 0) ||
+                                    ((compare_mode == 0x10) && (dest_dat >= compare)) ||
+                                    ((compare_mode == 0x18) && (dest_dat < compare)) ||
+                                    ((compare_mode == 0x20) && (dest_dat != compare)) ||
+                                    ((compare_mode == 0x28) && (dest_dat == compare)) ||
+                                    ((compare_mode == 0x30) && (dest_dat <= compare)) ||
+                                    ((compare_mode == 0x38) && (dest_dat > compare))) {
+                                    old_dest_dat = dest_dat;
+                                    MIX(mix_dat & 0x01, dest_dat, src_dat);
+                                    dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
+                                    WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
+                                }
                             }
-                            return;
-                        }
 
-                        ibm8514_log("BitBLT 8514/A=%04x, selfrmix=%d, selbkmix=%d, d(%d,%d), c(%d,%d), pixcntl=%d, sy=%d, frgdmix=%02x, bkgdmix=%02x, rdmask=%02x, wrtmask=%02x, linedraw=%d.\n", dev->accel.cmd, frgd_mix, bkgd_mix, dev->accel.dx, dev->accel.dy, dev->accel.cx, dev->accel.cy, pixcntl, dev->accel.sy, dev->accel.frgd_mix & 0x1f, dev->accel.bkgd_mix & 0x1f, dev->accel.rd_mask, wrt_mask, dev->accel.linedraw);
+                            dev->accel.temp_cnt--;
+                            mix_dat >>= 1;
+
+                            if (dev->accel.cmd & 0x20) {
+                                dev->accel.dx++;
+                                dev->accel.cx++;
+                            } else {
+                                dev->accel.dx--;
+                                dev->accel.cx--;
+                            }
+
+                            dev->accel.sx--;
+                            if (dev->accel.sx < 0) {
+                                dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
+
+                                if (dev->accel.cmd & 0x20) {
+                                    dev->accel.dx -= (dev->accel.sx + 1);
+                                    dev->accel.cx -= (dev->accel.sx + 1);
+                                } else {
+                                    dev->accel.dx += (dev->accel.sx + 1);
+                                    dev->accel.cx += (dev->accel.sx + 1);
+                                }
+
+                                if (dev->accel.cmd & 0x80) {
+                                    dev->accel.dy++;
+                                    dev->accel.cy++;
+                                } else {
+                                    dev->accel.dy--;
+                                    dev->accel.cy--;
+                                }
+
+                                if ((dev->accel_bpp == 24) || (dev->accel_bpp <= 8)) {
+                                    dev->accel.src  = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
+                                    dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.dy * dev->pitch);
+                                } else if (dev->bpp) {
+                                    dev->accel.src  = (dev->accel.ge_offset << 1) + (dev->accel.cy * dev->pitch);
+                                    dev->accel.dest = (dev->accel.ge_offset << 1) + (dev->accel.dy * dev->pitch);
+                                } else {
+                                    dev->accel.src  = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
+                                    dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.dy * dev->pitch);
+                                }
+                                dev->accel.sy--;
+
+                                if (dev->accel.sy < 0) {
+                                    dev->accel.destx = dev->accel.dx;
+                                    dev->accel.desty = dev->accel.dy;
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    if ((dev->accel_bpp == 24) && (dev->accel.cmd == 0xc2b5)) {
+                        int64_t cx;
+                        int64_t dx;
+
+                        cx = (int64_t) dev->accel.cx;
+                        dx = (int64_t) dev->accel.dx;
+
+                        while (1) {
+                            if ((dx >= (((int64_t)clip_l) * 3)) &&
+                                (dx <= (((uint64_t)clip_r) * 3)) &&
+                                (dev->accel.dy >= (clip_t << 1)) &&
+                                (dev->accel.dy <= (clip_b << 1))) {
+
+                                READ(dev->accel.src + cx, src_dat);
+                                READ(dev->accel.dest + dx, dest_dat);
+                                dest_dat = (src_dat & wrt_mask) | (dest_dat & ~wrt_mask);
+                                WRITE(dev->accel.dest + dx, dest_dat);
+                            }
+
+                            cx++;
+                            dx++;
+
+                            dev->accel.sx--;
+                            if (dev->accel.sx < 0)
+                                return;
+                        }
+                    } else {
                         while (count-- && dev->accel.sy >= 0) {
-                            if ((dev->accel.dx >= dev->accel.clip_left) && (dev->accel.dx <= clip_r) &&
-                                (dev->accel.dy >= dev->accel.clip_top) && (dev->accel.dy <= clip_b)) {
+                            if ((dev->accel.dx >= clip_l) &&
+                                (dev->accel.dx <= clip_r) &&
+                                (dev->accel.dy >= clip_t) &&
+                                (dev->accel.dy <= clip_b)) {
                                 if (pixcntl == 3) {
                                     if (!(dev->accel.cmd & 0x10) && ((frgd_mix != 3) || (bkgd_mix != 3))) {
                                         READ(dev->accel.src + dev->accel.cx, mix_dat);
@@ -3766,9 +3090,8 @@ bitblt:
                                     case 3:
                                         READ(dev->accel.src + dev->accel.cx, src_dat);
                                         if (pixcntl == 3) {
-                                            if ((dev->accel.cmd & 0x10) && !(dev->accel.cmd & 0x40)) {
+                                            if ((dev->accel.cmd & 0x10) && !(dev->accel.cmd & 0x40))
                                                 src_dat = ((src_dat & rd_mask) == rd_mask);
-                                            }
                                         }
                                         break;
 
@@ -3778,12 +3101,18 @@ bitblt:
 
                                 READ(dev->accel.dest + dev->accel.dx, dest_dat);
 
-                                if ((compare_mode == 0) || ((compare_mode == 0x10) && (dest_dat >= compare)) || ((compare_mode == 0x18) && (dest_dat < compare)) || ((compare_mode == 0x20) && (dest_dat != compare)) || ((compare_mode == 0x28) && (dest_dat == compare)) || ((compare_mode == 0x30) && (dest_dat <= compare)) || ((compare_mode == 0x38) && (dest_dat > compare))) {
+                                if ((compare_mode == 0) ||
+                                    ((compare_mode == 0x10) && (dest_dat >= compare)) ||
+                                    ((compare_mode == 0x18) && (dest_dat < compare)) ||
+                                    ((compare_mode == 0x20) && (dest_dat != compare)) ||
+                                    ((compare_mode == 0x28) && (dest_dat == compare)) ||
+                                    ((compare_mode == 0x30) && (dest_dat <= compare)) ||
+                                    ((compare_mode == 0x38) && (dest_dat > compare))) {
                                     old_dest_dat = dest_dat;
                                     MIX(mix_dat & mix_mask, dest_dat, src_dat);
                                     dest_dat = (dest_dat & wrt_mask) | (old_dest_dat & ~wrt_mask);
-                                    if (dev->accel.cmd & 4) {
-                                        if (dev->accel.sx > 0) {
+                                    if (dev->accel.cmd & 0x04) {
+                                        if (dev->accel.sx) {
                                             WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
                                         }
                                     } else {
@@ -3808,15 +3137,13 @@ bitblt:
                                 dev->accel.fill_state = 0;
                                 dev->accel.sx = dev->accel.maj_axis_pcnt & 0x7ff;
 
-                                dev->accel.dx = dev->accel.destx;
-
-                                if (dev->accel.destx >= 0x600)
-                                    dev->accel.dx |= ~0x5ff;
-
-                                dev->accel.cx = dev->accel.cur_x;
-
-                                if (dev->accel.cur_x >= 0x600)
-                                    dev->accel.cx |= ~0x5ff;
+                                if (dev->accel.cmd & 0x20) {
+                                    dev->accel.dx -= (dev->accel.sx + 1);
+                                    dev->accel.cx -= (dev->accel.sx + 1);
+                                } else {
+                                    dev->accel.dx += (dev->accel.sx + 1);
+                                    dev->accel.cx += (dev->accel.sx + 1);
+                                }
 
                                 if (dev->accel.cmd & 0x80) {
                                     dev->accel.dy++;
@@ -3826,12 +3153,23 @@ bitblt:
                                     dev->accel.cy--;
                                 }
 
-                                dev->accel.dest = dev->accel.dy * dev->pitch;
-                                dev->accel.src  = dev->accel.cy * dev->pitch;
+                                if ((dev->accel_bpp == 24) || (dev->accel_bpp <= 8)) {
+                                    dev->accel.src  = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
+                                    dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.dy * dev->pitch);
+                                } else if (dev->bpp) {
+                                    dev->accel.src  = (dev->accel.ge_offset << 1) + (dev->accel.cy * dev->pitch);
+                                    dev->accel.dest = (dev->accel.ge_offset << 1) + (dev->accel.dy * dev->pitch);
+                                } else {
+                                    dev->accel.src  = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
+                                    dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.dy * dev->pitch);
+                                }
                                 dev->accel.sy--;
 
-                                if (dev->accel.sy < 0)
+                                if (dev->accel.sy < 0) {
+                                    dev->accel.destx = dev->accel.dx;
+                                    dev->accel.desty = dev->accel.dy;
                                     return;
+                                }
                             }
                         }
                     }
@@ -3882,16 +3220,16 @@ ibm8514_render_8bpp(svga_t *svga)
 
         for (int x = 0; x <= dev->h_disp; x += 8) {
             dat  = *(uint32_t *) (&dev->vram[dev->ma & dev->vram_mask]);
-            p[0] = dev->pallook[dat & 0xff];
-            p[1] = dev->pallook[(dat >> 8) & 0xff];
-            p[2] = dev->pallook[(dat >> 16) & 0xff];
-            p[3] = dev->pallook[(dat >> 24) & 0xff];
+            p[0] = dev->pallook[dat & dev->dac_mask];
+            p[1] = dev->pallook[(dat >> 8) & dev->dac_mask];
+            p[2] = dev->pallook[(dat >> 16) & dev->dac_mask];
+            p[3] = dev->pallook[(dat >> 24) & dev->dac_mask];
 
             dat  = *(uint32_t *) (&dev->vram[(dev->ma + 4) & dev->vram_mask]);
-            p[4] = dev->pallook[dat & 0xff];
-            p[5] = dev->pallook[(dat >> 8) & 0xff];
-            p[6] = dev->pallook[(dat >> 16) & 0xff];
-            p[7] = dev->pallook[(dat >> 24) & 0xff];
+            p[4] = dev->pallook[dat & dev->dac_mask];
+            p[5] = dev->pallook[(dat >> 8) & dev->dac_mask];
+            p[6] = dev->pallook[(dat >> 16) & dev->dac_mask];
+            p[7] = dev->pallook[(dat >> 24) & dev->dac_mask];
 
             dev->ma += 8;
             p += 8;
@@ -4147,7 +3485,7 @@ ibm8514_poll(void *priv)
     int      wy;
 
     ibm8514_log("IBM 8514/A poll.\n");
-    if (dev->on[0] || dev->on[1]) {
+    if (dev->on) {
         ibm8514_log("ON!\n");
         if (!dev->linepos) {
             if ((dev->displine == ((dev->hwcursor_latch.y < 0) ? 0 : dev->hwcursor_latch.y)) && dev->hwcursor_latch.ena) {
@@ -4302,7 +3640,7 @@ ibm8514_recalctimings(svga_t *svga)
     } else
 #endif
     {
-        if (dev->on[0]) {
+        if (dev->on) {
             dev->h_total = dev->htotal + 1;
             dev->rowcount = !!(dev->disp_cntl & 0x08);
 
@@ -4336,6 +3674,11 @@ ibm8514_recalctimings(svga_t *svga)
             dev->pitch = 1024;
             dev->rowoffset = 0x80;
             svga->map8 = dev->pallook;
+            if (dev->vram_512k_8514) {
+                if (dev->h_disp == 640)
+                    dev->pitch = 640;
+            }
+            dev->accel_bpp = 8;
             svga->render8514 = ibm8514_render_8bpp;
             ibm8514_log("BPP=%d, Pitch = %d, rowoffset = %d, crtc13 = %02x, highres bit = %02x, has_vga? = %d.\n", dev->bpp, dev->pitch, dev->rowoffset, svga->crtc[0x13], dev->accel.advfunc_cntl & 4, !ibm8514_standalone_enabled);
         }
@@ -4382,8 +3725,7 @@ ibm8514_mca_reset(void *priv)
     ibm8514_t       *dev  = (ibm8514_t *) svga->dev8514;
 
     ibm8514_log("MCA reset.\n");
-    dev->on[0] = 0;
-    dev->on[1] = 0;
+    dev->on = 0;
     vga_on = 1;
 #ifdef ATI_8514_ULTRA
     if (dev->extensions)
@@ -4391,6 +3733,8 @@ ibm8514_mca_reset(void *priv)
     else
 #endif
         ibm8514_mca_write(0x102, 0, svga);
+
+    timer_set_callback(&svga->timer, svga_poll);
 }
 
 static void *
@@ -4409,12 +3753,15 @@ ibm8514_init(const device_t *info)
     svga->dev8514    = dev;
     svga->ext8514    = NULL;
 
-    dev->vram_size   = 1024 << 10;
+    dev->vram_amount = device_get_config_int("memory");
+    dev->vram_512k_8514 = dev->vram_amount == 512;
+    dev->vram_size   = dev->vram_amount << 10;
     dev->vram        = calloc(dev->vram_size, 1);
     dev->changedvram = calloc((dev->vram_size >> 12) + 1, 1);
     dev->vram_mask   = dev->vram_size - 1;
     dev->map8        = dev->pallook;
     dev->local       = 0;
+    dev->accel_bpp   = 8;
 
     dev->type     = info->flags;
     dev->bpp      = 0;
@@ -4450,6 +3797,7 @@ ibm8514_init(const device_t *info)
                              0x1000, MEM_MAPPING_EXTERNAL);
                     ati_eeprom_load(&mach->eeprom, "ati8514.nvr", 0);
                     mach->accel.scratch0 = (((bios_addr >> 7) - 0x1000) >> 4);
+                    mach->accel.scratch1 = mach->accel.scratch0 - 0x80;
                 }
                 ati8514_init(svga, svga->ext8514, svga->dev8514);
                 break;
@@ -4520,6 +3868,25 @@ ibm8514_force_redraw(void *priv)
 // clang-format off
 static const device_config_t ext8514_config[] = {
     {
+        .name = "memory",
+        .description = "Memory size",
+        .type = CONFIG_SELECTION,
+        .default_int = 1024,
+        .selection = {
+            {
+                .description = "512 KB",
+                .value = 512
+            },
+            {
+                .description = "1 MB",
+                .value = 1024
+            },
+            {
+                .description = ""
+            }
+        }
+    },
+    {
         .name = "extensions",
         .description = "Vendor",
         .type = CONFIG_SELECTION,
@@ -4566,6 +3933,32 @@ static const device_config_t ext8514_config[] = {
         .type = CONFIG_END
     }
 };
+#else
+// clang-format off
+static const device_config_t ext8514_config[] = {
+    {
+        .name = "memory",
+        .description = "Memory size",
+        .type = CONFIG_SELECTION,
+        .default_int = 1024,
+        .selection = {
+            {
+                .description = "512 KB",
+                .value = 512
+            },
+            {
+                .description = "1 MB",
+                .value = 1024
+            },
+            {
+                .description = ""
+            }
+        }
+    },
+    {
+        .type = CONFIG_END
+    }
+};
 #endif
 
 // clang-format off
@@ -4580,11 +3973,7 @@ const device_t gen8514_isa_device = {
     { .available = NULL },
     .speed_changed = ibm8514_speed_changed,
     .force_redraw = ibm8514_force_redraw,
-#ifdef ATI_8514_ULTRA
     .config = ext8514_config
-#else
-    .config = NULL
-#endif
 };
 
 const device_t ibm8514_mca_device = {
@@ -4598,11 +3987,7 @@ const device_t ibm8514_mca_device = {
     { .available = NULL },
     .speed_changed = ibm8514_speed_changed,
     .force_redraw = ibm8514_force_redraw,
-#ifdef ATI_8514_ULTRA
     .config = ext8514_config
-#else
-    .config = NULL
-#endif
 };
 
 

--- a/src/video/vid_ati68860_ramdac.c
+++ b/src/video/vid_ati68860_ramdac.c
@@ -74,16 +74,16 @@ ati68860_ramdac_out(uint16_t addr, uint8_t val, void *priv, svga_t *svga)
 
     switch (addr) {
         case 0:
-            svga_out((dev && (dev->on[0] || dev->on[1])) ? 0x2ec : 0x3c8, val, svga);
+            svga_out((dev && dev->on) ? 0x2ec : 0x3c8, val, svga);
             break;
         case 1:
-            svga_out((dev && (dev->on[0] || dev->on[1])) ? 0x2ed : 0x3c9, val, svga);
+            svga_out((dev && dev->on) ? 0x2ed : 0x3c9, val, svga);
             break;
         case 2:
-            svga_out((dev && (dev->on[0] || dev->on[1])) ? 0x2ea : 0x3c6, val, svga);
+            svga_out((dev && dev->on) ? 0x2ea : 0x3c6, val, svga);
             break;
         case 3:
-            svga_out((dev && (dev->on[0] || dev->on[1])) ? 0x2eb : 0x3c7, val, svga);
+            svga_out((dev && dev->on) ? 0x2eb : 0x3c7, val, svga);
             break;
         default:
             ramdac->regs[addr & 0xf] = val;
@@ -181,16 +181,16 @@ ati68860_ramdac_in(uint16_t addr, void *priv, svga_t *svga)
 
     switch (addr) {
         case 0:
-            temp = svga_in((dev && (dev->on[0] || dev->on[1])) ? 0x2ec : 0x3c8, svga);
+            temp = svga_in((dev && dev->on) ? 0x2ec : 0x3c8, svga);
             break;
         case 1:
-            temp = svga_in((dev && (dev->on[0] || dev->on[1])) ? 0x2ed : 0x3c9, svga);
+            temp = svga_in((dev && dev->on) ? 0x2ed : 0x3c9, svga);
             break;
         case 2:
-            temp = svga_in((dev && (dev->on[0] || dev->on[1])) ? 0x2ea : 0x3c6, svga);
+            temp = svga_in((dev && dev->on) ? 0x2ea : 0x3c6, svga);
             break;
         case 3:
-            temp = svga_in((dev && (dev->on[0] || dev->on[1])) ? 0x2eb : 0x3c7, svga);
+            temp = svga_in((dev && dev->on) ? 0x2eb : 0x3c7, svga);
             break;
         case 4:
         case 8:

--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -117,9 +117,8 @@ mach_log(const char *fmt, ...)
                 mach->accel.pix_trans[(n)] = vram_w[(dev->accel.dest + (cx) + (n)) & (dev->vram_mask >> 1)] & 0xff; \
             else \
                 mach->accel.pix_trans[(n)] = vram_w[(dev->accel.dest + (cx) + (n)) & (dev->vram_mask >> 1)] >> 8; \
-        } else { \
+        } else \
             mach->accel.pix_trans[(n)] = dev->vram[(dev->accel.dest + (cx) + (n)) & dev->vram_mask]; \
-        } \
     }
 
 #define READ_PIXTRANS_WORD(cx, n)                                                                    \
@@ -151,6 +150,9 @@ mach_log(const char *fmt, ...)
             dat = vram_w[(addr) & (dev->vram_mask >> 1)]; \
         else \
             dat = dev->vram[(addr) & (dev->vram_mask)];
+
+#define READ_HIGH(addr, dat) \
+        dat |= (dev->vram[(addr) & (dev->vram_mask)] << 8);
 
 #define MIX(mixmode, dest_dat, src_dat)                                                       \
     {                                                                                         \
@@ -237,7 +239,10 @@ mach_log(const char *fmt, ...)
                 dest_dat = MAX(0, (src_dat - dest_dat));                                      \
                 break;                                                                        \
             case 0x1b:                                                                        \
-                dest_dat = MIN(0xff, (dest_dat + src_dat));                                   \
+                if (dev->bpp)                                                                 \
+                    dest_dat = MIN(0xffff, (dest_dat + src_dat));                             \
+                else                                                                          \
+                    dest_dat = MIN(0xff, (dest_dat + src_dat));                               \
                 break;                                                                        \
             case 0x1c:                                                                        \
                 dest_dat = MAX(0, (dest_dat - src_dat)) / 2;                                  \
@@ -249,7 +254,10 @@ mach_log(const char *fmt, ...)
                 dest_dat = MAX(0, (src_dat - dest_dat)) / 2;                                  \
                 break;                                                                        \
             case 0x1f:                                                                        \
-                dest_dat = (0xff < (src_dat + dest_dat)) ? 0xff : ((src_dat + dest_dat) / 2); \
+                if (dev->bpp)                                                                 \
+                    dest_dat = (0xffff < (src_dat + dest_dat)) ? 0xffff : ((src_dat + dest_dat) / 2); \
+                else                                                                          \
+                    dest_dat = (0xff < (src_dat + dest_dat)) ? 0xff : ((src_dat + dest_dat) / 2); \
                 break;                                                                        \
         }                                                                                     \
     }
@@ -299,12 +307,12 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
     uint16_t      old_dest_dat;
     uint16_t     *vram_w    = (uint16_t *) dev->vram;
     uint16_t      mix       = 0;
-    int16_t       clip_l    = dev->accel.clip_left & 0x7ff;
-    int16_t       clip_t    = dev->accel.clip_top & 0x7ff;
-    int16_t       clip_r    = dev->accel.multifunc[4] & 0x7ff;
-    int16_t       clip_b    = dev->accel.multifunc[3] & 0x7ff;
     uint32_t      mono_dat0 = 0;
     uint32_t      mono_dat1 = 0;
+    int16_t      clip_t    = dev->accel.multifunc[1] & 0x7ff;
+    int16_t      clip_l    = dev->accel.multifunc[2] & 0x7ff;
+    int16_t      clip_b    = dev->accel.multifunc[3] & 0x7ff;
+    int16_t      clip_r    = dev->accel.multifunc[4] & 0x7ff;
 
     if (!dev->bpp) {
         rd_mask &= 0xff;
@@ -324,17 +332,13 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
 
     if (cpu_input) {
         if (dev->bpp) {
-            if ((mach->accel.dp_config & 0x200) && (count == 2)) {
+            if ((mach->accel.dp_config & 0x200) && (count == 2))
                 count >>= 1;
-            }
         }
     }
 
-    if ((dev->accel_bpp == 8) || (dev->accel_bpp == 15) || (dev->accel_bpp == 16) || (dev->accel_bpp == 24)) {
-        if ((cmd_type == 2) && cpu_input) {
-            mach_log("RdMask=%04x, DPCONFIG=%04x, Clipping: l=%d, r=%d, t=%d, b=%d, LineDrawOpt=%04x, BPP=%d, CMDType = %d, offs=%08x, cnt = %d, input = %d, mono_src = %d, frgdsel = %d, d(%d,%d), dstxend = %d, pitch = %d, extcrt = %d, rw = %x, monpattern = %x.\n", rd_mask, mach->accel.dp_config, clip_l, clip_r, clip_t, clip_b, mach->accel.linedraw_opt, dev->accel_bpp, cmd_type, mach->accel.ge_offset, count, cpu_input, mono_src, frgd_sel, dev->accel.cur_x, dev->accel.cur_y, mach->accel.dest_x_end, dev->ext_pitch, dev->ext_crt_pitch, mach->accel.dp_config & 1, mach->accel.mono_pattern_enable);
-        }
-    }
+    if ((dev->accel_bpp == 8) || (dev->accel_bpp == 15) || (dev->accel_bpp == 16) || (dev->accel_bpp == 24))
+        mach_log("RdMask=%04x, DPCONFIG=%04x, Clipping: l=%d, r=%d, t=%d, b=%d, LineDrawOpt=%04x, BPP=%d, CMDType = %d, offs=%08x, cnt = %d, input = %d, mono_src = %d, frgdsel = %d, d(%d,%d), dstxend = %d, pitch = %d, extcrt = %d, rw = %x, monpattern = %x.\n", dev->accel.rd_mask, mach->accel.dp_config, clip_l, clip_r, clip_t, clip_b, mach->accel.linedraw_opt, dev->accel_bpp, cmd_type, mach->accel.ge_offset, count, cpu_input, mono_src, frgd_sel, dev->accel.cur_x, dev->accel.cur_y, mach->accel.dest_x_end, dev->ext_pitch, dev->ext_crt_pitch, mach->accel.dp_config & 1, mach->accel.mono_pattern_enable);
 
     switch (cmd_type) {
         case 1: /*Extended Raw Linedraw from bres_count register (0x96ee)*/
@@ -342,6 +346,7 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                 dev->accel.dx = dev->accel.cur_x;
                 if (dev->accel.cur_x >= 0x600)
                     dev->accel.dx |= ~0x5ff;
+
                 dev->accel.dy = dev->accel.cur_y;
                 if (dev->accel.cur_y >= 0x600)
                     dev->accel.dy |= ~0x5ff;
@@ -349,6 +354,7 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                 dev->accel.cx = dev->accel.destx_distp;
                 if (dev->accel.destx_distp >= 0x600)
                     dev->accel.cx |= ~0x5ff;
+
                 dev->accel.cy = dev->accel.desty_axstp;
                 if (dev->accel.desty_axstp >= 0x600)
                     dev->accel.cy |= ~0x5ff;
@@ -356,8 +362,6 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                 mach->accel.width     = mach->accel.bres_count;
                 dev->accel.sx         = 0;
                 mach->accel.poly_fill = 0;
-
-                mach->accel.color_pattern_idx = ((dev->accel.cx + (dev->accel.cy << 3)) & mach->accel.patt_len);
 
                 mach->accel.stepx = (mach->accel.linedraw_opt & 0x20) ? 1 : -1;
                 mach->accel.stepy = (mach->accel.linedraw_opt & 0x80) ? 1 : -1;
@@ -377,19 +381,9 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                 }
             }
 
-            if (frgd_sel == 5) {
-                for (int x = 0; x <= mach->accel.patt_len; x++) {
-                    mach->accel.color_pattern[x] = mach->accel.patt_data[x & mach->accel.patt_len];
-                }
-
-                /*The destination coordinates should match the pattern index.*/
-                if (mach->accel.color_pattern_idx != mach->accel.patt_idx)
-                    mach->accel.color_pattern_idx = mach->accel.patt_idx;
-            }
-
             if (mono_src == 1) {
-                count               = mach->accel.width;
-                mix_dat             = mach->accel.patt_data[0x10];
+                count = mach->accel.width;
+                mix_dat = mach->accel.mono_pattern_normal[0];
                 dev->accel.temp_cnt = 8;
             }
 
@@ -404,7 +398,7 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                                 dev->accel.temp_cnt = 8;
                                 mix_dat >>= 8;
                             }
-                            mix = (mix_dat & 0x80);
+                            mix = !!(mix_dat & 0x80);
                             dev->accel.temp_cnt--;
                             mix_dat <<= 1;
                             mix_dat |= 1;
@@ -415,10 +409,10 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                                 mix_dat <<= 1;
                             } else {
                                 if (mach->accel.dp_config & 0x200) {
-                                    mix = mix_dat & 1;
+                                    mix = mix_dat & 0x01;
                                     mix_dat >>= 1;
                                 } else {
-                                    mix = mix_dat & 0x80;
+                                    mix = !!(mix_dat & 0x80);
                                     mix_dat <<= 1;
                                     mix_dat |= 1;
                                 }
@@ -437,7 +431,10 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                             break;
                     }
 
-                    if (((dev->accel.dx) >= clip_l) && ((dev->accel.dx) <= clip_r) && ((dev->accel.dy) >= clip_t) && ((dev->accel.dy) <= clip_b)) {
+                    if ((dev->accel.dx >= clip_l) &&
+                        (dev->accel.dx <= clip_r) &&
+                        (dev->accel.dy >= clip_t) &&
+                        (dev->accel.dy <= clip_b)) {
                         switch (mix ? frgd_sel : bkgd_sel) {
                             case 0:
                                 src_dat = dev->accel.bkgd_color;
@@ -453,20 +450,18 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                                     src_dat = cpu_dat;
                                 else {
                                     if (dev->bpp) {
-                                        READ((mach->accel.ge_offset << 1) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), src_dat);
+                                        READ((mach->accel.ge_offset << 1) + (dev->accel.cy * dev->pitch) + dev->accel.cx, src_dat);
                                     } else {
-                                        READ((mach->accel.ge_offset << 2) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), src_dat);
+                                        READ((mach->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch) + dev->accel.cx, src_dat);
                                     }
-                                    if (mono_src == 3) {
+                                    if (mono_src == 3)
                                         src_dat = (src_dat & rd_mask) == rd_mask;
-                                    }
                                 }
                                 break;
                             case 5:
-                                if (mix) {
-                                    src_dat = mach->accel.color_pattern[((dev->accel.dx) + ((dev->accel.dy) << 3)) & mach->accel.patt_len];
-                                } else
-                                    src_dat = 0;
+                                src_dat = mach->accel.color_pattern[mach->accel.color_pattern_idx];
+                                if (dev->bpp)
+                                    src_dat |= (mach->accel.color_pattern[mach->accel.color_pattern_idx + 1] << 8);
                                 break;
 
                             default:
@@ -555,6 +550,14 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                         cpu_dat >>= 16;
                     else
                         cpu_dat >>= 8;
+
+                    if (dev->bpp)
+                        mach->accel.color_pattern_idx += 2;
+                    else
+                        mach->accel.color_pattern_idx++;
+
+                    if (mach->accel.color_pattern_idx > mach->accel.patt_len)
+                        mach->accel.color_pattern_idx = 0;
 
                     switch (mach->accel.linedraw_opt & 0xe0) {
                         case 0x00:
@@ -648,7 +651,10 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                             break;
                     }
 
-                    if (((dev->accel.dx) >= clip_l) && ((dev->accel.dx) <= clip_r) && ((dev->accel.dy) >= clip_t) && ((dev->accel.dy) <= clip_b)) {
+                    if ((dev->accel.dx >= clip_l) &&
+                        (dev->accel.dx <= clip_r) &&
+                        (dev->accel.dy >= clip_t) &&
+                        (dev->accel.dy <= clip_b)) {
                         switch (mix ? frgd_sel : bkgd_sel) {
                             case 0:
                                 src_dat = dev->accel.bkgd_color;
@@ -674,10 +680,9 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                                 }
                                 break;
                             case 5:
-                                if (mix) {
-                                    src_dat = mach->accel.color_pattern[((dev->accel.dx) + ((dev->accel.dy) << 3)) & mach->accel.patt_len];
-                                } else
-                                    src_dat = 0;
+                                src_dat = mach->accel.color_pattern[mach->accel.color_pattern_idx];
+                                if (dev->bpp)
+                                    src_dat |= (mach->accel.color_pattern[mach->accel.color_pattern_idx + 1] << 8);
                                 break;
 
                             default:
@@ -767,6 +772,14 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                     else
                         cpu_dat >>= 8;
 
+                    if (dev->bpp)
+                        mach->accel.color_pattern_idx += 2;
+                    else
+                        mach->accel.color_pattern_idx++;
+
+                    if (mach->accel.color_pattern_idx > mach->accel.patt_len)
+                        mach->accel.color_pattern_idx = 0;
+
                     if (mach->accel.linedraw_opt & 0x40) {
                         dev->accel.dy += mach->accel.stepy;
                         if ((frgd_sel == 3) || (bkgd_sel == 3))
@@ -817,9 +830,8 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                     dev->accel.dy |= ~0x5ff;
 
                 if (mach->accel.dp_config == 0x5211) {
-                    if (mach->accel.dest_x_end == 1024) {
+                    if (mach->accel.dest_x_end == 1024)
                         goto skip_dx;
-                    }
                 }
                 /*Destination Width*/
                 if (mach->accel.dest_x_start != dev->accel.dx)
@@ -849,14 +861,8 @@ skip_dx:
                     mach_log("BitBLT: Dst Indeterminate X, dpconfig = %04x, destxend = %d, destxstart = %d.\n", mach->accel.dp_config, mach->accel.dest_x_end, mach->accel.dest_x_start);
                 }
 
-                dev->accel.sx                 = 0;
-                mach->accel.poly_fill         = 0;
-                mach->accel.color_pattern_idx = ((dev->accel.dx + (dev->accel.dy << 3)) & mach->accel.patt_len);
-                if ((dev->accel_bpp == 24) && (mono_src != 1)) {
-                    if (mach->accel.color_pattern_idx == mach->accel.patt_len)
-                        mach->accel.color_pattern_idx = mach->accel.patt_data_idx;
-                } else if ((dev->accel_bpp == 24) && (frgd_sel == 5) && (mono_src == 1) && (mach->accel.patt_len_reg & 0x4000))
-                    mach->accel.color_pattern_idx = 0;
+                dev->accel.sx = 0;
+                mach->accel.poly_fill = 0;
 
                 /*Height*/
                 mach->accel.dy_start = dev->accel.cur_y;
@@ -878,13 +884,16 @@ skip_dx:
                 }
 
                 dev->accel.sy = 0;
-                if (dev->bpp)
-                    dev->accel.dest = (mach->accel.ge_offset << 1) + (dev->accel.dy * (dev->pitch));
-                else
-                    dev->accel.dest = (mach->accel.ge_offset << 2) + (dev->accel.dy * (dev->pitch));
+                if (mach->accel.dp_config & 0x02)
+                    dev->accel.dest = (dev->accel.dy * dev->pitch);
+                else {
+                    if (dev->bpp)
+                        dev->accel.dest = (mach->accel.ge_offset << 1) + (dev->accel.dy * dev->pitch);
+                    else
+                        dev->accel.dest = (mach->accel.ge_offset << 2) + (dev->accel.dy * dev->pitch);
+                }
 
                 mach->accel.src_stepx = 0;
-
                 /*Source Width*/
                 dev->accel.cx = mach->accel.src_x;
                 if (mach->accel.src_x >= 0x600)
@@ -918,27 +927,28 @@ skip_dx:
                     mach_log("BitBLT: Src Indeterminate X: width = %d, coordinates: %d,%d px, end: %d px, stepx = %d, dpconfig = %04x, oddwidth = %d.\n", mach->accel.src_width, dev->accel.cx, dev->accel.cy, mach->accel.src_x_end, mach->accel.src_stepx, mach->accel.dp_config, mach->accel.src_width & 1);
                 }
                 mach->accel.sx = 0;
-                if (dev->bpp)
-                    dev->accel.src = (mach->accel.ge_offset << 1) + (dev->accel.cy * (dev->pitch));
+                if (mach->accel.patt_data_idx < 16)
+                    mach->accel.color_pattern_idx = mach->accel.patt_idx;
                 else
-                    dev->accel.src = (mach->accel.ge_offset << 2) + (dev->accel.cy * (dev->pitch));
+                    mach->accel.color_pattern_idx = 0;
 
-                if ((dev->accel_bpp == 24) && (frgd_sel == 5))
-                    mach_log("BitBLT=%04x, WH(%d,%d), SRCWidth=%d, c(%d,%d), s(%d,%d).\n", mach->accel.dp_config, mach->accel.width, mach->accel.height, mach->accel.src_width, dev->accel.dx, dev->accel.dy, dev->accel.cx, dev->accel.cy);
-                else if (mach->accel.dp_config & 0x02)
-                    mach_log("BitBLT=%04x, Pitch=%d, C(%d,%d), D(%d,%d), SRCWidth=%d, SRCXStep=%d, WH(%d,%d), clipt=%d, clipb=%d, geoffset=%08x.\n", mach->accel.dp_config, dev->ext_pitch, mach->accel.src_x, mach->accel.src_y, dev->accel.cur_x, dev->accel.cur_y, mach->accel.src_width, mach->accel.src_stepx, mach->accel.width, mach->accel.height, clip_t, clip_b, (mach->accel.ge_offset << 2));
+                if (dev->bpp)
+                    dev->accel.src = (mach->accel.ge_offset << 1) + (dev->accel.cy * dev->pitch);
+                else
+                    dev->accel.src = (mach->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
 
                 if (mono_src == 1) {
-                    if ((mach->accel.mono_pattern_enable) && !(mach->accel.patt_len_reg & 0x4000)) {
-                        mono_dat0 = mach->accel.patt_data[0x10];
-                        mono_dat0 |= (mach->accel.patt_data[0x11] << 8);
-                        mono_dat0 |= (mach->accel.patt_data[0x12] << 16);
-                        mono_dat0 |= (mach->accel.patt_data[0x13] << 24);
-                        mono_dat1 = mach->accel.patt_data[0x14];
-                        mono_dat1 |= (mach->accel.patt_data[0x15] << 8);
-                        mono_dat1 |= (mach->accel.patt_data[0x16] << 16);
-                        mono_dat1 |= (mach->accel.patt_data[0x17] << 24);
+                    if (mach->accel.mono_pattern_enable || mach->accel.block_write_mono_pattern_enable) {
+                        mono_dat0 = mach->accel.mono_pattern_normal[0];
+                        mono_dat0 |= (mach->accel.mono_pattern_normal[1] << 8);
+                        mono_dat0 |= (mach->accel.mono_pattern_normal[2] << 16);
+                        mono_dat0 |= (mach->accel.mono_pattern_normal[3] << 24);
+                        mono_dat1 = mach->accel.mono_pattern_normal[4];
+                        mono_dat1 |= (mach->accel.mono_pattern_normal[5] << 8);
+                        mono_dat1 |= (mach->accel.mono_pattern_normal[6] << 16);
+                        mono_dat1 |= (mach->accel.mono_pattern_normal[7] << 24);
 
+                        mach_log("MonoData0=%x, MonoData1=%x.\n", mono_dat0, mono_dat1);
                         for (uint8_t y = 0; y < 8; y++) {
                             for (uint8_t x = 0; x < 8; x++) {
                                 uint32_t temp                      = (y & 4) ? mono_dat1 : mono_dat0;
@@ -962,35 +972,12 @@ skip_dx:
             }
 
             if (mono_src == 1) {
-                if (!mach->accel.mono_pattern_enable && !(mach->accel.patt_len_reg & 0x4000)) {
-                    count               = mach->accel.width;
-                    mix_dat             = mach->accel.patt_data[0x10] ^ ((mach->accel.patt_idx & 1) ? 0xff : 0);
-                    dev->accel.temp_cnt = 8;
-                }
-            }
-
-            if (frgd_sel == 5) {
-                if (dev->bpp) {
-                    for (int x = 0; x <= mach->accel.patt_len; x += 2) {
-                        mach->accel.color_pattern_word[x + (mach->accel.color_pattern_idx & 1)] = (mach->accel.patt_data[x & mach->accel.patt_len] & 0xff);
-                        mach->accel.color_pattern_word[x + (mach->accel.color_pattern_idx & 1)] |= (mach->accel.patt_data[(x + 1) & mach->accel.patt_len] << 8);
-                    }
-                } else {
-                    if ((dev->accel_bpp == 24) && (mach->accel.patt_len < 3)) {
-                        for (int x = 0; x <= mach->accel.patt_len; x++) {
-                            mach->accel.color_pattern[x] = mach->accel.patt_data[x];
-                            mach_log("BITBLT: Color Pattern 24bpp[%d]=%02x, dataidx=%d, pattlen=%d.\n", x, mach->accel.color_pattern[x], mach->accel.patt_data_idx, mach->accel.patt_len);
-                        }
-                    } else {
-                        for (int x = 0; x <= mach->accel.patt_len; x++) {
-                            mach->accel.color_pattern[x] = mach->accel.patt_data[x & mach->accel.patt_len];
-                        }
+                if (!mach->accel.mono_pattern_enable && !mach->accel.block_write_mono_pattern_enable) {
+                    if (((dev->accel_bpp == 24) && (frgd_sel != 5)) || (dev->accel_bpp != 24)) {
+                        mix_dat = mach->accel.mono_pattern_normal[0] ^ ((mach->accel.patt_idx & 0x01) ? 0xff : 0);
+                        dev->accel.temp_cnt = 8;
                     }
                 }
-
-                /*The destination coordinates should match the pattern index.*/
-                if (mach->accel.color_pattern_idx != mach->accel.patt_idx)
-                    mach->accel.color_pattern_idx = mach->accel.patt_idx;
             }
 
             if (mach->accel.dy_end == mach->accel.dy_start) {
@@ -1016,24 +1003,22 @@ skip_dx:
             while (count--) {
                 switch (mono_src) {
                     case 0:
-                        mix = 1;
+                        mix = 0x01;
                         break;
                     case 1:
-                        if (mach->accel.mono_pattern_enable)
+                        if (mach->accel.mono_pattern_enable || mach->accel.block_write_mono_pattern_enable)
                             mix = mach->accel.mono_pattern[dev->accel.dy & 7][dev->accel.dx & 7];
+                        else if ((dev->accel_bpp == 24) && (frgd_sel == 5))
+                            mix = 0x01;
                         else {
-                            if ((dev->accel_bpp == 24) && (frgd_sel == 5) && (mach->accel.patt_len_reg & 0x4000))
-                                mix = 1;
-                            else {
-                                if (!dev->accel.temp_cnt) {
-                                    dev->accel.temp_cnt = 8;
-                                    mix_dat >>= 8;
-                                }
-                                mix = (mix_dat & 0x80);
-                                dev->accel.temp_cnt--;
-                                mix_dat <<= 1;
-                                mix_dat |= 1;
+                            if (!dev->accel.temp_cnt) {
+                                dev->accel.temp_cnt = 8;
+                                mix_dat >>= 8;
                             }
+                            mix = !!(mix_dat & 0x80);
+                            dev->accel.temp_cnt--;
+                            mix_dat <<= 1;
+                            mix_dat |= 1;
                         }
                         break;
                     case 2:
@@ -1042,10 +1027,10 @@ skip_dx:
                             mix_dat <<= 1;
                         } else {
                             if (mach->accel.dp_config & 0x200) {
-                                mix = mix_dat & 1;
+                                mix = mix_dat & 0x01;
                                 mix_dat >>= 1;
                             } else {
-                                mix = mix_dat & 0x80;
+                                mix = !!(mix_dat & 0x80);
                                 mix_dat <<= 1;
                                 mix_dat |= 1;
                             }
@@ -1060,15 +1045,18 @@ skip_dx:
                         break;
                 }
 
-                if (((dev->accel.dx) >= clip_l) && ((dev->accel.dx) <= clip_r) && ((dev->accel.dy) >= clip_t) && ((dev->accel.dy) <= clip_b)) {
-                    if ((mach->accel.dp_config & 0x02) || (mach->accel.linedraw_opt & 0x02)) {
+                if ((dev->accel.dx >= clip_l) &&
+                    (dev->accel.dx <= clip_r) &&
+                    (dev->accel.dy >= clip_t) &&
+                    (dev->accel.dy <= clip_b)) {
+                    if (mach->accel.dp_config & 0x02) {
                         READ(dev->accel.src + dev->accel.cx, poly_src);
                         poly_src = ((poly_src & rd_mask) == rd_mask);
                         if (poly_src)
                             mach->accel.poly_fill ^= 1;
                     }
 
-                    if (mach->accel.poly_fill || !(mach->accel.dp_config & 0x02) || !(mach->accel.linedraw_opt & 0x02)) {
+                    if (mach->accel.poly_fill || !(mach->accel.dp_config & 0x02)) {
                         switch (mix ? frgd_sel : bkgd_sel) {
                             case 0:
                                 src_dat = dev->accel.bkgd_color;
@@ -1089,22 +1077,18 @@ skip_dx:
                                 }
                                 break;
                             case 5:
-                                if (mix) {
-                                    if (dev->bpp)
-                                        src_dat = mach->accel.color_pattern_word[mach->accel.color_pattern_idx];
-                                    else
-                                        src_dat = mach->accel.color_pattern[mach->accel.color_pattern_idx];
-                                } else
-                                    src_dat = 0;
+                                src_dat = mach->accel.color_pattern[mach->accel.color_pattern_idx];
+                                if (dev->bpp)
+                                    src_dat |= (mach->accel.color_pattern[mach->accel.color_pattern_idx + 1] << 8);
                                 break;
 
                             default:
                                 break;
                         }
 
-                        if ((dev->accel_bpp == 24) && (mono_src == 1) && (frgd_sel == 5) && (mach->accel.patt_len_reg & 0x4000)) {
+                        if ((dev->accel_bpp == 24) && (mono_src == 1) && (frgd_sel == 5) && !mach->accel.mono_pattern_enable) {
                             if (dev->accel.sy & 1) {
-                                READ(dev->accel.dest + dev->accel.dx - dev->ext_pitch, dest_dat);
+                                READ(dev->accel.dest + dev->accel.dx - dev->pitch, dest_dat);
                             } else {
                                 READ(dev->accel.dest + dev->accel.dx, dest_dat);
                             }
@@ -1148,14 +1132,20 @@ skip_dx:
                         }
 
                         if (mach->accel.dp_config & 0x10) {
-                            if ((dev->accel_bpp == 24) && (mono_src == 1) && (frgd_sel == 5) && (mach->accel.patt_len_reg & 0x4000)) {
-                                if (dev->accel.sy & 1) {
-                                    WRITE(dev->accel.dest + dev->accel.dx - dev->ext_pitch, dest_dat);
-                                } else {
+                            if (mach->accel.block_write_mono_pattern_enable) {
+                                if (mix) {
                                     WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
                                 }
                             } else {
-                                WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
+                                if ((dev->accel_bpp == 24) && (mono_src == 1) && (frgd_sel == 5) && !mach->accel.mono_pattern_enable) {
+                                    if (dev->accel.sy & 1) {
+                                        WRITE(dev->accel.dest + dev->accel.dx - dev->pitch, dest_dat);
+                                    } else {
+                                        WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
+                                    }
+                                } else {
+                                    WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
+                                }
                             }
                         }
                     }
@@ -1166,54 +1156,45 @@ skip_dx:
                 else
                     cpu_dat >>= 8;
 
+                if (mach->accel.dp_config == 0x2071 || (mach->accel.dp_config == 0x2011))
+                    mach_log("FontBlit: SX=%d, C(%d,%d), SRCWidth=%d, frgdmix=%d, bkgdmix=%d, rdmask=%04x, D(%d,%d), geoffset=%x, addr=%08x,.\n", mach->accel.sx, dev->accel.cx, dev->accel.cy, mach->accel.src_width, dev->accel.frgd_mix & 0x1f, dev->accel.bkgd_mix & 0x1f, rd_mask, dev->accel.dx, dev->accel.dy, dev->accel.ge_offset, (dev->accel.src + dev->accel.cx) & dev->vram_mask);
+
                 if ((mono_src == 3) || (frgd_sel == 3) || (bkgd_sel == 3) || (mach->accel.dp_config & 0x02)) {
                     dev->accel.cx += mach->accel.src_stepx;
                     mach->accel.sx++;
                     if (mach->accel.sx >= mach->accel.src_width) {
                         mach->accel.sx = 0;
-                        if (mach->accel.src_stepx == -1)
+                        if (mach->accel.src_stepx < 0)
                             dev->accel.cx += mach->accel.src_width;
                         else
                             dev->accel.cx -= mach->accel.src_width;
 
                         dev->accel.cy += (mach->accel.src_y_dir ? 1 : -1);
                         if (dev->bpp)
-                            dev->accel.src = (mach->accel.ge_offset << 1) + (dev->accel.cy * (dev->pitch));
+                            dev->accel.src = (mach->accel.ge_offset << 1) + (dev->accel.cy * dev->pitch);
                         else
-                            dev->accel.src = (mach->accel.ge_offset << 2) + (dev->accel.cy * (dev->pitch));
+                            dev->accel.src = (mach->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
                     }
                 }
 
-                dev->accel.dx += mach->accel.stepx;
-
-                if ((dev->accel_bpp == 8) || ((dev->accel_bpp == 24) && (mach->accel.patt_len >= 3) && (mono_src != 1)))
-                    mach->accel.color_pattern_idx = (mach->accel.color_pattern_idx + mach->accel.stepx) & mach->accel.patt_len;
-
-                if ((dev->accel_bpp == 24) && (mach->accel.color_pattern_idx == mach->accel.patt_len) && (mach->accel.patt_len >= 3) && (mono_src != 1)) {
-                    mach->accel.color_pattern_idx = mach->accel.patt_data_idx;
-                } else if ((dev->accel_bpp == 24) && (mach->accel.patt_len < 3)) {
-                    if (mach->accel.patt_len == 2) {
-                        mach->accel.color_pattern_idx++;
-                        if (mach->accel.color_pattern_idx == 3)
-                            mach->accel.color_pattern_idx = 0;
-                    } else
-                        mach->accel.color_pattern_idx = (mach->accel.color_pattern_idx + mach->accel.stepx) & mach->accel.patt_len;
-
-                } else if ((dev->accel_bpp == 24) && (mach->accel.patt_len_reg & 0x4000) && (frgd_sel == 5)) {
+                if (dev->bpp)
+                    mach->accel.color_pattern_idx += 2;
+                else
                     mach->accel.color_pattern_idx++;
-                    if (mach->accel.color_pattern_idx == 3)
+
+                if ((mono_src == 1) && !mach->accel.mono_pattern_enable && !mach->accel.block_write_mono_pattern_enable && (frgd_sel == 5) && (dev->accel_bpp == 24)) {
+                    if (mach->accel.color_pattern_idx > 2)
+                        mach->accel.color_pattern_idx = 0;
+                } else {
+                    if (mach->accel.color_pattern_idx > mach->accel.patt_len)
                         mach->accel.color_pattern_idx = 0;
                 }
 
-                if (dev->bpp) {
-                    mach->accel.color_pattern_idx = (mach->accel.color_pattern_idx + mach->accel.stepx) & mach->accel.patt_len;
-                    mach->accel.color_pattern_idx = (mach->accel.color_pattern_idx + mach->accel.stepx) & mach->accel.patt_len;
-                }
-
+                dev->accel.dx += mach->accel.stepx;
                 dev->accel.sx++;
                 if ((dev->accel.sx >= mach->accel.width) || (dev->accel.dx >= 0x600)) {
                     dev->accel.sx         = 0;
-                    if (mach->accel.stepx == -1)
+                    if (mach->accel.stepx < 0)
                         dev->accel.dx += mach->accel.width;
                     else
                         dev->accel.dx -= mach->accel.width;
@@ -1222,27 +1203,19 @@ skip_dx:
                     dev->accel.sy++;
 
                     mach->accel.poly_fill = 0;
-                    if (dev->bpp)
-                        dev->accel.dest = (mach->accel.ge_offset << 1) + (dev->accel.dy * (dev->pitch));
-                    else
-                        dev->accel.dest = (mach->accel.ge_offset << 2) + (dev->accel.dy * (dev->pitch));
-
-                    if ((mono_src == 1) && (dev->accel_bpp == 24) && (frgd_sel == 5))
-                        mach->accel.color_pattern_idx = 0;
-                    else
-                        mach->accel.color_pattern_idx = ((dev->accel.dx + (dev->accel.dy << 3)) & mach->accel.patt_len);
-
-                    if ((dev->accel_bpp == 24) && (mach->accel.color_pattern_idx == mach->accel.patt_len) && (mono_src != 1))
-                        mach->accel.color_pattern_idx = 0;
-                    if ((mono_src == 1) && !mach->accel.mono_pattern_enable && !(mach->accel.patt_len_reg & 0x4000)) {
-                        dev->accel.cur_x = dev->accel.dx;
-                        dev->accel.cur_y = dev->accel.dy;
-                        return;
+                    if (mach->accel.dp_config & 0x02)
+                        dev->accel.dest = (dev->accel.dy * dev->pitch);
+                    else {
+                        if (dev->bpp)
+                            dev->accel.dest = (mach->accel.ge_offset << 1) + (dev->accel.dy * dev->pitch);
+                        else
+                            dev->accel.dest = (mach->accel.ge_offset << 2) + (dev->accel.dy * dev->pitch);
                     }
+
                     if (dev->accel.sy >= mach->accel.height) {
-                        if ((mono_src == 2) || (mono_src == 3) || (frgd_sel == 3) || (bkgd_sel == 3) || (mach->accel.dp_config & 0x02) || (mach->accel.linedraw_opt & 0x02))
+                        if ((mono_src == 2) || (mono_src == 3) || (frgd_sel == 3) || (bkgd_sel == 3) || (mach->accel.dp_config & 0x02))
                             return;
-                        if ((mono_src == 1) && (frgd_sel == 5) && (dev->accel_bpp == 24) && (mach->accel.patt_len_reg & 0x4000))
+                        if ((mono_src == 1) && (frgd_sel == 5) &&  (dev->accel_bpp == 24))
                             return;
                         dev->accel.cur_x = dev->accel.dx;
                         dev->accel.cur_y = dev->accel.dy;
@@ -1290,18 +1263,12 @@ skip_dx:
                 }
             }
 
-            if (frgd_sel == 5) {
-                for (int x = 0; x <= mach->accel.patt_len; x++) {
-                    mach->accel.color_pattern[x] = mach->accel.patt_data[x & mach->accel.patt_len];
-                }
-            }
-
             if (mono_src == 1) {
-                mix_dat             = mach->accel.patt_data[0x10];
+                mix_dat = mach->accel.mono_pattern_normal[0];
                 dev->accel.temp_cnt = 8;
             }
 
-            count             = (dev->accel.dx > dev->accel.dy) ? (dev->accel.dx >> 1) : (dev->accel.dy >> 1);
+            count = (dev->accel.dx > dev->accel.dy) ? (dev->accel.dx >> 1) : (dev->accel.dy >> 1);
             mach->accel.width = count;
 
             if (dev->accel.dx > dev->accel.dy) {
@@ -1317,7 +1284,10 @@ skip_dx:
                         mix_dat <<= 1;
                         mix_dat |= 1;
 
-                        if ((dev->accel.cx >= clip_l) && (dev->accel.cx <= clip_r) && (dev->accel.cy >= clip_t) && (dev->accel.cy <= clip_b)) {
+                        if ((dev->accel.cx >= clip_l) &&
+                            (dev->accel.cx <= clip_r) &&
+                            (dev->accel.cy >= clip_t) &&
+                            (dev->accel.cy <= clip_b)) {
                             mach->accel.clip_overrun = 0;
                             switch (mix ? frgd_sel : bkgd_sel) {
                                 case 0:
@@ -1336,10 +1306,9 @@ skip_dx:
                                         src_dat = 0;
                                     break;
                                 case 5:
-                                    if (mix)
-                                        src_dat = mach->accel.color_pattern[((dev->accel.cx) + ((dev->accel.cy) << 3)) & mach->accel.patt_len];
-                                    else
-                                        src_dat = 0;
+                                    src_dat = mach->accel.color_pattern[mach->accel.color_pattern_idx];
+                                    if (dev->bpp)
+                                        src_dat |= (mach->accel.color_pattern[mach->accel.color_pattern_idx + 1] << 8);
                                     break;
 
                                 default:
@@ -1404,6 +1373,14 @@ skip_dx:
                         else
                             cpu_dat >>= 8;
 
+                        if (dev->bpp)
+                            mach->accel.color_pattern_idx += 2;
+                        else
+                            mach->accel.color_pattern_idx++;
+
+                        if (mach->accel.color_pattern_idx > mach->accel.patt_len)
+                            mach->accel.color_pattern_idx = 0;
+
                         if (mach->accel.err >= 0) {
                             dev->accel.cy += mach->accel.stepy;
                             mach->accel.err -= dev->accel.dx;
@@ -1438,12 +1415,19 @@ skip_dx:
                                 break;
                         }
 
-                        if ((dev->accel.cx >= clip_l) && (dev->accel.cx <= clip_r) && (dev->accel.cy >= clip_t) && (dev->accel.cy <= clip_b)) {
+                        if ((dev->accel.cx >= clip_l) &&
+                            (dev->accel.cx <= clip_r) &&
+                            (dev->accel.cy >= clip_t) &&
+                            (dev->accel.cy <= clip_b)) {
                             mach->accel.clip_overrun = 0;
                             if (mach->accel.linedraw_opt & 0x02) {
-                                READ((mach->accel.ge_offset << 2) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), poly_src);
+                                if (dev->bpp) {
+                                    READ((mach->accel.ge_offset << 1) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), poly_src);
+                                } else {
+                                    READ((mach->accel.ge_offset << 2) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), poly_src);
+                                }
                                 if (poly_src)
-                                    mach->accel.poly_fill = !mach->accel.poly_fill;
+                                    mach->accel.poly_fill ^= 1;
                             }
 
                             switch (mix ? frgd_sel : bkgd_sel) {
@@ -1464,20 +1448,23 @@ skip_dx:
                                     }
                                     break;
                                 case 5:
-                                    if (mix) {
-                                        src_dat = mach->accel.color_pattern[((dev->accel.cx) + ((dev->accel.cy) << 3)) & mach->accel.patt_len];
-                                    } else
-                                        src_dat = 0;
+                                    src_dat = mach->accel.color_pattern[mach->accel.color_pattern_idx];
+                                    if (dev->bpp)
+                                        src_dat |= (mach->accel.color_pattern[mach->accel.color_pattern_idx + 1] << 8);
                                     break;
 
                                 default:
                                     break;
                             }
 
-                            if (dev->bpp) {
-                                READ((mach->accel.ge_offset << 1) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
+                            if (mach->accel.linedraw_opt & 0x02) {
+                                if (dev->bpp) {
+                                    READ((mach->accel.ge_offset << 1) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
+                                } else {
+                                    READ((mach->accel.ge_offset << 2) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
+                                }
                             } else {
-                                READ((mach->accel.ge_offset << 2) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
+                                READ(((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
                             }
 
                             switch (compare_mode) {
@@ -1520,17 +1507,25 @@ skip_dx:
                             if ((mach->accel.dp_config & 0x10) && (cmd_type == 3)) {
                                 if (mach->accel.linedraw_opt & 0x04) {
                                     if (dev->accel.sx < mach->accel.width) {
+                                        if (mach->accel.linedraw_opt & 0x02) {
+                                            if (dev->bpp) {
+                                                WRITE((mach->accel.ge_offset << 1) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
+                                            } else {
+                                                WRITE((mach->accel.ge_offset << 2) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
+                                            }
+                                        } else {
+                                            WRITE(((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
+                                        }
+                                    }
+                                } else {
+                                    if (mach->accel.linedraw_opt & 0x02) {
                                         if (dev->bpp) {
                                             WRITE((mach->accel.ge_offset << 1) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
                                         } else {
                                             WRITE((mach->accel.ge_offset << 2) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
                                         }
-                                    }
-                                } else {
-                                    if (dev->bpp) {
-                                        WRITE((mach->accel.ge_offset << 1) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
                                     } else {
-                                        WRITE((mach->accel.ge_offset << 2) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
+                                        WRITE(((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
                                     }
                                 }
                             }
@@ -1544,6 +1539,14 @@ skip_dx:
                             cpu_dat >>= 16;
                         else
                             cpu_dat >>= 8;
+
+                        if (dev->bpp)
+                            mach->accel.color_pattern_idx += 2;
+                        else
+                            mach->accel.color_pattern_idx++;
+
+                        if (mach->accel.color_pattern_idx > mach->accel.patt_len)
+                            mach->accel.color_pattern_idx = 0;
 
                         if (mach->accel.err >= 0) {
                             dev->accel.cy += mach->accel.stepy;
@@ -1568,7 +1571,10 @@ skip_dx:
                         mix_dat <<= 1;
                         mix_dat |= 1;
 
-                        if ((dev->accel.cx >= clip_l) && (dev->accel.cx <= clip_r) && (dev->accel.cy >= clip_t) && (dev->accel.cy <= clip_b)) {
+                        if ((dev->accel.cx >= clip_l) &&
+                            (dev->accel.cx <= clip_r) &&
+                            (dev->accel.cy >= clip_t) &&
+                            (dev->accel.cy <= clip_b)) {
                             mach->accel.clip_overrun = 0;
                             switch (mix ? frgd_sel : bkgd_sel) {
                                 case 0:
@@ -1588,10 +1594,9 @@ skip_dx:
                                     }
                                     break;
                                 case 5:
-                                    if (mix) {
-                                        src_dat = mach->accel.color_pattern[((dev->accel.cx) + ((dev->accel.cy) << 3)) & mach->accel.patt_len];
-                                    } else
-                                        src_dat = 0;
+                                    src_dat = mach->accel.color_pattern[mach->accel.color_pattern_idx];
+                                    if (dev->bpp)
+                                        src_dat |= (mach->accel.color_pattern[mach->accel.color_pattern_idx + 1] << 8);
                                     break;
 
                                 default:
@@ -1656,6 +1661,14 @@ skip_dx:
                         else
                             cpu_dat >>= 8;
 
+                        if (dev->bpp)
+                            mach->accel.color_pattern_idx += 2;
+                        else
+                            mach->accel.color_pattern_idx++;
+
+                        if (mach->accel.color_pattern_idx > mach->accel.patt_len)
+                            mach->accel.color_pattern_idx = 0;
+
                         if (mach->accel.err >= 0) {
                             dev->accel.cx += mach->accel.stepx;
                             mach->accel.err -= dev->accel.dy;
@@ -1690,9 +1703,11 @@ skip_dx:
                                 break;
                         }
 
-                        if ((dev->accel.cx >= clip_l) && (dev->accel.cx <= clip_r) && (dev->accel.cy >= clip_t) && (dev->accel.cy <= clip_b)) {
+                        if ((dev->accel.cx >= clip_l) &&
+                            (dev->accel.cx <= clip_r) &&
+                            (dev->accel.cy >= clip_t) &&
+                            (dev->accel.cy <= clip_b)) {
                             mach->accel.clip_overrun = 0;
-
                             switch (mix ? frgd_sel : bkgd_sel) {
                                 case 0:
                                     src_dat = dev->accel.bkgd_color;
@@ -1711,20 +1726,23 @@ skip_dx:
                                     }
                                     break;
                                 case 5:
-                                    if (mix) {
-                                        src_dat = mach->accel.color_pattern[((dev->accel.cx) + ((dev->accel.cy) << 3)) & mach->accel.patt_len];
-                                    } else
-                                        src_dat = 0;
+                                    src_dat = mach->accel.color_pattern[mach->accel.color_pattern_idx];
+                                    if (dev->bpp)
+                                        src_dat |= (mach->accel.color_pattern[mach->accel.color_pattern_idx + 1] << 8);
                                     break;
 
                                 default:
                                     break;
                             }
 
-                            if (dev->bpp) {
-                                READ((mach->accel.ge_offset << 1) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
+                            if (mach->accel.linedraw_opt & 0x02) {
+                                if (dev->bpp) {
+                                    READ((mach->accel.ge_offset << 1) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
+                                } else {
+                                    READ((mach->accel.ge_offset << 2) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
+                                }
                             } else {
-                                READ((mach->accel.ge_offset << 2) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
+                                READ(((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
                             }
 
                             switch (compare_mode) {
@@ -1765,17 +1783,25 @@ skip_dx:
                             if ((mach->accel.dp_config & 0x10) && (cmd_type == 3)) {
                                 if (mach->accel.linedraw_opt & 0x04) {
                                     if (dev->accel.sx < mach->accel.width) {
+                                        if (mach->accel.linedraw_opt & 0x02) {
+                                            if (dev->bpp) {
+                                                WRITE((mach->accel.ge_offset << 1) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
+                                            } else {
+                                                WRITE((mach->accel.ge_offset << 2) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
+                                            }
+                                        } else {
+                                            WRITE((dev->accel.cy * dev->pitch) + dev->accel.cx, dest_dat);
+                                        }
+                                    }
+                                } else {
+                                    if (mach->accel.linedraw_opt & 0x02) {
                                         if (dev->bpp) {
                                             WRITE((mach->accel.ge_offset << 1) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
                                         } else {
                                             WRITE((mach->accel.ge_offset << 2) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
                                         }
-                                    }
-                                } else {
-                                    if (dev->bpp) {
-                                        WRITE((mach->accel.ge_offset << 1) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
                                     } else {
-                                        WRITE((mach->accel.ge_offset << 2) + ((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
+                                        WRITE(((dev->accel.cy) * (dev->pitch)) + (dev->accel.cx), dest_dat);
                                     }
                                 }
                             }
@@ -1789,6 +1815,14 @@ skip_dx:
                             cpu_dat >>= 16;
                         else
                             cpu_dat >>= 8;
+
+                        if (dev->bpp)
+                            mach->accel.color_pattern_idx += 2;
+                        else
+                            mach->accel.color_pattern_idx++;
+
+                        if (mach->accel.color_pattern_idx > mach->accel.patt_len)
+                            mach->accel.color_pattern_idx = 0;
 
                         if (mach->accel.err >= 0) {
                             dev->accel.cx += mach->accel.stepx;
@@ -1842,8 +1876,6 @@ skip_dx:
                 }
 
                 dev->accel.sx = 0;
-                if ((dev->accel_bpp == 24) && (mach->accel.patt_len < 0x17))
-                    mach->accel.color_pattern_idx = 0;
 
                 /*Step Y*/
                 mach->accel.dy_start = dev->accel.cur_y;
@@ -1853,13 +1885,12 @@ skip_dx:
                 if (mach->accel.dest_y_end >= 0x600)
                     mach->accel.dy_end |= ~0x5ff;
 
-                if (mach->accel.dy_end > mach->accel.dy_start) {
+                if (mach->accel.dy_end > mach->accel.dy_start)
                     mach->accel.stepy = 1;
-                } else if (mach->accel.dy_end < mach->accel.dy_start) {
+                else if (mach->accel.dy_end < mach->accel.dy_start)
                     mach->accel.stepy = -1;
-                } else {
+                else
                     mach->accel.stepy = 0;
-                }
 
                 if (dev->bpp)
                     dev->accel.dest = (mach->accel.ge_offset << 1) + (dev->accel.dy * (dev->pitch));
@@ -1903,22 +1934,7 @@ skip_dx:
                 else
                     dev->accel.src = (mach->accel.ge_offset << 2) + (dev->accel.cy * (dev->pitch));
 
-                if ((dev->accel_bpp == 24) && (frgd_sel == 5)) {
-                    if (mach->accel.patt_len == 0x17)
-                        mach->accel.color_pattern_idx = 0;
-                    dev->accel.x1 = dev->accel.dx + mach->accel.width;
-                    if (dev->accel.x1 == dev->pitch) {
-                        dev->accel.x2 = mach->accel.width & 1;
-                    } else if ((dev->accel.x1 == mach->accel.width) && (dev->accel.dy & 1) && !dev->accel.y1 && dev->accel.x2) {
-                        if (mach->accel.patt_len == 0x17)
-                            mach->accel.color_pattern_idx = 3;
-                        dev->accel.x3 = 1;
-                    } else
-                        dev->accel.x3 = 0;
-                } else
-                    mach_log("ScanToX=%04x, Pitch=%d, C(%d,%d), SRCWidth=%d, WH(%d,%d), geoffset=%08x.\n", mach->accel.dp_config, dev->ext_pitch, dev->accel.cx, dev->accel.cy, mach->accel.src_width, mach->accel.width, mach->accel.height, (mach->accel.ge_offset << 1));
-
-                dev->accel.y1 = 0;
+                mach_log("ScanToX=%04x, MonoSRC=%d, FrgdSel=%d, BkgdSel=%d, Pitch=%d, C(%d,%d), SRCWidth=%d, WH(%d,%d), colorpattidx=%d, pattlen=%d.\n", mach->accel.dp_config, mono_src, frgd_sel, bkgd_sel, dev->ext_pitch, dev->accel.cx, dev->accel.cy, mach->accel.src_width, mach->accel.width, mach->accel.height, mach->accel.color_pattern_idx, mach->accel.patt_len);
 
                 if ((mono_src == 2) || (bkgd_sel == 2) || (frgd_sel == 2) || mach_pixel_read(mach)) {
                     if (mach_pixel_write(mach)) {
@@ -1935,28 +1951,8 @@ skip_dx:
 
             if (mono_src == 1) {
                 count               = mach->accel.width;
-                mix_dat             = mach->accel.patt_data[0x10];
+                mix_dat             = mach->accel.mono_pattern_normal[0];
                 dev->accel.temp_cnt = 8;
-            }
-
-            if (frgd_sel == 5) {
-                if (dev->accel_bpp != 24) {
-                    for (int x = 0; x <= mach->accel.patt_len; x++) {
-                        mach->accel.color_pattern[x] = mach->accel.patt_data[x & mach->accel.patt_len];
-                    }
-                } else {
-                    if (mach->accel.patt_len == 0x17) {
-                        for (int x = 0; x <= mach->accel.patt_len; x++) {
-                            mach->accel.color_pattern_full[x] = mach->accel.patt_data[x];
-                            mach_log("ScanToX: Color Pattern 24bpp[%d]=%02x, dataidx=%d, pattlen=%d.\n", x, mach->accel.color_pattern_full[x], mach->accel.patt_data_idx, mach->accel.patt_len);
-                        }
-                    } else {
-                        for (int x = 0; x <= mach->accel.patt_len; x++) {
-                            mach->accel.color_pattern[x] = mach->accel.patt_data[x];
-                            mach_log("ScanToX: Color Pattern 24bpp[%d]=%02x, dataidx=%d, pattlen=%d.\n", x, mach->accel.color_pattern[x], mach->accel.patt_data_idx, mach->accel.patt_len);
-                        }
-                    }
-                }
             }
 
             while (count--) {
@@ -1998,7 +1994,10 @@ skip_dx:
                         break;
                 }
 
-                if (((dev->accel.dx) >= clip_l) && ((dev->accel.dx) <= clip_r) && ((dev->accel.dy) >= clip_t) && ((dev->accel.dy) <= clip_b)) {
+                if ((dev->accel.dx >= clip_l) &&
+                    (dev->accel.dx <= clip_r) &&
+                    (dev->accel.dy >= clip_t) &&
+                    (dev->accel.dy <= clip_b)) {
                     switch (mix ? frgd_sel : bkgd_sel) {
                         case 0:
                             src_dat = dev->accel.bkgd_color;
@@ -2019,16 +2018,9 @@ skip_dx:
                             }
                             break;
                         case 5:
-                            if (mix) {
-                                if (dev->accel_bpp == 24) {
-                                    if (mach->accel.patt_len == 0x17)
-                                        src_dat = mach->accel.color_pattern_full[mach->accel.color_pattern_idx];
-                                    else
-                                        src_dat = mach->accel.color_pattern[mach->accel.color_pattern_idx];
-                                } else
-                                    src_dat = mach->accel.color_pattern[(dev->accel.dx + (dev->accel.dy << 3)) & mach->accel.patt_len];
-                            } else
-                                src_dat = 0;
+                            src_dat = mach->accel.color_pattern[mach->accel.color_pattern_idx];
+                            if (dev->bpp)
+                                src_dat |= (mach->accel.color_pattern[mach->accel.color_pattern_idx + 1] << 8);
                             break;
 
                         default:
@@ -2073,7 +2065,7 @@ skip_dx:
                     }
 
                     if (mach->accel.dp_config & 0x10) {
-                        WRITE(dev->accel.dest + (dev->accel.dx), dest_dat);
+                        WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
                     }
                 }
 
@@ -2097,23 +2089,15 @@ skip_dx:
                         dev->accel.src = (mach->accel.ge_offset << 2) + (dev->accel.cy * (dev->pitch));
                 }
 
-                dev->accel.dx += mach->accel.stepx;
-                if ((dev->accel_bpp == 24) && (mach->accel.patt_len == 0x17)) {
+                if (dev->bpp)
+                    mach->accel.color_pattern_idx += 2;
+                else
                     mach->accel.color_pattern_idx++;
-                    if (dev->accel.x3) {
-                        if (mach->accel.color_pattern_idx == 9)
-                            mach->accel.color_pattern_idx = 3;
-                    } else {
-                        if (mach->accel.color_pattern_idx == 6)
-                            mach->accel.color_pattern_idx = 0;
-                    }
-                } else if ((dev->accel_bpp == 24) && (mach->accel.patt_len < 3)) {
-                    mach->accel.color_pattern_idx++;
-                    if (mach->accel.color_pattern_idx == 3)
-                        mach->accel.color_pattern_idx = 0;
-                } else
-                    mach->accel.color_pattern_idx = (mach->accel.color_pattern_idx + mach->accel.stepx) & mach->accel.patt_len;
 
+                if (mach->accel.color_pattern_idx > mach->accel.patt_len)
+                    mach->accel.color_pattern_idx = 0;
+
+                dev->accel.dx += mach->accel.stepx;
                 dev->accel.sx++;
                 if (dev->accel.sx >= mach->accel.width) {
                     dev->accel.sx = 0;
@@ -2142,21 +2126,26 @@ mach_accel_out_pixtrans(mach_t *mach, ibm8514_t *dev, uint16_t val)
     int frgd_sel;
     int bkgd_sel;
     int mono_src;
+    int swap = 0;
 
     frgd_sel = (mach->accel.dp_config >> 13) & 7;
     bkgd_sel = (mach->accel.dp_config >> 7) & 3;
     mono_src = (mach->accel.dp_config >> 5) & 3;
 
-    if ((mach->accel.dp_config & 4) && (mach->accel.cmd_type != 5)) {
+    if ((mach->accel.dp_config & 0x04) && (mach->accel.cmd_type != 5)) {
+        mach_log("Read Host Monochrome Data.\n");
         val = (val >> 8) | (val << 8);
+        swap = 1;
     }
 
     switch (mach->accel.dp_config & 0x200) {
         case 0x000: /*8-bit size*/
             if (mono_src == 2) {
                 if ((frgd_sel != 2) && (bkgd_sel != 2)) {
-                    if (mach->accel.dp_config & 0x1000)
+                    if ((mach->accel.dp_config & 0x1000) && !swap) {
+                        mach_log("8-bit bus size swap.\n");
                         val = (val >> 8) | (val << 8);
+                    }
                     mach_accel_start(mach->accel.cmd_type, 1, 8, val | (val << 16), 0, mach, dev);
                 } else
                     mach_accel_start(mach->accel.cmd_type, 1, 1, -1, val | (val << 16), mach, dev);
@@ -2166,8 +2155,10 @@ mach_accel_out_pixtrans(mach_t *mach, ibm8514_t *dev, uint16_t val)
         case 0x200: /*16-bit size*/
             if (mono_src == 2) {
                 if ((frgd_sel != 2) && (bkgd_sel != 2)) {
-                    if (mach->accel.dp_config & 0x1000)
+                    if ((mach->accel.dp_config & 0x1000) && !swap) {
+                        mach_log("16-bit bus size swap.\n");
                         val = (val >> 8) | (val << 8);
+                    }
                     mach_accel_start(mach->accel.cmd_type, 1, 16, val | (val << 16), 0, mach, dev);
                 } else
                     mach_accel_start(mach->accel.cmd_type, 1, 2, -1, val | (val << 16), mach, dev);
@@ -2231,15 +2222,15 @@ mach_out(uint16_t addr, uint8_t val, void *priv)
                             mach->bank_r |= ((mach->regs[0xae] & 0x0c) << 2);
                             mach->bank_w |= ((mach->regs[0xae] & 3) << 4);
                         }
-                        if (dev->on[0] || dev->on[1])
+                        if (dev->on)
                             mach_log("Separate B2Bank = %02x, AEbank = %02x.\n", mach->regs[0xb2], mach->regs[0xae]);
                     } else { /* Single bank mode */
                         mach->bank_w = ((mach->regs[0xb2] & 0x1e) >> 1);
-                        if ((dev->local & 0xff) >= 0x02) {
+                        if ((dev->local & 0xff) >= 0x02)
                             mach->bank_w |= ((mach->regs[0xae] & 3) << 4);
-                        }
+
                         mach->bank_r = mach->bank_w;
-                        if (dev->on[0] || dev->on[1])
+                        if (dev->on)
                             mach_log("Single B2Bank = %02x, AEbank = %02x.\n", mach->regs[0xb2], mach->regs[0xae]);
                     }
                     svga->read_bank  = mach->bank_r << 16;
@@ -2356,7 +2347,7 @@ mach_in(uint16_t addr, void *priv)
     if (((addr & 0xFFF0) == 0x3D0 || (addr & 0xFFF0) == 0x3B0) && !(svga->miscout & 1))
         addr ^= 0x60;
 
-    if ((addr >= 0x3c6) && (addr <= 0x3c9) && (dev->on[0] || dev->on[1]))
+    if ((addr >= 0x3c6) && (addr <= 0x3c9) && dev->on)
         addr -= 0xdc;
 
     switch (addr) {
@@ -2457,8 +2448,8 @@ ati8514_recalctimings(svga_t *svga)
     mach_t       *mach = (mach_t *) svga->ext8514;
     ibm8514_t    *dev  = (ibm8514_t *) svga->dev8514;
 
-    mach_log("ON0=%d, ON1=%d, vgahdisp=%d.\n", dev->on[0], dev->on[1], svga->hdisp);
-    if (dev->on[0] || dev->on[1]) {
+    mach_log("ON=%d, vgahdisp=%d.\n", dev->on, svga->hdisp);
+    if (dev->on) {
         mach_log("8514/A ON.\n");
         dev->h_total                    = dev->htotal + 1;
         dev->rowcount                   = !!(dev->disp_cntl & 0x08);
@@ -2466,17 +2457,18 @@ ati8514_recalctimings(svga_t *svga)
         mach->accel.ge_offset           = dev->accel.ge_offset;
 
         mach_log("HDISP=%d, VDISP=%d, shadowset=%x, 8514/A mode=%x, clocksel=%02x.\n", dev->hdisp, dev->vdisp, mach->shadow_set & 0x03, dev->accel.advfunc_cntl & 0x04, mach->accel.clock_sel & 0xfe);
-        if (dev->accel.advfunc_cntl & 0x01) {
+
+        if (dev->hdisp) {
+            dev->h_disp = dev->hdisp;
+            dev->dispend = dev->vdisp;
+        } else {
             if (dev->accel.advfunc_cntl & 0x04) {
-                dev->h_disp = dev->hdisp;
-                dev->dispend = dev->vdisp;
+                dev->h_disp = 1024;
+                dev->dispend = 768;
             } else {
                 dev->h_disp = 640;
                 dev->dispend = 480;
             }
-        } else {
-            dev->h_disp = dev->hdisp;
-            dev->dispend = dev->vdisp;
         }
 
         if (dev->accel.advfunc_cntl & 0x04)
@@ -2500,6 +2492,16 @@ ati8514_recalctimings(svga_t *svga)
         dev->rowoffset = dev->ext_crt_pitch;
         mach_log("cntl=%d, hv(%d,%d), pitch=%d, rowoffset=%d, gextconfig=%03x, shadow=%x interlace=%d.\n", dev->accel.advfunc_cntl & 0x04, dev->h_disp, dev->dispend, dev->pitch, dev->rowoffset, mach->accel.ext_ge_config & 0xcec0, mach->shadow_set & 3, dev->interlace);
         svga->map8 = dev->pallook;
+        if (dev->vram_512k_8514) {
+            if (dev->h_disp == 640) {
+                dev->ext_pitch = 640;
+                dev->pitch = dev->ext_pitch;
+            } else {
+                dev->ext_pitch = 1024;
+                dev->pitch = dev->ext_pitch;
+            }
+        }
+        dev->accel_bpp = 8;
         svga->render8514 = ibm8514_render_8bpp;
     } else {
         if (!(svga->gdcreg[6] & 1) && !(svga->attrregs[0x10] & 1)) { /*Text mode*/
@@ -2567,17 +2569,39 @@ mach_recalctimings(svga_t *svga)
     }
 
     svga->render8514 = ibm8514_render_blank;
-    mach_log("ON[0]=%d, ON[1]=%d, exton[0]=%d, exton[1]=%d, vendormode0=%d, vendormode1=%d.\n", dev->on[0], dev->on[1], mach->ext_on[0], mach->ext_on[1], dev->vendor_mode[0], dev->vendor_mode[1]);
-    if (dev->on[0] || dev->on[1]) {
-        mach_log("8514/A ON.\n");
+    if (dev->on) {
+        mach_log("8514/A ON, extpitch=%d, devma=%x, vgamalatch=%x.\n", dev->ext_pitch, dev->ma, svga->ma_latch);
+        dev->pitch                      = dev->ext_pitch;
+        dev->rowoffset                  = dev->ext_crt_pitch;
         dev->h_total                    = dev->htotal + 1;
         dev->rowcount                   = !!(dev->disp_cntl & 0x08);
         dev->accel.ge_offset            = (mach->accel.ge_offset_lo | (mach->accel.ge_offset_hi << 16));
         mach->accel.ge_offset           = dev->accel.ge_offset;
 
         mach_log("HDISP=%d, VDISP=%d, shadowset=%x, 8514/A mode=%x, clocksel=%02x.\n", dev->hdisp, dev->vdisp, mach->shadow_set & 0x03, dev->accel.advfunc_cntl & 0x04, mach->accel.clock_sel & 0xfe);
-        if (!dev->bpp) {
-            if (dev->accel.advfunc_cntl & 0x01) {
+        if ((dev->local & 0xff) >= 0x02) {
+            if (dev->bpp || (dev->accel_bpp >= 24) || (mach->accel.clock_sel & 0x01)) {
+                dev->h_disp = dev->hdisp;
+                dev->dispend = dev->vdisp;
+            } else {
+                if (dev->interlace) { /*Interlaced displays are only for 800x600 and up.*/
+                    if (dev->accel.advfunc_cntl & 0x04) {
+                        dev->h_disp = dev->hdisp;
+                        dev->dispend = dev->vdisp;
+                    } else {
+                        dev->h_disp = 640;
+                        dev->dispend = 480;
+                    }
+                } else {
+                    dev->h_disp = dev->hdisp;
+                    dev->dispend = dev->vdisp;
+                }
+            }
+        } else {
+            if (mach->accel.clock_sel & 0x01) {
+                dev->h_disp = dev->hdisp;
+                dev->dispend = dev->vdisp;
+            } else {
                 if (dev->accel.advfunc_cntl & 0x04) {
                     dev->h_disp = dev->hdisp;
                     dev->dispend = dev->vdisp;
@@ -2585,13 +2609,7 @@ mach_recalctimings(svga_t *svga)
                     dev->h_disp = 640;
                     dev->dispend = 480;
                 }
-            } else {
-                dev->h_disp = dev->hdisp;
-                dev->dispend = dev->vdisp;
             }
-        } else {
-            dev->h_disp = dev->hdisp;
-            dev->dispend = dev->vdisp;
         }
 
         svga->clock8514 = (cpuclock * (double) (1ULL << 32)) / svga->getclock((mach->accel.clock_sel >> 2) & 0x0f, svga->clock_gen);
@@ -2614,9 +2632,7 @@ mach_recalctimings(svga_t *svga)
             dev->dispend += 2;
 
         if ((dev->local & 0xff) >= 0x02) {
-            mach_log("HDISP=%d.\n", dev->h_disp);
-            dev->pitch = dev->ext_pitch;
-            dev->rowoffset = dev->ext_crt_pitch;
+            mach_log("HDISP=%d, mask=%02x.\n", dev->h_disp, dev->dac_mask);
             if ((mach->accel.ext_ge_config & 0x800) || (!(mach->accel.ext_ge_config & 0x8000) && !(mach->accel.ext_ge_config & 0x800))) {
                 if ((mach->accel.ext_ge_config & 0x30) == 0x20) {
                     if ((mach->accel.ext_ge_config & 0xc0) == 0x40)
@@ -2628,9 +2644,20 @@ mach_recalctimings(svga_t *svga)
                         dev->accel_bpp = 32;
                     else
                         dev->accel_bpp = 24;
-                } else
+                } else if ((mach->accel.ext_ge_config & 0x30) == 0x10)
                     dev->accel_bpp = 8;
-
+                else {
+                    if (dev->vram_512k_8514) {
+                        if (dev->h_disp == 640) {
+                            dev->ext_pitch = 640;
+                            dev->pitch = dev->ext_pitch;
+                        } else {
+                            dev->ext_pitch = 1024;
+                            dev->pitch = dev->ext_pitch;
+                        }
+                    }
+                    dev->accel_bpp = 8;
+                }
                 mach_log("hv(%d,%d), pitch=%d, rowoffset=%d, gextconfig=%03x, bpp=%d, shadow=%x, vgahdisp=%d.\n", dev->h_disp, dev->dispend, dev->pitch, dev->ext_crt_pitch, mach->accel.ext_ge_config & 0xcec0, dev->accel_bpp, mach->shadow_set & 3, svga->hdisp);
                 switch (dev->accel_bpp) {
                     case 8:
@@ -2662,10 +2689,18 @@ mach_recalctimings(svga_t *svga)
                 }
             }
         } else {
-            dev->pitch = dev->ext_pitch;
-            dev->rowoffset = dev->ext_crt_pitch;
             mach_log("cntl=%d, hv(%d,%d), pitch=%d, rowoffset=%d, gextconfig=%03x, shadow=%x interlace=%d.\n", dev->accel.advfunc_cntl & 0x04, dev->h_disp, dev->dispend, dev->pitch, dev->rowoffset, mach->accel.ext_ge_config & 0xcec0, mach->shadow_set & 3, dev->interlace);
             svga->map8 = dev->pallook;
+            if (dev->vram_512k_8514) {
+                if (dev->h_disp == 640) {
+                    dev->ext_pitch = 640;
+                    dev->pitch = dev->ext_pitch;
+                } else {
+                    dev->ext_pitch = 1024;
+                    dev->pitch = dev->ext_pitch;
+                }
+            }
+            dev->accel_bpp = 8;
             svga->render8514 = ibm8514_render_8bpp;
         }
     }
@@ -2744,155 +2779,63 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
 
     switch (port) {
         case 0x82e8:
-        case 0x82e9:
         case 0x86e8:
         case 0x86e9:
         case 0xc2e8:
-        case 0xc2e9:
         case 0xc6e8:
-        case 0xc6e9:
             ibm8514_accel_out_fifo(svga, port, val, len);
             break;
         case 0xf6ee:
             ibm8514_accel_out_fifo(svga, 0x82e8, val, len);
             break;
-        case 0xf6ef:
-            ibm8514_accel_out_fifo(svga, 0x82e9, val, len);
-            break;
 
         case 0x8ae8:
         case 0xcae8:
             ibm8514_accel_out_fifo(svga, port, val, len);
-            if (len != 1)
-                mach->accel.src_y = val;
-            break;
-        case 0x8ae9:
-        case 0x8ee9:
-        case 0xcae9:
-        case 0xcee9:
-            ibm8514_accel_out_fifo(svga, port, val, len);
+            if (len == 2) {
+                mach_log("SRCY=%d.\n", val & 0x07ff);
+                mach->accel.src_y = val & 0x07ff;
+            }
             break;
 
         case 0x8ee8:
         case 0xcee8:
             ibm8514_accel_out_fifo(svga, port, val, len);
-            if (len != 1)
-                mach->accel.src_x = val;
+            if (len == 2) {
+                mach_log("SRCX=%d.\n", val & 0x07ff);
+                mach->accel.src_x = val & 0x07ff;
+            }
             break;
 
         case 0x92e8:
-        case 0x92e9:
-        case 0x96e9:
         case 0xd2e8:
-        case 0xd2e9:
-        case 0xd6e9:
             ibm8514_accel_out_fifo(svga, port, val, len);
             break;
 
         case 0x96e8:
         case 0xd6e8:
             ibm8514_accel_out_fifo(svga, port, val, len);
-            if (len != 1)
+            if (len == 2)
                 mach->accel.test = val & 0x1fff;
             break;
 
         case 0x9ae8:
         case 0xdae8:
-            dev->accel.ssv_state = 0;
-            if (len == 1)
-                dev->accel.cmd = (dev->accel.cmd & 0xff00) | val;
-            else {
-                dev->data_available  = 0;
-                dev->data_available2 = 0;
-                dev->accel.cmd       = val;
-                mach_log("CMD8514=%04x, len=%d, pixcntl=%02x.\n", val, len, dev->accel.multifunc[0x0a]);
-                mach->accel.cmd_type = -1;
-                if (port == 0xdae8) {
-                    if (dev->accel.cmd & 0x100)
-                        dev->accel.cmd_back = 0;
-                }
-                ibm8514_accel_start(-1, 0, -1, 0, svga, len);
-            }
-            break;
-        case 0x9ae9:
-        case 0xdae9:
-            if (len == 1) {
-                dev->data_available  = 0;
-                dev->data_available2 = 0;
-                dev->accel.cmd       = (dev->accel.cmd & 0xff) | (val << 8);
-                mach->accel.cmd_type = -1;
-                if (port == 0xdae9) {
-                    if (dev->accel.cmd & 0x100)
-                        dev->accel.cmd_back = 0;
-                }
-                ibm8514_accel_start(-1, 0, -1, 0, svga, len);
-            }
+            mach->accel.cmd_type = -1;
+            ibm8514_accel_out_fifo(svga, port, val, len);
             break;
 
         case 0x9ee8:
         case 0xdee8:
-            dev->accel.ssv_state = 1;
-            if (len == 1)
-                dev->accel.short_stroke = (dev->accel.short_stroke & 0xff00) | val;
-            else {
-                dev->accel.short_stroke = val;
-                dev->accel.cx           = dev->accel.cur_x;
-                dev->accel.cy           = dev->accel.cur_y;
-
-                if (dev->accel.cur_x >= 0x600)
-                    dev->accel.cx |= ~0x5ff;
-
-                if (dev->accel.cur_y >= 0x600)
-                    dev->accel.cy |= ~0x5ff;
-
-                if (dev->accel.cmd & 0x1000) {
-                    ibm8514_short_stroke_start(-1, 0, -1, 0, svga, dev->accel.short_stroke & 0xff, len);
-                    ibm8514_short_stroke_start(-1, 0, -1, 0, svga, dev->accel.short_stroke >> 8, len);
-                } else {
-                    ibm8514_short_stroke_start(-1, 0, -1, 0, svga, dev->accel.short_stroke >> 8, len);
-                    ibm8514_short_stroke_start(-1, 0, -1, 0, svga, dev->accel.short_stroke & 0xff, len);
-                }
-            }
-            break;
-        case 0x9ee9:
-        case 0xdee9:
-            if (len == 1) {
-                dev->accel.short_stroke = (dev->accel.short_stroke & 0xff) | (val << 8);
-                dev->accel.cx           = dev->accel.cur_x;
-                dev->accel.cy           = dev->accel.cur_y;
-
-                if (dev->accel.cur_x >= 0x600) {
-                    dev->accel.cx |= ~0x5ff;
-                }
-                if (dev->accel.cur_y >= 0x600) {
-                    dev->accel.cy |= ~0x5ff;
-                }
-
-                if (dev->accel.cmd & 0x1000) {
-                    ibm8514_short_stroke_start(-1, 0, -1, 0, svga, dev->accel.short_stroke & 0xff, len);
-                    ibm8514_short_stroke_start(-1, 0, -1, 0, svga, dev->accel.short_stroke >> 8, len);
-                } else {
-                    ibm8514_short_stroke_start(-1, 0, -1, 0, svga, dev->accel.short_stroke >> 8, len);
-                    ibm8514_short_stroke_start(-1, 0, -1, 0, svga, dev->accel.short_stroke & 0xff, len);
-                }
-            }
+            ibm8514_accel_out_fifo(svga, port, val, len);
             break;
 
         case 0xa2e8:
         case 0xe2e8:
             if (port == 0xe2e8) {
-                if (dev->accel.cmd_back) {
-                    if (len == 1)
-                        dev->accel.bkgd_color = (dev->accel.bkgd_color & 0x00ff) | val;
-                    else
+                if (len == 2) {
+                    if (dev->accel.cmd_back) {
                         dev->accel.bkgd_color = val;
-                } else {
-                    if (len == 1) {
-                        if (mach->accel.cmd_type >= 0) {
-                            if (mach_pixel_read(mach))
-                                break;
-                            mach->accel.pix_trans[1] = val;
-                        }
                     } else {
                         if (mach->accel.cmd_type >= 0) {
                             if (mach_pixel_read(mach))
@@ -2904,80 +2847,25 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                             ibm8514_accel_out_pixtrans(svga, port, val, len);
                         }
                     }
-                }
-            } else {
-                if (len == 1)
-                    dev->accel.bkgd_color = (dev->accel.bkgd_color & 0x00ff) | val;
-                else
-                    dev->accel.bkgd_color = val;
-            }
-            break;
-        case 0xa2e9:
-        case 0xe2e9:
-            if (port == 0xe2e9) {
-                if (dev->accel.cmd_back) {
-                    if (len == 1)
-                        dev->accel.bkgd_color = (dev->accel.bkgd_color & 0xff00) | (val << 8);
                 } else {
-                    if (len == 1) {
-                        if (mach->accel.cmd_type >= 0) {
-                            if (mach_pixel_read(mach))
-                                break;
-                            mach->accel.pix_trans[0] = val;
-                            frgd_sel                 = (mach->accel.dp_config >> 13) & 7;
-                            bkgd_sel                 = (mach->accel.dp_config >> 7) & 3;
-                            mono_src                 = (mach->accel.dp_config >> 5) & 3;
-
-                            switch (mach->accel.dp_config & 0x200) {
-                                case 0x000: /*8-bit size*/
-                                    if (mono_src == 2) {
-                                        if ((frgd_sel != 2) && (bkgd_sel != 2)) {
-                                            mach_accel_start(mach->accel.cmd_type, 1, 8, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), 0, mach, dev);
-                                        } else
-                                            mach_accel_start(mach->accel.cmd_type, 1, 1, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), mach, dev);
-                                    } else
-                                        mach_accel_start(mach->accel.cmd_type, 1, 1, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), mach, dev);
-                                    break;
-                                case 0x200: /*16-bit size*/
-                                    if (mono_src == 2) {
-                                        if ((frgd_sel != 2) && (bkgd_sel != 2)) {
-                                            if (mach->accel.dp_config & 0x1000)
-                                                mach_accel_start(mach->accel.cmd_type, 1, 16, mach->accel.pix_trans[1] | (mach->accel.pix_trans[0] << 8), 0, mach, dev);
-                                            else
-                                                mach_accel_start(mach->accel.cmd_type, 1, 16, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), 0, mach, dev);
-                                        } else
-                                            mach_accel_start(mach->accel.cmd_type, 1, 2, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), mach, dev);
-                                    } else
-                                        mach_accel_start(mach->accel.cmd_type, 1, 2, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), mach, dev);
-                                    break;
-
-                                default:
-                                    break;
-                            }
-                        }
+                    if (mach->accel.cmd_type >= 0) {
+                        if (mach_pixel_read(mach))
+                            break;
+                        mach->accel.pix_trans[1] = val;
                     }
                 }
             } else {
-                if (len == 1)
-                    dev->accel.bkgd_color = (dev->accel.bkgd_color & 0xff00) | (val << 8);
+                if (len == 2)
+                    dev->accel.bkgd_color = val;
             }
             break;
 
         case 0xa6e8:
         case 0xe6e8:
             if (port == 0xe6e8) {
-                if (dev->accel.cmd_back) {
-                    if (len == 1)
-                        dev->accel.frgd_color = (dev->accel.frgd_color & 0x00ff) | val;
-                    else
+                if (len == 2) {
+                    if (dev->accel.cmd_back) {
                         dev->accel.frgd_color = val;
-                } else {
-                    if (len == 1) {
-                        if (mach->accel.cmd_type >= 0) {
-                            if (mach_pixel_read(mach))
-                                break;
-                            mach->accel.pix_trans[1] = val;
-                        }
                     } else {
                         if (mach->accel.cmd_type >= 0) {
                             if (mach_pixel_read(mach))
@@ -2989,62 +2877,58 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                             ibm8514_accel_out_pixtrans(svga, port, val, len);
                         }
                     }
-                }
-            } else {
-                if (len == 1)
-                    dev->accel.frgd_color = (dev->accel.frgd_color & 0x00ff) | val;
-                else
-                    dev->accel.frgd_color = val;
-            }
-            break;
-        case 0xa6e9:
-        case 0xe6e9:
-            if (port == 0xe6e9) {
-                if (dev->accel.cmd_back) {
-                    if (len == 1)
-                        dev->accel.frgd_color = (dev->accel.frgd_color & 0xff00) | (val << 8);
                 } else {
-                    if (len == 1) {
-                        if (mach->accel.cmd_type >= 0) {
-                            if (mach_pixel_read(mach))
-                                break;
-                            mach->accel.pix_trans[0] = val;
-                            frgd_sel                 = (mach->accel.dp_config >> 13) & 7;
-                            bkgd_sel                 = (mach->accel.dp_config >> 7) & 3;
-                            mono_src                 = (mach->accel.dp_config >> 5) & 3;
-
-                            switch (mach->accel.dp_config & 0x200) {
-                                case 0x000: /*8-bit size*/
-                                    if (mono_src == 2) {
-                                        if ((frgd_sel != 2) && (bkgd_sel != 2)) {
-                                            mach_accel_start(mach->accel.cmd_type, 1, 8, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), 0, mach, dev);
-                                        } else
-                                            mach_accel_start(mach->accel.cmd_type, 1, 1, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), mach, dev);
-                                    } else
-                                        mach_accel_start(mach->accel.cmd_type, 1, 1, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), mach, dev);
-                                    break;
-                                case 0x200: /*16-bit size*/
-                                    if (mono_src == 2) {
-                                        if ((frgd_sel != 2) && (bkgd_sel != 2)) {
-                                            if (mach->accel.dp_config & 0x1000)
-                                                mach_accel_start(mach->accel.cmd_type, 1, 16, mach->accel.pix_trans[1] | (mach->accel.pix_trans[0] << 8), 0, mach, dev);
-                                            else
-                                                mach_accel_start(mach->accel.cmd_type, 1, 16, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), 0, mach, dev);
-                                        } else
-                                            mach_accel_start(mach->accel.cmd_type, 1, 2, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), mach, dev);
-                                    } else
-                                        mach_accel_start(mach->accel.cmd_type, 1, 2, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), mach, dev);
-                                    break;
-
-                                default:
-                                    break;
-                            }
-                        }
+                    if (mach->accel.cmd_type >= 0) {
+                        if (mach_pixel_read(mach))
+                            break;
+                        mach->accel.pix_trans[1] = val;
                     }
                 }
             } else {
-                if (len == 1)
-                    dev->accel.frgd_color = (dev->accel.frgd_color & 0xff00) | (val << 8);
+                if (len == 2)
+                    dev->accel.frgd_color = val;
+            }
+            break;
+
+        case 0xe2e9:
+        case 0xe6e9:
+            mach_log("Write PORT=%04x, 8514/A=%x, val=%04x, len=%d.\n", port, dev->accel.cmd_back, val, len);
+            if (len == 1) {
+                if (mach->accel.cmd_type >= 0) {
+                    if (mach_pixel_read(mach))
+                        break;
+                    mach->accel.pix_trans[0] = val;
+                    frgd_sel = (mach->accel.dp_config >> 13) & 7;
+                    bkgd_sel = (mach->accel.dp_config >> 7) & 3;
+                    mono_src = (mach->accel.dp_config >> 5) & 3;
+
+                    switch (mach->accel.dp_config & 0x200) {
+                        case 0x000: /*8-bit size*/
+                            if (mono_src == 2) {
+                                if ((frgd_sel != 2) && (bkgd_sel != 2)) {
+                                    mach_accel_start(mach->accel.cmd_type, 1, 8, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), 0, mach, dev);
+                                } else
+                                    mach_accel_start(mach->accel.cmd_type, 1, 1, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), mach, dev);
+                            } else
+                                mach_accel_start(mach->accel.cmd_type, 1, 1, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), mach, dev);
+                            break;
+                        case 0x200: /*16-bit size*/
+                            if (mono_src == 2) {
+                                if ((frgd_sel != 2) && (bkgd_sel != 2)) {
+                                    if (mach->accel.dp_config & 0x1000)
+                                        mach_accel_start(mach->accel.cmd_type, 1, 16, mach->accel.pix_trans[1] | (mach->accel.pix_trans[0] << 8), 0, mach, dev);
+                                    else
+                                        mach_accel_start(mach->accel.cmd_type, 1, 16, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), 0, mach, dev);
+                                } else
+                                    mach_accel_start(mach->accel.cmd_type, 1, 2, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), mach, dev);
+                            } else
+                                mach_accel_start(mach->accel.cmd_type, 1, 2, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), mach, dev);
+                            break;
+
+                        default:
+                            break;
+                    }
+                }
             }
             break;
 
@@ -3069,118 +2953,47 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
 
         case 0xbee8:
         case 0xfee8:
-            if (len == 1)
-                dev->accel.multifunc_cntl = (dev->accel.multifunc_cntl & 0xff00) | val;
-            else {
-                dev->accel.multifunc_cntl                             = val;
-                dev->accel.multifunc[dev->accel.multifunc_cntl >> 12] = dev->accel.multifunc_cntl & 0xfff;
-                if ((dev->accel.multifunc_cntl >> 12) == 1)
-                    dev->accel.clip_top = val & 0x7ff;
-
-                if ((dev->accel.multifunc_cntl >> 12) == 2)
-                    dev->accel.clip_left = val & 0x7ff;
-
-                if ((dev->accel.multifunc_cntl >> 12) == 3)
-                    dev->accel.multifunc[3] = val & 0x7ff;
-
-                if ((dev->accel.multifunc_cntl >> 12) == 4)
-                    dev->accel.multifunc[4] = val & 0x7ff;
-
-                mach_log("CLIPBOTTOM=%d, CLIPRIGHT=%d, bpp=%d, pitch=%d.\n", dev->accel.multifunc[3], dev->accel.multifunc[4], dev->accel_bpp, dev->pitch);
+            ibm8514_accel_out_fifo(svga, port, val, len);
+            if (len == 2) {
                 if ((dev->accel.multifunc_cntl >> 12) == 5) {
                     if ((dev->local & 0xff) < 0x02)
                         dev->ext_crt_pitch = 128;
                 }
-                if (port == 0xfee8)
-                    dev->accel.cmd_back = 1;
-                else
-                    dev->accel.cmd_back = 0;
-            }
-            break;
-        case 0xbee9:
-        case 0xfee9:
-            if (len == 1) {
-                dev->accel.multifunc_cntl                             = (dev->accel.multifunc_cntl & 0xff) | (val << 8);
-                dev->accel.multifunc[dev->accel.multifunc_cntl >> 12] = dev->accel.multifunc_cntl & 0xfff;
-                if ((dev->accel.multifunc_cntl >> 12) == 1)
-                    dev->accel.clip_top = dev->accel.multifunc_cntl & 0x7ff;
-
-                if ((dev->accel.multifunc_cntl >> 12) == 2)
-                    dev->accel.clip_left = dev->accel.multifunc_cntl & 0x7ff;
-
-                if ((dev->accel.multifunc_cntl >> 12) == 5) {
-                    if ((dev->local & 0xff) < 0x02)
-                        dev->ext_crt_pitch = 128;
-                }
-                if (port == 0xfee9)
-                    dev->accel.cmd_back = 1;
-                else
-                    dev->accel.cmd_back = 0;
             }
             break;
 
             /*ATI Mach8/32 specific registers*/
         case 0x82ee:
-            mach->accel.patt_data_idx = val & 0x1f;
-            mach_log("Pattern Data Index = %d.\n", val & 0x1f);
+            mach->accel.patt_data_idx_reg = val & 0x1f;
+            mach->accel.patt_data_idx = mach->accel.patt_data_idx_reg;
+
+            if (mach->accel.patt_data_idx_reg < 0x10)
+                mach->accel.color_pattern_idx = mach->accel.patt_idx;
+            else
+                mach->accel.color_pattern_idx = 0;
+
+            mach_log("Write Port 82ee: Pattern Data Index=%d.\n", val & 0x1f);
             break;
 
         case 0x8eee:
-            if (len == 1)
-                mach->accel.patt_data[mach->accel.patt_data_idx] = val;
-            else {
-                mach->accel.patt_data[mach->accel.patt_data_idx]     = val & 0xff;
-                mach->accel.patt_data[mach->accel.patt_data_idx + 1] = (val >> 8) & 0xff;
-                if (mach->accel.mono_pattern_enable)
-                    mach->accel.patt_data_idx = (mach->accel.patt_data_idx + 2) & 0x17;
-                else {
-                    frgd_sel = (mach->accel.dp_config >> 13) & 7;
-                    mono_src = (mach->accel.dp_config >> 5) & 3;
-                    if ((dev->accel_bpp == 24) && (mach->accel.patt_len == 0x17) && (frgd_sel == 5)) {
-                        mach->accel.patt_data_idx += 2;
-                        dev->accel.y1 = 1;
-                    } else {
-                        if (dev->accel_bpp == 24)
-                            mach->accel.patt_data_idx += 2;
-                        else
-                            mach->accel.patt_data_idx = (mach->accel.patt_data_idx + 2) & mach->accel.patt_len;
-                    }
-                    mach_log("ExtCONFIG = %04x, Pattern Mono = %04x, selidx = %d, dataidx = %d, bit 0 = %02x len = %d.\n", mach->accel.ext_ge_config, val, mach->accel.patt_idx, mach->accel.patt_data_idx, val & 1, mach->accel.patt_len);
+            if (len == 2) {
+                if (mach->accel.patt_data_idx_reg < 0x10) {
+                    mach->accel.color_pattern[mach->accel.patt_data_idx] = val & 0xff;
+                    mach->accel.color_pattern[mach->accel.patt_data_idx + 1] = (val >> 8) & 0xff;
+                    mach_log("Write Port 8eee: Color Pattern Word Data[%d]=%04x.\n", mach->accel.patt_data_idx, val);
+                } else {
+                    mach->accel.mono_pattern_normal[mach->accel.patt_data_idx - 0x10] = val & 0xff;
+                    mach->accel.mono_pattern_normal[(mach->accel.patt_data_idx + 1) - 0x10] = (val >> 8) & 0xff;
+                    mach_log("Write Port 8eee: Mono Pattern Word Data[%d]=%04x.\n", mach->accel.patt_data_idx - 0x10, val);
                 }
-            }
-            break;
-        case 0x8eef:
-            if (len == 1) {
-                mach->accel.patt_data[mach->accel.patt_data_idx + 1] = val;
-                if (mach->accel.mono_pattern_enable)
-                    mach->accel.patt_data_idx = (mach->accel.patt_data_idx + 2) & 7;
-                else {
-                    frgd_sel = (mach->accel.dp_config >> 13) & 7;
-                    if ((dev->accel_bpp == 24) && (mach->accel.patt_len == 0x17) && (frgd_sel == 5)) {
-                        mach->accel.patt_data_idx += 2;
-                        dev->accel.y1 = 1;
-                    } else
-                        mach->accel.patt_data_idx = (mach->accel.patt_data_idx + 2) & mach->accel.patt_len;
-                }
+                mach->accel.patt_data_idx += 2;
             }
             break;
 
         case 0x96ee:
-            if (len == 1)
-                mach->accel.bres_count = (mach->accel.bres_count & 0x700) | val;
-            else {
+            if (len == 2) {
                 mach->accel.bres_count = val & 0x7ff;
-                mach_log("BresenhamDraw = %04x.\n", mach->accel.dp_config);
-                dev->data_available  = 0;
-                dev->data_available2 = 0;
-                mach->accel.cmd_type = 1;
-                mach_accel_start(mach->accel.cmd_type, 0, -1, -1, 0, mach, dev);
-            }
-            break;
-        case 0x96ef:
-            if (len == 1) {
-                mach->accel.bres_count = (mach->accel.bres_count & 0xff) | ((val & 0x07) << 8);
-                mach_log("96EE (2) line draw.\n");
+                mach_log("BresenhamDraw=%04x.\n", mach->accel.dp_config);
                 dev->data_available  = 0;
                 dev->data_available2 = 0;
                 mach->accel.cmd_type = 1;
@@ -3193,15 +3006,13 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             break;
 
         case 0xa2ee:
-            mach_log("Line OPT = %04x\n", val);
-            if (len == 1)
-                mach->accel.linedraw_opt = (mach->accel.linedraw_opt & 0xff00) | val;
-            else {
+            mach_log("Line OPT=%04x.\n", val);
+            if (len == 2) {
                 mach->accel.linedraw_opt = val;
-                mach->accel.bbottom = dev->accel.multifunc[3] & 0x7ff;
-                mach->accel.btop = dev->accel.clip_top & 0x7ff;
-                mach->accel.bleft = dev->accel.clip_left & 0x7ff;
-                mach->accel.bright = dev->accel.multifunc[4] & 0x7ff;
+                mach->accel.bbottom = dev->accel.multifunc[3];
+                mach->accel.btop = dev->accel.multifunc[1];
+                mach->accel.bleft = dev->accel.multifunc[2];
+                mach->accel.bright = dev->accel.multifunc[4];
                 if (mach->accel.linedraw_opt & 0x100) {
                     mach->accel.bbottom = 2047;
                     mach->accel.btop = 0;
@@ -3210,87 +3021,49 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                 }
             }
             break;
-        case 0xa2ef:
-            if (len == 1)
-                mach->accel.linedraw_opt = (mach->accel.linedraw_opt & 0x00ff) | (val << 8);
-            break;
 
         case 0xa6ee:
-            if (len == 1)
-                mach->accel.dest_x_start = (mach->accel.dest_x_start & 0x700) | val;
-            else
+            if (len == 2)
                 mach->accel.dest_x_start = val & 0x7ff;
-            break;
-        case 0xa6ef:
-            if (len == 1)
-                mach->accel.dest_x_start = (mach->accel.dest_x_start & 0x0ff) | ((val & 0x07) << 8);
             break;
 
         case 0xaaee:
-            if (len == 1)
-                mach->accel.dest_x_end = (mach->accel.dest_x_end & 0x700) | val;
-            else
+            if (len == 2)
                 mach->accel.dest_x_end = val & 0x7ff;
-            break;
-        case 0xaaef:
-            if (len == 1)
-                mach->accel.dest_x_end = (mach->accel.dest_x_end & 0x0ff) | ((val & 0x07) << 8);
             break;
 
         case 0xaeee:
-            if (len == 1)
-                mach->accel.dest_y_end = (mach->accel.dest_y_end & 0x700) | val;
-            else {
+            if (len == 2) {
                 mach->accel.dest_y_end = val & 0x7ff;
                 if ((val + 1) == 0x10000) {
-                    mach_log("Dest_Y_end overflow val = %04x\n", val);
+                    mach_log("Dest_Y_end overflow val=%04x, DPCONFIG=%04x\n", val, mach->accel.dp_config);
                     mach->accel.dest_y_end = 0;
                 }
                 dev->data_available  = 0;
                 dev->data_available2 = 0;
-                mach_log("BitBLT = %04x.\n", mach->accel.dp_config);
+                mach_log("BitBLT=%04x.\n", mach->accel.dp_config);
+                mach_log(".\n");
                 mach->accel.cmd_type = 2; /*Non-conforming BitBLT from dest_y_end register (0xaeee)*/
-                mach_accel_start(mach->accel.cmd_type, 0, -1, -1, 0, mach, dev);
-            }
-            break;
-        case 0xaeef:
-            if (len == 1) {
-                mach->accel.dest_y_end = (mach->accel.dest_y_end & 0x0ff) | ((val & 0x07) << 8);
-                dev->data_available    = 0;
-                dev->data_available2   = 0;
-                mach->accel.cmd_type   = 2; /*Non-conforming BitBLT from dest_y_end register (0xaeee)*/
                 mach_accel_start(mach->accel.cmd_type, 0, -1, -1, 0, mach, dev);
             }
             break;
 
         case 0xb2ee:
-            if (len == 1)
-                mach->accel.src_x_start = (mach->accel.src_x_start & 0x700) | val;
-            else
+            if (len == 2)
                 mach->accel.src_x_start = val & 0x7ff;
-            break;
-        case 0xb2ef:
-            if (len == 1)
-                mach->accel.src_x_start = (mach->accel.src_x_start & 0x0ff) | ((val & 0x07) << 8);
             break;
 
         case 0xb6ee:
-            dev->accel.bkgd_mix = val & 0xff;
+            ibm8514_accel_out_fifo(svga, 0xb6e8, val, len);
             break;
 
         case 0xbaee:
-            dev->accel.frgd_mix = val & 0xff;
+            ibm8514_accel_out_fifo(svga, 0xbae8, val, len);
             break;
 
         case 0xbeee:
-            if (len == 1)
-                mach->accel.src_x_end = (mach->accel.src_x_end & 0x700) | val;
-            else
+            if (len == 2)
                 mach->accel.src_x_end = val & 0x7ff;
-            break;
-        case 0xbeef:
-            if (len == 1)
-                mach->accel.src_x_end = (mach->accel.src_x_end & 0x0ff) | ((val & 0x07) << 8);
             break;
 
         case 0xc2ee:
@@ -3303,9 +3076,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             break;
 
         case 0xcaee:
-            if (len == 1)
-                mach->accel.scan_to_x = (mach->accel.scan_to_x & 0x700) | val;
-            else {
+            if (len == 2) {
                 mach->accel.scan_to_x = (val & 0x7ff);
                 if ((val + 1) == 0x10000) {
                     mach_log("Scan_to_X overflow val = %04x\n", val);
@@ -3314,128 +3085,74 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                 dev->data_available  = 0;
                 dev->data_available2 = 0;
                 mach->accel.cmd_type = 5; /*Horizontal Raster Draw from scan_to_x register (0xcaee)*/
-                mach_log("ScanToX = %04x.\n", mach->accel.dp_config);
-                mach_accel_start(mach->accel.cmd_type, 0, -1, -1, 0, mach, dev);
-            }
-            break;
-        case 0xcaef:
-            if (len == 1) {
-                mach->accel.scan_to_x = (mach->accel.scan_to_x & 0x0ff) | ((val & 0x07) << 8);
-                dev->data_available   = 0;
-                dev->data_available2  = 0;
-                mach->accel.cmd_type  = 5; /*Horizontal Raster Draw from scan_to_x register (0xcaee)*/
+                mach_log("ScanToX=%04x.\n", mach->accel.dp_config);
+                mach_log(".\n");
                 mach_accel_start(mach->accel.cmd_type, 0, -1, -1, 0, mach, dev);
             }
             break;
 
         case 0xceee:
             mach_log("CEEE write val = %04x.\n", val);
-            if (len == 1)
-                mach->accel.dp_config = (mach->accel.dp_config & 0xff00) | val;
-            else {
+            if (len == 2) {
                 dev->data_available  = 0;
                 dev->data_available2 = 0;
                 mach->accel.dp_config = val;
             }
             break;
-        case 0xceef:
-            if (len == 1)
-                mach->accel.dp_config = (mach->accel.dp_config & 0x00ff) | (val << 8);
-            break;
 
         case 0xd2ee:
             mach->accel.patt_len = val & 0x1f;
-            mach_log("Pattern Length = %d, val = %04x.\n", val & 0x1f, val);
+            mach_log("Write Port d2ee: Pattern Length=%d, val=%04x.\n", val & 0x1f, val);
             mach->accel.mono_pattern_enable = !!(val & 0x80);
-            if (len != 1)
+            if (len == 2) {
+                mach->accel.block_write_mono_pattern_enable = !!(val & 0x8000);
                 mach->accel.patt_len_reg = val;
-            else
-                mach->accel.patt_len_reg = (mach->accel.patt_len_reg & 0xff00) | val;
-            break;
-        case 0xd2ef:
-            if (len == 1)
-                mach->accel.patt_len_reg = (mach->accel.patt_len_reg & 0x00ff) | (val << 8);
+            }
             break;
 
         case 0xd6ee:
             mach->accel.patt_idx = val & 0x1f;
-            mach_log("Pattern Index = %d, val = %02x.\n", val & 0x1f, val);
+            mach_log("Write Port d6ee: Pattern Index=%d.\n", val & 0x1f);
             break;
 
         case 0xdaee:
             mach_log("DAEE (extclipl) write val = %d\n", val);
-            if (len == 1)
-                dev->accel.clip_left = (dev->accel.clip_left & 0x700) | val;
-            else
-                dev->accel.clip_left = val & 0x7ff;
-            break;
-        case 0xdaef:
-            if (len == 1)
-                dev->accel.clip_left = (dev->accel.clip_left & 0x0ff) | ((val & 0x07) << 8);
+            if (len == 2)
+                dev->accel.multifunc[2] = val & 0x7ff;
             break;
 
         case 0xdeee:
             mach_log("DEEE (extclipt) write val = %d\n", val);
-            if (len == 1)
-                dev->accel.clip_top = (dev->accel.clip_top & 0x700) | val;
-            else
-                dev->accel.clip_top = val & 0x7ff;
-            break;
-        case 0xdeef:
-            if (len == 1)
-                dev->accel.clip_top = (dev->accel.clip_top & 0x0ff) | ((val & 0x07) << 8);
+            if (len == 2)
+                dev->accel.multifunc[1] = val & 0x7ff;
             break;
 
         case 0xe2ee:
             mach_log("E2EE (extclipr) write val = %d\n", val);
-            if (len == 1)
-                dev->accel.multifunc[4] = (dev->accel.multifunc[4] & 0x700) | val;
-            else
+            if (len == 2)
                 dev->accel.multifunc[4] = val & 0x7ff;
-            break;
-        case 0xe2ef:
-            if (len == 1)
-                dev->accel.multifunc[4] = (dev->accel.multifunc[4] & 0x0ff) | ((val & 0x07) << 8);
             break;
 
         case 0xe6ee:
             mach_log("E6EE (extclipb) write val = %d\n", val);
-            if (len == 1)
-                dev->accel.multifunc[3] = (dev->accel.multifunc[3] & 0x700) | val;
-            else
+            if (len == 2)
                 dev->accel.multifunc[3] = val & 0x7ff;
-            break;
-        case 0xe6ef:
-            if (len == 1)
-                dev->accel.multifunc[3] = (dev->accel.multifunc[3] & 0x0ff) | ((val & 0x07) << 8);
             break;
 
         case 0xeeee:
-            if (len == 1)
-                mach->accel.dest_cmp_fn = (mach->accel.dest_cmp_fn & 0xff00) | val;
-            else
+            if (len == 2)
                 mach->accel.dest_cmp_fn = val;
-            break;
-        case 0xeeef:
-            if (len == 1)
-                mach->accel.dest_cmp_fn = (mach->accel.dest_cmp_fn & 0x00ff) | (val << 8);
             break;
 
         case 0xf2ee:
             mach_log("F2EE.\n");
-            if (len == 1)
-                mach->accel.dst_clr_cmp_mask = (mach->accel.dst_clr_cmp_mask & 0xff00) | val;
-            else
+            if (len == 2)
                 mach->accel.dst_clr_cmp_mask = val;
-            break;
-        case 0xf2ef:
-            if (len == 1)
-                mach->accel.dst_clr_cmp_mask = (mach->accel.dst_clr_cmp_mask & 0x00ff) | (val << 8);
             break;
 
         case 0xfeee:
-            mach_log("LineDraw = %04x.\n", mach->accel.dp_config);
-            if (len != 1) {
+            mach_log("LineDraw=%04x.\n", mach->accel.dp_config);
+            if (len == 2) {
                 mach->accel.line_array[mach->accel.line_idx] = val;
                 dev->accel.cur_x                             = mach->accel.line_array[(mach->accel.line_idx == 4) ? 4 : 0];
                 dev->accel.cur_y                             = mach->accel.line_array[(mach->accel.line_idx == 5) ? 5 : 1];
@@ -3459,7 +3176,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
 static void
 mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8514_t *dev)
 {
-    if (port != 0x7aee && port != 0x7aef && port != 0x42e8 && port != 0x42e9)
+    if (port != 0x42e8 && port != 0x42e9)
         mach_log("[%04X:%08X]: Port CALL OUT=%04x, val=%02x.\n", CS, cpu_state.pc, port, val);
 
     switch (port) {
@@ -3467,10 +3184,6 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
         case 0x6e9:
         case 0xae8:
         case 0xee8:
-        case 0x12e8:
-        case 0x12e9:
-        case 0x1ae8:
-        case 0x1ae9:
         case 0x1ee8:
         case 0x1ee9:
         case 0x22e8:
@@ -3481,9 +3194,27 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
 
         case 0x6e8:
             /*In preparation to switch from VGA to 8514/A mode*/
-            if (!dev->on[0] || !dev->on[1] || (mach->accel.clock_sel & 0x01)) {
-                dev->hdisped = val;
-                dev->hdisp = (dev->hdisped + 1) << 3;
+            if (!(mach->shadow_cntl & 0x08)) {
+                if ((mach->shadow_set & 0x03) || (mach->accel.clock_sel & 0x01)) {
+                    dev->hdisped = val;
+                    dev->hdisp = (dev->hdisped + 1) << 3;
+                }
+            }
+            mach_log("[%04X:%08X]: ATI 8514/A: (0x%04x): hdisp=0x%02x.\n", CS, cpu_state.pc, port, val);
+            svga_recalctimings(svga);
+            break;
+
+        case 0x12e8:
+        case 0x12e9:
+            /*In preparation to switch from VGA to 8514/A mode*/
+            if (!(mach->shadow_cntl & 0x10)) {
+                if ((mach->shadow_set & 0x03) || (mach->accel.clock_sel & 0x01)) {
+                    WRITE8(port, dev->v_total_reg, val);
+                    dev->v_total_reg &= 0x1fff;
+                    dev->v_total = dev->v_total_reg + 1;
+                    if (dev->interlace)
+                        dev->v_total >>= 1;
+                }
             }
             mach_log("[%04X:%08X]: ATI 8514/A: (0x%04x): hdisp=0x%02x.\n", CS, cpu_state.pc, port, val);
             svga_recalctimings(svga);
@@ -3492,29 +3223,46 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
         case 0x16e8:
         case 0x16e9:
             /*In preparation to switch from VGA to 8514/A mode*/
-            if (!dev->on[0] || !dev->on[1] || (mach->accel.clock_sel & 0x01)) {
-                WRITE8(port, dev->v_disp, val);
-                dev->v_disp &= 0x1fff;
-                dev->vdisp = (dev->v_disp + 1) >> 1;
+            if (!(mach->shadow_cntl & 0x20)) {
+                if ((mach->shadow_set & 0x03) || (mach->accel.clock_sel & 0x01)) {
+                    WRITE8(port, dev->v_disp, val);
+                    dev->v_disp &= 0x1fff;
+                    dev->vdisp = (dev->v_disp + 1) >> 1;
+                }
             }
             mach_log("ATI 8514/A: V_DISP write 16E8 = %d\n", dev->v_disp);
             mach_log("ATI 8514/A: (0x%04x): vdisp=0x%02x.\n", port, val);
             svga_recalctimings(svga);
             break;
 
+        case 0x1ae8:
+        case 0x1ae9:
+            /*In preparation to switch from VGA to 8514/A mode*/
+            if (!(mach->shadow_cntl & 0x10)) {
+                if ((mach->shadow_set & 0x03) || (mach->accel.clock_sel & 0x01)) {
+                    WRITE8(port, dev->v_sync_start, val);
+                    dev->v_sync_start &= 0x1fff;
+                    dev->v_syncstart = dev->v_sync_start + 1;
+                    if (dev->interlace)
+                        dev->v_syncstart >>= 1;
+                }
+            }
+            mach_log("ATI 8514/A: V_SYNCSTART write 1AE8 = %d\n", dev->v_syncstart);
+            mach_log("ATI 8514/A: (0x%04x): vsyncstart=0x%02x.\n", port, val);
+            svga_recalctimings(svga);
+            break;
+
         case 0x4ae8:
-        case 0x4ae9:
             WRITE8(port, dev->accel.advfunc_cntl, val);
-            dev->on[port & 1] = dev->accel.advfunc_cntl & 0x01;
+            dev->on = dev->accel.advfunc_cntl & 0x01;
+            vga_on = !dev->on;
+
             if ((dev->local & 0xff) < 0x02)
                 dev->ext_crt_pitch = 128;
 
-            vga_on = !dev->on[port & 1];
-            mach->ext_on[port & 1] = dev->on[port & 1];
-            mach32_updatemapping(mach, svga);
-            dev->vendor_mode[port & 1] = 0;
-            mach_log("[%04X:%08X]: ATI 8514/A: (0x%04x): ON=%d, shadow crt=%x, hdisp=%d, vdisp=%d.\n", CS, cpu_state.pc, port, dev->on[port & 1], dev->accel.advfunc_cntl & 0x04, dev->hdisp, dev->vdisp);
-            mach_log("IBM mode set %s resolution.\n", (dev->accel.advfunc_cntl & 0x04) ? "2: 1024x768" : "1: 640x480");
+            mach_log("[%04X:%08X]: ATI 8514/A: (0x%04x): ON=%d, shadow crt=%x, hdisp=%d, vdisp=%d.\n", CS, cpu_state.pc, port, val & 0x01, dev->accel.advfunc_cntl & 0x04, dev->hdisp, dev->vdisp);
+            mach_log("Vendor IBM mode set %s resolution.\n", (dev->accel.advfunc_cntl & 0x04) ? "2: 1024x768" : "1: 640x480");
+
             svga_recalctimings(svga);
             break;
 
@@ -3546,6 +3294,7 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
             mach->cursor_offset_hi = mach->cursor_offset_hi_reg & 0x0f;
             dev->hwcursor.addr = ((mach->cursor_offset_lo | (mach->cursor_offset_hi << 16)) << 2);
             dev->hwcursor.ena = !!(mach->cursor_offset_hi_reg & 0x8000);
+            mach_log("HWCursorEnabled=%x.\n", dev->hwcursor.ena);
             break;
 
         case 0x12ee:
@@ -3593,6 +3342,8 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
                 else
                     dev->ext_crt_pitch <<= 1;
             }
+            dev->on = 1;
+            vga_on = 0;
             mach_log("ATI 8514/A: (0x%04x) val=0x%02x.\n", port, val);
             svga_recalctimings(svga);
             break;
@@ -3634,18 +3385,20 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
         case 0x46ef:
             WRITE8(port, mach->shadow_cntl, val);
             mach_log("ATI 8514/A: (0x%04x) val=%02x.\n", port, val);
+            mach32_updatemapping(mach, svga);
             break;
 
         case 0x4aee:
         case 0x4aef:
             WRITE8(port, mach->accel.clock_sel, val);
-            dev->on[port & 1] = mach->accel.clock_sel & 0x01;
-            mach_log("ATI 8514/A: (0x%04x): ON=%d, val=%04x, hdisp=%d, vdisp=%d, val=0x%02x.\n", port, dev->on[port & 1], val, dev->hdisp, dev->vdisp, val & 0xfe);
-            mach_log("ATI mode set %s resolution.\n", (dev->accel.advfunc_cntl & 0x04) ? "2: 1024x768" : "1: 640x480");
-            mach->ext_on[port & 1] = dev->on[port & 1];
-            vga_on = !dev->on[port & 1];
-            dev->vendor_mode[port & 1] = 1;
+            dev->on = mach->accel.clock_sel & 0x01;
+            mach_log("ATI 8514/A: (0x%04x): ON=%d, val=%04x, hdisp=%d, vdisp=%d, val=0x%02x.\n", port, dev->on, val, dev->hdisp, dev->vdisp, val & 0xfe);
+            if (!(port & 1))
+                mach_log("Vendor ATI mode set %s resolution.\n", (dev->accel.advfunc_cntl & 0x04) ? "2: 1024x768" : "1: 640x480");
+
+            vga_on = !dev->on;
             svga_recalctimings(svga);
+            mach32_updatemapping(mach, svga);
             break;
 
         case 0x52ee:
@@ -3670,6 +3423,8 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
                 mach_log("CRT Shadow Set 1: 640x480.\n");
             else if ((mach->shadow_set & 0x03) == 0x02)
                 mach_log("CRT Shadow Set 2: 1024x768.\n");
+
+            mach32_updatemapping(mach, svga);
             break;
 
         case 0x5eee:
@@ -3693,19 +3448,29 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
         case 0x6aee:
         case 0x6aef:
             WRITE8(port, mach->accel.max_waitstates, val);
+            mach->override_resolution = !!(mach->accel.max_waitstates & 0x400);
+            if (mach->override_resolution) {
+                dev->on = 1;
+                vga_on = !dev->on;
+                svga_recalctimings(svga);
+                mach32_updatemapping(mach, svga);
+            }
             break;
 
         case 0x6eee:
         case 0x6eef:
             WRITE8(port, mach->accel.ge_offset_lo, val);
             svga_recalctimings(svga);
+            mach_log("ATI 8514/A: (0x%04x) val=0x%02x, geoffset=%04x.\n", port, val, dev->accel.ge_offset);
+            mach32_updatemapping(mach, svga);
             break;
 
         case 0x72ee:
         case 0x72ef:
             WRITE8(port, mach->accel.ge_offset_hi, val);
-            mach_log("ATI 8514/A: (0x%04x) val=0x%02x, geoffset=%04x.\n", port, val, dev->accel.ge_offset);
             svga_recalctimings(svga);
+            mach_log("ATI 8514/A: (0x%04x) val=0x%02x, geoffset=%04x.\n", port, val, dev->accel.ge_offset);
+            mach32_updatemapping(mach, svga);
             break;
 
         case 0x76ee:
@@ -3714,6 +3479,7 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
             dev->ext_pitch = ((mach->accel.ge_pitch & 0xff) << 3);
             mach_log("ATI 8514/A: (0x%04x) val=0x%02x, extpitch=%d.\n", port, val, dev->ext_pitch);
             svga_recalctimings(svga);
+            mach32_updatemapping(mach, svga);
             break;
 
         case 0x7aee:
@@ -3722,8 +3488,9 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
             if ((dev->local & 0xff) >= 0x02) {
                 if (mach->accel.crt_pitch & 0xff)
                     dev->ext_crt_pitch = mach->accel.crt_pitch & 0xff;
+
                 switch (mach->accel.ext_ge_config & 0x30) {
-                    case 0:
+                    case 0x00:
                     case 0x10:
                         dev->bpp = 0;
                         break;
@@ -3743,11 +3510,11 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
                         break;
                 }
                 svga_set_ramdac_type(svga, !!(mach->accel.ext_ge_config & 0x4000));
-                dev->vendor_mode[port & 1] = 1;
-                mach32_updatemapping(mach, svga);
                 mach_log("ATI 8514/A: (0x%04x) val=%02x.\n", port, val);
                 svga_recalctimings(svga);
+                mach32_updatemapping(mach, svga);
             } else {
+                mach_log("ATI 8514/A: (0x%04x) val=%02x.\n", port, val & 0x30);
                 ati_eeprom_write(&mach->eeprom, !!(mach->accel.ext_ge_config & 0x4040), !!(mach->accel.ext_ge_config & 0x2020), !!(mach->accel.ext_ge_config & 0x1010));
             }
             break;
@@ -3796,9 +3563,10 @@ mach_accel_in_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, in
 
         case 0x9ae8:
         case 0xdae8:
-            if (len != 1) {
+            if (len == 2) {
                 if (dev->force_busy)
                     temp |= 0x200; /*Hardware busy*/
+
                 dev->force_busy = 0;
                 if (dev->data_available) {
                     temp |= 0x100; /*Read Data available*/
@@ -3829,10 +3597,11 @@ mach_accel_in_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, in
         case 0xdae9:
             if (len == 1) {
                 if (dev->force_busy2)
-                    temp |= 2; /*Hardware busy*/
+                    temp |= 0x02; /*Hardware busy*/
+
                 dev->force_busy2 = 0;
                 if (dev->data_available2) {
-                    temp |= 1; /*Read Data available*/
+                    temp |= 0x01; /*Read Data available*/
                     if (mach->accel.cmd_type >= 0) {
                         switch (mach->accel.cmd_type) {
                             case 2:
@@ -3877,18 +3646,23 @@ mach_accel_in_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, in
             } else {
                 if (ibm8514_cpu_dest(svga)) {
                     cmd = (dev->accel.cmd >> 13);
-                    if (len != 1) {
+                    if (len == 2) {
                         READ_PIXTRANS_WORD(dev->accel.cx, 0)
-                        if (dev->accel.input && !dev->accel.odd_in && !dev->accel.sx) {
-                            temp &= ~0xff00;
-                            temp |= (dev->vram[(dev->accel.newdest_in + dev->accel.cur_x) & dev->vram_mask] << 8);
-                        }
-                        if (dev->subsys_stat & 1) {
+                        if (dev->subsys_stat & 0x01) {
                             dev->force_busy = 1;
                             dev->data_available = 1;
                         }
+                        if (dev->accel.input) {
+                            ibm8514_accel_out_pixtrans(svga, port, temp & 0xff, len);
+                            if (dev->accel.odd_in) { /*WORDs on odd destination scan lengths.*/
+                                dev->accel.odd_in = 0;
+                                temp &= ~0xff00;
+                                READ_HIGH(dev->accel.dest + dev->accel.cx, temp);
+                            }
+                            ibm8514_accel_out_pixtrans(svga, port, (temp >> 8) & 0xff, len);
+                        } else
+                            ibm8514_accel_out_pixtrans(svga, port, temp, len);
                     }
-                    ibm8514_accel_out_pixtrans(svga, port, temp, len);
                 }
             }
             break;
@@ -3937,47 +3711,9 @@ mach_accel_in_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, in
             }
             break;
 
-        case 0xbee8:
-        case 0xfee8:
-            if (len != 1) {
-                mach_log("Multifunc_cntl = %d.\n", dev->accel.multifunc_cntl >> 12);
-                switch ((dev->accel.multifunc_cntl >> 12) & 0x0f) {
-                    case 0:
-                        temp = dev->accel.multifunc[0];
-                        break;
-                    case 1:
-                        temp = dev->accel.clip_top;
-                        break;
-                    case 2:
-                        temp = dev->accel.clip_left;
-                        break;
-                    case 3:
-                        temp = dev->accel.multifunc[3];
-                        break;
-                    case 4:
-                        temp = dev->accel.multifunc[4];
-                        break;
-                    case 5:
-                        temp = dev->accel.multifunc[5];
-                        break;
-                    case 8:
-                        temp = dev->accel.multifunc[8];
-                        break;
-                    case 9:
-                        temp = dev->accel.multifunc[9];
-                        break;
-                    case 0x0a:
-                        temp = dev->accel.multifunc[0x0a];
-                        break;
-
-                    default:
-                        break;
-                }
-            }
-            break;
-
         case 0x82ee:
-            temp = mach->accel.patt_data_idx;
+            if (len == 2)
+                temp = mach->accel.patt_data_idx;
             break;
 
         case 0x86ee:
@@ -4106,10 +3842,9 @@ mach_accel_in_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, in
             break;
 
         case 0xdaee:
-            if (len != 1) {
-                temp = mach->accel.src_x;
+            if (len == 2) {
                 if ((dev->local & 0xff) >= 0x02)
-                    temp &= 0x7ff;
+                    temp = mach->accel.src_x;
             } else
                 temp = mach->accel.src_x & 0xff;
             break;
@@ -4119,10 +3854,9 @@ mach_accel_in_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, in
             break;
 
         case 0xdeee:
-            if (len != 1) {
-                temp = mach->accel.src_y;
+            if (len == 2) {
                 if ((dev->local & 0xff) >= 0x02)
-                    temp &= 0x7ff;
+                    temp = mach->accel.src_y;
             } else
                 temp = mach->accel.src_y & 0xff;
             break;
@@ -4132,7 +3866,7 @@ mach_accel_in_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, in
             break;
 
         case 0xfaee:
-            if (len != 1) {
+            if (len == 2) {
                 if ((dev->local & 0xff) >= 0x02) {
                     if (mach->pci_bus)
                         temp = 0x0017;
@@ -4163,7 +3897,8 @@ mach_accel_in_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, in
             break;
     }
 
-    mach_log("[%04X:%08X]: Port FIFO IN=%04x, temp=%04x, len=%d.\n", CS, cpu_state.pc, port, temp, len);
+    if (port != 0x9aee && port != 0x62ee)
+        mach_log("[%04X:%08X]: Port FIFO IN=%04x, temp=%04x, len=%d.\n", CS, cpu_state.pc, port, temp, len);
 
     return temp;
 }
@@ -4171,14 +3906,7 @@ mach_accel_in_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, in
 static uint8_t
 mach_accel_in_call(uint16_t port, mach_t *mach, svga_t *svga, ibm8514_t *dev)
 {
-    uint8_t         temp        = 0;
-    uint16_t        clip_b_ibm  = dev->accel.multifunc[3];
-    uint16_t        clip_r_ibm  = dev->accel.multifunc[4];
-    int16_t         clip_l      = dev->accel.clip_left & 0x7ff;
-    int16_t         clip_t      = dev->accel.clip_top & 0x7ff;
-    int16_t         clip_r      = dev->accel.multifunc[4] & 0x7ff;
-    int16_t         clip_b      = dev->accel.multifunc[3] & 0x7ff;
-    int             cmd         = (dev->accel.cmd >> 13);
+    uint8_t temp = 0;
 
     switch (port) {
         case 0x2e8:
@@ -4196,24 +3924,8 @@ mach_accel_in_call(uint16_t port, mach_t *mach, svga_t *svga, ibm8514_t *dev)
             if (dev->vc == dev->v_syncstart)
                 dev->subsys_stat |= 1;
 
-            if (mach->accel.cmd_type >= 0) {
-                if (((dev->accel.dx) >= clip_l) && ((dev->accel.dx) <= clip_r) && ((dev->accel.dy) >= clip_t) && ((dev->accel.dy) <= clip_b))
-                    temp |= 2;
-            } else {
-                if (cmd == 6) {
-                    if (((dev->accel.dx) >= dev->accel.clip_left) && ((dev->accel.dx) <= clip_r_ibm) && ((dev->accel.dy) >= dev->accel.clip_top) && ((dev->accel.dy) <= clip_b_ibm))
-                        temp |= 2;
-                } else {
-                    if (((dev->accel.cx) >= dev->accel.clip_left) && ((dev->accel.dx) <= clip_r_ibm) && ((dev->accel.cy) >= dev->accel.clip_top) && ((dev->accel.cy) <= clip_b_ibm))
-                        temp |= 2;
-                }
-            }
-
-            if (!dev->force_busy)
-                temp |= 8;
-
             if (port & 1)
-                temp = 0x80;
+                temp = dev->vram_512k_8514 ? 0x00 : 0x80;
             else {
                 temp |= (dev->subsys_stat | 0x80);
                 if (mach->accel.ext_ge_config & 0x08)
@@ -4256,7 +3968,7 @@ mach_accel_in_call(uint16_t port, mach_t *mach, svga_t *svga, ibm8514_t *dev)
 
             if (!(port & 1)) {
                 temp &= ~0x0c;
-                switch (mach->memory) {
+                switch (dev->vram_amount) {
                     case 1024:
                         temp |= 0x04;
                         break;
@@ -4268,8 +3980,6 @@ mach_accel_in_call(uint16_t port, mach_t *mach, svga_t *svga, ibm8514_t *dev)
                         break;
 
                     default:
-                        if ((dev->local & 0xff) < 0x02)
-                            temp |= 0x04;
                         break;
                 }
             }
@@ -4351,7 +4061,7 @@ mach_accel_in_call(uint16_t port, mach_t *mach, svga_t *svga, ibm8514_t *dev)
         default:
             break;
     }
-    if (port != 0x62ee && port != 0x62ef && port != 0x42e8 && port != 0x42e9 && port != 0x02e8 && port != 0x02e9)
+    if (port != 0x42e8 && port != 0x42e9 && port != 0x62ee && port != 0x62ef && port != 0x02e8 && port != 0x02e9)
         mach_log("[%04X:%08X]: Port NORMAL IN=%04x, temp=%04x.\n", CS, cpu_state.pc, port, temp);
 
     return temp;
@@ -4568,43 +4278,6 @@ mach_accel_inl(uint16_t port, void *priv)
     return temp;
 }
 
-static uint32_t
-mach32_decode_addr(svga_t *svga, uint32_t addr, int write)
-{
-    int memory_map_mode = (svga->gdcreg[6] >> 2) & 3;
-
-    addr &= 0x1ffff;
-
-    switch (memory_map_mode) {
-        case 0:
-            break;
-        case 1:
-            if (addr >= 0x10000)
-                return 0xffffffff;
-            break;
-        case 2:
-            addr -= 0x10000;
-            if (addr >= 0x8000)
-                return 0xffffffff;
-            break;
-        default:
-        case 3:
-            addr -= 0x18000;
-            if (addr >= 0x8000)
-                return 0xffffffff;
-            break;
-    }
-
-    if (memory_map_mode <= 1) {
-        if (write)
-            addr = (addr & svga->banked_mask) + svga->write_bank;
-        else
-            addr = (addr & svga->banked_mask) + svga->read_bank;
-    }
-
-    return addr;
-}
-
 static __inline void
 mach32_write_common(uint32_t addr, uint8_t val, int linear, mach_t *mach, svga_t *svga)
 {
@@ -4613,37 +4286,51 @@ mach32_write_common(uint32_t addr, uint8_t val, int linear, mach_t *mach, svga_t
     int     reset_wm   = 0;
     latch8514_t vall;
     uint8_t wm = svga->writemask;
-    uint8_t count;
     uint8_t i;
 
     cycles -= svga->monitor->mon_video_timing_write_b;
 
     if (linear) {
+        if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00))
+            addr <<= 1;
+
         addr &= dev->vram_mask;
         dev->changedvram[addr >> 12] = svga->monitor->mon_changeframecount;
-        dev->vram[addr]              = val;
+        if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
+            switch (addr & 0x06) {
+                case 0x00:
+                case 0x06:
+                    dev->vram[addr] = val & 0x0f;
+                    dev->vram[addr + 1] = (val >> 4) & 0x0f;
+                    break;
+                case 0x02:
+                    dev->vram[addr + 2] = val & 0x0f;
+                    dev->vram[addr + 3] = (val >> 4) & 0x0f;
+                    break;
+                case 0x04:
+                    dev->vram[addr - 2] = val & 0x0f;
+                    dev->vram[addr - 1] = (val >> 4) & 0x0f;
+                    break;
+                default:
+                    break;
+            }
+        } else
+            dev->vram[addr] = val;
+
         return;
-    } else {
-        xga_write_test(addr, val, svga);
-        addr = mach32_decode_addr(svga, addr, 1);
-        if (addr == 0xffffffff)
-            return;
     }
 
     if (!(svga->gdcreg[6] & 1))
         svga->fullchange = 2;
 
-    if (((svga->chain4 && (svga->packed_chain4 || svga->force_old_addr)) || svga->fb_only) && (svga->writemode < 4)) {
+    if (svga->chain4) {
         writemask2 = 1 << (addr & 3);
         addr &= ~3;
-    } else if (svga->chain4 && (svga->writemode < 4)) {
-        writemask2 = 1 << (addr & 3);
-        addr &= ~3;
-        addr = ((addr & 0xfffc) << 2) | ((addr & 0x30000) >> 14) | (addr & ~0x3ffff);
     } else if (svga->chain2_write) {
         writemask2 &= ~0xa;
         if (addr & 1)
             writemask2 <<= 1;
+
         addr &= ~1;
         addr &= dev->vram_mask;
     } else {
@@ -4660,90 +4347,53 @@ mach32_write_common(uint32_t addr, uint8_t val, int linear, mach_t *mach, svga_t
 
     dev->changedvram[addr >> 12] = svga->monitor->mon_changeframecount;
 
-    count = 4;
+    val = ((val >> (svga->gdcreg[3] & 7)) | (val << (8 - (svga->gdcreg[3] & 7))));
+    if ((svga->gdcreg[8] == 0xff) && !(svga->gdcreg[3] & 0x18) && (!svga->gdcreg[1] || svga->set_reset_disabled)) {
+        for (i = 0; i < 4; i++) {
+            if (writemask2 & (1 << i))
+                dev->vram[addr | i] = val;
+        }
+    } else {
+        for (i = 0; i < 4; i++) {
+            if (svga->gdcreg[1] & (1 << i))
+                vall.b[i] = !!(svga->gdcreg[0] & (1 << i)) * 0xff;
+            else
+                vall.b[i] = val;
+        }
 
-    switch (svga->writemode) {
-        case 0:
-            val = ((val >> (svga->gdcreg[3] & 7)) | (val << (8 - (svga->gdcreg[3] & 7))));
-            if ((svga->gdcreg[8] == 0xff) && !(svga->gdcreg[3] & 0x18) && (!svga->gdcreg[1] || svga->set_reset_disabled)) {
-                for (i = 0; i < count; i++) {
-                    if (writemask2 & (1 << i))
-                        dev->vram[addr | i] = val;
-                }
-                return;
-            } else {
-                for (i = 0; i < count; i++) {
-                    if (svga->gdcreg[1] & (1 << i))
-                        vall.b[i] = !!(svga->gdcreg[0] & (1 << i)) * 0xff;
-                    else
-                        vall.b[i] = val;
-                }
-            }
-            break;
-        case 1:
-            for (i = 0; i < count; i++) {
-                if (writemask2 & (1 << i))
-                    dev->vram[addr | i] = dev->latch.b[i];
-            }
-            return;
-        case 2:
-            for (i = 0; i < count; i++)
-                vall.b[i] = !!(val & (1 << i)) * 0xff;
-
-            if (!(svga->gdcreg[3] & 0x18) && (!svga->gdcreg[1] || svga->set_reset_disabled)) {
-                for (i = 0; i < count; i++) {
+        switch (svga->gdcreg[3] & 0x18) {
+            case 0x00: /* Set */
+                for (i = 0; i < 4; i++) {
                     if (writemask2 & (1 << i))
                         dev->vram[addr | i] = (vall.b[i] & svga->gdcreg[8]) | (dev->latch.b[i] & ~svga->gdcreg[8]);
                 }
-                return;
-            }
-            break;
-        case 3:
-            val = ((val >> (svga->gdcreg[3] & 7)) | (val << (8 - (svga->gdcreg[3] & 7))));
-            wm  = svga->gdcreg[8];
-            svga->gdcreg[8] &= val;
+                break;
+            case 0x08: /* AND */
+                for (i = 0; i < 4; i++) {
+                    if (writemask2 & (1 << i))
+                        dev->vram[addr | i] = (vall.b[i] | ~svga->gdcreg[8]) & dev->latch.b[i];
+                }
+                break;
+            case 0x10: /* OR */
+                for (i = 0; i < 4; i++) {
+                    if (writemask2 & (1 << i))
+                        dev->vram[addr | i] = (vall.b[i] & svga->gdcreg[8]) | dev->latch.b[i];
+                }
+                break;
+            case 0x18: /* XOR */
+                for (i = 0; i < 4; i++) {
+                    if (writemask2 & (1 << i))
+                        dev->vram[addr | i] = (vall.b[i] & svga->gdcreg[8]) ^ dev->latch.b[i];
+                }
+                break;
 
-            for (i = 0; i < count; i++)
-                vall.b[i] = !!(svga->gdcreg[0] & (1 << i)) * 0xff;
+            default:
+                break;
+        }
 
-            reset_wm = 1;
-            break;
-        default:
-            break;
+        if (reset_wm)
+            svga->gdcreg[8] = wm;
     }
-
-    switch (svga->gdcreg[3] & 0x18) {
-        case 0x00: /* Set */
-            for (i = 0; i < count; i++) {
-                if (writemask2 & (1 << i))
-                    dev->vram[addr | i] = (vall.b[i] & svga->gdcreg[8]) | (dev->latch.b[i] & ~svga->gdcreg[8]);
-            }
-            break;
-        case 0x08: /* AND */
-            for (i = 0; i < count; i++) {
-                if (writemask2 & (1 << i))
-                    dev->vram[addr | i] = (vall.b[i] | ~svga->gdcreg[8]) & dev->latch.b[i];
-            }
-            break;
-        case 0x10: /* OR */
-            for (i = 0; i < count; i++) {
-                if (writemask2 & (1 << i))
-                    dev->vram[addr | i] = (vall.b[i] & svga->gdcreg[8]) | dev->latch.b[i];
-            }
-            break;
-        case 0x18: /* XOR */
-            for (i = 0; i < count; i++) {
-                if (writemask2 & (1 << i))
-                    dev->vram[addr | i] = (vall.b[i] & svga->gdcreg[8]) ^ dev->latch.b[i];
-            }
-            break;
-
-        default:
-            break;
-    }
-
-    if (reset_wm)
-        svga->gdcreg[8] = wm;
 }
 
 #ifdef ATI_8514_ULTRA
@@ -4780,25 +4430,90 @@ static void
 mach32_write(uint32_t addr, uint8_t val, void *priv)
 {
     mach_t *mach = (mach_t *) priv;
-    mach32_write_common(addr, val, 0, mach, &mach->svga);
+    svga_t *svga = &mach->svga;
+    ibm8514_t *dev = (ibm8514_t *) svga->dev8514;
+
+    xga_write_test(addr, val, svga);
+    addr = (addr & svga->banked_mask) + svga->write_bank;
+
+    if ((((dev->local & 0xff) >= 0x02) && !dev->vram_512k_8514) && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
+        addr <<= 1;
+        switch (addr & 0x06) {
+            case 0x00:
+            case 0x06:
+                mach32_write_common(addr, val & 0x0f, 0, mach, svga);
+                mach32_write_common(addr + 1, (val >> 4) & 0x0f, 0, mach, svga);
+                break;
+            case 0x02:
+                mach32_write_common(addr + 2, val & 0x0f, 0, mach, svga);
+                mach32_write_common(addr + 3, (val >> 4) & 0x0f, 0, mach, svga);
+                break;
+            case 0x04:
+                mach32_write_common(addr - 2, val & 0x0f, 0, mach, svga);
+                mach32_write_common(addr - 1, (val >> 4) & 0x0f, 0, mach, svga);
+                break;
+            default:
+                break;
+        }
+    } else
+        mach32_write_common(addr, val, 0, mach, svga);
 }
 
 static void
 mach32_writew(uint32_t addr, uint16_t val, void *priv)
 {
     mach_t *mach = (mach_t *) priv;
-    mach32_write_common(addr, val & 0xff, 0, mach, &mach->svga);
-    mach32_write_common(addr + 1, val >> 8, 0, mach, &mach->svga);
+    svga_t *svga = &mach->svga;
+    ibm8514_t *dev = (ibm8514_t *) svga->dev8514;
+
+    xga_write_test(addr, val, svga);
+    addr = (addr & svga->banked_mask) + svga->write_bank;
+
+    if ((((dev->local & 0xff) >= 0x02) && !dev->vram_512k_8514) && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
+        addr <<= 1;
+        if (addr & 0x04) {
+            mach32_write_common(addr - 2, val & 0x0f, 0, mach, svga);
+            mach32_write_common(addr - 1, (val >> 4) & 0x0f, 0, mach, svga);
+            mach32_write_common(addr + 2, (val >> 8) & 0x0f, 0, mach, svga);
+            mach32_write_common(addr + 3, (val >> 12) & 0x0f, 0, mach, svga);
+        } else {
+            mach32_write_common(addr, val & 0x0f, 0, mach, svga);
+            mach32_write_common(addr + 1, (val >> 4) & 0x0f, 0, mach, svga);
+            mach32_write_common(addr + 4, (val >> 8) & 0x0f, 0, mach, svga);
+            mach32_write_common(addr + 5, (val >> 12) & 0x0f, 0, mach, svga);
+        }
+    } else {
+        mach32_write_common(addr, val & 0xff, 0, mach, svga);
+        mach32_write_common(addr + 1, val >> 8, 0, mach, svga);
+    }
 }
 
 static void
 mach32_writel(uint32_t addr, uint32_t val, void *priv)
 {
     mach_t *mach = (mach_t *) priv;
-    mach32_write_common(addr, val & 0xff, 0, mach, &mach->svga);
-    mach32_write_common(addr + 1, val >> 8, 0, mach, &mach->svga);
-    mach32_write_common(addr + 2, val >> 16, 0, mach, &mach->svga);
-    mach32_write_common(addr + 3, val >> 24, 0, mach, &mach->svga);
+    svga_t *svga = &mach->svga;
+    ibm8514_t *dev = (ibm8514_t *) svga->dev8514;
+
+    xga_write_test(addr, val, svga);
+    addr = (addr & svga->banked_mask) + svga->write_bank;
+
+    if ((((dev->local & 0xff) >= 0x02) && !dev->vram_512k_8514) && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
+        addr <<= 1;
+        mach32_write_common(addr, val & 0x0f, 0, mach, svga);
+        mach32_write_common(addr + 1, (val >> 4) & 0x0f, 0, mach, svga);
+        mach32_write_common(addr + 4, (val >> 8) & 0x0f, 0, mach, svga);
+        mach32_write_common(addr + 5, (val >> 12) & 0x0f, 0, mach, svga);
+        mach32_write_common(addr + 2, (val >> 16) & 0x0f, 0, mach, svga);
+        mach32_write_common(addr + 3, (val >> 20) & 0x0f, 0, mach, svga);
+        mach32_write_common(addr + 6, (val >> 24) & 0x0f, 0, mach, svga);
+        mach32_write_common(addr + 7, (val >> 28) & 0x0f, 0, mach, svga);
+    } else {
+        mach32_write_common(addr, val & 0xff, 0, mach, svga);
+        mach32_write_common(addr + 1, val >> 8, 0, mach, svga);
+        mach32_write_common(addr + 2, val >> 16, 0, mach, svga);
+        mach32_write_common(addr + 3, val >> 24, 0, mach, svga);
+    }
 }
 
 static __inline void
@@ -4808,10 +4523,25 @@ mach32_writew_linear(uint32_t addr, uint16_t val, mach_t *mach)
     ibm8514_t *dev = (ibm8514_t *) svga->dev8514;
 
     cycles -= svga->monitor->mon_video_timing_write_w;
+    if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00))
+        addr <<= 1;
 
     addr &= dev->vram_mask;
     dev->changedvram[addr >> 12] = svga->monitor->mon_changeframecount;
-    *(uint16_t *) &dev->vram[addr] = val;
+    if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
+        if (addr & 0x04) {
+            dev->vram[addr - 2] = val & 0x0f;
+            dev->vram[addr - 1] = (val >> 4) & 0x0f;
+            dev->vram[addr + 2] = (val >> 8) & 0x0f;
+            dev->vram[addr + 3] = (val >> 12) & 0x0f;
+        } else {
+            dev->vram[addr] = val & 0x0f;
+            dev->vram[addr + 1] = (val >> 4) & 0x0f;
+            dev->vram[addr + 4] = (val >> 8) & 0x0f;
+            dev->vram[addr + 5] = (val >> 12) & 0x0f;
+        }
+    } else
+        *(uint16_t *) &dev->vram[addr] = val;
 }
 
 static __inline void
@@ -4822,9 +4552,22 @@ mach32_writel_linear(uint32_t addr, uint32_t val, mach_t *mach)
 
     cycles -= svga->monitor->mon_video_timing_write_l;
 
+    if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00))
+        addr <<= 1;
+
     addr &= dev->vram_mask;
     dev->changedvram[addr >> 12] = svga->monitor->mon_changeframecount;
-    *(uint32_t *) &dev->vram[addr] = val;
+    if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
+        dev->vram[addr] = val & 0x0f;
+        dev->vram[addr + 1] = (val >> 4) & 0x0f;
+        dev->vram[addr + 4] = (val >> 8) & 0x0f;
+        dev->vram[addr + 5] = (val >> 12) & 0x0f;
+        dev->vram[addr + 2] = (val >> 16) & 0x0f;
+        dev->vram[addr + 3] = (val >> 20) & 0x0f;
+        dev->vram[addr + 6] = (val >> 24) & 0x0f;
+        dev->vram[addr + 7] = (val >> 28) & 0x0f;
+    } else
+        *(uint32_t *) &dev->vram[addr] = val;
 }
 
 static __inline uint8_t
@@ -4835,17 +4578,37 @@ mach32_read_common(uint32_t addr, int linear, mach_t *mach, svga_t *svga)
     int              readplane  = svga->readplane;
     uint8_t          count;
     uint8_t          temp;
-    uint8_t          ret;
+    uint8_t          ret = 0x00;
 
     cycles -= svga->monitor->mon_video_timing_read_b;
 
     if (linear) {
-        return dev->vram[addr & dev->vram_mask];
-    } else {
-        (void) xga_read_test(addr, svga);
-        addr = mach32_decode_addr(svga, addr, 0);
-        if (addr == 0xffffffff)
-            return 0xff;
+        if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00))
+            addr <<= 1;
+
+        addr &= dev->vram_mask;
+        if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
+            switch (addr & 0x06) {
+                case 0x00:
+                case 0x06:
+                    ret = dev->vram[addr] & 0x0f;
+                    ret |= (dev->vram[addr + 1] << 4);
+                    break;
+                case 0x02:
+                    ret = dev->vram[addr + 2] & 0x0f;
+                    ret |= (dev->vram[addr + 3] << 4);
+                    break;
+                case 0x04:
+                    ret = dev->vram[addr - 2] & 0x0f;
+                    ret |= (dev->vram[addr - 1] << 4);
+                    break;
+                default:
+                    break;
+            }
+        } else
+            ret = dev->vram[addr];
+
+        return ret;
     }
 
     count = 2;
@@ -4853,7 +4616,7 @@ mach32_read_common(uint32_t addr, int linear, mach_t *mach, svga_t *svga)
     latch_addr = (addr << count) & svga->decode_mask;
     count      = (1 << count);
 
-    if ((svga->chain4 && (svga->packed_chain4 || svga->force_old_addr)) || svga->fb_only) {
+    if (svga->chain4) {
         addr &= svga->decode_mask;
         if (addr >= dev->vram_size)
             return 0xff;
@@ -4861,9 +4624,6 @@ mach32_read_common(uint32_t addr, int linear, mach_t *mach, svga_t *svga)
         for (uint8_t i = 0; i < count; i++)
             dev->latch.b[i] = dev->vram[latch_addr | i];
         return dev->vram[addr & dev->vram_mask];
-    } else if (svga->chain4 && !svga->force_old_addr) {
-        readplane = addr & 3;
-        addr      = ((addr & 0xfffc) << 2) | ((addr & 0x30000) >> 14) | (addr & ~0x3ffff);
     } else if (svga->chain2_read) {
         readplane = (readplane & 2) | (addr & 1);
         addr &= ~1;
@@ -4896,6 +4656,7 @@ mach32_read_common(uint32_t addr, int linear, mach_t *mach, svga_t *svga)
 
     addr &= dev->vram_mask;
 
+    mach_log("ReadMode=%02x.\n", svga->readmode);
     if (svga->readmode) {
         temp = 0xff;
 
@@ -4959,9 +4720,35 @@ static uint8_t
 mach32_read(uint32_t addr, void *priv)
 {
     mach_t *mach = (mach_t *) priv;
-    uint8_t          ret;
+    svga_t *svga = &mach->svga;
+    ibm8514_t *dev = (ibm8514_t *) svga->dev8514;
+    uint8_t ret = 0x00;
 
-    ret  = mach32_read_common(addr, 0, mach, &mach->svga);
+    (void) xga_read_test(addr, svga);
+    addr = (addr & svga->banked_mask) + svga->read_bank;
+
+    if ((((dev->local & 0xff) >= 0x02) && !dev->vram_512k_8514) && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
+        addr <<= 1;
+        switch (addr & 0x06) {
+            case 0x00:
+            case 0x06:
+                ret = mach32_read_common(addr, 0, mach, svga) & 0x0f;
+                ret |= (mach32_read_common(addr + 1, 0, mach, svga) << 4);
+                break;
+            case 0x02:
+                ret = mach32_read_common(addr + 2, 0, mach, svga) & 0x0f;
+                ret |= (mach32_read_common(addr + 3, 0, mach, svga) << 4);
+                break;
+            case 0x04:
+                ret = mach32_read_common(addr - 2, 0, mach, svga) & 0x0f;
+                ret |= (mach32_read_common(addr - 1, 0, mach, svga) << 4);
+                break;
+            default:
+                break;
+        }
+    } else
+        ret = mach32_read_common(addr, 0, mach, svga);
+
     return ret;
 }
 
@@ -4969,10 +4756,30 @@ static uint16_t
 mach32_readw(uint32_t addr, void *priv)
 {
     mach_t *mach = (mach_t *) priv;
-    uint16_t         ret;
+    svga_t *svga = &mach->svga;
+    ibm8514_t *dev = (ibm8514_t *) svga->dev8514;
+    uint16_t ret;
 
-    ret  = mach32_read_common(addr, 0, mach, &mach->svga);
-    ret  |= (mach32_read_common(addr + 1, 0, mach, &mach->svga) << 8);
+    (void) xga_read_test(addr, svga);
+    addr = (addr & svga->banked_mask) + svga->read_bank;
+
+    if ((((dev->local & 0xff) >= 0x02) && !dev->vram_512k_8514) && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
+        addr <<= 1;
+        if (addr & 0x04) {
+            ret = mach32_read_common(addr - 2, 0, mach, svga) & 0x0f;
+            ret |= (mach32_read_common(addr - 1, 0, mach, svga) << 4);
+            ret |= (mach32_read_common(addr + 2, 0, mach, svga) << 8);
+            ret |= (mach32_read_common(addr + 3, 0, mach, svga) << 12);
+        } else {
+            ret = mach32_read_common(addr, 0, mach, svga) & 0x0f;
+            ret |= (mach32_read_common(addr + 1, 0, mach, svga) << 4);
+            ret |= (mach32_read_common(addr + 4, 0, mach, svga) << 8);
+            ret |= (mach32_read_common(addr + 5, 0, mach, svga) << 12);
+        }
+    } else {
+        ret = mach32_read_common(addr, 0, mach, svga);
+        ret |= (mach32_read_common(addr + 1, 0, mach, svga) << 8);
+    }
     return ret;
 }
 
@@ -4980,12 +4787,29 @@ static uint32_t
 mach32_readl(uint32_t addr, void *priv)
 {
     mach_t *mach = (mach_t *) priv;
-    uint32_t         ret;
+    svga_t *svga = &mach->svga;
+    ibm8514_t *dev = (ibm8514_t *) svga->dev8514;
+    uint32_t ret;
 
-    ret  = mach32_read_common(addr, 0, mach, &mach->svga);
-    ret  |= (mach32_read_common(addr + 1, 0, mach, &mach->svga) << 8);
-    ret  |= (mach32_read_common(addr + 2, 0, mach, &mach->svga) << 16);
-    ret  |= (mach32_read_common(addr + 3, 0, mach, &mach->svga) << 24);
+    (void) xga_read_test(addr, svga);
+    addr = (addr & svga->banked_mask) + svga->read_bank;
+
+    if ((((dev->local & 0xff) >= 0x02) && !dev->vram_512k_8514) && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
+        addr <<= 1;
+        ret = mach32_read_common(addr, 0, mach, svga) & 0x0f;
+        ret |= (mach32_read_common(addr + 1, 0, mach, svga) << 4);
+        ret |= (mach32_read_common(addr + 4, 0, mach, svga) << 8);
+        ret |= (mach32_read_common(addr + 5, 0, mach, svga) << 12);
+        ret |= (mach32_read_common(addr + 2, 0, mach, svga) << 16);
+        ret |= (mach32_read_common(addr + 3, 0, mach, svga) << 20);
+        ret |= (mach32_read_common(addr + 6, 0, mach, svga) << 24);
+        ret |= (mach32_read_common(addr + 7, 0, mach, svga) << 28);
+    } else {
+        ret = mach32_read_common(addr, 0, mach, svga);
+        ret |= (mach32_read_common(addr + 1, 0, mach, svga) << 8);
+        ret |= (mach32_read_common(addr + 2, 0, mach, svga) << 16);
+        ret |= (mach32_read_common(addr + 3, 0, mach, svga) << 24);
+    }
     return ret;
 }
 
@@ -4994,10 +4818,27 @@ mach32_readw_linear(uint32_t addr, mach_t *mach)
 {
     svga_t          *svga       = &mach->svga;
     ibm8514_t       *dev        = (ibm8514_t *) svga->dev8514;
+    uint16_t         ret;
 
     cycles -= svga->monitor->mon_video_timing_read_w;
+    if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
+        addr <<= 1;
+        addr &= dev->vram_mask;
+        if (addr & 0x04) {
+            ret = dev->vram[addr - 2] & 0x0f;
+            ret |= (dev->vram[addr - 1] << 4);
+            ret |= (dev->vram[addr + 2] << 8);
+            ret |= (dev->vram[addr + 3] << 12);
+        } else {
+            ret = dev->vram[addr] & 0x0f;
+            ret |= (dev->vram[addr + 1] << 4);
+            ret |= (dev->vram[addr + 4] << 8);
+            ret |= (dev->vram[addr + 5] << 12);
+        }
+    } else
+        ret = *(uint16_t *) &dev->vram[addr & dev->vram_mask];
 
-    return *(uint16_t *) &dev->vram[addr & dev->vram_mask];
+    return ret;
 }
 
 static __inline uint32_t
@@ -5005,10 +4846,25 @@ mach32_readl_linear(uint32_t addr, mach_t *mach)
 {
     svga_t          *svga       = &mach->svga;
     ibm8514_t       *dev        = (ibm8514_t *) svga->dev8514;
+    uint32_t         ret;
 
     cycles -= svga->monitor->mon_video_timing_read_l;
 
-    return *(uint32_t *) &dev->vram[addr & dev->vram_mask];
+    if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
+        addr <<= 1;
+        addr &= dev->vram_mask;
+        ret = dev->vram[addr] & 0x0f;
+        ret |= (dev->vram[addr + 1] << 4);
+        ret |= (dev->vram[addr + 4] << 8);
+        ret |= (dev->vram[addr + 5] << 12);
+        ret |= (dev->vram[addr + 2] << 16);
+        ret |= (dev->vram[addr + 3] << 20);
+        ret |= (dev->vram[addr + 6] << 24);
+        ret |= (dev->vram[addr + 7] << 28);
+    } else
+        ret = *(uint32_t *) &dev->vram[addr & dev->vram_mask];
+
+    return ret;
 }
 
 static void
@@ -5029,10 +4885,10 @@ mach32_ap_writeb(uint32_t addr, uint8_t val, void *priv)
             mach_accel_outb(0x02e8 + (addr & 1) + (port_dword << 8), val, mach);
         }
     } else {
-        mach_log("Linear WORDB Write=%08x, val=%02x.\n", addr, val);
-        if (dev->on[0] || dev->on[1])
+        if (dev->on) {
+            mach_log("Linear WORDB Write=%08x, val=%02x, ON=%x, dpconfig=%04x, apsize=%08x.\n", addr & dev->vram_mask, val, dev->on, mach->accel.dp_config, mach->ap_size << 20);
             mach32_write_common(addr, val, 1, mach, svga);
-        else
+        } else
             svga_write_linear(addr, val, svga);
     }
 }
@@ -5055,8 +4911,8 @@ mach32_ap_writew(uint32_t addr, uint16_t val, void *priv)
             mach_accel_outw(0x02e8 + (port_dword << 8), val, mach);
         }
     } else {
-        mach_log("Linear WORDW Write=%08x, val=%04x.\n", addr, val);
-        if (dev->on[0] || dev->on[1]) {
+        if (dev->on) {
+            mach_log("Linear WORDW Write=%08x, val=%04x, ON=%x, dpconfig=%04x, apsize=%08x.\n", addr & dev->vram_mask, val, dev->on, mach->accel.dp_config, mach->ap_size << 20);
             mach32_writew_linear(addr, val, mach);
         } else
             svga_writew_linear(addr, val, svga);
@@ -5083,8 +4939,8 @@ mach32_ap_writel(uint32_t addr, uint32_t val, void *priv)
             mach_accel_outw(0x02e8 + (port_dword << 8) + 4, val >> 16, mach);
         }
     } else {
-        mach_log("Linear WORDL Write=%08x, val=%08x.\n", addr, val);
-        if (dev->on[0] || dev->on[1]) {
+        if (dev->on) {
+            mach_log("Linear WORDL Write=%08x, val=%08x, ON=%x, dpconfig=%04x, apsize=%08x.\n", addr & dev->vram_mask, val, dev->on, mach->accel.dp_config, mach->ap_size << 20);
             mach32_writel_linear(addr, val, mach);
         } else
             svga_writel_linear(addr, val, svga);
@@ -5107,7 +4963,7 @@ mach32_ap_readb(uint32_t addr, void *priv)
         else
             temp = mach_accel_inb(0x02e8 + (addr & 1) + (port_dword << 8), mach);
     } else {
-        if (dev->on[0] || dev->on[1])
+        if (dev->on)
             temp = mach32_read_common(addr, 1, mach, svga);
         else
             temp = svga_read_linear(addr, svga);
@@ -5134,7 +4990,7 @@ mach32_ap_readw(uint32_t addr, void *priv)
         else
             temp = mach_accel_inw(0x02e8 + (port_dword << 8), mach);
     } else {
-        if (dev->on[0] || dev->on[1]) {
+        if (dev->on) {
             temp = mach32_readw_linear(addr, mach);
         } else
             temp = svga_readw_linear(addr, svga);
@@ -5164,12 +5020,12 @@ mach32_ap_readl(uint32_t addr, void *priv)
             temp |= (mach_accel_inw(0x02e8 + (port_dword << 8) + 4, mach) << 8);
         }
     } else {
-        if (dev->on[0] || dev->on[1]) {
+        if (dev->on) {
             temp = mach32_readl_linear(addr, mach);
         } else
             temp = svga_readl_linear(addr, svga);
 
-        mach_log("Linear WORDL Read=%08x, ret=%08x, ON0=%d, ON1=%d.\n", addr, temp, dev->on[0], dev->on[1]);
+        mach_log("Linear WORDL Read=%08x, ret=%08x, ON%d.\n", addr, temp, dev->on);
     }
 
     return temp;
@@ -5186,7 +5042,7 @@ mach32_updatemapping(mach_t *mach, svga_t *svga)
         return;
     }
 
-    if (mach->regs[0xbd] & 4) {
+    if (mach->regs[0xbd] & 0x04) {
         mem_mapping_set_addr(&svga->mapping, 0xa0000, 0x20000);
         svga->banked_mask = 0xffff;
     } else {
@@ -5218,18 +5074,21 @@ mach32_updatemapping(mach_t *mach, svga_t *svga)
         if (((mach->memory_aperture & 3) == 1) && !mach->pci_bus) {
             /*1 MB aperture*/
             mach->ap_size = 1;
+            mach_log("Linear Enabled APSIZE=1.\n");
             mem_mapping_set_addr(&mach->mmio_linear_mapping, mach->linear_base, mach->ap_size << 20);
         } else {
             /*4 MB aperture*/
             mach->ap_size = 4;
+            mach_log("Linear Enabled APSIZE=4.\n");
             mem_mapping_set_addr(&mach->mmio_linear_mapping, mach->linear_base, mach->ap_size << 20);
         }
     } else {
         mach->ap_size = 4;
+        mach_log("Linear Disabled APSIZE=4.\n");
         mem_mapping_disable(&mach->mmio_linear_mapping);
     }
-    if ((dev->on[0] || dev->on[1]) && (mach->ext_on[0] || mach->ext_on[1]) && (dev->vendor_mode[0] || dev->vendor_mode[1])) {
-        mach_log("ExtON.\n");
+    if (dev->on && ((dev->local & 0xff) >= 0x02)) {
+        mach_log("Mach32 banked mapping.\n");
 #ifdef ATI_8514_ULTRA
         if (svga->ext8514 != NULL) {
             mem_mapping_set_handler(&svga->mapping, ati8514_read, ati8514_readw, ati8514_readl, ati8514_write, ati8514_writew, ati8514_writel);
@@ -5241,7 +5100,7 @@ mach32_updatemapping(mach_t *mach, svga_t *svga)
             mem_mapping_set_p(&svga->mapping, mach);
         }
     } else {
-        mach_log("ExtOFF.\n");
+        mach_log("IBM compatible banked mapping.\n");
         mem_mapping_set_handler(&svga->mapping, svga_read, svga_readw, svga_readl, svga_write, svga_writew, svga_writel);
         mem_mapping_set_p(&svga->mapping, svga);
     }
@@ -5267,6 +5126,7 @@ mach32_hwcursor_draw(svga_t *svga, int displine)
         case 8:
             color0 = dev->pallook[mach->cursor_col_0];
             color1 = dev->pallook[mach->cursor_col_1];
+            mach_log("4/8BPP: Color0=%08x, Color1=%08x.\n", color0, color1);
             break;
         case 15:
             color0 = video_15to32[((mach->ext_cur_col_0_r << 16) | (mach->ext_cur_col_0_g << 8) | mach->cursor_col_0) & 0xffff];
@@ -5288,6 +5148,7 @@ mach32_hwcursor_draw(svga_t *svga, int displine)
 
     for (int x = 0; x < 64; x += 8) {
         dat = dev->vram[dev->hwcursor_latch.addr & dev->vram_mask] | (dev->vram[(dev->hwcursor_latch.addr + 1) & dev->vram_mask] << 8);
+
         for (int xx = 0; xx < 8; xx++) {
             comb = (dat >> (xx << 1)) & 0x03;
 
@@ -5598,13 +5459,11 @@ mach_mca_reset(void *priv)
     svga_t    *svga = &mach->svga;
     ibm8514_t *dev  = (ibm8514_t *) svga->dev8514;
 
-    mem_mapping_disable(&mach->bios_rom.mapping);
-    mem_mapping_disable(&mach->bios_rom2.mapping);
     mach_log("MCA reset.\n");
-    dev->on[0] = 0;
-    dev->on[1] = 0;
+    dev->on = 0;
     vga_on = 1;
     mach_mca_write(0x102, 0, mach);
+    timer_set_callback(&svga->timer, svga_poll);
 }
 
 #ifdef ATI_8514_ULTRA
@@ -5794,8 +5653,9 @@ mach8_init(const device_t *info)
     dev->type        = info->flags;
     dev->local       = info->local & 0xff;
     mach->has_bios   = !(info->local & 0xff00);
-    mach->memory     = device_get_config_int("memory");
     mach->ramdac_type = mach->pci_bus ? device_get_config_int("ramdac") : 1;
+    dev->vram_amount = device_get_config_int("memory");
+    dev->vram_512k_8514 = dev->vram_amount == 512;
 
     if ((dev->local & 0xff) >= 0x02) {
         if (mach->pci_bus) {
@@ -5833,12 +5693,12 @@ mach8_init(const device_t *info)
                  0, MEM_MAPPING_EXTERNAL);
 
     if ((dev->local & 0xff) >= 0x02) {
-        svga_init(info, svga, mach, mach->memory << 10, /*default: 2MB for Mach32*/
+        svga_init(info, svga, mach, dev->vram_amount << 10, /*default: 2MB for Mach32*/
                       mach_recalctimings,
                       mach_in, mach_out,
                       mach32_hwcursor_draw,
                       NULL);
-        dev->vram_size   = mach->memory << 10;
+        dev->vram_size   = dev->vram_amount << 10;
         dev->vram        = calloc(dev->vram_size, 1);
         dev->changedvram = calloc((dev->vram_size >> 12) + 1, 1);
         dev->vram_mask   = dev->vram_size - 1;
@@ -5886,20 +5746,22 @@ mach8_init(const device_t *info)
                       mach_in, mach_out,
                       NULL,
                       NULL);
-        dev->vram_size   = (1024 << 10);
+        dev->vram_size   = (dev->vram_amount << 10);
         dev->vram        = calloc(dev->vram_size, 1);
         dev->changedvram = calloc((dev->vram_size >> 12) + 1, 1);
         dev->vram_mask   = dev->vram_size - 1;
         video_inform(VIDEO_FLAG_TYPE_8514, &timing_gfxultra_isa);
-        mach->config1 = 0x01 | 0x02 | 0x20 | 0x08 | 0x80;
+        mach->config1 = 0x01 | 0x02 | 0x08 | 0x80;
+        if (dev->vram_amount >= 1024)
+            mach->config1 |= 0x20;
+
         mach->config2 = 0x02;
         svga->clock_gen = device_add(&ati18811_0_device);
     }
     dev->bpp            = 0;
     svga->getclock      = ics2494_getclock;
 
-    dev->on[0] = 0;
-    dev->on[1] = 0;
+    dev->on = 0;
     dev->ext_pitch = 1024;
     dev->ext_crt_pitch = 0x80;
     dev->accel_bpp = 8;
@@ -5915,6 +5777,7 @@ mach8_init(const device_t *info)
 
     if ((dev->local & 0xff) >= 0x02) {
         svga->decode_mask     = (4 << 20) - 1;
+        mach->accel.cmd_type  = -1;
         mach->cursor_col_1    = 0xff;
         mach->ext_cur_col_1_r = 0xff;
         mach->ext_cur_col_1_g = 0xff;
@@ -5954,23 +5817,25 @@ ati8514_init(svga_t *svga, void *ext8514, void *dev8514)
     mach_t *mach = (mach_t *) ext8514;
     ibm8514_t *dev = (ibm8514_t *) dev8514;
 
-    dev->on[0] = 0;
-    dev->on[1] = 0;
+    dev->on = 0;
     dev->ext_pitch = 1024;
     dev->ext_crt_pitch = 0x80;
     dev->accel_bpp = 8;
     dev->rowoffset = 0x80;
-    dev->hdisp = 1024;
-    dev->vdisp = 768;
+    dev->hdisp = 0;
+    dev->vdisp = 0;
 
     io_sethandler(0x02ea, 4, ati8514_in, NULL, NULL, ati8514_out, NULL, NULL, svga);
     ati8514_io_set(svga);
     mach->mca_bus = !!(dev->type & DEVICE_MCA);
 
     if (mach->mca_bus)
-        mach->config1 = 0x02 | 0x04 | 0x08 | 0x20 | 0x80;
+        mach->config1 = 0x02 | 0x04;
     else
-        mach->config1 = 0x02 | 0x08 | 0x20 | 0x80;
+        mach->config1 = 0x02 | 0x2000;
+
+    if (dev->vram_amount >= 1024)
+        mach->config1 |= 0x20;
 
     mach->config2 = 0x01 | 0x02;
 }
@@ -6041,6 +5906,32 @@ mach_force_redraw(void *priv)
 
     svga->fullchange = svga->monitor->mon_changeframecount;
 }
+
+// clang-format off
+static const device_config_t mach8_config[] = {
+    {
+        .name = "memory",
+        .description = "Memory size",
+        .type = CONFIG_SELECTION,
+        .default_int = 1024,
+        .selection = {
+            {
+                .description = "512 KB",
+                .value = 512
+            },
+            {
+                .description = "1 MB",
+                .value = 1024
+            },
+            {
+                .description = ""
+            }
+        }
+    },
+    {
+        .type = CONFIG_END
+    }
+};
 
 // clang-format off
 static const device_config_t mach32_config[] = {
@@ -6140,7 +6031,7 @@ const device_t mach8_vga_isa_device = {
     { .available = mach8_vga_available },
     .speed_changed = mach_speed_changed,
     .force_redraw = mach_force_redraw,
-    .config = NULL
+    .config = mach8_config
 };
 
 const device_t mach32_isa_device = {

--- a/src/video/vid_bt481_ramdac.c
+++ b/src/video/vid_bt481_ramdac.c
@@ -1,0 +1,160 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          Emulation of the Brooktree BT481 true colour RAMDAC
+ *          family.
+ *
+ *
+ *
+ * Authors: TheCollector1995.
+ *
+ *          Copyright 2024 TheCollector1995.
+ */
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+#include <86box/86box.h>
+#include <86box/device.h>
+#include <86box/mem.h>
+#include <86box/timer.h>
+#include <86box/video.h>
+#include <86box/vid_svga.h>
+
+typedef struct bt481_ramdac_t {
+    int     state;
+    uint8_t cmd;
+} bt481_ramdac_t;
+
+static void
+bt481_ramdac_command(uint8_t val, void *priv, svga_t *svga)
+{
+    bt481_ramdac_t *ramdac  = (bt481_ramdac_t *) priv;
+    ramdac->cmd             = val;
+    pclog("RAMDAC CMD=%02x.\n", val);
+    switch ((ramdac->cmd >> 4) & 0x0f) {
+        default:
+        case 0x00:
+            svga->bpp = 8;
+            break;
+        case 0x08:
+        case 0x0a:
+            svga->bpp = 15;
+            break;
+        case 0x09:
+        case 0x0c:
+            svga->bpp = 16;
+            break;
+        case 0x0e:
+        case 0x0f:
+            svga->bpp = 24;
+            break;
+    }
+    svga_recalctimings(svga);
+}
+
+void
+bt481_ramdac_out(uint16_t addr, int rs2, uint8_t val, void *priv, svga_t *svga)
+{
+    bt481_ramdac_t *ramdac = (bt481_ramdac_t *) priv;
+    uint8_t             rs = (addr & 0x03) | ((!!rs2) << 2);
+
+    switch (rs) {
+        case 0x00:
+        case 0x01:
+        case 0x03:
+        case 0x04:
+        case 0x05:
+        case 0x07:
+            svga_out(addr, val, svga);
+            ramdac->state = 0;
+            break;
+        case 0x02:
+            pclog("RAMDAC Write State=%x.\n", ramdac->state);
+            switch (ramdac->state) {
+                case 4:
+                    bt481_ramdac_command(val, ramdac, svga);
+                    break;
+                default:
+                    svga_out(addr, val, svga);
+                    break;
+            }
+            break;
+        case 0x06:
+            bt481_ramdac_command(val, ramdac, svga);
+            ramdac->state = 0;
+            break;
+
+        default:
+            break;
+    }
+}
+
+uint8_t
+bt481_ramdac_in(uint16_t addr, int rs2, void *priv, svga_t *svga)
+{
+    bt481_ramdac_t * ramdac = (bt481_ramdac_t *) priv;
+    uint8_t          temp   = 0xff;
+    uint8_t          rs     = (addr & 0x03) | ((!!rs2) << 2);
+
+    switch (rs) {
+        case 0x02:
+        case 0x06:
+            switch (ramdac->state) {
+                case 4:
+                    temp = ramdac->cmd;
+                    break;
+                default:
+                    temp = svga_in(addr, svga);
+                    ramdac->state++;
+                    break;
+            }
+            break;
+
+        default:
+            temp          = svga_in(addr, svga);
+            ramdac->state = 0;
+            break;
+    }
+
+    pclog("RAMDAC IN=%02x, ret=%02x.\n", rs, temp);
+    return temp;
+}
+
+static void *
+bt481_ramdac_init(const device_t *info)
+{
+    bt481_ramdac_t *ramdac = (bt481_ramdac_t *) malloc(sizeof(bt481_ramdac_t));
+    memset(ramdac, 0, sizeof(bt481_ramdac_t));
+
+    return ramdac;
+}
+
+static void
+bt481_ramdac_close(void *priv)
+{
+    bt481_ramdac_t *ramdac = (bt481_ramdac_t *) priv;
+
+    if (ramdac)
+        free(ramdac);
+}
+
+const device_t bt481_ramdac_device = {
+    .name          = "Brooktree Bt481 RAMDAC",
+    .internal_name = "bt481_ramdac",
+    .flags         = 0,
+    .local         = 0,
+    .init          = bt481_ramdac_init,
+    .close         = bt481_ramdac_close,
+    .reset         = NULL,
+    { .available = NULL },
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = NULL
+};

--- a/src/video/vid_paradise.c
+++ b/src/video/vid_paradise.c
@@ -303,7 +303,7 @@ paradise_remap(paradise_t *paradise)
 void
 paradise_recalctimings(svga_t *svga)
 {
-    const paradise_t *paradise = (paradise_t *) svga->priv;
+    paradise_t *paradise = (paradise_t *) svga->priv;
 
     svga->lowres = !(svga->gdcreg[0x0e] & 0x01);
 
@@ -337,15 +337,11 @@ paradise_recalctimings(svga_t *svga)
                     svga->hdisp >>= 1;
                     if (svga->hdisp == 788)
                         svga->hdisp += 12;
-                    if (svga->hdisp == 800)
-                        svga->ma_latch -= 3;
                 } else if (svga->bpp == 15) {
                     svga->render = svga_render_15bpp_highres;
                     svga->hdisp >>= 1;
                     if (svga->hdisp == 788)
                         svga->hdisp += 12;
-                    if (svga->hdisp == 800)
-                        svga->ma_latch -= 3;
                 } else
                     svga->render = svga_render_8bpp_highres;
 
@@ -365,6 +361,11 @@ paradise_write(uint32_t addr, uint8_t val, void *priv)
     svga_t     *svga     = &paradise->svga;
     uint32_t    prev_addr;
     uint32_t    prev_addr2;
+
+    if (!(svga->attrregs[0x10] & 0x40)) {
+        svga_write(addr, val, svga);
+        return;
+    }
 
     addr = (addr & 0x7fff) + paradise->write_bank[(addr >> 15) & 3];
 
@@ -399,6 +400,11 @@ paradise_writew(uint32_t addr, uint16_t val, void *priv)
     uint32_t    prev_addr;
     uint32_t    prev_addr2;
 
+    if (!(svga->attrregs[0x10] & 0x40)) {
+        svga_writew(addr, val, svga);
+        return;
+    }
+
     addr = (addr & 0x7fff) + paradise->write_bank[(addr >> 15) & 3];
 
     /*Could be done in a better way but it works.*/
@@ -432,6 +438,9 @@ paradise_read(uint32_t addr, void *priv)
     uint32_t    prev_addr;
     uint32_t    prev_addr2;
 
+    if (!(svga->attrregs[0x10] & 0x40))
+        return svga_read(addr, svga);
+
     addr = (addr & 0x7fff) + paradise->read_bank[(addr >> 15) & 3];
 
     /*Could be done in a better way but it works.*/
@@ -464,6 +473,9 @@ paradise_readw(uint32_t addr, void *priv)
     svga_t     *svga     = &paradise->svga;
     uint32_t    prev_addr;
     uint32_t    prev_addr2;
+
+    if (!(svga->attrregs[0x10] & 0x40))
+        return svga_readw(addr, svga);
 
     addr = (addr & 0x7fff) + paradise->read_bank[(addr >> 15) & 3];
 


### PR DESCRIPTION
Summary
=======
8514/A/Mach8/32:
Reworked the acceleration a bit as well as the mode switches from VGA to ATI/8514/A mode and viceversa based on the documentation. Fixes the Linux GUI fonts using the Mach32 driver (possibly Mach8 too) and other anomalies (still needs more work on the acceleration though).

PVGA:
Minor fixes to the banking.

S3-based (Pre-ViRGE):
1. Made the chip class use its own banking so that the Enhanced Mode mapping (equivalent to 64K-based A0000) is taken into account (per bit 3 of CRTC31, which forces the mapping to be 64K A0000, regardless of the GDCREG6 bits). Fixes NT 3.1 347.1's S3 driver.
2. Initial rework on 15bpp/16bpp accelerated mode of the 911/924 chips (currently not 100% bug free, I need help with this chips).

XGA-1/2:
Get rid of the linear endian reverse variable hack used by OS/2 and, instead, use the already declared ones more wisely, fixes OS/2 2.1 reversed fonts and keeps everything else working as it should.

Misc:
Added the BT481 RAMDAC for future card use.


Checklist
=========
* [x] Closes #4888
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
