### PR TITLE
Fix a small typo with the password disable jumper fix that causes some checks to fail

### DIFF
--- a/src/device/kbc_at.c
+++ b/src/device/kbc_at.c
@@ -1106,7 +1106,7 @@ write64_generic(void *priv, uint8_t val)
                      */
                     uint8_t p1 = 0x30;
                     kbc_delay_to_ob(dev, p1, 0, 0x00);
-                } else if (!strcmp(machine_get_internal_name(), "dellplato") | !strcmp(machine_get_internal_name(), "dellhannibalp")) {
+                } else if (!strcmp(machine_get_internal_name(), "dellplato") || !strcmp(machine_get_internal_name(), "dellhannibalp")) {
                     /*
                        Dell Dimension XPS Pxxx & Pxxxa/Mxxxa:
                            - Bit 3: Password disable jumper (must be clear);


### PR DESCRIPTION
Summary
=======
Fix a small typo with the jumper fix PR I created that causes some checks to fail

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
