### PR TITLE
Fix keybinds being saved in native/localized form

### DIFF
--- a/src/include/86box/plat.h
+++ b/src/include/86box/plat.h
@@ -32,8 +32,8 @@
 /* String ID numbers. */
 enum {
     STRING_MOUSE_CAPTURE,             /* "Click to capture mouse" */
-    STRING_MOUSE_RELEASE,             /* "Press F8+F12 to release mouse" */
-    STRING_MOUSE_RELEASE_MMB,         /* "Press F8+F12 or middle button to release mouse" */
+    STRING_MOUSE_RELEASE,             /* "Press %1 to release mouse" */
+    STRING_MOUSE_RELEASE_MMB,         /* "Press %1 or middle button to release mouse" */
     STRING_INVALID_CONFIG,            /* "Invalid configuration" */
     STRING_NO_ST506_ESDI_CDROM,       /* "MFM/RLL or ESDI CD-ROM drives never existed" */
     STRING_NET_ERROR,                 /* "Failed to initialize network driver" */

--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -630,7 +630,7 @@ msgstr ""
 msgid " - PAUSED"
 msgstr ""
 
-msgid "Press Ctrl+Alt+PgDn to return to windowed mode."
+msgid "Press %1 to return to windowed mode."
 msgstr ""
 
 msgid "Speed"

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -630,8 +630,8 @@ msgstr "Error fatal"
 msgid " - PAUSED"
 msgstr " - EN PAUSA"
 
-msgid "Press %s to return to windowed mode."
-msgstr "Premeu %s per tornar al mode de finestra."
+msgid "Press %1 to return to windowed mode."
+msgstr "Premeu %1 per tornar al mode de finestra."
 
 msgid "Speed"
 msgstr "Velocitat"
@@ -717,11 +717,11 @@ msgstr "Altres perifèrics"
 msgid "Click to capture mouse"
 msgstr "Feu clic per capturar el ratolí"
 
-msgid "Press %s to release mouse"
-msgstr "Premeu %s per alliberar el ratolí"
+msgid "Press %1 to release mouse"
+msgstr "Premeu %1 per alliberar el ratolí"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "Premeu %s o el botó central per alliberar el ratolí"
+msgid "Press %1 or middle button to release mouse"
+msgstr "Premeu %1 o el botó central per alliberar el ratolí"
 
 msgid "Bus"
 msgstr "Bus"

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -630,8 +630,8 @@ msgstr "Kritická chyba"
 msgid " - PAUSED"
 msgstr " - POZASTAVENO"
 
-msgid "Press %s to return to windowed mode."
-msgstr "Stiskněte %s pro návrat z režimu celé obrazovky."
+msgid "Press %1 to return to windowed mode."
+msgstr "Stiskněte %1 pro návrat z režimu celé obrazovky."
 
 msgid "Speed"
 msgstr "Rychlost"
@@ -717,11 +717,11 @@ msgstr "Jiné příslušenství"
 msgid "Click to capture mouse"
 msgstr "Klikněte pro zabraní myši"
 
-msgid "Press %s to release mouse"
-msgstr "Stiskněte %s pro uvolnění myši"
+msgid "Press %1 to release mouse"
+msgstr "Stiskněte %1 pro uvolnění myši"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "Stiskněte %s nebo prostřední tlačítko pro uvolnění myši"
+msgid "Press %1 or middle button to release mouse"
+msgstr "Stiskněte %1 nebo prostřední tlačítko pro uvolnění myši"
 
 msgid "Bus"
 msgstr "Sběrnice"

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -630,8 +630,8 @@ msgstr "Fataler Fehler"
 msgid " - PAUSED"
 msgstr " - PAUSIERT"
 
-msgid "Press %s to return to windowed mode."
-msgstr "%s ab, zur Rückkehr in den Fenstermodus."
+msgid "Press %1 to return to windowed mode."
+msgstr "%1 ab, zur Rückkehr in den Fenstermodus."
 
 msgid "Speed"
 msgstr "Geschwindigkeit"
@@ -717,14 +717,11 @@ msgstr "Andere Peripheriegeräte"
 msgid "Click to capture mouse"
 msgstr "Klicken zum Einfangen des Mauszeigers"
 
-msgid "Press %s to release mouse"
-msgstr "Drücke %s zur Mausfreigabe"
+msgid "Press %1 to release mouse"
+msgstr "Drücke %1 zur Mausfreigabe"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "Drücke %s oder die mittlere Maustaste zur Mausfreigabe"
-
-msgid "Ctrl+End"
-msgstr "Strg+Ende"
+msgid "Press %1 or middle button to release mouse"
+msgstr "Drücke %1 oder die mittlere Maustaste zur Mausfreigabe"
 
 msgid "Bus"
 msgstr "Bus"

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -630,8 +630,8 @@ msgstr "Error fatal"
 msgid " - PAUSED"
 msgstr " - EN PAUSA"
 
-msgid "Press %s to return to windowed mode."
-msgstr "Pulsa %s para volver a modo ventana."
+msgid "Press %1 to return to windowed mode."
+msgstr "Pulsa %1 para volver a modo ventana."
 
 msgid "Speed"
 msgstr "Velocidad"
@@ -717,11 +717,11 @@ msgstr "Otros periféricos"
 msgid "Click to capture mouse"
 msgstr "Haga click para capturar el ratón"
 
-msgid "Press %s to release mouse"
-msgstr "Pulse %s para liberar el ratón"
+msgid "Press %1 to release mouse"
+msgstr "Pulse %1 para liberar el ratón"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "Pulse %s o el botón central para liberar el ratón"
+msgid "Press %1 or middle button to release mouse"
+msgstr "Pulse %1 o el botón central para liberar el ratón"
 
 msgid "Bus"
 msgstr "Bus"

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -630,8 +630,8 @@ msgstr "Vakava virhe"
 msgid " - PAUSED"
 msgstr " - TAUKO"
 
-msgid "Press %s to return to windowed mode."
-msgstr "Paina %s palataksesi ikkunoituun tilaan."
+msgid "Press %1 to return to windowed mode."
+msgstr "Paina %1 palataksesi ikkunoituun tilaan."
 
 msgid "Speed"
 msgstr "Nopeus"
@@ -717,11 +717,11 @@ msgstr "Muut oheislaitteet"
 msgid "Click to capture mouse"
 msgstr "Kaappaa hiiri klikkaamalla"
 
-msgid "Press %s to release mouse"
-msgstr "Paina %s vapauttaaksesi hiiren"
+msgid "Press %1 to release mouse"
+msgstr "Paina %1 vapauttaaksesi hiiren"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "Paina %s tai keskipainiketta vapauttaaksesi hiiren"
+msgid "Press %1 or middle button to release mouse"
+msgstr "Paina %1 tai keskipainiketta vapauttaaksesi hiiren"
 
 msgid "Bus"
 msgstr "Väylä"

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -630,8 +630,8 @@ msgstr "Erreur fatale"
 msgid " - PAUSED"
 msgstr " - EN PAUSE"
 
-msgid "Press %s to return to windowed mode."
-msgstr "Appuyez sur %s pour revenir au mode fenêtré."
+msgid "Press %1 to return to windowed mode."
+msgstr "Appuyez sur %1 pour revenir au mode fenêtré."
 
 msgid "Speed"
 msgstr "Vitesse"
@@ -717,11 +717,11 @@ msgstr "Autres périfériques"
 msgid "Click to capture mouse"
 msgstr "Cliquer pour capturer la souris"
 
-msgid "Press %s to release mouse"
-msgstr "Appuyer sur %s pour libérer la souris"
+msgid "Press %1 to release mouse"
+msgstr "Appuyer sur %1 pour libérer la souris"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "Appuyer sur %s ou le bouton central pour libérer la souris"
+msgid "Press %1 or middle button to release mouse"
+msgstr "Appuyer sur %1 ou le bouton central pour libérer la souris"
 
 msgid "Bus"
 msgstr "Bus"

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -630,8 +630,8 @@ msgstr "Fatalna greška"
 msgid " - PAUSED"
 msgstr " - ZASTAO"
 
-msgid "Press %s to return to windowed mode."
-msgstr "Pritisnite %s za povratak u prozorski način rada."
+msgid "Press %1 to return to windowed mode."
+msgstr "Pritisnite %1 za povratak u prozorski način rada."
 
 msgid "Speed"
 msgstr "Brzina"
@@ -717,11 +717,11 @@ msgstr "Ostali periferni uređaji"
 msgid "Click to capture mouse"
 msgstr "Kliknite da uhvatite miš"
 
-msgid "Press %s to release mouse"
-msgstr "Pritisnite %s za otpustanje miša"
+msgid "Press %1 to release mouse"
+msgstr "Pritisnite %1 za otpustanje miša"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "Pritisnite %s ili srednji gumb miša za otpuštanje miša"
+msgid "Press %1 or middle button to release mouse"
+msgstr "Pritisnite %1 ili srednji gumb miša za otpuštanje miša"
 
 msgid "Bus"
 msgstr "Bus"

--- a/src/qt/languages/hu-HU.po
+++ b/src/qt/languages/hu-HU.po
@@ -630,8 +630,8 @@ msgstr "Végzetes hiba"
 msgid " - PAUSED"
 msgstr " - SZÜNETELT"
 
-msgid "Press %s to return to windowed mode."
-msgstr "Használja a %s gombokat az ablakhoz való visszatéréshez."
+msgid "Press %1 to return to windowed mode."
+msgstr "Használja a %1 gombokat az ablakhoz való visszatéréshez."
 
 msgid "Speed"
 msgstr "Sebesség"
@@ -717,11 +717,11 @@ msgstr "Egyéb perifériák"
 msgid "Click to capture mouse"
 msgstr "Kattintson az egér elfogásához"
 
-msgid "Press %s to release mouse"
-msgstr "Nyomja meg az %s-t az egér elengédéséhez"
+msgid "Press %1 to release mouse"
+msgstr "Nyomja meg az %1-t az egér elengédéséhez"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "Nyomja meg az %s-t vagy a középső gombot az egér elengédéséhez"
+msgid "Press %1 or middle button to release mouse"
+msgstr "Nyomja meg az %1-t vagy a középső gombot az egér elengédéséhez"
 
 msgid "Bus"
 msgstr "Busz"

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -630,8 +630,8 @@ msgstr "Errore fatale"
 msgid " - PAUSED"
 msgstr " - IN PAUSA"
 
-msgid "Press %s to return to windowed mode."
-msgstr "Usa %s per tornare alla modalità finestra."
+msgid "Press %1 to return to windowed mode."
+msgstr "Usa %1 per tornare alla modalità finestra."
 
 msgid "Speed"
 msgstr "Velocità"
@@ -717,11 +717,11 @@ msgstr "Altre periferiche"
 msgid "Click to capture mouse"
 msgstr "Fare clic per catturare mouse"
 
-msgid "Press %s to release mouse"
-msgstr "Premi %s per rilasciare il mouse"
+msgid "Press %1 to release mouse"
+msgstr "Premi %1 per rilasciare il mouse"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "Premi %s o pulsante centrale per rilasciare il mouse"
+msgid "Press %1 or middle button to release mouse"
+msgstr "Premi %1 o pulsante centrale per rilasciare il mouse"
 
 msgid "Bus"
 msgstr "Bus"

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -630,8 +630,8 @@ msgstr "致命的なエラー"
 msgid " - PAUSED"
 msgstr " - 一時停止"
 
-msgid "Press %s to return to windowed mode."
-msgstr "%sでウィンドウ モードに戻ります。"
+msgid "Press %1 to return to windowed mode."
+msgstr "%1でウィンドウ モードに戻ります。"
 
 msgid "Speed"
 msgstr "速度"
@@ -717,11 +717,11 @@ msgstr "他の周辺デバイス"
 msgid "Click to capture mouse"
 msgstr "左クリックでマウスをキャプチャします"
 
-msgid "Press %s to release mouse"
-msgstr "%sキーでマウスを解放します"
+msgid "Press %1 to release mouse"
+msgstr "%1キーでマウスを解放します"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "%sキーまたは中クリックでマウスを解放します"
+msgid "Press %1 or middle button to release mouse"
+msgstr "%1キーまたは中クリックでマウスを解放します"
 
 msgid "Bus"
 msgstr "バス"

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -630,8 +630,8 @@ msgstr "치명적인 오류"
 msgid " - PAUSED"
 msgstr " - 일시 중지됨"
 
-msgid "Press %s to return to windowed mode."
-msgstr "%s 키를 누르면 창 모드로 전환합니다."
+msgid "Press %1 to return to windowed mode."
+msgstr "%1 키를 누르면 창 모드로 전환합니다."
 
 msgid "Speed"
 msgstr "속도"
@@ -717,11 +717,11 @@ msgstr "기타 주변기기"
 msgid "Click to capture mouse"
 msgstr "이 창을 클릭하면 마우스를 사용합니다"
 
-msgid "Press %s to release mouse"
-msgstr "%s키를 누르면 마우스를 해제합니다"
+msgid "Press %1 to release mouse"
+msgstr "%1키를 누르면 마우스를 해제합니다"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "%s키 또는 가운데 버튼을 클릭하면 마우스를 해제합니다"
+msgid "Press %1 or middle button to release mouse"
+msgstr "%1키 또는 가운데 버튼을 클릭하면 마우스를 해제합니다"
 
 msgid "Bus"
 msgstr "버스"

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -630,8 +630,8 @@ msgstr "Fatale fout"
 msgid " - PAUSED"
 msgstr " - GEPAUZEERD"
 
-msgid "Press %s to return to windowed mode."
-msgstr "Druk op %s om terug te gaan naar de venstermodus."
+msgid "Press %1 to return to windowed mode."
+msgstr "Druk op %1 om terug te gaan naar de venstermodus."
 
 msgid "Speed"
 msgstr "Snelheid"
@@ -717,11 +717,11 @@ msgstr "Andere randapparatuur"
 msgid "Click to capture mouse"
 msgstr "Klik om muis vast te leggen"
 
-msgid "Press %s to release mouse"
-msgstr "Druk op %s om de muis los te laten"
+msgid "Press %1 to release mouse"
+msgstr "Druk op %1 om de muis los te laten"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "Druk op %s of middelste knop om de muis los te laten"
+msgid "Press %1 or middle button to release mouse"
+msgstr "Druk op %1 of middelste knop om de muis los te laten"
 
 msgid "Bus"
 msgstr "Bus"

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -630,8 +630,8 @@ msgstr "Fatalny błąd"
 msgid " - PAUSED"
 msgstr " - PAUSED"
 
-msgid "Press %s to return to windowed mode."
-msgstr "Naciśnij klawisze %s aby wrócić to trybu okna."
+msgid "Press %1 to return to windowed mode."
+msgstr "Naciśnij klawisze %1 aby wrócić to trybu okna."
 
 msgid "Speed"
 msgstr "Szybkość"
@@ -717,11 +717,11 @@ msgstr "Inne urządzenia peryferyjne"
 msgid "Click to capture mouse"
 msgstr "Kliknij w celu przechwycenia myszy"
 
-msgid "Press %s to release mouse"
-msgstr "Naciśnij klawisze %s w celu uwolnienia myszy"
+msgid "Press %1 to release mouse"
+msgstr "Naciśnij klawisze %1 w celu uwolnienia myszy"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "Naciśnij klawisze %s lub środkowy przycisk w celu uwolnienia myszy"
+msgid "Press %1 or middle button to release mouse"
+msgstr "Naciśnij klawisze %1 lub środkowy przycisk w celu uwolnienia myszy"
 
 msgid "Bus"
 msgstr "Magistrala"

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -630,8 +630,8 @@ msgstr "Erro fatal"
 msgid " - PAUSED"
 msgstr " - PAUSADO"
 
-msgid "Press %s to return to windowed mode."
-msgstr "Use %s para retornar ao modo janela."
+msgid "Press %1 to return to windowed mode."
+msgstr "Use %1 para retornar ao modo janela."
 
 msgid "Speed"
 msgstr "Velocidade"
@@ -717,11 +717,11 @@ msgstr "Outros periféricos"
 msgid "Click to capture mouse"
 msgstr "Clique para capturar o mouse"
 
-msgid "Press %s to release mouse"
-msgstr "Aperte %s para liberar o mouse"
+msgid "Press %1 to release mouse"
+msgstr "Aperte %1 para liberar o mouse"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "Aperte %s ou botão do meio para liberar o mouse"
+msgid "Press %1 or middle button to release mouse"
+msgstr "Aperte %1 ou botão do meio para liberar o mouse"
 
 msgid "Bus"
 msgstr "Barramento"

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -630,8 +630,8 @@ msgstr "Erro fatal"
 msgid " - PAUSED"
 msgstr " - EM PAUSA"
 
-msgid "Press %s to return to windowed mode."
-msgstr "Pressione %s para voltar ao modo de janela."
+msgid "Press %1 to return to windowed mode."
+msgstr "Pressione %1 para voltar ao modo de janela."
 
 msgid "Speed"
 msgstr "Velocidade"
@@ -717,11 +717,11 @@ msgstr "Outros dispositivos"
 msgid "Click to capture mouse"
 msgstr "Clique para capturar o rato"
 
-msgid "Press %s to release mouse"
-msgstr "Pressione %s para soltar o rato"
+msgid "Press %1 to release mouse"
+msgstr "Pressione %1 para soltar o rato"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "Pressione %s ou tecla média para soltar o rato"
+msgid "Press %1 or middle button to release mouse"
+msgstr "Pressione %1 ou tecla média para soltar o rato"
 
 msgid "Bus"
 msgstr "Barramento"

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -630,8 +630,8 @@ msgstr "Неустранимая ошибка"
 msgid " - PAUSED"
 msgstr " - ПАУЗА"
 
-msgid "Press %s to return to windowed mode."
-msgstr "Нажмите %s для возврата в оконный режим."
+msgid "Press %1 to return to windowed mode."
+msgstr "Нажмите %1 для возврата в оконный режим."
 
 msgid "Speed"
 msgstr "Скорость"
@@ -717,11 +717,11 @@ msgstr "Другая периферия"
 msgid "Click to capture mouse"
 msgstr "Щёлкните мышью для захвата курсора"
 
-msgid "Press %s to release mouse"
-msgstr "Нажмите %s, чтобы освободить курсор"
+msgid "Press %1 to release mouse"
+msgstr "Нажмите %1, чтобы освободить курсор"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "Нажмите %s или среднюю кнопку мыши, чтобы освободить курсор"
+msgid "Press %1 or middle button to release mouse"
+msgstr "Нажмите %1 или среднюю кнопку мыши, чтобы освободить курсор"
 
 msgid "Bus"
 msgstr "Шина"

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -630,8 +630,8 @@ msgstr "Kritická chyba"
 msgid " - PAUSED"
 msgstr " - POZASTAVENÝ"
 
-msgid "Press %s to return to windowed mode."
-msgstr "Stlačte %s pre návrat z režimu celej obrazovky."
+msgid "Press %1 to return to windowed mode."
+msgstr "Stlačte %1 pre návrat z režimu celej obrazovky."
 
 msgid "Speed"
 msgstr "Rýchlosť"
@@ -717,11 +717,11 @@ msgstr "Iné príslušenstvo"
 msgid "Click to capture mouse"
 msgstr "Kliknite pre zabráni myši"
 
-msgid "Press %s to release mouse"
-msgstr "Stlačte %s pre uvoľnenie myši"
+msgid "Press %1 to release mouse"
+msgstr "Stlačte %1 pre uvoľnenie myši"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "Stlačte %s alebo prostredné tlačidlo na uvoľnenie myši"
+msgid "Press %1 or middle button to release mouse"
+msgstr "Stlačte %1 alebo prostredné tlačidlo na uvoľnenie myši"
 
 msgid "Bus"
 msgstr "Zbernica"

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -630,8 +630,8 @@ msgstr "Kritična napaka"
 msgid " - PAUSED"
 msgstr " - ZAUSTAVLJEN"
 
-msgid "Press %s to return to windowed mode."
-msgstr "Pritisnite %s za povratek iz celozaslonskega načina."
+msgid "Press %1 to return to windowed mode."
+msgstr "Pritisnite %1 za povratek iz celozaslonskega načina."
 
 msgid "Speed"
 msgstr "Hitrost"
@@ -717,11 +717,11 @@ msgstr "Druga periferija"
 msgid "Click to capture mouse"
 msgstr "Kliknite za zajem miške"
 
-msgid "Press %s to release mouse"
-msgstr "Pritisnite %s za izpust miške"
+msgid "Press %1 to release mouse"
+msgstr "Pritisnite %1 za izpust miške"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "Pritisnite %s ali srednji gumb za izpust miške"
+msgid "Press %1 or middle button to release mouse"
+msgstr "Pritisnite %1 ali srednji gumb za izpust miške"
 
 msgid "Bus"
 msgstr "Vodilo"

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -630,8 +630,8 @@ msgstr "Allvarligt fel"
 msgid " - PAUSED"
 msgstr " - PAUSAD"
 
-msgid "Press %s to return to windowed mode."
-msgstr "Tryck på %s för att återvända till fönsterläge."
+msgid "Press %1 to return to windowed mode."
+msgstr "Tryck på %1 för att återvända till fönsterläge."
 
 msgid "Speed"
 msgstr "Hastighet"
@@ -717,11 +717,11 @@ msgstr "Andra tillbehör"
 msgid "Click to capture mouse"
 msgstr "Klicka för att fånga upp musen"
 
-msgid "Press %s to release mouse"
-msgstr "Tryck på %s för att släppa musen"
+msgid "Press %1 to release mouse"
+msgstr "Tryck på %1 för att släppa musen"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "Tryck på %s eller mellersta musknappen för att släppa musen"
+msgid "Press %1 or middle button to release mouse"
+msgstr "Tryck på %1 eller mellersta musknappen för att släppa musen"
 
 msgid "Bus"
 msgstr "Buss"

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -630,8 +630,8 @@ msgstr "Kritik hata"
 msgid " - PAUSED"
 msgstr " - DURAKLATILDI"
 
-msgid "Press %s to return to windowed mode."
-msgstr "Pencere moduna geri dönmek için %s tuşlarına basın."
+msgid "Press %1 to return to windowed mode."
+msgstr "Pencere moduna geri dönmek için %1 tuşlarına basın."
 
 msgid "Speed"
 msgstr "Hız"
@@ -717,11 +717,11 @@ msgstr "Diğer cihazlar"
 msgid "Click to capture mouse"
 msgstr "Farenin yakalanması için tıklayın"
 
-msgid "Press %s to release mouse"
-msgstr "Farenin bırakılması için %s tuşlarına basın"
+msgid "Press %1 to release mouse"
+msgstr "Farenin bırakılması için %1 tuşlarına basın"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "Farenin bırakılması için %s tuşlarına veya tekerlek tuşuna basın"
+msgid "Press %1 or middle button to release mouse"
+msgstr "Farenin bırakılması için %1 tuşlarına veya tekerlek tuşuna basın"
 
 msgid "Bus"
 msgstr "Veri yolu"

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -630,8 +630,8 @@ msgstr "Непереробна помилка"
 msgid " - PAUSED"
 msgstr " - ПРИЗУПИНЕННЯ"
 
-msgid "Press %s to return to windowed mode."
-msgstr "Натисніть %s для повернення у віконний режим."
+msgid "Press %1 to return to windowed mode."
+msgstr "Натисніть %1 для повернення у віконний режим."
 
 msgid "Speed"
 msgstr "Швидкість"
@@ -717,11 +717,11 @@ msgstr "Інша периферія"
 msgid "Click to capture mouse"
 msgstr "Клацніть мишею для захвату курсора"
 
-msgid "Press %s to release mouse"
-msgstr "Натисніть %s, щоб звільнити курсор"
+msgid "Press %1 to release mouse"
+msgstr "Натисніть %1, щоб звільнити курсор"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "Натисніть %s або середню кнопку миші, щоб звільнити курсор"
+msgid "Press %1 or middle button to release mouse"
+msgstr "Натисніть %1 або середню кнопку миші, щоб звільнити курсор"
 
 msgid "Bus"
 msgstr "Шина"

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -630,8 +630,8 @@ msgstr "Lỗi nghiêm trọng"
 msgid " - PAUSED"
 msgstr " - TẠM DỪNG"
 
-msgid "Press %s to return to windowed mode."
-msgstr "Bấm %s để quay lại chế độ cửa sổ."
+msgid "Press %1 to return to windowed mode."
+msgstr "Bấm %1 để quay lại chế độ cửa sổ."
 
 msgid "Speed"
 msgstr "Vận tốc"
@@ -717,11 +717,11 @@ msgstr "Thiết bị ngoại vi khác"
 msgid "Click to capture mouse"
 msgstr "Nhấp vào khung hình để 'nhốt' chuột vào"
 
-msgid "Press %s to release mouse"
-msgstr "Nhấn %s để thả chuột"
+msgid "Press %1 to release mouse"
+msgstr "Nhấn %1 để thả chuột"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "Nhấn %s hoặc nhấp chuột giữa để thả chuột"
+msgid "Press %1 or middle button to release mouse"
+msgstr "Nhấn %1 hoặc nhấp chuột giữa để thả chuột"
 
 msgid "Bus"
 msgstr "Bus"

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -630,8 +630,8 @@ msgstr "致命错误"
 msgid " - PAUSED"
 msgstr " - 已暂停"
 
-msgid "Press Ctrl+Alt+PgDn to return to windowed mode."
-msgstr "按下 Ctrl+Alt+PgDn 返回到窗口模式。"
+msgid "Press %1 to return to windowed mode."
+msgstr "按下 %1 返回到窗口模式。"
 
 msgid "Speed"
 msgstr "速度"
@@ -717,11 +717,11 @@ msgstr "其他外围设备"
 msgid "Click to capture mouse"
 msgstr "单击窗口捕捉鼠标"
 
-msgid "Press %s to release mouse"
-msgstr "按下 %s 释放鼠标"
+msgid "Press %1 to release mouse"
+msgstr "按下 %1 释放鼠标"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "按下 %s 或鼠标中键释放鼠标"
+msgid "Press %1 or middle button to release mouse"
+msgstr "按下 %1 或鼠标中键释放鼠标"
 
 msgid "Bus"
 msgstr "总线"

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -630,8 +630,8 @@ msgstr "致命錯誤"
 msgid " - PAUSED"
 msgstr " - 已暫停"
 
-msgid "Press Ctrl+Alt+PgDn to return to windowed mode."
-msgstr "按下 Ctrl+Alt+PgDn 返回到視窗模式。"
+msgid "Press %1 to return to windowed mode."
+msgstr "按下 %1 返回到視窗模式。"
 
 msgid "Speed"
 msgstr "速度"
@@ -717,11 +717,11 @@ msgstr "其他周邊裝置"
 msgid "Click to capture mouse"
 msgstr "點擊視窗捕捉滑鼠"
 
-msgid "Press %s to release mouse"
-msgstr "按下 %s 釋放滑鼠"
+msgid "Press %1 to release mouse"
+msgstr "按下 %1 釋放滑鼠"
 
-msgid "Press %s or middle button to release mouse"
-msgstr "按下 %s 或滑鼠中鍵釋放滑鼠"
+msgid "Press %1 or middle button to release mouse"
+msgstr "按下 %1 或滑鼠中鍵釋放滑鼠"
 
 msgid "Bus"
 msgstr "匯流排"

--- a/src/qt/qt_keybind.cpp
+++ b/src/qt/qt_keybind.cpp
@@ -90,7 +90,7 @@ KeyBinder::BindKey(QWidget* widget, QString CurValue)
 	KeyBinder kb(widget);
 	kb.setWindowTitle(tr("Bind Key"));
     kb.setFixedSize(kb.minimumSizeHint());
-	kb.findChild<QKeySequenceEdit*>()->setKeySequence(QKeySequence::fromString(CurValue));
+	kb.findChild<QKeySequenceEdit*>()->setKeySequence(QKeySequence::fromString(CurValue, QKeySequence::NativeText));
 	kb.setEnabled(true);
 	
     if (kb.exec() == QDialog::Accepted) {

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -1347,10 +1347,9 @@ MainWindow::on_actionFullscreen_triggered()
         if (video_fullscreen_first) {
             bool wasCaptured = mouse_capture == 1;
 
-			char strFullscreen[100];
-			sprintf(strFullscreen, qPrintable(tr("Press %s to return to windowed mode.")), acc_keys[FindAccelerator("fullscreen")].seq);
-
-            QMessageBox questionbox(QMessageBox::Icon::Information, tr("Entering fullscreen mode"), QString(strFullscreen), QMessageBox::Ok, this);
+            QMessageBox questionbox(QMessageBox::Icon::Information, tr("Entering fullscreen mode"),
+                tr("Press %1 to return to windowed mode.").arg(QKeySequence(acc_keys[FindAccelerator("fullscreen")].seq, QKeySequence::PortableText).toString(QKeySequence::NativeText)),
+                QMessageBox::Ok, this);
             QCheckBox  *chkbox = new QCheckBox(tr("Don't show this message again"));
             questionbox.setCheckBox(chkbox);
             chkbox->setChecked(!video_fullscreen_first);

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -43,6 +43,7 @@
 #include <QTimer>
 #include <QProcess>
 #include <QRegularExpression>
+#include <QKeySequence>
 
 #include <QLibrary>
 #include <QElapsedTimer>
@@ -571,8 +572,6 @@ c16stombs(char dst[], const uint16_t src[], int len)
 }
 #endif
 
-#    define MOUSE_CAPTURE_KEYSEQ "F8+F12"
-
 #ifdef _WIN32
 #    if defined(__amd64__) || defined(_M_X64) || defined(__aarch64__) || defined(_M_ARM64)
 #        define LIB_NAME_GS   "gsdll64.dll"
@@ -595,14 +594,8 @@ ProgSettings::reloadStrings()
 {
     translatedstrings.clear();
     translatedstrings[STRING_MOUSE_CAPTURE]             = QCoreApplication::translate("", "Click to capture mouse").toStdWString();
-	
-	char mouseCaptureKeyseq[100];
-	sprintf(mouseCaptureKeyseq, qPrintable(QCoreApplication::translate("", "Press %s to release mouse")), acc_keys[FindAccelerator("release_mouse")].seq);
-	translatedstrings[STRING_MOUSE_RELEASE]             = QString(mouseCaptureKeyseq).toStdWString();
-	
-	sprintf(mouseCaptureKeyseq, qPrintable(QCoreApplication::translate("", "Press %s or middle button to release mouse")), acc_keys[FindAccelerator("release_mouse")].seq);
-	translatedstrings[STRING_MOUSE_RELEASE_MMB]         = QString(mouseCaptureKeyseq).toStdWString(); 
-	
+    translatedstrings[STRING_MOUSE_RELEASE]             = QCoreApplication::translate("", "Press %1 to release mouse").arg(QKeySequence(acc_keys[FindAccelerator("release_mouse")].seq, QKeySequence::PortableText).toString(QKeySequence::NativeText)).toStdWString();
+    translatedstrings[STRING_MOUSE_RELEASE_MMB]         = QCoreApplication::translate("", "Press %1 or middle button to release mouse").arg(QKeySequence(acc_keys[FindAccelerator("release_mouse")].seq, QKeySequence::PortableText).toString(QKeySequence::NativeText)).toStdWString();
     translatedstrings[STRING_INVALID_CONFIG]            = QCoreApplication::translate("", "Invalid configuration").toStdWString();
     translatedstrings[STRING_NO_ST506_ESDI_CDROM]       = QCoreApplication::translate("", "MFM/RLL or ESDI CD-ROM drives never existed").toStdWString();
     translatedstrings[STRING_PCAP_ERROR_NO_DEVICES]     = QCoreApplication::translate("", "No PCap devices found").toStdWString();

--- a/src/qt/qt_settingsinput.cpp
+++ b/src/qt/qt_settingsinput.cpp
@@ -162,7 +162,7 @@ SettingsInput::refreshInputList()
 
 	for (int x=0;x<NUM_ACCELS;x++) {
 		ui->tableKeys->setItem(x, 0, new QTableWidgetItem(tr(acc_keys_t[x].desc)));
-		ui->tableKeys->setItem(x, 1, new QTableWidgetItem(acc_keys_t[x].seq));
+		ui->tableKeys->setItem(x, 1, new QTableWidgetItem(QKeySequence(acc_keys_t[x].seq, QKeySequence::PortableText).toString(QKeySequence::NativeText)));
 		ui->tableKeys->setItem(x, 2, new QTableWidgetItem(acc_keys_t[x].name));
 	}
 }
@@ -201,7 +201,7 @@ SettingsInput::on_tableKeys_cellDoubleClicked(int row, int col)
 		// so we don't test against shortcuts the user already changed.
 		for(int x=0;x<NUM_ACCELS;x++)
 		{
-			if(QString::fromStdString(acc_keys_t[x].seq) == keyseq.toString(QKeySequence::NativeText))
+			if(QString::fromStdString(acc_keys_t[x].seq) == keyseq.toString(QKeySequence::PortableText))
 			{
 				// That key is already in use
 				main_window->showMessage(MBX_ANSI & MBX_INFO, "Bind conflict", "This key combo is already in use", false);
@@ -212,12 +212,12 @@ SettingsInput::on_tableKeys_cellDoubleClicked(int row, int col)
 		// Go ahead and apply the bind.
 		
 		// Find the correct accelerator key entry
-		int accKeyID = FindAccelerator(qPrintable(ui->tableKeys->item(row,2)->text()));
+		int accKeyID = FindAccelerator(ui->tableKeys->item(row,2)->text().toUtf8().constData());
 		if (accKeyID < 0) return; // this should never happen
 		
 		// Make the change
 		cell->setText(keyseq.toString(QKeySequence::NativeText));
-		strcpy(acc_keys_t[accKeyID].seq, qPrintable(keyseq.toString(QKeySequence::NativeText)));
+		strcpy(acc_keys_t[accKeyID].seq, keyseq.toString(QKeySequence::PortableText).toUtf8().constData());
 		
 		refreshInputList();
 	}
@@ -242,7 +242,7 @@ SettingsInput::on_pushButtonClearBind_clicked()
 	
 	cell->setText("");
 	// Find the correct accelerator key entry
-	int accKeyID = FindAccelerator(qPrintable(ui->tableKeys->item(cell->row(),2)->text()));
+	int accKeyID = FindAccelerator(ui->tableKeys->item(cell->row(),2)->text().toUtf8().constData());
 	if (accKeyID < 0) return; // this should never happen
 	
 	// Make the change


### PR DESCRIPTION
Summary
=======
Keybinds are now both saved and read in portable form and only converted to native one for display purposes, fixing them not being read correctly when certain languages are set.

Also get rid of `qPrintable()` due to it using the system 8-bit codepage instead of UTF-8, and some unnecessary QString ↔ C string conversions.

Patch originally written by @Cacodemon345.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A