### PR TITLE
Assorted UI fixes

### DIFF
--- a/src/printer/prt_escp.c
+++ b/src/printer/prt_escp.c
@@ -2097,7 +2097,7 @@ escp_close(void *priv)
 }
 
 const lpt_device_t lpt_prt_escp_device = {
-    .name             = "Generic ESC/P Dot-Matrix",
+    .name             = "Generic ESC/P Dot-Matrix Printer",
     .internal_name    = "dot_matrix",
     .init             = escp_init,
     .close            = escp_close,

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -2245,7 +2245,7 @@ msgid "Generic Text Printer"
 msgstr "Genel Metin Yazıcı"
 
 msgid "Generic ESC/P Dot-Matrix Printer"
-msgstr "Genel ESC/P Dot-Matrix"
+msgstr "Genel ESC/P Dot-Matrix Yazıcı"
 
 msgid "Generic PostScript Printer"
 msgstr "Genel PostScript Yazıcı"

--- a/src/qt/qt_deviceconfig.cpp
+++ b/src/qt/qt_deviceconfig.cpp
@@ -282,20 +282,30 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                 fileField->setObjectName(config->name);
                 fileField->setFileName(selected);
                 /* Get the actually used part of the filter */
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
                 QString filter = QString(config->file_filter).left(static_cast<int>(strcspn(config->file_filter, "|")));
+#else
+                QString filter = QString(config->file_filter).split("|").at(0);
+#endif
                 /* Extract the description and the extension list */
                 QRegularExpressionMatch match = QRegularExpression("(.+) \\((.+)\\)$").match(filter);
                 QString description = match.captured(1);
                 QString extensions = match.captured(2);
-                QStringList extensionList;
                 /* Split the extension list up and strip the filename globs */
                 QRegularExpression re("\\*\\.(.*)");
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+                QStringList extensionList;
                 int i = 0;
                 while (extensions.section(' ', i, i) != "") {
                     QString extension = re.match(extensions.section(' ', i, i)).captured(1);
                     extensionList.append(extension);
                     i++;
                 }
+#else
+                QStringList extensionList = extensions.split(" ");
+                for (int i = 0; i < extensionList.count(); i++)
+                    extensionList[i] = re.match(extensionList[i]).captured(1);
+#endif
                 fileField->setFilter(tr(description.toUtf8().constData()) % util::DlgFilter(extensionList) % tr("All files") % util::DlgFilter({ "*" }, true));
                 this->ui->formLayout->addRow(tr(config->description), fileField);
                 break;

--- a/src/qt/qt_harddiskdialog.ui
+++ b/src/qt/qt_harddiskdialog.ui
@@ -32,87 +32,24 @@
    <string>Dialog</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="9" column="0" colspan="6">
-    <widget class="QProgressBar" name="progressBar">
-     <property name="visible">
-      <bool>false</bool>
-     </property>
-     <property name="value">
-      <number>0</number>
-     </property>
-     <property name="textVisible">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="4">
-    <widget class="QLabel" name="label_5">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
      <property name="text">
-      <string>Sectors:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="labelFormat">
-     <property name="text">
-      <string>Image Format:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1" colspan="3">
-    <widget class="QComboBox" name="comboBoxBus">
-     <property name="maxVisibleItems">
-      <number>30</number>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_8">
-     <property name="text">
-      <string>Bus:</string>
+      <string>File name:</string>
      </property>
     </widget>
    </item>
    <item row="0" column="1" colspan="5">
     <widget class="FileField" name="fileField" native="true"/>
    </item>
-   <item row="4" column="2">
-    <widget class="QLabel" name="label_6">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>Type:</string>
+      <string>Cylinders:</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="5">
-    <widget class="QLineEdit" name="lineEditSectors">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>64</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="maxLength">
-      <number>32767</number>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="0" colspan="6">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
+   <item row="1" column="1">
     <widget class="QLineEdit" name="lineEditCylinders">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -128,58 +65,14 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="2">
+   <item row="1" column="2">
     <widget class="QLabel" name="label_4">
      <property name="text">
       <string>Heads:</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <widget class="QLineEdit" name="lineEditSize">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>64</width>
-       <height>16777215</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="5">
-    <widget class="QComboBox" name="comboBoxChannel">
-     <property name="maxVisibleItems">
-      <number>30</number>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Cylinders:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>File name:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Size (MB):</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="3">
+   <item row="1" column="3">
     <widget class="QLineEdit" name="lineEditHeads">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -198,28 +91,153 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="4">
-    <widget class="QLabel" name="label_7">
+   <item row="1" column="4">
+    <widget class="QLabel" name="label_5">
      <property name="text">
-      <string>Channel:</string>
+      <string>Sectors:</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="3" colspan="3">
+   <item row="1" column="5">
+    <widget class="QLineEdit" name="lineEditSectors">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>64</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="maxLength">
+      <number>32767</number>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Size (MB):</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="lineEditSize">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>64</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Type:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="3" colspan="3">
     <widget class="QComboBox" name="comboBoxType">
      <property name="maxVisibleItems">
       <number>30</number>
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_8">
+     <property name="text">
+      <string>Bus:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="3">
+    <widget class="QComboBox" name="comboBoxBus">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="4">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Channel:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="5">
+    <widget class="QComboBox" name="comboBoxChannel">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="text">
+      <string>Model:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="5">
+    <widget class="QComboBox" name="comboBoxSpeed">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="labelFormat">
+     <property name="text">
+      <string>Image Format:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1" colspan="5">
+    <widget class="QComboBox" name="comboBoxFormat">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
     <widget class="QLabel" name="labelBlockSize">
      <property name="text">
       <string>Block Size:</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="0" colspan="6">
+   <item row="6" column="1" colspan="5">
+    <widget class="QComboBox" name="comboBoxBlockSize">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="6">
+    <widget class="QProgressBar" name="progressBar">
+     <property name="visible">
+      <bool>false</bool>
+     </property>
+     <property name="value">
+      <number>0</number>
+     </property>
+     <property name="textVisible">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="6">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -232,31 +250,13 @@
      </property>
     </spacer>
    </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_9">
-     <property name="text">
-      <string>Model:</string>
+   <item row="9" column="0" colspan="6">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-    </widget>
-   </item>
-   <item row="6" column="1" colspan="5">
-    <widget class="QComboBox" name="comboBoxSpeed">
-     <property name="maxVisibleItems">
-      <number>30</number>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1" colspan="5">
-    <widget class="QComboBox" name="comboBoxFormat">
-     <property name="maxVisibleItems">
-      <number>30</number>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1" colspan="5">
-    <widget class="QComboBox" name="comboBoxBlockSize">
-     <property name="maxVisibleItems">
-      <number>30</number>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
@@ -270,17 +270,6 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
- <tabstops>
-  <tabstop>lineEditCylinders</tabstop>
-  <tabstop>lineEditHeads</tabstop>
-  <tabstop>lineEditSectors</tabstop>
-  <tabstop>lineEditSize</tabstop>
-  <tabstop>comboBoxType</tabstop>
-  <tabstop>comboBoxBus</tabstop>
-  <tabstop>comboBoxChannel</tabstop>
-  <tabstop>comboBoxFormat</tabstop>
-  <tabstop>comboBoxBlockSize</tabstop>
- </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/qt/qt_keybind.ui
+++ b/src/qt/qt_keybind.ui
@@ -22,7 +22,7 @@
         <string>Enter key combo:</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignmentFlag::AlignCenter</set>
+        <set>Qt::AlignCenter</set>
        </property>
       </widget>
      </item>
@@ -31,17 +31,17 @@
    <item>
     <widget class="Line" name="line">
      <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
+      <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
+      <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -304,8 +304,6 @@ MainWindow::MainWindow(QWidget *parent)
             }
         }
 #endif
-        ui->actionPause->setChecked(false);
-        ui->actionPause->setCheckable(false);
     });
     connect(this, &MainWindow::getTitleForNonQtThread, this, &MainWindow::getTitle_, Qt::BlockingQueuedConnection);
 

--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -341,9 +341,6 @@
    </property>
   </action>
   <action name="actionPause">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
    <property name="icon">
     <iconset resource="../qt_resources.qrc">
      <normaloff>:/menuicons/qt/icons/pause.ico</normaloff>:/menuicons/qt/icons/pause.ico</iconset>

--- a/src/qt/qt_openglshaderconfig.ui
+++ b/src/qt/qt_openglshaderconfig.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="sizeConstraint">
-    <enum>QLayout::SizeConstraint::SetMinAndMaxSize</enum>
+    <enum>QLayout::SetMinAndMaxSize</enum>
    </property>
    <item>
     <widget class="QScrollArea" name="scrollArea">
@@ -33,10 +33,10 @@
       </property>
       <layout class="QFormLayout" name="formLayout_2">
        <property name="sizeConstraint">
-        <enum>QLayout::SizeConstraint::SetMaximumSize</enum>
+        <enum>QLayout::SetMaximumSize</enum>
        </property>
        <property name="fieldGrowthPolicy">
-        <enum>QFormLayout::FieldGrowthPolicy::AllNonFixedFieldsGrow</enum>
+        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
        </property>
       </layout>
      </widget>
@@ -45,10 +45,10 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
+      <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok|QDialogButtonBox::StandardButton::Reset</set>
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::Reset</set>
      </property>
     </widget>
    </item>

--- a/src/qt/qt_openglshadermanagerdialog.ui
+++ b/src/qt/qt_openglshadermanagerdialog.ui
@@ -17,6 +17,80 @@
    <property name="sizeConstraint">
     <enum>QLayout::SetFixedSize</enum>
    </property>
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Render behavior</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetDefaultConstraint</enum>
+      </property>
+      <item row="0" column="0">
+       <widget class="QRadioButton" name="radioButtonVideoSync">
+        <property name="text">
+         <string>Synchronize with video</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QRadioButton" name="radioButtonTargetFramerate">
+        <property name="text">
+         <string>Use target framerate:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QSlider" name="horizontalSliderFramerate">
+        <property name="minimum">
+         <number>15</number>
+        </property>
+        <property name="maximum">
+         <number>240</number>
+        </property>
+        <property name="value">
+         <number>60</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="invertedAppearance">
+         <bool>false</bool>
+        </property>
+        <property name="invertedControls">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QSpinBox" name="targetFrameRate">
+        <property name="suffix">
+         <string> fps</string>
+        </property>
+        <property name="minimum">
+         <number>15</number>
+        </property>
+        <property name="maximum">
+         <number>240</number>
+        </property>
+        <property name="value">
+         <number>60</number>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="checkBoxVSync">
+        <property name="text">
+         <string>VSync</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item row="1" column="0">
     <widget class="QGroupBox" name="groupBoxShaders">
      <property name="title">
@@ -119,80 +193,6 @@
          </widget>
         </item>
        </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Render behavior</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <property name="sizeConstraint">
-       <enum>QLayout::SetDefaultConstraint</enum>
-      </property>
-      <item row="1" column="0">
-       <widget class="QRadioButton" name="radioButtonTargetFramerate">
-        <property name="text">
-         <string>Use target framerate:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QSlider" name="horizontalSliderFramerate">
-        <property name="minimum">
-         <number>15</number>
-        </property>
-        <property name="maximum">
-         <number>240</number>
-        </property>
-        <property name="value">
-         <number>60</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="invertedAppearance">
-         <bool>false</bool>
-        </property>
-        <property name="invertedControls">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QRadioButton" name="radioButtonVideoSync">
-        <property name="text">
-         <string>Synchronize with video</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QCheckBox" name="checkBoxVSync">
-        <property name="text">
-         <string>VSync</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QSpinBox" name="targetFrameRate">
-        <property name="suffix">
-         <string> fps</string>
-        </property>
-        <property name="minimum">
-         <number>15</number>
-        </property>
-        <property name="maximum">
-         <number>240</number>
-        </property>
-        <property name="value">
-         <number>60</number>
-        </property>
-       </widget>
       </item>
      </layout>
     </widget>

--- a/src/qt/qt_openglshadermanagerdialog.ui
+++ b/src/qt/qt_openglshadermanagerdialog.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <property name="sizeConstraint">
-    <enum>QLayout::SizeConstraint::SetFixedSize</enum>
+    <enum>QLayout::SetFixedSize</enum>
    </property>
    <item row="1" column="0">
     <widget class="QGroupBox" name="groupBoxShaders">
@@ -24,22 +24,22 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <property name="sizeConstraint">
-       <enum>QLayout::SizeConstraint::SetFixedSize</enum>
+       <enum>QLayout::SetFixedSize</enum>
       </property>
       <item>
        <widget class="QListWidget" name="shaderListWidget">
         <property name="dragDropMode">
-         <enum>QAbstractItemView::DragDropMode::InternalMove</enum>
+         <enum>QAbstractItemView::InternalMove</enum>
         </property>
         <property name="selectionBehavior">
-         <enum>QAbstractItemView::SelectionBehavior::SelectItems</enum>
+         <enum>QAbstractItemView::SelectItems</enum>
         </property>
        </widget>
       </item>
       <item>
        <layout class="QVBoxLayout" name="verticalLayout">
         <property name="sizeConstraint">
-         <enum>QLayout::SizeConstraint::SetFixedSize</enum>
+         <enum>QLayout::SetFixedSize</enum>
         </property>
         <item>
          <widget class="QPushButton" name="buttonAdd">
@@ -58,7 +58,7 @@
         <item>
          <spacer name="verticalSpacer">
           <property name="orientation">
-           <enum>Qt::Orientation::Vertical</enum>
+           <enum>Qt::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -95,7 +95,7 @@
         <item>
          <spacer name="verticalSpacer_2">
           <property name="orientation">
-           <enum>Qt::Orientation::Vertical</enum>
+           <enum>Qt::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -108,10 +108,10 @@
         <item>
          <widget class="QDialogButtonBox" name="buttonBox">
           <property name="orientation">
-           <enum>Qt::Orientation::Vertical</enum>
+           <enum>Qt::Vertical</enum>
           </property>
           <property name="standardButtons">
-           <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+           <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
           </property>
           <property name="centerButtons">
            <bool>false</bool>
@@ -130,7 +130,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <property name="sizeConstraint">
-       <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+       <enum>QLayout::SetDefaultConstraint</enum>
       </property>
       <item row="1" column="0">
        <widget class="QRadioButton" name="radioButtonTargetFramerate">
@@ -151,7 +151,7 @@
          <number>60</number>
         </property>
         <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
+         <enum>Qt::Horizontal</enum>
         </property>
         <property name="invertedAppearance">
          <bool>false</bool>

--- a/src/qt/qt_progsettings.cpp
+++ b/src/qt/qt_progsettings.cpp
@@ -173,7 +173,7 @@ ProgSettings::languageCodeToId(QString langCode)
 QString
 ProgSettings::languageIdToCode(int id)
 {
-    if ((id == 0) || (id >= languages.length())) {
+    if ((id <= 0) || (id >= languages.length())) {
         return "system";
     }
     return languages[id].first;

--- a/src/qt/qt_progsettings.ui
+++ b/src/qt/qt_progsettings.ui
@@ -27,7 +27,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <property name="sizeConstraint">
-    <enum>QLayout::SizeConstraint::SetFixedSize</enum>
+    <enum>QLayout::SetFixedSize</enum>
    </property>
    <item row="2" column="1">
     <widget class="QPushButton" name="pushButtonLanguage">
@@ -39,7 +39,7 @@
    <item row="5" column="0">
     <spacer name="horizontalSpacer_3">
      <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
+      <enum>Qt::Horizontal</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -74,7 +74,7 @@
    <item row="2" column="0">
     <spacer name="horizontalSpacer_2">
      <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
+      <enum>Qt::Horizontal</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -109,7 +109,7 @@
       <number>100</number>
      </property>
      <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
+      <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
@@ -130,10 +130,10 @@
    <item row="13" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
+      <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/qt/qt_progsettings.ui
+++ b/src/qt/qt_progsettings.ui
@@ -29,25 +29,12 @@
    <property name="sizeConstraint">
     <enum>QLayout::SetFixedSize</enum>
    </property>
-   <item row="2" column="1">
-    <widget class="QPushButton" name="pushButtonLanguage">
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>Default</string>
+      <string>Language:</string>
      </property>
     </widget>
-   </item>
-   <item row="5" column="0">
-    <spacer name="horizontalSpacer_3">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item row="1" column="0" colspan="2">
     <widget class="QComboBox" name="comboBoxLanguage">
@@ -59,16 +46,6 @@
        <string>(System Default)</string>
       </property>
      </item>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QCheckBox" name="openDirUsrPath">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Select media images from program working directory</string>
-     </property>
     </widget>
    </item>
    <item row="2" column="0">
@@ -84,10 +61,17 @@
      </property>
     </spacer>
    </item>
-   <item row="5" column="1">
-    <widget class="QPushButton" name="pushButton_2">
+   <item row="2" column="1">
+    <widget class="QPushButton" name="pushButtonLanguage">
      <property name="text">
       <string>Default</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Mouse sensitivity:</string>
      </property>
     </widget>
    </item>
@@ -113,27 +97,33 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Language:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0">
-    <widget class="QCheckBox" name="checkBoxConfirmSave">
-     <property name="text">
-      <string>Ask for confirmation before saving settings</string>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
+   <item row="5" column="0">
+    <spacer name="horizontalSpacer_3">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="5" column="1">
+    <widget class="QPushButton" name="pushButton_2">
+     <property name="text">
+      <string>Default</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QCheckBox" name="openDirUsrPath">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Select media images from program working directory</string>
      </property>
     </widget>
    </item>
@@ -144,10 +134,17 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_3">
+   <item row="8" column="0">
+    <widget class="QCheckBox" name="checkBoxConfirmSave">
      <property name="text">
-      <string>Mouse sensitivity:</string>
+      <string>Ask for confirmation before saving settings</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0">
+    <widget class="QCheckBox" name="checkBoxConfirmExit">
+     <property name="text">
+      <string>Ask for confirmation before quitting</string>
      </property>
     </widget>
    </item>
@@ -158,10 +155,13 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="0">
-    <widget class="QCheckBox" name="checkBoxConfirmExit">
-     <property name="text">
-      <string>Ask for confirmation before quitting</string>
+   <item row="13" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/qt/qt_settingsfloppycdrom.ui
+++ b/src/qt/qt_settingsfloppycdrom.ui
@@ -200,6 +200,17 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>tableViewFloppy</tabstop>
+  <tabstop>comboBoxFloppyType</tabstop>
+  <tabstop>checkBoxTurboTimings</tabstop>
+  <tabstop>checkBoxCheckBPB</tabstop>
+  <tabstop>tableViewCDROM</tabstop>
+  <tabstop>comboBoxBus</tabstop>
+  <tabstop>comboBoxChannel</tabstop>
+  <tabstop>comboBoxSpeed</tabstop>
+  <tabstop>comboBoxCDROMType</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/qt/qt_settingsinput.cpp
+++ b/src/qt/qt_settingsinput.cpp
@@ -140,6 +140,7 @@ SettingsInput::onCurrentMachineChanged(int machineId)
         c++;
     }
     keyboardModel->removeRows(0, removeRows);
+    ui->comboBoxKeyboard->setCurrentIndex(-1);
     ui->comboBoxKeyboard->setCurrentIndex(selectedRow);
 
     if ((c == 1) || has_int_kbd)
@@ -171,6 +172,7 @@ SettingsInput::onCurrentMachineChanged(int machineId)
             selectedRow = row - removeRows;
     }
     mouseModel->removeRows(0, removeRows);
+    ui->comboBoxMouse->setCurrentIndex(-1);
     ui->comboBoxMouse->setCurrentIndex(selectedRow);
 
     int         i             = 0;
@@ -287,6 +289,8 @@ SettingsInput::on_pushButtonClearBind_clicked()
 void
 SettingsInput::on_comboBoxKeyboard_currentIndexChanged(int index)
 {
+    if (index < 0)
+        return;
     int keyboardId = ui->comboBoxKeyboard->currentData().toInt();
     ui->pushButtonConfigureKeyboard->setEnabled(keyboard_has_config(keyboardId) > 0);
 }
@@ -294,6 +298,8 @@ SettingsInput::on_comboBoxKeyboard_currentIndexChanged(int index)
 void
 SettingsInput::on_comboBoxMouse_currentIndexChanged(int index)
 {
+    if (index < 0)
+        return;
     int mouseId = ui->comboBoxMouse->currentData().toInt();
     ui->pushButtonConfigureMouse->setEnabled(mouse_has_config(mouseId) > 0);
 }

--- a/src/qt/qt_settingsinput.ui
+++ b/src/qt/qt_settingsinput.ui
@@ -141,7 +141,7 @@
    <item row="5" column="0" colspan="4">
     <widget class="QTableWidget" name="tableKeys">
      <property name="editTriggers">
-      <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
+      <set>QAbstractItemView::NoEditTriggers</set>
      </property>
      <property name="tabKeyNavigation">
       <bool>false</bool>
@@ -153,7 +153,7 @@
       <bool>true</bool>
      </property>
      <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectionBehavior::SelectRows</enum>
+      <enum>QAbstractItemView::SelectRows</enum>
      </property>
     </widget>
    </item>

--- a/src/qt/qt_settingsmachine.ui
+++ b/src/qt/qt_settingsmachine.ui
@@ -41,6 +41,13 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Machine type:</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="comboBoxMachineType">
         <property name="maxVisibleItems">
@@ -48,42 +55,49 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_4">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>FPU:</string>
+         <string>Machine:</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Memory:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QComboBox" name="comboBoxFPU">
-        <property name="maxVisibleItems">
-         <number>30</number>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="QSpinBox" name="spinBoxRAM">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Machine type:</string>
-        </property>
+      <item row="1" column="1">
+       <widget class="QWidget" name="widget_3" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QComboBox" name="comboBoxMachine">
+           <property name="maxVisibleItems">
+            <number>30</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pushButtonConfigure">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Configure</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
       <item row="2" column="0">
@@ -147,56 +161,25 @@
         </layout>
        </widget>
       </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>FPU:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="comboBoxFPU">
+        <property name="maxVisibleItems">
+         <number>30</number>
+        </property>
+       </widget>
+      </item>
       <item row="4" column="0">
        <widget class="QLabel" name="label_5">
         <property name="text">
          <string>Wait states:</string>
         </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Machine:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QWidget" name="widget_3" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QComboBox" name="comboBoxMachine">
-           <property name="maxVisibleItems">
-            <number>30</number>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="pushButtonConfigure">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Configure</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </widget>
       </item>
       <item row="4" column="1">
@@ -248,6 +231,23 @@
           </widget>
          </item>
         </layout>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Memory:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QSpinBox" name="spinBoxRAM">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
        </widget>
       </item>
      </layout>
@@ -315,72 +315,102 @@
     </layout>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="title">
-      <string>Time synchronization</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <widget class="QRadioButton" name="radioButtonDisabled">
-        <property name="text">
-         <string>Disabled</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QRadioButton" name="radioButtonUTC">
-        <property name="text">
-         <string>Enabled (UTC)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QRadioButton" name="radioButtonLocalTime">
-        <property name="text">
-         <string>Enabled (local time)</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="title">
-      <string>CPU frame size</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QRadioButton" name="radioButtonLargerFrames">
-        <property name="text">
-         <string>Larger frames (less smooth)</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="radioButtonSmallerFrames">
-        <property name="text">
-         <string>Smaller frames (smoother)</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="0" column="0">
+      <widget class="QGroupBox" name="groupBox_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="title">
+        <string>CPU frame size</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QRadioButton" name="radioButtonLargerFrames">
+          <property name="text">
+           <string>Larger frames (less smooth)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radioButtonSmallerFrames">
+          <property name="text">
+           <string>Smaller frames (smoother)</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="1" column="0">
+      <widget class="QGroupBox" name="groupBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="title">
+        <string>Time synchronization</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <item>
+         <widget class="QRadioButton" name="radioButtonDisabled">
+          <property name="text">
+           <string>Disabled</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radioButtonLocalTime">
+          <property name="text">
+           <string>Enabled (local time)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radioButtonUTC">
+          <property name="text">
+           <string>Enabled (UTC)</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
    <item>
     <spacer name="verticalSpacer">
@@ -397,6 +427,24 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>comboBoxMachineType</tabstop>
+  <tabstop>comboBoxMachine</tabstop>
+  <tabstop>pushButtonConfigure</tabstop>
+  <tabstop>comboBoxCPU</tabstop>
+  <tabstop>comboBoxSpeed</tabstop>
+  <tabstop>comboBoxFPU</tabstop>
+  <tabstop>comboBoxWaitStates</tabstop>
+  <tabstop>comboBoxPitMode</tabstop>
+  <tabstop>spinBoxRAM</tabstop>
+  <tabstop>checkBoxDynamicRecompiler</tabstop>
+  <tabstop>checkBoxFPUSoftfloat</tabstop>
+  <tabstop>radioButtonDisabled</tabstop>
+  <tabstop>radioButtonLocalTime</tabstop>
+  <tabstop>radioButtonUTC</tabstop>
+  <tabstop>radioButtonLargerFrames</tabstop>
+  <tabstop>radioButtonSmallerFrames</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/qt/qt_settingsmachine.ui
+++ b/src/qt/qt_settingsmachine.ui
@@ -127,7 +127,7 @@
             <string>Frequency:</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
            </property>
           </widget>
          </item>
@@ -302,7 +302,7 @@
      <item>
       <spacer name="softFloatHorizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Orientation::Horizontal</enum>
+        <enum>Qt::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -362,7 +362,7 @@
       <string>CPU frame size</string>
      </property>
      <property name="alignment">
-      <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
@@ -385,7 +385,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Orientation::Vertical</enum>
+      <enum>Qt::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/src/qt/qt_settingsotherperipherals.ui
+++ b/src/qt/qt_settingsotherperipherals.ui
@@ -382,6 +382,32 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>comboBoxRTC</tabstop>
+  <tabstop>pushButtonConfigureRTC</tabstop>
+  <tabstop>comboBoxIsaMemCard1</tabstop>
+  <tabstop>pushButtonConfigureIsaMemCard1</tabstop>
+  <tabstop>comboBoxIsaMemCard2</tabstop>
+  <tabstop>pushButtonConfigureIsaMemCard2</tabstop>
+  <tabstop>comboBoxIsaMemCard3</tabstop>
+  <tabstop>pushButtonConfigureIsaMemCard3</tabstop>
+  <tabstop>comboBoxIsaMemCard4</tabstop>
+  <tabstop>pushButtonConfigureIsaMemCard4</tabstop>
+  <tabstop>comboBoxIsaRomCard1</tabstop>
+  <tabstop>pushButtonConfigureIsaRomCard1</tabstop>
+  <tabstop>comboBoxIsaRomCard2</tabstop>
+  <tabstop>pushButtonConfigureIsaRomCard2</tabstop>
+  <tabstop>comboBoxIsaRomCard3</tabstop>
+  <tabstop>pushButtonConfigureIsaRomCard3</tabstop>
+  <tabstop>comboBoxIsaRomCard4</tabstop>
+  <tabstop>pushButtonConfigureIsaRomCard4</tabstop>
+  <tabstop>checkBoxISABugger</tabstop>
+  <tabstop>checkBoxPOSTCard</tabstop>
+  <tabstop>checkBoxUnitTester</tabstop>
+  <tabstop>pushButtonConfigureUT</tabstop>
+  <tabstop>checkBoxKeyCard</tabstop>
+  <tabstop>pushButtonConfigureKeyCard</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/qt/qt_settingsotherremovable.ui
+++ b/src/qt/qt_settingsotherremovable.ui
@@ -152,29 +152,29 @@
    </item>
    <item>
     <widget class="QWidget" name="rdiskControls" native="true">
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
        <widget class="QLabel" name="labelRDiskBus">
         <property name="text">
          <string>Bus:</string>
         </property>
        </widget>
       </item>
-      <item>
+      <item row="0" column="1">
        <widget class="QComboBox" name="comboBoxRDiskBus">
         <property name="maxVisibleItems">
          <number>30</number>
         </property>
        </widget>
       </item>
-      <item>
+      <item row="0" column="2">
        <widget class="QLabel" name="labelRDiskChannel">
         <property name="text">
          <string>Channel:</string>
         </property>
        </widget>
       </item>
-      <item>
+      <item row="0" column="3">
        <widget class="QComboBox" name="comboBoxRDiskChannel">
         <property name="maxVisibleItems">
          <number>30</number>

--- a/src/qt/qt_settingsotherremovable.ui
+++ b/src/qt/qt_settingsotherremovable.ui
@@ -200,6 +200,16 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>tableViewMO</tabstop>
+  <tabstop>comboBoxMOBus</tabstop>
+  <tabstop>comboBoxMOChannel</tabstop>
+  <tabstop>comboBoxMOType</tabstop>
+  <tabstop>tableViewRDisk</tabstop>
+  <tabstop>comboBoxRDiskBus</tabstop>
+  <tabstop>comboBoxRDiskChannel</tabstop>
+  <tabstop>comboBoxRDiskType</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/qt/qt_settingsstoragecontrollers.ui
+++ b/src/qt/qt_settingsstoragecontrollers.ui
@@ -328,6 +328,29 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>comboBoxFD</tabstop>
+  <tabstop>pushButtonFD</tabstop>
+  <tabstop>comboBoxCDInterface</tabstop>
+  <tabstop>pushButtonCDInterface</tabstop>
+  <tabstop>comboBoxHD1</tabstop>
+  <tabstop>pushButtonHD1</tabstop>
+  <tabstop>comboBoxHD2</tabstop>
+  <tabstop>pushButtonHD2</tabstop>
+  <tabstop>comboBoxHD3</tabstop>
+  <tabstop>pushButtonHD3</tabstop>
+  <tabstop>comboBoxHD4</tabstop>
+  <tabstop>pushButtonHD4</tabstop>
+  <tabstop>comboBoxSCSI1</tabstop>
+  <tabstop>pushButtonSCSI1</tabstop>
+  <tabstop>comboBoxSCSI2</tabstop>
+  <tabstop>pushButtonSCSI2</tabstop>
+  <tabstop>comboBoxSCSI3</tabstop>
+  <tabstop>pushButtonSCSI3</tabstop>
+  <tabstop>comboBoxSCSI4</tabstop>
+  <tabstop>pushButtonSCSI4</tabstop>
+  <tabstop>checkBoxCassette</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/qt/qt_vmmanager_mainwindow.ui
+++ b/src/qt/qt_vmmanager_mainwindow.ui
@@ -56,7 +56,7 @@
     </size>
    </property>
    <property name="toolButtonStyle">
-    <enum>Qt::ToolButtonStyle::ToolButtonIconOnly</enum>
+    <enum>Qt::ToolButtonIconOnly</enum>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -157,7 +157,7 @@
     <string>&amp;Settings...</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::NoRole</enum>
+    <enum>QAction::NoRole</enum>
    </property>
    <property name="iconVisibleInMenu">
     <bool>false</bool>
@@ -183,7 +183,7 @@
     <string>Preferences</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::PreferencesRole</enum>
+    <enum>QAction::PreferencesRole</enum>
    </property>
   </action>
   <action name="actionStart">
@@ -208,13 +208,13 @@
   </action>
   <action name="actionExit">
    <property name="icon">
-    <iconset theme="QIcon::ThemeIcon::ApplicationExit"/>
+    <iconset theme="QIcon::ApplicationExit"/>
    </property>
    <property name="text">
     <string>&amp;Exit</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::MenuRole::QuitRole</enum>
+    <enum>QAction::QuitRole</enum>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Summary
=======
- Fix warnings when opening .ui Files in Qt Designer
- Add "Printer" to the name of the generic ESC/P dot-matrix printer, fixing broken translations which were set up for this name
- Fix keyboard configuration button not being enabled when the selected keyboard is the first in the list
- Fix removable disk type not being on its own row
- Fix groupbox size being uneven on machine settings page
- Fix messed up tab order in dialogs
- Miscellaneous cleanup

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
N/A