### PR TITLE
Fix on-board Audio on the SNI D943

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -11855,7 +11855,7 @@ const machine_t machines[] = {
         .fdc_device = NULL,
         .sio_device = NULL,
         .vid_device = &gd5436_onboard_pci_device,
-        .snd_device = &sb_vibra16s_onboard_device,
+        .snd_device = &sb_vibra16c_onboard_device,
         .net_device = NULL
     },
 


### PR DESCRIPTION

Summary
=======
TRW had some misinformation. It's NOT using a ViBRA 16S, but a 16C.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
