### PR TITLE
Attempt fixing OpenGL 3.x screenshot

### DIFF
--- a/src/qt/qt_openglrenderer.cpp
+++ b/src/qt/qt_openglrenderer.cpp
@@ -1668,6 +1668,9 @@ OpenGLRenderer::render()
         unsigned char *rgba = (unsigned char *)calloc(1, width * height * 4);
         
         glw.glFinish();
+        glw.glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        glw.glReadBuffer(GL_BACK);
+        glw.glFinish();
         glw.glReadPixels(window_rect.x, window_rect.y, width, height, GL_RGBA, GL_UNSIGNED_BYTE, rgba);
 
         QImage image(rgba, width, height, QImage::Format_RGBA8888);


### PR DESCRIPTION
Summary
=======
Attempt to fix OpenGL 3.x screenshot when using default shader.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
