### PR TITLE
Disable OpenGL 3.x logs

### DIFF
--- a/src/qt/qt_openglrenderer.cpp
+++ b/src/qt/qt_openglrenderer.cpp
@@ -145,6 +145,24 @@ const char* fragment_shader_default_color_src =
         "       outColor.a = 1.0;\n"
         "}\n";
 
+#ifdef ENABLE_OGL3_LOG
+int ogl3_do_log = ENABLE_OGL3_LOG;
+
+static void
+ogl3_log(const char *fmt, ...)
+{
+    va_list ap;
+
+    if (ogl3_do_log) {
+        va_start(ap, fmt);
+        ogl3_log_ex(fmt, ap);
+        va_end(ap);
+    }
+}
+#else
+#    define ogl3_log(fmt, ...)
+#endif
+
 static inline int
 next_pow2(unsigned int n)
 {
@@ -232,8 +250,8 @@ OpenGLRenderer::compile_shader(GLenum shader_type, const char *prepend, const ch
         main_window->showMessage(MBX_ERROR | MBX_FATAL, tr("GLSL Error"), tr("Could not compile shader:\n\n%1").arg(log).replace("\n", "<br>"));
         // wx_simple_messagebox("GLSL Error", "Could not compile shader:\n%s", log);
 
-        pclog("Could not compile shader: %s\n", log);
-        //                pclog("Shader: %s\n", program);
+        ogl3_log("Could not compile shader: %s\n", log);
+        //                ogl3_log("Shader: %s\n", program);
 
         free(log);
         return 0;
@@ -348,7 +366,7 @@ OpenGLRenderer::create_texture(struct shader_texture *tex)
         tex->width = max_texture_size;
     if (tex->height > max_texture_size)
         tex->height = max_texture_size;
-    pclog("Create texture with size %dx%d\n", tex->width, tex->height);
+    ogl3_log("Create texture with size %dx%d\n", tex->width, tex->height);
     glw.glGenTextures(1, (GLuint *) &tex->id);
     glw.glBindTexture(GL_TEXTURE_2D, tex->id);
     glw.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, tex->wrap_mode);
@@ -452,7 +470,7 @@ OpenGLRenderer::create_fbo(struct shader_fbo *fbo)
     glw.glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, fbo->texture.id, 0);
 
     if (glw.glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
-        pclog("Could not create framebuffer!\n");
+        ogl3_log("Could not create framebuffer!\n");
 
     glw.glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
@@ -629,12 +647,12 @@ OpenGLRenderer::load_glslp(glsl_t *glsl, int num_shader, const char *f)
             struct shader_lut_texture *tex = &gshader->lut_textures[i];
             strcpy(tex->name, texture->name);
 
-            pclog("Load texture %s...\n", file);
+            ogl3_log("Load texture %s...\n", file);
 
             if (!load_texture(file, &tex->texture)) {
                 //QMessageBox::critical(main_window, tr("GLSL Error"), tr("Could not load texture: %s").arg(file));
                 main_window->showMessage(MBX_ERROR | MBX_FATAL, tr("GLSL Error"), tr("Could not load texture: %1").arg(file));
-                pclog("Could not load texture %s!\n", file);
+                ogl3_log("Could not load texture %s!\n", file);
                 failed = 1;
                 break;
             }
@@ -676,16 +694,16 @@ OpenGLRenderer::load_glslp(glsl_t *glsl, int num_shader, const char *f)
                 if (!strlen(pass->alias))
                     sprintf(pass->alias, "Pass %u", (i + 1));
 
-                pclog("Creating pass %u (%s)\n", (i + 1), pass->alias);
-                pclog("Loading shader %s...\n", shader->shader_fn);
+                ogl3_log("Creating pass %u (%s)\n", (i + 1), pass->alias);
+                ogl3_log("Loading shader %s...\n", shader->shader_fn);
                 if (!shader->shader_program) {
                     main_window->showMessage(MBX_ERROR | MBX_FATAL, tr("GLSL Error"), tr("Could not load shader: %1").arg(shader->shader_fn));
                     // wx_simple_messagebox("GLSL Error", "Could not load shader: %s", shader->shader_fn);
-                    pclog("Could not load shader %s\n", shader->shader_fn);
+                    ogl3_log("Could not load shader %s\n", shader->shader_fn);
                     failed = 1;
                     break;
                 } else
-                    pclog("Shader %s loaded\n", shader->shader_fn);
+                    ogl3_log("Shader %s loaded\n", shader->shader_fn);
                 failed = !compile_shader(GL_VERTEX_SHADER, "#define VERTEX\n#define PARAMETER_UNIFORM\n",
                                          shader->shader_program, &pass->program.vertex_shader)
                     || !compile_shader(GL_FRAGMENT_SHADER, "#define FRAGMENT\n#define PARAMETER_UNIFORM\n",
@@ -856,15 +874,15 @@ OpenGLRenderer::initialize()
 
         glw.initializeOpenGLFunctions();
 
-        pclog("OpenGL information: [%s] %s (%s)\n", glw.glGetString(GL_VENDOR), glw.glGetString(GL_RENDERER), glw.glGetString(GL_VERSION));
+        ogl3_log("OpenGL information: [%s] %s (%s)\n", glw.glGetString(GL_VENDOR), glw.glGetString(GL_RENDERER), glw.glGetString(GL_VERSION));
         glsl_version[0] = glsl_version[1] = -1;
         glw.glGetIntegerv(GL_MAJOR_VERSION, &glsl_version[0]);
         glw.glGetIntegerv(GL_MINOR_VERSION, &glsl_version[1]);
         if (glsl_version[0] < 3) {
             throw opengl_init_error(tr("OpenGL version 3.0 or greater is required. Current GLSL version is %1.%2").arg(glsl_version[0]).arg(glsl_version[1]));
         }
-        pclog("Using OpenGL %s\n", glw.glGetString(GL_VERSION));
-        pclog("Using Shading Language %s\n", glw.glGetString(GL_SHADING_LANGUAGE_VERSION));
+        ogl3_log("Using OpenGL %s\n", glw.glGetString(GL_VERSION));
+        ogl3_log("Using Shading Language %s\n", glw.glGetString(GL_SHADING_LANGUAGE_VERSION));
 
         glslVersion = reinterpret_cast<const char *>(glw.glGetString(GL_SHADING_LANGUAGE_VERSION));
         glslVersion.truncate(4);
@@ -876,7 +894,7 @@ OpenGLRenderer::initialize()
             glslVersion.append(" core");
 
         glw.glGetIntegerv(GL_MAX_TEXTURE_SIZE, &max_texture_size);
-        pclog("Max texture size: %dx%d\n", max_texture_size, max_texture_size);
+        ogl3_log("Max texture size: %dx%d\n", max_texture_size, max_texture_size);
 
         glw.glEnable(GL_TEXTURE_2D);
 
@@ -1218,7 +1236,7 @@ OpenGLRenderer::render_pass(struct render_data *data)
     int    i;
     GLuint texture_unit = 0;
 
-    //        pclog("pass %d: %gx%g, %gx%g -> %gx%g, %gx%g, %gx%g\n", num_pass, pass->state.input_size[0],
+    //        ogl3_log("pass %d: %gx%g, %gx%g -> %gx%g, %gx%g, %gx%g\n", num_pass, pass->state.input_size[0],
     //        pass->state.input_size[1], pass->state.input_texture_size[0], pass->state.input_texture_size[1],
     //        pass->state.output_size[0], pass->state.output_size[1], pass->state.output_texture_size[0],
     //        pass->state.output_texture_size[1], output_size[0], output_size[1]);


### PR DESCRIPTION
Summary
=======
Disable OpenGL 3.x logs from the renderer.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
