### PR TITLE
Always load "opengl32.dll" from application directory if it exists

### DIFF
--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -102,6 +102,8 @@ bool cpu_thread_running = false;
 void qt_set_sequence_auto_mnemonic(bool b);
 
 #ifdef Q_OS_WINDOWS
+bool acp_utf8 = false;
+
 static void
 keyboard_getkeymap()
 {
@@ -515,6 +517,13 @@ extern bool windows_is_light_theme();
 int
 main(int argc, char *argv[])
 {
+#ifdef Q_OS_WINDOWS
+    /* Check if Windows supports UTF-8 */
+    if (GetACP() == CP_UTF8)
+	    acp_utf8 = 1;
+    else
+	    acp_utf8 = 0;
+#endif
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QApplication::setAttribute(Qt::AA_DisableHighDpiScaling, false);
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
@@ -530,6 +539,9 @@ main(int argc, char *argv[])
 
 #ifdef Q_OS_WINDOWS
     Q_INIT_RESOURCE(darkstyle);
+    if (QFile(QApplication::applicationDirPath() + "/opengl32.dll").exists()) {
+        qputenv("QT_OPENGL_DLL", QFileInfo(QApplication::applicationDirPath() + "/opengl32.dll").absoluteFilePath().toUtf8());
+    }
     QApplication::setAttribute(Qt::AA_NativeWindows);
 
     if (!windows_is_light_theme()) {

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -177,14 +177,28 @@ do_stop(void)
 #endif
 }
 
+extern bool acp_utf8;
 void
 plat_get_exe_name(char *s, int size)
 {
+#ifdef Q_OS_WINDOWS
+    wchar_t *temp;
+
+    if (acp_utf8)
+        GetModuleFileNameA(NULL, s, size);
+    else {
+        temp = (wchar_t*)calloc(size, sizeof(wchar_t));
+        GetModuleFileNameW(NULL, temp, size);
+        c16stombs(s, (uint16_t*)temp, size);
+        free(temp);
+    }
+#else
     QByteArray exepath_temp = QCoreApplication::applicationDirPath().toLocal8Bit();
 
     memcpy(s, exepath_temp.data(), std::min((qsizetype) exepath_temp.size(), (qsizetype) size));
 
     path_slash(s);
+#endif
 }
 
 uint32_t


### PR DESCRIPTION
Summary
=======
Always load "opengl32.dll" from application directory if it exists.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
