### PR TITLE
Add "The Entertainer" for Microprose Gunship 429.04

### DIFF
--- a/src/include/86box/snd_resid.h
+++ b/src/include/86box/snd_resid.h
@@ -4,7 +4,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-void   *sid_init(void);
+void   *sid_init(uint8_t type);
 void    sid_close(void *priv);
 void    sid_reset(void *priv);
 uint8_t sid_read(uint16_t addr, void *priv);

--- a/src/include/86box/sound.h
+++ b/src/include/86box/sound.h
@@ -192,6 +192,7 @@ extern const device_t ps1snd_device;
 
 /* Innovation SSI-2001 */
 extern const device_t ssi2001_device;
+extern const device_t entertainer_device;
 
 /* Pro Audio Spectrum Plus, 16, and 16D */
 extern const device_t pasplus_device;

--- a/src/sound/snd_resid.cpp
+++ b/src/sound/snd_resid.cpp
@@ -20,7 +20,7 @@ typedef struct psid_t {
 psid_t *psid;
 
 void *
-sid_init(void)
+sid_init(uint8_t type)
 {
     reSIDfp::SamplingMethod method         = reSIDfp::RESAMPLE;
     float                   cycles_per_sec = 14318180.0 / 16.0;
@@ -28,7 +28,13 @@ sid_init(void)
     psid      = new psid_t;
     psid->sid = new SID;
 
-    psid->sid->setChipModel(reSIDfp::MOS6581);
+    switch (type) {
+        default:
+        case 0:
+            psid->sid->setChipModel(reSIDfp::MOS6581);
+        case 1:
+            psid->sid->setChipModel(reSIDfp::MOS8580);
+    }
 
     psid->sid->reset();
 

--- a/src/sound/snd_resid.cpp
+++ b/src/sound/snd_resid.cpp
@@ -22,16 +22,10 @@ psid_t *psid;
 void *
 sid_init(void)
 {
-#if 0
-    psid_t *psid;
-#endif
     reSIDfp::SamplingMethod method         = reSIDfp::RESAMPLE;
     float                   cycles_per_sec = 14318180.0 / 16.0;
 
-    psid = new psid_t;
-#if 0
-    psid = (psid_t *) malloc(sizeof(sound_t));
-#endif
+    psid      = new psid_t;
     psid->sid = new SID;
 
     psid->sid->setChipModel(reSIDfp::MOS6581);
@@ -57,9 +51,6 @@ sid_init(void)
 void
 sid_close(UNUSED(void *priv))
 {
-#if 0
-    psid_t *psid = (psid_t *) priv;
-#endif
     delete psid->sid;
 #if 0
     free(psid);
@@ -69,10 +60,6 @@ sid_close(UNUSED(void *priv))
 void
 sid_reset(UNUSED(void *priv))
 {
-#if 0
-    psid_t *psid = (psid_t *) priv;
-#endif
-
     psid->sid->reset();
 
     for (uint8_t c = 0; c < 32; c++)
@@ -82,23 +69,12 @@ sid_reset(UNUSED(void *priv))
 uint8_t
 sid_read(uint16_t addr, UNUSED(void *priv))
 {
-#if 0
-    psid_t *psid = (psid_t *) priv;
-#endif
-
     return psid->sid->read(addr & 0x1f);
-#if 0
-    return 0xFF;
-#endif
 }
 
 void
 sid_write(uint16_t addr, uint8_t val, UNUSED(void *priv))
 {
-#if 0
-    psid_t *psid = (psid_t *) priv;
-#endif
-
     psid->sid->write(addr & 0x1f, val);
 }
 
@@ -116,9 +92,6 @@ fillbuf2(int &count, int16_t *buf, int len)
 void
 sid_fillbuf(int16_t *buf, int len, UNUSED(void *priv))
 {
-#if 0
-    psid_t *psid = (psid_t *) priv;
-#endif
     int x = CLOCK_DELTA(len);
 
     fillbuf2(x, buf, len);

--- a/src/sound/snd_ssi2001.c
+++ b/src/sound/snd_ssi2001.c
@@ -21,6 +21,10 @@ typedef struct ssi2001_t {
     int     gameport_enabled;
 } ssi2001_t;
 
+typedef struct entertainer_t {
+    uint8_t regs;
+} entertainer_t;
+
 static void
 ssi2001_update(ssi2001_t *ssi2001)
 {
@@ -90,6 +94,48 @@ ssi2001_close(void *priv)
     free(ssi2001);
 }
 
+static uint8_t
+entertainer_read(uint16_t addr, void *priv)
+{
+    return 0xa5;
+}
+
+static void
+entertainer_write(uint16_t addr, uint8_t val, void *priv)
+{
+    entertainer_t *entertainer = (entertainer_t *) priv;
+    entertainer->regs = val;
+}
+
+void *
+entertainer_init(UNUSED(const device_t *info))
+{
+    ssi2001_t     *ssi2001     = malloc(sizeof(ssi2001_t));
+    entertainer_t *entertainer = malloc(sizeof(entertainer_t));
+    memset(ssi2001, 0, sizeof(ssi2001_t));
+    memset(entertainer, 0, sizeof(entertainer_t));
+
+    ssi2001->psid = sid_init(0);
+    sid_reset(ssi2001->psid);
+    ssi2001->gameport_enabled = device_get_config_int("gameport");
+    io_sethandler(0x200, 0x0001, entertainer_read, NULL, NULL, entertainer_write, NULL, NULL, entertainer);
+    io_sethandler(0x280, 0x0020, ssi2001_read, NULL, NULL, ssi2001_write, NULL, NULL, ssi2001);
+    if (ssi2001->gameport_enabled)
+        gameport_remap(gameport_add(&gameport_201_device), 0x201);
+    sound_add_handler(ssi2001_get_buffer, ssi2001);
+    return ssi2001;
+}
+
+void
+entertainer_close(void *priv)
+{
+    ssi2001_t *ssi2001 = (ssi2001_t *) priv;
+
+    sid_close(ssi2001->psid);
+
+    free(ssi2001);
+}
+
 static const device_config_t ssi2001_config[] = {
     // clang-format off
     {
@@ -125,6 +171,13 @@ static const device_config_t ssi2001_config[] = {
 // clang-format off
 };
 
+static const device_config_t entertainer_config[] = {
+    // clang-format off
+    { "gameport", "Enable Game port", CONFIG_BINARY, "",  1 },
+    { "",         "",                                    -1 }
+// clang-format off
+};
+
 const device_t ssi2001_device = {
     .name          = "Innovation SSI-2001",
     .internal_name = "ssi2001",
@@ -137,4 +190,18 @@ const device_t ssi2001_device = {
     .speed_changed = NULL,
     .force_redraw  = NULL,
     .config        = ssi2001_config
+};
+
+const device_t entertainer_device = {
+    .name          = "The Entertainer",
+    .internal_name = "Entertainer",
+    .flags         = DEVICE_ISA,
+    .local         = 1,
+    .init          = entertainer_init,
+    .close         = entertainer_close,
+    .reset         = NULL,
+    { .available   = NULL },
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = entertainer_config
 };

--- a/src/sound/snd_ssi2001.c
+++ b/src/sound/snd_ssi2001.c
@@ -69,7 +69,7 @@ ssi2001_init(UNUSED(const device_t *info))
     ssi2001_t *ssi2001 = malloc(sizeof(ssi2001_t));
     memset(ssi2001, 0, sizeof(ssi2001_t));
 
-    ssi2001->psid = sid_init();
+    ssi2001->psid = sid_init(0);
     sid_reset(ssi2001->psid);
     uint16_t addr             = device_get_config_hex16("base");
     ssi2001->gameport_enabled = device_get_config_int("gameport");

--- a/src/sound/snd_ssi2001.c
+++ b/src/sound/snd_ssi2001.c
@@ -126,15 +126,15 @@ static const device_config_t ssi2001_config[] = {
 };
 
 const device_t ssi2001_device = {
-    .name = "Innovation SSI-2001",
+    .name          = "Innovation SSI-2001",
     .internal_name = "ssi2001",
-    .flags = DEVICE_ISA,
-    .local = 0,
-    .init = ssi2001_init,
-    .close = ssi2001_close,
-    .reset = NULL,
-    { .available = NULL },
+    .flags         = DEVICE_ISA,
+    .local         = 0,
+    .init          = ssi2001_init,
+    .close         = ssi2001_close,
+    .reset         = NULL,
+    { .available   = NULL },
     .speed_changed = NULL,
-    .force_redraw = NULL,
-    .config = ssi2001_config
+    .force_redraw  = NULL,
+    .config        = ssi2001_config
 };

--- a/src/sound/sound.c
+++ b/src/sound/sound.c
@@ -132,6 +132,7 @@ static const SOUND_CARD sound_cards[] = {
     { &sb_vibra16s_device           },
     { &sb_vibra16xv_device          },
     { &ssi2001_device               },
+    { &entertainer_device           },
     { &pasplus_device               },
     { &pas16_device                 },
     { &pas16d_device                },


### PR DESCRIPTION
Summary
=======
Add "The Entertainer" for Microprose Gunship 429.04

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://forum.vcfed.org/index.php?threads/the-entertainer-sound-card-exposed.41255/
