### PR TITLE
Add sanity checks to the Gameport pointer (July 10th, 2025)

### DIFF
--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -1152,11 +1152,13 @@ sb_ct1745_mixer_write(uint16_t addr, uint8_t val, void *priv)
                         else if ((val & 0x06) == 0x02)
                             mpu401_change_addr(sb->mpu, 0);
                     }
-                    sb->gameport_addr = 0;
-                    gameport_remap(sb->gameport, 0);
-                    if (!(val & 0x01)) {
-                        sb->gameport_addr = 0x200;
-                        gameport_remap(sb->gameport, 0x200);
+                    if (sb->gameport != NULL) {
+                        sb->gameport_addr = 0;
+                        gameport_remap(sb->gameport, 0);
+                        if (!(val & 0x01)) {
+                            sb->gameport_addr = 0x200;
+                            gameport_remap(sb->gameport, 0x200);
+                        }
                     }
                 }
                 break;
@@ -1371,7 +1373,7 @@ sb_ct1745_mixer_read(uint16_t addr, void *priv)
                     else
                         ret = 0x06; /* Should never happen. */
                 }
-                if (!sb->gameport_addr)
+                if (!sb->gameport_addr && (sb->gameport != NULL))
                     ret |= 0x01;
                 break;
 
@@ -1619,7 +1621,8 @@ ess_mixer_write(uint16_t addr, uint8_t val, void *priv)
                                          ess_fm_midi_write, NULL, NULL,
                                          ess);
 
-                        gameport_remap(ess->gameport, !(mixer->regs[0x40] & 0x2) ? 0x00 : 0x200);
+                        if (ess->gameport != NULL)
+                            gameport_remap(ess->gameport, !(mixer->regs[0x40] & 0x2) ? 0x00 : 0x200);
 
                         if (ess->dsp.sb_subtype > SB_SUBTYPE_ESS_ES1688) {
                             /* Not on ES1688. */


### PR DESCRIPTION
Summary
=======
Fixes hangs/crashes when disabled on win3.1x and other software.

Checklist
=========
* [X] Closes #5767
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
