### PR TITLE
Attempt to fix cdrom image loading crash #5829 by replacing segfaulting dev->ops->get_last_block with image_get_last_block

### DIFF
--- a/src/cdrom/cdrom_image.c
+++ b/src/cdrom/cdrom_image.c
@@ -2655,7 +2655,7 @@ image_open(cdrom_t *dev, const char *path)
 
         if (ret > 0) {
             if (img->is_dvd == 2) {
-                uint32_t lb = dev->ops->get_last_block(img);
+                uint32_t lb = image_get_last_block(img); /* Should be safer than previous way of doing it? */
                 img->is_dvd = (lb >= 524287);    /* Minimum 1 GB total capacity as threshold for DVD. */
             }
 


### PR DESCRIPTION
Summary
=======
This is a fix for #5829 by replacing dev->ops->get_last_block (which was segfaulting for an unknown reason) with image_get_last_block, existing code that should afaik do the same thing.

It is confirmed to fix the crash. I have not done further testing re: any effects on DVD vs CD detection.

Checklist
=========
* [x] Closes #5829
* [x] I have discussed this with core contributors already ~~(Nobody seems to be awake atm and this seems critical, so I PRed without discussing beyond what's on the discord already)~~
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
No datasheets or documentation necessary. All discussion regarding the segfault, faulting line, and reasoning for my fix is on the discord.
