### PR TITLE
Update the Biostar M5ATA BIOS to the latest version

### DIFF
--- a/src/machine/m_at_socket7.c
+++ b/src/machine/m_at_socket7.c
@@ -1555,7 +1555,7 @@ machine_at_m5ata_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear("roms/machines/m5ata/ATA1223.BIN",
+    ret = bios_load_linear("roms/machines/m5ata/ATA0527B.BIN",
                            0x000e0000, 131072, 0);
 
     if (bios_only || !ret)


### PR DESCRIPTION
This version adds proper support for AMD K6-2 CPUs

Summary
=======
Update the BIOS of the Biostar M5ATA to the latest revision, which adds proper support of AMD K6-2 CPUs.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [X] This pull request requires changes to the ROM set
  * [X] I have opened a roms pull request - https://github.com/86Box/roms/pull/356

References
==========
https://theretroweb.com/motherboards/s/biostar-m5ata#bios