### PR TITLE
Mach8 mode changes of the day (May 20th, 2025)

### DIFF
--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -2710,7 +2710,7 @@ mach_set_resolution(mach_t *mach, svga_t *svga)
 
     mach_log("VSYNCSTART=%d, VTOTAL=%d, interlace=%02x, vdisp=%d.\n", dev->v_syncstart, dev->v_total, dev->interlace, dev->vdisp);
 
-    if (ATI_8514A_ULTRA) {
+    if (!ATI_MACH32) {
         if ((mach->accel.clock_sel & 0x01) &&
             !(dev->accel.advfunc_cntl & 0x01))
             ret = 2;


### PR DESCRIPTION
Summary
=======
Make the previously Mach8 add-on only mode changes also available to the Graphics Ultra, should fix incorrect resolutions after switching from fullscreen DOS prompt to windowed and viceversa under Win98 (and SE).

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
