### PR TITLE
Remove onboard SCSI from V12P

### DIFF
--- a/src/machine/m_at_socket4.c
+++ b/src/machine/m_at_socket4.c
@@ -71,8 +71,7 @@ machine_at_v12p_init(const machine_t *model)
     device_add(&keyboard_ps2_acer_pci_device);
     device_add(&sio_zb_device);
     device_add_params(&pc87310_device, (void *) (PC87310_ALI));
-	device_add(&amd_am28f010_flash_device);
-	device_add(&ncr53c810_onboard_pci_device);
+    device_add(&amd_am28f010_flash_device);
 
     return ret;
 }

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -10079,7 +10079,7 @@ const machine_t machines[] = {
             .max_multi = MACHINE_MULTIPLIER_FIXED
         },
         .bus_flags = MACHINE_PS2_PCI,
-        .flags = MACHINE_IDE | MACHINE_SCSI | MACHINE_APM,
+        .flags = MACHINE_IDE | MACHINE_APM,
         .ram = {
             .min = 2048,
             .max = 196608,


### PR DESCRIPTION
Summary
=======
According to two photos of Acer V12P on The Retro Web, this does not have onboard NCR 53c810 SCSI controller, so this removes internal SCSI controller from the machine.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[Acer V12P page on The Retro Web](https://theretroweb.com/motherboards/s/acer-v12p)
