### PR TITLE
MKE: Fix channel not being saved

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3167,7 +3167,6 @@ save_floppy_and_cdrom_drives(void)
             ini_section_delete_var(cat, temp);
         else {
             ini_section_set_int(cat, temp, cdrom[c].mke_channel);
-            ini_section_set_string(cat, temp, tmp2);
         }
 
         sprintf(temp, "cdrom_%02i_ide_channel", c + 1);


### PR DESCRIPTION
Summary
=======
Fix MKE channel not being saved due to being overwritten by parameters

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
N/A