### PR TITLE
Text and translation updates

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -469,7 +469,6 @@ device_get_bios_local(const device_t *dev, const char *internal_name)
                            (bios->name != NULL) &&
                            (bios->internal_name != NULL) &&
                            (bios->files_no != 0)) {
-                        printf("Internal name was: %s", internal_name);
                         if (!strcmp(internal_name, bios->internal_name))
                             return bios->local;
                         bios++;

--- a/src/device/isamem.c
+++ b/src/device/isamem.c
@@ -1391,10 +1391,10 @@ static const device_config_t ems5150_config[] = {
         .spinner        = { 0 },
         .selection      = {
             { .description = "Disabled", .value = 0x0000 },
-            { .description = "Board 1",  .value = 0x0208 },
-            { .description = "Board 2",  .value = 0x020a },
-            { .description = "Board 3",  .value = 0x020c },
-            { .description = "Board 4",  .value = 0x020e },
+            { .description = "208H",     .value = 0x0208 },
+            { .description = "20AH",     .value = 0x020a },
+            { .description = "20CH",     .value = 0x020c },
+            { .description = "20EH",     .value = 0x020e },
             { .description = ""                          }
         },
         .bios           = { { 0 } }

--- a/src/device/isarom.c
+++ b/src/device/isarom.c
@@ -248,7 +248,7 @@ static const device_config_t isarom_config[] = {
     },
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0x00000,
@@ -557,7 +557,7 @@ static const device_config_t isarom_quad_config[] = {
 static const device_config_t lba_enhancer_config[] = {
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0xc8000,

--- a/src/device/isartc.c
+++ b/src/device/isartc.c
@@ -823,7 +823,7 @@ static const device_config_t mm58167_config[] = {
     },
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0xcc000,

--- a/src/disk/hdc_st506_xt.c
+++ b/src/disk/hdc_st506_xt.c
@@ -1915,7 +1915,7 @@ victor_v86p_available(void)
 static const device_config_t dtc_config[] = {
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0xc8000,
@@ -1969,7 +1969,7 @@ static const device_config_t st11_config[] = {
     },
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0xc8000,
@@ -2006,7 +2006,7 @@ static const device_config_t st11_config[] = {
 static const device_config_t wd_config[] = {
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0xc8000,
@@ -2089,7 +2089,7 @@ static const device_config_t wd_nobios_config[] = {
 static const device_config_t wd_rll_config[] = {
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0xc8000,
@@ -2153,7 +2153,7 @@ static const device_config_t wd_rll_config[] = {
 static const device_config_t wd1004a_config[] = {
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0xc8000,
@@ -2202,7 +2202,7 @@ static const device_config_t wd1004a_config[] = {
 static const device_config_t wd1004_rll_config[] = {
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0xc8000,

--- a/src/disk/hdc_xta.c
+++ b/src/disk/hdc_xta.c
@@ -1168,7 +1168,7 @@ static const device_config_t wdxt150_config[] = {
     },
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0xc8000,

--- a/src/disk/hdc_xtide.c
+++ b/src/disk/hdc_xtide.c
@@ -341,7 +341,7 @@ static const device_config_t xtide_config[] = {
     },
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0xd0000,

--- a/src/floppy/fdc_magitronic.c
+++ b/src/floppy/fdc_magitronic.c
@@ -110,7 +110,7 @@ static const device_config_t b215_config[] = {
   // clang-format off
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0xca000,

--- a/src/floppy/fdc_monster.c
+++ b/src/floppy/fdc_monster.c
@@ -162,7 +162,7 @@ static const device_config_t monster_fdc_config[] = {
 #endif
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0xc8000,

--- a/src/floppy/fdc_pii15xb.c
+++ b/src/floppy/fdc_pii15xb.c
@@ -123,7 +123,7 @@ static const device_config_t pii_config[] = {
   // clang-format off
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0xce000,

--- a/src/machine/m_xt_xi8088.c
+++ b/src/machine/m_xt_xi8088.c
@@ -110,11 +110,11 @@ static const device_config_t xi8088_config[] = {
         .type = CONFIG_SELECTION,
         .selection = {
             {
-                .description = "64 kB starting from F0000",
+                .description = "64 KB starting from F0000",
                 .value = 0
             },
             {
-                .description = "128 kB starting from E0000 (address MSB inverted, last 64KB first)",
+                .description = "128 KB starting from E0000 (address MSB inverted, last 64 KB first)",
                 .value = 1
             }
         },

--- a/src/network/net_3c503.c
+++ b/src/network/net_3c503.c
@@ -721,7 +721,7 @@ static const device_config_t threec503_config[] = {
     },
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0xCC000,

--- a/src/network/net_ne2000.c
+++ b/src/network/net_ne2000.c
@@ -1412,7 +1412,7 @@ static const device_config_t ne2000_config[] = {
     },
     {
         .name = "bios_addr",
-        .description = "BIOS Address",
+        .description = "BIOS address",
         .type = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0,
@@ -1510,7 +1510,7 @@ static const device_config_t ne2000_compat_config[] = {
     },
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0,
@@ -1602,7 +1602,7 @@ static const device_config_t ne2000_compat_8bit_config[] = {
     },
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0,

--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -1449,19 +1449,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1539,7 +1527,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr ""
 
 msgid "BIOS address (ROM #1)"
@@ -1582,9 +1570,6 @@ msgid "BIOS Revision"
 msgstr ""
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1989,10 +1974,10 @@ msgstr ""
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr ""
 
-msgid "64 kB starting from F0000"
+msgid "64 KB starting from F0000"
 msgstr ""
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
 msgstr ""
 
 msgid "Sine"

--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -27,6 +27,9 @@ msgstr ""
 msgid "&Pause"
 msgstr ""
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr ""
 

--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -642,18 +642,6 @@ msgstr ""
 msgid "Card 4:"
 msgstr ""
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -1449,19 +1449,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1539,7 +1527,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "Adreça de BIOS"
 
 msgid "BIOS address (ROM #1)"
@@ -1582,9 +1570,6 @@ msgid "BIOS Revision"
 msgstr "Revisió de la BIOS"
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1989,11 +1974,11 @@ msgstr "Sempre a la velocitat seleccionada"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "Configuració de la BIOS + Hotkeys (desactivat durant el POST)"
 
-msgid "64 kB starting from F0000"
-msgstr "64 kB a partir de F0000"
+msgid "64 KB starting from F0000"
+msgstr "64 KB a partir de F0000"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "128 kB a partir de E0000 (MSB de adreça invertit, els darrers 64KB primer)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "128 KB a partir de E0000 (MSB de adreça invertit, els darrers 64 KB primer)"
 
 msgid "Sine"
 msgstr "Sinusoidal"

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+&Esc"
 msgid "&Pause"
 msgstr "&Pausa"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "&Sortir ..."
 

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -642,18 +642,6 @@ msgstr "Targeta 3:"
 msgid "Card 4:"
 msgstr "Targeta 4:"
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+&Esc"
 msgid "&Pause"
 msgstr "P&ozastavit"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "&Ukončit"
 

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -1449,19 +1449,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1539,7 +1527,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "Adresa BIOSu"
 
 msgid "BIOS address (ROM #1)"
@@ -1582,9 +1570,6 @@ msgid "BIOS Revision"
 msgstr "Revize BIOSu"
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1989,11 +1974,11 @@ msgstr "Vždy při zvolené rychlosti"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "Nastavení BIOS + klávesové zkratky (vypnuto během POST)"
 
-msgid "64 kB starting from F0000"
-msgstr "64 kB od F0000"
+msgid "64 KB starting from F0000"
+msgstr "64 KB od F0000"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "128 kB od E0000 (invertovaný MSB adresy, nejprve posledních 64 kB)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "128 KB od E0000 (invertovaný MSB adresy, nejprve posledních 64 KB)"
 
 msgid "Sine"
 msgstr "Sinusový"

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -642,18 +642,6 @@ msgstr "Karta 3:"
 msgid "Card 4:"
 msgstr "Karta 4:"
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -1449,19 +1449,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1539,7 +1527,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "BIOS-Adresse"
 
 msgid "BIOS address (ROM #1)"
@@ -1582,9 +1570,6 @@ msgid "BIOS Revision"
 msgstr "BIOS-Revision"
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1989,11 +1974,11 @@ msgstr "Immer mit der gewählten Geschwindigkeit"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "BIOS-Einstellung + Hotkeys (aus während POST)"
 
-msgid "64 kB starting from F0000"
-msgstr "64 kB ab F0000"
+msgid "64 KB starting from F0000"
+msgstr "64 KB ab F0000"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "128 kB ab E0000 (MSB der Adresse invertiert, letzte 64KB zuerst)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "128 KB ab E0000 (MSB der Adresse invertiert, letzte 64 KB zuerst)"
 
 msgid "Sine"
 msgstr "Sinus"

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -642,18 +642,6 @@ msgstr "Steckkarte 3:"
 msgid "Card 4:"
 msgstr "Steckkarte 4:"
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -27,6 +27,9 @@ msgstr "Strg+Alt+&Esc"
 msgid "&Pause"
 msgstr "&Pause"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "Be&enden..."
 

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -1449,19 +1449,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1539,7 +1527,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "Dirección de BIOS"
 
 msgid "BIOS address (ROM #1)"
@@ -1582,9 +1570,6 @@ msgid "BIOS Revision"
 msgstr "Revisión de BIOS"
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1989,11 +1974,11 @@ msgstr "Siempre a la velocidad seleccionada"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "Configuración de la BIOS + Teclas de acceso rápido (desactivadas durante la POST)"
 
-msgid "64 kB starting from F0000"
-msgstr "64 kB desde F0000"
+msgid "64 KB starting from F0000"
+msgstr "64 KB desde F0000"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "128 kB desde E0000 (MSB de dirección invertido, últimas 64KB primero)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "128 KB desde E0000 (MSB de dirección invertido, últimas 64 KB primero)"
 
 msgid "Sine"
 msgstr "Sinusoidal"

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+&Esc"
 msgid "&Pause"
 msgstr "&Pausa"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "&Salir..."
 

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -642,18 +642,6 @@ msgstr "Tarjeta 3:"
 msgid "Card 4:"
 msgstr "Tarjeta 4:"
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+&Esc"
 msgid "&Pause"
 msgstr "&Tauko"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "&Poistu..."
 

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -715,7 +715,7 @@ msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video
 msgstr "Näytönohjainta \"%hs\" ei voi käyttää, koska roms/machines-hakemistosta puuttuvien ROM-tiedostojen vuoksi. Vaihdetaan käyttökelpoiseen näytönohjaimeen."
 
 msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr ""
+msgstr "Näytönohjainta 2 \"%hs\" ei voi käyttää, koska roms/machines-hakemistosta puuttuvien ROM-tiedostojen vuoksi. Toisen näytönohjaimen poistaminen käytöstä."
 
 msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
 msgstr "Laite \"%hs\" ei voi käyttää puuttuvien ROM-tiedostojen vuoksi. Laitteen huomiotta jättäminen."
@@ -1449,19 +1449,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1539,7 +1527,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "BIOS-osoite"
 
 msgid "BIOS address (ROM #1)"
@@ -1582,9 +1570,6 @@ msgid "BIOS Revision"
 msgstr "BIOS-tarkistus"
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1989,11 +1974,11 @@ msgstr "Aina valitulla nopeudella"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "BIOS-asetus + pikanäppäimet (pois päältä POSTin aikana)"
 
-msgid "64 kB starting from F0000"
-msgstr "64 kB alkaen F0000:sta"
+msgid "64 KB starting from F0000"
+msgstr "64 Kt alkaen F0000:sta"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "128 kB alkaen E0000:sta (osoitteen käänteinen MSB, viimeiset 64 kB ensin)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "128 Kt alkaen E0000:sta (osoitteen käänteinen MSB, viimeiset 64 Kt ensin)"
 
 msgid "Sine"
 msgstr "Sini"
@@ -2059,7 +2044,7 @@ msgid "2 MB"
 msgstr "2 Mt"
 
 msgid "8 MB"
-msgstr " 8 Mt"
+msgstr "8 Mt"
 
 msgid "28 MB"
 msgstr "28 Mt"
@@ -2462,9 +2447,3 @@ msgstr ""
 
 #~ msgid "ZIP images"
 #~ msgstr "ZIP-levykuvat"
-
-#~ msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-#~ msgstr "Näytönohjainta 2 \"%hs\" ei voi käyttää, koska roms/machines-hakemistosta puuttuvien ROM-tiedostojen vuoksi. Toisen näytönohjaimen poistaminen käytöstä."
-
-#~ msgid "No shader selected"
-#~ msgstr "Ei valittu varjostinohjelmatta"

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -642,18 +642,6 @@ msgstr "Kortti 3:"
 msgid "Card 4:"
 msgstr "Kortti 4:"
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+&Esc"
 msgid "&Pause"
 msgstr "&Pause"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "&Quitter..."
 

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -642,18 +642,6 @@ msgstr "Carte 3:"
 msgid "Card 4:"
 msgstr "Carte 4:"
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -1449,19 +1449,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1539,7 +1527,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "Adresse BIOS"
 
 msgid "BIOS address (ROM #1)"
@@ -1582,9 +1570,6 @@ msgid "BIOS Revision"
 msgstr "Révision BIOS"
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1989,11 +1974,11 @@ msgstr "Toujours à la vitesse sélectionnée"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "Paramètres du BIOS + touches de raccourci (désactivées pendant le POST)"
 
-msgid "64 kB starting from F0000"
-msgstr "64 ko à partir de F0000"
+msgid "64 KB starting from F0000"
+msgstr "64 Ko à partir de F0000"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "128 ko à partir de E0000 (adresse MSB inversée, derniers 64KB en premier)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "128 Ko à partir de E0000 (adresse MSB inversée, derniers 64 Ko en premier)"
 
 msgid "Sine"
 msgstr "Sinusoïdale"

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+&Esc"
 msgid "&Pause"
 msgstr "&Pauza"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "Iz&laz..."
 

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -642,18 +642,6 @@ msgstr "Kartica 3:"
 msgid "Card 4:"
 msgstr "Kartica 4:"
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -808,7 +808,7 @@ msgid "2-axis, 8-button joystick"
 msgstr "Palica za igru s 2 osi, 8 tipke"
 
 msgid "3-axis, 2-button joystick"
-msgstr ""
+msgstr "Palica za igru s 3 osi, 2 tipke"
 
 msgid "3-axis, 4-button joystick"
 msgstr "Palica za igru s 3 osi, 4 tipke"
@@ -1449,19 +1449,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1539,7 +1527,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "Adresa BIOS-a"
 
 msgid "BIOS address (ROM #1)"
@@ -1582,9 +1570,6 @@ msgid "BIOS Revision"
 msgstr "Revizija BIOS-a"
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1989,11 +1974,11 @@ msgstr "Uvijek na odabranoj brzini"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "Konfiguracija BIOS-a + Tipkovni prečaci (onemogućeni tekom POST-a)"
 
-msgid "64 kB starting from F0000"
-msgstr "64 kB od F0000"
+msgid "64 KB starting from F0000"
+msgstr "64 KB od F0000"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "128 kB od E0000 (MSB adrese invertiran, poslednjih 64KB prvo)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "128 KB od E0000 (MSB adrese invertiran, poslednjih 64 KB prvo)"
 
 msgid "Sine"
 msgstr "Sinusni"
@@ -2462,6 +2447,3 @@ msgstr ""
 
 #~ msgid "ZIP images"
 #~ msgstr "ZIP slike"
-
-#~ msgid "3-axis, 2-button joystick(s)"
-#~ msgstr "Palica za igru s 3 osi, 2 tipke"

--- a/src/qt/languages/hu-HU.po
+++ b/src/qt/languages/hu-HU.po
@@ -642,18 +642,6 @@ msgstr "Kártya 3:"
 msgid "Card 4:"
 msgstr "Kártya 4:"
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/hu-HU.po
+++ b/src/qt/languages/hu-HU.po
@@ -808,7 +808,7 @@ msgid "2-axis, 8-button joystick"
 msgstr "2-tengelyes, 8-gombos játékvezérlő"
 
 msgid "3-axis, 2-button joystick"
-msgstr ""
+msgstr "3-tengelyes, 2-gombos játékvezérlő"
 
 msgid "3-axis, 4-button joystick"
 msgstr "3-tengelyes, 4-gombos játékvezérlő"
@@ -928,7 +928,7 @@ msgid "%1 is required for automatic conversion of PostScript files to PDF.\n\nAn
 msgstr "%1 szükséges a PostScript fájlok PDF formátumba való automatikus konvertálásához.\n\nAz általános PostScript nyomtatóra küldött dokumentumok PostScript (.ps) fájlként kerülnek mentésre."
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
-msgstr ""
+msgstr "%1 szükséges a PCL fájlok PDF formátumba való automatikus konvertálásához.\n\nAz általános PCL nyomtatóra küldött dokumentumok Printer Command Language (.pcl) fájlként kerülnek mentésre."
 
 msgid "Don't show this message again"
 msgstr "Ne jelenítse meg újra ezt az üzenetet "
@@ -1449,19 +1449,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1539,7 +1527,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "BIOS cím"
 
 msgid "BIOS address (ROM #1)"
@@ -1582,9 +1570,6 @@ msgid "BIOS Revision"
 msgstr "BIOS felülvizsgálata"
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1989,11 +1974,11 @@ msgstr "Mindig a kiválasztott sebességen"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "BIOS beállítás + gyorsbillentyűk (kikapcsolva POST alatt)"
 
-msgid "64 kB starting from F0000"
-msgstr "64 kB F0000-től kezdődően"
+msgid "64 KB starting from F0000"
+msgstr "64 KB F0000-től kezdődően"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "128 kB E0000-től kezdődően (cím MSB invertálva, először az utolsó 64KB)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "128 KB E0000-től kezdődően (cím MSB invertálva, először az utolsó 64 KB)"
 
 msgid "Sine"
 msgstr "Szinuszos"
@@ -2463,8 +2448,3 @@ msgstr ""
 #~ msgid "ZIP images"
 #~ msgstr "ZIP-lemezképek"
 
-#~ msgid "3-axis, 2-button joystick(s)"
-#~ msgstr "3-tengelyes, 2-gombos játékvezérlő(k)"
-
-#~ msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Lnaugage (.pcl) files."
-#~ msgstr "%1 szükséges a PCL fájlok PDF formátumba való automatikus konvertálásához.\n\nAz általános PCL nyomtatóra küldött dokumentumok Printer Command Language (.pcl) fájlként kerülnek mentésre."

--- a/src/qt/languages/hu-HU.po
+++ b/src/qt/languages/hu-HU.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+&Esc"
 msgid "&Pause"
 msgstr "&Szüneteltetés"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "&Kilépés..."
 

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+&Esc"
 msgid "&Pause"
 msgstr "&Pausa"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "E&sci..."
 

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -642,18 +642,6 @@ msgstr "Scheda 3:"
 msgid "Card 4:"
 msgstr "Scheda 4:"
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -928,7 +928,7 @@ msgid "%1 is required for automatic conversion of PostScript files to PDF.\n\nAn
 msgstr "%1 è richiesto per la conversione automatica di file PostScript a file PDF.\n\nQualsiasi documento mandato alla stampante generica PostScript sarà salvato come file PostScript (.ps)."
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
-msgstr ""
+msgstr "%1 è richiesto per la conversione automatica di file PCL a file PDF.\n\nQualsiasi documento mandato alla stampante generica PCL sarà salvato come file Printer Command Language (.pcl)."
 
 msgid "Don't show this message again"
 msgstr "Non mostrare più questo messaggio"
@@ -1449,19 +1449,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1539,7 +1527,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "Indirizzo BIOS"
 
 msgid "BIOS address (ROM #1)"
@@ -1582,9 +1570,6 @@ msgid "BIOS Revision"
 msgstr "Revisione del BIOS"
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1989,11 +1974,11 @@ msgstr "Sempre alla velocità selezionata"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "Impostazione BIOS + Tasti di scelta rapida (disattivati durante il POST)"
 
-msgid "64 kB starting from F0000"
-msgstr "64 kB a partire da F0000"
+msgid "64 KB starting from F0000"
+msgstr "64 KB a partire da F0000"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "128 kB a partire da E0000 (indirizzo MSB invertito, prima gli ultimi 64KB)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "128 KB a partire da E0000 (indirizzo MSB invertito, prima gli ultimi 64 KB)"
 
 msgid "Sine"
 msgstr "Sinusoidale"
@@ -2462,6 +2447,3 @@ msgstr ""
 
 #~ msgid "ZIP images"
 #~ msgstr "Immagini ZIP"
-
-#~ msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PostScript printer will be saved as Printer Command Language (.pcl) files."
-#~ msgstr "%1 è richiesto per la conversione automatica di file PCL a file PDF.\n\nQualsiasi documento mandato alla stampante generica PCL sarà salvato come file Printer Command Language (.cl)."

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+Esc(&E)"
 msgid "&Pause"
 msgstr "一時停止(&P)"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "終了(&X)..."
 

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -1449,19 +1449,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1539,7 +1527,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "BIOSアドレス"
 
 msgid "BIOS address (ROM #1)"
@@ -1582,9 +1570,6 @@ msgid "BIOS Revision"
 msgstr "BIOSリビジョン"
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1989,10 +1974,10 @@ msgstr "常に選択された速度"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "BIOS設定＋ホットキー（POST中はオフ）"
 
-msgid "64 kB starting from F0000"
+msgid "64 KB starting from F0000"
 msgstr "F0000から始まる64キロバイト"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
 msgstr "E0000から始まる128キロバイト（アドレスMSBが反転、最後の64キロバイトが最初）"
 
 msgid "Sine"

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -642,18 +642,6 @@ msgstr "カード3:"
 msgid "Card 4:"
 msgstr "カード4:"
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -642,18 +642,6 @@ msgstr "카드 3:"
 msgid "Card 4:"
 msgstr "카드 4:"
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -406,7 +406,7 @@ msgid "Video:"
 msgstr "비디오 카드:"
 
 msgid "Video #2:"
-msgstr ""
+msgstr "비디오 카드 2:"
 
 msgid "Voodoo 1 or 2 Graphics"
 msgstr "Voodoo 1 또는 2 그래픽"
@@ -1449,19 +1449,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1539,7 +1527,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "BIOS 주소"
 
 msgid "BIOS address (ROM #1)"
@@ -1582,9 +1570,6 @@ msgid "BIOS Revision"
 msgstr "BIOS 개정"
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1989,11 +1974,11 @@ msgstr "항상 선택한 속도로"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "BIOS 설정 + 핫키(POST 중 꺼짐)"
 
-msgid "64 kB starting from F0000"
-msgstr "64kB부터 F0000"
+msgid "64 KB starting from F0000"
+msgstr "64 KB부터 F0000"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "E0000에서 시작하는 128kB(주소 MSB 반전, 마지막 64KB 먼저)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "E0000에서 시작하는 128KB(주소 MSB 반전, 마지막 64 KB 먼저)"
 
 msgid "Sine"
 msgstr "사인"
@@ -2453,9 +2438,6 @@ msgstr ""
 
 #~ msgid "HD Controller:"
 #~ msgstr "HD 컨트롤러:"
-
-#~ msgid "Video 2:"
-#~ msgstr "비디오 카드 2:"
 
 #~ msgid "ZIP drives:"
 #~ msgstr "ZIP 드라이브:"

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+Esc(&E)"
 msgid "&Pause"
 msgstr "일시정지(&P)"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "끝내기(&X)..."
 

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+&Esc"
 msgid "&Pause"
 msgstr "&Pauze"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "&Afsluiten..."
 

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -1449,19 +1449,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1539,7 +1527,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "BIOS-adres"
 
 msgid "BIOS address (ROM #1)"
@@ -1582,9 +1570,6 @@ msgid "BIOS Revision"
 msgstr "BIOS Revisie"
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1989,11 +1974,11 @@ msgstr "Altijd op geselecteerde snelheid"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "BIOS-instelling + Sneltoetsen (niet actief tijdens POST)"
 
-msgid "64 kB starting from F0000"
-msgstr "64 kB vanaf F0000"
+msgid "64 KB starting from F0000"
+msgstr "64 KB vanaf F0000"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "128 kB vanaf E0000 (geïnverteerd MSB adres, laatste 64KB eerst)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "128 KB vanaf E0000 (geïnverteerd MSB adres, laatste 64 KB eerst)"
 
 msgid "Sine"
 msgstr "Sinus"

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -642,18 +642,6 @@ msgstr "Kaart 3:"
 msgid "Card 4:"
 msgstr "Kaart 4:"
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -1449,32 +1449,11 @@ msgstr "Klawiatura AX"
 msgid "PS/2 Keyboard"
 msgstr "Klawiatura PS/2"
 
-msgid "PS/2 Keyboard"
-msgstr ""
-
-msgid "PS/2 Keyboard (US)"
-msgstr "Klawiatura PS/2 (ANSI)"
-
-msgid "PS/2 Keyboard (European)"
-msgstr "Klawiatura PS/2 (ISO)"
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr "Klawiatura PS/2 (JIS)"
-
-msgid "AT/PS/2 Keyboard"
-msgstr "Klawiatura AT/PS/2"
-
 msgid "PS/55 Keyboard"
 msgstr "Klawiatura PS/55"
 
 msgid "Keys"
 msgstr "Klawisze"
-
-msgid "AT/PS/2 Keyboard"
-msgstr ""
-
-msgid "Keys"
-msgstr ""
 
 msgid "Logitech/Microsoft Bus Mouse"
 msgstr "Mysz magistralowa Logitech/Microsoft"
@@ -1548,7 +1527,7 @@ msgstr "Plik BIOS (ROM nr 3)"
 msgid "BIOS file (ROM #4)"
 msgstr "Plik BIOS (ROM nr 4)"
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "Adres BIOS"
 
 msgid "BIOS address (ROM #1)"
@@ -1592,9 +1571,6 @@ msgstr "Rewizja BIOS-u"
 
 msgid "BIOS Version"
 msgstr "Wersja BIOS-u"
-
-msgid "BIOS Versions"
-msgstr "Wersje BIOS-u"
 
 msgid "BIOS Language"
 msgstr "Język BIOS-u"
@@ -1998,11 +1974,11 @@ msgstr "Zawsze z wybraną prędkością"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "Ustawienia BIOS + klawisze skrótu (wyłączone podczas testu POST)"
 
-msgid "64 kB starting from F0000"
-msgstr "64 kB począwszy od F0000"
+msgid "64 KB starting from F0000"
+msgstr "64 KB począwszy od F0000"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "128 kB począwszy od E0000 (adres MSB odwrócony, najpierw ostatnie 64KB)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "128 KB począwszy od E0000 (adres MSB odwrócony, najpierw ostatnie 64 KB)"
 
 msgid "Sine"
 msgstr "Sinusoidalny"

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+&Esc"
 msgid "&Pause"
 msgstr "&Pauza"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "W&yjdź..."
 

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -642,18 +642,6 @@ msgstr "Karta 3:"
 msgid "Card 4:"
 msgstr "Karta 4:"
 
-msgid "Board 1"
-msgstr "Płyta 1"
-
-msgid "Board 2"
-msgstr "Płyta 2"
-
-msgid "Board 3"
-msgstr "Płyta 3"
-
-msgid "Board 4"
-msgstr "Płyta 4"
-
 msgid "Generic ISA ROM Board"
 msgstr "Generyczna płyta ROM ISA"
 

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -642,18 +642,6 @@ msgstr "Placa 3:"
 msgid "Card 4:"
 msgstr "Placa 4:"
 
-msgid "Board 1"
-msgstr "Placa 1"
-
-msgid "Board 2"
-msgstr "Placa 2"
-
-msgid "Board 3"
-msgstr "Placa 3"
-
-msgid "Board 4"
-msgstr "Placa 4"
-
 msgid "Generic ISA ROM Board"
 msgstr "Placa ROM ISA Genérica"
 

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+&Esc"
 msgid "&Pause"
 msgstr "&Pausar"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "&Sair..."
 

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -1449,20 +1449,8 @@ msgstr "Teclado AX"
 msgid "PS/2 Keyboard"
 msgstr "Teclado PS/2"
 
-msgid "PS/2 Keyboard (US)"
-msgstr "Teclado PS/2 (Estados Unidos)"
-
-msgid "PS/2 Keyboard (European)"
-msgstr "Teclado PS/2 (Europeu)"
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr "Teclado PS/2 (Japonês)"
-
 msgid "PS/55 Keyboard"
 msgstr "Teclado PS/55"
-
-msgid "AT/PS/2 Keyboard"
-msgstr "Teclado AT/PS/2"
 
 msgid "Keys"
 msgstr "Teclas"
@@ -1539,7 +1527,7 @@ msgstr "Arquivo do BIOS (ROM #3)"
 msgid "BIOS file (ROM #4)"
 msgstr "Arquivo do BIOS (ROM #4)"
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "Endereço do BIOS"
 
 msgid "BIOS address (ROM #1)"
@@ -1583,9 +1571,6 @@ msgstr "Revisão do BIOS"
 
 msgid "BIOS Version"
 msgstr "Versão do BIOS"
-
-msgid "BIOS Versions"
-msgstr "Versões de BIOS"
 
 msgid "BIOS Language"
 msgstr "Idioma do BIOS"
@@ -1989,11 +1974,11 @@ msgstr "Sempre na velocidade selecionada"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "Configuração do BIOS + teclas de atalho (desativadas durante o POST)"
 
-msgid "64 kB starting from F0000"
-msgstr "64 kB a partir de F0000"
+msgid "64 KB starting from F0000"
+msgstr "64 KB a partir de F0000"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "128 kB a partir de E0000 (endereço MSB invertido, os últimos 64 kB primeiro)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "128 KB a partir de E0000 (endereço MSB invertido, os últimos 64 KB primeiro)"
 
 msgid "Sine"
 msgstr "Senoidal"

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+&Esc"
 msgid "&Pause"
 msgstr "&Pausa"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "&Sair..."
 

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -642,18 +642,6 @@ msgstr "Placa 3:"
 msgid "Card 4:"
 msgstr "Placa 4:"
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -1449,19 +1449,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1539,7 +1527,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "Endereço da BIOS"
 
 msgid "BIOS address (ROM #1)"
@@ -1582,9 +1570,6 @@ msgid "BIOS Revision"
 msgstr "Revisão da BIOS"
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1989,11 +1974,11 @@ msgstr "Sempre à velocidade selecionada"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "Definição da BIOS + Teclas de atalho (desligadas durante o POST)"
 
-msgid "64 kB starting from F0000"
-msgstr "64 kB a partir de F0000"
+msgid "64 KB starting from F0000"
+msgstr "64 KB a partir de F0000"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "128 kB a partir de E0000 (endereço MSB invertido, os últimos 64KB primeiro)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "128 KB a partir de E0000 (endereço MSB invertido, os últimos 64 KB primeiro)"
 
 msgid "Sine"
 msgstr "Sinusoidal"

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+&Esc"
 msgid "&Pause"
 msgstr "&Пауза"
 
+msgid "Re&sume"
+msgstr "В&озобновить"
+
 msgid "E&xit..."
 msgstr "&Выход..."
 

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -642,18 +642,6 @@ msgstr "Карта 3:"
 msgid "Card 4:"
 msgstr "Карта 4:"
 
-msgid "Board 1"
-msgstr "Плата 1"
-
-msgid "Board 2"
-msgstr "Плата 2"
-
-msgid "Board 3"
-msgstr "Плата 3"
-
-msgid "Board 4"
-msgstr "Плата 4"
-
 msgid "Generic ISA ROM Board"
 msgstr "Стандартная плата ISA ROM"
 

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -217,7 +217,7 @@ msgid "End trace"
 msgstr "Завершить трассировку"
 
 msgid "&Help"
-msgstr "&Помощь"
+msgstr "&Справка"
 
 msgid "&Documentation..."
 msgstr "&Документация..."
@@ -616,7 +616,7 @@ msgid "MO drives:"
 msgstr "Магнитооптические дисководы:"
 
 msgid "Removable disk drives:"
-msgstr "Съёмные дисковые устройства:"
+msgstr "Дисководы съёмных дисков:"
 
 msgid "ZIP 250"
 msgstr "ZIP 250"
@@ -643,13 +643,13 @@ msgid "Card 4:"
 msgstr "Карта 4:"
 
 msgid "Generic ISA ROM Board"
-msgstr "Стандартная плата ISA ROM"
+msgstr "Стандартная плата ПЗУ ISA"
 
 msgid "Generic Dual ISA ROM Board"
-msgstr "Стандартная плата Dual ISA ROM"
+msgstr "Стандартная плата на 2 ПЗУ ISA"
 
 msgid "Generic Quad ISA ROM Board"
-msgstr "Стандартная плата Quad ISA ROM"
+msgstr "Стандартная плата на 4 ПЗУ ISA"
 
 msgid "ISABugger device"
 msgstr "Устройство ISABugger"
@@ -676,7 +676,7 @@ msgid "Removable disk %1 (%2): %3"
 msgstr "Съёмный диск %1 (%2): %3"
 
 msgid "Removable disk images"
-msgstr "Съёмные образы дисков"
+msgstr "Образы съёмных дисков"
 
 msgid "Image %1"
 msgstr "Образ %1"
@@ -1439,6 +1439,7 @@ msgstr "Параметры рендеринга..."
 
 msgid "PC/XT Keyboard"
 msgstr "Клавиатура PC/XT"
+
 msgid "AT Keyboard"
 msgstr "Клавиатура AT"
 
@@ -1446,10 +1447,10 @@ msgid "AX Keyboard"
 msgstr "Клавиатура AX"
 
 msgid "PS/2 Keyboard"
-msgstr ""
+msgstr "Клавиатура PS/2"
 
 msgid "PS/55 Keyboard"
-msgstr ""
+msgstr "Клавиатура PS/55"
 
 msgid "Keys"
 msgstr "Клавиши"
@@ -1485,7 +1486,7 @@ msgid "3M MicroTouch (Serial)"
 msgstr "3M MicroTouch (последовательный)"
 
 msgid "Default Baud rate"
-msgstr "Скорость передачи данных (По умолчанию)"
+msgstr "Скорость передачи данных по умолчанию"
 
 msgid "[COM] Standard Hayes-compliant Modem"
 msgstr "[COM] Стандартный Hayes-совместимый модем"

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -1446,21 +1446,10 @@ msgid "AX Keyboard"
 msgstr "Клавиатура AX"
 
 msgid "PS/2 Keyboard"
-msgstr "Клавиатура PS/2"
-
-msgid "PS/2 Keyboard (US)"
-msgstr "Клавиатура PS/2 (US)"
-
-msgid "PS/2 Keyboard (European)"
-msgstr "Клавиатура PS/2 (European)"
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr "Клавиатура PS/2 (Japanese)"
+msgstr ""
 
 msgid "PS/55 Keyboard"
-msgstr "Клавиатура PS/55"
-msgid "AT/PS/2 Keyboard"
-msgstr "Клавиатура AT/PS/2"
+msgstr ""
 
 msgid "Keys"
 msgstr "Клавиши"
@@ -1537,7 +1526,7 @@ msgstr "Файл BIOS (ПЗУ #3)"
 msgid "BIOS file (ROM #4)"
 msgstr "Файл BIOS (ПЗУ #4)"
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "Адрес BIOS"
 
 msgid "BIOS address (ROM #1)"
@@ -1581,9 +1570,6 @@ msgstr "Версия BIOS"
 
 msgid "BIOS Version"
 msgstr "Версия BIOS"
-
-msgid "BIOS Versions"
-msgstr "Версии BIOS"
 
 msgid "BIOS Language"
 msgstr "Язык BIOS"
@@ -1987,10 +1973,10 @@ msgstr "Всегда на выбранной скорости"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "Настройка BIOS + горячие клавиши (отключается во время POST)"
 
-msgid "64 kB starting from F0000"
+msgid "64 KB starting from F0000"
 msgstr "64 КБ, начиная с F0000"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
 msgstr "128 КБ, начиная с E0000 (адрес MSB инвертирован, сначала последние 64 КБ)"
 
 msgid "Sine"

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+&Esc"
 msgid "&Pause"
 msgstr "P&ozastaviť"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "&Ukončiť"
 

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -919,7 +919,7 @@ msgid "Hardware not available"
 msgstr "Hardvér nie je dostupný"
 
 msgid "Make sure %1 is installed and that you are on a %1-compatible network connection."
-msgstr ""
+msgstr "Uistite sa, že je nainštalovaný %1 a používate sieťové pripojenie s ním kompatibilné."
 
 msgid "Invalid configuration"
 msgstr "Neplatná konfigurácia"
@@ -928,7 +928,7 @@ msgid "%1 is required for automatic conversion of PostScript files to PDF.\n\nAn
 msgstr "%1 je potrebná pre automatický prevod PostScript dokumentov do PDF.\n\nAkékoľvek dokumenty vytlačené cez všeobecnú PostScriptovú tlačiareň budú uložené ako PostScript (.ps) súbory."
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
-msgstr ""
+msgstr "%1 je potrebná pre automatický prevod PCL dokumentov do PDF.\n\nAkékoľvek dokumenty vytlačené cez všeobecnú PCLovú tlačiareň budú uložené ako Printer Command Language (.pcl) súbory."
 
 msgid "Don't show this message again"
 msgstr "Nezobrazovať ďalej túto správu"
@@ -1449,19 +1449,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1539,7 +1527,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "Adresa BIOS"
 
 msgid "BIOS address (ROM #1)"
@@ -1582,9 +1570,6 @@ msgid "BIOS Revision"
 msgstr "Revízia systému BIOS"
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1989,11 +1974,11 @@ msgstr "Vždy pri zvolenej rýchlosti"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "Nastavenie BIOS + klávesové skratky (vypnuté počas POST)"
 
-msgid "64 kB starting from F0000"
-msgstr "64 kB od F0000"
+msgid "64 KB starting from F0000"
+msgstr "64 KB od F0000"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "128 kB od E0000 (adresa MSB invertovaná, najprv posledných 64 kB)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "128 KB od E0000 (adresa MSB invertovaná, najprv posledných 64 KB)"
 
 msgid "Sine"
 msgstr "Sinusový"
@@ -2462,9 +2447,3 @@ msgstr ""
 
 #~ msgid "ZIP images"
 #~ msgstr "Obrazy ZIP diskov"
-
-#~ msgid "Make sure %1 is installed and that you are on a libpcap-compatible network connection."
-#~ msgstr "Uistite sa, že je nainštalovaný %1 a používate sieťové pripojenie s ním kompatibilné."
-
-#~ msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Lnaugage (.pcl) files."
-#~ msgstr "%1 je potrebná pre automatický prevod PCL dokumentov do PDF.\n\nAkékoľvek dokumenty vytlačené cez všeobecnú PCLovú tlačiareň budú uložené ako Printer Command Language (.pcl) súbory."

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -642,18 +642,6 @@ msgstr "Karta 3:"
 msgid "Card 4:"
 msgstr "Karta 4:"
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -919,7 +919,7 @@ msgid "Hardware not available"
 msgstr "Strojna oprema ni na voljo"
 
 msgid "Make sure %1 is installed and that you are on a %1-compatible network connection."
-msgstr ""
+msgstr "Prepičajte se, da je nameščen %1 in da ste na omrežni povezavi, združljivi z %1."
 
 msgid "Invalid configuration"
 msgstr "Neveljavna konfiguracija"
@@ -928,7 +928,7 @@ msgid "%1 is required for automatic conversion of PostScript files to PDF.\n\nAn
 msgstr "%1 je potreben za samodejno pretvorbo datotek PostScript v PDF.\n\nVsi dokumenti, poslani generičnemu tiskalniku PostScript bodo shranjeni kot datoteke PostScript (.ps)."
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
-msgstr ""
+msgstr "%1 je potreben za samodejno pretvorbo datotek PCL v PDF.\n\nVsi dokumenti, poslani generičnemu tiskalniku PCL bodo shranjeni kot datoteke Printer Command Language (.pcl)."
 
 msgid "Don't show this message again"
 msgstr "Ne pokaži več tega sporočila"
@@ -1449,19 +1449,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1539,7 +1527,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "Naslov BIOS-a"
 
 msgid "BIOS address (ROM #1)"
@@ -1582,9 +1570,6 @@ msgid "BIOS Revision"
 msgstr "Revizija BIOS-a"
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1989,11 +1974,11 @@ msgstr "Vedno pri izbrani hitrosti"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "Nastavitev BIOS-a + Vroče tipke (izklopljeno med POST)"
 
-msgid "64 kB starting from F0000"
-msgstr "64 kB od F0000"
+msgid "64 KB starting from F0000"
+msgstr "64 KB od F0000"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "128 kB od E0000 (MSB naslova invertiran, najprej zadnjih 64 kB)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "128 KB od E0000 (MSB naslova invertiran, najprej zadnjih 64 KB)"
 
 msgid "Sine"
 msgstr "Sinusna"
@@ -2462,9 +2447,3 @@ msgstr ""
 
 #~ msgid "ZIP images"
 #~ msgstr "ZIP slike"
-
-#~ msgid "Make sure %1 is installed and that you are on a libpcap-compatible network connection."
-#~ msgstr "Prepičajte se, da je nameščen %1 in da ste na omrežni povezavi, združljivi z libpcap."
-
-#~ msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Lnaugage (.pcl) files."
-#~ msgstr "%1 je potreben za samodejno pretvorbo datotek PCL v PDF.\n\nVsi dokumenti, poslani generičnemu tiskalniku PCL bodo shranjeni kot datoteke Printer Command Language (.pcl)."

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+&Esc"
 msgid "&Pause"
 msgstr "&Premor"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "Iz&hod..."
 

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -642,18 +642,6 @@ msgstr "Kartica 3:"
 msgid "Card 4:"
 msgstr "Kartica 4:"
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -642,18 +642,6 @@ msgstr "Kort 3:"
 msgid "Card 4:"
 msgstr "Kort 4:"
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+&Esc"
 msgid "&Pause"
 msgstr "&Pausa"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "A&vsluta..."
 

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -1449,19 +1449,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1539,7 +1527,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "BIOS-adress"
 
 msgid "BIOS address (ROM #1)"
@@ -1582,9 +1570,6 @@ msgid "BIOS Revision"
 msgstr "BIOS revision"
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1989,11 +1974,11 @@ msgstr "Alltid vid den valda hastigheten"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "BIOS-inställningar + Snabbtangenter (av under POST)"
 
-msgid "64 kB starting from F0000"
-msgstr "64 kB som börjar från F0000"
+msgid "64 KB starting from F0000"
+msgstr "64 KB som börjar från F0000"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "128 kB som börjar från E0000 (adress MSB inverterad, de sista 64KB först)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "128 KB som börjar från E0000 (adress MSB inverterad, de sista 64 KB först)"
 
 msgid "Sine"
 msgstr "Sinus"

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -642,18 +642,6 @@ msgstr "Kart 3:"
 msgid "Card 4:"
 msgstr "Kart 4:"
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -919,7 +919,7 @@ msgid "Hardware not available"
 msgstr "Cihaz mevcut değil"
 
 msgid "Make sure %1 is installed and that you are on a %1-compatible network connection."
-msgstr ""
+msgstr "%1 kurulu olduğundan ve %1 uyumlu bir internet ağı kullandığınızdan emin olun."
 
 msgid "Invalid configuration"
 msgstr "Geçersiz yapılandırma"
@@ -928,7 +928,7 @@ msgid "%1 is required for automatic conversion of PostScript files to PDF.\n\nAn
 msgstr "%1 PostScript dosyalarının otomatik olarak PDF dosyasına çevirilmesi için gereklidir.\n\nGenel PostScript yazıcısına gönderilen tüm dökümanlar PostScript (.ps) dosyası olarak kaydedilecektir."
 
 msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
-msgstr "%1 PCL dosyalarının otomatik olarak PDF dosyasına çevirilmesi için gereklidir.\n\nGenel PostScript yazıcısına gönderilen tüm dökümanlar Printer Command Language (.pcl) dosyası olarak kaydedilecektir."
+msgstr "%1 PCL dosyalarının otomatik olarak PDF dosyasına çevirilmesi için gereklidir.\n\nGenel PCL yazıcısına gönderilen tüm dökümanlar Printer Command Language (.pcl) dosyası olarak kaydedilecektir."
 
 msgid "Don't show this message again"
 msgstr "Bu mesajı bir daha gösterme"
@@ -1449,19 +1449,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1539,7 +1527,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "BIOS Adresi"
 
 msgid "BIOS address (ROM #1)"
@@ -1582,9 +1570,6 @@ msgid "BIOS Revision"
 msgstr "BIOS Sürümü"
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1989,11 +1974,11 @@ msgstr "Her zaman seçilen hızda"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "BIOS ayarı + Kısayol tuşları (POST sırasında kapalı)"
 
-msgid "64 kB starting from F0000"
+msgid "64 KB starting from F0000"
 msgstr "F0000'dan başlayarak 64 KB"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "E0000'dan başlayarak 128 kB (adresin MSB'si ters çevirilmiş, önce sondaki 64KB)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "E0000'dan başlayarak 128 KB (adresin MSB'si ters çevirilmiş, önce sondaki 64 KB)"
 
 msgid "Sine"
 msgstr "Sinüs"

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+&Alt+Esc"
 msgid "&Pause"
 msgstr "&Duraklat"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "&Çıkış yap..."
 

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -919,7 +919,7 @@ msgid "Hardware not available"
 msgstr "Обладнання недоступне"
 
 msgid "Make sure %1 is installed and that you are on a %1-compatible network connection."
-msgstr ""
+msgstr "Переконайтесь, що %1 встановлений і ваше мережеве з'єднання, сумісне з %1."
 
 msgid "Invalid configuration"
 msgstr "Неприпустима конфігурація"
@@ -1452,19 +1452,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1542,7 +1530,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "Адреса BIOS"
 
 msgid "BIOS address (ROM #1)"
@@ -1585,9 +1573,6 @@ msgid "BIOS Revision"
 msgstr "Ревізія BIOS"
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1992,11 +1977,11 @@ msgstr "Завжди на обраній швидкості"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "Налаштування BIOS + Гарячі клавіші (вимкнено під час POST)"
 
-msgid "64 kB starting from F0000"
-msgstr "64 кБ, починаючи з F0000"
+msgid "64 KB starting from F0000"
+msgstr "64 KБ, починаючи з F0000"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "128 кБ, починаючи з E0000 (адреса MSB інвертована, останні 64 кБ першими)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "128 KБ, починаючи з E0000 (адреса MSB інвертована, останні 64 KБ першими)"
 
 msgid "Sine"
 msgstr "Синусоїдальна"
@@ -2465,6 +2450,3 @@ msgstr ""
 
 #~ msgid "ZIP images"
 #~ msgstr "Образи ZIP"
-
-#~ msgid "Make sure %1 is installed and that you are on a libpcap-compatible network connection."
-#~ msgstr "Переконайтесь, що %1 встановлений і ваше мережеве з'єднання, сумісне з libpcap."

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -642,18 +642,6 @@ msgstr "Карта 3:"
 msgid "Card 4:"
 msgstr "Карта 4:"
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+&Esc"
 msgid "&Pause"
 msgstr "&Пауза"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "&Вихід..."
 

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -1449,19 +1449,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1539,7 +1527,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "Địa chỉ BIOS"
 
 msgid "BIOS address (ROM #1)"
@@ -1582,9 +1570,6 @@ msgid "BIOS Revision"
 msgstr "Sửa đổi BIOS"
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1989,11 +1974,11 @@ msgstr "Luôn ở tốc độ đã chọn"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "Cài đặt BIOS + phím nóng (TẮT trong POST)"
 
-msgid "64 kB starting from F0000"
-msgstr "64 kb bắt đầu từ f0000"
+msgid "64 KB starting from F0000"
+msgstr "64 KB bắt đầu từ f0000"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "128 kb bắt đầu từ E0000 (địa chỉ MSB đảo ngược, 64kb cuối cùng)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "128 KB bắt đầu từ E0000 (địa chỉ MSB đảo ngược, 64 KB cuối cùng)"
 
 msgid "Sine"
 msgstr "Sin"

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -642,18 +642,6 @@ msgstr "Thẻ 3:"
 msgid "Card 4:"
 msgstr "Thẻ 4:"
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+&Esc"
 msgid "&Pause"
 msgstr "Tạm &dừng"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "Th&oát..."
 

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+Esc(&E)"
 msgid "&Pause"
 msgstr "暂停(&P)"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "退出(&X)..."
 

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -642,18 +642,6 @@ msgstr "扩展卡 3:"
 msgid "Card 4:"
 msgstr "扩展卡 4:"
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -1449,19 +1449,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1539,7 +1527,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "BIOS 地址"
 
 msgid "BIOS address (ROM #1)"
@@ -1582,9 +1570,6 @@ msgid "BIOS Revision"
 msgstr "BIOS 修订版"
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1989,11 +1974,11 @@ msgstr "始终保持选定速度"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "BIOS 设置 + 热键 (开机自检期间关闭)"
 
-msgid "64 kB starting from F0000"
-msgstr "64 kB，从 F0000 开始"
+msgid "64 KB starting from F0000"
+msgstr "64 KB，从 F0000 开始"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "128 kB，从 E0000 开始 (地址 MSB 反相，最后 64KB 优先)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "128 KB，从 E0000 开始 (地址 MSB 反相，最后 64 KB 优先)"
 
 msgid "Sine"
 msgstr "正弦"

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -642,18 +642,6 @@ msgstr "擴充卡 3:"
 msgid "Card 4:"
 msgstr "擴充卡 4:"
 
-msgid "Board 1"
-msgstr ""
-
-msgid "Board 2"
-msgstr ""
-
-msgid "Board 3"
-msgstr ""
-
-msgid "Board 4"
-msgstr ""
-
 msgid "Generic ISA ROM Board"
 msgstr ""
 

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -919,7 +919,7 @@ msgid "Hardware not available"
 msgstr "硬體不可用"
 
 msgid "Make sure %1 is installed and that you are on a %1-compatible network connection."
-msgstr ""
+msgstr "請確認 %1 已安裝且使用相容 %1 的網路連線。"
 
 msgid "Invalid configuration"
 msgstr "無效設定"
@@ -1449,19 +1449,7 @@ msgstr ""
 msgid "PS/2 Keyboard"
 msgstr ""
 
-msgid "PS/2 Keyboard (US)"
-msgstr ""
-
-msgid "PS/2 Keyboard (European)"
-msgstr ""
-
-msgid "PS/2 Keyboard (Japanese)"
-msgstr ""
-
 msgid "PS/55 Keyboard"
-msgstr ""
-
-msgid "AT/PS/2 Keyboard"
 msgstr ""
 
 msgid "Keys"
@@ -1539,7 +1527,7 @@ msgstr ""
 msgid "BIOS file (ROM #4)"
 msgstr ""
 
-msgid "BIOS Address"
+msgid "BIOS address"
 msgstr "BIOS 位址"
 
 msgid "BIOS address (ROM #1)"
@@ -1582,9 +1570,6 @@ msgid "BIOS Revision"
 msgstr "BIOS 版本"
 
 msgid "BIOS Version"
-msgstr ""
-
-msgid "BIOS Versions"
 msgstr ""
 
 msgid "BIOS Language"
@@ -1989,11 +1974,11 @@ msgstr "永遠以所選速度運作"
 msgid "BIOS setting + Hotkeys (off during POST)"
 msgstr "BIOS 設定 + 熱鍵 (POST 期間關閉)"
 
-msgid "64 kB starting from F0000"
-msgstr "64 kB 從 F0000 開始"
+msgid "64 KB starting from F0000"
+msgstr "64 KB 從 F0000 開始"
 
-msgid "128 kB starting from E0000 (address MSB inverted, last 64KB first)"
-msgstr "128 kB 從 E0000 開始 (位址 MSB 反轉，後 64KB 為先)"
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "128 KB 從 E0000 開始 (位址 MSB 反轉，後 64 KB 為先)"
 
 msgid "Sine"
 msgstr "正弦"
@@ -2462,6 +2447,3 @@ msgstr ""
 
 #~ msgid "ZIP images"
 #~ msgstr "ZIP 映像"
-
-#~ msgid "Make sure %1 is installed and that you are on a libpcap-compatible network connection."
-#~ msgstr "請確認 %1 已安裝且使用相容 libpcap 的網路連線。"

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -27,6 +27,9 @@ msgstr "Ctrl+Alt+Esc(&E)"
 msgid "&Pause"
 msgstr "暫停(&P)"
 
+msgid "Re&sume"
+msgstr ""
+
 msgid "E&xit..."
 msgstr "退出(&X)..."
 

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -2115,8 +2115,11 @@ MainWindow::updateUiPauseState()
                                     QIcon(":/menuicons/qt/icons/pause.ico");
     const auto tooltip_text = dopause ? QString(tr("Resume execution")) :
                                     QString(tr("Pause execution"));
+    const auto menu_text = dopause ? QString(tr("Re&sume")) :
+                                    QString(tr("&Pause"));
     ui->actionPause->setIcon(pause_icon);
     ui->actionPause->setToolTip(tooltip_text);
+    ui->actionPause->setText(menu_text);
     emit vmmRunningStateChanged(static_cast<VMManagerProtocol::RunningState>(window_blocked ? (dopause ? VMManagerProtocol::RunningState::PausedWaiting : VMManagerProtocol::RunningState::RunningWaiting) : (VMManagerProtocol::RunningState)dopause));
 }
 

--- a/src/scsi/scsi_aha154x.c
+++ b/src/scsi/scsi_aha154x.c
@@ -1235,7 +1235,7 @@ static const device_config_t aha_154xb_config[] = {
     },
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0,
@@ -1312,7 +1312,7 @@ static const device_config_t aha_154x_config[] = {
     },
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0,
@@ -1389,7 +1389,7 @@ static const device_config_t aha_154xcf_config[] = {
     },
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0,

--- a/src/scsi/scsi_buslogic.c
+++ b/src/scsi/scsi_buslogic.c
@@ -1874,7 +1874,7 @@ static const device_config_t BT_ISA_Config[] = {
     },
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0,

--- a/src/scsi/scsi_ncr53c400.c
+++ b/src/scsi/scsi_ncr53c400.c
@@ -821,7 +821,7 @@ corel_ls2000_available(void)
 static const device_config_t ncr53c400_mmio_config[] = {
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0xD8000,
@@ -892,7 +892,7 @@ static const device_config_t rt1000b_config[] = {
     },
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0xD8000,
@@ -953,7 +953,7 @@ static const device_config_t rt1000b_mc_config[] = {
 static const device_config_t t130b_config[] = {
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0xD8000,

--- a/src/scsi/scsi_t128.c
+++ b/src/scsi/scsi_t128.c
@@ -548,7 +548,7 @@ t128_available(void)
 static const device_config_t t128_config[] = {
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0xD8000,

--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -4096,7 +4096,7 @@ static const device_config_t isa_ext8514_config[] = {
     },
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0xc8000,

--- a/src/video/vid_sigma.c
+++ b/src/video/vid_sigma.c
@@ -889,7 +889,7 @@ device_config_t sigma_config[] = {
     },
     {
         .name           = "bios_addr",
-        .description    = "BIOS Address",
+        .description    = "BIOS address",
         .type           = CONFIG_HEX20,
         .default_string = NULL,
         .default_int    = 0xc0000,


### PR DESCRIPTION
Summary
=======
- Update the "Pause" menu item to say "Resume" when the VM is paused
- Make the "Address" option for the Micro Mainframe EMS-5150 board show actual addresses instead of board numbers
- Remove a stray logging line in device.c
- Text and translation cleanup and consistency fixes:
    * "BIOS Address" -> "BIOS address" to match "BIOS address #_"
    * Consistency for two strings with "KB" in Xi8088 configuration (leftovers from the kB -> KB conversion)
    * Fix duplicate strings in the Polish Translation
    * Remove some unused strings
    * Fix translated strings in several languages being broken due to incorrect source strings; trivial edits to fit were made translations when needed
- Update the Russian translation
    
Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A