### PR TITLE
win_dynld: use LoadLibraryA specifically

### DIFF
--- a/src/qt/win_dynld.c
+++ b/src/qt/win_dynld.c
@@ -51,7 +51,7 @@ dynld_module(const char *name, dllimp_t *table)
     void     *func;
 
     /* See if we can load the desired module. */
-    if ((h = LoadLibrary(name)) == NULL) {
+    if ((h = LoadLibraryA(name)) == NULL) {
         dynld_log("DynLd(\"%s\"): library not found! (%08X)\n", name, GetLastError());
         return (NULL);
     }


### PR DESCRIPTION
Summary
=======
We usually specify `UNICODE`, but since `dynld_module` requires a `const char *`, let's use the ANSI `LoadLibraryA` function specifically. This way we avoid a type mismatch error.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
