### PR TITLE
AGP speed selection for Intel 4x0 and VIA Apollo chipsets

### DIFF
--- a/src/chipset/intel_4x0.c
+++ b/src/chipset/intel_4x0.c
@@ -1298,6 +1298,8 @@ i4x0_write(int func, int addr, uint8_t val, void *priv)
                     case INTEL_440ZX:
                     case INTEL_440GX:
                         regs[addr] = (val & 0x03);
+                        if (addr == 0xa8)
+                            cpu_set_agp_rate((val & 0x2) ? 2 : 1);
                         break;
                     default:
                         break;
@@ -1919,10 +1921,14 @@ i4x0_init(const device_t *info)
     if ((dev->type <= INTEL_440FX) && (cpu_busspeed >= 66666666))
         cpu_set_pci_speed(cpu_busspeed / 2);
 
-    if ((dev->type >= INTEL_440BX) && (cpu_busspeed >= 100000000))
+    if ((dev->type >= INTEL_440BX) && (cpu_busspeed >= 100000000)) {
         cpu_set_agp_speed(cpu_busspeed / 1.5);
-    else if (dev->type >= INTEL_440LX)
+        cpu_set_agp_rate(1);
+    }
+    else if (dev->type >= INTEL_440LX) {
         cpu_set_agp_speed(cpu_busspeed);
+        cpu_set_agp_rate(1);
+    }
 
     i4x0_write(regs[0x59], 0x59, 0x00, dev);
     i4x0_write(regs[0x5a], 0x5a, 0x00, dev);

--- a/src/chipset/via_apollo.c
+++ b/src/chipset/via_apollo.c
@@ -180,28 +180,34 @@ via_apollo_setup(via_apollo_t *dev)
         if (cpu_busspeed < 95000000) { /* 66 MHz */
             cpu_set_pci_speed(cpu_busspeed / 2);
             cpu_set_agp_speed(cpu_busspeed);
+            cpu_set_agp_rate(1);
             dev->pci_conf[0x68] |= 0x00;
         } else if (cpu_busspeed < 124000000) { /* 100 MHz */
             cpu_set_pci_speed(cpu_busspeed / 3);
             cpu_set_agp_speed(cpu_busspeed / 1.5);
+            cpu_set_agp_rate(1);
             dev->pci_conf[0x68] |= 0x01;
         } else { /* 133 MHz */
             cpu_set_pci_speed(cpu_busspeed / 4);
             cpu_set_agp_speed(cpu_busspeed / 2);
+            cpu_set_agp_rate(1);
             dev->pci_conf[0x68] |= (dev->id == VIA_8601) ? 0x03 : 0x02;
         }
     } else if (dev->id >= VIA_598) {
         if (cpu_busspeed < ((dev->id >= VIA_691) ? 100000000 : 75000000)) { /* 66 MHz */
             cpu_set_pci_speed(cpu_busspeed / 2);
             cpu_set_agp_speed(cpu_busspeed);
+            cpu_set_agp_rate(1);
             dev->pci_conf[0x68] |= 0x00;
         } else if (cpu_busspeed < 100000000) { /* 75/83 MHz (not available on 691) */
             cpu_set_pci_speed(cpu_busspeed / 2.5);
             cpu_set_agp_speed(cpu_busspeed / 1.25);
+            cpu_set_agp_rate(1);
             dev->pci_conf[0x68] |= 0x03;
         } else { /* 100 MHz */
             cpu_set_pci_speed(cpu_busspeed / 3);
             cpu_set_agp_speed(cpu_busspeed / 1.5);
+            cpu_set_agp_rate(1);
             dev->pci_conf[0x68] |= 0x01;
         }
     }
@@ -651,6 +657,7 @@ via_apollo_host_bridge_write(int func, int addr, uint8_t val, void *priv)
                 dev->pci_conf[0xa8] = (dev->pci_conf[0xa8] & ~0x33) | (val & 0x33);
             else
                 dev->pci_conf[0xa8] = (dev->pci_conf[0xa8] & ~0x03) | (val & 0x03);
+            cpu_set_agp_rate((dev->pci_conf[0xa8] & 0x2) ? 2 : 1);
             break;
         case 0xa9:
             dev->pci_conf[0xa9] = (dev->pci_conf[0xa9] & ~0x03) | (val & 0x03);

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -652,6 +652,7 @@ extern int cpu_cache_ext_enabled;
 extern int cpu_isa_speed;
 extern int cpu_pci_speed;
 extern int cpu_agp_speed;
+extern int cpu_agp_rate;
 
 extern int timing_rr;
 extern int timing_mr;
@@ -713,6 +714,7 @@ extern void cpu_set_isa_speed(int speed);
 extern void cpu_set_pci_speed(int speed);
 extern void cpu_set_isa_pci_div(int div);
 extern void cpu_set_agp_speed(int speed);
+extern void cpu_set_agp_rate(int rate);
 
 extern void cpu_CPUID(void);
 extern void cpu_RDMSR(void);

--- a/src/pit.c
+++ b/src/pit.c
@@ -1237,7 +1237,7 @@ pit_set_clock(uint32_t clock)
 
     /* PCICLK in us for use with timer_on_auto(). */
     PCICLK = pci_timing / (cpuclock / 1000000.0);
-    AGPCLK = agp_timing / (cpuclock / 1000000.0);
+    AGPCLK = (agp_timing / (cpuclock / 1000000.0)) * (double)cpu_agp_rate;
 
     if (cpu_busspeed >= 30000000)
         SYSCLK = bus_timing * 4.0;

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -220,7 +220,7 @@ if(WIN32)
     enable_language(RC)
     target_sources(86Box PUBLIC 86Box-qt.rc)
     target_sources(plat PRIVATE win_dynld.c)
-    target_link_libraries(86Box dwmapi)
+    target_link_libraries(86Box dwmapi dwrite)
 
     # CMake 3.22 messed this up for clang/clang++
     # See https://gitlab.kitware.com/cmake/cmake/-/issues/22611

--- a/src/video/vid_voodoo_banshee.c
+++ b/src/video/vid_voodoo_banshee.c
@@ -3654,6 +3654,10 @@ banshee_speed_changed(void *priv)
     banshee_t *banshee = (banshee_t *) priv;
 
     svga_recalctimings(&banshee->svga);
+
+    banshee->voodoo->read_time  = (banshee->agp ? agp_nonburst_time : pci_nonburst_time) + (banshee->agp ? agp_burst_time : pci_burst_time) * ((banshee->pciInit0 & 0x100) ? 2 : 1);
+    banshee->voodoo->burst_time = (banshee->agp ? agp_burst_time : pci_burst_time) * ((banshee->pciInit0 & 0x200) ? 1 : 0);
+    banshee->voodoo->write_time = (banshee->agp ? agp_nonburst_time : pci_nonburst_time) + banshee->voodoo->burst_time;
 }
 
 static void

--- a/src/video/video.c
+++ b/src/video/video.c
@@ -675,12 +675,12 @@ video_update_timing(void)
             *vid_timing_write_w = (int) (pci_timing * monitor_vid_timings->write_w);
             *vid_timing_write_l = (int) (pci_timing * monitor_vid_timings->write_l);
         } else if (monitor_vid_timings->type == VIDEO_AGP) {
-            *vid_timing_read_b  = (int) (agp_timing * monitor_vid_timings->read_b);
-            *vid_timing_read_w  = (int) (agp_timing * monitor_vid_timings->read_w);
-            *vid_timing_read_l  = (int) (agp_timing * monitor_vid_timings->read_l);
-            *vid_timing_write_b = (int) (agp_timing * monitor_vid_timings->write_b);
-            *vid_timing_write_w = (int) (agp_timing * monitor_vid_timings->write_w);
-            *vid_timing_write_l = (int) (agp_timing * monitor_vid_timings->write_l);
+            *vid_timing_read_b  = MAX((int) (agp_timing * monitor_vid_timings->read_b) / cpu_agp_rate, 1);
+            *vid_timing_read_w  = MAX((int) (agp_timing * monitor_vid_timings->read_w) / cpu_agp_rate, 1);
+            *vid_timing_read_l  = MAX((int) (agp_timing * monitor_vid_timings->read_l) / cpu_agp_rate, 1);
+            *vid_timing_write_b = MAX((int) (agp_timing * monitor_vid_timings->write_b) / cpu_agp_rate, 1);
+            *vid_timing_write_w = MAX((int) (agp_timing * monitor_vid_timings->write_w) / cpu_agp_rate, 1);
+            *vid_timing_write_l = MAX((int) (agp_timing * monitor_vid_timings->write_l) / cpu_agp_rate, 1);
         } else {
             *vid_timing_read_b  = (int) (bus_timing * monitor_vid_timings->read_b);
             *vid_timing_read_w  = (int) (bus_timing * monitor_vid_timings->read_w);


### PR DESCRIPTION
Summary
=======
Implements AGP speed selection for Intel 4x0 and VIA Apollo chipsets.

AGP speeds can be either 1x or 2x.

(Drive-by: Link to `dwrite` on Windows.)

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
