### PR TITLE
VIA Cyrix III (Samuel) - add codename

### DIFF
--- a/src/cpu/cpu_table.c
+++ b/src/cpu/cpu_table.c
@@ -7793,7 +7793,7 @@ const cpu_family_t cpu_families[] = {
     {
         .package       = CPU_PKG_SOCKET370,
         .manufacturer  = "VIA",
-        .name          = "Cyrix III",
+        .name          = "Cyrix III (Samuel)",
         .internal_name = "c3_samuel",
         .cpus          = (const CPU[]) {
             { /* out of multiplier range */


### PR DESCRIPTION
To distinguish from Cyrix-heritage Joshua CPUs. 

Summary
=======
added "(Samuel)" to the name Cyrix III.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
- #5451
