### PR TITLE
Vast overhaul for the Mach8/32/8514/A (March 29th, 2025)

### DIFF
--- a/src/include/86box/vid_8514a.h
+++ b/src/include/86box/vid_8514a.h
@@ -18,6 +18,12 @@
 #ifndef VIDEO_8514A_H
 #define VIDEO_8514A_H
 
+#define INT_VSY         (1 << 0)
+#define INT_GE_BSY      (1 << 1)
+#define INT_FIFO_OVR    (1 << 2)
+#define INT_FIFO_EMP    (1 << 3)
+#define INT_MASK        0xf
+
 typedef struct hwcursor8514_t {
     int      ena;
     int      x;
@@ -61,6 +67,7 @@ typedef struct ibm8514_t {
     uint32_t vram_mask;
     uint32_t pallook[512];
     uint32_t bios_addr;
+    uint32_t ma_latch;
 
     PALETTE   vgapal;
     uint8_t   hwcursor_oddeven;
@@ -85,8 +92,8 @@ typedef struct ibm8514_t {
         uint16_t advfunc_cntl;
         uint16_t cur_y;
         uint16_t cur_x;
-        int16_t  destx;
-        int16_t  desty;
+        uint16_t destx;
+        uint16_t desty;
         int16_t  desty_axstp;
         int16_t  destx_distp;
         int16_t  err_term;
@@ -117,6 +124,8 @@ typedef struct ibm8514_t {
         int      y1;
         int      y2;
         int      temp_cnt;
+        int16_t  dx_ibm;
+        int16_t  dy_ibm;
         int16_t  cx;
         int16_t  cx_back;
         int16_t  cy;
@@ -216,10 +225,9 @@ typedef struct ibm8514_t {
     uint16_t subsys_cntl;
     uint8_t subsys_stat;
 
-    atomic_int fifo_idx;
-    atomic_int ext_fifo_idx;
     atomic_int force_busy;
     atomic_int force_busy2;
+    atomic_int fifo_idx;
 
     int      blitter_busy;
     uint64_t blitter_time;
@@ -235,6 +243,11 @@ typedef struct ibm8514_t {
     PALETTE  _8514pal;
 
     latch8514_t latch;
+
+    void (*vblank_start)(void *priv);
+    void (*accel_out_fifo)(void *priv, uint16_t port, uint16_t val, int len);
+    void (*update_irqs)(void *priv);
+
 } ibm8514_t;
 
 #endif /*VIDEO_8514A_H*/

--- a/src/include/86box/vid_ati_mach8.h
+++ b/src/include/86box/vid_ati_mach8.h
@@ -25,6 +25,7 @@ typedef struct mach_t {
     rom_t         bios_rom;
     rom_t         bios_rom2;
     mem_mapping_t mmio_linear_mapping;
+    mem_mapping_t banked_mapping;
 
     int mca_bus;
     int pci_bus;
@@ -71,7 +72,12 @@ typedef struct mach_t {
     uint8_t  bank_r;
     uint16_t shadow_set;
     uint16_t shadow_cntl;
-    int override_resolution;
+    uint8_t overscan_col_8;
+    uint8_t overscan_b_col_24;
+    uint8_t overscan_g_col_24;
+    uint8_t overscan_r_col_24;
+    uint16_t fifo_test_data[17];
+    int resolution_crt;
 
     struct {
         uint8_t  line_idx;
@@ -79,9 +85,9 @@ typedef struct mach_t {
         uint8_t  patt_idx;
         uint8_t  patt_len;
         uint8_t  pix_trans[2];
-        uint8_t  eeprom_control;
         uint8_t  alu_bg_fn;
         uint8_t  alu_fg_fn;
+        uint16_t eeprom_control;
         uint16_t clip_left;
         uint16_t clip_right;
         uint16_t clip_top;
@@ -92,6 +98,7 @@ typedef struct mach_t {
         uint16_t src_x_end;
         uint16_t src_x_start;
         uint16_t src_x;
+        uint16_t r_src_x;
         uint16_t src_y;
         int16_t  bres_count;
         uint16_t clock_sel;
@@ -100,6 +107,8 @@ typedef struct mach_t {
         uint16_t dest_cmp_fn;
         uint16_t dp_config;
         uint16_t ext_ge_config;
+        uint16_t crt_offset_lo;
+        uint16_t crt_offset_hi;
         uint16_t ge_offset_lo;
         uint16_t ge_offset_hi;
         uint16_t linedraw_opt;
@@ -159,6 +168,7 @@ typedef struct mach_t {
     } accel;
 
     atomic_int force_busy;
+    atomic_int fifo_test_idx;
 } mach_t;
 
 #endif /*VIDEO_ATI_MACH8_H*/


### PR DESCRIPTION
Summary
=======
1. Implemented the FIFO test data to pass some tests of the Mach8 POST ROM and tests (not complete yet).
2. Overhauled the mode switches again, but this time with way less hacks and more on manual instructions.
3. Use a function pointer to determine if the Mach8 type used is a VGA combo or add-on.
4. Mach32 mode tests are no longer incorrectly green (was caused by improper pixtrans parts).
5. Implemented overscan color to the Mach32 as well as the CRT offset.
6. And fixed a PCI LFB GPF issue with the Mach32 2.3 drivers on Win3.1x.
7. Implemented memory boundary for both the Mach32 SVGA and its accelerator.
8. Added undocumented ports used by the FIFO (such as ports 0x8AEE and 0xEAEE).
9. Plus resetting the device right a la s3.
10. Temporarily switched the bus type of the Mach8 to 8-bit in both MCA and ISA variants.


Checklist
=========
* [x] Closes #5401
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
