### PR TITLE
P54NP4 fixes of the evening (May 7th, 2025)

### DIFF
--- a/src/machine/m_at_socket5.c
+++ b/src/machine/m_at_socket5.c
@@ -110,19 +110,19 @@ machine_at_p54np4_init(const machine_t *model)
         return ret;
 
     machine_at_common_init(model);
+    device_add(&ide_vlb_2ch_device);
 
-    pci_init(PCI_CONFIG_TYPE_2 | PCI_NO_IRQ_STEERING);
+    pci_init(PCI_CONFIG_TYPE_2 | PCI_CAN_SWITCH_TYPE);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x03, PCI_CARD_NORMAL,      1, 2, 3, 4); /* 03 = Slot 1 */
-    pci_register_slot(0x04, PCI_CARD_NORMAL,      2, 3, 4, 1); /* 04 = Slot 2 */
-    pci_register_slot(0x05, PCI_CARD_NORMAL,      3, 4, 1, 2); /* 05 = Slot 3 */
-    pci_register_slot(0x06, PCI_CARD_NORMAL,      4, 1, 2, 3); /* 06 = Slot 4 */
-    pci_register_slot(0x07, PCI_CARD_SCSI,        1, 2, 3, 4); /* 07 = SCSI   */
+    pci_register_slot(0x06, PCI_CARD_NORMAL,      1, 2, 3, 4); /* 06 = Slot 1 */
+    pci_register_slot(0x05, PCI_CARD_NORMAL,      2, 3, 4, 1); /* 05 = Slot 2 */
+    pci_register_slot(0x04, PCI_CARD_NORMAL,      3, 4, 1, 2); /* 04 = Slot 3 */
+    pci_register_slot(0x03, PCI_CARD_NORMAL,      4, 1, 2, 3); /* 03 = Slot 4 */
     pci_register_slot(0x02, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 0);
     device_add(&i430nx_device);
+    device_add(&sio_zb_device);
     device_add(&keyboard_ps2_ami_pci_device);
     device_add(&fdc37c665_ide_pri_device);
-    device_add(&ncr53c810_onboard_pci_device);
     device_add(&intel_flash_bxt_device);
 
     return ret;


### PR DESCRIPTION
Summary
=======
1. The 430NX does support PCI IRQ steering, fix it accordingly.
2. Reorder the number of the slots.
3. Add the SIO ZB device to said machine as it must have one.
4. Remove the onboard 810 SCSI controller.

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
