### PR TITLE
temporaly rename to Samsung s800 machine_table.c

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -5030,7 +5030,7 @@ const machine_t machines[] = {
     },
     /* Has IBM AT KBC firmware. */
     {
-        .name = "[C&T 386] Samsung SPC-6000A",
+        .name = "[C&T 386] Samsung S800",
         .internal_name = "spc6000a",
         .type = MACHINE_TYPE_386DX,
         .chipset = MACHINE_CHIPSET_CT_386,


### PR DESCRIPTION
was from samsung s800 which is wrong.

both have the same board
src:
spc-6000A
https://cafe.naver.com/oldsell/50603
s800
https://theretroweb.com/motherboards/s/samsung-s800#bios
https://media.discordapp.net/attachments/873940177716924416/1038148167784468560/unknown.png?ex=674215d3&is=6740c453&hm=e748aca5e21ff8744751b59c30c8acd09cc656855cb20521fe5a4df1936364fb&=&format=webp&quality=lossless&width=825&height=619

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
