### PR TITLE
XGA/VGA changes of the evening (March 8th, 2025)

### DIFF
--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -782,7 +782,8 @@ svga_recalctimings(svga_t *svga)
 
             if (xga_active && (svga->xga != NULL)) {
                 if (xga->on) {
-                    if ((svga->mapping.base == 0xb8000) && (xga->aperture_cntl == 1)) /*Some operating systems reset themselves with ctrl-alt-del by going into text mode.*/
+                    svga_log("XGA on=%d, base=%05x, ap=%x.\n", xga->on, svga->mapping.base, xga->aperture_cntl);
+                    if ((svga->mapping.base == 0xb8000) && (xga->aperture_cntl >= 1)) /*Some operating systems reset themselves with ctrl-alt-del by going into text mode.*/
                         xga->on = 0;
                 }
             }
@@ -1541,7 +1542,7 @@ svga_init(const device_t *info, svga_t *svga, void *priv, int memsize,
     svga->dac_hwcursor.cur_xsize = svga->dac_hwcursor.cur_ysize = 32;
 
     svga->translate_address         = NULL;
-    
+
     svga->cable_connected = 1;
     svga->ksc5601_english_font_type = 0;
 

--- a/src/video/vid_xga.c
+++ b/src/video/vid_xga.c
@@ -2738,7 +2738,7 @@ xga_write_test(uint32_t addr, uint8_t val, void *priv)
     xga_t  *xga        = (xga_t *) svga->xga;
 
     if (xga_active && xga) {
-        if (((xga->op_mode & 7) >= 1) && xga->aperture_cntl) {
+        if (((xga->op_mode & 7) >= 1) && xga->aperture_cntl && (svga->mapping.base == 0xb8000)) {
             xga_log("WriteAddr=%05x.\n", addr);
             if (val == 0xa5) { /*Memory size test of XGA*/
                 xga->test    = val;
@@ -2843,7 +2843,7 @@ xga_read_test(uint32_t addr, void *priv)
     uint8_t ret = 0x00;
 
     if (xga_active && xga) {
-        if (((xga->op_mode & 7) >= 1) && xga->aperture_cntl) {
+        if (((xga->op_mode & 7) >= 1) && xga->aperture_cntl && (svga->mapping.base == 0xb8000)) {
             if (xga->test == 0xa5) { /*Memory size test of XGA*/
                 if (addr == 0xa0001) {
                     ret = xga->test;


### PR DESCRIPTION
Summary
=======
Workaround xga/vga toggle bug in the inmos card so that it switches from xga to vga and viceversa on ami bioses.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
