### PR TITLE
Trantor SCSI changes of the day (April 2nd, 2025)

### DIFF
--- a/src/include/86box/scsi_device.h
+++ b/src/include/86box/scsi_device.h
@@ -467,9 +467,10 @@ typedef struct scsi_bus_t {
     int                msgout_pos;
     int                is_msgout;
     int                state;
-    int                dma_on_pio_enabled;
 
     uint32_t           bus_phase;
+    uint32_t           total_len;
+    uint32_t           data_repeat;
 
     double             period;
     double             speed;

--- a/src/include/86box/scsi_t128.h
+++ b/src/include/86box/scsi_t128.h
@@ -30,7 +30,7 @@ typedef struct t128_t {
     uint8_t status;
     uint8_t buffer[512];
     uint8_t ext_ram[0x80];
-    uint8_t block_count;
+    uint32_t block_count;
 
     int block_loaded;
     int pos, host_pos;
@@ -39,6 +39,7 @@ typedef struct t128_t {
 
     int bios_enabled;
     uint8_t pos_regs[8];
+    int type;
 
     pc_timer_t timer;
 } t128_t;

--- a/src/sound/snd_pas16.c
+++ b/src/sound/snd_pas16.c
@@ -792,7 +792,14 @@ pas16_in(uint16_t port, void *priv)
                 if ((scsi_bus->tx_mode == PIO_TX_BUS) && !(ret & 0x80))
                     ret |= 0x80;
 
-                pas16_log("5C01 read ret=%02x, status=%02x, txmode=%x.\n", ret, pas16->scsi->status & 0x06, scsi_bus->tx_mode);
+                if (ret & 0x80) {
+                    if (scsi_bus->data_repeat < MIN(511, scsi_bus->total_len))
+                        scsi_bus->data_repeat++;
+                } else {
+                    if (scsi_bus->data_repeat == MIN(511, scsi_bus->total_len))
+                        ret = 0x00;
+                }
+                pas16_log("%04X:%08X: Port %04x read ret=%02x, status=%02x, txmode=%x, repeat=%d.\n", CS, cpu_state.pc, port + pas16->base, ret, pas16->scsi->status & 0x06, scsi_bus->tx_mode, scsi_bus->data_repeat);
             }
             break;
         case 0x5c03:


### PR DESCRIPTION
Summary
=======
1. The PAS SCSI controller driver mamv1.sys dislikes having bits 0-6 set when a transfer has completed, take account from this, fixes mamv1.sys incomplete CD transfers (bits 0-6 get re-enabled when the transfer is ongoing).
2. I now understand why the T128 doesn't have a block count register, it does the block count manually from the SCSI layer directly, this fixes Pseudo-DMA transfers when using, e.g.: CD transfers using a sector size of 2340 bytes.


Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
