### PR TITLE
Video Refactor Part 5(gum): MDA Colour support 

### DIFF
--- a/src/include/86box/vid_mda.h
+++ b/src/include/86box/vid_mda.h
@@ -61,7 +61,7 @@ typedef enum mda_crtc_registers_e
 typedef enum mda_mode_flags_e
 {
     MDA_MODE_HIGHRES = 1 << 0,                          // MUST be enabled for sane operation
-    MDA_MODE_BLACKANDWHITE = 1 << 1,                    // UNUSED in most cases. Not present on Hercules
+    MDA_MODE_BW = 1 << 1,                    // UNUSED in most cases. Not present on Hercules
     MDA_MODE_VIDEO_ENABLE = 1 << 3, 
     MDA_MODE_BLINK = 1 << 5,
 } mda_mode_flags;

--- a/src/include/86box/vid_mda.h
+++ b/src/include/86box/vid_mda.h
@@ -66,6 +66,26 @@ typedef enum mda_mode_flags_e
     MDA_MODE_BLINK = 1 << 5,
 } mda_mode_flags;
 
+typedef enum mda_colors_e 
+{
+    MDA_COLOR_BLACK = 0,
+    MDA_COLOR_BLUE = 1,
+    MDA_COLOR_GREEN = 2,
+    MDA_COLOR_CYAN = 3,
+    MDA_COLOR_RED = 4,
+    MDA_COLOR_MAGENTA = 5,
+    MDA_COLOR_BROWN = 6,
+    MDA_COLOR_WHITE = 7,
+    MDA_COLOR_GREY = 8,
+    MDA_COLOR_BRIGHT_BLUE = 9,
+    MDA_COLOR_BRIGHT_GREEN = 10,
+    MDA_COLOR_BRIGHT_CYAN = 11,
+    MDA_COLOR_BRIGHT_RED = 12,
+    MDA_COLOR_BRIGHT_MAGENTA = 13,
+    MDA_COLOR_BRIGHT_YELLOW = 14,
+    MDA_COLOR_BRIGHT_WHITE = 15,
+} mda_colors; 
+
 typedef struct mda_t {
     mem_mapping_t mapping;
 

--- a/src/include/86box/vid_mda.h
+++ b/src/include/86box/vid_mda.h
@@ -69,34 +69,35 @@ typedef enum mda_mode_flags_e
 typedef struct mda_t {
     mem_mapping_t mapping;
 
-    uint8_t crtc[MDA_CRTC_NUM_REGISTERS];
-    int     crtcreg;
+    uint8_t     crtc[MDA_CRTC_NUM_REGISTERS];
+    int32_t     crtcreg;
 
-    uint8_t mode;
-    uint8_t status;
+    uint8_t     mode;
+    uint8_t     status;
 
-    uint64_t   dispontime;
-    uint64_t   dispofftime;
-    pc_timer_t timer;
+    uint64_t    dispontime;
+    uint64_t    dispofftime;
+    pc_timer_t  timer;
 
-    int firstline;
-    int lastline;
+    int32_t     firstline;
+    int32_t     lastline;
 
-    int      fontbase;
-    int      linepos;
-    int      displine;
-    int      vc;
-    int      scanline;
-    uint16_t memaddr;
-    uint16_t memaddr_backup;
-    int      cursorvisible;
-    int      cursoron;
-    int      dispon;
-    int      blink;
-    int      vsynctime;
-    int      vadj;
-    int      monitor_index;
-    int      prev_monitor_index;
+    int32_t     fontbase;
+    int32_t     linepos;
+    int32_t     displine;
+    int32_t     vc;
+    int32_t     scanline;
+    uint16_t    memaddr;
+    uint16_t    memaddr_backup;
+    int32_t     cursorvisible;
+    int32_t     cursoron;
+    int32_t     dispon;
+    int32_t     blink;
+    int32_t     vsynctime;
+    int32_t     vadj;
+    int32_t     monitor_index;
+    int32_t     prev_monitor_index;
+    int32_t     monitor_type;           // Used for MDA Colour support (REV0 u64)
 
     uint8_t *vram;
 } mda_t;

--- a/src/include/86box/video.h
+++ b/src/include/86box/video.h
@@ -187,6 +187,10 @@ extern bitmap_t *buffer32;
 #define efscrnsz_y           (monitors[monitor_index_global].mon_efscrnsz_y)
 #define unscaled_size_x      (monitors[monitor_index_global].mon_unscaled_size_x)
 #define unscaled_size_y      (monitors[monitor_index_global].mon_unscaled_size_y)
+
+#define CGAPAL_CGA_START    16            // Where the 16-color cga text/composite starts
+
+
 extern PALETTE      cgapal;
 extern PALETTE      cgapal_mono[6];
 #if 0

--- a/src/video/vid_mda.c
+++ b/src/video/vid_mda.c
@@ -192,8 +192,14 @@ mda_poll(void *priv)
                     {
                         color_bg = (attr >> 4) & 0x0F;
                         color_fg = (attr & 0x0F); 
-                    }
-                        
+
+                        // turn off bright bg colours in blink mode
+                        if ((mda->mode & MDA_MODE_BLINK)
+                        && (color_bg & 0x8))
+                        {
+                            color_bg & ~(0x8);
+                        }  
+                    }   
                 }
 
                 if (mda->scanline == 12 && ((attr & 7) == 1)) { // underline
@@ -222,10 +228,10 @@ mda_poll(void *priv)
                     {
                         bool is_fg = fontdatm[chr + mda->fontbase][mda->scanline] & 1;
 
-                        if (is_fg)
-                            buffer32->line[mda->displine][(x * 9) + 8] = mda_attr_to_color_table[attr][blink][is_fg] | color_fg; 
-                        else
+                        if (!is_fg)
                             buffer32->line[mda->displine][(x * 9) + 8] = mda_attr_to_color_table[attr][blink][is_fg] | color_bg; 
+                        else
+                            buffer32->line[mda->displine][(x * 9) + 8] = mda_attr_to_color_table[attr][blink][is_fg] | color_fg; 
                     }
                     else
                         buffer32->line[mda->displine][(x * 9) + 8] = mda_attr_to_color_table[attr][blink][0] | color_bg;

--- a/src/video/vid_mda.c
+++ b/src/video/vid_mda.c
@@ -210,6 +210,11 @@ mda_poll(void *priv)
                     if (color_fg == 0
                     && special_treatment)
                         color_fg = 7;
+
+                        // gray is black
+                    if (color_fg == 7
+                    && color_bg == 7)
+                        color_fg = 0;
                 }
 
                 if (mda->scanline == 12 && ((attr & 7) == 1)) 

--- a/src/video/vid_mda.c
+++ b/src/video/vid_mda.c
@@ -359,12 +359,13 @@ void
 mda_init(mda_t *mda)
 {
     
-    for (uint16_t c = 0; c < 256; c++) {
-        mda_attr_to_color_table[c][0][0] = mda_attr_to_color_table[c][1][0] = mda_attr_to_color_table[c][1][1] = 16;
-        if (c & 8)
-            mda_attr_to_color_table[c][0][1] = 15 + 16;
+    for (uint16_t attr = 0; attr < 256; attr++) 
+    {
+        mda_attr_to_color_table[attr][0][0] = mda_attr_to_color_table[attr][1][0] = mda_attr_to_color_table[attr][1][1] = 16;
+        if (attr & 8)
+            mda_attr_to_color_table[attr][0][1] = 15 + 16;
         else
-            mda_attr_to_color_table[c][0][1] = 7 + 16;
+            mda_attr_to_color_table[attr][0][1] = 7 + 16;
     }
     mda_attr_to_color_table[0x70][0][1] = 16;
     mda_attr_to_color_table[0x70][0][0] = mda_attr_to_color_table[0x70][1][0] = mda_attr_to_color_table[0x70][1][1] = CGAPAL_CGA_START + 15;

--- a/src/video/vid_mda.c
+++ b/src/video/vid_mda.c
@@ -193,18 +193,18 @@ mda_poll(void *priv)
 
                     bool special_treatment = (color_bg != 0 && color_bg != 7);
 
-                    if (color_fg == 8
+                    if (color_fg == MDA_COLOR_GREY
                         && special_treatment)
-                        color_fg = 15;
+                        color_fg = MDA_COLOR_BRIGHT_WHITE;
 
                     if (color_fg == 0
                         && special_treatment)
-                        color_fg = 8;
+                        color_fg = MDA_COLOR_GREY;
 
                     // gray is black
-                    if (color_fg == 8
-                        && (color_bg == 8 || color_bg == 0))
-                        color_fg = 0;
+                    if (color_fg == MDA_COLOR_GREY
+                        && (color_bg == MDA_COLOR_GREY || color_bg == MDA_COLOR_BLACK))
+                        color_fg = MDA_COLOR_BLACK;
                 }
 
                 if (mda->scanline == 12

--- a/src/video/vid_mda.c
+++ b/src/video/vid_mda.c
@@ -217,10 +217,16 @@ mda_poll(void *priv)
                         }
                         
                         buffer32->line[mda->displine][(x * 9) + c] = font_char;
-
                     }
                     if ((chr & ~0x1f) == 0xc0)
-                        buffer32->line[mda->displine][(x * 9) + 8] = mda_attr_to_color_table[attr][blink][fontdatm[chr + mda->fontbase][mda->scanline] & 1];
+                    {
+                        bool is_fg = fontdatm[chr + mda->fontbase][mda->scanline] & 1;
+
+                        if (is_fg)
+                            buffer32->line[mda->displine][(x * 9) + 8] = mda_attr_to_color_table[attr][blink][is_fg] | color_fg; 
+                        else
+                            buffer32->line[mda->displine][(x * 9) + 8] = mda_attr_to_color_table[attr][blink][is_fg] | color_bg; 
+                    }
                     else
                         buffer32->line[mda->displine][(x * 9) + 8] = mda_attr_to_color_table[attr][blink][0] | color_bg;
                 }

--- a/src/video/vid_mda.c
+++ b/src/video/vid_mda.c
@@ -198,7 +198,7 @@ mda_poll(void *priv)
 
                 if (mda->scanline == 12 && ((attr & 7) == 1)) { // underline
                     for (c = 0; c < 9; c++)
-                        buffer32->line[mda->displine][(x * 9) + c] = mda_attr_to_color_table[attr][blink][1] | color_bg;
+                        buffer32->line[mda->displine][(x * 9) + c] = mda_attr_to_color_table[attr][blink][1] | color_fg;
                 } else {
                     for (c = 0; c < 8; c++)
                     {
@@ -207,7 +207,8 @@ mda_poll(void *priv)
 
                         uint32_t font_char = mda_attr_to_color_table[attr][blink][is_fg];
 
-                        if (!(mda->mode & MDA_MODE_BW))
+                        if (mda->monitor_type == MDA_MONITOR_TYPE_RGBI 
+                            && !(mda->mode & MDA_MODE_BW))
                         {
                             if (!is_fg)
                                 font_char = 16 + color_bg; 

--- a/src/video/vid_mda.c
+++ b/src/video/vid_mda.c
@@ -213,7 +213,7 @@ mda_poll(void *priv)
 
                         // gray is black
                     if (color_fg == 7
-                    && color_bg == 7)
+                    && (color_bg == 7 || color_bg == 0))
                         color_fg = 0;
                 }
 

--- a/src/video/vid_mda.c
+++ b/src/video/vid_mda.c
@@ -203,17 +203,17 @@ mda_poll(void *priv)
 
                     bool special_treatment = (color_bg != 0 && color_bg != 7);
 
-                    if (color_fg == 7 
+                    if (color_fg == 8 
                     && special_treatment)
                         color_fg = 15;
                     
                     if (color_fg == 0
                     && special_treatment)
-                        color_fg = 7;
+                        color_fg = 8;
 
                         // gray is black
-                    if (color_fg == 7
-                    && (color_bg == 7 || color_bg == 0))
+                    if (color_fg == 8
+                    && (color_bg == 8 || color_bg == 0))
                         color_fg = 0;
                 }
 
@@ -225,7 +225,7 @@ mda_poll(void *priv)
                             && !(mda->mode & MDA_MODE_BW))
                         {
                             buffer32->line[mda->displine][(x * 9) + column] = CGAPAL_CGA_START + color_fg;
-                        }
+                   1     }
                         else
                             buffer32->line[mda->displine][(x * 9) + column] = mda_attr_to_color_table[attr][blink][1];
                     }

--- a/src/video/vid_mda.c
+++ b/src/video/vid_mda.c
@@ -186,15 +186,15 @@ mda_poll(void *priv)
                 int32_t color_bg = 0, color_fg = 0; 
     
                 // If we are using an RGBI monitor allow colour
-                //if (cga_palette == MDA_MONITOR_TYPE_RGBI)
-                //{
+                if (mda->monitor_type == MDA_MONITOR_TYPE_RGBI)
+                {
                     if (!(mda->mode & MDA_MODE_BW))
                     {
                         color_bg = (attr >> 4) & 0x0F;
                         color_fg = (attr & 0x0F); 
                     }
                         
-                //}
+                }
 
                 if (mda->scanline == 12 && ((attr & 7) == 1)) { // underline
                     for (c = 0; c < 9; c++)
@@ -360,7 +360,8 @@ mda_init(mda_t *mda)
     overscan_x = overscan_y = 0;
     mda->monitor_index      = monitor_index_global;
 
-    cga_palette = device_get_config_int("rgb_type") << 1;
+    mda->monitor_type = device_get_config_int("rgb_type");
+    cga_palette = mda->monitor_type << 1;
     if (cga_palette > 6) {
         cga_palette = 0;
     }

--- a/src/video/vid_mda.c
+++ b/src/video/vid_mda.c
@@ -183,24 +183,24 @@ mda_poll(void *priv)
                 drawcursor = ((mda->memaddr == cursoraddr) && mda->cursorvisible && mda->cursoron);
                 blink      = ((mda->blink & 16) && (mda->mode & MDA_MODE_BLINK) && (attr & 0x80) && !drawcursor);
 
+                // Colours that will be used
                 int32_t color_bg = 0, color_fg = 0; 
     
                 // If we are using an RGBI monitor allow colour
-                if (mda->monitor_type == MDA_MONITOR_TYPE_RGBI)
+                if (mda->monitor_type == MDA_MONITOR_TYPE_RGBI
+                && !(mda->mode & MDA_MODE_BW))
                 {
-                    if (!(mda->mode & MDA_MODE_BW))
-                    {
-                        color_bg = (attr >> 4) & 0x0F;
-                        color_fg = (attr & 0x0F); 
+                    color_bg = (attr >> 4) & 0x0F;
+                    color_fg = (attr & 0x0F); 
 
-                        // turn off bright bg colours in blink mode
-                        if ((mda->mode & MDA_MODE_BLINK)
-                        && (color_bg & 0x8))
-                            color_bg & ~(0x8);
-                    }   
+                    // turn off bright bg colours in blink mode
+                    if ((mda->mode & MDA_MODE_BLINK)
+                    && (color_bg & 0x8))
+                        color_bg & ~(0x8);
                 }
 
-                if (mda->scanline == 12 && ((attr & 7) == 1)) { // underline
+                if (mda->scanline == 12 && ((attr & 7) == 1)) 
+                { // underline
                     for (c = 0; c < 9; c++)
                     {
                         if (mda->monitor_type == MDA_MONITOR_TYPE_RGBI 
@@ -243,9 +243,11 @@ mda_poll(void *priv)
                     else
                         buffer32->line[mda->displine][(x * 9) + 8] = mda_attr_to_color_table[attr][blink][0] | color_bg;
                 }
+                
                 mda->memaddr++;
 
-                if (drawcursor) {
+                if (drawcursor) 
+                {
                     for (c = 0; c < 9; c++)
                         buffer32->line[mda->displine][(x * 9) + c] ^= mda_attr_to_color_table[attr][0][1] | color_fg;
                 }


### PR DESCRIPTION
Summary
=======
This enhances MDA to add MDA colour support:

1: Add "CGAPAL_CGA_BASE" define to video.h so cga palette using code can determine where the real cga palette starts
2: Add RGBI monitor type to MDA configuration
3: Add mda->monitor_type to store the selected monitor type (cgapalette is shifted left by 1)
4: When RGBI monitor type is selected, implement the unused rev0 MDA colour text support including forced underline for certain colours
5: Various comments and variable renames during mda, move from int to int32_t

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
