### PR TITLE
qt: For device config dialogs, default to the settings dialog as the parent

### DIFF
--- a/src/qt/qt_deviceconfig.hpp
+++ b/src/qt/qt_deviceconfig.hpp
@@ -23,7 +23,7 @@ public:
     ~DeviceConfig() override;
 
     static void    ConfigureDevice(const _device_ *device, int instance = 0,
-                                   Settings *settings = nullptr);
+                                   Settings *settings = qobject_cast<Settings *>(Settings::settings));
     static QString DeviceName(const _device_ *device, const char *internalName, int bus);
 
 private:

--- a/src/qt/qt_settingsdisplay.cpp
+++ b/src/qt/qt_settingsdisplay.cpp
@@ -122,22 +122,22 @@ SettingsDisplay::on_pushButtonConfigure_clicked()
     auto *device = video_card_getdevice(videoCard);
     if (videoCard == VID_INTERNAL)
         device = machine_get_vid_device(machineId);
-    DeviceConfig::ConfigureDevice(device, 0, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(device);
 }
 
 void
 SettingsDisplay::on_pushButtonConfigureVoodoo_clicked()
 {
-    DeviceConfig::ConfigureDevice(&voodoo_device, 0, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(&voodoo_device);
 }
 
 void
 SettingsDisplay::on_pushButtonConfigure8514_clicked()
 {
     if (machine_has_bus(machineId, MACHINE_BUS_MCA) > 0) {
-        DeviceConfig::ConfigureDevice(&ibm8514_mca_device, 0, qobject_cast<Settings *>(Settings::settings));
+        DeviceConfig::ConfigureDevice(&ibm8514_mca_device);
     } else {
-        DeviceConfig::ConfigureDevice(&gen8514_isa_device, 0, qobject_cast<Settings *>(Settings::settings));
+        DeviceConfig::ConfigureDevice(&gen8514_isa_device);
     }
 }
 
@@ -145,16 +145,16 @@ void
 SettingsDisplay::on_pushButtonConfigureXga_clicked()
 {
     if (machine_has_bus(machineId, MACHINE_BUS_MCA) > 0) {
-        DeviceConfig::ConfigureDevice(&xga_device, 0, qobject_cast<Settings *>(Settings::settings));
+        DeviceConfig::ConfigureDevice(&xga_device);
     } else {
-        DeviceConfig::ConfigureDevice(&xga_isa_device, 0, qobject_cast<Settings *>(Settings::settings));
+        DeviceConfig::ConfigureDevice(&xga_isa_device);
     }
 }
 
 void
 SettingsDisplay::on_pushButtonConfigureDa2_clicked()
 {
-    DeviceConfig::ConfigureDevice(&ps55da2_device, 0, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(&ps55da2_device);
 }
 
 void
@@ -298,5 +298,5 @@ void
 SettingsDisplay::on_pushButtonConfigureSecondary_clicked()
 {
     auto *device = video_card_getdevice(ui->comboBoxVideoSecondary->currentData().toInt());
-    DeviceConfig::ConfigureDevice(device, 0, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(device);
 }

--- a/src/qt/qt_settingsinput.cpp
+++ b/src/qt/qt_settingsinput.cpp
@@ -274,7 +274,7 @@ void
 SettingsInput::on_pushButtonConfigureMouse_clicked()
 {
     int mouseId = ui->comboBoxMouse->currentData().toInt();
-    DeviceConfig::ConfigureDevice(mouse_get_device(mouseId), 0, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(mouse_get_device(mouseId));
 }
 
 static int

--- a/src/qt/qt_settingsmachine.cpp
+++ b/src/qt/qt_settingsmachine.cpp
@@ -347,7 +347,7 @@ SettingsMachine::on_pushButtonConfigure_clicked()
     // deviceconfig_inst_open
     int         machineId = ui->comboBoxMachine->currentData().toInt();
     const auto *device    = machine_get_device(machineId);
-    DeviceConfig::ConfigureDevice(device, 0, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(device);
 }
 
 void SettingsMachine::on_checkBoxFPUSoftfloat_stateChanged(int state) {

--- a/src/qt/qt_settingsnetwork.cpp
+++ b/src/qt/qt_settingsnetwork.cpp
@@ -240,7 +240,7 @@ SettingsNetwork::on_pushButtonConf1_clicked()
     auto *device = network_card_getdevice(netCard);
     if (netCard == NET_INTERNAL)
         device = machine_get_net_device(machineId);
-    DeviceConfig::ConfigureDevice(device, 1, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(device, 1);
 }
 
 void
@@ -248,7 +248,7 @@ SettingsNetwork::on_pushButtonConf2_clicked()
 {
     int netCard = ui->comboBoxNIC2->currentData().toInt();
     auto *device = network_card_getdevice(netCard);
-    DeviceConfig::ConfigureDevice(device, 2, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(device, 2);
 }
 
 void
@@ -256,7 +256,7 @@ SettingsNetwork::on_pushButtonConf3_clicked()
 {
     int netCard = ui->comboBoxNIC3->currentData().toInt();
     auto *device = network_card_getdevice(netCard);
-    DeviceConfig::ConfigureDevice(device, 3, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(device, 3);
 }
 
 void
@@ -264,5 +264,5 @@ SettingsNetwork::on_pushButtonConf4_clicked()
 {
     int netCard = ui->comboBoxNIC4->currentData().toInt();
     auto *device = network_card_getdevice(netCard);
-    DeviceConfig::ConfigureDevice(device, 4, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(device, 4);
 }

--- a/src/qt/qt_settingsotherperipherals.cpp
+++ b/src/qt/qt_settingsotherperipherals.cpp
@@ -159,7 +159,7 @@ SettingsOtherPeripherals::on_comboBoxRTC_currentIndexChanged(int index)
 void
 SettingsOtherPeripherals::on_pushButtonConfigureRTC_clicked()
 {
-    DeviceConfig::ConfigureDevice(isartc_get_device(ui->comboBoxRTC->currentData().toInt()), 0, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(isartc_get_device(ui->comboBoxRTC->currentData().toInt()));
 }
 
 void
@@ -174,7 +174,7 @@ SettingsOtherPeripherals::on_comboBoxCard1_currentIndexChanged(int index)
 void
 SettingsOtherPeripherals::on_pushButtonConfigureCard1_clicked()
 {
-    DeviceConfig::ConfigureDevice(isamem_get_device(ui->comboBoxCard1->currentData().toInt()), 1, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(isamem_get_device(ui->comboBoxCard1->currentData().toInt()), 1);
 }
 
 void
@@ -189,7 +189,7 @@ SettingsOtherPeripherals::on_comboBoxCard2_currentIndexChanged(int index)
 void
 SettingsOtherPeripherals::on_pushButtonConfigureCard2_clicked()
 {
-    DeviceConfig::ConfigureDevice(isamem_get_device(ui->comboBoxCard2->currentData().toInt()), 2, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(isamem_get_device(ui->comboBoxCard2->currentData().toInt()), 2);
 }
 
 void
@@ -204,7 +204,7 @@ SettingsOtherPeripherals::on_comboBoxCard3_currentIndexChanged(int index)
 void
 SettingsOtherPeripherals::on_pushButtonConfigureCard3_clicked()
 {
-    DeviceConfig::ConfigureDevice(isamem_get_device(ui->comboBoxCard3->currentData().toInt()), 3, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(isamem_get_device(ui->comboBoxCard3->currentData().toInt()), 3);
 }
 
 void
@@ -219,7 +219,7 @@ SettingsOtherPeripherals::on_comboBoxCard4_currentIndexChanged(int index)
 void
 SettingsOtherPeripherals::on_pushButtonConfigureCard4_clicked()
 {
-    DeviceConfig::ConfigureDevice(isamem_get_device(ui->comboBoxCard4->currentData().toInt()), 4, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(isamem_get_device(ui->comboBoxCard4->currentData().toInt()), 4);
 }
 
 void

--- a/src/qt/qt_settingsports.cpp
+++ b/src/qt/qt_settingsports.cpp
@@ -254,43 +254,43 @@ SettingsPorts::on_checkBoxSerialPassThru7_stateChanged(int state)
 void
 SettingsPorts::on_pushButtonSerialPassThru1_clicked()
 {
-    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 1, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 1);
 }
 
 void
 SettingsPorts::on_pushButtonSerialPassThru2_clicked()
 {
-    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 2, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 2);
 }
 
 void
 SettingsPorts::on_pushButtonSerialPassThru3_clicked()
 {
-    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 3, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 3);
 }
 
 void
 SettingsPorts::on_pushButtonSerialPassThru4_clicked()
 {
-    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 4, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 4);
 }
 
 #if 0
 void
 SettingsPorts::on_pushButtonSerialPassThru5_clicked()
 {
-    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 5, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 5);
 }
 
 void
 SettingsPorts::on_pushButtonSerialPassThru6_clicked()
 {
-    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 6, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 6);
 }
 
 void
 SettingsPorts::on_pushButtonSerialPassThru7_clicked()
 {
-    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 7, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(&serial_passthrough_device, 7);
 }
 #endif

--- a/src/qt/qt_settingssound.cpp
+++ b/src/qt/qt_settingssound.cpp
@@ -232,7 +232,7 @@ SettingsSound::on_pushButtonConfigureSoundCard1_clicked()
 
     if (sndCard == SOUND_INTERNAL)
         device = machine_get_snd_device(machineId);
-    DeviceConfig::ConfigureDevice(device, 1, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(device, 1);
 }
 
 void
@@ -252,7 +252,7 @@ SettingsSound::on_pushButtonConfigureSoundCard2_clicked()
 {
     int             sndCard = ui->comboBoxSoundCard2->currentData().toInt();
     const device_t *device  = sound_card_getdevice(sndCard);
-    DeviceConfig::ConfigureDevice(device, 2, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(device, 2);
 }
 
 void
@@ -273,7 +273,7 @@ SettingsSound::on_pushButtonConfigureSoundCard3_clicked()
     int             sndCard = ui->comboBoxSoundCard3->currentData().toInt();
     const device_t *device  = sound_card_getdevice(sndCard);
 
-    DeviceConfig::ConfigureDevice(device, 3, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(device, 3);
 }
 
 void
@@ -294,7 +294,7 @@ SettingsSound::on_pushButtonConfigureSoundCard4_clicked()
     int             sndCard = ui->comboBoxSoundCard4->currentData().toInt();
     const device_t *device  = sound_card_getdevice(sndCard);
 
-    DeviceConfig::ConfigureDevice(device, 4, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(device, 4);
 }
 
 void
@@ -312,8 +312,7 @@ SettingsSound::on_comboBoxMidiOut_currentIndexChanged(int index)
 void
 SettingsSound::on_pushButtonConfigureMidiOut_clicked()
 {
-    DeviceConfig::ConfigureDevice(midi_out_device_getdevice(ui->comboBoxMidiOut->currentData().toInt()), 0,
-                                  qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(midi_out_device_getdevice(ui->comboBoxMidiOut->currentData().toInt()));
 }
 
 void
@@ -331,8 +330,7 @@ SettingsSound::on_comboBoxMidiIn_currentIndexChanged(int index)
 void
 SettingsSound::on_pushButtonConfigureMidiIn_clicked()
 {
-    DeviceConfig::ConfigureDevice(midi_in_device_getdevice(ui->comboBoxMidiIn->currentData().toInt()), 0,
-                                  qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(midi_in_device_getdevice(ui->comboBoxMidiIn->currentData().toInt()));
 }
 
 void
@@ -345,7 +343,7 @@ void
 SettingsSound::on_pushButtonConfigureMPU401_clicked()
 {
     if (machine_has_bus(machineId, MACHINE_BUS_MCA) > 0)
-        DeviceConfig::ConfigureDevice(&mpu401_mca_device, 0, qobject_cast<Settings *>(Settings::settings));
+        DeviceConfig::ConfigureDevice(&mpu401_mca_device);
     else
-        DeviceConfig::ConfigureDevice(&mpu401_device, 0, qobject_cast<Settings *>(Settings::settings));
+        DeviceConfig::ConfigureDevice(&mpu401_device);
 }

--- a/src/qt/qt_settingsstoragecontrollers.cpp
+++ b/src/qt/qt_settingsstoragecontrollers.cpp
@@ -281,31 +281,31 @@ SettingsStorageControllers::on_checkBoxQuaternaryIDE_stateChanged(int arg1)
 void
 SettingsStorageControllers::on_pushButtonHD_clicked()
 {
-    DeviceConfig::ConfigureDevice(hdc_get_device(ui->comboBoxHD->currentData().toInt()), 0, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(hdc_get_device(ui->comboBoxHD->currentData().toInt()));
 }
 
 void
 SettingsStorageControllers::on_pushButtonFD_clicked()
 {
-    DeviceConfig::ConfigureDevice(fdc_card_getdevice(ui->comboBoxFD->currentData().toInt()), 0, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(fdc_card_getdevice(ui->comboBoxFD->currentData().toInt()));
 }
 
 void
 SettingsStorageControllers::on_pushButtonCDInterface_clicked()
 {
-    DeviceConfig::ConfigureDevice(cdrom_interface_get_device(ui->comboBoxCDInterface->currentData().toInt()), 0, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(cdrom_interface_get_device(ui->comboBoxCDInterface->currentData().toInt()));
 }
 
 void
 SettingsStorageControllers::on_pushButtonTertiaryIDE_clicked()
 {
-    DeviceConfig::ConfigureDevice(&ide_ter_device, 0, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(&ide_ter_device);
 }
 
 void
 SettingsStorageControllers::on_pushButtonQuaternaryIDE_clicked()
 {
-    DeviceConfig::ConfigureDevice(&ide_qua_device, 0, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(&ide_qua_device);
 }
 
 void
@@ -347,25 +347,25 @@ SettingsStorageControllers::on_comboBoxSCSI4_currentIndexChanged(int index)
 void
 SettingsStorageControllers::on_pushButtonSCSI1_clicked()
 {
-    DeviceConfig::ConfigureDevice(scsi_card_getdevice(ui->comboBoxSCSI1->currentData().toInt()), 1, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(scsi_card_getdevice(ui->comboBoxSCSI1->currentData().toInt()), 1);
 }
 
 void
 SettingsStorageControllers::on_pushButtonSCSI2_clicked()
 {
-    DeviceConfig::ConfigureDevice(scsi_card_getdevice(ui->comboBoxSCSI2->currentData().toInt()), 2, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(scsi_card_getdevice(ui->comboBoxSCSI2->currentData().toInt()), 2);
 }
 
 void
 SettingsStorageControllers::on_pushButtonSCSI3_clicked()
 {
-    DeviceConfig::ConfigureDevice(scsi_card_getdevice(ui->comboBoxSCSI3->currentData().toInt()), 3, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(scsi_card_getdevice(ui->comboBoxSCSI3->currentData().toInt()), 3);
 }
 
 void
 SettingsStorageControllers::on_pushButtonSCSI4_clicked()
 {
-    DeviceConfig::ConfigureDevice(scsi_card_getdevice(ui->comboBoxSCSI4->currentData().toInt()), 4, qobject_cast<Settings *>(Settings::settings));
+    DeviceConfig::ConfigureDevice(scsi_card_getdevice(ui->comboBoxSCSI4->currentData().toInt()), 4);
 }
 
 void


### PR DESCRIPTION
Summary
=======
Fixes (somehow) controls being non-interactable when no parent dialog is passed and 86Box is running in settings-only mode (affected configurations of the LBA enhancer, unit tester and the NetWare key card).

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A
