### PR TITLE
XGA/SVGA mode changes of the day (July 22nd, 2025)

### DIFF
--- a/src/include/86box/vid_xga.h
+++ b/src/include/86box/vid_xga.h
@@ -19,8 +19,8 @@
 
 #include <86box/rom.h>
 
-#define INT_START_BLKNK_ENAB         (1 << 0)
-#define INT_MASK                     0xf
+#define XGA_INT_START_BLKNK_ENAB         (1 << 0)
+#define XGA_INT_MASK                     0xf
 
 typedef struct xga_hwcursor_t {
     int      ena;
@@ -152,10 +152,9 @@ typedef struct xga_t {
     int cursor_data_on;
     int pal_test;
     int a5_test;
+    int test_stage;
     int type;
     int bus;
-    int src_reverse_order;
-    int dst_reverse_order;
 
     uint32_t linear_base;
     uint32_t linear_size;
@@ -175,6 +174,7 @@ typedef struct xga_t {
     uint32_t px_map_base;
     uint32_t pallook[512];
     uint32_t bios_diag;
+    uint32_t mapping_base;
 
     PALETTE xgapal;
 

--- a/src/video/vid_ati_mach64.c
+++ b/src/video/vid_ati_mach64.c
@@ -37,6 +37,7 @@
 #include <86box/video.h>
 #include <86box/i2c.h>
 #include <86box/vid_ddc.h>
+#include <86box/vid_xga.h>
 #include <86box/vid_svga.h>
 #include <86box/vid_svga_render.h>
 #include <86box/vid_ati_eeprom.h>
@@ -586,6 +587,7 @@ void
 mach64_updatemapping(mach64_t *mach64)
 {
     svga_t *svga = &mach64->svga;
+    xga_t *xga   = (xga_t *) svga->xga;
 
     if (mach64->pci && !(mach64->pci_regs[PCI_REG_COMMAND] & PCI_COMMAND_MEM)) {
         mach64_log("Update mapping - PCI disabled\n");
@@ -611,6 +613,8 @@ mach64_updatemapping(mach64_t *mach64)
             mem_mapping_set_p(&svga->mapping, mach64);
             mem_mapping_set_addr(&svga->mapping, 0xa0000, 0x10000);
             svga->banked_mask = 0xffff;
+            if (xga_active && (svga->xga != NULL))
+                xga->on = 0;
             break;
         case 0x8: /*32k at B0000*/
             mem_mapping_set_handler(&svga->mapping, svga_read, svga_readw, svga_readl, svga_write, svga_writew, svga_writel);

--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -6218,6 +6218,7 @@ static void
 mach32_updatemapping(mach_t *mach, svga_t *svga)
 {
     ibm8514_t *dev = (ibm8514_t *) svga->dev8514;
+    xga_t     *xga = (xga_t *) svga->xga;
 
     if (mach->pci_bus && (!(mach->pci_regs[PCI_REG_COMMAND] & PCI_COMMAND_MEM))) {
         mach_log("No Mapping.\n");
@@ -6238,6 +6239,11 @@ mach32_updatemapping(mach_t *mach, svga_t *svga)
             case 0x4: /*64k at A0000*/
                 mem_mapping_set_addr(&svga->mapping, 0xa0000, 0x10000);
                 svga->banked_mask = 0xffff;
+                if (xga_active && (svga->xga != NULL)) {
+                    xga->on = 0;
+                    mem_mapping_set_handler(&svga->mapping, svga_read, svga_readw, svga_readl, svga_write, svga_writew, svga_writel);
+                    mem_mapping_set_p(&svga->mapping, svga);
+                }
                 break;
             case 0x8: /*32k at B0000*/
                 mem_mapping_set_addr(&svga->mapping, 0xb0000, 0x08000);

--- a/src/video/vid_cl54xx.c
+++ b/src/video/vid_cl54xx.c
@@ -1703,6 +1703,7 @@ static void
 gd543x_recalc_mapping(gd54xx_t *gd54xx)
 {
     svga_t  *svga = &gd54xx->svga;
+    xga_t   *xga  = (xga_t *) svga->xga;
     uint32_t base;
     uint32_t size;
 
@@ -1729,6 +1730,10 @@ gd543x_recalc_mapping(gd54xx_t *gd54xx)
             case 0x4: /*64k at A0000*/
                 mem_mapping_set_addr(&svga->mapping, 0xa0000, 0x10000);
                 svga->banked_mask = 0xffff;
+                if (xga_active && (svga->xga != NULL)) {
+                    xga->on = 0;
+                    mem_mapping_set_handler(&svga->mapping, svga->read, svga->readw, svga->readl, svga->write, svga->writew, svga->writel);
+                }
                 break;
             case 0x8: /*32k at B0000*/
                 mem_mapping_set_addr(&svga->mapping, 0xb0000, 0x08000);

--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -35,6 +35,7 @@
 #include <86box/video.h>
 #include <86box/i2c.h>
 #include <86box/vid_ddc.h>
+#include <86box/vid_xga.h>
 #include <86box/vid_svga.h>
 #include <86box/vid_svga_render.h>
 
@@ -1042,6 +1043,9 @@ mystique_recalctimings(svga_t *svga)
                 }
             } else {
                 switch (svga->bpp) {
+                    case 4:
+                        svga->render = svga_render_4bpp_highres;
+                        break;
                     case 8:
                         svga->render = svga_render_8bpp_highres;
                         break;
@@ -1061,6 +1065,9 @@ mystique_recalctimings(svga_t *svga)
             }
         } else {
             switch (svga->bpp) {
+                case 4:
+                    svga->render = svga_render_4bpp_highres;
+                    break;
                 case 8:
                     svga->render = svga_render_8bpp_highres;
                     break;
@@ -1104,6 +1111,7 @@ static void
 mystique_recalc_mapping(mystique_t *mystique)
 {
     svga_t *svga = &mystique->svga;
+    xga_t  *xga  = (xga_t *) svga->xga;
 
     io_removehandler(0x03c0, 0x0020, mystique_in, NULL, NULL, mystique_out, NULL, NULL, mystique);
     if ((mystique->pci_regs[PCI_REG_COMMAND] & PCI_COMMAND_IO) && (mystique->pci_regs[0x41] & 1))
@@ -1141,6 +1149,10 @@ mystique_recalc_mapping(mystique_t *mystique)
             case 0x4: /*64k at A0000*/
                 mem_mapping_set_addr(&svga->mapping, 0xa0000, 0x10000);
                 svga->banked_mask = 0xffff;
+                if (xga_active && (svga->xga != NULL)) {
+                    xga->on = 0;
+                    mem_mapping_set_handler(&svga->mapping, svga->read, svga->readw, svga->readl, svga->write, svga->writew, svga->writel);
+                }
                 break;
             case 0x8: /*32k at B0000*/
                 mem_mapping_set_addr(&svga->mapping, 0xb0000, 0x08000);

--- a/src/video/vid_paradise.c
+++ b/src/video/vid_paradise.c
@@ -30,6 +30,7 @@
 #include <86box/rom.h>
 #include <86box/device.h>
 #include <86box/video.h>
+#include <86box/vid_xga.h>
 #include <86box/vid_svga.h>
 #include <86box/vid_svga_render.h>
 
@@ -143,6 +144,7 @@ paradise_out(uint16_t addr, uint8_t val, void *priv)
 {
     paradise_t *paradise = (paradise_t *) priv;
     svga_t     *svga     = &paradise->svga;
+    xga_t      *xga      = (xga_t *) svga->xga;
     uint8_t     old;
 
     if (((addr & 0xfff0) == 0x3d0 || (addr & 0xfff0) == 0x3b0) && !(svga->miscout & 1))
@@ -188,6 +190,10 @@ paradise_out(uint16_t addr, uint8_t val, void *priv)
                             case 0x4: /*64k at A0000*/
                                 mem_mapping_set_addr(&svga->mapping, 0xa0000, 0x10000);
                                 svga->banked_mask = 0xffff;
+                                if (xga_active && (svga->xga != NULL)) {
+                                    xga->on = 0;
+                                    mem_mapping_set_handler(&svga->mapping, svga->read, svga->readw, svga->readl, svga->write, svga->writew, svga->writel);
+                                }
                                 break;
                             case 0x8: /*32k at B0000*/
                                 mem_mapping_set_addr(&svga->mapping, 0xb0000, 0x08000);
@@ -586,7 +592,7 @@ paradise_decode_addr(paradise_t *paradise, uint32_t addr, int write)
         addr = (addr & 0x7fff) + paradise->write_bank[(addr >> 15) & 3];
     else
         addr = (addr & 0x7fff) + paradise->read_bank[(addr >> 15) & 3];
- 
+
 
     return addr;
 }

--- a/src/video/vid_s3_virge.c
+++ b/src/video/vid_s3_virge.c
@@ -37,6 +37,7 @@
 #include <86box/video.h>
 #include <86box/i2c.h>
 #include <86box/vid_ddc.h>
+#include <86box/vid_xga.h>
 #include <86box/vid_svga.h>
 #include <86box/vid_svga_render.h>
 
@@ -1036,6 +1037,7 @@ static void
 s3_virge_updatemapping(virge_t *virge)
 {
     svga_t *svga = &virge->svga;
+    xga_t *xga   = (xga_t *) svga->xga;
 
     if (!(virge->pci_regs[PCI_REG_COMMAND] & PCI_COMMAND_MEM)) {
         mem_mapping_disable(&svga->mapping);
@@ -1053,6 +1055,10 @@ s3_virge_updatemapping(virge_t *virge)
         case 0x4: /*64k at A0000*/
             mem_mapping_set_addr(&svga->mapping, 0xa0000, 0x10000);
             svga->banked_mask = 0xffff;
+            if (xga_active && (svga->xga != NULL)) {
+                xga->on = 0;
+                mem_mapping_set_handler(&svga->mapping, svga->read, svga->readw, svga->readl, svga->write, svga->writew, svga->writel);
+            }
             break;
         case 0x8: /*32k at B0000*/
             mem_mapping_set_addr(&svga->mapping, 0xb0000, 0x08000);

--- a/src/video/vid_tgui9440.c
+++ b/src/video/vid_tgui9440.c
@@ -72,6 +72,7 @@
 #include <86box/video.h>
 #include <86box/i2c.h>
 #include <86box/vid_ddc.h>
+#include <86box/vid_xga.h>
 #include <86box/vid_svga.h>
 #include <86box/vid_svga_render.h>
 
@@ -911,6 +912,7 @@ static void
 tgui_recalcmapping(tgui_t *tgui)
 {
     svga_t *svga = &tgui->svga;
+    xga_t  *xga  = (xga_t *) svga->xga;
 
     if (tgui->type == TGUI_9400CXI) {
         if (svga->gdcreg[0x10] & EXT_CTRL_LATCH_COPY) {
@@ -964,6 +966,10 @@ tgui_recalcmapping(tgui_t *tgui)
                 case 0x4: /*64k at A0000*/
                     mem_mapping_set_addr(&svga->mapping, 0xa0000, 0x10000);
                     svga->banked_mask = 0xffff;
+                    if (xga_active && (svga->xga != NULL)) {
+                        xga->on = 0;
+                        mem_mapping_set_handler(&svga->mapping, svga->read, svga->readw, svga->readl, svga->write, svga->writew, svga->writel);
+                    }
                     break;
                 case 0x8: /*32k at B0000*/
                     mem_mapping_set_addr(&svga->mapping, 0xb0000, 0x08000);
@@ -988,6 +994,10 @@ tgui_recalcmapping(tgui_t *tgui)
             case 0x4: /*64k at A0000*/
                 mem_mapping_set_addr(&svga->mapping, 0xa0000, 0x10000);
                 svga->banked_mask = 0xffff;
+                if (xga_active && (svga->xga != NULL)) {
+                    xga->on = 0;
+                    mem_mapping_set_handler(&svga->mapping, svga->read, svga->readw, svga->readl, svga->write, svga->writew, svga->writel);
+                }
                 break;
             case 0x8: /*32k at B0000*/
                 mem_mapping_set_addr(&svga->mapping, 0xb0000, 0x08000);


### PR DESCRIPTION
Summary
=======
1. If the VGA mapping is for a 0xA0000 map for a length of 0x10000, then disable XGA mode (this is independent of the XGA extended mode aperture mode 1 which is XGA's own 0xA0000 mapping).
2. Remove text mode ctrl-alt-del hack.
3. Fixed cursor x coordinate in the Trio32 using 15bpp/16bpp modes.

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
