### PR TITLE
Add the Tulip AT Compact machine

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -631,6 +631,7 @@ extern int machine_at_cmdpc_init(const machine_t *);
 
 /* m_at_compaq.c */
 extern int machine_at_portableii_init(const machine_t *);
+extern int machine_at_tulip_tc7_init(const machine_t *);
 extern int machine_at_portableiii_init(const machine_t *);
 extern int machine_at_portableiii386_init(const machine_t *);
 extern int machine_at_deskpro386_init(const machine_t *);

--- a/src/machine/m_at_compaq.c
+++ b/src/machine/m_at_compaq.c
@@ -930,6 +930,23 @@ machine_at_portableii_init(const machine_t *model)
 }
 
 int
+machine_at_tulip_tc7_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_interleavedr("roms/machines/tulip_tc7/tc7be.bin",
+                                 "roms/machines/tulip_tc7/tc7b0.bin",
+                                 0x000f8000, 65536, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_compaq_init(model, COMPAQ_PORTABLEII);
+
+    return ret;
+}
+
+int
 machine_at_portableiii_init(const machine_t *model)
 {
     int ret;

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -2936,6 +2936,46 @@ const machine_t machines[] = {
     },
     /* Uses Compaq KBC firmware. */
     {
+        .name = "[ISA] Tulip AT Compact",
+        .internal_name = "tulip_tc7",
+        .type = MACHINE_TYPE_286,
+        .chipset = MACHINE_CHIPSET_PROPRIETARY,
+        .init = machine_at_tulip_tc7_init,
+        .p1_handler = NULL,
+        .gpio_handler = NULL,
+        .available_flag = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu = {
+            .package = CPU_PKG_286,
+            .block = CPU_BLOCK_NONE,
+            .min_bus = 6000000,
+            .max_bus = 16000000,
+            .min_voltage = 0,
+            .max_voltage = 0,
+            .min_multi = 0,
+            .max_multi = 0
+        },
+        .bus_flags = MACHINE_AT,
+        .flags = MACHINE_FLAGS_NONE,
+        .ram = {
+            .min = 640,
+            .max = 16384,
+            .step = 128
+        },
+        .nvrmask = 127,
+        .kbc_device = NULL,
+        .kbc_p1 = 0xff,
+        .gpio = 0xffffffff,
+        .gpio_acpi = 0xffffffff,
+        .device = NULL,
+        .fdc_device = NULL,
+        .sio_device = NULL,
+        .vid_device = NULL,
+        .snd_device = NULL,
+        .net_device = NULL
+    },
+    /* Uses Compaq KBC firmware. */
+    {
         .name = "[ISA] Compaq Portable III",
         .internal_name = "portableiii",
         .type = MACHINE_TYPE_286,


### PR DESCRIPTION
Summary
=======
Ported the Tulip AT Compact Machine from PCem, for now, it's a copy of the Compaq Portable II configuration but with the Tulip BIOS due to reports of the Tulip BIOS working perfectly with this config, but it might need to be adjusted later, so I will make this a draft

Checklist
=========
* [ ] I have discussed this with core contributors already
* [X] This pull request requires changes to the ROM set
  * [X] I have opened a roms pull request - https://github.com/86Box/roms/pull/341

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
