### PR TITLE
More fixes to the 8514/A compatible side.

### DIFF
--- a/src/include/86box/vid_8514a.h
+++ b/src/include/86box/vid_8514a.h
@@ -250,4 +250,9 @@ typedef struct ibm8514_t {
 
 } ibm8514_t;
 
+#define IBM_8514A (((dev->local & 0xff) == 0x00) && (dev->extensions == 0x00))
+#define ATI_8514A_ULTRA (((dev->local & 0xff) == 0x00) && (dev->extensions == 0x01))
+#define ATI_GRAPHICS_ULTRA ((dev->local & 0xff) == 0x01)
+#define ATI_MACH32 ((dev->local & 0xff) == 0x02)
+
 #endif /*VIDEO_8514A_H*/

--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -357,13 +357,13 @@ ibm8514_accel_out_fifo(svga_t *svga, uint16_t port, uint32_t val, int len)
 
         case 0xae8:
             WRITE8(port, dev->hsync_start, val);
-            pclog("IBM 8514/A compatible: (0x%04x): val=0x%02x, hsync_start=%d.\n", port, val, (val + 1) << 3);
+            ibm8514_log("IBM 8514/A compatible: (0x%04x): val=0x%02x, hsync_start=%d.\n", port, val, (val + 1) << 3);
             svga_recalctimings(svga);
             break;
 
         case 0xee8:
             WRITE8(port, dev->hsync_width, val);
-            pclog("IBM 8514/A compatible: (0x%04x): val=0x%02x, hsync_width=%d, hsyncpol=%02x.\n", port, val & 0x1f, ((val & 0x1f) + 1) << 3, val & 0x20);
+            ibm8514_log("IBM 8514/A compatible: (0x%04x): val=0x%02x, hsync_width=%d, hsyncpol=%02x.\n", port, val & 0x1f, ((val & 0x1f) + 1) << 3, val & 0x20);
             svga_recalctimings(svga);
             break;
 

--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -3846,10 +3846,7 @@ ibm8514_recalctimings(svga_t *svga)
             else
                 svga->clock8514 = (cpuclock * (double) (1ULL << 32)) / 25175000.0;
 
-            if (dev->dispend == 766)
-                dev->dispend += 2;
-
-            if (dev->dispend == 478)
+            if ((dev->dispend == 478) || (dev->dispend == 766))
                 dev->dispend += 2;
 
             if (dev->interlace)

--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -2725,7 +2725,7 @@ ati8514_recalctimings(svga_t *svga)
         dev->accel.ge_offset            = (mach->accel.ge_offset_lo | (mach->accel.ge_offset_hi << 16));
         mach->accel.ge_offset           = dev->accel.ge_offset;
 
-        pclog("HDISP=%d, VDISP=%d, shadowset=%x, 8514/A mode=%x, clocksel=%02x.\n",
+        mach_log("HDISP=%d, VDISP=%d, shadowset=%x, 8514/A mode=%x, clocksel=%02x.\n",
                  dev->hdisp, dev->vdisp, mach->shadow_set & 0x03, dev->accel.advfunc_cntl & 0x05, mach->accel.clock_sel & 0x01);
 
         dev->h_disp = dev->hdisp;

--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -2250,7 +2250,7 @@ mach_out(uint16_t addr, uint8_t val, void *priv)
     if (((addr & 0xFFF0) == 0x3D0 || (addr & 0xFFF0) == 0x3B0) && !(svga->miscout & 1))
         addr ^= 0x60;
 
-    if (((dev->disp_cntl & 0x60) == 0x20) && ((dev->local & 0xff) >= 0x02)) {
+    if (((dev->disp_cntl & 0x60) == 0x20) && ATI_MACH32) {
         if ((addr >= 0x3c6) && (addr <= 0x3c9)) {
             mach_log("VGA DAC write regs=%03x, on=%d, display control=%02x, on1=%x, clocksel=%02x.\n",
                      addr, dev->on, dev->disp_cntl & 0x60, dev->accel.advfunc_cntl & 0x01, mach->accel.clock_sel & 0x01);
@@ -2281,7 +2281,7 @@ mach_out(uint16_t addr, uint8_t val, void *priv)
                     }
                     break;
                 case 0xad:
-                    if ((dev->local & 0xff) >= 0x02) {
+                    if (ATI_MACH32) {
                         if ((old ^ val) & 0x0c) {
                             mach_log("ATI AD bits 2-3.\n");
                             svga_recalctimings(svga);
@@ -2301,14 +2301,14 @@ mach_out(uint16_t addr, uint8_t val, void *priv)
                     if (mach->regs[0xbe] & 0x08) { /* Read/write bank mode */
                         mach->bank_r = (((mach->regs[0xb2] & 1) << 3) | ((mach->regs[0xb2] & 0xe0) >> 5));
                         mach->bank_w = ((mach->regs[0xb2] & 0x1e) >> 1);
-                        if ((dev->local & 0xff) >= 0x02) {
+                        if (ATI_MACH32) {
                             mach->bank_r |= ((mach->regs[0xae] & 0x0c) << 2);
                             mach->bank_w |= ((mach->regs[0xae] & 3) << 4);
                         }
                         mach_log("Separate B2Bank = %02x, AEbank = %02x.\n", mach->regs[0xb2], mach->regs[0xae]);
                     } else { /* Single bank mode */
                         mach->bank_w = ((mach->regs[0xb2] & 0x1e) >> 1);
-                        if ((dev->local & 0xff) >= 0x02)
+                        if (ATI_MACH32)
                             mach->bank_w |= ((mach->regs[0xae] & 3) << 4);
 
                         mach->bank_r = mach->bank_w;
@@ -2338,7 +2338,7 @@ mach_out(uint16_t addr, uint8_t val, void *priv)
                     }
                     break;
                 case 0xb8:
-                    if ((dev->local & 0xff) >= 0x02) {
+                    if (ATI_MACH32) {
                         if ((old ^ val) & 0x40) {
                             mach_log("ATI B8 bit 6.\n");
                             svga_recalctimings(svga);
@@ -2367,7 +2367,7 @@ mach_out(uint16_t addr, uint8_t val, void *priv)
             rs2 = !!(mach->accel.ext_ge_config & 0x1000);
             rs3 = !!(mach->accel.ext_ge_config & 0x2000);
             mach_log("8514/A RS2=%d, RS3=%d, addr=%03x.\n", rs2, rs3, addr);
-            if ((dev->local & 0xff) >= 0x02) {
+            if (ATI_MACH32) {
                 if (mach->regs[0xb0] & 0x20) { /*ATI extended 8514/A mode.*/
                     mach_log("Extended 8514/A mode.\n");
                     dev->vendor_mode = 1;
@@ -2394,7 +2394,7 @@ mach_out(uint16_t addr, uint8_t val, void *priv)
             rs2 = !!(mach->regs[0xa0] & 0x20);
             rs3 = !!(mach->regs[0xa0] & 0x40);
             mach_log("VGA RS2=%d, RS3=%d, addr=%03x.\n", rs2, rs3, addr);
-            if ((dev->local & 0xff) >= 0x02) {
+            if (ATI_MACH32) {
                 if (svga->attrregs[0x10] & 0x40) {
                     mach_log("VGA mode.\n");
                     dev->vendor_mode = 0;
@@ -2495,7 +2495,7 @@ mach_in(uint16_t addr, void *priv)
                 case 0xb0:
                     temp = mach->regs[0xb0] | 0x80;
                     temp &= ~0x18;
-                    if ((dev->local & 0xff) >= 0x02) { /*Mach32 VGA 1MB memory*/
+                    if (ATI_MACH32) { /*Mach32 VGA 1MB memory*/
                         temp |= 0x08;
                     } else { /*ATI 28800 VGA 512kB memory*/
                         temp |= 0x10;
@@ -2524,7 +2524,7 @@ mach_in(uint16_t addr, void *priv)
         case 0x2ed:
             rs2 = !!(mach->accel.ext_ge_config & 0x1000);
             rs3 = !!(mach->accel.ext_ge_config & 0x2000);
-            if ((dev->local & 0xff) >= 0x02) {
+            if (ATI_MACH32) {
                 if (dev->on)
                     temp = svga_in(addr, svga);
                 else {
@@ -2669,6 +2669,9 @@ mach_set_resolution(mach_t *mach, svga_t *svga)
     ibm8514_t    *dev  = (ibm8514_t *) svga->dev8514;
 
     dev->hdisp = (dev->hdisped + 1) << 3;
+    if (!dev->htotal) /*Default to 1024x768 87hz 8514/A htotal timings if it goes to 0.*/
+        dev->htotal = 0x9d;
+
     dev->h_total = dev->htotal + 1;
 
     dev->vdisp = (dev->v_disp + 1) >> 1;
@@ -2693,6 +2696,16 @@ mach_set_resolution(mach_t *mach, svga_t *svga)
                 dev->vdisp = 480;
                 svga_recalctimings(svga);
             }
+        } else {
+            if (ATI_8514A_ULTRA) {
+                if (dev->accel.advfunc_cntl & 0x04) {
+                    if (dev->hdisp == 640) {
+                        dev->hdisp = 1024;
+                        dev->vdisp = 768;
+                        svga_recalctimings(svga);
+                    }
+                }
+            }
         }
     }
 }
@@ -2712,7 +2725,7 @@ ati8514_recalctimings(svga_t *svga)
         dev->accel.ge_offset            = (mach->accel.ge_offset_lo | (mach->accel.ge_offset_hi << 16));
         mach->accel.ge_offset           = dev->accel.ge_offset;
 
-        mach_log("HDISP=%d, VDISP=%d, shadowset=%x, 8514/A mode=%x, clocksel=%02x.\n",
+        pclog("HDISP=%d, VDISP=%d, shadowset=%x, 8514/A mode=%x, clocksel=%02x.\n",
                  dev->hdisp, dev->vdisp, mach->shadow_set & 0x03, dev->accel.advfunc_cntl & 0x05, mach->accel.clock_sel & 0x01);
 
         dev->h_disp = dev->hdisp;
@@ -2756,7 +2769,7 @@ mach_recalctimings(svga_t *svga)
 
     clock_sel = ((svga->miscout >> 2) & 3) | ((mach->regs[0xbe] & 0x10) >> 1) | ((mach->regs[0xb9] & 2) << 1);
 
-    if ((dev->local & 0xff) >= 0x02) {
+    if (ATI_MACH32) {
         if (mach->regs[0xad] & 0x04)
             svga->ma_latch |= 0x40000;
 
@@ -2785,7 +2798,7 @@ mach_recalctimings(svga_t *svga)
     } else
         svga->packed_4bpp = 0;
 
-    if ((dev->local & 0xff) < 0x02) {
+    if (!ATI_MACH32) {
         if ((mach->regs[0xb6] & 0x18) == 0x08) {
             svga->hdisp <<= 1;
             svga->htotal <<= 1;
@@ -2823,7 +2836,7 @@ mach_recalctimings(svga_t *svga)
         if (dev->interlace)
             dev->dispend >>= 1;
 
-        if ((dev->local & 0xff) >= 0x02) {
+        if (ATI_MACH32) {
             mach_log("cntl=%d, clksel=%x, hv(%d,%d), pitch=%d, rowoffset=%d, gextconfig=%03x, shadow=%x interlace=%d, vgahdisp=%d.\n",
                      dev->accel.advfunc_cntl & 0x04, mach->accel.clock_sel & 0x01, dev->h_disp, dev->dispend, dev->pitch, dev->rowoffset,
                      mach->accel.ext_ge_config & 0xcec0, mach->shadow_set & 3, dev->interlace, svga->hdisp);
@@ -2913,7 +2926,7 @@ mach_recalctimings(svga_t *svga)
                 if ((svga->gdcreg[5] & 0x40) || (svga->attrregs[0x10] & 0x40) || (mach->regs[0xb0] & 0x20)) {
                     svga->clock = (cpuclock * (double) (1ULL << 32)) / svga->getclock(clock_sel, svga->clock_gen);
                     mach_log("VGA clock=%02x.\n", mach->regs[0xa7] & 0x80);
-                    if ((dev->local & 0xff) >= 0x02) {
+                    if (ATI_MACH32) {
                         if (mach->regs[0xb8] & 0x40)
                             svga->clock *= 2;
                     } else {
@@ -2960,7 +2973,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
 
     switch (port) {
         case 0x2e8:
-            if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03))) { /*For 8514/A mode, take the shadow sets into account.*/
+            if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03)) || ATI_8514A_ULTRA) { /*For 8514/A mode, take the shadow sets into account.*/
                 if (!(mach->shadow_cntl & 0x04))
                     dev->htotal = val;
 
@@ -2969,7 +2982,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             break;
 
         case 0xae8:
-            if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03))) { /*For 8514/A mode, take the shadow sets into account.*/
+            if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03)) || ATI_8514A_ULTRA) { /*For 8514/A mode, take the shadow sets into account.*/
                 if (!(mach->shadow_cntl & 0x04)) {
                     WRITE8(port, dev->hsync_start, val);
                 }
@@ -2978,7 +2991,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             break;
 
         case 0xee8:
-            if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03))) { /*For 8514/A mode, take the shadow sets into account.*/
+            if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03)) || ATI_8514A_ULTRA) { /*For 8514/A mode, take the shadow sets into account.*/
                 if (!(mach->shadow_cntl & 0x04)) {
                     WRITE8(port, dev->hsync_width, val);
                 }
@@ -2995,14 +3008,17 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
         case 0x6e8:
             if (len == 2) {
                 mach_log("HDISP and HTOTAL=%04x, len=%d, set=%x, ATI mode bit=%x.\n", val, len, mach->shadow_set & 0x03, mach->accel.clock_sel & 0x01);
-                if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03))) { /*For 8514/A mode, take the shadow sets into account.*/
-                    if (!(mach->shadow_cntl & 0x08)) {
-                        WRITE8(port, dev->hdisped, val);
+                if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03)) || ATI_8514A_ULTRA) { /*For 8514/A mode, take the shadow sets into account.*/
+                    if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03))) {
+                        if (!(mach->shadow_cntl & 0x08)) {
+                            WRITE8(port, dev->hdisped, val);
+                        }
                     }
 
-                    if (!(mach->shadow_cntl & 0x04))
-                        dev->htotal = (val >> 8) & 0xff;
-
+                    if (ATI_8514A_ULTRA) {
+                        if (!(mach->shadow_cntl & 0x04))
+                            dev->htotal = (val >> 8) & 0xff;
+                    }
                     mach_set_resolution(mach, svga);
                 }
             } else {
@@ -3029,7 +3045,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
         case 0x6e9:
             if (len == 1) {
                 mach_log("HDISP and HTOTAL+1=%02x, len=%d, set=%x, ATI mode bit=%x.\n", val, len, mach->shadow_set & 0x03, mach->accel.clock_sel & 0x01);
-                if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03))) { /*For 8514/A mode, take the shadow sets into account.*/
+                if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03)) || ATI_8514A_ULTRA) { /*For 8514/A mode, take the shadow sets into account.*/
                     if (!(mach->shadow_cntl & 0x04)) {
                         dev->htotal = val;
                     }
@@ -3040,7 +3056,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
 
         case 0x12e8:
             if (len == 2) {
-                if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03))) { /*For 8514/A mode, take the shadow sets into account.*/
+                if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03)) || ATI_8514A_ULTRA) { /*For 8514/A mode, take the shadow sets into account.*/
                     if (!(mach->shadow_cntl & 0x10)) {
                         dev->v_total_reg = val;
                         dev->v_total_reg &= 0x1fff;
@@ -3048,7 +3064,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                     mach_set_resolution(mach, svga);
                 }
             } else {
-                if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03))) { /*For 8514/A mode, take the shadow sets into account.*/
+                if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03)) || ATI_8514A_ULTRA) { /*For 8514/A mode, take the shadow sets into account.*/
                     if (!(mach->shadow_cntl & 0x10)) {
                         WRITE8(port, dev->v_total_reg, val);
                         dev->v_total_reg &= 0x1fff;
@@ -3061,7 +3077,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
 
         case 0x12e9:
             if (len == 1) {
-                if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03))) {
+                if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03)) || ATI_8514A_ULTRA) {
                     if (!(mach->shadow_cntl & 0x10)) { /*For 8514/A mode, take the shadow sets into account.*/
                         WRITE8(port, dev->v_total_reg, val);
                         dev->v_total_reg &= 0x1fff;
@@ -3109,7 +3125,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
 
         case 0x1ae8:
             if (len == 2) {
-                if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03))) {
+                if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03)) || ATI_8514A_ULTRA) {
                     if (!(mach->shadow_cntl & 0x10)) { /*For 8514/A mode, take the shadow sets into account.*/
                         dev->v_sync_start = val;
                         dev->v_sync_start &= 0x1fff;
@@ -3119,7 +3135,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                 mach_log("ATI 8514/A: V_SYNCSTART write 1AE8 = %d\n", dev->v_syncstart);
                 mach_log("ATI 8514/A: (0x%04x): vsyncstart=0x%02x.\n", port, val);
             } else {
-                if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03))) {
+                if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03)) || ATI_8514A_ULTRA) {
                     if (!(mach->shadow_cntl & 0x10)) { /*For 8514/A mode, take the shadow sets into account.*/
                         WRITE8(port, dev->v_sync_start, val);
                         dev->v_sync_start &= 0x1fff;
@@ -3130,7 +3146,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             break;
         case 0x1ae9:
             if (len == 1) {
-                if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03))) {
+                if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03)) || ATI_8514A_ULTRA) {
                     if (!(mach->shadow_cntl & 0x10)) { /*For 8514/A mode, take the shadow sets into account.*/
                         WRITE8(port, dev->v_sync_start, val);
                         dev->v_sync_start &= 0x1fff;
@@ -3181,12 +3197,12 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             mach_log("[%04X:%08X]: ATI 8514/A: (0x%04x): ON=%d, shadow crt=%x, hdisp=%d, vdisp=%d.\n",
                      CS, cpu_state.pc, port, val & 0x01, dev->accel.advfunc_cntl & 0x04, dev->hdisp, dev->vdisp);
 
-            if ((dev->local & 0xff) < 0x02) {
-                dev->ext_crt_pitch = 128;
-                mach_set_resolution(mach, svga);
-            } else {
+            if (ATI_MACH32) {
                 mach_set_resolution(mach, svga);
                 mach32_updatemapping(mach, svga);
+            } else {
+                dev->ext_crt_pitch = 128;
+                mach_set_resolution(mach, svga);
             }
             mach_log("Vendor IBM mode set %s resolution.\n", (dev->accel.advfunc_cntl & 0x04) ? "2: 1024x768" : "1: 640x480");
             break;
@@ -3390,7 +3406,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             ibm8514_accel_out_fifo(svga, port, val, len);
             if (len == 2) {
                 if ((dev->accel.multifunc_cntl >> 12) == 5) {
-                    if ((dev->local & 0xff) < 0x02)
+                    if (!ATI_MACH32)
                         dev->ext_crt_pitch = 128;
                 }
             }
@@ -3514,12 +3530,12 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                 else
                     dev->ext_crt_pitch <<= 1;
             }
-            if ((dev->local & 0xff) >= 0x02) {
+            if (ATI_MACH32) {
                 dev->on |= 0x01;
                 dev->vendor_mode = 1;
             }
             svga_recalctimings(svga);
-            if ((dev->local & 0xff) >= 0x01)
+            if (ATI_GRAPHICS_ULTRA || ATI_MACH32)
                 mach32_updatemapping(mach, svga);
 
             mach_log("ATI 8514/A: (0x%04x) CRT Pitch, val=0x%02x, crtpitch=%x, len=%d, extended 8514/A mode=%02x.\n", port, val, dev->ext_crt_pitch, len, mach->regs[0xb0] & 0x20);
@@ -3548,17 +3564,17 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             else {
                 WRITE8(port, mach->local_cntl, val);
             }
-            if ((dev->local & 0xff) >= 0x01)
+            if (ATI_GRAPHICS_ULTRA || ATI_MACH32)
                 mach32_updatemapping(mach, svga);
             break;
 
         case 0x36ee:
         case 0x36ef:
             if (len == 2) {
-                if ((dev->local & 0xff) >= 0x02)
+                if (ATI_MACH32)
                     mach->misc = val;
             } else {
-                if ((dev->local & 0xff) >= 0x02)
+                if (ATI_MACH32)
                     WRITE8(port, mach->misc, val);
             }
             mach->misc &= 0xfff0;
@@ -3621,7 +3637,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             mach_log("Vendor ATI mode set %s resolution.\n",
                      (dev->accel.advfunc_cntl & 0x04) ? "2: 1024x768" : "1: 640x480");
             svga_recalctimings(svga);
-            if ((dev->local & 0xff) >= 0x01)
+            if (ATI_GRAPHICS_ULTRA || ATI_MACH32)
                 mach32_updatemapping(mach, svga);
             break;
 
@@ -3675,7 +3691,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             if (!mach->pci_bus)
                 mach->linear_base = (mach->memory_aperture & 0xff00) << 12;
 
-            if ((dev->local & 0xff) >= 0x01)
+            if (ATI_GRAPHICS_ULTRA || ATI_MACH32)
                 mach32_updatemapping(mach, svga);
             break;
 
@@ -3729,7 +3745,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             else {
                 WRITE8(port, mach->accel.ext_ge_config, val);
             }
-            if ((dev->local & 0xff) >= 0x02) {
+            if (ATI_MACH32) {
                 if (mach->accel.crt_pitch & 0xff)
                     dev->ext_crt_pitch = mach->accel.crt_pitch & 0xff;
 
@@ -4407,46 +4423,46 @@ mach_accel_in_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, in
 
         case 0xdaee:
             if (len == 2) {
-                if ((dev->local & 0xff) >= 0x02)
+                if (ATI_MACH32)
                     temp = mach->accel.src_x;
             } else {
-                if ((dev->local & 0xff) >= 0x02)
+                if (ATI_MACH32)
                     temp = mach->accel.src_x & 0xff;
             }
             break;
         case 0xdaef:
             if (len == 1) {
-                if ((dev->local & 0xff) >= 0x02)
+                if (ATI_MACH32)
                     temp = mach->accel.src_x >> 8;
             }
             break;
 
         case 0xdeee:
             if (len == 2) {
-                if ((dev->local & 0xff) >= 0x02)
+                if (ATI_MACH32)
                     temp = mach->accel.src_y;
             } else {
-                if ((dev->local & 0xff) >= 0x02)
+                if (ATI_MACH32)
                     temp = mach->accel.src_y & 0xff;
             }
             break;
         case 0xdeef:
             if (len == 1) {
-                if ((dev->local & 0xff) >= 0x02)
+                if (ATI_MACH32)
                     temp = mach->accel.src_y >> 8;
             }
             break;
 
         case 0xfaee:
             if (len == 2) {
-                if ((dev->local & 0xff) >= 0x02) {
+                if (ATI_MACH32) {
                     if (mach->pci_bus)
                         temp = 0x0017;
                     else
                         temp = 0x22f7;
                 }
             } else {
-                if ((dev->local & 0xff) >= 0x02) {
+                if (ATI_MACH32) {
                     if (mach->pci_bus)
                         temp = 0x17;
                     else
@@ -4456,7 +4472,7 @@ mach_accel_in_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, in
             break;
         case 0xfaef:
             if (len == 1) {
-                if ((dev->local & 0xff) >= 0x02) {
+                if (ATI_MACH32) {
                     if (mach->pci_bus)
                         temp = 0x00;
                     else
@@ -4604,7 +4620,7 @@ mach_accel_in_call(uint16_t port, mach_t *mach, svga_t *svga, ibm8514_t *dev)
 
         case 0x36ee:
         case 0x36ef:
-            if ((dev->local & 0xff) >= 0x02) {
+            if (ATI_MACH32) {
                 READ8(port, mach->misc);
                 if (!(port & 1)) {
                     temp &= ~0x0c;
@@ -5148,7 +5164,7 @@ mach32_write(uint32_t addr, uint8_t val, void *priv)
             return;
     }
 
-    if ((((dev->local & 0xff) >= 0x02) && !dev->vram_512k_8514) && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
+    if ((ATI_MACH32 && !dev->vram_512k_8514) && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
         addr <<= 1;
         switch (addr & 0x06) {
             case 0x00:
@@ -5188,7 +5204,7 @@ mach32_writew(uint32_t addr, uint16_t val, void *priv)
             return;
     }
 
-    if ((((dev->local & 0xff) >= 0x02) && !dev->vram_512k_8514) && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
+    if ((ATI_MACH32 && !dev->vram_512k_8514) && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
         addr <<= 1;
         if (addr & 0x04) {
             mach32_write_common(addr - 2, val & 0x0f, 0, mach, svga);
@@ -5223,7 +5239,7 @@ mach32_writel(uint32_t addr, uint32_t val, void *priv)
             return;
     }
 
-    if ((((dev->local & 0xff) >= 0x02) && !dev->vram_512k_8514) && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
+    if ((ATI_MACH32 && !dev->vram_512k_8514) && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
         addr <<= 1;
         mach32_write_common(addr, val & 0x0f, 0, mach, svga);
         mach32_write_common(addr + 1, (val >> 4) & 0x0f, 0, mach, svga);
@@ -5639,7 +5655,7 @@ mach32_read(uint32_t addr, void *priv)
     (void) xga_read_test(addr, svga);
     addr = (addr & svga->banked_mask) + svga->read_bank;
 
-    if ((((dev->local & 0xff) >= 0x02) && !dev->vram_512k_8514) && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
+    if ((ATI_MACH32 && !dev->vram_512k_8514) && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
         addr <<= 1;
         switch (addr & 0x06) {
             case 0x00:
@@ -5676,7 +5692,7 @@ mach32_readw(uint32_t addr, void *priv)
     (void) xga_read_test(addr, svga);
     addr = (addr & svga->banked_mask) + svga->read_bank;
 
-    if ((((dev->local & 0xff) >= 0x02) && !dev->vram_512k_8514) && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
+    if ((ATI_MACH32 && !dev->vram_512k_8514) && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
         addr <<= 1;
         if (addr & 0x04) {
             ret = mach32_read_common(addr - 2, 0, mach, svga) & 0x0f;
@@ -5708,7 +5724,7 @@ mach32_readl(uint32_t addr, void *priv)
     (void) xga_read_test(addr, svga);
     addr = (addr & svga->banked_mask) + svga->read_bank;
 
-    if ((((dev->local & 0xff) >= 0x02) && !dev->vram_512k_8514) && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
+    if ((ATI_MACH32 && !dev->vram_512k_8514) && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
         addr <<= 1;
         ret = mach32_read_common(addr, 0, mach, svga) & 0x0f;
         ret |= (mach32_read_common(addr + 1, 0, mach, svga) << 4);
@@ -5998,7 +6014,7 @@ mach32_updatemapping(mach_t *mach, svga_t *svga)
             case 0xC: /*32k at B8000*/
                 mem_mapping_set_addr(&svga->mapping, 0xb8000, 0x08000);
                 svga->banked_mask = 0x7fff;
-                if (((dev->local & 0xff) >= 0x02) && !(dev->accel.advfunc_cntl & 0x01) && !(mach->accel.clock_sel & 0x01)) {
+                if (ATI_MACH32 && !(dev->accel.advfunc_cntl & 0x01) && !(mach->accel.clock_sel & 0x01)) {
                     if ((svga->gdcreg[6] & 0x01) || (svga->attrregs[0x10] & 0x01)) {
                         if (svga->attrregs[0x10] & 0x40) {
                             dev->vendor_mode = 0;
@@ -6035,7 +6051,7 @@ mach32_updatemapping(mach_t *mach, svga_t *svga)
         mem_mapping_disable(&mach->mmio_linear_mapping);
     }
 
-    if ((dev->local & 0xff) >= 0x02) {
+    if (ATI_MACH32) {
         if (dev->on && dev->vendor_mode) {
             mach_log("Mach32 banked mapping.\n");
             mem_mapping_disable(&svga->mapping);
@@ -6216,6 +6232,7 @@ ati8514_io_set(svga_t *svga)
     io_sethandler(0x7eee, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
     io_sethandler(0x82ee, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
     io_sethandler(0x86ee, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
+    io_sethandler(0x8aee, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
     io_sethandler(0x8eee, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
     io_sethandler(0x92ee, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
     io_sethandler(0x96ee, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
@@ -6238,6 +6255,7 @@ ati8514_io_set(svga_t *svga)
     io_sethandler(0xdeee, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
     io_sethandler(0xe2ee, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
     io_sethandler(0xe6ee, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
+    io_sethandler(0xeaee, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
     io_sethandler(0xeeee, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
     io_sethandler(0xf2ee, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
     io_sethandler(0xf6ee, 0x0002, ati8514_accel_inb, ati8514_accel_inw, ati8514_accel_inl, ati8514_accel_outb, ati8514_accel_outw, ati8514_accel_outl, svga);
@@ -6331,6 +6349,7 @@ mach_io_remove(mach_t *mach)
     io_removehandler(0x7eee, 0x0002, mach_accel_inb, mach_accel_inw, mach_accel_inl, mach_accel_outb, mach_accel_outw, mach_accel_outl, mach);
     io_removehandler(0x82ee, 0x0002, mach_accel_inb, mach_accel_inw, mach_accel_inl, mach_accel_outb, mach_accel_outw, mach_accel_outl, mach);
     io_removehandler(0x86ee, 0x0002, mach_accel_inb, mach_accel_inw, mach_accel_inl, mach_accel_outb, mach_accel_outw, mach_accel_outl, mach);
+    io_removehandler(0x8aee, 0x0002, mach_accel_inb, mach_accel_inw, mach_accel_inl, mach_accel_outb, mach_accel_outw, mach_accel_outl, mach);
     io_removehandler(0x8eee, 0x0002, mach_accel_inb, mach_accel_inw, mach_accel_inl, mach_accel_outb, mach_accel_outw, mach_accel_outl, mach);
     io_removehandler(0x92ee, 0x0002, mach_accel_inb, mach_accel_inw, mach_accel_inl, mach_accel_outb, mach_accel_outw, mach_accel_outl, mach);
     io_removehandler(0x96ee, 0x0002, mach_accel_inb, mach_accel_inw, mach_accel_inl, mach_accel_outb, mach_accel_outw, mach_accel_outl, mach);
@@ -6353,6 +6372,7 @@ mach_io_remove(mach_t *mach)
     io_removehandler(0xdeee, 0x0002, mach_accel_inb, mach_accel_inw, mach_accel_inl, mach_accel_outb, mach_accel_outw, mach_accel_outl, mach);
     io_removehandler(0xe2ee, 0x0002, mach_accel_inb, mach_accel_inw, mach_accel_inl, mach_accel_outb, mach_accel_outw, mach_accel_outl, mach);
     io_removehandler(0xe6ee, 0x0002, mach_accel_inb, mach_accel_inw, mach_accel_inl, mach_accel_outb, mach_accel_outw, mach_accel_outl, mach);
+    io_removehandler(0xeaee, 0x0002, mach_accel_inb, mach_accel_inw, mach_accel_inl, mach_accel_outb, mach_accel_outw, mach_accel_outl, mach);
     io_removehandler(0xeeee, 0x0002, mach_accel_inb, mach_accel_inw, mach_accel_inl, mach_accel_outb, mach_accel_outw, mach_accel_outl, mach);
     io_removehandler(0xf2ee, 0x0002, mach_accel_inb, mach_accel_inw, mach_accel_inl, mach_accel_outb, mach_accel_outw, mach_accel_outl, mach);
     io_removehandler(0xf6ee, 0x0002, mach_accel_inb, mach_accel_inw, mach_accel_inl, mach_accel_outb, mach_accel_outw, mach_accel_outl, mach);
@@ -6817,7 +6837,7 @@ mach8_init(const device_t *info)
     dev->vram_512k_8514 = dev->vram_amount == 512;
     dev->accel.cmd_back = 1;
 
-    if ((dev->local & 0xff) >= 0x02) {
+    if (ATI_MACH32) {
         if (mach->pci_bus) {
             if (mach->has_bios) {
                 rom_init(&mach->bios_rom,
@@ -6852,7 +6872,7 @@ mach8_init(const device_t *info)
                  0xc0000, 0x8000, 0x7fff,
                  0, MEM_MAPPING_EXTERNAL);
 
-    if ((dev->local & 0xff) >= 0x02) {
+    if (ATI_MACH32) {
         svga_init(info, svga, mach, dev->vram_amount << 10, /*default: 2MB for Mach32*/
                       mach_recalctimings,
                       mach_in, mach_out,
@@ -6940,7 +6960,7 @@ mach8_init(const device_t *info)
     mach_io_set(mach);
     mach->accel.cmd_type = -2;
 
-    if ((dev->local & 0xff) >= 0x02) {
+    if (ATI_MACH32) {
         svga->decode_mask     = (4 << 20) - 1;
         mach->cursor_col_1    = 0xff;
         mach->ext_cur_col_1_r = 0xff;
@@ -6985,13 +7005,21 @@ ati8514_init(svga_t *svga, void *ext8514, void *dev8514)
     mach_t *mach = (mach_t *) ext8514;
     ibm8514_t *dev = (ibm8514_t *) dev8514;
 
+    /*Init as 1024x768 87hz interlaced first, per 8514/A.*/
     dev->on = 0;
     dev->ext_pitch = 1024;
     dev->ext_crt_pitch = 0x80;
     dev->accel_bpp = 8;
     dev->rowoffset = 0x80;
-    dev->hdisp = 1024;
-    dev->vdisp = 768;
+    dev->hdisped = 0x7f;
+    dev->v_disp = 0x05ff;
+    dev->htotal = 0x9d;
+    dev->v_total_reg = 0x0668;
+    dev->v_sync_start = 0x0600;
+    dev->disp_cntl = 0x33;
+    mach->accel.clock_sel = 0x1c;
+    mach->shadow_set = 0x02;
+    mach->resolution_crt = 0x02;
 
     io_sethandler(0x02ea, 4, ati8514_in, NULL, NULL, ati8514_out, NULL, NULL, svga);
     ati8514_io_set(svga);

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -904,7 +904,7 @@ svga_recalctimings(svga_t *svga)
         svga->recalctimings_ex(svga);
 
     if (ibm8514_active && (svga->dev8514 != NULL)) {
-        if ((dev->local & 0xff) == 0x00)
+        if (IBM_8514A || ATI_8514A_ULTRA)
             ibm8514_recalctimings(svga);
     }
 
@@ -1031,8 +1031,8 @@ svga_recalctimings(svga_t *svga)
     if (ibm8514_active && (svga->dev8514 != NULL)) {
         if (dev->on) {
             disptime8514 = dev->h_total;
-            _dispontime8514 = (dev->hdisped + 1) * 8;
-            svga_log("HDISPED 8514=%d, htotal=%02x.\n", (dev->hdisped + 1) << 3, dev->h_total);
+            _dispontime8514 = dev->h_disp;
+            svga_log("HTOTAL=%d, HDISP=%d.\n", dev->h_total, dev->h_disp);
         }
     }
 


### PR DESCRIPTION
Summary
=======
1. Use proper identification to what chips use what.
2. Apply some mode switch fixes to the ATI 8514/A Ultra and make 1024x768 87Hz interlaced the default mode if htotal is 0 and on ati8514_init.
3. Add the undocumented ports to the ATI 8514/A Ultra add-on as well.

Checklist
=========
* [x] Closes #5406
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
