### PR TITLE
Qt: Add special handling for real touchscreen devices

### DIFF
--- a/src/qt/qt_renderercommon.cpp
+++ b/src/qt/qt_renderercommon.cpp
@@ -144,6 +144,10 @@ RendererCommon::eventDelegate(QEvent *event, bool &result)
         case QEvent::MouseButtonPress:
         case QEvent::MouseMove:
         case QEvent::MouseButtonRelease:
+        case QEvent::TouchBegin:
+        case QEvent::TouchEnd:
+        case QEvent::TouchCancel:
+        case QEvent::TouchUpdate:
         case QEvent::Wheel:
         case QEvent::Enter:
         case QEvent::Leave:

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -38,6 +38,7 @@
 
 #include <QScreen>
 #include <QMessageBox>
+#include <QTouchEvent>
 
 #ifdef __APPLE__
 #    include <CoreGraphics/CoreGraphics.h>
@@ -63,6 +64,7 @@ RendererStack::RendererStack(QWidget *parent, int monitor_index)
     : QStackedWidget(parent)
     , ui(new Ui::RendererStack)
 {
+    setAttribute(Qt::WA_AcceptTouchEvents, true);
     rendererTakesScreenshots = false;
 #ifdef Q_OS_WINDOWS
     int raw = 1;
@@ -477,8 +479,8 @@ RendererStack::event(QEvent* event)
 
         if (m_monitor_index >= 1) {
             if (mouse_input_mode >= 1) {
-                mouse_x_abs       = (mouse_event->localPos().x()) / (long double)width();
-                mouse_y_abs       = (mouse_event->localPos().y()) / (long double)height();
+                mouse_x_abs       = (mouse_event->localPos().x()) / (double)width();
+                mouse_y_abs       = (mouse_event->localPos().y()) / (double)height();
                 if (!mouse_tablet_in_proximity)
                     mouse_tablet_in_proximity = mousedata.mouse_tablet_in_proximity;
             }
@@ -487,15 +489,66 @@ RendererStack::event(QEvent* event)
 
 #ifdef Q_OS_WINDOWS
         if (mouse_input_mode == 0) {
-            mouse_x_abs           = (mouse_event->localPos().x()) / (long double)width();
-            mouse_y_abs           = (mouse_event->localPos().y()) / (long double)height();
+            mouse_x_abs           = (mouse_event->localPos().x()) / (double)width();
+            mouse_y_abs           = (mouse_event->localPos().y()) / (double)height();
             return QStackedWidget::event(event);
         }
 #endif
 
-        mouse_x_abs               = (mouse_event->localPos().x()) / (long double)width();
-        mouse_y_abs               = (mouse_event->localPos().y()) / (long double)height();
+        mouse_x_abs               = (mouse_event->localPos().x()) / (double)width();
+        mouse_y_abs               = (mouse_event->localPos().y()) / (double)height();
         mouse_tablet_in_proximity = mousedata.mouse_tablet_in_proximity;
+    } else switch (event->type()) {
+        case QEvent::TouchBegin:
+        case QEvent::TouchUpdate:
+        {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+            QTouchEvent* touchevent = (QTouchEvent*)event;
+            if (mouse_input_mode == 0) break;
+            if (touchevent->touchPoints().count()) {
+                mouse_x_abs = (touchevent->touchPoints()[0].pos().x()) / (double)width();
+                mouse_y_abs = (touchevent->touchPoints()[0].pos().y()) / (double)height();
+            }
+            mouse_set_buttons_ex(mouse_get_buttons_ex() | 1);
+            touchevent->accept();
+            return true;
+#else
+            QTouchEvent* touchevent = (QTouchEvent*)event;
+            if (mouse_input_mode == 0) break;
+            if (touchevent->pointCount()) {
+                mouse_x_abs = (touchevent->point(0).position().x()) / (double)width();
+                mouse_y_abs = (touchevent->point(0).position().y()) / (double)height();
+            }
+            mouse_set_buttons_ex(mouse_get_buttons_ex() | 1);
+            touchevent->accept();
+            return true;
+#endif
+        }
+        case QEvent::TouchEnd:
+        case QEvent::TouchCancel:
+        {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+            QTouchEvent* touchevent = (QTouchEvent*)event;
+            if (mouse_input_mode == 0) break;
+            if (touchevent->touchPoints().count()) {
+                mouse_x_abs = (touchevent->touchPoints()[0].pos().x()) / (double)width();
+                mouse_y_abs = (touchevent->touchPoints()[0].pos().y()) / (double)height();
+            }
+            mouse_set_buttons_ex(mouse_get_buttons_ex() & ~1);
+            touchevent->accept();
+            return true;
+#else
+            QTouchEvent* touchevent = (QTouchEvent*)event;
+            if (mouse_input_mode == 0) break;
+            if (touchevent->pointCount()) {
+                mouse_x_abs = (touchevent->point(0).position().x()) / (double)width();
+                mouse_y_abs = (touchevent->point(0).position().y()) / (double)height();
+            }
+            mouse_set_buttons_ex(mouse_get_buttons_ex() & ~1);
+            touchevent->accept();
+            return true;
+#endif
+        }
     }
 
     return QStackedWidget::event(event);


### PR DESCRIPTION
Summary
=======
Add special handling on Qt UI for real touchscreen devices that will be used when 3M MicroTouch is used as emulated input device.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
