### PR TITLE
MKE: More UI fixes

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1396,7 +1396,7 @@ load_floppy_and_cdrom_drives(void)
                 cdrom_set_type(c, cdrom_get_from_internal_name("cr563_075"));
 
             sprintf(temp, "cdrom_%02i_mke_channel", c + 1);
-            cdrom[c].mke_channel = !!ini_section_get_int(cat, temp, c & 3);
+            cdrom[c].mke_channel = ini_section_get_int(cat, temp, c & 3);
 
             if (cdrom[c].mke_channel > 3)
                 cdrom[c].mke_channel = 3;

--- a/src/qt/qt_settingsfloppycdrom.cpp
+++ b/src/qt/qt_settingsfloppycdrom.cpp
@@ -414,6 +414,20 @@ SettingsFloppyCDROM::on_comboBoxBus_activated(int)
     setCDROMType(ui->tableViewCDROM->model(),
                  ui->tableViewCDROM->selectionModel()->currentIndex(),
                  ui->comboBoxCDROMType->currentData().toUInt());
+
+    int speed = cdrom_get_speed(ui->comboBoxCDROMType->currentData().toUInt());
+    if ((speed == -1) && (bus_type != CDROM_BUS_MITSUMI)) {
+        speed = ui->comboBoxSpeed->currentData().toUInt();
+        ui->comboBoxSpeed->setEnabled(bus_type != CDROM_BUS_DISABLED);
+    } else {
+        ui->comboBoxSpeed->setEnabled(false);
+        if (bus_type == CDROM_BUS_MITSUMI) // temp hack
+            speed = 0; 
+    }
+    ui->comboBoxSpeed->setCurrentIndex(speed == 0 ? 7 : speed - 1);
+    setCDROMSpeed(ui->tableViewCDROM->model(),
+                  ui->tableViewCDROM->selectionModel()->currentIndex(),
+                  speed);
     emit cdromChannelChanged();
 }
 

--- a/src/qt/qt_settingsfloppycdrom.cpp
+++ b/src/qt/qt_settingsfloppycdrom.cpp
@@ -277,7 +277,7 @@ SettingsFloppyCDROM::onCDROMRowChanged(const QModelIndex &current)
     int     speed   = cdrom_get_speed(type);
     if (speed == -1) {
         speed   = current.siblingAtColumn(1).data(Qt::UserRole).toUInt();
-        ui->comboBoxSpeed->setEnabled(true);
+        ui->comboBoxSpeed->setEnabled((bus == CDROM_BUS_DISABLED) ? false : true);
     } else
         ui->comboBoxSpeed->setEnabled(false);
     ui->comboBoxSpeed->setCurrentIndex(speed == 0 ? 7 : speed - 1);


### PR DESCRIPTION
Summary
=======
- Fix channels 2 and 3 not being usable;
- Disable the CD-ROM speed dropdown when the bus is set to "Disabled";
- Explicitly set CD-ROM speed on a bus change, preventing speed on Panasonic/MKE bus drives being wrongly considered variable.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A
