### PR TITLE
Fix the Password "Disabled by Jumper" error on Dimension XPS Pxxx and Pxxxa/Mxxxa

### DIFF
--- a/src/device/kbc_at.c
+++ b/src/device/kbc_at.c
@@ -1106,6 +1106,14 @@ write64_generic(void *priv, uint8_t val)
                      */
                     uint8_t p1 = 0x30;
                     kbc_delay_to_ob(dev, p1, 0, 0x00);
+                } else if (!strcmp(machine_get_internal_name(), "dellplato") | !strcmp(machine_get_internal_name(), "dellhannibalp")) {
+                    /*
+                       Dell Dimension XPS Pxxx & Pxxxa/Mxxxa:
+                           - Bit 3: Password disable jumper (must be clear);
+                           - Bit 4: Clear CMOS jumper (must be set);
+                     */
+                    uint8_t p1 = 0x10;
+                    kbc_delay_to_ob(dev, p1, 0, 0x00);
                 } else {
                     /* (B0 or F0) | (0x08 or 0x0c) */
                     uint8_t p1_out = ((dev->p1 | fixed_bits) & 0xf0) |


### PR DESCRIPTION
Summary
=======
This fixes the password "disabled by jumper" error in BIOS setup on Dimension XPS Pxxx and Pxxxa/Mxxxa, by setting and clearing the necessary General Purpose I/O (GPIO) pins. Specifically, it sets Bit 4 (0x10, for clear CMOS jumper) and clears Bit 3 (0x08, for password disable jumper)

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
My own testing of the necessary GPIO pins
