### PR TITLE
Honour `--nohook` on X11 as well

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -322,7 +322,8 @@ MainWindow::MainWindow(QWidget *parent)
         mouse_capture = state ? 1 : 0;
         qt_mouse_capture(mouse_capture);
         if (mouse_capture) {
-            this->grabKeyboard();
+            if (hook_enabled)
+                this->grabKeyboard();
             if (ui->stackedWidget->mouse_capture_func)
                 ui->stackedWidget->mouse_capture_func(this->windowHandle());
         } else {
@@ -1481,13 +1482,15 @@ MainWindow::eventFilter(QObject *receiver, QEvent *event)
             plat_pause(curdopause);
 #ifdef __unix__
             if (!QApplication::platformName().contains("wayland") && (this->windowState() & Qt::WindowActive)) {
-                this->grabKeyboard();
+                if (hook_enabled)
+                    this->grabKeyboard();
             }
 #endif
         } else if (event->type() == QEvent::WindowActivate) {
 #ifdef __unix__
             if (!QApplication::platformName().contains("wayland")) {
-                this->grabKeyboard();
+                if (hook_enabled)
+                    this->grabKeyboard();
             }
 #endif
         } else if (event->type() == QEvent::WindowDeactivate) {

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -77,7 +77,7 @@ RendererStack::RendererStack(QWidget *parent, int monitor_index)
 
     m_monitor_index = monitor_index;
 #if defined __unix__ && !defined __HAIKU__
-    char auto_mouse_type[16];
+    memset(auto_mouse_type, 0, sizeof (auto_mouse_type));
     mousedata.mouse_type = getenv("EMU86BOX_MOUSE");
     if (!mousedata.mouse_type || (mousedata.mouse_type[0] == '\0') || !stricmp(mousedata.mouse_type, "auto")) {
         if (QApplication::platformName().contains("wayland"))

--- a/src/qt/qt_rendererstack.hpp
+++ b/src/qt/qt_rendererstack.hpp
@@ -137,6 +137,8 @@ private:
 
     std::atomic_bool rendererTakesScreenshots;
     std::atomic_bool switchInProgress{false};
+
+    char auto_mouse_type[16];
 };
 
 #endif // QT_RENDERERCONTAINER_HPP


### PR DESCRIPTION
Summary
=======
Honour `--nohook` on X11 as well.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
