### PR TITLE
Add PNP 1IO and make Vibra16XV use it

### DIFF
--- a/src/game/gameport.c
+++ b/src/game/gameport.c
@@ -674,6 +674,20 @@ const device_t gameport_pnp_device = {
     .config        = NULL
 };
 
+const device_t gameport_pnp_1io_device = {
+    .name          = "Game port (Plug and Play only, 1 I/O port)",
+    .internal_name = "gameport_pnp_1io",
+    .flags         = 0,
+    .local         = GAMEPORT_1ADDR,
+    .init          = gameport_init,
+    .close         = gameport_close,
+    .reset         = NULL,
+    { .available = NULL },
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = NULL
+};
+
 const device_t gameport_pnp_6io_device = {
     .name          = "Game port (Plug and Play only, 6 I/O ports)",
     .internal_name = "gameport_pnp_6io",

--- a/src/include/86box/gameport.h
+++ b/src/include/86box/gameport.h
@@ -127,6 +127,7 @@ extern const device_t gameport_20d_device;
 extern const device_t gameport_20f_device;
 extern const device_t gameport_tm_acm_device;
 extern const device_t gameport_pnp_device;
+extern const device_t gameport_pnp_1io_device;
 extern const device_t gameport_pnp_6io_device;
 extern const device_t gameport_sio_device;
 extern const device_t gameport_sio_1io_device;


### PR DESCRIPTION
Summary
=======
Add PNP 1IO and make Vibra16XV use it

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None