### PR TITLE
Further improvements to the translation system

### DIFF
--- a/src/qt/qt_deviceconfig.cpp
+++ b/src/qt/qt_deviceconfig.cpp
@@ -124,11 +124,7 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
         return;
 
     while (config->type != -1) {
-        const int   config_type = config->type & CONFIG_TYPE_MASK;
-        const char *temp        = tr(config->description).toUtf8().data();
-        char        tdesc[512]  = { 0 };
-
-        strcpy(tdesc, temp);
+        const int config_type = config->type & CONFIG_TYPE_MASK;
 
         /* Ignore options of the wrong class. */
         if (!!(config->type & CONFIG_DEP) != is_dep)
@@ -172,7 +168,7 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                 auto *cbox  = new QCheckBox();
                 cbox->setObjectName(config->name);
                 cbox->setChecked(value > 0);
-                this->ui->formLayout->addRow(tdesc, cbox);
+                this->ui->formLayout->addRow(tr(config->description), cbox);
                 break;
             }
 #ifdef USE_RTMIDI
@@ -187,11 +183,11 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                     char midiName[512] = { 0 };
                     rtmidi_out_get_dev_name(i, midiName);
 
-                    Models::AddEntry(model, tr(midiName), i);
+                    Models::AddEntry(model, midiName, i);
                     if (i == value)
                         currentIndex = i;
                 }
-                this->ui->formLayout->addRow(tdesc, cbox);
+                this->ui->formLayout->addRow(tr(config->description), cbox);
                 cbox->setCurrentIndex(currentIndex);
                 break;
             }
@@ -206,11 +202,11 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                     char midiName[512] = { 0 };
                     rtmidi_in_get_dev_name(i, midiName);
 
-                    Models::AddEntry(model, tr(midiName), i);
+                    Models::AddEntry(model, midiName, i);
                     if (i == value)
                         currentIndex = i;
                 }
-                this->ui->formLayout->addRow(tdesc, cbox);
+                this->ui->formLayout->addRow(tr(config->description), cbox);
                 cbox->setCurrentIndex(currentIndex);
                 break;
             }
@@ -225,17 +221,15 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                 cbox->setMaxVisibleItems(30);
                 auto *model        = cbox->model();
                 int   currentIndex = -1;
+
                 for (auto *sel = config->selection; (sel != nullptr) && (sel->description != nullptr) &&
                                                     (strlen(sel->description) > 0); ++sel) {
-                    const char *temp2      = tr(sel->description).toUtf8().data();
-                    char        sdesc[512] = { 0 };
-                    strcpy(sdesc, temp2);
-                    int         row        = Models::AddEntry(model, sdesc, sel->value);
+                    int row = Models::AddEntry(model, tr(sel->description), sel->value);
 
                     if (sel->value == value)
                         currentIndex = row;
                 }
-                this->ui->formLayout->addRow(tdesc, cbox);
+                this->ui->formLayout->addRow(tr(config->description), cbox);
                 cbox->setCurrentIndex(currentIndex);
                 break;
             }
@@ -254,16 +248,13 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                     for (int d = 0; d < bios->files_no; d++)
                         p += !!rom_present(const_cast<char *>(bios->files[d]));
                     if (p == bios->files_no) {
-                        const char *temp2      = tr(bios->name).toUtf8().data();
-                        char        bname[512] = { 0 };
-                        strcpy(bname, temp2);
-                        const int   row   = Models::AddEntry(model, bname, q);
+                        const int row = Models::AddEntry(model, tr(bios->name), q);
                         if (!strcmp(selected.toUtf8().constData(), bios->internal_name))
                             currentIndex = row;
                     }
                     q++;
                 }
-                this->ui->formLayout->addRow(tdesc, cbox);
+                this->ui->formLayout->addRow(tr(config->description), cbox);
                 cbox->setCurrentIndex(currentIndex);
                 break;
             }
@@ -276,7 +267,7 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                 if (config->spinner.step > 0)
                     spinBox->setSingleStep(config->spinner.step);
                 spinBox->setValue(value);
-                this->ui->formLayout->addRow(tdesc, spinBox);
+                this->ui->formLayout->addRow(tr(config->description), spinBox);
                 break;
             }
             case CONFIG_FNAME:
@@ -286,7 +277,7 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                 fileField->setFileName(selected);
                 fileField->setFilter(QString(config->file_filter).left(static_cast<int>(strcspn(config->file_filter,
                                                                                                 "|"))));
-                this->ui->formLayout->addRow(tdesc, fileField);
+                this->ui->formLayout->addRow(tr(config->description), fileField);
                 break;
             }
             case CONFIG_STRING:
@@ -295,7 +286,7 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                 lineEdit->setObjectName(config->name);
                 lineEdit->setCursor(Qt::IBeamCursor);
                 lineEdit->setText(selected);
-                this->ui->formLayout->addRow(tdesc, lineEdit);
+                this->ui->formLayout->addRow(tr(config->description), lineEdit);
                 break;
             }
             case CONFIG_SERPORT:
@@ -314,7 +305,7 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                         currentIndex = row;
                 }
 
-                this->ui->formLayout->addRow(tdesc, cbox);
+                this->ui->formLayout->addRow(tr(config->description), cbox);
                 cbox->setCurrentIndex(currentIndex);
                 break;
             }
@@ -346,7 +337,7 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                 });
                 hboxLayout->addWidget(lineEdit);
                 hboxLayout->addWidget(generateButton);
-                this->ui->formLayout->addRow(tdesc, hboxLayout);
+                this->ui->formLayout->addRow(tr(config->description), hboxLayout);
                 break;
             }
         }
@@ -358,15 +349,15 @@ void
 DeviceConfig::ConfigureDevice(const _device_ *device, int instance, Settings *settings)
 {
     DeviceConfig dc(settings);
-    dc.setWindowTitle(QString(tr("%1 Device Configuration")).arg(device->name));
+    dc.setWindowTitle(tr("%1 Device Configuration").arg(tr(device->name)));
 
     device_context_t device_context;
     device_set_context(&device_context, device, instance);
 
-    const auto device_label       = new QLabel(device->name);
+    const auto device_label = new QLabel(tr(device->name));
     device_label->setAlignment(Qt::AlignCenter);
     dc.ui->formLayout->addRow(device_label);
-    const auto line               = new QFrame;
+    const auto line = new QFrame;
     line->setFrameShape(QFrame::HLine);
     line->setFrameShadow(QFrame::Sunken);
     dc.ui->formLayout->addRow(line);
@@ -472,6 +463,6 @@ DeviceConfig::DeviceName(const _device_ *device, const char *internalName, const
     else {
         char temp[512];
         device_get_name(device, bus, temp);
-        return tr(temp, nullptr, 512);
+        return tr((const char *) temp);
     }
 }

--- a/src/qt/qt_settingsinput.cpp
+++ b/src/qt/qt_settingsinput.cpp
@@ -77,7 +77,7 @@ SettingsInput::onCurrentMachineChanged(int machineId)
         mouseModel->insertRow(row);
         auto idx = mouseModel->index(row, 0);
 
-        mouseModel->setData(idx, tr(name.toUtf8().data()), Qt::DisplayRole);
+        mouseModel->setData(idx, name, Qt::DisplayRole);
         mouseModel->setData(idx, i, Qt::UserRole);
 
         if (i == mouse_type) {

--- a/src/qt/qt_settingsnetwork.cpp
+++ b/src/qt/qt_settingsnetwork.cpp
@@ -127,7 +127,7 @@ SettingsNetwork::onCurrentMachineChanged(int machineId)
             }
 
             if (network_card_available(c) && device_is_valid(network_card_getdevice(c), machineId)) {
-                int row = Models::AddEntry(model, tr(name.toUtf8().data()), c);
+                int row = Models::AddEntry(model, name, c);
                 if (c == net_cards_conf[i].device_num) {
                     selectedRow = row - removeRows;
                 }

--- a/src/qt/qt_settingssound.cpp
+++ b/src/qt/qt_settingssound.cpp
@@ -119,7 +119,7 @@ SettingsSound::onCurrentMachineChanged(const int machineId)
         }
 
         if (midi_out_device_available(c)) {
-            int row = Models::AddEntry(model, tr(name.toUtf8().data()), c);
+            int row = Models::AddEntry(model, name, c);
             if (c == midi_output_device_current) {
                 selectedRow = row - removeRows;
             }
@@ -142,7 +142,7 @@ SettingsSound::onCurrentMachineChanged(const int machineId)
         }
 
         if (midi_in_device_available(c)) {
-            int row = Models::AddEntry(model, tr(name.toUtf8().data()), c);
+            int row = Models::AddEntry(model, name, c);
             if (c == midi_input_device_current) {
                 selectedRow = row - removeRows;
             }


### PR DESCRIPTION
Summary
=======
- Improve string handling to reduce chance of corruption
- Device name as shown at the top of the device config dialog (as well as the title bar) is now translated too
- Don't attempt to translate system MIDI I/O port names

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
<https://doc.qt.io/qt-5/qobject.html>
<https://doc.qt.io/qt-5/qstring.html>