### PR TITLE
SAASound filter fixes

### DIFF
--- a/src/sound/saasound/SAAImpl.cpp
+++ b/src/sound/saasound/SAAImpl.cpp
@@ -306,7 +306,6 @@ void scale_for_output(unsigned int left_input, unsigned int right_input,
 void CSAASoundInternal::GenerateMany(BYTE* pBuffer, unsigned long nSamples)
 {
 	unsigned int left_mixed, right_mixed;
-	static double filterout_z1_left_mixed = 0, filterout_z1_right_mixed = 0;
 
 #if defined(DEBUGSAA) || defined(USE_CONFIG_FILE)
 	BYTE* pBufferStart = pBuffer;

--- a/src/sound/saasound/SAAImpl.h
+++ b/src/sound/saasound/SAAImpl.h
@@ -36,6 +36,8 @@ private:
 	unsigned int m_nSampleRate;
 	unsigned int m_nOversample;
 	bool m_bHighpass;
+	double filterout_z1_left_mixed = 0;
+	double filterout_z1_right_mixed = 0;
 #ifdef USE_CONFIG_FILE
 	SAAConfig m_Config;
 #endif


### PR DESCRIPTION
Summary
=======
SAASound filter variables is now properly per-class, eliminating some glitches.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
