### PR TITLE
Late day changes (January 2nd, 2025)

### DIFF
--- a/src/scsi/scsi_t128.c
+++ b/src/scsi/scsi_t128.c
@@ -509,6 +509,9 @@ t128_init(const device_t *info)
     if (!t128->bios_enabled && !(info->flags & DEVICE_MCA))
         t128->status                |= 0x80;
 
+    if (info->flags & DEVICE_MCA)
+        t128->status                |= 0x08;
+
     if (info->local == 0)
         timer_add(&t128->timer, t128_callback, t128, 0);
 


### PR DESCRIPTION
Summary
=======
Actually recognize the Trantor 228 MCA SCSI controller as such (bit 3 of status is for the PS/2 MCA bus type of the 128 controller)

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
