### PR TITLE
A few corrections and cleanups to the code

### DIFF
--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -246,7 +246,7 @@ gus_midi_update_int_status(gus_t *gus)
 }
 
 void
-writegus(uint16_t addr, uint8_t val, void *priv)
+gus_write(uint16_t addr, uint8_t val, void *priv)
 {
     gus_t   *gus = (gus_t *) priv;
     int      c;
@@ -703,7 +703,7 @@ writegus(uint16_t addr, uint8_t val, void *priv)
 }
 
 uint8_t
-readgus(uint16_t addr, void *priv)
+gus_read(uint16_t addr, void *priv)
 {
     gus_t   *gus = (gus_t *) priv;
     uint8_t  val = 0xff;
@@ -1357,10 +1357,10 @@ gus_init(UNUSED(const device_t *info))
 
     gus->base = device_get_config_hex16("base");
 
-    io_sethandler(gus->base, 0x0010, readgus, NULL, NULL, writegus, NULL, NULL, gus);
-    io_sethandler(0x0100 + gus->base, 0x0010, readgus, NULL, NULL, writegus, NULL, NULL, gus);
-    io_sethandler(0x0506 + gus->base, 0x0001, readgus, NULL, NULL, writegus, NULL, NULL, gus);
-    io_sethandler(0x0388, 0x0002, readgus, NULL, NULL, writegus, NULL, NULL, gus);
+    io_sethandler(gus->base, 0x0010, gus_read, NULL, NULL, gus_write, NULL, NULL, gus);
+    io_sethandler(0x0100 + gus->base, 0x0010, gus_read, NULL, NULL, gus_write, NULL, NULL, gus);
+    io_sethandler(0x0506 + gus->base, 0x0001, gus_read, NULL, NULL, gus_write, NULL, NULL, gus);
+    io_sethandler(0x0388, 0x0002, gus_read, NULL, NULL, gus_write, NULL, NULL, gus);
 
     if (gus->type == GUS_MAX) {
         ad1848_init(&gus->ad1848, AD1848_TYPE_CS4231);

--- a/src/sound/snd_ssi2001.c
+++ b/src/sound/snd_ssi2001.c
@@ -157,14 +157,13 @@ static const device_config_t ssi2001_config[] = {
         .description    = "Enable Game port",
         .type           = CONFIG_BINARY,
         .default_string = NULL,
-        .default_int    = 1,
+        .default_int    = 0,
         .file_filter    = NULL,
         .spinner        = { 0 },
         .selection      = { { 0 } },
         .bios           = { { 0 } }
     },
-	
-	{
+    {
         .name           = "sid_config",
         .description    = "SID Model",
         .type           = CONFIG_HEX16,
@@ -201,7 +200,7 @@ static const device_config_t entertainer_config[] = {
         .description    = "Enable Game port",
         .type           = CONFIG_BINARY,
         .default_string = NULL,
-        .default_int    = 1,
+        .default_int    = 0,
         .file_filter    = NULL,
         .spinner        = { 0 },
         .selection      = { { 0 } },


### PR DESCRIPTION
Summary
=======
[read/writegus -> gus_read/write](https://github.com/86Box/86Box/commit/c5d083bd28b4f6d9cf219072210cd0a6d51c5424)
[Some corrections in snd_ssi2001.c](https://github.com/86Box/86Box/commit/d79dd904eabd1614076af5f433e3e8e156c31f12)
* Gameport disabled by default on ssi2001 and entertainer

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None