### PR TITLE
Make sure that floppy icons and options do not appear if there's no floppy controller available

### DIFF
--- a/src/floppy/fdc.c
+++ b/src/floppy/fdc.c
@@ -79,6 +79,8 @@ int floppyrate[4];
 
 int fdc_current[FDC_MAX] = { 0, 0 };
 
+volatile int fdcinited = 0;
+
 #ifdef ENABLE_FDC_LOG
 int fdc_do_log = ENABLE_FDC_LOG;
 
@@ -2337,6 +2339,8 @@ fdc_close(void *priv)
 
     fifo_close(fdc->fifo_p);
 
+    fdcinited = 0;
+
     free(fdc);
 }
 
@@ -2381,6 +2385,8 @@ fdc_init(const device_t *info)
     mfm_set_fdc(fdc);
 
     fdc_reset(fdc);
+
+    fdcinited = 1;
 
     return fdc;
 }

--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -40,6 +40,8 @@ extern "C" {
 #include <86box/ui.h>
 #include <86box/machine_status.h>
 #include <86box/config.h>
+
+extern volatile int fdcinited;
 };
 
 #include <QIcon>
@@ -303,6 +305,9 @@ MachineStatus::hasSCSI()
 void
 MachineStatus::iterateFDD(const std::function<void(int)> &cb)
 {
+    if (!fdcinited)
+        return;
+
     for (int i = 0; i < FDD_NUM; ++i) {
         if (fdd_get_type(i) != 0) {
             cb(i);


### PR DESCRIPTION
Summary
=======
Make sure that floppy icons and options do not appear if there's no floppy controller available at all (either as part of the machine or as an external card).

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
