### PR TITLE
Remove the full-screen hotkey message

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -168,7 +168,6 @@ int      vid_api                                = 0;              /* (C) video r
 int      vid_cga_contrast                       = 0;              /* (C) video */
 int      video_fullscreen                       = 0;              /* (C) video */
 int      video_fullscreen_scale                 = 0;              /* (C) video */
-int      video_fullscreen_first                 = 0;              /* (C) video */
 int      enable_overscan                        = 0;              /* (C) video */
 int      force_43                               = 0;              /* (C) video */
 int      video_filter_method                    = 1;              /* (C) video */

--- a/src/config.c
+++ b/src/config.c
@@ -128,8 +128,6 @@ load_general(void)
 
     video_fullscreen_scale = ini_section_get_int(cat, "video_fullscreen_scale", 1);
 
-    video_fullscreen_first = ini_section_get_int(cat, "video_fullscreen_first", 1);
-
     video_filter_method = ini_section_get_int(cat, "video_filter_method", 1);
 
     inhibit_multimedia_keys = ini_section_get_int(cat, "inhibit_multimedia_keys", 0);
@@ -1832,7 +1830,6 @@ config_load(void)
         gfxcard[0]             = video_get_video_from_internal_name("cga");
         vid_api                = plat_vidapi("default");
         vid_resize             = 0;
-        video_fullscreen_first = 1;
         video_fullscreen_scale = 1;
         time_sync              = TIME_SYNC_ENABLED;
         hdc_current[0]         = hdc_get_from_internal_name("none");
@@ -1954,11 +1951,6 @@ save_general(void)
         ini_section_delete_var(cat, "video_fullscreen_scale");
     else
         ini_section_set_int(cat, "video_fullscreen_scale", video_fullscreen_scale);
-
-    if (video_fullscreen_first == 1)
-        ini_section_delete_var(cat, "video_fullscreen_first");
-    else
-        ini_section_set_int(cat, "video_fullscreen_first", video_fullscreen_first);
 
     if (video_filter_method == 1)
         ini_section_delete_var(cat, "video_filter_method");

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -121,7 +121,6 @@ extern int      dpi_scale;                  /* (C) DPI scaling of the emulated s
 extern int      vid_api;                    /* (C) video renderer */
 extern int      vid_cga_contrast;           /* (C) video */
 extern int      video_fullscreen;           /* (C) video */
-extern int      video_fullscreen_first;     /* (C) video */
 extern int      video_fullscreen_scale;     /* (C) video */
 extern int      enable_overscan;            /* (C) video */
 extern int      force_43;                   /* (C) video */

--- a/src/include/86box/video.h
+++ b/src/include/86box/video.h
@@ -189,7 +189,6 @@ extern uint32_t     pal_lookup[256];
 #endif
 extern int          video_fullscreen;
 extern int          video_fullscreen_scale;
-extern int          video_fullscreen_first;
 extern uint8_t      fontdat[2048][8];
 extern uint8_t      fontdatm[2048][16];
 extern uint8_t      fontdat2[2048][8];

--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -630,9 +630,6 @@ msgstr ""
 msgid " - PAUSED"
 msgstr ""
 
-msgid "Press %1 to return to windowed mode."
-msgstr ""
-
 msgid "Speed"
 msgstr ""
 
@@ -862,9 +859,6 @@ msgid "%1 is required for automatic conversion of PostScript files to PDF.\n\nAn
 msgstr ""
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
-msgstr ""
-
-msgid "Entering fullscreen mode"
 msgstr ""
 
 msgid "Don't show this message again"
@@ -1305,7 +1299,7 @@ msgstr ""
 msgid "\nFalling back to software rendering."
 msgstr ""
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
 msgstr ""
 
 msgid "This machine might have been moved or copied."
@@ -2110,9 +2104,6 @@ msgid "Ask for confirmation before hard resetting"
 msgstr ""
 
 msgid "Ask for confirmation before quitting"
-msgstr ""
-
-msgid "Display hotkey message when entering full-screen mode"
 msgstr ""
 
 msgid "Options"

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -630,9 +630,6 @@ msgstr "Error fatal"
 msgid " - PAUSED"
 msgstr " - EN PAUSA"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "Premeu %1 per tornar al mode de finestra."
-
 msgid "Speed"
 msgstr "Velocitat"
 
@@ -863,9 +860,6 @@ msgstr "%1 és necessària per a la conversió automàtica de fitxers PostScript
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
 msgstr "%1 és necessària per a la conversió automàtica de fitxers PCL a PDF.\n\nQualsevol document enviat a la impressora genèrica PCL es desarà com a fitxer Printer Command Language (.pcl)."
-
-msgid "Entering fullscreen mode"
-msgstr "Entrant en mode pantalla completa"
 
 msgid "Don't show this message again"
 msgstr "No mostreu més aquest missatge"
@@ -1305,8 +1299,8 @@ msgstr "Error en inicialitzar OpenGL"
 msgid "\nFalling back to software rendering."
 msgstr "\nTornant al renderitzador software."
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Quan seleccioneu imatges de suports (CD-ROM, disquet, etc.), el diàleg obert s’iniciarà al mateix directori que el fitxer de configuració 86Box. Aquesta configuració només farà una diferència en les macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>Quan seleccioneu imatges de suports (CD-ROM, disquet, etc.), el diàleg obert s’iniciarà al mateix directori que el fitxer de configuració 86Box. Aquesta configuració només farà una diferència en les macOS.</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "Aquesta màquina podria haver estat moguda o copiada."
@@ -2104,9 +2098,6 @@ msgid "Ask for confirmation before hard resetting"
 msgstr ""
 
 msgid "Ask for confirmation before quitting"
-msgstr ""
-
-msgid "Display hotkey message when entering full-screen mode"
 msgstr ""
 
 msgid "Options"

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -630,9 +630,6 @@ msgstr "Kritická chyba"
 msgid " - PAUSED"
 msgstr " - POZASTAVENO"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "Stiskněte %1 pro návrat z režimu celé obrazovky."
-
 msgid "Speed"
 msgstr "Rychlost"
 
@@ -863,9 +860,6 @@ msgstr "%1 je potřeba pro automatický převod PostScript dokumentů do PDF.\n\
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
 msgstr "%1 je potřeba pro automatický převod PCL dokumentů do PDF.\n\nJakékoliv dokumenty vytisknuté přes obecnou PCL-ovou tiskárnu budou uloženy jako Printer Command Language (.pcl) soubory."
-
-msgid "Entering fullscreen mode"
-msgstr "Vstup do režimu celé obrazovky"
 
 msgid "Don't show this message again"
 msgstr "Nezobrazovat dále tuto zprávu"
@@ -1305,8 +1299,8 @@ msgstr "Chyba při inicializaci OpenGL"
 msgid "\nFalling back to software rendering."
 msgstr "\nNávrat k softwarovému vykreslování."
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Při výběru obrazů médií (CD-ROM, disketa atd.) se otevřené dialogové okno spustí ve stejném adresáři jako konfigurační soubor 86Box. Toto nastavení bude mít pravděpodobně význam pouze v systému MacOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>Při výběru obrazů médií (CD-ROM, disketa atd.) se otevřené dialogové okno spustí ve stejném adresáři jako konfigurační soubor 86Box. Toto nastavení bude mít pravděpodobně význam pouze v systému MacOS.</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "Tento počítač mohl být přemístěn nebo zkopírován."
@@ -2104,9 +2098,6 @@ msgid "Ask for confirmation before hard resetting"
 msgstr ""
 
 msgid "Ask for confirmation before quitting"
-msgstr ""
-
-msgid "Display hotkey message when entering full-screen mode"
 msgstr ""
 
 msgid "Options"

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -630,9 +630,6 @@ msgstr "Fataler Fehler"
 msgid " - PAUSED"
 msgstr " - PAUSIERT"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "%1 ab, zur Rückkehr in den Fenstermodus."
-
 msgid "Speed"
 msgstr "Geschwindigkeit"
 
@@ -863,9 +860,6 @@ msgstr "%1 wird zur automatischen Konvertierung von PostScript-Dateien ins PDF-F
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
 msgstr "%1 wird zur automatischen Konvertierung von PCL-Dateien ins PDF-Format benötigt.\n\nSämtliche an den generischen PCL-Drucker gesendete Dateien werden als Printer Command Language (*.pcl) Dateien gesichert."
-
-msgid "Entering fullscreen mode"
-msgstr "Vollbildmodus wird aktiviert"
 
 msgid "Don't show this message again"
 msgstr "Diese Nachricht nicht mehr anzeigen"
@@ -1305,8 +1299,8 @@ msgstr "Fehler beim Initialisieren von OpenGL"
 msgid "\nFalling back to software rendering."
 msgstr "\nRückgriff auf Software-Rendering."
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Bei der Auswahl von Medien-Abbildern (CD-ROM, Diskette usw.) wird der Öffnungsdialog im selben Verzeichnis wie die 86Box-Konfigurationsdatei gestartet. Diese Einstellung macht wahrscheinlich nur unter macOS einen Unterschied.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>Bei der Auswahl von Medien-Abbildern (CD-ROM, Diskette usw.) wird der Öffnungsdialog im selben Verzeichnis wie die 86Box-Konfigurationsdatei gestartet. Diese Einstellung macht wahrscheinlich nur unter macOS einen Unterschied.</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "Dieses System wurde möglicherweise verschoben oder kopiert."
@@ -2104,9 +2098,6 @@ msgid "Ask for confirmation before hard resetting"
 msgstr ""
 
 msgid "Ask for confirmation before quitting"
-msgstr ""
-
-msgid "Display hotkey message when entering full-screen mode"
 msgstr ""
 
 msgid "Options"

--- a/src/qt/languages/en-GB.po
+++ b/src/qt/languages/en-GB.po
@@ -39,8 +39,8 @@ msgstr "Synchronise with video"
 msgid "Error initializing OpenGL"
 msgstr "Error initialising OpenGL"
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialogue will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialogue will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
 
 msgid "Color (generic)"
 msgstr "Colour (generic)"

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -630,9 +630,6 @@ msgstr "Error fatal"
 msgid " - PAUSED"
 msgstr " - EN PAUSA"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "Pulsa %1 para volver a modo ventana."
-
 msgid "Speed"
 msgstr "Velocidad"
 
@@ -863,9 +860,6 @@ msgstr "%1 es necesaria para la conversión automática de archivos PostScript a
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
 msgstr "%1 es necesaria para la conversión automática de archivos PCL a PDF.\n\nCualquier documento enviado a la impresora genérica PCL se guardará como archivo Printer Command Language (.pcl)."
-
-msgid "Entering fullscreen mode"
-msgstr "Entrando en modo pantalla completa"
 
 msgid "Don't show this message again"
 msgstr "No mostrar más este mensaje"
@@ -1304,8 +1298,8 @@ msgstr "Error al inicializar OpenGL"
 msgid "\nFalling back to software rendering."
 msgstr "\nRecurrir al renderizado por software."
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Al seleccionar imágenes multimedia (CD-ROM, disquete, etc.), el diálogo de apertura se iniciará en el mismo directorio que el archivo de configuración de 86Box. Es probable que este ajuste sólo suponga una diferencia en macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>Al seleccionar imágenes multimedia (CD-ROM, disquete, etc.), el diálogo de apertura se iniciará en el mismo directorio que el archivo de configuración de 86Box. Es probable que este ajuste sólo suponga una diferencia en macOS.</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "Esta máquina puede haber sido movida o copiado."
@@ -2103,9 +2097,6 @@ msgid "Ask for confirmation before hard resetting"
 msgstr ""
 
 msgid "Ask for confirmation before quitting"
-msgstr ""
-
-msgid "Display hotkey message when entering full-screen mode"
 msgstr ""
 
 msgid "Options"

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -630,9 +630,6 @@ msgstr "Vakava virhe"
 msgid " - PAUSED"
 msgstr " - TAUKO"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "Paina %1 palataksesi ikkunoituun tilaan."
-
 msgid "Speed"
 msgstr "Nopeus"
 
@@ -863,9 +860,6 @@ msgstr "%1 vaaditaan PostScript-tiedostojen automaattiseen muuntamiseen PDF-tied
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
 msgstr "%1 vaaditaan PCL-tiedostojen automaattiseen muuntamiseen PDF-tiedostoiksi.\n\nKaikki geneeriselle PCL-tulostimelle lähetetyt asiakirjat tallennetaan Printer Command Language (.ps) -tiedostoina."
-
-msgid "Entering fullscreen mode"
-msgstr "Siirrytään koko näytön tilaan"
 
 msgid "Don't show this message again"
 msgstr "Älä näytä tätä viestiä uudelleen"
@@ -1308,8 +1302,8 @@ msgstr "Virhe OpenGL:n alustamisessa"
 msgid "\nFalling back to software rendering."
 msgstr "\nPaluu ohjelmistoalustusöintiin."
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kun valitset mediakuvia (CD-ROM, levykkeet jne.), avausikkuna käynnistyy samaan hakemistoon kuin 86Boxin konfigurointitiedosto. Tällä asetuksella on todennäköisesti merkitystä vain macOS-käyttöjärjestelmässä.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>Kun valitset mediakuvia (CD-ROM, levykkeet jne.), avausikkuna käynnistyy samaan hakemistoon kuin 86Boxin konfigurointitiedosto. Tällä asetuksella on todennäköisesti merkitystä vain macOS-käyttöjärjestelmässä.</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "Kone on saatettu siirtää tai kopioida."
@@ -2107,9 +2101,6 @@ msgid "Ask for confirmation before hard resetting"
 msgstr ""
 
 msgid "Ask for confirmation before quitting"
-msgstr ""
-
-msgid "Display hotkey message when entering full-screen mode"
 msgstr ""
 
 msgid "Options"

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -630,9 +630,6 @@ msgstr "Erreur fatale"
 msgid " - PAUSED"
 msgstr " - EN PAUSE"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "Appuyez sur %1 pour revenir au mode fenêtré."
-
 msgid "Speed"
 msgstr "Vitesse"
 
@@ -863,9 +860,6 @@ msgstr "%1 est nécessaire pour la conversion automatique des fichiers PostScrip
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
 msgstr "%1 est nécessaire pour la conversion automatique des fichiers PCL en PDF.\n\nTous les documents envoyés à l'imprimante générique PCL seront sauvés en tant quefichiers Printer Command Language (.pcl)."
-
-msgid "Entering fullscreen mode"
-msgstr "Entrer en mode plein écran"
 
 msgid "Don't show this message again"
 msgstr "Ne pas montrer ce message à nouveau"
@@ -1305,8 +1299,8 @@ msgstr "Erreur d'initialisation d'OpenGL"
 msgid "\nFalling back to software rendering."
 msgstr "\nSe rabattre sur le rendu logiciel."
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lors de la sélection d'images multimédia (CD-ROM, disquette, etc.), la boîte de dialogue d'ouverture démarrera dans le même répertoire que le fichier de configuration de 86Box. Ce paramètre ne fera probablement une différence que sur macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>Lors de la sélection d'images multimédia (CD-ROM, disquette, etc.), la boîte de dialogue d'ouverture démarrera dans le même répertoire que le fichier de configuration de 86Box. Ce paramètre ne fera probablement une différence que sur macOS.</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "Cette machine peut avoir été déplacée ou copiée."
@@ -2105,9 +2099,6 @@ msgstr "Demander confirmation avant Hard Reset"
 
 msgid "Ask for confirmation before quitting"
 msgstr "Demander confirmation avant de quitter"
-
-msgid "Display hotkey message when entering full-screen mode"
-msgstr "Afficher Raccourcis Clavier avant de passer en plein écran"
 
 msgid "Options"
 msgstr "Options"

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -630,9 +630,6 @@ msgstr "Fatalna greška"
 msgid " - PAUSED"
 msgstr " - ZASTAO"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "Pritisnite %1 za povratak u prozorski način rada."
-
 msgid "Speed"
 msgstr "Brzina"
 
@@ -863,9 +860,6 @@ msgstr "%1 je potrebno za automatsku konverziju PostScript datoteke u PDF datote
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
 msgstr "%1 je potrebno za automatsku konverziju PCL datoteke u PDF datoteke.\n\nSvi dokumenti poslani na generički PCL pisač bit će spremljeni kao Printer Command Language (.pcl) datoteke."
-
-msgid "Entering fullscreen mode"
-msgstr "Ulazim u cijelozaslonski način"
 
 msgid "Don't show this message again"
 msgstr "Ne pokazi više ovu poruku"
@@ -1305,8 +1299,8 @@ msgstr "Nije moguće inicijalizirati OpenGL"
 msgid "\nFalling back to software rendering."
 msgstr "\nVraća se na softverski renderer."
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prilikom odabira medijskih slika (CD-ROM, diskete itd.), otvoreni dijalog zopočet će u istom direktoriju kao i konfiguracijska datoteka 86Box-a. Razlika će vjerojatno biti primjetna samo na macOS-u.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>Prilikom odabira medijskih slika (CD-ROM, diskete itd.), otvoreni dijalog zopočet će u istom direktoriju kao i konfiguracijska datoteka 86Box-a. Razlika će vjerojatno biti primjetna samo na macOS-u.</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "Ovaj je sistem mogao biti premješten ili kopiran."
@@ -2104,9 +2098,6 @@ msgid "Ask for confirmation before hard resetting"
 msgstr ""
 
 msgid "Ask for confirmation before quitting"
-msgstr ""
-
-msgid "Display hotkey message when entering full-screen mode"
 msgstr ""
 
 msgid "Options"

--- a/src/qt/languages/hu-HU.po
+++ b/src/qt/languages/hu-HU.po
@@ -630,9 +630,6 @@ msgstr "Végzetes hiba"
 msgid " - PAUSED"
 msgstr " - SZÜNETELT"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "Használja a %1 gombokat az ablakhoz való visszatéréshez."
-
 msgid "Speed"
 msgstr "Sebesség"
 
@@ -863,9 +860,6 @@ msgstr "%1 szükséges a PostScript fájlok PDF formátumba való automatikus ko
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Lnaugage (.pcl) files."
 msgstr "%1 szükséges a PCL fájlok PDF formátumba való automatikus konvertálásához.\n\nAz általános PCL nyomtatóra küldött dokumentumok Printer Command Language (.pcl) fájlként kerülnek mentésre."
-
-msgid "Entering fullscreen mode"
-msgstr "Teljes képernyős módra váltás"
 
 msgid "Don't show this message again"
 msgstr "Ne jelenítse meg újra ezt az üzenetet "
@@ -1305,8 +1299,8 @@ msgstr "Hiba az OpenGL inicializálásában"
 msgid "\nFalling back to software rendering."
 msgstr "\nVisszatérés a szoftveres rendereléshez."
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A médiaképek (CD-ROM, floppy stb.) kiválasztásakor a megnyitási párbeszédpanel ugyanabban a könyvtárban indul, mint a 86Box konfigurációs fájl. Ez a beállítás valószínűleg csak a macOS rendszerben jelent különbséget.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>A médiaképek (CD-ROM, floppy stb.) kiválasztásakor a megnyitási párbeszédpanel ugyanabban a könyvtárban indul, mint a 86Box konfigurációs fájl. Ez a beállítás valószínűleg csak a macOS rendszerben jelent különbséget.</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "Lehet, hogy ezt a gépet áthelyezték vagy lemásolták."
@@ -2104,9 +2098,6 @@ msgid "Ask for confirmation before hard resetting"
 msgstr ""
 
 msgid "Ask for confirmation before quitting"
-msgstr ""
-
-msgid "Display hotkey message when entering full-screen mode"
 msgstr ""
 
 msgid "Options"

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -630,9 +630,6 @@ msgstr "Errore fatale"
 msgid " - PAUSED"
 msgstr " - IN PAUSA"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "Usa %1 per tornare alla modalità finestra."
-
 msgid "Speed"
 msgstr "Velocità"
 
@@ -863,9 +860,6 @@ msgstr "%1 è richiesto per la conversione automatica di file PostScript a file 
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PostScript printer will be saved as Printer Command Language (.pcl) files."
 msgstr "%1 è richiesto per la conversione automatica di file PCL a file PDF.\n\nQualsiasi documento mandato alla stampante generica PCL sarà salvato come file Printer Command Language (.cl)."
-
-msgid "Entering fullscreen mode"
-msgstr "Entrando nella modalità schermo intero"
 
 msgid "Don't show this message again"
 msgstr "Non mostrare più questo messaggio"
@@ -1305,8 +1299,8 @@ msgstr "Errore nell'inizializzazione di OpenGL"
 msgid "\nFalling back to software rendering."
 msgstr "\nRicaduta sul rendering software."
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Quando si selezionano immagini multimediali (CD-ROM, floppy, ecc.) la finestra di dialogo di apertura si avvia nella stessa directory del file di configurazione di 86Box. Questa impostazione probabilmente farà la differenza solo su macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>Quando si selezionano immagini multimediali (CD-ROM, floppy, ecc.) la finestra di dialogo di apertura si avvia nella stessa directory del file di configurazione di 86Box. Questa impostazione probabilmente farà la differenza solo su macOS.</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "Questa macchina potrebbe essere stata spostata o copiata."
@@ -2104,9 +2098,6 @@ msgid "Ask for confirmation before hard resetting"
 msgstr ""
 
 msgid "Ask for confirmation before quitting"
-msgstr ""
-
-msgid "Display hotkey message when entering full-screen mode"
 msgstr ""
 
 msgid "Options"

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -630,9 +630,6 @@ msgstr "致命的なエラー"
 msgid " - PAUSED"
 msgstr " - 一時停止"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "%1でウィンドウ モードに戻ります。"
-
 msgid "Speed"
 msgstr "速度"
 
@@ -863,9 +860,6 @@ msgstr "PostScriptファイルをPDFに自動変換するには%1が必要です
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
 msgstr "PCLファイルをPDFに自動変換するには%1が必要です。\n\n汎用PCLプリンターに送信された文書は、Printer Command Language (.pcl) ファイルとして保存されます。"
-
-msgid "Entering fullscreen mode"
-msgstr "全画面モードを入力"
 
 msgid "Don't show this message again"
 msgstr "今後、このメッセージを表示しない"
@@ -1305,8 +1299,8 @@ msgstr "OpenGLの初期化エラー"
 msgid "\nFalling back to software rendering."
 msgstr "\nソフトウェアレンダリングに逆戻り。"
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;メディアイメージ（CD-ROM、フロッピーなど）を選択するとき、オープンダイアログは86Box設定ファイルと同じディレクトリで開始します。この設定は、おそらく macOS でのみ違いがあります。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>メディアイメージ（CD-ROM、フロッピーなど）を選択するとき、オープンダイアログは86Box設定ファイルと同じディレクトリで開始します。この設定は、おそらく macOS でのみ違いがあります。</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "このマシンは移動されたかコピーされた可能性がある。"
@@ -2104,9 +2098,6 @@ msgid "Ask for confirmation before hard resetting"
 msgstr ""
 
 msgid "Ask for confirmation before quitting"
-msgstr ""
-
-msgid "Display hotkey message when entering full-screen mode"
 msgstr ""
 
 msgid "Options"

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -630,9 +630,6 @@ msgstr "치명적인 오류"
 msgid " - PAUSED"
 msgstr " - 일시 중지됨"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "%1 키를 누르면 창 모드로 전환합니다."
-
 msgid "Speed"
 msgstr "속도"
 
@@ -863,9 +860,6 @@ msgstr "%1은(는) PostScript 파일을 PDF로 자동변환하는 데에 필요�
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
 msgstr "%1은(는) PCL 파일을 PDF로 자동변환하는 데에 필요합니다.\n\n표준 PCL 프린터로 보내신 임의의 문서는 Printer Command Language (.pcl) 파일로 저장됩니다."
-
-msgid "Entering fullscreen mode"
-msgstr "전체 화면으로 전환"
 
 msgid "Don't show this message again"
 msgstr "이 메시지 그만 보기"
@@ -1305,8 +1299,8 @@ msgstr "OpenGL 초기화 중 오류 발생"
 msgid "\nFalling back to software rendering."
 msgstr "\n소프트웨어 렌더링으로 돌아가기."
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;미디어 이미지(CD-ROM, 플로피 등)를 선택하면 86Box 구성 파일과 동일한 디렉터리에서 열기 대화 상자가 시작됩니다. 이 설정은 macOS에서만 차이가 있을 수 있습니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>미디어 이미지(CD-ROM, 플로피 등)를 선택하면 86Box 구성 파일과 동일한 디렉터리에서 열기 대화 상자가 시작됩니다. 이 설정은 macOS에서만 차이가 있을 수 있습니다.</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "이 컴퓨터가 이동되었거나 복사되었을 수 있습니다."
@@ -2104,9 +2098,6 @@ msgid "Ask for confirmation before hard resetting"
 msgstr ""
 
 msgid "Ask for confirmation before quitting"
-msgstr ""
-
-msgid "Display hotkey message when entering full-screen mode"
 msgstr ""
 
 msgid "Options"

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -630,9 +630,6 @@ msgstr "Fatale fout"
 msgid " - PAUSED"
 msgstr " - GEPAUZEERD"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "Druk op %1 om terug te gaan naar de venstermodus."
-
 msgid "Speed"
 msgstr "Snelheid"
 
@@ -863,9 +860,6 @@ msgstr "%1 is vereist voor automatische conversie van PostScript-bestanden naar 
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
 msgstr "%1 is vereist voor automatische conversie van PCL-bestanden naar PDF.\n\nAlle documenten die naar de generieke PCL-printer worden gestuurd, worden opgeslagen als Printer Command Language (.pcl) bestanden."
-
-msgid "Entering fullscreen mode"
-msgstr "Volledig scherm modus openen"
 
 msgid "Don't show this message again"
 msgstr "Dit bericht niet meer tonen"
@@ -1305,8 +1299,8 @@ msgstr "Fout bij het initialiseren van OpenGL"
 msgid "\nFalling back to software rendering."
 msgstr "\nTerugvallen op software rendering."
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Bij het selecteren van media-images (CD-ROM, floppy, etc.) zal de \"open dialoog\" starten in dezelfde map als het 86Box configuratiebestand. Deze instelling is doet er waarschijnlijk alleen toe op macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>Bij het selecteren van media-images (CD-ROM, floppy, etc.) zal de \"open dialoog\" starten in dezelfde map als het 86Box configuratiebestand. Deze instelling is doet er waarschijnlijk alleen toe op macOS.</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "Deze machine is misschien verplaatst of gekopieerd."
@@ -2105,9 +2099,6 @@ msgstr "Vraag om bevestiging voor een harde reset"
 
 msgid "Ask for confirmation before quitting"
 msgstr "Vraag om bevestiging voor afsluiten"
-
-msgid "Display hotkey message when entering full-screen mode"
-msgstr "Toon een sneltoetsmelding bij het openen van de volledigschermmodus"
 
 msgid "Options"
 msgstr "Opties"

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -630,9 +630,6 @@ msgstr "Fatalny błąd"
 msgid " - PAUSED"
 msgstr " - PAUSED"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "Naciśnij klawisze %1 aby wrócić to trybu okna."
-
 msgid "Speed"
 msgstr "Szybkość"
 
@@ -863,9 +860,6 @@ msgstr "%1 jest wymagany do automatycznej konwersji plików PostScript do PDF.\n
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
 msgstr "%1 jest wymagany do automatycznej konwersji plików PCL do PDF.\n\nDokumenty wysłane do generycznej drukarki PCL zostaną zapisane jako pliki Printer Command Language (.pcl)."
-
-msgid "Entering fullscreen mode"
-msgstr "Przechodzenie do trybu pełnoekranowego"
 
 msgid "Don't show this message again"
 msgstr "Nie pokazuj więcej tego komunikatu"
@@ -1305,8 +1299,8 @@ msgstr "Błąd inicjalizacji OpenGL"
 msgid "\nFalling back to software rendering."
 msgstr "\nPowrót do renderowania oprogramowania."
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Podczas wybierania obrazów nośników (CD-ROM, dyskietka itp.) otwarte okno dialogowe rozpocznie się w tym samym katalogu, co plik konfiguracyjny 86Box. To ustawienie prawdopodobnie będzie miało znaczenie tylko na macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>Podczas wybierania obrazów nośników (CD-ROM, dyskietka itp.) otwarte okno dialogowe rozpocznie się w tym samym katalogu, co plik konfiguracyjny 86Box. To ustawienie prawdopodobnie będzie miało znaczenie tylko na macOS.</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "To urządzenie mogło zostać przeniesione lub skopiowane."
@@ -2104,9 +2098,6 @@ msgid "Ask for confirmation before hard resetting"
 msgstr ""
 
 msgid "Ask for confirmation before quitting"
-msgstr ""
-
-msgid "Display hotkey message when entering full-screen mode"
 msgstr ""
 
 msgid "Options"

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -630,9 +630,6 @@ msgstr "Erro fatal"
 msgid " - PAUSED"
 msgstr " - PAUSADO"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "Use %1 para retornar ao modo janela."
-
 msgid "Speed"
 msgstr "Velocidade"
 
@@ -863,9 +860,6 @@ msgstr "%1 é necessário para a conversão automática de arquivos PostScript p
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
 msgstr "%1 é necessário para a conversão automática de arquivos PCL para PDF.\n\nQualquer documento enviado para a impressora genérica PCL será salvo como arquivos Printer Command Language (.pcl)."
-
-msgid "Entering fullscreen mode"
-msgstr "Entrando no modo de tela cheia"
 
 msgid "Don't show this message again"
 msgstr "Não exibir esta mensagem novamente"
@@ -1305,8 +1299,8 @@ msgstr "Erro ao inicializar o OpenGL"
 msgid "\nFalling back to software rendering."
 msgstr "\nVoltando à renderização de software."
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ao selecionar imagens de mídia (CD-ROM, disquete, etc.), a caixa de diálogo de abertura será iniciada no mesmo diretório do arquivo de configuração do 86Box. Essa configuração provavelmente só fará diferença no macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>Ao selecionar imagens de mídia (CD-ROM, disquete, etc.), a caixa de diálogo de abertura será iniciada no mesmo diretório do arquivo de configuração do 86Box. Essa configuração provavelmente só fará diferença no macOS.</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "Essa máquina pode ter sido movida ou copiada."
@@ -2105,9 +2099,6 @@ msgstr "Perguntar antes de reinicialização completa"
 
 msgid "Ask for confirmation before quitting"
 msgstr "Perguntar antes de sair"
-
-msgid "Display hotkey message when entering full-screen mode"
-msgstr "Mostrar mensagem de atalho quando entrar em tela cheia"
 
 msgid "Options"
 msgstr "Opções"

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -630,9 +630,6 @@ msgstr "Erro fatal"
 msgid " - PAUSED"
 msgstr " - EM PAUSA"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "Pressione %1 para voltar ao modo de janela."
-
 msgid "Speed"
 msgstr "Velocidade"
 
@@ -863,9 +860,6 @@ msgstr "%1 é requerido para a conversão automática de ficheiros PostScript pa
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
 msgstr "%1 é requerido para a conversão automática de ficheiros PCL para ficheiros PDF.\n\nQualquer documento enviado para a impressora PCL genérica será gravado como um ficheiro Printer Command Language (.pcl)."
-
-msgid "Entering fullscreen mode"
-msgstr "A entrar no modo de tela cheia"
 
 msgid "Don't show this message again"
 msgstr "Não mostrar mais esta mensagem"
@@ -1305,8 +1299,8 @@ msgstr "Erro ao inicializar o OpenGL"
 msgid "\nFalling back to software rendering."
 msgstr "\nRecuando para a renderização de software."
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ao selecionar imagens multimédia (CD-ROM, disquete, etc.) a caixa de diálogo de abertura irá começar no mesmo diretório que o ficheiro de configuração da 86Box. Esta configuração provavelmente só fará diferença no macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>Ao selecionar imagens multimédia (CD-ROM, disquete, etc.) a caixa de diálogo de abertura irá começar no mesmo diretório que o ficheiro de configuração da 86Box. Esta configuração provavelmente só fará diferença no macOS.</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "Esta máquina pode ter sido deslocada ou copiada."
@@ -2104,9 +2098,6 @@ msgid "Ask for confirmation before hard resetting"
 msgstr ""
 
 msgid "Ask for confirmation before quitting"
-msgstr ""
-
-msgid "Display hotkey message when entering full-screen mode"
 msgstr ""
 
 msgid "Options"

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -630,9 +630,6 @@ msgstr "Неустранимая ошибка"
 msgid " - PAUSED"
 msgstr " - ПАУЗА"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "Нажмите %1 для возврата в оконный режим."
-
 msgid "Speed"
 msgstr "Скорость"
 
@@ -863,9 +860,6 @@ msgstr "Для автоматического преобразования фа�
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
 msgstr "Для автоматического преобразования файлов PCL в PDF требуется %1.\n\nВсе документы, отправленные на стандартный принтер PCL, будут сохранены в виде файлов Printer Command Language (.pcl)."
-
-msgid "Entering fullscreen mode"
-msgstr "Вход в полноэкранный режим"
 
 msgid "Don't show this message again"
 msgstr "Больше не показывать это сообщение"
@@ -1305,8 +1299,8 @@ msgstr "Ошибка инициализации OpenGL"
 msgid "\nFalling back to software rendering."
 msgstr "\nПереключение на программный рендеринг."
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;При выборе образов носителей (CD-ROM, дискет и т. д.) диалог открытия будет запускаться в том же каталоге, что и файл конфигурации 86Box. Эта настройка, скорее всего, будет иметь значение только на macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>При выборе образов носителей (CD-ROM, дискет и т. д.) диалог открытия будет запускаться в том же каталоге, что и файл конфигурации 86Box. Эта настройка, скорее всего, будет иметь значение только на macOS.</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "Возможно, эта машина была перемещена или скопирована."
@@ -2111,9 +2105,6 @@ msgstr "Запрашивать подтверждение перед холод�
 
 msgid "Ask for confirmation before quitting"
 msgstr "Запрашивать подтверждение перед выходом"
-
-msgid "Display hotkey message when entering full-screen mode"
-msgstr "Показывать сообщение о горячей клавише при входе в полноэкранный режим"
 
 msgid "Options"
 msgstr "Параметры"

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -630,9 +630,6 @@ msgstr "Kritická chyba"
 msgid " - PAUSED"
 msgstr " - POZASTAVENÝ"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "Stlačte %1 pre návrat z režimu celej obrazovky."
-
 msgid "Speed"
 msgstr "Rýchlosť"
 
@@ -863,9 +860,6 @@ msgstr "%1 je potrebná pre automatický prevod PostScript dokumentov do PDF.\n\
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Lnaugage (.pcl) files."
 msgstr "%1 je potrebná pre automatický prevod PCL dokumentov do PDF.\n\nAkékoľvek dokumenty vytlačené cez všeobecnú PCLovú tlačiareň budú uložené ako Printer Command Language (.pcl) súbory."
-
-msgid "Entering fullscreen mode"
-msgstr "Vstup do režimu celej obrazovky"
 
 msgid "Don't show this message again"
 msgstr "Nezobrazovať ďalej túto správu"
@@ -1306,8 +1300,8 @@ msgstr "Chyba pri inicializácii OpenGL"
 msgid "\nFalling back to software rendering."
 msgstr "\nNávrat k softvérovému vykresľovaniu."
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pri výbere multimediálnych obrazov (CD-ROM, disketa atď.) sa dialógové okno otvorenia spustí v rovnakom adresári ako konfiguračný súbor 86Box. Toto nastavenie bude mať pravdepodobne význam len v systéme MacOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>Pri výbere multimediálnych obrazov (CD-ROM, disketa atď.) sa dialógové okno otvorenia spustí v rovnakom adresári ako konfiguračný súbor 86Box. Toto nastavenie bude mať pravdepodobne význam len v systéme MacOS.</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "Tento stroj mohol byť premiestnený alebo skopírovaný."
@@ -2105,9 +2099,6 @@ msgid "Ask for confirmation before hard resetting"
 msgstr ""
 
 msgid "Ask for confirmation before quitting"
-msgstr ""
-
-msgid "Display hotkey message when entering full-screen mode"
 msgstr ""
 
 msgid "Options"

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -630,9 +630,6 @@ msgstr "Kritična napaka"
 msgid " - PAUSED"
 msgstr " - ZAUSTAVLJEN"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "Pritisnite %1 za povratek iz celozaslonskega načina."
-
 msgid "Speed"
 msgstr "Hitrost"
 
@@ -863,9 +860,6 @@ msgstr "%1 je potreben za samodejno pretvorbo datotek PostScript v PDF.\n\nVsi d
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Lnaugage (.pcl) files."
 msgstr "%1 je potreben za samodejno pretvorbo datotek PCL v PDF.\n\nVsi dokumenti, poslani generičnemu tiskalniku PCL bodo shranjeni kot datoteke Printer Command Language (.pcl)."
-
-msgid "Entering fullscreen mode"
-msgstr "Preklapljam v celozaslonski način"
 
 msgid "Don't show this message again"
 msgstr "Ne pokaži več tega sporočila"
@@ -1305,8 +1299,8 @@ msgstr "Napaka pri inicializaciji OpenGL"
 msgid "\nFalling back to software rendering."
 msgstr "\nVrnitev na programsko upodabljanje."
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pri izbiri medijskih slik (CD-ROM, disketa itd.) se bo odprto pogovorno okno začelo v istem imeniku kot konfiguracijska datoteka 86Box. Ta nastavitev bo verjetno imela pomen le v operacijskem sistemu MacOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>Pri izbiri medijskih slik (CD-ROM, disketa itd.) se bo odprto pogovorno okno začelo v istem imeniku kot konfiguracijska datoteka 86Box. Ta nastavitev bo verjetno imela pomen le v operacijskem sistemu MacOS.</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "Ta naprava je bila morda premeščena ali kopirana."
@@ -2105,9 +2099,6 @@ msgstr "Vprašaj za potrditev pred ponovnim zagonom"
 
 msgid "Ask for confirmation before quitting"
 msgstr "Vprašaj za potrditev pred izhodom"
-
-msgid "Display hotkey message when entering full-screen mode"
-msgstr "Prikaži obvestilo o bližnjični tipki pri prehodu v celozaslonski način"
 
 msgid "Options"
 msgstr "Možnosti"

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -630,9 +630,6 @@ msgstr "Allvarligt fel"
 msgid " - PAUSED"
 msgstr " - PAUSAD"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "Tryck på %1 för att återvända till fönsterläge."
-
 msgid "Speed"
 msgstr "Hastighet"
 
@@ -863,9 +860,6 @@ msgstr "%1 krävs för automatisk omvandling av PostScript-filer till PDF.\n\nAl
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
 msgstr "%1 krävs för automatisk omvandling av PCL-filer till PDF.\n\nAlla dokument som skickas till den allmänna PCL-skrivaren kommer att sparas som Printer Command Language-filer (.pcl)."
-
-msgid "Entering fullscreen mode"
-msgstr "Startar helskärmsläge"
 
 msgid "Don't show this message again"
 msgstr "Visa inte detta meddelande igen"
@@ -1305,8 +1299,8 @@ msgstr "Fel vid initialisering av OpenGL"
 msgid "\nFalling back to software rendering."
 msgstr "\nFaller tillbaka på mjukvarurendering."
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Vid val av medieavbildningar (CD-ROM, diskett, osv.) så kommer fönstret att börja i samma mapp som 86Box konfigurationsfil. Denna inställning kommer troligtvis endast göra en skillnad på macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>Vid val av medieavbildningar (CD-ROM, diskett, osv.) så kommer fönstret att börja i samma mapp som 86Box konfigurationsfil. Denna inställning kommer troligtvis endast göra en skillnad på macOS.</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "Denna maskin kan ha flyttats eller kopierats."
@@ -2111,9 +2105,6 @@ msgstr "Bekräfta innan hård omstart"
 
 msgid "Ask for confirmation before quitting"
 msgstr "Bekräfta innan avslut"
-
-msgid "Display hotkey message when entering full-screen mode"
-msgstr "Visa meddelande om snabbtangenter när helskärmsläget startas"
 
 msgid "Options"
 msgstr "Alternativ"

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -630,9 +630,6 @@ msgstr "Kritik hata"
 msgid " - PAUSED"
 msgstr " - DURAKLATILDI"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "Pencere moduna geri dönmek için %1 tuşlarına basın."
-
 msgid "Speed"
 msgstr "Hız"
 
@@ -863,9 +860,6 @@ msgstr "%1 PostScript dosyalarının otomatik olarak PDF dosyalarına çevirilme
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PostScript printer will be saved as Printer Command Language (.pcl) files."
 msgstr "%1 PCL dosyalarının otomatik olarak PDF dosyalarına çevirilmesi için gereklidir.\n\nBu bulunmadığından dolayı genel PostScript yazıcısına gönderilen tüm dökümanlar Printer Command Language (.pcl) dosyası olarak kaydedilecektir."
-
-msgid "Entering fullscreen mode"
-msgstr "Tam ekran moduna geçiş yapılıyor"
 
 msgid "Don't show this message again"
 msgstr "Bu mesajı bir daha gösterme"
@@ -1305,8 +1299,8 @@ msgstr "OpenGL başlatılırken hata oluştu"
 msgid "\nFalling back to software rendering."
 msgstr "\nYazılım işleyicisine geri dönülüyor."
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Medya görüntüsü (CD-ROM, disket, vb.) seçme diyaloğu 86Box yapılandırma dosyasıyla aynı dizinde başlayacaktır. Bu ayar muhtemelen sadece macOS üzerinde bir fark meydana getirecektir.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>Medya görüntüsü (CD-ROM, disket, vb.) seçme diyaloğu 86Box yapılandırma dosyasıyla aynı dizinde başlayacaktır. Bu ayar muhtemelen sadece macOS üzerinde bir fark meydana getirecektir.</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "Bu makine taşınmış veya kopyalanmış olabilir."
@@ -2104,9 +2098,6 @@ msgid "Ask for confirmation before hard resetting"
 msgstr ""
 
 msgid "Ask for confirmation before quitting"
-msgstr ""
-
-msgid "Display hotkey message when entering full-screen mode"
 msgstr ""
 
 msgid "Options"

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -630,9 +630,6 @@ msgstr "Непереробна помилка"
 msgid " - PAUSED"
 msgstr " - ПРИЗУПИНЕННЯ"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "Натисніть %1 для повернення у віконний режим."
-
 msgid "Speed"
 msgstr "Швидкість"
 
@@ -863,9 +860,6 @@ msgstr "%1 потрібно для автоматичного перетворе
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
 msgstr "%1 потрібно для автоматичного перетворення файлів PCL в PDF.\n\nВсі документи, відправлені на загальний принтер PCL, будуть збережені у вигляді файлів Printer Command Language (.ps)."
-
-msgid "Entering fullscreen mode"
-msgstr "Вхід у повноекранний режим"
 
 msgid "Don't show this message again"
 msgstr "Більше не показувати це повідомлення"
@@ -1305,8 +1299,8 @@ msgstr "Помилка ініціалізації OpenGL"
 msgid "\nFalling back to software rendering."
 msgstr "\nПовернення до програмного рендерингу."
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;При виборі медіа-образів (CD-ROM, дискета і т.д.) діалогове вікно буде відкриватися в тому ж каталозі, що і файл конфігурації 86Box. Цей параметр, швидше за все, матиме значення лише на macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>При виборі медіа-образів (CD-ROM, дискета і т.д.) діалогове вікно буде відкриватися в тому ж каталозі, що і файл конфігурації 86Box. Цей параметр, швидше за все, матиме значення лише на macOS.</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "Цю машину могли перемістити або скопіювати."
@@ -2110,9 +2104,6 @@ msgid "Ask for confirmation before hard resetting"
 msgstr ""
 
 msgid "Ask for confirmation before quitting"
-msgstr ""
-
-msgid "Display hotkey message when entering full-screen mode"
 msgstr ""
 
 msgid "Options"

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -630,9 +630,6 @@ msgstr "Lỗi nghiêm trọng"
 msgid " - PAUSED"
 msgstr " - TẠM DỪNG"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "Bấm %1 để quay lại chế độ cửa sổ."
-
 msgid "Speed"
 msgstr "Vận tốc"
 
@@ -863,9 +860,6 @@ msgstr "Cần có %1 để tự động chuyển đổi file PostScript qua PDF.
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
 msgstr "Cần có %1 để tự động chuyển đổi file PCL qua PDF.\n\nMọi tài liệu được đưa qua máy in generic PCL sẽ lưu ở dạng Printer Command Language (.pcl)."
-
-msgid "Entering fullscreen mode"
-msgstr "Đang tiến vào chế độ toàn màn hình"
 
 msgid "Don't show this message again"
 msgstr "Không hiện thông báo này nữa"
@@ -1305,8 +1299,8 @@ msgstr "Lỗi khởi tạo OpenGL"
 msgid "\nFalling back to software rendering."
 msgstr "\nQuay trở lại kết xuất phần mềm."
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Khi chọn hình ảnh phương tiện (CD-ROM, ổ mềm, v.v.), hộp thoại mở sẽ bắt đầu trong cùng thư mục với tệp cấu hình 86box. Cài đặt này có thể sẽ chỉ tạo ra sự khác biệt trên macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>Khi chọn hình ảnh phương tiện (CD-ROM, ổ mềm, v.v.), hộp thoại mở sẽ bắt đầu trong cùng thư mục với tệp cấu hình 86box. Cài đặt này có thể sẽ chỉ tạo ra sự khác biệt trên macOS.</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "Cấu hình máy này có thể đã được di chuyển hoặc sao chép."
@@ -2104,9 +2098,6 @@ msgid "Ask for confirmation before hard resetting"
 msgstr ""
 
 msgid "Ask for confirmation before quitting"
-msgstr ""
-
-msgid "Display hotkey message when entering full-screen mode"
 msgstr ""
 
 msgid "Options"

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -630,9 +630,6 @@ msgstr "致命错误"
 msgid " - PAUSED"
 msgstr " - 已暂停"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "按下 %1 返回到窗口模式。"
-
 msgid "Speed"
 msgstr "速度"
 
@@ -863,9 +860,6 @@ msgstr "%1 是将 PostScript 文件转换为 PDF 所需要的库。\n\n使用通
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
 msgstr "%1 是将 PCL 文件转换为 PDF 所需要的库。\n\n使用通用 PCL 打印机打印的文档将被保存为 Printer Command Language (.pcl) 文件。"
-
-msgid "Entering fullscreen mode"
-msgstr "正在进入全屏模式"
 
 msgid "Don't show this message again"
 msgstr "不要再显示此消息"
@@ -1305,8 +1299,8 @@ msgstr "初始化 OpenGL 时出错"
 msgid "\nFalling back to software rendering."
 msgstr "\n回到软件渲染。"
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;选择媒体图像（光盘、软盘等）时，打开对话框将从与 86Box 配置文件相同的目录开始。这一设置可能只会在 macOS 上产生影响。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt；"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>选择媒体图像（光盘、软盘等）时，打开对话框将从与 86Box 配置文件相同的目录开始。这一设置可能只会在 macOS 上产生影响。</p></body></html&gt；"
 
 msgid "This machine might have been moved or copied."
 msgstr "这台机器可能被移动或复制过。"
@@ -2104,9 +2098,6 @@ msgid "Ask for confirmation before hard resetting"
 msgstr ""
 
 msgid "Ask for confirmation before quitting"
-msgstr ""
-
-msgid "Display hotkey message when entering full-screen mode"
 msgstr ""
 
 msgid "Options"

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -630,9 +630,6 @@ msgstr "致命錯誤"
 msgid " - PAUSED"
 msgstr " - 已暫停"
 
-msgid "Press %1 to return to windowed mode."
-msgstr "按下 %1 返回到視窗模式。"
-
 msgid "Speed"
 msgstr "速度"
 
@@ -863,9 +860,6 @@ msgstr "%1 是將 PostScript 檔案轉換為 PDF 所需要的庫。\n\n使用通
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
 msgstr "%1 是將 PCL 檔案轉換為 PDF 所需要的庫。\n\n使用通用 PCL 印表機列印的文件將被儲存為 Printer Command Language (.pcl) 檔案。"
-
-msgid "Entering fullscreen mode"
-msgstr "正在進入全螢幕模式"
 
 msgid "Don't show this message again"
 msgstr "不要再顯示此消息"
@@ -1305,8 +1299,8 @@ msgstr "初始化 OpenGL 出錯"
 msgid "\nFalling back to software rendering."
 msgstr "\n回退到軟體渲染。"
 
-msgid "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
-msgstr "&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;當選擇媒體映像 (CD-ROM、軟碟等) 時，開啟對話方塊會在與 86Box 設定檔相同的目錄中開始。此設定可能只會在 macOS 上有所影響。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>當選擇媒體映像 (CD-ROM、軟碟等) 時，開啟對話方塊會在與 86Box 設定檔相同的目錄中開始。此設定可能只會在 macOS 上有所影響。</p></body></html>"
 
 msgid "This machine might have been moved or copied."
 msgstr "這台機器可能已被移動或複製。"
@@ -2104,9 +2098,6 @@ msgid "Ask for confirmation before hard resetting"
 msgstr ""
 
 msgid "Ask for confirmation before quitting"
-msgstr ""
-
-msgid "Display hotkey message when entering full-screen mode"
 msgstr ""
 
 msgid "Options"

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -1345,26 +1345,6 @@ MainWindow::on_actionFullscreen_triggered()
             emit resizeContents(vid_resize == 2 ? fixed_size_x : monitors[0].mon_scrnsz_x, vid_resize == 2 ? fixed_size_y : monitors[0].mon_scrnsz_y);
         }
     } else {
-        if (video_fullscreen_first) {
-            bool wasCaptured = mouse_capture == 1;
-
-            QMessageBox questionbox(QMessageBox::Icon::Information, tr("Entering fullscreen mode"),
-                tr("Press %1 to return to windowed mode.").arg(QKeySequence(acc_keys[FindAccelerator("fullscreen")].seq, QKeySequence::PortableText).toString(QKeySequence::NativeText)),
-                QMessageBox::Ok, this);
-            QCheckBox  *chkbox = new QCheckBox(tr("Don't show this message again"));
-            questionbox.setCheckBox(chkbox);
-            chkbox->setChecked(!video_fullscreen_first);
-
-            QObject::connect(chkbox, &QCheckBox::stateChanged, [](int state) {
-                video_fullscreen_first = (state == Qt::CheckState::Unchecked);
-            });
-            questionbox.exec();
-            config_save();
-
-            /* (re-capture mouse after dialog). */
-            if (wasCaptured)
-                emit setMouseCapture(true);
-        }
         video_fullscreen = 1;
         setFixedSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
         ui->menubar->hide();

--- a/src/qt/qt_progsettings.cpp
+++ b/src/qt/qt_progsettings.cpp
@@ -96,7 +96,6 @@ ProgSettings::ProgSettings(QWidget *parent)
     ui->checkBoxConfirmExit->setChecked(confirm_exit);
     ui->checkBoxConfirmSave->setChecked(confirm_save);
     ui->checkBoxConfirmHardReset->setChecked(confirm_reset);
-    ui->checkBoxFullscreenFirst->setChecked(video_fullscreen_first);
 
 #ifndef Q_OS_WINDOWS
     ui->checkBoxMultimediaKeys->setHidden(true);
@@ -111,7 +110,6 @@ ProgSettings::accept()
     confirm_exit            = ui->checkBoxConfirmExit->isChecked() ? 1 : 0;
     confirm_save            = ui->checkBoxConfirmSave->isChecked() ? 1 : 0;
     confirm_reset           = ui->checkBoxConfirmHardReset->isChecked() ? 1 : 0;
-    video_fullscreen_first  = ui->checkBoxFullscreenFirst->isChecked() ? 1 : 0;
     inhibit_multimedia_keys = ui->checkBoxMultimediaKeys->isChecked() ? 1 : 0;
 
     loadTranslators(QCoreApplication::instance());

--- a/src/qt/qt_progsettings.ui
+++ b/src/qt/qt_progsettings.ui
@@ -165,13 +165,6 @@
      </property>
     </widget>
    </item>
-   <item row="11" column="0">
-    <widget class="QCheckBox" name="checkBoxFullscreenFirst">
-     <property name="text">
-      <string>Display hotkey message when entering full-screen mode</string>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <resources/>


### PR DESCRIPTION
Summary
=======
Removes the notice before entering full-screen mode for the first time, because it's no longer needed after the hotkeys to enter and exit full-screen mode were merged into one.

(Drive-by: fix translations for a tooltip in the preferences dialog)

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A