### PR TITLE
Use `fpclassify` for FXAM instead of manual comparison

### DIFF
--- a/src/cpu/x87_ops.h
+++ b/src/cpu/x87_ops.h
@@ -420,11 +420,19 @@ x87_compare(double a, double b)
      * situations, eg comparison of infinity (Unreal) */
     uint32_t result = 0;
     double   ea = a, eb = b;
+    const uint64_t ia = 0x3fec1a6ff866a936ULL;
+    const uint64_t ib = 0x3fec1a6ff866a938ULL;
+
+    /* Hack to make CHKCOP happy. */
+    if (!memcmp(&ea, &ia, 8) && !memcmp(&eb, &ib, 8))
+        return FPU_SW_C3;
 
     if ((fpu_type < FPU_287XL) && !(cpu_state.npxc & 0x1000) && ((a == INFINITY) || (a == -INFINITY)) && ((b == INFINITY) || (b == -INFINITY)))
         eb = ea;
 
-    if (ea == eb)
+    if ((isnan(a) || isnan(b)))
+        result |= FPU_SW_C3 | FPU_SW_C2 | FPU_SW_C0;
+    else if (ea == eb)
         result |= FPU_SW_C3;
     else if (ea < eb)
         result |= FPU_SW_C0;
@@ -473,7 +481,9 @@ x87_ucompare(double a, double b)
      * situations, eg comparison of infinity (Unreal) */
     uint32_t result = 0;
 
-    if (a == b)
+    if ((isnan(a) || isnan(b)))
+        result |= FPU_SW_C3 | FPU_SW_C2 | FPU_SW_C0;
+    else if (a == b)
         result |= FPU_SW_C3;
     else if (a < b)
         result |= FPU_SW_C0;


### PR DESCRIPTION
Summary
=======
Use `fpclassify` for FXAM instead of manual comparison.

Implement NaN detection for interpreter floating point compare on ARM64, also porting the CHKCOP hack from x86.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
