### PR TITLE
Embed Qt base translations in the executable

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -593,7 +593,7 @@ else
         grep -q " bullseye " /etc/apt/sources.list || echo [!] WARNING: System not running the expected Debian version
 
 	# Establish general dependencies.
-	pkgs="cmake ninja-build pkg-config git wget p7zip-full extra-cmake-modules wayland-protocols tar gzip file appstream"
+	pkgs="cmake ninja-build pkg-config git wget p7zip-full extra-cmake-modules wayland-protocols tar gzip file appstream qttranslations5-l10n"
 	if [ "$(dpkg --print-architecture)" = "$arch_deb" ]
 	then
 		pkgs="$pkgs build-essential"

--- a/.github/workflows/cmake_linux.yml
+++ b/.github/workflows/cmake_linux.yml
@@ -63,6 +63,7 @@ jobs:
               qtbase5-dev
               qtbase5-private-dev
               qttools5-dev
+              qttranslations5-l10n
               libevdev-dev
               libxkbcommon-x11-dev
 

--- a/.github/workflows/codeql_linux.yml
+++ b/.github/workflows/codeql_linux.yml
@@ -66,6 +66,7 @@ jobs:
               qtbase5-dev
               qtbase5-private-dev
               qttools5-dev
+              qttranslations5-l10n
               libevdev-dev
               libxkbcommon-x11-dev
 

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -454,10 +454,49 @@ if (UNIX AND NOT APPLE AND NOT HAIKU)
         endif()
     endif()
 endif()
+
+# Get the Qt translations directory
+get_target_property(QT_QMAKE_EXECUTABLE Qt${QT_MAJOR}::qmake IMPORTED_LOCATION)
+execute_process(COMMAND ${QT_QMAKE_EXECUTABLE} -query QT_INSTALL_TRANSLATIONS OUTPUT_VARIABLE QT_TRANSLATIONS_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)
+
 set(QM_FILES)
 file(GLOB po_files "${CMAKE_CURRENT_SOURCE_DIR}/languages/*.po")
 foreach(po_file ${po_files})
     get_filename_component(PO_FILE_NAME ${po_file} NAME_WE)
+
+    # Get the language and country
+    string(REGEX MATCH "^[a-z]+" PO_LANGUAGE ${PO_FILE_NAME})
+    string(REGEX MATCH "[A-Z]+$" PO_COUNTRY ${PO_FILE_NAME})
+
+    # Find the base Qt translation for the language and country
+    set(qt_translation_file_dest "qt_${PO_LANGUAGE}_${PO_COUNTRY}.qm")
+    if (EXISTS "${QT_TRANSLATIONS_DIR}/qtbase_${PO_LANGUAGE}_${PO_COUNTRY}.qm")
+        set(qt_translation_file "qtbase_${PO_LANGUAGE}_${PO_COUNTRY}.qm")
+    # Fall back to just the language if country isn't found
+    elseif (EXISTS "${QT_TRANSLATIONS_DIR}/qtbase_${PO_LANGUAGE}.qm")
+        set(qt_translation_file "qtbase_${PO_LANGUAGE}.qm")
+    # If the translation is still not found, try the legacy Qt one
+    elseif (EXISTS "${QT_TRANSLATIONS_DIR}/qt_${PO_LANGUAGE}_${PO_COUNTRY}.qm")
+        set(qt_translation_file "qt_${PO_LANGUAGE}_${PO_COUNTRY}.qm")
+    # Fall back to just the language again
+    elseif (EXISTS "${QT_TRANSLATIONS_DIR}/qt_${PO_LANGUAGE}.qm")
+        set(qt_translation_file "qt_${PO_LANGUAGE}.qm")
+    else()
+        unset(qt_translation_file)
+    endif()
+
+    # Copy the translation file to the build directory
+    if (qt_translation_file)
+        file(COPY "${QT_TRANSLATIONS_DIR}/${qt_translation_file}" DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+        if (NOT (qt_translation_file STREQUAL qt_translation_file_dest))
+            # Rename the file for consistency
+            file(RENAME "${CMAKE_CURRENT_BINARY_DIR}/${qt_translation_file}" "${CMAKE_CURRENT_BINARY_DIR}/${qt_translation_file_dest}")
+        endif()
+        # Add the file to the translations list
+        string(APPEND QT_TRANSLATIONS_LIST "        <file>${qt_translation_file_dest}</file>\n")
+        list(APPEND QM_FILES "${CMAKE_CURRENT_BINARY_DIR}/${qt_translation_file_dest}")
+    endif()
+
     add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/86box_${PO_FILE_NAME}.qm"
                        COMMAND "$<TARGET_FILE:Qt${QT_MAJOR}::lconvert>" -i ${po_file} -o ${CMAKE_CURRENT_BINARY_DIR}/86box_${PO_FILE_NAME}.qm
                        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
@@ -465,5 +504,6 @@ foreach(po_file ${po_files})
     list(APPEND QM_FILES "${CMAKE_CURRENT_BINARY_DIR}/86box_${PO_FILE_NAME}.qm")
     list(APPEND QM_FILES "${po_file}")
 endforeach()
-configure_file(qt_translations.qrc ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
+
+configure_file(qt_translations.qrc.in ${CMAKE_CURRENT_BINARY_DIR}/qt_translations.qrc)
 target_sources(ui PRIVATE ${QM_FILES} ${CMAKE_CURRENT_BINARY_DIR}/qt_translations.qrc)

--- a/src/qt/qt_progsettings.cpp
+++ b/src/qt/qt_progsettings.cpp
@@ -195,7 +195,9 @@ ProgSettings::loadTranslators(QObject *parent)
                 qDebug() << "Translations loaded.\n";
                 QCoreApplication::installTranslator(translator);
                 if (!qtTranslator->load(QLatin1String("qtbase_") + localetofilename.replace('-', '_'), QLibraryInfo::location(QLibraryInfo::TranslationsPath)))
-                    qtTranslator->load(QLatin1String("qt_") + localetofilename.replace('-', '_'), QApplication::applicationDirPath() + "/./translations/");
+                    if (!qtTranslator->load(QLatin1String("qtbase_") + localetofilename.left(localetofilename.indexOf('-')), QLibraryInfo::location(QLibraryInfo::TranslationsPath)))
+                        if (!qtTranslator->load(QLatin1String("qt_") + localetofilename.replace('-', '_'), QApplication::applicationDirPath() + "/./translations/"))
+                            qtTranslator->load(QLatin1String("qt_") + localetofilename.replace('-', '_'), QLatin1String(":/"));
                 if (QApplication::installTranslator(qtTranslator)) {
                     qDebug() << "Qt translations loaded."
                              << "\n";
@@ -207,7 +209,10 @@ ProgSettings::loadTranslators(QObject *parent)
         translator->load(QLatin1String("86box_") + lcid_langcode[lang_id].first, QLatin1String(":/"));
         QCoreApplication::installTranslator(translator);
         if (!qtTranslator->load(QLatin1String("qtbase_") + QString(lcid_langcode[lang_id].first).replace('-', '_'), QLibraryInfo::location(QLibraryInfo::TranslationsPath)))
-            qtTranslator->load(QLatin1String("qt_") + QString(lcid_langcode[lang_id].first).replace('-', '_'), QApplication::applicationDirPath() + "/./translations/");
+            if (!qtTranslator->load(QLatin1String("qtbase_") + QString(lcid_langcode[lang_id].first).left(QString(lcid_langcode[lang_id].first).indexOf('-')), QLibraryInfo::location(QLibraryInfo::TranslationsPath)))
+                if(!qtTranslator->load(QLatin1String("qt_") + QString(lcid_langcode[lang_id].first).replace('-', '_'), QApplication::applicationDirPath() + "/./translations/"))
+                    qtTranslator->load(QLatin1String("qt_") + QString(lcid_langcode[lang_id].first).replace('-', '_'), QLatin1String(":/"));
+
         QCoreApplication::installTranslator(qtTranslator);
     }
 }

--- a/src/qt/qt_translations.qrc.in
+++ b/src/qt/qt_translations.qrc.in
@@ -24,5 +24,6 @@
         <file>86box_vi-VN.qm</file>
         <file>86box_zh-CN.qm</file>
         <file>86box_zh-TW.qm</file>
+@QT_TRANSLATIONS_LIST@
     </qresource>
 </RCC>


### PR DESCRIPTION
Fixes standard messagebox buttons not being translated

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
