### PR TITLE
Some machine changes of the day (January 1st, 2025)

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -643,6 +643,7 @@ extern int machine_at_p5sp4_init(const machine_t *);
 extern int machine_at_plato_init(const machine_t *);
 extern int machine_at_dellplato_init(const machine_t *);
 extern int machine_at_ambradp90_init(const machine_t *);
+extern int machine_at_p54np4_init(const machine_t *);
 extern int machine_at_586ip_init(const machine_t *);
 extern int machine_at_tek932_init(const machine_t *);
 

--- a/src/machine/m_at_socket4.c
+++ b/src/machine/m_at_socket4.c
@@ -126,7 +126,6 @@ machine_at_p5mp3_init(const machine_t *model)
         return ret;
 
     machine_at_common_init(model);
-    device_add(&ide_pci_device);
 
     pci_init(PCI_CONFIG_TYPE_2 | PCI_NO_IRQ_STEERING);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);

--- a/src/machine/m_at_socket5.c
+++ b/src/machine/m_at_socket5.c
@@ -98,6 +98,36 @@ machine_at_ambradp90_init(const machine_t *model)
 }
 
 int
+machine_at_p54np4_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/p54np4/asus-642accdebcb75833703472.bin",
+                           0x000e0000, 131072, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_common_init(model);
+
+    pci_init(PCI_CONFIG_TYPE_2 | PCI_NO_IRQ_STEERING);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x03, PCI_CARD_NORMAL,      1, 2, 3, 4); /* 03 = Slot 1 */
+    pci_register_slot(0x04, PCI_CARD_NORMAL,      2, 3, 4, 1); /* 04 = Slot 2 */
+    pci_register_slot(0x05, PCI_CARD_NORMAL,      3, 4, 1, 2); /* 05 = Slot 3 */
+    pci_register_slot(0x06, PCI_CARD_NORMAL,      4, 1, 2, 3); /* 06 = Slot 4 */
+    pci_register_slot(0x07, PCI_CARD_SCSI,        1, 2, 3, 4); /* 07 = SCSI   */
+    pci_register_slot(0x02, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 0);
+    device_add(&i430nx_device);
+    device_add(&keyboard_ps2_ami_pci_device);
+    device_add(&fdc37c665_ide_pri_device);
+    device_add(&ncr53c810_onboard_pci_device);
+    device_add(&intel_flash_bxt_device);
+
+    return ret;
+}
+
+int
 machine_at_586ip_init(const machine_t *model)
 {
     int ret;

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -4348,9 +4348,9 @@ const machine_t machines[] = {
             .max_voltage = 0,
             .min_multi = 0,
             .max_multi = 0,
-            
+
         },
-        .bus_flags = MACHINE_PS2, 
+        .bus_flags = MACHINE_PS2,
         .flags = MACHINE_IDE | MACHINE_VIDEO , /* Machine has internal OTI 077 Video card*/
         .ram = {
             .min = 2048,
@@ -9643,6 +9643,46 @@ const machine_t machines[] = {
         .ram = {
             .min = 2048,
             .max = 131072,
+            .step = 2048
+        },
+        .nvrmask = 127,
+        .kbc_device = NULL,
+        .kbc_p1 = 0xff,
+        .gpio = 0xffffffff,
+        .gpio_acpi = 0xffffffff,
+        .device = NULL,
+        .fdc_device = NULL,
+        .sio_device = NULL,
+        .vid_device = NULL,
+        .snd_device = NULL,
+        .net_device = NULL
+    },
+    /* Has AMI 'H' KBC firmware. */
+    {
+        .name = "[i430NX] ASUS PCI/I-P54NP4",
+        .internal_name = "p54np4",
+        .type = MACHINE_TYPE_SOCKET5,
+        .chipset = MACHINE_CHIPSET_INTEL_430NX,
+        .init = machine_at_p54np4_init,
+        .p1_handler = NULL,
+        .gpio_handler = NULL,
+        .available_flag = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu = {
+            .package = CPU_PKG_SOCKET5_7,
+            .block = CPU_BLOCK_NONE,
+            .min_bus = 60000000,
+            .max_bus = 66666667,
+            .min_voltage = 3520,
+            .max_voltage = 3520,
+            .min_multi = 1.5,
+            .max_multi = 1.5
+        },
+        .bus_flags = MACHINE_PS2_PCI,
+        .flags = MACHINE_IDE | MACHINE_SCSI | MACHINE_APM,
+        .ram = {
+            .min = 2048,
+            .max = 524288,
             .step = 2048
         },
         .nvrmask = 127,


### PR DESCRIPTION
Summary
=======
1. Added the Award 430NX-based (Socket 5) ASUS P54NP4 with the right configuration.
2. Based on the pictures of the board, the IDE controller is not built-in in the ASUS P5MP3, but on a riser card, iirc, therefore, make IDE optional.


Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/285/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
