### PR TITLE
Qt: Fix HiDPI scaling on non-software renderers

### DIFF
--- a/src/qt/qt_hardwarerenderer.cpp
+++ b/src/qt/qt_hardwarerenderer.cpp
@@ -37,7 +37,7 @@ void
 HardwareRenderer::resizeGL(int w, int h)
 {
     m_context->makeCurrent(this);
-    glViewport(0, 0, qRound(w * devicePixelRatio()), qRound(h * devicePixelRatio()));
+    glViewport(0, 0, qRound(w * devicePixelRatioF()), qRound(h * devicePixelRatioF()));
 }
 
 #define PROGRAM_VERTEX_ATTRIBUTE   0
@@ -220,14 +220,17 @@ HardwareRenderer::onBlit(int buf_idx, int x, int y, int w, int h)
 #endif
     buf_usage[buf_idx].clear();
     source.setRect(x, y, w, h);
-    if (origSource != source)
+    if (origSource != source) {
+        this->pixelRatio = devicePixelRatioF();
         onResize(this->width(), this->height());
+    }
     update();
 }
 
 void
 HardwareRenderer::resizeEvent(QResizeEvent *event)
 {
+    this->pixelRatio = devicePixelRatioF();
     onResize(width(), height());
 
     QOpenGLWindow::resizeEvent(event);

--- a/src/qt/qt_openglrenderer.cpp
+++ b/src/qt/qt_openglrenderer.cpp
@@ -1154,14 +1154,15 @@ OpenGLRenderer::onBlit(int buf_idx, int x, int y, int w, int h)
 
     buf_usage[buf_idx].clear();
     source.setRect(x, y, w, h);
+    this->pixelRatio = devicePixelRatio();
     onResize(this->width(), this->height());
 
 #ifdef Q_OS_MACOS
     glw.glViewport(
-        destination.x() * devicePixelRatio(),
-        destination.y() * devicePixelRatio(),
-        destination.width() * devicePixelRatio(),
-        destination.height() * devicePixelRatio());
+        destination.x(),
+        destination.y(),
+        destination.width(),
+        destination.height());
 #endif
 
     if (video_framerate == -1)
@@ -1187,6 +1188,7 @@ OpenGLRenderer::exposeEvent(QExposeEvent *event)
     if (!isInitialized)
         initialize();
 
+    this->pixelRatio = devicePixelRatio();
     onResize(size().width(), size().height());
 }
 
@@ -1195,6 +1197,7 @@ OpenGLRenderer::resizeEvent(QResizeEvent *event)
 {
     Q_UNUSED(event);
 
+    this->pixelRatio = devicePixelRatio();
     onResize(event->size().width(), event->size().height());
 
     if (notReady())
@@ -1203,10 +1206,10 @@ OpenGLRenderer::resizeEvent(QResizeEvent *event)
     context->makeCurrent(this);
 
     glw.glViewport(
-        destination.x() * devicePixelRatio(),
-        destination.y() * devicePixelRatio(),
-        destination.width() * devicePixelRatio(),
-        destination.height() * devicePixelRatio());
+        destination.x(),
+        destination.y(),
+        destination.width(),
+        destination.height());
 }
 
 void
@@ -1386,10 +1389,10 @@ OpenGLRenderer::render()
         uint32_t x, y, w, h;
     } window_rect;
 
-    window_rect.x = destination.x() * devicePixelRatio();
-    window_rect.y = destination.y() * devicePixelRatio();
-    window_rect.w = destination.width() * devicePixelRatio();
-    window_rect.h = destination.height() * devicePixelRatio();
+    window_rect.x = destination.x();
+    window_rect.y = destination.y();
+    window_rect.w = destination.width();
+    window_rect.h = destination.height();
 
     glw.glBindTexture(GL_TEXTURE_2D, scene_texture.id);
     scene_texture.min_filter = scene_texture.mag_filter = video_filter_method ? GL_LINEAR : GL_NEAREST;
@@ -1652,7 +1655,7 @@ OpenGLRenderer::render()
     }
 
     if (monitors[r_monitor_index].mon_screenshots) {
-        int width = destination.width() * devicePixelRatio(), height = destination.height() * devicePixelRatio();
+        int width = destination.width(), height = destination.height();
         char path[1024];
         char fn[256];
     

--- a/src/qt/qt_renderercommon.cpp
+++ b/src/qt/qt_renderercommon.cpp
@@ -59,6 +59,9 @@ RendererCommon::onResize(int width, int height)
     bool main_max = main_window->isMaximized();
     bool main_is_max = (main_is_ancestor && main_max == false);
 
+    width = round(pixelRatio * width);
+    height = round(pixelRatio * height);
+
     if (is_fs && (video_fullscreen_scale_maximized ? (parent_max && main_is_max) : 1))
         destination.setRect(0, 0, width, height);
     else {

--- a/src/qt/qt_renderercommon.hpp
+++ b/src/qt/qt_renderercommon.hpp
@@ -49,5 +49,7 @@ protected:
     QRect    destination;
     QWidget *parentWidget { nullptr };
 
+    double pixelRatio = 1.0;
+
     std::vector<std::atomic_flag> buf_usage;
 };

--- a/src/qt/qt_vulkanrenderer.cpp
+++ b/src/qt/qt_vulkanrenderer.cpp
@@ -970,17 +970,11 @@ VulkanRenderer2::startNextFrame()
     m_devFuncs->vkCmdBindVertexBuffers(cb, 0, 1, &m_buf, &vbOffset);
 
     VkViewport viewport;
-    if (dpi_scale) {
-        viewport.x        = destination.x() * m_window->devicePixelRatio();
-        viewport.y        = destination.y() * m_window->devicePixelRatio();
-        viewport.width    = destination.width() * m_window->devicePixelRatio();
-        viewport.height   = destination.height() * m_window->devicePixelRatio();
-    } else {
-        viewport.x        = destination.x();
-        viewport.y        = destination.y();
-        viewport.width    = destination.width();
-        viewport.height   = destination.height();
-    }
+    viewport.x        = destination.x();
+    viewport.y        = destination.y();
+    viewport.width    = destination.width();
+    viewport.height   = destination.height();
+    
     viewport.minDepth = 0;
     viewport.maxDepth = 1;
     m_devFuncs->vkCmdSetViewport(cb, 0, 1, &viewport);

--- a/src/qt/qt_vulkanwindowrenderer.cpp
+++ b/src/qt/qt_vulkanwindowrenderer.cpp
@@ -846,6 +846,7 @@ VulkanWindowRenderer::createRenderer()
 void
 VulkanWindowRenderer::resizeEvent(QResizeEvent *event)
 {
+    this->pixelRatio = devicePixelRatio();
     onResize(width(), height());
 
     QVulkanWindow::resizeEvent(event);
@@ -868,8 +869,10 @@ VulkanWindowRenderer::onBlit(int buf_idx, int x, int y, int w, int h)
     if (isExposed())
         requestUpdate();
     buf_usage[0].clear();
-    if (origSource != source)
+    if (origSource != source) {
+        this->pixelRatio = devicePixelRatio();
         onResize(this->width(), this->height());
+    }
 }
 
 uint32_t


### PR DESCRIPTION
Summary
=======
Qt: Fix HiDPI scaling on non-software renderers.

Checklist
=========
* [X] Closes #5411
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
