### PR TITLE
PAS16/Plus change of the day (April 15th, 2025)

### DIFF
--- a/src/sound/snd_pas16.c
+++ b/src/sound/snd_pas16.c
@@ -1756,7 +1756,7 @@ static uint16_t
 pas16_readdmaw_stereo(pas16_t *pas16)
 {
     uint16_t ret;
-    uint16_t ticks = (pas16->sys_conf_1 & 0x02) ? (1 + (pas16->dma < 5)) : 2;
+    uint16_t ticks = (pas16->sys_conf_1 & 0x02) ? (1 + (pas16->dma < 5)) : 1;
 
     ret = pas16_dma_readw(pas16, ticks);
 


### PR DESCRIPTION
Summary
=======
Actually make the DMA transfer speed normal in when in 16-bit stereo mode with System Configuration 1 bit 1 (Master Clock) cleared. Fixes audio being too quick with said configuration.

Checklist
=========
* [x] Closes #5466
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
