### PR TITLE
Fix "internal_name" for Phoenix PS/2 PCI KBC

### DIFF
--- a/src/device/kbc_at.c
+++ b/src/device/kbc_at.c
@@ -2807,7 +2807,7 @@ const device_t keyboard_ps2_acer_pci_device = {
 
 const device_t keyboard_ps2_phoenix_pci_device = {
     .name          = "PS/2 Keyboard (Phoenix)",
-    .internal_name = "keyboard_ps2_acer_pci",
+    .internal_name = "keyboard_ps2_phoenix_pci",
     .flags         = DEVICE_KBC | DEVICE_PCI,
     .local         = KBC_TYPE_PS2_1 | KBC_VEN_PHOENIX,
     .init          = kbc_at_init,


### PR DESCRIPTION
Summary
=======
Title says at all.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
Referenced by this [commit](https://github.com/86Box/86Box/commit/fd2214f54471c02bea2c99deda54ac138f5d4f43), but because the "internal_name" is a duplicate of Acer PS/2 PCI KBC, I corrected them for Phoenix PS/2 PCI KBC