### PR TITLE
Don't use startblit/endblit for renderer switches

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -2025,8 +2025,8 @@ MainWindow::on_actionRenderer_options_triggered()
             ui->stackedWidget->switchRenderer(static_cast<RendererStack::Renderer>(vid_api));
             if (show_second_monitors) {
                 for (int i = 1; i < MONITORS_NUM; i++) {
-                    if (renderers[i] && renderers[i]->reloadRendererOption() && renderers[i]->hasOptions()) {
-                        ui->stackedWidget->switchRenderer(static_cast<RendererStack::Renderer>(vid_api));
+                    if (renderers[i]) {
+                        renderers[i]->switchRenderer(static_cast<RendererStack::Renderer>(vid_api));
                     }
                 }
             }

--- a/src/qt/qt_rendererstack.hpp
+++ b/src/qt/qt_rendererstack.hpp
@@ -113,6 +113,7 @@ private:
     std::unique_ptr<QWidget> current;
 
     std::atomic_bool rendererTakesScreenshots;
+    std::atomic_bool switchInProgress{false};
 };
 
 #endif // QT_RENDERERCONTAINER_HPP


### PR DESCRIPTION
Summary
=======
Don't use starblit/endblit for renderer switches.

Also switch renderers properly for secondary monitors if shader settings were altered.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
