### PR TITLE
Make renderer options item enabled/disabled instead

### DIFF
--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -37,7 +37,7 @@ msgid "&Hide status bar"
 msgstr "&Masquer la barre de status"
 
 msgid "Hide &toolbar"
-msgstr "Hide &toolbar"
+msgstr "Masquer la &barre d'outils"
 
 msgid "&Resizeable window"
 msgstr "Fenètre &Retaillable"

--- a/src/qt/qt.c
+++ b/src/qt/qt.c
@@ -54,8 +54,6 @@ plat_vidapi(const char *api)
         return 4;
     } else if (!strcasecmp(api, "vnc")) {
         return 5;
-    } else if (!strcasecmp(api, "qt_opengl3_pcem")) {
-        return 6;
     }
 
     return 0;
@@ -84,9 +82,6 @@ plat_vidapi_name(int api)
             break;
         case 5:
             name = "vnc";
-            break;
-        case 6:
-            name = "qt_opengl3_pcem";
             break;
         default:
             fatal("Unknown renderer: %i\n", api);

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -454,9 +454,6 @@ MainWindow::MainWindow(QWidget *parent)
                     endblit();
                 }
 #endif
-            case 6:
-                newVidApi = RendererStack::Renderer::OpenGL3PCem;
-                break;
         }
         ui->stackedWidget->switchRenderer(newVidApi);
         if (!show_second_monitors)
@@ -468,7 +465,7 @@ MainWindow::MainWindow(QWidget *parent)
     });
 
     connect(ui->stackedWidget, &RendererStack::rendererChanged, [this]() {
-        ui->actionRenderer_options->setVisible(ui->stackedWidget->hasOptions());
+        ui->actionRenderer_options->setEnabled(ui->stackedWidget->hasOptions());
     });
 
     /* Trigger initial renderer switch */

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -339,26 +339,6 @@ RendererStack::createRenderer(Renderer renderer)
                 current.reset(this->createWindowContainer(hw, this));
                 break;
             }
-        case Renderer::OpenGL3PCem:
-            {
-                this->createWinId();
-                auto hw        = new OpenGLRenderer(this);
-                rendererWindow = hw;
-                connect(this, &RendererStack::blitToRenderer, hw, &OpenGLRenderer::onBlit, Qt::QueuedConnection);
-                connect(hw, &OpenGLRenderer::initialized, [=]() {
-                    /* Buffers are available only after initialization. */
-                    imagebufs = rendererWindow->getBuffers();
-                    endblit();
-                    emit rendererChanged();
-                });
-                connect(hw, &OpenGLRenderer::errorInitializing, [=]() {
-                    /* Renderer not could initialize, fallback to software. */
-                    imagebufs = {};
-                    QTimer::singleShot(0, this, [this]() { switchRenderer(Renderer::Software); });
-                });
-                current.reset(this->createWindowContainer(hw, this));
-                break;
-            }
         case Renderer::OpenGL3:
             {
                 this->createWinId();
@@ -431,7 +411,7 @@ RendererStack::createRenderer(Renderer renderer)
 
     currentBuf = 0;
 
-    if (renderer != Renderer::OpenGL3 && renderer != Renderer::Vulkan && renderer != Renderer::OpenGL3PCem) {
+    if (renderer != Renderer::OpenGL3 && renderer != Renderer::Vulkan) {
         imagebufs = rendererWindow->getBuffers();
         endblit();
         emit rendererChanged();

--- a/src/qt/qt_rendererstack.hpp
+++ b/src/qt/qt_rendererstack.hpp
@@ -61,7 +61,6 @@ public:
         OpenGLES,
         OpenGL3,
         Vulkan,
-        OpenGL3PCem = 6,
         None = -1
     };
     void switchRenderer(Renderer renderer);


### PR DESCRIPTION
Summary
=======
Make renderer options item enabled/disabled instead of hidden/visible.

Also a missed French translation and some cleanups.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
