### PR TITLE
8514/A and S3 changes of the late day (January 9th, 2025)

### DIFF
--- a/src/include/86box/vid_8514a.h
+++ b/src/include/86box/vid_8514a.h
@@ -138,6 +138,7 @@ typedef struct ibm8514_t {
         int      output2;
 
         int      ssv_len;
+        int      ssv_len_back;
         uint8_t  ssv_dir;
         uint8_t  ssv_draw;
         int      odd_in;


### PR DESCRIPTION
Summary
=======
S3:
1. Cleaned up the Short Stroke command processing.
2. Proceed calculating the error term only when it's equal or greater than the line length (Draw Line, Command 1 and also applies to Short Strokes, Command 0).

8514/A compatibles:
1. Reworked the polygon draw type A processing.
2. As with the S3, reworked the way error term is handled in the processing, and on Command 5 (Draw Polygon Boundary Line).

Checklist
=========
* [x] Closes #5112
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
