### PR TITLE
Small but important video changes of the day (October 27th, 2024)

### DIFF
--- a/src/include/86box/vid_8514a.h
+++ b/src/include/86box/vid_8514a.h
@@ -198,13 +198,16 @@ typedef struct ibm8514_t {
     int     hsync_width;
     int     htotal;
     int     hdisp;
+    int     hdisp2;
     int     hdisped;
     int     sc;
     int     vsyncstart;
     int     vsyncwidth;
     int     vtotal;
     int     v_disp;
+    int     v_disp2;
     int     vdisp;
+    int     vdisp2;
     int     disp_cntl;
     int     interlace;
     uint8_t subsys_cntl;

--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -498,6 +498,24 @@ ibm8514_accel_out_fifo(svga_t *svga, uint16_t port, uint32_t val, int len)
                 dev->accel.multifunc_cntl                             = val;
                 dev->accel.multifunc[dev->accel.multifunc_cntl >> 12] = dev->accel.multifunc_cntl & 0xfff;
                 dev->accel.cmd_back = !!(port == 0xfee8);
+
+                if ((dev->accel.multifunc_cntl >> 12) == 1) {
+                    dev->accel.clip_top = dev->accel.multifunc[1] & 0x3ff;
+                    if (dev->accel.multifunc[1] & 0x400)
+                        dev->accel.clip_top |= ~0x3ff;
+                }
+
+                if ((dev->accel.multifunc_cntl >> 12) == 2) {
+                    dev->accel.clip_left = dev->accel.multifunc[2] & 0x3ff;
+                    if (dev->accel.multifunc[2] & 0x400)
+                        dev->accel.clip_left |= ~0x3ff;
+                }
+                if ((dev->accel.multifunc_cntl >> 12) == 3)
+                    dev->accel.clip_bottom = dev->accel.multifunc[3] & 0x7ff;
+
+                if ((dev->accel.multifunc_cntl >> 12) == 4)
+                    dev->accel.clip_right = dev->accel.multifunc[4] & 0x7ff;
+
             }
             break;
 
@@ -914,10 +932,10 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
     uint16_t   old_dest_dat;
     int        frgd_mix;
     int        bkgd_mix;
-    int16_t    clip_t          = dev->accel.multifunc[1] & 0x7ff;
-    int16_t    clip_l          = dev->accel.multifunc[2] & 0x7ff;
-    uint16_t   clip_b          = dev->accel.multifunc[3] & 0x7ff;
-    uint16_t   clip_r          = dev->accel.multifunc[4] & 0x7ff;
+    int16_t    clip_t          = dev->accel.clip_top;
+    int16_t    clip_l          = dev->accel.clip_left;
+    uint16_t   clip_b          = dev->accel.clip_bottom;
+    uint16_t   clip_r          = dev->accel.clip_right;
     int        pixcntl         = (dev->accel.multifunc[0x0a] >> 6) & 3;
     uint16_t   mix_mask        = dev->bpp ? 0x8000 : 0x80;
     uint16_t   compare         = dev->accel.color_cmp;

--- a/src/video/vid_xga.c
+++ b/src/video/vid_xga.c
@@ -925,8 +925,10 @@ xga_accel_read_pattern_map_pixel(svga_t *svga, int x, int y, uint32_t base, int 
     bits = 7 - (x & 7);
 
     if (!(xga->accel.px_map_format[xga->accel.src_map] & 0x08) && !(xga->accel.px_map_format[xga->accel.dst_map] & 0x08)) {
-        if (((xga->accel.px_map_format[xga->accel.src_map] & 0x07) >= 0x02) && ((xga->accel.px_map_format[xga->accel.dst_map] & 0x07) >= 0x02))
+        if (((xga->accel.px_map_format[xga->accel.src_map] & 0x07) >= 0x02) && ((xga->accel.px_map_format[xga->accel.dst_map] & 0x07) >= 0x02) && (xga->accel.pat_src <= 2)) {
+            xga_log("Reverse, access mode=%02x, dstmap=%x, srcmap=%x, pat=%x.\n", xga->access_mode & 0x08, xga->accel.px_map_format[xga->accel.dst_map], xga->accel.px_map_format[xga->accel.src_map], xga->accel.pat_src);
             bits ^= 7;
+        }
     }
 
     px = (byte >> bits) & 1;


### PR DESCRIPTION
Summary
=======
8514/A compatibles:
1. The mode switch (from VGA to 8514/A/ATI and vice-versa) has been fixed again (for the Nth time).
2. Removed a pattern hack used on DPCONFIG = 0x5211 on bitblt, now patterns work properly using the ATI Mach8 3.0 win3.1x drivers.
3. Clipping regs are more accurate for acceleration.

XGA 1-2:
A picky OS is a picky OS, fixes to the Win95 fonts (which uses the pattern sources) applied.


Checklist
=========
* [x] Closes #4921
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
