### PR TITLE
Fix for NetBSD

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -263,3 +263,7 @@ else()
     add_compile_definitions(USE_SDL_UI)
     add_subdirectory(unix)
 endif()
+
+if(CMAKE_SYSTEM_NAME MATCHES "NetBSD")
+    add_custom_command(TARGET 86Box POST_BUILD COMMAND paxctl ARGS +m $<TARGET_FILE:86Box> COMMENT "Disable PaX MPROTECT")
+endif()

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -20,6 +20,11 @@
 #ifndef EMU_86BOX_H
 #define EMU_86BOX_H
 
+#ifdef __NetBSD__
+/* Doesn't compile on NetBSD without this include */
+#include <stdarg.h>
+#endif
+
 /* Configuration values. */
 #define GFXCARD_MAX  2
 #define SERIAL_MAX   7

--- a/src/include/86box/bswap.h
+++ b/src/include/86box/bswap.h
@@ -35,13 +35,12 @@
  *   USA.
  */
 
-#ifndef __NetBSD__
-
 #ifndef BSWAP_H
 #define BSWAP_H
 
 #include <stdint.h>
 
+#ifndef __NetBSD__
 #define bswap_16(x)					\
 	((uint16_t)((((x) & 0x00ffu) << 8) |		\
 		    (((x) & 0xff00u) >> 8)))
@@ -91,6 +90,7 @@ bswap64(uint64_t x)
     return bswap_16(x);
 #endif
 }
+#endif
 
 static __inline void
 bswap16s(uint16_t *s)
@@ -241,5 +241,3 @@ cpu_to_be32wu(uint32_t *p, uint32_t v)
 #undef be_bswaps
 
 #endif /*BSWAP_H*/
-
-#endif

--- a/src/include/86box/log.h
+++ b/src/include/86box/log.h
@@ -24,6 +24,11 @@
 extern "C" {
 #    endif
 
+#ifdef __NetBSD__
+/* Doesn't compile on NetBSD without this include */
+#include <stdarg.h>
+#endif
+
 #define LOG_SIZE_BUFFER                 1024            /* Log size buffer */
 #define LOG_SIZE_BUFFER_CYCLIC_LINES    32              /* Cyclic log size buffer (number of lines that should be cehcked) */
 #define LOG_MINIMUM_REPEAT_ORDER        4               /* Minimum repeat size */

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -836,7 +836,7 @@ plat_set_thread_name(void *thread, const char *name)
 #    if defined(Q_OS_DARWIN)
     pthread_setname_np(truncated);
 #    elif defined(Q_OS_NETBSD)
-    pthread_setname_np(thread ? *((pthread_t *) thread) : pthread_self(), truncated, "%s");
+    pthread_setname_np(thread ? *((pthread_t *) thread) : pthread_self(), truncated, (void*)"%s");
 #    elif defined(__HAIKU__)
     rename_thread(find_thread(NULL), truncated);
 #    elif defined(Q_OS_OPENBSD)

--- a/src/unix/unix_serial_passthrough.c
+++ b/src/unix/unix_serial_passthrough.c
@@ -26,6 +26,7 @@
 #endif
 #ifdef __NetBSD__
 #    define _NETBSD_VISIBLE 1
+#    define _NETBSD_SOURCE 1
 #endif
 #include <stdio.h>
 #include <fcntl.h>
@@ -149,8 +150,11 @@ plat_serpt_set_params(void *priv)
         BAUDRATE_RANGE(dev->baudrate, 9600, 19200, B9600);
         BAUDRATE_RANGE(dev->baudrate, 19200, 38400, B19200);
         BAUDRATE_RANGE(dev->baudrate, 38400, 57600, B38400);
+#ifndef __NetBSD__
+	/* nonexistent on NetBSD */
         BAUDRATE_RANGE(dev->baudrate, 57600, 115200, B57600);
         BAUDRATE_RANGE(dev->baudrate, 115200, 0xFFFFFFFF, B115200);
+#endif
 
         term_attr.c_cflag &= ~CSIZE;
         switch (dev->data_bits) {


### PR DESCRIPTION
Summary
=======
- Fixed stdarg.h-related issues
- Fixed bswap.h, moved macro position.
- Fixed pthread_setname_np, `arg` needs to be `void*`.
- Fixed baud rate stuffs. NetBSD does not have these baud rates.

Checklist
=========
* [x] I have discussed this with core contributors already

References
==========
https://man.netbsd.org/paxctl.8
https://man.netbsd.org/pthread_setname_np.3