### PR TITLE
Replace MACHINE_PCI with MACHINE_PS2_PCI for pl4600c and  Dell Dimension XPS P60 machine_table.c

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -8902,7 +8902,7 @@ const machine_t machines[] = {
             .min_multi = 0,
             .max_multi = 0
         },
-        .bus_flags = MACHINE_PCI,
+        .bus_flags = MACHINE_PS2_PCI,
         .flags = MACHINE_IDE_DUAL | MACHINE_VIDEO | MACHINE_SOUND | MACHINE_APM,
         .ram = {
             .min = 1024,

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -9358,7 +9358,7 @@ const machine_t machines[] = {
             .min_multi = MACHINE_MULTIPLIER_FIXED,
             .max_multi = MACHINE_MULTIPLIER_FIXED
         },
-        .bus_flags = MACHINE_PCI,
+        .bus_flags = MACHINE_PS2_PCI,
         .flags = MACHINE_IDE | MACHINE_APM,
         .ram = {
             .min = 2048,


### PR DESCRIPTION
this will be solved the ps2 mouse  not appear on the setting

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
https://theretroweb.com/motherboards/s/mitac-trigon-pwa-pl4600c
https://theretroweb.com/motherboards/s/dell-dimension-xps-p60
