### PR TITLE
SVGA: Don't draw blank screens out of bounds

### DIFF
--- a/src/video/vid_svga_render.c
+++ b/src/video/vid_svga_render.c
@@ -58,7 +58,7 @@ svga_render_null(svga_t *svga)
 void
 svga_render_blank(svga_t *svga)
 {
-    if ((svga->displine + svga->y_add) < 0)
+    if ((svga->displine + svga->y_add) < 0 || (svga->displine + svga->y_add) >= 2048)
         return;
 
     if (svga->firstline_draw == 2000)


### PR DESCRIPTION
Summary
=======
SVGA: Don't draw blank screens out of bounds.

Checklist
=========
* [X} Closes #5758
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
