### PR TITLE
Microtouch touch points now work properly in fullscreen/maximized with scaling modes

### DIFF
--- a/src/qt/qt_renderercommon.cpp
+++ b/src/qt/qt_renderercommon.cpp
@@ -132,6 +132,9 @@ RendererCommon::onResize(int width, int height)
 
     monitors[r_monitor_index].mon_res_x = (double) destination.width();
     monitors[r_monitor_index].mon_res_y = (double) destination.height();
+
+    destinationF.setRect((double)destination.x() / (double)width, (double)destination.y() / (double)height,
+                        (double)destination.width() / (double)width, (double)destination.height() / (double)height);
 }
 
 bool

--- a/src/qt/qt_renderercommon.hpp
+++ b/src/qt/qt_renderercommon.hpp
@@ -4,6 +4,7 @@
 #include <QEvent>
 #include <QImage>
 #include <QRect>
+#include <QRectF>
 #include <QWidget>
 
 #include <atomic>
@@ -40,6 +41,7 @@ public:
     virtual bool rendererTakeScreenshot() { return false; }
 
     int      r_monitor_index = 0;
+    QRectF   destinationF = QRectF(0, 0, 1, 1); /* normalized to 0.0-1.0 range. */
 
 protected:
     bool     eventDelegate(QEvent *event, bool &result);

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -488,6 +488,17 @@ RendererStack::event(QEvent* event)
                 mouse_y_abs       = (mouse_event->localPos().y()) / (double)height();
                 if (!mouse_tablet_in_proximity)
                     mouse_tablet_in_proximity = mousedata.mouse_tablet_in_proximity;
+                mouse_x_abs -= rendererWindow->destinationF.left();
+                mouse_y_abs -= rendererWindow->destinationF.top();
+
+                if (mouse_x_abs < 0) mouse_x_abs = 0;
+                if (mouse_y_abs < 0) mouse_y_abs = 0;
+
+                mouse_x_abs /= rendererWindow->destinationF.width();
+                mouse_y_abs /= rendererWindow->destinationF.height();
+
+                if (mouse_x_abs > 1) mouse_x_abs = 1;
+                if (mouse_y_abs > 1) mouse_y_abs = 1;
             }
             return QStackedWidget::event(event);
         }
@@ -496,12 +507,34 @@ RendererStack::event(QEvent* event)
         if (mouse_input_mode == 0) {
             mouse_x_abs           = (mouse_event->localPos().x()) / (double)width();
             mouse_y_abs           = (mouse_event->localPos().y()) / (double)height();
+            mouse_x_abs          -= rendererWindow->destinationF.left();
+            mouse_y_abs          -= rendererWindow->destinationF.top();
+
+            if (mouse_x_abs < 0) mouse_x_abs = 0;
+            if (mouse_y_abs < 0) mouse_y_abs = 0;
+
+            mouse_x_abs /= rendererWindow->destinationF.width();
+            mouse_y_abs /= rendererWindow->destinationF.height();
+
+            if (mouse_x_abs > 1) mouse_x_abs = 1;
+            if (mouse_y_abs > 1) mouse_y_abs = 1;
             return QStackedWidget::event(event);
         }
 #endif
 
         mouse_x_abs               = (mouse_event->localPos().x()) / (double)width();
         mouse_y_abs               = (mouse_event->localPos().y()) / (double)height();
+        mouse_x_abs              -= rendererWindow->destinationF.left();
+        mouse_y_abs              -= rendererWindow->destinationF.top();
+
+        if (mouse_x_abs < 0) mouse_x_abs = 0;
+        if (mouse_y_abs < 0) mouse_y_abs = 0;
+
+        mouse_x_abs /= rendererWindow->destinationF.width();
+        mouse_y_abs /= rendererWindow->destinationF.height();
+
+        if (mouse_x_abs > 1) mouse_x_abs = 1;
+        if (mouse_y_abs > 1) mouse_y_abs = 1;
         mouse_tablet_in_proximity = mousedata.mouse_tablet_in_proximity;
     } else switch (event->type()) {
         case QEvent::TouchBegin:
@@ -511,8 +544,19 @@ RendererStack::event(QEvent* event)
             QTouchEvent* touchevent = (QTouchEvent*)event;
             if (mouse_input_mode == 0) break;
             if (touchevent->touchPoints().count()) {
-                mouse_x_abs = (touchevent->touchPoints()[0].pos().x()) / (double)width();
-                mouse_y_abs = (touchevent->touchPoints()[0].pos().y()) / (double)height();
+                mouse_x_abs  = (touchevent->touchPoints()[0].pos().x()) / (double)width();
+                mouse_y_abs  = (touchevent->touchPoints()[0].pos().y()) / (double)height();
+                mouse_x_abs -= rendererWindow->destinationF.left();
+                mouse_y_abs -= rendererWindow->destinationF.top();
+        
+                if (mouse_x_abs < 0) mouse_x_abs = 0;
+                if (mouse_y_abs < 0) mouse_y_abs = 0;
+        
+                mouse_x_abs /= rendererWindow->destinationF.width();
+                mouse_y_abs /= rendererWindow->destinationF.height();
+
+                if (mouse_x_abs > 1) mouse_x_abs = 1;
+                if (mouse_y_abs > 1) mouse_y_abs = 1;
             }
             mouse_set_buttons_ex(mouse_get_buttons_ex() | 1);
             touchevent->accept();
@@ -521,8 +565,19 @@ RendererStack::event(QEvent* event)
             QTouchEvent* touchevent = (QTouchEvent*)event;
             if (mouse_input_mode == 0) break;
             if (touchevent->pointCount()) {
-                mouse_x_abs = (touchevent->point(0).position().x()) / (double)width();
-                mouse_y_abs = (touchevent->point(0).position().y()) / (double)height();
+                mouse_x_abs  = (touchevent->point(0).position().x()) / (double)width();
+                mouse_y_abs  = (touchevent->point(0).position().y()) / (double)height();
+                mouse_x_abs -= rendererWindow->destinationF.left();
+                mouse_y_abs -= rendererWindow->destinationF.top();
+        
+                if (mouse_x_abs < 0) mouse_x_abs = 0;
+                if (mouse_y_abs < 0) mouse_y_abs = 0;
+        
+                mouse_x_abs /= rendererWindow->destinationF.width();
+                mouse_y_abs /= rendererWindow->destinationF.height();
+
+                if (mouse_x_abs > 1) mouse_x_abs = 1;
+                if (mouse_y_abs > 1) mouse_y_abs = 1;
             }
             mouse_set_buttons_ex(mouse_get_buttons_ex() | 1);
             touchevent->accept();
@@ -538,6 +593,17 @@ RendererStack::event(QEvent* event)
             if (touchevent->touchPoints().count()) {
                 mouse_x_abs = (touchevent->touchPoints()[0].pos().x()) / (double)width();
                 mouse_y_abs = (touchevent->touchPoints()[0].pos().y()) / (double)height();
+                mouse_x_abs              -= rendererWindow->destinationF.left();
+                mouse_y_abs              -= rendererWindow->destinationF.top();
+        
+                if (mouse_x_abs < 0) mouse_x_abs = 0;
+                if (mouse_y_abs < 0) mouse_y_abs = 0;
+        
+                mouse_x_abs /= rendererWindow->destinationF.width();
+                mouse_y_abs /= rendererWindow->destinationF.height();
+
+                if (mouse_x_abs > 1) mouse_x_abs = 1;
+                if (mouse_y_abs > 1) mouse_y_abs = 1;
             }
             mouse_set_buttons_ex(mouse_get_buttons_ex() & ~1);
             touchevent->accept();
@@ -548,6 +614,17 @@ RendererStack::event(QEvent* event)
             if (touchevent->pointCount()) {
                 mouse_x_abs = (touchevent->point(0).position().x()) / (double)width();
                 mouse_y_abs = (touchevent->point(0).position().y()) / (double)height();
+                mouse_x_abs              -= rendererWindow->destinationF.left();
+                mouse_y_abs              -= rendererWindow->destinationF.top();
+        
+                if (mouse_x_abs < 0) mouse_x_abs = 0;
+                if (mouse_y_abs < 0) mouse_y_abs = 0;
+        
+                mouse_x_abs /= rendererWindow->destinationF.width();
+                mouse_y_abs /= rendererWindow->destinationF.height();
+
+                if (mouse_x_abs > 1) mouse_x_abs = 1;
+                if (mouse_y_abs > 1) mouse_y_abs = 1;
             }
             mouse_set_buttons_ex(mouse_get_buttons_ex() & ~1);
             touchevent->accept();


### PR DESCRIPTION
Summary
=======
When using the Microtouch, if the scaling modes are active, the touch points will now properly scale to those instead of always assuming the default strecth-to-entire-screen mode is active.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
