### PR TITLE
No AGP slot on Delhi III and internal device note for 2 machines 

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -14860,7 +14860,7 @@ const machine_t machines[] = {
             .min_multi = 1.5,
             .max_multi = 8.0
         },
-        .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB, /* Has internal video: SGS Thompson Riva 128 AGP, network: NEC PK-UG-X006 (Intel 82558B chip) sound: OAK Audia 3D (OTI-610) */
+        .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB, /* Has internal video: SGS Thompson Riva 128 AGP, network: NEC PK-UG-X006 (Intel 82558B chip) and sound: OAK Audia 3D (OTI-610) */
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
         .ram = {
             .min = 8192,

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -14860,7 +14860,7 @@ const machine_t machines[] = {
             .min_multi = 1.5,
             .max_multi = 8.0
         },
-        .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB, /* Has internal video: SGS Thompson Riva 128 AGP and sound: OAK Audia 3D (OTI-610) */
+        .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB, /* Has internal video: SGS Thompson Riva 128 AGP, network: NEC PK-UG-X006 (Intel 82558B chip) sound: OAK Audia 3D (OTI-610) */
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
         .ram = {
             .min = 8192,

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -14035,7 +14035,7 @@ const machine_t machines[] = {
             .min_multi = 1.5,
             .max_multi = 5.5
         },
-        .bus_flags = MACHINE_PS2_AGP | MACHINE_BUS_USB,
+        .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB, /* Has internal video: ATI 3D Rage IIc AGP (Rage 2) */
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_SOUND | MACHINE_USB,
         .ram = {
             .min = 8192,
@@ -14860,7 +14860,7 @@ const machine_t machines[] = {
             .min_multi = 1.5,
             .max_multi = 8.0
         },
-        .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
+        .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB, /* Has internal video: SGS Thompson Riva 128 AGP and sound: OAK Audia 3D (OTI-610) */
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
         .ram = {
             .min = 8192,


### PR DESCRIPTION
Summary
=======
I find the newly-added Delhi III has an onboard video chip: ATI 3D Rage IIc, and the emulated machine cannot boot with an AGP card (several beeps, indicating video issue). And I find a photo which indicates NEC Mate NX MA23D has an OAK OTI-610 audio chip. Perhaps it is the same on MA30D.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[MA23D on eBay](https://www.ebay.com/itm/116193982911)
https://theretroweb.com/motherboards/s/trigem-delhi-iii
https://nicmania.sakura.ne.jp/etc/img/06_82558b.jpg