### PR TITLE
Remove video flag from D842.

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -10369,7 +10369,7 @@ const machine_t machines[] = {
             .max_multi = 2.0
 		},	
         .bus_flags = MACHINE_PS2_PCI,
-        .flags = MACHINE_IDE_DUAL | MACHINE_VIDEO | MACHINE_APM,
+        .flags = MACHINE_IDE_DUAL | MACHINE_APM,
         .ram = {
             .min = 2048,
             .max = 131072,


### PR DESCRIPTION
Summary
=======
This removes the Video flag from the Siemens-Nixdorf D842.
Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
