### PR TITLE
More changes to the 5380 chips (January 26th, 2025)

### DIFF
--- a/src/include/86box/scsi_ncr5380.h
+++ b/src/include/86box/scsi_ncr5380.h
@@ -74,6 +74,7 @@ typedef struct ncr_t {
     uint8_t output_data;
     uint8_t tx_data;
     uint8_t irq_state;
+    uint8_t isr_reg;
 
     uint8_t bus;
 

--- a/src/scsi/scsi_ncr5380.c
+++ b/src/scsi/scsi_ncr5380.c
@@ -195,7 +195,7 @@ ncr5380_write(uint16_t port, uint8_t val, ncr_t *ncr)
             break;
 
         case 5: /* start DMA Send */
-            pclog("Write: start DMA send register\n");
+            ncr5380_log("Write: start DMA send register\n");
             /*a Write 6/10 has occurred, start the timer when the block count is loaded*/
             scsi_bus->tx_mode = DMA_OUT_TX_BUS;
             if (ncr->dma_send_ext)
@@ -238,7 +238,7 @@ ncr5380_read(uint16_t port, ncr_t *ncr)
                 } else
                     ret = ncr->output_data;
 
-                ncr5380_log("[%04X:%08X]: Data Bus Phase, ret=%02x, clearreq=%d, waitdata=%x, txmode=%x.\n", CS, cpu_state.pc, ret, scsi_bus->clear_req, scsi_bus->wait_data, scsi_bus->tx_mode);
+                ncr5380_log("[%04X:%08X]: Data Bus Phase, CMDissued=%d, ret=%02x, clearreq=%d, waitdata=%x, txmode=%x.\n", CS, cpu_state.pc, scsi_bus->command_issued, ret, scsi_bus->clear_req, scsi_bus->wait_data, scsi_bus->tx_mode);
             } else {
                 /*Return the data from the SCSI bus*/
                 bus = scsi_bus_read(scsi_bus);
@@ -271,10 +271,6 @@ ncr5380_read(uint16_t port, ncr_t *ncr)
                 ret |= BUS_SEL;
             if (ncr->icr & ICR_BSY)
                 ret |= BUS_BSY;
-
-            /*Note by TC1995: Horrible hack, I know.*/
-            (void) scsi_bus_read(scsi_bus);
-            (void) scsi_bus_read(scsi_bus);
             break;
 
         case 5: /* Bus and Status register */
@@ -319,6 +315,7 @@ ncr5380_read(uint16_t port, ncr_t *ncr)
                 ret |= STATUS_BUSY_ERROR;
             }
             ret |= (ncr->isr & (STATUS_INT | STATUS_END_OF_DMA));
+            ncr->isr_reg = ret;
             break;
 
         case 6:


### PR DESCRIPTION
Summary
=======
Apparently the Trantor T130B SCSI controllers has a different way of calculating the timings and removed the scsi_bus_read() calls from the Current SCSI bus status port (Read Port+4). Fixes NT using said controller as well as CD swapping while maintaining the correct accurate CD speed.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
