### PR TITLE
Fix various errors with the machine table for 586-based machines (Part 1)

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -11121,9 +11121,9 @@ const machine_t machines[] = {
         .bus_flags = MACHINE_PS2_PCI,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM,
         .ram = {
-            .min = 8192,
-            .max = 196608,
-            .step = 8192
+            .min = 4096,
+            .max = 524288,
+            .step = 4096
         },
         .nvrmask = 511,
         .kbc_device = NULL,
@@ -11156,14 +11156,14 @@ const machine_t machines[] = {
             .min_voltage = 3450,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 2.5
         },
         .bus_flags = MACHINE_PS2_PCI,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM,
         .ram = {
-            .min = 8192,
+            .min = 4096,
             .max = 524288,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 127,
         .kbc_device = NULL,
@@ -11201,9 +11201,9 @@ const machine_t machines[] = {
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_USB,
         .ram = {
-            .min = 8192,
+            .min = 4096,
             .max = 524288,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 127,
         .kbc_device = NULL,
@@ -11246,7 +11246,7 @@ const machine_t machines[] = {
         .ram = {
             .min = 8192,
             .max = 131072,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 511,
         .kbc_device = NULL,
@@ -11470,7 +11470,7 @@ const machine_t machines[] = {
     /* Has a SM(S)C FDC37C935 Super I/O chip with on-chip KBC with Phoenix
        MultiKey/42 (version 1.38) KBC firmware. */
     {
-        .name = "[i430HX] Acer M3A",
+        .name = "[i430HX] Acer AcerPower Ultima",
         .internal_name = "acerm3a",
         .type = MACHINE_TYPE_SOCKET7,
         .chipset = MACHINE_CHIPSET_INTEL_430HX,
@@ -11492,9 +11492,9 @@ const machine_t machines[] = {
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_GAMEPORT | MACHINE_USB, /* Machine has internal SCSI */
         .ram = {
-            .min = 8192,
-            .max = 196608,
-            .step = 8192
+            .min = 4096,
+            .max = 524288,
+            .step = 4096
         },
         .nvrmask = 511,
         .kbc_device = NULL,
@@ -11523,18 +11523,18 @@ const machine_t machines[] = {
             .package = CPU_PKG_SOCKET5_7,
             .block = CPU_BLOCK_NONE,
             .min_bus = 50000000,
-            .max_bus = 83333333,
+            .max_bus = 75000000,
             .min_voltage = 2500,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 4.0
         },
         .bus_flags = MACHINE_PS2_PCI,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM,
         .ram = {
-            .min = 8192,
-            .max = 262144,
-            .step = 8192
+            .min = 4096,
+            .max = 524288,
+            .step = 4096
         },
         .nvrmask = 127,
         .kbc_device = NULL,
@@ -11567,14 +11567,14 @@ const machine_t machines[] = {
             .min_voltage = 2500,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB, /* Machine has AMB */
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_USB,
         .ram = {
-            .min = 8192,
+            .min = 4096,
             .max = 524288,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 127,
         .kbc_device = NULL,
@@ -11603,7 +11603,7 @@ const machine_t machines[] = {
         .cpu = {
             .package = CPU_PKG_SOCKET5_7,
             .block = CPU_BLOCK_NONE,
-            .min_bus = 50000000,
+            .min_bus = 60000000,
             .max_bus = 66666667,
             .min_voltage = 2800,
             .max_voltage = 3520,
@@ -11613,9 +11613,9 @@ const machine_t machines[] = {
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_GAMEPORT | MACHINE_USB,
         .ram = {
-            .min = 8192,
-            .max = 131072,
-            .step = 8192
+            .min = 4096,
+            .max = 524288,
+            .step = 4096
         },
         .nvrmask = 511,
         .kbc_device = NULL,
@@ -11633,7 +11633,7 @@ const machine_t machines[] = {
        PC87306 Super I/O chip, command 0xA1 returns '5'.
        Command 0xA0 copyright string: (C)1994 AMI . */
     {
-        .name = "[i430HX] Intel TC430HX",
+        .name = "[i430HX] Intel TC430HX (Tucson)",
         .internal_name = "tc430hx",
         .type = MACHINE_TYPE_SOCKET7,
         .chipset = MACHINE_CHIPSET_INTEL_430HX,
@@ -11650,14 +11650,14 @@ const machine_t machines[] = {
             .min_voltage = 2800,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_VIDEO | MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_GAMEPORT | MACHINE_USB, /* Has internal sound: Yamaha YMF701-S */
         .ram = {
             .min = 8192,
-            .max = 131072,
-            .step = 8192
+            .max = 524288,
+            .step = 4096
         },
         .nvrmask = 255,
         .kbc_device = NULL,
@@ -11673,7 +11673,7 @@ const machine_t machines[] = {
     },
     /* OEM version of Intel TC430HX, has AMI MegaKey KBC firmware on the PC87306 Super I/O chip. */
     {
-        .name = "[i430HX] Toshiba Infinia 7200",
+        .name = "[i430HX] Toshiba Infinia 7201",
         .internal_name = "infinia7200",
         .type = MACHINE_TYPE_SOCKET7,
         .chipset = MACHINE_CHIPSET_INTEL_430HX,
@@ -11690,14 +11690,14 @@ const machine_t machines[] = {
             .min_voltage = 2800,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_VIDEO | MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_GAMEPORT | MACHINE_USB, /* Has internal sound: Yamaha YMF701-S */
         .ram = {
             .min = 8192,
-            .max = 131072,
-            .step = 8192
+            .max = 524288,
+            .step = 4096
         },
         .nvrmask = 255,
         .kbc_device = NULL,
@@ -11713,7 +11713,7 @@ const machine_t machines[] = {
     },
     /* OEM-only Intel CU430HX, has AMI MegaKey KBC firmware on the PC87306 Super I/O chip. */
     {
-        .name = "[i430HX] Intel CU430HX",
+        .name = "[i430HX] Intel CU430HX (Cumberland)",
         .internal_name = "cu430hx",
         .type = MACHINE_TYPE_SOCKET7,
         .chipset = MACHINE_CHIPSET_INTEL_430HX,
@@ -11730,14 +11730,14 @@ const machine_t machines[] = {
             .min_voltage = 2800,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_SOUND | MACHINE_APM | MACHINE_USB,
         .ram = {
             .min = 8192,
-            .max = 196608,
-            .step = 8192
+            .max = 524288,
+            .step = 4096
         },
         .nvrmask = 255,
         .kbc_device = NULL,
@@ -11770,14 +11770,14 @@ const machine_t machines[] = {
             .min_voltage = 2800,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_SOUND | MACHINE_APM | MACHINE_USB,
         .ram = {
             .min = 8192,
-            .max = 196608,
-            .step = 8192
+            .max = 524288,
+            .step = 4096
         },
         .nvrmask = 255,
         .kbc_device = NULL,
@@ -11806,18 +11806,18 @@ const machine_t machines[] = {
             .package = CPU_PKG_SOCKET5_7,
             .block = CPU_BLOCK_NONE,
             .min_bus = 50000000,
-            .max_bus = 83333333,
+            .max_bus = 66666667,
             .min_voltage = 2500,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM,
         .ram = {
-            .min = 8192,
-            .max = 262144,
-            .step = 8192
+            .min = 4096,
+            .max = 524288,
+            .step = 4096
         },
         .nvrmask = 127,
         .kbc_device = NULL,
@@ -11859,8 +11859,8 @@ const machine_t machines[] = {
         .flags = MACHINE_IDE_DUAL | MACHINE_APM,
         .ram = {
             .min = 8192,
-            .max = 196608,
-            .step = 8192
+            .max = 524288,
+            .step = 4096
         },
         .nvrmask = 255,
         .kbc_device = NULL,
@@ -11899,9 +11899,9 @@ const machine_t machines[] = {
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_USB,
         .ram = {
-            .min = 8192,
-            .max = 786432,
-            .step = 8192
+            .min = 4096,
+            .max = 524288,
+            .step = 4096
         },
         .nvrmask = 255,
         .kbc_device = NULL,
@@ -11941,9 +11941,9 @@ const machine_t machines[] = {
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_SCSI | MACHINE_APM | MACHINE_USB,
         .ram = {
-            .min = 8192,
+            .min = 4096,
             .max = 131072,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 127,
         .kbc_device = NULL,
@@ -11976,14 +11976,14 @@ const machine_t machines[] = {
             .min_voltage = 2500,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB, /* Machine has AMB */
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_USB,
         .ram = {
-            .min = 8192,
+            .min = 4096,
             .max = 131072,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 127,
         .kbc_device = NULL,
@@ -12017,14 +12017,14 @@ const machine_t machines[] = {
             .min_voltage = 2500,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_USB,
         .ram = {
-            .min = 8192,
+            .min = 4096,
             .max = 131072,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 127,
         .kbc_device = NULL,
@@ -12062,9 +12062,9 @@ const machine_t machines[] = {
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_USB,
         .ram = {
-            .min = 8192,
+            .min = 4096,
             .max = 131072,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 127,
         .kbc_device = NULL,
@@ -12081,7 +12081,7 @@ const machine_t machines[] = {
     /* Has a SM(S)C FDC37C932QF Super I/O chip with on-chip KBC with AMI
        MegaKey (revision '5') KBC firmware. */
     {
-        .name = "[i430VX] Compaq Presario 2240",
+        .name = "[i430VX] Compaq Presario 224x",
         .internal_name = "presario2240",
         .type = MACHINE_TYPE_SOCKET7,
         .chipset = MACHINE_CHIPSET_INTEL_430VX,
@@ -12093,19 +12093,19 @@ const machine_t machines[] = {
         .cpu = {
             .package = CPU_PKG_SOCKET5_7,
             .block = CPU_BLOCK_NONE,
-            .min_bus = 50000000,
+            .min_bus = 66666667,
             .max_bus = 66666667,
             .min_voltage = 2800,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI,
         .flags = MACHINE_IDE_DUAL | MACHINE_VIDEO | MACHINE_APM | MACHINE_ACPI,
         .ram = {
-            .min = 8192,
-            .max = 131072,
-            .step = 8192
+            .min = 16384,
+            .max = 49152,
+            .step = 4096
         },
         .nvrmask = 511,
         .kbc_device = NULL,
@@ -12122,7 +12122,7 @@ const machine_t machines[] = {
     /* Has a SM(S)C FDC37C931APM Super I/O chip with on-chip KBC with Compaq
        KBC firmware. */
     {
-        .name = "[i430VX] Compaq Presario 4500",
+        .name = "[i430VX] Compaq Presario 45xx",
         .internal_name = "presario4500",
         .type = MACHINE_TYPE_SOCKET7,
         .chipset = MACHINE_CHIPSET_INTEL_430VX,
@@ -12134,19 +12134,19 @@ const machine_t machines[] = {
         .cpu = {
             .package = CPU_PKG_SOCKET5_7,
             .block = CPU_BLOCK_NONE,
-            .min_bus = 50000000,
+            .min_bus = 66666667,
             .max_bus = 66666667,
             .min_voltage = 2800,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI,
         .flags = MACHINE_IDE_DUAL | MACHINE_VIDEO | MACHINE_APM | MACHINE_ACPI,
         .ram = {
-            .min = 8192,
-            .max = 131072,
-            .step = 8192
+            .min = 16384,
+            .max = 49152,
+            .step = 4096
         },
         .nvrmask = 511,
         .kbc_device = NULL,
@@ -12163,7 +12163,7 @@ const machine_t machines[] = {
     /* Has a SM(S)C FDC37C932FR Super I/O chip with on-chip KBC with AMI
        MegaKey (revision '5') KBC firmware. */
     {
-        .name = "[i430VX] Dell Hannibal+",
+        .name = "[i430VX] Dell Dimension XPS Pxxxa/Mxxxa",
         .internal_name = "dellhannibalp",
         .type = MACHINE_TYPE_SOCKET7,
         .chipset = MACHINE_CHIPSET_INTEL_430VX,
@@ -12180,14 +12180,14 @@ const machine_t machines[] = {
             .min_voltage = 2500,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_USB,
         .ram = {
             .min = 8192,
             .max = 131072,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 511,
         .kbc_device = NULL,
@@ -12225,9 +12225,9 @@ const machine_t machines[] = {
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_USB,
         .ram = {
-            .min = 8192,
+            .min = 4096,
             .max = 131072,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 127,
         .kbc_device = NULL,
@@ -12257,7 +12257,7 @@ const machine_t machines[] = {
             .package = CPU_PKG_SOCKET5_7,
             .block = CPU_BLOCK_NONE,
             .min_bus = 50000000,
-            .max_bus = 66666667,
+            .max_bus = 75000000,
             .min_voltage = 2500,
             .max_voltage = 3520,
             .min_multi = 1.5,
@@ -12266,9 +12266,9 @@ const machine_t machines[] = {
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_USB,
         .ram = {
-            .min = 8192,
+            .min = 4096,
             .max = 131072,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 511,
         .kbc_device = NULL,
@@ -12309,7 +12309,7 @@ const machine_t machines[] = {
         .ram = {
             .min = 8192,
             .max = 131072,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 511,
         .kbc_device = NULL,
@@ -12343,14 +12343,14 @@ const machine_t machines[] = {
             .min_voltage = 2200,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM,
         .ram = {
-            .min = 16384,
+            .min = 8192,
             .max = 131072,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 511,
         .kbc_device = NULL,
@@ -12368,7 +12368,7 @@ const machine_t machines[] = {
        PC87306 Super I/O chip, command 0xA1 returns '5'.
        Command 0xA0 copyright string: (C)1994 AMI . */
     {
-        .name = "[i430VX] Packard Bell PB680",
+        .name = "[i430VX] Packard Bell Multimedia C110",
         .internal_name = "pb680",
         .type = MACHINE_TYPE_SOCKET7,
         .chipset = MACHINE_CHIPSET_INTEL_430VX,
@@ -12392,7 +12392,7 @@ const machine_t machines[] = {
         .ram = {
             .min = 8192,
             .max = 131072,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 255,
         .kbc_device = NULL,
@@ -12409,7 +12409,7 @@ const machine_t machines[] = {
     /* Has a SM(S)C FDC37C935 Super I/O chip with on-chip KBC with Phoenix
        MultiKey/42 (version 1.38) KBC firmware. */
     {
-        .name = "[i430VX] Packard Bell PB810",
+        .name = "[i430VX] Packard Bell Multimedia M415",
         .internal_name = "pb810",
         .type = MACHINE_TYPE_SOCKET7,
         .chipset = MACHINE_CHIPSET_INTEL_430VX,
@@ -12426,14 +12426,14 @@ const machine_t machines[] = {
             .min_voltage = 2500,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 4.0
         },
         .bus_flags = MACHINE_PS2_PCI,
         .flags = MACHINE_IDE_DUAL | MACHINE_SOUND | MACHINE_APM,
         .ram = {
-            .min = 8192,
+            .min = 4096,
             .max = 131072,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 511,
         .kbc_device = NULL,
@@ -12467,14 +12467,14 @@ const machine_t machines[] = {
             .min_voltage = 2600,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_USB,
         .ram = {
-            .min = 8192,
+            .min = 4096,
             .max = 131072,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 127,
         .kbc_device = NULL,
@@ -12513,9 +12513,9 @@ const machine_t machines[] = {
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_GAMEPORT | MACHINE_APM | MACHINE_USB,
         .ram = {
-            .min = 8192,
+            .min = 4096,
             .max = 131072,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 127,
         .kbc_device = NULL,
@@ -12590,7 +12590,7 @@ const machine_t machines[] = {
             .min_voltage = 2500,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
@@ -12613,7 +12613,7 @@ const machine_t machines[] = {
     },
     /* [TEST] Has AMI Megakey '5' KBC firmware on the SM(S)C FDC37C67x Super I/O chip. */
     {
-        .name = "[i430TX] Gateway Tomahawk",
+        .name = "[i430TX] Gateway E-1000",
         .internal_name = "tomahawk",
         .type = MACHINE_TYPE_SOCKET7,
         .chipset = MACHINE_CHIPSET_INTEL_430TX,
@@ -12625,12 +12625,12 @@ const machine_t machines[] = {
         .cpu = {
             .package = CPU_PKG_SOCKET5_7,
             .block = CPU_BLOCK_NONE,
-            .min_bus = 50000000,
+            .min_bus = 60000000,
             .max_bus = 66666667,
             .min_voltage = 2100,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 5.5
         },
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_VIDEO | MACHINE_SOUND | MACHINE_NIC | MACHINE_USB,
@@ -12654,7 +12654,7 @@ const machine_t machines[] = {
 #ifdef USE_AN430TX
     /* This has the Phoenix MultiKey KBC firmware. */
     {
-        .name = "[i430TX] Intel AN430TX",
+        .name = "[i430TX] Intel AN430TX (Anchorage)",
         .internal_name = "an430tx",
         .type = MACHINE_TYPE_SOCKET7,
         .chipset = MACHINE_CHIPSET_INTEL_430TX,
@@ -12671,7 +12671,7 @@ const machine_t machines[] = {
             .min_voltage = 2800,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI,
@@ -12695,7 +12695,7 @@ const machine_t machines[] = {
 #endif /* USE_AN430TX */
     /* This has the AMIKey KBC firmware, which is an updated 'F' type. */
     {
-        .name = "[i430TX] Intel YM430TX",
+        .name = "[i430TX] Intel YM430TX (Yamamoto)",
         .internal_name = "ym430tx",
         .type = MACHINE_TYPE_SOCKET7,
         .chipset = MACHINE_CHIPSET_INTEL_430TX,
@@ -12712,14 +12712,14 @@ const machine_t machines[] = {
             .min_voltage = 2800,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
         .ram = {
-            .min = 8192,
+            .min = 4096,
             .max = 262144,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 255,
         .kbc_device = NULL,
@@ -12733,7 +12733,7 @@ const machine_t machines[] = {
         .snd_device = NULL,
         .net_device = NULL
     },
-	/* PhoenixBIOS 4.0 Rel 6.0 for 430TX, most likely has AMI KBC of some sort. Also has onboard Yamaha YMF701 which can't be emulated yet. */
+	/* PhoenixBIOS 4.0 Rel 6.0 for 430TX, has onboard Yamaha YMF701 which is not emulated yet. */
     /* Has a SM(S)C FDC37C935 Super I/O chip with on-chip KBC with Phoenix
        MultiKey/42 (version 1.38) KBC firmware. */
     {
@@ -12749,12 +12749,12 @@ const machine_t machines[] = {
         .cpu = {
             .package = CPU_PKG_SOCKET5_7,
             .block = CPU_BLOCK(CPU_WINCHIP, CPU_WINCHIP2),
-            .min_bus = 50000000,
+            .min_bus = 60000000,
             .max_bus = 66666667,
             .min_voltage = 2500,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_GAMEPORT | MACHINE_USB, /* Machine has internal sound: Yamaha YMF701-S */
@@ -12795,13 +12795,13 @@ const machine_t machines[] = {
             .min_voltage = 2700,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
         .ram = {
             .min = 8192,
-            .max = 786432,
+            .max = 262144,
             .step = 8192
         },
         .nvrmask = 255,
@@ -12836,14 +12836,14 @@ const machine_t machines[] = {
             .min_voltage = 2700,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
         .ram = {
-            .min = 8192,
+            .min = 4096,
             .max = 262144,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 255,
         .kbc_device = NULL,
@@ -12871,8 +12871,8 @@ const machine_t machines[] = {
         .cpu = {
             .package = CPU_PKG_SOCKET5_7,
             .block = CPU_BLOCK_NONE,
-            .min_bus = 55000000,
-            .max_bus = 75000000,
+            .min_bus = 60000000,
+            .max_bus = 66666667,
             .min_voltage = 2800,
             .max_voltage = 3520,
             .min_multi = 1.5,
@@ -12881,9 +12881,9 @@ const machine_t machines[] = {
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
         .ram = {
-            .min = 8192,
+            .min = 4096,
             .max = 262144,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 255,
         .kbc_device = NULL,
@@ -12912,18 +12912,18 @@ const machine_t machines[] = {
             .package = CPU_PKG_SOCKET5_7,
             .block = CPU_BLOCK_NONE,
             .min_bus = 50000000,
-            .max_bus = 66666667,
+            .max_bus = 75000000,
             .min_voltage = 2100,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
         .ram = {
-            .min = 8192,
+            .min = 4096,
             .max = 262144,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 255,
         .kbc_device = NULL,
@@ -12939,7 +12939,7 @@ const machine_t machines[] = {
     },
     /* [TEST] Has AMIKey 'H' KBC firmware. */
     {
-        .name = "[i430TX] TriGem Richmond",
+        .name = "[i430TX] TriGem RD535 (Richmond)",
         .internal_name = "richmond",
         .type = MACHINE_TYPE_SOCKET7,
         .chipset = MACHINE_CHIPSET_INTEL_430TX,
@@ -12951,12 +12951,12 @@ const machine_t machines[] = {
         .cpu = {
             .package = CPU_PKG_SOCKET5_7,
             .block = CPU_BLOCK_NONE,
-            .min_bus = 50000000,
+            .min_bus = 60000000,
             .max_bus = 66666667,
             .min_voltage = 2100,
             .max_voltage = 3520,
             .min_multi = 1.5,
-            .max_multi = 3.0
+            .max_multi = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
@@ -13108,7 +13108,7 @@ const machine_t machines[] = {
     /* SiS 5571 */
     /* Has the SiS 5571 chipset with on-chip KBC. */
     {
-        .name = "[SiS 5571] Daewoo CB52X-SI",
+        .name = "[SiS 5571] Daewoo CD520",
         .internal_name = "cb52xsi",
         .type = MACHINE_TYPE_SOCKET7,
         .chipset = MACHINE_CHIPSET_SIS_5571,


### PR DESCRIPTION
Summary
=======
This is the Part 1 of a planned series of pull requests I will make to fix the machine table entries for 586-based (Pentium, K6, WinChip etc.) machines.

All changes with the commit for this PR are listed below:

Changes
=======
### 430HX

- **ALL BOARDS (except Gateway Mailman, TC430HX, Infinia 7200, CU430HX, Equium 5200D, PCV-90):** Decreased min RAM to 4MB
- **ALL BOARDS:** Decreased min RAM increasement amounts to 4MB
- **ALL INTEL BOARDS (excluding OEM):** Board codename added to the entry names
- **Acer V35N:** Increased max RAM to 512MB; renamed to "Acer AcerPower Ultima"
- **AOpen AP53:** Increased max RAM to 512MB; decreased max multiplier to x2.5; added revision to board name
- **Acer M3A:** Increased max RAM to 512MB
- **ASUS P/I-P55T2P4:** Increased max RAM to 512MB and max multiplier to x4.0; decreased max FSB to 75MHz
- **ASUS P/I-P65UP5 (C-P55T2D):** Increased max multiplier to x3.5
- **Micronics M7S-Hi:** Increased max RAM to 512MB and min FSB to 60MHz
- **Intel TC430HX:** Increased max RAM to 512MB and max multiplier to x3.5
- **Toshiba Infinia 7200:** Increased max RAM to 512MB and max multiplier to x3.5; renamed to "Toshiba Infinia 7201" (as the 7200 has S3 ViRGE non-DX instead)
- **Intel CU430HX:** Increased max RAM to 512MB and max multiplier to x3.5
- **Toshiba Equium 5200D:** Increased max RAM to 512MB and max multiplier to x3.5
- **Radisys EPC-2102:** Increased max RAM to 512MB and max multiplier to x3.5; decreased max FSB to 66MHz
- **Sony Vaio PCV-90:** Increased max RAM to 512MB
- **Supermicro P55T2S:** Decreased max RAM to 512MB (NOTE: Although Micro House specifications claim this board supports up to 768MB, this must be an error as the 430HX chipset only supports up to 512MB, according to official Intel datasheets)

### 430VX

- **ALL BOARDS (except Presario 2240/4500, Gateway 2000 Hitman, HP Brio 80xx and Packard Bell PB640):** Decreased min RAM amounts to 4MB
- **ALL BOARDS:** Decreased min RAM increasement amounts to 4MB
- **ASUS P/I-P55TVP4:** Increased max multiplier to x3.5
- **Azza PT-5IV:** Increased max multiplier to x3.5
- **Compaq Presario 2240:** Increased min FSB to 66MHz, min RAM to 16MB and max multiplier to x3.5; decreased max RAM to 48MB; renamed to "Compaq Presario 224x"
- **Compaq Presario 4500:** Increased min FSB to 66MHz, min RAM to 16MB and max multiplier to x3.5; decreased max RAM to 48MB; renamed to "Compaq Presario 45xx"
- **Dell Hannibal+:** Increased max multiplier to x3.5; renamed to "Dell Dimension XPS Pxxxa/Mxxxa"
- **Epox P55-VA:** Increased max FSB to 75MHz
- **HP Brio 80xx:** Increased max multiplier to x3.5
- **Packard Bell PB680:** Renamed to "Packard Bell Multimedia C110"
- **Packard Bell PB810:** Increased max multiplier to x4.0; renamed to "Packard Bell Multimedia M415"

### 430TX

- **ALL INTEL BOARDS (excluding OEM):** Board codename added to the entry names
- **ASUS TX97:** Increased max multiplier to x3.5
- **Gateway Tomahawk:** Increased min FSB to 60MHz, max multiplier to x5.5; renamed to "Gateway E-1000"
- **Intel AN430TX (dev. builds only):** Increased max multiplier to x3.5
- **Intel YM430TX:** Increased max multiplier to x3.5; decreased min RAM to 4MB; decreased min RAM increasement amount to 4MB
- **Micronics Thunderbolt:** Increased min FSB to 60MHz, max multiplier to x3.5
- **NEC Mate NX MA23C:** Increased max multiplier to x3.5; decreased max RAM to 256MB
- **PC Partner MB540N:** Increased max multiplier to x3.5; decreased min RAM to 4MB; decreased min RAM increasement amount to 4MB
- **Soltek SL-56A5:** Increased min FSB to 60MHz; decreased max FSB to 66MHz; decreased min RAM to 4MB; decreased min RAM increasement amount to 4MB
- **Supermicro P5MMS98:** Increased max FSB to 75MHz, max multiplier to x3.5; decreased min RAM to 4MB; decreased min RAM increasement amount to 4MB
- **TriGem Richmond:** Increased min FSB to 60MHz; max multiplier to x3.5; renamed to "TriGem RD535 (Richmond)"

### SiS 5571

- **Daewoo CB52X-SI:** Renamed to "Daewoo CD520"

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
Relevant manuals and pictures, including those from https://theretroweb.com/ and other manufacturer websites (some archived on the Internet Archive and/or on their Wayback Machine service)
