### PR TITLE
Revert a minor commit from Spock. (April 7th, 2025)

### DIFF
--- a/src/scsi/scsi_spock.c
+++ b/src/scsi/scsi_spock.c
@@ -1050,7 +1050,7 @@ spock_callback(void *priv)
             spock_execute_cmd(scsi, scb);
     }
 
-    if (scsi->attention_wait) {
+    if (scsi->attention_wait && ((scsi->scb_state == 0) || (scsi->attention_pending & 0xf0) == 0xe0)) {
         scsi->attention_wait--;
         if (!scsi->attention_wait) {
             scsi->attention = scsi->attention_pending;


### PR DESCRIPTION
Summary
=======
This fixes OS/2 Warp on a PS/2 machine using the Spock/Tribble during the file copy phase (the bug was probably too many IRQ's being fired).


Checklist
=========
* [x] Closes #5444 
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
