### PR TITLE
OpenGL 3.x: Fix shader manager dialog crash when using multi-monitors

### DIFF
--- a/src/qt/qt_openglrenderer.cpp
+++ b/src/qt/qt_openglrenderer.cpp
@@ -809,6 +809,7 @@ OpenGLRenderer::OpenGLRenderer(QWidget *parent)
     source.setRect(0, 0, 100, 100);
     isInitialized = false;
     isFinalized = false;
+    context = nullptr;
 }
 
 OpenGLRenderer::~OpenGLRenderer() { finalize(); }
@@ -1088,7 +1089,7 @@ OpenGLRenderer::initialize()
 void
 OpenGLRenderer::finalize()
 {
-    if (isFinalized)
+    if (isFinalized || !context)
         return;
 
     context->makeCurrent(this);


### PR DESCRIPTION
Summary
=======
Fix shader manager dialog crash when using multi-monitors with the OpenGL 3.x renderer.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
