### PR TITLE
Add Packard Bell PB286

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -438,6 +438,8 @@ extern int machine_at_ibmatquadtel_init(const machine_t *); // IBM AT with Quadt
 
 extern int machine_at_ibmxt286_init(const machine_t *);
 
+extern int machine_at_pb286_init(const machine_t *);
+
 extern int machine_at_siemens_init(const machine_t *); // Siemens PCD-2L. N82330 discrete machine. It segfaults in some places
 
 extern int machine_at_wellamerastar_init(const machine_t *); // Wells American A*Star with custom award BIOS 

--- a/src/machine/m_at.c
+++ b/src/machine/m_at.c
@@ -332,6 +332,7 @@ machine_at_ibmxt286_init(const machine_t *model)
     return ret;
 }
 
+int
 machine_at_pb286_init(const machine_t *model)
 {
     int ret;

--- a/src/machine/m_at.c
+++ b/src/machine/m_at.c
@@ -332,6 +332,22 @@ machine_at_ibmxt286_init(const machine_t *model)
     return ret;
 }
 
+machine_at_pb286_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_interleaved("roms/machines/pb286/LB_V332P.BIN",
+                                "roms/machines/pb286/HB_V332P.BIN",
+                                0x000f0000, 65536, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_ibm_common_init(model);
+
+    return ret;
+}
+
 int
 machine_at_siemens_init(const machine_t *model)
 {

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -3286,7 +3286,7 @@ const machine_t machines[] = {
         .ram = {
             .min = 256,
             .max = 1024,
-            .step = 256
+            .step = 128
         },
         .nvrmask = 63,
         .kbc_device = NULL,

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -3259,6 +3259,47 @@ const machine_t machines[] = {
         .snd_device = NULL,
         .net_device = NULL
     },
+    /* Has IBM AT KBC firmware. */
+    /* To configure the BIOS, use PB_2330a_diag.IMA from MS-DOS 3.30 Packard Bell OEM, GSETUP might work too*/
+    {
+        .name = "[ISA] Packard Bell PB286",
+        .internal_name = "pb286",
+        .type = MACHINE_TYPE_286,
+        .chipset = MACHINE_CHIPSET_DISCRETE,
+        .init = machine_at_pb286_init,
+        .p1_handler = NULL,
+        .gpio_handler = NULL,
+        .available_flag = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu = {
+            .package = CPU_PKG_286,
+            .block = CPU_BLOCK_NONE,
+            .min_bus = 0,
+            .max_bus = 0,
+            .min_voltage = 0,
+            .max_voltage = 0,
+            .min_multi = 0,
+            .max_multi = 0
+        },
+        .bus_flags = MACHINE_AT,
+        .flags = MACHINE_FLAGS_NONE,
+        .ram = {
+            .min = 256,
+            .max = 1024,
+            .step = 256
+        },
+        .nvrmask = 63,
+        .kbc_device = NULL,
+        .kbc_p1 = 0xff,
+        .gpio = 0xffffffff,
+        .gpio_acpi = 0xffffffff,
+        .device = NULL,
+        .fdc_device = NULL,
+        .sio_device = NULL,
+        .vid_device = NULL,
+        .snd_device = NULL,
+        .net_device = NULL
+    },
     /* This has a Siemens proprietary KBC which is completely undocumented. */
     {
         .name = "[ISA] Siemens PCD-2L",


### PR DESCRIPTION
Summary
=======
A chipset-less 286 AT machine, almost identical to the IBM AT, but supports 1 MB onboard RAM instead of just 512 KB
BIOS can be configured using the utilities from PB_2330a_diag.IMA found in MS-DOS 3.30 Packard Bell OEM from WinWorldPC

Checklist
=========
* [ ] I have discussed this with core contributors already
* [X] This pull request requires changes to the ROM set
  * [X] I have opened a roms pull request - https://github.com/86Box/roms/pull/304

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
https://theretroweb.com/motherboards/s/packard-bell-pb286-is-vt286-version-2