### PR TITLE
Actually fix the timing of the PAS16/Plus SCSI side (May 8th, 2025)

### DIFF
--- a/src/sound/snd_pas16.c
+++ b/src/sound/snd_pas16.c
@@ -792,14 +792,10 @@ pas16_in(uint16_t port, void *priv)
                 if ((scsi_bus->tx_mode == PIO_TX_BUS) && !(ret & 0x80))
                     ret |= 0x80;
 
-                if (ret & 0x80) {
-                    if (scsi_bus->data_repeat < MIN(511, scsi_bus->total_len))
-                        scsi_bus->data_repeat++;
-                } else {
-                    if (scsi_bus->data_repeat == MIN(511, scsi_bus->total_len))
-                        ret = 0x00;
-                }
-                pas16_log("%04X:%08X: Port %04x read ret=%02x, status=%02x, txmode=%x, repeat=%d.\n", CS, cpu_state.pc, port + pas16->base, ret, pas16->scsi->status & 0x06, scsi_bus->tx_mode, scsi_bus->data_repeat);
+                if ((pas16->scsi->status & 0x06) == 0x00)
+                    ret = 0x00;
+
+                pas16_log("%04X:%08X: Port %04x read ret=%02x, status=%02x, txmode=%x, repeat=%d, total=%d.\n", CS, cpu_state.pc, port + pas16->base, ret, pas16->scsi->status & 0x06, scsi_bus->tx_mode, scsi_bus->data_repeat, MIN(511, scsi_bus->total_len));
             }
             break;
         case 0x5c03:


### PR DESCRIPTION
Summary
=======
See above, fixes the non-audio mamv1.sys SCSI controller driver using CD/HDD reads/writes.

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
