### PR TITLE
Fix EGA/VGA/SVGA odd-even handling of write mask

### DIFF
--- a/src/video/vid_ega.c
+++ b/src/video/vid_ega.c
@@ -1180,9 +1180,7 @@ ega_write(uint32_t addr, uint8_t val, void *priv)
     cycles -= video_timing_write_b;
 
     if (ega->chain2_write) {
-        writemask2 &= ~0xa;
-        if (addr & 1)
-            writemask2 <<= 1;
+        writemask2 &= 0x5 << (addr & 1);
     }
 
     addr = ega_remap_cpu_addr(addr, ega);

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -1689,9 +1689,7 @@ svga_write_common(uint32_t addr, uint8_t val, uint8_t linear, void *priv)
             addr &= ~3;
         addr = ((addr & 0xfffc) << 2) | ((addr & 0x30000) >> 14) | (addr & ~0x3ffff);
     } else if (svga->chain2_write) {
-        writemask2 &= ~0xa;
-        if (addr & 1)
-            writemask2 <<= 1;
+        writemask2 &= 0x5 << (addr & 1);
         addr &= ~1;
         addr <<= 2;
     } else


### PR DESCRIPTION
Summary
=======
This fixes a bug in the EGA and (S)VGA code where SR04.2 odd/even mode was computing the mask incorrectly.

Chain4 mode may also be broken but I'm holding off fixing that as it likely varies across the many different SVGA chipsets we emulate.

Checklist
=========
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
Miscellaneous hardware, namely my AMD Stoney laptop and my S3 Trio64V2.

I did cross-reference with the Intel GPU 2023 docs which tends to be more accurate than the IBM docs, but it turns out that it implies that the write mask is ignored in odd/even mode (the SR04 bit 2 part) where it is clearly not ignored on a lot of hardware (plus how would 640x350x2bpp mono mode work without that being the case, anyway?).

Test program for comparison which I originally wrote here: https://github.com/joncampbell123/dosbox-x/issues/5533#issuecomment-2841082706

```
a100
mov ax,b800
mov es,ax
xor di,di
mov cx,800
mov al,21
stosw        <--- 10c
inc ah
loop 10c
mov dx,3c4
mov al,2
out dx,al
inc dx
mov al,1
out dx,al
int 3

g=100
q
```
