### PR TITLE
Fix Netware key card registers

### DIFF
--- a/src/device/novell_cardkey.c
+++ b/src/device/novell_cardkey.c
@@ -37,24 +37,29 @@ novell_cardkey_read(uint16_t port, void *priv)
     novell_cardkey_t* cardkey = (novell_cardkey_t*)priv;
     uint8_t val = 0x00;
     switch (port) {
+        /* Byte 5 high nibble + byte 4 high nibble */
         case 0x23A:
-            val = (((cardkey->serial_number_str[11] > 'A') ? ((cardkey->serial_number_str[11] - 'A') + 10) : (cardkey->serial_number_str[11] - '0')) << 4) | (((cardkey->serial_number_str[9] > 'A') ? ((cardkey->serial_number_str[9] - 'A') + 10) : (cardkey->serial_number_str[9] - '0')) << 4);
-            break;
-        case 0x23B:
             val = (((cardkey->serial_number_str[10] > 'A') ? ((cardkey->serial_number_str[10] - 'A') + 10) : (cardkey->serial_number_str[10] - '0')) << 4) | (((cardkey->serial_number_str[8] > 'A') ? ((cardkey->serial_number_str[8] - 'A') + 10) : (cardkey->serial_number_str[8] - '0')) << 4);
             break;
-
+        /* Byte 5 low nibble + byte 4 low nibble */
+        case 0x23B:
+            val = (((cardkey->serial_number_str[11] > 'A') ? ((cardkey->serial_number_str[11] - 'A') + 10) : (cardkey->serial_number_str[11] - '0')) << 4) | (((cardkey->serial_number_str[9] > 'A') ? ((cardkey->serial_number_str[9] - 'A') + 10) : (cardkey->serial_number_str[9] - '0')) << 4);
+            break;
+        /* Byte 2 low nibble + byte 1 low nibble */
         case 0x23C:
-            val = ((cardkey->serial_number_str[4] - '0') << 4) | ((cardkey->serial_number_str[2] - '0'));
+            val = ((cardkey->serial_number_str[5] - '0') << 4) | ((cardkey->serial_number_str[3] - '0'));
             break;
+        /* Byte 0 high nibble + byte 3 low nibble*/
         case 0x23D:
-            val = ((cardkey->serial_number_str[1] - '0') << 4) | ((cardkey->serial_number_str[6] - '0'));
-            break;
-        case 0x23E:
             val = ((cardkey->serial_number_str[0] - '0') << 4) | ((cardkey->serial_number_str[7] - '0'));
             break;
+        /* Byte 0 low nibble + byte 3 high nibble */
+        case 0x23E:
+            val = ((cardkey->serial_number_str[1] - '0') << 4) | ((cardkey->serial_number_str[6] - '0'));
+            break;
+        /* Byte 1 high nibble + byte 2 high nibble*/
         case 0x23F:
-            val = ((cardkey->serial_number_str[3] - '0') << 4) | ((cardkey->serial_number_str[5] - '0'));
+            val = ((cardkey->serial_number_str[2] - '0') << 4) | ((cardkey->serial_number_str[4] - '0'));
             break;
     }
     return val ^ 0xFF;
@@ -110,7 +115,7 @@ static const device_config_t keycard_config[] = {
 
 const device_t novell_keycard_device = {
     .name          = "Novell NetWare 2.x Key Card",
-    .internal_name = "mssystems",
+    .internal_name = "novellkeycard",
     .flags         = DEVICE_ISA,
     .local         = 0,
     .init          = novell_cardkey_init,


### PR DESCRIPTION
Summary
=======
The registers previously were mixed up which made the device not work, this PR fixes that.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://www.os2museum.com/wp/unlocking-netware-2-0a/
