### PR TITLE
Add Biostar M5ATA motherboard

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -789,6 +789,7 @@ extern int machine_at_ms5146_init(const machine_t *);
 extern int machine_at_cb52xsi_init(const machine_t *);
 
 extern int machine_at_m560_init(const machine_t *);
+extern int machine_at_m5ata_init(const machine_t *);
 extern int machine_at_ms5164_init(const machine_t *);
 
 extern int machine_at_sp97xv_init(const machine_t *);

--- a/src/machine/m_at_socket7.c
+++ b/src/machine/m_at_socket7.c
@@ -1551,6 +1551,35 @@ machine_at_m560_init(const machine_t *model)
 }
 
 int
+machine_at_m5ata_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/m5ata/ATA1223.BIN",
+                           0x000e0000, 131072, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_common_init_ex(model, 2);
+
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE,     1, 2, 3, 4);
+    pci_register_slot(0x02, PCI_CARD_SOUTHBRIDGE,     1, 2, 3, 4);
+    pci_register_slot(0x0B, PCI_CARD_SOUTHBRIDGE_IDE, 1, 2, 3, 4);
+    pci_register_slot(0x03, PCI_CARD_NORMAL,          1, 2, 3, 4);
+    pci_register_slot(0x04, PCI_CARD_NORMAL,          2, 3, 4, 1);
+    pci_register_slot(0x05, PCI_CARD_NORMAL,          3, 4, 1, 2);
+    pci_register_slot(0x06, PCI_CARD_NORMAL,          4, 1, 2, 3);
+
+    device_add(&ali1531_device);
+    device_add(&ali1543_device); /* -5 */
+    spd_register(SPD_TYPE_SDRAM, 0x3, 64);
+
+    return ret;
+}
+
+int
 machine_at_ms5164_init(const machine_t *model)
 {
     int ret;

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -14504,6 +14504,46 @@ const machine_t machines[] = {
     /* ALi ALADDiN IV+ */
     /* Has the ALi M1543 southbridge with on-chip KBC. */
     {
+        .name = "[ALi ALADDiN IV+] Biostar M5ATA",
+        .internal_name = "m5ata",
+        .type = MACHINE_TYPE_SOCKET7,
+        .chipset = MACHINE_CHIPSET_ALI_ALADDIN_IV_PLUS,
+        .init = machine_at_m5ata_init,
+        .p1_handler = NULL,
+        .gpio_handler = NULL,
+        .available_flag = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu = {
+            .package = CPU_PKG_SOCKET5_7,
+            .block = CPU_BLOCK_NONE,
+            .min_bus = 60000000,
+            .max_bus = 66666667,
+            .min_voltage = 2100,
+            .max_voltage = 3500,
+            .min_multi = 1.5,
+            .max_multi = 4.5
+        },
+        .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
+        .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_USB,
+        .ram = {
+            .min = 8192,
+            .max = 262144,
+            .step = 8192
+        },
+        .nvrmask = 127,
+        .kbc_device = NULL,
+        .kbc_p1 = 0xff,
+        .gpio = 0xffffffff,
+        .gpio_acpi = 0xffffffff,
+        .device = NULL,
+        .fdc_device = NULL,
+        .sio_device = NULL,
+        .vid_device = NULL,
+        .snd_device = NULL,
+        .net_device = NULL
+    },
+    /* Has the ALi M1543 southbridge with on-chip KBC. */
+    {
         .name = "[ALi ALADDiN IV+] MSI MS-5164",
         .internal_name = "ms5164",
         .type = MACHINE_TYPE_SOCKET7,


### PR DESCRIPTION
Summary
=======
This PR adds support for the Biostar M5ATA motherboard, a Socket 7 board.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
I've dumped the ROM from my own board.
The manual can be found at [The Retro Web's page for Biostar M5ATA](https://theretroweb.com/motherboards/s/biostar-m5ata#docs).
The PCI IRQ steering table was obtained using PCIREG and refined based on feedback obtained on the Discord server.
