### PR TITLE
All held-down keys are now released when Alt-Tab'ing out

### DIFF
--- a/src/device/keyboard.c
+++ b/src/device/keyboard.c
@@ -332,6 +332,20 @@ keyboard_input(int down, uint16_t scan)
     }
 }
 
+void
+keyboard_all_up(void)
+{
+    for (unsigned short i = 0; i < 0x200; i++) {
+        if (recv_key_ui[i]) {
+            recv_key_ui[i] = 0;
+        }
+        if (recv_key[i]) {
+            recv_key[i] = 0;
+            key_process(i, 0);
+        }
+    }
+}
+
 static uint8_t
 keyboard_do_break(uint16_t scan)
 {

--- a/src/include/86box/keyboard.h
+++ b/src/include/86box/keyboard.h
@@ -269,6 +269,7 @@ extern void     keyboard_poll_host(void);
 extern void     keyboard_process(void);
 extern uint16_t keyboard_convert(int ch);
 extern void     keyboard_input(int down, uint16_t scan);
+extern void     keyboard_all_up(void);
 extern void     keyboard_update_states(uint8_t cl, uint8_t nl, uint8_t sl);
 extern uint8_t  keyboard_get_shift(void);
 extern void     keyboard_get_states(uint8_t *cl, uint8_t *nl, uint8_t *sl);

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -277,6 +277,8 @@ MainWindow::MainWindow(QWidget *parent)
             if (mouse_capture)
                 emit setMouseCapture(false);
 
+            keyboard_all_up();
+
             if (do_auto_pause && !dopause) {
                 auto_paused = 1;
                 plat_pause(1);


### PR DESCRIPTION
Summary
=======
All held-down keys are now released when Alt-Tab'ing out of 86Box (or when it is not the active window anymore).

Only applies when Raw Input is in use on Windows.

Checklist
=========
* [X] Closes #5256
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
