### PR TITLE
Fix conversion to/from VHD-compatible CHS geometry not working properly

### DIFF
--- a/src/qt/qt_harddiskdialog.hpp
+++ b/src/qt/qt_harddiskdialog.hpp
@@ -64,4 +64,10 @@ private:
     void recalcSelection();
 };
 
+typedef struct _86BoxGeom {
+    uint32_t cyl;
+    uint32_t heads;
+    uint32_t spt;
+} _86BoxGeom;
+
 #endif // QT_HARDDISKDIALOG_HPP


### PR DESCRIPTION
Summary
=======
Fixes the automatic conversion to or from VHD-compatible (up to 65535/16/255) CHS geometry not working properly in certain cases (like manually entered CHS, or adding an existing VHD) due to using wrong size for variables storing the unconverted (up to 266305/16/63) geometry.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A