### PR TITLE
Mach64 ISA/VLB LFB update of the day (March 30th, 2025)

### DIFF
--- a/src/video/vid_ati_mach64.c
+++ b/src/video/vid_ati_mach64.c
@@ -3768,6 +3768,9 @@ mach64_ext_outb(uint16_t port, uint8_t val, void *priv)
         case 0x6aee:
         case 0x6aef:
             WRITE8(port, mach64->config_cntl, val);
+            if (!mach64->pci)
+                mach64->linear_base = (mach64->config_cntl & 0x3ff0) << 18;
+
             mach64_updatemapping(mach64);
             break;
 


### PR DESCRIPTION
Summary
=======
The LFB can now be enabled properly on the ISA/VLB variants of the Mach64GX.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
