### PR TITLE
DMA change of the day (December 31st, 2024)

### DIFF
--- a/src/dma.c
+++ b/src/dma.c
@@ -665,6 +665,19 @@ dma_ps2_read(uint16_t addr, UNUSED(void *priv))
                     temp = dma_c->arb_level;
                     break;
 
+                case 9: /*Set DMA mask*/
+                    dma_m |= (1 << dma_ps2.xfr_channel);
+                    break;
+
+                case 0xa: /*Reset DMA mask*/
+                    dma_m &= ~(1 << dma_ps2.xfr_channel);
+                    break;
+
+                case 0xb:
+                    if (!(dma_m & (1 << dma_ps2.xfr_channel)))
+                        dma_ps2_run(dma_ps2.xfr_channel);
+                    break;
+
                 default:
                     fatal("Bad XFR Read command %i channel %i\n", dma_ps2.xfr_command, dma_ps2.xfr_channel);
             }
@@ -765,6 +778,19 @@ dma_ps2_write(uint16_t addr, uint8_t val, UNUSED(void *priv))
 
                 case 8: /*Arbitration Level*/
                     dma_c->arb_level = val;
+                    break;
+
+                case 9: /*Set DMA mask*/
+                    dma_m |= (1 << dma_ps2.xfr_channel);
+                    break;
+
+                case 0xa: /*Reset DMA mask*/
+                    dma_m &= ~(1 << dma_ps2.xfr_channel);
+                    break;
+
+                case 0xb:
+                    if (!(dma_m & (1 << dma_ps2.xfr_channel)))
+                        dma_ps2_run(dma_ps2.xfr_channel);
                     break;
 
                 default:


### PR DESCRIPTION
Summary
=======
Actually add DMA PS/2 (MCA) XFER commands 0x9 (Set DMA Mask), 0xa (Reset DMA mask) and 0xb to addr 0x1a in both r/w parts.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
