### PR TITLE
Qt: Make tooltip displays consistent

### DIFF
--- a/src/qt/qdarkstyle/dark/darkstyle.qss
+++ b/src/qt/qdarkstyle/dark/darkstyle.qss
@@ -130,16 +130,6 @@ QStatusBar::item {
   border: none;
 }
 
-QStatusBar QToolTip {
-  background-color: #666666;
-  border: 1px solid #272727;
-  color: #272727;
-  /* Remove padding, for fix combo box tooltip */
-  padding: 0px;
-  /* Reducing transparency to read better */
-  opacity: 230;
-}
-
 QStatusBar QLabel {
   /* Fixes Spyder #9120, #9121 */
   background: transparent;


### PR DESCRIPTION
Summary
=======
Make tooltip display on the status bar icons consistent with the ones on the toolbar.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
