### PR TITLE
Add option to inhibit multimedia keys from host on Windows

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -213,6 +213,7 @@ int      hook_enabled                           = 1;              /* (C) Keyboar
 int      test_mode                              = 0;              /* (C) Test mode */
 char     uuid[MAX_UUID_LEN]                     = { '\0' };       /* (C) UUID or machine identifier */
 int      sound_muted                            = 0;              /* (C) Is sound muted? */
+int      inhibit_multimedia_keys;                                 /* (C) Inhibit multimedia keys on Windows. */
 
 int      other_ide_present = 0;                                   /* IDE controllers from non-IDE cards are
                                                                      present */

--- a/src/config.c
+++ b/src/config.c
@@ -131,6 +131,8 @@ load_general(void)
 
     video_filter_method = ini_section_get_int(cat, "video_filter_method", 1);
 
+    inhibit_multimedia_keys = ini_section_get_int(cat, "inhibit_multimedia_keys", 0);
+
     force_43 = !!ini_section_get_int(cat, "force_43", 0);
     scale    = ini_section_get_int(cat, "scale", 1);
     if (scale > 9)
@@ -1899,6 +1901,10 @@ save_general(void)
     char          buffer[512] = { 0 };
 
     const char *va_name;
+
+    ini_section_set_int(cat, "inhibit_multimedia_keys", inhibit_multimedia_keys);
+    if (inhibit_multimedia_keys == 0)
+        ini_section_delete_var(cat, "inhibit_multimedia_keys");
 
     ini_section_set_int(cat, "sound_muted", sound_muted);
     if (sound_muted == 0)

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -107,6 +107,7 @@ extern uint64_t instru_run_ms;
 #define window_y monitor_settings[0].mon_window_y
 #define window_w monitor_settings[0].mon_window_w
 #define window_h monitor_settings[0].mon_window_h
+extern int      inhibit_multimedia_keys;    /* (C) Inhibit multimedia keys on Windows. */
 extern int      window_remember;
 extern int      vid_resize;                 /* (C) allow resizing */
 extern int      invert_display;             /* (C) invert the display */

--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -2141,3 +2141,6 @@ msgstr ""
 
 msgid "TrueType fonts in the \"roms/printer/fonts\" directory are required for the emulation of the Generic ESC/P Dot-Matrix Printer."
 msgstr ""
+
+msgid "Inhibit multimedia keys on Windows"
+msgstr ""

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -226,7 +226,30 @@ emu_LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
            detection; rest can't be reliably detected. */
         DWORD vkCode = lpKdhs->vkCode;
         bool up = !!(lpKdhs->flags & LLKHF_UP);
-        ret = CallNextHookEx(NULL, nCode, wParam, lParam);;
+
+        if (inhibit_multimedia_keys
+            && (lpKdhs->vkCode == VK_MEDIA_PLAY_PAUSE
+            || lpKdhs->vkCode == VK_MEDIA_NEXT_TRACK
+            || lpKdhs->vkCode == VK_MEDIA_PREV_TRACK
+            || lpKdhs->vkCode == VK_VOLUME_DOWN
+            || lpKdhs->vkCode == VK_VOLUME_UP
+            || lpKdhs->vkCode == VK_VOLUME_MUTE
+            || lpKdhs->vkCode == VK_MEDIA_STOP
+            || lpKdhs->vkCode == VK_LAUNCH_MEDIA_SELECT
+            || lpKdhs->vkCode == VK_LAUNCH_MAIL
+            || lpKdhs->vkCode == VK_LAUNCH_APP1
+            || lpKdhs->vkCode == VK_LAUNCH_APP2
+            || lpKdhs->vkCode == VK_HELP
+            || lpKdhs->vkCode == VK_BROWSER_BACK
+            || lpKdhs->vkCode == VK_BROWSER_FORWARD
+            || lpKdhs->vkCode == VK_BROWSER_FAVORITES
+            || lpKdhs->vkCode == VK_BROWSER_HOME
+            || lpKdhs->vkCode == VK_BROWSER_REFRESH
+            || lpKdhs->vkCode == VK_BROWSER_SEARCH
+            || lpKdhs->vkCode == VK_BROWSER_STOP))
+            ret = TRUE;
+        else
+            ret = CallNextHookEx(NULL, nCode, wParam, lParam);
 
         switch (vkCode)
         {
@@ -348,6 +371,27 @@ emu_LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
     else if ((lpKdhs->scanCode == 0x49) && bCtrlDown && !(lpKdhs->flags & LLKHF_UP))
         ret = TRUE;
     else if ((lpKdhs->scanCode >= 0x5b) && (lpKdhs->scanCode <= 0x5d) && (lpKdhs->flags & LLKHF_EXTENDED))
+        ret = TRUE;
+    else if (inhibit_multimedia_keys
+        && (lpKdhs->vkCode == VK_MEDIA_PLAY_PAUSE
+        || lpKdhs->vkCode == VK_MEDIA_NEXT_TRACK
+        || lpKdhs->vkCode == VK_MEDIA_PREV_TRACK
+        || lpKdhs->vkCode == VK_VOLUME_DOWN
+        || lpKdhs->vkCode == VK_VOLUME_UP
+        || lpKdhs->vkCode == VK_VOLUME_MUTE
+        || lpKdhs->vkCode == VK_MEDIA_STOP
+        || lpKdhs->vkCode == VK_LAUNCH_MEDIA_SELECT
+        || lpKdhs->vkCode == VK_LAUNCH_MAIL
+        || lpKdhs->vkCode == VK_LAUNCH_APP1
+        || lpKdhs->vkCode == VK_LAUNCH_APP2
+        || lpKdhs->vkCode == VK_HELP
+        || lpKdhs->vkCode == VK_BROWSER_BACK
+        || lpKdhs->vkCode == VK_BROWSER_FORWARD
+        || lpKdhs->vkCode == VK_BROWSER_FAVORITES
+        || lpKdhs->vkCode == VK_BROWSER_HOME
+        || lpKdhs->vkCode == VK_BROWSER_REFRESH
+        || lpKdhs->vkCode == VK_BROWSER_SEARCH
+        || lpKdhs->vkCode == VK_BROWSER_STOP))
         ret = TRUE;
     else
         ret = CallNextHookEx(NULL, nCode, wParam, lParam);

--- a/src/qt/qt_progsettings.cpp
+++ b/src/qt/qt_progsettings.cpp
@@ -115,14 +115,19 @@ ProgSettings::ProgSettings(QWidget *parent)
     mouseSensitivity = mouse_sensitivity;
     ui->horizontalSlider->setValue(mouseSensitivity * 100.);
     ui->openDirUsrPath->setChecked(open_dir_usr_path > 0);
+    ui->checkBoxMultimediaKeys->setChecked(inhibit_multimedia_keys);
+#ifndef Q_OS_WINDOWS
+    ui->checkBoxMultimediaKeys->setHidden(true);
+#endif
 }
 
 void
 ProgSettings::accept()
 {
     strcpy(icon_set, ui->comboBox->currentData().toString().toUtf8().data());
-    lang_id           = ui->comboBoxLanguage->currentData().toUInt();
-    open_dir_usr_path = ui->openDirUsrPath->isChecked() ? 1 : 0;
+    lang_id                 = ui->comboBoxLanguage->currentData().toUInt();
+    open_dir_usr_path       = ui->openDirUsrPath->isChecked() ? 1 : 0;
+    inhibit_multimedia_keys = ui->checkBoxMultimediaKeys->isChecked();
 
     loadTranslators(QCoreApplication::instance());
     reloadStrings();

--- a/src/qt/qt_progsettings.ui
+++ b/src/qt/qt_progsettings.ui
@@ -27,8 +27,122 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <property name="sizeConstraint">
-    <enum>QLayout::SetFixedSize</enum>
+    <enum>QLayout::SizeConstraint::SetFixedSize</enum>
    </property>
+   <item row="9" column="0">
+    <widget class="QCheckBox" name="openDirUsrPath">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Select media images from program working directory</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <spacer name="horizontalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="5" column="0">
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QComboBox" name="comboBoxLanguage">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
+     <item>
+      <property name="text">
+       <string>(System Default)</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QPushButton" name="pushButtonLanguage">
+     <property name="text">
+      <string>Default</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="13" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Icon set:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Language:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="3">
+    <widget class="QSlider" name="horizontalSlider">
+     <property name="minimum">
+      <number>10</number>
+     </property>
+     <property name="maximum">
+      <number>200</number>
+     </property>
+     <property name="singleStep">
+      <number>10</number>
+     </property>
+     <property name="pageStep">
+      <number>20</number>
+     </property>
+     <property name="value">
+      <number>100</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="0" colspan="2">
     <widget class="QComboBox" name="comboBox">
      <property name="editable">
@@ -51,86 +165,8 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Icon set:</string>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="1">
     <widget class="QPushButton" name="pushButton">
-     <property name="text">
-      <string>Default</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0">
-    <spacer name="horizontalSpacer_3">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="12" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="3">
-    <widget class="QSlider" name="horizontalSlider">
-     <property name="minimum">
-      <number>10</number>
-     </property>
-     <property name="maximum">
-      <number>200</number>
-     </property>
-     <property name="singleStep">
-      <number>10</number>
-     </property>
-     <property name="pageStep">
-      <number>20</number>
-     </property>
-     <property name="value">
-      <number>100</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QComboBox" name="comboBoxLanguage">
-     <property name="maxVisibleItems">
-      <number>30</number>
-     </property>
-     <item>
-      <property name="text">
-       <string>(System Default)</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Language:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QPushButton" name="pushButtonLanguage">
      <property name="text">
       <string>Default</string>
      </property>
@@ -143,39 +179,10 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
-    <spacer name="horizontalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="2" column="0">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="9" column="0">
-    <widget class="QCheckBox" name="openDirUsrPath">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
+   <item row="10" column="0">
+    <widget class="QCheckBox" name="checkBoxMultimediaKeys">
      <property name="text">
-      <string>Select media images from program working directory</string>
+      <string>Inhibit multimedia keys on Windows</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Summary
=======
Add an option to inhibit multimedia keys from host on Windows.

It will be completely hidden on non-Windows platforms.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
