### PR TITLE
Video: more changes and fixes of the day (June 26th, 2025)

### DIFF
--- a/src/include/86box/vid_ati_mach8.h
+++ b/src/include/86box/vid_ati_mach8.h
@@ -18,6 +18,12 @@
 #ifndef VIDEO_ATI_MACH8_H
 #define VIDEO_ATI_MACH8_H
 
+typedef enum {
+    ATI_68875 = 0,
+    ATI_68860,
+    RAMDAC_MAX
+} mach_ramdac_type;
+
 typedef struct mach_t {
     ati_eeprom_t eeprom;
     svga_t       svga;
@@ -39,7 +45,7 @@ typedef struct mach_t {
     uint8_t irq_state;
 
     int index;
-    int ramdac_type;
+    mach_ramdac_type ramdac_type;
     int old_mode;
 
     uint16_t config1;

--- a/src/include/86box/vid_svga.h
+++ b/src/include/86box/vid_svga.h
@@ -136,6 +136,7 @@ typedef struct svga_t {
     int packed_4bpp;
     int ps_bit_bug;
     int ati_4color;
+    int vblankend;
 
     /*The three variables below allow us to implement memory maps like that seen on a 1MB Trio64 :
       0MB-1MB - VRAM
@@ -404,15 +405,15 @@ uint32_t svga_lookup_lut_ram(svga_t* svga, uint32_t val);
 
 /* We need a way to add a device with a pointer to a parent device so it can attach itself to it, and
    possibly also a second ATi 68860 RAM DAC type that auto-sets SVGA render on RAM DAC render change. */
-extern void    ati68860_ramdac_out(uint16_t addr, uint8_t val, void *priv, svga_t *svga);
-extern uint8_t ati68860_ramdac_in(uint16_t addr, void *priv, svga_t *svga);
+extern void    ati68860_ramdac_out(uint16_t addr, uint8_t val, int is_8514, void *priv, svga_t *svga);
+extern uint8_t ati68860_ramdac_in(uint16_t addr, int is_8514, void *priv, svga_t *svga);
 extern void    ati68860_set_ramdac_type(void *priv, int type);
 extern void    ati68860_ramdac_set_render(void *priv, svga_t *svga);
 extern void    ati68860_ramdac_set_pallook(void *priv, int i, uint32_t col);
 extern void    ati68860_hwcursor_draw(svga_t *svga, int displine);
 
-extern void    ati68875_ramdac_out(uint16_t addr, int rs2, int rs3, uint8_t val, void *priv, svga_t *svga);
-extern uint8_t ati68875_ramdac_in(uint16_t addr, int rs2, int rs3, void *priv, svga_t *svga);
+extern void    ati68875_ramdac_out(uint16_t addr, int rs2, int rs3, uint8_t val, int is_8514, void *priv, svga_t *svga);
+extern uint8_t ati68875_ramdac_in(uint16_t addr, int rs2, int rs3, int is_8514, void *priv, svga_t *svga);
 
 extern void    att49x_ramdac_out(uint16_t addr, int rs2, uint8_t val, void *priv, svga_t *svga);
 extern uint8_t att49x_ramdac_in(uint16_t addr, int rs2, void *priv, svga_t *svga);

--- a/src/video/ramdac/vid_ramdac_ati68860.c
+++ b/src/video/ramdac/vid_ramdac_ati68860.c
@@ -67,22 +67,22 @@ typedef struct ati68860_ramdac_t {
 } ati68860_ramdac_t;
 
 void
-ati68860_ramdac_out(uint16_t addr, uint8_t val, void *priv, svga_t *svga)
+ati68860_ramdac_out(uint16_t addr, uint8_t val, int is_8514, void *priv, svga_t *svga)
 {
     ati68860_ramdac_t *ramdac = (ati68860_ramdac_t *) priv;
 
     switch (addr) {
         case 0:
-            svga_out(0x3c8, val, svga);
+            svga_out(is_8514 ? 0x2ec : 0x3c8, val, svga);
             break;
         case 1:
-            svga_out(0x3c9, val, svga);
+            svga_out(is_8514 ? 0x2ed : 0x3c9, val, svga);
             break;
         case 2:
-            svga_out(0x3c6, val, svga);
+            svga_out(is_8514 ? 0x2ea : 0x3c6, val, svga);
             break;
         case 3:
-            svga_out(0x3c7, val, svga);
+            svga_out(is_8514 ? 0x2eb : 0x3c7, val, svga);
             break;
         default:
             ramdac->regs[addr & 0xf] = val;
@@ -172,23 +172,23 @@ ati68860_ramdac_out(uint16_t addr, uint8_t val, void *priv, svga_t *svga)
 }
 
 uint8_t
-ati68860_ramdac_in(uint16_t addr, void *priv, svga_t *svga)
+ati68860_ramdac_in(uint16_t addr, int is_8514, void *priv, svga_t *svga)
 {
     const ati68860_ramdac_t *ramdac = (ati68860_ramdac_t *) priv;
     uint8_t                  temp   = 0;
 
     switch (addr) {
         case 0:
-            temp = svga_in(0x3c8, svga);
+            temp = svga_in(is_8514 ? 0x2ec : 0x3c8, svga);
             break;
         case 1:
-            temp = svga_in(0x3c9, svga);
+            temp = svga_in(is_8514 ? 0x2ed : 0x3c9, svga);
             break;
         case 2:
-            temp = svga_in(0x3c6, svga);
+            temp = svga_in(is_8514 ? 0x2ea : 0x3c6, svga);
             break;
         case 3:
-            temp = svga_in(0x3c7, svga);
+            temp = svga_in(is_8514 ? 0x2eb : 0x3c7, svga);
             break;
         case 4:
         case 8:

--- a/src/video/ramdac/vid_ramdac_ati68875.c
+++ b/src/video/ramdac/vid_ramdac_ati68875.c
@@ -38,7 +38,7 @@ typedef struct ati68875_ramdac_t {
 } ati68875_ramdac_t;
 
 void
-ati68875_ramdac_out(uint16_t addr, int rs2, int rs3, uint8_t val, void *priv, svga_t *svga)
+ati68875_ramdac_out(uint16_t addr, int rs2, int rs3, uint8_t val, int is_8514, void *priv, svga_t *svga)
 {
     ati68875_ramdac_t *ramdac = (ati68875_ramdac_t *) priv;
     uint8_t rs = (addr & 0x03);
@@ -48,10 +48,16 @@ ati68875_ramdac_out(uint16_t addr, int rs2, int rs3, uint8_t val, void *priv, sv
 
     switch (rs) {
         case 0x00: /* Palette Write Index Register (RS value = 0000) */
+            svga_out(is_8514 ? 0x2ec : 0x3c8, val, svga);
+            break;
         case 0x01: /* Palette Data Register (RS value = 0001) */
+            svga_out(is_8514 ? 0x2ed : 0x3c9, val, svga);
+            break;
         case 0x02: /* Pixel Read Mask Register (RS value = 0010) */
-        case 0x03:
-            svga_out(addr, val, svga);
+            svga_out(is_8514 ? 0x2ea : 0x3c6, val, svga);
+            break;
+        case 0x03: /* Palette Read Index Register (RS value = 0011) */
+            svga_out(is_8514 ? 0x2eb : 0x3c7, val, svga);
             break;
         case 0x08: /* General Control Register (RS value = 1000) */
             ramdac->gen_cntl = val;
@@ -83,7 +89,7 @@ ati68875_ramdac_out(uint16_t addr, int rs2, int rs3, uint8_t val, void *priv, sv
 }
 
 uint8_t
-ati68875_ramdac_in(uint16_t addr, int rs2, int rs3, void *priv, svga_t *svga)
+ati68875_ramdac_in(uint16_t addr, int rs2, int rs3, int is_8514, void *priv, svga_t *svga)
 {
     const ati68875_ramdac_t *ramdac = (ati68875_ramdac_t *) priv;
     uint8_t                  rs = (addr & 0x03);
@@ -94,10 +100,16 @@ ati68875_ramdac_in(uint16_t addr, int rs2, int rs3, void *priv, svga_t *svga)
 
     switch (rs) {
         case 0x00: /* Palette Write Index Register (RS value = 0000) */
+            temp = svga_in(is_8514 ? 0x2ec : 0x3c8, svga);
+            break;
         case 0x01: /* Palette Data Register (RS value = 0001) */
+            temp = svga_in(is_8514 ? 0x2ed : 0x3c9, svga);
+            break;
         case 0x02: /* Pixel Read Mask Register (RS value = 0010) */
-        case 0x03:
-            temp = svga_in(addr, svga);
+            temp = svga_in(is_8514 ? 0x2ea : 0x3c6, svga);
+            break;
+        case 0x03: /* Palette Read Index Register (RS value = 0011) */
+            temp = svga_in(is_8514 ? 0x2eb : 0x3c7, svga);
             break;
         case 0x08: /* General Control Register (RS value = 1000) */
             temp = ramdac->gen_cntl;

--- a/src/video/vid_ati_mach64.c
+++ b/src/video/vid_ati_mach64.c
@@ -425,7 +425,7 @@ mach64_out(uint16_t addr, uint8_t val, void *priv)
         case 0x3C8:
         case 0x3C9:
             if (mach64->type == MACH64_GX)
-                ati68860_ramdac_out((addr & 3) | ((mach64->dac_cntl & 3) << 2), val, svga->ramdac, svga);
+                ati68860_ramdac_out((addr & 3) | ((mach64->dac_cntl & 3) << 2), val, 0, svga->ramdac, svga);
             else
                 svga_out(addr, val, svga);
             return;
@@ -492,7 +492,7 @@ mach64_in(uint16_t addr, void *priv)
         case 0x3C8:
         case 0x3C9:
             if (mach64->type == MACH64_GX)
-                return ati68860_ramdac_in((addr & 3) | ((mach64->dac_cntl & 3) << 2), svga->ramdac, svga);
+                return ati68860_ramdac_in((addr & 3) | ((mach64->dac_cntl & 3) << 2), 0, svga->ramdac, svga);
             return svga_in(addr, svga);
 
         case 0x3D4:
@@ -2530,7 +2530,7 @@ mach64_ext_readb(uint32_t addr, void *priv)
             case 0xc2:
             case 0xc3:
                 if (mach64->type == MACH64_GX)
-                    ret = ati68860_ramdac_in((addr & 3) | ((mach64->dac_cntl & 3) << 2), mach64->svga.ramdac, &mach64->svga);
+                    ret = ati68860_ramdac_in((addr & 3) | ((mach64->dac_cntl & 3) << 2), 0, mach64->svga.ramdac, &mach64->svga);
                 else {
                     switch (addr & 3) {
                         case 0:
@@ -3313,7 +3313,7 @@ mach64_ext_writeb(uint32_t addr, uint8_t val, void *priv)
             case 0xc2:
             case 0xc3:
                 if (mach64->type == MACH64_GX)
-                    ati68860_ramdac_out((addr & 3) | ((mach64->dac_cntl & 3) << 2), val, svga->ramdac, svga);
+                    ati68860_ramdac_out((addr & 3) | ((mach64->dac_cntl & 3) << 2), val, 0, svga->ramdac, svga);
                 else {
                     switch (addr & 3) {
                         case 0:
@@ -3574,7 +3574,7 @@ mach64_ext_inb(uint16_t port, void *priv)
         case 0x5eee:
         case 0x5eef:
             if (mach64->type == MACH64_GX)
-                ret = ati68860_ramdac_in((port & 3) | ((mach64->dac_cntl & 3) << 2), mach64->svga.ramdac, &mach64->svga);
+                ret = ati68860_ramdac_in((port & 3) | ((mach64->dac_cntl & 3) << 2), 0, mach64->svga.ramdac, &mach64->svga);
             else {
                 switch (port & 3) {
                     case 0:
@@ -3820,7 +3820,7 @@ mach64_ext_outb(uint16_t port, uint8_t val, void *priv)
         case 0x5eee:
         case 0x5eef:
             if (mach64->type == MACH64_GX)
-                ati68860_ramdac_out((port & 3) | ((mach64->dac_cntl & 3) << 2), val, svga->ramdac, svga);
+                ati68860_ramdac_out((port & 3) | ((mach64->dac_cntl & 3) << 2), val, 0, svga->ramdac, svga);
             else {
                 switch (port & 3) {
                     case 0:
@@ -4801,6 +4801,7 @@ mach64vt2_init(const device_t *info)
     video_inform(VIDEO_FLAG_TYPE_SPECIAL, &timing_mach64_pci);
 
     mach64->pci                  = 1;
+    mach64->vlb                  = 0;
     mach64->pci_id               = 0x5654;
     mach64->config_chip_id       = 0x40005654;
     mach64->dac_cntl             = 1 << 16; /*Internal 24-bit DAC*/

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -693,7 +693,6 @@ svga_recalctimings(svga_t *svga)
     double           _dispontime_xga = 0.0;
     double           _dispofftime_xga = 0.0;
     double           disptime_xga = 0.0;
-    int              vblankend;
 #ifdef ENABLE_SVGA_LOG
     int              vsyncend;
     int              hdispend;
@@ -913,9 +912,9 @@ svga_recalctimings(svga_t *svga)
     if (xga_active && (svga->xga != NULL))
         xga_recalctimings(svga);
 
-    vblankend = (svga->vblankstart & 0xffffff80) | (svga->crtc[0x16] & 0x7f);
-    if (vblankend <= svga->vblankstart)
-        vblankend += 0x00000080;
+    svga->vblankend = (svga->vblankstart & 0xffffff80) | (svga->crtc[0x16] & 0x7f);
+    if (svga->vblankend <= svga->vblankstart)
+        svga->vblankend += 0x00000080;
 
     if (svga->hoverride || svga->override) {
         if (svga->hdisp >= 2048)
@@ -969,7 +968,7 @@ svga_recalctimings(svga_t *svga)
         }
 
         /* - 1 because + 1 but also - 2 to compensate for the + 2 added to vtotal above. */
-        svga->y_add = svga->vtotal - vblankend - 1;
+        svga->y_add = svga->vtotal - svga->vblankend - 1;
         svga->monitor->mon_overscan_y = svga->y_add + abs(svga->vblankstart - svga->dispend);
 
         if ((svga->dispend >= 2048) || (svga->y_add < 0)) {
@@ -1050,7 +1049,7 @@ svga_recalctimings(svga_t *svga)
              "\n"
              "\n",
              svga->vtotal, svga->dispend, svga->vsyncstart, vsyncend,
-             svga->vblankstart, vblankend,
+             svga->vblankstart, svga->vblankend,
              svga->htotal, hdispstart, hdispend, hsyncstart, hsyncend,
              svga->hblankstart, svga->hblankend);
 


### PR DESCRIPTION
Summary
=======
1. Convert the ramdac types into an enumerator.
2. Make sure the 8514/A compatible ramdacs are, if in VGA mode, using VGA compatible ports and/or, in 8514/A mode, the 8514/A ports when needed, fixes color issues in 1280x1024 resolutions on NT 3.1 and various stuff using the Mach32.
3. Add pitch initialization on reset, fixes 8514/A display drivers on various stuff on Mach8/Mach32 cards.

Checklist
=========
* [X] Closes #5708
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
