### PR TITLE
The delayed video changes of the night (January 20th, 2025)

### DIFF
--- a/src/include/86box/vid_svga.h
+++ b/src/include/86box/vid_svga.h
@@ -202,6 +202,14 @@ typedef struct svga_t {
 
     void (*vblank_start)(struct svga_t *svga);
 
+    void (*write)(uint32_t addr, uint8_t val, void *priv);
+    void (*writew)(uint32_t addr, uint16_t val, void *priv);
+    void (*writel)(uint32_t addr, uint32_t val, void *priv);
+
+    uint8_t (*read)(uint32_t addr, void *priv);
+    uint16_t (*readw)(uint32_t addr, void *priv);
+    uint32_t (*readl)(uint32_t addr, void *priv);
+
     void (*ven_write)(struct svga_t *svga, uint8_t val, uint32_t addr);
     float (*getclock)(int clock, void *priv);
     float (*getclock8514)(int clock, void *priv);

--- a/src/video/vid_cl54xx.c
+++ b/src/video/vid_cl54xx.c
@@ -4403,7 +4403,13 @@ gd54xx_init(const device_t *info)
     if ((vram == 1) || (vram >= 256 && vram <= 1024))
         svga->decode_mask = gd54xx->vram_mask;
 
+    svga->read = gd54xx_read;
+    svga->readw = gd54xx_readw;
+    svga->write = gd54xx_write;
+    svga->writew = gd54xx_writew;
     if (gd54xx->bit32) {
+        svga->readl = gd54xx_readl;
+        svga->writel = gd54xx_writel;
         mem_mapping_set_handler(&svga->mapping, gd54xx_read, gd54xx_readw, gd54xx_readl,
                                 gd54xx_write, gd54xx_writew, gd54xx_writel);
         mem_mapping_add(&gd54xx->mmio_mapping, 0, 0,
@@ -4423,6 +4429,8 @@ gd54xx_init(const device_t *info)
                         gd5480_vgablt_write, gd5480_vgablt_writew, gd5480_vgablt_writel,
                         NULL, MEM_MAPPING_EXTERNAL, gd54xx);
     } else {
+        svga->readl = NULL;
+        svga->writel = NULL;
         mem_mapping_set_handler(&svga->mapping, gd54xx_read, gd54xx_readw, NULL,
                                 gd54xx_write, gd54xx_writew, NULL);
         mem_mapping_add(&gd54xx->mmio_mapping, 0, 0,

--- a/src/video/vid_ht216.c
+++ b/src/video/vid_ht216.c
@@ -33,9 +33,12 @@
 #include <86box/rom.h>
 #include <86box/device.h>
 #include <86box/video.h>
+#include <86box/vid_8514a.h>
 #include <86box/vid_xga.h>
 #include <86box/vid_svga.h>
 #include <86box/vid_svga_render.h>
+#include <86box/vid_ati_eeprom.h>
+#include <86box/vid_ati_mach8.h>
 #include <86box/plat_fallthrough.h>
 #include <86box/plat_unused.h>
 
@@ -425,9 +428,8 @@ ht216_out(uint16_t addr, uint8_t val, void *priv)
                     svga->banked_mask = 0xffff;
             }
 
-            if (svga->gdcaddr <= 8) {
+            if (svga->gdcaddr <= 8)
                 svga->fast = (svga->gdcreg[8] == 0xff && !(svga->gdcreg[3] & 0x18) && !svga->gdcreg[1]) && svga->chain4 && svga->packed_chain4;
-            }
             break;
 
         case 0x3D4:
@@ -625,7 +627,9 @@ ht216_remap(ht216_t *ht216)
 void
 ht216_recalctimings(svga_t *svga)
 {
-    ht216_t *ht216        = (ht216_t *) svga->priv;
+    ht216_t   *ht216      = (ht216_t *) svga->priv;
+    ibm8514_t *dev        = (ibm8514_t *) svga->dev8514;
+    mach_t    *mach       = (mach_t *) svga->ext8514;
     int      high_res_256 = 0;
 
 
@@ -672,10 +676,16 @@ ht216_recalctimings(svga_t *svga)
 
     if (!svga->scrblank && svga->attr_palette_enable) {
         if (!(svga->gdcreg[6] & 1) && !(svga->attrregs[0x10] & 1)) { /*Text mode*/
-            if (svga->seqregs[1] & 8) /*40 column*/ {
+            if (svga->seqregs[1] & 8) /*40 column*/
                 svga->render = svga_render_text_40;
-            } else {
+            else
                 svga->render = svga_render_text_80;
+
+            if (ibm8514_active && (svga->dev8514 != NULL)) {
+                if (svga->ext8514 != NULL) {
+                    if (!(dev->accel.advfunc_cntl & 0x01) && !(mach->accel.clock_sel & 0x01)) /*FIXME: Possibly a BIOS bug within the V7 chips when it's used with a 8514/A card?*/
+                        dev->on &= ~0x01;
+                }
             }
         } else {
             if (svga->crtc[0x17] == 0xeb) {
@@ -1576,10 +1586,17 @@ ht216_init(const device_t *info, uint32_t mem_size, int has_rom)
     if (has_rom == 4)
         svga->ramdac = device_add(&sc11484_nors2_ramdac_device);
 
+    svga->read = ht216_read;
+    svga->readw = NULL;
+    svga->readl = NULL;
+    svga->write = ht216_write;
+    svga->writew = ht216_writew;
     if ((info->flags & DEVICE_VLB) || (info->flags & DEVICE_MCA)) {
+        svga->writel = ht216_writel;
         mem_mapping_set_handler(&svga->mapping, ht216_read, NULL, NULL, ht216_write, ht216_writew, ht216_writel);
         mem_mapping_add(&ht216->linear_mapping, 0, 0, ht216_read_linear, NULL, NULL, ht216_write_linear, ht216_writew_linear, ht216_writel_linear, NULL, MEM_MAPPING_EXTERNAL, svga);
     } else {
+        svga->writel = NULL;
         mem_mapping_set_handler(&svga->mapping, ht216_read, NULL, NULL, ht216_write, ht216_writew, NULL);
         mem_mapping_add(&ht216->linear_mapping, 0, 0, ht216_read_linear, NULL, NULL, ht216_write_linear, ht216_writew_linear, NULL, NULL, MEM_MAPPING_EXTERNAL, svga);
     }

--- a/src/video/vid_paradise.c
+++ b/src/video/vid_paradise.c
@@ -362,11 +362,6 @@ paradise_write(uint32_t addr, uint8_t val, void *priv)
     uint32_t    prev_addr;
     uint32_t    prev_addr2;
 
-    if (!(svga->attrregs[0x10] & 0x40)) {
-        svga_write(addr, val, svga);
-        return;
-    }
-
     addr = (addr & 0x7fff) + paradise->write_bank[(addr >> 15) & 3];
 
     /*Could be done in a better way but it works.*/
@@ -399,11 +394,6 @@ paradise_writew(uint32_t addr, uint16_t val, void *priv)
     svga_t     *svga     = &paradise->svga;
     uint32_t    prev_addr;
     uint32_t    prev_addr2;
-
-    if (!(svga->attrregs[0x10] & 0x40)) {
-        svga_writew(addr, val, svga);
-        return;
-    }
 
     addr = (addr & 0x7fff) + paradise->write_bank[(addr >> 15) & 3];
 
@@ -438,9 +428,6 @@ paradise_read(uint32_t addr, void *priv)
     uint32_t    prev_addr;
     uint32_t    prev_addr2;
 
-    if (!(svga->attrregs[0x10] & 0x40))
-        return svga_read(addr, svga);
-
     addr = (addr & 0x7fff) + paradise->read_bank[(addr >> 15) & 3];
 
     /*Could be done in a better way but it works.*/
@@ -473,9 +460,6 @@ paradise_readw(uint32_t addr, void *priv)
     svga_t     *svga     = &paradise->svga;
     uint32_t    prev_addr;
     uint32_t    prev_addr2;
-
-    if (!(svga->attrregs[0x10] & 0x40))
-        return svga_readw(addr, svga);
 
     addr = (addr & 0x7fff) + paradise->read_bank[(addr >> 15) & 3];
 
@@ -550,6 +534,12 @@ paradise_init(const device_t *info, uint32_t memory)
             break;
     }
 
+    svga->read = paradise_read;
+    svga->readw = paradise_readw;
+    svga->readl = NULL;
+    svga->write = paradise_write;
+    svga->writew = paradise_writew;
+    svga->writel = NULL;
     mem_mapping_set_handler(&svga->mapping, paradise_read, paradise_readw, NULL, paradise_write, paradise_writew, NULL);
     mem_mapping_set_p(&svga->mapping, paradise);
 

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -984,7 +984,7 @@ svga_recalctimings(svga_t *svga)
             svga_log("IBM 8514/A poll.\n");
             timer_set_callback(&svga->timer, ibm8514_poll);
         } else {
-            svga_log("SVGA Poll.\n");
+            svga_log("SVGA poll enabled.\n");
             timer_set_callback(&svga->timer, svga_poll);
         }
     }
@@ -1081,6 +1081,7 @@ svga_poll(void *priv)
         }
     }
 
+    svga_log("SVGA Poll.\n");
     if (!svga->linepos) {
         if (svga->displine == ((svga->hwcursor_latch.y < 0) ? 0 : svga->hwcursor_latch.y) && svga->hwcursor_latch.ena) {
             svga->hwcursor_on      = svga->hwcursor_latch.cur_ysize - svga->hwcursor_latch.yoff;
@@ -1406,16 +1407,34 @@ svga_init(const device_t *info, svga_t *svga, void *priv, int memsize,
     svga->ksc5601_english_font_type = 0;
 
     if ((info->flags & DEVICE_PCI) || (info->flags & DEVICE_VLB) || (info->flags & DEVICE_MCA)) {
+        svga->read = svga_read;
+        svga->readw = svga_readw;
+        svga->readl = svga_readl;
+        svga->write = svga_write;
+        svga->writew = svga_writew;
+        svga->writel = svga_writel;
         mem_mapping_add(&svga->mapping, 0xa0000, 0x20000,
                         svga_read, svga_readw, svga_readl,
                         svga_write, svga_writew, svga_writel,
                         NULL, MEM_MAPPING_EXTERNAL, svga);
     } else if ((info->flags & DEVICE_ISA) && (info->flags & DEVICE_AT)) {
+        svga->read = svga_read;
+        svga->readw = svga_readw;
+        svga->readl = NULL;
+        svga->write = svga_write;
+        svga->writew = svga_writew;
+        svga->writel = NULL;
         mem_mapping_add(&svga->mapping, 0xa0000, 0x20000,
                         svga_read, svga_readw, NULL,
                         svga_write, svga_writew, NULL,
                         NULL, MEM_MAPPING_EXTERNAL, svga);
     } else {
+        svga->read = svga_read;
+        svga->readw = NULL;
+        svga->readl = NULL;
+        svga->write = svga_write;
+        svga->writew = NULL;
+        svga->writel = NULL;
         mem_mapping_add(&svga->mapping, 0xa0000, 0x20000,
                         svga_read, NULL, NULL,
                         svga_write, NULL, NULL,


### PR DESCRIPTION
Summary
=======
Generic SVGA layer:
Added function pointers of the banked mapping for use with add-on cards with their own mapping when the VGA card banked mapping is not active or viceversa (e.g.: XGA).

XGA-1/2:
1. Reimplemented Area Fill and Boundary Mode as best as possible.
2. Fixed conflicts with banked mapping with VGA clones.
3. Fixed inverted colors (again) on accelerated 16bpp mode under OS/2.

Video7 with ATI 8514/A add-on.
Added a workaround (BIOS issue? I don't know) that disables 8514/A mode and reenables VGA mode when needed. Fixes screen freezes and polling issues with various drivers for Windows and others.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
