### PR TITLE
Add Compaq Presario 7100/7200 Series 486 Machine (UMC 8881)

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -593,6 +593,7 @@ extern int machine_at_pcm5330_init(const machine_t *);
 
 extern int machine_at_ecs486_init(const machine_t *);
 extern int machine_at_hot433a_init(const machine_t *);
+extern int machine_at_pl4600c_init(const machine_t *);
 extern int machine_at_atc1415_init(const machine_t *);
 extern int machine_at_actionpc2600_init(const machine_t *);
 extern int machine_at_actiontower8400_init(const machine_t *);

--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -48,6 +48,7 @@
 #include <86box/hwm.h>
 #include <86box/machine.h>
 #include <86box/plat_unused.h>
+#include <86box/sound.h>
 
 int
 machine_at_acc386_init(const machine_t *model)
@@ -1958,6 +1959,48 @@ machine_at_hot433a_init(const machine_t *model)
     device_add(&um8669f_device);
     device_add(&winbond_flash_w29c010_device);
     device_add(&keyboard_at_ami_device);
+
+    return ret;
+}
+
+int
+machine_at_pl4600c_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/pl4600c/SST29EE010.BIN",
+                           0x000e0000, 131072, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_common_init(model);
+
+    pci_init(PCI_CONFIG_TYPE_1);
+
+    pci_register_slot(0x0C, PCI_CARD_NORMAL,      1, 2, 3, 4); /* Slot 01 */
+    pci_register_slot(0x0D, PCI_CARD_NORMAL,      4, 1, 2, 3); /* Slot 02 */
+    pci_register_slot(0x10, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x12, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 0); /* Onboard */
+    pci_register_slot(0x13, PCI_CARD_VIDEO,       0, 0, 0, 0); /* Onboard */ 
+
+
+    device_add(&umc_hb4_device);
+    device_add(&umc_8886af_device);
+    device_add(&um8663af_device);
+    device_add(&sst_flash_29ee010_device);
+    device_add(&keyboard_ps2_ami_pci_device);
+
+    if (gfxcard[0] == VID_INTERNAL)
+        device_add(&gd5430_onboard_pci_device);
+
+    if (sound_card_current[0] == SOUND_INTERNAL)
+        device_add(&ess_1688_device);
+
+    if (fdc_current[0] == FDC_INTERNAL){
+        fdd_set_turbo(0, 1);
+        fdd_set_turbo(1, 1);
+    }
 
     return ret;
 }

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -8668,6 +8668,45 @@ const machine_t machines[] = {
         .snd_device = NULL,
         .net_device = NULL
     },
+    {
+        .name = "[UMC 8881] Compaq Presario 7100/7200 Series 486",
+        .internal_name = "pl4600c",
+        .type = MACHINE_TYPE_486_S3,
+        .chipset = MACHINE_CHIPSET_UMC_UM8881,
+        .init = machine_at_pl4600c_init,
+        .p1_handler = NULL,
+        .gpio_handler = NULL,
+        .available_flag = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu = {
+            .package = CPU_PKG_SOCKET3,
+            .block = CPU_BLOCK_NONE,
+            .min_bus = 0,
+            .max_bus = 0,
+            .min_voltage = 0,
+            .max_voltage = 0,
+            .min_multi = 0,
+            .max_multi = 0
+        },
+        .bus_flags = MACHINE_PCI,
+        .flags = MACHINE_IDE_DUAL | MACHINE_VIDEO | MACHINE_SOUND | MACHINE_APM,
+        .ram = {
+            .min = 1024,
+            .max = 65536,
+            .step = 1024
+        },
+        .nvrmask = 255,
+        .kbc_device = NULL,
+        .kbc_p1 = 0xff,
+        .gpio = 0xffffffff,
+        .gpio_acpi = 0xffffffff,
+        .device = NULL,
+        .fdc_device = NULL,
+        .sio_device = NULL,
+        .vid_device = &gd5430_onboard_pci_device,
+        .snd_device = &ess_1688_device,
+        .net_device = NULL
+    },
     /* Has a VIA VT82C406 KBC+RTC that likely has identical commands to the VT82C42N. */
     {
         .name = "[VIA VT82C496G] DFI G486VPA",

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -8668,6 +8668,8 @@ const machine_t machines[] = {
         .snd_device = NULL,
         .net_device = NULL
     },
+    /* Compaq Presario 7100 / 7200 Series, using MiTAC/Trigon PL4600C (486). */
+    /* Has a VIA VT82C42N KBC. */
     {
         .name = "[UMC 8881] Compaq Presario 7100/7200 Series 486",
         .internal_name = "pl4600c",


### PR DESCRIPTION
Summary
=======
Adding 486 based machine: Compaq Presario 7100/7200 Series
Based on the MiTAC/Trigon PL4600C(-II) Mainboard, Configuration based on Presario 7106 (AMD DX4).



Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already https://discordapp.com/channels/262614059009048590/1322532692042059937/1322532697385467927
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/288

References
==========
https://theretroweb.com/motherboards/s/mitac-trigon-pl4600c
