### PR TITLE
Fix Toshiba T3100E CGA 320*200 mode

### DIFF
--- a/src/video/vid_cga_toshiba_t3100e.c
+++ b/src/video/vid_cga_toshiba_t3100e.c
@@ -407,7 +407,7 @@ t3100e_cgaline4(t3100e_t *t3100e)
     uint32_t ink1 = 0;
     uint16_t addr;
 
-    uint16_t memaddr = (t3100e->cga.crtc[CGA_CRTC_START_ADDR_HIGH] | (t3100e->cga.crtc[CGA_CRTC_CURSOR_END] << 8)) & 0x7fff;
+    uint16_t memaddr = (t3100e->cga.crtc[CGA_CRTC_START_ADDR_LOW] | (t3100e->cga.crtc[CGA_CRTC_START_ADDR_HIGH] << 8)) & 0x7fff;
     if (t3100e->cga.crtc[CGA_CRTC_MAX_SCANLINE_ADDR] == 3) /* 320*400 undocumented */
     {
         addr = ((t3100e->displine) & 1) * 0x2000 + ((t3100e->displine >> 1) & 1) * 0x4000 + (t3100e->displine >> 2) * 80 + ((memaddr & ~1) << 1);


### PR DESCRIPTION
Summary
=======
Fix a regression due to incorrect porting job to the new CGA code in Toshiba T3100E

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
