### PR TITLE
Allow selection between PCI and PNP BIOSes on the PB450.

### DIFF
--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -707,10 +707,10 @@ static const device_config_t pb450_config[] = {
 };
 
 const device_t pb450_device = {
-    .name = "Packard Bell PB450 Devices",
+    .name          = "Packard Bell PB450 Devices",
     .internal_name = "pb450_device",
-    .flags = 0,
-    .local = 0,
+    .flags         = 0,
+    .local         = 0,
     .init          = NULL,
     .close         = NULL,
     .reset         = NULL,

--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -741,7 +741,6 @@ machine_at_pb450_init(const machine_t *model)
     machine_at_common_init_ex(model, 2);
     device_add(&ide_vlb_2ch_device);
 
-    /* TODO: Detect if we're using the PNP and not the PCI ROM and don't add these? */
     pci_init(PCI_CONFIG_TYPE_1);
     pci_register_slot(0x10, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
     pci_register_slot(0x11, PCI_CARD_NORMAL,      1, 2, 3, 4);
@@ -757,7 +756,6 @@ machine_at_pb450_init(const machine_t *model)
     device_add(&fdc37c665_ide_device);
     device_add(&ide_opti611_vlb_sec_device);
     device_add(&intel_flash_bxt_device);
-    /* TODO: Detect if we're using the PNP and not the PCI ROM and don't add this? */
     device_add(&phoenix_486_jumper_pci_device);
 
     return ret;

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -63,6 +63,7 @@ extern const device_t ibmxt_device;
 extern const device_t ibmxt86_device;
 extern const device_t ibmat_device;
 extern const device_t ibmxt286_device;
+extern const device_t pb450_device;
 
 const machine_filter_t machine_types[] = {
     { "None",                             MACHINE_TYPE_NONE       },
@@ -6888,7 +6889,7 @@ const machine_t machines[] = {
         .kbc_p1 = 0xff,
         .gpio = 0xffffffff,
         .gpio_acpi = 0xffffffff,
-        .device = NULL,
+        .device = &pb450_device,
         .fdc_device = NULL,
         .sio_device = NULL,
         .vid_device = &gd5428_vlb_onboard_device,


### PR DESCRIPTION
Summary
=======
This PR simply allows the selection of either the current default PCI 1.0A BIOS or the PNP 1.1A BIOS in 86Box. Note that nvr (both nvr/pb450.bin and nvr/pb450.nvr) need to be cleared after switching for the change to actually happen.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already (Briefly :P)
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/292

References
==========
https://theretroweb.com/motherboards/s/packard-bell-pb450#bios
Own experience with PNP 1.1A PB450 board.
