### PR TITLE
qt: implement authentic icon grayscaling

### DIFF
--- a/src/qt/qt_styleoverride.cpp
+++ b/src/qt/qt_styleoverride.cpp
@@ -18,6 +18,9 @@
 
 #include <QComboBox>
 #include <QAbstractItemView>
+#include <QPixmap>
+#include <QIcon>
+#include <QStyleOption>
 
 #ifdef Q_OS_WINDOWS
 #include <dwmapi.h>
@@ -65,4 +68,41 @@ StyleOverride::polish(QWidget *widget)
     if (qobject_cast<QComboBox *>(widget)) {
         qobject_cast<QComboBox *>(widget)->view()->setMinimumWidth(widget->minimumSizeHint().width());
     }
+}
+
+QPixmap
+StyleOverride::generatedIconPixmap(QIcon::Mode iconMode, const QPixmap &pixmap, const QStyleOption *option) const
+{
+    if (iconMode != QIcon::Disabled) {
+        return QProxyStyle::generatedIconPixmap(iconMode, pixmap, option);
+    }
+
+    auto image = pixmap.toImage();
+
+    for (int y = 0; y < image.height(); y++) {
+        for (int x = 0; x < image.width(); x++) {
+            // checkerboard transparency
+            if (((x ^ y) & 1) == 0) {
+                image.setPixelColor(x, y, Qt::transparent);
+                continue;
+            }
+
+            auto color = image.pixelColor(x, y);
+
+            // convert to grayscale using the NTSC formula
+            auto avg = 0.0;
+            avg += color.blueF() * 0.114;
+            avg += color.greenF() * 0.587;
+            avg += color.redF() * 0.299;
+
+            color.setRedF(avg);
+            color.setGreenF(avg);
+            color.setBlueF(avg);
+
+            image.setPixelColor(x, y, color);
+
+        }
+    }
+
+    return QPixmap::fromImage(image);
 }

--- a/src/qt/qt_styleoverride.hpp
+++ b/src/qt/qt_styleoverride.hpp
@@ -4,6 +4,9 @@
 #include <QProxyStyle>
 #include <QWidget>
 #include <QLayout>
+#include <QPixmap>
+#include <QIcon>
+#include <QStyleOption>
 
 class StyleOverride : public QProxyStyle {
 public:
@@ -14,6 +17,7 @@ public:
         QStyleHintReturn   *returnData = nullptr) const override;
 
     void polish(QWidget *widget) override;
+    QPixmap generatedIconPixmap(QIcon::Mode iconMode, const QPixmap &pixmap, const QStyleOption *option) const override;
 };
 
 #endif


### PR DESCRIPTION
Summary
=======
Overrides Qt's default implementation of disabled icon grayscaling with one that replicates our existing icons aesthetic

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
