### PR TITLE
Set LC_NUMERIC to "C" in program startup to fix GLSL parameter parsing

### DIFF
--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -94,6 +94,8 @@ extern int qt_nvr_save(void);
 bool cpu_thread_running = false;
 }
 
+#include <locale.h>
+
 void qt_set_sequence_auto_mnemonic(bool b);
 
 #ifdef Q_OS_WINDOWS
@@ -525,6 +527,7 @@ main(int argc, char *argv[])
 
     QApplication app(argc, argv);
     QLocale::setDefault(QLocale::C);
+    setlocale(LC_NUMERIC, "C");
 
 #ifdef Q_OS_WINDOWS
     Q_INIT_RESOURCE(darkstyle);

--- a/src/utils/ini.c
+++ b/src/utils/ini.c
@@ -756,8 +756,9 @@ double
 ini_section_get_double(ini_section_t self, const char *name, double def)
 {
     section_t     *section = (section_t *) self;
-    const entry_t *entry;
-    double         value = 0;
+    entry_t *entry;
+    double   value = 0;
+    int      res = 0;
 
     if (section == NULL)
         return def;
@@ -766,7 +767,17 @@ ini_section_get_double(ini_section_t self, const char *name, double def)
     if (entry == NULL)
         return def;
 
-    sscanf(entry->data, "%lg", &value);
+    res = sscanf(entry->data, "%lg", &value);
+    if (res == EOF || res <= 0) {
+        int i = 0;
+        for (i = 0; i < strlen(entry->data); i++) {
+            if (entry->data[i] == ',') {
+                entry->data[i] = '.';
+                entry->wdata[i] = L'.';
+            }
+        }
+        (void)sscanf(entry->data, "%lg", &value);
+    }
 
     return value;
 }


### PR DESCRIPTION
Summary
=======
Set LC_NUMERIC to "C" in program startup to fix GLSL parameter parsing issues.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
