### PR TITLE
Video and emulator GUI changes of the day (October 28th, 2024)

### DIFF
--- a/src/include/86box/vid_8514a_device.h
+++ b/src/include/86box/vid_8514a_device.h
@@ -1,0 +1,25 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          Emulation of the 8514/A card from IBM for the MCA bus and
+ *          generic ISA bus clones without vendor extensions.
+ *
+ *
+ *
+ * Authors: TheCollector1995
+ *
+ *          Copyright 2024 TheCollector1995.
+ */
+#ifndef VIDEO_8514A_DEVICE_H
+#define VIDEO_8514A_DEVICE_H
+
+#ifdef EMU_DEVICE_H
+extern const device_t ibm8514_mca_device;
+extern const device_t gen8514_isa_device;
+#endif
+#endif /*VIDEO_XGA_DEVICE_H*/

--- a/src/qt/qt_settingsdisplay.cpp
+++ b/src/qt/qt_settingsdisplay.cpp
@@ -24,6 +24,7 @@ extern "C" {
 #include <86box/device.h>
 #include <86box/machine.h>
 #include <86box/video.h>
+#include <86box/vid_8514a_device.h>
 #include <86box/vid_xga_device.h>
 }
 
@@ -53,6 +54,7 @@ SettingsDisplay::save()
     // TODO
     for (uint8_t i = 1; i < GFXCARD_MAX; i ++)
         gfxcard[i]                 = ui->comboBoxVideoSecondary->currentData().toInt();
+
     voodoo_enabled             = ui->checkBoxVoodoo->isChecked() ? 1 : 0;
     ibm8514_standalone_enabled = ui->checkBox8514->isChecked() ? 1 : 0;
     xga_standalone_enabled     = ui->checkBoxXga->isChecked() ? 1 : 0;
@@ -128,6 +130,16 @@ SettingsDisplay::on_pushButtonConfigureVoodoo_clicked()
 }
 
 void
+SettingsDisplay::on_pushButtonConfigure8514_clicked()
+{
+    if (machine_has_bus(machineId, MACHINE_BUS_MCA) > 0) {
+        DeviceConfig::ConfigureDevice(&ibm8514_mca_device, 0, qobject_cast<Settings *>(Settings::settings));
+    } else {
+        DeviceConfig::ConfigureDevice(&gen8514_isa_device, 0, qobject_cast<Settings *>(Settings::settings));
+    }
+}
+
+void
 SettingsDisplay::on_pushButtonConfigureXga_clicked()
 {
     if (machine_has_bus(machineId, MACHINE_BUS_MCA) > 0) {
@@ -165,6 +177,8 @@ SettingsDisplay::on_comboBoxVideo_currentIndexChanged(int index)
 
     ui->checkBox8514->setEnabled(machineSupports8514);
     ui->checkBox8514->setChecked(ibm8514_standalone_enabled && machineSupports8514);
+
+    ui->pushButtonConfigure8514->setEnabled(ui->checkBox8514->isEnabled() && ui->checkBox8514->isChecked());
 
     ui->checkBoxXga->setEnabled(machineSupportsXga);
     ui->checkBoxXga->setChecked(xga_standalone_enabled && machineSupportsXga);
@@ -236,6 +250,12 @@ void
 SettingsDisplay::on_checkBoxVoodoo_stateChanged(int state)
 {
     ui->pushButtonConfigureVoodoo->setEnabled(state == Qt::Checked);
+}
+
+void
+SettingsDisplay::on_checkBox8514_stateChanged(int state)
+{
+    ui->pushButtonConfigure8514->setEnabled(state == Qt::Checked);
 }
 
 void

--- a/src/qt/qt_settingsdisplay.hpp
+++ b/src/qt/qt_settingsdisplay.hpp
@@ -29,9 +29,11 @@ private slots:
 
 private slots:
     void on_checkBoxVoodoo_stateChanged(int state);
+    void on_checkBox8514_stateChanged(int state);
     void on_checkBoxXga_stateChanged(int state);
     void on_comboBoxVideo_currentIndexChanged(int index);
     void on_pushButtonConfigureVoodoo_clicked();
+    void on_pushButtonConfigure8514_clicked();
     void on_pushButtonConfigureXga_clicked();
     void on_pushButtonConfigure_clicked();
 

--- a/src/qt/qt_settingsdisplay.ui
+++ b/src/qt/qt_settingsdisplay.ui
@@ -106,6 +106,13 @@
      </property>
     </widget>
    </item>
+   <item row="5" column="2">
+    <widget class="QPushButton" name="pushButtonConfigure8514">
+     <property name="text">
+      <string>Configure</string>
+     </property>
+    </widget>
+   </item>
    <item row="6" column="2">
     <widget class="QPushButton" name="pushButtonConfigureXga">
      <property name="text">

--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -35,6 +35,7 @@
 #include <86box/thread.h>
 #include <86box/video.h>
 #include <86box/vid_8514a.h>
+#include <86box/vid_8514a_device.h>
 #include <86box/vid_xga.h>
 #include <86box/vid_svga.h>
 #include <86box/vid_svga_render.h>

--- a/src/video/vid_xga.c
+++ b/src/video/vid_xga.c
@@ -3487,15 +3487,13 @@ xga_init(const device_t *info)
             xga->rom_addr    = 0xc0000 + (((xga->pos_regs[2] & 0xf0) >> 4) * 0x2000);
             xga->instance    = (xga->pos_regs[2] & 0x0e) >> 1;
             xga->pos_regs[2] |= 0x01;
-            if (mem_size >= 15360) {
-                xga->pos_regs[4] |= 0x01;
+            xga->pos_regs[4] |= 0x01;
+            if (mem_size >= 15360)
                 xga->pos_regs[5] = 0;
-            } else {
+            else {
                 xga->pos_regs[5] = ((mem_size * 64) >> 0x10) + 1;
-                if (xga->pos_regs[5] == 0x10) {
+                if (xga->pos_regs[5] == 0x10)
                     xga->pos_regs[5] = 0x00;
-                    xga->pos_regs[4] |= 0x01;
-                }
             }
             xga->base_addr_1mb = (xga->pos_regs[5] & 0x0f) << 20;
             xga->linear_base = ((xga->pos_regs[4] & 0xfe) * 0x1000000) + (xga->instance << 22);


### PR DESCRIPTION
Summary
=======
IBM 8514/A (MCA/ISA).
Added a configure button to the QT frontend for the amount of memory used by said add-on chips.

XGA:
Forgot a change about the 4mb aperture.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
