### PR TITLE
workflows: Don't rebuild libsndfile on macOS

### DIFF
--- a/.github/workflows/cmake_macos.yml
+++ b/.github/workflows/cmake_macos.yml
@@ -56,22 +56,13 @@ jobs:
           - name: SDL GUI
             qt: off
             static: on
-            src-packages: >-
-              libsndfile
           - name: Qt GUI
             qt: on
             slug: -Qt
             packages: >-
               qt@5
-            src-packages: >-
-              libsndfile
 
     steps:
-      - name: Install source dependencies
-        run: >-
-          brew reinstall -s
-          ${{ matrix.ui.src-packages }}
-
       - name: Install dependencies
         run: >-
           brew install
@@ -158,22 +149,13 @@ jobs:
           - name: SDL GUI
             qt: off
             static: on
-            src-packages: >-
-              libsndfile
           - name: Qt GUI
             qt: on
             slug: -Qt
             packages: >-
               qt@5
-            src-packages: >-
-              libsndfile
 
     steps:
-      - name: Install source dependencies
-        run: >-
-          brew reinstall -s
-          ${{ matrix.ui.src-packages }}
-
       - name: Install dependencies
         run: >-
           brew install


### PR DESCRIPTION
Summary
=======
Not only is this workaround no longer needed for packaging, it breaks the workflow completely due to CMake 4.0.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A