### PR TITLE
Disable Windows 11 rounded window corners when they cover the emulated screen

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -122,6 +122,19 @@ extern int qt_nvr_save(void);
 #include "x11_util.h"
 #endif
 
+#ifdef Q_OS_WINDOWS
+#include <dwmapi.h>
+#ifndef DWMWA_WINDOW_CORNER_PREFERENCE
+#define DWMWA_WINDOW_CORNER_PREFERENCE 33
+#endif
+#ifndef DWMWCP_DEFAULT
+#define DWMWCP_DEFAULT 0
+#endif
+#ifndef DWMWCP_DONOTROUND
+#define DWMWCP_DONOTROUND 1
+#endif
+#endif
+
 #ifdef Q_OS_MACOS
 #    include "cocoa_keyboard.hpp"
 // The namespace is required to avoid clashing typedefs; we only use this
@@ -181,6 +194,10 @@ MainWindow::MainWindow(QWidget *parent)
     status->setSoundGainAction(ui->actionSound_gain);
     ui->stackedWidget->setMouseTracking(true);
     statusBar()->setVisible(!hide_status_bar);
+#ifdef Q_OS_WINDOWS
+    auto cornerPreference = (hide_status_bar ? DWMWCP_DONOTROUND : DWMWCP_DEFAULT);
+    DwmSetWindowAttribute((HWND) this->winId(), DWMWA_WINDOW_CORNER_PREFERENCE, (LPCVOID) &cornerPreference, sizeof(cornerPreference));
+#endif
     statusBar()->setStyleSheet("QStatusBar::item {border: None; } QStatusBar QLabel { margin-right: 2px; margin-bottom: 1px; }");
     this->centralWidget()->setStyleSheet("background-color: black;");
     ui->toolBar->setVisible(!hide_tool_bar);
@@ -1833,6 +1850,10 @@ MainWindow::on_actionHide_status_bar_triggered()
     hide_status_bar ^= 1;
     ui->actionHide_status_bar->setChecked(hide_status_bar);
     statusBar()->setVisible(!hide_status_bar);
+#ifdef Q_OS_WINDOWS
+    auto cornerPreference = (hide_status_bar ? DWMWCP_DONOTROUND : DWMWCP_DEFAULT);
+    DwmSetWindowAttribute((HWND) main_window->winId(), DWMWA_WINDOW_CORNER_PREFERENCE, (LPCVOID) &cornerPreference, sizeof(cornerPreference));
+#endif
     if (vid_resize >= 2) {
         setFixedSize(fixed_size_x, fixed_size_y + menuBar()->height() + (hide_status_bar ? 0 : statusBar()->height()) + (hide_tool_bar ? 0 : ui->toolBar->height()));
     } else {

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -122,19 +122,6 @@ extern int qt_nvr_save(void);
 #include "x11_util.h"
 #endif
 
-#ifdef Q_OS_WINDOWS
-#include <dwmapi.h>
-#ifndef DWMWA_WINDOW_CORNER_PREFERENCE
-#define DWMWA_WINDOW_CORNER_PREFERENCE 33
-#endif
-#ifndef DWMWCP_DEFAULT
-#define DWMWCP_DEFAULT 0
-#endif
-#ifndef DWMWCP_DONOTROUND
-#define DWMWCP_DONOTROUND 1
-#endif
-#endif
-
 #ifdef Q_OS_MACOS
 #    include "cocoa_keyboard.hpp"
 // The namespace is required to avoid clashing typedefs; we only use this
@@ -195,8 +182,7 @@ MainWindow::MainWindow(QWidget *parent)
     ui->stackedWidget->setMouseTracking(true);
     statusBar()->setVisible(!hide_status_bar);
 #ifdef Q_OS_WINDOWS
-    auto cornerPreference = (hide_status_bar ? DWMWCP_DONOTROUND : DWMWCP_DEFAULT);
-    DwmSetWindowAttribute((HWND) this->winId(), DWMWA_WINDOW_CORNER_PREFERENCE, (LPCVOID) &cornerPreference, sizeof(cornerPreference));
+    util::setWin11RoundedCorners(this->winId(), (hide_status_bar ? false : true));
 #endif
     statusBar()->setStyleSheet("QStatusBar::item {border: None; } QStatusBar QLabel { margin-right: 2px; margin-bottom: 1px; }");
     this->centralWidget()->setStyleSheet("background-color: black;");
@@ -817,8 +803,7 @@ MainWindow::initRendererMonitorSlot(int monitor_index)
             secondaryRenderer->setFixedSize(fixed_size_x, fixed_size_y);
         secondaryRenderer->setWindowIcon(this->windowIcon());
 #ifdef Q_OS_WINDOWS
-        auto cornerPreference = DWMWCP_DONOTROUND;
-        DwmSetWindowAttribute((HWND) secondaryRenderer->winId(), DWMWA_WINDOW_CORNER_PREFERENCE, (LPCVOID) &cornerPreference, sizeof(cornerPreference));
+        util::setWin11RoundedCorners(secondaryRenderer->winId(), false);
 #endif
         if (show_second_monitors) {
             secondaryRenderer->show();
@@ -1855,8 +1840,7 @@ MainWindow::on_actionHide_status_bar_triggered()
     ui->actionHide_status_bar->setChecked(hide_status_bar);
     statusBar()->setVisible(!hide_status_bar);
 #ifdef Q_OS_WINDOWS
-    auto cornerPreference = (hide_status_bar ? DWMWCP_DONOTROUND : DWMWCP_DEFAULT);
-    DwmSetWindowAttribute((HWND) main_window->winId(), DWMWA_WINDOW_CORNER_PREFERENCE, (LPCVOID) &cornerPreference, sizeof(cornerPreference));
+    util::setWin11RoundedCorners(main_window->winId(), (hide_status_bar ? false : true));
 #endif
     if (vid_resize >= 2) {
         setFixedSize(fixed_size_x, fixed_size_y + menuBar()->height() + (hide_status_bar ? 0 : statusBar()->height()) + (hide_tool_bar ? 0 : ui->toolBar->height()));

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -816,6 +816,10 @@ MainWindow::initRendererMonitorSlot(int monitor_index)
         if (vid_resize == 2)
             secondaryRenderer->setFixedSize(fixed_size_x, fixed_size_y);
         secondaryRenderer->setWindowIcon(this->windowIcon());
+#ifdef Q_OS_WINDOWS
+        auto cornerPreference = DWMWCP_DONOTROUND;
+        DwmSetWindowAttribute((HWND) secondaryRenderer->winId(), DWMWA_WINDOW_CORNER_PREFERENCE, (LPCVOID) &cornerPreference, sizeof(cornerPreference));
+#endif
         if (show_second_monitors) {
             secondaryRenderer->show();
             if (window_remember) {

--- a/src/qt/qt_util.cpp
+++ b/src/qt/qt_util.cpp
@@ -26,6 +26,19 @@
 #include <QUuid>
 #include "qt_util.hpp"
 
+#ifdef Q_OS_WINDOWS
+#    include <dwmapi.h>
+#    ifndef DWMWA_WINDOW_CORNER_PREFERENCE
+#        define DWMWA_WINDOW_CORNER_PREFERENCE 33
+#    endif
+#    ifndef DWMWCP_DEFAULT
+#        define DWMWCP_DEFAULT 0
+#    endif
+#    ifndef DWMWCP_DONOTROUND
+#        define DWMWCP_DONOTROUND 1
+#    endif
+#endif
+
 extern "C" {
 #include <86box/86box.h>
 #include <86box/config.h>
@@ -47,6 +60,15 @@ screenOfWidget(QWidget *widget)
     return widget->screen();
 #endif
 }
+
+#ifdef Q_OS_WINDOWS
+void
+setWin11RoundedCorners(WId hwnd, bool enable)
+{
+    auto cornerPreference = (enable ? DWMWCP_DEFAULT : DWMWCP_DONOTROUND);
+    DwmSetWindowAttribute((HWND) hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, (LPCVOID) &cornerPreference, sizeof(cornerPreference));
+}
+#endif
 
 QString
 DlgFilter(std::initializer_list<QString> extensions, bool last)

--- a/src/qt/qt_util.hpp
+++ b/src/qt/qt_util.hpp
@@ -13,6 +13,9 @@ static constexpr auto UUID_MIN_LENGTH = 36;
 QString DlgFilter(std::initializer_list<QString> extensions, bool last = false);
 /* Returns screen the widget is on */
 QScreen *screenOfWidget(QWidget *widget);
+#ifdef Q_OS_WINDOWS
+void setWin11RoundedCorners(WId hwnd, bool enable);
+#endif
 QString currentUuid();
 void storeCurrentUuid();
 bool compareUuid();


### PR DESCRIPTION
Summary
=======
Disables Windows 11's rounded window corners on secondary monitor windows, as well as the main emulator window when the status bar is disabled.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
<https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/nf-dwmapi-dwmsetwindowattribute>
<https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwm_window_corner_preference>