### PR TITLE
Small important change for the 53c400 (May 30th, 2025)

### DIFF
--- a/src/scsi/scsi_ncr53c400.c
+++ b/src/scsi/scsi_ncr53c400.c
@@ -759,7 +759,7 @@ ncr53c400_init(const device_t *info)
     scsi_bus->bus_device            = ncr->bus;
     scsi_bus->timer                 = ncr->timer;
     scsi_bus->priv                  = ncr->priv;
-    ncr400->status_ctrl             = STATUS_BUFFER_NOT_READY;
+    ncr400->status_ctrl             = 0x00;
     ncr400->buffer_host_pos         = 128;
     timer_add(&ncr400->timer, ncr53c400_callback, ncr400, 0);
 


### PR DESCRIPTION
Summary
=======
Upon an initial POST, the initital status/control 53c400 port should be 0, fixes various versions of the T130B driver on Windows 95 builds.

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
