### PR TITLE
Assorted device fixes (Jun 10)

### DIFF
--- a/src/machine/m_at_286_386sx.c
+++ b/src/machine/m_at_286_386sx.c
@@ -1128,7 +1128,7 @@ machine_at_3302_init(const machine_t *model)
         device_add(&fdc_at_device);
 
     if (gfxcard[0] == VID_INTERNAL)
-        device_add(&paradise_pvga1a_ncr3302_device);
+        device_add(machine_get_vid_device(machine));
 
     device_add(&keyboard_at_ncr_device);
 

--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -2447,7 +2447,7 @@ machine_at_actionpc2600_init(const machine_t *model)
     device_add(&keyboard_ps2_tg_ami_device);
 
     if (gfxcard[0] == VID_INTERNAL)
-        device_add(&tgui9440_onboard_pci_device);
+        device_add(machine_get_vid_device(machine));
 
     return ret;
 }
@@ -2479,7 +2479,7 @@ machine_at_actiontower8400_init(const machine_t *model)
     device_add(&intel_flash_bxt_device); // The ActionPC 2600 has this so I'm gonna assume this does too.
     device_add(&keyboard_ps2_ami_pci_device);
     if (gfxcard[0] == VID_INTERNAL)
-        device_add(&gd5430_onboard_pci_device);
+        device_add(machine_get_vid_device(machine));
 
     return ret;
 }

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -3692,7 +3692,7 @@ const machine_t machines[] = {
         .device = NULL,
         .fdc_device = NULL,
         .sio_device = NULL,
-        .vid_device = NULL,
+        .vid_device = &paradise_pvga1a_ncr3302_device,
         .snd_device = NULL,
         .net_device = NULL
     },
@@ -9235,7 +9235,7 @@ const machine_t machines[] = {
         .device = NULL,
         .fdc_device = NULL,
         .sio_device = NULL,
-        .vid_device = NULL,
+        .vid_device = &tgui9440_onboard_pci_device,
         .snd_device = NULL,
         .net_device = NULL
     },
@@ -9276,7 +9276,7 @@ const machine_t machines[] = {
         .device = NULL,
         .fdc_device = NULL,
         .sio_device = NULL,
-        .vid_device = NULL,
+        .vid_device = &gd5430_onboard_pci_device,
         .snd_device = NULL,
         .net_device = NULL
     },


### PR DESCRIPTION
Summary
=======
Make the internal video for 3302, ActionPC and ActionTower configurable.

**NOTE**: My commit name is wrong (it supposed to be Jun 10 but I mistyped as Jun 30). I apologize for that.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
