### PR TITLE
Fix unnecessary space in some translations.

### DIFF
--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -1834,7 +1834,7 @@ msgid "2 MB"
 msgstr "2 MB"
 
 msgid "8 MB"
-msgstr " 8 MB"
+msgstr "8 MB"
 
 msgid "28 MB"
 msgstr "28 MB"

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -1834,7 +1834,7 @@ msgid "2 MB"
 msgstr "2 MB"
 
 msgid "8 MB"
-msgstr " 8 MB"
+msgstr "8 MB"
 
 msgid "28 MB"
 msgstr "28 MB"

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -1834,7 +1834,7 @@ msgid "2 MB"
 msgstr "2 MB"
 
 msgid "8 MB"
-msgstr " 8 MB"
+msgstr "8 MB"
 
 msgid "28 MB"
 msgstr "28 MB"

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -1833,7 +1833,7 @@ msgid "2 MB"
 msgstr "2 MB"
 
 msgid "8 MB"
-msgstr " 8 MB"
+msgstr "8 MB"
 
 msgid "28 MB"
 msgstr "28 MB"

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -1834,7 +1834,7 @@ msgid "2 MB"
 msgstr "2 MB"
 
 msgid "8 MB"
-msgstr " 8 MB"
+msgstr "8 MB"
 
 msgid "28 MB"
 msgstr "28 MB"


### PR DESCRIPTION
Summary
=======
This pull request fixes a unnecessary space in some translations (German, Czech, Spanish, Catalan, and Croatian) which makes the string "8 MB" look out of place.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
