### PR TITLE
Misc. changes for new dynamic recompiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,12 +132,17 @@ option(RTMIDI       "RtMidi"                                                    
 option(FLUIDSYNTH   "FluidSynth"                                                 ON)
 option(MUNT         "MUNT"                                                       ON)
 option(VNC          "VNC renderer"                                               OFF)
-option(NEW_DYNAREC  "Use the PCem v15 (\"new\") dynamic recompiler"              OFF)
 option(MINITRACE    "Enable Chrome tracing using the modified minitrace library" OFF)
 option(GDBSTUB      "Enable GDB stub server for debugging"                       OFF)
 option(DEV_BRANCH   "Development branch"                                         OFF)
 option(DISCORD      "Discord Rich Presence support"                              ON)
 option(DEBUGREGS486 "Enable debug register opeartion on 486+ CPUs"               OFF)
+
+if((ARCH STREQUAL "arm64") OR (ARCH STREQUAL "arm"))
+    set(NEW_DYNAREC ON)
+else()
+    option(NEW_DYNAREC "Use the PCem v15 (\"new\") dynamic recompiler" OFF)
+endif()
 
 if(WIN32)
     set(QT ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -223,6 +223,9 @@ elseif(APPLE AND NOT QT)
     COMPONENT Runtime)
 endif()
 
+if(NEW_DYNAREC AND (ARCH STREQUAL "x86_64") AND (NOT WIN32))
+    add_compile_options(-mno-red-zone -fno-omit-frame-pointer)
+endif()
 
 # Install the PDB file on Windows builds
 if(MSVC)

--- a/src/codegen_new/codegen_backend_x86-64.c
+++ b/src/codegen_new/codegen_backend_x86-64.c
@@ -315,13 +315,19 @@ codegen_backend_init(void)
 #    endif
     host_x86_CALL(block, (void *) x86gpf);
     codegen_exit_rout = &codeblock[block_current].data[block_pos];
+#ifdef _WIN64
     host_x86_ADD64_REG_IMM(block, REG_RSP, 0x38);
+#else
+    host_x86_ADD64_REG_IMM(block, REG_RSP, 0x48);
+#endif
     host_x86_POP(block, REG_R15);
     host_x86_POP(block, REG_R14);
     host_x86_POP(block, REG_R13);
     host_x86_POP(block, REG_R12);
+#ifdef _WIN64
     host_x86_POP(block, REG_RDI);
     host_x86_POP(block, REG_RSI);
+#endif
     host_x86_POP(block, REG_RBP);
     host_x86_POP(block, REG_RDX);
     host_x86_RET(block);
@@ -346,13 +352,19 @@ codegen_backend_prologue(codeblock_t *block)
     block_pos = BLOCK_START; /*Entry code*/
     host_x86_PUSH(block, REG_RBX);
     host_x86_PUSH(block, REG_RBP);
+#ifdef _WIN64
     host_x86_PUSH(block, REG_RSI);
     host_x86_PUSH(block, REG_RDI);
+#endif
     host_x86_PUSH(block, REG_R12);
     host_x86_PUSH(block, REG_R13);
     host_x86_PUSH(block, REG_R14);
     host_x86_PUSH(block, REG_R15);
+#ifdef _WIN64
     host_x86_SUB64_REG_IMM(block, REG_RSP, 0x38);
+#else
+    host_x86_SUB64_REG_IMM(block, REG_RSP, 0x48);
+#endif
     host_x86_MOV64_REG_IMM(block, REG_RBP, ((uintptr_t) &cpu_state) + 128);
     if (block->flags & CODEBLOCK_HAS_FPU) {
         host_x86_MOV32_REG_ABS(block, REG_EAX, &cpu_state.TOP);
@@ -366,13 +378,19 @@ codegen_backend_prologue(codeblock_t *block)
 void
 codegen_backend_epilogue(codeblock_t *block)
 {
+#ifdef _WIN64
     host_x86_ADD64_REG_IMM(block, REG_RSP, 0x38);
+#else
+    host_x86_ADD64_REG_IMM(block, REG_RSP, 0x48);
+#endif
     host_x86_POP(block, REG_R15);
     host_x86_POP(block, REG_R14);
     host_x86_POP(block, REG_R13);
     host_x86_POP(block, REG_R12);
+#ifdef _WIN64
     host_x86_POP(block, REG_RDI);
     host_x86_POP(block, REG_RSI);
+#endif
     host_x86_POP(block, REG_RBP);
     host_x86_POP(block, REG_RDX);
     host_x86_RET(block);

--- a/src/codegen_new/codegen_backend_x86-64_ops.c
+++ b/src/codegen_new/codegen_backend_x86-64_ops.c
@@ -848,11 +848,11 @@ host_x86_MOV16_REG_BASE_OFFSET(codeblock_t *block, int dst_reg, int base_reg, in
     if (offset >= -128 && offset <= 127) {
         if (base_reg == REG_RSP) {
             codegen_alloc_bytes(block, 5);
-            codegen_addbyte(block, 0x66);
+            codegen_addbyte(block, 0x66); /* MOV dst_reg, [RSP + offset] */
             codegen_addbyte4(block, 0x8b, 0x40 | base_reg | (dst_reg << 3), 0x24, offset);
         } else {
             codegen_alloc_bytes(block, 4);
-            codegen_addbyte4(block, 0x66, 0x8b, 0x40 | base_reg | (dst_reg << 3), offset);
+            codegen_addbyte4(block, 0x66, 0x8b, 0x40 | base_reg | (dst_reg << 3), offset);  /* MOV dst_reg, [base_reg + offset] */
         }
     } else
         fatal("MOV16_REG_BASE_OFFSET - offset %i\n", offset);
@@ -866,10 +866,10 @@ host_x86_MOV32_REG_BASE_OFFSET(codeblock_t *block, int dst_reg, int base_reg, in
     if (offset >= -128 && offset <= 127) {
         if (base_reg == REG_RSP) {
             codegen_alloc_bytes(block, 4);
-            codegen_addbyte4(block, 0x8b, 0x40 | base_reg | (dst_reg << 3), 0x24, offset);
+            codegen_addbyte4(block, 0x8b, 0x40 | base_reg | (dst_reg << 3), 0x24, offset); /* MOV dst_reg, [RSP + offset] */
         } else {
             codegen_alloc_bytes(block, 3);
-            codegen_addbyte3(block, 0x8b, 0x40 | base_reg | (dst_reg << 3), offset);
+            codegen_addbyte3(block, 0x8b, 0x40 | base_reg | (dst_reg << 3), offset);  /* MOV dst_reg, [base_reg + offset] */
         }
     } else
         fatal("MOV32_REG_BASE_OFFSET - offset %i\n", offset);
@@ -883,11 +883,11 @@ host_x86_MOV64_REG_BASE_OFFSET(codeblock_t *block, int dst_reg, int base_reg, in
     if (offset >= -128 && offset <= 127) {
         if (base_reg == REG_RSP) {
             codegen_alloc_bytes(block, 5);
-            codegen_addbyte(block, 0x48);
+            codegen_addbyte(block, 0x48); /* MOV dst_reg, [RSP + offset] */
             codegen_addbyte4(block, 0x8b, 0x40 | base_reg | (dst_reg << 3), 0x24, offset);
         } else {
             codegen_alloc_bytes(block, 4);
-            codegen_addbyte4(block, 0x48, 0x8b, 0x40 | base_reg | (dst_reg << 3), offset);
+            codegen_addbyte4(block, 0x48, 0x8b, 0x40 | base_reg | (dst_reg << 3), offset);  /* MOV dst_reg, [base_reg + offset] */
         }
     } else
         fatal("MOV32_REG_BASE_OFFSET - offset %i\n", offset);
@@ -901,11 +901,11 @@ host_x86_MOV32_BASE_OFFSET_REG(codeblock_t *block, int base_reg, int offset, int
 
     if (offset >= -128 && offset <= 127) {
         if (base_reg == REG_RSP) {
-            codegen_alloc_bytes(block, 4);
+            codegen_alloc_bytes(block, 4); /* MOV [RSP + offset], src_reg*/
             codegen_addbyte4(block, 0x89, 0x40 | base_reg | (src_reg << 3), 0x24, offset);
         } else {
             codegen_alloc_bytes(block, 3);
-            codegen_addbyte3(block, 0x89, 0x40 | base_reg | (src_reg << 3), offset);
+            codegen_addbyte3(block, 0x89, 0x40 | base_reg | (src_reg << 3), offset);  /* MOV [base_reg + offset], src_reg*/
         }
     } else
         fatal("MOV32_BASE_OFFSET_REG - offset %i\n", offset);
@@ -919,11 +919,11 @@ host_x86_MOV64_BASE_OFFSET_REG(codeblock_t *block, int base_reg, int offset, int
     if (offset >= -128 && offset <= 127) {
         if (base_reg == REG_RSP) {
             codegen_alloc_bytes(block, 5);
-            codegen_addbyte(block, 0x48);
+            codegen_addbyte(block, 0x48); /* MOV [RSP + offset], src_reg*/
             codegen_addbyte4(block, 0x89, 0x40 | base_reg | (src_reg << 3), 0x24, offset);
         } else {
             codegen_alloc_bytes(block, 4);
-            codegen_addbyte4(block, 0x48, 0x89, 0x40 | base_reg | (src_reg << 3), offset);
+            codegen_addbyte4(block, 0x48, 0x89, 0x40 | base_reg | (src_reg << 3), offset);  /* MOV [base_reg + offset], src_reg*/
         }
     } else
         fatal("MOV64_BASE_OFFSET_REG - offset %i\n", offset);
@@ -938,11 +938,11 @@ host_x86_MOV32_BASE_OFFSET_IMM(codeblock_t *block, int base_reg, int offset, uin
     if (offset >= -128 && offset <= 127) {
         if (base_reg == REG_RSP) {
             codegen_alloc_bytes(block, 8);
-            codegen_addbyte4(block, 0xc7, 0x40 | base_reg, 0x24, offset);
+            codegen_addbyte4(block, 0xc7, 0x40 | base_reg, 0x24, offset); /* MOV [RSP + offset], imm_data */
             codegen_addlong(block, imm_data);
         } else {
             codegen_alloc_bytes(block, 7);
-            codegen_addbyte3(block, 0xc7, 0x40 | base_reg, offset);
+            codegen_addbyte3(block, 0xc7, 0x40 | base_reg, offset);  /* MOV [base_reg + offset], src_reg*/
             codegen_addlong(block, imm_data);
         }
     } else


### PR DESCRIPTION
Summary
=======
1. NDR is now enforced on ARMv7/ARM64 instead of bombing out with an error.
2. Make GCC/Clang not use anything in the red zone on x64 for now.
3. Compile with `-fno-omit-frame-pointer` on x64 as well.
4. More comments for non-commented machine code.
5. Don't attempt saving/restoring RSI and RDI outside Windows since both are volatile in the System V ABI.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
