### PR TITLE
Fix mono pattern position in the Mach64 cards using 24bpp mode (May 7th, 2025)

### DIFF
--- a/src/video/vid_ati_mach64.c
+++ b/src/video/vid_ati_mach64.c
@@ -1670,7 +1670,7 @@ mach64_blit(uint32_t cpu_dat, int count, mach64_t *mach64)
                     case MONO_SRC_PAT:
                         if (mach64->dst_cntl & DST_24_ROT_EN) {
                             if (!mach64->accel.xx_count)
-                                mix = mach64->accel.pattern[dst_y & 7][dst_x & 7];
+                                mix = mach64->accel.pattern[dst_y & 7][(dst_x / 3) & 7];
                         } else
                             mix = mach64->accel.pattern[dst_y & 7][dst_x & 7];
                         break;


### PR DESCRIPTION
Summary
=======
See above.

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
