### PR TITLE
Diagnostics ROMs for 5150-5170

### DIFF
--- a/src/machine/m_at.c
+++ b/src/machine/m_at.c
@@ -154,32 +154,68 @@ machine_at_ps2_ide_init(const machine_t *model)
 static const device_config_t ibmat_config[] = {
     // clang-format off
     {
-        .name = "bios",
-        .description = "BIOS Version",
-        .type = CONFIG_BIOS,
+        .name           = "bios",
+        .description    = "BIOS Version",
+        .type           = CONFIG_BIOS,
         .default_string = "ibm5170_111585",
-        .default_int = 0,
-        .file_filter = "",
-        .spinner = { 0 },
-        .bios = {
-            { .name = "62X082x (11/15/85)", .internal_name = "ibm5170_111585", .bios_type = BIOS_NORMAL,
-              .files_no = 2, .local = 0, .size = 65536, .files = { "roms/machines/ibmat/BIOS_5170_15NOV85_U27.BIN", "roms/machines/ibmat/BIOS_5170_15NOV85_U47.BIN", "" } },
+        .default_int    = 0,
+        .file_filter    = "",
+        .spinner        = { 0 },
+        .bios           = {
+            {
+                .name          = "62X082x (11/15/85)",
+                .internal_name = "ibm5170_111585",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 0,
+                .size          = 65536,
+                .files         = { "roms/machines/ibmat/BIOS_5170_15NOV85_U27.BIN", "roms/machines/ibmat/BIOS_5170_15NOV85_U47.BIN", "" }
+            },
+            {
+                .name          = "61X9266 (11/15/85) (Alt)",
+                .internal_name = "ibm5170_111585_alt",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 0,
+                .size          = 65536,
+                .files         = { "roms/machines/ibmat/BIOS_5170_15NOV85_U27_61X9266.BIN", "roms/machines/ibmat/BIOS_5170_15NOV85_U47_61X9265.BIN", "" }
+            },
+            {
+                .name          = "648009x (06/10/85)",
+                .internal_name = "ibm5170_061085",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 0,
+                .size          = 65536,
+                .files         = { "roms/machines/ibmat/BIOS_5170_10JUN85_U27.BIN", "roms/machines/ibmat/BIOS_5170_10JUN85_U47.BIN", "" }
+            },
+            {
+                .name          = "618102x (01/10/84)",
+                .internal_name = "ibm5170_011084",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 0,
+                .size          = 65536,
+                .files         = { "roms/machines/ibmat/BIOS_5170_10JAN84_U27.BIN", "roms/machines/ibmat/BIOS_5170_10JAN84_U47.BIN", "" }
+            },
+            // The following are Diagnostic ROMs.
+            {
+                .name          = "Supersoft Diagnostics",
+                .internal_name = "diag_supersoft",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 2,
+                .size          = 65536,
+                .files         = { "roms/machines/diagnostic/5170_EVEN_LOW_U27_27256.bin", "roms/machines/diagnostic/5170_ODD_HIGH_U47_27256.bin", "" }
+            },
 
-            { .name = "61X9266 (11/15/85) (Alt)", .internal_name = "ibm5170_111585_alt", .bios_type = BIOS_NORMAL,
-              .files_no = 2, .local = 0, .size = 65536, .files = { "roms/machines/ibmat/BIOS_5170_15NOV85_U27_61X9266.BIN", "roms/machines/ibmat/BIOS_5170_15NOV85_U47_61X9265.BIN", "" } },
-
-            { .name = "648009x (06/10/85)", .internal_name = "ibm5170_061085", .bios_type = BIOS_NORMAL,
-              .files_no = 2, .local = 0, .size = 65536, .files = { "roms/machines/ibmat/BIOS_5170_10JUN85_U27.BIN", "roms/machines/ibmat/BIOS_5170_10JUN85_U47.BIN", "" } },
-
-            { .name = "618102x (01/10/84)", .internal_name = "ibm5170_011084", .bios_type = BIOS_NORMAL,
-              .files_no = 2, .local = 0, .size = 65536, .files = { "roms/machines/ibmat/BIOS_5170_10JAN84_U27.BIN", "roms/machines/ibmat/BIOS_5170_10JAN84_U47.BIN", "" } },
             { .files_no = 0 }
         },
     },
     {
-        .name = "enable_5161",
+        .name        = "enable_5161",
         .description = "IBM 5161 Expansion Unit",
-        .type = CONFIG_BINARY,
+        .type        = CONFIG_BINARY,
         .default_int = 0
     },
     { .name = "", .description = "", .type = CONFIG_END }

--- a/src/machine/m_xt.c
+++ b/src/machine/m_xt.c
@@ -85,7 +85,7 @@ static const device_config_t ibmpc_config[] = {
             { .name = "Supersoft Diagnostics", .internal_name = "diag_supersoft", .bios_type = BIOS_NORMAL,
               .files_no = 1, .local = 0, .size = 40960, .files = { "roms/machines/diagnostic/Supersoft_PCXT_8KB.bin", "" } },
             { .name = "Ruud's Diagnostic Rom", .internal_name = "diag_ruuds", .bios_type = BIOS_NORMAL,
-              .files_no = 1, .local = 0, .size = 40960, .files = { "roms/machines/diagnostic/ruuds_diagnostic_rom_v5.3_8kb.bin", "" } },
+              .files_no = 1, .local = 0, .size = 40960, .files = { "roms/machines/diagnostic/ruuds_diagnostic_rom_v5.4_8kb.bin", "" } },
             { .name = "XT RAM Test", .internal_name = "diag_xtramtest", .bios_type = BIOS_NORMAL,
               .files_no = 1, .local = 0, .size = 40960, .files = { "roms/machines/diagnostic/xtramtest_8k.bin", "" } },
             { .files_no = 0 }
@@ -195,7 +195,7 @@ static const device_config_t ibmpc82_config[] = {
             { .name = "Supersoft Diagnostics", .internal_name = "diag_supersoft", .bios_type = BIOS_NORMAL,
               .files_no = 1, .local = 0, .size = 40960, .files = { "roms/machines/diagnostic/Supersoft_PCXT_8KB.bin", "" } },
             { .name = "Ruud's Diagnostic Rom", .internal_name = "diag_ruuds", .bios_type = BIOS_NORMAL,
-              .files_no = 1, .local = 0, .size = 40960, .files = { "roms/machines/diagnostic/ruuds_diagnostic_rom_v5.3_8kb.bin", "" } },
+              .files_no = 1, .local = 0, .size = 40960, .files = { "roms/machines/diagnostic/ruuds_diagnostic_rom_v5.4_8kb.bin", "" } },
             { .name = "XT RAM Test", .internal_name = "diag_xtramtest", .bios_type = BIOS_NORMAL,
               .files_no = 1, .local = 0, .size = 40960, .files = { "roms/machines/diagnostic/xtramtest_8k.bin", "" } },
             { .files_no = 0 }
@@ -355,7 +355,7 @@ static const device_config_t ibmxt_config[] = {
                 .files_no      = 2,
                 .local         = 2,
                 .size          = 65536,
-                .files         = { "roms/machines/diagnostic/ruuds_diagnostic_rom_v5.3_32kb.bin", "roms/machines/ibmxt/BIOS_5160_08NOV82_U19_5000027.BIN", "" }
+                .files         = { "roms/machines/diagnostic/ruuds_diagnostic_rom_v5.4_32kb.bin", "roms/machines/ibmxt/BIOS_5160_08NOV82_U19_5000027.BIN", "" }
             },
             {
                 .name          = "XT RAM Test",
@@ -544,7 +544,7 @@ static const device_config_t ibmxt86_config[] = {
                 .files_no      = 2,
                 .local         = 2,
                 .size          = 65536,
-                .files         = { "roms/machines/diagnostic/ruuds_diagnostic_rom_v5.3_32kb.bin", "roms/machines/ibmxt86/BIOS_5160_09MAY86_U19_62X0819_68X4370_27256_F000.BIN", "" }
+                .files         = { "roms/machines/diagnostic/ruuds_diagnostic_rom_v5.4_32kb.bin", "roms/machines/ibmxt86/BIOS_5160_09MAY86_U19_62X0819_68X4370_27256_F000.BIN", "" }
             },
             {
                 .name          = "XT RAM Test",

--- a/src/machine/m_xt.c
+++ b/src/machine/m_xt.c
@@ -282,48 +282,103 @@ machine_pc82_init(const machine_t *model)
 static const device_config_t ibmxt_config[] = {
     // clang-format off
     {
-        .name = "bios",
-        .description = "BIOS Version",
-        .type = CONFIG_BIOS,
+        .name           = "bios",
+        .description    = "BIOS Version",
+        .type           = CONFIG_BIOS,
         .default_string = "ibm5160_1501512_5000027",
-        .default_int = 0,
-        .file_filter = "",
-        .spinner = { 0 },
-        .bios = {
-            { .name = "1501512 (11/08/82)", .internal_name = "ibm5160_1501512_5000027", .bios_type = BIOS_NORMAL,
-              .files_no = 2, .local = 0, .size = 65536, .files = { "roms/machines/ibmxt/BIOS_5160_08NOV82_U18_1501512.BIN", "roms/machines/ibmxt/BIOS_5160_08NOV82_U19_5000027.BIN", "" } },
-            { .name = "1501512 (11/08/82) (Alt)", .internal_name = "ibm5160_1501512_6359116", .bios_type = BIOS_NORMAL,
-              .files_no = 2, .local = 0, .size = 65536, .files = { "roms/machines/ibmxt/BIOS_5160_08NOV82_U18_1501512.BIN", "roms/machines/ibmxt/BIOS_5160_08NOV82_U19_6359116.BIN", "" } },
-            { .name = "5000026 (08/16/82)", .internal_name = "ibm5160_5000026_5000027", .bios_type = BIOS_NORMAL,
-              .files_no = 2, .local = 0, .size = 65536, .files = { "roms/machines/ibmxt/BIOS_5160_16AUG82_U18_5000026.BIN", "roms/machines/ibmxt/BIOS_5160_16AUG82_U19_5000027.BIN", "" } },
-#if 0
+        .default_int    = 0,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .bios           = {
+            {
+                .name          = "1501512 (11/08/82)",
+                .internal_name = "ibm5160_1501512_5000027",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 0,
+                .size          = 65536,
+                .files         = { "roms/machines/ibmxt/BIOS_5160_08NOV82_U18_1501512.BIN", "roms/machines/ibmxt/BIOS_5160_08NOV82_U19_5000027.BIN", "" }
+            },
+            {
+                .name          = "1501512 (11/08/82) (Alt)",
+                .internal_name = "ibm5160_1501512_6359116",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 0,
+                .size          = 65536,
+                .files         = { "roms/machines/ibmxt/BIOS_5160_08NOV82_U18_1501512.BIN", "roms/machines/ibmxt/BIOS_5160_08NOV82_U19_6359116.BIN", "" }
+            },
+            {
+                .name          = "5000026 (08/16/82)",
+                .internal_name = "ibm5160_5000026_5000027",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 0,
+                .size          = 65536,
+                .files         = { "roms/machines/ibmxt/BIOS_5160_16AUG82_U18_5000026.BIN", "roms/machines/ibmxt/BIOS_5160_16AUG82_U19_5000027.BIN", "" }
+            },
+
             // GlaBIOS for IBM XT
-            { .name = "GlaBIOS 0.2.5 (8088)", .internal_name = "glabios_025_8088", .bios_type = BIOS_NORMAL,
-              .files_no = 1, .local = 0, .size = 40960, .files = { "roms/machines/glabios/GLABIOS_0.2.5_8X.ROM", "" } },
-            { .name = "GlaBIOS 0.2.5 (V20)", .internal_name = "glabios_025_v20", .bios_type = BIOS_NORMAL,
-              .files_no = 1, .local = 0, .size = 40960, .files = { "roms/machines/glabios/GLABIOS_0.2.5_VX.ROM", "" } },
+            {
+                .name          = "GlaBIOS 0.2.5 (8088)",
+                .internal_name = "glabios_025_8088",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 1,
+                .size          = 40960,
+                .files         = { "roms/machines/glabios/GLABIOS_0.2.5_8X.ROM", "roms/machines/ibmxt/BIOS_5160_08NOV82_U19_5000027.BIN", "" }
+            },
+            {
+                .name          = "GlaBIOS 0.2.5 (V20)",
+                .internal_name = "glabios_025_v20",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 1,
+                .size          = 40960,
+                .files         = { "roms/machines/glabios/GLABIOS_0.2.5_VX.ROM", "roms/machines/ibmxt/BIOS_5160_08NOV82_U19_5000027.BIN", "" }
+            },
 
             // The following are Diagnostic ROMs.
-            { .name = "Supersoft Diagnostics", .internal_name = "diag_supersoft", .bios_type = BIOS_NORMAL,
-              .files_no = 1, .local = 0, .size = 65536, .files = { "roms/machines/diagnostic/Supersoft_PCXT_8KB.bin", "" } },
-            { .name = "Ruud's Diagnostic Rom", .internal_name = "diag_ruuds", .bios_type = BIOS_NORMAL,
-              .files_no = 1, .local = 0, .size = 65536, .files = { "roms/machines/diagnostic/ruuds_diagnostic_rom_v5.3_8kb.bin", "" } },
-            { .name = "XT RAM Test", .internal_name = "diag_xtramtest", .bios_type = BIOS_NORMAL,
-              .files_no = 1, .local = 0, .size = 65536, .files = { "roms/machines/diagnostic/xtramtest_8k.bin", "" } },
-#endif
+            {
+                .name          = "Supersoft Diagnostics",
+                .internal_name = "diag_supersoft",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 2,
+                .size          = 65536,
+                .files         = { "roms/machines/diagnostic/Supersoft_PCXT_32KB.bin", "roms/machines/ibmxt/BIOS_5160_08NOV82_U19_5000027.BIN", "" }
+            },
+            {
+                .name          = "Ruud's Diagnostic Rom",
+                .internal_name = "diag_ruuds",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 2,
+                .size          = 65536,
+                .files         = { "roms/machines/diagnostic/ruuds_diagnostic_rom_v5.3_32kb.bin", "roms/machines/ibmxt/BIOS_5160_08NOV82_U19_5000027.BIN", "" }
+            },
+            {
+                .name          = "XT RAM Test",
+                .internal_name = "diag_xtramtest",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 2,
+                .size          = 65536,
+                .files         = { "roms/machines/diagnostic/xtramtest_32k.bin", "roms/machines/ibmxt/BIOS_5160_08NOV82_U19_5000027.BIN", "" }
+            },
             { .files_no = 0 }
         },
     },
     {
-        .name = "enable_5161",
+        .name        = "enable_5161",
         .description = "IBM 5161 Expansion Unit",
-        .type = CONFIG_BINARY,
+        .type        = CONFIG_BINARY,
         .default_int = 1
     },
     {
-        .name = "enable_basic",
+        .name        = "enable_basic",
         .description = "IBM Cassette Basic",
-        .type = CONFIG_BINARY,
+        .type        = CONFIG_BINARY,
         .default_int = 1
     },
     { .name = "", .description = "", .type = CONFIG_END }
@@ -351,6 +406,8 @@ machine_xt_init(const machine_t *model)
     uint8_t     enable_5161;
     uint8_t     enable_basic;
     const char *fn;
+    uint16_t    offset = 0;
+    uint32_t    local  = 0;
 
     /* No ROMs available. */
     if (!device_available(model->device))
@@ -360,11 +417,17 @@ machine_xt_init(const machine_t *model)
     enable_5161  = machine_get_config_int("enable_5161");
     enable_basic = machine_get_config_int("enable_basic");
     fn           = device_get_bios_file(model->device, device_get_config_bios("bios"), 0);
-    ret          = bios_load_linear(fn, 0x000fe000, 65536, 0x6000);
+    local        = device_get_bios_local(model->device, device_get_config_bios("bios"));
+ 
+    if (local == 0) // Offset for stock roms
+         offset   = 0x6000;
+    ret          = bios_load_linear(fn, 0x000fe000, 65536, offset);
 
     if (enable_basic && ret) {
-        fn = device_get_bios_file(model->device, device_get_config_bios("bios"), 0);
-        (void) bios_load_aux_linear(fn, 0x000f8000, 24576, 0);
+        if (local == 0) { // needed for stock roms
+            fn = device_get_bios_file(model->device, device_get_config_bios("bios"), 0);
+            (void) bios_load_aux_linear(fn, 0x000f8000, 24576, 0);
+        }
         fn = device_get_bios_file(model->device, device_get_config_bios("bios"), 1);
         /* On the real machine, the BASIC is repeated. */
         (void) bios_load_aux_linear(fn, 0x000f0000, 8192, 0);

--- a/src/machine/m_xt.c
+++ b/src/machine/m_xt.c
@@ -471,42 +471,98 @@ machine_genxt_init(const machine_t *model)
 static const device_config_t ibmxt86_config[] = {
     // clang-format off
     {
-        .name = "bios",
-        .description = "BIOS Version",
-        .type = CONFIG_BIOS,
+        .name           = "bios",
+        .description    = "BIOS Version",
+        .type           = CONFIG_BIOS,
         .default_string = "ibm5160_050986",
-        .default_int = 0,
-        .file_filter = "",
-        .spinner = { 0 },
-        .bios = {
-            { .name = "1501512 (05/09/86)", .internal_name = "ibm5160_050986", .bios_type = BIOS_NORMAL,
-              .files_no = 2, .local = 0, .size = 65536, .files = { "roms/machines/ibmxt86/BIOS_5160_09MAY86_U18_59X7268_62X0890_27256_F800.BIN", "roms/machines/ibmxt86/BIOS_5160_09MAY86_U19_62X0819_68X4370_27256_F000.BIN", "" } },
-            { .name = "5000026 (01/10/86)", .internal_name = "ibm5160_011086", .bios_type = BIOS_NORMAL,
-              .files_no = 2, .local = 0, .size = 65536, .files = { "roms/machines/ibmxt86/BIOS_5160_10JAN86_U18_62X0851_27256_F800.BIN", "roms/machines/ibmxt86/BIOS_5160_10JAN86_U19_62X0854_27256_F000.BIN", "" } },
-            { .name = "1501512 (01/10/86) (Alt)", .internal_name = "ibm5160_011086_alt", .bios_type = BIOS_NORMAL,
-              .files_no = 2, .local = 0, .size = 65536, .files = { "roms/machines/ibmxt86/BIOS_5160_10JAN86_U18_62X0852_27256_F800.BIN", "roms/machines/ibmxt86/BIOS_5160_10JAN86_U19_62X0853_27256_F000.BIN", "" } },
-#if 0
+        .default_int    = 0,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .bios           = {
+            {
+                .name          = "1501512 (05/09/86)",
+                .internal_name = "ibm5160_050986",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 0,
+                .size          = 65536,
+                .files         = { "roms/machines/ibmxt86/BIOS_5160_09MAY86_U18_59X7268_62X0890_27256_F800.BIN", "roms/machines/ibmxt86/BIOS_5160_09MAY86_U19_62X0819_68X4370_27256_F000.BIN", "" }
+            },
+            {
+                .name          = "5000026 (01/10/86)",
+                .internal_name = "ibm5160_011086",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 0,
+                .size          = 65536,
+                .files         = { "roms/machines/ibmxt86/BIOS_5160_10JAN86_U18_62X0851_27256_F800.BIN", "roms/machines/ibmxt86/BIOS_5160_10JAN86_U19_62X0854_27256_F000.BIN", "" }
+            },
+            {
+                .name          = "1501512 (01/10/86) (Alt)",
+                .internal_name = "ibm5160_011086_alt",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 0,
+                .size          = 65536,
+                .files         = { "roms/machines/ibmxt86/BIOS_5160_10JAN86_U18_62X0852_27256_F800.BIN", "roms/machines/ibmxt86/BIOS_5160_10JAN86_U19_62X0853_27256_F000.BIN", "" }
+            },
+
             // GlaBIOS for IBM XT
-            { .name = "GlaBIOS 0.2.5 (8088)", .internal_name = "glabios_025_8088", .bios_type = BIOS_NORMAL,
-              .files_no = 1, .local = 0, .size = 40960, .files = { "roms/machines/glabios/GLABIOS_0.2.5_8X.ROM", "" } },
-            { .name = "GlaBIOS 0.2.5 (V20)", .internal_name = "glabios_025_v20", .bios_type = BIOS_NORMAL,
-              .files_no = 1, .local = 0, .size = 40960, .files = { "roms/machines/glabios/GLABIOS_0.2.5_VX.ROM", "" } },
+            {
+                .name          = "GlaBIOS 0.2.5 (8088)",
+                .internal_name = "glabios_025_8088",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 1,
+                .size          = 65536,
+                .files         = { "roms/machines/glabios/GLABIOS_0.2.5_8X.ROM", "roms/machines/ibmxt86/BIOS_5160_09MAY86_U19_62X0819_68X4370_27256_F000.BIN", "" }
+            },
+            {
+                .name          = "GlaBIOS 0.2.5 (V20)",
+                .internal_name = "glabios_025_v20",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 1,
+                .size          = 65536,
+                .files         = { "roms/machines/glabios/GLABIOS_0.2.5_VX.ROM", "roms/machines/ibmxt86/BIOS_5160_09MAY86_U19_62X0819_68X4370_27256_F000.BIN", "" }
+            },
 
             // The following are Diagnostic ROMs.
-            { .name = "Supersoft Diagnostics", .internal_name = "diag_supersoft", .bios_type = BIOS_NORMAL,
-              .files_no = 1, .local = 0, .size = 65536, .files = { "roms/machines/diagnostic/Supersoft_PCXT_8KB.bin", "" } },
-            { .name = "Ruud's Diagnostic Rom", .internal_name = "diag_ruuds", .bios_type = BIOS_NORMAL,
-              .files_no = 1, .local = 0, .size = 65536, .files = { "roms/machines/diagnostic/ruuds_diagnostic_rom_v5.3_8kb.bin", "" } },
-            { .name = "XT RAM Test", .internal_name = "diag_xtramtest", .bios_type = BIOS_NORMAL,
-              .files_no = 1, .local = 0, .size = 65536, .files = { "roms/machines/diagnostic/xtramtest_8k.bin", "" } },
-#endif
+            {
+                .name          = "Supersoft Diagnostics",
+                .internal_name = "diag_supersoft",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 2,
+                .size          = 65536,
+                .files         = { "roms/machines/diagnostic/Supersoft_PCXT_32KB.bin", "roms/machines/ibmxt86/BIOS_5160_09MAY86_U19_62X0819_68X4370_27256_F000.BIN", "" }
+            },
+            {
+                .name          = "Ruud's Diagnostic Rom",
+                .internal_name = "diag_ruuds",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 2,
+                .size          = 65536,
+                .files         = { "roms/machines/diagnostic/ruuds_diagnostic_rom_v5.3_32kb.bin", "roms/machines/ibmxt86/BIOS_5160_09MAY86_U19_62X0819_68X4370_27256_F000.BIN", "" }
+            },
+            {
+                .name          = "XT RAM Test",
+                .internal_name = "diag_xtramtest",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 2,
+                .size          = 65536,
+                .files         = { "roms/machines/diagnostic/xtramtest_32k.bin", "roms/machines/ibmxt86/BIOS_5160_09MAY86_U19_62X0819_68X4370_27256_F000.BIN", "" }
+            },
+
             { .files_no = 0 }
         },
     },
     {
-        .name = "enable_5161",
+        .name        = "enable_5161",
         .description = "IBM 5161 Expansion Unit",
-        .type = CONFIG_BINARY,
+        .type        = CONFIG_BINARY,
         .default_int = 1
     },
     { .name = "", .description = "", .type = CONFIG_END }
@@ -533,6 +589,8 @@ machine_xt86_init(const machine_t *model)
     int         ret = 0;
     uint8_t     enable_5161;
     const char *fn;
+    uint16_t    offset = 0;
+    uint32_t    local = 0;
 
     /* No ROMs available. */
     if (!device_available(model->device))
@@ -541,11 +599,17 @@ machine_xt86_init(const machine_t *model)
     device_context(model->device);
     enable_5161  = machine_get_config_int("enable_5161");
     fn           = device_get_bios_file(model->device, device_get_config_bios("bios"), 0);
-    ret          = bios_load_linear(fn, 0x000fe000, 65536, 0x6000);
+    local        = device_get_bios_local(model->device, device_get_config_bios("bios"));
+
+    if (local == 0) // Offset for stock roms
+        offset   = 0x6000;
+    ret          = bios_load_linear(fn, 0x000fe000, 65536, offset);
 
     if (ret) {
-        fn = device_get_bios_file(model->device, device_get_config_bios("bios"), 0);
-        (void) bios_load_aux_linear(fn, 0x000f8000, 24576, 0);
+        if (local == 0) { // needed for stock roms
+            fn = device_get_bios_file(model->device, device_get_config_bios("bios"), 0);
+            (void) bios_load_aux_linear(fn, 0x000f8000, 24576, 0);
+        }
         fn = device_get_bios_file(model->device, device_get_config_bios("bios"), 1);
         (void) bios_load_aux_linear(fn, 0x000f0000, 32768, 0);
     }


### PR DESCRIPTION
Summary
=======
* [Make XT82 diag's and debug roms work](https://github.com/86Box/86Box/commit/c135786d0c198d9e4e72867053eab88be675a13e)
* [Make XT86 diag's and debug roms work](https://github.com/86Box/86Box/commit/f542b5a8af2e79d61cbf4bb73889723838d44df0)
* [Update Ruuds diagnostic rom to 5.4](https://github.com/86Box/86Box/commit/9f37d0b1d163e08a6cf97380e43d44e82d70c6ef)
* [Add Supersoft Diagnostics to IBM 5170](https://github.com/86Box/86Box/commit/301cd7be7a0a3face438b15b1138479ab9c9918f)

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [X] This pull request requires changes to the ROM set
  * [X] I have opened a roms pull request - https://github.com/86Box/roms/pull/343/

References
==========
None