### PR TITLE
Raise minimum RAM amount of the Hyundai SCAT machines

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -3926,7 +3926,7 @@ const machine_t machines[] = {
         .bus_flags = MACHINE_AT,
         .flags = MACHINE_IDE,
         .ram = {
-            .min = 512,
+            .min = 640,
             .max = 8192,
             .step = 128
         },
@@ -3966,7 +3966,7 @@ const machine_t machines[] = {
         .bus_flags = MACHINE_AT,
         .flags = MACHINE_FLAGS_NONE,
         .ram = {
-            .min = 512,
+            .min = 640,
             .max = 8192,
             .step = 128
         },


### PR DESCRIPTION
Summary
=======
Bandaid solution to fix graphics corruptions and hanging until we figure out the issue is

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
