### PR TITLE
Restore older GLSL version code

### DIFF
--- a/src/qt/qt_openglrenderer.cpp
+++ b/src/qt/qt_openglrenderer.cpp
@@ -34,6 +34,7 @@ extern MainWindow* main_window;
 #include <QEvent>
 #include <QApplication>
 #include <QString>
+#include <QByteArray>
 
 #include <QOpenGLContext>
 #include <QOpenGLFunctions>
@@ -171,30 +172,33 @@ OpenGLRenderer::create_program(struct shader_program *program)
 int
 OpenGLRenderer::compile_shader(GLenum shader_type, const char *prepend, const char *program, int *dst)
 {
-    const char *source[3];
+    QRegularExpression versionRegex("^\\s*(#version\\s+\\w+)", QRegularExpression::MultilineOption);
+    QString progSource = QString(program);
+    QByteArray  finalSource = nullptr;
+    const char *source[5];
     char        version[50];
     int         ver         = 0;
     char       *version_loc = (char *) strstr(program, "#version");
-    if (version_loc)
-        ver = (int) strtol(version_loc + 8, (char **) &program, 10);
-    else {
-        ver = glsl_version[0] * 100 + glsl_version[1] * 10;
-        if (ver == 300)
-            ver = 130;
-        else if (ver == 310)
-            ver = 140;
-        else if (ver == 320)
-            ver = 150;
+    if (version_loc) {
+        snprintf(version, 49, "%s\n", versionRegex.match(progSource).captured(1).toLatin1().data());
+        progSource.remove(versionRegex);
+    } else {
+        snprintf(version, 49, "%s\n", this->glslVersion.toLatin1().data());
     }
-    sprintf(version, "#version %d\n", ver);
-    source[0] = version;
-    source[1] = prepend ? prepend : "";
-    source[2] = program;
+    
+    /* Remove parameter lines. */
+    progSource.remove(QRegularExpression("^\\s*#pragma parameter.*?\\n", QRegularExpression::MultilineOption));
 
-    pclog("GLSL version %d\n", ver);
+    finalSource = progSource.toLatin1();
+
+    source[0] = version;
+    source[1] = "\n#extension GL_ARB_shading_language_420pack : enable\n";
+    source[2] = prepend ? prepend : "";
+    source[3] = "\n#line 1\n";
+    source[4] = finalSource.data();
 
     GLuint shader = glw.glCreateShader(shader_type);
-    glw.glShaderSource(shader, 3, source, NULL);
+    glw.glShaderSource(shader, 5, source, NULL);
     glw.glCompileShader(shader);
 
     GLint status = 0;
@@ -839,6 +843,15 @@ OpenGLRenderer::initialize()
         }
         pclog("Using OpenGL %s\n", glw.glGetString(GL_VERSION));
         pclog("Using Shading Language %s\n", glw.glGetString(GL_SHADING_LANGUAGE_VERSION));
+
+        glslVersion = reinterpret_cast<const char *>(glw.glGetString(GL_SHADING_LANGUAGE_VERSION));
+        glslVersion.truncate(4);
+        glslVersion.remove('.');
+        glslVersion.prepend("#version ");
+        if (QOpenGLContext::openGLModuleType() == QOpenGLContext::LibGLES)
+            glslVersion.append(" es");
+        else if (context->format().profile() == QSurfaceFormat::CoreProfile)
+            glslVersion.append(" core");
 
         glw.glGetIntegerv(GL_MAX_TEXTURE_SIZE, &max_texture_size);
         pclog("Max texture size: %dx%d\n", max_texture_size, max_texture_size);


### PR DESCRIPTION
Summary
=======
Restore GLSL version code from the earlier OpenGL renderer.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
