### PR TITLE
Add cmake files for linux clang and intel compilers

### DIFF
--- a/cmake/intel-linux-x86_64.cmake
+++ b/cmake/intel-linux-x86_64.cmake
@@ -1,0 +1,20 @@
+#
+# 86Box    A hypervisor and IBM PC system emulator that specializes in
+#          running old operating systems and software designed for IBM
+#          PC systems and compatibles from 1981 through fairly recent
+#          system designs based on the PCI bus.
+#
+#          This file is part of the 86Box distribution.
+#
+#          CMake toolchain file defining GCC compiler flags
+#          for 64-bit x86 targets.
+#
+# Authors: David Hrdlička, <hrdlickadavid@outlook.com>
+#
+#          Copyright 2021 David Hrdlička.
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/flags-gcc-x86_64.cmake)
+
+set(CMAKE_C_COMPILER    icx)
+set(CMAKE_CXX_COMPILER  icpx)

--- a/cmake/llvm-linux-x86_64.cmake
+++ b/cmake/llvm-linux-x86_64.cmake
@@ -1,0 +1,23 @@
+#
+# 86Box    A hypervisor and IBM PC system emulator that specializes in
+#          running old operating systems and software designed for IBM
+#          PC systems and compatibles from 1981 through fairly recent
+#          system designs based on the PCI bus.
+#
+#          This file is part of the 86Box distribution.
+#
+#          CMake toolchain file defining Clang compiler flags
+#          for 64-bit x86 targets.
+#
+# Authors: David Hrdlička, <hrdlickadavid@outlook.com>
+#          dob205
+#
+#          Copyright 2021 David Hrdlička.
+#          Copyright 2022 dob205.
+#
+
+include(${CMAKE_CURRENT_LIST_DIR}/flags-gcc-x86_64.cmake)
+
+# Use the GCC-compatible Clang executables in order to use our flags
+set(CMAKE_C_COMPILER    clang)
+set(CMAKE_CXX_COMPILER  clang++)


### PR DESCRIPTION
Summary
=======
Added cmake files for x86_64 linux llvm clang/clang++ and intel icx/icpx compilers.
Build successfully with clang 14.0 and Intel oneAPI 2025.0 on Linux Mint LMDE 6.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

