### PR TITLE
Add confirmation dialog checkboxes in Preferences

### DIFF
--- a/src/qt/qt_progsettings.cpp
+++ b/src/qt/qt_progsettings.cpp
@@ -116,6 +116,8 @@ ProgSettings::ProgSettings(QWidget *parent)
     ui->horizontalSlider->setValue(mouseSensitivity * 100.);
     ui->openDirUsrPath->setChecked(open_dir_usr_path > 0);
     ui->checkBoxMultimediaKeys->setChecked(inhibit_multimedia_keys);
+    ui->checkBoxConfirmExit->setChecked(confirm_exit);
+    ui->checkBoxConfirmSave->setChecked(confirm_save);
 #ifndef Q_OS_WINDOWS
     ui->checkBoxMultimediaKeys->setHidden(true);
 #endif
@@ -127,6 +129,8 @@ ProgSettings::accept()
     strcpy(icon_set, ui->comboBox->currentData().toString().toUtf8().data());
     lang_id                 = ui->comboBoxLanguage->currentData().toUInt();
     open_dir_usr_path       = ui->openDirUsrPath->isChecked() ? 1 : 0;
+    confirm_exit            = ui->checkBoxConfirmExit->isChecked() ? 1 : 0;
+    confirm_save            = ui->checkBoxConfirmSave->isChecked() ? 1 : 0;
     inhibit_multimedia_keys = ui->checkBoxMultimediaKeys->isChecked();
 
     loadTranslators(QCoreApplication::instance());

--- a/src/qt/qt_progsettings.ui
+++ b/src/qt/qt_progsettings.ui
@@ -29,56 +29,25 @@
    <property name="sizeConstraint">
     <enum>QLayout::SizeConstraint::SetFixedSize</enum>
    </property>
-   <item row="9" column="0">
-    <widget class="QCheckBox" name="openDirUsrPath">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+   <item row="14" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="QPushButton" name="pushButton_2">
      <property name="text">
-      <string>Select media images from program working directory</string>
+      <string>Default</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
-    <spacer name="horizontalSpacer_3">
-     <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="5" column="0">
-    <spacer name="horizontalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QComboBox" name="comboBoxLanguage">
-     <property name="maxVisibleItems">
-      <number>30</number>
-     </property>
-     <item>
-      <property name="text">
-       <string>(System Default)</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QPushButton" name="pushButtonLanguage">
+   <item row="2" column="1">
+    <widget class="QPushButton" name="pushButton">
      <property name="text">
       <string>Default</string>
      </property>
@@ -97,13 +66,20 @@
      </property>
     </spacer>
    </item>
-   <item row="13" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
+   <item row="5" column="1">
+    <widget class="QPushButton" name="pushButtonLanguage">
+     <property name="text">
+      <string>Default</string>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+    </widget>
+   </item>
+   <item row="9" column="0">
+    <widget class="QCheckBox" name="openDirUsrPath">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Select media images from program working directory</string>
      </property>
     </widget>
    </item>
@@ -118,6 +94,80 @@
     <widget class="QLabel" name="label_2">
      <property name="text">
       <string>Language:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0">
+    <widget class="QCheckBox" name="checkBoxConfirmSave">
+     <property name="text">
+      <string>Ask for confirmation before saving settings</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QComboBox" name="comboBoxLanguage">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
+     <item>
+      <property name="text">
+       <string>(System Default)</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <spacer name="horizontalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="10" column="0">
+    <widget class="QCheckBox" name="checkBoxMultimediaKeys">
+     <property name="text">
+      <string>Inhibit multimedia keys on Windows</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QComboBox" name="comboBox">
+     <property name="editable">
+      <bool>false</bool>
+     </property>
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
+     <item>
+      <property name="text">
+       <string>(Default)</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Mouse sensitivity:</string>
      </property>
     </widget>
    </item>
@@ -143,46 +193,10 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QComboBox" name="comboBox">
-     <property name="editable">
-      <bool>false</bool>
-     </property>
-     <property name="maxVisibleItems">
-      <number>30</number>
-     </property>
-     <item>
-      <property name="text">
-       <string>(Default)</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_3">
+   <item row="12" column="0">
+    <widget class="QCheckBox" name="checkBoxConfirmExit">
      <property name="text">
-      <string>Mouse sensitivity:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QPushButton" name="pushButton">
-     <property name="text">
-      <string>Default</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
-    <widget class="QPushButton" name="pushButton_2">
-     <property name="text">
-      <string>Default</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0">
-    <widget class="QCheckBox" name="checkBoxMultimediaKeys">
-     <property name="text">
-      <string>Inhibit multimedia keys on Windows</string>
+      <string>Ask for confirmation before quitting</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Summary
=======
Add confirmation dialog checkboxes in Preferences to alter confirmation dialog behaviour when saving machine settings or closing the emulator.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
