### PR TITLE
Fix wrong sample rate of ES1370 software synth playback

### DIFF
--- a/src/sound/snd_audiopci.c
+++ b/src/sound/snd_audiopci.c
@@ -423,9 +423,9 @@ es1370_calc_sample_rate(es137x_t *dev)
         dev->calc_sample_rate = 5512;
     }
 
-    dev->calc_sample_rate_synth = 44100 / (1 << ((dev->int_ctrl >> 12) & 3));
-    dev->interp_factor_synth    = 1. / (double) (1 << ((dev->int_ctrl >> 12) & 3));
-    dev->interp_step_synth      = (1 << ((dev->int_ctrl >> 12) & 3));
+    dev->calc_sample_rate_synth = 44100 / (1 << (((dev->int_ctrl >> 12) & 3) ^ 3));
+    dev->interp_factor_synth    = 1. / (double) ((1 << ((dev->int_ctrl >> 12) & 3) ^ 3));
+    dev->interp_step_synth      = (1 << (((dev->int_ctrl >> 12) & 3) ^ 3));
 }
 
 static void


### PR DESCRIPTION
Summary
=======
Fixes low pitch problems when MIDI is played back through the software synth.

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
