### PR TITLE
8514/A change of the day (December 22nd, 2024)

### DIFF
--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -285,7 +285,7 @@ ibm8514_accel_out_pixtrans(svga_t *svga, UNUSED(uint16_t port), uint32_t val, in
                             if ((cmd >= 2) && (dev->accel.cmd & 0x1000))
                                 val = (val >> 8) | (val << 8);
                         }
-                        if ((cmd <= 2) || (cmd == 4)) {
+                        if ((cmd <= 2) || (cmd == 4) || ((cmd == 6))) {
                             if ((dev->accel.cmd & 0x08) && (cmd >= 2))
                                 monoxfer = val;
                             else {


### PR DESCRIPTION
Summary
=======
Fix nibble pixtrans on bitblt command (CMD 6), this makes icons and stuff on MS OS/2 1.10 Nokia's 8514 driver no longer glitchy (IBM's was already fine as is and it still is).


Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
