### PR TITLE
IBM PS/2 Model 30-286 fixes

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -2756,7 +2756,7 @@ const machine_t machines[] = {
             .max_multi = 0
         },
         .bus_flags = MACHINE_PS2,
-        .flags = MACHINE_XTA | MACHINE_VIDEO,
+        .flags = MACHINE_XTA | MACHINE_VIDEO_FIXED,
         .ram = {
             .min = 512,
             .max = 16384,

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -2756,11 +2756,11 @@ const machine_t machines[] = {
             .max_multi = 0
         },
         .bus_flags = MACHINE_PS2,
-        .flags = MACHINE_XTA | MACHINE_VIDEO_FIXED,
+        .flags = MACHINE_XTA | MACHINE_VIDEO,
         .ram = {
-            .min = 1024,
+            .min = 512,
             .max = 16384,
-            .step = 1024
+            .step = 512
         },
         .nvrmask = 127,
         .kbc_device = NULL,


### PR DESCRIPTION
The real machine supports 512 KB RAM configurations and ISA video cards, however in my testing I could not use a ISA VGA card reliably, possible due to BIOS bug or a 86Box bug that makes the onboard video still active even when ISA VGA is added

Summary
=======
Change the minimum RAM to 512 KB in the IBM PS/2 Model 30-286 machine, to reflect the real machine.

Checklist
=========
* [ ] I have discussed this with core contributors already

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
https://en.wikipedia.org/wiki/IBM_PS/2_Model_30#Model_30_286
https://www.youtube.com/watch?v=T3XIFXxIxlM (a video of this machine booting with a Cirrus Logic ISA SVGA card)