### PR TITLE
Voodoo: Recalculate texture parameters on `textureMode` writes

### DIFF
--- a/src/video/vid_voodoo_reg.c
+++ b/src/video/vid_voodoo_reg.c
@@ -965,10 +965,12 @@ voodoo_reg_writel(uint32_t addr, uint32_t val, void *priv)
             if (chip & CHIP_TREX0) {
                 voodoo->params.textureMode[0] = val;
                 voodoo->params.tformat[0]     = (val >> 8) & 0xf;
+                voodoo_recalc_tex(voodoo, 0);
             }
             if (chip & CHIP_TREX1) {
                 voodoo->params.textureMode[1] = val;
                 voodoo->params.tformat[1]     = (val >> 8) & 0xf;
+                voodoo_recalc_tex(voodoo, 1);
             }
             break;
         case SST_tLOD:


### PR DESCRIPTION
Summary
=======
Voodoo: Recalculate texture parameters on `textureMode` writes

Fixes corrupted textures on Screamer Rally.

Checklist
=========
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
