### PR TITLE
Laser Turbo XT memory fixes

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -1734,7 +1734,7 @@ const machine_t machines[] = {
         .ram = {
             .min = 256,
             .max = 640,
-            .step = 256
+            .step = 128
         },
         .nvrmask = 0,
         .kbc_device = &keyboard_xt_device,

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -1734,7 +1734,7 @@ const machine_t machines[] = {
         .ram = {
             .min = 256,
             .max = 640,
-            .step = 128
+            .step = 64
         },
         .nvrmask = 0,
         .kbc_device = &keyboard_xt_device,


### PR DESCRIPTION
Summary
=======
This corrects the memory step configuration on VTech Laster Turbo XT.

Checklist
=========
* [x] Closes #5554 
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
