### PR TITLE
Some more changes to the Mach8/32/8514/A side (April 29th, 2025)

### DIFF
--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -961,7 +961,7 @@ ibm8514_accel_in(uint16_t port, svga_t *svga)
                         temp |= INT_GE_BSY;
                 }
 
-                if (!dev->fifo_idx) {
+                if (!dev->fifo_idx && !dev->on) {
                     dev->force_busy = 0;
                     dev->force_busy2 = 0;
                     dev->data_available = 0;


### PR DESCRIPTION
Summary
=======
1. Do not stall the guest when the passthrough mode is on, fixes hang ups in Windows 3.1 using the 2.3 drivers.
2. In the pitch register, make sure the passthrough goes on when needed only on the ATI Mach32, not 8, fixes mode on/off in text mode when needed.
3. Cosmetic changes and logs.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
