### PR TITLE
SCSI CD-ROM change of the day (December 31st, 2024)

### DIFF
--- a/src/include/86box/scsi_device.h
+++ b/src/include/86box/scsi_device.h
@@ -129,6 +129,7 @@
 #define GPCMD_CADDY_EJECT_TOSHIBA                     0xc4 /* Toshiba Vendor Unique command */
 #define GPCMD_PAUSE_SONY                              0xc5 /* Sony Vendor Unique command */
 #define GPCMD_PLAY_AUDIO_MATSUSHITA                   0xc5 /* Matsushita Vendor Unique command */
+#define GPCMD_UNKNOWN_SCSI2_NEC                       0xc5 /* NEC Vendor Unique Command */
 #define GPCMD_STOP_CHINON                             0xc6 /* Chinon Vendor Unique command */
 #define GPCMD_PLAY_TRACK_SONY                         0xc6 /* Sony Vendor Unique command */
 #define GPCMD_READ_SUBCODEQ_PLAYING_STATUS_TOSHIBA    0xc6 /* Toshiba Vendor Unique command */

--- a/src/scsi/scsi_cdrom.c
+++ b/src/scsi/scsi_cdrom.c
@@ -2114,7 +2114,7 @@ scsi_cdrom_command_matsushita(void *sc, uint8_t *cdb, int32_t *BufLen)
             dev->current_cdb[0] = cdb[0];
             /* Keep cmd_stat at 0x00, therefore, it's going to process it as GPCMD_PLAY_AUDIO_MSF. */
             break;
-  
+
         case GPCMD_PLAY_AUDIO_TRACK_INDEX_MATSUSHITA:
             cdb[0]              = GPCMD_PLAY_AUDIO_TRACK_INDEX;
             dev->current_cdb[0] = cdb[0];
@@ -2161,6 +2161,12 @@ scsi_cdrom_command_nec(void *sc, uint8_t *cdb, int32_t *BufLen)
 
     switch (cdb[0]) {
         case GPCMD_NO_OPERATION_NEC:
+            scsi_cdrom_set_phase(dev, SCSI_PHASE_STATUS);
+            scsi_cdrom_command_complete(dev);
+            cmd_stat = 0x01;
+            break;
+
+        case GPCMD_UNKNOWN_SCSI2_NEC:
             scsi_cdrom_set_phase(dev, SCSI_PHASE_STATUS);
             scsi_cdrom_command_complete(dev);
             cmd_stat = 0x01;
@@ -2305,7 +2311,7 @@ scsi_cdrom_command_pioneer(void *sc, uint8_t *cdb, int32_t *BufLen)
             else {
                 ret = cdrom_read_disc_info_toc(dev->drv, dev->buffer, cdb[2], cdb[1] & 3);
                 len = 4;
-        
+
                 if (ret) {
                     scsi_cdrom_set_buf_len(dev, BufLen, &len);
                     scsi_cdrom_data_command_finish(dev, len, len, len, 0);
@@ -2844,7 +2850,7 @@ scsi_cdrom_command(scsi_common_t *sc, uint8_t *cdb)
                         }
                     } else
                         ret = scsi_cdrom_read_blocks(dev, &alloc_length, 1, 0);
-    
+
                     if (ret > 0) {
                         dev->requested_blocks = max_len;
                         dev->packet_len       = alloc_length;


### PR DESCRIPTION
Summary
=======
Added undocumented 0xC5 NEC SCSI-2 CD-ROM command (most likely a no op command like 0x0D).

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
