### PR TITLE
Mouse cursor now properly appears after uncapture

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -262,8 +262,10 @@ MainWindow::MainWindow(QWidget *parent)
                 ui->stackedWidget->mouse_capture_func(this->windowHandle());
         } else {
             this->releaseKeyboard();
-            if (ui->stackedWidget->mouse_uncapture_func)
+            if (ui->stackedWidget->mouse_uncapture_func) {
                 ui->stackedWidget->mouse_uncapture_func();
+            }
+            ui->stackedWidget->unsetCursor();
         }
     });
 

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -155,7 +155,7 @@ RendererStack::mouseReleaseEvent(QMouseEvent *event)
     }
     if (mouse_capture && (event->button() == Qt::MiddleButton) && (mouse_get_buttons() < 3)) {
         plat_mouse_capture(0);
-        this->setCursor(Qt::ArrowCursor);
+        this->unsetCursor();
         isMouseDown &= ~1;
         return;
     }


### PR DESCRIPTION
Summary
=======
Mouse cursor now properly appears after uncapture.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
