### PR TITLE
Small IRQ correction on ad1848/cs4231 (June 5th, 2025)

### DIFF
--- a/src/sound/snd_ad1848.c
+++ b/src/sound/snd_ad1848.c
@@ -731,9 +731,11 @@ ad1848_poll(void *priv)
             if (!(ad1848->status & 0x01)) {
                 ad1848->status |= 0x01;
                 ad1848->regs[24] |= 0x10;
-                if (ad1848->regs[10] & 2)
-                    picint(1 << ad1848->irq);
             }
+            if (ad1848->regs[10] & 2)
+                picint(1 << ad1848->irq);
+            else
+                picintc(1 << ad1848->irq);
         }
 
         if (!(ad1848->adpcm_pos & 7)) /* ADPCM counts down every 4 bytes */


### PR DESCRIPTION
Summary
=======
This fixes the the looping wave plays in Win95 using GUS MAX and possibly on WSS derived products.

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[AD1848K manual](https://theretroweb.com/chip/documentation/ad1848k-656257163ec73854266197.pdf)
[CS4231A manual](https://www.cebix.net/downloads/bebox/cs4231a.pdf)
