### PR TITLE
Add variants of the CH Flightstick Pro and Thrustmaster FCS with rudder pedals attached

### DIFF
--- a/src/game/gameport.c
+++ b/src/game/gameport.c
@@ -88,18 +88,20 @@ static const joystick_if_t joystick_none = {
 static const struct {
     const joystick_if_t *joystick;
 } joysticks[] = {
-    { &joystick_none               },
-    { &joystick_2axis_2button      },
-    { &joystick_2axis_4button      },
-    { &joystick_2axis_6button      },
-    { &joystick_2axis_8button      },
-    { &joystick_3axis_2button      },
-    { &joystick_3axis_4button      },
-    { &joystick_4axis_4button      },
-    { &joystick_ch_flightstick_pro },
-    { &joystick_sw_pad             },
-    { &joystick_tm_fcs             },
-    { NULL                         }
+    { &joystick_none                         },
+    { &joystick_2axis_2button                },
+    { &joystick_2axis_4button                },
+    { &joystick_2axis_6button                },
+    { &joystick_2axis_8button                },
+    { &joystick_3axis_2button                },
+    { &joystick_3axis_4button                },
+    { &joystick_4axis_4button                },
+    { &joystick_ch_flightstick_pro           },
+    { &joystick_ch_flightstick_pro_ch_pedals },
+    { &joystick_sw_pad                       },
+    { &joystick_tm_fcs                       },
+    { &joystick_tm_fcs_rcs                   },
+    { NULL                                   }
 };
 
 static joystick_instance_t *joystick_instance[GAMEPORT_MAX] = { NULL, NULL };

--- a/src/game/joystick_ch_flightstick_pro.c
+++ b/src/game/joystick_ch_flightstick_pro.c
@@ -112,6 +112,26 @@ ch_flightstick_pro_read_axis(UNUSED(void *priv), int axis)
     }
 }
 
+static int
+ch_flightstick_pro_ch_pedals_read_axis(UNUSED(void *priv), int axis)
+{
+    if (!JOYSTICK_PRESENT(0, 0))
+        return AXIS_NOT_PRESENT;
+
+    switch (axis) {
+        case 0:
+            return joystick_state[0][0].axis[0];
+        case 1:
+            return joystick_state[0][0].axis[1];
+        case 2:
+            return joystick_state[0][0].axis[3];
+        case 3:
+            return joystick_state[0][0].axis[2];
+        default:
+            return 0;
+    }
+}
+
 static void
 ch_flightstick_pro_a0_over(UNUSED(void *priv))
 {
@@ -132,6 +152,24 @@ const joystick_if_t joystick_ch_flightstick_pro = {
     .pov_count     = 1,
     .max_joysticks = 1,
     .axis_names    = { "X axis", "Y axis", "Throttle" },
+    .button_names  = { "Button 1", "Button 2", "Button 3", "Button 4" },
+    .pov_names     = { "POV" }
+};
+
+const joystick_if_t joystick_ch_flightstick_pro_ch_pedals = {
+    .name          = "CH Flightstick Pro + CH Pedals",
+    .internal_name = "ch_flightstick_pro_ch_pedals",
+    .init          = ch_flightstick_pro_init,
+    .close         = ch_flightstick_pro_close,
+    .read          = ch_flightstick_pro_read,
+    .write         = ch_flightstick_pro_write,
+    .read_axis     = ch_flightstick_pro_ch_pedals_read_axis,
+    .a0_over       = ch_flightstick_pro_a0_over,
+    .axis_count    = 4,
+    .button_count  = 4,
+    .pov_count     = 1,
+    .max_joysticks = 1,
+    .axis_names    = { "X axis", "Y axis", "Throttle", "Rudder" },
     .button_names  = { "Button 1", "Button 2", "Button 3", "Button 4" },
     .pov_names     = { "POV" }
 };

--- a/src/game/joystick_tm_fcs.c
+++ b/src/game/joystick_tm_fcs.c
@@ -112,6 +112,36 @@ tm_fcs_read_axis(UNUSED(void *priv), int axis)
     }
 }
 
+static int
+tm_fcs_rcs_read_axis(UNUSED(void *priv), int axis)
+{
+    if (!JOYSTICK_PRESENT(0, 0))
+        return AXIS_NOT_PRESENT;
+
+    switch (axis) {
+        case 0:
+            return joystick_state[0][0].axis[0];
+        case 1:
+            return joystick_state[0][0].axis[1];
+        case 2:
+            return joystick_state[0][0].axis[2];
+        case 3:
+            if (joystick_state[0][0].pov[0] == -1)
+                return 32767;
+            if (joystick_state[0][0].pov[0] > 315 || joystick_state[0][0].pov[0] < 45)
+                return -32768;
+            if (joystick_state[0][0].pov[0] >= 45 && joystick_state[0][0].pov[0] < 135)
+                return -16384;
+            if (joystick_state[0][0].pov[0] >= 135 && joystick_state[0][0].pov[0] < 225)
+                return 0;
+            if (joystick_state[0][0].pov[0] >= 225 && joystick_state[0][0].pov[0] < 315)
+                return 16384;
+            return 0;
+        default:
+            return 0;
+    }
+}
+
 static void
 tm_fcs_a0_over(UNUSED(void *priv))
 {
@@ -132,6 +162,24 @@ const joystick_if_t joystick_tm_fcs = {
     .pov_count     = 1,
     .max_joysticks = 1,
     .axis_names    = { "X axis", "Y axis" },
+    .button_names  = { "Button 1", "Button 2", "Button 3", "Button 4" },
+    .pov_names     = { "POV" }
+};
+
+const joystick_if_t joystick_tm_fcs_rcs = {
+    .name          = "Thrustmaster FCS + Rudder Control System",
+    .internal_name = "thrustmaster_fcs_rcs",
+    .init          = tm_fcs_init,
+    .close         = tm_fcs_close,
+    .read          = tm_fcs_read,
+    .write         = tm_fcs_write,
+    .read_axis     = tm_fcs_rcs_read_axis,
+    .a0_over       = tm_fcs_a0_over,
+    .axis_count    = 3,
+    .button_count  = 4,
+    .pov_count     = 1,
+    .max_joysticks = 1,
+    .axis_names    = { "X axis", "Y axis", "Rudder" },
     .button_names  = { "Button 1", "Button 2", "Button 3", "Button 4" },
     .pov_names     = { "POV" }
 };

--- a/src/include/86box/gameport.h
+++ b/src/include/86box/gameport.h
@@ -179,10 +179,12 @@ extern const joystick_if_t joystick_2axis_6button;
 extern const joystick_if_t joystick_2axis_8button;
 
 extern const joystick_if_t joystick_ch_flightstick_pro;
+extern const joystick_if_t joystick_ch_flightstick_pro_ch_pedals;
 
 extern const joystick_if_t joystick_sw_pad;
 
 extern const joystick_if_t joystick_tm_fcs;
+extern const joystick_if_t joystick_tm_fcs_rcs;
 
 extern int             gameport_available(int);
 extern int             gameport_has_config(int);


### PR DESCRIPTION
Summary
=======
Add variants of the CH Flightstick Pro and Thrustmaster Flight Control System with rudder pedals (CH Pedals in rudder mode and Thrustmaster Rudder Control System respectively) connected between the joystick and the machine.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A