### PR TITLE
Revert X11-related keyboard grabbing changes (except for `--nohook` ones)

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -327,8 +327,7 @@ MainWindow::MainWindow(QWidget *parent)
             if (ui->stackedWidget->mouse_capture_func)
                 ui->stackedWidget->mouse_capture_func(this->windowHandle());
         } else {
-            if (!(windowState() & Qt::WindowActive))
-                this->releaseKeyboard();
+            this->releaseKeyboard();
             if (ui->stackedWidget->mouse_uncapture_func) {
                 ui->stackedWidget->mouse_uncapture_func();
             }
@@ -1480,25 +1479,6 @@ MainWindow::eventFilter(QObject *receiver, QEvent *event)
             releaseKeyboard();
         } else if (event->type() == QEvent::WindowUnblocked) {
             plat_pause(curdopause);
-#ifdef __unix__
-            if (!QApplication::platformName().contains("wayland") && (this->windowState() & Qt::WindowActive)) {
-                if (hook_enabled)
-                    this->grabKeyboard();
-            }
-#endif
-        } else if (event->type() == QEvent::WindowActivate) {
-#ifdef __unix__
-            if (!QApplication::platformName().contains("wayland")) {
-                if (hook_enabled)
-                    this->grabKeyboard();
-            }
-#endif
-        } else if (event->type() == QEvent::WindowDeactivate) {
-#ifdef __unix__
-            if (!QApplication::platformName().contains("wayland")) {
-                this->releaseKeyboard();
-            }
-#endif
         }
     }
 	


### PR DESCRIPTION
Summary
=======
Revert X11-related keyboard grabbing changes (except for `--nohook` ones).

Fixes moving with titlebar on GNOME and Cinnamon.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
