### PR TITLE
Add initial support for YM2151 & YM2164

### DIFF
--- a/src/include/86box/snd_opl.h
+++ b/src/include/86box/snd_opl.h
@@ -22,9 +22,13 @@ enum fm_type {
     FM_YMF262    = 1, /* OPL3 */
     FM_YMF289B   = 2, /* OPL3-L */
     FM_YMF278B   = 3, /* OPL4 */
-    FM_ESFM      = 4, /* ESFM */
-    FM_OPL2BOARD = 5, /* OPL2Board (External Device) */
-    FM_MAX       = 6
+    FM_YM2151    = 4, /* OPM */
+#if 0
+    FM_YM2164    = 5, /* OPP */
+#endif
+    FM_ESFM      = 6, /* ESFM */
+    FM_OPL2BOARD = 7, /* OPL2Board (External Device) */
+    FM_MAX       = 8
 };
 
 enum fm_driver {
@@ -58,6 +62,11 @@ extern const device_t ym3812_ymfm_device;
 extern const device_t ymf262_ymfm_device;
 extern const device_t ymf289b_ymfm_device;
 extern const device_t ymf278b_ymfm_device;
+
+extern const device_t ym2151_ymfm_device;
+#if 0
+extern const device_t ym2164_ymfm_device;
+#endif
 
 extern const device_t esfm_esfmu_device;
 

--- a/src/sound/snd_opl.c
+++ b/src/sound/snd_opl.c
@@ -68,6 +68,18 @@ fm_driver_get(int chip_id, fm_drv_t *drv)
             *drv      = ymfm_drv;
             drv->priv = device_add_inst(&ymf278b_ymfm_device, fm_dev_inst[fm_driver][chip_id]++);
             break;
+
+        case FM_YM2151: /* OPM */
+            *drv      = ymfm_drv;
+            drv->priv = device_add_inst(&ym2151_ymfm_device, fm_dev_inst[fm_driver][chip_id]++);
+            break;
+
+#if 0
+        case FM_YM2164: /* OPP */
+            *drv      = ymfm_drv;
+            drv->priv = device_add_inst(&ym2164_ymfm_device, fm_dev_inst[fm_driver][chip_id]++);
+            break;
+#endif
         
         case FM_ESFM:
             *drv      = esfmu_opl_drv;

--- a/src/sound/snd_opl_ymfm.cpp
+++ b/src/sound/snd_opl_ymfm.cpp
@@ -19,6 +19,7 @@
 #include <cstdlib>
 #include <cstring>
 #include "ymfm/ymfm_opl.h"
+#include "ymfm/ymfm_opm.h"
 
 extern "C" {
 #define HAVE_STDARG_H
@@ -320,23 +321,33 @@ ymfm_drv_init(const device_t *info)
 
     switch (info->local) {
         default:
-        case FM_YM3812:
+        case FM_YM3812: /* OPL2 */
             fm = (YMFMChipBase *) new YMFMChip<ymfm::ym3812>(3579545, FM_YM3812, FREQ_49716);
             break;
 
-        case FM_YMF262:
+        case FM_YMF262: /* OPL3 */
             fm = (YMFMChipBase *) new YMFMChip<ymfm::ymf262>(14318181, FM_YMF262, FREQ_49716);
             break;
 
-        case FM_YMF289B:
+        case FM_YMF289B: /* OPL3-L */
             /* According to the datasheet, we should be using 33868800, but YMFM appears
                to cheat and does it using the same values as the YMF262. */
             fm = (YMFMChipBase *) new YMFMChip<ymfm::ymf289b>(14318181, FM_YMF289B, FREQ_49716);
             break;
 
-        case FM_YMF278B:
+        case FM_YMF278B: /* OPL4 */
             fm = (YMFMChipBase *) new YMFMChip<ymfm::ymf278b>(33868800, FM_YMF278B, FREQ_44100);
             break;
+
+        case FM_YM2151: /* OPM */
+            fm = (YMFMChipBase *) new YMFMChip<ymfm::ym2151>(14318181, FM_YM2151, FREQ_49716);
+            break;
+
+#if 0
+        case FM_YM2164: /* OPP */
+            fm = (YMFMChipBase *) new YMFMChip<ymfm::ym2164>(14318181, FM_YM2164, FREQ_49716);
+            break;
+#endif
     }
 
     fm->set_do_cycles(1);
@@ -458,6 +469,36 @@ const device_t ymf289b_ymfm_device = {
     .force_redraw  = NULL,
     .config        = NULL
 };
+
+const device_t ym2151_ymfm_device = {
+    .name          = "Yamaha YM2151 OPM (YMFM)",
+    .internal_name = "ym2151_ymfm",
+    .flags         = 0,
+    .local         = FM_YM2151,
+    .init          = ymfm_drv_init,
+    .close         = ymfm_drv_close,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = NULL
+};
+
+#if 0
+const device_t ym2164_ymfm_device = {
+    .name          = "Yamaha YM2164 OPP (YMFM)",
+    .internal_name = "ym2164_ymfm",
+    .flags         = 0,
+    .local         = FM_YM2164,
+    .init          = ymfm_drv_init,
+    .close         = ymfm_drv_close,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = NULL
+};
+#endif
 
 const device_t ymf278b_ymfm_device = {
     .name          = "Yamaha YMF278B OPL4 (YMFM)",


### PR DESCRIPTION
Summary
=======
Add initial support for YM2151 & YM2164
(Specifically the underlying hooks for the SAAYM and IBM Music Feature Card in YMFM)

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
