### PR TITLE
Make picture bouncing effect work on Copper demo on ET4000AX and ET3000AX

### DIFF
--- a/src/video/vid_et3000.c
+++ b/src/video/vid_et3000.c
@@ -481,6 +481,17 @@ et3000_recalctimings(svga_t *svga)
         svga->render = svga_render_4bpp_tseng_highres;
 }
 
+static int
+et3000_line_compare(svga_t* svga)
+{
+    if (svga->split > svga->vsyncstart) {
+        /* Don't do line compare if we're already in vertical retrace. */
+        /* This makes picture bouncing effect work on Copper demo. */
+        return 0;
+    }
+    return 1;
+}
+
 static void *
 et3000_init(const device_t *info)
 {
@@ -514,6 +525,7 @@ et3000_init(const device_t *info)
     dev->svga.miscout = 1;
 
     dev->svga.packed_chain4 = 1;
+    dev->svga.line_compare  = et3000_line_compare;
 
     return dev;
 }

--- a/src/video/vid_et4000.c
+++ b/src/video/vid_et4000.c
@@ -784,6 +784,17 @@ et4000_mca_feedb(UNUSED(void *priv))
     return et4000->pos_regs[2] & 1;
 }
 
+static int
+et4000_line_compare(svga_t* svga)
+{
+    if (svga->split > svga->vsyncstart) {
+        /* Don't do line compare if we're already in vertical retrace. */
+        /* This makes picture bouncing effect work on Copper demo. */
+        return 0;
+    }
+    return 1;
+}
+
 static void *
 et4000_init(const device_t *info)
 {
@@ -896,6 +907,8 @@ et4000_init(const device_t *info)
         dev->svga.adv_flags |= FLAG_PRECISETIME;
 
     dev->vram_mask = dev->vram_size - 1;
+
+    dev->svga.line_compare = et4000_line_compare;
 
     rom_init(&dev->bios_rom, fn,
         0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);


### PR DESCRIPTION
Summary
=======
Make picture bouncing effect work on Copper demo on ET4000AX and ET3000AX.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
