### PR TITLE
Initialize the sound icon menu pointer

### DIFF
--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -259,6 +259,7 @@ MachineStatus::MachineStatus(QObject *parent)
 {
     d = std::make_unique<MachineStatus::States>(this);
     muteUnmuteAction = nullptr;
+    soundMenu = nullptr;
     connect(refreshTimer, &QTimer::timeout, this, &MachineStatus::refreshIcons);
     refreshTimer->start(75);
 }


### PR DESCRIPTION
Summary
=======
Fixes a crash when right- or double-clicking the sound status bar icon.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A