### PR TITLE
Add initial Mazovia 1016 emulation

### DIFF
--- a/src/cpu/808x.c
+++ b/src/cpu/808x.c
@@ -240,13 +240,13 @@ cpu_io(int bits, int out, uint16_t port)
     int old_cycles = cycles;
 
     if (out) {
-        wait(4, 1);
+        wait(is_mazovia ? 5 : 4, 1);
         if (bits == 16) {
             if (is8086 && !(port & 1)) {
                 old_cycles = cycles;
                 outw(port, AX);
             } else {
-                wait(4, 1);
+                wait(is_mazovia ? 5 : 4, 1);
                 old_cycles = cycles;
                 outb(port++, AL);
                 outb(port, AH);
@@ -256,13 +256,13 @@ cpu_io(int bits, int out, uint16_t port)
             outb(port, AL);
         }
     } else {
-        wait(4, 1);
+        wait(is_mazovia ? 5 : 4, 1);
         if (bits == 16) {
             if (is8086 && !(port & 1)) {
                 old_cycles = cycles;
                 AX         = inw(port);
             } else {
-                wait(4, 1);
+                wait(is_mazovia ? 5 : 4, 1);
                 old_cycles = cycles;
                 AL         = inb(port++);
                 AH         = inb(port);

--- a/src/cpu/cpu.c
+++ b/src/cpu/cpu.c
@@ -203,6 +203,7 @@ int cpu_override_interpreter;
 int CPUID;
 
 int is186;
+int is_mazovia;
 int is_nec;
 int is286;
 int is386;
@@ -517,6 +518,7 @@ cpu_set(void)
 
     CPUID       = cpu_s->cpuid_model;
     is8086      = (cpu_s->cpu_type > CPU_8088) && (cpu_s->cpu_type != CPU_V20) && (cpu_s->cpu_type != CPU_188);
+    is_mazovia  = (cpu_s->cpu_type == CPU_8086_MAZOVIA);
     is_nec      = (cpu_s->cpu_type == CPU_V20) || (cpu_s->cpu_type == CPU_V30);
     is186       = (cpu_s->cpu_type == CPU_186) || (cpu_s->cpu_type == CPU_188) || (cpu_s->cpu_type == CPU_V20) || (cpu_s->cpu_type == CPU_V30);
     is286       = (cpu_s->cpu_type >= CPU_286);
@@ -767,6 +769,7 @@ cpu_set(void)
     switch (cpu_s->cpu_type) {
         case CPU_8088:
         case CPU_8086:
+        case CPU_8086_MAZOVIA:
             break;
 
         case CPU_V20:

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -35,6 +35,7 @@ enum {
 enum {
     CPU_8088 = 1, /* 808x class CPUs */
     CPU_8086,
+    CPU_8086_MAZOVIA,
     CPU_V20, /* NEC 808x class CPUs */
     CPU_V30,
     CPU_188, /* 18x class CPUs */
@@ -87,28 +88,29 @@ enum {
     CPU_PKG_8088             = (1 << 0),
     CPU_PKG_8088_EUROPC      = (1 << 1),
     CPU_PKG_8086             = (1 << 2),
-    CPU_PKG_188              = (1 << 3),
-    CPU_PKG_186              = (1 << 4),
-    CPU_PKG_286              = (1 << 5),
-    CPU_PKG_386SX            = (1 << 6),
-    CPU_PKG_386DX            = (1 << 7),
-    CPU_PKG_386DX_DESKPRO386 = (1 << 8),
-    CPU_PKG_M6117            = (1 << 9),
-    CPU_PKG_386SLC_IBM       = (1 << 10),
-    CPU_PKG_486SLC           = (1 << 11),
-    CPU_PKG_486SLC_IBM       = (1 << 12),
-    CPU_PKG_486BL            = (1 << 13),
-    CPU_PKG_486DLC           = (1 << 14),
-    CPU_PKG_SOCKET1          = (1 << 15),
-    CPU_PKG_SOCKET3          = (1 << 16),
-    CPU_PKG_SOCKET3_PC330    = (1 << 17),
-    CPU_PKG_STPC             = (1 << 18),
-    CPU_PKG_SOCKET4          = (1 << 19),
-    CPU_PKG_SOCKET5_7        = (1 << 20),
-    CPU_PKG_SOCKET8          = (1 << 21),
-    CPU_PKG_SLOT1            = (1 << 22),
-    CPU_PKG_SLOT2            = (1 << 23),
-    CPU_PKG_SOCKET370        = (1 << 24)
+    CPU_PKG_8086_MAZOVIA     = (1 << 3),
+    CPU_PKG_188              = (1 << 4),
+    CPU_PKG_186              = (1 << 5),
+    CPU_PKG_286              = (1 << 6),
+    CPU_PKG_386SX            = (1 << 7),
+    CPU_PKG_386DX            = (1 << 8),
+    CPU_PKG_386DX_DESKPRO386 = (1 << 9),
+    CPU_PKG_M6117            = (1 << 10),
+    CPU_PKG_386SLC_IBM       = (1 << 11),
+    CPU_PKG_486SLC           = (1 << 12),
+    CPU_PKG_486SLC_IBM       = (1 << 13),
+    CPU_PKG_486BL            = (1 << 14),
+    CPU_PKG_486DLC           = (1 << 15),
+    CPU_PKG_SOCKET1          = (1 << 16),
+    CPU_PKG_SOCKET3          = (1 << 17),
+    CPU_PKG_SOCKET3_PC330    = (1 << 18),
+    CPU_PKG_STPC             = (1 << 19),
+    CPU_PKG_SOCKET4          = (1 << 20),
+    CPU_PKG_SOCKET5_7        = (1 << 21),
+    CPU_PKG_SOCKET8          = (1 << 22),
+    CPU_PKG_SLOT1            = (1 << 23),
+    CPU_PKG_SLOT2            = (1 << 24),
+    CPU_PKG_SOCKET370        = (1 << 25)
 };
 
 #define CPU_SUPPORTS_DYNAREC 1
@@ -518,6 +520,7 @@ extern int is_p6;
 extern int is_cxsmm;
 extern int hascache;
 extern int isibm486;
+extern int is_mazovia;
 extern int is_nec;
 extern int is_rapidcad;
 extern int hasfpu;

--- a/src/cpu/cpu_table.c
+++ b/src/cpu/cpu_table.c
@@ -374,6 +374,32 @@ const cpu_family_t cpu_families[] = {
         }
     },
     {
+        .package       = CPU_PKG_8086_MAZOVIA,
+        .manufacturer  = "Kyiv Research Institute of Microdevices",
+        .name          = "K1810VM86",
+        .internal_name = "8086_mazovia",
+        .cpus          = (const CPU[]) {
+            {
+                .name               = "4.77",
+                .cpu_type           = CPU_8086_MAZOVIA,
+                .fpus               = fpus_8088,
+                .rspeed             = 4772728,
+                .multi              = 1,
+                .voltage            = 5000,
+                .edx_reset          = 0,
+                .cpuid_model        = 0,
+                .cyrix_id           = 0,
+                .cpu_flags          = CPU_ALTERNATE_XTAL,
+                .mem_read_cycles    = 0,
+                .mem_write_cycles   = 0,
+                .cache_read_cycles  = 0,
+                .cache_write_cycles = 0,
+                .atclk_div          = 1
+            },
+            { .name = "", 0 }
+        }
+    },
+    {
         .package       = CPU_PKG_188,
         .manufacturer  = "Intel",
         .name          = "80188",

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -939,6 +939,7 @@ extern int machine_xt_iskra3104_init(const machine_t *);
 extern int machine_xt_pravetz16_imko4_init(const machine_t *);
 extern int machine_xt_pravetz16s_cpu12p_init(const machine_t *);
 extern int machine_xt_micoms_xl7turbo_init(const machine_t *);
+extern int machine_xt_maz1016_init(const machine_t *);
 
 /* m_xt_compaq.c */
 extern int machine_xt_compaq_deskpro_init(const machine_t *);

--- a/src/machine/m_xt.c
+++ b/src/machine/m_xt.c
@@ -19,6 +19,7 @@
 #include <86box/machine.h>
 #include <86box/chipset.h>
 #include <86box/port_6x.h>
+#include <86box/video.h>
 
 extern const device_t vendex_xt_rtc_onboard_device;
 
@@ -324,6 +325,35 @@ machine_xt_iskra3104_init(const machine_t *model)
 
     if (bios_only || !ret)
         return ret;
+
+    machine_xt_clone_init(model, 0);
+
+    return ret;
+}
+
+int
+machine_xt_maz1016_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_interleaved("roms/machines/maz1016/e1.bin",
+                                "roms/machines/maz1016/e4.bin",
+                                0x000fc000, 49152, 0);
+
+    if (ret) {
+        bios_load_aux_interleaved("roms/machines/maz1016/e2.bin",
+                                  "roms/machines/maz1016/e5.bin",
+                                  0x000f8000, 16384, 0);
+
+        bios_load_aux_interleaved("roms/machines/maz1016/e3.bin",
+                                  "roms/machines/maz1016/e6b.bin",
+                                  0x000f4000, 16384, 0);
+    }
+
+    if (bios_only || !ret)
+        return ret;
+
+    loadfont("roms/machines/maz1016/crt-8.bin", 0);
 
     machine_xt_clone_init(model, 0);
 

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -2284,6 +2284,45 @@ const machine_t machines[] = {
         .net_device = NULL
     },
     {
+        .name = "[8086] Mazovia 1016",
+        .internal_name = "maz1016",
+        .type = MACHINE_TYPE_8086,
+        .chipset = MACHINE_CHIPSET_DISCRETE,
+        .init = machine_xt_maz1016_init,
+        .p1_handler = NULL,
+        .gpio_handler = NULL,
+        .available_flag = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu = {
+            .package = CPU_PKG_8086_MAZOVIA,
+            .block = CPU_BLOCK_NONE,
+            .min_bus = 0,
+            .max_bus = 0,
+            .min_voltage = 0,
+            .max_voltage = 0,
+            .min_multi = 0,
+            .max_multi = 0
+        },
+        .bus_flags = MACHINE_PC,
+        .flags = MACHINE_FLAGS_NONE,
+        .ram = {
+            .min = 256,
+            .max = 640,
+            .step = 384
+        },
+        .nvrmask = 0,
+        .kbc_device = &keyboard_xtclone_device,
+        .kbc_p1 = 0xff,
+        .gpio = 0xffffffff,
+        .gpio_acpi = 0xffffffff,
+        .device = NULL,
+        .fdc_device = NULL,
+        .sio_device = NULL,
+        .vid_device = NULL,
+        .snd_device = NULL,
+        .net_device = NULL
+    },
+    {
         .name = "[8086] Olivetti M21/24/24SP",
         .internal_name = "m24",
         .type = MACHINE_TYPE_8086,


### PR DESCRIPTION
Summary
=======

![Mazovia 1016 emulation in a local branch of 86Box](https://img.asie.pl/DkKl.png)

This pull request adds initial emulation of the Mazovia 1016, which was a homegrown IBM PC/XT clone designed in Poland using components available in the Eastern Bloc. Notably, as 8088 clone CPUs were not available at this time, the Mazovia adapts the XT design to use an 8086 CPU, albeit with I/O bus accesses lengthened by an additional cycle (as documented by the references).

Note that this attempts to emulate the original "M86" design. Some manufacturers of the Mazovia later switched to using the same cases to fit (cheaper) Taiwanese 8088 XT boards under their own brand - for example, there exists a BIOS dump from 1989 which is the Phoenix XT 2.27 BIOS with stripped out and replaced copyright notices (no, really, [that's the only major difference](https://img.asie.pl/aiIT.png)). I'm not sure if there's a point in emulating _that_.

Unfortunately, as I do not have access to a functional unit, some aspects (in particular, if the keyboard emits any non-standard scancodes) could not be documented; thus why I consider this emulation "initial", but sufficient.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/281

References
==========

- [Popko, Janusz. 1988. Jednostka centralna Mazovii 1016. Informatyka 1/1988, pages 9-10](http://delibra.bg.polsl.pl/Content/6384/Nr1_88_AB.pdf) (system architecture overview)