### PR TITLE
audio(4) support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,9 @@ else()
 endif()
 
 if((CMAKE_SYSTEM_NAME STREQUAL "NetBSD") OR (CMAKE_SYSTEM_NAME STREQUAL "OpenBSD"))
-    set(AUDIO4 ON)
+    option(AUDIO4 "Use audio(4) as sound backend" ON)
+else()
+    set(AUDIO4 OFF)
 endif()
 
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,10 @@ else()
     option(NEW_DYNAREC "Use the PCem v15 (\"new\") dynamic recompiler" OFF)
 endif()
 
+if((CMAKE_SYSTEM_NAME STREQUAL "NetBSD") OR (CMAKE_SYSTEM_NAME STREQUAL "OpenBSD"))
+    set(AUDIO4 ON)
+endif()
+
 if(WIN32)
     set(QT ON)
     option(CPPTHREADS "C++11 threads" OFF)

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -20,8 +20,8 @@
 #ifndef EMU_86BOX_H
 #define EMU_86BOX_H
 
-#ifdef __NetBSD__
-/* Doesn't compile on NetBSD without this include */
+#if defined(__NetBSD__) || defined(__OpenBSD__)
+/* Doesn't compile on NetBSD/OpenBSD without this include */
 #include <stdarg.h>
 #endif
 

--- a/src/sound/CMakeLists.txt
+++ b/src/sound/CMakeLists.txt
@@ -53,7 +53,10 @@ add_library(snd OBJECT
     snd_opl_esfm.c
 )
 
-if(OPENAL)
+# TODO: Should platform-specific audio driver be here?
+if(AUDIO4)
+    target_sources(snd PRIVATE audio4.c)
+elseif(OPENAL)
     if(VCPKG_TOOLCHAIN)
         find_package(OpenAL CONFIG REQUIRED)
     elseif(MINGW)

--- a/src/sound/audio4.c
+++ b/src/sound/audio4.c
@@ -112,11 +112,19 @@ void givealbuffer_common(const void *buf, const uint8_t src, const int size){
 		memcpy(conv, buf, conv_size);
 	}
 
+#ifdef USE_NEW_API
+	output_size = (double)conv_size * info[src].rate / freq;
+#else
 	output_size = (double)conv_size * info[src].play.sample_rate / freq;
+#endif
 	output = malloc(output_size);
 	
 	for(i = 0; i < output_size / sizeof(int16_t) / 2; i++){
+#ifdef USE_NEW_API
+		int ind = i * freq / info[src].rate * 2;
+#else
 		int ind = i * freq / info[src].play.sample_rate * 2;
+#endif
 		output[i * 2 + 0] = conv[ind + 0] * gain;
 		output[i * 2 + 1] = conv[ind + 1] * gain;
 	}

--- a/src/sound/audio4.c
+++ b/src/sound/audio4.c
@@ -126,7 +126,6 @@ void givealbuffer_common(const void *buf, const uint8_t src, const int size){
 	
 	for(i = 0; i < output_size / sizeof(int16_t) / 2; i++){
 		int ind = i * freq / target_rate * 2;
-		ind -= ind % 2;
 		output[i * 2 + 0] = conv[ind + 0] * gain;
 		output[i * 2 + 1] = conv[ind + 1] * gain;
 	}

--- a/src/sound/audio4.c
+++ b/src/sound/audio4.c
@@ -7,7 +7,6 @@
  *           This file is part of the 86Box distribution.
  *
  *           Interface to audio(4) for NetBSD/OpenBSD.
- *           TODO: Test on OpenBSD
  *
  *
  * Authors:  Nishi

--- a/src/sound/audio4.c
+++ b/src/sound/audio4.c
@@ -6,8 +6,8 @@
  *
  *           This file is part of the 86Box distribution.
  *
- *           Interface to audio(4).
- *
+ *           Interface to audio(4) for NetBSD/OpenBSD.
+ *           TODO: Test on OpenBSD
  *
  *
  * Authors:  Nishi
@@ -15,37 +15,121 @@
  *           Copyright 2025 Nishi.
  */
 #include <stdint.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
 
+#include <sys/audioio.h>
+#include <sys/param.h>
+
+#include <86box/86box.h>
 #include <86box/sound.h>
+#include <86box/plat_unused.h>
 
-#define FREQ   SOUND_FREQ
-#define BUFLEN SOUNDBUFLEN
+#define I_NORMAL 0
+#define I_MUSIC 1
+#define I_WT 2
+#define I_CD 3
+#define I_MIDI 4
 
-static int midi_freq = 44100;
-static int midi_buf_size = 4410;
+static int audio[5] = {-1, -1, -1, -1, -1};
+static audio_offset_t offset[5];
+static audio_info_t info[5];
+static int freqs[5] = {SOUND_FREQ, MUSIC_FREQ, WT_FREQ, CD_FREQ, 0};
 
 void closeal(void){
+	int i;
+	for(i = 0; i < sizeof(audio) / sizeof(audio[0]); i++){
+		if(audio[i] != -1){
+			close(audio[i]);
+		}
+		audio[i] = -1;
+	}
 }
 
 void inital(void){
+	int i;
+	for(i = 0; i < sizeof(audio) / sizeof(audio[0]); i++){
+		audio[i] = open("/dev/audio", O_WRONLY);
+		if(audio[i] != -1){
+			AUDIO_INITINFO(&info[i]);
+#if defined(__NetBSD__) && (__NetBSD_Version__ >= 900000000)
+			ioctl(audio[i], AUDIO_GETFORMAT, &info[i]);
+#else
+			ioctl(audio[i], AUDIO_GETINFO, &info[i]);
+#endif
+			info[i].play.channels = 2;
+			info[i].play.precision = 16;
+			info[i].play.encoding = AUDIO_ENCODING_SLINEAR;
+			info[i].hiwat = 5;
+			info[i].lowat = 3;
+			ioctl(audio[i], AUDIO_SETINFO, &info[i]);
+		}
+	}
+}
+
+void givealbuffer_common(const void *buf, const uint8_t src, const int size){
+	const int freq = freqs[src];
+	int16_t* output;
+	int output_size;
+	int16_t* conv;
+	int conv_size;
+	int i;
+        double gain;
+	if(audio[src] == -1) return;
+
+	gain = sound_muted ? 0.0 : pow(10.0, (double) sound_gain / 20.0);
+
+	if(sound_is_float){
+		float* input = (float*)buf;
+		conv_size = sizeof(int16_t) * size;
+		conv = malloc(conv_size);
+		for(i = 0; i < conv_size / sizeof(int16_t); i++){
+			conv[i] = 32767 * input[i];
+		}
+	}else{
+		conv_size = size * sizeof(int16_t);
+		conv = malloc(conv_size);
+		memcpy(conv, buf, conv_size);
+	}
+
+	output_size = (double)conv_size * info[src].play.sample_rate / freq;
+	output = malloc(output_size);
+	
+	for(i = 0; i < output_size / sizeof(int16_t) / 2; i++){
+		int ind = i * freq / info[src].play.sample_rate * 2;
+		output[i * 2 + 0] = conv[ind + 0] * gain;
+		output[i * 2 + 1] = conv[ind + 1] * gain;
+	}
+
+	write(audio[src], output, output_size);
+
+	free(conv);
+	free(output);
 }
 
 void givealbuffer(const void *buf){
+	givealbuffer_common(buf, I_NORMAL, SOUNDBUFLEN << 1);
 }
 
 void givealbuffer_music(const void *buf){
+	givealbuffer_common(buf, I_MUSIC, MUSICBUFLEN << 1);
 }
 
 void givealbuffer_wt(const void *buf){
+	givealbuffer_common(buf, I_WT, WTBUFLEN << 1);
 }
 
 void givealbuffer_cd(const void *buf){
+	givealbuffer_common(buf, I_CD, CD_BUFLEN << 1);
 }
-
 void givealbuffer_midi(const void *buf, const uint32_t size){
+	givealbuffer_common(buf, I_MIDI, (int) size);
 }
 	
-void al_set_midi(const int freq, const int buf_size){
-    midi_freq     = freq;
-    midi_buf_size = buf_size;
+void al_set_midi(const int freq, UNUSED(const int buf_size)){
+	freqs[I_MIDI] = freq;
 }

--- a/src/sound/audio4.c
+++ b/src/sound/audio4.c
@@ -62,7 +62,7 @@ void inital(void){
 	int i;
 	for(i = 0; i < sizeof(audio) / sizeof(audio[0]); i++){
 		audio[i] = open("/dev/audio", O_WRONLY);
-		if(audio[i] != -1) audio[i] = open("/dev/audio0", O_WRONLY);
+		if(audio[i] == -1) audio[i] = open("/dev/audio0", O_WRONLY);
 		if(audio[i] != -1){
 #ifdef USE_NEW_API
 			AUDIO_INITPAR(&info[i]);

--- a/src/sound/audio4.c
+++ b/src/sound/audio4.c
@@ -96,6 +96,7 @@ void givealbuffer_common(const void *buf, const uint8_t src, const int size){
 	int conv_size;
 	int i;
         double gain;
+	int target_rate;
 	if(audio[src] == -1) return;
 
 	gain = sound_muted ? 0.0 : pow(10.0, (double) sound_gain / 20.0);
@@ -114,18 +115,18 @@ void givealbuffer_common(const void *buf, const uint8_t src, const int size){
 	}
 
 #ifdef USE_NEW_API
-	output_size = (double)conv_size * info[src].rate / freq;
+	target_rate = info[src].rate;
 #else
-	output_size = (double)conv_size * info[src].play.sample_rate / freq;
+	target_rate = info[src].play.sample_rate;
 #endif
+
+	output_size = (double)conv_size * target_rate / freq;
+	output_size -= output_size % 2;
 	output = malloc(output_size);
 	
 	for(i = 0; i < output_size / sizeof(int16_t) / 2; i++){
-#ifdef USE_NEW_API
-		int ind = i * freq / info[src].rate * 2;
-#else
-		int ind = i * freq / info[src].play.sample_rate * 2;
-#endif
+		int ind = i * freq / target_rate * 2;
+		ind -= ind % 2;
 		output[i * 2 + 0] = conv[ind + 0] * gain;
 		output[i * 2 + 1] = conv[ind + 1] * gain;
 	}

--- a/src/sound/audio4.c
+++ b/src/sound/audio4.c
@@ -62,6 +62,7 @@ void inital(void){
 	int i;
 	for(i = 0; i < sizeof(audio) / sizeof(audio[0]); i++){
 		audio[i] = open("/dev/audio", O_WRONLY);
+		if(audio[i] != -1) audio[i] = open("/dev/audio0", O_WRONLY);
 		if(audio[i] != -1){
 #ifdef USE_NEW_API
 			AUDIO_INITPAR(&info[i]);

--- a/src/sound/audio4.c
+++ b/src/sound/audio4.c
@@ -1,0 +1,51 @@
+/*
+ * 86Box     A hypervisor and IBM PC system emulator that specializes in
+ *           running old operating systems and software designed for IBM
+ *           PC systems and compatibles from 1981 through fairly recent
+ *           system designs based on the PCI bus.
+ *
+ *           This file is part of the 86Box distribution.
+ *
+ *           Interface to audio(4).
+ *
+ *
+ *
+ * Authors:  Nishi
+ *
+ *           Copyright 2025 Nishi.
+ */
+#include <stdint.h>
+
+#include <86box/sound.h>
+
+#define FREQ   SOUND_FREQ
+#define BUFLEN SOUNDBUFLEN
+
+static int midi_freq = 44100;
+static int midi_buf_size = 4410;
+
+void closeal(void){
+}
+
+void inital(void){
+}
+
+void givealbuffer(const void *buf){
+}
+
+void givealbuffer_music(const void *buf){
+}
+
+void givealbuffer_wt(const void *buf){
+}
+
+void givealbuffer_cd(const void *buf){
+}
+
+void givealbuffer_midi(const void *buf, const uint32_t size){
+}
+	
+void al_set_midi(const int freq, const int buf_size){
+    midi_freq     = freq;
+    midi_buf_size = buf_size;
+}

--- a/src/sound/audio4.c
+++ b/src/sound/audio4.c
@@ -121,7 +121,7 @@ void givealbuffer_common(const void *buf, const uint8_t src, const int size){
 #endif
 
 	output_size = (double)conv_size * target_rate / freq;
-	output_size -= output_size % 2;
+	output_size -= output_size % 4;
 	output = malloc(output_size);
 	
 	for(i = 0; i < output_size / sizeof(int16_t) / 2; i++){

--- a/src/sound/audio4.c
+++ b/src/sound/audio4.c
@@ -18,6 +18,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
+#include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>


### PR DESCRIPTION
Summary
=======
 - audio(4) support for NetBSD/OpenBSD
 - Make audio(4) default for NetBSD/OpenBSD
 - Fix 86box/86box.h to include stdarg.h on OpenBSD so it compiles (Should be separated PR, but found it was needed anyways.)

Checklist
=========
* [x] I have discussed this with core contributors already

References
==========
https://man.netbsd.org/audio.4
https://github.com/mackron/miniaudio/blob/master/miniaudio.h
https://man.openbsd.org/audio.4