### PR TITLE
Video Refactor Part 3/bignumber: The one where the variable names become readable

### DIFF
--- a/src/include/86box/m_pcjr.h
+++ b/src/include/86box/m_pcjr.h
@@ -36,7 +36,7 @@ typedef struct pcjr_s
     uint8_t      *b8000;
     int           linepos;
     int           displine;
-    int           sc;
+    int           scanline;
     int           vc;
     int           dispon;
     int           cursorvisible;            // Is the cursor visible on the current scanline?
@@ -45,8 +45,8 @@ typedef struct pcjr_s
     int           vsynctime;
     int           fullchange;
     int           vadj;
-    uint16_t      ma;
-    uint16_t      maback;
+    uint16_t      memaddr;
+    uint16_t      memaddr_backup;
     uint64_t      dispontime;
     uint64_t      dispofftime;
     pc_timer_t    timer;

--- a/src/include/86box/m_tandy.h
+++ b/src/include/86box/m_tandy.h
@@ -38,7 +38,7 @@ typedef struct t1kvid_t {
 
     int      linepos;
     int      displine;
-    int      sc;
+    int      scanline;
     int      vc;
     int      dispon;
     int      cursorvisible;
@@ -47,8 +47,8 @@ typedef struct t1kvid_t {
     int      fullchange;
     int      vsynctime;
     int      vadj;
-    uint16_t ma;
-    uint16_t maback;
+    uint16_t memaddr;
+    uint16_t memaddr_backup;
 
     uint64_t   dispontime;
     uint64_t   dispofftime;

--- a/src/include/86box/vid_8514a.h
+++ b/src/include/86box/vid_8514a.h
@@ -80,7 +80,7 @@ typedef struct ibm8514_t {
     uint32_t vram_mask;
     uint32_t pallook[512];
     uint32_t bios_addr;
-    uint32_t ma_latch;
+    uint32_t memaddr_latch;
 
     PALETTE   vgapal;
     uint8_t   hwcursor_oddeven;
@@ -220,8 +220,8 @@ typedef struct ibm8514_t {
     int      lastline_draw;
     int      displine;
     int      fullchange;
-    uint32_t ma;
-    uint32_t maback;
+    uint32_t memaddr;
+    uint32_t memaddr_backup;
 
     uint8_t *vram;
     uint8_t *changedvram;
@@ -236,7 +236,7 @@ typedef struct ibm8514_t {
     int     hdisp;
     int     hdisp2;
     int     hdisped;
-    int     sc;
+    int     scanline;
     int     vsyncstart;
     int     vsyncwidth;
     int     vtotal;

--- a/src/include/86box/vid_cga.h
+++ b/src/include/86box/vid_cga.h
@@ -87,7 +87,7 @@ typedef struct cga_t {
     int      fontbase;
     int      linepos;
     int      displine;
-    int      sc;
+    int      scanline;
     int      vc;
     int      cgadispon;
     int      cursorvisible;             // Determines if the cursor is visible FOR THE CURRENT SCANLINE.
@@ -95,8 +95,8 @@ typedef struct cga_t {
     int      cgablink;
     int      vsynctime;
     int      vadj;
-    uint16_t ma;
-    uint16_t maback;
+    uint16_t memaddr;
+    uint16_t memaddr_backup;
     int      oddeven;
 
     uint64_t   dispontime;

--- a/src/include/86box/vid_ega.h
+++ b/src/include/86box/vid_ega.h
@@ -73,7 +73,7 @@ typedef struct ega_t {
     int oddeven_chain;
     int vc;
     int real_vc;
-    int sc;
+    int scanline;
     int dispon;
     int hdisp_on;
     int cursoron;
@@ -119,10 +119,10 @@ typedef struct ega_t {
 
     uint32_t charseta;
     uint32_t charsetb;
-    uint32_t ma_latch;
-    uint32_t ma;
-    uint32_t maback;
-    uint32_t ca;
+    uint32_t memaddr_latch;
+    uint32_t memaddr;
+    uint32_t memaddr_backup;
+    uint32_t cursoraddr;
     uint32_t vram_limit;
     uint32_t overscan_color;
     uint32_t cca;
@@ -189,10 +189,10 @@ extern void    ega_set_type(void *priv, uint32_t local);
 extern int firstline_draw;
 extern int lastline_draw;
 extern int displine;
-extern int sc;
+extern int scanline;
 
-extern uint32_t ma;
-extern uint32_t ca;
+extern uint32_t memaddr;
+extern uint32_t cursoraddr;
 extern int      cursorvisible;
 extern int      cursoron;
 extern int      cgablink;

--- a/src/include/86box/vid_ega_render_remap.h
+++ b/src/include/86box/vid_ega_render_remap.h
@@ -33,9 +33,9 @@
         }                                                                                               \
                                                                                                         \
         if (nr & VAR_ROW0_MA13)                                                                         \
-            out_addr = (out_addr & ~0x8000) | ((ega->sc & 1) ? 0x8000 : 0);                             \
+            out_addr = (out_addr & ~0x8000) | ((ega->scanline & 1) ? 0x8000 : 0);                             \
         if (nr & VAR_ROW1_MA14)                                                                         \
-            out_addr = (out_addr & ~0x10000) | ((ega->sc & 2) ? 0x10000 : 0);                           \
+            out_addr = (out_addr & ~0x10000) | ((ega->scanline & 2) ? 0x10000 : 0);                           \
                                                                                                         \
         return out_addr;                                                                                \
     }

--- a/src/include/86box/vid_hercules.h
+++ b/src/include/86box/vid_hercules.h
@@ -43,9 +43,9 @@ typedef struct {
     int      linepos;
     int      displine;
     int      vc;
-    int      sc;
-    uint16_t ma;
-    uint16_t maback;
+    int      scanline;
+    uint16_t memaddr;
+    uint16_t memaddr_backup;
     int      cursorvisible;
     int      cursoron;
     int      dispon;

--- a/src/include/86box/vid_mda.h
+++ b/src/include/86box/vid_mda.h
@@ -25,9 +25,9 @@ typedef struct mda_t {
     int      linepos;
     int      displine;
     int      vc;
-    int      sc;
-    uint16_t ma;
-    uint16_t maback;
+    int      scanline;
+    uint16_t memaddr;
+    uint16_t memaddr_backup;
     int      cursorvisible;
     int      cursoron;
     int      dispon;

--- a/src/include/86box/vid_pgc.h
+++ b/src/include/86box/vid_pgc.h
@@ -120,8 +120,8 @@ typedef struct pgc {
     int      cgablink;
     int      vsynctime;
     int      vadj;
-    uint16_t ma;
-    uint16_t maback;
+    uint16_t memaddr;
+    uint16_t memaddr_backup;
     int      oddeven;
 
     uint64_t dispontime;

--- a/src/include/86box/vid_svga.h
+++ b/src/include/86box/vid_svga.h
@@ -100,7 +100,7 @@ typedef struct svga_t {
     int dispon;
     int hdisp_on;
     int vc;
-    int sc;
+    int scanline;
     int linepos;
     int vslines;
     int linecountff;
@@ -152,15 +152,15 @@ typedef struct svga_t {
     uint32_t  charseta;
     uint32_t  charsetb;
     uint32_t  adv_flags;
-    uint32_t  ma_latch;
+    uint32_t  memaddr_latch;
     uint32_t  ca_adj;
-    uint32_t  ma;
-    uint32_t  maback;
+    uint32_t  memaddr;
+    uint32_t  memaddr_backup;
     uint32_t  write_bank;
     uint32_t  read_bank;
     uint32_t  extra_banks[2];
     uint32_t  banked_mask;
-    uint32_t  ca;
+    uint32_t  cursoraddr;
     uint32_t  overscan_color;
     uint32_t *map8;
     uint32_t  pallook[512];

--- a/src/include/86box/vid_svga_render.h
+++ b/src/include/86box/vid_svga_render.h
@@ -23,10 +23,10 @@
 extern int firstline_draw;
 extern int lastline_draw;
 extern int displine;
-extern int sc;
+extern int scanline;
 
-extern uint32_t ma;
-extern uint32_t ca;
+extern uint32_t memaddr;
+extern uint32_t cursoraddr;
 extern int      cursorvisible;
 extern int      cursoron;
 extern int      cgablink;

--- a/src/include/86box/vid_svga_render_remap.h
+++ b/src/include/86box/vid_svga_render_remap.h
@@ -47,9 +47,9 @@
         }                                                                                               \
                                                                                                         \
         if (nr & VAR_ROW0_MA13)                                                                         \
-            out_addr = (out_addr & ~0x8000) | ((svga->sc & 1) ? 0x8000 : 0);                            \
+            out_addr = (out_addr & ~0x8000) | ((svga->scanline & 1) ? 0x8000 : 0);                            \
         if (nr & VAR_ROW1_MA14)                                                                         \
-            out_addr = (out_addr & ~0x10000) | ((svga->sc & 2) ? 0x10000 : 0);                          \
+            out_addr = (out_addr & ~0x10000) | ((svga->scanline & 2) ? 0x10000 : 0);                          \
                                                                                                         \
         return out_addr;                                                                                \
     }

--- a/src/include/86box/vid_xga.h
+++ b/src/include/86box/vid_xga.h
@@ -127,7 +127,7 @@ typedef struct xga_t {
     int dispon;
     int h_disp_on;
     int vc;
-    int sc;
+    int scanline;
     int linepos;
     int oddeven;
     int firstline;
@@ -160,12 +160,12 @@ typedef struct xga_t {
     uint32_t hwc_color0;
     uint32_t hwc_color1;
     uint32_t disp_start_addr;
-    uint32_t ma_latch;
+    uint32_t memaddr_latch;
     uint32_t vram_size;
     uint32_t vram_mask;
     uint32_t rom_addr;
-    uint32_t ma;
-    uint32_t maback;
+    uint32_t memaddr;
+    uint32_t memaddr_backup;
     uint32_t read_bank;
     uint32_t write_bank;
     uint32_t px_map_base;

--- a/src/machine/m_amstrad.c
+++ b/src/machine/m_amstrad.c
@@ -113,7 +113,7 @@ typedef struct amsvid_t {
     int        fontbase;    /* 1512/200 */
     int        linepos;
     int        displine;
-    int        sc;
+    int        scanline;
     int        vc;
     int        cgadispon;
     int        cursorvisible;
@@ -122,8 +122,8 @@ typedef struct amsvid_t {
     int        vsynctime;
     int        fullchange;
     int        vadj;
-    uint16_t   ma;
-    uint16_t   maback;
+    uint16_t   memaddr;
+    uint16_t   memaddr_backup;
     int        dispon;
     int        blink;
     uint64_t   dispontime;  /* 1512/1640 */
@@ -339,7 +339,7 @@ static void
 vid_poll_1512(void *priv)
 {
     amsvid_t *vid = (amsvid_t *) priv;
-    uint16_t  ca  = (vid->crtc[15] | (vid->crtc[14] << 8)) & 0x3fff;
+    uint16_t  cursoraddr  = (vid->crtc[15] | (vid->crtc[14] << 8)) & 0x3fff;
     int       drawcursor;
     int       x;
     int       c;
@@ -353,13 +353,13 @@ vid_poll_1512(void *priv)
     uint16_t  dat4;
     int       cols[4];
     int       col;
-    int       oldsc;
+    int       scanline_old;
 
     if (!vid->linepos) {
         timer_advance_u64(&vid->timer, vid->dispofftime);
         vid->stat |= 1;
         vid->linepos = 1;
-        oldsc        = vid->sc;
+        scanline_old        = vid->scanline;
         if (vid->dispon) {
             if (vid->displine < vid->firstline) {
                 vid->firstline = vid->displine;
@@ -385,9 +385,9 @@ vid_poll_1512(void *priv)
             }
             if (vid->cgamode & CGA_MODE_FLAG_HIGHRES) {
                 for (x = 0; x < 80; x++) {
-                    chr        = vid->vram[(vid->ma << 1) & 0x3fff];
-                    attr       = vid->vram[((vid->ma << 1) + 1) & 0x3fff];
-                    drawcursor = ((vid->ma == ca) && vid->cursorvisible && vid->cursoron);
+                    chr        = vid->vram[(vid->memaddr<< 1) & 0x3fff];
+                    attr       = vid->vram[((vid->memaddr<< 1) + 1) & 0x3fff];
+                    drawcursor = ((vid->memaddr== cursoraddr) && vid->cursorvisible && vid->cursoron);
                     if (vid->cgamode & CGA_MODE_FLAG_BLINK) {
                         cols[1] = (attr & 15) + 16;
                         cols[0] = ((attr >> 4) & 7) + 16;
@@ -399,20 +399,20 @@ vid_poll_1512(void *priv)
                     }
                     if (drawcursor) {
                         for (c = 0; c < 8; c++) {
-                            buffer32->line[vid->displine << 1][(x << 3) + c + 8] = buffer32->line[(vid->displine << 1) + 1][(x << 3) + c + 8] = cols[(fontdat[vid->fontbase + chr][vid->sc & 7] & (1 << (c ^ 7))) ? 1 : 0] ^ 15;
+                            buffer32->line[vid->displine << 1][(x << 3) + c + 8] = buffer32->line[(vid->displine << 1) + 1][(x << 3) + c + 8] = cols[(fontdat[vid->fontbase + chr][vid->scanline & 7] & (1 << (c ^ 7))) ? 1 : 0] ^ 15;
                         }
                     } else {
                         for (c = 0; c < 8; c++) {
-                            buffer32->line[vid->displine << 1][(x << 3) + c + 8] = buffer32->line[(vid->displine << 1) + 1][(x << 3) + c + 8] = cols[(fontdat[vid->fontbase + chr][vid->sc & 7] & (1 << (c ^ 7))) ? 1 : 0];
+                            buffer32->line[vid->displine << 1][(x << 3) + c + 8] = buffer32->line[(vid->displine << 1) + 1][(x << 3) + c + 8] = cols[(fontdat[vid->fontbase + chr][vid->scanline & 7] & (1 << (c ^ 7))) ? 1 : 0];
                         }
                     }
-                    vid->ma++;
+                    vid->memaddr++;
                 }
             } else if (!(vid->cgamode & CGA_MODE_FLAG_GRAPHICS)) {
                 for (x = 0; x < 40; x++) {
-                    chr        = vid->vram[(vid->ma << 1) & 0x3fff];
-                    attr       = vid->vram[((vid->ma << 1) + 1) & 0x3fff];
-                    drawcursor = ((vid->ma == ca) && vid->cursorvisible && vid->cursoron);
+                    chr        = vid->vram[(vid->memaddr<< 1) & 0x3fff];
+                    attr       = vid->vram[((vid->memaddr<< 1) + 1) & 0x3fff];
+                    drawcursor = ((vid->memaddr== cursoraddr) && vid->cursorvisible && vid->cursoron);
                     if (vid->cgamode & CGA_MODE_FLAG_BLINK) {
                         cols[1] = (attr & 15) + 16;
                         cols[0] = ((attr >> 4) & 7) + 16;
@@ -422,14 +422,14 @@ vid_poll_1512(void *priv)
                         cols[1] = (attr & 15) + 16;
                         cols[0] = (attr >> 4) + 16;
                     }
-                    vid->ma++;
+                    vid->memaddr++;
                     if (drawcursor) {
                         for (c = 0; c < 8; c++) {
-                            buffer32->line[vid->displine << 1][(x << 4) + (c << 1) + 8] = buffer32->line[vid->displine << 1][(x << 4) + (c << 1) + 1 + 8] = buffer32->line[(vid->displine << 1) + 1][(x << 4) + (c << 1) + 8] = buffer32->line[(vid->displine << 1) + 1][(x << 4) + (c << 1) + 1 + 8] = cols[(fontdat[vid->fontbase + chr][vid->sc & 7] & (1 << (c ^ 7))) ? 1 : 0] ^ 15;
+                            buffer32->line[vid->displine << 1][(x << 4) + (c << 1) + 8] = buffer32->line[vid->displine << 1][(x << 4) + (c << 1) + 1 + 8] = buffer32->line[(vid->displine << 1) + 1][(x << 4) + (c << 1) + 8] = buffer32->line[(vid->displine << 1) + 1][(x << 4) + (c << 1) + 1 + 8] = cols[(fontdat[vid->fontbase + chr][vid->scanline & 7] & (1 << (c ^ 7))) ? 1 : 0] ^ 15;
                         }
                     } else {
                         for (c = 0; c < 8; c++) {
-                            buffer32->line[vid->displine << 1][(x << 4) + (c << 1) + 8] = buffer32->line[vid->displine << 1][(x << 4) + (c << 1) + 1 + 8] = buffer32->line[(vid->displine << 1) + 1][(x << 4) + (c << 1) + 8] = buffer32->line[(vid->displine << 1) + 1][(x << 4) + (c << 1) + 1 + 8] = cols[(fontdat[vid->fontbase + chr][vid->sc & 7] & (1 << (c ^ 7))) ? 1 : 0];
+                            buffer32->line[vid->displine << 1][(x << 4) + (c << 1) + 8] = buffer32->line[vid->displine << 1][(x << 4) + (c << 1) + 1 + 8] = buffer32->line[(vid->displine << 1) + 1][(x << 4) + (c << 1) + 8] = buffer32->line[(vid->displine << 1) + 1][(x << 4) + (c << 1) + 1 + 8] = cols[(fontdat[vid->fontbase + chr][vid->scanline & 7] & (1 << (c ^ 7))) ? 1 : 0];
                         }
                     }
                 }
@@ -450,8 +450,8 @@ vid_poll_1512(void *priv)
                     cols[3] = col | 6;
                 }
                 for (x = 0; x < 40; x++) {
-                    dat = (vid->vram[((vid->ma << 1) & 0x1fff) + ((vid->sc & 1) * 0x2000)] << 8) | vid->vram[((vid->ma << 1) & 0x1fff) + ((vid->sc & 1) * 0x2000) + 1];
-                    vid->ma++;
+                    dat = (vid->vram[((vid->memaddr<< 1) & 0x1fff) + ((vid->scanline & 1) * 0x2000)] << 8) | vid->vram[((vid->memaddr<< 1) & 0x1fff) + ((vid->scanline & 1) * 0x2000) + 1];
+                    vid->memaddr++;
                     for (c = 0; c < 8; c++) {
                         buffer32->line[vid->displine << 1][(x << 4) + (c << 1) + 8] = buffer32->line[vid->displine << 1][(x << 4) + (c << 1) + 1 + 8] = buffer32->line[(vid->displine << 1) + 1][(x << 4) + (c << 1) + 8] = buffer32->line[(vid->displine << 1) + 1][(x << 4) + (c << 1) + 1 + 8] = cols[dat >> 14];
                         dat <<= 2;
@@ -459,13 +459,13 @@ vid_poll_1512(void *priv)
                 }
             } else {
                 for (x = 0; x < 40; x++) {
-                    ca   = ((vid->ma << 1) & 0x1fff) + ((vid->sc & 1) * 0x2000);
-                    dat  = (vid->vram[ca] << 8) | vid->vram[ca + 1];
-                    dat2 = (vid->vram[ca + 0x4000] << 8) | vid->vram[ca + 0x4001];
-                    dat3 = (vid->vram[ca + 0x8000] << 8) | vid->vram[ca + 0x8001];
-                    dat4 = (vid->vram[ca + 0xc000] << 8) | vid->vram[ca + 0xc001];
+                    cursoraddr   = ((vid->memaddr<< 1) & 0x1fff) + ((vid->scanline & 1) * 0x2000);
+                    dat  = (vid->vram[cursoraddr] << 8) | vid->vram[cursoraddr + 1];
+                    dat2 = (vid->vram[cursoraddr + 0x4000] << 8) | vid->vram[cursoraddr + 0x4001];
+                    dat3 = (vid->vram[cursoraddr + 0x8000] << 8) | vid->vram[cursoraddr + 0x8001];
+                    dat4 = (vid->vram[cursoraddr + 0xc000] << 8) | vid->vram[cursoraddr + 0xc001];
 
-                    vid->ma++;
+                    vid->memaddr++;
                     for (c = 0; c < 16; c++) {
                         buffer32->line[vid->displine << 1][(x << 4) + c + 8] = buffer32->line[(vid->displine << 1) + 1][(x << 4) + c + 8] = (((dat >> 15) | ((dat2 >> 15) << 1) | ((dat3 >> 15) << 2) | ((dat4 >> 15) << 3)) & (vid->cgacol & 15)) + 16;
                         dat <<= 1;
@@ -494,7 +494,7 @@ vid_poll_1512(void *priv)
         video_process_8(x, vid->displine << 1);
         video_process_8(x, (vid->displine << 1) + 1);
 
-        vid->sc = oldsc;
+        vid->scanline = scanline_old;
         if (vid->vsynctime)
             vid->stat |= 8;
         vid->displine++;
@@ -512,22 +512,22 @@ vid_poll_1512(void *priv)
             if (!vid->vsynctime)
                 vid->stat &= ~8;
         }
-        if (vid->sc == (vid->crtc[11] & 31)) {
+        if (vid->scanline == (vid->crtc[11] & 31)) {
             vid->cursorvisible  = 0;
         }
         if (vid->vadj) {
-            vid->sc++;
-            vid->sc &= 31;
-            vid->ma = vid->maback;
+            vid->scanline++;
+            vid->scanline &= 31;
+            vid->memaddr= vid->memaddr_backup;
             vid->vadj--;
             if (!vid->vadj) {
                 vid->dispon = 1;
-                vid->ma = vid->maback = (vid->crtc[13] | (vid->crtc[12] << 8)) & 0x3fff;
-                vid->sc               = 0;
+                vid->memaddr= vid->memaddr_backup = (vid->crtc[13] | (vid->crtc[12] << 8)) & 0x3fff;
+                vid->scanline               = 0;
             }
-        } else if (vid->sc == vid->crtc[9]) {
-            vid->maback = vid->ma;
-            vid->sc     = 0;
+        } else if (vid->scanline == vid->crtc[9]) {
+            vid->memaddr_backup = vid->memaddr;
+            vid->scanline     = 0;
             vid->vc++;
             vid->vc &= 127;
 
@@ -602,11 +602,11 @@ vid_poll_1512(void *priv)
                 vid->blink++;
             }
         } else {
-            vid->sc++;
-            vid->sc &= 31;
-            vid->ma = vid->maback;
+            vid->scanline++;
+            vid->scanline &= 31;
+            vid->memaddr= vid->memaddr_backup;
         }
-        if (vid->sc == (vid->crtc[10] & 31))
+        if (vid->scanline == (vid->crtc[10] & 31))
             vid->cursorvisible = 1;
     }
 }
@@ -1210,11 +1210,11 @@ vid_out_200(uint16_t addr, uint8_t val, void *priv)
 
 static void
 lcd_draw_char_80(amsvid_t *vid, uint32_t *buffer, uint8_t chr,
-                 uint8_t attr, int drawcursor, int blink, int sc,
+                 uint8_t attr, int drawcursor, int blink, int scanline,
                  int mode160, uint8_t control)
 {
     int      c;
-    uint8_t  bits   = fontdat[chr + vid->cga.fontbase][sc];
+    uint8_t  bits   = fontdat[chr + vid->cga.fontbase][scanline];
     uint8_t  bright = 0;
     uint16_t mask;
 
@@ -1245,10 +1245,10 @@ lcd_draw_char_80(amsvid_t *vid, uint32_t *buffer, uint8_t chr,
 
 static void
 lcd_draw_char_40(amsvid_t *vid, uint32_t *buffer, uint8_t chr,
-                 uint8_t attr, int drawcursor, int blink, int sc,
+                 uint8_t attr, int drawcursor, int blink, int scanline,
                  uint8_t control)
 {
-    uint8_t bits = fontdat[chr + vid->cga.fontbase][sc];
+    uint8_t bits = fontdat[chr + vid->cga.fontbase][scanline];
     uint8_t mask = 0x80;
 
     if (attr & 8) /* bright */
@@ -1269,38 +1269,38 @@ static void
 lcdm_poll(amsvid_t *vid)
 {
     mda_t   *mda = &vid->mda;
-    uint16_t ca  = (mda->crtc[15] | (mda->crtc[14] << 8)) & 0x3fff;
+    uint16_t cursoraddr  = (mda->crtc[15] | (mda->crtc[14] << 8)) & 0x3fff;
     int      drawcursor;
     int      x;
     int      oldvc;
     uint8_t  chr;
     uint8_t  attr;
-    int      oldsc;
+    int      scanline_old;
     int      blink;
 
     if (!mda->linepos) {
         timer_advance_u64(&vid->timer, mda->dispofftime);
         mda->stat |= 1;
         mda->linepos = 1;
-        oldsc        = mda->sc;
+        scanline_old        = mda->scanline;
         if ((mda->crtc[8] & 3) == 3)
-            mda->sc = (mda->sc << 1) & 7;
+            mda->scanline = (mda->scanline << 1) & 7;
         if (mda->dispon) {
             if (mda->displine < mda->firstline)
                 mda->firstline = mda->displine;
             mda->lastline = mda->displine;
             for (x = 0; x < mda->crtc[1]; x++) {
-                chr        = mda->vram[(mda->ma << 1) & 0xfff];
-                attr       = mda->vram[((mda->ma << 1) + 1) & 0xfff];
-                drawcursor = ((mda->ma == ca) && mda->cursorvisible && mda->cursoron);
+                chr        = mda->vram[(mda->memaddr<< 1) & 0xfff];
+                attr       = mda->vram[((mda->memaddr<< 1) + 1) & 0xfff];
+                drawcursor = ((mda->memaddr== cursoraddr) && mda->cursorvisible && mda->cursoron);
                 blink      = ((mda->blink & 16) && (mda->ctrl & 0x20) && (attr & 0x80) && !drawcursor);
 
-                lcd_draw_char_80(vid, &(buffer32->line[mda->displine])[x * 8], chr, attr, drawcursor, blink, mda->sc, 0, mda->ctrl);
-                mda->ma++;
+                lcd_draw_char_80(vid, &(buffer32->line[mda->displine])[x * 8], chr, attr, drawcursor, blink, mda->scanline, 0, mda->ctrl);
+                mda->memaddr++;
             }
         }
-        mda->sc = oldsc;
-        if (mda->vc == mda->crtc[7] && !mda->sc)
+        mda->scanline = scanline_old;
+        if (mda->vc == mda->crtc[7] && !mda->scanline)
             mda->stat |= 8;
         mda->displine++;
         if (mda->displine >= 500)
@@ -1315,22 +1315,22 @@ lcdm_poll(amsvid_t *vid)
             if (!mda->vsynctime)
                 mda->stat &= ~8;
         }
-        if (mda->sc == (mda->crtc[11] & 31) || ((mda->crtc[8] & 3) == 3 && mda->sc == ((mda->crtc[11] & 31) >> 1))) {
+        if (mda->scanline == (mda->crtc[11] & 31) || ((mda->crtc[8] & 3) == 3 && mda->scanline == ((mda->crtc[11] & 31) >> 1))) {
             mda->cursorvisible  = 0;
         }
         if (mda->vadj) {
-            mda->sc++;
-            mda->sc &= 31;
-            mda->ma = mda->maback;
+            mda->scanline++;
+            mda->scanline &= 31;
+            mda->memaddr= mda->memaddr_backup;
             mda->vadj--;
             if (!mda->vadj) {
                 mda->dispon = 1;
-                mda->ma = mda->maback = (mda->crtc[13] | (mda->crtc[12] << 8)) & 0x3fff;
-                mda->sc               = 0;
+                mda->memaddr= mda->memaddr_backup = (mda->crtc[13] | (mda->crtc[12] << 8)) & 0x3fff;
+                mda->scanline               = 0;
             }
-        } else if (mda->sc == mda->crtc[9] || ((mda->crtc[8] & 3) == 3 && mda->sc == (mda->crtc[9] >> 1))) {
-            mda->maback = mda->ma;
-            mda->sc     = 0;
+        } else if (mda->scanline == mda->crtc[9] || ((mda->crtc[8] & 3) == 3 && mda->scanline == (mda->crtc[9] >> 1))) {
+            mda->memaddr_backup = mda->memaddr;
+            mda->scanline     = 0;
             oldvc       = mda->vc;
             mda->vc++;
             mda->vc &= 127;
@@ -1342,7 +1342,7 @@ lcdm_poll(amsvid_t *vid)
                 if (!mda->vadj)
                     mda->dispon = 1;
                 if (!mda->vadj)
-                    mda->ma = mda->maback = (mda->crtc[13] | (mda->crtc[12] << 8)) & 0x3fff;
+                    mda->memaddr= mda->memaddr_backup = (mda->crtc[13] | (mda->crtc[12] << 8)) & 0x3fff;
                 if ((mda->crtc[10] & 0x60) == 0x20)
                     mda->cursoron = 0;
                 else
@@ -1378,11 +1378,11 @@ lcdm_poll(amsvid_t *vid)
                 mda->blink++;
             }
         } else {
-            mda->sc++;
-            mda->sc &= 31;
-            mda->ma = mda->maback;
+            mda->scanline++;
+            mda->scanline &= 31;
+            mda->memaddr= mda->memaddr_backup;
         }
-        if (mda->sc == (mda->crtc[10] & 31) || ((mda->crtc[8] & 3) == 3 && mda->sc == ((mda->crtc[10] & 31) >> 1)))
+        if (mda->scanline == (mda->crtc[10] & 31) || ((mda->crtc[8] & 3) == 3 && mda->scanline == ((mda->crtc[10] & 31) >> 1)))
             mda->cursorvisible = 1;
     }
 }
@@ -1399,19 +1399,19 @@ lcdc_poll(amsvid_t *vid)
     uint8_t  chr;
     uint8_t  attr;
     uint16_t dat;
-    int      oldsc;
-    uint16_t ca;
+    int      scanline_old;
+    uint16_t cursoraddr;
     int      blink;
 
-    ca = (cga->crtc[CGA_CRTC_CURSOR_ADDR_LOW] | (cga->crtc[CGA_CRTC_CURSOR_ADDR_HIGH] << 8)) & 0x3fff;
+    cursoraddr = (cga->crtc[CGA_CRTC_CURSOR_ADDR_LOW] | (cga->crtc[CGA_CRTC_CURSOR_ADDR_HIGH] << 8)) & 0x3fff;
 
     if (!cga->linepos) {
         timer_advance_u64(&vid->timer, cga->dispofftime);
         cga->cgastat |= 1;
         cga->linepos = 1;
-        oldsc        = cga->sc;
+        scanline_old        = cga->scanline;
         if ((cga->crtc[CGA_CRTC_INTERLACE] & 3) == 3)
-            cga->sc = ((cga->sc << 1) + cga->oddeven) & 7;
+            cga->scanline = ((cga->scanline << 1) + cga->oddeven) & 7;
         if (cga->cgadispon) {
             if (cga->displine < cga->firstline) {
                 cga->firstline = cga->displine;
@@ -1423,26 +1423,26 @@ lcdc_poll(amsvid_t *vid)
                 for (x = 0; x < cga->crtc[CGA_CRTC_HDISP]; x++) {
                     chr        = cga->charbuffer[x << 1];
                     attr       = cga->charbuffer[(x << 1) + 1];
-                    drawcursor = ((cga->ma == ca) && cga->cursorvisible && cga->cursoron);
+                    drawcursor = ((cga->memaddr == cursoraddr) && cga->cursorvisible && cga->cursoron);
                     blink      = ((cga->cgablink & 16) && (cga->cgamode & CGA_MODE_FLAG_BLINK) && (attr & 0x80) && !drawcursor);
-                    lcd_draw_char_80(vid, &(buffer32->line[cga->displine << 1])[x * 8], chr, attr, drawcursor, blink, cga->sc, cga->cgamode & 0x40, cga->cgamode);
-                    lcd_draw_char_80(vid, &(buffer32->line[(cga->displine << 1) + 1])[x * 8], chr, attr, drawcursor, blink, cga->sc, cga->cgamode & 0x40, cga->cgamode);
-                    cga->ma++;
+                    lcd_draw_char_80(vid, &(buffer32->line[cga->displine << 1])[x * 8], chr, attr, drawcursor, blink, cga->scanline, cga->cgamode & 0x40, cga->cgamode);
+                    lcd_draw_char_80(vid, &(buffer32->line[(cga->displine << 1) + 1])[x * 8], chr, attr, drawcursor, blink, cga->scanline, cga->cgamode & 0x40, cga->cgamode);
+                    cga->memaddr++;
                 }
             } else if (!(cga->cgamode & CGA_MODE_FLAG_GRAPHICS)) {
                 for (x = 0; x < cga->crtc[CGA_CRTC_HDISP]; x++) {
-                    chr        = cga->vram[(cga->ma << 1) & 0x3fff];
-                    attr       = cga->vram[((cga->ma << 1) + 1) & 0x3fff];
-                    drawcursor = ((cga->ma == ca) && cga->cursorvisible && cga->cursoron);
+                    chr        = cga->vram[(cga->memaddr << 1) & 0x3fff];
+                    attr       = cga->vram[((cga->memaddr << 1) + 1) & 0x3fff];
+                    drawcursor = ((cga->memaddr == cursoraddr) && cga->cursorvisible && cga->cursoron);
                     blink      = ((cga->cgablink & 16) && (cga->cgamode & CGA_MODE_FLAG_BLINK) && (attr & 0x80) && !drawcursor);
-                    lcd_draw_char_40(vid, &(buffer32->line[cga->displine << 1])[x * 16], chr, attr, drawcursor, blink, cga->sc, cga->cgamode);
-                    lcd_draw_char_40(vid, &(buffer32->line[(cga->displine << 1) + 1])[x * 16], chr, attr, drawcursor, blink, cga->sc, cga->cgamode);
-                    cga->ma++;
+                    lcd_draw_char_40(vid, &(buffer32->line[cga->displine << 1])[x * 16], chr, attr, drawcursor, blink, cga->scanline, cga->cgamode);
+                    lcd_draw_char_40(vid, &(buffer32->line[(cga->displine << 1) + 1])[x * 16], chr, attr, drawcursor, blink, cga->scanline, cga->cgamode);
+                    cga->memaddr++;
                 }
             } else { /* Graphics mode */
                 for (x = 0; x < cga->crtc[CGA_CRTC_HDISP]; x++) {
-                    dat = (cga->vram[((cga->ma << 1) & 0x1fff) + ((cga->sc & 1) * 0x2000)] << 8) | cga->vram[((cga->ma << 1) & 0x1fff) + ((cga->sc & 1) * 0x2000) + 1];
-                    cga->ma++;
+                    dat = (cga->vram[((cga->memaddr << 1) & 0x1fff) + ((cga->scanline & 1) * 0x2000)] << 8) | cga->vram[((cga->memaddr << 1) & 0x1fff) + ((cga->scanline & 1) * 0x2000) + 1];
+                    cga->memaddr++;
                     for (uint8_t c = 0; c < 16; c++) {
                         buffer32->line[cga->displine << 1][(x << 4) + c] = buffer32->line[(cga->displine << 1) + 1][(x << 4) + c] = (dat & 0x8000) ? blue : green;
                         dat <<= 1;
@@ -1464,8 +1464,8 @@ lcdc_poll(amsvid_t *vid)
         else
             x = (cga->crtc[CGA_CRTC_HDISP] << 4);
 
-        cga->sc = oldsc;
-        if (cga->vc == cga->crtc[CGA_CRTC_VSYNC] && !cga->sc)
+        cga->scanline = scanline_old;
+        if (cga->vc == cga->crtc[CGA_CRTC_VSYNC] && !cga->scanline)
             cga->cgastat |= 8;
         cga->displine++;
         if (cga->displine >= 360)
@@ -1478,24 +1478,24 @@ lcdc_poll(amsvid_t *vid)
             if (!cga->vsynctime)
                 cga->cgastat &= ~8;
         }
-        if (cga->sc == (cga->crtc[CGA_CRTC_CURSOR_END] & 31) || ((cga->crtc[CGA_CRTC_INTERLACE] & 3) == 3 && cga->sc == ((cga->crtc[CGA_CRTC_CURSOR_END] & 31) >> 1))) {
+        if (cga->scanline == (cga->crtc[CGA_CRTC_CURSOR_END] & 31) || ((cga->crtc[CGA_CRTC_INTERLACE] & 3) == 3 && cga->scanline == ((cga->crtc[CGA_CRTC_CURSOR_END] & 31) >> 1))) {
             cga->cursorvisible  = 0;
         }
-        if ((cga->crtc[CGA_CRTC_INTERLACE] & 3) == 3 && cga->sc == (cga->crtc[CGA_CRTC_MAX_SCANLINE_ADDR] >> 1))
-            cga->maback = cga->ma;
+        if ((cga->crtc[CGA_CRTC_INTERLACE] & 3) == 3 && cga->scanline == (cga->crtc[CGA_CRTC_MAX_SCANLINE_ADDR] >> 1))
+            cga->memaddr_backup = cga->memaddr;
         if (cga->vadj) {
-            cga->sc++;
-            cga->sc &= 31;
-            cga->ma = cga->maback;
+            cga->scanline++;
+            cga->scanline &= 31;
+            cga->memaddr = cga->memaddr_backup;
             cga->vadj--;
             if (!cga->vadj) {
                 cga->cgadispon = 1;
-                cga->ma = cga->maback = (cga->crtc[CGA_CRTC_START_ADDR_LOW] | (cga->crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
-                cga->sc               = 0;
+                cga->memaddr = cga->memaddr_backup = (cga->crtc[CGA_CRTC_START_ADDR_LOW] | (cga->crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
+                cga->scanline               = 0;
             }
-        } else if (cga->sc == cga->crtc[CGA_CRTC_MAX_SCANLINE_ADDR]) {
-            cga->maback = cga->ma;
-            cga->sc     = 0;
+        } else if (cga->scanline == cga->crtc[CGA_CRTC_MAX_SCANLINE_ADDR]) {
+            cga->memaddr_backup = cga->memaddr;
+            cga->scanline     = 0;
             oldvc       = cga->vc;
             cga->vc++;
             cga->vc &= 127;
@@ -1509,7 +1509,7 @@ lcdc_poll(amsvid_t *vid)
                 if (!cga->vadj)
                     cga->cgadispon = 1;
                 if (!cga->vadj)
-                    cga->ma = cga->maback = (cga->crtc[CGA_CRTC_START_ADDR_LOW] | (cga->crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
+                    cga->memaddr = cga->memaddr_backup = (cga->crtc[CGA_CRTC_START_ADDR_LOW] | (cga->crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
                 if ((cga->crtc[CGA_CRTC_CURSOR_START] & 0x60) == 0x20)
                     cga->cursoron = 0;
                 else
@@ -1573,17 +1573,17 @@ lcdc_poll(amsvid_t *vid)
                 cga->oddeven ^= 1;
             }
         } else {
-            cga->sc++;
-            cga->sc &= 31;
-            cga->ma = cga->maback;
+            cga->scanline++;
+            cga->scanline &= 31;
+            cga->memaddr = cga->memaddr_backup;
         }
         if (cga->cgadispon)
             cga->cgastat &= ~1;
-        if (cga->sc == (cga->crtc[CGA_CRTC_CURSOR_START] & 31) || ((cga->crtc[CGA_CRTC_INTERLACE] & 3) == 3 && cga->sc == ((cga->crtc[CGA_CRTC_CURSOR_START] & 31) >> 1)))
+        if (cga->scanline == (cga->crtc[CGA_CRTC_CURSOR_START] & 31) || ((cga->crtc[CGA_CRTC_INTERLACE] & 3) == 3 && cga->scanline == ((cga->crtc[CGA_CRTC_CURSOR_START] & 31) >> 1)))
             cga->cursorvisible = 1;
         if (cga->cgadispon && (cga->cgamode & CGA_MODE_FLAG_HIGHRES)) {
             for (x = 0; x < (cga->crtc[CGA_CRTC_HDISP] << 1); x++)
-                cga->charbuffer[x] = cga->vram[((cga->ma << 1) + x) & 0x3fff];
+                cga->charbuffer[x] = cga->vram[((cga->memaddr << 1) + x) & 0x3fff];
         }
     }
 }

--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -3383,7 +3383,7 @@ ibm8514_render_8bpp(svga_t *svga)
     if ((dev->displine + svga->y_add) < 0)
         return;
 
-    if (dev->changedvram[dev->ma >> 12] || dev->changedvram[(dev->ma >> 12) + 1] || svga->fullchange) {
+    if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
         p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
 
         if (dev->firstline_draw == 2000)
@@ -3391,22 +3391,22 @@ ibm8514_render_8bpp(svga_t *svga)
         dev->lastline_draw = dev->displine;
 
         for (int x = 0; x <= dev->h_disp; x += 8) {
-            dat  = *(uint32_t *) (&dev->vram[dev->ma & dev->vram_mask]);
+            dat  = *(uint32_t *) (&dev->vram[dev->memaddr & dev->vram_mask]);
             p[0] = dev->pallook[dat & dev->dac_mask & 0xff];
             p[1] = dev->pallook[(dat >> 8) & dev->dac_mask & 0xff];
             p[2] = dev->pallook[(dat >> 16) & dev->dac_mask & 0xff];
             p[3] = dev->pallook[(dat >> 24) & dev->dac_mask & 0xff];
 
-            dat  = *(uint32_t *) (&dev->vram[(dev->ma + 4) & dev->vram_mask]);
+            dat  = *(uint32_t *) (&dev->vram[(dev->memaddr + 4) & dev->vram_mask]);
             p[4] = dev->pallook[dat & dev->dac_mask & 0xff];
             p[5] = dev->pallook[(dat >> 8) & dev->dac_mask & 0xff];
             p[6] = dev->pallook[(dat >> 16) & dev->dac_mask & 0xff];
             p[7] = dev->pallook[(dat >> 24) & dev->dac_mask & 0xff];
 
-            dev->ma += 8;
+            dev->memaddr += 8;
             p += 8;
         }
-        dev->ma &= dev->vram_mask;
+        dev->memaddr &= dev->vram_mask;
     }
 }
 
@@ -3421,7 +3421,7 @@ ibm8514_render_15bpp(svga_t *svga)
     if ((dev->displine + svga->y_add) < 0)
         return;
 
-    if (dev->changedvram[dev->ma >> 12] || dev->changedvram[(dev->ma >> 12) + 1] || svga->fullchange) {
+    if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
         p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
 
         if (dev->firstline_draw == 2000)
@@ -3429,24 +3429,24 @@ ibm8514_render_15bpp(svga_t *svga)
         dev->lastline_draw = dev->displine;
 
         for (x = 0; x <= dev->h_disp; x += 8) {
-            dat      = *(uint32_t *) (&dev->vram[(dev->ma + (x << 1)) & dev->vram_mask]);
+            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1)) & dev->vram_mask]);
             p[x]     = video_15to32[dat & 0xffff];
             p[x + 1] = video_15to32[dat >> 16];
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->ma + (x << 1) + 4) & dev->vram_mask]);
+            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1) + 4) & dev->vram_mask]);
             p[x + 2] = video_15to32[dat & 0xffff];
             p[x + 3] = video_15to32[dat >> 16];
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->ma + (x << 1) + 8) & dev->vram_mask]);
+            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1) + 8) & dev->vram_mask]);
             p[x + 4] = video_15to32[dat & 0xffff];
             p[x + 5] = video_15to32[dat >> 16];
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->ma + (x << 1) + 12) & dev->vram_mask]);
+            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1) + 12) & dev->vram_mask]);
             p[x + 6] = video_15to32[dat & 0xffff];
             p[x + 7] = video_15to32[dat >> 16];
         }
-        dev->ma += (x << 1);
-        dev->ma &= dev->vram_mask;
+        dev->memaddr += (x << 1);
+        dev->memaddr &= dev->vram_mask;
     }
 }
 
@@ -3461,7 +3461,7 @@ ibm8514_render_16bpp(svga_t *svga)
     if ((dev->displine + svga->y_add) < 0)
         return;
 
-    if (dev->changedvram[dev->ma >> 12] || dev->changedvram[(dev->ma >> 12) + 1] || svga->fullchange) {
+    if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
         p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
 
         if (dev->firstline_draw == 2000)
@@ -3469,24 +3469,24 @@ ibm8514_render_16bpp(svga_t *svga)
         dev->lastline_draw = dev->displine;
 
         for (x = 0; x <= dev->h_disp; x += 8) {
-            dat      = *(uint32_t *) (&dev->vram[(dev->ma + (x << 1)) & dev->vram_mask]);
+            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1)) & dev->vram_mask]);
             p[x]     = video_16to32[dat & 0xffff];
             p[x + 1] = video_16to32[dat >> 16];
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->ma + (x << 1) + 4) & dev->vram_mask]);
+            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1) + 4) & dev->vram_mask]);
             p[x + 2] = video_16to32[dat & 0xffff];
             p[x + 3] = video_16to32[dat >> 16];
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->ma + (x << 1) + 8) & dev->vram_mask]);
+            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1) + 8) & dev->vram_mask]);
             p[x + 4] = video_16to32[dat & 0xffff];
             p[x + 5] = video_16to32[dat >> 16];
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->ma + (x << 1) + 12) & dev->vram_mask]);
+            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1) + 12) & dev->vram_mask]);
             p[x + 6] = video_16to32[dat & 0xffff];
             p[x + 7] = video_16to32[dat >> 16];
         }
-        dev->ma += (x << 1);
-        dev->ma &= dev->vram_mask;
+        dev->memaddr += (x << 1);
+        dev->memaddr &= dev->vram_mask;
     }
 }
 
@@ -3500,7 +3500,7 @@ ibm8514_render_24bpp(svga_t *svga)
     if ((dev->displine + svga->y_add) < 0)
         return;
 
-    if (dev->changedvram[dev->ma >> 12] || dev->changedvram[(dev->ma >> 12) + 1] || svga->fullchange) {
+    if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
         p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
 
         if (dev->firstline_draw == 2000)
@@ -3508,21 +3508,21 @@ ibm8514_render_24bpp(svga_t *svga)
         dev->lastline_draw = dev->displine;
 
         for (int x = 0; x <= dev->h_disp; x += 4) {
-            dat  = *(uint32_t *) (&dev->vram[dev->ma & dev->vram_mask]);
+            dat  = *(uint32_t *) (&dev->vram[dev->memaddr & dev->vram_mask]);
             p[x] = dat & 0xffffff;
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->ma + 3) & dev->vram_mask]);
+            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 3) & dev->vram_mask]);
             p[x + 1] = dat & 0xffffff;
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->ma + 6) & dev->vram_mask]);
+            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 6) & dev->vram_mask]);
             p[x + 2] = dat & 0xffffff;
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->ma + 9) & dev->vram_mask]);
+            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 9) & dev->vram_mask]);
             p[x + 3] = dat & 0xffffff;
 
-            dev->ma += 12;
+            dev->memaddr += 12;
         }
-        dev->ma &= dev->vram_mask;
+        dev->memaddr &= dev->vram_mask;
     }
 }
 
@@ -3536,7 +3536,7 @@ ibm8514_render_BGR(svga_t *svga)
     if ((dev->displine + svga->y_add) < 0)
         return;
 
-    if (dev->changedvram[dev->ma >> 12] || dev->changedvram[(dev->ma >> 12) + 1] || svga->fullchange) {
+    if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
         p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
 
         if (dev->firstline_draw == 2000)
@@ -3544,21 +3544,21 @@ ibm8514_render_BGR(svga_t *svga)
         dev->lastline_draw = dev->displine;
 
         for (int x = 0; x <= dev->h_disp; x += 4) {
-            dat  = *(uint32_t *) (&dev->vram[dev->ma & dev->vram_mask]);
+            dat  = *(uint32_t *) (&dev->vram[dev->memaddr & dev->vram_mask]);
             p[x] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->ma + 3) & dev->vram_mask]);
+            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 3) & dev->vram_mask]);
             p[x + 1] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->ma + 6) & dev->vram_mask]);
+            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 6) & dev->vram_mask]);
             p[x + 2] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->ma + 9) & dev->vram_mask]);
+            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 9) & dev->vram_mask]);
             p[x + 3] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
 
-            dev->ma += 12;
+            dev->memaddr += 12;
         }
-        dev->ma &= dev->vram_mask;
+        dev->memaddr &= dev->vram_mask;
     }
 }
 
@@ -3573,7 +3573,7 @@ ibm8514_render_ABGR8888(svga_t *svga)
     if ((dev->displine + svga->y_add) < 0)
         return;
 
-    if (dev->changedvram[dev->ma >> 12] || dev->changedvram[(dev->ma >> 12) + 1] || svga->fullchange) {
+    if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
         p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
 
         if (dev->firstline_draw == 2000)
@@ -3581,11 +3581,11 @@ ibm8514_render_ABGR8888(svga_t *svga)
         dev->lastline_draw = dev->displine;
 
         for (x = 0; x <= dev->h_disp; x++) {
-            dat  = *(uint32_t *) (&dev->vram[(dev->ma + (x << 2)) & dev->vram_mask]);
+            dat  = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 2)) & dev->vram_mask]);
             *p++ = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
         }
-        dev->ma += (x * 4);
-        dev->ma &= dev->vram_mask;
+        dev->memaddr += (x * 4);
+        dev->memaddr &= dev->vram_mask;
     }
 }
 
@@ -3600,7 +3600,7 @@ ibm8514_render_32bpp(svga_t *svga)
     if ((dev->displine + svga->y_add) < 0)
         return;
 
-    if (dev->changedvram[dev->ma >> 12] || dev->changedvram[(dev->ma >> 12) + 1] || dev->changedvram[(dev->ma >> 12) + 2] || svga->fullchange) {
+    if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || dev->changedvram[(dev->memaddr >> 12) + 2] || svga->fullchange) {
         p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
 
         if (dev->firstline_draw == 2000)
@@ -3608,11 +3608,11 @@ ibm8514_render_32bpp(svga_t *svga)
         dev->lastline_draw = dev->displine;
 
         for (x = 0; x <= dev->h_disp; x++) {
-            dat  = *(uint32_t *) (&dev->vram[(dev->ma + (x << 2)) & dev->vram_mask]);
+            dat  = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 2)) & dev->vram_mask]);
             p[x] = dat & 0xffffff;
         }
-        dev->ma += (x * 4);
-        dev->ma &= dev->vram_mask;
+        dev->memaddr += (x * 4);
+        dev->memaddr &= dev->vram_mask;
     }
 }
 
@@ -3681,7 +3681,7 @@ ibm8514_poll(void *priv)
             if (dev->dispon) {
                 dev->hdisp_on = 1;
 
-                dev->ma &= dev->vram_mask;
+                dev->memaddr &= dev->vram_mask;
 
                 if (dev->firstline == 2000) {
                     dev->firstline = dev->displine;
@@ -3689,7 +3689,7 @@ ibm8514_poll(void *priv)
                 }
 
                 if (dev->hwcursor_on)
-                    dev->changedvram[dev->ma >> 12] = dev->changedvram[(dev->ma >> 12) + 1] = dev->interlace ? 3 : 2;
+                    dev->changedvram[dev->memaddr >> 12] = dev->changedvram[(dev->memaddr >> 12) + 1] = dev->interlace ? 3 : 2;
 
                 svga->render8514(svga);
 
@@ -3726,18 +3726,18 @@ ibm8514_poll(void *priv)
 
             dev->linepos = 0;
             if (dev->dispon) {
-                if (dev->sc == dev->rowcount) {
-                    dev->sc = 0;
-                    dev->maback += (dev->rowoffset << 3);
+                if (dev->scanline == dev->rowcount) {
+                    dev->scanline = 0;
+                    dev->memaddr_backup += (dev->rowoffset << 3);
                     if (dev->interlace)
-                        dev->maback += (dev->rowoffset << 3);
+                        dev->memaddr_backup += (dev->rowoffset << 3);
 
-                    dev->maback &= dev->vram_mask;
-                    dev->ma = dev->maback;
+                    dev->memaddr_backup &= dev->vram_mask;
+                    dev->memaddr = dev->memaddr_backup;
                 } else {
-                    dev->sc++;
-                    dev->sc &= 0x1f;
-                    dev->ma = dev->maback;
+                    dev->scanline++;
+                    dev->scanline &= 0x1f;
+                    dev->memaddr = dev->memaddr_backup;
                 }
             }
 
@@ -3783,16 +3783,16 @@ ibm8514_poll(void *priv)
                 svga->vslines    = 0;
 
                 if (dev->interlace && dev->oddeven)
-                    dev->ma = dev->maback = (dev->rowoffset << 1);
+                    dev->memaddr = dev->memaddr_backup = (dev->rowoffset << 1);
                 else
-                    dev->ma = dev->maback = 0;
+                    dev->memaddr = dev->memaddr_backup = 0;
 
-                dev->ma     = (dev->ma << 2);
-                dev->maback = (dev->maback << 2);
+                dev->memaddr     = (dev->memaddr << 2);
+                dev->memaddr_backup = (dev->memaddr_backup << 2);
             }
             if (dev->vc == dev->v_total) {
                 dev->vc       = 0;
-                dev->sc       = (svga->crtc[0x8] & 0x1f);
+                dev->scanline       = (svga->crtc[0x8] & 0x1f);
                 dev->dispon   = 1;
                 dev->displine = (dev->interlace && dev->oddeven) ? 1 : 0;
 

--- a/src/video/vid_ati18800.c
+++ b/src/video/vid_ati18800.c
@@ -109,7 +109,7 @@ ati18800_out(uint16_t addr, uint8_t val, void *priv)
                 if (svga->crtcreg < 0xe || svga->crtcreg > 0x10) {
                     if ((svga->crtcreg == 0xc) || (svga->crtcreg == 0xd)) {
                         svga->fullchange = 3;
-                        svga->ma_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
+                        svga->memaddr_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
                     } else {
                         svga->fullchange = changeframecount;
                         svga_recalctimings(svga);
@@ -223,7 +223,7 @@ ati18800_recalctimings(svga_t *svga)
                             else {
                                 svga->render = svga_render_8bpp_highres;
                                 if (!svga->packed_4bpp) {
-                                    svga->ma_latch <<= 1;
+                                    svga->memaddr_latch <<= 1;
                                     svga->rowoffset <<= 1;
                                 }
                             }

--- a/src/video/vid_ati28800.c
+++ b/src/video/vid_ati28800.c
@@ -206,7 +206,7 @@ ati28800_out(uint16_t addr, uint8_t val, void *priv)
                 if (svga->crtcreg < 0xe || svga->crtcreg > 0x10) {
                     if ((svga->crtcreg == 0xc) || (svga->crtcreg == 0xd)) {
                         svga->fullchange = 3;
-                        svga->ma_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
+                        svga->memaddr_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
                     } else {
                         svga->fullchange = changeframecount;
                         svga_recalctimings(svga);
@@ -416,10 +416,10 @@ ati28800_recalctimings(svga_t *svga)
                 ((ati28800->regs[0xb9] & 2) << 1);
 
     if (ati28800->regs[0xa3] & 0x10)
-        svga->ma_latch |= 0x10000;
+        svga->memaddr_latch |= 0x10000;
 
     if (ati28800->regs[0xb0] & 0x40)
-        svga->ma_latch |= 0x20000;
+        svga->memaddr_latch |= 0x20000;
 
     if (ati28800->regs[0xb8] & 0x40)
         svga->clock *= 2;
@@ -483,7 +483,7 @@ ati28800_recalctimings(svga_t *svga)
                             else {
                                 svga->render = svga_render_8bpp_highres;
                                 if (!svga->packed_4bpp) {
-                                    svga->ma_latch <<= 1;
+                                    svga->memaddr_latch <<= 1;
                                     svga->rowoffset <<= 1;
                                 }
                             }
@@ -496,7 +496,7 @@ ati28800_recalctimings(svga_t *svga)
                                 svga->hdisp >>= 1;
                                 svga->dots_per_clock >>= 1;
                                 svga->rowoffset <<= 1;
-                                svga->ma_latch <<= 1;
+                                svga->memaddr_latch <<= 1;
                             }
                             break;
                         default:

--- a/src/video/vid_ati_mach64.c
+++ b/src/video/vid_ati_mach64.c
@@ -456,7 +456,7 @@ mach64_out(uint16_t addr, uint8_t val, void *priv)
                 if (svga->crtcreg < 0xe || svga->crtcreg > 0x10) {
                     if ((svga->crtcreg == 0xc) || (svga->crtcreg == 0xd)) {
                         svga->fullchange = 3;
-                        svga->ma_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
+                        svga->memaddr_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
                     } else {
                         svga->fullchange = svga->monitor->mon_changeframecount;
                         svga_recalctimings(svga);
@@ -524,7 +524,7 @@ mach64_recalctimings(svga_t *svga)
         svga->vsyncstart               = (mach64->crtc_v_sync_strt_wid & 2047) + 1;
         svga->rowoffset                = (mach64->crtc_off_pitch >> 22);
         svga->clock                    = (cpuclock * (double) (1ULL << 32)) / ics2595_getclock(svga->clock_gen);
-        svga->ma_latch                 = (mach64->crtc_off_pitch & 0x1fffff) * 2;
+        svga->memaddr_latch                 = (mach64->crtc_off_pitch & 0x1fffff) * 2;
         svga->linedbl = svga->rowcount = 0;
         svga->split                    = 0xffffff;
         svga->vblankstart              = svga->dispend;

--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -2461,7 +2461,7 @@ mach_out(uint16_t addr, uint8_t val, void *priv)
                 if (svga->crtcreg < 0xe || svga->crtcreg > 0x10) {
                     if ((svga->crtcreg == 0xc) || (svga->crtcreg == 0xd)) {
                         svga->fullchange = 3;
-                        svga->ma_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
+                        svga->memaddr_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
                     } else {
                         svga->fullchange = svga->monitor->mon_changeframecount;
                         svga_recalctimings(svga);
@@ -2604,7 +2604,7 @@ ati_render_24bpp(svga_t *svga)
     if ((dev->displine + svga->y_add) < 0)
         return;
 
-    if (dev->changedvram[dev->ma >> 12] || dev->changedvram[(dev->ma >> 12) + 1] || svga->fullchange) {
+    if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
         p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
 
         if (dev->firstline_draw == 2000)
@@ -2613,38 +2613,38 @@ ati_render_24bpp(svga_t *svga)
 
         if (mach->accel.ext_ge_config & 0x400) { /*BGR, Blue-(23:16), Green-(15:8), Red-(7:0)*/
             for (int x = 0; x <= dev->h_disp; x += 4) {
-                dat  = *(uint32_t *) (&dev->vram[dev->ma & dev->vram_mask]);
+                dat  = *(uint32_t *) (&dev->vram[dev->memaddr & dev->vram_mask]);
                 p[x] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
 
-                dat      = *(uint32_t *) (&dev->vram[(dev->ma + 3) & dev->vram_mask]);
+                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 3) & dev->vram_mask]);
                 p[x + 1] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
 
-                dat      = *(uint32_t *) (&dev->vram[(dev->ma + 6) & dev->vram_mask]);
+                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 6) & dev->vram_mask]);
                 p[x + 2] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
 
-                dat      = *(uint32_t *) (&dev->vram[(dev->ma + 9) & dev->vram_mask]);
+                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 9) & dev->vram_mask]);
                 p[x + 3] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
 
-                dev->ma += 12;
+                dev->memaddr += 12;
             }
         } else { /*RGB, Red-(23:16), Green-(15:8), Blue-(7:0)*/
             for (int x = 0; x <= dev->h_disp; x += 4) {
-                dat  = *(uint32_t *) (&dev->vram[dev->ma & dev->vram_mask]);
+                dat  = *(uint32_t *) (&dev->vram[dev->memaddr & dev->vram_mask]);
                 p[x] = dat & 0xffffff;
 
-                dat      = *(uint32_t *) (&dev->vram[(dev->ma + 3) & dev->vram_mask]);
+                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 3) & dev->vram_mask]);
                 p[x + 1] = dat & 0xffffff;
 
-                dat      = *(uint32_t *) (&dev->vram[(dev->ma + 6) & dev->vram_mask]);
+                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 6) & dev->vram_mask]);
                 p[x + 2] = dat & 0xffffff;
 
-                dat      = *(uint32_t *) (&dev->vram[(dev->ma + 9) & dev->vram_mask]);
+                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 9) & dev->vram_mask]);
                 p[x + 3] = dat & 0xffffff;
 
-                dev->ma += 12;
+                dev->memaddr += 12;
             }
         }
-        dev->ma &= dev->vram_mask;
+        dev->memaddr &= dev->vram_mask;
     }
 }
 
@@ -2660,7 +2660,7 @@ ati_render_32bpp(svga_t *svga)
     if ((dev->displine + svga->y_add) < 0)
         return;
 
-    if (dev->changedvram[dev->ma >> 12] || dev->changedvram[(dev->ma >> 12) + 1] || dev->changedvram[(dev->ma >> 12) + 2] || svga->fullchange) {
+    if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || dev->changedvram[(dev->memaddr >> 12) + 2] || svga->fullchange) {
         p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
 
         if (dev->firstline_draw == 2000)
@@ -2669,17 +2669,17 @@ ati_render_32bpp(svga_t *svga)
 
         if (mach->accel.ext_ge_config & 0x400) { /*BGR, Blue-(23:16), Green-(15:8), Red-(7:0)*/
             for (x = 0; x <= dev->h_disp; x++) {
-                dat  = *(uint32_t *) (&dev->vram[(dev->ma + (x << 2)) & dev->vram_mask]);
+                dat  = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 2)) & dev->vram_mask]);
                 *p++ = ((dat & 0x00ff0000) >> 16) | (dat & 0x0000ff00) | ((dat & 0x000000ff) << 16);
             }
         } else { /*RGB, Red-(31:24), Green-(23:16), Blue-(15:8)*/
             for (x = 0; x <= dev->h_disp; x++) {
-                dat  = *(uint32_t *) (&dev->vram[(dev->ma + (x << 2)) & dev->vram_mask]);
+                dat  = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 2)) & dev->vram_mask]);
                 *p++ = ((dat & 0xffffff00) >> 8);
             }
         }
-        dev->ma += (x * 4);
-        dev->ma &= dev->vram_mask;
+        dev->memaddr += (x * 4);
+        dev->memaddr &= dev->vram_mask;
     }
 }
 
@@ -2847,17 +2847,17 @@ mach_recalctimings(svga_t *svga)
 
     if (ATI_MACH32) {
         if (mach->regs[0xad] & 0x04)
-            svga->ma_latch |= 0x40000;
+            svga->memaddr_latch |= 0x40000;
 
         if (mach->regs[0xad] & 0x08)
-            svga->ma_latch |= 0x80000;
+            svga->memaddr_latch |= 0x80000;
     }
 
     if (mach->regs[0xa3] & 0x10)
-        svga->ma_latch |= 0x10000;
+        svga->memaddr_latch |= 0x10000;
 
     if (mach->regs[0xb0] & 0x40)
-        svga->ma_latch |= 0x20000;
+        svga->memaddr_latch |= 0x20000;
 
     if ((mach->regs[0xb6] & 0x18) >= 0x10) {
         svga->hdisp <<= 1;
@@ -2886,7 +2886,7 @@ mach_recalctimings(svga_t *svga)
 
     mach_log("ON=%d, override=%d, gelo=%04x, gehi=%04x, vgahdisp=%d.\n", dev->on, svga->override, mach->accel.ge_offset_lo, mach->accel.ge_offset_hi, svga->hdisp);
     if (dev->on) {
-        dev->ma_latch                   = 0; /*(mach->accel.crt_offset_lo | (mach->accel.crt_offset_hi << 16)) << 2;*/
+        dev->memaddr_latch                   = 0; /*(mach->accel.crt_offset_lo | (mach->accel.crt_offset_hi << 16)) << 2;*/
         dev->interlace                  = !!(dev->disp_cntl & 0x10);
         dev->pitch                      = dev->ext_pitch;
         dev->rowoffset                  = dev->ext_crt_pitch;
@@ -3085,7 +3085,7 @@ mach_recalctimings(svga_t *svga)
                     else {
                         svga->render = svga_render_8bpp_highres;
                         if (!svga->packed_4bpp) {
-                            svga->ma_latch <<= 1;
+                            svga->memaddr_latch <<= 1;
                             svga->rowoffset <<= 1;
                         }
                     }
@@ -3972,7 +3972,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             break;
 
         case 0x92ee:
-            mach_log("Write port 92ee, malatch=%08x.\n", svga->ma_latch);
+            mach_log("Write port 92ee, malatch=%08x.\n", svga->memaddr_latch);
             break;
 
         case 0x96ee:
@@ -4227,7 +4227,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             break;
 
         default:
-            mach_log("Unknown or reserved write to %04x, val=%04x, len=%d, latch=%08x.\n", port, val, len, svga->ma_latch);
+            mach_log("Unknown or reserved write to %04x, val=%04x, len=%d, latch=%08x.\n", port, val, len, svga->memaddr_latch);
             break;
     }
 }

--- a/src/video/vid_bochs_vbe.c
+++ b/src/video/vid_bochs_vbe.c
@@ -336,13 +336,13 @@ bochs_vbe_recalctimings(svga_t* svga)
 
         if (svga->bpp == 4) {
             svga->rowoffset = (dev->vbe_regs[VBE_DISPI_INDEX_VIRT_WIDTH] / 2) >> 3;
-            svga->ma_latch  = (dev->vbe_regs[VBE_DISPI_INDEX_Y_OFFSET] * svga->rowoffset) +
+            svga->memaddr_latch  = (dev->vbe_regs[VBE_DISPI_INDEX_Y_OFFSET] * svga->rowoffset) +
                               (dev->vbe_regs[VBE_DISPI_INDEX_X_OFFSET] >> 3);
 
             svga->fullchange = 3;
         } else {
             svga->rowoffset = dev->vbe_regs[VBE_DISPI_INDEX_VIRT_WIDTH] * ((svga->bpp == 15) ? 2 : (svga->bpp / 8));
-            svga->ma_latch = (dev->vbe_regs[VBE_DISPI_INDEX_Y_OFFSET] * svga->rowoffset) +
+            svga->memaddr_latch = (dev->vbe_regs[VBE_DISPI_INDEX_Y_OFFSET] * svga->rowoffset) +
                              (dev->vbe_regs[VBE_DISPI_INDEX_X_OFFSET] * ((svga->bpp == 15) ? 2 : (svga->bpp / 8)));
             svga->fullchange = 3;
         }
@@ -470,11 +470,11 @@ bochs_vbe_outw(const uint16_t addr, const uint16_t val, void *priv)
                 svga_t *svga = &dev->svga;
                 if (svga->bpp == 4) {
                     svga->rowoffset = (dev->vbe_regs[VBE_DISPI_INDEX_VIRT_WIDTH] / 2) >> 3;
-                    svga->ma_latch  = (dev->vbe_regs[VBE_DISPI_INDEX_Y_OFFSET] * svga->rowoffset) +
+                    svga->memaddr_latch  = (dev->vbe_regs[VBE_DISPI_INDEX_Y_OFFSET] * svga->rowoffset) +
                                     (dev->vbe_regs[VBE_DISPI_INDEX_X_OFFSET] >> 3);
                 } else {
                     svga->rowoffset = dev->vbe_regs[VBE_DISPI_INDEX_VIRT_WIDTH] * ((svga->bpp == 15) ? 2 : (svga->bpp / 8));
-                    svga->ma_latch = (dev->vbe_regs[VBE_DISPI_INDEX_Y_OFFSET] * svga->rowoffset) +
+                    svga->memaddr_latch = (dev->vbe_regs[VBE_DISPI_INDEX_Y_OFFSET] * svga->rowoffset) +
                                     (dev->vbe_regs[VBE_DISPI_INDEX_X_OFFSET] * ((svga->bpp == 15) ? 2 : (svga->bpp / 8)));
                 }
 
@@ -575,7 +575,7 @@ bochs_vbe_out(uint16_t addr, uint8_t val, void *priv)
                 if (svga->crtcreg < 0xe || svga->crtcreg > 0x10) {
                     if ((svga->crtcreg == 0xc) || (svga->crtcreg == 0xd)) {
                         svga->fullchange = 3;
-                        svga->ma_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
+                        svga->memaddr_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
                     } else {
                         svga->fullchange = changeframecount;
                         svga_recalctimings(svga);

--- a/src/video/vid_cga.c
+++ b/src/video/vid_cga.c
@@ -253,7 +253,7 @@ cga_recalctimings(cga_t *cga)
 static void
 cga_render(cga_t *cga, int line)
 {
-    uint16_t ca  = (cga->crtc[CGA_CRTC_CURSOR_ADDR_LOW] | (cga->crtc[CGA_CRTC_CURSOR_ADDR_HIGH] << 8)) & 0x3fff;
+    uint16_t cursoraddr  = (cga->crtc[CGA_CRTC_CURSOR_ADDR_LOW] | (cga->crtc[CGA_CRTC_CURSOR_ADDR_HIGH] << 8)) & 0x3fff;
     int      drawcursor;
     int      x;
     int      c;
@@ -289,7 +289,7 @@ cga_render(cga_t *cga, int line)
                 attr = cga->charbuffer[(x << 1) + 1];
             } else
                 chr = attr = 0;
-            drawcursor = ((cga->ma == ca) && cga->cursorvisible && cga->cursoron);
+            drawcursor = ((cga->memaddr == cursoraddr) && cga->cursorvisible && cga->cursoron);
             cols[1]    = (attr & 15) + 16;
             if (cga->cgamode & CGA_MODE_FLAG_BLINK) {
                 cols[0] = ((attr >> 4) & 7) + 16;
@@ -300,24 +300,24 @@ cga_render(cga_t *cga, int line)
             if (drawcursor) {
                 for (c = 0; c < 8; c++) {
                     buffer32->line[line][(x << 3) + c + 8]
-                        = cols[(fontdat[chr + cga->fontbase][cga->sc & 7] & (1 << (c ^ 7))) ? 1 : 0] ^ 15;
+                        = cols[(fontdat[chr + cga->fontbase][cga->scanline & 7] & (1 << (c ^ 7))) ? 1 : 0] ^ 15;
                 }
             } else {
                 for (c = 0; c < 8; c++) {
                     buffer32->line[line][(x << 3) + c + 8]
-                        = cols[(fontdat[chr + cga->fontbase][cga->sc & 7] & (1 << (c ^ 7))) ? 1 : 0];
+                        = cols[(fontdat[chr + cga->fontbase][cga->scanline & 7] & (1 << (c ^ 7))) ? 1 : 0];
                 }
             }
-            cga->ma++;
+            cga->memaddr++;
         }
     } else if (!(cga->cgamode & CGA_MODE_FLAG_GRAPHICS)) {
         for (x = 0; x < cga->crtc[CGA_CRTC_HDISP]; x++) {
             if (cga->cgamode & CGA_MODE_FLAG_VIDEO_ENABLE) {
-                chr  = cga->vram[(cga->ma << 1) & 0x3fff];
-                attr = cga->vram[((cga->ma << 1) + 1) & 0x3fff];
+                chr  = cga->vram[(cga->memaddr << 1) & 0x3fff];
+                attr = cga->vram[((cga->memaddr << 1) + 1) & 0x3fff];
             } else
                 chr = attr = 0;
-            drawcursor = ((cga->ma == ca) && cga->cursorvisible && cga->cursoron);
+            drawcursor = ((cga->memaddr == cursoraddr) && cga->cursorvisible && cga->cursoron);
             cols[1]    = (attr & 15) + 16;
             if (cga->cgamode & CGA_MODE_FLAG_BLINK) {
                 cols[0] = ((attr >> 4) & 7) + 16;
@@ -325,18 +325,18 @@ cga_render(cga_t *cga, int line)
                     cols[1] = cols[0];
             } else
                 cols[0] = (attr >> 4) + 16;
-            cga->ma++;
+            cga->memaddr++;
             if (drawcursor) {
                 for (c = 0; c < 8; c++) {
                     buffer32->line[line][(x << 4) + (c << 1) + 8]
                         = buffer32->line[line][(x << 4) + (c << 1) + 9]
-                        = cols[(fontdat[chr + cga->fontbase][cga->sc & 7] & (1 << (c ^ 7))) ? 1 : 0] ^ 15;
+                        = cols[(fontdat[chr + cga->fontbase][cga->scanline & 7] & (1 << (c ^ 7))) ? 1 : 0] ^ 15;
                 }
             } else {
                 for (c = 0; c < 8; c++) {
                     buffer32->line[line][(x << 4) + (c << 1) + 8]
                         = buffer32->line[line][(x << 4) + (c << 1) + 9] 
-                        = cols[(fontdat[chr + cga->fontbase][cga->sc & 7] & (1 << (c ^ 7))) ? 1 : 0];
+                        = cols[(fontdat[chr + cga->fontbase][cga->scanline & 7] & (1 << (c ^ 7))) ? 1 : 0];
                 }
             }
         }
@@ -358,11 +358,11 @@ cga_render(cga_t *cga, int line)
         }
         for (x = 0; x < cga->crtc[CGA_CRTC_HDISP]; x++) {
             if (cga->cgamode & CGA_MODE_FLAG_VIDEO_ENABLE)
-                dat = (cga->vram[((cga->ma << 1) & 0x1fff) + ((cga->sc & 1) * 0x2000)] << 8) |
-                      cga->vram[((cga->ma << 1) & 0x1fff) + ((cga->sc & 1) * 0x2000) + 1];
+                dat = (cga->vram[((cga->memaddr << 1) & 0x1fff) + ((cga->scanline & 1) * 0x2000)] << 8) |
+                      cga->vram[((cga->memaddr << 1) & 0x1fff) + ((cga->scanline & 1) * 0x2000) + 1];
             else
                 dat = 0;
-            cga->ma++;
+            cga->memaddr++;
             for (c = 0; c < 8; c++) {
                 buffer32->line[line][(x << 4) + (c << 1) + 8]
                     = buffer32->line[line][(x << 4) + (c << 1) + 9]
@@ -375,11 +375,11 @@ cga_render(cga_t *cga, int line)
         cols[1] = (cga->cgacol & 15) + 16;
         for (x = 0; x < cga->crtc[CGA_CRTC_HDISP]; x++) {
             if (cga->cgamode & CGA_MODE_FLAG_VIDEO_ENABLE)
-                dat = (cga->vram[((cga->ma << 1) & 0x1fff) + ((cga->sc & 1) * 0x2000)] << 8) |
-                      cga->vram[((cga->ma << 1) & 0x1fff) + ((cga->sc & 1) * 0x2000) + 1];
+                dat = (cga->vram[((cga->memaddr << 1) & 0x1fff) + ((cga->scanline & 1) * 0x2000)] << 8) |
+                      cga->vram[((cga->memaddr << 1) & 0x1fff) + ((cga->scanline & 1) * 0x2000) + 1];
             else
                 dat = 0;
-            cga->ma++;
+            cga->memaddr++;
             for (c = 0; c < 16; c++) {
                 buffer32->line[line][(x << 4) + c + 8] = cols[dat >> 15];
                 dat <<= 1;
@@ -519,7 +519,7 @@ cga_poll(void *priv)
 {
     cga_t   *cga = (cga_t *) priv;
     int      x;
-    int      oldsc;
+    int      scanline_old;
     int      oldvc;
     int      xs_temp;
     int      ys_temp;
@@ -529,9 +529,9 @@ cga_poll(void *priv)
         timer_advance_u64(&cga->timer, cga->dispofftime);
         cga->cgastat |= 1;
         cga->linepos = 1;
-        oldsc        = cga->sc;
+        scanline_old        = cga->scanline;
         if ((cga->crtc[CGA_CRTC_INTERLACE] & 3) == 3)
-            cga->sc = ((cga->sc << 1) + cga->oddeven) & 7;
+            cga->scanline = ((cga->scanline << 1) + cga->oddeven) & 7;
         if (cga->cgadispon) {
             if (cga->displine < cga->firstline) {
                 cga->firstline = cga->displine;
@@ -547,9 +547,9 @@ cga_poll(void *priv)
                     cga_render(cga, cga->displine);
                     break;
                 case DOUBLE_SIMPLE:
-                    old_ma = cga->ma;
+                    old_ma = cga->memaddr;
                     cga_render(cga, cga->displine << 1);
-                    cga->ma = old_ma;
+                    cga->memaddr = old_ma;
                     cga_render(cga, (cga->displine << 1) + 1);
                     break;
             }
@@ -578,8 +578,8 @@ cga_poll(void *priv)
                 break;
         }
 
-        cga->sc = oldsc;
-        if (cga->vc == cga->crtc[CGA_CRTC_VSYNC] && !cga->sc)
+        cga->scanline = scanline_old;
+        if (cga->vc == cga->crtc[CGA_CRTC_VSYNC] && !cga->scanline)
             cga->cgastat |= 8;
         cga->displine++;
         if (cga->displine >= 360)
@@ -592,25 +592,25 @@ cga_poll(void *priv)
             if (!cga->vsynctime)
                 cga->cgastat &= ~8;
         }
-        if (cga->sc == (cga->crtc[CGA_CRTC_CURSOR_END] & 31) || ((cga->crtc[CGA_CRTC_INTERLACE] & 3) == 3 &&
-            cga->sc == ((cga->crtc[CGA_CRTC_CURSOR_END] & 31) >> 1))) {
+        if (cga->scanline == (cga->crtc[CGA_CRTC_CURSOR_END] & 31) || ((cga->crtc[CGA_CRTC_INTERLACE] & 3) == 3 &&
+            cga->scanline == ((cga->crtc[CGA_CRTC_CURSOR_END] & 31) >> 1))) {
             cga->cursorvisible  = 0;
         }
-        if ((cga->crtc[CGA_CRTC_INTERLACE] & 3) == 3 && cga->sc == (cga->crtc[CGA_CRTC_MAX_SCANLINE_ADDR] >> 1))
-            cga->maback = cga->ma;
+        if ((cga->crtc[CGA_CRTC_INTERLACE] & 3) == 3 && cga->scanline == (cga->crtc[CGA_CRTC_MAX_SCANLINE_ADDR] >> 1))
+            cga->memaddr_backup = cga->memaddr;
         if (cga->vadj) {
-            cga->sc++;
-            cga->sc &= 31;
-            cga->ma = cga->maback;
+            cga->scanline++;
+            cga->scanline &= 31;
+            cga->memaddr = cga->memaddr_backup;
             cga->vadj--;
             if (!cga->vadj) {
                 cga->cgadispon = 1;
-                cga->ma = cga->maback = (cga->crtc[CGA_CRTC_START_ADDR_LOW] | (cga->crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
-                cga->sc               = 0;
+                cga->memaddr = cga->memaddr_backup = (cga->crtc[CGA_CRTC_START_ADDR_LOW] | (cga->crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
+                cga->scanline               = 0;
             }
-        } else if (cga->sc == cga->crtc[CGA_CRTC_MAX_SCANLINE_ADDR]) {
-            cga->maback = cga->ma;
-            cga->sc     = 0;
+        } else if (cga->scanline == cga->crtc[CGA_CRTC_MAX_SCANLINE_ADDR]) {
+            cga->memaddr_backup = cga->memaddr;
+            cga->scanline     = 0;
             oldvc       = cga->vc;
             cga->vc++;
             cga->vc &= 127;
@@ -623,7 +623,7 @@ cga_poll(void *priv)
                 cga->vadj = cga->crtc[CGA_CRTC_VTOTAL_ADJUST];
                 if (!cga->vadj) {
                     cga->cgadispon = 1;
-                    cga->ma = cga->maback = (cga->crtc[CGA_CRTC_START_ADDR_LOW] | (cga->crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
+                    cga->memaddr = cga->memaddr_backup = (cga->crtc[CGA_CRTC_START_ADDR_LOW] | (cga->crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
                 }
                 
                 switch (cga->crtc[CGA_CRTC_CURSOR_START] & 0x60) {
@@ -717,18 +717,18 @@ cga_poll(void *priv)
                 cga->oddeven ^= 1;
             }
         } else {
-            cga->sc++;
-            cga->sc &= 31;
-            cga->ma = cga->maback;
+            cga->scanline++;
+            cga->scanline &= 31;
+            cga->memaddr = cga->memaddr_backup;
         }
         if (cga->cgadispon)
             cga->cgastat &= ~1;
-        if (cga->sc == (cga->crtc[CGA_CRTC_CURSOR_START] & 31) || ((cga->crtc[CGA_CRTC_INTERLACE] & 3) == 3 &&
-            cga->sc == ((cga->crtc[CGA_CRTC_CURSOR_START] & 31) >> 1)))
+        if (cga->scanline == (cga->crtc[CGA_CRTC_CURSOR_START] & 31) || ((cga->crtc[CGA_CRTC_INTERLACE] & 3) == 3 &&
+            cga->scanline == ((cga->crtc[CGA_CRTC_CURSOR_START] & 31) >> 1)))
             cga->cursorvisible = 1;
         if (cga->cgadispon && (cga->cgamode & CGA_MODE_FLAG_HIGHRES)) {
             for (x = 0; x < (cga->crtc[CGA_CRTC_HDISP] << 1); x++)
-                cga->charbuffer[x] = cga->vram[((cga->ma << 1) + x) & 0x3fff];
+                cga->charbuffer[x] = cga->vram[((cga->memaddr << 1) + x) & 0x3fff];
         }
     }
 }

--- a/src/video/vid_cga_compaq_plasma.c
+++ b/src/video/vid_cga_compaq_plasma.c
@@ -435,7 +435,7 @@ compaq_plasma_poll(void *priv)
                         else
                             cursorinvisible = ((self->cga.crtc[CGA_CRTC_CURSOR_END] & 0x0f) << 1);
 
-                        cursorline = (cursorvisible <= scanline) && (cursorinvisible >= sc);
+                        cursorline = (cursorvisible <= scanline) && (cursorinvisible >= scanline);
                     }
 
                     for (x = 0; x < 40; x++) {

--- a/src/video/vid_cga_compaq_plasma.c
+++ b/src/video/vid_cga_compaq_plasma.c
@@ -314,7 +314,7 @@ compaq_plasma_poll(void *priv)
                         else
                             cursorinvisible = ((self->cga.crtc[CGA_CRTC_CURSOR_END] & 0x0f) << 1);
 
-                        cursorline = (cursorvisible <= scanline) && (cursorinvisible >= sc);
+                        cursorline = (cursorvisible <= scanline) && (cursorinvisible >= scanline);
                     }
 
                     /* for each text column */

--- a/src/video/vid_cga_toshiba_t1000.c
+++ b/src/video/vid_cga_toshiba_t1000.c
@@ -245,23 +245,23 @@ t1000_text_row80(t1000_t *t1000)
     int      bold;
     int      blink;
     uint16_t addr;
-    uint8_t  sc;
-    uint16_t ma = (t1000->cga.crtc[CGA_CRTC_START_ADDR_LOW] | (t1000->cga.crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
-    uint16_t ca = (t1000->cga.crtc[CGA_CRTC_CURSOR_ADDR_LOW] | (t1000->cga.crtc[CGA_CRTC_CURSOR_ADDR_HIGH] << 8)) & 0x3fff;
+    uint8_t  scanline;
+    uint16_t memaddr = (t1000->cga.crtc[CGA_CRTC_START_ADDR_LOW] | (t1000->cga.crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
+    uint16_t cursoraddr = (t1000->cga.crtc[CGA_CRTC_CURSOR_ADDR_LOW] | (t1000->cga.crtc[CGA_CRTC_CURSOR_ADDR_HIGH] << 8)) & 0x3fff;
 
-    sc   = (t1000->displine) & 7;
-    addr = ((ma & ~1) + (t1000->displine >> 3) * 80) * 2;
-    ma += (t1000->displine >> 3) * 80;
+    scanline   = (t1000->displine) & 7;
+    addr = ((memaddr & ~1) + (t1000->displine >> 3) * 80) * 2;
+    memaddr += (t1000->displine >> 3) * 80;
 
     if ((t1000->cga.crtc[CGA_CRTC_CURSOR_START] & 0x60) == 0x20) {
         cursorline = 0;
     } else {
-        cursorline = ((t1000->cga.crtc[CGA_CRTC_CURSOR_START] & 0x0F) <= sc) && ((t1000->cga.crtc[CGA_CRTC_CURSOR_END] & 0x0F) >= sc);
+        cursorline = ((t1000->cga.crtc[CGA_CRTC_CURSOR_START] & 0x0F) <= scanline) && ((t1000->cga.crtc[CGA_CRTC_CURSOR_END] & 0x0F) >= scanline);
     }
     for (uint8_t x = 0; x < 80; x++) {
         chr        = t1000->vram[(addr + 2 * x) & 0x3FFF];
         attr       = t1000->vram[(addr + 2 * x + 1) & 0x3FFF];
-        drawcursor = ((ma == ca) && cursorline && (t1000->cga.cgamode & CGA_MODE_FLAG_VIDEO_ENABLE) && (t1000->cga.cgablink & 16));
+        drawcursor = ((memaddr == cursoraddr) && cursorline && (t1000->cga.cgamode & CGA_MODE_FLAG_VIDEO_ENABLE) && (t1000->cga.cgablink & 16));
 
         blink = ((t1000->cga.cgablink & 16) && (t1000->cga.cgamode & CGA_MODE_FLAG_BLINK) && (attr & 0x80) && !drawcursor);
 
@@ -284,13 +284,13 @@ t1000_text_row80(t1000_t *t1000)
         }
         if (drawcursor) {
             for (uint8_t c = 0; c < 8; c++) {
-                (buffer32->line[t1000->displine])[(x << 3) + c] = cols[(fontdat[bold][sc] & (1 << (c ^ 7))) ? 1 : 0] ^ (blue ^ grey);
+                (buffer32->line[t1000->displine])[(x << 3) + c] = cols[(fontdat[bold][scanline] & (1 << (c ^ 7))) ? 1 : 0] ^ (blue ^ grey);
             }
         } else {
             for (uint8_t c = 0; c < 8; c++)
-                (buffer32->line[t1000->displine])[(x << 3) + c] = cols[(fontdat[bold][sc] & (1 << (c ^ 7))) ? 1 : 0];
+                (buffer32->line[t1000->displine])[(x << 3) + c] = cols[(fontdat[bold][scanline] & (1 << (c ^ 7))) ? 1 : 0];
         }
-        ++ma;
+        ++memaddr;
     }
 }
 
@@ -306,23 +306,23 @@ t1000_text_row40(t1000_t *t1000)
     int      bold;
     int      blink;
     uint16_t addr;
-    uint8_t  sc;
-    uint16_t ma = (t1000->cga.crtc[CGA_CRTC_START_ADDR_LOW] | (t1000->cga.crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
-    uint16_t ca = (t1000->cga.crtc[CGA_CRTC_CURSOR_ADDR_LOW] | (t1000->cga.crtc[CGA_CRTC_CURSOR_ADDR_HIGH] << 8)) & 0x3fff;
+    uint8_t  scanline;
+    uint16_t memaddr = (t1000->cga.crtc[CGA_CRTC_START_ADDR_LOW] | (t1000->cga.crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
+    uint16_t cursoraddr = (t1000->cga.crtc[CGA_CRTC_CURSOR_ADDR_LOW] | (t1000->cga.crtc[CGA_CRTC_CURSOR_ADDR_HIGH] << 8)) & 0x3fff;
 
-    sc   = (t1000->displine) & 7;
-    addr = ((ma & ~1) + (t1000->displine >> 3) * 40) * 2;
-    ma += (t1000->displine >> 3) * 40;
+    scanline   = (t1000->displine) & 7;
+    addr = ((memaddr & ~1) + (t1000->displine >> 3) * 40) * 2;
+    memaddr += (t1000->displine >> 3) * 40;
 
     if ((t1000->cga.crtc[CGA_CRTC_CURSOR_START] & 0x60) == 0x20) {
         cursorline = 0;
     } else {
-        cursorline = ((t1000->cga.crtc[CGA_CRTC_CURSOR_START] & 0x0F) <= sc) && ((t1000->cga.crtc[CGA_CRTC_CURSOR_END] & 0x0F) >= sc);
+        cursorline = ((t1000->cga.crtc[CGA_CRTC_CURSOR_START] & 0x0F) <= scanline) && ((t1000->cga.crtc[CGA_CRTC_CURSOR_END] & 0x0F) >= scanline);
     }
     for (uint8_t x = 0; x < 40; x++) {
         chr        = t1000->vram[(addr + 2 * x) & 0x3FFF];
         attr       = t1000->vram[(addr + 2 * x + 1) & 0x3FFF];
-        drawcursor = ((ma == ca) && cursorline && (t1000->cga.cgamode & CGA_MODE_FLAG_VIDEO_ENABLE) && (t1000->cga.cgablink & 16));
+        drawcursor = ((memaddr == cursoraddr) && cursorline && (t1000->cga.cgamode & CGA_MODE_FLAG_VIDEO_ENABLE) && (t1000->cga.cgablink & 16));
 
         blink = ((t1000->cga.cgablink & 16) && (t1000->cga.cgamode & CGA_MODE_FLAG_BLINK) && (attr & 0x80) && !drawcursor);
 
@@ -345,14 +345,14 @@ t1000_text_row40(t1000_t *t1000)
         }
         if (drawcursor) {
             for (uint8_t c = 0; c < 8; c++) {
-                (buffer32->line[t1000->displine])[(x << 4) + c * 2] = (buffer32->line[t1000->displine])[(x << 4) + c * 2 + 1] = cols[(fontdat[bold][sc] & (1 << (c ^ 7))) ? 1 : 0] ^ (blue ^ grey);
+                (buffer32->line[t1000->displine])[(x << 4) + c * 2] = (buffer32->line[t1000->displine])[(x << 4) + c * 2 + 1] = cols[(fontdat[bold][scanline] & (1 << (c ^ 7))) ? 1 : 0] ^ (blue ^ grey);
             }
         } else {
             for (uint8_t c = 0; c < 8; c++) {
-                (buffer32->line[t1000->displine])[(x << 4) + c * 2] = (buffer32->line[t1000->displine])[(x << 4) + c * 2 + 1] = cols[(fontdat[bold][sc] & (1 << (c ^ 7))) ? 1 : 0];
+                (buffer32->line[t1000->displine])[(x << 4) + c * 2] = (buffer32->line[t1000->displine])[(x << 4) + c * 2 + 1] = cols[(fontdat[bold][scanline] & (1 << (c ^ 7))) ? 1 : 0];
             }
         }
-        ++ma;
+        ++memaddr;
     }
 }
 
@@ -366,9 +366,9 @@ t1000_cgaline6(t1000_t *t1000)
     uint32_t fg = (t1000->cga.cgacol & 0x0F) ? blue : grey;
     uint32_t bg = grey;
 
-    uint16_t ma = (t1000->cga.crtc[CGA_CRTC_START_ADDR_LOW] | (t1000->cga.crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
+    uint16_t memaddr = (t1000->cga.crtc[CGA_CRTC_START_ADDR_LOW] | (t1000->cga.crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
 
-    addr = ((t1000->displine) & 1) * 0x2000 + (t1000->displine >> 1) * 80 + ((ma & ~1) << 1);
+    addr = ((t1000->displine) & 1) * 0x2000 + (t1000->displine >> 1) * 80 + ((memaddr & ~1) << 1);
 
     for (uint8_t x = 0; x < 80; x++) {
         dat = t1000->vram[addr & 0x3FFF];
@@ -395,8 +395,8 @@ t1000_cgaline4(t1000_t *t1000)
     uint32_t ink1;
     uint16_t addr;
 
-    uint16_t ma = (t1000->cga.crtc[CGA_CRTC_START_ADDR_LOW] | (t1000->cga.crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
-    addr        = ((t1000->displine) & 1) * 0x2000 + (t1000->displine >> 1) * 80 + ((ma & ~1) << 1);
+    uint16_t memaddr = (t1000->cga.crtc[CGA_CRTC_START_ADDR_LOW] | (t1000->cga.crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
+    addr        = ((t1000->displine) & 1) * 0x2000 + (t1000->displine >> 1) * 80 + ((memaddr & ~1) << 1);
 
     for (uint8_t x = 0; x < 80; x++) {
         dat = t1000->vram[addr & 0x3FFF];

--- a/src/video/vid_cga_toshiba_t3100e.c
+++ b/src/video/vid_cga_toshiba_t3100e.c
@@ -254,23 +254,23 @@ t3100e_text_row80(t3100e_t *t3100e)
     int      bold;
     int      blink;
     uint16_t addr;
-    uint8_t  sc;
-    uint16_t ma = (t3100e->cga.crtc[CGA_CRTC_START_ADDR_LOW] | (t3100e->cga.crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x7fff;
-    uint16_t ca = (t3100e->cga.crtc[CGA_CRTC_CURSOR_ADDR_LOW] | (t3100e->cga.crtc[CGA_CRTC_CURSOR_ADDR_HIGH] << 8)) & 0x7fff;
+    uint8_t  scanline;
+    uint16_t memaddr = (t3100e->cga.crtc[CGA_CRTC_START_ADDR_LOW] | (t3100e->cga.crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x7fff;
+    uint16_t cursoraddr = (t3100e->cga.crtc[CGA_CRTC_CURSOR_ADDR_LOW] | (t3100e->cga.crtc[CGA_CRTC_CURSOR_ADDR_HIGH] << 8)) & 0x7fff;
 
-    sc   = (t3100e->displine) & 15;
-    addr = ((ma & ~1) + (t3100e->displine >> 4) * 80) * 2;
-    ma += (t3100e->displine >> 4) * 80;
+    scanline   = (t3100e->displine) & 15;
+    addr = ((memaddr & ~1) + (t3100e->displine >> 4) * 80) * 2;
+    memaddr += (t3100e->displine >> 4) * 80;
 
     if ((t3100e->cga.crtc[CGA_CRTC_CURSOR_START] & 0x60) == 0x20) {
         cursorline = 0;
     } else {
-        cursorline = ((t3100e->cga.crtc[CGA_CRTC_CURSOR_START] & 0x0F) * 2 <= sc) && ((t3100e->cga.crtc[CGA_CRTC_CURSOR_END] & 0x0F) * 2 >= sc);
+        cursorline = ((t3100e->cga.crtc[CGA_CRTC_CURSOR_START] & 0x0F) * 2 <= scanline) && ((t3100e->cga.crtc[CGA_CRTC_CURSOR_END] & 0x0F) * 2 >= scanline);
     }
     for (uint8_t x = 0; x < 80; x++) {
         chr        = t3100e->vram[(addr + 2 * x) & 0x7FFF];
         attr       = t3100e->vram[(addr + 2 * x + 1) & 0x7FFF];
-        drawcursor = ((ma == ca) && cursorline && (t3100e->cga.cgamode & CGA_MODE_FLAG_VIDEO_ENABLE) && (t3100e->cga.cgablink & 16));
+        drawcursor = ((memaddr == cursoraddr) && cursorline && (t3100e->cga.cgamode & CGA_MODE_FLAG_VIDEO_ENABLE) && (t3100e->cga.cgablink & 16));
 
         blink = ((t3100e->cga.cgablink & 16) && (t3100e->cga.cgamode & CGA_MODE_FLAG_BLINK) && (attr & 0x80) && !drawcursor);
 
@@ -292,13 +292,13 @@ t3100e_text_row80(t3100e_t *t3100e)
         }
         if (drawcursor) {
             for (uint8_t c = 0; c < 8; c++) {
-                (buffer32->line[t3100e->displine])[(x << 3) + c] = cols[(fontdatm[bold][sc] & (1 << (c ^ 7))) ? 1 : 0] ^ (amber ^ black);
+                (buffer32->line[t3100e->displine])[(x << 3) + c] = cols[(fontdatm[bold][scanline] & (1 << (c ^ 7))) ? 1 : 0] ^ (amber ^ black);
             }
         } else {
             for (uint8_t c = 0; c < 8; c++)
-                (buffer32->line[t3100e->displine])[(x << 3) + c] = cols[(fontdatm[bold][sc] & (1 << (c ^ 7))) ? 1 : 0];
+                (buffer32->line[t3100e->displine])[(x << 3) + c] = cols[(fontdatm[bold][scanline] & (1 << (c ^ 7))) ? 1 : 0];
         }
-        ++ma;
+        ++memaddr;
     }
 }
 
@@ -315,23 +315,23 @@ t3100e_text_row40(t3100e_t *t3100e)
     int      bold;
     int      blink;
     uint16_t addr;
-    uint8_t  sc;
-    uint16_t ma = (t3100e->cga.crtc[CGA_CRTC_START_ADDR_LOW] | (t3100e->cga.crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x7fff;
-    uint16_t ca = (t3100e->cga.crtc[CGA_CRTC_CURSOR_ADDR_LOW] | (t3100e->cga.crtc[CGA_CRTC_CURSOR_ADDR_HIGH] << 8)) & 0x7fff;
+    uint8_t  scanline;
+    uint16_t memaddr = (t3100e->cga.crtc[CGA_CRTC_START_ADDR_LOW] | (t3100e->cga.crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x7fff;
+    uint16_t cursoraddr = (t3100e->cga.crtc[CGA_CRTC_CURSOR_ADDR_LOW] | (t3100e->cga.crtc[CGA_CRTC_CURSOR_ADDR_HIGH] << 8)) & 0x7fff;
 
-    sc   = (t3100e->displine) & 15;
-    addr = ((ma & ~1) + (t3100e->displine >> 4) * 40) * 2;
-    ma += (t3100e->displine >> 4) * 40;
+    scanline   = (t3100e->displine) & 15;
+    addr = ((memaddr & ~1) + (t3100e->displine >> 4) * 40) * 2;
+    memaddr += (t3100e->displine >> 4) * 40;
 
     if ((t3100e->cga.crtc[CGA_CRTC_CURSOR_START] & 0x60) == 0x20) {
         cursorline = 0;
     } else {
-        cursorline = ((t3100e->cga.crtc[CGA_CRTC_CURSOR_START] & 0x0F) * 2 <= sc) && ((t3100e->cga.crtc[CGA_CRTC_CURSOR_END] & 0x0F) * 2 >= sc);
+        cursorline = ((t3100e->cga.crtc[CGA_CRTC_CURSOR_START] & 0x0F) * 2 <= scanline) && ((t3100e->cga.crtc[CGA_CRTC_CURSOR_END] & 0x0F) * 2 >= scanline);
     }
     for (uint8_t x = 0; x < 40; x++) {
         chr        = t3100e->vram[(addr + 2 * x) & 0x7FFF];
         attr       = t3100e->vram[(addr + 2 * x + 1) & 0x7FFF];
-        drawcursor = ((ma == ca) && cursorline && (t3100e->cga.cgamode & CGA_MODE_FLAG_VIDEO_ENABLE) && (t3100e->cga.cgablink & 16));
+        drawcursor = ((memaddr == cursoraddr) && cursorline && (t3100e->cga.cgamode & CGA_MODE_FLAG_VIDEO_ENABLE) && (t3100e->cga.cgablink & 16));
 
         blink = ((t3100e->cga.cgablink & 16) && (t3100e->cga.cgamode & CGA_MODE_FLAG_BLINK) && (attr & 0x80) && !drawcursor);
 
@@ -353,14 +353,14 @@ t3100e_text_row40(t3100e_t *t3100e)
         }
         if (drawcursor) {
             for (c = 0; c < 8; c++) {
-                (buffer32->line[t3100e->displine])[(x << 4) + c * 2] = (buffer32->line[t3100e->displine])[(x << 4) + c * 2 + 1] = cols[(fontdatm[bold][sc] & (1 << (c ^ 7))) ? 1 : 0] ^ (amber ^ black);
+                (buffer32->line[t3100e->displine])[(x << 4) + c * 2] = (buffer32->line[t3100e->displine])[(x << 4) + c * 2 + 1] = cols[(fontdatm[bold][scanline] & (1 << (c ^ 7))) ? 1 : 0] ^ (amber ^ black);
             }
         } else {
             for (c = 0; c < 8; c++) {
-                (buffer32->line[t3100e->displine])[(x << 4) + c * 2] = (buffer32->line[t3100e->displine])[(x << 4) + c * 2 + 1] = cols[(fontdatm[bold][sc] & (1 << (c ^ 7))) ? 1 : 0];
+                (buffer32->line[t3100e->displine])[(x << 4) + c * 2] = (buffer32->line[t3100e->displine])[(x << 4) + c * 2 + 1] = cols[(fontdatm[bold][scanline] & (1 << (c ^ 7))) ? 1 : 0];
             }
         }
-        ++ma;
+        ++memaddr;
     }
 }
 
@@ -374,13 +374,13 @@ t3100e_cgaline6(t3100e_t *t3100e)
     uint32_t fg = (t3100e->cga.cgacol & 0x0F) ? amber : black;
     uint32_t bg = black;
 
-    uint16_t ma = (t3100e->cga.crtc[CGA_CRTC_START_ADDR_LOW] | (t3100e->cga.crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x7fff;
+    uint16_t memaddr = (t3100e->cga.crtc[CGA_CRTC_START_ADDR_LOW] | (t3100e->cga.crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x7fff;
 
     if (t3100e->cga.crtc[CGA_CRTC_MAX_SCANLINE_ADDR] == 3) /* 640*400 */
     {
-        addr = ((t3100e->displine) & 1) * 0x2000 + ((t3100e->displine >> 1) & 1) * 0x4000 + (t3100e->displine >> 2) * 80 + ((ma & ~1) << 1);
+        addr = ((t3100e->displine) & 1) * 0x2000 + ((t3100e->displine >> 1) & 1) * 0x4000 + (t3100e->displine >> 2) * 80 + ((memaddr & ~1) << 1);
     } else {
-        addr = ((t3100e->displine >> 1) & 1) * 0x2000 + (t3100e->displine >> 2) * 80 + ((ma & ~1) << 1);
+        addr = ((t3100e->displine >> 1) & 1) * 0x2000 + (t3100e->displine >> 2) * 80 + ((memaddr & ~1) << 1);
     }
     for (uint8_t x = 0; x < 80; x++) {
         dat = t3100e->vram[addr & 0x7FFF];
@@ -407,13 +407,13 @@ t3100e_cgaline4(t3100e_t *t3100e)
     uint32_t ink1 = 0;
     uint16_t addr;
 
-    uint16_t ma = (t3100e->cga.crtc[CGA_CRTC_START_ADDR_HIGH] | (t3100e->cga.crtc[CGA_CRTC_CURSOR_END] << 8)) & 0x7fff;
+    uint16_t memaddr = (t3100e->cga.crtc[CGA_CRTC_START_ADDR_HIGH] | (t3100e->cga.crtc[CGA_CRTC_CURSOR_END] << 8)) & 0x7fff;
     if (t3100e->cga.crtc[CGA_CRTC_MAX_SCANLINE_ADDR] == 3) /* 320*400 undocumented */
     {
-        addr = ((t3100e->displine) & 1) * 0x2000 + ((t3100e->displine >> 1) & 1) * 0x4000 + (t3100e->displine >> 2) * 80 + ((ma & ~1) << 1);
+        addr = ((t3100e->displine) & 1) * 0x2000 + ((t3100e->displine >> 1) & 1) * 0x4000 + (t3100e->displine >> 2) * 80 + ((memaddr & ~1) << 1);
     } else /* 320*200 */
     {
-        addr = ((t3100e->displine >> 1) & 1) * 0x2000 + (t3100e->displine >> 2) * 80 + ((ma & ~1) << 1);
+        addr = ((t3100e->displine >> 1) & 1) * 0x2000 + (t3100e->displine >> 2) * 80 + ((memaddr & ~1) << 1);
     }
     for (uint8_t x = 0; x < 80; x++) {
         dat = t3100e->vram[addr & 0x7FFF];

--- a/src/video/vid_chips_69000.c
+++ b/src/video/vid_chips_69000.c
@@ -1098,7 +1098,7 @@ chips_69000_recalctimings(svga_t *svga)
         svga->hblank_end_val = ((svga->crtc[3] & 0x1f) | ((svga->crtc[5] & 0x80) ? 0x20 : 0x00)) | (svga->crtc[0x3c] & 0b11000000);
         svga->hblank_end_mask = 0xff;
 
-        svga->ma_latch |= (svga->crtc[0x40] & 0xF) << 16;
+        svga->memaddr_latch |= (svga->crtc[0x40] & 0xF) << 16;
         svga->rowoffset |= (svga->crtc[0x41] & 0xF) << 8;
 
         svga->interlace = !!(svga->crtc[0x70] & 0x80);
@@ -2044,7 +2044,7 @@ chips_69000_out(uint16_t addr, uint8_t val, void *priv)
                 if (svga->crtcreg < 0xe || svga->crtcreg > 0x10) {
                     if ((svga->crtcreg == 0xc) || (svga->crtcreg == 0xd)) {
                         svga->fullchange = 3;
-                        svga->ma_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
+                        svga->memaddr_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
                     } else {
                         svga->fullchange = changeframecount;
                         svga_recalctimings(svga);

--- a/src/video/vid_cl54xx.c
+++ b/src/video/vid_cl54xx.c
@@ -575,7 +575,7 @@ gd54xx_overlay_draw(svga_t *svga, int displine)
     uint8_t        *src         = &svga->vram[(svga->overlay_latch.addr << shift) & svga->vram_mask];
     int             bpp         = svga->bpp;
     int             bytesperpix = (bpp + 7) / 8;
-    uint8_t        *src2        = &svga->vram[(svga->ma - (svga->hdisp * bytesperpix)) & svga->vram_display_mask];
+    uint8_t        *src2        = &svga->vram[(svga->memaddr - (svga->hdisp * bytesperpix)) & svga->vram_display_mask];
     int             occl;
     int             ckval;
 
@@ -1255,7 +1255,7 @@ gd54xx_out(uint16_t addr, uint8_t val, void *priv)
                 if (svga->crtcreg < 0xe || svga->crtcreg > 0x10) {
                     if ((svga->crtcreg == 0xc) || (svga->crtcreg == 0xd)) {
                         svga->fullchange = 3;
-                        svga->ma_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) +
+                        svga->memaddr_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) +
                                            ((svga->crtc[8] & 0x60) >> 5);
                     } else {
                         svga->fullchange = changeframecount;
@@ -1875,7 +1875,7 @@ gd54xx_recalctimings(svga_t *svga)
     } else if (svga->gdcreg[5] & 0x40)
         svga->render = svga_render_8bpp_lowres;
 
-    svga->ma_latch |= ((svga->crtc[0x1b] & 0x01) << 16) | ((svga->crtc[0x1b] & 0xc) << 15);
+    svga->memaddr_latch |= ((svga->crtc[0x1b] & 0x01) << 16) | ((svga->crtc[0x1b] & 0xc) << 15);
 
     svga->bpp = 8;
 

--- a/src/video/vid_ega_render.c
+++ b/src/video/vid_ega_render.c
@@ -141,9 +141,9 @@ ega_render_text(ega_t *ega)
         }
 
         for (int x = 0; x < (ega->hdisp + ega->scrollcache); x += charwidth) {
-            uint32_t addr = ega->remap_func(ega, ega->ma) & ega->vrammask;
+            uint32_t addr = ega->remap_func(ega, ega->memaddr) & ega->vrammask;
 
-            int drawcursor = ((ega->ma == ega->ca) && ega->cursorvisible && ega->cursoron);
+            int drawcursor = ((ega->memaddr == ega->cursoraddr) && ega->cursorvisible && ega->cursoron);
 
             uint32_t chr;
             uint32_t attr;
@@ -175,7 +175,7 @@ ega_render_text(ega_t *ega)
                 }
             }
 
-            uint32_t dat = ega->vram[charaddr + (ega->sc << 2)];
+            uint32_t dat = ega->vram[charaddr + (ega->scanline << 2)];
             dat <<= 1;
             if (((chr & ~0x1f) == 0xc0) && attrlinechars)
                 dat |= (dat >> 1) & 1;
@@ -184,7 +184,7 @@ ega_render_text(ega_t *ega)
                 if (monoattrs) {
                     int bit   = (dat & (0x100 >> (xx >> dwshift))) ? 1 : 0;
                     int blink = (!drawcursor && (attr & 0x80) && attrblink && blinked);
-                    if ((ega->sc == ega->crtc[0x14]) && ((attr & 7) == 1))
+                    if ((ega->scanline == ega->crtc[0x14]) && ((attr & 7) == 1))
                         p[xx] = ega->mdacols[attr][blink][1];
                     else
                         p[xx] = ega->mdacols[attr][blink][bit];
@@ -195,10 +195,10 @@ ega_render_text(ega_t *ega)
                     p[xx] = (dat & (0x100 >> (xx >> dwshift))) ? fg : bg;
             }
 
-            ega->ma += 4;
+            ega->memaddr += 4;
             p += charwidth;
         }
-        ega->ma &= 0x3ffff;
+        ega->memaddr &= 0x3ffff;
     }
 }
 
@@ -236,7 +236,7 @@ ega_render_graphics(ega_t *ega)
     }
 
     for (int x = 0; x <= (ega->hdisp + ega->scrollcache); x += charwidth) {
-        uint32_t addr = ega->remap_func(ega, ega->ma) & ega->vrammask;
+        uint32_t addr = ega->remap_func(ega, ega->memaddr) & ega->vrammask;
 
         uint8_t edat[4];
         if (seqoddeven) {
@@ -247,12 +247,12 @@ ega_render_graphics(ega_t *ega)
             edat[3]    = ega->vram[(addr | 3) ^ secondcclk];
             secondcclk = (secondcclk + 1) & 1;
             if (secondcclk == 0)
-                ega->ma += 4;
+                ega->memaddr += 4;
         } else {
             *(uint32_t *) (&edat[0]) = *(uint32_t *) (&ega->vram[addr]);
-            ega->ma += 4;
+            ega->memaddr += 4;
         }
-        ega->ma &= 0x3ffff;
+        ega->memaddr &= 0x3ffff;
 
         if (cga2bpp) {
             // Remap CGA 2bpp-chunky data into fully planar data

--- a/src/video/vid_et3000.c
+++ b/src/video/vid_et3000.c
@@ -424,7 +424,7 @@ et3000_out(uint16_t addr, uint8_t val, void *priv)
 static void
 et3000_recalctimings(svga_t *svga)
 {
-    svga->ma_latch |= (svga->crtc[0x23] & 2) << 15;
+    svga->memaddr_latch |= (svga->crtc[0x23] & 2) << 15;
     if (svga->crtc[0x25] & 1)
         svga->vblankstart |= 0x400;
     if (svga->crtc[0x25] & 2)
@@ -439,7 +439,7 @@ et3000_recalctimings(svga_t *svga)
     svga->interlace = !!(svga->crtc[0x25] & 0x80);
 
     if (svga->attrregs[0x16] & 0x10) {
-        svga->ma_latch <<= (1 << 0);
+        svga->memaddr_latch <<= (1 << 0);
         svga->rowoffset <<= (1 << 0);
         switch (svga->gdcreg[5] & 0x60) {
             case 0x00:

--- a/src/video/vid_et4000.c
+++ b/src/video/vid_et4000.c
@@ -378,7 +378,7 @@ et4000_out(uint16_t addr, uint8_t val, void *priv)
                 if (svga->crtcreg < 0xe || svga->crtcreg > 0x10) {
                     if ((svga->crtcreg == 0xc) || (svga->crtcreg == 0xd)) {
                         svga->fullchange = 3;
-                        svga->ma_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
+                        svga->memaddr_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
                     } else {
                         svga->fullchange = changeframecount;
                         svga_recalctimings(svga);
@@ -642,7 +642,7 @@ et4000_recalctimings(svga_t *svga)
 {
     const et4000_t *dev = (et4000_t *) svga->priv;
 
-    svga->ma_latch |= (svga->crtc[0x33] & 3) << 16;
+    svga->memaddr_latch |= (svga->crtc[0x33] & 3) << 16;
 
     svga->hblankstart = (((svga->crtc[0x3f] & 0x4) >> 2) << 8) + svga->crtc[2];
 
@@ -701,7 +701,7 @@ et4000_recalctimings(svga_t *svga)
     if (dev->type == ET4000_TYPE_KOREAN || dev->type == ET4000_TYPE_TRIGEM || dev->type == ET4000_TYPE_KASAN) {
         if ((svga->render == svga_render_text_80) && ((svga->crtc[0x37] & 0x0A) == 0x0A)) {
             if (dev->port_32cb_val & 0x80) {
-                svga->ma_latch -= 2;
+                svga->memaddr_latch -= 2;
                 svga->ca_adj = -2;
             }
             if ((dev->port_32cb_val & 0xB4) == ((svga->crtc[0x37] & 3) == 2 ? 0xB4 : 0xB0)) {
@@ -719,7 +719,7 @@ et4000_recalctimings(svga_t *svga)
     }
 
     if ((svga->seqregs[0x0e] & 0x02) && ((svga->gdcreg[5] & 0x60) >= 0x40) && svga->lowres) {
-        svga->ma_latch <<= 1;
+        svga->memaddr_latch <<= 1;
         svga->rowoffset <<= 1;
         svga->render = svga_render_8bpp_highres;
     }
@@ -734,7 +734,7 @@ et4000_kasan_recalctimings(svga_t *svga)
 
     if (svga->render == svga_render_text_80 && (et4000->kasan_cfg_regs[0] & 8)) {
         svga->hdisp             += svga->dots_per_clock;
-        svga->ma_latch          -= 4;
+        svga->memaddr_latch          -= 4;
         svga->ca_adj             = (et4000->kasan_cfg_regs[0] >> 6) - 3;
         svga->ksc5601_sbyte_mask = (et4000->kasan_cfg_regs[0] & 4) << 5;
         if ((et4000->kasan_cfg_regs[0] & 0x23) == 0x20 && (et4000->kasan_cfg_regs[4] & 0x80) && ((svga->crtc[0x37] & 0x0B) == 0x0A))

--- a/src/video/vid_et4000w32.c
+++ b/src/video/vid_et4000w32.c
@@ -238,7 +238,7 @@ et4000w32p_out(uint16_t addr, uint8_t val, void *priv)
                 if (svga->crtcreg < 0xe || svga->crtcreg > 0x10) {
                     if ((svga->crtcreg == 0xc) || (svga->crtcreg == 0xd)) {
                         svga->fullchange = 3;
-                        svga->ma_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
+                        svga->memaddr_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
                     } else {
                         svga->fullchange = changeframecount;
                         svga_recalctimings(svga);
@@ -430,7 +430,7 @@ et4000w32p_recalctimings(svga_t *svga)
 {
     et4000w32p_t *et4000 = (et4000w32p_t *) svga->priv;
 
-    svga->ma_latch |= (svga->crtc[0x33] & 0x7) << 16;
+    svga->memaddr_latch |= (svga->crtc[0x33] & 0x7) << 16;
 
     svga->hblankstart    = (((svga->crtc[0x3f] & 0x4) >> 2) << 8) + svga->crtc[2];
 

--- a/src/video/vid_f82c425.c
+++ b/src/video/vid_f82c425.c
@@ -361,26 +361,26 @@ f82c425_text_row(f82c425_t *f82c425)
     int      cursorline;
     int      blink;
     uint16_t addr;
-    uint8_t  sc;
-    uint16_t ma      = (f82c425->cga.crtc[CGA_CRTC_START_ADDR_LOW] | (f82c425->cga.crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
-    uint16_t ca      = (f82c425->cga.crtc[0x0f] | (f82c425->cga.crtc[0x0e] << 8)) & 0x3fff;
+    uint8_t  scanline;
+    uint16_t memaddr      = (f82c425->cga.crtc[CGA_CRTC_START_ADDR_LOW] | (f82c425->cga.crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
+    uint16_t cursoraddr      = (f82c425->cga.crtc[0x0f] | (f82c425->cga.crtc[0x0e] << 8)) & 0x3fff;
     uint8_t  sl      = f82c425->cga.crtc[CGA_CRTC_MAX_SCANLINE_ADDR] + 1;
     int      columns = f82c425->cga.crtc[CGA_CRTC_HDISP];
 
-    sc   = (f82c425->displine) & 7;
-    addr = ((ma & ~1) + (f82c425->displine >> 3) * columns) * 2;
-    ma += (f82c425->displine >> 3) * columns;
+    scanline   = (f82c425->displine) & 7;
+    addr = ((memaddr & ~1) + (f82c425->displine >> 3) * columns) * 2;
+    memaddr += (f82c425->displine >> 3) * columns;
 
     if ((f82c425->cga.crtc[CGA_CRTC_CURSOR_START] & 0x60) == 0x20) {
         cursorline = 0;
     } else {
-        cursorline = ((f82c425->cga.crtc[CGA_CRTC_CURSOR_START] & 0x0F) <= sc) && ((f82c425->cga.crtc[CGA_CRTC_CURSOR_END] & 0x0F) >= sc);
+        cursorline = ((f82c425->cga.crtc[CGA_CRTC_CURSOR_START] & 0x0F) <= scanline) && ((f82c425->cga.crtc[CGA_CRTC_CURSOR_END] & 0x0F) >= scanline);
     }
 
     for (int x = 0; x < columns; x++) {
         chr        = f82c425->vram[(addr + 2 * x) & 0x3FFF];
         attr       = f82c425->vram[(addr + 2 * x + 1) & 0x3FFF];
-        drawcursor = ((ma == ca) && cursorline && (f82c425->cga.cgamode & CGA_MODE_FLAG_VIDEO_ENABLE) && (f82c425->cga.cgablink & 0x10));
+        drawcursor = ((memaddr == cursoraddr) && cursorline && (f82c425->cga.cgamode & CGA_MODE_FLAG_VIDEO_ENABLE) && (f82c425->cga.cgablink & 0x10));
 
         blink = ((f82c425->cga.cgablink & 0x10) && (f82c425->cga.cgamode & CGA_MODE_FLAG_BLINK) && (attr & 0x80) && !drawcursor);
 
@@ -398,16 +398,16 @@ f82c425_text_row(f82c425_t *f82c425)
         if (f82c425->cga.cgamode & 0x01) {
             /* High resolution (80 cols) */
             for (c = 0; c < sl; c++) {
-                (buffer32->line[f82c425->displine])[(x << 3) + c] = colors[(fontdat[chr][sc] & (1 << (c ^ 7))) ? 1 : 0];
+                (buffer32->line[f82c425->displine])[(x << 3) + c] = colors[(fontdat[chr][scanline] & (1 << (c ^ 7))) ? 1 : 0];
             }
         } else {
             /* Low resolution (40 columns, stretch pixels horizontally) */
             for (c = 0; c < sl; c++) {
-                (buffer32->line[f82c425->displine])[(x << 4) + c * 2] = (buffer32->line[f82c425->displine])[(x << 4) + c * 2 + 1] = colors[(fontdat[chr][sc] & (1 << (c ^ 7))) ? 1 : 0];
+                (buffer32->line[f82c425->displine])[(x << 4) + c * 2] = (buffer32->line[f82c425->displine])[(x << 4) + c * 2 + 1] = colors[(fontdat[chr][scanline] & (1 << (c ^ 7))) ? 1 : 0];
             }
         }
 
-        ++ma;
+        ++memaddr;
     }
 }
 
@@ -418,9 +418,9 @@ f82c425_cgaline6(f82c425_t *f82c425)
     uint8_t  dat;
     uint16_t addr;
 
-    uint16_t ma = (f82c425->cga.crtc[CGA_CRTC_START_ADDR_LOW] | (f82c425->cga.crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
+    uint16_t memaddr = (f82c425->cga.crtc[CGA_CRTC_START_ADDR_LOW] | (f82c425->cga.crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
 
-    addr = ((f82c425->displine) & 1) * 0x2000 + (f82c425->displine >> 1) * 80 + ((ma & ~1) << 1);
+    addr = ((f82c425->displine) & 1) * 0x2000 + (f82c425->displine >> 1) * 80 + ((memaddr & ~1) << 1);
 
     for (uint8_t x  = 0; x < 80; x++) {
         dat = f82c425->vram[addr & 0x3FFF];
@@ -442,8 +442,8 @@ f82c425_cgaline4(f82c425_t *f82c425)
     uint8_t  pattern;
     uint16_t addr;
 
-    uint16_t ma = (f82c425->cga.crtc[CGA_CRTC_START_ADDR_LOW] | (f82c425->cga.crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
-    addr        = ((f82c425->displine) & 1) * 0x2000 + (f82c425->displine >> 1) * 80 + ((ma & ~1) << 1);
+    uint16_t memaddr = (f82c425->cga.crtc[CGA_CRTC_START_ADDR_LOW] | (f82c425->cga.crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x3fff;
+    addr        = ((f82c425->displine) & 1) * 0x2000 + (f82c425->displine >> 1) * 80 + ((memaddr & ~1) << 1);
 
     for (uint8_t x = 0; x < 80; x++) {
         dat = f82c425->vram[addr & 0x3FFF];

--- a/src/video/vid_hercules.c
+++ b/src/video/vid_hercules.c
@@ -168,9 +168,9 @@ hercules_in(uint16_t addr, void *priv)
         case 0x03b5:
         case 0x03b7:
             if (dev->crtcreg == 0x0c)
-                ret = (dev->ma >> 8) & 0x3f;
+                ret = (dev->memaddr >> 8) & 0x3f;
             else if (dev->crtcreg == 0x0d)
-                ret = dev->ma & 0xff;
+                ret = dev->memaddr & 0xff;
             else
                 ret = dev->crtc[dev->crtcreg];
             break;
@@ -281,10 +281,10 @@ hercules_poll(void *priv)
     hercules_t *dev = (hercules_t *) priv;
     uint8_t     chr;
     uint8_t     attr;
-    uint16_t    ca;
+    uint16_t    cursoraddr;
     uint16_t    dat;
     uint16_t    pa;
-    int         oldsc;
+    int         scanline_old;
     int         blink;
     int         x;
     int         xx;
@@ -296,16 +296,16 @@ hercules_poll(void *priv)
     uint32_t   *p;
 
     VIDEO_MONITOR_PROLOGUE()
-    ca = (dev->crtc[15] | (dev->crtc[14] << 8)) & 0x3fff;
+    cursoraddr = (dev->crtc[15] | (dev->crtc[14] << 8)) & 0x3fff;
 
     if (!dev->linepos) {
         timer_advance_u64(&dev->timer, dev->dispofftime);
         dev->stat |= 1;
         dev->linepos = 1;
-        oldsc        = dev->sc;
+        scanline_old        = dev->scanline;
 
         if ((dev->crtc[8] & 3) == 3)
-            dev->sc = (dev->sc << 1) & 7;
+            dev->scanline = (dev->scanline << 1) & 7;
 
         if (dev->dispon) {
             if (dev->displine < dev->firstline) {
@@ -317,16 +317,16 @@ hercules_poll(void *priv)
             hercules_render_overscan_left(dev);
 
             if (dev->ctrl & 0x02) {
-                ca = (dev->sc & 3) * 0x2000;
+                cursoraddr = (dev->scanline & 3) * 0x2000;
                 if (dev->ctrl & 0x80)
-                    ca += 0x8000;
+                    cursoraddr += 0x8000;
 
                 for (x = 0; x < dev->crtc[1]; x++) {
                     if (dev->ctrl & 8)
-                        dat = (dev->vram[((dev->ma << 1) & 0x1fff) + ca] << 8) | dev->vram[((dev->ma << 1) & 0x1fff) + ca + 1];
+                        dat = (dev->vram[((dev->memaddr << 1) & 0x1fff) + cursoraddr] << 8) | dev->vram[((dev->memaddr << 1) & 0x1fff) + cursoraddr + 1];
                     else
                         dat = 0;
-                    dev->ma++;
+                    dev->memaddr++;
                     for (c = 0; c < 16; c++)
                         buffer32->line[dev->displine + 14][(x << 4) + c + 8] = (dat & (32768 >> c)) ? 7 : 0;
                     for (c = 0; c < 16; c += 8)
@@ -341,25 +341,25 @@ hercules_poll(void *priv)
                         attr = dev->charbuffer[(x << 1) + 1];
                     } else
                         chr = attr = 0;
-                    drawcursor = ((dev->ma == ca) && dev->cursorvisible && dev->cursoron);
+                    drawcursor = ((dev->memaddr == cursoraddr) && dev->cursorvisible && dev->cursoron);
                     blink      = ((dev->blink & 16) && (dev->ctrl & 0x20) && (attr & 0x80) && !drawcursor);
 
-                    if (dev->sc == 12 && ((attr & 7) == 1)) {
+                    if (dev->scanline == 12 && ((attr & 7) == 1)) {
                         for (c = 0; c < 9; c++)
                             buffer32->line[dev->displine + 14][(x * 9) + c + 8] = dev->cols[attr][blink][1];
                     } else {
                         for (c = 0; c < 8; c++)
-                            buffer32->line[dev->displine + 14][(x * 9) + c + 8] = dev->cols[attr][blink][(fontdatm[chr][dev->sc] & (1 << (c ^ 7))) ? 1 : 0];
+                            buffer32->line[dev->displine + 14][(x * 9) + c + 8] = dev->cols[attr][blink][(fontdatm[chr][dev->scanline] & (1 << (c ^ 7))) ? 1 : 0];
 
                         if ((chr & ~0x1f) == 0xc0)
-                            buffer32->line[dev->displine + 14][(x * 9) + 8 + 8] = dev->cols[attr][blink][fontdatm[chr][dev->sc] & 1];
+                            buffer32->line[dev->displine + 14][(x * 9) + 8 + 8] = dev->cols[attr][blink][fontdatm[chr][dev->scanline] & 1];
                         else
                             buffer32->line[dev->displine + 14][(x * 9) + 8 + 8] = dev->cols[attr][blink][0];
                     }
                     if (dev->ctrl2 & 0x01)
-                        dev->ma = (dev->ma + 1) & 0x3fff;
+                        dev->memaddr = (dev->memaddr + 1) & 0x3fff;
                     else
-                        dev->ma = (dev->ma + 1) & 0x7ff;
+                        dev->memaddr = (dev->memaddr + 1) & 0x7ff;
 
                     if (drawcursor) {
                         for (c = 0; c < 9; c++)
@@ -377,9 +377,9 @@ hercules_poll(void *priv)
 
             video_process_8(x + 16, dev->displine + 14);
         }
-        dev->sc = oldsc;
+        dev->scanline = scanline_old;
 
-        if (dev->vc == dev->crtc[7] && !dev->sc)
+        if (dev->vc == dev->crtc[7] && !dev->scanline)
             dev->stat |= 8;
         dev->displine++;
         if (dev->displine >= 500)
@@ -397,23 +397,23 @@ hercules_poll(void *priv)
                 dev->stat &= ~8;
         }
 
-        if (dev->sc == (dev->crtc[11] & 31) || ((dev->crtc[8] & 3) == 3 && dev->sc == ((dev->crtc[11] & 31) >> 1))) {
+        if (dev->scanline == (dev->crtc[11] & 31) || ((dev->crtc[8] & 3) == 3 && dev->scanline == ((dev->crtc[11] & 31) >> 1))) {
             dev->cursorvisible  = 0;
         }
 
         if (dev->vadj) {
-            dev->sc++;
-            dev->sc &= 31;
-            dev->ma = dev->maback;
+            dev->scanline++;
+            dev->scanline &= 31;
+            dev->memaddr = dev->memaddr_backup;
             dev->vadj--;
             if (!dev->vadj) {
                 dev->dispon = 1;
-                dev->ma = dev->maback = (dev->crtc[13] | (dev->crtc[12] << 8)) & 0x3fff;
-                dev->sc               = 0;
+                dev->memaddr = dev->memaddr_backup = (dev->crtc[13] | (dev->crtc[12] << 8)) & 0x3fff;
+                dev->scanline               = 0;
             }
-        } else if (((dev->crtc[8] & 3) != 3 && dev->sc == dev->crtc[9]) || ((dev->crtc[8] & 3) == 3 && dev->sc == (dev->crtc[9] >> 1))) {
-            dev->maback = dev->ma;
-            dev->sc     = 0;
+        } else if (((dev->crtc[8] & 3) != 3 && dev->scanline == dev->crtc[9]) || ((dev->crtc[8] & 3) == 3 && dev->scanline == (dev->crtc[9] >> 1))) {
+            dev->memaddr_backup = dev->memaddr;
+            dev->scanline     = 0;
             oldvc       = dev->vc;
             dev->vc++;
             dev->vc &= 127;
@@ -426,7 +426,7 @@ hercules_poll(void *priv)
                 dev->vadj = dev->crtc[5];
                 if (!dev->vadj) {
                     dev->dispon = 1;
-                    dev->ma = dev->maback = (dev->crtc[13] | (dev->crtc[12] << 8)) & 0x3fff;
+                    dev->memaddr = dev->memaddr_backup = (dev->crtc[13] | (dev->crtc[12] << 8)) & 0x3fff;
                 }
                 switch (dev->crtc[10] & 0x60) {
                     case 0x20:
@@ -511,17 +511,17 @@ hercules_poll(void *priv)
                 dev->blink++;
             }
         } else {
-            dev->sc++;
-            dev->sc &= 31;
-            dev->ma = dev->maback;
+            dev->scanline++;
+            dev->scanline &= 31;
+            dev->memaddr = dev->memaddr_backup;
         }
 
-        if (dev->sc == (dev->crtc[10] & 31) || ((dev->crtc[8] & 3) == 3 && dev->sc == ((dev->crtc[10] & 31) >> 1)))
+        if (dev->scanline == (dev->crtc[10] & 31) || ((dev->crtc[8] & 3) == 3 && dev->scanline == ((dev->crtc[10] & 31) >> 1)))
             dev->cursorvisible = 1;
         if (dev->dispon && !(dev->ctrl & 0x02)) {
             for (x = 0; x < (dev->crtc[1] << 1); x++) {
                 pa                 = (dev->ctrl & 0x80) ? ((x & 1) ? 0x0000 : 0x8000) : 0x0000;
-                dev->charbuffer[x] = dev->vram[(((dev->ma << 1) + x) & 0x3fff) + pa];
+                dev->charbuffer[x] = dev->vram[(((dev->memaddr << 1) + x) & 0x3fff) + pa];
             }
         }
     }

--- a/src/video/vid_hercules_incolor.c
+++ b/src/video/vid_hercules_incolor.c
@@ -165,8 +165,8 @@ typedef struct {
     int firstline, lastline;
 
     int      linepos, displine;
-    int      vc, sc;
-    uint16_t ma, maback;
+    int      vc, scanline;
+    uint16_t memaddr, memaddr_backup;
     int      cursorvisible, cursoron;
     int      dispon, blink;
     int      vsynctime;
@@ -483,11 +483,11 @@ draw_char_rom(incolor_t *dev, int x, uint8_t chr, uint8_t attr)
         elg = ((chr >= 0xc0) && (chr <= 0xdf));
     }
 
-    fnt = &(fontdatm[chr][dev->sc]);
+    fnt = &(fontdatm[chr][dev->scanline]);
 
     if (blk) {
         val = 0x000; /* Blinking, draw all background */
-    } else if (dev->sc == ull) {
+    } else if (dev->scanline == ull) {
         val = 0x1ff; /* Underscore, draw all foreground */
     } else {
         val = fnt[0] << 1;
@@ -559,12 +559,12 @@ draw_char_ram4(incolor_t *dev, int x, uint8_t chr, uint8_t attr)
     } else {
         elg = ((chr >= 0xc0) && (chr <= 0xdf));
     }
-    fnt = dev->vram + 0x4000 + 16 * chr + dev->sc;
+    fnt = dev->vram + 0x4000 + 16 * chr + dev->scanline;
 
     if (blk) {
         /* Blinking, draw all background */
         val[0] = val[1] = val[2] = val[3] = 0x000;
-    } else if (dev->sc == ull) {
+    } else if (dev->scanline == ull) {
         /* Underscore, draw all foreground */
         val[0] = val[1] = val[2] = val[3] = 0x1ff;
     } else {
@@ -685,12 +685,12 @@ draw_char_ram48(incolor_t *dev, int x, uint8_t chr, uint8_t attr)
     } else {
         elg = ((chr >= 0xc0) && (chr <= 0xdf));
     }
-    fnt = dev->vram + 0x4000 + 16 * chr + 4096 * font + dev->sc;
+    fnt = dev->vram + 0x4000 + 16 * chr + 4096 * font + dev->scanline;
 
     if (blk) {
         /* Blinking, draw all background */
         val[0] = val[1] = val[2] = val[3] = 0x000;
-    } else if (dev->sc == ull) {
+    } else if (dev->scanline == ull) {
         /* Underscore, draw all foreground */
         val[0] = val[1] = val[2] = val[3] = 0x1ff;
     } else {
@@ -716,9 +716,9 @@ draw_char_ram48(incolor_t *dev, int x, uint8_t chr, uint8_t attr)
         /* Generate pixel colour */
         cfg   = 0;
         pmask = 1;
-        if (dev->sc == oll) {
+        if (dev->scanline == oll) {
             cfg = olc ^ ibg; /* Strikethrough */
-        } else if (dev->sc == ull) {
+        } else if (dev->scanline == ull) {
             cfg = ulc ^ ibg; /* Underline */
         } else {
             for (uint8_t plane = 0; plane < 4; plane++, pmask = pmask << 1) {
@@ -746,7 +746,7 @@ draw_char_ram48(incolor_t *dev, int x, uint8_t chr, uint8_t attr)
 }
 
 static void
-text_line(incolor_t *dev, uint16_t ca)
+text_line(incolor_t *dev, uint16_t cursoraddr)
 {
     int      drawcursor;
     uint8_t  chr;
@@ -755,12 +755,12 @@ text_line(incolor_t *dev, uint16_t ca)
 
     for (uint8_t x = 0; x < dev->crtc[1]; x++) {
         if (dev->ctrl & 8) {
-            chr  = dev->vram[(dev->ma << 1) & 0x3fff];
-            attr = dev->vram[((dev->ma << 1) + 1) & 0x3fff];
+            chr  = dev->vram[(dev->memaddr << 1) & 0x3fff];
+            attr = dev->vram[((dev->memaddr << 1) + 1) & 0x3fff];
         } else
             chr = attr = 0;
 
-        drawcursor = ((dev->ma == ca) && dev->cursorvisible && dev->cursoron);
+        drawcursor = ((dev->memaddr == cursoraddr) && dev->cursorvisible && dev->cursoron);
 
         switch (dev->crtc[INCOLOR_CRTC_XMODE] & 5) {
             case 0:
@@ -779,7 +779,7 @@ text_line(incolor_t *dev, uint16_t ca)
             default:
                 break;
         }
-        ++dev->ma;
+        ++dev->memaddr;
 
         if (drawcursor) {
             int     cw  = INCOLOR_CW;
@@ -808,29 +808,29 @@ static void
 graphics_line(incolor_t *dev)
 {
     uint8_t  mask;
-    uint16_t ca;
+    uint16_t cursoraddr;
     int      plane;
     int      col;
     uint8_t  ink;
     uint16_t val[4];
 
     /* Graphics mode. */
-    ca = (dev->sc & 3) * 0x2000;
+    cursoraddr = (dev->scanline & 3) * 0x2000;
     if ((dev->ctrl & INCOLOR_CTRL_PAGE1) && (dev->ctrl2 & INCOLOR_CTRL2_PAGE1))
-        ca += 0x8000;
+        cursoraddr += 0x8000;
 
     for (uint8_t x = 0; x < dev->crtc[1]; x++) {
         mask = dev->crtc[INCOLOR_CRTC_MASK]; /* Planes to display */
         for (plane = 0; plane < 4; plane++, mask = mask >> 1) {
             if (dev->ctrl & 8) {
                 if (mask & 1)
-                    val[plane] = (dev->vram[((dev->ma << 1) & 0x1fff) + ca + 0x10000 * plane] << 8) | dev->vram[((dev->ma << 1) & 0x1fff) + ca + 0x10000 * plane + 1];
+                    val[plane] = (dev->vram[((dev->memaddr << 1) & 0x1fff) + cursoraddr + 0x10000 * plane] << 8) | dev->vram[((dev->memaddr << 1) & 0x1fff) + cursoraddr + 0x10000 * plane + 1];
                 else
                     val[plane] = 0;
             } else
                 val[plane] = 0;
         }
-        dev->ma++;
+        dev->memaddr++;
 
         for (uint8_t c = 0; c < 16; c++) {
             ink = 0;
@@ -855,19 +855,19 @@ static void
 incolor_poll(void *priv)
 {
     incolor_t *dev = (incolor_t *) priv;
-    uint16_t   ca  = (dev->crtc[15] | (dev->crtc[14] << 8)) & 0x3fff;
+    uint16_t   cursoraddr  = (dev->crtc[15] | (dev->crtc[14] << 8)) & 0x3fff;
     int        x;
     int        oldvc;
-    int        oldsc;
+    int        scanline_old;
     int        cw      = INCOLOR_CW;
 
     if (!dev->linepos) {
         timer_advance_u64(&dev->timer, dev->dispofftime);
         dev->stat |= 1;
         dev->linepos = 1;
-        oldsc        = dev->sc;
+        scanline_old        = dev->scanline;
         if ((dev->crtc[8] & 3) == 3)
-            dev->sc = (dev->sc << 1) & 7;
+            dev->scanline = (dev->scanline << 1) & 7;
 
         if (dev->dispon) {
             if (dev->displine < dev->firstline) {
@@ -878,10 +878,10 @@ incolor_poll(void *priv)
             if ((dev->ctrl & INCOLOR_CTRL_GRAPH) && (dev->ctrl2 & INCOLOR_CTRL2_GRAPH))
                 graphics_line(dev);
             else
-                text_line(dev, ca);
+                text_line(dev, cursoraddr);
         }
-        dev->sc = oldsc;
-        if (dev->vc == dev->crtc[7] && !dev->sc)
+        dev->scanline = scanline_old;
+        if (dev->vc == dev->crtc[7] && !dev->scanline)
             dev->stat |= 8;
         dev->displine++;
         if (dev->displine >= 500)
@@ -897,24 +897,24 @@ incolor_poll(void *priv)
                 dev->stat &= ~8;
         }
 
-        if (dev->sc == (dev->crtc[11] & 31) || ((dev->crtc[8] & 3) == 3 && dev->sc == ((dev->crtc[11] & 31) >> 1))) {
+        if (dev->scanline == (dev->crtc[11] & 31) || ((dev->crtc[8] & 3) == 3 && dev->scanline == ((dev->crtc[11] & 31) >> 1))) {
             dev->cursorvisible  = 0;
         }
 
         if (dev->vadj) {
-            dev->sc++;
-            dev->sc &= 31;
-            dev->ma = dev->maback;
+            dev->scanline++;
+            dev->scanline &= 31;
+            dev->memaddr = dev->memaddr_backup;
             dev->vadj--;
             if (!dev->vadj) {
                 dev->dispon = 1;
-                dev->ma = dev->maback = (dev->crtc[13] | (dev->crtc[12] << 8)) & 0x3fff;
-                dev->sc               = 0;
+                dev->memaddr = dev->memaddr_backup = (dev->crtc[13] | (dev->crtc[12] << 8)) & 0x3fff;
+                dev->scanline = 0;
             }
-        } else if (dev->sc == dev->crtc[9] || ((dev->crtc[8] & 3) == 3 && dev->sc == (dev->crtc[9] >> 1))) {
-            dev->maback = dev->ma;
-            dev->sc     = 0;
-            oldvc       = dev->vc;
+        } else if (dev->scanline == dev->crtc[9] || ((dev->crtc[8] & 3) == 3 && dev->scanline == (dev->crtc[9] >> 1))) {
+            dev->memaddr_backup = dev->memaddr;
+            dev->scanline = 0;
+            oldvc = dev->vc;
             dev->vc++;
             dev->vc &= 127;
             if (dev->vc == dev->crtc[6])
@@ -925,7 +925,7 @@ incolor_poll(void *priv)
                 if (!dev->vadj)
                     dev->dispon = 1;
                 if (!dev->vadj)
-                    dev->ma = dev->maback = (dev->crtc[13] | (dev->crtc[12] << 8)) & 0x3fff;
+                    dev->memaddr = dev->memaddr_backup = (dev->crtc[13] | (dev->crtc[12] << 8)) & 0x3fff;
                 if ((dev->crtc[10] & 0x60) == 0x20)
                     dev->cursoron = 0;
                 else
@@ -971,12 +971,12 @@ incolor_poll(void *priv)
                 dev->blink++;
             }
         } else {
-            dev->sc++;
-            dev->sc &= 31;
-            dev->ma = dev->maback;
+            dev->scanline++;
+            dev->scanline &= 31;
+            dev->memaddr = dev->memaddr_backup;
         }
 
-        if (dev->sc == (dev->crtc[10] & 31) || ((dev->crtc[8] & 3) == 3 && dev->sc == ((dev->crtc[10] & 31) >> 1)))
+        if (dev->scanline == (dev->crtc[10] & 31) || ((dev->crtc[8] & 3) == 3 && dev->scanline == ((dev->crtc[10] & 31) >> 1)))
             dev->cursorvisible = 1;
     }
 }

--- a/src/video/vid_hercules_plus.c
+++ b/src/video/vid_hercules_plus.c
@@ -75,8 +75,8 @@ typedef struct {
     int firstline, lastline;
 
     int      linepos, displine;
-    int      vc, sc;
-    uint16_t ma, maback;
+    int      vc, scanline;
+    uint16_t memaddr, memaddr_backup;
     int      cursorvisible, cursoron;
     int      dispon, blink;
     int      vsynctime;
@@ -260,11 +260,11 @@ draw_char_rom(herculesplus_t *dev, int x, uint8_t chr, uint8_t attr)
     else
         elg = ((chr >= 0xc0) && (chr <= 0xdf));
 
-    fnt = &(fontdatm[chr][dev->sc]);
+    fnt = &(fontdatm[chr][dev->scanline]);
 
     if (blk) {
         val = 0x000; /* Blinking, draw all background */
-    } else if (dev->sc == ull) {
+    } else if (dev->scanline == ull) {
         val = 0x1ff; /* Underscore, draw all foreground */
     } else {
         val = fnt[0] << 1;
@@ -319,11 +319,11 @@ draw_char_ram4(herculesplus_t *dev, int x, uint8_t chr, uint8_t attr)
     else
         elg = ((chr >= 0xc0) && (chr <= 0xdf));
 
-    fnt = dev->vram + 0x4000 + 16 * chr + dev->sc;
+    fnt = dev->vram + 0x4000 + 16 * chr + dev->scanline;
 
     if (blk) {
         val = 0x000; /* Blinking, draw all background */
-    } else if (dev->sc == ull) {
+    } else if (dev->scanline == ull) {
         val = 0x1ff; /* Underscore, draw all foreground */
     } else {
         val = fnt[0] << 1;
@@ -384,11 +384,11 @@ draw_char_ram48(herculesplus_t *dev, int x, uint8_t chr, uint8_t attr)
     else
         elg = ((chr >= 0xc0) && (chr <= 0xdf));
 
-    fnt = dev->vram + 0x4000 + 16 * chr + 4096 * font + dev->sc;
+    fnt = dev->vram + 0x4000 + 16 * chr + 4096 * font + dev->scanline;
 
     if (blk) {
         val = 0x000; /* Blinking, draw all background */
-    } else if (dev->sc == ull) {
+    } else if (dev->scanline == ull) {
         val = 0x1ff; /* Underscore, draw all foreground */
     } else {
         val = fnt[0] << 1;
@@ -404,7 +404,7 @@ draw_char_ram48(herculesplus_t *dev, int x, uint8_t chr, uint8_t attr)
 }
 
 static void
-text_line(herculesplus_t *dev, uint16_t ca)
+text_line(herculesplus_t *dev, uint16_t cursoraddr)
 {
     int      drawcursor;
     uint8_t  chr;
@@ -413,12 +413,12 @@ text_line(herculesplus_t *dev, uint16_t ca)
 
     for (uint8_t x = 0; x < dev->crtc[1]; x++) {
         if (dev->ctrl & 8) {
-            chr  = dev->vram[(dev->ma << 1) & 0x3fff];
-            attr = dev->vram[((dev->ma << 1) + 1) & 0x3fff];
+            chr  = dev->vram[(dev->memaddr << 1) & 0x3fff];
+            attr = dev->vram[((dev->memaddr << 1) + 1) & 0x3fff];
         } else
             chr = attr = 0;
 
-        drawcursor = ((dev->ma == ca) && dev->cursorvisible && dev->cursoron);
+        drawcursor = ((dev->memaddr == cursoraddr) && dev->cursorvisible && dev->cursoron);
 
         switch (dev->crtc[HERCULESPLUS_CRTC_XMODE] & 5) {
             case 0:
@@ -437,7 +437,7 @@ text_line(herculesplus_t *dev, uint16_t ca)
             default:
                 break;
         }
-        ++dev->ma;
+        ++dev->memaddr;
 
         if (drawcursor) {
             int cw = HERCULESPLUS_CW;
@@ -452,24 +452,24 @@ text_line(herculesplus_t *dev, uint16_t ca)
 static void
 graphics_line(herculesplus_t *dev)
 {
-    uint16_t ca;
+    uint16_t cursoraddr;
     int      c;
     int      plane = 0;
     uint16_t val;
 
     /* Graphics mode. */
-    ca = (dev->sc & 3) * 0x2000;
+    cursoraddr = (dev->scanline & 3) * 0x2000;
     if ((dev->ctrl & HERCULESPLUS_CTRL_PAGE1) && (dev->ctrl2 & HERCULESPLUS_CTRL2_PAGE1))
-        ca += 0x8000;
+        cursoraddr += 0x8000;
 
     for (uint8_t x = 0; x < dev->crtc[1]; x++) {
         if (dev->ctrl & 8)
-            val = (dev->vram[((dev->ma << 1) & 0x1fff) + ca + 0x10000 * plane] << 8)
-                | dev->vram[((dev->ma << 1) & 0x1fff) + ca + 0x10000 * plane + 1];
+            val = (dev->vram[((dev->memaddr << 1) & 0x1fff) + cursoraddr + 0x10000 * plane] << 8)
+                | dev->vram[((dev->memaddr << 1) & 0x1fff) + cursoraddr + 0x10000 * plane + 1];
         else
             val = 0;
 
-        dev->ma++;
+        dev->memaddr++;
         for (c = 0; c < 16; c++) {
             buffer32->line[dev->displine][(x << 4) + c] = (val & 0x8000) ? 7 : 0;
 
@@ -485,10 +485,10 @@ static void
 herculesplus_poll(void *priv)
 {
     herculesplus_t *dev = (herculesplus_t *) priv;
-    uint16_t        ca  = (dev->crtc[15] | (dev->crtc[14] << 8)) & 0x3fff;
+    uint16_t        cursoraddr  = (dev->crtc[15] | (dev->crtc[14] << 8)) & 0x3fff;
     int             x;
     int             oldvc;
-    int             oldsc;
+    int             scanline_old;
     int             cw = HERCULESPLUS_CW;
 
     VIDEO_MONITOR_PROLOGUE();
@@ -496,9 +496,9 @@ herculesplus_poll(void *priv)
         timer_advance_u64(&dev->timer, dev->dispofftime);
         dev->stat |= 1;
         dev->linepos = 1;
-        oldsc        = dev->sc;
+        scanline_old        = dev->scanline;
         if ((dev->crtc[8] & 3) == 3)
-            dev->sc = (dev->sc << 1) & 7;
+            dev->scanline = (dev->scanline << 1) & 7;
         if (dev->dispon) {
             if (dev->displine < dev->firstline) {
                 dev->firstline = dev->displine;
@@ -508,7 +508,7 @@ herculesplus_poll(void *priv)
             if ((dev->ctrl & HERCULESPLUS_CTRL_GRAPH) && (dev->ctrl2 & HERCULESPLUS_CTRL2_GRAPH))
                 graphics_line(dev);
             else
-                text_line(dev, ca);
+                text_line(dev, cursoraddr);
 
             if ((dev->ctrl & HERCULESPLUS_CTRL_GRAPH) && (dev->ctrl2 & HERCULESPLUS_CTRL2_GRAPH))
                 x = dev->crtc[1] << 4;
@@ -517,8 +517,8 @@ herculesplus_poll(void *priv)
 
             video_process_8(x, dev->displine);
         }
-        dev->sc = oldsc;
-        if (dev->vc == dev->crtc[7] && !dev->sc)
+        dev->scanline = scanline_old;
+        if (dev->vc == dev->crtc[7] && !dev->scanline)
             dev->stat |= 8;
         dev->displine++;
         if (dev->displine >= 500)
@@ -534,22 +534,22 @@ herculesplus_poll(void *priv)
                 dev->stat &= ~8;
         }
 
-        if (dev->sc == (dev->crtc[11] & 31) || ((dev->crtc[8] & 3) == 3 && dev->sc == ((dev->crtc[11] & 31) >> 1))) {
+        if (dev->scanline == (dev->crtc[11] & 31) || ((dev->crtc[8] & 3) == 3 && dev->scanline == ((dev->crtc[11] & 31) >> 1))) {
             dev->cursorvisible  = 0;
         }
         if (dev->vadj) {
-            dev->sc++;
-            dev->sc &= 31;
-            dev->ma = dev->maback;
+            dev->scanline++;
+            dev->scanline &= 31;
+            dev->memaddr = dev->memaddr_backup;
             dev->vadj--;
             if (!dev->vadj) {
                 dev->dispon = 1;
-                dev->ma = dev->maback = (dev->crtc[13] | (dev->crtc[12] << 8)) & 0x3fff;
-                dev->sc               = 0;
+                dev->memaddr = dev->memaddr_backup = (dev->crtc[13] | (dev->crtc[12] << 8)) & 0x3fff;
+                dev->scanline               = 0;
             }
-        } else if (dev->sc == dev->crtc[9] || ((dev->crtc[8] & 3) == 3 && dev->sc == (dev->crtc[9] >> 1))) {
-            dev->maback = dev->ma;
-            dev->sc     = 0;
+        } else if (dev->scanline == dev->crtc[9] || ((dev->crtc[8] & 3) == 3 && dev->scanline == (dev->crtc[9] >> 1))) {
+            dev->memaddr_backup = dev->memaddr;
+            dev->scanline     = 0;
             oldvc       = dev->vc;
             dev->vc++;
             dev->vc &= 127;
@@ -561,7 +561,7 @@ herculesplus_poll(void *priv)
                 if (!dev->vadj)
                     dev->dispon = 1;
                 if (!dev->vadj)
-                    dev->ma = dev->maback = (dev->crtc[13] | (dev->crtc[12] << 8)) & 0x3fff;
+                    dev->memaddr = dev->memaddr_backup = (dev->crtc[13] | (dev->crtc[12] << 8)) & 0x3fff;
                 if ((dev->crtc[10] & 0x60) == 0x20)
                     dev->cursoron = 0;
                 else
@@ -606,12 +606,12 @@ herculesplus_poll(void *priv)
                 dev->blink++;
             }
         } else {
-            dev->sc++;
-            dev->sc &= 31;
-            dev->ma = dev->maback;
+            dev->scanline++;
+            dev->scanline &= 31;
+            dev->memaddr = dev->memaddr_backup;
         }
 
-        if (dev->sc == (dev->crtc[10] & 31) || ((dev->crtc[8] & 3) == 3 && dev->sc == ((dev->crtc[10] & 31) >> 1)))
+        if (dev->scanline == (dev->crtc[10] & 31) || ((dev->crtc[8] & 3) == 3 && dev->scanline == ((dev->crtc[10] & 31) >> 1)))
             dev->cursorvisible = 1;
     }
 

--- a/src/video/vid_ht216.c
+++ b/src/video/vid_ht216.c
@@ -448,7 +448,7 @@ ht216_out(uint16_t addr, uint8_t val, void *priv)
                 if (svga->crtcreg < 0xe || svga->crtcreg > 0x10) {
                     if ((svga->crtcreg == 0xc) || (svga->crtcreg == 0xd)) {
                         svga->fullchange = 3;
-                        svga->ma_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
+                        svga->memaddr_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
                     } else {
                         svga->fullchange = changeframecount;
                         svga_recalctimings(svga);
@@ -660,10 +660,10 @@ ht216_recalctimings(svga_t *svga)
             break;
     }
 
-    svga->ma_latch |= ((ht216->ht_regs[0xf6] & 0x30) << 12);
+    svga->memaddr_latch |= ((ht216->ht_regs[0xf6] & 0x30) << 12);
 
     if (ht216->ht_regs[0xf6] & 0x80)
-        svga->ma_latch = ((ht216->ht_regs[0xf6] & 0x30) << 12);
+        svga->memaddr_latch = ((ht216->ht_regs[0xf6] & 0x30) << 12);
 
     svga->interlace = ht216->ht_regs[0xe0] & 0x01;
 

--- a/src/video/vid_ibm_rgb528_ramdac.c
+++ b/src/video/vid_ibm_rgb528_ramdac.c
@@ -104,7 +104,7 @@ ibm_rgb528_render_4bpp(svga_t *svga)
     if ((svga->displine + svga->y_add) < 0)
         return;
 
-    if (svga->changedvram[svga->ma >> 12] || svga->changedvram[(svga->ma >> 12) + 1] || svga->changedvram[(svga->ma >> 12) + 2] || svga->fullchange) {
+    if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->changedvram[(svga->memaddr >> 12) + 2] || svga->fullchange) {
         p = &buffer32->line[svga->displine + svga->y_add][svga->x_add];
 
         if (svga->firstline_draw == 2000)
@@ -114,8 +114,8 @@ ibm_rgb528_render_4bpp(svga_t *svga)
         for (int x = 0; x <= (svga->hdisp + svga->scrollcache); x++) {
             if (vram_size == 3) {
                 if (!(x & 31)) {
-                    dat64  = *(uint64_t *) (&svga->vram[svga->ma]);
-                    dat642 = *(uint64_t *) (&svga->vram[svga->ma + 8]);
+                    dat64  = *(uint64_t *) (&svga->vram[svga->memaddr]);
+                    dat642 = *(uint64_t *) (&svga->vram[svga->memaddr + 8]);
                     if (swap_word) {
                         dat64  = (dat64 << 32ULL) | (dat64 >> 32ULL);
                         dat642 = (dat642 << 32ULL) | (dat642 >> 32ULL);
@@ -127,7 +127,7 @@ ibm_rgb528_render_4bpp(svga_t *svga)
                     dat = (((x & 16) ? dat642 : dat64) >> (((x & 15) << 2) ^ 4)) & 0xf;
             } else if (vram_size == 1) {
                 if (!(x & 15)) {
-                    dat64 = *(uint64_t *) (&svga->vram[svga->ma]);
+                    dat64 = *(uint64_t *) (&svga->vram[svga->memaddr]);
                     if (swap_word)
                         dat64 = (dat64 << 32ULL) | (dat64 >> 32ULL);
                 }
@@ -137,7 +137,7 @@ ibm_rgb528_render_4bpp(svga_t *svga)
                     dat = (dat64 >> (((x & 15) << 2) ^ 4)) & 0xf;
             } else {
                 if (!(x & 7))
-                    dat32 = *(uint32_t *) (&svga->vram[svga->ma]);
+                    dat32 = *(uint32_t *) (&svga->vram[svga->memaddr]);
                 if (swap_nib)
                     dat = (dat32 >> ((x & 7) << 2)) & 0xf;
                 else
@@ -156,11 +156,11 @@ ibm_rgb528_render_4bpp(svga_t *svga)
                 p[x] = dat_out.pixel & 0xffffff;
 
             if ((vram_size == 3) && ((x & 31) == 31))
-                svga->ma = (svga->ma + 16) & svga->vram_display_mask;
+                svga->memaddr = (svga->memaddr + 16) & svga->vram_display_mask;
             if ((vram_size == 1) && ((x & 15) == 15))
-                svga->ma = (svga->ma + 8) & svga->vram_display_mask;
+                svga->memaddr = (svga->memaddr + 8) & svga->vram_display_mask;
             else if ((!vram_size) && ((x & 7) == 7))
-                svga->ma = (svga->ma + 4) & svga->vram_display_mask;
+                svga->memaddr = (svga->memaddr + 4) & svga->vram_display_mask;
         }
     }
 }
@@ -182,7 +182,7 @@ ibm_rgb528_render_8bpp(svga_t *svga)
     if ((svga->displine + svga->y_add) < 0)
         return;
 
-    if (svga->changedvram[svga->ma >> 12] || svga->changedvram[(svga->ma >> 12) + 1] || svga->changedvram[(svga->ma >> 12) + 2] || svga->fullchange) {
+    if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->changedvram[(svga->memaddr >> 12) + 2] || svga->fullchange) {
         p = &buffer32->line[svga->displine + svga->y_add][svga->x_add];
 
         if (svga->firstline_draw == 2000)
@@ -192,8 +192,8 @@ ibm_rgb528_render_8bpp(svga_t *svga)
         for (int x = 0; x <= (svga->hdisp + svga->scrollcache); x++) {
             if (vram_size == 3) {
                 if (!(x & 15)) {
-                    dat64  = *(uint64_t *) (&svga->vram[svga->ma]);
-                    dat642 = *(uint64_t *) (&svga->vram[svga->ma + 8]);
+                    dat64  = *(uint64_t *) (&svga->vram[svga->memaddr]);
+                    dat642 = *(uint64_t *) (&svga->vram[svga->memaddr + 8]);
                     if (swap_word) {
                         dat64  = (dat64 << 32ULL) | (dat64 >> 32ULL);
                         dat642 = (dat642 << 32ULL) | (dat642 >> 32ULL);
@@ -202,14 +202,14 @@ ibm_rgb528_render_8bpp(svga_t *svga)
                 dat = (((x & 8) ? dat642 : dat64) >> ((x & 7) << 3)) & 0xff;
             } else if (vram_size == 1) {
                 if (!(x & 7)) {
-                    dat64 = *(uint64_t *) (&svga->vram[svga->ma]);
+                    dat64 = *(uint64_t *) (&svga->vram[svga->memaddr]);
                     if (swap_word)
                         dat64 = (dat64 << 32ULL) | (dat64 >> 32ULL);
                 }
                 dat = (dat64 >> ((x & 7) << 3)) & 0xff;
             } else {
                 if (!(x & 3))
-                    dat32 = *(uint32_t *) (&svga->vram[svga->ma]);
+                    dat32 = *(uint32_t *) (&svga->vram[svga->memaddr]);
                 dat = (dat32 >> ((x & 3) << 3)) & 0xff;
             }
             if (b8_dcol == 0x00) {
@@ -225,11 +225,11 @@ ibm_rgb528_render_8bpp(svga_t *svga)
                 p[x] = dat_out.pixel & 0xffffff;
 
             if ((vram_size == 3) && ((x & 15) == 15))
-                svga->ma = (svga->ma + 16) & svga->vram_display_mask;
+                svga->memaddr = (svga->memaddr + 16) & svga->vram_display_mask;
             else if ((vram_size == 1) && ((x & 7) == 7))
-                svga->ma = (svga->ma + 8) & svga->vram_display_mask;
+                svga->memaddr = (svga->memaddr + 8) & svga->vram_display_mask;
             else if ((!vram_size) && ((x & 3) == 3))
-                svga->ma = (svga->ma + 4) & svga->vram_display_mask;
+                svga->memaddr = (svga->memaddr + 4) & svga->vram_display_mask;
         }
     }
 }
@@ -262,7 +262,7 @@ ibm_rgb528_render_15_16bpp(svga_t *svga)
     if (b555_565 && (b16_dcol != 0x01))
         partition &= 0xc0;
 
-    if (svga->changedvram[svga->ma >> 12] || svga->changedvram[(svga->ma >> 12) + 1] || svga->changedvram[(svga->ma >> 12) + 2] || svga->fullchange) {
+    if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->changedvram[(svga->memaddr >> 12) + 2] || svga->fullchange) {
         p = &buffer32->line[svga->displine + svga->y_add][svga->x_add];
 
         if (svga->firstline_draw == 2000)
@@ -272,8 +272,8 @@ ibm_rgb528_render_15_16bpp(svga_t *svga)
         for (int x = 0; x <= (svga->hdisp + svga->scrollcache); x++) {
             if (vram_size == 2) {
                 if (!(x & 7)) {
-                    dat64  = *(uint64_t *) (&svga->vram[svga->ma]);
-                    dat642 = *(uint64_t *) (&svga->vram[svga->ma + 8]);
+                    dat64  = *(uint64_t *) (&svga->vram[svga->memaddr]);
+                    dat642 = *(uint64_t *) (&svga->vram[svga->memaddr + 8]);
                     if (swap_word) {
                         dat64  = (dat64 << 32ULL) | (dat64 >> 32ULL);
                         dat642 = (dat64 << 32ULL) | (dat642 >> 32ULL);
@@ -282,14 +282,14 @@ ibm_rgb528_render_15_16bpp(svga_t *svga)
                 dat = (((x & 4) ? dat642 : dat64) >> ((x & 3) << 4)) & 0xffff;
             } else if (vram_size == 1) {
                 if (!(x & 3)) {
-                    dat64 = *(uint64_t *) (&svga->vram[svga->ma]);
+                    dat64 = *(uint64_t *) (&svga->vram[svga->memaddr]);
                     if (swap_word)
                         dat64 = (dat64 << 32ULL) | (dat64 >> 32ULL);
                 }
                 dat = (dat64 >> ((x & 3) << 4)) & 0xffff;
             } else {
                 if (!(x & 1))
-                    dat32 = *(uint32_t *) (&svga->vram[svga->ma]);
+                    dat32 = *(uint32_t *) (&svga->vram[svga->memaddr]);
                 dat = (dat32 >> ((x & 1) << 4)) & 0xffff;
             }
             dat_ex = (ibm_rgb528_pixel16_t *) &dat;
@@ -350,11 +350,11 @@ ibm_rgb528_render_15_16bpp(svga_t *svga)
                 p[x] = dat_out.pixel & 0xffffff;
 
             if ((vram_size == 3) && ((x & 7) == 7))
-                svga->ma = (svga->ma + 16) & svga->vram_display_mask;
+                svga->memaddr = (svga->memaddr + 16) & svga->vram_display_mask;
             else if ((vram_size == 1) && ((x & 3) == 3))
-                svga->ma = (svga->ma + 8) & svga->vram_display_mask;
+                svga->memaddr = (svga->memaddr + 8) & svga->vram_display_mask;
             else if (!vram_size && ((x & 1) == 1))
-                svga->ma = (svga->ma + 4) & svga->vram_display_mask;
+                svga->memaddr = (svga->memaddr + 4) & svga->vram_display_mask;
         }
     }
 }
@@ -378,7 +378,7 @@ ibm_rgb528_render_24bpp(svga_t *svga)
     if ((svga->displine + svga->y_add) < 0)
         return;
 
-    if (svga->changedvram[svga->ma >> 12] || svga->changedvram[(svga->ma >> 12) + 1] || svga->changedvram[(svga->ma >> 12) + 2] || svga->fullchange) {
+    if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->changedvram[(svga->memaddr >> 12) + 2] || svga->fullchange) {
         p = &buffer32->line[svga->displine + svga->y_add][svga->x_add];
 
         if (svga->firstline_draw == 2000)
@@ -389,12 +389,12 @@ ibm_rgb528_render_24bpp(svga_t *svga)
             dat_ex = (ibm_rgb528_pixel32_t *) &dat;
             if (vram_size == 3) {
                 if ((x & 15) == 0) {
-                    dat64[0] = *(uint64_t *) (&svga->vram[svga->ma & svga->vram_display_mask]);
-                    dat64[1] = *(uint64_t *) (&svga->vram[(svga->ma + 8) & svga->vram_display_mask]);
-                    dat64[2] = *(uint64_t *) (&svga->vram[(svga->ma + 16) & svga->vram_display_mask]);
-                    dat64[3] = *(uint64_t *) (&svga->vram[(svga->ma + 24) & svga->vram_display_mask]);
-                    dat64[4] = *(uint64_t *) (&svga->vram[(svga->ma + 32) & svga->vram_display_mask]);
-                    dat64[5] = *(uint64_t *) (&svga->vram[(svga->ma + 40) & svga->vram_display_mask]);
+                    dat64[0] = *(uint64_t *) (&svga->vram[svga->memaddr & svga->vram_display_mask]);
+                    dat64[1] = *(uint64_t *) (&svga->vram[(svga->memaddr + 8) & svga->vram_display_mask]);
+                    dat64[2] = *(uint64_t *) (&svga->vram[(svga->memaddr + 16) & svga->vram_display_mask]);
+                    dat64[3] = *(uint64_t *) (&svga->vram[(svga->memaddr + 24) & svga->vram_display_mask]);
+                    dat64[4] = *(uint64_t *) (&svga->vram[(svga->memaddr + 32) & svga->vram_display_mask]);
+                    dat64[5] = *(uint64_t *) (&svga->vram[(svga->memaddr + 40) & svga->vram_display_mask]);
                     if (swap_word) {
                         dat64[0] = (dat64[0] << 32ULL) | (dat64[0] >> 32ULL);
                         dat64[1] = (dat64[1] << 32ULL) | (dat64[1] >> 32ULL);
@@ -407,9 +407,9 @@ ibm_rgb528_render_24bpp(svga_t *svga)
                 dat_ex = (ibm_rgb528_pixel32_t *) &(dat8[(x & 15) * 3]);
             } else if (vram_size == 1) {
                 if ((x & 7) == 0) {
-                    dat64[0] = *(uint64_t *) (&svga->vram[svga->ma & svga->vram_display_mask]);
-                    dat64[1] = *(uint64_t *) (&svga->vram[(svga->ma + 8) & svga->vram_display_mask]);
-                    dat64[2] = *(uint64_t *) (&svga->vram[(svga->ma + 16) & svga->vram_display_mask]);
+                    dat64[0] = *(uint64_t *) (&svga->vram[svga->memaddr & svga->vram_display_mask]);
+                    dat64[1] = *(uint64_t *) (&svga->vram[(svga->memaddr + 8) & svga->vram_display_mask]);
+                    dat64[2] = *(uint64_t *) (&svga->vram[(svga->memaddr + 16) & svga->vram_display_mask]);
                     if (swap_word) {
                         dat64[0] = (dat64[0] << 32ULL) | (dat64[0] >> 32ULL);
                         dat64[1] = (dat64[1] << 32ULL) | (dat64[1] >> 32ULL);
@@ -441,9 +441,9 @@ ibm_rgb528_render_24bpp(svga_t *svga)
                 p[x] = dat_ex->pixel & 0xffffff;
 
             if ((vram_size == 3) && ((x & 15) == 15))
-                svga->ma = (svga->ma + 48) & svga->vram_display_mask;
+                svga->memaddr = (svga->memaddr + 48) & svga->vram_display_mask;
             else if ((vram_size == 1) && ((x & 7) == 7))
-                svga->ma = (svga->ma + 24) & svga->vram_display_mask;
+                svga->memaddr = (svga->memaddr + 24) & svga->vram_display_mask;
         }
     }
 }
@@ -468,7 +468,7 @@ ibm_rgb528_render_32bpp(svga_t *svga)
     if ((svga->displine + svga->y_add) < 0)
         return;
 
-    if (svga->changedvram[svga->ma >> 12] || svga->changedvram[(svga->ma >> 12) + 1] || svga->changedvram[(svga->ma >> 12) + 2] || svga->fullchange) {
+    if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->changedvram[(svga->memaddr >> 12) + 2] || svga->fullchange) {
         p = &buffer32->line[svga->displine + svga->y_add][svga->x_add];
 
         if (svga->firstline_draw == 2000)
@@ -478,8 +478,8 @@ ibm_rgb528_render_32bpp(svga_t *svga)
         for (int x = 0; x <= (svga->hdisp + svga->scrollcache); x++) {
             if (vram_size == 3) {
                 if (!(x & 3)) {
-                    dat64  = *(uint64_t *) (&svga->vram[svga->ma]);
-                    dat642 = *(uint64_t *) (&svga->vram[svga->ma + 8]);
+                    dat64  = *(uint64_t *) (&svga->vram[svga->memaddr]);
+                    dat642 = *(uint64_t *) (&svga->vram[svga->memaddr + 8]);
                     if (swap_word) {
                         dat64  = (dat64 << 32ULL) | (dat64 >> 32ULL);
                         dat642 = (dat642 << 32ULL) | (dat642 >> 32ULL);
@@ -488,13 +488,13 @@ ibm_rgb528_render_32bpp(svga_t *svga)
                 dat = (((x & 2) ? dat642 : dat64) >> ((x & 1ULL) << 5ULL)) & 0xffffffff;
             } else if (vram_size == 1) {
                 if (!(x & 1)) {
-                    dat64 = *(uint64_t *) (&svga->vram[svga->ma]);
+                    dat64 = *(uint64_t *) (&svga->vram[svga->memaddr]);
                     if (swap_word)
                         dat64 = (dat64 << 32ULL) | (dat64 >> 32ULL);
                 }
                 dat = (dat64 >> ((x & 1ULL) << 5ULL)) & 0xffffffff;
             } else
-                dat = *(uint32_t *) (&svga->vram[svga->ma]);
+                dat = *(uint32_t *) (&svga->vram[svga->memaddr]);
             dat_ex = (ibm_rgb528_pixel32_t *) &dat;
             if (swaprb) {
                 temp      = dat_ex->r;
@@ -520,11 +520,11 @@ ibm_rgb528_render_32bpp(svga_t *svga)
                 p[x] = dat_ex->pixel & 0xffffff;
 
             if ((vram_size == 3) && ((x & 3) == 3))
-                svga->ma = (svga->ma + 16) & svga->vram_display_mask;
+                svga->memaddr = (svga->memaddr + 16) & svga->vram_display_mask;
             else if ((vram_size == 1) && ((x & 1) == 1))
-                svga->ma = (svga->ma + 8) & svga->vram_display_mask;
+                svga->memaddr = (svga->memaddr + 8) & svga->vram_display_mask;
             else if (!vram_size)
-                svga->ma = (svga->ma + 4) & svga->vram_display_mask;
+                svga->memaddr = (svga->memaddr + 4) & svga->vram_display_mask;
         }
     }
 }

--- a/src/video/vid_jega.c
+++ b/src/video/vid_jega.c
@@ -116,7 +116,7 @@ typedef struct jega_t {
     int       cursorvisible;
     int       cursoron;
     int       cursorblink_disable;
-    int       ca;
+    int       cursoraddr;
     int       font_index;
     int       sbcsbank_inv;
     int       attr3_sbcsbank;
@@ -222,14 +222,14 @@ jega_render_text(void *priv)
                                               &jega->ega.x_add;
     int *     y_add          = jega->is_vga ? &jega->vga.svga.y_add :
                                               &jega->ega.y_add;
-    int *     sc             = jega->is_vga ? &jega->vga.svga.sc :
-                                              &jega->ega.sc;
+    int *     sc             = jega->is_vga ? &jega->vga.svga.scanline :
+                                              &jega->ega.scanline;
     int *     hdisp          = jega->is_vga ? &jega->vga.svga.hdisp :
                                               &jega->ega.hdisp;
     int *     scrollcache    = jega->is_vga ? &jega->vga.svga.scrollcache :
                                               &jega->ega.scrollcache;
-    uint32_t *ma             = jega->is_vga ? &jega->vga.svga.ma :
-                                              &jega->ega.ma;
+    uint32_t *memaddr             = jega->is_vga ? &jega->vga.svga.memaddr :
+                                              &jega->ega.memaddr;
     uint8_t   mask           = jega->is_vga ? jega->vga.svga.dac_mask : 0xff;
 
     if (*firstline_draw == 2000)
@@ -260,12 +260,12 @@ jega_render_text(void *priv)
 
             if (jega->is_vga) {
                 if (!jega->vga.svga.force_old_addr)
-                    addr = jega->vga.svga.remap_func(&jega->vga.svga, jega->vga.svga.ma) &
+                    addr = jega->vga.svga.remap_func(&jega->vga.svga, jega->vga.svga.memaddr) &
                                                      jega->vga.svga.vram_display_mask;
             } else
-                addr = jega->ega.remap_func(&jega->ega, *ma) & jega->ega.vrammask;
+                addr = jega->ega.remap_func(&jega->ega, *memaddr) & jega->ega.vrammask;
 
-            int drawcursor = ((*ma == jega->ca) && cursoron);
+            int drawcursor = ((*memaddr == jega->cursoraddr) && cursoron);
 
             uint32_t chr;
             uint32_t attr;
@@ -399,9 +399,9 @@ jega_render_text(void *priv)
                     p += charwidth;
                 }
             }
-            *ma += 4;
+            *memaddr += 4;
         }
-        *ma &= 0x3ffff;
+        *memaddr &= 0x3ffff;
     }
 }
 
@@ -523,7 +523,7 @@ jega_out(uint16_t addr, uint8_t val, void *priv)
                         break;
                     case RCCLH:
                     case RCCLL:
-                        jega->ca = jega->regs[RCCLH] << 10 | jega->regs[RCCLL] << 2;
+                        jega->cursoraddr = jega->regs[RCCLH] << 10 | jega->regs[RCCLL] << 2;
                         break;
                     case RCMOD:
                         jega->cursoron = (val & 0x80);

--- a/src/video/vid_oak_oti.c
+++ b/src/video/vid_oak_oti.c
@@ -124,7 +124,7 @@ oti_out(uint16_t addr, uint8_t val, void *priv)
                 if ((idx < 0x0e) || (idx > 0x10)) {
                     if (idx == 0x0c || idx == 0x0d) {
                         svga->fullchange = 3;
-                        svga->ma_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
+                        svga->memaddr_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
                     } else {
                         svga->fullchange = changeframecount;
                         svga_recalctimings(svga);
@@ -393,9 +393,9 @@ oti_recalctimings(svga_t *svga)
 
     if (oti->chip_id > 0) {
         if (oti->regs[0x14] & 0x08)
-            svga->ma_latch |= 0x10000;
+            svga->memaddr_latch |= 0x10000;
         if (oti->regs[0x16] & 0x08)
-            svga->ma_latch |= 0x20000;
+            svga->memaddr_latch |= 0x20000;
 
         if (oti->regs[0x14] & 0x01)
             svga->vtotal += 0x400;

--- a/src/video/vid_paradise.c
+++ b/src/video/vid_paradise.c
@@ -245,7 +245,7 @@ paradise_out(uint16_t addr, uint8_t val, void *priv)
                 if (svga->crtcreg < 0xe || svga->crtcreg > 0x10) {
                     if ((svga->crtcreg == 0xc) || (svga->crtcreg == 0xd)) {
                         svga->fullchange = 3;
-                        svga->ma_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
+                        svga->memaddr_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
                     } else {
                         svga->fullchange = changeframecount;
                         svga_recalctimings(svga);

--- a/src/video/vid_pcjr.c
+++ b/src/video/vid_pcjr.c
@@ -299,7 +299,7 @@ static void
 vid_poll(void *priv)
 {
     pcjr_t  *pcjr = (pcjr_t *) priv;
-    uint16_t ca   = (pcjr->crtc[15] | (pcjr->crtc[14] << 8)) & 0x3fff;
+    uint16_t cursoraddr   = (pcjr->crtc[15] | (pcjr->crtc[14] << 8)) & 0x3fff;
     int      drawcursor;
     int      x;
     int      xs_temp;
@@ -309,7 +309,7 @@ vid_poll(void *priv)
     uint8_t  attr;
     uint16_t dat;
     int      cols[4];
-    int      oldsc;
+    int      scanline_old;
     int      l = (pcjr->displine << 1) + 16;
     int      ho_s = vid_get_h_overscan_size(pcjr);
     int      ho_d = vid_get_h_overscan_delta(pcjr) + (ho_s / 2);
@@ -318,9 +318,9 @@ vid_poll(void *priv)
         timer_advance_u64(&pcjr->timer, pcjr->dispofftime);
         pcjr->stat &= ~1;
         pcjr->linepos = 1;
-        oldsc         = pcjr->sc;
+        scanline_old         = pcjr->scanline;
         if ((pcjr->crtc[8] & 3) == 3)
-            pcjr->sc = (pcjr->sc << 1) & 7;
+            pcjr->scanline = (pcjr->scanline << 1) & 7;
         if (pcjr->dispon) {
             uint16_t offset = 0;
             uint16_t mask   = 0x1fff;
@@ -346,10 +346,10 @@ vid_poll(void *priv)
                     mask   = 0x3fff;
                     break;
                 case 1: /*Low resolution graphics*/
-                    offset = (pcjr->sc & 1) * 0x2000;
+                    offset = (pcjr->scanline & 1) * 0x2000;
                     break;
                 case 3: /*High resolution graphics*/
-                    offset = (pcjr->sc & 3) * 0x2000;
+                    offset = (pcjr->scanline & 3) * 0x2000;
                     break;
                 default:
                     break;
@@ -358,9 +358,9 @@ vid_poll(void *priv)
                 case 0x13: /*320x200x16*/
                     for (x = 0; x < pcjr->crtc[1]; x++) {
                         int ef_x = (x << 3) + ho_d;
-                        dat = (pcjr->vram[((pcjr->ma << 1) & mask) + offset] << 8) |
-                              pcjr->vram[((pcjr->ma << 1) & mask) + offset + 1];
-                        pcjr->ma++;
+                        dat = (pcjr->vram[((pcjr->memaddr << 1) & mask) + offset] << 8) |
+                              pcjr->vram[((pcjr->memaddr << 1) & mask) + offset + 1];
+                        pcjr->memaddr++;
                         buffer32->line[l][ef_x] = buffer32->line[l][ef_x + 1] =
                         buffer32->line[l + 1][ef_x] = buffer32->line[l + 1][ef_x + 1] =
                             pcjr->array[((dat >> 12) & pcjr->array[1] & 0x0f) + 16] + 16;
@@ -378,9 +378,9 @@ vid_poll(void *priv)
                 case 0x12: /*160x200x16*/
                     for (x = 0; x < pcjr->crtc[1]; x++) {
                         int ef_x = (x << 4) + ho_d;
-                        dat = (pcjr->vram[((pcjr->ma << 1) & mask) + offset] << 8) |
-                              pcjr->vram[((pcjr->ma << 1) & mask) + offset + 1];
-                        pcjr->ma++;
+                        dat = (pcjr->vram[((pcjr->memaddr << 1) & mask) + offset] << 8) |
+                              pcjr->vram[((pcjr->memaddr << 1) & mask) + offset + 1];
+                        pcjr->memaddr++;
                         buffer32->line[l][ef_x] = buffer32->line[l][ef_x + 1] =
                         buffer32->line[l][ef_x + 2] = buffer32->line[l][ef_x + 3] =
                         buffer32->line[l + 1][ef_x] = buffer32->line[l + 1][ef_x + 1] =
@@ -406,9 +406,9 @@ vid_poll(void *priv)
                 case 0x03: /*640x200x4*/
                     for (x = 0; x < pcjr->crtc[1]; x++) {
                         int ef_x = (x << 3) + ho_d;
-                        dat = (pcjr->vram[((pcjr->ma << 1) & mask) + offset + 1] << 8) |
-                              pcjr->vram[((pcjr->ma << 1) & mask) + offset];
-                        pcjr->ma++;
+                        dat = (pcjr->vram[((pcjr->memaddr << 1) & mask) + offset + 1] << 8) |
+                              pcjr->vram[((pcjr->memaddr << 1) & mask) + offset];
+                        pcjr->memaddr++;
                         for (uint8_t c = 0; c < 8; c++) {
                             chr = (dat >> 7) & 1;
                             chr |= ((dat >> 14) & 2);
@@ -421,9 +421,9 @@ vid_poll(void *priv)
                 case 0x01: /*80 column text*/
                     for (x = 0; x < pcjr->crtc[1]; x++) {
                         int ef_x = (x << 3) + ho_d;
-                        chr        = pcjr->vram[((pcjr->ma << 1) & mask) + offset];
-                        attr       = pcjr->vram[((pcjr->ma << 1) & mask) + offset + 1];
-                        drawcursor = ((pcjr->ma == ca) && pcjr->cursorvisible && pcjr->cursoron);
+                        chr        = pcjr->vram[((pcjr->memaddr << 1) & mask) + offset];
+                        attr       = pcjr->vram[((pcjr->memaddr << 1) & mask) + offset + 1];
+                        drawcursor = ((pcjr->memaddr == cursoraddr) && pcjr->cursorvisible && pcjr->cursoron);
                         if (pcjr->array[3] & 4) {
                             cols[1] = pcjr->array[((attr & 15) & pcjr->array[1] & 0x0f) + 16] + 16;
                             cols[0] = pcjr->array[(((attr >> 4) & 7) & pcjr->array[1] & 0x0f) + 16] + 16;
@@ -433,7 +433,7 @@ vid_poll(void *priv)
                             cols[1] = pcjr->array[((attr & 15) & pcjr->array[1] & 0x0f) + 16] + 16;
                             cols[0] = pcjr->array[((attr >> 4) & pcjr->array[1] & 0x0f) + 16] + 16;
                         }
-                        if (pcjr->sc & 8)
+                        if (pcjr->scanline & 8)
                             for (uint8_t c = 0; c < 8; c++)
                                 buffer32->line[l][ef_x + c] =
                                 buffer32->line[l + 1][ef_x + c] = cols[0];
@@ -441,21 +441,21 @@ vid_poll(void *priv)
                             for (uint8_t c = 0; c < 8; c++)
                                 buffer32->line[l][ef_x + c] =
                                 buffer32->line[l + 1][ef_x + c] =
-                                    cols[(fontdat[chr][pcjr->sc & 7] & (1 << (c ^ 7))) ? 1 : 0];
+                                    cols[(fontdat[chr][pcjr->scanline & 7] & (1 << (c ^ 7))) ? 1 : 0];
                         if (drawcursor)
                             for (uint8_t c = 0; c < 8; c++) {
                                 buffer32->line[l][ef_x + c] ^= 15;
                                 buffer32->line[l + 1][ef_x + c] ^= 15;
                             }
-                        pcjr->ma++;
+                        pcjr->memaddr++;
                     }
                     break;
                 case 0x00: /*40 column text*/
                     for (x = 0; x < pcjr->crtc[1]; x++) {
                         int ef_x = (x << 4) + ho_d;
-                        chr        = pcjr->vram[((pcjr->ma << 1) & mask) + offset];
-                        attr       = pcjr->vram[((pcjr->ma << 1) & mask) + offset + 1];
-                        drawcursor = ((pcjr->ma == ca) && pcjr->cursorvisible && pcjr->cursoron);
+                        chr        = pcjr->vram[((pcjr->memaddr << 1) & mask) + offset];
+                        attr       = pcjr->vram[((pcjr->memaddr << 1) & mask) + offset + 1];
+                        drawcursor = ((pcjr->memaddr == cursoraddr) && pcjr->cursorvisible && pcjr->cursoron);
                         if (pcjr->array[3] & 4) {
                             cols[1] = pcjr->array[((attr & 15) & pcjr->array[1] & 0x0f) + 16] + 16;
                             cols[0] = pcjr->array[(((attr >> 4) & 7) & pcjr->array[1] & 0x0f) + 16] + 16;
@@ -465,8 +465,8 @@ vid_poll(void *priv)
                             cols[1] = pcjr->array[((attr & 15) & pcjr->array[1] & 0x0f) + 16] + 16;
                             cols[0] = pcjr->array[((attr >> 4) & pcjr->array[1] & 0x0f) + 16] + 16;
                         }
-                        pcjr->ma++;
-                        if (pcjr->sc & 8)
+                        pcjr->memaddr++;
+                        if (pcjr->scanline & 8)
                             for (uint8_t c = 0; c < 8; c++)
                                 buffer32->line[l][ef_x + (c << 1)] =
                                 buffer32->line[l][ef_x + (c << 1) + 1] =
@@ -478,7 +478,7 @@ vid_poll(void *priv)
                                 buffer32->line[l][ef_x + (c << 1) + 1] =
                                 buffer32->line[l + 1][ef_x + (c << 1)] =
                                 buffer32->line[l + 1][ef_x + (c << 1) + 1] =
-                                    cols[(fontdat[chr][pcjr->sc & 7] & (1 << (c ^ 7))) ? 1 : 0];
+                                    cols[(fontdat[chr][pcjr->scanline & 7] & (1 << (c ^ 7))) ? 1 : 0];
                         if (drawcursor)
                             for (uint8_t c = 0; c < 16; c++) {
                                 buffer32->line[l][ef_x + c] ^= 15;
@@ -493,9 +493,9 @@ vid_poll(void *priv)
                     cols[3] = pcjr->array[3 + 16] + 16;
                     for (x = 0; x < pcjr->crtc[1]; x++) {
                         int ef_x = (x << 4) + ho_d;
-                        dat = (pcjr->vram[((pcjr->ma << 1) & mask) + offset] << 8) |
-                              pcjr->vram[((pcjr->ma << 1) & mask) + offset + 1];
-                        pcjr->ma++;
+                        dat = (pcjr->vram[((pcjr->memaddr << 1) & mask) + offset] << 8) |
+                              pcjr->vram[((pcjr->memaddr << 1) & mask) + offset + 1];
+                        pcjr->memaddr++;
                         for (uint8_t c = 0; c < 8; c++) {
                             buffer32->line[l][ef_x + (c << 1)] =
                             buffer32->line[l][ef_x + (c << 1) + 1] =
@@ -510,9 +510,9 @@ vid_poll(void *priv)
                     cols[1] = pcjr->array[1 + 16] + 16;
                     for (x = 0; x < pcjr->crtc[1]; x++) {
                         int ef_x = (x << 4) + ho_d;
-                        dat = (pcjr->vram[((pcjr->ma << 1) & mask) + offset] << 8) |
-                              pcjr->vram[((pcjr->ma << 1) & mask) + offset + 1];
-                        pcjr->ma++;
+                        dat = (pcjr->vram[((pcjr->memaddr << 1) & mask) + offset] << 8) |
+                              pcjr->vram[((pcjr->memaddr << 1) & mask) + offset + 1];
+                        pcjr->memaddr++;
                         for (uint8_t c = 0; c < 16; c++) {
                             buffer32->line[l][ef_x + c] = buffer32->line[l + 1][ef_x + c] =
                                 cols[dat >> 15];
@@ -555,8 +555,8 @@ vid_poll(void *priv)
             video_process_8(x, l);
             video_process_8(x, l + 1);
         }
-        pcjr->sc = oldsc;
-        if (pcjr->vc == pcjr->crtc[7] && !pcjr->sc) {
+        pcjr->scanline = scanline_old;
+        if (pcjr->vc == pcjr->crtc[7] && !pcjr->scanline) {
             pcjr->stat |= 8;
         }
         pcjr->displine++;
@@ -573,22 +573,22 @@ vid_poll(void *priv)
                 pcjr->stat &= ~8;
             }
         }
-        if (pcjr->sc == (pcjr->crtc[11] & 31) || ((pcjr->crtc[8] & 3) == 3 && pcjr->sc == ((pcjr->crtc[11] & 31) >> 1))) {
+        if (pcjr->scanline == (pcjr->crtc[11] & 31) || ((pcjr->crtc[8] & 3) == 3 && pcjr->scanline == ((pcjr->crtc[11] & 31) >> 1))) {
             pcjr->cursorvisible  = 0;
         }
         if (pcjr->vadj) {
-            pcjr->sc++;
-            pcjr->sc &= 31;
-            pcjr->ma = pcjr->maback;
+            pcjr->scanline++;
+            pcjr->scanline &= 31;
+            pcjr->memaddr = pcjr->memaddr_backup;
             pcjr->vadj--;
             if (!pcjr->vadj) {
                 pcjr->dispon = 1;
-                pcjr->ma = pcjr->maback = (pcjr->crtc[13] | (pcjr->crtc[12] << 8)) & 0x3fff;
-                pcjr->sc                = 0;
+                pcjr->memaddr = pcjr->memaddr_backup = (pcjr->crtc[13] | (pcjr->crtc[12] << 8)) & 0x3fff;
+                pcjr->scanline                = 0;
             }
-        } else if (pcjr->sc == pcjr->crtc[9] || ((pcjr->crtc[8] & 3) == 3 && pcjr->sc == (pcjr->crtc[9] >> 1))) {
-            pcjr->maback = pcjr->ma;
-            pcjr->sc     = 0;
+        } else if (pcjr->scanline == pcjr->crtc[9] || ((pcjr->crtc[8] & 3) == 3 && pcjr->scanline == (pcjr->crtc[9] >> 1))) {
+            pcjr->memaddr_backup = pcjr->memaddr;
+            pcjr->scanline     = 0;
             oldvc        = pcjr->vc;
             pcjr->vc++;
             pcjr->vc &= 127;
@@ -600,7 +600,7 @@ vid_poll(void *priv)
                 if (!pcjr->vadj)
                     pcjr->dispon = 1;
                 if (!pcjr->vadj)
-                    pcjr->ma = pcjr->maback = (pcjr->crtc[13] | (pcjr->crtc[12] << 8)) & 0x3fff;
+                    pcjr->memaddr = pcjr->memaddr_backup = (pcjr->crtc[13] | (pcjr->crtc[12] << 8)) & 0x3fff;
                 if ((pcjr->crtc[10] & 0x60) == 0x20)
                     pcjr->cursoron = 0;
                 else
@@ -664,11 +664,11 @@ vid_poll(void *priv)
                 pcjr->blink++;
             }
         } else {
-            pcjr->sc++;
-            pcjr->sc &= 31;
-            pcjr->ma = pcjr->maback;
+            pcjr->scanline++;
+            pcjr->scanline &= 31;
+            pcjr->memaddr = pcjr->memaddr_backup;
         }
-        if (pcjr->sc == (pcjr->crtc[10] & 31) || ((pcjr->crtc[8] & 3) == 3 && pcjr->sc == ((pcjr->crtc[10] & 31) >> 1)))
+        if (pcjr->scanline == (pcjr->crtc[10] & 31) || ((pcjr->crtc[8] & 3) == 3 && pcjr->scanline == ((pcjr->crtc[10] & 31) >> 1)))
             pcjr->cursorvisible = 1;
     }
 }

--- a/src/video/vid_ps55da2.c
+++ b/src/video/vid_ps55da2.c
@@ -349,7 +349,7 @@ typedef struct da2_t {
     int      lowres;
     int      rowcount;
     double   clock;
-    uint32_t ma_latch, ca_adj;
+    uint32_t memaddr_latch, ca_adj;
 
     uint64_t   dispontime, dispofftime;
     pc_timer_t timer;
@@ -358,9 +358,9 @@ typedef struct da2_t {
     int dispon;
     int hdisp_on;
 
-    uint32_t ma, maback, ca;
+    uint32_t memaddr, memaddr_backup, cursoraddr;
     int      vc;
-    int      sc;
+    int      scanline;
     int      linepos, vslines, linecountff;
     int      cursorvisible, cursoron, blink, blinkconf;
     int      scrollcache;
@@ -1960,10 +1960,10 @@ da2_render_text(da2_t *da2)
         uint32_t  chr_dbcs;
         int       chr_wide = 0;
         int       colormode = ((da2->attrc[LV_PAS_STATUS_CNTRL] & 0x80) == 0x80);
-        // da2_log("\nda2ma: %x, da2sc: %x\n", da2->ma, da2->sc);
+        // da2_log("\nda2ma: %x, da2sc: %x\n", da2->memaddr, da2->scanline);
         for (x = 0; x < da2->hdisp; x += 13) {
-            chr  = da2->cram[(da2->ma) & DA2_MASK_CRAM];
-            attr = da2->cram[(da2->ma + 1) & DA2_MASK_CRAM];
+            chr  = da2->cram[(da2->memaddr) & DA2_MASK_CRAM];
+            attr = da2->cram[(da2->memaddr + 1) & DA2_MASK_CRAM];
             // if(chr!=0x20) da2_log("chr: %x, attr: %x    ", chr, attr);
             if (colormode) /* IO 3E8h, Index 1Dh */
             {                                           /* --Parse attribute byte in color mode-- */
@@ -2003,11 +2003,11 @@ da2_render_text(da2_t *da2)
                 /* Stay drawing If the char code is DBCS and not at last column. */
                 if (chr_wide) {
                     /* Get high DBCS code from the next video address */
-                    chr_dbcs = da2->cram[(da2->ma + 2) & DA2_MASK_CRAM];
+                    chr_dbcs = da2->cram[(da2->memaddr + 2) & DA2_MASK_CRAM];
                     chr_dbcs <<= 8;
                     chr_dbcs |= chr;
                     /* Get the font pattern */
-                    uint32_t font = getfont_ps55dbcs(chr_dbcs, da2->sc, da2);
+                    uint32_t font = getfont_ps55dbcs(chr_dbcs, da2->scanline, da2);
                     /* Draw 13 dots */
                     for (uint32_t n = 0; n < 13; n++) {
                         p[n] = da2->pallook[da2->egapal[(font & 0x80000000) ? fg : bg]];
@@ -2020,10 +2020,10 @@ da2_render_text(da2_t *da2)
                         fontbase = DA2_GAIJIRAM_SBEX;
                     else
                         fontbase = DA2_GAIJIRAM_SBCS;
-                    uint16_t font = da2->mmio.ram[fontbase + chr * 0x40 + da2->sc * 2]; /* w13xh29 font */
+                    uint16_t font = da2->mmio.ram[fontbase + chr * 0x40 + da2->scanline * 2]; /* w13xh29 font */
                     font <<= 8;
-                    font |= da2->mmio.ram[fontbase + chr * 0x40 + da2->sc * 2 + 1]; /* w13xh29 font */
-                    // if(chr!=0x20) da2_log("ma: %x, sc: %x, chr: %x, font: %x    ", da2->ma, da2->sc, chr, font);
+                    font |= da2->mmio.ram[fontbase + chr * 0x40 + da2->scanline * 2 + 1]; /* w13xh29 font */
+                    // if(chr!=0x20) da2_log("memaddr: %x, scanline: %x, chr: %x, font: %x    ", da2->memaddr, da2->scanline, chr, font);
                     /* Draw 13 dots */
                     for (uint32_t n = 0; n < 13; n++) {
                         p[n] = da2->pallook[da2->egapal[(font & 0x8000) ? fg : bg]];
@@ -2033,7 +2033,7 @@ da2_render_text(da2_t *da2)
             }
             /* right half of DBCS */
             else {
-                uint32_t font = getfont_ps55dbcs(chr_dbcs, da2->sc, da2);
+                uint32_t font = getfont_ps55dbcs(chr_dbcs, da2->scanline, da2);
                 /* Draw 13 dots */
                 for (uint32_t n = 0; n < 13; n++) {
                     p[n] = da2->pallook[da2->egapal[(font & 0x8000) ? fg : bg]];
@@ -2042,7 +2042,7 @@ da2_render_text(da2_t *da2)
                 chr_wide = 0;
             }
             /* Line 28 (Underscore) Note: Draw this first to display blink + vertical + underline correctly. */
-            if (da2->sc == da2->crtc[LC_UNDERLINE_LOCATION] && attr & 0x40 && !colormode) { /* Underscore only in monochrome mode */
+            if (da2->scanline == da2->crtc[LC_UNDERLINE_LOCATION] && attr & 0x40 && !colormode) { /* Underscore only in monochrome mode */
                 for (uint32_t n = 0; n < 13; n++)
                     p[n] = da2->pallook[da2->egapal[fg]]; /* under line (white) */
             }
@@ -2050,13 +2050,13 @@ da2_render_text(da2_t *da2)
             if (attr & 0x10) {
                 p[0] = da2->pallook[da2->egapal[(colormode) ? IRGBtoBGRI(da2->attrc[LV_GRID_COLOR_0]) : 2]]; /* vertical line (white) */
             }
-            if (da2->sc == 0 && attr & 0x20 && ~da2->attrc[LV_PAS_STATUS_CNTRL]) { /* HGrid */
+            if (da2->scanline == 0 && attr & 0x20 && ~da2->attrc[LV_PAS_STATUS_CNTRL]) { /* HGrid */
                 for (uint32_t n = 0; n < 13; n++)
                     p[n] = da2->pallook[da2->egapal[(colormode) ? IRGBtoBGRI(da2->attrc[LV_GRID_COLOR_0]) : 2]]; /* horizontal line (white) */
             }
             /* Drawing text cursor */
-            drawcursor = ((da2->ma == da2->ca) && da2->cursorvisible && da2->cursoron);
-            if (drawcursor && da2->sc >= da2->crtc[LC_CURSOR_ROW_START] && da2->sc <= da2->crtc[LC_CURSOR_ROW_END]) {
+            drawcursor = ((da2->memaddr == da2->cursoraddr) && da2->cursorvisible && da2->cursoron);
+            if (drawcursor && da2->scanline >= da2->crtc[LC_CURSOR_ROW_START] && da2->scanline <= da2->crtc[LC_CURSOR_ROW_END]) {
                 int cursorwidth = (da2->crtc[LC_COMPATIBILITY] & 0x20 ? 26 : 13);
                 int cursorcolor = (colormode) ? IRGBtoBGRI(da2->attrc[LV_CURSOR_COLOR]) : 2; /* Choose color 2 if mode 8 */
                 fg              = (colormode) ? getPS55ForeColor(attr, da2) : ((attr & 0x08) ? 3 : 2);
@@ -2071,10 +2071,10 @@ da2_render_text(da2_t *da2)
                     else
                         p[n] = (p[n] == da2->pallook[da2->egapal[bg]]) ? da2->pallook[da2->egapal[cursorcolor]] : p[n];
             }
-            da2->ma += 2;
+            da2->memaddr += 2;
             p += 13;
         }
-        // da2->ma &= DA2_MASK_CRAM;
+        // da2->memaddr &= DA2_MASK_CRAM;
         // da2->writelines++;
     }
 }
@@ -2096,12 +2096,12 @@ da2_render_textm3(da2_t *da2)
         int       fg, bg;
         uint32_t  chr_dbcs;
         int       chr_wide = 0;
-        // da2_log("\nda2ma: %x, da2sc: %x\n", da2->ma, da2->sc);
+        // da2_log("\nda2ma: %x, da2sc: %x\n", da2->memaddr, da2->scanline);
         for (x = 0; x < da2->hdisp; x += 13) {
-            chr     = da2_vram_r(DA2_VM03_BASECHR + da2->ma, da2);
-            attr    = da2_vram_r(DA2_VM03_BASECHR + da2->ma + 1, da2);
-            extattr = da2_vram_r(DA2_VM03_BASEEXATTR + da2->ma + 1, da2);
-            // if(chr!=0x20) da2_log("addr: %x, chr: %x, attr: %x    ", (DA2_VM03_BASECHR + da2->ma << 1) & da2->vram_mask, chr, attr);
+            chr     = da2_vram_r(DA2_VM03_BASECHR + da2->memaddr, da2);
+            attr    = da2_vram_r(DA2_VM03_BASECHR + da2->memaddr + 1, da2);
+            extattr = da2_vram_r(DA2_VM03_BASEEXATTR + da2->memaddr + 1, da2);
+            // if(chr!=0x20) da2_log("addr: %x, chr: %x, attr: %x    ", (DA2_VM03_BASECHR + da2->memaddr << 1) & da2->vram_mask, chr, attr);
             bg = attr >> 4;
             // if (da2->blink) bg &= ~0x8;
             // fg = (da2->blink || (!(attr & 0x80))) ? (attr & 0xf) : bg;
@@ -2118,11 +2118,11 @@ da2_render_textm3(da2_t *da2)
                 /* Stay drawing if the char code is DBCS and not at last column. */
                 if (chr_wide) {
                     /* Get high DBCS code from the next video address */
-                    chr_dbcs = da2_vram_r(DA2_VM03_BASECHR + da2->ma + 2, da2);
+                    chr_dbcs = da2_vram_r(DA2_VM03_BASECHR + da2->memaddr + 2, da2);
                     chr_dbcs <<= 8;
                     chr_dbcs |= chr;
                     /* Get the font pattern */
-                    uint32_t font = getfont_ps55dbcs(chr_dbcs, da2->sc, da2);
+                    uint32_t font = getfont_ps55dbcs(chr_dbcs, da2->scanline, da2);
                     /* Draw 13 dots */
                     for (uint32_t n = 0; n < 13; n++) {
                         p[n] = da2->pallook[da2->egapal[(font & 0x80000000) ? fg : bg]];
@@ -2135,10 +2135,10 @@ da2_render_textm3(da2_t *da2)
                         fontbase = DA2_GAIJIRAM_SBEX;
                     else
                         fontbase = DA2_GAIJIRAM_SBCS;
-                    uint16_t font = da2->mmio.ram[fontbase+ chr * 0x40 + da2->sc * 2]; /* w13xh29 font */
+                    uint16_t font = da2->mmio.ram[fontbase+ chr * 0x40 + da2->scanline * 2]; /* w13xh29 font */
                     font <<= 8;
-                    font |= da2->mmio.ram[fontbase + chr * 0x40 + da2->sc * 2 + 1]; /* w13xh29 font */
-                    // if(chr!=0x20) da2_log("ma: %x, sc: %x, chr: %x, font: %x    ", da2->ma, da2->sc, chr, font);
+                    font |= da2->mmio.ram[fontbase + chr * 0x40 + da2->scanline * 2 + 1]; /* w13xh29 font */
+                    // if(chr!=0x20) da2_log("memaddr: %x, scanline: %x, chr: %x, font: %x    ", da2->memaddr, da2->scanline, chr, font);
                     for (uint32_t n = 0; n < 13; n++) {
                         p[n] = da2->pallook[da2->egapal[(font & 0x8000) ? fg : bg]];
                         font <<= 1;
@@ -2147,7 +2147,7 @@ da2_render_textm3(da2_t *da2)
             }
             /* right half of DBCS */
             else {
-                uint32_t font = getfont_ps55dbcs(chr_dbcs, da2->sc, da2);
+                uint32_t font = getfont_ps55dbcs(chr_dbcs, da2->scanline, da2);
                 /* Draw 13 dots */
                 for (uint32_t n = 0; n < 13; n++) {
                     p[n] = da2->pallook[da2->egapal[(font & 0x8000) ? fg : bg]];
@@ -2155,8 +2155,8 @@ da2_render_textm3(da2_t *da2)
                 }
                 chr_wide = 0;
             }
-            drawcursor = ((da2->ma == da2->ca) && da2->cursorvisible && da2->cursoron);
-            if (drawcursor && da2->sc >= da2->crtc[LC_CURSOR_ROW_START] && da2->sc <= da2->crtc[LC_CURSOR_ROW_END]) {
+            drawcursor = ((da2->memaddr == da2->cursoraddr) && da2->cursorvisible && da2->cursoron);
+            if (drawcursor && da2->scanline >= da2->crtc[LC_CURSOR_ROW_START] && da2->scanline <= da2->crtc[LC_CURSOR_ROW_END]) {
                 // int cursorwidth = (da2->crtc[0x1f] & 0x20 ? 26 : 13);
                 // int cursorcolor = (colormode) ? IRGBtoBGRI(da2->attrc[0x1a]) : 2;/* Choose color 2 if mode 8 */
                 // fg = (colormode) ? getPS55ForeColor(attr, da2) : (attr & 0x08) ? 3 : 2;
@@ -2168,10 +2168,10 @@ da2_render_textm3(da2_t *da2)
                 for (uint32_t n = 0; n < 13; n++)
                     p[n] = da2->pallook[da2->egapal[fg]];
             }
-            da2->ma += 2;
+            da2->memaddr += 2;
             p += 13;
         }
-        // da2->ma &= DA2_MASK_CRAM;
+        // da2->memaddr &= DA2_MASK_CRAM;
         // da2->writelines++;
     }
 }
@@ -2179,8 +2179,8 @@ da2_render_textm3(da2_t *da2)
 static void
 da2_render_color_4bpp(da2_t *da2)
 {
-    int changed_offset = da2->ma >> 9;
-    // da2_log("ma %x cf %x\n", da2->ma, changed_offset);
+    int changed_offset = da2->memaddr >> 9;
+    // da2_log("memaddr %x cf %x\n", da2->memaddr, changed_offset);
     da2->plane_mask &= 0x0f; /*safety */
 
     if (da2->changedvram[changed_offset] || da2->changedvram[changed_offset + 1] || da2->fullchange) {
@@ -2191,7 +2191,7 @@ da2_render_color_4bpp(da2_t *da2)
         if (da2->firstline_draw == 2000)
             da2->firstline_draw = da2->displine;
         da2->lastline_draw = da2->displine;
-        // da2_log("d %X\n", da2->ma);
+        // da2_log("d %X\n", da2->memaddr);
 
         for (x = 0; x <= da2->hdisp; x += 8) /* hdisp = 1024 */
         {
@@ -2199,9 +2199,9 @@ da2_render_color_4bpp(da2_t *da2)
             uint8_t dat;
 
             /* get 8 pixels from vram */
-            da2->ma &= da2->vram_display_mask;
-            *(uint32_t *) (&edat[0]) = *(uint32_t *) (&da2->vram[da2->ma << 3]);
-            da2->ma += 1;
+            da2->memaddr &= da2->vram_display_mask;
+            *(uint32_t *) (&edat[0]) = *(uint32_t *) (&da2->vram[da2->memaddr << 3]);
+            da2->memaddr += 1;
 
             dat  = ((edat[0] >> 7) & (1 << 0)) | ((edat[1] >> 6) & (1 << 1)) | ((edat[2] >> 5) & (1 << 2)) | ((edat[3] >> 4) & (1 << 3));
             p[0] = da2->pallook[da2->egapal[dat & da2->plane_mask]];
@@ -2228,8 +2228,8 @@ da2_render_color_4bpp(da2_t *da2)
 static void
 da2_render_color_8bpp(da2_t *da2)
 {
-    int changed_offset = da2->ma >> 9;
-    // da2_log("ma %x cf %x\n", da2->ma, changed_offset);
+    int changed_offset = da2->memaddr >> 9;
+    // da2_log("memaddr %x cf %x\n", da2->memaddr, changed_offset);
 
     if (da2->changedvram[changed_offset] || da2->changedvram[changed_offset + 1] || da2->fullchange) {
         int       x;
@@ -2239,7 +2239,7 @@ da2_render_color_8bpp(da2_t *da2)
         if (da2->firstline_draw == 2000)
             da2->firstline_draw = da2->displine;
         da2->lastline_draw = da2->displine;
-        // da2_log("d %X\n", da2->ma);
+        // da2_log("d %X\n", da2->memaddr);
 
         for (x = 0; x <= da2->hdisp; x += 8) /* hdisp = 1024 */
         {
@@ -2247,10 +2247,10 @@ da2_render_color_8bpp(da2_t *da2)
             uint8_t dat;
 
             /* get 8 pixels from vram */
-            da2->ma &= da2->vram_display_mask;
-            *(uint32_t *) (&edat[0]) = *(uint32_t *) (&da2->vram[da2->ma << 3]);
-            *(uint32_t *) (&edat[4]) = *(uint32_t *) (&da2->vram[(da2->ma << 3) + 4]);
-            da2->ma += 1;
+            da2->memaddr &= da2->vram_display_mask;
+            *(uint32_t *) (&edat[0]) = *(uint32_t *) (&da2->vram[da2->memaddr << 3]);
+            *(uint32_t *) (&edat[4]) = *(uint32_t *) (&da2->vram[(da2->memaddr << 3) + 4]);
+            da2->memaddr += 1;
 
             dat  = ((edat[0] >> 7) & (1 << 0)) | ((edat[1] >> 6) & (1 << 1)) | ((edat[2] >> 5) & (1 << 2)) | ((edat[3] >> 4) & (1 << 3)) | ((edat[4] >> 3) & (1 << 4)) | ((edat[5] >> 2) & (1 << 5)) | ((edat[6] >> 1) & (1 << 6)) | ((edat[7] >> 0) & (1 << 7));
             p[0] = da2->pallook[dat];
@@ -2343,9 +2343,9 @@ da2_recalctimings(da2_t *da2)
     if (da2->rowoffset == 0)
         da2->rowoffset = 64 * 2; /* To avoid causing a DBZ error */
     if (da2->split == 0) /* To avoid a glitch in MODE 1 of OS/2 J1.3 DOSBox. */
-        da2->ma_latch = 0;
+        da2->memaddr_latch = 0;
     else
-        da2->ma_latch = ((da2->crtc[LC_START_ADDRESS_HIGH] & 0x3ff) << 8) | da2->crtc[LC_START_ADDRESS_LOW];
+        da2->memaddr_latch = ((da2->crtc[LC_START_ADDRESS_HIGH] & 0x3ff) << 8) | da2->crtc[LC_START_ADDRESS_LOW];
 
     da2->ca_adj = 0;
     da2->rowcount = da2->crtc[LC_MAXIMUM_SCAN_LINE];
@@ -3022,7 +3022,7 @@ da2_poll(void *priv)
         if (da2->dispon) {
             da2->hdisp_on = 1;
 
-            da2->ma &= da2->vram_display_mask;
+            da2->memaddr &= da2->vram_display_mask;
             if (da2->firstline == 2000) {
                 da2->firstline = da2->displine;
                 video_wait_for_buffer();
@@ -3035,7 +3035,7 @@ da2_poll(void *priv)
                 da2->lastline = da2->displine;
         }
 
-        // da2_log("%03i %06X %06X\n", da2->displine, da2->ma,da2->vram_display_mask);
+        // da2_log("%03i %06X %06X\n", da2->displine, da2->memaddr,da2->vram_display_mask);
         da2->displine++;
         if ((da2->cgastat & 8) && ((da2->displine & 0xf) == (da2->crtc[LC_VERTICAL_SYNC_END] & 0xf)) && da2->vslines) {
             // da2_log("Vsync off at line %i\n",displine);
@@ -3045,9 +3045,9 @@ da2_poll(void *priv)
         if (da2->displine > 1200)
             da2->displine = 0;
         // da2_log("Col is %08X %08X %08X   %i %i  %08X\n",((uint32_t *)buffer32->line[displine])[320],((uint32_t *)buffer32->line[displine])[321],((uint32_t *)buffer32->line[displine])[322],
-        // displine, vc, ma);
+        // displine, vc, memaddr);
     } else {
-        // da2_log("VC %i ma %05X\n", da2->vc, da2->ma);
+        // da2_log("VC %i memaddr %05X\n", da2->vc, da2->memaddr);
         timer_advance_u64(&da2->timer, da2->dispontime);
 
         if (da2->dispon)
@@ -3055,20 +3055,20 @@ da2_poll(void *priv)
         da2->hdisp_on = 0;
 
         da2->linepos = 0;
-        if (da2->sc == (da2->crtc[LC_CURSOR_ROW_END] & 31))
+        if (da2->scanline == (da2->crtc[LC_CURSOR_ROW_END] & 31))
             da2->cursorvisible = 0;
         if (da2->dispon) {
-            if (da2->sc == da2->rowcount) {
+            if (da2->scanline == da2->rowcount) {
                 da2->linecountff = 0;
-                da2->sc          = 0;
+                da2->scanline          = 0;
 
-                da2->maback += (da2->rowoffset << 1); /*   color = 0x50(80), mono = 0x40(64) */
-                da2->maback &= da2->vram_display_mask;
-                da2->ma = da2->maback;
+                da2->memaddr_backup += (da2->rowoffset << 1); /*   color = 0x50(80), mono = 0x40(64) */
+                da2->memaddr_backup &= da2->vram_display_mask;
+                da2->memaddr = da2->memaddr_backup;
             } else {
-                da2->sc++;
-                da2->sc &= 31;
-                da2->ma = da2->maback;
+                da2->scanline++;
+                da2->scanline &= 31;
+                da2->memaddr = da2->memaddr_backup;
             }
         }
 
@@ -3076,9 +3076,9 @@ da2_poll(void *priv)
         da2->vc &= 2047;
 
         if (da2->vc == da2->split) {
-            // da2->ma = da2->maback = da2->hblank_sub;
-            da2->ma = da2->maback = 0;
-            da2->sc = 0;
+            // da2->memaddr = da2->memaddr_backup = da2->hblank_sub;
+            da2->memaddr = da2->memaddr_backup = 0;
+            da2->scanline = 0;
             // da2->displine    = 0;
         }
 
@@ -3128,23 +3128,23 @@ da2_poll(void *priv)
             changeframecount = 2;
             da2->vslines     = 0;
 
-            da2->ma
-                = da2->maback = da2->ma_latch << 1;
-            da2->ca           = ((da2->crtc[LC_CURSOR_LOC_HIGH] << 8) | da2->crtc[LC_CURSOR_LOC_LOWJ]) + da2->ca_adj;
-            da2->ca <<= 1;
+            da2->memaddr
+                = da2->memaddr_backup = da2->memaddr_latch << 1;
+            da2->cursoraddr           = ((da2->crtc[LC_CURSOR_LOC_HIGH] << 8) | da2->crtc[LC_CURSOR_LOC_LOWJ]) + da2->ca_adj;
+            da2->cursoraddr <<= 1;
 
-            // da2_log("Addr %08X vson %03X vsoff %01X\n",da2->ma,da2->vsyncstart,da2->crtc[0x11]&0xF);
+            // da2_log("Addr %08X vson %03X vsoff %01X\n",da2->memaddr,da2->vsyncstart,da2->crtc[0x11]&0xF);
         }
         if (da2->vc == da2->vtotal) {
             // da2_log("VC vtotal\n");
             // printf("Frame over at line %i %i  %i %i\n",displine,vc,da2_vsyncstart,da2_dispend);
             da2->vc          = 0;
-            da2->sc          = da2->crtc[LC_PRESET_ROW_SCANJ] & 0x1f;
+            da2->scanline          = da2->crtc[LC_PRESET_ROW_SCANJ] & 0x1f;
             da2->dispon      = 1;
             da2->displine    = 0;
             da2->scrollcache = da2->attrc[LV_PANNING] & 7;
         }
-        if (da2->sc == (da2->crtc[LC_CURSOR_ROW_START] & 31))
+        if (da2->scanline == (da2->crtc[LC_CURSOR_ROW_START] & 31))
             da2->cursorvisible = 1;
     }
 }
@@ -3231,7 +3231,7 @@ da2_reset(void *priv)
     da2->attrc[LV_CURSOR_COLOR]    = 0x0f;                   /* cursor color */
     da2->crtc[LC_HORIZONTAL_TOTAL] = 63;                     /* Horizontal Total */
     da2->crtc[LC_VERTICAL_TOTALJ]  = 255;                    /* Vertical Total (These two must be set before the timer starts.) */
-    da2->ma_latch                  = 0;
+    da2->memaddr_latch                  = 0;
     da2->attrc[LV_CURSOR_CONTROL]  = 0x13; /* cursor options */
     da2->attr_palette_enable       = 0;    /* disable attribute generator */
 

--- a/src/video/vid_rtg310x.c
+++ b/src/video/vid_rtg310x.c
@@ -180,7 +180,7 @@ rtg_out(uint16_t addr, uint8_t val, void *priv)
                 if (svga->crtcreg < 0xe || svga->crtcreg > 0x10) {
                     if ((svga->crtcreg == 0xc) || (svga->crtcreg == 0xd)) {
                         svga->fullchange = 3;
-                        svga->ma_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
+                        svga->memaddr_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
                     } else {
                         svga->fullchange = changeframecount;
                         svga_recalctimings(svga);
@@ -211,7 +211,7 @@ rtg_recalctimings(svga_t *svga)
 {
     const rtg_t  *dev  = (rtg_t *) svga->priv;
 
-    svga->ma_latch |= ((svga->crtc[0x19] & 0x10) << 16) | ((svga->crtc[0x19] & 0x40) << 17);
+    svga->memaddr_latch |= ((svga->crtc[0x19] & 0x10) << 16) | ((svga->crtc[0x19] & 0x40) << 17);
 
     svga->interlace = (svga->crtc[0x19] & 1);
 

--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -3179,9 +3179,9 @@ s3_out(uint16_t addr, uint8_t val, void *priv)
                 if (svga->crtcreg < 0xe || svga->crtcreg > 0x10) {
                     if ((svga->crtcreg == 0xc) || (svga->crtcreg == 0xd)) {
                         svga->fullchange = 3;
-                        svga->ma_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
+                        svga->memaddr_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
                         if ((((svga->crtc[0x67] & 0xc) != 0xc) && (s3->chip >= S3_TRIO64V)) || (s3->chip < S3_TRIO64V))
-                            svga->ma_latch |= (s3->ma_ext << 16);
+                            svga->memaddr_latch |= (s3->ma_ext << 16);
                     } else {
                         svga->fullchange = svga->monitor->mon_changeframecount;
                         svga_recalctimings(svga);
@@ -3503,7 +3503,7 @@ s3_recalctimings(svga_t *svga)
     }
 
     svga->hdisp = svga->hdisp_old;
-    svga->ma_latch |= (s3->ma_ext << 16);
+    svga->memaddr_latch |= (s3->ma_ext << 16);
 
     svga->lowres = (!!(svga->attrregs[0x10] & 0x40) && !(svga->crtc[0x3a] & 0x10));
 
@@ -4379,7 +4379,7 @@ s3_trio64v_recalctimings(svga_t *svga)
 
     if ((svga->crtc[0x67] & 0xc) != 0xc) /*VGA mode*/
     {
-        svga->ma_latch |= (s3->ma_ext << 16);
+        svga->memaddr_latch |= (s3->ma_ext << 16);
         if (svga->crtc[0x51] & 0x30)
             svga->rowoffset |= (svga->crtc[0x51] & 0x30) << 4;
         else if (svga->crtc[0x43] & 0x04)
@@ -4427,9 +4427,9 @@ s3_trio64v_recalctimings(svga_t *svga)
     } else /*Streams mode*/
     {
         if (s3->streams.buffer_ctrl & 1)
-            svga->ma_latch = s3->streams.pri_fb1 >> 2;
+            svga->memaddr_latch = s3->streams.pri_fb1 >> 2;
         else
-            svga->ma_latch = s3->streams.pri_fb0 >> 2;
+            svga->memaddr_latch = s3->streams.pri_fb0 >> 2;
 
         svga->hdisp = s3->streams.pri_w + 1;
         if (s3->streams.pri_h < svga->dispend)

--- a/src/video/vid_s3_virge.c
+++ b/src/video/vid_s3_virge.c
@@ -688,10 +688,10 @@ s3_virge_out(uint16_t addr, uint8_t val, void *priv)
                 if (svga->crtcreg < 0xe || svga->crtcreg > 0x10) {
                     if ((svga->crtcreg == 0xc) || (svga->crtcreg == 0xd)) {
                         svga->fullchange = 3;
-                        svga->ma_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) +
+                        svga->memaddr_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) +
                                            ((svga->crtc[8] & 0x60) >> 5);
                         if ((svga->crtc[0x67] & 0xc) != 0xc)
-                            svga->ma_latch |= (virge->ma_ext << 16);
+                            svga->memaddr_latch |= (virge->ma_ext << 16);
                     } else {
                         svga->fullchange = changeframecount;
                         svga_recalctimings(svga);
@@ -890,7 +890,7 @@ s3_virge_recalctimings(svga_t *svga)
     }
 
     if ((svga->crtc[0x67] & 0xc) != 0xc) { /*VGA mode*/
-        svga->ma_latch |= (virge->ma_ext << 16);
+        svga->memaddr_latch |= (virge->ma_ext << 16);
         if (svga->crtc[0x51] & 0x30)
             svga->rowoffset |= (svga->crtc[0x51] & 0x30) << 4;
         else if (svga->crtc[0x43] & 0x04)
@@ -935,9 +935,9 @@ s3_virge_recalctimings(svga_t *svga)
     } else { /*Streams mode*/
         if (virge->chip < S3_VIRGEGX2) {
             if (virge->streams.buffer_ctrl & 1)
-                svga->ma_latch = virge->streams.pri_fb1 >> 2;
+                svga->memaddr_latch = virge->streams.pri_fb1 >> 2;
             else
-                svga->ma_latch = virge->streams.pri_fb0 >> 2;
+                svga->memaddr_latch = virge->streams.pri_fb0 >> 2;
 
             svga->hdisp = virge->streams.pri_w + 1;
             if (virge->streams.pri_h < svga->dispend)
@@ -946,7 +946,7 @@ s3_virge_recalctimings(svga_t *svga)
             svga->overlay.x = virge->streams.sec_x - virge->streams.pri_x;
             svga->overlay.y = virge->streams.sec_y - virge->streams.pri_y;
         } else {
-            svga->ma_latch |= (virge->ma_ext << 16);
+            svga->memaddr_latch |= (virge->ma_ext << 16);
             if (svga->crtc[0x51] & 0x30)
                 svga->rowoffset |= (svga->crtc[0x51] & 0x30) << 4;
             else if (svga->crtc[0x43] & 0x04)

--- a/src/video/vid_sigma.c
+++ b/src/video/vid_sigma.c
@@ -151,12 +151,12 @@ typedef struct sigma_t {
 
     uint8_t sigmamode; /* Mode control register [0x2D8] */
 
-    uint16_t ma, maback;
+    uint16_t memaddr, memaddr_backup;
 
     int crtcreg; /* CRTC: Real selected register */
 
     int linepos, displine;
-    int sc, vc;
+    int scanline, vc;
     int cgadispon;
     int cursorvisible, cursoron, cgablink;
     int vsynctime, vadj;
@@ -414,23 +414,23 @@ sigma_text80(sigma_t *sigma)
 {
     uint8_t        chr;
     uint8_t        attr;
-    uint16_t       ca = (sigma->crtc[15] | (sigma->crtc[14] << 8));
-    uint16_t       ma = ((sigma->ma & 0x3FFF) << 1);
+    uint16_t       cursoraddr = (sigma->crtc[15] | (sigma->crtc[14] << 8));
+    uint16_t       memaddr = ((sigma->memaddr & 0x3FFF) << 1);
     int            drawcursor;
     uint32_t       cols[4];
-    const uint8_t *vram = sigma->vram + (ma << 1);
+    const uint8_t *vram = sigma->vram + (memaddr << 1);
 
-    ca = ca << 1;
+    cursoraddr = cursoraddr << 1;
     if (sigma->sigma_ctl & CTL_CURSOR)
-        ++ca;
-    ca &= 0x3fff;
+        ++cursoraddr;
+    cursoraddr &= 0x3fff;
 
     /* The Sigma 400 seems to use screen widths stated in words
        (40 for 80-column, 20 for 40-column) */
     for (uint32_t x = 0; x < (sigma->crtc[1] << 1); x++) {
         chr        = vram[x << 1];
         attr       = vram[(x << 1) + 1];
-        drawcursor = ((ma == ca) && sigma->cursorvisible && sigma->cursoron);
+        drawcursor = ((memaddr == cursoraddr) && sigma->cursorvisible && sigma->cursoron);
 
         if (!(sigma->sigmamode & MODE_NOBLINK)) {
             cols[1] = (attr & 15) | 16;
@@ -445,22 +445,22 @@ sigma_text80(sigma_t *sigma)
         if (drawcursor) {
             for (uint8_t c = 0; c < 8; c++) {
                 if (sigma->sigmamode & MODE_FONT16)
-                    buffer32->line[sigma->displine][(x << 3) + c + 8] = cols[(fontdatm[chr][sigma->sc & 15] & (1 << (c ^ 7))) ? 1 : 0] ^ 0xf;
+                    buffer32->line[sigma->displine][(x << 3) + c + 8] = cols[(fontdatm[chr][sigma->scanline & 15] & (1 << (c ^ 7))) ? 1 : 0] ^ 0xf;
                 else
-                    buffer32->line[sigma->displine][(x << 3) + c + 8] = cols[(fontdat[chr][sigma->sc & 7] & (1 << (c ^ 7))) ? 1 : 0] ^ 0xf;
+                    buffer32->line[sigma->displine][(x << 3) + c + 8] = cols[(fontdat[chr][sigma->scanline & 7] & (1 << (c ^ 7))) ? 1 : 0] ^ 0xf;
             }
         } else {
             for (uint8_t c = 0; c < 8; c++) {
                 if (sigma->sigmamode & MODE_FONT16)
-                    buffer32->line[sigma->displine][(x << 3) + c + 8] = cols[(fontdatm[chr][sigma->sc & 15] & (1 << (c ^ 7))) ? 1 : 0];
+                    buffer32->line[sigma->displine][(x << 3) + c + 8] = cols[(fontdatm[chr][sigma->scanline & 15] & (1 << (c ^ 7))) ? 1 : 0];
                 else
-                    buffer32->line[sigma->displine][(x << 3) + c + 8] = cols[(fontdat[chr][sigma->sc & 7] & (1 << (c ^ 7))) ? 1 : 0];
+                    buffer32->line[sigma->displine][(x << 3) + c + 8] = cols[(fontdat[chr][sigma->scanline & 7] & (1 << (c ^ 7))) ? 1 : 0];
             }
         }
-        ++ma;
+        ++memaddr;
     }
 
-    sigma->ma += sigma->crtc[1];
+    sigma->memaddr += sigma->crtc[1];
 }
 
 /* Render a line in 40-column text mode */
@@ -469,23 +469,23 @@ sigma_text40(sigma_t *sigma)
 {
     uint8_t        chr;
     uint8_t        attr;
-    uint16_t       ca = (sigma->crtc[15] | (sigma->crtc[14] << 8));
-    uint16_t       ma = ((sigma->ma & 0x3FFF) << 1);
+    uint16_t       cursoraddr = (sigma->crtc[15] | (sigma->crtc[14] << 8));
+    uint16_t       memaddr = ((sigma->memaddr & 0x3FFF) << 1);
     int            drawcursor;
     uint32_t       cols[4];
-    const uint8_t *vram = sigma->vram + ((ma << 1) & 0x3FFF);
+    const uint8_t *vram = sigma->vram + ((memaddr << 1) & 0x3FFF);
 
-    ca = ca << 1;
+    cursoraddr = cursoraddr << 1;
     if (sigma->sigma_ctl & CTL_CURSOR)
-        ++ca;
-    ca &= 0x3fff;
+        ++cursoraddr;
+    cursoraddr &= 0x3fff;
 
     /* The Sigma 400 seems to use screen widths stated in words
        (40 for 80-column, 20 for 40-column) */
     for (uint32_t x = 0; x < (sigma->crtc[1] << 1); x++) {
         chr        = vram[x << 1];
         attr       = vram[(x << 1) + 1];
-        drawcursor = ((ma == ca) && sigma->cursorvisible && sigma->cursoron);
+        drawcursor = ((memaddr == cursoraddr) && sigma->cursorvisible && sigma->cursoron);
 
         if (!(sigma->sigmamode & MODE_NOBLINK)) {
             cols[1] = (attr & 15) | 16;
@@ -499,24 +499,24 @@ sigma_text40(sigma_t *sigma)
 
         if (drawcursor) {
             for (uint8_t c = 0; c < 8; c++) {
-                buffer32->line[sigma->displine][(x << 4) + 2 * c + 8] = buffer32->line[sigma->displine][(x << 4) + 2 * c + 9] = cols[(fontdatm[chr][sigma->sc & 15] & (1 << (c ^ 7))) ? 1 : 0] ^ 0xf;
+                buffer32->line[sigma->displine][(x << 4) + 2 * c + 8] = buffer32->line[sigma->displine][(x << 4) + 2 * c + 9] = cols[(fontdatm[chr][sigma->scanline & 15] & (1 << (c ^ 7))) ? 1 : 0] ^ 0xf;
             }
         } else {
             for (uint8_t c = 0; c < 8; c++) {
-                buffer32->line[sigma->displine][(x << 4) + 2 * c + 8] = buffer32->line[sigma->displine][(x << 4) + 2 * c + 9] = cols[(fontdatm[chr][sigma->sc & 15] & (1 << (c ^ 7))) ? 1 : 0];
+                buffer32->line[sigma->displine][(x << 4) + 2 * c + 8] = buffer32->line[sigma->displine][(x << 4) + 2 * c + 9] = cols[(fontdatm[chr][sigma->scanline & 15] & (1 << (c ^ 7))) ? 1 : 0];
             }
         }
-        ma++;
+        memaddr++;
     }
 
-    sigma->ma += sigma->crtc[1];
+    sigma->memaddr += sigma->crtc[1];
 }
 
 /* Draw a line in the 640x400 graphics mode */
 static void
 sigma_gfx400(sigma_t *sigma)
 {
-    const uint8_t *vram = &sigma->vram[((sigma->ma << 1) & 0x1FFF) + (sigma->sc & 3) * 0x2000];
+    const uint8_t *vram = &sigma->vram[((sigma->memaddr << 1) & 0x1FFF) + (sigma->scanline & 3) * 0x2000];
     uint8_t        plane[4];
     uint8_t        col;
 
@@ -532,7 +532,7 @@ sigma_gfx400(sigma_t *sigma)
             buffer32->line[sigma->displine][(x << 3) + c + 8] = col;
         }
         if (x & 1)
-            ++sigma->ma;
+            ++sigma->memaddr;
     }
 }
 
@@ -544,7 +544,7 @@ sigma_gfx400(sigma_t *sigma)
 static void
 sigma_gfx200(sigma_t *sigma)
 {
-    const uint8_t *vram = &sigma->vram[((sigma->ma << 1) & 0x1FFF) + (sigma->sc & 2) * 0x1000];
+    const uint8_t *vram = &sigma->vram[((sigma->memaddr << 1) & 0x1FFF) + (sigma->scanline & 2) * 0x1000];
     uint8_t        plane[4];
     uint8_t        col;
 
@@ -561,7 +561,7 @@ sigma_gfx200(sigma_t *sigma)
         }
 
         if (x & 1)
-            ++sigma->ma;
+            ++sigma->memaddr;
     }
 }
 
@@ -569,7 +569,7 @@ sigma_gfx200(sigma_t *sigma)
 static void
 sigma_gfx4col(sigma_t *sigma)
 {
-    const uint8_t *vram = &sigma->vram[((sigma->ma << 1) & 0x1FFF) + (sigma->sc & 2) * 0x1000];
+    const uint8_t *vram = &sigma->vram[((sigma->memaddr << 1) & 0x1FFF) + (sigma->scanline & 2) * 0x1000];
     uint8_t        plane[4];
     uint8_t        mask;
     uint8_t        col;
@@ -592,7 +592,7 @@ sigma_gfx4col(sigma_t *sigma)
         }
 
         if (x & 1)
-            ++sigma->ma;
+            ++sigma->memaddr;
     }
 }
 
@@ -604,15 +604,15 @@ sigma_poll(void *priv)
     int      c;
     int      oldvc;
     uint32_t cols[4];
-    int      oldsc;
+    int      scanline_old;
 
     if (!sigma->linepos) {
         timer_advance_u64(&sigma->timer, sigma->dispofftime);
         sigma->sigmastat |= STATUS_RETR_H;
         sigma->linepos = 1;
-        oldsc          = sigma->sc;
+        scanline_old          = sigma->scanline;
         if ((sigma->crtc[8] & 3) == 3)
-            sigma->sc = ((sigma->sc << 1) + sigma->oddeven) & 7;
+            sigma->scanline = ((sigma->scanline << 1) + sigma->oddeven) & 7;
         if (sigma->cgadispon) {
             if (sigma->displine < sigma->firstline) {
                 sigma->firstline = sigma->displine;
@@ -660,8 +660,8 @@ sigma_poll(void *priv)
 
         video_process_8(x, sigma->displine);
 
-        sigma->sc = oldsc;
-        if (sigma->vc == sigma->crtc[7] && !sigma->sc)
+        sigma->scanline = scanline_old;
+        if (sigma->vc == sigma->crtc[7] && !sigma->scanline)
             sigma->sigmastat |= STATUS_RETR_V;
         sigma->displine++;
         if (sigma->displine >= 560)
@@ -674,24 +674,24 @@ sigma_poll(void *priv)
             if (!sigma->vsynctime)
                 sigma->sigmastat &= ~STATUS_RETR_V;
         }
-        if (sigma->sc == (sigma->crtc[11] & 31) || ((sigma->crtc[8] & 3) == 3 && sigma->sc == ((sigma->crtc[11] & 31) >> 1))) {
+        if (sigma->scanline == (sigma->crtc[11] & 31) || ((sigma->crtc[8] & 3) == 3 && sigma->scanline == ((sigma->crtc[11] & 31) >> 1))) {
             sigma->cursorvisible  = 0;
         }
-        if ((sigma->crtc[8] & 3) == 3 && sigma->sc == (sigma->crtc[9] >> 1))
-            sigma->maback = sigma->ma;
+        if ((sigma->crtc[8] & 3) == 3 && sigma->scanline == (sigma->crtc[9] >> 1))
+            sigma->memaddr_backup = sigma->memaddr;
         if (sigma->vadj) {
-            sigma->sc++;
-            sigma->sc &= 31;
-            sigma->ma = sigma->maback;
+            sigma->scanline++;
+            sigma->scanline &= 31;
+            sigma->memaddr = sigma->memaddr_backup;
             sigma->vadj--;
             if (!sigma->vadj) {
                 sigma->cgadispon = 1;
-                sigma->ma = sigma->maback = (sigma->crtc[13] | (sigma->crtc[12] << 8)) & 0x3fff;
-                sigma->sc                 = 0;
+                sigma->memaddr = sigma->memaddr_backup = (sigma->crtc[13] | (sigma->crtc[12] << 8)) & 0x3fff;
+                sigma->scanline                 = 0;
             }
-        } else if (sigma->sc == sigma->crtc[9]) {
-            sigma->maback = sigma->ma;
-            sigma->sc     = 0;
+        } else if (sigma->scanline == sigma->crtc[9]) {
+            sigma->memaddr_backup = sigma->memaddr;
+            sigma->scanline     = 0;
             oldvc         = sigma->vc;
             sigma->vc++;
             sigma->vc &= 127;
@@ -705,7 +705,7 @@ sigma_poll(void *priv)
                 if (!sigma->vadj)
                     sigma->cgadispon = 1;
                 if (!sigma->vadj)
-                    sigma->ma = sigma->maback = (sigma->crtc[13] | (sigma->crtc[12] << 8)) & 0x3fff;
+                    sigma->memaddr = sigma->memaddr_backup = (sigma->crtc[13] | (sigma->crtc[12] << 8)) & 0x3fff;
                 if ((sigma->crtc[10] & 0x60) == 0x20)
                     sigma->cursoron = 0;
                 else
@@ -768,13 +768,13 @@ sigma_poll(void *priv)
                 sigma->oddeven ^= 1;
             }
         } else {
-            sigma->sc++;
-            sigma->sc &= 31;
-            sigma->ma = sigma->maback;
+            sigma->scanline++;
+            sigma->scanline &= 31;
+            sigma->memaddr = sigma->memaddr_backup;
         }
         if (sigma->cgadispon)
             sigma->sigmastat &= ~STATUS_RETR_H;
-        if (sigma->sc == (sigma->crtc[10] & 31) || ((sigma->crtc[8] & 3) == 3 && sigma->sc == ((sigma->crtc[10] & 31) >> 1)))
+        if (sigma->scanline == (sigma->crtc[10] & 31) || ((sigma->crtc[8] & 3) == 3 && sigma->scanline == ((sigma->crtc[10] & 31) >> 1)))
             sigma->cursorvisible = 1;
     }
 }

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -754,7 +754,7 @@ svga_recalctimings(svga_t *svga)
 
     svga->interlace = 0;
 
-    svga->ma_latch = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
+    svga->memaddr_latch = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
     svga->ca_adj   = 0;
 
     svga->rowcount = svga->crtc[9] & 0x1f;
@@ -1283,17 +1283,17 @@ svga_poll(void *priv)
         if (svga->dispon) {
             svga->hdisp_on = 1;
 
-            svga->ma &= svga->vram_display_mask;
+            svga->memaddr &= svga->vram_display_mask;
             if (svga->firstline == 2000) {
                 svga->firstline = svga->displine;
                 video_wait_for_buffer_monitor(svga->monitor_index);
             }
 
             if (svga->hwcursor_on || svga->dac_hwcursor_on || svga->overlay_on)
-                svga->changedvram[svga->ma >> 12] = svga->changedvram[(svga->ma >> 12) + 1] = svga->interlace ? 3 : 2;
+                svga->changedvram[svga->memaddr >> 12] = svga->changedvram[(svga->memaddr >> 12) + 1] = svga->interlace ? 3 : 2;
 
             if (svga->vertical_linedbl) {
-                old_ma = svga->ma;
+                old_ma = svga->memaddr;
 
                 svga->displine <<= 1;
                 svga->y_add <<= 1;
@@ -1302,7 +1302,7 @@ svga_poll(void *priv)
 
                 svga->displine++;
 
-                svga->ma = old_ma;
+                svga->memaddr = old_ma;
 
                 svga_do_render(svga);
 
@@ -1331,29 +1331,29 @@ svga_poll(void *priv)
         svga->hdisp_on = 0;
 
         svga->linepos = 0;
-        if ((svga->sc == (svga->crtc[11] & 31)) || (svga->sc == svga->rowcount))
+        if ((svga->scanline == (svga->crtc[11] & 31)) || (svga->scanline == svga->rowcount))
             svga->cursorvisible = 0;
         if (svga->dispon) {
             /* TODO: Verify real hardware behaviour for out-of-range fine vertical scroll
-               - S3 Trio64V2/DX: sc == rowcount, wrapping 5-bit counter. */
+               - S3 Trio64V2/DX: scanline == rowcount, wrapping 5-bit counter. */
             if (svga->linedbl && !svga->linecountff) {
                 svga->linecountff = 1;
-                svga->ma          = svga->maback;
-            } else if (svga->sc == svga->rowcount) {
+                svga->memaddr          = svga->memaddr_backup;
+            } else if (svga->scanline == svga->rowcount) {
                 svga->linecountff = 0;
-                svga->sc          = 0;
+                svga->scanline          = 0;
 
-                svga->maback += (svga->adv_flags & FLAG_NO_SHIFT3) ? svga->rowoffset : (svga->rowoffset << 3);
+                svga->memaddr_backup += (svga->adv_flags & FLAG_NO_SHIFT3) ? svga->rowoffset : (svga->rowoffset << 3);
                 if (svga->interlace)
-                    svga->maback += (svga->adv_flags & FLAG_NO_SHIFT3) ? svga->rowoffset : (svga->rowoffset << 3);
+                    svga->memaddr_backup += (svga->adv_flags & FLAG_NO_SHIFT3) ? svga->rowoffset : (svga->rowoffset << 3);
 
-                svga->maback &= svga->vram_display_mask;
-                svga->ma = svga->maback;
+                svga->memaddr_backup &= svga->vram_display_mask;
+                svga->memaddr = svga->memaddr_backup;
             } else {
                 svga->linecountff = 0;
-                svga->sc++;
-                svga->sc &= 0x1f;
-                svga->ma = svga->maback;
+                svga->scanline++;
+                svga->scanline &= 0x1f;
+                svga->memaddr = svga->memaddr_backup;
             }
         }
 
@@ -1373,14 +1373,14 @@ svga_poll(void *priv)
 
             if (ret) {
                 if (svga->interlace && svga->oddeven)
-                    svga->ma = svga->maback = (svga->rowoffset << 1) + svga->hblank_sub;
+                    svga->memaddr = svga->memaddr_backup = (svga->rowoffset << 1) + svga->hblank_sub;
                 else
-                    svga->ma = svga->maback = svga->hblank_sub;
+                    svga->memaddr = svga->memaddr_backup = svga->hblank_sub;
 
-                svga->ma     = (svga->ma << 2);
-                svga->maback = (svga->maback << 2);
+                svga->memaddr     = (svga->memaddr << 2);
+                svga->memaddr_backup = (svga->memaddr_backup << 2);
 
-                svga->sc = 0;
+                svga->scanline = 0;
                 if (svga->attrregs[0x10] & 0x20) {
                     svga->scrollcache = 0;
                     svga->x_add       = svga->left_overscan;
@@ -1449,16 +1449,16 @@ svga_poll(void *priv)
             svga->vslines                       = 0;
 
             if (svga->interlace && svga->oddeven)
-                svga->ma = svga->maback = svga->ma_latch + (svga->rowoffset << 1) + svga->hblank_sub;
+                svga->memaddr = svga->memaddr_backup = svga->memaddr_latch + (svga->rowoffset << 1) + svga->hblank_sub;
             else
-                svga->ma = svga->maback = svga->ma_latch + svga->hblank_sub;
+                svga->memaddr = svga->memaddr_backup = svga->memaddr_latch + svga->hblank_sub;
 
-            svga->ca     = ((svga->crtc[0xe] << 8) | svga->crtc[0xf]) + ((svga->crtc[0xb] & 0x60) >> 5) + svga->ca_adj;
+            svga->cursoraddr     = ((svga->crtc[0xe] << 8) | svga->crtc[0xf]) + ((svga->crtc[0xb] & 0x60) >> 5) + svga->ca_adj;
             if (!(svga->adv_flags & FLAG_NO_SHIFT3)) {
-                svga->ma     = (svga->ma << 2);
-                svga->maback = (svga->maback << 2);
+                svga->memaddr     = (svga->memaddr << 2);
+                svga->memaddr_backup = (svga->memaddr_backup << 2);
             }
-            svga->ca     = (svga->ca << 2);
+            svga->cursoraddr     = (svga->cursoraddr << 2);
 
             if (svga->vsync_callback)
                 svga->vsync_callback(svga);
@@ -1468,7 +1468,7 @@ svga_poll(void *priv)
 #endif
         if (svga->vc == svga->vtotal) {
             svga->vc       = 0;
-            svga->sc       = (svga->crtc[0x8] & 0x1f);
+            svga->scanline       = (svga->crtc[0x8] & 0x1f);
             svga->dispon   = 1;
             svga->displine = (svga->interlace && svga->oddeven) ? 1 : 0;
 
@@ -1502,7 +1502,7 @@ svga_poll(void *priv)
             svga->overlay_on    = 0;
             svga->overlay_latch = svga->overlay;
         }
-        if (svga->sc == (svga->crtc[10] & 31))
+        if (svga->scanline == (svga->crtc[10] & 31))
             svga->cursorvisible = 1;
     }
 }

--- a/src/video/vid_svga_render.c
+++ b/src/video/vid_svga_render.c
@@ -156,13 +156,13 @@ svga_render_text_40(svga_t *svga)
 
         for (int x = 0; x < (svga->hdisp + svga->scrollcache); x += xinc) {
             if (!svga->force_old_addr)
-                addr = svga->remap_func(svga, svga->ma) & svga->vram_display_mask;
+                addr = svga->remap_func(svga, svga->memaddr) & svga->vram_display_mask;
 
-            drawcursor = ((svga->ma == svga->ca) && svga->cursorvisible && svga->cursoron);
+            drawcursor = ((svga->memaddr == svga->cursoraddr) && svga->cursorvisible && svga->cursoron);
 
             if (svga->force_old_addr) {
-                chr  = svga->vram[(svga->ma << 1) & svga->vram_display_mask];
-                attr = svga->vram[((svga->ma << 1) + 1) & svga->vram_display_mask];
+                chr  = svga->vram[(svga->memaddr << 1) & svga->vram_display_mask];
+                attr = svga->vram[((svga->memaddr << 1) + 1) & svga->vram_display_mask];
             } else {
                 chr  = svga->vram[addr];
                 attr = svga->vram[addr + 1];
@@ -187,7 +187,7 @@ svga_render_text_40(svga_t *svga)
                 }
             }
 
-            dat = svga->vram[charaddr + (svga->sc << 2)];
+            dat = svga->vram[charaddr + (svga->scanline << 2)];
             if (svga->seqregs[1] & 1) {
                 for (xx = 0; xx < 16; xx += 2)
                     p[xx] = p[xx + 1] = (dat & (0x80 >> (xx >> 1))) ? fg : bg;
@@ -199,10 +199,10 @@ svga_render_text_40(svga_t *svga)
                 else
                     p[16] = p[17] = (dat & 1) ? fg : bg;
             }
-            svga->ma += 4;
+            svga->memaddr += 4;
             p += xinc;
         }
-        svga->ma &= svga->vram_display_mask;
+        svga->memaddr &= svga->vram_display_mask;
     }
 }
 
@@ -239,13 +239,13 @@ svga_render_text_80(svga_t *svga)
 
         for (int x = 0; x < (svga->hdisp + svga->scrollcache); x += xinc) {
             if (!svga->force_old_addr)
-                addr = svga->remap_func(svga, svga->ma) & svga->vram_display_mask;
+                addr = svga->remap_func(svga, svga->memaddr) & svga->vram_display_mask;
 
-            drawcursor = ((svga->ma == svga->ca) && svga->cursorvisible && svga->cursoron);
+            drawcursor = ((svga->memaddr == svga->cursoraddr) && svga->cursorvisible && svga->cursoron);
 
             if (svga->force_old_addr) {
-                chr  = svga->vram[(svga->ma << 1) & svga->vram_display_mask];
-                attr = svga->vram[((svga->ma << 1) + 1) & svga->vram_display_mask];
+                chr  = svga->vram[(svga->memaddr << 1) & svga->vram_display_mask];
+                attr = svga->vram[((svga->memaddr << 1) + 1) & svga->vram_display_mask];
             } else {
                 chr  = svga->vram[addr];
                 attr = svga->vram[addr + 1];
@@ -269,7 +269,7 @@ svga_render_text_80(svga_t *svga)
                 }
             }
 
-            dat = svga->vram[charaddr + (svga->sc << 2)];
+            dat = svga->vram[charaddr + (svga->scanline << 2)];
             if (svga->seqregs[1] & 1) {
                 for (xx = 0; xx < 8; xx++)
                     p[xx] = (dat & (0x80 >> xx)) ? fg : bg;
@@ -281,10 +281,10 @@ svga_render_text_80(svga_t *svga)
                 else
                     p[8] = (dat & 1) ? fg : bg;
             }
-            svga->ma += 4;
+            svga->memaddr += 4;
             p += xinc;
         }
-        svga->ma &= svga->vram_display_mask;
+        svga->memaddr &= svga->vram_display_mask;
     }
 }
 
@@ -317,8 +317,8 @@ svga_render_text_80_ksc5601(svga_t *svga)
         xinc = (svga->seqregs[1] & 1) ? 8 : 9;
 
         for (int x = 0; x < (svga->hdisp + svga->scrollcache); x += xinc) {
-            uint32_t addr = svga->remap_func(svga, svga->ma) & svga->vram_display_mask;
-            drawcursor    = ((svga->ma == svga->ca) && svga->cursorvisible && svga->cursoron);
+            uint32_t addr = svga->remap_func(svga, svga->memaddr) & svga->vram_display_mask;
+            drawcursor    = ((svga->memaddr == svga->cursoraddr) && svga->cursorvisible && svga->cursoron);
             chr           = svga->vram[addr];
             nextchr       = svga->vram[addr + 8];
             attr          = svga->vram[addr + 1];
@@ -338,7 +338,7 @@ svga_render_text_80_ksc5601(svga_t *svga)
 
             if ((x + xinc) < svga->hdisp && (chr & (nextchr | svga->ksc5601_sbyte_mask) & 0x80)) {
                 if ((chr == svga->ksc5601_udc_area_msb[0] || chr == svga->ksc5601_udc_area_msb[1]) && (nextchr > 0xa0 && nextchr < 0xff))
-                    dat = fontdatksc5601_user[(chr == svga->ksc5601_udc_area_msb[1] ? 96 : 0) + (nextchr & 0x7F) - 0x20].chr[svga->sc];
+                    dat = fontdatksc5601_user[(chr == svga->ksc5601_udc_area_msb[1] ? 96 : 0) + (nextchr & 0x7F) - 0x20].chr[svga->scanline];
                 else if (nextchr & 0x80) {
                     if (svga->ksc5601_swap_mode == 1 && (nextchr > 0xa0 && nextchr < 0xff)) {
                         if (chr >= 0x80 && chr < 0x99)
@@ -346,7 +346,7 @@ svga_render_text_80_ksc5601(svga_t *svga)
                         else if (chr >= 0xB0 && chr < 0xC9)
                             chr -= 0x30;
                     }
-                    dat = fontdatksc5601[((chr & 0x7F) << 7) | (nextchr & 0x7F)].chr[svga->sc];
+                    dat = fontdatksc5601[((chr & 0x7F) << 7) | (nextchr & 0x7F)].chr[svga->scanline];
                 } else
                     dat = 0xff;
             } else {
@@ -356,9 +356,9 @@ svga_render_text_80_ksc5601(svga_t *svga)
                     charaddr = svga->charseta + (chr * 128);
 
                 if ((svga->ksc5601_english_font_type >> 8) == 1)
-                    dat = fontdatksc5601[((svga->ksc5601_english_font_type & 0x7F) << 7) | (chr >> 1)].chr[((chr & 1) << 4) | svga->sc];
+                    dat = fontdatksc5601[((svga->ksc5601_english_font_type & 0x7F) << 7) | (chr >> 1)].chr[((chr & 1) << 4) | svga->scanline];
                 else
-                    dat = svga->vram[charaddr + (svga->sc << 2)];
+                    dat = svga->vram[charaddr + (svga->scanline << 2)];
             }
 
             if (svga->seqregs[1] & 1) {
@@ -372,11 +372,11 @@ svga_render_text_80_ksc5601(svga_t *svga)
                 else
                     p[8] = (dat & 1) ? fg : bg;
             }
-            svga->ma += 4;
+            svga->memaddr += 4;
             p += xinc;
 
             if ((x + xinc) < svga->hdisp && (chr & (nextchr | svga->ksc5601_sbyte_mask) & 0x80)) {
-                attr = svga->vram[((svga->ma << 1) + 1) & svga->vram_display_mask];
+                attr = svga->vram[((svga->memaddr << 1) + 1) & svga->vram_display_mask];
 
                 if (drawcursor) {
                     bg = svga->pallook[svga->egapal[attr & 15] & svga->dac_mask];
@@ -392,9 +392,9 @@ svga_render_text_80_ksc5601(svga_t *svga)
                 }
 
                 if ((chr == svga->ksc5601_udc_area_msb[0] || chr == svga->ksc5601_udc_area_msb[1]) && (nextchr > 0xa0 && nextchr < 0xff))
-                    dat = fontdatksc5601_user[(chr == svga->ksc5601_udc_area_msb[1] ? 96 : 0) + (nextchr & 0x7F) - 0x20].chr[svga->sc + 16];
+                    dat = fontdatksc5601_user[(chr == svga->ksc5601_udc_area_msb[1] ? 96 : 0) + (nextchr & 0x7F) - 0x20].chr[svga->scanline + 16];
                 else if (nextchr & 0x80)
-                    dat = fontdatksc5601[((chr & 0x7f) << 7) | (nextchr & 0x7F)].chr[svga->sc + 16];
+                    dat = fontdatksc5601[((chr & 0x7f) << 7) | (nextchr & 0x7F)].chr[svga->scanline + 16];
                 else
                     dat = 0xff;
 
@@ -410,12 +410,12 @@ svga_render_text_80_ksc5601(svga_t *svga)
                         p[8] = (dat & 1) ? fg : bg;
                 }
 
-                svga->ma += 4;
+                svga->memaddr += 4;
                 p += xinc;
                 x += xinc;
             }
         }
-        svga->ma &= svga->vram_display_mask;
+        svga->memaddr &= svga->vram_display_mask;
     }
 }
 
@@ -433,7 +433,7 @@ svga_render_2bpp_s3_lowres(svga_t *svga)
         return;
 
     if (svga->force_old_addr) {
-        changed_offset = ((svga->ma << 1) + (svga->sc & ~svga->crtc[0x17] & 3) * 0x8000) >> 12;
+        changed_offset = ((svga->memaddr << 1) + (svga->scanline & ~svga->crtc[0x17] & 3) * 0x8000) >> 12;
 
         if (svga->changedvram[changed_offset] || svga->changedvram[changed_offset + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
@@ -443,32 +443,32 @@ svga_render_2bpp_s3_lowres(svga_t *svga)
             svga->lastline_draw = svga->displine;
 
             for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 16) {
-                addr = svga->ma;
+                addr = svga->memaddr;
 
                 if (!(svga->crtc[0x17] & 0x40)) {
                     addr = (addr << 1) & svga->vram_mask;
                     addr &= ~7;
 
-                    if ((svga->crtc[0x17] & 0x20) && (svga->ma & 0x20000))
+                    if ((svga->crtc[0x17] & 0x20) && (svga->memaddr & 0x20000))
                         addr |= 4;
 
-                    if (!(svga->crtc[0x17] & 0x20) && (svga->ma & 0x8000))
+                    if (!(svga->crtc[0x17] & 0x20) && (svga->memaddr & 0x8000))
                         addr |= 4;
                 }
 
                 if (!(svga->crtc[0x17] & 0x01))
-                    addr = (addr & ~0x8000) | ((svga->sc & 1) ? 0x8000 : 0);
+                    addr = (addr & ~0x8000) | ((svga->scanline & 1) ? 0x8000 : 0);
 
                 if (!(svga->crtc[0x17] & 0x02))
-                    addr = (addr & ~0x10000) | ((svga->sc & 2) ? 0x10000 : 0);
+                    addr = (addr & ~0x10000) | ((svga->scanline & 2) ? 0x10000 : 0);
 
                 dat[0] = svga->vram[addr];
                 dat[1] = svga->vram[addr | 0x1];
                 if (svga->seqregs[1] & 4)
-                    svga->ma += 2;
+                    svga->memaddr += 2;
                 else
-                    svga->ma += 4;
-                svga->ma &= svga->vram_mask;
+                    svga->memaddr += 4;
+                svga->memaddr &= svga->vram_mask;
                 p[0] = p[1] = svga->pallook[svga->egapal[(dat[0] >> 6) & 3] & svga->dac_mask];
                 p[2] = p[3] = svga->pallook[svga->egapal[(dat[0] >> 4) & 3] & svga->dac_mask];
                 p[4] = p[5] = svga->pallook[svga->egapal[(dat[0] >> 2) & 3] & svga->dac_mask];
@@ -481,7 +481,7 @@ svga_render_2bpp_s3_lowres(svga_t *svga)
             }
         }
     } else {
-        changed_addr = svga->remap_func(svga, svga->ma);
+        changed_addr = svga->remap_func(svga, svga->memaddr);
 
         if (svga->changedvram[changed_addr >> 12] || svga->changedvram[(changed_addr >> 12) + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
@@ -491,16 +491,16 @@ svga_render_2bpp_s3_lowres(svga_t *svga)
             svga->lastline_draw = svga->displine;
 
             for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 16) {
-                addr = svga->remap_func(svga, svga->ma);
+                addr = svga->remap_func(svga, svga->memaddr);
 
                 dat[0] = svga->vram[addr];
                 dat[1] = svga->vram[addr | 0x1];
                 if (svga->seqregs[1] & 4)
-                    svga->ma += 2;
+                    svga->memaddr += 2;
                 else
-                    svga->ma += 4;
+                    svga->memaddr += 4;
 
-                svga->ma &= svga->vram_mask;
+                svga->memaddr &= svga->vram_mask;
 
                 p[0] = p[1] = svga->pallook[svga->egapal[(dat[0] >> 6) & 3] & svga->dac_mask];
                 p[2] = p[3] = svga->pallook[svga->egapal[(dat[0] >> 4) & 3] & svga->dac_mask];
@@ -531,7 +531,7 @@ svga_render_2bpp_s3_highres(svga_t *svga)
         return;
 
     if (svga->force_old_addr) {
-        changed_offset = ((svga->ma << 1) + (svga->sc & ~svga->crtc[0x17] & 3) * 0x8000) >> 12;
+        changed_offset = ((svga->memaddr << 1) + (svga->scanline & ~svga->crtc[0x17] & 3) * 0x8000) >> 12;
 
         if (svga->changedvram[changed_offset] || svga->changedvram[changed_offset + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
@@ -541,32 +541,32 @@ svga_render_2bpp_s3_highres(svga_t *svga)
             svga->lastline_draw = svga->displine;
 
             for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 8) {
-                addr = svga->ma;
+                addr = svga->memaddr;
 
                 if (!(svga->crtc[0x17] & 0x40)) {
                     addr = (addr << 1) & svga->vram_mask;
                     addr &= ~7;
 
-                    if ((svga->crtc[0x17] & 0x20) && (svga->ma & 0x20000))
+                    if ((svga->crtc[0x17] & 0x20) && (svga->memaddr & 0x20000))
                         addr |= 4;
 
-                    if (!(svga->crtc[0x17] & 0x20) && (svga->ma & 0x8000))
+                    if (!(svga->crtc[0x17] & 0x20) && (svga->memaddr & 0x8000))
                         addr |= 4;
                 }
 
                 if (!(svga->crtc[0x17] & 0x01))
-                    addr = (addr & ~0x8000) | ((svga->sc & 1) ? 0x8000 : 0);
+                    addr = (addr & ~0x8000) | ((svga->scanline & 1) ? 0x8000 : 0);
 
                 if (!(svga->crtc[0x17] & 0x02))
-                    addr = (addr & ~0x10000) | ((svga->sc & 2) ? 0x10000 : 0);
+                    addr = (addr & ~0x10000) | ((svga->scanline & 2) ? 0x10000 : 0);
 
                 dat[0] = svga->vram[addr];
                 dat[1] = svga->vram[addr | 0x1];
                 if (svga->seqregs[1] & 4)
-                    svga->ma += 2;
+                    svga->memaddr += 2;
                 else
-                    svga->ma += 4;
-                svga->ma &= svga->vram_mask;
+                    svga->memaddr += 4;
+                svga->memaddr &= svga->vram_mask;
                 p[0] = svga->pallook[svga->egapal[(dat[0] >> 6) & 3] & svga->dac_mask];
                 p[1] = svga->pallook[svga->egapal[(dat[0] >> 4) & 3] & svga->dac_mask];
                 p[2] = svga->pallook[svga->egapal[(dat[0] >> 2) & 3] & svga->dac_mask];
@@ -579,7 +579,7 @@ svga_render_2bpp_s3_highres(svga_t *svga)
             }
         }
     } else {
-        changed_addr = svga->remap_func(svga, svga->ma);
+        changed_addr = svga->remap_func(svga, svga->memaddr);
 
         if (svga->changedvram[changed_addr >> 12] || svga->changedvram[(changed_addr >> 12) + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
@@ -589,16 +589,16 @@ svga_render_2bpp_s3_highres(svga_t *svga)
             svga->lastline_draw = svga->displine;
 
             for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 8) {
-                addr = svga->remap_func(svga, svga->ma);
+                addr = svga->remap_func(svga, svga->memaddr);
 
                 dat[0] = svga->vram[addr];
                 dat[1] = svga->vram[addr | 0x1];
                 if (svga->seqregs[1] & 4)
-                    svga->ma += 2;
+                    svga->memaddr += 2;
                 else
-                    svga->ma += 4;
+                    svga->memaddr += 4;
 
-                svga->ma &= svga->vram_mask;
+                svga->memaddr &= svga->vram_mask;
 
                 p[0] = svga->pallook[svga->egapal[(dat[0] >> 6) & 3] & svga->dac_mask];
                 p[1] = svga->pallook[svga->egapal[(dat[0] >> 4) & 3] & svga->dac_mask];
@@ -628,7 +628,7 @@ svga_render_2bpp_headland_highres(svga_t *svga)
     if ((svga->displine + svga->y_add) < 0)
         return;
 
-    changed_addr = svga->remap_func(svga, svga->ma);
+    changed_addr = svga->remap_func(svga, svga->memaddr);
 
     if (svga->changedvram[changed_addr >> 12] || svga->changedvram[(changed_addr >> 12) + 1] || svga->fullchange) {
         p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
@@ -638,7 +638,7 @@ svga_render_2bpp_headland_highres(svga_t *svga)
         svga->lastline_draw = svga->displine;
 
         for (int x = 0; x <= (svga->hdisp + svga->scrollcache); x += 8) {
-            addr    = svga->remap_func(svga, svga->ma);
+            addr    = svga->remap_func(svga, svga->memaddr);
             oddeven = 0;
 
             if (svga->seqregs[1] & 4) {
@@ -649,8 +649,8 @@ svga_render_2bpp_headland_highres(svga_t *svga)
             } else {
                 *(uint32_t *) (&edat[0]) = *(uint32_t *) (&svga->vram[addr]);
             }
-            svga->ma += 4;
-            svga->ma &= svga->vram_mask;
+            svga->memaddr += 4;
+            svga->memaddr &= svga->vram_mask;
 
             dat  = edatlookup[edat[0] >> 6][edat[1] >> 6] | (edatlookup[edat[2] >> 6][edat[3] >> 6] << 2);
             p[0] = svga->pallook[svga->egapal[(dat >> 4) & svga->plane_mask] & svga->dac_mask];
@@ -736,9 +736,9 @@ svga_render_indexed_gfx(svga_t *svga, bool highres, bool combine8bits)
         return;
 
     if (svga->force_old_addr)
-        changed_offset = (svga->ma + (svga->sc & ~svga->crtc[0x17] & 3) * 0x8000) >> 12;
+        changed_offset = (svga->memaddr + (svga->scanline & ~svga->crtc[0x17] & 3) * 0x8000) >> 12;
     else
-        changed_offset = svga->remap_func(svga, svga->ma) >> 12;
+        changed_offset = svga->remap_func(svga, svga->memaddr) >> 12;
 
     if (!(svga->changedvram[changed_offset] || svga->changedvram[changed_offset + 1] || svga->fullchange))
         return;
@@ -755,19 +755,19 @@ svga_render_indexed_gfx(svga_t *svga, bool highres, bool combine8bits)
         if (load_counter == 0) {
             /* Find our address */
             if (svga->force_old_addr) {
-                addr = ((svga->ma & ~0x3) << incbypow2);
+                addr = ((svga->memaddr & ~0x3) << incbypow2);
 
                 if (incbypow2 == 2) {
-                    if (svga->ma & (4 << 15))
+                    if (svga->memaddr & (4 << 15))
                         addr |= 0x8;
-                    if (svga->ma & (4 << 14))
+                    if (svga->memaddr & (4 << 14))
                         addr |= 0x4;
                 } else if (incbypow2 == 1) {
                     if ((svga->crtc[0x17] & 0x20)) {
-                        if (svga->ma & (4 << 15))
+                        if (svga->memaddr & (4 << 15))
                             addr |= 0x4;
                     } else {
-                        if (svga->ma & (4 << 13))
+                        if (svga->memaddr & (4 << 13))
                             addr |= 0x4;
                     }
                 } else {
@@ -775,13 +775,13 @@ svga_render_indexed_gfx(svga_t *svga, bool highres, bool combine8bits)
                 }
 
                 if (!(svga->crtc[0x17] & 0x01))
-                    addr = (addr & ~0x8000) | ((svga->sc & 1) ? 0x8000 : 0);
+                    addr = (addr & ~0x8000) | ((svga->scanline & 1) ? 0x8000 : 0);
                 if (!(svga->crtc[0x17] & 0x02))
-                    addr = (addr & ~0x10000) | ((svga->sc & 2) ? 0x10000 : 0);
+                    addr = (addr & ~0x10000) | ((svga->scanline & 2) ? 0x10000 : 0);
             } else if (svga->remap_required)
-                addr = svga->remap_func(svga, svga->ma);
+                addr = svga->remap_func(svga, svga->memaddr);
             else
-                addr = svga->ma;
+                addr = svga->memaddr;
 
             addr &= svga->vram_display_mask;
 
@@ -819,9 +819,9 @@ svga_render_indexed_gfx(svga_t *svga, bool highres, bool combine8bits)
         incr_counter += 1;
         if (incr_counter >= incevery) {
             incr_counter = 0;
-            svga->ma += 4;
+            svga->memaddr += 4;
             /* DISCREPANCY TODO FIXME 2/4bpp used vram_mask, 8bpp used vram_display_mask --GM */
-            svga->ma &= svga->vram_display_mask;
+            svga->memaddr &= svga->vram_display_mask;
         }
 
         uint32_t current_shift = shift_values;
@@ -926,7 +926,7 @@ svga_render_8bpp_clone_highres(svga_t *svga)
         return;
 
     if (svga->force_old_addr) {
-        if (svga->changedvram[svga->ma >> 12] || svga->changedvram[(svga->ma >> 12) + 1] || svga->fullchange) {
+        if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
 
             if (svga->firstline_draw == 2000)
@@ -934,25 +934,25 @@ svga_render_8bpp_clone_highres(svga_t *svga)
             svga->lastline_draw = svga->displine;
 
             for (x = 0; x <= (svga->hdisp /* + svga->scrollcache*/); x += 8) {
-                dat  = *(uint32_t *) (&svga->vram[svga->ma & svga->vram_display_mask]);
+                dat  = *(uint32_t *) (&svga->vram[svga->memaddr & svga->vram_display_mask]);
                 p[0] = svga->map8[dat & svga->dac_mask & 0xff];
                 p[1] = svga->map8[(dat >> 8) & svga->dac_mask & 0xff];
                 p[2] = svga->map8[(dat >> 16) & svga->dac_mask & 0xff];
                 p[3] = svga->map8[(dat >> 24) & svga->dac_mask & 0xff];
 
-                dat  = *(uint32_t *) (&svga->vram[(svga->ma + 4) & svga->vram_display_mask]);
+                dat  = *(uint32_t *) (&svga->vram[(svga->memaddr + 4) & svga->vram_display_mask]);
                 p[4] = svga->map8[dat & svga->dac_mask & 0xff];
                 p[5] = svga->map8[(dat >> 8) & svga->dac_mask & 0xff];
                 p[6] = svga->map8[(dat >> 16) & svga->dac_mask & 0xff];
                 p[7] = svga->map8[(dat >> 24) & svga->dac_mask & 0xff];
 
-                svga->ma += 8;
+                svga->memaddr += 8;
                 p += 8;
             }
-            svga->ma &= svga->vram_display_mask;
+            svga->memaddr &= svga->vram_display_mask;
         }
     } else {
-        changed_addr = svga->remap_func(svga, svga->ma);
+        changed_addr = svga->remap_func(svga, svga->memaddr);
 
         if (svga->changedvram[changed_addr >> 12] || svga->changedvram[(changed_addr >> 12) + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
@@ -963,35 +963,35 @@ svga_render_8bpp_clone_highres(svga_t *svga)
 
             if (!svga->remap_required) {
                 for (x = 0; x <= (svga->hdisp /* + svga->scrollcache*/); x += 8) {
-                    dat  = *(uint32_t *) (&svga->vram[svga->ma & svga->vram_display_mask]);
+                    dat  = *(uint32_t *) (&svga->vram[svga->memaddr & svga->vram_display_mask]);
                     p[0] = svga->map8[dat & svga->dac_mask & 0xff];
                     p[1] = svga->map8[(dat >> 8) & svga->dac_mask & 0xff];
                     p[2] = svga->map8[(dat >> 16) & svga->dac_mask & 0xff];
                     p[3] = svga->map8[(dat >> 24) & svga->dac_mask & 0xff];
 
-                    dat  = *(uint32_t *) (&svga->vram[(svga->ma + 4) & svga->vram_display_mask]);
+                    dat  = *(uint32_t *) (&svga->vram[(svga->memaddr + 4) & svga->vram_display_mask]);
                     p[4] = svga->map8[dat & svga->dac_mask & 0xff];
                     p[5] = svga->map8[(dat >> 8) & svga->dac_mask & 0xff];
                     p[6] = svga->map8[(dat >> 16) & svga->dac_mask & 0xff];
                     p[7] = svga->map8[(dat >> 24) & svga->dac_mask & 0xff];
 
-                    svga->ma += 8;
+                    svga->memaddr += 8;
                     p += 8;
                 }
             } else {
                 for (x = 0; x <= (svga->hdisp /* + svga->scrollcache*/); x += 4) {
-                    addr = svga->remap_func(svga, svga->ma);
+                    addr = svga->remap_func(svga, svga->memaddr);
                     dat  = *(uint32_t *) (&svga->vram[addr & svga->vram_display_mask]);
                     p[0] = svga->map8[dat & svga->dac_mask & 0xff];
                     p[1] = svga->map8[(dat >> 8) & svga->dac_mask & 0xff];
                     p[2] = svga->map8[(dat >> 16) & svga->dac_mask & 0xff];
                     p[3] = svga->map8[(dat >> 24) & svga->dac_mask & 0xff];
 
-                    svga->ma += 4;
+                    svga->memaddr += 4;
                     p += 4;
                 }
             }
-            svga->ma &= svga->vram_display_mask;
+            svga->memaddr &= svga->vram_display_mask;
         }
     }
 }
@@ -1011,7 +1011,7 @@ svga_render_8bpp_lowres(svga_t *svga)
         return;
 
     if (svga->force_old_addr) {
-        if (svga->changedvram[svga->ma >> 12] || svga->changedvram[(svga->ma >> 12) + 1] || svga->fullchange) {
+        if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
 
             if (svga->firstline_draw == 2000)
@@ -1019,20 +1019,20 @@ svga_render_8bpp_lowres(svga_t *svga)
             svga->lastline_draw = svga->displine;
 
             for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 8) {
-                dat = *(uint32_t *) (&svga->vram[svga->ma & svga->vram_display_mask]);
+                dat = *(uint32_t *) (&svga->vram[svga->memaddr & svga->vram_display_mask]);
 
                 p[0] = p[1] = svga->map8[dat & 0xff];
                 p[2] = p[3] = svga->map8[(dat >> 8) & 0xff];
                 p[4] = p[5] = svga->map8[(dat >> 16) & 0xff];
                 p[6] = p[7] = svga->map8[(dat >> 24) & 0xff];
 
-                svga->ma += 4;
+                svga->memaddr += 4;
                 p += 8;
             }
-            svga->ma &= svga->vram_display_mask;
+            svga->memaddr &= svga->vram_display_mask;
         }
     } else {
-        changed_addr = svga->remap_func(svga, svga->ma);
+        changed_addr = svga->remap_func(svga, svga->memaddr);
 
         if (svga->changedvram[changed_addr >> 12] || svga->changedvram[(changed_addr >> 12) + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
@@ -1043,29 +1043,29 @@ svga_render_8bpp_lowres(svga_t *svga)
 
             if (!svga->remap_required) {
                 for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 8) {
-                    dat  = *(uint32_t *) (&svga->vram[svga->ma & svga->vram_display_mask]);
+                    dat  = *(uint32_t *) (&svga->vram[svga->memaddr & svga->vram_display_mask]);
                     p[0] = p[1] = svga->map8[dat & svga->dac_mask & 0xff];
                     p[2] = p[3] = svga->map8[(dat >> 8) & svga->dac_mask & 0xff];
                     p[4] = p[5] = svga->map8[(dat >> 16) & svga->dac_mask & 0xff];
                     p[6] = p[7] = svga->map8[(dat >> 24) & svga->dac_mask & 0xff];
 
-                    svga->ma += 4;
+                    svga->memaddr += 4;
                     p += 8;
                 }
             } else {
                 for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 8) {
-                    addr = svga->remap_func(svga, svga->ma);
+                    addr = svga->remap_func(svga, svga->memaddr);
                     dat  = *(uint32_t *) (&svga->vram[addr & svga->vram_display_mask]);
                     p[0] = p[1] = svga->map8[dat & svga->dac_mask & 0xff];
                     p[2] = p[3] = svga->map8[(dat >> 8) & svga->dac_mask & 0xff];
                     p[4] = p[5] = svga->map8[(dat >> 16) & svga->dac_mask & 0xff];
                     p[6] = p[7] = svga->map8[(dat >> 24) & svga->dac_mask & 0xff];
 
-                    svga->ma += 4;
+                    svga->memaddr += 4;
                     p += 8;
                 }
             }
-            svga->ma &= svga->vram_display_mask;
+            svga->memaddr &= svga->vram_display_mask;
         }
     }
 }
@@ -1083,7 +1083,7 @@ svga_render_8bpp_highres(svga_t *svga)
         return;
 
     if (svga->force_old_addr) {
-        if (svga->changedvram[svga->ma >> 12] || svga->changedvram[(svga->ma >> 12) + 1] || svga->fullchange) {
+        if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
 
             if (svga->firstline_draw == 2000)
@@ -1091,25 +1091,25 @@ svga_render_8bpp_highres(svga_t *svga)
             svga->lastline_draw = svga->displine;
 
             for (x = 0; x <= (svga->hdisp /* + svga->scrollcache*/); x += 8) {
-                dat  = *(uint32_t *) (&svga->vram[svga->ma & svga->vram_display_mask]);
+                dat  = *(uint32_t *) (&svga->vram[svga->memaddr & svga->vram_display_mask]);
                 p[0] = svga->map8[dat & svga->dac_mask & 0xff];
                 p[1] = svga->map8[(dat >> 8) & svga->dac_mask & 0xff];
                 p[2] = svga->map8[(dat >> 16) & svga->dac_mask & 0xff];
                 p[3] = svga->map8[(dat >> 24) & svga->dac_mask & 0xff];
 
-                dat  = *(uint32_t *) (&svga->vram[(svga->ma + 4) & svga->vram_display_mask]);
+                dat  = *(uint32_t *) (&svga->vram[(svga->memaddr + 4) & svga->vram_display_mask]);
                 p[4] = svga->map8[dat & svga->dac_mask & 0xff];
                 p[5] = svga->map8[(dat >> 8) & svga->dac_mask & 0xff];
                 p[6] = svga->map8[(dat >> 16) & svga->dac_mask & 0xff];
                 p[7] = svga->map8[(dat >> 24) & svga->dac_mask & 0xff];
 
-                svga->ma += 8;
+                svga->memaddr += 8;
                 p += 8;
             }
-            svga->ma &= svga->vram_display_mask;
+            svga->memaddr &= svga->vram_display_mask;
         }
     } else {
-        changed_addr = svga->remap_func(svga, svga->ma);
+        changed_addr = svga->remap_func(svga, svga->memaddr);
 
         if (svga->changedvram[changed_addr >> 12] || svga->changedvram[(changed_addr >> 12) + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
@@ -1120,35 +1120,35 @@ svga_render_8bpp_highres(svga_t *svga)
 
             if (!svga->remap_required) {
                 for (x = 0; x <= (svga->hdisp /* + svga->scrollcache*/); x += 8) {
-                    dat  = *(uint32_t *) (&svga->vram[svga->ma & svga->vram_display_mask]);
+                    dat  = *(uint32_t *) (&svga->vram[svga->memaddr & svga->vram_display_mask]);
                     p[0] = svga->map8[dat & svga->dac_mask & 0xff];
                     p[1] = svga->map8[(dat >> 8) & svga->dac_mask & 0xff];
                     p[2] = svga->map8[(dat >> 16) & svga->dac_mask & 0xff];
                     p[3] = svga->map8[(dat >> 24) & svga->dac_mask & 0xff];
 
-                    dat  = *(uint32_t *) (&svga->vram[(svga->ma + 4) & svga->vram_display_mask]);
+                    dat  = *(uint32_t *) (&svga->vram[(svga->memaddr + 4) & svga->vram_display_mask]);
                     p[4] = svga->map8[dat & svga->dac_mask & 0xff];
                     p[5] = svga->map8[(dat >> 8) & svga->dac_mask & 0xff];
                     p[6] = svga->map8[(dat >> 16) & svga->dac_mask & 0xff];
                     p[7] = svga->map8[(dat >> 24) & svga->dac_mask & 0xff];
 
-                    svga->ma += 8;
+                    svga->memaddr += 8;
                     p += 8;
                 }
             } else {
                 for (x = 0; x <= (svga->hdisp /* + svga->scrollcache*/); x += 4) {
-                    addr = svga->remap_func(svga, svga->ma);
+                    addr = svga->remap_func(svga, svga->memaddr);
                     dat  = *(uint32_t *) (&svga->vram[addr & svga->vram_display_mask]);
                     p[0] = svga->map8[dat & svga->dac_mask & 0xff];
                     p[1] = svga->map8[(dat >> 8) & svga->dac_mask & 0xff];
                     p[2] = svga->map8[(dat >> 16) & svga->dac_mask & 0xff];
                     p[3] = svga->map8[(dat >> 24) & svga->dac_mask & 0xff];
 
-                    svga->ma += 4;
+                    svga->memaddr += 4;
                     p += 4;
                 }
             }
-            svga->ma &= svga->vram_display_mask;
+            svga->memaddr &= svga->vram_display_mask;
         }
     }
 }
@@ -1163,7 +1163,7 @@ svga_render_8bpp_tseng_lowres(svga_t *svga)
     if ((svga->displine + svga->y_add) < 0)
         return;
 
-    if (svga->changedvram[svga->ma >> 12] || svga->changedvram[(svga->ma >> 12) + 1] || svga->fullchange) {
+    if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->fullchange) {
         p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
 
         if (svga->firstline_draw == 2000)
@@ -1171,7 +1171,7 @@ svga_render_8bpp_tseng_lowres(svga_t *svga)
         svga->lastline_draw = svga->displine;
 
         for (int x = 0; x <= (svga->hdisp + svga->scrollcache); x += 8) {
-            dat = *(uint32_t *) (&svga->vram[svga->ma & svga->vram_display_mask]);
+            dat = *(uint32_t *) (&svga->vram[svga->memaddr & svga->vram_display_mask]);
             if (svga->attrregs[0x10] & 0x80)
                 dat = (dat & ~0xf0) | ((svga->attrregs[0x14] & 0x0f) << 4);
             p[0] = p[1] = svga->map8[dat & svga->dac_mask & 0xff];
@@ -1188,10 +1188,10 @@ svga_render_8bpp_tseng_lowres(svga_t *svga)
                 dat = (dat & ~0xf0) | ((svga->attrregs[0x14] & 0x0f) << 4);
             p[6] = p[7] = svga->map8[dat & svga->dac_mask & 0xff];
 
-            svga->ma += 4;
+            svga->memaddr += 4;
             p += 8;
         }
-        svga->ma &= svga->vram_display_mask;
+        svga->memaddr &= svga->vram_display_mask;
     }
 }
 
@@ -1204,7 +1204,7 @@ svga_render_8bpp_tseng_highres(svga_t *svga)
     if ((svga->displine + svga->y_add) < 0)
         return;
 
-    if (svga->changedvram[svga->ma >> 12] || svga->changedvram[(svga->ma >> 12) + 1] || svga->fullchange) {
+    if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->fullchange) {
         p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
 
         if (svga->firstline_draw == 2000)
@@ -1212,7 +1212,7 @@ svga_render_8bpp_tseng_highres(svga_t *svga)
         svga->lastline_draw = svga->displine;
 
         for (int x = 0; x <= (svga->hdisp /* + svga->scrollcache*/); x += 8) {
-            dat = *(uint32_t *) (&svga->vram[svga->ma & svga->vram_display_mask]);
+            dat = *(uint32_t *) (&svga->vram[svga->memaddr & svga->vram_display_mask]);
             if (svga->attrregs[0x10] & 0x80)
                 dat = (dat & ~0xf0) | ((svga->attrregs[0x14] & 0x0f) << 4);
             p[0] = svga->map8[dat & svga->dac_mask & 0xff];
@@ -1229,7 +1229,7 @@ svga_render_8bpp_tseng_highres(svga_t *svga)
                 dat = (dat & ~0xf0) | ((svga->attrregs[0x14] & 0x0f) << 4);
             p[3] = svga->map8[dat & svga->dac_mask & 0xff];
 
-            dat = *(uint32_t *) (&svga->vram[(svga->ma + 4) & svga->vram_display_mask]);
+            dat = *(uint32_t *) (&svga->vram[(svga->memaddr + 4) & svga->vram_display_mask]);
             if (svga->attrregs[0x10] & 0x80)
                 dat = (dat & ~0xf0) | ((svga->attrregs[0x14] & 0x0f) << 4);
             p[4] = svga->map8[dat & svga->dac_mask & 0xff];
@@ -1246,10 +1246,10 @@ svga_render_8bpp_tseng_highres(svga_t *svga)
                 dat = (dat & ~0xf0) | ((svga->attrregs[0x14] & 0x0f) << 4);
             p[7] = svga->map8[dat & svga->dac_mask & 0xff];
 
-            svga->ma += 8;
+            svga->memaddr += 8;
             p += 8;
         }
-        svga->ma &= svga->vram_display_mask;
+        svga->memaddr &= svga->vram_display_mask;
     }
 }
 
@@ -1266,7 +1266,7 @@ svga_render_15bpp_lowres(svga_t *svga)
         return;
 
     if (svga->force_old_addr) {
-        if (svga->changedvram[svga->ma >> 12] || svga->changedvram[(svga->ma >> 12) + 1] || svga->fullchange) {
+        if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
 
             if (svga->firstline_draw == 2000)
@@ -1274,21 +1274,21 @@ svga_render_15bpp_lowres(svga_t *svga)
             svga->lastline_draw = svga->displine;
 
             for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 4) {
-                dat = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1)) & svga->vram_display_mask]);
+                dat = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1)) & svga->vram_display_mask]);
 
                 p[x << 1] = p[(x << 1) + 1] = svga->conv_16to32(svga, dat & 0xffff, 15);
                 p[(x << 1) + 2] = p[(x << 1) + 3] = svga->conv_16to32(svga, dat >> 16, 15);
 
-                dat = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1) + 4) & svga->vram_display_mask]);
+                dat = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 4) & svga->vram_display_mask]);
 
                 p[(x << 1) + 4] = p[(x << 1) + 5] = svga->conv_16to32(svga, dat & 0xffff, 15);
                 p[(x << 1) + 6] = p[(x << 1) + 7] = svga->conv_16to32(svga, dat >> 16, 15);
             }
-            svga->ma += x << 1;
-            svga->ma &= svga->vram_display_mask;
+            svga->memaddr += x << 1;
+            svga->memaddr &= svga->vram_display_mask;
         }
     } else {
-        changed_addr = svga->remap_func(svga, svga->ma);
+        changed_addr = svga->remap_func(svga, svga->memaddr);
 
         if (svga->changedvram[changed_addr >> 12] || svga->changedvram[(changed_addr >> 12) + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
@@ -1299,28 +1299,28 @@ svga_render_15bpp_lowres(svga_t *svga)
 
             if (!svga->remap_required) {
                 for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 4) {
-                    dat = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1)) & svga->vram_display_mask]);
+                    dat = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1)) & svga->vram_display_mask]);
 
                     *p++ = svga->conv_16to32(svga, dat & 0xffff, 15);
                     *p++ = svga->conv_16to32(svga, dat >> 16, 15);
 
-                    dat = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1) + 4) & svga->vram_display_mask]);
+                    dat = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 4) & svga->vram_display_mask]);
 
                     *p++ = svga->conv_16to32(svga, dat & 0xffff, 15);
                     *p++ = svga->conv_16to32(svga, dat >> 16, 15);
                 }
-                svga->ma += x << 1;
+                svga->memaddr += x << 1;
             } else {
                 for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 2) {
-                    addr = svga->remap_func(svga, svga->ma);
+                    addr = svga->remap_func(svga, svga->memaddr);
                     dat  = *(uint32_t *) (&svga->vram[addr & svga->vram_display_mask]);
 
                     *p++ = svga->conv_16to32(svga, dat & 0xffff, 15);
                     *p++ = svga->conv_16to32(svga, dat >> 16, 15);
-                    svga->ma += 4;
+                    svga->memaddr += 4;
                 }
             }
-            svga->ma &= svga->vram_display_mask;
+            svga->memaddr &= svga->vram_display_mask;
         }
     }
 }
@@ -1338,7 +1338,7 @@ svga_render_15bpp_highres(svga_t *svga)
         return;
 
     if (svga->force_old_addr) {
-        if (svga->changedvram[svga->ma >> 12] || svga->changedvram[(svga->ma >> 12) + 1] || svga->fullchange) {
+        if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
 
             if (svga->firstline_draw == 2000)
@@ -1346,27 +1346,27 @@ svga_render_15bpp_highres(svga_t *svga)
             svga->lastline_draw = svga->displine;
 
             for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 8) {
-                dat      = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1)) & svga->vram_display_mask]);
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1)) & svga->vram_display_mask]);
                 p[x]     = svga->conv_16to32(svga, dat & 0xffff, 15);
                 p[x + 1] = svga->conv_16to32(svga, dat >> 16, 15);
 
-                dat      = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1) + 4) & svga->vram_display_mask]);
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 4) & svga->vram_display_mask]);
                 p[x + 2] = svga->conv_16to32(svga, dat & 0xffff, 15);
                 p[x + 3] = svga->conv_16to32(svga, dat >> 16, 15);
 
-                dat      = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1) + 8) & svga->vram_display_mask]);
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 8) & svga->vram_display_mask]);
                 p[x + 4] = svga->conv_16to32(svga, dat & 0xffff, 15);
                 p[x + 5] = svga->conv_16to32(svga, dat >> 16, 15);
 
-                dat      = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1) + 12) & svga->vram_display_mask]);
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 12) & svga->vram_display_mask]);
                 p[x + 6] = svga->conv_16to32(svga, dat & 0xffff, 15);
                 p[x + 7] = svga->conv_16to32(svga, dat >> 16, 15);
             }
-            svga->ma += x << 1;
-            svga->ma &= svga->vram_display_mask;
+            svga->memaddr += x << 1;
+            svga->memaddr &= svga->vram_display_mask;
         }
     } else {
-        changed_addr = svga->remap_func(svga, svga->ma);
+        changed_addr = svga->remap_func(svga, svga->memaddr);
 
         if (svga->changedvram[changed_addr >> 12] || svga->changedvram[(changed_addr >> 12) + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
@@ -1377,34 +1377,34 @@ svga_render_15bpp_highres(svga_t *svga)
 
             if (!svga->remap_required) {
                 for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 8) {
-                    dat  = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1)) & svga->vram_display_mask]);
+                    dat  = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1)) & svga->vram_display_mask]);
                     *p++ = svga->conv_16to32(svga, dat & 0xffff, 15);
                     *p++ = svga->conv_16to32(svga, dat >> 16, 15);
 
-                    dat  = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1) + 4) & svga->vram_display_mask]);
+                    dat  = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 4) & svga->vram_display_mask]);
                     *p++ = svga->conv_16to32(svga, dat & 0xffff, 15);
                     *p++ = svga->conv_16to32(svga, dat >> 16, 15);
 
-                    dat  = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1) + 8) & svga->vram_display_mask]);
+                    dat  = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 8) & svga->vram_display_mask]);
                     *p++ = svga->conv_16to32(svga, dat & 0xffff, 15);
                     *p++ = svga->conv_16to32(svga, dat >> 16, 15);
 
-                    dat  = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1) + 12) & svga->vram_display_mask]);
+                    dat  = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 12) & svga->vram_display_mask]);
                     *p++ = svga->conv_16to32(svga, dat & 0xffff, 15);
                     *p++ = svga->conv_16to32(svga, dat >> 16, 15);
                 }
-                svga->ma += x << 1;
+                svga->memaddr += x << 1;
             } else {
                 for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 2) {
-                    addr = svga->remap_func(svga, svga->ma);
+                    addr = svga->remap_func(svga, svga->memaddr);
                     dat  = *(uint32_t *) (&svga->vram[addr & svga->vram_display_mask]);
 
                     *p++ = svga->conv_16to32(svga, dat & 0xffff, 15);
                     *p++ = svga->conv_16to32(svga, dat >> 16, 15);
-                    svga->ma += 4;
+                    svga->memaddr += 4;
                 }
             }
-            svga->ma &= svga->vram_display_mask;
+            svga->memaddr &= svga->vram_display_mask;
         }
     }
 }
@@ -1419,7 +1419,7 @@ svga_render_15bpp_mix_lowres(svga_t *svga)
     if ((svga->displine + svga->y_add) < 0)
         return;
 
-    if (svga->changedvram[svga->ma >> 12] || svga->changedvram[(svga->ma >> 12) + 1] || svga->fullchange) {
+    if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->fullchange) {
         p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
 
         if (svga->firstline_draw == 2000)
@@ -1427,20 +1427,20 @@ svga_render_15bpp_mix_lowres(svga_t *svga)
         svga->lastline_draw = svga->displine;
 
         for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 4) {
-            dat       = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1)) & svga->vram_display_mask]);
+            dat       = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1)) & svga->vram_display_mask]);
             p[x << 1] = p[(x << 1) + 1] = (dat & 0x00008000) ? svga->pallook[dat & 0xff] : svga->conv_16to32(svga, dat & 0xffff, 15);
 
             dat >>= 16;
             p[(x << 1) + 2] = p[(x << 1) + 3] = (dat & 0x00008000) ? svga->pallook[dat & 0xff] : svga->conv_16to32(svga, dat & 0xffff, 15);
 
-            dat             = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1) + 4) & svga->vram_display_mask]);
+            dat             = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 4) & svga->vram_display_mask]);
             p[(x << 1) + 4] = p[(x << 1) + 5] = (dat & 0x00008000) ? svga->pallook[dat & 0xff] : svga->conv_16to32(svga, dat & 0xffff, 15);
 
             dat >>= 16;
             p[(x << 1) + 6] = p[(x << 1) + 7] = (dat & 0x00008000) ? svga->pallook[dat & 0xff] : svga->conv_16to32(svga, dat & 0xffff, 15);
         }
-        svga->ma += x << 1;
-        svga->ma &= svga->vram_display_mask;
+        svga->memaddr += x << 1;
+        svga->memaddr &= svga->vram_display_mask;
     }
 }
 
@@ -1454,7 +1454,7 @@ svga_render_15bpp_mix_highres(svga_t *svga)
     if ((svga->displine + svga->y_add) < 0)
         return;
 
-    if (svga->changedvram[svga->ma >> 12] || svga->changedvram[(svga->ma >> 12) + 1] || svga->fullchange) {
+    if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->fullchange) {
         p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
 
         if (svga->firstline_draw == 2000)
@@ -1462,28 +1462,28 @@ svga_render_15bpp_mix_highres(svga_t *svga)
         svga->lastline_draw = svga->displine;
 
         for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 8) {
-            dat  = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1)) & svga->vram_display_mask]);
+            dat  = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1)) & svga->vram_display_mask]);
             p[x] = (dat & 0x00008000) ? svga->pallook[dat & 0xff] : svga->conv_16to32(svga, dat & 0xffff, 15);
             dat >>= 16;
             p[x + 1] = (dat & 0x00008000) ? svga->pallook[dat & 0xff] : svga->conv_16to32(svga, dat & 0xffff, 15);
 
-            dat      = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1) + 4) & svga->vram_display_mask]);
+            dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 4) & svga->vram_display_mask]);
             p[x + 2] = (dat & 0x00008000) ? svga->pallook[dat & 0xff] : svga->conv_16to32(svga, dat & 0xffff, 15);
             dat >>= 16;
             p[x + 3] = (dat & 0x00008000) ? svga->pallook[dat & 0xff] : svga->conv_16to32(svga, dat & 0xffff, 15);
 
-            dat      = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1) + 8) & svga->vram_display_mask]);
+            dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 8) & svga->vram_display_mask]);
             p[x + 4] = (dat & 0x00008000) ? svga->pallook[dat & 0xff] : svga->conv_16to32(svga, dat & 0xffff, 15);
             dat >>= 16;
             p[x + 5] = (dat & 0x00008000) ? svga->pallook[dat & 0xff] : svga->conv_16to32(svga, dat & 0xffff, 15);
 
-            dat      = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1) + 12) & svga->vram_display_mask]);
+            dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 12) & svga->vram_display_mask]);
             p[x + 6] = (dat & 0x00008000) ? svga->pallook[dat & 0xff] : svga->conv_16to32(svga, dat & 0xffff, 15);
             dat >>= 16;
             p[x + 7] = (dat & 0x00008000) ? svga->pallook[dat & 0xff] : svga->conv_16to32(svga, dat & 0xffff, 15);
         }
-        svga->ma += x << 1;
-        svga->ma &= svga->vram_display_mask;
+        svga->memaddr += x << 1;
+        svga->memaddr &= svga->vram_display_mask;
     }
 }
 
@@ -1500,7 +1500,7 @@ svga_render_16bpp_lowres(svga_t *svga)
         return;
 
     if (svga->force_old_addr) {
-        if (svga->changedvram[svga->ma >> 12] || svga->changedvram[(svga->ma >> 12) + 1] || svga->fullchange) {
+        if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
 
             if (svga->firstline_draw == 2000)
@@ -1508,19 +1508,19 @@ svga_render_16bpp_lowres(svga_t *svga)
             svga->lastline_draw = svga->displine;
 
             for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 4) {
-                dat       = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1)) & svga->vram_display_mask]);
+                dat       = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1)) & svga->vram_display_mask]);
                 p[x << 1] = p[(x << 1) + 1] = svga->conv_16to32(svga, dat & 0xffff, 16);
                 p[(x << 1) + 2] = p[(x << 1) + 3] = svga->conv_16to32(svga, dat >> 16, 16);
 
-                dat             = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1) + 4) & svga->vram_display_mask]);
+                dat             = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 4) & svga->vram_display_mask]);
                 p[(x << 1) + 4] = p[(x << 1) + 5] = svga->conv_16to32(svga, dat & 0xffff, 16);
                 p[(x << 1) + 6] = p[(x << 1) + 7] = svga->conv_16to32(svga, dat >> 16, 16);
             }
-            svga->ma += x << 1;
-            svga->ma &= svga->vram_display_mask;
+            svga->memaddr += x << 1;
+            svga->memaddr &= svga->vram_display_mask;
         }
     } else {
-        changed_addr = svga->remap_func(svga, svga->ma);
+        changed_addr = svga->remap_func(svga, svga->memaddr);
 
         if (svga->changedvram[changed_addr >> 12] || svga->changedvram[(changed_addr >> 12) + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
@@ -1531,28 +1531,28 @@ svga_render_16bpp_lowres(svga_t *svga)
 
             if (!svga->remap_required) {
                 for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 4) {
-                    dat = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1)) & svga->vram_display_mask]);
+                    dat = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1)) & svga->vram_display_mask]);
 
                     *p++ = svga->conv_16to32(svga, dat & 0xffff, 16);
                     *p++ = svga->conv_16to32(svga, dat >> 16, 16);
 
-                    dat = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1) + 4) & svga->vram_display_mask]);
+                    dat = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 4) & svga->vram_display_mask]);
 
                     *p++ = svga->conv_16to32(svga, dat & 0xffff, 16);
                     *p++ = svga->conv_16to32(svga, dat >> 16, 16);
                 }
-                svga->ma += x << 1;
+                svga->memaddr += x << 1;
             } else {
                 for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 2) {
-                    addr = svga->remap_func(svga, svga->ma);
+                    addr = svga->remap_func(svga, svga->memaddr);
                     dat  = *(uint32_t *) (&svga->vram[addr & svga->vram_display_mask]);
 
                     *p++ = svga->conv_16to32(svga, dat & 0xffff, 16);
                     *p++ = svga->conv_16to32(svga, dat >> 16, 16);
                 }
-                svga->ma += 4;
+                svga->memaddr += 4;
             }
-            svga->ma &= svga->vram_display_mask;
+            svga->memaddr &= svga->vram_display_mask;
         }
     }
 }
@@ -1570,7 +1570,7 @@ svga_render_16bpp_highres(svga_t *svga)
         return;
 
     if (svga->force_old_addr) {
-        if (svga->changedvram[svga->ma >> 12] || svga->changedvram[(svga->ma >> 12) + 1] || svga->fullchange) {
+        if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
 
             if (svga->firstline_draw == 2000)
@@ -1578,27 +1578,27 @@ svga_render_16bpp_highres(svga_t *svga)
             svga->lastline_draw = svga->displine;
 
             for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 8) {
-                uint32_t dat = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1)) & svga->vram_display_mask]);
+                uint32_t dat = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1)) & svga->vram_display_mask]);
                 p[x]         = svga->conv_16to32(svga, dat & 0xffff, 16);
                 p[x + 1]     = svga->conv_16to32(svga, dat >> 16, 16);
 
-                dat      = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1) + 4) & svga->vram_display_mask]);
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 4) & svga->vram_display_mask]);
                 p[x + 2] = svga->conv_16to32(svga, dat & 0xffff, 16);
                 p[x + 3] = svga->conv_16to32(svga, dat >> 16, 16);
 
-                dat      = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1) + 8) & svga->vram_display_mask]);
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 8) & svga->vram_display_mask]);
                 p[x + 4] = svga->conv_16to32(svga, dat & 0xffff, 16);
                 p[x + 5] = svga->conv_16to32(svga, dat >> 16, 16);
 
-                dat      = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1) + 12) & svga->vram_display_mask]);
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 12) & svga->vram_display_mask]);
                 p[x + 6] = svga->conv_16to32(svga, dat & 0xffff, 16);
                 p[x + 7] = svga->conv_16to32(svga, dat >> 16, 16);
             }
-            svga->ma += x << 1;
-            svga->ma &= svga->vram_display_mask;
+            svga->memaddr += x << 1;
+            svga->memaddr &= svga->vram_display_mask;
         }
     } else {
-        changed_addr = svga->remap_func(svga, svga->ma);
+        changed_addr = svga->remap_func(svga, svga->memaddr);
 
         if (svga->changedvram[changed_addr >> 12] || svga->changedvram[(changed_addr >> 12) + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
@@ -1609,35 +1609,35 @@ svga_render_16bpp_highres(svga_t *svga)
 
             if (!svga->remap_required) {
                 for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 8) {
-                    dat  = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1)) & svga->vram_display_mask]);
+                    dat  = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1)) & svga->vram_display_mask]);
                     *p++ = svga->conv_16to32(svga, dat & 0xffff, 16);
                     *p++ = svga->conv_16to32(svga, dat >> 16, 16);
 
-                    dat  = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1) + 4) & svga->vram_display_mask]);
+                    dat  = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 4) & svga->vram_display_mask]);
                     *p++ = svga->conv_16to32(svga, dat & 0xffff, 16);
                     *p++ = svga->conv_16to32(svga, dat >> 16, 16);
 
-                    dat  = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1) + 8) & svga->vram_display_mask]);
+                    dat  = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 8) & svga->vram_display_mask]);
                     *p++ = svga->conv_16to32(svga, dat & 0xffff, 16);
                     *p++ = svga->conv_16to32(svga, dat >> 16, 16);
 
-                    dat  = *(uint32_t *) (&svga->vram[(svga->ma + (x << 1) + 12) & svga->vram_display_mask]);
+                    dat  = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 12) & svga->vram_display_mask]);
                     *p++ = svga->conv_16to32(svga, dat & 0xffff, 16);
                     *p++ = svga->conv_16to32(svga, dat >> 16, 16);
                 }
-                svga->ma += x << 1;
+                svga->memaddr += x << 1;
             } else {
                 for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 2) {
-                    addr = svga->remap_func(svga, svga->ma);
+                    addr = svga->remap_func(svga, svga->memaddr);
                     dat  = *(uint32_t *) (&svga->vram[addr & svga->vram_display_mask]);
 
                     *p++ = svga->conv_16to32(svga, dat & 0xffff, 16);
                     *p++ = svga->conv_16to32(svga, dat >> 16, 16);
 
-                    svga->ma += 4;
+                    svga->memaddr += 4;
                 }
             }
-            svga->ma &= svga->vram_display_mask;
+            svga->memaddr &= svga->vram_display_mask;
         }
     }
 }
@@ -1661,20 +1661,20 @@ svga_render_24bpp_lowres(svga_t *svga)
         if ((svga->displine + svga->y_add) < 0)
             return;
 
-        if (svga->changedvram[svga->ma >> 12] || svga->changedvram[(svga->ma >> 12) + 1] || svga->fullchange) {
+        if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->fullchange) {
             if (svga->firstline_draw == 2000)
                 svga->firstline_draw = svga->displine;
             svga->lastline_draw = svga->displine;
 
             for (x = 0; x <= (svga->hdisp + svga->scrollcache); x++) {
-                fg = svga->vram[svga->ma] | (svga->vram[svga->ma + 1] << 8) | (svga->vram[svga->ma + 2] << 16);
-                svga->ma += 3;
-                svga->ma &= svga->vram_display_mask;
+                fg = svga->vram[svga->memaddr] | (svga->vram[svga->memaddr + 1] << 8) | (svga->vram[svga->memaddr + 2] << 16);
+                svga->memaddr += 3;
+                svga->memaddr &= svga->vram_display_mask;
                 svga->monitor->target_buffer->line[svga->displine + svga->y_add][(x << 1) + svga->x_add] = svga->monitor->target_buffer->line[svga->displine + svga->y_add][(x << 1) + 1 + svga->x_add] = lookup_lut(fg);
             }
         }
     } else {
-        changed_addr = svga->remap_func(svga, svga->ma);
+        changed_addr = svga->remap_func(svga, svga->memaddr);
 
         if (svga->changedvram[changed_addr >> 12] || svga->changedvram[(changed_addr >> 12) + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
@@ -1685,24 +1685,24 @@ svga_render_24bpp_lowres(svga_t *svga)
 
             if (!svga->remap_required) {
                 for (x = 0; x <= (svga->hdisp + svga->scrollcache); x++) {
-                    dat0 = *(uint32_t *) (&svga->vram[svga->ma & svga->vram_display_mask]);
-                    dat1 = *(uint32_t *) (&svga->vram[(svga->ma + 4) & svga->vram_display_mask]);
-                    dat2 = *(uint32_t *) (&svga->vram[(svga->ma + 8) & svga->vram_display_mask]);
+                    dat0 = *(uint32_t *) (&svga->vram[svga->memaddr & svga->vram_display_mask]);
+                    dat1 = *(uint32_t *) (&svga->vram[(svga->memaddr + 4) & svga->vram_display_mask]);
+                    dat2 = *(uint32_t *) (&svga->vram[(svga->memaddr + 8) & svga->vram_display_mask]);
 
                     p[0] = p[1] = lookup_lut(dat0 & 0xffffff);
                     p[2] = p[3] = lookup_lut((dat0 >> 24) | ((dat1 & 0xffff) << 8));
                     p[4] = p[5] = lookup_lut((dat1 >> 16) | ((dat2 & 0xff) << 16));
                     p[6] = p[7] = lookup_lut(dat2 >> 8);
 
-                    svga->ma += 12;
+                    svga->memaddr += 12;
                 }
             } else {
                 for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 4) {
-                    addr = svga->remap_func(svga, svga->ma);
+                    addr = svga->remap_func(svga, svga->memaddr);
                     dat0 = *(uint32_t *) (&svga->vram[addr & svga->vram_display_mask]);
-                    addr = svga->remap_func(svga, svga->ma + 4);
+                    addr = svga->remap_func(svga, svga->memaddr + 4);
                     dat1 = *(uint32_t *) (&svga->vram[addr & svga->vram_display_mask]);
-                    addr = svga->remap_func(svga, svga->ma + 8);
+                    addr = svga->remap_func(svga, svga->memaddr + 8);
                     dat2 = *(uint32_t *) (&svga->vram[addr & svga->vram_display_mask]);
 
                     p[0] = p[1] = lookup_lut(dat0 & 0xffffff);
@@ -1710,10 +1710,10 @@ svga_render_24bpp_lowres(svga_t *svga)
                     p[4] = p[5] = lookup_lut((dat1 >> 16) | ((dat2 & 0xff) << 16));
                     p[6] = p[7] = lookup_lut(dat2 >> 8);
 
-                    svga->ma += 12;
+                    svga->memaddr += 12;
                 }
             }
-            svga->ma &= svga->vram_display_mask;
+            svga->memaddr &= svga->vram_display_mask;
         }
     }
 }
@@ -1734,7 +1734,7 @@ svga_render_24bpp_highres(svga_t *svga)
         return;
 
     if (svga->force_old_addr) {
-        if (svga->changedvram[svga->ma >> 12] || svga->changedvram[(svga->ma >> 12) + 1] || svga->fullchange) {
+        if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
 
             if (svga->firstline_draw == 2000)
@@ -1742,24 +1742,24 @@ svga_render_24bpp_highres(svga_t *svga)
             svga->lastline_draw = svga->displine;
 
             for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 4) {
-                dat  = *(uint32_t *) (&svga->vram[svga->ma & svga->vram_display_mask]);
+                dat  = *(uint32_t *) (&svga->vram[svga->memaddr & svga->vram_display_mask]);
                 p[x] = lookup_lut(dat & 0xffffff);
 
-                dat      = *(uint32_t *) (&svga->vram[(svga->ma + 3) & svga->vram_display_mask]);
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + 3) & svga->vram_display_mask]);
                 p[x + 1] = lookup_lut(dat & 0xffffff);
 
-                dat      = *(uint32_t *) (&svga->vram[(svga->ma + 6) & svga->vram_display_mask]);
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + 6) & svga->vram_display_mask]);
                 p[x + 2] = lookup_lut(dat & 0xffffff);
 
-                dat      = *(uint32_t *) (&svga->vram[(svga->ma + 9) & svga->vram_display_mask]);
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + 9) & svga->vram_display_mask]);
                 p[x + 3] = lookup_lut(dat & 0xffffff);
 
-                svga->ma += 12;
+                svga->memaddr += 12;
             }
-            svga->ma &= svga->vram_display_mask;
+            svga->memaddr &= svga->vram_display_mask;
         }
     } else {
-        changed_addr = svga->remap_func(svga, svga->ma);
+        changed_addr = svga->remap_func(svga, svga->memaddr);
 
         if (svga->changedvram[changed_addr >> 12] || svga->changedvram[(changed_addr >> 12) + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
@@ -1770,24 +1770,24 @@ svga_render_24bpp_highres(svga_t *svga)
 
             if (!svga->remap_required) {
                 for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 4) {
-                    dat0 = *(uint32_t *) (&svga->vram[svga->ma & svga->vram_display_mask]);
-                    dat1 = *(uint32_t *) (&svga->vram[(svga->ma + 4) & svga->vram_display_mask]);
-                    dat2 = *(uint32_t *) (&svga->vram[(svga->ma + 8) & svga->vram_display_mask]);
+                    dat0 = *(uint32_t *) (&svga->vram[svga->memaddr & svga->vram_display_mask]);
+                    dat1 = *(uint32_t *) (&svga->vram[(svga->memaddr + 4) & svga->vram_display_mask]);
+                    dat2 = *(uint32_t *) (&svga->vram[(svga->memaddr + 8) & svga->vram_display_mask]);
 
                     *p++ = lookup_lut(dat0 & 0xffffff);
                     *p++ = lookup_lut((dat0 >> 24) | ((dat1 & 0xffff) << 8));
                     *p++ = lookup_lut((dat1 >> 16) | ((dat2 & 0xff) << 16));
                     *p++ = lookup_lut(dat2 >> 8);
 
-                    svga->ma += 12;
+                    svga->memaddr += 12;
                 }
             } else {
                 for (x = 0; x <= (svga->hdisp + svga->scrollcache); x += 4) {
-                    addr = svga->remap_func(svga, svga->ma);
+                    addr = svga->remap_func(svga, svga->memaddr);
                     dat0 = *(uint32_t *) (&svga->vram[addr & svga->vram_display_mask]);
-                    addr = svga->remap_func(svga, svga->ma + 4);
+                    addr = svga->remap_func(svga, svga->memaddr + 4);
                     dat1 = *(uint32_t *) (&svga->vram[addr & svga->vram_display_mask]);
-                    addr = svga->remap_func(svga, svga->ma + 8);
+                    addr = svga->remap_func(svga, svga->memaddr + 8);
                     dat2 = *(uint32_t *) (&svga->vram[addr & svga->vram_display_mask]);
 
                     *p++ = lookup_lut(dat0 & 0xffffff);
@@ -1795,10 +1795,10 @@ svga_render_24bpp_highres(svga_t *svga)
                     *p++ = lookup_lut((dat1 >> 16) | ((dat2 & 0xff) << 16));
                     *p++ = lookup_lut(dat2 >> 8);
 
-                    svga->ma += 12;
+                    svga->memaddr += 12;
                 }
             }
-            svga->ma &= svga->vram_display_mask;
+            svga->memaddr &= svga->vram_display_mask;
         }
     }
 }
@@ -1816,20 +1816,20 @@ svga_render_32bpp_lowres(svga_t *svga)
         return;
 
     if (svga->force_old_addr) {
-        if (svga->changedvram[svga->ma >> 12] || svga->changedvram[(svga->ma >> 12) + 1] || svga->fullchange) {
+        if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->fullchange) {
             if (svga->firstline_draw == 2000)
                 svga->firstline_draw = svga->displine;
             svga->lastline_draw = svga->displine;
 
             for (x = 0; x <= (svga->hdisp + svga->scrollcache); x++) {
-                dat = svga->vram[svga->ma] | (svga->vram[svga->ma + 1] << 8) | (svga->vram[svga->ma + 2] << 16);
-                svga->ma += 4;
-                svga->ma &= svga->vram_display_mask;
+                dat = svga->vram[svga->memaddr] | (svga->vram[svga->memaddr + 1] << 8) | (svga->vram[svga->memaddr + 2] << 16);
+                svga->memaddr += 4;
+                svga->memaddr &= svga->vram_display_mask;
                 svga->monitor->target_buffer->line[svga->displine + svga->y_add][(x << 1) + svga->x_add] = svga->monitor->target_buffer->line[svga->displine + svga->y_add][(x << 1) + 1 + svga->x_add] = lookup_lut(dat);
             }
         }
     } else {
-        changed_addr = svga->remap_func(svga, svga->ma);
+        changed_addr = svga->remap_func(svga, svga->memaddr);
 
         if (svga->changedvram[changed_addr >> 12] || svga->changedvram[(changed_addr >> 12) + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
@@ -1840,20 +1840,20 @@ svga_render_32bpp_lowres(svga_t *svga)
 
             if (!svga->remap_required) {
                 for (x = 0; x <= (svga->hdisp + svga->scrollcache); x++) {
-                    dat  = *(uint32_t *) (&svga->vram[(svga->ma + (x << 2)) & svga->vram_display_mask]);
+                    dat  = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 2)) & svga->vram_display_mask]);
                     *p++ = lookup_lut(dat & 0xffffff);
                     *p++ = lookup_lut(dat & 0xffffff);
                 }
-                svga->ma += (x * 4);
+                svga->memaddr += (x * 4);
             } else {
                 for (x = 0; x <= (svga->hdisp + svga->scrollcache); x++) {
-                    addr = svga->remap_func(svga, svga->ma);
+                    addr = svga->remap_func(svga, svga->memaddr);
                     dat  = *(uint32_t *) (&svga->vram[addr & svga->vram_display_mask]);
                     *p++ = lookup_lut(dat & 0xffffff);
                     *p++ = lookup_lut(dat & 0xffffff);
-                    svga->ma += 4;
+                    svga->memaddr += 4;
                 }
-                svga->ma &= svga->vram_display_mask;
+                svga->memaddr &= svga->vram_display_mask;
             }
         }
     }
@@ -1872,7 +1872,7 @@ svga_render_32bpp_highres(svga_t *svga)
         return;
 
     if (svga->force_old_addr) {
-        if (svga->changedvram[svga->ma >> 12] || svga->changedvram[(svga->ma >> 12) + 1] || svga->changedvram[(svga->ma >> 12) + 2] || svga->fullchange) {
+        if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->changedvram[(svga->memaddr >> 12) + 2] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
 
             if (svga->firstline_draw == 2000)
@@ -1880,14 +1880,14 @@ svga_render_32bpp_highres(svga_t *svga)
             svga->lastline_draw = svga->displine;
 
             for (x = 0; x <= (svga->hdisp + svga->scrollcache); x++) {
-                dat  = *(uint32_t *) (&svga->vram[(svga->ma + (x << 2)) & svga->vram_display_mask]);
+                dat  = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 2)) & svga->vram_display_mask]);
                 p[x] = lookup_lut(dat & 0xffffff);
             }
-            svga->ma += 4;
-            svga->ma &= svga->vram_display_mask;
+            svga->memaddr += 4;
+            svga->memaddr &= svga->vram_display_mask;
         }
     } else {
-        changed_addr = svga->remap_func(svga, svga->ma);
+        changed_addr = svga->remap_func(svga, svga->memaddr);
 
         if (svga->changedvram[changed_addr >> 12] || svga->changedvram[(changed_addr >> 12) + 1] || svga->fullchange) {
             p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
@@ -1898,20 +1898,20 @@ svga_render_32bpp_highres(svga_t *svga)
 
             if (!svga->remap_required) {
                 for (x = 0; x <= (svga->hdisp + svga->scrollcache); x++) {
-                    dat  = *(uint32_t *) (&svga->vram[(svga->ma + (x << 2)) & svga->vram_display_mask]);
+                    dat  = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 2)) & svga->vram_display_mask]);
                     *p++ = lookup_lut(dat & 0xffffff);
                 }
-                svga->ma += (x * 4);
+                svga->memaddr += (x * 4);
             } else {
                 for (x = 0; x <= (svga->hdisp + svga->scrollcache); x++) {
-                    addr = svga->remap_func(svga, svga->ma);
+                    addr = svga->remap_func(svga, svga->memaddr);
                     dat  = *(uint32_t *) (&svga->vram[addr & svga->vram_display_mask]);
                     *p++ = lookup_lut(dat & 0xffffff);
 
-                    svga->ma += 4;
+                    svga->memaddr += 4;
                 }
             }
-            svga->ma &= svga->vram_display_mask;
+            svga->memaddr &= svga->vram_display_mask;
         }
     }
 }
@@ -1928,7 +1928,7 @@ svga_render_ABGR8888_highres(svga_t *svga)
     if ((svga->displine + svga->y_add) < 0)
         return;
 
-    changed_addr = svga->remap_func(svga, svga->ma);
+    changed_addr = svga->remap_func(svga, svga->memaddr);
 
     if (svga->changedvram[changed_addr >> 12] || svga->changedvram[(changed_addr >> 12) + 1] || svga->fullchange) {
         p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
@@ -1939,20 +1939,20 @@ svga_render_ABGR8888_highres(svga_t *svga)
 
         if (!svga->remap_required) {
             for (x = 0; x <= (svga->hdisp + svga->scrollcache); x++) {
-                dat  = *(uint32_t *) (&svga->vram[(svga->ma + (x << 2)) & svga->vram_display_mask]);
+                dat  = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 2)) & svga->vram_display_mask]);
                 *p++ = lookup_lut(((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16));
             }
-            svga->ma += x * 4;
+            svga->memaddr += x * 4;
         } else {
             for (x = 0; x <= (svga->hdisp + svga->scrollcache); x++) {
-                addr = svga->remap_func(svga, svga->ma);
+                addr = svga->remap_func(svga, svga->memaddr);
                 dat  = *(uint32_t *) (&svga->vram[addr & svga->vram_display_mask]);
                 *p++ = lookup_lut(((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16));
 
-                svga->ma += 4;
+                svga->memaddr += 4;
             }
         }
-        svga->ma &= svga->vram_display_mask;
+        svga->memaddr &= svga->vram_display_mask;
     }
 }
 
@@ -1968,7 +1968,7 @@ svga_render_RGBA8888_highres(svga_t *svga)
     if ((svga->displine + svga->y_add) < 0)
         return;
 
-    changed_addr = svga->remap_func(svga, svga->ma);
+    changed_addr = svga->remap_func(svga, svga->memaddr);
 
     if (svga->changedvram[changed_addr >> 12] || svga->changedvram[(changed_addr >> 12) + 1] || svga->fullchange) {
         p = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
@@ -1979,19 +1979,19 @@ svga_render_RGBA8888_highres(svga_t *svga)
 
         if (!svga->remap_required) {
             for (x = 0; x <= (svga->hdisp + svga->scrollcache); x++) {
-                dat  = *(uint32_t *) (&svga->vram[(svga->ma + (x << 2)) & svga->vram_display_mask]);
+                dat  = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 2)) & svga->vram_display_mask]);
                 *p++ = lookup_lut(dat >> 8);
             }
-            svga->ma += (x * 4);
+            svga->memaddr += (x * 4);
         } else {
             for (x = 0; x <= (svga->hdisp + svga->scrollcache); x++) {
-                addr = svga->remap_func(svga, svga->ma);
+                addr = svga->remap_func(svga, svga->memaddr);
                 dat  = *(uint32_t *) (&svga->vram[addr & svga->vram_display_mask]);
                 *p++ = lookup_lut(dat >> 8);
 
-                svga->ma += 4;
+                svga->memaddr += 4;
             }
         }
-        svga->ma &= svga->vram_display_mask;
+        svga->memaddr &= svga->vram_display_mask;
     }
 }

--- a/src/video/vid_tgui9440.c
+++ b/src/video/vid_tgui9440.c
@@ -543,7 +543,7 @@ tgui_out(uint16_t addr, uint8_t val, void *priv)
                 if (svga->crtcreg < 0xe || svga->crtcreg > 0x10) {
                     if ((svga->crtcreg == 0xc) || (svga->crtcreg == 0xd)) {
                         svga->fullchange = 3;
-                        svga->ma_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
+                        svga->memaddr_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
                     } else {
                         svga->fullchange = svga->monitor->mon_changeframecount;
                         svga_recalctimings(svga);
@@ -726,13 +726,13 @@ tgui_recalctimings(svga_t *svga)
 #endif
 
     if ((svga->crtc[0x1e] & 0xA0) == 0xA0)
-        svga->ma_latch |= 0x10000;
+        svga->memaddr_latch |= 0x10000;
     if (svga->crtc[0x27] & 0x01)
-        svga->ma_latch |= 0x20000;
+        svga->memaddr_latch |= 0x20000;
     if (svga->crtc[0x27] & 0x02)
-        svga->ma_latch |= 0x40000;
+        svga->memaddr_latch |= 0x40000;
     if (svga->crtc[0x27] & 0x04)
-        svga->ma_latch |= 0x80000;
+        svga->memaddr_latch |= 0x80000;
 
     if (svga->crtc[0x27] & 0x08)
         svga->split |= 0x400;
@@ -759,7 +759,7 @@ tgui_recalctimings(svga_t *svga)
         svga->vdisp += 2;
 
     if (tgui->oldctrl2 & 0x10)
-        svga->ma_latch <<= 1;
+        svga->memaddr_latch <<= 1;
 
     svga->lowres = !(svga->crtc[0x2a] & 0x40);
 

--- a/src/video/vid_tvga.c
+++ b/src/video/vid_tvga.c
@@ -168,7 +168,7 @@ tvga_out(uint16_t addr, uint8_t val, void *priv)
                 if (svga->crtcreg < 0xe || svga->crtcreg > 0x10) {
                     if ((svga->crtcreg == 0xc) || (svga->crtcreg == 0xd)) {
                         svga->fullchange = 3;
-                        svga->ma_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
+                        svga->memaddr_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
                     } else {
                         svga->fullchange = changeframecount;
                         svga_recalctimings(svga);
@@ -293,15 +293,15 @@ tvga_recalctimings(svga_t *svga)
         svga->hdisp = (svga->crtc[1] + 1) * 8;
 
     if ((svga->crtc[0x1e] & 0xA0) == 0xA0)
-        svga->ma_latch |= 0x10000;
+        svga->memaddr_latch |= 0x10000;
     if ((svga->crtc[0x27] & 0x01) == 0x01)
-        svga->ma_latch |= 0x20000;
+        svga->memaddr_latch |= 0x20000;
     if ((svga->crtc[0x27] & 0x02) == 0x02)
-        svga->ma_latch |= 0x40000;
+        svga->memaddr_latch |= 0x40000;
 
     if (tvga->oldctrl2 & 0x10) {
         svga->rowoffset <<= 1;
-        svga->ma_latch <<= 1;
+        svga->memaddr_latch <<= 1;
     }
 
     if (svga->gdcreg[0xf] & 0x08) {

--- a/src/video/vid_vga.c
+++ b/src/video/vid_vga.c
@@ -63,7 +63,7 @@ vga_out(uint16_t addr, uint8_t val, void *priv)
                 if (svga->crtcreg < 0xe || svga->crtcreg > 0x10) {
                     if ((svga->crtcreg == 0xc) || (svga->crtcreg == 0xd)) {
                         svga->fullchange = 3;
-                        svga->ma_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
+                        svga->memaddr_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
                     } else {
                         svga->fullchange = changeframecount;
                         svga_recalctimings(svga);

--- a/src/video/vid_voodoo_banshee.c
+++ b/src/video/vid_voodoo_banshee.c
@@ -385,7 +385,7 @@ banshee_out(uint16_t addr, uint8_t val, void *priv)
                 if (svga->crtcreg < 0xe || svga->crtcreg > 0x11 || (svga->crtcreg == 0x11 && old != val)) {
                     if ((svga->crtcreg == 0xc) || (svga->crtcreg == 0xd)) {
                         svga->fullchange = 3;
-                        svga->ma_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
+                        svga->memaddr_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
                     } else {
                         svga->fullchange = changeframecount;
                         svga_recalctimings(svga);
@@ -663,7 +663,7 @@ banshee_recalctimings(svga_t *svga)
             svga->rowoffset = ((banshee->vidDesktopOverlayStride & 0x3fff) * 128) >> 3;
         else
             svga->rowoffset = (banshee->vidDesktopOverlayStride & 0x3fff) >> 3;
-        svga->ma_latch                = banshee->vidDesktopStartAddr >> 2;
+        svga->memaddr_latch                = banshee->vidDesktopStartAddr >> 2;
         banshee->desktop_stride_tiled = (banshee->vidDesktopOverlayStride & 0x3fff) * 128 * 32;
 #if 0
         banshee_log("Extended shift out %i rowoffset=%i %02x\n", VIDPROCCFG_DESKTOP_PIX_FORMAT, svga->rowoffset, svga->crtc[1]);


### PR DESCRIPTION
Summary
=======
The video code had very difficult to parse (for developers not attuned to the codebase) variable names. This starts the work of improving that by renaming variables: 

ma -> memaddr
ma_latch -> memaddr_latch
maback -> memaddr_backup
ca -> cursoraddr
sc -> scanline
oldsc -> scanline_old

Checklist
=========
* [ ] Closes #xxx
* [ X ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
