### PR TITLE
AppImage: Use XZ compression instead of ZSTD

### DIFF
--- a/.ci/AppImageBuilder.yml
+++ b/.ci/AppImageBuilder.yml
@@ -96,4 +96,4 @@ AppDir:
 AppImage:
   arch: !ENV '${arch_appimage}'
   file_name: !ENV '${appimage_path}'
-  comp: zstd
+  comp: xz


### PR DESCRIPTION
Summary
=======
AppImage: Use XZ compression instead of ZSTD for the squashfs image, should fix it failing to run on some distros

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A