### PR TITLE
Add ISA 86c805 (ELSA Winner 1000)

### DIFF
--- a/src/include/86box/video.h
+++ b/src/include/86box/video.h
@@ -488,6 +488,7 @@ extern const device_t s3_metheus_86c928_isa_device;
 extern const device_t s3_metheus_86c928_vlb_device;
 extern const device_t s3_spea_mercury_lite_86c928_pci_device;
 extern const device_t s3_spea_mirage_86c801_isa_device;
+extern const device_t s3_winner1000_805_isa_device;
 extern const device_t s3_86c805_onboard_vlb_device;
 extern const device_t s3_spea_mirage_86c805_vlb_device;
 extern const device_t s3_mirocrystal_8s_805_vlb_device;

--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -10297,6 +10297,7 @@ s3_init(const device_t *info)
 
         case S3_SPEA_MIRAGE_86C801:
         case S3_SPEA_MIRAGE_86C805:
+        case S3_WINNER1000_805:
             svga->decode_mask = (2 << 20) - 1;
             stepping          = 0xa2; /*86C801/86C805*/
             s3->id            = stepping;
@@ -10326,7 +10327,6 @@ s3_init(const device_t *info)
 
         case S3_PHOENIX_86C801:
         case S3_PHOENIX_86C805:
-        case S3_WINNER1000_805:
             svga->decode_mask = (2 << 20) - 1;
             stepping          = 0xa0; /*86C801/86C805*/
             s3->id            = stepping;

--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -54,7 +54,7 @@
 #define ROM_MIROCRYSTAL20SV_964_PCI    "roms/video/s3/mirocrystal.VBI"
 #define ROM_MIROCRYSTAL20SD_864_VLB    "roms/video/s3/Miro20SD.BIN"
 #define ROM_PHOENIX_86C80X             "roms/video/s3/805.VBI"
-#define ROM_WINNER1000_805             "roms/video/s3/v01_05_00-C.BIN.bin"
+#define ROM_WINNER1000_805             "roms/video/s3/v01_05_00-C.BIN"
 #define ROM_PARADISE_BAHAMAS64         "roms/video/s3/bahamas64.bin"
 #define ROM_PHOENIX_VISION864          "roms/video/s3/86c864p.bin"
 #define ROM_DIAMOND_STEALTH64_964      "roms/video/s3/964_107h.rom"

--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -54,6 +54,7 @@
 #define ROM_MIROCRYSTAL20SV_964_PCI    "roms/video/s3/mirocrystal.VBI"
 #define ROM_MIROCRYSTAL20SD_864_VLB    "roms/video/s3/Miro20SD.BIN"
 #define ROM_PHOENIX_86C80X             "roms/video/s3/805.VBI"
+#define ROM_WINNER1000_805             "roms/video/s3/v01_05_00-C.BIN.bin"
 #define ROM_PARADISE_BAHAMAS64         "roms/video/s3/bahamas64.bin"
 #define ROM_PHOENIX_VISION864          "roms/video/s3/86c864p.bin"
 #define ROM_DIAMOND_STEALTH64_964      "roms/video/s3/964_107h.rom"
@@ -117,7 +118,8 @@ enum {
     S3_NUMBER9_9FX_771,
     S3_SPEA_MERCURY_LITE_PCI,
     S3_86C805_ONBOARD,
-    S3_DIAMOND_STEALTH64_968
+    S3_DIAMOND_STEALTH64_968,
+    S3_WINNER1000_805
 };
 
 enum {
@@ -3782,6 +3784,7 @@ s3_recalctimings(svga_t *svga)
                         switch (s3->card_type) {
                             case S3_MIROCRYSTAL8S_805:
                             case S3_MIROCRYSTAL10SD_805:
+                            case S3_WINNER1000_805:
                             case S3_PHOENIX_86C805:
                             case S3_86C805_ONBOARD:
                                 svga->hdisp >>= 1;
@@ -3950,6 +3953,7 @@ s3_recalctimings(svga_t *svga)
                         switch (s3->card_type) {
                             case S3_MIROCRYSTAL8S_805:
                             case S3_MIROCRYSTAL10SD_805:
+                            case S3_WINNER1000_805:
                             case S3_PHOENIX_86C805:
                             case S3_86C805_ONBOARD:
                                 svga->hdisp >>= 1;
@@ -4122,6 +4126,7 @@ s3_recalctimings(svga_t *svga)
                         switch (s3->card_type) {
                             case S3_MIROCRYSTAL8S_805:
                             case S3_MIROCRYSTAL10SD_805:
+                            case S3_WINNER1000_805:
                             case S3_PHOENIX_86C805:
                             case S3_SPEA_MIRAGE_86C805:
                             case S3_86C805_ONBOARD:
@@ -9835,6 +9840,11 @@ s3_init(const device_t *info)
             chip    = S3_86C801;
             video_inform(VIDEO_FLAG_TYPE_SPECIAL, &timing_s3_86c801);
             break;
+        case S3_WINNER1000_805:
+            bios_fn = ROM_WINNER1000_805;
+            chip    = S3_86C805;
+            video_inform(VIDEO_FLAG_TYPE_SPECIAL, &timing_s3_86c805);
+            break;
         case S3_86C805_ONBOARD:
             bios_fn = NULL;
             chip    = S3_86C805;
@@ -10316,6 +10326,7 @@ s3_init(const device_t *info)
 
         case S3_PHOENIX_86C801:
         case S3_PHOENIX_86C805:
+        case S3_WINNER1000_805:
             svga->decode_mask = (2 << 20) - 1;
             stepping          = 0xa0; /*86C801/86C805*/
             s3->id            = stepping;
@@ -10583,6 +10594,12 @@ static int
 s3_phoenix_86c80x_available(void)
 {
     return rom_present(ROM_PHOENIX_86C80X);
+}
+
+static int
+s3_winner1000_805_available(void)
+{
+    return rom_present(ROM_WINNER1000_805);
 }
 
 static int
@@ -10969,6 +10986,20 @@ const device_t s3_spea_mirage_86c801_isa_device = {
     .close         = s3_close,
     .reset         = s3_reset,
     .available     = s3_spea_mirage_86c801_available,
+    .speed_changed = s3_speed_changed,
+    .force_redraw  = s3_force_redraw,
+    .config        = s3_9fx_config
+};
+
+const device_t s3_winner1000_805_isa_device = {
+    .name          = "S3 86c805 ISA (ELSA Winner 1000)",
+    .internal_name = "winner1000_805_isa",
+    .flags         = DEVICE_ISA16,
+    .local         = S3_WINNER1000_805,
+    .init          = s3_init,
+    .close         = s3_close,
+    .reset         = s3_reset,
+    .available = s3_winner1000_805_available,
     .speed_changed = s3_speed_changed,
     .force_redraw  = s3_force_redraw,
     .config        = s3_9fx_config

--- a/src/video/vid_table.c
+++ b/src/video/vid_table.c
@@ -115,6 +115,7 @@ video_cards[] = {
     { .device = &s3_metheus_86c928_isa_device,                  .flags = VIDEO_FLAG_TYPE_NONE },
     { .device = &s3_phoenix_86c801_isa_device,                  .flags = VIDEO_FLAG_TYPE_NONE },
     { .device = &s3_spea_mirage_86c801_isa_device,              .flags = VIDEO_FLAG_TYPE_NONE },
+    { .device = &s3_winner1000_805_isa_device,                  .flags = VIDEO_FLAG_TYPE_NONE },
     { .device = &sigma_device,                                  .flags = VIDEO_FLAG_TYPE_NONE },
     { .device = &tvga8900b_device,                              .flags = VIDEO_FLAG_TYPE_NONE },
     { .device = &tvga8900d_device,                              .flags = VIDEO_FLAG_TYPE_NONE },


### PR DESCRIPTION
Summary
=======
There is no ISA-specific S3 86c805 video card on 86Box until now. This adds ISA16/86c805-based ELSA Winner 1000 to the video card list.

Note: ATT491 RAMDAC is being used for this video card as ATT409 RAMDAC is not added yet.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/317

References
==========
https://theretroweb.com/expansioncards/s/elsa-winner-1000isa