### PR TITLE
Copper demo wobbling effects now show up correctly

### DIFF
--- a/src/include/86box/vid_svga.h
+++ b/src/include/86box/vid_svga.h
@@ -30,6 +30,7 @@
 #    define FLAG_S3_911_16BIT 256
 #    define FLAG_512K_MASK    512
 #    define FLAG_NO_SHIFT3    1024 /* Needed for Bochs VBE. */
+#    define FLAG_PRECISETIME  2048 /* Needed for Copper demo if on dynarec. */
 struct monitor_t;
 
 typedef struct hwcursor_t {
@@ -138,6 +139,8 @@ typedef struct svga_t {
     int ati_4color;
     int vblankend;
     int panning_blank;
+    int render_line_offset;
+    int start_retrace_latch;
 
     /*The three variables below allow us to implement memory maps like that seen on a 1MB Trio64 :
       0MB-1MB - VRAM

--- a/src/video/vid_et4000.c
+++ b/src/video/vid_et4000.c
@@ -892,6 +892,9 @@ et4000_init(const device_t *info)
     if (dev->type >= ET4000_TYPE_ISA)
         dev->svga.ramdac = device_add(&sc1502x_ramdac_device);
 
+    if (dev->type == ET4000_TYPE_TC6058AF)
+        dev->svga.adv_flags |= FLAG_PRECISETIME;
+
     dev->vram_mask = dev->vram_size - 1;
 
     rom_init(&dev->bios_rom, fn,

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -703,6 +703,13 @@ svga_recalctimings(svga_t *svga)
     int              old_monitor_overscan_x = svga->monitor->mon_overscan_x;
     int              old_monitor_overscan_y = svga->monitor->mon_overscan_y;
 
+    if (svga->adv_flags & FLAG_PRECISETIME) {
+#ifdef USE_DYNAREC
+        if (cpu_use_dynarec)
+            update_tsc();
+#endif
+    }
+
     svga->vtotal      = svga->crtc[6];
     svga->dispend     = svga->crtc[0x12];
     svga->vsyncstart  = svga->crtc[0x10];
@@ -1253,6 +1260,7 @@ svga_do_render(svga_t *svga)
     }
 
     if (!svga->override) {
+        svga->render_line_offset = svga->start_retrace_latch - svga->crtc[0x4];
         svga->render(svga);
 
         svga->x_add = svga->left_overscan;
@@ -1514,6 +1522,8 @@ svga_poll(void *priv)
 
             if (svga->vsync_callback)
                 svga->vsync_callback(svga);
+
+            svga->start_retrace_latch = svga->crtc[0x4];
         }
 #if 0
         if (svga->vc == lines_num) {


### PR DESCRIPTION
Summary
=======
Copper demo wobbling effects now show up correctly.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
