### PR TITLE
Rename the Olivetti M24 and M240 to add the names of their AT&T counterparts

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -2377,7 +2377,7 @@ const machine_t machines[] = {
         .net_device = NULL
     },
     {
-        .name = "[8086] Olivetti M21/24/24SP",
+        .name = "[8086] Olivetti M21/24/24SP/AT&T PC 6300",
         .internal_name = "m24",
         .type = MACHINE_TYPE_8086,
         .chipset = MACHINE_CHIPSET_PROPRIETARY,
@@ -2417,7 +2417,7 @@ const machine_t machines[] = {
     },
     /* Has Olivetti KBC firmware. */
     {
-        .name = "[8086] Olivetti M240",
+        .name = "[8086] Olivetti M240/AT&T PC 6300 WGS",
         .internal_name = "m240",
         .type = MACHINE_TYPE_8086,
         .chipset = MACHINE_CHIPSET_PROPRIETARY,


### PR DESCRIPTION

Summary
=======
Because the Olivetti M24 was very widely known under the AT&T PC 6300 name, while the M240 was known as AT&T PC 6300 WGS, I changed the machine table to reflect these alternative names due to the big popularity of the AT&T counterparts

Checklist
=========
* [ ] I have discussed this with core contributors already

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
