### PR TITLE
Fix ES1370 detection

### DIFF
--- a/src/sound/snd_audiopci.c
+++ b/src/sound/snd_audiopci.c
@@ -489,7 +489,10 @@ es137x_reset(void *priv)
 
     /* Serial Interface Control Register, Address 20H
        Addressable as byte, word, longword */
-    dev->si_cr = 0xff800000;
+    if (dev->type == AUDIOPCI_ES1370)
+        dev->si_cr = 0x00000000;
+    else
+        dev->si_cr = 0xff800000;
 
     /* DAC1 Channel Sample Count Register, Address 24H
        Addressable as word, longword */


### PR DESCRIPTION
Summary
=======
Fix ES1370 detection courtesy of TC1995

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
