### PR TITLE
Two fixes to the keybind UI

### DIFF
--- a/src/qt/qt_settingsinput.cpp
+++ b/src/qt/qt_settingsinput.cpp
@@ -57,7 +57,7 @@ SettingsInput::SettingsInput(QWidget *parent)
     horizontalHeader.append(tr("Keybind"));
 
     QTableWidget *keyTable = ui->tableKeys;
-    keyTable->setRowCount(10);
+    keyTable->setRowCount(NUM_ACCELS);
     keyTable->setColumnCount(3);
     keyTable->setColumnHidden(2, true);
     keyTable->setColumnWidth(0, 200);

--- a/src/qt/qt_settingsinput.cpp
+++ b/src/qt/qt_settingsinput.cpp
@@ -21,6 +21,7 @@
 
 #include <QDebug>
 #include <QKeySequence>
+#include <QMessageBox>
 #include <string>
 
 extern "C" {
@@ -236,7 +237,7 @@ SettingsInput::on_tableKeys_cellDoubleClicked(int row, int col)
         for(int x = 0; x < NUM_ACCELS; x++) {
             if(QString::fromStdString(acc_keys_t[x].seq) == keyseq.toString(QKeySequence::PortableText)) {
                 // That key is already in use
-                main_window->showMessage(MBX_ANSI & MBX_INFO, tr("Bind conflict"), tr("This key combo is already in use."), false);
+                QMessageBox::warning(this, tr("Bind conflict"), tr("This key combo is already in use."), QMessageBox::StandardButton::Ok);
                 return;
             }
         }


### PR DESCRIPTION
Summary
=======
- Fix a crash when in settings-only mode and attempting to bind a hotkey already in use
- Remove the extra empty rows from the keybind table

Checklist
=========
* [x] Closes #5860
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A