### PR TITLE
net_modem: fix response to unrecognized will/wont telnet commands

### DIFF
--- a/src/network/net_modem.c
+++ b/src/network/net_modem.c
@@ -1177,9 +1177,15 @@ modem_process_telnet(modem_t *modem, uint8_t *data, uint32_t size)
         uint8_t c = data[i];
         if (modem->telClient.inIAC) {
             if (modem->telClient.recCommand) {
+                modem_log("modem_process_telnet: received command %i, option %i\n", modem->telClient.command, c);
+
                 if ((c != 0) && (c != 1) && (c != 3)) {
-                    if (modem->telClient.command > 250) {
-                        /* Reject anything we don't recognize */
+                    /* Reject anything we don't recognize */
+                    if (modem->telClient.command == 251 || modem->telClient.command == 252) {
+                        modem_data_mode_process_byte(modem, 0xff);
+                        modem_data_mode_process_byte(modem, 254);
+                        modem_data_mode_process_byte(modem, c); /* Don't do crap! */
+                    } else if (modem->telClient.command == 253 || modem->telClient.command == 254) {
                         modem_data_mode_process_byte(modem, 0xff);
                         modem_data_mode_process_byte(modem, 252);
                         modem_data_mode_process_byte(modem, c); /* We won't do crap! */


### PR DESCRIPTION
Summary
=======
Sends `DONT` instead of `WONT` in response to `WILL`/`WONT` for unrecognized options. This fixes connections to GNU telnetd, which expects a proper reply to `WILL ENCRYPT`

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
