### PR TITLE
Linux mouse fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ CMakeLists.txt.user
 
 # clangd
 .cache
+
+# Jetbrains CLion
+.idea

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -200,10 +200,14 @@ RendererStack::mousePressEvent(QMouseEvent *event)
 void
 RendererStack::wheelEvent(QWheelEvent *event)
 {
+    if (!mouse_capture) {
+        event->ignore();
+        return;
+    }
+
     double numSteps = (double) event->angleDelta().y() / 120.0;
 
     mouse_set_z((int) numSteps);
-
     event->accept();
 }
 

--- a/src/qt/xinput2_mouse.cpp
+++ b/src/qt/xinput2_mouse.cpp
@@ -132,7 +132,7 @@ xinput2_proc()
         XGenericEventCookie *cookie = (XGenericEventCookie *) &ev.xcookie;
         XNextEvent(disp, (XEvent *) &ev);
 
-        if (XGetEventData(disp, cookie) && (cookie->type == GenericEvent) && (cookie->extension == xi2opcode)) {
+        if (XGetEventData(disp, cookie) && (cookie->type == GenericEvent) && (cookie->extension == xi2opcode) && mouse_capture) {
             const XIRawEvent *rawev     = (const XIRawEvent *) cookie->data;
             double            coords[2] = { 0.0 };
 
@@ -214,8 +214,6 @@ common_motion:
                         }
 
                         prev_time = rawev->time;
-                        if (!mouse_capture)
-                            break;
                         XWindowAttributes winattrib {};
                         if (XGetWindowAttributes(disp, main_window->winId(), &winattrib)) {
                             auto globalPoint = main_window->mapToGlobal(QPoint(main_window->width() / 2, main_window->height() / 2));


### PR DESCRIPTION
Summary
=======
1. Added a line to .gitignore to ignore IDE configuration files generated by the Jetbrains CLion IDE.
2. Moved the check for `mouse_capture` to a position before XInput events are handled. In commit `c695cb8d`, the behavior of `xinput2_proc` was changed to call the function `mouse_scale_x`/`mouse_scale_y` from the previous behavior of modifying xinput-related variables. These calls were made before the `mouse_capture` check, modifying global mouse variables when the mouse input was not captured.
3. Added a check for `mouse_capture` before handling a QWheelEvent. This prevents an issue where mouse scrolls made while the mouse isn't captured cause the behavior of the mouse wheel being 'stuck'  on certain configurations.

Checklist
=========
* [x] Closes #4693, #3873, potentially middle mouse button related issues in #4239
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
