### PR TITLE
Add the Soyo SY-7SBB (SiS 600, Socket 370)

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -855,6 +855,7 @@ extern int machine_at_s1857_init(const machine_t *);
 extern int machine_at_p6bap_init(const machine_t *);
 extern int machine_at_p6bat_init(const machine_t *);
 extern int machine_at_prosignias31x_bx_init(const machine_t *);
+extern int machine_at_7sbb_init(const machine_t *);
 
 /* m_at_misc.c */
 extern int machine_at_vpc2007_init(const machine_t *);

--- a/src/machine/m_at_socket370.c
+++ b/src/machine/m_at_socket370.c
@@ -541,3 +541,31 @@ machine_at_6via90ap_init(const machine_t *model)
 
     return ret;
 }
+
+int
+machine_at_7sbb_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/7sbb/sbb12aa2.bin",
+                           0x000c0000, 262144, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_common_init_ex(model, 2);
+
+    pci_init(PCI_CONFIG_TYPE_1 | FLAG_TRC_CONTROLS_CPURST);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x01, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x0F, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x10, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x11, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x02, PCI_CARD_AGPBRIDGE,   0, 0, 0, 0);
+    device_add(&sis_5600_device);
+    device_add(&keyboard_ps2_ami_pci_device);
+    device_add(&it8661f_device);
+    device_add(&sst_flash_29ee020_device); /* assumed */
+
+    return ret;
+}

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -16227,6 +16227,48 @@ const machine_t machines[] = {
         .snd_device = &cmi8738_onboard_device,
         .net_device = NULL
     },
+    /* SiS (5)600 */
+    /* Has the SiS 600 chipset, which is a re-brand of the 5600, with
+       on-chip KBC. */
+    {
+        .name = "[SiS 600] Soyo SY-7SBB",
+        .internal_name = "7sbb",
+        .type = MACHINE_TYPE_SOCKET370,
+        .chipset = MACHINE_CHIPSET_SIS_5600,
+        .init = machine_at_7sbb_init,
+        .p1_handler = NULL,
+        .gpio_handler = NULL,
+        .available_flag = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu = {
+            .package = CPU_PKG_SOCKET370,
+            .block = CPU_BLOCK(CPU_CYRIX3S),
+            .min_bus = 60000000,
+            .max_bus = 100000000,
+            .min_voltage = 1800,
+            .max_voltage = 3500,
+            .min_multi = 1.5,
+            .max_multi = 8.0
+        },
+        .bus_flags = MACHINE_PS2_AGP | MACHINE_BUS_USB,
+        .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
+        .ram = {
+            .min = 8192,
+            .max = 1572864,
+            .step = 1024
+        },
+        .nvrmask = 255,
+        .kbc_device = NULL,
+        .kbc_p1 = 0xff,
+        .gpio = 0xffffffff,
+        .gpio_acpi = 0xffffffff,
+        .device = NULL,
+        .fdc_device = NULL,
+        .sio_device = NULL,
+        .vid_device = NULL,
+        .snd_device = NULL,
+        .net_device = NULL
+    },
 
     /* Miscellaneous/Fake/Hypervisor machines */
     /* Has a Winbond W83977F Super I/O chip with on-chip KBC with AMIKey-2 KBC


### PR DESCRIPTION
Summary
=======
Add the Soyo SY-7SBB motherboard with the SiS (5)600 chipset and PPGA Socket 370.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/306

References
==========
https://theretroweb.com/motherboards/s/soyo-sy-7sbb
https://theretroweb.com/motherboard/manual/m7sbb10-62fa38f2695a3949534707.pdf
