### PR TITLE
Readd XT and AT floppy controllers

### DIFF
--- a/src/floppy/fdc.c
+++ b/src/floppy/fdc.c
@@ -105,6 +105,8 @@ static fdc_cards_t fdc_cards[] = {
     // clang-format off
     { &device_none               },
     { &device_internal           },
+    { &fdc_xt_device             },
+    { &fdc_at_device             },
     { &fdc_b215_device           },
     { &fdc_pii151b_device        },
     { &fdc_pii158b_device        },


### PR DESCRIPTION
Summary
=======
The title says at all.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
They are removed for a year by a [commit](https://github.com/86Box/86Box/commit/abb066f6ef2efa9c83daad8ec50bcfb1fbcc29d8).
