### PR TITLE
ViRGE: Revert all FIFO changes and keep only IRQ handling

### DIFF
--- a/src/video/vid_s3_virge.c
+++ b/src/video/vid_s3_virge.c
@@ -338,7 +338,6 @@ typedef struct virge_t {
     event_t *    fifo_not_full_event;
 
     atomic_int   virge_busy;
-    atomic_uint  virge_irq_req;
 
     uint8_t      subsys_stat;
     uint8_t      subsys_cntl;
@@ -374,9 +373,6 @@ typedef struct virge_t {
     uint32_t     dma_mmio_addr;
     uint32_t     dma_data_type;
 
-    pc_timer_t   wake_timer;
-    pc_timer_t   irq_timer;
-
     int          pci;
     int          is_agp;
 } virge_t;
@@ -385,28 +381,6 @@ static __inline void
 wake_fifo_thread(virge_t *virge) {
     /* Wake up FIFO thread if moving from idle */
     thread_set_event(virge->wake_fifo_thread);
-}
-
-void
-s3_virge_wake_fifo_timer(void* priv)
-{
-    virge_t *virge = (virge_t *) priv;
-
-    thread_set_event(virge->wake_fifo_thread); /*Wake up FIFO thread if moving from idle*/
-}
-
-void
-s3_virge_wake_fifo_thread(virge_t *virge)
-{
-    if (!timer_is_enabled(&virge->wake_timer)) {
-        /*Don't wake FIFO thread immediately - if we do that it will probably
-          process one word and go back to sleep, requiring it to be woken on
-          almost every write. Instead, wait a short while so that the CPU
-          emulation writes more data so we have more batched-up work.*/
-        timer_on_auto(&virge->wake_timer, 100.0);
-    }
-    if (!timer_is_enabled(&virge->irq_timer))
-        timer_on_auto(&virge->irq_timer, 100.0);
 }
 
 static virge_t         *reset_state = NULL;
@@ -495,19 +469,6 @@ s3_virge_update_irqs(virge_t *virge)
         pci_set_irq(virge->pci_slot, PCI_INTA, &virge->irq_state);
     else
         pci_clear_irq(virge->pci_slot, PCI_INTA, &virge->irq_state);
-}
-
-void
-s3_virge_update_irq_timer(void* priv)
-{
-    virge_t *virge = (virge_t *) priv;
-
-    if (virge->virge_irq_req) {
-        virge->virge_irq_req--;
-        s3_virge_update_irqs(virge);
-    }
-
-    timer_on_auto(&virge->irq_timer, 100.);
 }
 
 static void
@@ -1139,9 +1100,6 @@ s3_virge_updatemapping(virge_t *virge) {
 static void
 s3_virge_vblank_start(svga_t *svga) {
     virge_t *virge = (virge_t *) svga->priv;
-
-    if (virge->virge_irq_req)
-        virge->virge_irq_req--;
 
     virge->subsys_stat |= INT_VSY;
     s3_virge_update_irqs(virge);
@@ -1837,8 +1795,7 @@ fifo_thread(void *param)
          if (virge->cmd_dma)
             virge->subsys_stat |= (INT_HOST_DONE | INT_CMD_DONE);
 
-         //s3_virge_update_irqs(virge);
-         virge->virge_irq_req++;
+         s3_virge_update_irqs(virge);
     }
 }
 
@@ -1878,8 +1835,10 @@ s3_virge_queue(virge_t *virge, uint32_t addr, uint32_t val, uint32_t type)
 
     virge->fifo_write_idx++;
 
-    if (FIFO_ENTRIES > 0xe000 || FIFO_ENTRIES < 16)
-        s3_virge_wake_fifo_thread(virge);
+    if (FIFO_ENTRIES > 0xe000)
+        wake_fifo_thread(virge);
+    if (FIFO_ENTRIES > 0xe000 || FIFO_ENTRIES < 8)
+        wake_fifo_thread(virge);
 }
 
 static void
@@ -4445,8 +4404,7 @@ render_thread(void *param)
         }
         virge->s3d_busy = 0;
         virge->subsys_stat |= INT_S3D_DONE;
-        //s3_virge_update_irqs(virge);
-        virge->virge_irq_req++;
+        s3_virge_update_irqs(virge);
     }
 }
 
@@ -5374,9 +5332,6 @@ s3_virge_init(const device_t *info)
     virge->wake_fifo_thread = thread_create_event();
     virge->fifo_not_full_event = thread_create_event();
     virge->fifo_thread = thread_create(fifo_thread, virge);
-
-    timer_add(&virge->wake_timer, s3_virge_wake_fifo_timer, virge, 0);
-    timer_add(&virge->irq_timer, s3_virge_update_irq_timer, virge, 0);
 
     virge->local = info->local;
 


### PR DESCRIPTION
Summary
=======
This PR reverts all FIFO changes to the S3 ViRGE and only keeps the newer IRQ handling.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
