### PR TITLE
Keybind UI fixes

### DIFF
--- a/src/qt/qt_keybind.cpp
+++ b/src/qt/qt_keybind.cpp
@@ -6,15 +6,15 @@
  *
  *          This file is part of the 86Box distribution.
  *
- *          Device configuration UI code.
+ *          Keybind dialog
  *
  *
  *
- * Authors: Joakim L. Gilje <jgilje@jgilje.net>
+ * Authors: Cathode Ray Dude
  *          Cacodemon345
  *
- *          Copyright 2021 Joakim L. Gilje
- *          Copyright 2022 Cacodemon345
+ *          Copyright 2025 Cathode Ray Dude
+ *          Copyright 2025 Cacodemon345
  */
 #include "qt_keybind.hpp"
 #include "ui_qt_keybind.h"
@@ -85,12 +85,13 @@ bool KeyBinder::eventFilter(QObject *obj, QEvent *event)
 }
 
 QKeySequence
-KeyBinder::BindKey(QString CurValue)
+KeyBinder::BindKey(QWidget* widget, QString CurValue)
 {
-	KeyBinder kb;
+	KeyBinder kb(widget);
 	kb.setWindowTitle("Bind Key");
     kb.setFixedSize(kb.minimumSizeHint());
 	kb.findChild<QKeySequenceEdit*>()->setKeySequence(QKeySequence::fromString(CurValue));
+	kb.setEnabled(true);
 	
     if (kb.exec() == QDialog::Accepted) {
 		QKeySequenceEdit *seq = kb.findChild<QKeySequenceEdit*>();

--- a/src/qt/qt_keybind.hpp
+++ b/src/qt/qt_keybind.hpp
@@ -22,7 +22,7 @@ public:
     explicit KeyBinder(QWidget *parent = nullptr);
     ~KeyBinder() override;
 
-    static QKeySequence BindKey(QString CurValue);
+    static QKeySequence BindKey(QWidget* widget, QString CurValue);
 
 private:
     Ui::KeyBinder *ui;

--- a/src/qt/qt_settingsinput.cpp
+++ b/src/qt/qt_settingsinput.cpp
@@ -63,7 +63,7 @@ SettingsInput::SettingsInput(QWidget *parent)
 	keyTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
 	QStringList headers;
 	//headers << "Action" << "Bound key";
-	keyTable->setHorizontalHeaderLabels(headers);
+	keyTable->setHorizontalHeaderLabels(horizontalHeader);
 	keyTable->verticalHeader()->setVisible(false);
 	keyTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
 	keyTable->setSelectionBehavior(QAbstractItemView::SelectRows);
@@ -201,7 +201,7 @@ SettingsInput::on_tableKeys_doubleClicked(int row, int col)
 	QTableWidgetItem *cell = ui->tableKeys->item(row,1);
 	if (!cell) return;
 	
-	QKeySequence keyseq = KeyBinder::BindKey(cell->text());
+	QKeySequence keyseq = KeyBinder::BindKey(this, cell->text());
 	if (keyseq != false) {
 		// If no change was made, don't change anything.
 		if (keyseq.toString(QKeySequence::NativeText) == cell->text()) return;
@@ -247,7 +247,7 @@ void
 SettingsInput::on_pushButtonClearBind_Clicked()
 {
 	// Wipe bind
-	QTableWidgetItem *cell = ui->tableKeys->currentItem();
+	QTableWidgetItem *cell = ui->tableKeys->item(ui->tableKeys->currentRow(), 1);
 	if (!cell) return;
 	
 	cell->setText("");


### PR DESCRIPTION
Summary
=======
Keybind UI fixes

1. Don't clear the description text cell if selected; clear the actual keybind text instead.
2. Header texts are now correct.
3. Make the keybind dialog model and usable with dark mode.
4. Copyright text fixes.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
