### PR TITLE
1st set of changes (video-related) of the day (January 16th, 2025)

### DIFF
--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -3493,14 +3493,17 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
                 dev->vendor_mode = 1;
             }
             svga_recalctimings(svga);
-            mach32_updatemapping(mach, svga);
+            if ((dev->local & 0xff) >= 0x01)
+                mach32_updatemapping(mach, svga);
+
             mach_log("ATI 8514/A: (0x%04x) val=0x%02x, extended 8514/A mode=%02x.\n", port, val, mach->regs[0xb0] & 0x20);
             break;
 
         case 0x32ee:
         case 0x32ef:
             WRITE8(port, mach->local_cntl, val);
-            mach32_updatemapping(mach, svga);
+            if ((dev->local & 0xff) >= 0x01)
+                mach32_updatemapping(mach, svga);
             break;
 
         case 0x36ee:
@@ -3546,7 +3549,8 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
             mach_log("ATI 8514/A: (0x%04x): ON=%d, val=%04x, hdisp=%d, vdisp=%d.\n", port, mach->accel.clock_sel & 0x01, val, dev->hdisp, dev->vdisp);
             mach_log("Vendor ATI mode set %s resolution.\n", (dev->accel.advfunc_cntl & 0x04) ? "2: 1024x768" : "1: 640x480");
             svga_recalctimings(svga);
-            mach32_updatemapping(mach, svga);
+            if ((dev->local & 0xff) >= 0x01)
+                mach32_updatemapping(mach, svga);
             break;
 
         case 0x52ee:
@@ -3580,7 +3584,8 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
             if (!mach->pci_bus)
                 mach->linear_base = (mach->memory_aperture & 0xff00) << 12;
 
-            mach32_updatemapping(mach, svga);
+            if ((dev->local & 0xff) >= 0x01)
+                mach32_updatemapping(mach, svga);
             break;
 
         case 0x62ee:


### PR DESCRIPTION
Summary
=======
ATI Mach8-based (add-on only):
Do not override the clone VGA banked mapping with the standard VGA when needed. Fixes issues with banked mapping with ATI 8514/A enabled on cards with clone mappings such as Cirrus, Video7, Paradise/WD, etc.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
