### PR TITLE
Qt: Fix translations for the "keybind already in use" error

### DIFF
--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -2406,6 +2406,12 @@ msgstr ""
 msgid "Enter key combo:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr ""
 

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -2406,6 +2406,12 @@ msgstr ""
 msgid "Enter key combo:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr ""
 

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -2406,6 +2406,12 @@ msgstr ""
 msgid "Enter key combo:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr ""
 

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -2406,6 +2406,12 @@ msgstr ""
 msgid "Enter key combo:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr ""
 

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -2406,6 +2406,12 @@ msgstr ""
 msgid "Enter key combo:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr ""
 

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -2406,6 +2406,12 @@ msgstr ""
 msgid "Enter key combo:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr ""
 

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -2406,6 +2406,12 @@ msgstr ""
 msgid "Enter key combo:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr ""
 

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -2406,6 +2406,12 @@ msgstr ""
 msgid "Enter key combo:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr ""
 

--- a/src/qt/languages/hu-HU.po
+++ b/src/qt/languages/hu-HU.po
@@ -2406,6 +2406,12 @@ msgstr ""
 msgid "Enter key combo:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr ""
 

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -2406,6 +2406,12 @@ msgstr ""
 msgid "Enter key combo:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr ""
 

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -2406,6 +2406,12 @@ msgstr ""
 msgid "Enter key combo:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr ""
 

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -2406,6 +2406,12 @@ msgstr ""
 msgid "Enter key combo:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr ""
 

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -2406,6 +2406,12 @@ msgstr ""
 msgid "Enter key combo:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr ""
 

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -2406,6 +2406,12 @@ msgstr "Przypisanie klawiszy"
 msgid "Enter key combo:"
 msgstr "Wciśnij kombinację klawiszy:"
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr "Wyślij Control+Alt+Del"
 

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -2406,6 +2406,12 @@ msgstr "Vincular tecla"
 msgid "Enter key combo:"
 msgstr "Pressione combinação de teclas:"
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr "Enviar Control+Alt+Del"
 

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -2406,6 +2406,12 @@ msgstr ""
 msgid "Enter key combo:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr ""
 

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -2406,6 +2406,12 @@ msgstr "Привязать клавишу"
 msgid "Enter key combo:"
 msgstr "Введите комбинацию клавиш:"
 
+msgid "Bind conflict"
+msgstr "Конфликт привязки"
+
+msgid "This key combo is already in use."
+msgstr "Эта комбинация клавиш уже используется."
+
 msgid "Send Control+Alt+Del"
 msgstr "Отправить Control+Alt+Del"
 

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -2406,6 +2406,12 @@ msgstr ""
 msgid "Enter key combo:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr ""
 

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -2406,6 +2406,12 @@ msgstr ""
 msgid "Enter key combo:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr ""
 

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -2406,6 +2406,12 @@ msgstr ""
 msgid "Enter key combo:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr ""
 

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -2406,6 +2406,12 @@ msgstr ""
 msgid "Enter key combo:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr ""
 

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -2409,6 +2409,12 @@ msgstr ""
 msgid "Enter key combo:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr ""
 

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -2388,6 +2388,12 @@ msgstr ""
 msgid "Key Bindings:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Action"
 msgstr ""
 

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -2406,6 +2406,12 @@ msgstr ""
 msgid "Enter key combo:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr ""
 

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -2406,6 +2406,12 @@ msgstr ""
 msgid "Enter key combo:"
 msgstr ""
 
+msgid "Bind conflict"
+msgstr ""
+
+msgid "This key combo is already in use."
+msgstr ""
+
 msgid "Send Control+Alt+Del"
 msgstr ""
 

--- a/src/qt/qt_settingsinput.cpp
+++ b/src/qt/qt_settingsinput.cpp
@@ -236,7 +236,7 @@ SettingsInput::on_tableKeys_cellDoubleClicked(int row, int col)
         for(int x = 0; x < NUM_ACCELS; x++) {
             if(QString::fromStdString(acc_keys_t[x].seq) == keyseq.toString(QKeySequence::PortableText)) {
                 // That key is already in use
-                main_window->showMessage(MBX_ANSI & MBX_INFO, "Bind conflict", "This key combo is already in use", false);
+                main_window->showMessage(MBX_ANSI & MBX_INFO, tr("Bind conflict"), tr("This key combo is already in use."), false);
                 return;
             }
         }


### PR DESCRIPTION
Summary
=======
Title.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A