### PR TITLE
Microtouch: Properly restore system cursor if "Show Crosshair" is enabled

### DIFF
--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -270,7 +270,7 @@ RendererStack::leaveEvent(QEvent *event)
 {
     mousedata.mouse_tablet_in_proximity = 0;
 
-    if (mouse_input_mode == 1 && QApplication::overrideCursor()) {
+    if (mouse_input_mode >= 1 && QApplication::overrideCursor()) {
         while (QApplication::overrideCursor())
             QApplication::restoreOverrideCursor();
     }


### PR DESCRIPTION
Summary
=======
Properly restore system cursor if "Show Crosshair" is enabled with Microtouch touchscreen input active.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
