### PR TITLE
Make Qt shortcuts actually work in fullscreen

### DIFF
--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -194,8 +194,6 @@ win_keyboard_handle(uint32_t scancode, int up, int e0, int e1)
            it's not an invalid scan code. */
         if (scancode != 0xFFFF)
             keyboard_input(!up, scancode);
-
-        main_window->checkFullscreenHotkey();
     }
 }
 
@@ -369,8 +367,6 @@ emu_LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
         ret = TRUE;
     else if ((lpKdhs->scanCode == 0x3e) && (lpKdhs->flags & LLKHF_ALTDOWN) &&
              !(lpKdhs->flags & (LLKHF_UP | LLKHF_EXTENDED)))
-        ret = TRUE;
-    else if ((lpKdhs->scanCode == 0x49) && bCtrlDown && !(lpKdhs->flags & LLKHF_UP))
         ret = TRUE;
     else if ((lpKdhs->scanCode >= 0x5b) && (lpKdhs->scanCode <= 0x5d) && (lpKdhs->flags & LLKHF_EXTENDED))
         ret = TRUE;

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -31,7 +31,6 @@ public:
     void  blitToWidget(int x, int y, int w, int h, int monitor_index);
     QSize getRenderWidgetSize();
     void  setSendKeyboardInput(bool enabled);
-    void  checkFullscreenHotkey();
     void  reloadAllRenderers();
 
     std::array<std::unique_ptr<RendererStack>, 8> renderers;


### PR DESCRIPTION
Summary
=======
Make Qt shortcuts actually work in fullscreen

Also removes hacks related to fullscreen.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
