### PR TITLE
Fix cleared keybindings not being reloaded

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1774,9 +1774,12 @@ load_keybinds(void)
 
     /* Now load values from config */
     for (int x = 0; x < NUM_ACCELS; x++) {
-         p = ini_section_get_string(cat, acc_keys[x].name, "none");
+         p = ini_section_get_string(cat, acc_keys[x].name, "default");
+         /* Check if the binding was marked as cleared */
+         if (strcmp(p, "none") == 0)
+             acc_keys[x].seq[0] = '\0';
          /* If there's no binding in the file, leave it alone. */
-         if (strcmp(p, "none") != 0) {
+         else if (strcmp(p, "default") != 0) {
              /*
                 It would be ideal to validate whether the user entered a
                 valid combo at this point, but the Qt method for testing that is
@@ -2527,6 +2530,9 @@ save_keybinds(void)
         /* Has accelerator been changed from default? */
         if (strcmp(def_acc_keys[x].seq, acc_keys[x].seq) == 0)
             ini_section_delete_var(cat, acc_keys[x].name);
+        /* Check for a cleared binding to avoid saving it as an empty string */
+        else if (acc_keys[x].seq[0] == '\0')
+            ini_section_set_string(cat, acc_keys[x].name, "none");
         else
             ini_section_set_string(cat, acc_keys[x].name, acc_keys[x].seq);
     }

--- a/src/qt/qt_settingsinput.cpp
+++ b/src/qt/qt_settingsinput.cpp
@@ -79,15 +79,6 @@ SettingsInput::SettingsInput(QWidget *parent)
 
 	refreshInputList();
 
- 	connect(ui->tableKeys, &QTableWidget::cellDoubleClicked,
-        this, &SettingsInput::on_tableKeys_doubleClicked);
-		
-	connect(ui->pushButtonBind, &QPushButton::clicked,
-        this, &SettingsInput::on_pushButtonBind_Clicked);
-		
-	connect(ui->pushButtonClearBind, &QPushButton::clicked,
-        this, &SettingsInput::on_pushButtonClearBind_Clicked);
-
     onCurrentMachineChanged(machine);
 }
 
@@ -194,7 +185,7 @@ SettingsInput::on_tableKeys_currentCellChanged(int currentRow, int currentColumn
 }
 
 void
-SettingsInput::on_tableKeys_doubleClicked(int row, int col)
+SettingsInput::on_tableKeys_cellDoubleClicked(int row, int col)
 {
 	// Edit bind
 	QTableWidgetItem *cell = ui->tableKeys->item(row,1);
@@ -233,17 +224,17 @@ SettingsInput::on_tableKeys_doubleClicked(int row, int col)
 }
 
 void
-SettingsInput::on_pushButtonBind_Clicked()
+SettingsInput::on_pushButtonBind_clicked()
 {
 	// Edit bind
 	QTableWidgetItem *cell = ui->tableKeys->currentItem();
 	if (!cell) return;
 	
-	on_tableKeys_doubleClicked(cell->row(), cell->column());
+	on_tableKeys_cellDoubleClicked(cell->row(), cell->column());
 }
 
 void
-SettingsInput::on_pushButtonClearBind_Clicked()
+SettingsInput::on_pushButtonClearBind_clicked()
 {
 	// Wipe bind
 	QTableWidgetItem *cell = ui->tableKeys->item(ui->tableKeys->currentRow(), 1);

--- a/src/qt/qt_settingsinput.hpp
+++ b/src/qt/qt_settingsinput.hpp
@@ -33,10 +33,10 @@ private slots:
     void on_pushButtonJoystick2_clicked();
     void on_pushButtonJoystick3_clicked();
     void on_pushButtonJoystick4_clicked();
-	void on_tableKeys_doubleClicked(int row, int col);
+	void on_tableKeys_cellDoubleClicked(int row, int col);
 	void on_tableKeys_currentCellChanged(int currentRow, int currentColumn, int previousRow, int previousColumn);
-	void on_pushButtonBind_Clicked();
-	void on_pushButtonClearBind_Clicked();
+	void on_pushButtonBind_clicked();
+	void on_pushButtonClearBind_clicked();
 
 private:
     Ui::SettingsInput *ui;


### PR DESCRIPTION
Summary
=======
Fixes cleared keybindings being reset to default on startup by saving them as "none" instead of empty strings.

Also fixes `QMetaObject::connectSlotsByName: No matching signal for...` warnings on run time.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A