### PR TITLE
replace the wrong bios with correct samsung spc6000a

### DIFF
--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -229,7 +229,7 @@ machine_at_spc6000a_init(const machine_t *model)
 
     ret = bios_load_interleaved("roms/machines/spc6000a/6000A.U27",
                                 "roms/machines/spc6000a/6000A.U26",
-                                0x000f8000, 65536, 0);
+                                0x000f0000, 65536, 0);
 
     if (bios_only || !ret)
         return ret;

--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -227,9 +227,9 @@ machine_at_spc6000a_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_interleaved("roms/machines/spc6000a/3c80.u27",
-                                "roms/machines/spc6000a/9f80.u26",
-                                0x000f8000, 32768, 0);
+    ret = bios_load_interleaved("roms/machines/spc6000a/6000A.U27",
+                                "roms/machines/spc6000a/6000A.U26",
+                                0x000f8000, 65536, 0);
 
     if (bios_only || !ret)
         return ret;


### PR DESCRIPTION
was from s800.
I Should add Samsung s800 machine?
since has same board
src: https://cafe.naver.com/oldsell/50603
https://theretroweb.com/motherboards/s/samsung-s800

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [X ] I have opened a roms pull request - https://github.com/flama12333/roms/
References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
