### PR TITLE
fix SID emulation logic, add some UI elements for SID config

### DIFF
--- a/src/sound/snd_resid.cpp
+++ b/src/sound/snd_resid.cpp
@@ -20,23 +20,28 @@ typedef struct psid_t {
 psid_t *psid;
 
 void *
-sid_init(uint8_t type)
+sid_init(uint8_t type, double range)
 {
     reSIDfp::SamplingMethod method         = reSIDfp::RESAMPLE;
     float                   cycles_per_sec = 14318180.0 / 16.0;
 
     psid      = new psid_t;
     psid->sid = new SID;
-
+	psid->sid->setFilter6581Range(range);
+	psid->sid->reset();
     switch (type) {
         default:
+		    psid->sid->setChipModel(reSIDfp::MOS6581);
+			break;
         case 0:
             psid->sid->setChipModel(reSIDfp::MOS6581);
+			break;
         case 1:
             psid->sid->setChipModel(reSIDfp::MOS8580);
+			break;
     }
 
-    psid->sid->reset();
+
 
     for (uint8_t c = 0; c < 32; c++)
         psid->sid->write(c, 0);

--- a/src/sound/snd_ssi2001.c
+++ b/src/sound/snd_ssi2001.c
@@ -72,7 +72,7 @@ ssi2001_init(UNUSED(const device_t *info))
 {
     ssi2001_t *ssi2001 = calloc(1, sizeof(ssi2001_t));
 
-    ssi2001->psid = sid_init(0);
+    ssi2001->psid = sid_init(device_get_config_int("sid_config"),device_get_config_int("sid_adjustment"));
     sid_reset(ssi2001->psid);
     uint16_t addr             = device_get_config_hex16("base");
     ssi2001->gameport_enabled = device_get_config_int("gameport");
@@ -112,7 +112,7 @@ entertainer_init(UNUSED(const device_t *info))
     ssi2001_t     *ssi2001     = calloc(1, sizeof(ssi2001_t));
     entertainer_t *entertainer = calloc(1, sizeof(entertainer_t));
 
-    ssi2001->psid = sid_init(0);
+    ssi2001->psid = sid_init(0, 0.5);
     sid_reset(ssi2001->psid);
     ssi2001->gameport_enabled = device_get_config_int("gameport");
     io_sethandler(0x200, 0x0001, entertainer_read, NULL, NULL, entertainer_write, NULL, NULL, entertainer);
@@ -161,6 +161,33 @@ static const device_config_t ssi2001_config[] = {
         .file_filter    = NULL,
         .spinner        = { 0 },
         .selection      = { { 0 } },
+        .bios           = { { 0 } }
+    },
+	
+	{
+        .name           = "sid_config",
+        .description    = "SID Model",
+        .type           = CONFIG_HEX16,
+        .default_string = NULL,
+        .default_int    = 0x000,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .selection      = {             
+		{ .description = "8580", .value = 0x001 },
+        { .description = "6581", .value = 0x000 },
+		{ .description = ""                      }
+		},
+        .bios           = { { 0 } }
+    },
+	{
+        .name           = "sid_adjustment",
+        .description    = "SID Filter Strength",
+        .type           = CONFIG_STRING,
+        .default_string = "0.5",
+		.default_int    = 0,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .selection      = {{"0.5"}},
         .bios           = { { 0 } }
     },
     { .name = "", .description = "", .type = CONFIG_END }


### PR DESCRIPTION
Summary
=======
_Briefly describe what you are submitting._
Fixed up SID emulation. There were no breaks in the switch case so it was always falling to 8580 emu no matter the type select.
Added controls for SID filter strength, and added a selector for SID model (8580 and 6581).

Checklist
=========
* [ ] I have discussed this with core contributors already - Yes
* [ ] This pull request requires changes to the ROM set - No

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
None