### PR TITLE
Hardware Renderer: Make sure to account for devicePixelRatio when setting up the matrix

### DIFF
--- a/src/qt/qt_hardwarerenderer.cpp
+++ b/src/qt/qt_hardwarerenderer.cpp
@@ -145,7 +145,7 @@ HardwareRenderer::paintGL()
     QVector<QVector2D> texcoords;
     QMatrix4x4         mat;
     mat.setToIdentity();
-    mat.ortho(QRectF(0, 0, (qreal) width(), (qreal) height()));
+    mat.ortho(QRectF(0, 0, (qreal) width() * (qreal) devicePixelRatioF(), (qreal) height() * (qreal) devicePixelRatioF()));
     verts.push_back(QVector2D((float) destination.x(), (float) destination.y()));
     verts.push_back(QVector2D((float) destination.x(), (float) destination.y() + (float) destination.height()));
     verts.push_back(QVector2D((float) destination.x() + (float) destination.width(), (float) destination.y() + (float) destination.height()));


### PR DESCRIPTION
Summary
=======
Hardware Renderer: Make sure to account for devicePixelRatio when setting up the matrix

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
