### PR TITLE
Fixes for the ports page of the settings dialog

### DIFF
--- a/src/qt/qt_settings.cpp
+++ b/src/qt/qt_settings.cpp
@@ -153,6 +153,8 @@ Settings::Settings(QWidget *parent)
             &SettingsSound::onCurrentMachineChanged);
     connect(machine, &SettingsMachine::currentMachineChanged, network,
             &SettingsNetwork::onCurrentMachineChanged);
+    connect(machine, &SettingsMachine::currentMachineChanged, ports,
+            &SettingsPorts::onCurrentMachineChanged);
     connect(machine, &SettingsMachine::currentMachineChanged, storageControllers,
             &SettingsStorageControllers::onCurrentMachineChanged);
     connect(machine, &SettingsMachine::currentMachineChanged, otherPeripherals,

--- a/src/qt/qt_settingsports.cpp
+++ b/src/qt/qt_settingsports.cpp
@@ -68,21 +68,14 @@ SettingsPorts::SettingsPorts(QWidget *parent)
     for (int i = 0; i < SERIAL_MAX; i++) {
         auto *checkBox     = findChild<QCheckBox *>(QString("checkBoxSerial%1").arg(i + 1));
         auto *checkBoxPass = findChild<QCheckBox *>(QString("checkBoxSerialPassThru%1").arg(i + 1));
+        auto *buttonPass   = findChild<QPushButton *>(QString("pushButtonSerialPassThru%1").arg(i + 1));
         if (checkBox != NULL)
             checkBox->setChecked(com_ports[i].enabled > 0);
-        if (checkBoxPass != NULL)
+        if (checkBoxPass != NULL) {
             checkBoxPass->setChecked(serial_passthrough_enabled[i]);
+            buttonPass->setEnabled(serial_passthrough_enabled[i]);
+        }
     }
-
-    ui->pushButtonSerialPassThru1->setEnabled(serial_passthrough_enabled[0]);
-    ui->pushButtonSerialPassThru2->setEnabled(serial_passthrough_enabled[1]);
-    ui->pushButtonSerialPassThru3->setEnabled(serial_passthrough_enabled[2]);
-    ui->pushButtonSerialPassThru4->setEnabled(serial_passthrough_enabled[3]);
-#if 0
-    ui->pushButtonSerialPassThru5->setEnabled(serial_passthrough_enabled[4]);
-    ui->pushButtonSerialPassThru6->setEnabled(serial_passthrough_enabled[5]);
-    ui->pushButtonSerialPassThru7->setEnabled(serial_passthrough_enabled[6]);
-#endif
 }
 
 SettingsPorts::~SettingsPorts()
@@ -181,45 +174,45 @@ SettingsPorts::on_pushButtonSerialPassThru7_clicked()
 #endif
 
 void
-SettingsPorts::on_checkBoxSerialPassThru1_clicked(bool checked)
+SettingsPorts::on_checkBoxSerialPassThru1_stateChanged(int state)
 {
-    ui->pushButtonSerialPassThru1->setEnabled(checked);
+    ui->pushButtonSerialPassThru1->setEnabled(state == Qt::Checked);
 }
 
 void
-SettingsPorts::on_checkBoxSerialPassThru2_clicked(bool checked)
+SettingsPorts::on_checkBoxSerialPassThru2_stateChanged(int state)
 {
-    ui->pushButtonSerialPassThru2->setEnabled(checked);
+    ui->pushButtonSerialPassThru2->setEnabled(state == Qt::Checked);
 }
 
 void
-SettingsPorts::on_checkBoxSerialPassThru3_clicked(bool checked)
+SettingsPorts::on_checkBoxSerialPassThru3_stateChanged(int state)
 {
-    ui->pushButtonSerialPassThru3->setEnabled(checked);
+    ui->pushButtonSerialPassThru3->setEnabled(state == Qt::Checked);
 }
 
 void
-SettingsPorts::on_checkBoxSerialPassThru4_clicked(bool checked)
+SettingsPorts::on_checkBoxSerialPassThru4_stateChanged(int state)
 {
-    ui->pushButtonSerialPassThru4->setEnabled(checked);
+    ui->pushButtonSerialPassThru4->setEnabled(state == Qt::Checked);
 }
 
 #if 0
 void
-SettingsPorts::on_checkBoxSerialPassThru5_clicked(bool checked)
+SettingsPorts::on_checkBoxSerialPassThru5_stateChanged(int state)
 {
-    ui->pushButtonSerialPassThru5->setEnabled(checked);
+    ui->pushButtonSerialPassThru5->setEnabled(state == Qt::Checked);
 }
 
 void
-SettingsPorts::on_checkBoxSerialPassThru6_clicked(bool checked)
+SettingsPorts::on_checkBoxSerialPassThru6_stateChanged(int state)
 {
-    ui->pushButtonSerialPassThru6->setEnabled(checked);
+    ui->pushButtonSerialPassThru6->setEnabled(state == Qt::Checked);
 }
 
 void
-SettingsPorts::on_checkBoxSerialPassThru7_clicked(bool checked)
+SettingsPorts::on_checkBoxSerialPassThru7_stateChanged(int state)
 {
-    ui->pushButtonSerialPassThru7->setEnabled(checked);
+    ui->pushButtonSerialPassThru7->setEnabled(state == Qt::Checked);
 }
 #endif

--- a/src/qt/qt_settingsports.cpp
+++ b/src/qt/qt_settingsports.cpp
@@ -72,8 +72,9 @@ SettingsPorts::SettingsPorts(QWidget *parent)
         if (checkBox != NULL)
             checkBox->setChecked(com_ports[i].enabled > 0);
         if (checkBoxPass != NULL) {
+            checkBoxPass->setEnabled(com_ports[i].enabled > 0);
             checkBoxPass->setChecked(serial_passthrough_enabled[i]);
-            buttonPass->setEnabled(serial_passthrough_enabled[i]);
+            buttonPass->setEnabled((com_ports[i].enabled > 0) && serial_passthrough_enabled[i]);
         }
     }
 }
@@ -170,6 +171,57 @@ void
 SettingsPorts::on_pushButtonSerialPassThru7_clicked()
 {
     DeviceConfig::ConfigureDevice(&serial_passthrough_device, 7, qobject_cast<Settings *>(Settings::settings));
+}
+#endif
+
+void
+SettingsPorts::on_checkBoxSerial1_stateChanged(int state)
+{
+    ui->checkBoxSerialPassThru1->setEnabled(state == Qt::Checked);
+    ui->pushButtonSerialPassThru1->setEnabled((state == Qt::Checked) && ui->checkBoxSerialPassThru1->isChecked());
+}
+
+void
+SettingsPorts::on_checkBoxSerial2_stateChanged(int state)
+{
+    ui->checkBoxSerialPassThru2->setEnabled(state == Qt::Checked);
+    ui->pushButtonSerialPassThru2->setEnabled((state == Qt::Checked) && ui->checkBoxSerialPassThru2->isChecked());
+}
+
+void
+SettingsPorts::on_checkBoxSerial3_stateChanged(int state)
+{
+    ui->checkBoxSerialPassThru3->setEnabled(state == Qt::Checked);
+    ui->pushButtonSerialPassThru3->setEnabled((state == Qt::Checked) && ui->checkBoxSerialPassThru3->isChecked());
+}
+
+void
+SettingsPorts::on_checkBoxSerial4_stateChanged(int state)
+{
+    ui->checkBoxSerialPassThru4->setEnabled(state == Qt::Checked);
+    ui->pushButtonSerialPassThru4->setEnabled((state == Qt::Checked) && ui->checkBoxSerialPassThru4->isChecked());
+}
+
+#if 0
+void
+SettingsPorts::on_checkBoxSerial5_stateChanged(int state)
+{
+    ui->checkBoxSerialPassThru5->setEnabled(state == Qt::Checked);
+    ui->pushButtonSerialPassThru5->setEnabled((state == Qt::Checked) && ui->checkBoxSerialPassThru5->isChecked());
+}
+
+void
+SettingsPorts::on_checkBoxSerial6_stateChanged(int state)
+{
+    ui->checkBoxSerialPassThru6->setEnabled(state == Qt::Checked);
+    ui->pushButtonSerialPassThru6->setEnabled((state == Qt::Checked) && ui->checkBoxSerialPassThru6->isChecked());
+}
+
+void
+SettingsPorts::on_checkBoxSerial7_stateChanged(int state)
+{
+    ui->checkBoxSerialPassThru7->setEnabled(state == Qt::Checked);
+    ui->pushButtonSerialPassThru7->setEnabled((state == Qt::Checked) && ui->checkBoxSerialPassThru7->isChecked());
 }
 #endif
 

--- a/src/qt/qt_settingsports.cpp
+++ b/src/qt/qt_settingsports.cpp
@@ -38,6 +38,40 @@ SettingsPorts::SettingsPorts(QWidget *parent)
     , ui(new Ui::SettingsPorts)
 {
     ui->setupUi(this);
+    onCurrentMachineChanged(machine);
+}
+
+SettingsPorts::~SettingsPorts()
+{
+    delete ui;
+}
+
+void
+SettingsPorts::save()
+{
+    for (int i = 0; i < PARALLEL_MAX; i++) {
+        auto *cbox     = findChild<QComboBox *>(QString("comboBoxLpt%1").arg(i + 1));
+        auto *checkBox       = findChild<QCheckBox *>(QString("checkBoxParallel%1").arg(i + 1));
+        if (cbox != NULL)
+            lpt_ports[i].device  = cbox->currentData().toInt();
+        if (checkBox != NULL)
+            lpt_ports[i].enabled = checkBox->isChecked() ? 1 : 0;
+    }
+
+    for (int i = 0; i < SERIAL_MAX; i++) {
+        auto *checkBox     = findChild<QCheckBox *>(QString("checkBoxSerial%1").arg(i + 1));
+        auto *checkBoxPass = findChild<QCheckBox *>(QString("checkBoxSerialPassThru%1").arg(i + 1));
+        if (checkBox != NULL)
+            com_ports[i].enabled = checkBox->isChecked() ? 1 : 0;
+        if (checkBoxPass != NULL)
+            serial_passthrough_enabled[i] = checkBoxPass->isChecked();
+    }
+}
+
+void
+SettingsPorts::onCurrentMachineChanged(int machineId)
+{
+    this->machineId = machineId;
 
     for (int i = 0; i < PARALLEL_MAX; i++) {
         auto *cbox        = findChild<QComboBox *>(QString("comboBoxLpt%1").arg(i + 1));
@@ -79,33 +113,6 @@ SettingsPorts::SettingsPorts(QWidget *parent)
     }
 }
 
-SettingsPorts::~SettingsPorts()
-{
-    delete ui;
-}
-
-void
-SettingsPorts::save()
-{
-    for (int i = 0; i < PARALLEL_MAX; i++) {
-        auto *cbox     = findChild<QComboBox *>(QString("comboBoxLpt%1").arg(i + 1));
-        auto *checkBox       = findChild<QCheckBox *>(QString("checkBoxParallel%1").arg(i + 1));
-        if (cbox != NULL)
-            lpt_ports[i].device  = cbox->currentData().toInt();
-        if (checkBox != NULL)
-            lpt_ports[i].enabled = checkBox->isChecked() ? 1 : 0;
-    }
-
-    for (int i = 0; i < SERIAL_MAX; i++) {
-        auto *checkBox     = findChild<QCheckBox *>(QString("checkBoxSerial%1").arg(i + 1));
-        auto *checkBoxPass = findChild<QCheckBox *>(QString("checkBoxSerialPassThru%1").arg(i + 1));
-        if (checkBox != NULL)
-            com_ports[i].enabled = checkBox->isChecked() ? 1 : 0;
-        if (checkBoxPass != NULL)
-            serial_passthrough_enabled[i] = checkBoxPass->isChecked();
-    }
-}
-
 void
 SettingsPorts::on_checkBoxParallel1_stateChanged(int state)
 {
@@ -129,50 +136,6 @@ SettingsPorts::on_checkBoxParallel4_stateChanged(int state)
 {
     ui->comboBoxLpt4->setEnabled(state == Qt::Checked);
 }
-
-void
-SettingsPorts::on_pushButtonSerialPassThru1_clicked()
-{
-    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 1, qobject_cast<Settings *>(Settings::settings));
-}
-
-void
-SettingsPorts::on_pushButtonSerialPassThru2_clicked()
-{
-    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 2, qobject_cast<Settings *>(Settings::settings));
-}
-
-void
-SettingsPorts::on_pushButtonSerialPassThru3_clicked()
-{
-    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 3, qobject_cast<Settings *>(Settings::settings));
-}
-
-void
-SettingsPorts::on_pushButtonSerialPassThru4_clicked()
-{
-    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 4, qobject_cast<Settings *>(Settings::settings));
-}
-
-#if 0
-void
-SettingsPorts::on_pushButtonSerialPassThru5_clicked()
-{
-    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 5, qobject_cast<Settings *>(Settings::settings));
-}
-
-void
-SettingsPorts::on_pushButtonSerialPassThru6_clicked()
-{
-    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 6, qobject_cast<Settings *>(Settings::settings));
-}
-
-void
-SettingsPorts::on_pushButtonSerialPassThru7_clicked()
-{
-    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 7, qobject_cast<Settings *>(Settings::settings));
-}
-#endif
 
 void
 SettingsPorts::on_checkBoxSerial1_stateChanged(int state)
@@ -266,5 +229,49 @@ void
 SettingsPorts::on_checkBoxSerialPassThru7_stateChanged(int state)
 {
     ui->pushButtonSerialPassThru7->setEnabled(state == Qt::Checked);
+}
+#endif
+
+void
+SettingsPorts::on_pushButtonSerialPassThru1_clicked()
+{
+    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 1, qobject_cast<Settings *>(Settings::settings));
+}
+
+void
+SettingsPorts::on_pushButtonSerialPassThru2_clicked()
+{
+    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 2, qobject_cast<Settings *>(Settings::settings));
+}
+
+void
+SettingsPorts::on_pushButtonSerialPassThru3_clicked()
+{
+    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 3, qobject_cast<Settings *>(Settings::settings));
+}
+
+void
+SettingsPorts::on_pushButtonSerialPassThru4_clicked()
+{
+    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 4, qobject_cast<Settings *>(Settings::settings));
+}
+
+#if 0
+void
+SettingsPorts::on_pushButtonSerialPassThru5_clicked()
+{
+    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 5, qobject_cast<Settings *>(Settings::settings));
+}
+
+void
+SettingsPorts::on_pushButtonSerialPassThru6_clicked()
+{
+    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 6, qobject_cast<Settings *>(Settings::settings));
+}
+
+void
+SettingsPorts::on_pushButtonSerialPassThru7_clicked()
+{
+    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 7, qobject_cast<Settings *>(Settings::settings));
 }
 #endif

--- a/src/qt/qt_settingsports.hpp
+++ b/src/qt/qt_settingsports.hpp
@@ -16,44 +16,47 @@ public:
 
     void save();
 
+public slots:
+    void onCurrentMachineChanged(int machineId);
+
 private slots:
-#if 0
-    void on_checkBoxSerialPassThru7_stateChanged(int state);
-    void on_checkBoxSerialPassThru6_stateChanged(int state);
-    void on_checkBoxSerialPassThru5_stateChanged(int state);
-#endif
-    void on_checkBoxSerialPassThru4_stateChanged(int state);
-    void on_checkBoxSerialPassThru3_stateChanged(int state);
-    void on_checkBoxSerialPassThru2_stateChanged(int state);
-    void on_checkBoxSerialPassThru1_stateChanged(int state);
-
-#if 0
-    void on_checkBoxSerial7_stateChanged(int state);
-    void on_checkBoxSerial6_stateChanged(int state);
-    void on_checkBoxSerial5_stateChanged(int state);
-#endif
-    void on_checkBoxSerial4_stateChanged(int state);
-    void on_checkBoxSerial3_stateChanged(int state);
-    void on_checkBoxSerial2_stateChanged(int state);
-    void on_checkBoxSerial1_stateChanged(int state);
-
-#if 0
-    void on_pushButtonSerialPassThru7_clicked();
-    void on_pushButtonSerialPassThru6_clicked();
-    void on_pushButtonSerialPassThru5_clicked();
-#endif
-    void on_pushButtonSerialPassThru4_clicked();
-    void on_pushButtonSerialPassThru3_clicked();
-    void on_pushButtonSerialPassThru2_clicked();
-    void on_pushButtonSerialPassThru1_clicked();
-
-    void on_checkBoxParallel4_stateChanged(int state);
-    void on_checkBoxParallel3_stateChanged(int state);
-    void on_checkBoxParallel2_stateChanged(int state);
     void on_checkBoxParallel1_stateChanged(int state);
+    void on_checkBoxParallel2_stateChanged(int state);
+    void on_checkBoxParallel3_stateChanged(int state);
+    void on_checkBoxParallel4_stateChanged(int state);
+
+    void on_checkBoxSerial1_stateChanged(int state);
+    void on_checkBoxSerial2_stateChanged(int state);
+    void on_checkBoxSerial3_stateChanged(int state);
+    void on_checkBoxSerial4_stateChanged(int state);
+#if 0
+    void on_checkBoxSerial5_stateChanged(int state);
+    void on_checkBoxSerial6_stateChanged(int state);
+    void on_checkBoxSerial7_stateChanged(int state);
+#endif
+    void on_checkBoxSerialPassThru1_stateChanged(int state);
+    void on_checkBoxSerialPassThru2_stateChanged(int state);
+    void on_checkBoxSerialPassThru3_stateChanged(int state);
+    void on_checkBoxSerialPassThru4_stateChanged(int state);
+#if 0
+    void on_checkBoxSerialPassThru5_stateChanged(int state);
+    void on_checkBoxSerialPassThru6_stateChanged(int state);
+    void on_checkBoxSerialPassThru7_stateChanged(int state);
+#endif
+
+    void on_pushButtonSerialPassThru1_clicked();
+    void on_pushButtonSerialPassThru2_clicked();
+    void on_pushButtonSerialPassThru3_clicked();
+    void on_pushButtonSerialPassThru4_clicked();
+#if 0
+    void on_pushButtonSerialPassThru5_clicked();
+    void on_pushButtonSerialPassThru6_clicked();
+    void on_pushButtonSerialPassThru7_clicked();
+#endif
 
 private:
     Ui::SettingsPorts *ui;
+    int                machineId = 0;
 };
 
 #endif // QT_SETTINGSPORTS_HPP

--- a/src/qt/qt_settingsports.hpp
+++ b/src/qt/qt_settingsports.hpp
@@ -18,14 +18,14 @@ public:
 
 #if 0
 private slots:
-    void on_checkBoxSerialPassThru7_clicked(bool checked);
-    void on_checkBoxSerialPassThru6_clicked(bool checked);
-    void on_checkBoxSerialPassThru5_clicked(bool checked);
+    void on_checkBoxSerialPassThru7_stateChanged(int state);
+    void on_checkBoxSerialPassThru6_stateChanged(int state);
+    void on_checkBoxSerialPassThru5_stateChanged(int state);
 #endif
-    void on_checkBoxSerialPassThru4_clicked(bool checked);
-    void on_checkBoxSerialPassThru3_clicked(bool checked);
-    void on_checkBoxSerialPassThru2_clicked(bool checked);
-    void on_checkBoxSerialPassThru1_clicked(bool checked);
+    void on_checkBoxSerialPassThru4_stateChanged(int state);
+    void on_checkBoxSerialPassThru3_stateChanged(int state);
+    void on_checkBoxSerialPassThru2_stateChanged(int state);
+    void on_checkBoxSerialPassThru1_stateChanged(int state);
 
 private slots:
 #if 0

--- a/src/qt/qt_settingsports.hpp
+++ b/src/qt/qt_settingsports.hpp
@@ -16,8 +16,8 @@ public:
 
     void save();
 
-#if 0
 private slots:
+#if 0
     void on_checkBoxSerialPassThru7_stateChanged(int state);
     void on_checkBoxSerialPassThru6_stateChanged(int state);
     void on_checkBoxSerialPassThru5_stateChanged(int state);
@@ -27,7 +27,16 @@ private slots:
     void on_checkBoxSerialPassThru2_stateChanged(int state);
     void on_checkBoxSerialPassThru1_stateChanged(int state);
 
-private slots:
+#if 0
+    void on_checkBoxSerial7_stateChanged(int state);
+    void on_checkBoxSerial6_stateChanged(int state);
+    void on_checkBoxSerial5_stateChanged(int state);
+#endif
+    void on_checkBoxSerial4_stateChanged(int state);
+    void on_checkBoxSerial3_stateChanged(int state);
+    void on_checkBoxSerial2_stateChanged(int state);
+    void on_checkBoxSerial1_stateChanged(int state);
+
 #if 0
     void on_pushButtonSerialPassThru7_clicked();
     void on_pushButtonSerialPassThru6_clicked();
@@ -38,11 +47,10 @@ private slots:
     void on_pushButtonSerialPassThru2_clicked();
     void on_pushButtonSerialPassThru1_clicked();
 
-private slots:
-    void on_checkBoxParallel4_stateChanged(int arg1);
-    void on_checkBoxParallel3_stateChanged(int arg1);
-    void on_checkBoxParallel2_stateChanged(int arg1);
-    void on_checkBoxParallel1_stateChanged(int arg1);
+    void on_checkBoxParallel4_stateChanged(int state);
+    void on_checkBoxParallel3_stateChanged(int state);
+    void on_checkBoxParallel2_stateChanged(int state);
+    void on_checkBoxParallel1_stateChanged(int state);
 
 private:
     Ui::SettingsPorts *ui;


### PR DESCRIPTION
Summary
=======
Fixes serial passthrough configuration buttons not enabling when the corresponding serial passthrough checkboxes are checked, and disables said checkboxes when the corresponding serial ports are turned off. Also adds plumbing for the page updates on a machine change.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A