### PR TITLE
Fix Acer 100T machine not showing up on Linux due to case-sensitivity.

### DIFF
--- a/src/machine/m_at_286_386sx.c
+++ b/src/machine/m_at_286_386sx.c
@@ -742,7 +742,7 @@ machine_at_acer100t_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear("roms/machines/acer100t/acer386.bin",
+    ret = bios_load_linear("roms/machines/acer100t/acer386.BIN",
                            0x000f0000, 65536, 0);
 
     if (bios_only || !ret)


### PR DESCRIPTION
Summary
=======
This machine wasn't showing up due to searching for a ".bin" when the file was named ".BIN".

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
