### PR TITLE
ESC/P: Fix a handle leak on reset

### DIFF
--- a/src/printer/prt_escp.c
+++ b/src/printer/prt_escp.c
@@ -2053,6 +2053,7 @@ escp_close(void *priv)
         free(dev->page);
     }
 
+    FT_Done_Face(dev->fontface);
     free(dev);
 }
 


### PR DESCRIPTION
Summary
=======
Fix a handle leak in the ESC/P printer caused by not properly unloading the font on hard reset or exit

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A