### PR TITLE
Fixed stack overflow in CharPointer::operator=

### DIFF
--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -87,13 +87,13 @@ public:
     CharPointer &operator=(const QByteArray &ba)
     {
         if (s > 0) {
+            // If the size is known, copy up to s - 1 bytes
+            // and null-terminate the string.
             strncpy(b, ba.data(), s - 1);
-            b[s] = 0;
-        } else {
-            // if we haven't been told the length of b, just assume enough
-            // because we didn't get it from emulator code
+            b[s - 1] = 0;
+        } else if (ba.size() > 0) {
+            // If the size is unknown, copy the whole QByteArray
             strcpy(b, ba.data());
-            b[ba.size()] = 0;
         }
         return *this;
     }


### PR DESCRIPTION
Summary
=======
Fixes the OOB write caused by `b[s] = 0;` in `CharPointer::operator=`. Since arrays in C are zero-indexed, the last index in an array of size 1 would be 0, i.e. size - 1.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
