### PR TITLE
Voodoo 3D change of the day (June 16th, 2025)

### DIFF
--- a/src/video/vid_voodoo.c
+++ b/src/video/vid_voodoo.c
@@ -530,6 +530,7 @@ voodoo_writel(uint32_t addr, uint32_t val, void *priv)
                         voodoo_recalc(voodoo);
                         voodoo->front_offset = voodoo->params.front_offset;
                     }
+                    svga_recalctimings(voodoo->svga);
                 }
                 break;
             case SST_fbiInit1:


### PR DESCRIPTION
Summary
=======
When 3D is enabled on the behalf of the Voodoo, make sure the override is reflected in recalctimings as well so that it can use the old calculation way of the overscan. Fixes more blackness in some areas of some games (and possibly more).

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
