### PR TITLE
Always make sure emulator is not off-screen when resizing

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -799,6 +799,30 @@ MainWindow::closeEvent(QCloseEvent *event)
 }
 
 void
+MainWindow::resizeEvent(QResizeEvent *event)
+{
+    //qDebug() << pos().x() + event->size().width();
+    //qDebug() << pos().y() + event->size().height();
+    if (vid_resize == 1)
+        return;
+
+    int newX = pos().x();
+    int newY = pos().y();
+
+    if (((frameGeometry().x() + event->size().width() + 1) > util::screenOfWidget(this)->availableGeometry().right())) {
+        //move(util::screenOfWidget(this)->availableGeometry().right() - size().width() - 1, pos().y());
+        newX = util::screenOfWidget(this)->availableGeometry().right() - frameGeometry().width() - 1;
+        if (newX < 1) newX = 1;
+    }
+
+    if (((frameGeometry().y() + event->size().height() + 1) > util::screenOfWidget(this)->availableGeometry().bottom())) {
+        newY = util::screenOfWidget(this)->availableGeometry().bottom() - frameGeometry().height() - 1;
+        if (newY < 1) newY = 1;
+    }
+    move(newX, newY);
+}
+
+void
 MainWindow::initRendererMonitorSlot(int monitor_index)
 {
     auto &secondaryRenderer = this->renderers[monitor_index];

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -137,6 +137,7 @@ protected:
     void showEvent(QShowEvent *event) override;
     void closeEvent(QCloseEvent *event) override;
     void changeEvent(QEvent *event) override;
+    void resizeEvent(QResizeEvent *event) override;
 
 private slots:
     void on_actionPen_triggered();

--- a/src/qt/qt_rendererstack.hpp
+++ b/src/qt/qt_rendererstack.hpp
@@ -7,6 +7,7 @@
 #include <QStackedWidget>
 #include <QWidget>
 #include <QCursor>
+#include <QScreen>
 
 #include <atomic>
 #include <memory>
@@ -14,11 +15,17 @@
 #include <vector>
 
 #include "qt_renderercommon.hpp"
+#include "qt_util.hpp"
 
 #include <atomic>
 
 namespace Ui {
 class RendererStack;
+}
+
+extern "C"
+{
+    extern int vid_resize;
 }
 
 class RendererCommon;
@@ -43,6 +50,22 @@ public:
     void changeEvent(QEvent *event) override;
     void resizeEvent(QResizeEvent *event) override
     {
+        if (this->m_monitor_index != 0 && vid_resize != 1) {
+            int newX = pos().x();
+            int newY = pos().y();
+        
+            if (((frameGeometry().x() + event->size().width() + 1) > util::screenOfWidget(this)->availableGeometry().right())) {
+                //move(util::screenOfWidget(this)->availableGeometry().right() - size().width() - 1, pos().y());
+                newX = util::screenOfWidget(this)->availableGeometry().right() - frameGeometry().width() - 1;
+                if (newX < 1) newX = 1;
+            }
+        
+            if (((frameGeometry().y() + event->size().height() + 1) > util::screenOfWidget(this)->availableGeometry().bottom())) {
+                newY = util::screenOfWidget(this)->availableGeometry().bottom() - frameGeometry().height() - 1;
+                if (newY < 1) newY = 1;
+            }
+            move(newX, newY);
+        }
         onResize(event->size().width(), event->size().height());
     }
     void keyPressEvent(QKeyEvent *event) override


### PR DESCRIPTION
Summary
=======
Always make sure emulator is not off-screen when resizing

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
