### PR TITLE
Replaced hardcoded uncapture sequence with cfg directive and clarifie…

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -654,7 +654,7 @@ usage:
 #ifdef USE_INSTRUMENT
             printf("-J or --instrument name - set 'name' to be the profiling instrument\n");
 #endif
-            printf("-K or --keycodes codes  - set 'codes' to be the uncapture combination\n");
+            printf("-K or --keycodes codes  - set the uncapture combination (leave codes blank for instructions)\n");
             printf("-L or --logfile path    - set 'path' to be the logfile\n");
             printf("-M or --missing         - dump missing machines and video cards\n");
             printf("-N or --noconfirm       - do not ask for confirmation on quit\n");
@@ -728,7 +728,7 @@ usage:
             temp2 = NULL;
         } else if (!strcasecmp(argv[c], "--vmname") || !strcasecmp(argv[c], "-V")) {
             if ((c + 1) == argc)
-                goto usage;
+				goto usage;
 
             strcpy(vm_name, argv[++c]);
 #ifndef USE_SDL_UI
@@ -747,11 +747,17 @@ usage:
             hook_enabled = 0;
         } else if (!strcasecmp(argv[c], "--keycodes") || !strcasecmp(argv[c], "-K")) {
             if ((c + 1) == argc)
-                goto usage;
-
-            sscanf(argv[++c], "%03hX,%03hX,%03hX,%03hX,%03hX,%03hX",
-                   &key_prefix_1_1, &key_prefix_1_2, &key_prefix_2_1, &key_prefix_2_2,
-                   &key_uncapture_1, &key_uncapture_2);
+			{
+				// user didn't enter keycodes; print usage and exit.
+                printf("Enter codes in the format 0xNNN,0xNNN\n");
+				printf("Each value is a keyboard scancode in hexadecimal format.\n\n");
+				printf("\tFor F8+F12: --keycodes 0x042,0x058\n\n");
+				printf("Special keys are often shifted, adding 0x100. This includes Ctrl.\n\n");
+				printf("\tFor Ctrl+End: --keycodes 0x01d,0x14f\n\n");
+				return 0; // exit
+			}
+			
+            sscanf(argv[++c], "0x%03hX,0x%03hX", &key_uncapture_1_1, &key_uncapture_1_2);
         } else if (!strcasecmp(argv[c], "--clearboth") || !strcasecmp(argv[c], "-X")) {
             if ((c + 1) == argc)
                 goto usage;

--- a/src/config.c
+++ b/src/config.c
@@ -182,6 +182,31 @@ load_general(void)
     confirm_exit  = ini_section_get_int(cat, "confirm_exit", 1);
     confirm_save  = ini_section_get_int(cat, "confirm_save", 1);
 
+	p = ini_section_get_string(cat, "escape_combo", NULL);
+	if (p == NULL) p = "f8_f12";
+	// If the keys are already defined, it means the user passed
+	// --keycodes, so don't override.
+	if (key_uncapture_1_1 == 0x000) {
+		// Check if escape_combo can be parsed as a pair of scancodes
+		if(sscanf(p, "0x%03hX,0x%03hX", &key_uncapture_1_1, &key_uncapture_1_2) == 2)
+		{
+			// Yep. Parse it again and this time update the capture codes.
+			sscanf(p, "0x%03hX,0x%03hX", &key_uncapture_1_1, &key_uncapture_1_2);
+		}
+		else if(!stricmp(p, "ctrl_end"))
+		{
+			// User chose the ctrl_end shorthand.
+			key_uncapture_1_1 = 0x01d;
+			key_uncapture_1_2 = 0x14f;
+		}
+		else
+		{
+			// Default; F8+F12
+			key_uncapture_1_1 = 0x042;
+			key_uncapture_1_2 = 0x058;
+		}
+	}
+
     p = ini_section_get_string(cat, "language", NULL);
     if (p != NULL)
         lang_id = plat_language_code(p);

--- a/src/device/keyboard.c
+++ b/src/device/keyboard.c
@@ -36,13 +36,9 @@ uint16_t     scancode_map[768] = { 0 };
 
 int          keyboard_scan;
 
-/* F8+F12 */
-uint16_t key_prefix_1_1 = 0x042;     /* F8 */
-uint16_t key_prefix_1_2 = 0x000;     /* Invalid */
-uint16_t key_prefix_2_1 = 0x000;     /* Invalid */
-uint16_t key_prefix_2_2 = 0x000;     /* Invalid */
-uint16_t key_uncapture_1 = 0x058;    /* F12 */
-uint16_t key_uncapture_2 = 0x000;    /* Invalid */
+/* "Uncapture mouse" key combos (defined from config, overriden by --keycodes) */
+uint16_t key_uncapture_1_1 = 0x000;
+uint16_t key_uncapture_1_2 = 0x000;
 
 #ifdef ENABLE_KBC_AT_LOG
 int kbc_at_do_log = ENABLE_KBC_AT_LOG;
@@ -485,13 +481,7 @@ keyboard_isfsexit_up(void)
 int
 keyboard_ismsexit(void)
 {
-    if ((key_prefix_2_1 != 0x000) || (key_prefix_2_2 != 0x000))
-        return ((recv_key_ui[key_prefix_1_1] || recv_key_ui[key_prefix_1_2]) &&
-                (recv_key_ui[key_prefix_2_1] || recv_key_ui[key_prefix_2_2]) &&
-                (recv_key_ui[key_uncapture_1] || recv_key_ui[key_uncapture_2]));
-    else
-        return ((recv_key_ui[key_prefix_1_1] || recv_key_ui[key_prefix_1_2]) &&
-                (recv_key_ui[key_uncapture_1] || recv_key_ui[key_uncapture_2]));
+	return (recv_key_ui[key_uncapture_1_1] && recv_key_ui[key_uncapture_1_2]);
 }
 
 /* This is so we can disambiguate scan codes that would otherwise conflict and get

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -172,13 +172,9 @@ extern int    pit_mode;                     /* (C) force setting PIT mode */
 extern int    fm_driver;                    /* (C) select FM sound driver */
 extern int    hook_enabled;                 /* (C) Keyboard hook is enabled */
 
-/* Keyboard variables for future key combination redefinition. */
-extern uint16_t key_prefix_1_1;
-extern uint16_t key_prefix_1_2;
-extern uint16_t key_prefix_2_1;
-extern uint16_t key_prefix_2_2;
-extern uint16_t key_uncapture_1;
-extern uint16_t key_uncapture_2;
+/* Keyboard variables for mouse release combo. */
+extern uint16_t key_uncapture_1_1;
+extern uint16_t key_uncapture_1_2;
 
 extern char exe_path[2048];     /* path (dir) of executable */
 extern char usr_path[1024];     /* path (dir) of user data */

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -354,7 +354,44 @@ MainWindow::MainWindow(QWidget *parent)
     ui->actionUpdate_status_bar_icons->setChecked(update_icons);
     ui->actionEnable_Discord_integration->setChecked(enable_discord);
     ui->actionApply_fullscreen_stretch_mode_when_maximized->setChecked(video_fullscreen_scale_maximized);
+	
+	auto actGroup = new QActionGroup(this);
+    actGroup->addAction(ui->actionRelease_F8_F12);
+    actGroup->addAction(ui->actionRelease_Ctrl_End);	
+	actGroup->setExclusive(true);
+    connect(actGroup, &QActionGroup::triggered, [this](QAction *action) {
+        if (action->property("release_combo").toInt() == 1)
+		{
+			// User chose the ctrl_end shorthand.
+			key_uncapture_1_1 = 0x01d;
+			key_uncapture_1_2 = 0x14f;
+		}
+		else
+		{
+			// Default; F8+F12
+			key_uncapture_1_1 = 0x042;
+			key_uncapture_1_2 = 0x058;
+		}
+	});
 
+	// Set mouse capture combo menu option
+	if (key_uncapture_1_1 == 0x042 && key_uncapture_1_2 == 0x058)
+	{
+		// F8+F12
+		ui->actionRelease_F8_F12->setChecked(true);
+		emit actGroup->triggered(ui->actionRelease_F8_F12);
+	} else if (key_uncapture_1_1 == 0x01d && key_uncapture_1_2 == 0x14f) {
+		// Ctrl+End
+		ui->actionRelease_Ctrl_End->setChecked(true);
+		emit actGroup->triggered(ui->actionRelease_Ctrl_End);
+	} else {
+		// Disable menu
+		ui->menuCombo->setEnabled(false);
+		ui->menuCombo->setTitle("Mouse release key (overridden)");
+	}
+
+	
+	
 #ifndef DISCORD
     ui->actionEnable_Discord_integration->setVisible(false);
 #else
@@ -408,7 +445,7 @@ MainWindow::MainWindow(QWidget *parent)
         ui->actionVulkan->setVisible(false);
     }
 
-    auto actGroup = new QActionGroup(this);
+	actGroup = new QActionGroup(this);
     actGroup->addAction(ui->actionSoftware_Renderer);
     actGroup->addAction(ui->actionHardware_Renderer_OpenGL);
     actGroup->addAction(ui->actionHardware_Renderer_OpenGL_ES);

--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -72,6 +72,14 @@
     <addaction name="separator"/>
     <addaction name="actionKeyboard_requires_capture"/>
     <addaction name="actionRight_CTRL_is_left_ALT"/>
+	<widget class="QMenu" name="menuCombo">
+     <property name="title">
+      <string>Mouse release key</string>
+     </property>
+     <addaction name="actionRelease_F8_F12"/>
+     <addaction name="actionRelease_Ctrl_End"/>
+    </widget>
+	<addaction name="menuCombo"/>
     <addaction name="menuTablet_tool"/>
     <addaction name="separator"/>
     <addaction name="actionPause"/>
@@ -410,6 +418,30 @@
     <number>1</number>
    </property>
   </action>
+  
+   <action name="actionRelease_F8_F12">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>F8 + F12</string>
+   </property>
+   <property name="release_combo" stdset="0">
+    <number>0</number>
+   </property>
+  </action>
+    <action name="actionRelease_Ctrl_End">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Ctrl + End</string>
+   </property>
+   <property name="release_combo" stdset="0">
+    <number>1</number>
+   </property>
+  </action>
+  
   <action name="actionHardware_Renderer_OpenGL_ES">
    <property name="checkable">
     <bool>true</bool>

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -571,7 +571,7 @@ c16stombs(char dst[], const uint16_t src[], int len)
 }
 #endif
 
-#    define MOUSE_CAPTURE_KEYSEQ "F8+F12"
+QString MOUSE_CAPTURE_KEYSEQ;
 
 #ifdef _WIN32
 #    if defined(__amd64__) || defined(_M_X64) || defined(__aarch64__) || defined(_M_ARM64)
@@ -595,9 +595,21 @@ ProgSettings::reloadStrings()
 {
     translatedstrings.clear();
     translatedstrings[STRING_MOUSE_CAPTURE]             = QCoreApplication::translate("", "Click to capture mouse").toStdWString();
-    translatedstrings[STRING_MOUSE_RELEASE]             = QCoreApplication::translate("", "Press %1 to release mouse").arg(QCoreApplication::translate("", MOUSE_CAPTURE_KEYSEQ)).toStdWString();
-    translatedstrings[STRING_MOUSE_RELEASE_MMB]         = QCoreApplication::translate("", "Press %1 or middle button to release mouse").arg(QCoreApplication::translate("", MOUSE_CAPTURE_KEYSEQ)).toStdWString();
-    translatedstrings[STRING_INVALID_CONFIG]            = QCoreApplication::translate("", "Invalid configuration").toStdWString();
+	
+	// Switch the mouse uncapture combo string based on config directive
+	if (key_uncapture_1_1 == 0x042 && key_uncapture_1_2 == 0x058)
+	{
+		MOUSE_CAPTURE_KEYSEQ = "F8+F12";
+	} else if (key_uncapture_1_1 == 0x01d && key_uncapture_1_2 == 0x14f) {
+		MOUSE_CAPTURE_KEYSEQ = "Ctrl+End";
+	} else {
+		MOUSE_CAPTURE_KEYSEQ = "custom key combo";
+	}
+	
+    translatedstrings[STRING_MOUSE_RELEASE]             = QCoreApplication::translate("", "Press %1 to release mouse").arg(QCoreApplication::translate("", qPrintable(MOUSE_CAPTURE_KEYSEQ))).toStdWString();
+    translatedstrings[STRING_MOUSE_RELEASE_MMB]         = QCoreApplication::translate("", "Press %1 or middle button to release mouse").arg(QCoreApplication::translate("", qPrintable(MOUSE_CAPTURE_KEYSEQ))).toStdWString();
+    
+	translatedstrings[STRING_INVALID_CONFIG]            = QCoreApplication::translate("", "Invalid configuration").toStdWString();
     translatedstrings[STRING_NO_ST506_ESDI_CDROM]       = QCoreApplication::translate("", "MFM/RLL or ESDI CD-ROM drives never existed").toStdWString();
     translatedstrings[STRING_PCAP_ERROR_NO_DEVICES]     = QCoreApplication::translate("", "No PCap devices found").toStdWString();
     translatedstrings[STRING_PCAP_ERROR_INVALID_DEVICE] = QCoreApplication::translate("", "Invalid PCap device").toStdWString();


### PR DESCRIPTION
Regarding #1639: added config directive escape_keys, which accepts either "f8_f12", "ctrl_end", or two hex scancodes in "0x000,0x000" format. Also updates status line above display if either preset is selected; otherwise says "Press custom key combo [...]"

While implementing, discovered existing --keycodes command line param with unclear usage. Replaced with new code that accepts 0x000,0x000 format and provides usage instructions.

Needs a GUI element IMO (I think a menu option in Action would be ideal), I can try to provide that in a future PR. Doesn't solve the longterm need for a robust key binding system, but it should be a stopgap. I am not a heavily experienced C/++ dev so hopefully my code quality is adequate, I tried to mirror the existing style.

Note: On my machine (windows 11) 86box does not appear to output stdin unless I manually "> stdin.txt", but as long as I do that the usage text does work.