### PR TITLE
CONFIG_BIOS related changes and some hardening

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -429,6 +429,113 @@ device_available(const device_t *dev)
     return 0;
 }
 
+uint8_t
+device_get_bios_type(const device_t *dev, const char *internal_name)
+{
+    const device_config_t      *config = NULL;
+    const device_config_bios_t *bios   = NULL;
+
+    if (dev != NULL) {
+        config = dev->config;
+        if (config != NULL) {
+            while (config->type != CONFIG_END) {
+                if (config->type == CONFIG_BIOS) {
+                    bios = config->bios;
+                    while (bios->files_no != 0) {
+                        if (!strcmp(internal_name, bios->internal_name))
+                            return bios->bios_type;
+                        bios++;
+                    }
+                }
+                config++;
+            }
+        }
+    }
+
+    return 0;
+}
+
+uint8_t
+device_get_bios_num_files(const device_t *dev, const char *internal_name)
+{
+    const device_config_t      *config = NULL;
+    const device_config_bios_t *bios   = NULL;
+
+    if (dev != NULL) {
+        config = dev->config;
+        if (config != NULL) {
+            while (config->type != CONFIG_END) {
+                if (config->type == CONFIG_BIOS) {
+                    bios = config->bios;
+                    while (bios->files_no != 0) {
+                        if (!strcmp(internal_name, bios->internal_name))
+                            return bios->files_no;
+                        bios++;
+                    }
+                }
+                config++;
+            }
+        }
+    }
+
+    return 0;
+}
+
+uint32_t
+device_get_bios_local(const device_t *dev, const char *internal_name)
+{
+    const device_config_t      *config = NULL;
+    const device_config_bios_t *bios   = NULL;
+
+    if (dev != NULL) {
+        config = dev->config;
+        if (config != NULL) {
+            while (config->type != CONFIG_END) {
+                if (config->type == CONFIG_BIOS) {
+                    bios = config->bios;
+                    while (bios->files_no != 0) {
+                        printf("Internal name was: %s", internal_name);
+                        if (!strcmp(internal_name, bios->internal_name))
+                            return bios->local;
+                        bios++;
+                    }
+                }
+                config++;
+            }
+        }
+    }
+
+    return 0;
+}
+
+uint32_t
+device_get_bios_file_size(const device_t *dev, const char *internal_name)
+{
+    const device_config_t      *config = NULL;
+    const device_config_bios_t *bios   = NULL;
+
+    if (dev != NULL) {
+        config = dev->config;
+        if (config != NULL) {
+            while (config->type != CONFIG_END) {
+                if (config->type == CONFIG_BIOS) {
+                    bios = config->bios;
+
+                    /* Go through the ROM's in the device configuration. */
+                    while (bios->files_no != 0) {
+                        if (!strcmp(internal_name, bios->internal_name))
+                            return bios->size;
+                        bios++;
+                    }
+                }
+                config++;
+            }
+        }
+    }
+
+    return 0;
+}
+
 const char *
 device_get_bios_file(const device_t *dev, const char *internal_name, int file_no)
 {

--- a/src/device.c
+++ b/src/device.c
@@ -390,22 +390,21 @@ device_get_priv(const device_t *dev)
 int
 device_available(const device_t *dev)
 {
-    const device_config_t      *config       = NULL;
-    const device_config_bios_t *bios         = NULL;
-
     if (dev != NULL) {
-        config = dev->config;
+        const device_config_t *config = dev->config;
         if (config != NULL) {
             while (config->type != CONFIG_END) {
                 if (config->type == CONFIG_BIOS) {
                     int roms_present = 0;
-
-                    bios = (const device_config_bios_t *) config->bios;
+                    const device_config_bios_t *bios = (const device_config_bios_t *) config->bios;
 
                     /* Go through the ROM's in the device configuration. */
-                    while (bios->files_no != 0) {
+                    while ((bios != NULL) &&
+                           (bios->name != NULL) &&
+                           (bios->internal_name != NULL) &&
+                           (bios->files_no != 0)) {
                         int i = 0;
-                        for (int bf = 0; bf < bios->files_no; bf++)
+                        for (uint8_t bf = 0; bf < bios->files_no; bf++)
                             i += !!rom_present(bios->files[bf]);
                         if (i == bios->files_no)
                             roms_present++;
@@ -432,16 +431,16 @@ device_available(const device_t *dev)
 uint8_t
 device_get_bios_type(const device_t *dev, const char *internal_name)
 {
-    const device_config_t      *config = NULL;
-    const device_config_bios_t *bios   = NULL;
-
     if (dev != NULL) {
-        config = dev->config;
+        const device_config_t *config = dev->config;
         if (config != NULL) {
             while (config->type != CONFIG_END) {
                 if (config->type == CONFIG_BIOS) {
-                    bios = config->bios;
-                    while (bios->files_no != 0) {
+                    const device_config_bios_t *bios = (const device_config_bios_t *) config->bios;
+                    while ((bios != NULL) &&
+                           (bios->name != NULL) &&
+                           (bios->internal_name != NULL) &&
+                           (bios->files_no != 0)) {
                         if (!strcmp(internal_name, bios->internal_name))
                             return bios->bios_type;
                         bios++;
@@ -458,16 +457,16 @@ device_get_bios_type(const device_t *dev, const char *internal_name)
 uint8_t
 device_get_bios_num_files(const device_t *dev, const char *internal_name)
 {
-    const device_config_t      *config = NULL;
-    const device_config_bios_t *bios   = NULL;
-
     if (dev != NULL) {
-        config = dev->config;
+        const device_config_t *config = dev->config;
         if (config != NULL) {
             while (config->type != CONFIG_END) {
                 if (config->type == CONFIG_BIOS) {
-                    bios = config->bios;
-                    while (bios->files_no != 0) {
+                    const device_config_bios_t *bios = (const device_config_bios_t *) config->bios;
+                    while ((bios != NULL) &&
+                           (bios->name != NULL) &&
+                           (bios->internal_name != NULL) &&
+                           (bios->files_no != 0)) {
                         if (!strcmp(internal_name, bios->internal_name))
                             return bios->files_no;
                         bios++;
@@ -484,16 +483,16 @@ device_get_bios_num_files(const device_t *dev, const char *internal_name)
 uint32_t
 device_get_bios_local(const device_t *dev, const char *internal_name)
 {
-    const device_config_t      *config = NULL;
-    const device_config_bios_t *bios   = NULL;
-
     if (dev != NULL) {
-        config = dev->config;
+        const device_config_t *config = dev->config;
         if (config != NULL) {
             while (config->type != CONFIG_END) {
                 if (config->type == CONFIG_BIOS) {
-                    bios = config->bios;
-                    while (bios->files_no != 0) {
+                    const device_config_bios_t *bios = (const device_config_bios_t *) config->bios;
+                    while ((bios != NULL) &&
+                           (bios->name != NULL) &&
+                           (bios->internal_name != NULL) &&
+                           (bios->files_no != 0)) {
                         printf("Internal name was: %s", internal_name);
                         if (!strcmp(internal_name, bios->internal_name))
                             return bios->local;
@@ -511,18 +510,18 @@ device_get_bios_local(const device_t *dev, const char *internal_name)
 uint32_t
 device_get_bios_file_size(const device_t *dev, const char *internal_name)
 {
-    const device_config_t      *config = NULL;
-    const device_config_bios_t *bios   = NULL;
-
     if (dev != NULL) {
-        config = dev->config;
+        const device_config_t *config = dev->config;
         if (config != NULL) {
             while (config->type != CONFIG_END) {
                 if (config->type == CONFIG_BIOS) {
-                    bios = config->bios;
+                    const device_config_bios_t *bios = (const device_config_bios_t *) config->bios;
 
                     /* Go through the ROM's in the device configuration. */
-                    while (bios->files_no != 0) {
+                    while ((bios != NULL) &&
+                           (bios->name != NULL) &&
+                           (bios->internal_name != NULL) &&
+                           (bios->files_no != 0)) {
                         if (!strcmp(internal_name, bios->internal_name))
                             return bios->size;
                         bios++;
@@ -539,18 +538,20 @@ device_get_bios_file_size(const device_t *dev, const char *internal_name)
 const char *
 device_get_bios_file(const device_t *dev, const char *internal_name, int file_no)
 {
-    const device_config_t      *config = NULL;
     const device_config_bios_t *bios   = NULL;
 
     if (dev != NULL) {
-        config = dev->config;
+        const device_config_t *config = dev->config;
         if (config != NULL) {
             while (config->type != CONFIG_END) {
                 if (config->type == CONFIG_BIOS) {
-                    bios = config->bios;
+                    const device_config_bios_t *bios = (const device_config_bios_t *) config->bios;
 
                     /* Go through the ROM's in the device configuration. */
-                    while (bios->files_no != 0) {
+                    while ((bios != NULL) &&
+                           (bios->name != NULL) &&
+                           (bios->internal_name != NULL) &&
+                           (bios->files_no != 0)) {
                         if (!strcmp(internal_name, bios->internal_name)) {
                             if (file_no < bios->files_no)
                                 return bios->files[file_no];

--- a/src/device.c
+++ b/src/device.c
@@ -660,13 +660,15 @@ device_get_config_string(const char *str)
 int
 device_get_config_int(const char *str)
 {
-    const device_config_t *cfg = device_current.dev->config;
+    if (device_current.dev != NULL) {
+        const device_config_t *cfg = device_current.dev->config;
 
-    while (cfg && cfg->type != CONFIG_END) {
-        if (!strcmp(str, cfg->name))
-            return (config_get_int((char *) device_current.name, (char *) str, cfg->default_int));
+        while ((cfg != NULL) && (cfg->type != CONFIG_END)) {
+            if (!strcmp(str, cfg->name))
+                return (config_get_int((char *) device_current.name, (char *) str, cfg->default_int));
 
-        cfg++;
+            cfg++;
+        }
     }
 
     return 0;
@@ -675,13 +677,15 @@ device_get_config_int(const char *str)
 int
 device_get_config_int_ex(const char *str, int def)
 {
-    const device_config_t *cfg = device_current.dev->config;
+    if (device_current.dev != NULL) {
+        const device_config_t *cfg = device_current.dev->config;
 
-    while (cfg && cfg->type != CONFIG_END) {
-        if (!strcmp(str, cfg->name))
-            return (config_get_int((char *) device_current.name, (char *) str, def));
+        while ((cfg != NULL) && (cfg->type != CONFIG_END)) {
+            if (!strcmp(str, cfg->name))
+                return (config_get_int((char *) device_current.name, (char *) str, def));
 
-        cfg++;
+            cfg++;
+        }
     }
 
     return def;
@@ -690,13 +694,15 @@ device_get_config_int_ex(const char *str, int def)
 int
 device_get_config_hex16(const char *str)
 {
-    const device_config_t *cfg = device_current.dev->config;
+    if (device_current.dev != NULL) {
+        const device_config_t *cfg = device_current.dev->config;
 
-    while (cfg && cfg->type != CONFIG_END) {
-        if (!strcmp(str, cfg->name))
-            return (config_get_hex16((char *) device_current.name, (char *) str, cfg->default_int));
+        while ((cfg != NULL) && (cfg->type != CONFIG_END)) {
+            if (!strcmp(str, cfg->name))
+                return (config_get_hex16((char *) device_current.name, (char *) str, cfg->default_int));
 
-        cfg++;
+            cfg++;
+        }
     }
 
     return 0;
@@ -705,13 +711,15 @@ device_get_config_hex16(const char *str)
 int
 device_get_config_hex20(const char *str)
 {
-    const device_config_t *cfg = device_current.dev->config;
+    if (device_current.dev != NULL) {
+        const device_config_t *cfg = device_current.dev->config;
 
-    while (cfg && cfg->type != CONFIG_END) {
-        if (!strcmp(str, cfg->name))
-            return (config_get_hex20((char *) device_current.name, (char *) str, cfg->default_int));
+        while ((cfg != NULL) && (cfg->type != CONFIG_END)) {
+            if (!strcmp(str, cfg->name))
+                return (config_get_hex20((char *) device_current.name, (char *) str, cfg->default_int));
 
-        cfg++;
+            cfg++;
+        }
     }
 
     return 0;
@@ -720,13 +728,15 @@ device_get_config_hex20(const char *str)
 int
 device_get_config_mac(const char *str, int def)
 {
-    const device_config_t *cfg = device_current.dev->config;
+    if (device_current.dev != NULL) {
+        const device_config_t *cfg = device_current.dev->config;
 
-    while (cfg && cfg->type != CONFIG_END) {
-        if (!strcmp(str, cfg->name))
-            return (config_get_mac((char *) device_current.name, (char *) str, def));
+        while ((cfg != NULL) && (cfg->type != CONFIG_END)) {
+            if (!strcmp(str, cfg->name))
+                return (config_get_mac((char *) device_current.name, (char *) str, def));
 
-        cfg++;
+            cfg++;
+        }
     }
 
     return def;
@@ -735,60 +745,68 @@ device_get_config_mac(const char *str, int def)
 void
 device_set_config_int(const char *str, int val)
 {
-    const device_config_t *cfg = device_current.dev->config;
+    if (device_current.dev != NULL) {
+        const device_config_t *cfg = device_current.dev->config;
 
-    while (cfg && cfg->type != CONFIG_END) {
-        if (!strcmp(str, cfg->name)) {
-            config_set_int((char *) device_current.name, (char *) str, val);
-            break;
+        while ((cfg != NULL) && (cfg->type != CONFIG_END)) {
+            if (!strcmp(str, cfg->name)) {
+                config_set_int((char *) device_current.name, (char *) str, val);
+                break;
+            }
+
+            cfg++;
         }
-
-        cfg++;
     }
 }
 
 void
 device_set_config_hex16(const char *str, int val)
 {
-    const device_config_t *cfg = device_current.dev->config;
+    if (device_current.dev != NULL) {
+        const device_config_t *cfg = device_current.dev->config;
 
-    while (cfg && cfg->type != CONFIG_END) {
-        if (!strcmp(str, cfg->name)) {
-            config_set_hex16((char *) device_current.name, (char *) str, val);
-            break;
+        while ((cfg != NULL) && (cfg->type != CONFIG_END)) {
+            if (!strcmp(str, cfg->name)) {
+                config_set_hex16((char *) device_current.name, (char *) str, val);
+                break;
+            }
+
+            cfg++;
         }
-
-        cfg++;
     }
 }
 
 void
 device_set_config_hex20(const char *str, int val)
 {
-    const device_config_t *cfg = device_current.dev->config;
+    if (device_current.dev != NULL) {
+        const device_config_t *cfg = device_current.dev->config;
 
-    while (cfg && cfg->type != CONFIG_END) {
-        if (!strcmp(str, cfg->name)) {
-            config_set_hex20((char *) device_current.name, (char *) str, val);
-            break;
-        }
+        while ((cfg != NULL) && (cfg->type != CONFIG_END)) {
+            if (!strcmp(str, cfg->name)) {
+                config_set_hex20((char *) device_current.name, (char *) str, val);
+                break;
+            }
 
         cfg++;
+        }
     }
 }
 
 void
 device_set_config_mac(const char *str, int val)
 {
-    const device_config_t *cfg = device_current.dev->config;
+    if (device_current.dev != NULL) {
+        const device_config_t *cfg = device_current.dev->config;
 
-    while (cfg && cfg->type != CONFIG_END) {
-        if (!strcmp(str, cfg->name)) {
-            config_set_mac((char *) device_current.name, (char *) str, val);
-            break;
+        while ((cfg != NULL) && (cfg->type != CONFIG_END)) {
+            if (!strcmp(str, cfg->name)) {
+                config_set_mac((char *) device_current.name, (char *) str, val);
+                break;
+            }
+
+            cfg++;
         }
-
-        cfg++;
     }
 }
 
@@ -806,20 +824,18 @@ device_is_valid(const device_t *device, int mch)
 int
 machine_get_config_int(char *str)
 {
-    const device_t        *dev = machine_get_device(machine);
-    const device_config_t *cfg;
+    const device_t *dev = machine_get_device(machine);
 
-    if (dev == NULL)
-        return 0;
+    if (dev != NULL) {
+        const device_config_t *cfg = dev->config;
 
-    cfg = dev->config;
-    while (cfg && cfg->type != CONFIG_END) {
-        if (!strcmp(str, cfg->name))
-            return (config_get_int((char *) dev->name, str, cfg->default_int));
+        while ((cfg != NULL) && (cfg->type != CONFIG_END)) {
+            if (!strcmp(str, cfg->name))
+                return (config_get_int((char *) dev->name, str, cfg->default_int));
 
-        cfg++;
+            cfg++;
+        }
     }
-
     return 0;
 }
 
@@ -830,9 +846,8 @@ machine_get_config_string(char *str)
     const char     *ret = "";
 
     if (dev != NULL) {
-        const device_config_t *cfg;
+        const device_config_t *cfg = dev->config;
 
-        cfg = dev->config;
         while ((cfg != NULL) && (cfg->type != CONFIG_END)) {
             if (!strcmp(str, cfg->name)) {
                 const char *s = config_get_string((char *) dev->name, str,

--- a/src/include/86box/device.h
+++ b/src/include/86box/device.h
@@ -137,8 +137,8 @@ typedef struct device_config_spinner_t {
 typedef struct device_config_bios_t {
     const char *name;
     const char *internal_name;
-    int         bios_type;
-    int         files_no;
+    uint8_t     bios_type;
+    uint8_t     files_no;
     uint32_t    local;
     uint32_t    size;
     void       *dev1;
@@ -211,6 +211,11 @@ extern void  device_speed_changed(void);
 extern void  device_force_redraw(void);
 extern void  device_get_name(const device_t *dev, int bus, char *name);
 extern int   device_has_config(const device_t *dev);
+
+extern uint8_t     device_get_bios_type(const device_t *dev, const char *internal_name);
+extern uint8_t     device_get_bios_num_files(const device_t *dev, const char *internal_name);
+extern uint32_t    device_get_bios_local(const device_t *dev, const char *internal_name);
+extern uint32_t    device_get_bios_file_size(const device_t *dev, const char *internal_name);
 extern const char *device_get_bios_file(const device_t *dev, const char *internal_name, int file_no);
 
 extern int device_is_valid(const device_t *, int mch);

--- a/src/include/86box/device.h
+++ b/src/include/86box/device.h
@@ -141,8 +141,7 @@ typedef struct device_config_bios_t {
     uint8_t     files_no;
     uint32_t    local;
     uint32_t    size;
-    void       *dev1;
-    void       *dev2;
+    void       *dev[2];
     const char *files[9];
 } device_config_bios_t;
 

--- a/src/qt/qt_deviceconfig.cpp
+++ b/src/qt/qt_deviceconfig.cpp
@@ -242,8 +242,12 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                 int   currentIndex = -1;
 
                 q = 0;
-                for (auto *bios = config->bios; (bios != nullptr) && (bios->name != nullptr) &&
-                                                (strlen(bios->name) > 0); ++bios) {
+                for (auto *bios = config->bios; (bios != nullptr) &&
+                                                (bios->name != nullptr) &&
+                                                (bios->internal_name != nullptr) &&
+                                                (strlen(bios->name) > 0) &&
+                                                (strlen(bios->internal_name) > 0) &&
+                                                (bios->files_no > 0); ++bios) {
                     p = 0;
                     for (int d = 0; d < bios->files_no; d++)
                         p += !!rom_present(const_cast<char *>(bios->files[d]));

--- a/src/qt/qt_deviceconfig.cpp
+++ b/src/qt/qt_deviceconfig.cpp
@@ -123,7 +123,7 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
     if (config == NULL)
         return;
 
-    while (config->type != -1) {
+    while (config->type != CONFIG_END) {
         const int config_type = config->type & CONFIG_TYPE_MASK;
 
         /* Ignore options of the wrong class. */
@@ -376,7 +376,7 @@ DeviceConfig::ConfigureDevice(const _device_ *device, int instance, Settings *se
             return;
 
         config = device->config;
-        while (config->type != -1) {
+        while (config->type != CONFIG_END) {
             switch (config->type) {
                 default:
                     break;


### PR DESCRIPTION
Summary
=======
* [Fix a few potential segfaults found in device.c](https://github.com/86Box/86Box/commit/29b6cd484cfdd5e2477b33cfc0fe40f3e710aef1)
* [Extra CONFIG_BIOS Helpers](https://github.com/86Box/86Box/commit/a7d8f4a4e1e0808fae91ecc28149d443fc6b54d4)
* [Improve empty bios file entry support](https://github.com/86Box/86Box/commit/6740b62d23e8443d7a44ebaf2e88bbdf9e3c2f1b)
* [Make config_bios_t dev's into an array](https://github.com/86Box/86Box/commit/4504348fffc8fb3885347c124228fa25d19f6c86)
* [Two missing CONFIG_END's in qt_deviceconfig.cpp](https://github.com/86Box/86Box/commit/097ea4abf2d6220b2951be2996e72e9c528d2d34)

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
