### PR TITLE
Bochs SVGA: Buffer window switching now works properly

### DIFF
--- a/src/video/vid_bochs_vbe.c
+++ b/src/video/vid_bochs_vbe.c
@@ -338,20 +338,13 @@ bochs_vbe_recalctimings(svga_t* svga)
             svga->rowoffset = (dev->vbe_regs[VBE_DISPI_INDEX_VIRT_WIDTH] / 2) >> 3;
             svga->ma_latch  = (dev->vbe_regs[VBE_DISPI_INDEX_Y_OFFSET] * svga->rowoffset) +
                               (dev->vbe_regs[VBE_DISPI_INDEX_X_OFFSET] >> 3);
+
+            svga->fullchange = 3;
         } else {
             svga->rowoffset = dev->vbe_regs[VBE_DISPI_INDEX_VIRT_WIDTH] * ((svga->bpp == 15) ? 2 : (svga->bpp / 8));
             svga->ma_latch = (dev->vbe_regs[VBE_DISPI_INDEX_Y_OFFSET] * svga->rowoffset) +
-                             (dev->vbe_regs[VBE_DISPI_INDEX_X_OFFSET] * ((svga->bpp == 15) ? 2 : (svga->bpp / 8)));            
-        }
-        if (svga->ma_latch != dev->ma_latch_old) {
-            if (svga->bpp == 4) {
-                svga->maback = (svga->maback - (dev->ma_latch_old << 2)) +
-                               (svga->ma_latch << 2);
-            } else {
-                svga->maback = (svga->maback - (dev->ma_latch_old)) +
-                                (svga->ma_latch);
-                dev->ma_latch_old = svga->ma_latch;
-            }
+                             (dev->vbe_regs[VBE_DISPI_INDEX_X_OFFSET] * ((svga->bpp == 15) ? 2 : (svga->bpp / 8)));
+            svga->fullchange = 3;     
         }
 
         if (svga->bpp == 4)
@@ -482,18 +475,10 @@ bochs_vbe_outw(const uint16_t addr, const uint16_t val, void *priv)
                 } else {
                     svga->rowoffset = dev->vbe_regs[VBE_DISPI_INDEX_VIRT_WIDTH] * ((svga->bpp == 15) ? 2 : (svga->bpp / 8));
                     svga->ma_latch = (dev->vbe_regs[VBE_DISPI_INDEX_Y_OFFSET] * svga->rowoffset) +
-                                    (dev->vbe_regs[VBE_DISPI_INDEX_X_OFFSET] * ((svga->bpp == 15) ? 2 : (svga->bpp / 8)));            
+                                    (dev->vbe_regs[VBE_DISPI_INDEX_X_OFFSET] * ((svga->bpp == 15) ? 2 : (svga->bpp / 8)));
                 }
-                if (svga->ma_latch != dev->ma_latch_old) {
-                    if (svga->bpp == 4) {
-                        svga->maback = (svga->maback - (dev->ma_latch_old << 2)) +
-                                    (svga->ma_latch << 2);
-                    } else {
-                        svga->maback = (svga->maback - (dev->ma_latch_old)) +
-                                        (svga->ma_latch);
-                        dev->ma_latch_old = svga->ma_latch;
-                    }
-                }
+
+                svga->fullchange = 3;
             }
             else
                 svga_recalctimings(&dev->svga);


### PR DESCRIPTION
Summary
=======
Bochs SVGA: Buffer window switching now works properly.

Fixes Duke Nukem 3D display being glitchy.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
