### PR TITLE
Add the Phoenix BIOS variant of the Micronics 09-00021 386DX machine

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -519,6 +519,7 @@ extern int machine_at_asus386_init(const machine_t *);
 extern int machine_at_ecs386_init(const machine_t *);
 extern int machine_at_spc6000a_init(const machine_t *);
 extern int machine_at_micronics386_init(const machine_t *);
+extern int machine_at_micronics386px_init(const machine_t *);
 extern int machine_at_ecs386v_init(const machine_t *);
 extern int machine_at_tandy4000_init(const machine_t *);
 

--- a/src/machine/m_at_286_386sx.c
+++ b/src/machine/m_at_286_386sx.c
@@ -281,6 +281,26 @@ machine_at_micronics386_init(const machine_t *model)
     return ret;
 }
 
+int
+machine_at_micronics386px_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_interleaved("roms/machines/micronics386/386-Micronics-09-00021-LO.BIN",
+                                "roms/machines/micronics386/386-Micronics-09-00021-HI.BIN",
+                                0x000f0000, 65536, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_init(model);
+
+    if (fdc_current[0] == FDC_INTERNAL)
+        device_add(&fdc_at_device);
+
+    return ret;
+}
+
 static void
 machine_at_scat_init(const machine_t *model, int is_v4, int is_ami)
 {

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -5435,11 +5435,51 @@ const machine_t machines[] = {
     },
     /* Has IBM AT KBC firmware. */
     {
-        .name = "[ISA] Micronics 09-00021",
+        .name = "[ISA] Micronics 09-00021 (Tandon BIOS)",
         .internal_name = "micronics386",
         .type = MACHINE_TYPE_386DX,
         .chipset = MACHINE_CHIPSET_DISCRETE,
         .init = machine_at_micronics386_init,
+        .p1_handler = NULL,
+        .gpio_handler = NULL,
+        .available_flag = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu = {
+            .package = CPU_PKG_386DX,
+            .block = CPU_BLOCK_NONE,
+            .min_bus = 0,
+            .max_bus = 0,
+            .min_voltage = 0,
+            .max_voltage = 0,
+            .min_multi = 0,
+            .max_multi = 0
+        },
+        .bus_flags = MACHINE_AT,
+        .flags = MACHINE_APM,
+        .ram = {
+            .min = 512,
+            .max = 8192,
+            .step = 128
+        },
+        .nvrmask = 127,
+        .kbc_device = NULL,
+        .kbc_p1 = 0xff,
+        .gpio = 0xffffffff,
+        .gpio_acpi = 0xffffffff,
+        .device = NULL,
+        .fdc_device = NULL,
+        .sio_device = NULL,
+        .vid_device = NULL,
+        .snd_device = NULL,
+        .net_device = NULL
+    },
+    /* Has IBM AT KBC firmware. */
+    {
+        .name = "[ISA] Micronics 09-00021 (Phoenix BIOS)",
+        .internal_name = "micronics386px",
+        .type = MACHINE_TYPE_386DX,
+        .chipset = MACHINE_CHIPSET_DISCRETE,
+        .init = machine_at_micronics386px_init,
         .p1_handler = NULL,
         .gpio_handler = NULL,
         .available_flag = MACHINE_AVAILABLE,


### PR DESCRIPTION
Summary
=======
Add the Phoenix BIOS variant for the Micronics 09-00021, in addition to the existing Tandon BIOS variant, since the Phoenix BIOS is much less limited.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [X] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request -https://github.com/86Box/roms/pull/322

References
==========
[_Provide links to datasheets or other documentation that helped you implement this pull request._
](https://theretroweb.com/motherboards/s/micronics-386-i-cache-09-00010-xx-09-00021-#bios)