### PR TITLE
Video changes of the day (January 26th, 2025)

### DIFF
--- a/src/include/86box/vid_svga.h
+++ b/src/include/86box/vid_svga.h
@@ -189,6 +189,7 @@ typedef struct svga_t {
 
     void (*render)(struct svga_t *svga);
     void (*render8514)(struct svga_t *svga);
+    void (*render_xga)(struct svga_t *svga);
     void (*recalctimings_ex)(struct svga_t *svga);
 
     void (*video_out)(uint16_t addr, uint8_t val, void *priv);
@@ -306,6 +307,7 @@ typedef struct svga_t {
     void *  xga;
 } svga_t;
 
+extern void     ibm8514_set_poll(svga_t *svga);
 extern void     ibm8514_poll(void *priv);
 extern void     ibm8514_recalctimings(svga_t *svga);
 extern uint8_t  ibm8514_ramdac_in(uint16_t port, void *priv);
@@ -328,10 +330,11 @@ extern void     ati8514_mca_write(int port, uint8_t val, void *priv);
 extern void     ati8514_pos_write(uint16_t port, uint8_t val, void *priv);
 extern void     ati8514_init(svga_t *svga, void *ext8514, void *dev8514);
 
-extern void xga_write_test(uint32_t addr, uint8_t val, void *priv);
-extern uint8_t xga_read_test(uint32_t addr, void *priv);
-extern void xga_poll(void *priv);
-extern void xga_recalctimings(svga_t *svga);
+extern void     xga_write_test(uint32_t addr, uint8_t val, void *priv);
+extern uint8_t  xga_read_test(uint32_t addr, void *priv);
+extern void     xga_set_poll(svga_t *svga);
+extern void     xga_poll(void *priv);
+extern void     xga_recalctimings(svga_t *svga);
 
 extern uint32_t svga_decode_addr(svga_t *svga, uint32_t addr, int write);
 
@@ -376,6 +379,7 @@ uint32_t svga_mask_addr(uint32_t addr, svga_t *svga);
 uint32_t svga_mask_changedaddr(uint32_t addr, svga_t *svga);
 
 void svga_doblit(int wx, int wy, svga_t *svga);
+void svga_set_poll(svga_t *svga);
 void svga_poll(void *priv);
 
 enum {

--- a/src/include/86box/vid_xga.h
+++ b/src/include/86box/vid_xga.h
@@ -240,8 +240,6 @@ typedef struct xga_t {
         uint16_t px_map_height[4];
         uint32_t px_map_base[4];
     } accel;
-
-    int big_endian_linear;
 } xga_t;
 
 #endif /*VIDEO_XGA_H*/

--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -301,7 +301,7 @@ ibm8514_accel_out_pixtrans(svga_t *svga, UNUSED(uint16_t port), uint32_t val, in
                             if ((cmd >= 2) && (dev->accel.cmd & 0x1000))
                                 val = (val >> 8) | (val << 8);
                         }
-                        if ((cmd <= 2) || (cmd == 4) || ((cmd == 6))) {
+                        if ((cmd <= 2) || (cmd == 4) || (cmd == 6)) {
                             if ((dev->accel.cmd & 0x08) && (cmd >= 2))
                                 monoxfer = val;
                             else {
@@ -3606,6 +3606,12 @@ ibm8514_render_overscan_right(ibm8514_t *dev, svga_t *svga)
 }
 
 void
+ibm8514_set_poll(svga_t *svga)
+{
+    timer_set_callback(&svga->timer, ibm8514_poll);
+}
+
+void
 ibm8514_poll(void *priv)
 {
     svga_t *svga = (svga_t *)priv;
@@ -3614,7 +3620,7 @@ ibm8514_poll(void *priv)
     int      wx;
     int      wy;
 
-    ibm8514_log("IBM 8514/A poll.\n");
+    ibm8514_log("IBM 8514/A poll=%x.\n", dev->on);
     if (dev->on) {
         ibm8514_log("ON!\n");
         if (!dev->linepos) {
@@ -3857,7 +3863,7 @@ ibm8514_mca_reset(void *priv)
     else
         ibm8514_mca_write(0x102, 0, svga);
 
-    timer_set_callback(&svga->timer, svga_poll);
+    svga_set_poll(svga);
 }
 
 static void *

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -84,25 +84,75 @@ svga_get_pri(void)
 }
 
 void
+svga_set_poll(svga_t *svga)
+{
+    svga_log("SVGA Timer activated, enabled?=%x.\n", timer_is_enabled(&svga->timer));
+    timer_set_callback(&svga->timer, svga_poll);
+    if (!timer_is_enabled(&svga->timer))
+        timer_enable(&svga->timer);
+}
+
+void
 svga_set_override(svga_t *svga, int val)
 {
     ibm8514_t *dev = (ibm8514_t *) svga->dev8514;
+    xga_t     *xga = (xga_t *) svga->xga;
+    uint8_t    ret_poll = 0;
 
     if (svga->override && !val)
         svga->fullchange = svga->monitor->mon_changeframecount;
+
     svga->override = val;
 
     svga_log("Override=%x.\n", val);
-    if (ibm8514_active && (svga->dev8514 != NULL)) {
-        if (dev->on) {
-            if (svga->override)
-                timer_set_callback(&svga->timer, svga_poll);
-            else
-                timer_set_callback(&svga->timer, ibm8514_poll);
-        } else
-            timer_set_callback(&svga->timer, svga_poll);
-    } else
-        timer_set_callback(&svga->timer, svga_poll);
+    if (ibm8514_active && (svga->dev8514 != NULL))
+        ret_poll |= 1;
+
+    if (xga_active && (svga->xga != NULL))
+        ret_poll |= 2;
+
+    if (svga->override)
+        svga_set_poll(svga);
+    else {
+        switch (ret_poll) {
+            case 0:
+            default:
+                svga_set_poll(svga);
+                break;
+
+            case 1:
+                if (ibm8514_active && (svga->dev8514 != NULL)) {
+                    if (dev->on)
+                        ibm8514_set_poll(svga);
+                    else
+                        svga_set_poll(svga);
+                } else
+                    svga_set_poll(svga);
+                break;
+
+            case 2:
+                if (xga_active && (svga->xga != NULL)) {
+                    if (xga->on)
+                        xga_set_poll(svga);
+                    else
+                        svga_set_poll(svga);
+                } else
+                    svga_set_poll(svga);
+                break;
+
+            case 3:
+                if (ibm8514_active && (svga->dev8514 != NULL) && xga_active && (svga->xga != NULL))  {
+                    if (dev->on)
+                        ibm8514_set_poll(svga);
+                    else if (xga->on)
+                        xga_set_poll(svga);
+                    else
+                        svga_set_poll(svga);
+                } else
+                    svga_set_poll(svga);
+                break;
+        }
+    }
 
 #ifdef OVERRIDE_OVERSCAN
     if (!val) {
@@ -241,7 +291,7 @@ svga_out(uint16_t addr, uint8_t val, void *priv)
             if (ibm8514_active && dev)
                 dev->on = (val & 0x01) ? 0 : 1;
 
-            svga_log("Write Port 3C3.\n");
+            svga_log("Write Port 3C3=%x.\n", val & 0x01);
             svga_recalctimings(svga);
             break;
         case 0x3c4:
@@ -612,6 +662,8 @@ void
 svga_recalctimings(svga_t *svga)
 {
     ibm8514_t       *dev = (ibm8514_t *) svga->dev8514;
+    xga_t           *xga = (xga_t *) svga->xga;
+    uint8_t          set_timer = 0;
     double           crtcconst;
     double           _dispontime;
     double           _dispofftime;
@@ -620,6 +672,10 @@ svga_recalctimings(svga_t *svga)
     double           _dispontime8514 = 0.0;
     double           _dispofftime8514 = 0.0;
     double           disptime8514 = 0.0;
+    double           crtcconst_xga = 0.0;
+    double           _dispontime_xga = 0.0;
+    double           _dispofftime_xga = 0.0;
+    double           disptime_xga = 0.0;
 #ifdef ENABLE_SVGA_LOG
     int              vsyncend;
     int              vblankend;
@@ -709,6 +765,12 @@ svga_recalctimings(svga_t *svga)
             } else
                 svga->render = svga_render_text_80;
 
+            if (xga_active && (svga->xga != NULL)) {
+                if (xga->on) {
+                    if ((svga->mapping.base == 0xb8000) && (xga->aperture_cntl == 1)) /*Some operating systems reset themselves with ctrl-alt-del by going into text mode.*/
+                        xga->on = 0;
+                }
+            }
             svga->hdisp_old = svga->hdisp;
         } else {
             svga->hdisp_old = svga->hdisp;
@@ -904,6 +966,10 @@ svga_recalctimings(svga_t *svga)
         if (dev->on)
             crtcconst8514 = svga->clock8514;
     }
+    if (xga_active && (svga->xga != NULL)) {
+        if (xga->on)
+            crtcconst_xga = svga->clock_xga;
+    }
 
 #ifdef ENABLE_SVGA_LOG
     vsyncend = (svga->vsyncstart & 0xfffffff0) | (svga->crtc[0x11] & 0x0f);
@@ -952,6 +1018,13 @@ svga_recalctimings(svga_t *svga)
         }
     }
 
+    if (xga_active && (svga->xga != NULL)) {
+        if (xga->on) {
+            disptime_xga = xga->h_total ? xga->h_total : TIMER_USEC;
+            _dispontime_xga = xga->h_disp;
+        }
+    }
+
     if (svga->seqregs[1] & 8) {
         disptime *= 2;
         _dispontime *= 2;
@@ -968,25 +1041,84 @@ svga_recalctimings(svga_t *svga)
     if (svga->dispofftime < TIMER_USEC)
         svga->dispofftime = TIMER_USEC;
 
-    if (ibm8514_active && (svga->dev8514 != NULL)) {
-        if (dev->on) {
-            _dispofftime8514 = disptime8514 - _dispontime8514;
-            _dispontime8514 *= crtcconst8514;
-            _dispofftime8514 *= crtcconst8514;
+    if (ibm8514_active && (svga->dev8514 != NULL))
+        set_timer |= 1;
 
-            dev->dispontime  = (uint64_t) (_dispontime8514);
-            dev->dispofftime = (uint64_t) (_dispofftime8514);
-            if (dev->dispontime < TIMER_USEC)
-                dev->dispontime = TIMER_USEC;
-            if (dev->dispofftime < TIMER_USEC)
-                dev->dispofftime = TIMER_USEC;
+    if (xga_active && (svga->xga != NULL))
+        set_timer |= 2;
 
-            svga_log("IBM 8514/A poll.\n");
-            timer_set_callback(&svga->timer, ibm8514_poll);
-        } else {
-            svga_log("SVGA poll enabled.\n");
-            timer_set_callback(&svga->timer, svga_poll);
-        }
+    switch (set_timer) {
+        default:
+        case 0: /*VGA only*/
+            svga_set_poll(svga);
+            break;
+
+        case 1: /*Plus 8514/A*/
+            if (dev->on) {
+                _dispofftime8514 = disptime8514 - _dispontime8514;
+                _dispontime8514 *= crtcconst8514;
+                _dispofftime8514 *= crtcconst8514;
+
+                dev->dispontime  = (uint64_t) (_dispontime8514);
+                dev->dispofftime = (uint64_t) (_dispofftime8514);
+                if (dev->dispontime < TIMER_USEC)
+                    dev->dispontime = TIMER_USEC;
+                if (dev->dispofftime < TIMER_USEC)
+                    dev->dispofftime = TIMER_USEC;
+
+                ibm8514_set_poll(svga);
+            } else
+                svga_set_poll(svga);
+            break;
+
+        case 2: /*Plus XGA*/
+            if (xga->on) {
+                _dispofftime_xga = disptime_xga - _dispontime_xga;
+                _dispontime_xga *= crtcconst_xga;
+                _dispofftime_xga *= crtcconst_xga;
+
+                xga->dispontime  = (uint64_t) (_dispontime_xga);
+                xga->dispofftime = (uint64_t) (_dispofftime_xga);
+                if (xga->dispontime < TIMER_USEC)
+                    xga->dispontime = TIMER_USEC;
+                if (xga->dispofftime < TIMER_USEC)
+                    xga->dispofftime = TIMER_USEC;
+
+                xga_set_poll(svga);
+            } else
+                svga_set_poll(svga);
+            break;
+
+        case 3: /*Plus 8514/A and XGA*/
+            if (dev->on) {
+                _dispofftime8514 = disptime8514 - _dispontime8514;
+                _dispontime8514 *= crtcconst8514;
+                _dispofftime8514 *= crtcconst8514;
+
+                dev->dispontime  = (uint64_t) (_dispontime8514);
+                dev->dispofftime = (uint64_t) (_dispofftime8514);
+                if (dev->dispontime < TIMER_USEC)
+                    dev->dispontime = TIMER_USEC;
+                if (dev->dispofftime < TIMER_USEC)
+                    dev->dispofftime = TIMER_USEC;
+
+                ibm8514_set_poll(svga);
+            } else if (xga->on) {
+                _dispofftime_xga = disptime_xga - _dispontime_xga;
+                _dispontime_xga *= crtcconst_xga;
+                _dispofftime_xga *= crtcconst_xga;
+
+                xga->dispontime  = (uint64_t) (_dispontime_xga);
+                xga->dispofftime = (uint64_t) (_dispofftime_xga);
+                if (xga->dispontime < TIMER_USEC)
+                    xga->dispontime = TIMER_USEC;
+                if (xga->dispofftime < TIMER_USEC)
+                    xga->dispofftime = TIMER_USEC;
+
+                xga_set_poll(svga);
+            } else
+                svga_set_poll(svga);
+            break;
     }
 
     if (!svga->force_old_addr)
@@ -1064,22 +1196,12 @@ void
 svga_poll(void *priv)
 {
     svga_t    *svga = (svga_t *) priv;
-    xga_t     *xga  = (xga_t *) svga->xga;
     uint32_t   x;
     uint32_t   blink_delay;
     int        wx;
     int        wy;
     int        ret;
     int        old_ma;
-
-    if (!svga->override) {
-        if (xga_active && xga && xga->on) {
-            if ((xga->disp_cntl_2 & 7) >= 2) {
-                xga_poll(svga);
-                return;
-            }
-        }
-    }
 
     svga_log("SVGA Poll.\n");
     if (!svga->linepos) {
@@ -2070,6 +2192,8 @@ svga_readw_common(uint32_t addr, uint8_t linear, void *priv)
     cycles -= svga->monitor->mon_video_timing_read_w;
 
     if (!linear) {
+        (void) xga_read_test(addr, svga);
+        (void) xga_read_test(addr + 1, svga);
         addr = svga_decode_addr(svga, addr, 0);
         if (addr == 0xffffffff)
             return 0xffff;
@@ -2116,6 +2240,10 @@ svga_readl_common(uint32_t addr, uint8_t linear, void *priv)
     cycles -= svga->monitor->mon_video_timing_read_l;
 
     if (!linear) {
+        (void) xga_read_test(addr, svga);
+        (void) xga_read_test(addr + 1, svga);
+        (void) xga_read_test(addr + 2, svga);
+        (void) xga_read_test(addr + 3, svga);
         addr = svga_decode_addr(svga, addr, 0);
         if (addr == 0xffffffff)
             return 0xffffffff;


### PR DESCRIPTION
Summary
=======
XGA:
1. Added a proper poll so to have its timings independent of the SVGA core and changes its renderer accordingly, mainly a blank render one.
2. Workaround the Ctrl-Alt-Del reset of Windows 2.x so that it switches back to VGA text mode correctly when using the 0xA000 64K aperture (in vid_svga.c).

SVGA core:
Re-organized the way the different timers are organized so that the XGA and 8514/A pollers can coexist with the SVGA timer without conflicts.

ATI Mach32:
Reworked the true color renderer and made it a Mach32 exclusive due to its differences from the standard one. Fixes wrong rendered colors in NT using the 32bpp renderer in RGB mode.


Checklist
=========
* [x] Closes #5127
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
