### PR TITLE
Update 86Box.pot and merge into PO files

### DIFF
--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -147,6 +147,9 @@ msgstr ""
 msgid "&RGB Grayscale"
 msgstr ""
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr ""
 
@@ -384,6 +387,15 @@ msgstr ""
 msgid "Dynamic Recompiler"
 msgstr ""
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr ""
 
@@ -588,7 +600,7 @@ msgstr ""
 msgid "MO drives:"
 msgstr ""
 
-msgid "ZIP drives:"
+msgid "Removable disk drives:"
 msgstr ""
 
 msgid "ZIP 250"
@@ -598,6 +610,9 @@ msgid "ISA RTC:"
 msgstr ""
 
 msgid "ISA Memory Expansion"
+msgstr ""
+
+msgid "ISA ROM Cards"
 msgstr ""
 
 msgid "Card 1:"
@@ -610,6 +625,27 @@ msgid "Card 3:"
 msgstr ""
 
 msgid "Card 4:"
+msgstr ""
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
 msgstr ""
 
 msgid "ISABugger device"
@@ -633,10 +669,13 @@ msgstr ""
 msgid "Speed"
 msgstr ""
 
-msgid "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
-msgid "ZIP images"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
 msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
@@ -777,10 +816,37 @@ msgstr ""
 msgid "CH Flightstick Pro"
 msgstr ""
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr ""
 
 msgid "Thrustmaster Flight Control System"
+msgstr ""
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
 msgstr ""
 
 msgid "None"
@@ -1377,7 +1443,13 @@ msgstr ""
 msgid "Mouse Systems Serial Mouse"
 msgstr ""
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
+msgstr ""
+
+msgid "Microsoft Serial BallPoint"
 msgstr ""
 
 msgid "Logitech Serial Mouse"
@@ -1387,6 +1459,9 @@ msgid "PS/2 Mouse"
 msgstr ""
 
 msgid "3M MicroTouch (Serial)"
+msgstr ""
+
+msgid "Default Baud rate"
 msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
@@ -1413,10 +1488,52 @@ msgstr ""
 msgid "MIDI Input Device"
 msgstr ""
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr ""
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
 msgstr ""
 
 msgid "Address"
@@ -1426,6 +1543,21 @@ msgid "IRQ"
 msgstr ""
 
 msgid "BIOS Revision"
+msgstr ""
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
 msgstr ""
 
 msgid "Translate 26 -> 17"
@@ -1441,6 +1573,18 @@ msgid "Invert colors"
 msgstr ""
 
 msgid "BIOS size"
+msgstr ""
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
 msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
@@ -1516,6 +1660,9 @@ msgid "Reverb Level"
 msgstr ""
 
 msgid "Interpolation Method"
+msgstr ""
+
+msgid "Dynamic Sample Loading"
 msgstr ""
 
 msgid "Reverb Output Gain"
@@ -1605,6 +1752,12 @@ msgstr ""
 msgid "Enable Game port"
 msgstr ""
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr ""
 
@@ -1615,6 +1768,9 @@ msgid "Raise CODEC interrupt on CODEC setup (needed by some drivers)"
 msgstr ""
 
 msgid "SB Address"
+msgstr ""
+
+msgid "Use EEPROM setting"
 msgstr ""
 
 msgid "WSS IRQ"
@@ -1701,6 +1857,9 @@ msgstr ""
 msgid "Blend"
 msgstr ""
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr ""
 
@@ -1744,6 +1903,33 @@ msgid "Transfer Speed"
 msgstr ""
 
 msgid "EMS mode"
+msgstr ""
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
 msgstr ""
 
 msgid "Address for > 2 MB"
@@ -1902,6 +2088,15 @@ msgstr ""
 msgid "Linear interpolation"
 msgstr ""
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr ""
 
@@ -1935,6 +2130,9 @@ msgstr ""
 msgid "Gray"
 msgstr ""
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr ""
 
@@ -1948,6 +2146,12 @@ msgid "Other languages"
 msgstr ""
 
 msgid "Bochs latest"
+msgstr ""
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
 msgstr ""
 
 msgid "Mono Non-Interlaced"
@@ -2152,4 +2356,58 @@ msgid "Move down"
 msgstr ""
 
 msgid "Could not load file %1"
+msgstr ""
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
 msgstr ""

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -147,6 +147,9 @@ msgstr "RGB &Color"
 msgid "&RGB Grayscale"
 msgstr "RGB &Grisos"
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "Monitor & Ambre"
 
@@ -384,6 +387,15 @@ msgstr "Activat (UTC)"
 msgid "Dynamic Recompiler"
 msgstr "Recopilador Dinàmic"
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr "Vídeo:"
 
@@ -588,8 +600,8 @@ msgstr "Unitats de CD-ROM:"
 msgid "MO drives:"
 msgstr "Unitats MO:"
 
-msgid "ZIP drives:"
-msgstr "Unitats ZIP:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "ISA RTC:"
 
 msgid "ISA Memory Expansion"
 msgstr "Expansió de memòria ISA"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "Targeta 1:"
@@ -611,6 +626,27 @@ msgstr "Targeta 3:"
 
 msgid "Card 4:"
 msgstr "Targeta 4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "Dispositiu ISABugger"
@@ -633,11 +669,14 @@ msgstr " - EN PAUSA"
 msgid "Speed"
 msgstr "Velocitat"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "Imatges ZIP"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "86Box no ha pogut trobar cap imatge ROM utilitzable.\n\nSi us plau, <a href=\"https://github.com/86Box/roms/releases/latest\">descarregueu</a> un conjunt de ROM i extreu-lo al directori \"roms\"."
@@ -777,11 +816,38 @@ msgstr "Joystick de 4 eixes, 4 botons"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinder Pad"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Thrustmaster Flight Control System"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "Cap"
@@ -1377,8 +1443,14 @@ msgstr "Ratolí bus Microsoft (InPort)"
 msgid "Mouse Systems Serial Mouse"
 msgstr "Ratolí sèrie Mouse Systems"
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
 msgstr "Ratolí sèrie Microsoft"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
 
 msgid "Logitech Serial Mouse"
 msgstr "Ratolí sèrie Logitech"
@@ -1388,6 +1460,9 @@ msgstr "Ratolí PS/2"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (sèrie)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] Mòdem estàndard, complint els Hayes"
@@ -1413,11 +1488,53 @@ msgstr "MIDI de sistema"
 msgid "MIDI Input Device"
 msgstr "Dispositiu d'entrada MIDI"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "Adreça de BIOS"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "Activar les escrits a la ROM extensor de BIOS"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "Adreça"
@@ -1427,6 +1544,21 @@ msgstr "IRQ"
 
 msgid "BIOS Revision"
 msgstr "Revisió de la BIOS"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "Traduir 26 -> 17"
@@ -1442,6 +1574,18 @@ msgstr "Colors invertits"
 
 msgid "BIOS size"
 msgstr "Grandària de la BIOS"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "Mapa C0000-C7FFF com UMB"
@@ -1517,6 +1661,9 @@ msgstr "Nivell de reverberació"
 
 msgid "Interpolation Method"
 msgstr "Mètode d'interpolació"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "Guany de sortida de reverberació"
@@ -1605,6 +1752,12 @@ msgstr "DMA baix"
 msgid "Enable Game port"
 msgstr "Activar port de joc"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "Mòdul Surround"
 
@@ -1616,6 +1769,9 @@ msgstr "Activar la interrupció del codec en la configuració del CODEC (necessa
 
 msgid "SB Address"
 msgstr "Adreça de SB"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "IRQ de WSS"
@@ -1701,6 +1857,9 @@ msgstr "Tipus de RAMDAC"
 msgid "Blend"
 msgstr "Barrejar"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "Filtratge bilineal"
 
@@ -1745,6 +1904,33 @@ msgstr "Velocitat de transferència"
 
 msgid "EMS mode"
 msgstr "Mode EMS"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "Adreça per a > 2 MB"
@@ -1902,6 +2088,15 @@ msgstr "Interpolació sRGB"
 msgid "Linear interpolation"
 msgstr "Interpolació lineal"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 KB"
 
@@ -1935,6 +2130,9 @@ msgstr "Ambre"
 msgid "Gray"
 msgstr "Gris"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "Color"
 
@@ -1949,6 +2147,12 @@ msgstr "Altres idiomes"
 
 msgid "Bochs latest"
 msgstr "Bochs més recent"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "Monocrom no interlat"
@@ -2076,6 +2280,12 @@ msgstr "Clon IBM 8514/A (ISA)"
 msgid "Vendor"
 msgstr "Frabricant"
 
+msgid "30 Hz (JMP2 = 1)"
+msgstr ""
+
+msgid "60 Hz (JMP2 = 2)"
+msgstr ""
+
 msgid "Generic PC/XT Memory Expansion"
 msgstr "Expansió de memòria genèrica PC/XT"
 
@@ -2147,3 +2357,66 @@ msgstr ""
 
 msgid "Could not load file %1"
 msgstr ""
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "ZIP drives:"
+#~ msgstr "Unitats ZIP:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "Imatges ZIP"

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -147,6 +147,9 @@ msgstr "RGB &barevný"
 msgid "&RGB Grayscale"
 msgstr "&Odstíny šedi"
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "&Jantarová obrazovka"
 
@@ -384,6 +387,15 @@ msgstr "Zapnuta (UTC)"
 msgid "Dynamic Recompiler"
 msgstr "Dynamický překladač"
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr "Grafika:"
 
@@ -588,8 +600,8 @@ msgstr "Mechaniky CD-ROM:"
 msgid "MO drives:"
 msgstr "Magnetooptické mechaniky:"
 
-msgid "ZIP drives:"
-msgstr "Mechaniky ZIP:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "ISA hodiny:"
 
 msgid "ISA Memory Expansion"
 msgstr "ISA rozšíření paměti"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "Karta 1:"
@@ -611,6 +626,27 @@ msgstr "Karta 3:"
 
 msgid "Card 4:"
 msgstr "Karta 4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "Zařízení ISABugger"
@@ -633,11 +669,14 @@ msgstr " - POZASTAVENO"
 msgid "Speed"
 msgstr "Rychlost"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "Obrazy ZIP disků"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "86Box nenalezl žádné použitelné image pamětí ROM.\n\n<a href=\"https://github.com/86Box/roms/releases/latest\">Stáhněte</a> sadu obrazů ROM a extrahujte ji do složky \"roms\"."
@@ -777,11 +816,38 @@ msgstr "4osový, 4tlačítkový joystick"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinder Pad"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Thrustmaster Flight Control System"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "Žadné"
@@ -1377,8 +1443,14 @@ msgstr "Sběrnicová myš Microsoft (InPort)"
 msgid "Mouse Systems Serial Mouse"
 msgstr "Sériová myš Mouse Systems"
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
 msgstr "Sériová myš Microsoft"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
 
 msgid "Logitech Serial Mouse"
 msgstr "Sériová myš Logitech"
@@ -1388,6 +1460,9 @@ msgstr "Myš PS/2"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (sériová)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] Modem kompatibilní se standardem Hayes"
@@ -1413,11 +1488,53 @@ msgstr "Systémové MIDI"
 msgid "MIDI Input Device"
 msgstr "Vstupní zařízení MIDI"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "Adresa BIOSu"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "Povolení zápisu do rozšiřující paměti ROM systému BIOS"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "Adresa"
@@ -1427,6 +1544,21 @@ msgstr "IRQ"
 
 msgid "BIOS Revision"
 msgstr "Revize BIOSu"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "Přeložit 26 -> 17"
@@ -1442,6 +1574,18 @@ msgstr "Invertování barev"
 
 msgid "BIOS size"
 msgstr "Velikost BIOSu"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "Mapovat C0000-C7FFF jako UMB"
@@ -1517,6 +1661,9 @@ msgstr "Úroveň dozvuku"
 
 msgid "Interpolation Method"
 msgstr "Metoda interpolace"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "Zesílení výstupu dozvuku"
@@ -1605,6 +1752,12 @@ msgstr "Nízký DMA"
 msgid "Enable Game port"
 msgstr "Povolit herní port"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "Modul Surround"
 
@@ -1616,6 +1769,9 @@ msgstr "Vyvolání přerušení CODEC při nastavení CODEC (potřebují někter
 
 msgid "SB Address"
 msgstr "Adresa SB"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "IRQ WSS"
@@ -1701,6 +1857,9 @@ msgstr "Typ RAMDACu"
 msgid "Blend"
 msgstr "Směs"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "Bilineární filtrování"
 
@@ -1745,6 +1904,33 @@ msgstr "Rychlost přenosu"
 
 msgid "EMS mode"
 msgstr "Režím EMS"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "Adresa pro > 2 MB"
@@ -1902,6 +2088,15 @@ msgstr "Interpolace sRGB"
 msgid "Linear interpolation"
 msgstr "Lineární interpolace"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 KB"
 
@@ -1935,6 +2130,9 @@ msgstr "Jantarový"
 msgid "Gray"
 msgstr "Šedý"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "Barevný"
 
@@ -1949,6 +2147,12 @@ msgstr "Ostatní jazyky"
 
 msgid "Bochs latest"
 msgstr "Bochs nejnovější"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "Monochromatický bez prokládání"
@@ -2076,6 +2280,12 @@ msgstr "Klon IBM 8514/A (ISA)"
 msgid "Vendor"
 msgstr "Výrobce"
 
+msgid "30 Hz (JMP2 = 1)"
+msgstr ""
+
+msgid "60 Hz (JMP2 = 2)"
+msgstr ""
+
 msgid "Generic PC/XT Memory Expansion"
 msgstr "Obecné rozšíření paměti PC/XT"
 
@@ -2147,3 +2357,66 @@ msgstr ""
 
 msgid "Could not load file %1"
 msgstr ""
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "ZIP drives:"
+#~ msgstr "Mechaniky ZIP:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "Obrazy ZIP disků"

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -147,6 +147,9 @@ msgstr "&RGB-Farbe"
 msgid "&RGB Grayscale"
 msgstr "&RGB-Graustufen"
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "&Bernstein-Monitor"
 
@@ -384,6 +387,15 @@ msgstr "Eingeschaltet (UTC)"
 msgid "Dynamic Recompiler"
 msgstr "Dynamischer Recompiler"
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr "Videokarte:"
 
@@ -588,8 +600,8 @@ msgstr "CD-ROM-Laufwerke:"
 msgid "MO drives:"
 msgstr "MO-Laufwerke:"
 
-msgid "ZIP drives:"
-msgstr "ZIP-Laufwerke:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "ISA-Echtzeituhr:"
 
 msgid "ISA Memory Expansion"
 msgstr "ISA-Speichererweiterung:"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "Steckkarte 1:"
@@ -611,6 +626,27 @@ msgstr "Steckkarte 3:"
 
 msgid "Card 4:"
 msgstr "Steckkarte 4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "ISABugger-Gerät"
@@ -633,11 +669,14 @@ msgstr " - PAUSIERT"
 msgid "Speed"
 msgstr "Geschwindigkeit"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "ZIP-Abbilder"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "86Box konnte keine nutzbaren ROM-Dateien finden.\n\nBitte besuchen Sie <a href=\"https://github.com/86Box/roms/releases/latest\">download</a>, laden ein ROM-Set herunter und extrahieren dies in das \"roms\"-Verzeichnis."
@@ -777,11 +816,38 @@ msgstr "4-Achsen-, 4-Tasten-Joystick"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinder Pad"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Thrustmaster Flight Control System"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "Ohne"
@@ -1377,8 +1443,14 @@ msgstr "Microsoft Bus-Maus (InPort)"
 msgid "Mouse Systems Serial Mouse"
 msgstr "Mouse Systems Serielle Maus"
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
 msgstr "Microsoft Serielle Maus"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
 
 msgid "Logitech Serial Mouse"
 msgstr "Logitech Serielle Maus"
@@ -1388,6 +1460,9 @@ msgstr "PS/2-Maus"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (Seriell)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] Standard Hayes-kompatibles Modem"
@@ -1413,11 +1488,53 @@ msgstr "System MIDI"
 msgid "MIDI Input Device"
 msgstr "MIDI-Eingabegerät"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "BIOS-Adresse"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "Schreiben in BIOS Erweiterungs ROMs zulassen"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "Adresse"
@@ -1427,6 +1544,21 @@ msgstr "IRQ"
 
 msgid "BIOS Revision"
 msgstr "BIOS-Revision"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "Übersetzen 26 -> 17"
@@ -1442,6 +1574,18 @@ msgstr "Farben invertieren"
 
 msgid "BIOS size"
 msgstr "BIOS-Größe"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "C0000-C7FFF als UMB zuordnen"
@@ -1517,6 +1661,9 @@ msgstr "Nachhall-Pegel"
 
 msgid "Interpolation Method"
 msgstr "Interpolationsmethode"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "Nachhall-Ausgangsverstärkung"
@@ -1605,6 +1752,12 @@ msgstr "Niedrige DMA"
 msgid "Enable Game port"
 msgstr "Game-Port einschalten"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "Surround-Modul"
 
@@ -1616,6 +1769,9 @@ msgstr "CODEC-Interrupt bei CODEC-Einrichtung auslösen (wird von einigen Treibe
 
 msgid "SB Address"
 msgstr "SB-Adresse"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "WSS-IRQ"
@@ -1701,6 +1857,9 @@ msgstr "RAMDAC-Typ"
 msgid "Blend"
 msgstr "Mischung"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "Bilineare Filterung"
 
@@ -1745,6 +1904,33 @@ msgstr "Übertragungsgeschwindigkeit"
 
 msgid "EMS mode"
 msgstr "EMS-Modus"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "Adresse für > 2 MB"
@@ -1902,6 +2088,15 @@ msgstr "sRGB-Interpolation"
 msgid "Linear interpolation"
 msgstr "Lineare Interpolation"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 KB"
 
@@ -1935,6 +2130,9 @@ msgstr "Bernsteinfarben"
 msgid "Gray"
 msgstr "Graues"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "Farbe"
 
@@ -1949,6 +2147,12 @@ msgstr "Andere Sprachen"
 
 msgid "Bochs latest"
 msgstr "Bochs neueste"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "Monochrom (Kein Zeilensprungverfahren)"
@@ -2076,6 +2280,12 @@ msgstr "IBM 8514/A-Klon (ISA)"
 msgid "Vendor"
 msgstr "Hersteller"
 
+msgid "30 Hz (JMP2 = 1)"
+msgstr ""
+
+msgid "60 Hz (JMP2 = 2)"
+msgstr ""
+
 msgid "Generic PC/XT Memory Expansion"
 msgstr "Generische PC/XT-Speichererweiterung"
 
@@ -2147,3 +2357,66 @@ msgstr ""
 
 msgid "Could not load file %1"
 msgstr ""
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "ZIP drives:"
+#~ msgstr "ZIP-Laufwerke:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "ZIP-Abbilder"

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -147,6 +147,9 @@ msgstr "RGB &Color"
 msgid "&RGB Grayscale"
 msgstr "RGB &Grises"
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "Monitor &Ámbar"
 
@@ -384,6 +387,15 @@ msgstr "Habilitado (UTC)"
 msgid "Dynamic Recompiler"
 msgstr "Recompilador Dinámico"
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr "Vídeo:"
 
@@ -588,8 +600,8 @@ msgstr "Unidades de CD-ROM:"
 msgid "MO drives:"
 msgstr "Unidades MO:"
 
-msgid "ZIP drives:"
-msgstr "Unidades ZIP:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "ISA RTC:"
 
 msgid "ISA Memory Expansion"
 msgstr "Expansión de Memoria ISA"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "Tarjeta 1:"
@@ -611,6 +626,27 @@ msgstr "Tarjeta 3:"
 
 msgid "Card 4:"
 msgstr "Tarjeta 4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "Dispositivo ISABugger"
@@ -633,11 +669,14 @@ msgstr " - EN PAUSA"
 msgid "Speed"
 msgstr "Velocidad"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "Imagenes ZIP"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "86Box no pudo encontrar ninguna imagen ROM usable.\n\nPor favor <a href=\"https://github.com/86Box/roms/releases/latest\">descargue</a> un conjunte de ROMs y extráigalo en el directorio \"roms\"."
@@ -777,11 +816,38 @@ msgstr "Mando de 4 ejes, 4 botones"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinder Pad"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Thrustmaster Flight Control System"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "Ninguno"
@@ -1187,6 +1253,7 @@ msgstr "WinBox ya no recibe soporte"
 
 msgid "Development of the WinBox manager stopped in 2022 due to a lack of maintainers. As we direct our efforts towards making 86Box even better, we have made the decision to no longer support WinBox as a manager.\n\nNo further updates will be provided through WinBox, and you may encounter incorrect behavior should you continue using it with newer versions of 86Box. Any bug reports related to WinBox behavior will be closed as invalid.\n\nGo to 86box.net for a list of other managers you can use."
 msgstr "El desarrollo del gestor WinBox se detuvo en 2022 debido a la falta de mantenedores. Como dirigimos nuestros esfuerzos a hacer 86Box aún mejor, hemos tomado la decisión de dejar de dar soporte a WinBox como gestor.\n\nNo se proporcionarán más actualizaciones a través de WinBox, y puede encontrar un comportamiento incorrecto si continúa usándolo con versiones más nuevas de 86Box. Cualquier informe de error relacionado con el comportamiento de WinBox será cerrado como inválido.\n\nVaya a 86box.net para una lista de otros gestores que puede utilizar."
+
 msgid "Generate"
 msgstr "Vytvoř"
 
@@ -1376,8 +1443,14 @@ msgstr "Ratón de bus Microsoft (InPort)"
 msgid "Mouse Systems Serial Mouse"
 msgstr "Ratón serie Mouse Systems"
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
 msgstr "Ratón serie Microsoft"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
 
 msgid "Logitech Serial Mouse"
 msgstr "Ratón serie Logitech"
@@ -1387,6 +1460,9 @@ msgstr "Ratón PS/2"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (serie)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] Módem estándar compatible con Hayes"
@@ -1412,11 +1488,53 @@ msgstr "MIDI del sistema"
 msgid "MIDI Input Device"
 msgstr "Dispositivo de entrada MIDI"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "Dirección de BIOS"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "Habilitar escrituras para el ROM de extensión de BIOS"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "Dirección"
@@ -1426,6 +1544,21 @@ msgstr "IRQ"
 
 msgid "BIOS Revision"
 msgstr "Revisión de BIOS"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "Traducir 26 -> 17"
@@ -1441,6 +1574,18 @@ msgstr "Invertir colores"
 
 msgid "BIOS size"
 msgstr "Tamaño de BIOS"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "Mapear a C0000-C7FFF como UMB"
@@ -1516,6 +1661,9 @@ msgstr "Nível de reverberación"
 
 msgid "Interpolation Method"
 msgstr "Método de interpolación"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "Ganancia de salida de reverberación"
@@ -1604,6 +1752,12 @@ msgstr "DMA bajo"
 msgid "Enable Game port"
 msgstr "Habilitar puerto de juegos"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "Módulo Surround"
 
@@ -1615,6 +1769,9 @@ msgstr "Activar la interrupción CODEC en la configuración CODEC (necesario par
 
 msgid "SB Address"
 msgstr "Dirección del SB"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "IRQ de WSS"
@@ -1700,6 +1857,9 @@ msgstr "Tipo de RAMDAC"
 msgid "Blend"
 msgstr "Mezclar"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "Filtrado bilineal"
 
@@ -1744,6 +1904,33 @@ msgstr "Velocidad de transferencia"
 
 msgid "EMS mode"
 msgstr "Modo EMS"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "Dirección para > 2 MB"
@@ -1901,6 +2088,15 @@ msgstr "Interpolación sRGB"
 msgid "Linear interpolation"
 msgstr "Interpolación lineare"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 KB"
 
@@ -1934,6 +2130,9 @@ msgstr "Ámbar"
 msgid "Gray"
 msgstr "Gris"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "Color"
 
@@ -1948,6 +2147,12 @@ msgstr "Otros idiomas"
 
 msgid "Bochs latest"
 msgstr "Bochs más nuevo"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "Monocromo no entrelazado"
@@ -2075,6 +2280,12 @@ msgstr "Clon IBM 8514/A (ISA)"
 msgid "Vendor"
 msgstr "Fabricante"
 
+msgid "30 Hz (JMP2 = 1)"
+msgstr ""
+
+msgid "60 Hz (JMP2 = 2)"
+msgstr ""
+
 msgid "Generic PC/XT Memory Expansion"
 msgstr "Expansión de Memoria Generica PC/XT"
 
@@ -2146,3 +2357,66 @@ msgstr ""
 
 msgid "Could not load file %1"
 msgstr ""
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "ZIP drives:"
+#~ msgstr "Unidades ZIP:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "Imagenes ZIP"

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -147,6 +147,9 @@ msgstr "RGB, &värit"
 msgid "&RGB Grayscale"
 msgstr "&RGB, harmaasävy"
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "&Meripihkanvärinen"
 
@@ -384,6 +387,15 @@ msgstr "Käytössä (UTC)"
 msgid "Dynamic Recompiler"
 msgstr "Dynaaminen uudelleenkääntäjä"
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr "Näytönohjain:"
 
@@ -588,8 +600,8 @@ msgstr "CD-ROM-asemat:"
 msgid "MO drives:"
 msgstr "Magneettisoptiset asemat (MO):"
 
-msgid "ZIP drives:"
-msgstr "ZIP-asemat:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "ISA-RTC (kello):"
 
 msgid "ISA Memory Expansion"
 msgstr "ISA-muistilaajennus"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "Kortti 1:"
@@ -611,6 +626,27 @@ msgstr "Kortti 3:"
 
 msgid "Card 4:"
 msgstr "Kortti 4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "ISABugger-laite"
@@ -633,11 +669,14 @@ msgstr " - TAUKO"
 msgid "Speed"
 msgstr "Nopeus"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "ZIP-levykuvat"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "86Box ei löytänyt käyttökelpoisia ROM-tiedostoja.\n\nVoit <a href=\"https://github.com/86Box/roms/releases/latest\">ladata</a> ROM-paketin ja purkaa sen \"roms\"-hakemistoon."
@@ -672,8 +711,8 @@ msgstr "Konetta \"%hs\" ei voi käyttää, koska roms/machines-hakemistosta puut
 msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
 msgstr "Näytönohjainta \"%hs\" ei voi käyttää, koska roms/machines-hakemistosta puuttuvien ROM-tiedostojen vuoksi. Vaihdetaan käyttökelpoiseen näytönohjaimeen."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "Näytönohjainta 2 \"%hs\" ei voi käyttää, koska roms/machines-hakemistosta puuttuvien ROM-tiedostojen vuoksi. Toisen näytönohjaimen poistaminen käytöstä."
+msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr ""
 
 msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
 msgstr "Laite \"%hs\" ei voi käyttää puuttuvien ROM-tiedostojen vuoksi. Laitteen huomiotta jättäminen."
@@ -777,11 +816,38 @@ msgstr "4-akselinen 4-painikkeinen peliohjain"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinder Pad"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Thrustmaster Flight Control System"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "Ei mikään"
@@ -1281,9 +1347,6 @@ msgstr "Varjostinohjelmat"
 msgid "Remove"
 msgstr "Poista"
 
-msgid "No shader selected"
-msgstr "Ei valittu varjostinohjelmatta"
-
 msgid "Browse..."
 msgstr "Selaa..."
 
@@ -1380,8 +1443,14 @@ msgstr "Microsoft-väylähiiri (InPort)"
 msgid "Mouse Systems Serial Mouse"
 msgstr "Mouse Systems-sarjahiiri"
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
 msgstr "Microsoft-sarjahiiri"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
 
 msgid "Logitech Serial Mouse"
 msgstr "Logitech-sarjahiiri"
@@ -1391,6 +1460,9 @@ msgstr "PS/2 hiiri"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (sarja)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] Tavallinen Hayes-yhteensopiva modeemi"
@@ -1416,11 +1488,53 @@ msgstr "Järjestelmän MIDI"
 msgid "MIDI Input Device"
 msgstr "MIDI-syöttölaite"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "BIOS-osoite"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "Käytä BIOS-laajennuksen ROM-kirjoitusten"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "Osoite"
@@ -1430,6 +1544,21 @@ msgstr "IRQ"
 
 msgid "BIOS Revision"
 msgstr "BIOS-tarkistus"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "Käännä 26 -> 17"
@@ -1445,6 +1574,18 @@ msgstr "Käännä värit"
 
 msgid "BIOS size"
 msgstr "BIOS-koko"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "Kartta C0000-C7FFF UMB:nä"
@@ -1520,6 +1661,9 @@ msgstr "Jälkikaiunnan taso"
 
 msgid "Interpolation Method"
 msgstr "Interpolointimenetelmä"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "Jälkikaiunta lähtötaso"
@@ -1608,6 +1752,12 @@ msgstr "Matala DMA"
 msgid "Enable Game port"
 msgstr "Käytä peliporttita"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "Surround-moduuli"
 
@@ -1619,6 +1769,9 @@ msgstr "CODEC-keskeytyksen nostaminen CODEC-asennuksen yhteydessä (jotkut ohjai
 
 msgid "SB Address"
 msgstr "SB-osoite"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "WSS-IRQ"
@@ -1704,6 +1857,9 @@ msgstr "RAMDAC-tyyppi"
 msgid "Blend"
 msgstr "Sekoitus"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "Bilineaarinen suodatus"
 
@@ -1748,6 +1904,33 @@ msgstr "Siirtonopeus"
 
 msgid "EMS mode"
 msgstr "EMS-tila"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "Osoite > 2 Mt"
@@ -1905,6 +2088,15 @@ msgstr "sRGB-interpolointi"
 msgid "Linear interpolation"
 msgstr "Lineaarinen interpolointi"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 Kt"
 
@@ -1938,6 +2130,9 @@ msgstr "Keltainen"
 msgid "Gray"
 msgstr "Harmaa"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "Väri"
 
@@ -1952,6 +2147,12 @@ msgstr "Muut kielet"
 
 msgid "Bochs latest"
 msgstr "Bochs uusin"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "Yksivärinen ei-välitetyt"
@@ -2079,6 +2280,12 @@ msgstr "IBM 8514/A-klooni (ISA)"
 msgid "Vendor"
 msgstr "Valmistaja"
 
+msgid "30 Hz (JMP2 = 1)"
+msgstr ""
+
+msgid "60 Hz (JMP2 = 2)"
+msgstr ""
+
 msgid "Generic PC/XT Memory Expansion"
 msgstr "Yleinen PC/XT-muistilaajennus"
 
@@ -2150,3 +2357,72 @@ msgstr ""
 
 msgid "Could not load file %1"
 msgstr ""
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "ZIP drives:"
+#~ msgstr "ZIP-asemat:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "ZIP-levykuvat"
+
+#~ msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+#~ msgstr "Näytönohjainta 2 \"%hs\" ei voi käyttää, koska roms/machines-hakemistosta puuttuvien ROM-tiedostojen vuoksi. Toisen näytönohjaimen poistaminen käytöstä."
+
+#~ msgid "No shader selected"
+#~ msgstr "Ei valittu varjostinohjelmatta"

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -147,6 +147,9 @@ msgstr "&Couleurs RGB"
 msgid "&RGB Grayscale"
 msgstr "Niveau de Gris &RGB "
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "Moniteur &Ambre"
 
@@ -384,6 +387,15 @@ msgstr "Activé (UTC)"
 msgid "Dynamic Recompiler"
 msgstr "Recompilateur dynamique"
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr "Vidéo:"
 
@@ -588,8 +600,8 @@ msgstr "Lecteurs CD-ROM:"
 msgid "MO drives:"
 msgstr "Lecteurs magnéto-optiques:"
 
-msgid "ZIP drives:"
-msgstr "Lecteurs ZIP:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "Horloge temps réel ISA:"
 
 msgid "ISA Memory Expansion"
 msgstr "Extension de la mémoire ISA"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "Carte 1:"
@@ -611,6 +626,27 @@ msgstr "Carte 3:"
 
 msgid "Card 4:"
 msgstr "Carte 4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "Dispositif ISABugger"
@@ -633,11 +669,14 @@ msgstr " - EN PAUSE"
 msgid "Speed"
 msgstr "Vitesse"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "Images ZIP"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "86Box n'a pas pu trouver d'images ROM utilisables.\n\nS'il vous plait, <a href=\"https://github.com/86Box/roms/releases/latest\">téléchargez</a> un ensemble ROM et extrayez-le dans le répertoire \"roms\"."
@@ -777,11 +816,38 @@ msgstr "Manette avec 4 axes, 4 boutons"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinder Pad"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Système de contrôle de vol Thrustmaster"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "Aucun"
@@ -1377,8 +1443,14 @@ msgstr "Souris bus Microsoft (InPort)"
 msgid "Mouse Systems Serial Mouse"
 msgstr "Souris série Mouse Systems"
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
 msgstr "Souris série Microsoft"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
 
 msgid "Logitech Serial Mouse"
 msgstr "Souris série Logitech"
@@ -1388,6 +1460,9 @@ msgstr "Souris PS/2"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (série)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] Modem standard conforme à la norme Hayes"
@@ -1413,11 +1488,53 @@ msgstr "Système MIDI"
 msgid "MIDI Input Device"
 msgstr "Dispositif d'entrée MIDI"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "Adresse BIOS"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "Activer les écritures au ROM d'extension du BIOS"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "Adresse"
@@ -1427,6 +1544,21 @@ msgstr "IRQ"
 
 msgid "BIOS Revision"
 msgstr "Révision BIOS"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "Traduire 26 -> 17"
@@ -1442,6 +1574,18 @@ msgstr "Inversion des couleurs"
 
 msgid "BIOS size"
 msgstr "Taille du BIOS"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "Mapper C0000-C7FFF en tant qu'UMB"
@@ -1517,6 +1661,9 @@ msgstr "Niveau de réverbération"
 
 msgid "Interpolation Method"
 msgstr "Méthode d'interpolation"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "Gain de sortie réverbération"
@@ -1605,6 +1752,12 @@ msgstr "DMA bas"
 msgid "Enable Game port"
 msgstr "Activer le port de jeu"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "Module Surround"
 
@@ -1616,6 +1769,9 @@ msgstr "Lever l'interruption CODEC lors de la configuration du CODEC (nécessair
 
 msgid "SB Address"
 msgstr "Adresse SB"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "IRQ WSS"
@@ -1701,6 +1857,9 @@ msgstr "Type de RAMDAC"
 msgid "Blend"
 msgstr "Mélanger"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "Filtrage bilinéaire"
 
@@ -1745,6 +1904,33 @@ msgstr "Vitesse de transfert"
 
 msgid "EMS mode"
 msgstr "Mode EMS"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "Adresse pour > 2 MB"
@@ -1902,6 +2088,15 @@ msgstr "Interpolation sRVB"
 msgid "Linear interpolation"
 msgstr "Interpolation linéaire"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 Ko"
 
@@ -1935,6 +2130,9 @@ msgstr "Ambre"
 msgid "Gray"
 msgstr "Gris"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "Couleur"
 
@@ -1949,6 +2147,12 @@ msgstr "Autres langues"
 
 msgid "Bochs latest"
 msgstr "Bochs dernière"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "Monochrome non entrelacé"
@@ -2076,6 +2280,12 @@ msgstr "Clone IBM 8514/A (ISA)"
 msgid "Vendor"
 msgstr "Fabricant"
 
+msgid "30 Hz (JMP2 = 1)"
+msgstr ""
+
+msgid "60 Hz (JMP2 = 2)"
+msgstr ""
+
 msgid "Generic PC/XT Memory Expansion"
 msgstr "Extension mémoire générique PC/XT"
 
@@ -2102,6 +2312,9 @@ msgstr "Demander confirmation avant de quitter"
 
 msgid "Options"
 msgstr "Options"
+
+msgid "Model"
+msgstr ""
 
 msgid "Model:"
 msgstr "Modèle:"
@@ -2144,3 +2357,66 @@ msgstr "Descendre"
 
 msgid "Could not load file %1"
 msgstr "Impossible de charger le fichier %1"
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "ZIP drives:"
+#~ msgstr "Lecteurs ZIP:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "Images ZIP"

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -147,6 +147,9 @@ msgstr "RGB u &boji"
 msgid "&RGB Grayscale"
 msgstr "&RGB u nijansama sive boje"
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "&Jantarni zaslon"
 
@@ -384,6 +387,15 @@ msgstr "Uključeno (UTC)"
 msgid "Dynamic Recompiler"
 msgstr "Dinamički rekompilator"
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr "Video:"
 
@@ -588,8 +600,8 @@ msgstr "CD-ROM pogoni:"
 msgid "MO drives:"
 msgstr "MO pogoni:"
 
-msgid "ZIP drives:"
-msgstr "ZIP pogoni:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "Sat stvarnog vremena (RTC):"
 
 msgid "ISA Memory Expansion"
 msgstr "Proširenje memorije ISA"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "Kartica 1:"
@@ -611,6 +626,27 @@ msgstr "Kartica 3:"
 
 msgid "Card 4:"
 msgstr "Kartica 4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "Uređaj ISABugger"
@@ -633,11 +669,14 @@ msgstr " - ZASTAO"
 msgid "Speed"
 msgstr "Brzina"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "ZIP slike"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "86Box nije mogao pronaći upotrebljive ROM datoteke.\n\nMolimte posjetite <a href=\"https://github.com/86Box/roms/releases/latest\"></a> sknite paket s ROM datotekama i ekstrahirajte paket u mapu \"roms\"."
@@ -765,8 +804,8 @@ msgstr "Palica za igru s 2 osi, 6 tipke"
 msgid "2-axis, 8-button joystick"
 msgstr "Palica za igru s 2 osi, 8 tipke"
 
-msgid "3-axis, 2-button joystick(s)"
-msgstr "Palica za igru s 3 osi, 2 tipke"
+msgid "3-axis, 2-button joystick"
+msgstr ""
 
 msgid "3-axis, 4-button joystick"
 msgstr "Palica za igru s 3 osi, 4 tipke"
@@ -777,11 +816,38 @@ msgstr "Palica za igru s 4 osi, 4 tipke"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinder Pad"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Thrustmaster Flight Control System"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "Bez"
@@ -1377,8 +1443,14 @@ msgstr "Sabirnički miš Microsoft (InPort)"
 msgid "Mouse Systems Serial Mouse"
 msgstr "Serijski miš Mouse Systems"
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
 msgstr "Serijski miš Microsoft"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
 
 msgid "Logitech Serial Mouse"
 msgstr "Serijski miš Logitech"
@@ -1388,6 +1460,9 @@ msgstr "Miš PS/2"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (serijski)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] Standardni modem, usklađen s standardom Hayesom"
@@ -1413,11 +1488,53 @@ msgstr "Sistemski MIDI"
 msgid "MIDI Input Device"
 msgstr "Ulazni uređaj MIDI"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "Adresa BIOS-a"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "Omogući pisanje u ROM proširenja BIOS-a"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "Adresa"
@@ -1427,6 +1544,21 @@ msgstr "IRQ"
 
 msgid "BIOS Revision"
 msgstr "Revizija BIOS-a"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "Prevedi 26 -> 17"
@@ -1442,6 +1574,18 @@ msgstr "Invertiraj boje"
 
 msgid "BIOS size"
 msgstr "Veličina BIOS-a"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "Mapiraj C0000-C7FFF kao UMB"
@@ -1517,6 +1661,9 @@ msgstr "Nivo odjeka"
 
 msgid "Interpolation Method"
 msgstr "Metoda interpolacije"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "Pojačavanje izlaza odjeka"
@@ -1605,6 +1752,12 @@ msgstr "Niski DMA"
 msgid "Enable Game port"
 msgstr "Omogoći vrata za igru"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "Modul Surround"
 
@@ -1616,6 +1769,9 @@ msgstr "Podigni prekid CODEC na postavljanju CODEC-a (potrebno nekim upravljačk
 
 msgid "SB Address"
 msgstr "Adresa SB-a"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "IRQ WSS-a"
@@ -1701,6 +1857,9 @@ msgstr "Vrsta RAMDAC-a"
 msgid "Blend"
 msgstr "Miješaj"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "Bilinearno filtriranje"
 
@@ -1745,6 +1904,33 @@ msgstr "Brzina prijenosa"
 
 msgid "EMS mode"
 msgstr "Načina EMS"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "Adresa za > 2 MB"
@@ -1902,6 +2088,15 @@ msgstr "Interpolacija sRGB"
 msgid "Linear interpolation"
 msgstr "Linearna interpolacija"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 KB"
 
@@ -1935,6 +2130,9 @@ msgstr "Jantarna"
 msgid "Gray"
 msgstr "Siva"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "Bojna"
 
@@ -1949,6 +2147,12 @@ msgstr "Ostali jezici"
 
 msgid "Bochs latest"
 msgstr "Bochs poslednji"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "Crno-biljeli bez preplitanja"
@@ -2076,6 +2280,12 @@ msgstr "Klon IBM 8514/A (ISA)"
 msgid "Vendor"
 msgstr "Proizvođać"
 
+msgid "30 Hz (JMP2 = 1)"
+msgstr ""
+
+msgid "60 Hz (JMP2 = 2)"
+msgstr ""
+
 msgid "Generic PC/XT Memory Expansion"
 msgstr "Generičko proširenje memorije PC/XT"
 
@@ -2147,3 +2357,69 @@ msgstr ""
 
 msgid "Could not load file %1"
 msgstr ""
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "ZIP drives:"
+#~ msgstr "ZIP pogoni:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "ZIP slike"
+
+#~ msgid "3-axis, 2-button joystick(s)"
+#~ msgstr "Palica za igru s 3 osi, 2 tipke"

--- a/src/qt/languages/hu-HU.po
+++ b/src/qt/languages/hu-HU.po
@@ -147,6 +147,9 @@ msgstr "RGB &színes"
 msgid "&RGB Grayscale"
 msgstr "&RGB szürkeárnyalatos"
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "&Gyömbér kijelző"
 
@@ -384,6 +387,15 @@ msgstr "Engedélyezve (UTC)"
 msgid "Dynamic Recompiler"
 msgstr "Dinamikus újrafordítás"
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr "Videokártya:"
 
@@ -588,8 +600,8 @@ msgstr "CD-ROM meghajtók:"
 msgid "MO drives:"
 msgstr "MO-meghajtók:"
 
-msgid "ZIP drives:"
-msgstr "ZIP-meghajtók:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "ISA RTC (óra):"
 
 msgid "ISA Memory Expansion"
 msgstr "ISA memóriabővítők"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "Kártya 1:"
@@ -611,6 +626,27 @@ msgstr "Kártya 3:"
 
 msgid "Card 4:"
 msgstr "Kártya 4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "ISABugger eszköz"
@@ -633,11 +669,14 @@ msgstr " - SZÜNETELT"
 msgid "Speed"
 msgstr "Sebesség"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "ZIP-lemezképek"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "A 86Box nem talált használható ROM-képeket\n\nKérem <a href=\"https://github.com/86Box/roms/releases/latest\">töltse le</a> a ROM készletet és bontsa ki a \"roms\" könyvtárba."
@@ -765,8 +804,8 @@ msgstr "2-tengelyes, 6-gombos játékvezérlő"
 msgid "2-axis, 8-button joystick"
 msgstr "2-tengelyes, 8-gombos játékvezérlő"
 
-msgid "3-axis, 2-button joystick(s)"
-msgstr "3-tengelyes, 2-gombos játékvezérlő(k)"
+msgid "3-axis, 2-button joystick"
+msgstr ""
 
 msgid "3-axis, 4-button joystick"
 msgstr "3-tengelyes, 4-gombos játékvezérlő"
@@ -777,11 +816,38 @@ msgstr "4-tengelyes, 4-gombos játékvezérlő"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinder Pad"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Thrustmaster Flight Control System"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "Nincs"
@@ -858,8 +924,8 @@ msgstr "Érvénytelen konfiguráció"
 msgid "%1 is required for automatic conversion of PostScript files to PDF.\n\nAny documents sent to the generic PostScript printer will be saved as PostScript (.ps) files."
 msgstr "%1 szükséges a PostScript fájlok PDF formátumba való automatikus konvertálásához.\n\nAz általános PostScript nyomtatóra küldött dokumentumok PostScript (.ps) fájlként kerülnek mentésre."
 
-msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Lnaugage (.pcl) files."
-msgstr "%1 szükséges a PCL fájlok PDF formátumba való automatikus konvertálásához.\n\nAz általános PCL nyomtatóra küldött dokumentumok Printer Command Language (.pcl) fájlként kerülnek mentésre."
+msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
+msgstr ""
 
 msgid "Don't show this message again"
 msgstr "Ne jelenítse meg újra ezt az üzenetet "
@@ -1377,8 +1443,14 @@ msgstr "Microsoft buszos egér (InPort)"
 msgid "Mouse Systems Serial Mouse"
 msgstr "Egérrendszerek Soros egér"
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
 msgstr "Microsoft soros egér"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
 
 msgid "Logitech Serial Mouse"
 msgstr "Logitech soros egér"
@@ -1388,6 +1460,9 @@ msgstr "PS/2 egér"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (soros)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] Szabványos Hayes-kompatibilis modem"
@@ -1413,11 +1488,53 @@ msgstr "Rendszer MIDI"
 msgid "MIDI Input Device"
 msgstr "MIDI bemeneti eszköz"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "BIOS cím"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "BIOS bővítés ROM írások engedélyezése"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "Cím:"
@@ -1427,6 +1544,21 @@ msgstr "IRQ"
 
 msgid "BIOS Revision"
 msgstr "BIOS felülvizsgálata"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "Fordítsd le 26 -> 17"
@@ -1442,6 +1574,18 @@ msgstr "Invertált színek"
 
 msgid "BIOS size"
 msgstr "BIOS mérete"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "C0000-C7FFF mint UMB leképezése"
@@ -1517,6 +1661,9 @@ msgstr "Visszhang szint"
 
 msgid "Interpolation Method"
 msgstr "Interpolációs módszer"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "Visszhang kimenetének erősítése"
@@ -1605,6 +1752,12 @@ msgstr "Alacsony DMA"
 msgid "Enable Game port"
 msgstr "Játékport engedélyezése"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "Surround modul"
 
@@ -1616,6 +1769,9 @@ msgstr "CODEC megszakítás felemelése CODEC beállításakor (néhány illeszt
 
 msgid "SB Address"
 msgstr "SB cím"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "WSS IRQ"
@@ -1701,6 +1857,9 @@ msgstr "RAMDAC típus"
 msgid "Blend"
 msgstr "Blend"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "Bilineáris szűrés"
 
@@ -1745,6 +1904,33 @@ msgstr "Átviteli sebesség"
 
 msgid "EMS mode"
 msgstr "EMS üzemmód"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "Cím > 2 MB"
@@ -1902,6 +2088,15 @@ msgstr "sRGB interpoláció"
 msgid "Linear interpolation"
 msgstr "Lineáris interpoláció"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 KB"
 
@@ -1935,6 +2130,9 @@ msgstr "Sárga"
 msgid "Gray"
 msgstr "Szürke"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "Színes"
 
@@ -1949,6 +2147,12 @@ msgstr "Egyéb nyelvek"
 
 msgid "Bochs latest"
 msgstr "Bochs legújabb"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "Monokróm nem átlapolt"
@@ -2076,6 +2280,12 @@ msgstr "IBM 8514/A klón (ISA)"
 msgid "Vendor"
 msgstr "Gyártó"
 
+msgid "30 Hz (JMP2 = 1)"
+msgstr ""
+
+msgid "60 Hz (JMP2 = 2)"
+msgstr ""
+
 msgid "Generic PC/XT Memory Expansion"
 msgstr "Általános PC/XT memóriabővítők"
 
@@ -2147,3 +2357,72 @@ msgstr ""
 
 msgid "Could not load file %1"
 msgstr ""
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "ZIP drives:"
+#~ msgstr "ZIP-meghajtók:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "ZIP-lemezképek"
+
+#~ msgid "3-axis, 2-button joystick(s)"
+#~ msgstr "3-tengelyes, 2-gombos játékvezérlő(k)"
+
+#~ msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Lnaugage (.pcl) files."
+#~ msgstr "%1 szükséges a PCL fájlok PDF formátumba való automatikus konvertálásához.\n\nAz általános PCL nyomtatóra küldött dokumentumok Printer Command Language (.pcl) fájlként kerülnek mentésre."

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -147,6 +147,9 @@ msgstr "RGB &Color"
 msgid "&RGB Grayscale"
 msgstr "&RGB Monocroma"
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "&Monitor ambra"
 
@@ -384,6 +387,15 @@ msgstr "Abilitata (UTC)"
 msgid "Dynamic Recompiler"
 msgstr "Ricompilatore dinamico"
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr "Video:"
 
@@ -588,8 +600,8 @@ msgstr "Unità CD-ROM:"
 msgid "MO drives:"
 msgstr "Unità magneto-ottiche:"
 
-msgid "ZIP drives:"
-msgstr "Unità ZIP:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "RTC ISA:"
 
 msgid "ISA Memory Expansion"
 msgstr "Espansione memoria ISA"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "Scheda 1:"
@@ -611,6 +626,27 @@ msgstr "Scheda 3:"
 
 msgid "Card 4:"
 msgstr "Scheda 4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "Dispositivo ISABugger"
@@ -633,11 +669,14 @@ msgstr " - IN PAUSA"
 msgid "Speed"
 msgstr "Velocità"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "Immagini ZIP"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "86Box non può trovare immagini ROM utilizzabili.\n\nSi prega di <a href=\"https://github.com/86Box/roms/releases/latest\">scaricare</a> un set di ROM ed estrarlo nella directory \"roms\"."
@@ -777,11 +816,38 @@ msgstr "Joystick da 4 assi, 4 pulsanti"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinder Pad"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Thrustmaster Flight Control System"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "Nessuno"
@@ -858,8 +924,8 @@ msgstr "Configurazione invalida"
 msgid "%1 is required for automatic conversion of PostScript files to PDF.\n\nAny documents sent to the generic PostScript printer will be saved as PostScript (.ps) files."
 msgstr "%1 è richiesto per la conversione automatica di file PostScript a file PDF.\n\nQualsiasi documento mandato alla stampante generica PostScript sarà salvato come file PostScript (.ps)."
 
-msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PostScript printer will be saved as Printer Command Language (.pcl) files."
-msgstr "%1 è richiesto per la conversione automatica di file PCL a file PDF.\n\nQualsiasi documento mandato alla stampante generica PCL sarà salvato come file Printer Command Language (.cl)."
+msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
+msgstr ""
 
 msgid "Don't show this message again"
 msgstr "Non mostrare più questo messaggio"
@@ -1377,8 +1443,14 @@ msgstr "Mouse bus Microsoft (InPort)"
 msgid "Mouse Systems Serial Mouse"
 msgstr "Mouse seriale Mouse Systems"
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
 msgstr "Mouse seriale Microsoft"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
 
 msgid "Logitech Serial Mouse"
 msgstr "Mouse seriale Logitech"
@@ -1388,6 +1460,9 @@ msgstr "Mouse PS/2"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (seriale)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] Modem standard conforme a Hayes"
@@ -1413,11 +1488,53 @@ msgstr "MIDI di sistema"
 msgid "MIDI Input Device"
 msgstr "Dispositivo di ingresso MIDI"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "Indirizzo BIOS"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "Abilita scrittura al ROM dell'estensione del BIOS"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "Indirizzo"
@@ -1427,6 +1544,21 @@ msgstr "IRQ"
 
 msgid "BIOS Revision"
 msgstr "Revisione del BIOS"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "Tradurre 26 -> 17"
@@ -1442,6 +1574,18 @@ msgstr "Invertire i colori"
 
 msgid "BIOS size"
 msgstr "Dimensione del BIOS"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "Mappa C0000-C7FFF come UMB"
@@ -1517,6 +1661,9 @@ msgstr "Livello di riverbero"
 
 msgid "Interpolation Method"
 msgstr "Metodo di interpolazione"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "Guadagno dell'uscita del riverbero"
@@ -1605,6 +1752,12 @@ msgstr "DMA basso"
 msgid "Enable Game port"
 msgstr "Abilita la porta giochi"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "Modulo surround"
 
@@ -1616,6 +1769,9 @@ msgstr "Solleva l'interrupt del CODEC all'impostazione del CODEC (necessario per
 
 msgid "SB Address"
 msgstr "Indirizzo SB"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "IRQ WSS"
@@ -1701,6 +1857,9 @@ msgstr "Tipo di RAMDAC"
 msgid "Blend"
 msgstr "Miscela"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "Filtraggio bilineare"
 
@@ -1745,6 +1904,33 @@ msgstr "Velocità di trasferimento"
 
 msgid "EMS mode"
 msgstr "Modalità EMS"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "Indirizzo per > 2 MB"
@@ -1902,6 +2088,15 @@ msgstr "Interpolazione sRGB"
 msgid "Linear interpolation"
 msgstr "Interpolazione lineare"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 KB"
 
@@ -1935,6 +2130,9 @@ msgstr "Ambra"
 msgid "Gray"
 msgstr "Grigio"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "Colore"
 
@@ -1949,6 +2147,12 @@ msgstr "Altre lingue"
 
 msgid "Bochs latest"
 msgstr "Bochs ultima versione"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "Mono non interlacciato"
@@ -2076,6 +2280,12 @@ msgstr "Clone IBM 8514/A (ISA)"
 msgid "Vendor"
 msgstr "Fabricante"
 
+msgid "30 Hz (JMP2 = 1)"
+msgstr ""
+
+msgid "60 Hz (JMP2 = 2)"
+msgstr ""
+
 msgid "Generic PC/XT Memory Expansion"
 msgstr "Espansione di memoria generica PC/XT"
 
@@ -2147,3 +2357,69 @@ msgstr ""
 
 msgid "Could not load file %1"
 msgstr ""
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "ZIP drives:"
+#~ msgstr "Unità ZIP:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "Immagini ZIP"
+
+#~ msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PostScript printer will be saved as Printer Command Language (.pcl) files."
+#~ msgstr "%1 è richiesto per la conversione automatica di file PCL a file PDF.\n\nQualsiasi documento mandato alla stampante generica PCL sarà salvato come file Printer Command Language (.cl)."

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -147,6 +147,9 @@ msgstr "RGB(カラー)(&C)"
 msgid "&RGB Grayscale"
 msgstr "RGB(グレースケール)(&R)"
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "モニター(黄色)(&A)"
 
@@ -384,6 +387,15 @@ msgstr "有効(UTC)"
 msgid "Dynamic Recompiler"
 msgstr "動的再コンパイル"
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr "ビデオカード:"
 
@@ -588,8 +600,8 @@ msgstr "CD-ROMドライブ:"
 msgid "MO drives:"
 msgstr "光磁気ドライブ:"
 
-msgid "ZIP drives:"
-msgstr "ZIPドライブ:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "ISA RTCカード:"
 
 msgid "ISA Memory Expansion"
 msgstr "ISAメモリ拡張カード"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "カード1:"
@@ -611,6 +626,27 @@ msgstr "カード3:"
 
 msgid "Card 4:"
 msgstr "カード4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "ISABuggerデバイス"
@@ -633,11 +669,14 @@ msgstr " - 一時停止"
 msgid "Speed"
 msgstr "速度"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "ZIPイメージ"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "86Boxで使用可能なROMイメージが見つかりません。\n\nROMセットを<a href=\"https://github.com/86Box/roms/releases/latest\">ダウンロード</a>して、roms ディレクトリに解凍してください。"
@@ -777,11 +816,38 @@ msgstr "ジョイスティック(4軸、4ボタン)"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinderパッド"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Thrustmaster飛行制御システム"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "なし"
@@ -1377,8 +1443,14 @@ msgstr "Microsoft バスマウス（InPort）"
 msgid "Mouse Systems Serial Mouse"
 msgstr "Mouse Systems シリアルマウス"
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
 msgstr "Microsoft シリアルマウス"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
 
 msgid "Logitech Serial Mouse"
 msgstr "Logitech シリアルマウス"
@@ -1388,6 +1460,9 @@ msgstr "PS/2マウス"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3Mマイクロタッチ（シリアル）"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] 標準ヘイズ準拠モデム"
@@ -1413,11 +1488,53 @@ msgstr "システムMIDI"
 msgid "MIDI Input Device"
 msgstr "MIDI入力デバイス"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "BIOSアドレス"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "BIOS拡張ROM書き込みを有効にする"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "アドレス"
@@ -1427,6 +1544,21 @@ msgstr "割り込み要求"
 
 msgid "BIOS Revision"
 msgstr "BIOSリビジョン"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "26→17を翻訳"
@@ -1442,6 +1574,18 @@ msgstr "色の反転"
 
 msgid "BIOS size"
 msgstr "BIOSサイズ"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "C0000-C7FFFをUMBとしてマップ"
@@ -1517,6 +1661,9 @@ msgstr "リバーブ・レベル"
 
 msgid "Interpolation Method"
 msgstr "補間法"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "リバーブ出力のゲイン"
@@ -1605,6 +1752,12 @@ msgstr "低DMA"
 msgid "Enable Game port"
 msgstr "ゲームポートを有効にする"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "サラウンド・モジュール"
 
@@ -1616,6 +1769,9 @@ msgstr "CODECセットアップ時にCODEC割り込みを発生させる(一部�
 
 msgid "SB Address"
 msgstr "SBアドレス"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "WSS IRQ"
@@ -1701,6 +1857,9 @@ msgstr "RAMDACタイプ"
 msgid "Blend"
 msgstr "ブレンド"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "バイリニア・フィルタリング"
 
@@ -1745,6 +1904,33 @@ msgstr "転送速度"
 
 msgid "EMS mode"
 msgstr "EMSモード"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "2MB以上のアドレス"
@@ -1902,6 +2088,15 @@ msgstr "sRGB補間"
 msgid "Linear interpolation"
 msgstr "線形補間"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 KB"
 
@@ -1935,6 +2130,9 @@ msgstr "鼈甲色"
 msgid "Gray"
 msgstr "ねずみ色"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "カラー"
 
@@ -1949,6 +2147,12 @@ msgstr "その他の言語"
 
 msgid "Bochs latest"
 msgstr "Bochs latest"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "モノラル・ノンインターレース"
@@ -2076,6 +2280,12 @@ msgstr "IBM 8514/A クローン（ISA）"
 msgid "Vendor"
 msgstr "業者"
 
+msgid "30 Hz (JMP2 = 1)"
+msgstr ""
+
+msgid "60 Hz (JMP2 = 2)"
+msgstr ""
+
 msgid "Generic PC/XT Memory Expansion"
 msgstr "汎用PC/XTメモリ拡張カード"
 
@@ -2147,3 +2357,66 @@ msgstr ""
 
 msgid "Could not load file %1"
 msgstr ""
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "ZIP drives:"
+#~ msgstr "ZIPドライブ:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "ZIPイメージ"

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -147,6 +147,9 @@ msgstr "RGB 천연색(&C)"
 msgid "&RGB Grayscale"
 msgstr "RGB 회색조(&R)"
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "주황색 모니터(&A)"
 
@@ -384,11 +387,20 @@ msgstr "사용 (UTC)"
 msgid "Dynamic Recompiler"
 msgstr "동적 재컴파일"
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr "비디오 카드:"
 
-msgid "Video 2:"
-msgstr "비디오 카드 2:"
+msgid "Video #2:"
+msgstr ""
 
 msgid "Voodoo 1 or 2 Graphics"
 msgstr "Voodoo 1 또는 2 그래픽"
@@ -588,8 +600,8 @@ msgstr "CD-ROM 드라이브:"
 msgid "MO drives:"
 msgstr "광자기 드라이브:"
 
-msgid "ZIP drives:"
-msgstr "ZIP 드라이브:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "ISA RTC 카드:"
 
 msgid "ISA Memory Expansion"
 msgstr "ISA 메모리 확장 카드"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "카드 1:"
@@ -611,6 +626,27 @@ msgstr "카드 3:"
 
 msgid "Card 4:"
 msgstr "카드 4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "ISABugger 장치"
@@ -633,11 +669,14 @@ msgstr " - 일시 중지됨"
 msgid "Speed"
 msgstr "속도"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "ZIP 이미지"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "86Box에서 사용 가능한 ROM 이미지를 찾을 수 없습니다.\n\nROM 세트를<a href=\"https://github.com/86Box/roms/releases/latest\">다운로드</a> 후 \"roms\" 디렉토리에 압축을 풀어 주세요."
@@ -777,11 +816,38 @@ msgstr "4축, 4버튼 조이스틱"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinder Pad"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Thrustmaster Flight Control System"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "없음"
@@ -1377,8 +1443,14 @@ msgstr "마이크로소프트 버스 마우스(인포트)"
 msgid "Mouse Systems Serial Mouse"
 msgstr "마우스 시스템 시리얼 마우스"
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
 msgstr "마이크로소프트 직렬 마우스"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
 
 msgid "Logitech Serial Mouse"
 msgstr "로지텍 직렬 마우스"
@@ -1388,6 +1460,9 @@ msgstr "PS/2 마우스"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M 마이크로터치(직렬)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] 표준 헤이즈 호환 모뎀"
@@ -1413,11 +1488,53 @@ msgstr "시스템 미디"
 msgid "MIDI Input Device"
 msgstr "미디 입력 장치"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "BIOS 주소"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "BIOS 확장 ROM 쓰기 활성화"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "주소"
@@ -1427,6 +1544,21 @@ msgstr "IRQ"
 
 msgid "BIOS Revision"
 msgstr "BIOS 개정"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "번역 26 -> 17"
@@ -1442,6 +1574,18 @@ msgstr "색상 반전"
 
 msgid "BIOS size"
 msgstr "BIOS 크기"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "C0000-C7FFF를 UMB로 매핑하기"
@@ -1517,6 +1661,9 @@ msgstr "리버브 레벨"
 
 msgid "Interpolation Method"
 msgstr "보간 방법"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "리버브 출력의 게인"
@@ -1605,6 +1752,12 @@ msgstr "낮은 DMA"
 msgid "Enable Game port"
 msgstr "게임 포트 사용"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "서라운드 모듈"
 
@@ -1616,6 +1769,9 @@ msgstr "코덱 설정 시 코덱 인터럽트 올리기(일부 드라이버에 �
 
 msgid "SB Address"
 msgstr "SB 주소"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "WSS IRQ"
@@ -1701,6 +1857,9 @@ msgstr "램닥 유형"
 msgid "Blend"
 msgstr "블렌드"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "이중선형 필터링"
 
@@ -1745,6 +1904,33 @@ msgstr "전송 속도"
 
 msgid "EMS mode"
 msgstr "EMS 모드"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "2MB 이상의 주소"
@@ -1902,6 +2088,15 @@ msgstr "sRGB 보간"
 msgid "Linear interpolation"
 msgstr "선형 보간"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 KB"
 
@@ -1935,6 +2130,9 @@ msgstr "Amber"
 msgid "Gray"
 msgstr "회색"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "색상"
 
@@ -1949,6 +2147,12 @@ msgstr "기타 언어"
 
 msgid "Bochs latest"
 msgstr "Bochs 최신 정보"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "모노 비인터레이스"
@@ -2076,6 +2280,12 @@ msgstr "IBM 8514/A 클론(ISA)"
 msgid "Vendor"
 msgstr "제조사"
 
+msgid "30 Hz (JMP2 = 1)"
+msgstr ""
+
+msgid "60 Hz (JMP2 = 2)"
+msgstr ""
+
 msgid "Generic PC/XT Memory Expansion"
 msgstr "일반 PC/XT 메모리 확장 카드"
 
@@ -2147,3 +2357,69 @@ msgstr ""
 
 msgid "Could not load file %1"
 msgstr ""
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "Video 2:"
+#~ msgstr "비디오 카드 2:"
+
+#~ msgid "ZIP drives:"
+#~ msgstr "ZIP 드라이브:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "ZIP 이미지"

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -147,6 +147,9 @@ msgstr "RGB &Kleur"
 msgid "&RGB Grayscale"
 msgstr "&RGB grijstinten"
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "&Amber monitor"
 
@@ -384,6 +387,15 @@ msgstr "Ingeschakeld (UTC)"
 msgid "Dynamic Recompiler"
 msgstr "Dynamische Recompiler"
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr "Video:"
 
@@ -588,8 +600,8 @@ msgstr "CD-ROM-stations:"
 msgid "MO drives:"
 msgstr "MO-schijven:"
 
-msgid "ZIP drives:"
-msgstr "ZIP-schijven:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "ISA RTC:"
 
 msgid "ISA Memory Expansion"
 msgstr "ISA-geheugenuitbreiding"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "Kaart 1:"
@@ -611,6 +626,27 @@ msgstr "Kaart 3:"
 
 msgid "Card 4:"
 msgstr "Kaart 4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "ISABugger-apparaat"
@@ -633,11 +669,14 @@ msgstr " - GEPAUZEERD"
 msgid "Speed"
 msgstr "Snelheid"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "ZIP-images"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "86Box kon geen bruikbare ROM images vinden.\n\n<a href=\"https://github.com/86Box/roms/releases/latest\">Download</a> een ROM set en pak deze uit in de map \"roms\"."
@@ -777,11 +816,38 @@ msgstr "Joystick met 4 assen en 4 knoppen"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinder Pad"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Thrustmaster Flight Control systeem"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "Geen"
@@ -1377,8 +1443,14 @@ msgstr "Microsoft busmuis (InPort)"
 msgid "Mouse Systems Serial Mouse"
 msgstr "Mouse Systems seriële muis"
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
 msgstr "Microsoft seriële muis"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
 
 msgid "Logitech Serial Mouse"
 msgstr "Logitech seriële muis"
@@ -1388,6 +1460,9 @@ msgstr "PS/2-muis"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (serieel)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "COM] Standaard Hayes-compatibele modem "
@@ -1413,11 +1488,53 @@ msgstr "Systeem MIDI"
 msgid "MIDI Input Device"
 msgstr "MIDI-ingangsapparaat"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "BIOS-adres"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "BIOS-extensie ROM Writes inschakelen"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "Adres"
@@ -1427,6 +1544,21 @@ msgstr "IRQ"
 
 msgid "BIOS Revision"
 msgstr "BIOS Revisie"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "Vertaal 26 -> 17"
@@ -1442,6 +1574,18 @@ msgstr "Kleuren inverteren"
 
 msgid "BIOS size"
 msgstr "BIOS-grootte"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "Geheugenadres C0000-C7FFF toewijzen aan UMB"
@@ -1517,6 +1661,9 @@ msgstr "Reverbniveau"
 
 msgid "Interpolation Method"
 msgstr "Interpolatiemethode"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "Reverbuitgang Versterking"
@@ -1605,6 +1752,12 @@ msgstr "Lage DMA"
 msgid "Enable Game port"
 msgstr "Game-poort inschakelen"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "Surroundmodule"
 
@@ -1616,6 +1769,9 @@ msgstr "Verhoog CODEC interrupt bij CODEC setup (nodig voor sommige stuurprogram
 
 msgid "SB Address"
 msgstr "SB-adres"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "WSS IRQ"
@@ -1701,6 +1857,9 @@ msgstr "RAMDAC type"
 msgid "Blend"
 msgstr "Mengen"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "Bilineaire filtering"
 
@@ -1745,6 +1904,33 @@ msgstr "Overdrachtssnelheid"
 
 msgid "EMS mode"
 msgstr "EMS-modus"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "Adres voor > 2 MB"
@@ -1902,6 +2088,15 @@ msgstr "sRGB-interpolatie"
 msgid "Linear interpolation"
 msgstr "Lineaire interpolatie"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 KB"
 
@@ -1935,6 +2130,9 @@ msgstr "Amber"
 msgid "Gray"
 msgstr "Grijs"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "Kleur"
 
@@ -1949,6 +2147,12 @@ msgstr "Andere talen"
 
 msgid "Bochs latest"
 msgstr "Bochs nieuwste"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "Mono niet geïnterlaced"
@@ -2076,6 +2280,12 @@ msgstr "IBM 8514/A-kloon (ISA)"
 msgid "Vendor"
 msgstr "Leverancier"
 
+msgid "30 Hz (JMP2 = 1)"
+msgstr ""
+
+msgid "60 Hz (JMP2 = 2)"
+msgstr ""
+
 msgid "Generic PC/XT Memory Expansion"
 msgstr "Generieke PC/XT geheugenuitbreiding"
 
@@ -2147,3 +2357,66 @@ msgstr "Omlaag verplaatsen"
 
 msgid "Could not load file %1"
 msgstr "Kon bestand %1 niet laden"
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "ZIP drives:"
+#~ msgstr "ZIP-schijven:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "ZIP-images"

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -147,6 +147,9 @@ msgstr "RGB - &Kolorowy"
 msgid "&RGB Grayscale"
 msgstr "&RGB - Skala odcieni szarości"
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "&Bursztynowy monitor"
 
@@ -384,6 +387,15 @@ msgstr "Włączona (UTC)"
 msgid "Dynamic Recompiler"
 msgstr "Dynamiczny rekompilator"
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr "Wideo:"
 
@@ -588,8 +600,8 @@ msgstr "Napędy CD-ROM:"
 msgid "MO drives:"
 msgstr "Napędy MO:"
 
-msgid "ZIP drives:"
-msgstr "Napędy ZIP:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "ISA RTC:"
 
 msgid "ISA Memory Expansion"
 msgstr "Rozszerzenie pamięci ISA"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "Karta 1:"
@@ -611,6 +626,27 @@ msgstr "Karta 3:"
 
 msgid "Card 4:"
 msgstr "Karta 4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "Urządzenie ISABugger"
@@ -633,11 +669,14 @@ msgstr " - PAUZA"
 msgid "Speed"
 msgstr "Szybkość"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "Obrazy ZIP"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "86Box nie może znaleźć obrazów ROM nadających się do użytku.\n\nProszę pobrać zestaw obrazów ROM ze strony <a href=\"https://github.com/86Box/roms/releases/latest\">download</a>, i rozpakować je do katalogu \"roms\"."
@@ -777,11 +816,38 @@ msgstr "Joystick 4-osiowy, 4-przyciskowy"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinder Pad"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Thrustmaster Flight Control System"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "Żaden"
@@ -1377,8 +1443,14 @@ msgstr "Mysz magistralowa Microsoft (InPort)"
 msgid "Mouse Systems Serial Mouse"
 msgstr "Mysz szeregowa Mouse Systems"
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
 msgstr "Mysz szeregowa Microsoft"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
 
 msgid "Logitech Serial Mouse"
 msgstr "Mysz szeregowa Logitech"
@@ -1388,6 +1460,9 @@ msgstr "Mysz PS/2"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (szeregowy)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] Standardowy modem zgodny z Hayes"
@@ -1413,11 +1488,53 @@ msgstr "System MIDI"
 msgid "MIDI Input Device"
 msgstr "Urządzenie wejściowe MIDI"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "Adres BIOS"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "Włączenie zapisu do pamięci ROM rozszerzenia BIOS"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "Adres"
@@ -1427,6 +1544,21 @@ msgstr "IRQ"
 
 msgid "BIOS Revision"
 msgstr "Wersja BIOS-u"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "Przetłumacz 26 -> 17"
@@ -1442,6 +1574,18 @@ msgstr "Odwracanie kolorów"
 
 msgid "BIOS size"
 msgstr "Rozmiar BIOS-u"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "Mapowanie C0000-C7FFF jako UMB"
@@ -1517,6 +1661,9 @@ msgstr "Poziom pogłosu"
 
 msgid "Interpolation Method"
 msgstr "Metoda interpolacji"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "Wzmocnienie sygnału wyjściowego pogłosu"
@@ -1605,6 +1752,12 @@ msgstr "Niski poziom DMA"
 msgid "Enable Game port"
 msgstr "Włącz port gier"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "Moduł Surround"
 
@@ -1616,6 +1769,9 @@ msgstr "Podnieś przerwanie CODEC podczas konfiguracji CODEC-a (wymagane przez n
 
 msgid "SB Address"
 msgstr "Adres SB"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "WSS IRQ"
@@ -1701,6 +1857,9 @@ msgstr "Typ RAMDAC"
 msgid "Blend"
 msgstr "Mieszanka"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "Filtrowanie dwuliniowe"
 
@@ -1745,6 +1904,33 @@ msgstr "Prędkość transferu"
 
 msgid "EMS mode"
 msgstr "Tryb EMS"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "Adres dla > 2 MB"
@@ -1902,6 +2088,15 @@ msgstr "Interpolacja sRGB"
 msgid "Linear interpolation"
 msgstr "Interpolacja liniowa"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 KB"
 
@@ -1935,6 +2130,9 @@ msgstr "Bursztynowy"
 msgid "Gray"
 msgstr "Szary"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "Kolorowy"
 
@@ -1949,6 +2147,12 @@ msgstr "Inne języki"
 
 msgid "Bochs latest"
 msgstr "Najnowszy Bochs"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "Monochromatyczny bez przeplotu"
@@ -2076,6 +2280,12 @@ msgstr "Klon IBM 8514/A (ISA)"
 msgid "Vendor"
 msgstr "Producent"
 
+msgid "30 Hz (JMP2 = 1)"
+msgstr ""
+
+msgid "60 Hz (JMP2 = 2)"
+msgstr ""
+
 msgid "Generic PC/XT Memory Expansion"
 msgstr "Generyczne rozszerzenie pamięci PC/XT"
 
@@ -2147,3 +2357,66 @@ msgstr "Przesuń w dół"
 
 msgid "Could not load file %1"
 msgstr "Nie można wczytać pliku %1"
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "ZIP drives:"
+#~ msgstr "Napędy ZIP:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "Obrazy ZIP"

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -147,6 +147,9 @@ msgstr "&Cores RGB"
 msgid "&RGB Grayscale"
 msgstr "&RGB em escala de cinzentos"
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "Monitor âmb&ar"
 
@@ -384,6 +387,15 @@ msgstr "Ativada (UTC)"
 msgid "Dynamic Recompiler"
 msgstr "Recompilador dinâmico"
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr "Vídeo:"
 
@@ -588,8 +600,8 @@ msgstr "Unidades CD-ROM:"
 msgid "MO drives:"
 msgstr "Unidades magneto-ópticas:"
 
-msgid "ZIP drives:"
-msgstr "Unidades ZIP:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "ISA RTC:"
 
 msgid "ISA Memory Expansion"
 msgstr "Expansão de memória ISA"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "Placa 1:"
@@ -611,6 +626,27 @@ msgstr "Placa 3:"
 
 msgid "Card 4:"
 msgstr "Placa 4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "Dispositivo ISABugger"
@@ -633,11 +669,14 @@ msgstr " - EM PAUSA"
 msgid "Speed"
 msgstr "Velocidade"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "Imagens ZIP"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "O 86Box não conseguiu encontrar nenhuma imagem ROM utilizável.\n\nPor favor, vá a href=\"https://github.com/86Box/roms/releases/latest\">descarregue</a> um pacote ROM e instale-o na pasta \"roms\"."
@@ -777,11 +816,38 @@ msgstr "Joystick de 4 eixos, 4 botões"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinder Pad"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Thrustmaster Flight Control System"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "Nenhum"
@@ -1377,8 +1443,14 @@ msgstr "Rato Microsoft Bus (InPort)"
 msgid "Mouse Systems Serial Mouse"
 msgstr "Sistemas de ratos Rato de série"
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
 msgstr "Rato de série Microsoft"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
 
 msgid "Logitech Serial Mouse"
 msgstr "Rato de série Logitech"
@@ -1388,6 +1460,9 @@ msgstr "Rato PS/2"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (série)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] Modem padrão compatível com Hayes"
@@ -1413,11 +1488,53 @@ msgstr "Sistema MIDI"
 msgid "MIDI Input Device"
 msgstr "Dispositivo de entrada MIDI"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "Endereço da BIOS"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "Ativar as escritas de ROM de extensão da BIOS"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "Endereço"
@@ -1427,6 +1544,21 @@ msgstr "IRQ"
 
 msgid "BIOS Revision"
 msgstr "Revisão da BIOS"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "Traduzir 26 -> 17"
@@ -1442,6 +1574,18 @@ msgstr "Inverter cores"
 
 msgid "BIOS size"
 msgstr "Tamanho da BIOS"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "Mapear C0000-C7FFF como UMB"
@@ -1517,6 +1661,9 @@ msgstr "Nível de reverberação"
 
 msgid "Interpolation Method"
 msgstr "Método de interpolação"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "Ganho da saída do reverb"
@@ -1605,6 +1752,12 @@ msgstr "DMA baixo"
 msgid "Enable Game port"
 msgstr "Ativar a porta de jogos"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "Módulo Surround"
 
@@ -1616,6 +1769,9 @@ msgstr "Ativar a interrupção do CODEC na configuração do CODEC (necessário 
 
 msgid "SB Address"
 msgstr "Endereço SB"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "WSS IRQ"
@@ -1701,6 +1857,9 @@ msgstr "Tipo de RAMDAC"
 msgid "Blend"
 msgstr "Mistura"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "Filtragem bilinear"
 
@@ -1745,6 +1904,33 @@ msgstr "Velocidade de transferência"
 
 msgid "EMS mode"
 msgstr "Modo EMS"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "Endereço para > 2 MB"
@@ -1902,6 +2088,15 @@ msgstr "interpolação sRGB"
 msgid "Linear interpolation"
 msgstr "Interpolação linear"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 KB"
 
@@ -1935,6 +2130,9 @@ msgstr "Âmbar"
 msgid "Gray"
 msgstr "Cinzento"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "Cor"
 
@@ -1949,6 +2147,12 @@ msgstr "Outros idiomas"
 
 msgid "Bochs latest"
 msgstr "Bochs mais recente"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "Monocromático não entrelaçado"
@@ -2076,6 +2280,12 @@ msgstr "Clone IBM 8514/A (ISA)"
 msgid "Vendor"
 msgstr "Fabricante"
 
+msgid "30 Hz (JMP2 = 1)"
+msgstr ""
+
+msgid "60 Hz (JMP2 = 2)"
+msgstr ""
+
 msgid "Generic PC/XT Memory Expansion"
 msgstr "Expansão de memória genérica PC/XT"
 
@@ -2147,3 +2357,66 @@ msgstr ""
 
 msgid "Could not load file %1"
 msgstr ""
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "ZIP drives:"
+#~ msgstr "Unidades ZIP:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "Imagens ZIP"

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -147,9 +147,6 @@ msgstr "RGB &цветной"
 msgid "&RGB Grayscale"
 msgstr "&RGB монохромный"
 
-msgid "RGB (no brown)"
-msgstr "RGB (без коричневого)"
-
 msgid "Generic RGBI color monitor"
 msgstr "Стандартный цветной монитор RGBI"
 
@@ -603,8 +600,8 @@ msgstr "Дисководы CD-ROM:"
 msgid "MO drives:"
 msgstr "Магнитооптические дисководы:"
 
-msgid "ZIP drives:"
-msgstr "ZIP дисководы:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -630,6 +627,27 @@ msgstr "Карта 3:"
 msgid "Card 4:"
 msgstr "Карта 4:"
 
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
+
 msgid "ISABugger device"
 msgstr "Устройство ISABugger"
 
@@ -651,11 +669,14 @@ msgstr " - ПАУЗА"
 msgid "Speed"
 msgstr "Скорость"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "Образы ZIP"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "86Box не смог найти ни одного подходящего для использования файла с ПЗУ.\n\nПожалуйста <a href=\"https://github.com/86Box/roms/releases/latest\">скачайте</a> набор ПЗУ и извлеките его в каталог \"roms\"."
@@ -774,20 +795,8 @@ msgstr "Неверное устройство PCap"
 msgid "2-axis, 2-button joystick(s)"
 msgstr "2-осевой, 2-кнопочный джойстик"
 
-msgid "2-button gamepad(s)"
-msgstr "2-кнопочный геймпад"
-
-msgid "2-button flight yoke"
-msgstr "2-кнопочный flight yoke"
-
 msgid "2-axis, 4-button joystick"
 msgstr "2-осевой, 4-кнопочный джойстик"
-
-msgid "4-button gamepad"
-msgstr "4-кнопочный геймпад"
-
-msgid "4-button flight yoke"
-msgstr "4-кнопочный flight yoke"
 
 msgid "2-axis, 6-button joystick"
 msgstr "2-осевой, 6-кнопочный джойстик"
@@ -798,17 +807,8 @@ msgstr "2-осевой, 8-кнопочный джойстик"
 msgid "3-axis, 2-button joystick"
 msgstr "3-осевой, 2-кнопочный джойстик"
 
-msgid "2-button flight yoke with throttle"
-msgstr "2-кнопочный flight yoke с дросселем"
-
 msgid "3-axis, 4-button joystick"
 msgstr "3-осевой, 4-кнопочный джойстик"
-
-msgid "Win95 Steering Wheel (3-axis, 4-button)"
-msgstr "Руль Win95 (3-осевой, 4-кнопочный)"
-
-msgid "4-button flight yoke with throttle"
-msgstr "4-кнопочный flight yoke с дросселем"
 
 msgid "4-axis, 4-button joystick"
 msgstr "4-осевой, 4-кнопочный джойстик"
@@ -827,6 +827,27 @@ msgstr "Система управления полётом Thrustmaster"
 
 msgid "Thrustmaster FCS + Rudder Control System"
 msgstr "Thrustmaster FCS + Система управления рулем"
+
+msgid "2-button gamepad(s)"
+msgstr "2-кнопочный геймпад"
+
+msgid "2-button flight yoke"
+msgstr "2-кнопочный flight yoke"
+
+msgid "4-button gamepad"
+msgstr "4-кнопочный геймпад"
+
+msgid "4-button flight yoke"
+msgstr "4-кнопочный flight yoke"
+
+msgid "2-button flight yoke with throttle"
+msgstr "2-кнопочный flight yoke с дросселем"
+
+msgid "4-button flight yoke with throttle"
+msgstr "4-кнопочный flight yoke с дросселем"
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr "Руль Win95 (3-осевой, 4-кнопочный)"
 
 msgid "None"
 msgstr "Нет"
@@ -1428,6 +1449,9 @@ msgstr "Bus-мышь Mouse Systems"
 msgid "Microsoft Serial Mouse"
 msgstr "COM-мышь Microsoft"
 
+msgid "Microsoft Serial BallPoint"
+msgstr ""
+
 msgid "Logitech Serial Mouse"
 msgstr "COM-мышь Logitech"
 
@@ -1436,6 +1460,9 @@ msgstr "Мышь PS/2"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (последовательный)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] Стандартный Hayes-совместимый модем"
@@ -1833,18 +1860,6 @@ msgstr "Смесь"
 msgid "Font"
 msgstr "Шрифт"
 
-msgid "Has secondary 8x8 character set"
-msgstr "Вторичный набор символов 8x8"
-
-msgid "Has Quadcolor II daughter board"
-msgstr "Дочерняя плата Quadcolor II"
-
-msgid "Alternate monochrome contrast"
-msgstr "Альтернативный монохромный контраст"
-
-msgid "Video chroma-keying"
-msgstr "Видео хромакеинг"
-
 msgid "Bilinear filtering"
 msgstr "Билинейная фильтрация"
 
@@ -2073,6 +2088,15 @@ msgstr "Интерполяция sRGB"
 msgid "Linear interpolation"
 msgstr "Линейная интерполяция"
 
+msgid "Has secondary 8x8 character set"
+msgstr "Вторичный набор символов 8x8"
+
+msgid "Has Quadcolor II daughter board"
+msgstr "Дочерняя плата Quadcolor II"
+
+msgid "Alternate monochrome contrast"
+msgstr "Альтернативный монохромный контраст"
+
 msgid "128 KB"
 msgstr "128 КБ"
 
@@ -2210,9 +2234,6 @@ msgstr "Скорость передачи данных через канал"
 
 msgid "Named Pipe (Server)"
 msgstr "Именованный пайп (Сервер)"
-
-msgid "Named Pipe (Client)"
-msgstr "Именованный пайп (Клиент)"
 
 msgid "Host Serial Passthrough"
 msgstr "Последовательный порт хоста"
@@ -2382,8 +2403,29 @@ msgstr "Переключить беззвучный режим"
 msgid "Text files"
 msgstr "Текстовые файлы"
 
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
 msgid "ROM files"
 msgstr "Файлы ПЗУ"
 
 msgid "SoundFont files"
 msgstr "Файлы SoundFont"
+
+#~ msgid "RGB (no brown)"
+#~ msgstr "RGB (без коричневого)"
+
+#~ msgid "ZIP drives:"
+#~ msgstr "ZIP дисководы:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "Образы ZIP"
+
+#~ msgid "Video chroma-keying"
+#~ msgstr "Видео хромакеинг"
+
+#~ msgid "Named Pipe (Client)"
+#~ msgstr "Именованный пайп (Клиент)"

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -147,6 +147,9 @@ msgstr "RGB &farebný"
 msgid "&RGB Grayscale"
 msgstr "&Odtiene sivej"
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "&Jantárová obrazovka"
 
@@ -384,6 +387,15 @@ msgstr "Zapnutá (UTC)"
 msgid "Dynamic Recompiler"
 msgstr "Dynamický prekladač"
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr "Grafika:"
 
@@ -588,8 +600,8 @@ msgstr "Mechaniky CD-ROM:"
 msgid "MO drives:"
 msgstr "Magnetooptické mechaniky:"
 
-msgid "ZIP drives:"
-msgstr "Mechaniky ZIP:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "ISA hodiny:"
 
 msgid "ISA Memory Expansion"
 msgstr "ISA rozšírenie pamäte"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "Karta 1:"
@@ -611,6 +626,27 @@ msgstr "Karta 3:"
 
 msgid "Card 4:"
 msgstr "Karta 4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "Zariadenie ISABugger"
@@ -633,11 +669,14 @@ msgstr " - POZASTAVENÝ"
 msgid "Speed"
 msgstr "Rýchlosť"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "Obrazy ZIP diskov"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "86Box nenašiel žiadne použiteľné imidž pamätí ROM.\n\n<a href=\"https://github.com/86Box/roms/releases/latest\">Stiahnite</a> sadu obrazov ROM a extrahujte ju do zložky \"roms\"."
@@ -777,11 +816,38 @@ msgstr "4-osový, 4-tlačidlový joystick"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinder Pad"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Thrustmaster Flight Control System"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "Žiadne"
@@ -849,8 +915,8 @@ msgstr "Emulátor starých počítačov\n\nAutori: Miran Grča (OBattler), Richa
 msgid "Hardware not available"
 msgstr "Hardvér nie je dostupný"
 
-msgid "Make sure %1 is installed and that you are on a libpcap-compatible network connection."
-msgstr "Uistite sa, že je nainštalovaný %1 a používate sieťové pripojenie s ním kompatibilné."
+msgid "Make sure %1 is installed and that you are on a %1-compatible network connection."
+msgstr ""
 
 msgid "Invalid configuration"
 msgstr "Neplatná konfigurácia"
@@ -858,8 +924,8 @@ msgstr "Neplatná konfigurácia"
 msgid "%1 is required for automatic conversion of PostScript files to PDF.\n\nAny documents sent to the generic PostScript printer will be saved as PostScript (.ps) files."
 msgstr "%1 je potrebná pre automatický prevod PostScript dokumentov do PDF.\n\nAkékoľvek dokumenty vytlačené cez všeobecnú PostScriptovú tlačiareň budú uložené ako PostScript (.ps) súbory."
 
-msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Lnaugage (.pcl) files."
-msgstr "%1 je potrebná pre automatický prevod PCL dokumentov do PDF.\n\nAkékoľvek dokumenty vytlačené cez všeobecnú PCLovú tlačiareň budú uložené ako Printer Command Language (.pcl) súbory."
+msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
+msgstr ""
 
 msgid "Don't show this message again"
 msgstr "Nezobrazovať ďalej túto správu"
@@ -1260,7 +1326,6 @@ msgstr "Nulový ovládač"
 msgid "NIC %1 (%2) %3"
 msgstr "NIC %1 (%2) %3"
 
-
 msgid "Render behavior"
 msgstr "Správanie pri vykresľovaní"
 
@@ -1378,8 +1443,14 @@ msgstr "Zbernicová myš Microsoft (InPort)"
 msgid "Mouse Systems Serial Mouse"
 msgstr "Zbernicová myš Mouse Systems"
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
 msgstr "Sériová myš Microsoft"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
 
 msgid "Logitech Serial Mouse"
 msgstr "Sériová myš Logitech"
@@ -1389,6 +1460,9 @@ msgstr "Myš PS/2"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (sériová)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] Štandardný modem kompatibilný s Hayesom"
@@ -1414,11 +1488,53 @@ msgstr "Systém MIDI"
 msgid "MIDI Input Device"
 msgstr "Vstupné zariadenie MIDI"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "Adresa BIOS"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "Povolenie zápisu do pamäte ROM s rozšírením BIOS"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "Adresa"
@@ -1428,6 +1544,21 @@ msgstr "IRQ"
 
 msgid "BIOS Revision"
 msgstr "Revízia systému BIOS"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "Preložiť 26 -> 17"
@@ -1443,6 +1574,18 @@ msgstr "Invertovanie farieb"
 
 msgid "BIOS size"
 msgstr "Veľkosť systému BIOS"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "Mapa C0000-C7FFF ako UMB"
@@ -1518,6 +1661,9 @@ msgstr "Úroveň dozvuku"
 
 msgid "Interpolation Method"
 msgstr "Metóda interpolácie"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "Zosilnenie výstupu dozvuku"
@@ -1606,6 +1752,12 @@ msgstr "Nízka hodnota DMA"
 msgid "Enable Game port"
 msgstr "Povolenie herného portu"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "Surround modul"
 
@@ -1617,6 +1769,9 @@ msgstr "Zvýšenie prerušenia CODEC pri nastavení CODEC (potrebné v niektorý
 
 msgid "SB Address"
 msgstr "Adresa SB"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "WSS IRQ"
@@ -1702,6 +1857,9 @@ msgstr "Typ RAMDAC"
 msgid "Blend"
 msgstr "Zmes"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "Bilineárne filtrovanie"
 
@@ -1746,6 +1904,33 @@ msgstr "Rýchlosť prenosu"
 
 msgid "EMS mode"
 msgstr "Režim EMS"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "Adresa pre > 2 MB"
@@ -1903,6 +2088,15 @@ msgstr "Interpolácia sRGB"
 msgid "Linear interpolation"
 msgstr "Lineárna interpolácia"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 KB"
 
@@ -1936,6 +2130,9 @@ msgstr "Oranžový"
 msgid "Gray"
 msgstr "Šedý"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "Farebný"
 
@@ -1950,6 +2147,12 @@ msgstr "Ostatné jazyky"
 
 msgid "Bochs latest"
 msgstr "Bochs najnovšie"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "Mono bez prelínania"
@@ -2077,6 +2280,12 @@ msgstr "Klon IBM 8514/A (ISA)"
 msgid "Vendor"
 msgstr "Výrobca"
 
+msgid "30 Hz (JMP2 = 1)"
+msgstr ""
+
+msgid "60 Hz (JMP2 = 2)"
+msgstr ""
+
 msgid "Generic PC/XT Memory Expansion"
 msgstr "Všeobecné rozšírenie pamäte PC/XT"
 
@@ -2148,3 +2357,72 @@ msgstr ""
 
 msgid "Could not load file %1"
 msgstr ""
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "ZIP drives:"
+#~ msgstr "Mechaniky ZIP:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "Obrazy ZIP diskov"
+
+#~ msgid "Make sure %1 is installed and that you are on a libpcap-compatible network connection."
+#~ msgstr "Uistite sa, že je nainštalovaný %1 a používate sieťové pripojenie s ním kompatibilné."
+
+#~ msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Lnaugage (.pcl) files."
+#~ msgstr "%1 je potrebná pre automatický prevod PCL dokumentov do PDF.\n\nAkékoľvek dokumenty vytlačené cez všeobecnú PCLovú tlačiareň budú uložené ako Printer Command Language (.pcl) súbory."

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -147,6 +147,9 @@ msgstr "&Barvni RGB"
 msgid "&RGB Grayscale"
 msgstr "&Sivinski RGB"
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "&Rumeni zaslon"
 
@@ -384,6 +387,15 @@ msgstr "Omogočeno (UTC)"
 msgid "Dynamic Recompiler"
 msgstr "Dinamični prevajalnik"
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr "Video:"
 
@@ -588,8 +600,8 @@ msgstr "Pogoni CD-ROM:"
 msgid "MO drives:"
 msgstr "Magnetno-optični pogoni:"
 
-msgid "ZIP drives:"
-msgstr "Pogoni ZIP:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "Ura realnega časa ISA:"
 
 msgid "ISA Memory Expansion"
 msgstr "Razširitev pomnilnika ISA"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "Kartica 1:"
@@ -611,6 +626,27 @@ msgstr "Kartica 3:"
 
 msgid "Card 4:"
 msgstr "Kartica 4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "Naprava ISABugger"
@@ -633,11 +669,14 @@ msgstr " - ZAUSTAVLJEN"
 msgid "Speed"
 msgstr "Hitrost"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "ZIP slike"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "86Box ni našel nobenih uporabnih ROM slik.\n\nProsim <a href=\"https://github.com/86Box/roms/releases/latest\">prenesite</a> komplet ROM-ov in ga razširite v mapo \"roms\"."
@@ -777,11 +816,38 @@ msgstr "Igralna palica z 4 osmi, 4 gumbi"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinder Pad"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Thrustmaster Flight Control System"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "Brez"
@@ -849,8 +915,8 @@ msgstr "Emulator starih računalnikov\n\nAvtorji: Miran Grča (OBattler), Richar
 msgid "Hardware not available"
 msgstr "Strojna oprema ni na voljo"
 
-msgid "Make sure %1 is installed and that you are on a libpcap-compatible network connection."
-msgstr "Prepičajte se, da je nameščen %1 in da ste na omrežni povezavi, združljivi z libpcap."
+msgid "Make sure %1 is installed and that you are on a %1-compatible network connection."
+msgstr ""
 
 msgid "Invalid configuration"
 msgstr "Neveljavna konfiguracija"
@@ -858,8 +924,8 @@ msgstr "Neveljavna konfiguracija"
 msgid "%1 is required for automatic conversion of PostScript files to PDF.\n\nAny documents sent to the generic PostScript printer will be saved as PostScript (.ps) files."
 msgstr "%1 je potreben za samodejno pretvorbo datotek PostScript v PDF.\n\nVsi dokumenti, poslani generičnemu tiskalniku PostScript bodo shranjeni kot datoteke PostScript (.ps)."
 
-msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Lnaugage (.pcl) files."
-msgstr "%1 je potreben za samodejno pretvorbo datotek PCL v PDF.\n\nVsi dokumenti, poslani generičnemu tiskalniku PCL bodo shranjeni kot datoteke Printer Command Language (.pcl)."
+msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
+msgstr ""
 
 msgid "Don't show this message again"
 msgstr "Ne pokaži več tega sporočila"
@@ -1377,8 +1443,14 @@ msgstr "Miška na vodilu Microsoft (InPort)"
 msgid "Mouse Systems Serial Mouse"
 msgstr "Serijska miška Mouse Systems"
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
 msgstr "Serijska miška Microsoft"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
 
 msgid "Logitech Serial Mouse"
 msgstr "Serijska miška Logitech"
@@ -1388,6 +1460,9 @@ msgstr "Miška PS/2"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (serijska)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] Standardni modem v skladen s Hayes"
@@ -1413,11 +1488,53 @@ msgstr "Sistemski MIDI"
 msgid "MIDI Input Device"
 msgstr "Vhodna naprava MIDI"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "Naslov BIOS-a"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "Omogoči zapisovanje razširitev BIOS ROM-a"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "Naslov"
@@ -1427,6 +1544,21 @@ msgstr "IRQ"
 
 msgid "BIOS Revision"
 msgstr "Revizija BIOS-a"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "Prevedi 26 -> 17"
@@ -1442,6 +1574,18 @@ msgstr "Invertiraj barve"
 
 msgid "BIOS size"
 msgstr "Velikost BIOS-a"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "Preslikaj C0000-C7FFF kot UMB"
@@ -1517,6 +1661,9 @@ msgstr "Raven odmeva"
 
 msgid "Interpolation Method"
 msgstr "Metoda interpolacije"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "Ojačanje izhoda odmeva"
@@ -1605,6 +1752,12 @@ msgstr "Nizki DMA"
 msgid "Enable Game port"
 msgstr "Omogočanje igralnih vrat"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "Prostorski modul"
 
@@ -1616,6 +1769,9 @@ msgstr "Dvigni prekinitev za CODEC ob nastavitvi CODEC-a (to potrebujejo nekater
 
 msgid "SB Address"
 msgstr "Naslov SB"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "IRQ WSS"
@@ -1701,6 +1857,9 @@ msgstr "Vrsta RAMDAC"
 msgid "Blend"
 msgstr "Mešanica"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "Bilinearno filtriranje"
 
@@ -1745,6 +1904,33 @@ msgstr "Hitrost prenosa"
 
 msgid "EMS mode"
 msgstr "Način EMS"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "Naslov za > 2 MB"
@@ -1902,6 +2088,15 @@ msgstr "Interpolacija sRGB"
 msgid "Linear interpolation"
 msgstr "Linearna interpolacija"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 KB"
 
@@ -1935,6 +2130,9 @@ msgstr "Jantarni"
 msgid "Gray"
 msgstr "Sivi"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "Barvni"
 
@@ -1949,6 +2147,12 @@ msgstr "Drugi jeziki"
 
 msgid "Bochs latest"
 msgstr "Bochs najnovejše"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "Enobarvni brez prepletanja"
@@ -2076,6 +2280,12 @@ msgstr "Klon IBM 8514/A (ISA)"
 msgid "Vendor"
 msgstr "Proizvajalec"
 
+msgid "30 Hz (JMP2 = 1)"
+msgstr ""
+
+msgid "60 Hz (JMP2 = 2)"
+msgstr ""
+
 msgid "Generic PC/XT Memory Expansion"
 msgstr "Generična razširitev pomnilnika PC/XT"
 
@@ -2147,3 +2357,72 @@ msgstr "Premakni dol"
 
 msgid "Could not load file %1"
 msgstr "Ni bilo mogoče naložiti datoteke %1"
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "ZIP drives:"
+#~ msgstr "Pogoni ZIP:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "ZIP slike"
+
+#~ msgid "Make sure %1 is installed and that you are on a libpcap-compatible network connection."
+#~ msgstr "Prepičajte se, da je nameščen %1 in da ste na omrežni povezavi, združljivi z libpcap."
+
+#~ msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Lnaugage (.pcl) files."
+#~ msgstr "%1 je potreben za samodejno pretvorbo datotek PCL v PDF.\n\nVsi dokumenti, poslani generičnemu tiskalniku PCL bodo shranjeni kot datoteke Printer Command Language (.pcl)."

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -147,6 +147,9 @@ msgstr "RGB &färg"
 msgid "&RGB Grayscale"
 msgstr "&RGB gråskala"
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "&Bärnstensfärgad skärm"
 
@@ -384,6 +387,15 @@ msgstr "Aktiverad (UTC)"
 msgid "Dynamic Recompiler"
 msgstr "Dynamisk omkompilering"
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr "Bildskärmskort:"
 
@@ -588,8 +600,8 @@ msgstr "CD-ROM-enheter:"
 msgid "MO drives:"
 msgstr "MO-enheter:"
 
-msgid "ZIP drives:"
-msgstr "Zip-enheter:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "ISA realtidsklocka:"
 
 msgid "ISA Memory Expansion"
 msgstr "ISA minnesexpansion"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "Kort 1:"
@@ -611,6 +626,27 @@ msgstr "Kort 3:"
 
 msgid "Card 4:"
 msgstr "Kort 4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "ISABugger-enhet"
@@ -633,11 +669,14 @@ msgstr " - PAUSAD"
 msgid "Speed"
 msgstr "Hastighet"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "Zip-avbildningar"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "86Box kunde inte hitta några användbara ROM-avbildningar.\n\nVänligen <a href=\"https://github.com/86Box/roms/releases/latest\">ladda ner</a> en ROM-uppsättning och extrahera den till mappen \"roms\"."
@@ -777,11 +816,38 @@ msgstr "Styrspak med 4 axlar och 4 knappar"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinder Pad"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Thrustmaster Flight Control System"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "Ingen"
@@ -1377,8 +1443,14 @@ msgstr "Microsoft-buss-mus (InPort)"
 msgid "Mouse Systems Serial Mouse"
 msgstr "Mouse Systems seriemus"
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
 msgstr "Microsoft seriemus"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
 
 msgid "Logitech Serial Mouse"
 msgstr "Logitech seriemus"
@@ -1388,6 +1460,9 @@ msgstr "PS/2-mus"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (serie)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] Standard Hayes-kompatibelt modem"
@@ -1413,11 +1488,53 @@ msgstr "System-MIDI"
 msgid "MIDI Input Device"
 msgstr "Indataenhet för MIDI"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "BIOS-adress"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "Aktivera ROM-skrivningar för utökat BIOS"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "Adress"
@@ -1427,6 +1544,21 @@ msgstr "IRQ"
 
 msgid "BIOS Revision"
 msgstr "BIOS revision"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "Översätt 26 -> 17"
@@ -1442,6 +1574,18 @@ msgstr "Invertera färger"
 
 msgid "BIOS size"
 msgstr "Storlek på BIOS"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "Kartlägg C0000-C7FFF som UMB"
@@ -1517,6 +1661,9 @@ msgstr "Reverb nivå"
 
 msgid "Interpolation Method"
 msgstr "Interpoleringsmetod"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "Reverb utmatningsförstärkning"
@@ -1605,6 +1752,12 @@ msgstr "Låg DMA"
 msgid "Enable Game port"
 msgstr "Aktivera spelport"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "Sorround-modul"
 
@@ -1616,6 +1769,9 @@ msgstr "Öka avbrottsnummer för CODEC vid CODEC-installation (krävs av vissa d
 
 msgid "SB Address"
 msgstr "Adress för SB"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "WSS IRQ"
@@ -1701,6 +1857,9 @@ msgstr "RAMDAC-typ"
 msgid "Blend"
 msgstr "Blanda"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "Bilinjär filtrering"
 
@@ -1745,6 +1904,33 @@ msgstr "Överföringshastighet"
 
 msgid "EMS mode"
 msgstr "EMS-läge"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "Adress till > 2 MB"
@@ -1902,6 +2088,15 @@ msgstr "sRGB-interpolering"
 msgid "Linear interpolation"
 msgstr "Linjär interpolering"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 KB"
 
@@ -1935,6 +2130,9 @@ msgstr "Bärnstensfärgad"
 msgid "Gray"
 msgstr "Grå"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "Färg"
 
@@ -1949,6 +2147,12 @@ msgstr "Andra språk"
 
 msgid "Bochs latest"
 msgstr "Bochs senaste"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "Ej sammanflätad monokrom"
@@ -2153,3 +2357,66 @@ msgstr "Flytta ner"
 
 msgid "Could not load file %1"
 msgstr "Kunde inte ladda fil %1"
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "ZIP drives:"
+#~ msgstr "Zip-enheter:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "Zip-avbildningar"

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -147,6 +147,9 @@ msgstr "RGB (&Çok renkli)"
 msgid "&RGB Grayscale"
 msgstr "RGB (&Gri tonlu)"
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "&Kehribar monitör"
 
@@ -189,14 +192,14 @@ msgstr "Durum &çubuğu simgelerini güncelle"
 msgid "Take s&creenshot"
 msgstr "&Ekran görüntüsü al"
 
+msgid "S&ound"
+msgstr "&Ses"
+
 msgid "&Preferences..."
 msgstr "&Tercihler..."
 
 msgid "Enable &Discord integration"
 msgstr "&Discord entegrasyonunu etkinleştir"
-
-msgid "S&ound"
-msgstr "&Ses"
 
 msgid "Sound &gain..."
 msgstr "&Sesi artır..."
@@ -383,6 +386,15 @@ msgstr "Etkin (UTC)"
 
 msgid "Dynamic Recompiler"
 msgstr "Dinamik Derleyici"
+
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
 
 msgid "Video:"
 msgstr "Ekran kartı:"
@@ -588,8 +600,8 @@ msgstr "CD-ROM sürücüleri:"
 msgid "MO drives:"
 msgstr "MO sürücüleri:"
 
-msgid "ZIP drives:"
-msgstr "ZIP sürücüleri:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "ISA RTC:"
 
 msgid "ISA Memory Expansion"
 msgstr "ISA Bellek Artırıcı"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "Kart 1:"
@@ -611,6 +626,27 @@ msgstr "Kart 3:"
 
 msgid "Card 4:"
 msgstr "Kart 4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "ISABugger cihazı"
@@ -633,20 +669,17 @@ msgstr " - DURAKLATILDI"
 msgid "Speed"
 msgstr "Hız"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
-
-msgid "ZIP images"
-msgstr "ZIP imajları"
-
-msgid ""
-"86Box could not find any usable ROM images.\n"
-"\n"
-"Please <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
+msgid "Removable disk %1 (%2): %3"
 msgstr ""
-"86Box kullanılabilir hiçbir ROM dosyası bulamadı.\n"
-"\n"
-"Lütfen bir ROM seti <a href=\"https://github.com/86Box/roms/releases/latest\">indirip</a> \"roms\" klasörüne çıkarın."
+
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
+
+msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
+msgstr ""
 
 msgid "(empty)"
 msgstr "(boş)"
@@ -783,11 +816,38 @@ msgstr "4 eksenli, 4 düğmeli oyun kolu"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinder Pad"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Thrustmaster Flight Control System"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "Hiçbiri"
@@ -849,49 +909,23 @@ msgstr "86Box hakkında"
 msgid "86Box v"
 msgstr "86Box v"
 
-msgid ""
-"An emulator of old computers\n"
-"\n"
-"Authors: Miran Grča (OBattler), RichardG867, Jasmine Iwanek, TC1995, coldbrewed, Teemu Korhonen (Manaatti), Joakim L. Gilje, Adrien Moulin (elyosh), Daniel Balsom (gloriouscow), Cacodemon345, Fred N. van Kempen (waltje), Tiseno100, reenigne, and others.\n"
-"\n"
-"With previous core contributions from Sarah Walker, leilei, JohnElliott, greatpsycho, and others.\n"
-"\n"
-"Released under the GNU General Public License version 2 or later. See LICENSE for more information."
+msgid "An emulator of old computers\n\nAuthors: Miran Grča (OBattler), RichardG867, Jasmine Iwanek, TC1995, coldbrewed, Teemu Korhonen (Manaatti), Joakim L. Gilje, Adrien Moulin (elyosh), Daniel Balsom (gloriouscow), Cacodemon345, Fred N. van Kempen (waltje), Tiseno100, reenigne, and others.\n\nWith previous core contributions from Sarah Walker, leilei, JohnElliott, greatpsycho, and others.\n\nReleased under the GNU General Public License version 2 or later. See LICENSE for more information."
 msgstr ""
-"Bir eski bilgisayar emülatörü\n"
-"\n"
-"Yapımcılar: Miran Grča (OBattler), RichardG867, Jasmine Iwanek, TC1995, coldbrewed, Teemu Korhonen (Manaatti), Joakim L. Gilje, Adrien Moulin (elyosh), Daniel Balsom (gloriouscow), Cacodemon345, Fred N. van Kempen (waltje), Tiseno100, reenigne ve diğerleri.\n"
-"\n"
-"Sarah Walker, leilei, JohnElliott, greatpsycho, ve diğerlerinin önceki katkılarıyla birlikte.\n"
-"\n"
-"GNU Genel Kamu Lisansı versiyon 2 veya sonrası altında yayınlanmıştır. Daha fazla bilgi için LICENSE kısmını gözden geçirin."
 
 msgid "Hardware not available"
 msgstr "Cihaz mevcut değil"
 
-msgid "Make sure %1 is installed and that you are on a libpcap-compatible network connection."
-msgstr "%1 kurulu olduğundan ve libpcap uyumlu bir internet ağı kullandığınızdan emin olun."
+msgid "Make sure %1 is installed and that you are on a %1-compatible network connection."
+msgstr ""
 
 msgid "Invalid configuration"
 msgstr "Geçersiz yapılandırma"
 
-msgid ""
-"%1 is required for automatic conversion of PostScript files to PDF.\n"
-"\n"
-"Any documents sent to the generic PostScript printer will be saved as PostScript (.ps) files."
+msgid "%1 is required for automatic conversion of PostScript files to PDF.\n\nAny documents sent to the generic PostScript printer will be saved as PostScript (.ps) files."
 msgstr ""
-"%1 PostScript dosyalarının otomatik olarak PDF dosyasına çevirilmesi için gereklidir.\n"
-"\n"
-"Genel PostScript yazıcısına gönderilen tüm dökümanlar PostScript (.ps) dosyası olarak kaydedilecektir."
 
-msgid ""
-"%1 is required for automatic conversion of PCL files to PDF.\n"
-"\n"
-"Any documents sent to the generic PostScript printer will be saved as Printer Command Language (.pcl) files."
+msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
 msgstr ""
-"%1 PCL dosyalarının otomatik olarak PDF dosyasına çevirilmesi için gereklidir.\n"
-"\n"
-"Genel PostScript yazıcısına gönderilen tüm dökümanlar Printer Command Language (.pcl) dosyası olarak kaydedilecektir."
 
 msgid "Don't show this message again"
 msgstr "Bu mesajı bir daha gösterme"
@@ -920,18 +954,8 @@ msgstr "GLSL gölgelendiricileri"
 msgid "You are loading an unsupported configuration"
 msgstr "Desteklenmeyen bir yapılandırma kullanıyorsunuz"
 
-msgid ""
-"CPU type filtering based on selected machine is disabled for this emulated machine.\n"
-"\n"
-"This makes it possible to choose a CPU that is otherwise incompatible with the selected machine. However, you may run into incompatibilities with the machine BIOS or other software.\n"
-"\n"
-"Enabling this setting is not officially supported and any bug reports filed may be closed as invalid."
+msgid "CPU type filtering based on selected machine is disabled for this emulated machine.\n\nThis makes it possible to choose a CPU that is otherwise incompatible with the selected machine. However, you may run into incompatibilities with the machine BIOS or other software.\n\nEnabling this setting is not officially supported and any bug reports filed may be closed as invalid."
 msgstr ""
-"Seçtiğiniz makineyle uygun işlemci filtresi bu yapılandırma için devre dışı bırakıldı.\n"
-"\n"
-"Bu durum seçili makine ile uyumsuz bir işlemci kullanmanızı mümkün kılmaktadır. Ancak bundan dolayı makinenin BIOS'unda veya çalıştırılan diğer yazılımlarda uyumsuzluk sorunları meydana gelebilir.\n"
-"\n"
-"İşlemci filtresinin devre dışı bırakılması resmi olarak desteklenmemektedir ve bu esnada açtığınız hata raporları geçersiz sayılabilir."
 
 msgid "Continue"
 msgstr "Devam et"
@@ -1086,18 +1110,8 @@ msgstr "VHD dosyaları"
 msgid "Select the parent VHD"
 msgstr "Ana VHD dosyasını seçin"
 
-msgid ""
-"This could mean that the parent image was modified after the differencing image was created.\n"
-"\n"
-"It can also happen if the image files were moved or copied, or by a bug in the program that created this disk.\n"
-"\n"
-"Do you want to fix the timestamps?"
+msgid "This could mean that the parent image was modified after the differencing image was created.\n\nIt can also happen if the image files were moved or copied, or by a bug in the program that created this disk.\n\nDo you want to fix the timestamps?"
 msgstr ""
-"Bu, farklandırmış imaj dosyası oluşturulduktan sonra ana imaj dosyasında bir değişiklik yapıldığı anlamına geliyor olabilir.\n"
-"\n"
-"Bu durum ayrıca imaj dosyalarının kopyalanmasından, yerlerinin değiştirilmesinden veya dosyaları oluşturan programdaki bir hatadan dolayı da meydana gelmiş olabilir.\n"
-"\n"
-"Zaman damgalarını düzeltmek ister misiniz?"
 
 msgid "Parent and child disk timestamps do not match"
 msgstr "Ana ve ek disklerin zaman damgaları uyuşmuyor"
@@ -1237,18 +1251,8 @@ msgstr "Pencereye &odaklanmıyorken duraklat"
 msgid "WinBox is no longer supported"
 msgstr "WinBox artık desteklenmemektedir"
 
-msgid ""
-"Development of the WinBox manager stopped in 2022 due to a lack of maintainers. As we direct our efforts towards making 86Box even better, we have made the decision to no longer support WinBox as a manager.\n"
-"\n"
-"No further updates will be provided through WinBox, and you may encounter incorrect behavior should you continue using it with newer versions of 86Box. Any bug reports related to WinBox behavior will be closed as invalid.\n"
-"\n"
-"Go to 86box.net for a list of other managers you can use."
+msgid "Development of the WinBox manager stopped in 2022 due to a lack of maintainers. As we direct our efforts towards making 86Box even better, we have made the decision to no longer support WinBox as a manager.\n\nNo further updates will be provided through WinBox, and you may encounter incorrect behavior should you continue using it with newer versions of 86Box. Any bug reports related to WinBox behavior will be closed as invalid.\n\nGo to 86box.net for a list of other managers you can use."
 msgstr ""
-"WinBox yöneticisinin geliştirilmesi geliştirici eksikliği nedeniyle 2022 yılında durduruldu. 86Box'ı daha iyi hale getirmeye odaklanmak amacıyla bu yöneticiyi artık desteklememe kararı aldık.\n"
-"\n"
-"Artık WinBox aracılığıyla güncellemeler yayınlanmayacaktır ve bu yöneticiyi 86Box'ın yeni sürümleriyle kullanmanız halinde hatalarla karşılaşabilirsiniz. WinBox'ın kullanımıyla ilgili tüm hata raporları geçersiz sayılacaktır.\n"
-"\n"
-"Kullanabileceğiniz diğer yöneticilerin bir listesi için lütfen 86box.net adresini ziyaret edin."
 
 msgid "Generate"
 msgstr "Oluştur"
@@ -1358,12 +1362,8 @@ msgstr "OpenGL sürüm 3.0 veya üstü gereklidir. Geçerli sürüm %1.%2"
 msgid "Error initializing OpenGL"
 msgstr "OpenGL başlatılırken hata oluştu"
 
-msgid ""
-"\n"
-"Falling back to software rendering."
-msgstr ""
-"\n"
-"Yazılım derleyicisine geri dönülüyor."
+msgid "\nFalling back to software rendering."
+msgstr "\nYazılım derleyicisine geri dönülüyor."
 
 msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
 msgstr "<html><head/><body><p>Medya görüntüsü (CD-ROM, disket, vb.) seçme diyaloğu 86Box yapılandırma dosyasının bulunduğu dizinde başlayacaktır. Bu ayar muhtemelen sadece macOS üzerinde bir değişiklik meydana getirecektir.</p></body></html>"
@@ -1371,14 +1371,8 @@ msgstr "<html><head/><body><p>Medya görüntüsü (CD-ROM, disket, vb.) seçme d
 msgid "This machine might have been moved or copied."
 msgstr "Bu makine taşınmış veya kopyalanmış olabilir."
 
-msgid ""
-"In order to ensure proper networking functionality, 86Box needs to know if this machine was moved or copied.\n"
-"\n"
-"Select \"I Copied It\" if you are not sure."
+msgid "In order to ensure proper networking functionality, 86Box needs to know if this machine was moved or copied.\n\nSelect \"I Copied It\" if you are not sure."
 msgstr ""
-"Ağ bağlantısı özelliğinin doğru bir şekilde çalışması için 86Box'ın bu makinenin başka bir konuma taşındığını mı yoksa kopyalandığını mı belirlemesi gerekmektedir.\n"
-"\n"
-"Bundan emin değilseniz \"Kopyalandı\" seçeneğini seçin."
 
 msgid "I Moved It"
 msgstr "Taşındı"
@@ -1455,6 +1449,9 @@ msgstr "Mouse Systems Bus Fare"
 msgid "Microsoft Serial Mouse"
 msgstr "Microsoft Seri Fare"
 
+msgid "Microsoft Serial BallPoint"
+msgstr ""
+
 msgid "Logitech Serial Mouse"
 msgstr "Logitech Seri Fare"
 
@@ -1463,6 +1460,9 @@ msgstr "PS/2 fare"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (seri)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] Standart Hayes Uyumlu Modem"
@@ -1488,11 +1488,53 @@ msgstr "Sistem MIDI'si"
 msgid "MIDI Input Device"
 msgstr "MIDI Giriş Cihazı"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "BIOS Adresi"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "BIOS uzantı ROM yazımlarını etkinleştir"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "Adres"
@@ -1502,6 +1544,21 @@ msgstr "IRQ"
 
 msgid "BIOS Revision"
 msgstr "BIOS Sürümü"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "26 -> 17 olarak çevir"
@@ -1517,6 +1574,18 @@ msgstr "Renkleri tersine çevir"
 
 msgid "BIOS size"
 msgstr "BIOS boyutu"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "C0000-C7FFF'yi UMB olarak eşle"
@@ -1592,6 +1661,9 @@ msgstr "Yankı Seviyesi"
 
 msgid "Interpolation Method"
 msgstr "İnterpolasyon Yöntemi"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "Yankı Çıkış Sesi Artışı"
@@ -1680,6 +1752,12 @@ msgstr "Düşük DMA"
 msgid "Enable Game port"
 msgstr "Gameport'ı etkinleştir"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "Surround modülü"
 
@@ -1691,6 +1769,9 @@ msgstr "CODEC kurulumunda CODEC kesmesini yükselt (bazı sürücüler tarafınd
 
 msgid "SB Address"
 msgstr "SB adresi"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "WSS IRQ"
@@ -1776,6 +1857,9 @@ msgstr "RAMDAC türü"
 msgid "Blend"
 msgstr "Karışım"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "Bilineer filtreleme"
 
@@ -1820,6 +1904,33 @@ msgstr "Transfer hızı"
 
 msgid "EMS mode"
 msgstr "EMS modu"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "> 2 MB için adres"
@@ -1977,6 +2088,15 @@ msgstr "sRGB interpolasyonu"
 msgid "Linear interpolation"
 msgstr "Doğrusal interpolasyon"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 KB"
 
@@ -2010,6 +2130,9 @@ msgstr "Kehribar"
 msgid "Gray"
 msgstr "Gri"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "Renk"
 
@@ -2024,6 +2147,12 @@ msgstr "Diğer diller"
 
 msgid "Bochs latest"
 msgstr "Bochs'un en son sürümü"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "Tek Renkli (Geçiş Taramasız)"
@@ -2067,8 +2196,8 @@ msgstr "Stereo LPT DAC"
 msgid "Generic Text Printer"
 msgstr "Genel Metin Yazıcı"
 
-msgid "Generic ESC/P Dot-Matrix"
-msgstr "Genel ESC/P Dot-Matrix"
+msgid "Generic ESC/P Dot-Matrix Printer"
+msgstr ""
 
 msgid "Generic PostScript Printer"
 msgstr "Genel PostScript Yazıcı"
@@ -2151,6 +2280,12 @@ msgstr "IBM 8514/A klonu (ISA)"
 msgid "Vendor"
 msgstr "Üretici"
 
+msgid "30 Hz (JMP2 = 1)"
+msgstr ""
+
+msgid "60 Hz (JMP2 = 2)"
+msgstr ""
+
 msgid "Generic PC/XT Memory Expansion"
 msgstr "Genel PC/XT Bellek Artırıcı"
 
@@ -2199,17 +2334,11 @@ msgstr "OpenGL sürüm 3.0 veya daha yükseği gereklidir. Şu anki GLSL sürüm
 msgid "Could not load texture: %1"
 msgstr "%1 dokusu yüklenemedi"
 
-msgid ""
-"Could not compile shader:\n"
-"\n"
-"%1"
-msgstr "%1 gölgelendiricisi derlenemedi"
+msgid "Could not compile shader:\n\n%1"
+msgstr ""
 
-msgid ""
-"Program not linked:\n"
-"\n"
-"%1"
-msgstr "%1 programı bağlanamadı"
+msgid "Program not linked:\n\n%1"
+msgstr ""
 
 msgid "Shader Manager"
 msgstr "Gölgelendirici Yöneticisi"
@@ -2228,3 +2357,176 @@ msgstr "Aşağı taşı"
 
 msgid "Could not load file %1"
 msgstr "%1 dosyası yüklenemedi"
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "ZIP drives:"
+#~ msgstr "ZIP sürücüleri:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "ZIP imajları"
+
+#~ msgid ""
+#~ "86Box could not find any usable ROM images.\n"
+#~ "\n"
+#~ "Please <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
+#~ msgstr ""
+#~ "86Box kullanılabilir hiçbir ROM dosyası bulamadı.\n"
+#~ "\n"
+#~ "Lütfen bir ROM seti <a href=\"https://github.com/86Box/roms/releases/latest\">indirip</a> \"roms\" klasörüne çıkarın."
+
+#~ msgid ""
+#~ "An emulator of old computers\n"
+#~ "\n"
+#~ "Authors: Miran Grča (OBattler), RichardG867, Jasmine Iwanek, TC1995, coldbrewed, Teemu Korhonen (Manaatti), Joakim L. Gilje, Adrien Moulin (elyosh), Daniel Balsom (gloriouscow), Cacodemon345, Fred N. van Kempen (waltje), Tiseno100, reenigne, and others.\n"
+#~ "\n"
+#~ "With previous core contributions from Sarah Walker, leilei, JohnElliott, greatpsycho, and others.\n"
+#~ "\n"
+#~ "Released under the GNU General Public License version 2 or later. See LICENSE for more information."
+#~ msgstr ""
+#~ "Bir eski bilgisayar emülatörü\n"
+#~ "\n"
+#~ "Yapımcılar: Miran Grča (OBattler), RichardG867, Jasmine Iwanek, TC1995, coldbrewed, Teemu Korhonen (Manaatti), Joakim L. Gilje, Adrien Moulin (elyosh), Daniel Balsom (gloriouscow), Cacodemon345, Fred N. van Kempen (waltje), Tiseno100, reenigne ve diğerleri.\n"
+#~ "\n"
+#~ "Sarah Walker, leilei, JohnElliott, greatpsycho, ve diğerlerinin önceki katkılarıyla birlikte.\n"
+#~ "\n"
+#~ "GNU Genel Kamu Lisansı versiyon 2 veya sonrası altında yayınlanmıştır. Daha fazla bilgi için LICENSE kısmını gözden geçirin."
+
+#~ msgid "Make sure %1 is installed and that you are on a libpcap-compatible network connection."
+#~ msgstr "%1 kurulu olduğundan ve libpcap uyumlu bir internet ağı kullandığınızdan emin olun."
+
+#~ msgid ""
+#~ "%1 is required for automatic conversion of PostScript files to PDF.\n"
+#~ "\n"
+#~ "Any documents sent to the generic PostScript printer will be saved as PostScript (.ps) files."
+#~ msgstr ""
+#~ "%1 PostScript dosyalarının otomatik olarak PDF dosyasına çevirilmesi için gereklidir.\n"
+#~ "\n"
+#~ "Genel PostScript yazıcısına gönderilen tüm dökümanlar PostScript (.ps) dosyası olarak kaydedilecektir."
+
+#~ msgid ""
+#~ "%1 is required for automatic conversion of PCL files to PDF.\n"
+#~ "\n"
+#~ "Any documents sent to the generic PostScript printer will be saved as Printer Command Language (.pcl) files."
+#~ msgstr ""
+#~ "%1 PCL dosyalarının otomatik olarak PDF dosyasına çevirilmesi için gereklidir.\n"
+#~ "\n"
+#~ "Genel PostScript yazıcısına gönderilen tüm dökümanlar Printer Command Language (.pcl) dosyası olarak kaydedilecektir."
+
+#~ msgid ""
+#~ "CPU type filtering based on selected machine is disabled for this emulated machine.\n"
+#~ "\n"
+#~ "This makes it possible to choose a CPU that is otherwise incompatible with the selected machine. However, you may run into incompatibilities with the machine BIOS or other software.\n"
+#~ "\n"
+#~ "Enabling this setting is not officially supported and any bug reports filed may be closed as invalid."
+#~ msgstr ""
+#~ "Seçtiğiniz makineyle uygun işlemci filtresi bu yapılandırma için devre dışı bırakıldı.\n"
+#~ "\n"
+#~ "Bu durum seçili makine ile uyumsuz bir işlemci kullanmanızı mümkün kılmaktadır. Ancak bundan dolayı makinenin BIOS'unda veya çalıştırılan diğer yazılımlarda uyumsuzluk sorunları meydana gelebilir.\n"
+#~ "\n"
+#~ "İşlemci filtresinin devre dışı bırakılması resmi olarak desteklenmemektedir ve bu esnada açtığınız hata raporları geçersiz sayılabilir."
+
+#~ msgid ""
+#~ "This could mean that the parent image was modified after the differencing image was created.\n"
+#~ "\n"
+#~ "It can also happen if the image files were moved or copied, or by a bug in the program that created this disk.\n"
+#~ "\n"
+#~ "Do you want to fix the timestamps?"
+#~ msgstr ""
+#~ "Bu, farklandırmış imaj dosyası oluşturulduktan sonra ana imaj dosyasında bir değişiklik yapıldığı anlamına geliyor olabilir.\n"
+#~ "\n"
+#~ "Bu durum ayrıca imaj dosyalarının kopyalanmasından, yerlerinin değiştirilmesinden veya dosyaları oluşturan programdaki bir hatadan dolayı da meydana gelmiş olabilir.\n"
+#~ "\n"
+#~ "Zaman damgalarını düzeltmek ister misiniz?"
+
+#~ msgid ""
+#~ "Development of the WinBox manager stopped in 2022 due to a lack of maintainers. As we direct our efforts towards making 86Box even better, we have made the decision to no longer support WinBox as a manager.\n"
+#~ "\n"
+#~ "No further updates will be provided through WinBox, and you may encounter incorrect behavior should you continue using it with newer versions of 86Box. Any bug reports related to WinBox behavior will be closed as invalid.\n"
+#~ "\n"
+#~ "Go to 86box.net for a list of other managers you can use."
+#~ msgstr ""
+#~ "WinBox yöneticisinin geliştirilmesi geliştirici eksikliği nedeniyle 2022 yılında durduruldu. 86Box'ı daha iyi hale getirmeye odaklanmak amacıyla bu yöneticiyi artık desteklememe kararı aldık.\n"
+#~ "\n"
+#~ "Artık WinBox aracılığıyla güncellemeler yayınlanmayacaktır ve bu yöneticiyi 86Box'ın yeni sürümleriyle kullanmanız halinde hatalarla karşılaşabilirsiniz. WinBox'ın kullanımıyla ilgili tüm hata raporları geçersiz sayılacaktır.\n"
+#~ "\n"
+#~ "Kullanabileceğiniz diğer yöneticilerin bir listesi için lütfen 86box.net adresini ziyaret edin."
+
+#~ msgid ""
+#~ "In order to ensure proper networking functionality, 86Box needs to know if this machine was moved or copied.\n"
+#~ "\n"
+#~ "Select \"I Copied It\" if you are not sure."
+#~ msgstr ""
+#~ "Ağ bağlantısı özelliğinin doğru bir şekilde çalışması için 86Box'ın bu makinenin başka bir konuma taşındığını mı yoksa kopyalandığını mı belirlemesi gerekmektedir.\n"
+#~ "\n"
+#~ "Bundan emin değilseniz \"Kopyalandı\" seçeneğini seçin."
+
+#~ msgid "Generic ESC/P Dot-Matrix"
+#~ msgstr "Genel ESC/P Dot-Matrix"
+
+#~ msgid ""
+#~ "Could not compile shader:\n"
+#~ "\n"
+#~ "%1"
+#~ msgstr "%1 gölgelendiricisi derlenemedi"
+
+#~ msgid ""
+#~ "Program not linked:\n"
+#~ "\n"
+#~ "%1"
+#~ msgstr "%1 programı bağlanamadı"

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -147,6 +147,9 @@ msgstr "RGB &кольоровий"
 msgid "&RGB Grayscale"
 msgstr "&RGB монохромний"
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "&Бурштиновий відтінок"
 
@@ -384,6 +387,15 @@ msgstr "Увімкнути (UTC)"
 msgid "Dynamic Recompiler"
 msgstr "Динамічний рекомпілятор"
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr "Відеокарта:"
 
@@ -588,8 +600,8 @@ msgstr "Дисководи CD-ROM:"
 msgid "MO drives:"
 msgstr "Магнітооптичні дисководи:"
 
-msgid "ZIP drives:"
-msgstr "ZIP дисководи:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "ISA RTC:"
 
 msgid "ISA Memory Expansion"
 msgstr "Карта розширення пам'яті (ISA)"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "Карта 1:"
@@ -611,6 +626,27 @@ msgstr "Карта 3:"
 
 msgid "Card 4:"
 msgstr "Карта 4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "Пристрій ISABugger"
@@ -633,11 +669,14 @@ msgstr " - ПРИЗУПИНЕННЯ"
 msgid "Speed"
 msgstr "Швидкість"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "Образи ZIP"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "86Box не зміг знайти жодного відповідного для використання файлу з ПЗУ.\n\nБудь ласка <a href=\"https://github.com/86Box/roms/releases/latest\">завантажте</a> набір ПЗУ і витягніть його в каталог \"roms\"."
@@ -777,11 +816,38 @@ msgstr "4-осьовий, 4-кнопковий джойстик"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinder Pad"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Система управління польотом Thrustmaster"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "Ні"
@@ -849,8 +915,8 @@ msgstr "Емулятор старих комп'ютерів\n\nАвтори: Mir
 msgid "Hardware not available"
 msgstr "Обладнання недоступне"
 
-msgid "Make sure %1 is installed and that you are on a libpcap-compatible network connection."
-msgstr "Переконайтесь, що %1 встановлений і ваше мережеве з'єднання, сумісне з libpcap."
+msgid "Make sure %1 is installed and that you are on a %1-compatible network connection."
+msgstr ""
 
 msgid "Invalid configuration"
 msgstr "Неприпустима конфігурація"
@@ -1045,7 +1111,10 @@ msgid "Select the parent VHD"
 msgstr "Виберіть батьківський VHD"
 
 msgid "This could mean that the parent image was modified after the differencing image was created.\n\nIt can also happen if the image files were moved or copied, or by a bug in the program that created this disk.\n\nDo you want to fix the timestamps?"
-msgstr "Це може означати, що батьківський образ був змінений після того, як було створено диференційований образ.\n\nЦе також може статися, якщо файли зображення були переміщені або скопійовані, або через помилку в програмі, що створила цей диск.\n \nВи хочете виправити тимчасові позначки?"
+msgstr ""
+"Це може означати, що батьківський образ був змінений після того, як було створено диференційований образ.\n\nЦе також може статися, якщо файли зображення були переміщені або скопійовані, або через помилку в програмі, що створила цей диск.\n"
+" \n"
+"Ви хочете виправити тимчасові позначки?"
 
 msgid "Parent and child disk timestamps do not match"
 msgstr "Тимчасові мітки батьківського та дочірнього дисків не співпадають"
@@ -1377,8 +1446,14 @@ msgstr "Шинна миша Microsoft (InPort)"
 msgid "Mouse Systems Serial Mouse"
 msgstr "Послідовна миша Mouse Systems"
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
 msgstr "Послідовна миша Microsoft"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
 
 msgid "Logitech Serial Mouse"
 msgstr "Послідовна миша Logitech"
@@ -1388,6 +1463,9 @@ msgstr "Миша PS/2"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (послідовна)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] Стандартний модем, сумісний зі стандартом Hayes"
@@ -1413,11 +1491,53 @@ msgstr "MIDI системи"
 msgid "MIDI Input Device"
 msgstr "Пристрій введення MIDI"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "Адреса BIOS"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "Увімкнути розширення BIOS Записи в ПЗУ"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "Адреса"
@@ -1427,6 +1547,21 @@ msgstr "IRQ"
 
 msgid "BIOS Revision"
 msgstr "Ревізія BIOS"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "Перекладіть 26 -> 17"
@@ -1442,6 +1577,18 @@ msgstr "Інвертувати кольори"
 
 msgid "BIOS size"
 msgstr "Розмір BIOS"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "Зіставлення C0000-C7FFF як UMB"
@@ -1517,6 +1664,9 @@ msgstr "Рівень реверберації"
 
 msgid "Interpolation Method"
 msgstr "Метод інтерполяції"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "Посилення виходу реверберації"
@@ -1605,6 +1755,12 @@ msgstr "Низький рівень DMA"
 msgid "Enable Game port"
 msgstr "Увімкнути ігровий порт"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "Модуль об'ємного звучання"
 
@@ -1616,6 +1772,9 @@ msgstr "Піднімати переривання CODEC під час встан
 
 msgid "SB Address"
 msgstr "Адреса SB"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "IRQ WSS"
@@ -1701,6 +1860,9 @@ msgstr "Тип RAMDAC"
 msgid "Blend"
 msgstr "Суміш"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "Білінійна фільтрація"
 
@@ -1745,6 +1907,33 @@ msgstr "Швидкість передачі даних"
 
 msgid "EMS mode"
 msgstr "Режим EMS"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "Адреса для > 2 МБ"
@@ -1902,6 +2091,15 @@ msgstr "sRGB інтерполяція"
 msgid "Linear interpolation"
 msgstr "Лінійна інтерполяція"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 КБ"
 
@@ -1935,6 +2133,9 @@ msgstr "Бурштиновий"
 msgid "Gray"
 msgstr "Сірий"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "Кольоровий"
 
@@ -1949,6 +2150,12 @@ msgstr "Інші мови"
 
 msgid "Bochs latest"
 msgstr "Bochs останній"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "Монохромний неінтерлейсний"
@@ -2153,3 +2360,69 @@ msgstr ""
 
 msgid "Could not load file %1"
 msgstr ""
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "ZIP drives:"
+#~ msgstr "ZIP дисководи:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "Образи ZIP"
+
+#~ msgid "Make sure %1 is installed and that you are on a libpcap-compatible network connection."
+#~ msgstr "Переконайтесь, що %1 встановлений і ваше мережеве з'єднання, сумісне з libpcap."

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -147,6 +147,9 @@ msgstr "Màu R&GB"
 msgid "&RGB Grayscale"
 msgstr "Thang xám RG&B"
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "Màn hình vàng hổ phách (amber)"
 
@@ -384,6 +387,15 @@ msgstr "Bật (UTC)"
 msgid "Dynamic Recompiler"
 msgstr "Bộ tái biên dịch động (Dynamic Recompiler)"
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr "Video:"
 
@@ -588,8 +600,8 @@ msgstr "Ổ đĩa CD-ROM:"
 msgid "MO drives:"
 msgstr "Ổ đĩa MO:"
 
-msgid "ZIP drives:"
-msgstr "Ổ đĩa ZIP:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "ISA RTC:"
 
 msgid "ISA Memory Expansion"
 msgstr "Mở rộng bộ nhớ qua ISA"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "Thẻ 1:"
@@ -611,6 +626,27 @@ msgstr "Thẻ 3:"
 
 msgid "Card 4:"
 msgstr "Thẻ 4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "Thiết bị ISABugger"
@@ -633,11 +669,14 @@ msgstr " - TẠM DỪNG"
 msgid "Speed"
 msgstr "Vận tốc"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "Ảnh đĩa ZIP"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "86Box không tìm được bản ROM nào.\n\nVui lòng <a href=\"https://github.com/86Box/roms/releases/latest\">tải về</a> bộ ROM và trích xuất về thư mục \"roms\"."
@@ -777,11 +816,38 @@ msgstr "Cần điều khiển bốn trục, bốn nút"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinder Pad"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Thrustmaster Flight Control System"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "Không có"
@@ -1377,8 +1443,14 @@ msgstr "Chuột bus Microsoft (INPORT)"
 msgid "Mouse Systems Serial Mouse"
 msgstr "Chuột serial Mouse Systems"
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
 msgstr "Chuột serial Microsoft"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
 
 msgid "Logitech Serial Mouse"
 msgstr "Chuột serial Logitech"
@@ -1388,6 +1460,9 @@ msgstr "Chuột PS/2"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (Serial)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] Modem tuân thủ tiêu chuẩn Hayes"
@@ -1413,11 +1488,53 @@ msgstr "MIDI của hệ thống"
 msgid "MIDI Input Device"
 msgstr "Thiết bị nhập MIDI"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "Địa chỉ BIOS"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "Kích hoạt ghi ROM mở rộng BIOS"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "Địa chỉ"
@@ -1427,6 +1544,21 @@ msgstr "IRQ"
 
 msgid "BIOS Revision"
 msgstr "Sửa đổi BIOS"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "Dịch 26 -> 17"
@@ -1442,6 +1574,18 @@ msgstr "Đảo ngược màu sắc"
 
 msgid "BIOS size"
 msgstr "Kích thước BIOS"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "Map C0000-C7FFF dưới dạng UMB"
@@ -1517,6 +1661,9 @@ msgstr "Mức độ hồi âm"
 
 msgid "Interpolation Method"
 msgstr "Phương pháp nội suy"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "Tăng đầu ra hồi âm"
@@ -1605,6 +1752,12 @@ msgstr "DMA thấp"
 msgid "Enable Game port"
 msgstr "Bật cổng trò chơi"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "Mô đun vòm"
 
@@ -1616,6 +1769,9 @@ msgstr "Tăng ngắt CODEC trên thiết lập CODEC (cần bởi một số tr�
 
 msgid "SB Address"
 msgstr "Địa chỉ SB"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "WSS IRQ"
@@ -1701,6 +1857,9 @@ msgstr "Loại RAMDAC"
 msgid "Blend"
 msgstr "Trộn"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "Lọc song tuyến"
 
@@ -1745,6 +1904,33 @@ msgstr "Tốc độ truyền tải"
 
 msgid "EMS mode"
 msgstr "Chế độ EMS"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "Địa chỉ cho > 2 MB"
@@ -1902,6 +2088,15 @@ msgstr "Nội suy SRGB"
 msgid "Linear interpolation"
 msgstr "Nội suy tuyến tính"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 KB"
 
@@ -1935,6 +2130,9 @@ msgstr "Màu hổ phách"
 msgid "Gray"
 msgstr "Màu xám"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "Màu sắc"
 
@@ -1949,6 +2147,12 @@ msgstr "Các ngôn ngữ khác"
 
 msgid "Bochs latest"
 msgstr "Bochs mới nhất"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "Đơn sắc không xen kẽ"
@@ -2076,6 +2280,12 @@ msgstr "IBM 8514/A bản nhái (ISA)"
 msgid "Vendor"
 msgstr "Nhà sản xuất"
 
+msgid "30 Hz (JMP2 = 1)"
+msgstr ""
+
+msgid "60 Hz (JMP2 = 2)"
+msgstr ""
+
 msgid "Generic PC/XT Memory Expansion"
 msgstr "Chung mở rộng bộ nhớ qua PC/XT"
 
@@ -2147,3 +2357,66 @@ msgstr ""
 
 msgid "Could not load file %1"
 msgstr ""
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "ZIP drives:"
+#~ msgstr "Ổ đĩa ZIP:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "Ảnh đĩa ZIP"

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -147,6 +147,9 @@ msgstr "RGB 彩色(&C)"
 msgid "&RGB Grayscale"
 msgstr "RGB 灰度(&R)"
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "琥珀色单色显示器(&A)"
 
@@ -384,6 +387,15 @@ msgstr "启用 (UTC)"
 msgid "Dynamic Recompiler"
 msgstr "动态重编译器"
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr "显卡:"
 
@@ -588,8 +600,8 @@ msgstr "光盘驱动器:"
 msgid "MO drives:"
 msgstr "磁光盘驱动器:"
 
-msgid "ZIP drives:"
-msgstr "ZIP 驱动器:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "ISA 实时时钟:"
 
 msgid "ISA Memory Expansion"
 msgstr "ISA 内存扩展"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "扩展卡 1:"
@@ -611,6 +626,27 @@ msgstr "扩展卡 3:"
 
 msgid "Card 4:"
 msgstr "扩展卡 4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "ISABugger 设备"
@@ -633,11 +669,14 @@ msgstr " - 已暂停"
 msgid "Speed"
 msgstr "速度"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "ZIP 映像"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "86Box 找不到任何可用的 ROM 映像。\n\n请<a href=\"https://github.com/86Box/roms/releases/latest\">下载</a> ROM 包并将其解压到 \"roms\" 文件夹中。"
@@ -777,11 +816,38 @@ msgstr "4 轴, 4 键操纵杆"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinder Pad"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Thrustmaster Flight Control System"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "无"
@@ -1377,8 +1443,14 @@ msgstr "Microsoft 总线鼠标（InPort）"
 msgid "Mouse Systems Serial Mouse"
 msgstr "Mouse Systems 串行鼠标"
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
 msgstr "Microsoft 串行鼠标"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
 
 msgid "Logitech Serial Mouse"
 msgstr "Logitech 串行鼠标"
@@ -1388,6 +1460,9 @@ msgstr "PS/2 鼠标"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (串行)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] 标准 Hayes 兼容调制解调器"
@@ -1413,11 +1488,53 @@ msgstr "系统 MIDI"
 msgid "MIDI Input Device"
 msgstr "MIDI 输入设备"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "BIOS 地址"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "启用 BIOS 扩展 ROM 写入功能"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "地址"
@@ -1427,6 +1544,21 @@ msgstr "IRQ"
 
 msgid "BIOS Revision"
 msgstr "BIOS 修订版"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "翻译 26 -> 17"
@@ -1442,6 +1574,18 @@ msgstr "反转颜色"
 
 msgid "BIOS size"
 msgstr "BIOS 大小"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "将 C0000-C7FFF 映射为 UMB"
@@ -1517,6 +1661,9 @@ msgstr "混响电平"
 
 msgid "Interpolation Method"
 msgstr "插值法"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "混响输出的增益"
@@ -1605,6 +1752,12 @@ msgstr "低 DMA"
 msgid "Enable Game port"
 msgstr "启用游戏端口"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "环绕声模块"
 
@@ -1616,6 +1769,9 @@ msgstr "在 CODEC 设置时引发 CODEC 中断（某些驱动程序需要）。"
 
 msgid "SB Address"
 msgstr "SB 地址"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "WSS IRQ"
@@ -1701,6 +1857,9 @@ msgstr "RAMDAC 类型"
 msgid "Blend"
 msgstr "混合"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "双线性滤波"
 
@@ -1745,6 +1904,33 @@ msgstr "传输速度"
 
 msgid "EMS mode"
 msgstr "EMS (扩展内存)模式"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "地址 > 2 MB"
@@ -1902,6 +2088,15 @@ msgstr "sRGB 插值"
 msgid "Linear interpolation"
 msgstr "线性插值"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 KB"
 
@@ -1935,6 +2130,9 @@ msgstr "琥珀色"
 msgid "Gray"
 msgstr "灰色"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "彩色"
 
@@ -1949,6 +2147,12 @@ msgstr "其他语言"
 
 msgid "Bochs latest"
 msgstr "Bochs 最新版本"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "单色非隔行扫描"
@@ -2153,3 +2357,66 @@ msgstr "下移"
 
 msgid "Could not load file %1"
 msgstr "无法加载文件 %1"
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "ZIP drives:"
+#~ msgstr "ZIP 驱动器:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "ZIP 映像"

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -147,6 +147,9 @@ msgstr "RGB 彩色(&C)"
 msgid "&RGB Grayscale"
 msgstr "RGB 灰度(&R)"
 
+msgid "Generic RGBI color monitor"
+msgstr ""
+
 msgid "&Amber monitor"
 msgstr "琥珀色單色顯示器(&A)"
 
@@ -384,6 +387,15 @@ msgstr "啟用 (UTC)"
 msgid "Dynamic Recompiler"
 msgstr "動態重編譯器"
 
+msgid "CPU frame size"
+msgstr ""
+
+msgid "Larger frames (less smooth)"
+msgstr ""
+
+msgid "Smaller frames (smoother)"
+msgstr ""
+
 msgid "Video:"
 msgstr "顯示卡:"
 
@@ -588,8 +600,8 @@ msgstr "光碟機:"
 msgid "MO drives:"
 msgstr "磁光碟機:"
 
-msgid "ZIP drives:"
-msgstr "ZIP 磁碟機:"
+msgid "Removable disk drives:"
+msgstr ""
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -599,6 +611,9 @@ msgstr "ISA 實時時鐘:"
 
 msgid "ISA Memory Expansion"
 msgstr "ISA 記憶體擴充"
+
+msgid "ISA ROM Cards"
+msgstr ""
 
 msgid "Card 1:"
 msgstr "擴充卡 1:"
@@ -611,6 +626,27 @@ msgstr "擴充卡 3:"
 
 msgid "Card 4:"
 msgstr "擴充卡 4:"
+
+msgid "Board 1"
+msgstr ""
+
+msgid "Board 2"
+msgstr ""
+
+msgid "Board 3"
+msgstr ""
+
+msgid "Board 4"
+msgstr ""
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
 
 msgid "ISABugger device"
 msgstr "ISABugger 裝置"
@@ -633,11 +669,14 @@ msgstr " - 已暫停"
 msgid "Speed"
 msgstr "速度"
 
-msgid "ZIP %1 %2 (%3): %4"
-msgstr "ZIP %1 %2 (%3): %4"
+msgid "Removable disk %1 (%2): %3"
+msgstr ""
 
-msgid "ZIP images"
-msgstr "ZIP 映像"
+msgid "Removable disk images"
+msgstr ""
+
+msgid "Image %1"
+msgstr ""
 
 msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
 msgstr "86Box 找不到任何可用的 ROM 映像。\n\n請<a href=\"https://github.com/86Box/roms/releases/latest\">下載</a> ROM 套件並將其解壓到 \"roms\" 資料夾。"
@@ -777,11 +816,38 @@ msgstr "4 軸, 4 鍵搖桿"
 msgid "CH Flightstick Pro"
 msgstr "CH Flightstick Pro"
 
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
 msgid "Microsoft SideWinder Pad"
 msgstr "Microsoft SideWinder Pad"
 
 msgid "Thrustmaster Flight Control System"
 msgstr "Thrustmaster Flight Control System"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr ""
+
+msgid "2-button flight yoke"
+msgstr ""
+
+msgid "4-button gamepad"
+msgstr ""
+
+msgid "4-button flight yoke"
+msgstr ""
+
+msgid "2-button flight yoke with throttle"
+msgstr ""
+
+msgid "4-button flight yoke with throttle"
+msgstr ""
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr ""
 
 msgid "None"
 msgstr "無"
@@ -849,8 +915,8 @@ msgstr "一個舊式電腦模擬器\n\n作者: Miran Grča (OBattler)、RichardG
 msgid "Hardware not available"
 msgstr "硬體不可用"
 
-msgid "Make sure %1 is installed and that you are on a libpcap-compatible network connection."
-msgstr "請確認 %1 已安裝且使用相容 libpcap 的網路連線。"
+msgid "Make sure %1 is installed and that you are on a %1-compatible network connection."
+msgstr ""
 
 msgid "Invalid configuration"
 msgstr "無效設定"
@@ -1377,8 +1443,14 @@ msgstr "Microsoft 匯流排滑鼠 (InPort)"
 msgid "Mouse Systems Serial Mouse"
 msgstr "Mouse Systems 序列滑鼠"
 
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
 msgid "Microsoft Serial Mouse"
 msgstr "Microsoft 序列滑鼠"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
 
 msgid "Logitech Serial Mouse"
 msgstr "Logitech 序列滑鼠"
@@ -1388,6 +1460,9 @@ msgstr "PS/2 滑鼠"
 
 msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (序列)"
+
+msgid "Default Baud rate"
+msgstr ""
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] 標準 Hayes 相容的數據機"
@@ -1413,11 +1488,53 @@ msgstr "系統的 MIDI"
 msgid "MIDI Input Device"
 msgstr "MIDI 輸入裝置"
 
+msgid "BIOS file"
+msgstr ""
+
+msgid "BIOS file (ROM #1)"
+msgstr ""
+
+msgid "BIOS file (ROM #2)"
+msgstr ""
+
+msgid "BIOS file (ROM #3)"
+msgstr ""
+
+msgid "BIOS file (ROM #4)"
+msgstr ""
+
 msgid "BIOS Address"
 msgstr "BIOS 位址"
 
+msgid "BIOS address (ROM #1)"
+msgstr ""
+
+msgid "BIOS address (ROM #2)"
+msgstr ""
+
+msgid "BIOS address (ROM #3)"
+msgstr ""
+
+msgid "BIOS address (ROM #4)"
+msgstr ""
+
 msgid "Enable BIOS extension ROM Writes"
 msgstr "啟用 BIOS 擴充 ROM 寫入"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr ""
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr ""
+
+msgid "Linear framebuffer base"
+msgstr ""
 
 msgid "Address"
 msgstr "位址"
@@ -1427,6 +1544,21 @@ msgstr "IRQ"
 
 msgid "BIOS Revision"
 msgstr "BIOS 版本"
+
+msgid "BIOS Version"
+msgstr ""
+
+msgid "BIOS Versions"
+msgstr ""
+
+msgid "BIOS Language"
+msgstr ""
+
+msgid "IBM 5161 Expansion Unit"
+msgstr ""
+
+msgid "IBM Cassette Basic"
+msgstr ""
 
 msgid "Translate 26 -> 17"
 msgstr "轉換 26 -> 17"
@@ -1442,6 +1574,18 @@ msgstr "反轉顏色"
 
 msgid "BIOS size"
 msgstr "BIOS 大小"
+
+msgid "BIOS size (ROM #1)"
+msgstr ""
+
+msgid "BIOS size (ROM #2)"
+msgstr ""
+
+msgid "BIOS size (ROM #3)"
+msgstr ""
+
+msgid "BIOS size (ROM #4)"
+msgstr ""
 
 msgid "Map C0000-C7FFF as UMB"
 msgstr "映射 C0000-C7FFF 為 UMB"
@@ -1517,6 +1661,9 @@ msgstr "混響電平"
 
 msgid "Interpolation Method"
 msgstr "插值方法"
+
+msgid "Dynamic Sample Loading"
+msgstr ""
 
 msgid "Reverb Output Gain"
 msgstr "迴響輸出增益"
@@ -1605,6 +1752,12 @@ msgstr "低 DMA"
 msgid "Enable Game port"
 msgstr "啟用遊戲埠"
 
+msgid "SID Model"
+msgstr ""
+
+msgid "SID Filter Strength"
+msgstr ""
+
 msgid "Surround module"
 msgstr "環繞聲模組"
 
@@ -1616,6 +1769,9 @@ msgstr "在 CODEC 設定時啟動 CODEC 中斷 (某些驅動程式需要)"
 
 msgid "SB Address"
 msgstr "SB 位址"
+
+msgid "Use EEPROM setting"
+msgstr ""
 
 msgid "WSS IRQ"
 msgstr "WSS IRQ"
@@ -1701,6 +1857,9 @@ msgstr "RAMDAC 類型"
 msgid "Blend"
 msgstr "混合"
 
+msgid "Font"
+msgstr ""
+
 msgid "Bilinear filtering"
 msgstr "雙線性濾波"
 
@@ -1745,6 +1904,33 @@ msgstr "傳輸速度"
 
 msgid "EMS mode"
 msgstr "EMS 模式"
+
+msgid "EMS Address"
+msgstr ""
+
+msgid "EMS 1 Address"
+msgstr ""
+
+msgid "EMS 2 Address"
+msgstr ""
+
+msgid "EMS Memory Size"
+msgstr ""
+
+msgid "EMS 1 Memory Size"
+msgstr ""
+
+msgid "EMS 2 Memory Size"
+msgstr ""
+
+msgid "Enable EMS"
+msgstr ""
+
+msgid "Enable EMS 1"
+msgstr ""
+
+msgid "Enable EMS 2"
+msgstr ""
 
 msgid "Address for > 2 MB"
 msgstr "> 2 MB 的位址"
@@ -1902,6 +2088,15 @@ msgstr "sRGB 插值"
 msgid "Linear interpolation"
 msgstr "線性插補"
 
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr ""
+
 msgid "128 KB"
 msgstr "128 KB"
 
@@ -1935,6 +2130,9 @@ msgstr "琥珀色"
 msgid "Gray"
 msgstr "灰色"
 
+msgid "Grayscale"
+msgstr ""
+
 msgid "Color"
 msgstr "顏色"
 
@@ -1949,6 +2147,12 @@ msgstr "其他語言"
 
 msgid "Bochs latest"
 msgstr "Bochs 最新"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr ""
 
 msgid "Mono Non-Interlaced"
 msgstr "單色非隔行掃描"
@@ -2076,6 +2280,12 @@ msgstr "IBM 8514/A 克隆 (ISA)"
 msgid "Vendor"
 msgstr "製造商"
 
+msgid "30 Hz (JMP2 = 1)"
+msgstr ""
+
+msgid "60 Hz (JMP2 = 2)"
+msgstr ""
+
 msgid "Generic PC/XT Memory Expansion"
 msgstr "通用 PC/XT 記憶體擴充"
 
@@ -2147,3 +2357,69 @@ msgstr ""
 
 msgid "Could not load file %1"
 msgstr ""
+
+msgid "Key Bindings:"
+msgstr ""
+
+msgid "Action"
+msgstr ""
+
+msgid "Keybind"
+msgstr ""
+
+msgid "Clear binding"
+msgstr ""
+
+msgid "Bind"
+msgstr ""
+
+msgid "Bind Key"
+msgstr ""
+
+msgid "Enter key combo:"
+msgstr ""
+
+msgid "Send Control+Alt+Del"
+msgstr ""
+
+msgid "Send Control+Alt+Escape"
+msgstr ""
+
+msgid "Toggle fullscreen"
+msgstr ""
+
+msgid "Screenshot"
+msgstr ""
+
+msgid "Release mouse pointer"
+msgstr ""
+
+msgid "Toggle pause"
+msgstr ""
+
+msgid "Toggle mute"
+msgstr ""
+
+msgid "Text files"
+msgstr ""
+
+msgid "ROM files (*.bin *.rom)|*.bin,*.rom"
+msgstr ""
+
+msgid "ROM files"
+msgstr ""
+
+msgid "SoundFont files"
+msgstr ""
+
+#~ msgid "ZIP drives:"
+#~ msgstr "ZIP 磁碟機:"
+
+#~ msgid "ZIP %1 %2 (%3): %4"
+#~ msgstr "ZIP %1 %2 (%3): %4"
+
+#~ msgid "ZIP images"
+#~ msgstr "ZIP 映像"
+
+#~ msgid "Make sure %1 is installed and that you are on a libpcap-compatible network connection."
+#~ msgstr "請確認 %1 已安裝且使用相容 libpcap 的網路連線。"


### PR DESCRIPTION
Summary
=======
This PR adds msgids for the following itens in the 86Box POT template and merges it with the PO files so translators can add their translations to the missing itens.

Addes msgids:
- IBM PCs, XTs, VTech Laser XT machines settings
- Quadram QuadColor video card settings
- Innovation SSI-2001 settings
- ISA ROM Cards names and settings
- Mouse and Joystick names and settings
- Key bindings settings dialog
- CPU frame size option

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
