### PR TITLE
Pre-calculate `pow` table for FXTRACT instruction

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -32,6 +32,7 @@
 #include <wchar.h>
 #include <stdatomic.h>
 #include <unistd.h>
+#include <math.h>
 
 #ifndef _WIN32
 #    include <pwd.h>
@@ -232,6 +233,8 @@ int framecount;
 extern int CPUID;
 extern int output;
 int        atfullspeed;
+
+extern double exp_pow_table[0x800];
 
 char  exe_path[2048]; /* path (dir) of executable */
 char  usr_path[1024]; /* path (dir) of user data */
@@ -1085,6 +1088,11 @@ pc_init_modules(void)
     video_reset_close();
 
     machine_status_init();
+
+    for (c = 0; c <= 0x7ff; c++) {
+        int64_t exp = c - 1023; /* 1023 = BIAS64 */
+        exp_pow_table[c] = pow(2.0, (double) exp);
+    }
 
     if (do_nothing) {
         do_nothing = 0;

--- a/src/cpu/cpu.c
+++ b/src/cpu/cpu.c
@@ -287,6 +287,9 @@ uint8_t reg_30 = 0x00;
 uint8_t arr[24] = { 0 };
 uint8_t rcr[8] = { 0 };
 
+/* Table for FXTRACT. */
+double exp_pow_table[0x800];
+
 static int cyrix_addr;
 
 static void    cpu_write(uint16_t addr, uint8_t val, void *priv);

--- a/src/cpu/x87_ops.h
+++ b/src/cpu/x87_ops.h
@@ -36,6 +36,8 @@ extern void fpu_log(const char *fmt, ...);
 #    endif
 #endif
 
+extern double exp_pow_table[0x800];
+
 static int rounding_modes[4] = { FE_TONEAREST, FE_DOWNWARD, FE_UPWARD, FE_TOWARDZERO };
 
 #define ST(x)             cpu_state.ST[((cpu_state.TOP + (x)) & 7)]

--- a/src/cpu/x87_ops_misc.h
+++ b/src/cpu/x87_ops_misc.h
@@ -46,7 +46,7 @@ opFXTRACT(UNUSED(uint32_t fetchdat))
     test.eind.d = ST(0);
     exp80       = test.eind.ll & 0x7ff0000000000000LL;
     exp80final  = (exp80 >> 52) - BIAS64;
-    mant        = test.eind.d / (pow(2.0, (double) exp80final));
+    mant        = test.eind.d / exp_pow_table[exp80 >> 52];
     ST(0)       = (double) exp80final;
     FP_TAG_VALID;
     x87_push(mant);


### PR DESCRIPTION
Summary
=======
Pre-calculate `pow` table for FXTRACT instruction as an optimization.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
