### PR TITLE
Add BEK-Tronic BEK-p407 machine type.

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -572,6 +572,7 @@ extern int machine_at_sb486p_init(const machine_t *);
 extern int machine_at_486sp3_init(const machine_t *);
 extern int machine_at_486sp3c_init(const machine_t *);
 extern int machine_at_486sp3g_init(const machine_t *);
+extern int machine_at_486bekp407_init(const machine_t *);
 extern int machine_at_486ap4_init(const machine_t *);
 extern int machine_at_g486vpa_init(const machine_t *);
 extern int machine_at_486vipio2_init(const machine_t *);

--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -1125,7 +1125,33 @@ machine_at_ls486e_init(const machine_t *model)
 
     return ret;
 }
+int
+machine_at_486bekp407_init(const machine_t *model)
+{
+    int ret;
 
+    ret = bios_load_linear("roms/machines/bekp407/bekp407.bin",
+                           0x000e0000, 131072, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_common_init_ex(model, 2);
+
+    machine_at_sis_85c496_common_init(model);
+    device_add(&sis_85c496_device);
+    pci_register_slot(0x0C, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL, 2, 3, 4, 1);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL, 3, 4, 1, 2);
+
+    //device_add(&fdc37c665_device);
+    device_add(&prime3b_device);
+    device_add(&keyboard_at_ami_device);
+
+    device_add(&intel_flash_bxt_device);
+
+    return ret;
+}
 int
 machine_at_4dps_init(const machine_t *model)
 {

--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -1144,7 +1144,6 @@ machine_at_486bekp407_init(const machine_t *model)
     pci_register_slot(0x0B, PCI_CARD_NORMAL, 2, 3, 4, 1);
     pci_register_slot(0x0A, PCI_CARD_NORMAL, 3, 4, 1, 2);
 
-    //device_add(&fdc37c665_device);
     device_add(&prime3b_device);
     device_add(&keyboard_at_ami_device);
 

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -8235,6 +8235,46 @@ const machine_t machines[] = {
     },
     /* This has an AMIKey-2, which is an updated version of type 'H'. */
     {
+        .name = "[SiS 496] BEK-tronic BEK-P407",
+        .internal_name = "486bekp407",
+        .type = MACHINE_TYPE_486_S3,
+        .chipset = MACHINE_CHIPSET_SIS_496,
+        .init = machine_at_486bekp407_init,
+        .p1_handler = NULL,
+        .gpio_handler = NULL,
+        .available_flag = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu = {
+            .package = CPU_PKG_SOCKET3,
+            .block = CPU_BLOCK_NONE,
+            .min_bus = 0,
+            .max_bus = 0,
+            .min_voltage = 0,
+            .max_voltage = 0,
+            .min_multi = 0,
+            .max_multi = 0
+        },
+        .bus_flags = MACHINE_PCI,
+        .flags = MACHINE_IDE_DUAL | MACHINE_APM,
+        .ram = {
+            .min = 1024,
+            .max =  131072, //261120, orignal
+            .step = 1024
+        },
+        .nvrmask = 255,
+        .kbc_device = NULL,
+        .kbc_p1 = 0xff,
+        .gpio = 0xffffffff,
+        .gpio_acpi = 0xffffffff,
+        .device = NULL,
+        .fdc_device = NULL,
+        .sio_device = NULL,
+        .vid_device = NULL,
+        .snd_device = NULL,
+        .net_device = NULL
+    },
+    /* This has an AMIKey-2, which is an updated version of type 'H'. */
+    {
         .name = "[SiS 496] Lucky Star LS-486E",
         .internal_name = "ls486e",
         .type = MACHINE_TYPE_486_S3,


### PR DESCRIPTION
Summary
=======
Adding the BEK-Tronic BEK-p407 486 motherboard as a select-able machine type. (Socket 3, SiS 496, Prime3B)

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/302

References
==========
https://theretroweb.com/motherboard/manual/bek-p407-652aa211503a3636004898.pdf
https://theretroweb.com/motherboards/s/bek-tronic-bek-p407#chips



