### PR TITLE
pc87307: Fix GPIO base address configuration

### DIFF
--- a/src/sio/sio_pc87307.c
+++ b/src/sio/sio_pc87307.c
@@ -34,6 +34,7 @@
 #include <86box/fdd.h>
 #include <86box/fdc.h>
 #include <86box/sio.h>
+#include <86box/plat_fallthrough.h>
 
 typedef struct pc87307_t {
     uint8_t   id;
@@ -323,8 +324,12 @@ pc87307_write(uint16_t port, uint8_t val, void *priv)
             }
             break;
         case 0x60:
+            if (dev->regs[0x07] == 0x04) {
+                val &= 0x03;
+            }
+            fallthrough;
         case 0x62:
-            dev->ld_regs[dev->regs[0x07]][dev->cur_reg - 0x30] = val & 0x07;
+            dev->ld_regs[dev->regs[0x07]][dev->cur_reg - 0x30] = val;
             if ((dev->cur_reg == 0x62) && (dev->regs[0x07] != 0x07))
                 break;
             switch (dev->regs[0x07]) {


### PR DESCRIPTION
Summary
=======
Don't clobber the GPIO I/O Base value.

According to the PC87307 datasheet, port 0x60 bits [2:7] are read-only for the Parallel Port (4) device and cannot be altered by software. For others devices, the 0x60 port may be written with any value.

The SGI firmware emits the following PC87307 initialization sequence after each reset:
```
/* Select the GPIO device (7) */
SIO IDX: 2E <-- 07
SIO DAT: 2F <-- 07

/* I/O Base MSB = 0x0F */
SIO IDX: 2E <-- 60
SIO DAT: 2F <-- 0F

/* I/O Base LSB = 0xC0 */
SIO IDX: 2E <-- 61
SIO DAT: 2F <-- C0

/* Enable address decoding (I/O Base = 0xFC0) */
SIO IDX: 2E <-- 30
SIO DAT: 2F <-- 01
```
The GPIO I/O Base is erroneously assigned to 0x7C0. Fix by removing the 0x07 mask.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[PC87307 datasheet](https://theretroweb.com/chip/documentation/pc87306-mar1998-6419bc96b5cee855091194.pdf)
