### PR TITLE
Manager: Allow whitespace and some special characters in machine crea…

### DIFF
--- a/src/qt/qt_vmmanager_addmachine.cpp
+++ b/src/qt/qt_vmmanager_addmachine.cpp
@@ -210,7 +210,13 @@ NameAndLocationPage(QWidget *parent)
 {
     setTitle(tr("System name and location"));
 
-    dirValidate = QRegularExpression(R"(^[^\\/:*?"<>|\s]+$)");
+#if defined(_WIN32)
+    dirValidate = QRegularExpression(R"(^[^\\/:*?"<>|]+$)");
+#elif defined(__APPLE__)
+    dirValidate = QRegularExpression(R"(^[^/:]+$)");
+#else
+    dirValidate = QRegularExpression(R"(^[^/]+$)");
+#endif
 
     const auto topLabel = new QLabel(tr("Enter the name of the system and choose the location"));
     topLabel->setWordWrap(true);
@@ -282,7 +288,7 @@ NameAndLocationPage::isComplete() const
     if (systemName->text().isEmpty()) {
         systemNameValidation->setText(tr("Please enter a system name"));
     } else if (!systemName->text().contains(dirValidate)) {
-        systemNameValidation->setText(tr("System name cannot contain a space or certain characters"));
+        systemNameValidation->setText(tr("System name cannot certain characters"));
     } else if (const QDir newDir = QDir::cleanPath(systemLocation->text() + "/" + systemName->text()); newDir.exists()) {
         systemNameValidation->setText(tr("System name already exists"));
     } else {


### PR DESCRIPTION
…tion wizard


Summary
=======

I'm not sure why whitespace was disallowed in the first place as Windows accepts them everywhere, including at the start of the name. The character blacklist was Windows-centric, but macOS accepts everything besides slash and colon and Linux disallows only a slash.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request

References
==========
