### PR TITLE
Fix incorrect Opti chipset for MVI486

### DIFF
--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -834,7 +834,7 @@ machine_at_mvi486_init(const machine_t *model)
 
     machine_at_common_init(model);
 
-    device_add(&opti895_device);
+    device_add(&opti495_device);
     device_add(&keyboard_at_device);
     device_add(&pc87311_ide_device);
 

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -5962,10 +5962,10 @@ const machine_t machines[] = {
     /* Uses some variant of Phoenix MultiKey/42 as the Intel 8242 chip has a Phoenix
        copyright. */
     {
-        .name = "[OPTi 895] Mylex MVI486",
+        .name = "[OPTi 495] Mylex MVI486",
         .internal_name = "mvi486",
         .type = MACHINE_TYPE_486,
-        .chipset = MACHINE_CHIPSET_OPTI_895_802G,
+        .chipset = MACHINE_CHIPSET_OPTI_495,
         .init = machine_at_mvi486_init,
         .p1_handler = NULL,
         .gpio_handler = NULL,


### PR DESCRIPTION
Summary
=======
The Mylex MVI486 system currently lists and uses the Opti 895/82C895 chipset in 86Box.  The real board uses the Opti 498/82C498 chipset, which is a variant of the Opti 495.  This PR updates `machine_table.c` to reflect and select the 495 chipset, and updates `m_at_386dx_486.c` to add the `opti495` device to the machine instead of the `opti895` device.  I have tested basic functionality with the current ROM set.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://theretroweb.com/motherboards/s/mylex-mvi486
https://theretroweb.com/chipsets/379
http://66.113.161.23/~mR_Slug/chipset/cs-search.pl?searchOne=*82C498%20
