### PR TITLE
GitHub Actions maintenance

### DIFF
--- a/.github/workflows/cmake_linux.yml
+++ b/.github/workflows/cmake_linux.yml
@@ -81,6 +81,7 @@ jobs:
           libopenal-dev
           libslirp-dev
           libfluidsynth-dev
+          libvdeplug-dev
           ${{ matrix.ui.packages }}
 
       - name: Checkout repository

--- a/.github/workflows/cmake_macos.yml
+++ b/.github/workflows/cmake_macos.yml
@@ -81,6 +81,7 @@ jobs:
           openal-soft
           fluidsynth
           libslirp
+          vde
           ${{ matrix.ui.packages }}
 
       - name: Checkout repository

--- a/.github/workflows/cmake_windows_msys2.yml
+++ b/.github/workflows/cmake_windows_msys2.yml
@@ -67,15 +67,9 @@ jobs:
         environment:
 #          - msystem: MSYS
 #            toolchain: ./cmake/flags-gcc-x86_64.cmake
-#          - msystem: MINGW32
-#            prefix: mingw-w64-i686
-#            toolchain: ./cmake/flags-gcc-i686.cmake
           - msystem: MINGW64
             prefix: mingw-w64-x86_64
             toolchain: ./cmake/flags-gcc-x86_64.cmake
-#          - msystem: CLANG32
-#            prefix: mingw-w64-clang-i686
-#            toolchain: ./cmake/llvm-win32-i686.cmake
 #          - msystem: CLANG64
 #            prefix: mingw-w64-clang-x86_64
 #            toolchain: ./cmake/llvm-win32-x86_64.cmake

--- a/.github/workflows/codeql_linux.yml
+++ b/.github/workflows/codeql_linux.yml
@@ -84,6 +84,7 @@ jobs:
           libopenal-dev
           libslirp-dev
           libfluidsynth-dev
+          libvdeplug-dev
           ${{ matrix.ui.packages }}
 
       - name: Checkout repository

--- a/.github/workflows/codeql_macos.yml
+++ b/.github/workflows/codeql_macos.yml
@@ -75,6 +75,7 @@ jobs:
           openal-soft
           fluidsynth
           libslirp
+          vde
           ${{ matrix.ui.packages }}
 
       - name: Checkout repository

--- a/.github/workflows/codeql_windows_msys2.yml
+++ b/.github/workflows/codeql_windows_msys2.yml
@@ -72,15 +72,9 @@ jobs:
         environment:
 #          - msystem: MSYS
 #            toolchain: ./cmake/flags-gcc-x86_64.cmake
-          - msystem: MINGW32
-            prefix: mingw-w64-i686
-            toolchain: ./cmake/flags-gcc-i686.cmake
           - msystem: MINGW64
             prefix: mingw-w64-x86_64
             toolchain: ./cmake/flags-gcc-x86_64.cmake
-#          - msystem: CLANG32
-#            prefix: mingw-w64-clang-i686
-#            toolchain: ./cmake/llvm-win32-i686.cmake
 #          - msystem: CLANG64
 #            prefix: mingw-w64-clang-x86_64
 #            toolchain: ./cmake/llvm-win32-x86_64.cmake


### PR DESCRIPTION
Summary
=======
- Drop the remnants of 32-bit Windows builds, in anticipation of MSYS2's CLANG32 environment being phased out, and the qt5-static package dropping MINGW32
- Add libvdeplug as a dependency on \*nix

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A