### PR TITLE
Disable VM Manager updater on EMU_BUILD_NUM == 0 (local/GHA builds).

### DIFF
--- a/src/qt/qt_vmmanager_main.cpp
+++ b/src/qt/qt_vmmanager_main.cpp
@@ -456,6 +456,7 @@ VMManagerMain::onPreferencesUpdated()
 void
 VMManagerMain::backgroundUpdateCheckStart() const
 {
+#if EMU_BUILD_NUM != 0
     auto updateChannel = UpdateCheck::UpdateChannel::CI;
 #ifdef RELEASE_BUILD
     updateChannel = UpdateCheck::UpdateChannel::Stable;
@@ -464,6 +465,7 @@ VMManagerMain::backgroundUpdateCheckStart() const
     connect(updateCheck, &UpdateCheck::updateCheckComplete, this, &VMManagerMain::backgroundUpdateCheckComplete);
     connect(updateCheck, &UpdateCheck::updateCheckError, this, &VMManagerMain::backgroundUpdateCheckError);
     updateCheck->checkForUpdates();
+#endif
 }
 
 void

--- a/src/qt/qt_vmmanager_mainwindow.cpp
+++ b/src/qt/qt_vmmanager_mainwindow.cpp
@@ -48,8 +48,13 @@ VMManagerMainWindow(QWidget *parent)
     connect(ui->actionNew_Machine, &QAction::triggered, vmm, &VMManagerMain::newMachineWizard);
 
     // Set up menu actions
-    connect(ui->actionCheck_for_updates, &QAction::triggered, this, &VMManagerMainWindow::checkForUpdatesTriggered);
-
+    // (Disable this if the EMU_BUILD_NUM == 0)
+    #if EMU_BUILD_NUM == 0
+        ui->actionCheck_for_updates->setVisible(false);
+    #else
+        connect(ui->actionCheck_for_updates, &QAction::triggered, this, &VMManagerMainWindow::checkForUpdatesTriggered);
+    #endif
+    
     // TODO: Remove all of this (all the way to END REMOVE) once certain the search will no longer be in the toolbar.
     // BEGIN REMOVE
     // Everything is still setup here for it but it is all hidden. None of it will be


### PR DESCRIPTION
Summary
=======
Disables both the initial background update check and the "Tools->Check for updates" menu if the EMU_BUILD_NUM is 0, removing this code from being active on local or GitHub Actions builds.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
