### PR TITLE
Fix swapped value of the ramdacs used by the Mach32 PCI.

### DIFF
--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -7141,9 +7141,9 @@ mach8_init(const device_t *info)
             video_inform(VIDEO_FLAG_TYPE_8514, &timing_mach32_pci);
             mach->config1 |= 0x0e;
             if (mach->ramdac_type == ATI_68860)
-                mach->config1 |= 0x0400;
-            else
                 mach->config1 |= 0x0a00;
+            else
+                mach->config1 |= 0x0400;
             mach->config2 |= 0x2000;
             svga->clock_gen = device_add(&ati18811_1_device);
         } else {


### PR DESCRIPTION
Summary
=======
Now it correctly detects what's selected as the ramdac.

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[Mach32 manual, page 301 of the PDF](https://fenarinarsa.com/misc/atari-forum/reg-688000-15_programmers_guide_to_the_mach32_registers.pdf)
