### PR TITLE
Siemens-Nixdorf D943: Correct memory step

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -12290,7 +12290,7 @@ const machine_t machines[] = {
         .ram = {
             .min = 8192,
             .max = 131072,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask = 511,
         .kbc_device = NULL,


### PR DESCRIPTION
Summary
=======
Correct RAM memory step from `8192` to `4096`

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
According to D943's [technical manual](https://theretroweb.com/motherboard/manual/fts-systemboardd943technicalmanualen-10-1083435.pdf-5f6735e51714c464590416.pdf), it supports 4mb memory modules.