### PR TITLE
Revert all FPU changes for Final Reality

### DIFF
--- a/src/codegen/codegen_ops_x86-64.h
+++ b/src/codegen/codegen_ops_x86-64.h
@@ -3571,8 +3571,6 @@ FP_FLD(int reg)
     addbyte(0x89); /*MOV [TOP], EBX*/
     addbyte(0x5d);
     addbyte((uint8_t) cpu_state_offset(TOP));
-
-    CALL_FUNC((uintptr_t) x87_to_mmxreg);
 }
 
 static __inline void
@@ -3690,8 +3688,6 @@ FP_LOAD_S(void)
     addbyte(0x44);
     addbyte(0x1d);
     addbyte((uint8_t) cpu_state_offset(tag));
-    
-    CALL_FUNC((uintptr_t) x87_to_mmxreg);
 }
 static __inline void
 FP_LOAD_D(void)
@@ -3721,8 +3717,6 @@ FP_LOAD_D(void)
     addbyte(0x44);
     addbyte(0x1d);
     addbyte((uint8_t) cpu_state_offset(tag));
-
-    CALL_FUNC((uintptr_t) x87_to_mmxreg);
 }
 
 static __inline void
@@ -3760,8 +3754,6 @@ FP_LOAD_IW(void)
     addbyte(0x44);
     addbyte(0x1d);
     addbyte((uint8_t) cpu_state_offset(tag));
-
-    CALL_FUNC((uintptr_t) x87_to_mmxreg);
 }
 static __inline void
 FP_LOAD_IL(void)
@@ -3795,8 +3787,6 @@ FP_LOAD_IL(void)
     addbyte(0x44);
     addbyte(0x1d);
     addbyte((uint8_t) cpu_state_offset(tag));
-
-    CALL_FUNC((uintptr_t) x87_to_mmxreg);
 }
 static __inline void
 FP_LOAD_IQ(void)
@@ -3841,8 +3831,6 @@ FP_LOAD_IQ(void)
     addbyte(0x44);
     addbyte(0x1d);
     addbyte((uint8_t) cpu_state_offset(tag));
-
-    CALL_FUNC((uintptr_t) x87_to_mmxreg);
 }
 
 static __inline void
@@ -3875,8 +3863,6 @@ FP_LOAD_IMM_Q(uint64_t v)
     addbyte(0x1d);
     addbyte((uint8_t) cpu_state_offset(tag));
     addbyte(v ? 0 : 1);
-
-    CALL_FUNC((uintptr_t) x87_to_mmxreg);
 }
 
 static __inline void

--- a/src/codegen/codegen_ops_x86.h
+++ b/src/codegen/codegen_ops_x86.h
@@ -1794,7 +1794,6 @@ FP_FLD(int reg)
         addbyte(0x5d);
         addbyte((uint8_t) cpu_state_offset(TOP));
     }
-    CALL_FUNC((uintptr_t) x87_to_mmxreg);
 }
 
 static __inline void
@@ -2038,7 +2037,6 @@ FP_LOAD_S(void)
         addbyte(0x1d);
         addbyte((uint8_t) cpu_state_offset(tag[0]));
     }
-    CALL_FUNC((uintptr_t) x87_to_mmxreg);
 }
 static __inline void
 FP_LOAD_D(void)
@@ -2098,7 +2096,6 @@ FP_LOAD_D(void)
         addbyte(0x1d);
         addbyte((uint8_t) cpu_state_offset(tag[0]));
     }
-    CALL_FUNC((uintptr_t) x87_to_mmxreg);
 }
 static __inline void
 FP_LOAD_IW(void)
@@ -2157,7 +2154,6 @@ FP_LOAD_IW(void)
         addbyte(0x1d);
         addbyte((uint8_t) cpu_state_offset(tag[0]));
     }
-    CALL_FUNC((uintptr_t) x87_to_mmxreg);
 }
 static __inline void
 FP_LOAD_IL(void)
@@ -2214,7 +2210,6 @@ FP_LOAD_IL(void)
         addbyte(0x1d);
         addbyte((uint8_t) cpu_state_offset(tag[0]));
     }
-    CALL_FUNC((uintptr_t) x87_to_mmxreg);
 }
 static __inline void
 FP_LOAD_IQ(void)
@@ -2290,7 +2285,6 @@ FP_LOAD_IQ(void)
         addbyte(0x1d);
         addbyte((uint8_t) cpu_state_offset(tag[0]));
     }
-    CALL_FUNC((uintptr_t) x87_to_mmxreg);
 }
 
 static __inline void
@@ -2342,7 +2336,6 @@ FP_LOAD_IMM_Q(uint64_t v)
         addbyte(0x5d);
         addbyte((uint8_t) cpu_state_offset(TOP));
     }
-    CALL_FUNC((uintptr_t) x87_to_mmxreg);
 }
 
 static __inline int

--- a/src/codegen_new/codegen_ops_helpers.h
+++ b/src/codegen_new/codegen_ops_helpers.h
@@ -64,9 +64,6 @@ fpu_POP2(codeblock_t *block, ir_data_t *ir)
 static inline void
 fpu_PUSH(codeblock_t *block, ir_data_t *ir)
 {
-    uop_LOAD_FUNC_ARG_IMM(ir, 0, ((uint16_t)cpu_state.TOP - 1));
-    uop_CALL_FUNC(ir, x87_to_mmxreg);
-
     if (block->flags & CODEBLOCK_STATIC_TOP)
         uop_MOV_IMM(ir, IREG_FPU_TOP, cpu_state.TOP - 1);
     else

--- a/src/cpu/386_dynarec.c
+++ b/src/cpu/386_dynarec.c
@@ -74,51 +74,6 @@ x386_dynarec_log(const char *fmt, ...)
 #    define x386_dynarec_log(fmt, ...)
 #endif
 
-/* Deliberately stashed here; this function is only relevant for dynamic recompilers. */
-#if defined(_MSC_VER) && !defined(__clang__)
-#    if defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86
-#        define X87_INLINE_ASM
-#    endif
-#else
-#    if defined i386 || defined __i386 || defined __i386__ || defined _X86_ || defined _M_IX86 || defined _M_X64 || defined __amd64__
-#        define X87_INLINE_ASM
-#    endif
-#endif
-
-#ifdef USE_NEW_DYNAREC
-void
-x87_to_mmxreg(uint16_t reg)
-#else
-void
-x87_to_mmxreg(void)
-#endif
-{
-#ifndef USE_NEW_DYNAREC
-    uint32_t reg = cpu_state.TOP & 7;
-#endif
-    double val = cpu_state.ST[reg & 7];
-#ifdef X87_INLINE_ASM
-    unsigned char buffer[10];
-#else
-    x87_conv_t test;
-#endif
-
-#ifdef X87_INLINE_ASM
-    __asm volatile(""
-        :
-        :
-        : "memory");
-
-    __asm volatile("fldl %1\n"
-                    "fstpt %0\n" : "=m"(buffer) : "m"(val));
-
-    cpu_state.MM[reg & 7].q = (*(uint64_t*)buffer);
-#else
-    x87_to80(val, &test);
-    cpu_state.MM[reg & 7].q = test.eind.ll;
-#endif
-}
-
 static __inline void
 fetch_ea_32_long(uint32_t rmdat)
 {

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -829,12 +829,6 @@ extern uint16_t prefetch_queue_get_ip(void);
 extern int      prefetch_queue_get_prefetching(void);
 extern int      prefetch_queue_get_size(void);
 
-#ifdef USE_NEW_DYNAREC
-extern void     x87_to_mmxreg(uint16_t reg);
-#else
-extern void     x87_to_mmxreg(void);
-#endif
-
 #define prefetch_queue_set_suspended(s) prefetch_queue_set_prefetching(!s)
 #define prefetch_queue_get_suspended !prefetch_queue_get_prefetching
 

--- a/src/cpu/x87_ops.h
+++ b/src/cpu/x87_ops.h
@@ -113,33 +113,12 @@ typedef union {
 static __inline void
 x87_push(double i)
 {
-#ifdef X87_INLINE_ASM
-    unsigned char buffer[10];
-#else
-    x87_conv_t test;
-#endif
 #ifdef USE_NEW_DYNAREC
     cpu_state.TOP--;
 #else
     cpu_state.TOP                    = (cpu_state.TOP - 1) & 7;
 #endif
     cpu_state.ST[cpu_state.TOP & 7] = i;
-
-#ifdef X87_INLINE_ASM
-    __asm volatile(""
-        :
-        :
-        : "memory");
-
-    __asm volatile("fldl %1\n"
-                    "fstpt %0\n" : "=m"(buffer) : "m"(i));
-
-    cpu_state.MM[cpu_state.TOP & 7].q = (*(uint64_t*)buffer);
-#else
-    x87_to80(i, &test);
-    cpu_state.MM[cpu_state.TOP & 7].q = test.eind.ll;
-#endif
-
 #ifdef USE_NEW_DYNAREC
     cpu_state.tag[cpu_state.TOP & 7] = TAG_VALID;
 #else
@@ -150,11 +129,6 @@ x87_push(double i)
 static __inline void
 x87_push_u64(uint64_t i)
 {
-#ifdef X87_INLINE_ASM
-    unsigned char buffer[10];
-#else
-    x87_conv_t test;
-#endif
     union {
         double   d;
         uint64_t ll;
@@ -168,21 +142,6 @@ x87_push_u64(uint64_t i)
     cpu_state.TOP                    = (cpu_state.TOP - 1) & 7;
 #endif
     cpu_state.ST[cpu_state.TOP & 7] = td.d;
-
-#ifdef X87_INLINE_ASM
-    __asm volatile(""
-        :
-        :
-        : "memory");
-
-    __asm volatile("fldl %1\n"
-                    "fstpt %0\n" : "=m"(buffer) : "m"(td.d));
-
-    cpu_state.MM[cpu_state.TOP & 7].q = (*(uint64_t*)buffer);
-#else
-    x87_to80(td.d, &test);
-    cpu_state.MM[cpu_state.TOP & 7].q = test.eind.ll;
-#endif
 #ifdef USE_NEW_DYNAREC
     cpu_state.tag[cpu_state.TOP & 7] = TAG_VALID;
 #else


### PR DESCRIPTION
Summary
=======
This PR reverts all FPU changes made for Final Reality.

Need For Speed III renders to screen discolored with the recent FPU changes made. Fixing Final Reality without breaking everything else will need more thorough changes.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
