### PR TITLE
Small ATI Mach8 changes (May 19th, 2025)

### DIFF
--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -2510,6 +2510,12 @@ mach_in(uint16_t addr, void *priv)
                 case 0xa9:
                     temp = svga->vc & 0xff;
                     break;
+                case 0xaa:
+                    if (ATI_GRAPHICS_ULTRA)
+                        temp = 0x06;
+                    else
+                        temp = 0x00;
+                    break;
                 case 0xb0:
                     temp = mach->regs[0xb0] | 0x80;
                     temp &= ~0x18;
@@ -2699,12 +2705,10 @@ mach_set_resolution(mach_t *mach, svga_t *svga)
         dev->vdisp += 2;
 
     dev->v_total = dev->v_total_reg + 1;
-    if (dev->interlace)
-        dev->v_total >>= 1;
 
     dev->v_syncstart = dev->v_sync_start + 1;
-    if (dev->interlace)
-        dev->v_syncstart >>= 1;
+
+    mach_log("VSYNCSTART=%d, VTOTAL=%d, interlace=%02x, vdisp=%d.\n", dev->v_syncstart, dev->v_total, dev->interlace, dev->vdisp);
 
     if (ATI_8514A_ULTRA) {
         if ((mach->accel.clock_sel & 0x01) &&
@@ -3233,7 +3237,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             if (len == 1) {
                 if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03))) { /*For 8514/A mode, take the shadow sets into account.*/
                     if (!(mach->shadow_cntl & 0x20)) {
-                        WRITE8(port, dev->v_disp, val);
+                        WRITE8(port, dev->v_disp, val >> 8);
                         dev->v_disp &= 0x1fff;
                     }
                 }
@@ -3267,7 +3271,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             if (len == 1) {
                 if ((mach->accel.clock_sel & 0x01) || (!(mach->accel.clock_sel & 0x01) && (mach->shadow_set & 0x03))) {  /*For 8514/A mode, take the shadow sets into account.*/
                     if (!(mach->shadow_cntl & 0x10)) {
-                        WRITE8(port, dev->v_sync_start, val);
+                        WRITE8(port, dev->v_sync_start, val >> 8);
                         dev->v_sync_start &= 0x1fff;
                     }
                 }


### PR DESCRIPTION
Summary
=======
1. Report the ATI 28800 of the Graphics Ultra as 28800-6.
2. Access the upper word properly on vdisp.
3. Make sure there's enough vsyncstart/vtotal space for a full vertical display.


Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
