### PR TITLE
Fixes for broken translation

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -1754,7 +1754,7 @@ MainWindow::on_actionAbout_86Box_triggered()
     versioninfo.append(QString(" [%1, %2]").arg(QSysInfo::buildCpuArchitecture(), tr(DYNAREC_STR)));
     msgBox.setText(QString("<b>%3%1%2</b>").arg(EMU_VERSION_FULL, versioninfo, tr("86Box v")));
     msgBox.setInformativeText(tr("An emulator of old computers\n\nAuthors: Miran Grča (OBattler), RichardG867, Jasmine Iwanek, TC1995, coldbrewed, Teemu Korhonen (Manaatti), Joakim L. Gilje, Adrien Moulin (elyosh), Daniel Balsom (gloriouscow), Cacodemon345, Fred N. van Kempen (waltje), Tiseno100, reenigne, and others.\n\nWith previous core contributions from Sarah Walker, leilei, JohnElliott, greatpsycho, and others.\n\nReleased under the GNU General Public License version 2 or later. See LICENSE for more information."));
-    msgBox.setWindowTitle("About 86Box");
+    msgBox.setWindowTitle(tr("About 86Box"));
     const auto closeButton = msgBox.addButton("OK", QMessageBox::ButtonRole::AcceptRole);
     msgBox.setEscapeButton(closeButton);
     const auto webSiteButton = msgBox.addButton(EMU_SITE, QMessageBox::ButtonRole::HelpRole);

--- a/src/sound/snd_audiopci.c
+++ b/src/sound/snd_audiopci.c
@@ -2742,7 +2742,7 @@ static const device_config_t es1370_config[] = {
     // clang-format off
     {
         .name           = "receive_input",
-        .description    = "Receive input (MIDI)",
+        .description    = "Receive MIDI input",
         .type           = CONFIG_BINARY,
         .default_string = NULL,
         .default_int    = 1,


### PR DESCRIPTION
Summary
=======
1. Fixes broken translation of "About 86Box"
2. Fixes broken translation of "Receive MIDI Input" for Ensoniq AudioPCI (ES1370)

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
