### PR TITLE
Olivetti M290 fixes

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -3141,7 +3141,7 @@ const machine_t machines[] = {
     },
     /* Has Olivetti KBC firmware. */
     {
-        .name = "[ISA] Olivetti M290",
+        .name = "[ISA] Olivetti M290/AT&T 6286 WGS",
         .internal_name = "m290",
         .type = MACHINE_TYPE_286,
         .chipset = MACHINE_CHIPSET_PROPRIETARY,
@@ -3163,7 +3163,7 @@ const machine_t machines[] = {
         .bus_flags = MACHINE_AT,
         .flags = MACHINE_FLAGS_NONE,
         .ram = {
-            .min = 640,
+            .min = 1024,
             .max = 16384,
             .step = 128
         },


### PR DESCRIPTION
Change minimum RAM to 1 MB and add the name of the AT&T variant, which seems to have the exact same BIOS

Summary
=======
Since the Olivetti M290 does not boot correctly with less than 1 MB of RAM, I have changed the minimum RAM amount to 1 MB. Also, I changed the machine name to reflect the name of the AT&T counterpart, which from photos, seems to have the exact same BIOS.

Checklist
=========
* [ ] I have discussed this with core contributors already

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
https://wiki.preterhuman.net/AT%26T_6286_WGS the BIOS photo shows the same revision and POST screen as the M290 BIOS in 86Box