### PR TITLE
Actually use the configuration of the FDC cards when needed.

### DIFF
--- a/src/qt/qt_settingsstoragecontrollers.cpp
+++ b/src/qt/qt_settingsstoragecontrollers.cpp
@@ -243,7 +243,7 @@ SettingsStorageControllers::on_comboBoxFD_currentIndexChanged(int index)
     if (index < 0)
         return;
 
-    ui->pushButtonFD->setEnabled(hdc_has_config(ui->comboBoxFD->currentData().toInt()) > 0);
+    ui->pushButtonFD->setEnabled(fdc_card_has_config(ui->comboBoxFD->currentData().toInt()) > 0);
 }
 
 void


### PR DESCRIPTION
Summary
=======
Should fix unavailable configuration boxes in the 86box settings GUI.

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
