### PR TITLE
8514/A compatible changes of the day (March 6th, 2025)

### DIFF
--- a/src/include/86box/vid_8514a.h
+++ b/src/include/86box/vid_8514a.h
@@ -213,7 +213,7 @@ typedef struct ibm8514_t {
     int     vdisp2;
     int     disp_cntl;
     int     interlace;
-    uint8_t subsys_cntl;
+    uint16_t subsys_cntl;
     uint8_t subsys_stat;
 
     atomic_int fifo_idx;

--- a/src/video/vid_ati68860_ramdac.c
+++ b/src/video/vid_ati68860_ramdac.c
@@ -70,20 +70,19 @@ void
 ati68860_ramdac_out(uint16_t addr, uint8_t val, void *priv, svga_t *svga)
 {
     ati68860_ramdac_t *ramdac = (ati68860_ramdac_t *) priv;
-    const ibm8514_t   *dev    = (ibm8514_t *) svga->dev8514;
 
     switch (addr) {
         case 0:
-            svga_out((dev && dev->on) ? 0x2ec : 0x3c8, val, svga);
+            svga_out(0x3c8, val, svga);
             break;
         case 1:
-            svga_out((dev && dev->on) ? 0x2ed : 0x3c9, val, svga);
+            svga_out(0x3c9, val, svga);
             break;
         case 2:
-            svga_out((dev && dev->on) ? 0x2ea : 0x3c6, val, svga);
+            svga_out(0x3c6, val, svga);
             break;
         case 3:
-            svga_out((dev && dev->on) ? 0x2eb : 0x3c7, val, svga);
+            svga_out(0x3c7, val, svga);
             break;
         default:
             ramdac->regs[addr & 0xf] = val;
@@ -176,21 +175,20 @@ uint8_t
 ati68860_ramdac_in(uint16_t addr, void *priv, svga_t *svga)
 {
     const ati68860_ramdac_t *ramdac = (ati68860_ramdac_t *) priv;
-    const ibm8514_t         *dev    = (ibm8514_t *) svga->dev8514;
     uint8_t                  temp   = 0;
 
     switch (addr) {
         case 0:
-            temp = svga_in((dev && dev->on) ? 0x2ec : 0x3c8, svga);
+            temp = svga_in(0x3c8, svga);
             break;
         case 1:
-            temp = svga_in((dev && dev->on) ? 0x2ed : 0x3c9, svga);
+            temp = svga_in(0x3c9, svga);
             break;
         case 2:
-            temp = svga_in((dev && dev->on) ? 0x2ea : 0x3c6, svga);
+            temp = svga_in(0x3c6, svga);
             break;
         case 3:
-            temp = svga_in((dev && dev->on) ? 0x2eb : 0x3c7, svga);
+            temp = svga_in(0x3c7, svga);
             break;
         case 4:
         case 8:

--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -438,6 +438,7 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                         (dev->accel.dx <= clip_r) &&
                         (dev->accel.dy >= clip_t) &&
                         (dev->accel.dy <= clip_b)) {
+                        dev->subsys_stat |= 0x02;
                         switch (mix ? frgd_sel : bkgd_sel) {
                             case 0:
                                 src_dat = dev->accel.bkgd_color;
@@ -661,6 +662,7 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                         (dev->accel.dx <= clip_r) &&
                         (dev->accel.dy >= clip_t) &&
                         (dev->accel.dy <= clip_b)) {
+                        dev->subsys_stat |= 0x02;
                         switch (mix ? frgd_sel : bkgd_sel) {
                             case 0:
                                 src_dat = dev->accel.bkgd_color;
@@ -1067,6 +1069,7 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                     (dev->accel.dx <= clip_r) &&
                     (dev->accel.dy >= clip_t) &&
                     (dev->accel.dy <= clip_b)) {
+                    dev->subsys_stat |= 0x02;
                     if (mach->accel.dp_config & 0x02) {
                         READ(dev->accel.src + dev->accel.cx, poly_src);
                         poly_src = ((poly_src & rd_mask) == rd_mask);
@@ -1308,6 +1311,7 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                             (dev->accel.cx <= clip_r) &&
                             (dev->accel.cy >= clip_t) &&
                             (dev->accel.cy <= clip_b)) {
+                            dev->subsys_stat |= 0x02;
                             mach->accel.clip_overrun = 0;
                             switch (mix ? frgd_sel : bkgd_sel) {
                                 case 0:
@@ -1441,6 +1445,7 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                             (dev->accel.cx <= clip_r) &&
                             (dev->accel.cy >= clip_t) &&
                             (dev->accel.cy <= clip_b)) {
+                            dev->subsys_stat |= 0x02;
                             mach->accel.clip_overrun = 0;
                             if (mach->accel.linedraw_opt & 0x02) {
                                 if (dev->bpp) {
@@ -1599,6 +1604,7 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                             (dev->accel.cx <= clip_r) &&
                             (dev->accel.cy >= clip_t) &&
                             (dev->accel.cy <= clip_b)) {
+                            dev->subsys_stat |= 0x02;
                             mach->accel.clip_overrun = 0;
                             switch (mix ? frgd_sel : bkgd_sel) {
                                 case 0:
@@ -1733,6 +1739,7 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                             (dev->accel.cx <= clip_r) &&
                             (dev->accel.cy >= clip_t) &&
                             (dev->accel.cy <= clip_b)) {
+                            dev->subsys_stat |= 0x02;
                             mach->accel.clip_overrun = 0;
                             switch (mix ? frgd_sel : bkgd_sel) {
                                 case 0:
@@ -2028,6 +2035,7 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                     (dev->accel.dx <= clip_r) &&
                     (dev->accel.dy >= clip_t) &&
                     (dev->accel.dy <= clip_b)) {
+                    dev->subsys_stat |= 0x02;
                     switch (mix ? frgd_sel : bkgd_sel) {
                         case 0:
                             src_dat = dev->accel.bkgd_color;
@@ -2333,6 +2341,7 @@ mach_out(uint16_t addr, uint8_t val, void *priv)
         case 0x2ed:
             rs2 = !!(mach->accel.ext_ge_config & 0x1000);
             rs3 = !!(mach->accel.ext_ge_config & 0x2000);
+            mach_log("8514/A RS2=%d, RS3=%d, addr=%03x.\n", rs2, rs3, addr);
             if ((dev->local & 0xff) >= 0x02) {
                 if (mach->regs[0xb0] & 0x20) { /*ATI extended 8514/A mode.*/
                     mach_log("Extended 8514/A mode.\n");
@@ -2341,10 +2350,14 @@ mach_out(uint16_t addr, uint8_t val, void *priv)
                     svga_recalctimings(svga);
                     mach32_updatemapping(mach, svga);
                 }
-                if (mach->pci_bus && !mach->ramdac_type)
-                    ati68860_ramdac_out((addr & 0x03) | (rs2 << 2) | (rs3 << 3), val, svga->ramdac, svga);
-                else
-                    ati68875_ramdac_out(addr, rs2, rs3, val, svga->ramdac, svga);
+                if (dev->on)
+                    svga_out(addr, val, svga);
+                else {
+                    if (mach->pci_bus && !mach->ramdac_type)
+                        ati68860_ramdac_out((addr & 0x03) | (rs2 << 2) | (rs3 << 3), val, svga->ramdac, svga);
+                    else
+                        ati68875_ramdac_out(addr, rs2, rs3, val, svga->ramdac, svga);
+                }
             } else
                 svga_out(addr, val, svga);
             return;
@@ -2355,6 +2368,7 @@ mach_out(uint16_t addr, uint8_t val, void *priv)
         case 0x3C9:
             rs2 = !!(mach->regs[0xa0] & 0x20);
             rs3 = !!(mach->regs[0xa0] & 0x40);
+            mach_log("VGA RS2=%d, RS3=%d, addr=%03x.\n", rs2, rs3, addr);
             if ((dev->local & 0xff) >= 0x02) {
                 if (svga->attrregs[0x10] & 0x40) {
                     mach_log("VGA mode.\n");
@@ -2363,10 +2377,14 @@ mach_out(uint16_t addr, uint8_t val, void *priv)
                     svga_recalctimings(svga);
                     mach32_updatemapping(mach, svga);
                 }
-                if (mach->pci_bus && !mach->ramdac_type)
-                    ati68860_ramdac_out((addr & 0x03) | (rs2 << 2) | (rs3 << 3), val, svga->ramdac, svga);
-                else
-                    ati68875_ramdac_out(addr, rs2, rs3, val, svga->ramdac, svga);
+                if (dev->on)
+                    svga_out(addr, val, svga);
+                else {
+                    if (mach->pci_bus && !mach->ramdac_type)
+                        ati68860_ramdac_out((addr & 0x03) | (rs2 << 2) | (rs3 << 3), val, svga->ramdac, svga);
+                    else
+                        ati68875_ramdac_out(addr, rs2, rs3, val, svga->ramdac, svga);
+                }
             } else
                 svga_out(addr, val, svga);
             return;
@@ -2481,10 +2499,14 @@ mach_in(uint16_t addr, void *priv)
             rs2 = !!(mach->accel.ext_ge_config & 0x1000);
             rs3 = !!(mach->accel.ext_ge_config & 0x2000);
             if ((dev->local & 0xff) >= 0x02) {
-                if (mach->pci_bus && !mach->ramdac_type)
-                    temp = ati68860_ramdac_in((addr & 3) | (rs2 << 2) | (rs3 << 3), svga->ramdac, svga);
-                else
-                    temp = ati68875_ramdac_in(addr, rs2, rs3, svga->ramdac, svga);
+                if (dev->on)
+                    temp = svga_in(addr, svga);
+                else {
+                    if (mach->pci_bus && !mach->ramdac_type)
+                        temp = ati68860_ramdac_in((addr & 3) | (rs2 << 2) | (rs3 << 3), svga->ramdac, svga);
+                    else
+                        temp = ati68875_ramdac_in(addr, rs2, rs3, svga->ramdac, svga);
+                }
             } else
                 temp = svga_in(addr, svga);
             break;
@@ -3407,7 +3429,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
 static void
 mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8514_t *dev)
 {
-    if (port != 0x42e8 && port != 0x42e9)
+    if (port == 0x42e8 || port == 0x42e9)
         mach_log("[%04X:%08X]: Port CALL OUT=%04x, val=%02x.\n", CS, cpu_state.pc, port, val);
 
     switch (port) {
@@ -3422,7 +3444,7 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
             break;
         case 0x42e9:
             ibm8514_accel_out(port, val, svga, 2);
-            if ((val & 0xc0) == 0xc0) {
+            if ((val & 0xc0) == 0x80) {
                 dev->ext_fifo_idx = 0;
                 mach->force_busy = 0;
             }
@@ -3511,6 +3533,11 @@ mach_accel_out_call(uint16_t port, uint8_t val, mach_t *mach, svga_t *svga, ibm8
             mach_log("ATI 8514/A: DISP_CNTL write %04x=%02x, written=%02x, interlace=%d.\n",
                      port, val & 0x70, dev->disp_cntl & 0x70, dev->interlace);
             svga_recalctimings(svga);
+            break;
+
+        case 0x46e8:
+        case 0x46e9:
+            mach_log("0x%04x write: VGA subsystem enable add-on=%02x.\n", port, val);
             break;
 
         case 0x4ae8:
@@ -4201,6 +4228,7 @@ mach_accel_in_call(uint16_t port, mach_t *mach, svga_t *svga, ibm8514_t *dev)
 
     switch (port) {
         case 0x2e8:
+        case 0x2e9:
         case 0x6e8:
         case 0x22e8:
         case 0x26e8:
@@ -4212,18 +4240,22 @@ mach_accel_in_call(uint16_t port, mach_t *mach, svga_t *svga, ibm8514_t *dev)
 
         case 0x42e8:
         case 0x42e9:
-            if (dev->vc == dev->v_syncstart)
+            if ((dev->subsys_cntl & 0x01) && !(dev->subsys_stat & 0x01) && (dev->vc == dev->dispend))
                 temp |= 0x01;
 
             if (mach->accel.cmd_type == -1) {
                 if (cmd == 6) {
-                    if ((dev->accel.dx >= clip_l) &&
+                    if ((dev->subsys_cntl & 0x02) &&
+                        !(dev->subsys_stat & 0x02) &&
+                        (dev->accel.dx >= clip_l) &&
                         (dev->accel.dx <= clip_r_ibm) &&
                         (dev->accel.dy >= clip_t) &&
                         (dev->accel.dy <= clip_b_ibm))
                         temp |= 0x02;
                 } else {
-                    if ((dev->accel.cx >= clip_l) &&
+                    if ((dev->subsys_cntl & 0x02) &&
+                        !(dev->subsys_stat & 0x02) &&
+                        (dev->accel.cx >= clip_l) &&
                         (dev->accel.cx <= clip_r_ibm) &&
                         (dev->accel.cy >= clip_t) &&
                         (dev->accel.cy <= clip_b_ibm))
@@ -4234,7 +4266,9 @@ mach_accel_in_call(uint16_t port, mach_t *mach, svga_t *svga, ibm8514_t *dev)
                     case 1:
                     case 2:
                     case 5:
-                        if ((dev->accel.dx >= clip_l) &&
+                        if ((dev->subsys_cntl & 0x02) &&
+                            !(dev->subsys_stat & 0x02) &&
+                            (dev->accel.dx >= clip_l) &&
                             (dev->accel.dx <= clip_r) &&
                             (dev->accel.dy >= clip_t) &&
                             (dev->accel.dy <= clip_b))
@@ -4242,7 +4276,9 @@ mach_accel_in_call(uint16_t port, mach_t *mach, svga_t *svga, ibm8514_t *dev)
                         break;
                     case 3:
                     case 4:
-                        if ((dev->accel.cx >= clip_l) &&
+                        if ((dev->subsys_cntl & 0x02) &&
+                            !(dev->subsys_stat & 0x02) &&
+                            (dev->accel.cx >= clip_l) &&
                             (dev->accel.cx <= clip_r) &&
                             (dev->accel.cy >= clip_t) &&
                             (dev->accel.cy <= clip_b))
@@ -4257,16 +4293,17 @@ mach_accel_in_call(uint16_t port, mach_t *mach, svga_t *svga, ibm8514_t *dev)
                 if ((!dev->force_busy && !dev->force_busy2) || !mach->force_busy)
                     temp |= 0x08;
             }
-            if (port & 1)
+            if (port & 1) {
                 temp = dev->vram_512k_8514 ? 0x00 : 0x80;
-            else {
+                temp |= (dev->subsys_cntl >> 8);
+            } else {
                 temp |= (dev->subsys_stat | (dev->vram_512k_8514 ? 0x00 : 0x80));
                 if (mach->accel.ext_ge_config & 0x08)
                     temp |= ((mach->accel.ext_ge_config & 0x07) << 4);
                 else
                     temp |= 0x20;
             }
-            mach_log("0x%04x read: Subsystem Status=%02x.\n", port, temp);
+            mach_log("0x%04x read: Subsystem Status=%02x, monitoralias=%02x.\n", port, temp, mach->accel.ext_ge_config & 0x07);
             break;
 
             /*ATI Mach8/32 specific registers*/
@@ -4403,7 +4440,8 @@ mach_accel_in_call(uint16_t port, mach_t *mach, svga_t *svga, ibm8514_t *dev)
         default:
             break;
     }
-    mach_log("[%04X:%08X]: Port NORMAL IN=%04x, temp=%04x.\n", CS, cpu_state.pc, port, temp);
+    if (port == 0x2ee8 || port == 0x2ee9 || port == 0x42e8 || port == 0x42e9)
+        mach_log("[%04X:%08X]: Port NORMAL IN=%04x, temp=%04x.\n", CS, cpu_state.pc, port, temp);
 
     return temp;
 }
@@ -5419,6 +5457,10 @@ mach32_updatemapping(mach_t *mach, svga_t *svga)
             mem_mapping_set_handler(&svga->mapping, mach32_read, mach32_readw, mach32_readl, mach32_write, mach32_writew, mach32_writel);
             mem_mapping_set_p(&svga->mapping, mach);
         } else {
+            if (!dev->on) {
+                memset(dev->vram, 0, dev->vram_size);
+                memset(dev->changedvram, 0, (dev->vram_size >> 12) + 1);
+            }
             mach_log("IBM compatible banked mapping.\n");
             mem_mapping_set_handler(&svga->mapping, svga_read, svga_readw, svga_readl, svga_write, svga_writew, svga_writel);
             mem_mapping_set_p(&svga->mapping, svga);


### PR DESCRIPTION
Summary
=======
1. Follow the Mach32 manual more closely regarding vblank support.
2. The subsystem status now takes account of the other bits more accurately.
3. The Mach32 PCI, when used with the ATI 68860 ramdac, has its own bpp's when in accelerator mode, separate from the VGA compatible side, so fix this accordingly.
4. Reset the vram when a mapping change occurs, should clear the messups in the ATI Mach8/32 accel video mode tests.


Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[Mach32 manual for the subsystem stuff](https://fenarinarsa.com/misc/atari-forum/reg-688000-15_programmers_guide_to_the_mach32_registers.pdf)
