### PR TITLE
Fix one edge case of gpstatus stall.

### DIFF
--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -270,7 +270,7 @@ mach_log(const char *fmt, ...)
 static int
 mach_pixel_write(mach_t *mach)
 {
-    if (mach->accel.dp_config & 1)
+    if (mach->accel.dp_config & 0x01)
         return 1;
 
     return 0;
@@ -279,7 +279,7 @@ mach_pixel_write(mach_t *mach)
 static int
 mach_pixel_read(mach_t *mach)
 {
-    if (mach->accel.dp_config & 1)
+    if (mach->accel.dp_config & 0x01)
         return 0;
 
     return 1;
@@ -4303,6 +4303,10 @@ mach_accel_in_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, in
                                     dev->force_busy = 0;
                                 else if ((mono_src == 2) || (frgd_sel == 2) || (bkgd_sel == 2))
                                     dev->force_busy = 0;
+                                else if (!dev->accel.cmd_back)
+                                    dev->force_busy = 0;
+
+                                mach_log("2Force Busy=%d, frgdsel=%d, bkgdsel=%d, monosrc=%d, read=%d, dpconfig=%04x, back=%d.\n", dev->force_busy, frgd_sel, bkgd_sel, mono_src, mach_pixel_read(mach), mach->accel.dp_config, dev->accel.cmd_back);
                                 break;
                             case 5:
                                 if (dev->accel.sx >= mach->accel.width)


### PR DESCRIPTION
Summary
=======
Which fixes Win3.1's Mach32 2.3 4bpp driver stalling.

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
