### PR TITLE
fix for conflicting types of Display

### DIFF
--- a/src/qt/qt_vmmanager_details.cpp
+++ b/src/qt/qt_vmmanager_details.cpp
@@ -26,6 +26,8 @@
 extern bool windows_is_light_theme();
 #endif
 
+using namespace VMManager;
+
 VMManagerDetails::VMManagerDetails(QWidget *parent) :
     QWidget(parent), ui(new Ui::VMManagerDetails) {
     ui->setupUi(this);

--- a/src/qt/qt_vmmanager_detailsection.cpp
+++ b/src/qt/qt_vmmanager_detailsection.cpp
@@ -21,6 +21,7 @@
 #include <QPushButton>
 
 const QString VMManagerDetailSection::sectionSeparator = ";";
+using namespace VMManager;
 
 VMManagerDetailSection::
 VMManagerDetailSection(const QString &sectionName)

--- a/src/qt/qt_vmmanager_detailsection.hpp
+++ b/src/qt/qt_vmmanager_detailsection.hpp
@@ -60,7 +60,7 @@ public:
 
     ~VMManagerDetailSection() override;
 
-    void addSection(const QString &name, const QString &value, Display::Name displayField = Display::Name::Unknown);
+    void addSection(const QString &name, const QString &value, VMManager::Display::Name displayField = VMManager::Display::Name::Unknown);
     void clear();
 
     CollapseButton *collapseButton;

--- a/src/qt/qt_vmmanager_system.cpp
+++ b/src/qt/qt_vmmanager_system.cpp
@@ -51,6 +51,8 @@ extern "C" {
 #include <86box/mouse.h>
 }
 
+using namespace VMManager;
+
 VMManagerSystem::VMManagerSystem(const QString &sysconfig_file)  {
 
     // The 86Box configuration file

--- a/src/qt/qt_vmmanager_system.hpp
+++ b/src/qt/qt_vmmanager_system.hpp
@@ -34,6 +34,8 @@ inline uint qHash(const T &t, uint seed) { \
     return ::qHash(static_cast<typename std::underlying_type<T>::type>(t), seed); \
 }
 
+namespace VMManager {
+Q_NAMESPACE
 namespace Display {
 Q_NAMESPACE
 enum class Name {
@@ -58,11 +60,12 @@ enum class Name {
 Q_ENUM_NS(Name)
 QHASH_FOR_CLASS_ENUM(Name)
 }
+}
 
 class VMManagerSystem : public QWidget {
     Q_OBJECT
 
-    typedef QHash<Display::Name, QString> display_table_t;
+    typedef QHash<VMManager::Display::Name, QString> display_table_t;
     typedef QHash <QString, QHash <QString, QString>> config_hash_t;
 
 public:
@@ -127,7 +130,7 @@ public:
 
     bool window_obscured;
 
-    QString getDisplayValue(Display::Name key);
+    QString getDisplayValue(VMManager::Display::Name key);
     QFileInfoList getScreenshots();
 
     inline bool operator==(const VMManagerSystem &rhs) const


### PR DESCRIPTION
Summary
=======
Compiling leads to a conflicting definition of Display if Qt is compiled with xcb (check the guard in QtGui/qguiapplication_platform.h). The other definition is from vmmanager in 86box. This conflicts during the moc-compilation for the qt-sources.

```
FAILED: src/qt/CMakeFiles/ui.dir/ui_autogen/mocs_compilation.cpp.o 
(clipped lots of lines)
qt_vmmanager_system.hpp: At global scope:
qt_vmmanager_system.hpp:37:11: error: ‘namespace Display { }’ redeclared as different kind of entity
   37 | namespace Display {
      |           ^~~~~~~
(further clipping)
/usr/include/qt6/QtGui/qguiapplication_platform.h:22:16: note: forward declaration of ‘struct _XDisplay’
   22 | typedef struct _XDisplay Display;
```

My suggestion is to namespace 86box's Display defintion further into something along the lines of VMManager.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
(none)
