### PR TITLE
Fix mach8/32 win2000 blit regression (June 15th, 2025)

### DIFF
--- a/src/include/86box/vid_ati_mach8.h
+++ b/src/include/86box/vid_ati_mach8.h
@@ -137,6 +137,7 @@ typedef struct mach_t {
         int16_t  dx_end;
         int16_t  dy;
         int16_t  dy_end;
+        int16_t  dx_first_row_start;
         int16_t  dx_start;
         int16_t  dy_start;
         int16_t  cy;


### PR DESCRIPTION
Summary
=======
If the height is 1, then make sure Cur_X is used for the destination X start, otherwise, Dest_X_Start is the destination X start for the blit. This fixes some blit errors on Win2000's mach8/32 drivers.

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[Mach32 manual, blit section](https://fenarinarsa.com/misc/atari-forum/reg-688000-15_programmers_guide_to_the_mach32_registers.pdf)
