### PR TITLE
Fix a small mistake with the IRQ table of the OptiPlex GXa

### DIFF
--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -167,7 +167,7 @@ machine_at_optiplex_gxa_init(const machine_t *model)
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 1, 2, 3, 4);
     pci_register_slot(0x0D, PCI_CARD_NORMAL,      2, 1, 3, 4);
     pci_register_slot(0x0E, PCI_CARD_NORMAL,      3, 4, 2, 1);
-    pci_register_slot(0x11, PCI_CARD_NORMAL,      4, 0, 0, 0);
+    pci_register_slot(0x11, PCI_CARD_NETWORK,     4, 0, 0, 0);
     pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 4);
     pci_register_slot(0x01, PCI_CARD_AGPBRIDGE,   1, 2, 3, 4);
 


### PR DESCRIPTION
Summary
=======
This fixes an incorrectly stated PCI slot in the IRQ table of the OptiPlex GXa

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
