### PR TITLE
Changes to 8514/A compatible stuff (November 2nd, 2024)

### DIFF
--- a/src/cpu/x86.c
+++ b/src/cpu/x86.c
@@ -384,9 +384,6 @@ softresetx86(void)
     if (soft_reset_mask)
         return;
 
-    if (ibm8514_active || xga_active)
-        vga_on = 1;
-
     reset_common(0);
 }
 

--- a/src/include/86box/vid_8514a.h
+++ b/src/include/86box/vid_8514a.h
@@ -42,7 +42,6 @@ typedef union {
 typedef struct ibm8514_t {
     rom_t bios_rom;
     rom_t bios_rom2;
-    rom_t bios_rom3;
     hwcursor8514_t hwcursor;
     hwcursor8514_t hwcursor_latch;
     uint8_t        pos_regs[8];
@@ -228,6 +227,7 @@ typedef struct ibm8514_t {
     uint32_t vram_amount;
     int      vram_512k_8514;
     PALETTE  _8514pal;
+    int      vendor_mode;
 
     latch8514_t latch;
 } ibm8514_t;

--- a/src/include/86box/vid_svga.h
+++ b/src/include/86box/vid_svga.h
@@ -79,6 +79,7 @@ typedef struct svga_t {
     uint8_t fcr;
     uint8_t hblank_overscan;
     uint8_t vidsys_ena;
+    uint8_t sleep;
 
     int dac_addr;
     int dac_pos;
@@ -297,8 +298,6 @@ typedef struct svga_t {
     void *  xga;
 } svga_t;
 
-extern int      vga_on;
-
 extern void     ibm8514_poll(void *priv);
 extern void     ibm8514_recalctimings(svga_t *svga);
 extern uint8_t  ibm8514_ramdac_in(uint16_t port, void *priv);
@@ -314,6 +313,8 @@ extern void     ibm8514_short_stroke_start(int count, int cpu_input, uint32_t mi
 extern void     ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, svga_t *svga, int len);
 
 #ifdef ATI_8514_ULTRA
+extern void     ati8514_out(uint16_t addr, uint8_t val, void *priv);
+extern uint8_t  ati8514_in(uint16_t addr, void *priv);
 extern void     ati8514_recalctimings(svga_t *svga);
 extern uint8_t  ati8514_mca_read(int port, void *priv);
 extern void     ati8514_mca_write(int port, uint8_t val, void *priv);

--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -98,14 +98,13 @@ ibm8514_log(const char *fmt, ...)
     } else {                                                                                         \
         temp = dev->vram[(dev->accel.dest + (cx) + (n)) & dev->vram_mask];                           \
         temp |= (dev->vram[(dev->accel.dest + (cx) + (n + 1)) & dev->vram_mask] << 8);               \
-    }
+    }                                                                                                \
 
 #define READ(addr, dat) \
-    if (dev->bpp) { \
+    if (dev->bpp) \
         dat = vram_w[(addr) & (dev->vram_mask >> 1)]; \
-    } else { \
+    else \
         dat = (dev->vram[(addr) & (dev->vram_mask)]); \
-    }
 
 #define READ_HIGH(addr, dat) \
     dat |= (dev->vram[(addr) & (dev->vram_mask)] << 8);
@@ -396,10 +395,10 @@ ibm8514_accel_out_fifo(svga_t *svga, uint16_t port, uint32_t val, int len)
                 dev->data_available  = 0;
                 dev->data_available2 = 0;
                 dev->accel.cmd       = val;
-                if (port == 0xdae8) {
-                    if (dev->accel.cmd & 0x100)
-                        dev->accel.cmd_back = 0;
-                }
+                dev->accel.cmd_back  = 1;
+                if (dev->accel.cmd & 0x100)
+                    dev->accel.cmd_back = 0;
+
                 ibm8514_log("8514/A CMD=%04x, back=%d.\n", dev->accel.cmd, dev->accel.cmd_back);
                 ibm8514_accel_start(-1, 0, -1, 0, svga, len);
             }
@@ -498,7 +497,6 @@ ibm8514_accel_out_fifo(svga_t *svga, uint16_t port, uint32_t val, int len)
             if (len == 2) {
                 dev->accel.multifunc_cntl                             = val;
                 dev->accel.multifunc[dev->accel.multifunc_cntl >> 12] = dev->accel.multifunc_cntl & 0xfff;
-                dev->accel.cmd_back = !!(port == 0xfee8);
 
                 if ((dev->accel.multifunc_cntl >> 12) == 1) {
                     dev->accel.clip_top = dev->accel.multifunc[1] & 0x3ff;
@@ -714,7 +712,6 @@ ibm8514_accel_out(uint16_t port, uint32_t val, svga_t *svga, int len)
             case 0x4ae8:
                 WRITE8(port, dev->accel.advfunc_cntl, val);
                 dev->on = dev->accel.advfunc_cntl & 0x01;
-                vga_on = !dev->on;
                 ibm8514_log("[%04X:%08X]: IBM 8514/A: (0x%04x): ON=%d, shadow crt=%x, hdisp=%d, vdisp=%d.\n", CS, cpu_state.pc, port, dev->on, dev->accel.advfunc_cntl & 0x04, dev->hdisp, dev->vdisp);
                 ibm8514_log("IBM mode set %s resolution.\n", (dev->accel.advfunc_cntl & 0x04) ? "2: 1024x768" : "1: 640x480");
                 svga_recalctimings(svga);
@@ -788,10 +785,10 @@ ibm8514_accel_in_fifo(svga_t *svga, uint16_t port, int len)
         case 0xdae9:
             if (len == 1) {
                 if (dev->force_busy2)
-                    temp |= 2; /*Hardware busy*/
+                    temp |= 0x02; /*Hardware busy*/
                 dev->force_busy2 = 0;
                 if (dev->data_available2) {
-                    temp |= 1; /*Read Data available*/
+                    temp |= 0x01; /*Read Data available*/
                     dev->data_available2 = 0;
                 }
             }
@@ -826,13 +823,18 @@ ibm8514_accel_in_fifo(svga_t *svga, uint16_t port, int len)
 uint8_t
 ibm8514_accel_in(uint16_t port, svga_t *svga)
 {
-    ibm8514_t *dev       = (ibm8514_t *) svga->dev8514;
-    uint8_t   temp       = 0;
+    ibm8514_t *dev = (ibm8514_t *) svga->dev8514;
+    uint8_t   temp = 0;
+    int16_t clip_t = dev->accel.clip_top;
+    int16_t clip_l = dev->accel.clip_left;
+    uint16_t clip_b_ibm = dev->accel.clip_bottom;
+    uint16_t clip_r_ibm = dev->accel.clip_right;
+    int cmd = dev->accel.cmd >> 13;
 
     switch (port) {
         case 0x2e8:
             if (dev->vc == dev->v_syncstart)
-                temp |= 2;
+                temp |= 0x02;
 
             ibm8514_log("0x2E8 read: Display Status=%02x.\n", temp);
             break;
@@ -860,7 +862,21 @@ ibm8514_accel_in(uint16_t port, svga_t *svga)
         case 0x42e8:
         case 0x42e9:
             if (dev->vc == dev->v_syncstart)
-                dev->subsys_stat |= 1;
+                dev->subsys_stat |= 0x01;
+
+            if (cmd == 6) {
+                if ((dev->accel.dx >= clip_l) &&
+                    (dev->accel.dx <= clip_r_ibm) &&
+                    (dev->accel.dy >= clip_t) &&
+                    (dev->accel.dy <= clip_b_ibm))
+                    dev->subsys_stat |= 0x02;
+            } else {
+                if ((dev->accel.cx >= clip_l) &&
+                    (dev->accel.cx <= clip_r_ibm) &&
+                    (dev->accel.cy >= clip_t) &&
+                    (dev->accel.cy <= clip_b_ibm))
+                    dev->subsys_stat |= 0x02;
+            }
 
             if (port & 1)
                 temp = dev->vram_512k_8514 ? 0x00 : 0x80;
@@ -1126,8 +1142,10 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
                     else
                         cpu_dat >>= 8;
 
-                    if (!dev->accel.ssv_len)
+                    if (!dev->accel.ssv_len) {
+                        dev->accel.cmd_back = 1;
                         break;
+                    }
 
                     switch (dev->accel.ssv_dir & 0xe0) {
                         case 0x00:
@@ -1219,8 +1237,10 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
                     else
                         cpu_dat >>= 8;
 
-                    if (!dev->accel.ssv_len)
+                    if (!dev->accel.ssv_len) {
+                        dev->accel.cmd_back = 1;
                         break;
+                    }
 
                     if (dev->accel.err_term >= dev->accel.maj_axis_pcnt) {
                         dev->accel.err_term += dev->accel.destx_distp;
@@ -1427,8 +1447,10 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
                         }
                     }
 
-                    if (!dev->accel.sy)
+                    if (!dev->accel.sy) {
+                        dev->accel.cmd_back = 1;
                         break;
+                    }
 
                     if (dev->accel.output)
                         mix_dat >>= 1;
@@ -1542,8 +1564,10 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
                         else
                             cpu_dat >>= 8;
 
-                        if (dev->accel.sy == 0)
+                        if (!dev->accel.sy) {
+                            dev->accel.cmd_back = 1;
                             break;
+                        }
 
                         if (dev->accel.cmd & 0x40) {
                             if (dev->accel.cmd & 0x80)
@@ -1642,8 +1666,10 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
                         else
                             cpu_dat >>= 8;
 
-                        if (dev->accel.sy == 0)
+                        if (!dev->accel.sy) {
+                            dev->accel.cmd_back = 1;
                             break;
+                        }
 
                         if (dev->accel.cmd & 0x40) {
                             if (dev->accel.cmd & 0x80)
@@ -1917,6 +1943,9 @@ skip_vector_rect_write:
 
                                 dev->accel.sy--;
                                 dev->accel.x_count = 0;
+
+                                if (dev->accel.sy < 0)
+                                    dev->accel.cmd_back = 1;
                                 return;
                             }
                         }
@@ -2072,6 +2101,9 @@ skip_nibble_rect_write:
 
                             dev->accel.sy--;
                             dev->accel.x_count = 0;
+
+                            if (dev->accel.sy < 0)
+                                dev->accel.cmd_back = 1;
                             return;
                         }
                     }
@@ -2154,6 +2186,9 @@ skip_nibble_rect_write:
                                         dev->accel.dest = (dev->accel.ge_offset << 2) + (dev->accel.cy * dev->pitch);
 
                                     dev->accel.sy--;
+
+                                    if (dev->accel.sy < 0)
+                                        dev->accel.cmd_back = 1;
                                     return;
                                 }
                             }
@@ -2236,6 +2271,7 @@ skip_nibble_rect_write:
                                             dev->accel.cur_x = dev->accel.cx;
                                             dev->accel.cur_y = dev->accel.cy;
                                         }
+                                        dev->accel.cmd_back = 1;
                                         return;
                                     }
                                 }
@@ -2314,6 +2350,7 @@ skip_nibble_rect_write:
 
                                 if (dev->accel.sy < 0) {
                                     ibm8514_log(".\n");
+                                    dev->accel.cmd_back = 1;
                                     return;
                                 }
                             }
@@ -2399,6 +2436,7 @@ skip_nibble_rect_write:
                                         dev->accel.cur_x = dev->accel.cx;
                                         dev->accel.cur_y = dev->accel.cy;
                                     }
+                                    dev->accel.cmd_back = 1;
                                     return;
                                 }
                             }
@@ -2499,8 +2537,10 @@ skip_nibble_rect_write:
                     else
                         cpu_dat >>= 8;
 
-                    if (!dev->accel.sy)
+                    if (!dev->accel.sy) {
+                        dev->accel.cmd_back = 1;
                         break;
+                    }
 
                     switch (dev->accel.cmd & 0xe0) {
                         case 0x00:
@@ -2601,8 +2641,10 @@ skip_nibble_rect_write:
                     else
                         cpu_dat >>= 8;
 
-                    if (!dev->accel.sy)
+                    if (!dev->accel.sy) {
+                        dev->accel.cmd_back = 1;
                         break;
+                    }
 
                     if (dev->accel.cmd & 0x40) {
                         dev->accel.oldcy = dev->accel.cy;
@@ -2856,6 +2898,9 @@ skip_nibble_bitblt_write:
 
                         dev->accel.sy--;
                         dev->accel.x_count = 0;
+
+                        if (dev->accel.sy < 0)
+                            dev->accel.cmd_back = 1;
                         return;
                     }
                 }
@@ -2953,6 +2998,9 @@ skip_nibble_bitblt_write:
                                 }
 
                                 dev->accel.sy--;
+
+                                if (dev->accel.sy < 0)
+                                    dev->accel.cmd_back = 1;
                                 return;
                             }
                         }
@@ -3047,6 +3095,7 @@ skip_nibble_bitblt_write:
                                 if (dev->accel.sy < 0) {
                                     dev->accel.destx = dev->accel.dx;
                                     dev->accel.desty = dev->accel.dy;
+                                    dev->accel.cmd_back = 1;
                                     return;
                                 }
                             }
@@ -3076,8 +3125,10 @@ skip_nibble_bitblt_write:
                             dx++;
 
                             dev->accel.sx--;
-                            if (dev->accel.sx < 0)
+                            if (dev->accel.sx < 0) {
+                                dev->accel.cmd_back = 1;
                                 return;
+                            }
                         }
                     } else {
                         while (count-- && dev->accel.sy >= 0) {
@@ -3187,6 +3238,7 @@ skip_nibble_bitblt_write:
                                 if (dev->accel.sy < 0) {
                                     dev->accel.destx = dev->accel.dx;
                                     dev->accel.desty = dev->accel.dy;
+                                    dev->accel.cmd_back = 1;
                                     return;
                                 }
                             }
@@ -3265,9 +3317,8 @@ ibm8514_render_15bpp(svga_t *svga)
     uint32_t  *p;
     uint32_t   dat;
 
-    if ((dev->displine + svga->y_add) < 0) {
+    if ((dev->displine + svga->y_add) < 0)
         return;
-    }
 
     if (dev->changedvram[dev->ma >> 12] || dev->changedvram[(dev->ma >> 12) + 1] || svga->fullchange) {
         p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
@@ -3306,9 +3357,8 @@ ibm8514_render_16bpp(svga_t *svga)
     uint32_t  *p;
     uint32_t   dat;
 
-    if ((dev->displine + svga->y_add) < 0) {
+    if ((dev->displine + svga->y_add) < 0)
         return;
-    }
 
     if (dev->changedvram[dev->ma >> 12] || dev->changedvram[(dev->ma >> 12) + 1] || svga->fullchange) {
         p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
@@ -3745,7 +3795,6 @@ ibm8514_mca_reset(void *priv)
 
     ibm8514_log("MCA reset.\n");
     dev->on = 0;
-    vga_on = 1;
 #ifdef ATI_8514_ULTRA
     if (dev->extensions)
         ati8514_mca_write(0x102, 0, svga);
@@ -3803,20 +3852,15 @@ ibm8514_init(const device_t *info)
                     dev->pos_regs[0] = 0x88;
                     dev->pos_regs[1] = 0x80;
                     mca_add(ati8514_mca_read, ati8514_mca_write, ibm8514_mca_feedb, ibm8514_mca_reset, svga);
-                    ati_eeprom_load(&mach->eeprom, "ati8514_mca.nvr", 0);
+                    ati_eeprom_load_mach8(&mach->eeprom, "ati8514_mca.nvr");
                     mem_mapping_disable(&dev->bios_rom.mapping);
                 } else {
                     rom_init(&dev->bios_rom,
                              BIOS_MACH8_ROM_PATH,
-                             bios_addr, 0x1000, 0xfff,
+                             bios_addr, 0x2000, 0x1fff,
                              0, MEM_MAPPING_EXTERNAL);
-                    rom_init(&dev->bios_rom2,
-                             BIOS_MACH8_ROM_PATH,
-                             bios_addr + 0x1000, 0x800, 0x7ff,
-                             0x1000, MEM_MAPPING_EXTERNAL);
-                    ati_eeprom_load(&mach->eeprom, "ati8514.nvr", 0);
                     mach->accel.scratch0 = (((bios_addr >> 7) - 0x1000) >> 4);
-                    mach->accel.scratch1 = mach->accel.scratch0 - 0x80;
+                    ati_eeprom_load_mach8(&mach->eeprom, "ati8514.nvr");
                 }
                 ati8514_init(svga, svga->ext8514, svga->dev8514);
                 break;

--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -113,12 +113,14 @@ mach_log(const char *fmt, ...)
 #define READ_PIXTRANS_BYTE_IO(cx, n) \
     if ((mach->accel.cmd_type == 2) || (mach->accel.cmd_type == 5)) { \
         if (dev->bpp) { \
-            if (n == 0) \
+            if (n == 0)\
                 mach->accel.pix_trans[(n)] = vram_w[(dev->accel.dest + (cx) + (n)) & (dev->vram_mask >> 1)] & 0xff; \
             else \
                 mach->accel.pix_trans[(n)] = vram_w[(dev->accel.dest + (cx) + (n)) & (dev->vram_mask >> 1)] >> 8; \
+            \
         } else \
             mach->accel.pix_trans[(n)] = dev->vram[(dev->accel.dest + (cx) + (n)) & dev->vram_mask]; \
+        \
     }
 
 #define READ_PIXTRANS_WORD(cx, n)                                                                    \
@@ -146,13 +148,13 @@ mach_log(const char *fmt, ...)
     }
 
 #define READ(addr, dat) \
-        if (dev->bpp) \
-            dat = vram_w[(addr) & (dev->vram_mask >> 1)]; \
-        else \
-            dat = dev->vram[(addr) & (dev->vram_mask)];
+    if (dev->bpp) \
+        dat = vram_w[(addr) & (dev->vram_mask >> 1)]; \
+    else \
+        dat = (dev->vram[(addr) & (dev->vram_mask)]);
 
 #define READ_HIGH(addr, dat) \
-        dat |= (dev->vram[(addr) & (dev->vram_mask)] << 8);
+    dat |= (dev->vram[(addr) & (dev->vram_mask)] << 8);
 
 #define MIX(mixmode, dest_dat, src_dat)                                                       \
     {                                                                                         \
@@ -265,7 +267,7 @@ mach_log(const char *fmt, ...)
 
 #define WRITE(addr, dat)                                         \
     if (dev->bpp) { \
-        vram_w[((addr)) & (dev->vram_mask >> 1)]                = dat; \
+        vram_w[((addr)) & (dev->vram_mask >> 1)]                    = dat; \
         dev->changedvram[(((addr)) & (dev->vram_mask >> 1)) >> 11] = changeframecount; \
     } else { \
         dev->vram[((addr)) & (dev->vram_mask)]                = dat; \
@@ -291,7 +293,7 @@ mach_pixel_read(mach_t *mach)
 }
 
 static void
-mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint32_t cpu_dat, mach_t *mach, ibm8514_t *dev)
+mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint32_t cpu_dat, svga_t *svga, mach_t *mach, ibm8514_t *dev)
 {
     int           compare_mode;
     uint16_t      poly_src     = 0;
@@ -309,10 +311,10 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
     uint16_t      mix       = 0;
     uint32_t      mono_dat0 = 0;
     uint32_t      mono_dat1 = 0;
-    int16_t      clip_t    = dev->accel.clip_top;
-    int16_t      clip_l    = dev->accel.clip_left;
-    int16_t      clip_b    = dev->accel.clip_bottom;
-    int16_t      clip_r    = dev->accel.clip_right;
+    int16_t       clip_t    = dev->accel.clip_top;
+    int16_t       clip_l    = dev->accel.clip_left;
+    int16_t       clip_b    = dev->accel.clip_bottom;
+    int16_t       clip_r    = dev->accel.clip_right;
 
     if (!dev->bpp) {
         rd_mask &= 0xff;
@@ -541,10 +543,13 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                         }
                     }
 
-                    if ((mono_src == 1) && !count)
+                    if ((mono_src == 1) && !count) {
+                        dev->accel.cmd_back = 1;
                         break;
-                    else if ((mono_src != 1) && (dev->accel.sx >= mach->accel.width))
+                    } else if ((mono_src != 1) && (dev->accel.sx >= mach->accel.width)) {
+                        dev->accel.cmd_back = 1;
                         break;
+                    }
 
                     if (dev->bpp)
                         cpu_dat >>= 16;
@@ -762,10 +767,13 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                         }
                     }
 
-                    if ((mono_src == 1) && !count)
+                    if ((mono_src == 1) && !count) {
+                        dev->accel.cmd_back = 1;
                         break;
-                    else if ((mono_src != 1) && (dev->accel.sx >= mach->accel.width))
+                    } else if ((mono_src != 1) && (dev->accel.sx >= mach->accel.width)) {
+                        dev->accel.cmd_back = 1;
                         break;
+                    }
 
                     if (dev->bpp)
                         cpu_dat >>= 16;
@@ -834,6 +842,7 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                 if (mach->accel.dest_x_start >= 0x600)
                     mach->accel.dx_start |= ~0x5ff;
 
+                mach_log("DXStart=%d, CURX=%d.\n", mach->accel.dx_start, dev->accel.dx);
                 mach->accel.dx_end = mach->accel.dest_x_end;
                 if (mach->accel.dest_x_end >= 0x600)
                     mach->accel.dx_end |= ~0x5ff;
@@ -975,12 +984,14 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
 
             if (mach->accel.dy_end == mach->accel.dy_start) {
                 mach_log("No DEST.\n");
+                dev->accel.cmd_back = 1;
                 return;
             }
 
             if ((mono_src == 3) || (bkgd_sel == 3) || (frgd_sel == 3)) {
                 if (mach->accel.sx_end == mach->accel.sx_start) {
                     mach_log("No SRC.\n");
+                    dev->accel.cmd_back = 1;
                     return;
                 }
             }
@@ -990,6 +1001,7 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                     mach_log("DPCONFIG 3251: monosrc=%d, frgdsel=%d, bkgdsel=%d, pitch=%d.\n", mono_src, frgd_sel, bkgd_sel, dev->pitch);
                     if (dev->accel.sy == mach->accel.height) {
                         mach_log("No Blit on DPCONFIG=3251.\n");
+                        dev->accel.cmd_back = 1;
                         return;
                     }
                 }
@@ -1127,20 +1139,14 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                         }
 
                         if (mach->accel.dp_config & 0x10) {
-                            if (mach->accel.block_write_mono_pattern_enable) {
-                                if (mix) {
-                                    WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
-                                }
-                            } else {
-                                if ((dev->accel_bpp == 24) && (mono_src == 1) && (frgd_sel == 5) && !mach->accel.mono_pattern_enable) {
-                                    if (dev->accel.sy & 1) {
-                                        WRITE(dev->accel.dest + dev->accel.dx - dev->pitch, dest_dat);
-                                    } else {
-                                        WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
-                                    }
+                            if ((dev->accel_bpp == 24) && (mono_src == 1) && (frgd_sel == 5) && !mach->accel.mono_pattern_enable) {
+                                if (dev->accel.sy & 1) {
+                                    WRITE(dev->accel.dest + dev->accel.dx - dev->pitch, dest_dat);
                                 } else {
                                     WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
                                 }
+                            } else {
+                                WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
                             }
                         }
                     }
@@ -1208,9 +1214,10 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                     }
 
                     if (dev->accel.sy >= mach->accel.height) {
+                        dev->accel.cmd_back = 1;
                         if ((mono_src == 2) || (mono_src == 3) || (frgd_sel == 3) || (bkgd_sel == 3) || (mach->accel.dp_config & 0x02))
                             return;
-                        if ((mono_src == 1) && (frgd_sel == 5) &&  (dev->accel_bpp == 24))
+                        if ((mono_src == 1) && (frgd_sel == 5) && (dev->accel_bpp == 24))
                             return;
                         dev->accel.cur_x = dev->accel.dx;
                         dev->accel.cur_y = dev->accel.dy;
@@ -1360,8 +1367,10 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                         } else
                             mach->accel.clip_overrun = ((mach->accel.clip_overrun + 1) & 0x0f);
 
-                        if (!count)
+                        if (!count) {
+                            dev->accel.cmd_back = 1;
                             break;
+                        }
 
                         if (dev->bpp)
                             cpu_dat >>= 16;
@@ -1527,8 +1536,10 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                         } else
                             mach->accel.clip_overrun = ((mach->accel.clip_overrun + 1) & 0x0f);
 
-                        if (dev->accel.sx >= mach->accel.width)
+                        if (dev->accel.sx >= mach->accel.width) {
+                            dev->accel.cmd_back = 1;
                             break;
+                        }
 
                         if (dev->bpp)
                             cpu_dat >>= 16;
@@ -1648,8 +1659,10 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                         } else
                             mach->accel.clip_overrun = ((mach->accel.clip_overrun + 1) & 0x0f);
 
-                        if (!count)
+                        if (!count) {
+                            dev->accel.cmd_back = 1;
                             break;
+                        }
 
                         if (dev->bpp)
                             cpu_dat >>= 16;
@@ -1803,8 +1816,10 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                         } else
                             mach->accel.clip_overrun = ((mach->accel.clip_overrun + 1) & 0x0f);
 
-                        if (dev->accel.sx >= mach->accel.width)
+                        if (dev->accel.sx >= mach->accel.width) {
+                            dev->accel.cmd_back = 1;
                             break;
+                        }
 
                         if (dev->bpp)
                             cpu_dat >>= 16;
@@ -2098,13 +2113,14 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                     dev->accel.sx = 0;
                     dev->accel.dy += mach->accel.stepy;
                     if (dev->bpp)
-                        dev->accel.dest = (mach->accel.ge_offset << 1) + (dev->accel.dy * (dev->pitch));
+                        dev->accel.dest = (mach->accel.ge_offset << 1) + (dev->accel.dy * dev->pitch);
                     else
-                        dev->accel.dest = (mach->accel.ge_offset << 2) + (dev->accel.dy * (dev->pitch));
+                        dev->accel.dest = (mach->accel.ge_offset << 2) + (dev->accel.dy * dev->pitch);
                     if (mach->accel.line_idx == 2) {
                         mach->accel.line_array[0] = dev->accel.dx;
                         mach->accel.line_array[4] = dev->accel.dx;
                     }
+                    dev->accel.cmd_back = 1;
                     return;
                 }
             }
@@ -2116,7 +2132,7 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
 }
 
 static void
-mach_accel_out_pixtrans(mach_t *mach, ibm8514_t *dev, uint16_t val)
+mach_accel_out_pixtrans(svga_t *svga, mach_t *mach, ibm8514_t *dev, uint16_t val)
 {
     int frgd_sel;
     int bkgd_sel;
@@ -2141,11 +2157,11 @@ mach_accel_out_pixtrans(mach_t *mach, ibm8514_t *dev, uint16_t val)
                         mach_log("8-bit bus size swap.\n");
                         val = (val >> 8) | (val << 8);
                     }
-                    mach_accel_start(mach->accel.cmd_type, 1, 8, val | (val << 16), 0, mach, dev);
+                    mach_accel_start(mach->accel.cmd_type, 1, 8, val | (val << 16), 0, svga, mach, dev);
                 } else
-                    mach_accel_start(mach->accel.cmd_type, 1, 1, -1, val | (val << 16), mach, dev);
+                    mach_accel_start(mach->accel.cmd_type, 1, 1, -1, val | (val << 16), svga, mach, dev);
             } else
-                mach_accel_start(mach->accel.cmd_type, 1, 1, -1, val | (val << 16), mach, dev);
+                mach_accel_start(mach->accel.cmd_type, 1, 1, -1, val | (val << 16), svga, mach, dev);
             break;
         case 0x200: /*16-bit size*/
             if (mono_src == 2) {
@@ -2154,11 +2170,11 @@ mach_accel_out_pixtrans(mach_t *mach, ibm8514_t *dev, uint16_t val)
                         mach_log("16-bit bus size swap.\n");
                         val = (val >> 8) | (val << 8);
                     }
-                    mach_accel_start(mach->accel.cmd_type, 1, 16, val | (val << 16), 0, mach, dev);
+                    mach_accel_start(mach->accel.cmd_type, 1, 16, val | (val << 16), 0, svga, mach, dev);
                 } else
-                    mach_accel_start(mach->accel.cmd_type, 1, 2, -1, val | (val << 16), mach, dev);
+                    mach_accel_start(mach->accel.cmd_type, 1, 2, -1, val | (val << 16), svga, mach, dev);
             } else
-                mach_accel_start(mach->accel.cmd_type, 1, 2, -1, val | (val << 16), mach, dev);
+                mach_accel_start(mach->accel.cmd_type, 1, 2, -1, val | (val << 16), svga, mach, dev);
             break;
 
         default:
@@ -2171,13 +2187,23 @@ mach_out(uint16_t addr, uint8_t val, void *priv)
 {
     mach_t          *mach = (mach_t *) priv;
     svga_t          *svga = &mach->svga;
-    const ibm8514_t *dev  = (ibm8514_t *) svga->dev8514;
+    ibm8514_t       *dev  = (ibm8514_t *) svga->dev8514;
     uint8_t          old;
     uint8_t          rs2;
     uint8_t          rs3;
 
     if (((addr & 0xFFF0) == 0x3D0 || (addr & 0xFFF0) == 0x3B0) && !(svga->miscout & 1))
         addr ^= 0x60;
+
+    if (((dev->disp_cntl & 0x60) == 0x20) && ((dev->local & 0xff) >= 0x02)) {
+        if ((addr >= 0x3c7) && (addr <= 0x3c9)) {
+            if (dev->bpp && !(svga->attrregs[0x10] & 0x40))
+                addr -= 0xdc;
+
+            mach_log("VGA DAC write regs=%03x, on=%d, display control=%02x, on1=%x, clocksel=%02x.\n", addr, dev->on, dev->disp_cntl & 0x60, dev->accel.advfunc_cntl & 0x01, mach->accel.clock_sel & 0x01);
+        } else if ((addr >= 0x2eb) && (addr <= 0x2ed))
+            mach_log("8514/A DAC write regs=%03x, on=%d, display control=%02x, on1=%x, clocksel=%02x.\n", addr, dev->on, dev->disp_cntl & 0x60, dev->accel.advfunc_cntl & 0x01, mach->accel.clock_sel & 0x01);
+    }
 
     switch (addr) {
         case 0x1ce:
@@ -2186,25 +2212,33 @@ mach_out(uint16_t addr, uint8_t val, void *priv)
         case 0x1cf:
             old                     = mach->regs[mach->index];
             mach->regs[mach->index] = val;
-            mach_log("ATI VGA write reg=0x%02X, val=0x%02X\n", mach->index, val);
+            mach_log("ATI VGA write reg=%02x, val=%02x.\n", mach->index, val);
             switch (mach->index) {
                 case 0xa3:
-                    if ((old ^ val) & 0x10)
+                    if ((old ^ val) & 0x10) {
+                        mach_log("ATI A3 bit 7.\n");
                         svga_recalctimings(svga);
+                    }
                     break;
                 case 0xa7:
-                    if ((old ^ val) & 0x80)
+                    if ((old ^ val) & 0x80) {
+                        mach_log("ATI A7 bit 7.\n");
                         svga_recalctimings(svga);
+                    }
                     break;
                 case 0xad:
                     if ((dev->local & 0xff) >= 0x02) {
-                        if ((old ^ val) & 0x0c)
+                        if ((old ^ val) & 0x0c) {
+                            mach_log("ATI AD bits 2-3.\n");
                             svga_recalctimings(svga);
+                        }
                     }
                     break;
                 case 0xb0:
-                    if ((old ^ val) & 0x60)
+                    if ((old ^ val) & 0x60) {
+                        mach_log("ATI B0 bits 5-6: old=%02x, val=%02x.\n", old & 0x60, val & 0x60);
                         svga_recalctimings(svga);
+                    }
                     break;
                 case 0xae:
                 case 0xb2:
@@ -2232,34 +2266,41 @@ mach_out(uint16_t addr, uint8_t val, void *priv)
                     svga->write_bank = mach->bank_w << 16;
 
                     if (mach->index == 0xbe) {
-                        if ((old ^ val) & 0x10)
+                        if ((old ^ val) & 0x10) {
+                            mach_log("ATI BE bit 4.\n");
                             svga_recalctimings(svga);
+                        }
                     }
                     break;
                 case 0xbd:
-                    if ((old ^ val) & 4) {
+                    if ((old ^ val) & 0x04)
                         mach32_updatemapping(mach, svga);
-                    }
                     break;
                 case 0xb3:
-                    ati_eeprom_write(&mach->eeprom, val & 8, val & 2, val & 1);
+                    ati_eeprom_write(&mach->eeprom, val & 0x08, val & 0x02, val & 0x01);
                     break;
                 case 0xb6:
-                    if ((old ^ val) & 0x10)
+                    if ((old ^ val) & 0x10) {
+                        mach_log("ATI B6 bit 4.\n");
                         svga_recalctimings(svga);
+                    }
                     break;
                 case 0xb8:
                     if ((dev->local & 0xff) >= 0x02) {
-                        if ((old ^ val) & 0x40)
+                        if ((old ^ val) & 0x40) {
+                            mach_log("ATI B8 bit 6.\n");
                             svga_recalctimings(svga);
+                        }
                     } else {
                         if ((old ^ val) & 0xc0)
                             svga_recalctimings(svga);
                     }
                     break;
                 case 0xb9:
-                    if ((old ^ val) & 2)
+                    if ((old ^ val) & 0x02) {
+                        mach_log("ATI B9 bit 1.\n");
                         svga_recalctimings(svga);
+                    }
                     break;
 
                 default:
@@ -2274,10 +2315,20 @@ mach_out(uint16_t addr, uint8_t val, void *priv)
             rs2 = !!(mach->accel.ext_ge_config & 0x1000);
             rs3 = !!(mach->accel.ext_ge_config & 0x2000);
             if ((dev->local & 0xff) >= 0x02) {
+                if (addr != 0x2ea) {
+                    if (!(dev->accel.advfunc_cntl & 0x01) && !(mach->accel.clock_sel & 0x01) && ((svga->gdcreg[6] & 0x01) || (svga->attrregs[0x10] & 0x01)))
+                        dev->on |= 0x01;
+                }
+
                 if (mach->pci_bus && !mach->ramdac_type)
-                    ati68860_ramdac_out((addr & 3) | (rs2 << 2) | (rs3 << 3), val, svga->ramdac, svga);
+                    ati68860_ramdac_out((addr & 0x03) | (rs2 << 2) | (rs3 << 3), val, svga->ramdac, svga);
                 else
                     ati68875_ramdac_out(addr, rs2, rs3, val, svga->ramdac, svga);
+
+                if (addr != 0x2ea) {
+                    svga_recalctimings(svga);
+                    mach32_updatemapping(mach, svga);
+                }
             } else
                 svga_out(addr, val, svga);
             return;
@@ -2289,10 +2340,20 @@ mach_out(uint16_t addr, uint8_t val, void *priv)
             rs2 = !!(mach->regs[0xa0] & 0x20);
             rs3 = !!(mach->regs[0xa0] & 0x40);
             if ((dev->local & 0xff) >= 0x02) {
+                if (addr != 0x3C6) {
+                    if (!(dev->accel.advfunc_cntl & 0x01) && ((mach->accel.clock_sel & 0x01) || (svga->attrregs[0x10] & 0x40)))
+                        dev->on &= ~0x01;
+                }
+
                 if (mach->pci_bus && !mach->ramdac_type)
-                    ati68860_ramdac_out((addr & 3) | (rs2 << 2) | (rs3 << 3), val, svga->ramdac, svga);
+                    ati68860_ramdac_out((addr & 0x03) | (rs2 << 2) | (rs3 << 3), val, svga->ramdac, svga);
                 else
                     ati68875_ramdac_out(addr, rs2, rs3, val, svga->ramdac, svga);
+
+                if (addr != 0x3C6) {
+                    svga_recalctimings(svga);
+                    mach32_updatemapping(mach, svga);
+                }
             } else
                 svga_out(addr, val, svga);
             return;
@@ -2334,7 +2395,7 @@ mach_in(uint16_t addr, void *priv)
 {
     mach_t          *mach = (mach_t *) priv;
     svga_t          *svga = &mach->svga;
-    const ibm8514_t *dev  = (ibm8514_t *) svga->dev8514;
+    ibm8514_t       *dev  = (ibm8514_t *) svga->dev8514;
     uint8_t          temp = 0xff;
     uint8_t          rs2;
     uint8_t          rs3;
@@ -2342,8 +2403,11 @@ mach_in(uint16_t addr, void *priv)
     if (((addr & 0xFFF0) == 0x3D0 || (addr & 0xFFF0) == 0x3B0) && !(svga->miscout & 1))
         addr ^= 0x60;
 
-    if ((addr >= 0x3c6) && (addr <= 0x3c9) && dev->on)
+    if ((addr >= 0x3c6) && (addr <= 0x3c9)) {
         addr -= 0xdc;
+        mach_log("VGA DAC read regs=%03x.\n", addr);
+    } else if ((addr >= 0x2ea) && (addr <= 0x2ed))
+        mach_log("8514/A DAC read regs=%03x.\n", addr);
 
     switch (addr) {
         case 0x1ce:
@@ -2419,19 +2483,62 @@ mach_in(uint16_t addr, void *priv)
 
 
 #ifdef ATI_8514_ULTRA
-static void
+void
 ati8514_out(uint16_t addr, uint8_t val, void *priv)
 {
+    svga_t *svga = (svga_t *)priv;
+    ibm8514_t *dev  = (ibm8514_t *) svga->dev8514;
+
     mach_log("[%04X:%08X]: ADDON OUT addr=%03x, val=%02x.\n", CS, cpu_state.pc, addr, val);
-    svga_out(addr, val, priv);
+
+    switch (addr) {
+        case 0x0102:
+            dev->pos_regs[2] = val;
+            mem_mapping_disable(&dev->bios_rom.mapping);
+            if (dev->pos_regs[2] & 0x01)
+                mem_mapping_enable(&dev->bios_rom.mapping);
+            break;
+        case 0x0103:
+            dev->pos_regs[3] = val;
+            dev->bios_addr = 0xc0000 + (((dev->pos_regs[3] >> 1) & 0x7f) << 11);
+            if (dev->pos_regs[3] & 0x01)
+                mem_mapping_set_addr(&dev->bios_rom.mapping, dev->bios_addr, 0x2000);
+            break;
+        case 0x0104:
+        case 0x0105:
+        case 0x0106:
+        case 0x0107:
+            dev->pos_regs[addr & 7] = val;
+            break;
+        default:
+            svga_out(addr, val, priv);
+            break;
+    }
 }
 
-static uint8_t
+uint8_t
 ati8514_in(uint16_t addr, void *priv)
 {
+    svga_t *svga = (svga_t *)priv;
+    ibm8514_t *dev  = (ibm8514_t *) svga->dev8514;
     uint8_t temp = 0xff;
 
-    temp = svga_in(addr, priv);
+    switch (addr) {
+        case 0x0100:
+        case 0x0101:
+        case 0x0102:
+        case 0x0103:
+        case 0x0104:
+        case 0x0105:
+        case 0x0106:
+        case 0x0107:
+            temp = dev->pos_regs[addr & 7];
+            break;
+        default:
+            temp = svga_in(addr, priv);
+            break;
+
+    }
 
     mach_log("[%04X:%08X]: ADDON IN addr=%03x, temp=%02x.\n", CS, cpu_state.pc, addr, temp);
     return temp;
@@ -2446,6 +2553,8 @@ ati8514_recalctimings(svga_t *svga)
     mach_log("ON=%d, vgahdisp=%d.\n", dev->on, svga->hdisp);
     if (dev->on) {
         mach_log("8514/A ON.\n");
+        dev->pitch                      = dev->ext_pitch;
+        dev->rowoffset                  = dev->ext_crt_pitch;
         dev->h_total                    = dev->htotal + 1;
         dev->rowcount                   = !!(dev->disp_cntl & 0x08);
         dev->accel.ge_offset            = (mach->accel.ge_offset_lo | (mach->accel.ge_offset_hi << 16));
@@ -2453,13 +2562,13 @@ ati8514_recalctimings(svga_t *svga)
 
         mach_log("HDISP=%d, VDISP=%d, shadowset=%x, 8514/A mode=%x, clocksel=%02x.\n", dev->hdisp, dev->vdisp, mach->shadow_set & 0x03, dev->accel.advfunc_cntl & 0x04, mach->accel.clock_sel & 0xfe);
 
-        if (dev->hdisp) {
+        if (mach->accel.clock_sel & 0x01) {
             dev->h_disp = dev->hdisp;
             dev->dispend = dev->vdisp;
         } else {
             if (dev->accel.advfunc_cntl & 0x04) {
-                dev->h_disp = 1024;
-                dev->dispend = 768;
+                dev->h_disp = dev->hdisp;
+                dev->dispend = dev->vdisp;
             } else {
                 dev->h_disp = 640;
                 dev->dispend = 480;
@@ -2474,17 +2583,6 @@ ati8514_recalctimings(svga_t *svga)
         if (dev->interlace)
             dev->dispend >>= 1;
 
-        if (dev->dispend == 766)
-            dev->dispend += 2;
-
-        if (dev->dispend == 598)
-            dev->dispend += 2;
-
-        if (dev->dispend == 478)
-            dev->dispend += 2;
-
-        dev->pitch = dev->ext_pitch;
-        dev->rowoffset = dev->ext_crt_pitch;
         mach_log("cntl=%d, hv(%d,%d), pitch=%d, rowoffset=%d, gextconfig=%03x, shadow=%x interlace=%d.\n", dev->accel.advfunc_cntl & 0x04, dev->h_disp, dev->dispend, dev->pitch, dev->rowoffset, mach->accel.ext_ge_config & 0xcec0, mach->shadow_set & 3, dev->interlace);
         svga->map8 = dev->pallook;
         if (dev->vram_512k_8514) {
@@ -2498,14 +2596,6 @@ ati8514_recalctimings(svga_t *svga)
         }
         dev->accel_bpp = 8;
         svga->render8514 = ibm8514_render_8bpp;
-    } else {
-        if (!(svga->gdcreg[6] & 1) && !(svga->attrregs[0x10] & 1)) { /*Text mode*/
-            if (svga->seqregs[1] & 8) {                              /*40 column*/
-                svga->render = svga_render_text_40;
-            } else {
-                svga->render = svga_render_text_80;
-            }
-        }
     }
 }
 #endif
@@ -2541,11 +2631,9 @@ mach_recalctimings(svga_t *svga)
         svga->htotal <<= 1;
         svga->dots_per_clock <<= 1;
         svga->rowoffset <<= 1;
-        svga->gdcreg[5] &= ~0x40;
     }
 
     if (mach->regs[0xb0] & 0x20) {
-        svga->gdcreg[5] |= 0x40;
         if ((mach->regs[0xb6] & 0x18) >= 0x10)
             svga->packed_4bpp = 1;
         else
@@ -2554,7 +2642,7 @@ mach_recalctimings(svga_t *svga)
         svga->packed_4bpp = 0;
 
     if ((dev->local & 0xff) < 0x02) {
-        if ((mach->regs[0xb6] & 0x18) == 8) {
+        if ((mach->regs[0xb6] & 0x18) == 0x08) {
             svga->hdisp <<= 1;
             svga->htotal <<= 1;
             svga->dots_per_clock <<= 1;
@@ -2563,8 +2651,7 @@ mach_recalctimings(svga_t *svga)
             svga->ati_4color = 0;
     }
 
-    svga->render8514 = ibm8514_render_blank;
-    mach_log("ON?=%d.\n", dev->on);
+    mach_log("ON?=%d, override=%d.\n", dev->on, svga->override);
     if (dev->on) {
         mach_log("8514/A ON, extpitch=%d, devma=%x, vgamalatch=%x.\n", dev->ext_pitch, dev->ma, svga->ma_latch);
         dev->pitch                      = dev->ext_pitch;
@@ -2576,7 +2663,7 @@ mach_recalctimings(svga_t *svga)
 
         mach_log("HDISP=%d, VDISP=%d, shadowset=%x, 8514/A mode=%x, clocksel=%02x, interlace=%x.\n", dev->hdisp, dev->vdisp, mach->shadow_set & 0x03, dev->accel.advfunc_cntl & 0x04, mach->accel.clock_sel & 0xfe, dev->interlace);
         if ((dev->local & 0xff) >= 0x02) {
-            if (dev->bpp || (dev->accel_bpp >= 24) || (mach->accel.clock_sel & 0x01)) {
+            if (dev->bpp || ((mach->accel.ext_ge_config & 0x30) == 0x30) || (mach->accel.clock_sel & 0x01)) {
                 dev->h_disp = dev->hdisp;
                 dev->dispend = dev->vdisp;
             } else {
@@ -2647,6 +2734,8 @@ mach_recalctimings(svga_t *svga)
                     }
                     dev->accel_bpp = 8;
                 }
+
+                svga->render8514 = ibm8514_render_blank;
                 mach_log("hv(%d,%d), pitch=%d, rowoffset=%d, gextconfig=%03x, bpp=%d, shadow=%x, vgahdisp=%d.\n", dev->h_disp, dev->dispend, dev->pitch, dev->ext_crt_pitch, mach->accel.ext_ge_config & 0xcec0, dev->accel_bpp, mach->shadow_set & 3, svga->hdisp);
                 switch (dev->accel_bpp) {
                     case 8:
@@ -2678,8 +2767,8 @@ mach_recalctimings(svga_t *svga)
                 }
             }
         } else {
+            svga->render8514 = ibm8514_render_blank;
             mach_log("cntl=%d, hv(%d,%d), pitch=%d, rowoffset=%d, gextconfig=%03x, shadow=%x interlace=%d.\n", dev->accel.advfunc_cntl & 0x04, dev->h_disp, dev->dispend, dev->pitch, dev->rowoffset, mach->accel.ext_ge_config & 0xcec0, mach->shadow_set & 3, dev->interlace);
-            svga->map8 = dev->pallook;
             if (dev->vram_512k_8514) {
                 if (dev->h_disp == 640) {
                     dev->ext_pitch = 640;
@@ -2691,67 +2780,47 @@ mach_recalctimings(svga_t *svga)
             }
             dev->accel_bpp = 8;
             svga->render8514 = ibm8514_render_8bpp;
+            goto mach8_vga_modes;
         }
-    }
+    } else {
+mach8_vga_modes:
+        if (!svga->scrblank && (svga->crtc[0x17] & 0x80) && svga->attr_palette_enable) {
+            mach_log("GDCREG5=%02x, ATTR10=%02x, ATI B0 bit 5=%02x, ON=%d.\n", svga->gdcreg[5] & 0x60, svga->attrregs[0x10] & 0x40, mach->regs[0xb0] & 0x20, dev->on);
+            if ((svga->gdcreg[6] & 0x01) || (svga->attrregs[0x10] & 0x01)) {
+                if ((svga->gdcreg[5] & 0x40) || (svga->attrregs[0x10] & 0x40) || (mach->regs[0xb0] & 0x20)) {
+                    svga->clock = (cpuclock * (double) (1ULL << 32)) / svga->getclock(clock_sel, svga->clock_gen);
+                    mach_log("VGA clock=%02x.\n", mach->regs[0xa7] & 0x80);
+                    if ((dev->local & 0xff) >= 0x02) {
+                        if (mach->regs[0xb8] & 0x40)
+                            svga->clock *= 2;
+                    } else {
+                        switch (mach->regs[0xb8] & 0xc0) {
+                            case 0x40:
+                                svga->clock *= 2;
+                                break;
+                            case 0x80:
+                                svga->clock *= 3;
+                                break;
+                            case 0xc0:
+                                svga->clock *= 4;
+                                break;
 
-    if (!svga->scrblank && (svga->crtc[0x17] & 0x80) && svga->attr_palette_enable) {
-        if (((svga->gdcreg[6] & 1) || (svga->attrregs[0x10] & 1))) {
-            svga->clock = (cpuclock * (double) (1ULL << 32)) / svga->getclock(clock_sel, svga->clock_gen);
-            mach_log("VGA clock=%02x.\n", mach->regs[0xa7] & 0x80);
-            if ((dev->local & 0xff) >= 0x02) {
-                if (mach->regs[0xb8] & 0x40)
-                    svga->clock *= 2;
-            } else {
-                switch (mach->regs[0xb8] & 0xc0) {
-                    case 0x40:
-                        svga->clock *= 2;
-                        break;
-                    case 0x80:
-                        svga->clock *= 3;
-                        break;
-                    case 0xc0:
-                        svga->clock *= 4;
-                        break;
-
-                    default:
-                        break;
-                }
-            }
-            switch (svga->gdcreg[5] & 0x60) {
-                case 0x00:
-                    if (svga->seqregs[1] & 8) /*Low res (320)*/
-                        svga->render = svga_render_4bpp_lowres;
-                    else
-                        svga->render = svga_render_4bpp_highres;
-                    break;
-                case 0x20:                    /*4 colours*/
-                    if (svga->seqregs[1] & 8) /*Low res (320)*/
-                        svga->render = svga_render_2bpp_lowres;
-                    else
-                        svga->render = svga_render_2bpp_highres;
-                    break;
-                case 0x40:
-                case 0x60: /*256+ colours*/
-                    switch (svga->bpp) {
-                        default:
-                        case 8:
-                            svga->map8 = svga->pallook;
-                            mach_log("Lowres=%x, seqreg[1]bit3=%x.\n", svga->lowres, svga->seqregs[1] & 8);
-                            if (svga->lowres)
-                                svga->render = svga_render_8bpp_lowres;
-                            else {
-                                svga->render = svga_render_8bpp_highres;
-                                if (!svga->packed_4bpp) {
-                                    svga->ma_latch <<= 1;
-                                    svga->rowoffset <<= 1;
-                                }
-                            }
-                            break;
+                            default:
+                                break;
+                        }
                     }
-                    break;
-
-                default:
-                    break;
+                    svga->map8 = svga->pallook;
+                    mach_log("Lowres=%x, seqreg[1]bit3=%x.\n", svga->lowres, svga->seqregs[1] & 8);
+                    if (svga->lowres)
+                        svga->render = svga_render_8bpp_lowres;
+                    else {
+                        svga->render = svga_render_8bpp_highres;
+                        if (!svga->packed_4bpp) {
+                            svga->ma_latch <<= 1;
+                            svga->rowoffset <<= 1;
+                        }
+                    }
+                }
             }
         }
     }
@@ -2769,7 +2838,6 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
     switch (port) {
         case 0x82e8:
         case 0x86e8:
-        case 0x86e9:
         case 0xc2e8:
         case 0xc6e8:
             ibm8514_accel_out_fifo(svga, port, val, len);
@@ -2825,11 +2893,12 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                 if (len == 2) {
                     if (dev->accel.cmd_back) {
                         dev->accel.bkgd_color = val;
+                        mach_log("CMDBack BKGDCOLOR, sy=%d, height=%d, val=%04x.\n", dev->accel.sy, mach->accel.height, val);
                     } else {
                         if (mach->accel.cmd_type >= 0) {
                             if (mach_pixel_read(mach))
                                 break;
-                            mach_accel_out_pixtrans(mach, dev, val);
+                            mach_accel_out_pixtrans(svga, mach, dev, val);
                         } else {
                             if (ibm8514_cpu_dest(svga))
                                 break;
@@ -2853,13 +2922,13 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
         case 0xe6e8:
             if (port == 0xe6e8) {
                 if (len == 2) {
-                    if (dev->accel.cmd_back) {
+                    if (dev->accel.cmd_back)
                         dev->accel.frgd_color = val;
-                    } else {
+                    else {
                         if (mach->accel.cmd_type >= 0) {
                             if (mach_pixel_read(mach))
                                 break;
-                            mach_accel_out_pixtrans(mach, dev, val);
+                            mach_accel_out_pixtrans(svga, mach, dev, val);
                         } else {
                             if (ibm8514_cpu_dest(svga))
                                 break;
@@ -2895,23 +2964,23 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                         case 0x000: /*8-bit size*/
                             if (mono_src == 2) {
                                 if ((frgd_sel != 2) && (bkgd_sel != 2)) {
-                                    mach_accel_start(mach->accel.cmd_type, 1, 8, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), 0, mach, dev);
+                                    mach_accel_start(mach->accel.cmd_type, 1, 8, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), 0, svga, mach, dev);
                                 } else
-                                    mach_accel_start(mach->accel.cmd_type, 1, 1, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), mach, dev);
+                                    mach_accel_start(mach->accel.cmd_type, 1, 1, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), svga, mach, dev);
                             } else
-                                mach_accel_start(mach->accel.cmd_type, 1, 1, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), mach, dev);
+                                mach_accel_start(mach->accel.cmd_type, 1, 1, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), svga, mach, dev);
                             break;
                         case 0x200: /*16-bit size*/
                             if (mono_src == 2) {
                                 if ((frgd_sel != 2) && (bkgd_sel != 2)) {
                                     if (mach->accel.dp_config & 0x1000)
-                                        mach_accel_start(mach->accel.cmd_type, 1, 16, mach->accel.pix_trans[1] | (mach->accel.pix_trans[0] << 8), 0, mach, dev);
+                                        mach_accel_start(mach->accel.cmd_type, 1, 16, mach->accel.pix_trans[1] | (mach->accel.pix_trans[0] << 8), 0, svga, mach, dev);
                                     else
-                                        mach_accel_start(mach->accel.cmd_type, 1, 16, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), 0, mach, dev);
+                                        mach_accel_start(mach->accel.cmd_type, 1, 16, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), 0, svga, mach, dev);
                                 } else
-                                    mach_accel_start(mach->accel.cmd_type, 1, 2, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), mach, dev);
+                                    mach_accel_start(mach->accel.cmd_type, 1, 2, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), svga, mach, dev);
                             } else
-                                mach_accel_start(mach->accel.cmd_type, 1, 2, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), mach, dev);
+                                mach_accel_start(mach->accel.cmd_type, 1, 2, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), svga, mach, dev);
                             break;
 
                         default:
@@ -2919,22 +2988,17 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                     }
                 }
             }
+            mach_log("Write Port=%04x, Busy=%02x.\n", port, dev->force_busy2);
             break;
 
         case 0xaae8:
-        case 0xaae9:
         case 0xaee8:
-        case 0xaee9:
         case 0xb2e8:
-        case 0xb2e9:
         case 0xb6e8:
         case 0xbae8:
         case 0xeae8:
-        case 0xeae9:
         case 0xeee8:
-        case 0xeee9:
         case 0xf2e8:
-        case 0xf2e9:
         case 0xf6e8:
         case 0xfae8:
             ibm8514_accel_out_fifo(svga, port, val, len);
@@ -2983,10 +3047,18 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             if (len == 2) {
                 mach->accel.bres_count = val & 0x7ff;
                 mach_log("BresenhamDraw=%04x.\n", mach->accel.dp_config);
-                dev->data_available  = 0;
+                dev->data_available = 0;
                 dev->data_available2 = 0;
                 mach->accel.cmd_type = 1;
-                mach_accel_start(mach->accel.cmd_type, 0, -1, -1, 0, mach, dev);
+                frgd_sel = (mach->accel.dp_config >> 13) & 7;
+                bkgd_sel = (mach->accel.dp_config >> 7) & 3;
+                mono_src = (mach->accel.dp_config >> 5) & 3;
+
+                dev->accel.cmd_back = 1;
+                if ((mono_src == 2) || (bkgd_sel == 2) || (frgd_sel == 2) || mach_pixel_read(mach))
+                    dev->accel.cmd_back = 0;
+
+                mach_accel_start(mach->accel.cmd_type, 0, -1, -1, 0, svga, mach, dev);
             }
             break;
 
@@ -2998,10 +3070,10 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             mach_log("Line OPT=%04x.\n", val);
             if (len == 2) {
                 mach->accel.linedraw_opt = val;
-                mach->accel.bbottom = dev->accel.multifunc[3];
-                mach->accel.btop = dev->accel.multifunc[1];
-                mach->accel.bleft = dev->accel.multifunc[2];
-                mach->accel.bright = dev->accel.multifunc[4];
+                mach->accel.bbottom = dev->accel.clip_bottom;
+                mach->accel.btop = dev->accel.clip_top;
+                mach->accel.bleft = dev->accel.clip_left;
+                mach->accel.bright = dev->accel.clip_right;
                 if (mach->accel.linedraw_opt & 0x100) {
                     mach->accel.bbottom = 2047;
                     mach->accel.btop = 0;
@@ -3033,7 +3105,16 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                 mach_log("BitBLT=%04x.\n", mach->accel.dp_config);
                 mach_log(".\n");
                 mach->accel.cmd_type = 2; /*Non-conforming BitBLT from dest_y_end register (0xaeee)*/
-                mach_accel_start(mach->accel.cmd_type, 0, -1, -1, 0, mach, dev);
+
+                frgd_sel = (mach->accel.dp_config >> 13) & 7;
+                bkgd_sel = (mach->accel.dp_config >> 7) & 3;
+                mono_src = (mach->accel.dp_config >> 5) & 3;
+
+                dev->accel.cmd_back = 1;
+                if ((mono_src == 2) || (bkgd_sel == 2) || (frgd_sel == 2) || mach_pixel_read(mach))
+                    dev->accel.cmd_back = 0;
+
+                mach_accel_start(mach->accel.cmd_type, 0, -1, -1, 0, svga, mach, dev);
             }
             break;
 
@@ -3060,8 +3141,17 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             break;
 
         case 0xc6ee:
-            mach->accel.cmd_type = 0;
-            mach_log("TODO: Short Stroke.\n");
+            if (len == 2) {
+                mach->accel.cmd_type = 0;
+                mach_log("TODO: Short Stroke.\n");
+                frgd_sel = (mach->accel.dp_config >> 13) & 7;
+                bkgd_sel = (mach->accel.dp_config >> 7) & 3;
+                mono_src = (mach->accel.dp_config >> 5) & 3;
+
+                dev->accel.cmd_back = 1;
+                if ((mono_src == 2) || (bkgd_sel == 2) || (frgd_sel == 2) || mach_pixel_read(mach))
+                    dev->accel.cmd_back = 0;
+            }
             break;
 
         case 0xcaee:
@@ -3076,7 +3166,16 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                 mach->accel.cmd_type = 5; /*Horizontal Raster Draw from scan_to_x register (0xcaee)*/
                 mach_log("ScanToX=%04x.\n", mach->accel.dp_config);
                 mach_log(".\n");
-                mach_accel_start(mach->accel.cmd_type, 0, -1, -1, 0, mach, dev);
+
+                frgd_sel = (mach->accel.dp_config >> 13) & 7;
+                bkgd_sel = (mach->accel.dp_config >> 7) & 3;
+                mono_src = (mach->accel.dp_config >> 5) & 3;
+
+                dev->accel.cmd_back = 1;
+                if ((mono_src == 2) || (bkgd_sel == 2) || (frgd_sel == 2) || mach_pixel_read(mach))
+                    dev->accel.cmd_back = 0;
+
+                mach_accel_start(mach->accel.cmd_type, 0, -1, -1, 0, svga, mach, dev);
             }
             break;
 
@@ -3105,43 +3204,44 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             break;
 
         case 0xdaee:
-            mach_log("DAEE (extclipl) write val = %d\n", val & 0x7ff);
             if (len == 2) {
                 dev->accel.multifunc[2] = val & 0x7ff;
                 dev->accel.clip_left = dev->accel.multifunc[2];
                 if (val & 0x800)
                     dev->accel.clip_left |= ~0x7ff;
             }
+            mach_log("DAEE (extclipl) write val=%d, left=%d.\n", val, dev->accel.clip_left);
             break;
 
         case 0xdeee:
-            mach_log("DEEE (extclipt) write val = %d\n", val & 0x7ff);
             if (len == 2) {
                 dev->accel.multifunc[1] = val & 0x7ff;
                 dev->accel.clip_top = dev->accel.multifunc[1];
-                if (val & 0x800)
+                if (val & 0x800) {
                     dev->accel.clip_top |= ~0x7ff;
+                }
             }
+            mach_log("DEEE (extclipt) write val = %d\n", val);
             break;
 
         case 0xe2ee:
-            mach_log("E2EE (extclipr) write val = %d\n", val & 0x7ff);
             if (len == 2) {
                 dev->accel.multifunc[4] = val & 0x7ff;
                 dev->accel.clip_right = dev->accel.multifunc[4];
                 if (val & 0x800)
                     dev->accel.clip_right |= ~0x7ff;
             }
+            mach_log("E2EE (extclipr) write val = %d\n", val);
             break;
 
         case 0xe6ee:
-            mach_log("E6EE (extclipb) write val = %d\n", val & 0x7ff);
             if (len == 2) {
                 dev->accel.multifunc[3] = val & 0x7ff;
                 dev->accel.clip_bottom = dev->accel.multifunc[3];
                 if (val & 0x800)
                     dev->accel.clip_bottom |= ~0x7ff;
             }
+            mach_log("E6EE (extclipb) write val = %d\n", val);
             break;
 
         case 0xeeee:
@@ -3165,7 +3265,15 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                 mach->accel.cy_end_line                      = mach->accel.line_array[3];
                 if ((mach->accel.line_idx == 3) || (mach->accel.line_idx == 5)) {
                     mach->accel.cmd_type = (mach->accel.line_idx == 5) ? 4 : 3;
-                    mach_accel_start(mach->accel.cmd_type, 0, -1, -1, 0, mach, dev);
+                    frgd_sel = (mach->accel.dp_config >> 13) & 7;
+                    bkgd_sel = (mach->accel.dp_config >> 7) & 3;
+                    mono_src = (mach->accel.dp_config >> 5) & 3;
+
+                    dev->accel.cmd_back = 1;
+                    if ((mono_src == 2) || (bkgd_sel == 2) || (frgd_sel == 2) || mach_pixel_read(mach))
+                        dev->accel.cmd_back = 0;
+
+                    mach_accel_start(mach->accel.cmd_type, 0, -1, -1, 0, svga, mach, dev);
                     mach->accel.line_idx = (mach->accel.line_idx == 5) ? 4 : 2;
                     break;
                 }
@@ -3275,24 +3383,28 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
                     dev->interlace = !!(dev->disp_cntl & 0x10);
                 }
             }
-            mach_log("ATI 8514/A: DISP_CNTL write %04x=%02x, interlace=%d.\n", port, dev->disp_cntl, dev->interlace);
+            mach_log("ATI 8514/A: DISP_CNTL write %04x=%02x, written=%02x, interlace=%d.\n", port, val & 0x70, dev->disp_cntl & 0x70, dev->interlace);
             svga_recalctimings(svga);
             break;
 
         case 0x4ae8:
             dev->accel.advfunc_cntl = val;
-            mach_log("[%04X:%08X]: ATI 8514/A: (0x%04x): ON=%d, shadow crt=%x, hdisp=%d, vdisp=%d.\n", CS, cpu_state.pc, port, dev->accel.advfunc_cntl & 0x01, dev->accel.advfunc_cntl & 0x04, dev->hdisp, dev->vdisp);
+            mach_log("[%04X:%08X]: ATI 8514/A: (0x%04x): ON=%d, shadow crt=%x, hdisp=%d, vdisp=%d.\n", CS, cpu_state.pc, port, val & 0x01, dev->accel.advfunc_cntl & 0x04, dev->hdisp, dev->vdisp);
 
-            if ((dev->local & 0xff) < 0x02)
+            if ((dev->local & 0xff) < 0x02) {
                 dev->ext_crt_pitch = 128;
-            break;
-        case 0x4ae9:
-            dev->on = dev->accel.advfunc_cntl & 0x01;
-            vga_on = !dev->on;
-            mach_log("[%04X:%08X]: ATI 8514/A: (0x%04x): ON=%d, shadow crt=%x, hdisp=%d, vdisp=%d.\n", CS, cpu_state.pc, port, dev->accel.advfunc_cntl & 0x01, dev->accel.advfunc_cntl & 0x04, dev->hdisp, dev->vdisp);
+                dev->on = dev->accel.advfunc_cntl & 0x01;
+                svga_recalctimings(svga);
+            } else {
+                dev->on = (dev->accel.advfunc_cntl & 0x01) | (mach->accel.clock_sel & 0x01);
+                if (!dev->on && dev->vendor_mode) {
+                    dev->on |= 0x01;
+                    dev->vendor_mode = 0;
+                }
+                svga_recalctimings(svga);
+                mach32_updatemapping(mach, svga);
+            }
             mach_log("Vendor IBM mode set %s resolution.\n", (dev->accel.advfunc_cntl & 0x04) ? "2: 1024x768" : "1: 640x480");
-
-            svga_recalctimings(svga);
             break;
 
         /*ATI Mach8/32 specific registers*/
@@ -3371,8 +3483,16 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
                 else
                     dev->ext_crt_pitch <<= 1;
             }
+            if ((dev->local & 0xff) >= 0x02) {
+                dev->vendor_mode = 1;
+                dev->on = (dev->accel.advfunc_cntl & 0x01) | (mach->accel.clock_sel & 0x01);
+                if (!dev->on)
+                    dev->on |= 0x01;
+
+                svga_recalctimings(svga);
+                mach32_updatemapping(mach, svga);
+            }
             mach_log("ATI 8514/A: (0x%04x) val=0x%02x.\n", port, val);
-            svga_recalctimings(svga);
             break;
 
         case 0x32ee:
@@ -3404,7 +3524,7 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
 
         case 0x42ee:
         case 0x42ef:
-            mach_log("ATI 8514/A: (0x%04x) val = %04x.\n", port, val);
+            mach_log("ATI 8514/A: (0x%04x) val=%04x.\n", port, val);
             WRITE8(port, mach->accel.test2, val);
             break;
 
@@ -3418,16 +3538,20 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
         case 0x4aee:
         case 0x4aef:
             WRITE8(port, mach->accel.clock_sel, val);
-            if (port & 1)
+            if ((dev->local & 0xff) < 0x02) {
                 dev->on = mach->accel.clock_sel & 0x01;
-
-            mach_log("ATI 8514/A: (0x%04x): ON=%d, val=%04x, hdisp=%d, vdisp=%d, val=0x%02x.\n", port, dev->on, val, dev->hdisp, dev->vdisp, val & 0xfe);
-            if (!(port & 1))
-                mach_log("Vendor ATI mode set %s resolution.\n", (dev->accel.advfunc_cntl & 0x04) ? "2: 1024x768" : "1: 640x480");
-
-            vga_on = !dev->on;
-            svga_recalctimings(svga);
-            mach32_updatemapping(mach, svga);
+                svga_recalctimings(svga);
+            } else {
+                dev->on = (dev->accel.advfunc_cntl & 0x01) | (mach->accel.clock_sel & 0x01);
+                if (!dev->on && dev->vendor_mode) {
+                    dev->on |= 0x01;
+                    dev->vendor_mode = 0;
+                }
+                svga_recalctimings(svga);
+                mach32_updatemapping(mach, svga);
+            }
+            mach_log("ATI 8514/A: (0x%04x): ON=%d, val=%04x, hdisp=%d, vdisp=%d.\n", port, mach->accel.clock_sel & 0x01, val, dev->hdisp, dev->vdisp);
+            mach_log("Vendor ATI mode set %s resolution.\n", (dev->accel.advfunc_cntl & 0x04) ? "2: 1024x768" : "1: 640x480");
             break;
 
         case 0x52ee:
@@ -3479,9 +3603,8 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
             WRITE8(port, mach->accel.max_waitstates, val);
             mach->override_resolution = !!(mach->accel.max_waitstates & 0x400);
             mach_log("Override=%d.\n", mach->override_resolution);
-            if (mach->override_resolution) {
-                dev->on = 1;
-                vga_on = !dev->on;
+            if (mach->override_resolution && ((dev->local & 0xff) < 0x02)) {
+                dev->on |= 0x01;
                 svga_recalctimings(svga);
                 mach32_updatemapping(mach, svga);
             }
@@ -3492,7 +3615,6 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
             WRITE8(port, mach->accel.ge_offset_lo, val);
             svga_recalctimings(svga);
             mach_log("ATI 8514/A: (0x%04x) val=0x%02x, geoffset=%04x.\n", port, val, dev->accel.ge_offset);
-            mach32_updatemapping(mach, svga);
             break;
 
         case 0x72ee:
@@ -3500,7 +3622,6 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
             WRITE8(port, mach->accel.ge_offset_hi, val);
             svga_recalctimings(svga);
             mach_log("ATI 8514/A: (0x%04x) val=0x%02x, geoffset=%04x.\n", port, val, dev->accel.ge_offset);
-            mach32_updatemapping(mach, svga);
             break;
 
         case 0x76ee:
@@ -3509,7 +3630,6 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
             dev->ext_pitch = ((mach->accel.ge_pitch & 0xff) << 3);
             mach_log("ATI 8514/A: (0x%04x) val=0x%02x, extpitch=%d.\n", port, val, dev->ext_pitch);
             svga_recalctimings(svga);
-            mach32_updatemapping(mach, svga);
             break;
 
         case 0x7aee:
@@ -3542,10 +3662,9 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
                 svga_set_ramdac_type(svga, !!(mach->accel.ext_ge_config & 0x4000));
                 mach_log("ATI 8514/A: (0x%04x) val=%02x.\n", port, val);
                 svga_recalctimings(svga);
-                mach32_updatemapping(mach, svga);
             } else {
                 mach_log("ATI 8514/A: (0x%04x) val=%02x.\n", port, val & 0x30);
-                ati_eeprom_write(&mach->eeprom, !!(mach->accel.ext_ge_config & 0x4040), !!(mach->accel.ext_ge_config & 0x2020), !!(mach->accel.ext_ge_config & 0x1010));
+                ati_eeprom_write(&mach->eeprom, !!(mach->accel.ext_ge_config & 0x4000), !!(mach->accel.ext_ge_config & 0x2000), !!(mach->accel.ext_ge_config & 0x1000));
             }
             break;
 
@@ -3553,7 +3672,7 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
         case 0x7eef:
             WRITE8(port, mach->accel.eeprom_control, val);
             ati_eeprom_write(&mach->eeprom, !!(mach->accel.eeprom_control & 8), !!(mach->accel.eeprom_control & 2), !!(mach->accel.eeprom_control & 1));
-            mach_log("ATI 8514/A: (0x%04x) val = %04x.\n", port, val);
+            mach_log("ATI 8514/A: (0x%04x) val=%02x.\n", port, val);
             break;
 
         default:
@@ -3670,7 +3789,7 @@ mach_accel_in_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, in
                         } else {
                             READ_PIXTRANS_WORD(dev->accel.dx, 0)
                         }
-                        mach_accel_out_pixtrans(mach, dev, temp);
+                        mach_accel_out_pixtrans(svga, mach, dev, temp);
                     }
                 }
             } else {
@@ -3714,23 +3833,23 @@ mach_accel_in_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, in
                             case 0x000: /*8-bit size*/
                                 if (mono_src == 2) {
                                     if ((frgd_sel != 2) && (bkgd_sel != 2)) {
-                                        mach_accel_start(mach->accel.cmd_type, 1, 8, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), 0, mach, dev);
+                                        mach_accel_start(mach->accel.cmd_type, 1, 8, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), 0, svga, mach, dev);
                                     } else
-                                        mach_accel_start(mach->accel.cmd_type, 1, 1, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), mach, dev);
+                                        mach_accel_start(mach->accel.cmd_type, 1, 1, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), svga, mach, dev);
                                 } else
-                                    mach_accel_start(mach->accel.cmd_type, 1, 1, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), mach, dev);
+                                    mach_accel_start(mach->accel.cmd_type, 1, 1, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), svga, mach, dev);
                                 break;
                             case 0x200: /*16-bit size*/
                                 if (mono_src == 2) {
                                     if ((frgd_sel != 2) && (bkgd_sel != 2)) {
                                         if (mach->accel.dp_config & 0x1000)
-                                            mach_accel_start(mach->accel.cmd_type, 1, 16, mach->accel.pix_trans[1] | (mach->accel.pix_trans[0] << 8), 0, mach, dev);
+                                            mach_accel_start(mach->accel.cmd_type, 1, 16, mach->accel.pix_trans[1] | (mach->accel.pix_trans[0] << 8), 0, svga, mach, dev);
                                         else
-                                            mach_accel_start(mach->accel.cmd_type, 1, 16, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), 0, mach, dev);
+                                            mach_accel_start(mach->accel.cmd_type, 1, 16, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), 0, svga, mach, dev);
                                     } else
-                                        mach_accel_start(mach->accel.cmd_type, 1, 2, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), mach, dev);
+                                        mach_accel_start(mach->accel.cmd_type, 1, 2, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), svga, mach, dev);
                                 } else
-                                    mach_accel_start(mach->accel.cmd_type, 1, 2, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), mach, dev);
+                                    mach_accel_start(mach->accel.cmd_type, 1, 2, -1, mach->accel.pix_trans[0] | (mach->accel.pix_trans[1] << 8), svga, mach, dev);
                                 break;
 
                             default:
@@ -3861,14 +3980,16 @@ mach_accel_in_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, in
             break;
 
         case 0xceee:
+            mach_log("CEEE read=%d.\n", len);
             if (len == 1)
                 temp = dev->vc & 0xff;
             else
                 temp = dev->vc & 0x7ff;
             break;
         case 0xceef:
+            mach_log("CEEF read=%d.\n", len);
             if (len == 1)
-                temp = (dev->vc >> 8) & 7;
+                temp = (dev->vc >> 8) & 0x07;
             break;
 
         case 0xdaee:
@@ -3895,8 +4016,10 @@ mach_accel_in_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, in
                 temp = mach->accel.src_y & 0xff;
             break;
         case 0xdeef:
-            if (len == 1)
-                temp = mach->accel.src_y >> 8;
+            if (len == 1) {
+                if ((dev->local & 0xff) >= 0x02)
+                    temp = mach->accel.src_y >> 8;
+            }
             break;
 
         case 0xfaee:
@@ -3941,6 +4064,13 @@ static uint8_t
 mach_accel_in_call(uint16_t port, mach_t *mach, svga_t *svga, ibm8514_t *dev)
 {
     uint8_t temp = 0;
+    int16_t clip_t = dev->accel.clip_top;
+    int16_t clip_l = dev->accel.clip_left;
+    int16_t clip_b = dev->accel.clip_bottom;
+    int16_t clip_r = dev->accel.clip_right;
+    uint16_t clip_b_ibm = dev->accel.clip_bottom;
+    uint16_t clip_r_ibm = dev->accel.clip_right;
+    int cmd = dev->accel.cmd >> 13;
 
     switch (port) {
         case 0x2e8:
@@ -3956,7 +4086,45 @@ mach_accel_in_call(uint16_t port, mach_t *mach, svga_t *svga, ibm8514_t *dev)
         case 0x42e8:
         case 0x42e9:
             if (dev->vc == dev->v_syncstart)
-                dev->subsys_stat |= 1;
+                dev->subsys_stat |= 0x01;
+
+            if (mach->accel.cmd_type == -1) {
+                if (cmd == 6) {
+                    if ((dev->accel.dx >= clip_l) &&
+                        (dev->accel.dx <= clip_r_ibm) &&
+                        (dev->accel.dy >= clip_t) &&
+                        (dev->accel.dy <= clip_b_ibm))
+                        dev->subsys_stat |= 0x02;
+                } else {
+                    if ((dev->accel.cx >= clip_l) &&
+                        (dev->accel.cx <= clip_r_ibm) &&
+                        (dev->accel.cy >= clip_t) &&
+                        (dev->accel.cy <= clip_b_ibm))
+                        dev->subsys_stat |= 0x02;
+                }
+            } else {
+                switch (mach->accel.cmd_type) {
+                    case 1:
+                    case 2:
+                    case 5:
+                        if ((dev->accel.dx >= clip_l) &&
+                            (dev->accel.dx <= clip_r) &&
+                            (dev->accel.dy >= clip_t) &&
+                            (dev->accel.dy <= clip_b))
+                            dev->subsys_stat |= 0x02;
+                        break;
+                    case 3:
+                    case 4:
+                    if ((dev->accel.cx >= clip_l) &&
+                        (dev->accel.cx <= clip_r) &&
+                        (dev->accel.cy >= clip_t) &&
+                        (dev->accel.cy <= clip_b))
+                            dev->subsys_stat |= 0x02;
+                        break;
+                    default:
+                        break;
+                }
+            }
 
             if (port & 1)
                 temp = dev->vram_512k_8514 ? 0x00 : 0x80;
@@ -4037,6 +4205,16 @@ mach_accel_in_call(uint16_t port, mach_t *mach, svga_t *svga, ibm8514_t *dev)
         case 0x52ee:
         case 0x52ef:
             READ8(port, mach->accel.scratch0);
+#ifdef ATI_8514_ULTRA
+            if (dev->extensions && ((dev->local & 0xff) == 0x00)) {
+                if (mach->mca_bus) {
+                    if (port & 1)
+                        temp = dev->pos_regs[5];
+                    else
+                        temp = dev->pos_regs[4];
+                }
+            }
+#endif
             break;
 
         case 0x56ee:
@@ -4380,7 +4558,6 @@ mach32_write_common(uint32_t addr, uint8_t val, int linear, mach_t *mach, svga_t
     }
 
     addr &= dev->vram_mask;
-
     dev->changedvram[addr >> 12] = svga->monitor->mon_changeframecount;
 
     switch (svga->writemode) {
@@ -4466,36 +4643,6 @@ mach32_write_common(uint32_t addr, uint8_t val, int linear, mach_t *mach, svga_t
     if (reset_wm)
         svga->gdcreg[8] = wm;
 }
-
-#ifdef ATI_8514_ULTRA
-static void
-ati8514_write(uint32_t addr, uint8_t val, void *priv)
-{
-    svga_t *svga = (svga_t *) priv;
-    mach_t *mach = (mach_t *) svga->ext8514;
-    mach32_write_common(addr, val, 0, mach, svga);
-}
-
-static void
-ati8514_writew(uint32_t addr, uint16_t val, void *priv)
-{
-    svga_t *svga = (svga_t *) priv;
-    mach_t *mach = (mach_t *) svga->ext8514;
-    mach32_write_common(addr, val & 0xff, 0, mach, svga);
-    mach32_write_common(addr + 1, val >> 8, 0, mach, svga);
-}
-
-static void
-ati8514_writel(uint32_t addr, uint32_t val, void *priv)
-{
-    svga_t *svga = (svga_t *) priv;
-    mach_t *mach = (mach_t *) svga->ext8514;
-    mach32_write_common(addr, val & 0xff, 0, mach, svga);
-    mach32_write_common(addr + 1, val >> 8, 0, mach, svga);
-    mach32_write_common(addr + 2, val >> 16, 0, mach, svga);
-    mach32_write_common(addr + 3, val >> 24, 0, mach, svga);
-}
-#endif
 
 static void
 mach32_write(uint32_t addr, uint8_t val, void *priv)
@@ -4710,6 +4857,8 @@ mach32_read_common(uint32_t addr, int linear, mach_t *mach, svga_t *svga)
         latch_addr = (addr & dev->vram_mask) & ~3;
         for (uint8_t i = 0; i < count; i++)
             dev->latch.b[i] = dev->vram[latch_addr | i];
+
+        mach_log("Read (normal) addr=%06x, ret=%02x.\n", addr, dev->vram[addr & dev->vram_mask]);
         return dev->vram[addr & dev->vram_mask];
     }
 
@@ -4734,7 +4883,6 @@ mach32_read_common(uint32_t addr, int linear, mach_t *mach, svga_t *svga)
 
     addr &= dev->vram_mask;
 
-    mach_log("ReadMode=%02x.\n", svga->readmode);
     if (svga->readmode) {
         temp = 0xff;
 
@@ -4752,47 +4900,9 @@ mach32_read_common(uint32_t addr, int linear, mach_t *mach, svga_t *svga)
     } else
         ret = dev->vram[addr | readplane];
 
+    mach_log("ReadMode=%02x, addr=%06x, ret=%02x.\n", svga->readmode, addr, ret);
     return ret;
 }
-
-#ifdef ATI_8514_ULTRA
-static uint8_t
-ati8514_read(uint32_t addr, void *priv)
-{
-    svga_t *svga = (svga_t *) priv;
-    mach_t *mach = (mach_t *) svga->ext8514;
-    uint8_t          ret;
-
-    ret  = mach32_read_common(addr, 0, mach, svga);
-    return ret;
-}
-
-static uint16_t
-ati8514_readw(uint32_t addr, void *priv)
-{
-    svga_t *svga = (svga_t *) priv;
-    mach_t *mach = (mach_t *) svga->ext8514;
-    uint16_t         ret;
-
-    ret  = mach32_read_common(addr, 0, mach, svga);
-    ret  |= (mach32_read_common(addr + 1, 0, mach, svga) << 8);
-    return ret;
-}
-
-static uint32_t
-ati8514_readl(uint32_t addr, void *priv)
-{
-    svga_t *svga = (svga_t *) priv;
-    mach_t *mach = (mach_t *) svga->ext8514;
-    uint32_t         ret;
-
-    ret  = mach32_read_common(addr, 0, mach, svga);
-    ret  |= (mach32_read_common(addr + 1, 0, mach, svga) << 8);
-    ret  |= (mach32_read_common(addr + 2, 0, mach, svga) << 16);
-    ret  |= (mach32_read_common(addr + 3, 0, mach, svga) << 24);
-    return ret;
-}
-#endif
 
 static uint8_t
 mach32_read(uint32_t addr, void *priv)
@@ -4927,7 +5037,6 @@ mach32_readl_linear(uint32_t addr, mach_t *mach)
     uint32_t         ret;
 
     cycles -= svga->monitor->mon_video_timing_read_l;
-
     if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
         addr <<= 1;
         addr &= dev->vram_mask;
@@ -5115,6 +5224,7 @@ mach32_updatemapping(mach_t *mach, svga_t *svga)
     ibm8514_t *dev = (ibm8514_t *) svga->dev8514;
 
     if (mach->pci_bus && (!(mach->pci_regs[PCI_REG_COMMAND] & PCI_COMMAND_MEM))) {
+        mach_log("No Mapping.\n");
         mem_mapping_disable(&svga->mapping);
         mem_mapping_disable(&mach->mmio_linear_mapping);
         return;
@@ -5165,17 +5275,15 @@ mach32_updatemapping(mach_t *mach, svga_t *svga)
         mach_log("Linear Disabled APSIZE=4.\n");
         mem_mapping_disable(&mach->mmio_linear_mapping);
     }
-    if (dev->on && ((dev->local & 0xff) >= 0x02)) {
-        mach_log("Mach32 banked mapping.\n");
-#ifdef ATI_8514_ULTRA
-        if (svga->ext8514 != NULL) {
-            mem_mapping_set_handler(&svga->mapping, ati8514_read, ati8514_readw, ati8514_readl, ati8514_write, ati8514_writew, ati8514_writel);
-            mem_mapping_set_p(&svga->mapping, svga);
-        } else
-#endif
-        {
+    if ((dev->local & 0xff) >= 0x02) {
+        if (dev->on) {
+            mach_log("Mach32 banked mapping.\n");
             mem_mapping_set_handler(&svga->mapping, mach32_read, mach32_readw, mach32_readl, mach32_write, mach32_writew, mach32_writel);
             mem_mapping_set_p(&svga->mapping, mach);
+        } else {
+            mach_log("IBM compatible banked mapping.\n");
+            mem_mapping_set_handler(&svga->mapping, svga_read, svga_readw, svga_readl, svga_write, svga_writew, svga_writel);
+            mem_mapping_set_p(&svga->mapping, svga);
         }
     } else {
         mach_log("IBM compatible banked mapping.\n");
@@ -5191,12 +5299,14 @@ mach32_hwcursor_draw(svga_t *svga, int displine)
     ibm8514_t    *dev    = (ibm8514_t *) svga->dev8514;
     uint16_t      dat;
     int           comb;
-    int           offset = dev->hwcursor_latch.x - dev->hwcursor_latch.xoff;
+    int           offset;
     uint32_t      color0;
     uint32_t      color1;
     uint32_t      *p;
     int           x_pos;
     int           y_pos;
+
+    offset = dev->hwcursor_latch.x - dev->hwcursor_latch.xoff;
 
     mach_log("BPP=%d, displine=%d.\n", dev->accel_bpp, displine);
     switch (dev->accel_bpp) {
@@ -5255,6 +5365,7 @@ mach32_hwcursor_draw(svga_t *svga, int displine)
         }
         dev->hwcursor_latch.addr += 2;
     }
+
     if (dev->interlace && !dev->hwcursor_oddeven)
         dev->hwcursor_latch.addr += 16;
 }
@@ -5263,7 +5374,6 @@ mach32_hwcursor_draw(svga_t *svga, int displine)
 static void
 ati8514_io_set(svga_t *svga)
 {
-    io_sethandler(0x2e8, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
     io_sethandler(0x6e8, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
     io_sethandler(0xae8, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
     io_sethandler(0xee8, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
@@ -5275,7 +5385,6 @@ ati8514_io_set(svga_t *svga)
     io_sethandler(0x26e8, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
     io_sethandler(0x2ee8, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
     io_sethandler(0x42e8, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
-    io_sethandler(0x46e8, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
     io_sethandler(0x4ae8, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
     io_sethandler(0x52e8, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
     io_sethandler(0x56e8, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
@@ -5539,7 +5648,6 @@ mach_mca_reset(void *priv)
 
     mach_log("MCA reset.\n");
     dev->on = 0;
-    vga_on = 1;
     mach_mca_write(0x102, 0, mach);
     timer_set_callback(&svga->timer, svga_poll);
 }
@@ -5900,22 +6008,22 @@ ati8514_init(svga_t *svga, void *ext8514, void *dev8514)
     dev->ext_crt_pitch = 0x80;
     dev->accel_bpp = 8;
     dev->rowoffset = 0x80;
-    dev->hdisp = 0;
-    dev->vdisp = 0;
+    dev->hdisp = 1024;
+    dev->vdisp = 768;
 
     io_sethandler(0x02ea, 4, ati8514_in, NULL, NULL, ati8514_out, NULL, NULL, svga);
     ati8514_io_set(svga);
     mach->mca_bus = !!(dev->type & DEVICE_MCA);
 
+    mach->config1 = 0x01 | 0x02 | 0x08 | 0x80;
+
     if (mach->mca_bus)
-        mach->config1 = 0x02 | 0x04;
-    else
-        mach->config1 = 0x02 | 0x2000;
+        mach->config1 |= 0x04;
 
     if (dev->vram_amount >= 1024)
         mach->config1 |= 0x20;
 
-    mach->config2 = 0x01 | 0x02;
+    mach->config2 = 0x02;
 }
 #endif
 

--- a/src/video/vid_xga.c
+++ b/src/video/vid_xga.c
@@ -442,7 +442,6 @@ xga_ext_out_reg(xga_t *xga, svga_t *svga, uint8_t idx, uint8_t val)
             xga_log("Reg51 write = %02x.\n", val);
             xga->disp_cntl_2 = val;
             xga->on          = ((val & 7) >= 2);
-            vga_on           = !xga->on;
             svga_recalctimings(svga);
             break;
 
@@ -2661,22 +2660,18 @@ xga_write_test(uint32_t addr, uint8_t val, void *priv)
                     xga->a5_test = 2;
 
                 xga->on = 0;
-                vga_on = 1;
                 xga_log("XGA test1 addr=%05x, test=%02x.\n", addr, xga->a5_test);
             } else if (val == 0x5a) {
                 xga->test = val;
                 xga->on = 0;
-                vga_on = 1;
                 xga_log("XGA test2 addr = %05x.\n", addr);
             } else if ((addr == 0xa0000) || (addr == 0xa0010)) {
                 addr += xga->write_bank;
                 xga->vram[addr & xga->vram_mask] = val;
                 xga_log("XGA Linear endian reverse write, val = %02x, addr = %05x, banked mask = %04x, a5test=%d.\n", val, addr, svga->banked_mask, xga->a5_test);
             }
-        } else if (xga->aperture_cntl) {
+        } else if (xga->aperture_cntl)
             xga->on = 0;
-            vga_on = 1;
-        }
     }
 }
 
@@ -2763,7 +2758,6 @@ xga_read_test(uint32_t addr, void *priv)
                 if (addr == 0xa0001) {
                     ret = xga->test;
                     xga->on = 1;
-                    vga_on = 0;
                 } else if ((addr == 0xa0000) && (xga->a5_test == 1)) { /*This is required by XGAKIT to pass the memory test*/
                     xga_log("A5 test bank = %x.\n", addr);
                     addr += xga->read_bank;
@@ -2771,14 +2765,12 @@ xga_read_test(uint32_t addr, void *priv)
                 } else {
                     ret = xga->test;
                     xga->on = 1;
-                    vga_on = 0;
                 }
                 xga_log("A5 read: XGA ON = %d, addr = %05x, ret = %02x, test1 = %x.\n", xga->on, addr, ret, xga->a5_test);
                 return ret;
             } else if (xga->test == 0x5a) {
                 ret = xga->test;
                 xga->on = 1;
-                vga_on = 0;
                 xga_log("5A read: XGA ON = %d.\n", xga->on);
                 return ret;
             } else if ((addr == 0xa0000) || (addr == 0xa0010)) {
@@ -2787,7 +2779,6 @@ xga_read_test(uint32_t addr, void *priv)
             }
         } else if (xga->aperture_cntl) {
             xga->on = 0;
-            vga_on = 1;
         }
     }
     return ret;
@@ -3041,7 +3032,6 @@ xga_poll(void *priv)
             if (xga->hwcursor_on)
                 xga->changedvram[xga->ma >> 12] = xga->changedvram[(xga->ma >> 12) + 1] = xga->interlace ? 3 : 2;
 
-            xga_log("DISPCNTL = %d, vga = %d.\n", xga->disp_cntl_2 & 7, vga_on);
             switch (xga->disp_cntl_2 & 7) {
                 case 2:
                     xga_render_4bpp(svga);
@@ -3202,7 +3192,6 @@ xga_mca_write(int port, uint8_t val, void *priv)
     io_removehandler(0x2100 + (xga->instance << 4), 0x0010, xga_ext_inb, NULL, NULL, xga_ext_outb, NULL, NULL, svga);
     mem_mapping_disable(&xga->memio_mapping);
     xga->on                    = 0;
-    vga_on                     = 1;
     xga->a5_test               = 0;
 
     /* Save the MCA register value. */
@@ -3260,7 +3249,6 @@ xga_reset(void *priv)
         mem_mapping_disable(&xga->memio_mapping);
 
     xga->on                    = 0;
-    vga_on                     = 1;
     xga->a5_test               = 0;
     mem_mapping_set_handler(&svga->mapping, svga_read, svga_readw, svga_readl, svga_write, svga_writew, svga_writel);
 }


### PR DESCRIPTION
Summary
=======
1. vga_on global variable removed, as it didn't play well with 2 subsystems at once (8514/A and XGA both enabled).
2. Emulate the Foreground/Background Color aliases of PIX_TRANS properly when not executing a command.
3. Voodoo 3D override now works properly (again) with Mach32 PCI cards and others by turning the 8514/A timer off and on accordingly.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
