### PR TITLE
OpenGL: Always use an alpha value of 1.0 for drawing scene to texture

### DIFF
--- a/src/qt/qt_openglrenderer.cpp
+++ b/src/qt/qt_openglrenderer.cpp
@@ -107,6 +107,7 @@ const char* fragment_shader_default_tex_src =
         "void main()\n"
         "{\n"
         "       color = texture(Texture, texCoord);\n"
+        "       color.a = 1.0;\n"
         "}\n";
 
 const char* vertex_shader_default_color_src =
@@ -141,6 +142,7 @@ const char* fragment_shader_default_color_src =
         "void main()\n"
         "{\n"
         "       outColor = color;\n"
+        "       outColor.a = 1.0;\n"
         "}\n";
 
 static inline int
@@ -1667,9 +1669,6 @@ OpenGLRenderer::render()
 
         unsigned char *rgba = (unsigned char *)calloc(1, width * height * 4);
         
-        glw.glFinish();
-        glw.glBindFramebuffer(GL_FRAMEBUFFER, 0);
-        glw.glReadBuffer(GL_BACK);
         glw.glFinish();
         glw.glReadPixels(window_rect.x, window_rect.y, width, height, GL_RGBA, GL_UNSIGNED_BYTE, rgba);
 


### PR DESCRIPTION
Summary
=======
Always use an alpha value of 1.0 for drawing scene to texture

Fixes invisible screenshots and blank screens on certain systems

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
