### PR TITLE
More fixes for 5380-based SCSI chips of the day (March 29th, 2025)

### DIFF
--- a/src/scsi/scsi_ncr5380.c
+++ b/src/scsi/scsi_ncr5380.c
@@ -95,9 +95,6 @@ ncr5380_reset(ncr_t *ncr)
 
     ncr->timer(ncr->priv, 0.0);
 
-    for (int i = 0; i < 8; i++)
-        scsi_device_reset(&scsi_devices[ncr->bus][i]);
-
     scsi_bus->state = STATE_IDLE;
     scsi_bus->clear_req = 0;
     scsi_bus->wait_complete = 0;


### PR DESCRIPTION
Summary
=======
1. Avoid audio stops when they don't need to be.
2. And improved the MMIO-based NCR 53c400 timings to be similar to the port I/O-based one (T130B).
3. Minor timing fixes to the T128/PAS as well (especially for the hdd, when entering Windows 1.x using a SCSI HDD).

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
