### PR TITLE
XGA changes of the day (July 12th, 2025)

### DIFF
--- a/src/include/86box/vid_xga.h
+++ b/src/include/86box/vid_xga.h
@@ -19,6 +19,9 @@
 
 #include <86box/rom.h>
 
+#define INT_START_BLKNK_ENAB         (1 << 0)
+#define INT_MASK                     0xf
+
 typedef struct xga_hwcursor_t {
     int      ena;
     int      x;
@@ -84,13 +87,13 @@ typedef struct xga_t {
     uint8_t  border_color;
     uint8_t  direct_color;
     uint8_t  dma_channel;
-    uint8_t  instance_isa;
     uint8_t  instance_num;
-    uint8_t  ext_mem_addr;
     uint8_t  vga_post;
     uint8_t  addr_test;
     uint8_t *vram;
     uint8_t *changedvram;
+    uint8_t int_ena;
+    uint8_t int_stat;
 
     int16_t hwc_pos_x;
     int16_t hwc_pos_y;
@@ -205,6 +208,10 @@ typedef struct xga_t {
         uint16_t dst_map_y;
         uint16_t pat_map_x;
         uint16_t pat_map_y;
+        uint16_t clip_l;
+        uint16_t clip_r;
+        uint16_t clip_t;
+        uint16_t clip_b;
 
         int ssv_state;
         int pat_src;
@@ -225,6 +232,8 @@ typedef struct xga_t {
         int pattern;
         int command_len;
         int filling;
+        int x_len;
+        int py_alt;
 
         uint32_t short_stroke;
         uint32_t color_cmp;
@@ -234,6 +243,7 @@ typedef struct xga_t {
         uint32_t bkgd_color;
         uint32_t command;
         uint32_t dir_cmd;
+        uint32_t srcbase_new;
 
         uint8_t  px_map_format[4];
         uint16_t px_map_width[4];


### PR DESCRIPTION
Summary
=======
1. XGADemo now displays the correct colors through implementation of the palette sequence order in bit 2 of reg66 (Palette Sequence) of the XGA  ports and no longer hangs DOS when displaying the demo per interrupt r/w ports implementation.
2. And some more checks for more patterns needed by some software.

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[XGA manual](https://dn790007.ca.archive.org/0/items/bitsavers_ibmpccardseferenceManualMay92_1756350/IBM_VGA_XGA_Technical_Reference_Manual_May92.pdf)
