### PR TITLE
S3 and Cirrus updates of the first day of winter (December 21, 2024)

### DIFF
--- a/src/video/vid_cl54xx.c
+++ b/src/video/vid_cl54xx.c
@@ -3541,6 +3541,10 @@ gd54xx_mem_sys_src(gd54xx_t *gd54xx, uint32_t cpu_dat, uint32_t count)
             mask_shift = 31 - byte_pos;
             if (!(gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND))
                 cpu_dat >>= byte_pos;
+            else {
+                if (gd54xx->blt.modeext & CIRRUS_BLTMODEEXT_DWORDGRANULARITY)
+                    cpu_dat = ((cpu_dat & 0xff000000) >> 24) | ((cpu_dat & 0x00ff0000) >> 8) | ((cpu_dat & 0x0000ff00) << 8) | ((cpu_dat & 0x000000ff) << 24);
+            }
         } else
             mask_shift = 7;
 

--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -4312,7 +4312,7 @@ s3_recalctimings(svga_t *svga)
         }
     }
 
-    if ((s3->chip == S3_TRIO32) || (s3->chip == S3_TRIO64) || (s3->chip == S3_VISION864))
+    if ((s3->chip == S3_TRIO32) || (s3->chip == S3_TRIO64) || (s3->chip == S3_VISION864) || (s3->chip == S3_VISION868) || (s3->chip == S3_VISION968))
         svga->hoverride = 1;
     else
         svga->hoverride = 0;
@@ -8337,7 +8337,13 @@ s3_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat, voi
                     if (update) {
                         READ(s3->accel.dest + s3->accel.cx - s3->accel.minus, dest_dat);
 
-                        MIX
+                        if (s3_cpu_dest(s3)) {
+                            if (vram_mask) {
+                                MIX
+                            }
+                        } else {
+                            MIX
+                        }
 
                         if (s3->accel.cmd & 0x10) {
                             if (s3->accel.cmd == 0x41b3)


### PR DESCRIPTION
Summary
=======
Cirrus 5436/46 and 5480.
Finally fixed the Solaris 2.6 font issue, was a dword swap one with color expansion.

S3.
1. Make 868/968 ignore horizontal skew, ergo horizontal override until a proper solution is found regarding hardware tests.
2. Fixed a minor mix issue with S3 911/924 Win3.1 drivers in 8bpp mode.

Checklist
=========
* [x] Closes #4868
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
