### PR TITLE
Make keyboard navigation accelerators/mnemonics actually usable

### DIFF
--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -63,7 +63,7 @@ msgstr ""
 msgid "&VNC"
 msgstr ""
 
-msgid "Specify dimensions..."
+msgid "Specify &dimensions..."
 msgstr ""
 
 msgid "F&orce 4:3 display ratio"
@@ -102,7 +102,7 @@ msgstr ""
 msgid "&8x"
 msgstr ""
 
-msgid "Filter method"
+msgid "Fi&lter method"
 msgstr ""
 
 msgid "&Nearest"
@@ -675,6 +675,9 @@ msgstr ""
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr ""
 msgid "Floppy %1 (%2): %3"
 msgstr ""
 
+msgid "&Floppy %1 (%2): %3"
+msgstr ""
+
 msgid "Advanced sector images"
 msgstr ""
 
@@ -880,6 +886,9 @@ msgid "Unable to initialize GhostPCL"
 msgstr ""
 
 msgid "MO %1 (%2): %3"
+msgstr ""
+
+msgid "&MO %1 (%2): %3"
 msgstr ""
 
 msgid "MO images"
@@ -966,10 +975,16 @@ msgstr ""
 msgid "Cassette: %1"
 msgstr ""
 
+msgid "C&assette: %1"
+msgstr ""
+
 msgid "Cassette images"
 msgstr ""
 
 msgid "Cartridge %1: %2"
+msgstr ""
+
+msgid "Car&tridge %1: %2"
 msgstr ""
 
 msgid "Cartridge images"
@@ -991,6 +1006,9 @@ msgid "Hard reset"
 msgstr ""
 
 msgid "ACPI shutdown"
+msgstr ""
+
+msgid "ACP&I shutdown"
 msgstr ""
 
 msgid "Hard disk (%1)"
@@ -1140,6 +1158,9 @@ msgstr ""
 msgid "CD-ROM %1 (%2): %3"
 msgstr ""
 
+msgid "&CD-ROM %1 (%2): %3"
+msgstr ""
+
 msgid "160 KB"
 msgstr ""
 
@@ -1278,40 +1299,40 @@ msgstr ""
 msgid "List of MCA devices:"
 msgstr ""
 
-msgid "Tablet tool"
+msgid "&Tablet tool"
 msgstr ""
 
 msgid "Qt (OpenGL &ES)"
 msgstr ""
 
-msgid "About Qt"
+msgid "About &Qt"
 msgstr ""
 
-msgid "MCA devices..."
+msgid "&MCA devices..."
 msgstr ""
 
-msgid "Show non-primary monitors"
+msgid "Show non-&primary monitors"
 msgstr ""
 
-msgid "Open screenshots folder..."
+msgid "Open screenshots &folder..."
 msgstr ""
 
-msgid "Apply fullscreen stretch mode when maximized"
+msgid "Appl&y fullscreen stretch mode when maximized"
 msgstr ""
 
-msgid "Cursor/Puck"
+msgid "&Cursor/Puck"
 msgstr ""
 
-msgid "Pen"
+msgid "&Pen"
 msgstr ""
 
-msgid "Host CD/DVD Drive (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
 msgstr ""
 
 msgid "&Connected"
 msgstr ""
 
-msgid "Clear image history"
+msgid "Clear image &history"
 msgstr ""
 
 msgid "Create..."
@@ -1327,6 +1348,9 @@ msgid "Null Driver"
 msgstr ""
 
 msgid "NIC %1 (%2) %3"
+msgstr ""
+
+msgid "&NIC %1 (%2) %3"
 msgstr ""
 
 msgid "Render behavior"
@@ -1434,7 +1458,7 @@ msgstr ""
 msgid "Serial port passthrough 4"
 msgstr ""
 
-msgid "Renderer options..."
+msgid "Renderer &options..."
 msgstr ""
 
 msgid "PC/XT Keyboard"

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -63,7 +63,7 @@ msgstr "Open&GL (3.0 Core)"
 msgid "&VNC"
 msgstr "&VNC"
 
-msgid "Specify dimensions..."
+msgid "Specify &dimensions..."
 msgstr "E&specificar dimensions ..."
 
 msgid "F&orce 4:3 display ratio"
@@ -102,7 +102,7 @@ msgstr "&7x"
 msgid "&8x"
 msgstr "&8x"
 
-msgid "Filter method"
+msgid "Fi&lter method"
 msgstr "&Mètode de filtrat"
 
 msgid "&Nearest"
@@ -675,6 +675,9 @@ msgstr "Velocitat"
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr "%1 MB (CHS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "Disquet %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "&Disquet %1 (%2): %3"
+
 msgid "Advanced sector images"
 msgstr "Imatges avançates del sector"
 
@@ -881,6 +887,9 @@ msgstr "No es pot inicialitzar GhostPCL"
 
 msgid "MO %1 (%2): %3"
 msgstr "MO %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "&MO %1 (%2): %3"
 
 msgid "MO images"
 msgstr "Imatges MO"
@@ -966,11 +975,17 @@ msgstr "Continuar"
 msgid "Cassette: %1"
 msgstr "Casset: %1"
 
+msgid "C&assette: %1"
+msgstr "C&asset: %1"
+
 msgid "Cassette images"
 msgstr "Imatges de casset"
 
 msgid "Cartridge %1: %2"
 msgstr "Cartutx %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "Car&tutx %1: %2"
 
 msgid "Cartridge images"
 msgstr "Imatges de cartutx"
@@ -992,6 +1007,9 @@ msgstr "Reinicialització completa"
 
 msgid "ACPI shutdown"
 msgstr "Apagada ACPI"
+
+msgid "ACP&I shutdown"
+msgstr "Apagada ACP&I"
 
 msgid "Hard disk (%1)"
 msgstr "Disc dur (%1)"
@@ -1140,6 +1158,9 @@ msgstr "ATAPI"
 msgid "CD-ROM %1 (%2): %3"
 msgstr "CD-ROM %1 (%2): %3"
 
+msgid "&CD-ROM %1 (%2): %3"
+msgstr "&CD-ROM %1 (%2): %3"
+
 msgid "160 KB"
 msgstr "160 KB"
 
@@ -1278,41 +1299,41 @@ msgstr "Dispositius MCA"
 msgid "List of MCA devices:"
 msgstr "Lista de dispositius MCA:"
 
-msgid "Tablet tool"
+msgid "&Tablet tool"
 msgstr "Eina de tauleta"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "Quant a Qt"
+msgid "About &Qt"
+msgstr "Quant a &Qt"
 
-msgid "MCA devices..."
+msgid "&MCA devices..."
 msgstr "Dispositius MCA ..."
 
-msgid "Show non-primary monitors"
+msgid "Show non-&primary monitors"
 msgstr "Mostrar monitors no primaris"
 
-msgid "Open screenshots folder..."
+msgid "Open screenshots &folder..."
 msgstr "Obrir la carpeta de captures de pantalla ..."
 
-msgid "Apply fullscreen stretch mode when maximized"
+msgid "Appl&y fullscreen stretch mode when maximized"
 msgstr "Apliqueu el mode d’estirament de pantalla completa en màxima"
 
-msgid "Cursor/Puck"
-msgstr "Cursor/Puck"
+msgid "&Cursor/Puck"
+msgstr "&Cursor/Puck"
 
-msgid "Pen"
-msgstr "Ploma"
+msgid "&Pen"
+msgstr "&Ploma"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "Unitat CD/DVD d'amfitrió (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "&Unitat CD/DVD d'amfitrió (%1:)"
 
 msgid "&Connected"
 msgstr "&Connectat"
 
-msgid "Clear image history"
-msgstr "Esborrar la història de imatges"
+msgid "Clear image &history"
+msgstr "Esborrar la &història de imatges"
 
 msgid "Create..."
 msgstr "Crear ..."
@@ -1328,6 +1349,9 @@ msgstr "Controlador nul"
 
 msgid "NIC %1 (%2) %3"
 msgstr "NIC %1 (%2) %3"
+
+msgid "&NIC %1 (%2) %3"
+msgstr "&NIC %1 (%2) %3"
 
 msgid "Render behavior"
 msgstr "Comportament del renderitzador"
@@ -1434,7 +1458,7 @@ msgstr "Pas del port sèrie 3"
 msgid "Serial port passthrough 4"
 msgstr "Pas del port sèrie 4"
 
-msgid "Renderer options..."
+msgid "Renderer &options..."
 msgstr "Opcions del renderitzador ..."
 
 msgid "PC/XT Keyboard"

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -63,7 +63,7 @@ msgstr "Open&GL (3.0 Core)"
 msgid "&VNC"
 msgstr "&VNC"
 
-msgid "Specify dimensions..."
+msgid "Specify &dimensions..."
 msgstr "&Zadat velikost..."
 
 msgid "F&orce 4:3 display ratio"
@@ -102,7 +102,7 @@ msgstr "&7x"
 msgid "&8x"
 msgstr "&8x"
 
-msgid "Filter method"
+msgid "Fi&lter method"
 msgstr "Metoda &filtrování"
 
 msgid "&Nearest"
@@ -675,6 +675,9 @@ msgstr "Rychlost"
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr "%1 MB (CHS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "Disketová mechanika %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "&Disketová mechanika %1 (%2): %3"
+
 msgid "Advanced sector images"
 msgstr "Rozšířené sektorové obrazy"
 
@@ -881,6 +887,9 @@ msgstr "Nastala chyba při inicializaci knihovny GhostPCL"
 
 msgid "MO %1 (%2): %3"
 msgstr "MO %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "&MO %1 (%2): %3"
 
 msgid "MO images"
 msgstr "Obrazy MO"
@@ -966,11 +975,17 @@ msgstr "Pokračovat"
 msgid "Cassette: %1"
 msgstr "Kazeta: %1"
 
+msgid "C&assette: %1"
+msgstr "K&azeta: %1"
+
 msgid "Cassette images"
 msgstr "Kazetové nahrávky"
 
 msgid "Cartridge %1: %2"
 msgstr "Cartridge %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "Car&tridge %1: %2"
 
 msgid "Cartridge images"
 msgstr "Obrazy cartridge"
@@ -992,6 +1007,9 @@ msgstr "Resetovat"
 
 msgid "ACPI shutdown"
 msgstr "Vypnout skrze rozhraní ACPI"
+
+msgid "ACP&I shutdown"
+msgstr "Vypnout skrze rozhraní ACP&I"
 
 msgid "Hard disk (%1)"
 msgstr "Pevný disk (%1)"
@@ -1140,6 +1158,9 @@ msgstr "ATAPI"
 msgid "CD-ROM %1 (%2): %3"
 msgstr "CD-ROM %1 (%2): %3"
 
+msgid "&CD-ROM %1 (%2): %3"
+msgstr "&CD-ROM %1 (%2): %3"
+
 msgid "160 KB"
 msgstr "160 KB"
 
@@ -1278,41 +1299,41 @@ msgstr "Zařízení MCA"
 msgid "List of MCA devices:"
 msgstr "Seznam zařízení MCA:"
 
-msgid "Tablet tool"
+msgid "&Tablet tool"
 msgstr "Nástroj pro tablety"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "O programu Qt"
+msgid "About &Qt"
+msgstr "O programu &Qt"
 
-msgid "MCA devices..."
+msgid "&MCA devices..."
 msgstr "Zařízení MCA ..."
 
-msgid "Show non-primary monitors"
+msgid "Show non-&primary monitors"
 msgstr "Zobrazit neprimární monitory"
 
-msgid "Open screenshots folder..."
+msgid "Open screenshots &folder..."
 msgstr "Otevři složku screenshots..."
 
-msgid "Apply fullscreen stretch mode when maximized"
+msgid "Appl&y fullscreen stretch mode when maximized"
 msgstr "Použití režimu roztá&hnutí při celé obrazovce při maximalizaci"
 
-msgid "Cursor/Puck"
-msgstr "Kurzor/Puk"
+msgid "&Cursor/Puck"
+msgstr "&Kurzor/Puk"
 
-msgid "Pen"
-msgstr "Pero"
+msgid "&Pen"
+msgstr "&Pero"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "Jednotka CD/DVD hostitele (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "&Jednotka CD/DVD hostitele (%1:)"
 
 msgid "&Connected"
 msgstr "&Připojeno"
 
-msgid "Clear image history"
-msgstr "Vymaž historie snímků"
+msgid "Clear image &history"
+msgstr "Vymaž &historie snímků"
 
 msgid "Create..."
 msgstr "Vytvoř..."
@@ -1328,6 +1349,9 @@ msgstr "Nulový ovladač"
 
 msgid "NIC %1 (%2) %3"
 msgstr "NIC %1 (%2) %3"
+
+msgid "&NIC %1 (%2) %3"
+msgstr "&NIC %1 (%2) %3"
 
 msgid "Render behavior"
 msgstr "Chování vykreslování"
@@ -1434,7 +1458,7 @@ msgstr "Průchod sériového portu 3"
 msgid "Serial port passthrough 4"
 msgstr "Průchod sériového portu 4"
 
-msgid "Renderer options..."
+msgid "Renderer &options..."
 msgstr "Možnosti vykreslovače..."
 
 msgid "PC/XT Keyboard"

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -63,7 +63,7 @@ msgstr "Open&GL (3.0-Kern)"
 msgid "&VNC"
 msgstr "&VNC"
 
-msgid "Specify dimensions..."
+msgid "Specify &dimensions..."
 msgstr "Fenstergröße einstellen..."
 
 msgid "F&orce 4:3 display ratio"
@@ -102,7 +102,7 @@ msgstr "&7x"
 msgid "&8x"
 msgstr "&8x"
 
-msgid "Filter method"
+msgid "Fi&lter method"
 msgstr "Filterungsmethode"
 
 msgid "&Nearest"
@@ -675,6 +675,9 @@ msgstr "Geschwindigkeit"
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr "%1 MB (CHS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "Diskette %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "&Diskette %1 (%2): %3"
+
 msgid "Advanced sector images"
 msgstr "Fortgeschrittene Sektorabbilder"
 
@@ -881,6 +887,9 @@ msgstr "GhostPCL konnte nicht initialisiert werden"
 
 msgid "MO %1 (%2): %3"
 msgstr "MO %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "&MO %1 (%2): %3"
 
 msgid "MO images"
 msgstr "MO-Abbilder"
@@ -966,11 +975,17 @@ msgstr "Fortfahren"
 msgid "Cassette: %1"
 msgstr "Kassette: %1"
 
+msgid "C&assette: %1"
+msgstr "K&assette: %1"
+
 msgid "Cassette images"
 msgstr "Kassettenabbilder"
 
 msgid "Cartridge %1: %2"
 msgstr "Cartridge %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "Car&tridge %1: %2"
 
 msgid "Cartridge images"
 msgstr "Cartridgeabbilder"
@@ -992,6 +1007,9 @@ msgstr "Kaltstart"
 
 msgid "ACPI shutdown"
 msgstr "ACPI basiertes Herunterfahren"
+
+msgid "ACP&I shutdown"
+msgstr "ACP&I basiertes Herunterfahren"
 
 msgid "Hard disk (%1)"
 msgstr "Festplatte (%1)"
@@ -1140,6 +1158,9 @@ msgstr "ATAPI"
 msgid "CD-ROM %1 (%2): %3"
 msgstr "CD-ROM %1 (%2): %3"
 
+msgid "&CD-ROM %1 (%2): %3"
+msgstr "&CD-ROM %1 (%2): %3"
+
 msgid "160 KB"
 msgstr "160 KB"
 
@@ -1278,41 +1299,41 @@ msgstr "MCA-Geräte"
 msgid "List of MCA devices:"
 msgstr "Liste die MCA-Geräte:"
 
-msgid "Tablet tool"
+msgid "&Tablet tool"
 msgstr "Tablet-Werkzeug"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "Über Qt"
+msgid "About &Qt"
+msgstr "Über &Qt"
 
-msgid "MCA devices..."
+msgid "&MCA devices..."
 msgstr "MCA-Geräte..."
 
-msgid "Show non-primary monitors"
+msgid "Show non-&primary monitors"
 msgstr "Nicht-primäre Monitore anzeigen"
 
-msgid "Open screenshots folder..."
+msgid "Open screenshots &folder..."
 msgstr "Ordner „screenshots“ öffnen..."
 
-msgid "Apply fullscreen stretch mode when maximized"
+msgid "Appl&y fullscreen stretch mode when maximized"
 msgstr "Vollbild-Streckmodus aktivieren, wenn das Fenster maximiert ist"
 
-msgid "Cursor/Puck"
-msgstr "Mauszeiger/Puck"
+msgid "&Cursor/Puck"
+msgstr "&Mauszeiger/Puck"
 
-msgid "Pen"
-msgstr "Stift"
+msgid "&Pen"
+msgstr "&Stift"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "Host-CD/DVD-Laufwerk (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "&Host-CD/DVD-Laufwerk (%1:)"
 
 msgid "&Connected"
 msgstr "&Verbunden"
 
-msgid "Clear image history"
-msgstr "Abbildverlauf löschen"
+msgid "Clear image &history"
+msgstr "&Abbildverlauf löschen"
 
 msgid "Create..."
 msgstr "Erstellen..."
@@ -1328,6 +1349,9 @@ msgstr "Nulltreiber"
 
 msgid "NIC %1 (%2) %3"
 msgstr "NIC %1 (%2) %3"
+
+msgid "&NIC %1 (%2) %3"
+msgstr "&NIC %1 (%2) %3"
 
 msgid "Render behavior"
 msgstr "Rendering-Verhalten"
@@ -1434,7 +1458,7 @@ msgstr "Durchreichung der Serielle Schnittstelle 3"
 msgid "Serial port passthrough 4"
 msgstr "Durchreichung der Serielle Schnittstelle 4"
 
-msgid "Renderer options..."
+msgid "Renderer &options..."
 msgstr "Renderer-Optionen..."
 
 msgid "PC/XT Keyboard"

--- a/src/qt/languages/en-GB.po
+++ b/src/qt/languages/en-GB.po
@@ -24,8 +24,8 @@ msgstr "Unable to initialise GhostPCL"
 msgid "Development of the WinBox manager stopped in 2022 due to a lack of maintainers. As we direct our efforts towards making 86Box even better, we have made the decision to no longer support WinBox as a manager.\n\nNo further updates will be provided through WinBox, and you may encounter incorrect behavior should you continue using it with newer versions of 86Box. Any bug reports related to WinBox behavior will be closed as invalid.\n\nGo to 86box.net for a list of other managers you can use."
 msgstr "Development of the WinBox manager stopped in 2022 due to a lack of maintainers. As we direct our efforts towards making 86Box even better, we have made the decision to no longer support WinBox as a manager.\n\nNo further updates will be provided through WinBox, and you may encounter incorrect behavior should you continue using it with newer versions of 86Box. Any bug reports related to WinBox behaviour will be closed as invalid.\n\nGo to 86box.net for a list of other managers you can use."
 
-msgid "Apply fullscreen stretch mode when maximized"
-msgstr "Apply fullscreen stretch mode when maximised"
+msgid "Appl&y fullscreen stretch mode when maximized"
+msgstr "Appl&y fullscreen stretch mode when maximised"
 
 msgid "Failed to initialize network driver"
 msgstr "Failed to initialise network driver"

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -63,7 +63,7 @@ msgstr "Open&GL (3.0 Core)"
 msgid "&VNC"
 msgstr "&VNC"
 
-msgid "Specify dimensions..."
+msgid "Specify &dimensions..."
 msgstr "E&specificar dimensiones..."
 
 msgid "F&orce 4:3 display ratio"
@@ -102,7 +102,7 @@ msgstr "&7x"
 msgid "&8x"
 msgstr "&8x"
 
-msgid "Filter method"
+msgid "Fi&lter method"
 msgstr "&Método de filtrado"
 
 msgid "&Nearest"
@@ -675,6 +675,9 @@ msgstr "Velocidad"
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr "%1 MB (CHS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "Disquete %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "&Disquete %1 (%2): %3"
+
 msgid "Advanced sector images"
 msgstr "Imágenes avanzadas de sector"
 
@@ -881,6 +887,9 @@ msgstr "No fué posible inicializar GhostPCL"
 
 msgid "MO %1 (%2): %3"
 msgstr "MO %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "&MO %1 (%2): %3"
 
 msgid "MO images"
 msgstr "Imágenes de MO"
@@ -966,11 +975,17 @@ msgstr "Continuar"
 msgid "Cassette: %1"
 msgstr "Cassette: %1"
 
+msgid "C&assette: %1"
+msgstr "C&assette: %1"
+
 msgid "Cassette images"
 msgstr "Imágenes de Cassette"
 
 msgid "Cartridge %1: %2"
 msgstr "Cartucho %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "Car&tucho %1: %2"
 
 msgid "Cartridge images"
 msgstr "Imágenes de Cartucho"
@@ -992,6 +1007,9 @@ msgstr "Hard reset"
 
 msgid "ACPI shutdown"
 msgstr "Parada ACPI"
+
+msgid "ACP&I shutdown"
+msgstr "Parada ACP&I"
 
 msgid "Hard disk (%1)"
 msgstr "Disco duro (%1)"
@@ -1140,6 +1158,9 @@ msgstr "ATAPI"
 msgid "CD-ROM %1 (%2): %3"
 msgstr "CD-ROM %1 (%2): %3"
 
+msgid "&CD-ROM %1 (%2): %3"
+msgstr "&CD-ROM %1 (%2): %3"
+
 msgid "160 KB"
 msgstr "160 KB"
 
@@ -1278,41 +1299,41 @@ msgstr "Dispositivos MCA"
 msgid "List of MCA devices:"
 msgstr "Lista de dispositivos MCA:"
 
-msgid "Tablet tool"
+msgid "&Tablet tool"
 msgstr "Herramienta de tableta"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "Acerca de Qt"
+msgid "About &Qt"
+msgstr "Acerca de &Qt"
 
-msgid "MCA devices..."
+msgid "&MCA devices..."
 msgstr "Dispositivos MCA ..."
 
-msgid "Show non-primary monitors"
+msgid "Show non-&primary monitors"
 msgstr "Mostrar monitores no primarios"
 
-msgid "Open screenshots folder..."
+msgid "Open screenshots &folder..."
 msgstr "Abrir la carpeta screenshots..."
 
-msgid "Apply fullscreen stretch mode when maximized"
+msgid "Appl&y fullscreen stretch mode when maximized"
 msgstr "Usar escalado pantalla completa en modalidad maximizada"
 
-msgid "Cursor/Puck"
-msgstr "Cursor/Puck"
+msgid "&Cursor/Puck"
+msgstr "&Cursor/Puck"
 
-msgid "Pen"
-msgstr "Bolígrafo"
+msgid "&Pen"
+msgstr "&Bolígrafo"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "Unidad de CD/DVD anfitriona (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "&Unidad de CD/DVD anfitriona (%1:)"
 
 msgid "&Connected"
 msgstr "&Conectrado"
 
-msgid "Clear image history"
-msgstr "Eliminar historia de imágenes"
+msgid "Clear image &history"
+msgstr "Eliminar &historia de imágenes"
 
 msgid "Create..."
 msgstr "Crear..."
@@ -1328,6 +1349,9 @@ msgstr "Controlador nulo"
 
 msgid "NIC %1 (%2) %3"
 msgstr "NIC %1 (%2) %3"
+
+msgid "&NIC %1 (%2) %3"
+msgstr "&NIC %1 (%2) %3"
 
 msgid "Render behavior"
 msgstr "Comportamiento del renderizador"
@@ -1434,7 +1458,7 @@ msgstr "Paso de puerto serie 3"
 msgid "Serial port passthrough 4"
 msgstr "Paso de puerto serie 4"
 
-msgid "Renderer options..."
+msgid "Renderer &options..."
 msgstr "Opciones del renderizador..."
 
 msgid "PC/XT Keyboard"

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -63,7 +63,7 @@ msgstr "Open&GL (3.0 Core)"
 msgid "&VNC"
 msgstr "&VNC"
 
-msgid "Specify dimensions..."
+msgid "Specify &dimensions..."
 msgstr "&Määritä koko..."
 
 msgid "F&orce 4:3 display ratio"
@@ -102,7 +102,7 @@ msgstr "&7x"
 msgid "&8x"
 msgstr "&8x"
 
-msgid "Filter method"
+msgid "Fi&lter method"
 msgstr "&Suodatusmetodi"
 
 msgid "&Nearest"
@@ -675,6 +675,9 @@ msgstr "Nopeus"
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr "%1 Mt (CHS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "Levyke %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "&Levyke %1 (%2): %3"
+
 msgid "Advanced sector images"
 msgstr "Kehittyneet sektorilevykuvat"
 
@@ -881,6 +887,9 @@ msgstr "GhostPCLin alustus epäonnistui"
 
 msgid "MO %1 (%2): %3"
 msgstr "MO %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "&MO %1 (%2): %3"
 
 msgid "MO images"
 msgstr "MO-levykuvat"
@@ -966,11 +975,17 @@ msgstr "Jatka"
 msgid "Cassette: %1"
 msgstr "Kasetti: %1"
 
+msgid "C&assette: %1"
+msgstr "K&asetti: %1"
+
 msgid "Cassette images"
 msgstr "Kasettitiedostot"
 
 msgid "Cartridge %1: %2"
 msgstr "ROM-moduuli %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "R&OM-moduuli %1: %2"
 
 msgid "Cartridge images"
 msgstr "ROM-moduulikuvat"
@@ -992,6 +1007,9 @@ msgstr "Kylmä uudelleenkäynnistys"
 
 msgid "ACPI shutdown"
 msgstr "ACPI-sammutus"
+
+msgid "ACP&I shutdown"
+msgstr "ACP&I-sammutus"
 
 msgid "Hard disk (%1)"
 msgstr "Kiintolevy (%1)"
@@ -1140,6 +1158,9 @@ msgstr "ATAPI"
 msgid "CD-ROM %1 (%2): %3"
 msgstr "CD-ROM %1 (%2): %3"
 
+msgid "&CD-ROM %1 (%2): %3"
+msgstr "&CD-ROM %1 (%2): %3"
+
 msgid "160 KB"
 msgstr "160 Kt"
 
@@ -1278,41 +1299,41 @@ msgstr "MCA-laitteet"
 msgid "List of MCA devices:"
 msgstr "Luettelo MCA-laitteista:"
 
-msgid "Tablet tool"
+msgid "&Tablet tool"
 msgstr "Tablettityökalu"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "Tietoja Qt:sta"
+msgid "About &Qt"
+msgstr "Tietoja &Qt:sta"
 
-msgid "MCA devices..."
+msgid "&MCA devices..."
 msgstr "MCA-laitteet..."
 
-msgid "Show non-primary monitors"
+msgid "Show non-&primary monitors"
 msgstr "Näytä muut kuin ensisijaiset monitorit"
 
-msgid "Open screenshots folder..."
+msgid "Open screenshots &folder..."
 msgstr "Avaa kuvakaappaukset-kansio..."
 
-msgid "Apply fullscreen stretch mode when maximized"
+msgid "Appl&y fullscreen stretch mode when maximized"
 msgstr "Sovelletaan koko näytön venytystilaa maksimoidessa"
 
-msgid "Cursor/Puck"
-msgstr "Kursori/Kiekko"
+msgid "&Cursor/Puck"
+msgstr "&Kursori/Kiekko"
 
-msgid "Pen"
-msgstr "Kynä"
+msgid "&Pen"
+msgstr "K&ynä"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "Isäntä CD/DVD-asema (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "&Isäntä CD/DVD-asema (%1:)"
 
 msgid "&Connected"
 msgstr "&Yhdistetty"
 
-msgid "Clear image history"
-msgstr "Tyhjennä kuvahistoria"
+msgid "Clear image &history"
+msgstr "Tyhjennä kuva&historia"
 
 msgid "Create..."
 msgstr "Luo..."
@@ -1328,6 +1349,9 @@ msgstr "Nolla-ajuri"
 
 msgid "NIC %1 (%2) %3"
 msgstr "NIC %1 (%2) %3"
+
+msgid "&NIC %1 (%2) %3"
+msgstr "&NIC %1 (%2) %3"
 
 msgid "Render behavior"
 msgstr "Renderöintikäyttäytyminen"
@@ -1434,7 +1458,7 @@ msgstr "Sarjaportin läpivienti 3"
 msgid "Serial port passthrough 4"
 msgstr "Sarjaportin läpivienti 4"
 
-msgid "Renderer options..."
+msgid "Renderer &options..."
 msgstr "Alustusasetukset..."
 
 msgid "PC/XT Keyboard"

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -63,7 +63,7 @@ msgstr "Open&GL (3.0 Core)"
 msgid "&VNC"
 msgstr "&VNC"
 
-msgid "Specify dimensions..."
+msgid "Specify &dimensions..."
 msgstr "Spécifier dimensions..."
 
 msgid "F&orce 4:3 display ratio"
@@ -102,7 +102,7 @@ msgstr "&7x"
 msgid "&8x"
 msgstr "&8x"
 
-msgid "Filter method"
+msgid "Fi&lter method"
 msgstr "Méthode de Filtre"
 
 msgid "&Nearest"
@@ -675,6 +675,9 @@ msgstr "Vitesse"
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr "%1 Mo (CTS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "Disquette %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "&Disquette %1 (%2): %3"
+
 msgid "Advanced sector images"
 msgstr "Images secteur avancé"
 
@@ -881,6 +887,9 @@ msgstr "Impossible d'initialiser GhostPCL"
 
 msgid "MO %1 (%2): %3"
 msgstr "Magnéto-optique %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "&Magnéto-optique %1 (%2): %3"
 
 msgid "MO images"
 msgstr "Images magnéto-optiques"
@@ -966,11 +975,17 @@ msgstr "Continuer"
 msgid "Cassette: %1"
 msgstr "Cassette: %1"
 
+msgid "C&assette: %1"
+msgstr "C&assette: %1"
+
 msgid "Cassette images"
 msgstr "Images cassette"
 
 msgid "Cartridge %1: %2"
 msgstr "Cartouche %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "Car&touche %1: %2"
 
 msgid "Cartridge images"
 msgstr "Images cartouche"
@@ -992,6 +1007,9 @@ msgstr "Hard reset"
 
 msgid "ACPI shutdown"
 msgstr "Arrêt ACPI"
+
+msgid "ACP&I shutdown"
+msgstr "Arrêt ACP&I"
 
 msgid "Hard disk (%1)"
 msgstr "Disque dur (%1)"
@@ -1140,6 +1158,9 @@ msgstr "ATAPI"
 msgid "CD-ROM %1 (%2): %3"
 msgstr "CD-ROM %1 (%2): %3"
 
+msgid "&CD-ROM %1 (%2): %3"
+msgstr "&CD-ROM %1 (%2): %3"
+
 msgid "160 KB"
 msgstr "160 Ko"
 
@@ -1278,41 +1299,41 @@ msgstr "Dispositifs MCA"
 msgid "List of MCA devices:"
 msgstr "Liste des dispositifs MCA :"
 
-msgid "Tablet tool"
+msgid "&Tablet tool"
 msgstr "Outil Tablette"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "A propos de Qt"
+msgid "About &Qt"
+msgstr "A propos de &Qt"
 
-msgid "MCA devices..."
+msgid "&MCA devices..."
 msgstr "Dispositifs MCA..."
 
-msgid "Show non-primary monitors"
+msgid "Show non-&primary monitors"
 msgstr "Afficher les moniteurs non primaires"
 
-msgid "Open screenshots folder..."
+msgid "Open screenshots &folder..."
 msgstr "Ouvrir le dossier des captures d'écran..."
 
-msgid "Apply fullscreen stretch mode when maximized"
+msgid "Appl&y fullscreen stretch mode when maximized"
 msgstr "Appliquer le mode élargi plein écran lorsque la fenêtre est maximisée"
 
-msgid "Cursor/Puck"
-msgstr "Curseur/Palette"
+msgid "&Cursor/Puck"
+msgstr "&Curseur/Palette"
 
-msgid "Pen"
-msgstr "Stylo"
+msgid "&Pen"
+msgstr "&Stylo"
 
 msgid "Host CD/DVD Drive (%1:)"
-msgstr "Lecteur CD/DVD hôte (%1:)"
+msgstr "&Lecteur CD/DVD hôte (%1:)"
 
 msgid "&Connected"
 msgstr "&Connecté"
 
-msgid "Clear image history"
-msgstr "Effacer l'historique de l'image"
+msgid "Clear image &history"
+msgstr "Effacer l'&historique de l'image"
 
 msgid "Create..."
 msgstr "Créer..."
@@ -1328,6 +1349,9 @@ msgstr "Pilote NULL"
 
 msgid "NIC %1 (%2) %3"
 msgstr "NIC %1 (%2) %3"
+
+msgid "&NIC %1 (%2) %3"
+msgstr "&NIC %1 (%2) %3"
 
 msgid "Render behavior"
 msgstr "Comportement du rendu"
@@ -1434,7 +1458,7 @@ msgstr "Transfert du port série 3"
 msgid "Serial port passthrough 4"
 msgstr "Transfert du port série 4"
 
-msgid "Renderer options..."
+msgid "Renderer &options..."
 msgstr "Options du rendu..."
 
 msgid "PC/XT Keyboard"

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -63,7 +63,7 @@ msgstr "Open&GL (3.0 jezgra)"
 msgid "&VNC"
 msgstr "&VNC"
 
-msgid "Specify dimensions..."
+msgid "Specify &dimensions..."
 msgstr "Odrediti veličinu..."
 
 msgid "F&orce 4:3 display ratio"
@@ -102,7 +102,7 @@ msgstr "&7x"
 msgid "&8x"
 msgstr "&8x"
 
-msgid "Filter method"
+msgid "Fi&lter method"
 msgstr "Metoda filtriranja"
 
 msgid "&Nearest"
@@ -675,6 +675,9 @@ msgstr "Brzina"
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr "%1 MB (CHS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "Disketa %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "&Disketa %1 (%2): %3"
+
 msgid "Advanced sector images"
 msgstr "Napredne sektorske slike"
 
@@ -881,6 +887,9 @@ msgstr "Nije moguće inicijalizirati GhostPCL"
 
 msgid "MO %1 (%2): %3"
 msgstr "MO %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "&MO %1 (%2): %3"
 
 msgid "MO images"
 msgstr "MO slike"
@@ -966,11 +975,17 @@ msgstr "Nastavi"
 msgid "Cassette: %1"
 msgstr "Audio kaseta: %1"
 
+msgid "C&assette: %1"
+msgstr "&Audio kaseta: %1"
+
 msgid "Cassette images"
 msgstr "Slike audio kasete"
 
 msgid "Cartridge %1: %2"
 msgstr "Kaseta %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "&Kaseta %1: %2"
 
 msgid "Cartridge images"
 msgstr "Slike kasete"
@@ -992,6 +1007,9 @@ msgstr "Ponovno pokretanje"
 
 msgid "ACPI shutdown"
 msgstr "ACPI bazirano gašenje"
+
+msgid "ACP&I shutdown"
+msgstr "ACP&I bazirano gašenje"
 
 msgid "Hard disk (%1)"
 msgstr "Tvrdi disk (%1)"
@@ -1140,6 +1158,9 @@ msgstr "ATAPI"
 msgid "CD-ROM %1 (%2): %3"
 msgstr "CD-ROM %1 (%2): %3"
 
+msgid "&CD-ROM %1 (%2): %3"
+msgstr "&CD-ROM %1 (%2): %3"
+
 msgid "160 KB"
 msgstr "160 KB"
 
@@ -1278,41 +1299,41 @@ msgstr "Uređaji MCA"
 msgid "List of MCA devices:"
 msgstr "Spisak uređaja MCA:"
 
-msgid "Tablet tool"
+msgid "&Tablet tool"
 msgstr "Alat za tablet"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "O programu Qt"
+msgid "About &Qt"
+msgstr "O programu &Qt"
 
-msgid "MCA devices..."
+msgid "&MCA devices..."
 msgstr "Uređaji MCA ..."
 
-msgid "Show non-primary monitors"
+msgid "Show non-&primary monitors"
 msgstr "Prikaži neprimarne monitore"
 
-msgid "Open screenshots folder..."
+msgid "Open screenshots &folder..."
 msgstr "Otvori mapu snimaka zaslona..."
 
-msgid "Apply fullscreen stretch mode when maximized"
+msgid "Appl&y fullscreen stretch mode when maximized"
 msgstr "Primijeni način cijelozaslonskog rastezanja u maksimiziranom načinu"
 
-msgid "Cursor/Puck"
-msgstr "Kursor/Pak"
+msgid "&Cursor/Puck"
+msgstr "&Kursor/Pak"
 
-msgid "Pen"
-msgstr "Olovka"
+msgid "&Pen"
+msgstr "&Olovka"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "CD/DVD pogon nositelja (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "CD/DVD pogon &nositelja (%1:)"
 
 msgid "&Connected"
 msgstr "&Povezan"
 
-msgid "Clear image history"
-msgstr "Očisti povijest slika"
+msgid "Clear image &history"
+msgstr "Očisti &povijest slika"
 
 msgid "Create..."
 msgstr "Stvori..."
@@ -1328,6 +1349,9 @@ msgstr "Nulti upravljački program"
 
 msgid "NIC %1 (%2) %3"
 msgstr "NIC %1 (%2) %3"
+
+msgid "&NIC %1 (%2) %3"
+msgstr "&NIC %1 (%2) %3"
 
 msgid "Render behavior"
 msgstr "Ponašanje rendera"
@@ -1434,7 +1458,7 @@ msgstr "Prolaz serijskih vrata 3"
 msgid "Serial port passthrough 4"
 msgstr "Prolaz serijskih vrata 4"
 
-msgid "Renderer options..."
+msgid "Renderer &options..."
 msgstr "Opcije rendera..."
 
 msgid "PC/XT Keyboard"

--- a/src/qt/languages/hu-HU.po
+++ b/src/qt/languages/hu-HU.po
@@ -63,7 +63,7 @@ msgstr "Open&GL (3.0 Core)"
 msgid "&VNC"
 msgstr "&VNC"
 
-msgid "Specify dimensions..."
+msgid "Specify &dimensions..."
 msgstr "Méretek kézi megadása..."
 
 msgid "F&orce 4:3 display ratio"
@@ -102,7 +102,7 @@ msgstr "&7x"
 msgid "&8x"
 msgstr "&8x"
 
-msgid "Filter method"
+msgid "Fi&lter method"
 msgstr "Szűrési mód"
 
 msgid "&Nearest"
@@ -675,6 +675,9 @@ msgstr "Sebesség"
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr "%1 MB (CHS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "Floppy %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "&Floppy %1 (%2): %3"
+
 msgid "Advanced sector images"
 msgstr "Továbbfejlesztett szektor képek"
 
@@ -881,6 +887,9 @@ msgstr "Nem sikerült inicializálni a GhostPCL-et"
 
 msgid "MO %1 (%2): %3"
 msgstr "MO %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "&MO %1 (%2): %3"
 
 msgid "MO images"
 msgstr "MO-képfájlok"
@@ -966,6 +975,9 @@ msgstr "Folytatás"
 msgid "Cassette: %1"
 msgstr "Magnókazetta: %1"
 
+msgid "C&assette: %1"
+msgstr "M&agnókazetta: %1"
+
 msgid "Cassette images"
 msgstr "Magnókazetta-képek"
 
@@ -992,6 +1004,9 @@ msgstr "Hardveres újraindítás"
 
 msgid "ACPI shutdown"
 msgstr "ACPI leállítás"
+
+msgid "ACP&I shutdown"
+msgstr "ACP&I leállítás"
 
 msgid "Hard disk (%1)"
 msgstr "Merevlemez (%1)"
@@ -1140,6 +1155,9 @@ msgstr "ATAPI"
 msgid "CD-ROM %1 (%2): %3"
 msgstr "CD-ROM %1 (%2): %3"
 
+msgid "&CD-ROM %1 (%2): %3"
+msgstr "&CD-ROM %1 (%2): %3"
+
 msgid "160 KB"
 msgstr "160 KB"
 
@@ -1278,41 +1296,41 @@ msgstr "MCA eszközök"
 msgid "List of MCA devices:"
 msgstr "Az MCA-eszközök listája:"
 
-msgid "Tablet tool"
+msgid "&Tablet tool"
 msgstr "Tablet eszköz"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "A Qt-ről"
+msgid "About &Qt"
+msgstr "A &Qt-ről"
 
-msgid "MCA devices..."
+msgid "&MCA devices..."
 msgstr "MCA eszközök..."
 
-msgid "Show non-primary monitors"
+msgid "Show non-&primary monitors"
 msgstr "Nem elsődleges monitorok megjelenítése"
 
-msgid "Open screenshots folder..."
+msgid "Open screenshots &folder..."
 msgstr "Nyissa meg a képernyőképek mappát..."
 
-msgid "Apply fullscreen stretch mode when maximized"
+msgid "Appl&y fullscreen stretch mode when maximized"
 msgstr "Teljes képernyős méretezés alkalmazása maximalizáláskor"
 
-msgid "Cursor/Puck"
-msgstr "Cursor/Puck"
+msgid "&Cursor/Puck"
+msgstr "&Cursor/Puck"
 
-msgid "Pen"
-msgstr "Toll"
+msgid "&Pen"
+msgstr "&Toll"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "Gazdag CD/DVD-meghajtó (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "&Gazdag CD/DVD-meghajtó (%1:)"
 
 msgid "&Connected"
 msgstr ""
 
-msgid "Clear image history"
-msgstr "Törölje a kép előzményeit"
+msgid "Clear image &history"
+msgstr "Törölje a kép &előzményeit"
 
 msgid "Create..."
 msgstr "Hozzon létre..."
@@ -1328,6 +1346,9 @@ msgstr "Null Driver"
 
 msgid "NIC %1 (%2) %3"
 msgstr "NIC %1 (%2) %3"
+
+msgid "&NIC %1 (%2) %3"
+msgstr "&NIC %1 (%2) %3"
 
 msgid "Render behavior"
 msgstr "Renderelési viselkedés"
@@ -1434,7 +1455,7 @@ msgstr "Soros port áthaladás 3"
 msgid "Serial port passthrough 4"
 msgstr "Soros port áthaladás 4"
 
-msgid "Renderer options..."
+msgid "Renderer &options..."
 msgstr "Renderer opciók..."
 
 msgid "PC/XT Keyboard"

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -63,7 +63,7 @@ msgstr "Open&GL (3.0 Core)"
 msgid "&VNC"
 msgstr "&VNC"
 
-msgid "Specify dimensions..."
+msgid "Specify &dimensions..."
 msgstr "Specifica dimensioni..."
 
 msgid "F&orce 4:3 display ratio"
@@ -102,7 +102,7 @@ msgstr "&7x"
 msgid "&8x"
 msgstr "&8x"
 
-msgid "Filter method"
+msgid "Fi&lter method"
 msgstr "Metodo filtro"
 
 msgid "&Nearest"
@@ -675,6 +675,9 @@ msgstr "Velocità"
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr "%1 MB (CHS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "Floppy %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "&Floppy %1 (%2): %3"
+
 msgid "Advanced sector images"
 msgstr "Immagini da settori avanzati"
 
@@ -881,6 +887,9 @@ msgstr "Impossibile inizializzare GhostPCL"
 
 msgid "MO %1 (%2): %3"
 msgstr "MO %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "&MO %1 (%2): %3"
 
 msgid "MO images"
 msgstr "Immagini MO"
@@ -966,11 +975,17 @@ msgstr "Continua"
 msgid "Cassette: %1"
 msgstr "Cassetta: %1"
 
+msgid "C&assette: %1"
+msgstr "C&assetta: %1"
+
 msgid "Cassette images"
 msgstr "Immagini cassetta"
 
 msgid "Cartridge %1: %2"
 msgstr "Cartuccia %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "Car&tuccia %1: %2"
 
 msgid "Cartridge images"
 msgstr "Immagini cartuccia"
@@ -992,6 +1007,9 @@ msgstr "Riavvia"
 
 msgid "ACPI shutdown"
 msgstr "Arresto ACPI"
+
+msgid "ACP&I shutdown"
+msgstr "Arresto ACP&I"
 
 msgid "Hard disk (%1)"
 msgstr "Hard disk (%1)"
@@ -1140,6 +1158,9 @@ msgstr "ATAPI"
 msgid "CD-ROM %1 (%2): %3"
 msgstr "CD-ROM %1 (%2): %3"
 
+msgid "&CD-ROM %1 (%2): %3"
+msgstr "&CD-ROM %1 (%2): %3"
+
 msgid "160 KB"
 msgstr "160 KB"
 
@@ -1278,41 +1299,41 @@ msgstr "Dispositivi MCA"
 msgid "List of MCA devices:"
 msgstr "Elenco dei dispositivi MCA:"
 
-msgid "Tablet tool"
+msgid "&Tablet tool"
 msgstr "Strumento tablet"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "Informazioni su Qt"
+msgid "About &Qt"
+msgstr "Informazioni su &Qt"
 
-msgid "MCA devices..."
+msgid "&MCA devices..."
 msgstr "Dispositivi MCA..."
 
-msgid "Show non-primary monitors"
+msgid "Show non-&primary monitors"
 msgstr "Mostra i monitor non primari"
 
-msgid "Open screenshots folder..."
+msgid "Open screenshots &folder..."
 msgstr "Aprire la cartella screenshot..."
 
-msgid "Apply fullscreen stretch mode when maximized"
+msgid "Appl&y fullscreen stretch mode when maximized"
 msgstr "Applica la modalità adattamento schermo intero in modalità massimizzata"
 
-msgid "Cursor/Puck"
-msgstr "Cursore/Puck"
+msgid "&Cursor/Puck"
+msgstr "&Cursore/Puck"
 
-msgid "Pen"
-msgstr "Penna"
+msgid "&Pen"
+msgstr "&Penna"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "Unità CD/DVD host (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "&Unità CD/DVD host (%1:)"
 
 msgid "&Connected"
 msgstr "&Connesso"
 
-msgid "Clear image history"
-msgstr "Cancella la cronologia delle immagini"
+msgid "Clear image &history"
+msgstr "Cancella la cr&onologia delle immagini"
 
 msgid "Create..."
 msgstr "Creare..."
@@ -1328,6 +1349,9 @@ msgstr "Driver nullo"
 
 msgid "NIC %1 (%2) %3"
 msgstr "NIC %1 (%2) %3"
+
+msgid "&NIC %1 (%2) %3"
+msgstr "&NIC %1 (%2) %3"
 
 msgid "Render behavior"
 msgstr "Comportamento di rendering"
@@ -1434,7 +1458,7 @@ msgstr "Passaggio della porta seriale 3"
 msgid "Serial port passthrough 4"
 msgstr "Passaggio della porta seriale 4"
 
-msgid "Renderer options..."
+msgid "Renderer &options..."
 msgstr "Opzioni del renderer..."
 
 msgid "PC/XT Keyboard"

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -63,8 +63,8 @@ msgstr "OpenGL (3.0 Core)(&G)"
 msgid "&VNC"
 msgstr "VNC(&V)"
 
-msgid "Specify dimensions..."
-msgstr "ディメンションを指定..."
+msgid "Specify &dimensions..."
+msgstr "ディメンションを指定...(&D)"
 
 msgid "F&orce 4:3 display ratio"
 msgstr "4:3の縦横比を強制表示(&O)"
@@ -102,8 +102,8 @@ msgstr "7x(&7)"
 msgid "&8x"
 msgstr "8x(&8)"
 
-msgid "Filter method"
-msgstr "フィルター方式"
+msgid "Fi&lter method"
+msgstr "フィルター方式(&L)"
 
 msgid "&Nearest"
 msgstr "最近傍補間(&N)"
@@ -675,6 +675,9 @@ msgstr "速度"
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr "%u MB (CHS値: %i、%i、%i)"
 msgid "Floppy %1 (%2): %3"
 msgstr "フロッピー %1 (%2): %3"
 
+msgid "Floppy %1 (%2): %3 (&F)"
+msgstr "フロッピー %1 (%2): %3(&F)"
+
 msgid "Advanced sector images"
 msgstr "アドバンスドセクターイメージ"
 
@@ -881,6 +887,9 @@ msgstr "GhostPCLが初期化できません"
 
 msgid "MO %1 (%2): %3"
 msgstr "光磁気 %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "光磁気 %1 (%2): %3(&M)"
 
 msgid "MO images"
 msgstr "光磁気イメージ"
@@ -966,11 +975,17 @@ msgstr "続行"
 msgid "Cassette: %1"
 msgstr "カセット: %1"
 
+msgid "C&assette: %1"
+msgstr "カセット: %1(&A)"
+
 msgid "Cassette images"
 msgstr "カセットイメージ"
 
 msgid "Cartridge %1: %2"
 msgstr "カートリッジ %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "カートリッジ %1: %2(&T)"
 
 msgid "Cartridge images"
 msgstr "カートリッジイメージ"
@@ -992,6 +1007,9 @@ msgstr "ハードリセット"
 
 msgid "ACPI shutdown"
 msgstr "ACPIシャットダウン"
+
+msgid "ACP&I shutdown"
+msgstr "ACP&Iシャットダウン"
 
 msgid "Hard disk (%1)"
 msgstr "ハードディスク (%1)"
@@ -1140,6 +1158,9 @@ msgstr "ATAPI"
 msgid "CD-ROM %1 (%2): %3"
 msgstr "CD-ROM %1 (%2): %3"
 
+msgid "&CD-ROM %1 (%2): %3"
+msgstr "&CD-ROM %1 (%2): %3"
+
 msgid "160 KB"
 msgstr "160 KB"
 
@@ -1278,41 +1299,41 @@ msgstr "MCAデバイス"
 msgid "List of MCA devices:"
 msgstr "MCAデバイスのリスト："
 
-msgid "Tablet tool"
-msgstr "タブレットツール"
+msgid "&Tablet tool"
+msgstr "タブレットツール(&T)"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "Qtについて"
+msgid "About &Qt"
+msgstr "&Qtについて"
 
-msgid "MCA devices..."
-msgstr "MCAデバイス..."
+msgid "&MCA devices..."
+msgstr "&MCAデバイス..."
 
-msgid "Show non-primary monitors"
-msgstr "プライマリーモニター以外のモニターを表示する"
+msgid "Show non-&primary monitors"
+msgstr "プライマリーモニター以外のモニターを表示する(&P)"
 
-msgid "Open screenshots folder..."
-msgstr "スクリーンショットフォルダを開く"
+msgid "Open screenshots &folder..."
+msgstr "スクリーンショットフォルダを開く(&F)"
 
-msgid "Apply fullscreen stretch mode when maximized"
-msgstr "最大化時にフルスクリーンストレッチモードを適用"
+msgid "Appl&y fullscreen stretch mode when maximized"
+msgstr "最大化時にフルスクリーンストレッチモードを適用(&Y)"
 
-msgid "Cursor/Puck"
-msgstr "カーソル/パック"
+msgid "&Cursor/Puck"
+msgstr "カーソル/パック(&C)"
 
-msgid "Pen"
-msgstr "ペン"
+msgid "&Pen"
+msgstr "ペン(&P)"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "ホスト CD/DVD ドライブ (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "ホスト CD/DVD ドライブ (%1:) (&H)"
 
 msgid "&Connected"
 msgstr "コネクテッド"
 
-msgid "Clear image history"
-msgstr "クリア画像履歴"
+msgid "Clear image &history"
+msgstr "クリア画像履歴(&H)"
 
 msgid "Create..."
 msgstr "作成..."
@@ -1328,6 +1349,9 @@ msgstr "ヌル・ドライバー"
 
 msgid "NIC %1 (%2) %3"
 msgstr "NIC %1 (%2) %3"
+
+msgid "&NIC %1 (%2) %3"
+msgstr "&NIC %1 (%2) %3"
 
 msgid "Render behavior"
 msgstr "レンダリング動作"
@@ -1434,8 +1458,8 @@ msgstr "シリアル・ポート・パススルー 3"
 msgid "Serial port passthrough 4"
 msgstr "シリアル・ポート・パススルー 4"
 
-msgid "Renderer options..."
-msgstr "レンダラー設定..."
+msgid "Renderer &options..."
+msgstr "レンダラー設定...(&O)"
 
 msgid "PC/XT Keyboard"
 msgstr ""

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -63,8 +63,8 @@ msgstr "OpenGL (3.0 Core)(&G)"
 msgid "&VNC"
 msgstr "VNC(&V)"
 
-msgid "Specify dimensions..."
-msgstr "창 크기 지정하기..."
+msgid "Specify &dimensions..."
+msgstr "창 크기 지정하기...(&D)"
 
 msgid "F&orce 4:3 display ratio"
 msgstr "화면 비율을 4:3으로 맞추기(&O)"
@@ -102,8 +102,8 @@ msgstr "7배(&7)"
 msgid "&8x"
 msgstr "8배(&8)"
 
-msgid "Filter method"
-msgstr "필터 형식"
+msgid "Fi&lter method"
+msgstr "필터 형식(&L)"
 
 msgid "&Nearest"
 msgstr "최근방 이웃 보간법(&N)"
@@ -675,6 +675,9 @@ msgstr "속도"
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr "%1 MB (CHS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "플로피 %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "플로피 %1 (%2): %3(&F)"
+
 msgid "Advanced sector images"
 msgstr "어드밴스드 섹터 이미지"
 
@@ -881,6 +887,9 @@ msgstr "GhostPCL를 초기화할 수 없습니다"
 
 msgid "MO %1 (%2): %3"
 msgstr "광자기 %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "광자기 %1 (%2): %3(&M)"
 
 msgid "MO images"
 msgstr "광자기 이미지"
@@ -966,11 +975,17 @@ msgstr "계속"
 msgid "Cassette: %1"
 msgstr "카세트: %1"
 
+msgid "C&assette: %1"
+msgstr "카세트: %1(&A)"
+
 msgid "Cassette images"
 msgstr "카세트 이미지"
 
 msgid "Cartridge %1: %2"
 msgstr "카트리지 %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "카트리지 %1: %2(&T)"
 
 msgid "Cartridge images"
 msgstr "카트리지 이미지"
@@ -992,6 +1007,9 @@ msgstr "재시작"
 
 msgid "ACPI shutdown"
 msgstr "ACPI 종료"
+
+msgid "ACP&I shutdown"
+msgstr "ACP&I 종료"
 
 msgid "Hard disk (%1)"
 msgstr "하드 디스크 (%1)"
@@ -1278,41 +1296,41 @@ msgstr "MCA 장치"
 msgid "List of MCA devices:"
 msgstr "MCA 장치 목록:"
 
-msgid "Tablet tool"
-msgstr "태블릿 도구"
+msgid "&Tablet tool"
+msgstr "태블릿 도구(&T)"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt(OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "Qt 소개"
+msgid "About &Qt"
+msgstr "&Qt 소개"
 
-msgid "MCA devices..."
-msgstr "MCA 장치..."
+msgid "&MCA devices..."
+msgstr "&MCA 장치..."
 
-msgid "Show non-primary monitors"
-msgstr "기본 모니터가 아닌 모니터 표시"
+msgid "Show non-&primary monitors"
+msgstr "기본 모니터가 아닌 모니터 표시(&P)"
 
-msgid "Open screenshots folder..."
-msgstr "스크린샷 폴더 열기..."
+msgid "Open screenshots &folder..."
+msgstr "스크린샷 폴더 열기...(&F)"
 
-msgid "Apply fullscreen stretch mode when maximized"
-msgstr "최대화 시 전체 화면 비율 적용"
+msgid "Appl&y fullscreen stretch mode when maximized"
+msgstr "최대화 시 전체 화면 비율 적용(&Y)"
 
-msgid "Cursor/Puck"
-msgstr "커서/퍽"
+msgid "&Cursor/Puck"
+msgstr "커서/퍽(&P)"
 
-msgid "Pen"
-msgstr "펜"
+msgid "&Pen"
+msgstr "펜(&P)"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "호스트 CD/DVD 드라이브(%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "호스트 CD/DVD 드라이브(%1:) (&H)"
 
 msgid "&Connected"
 msgstr "&커넥티드"
 
-msgid "Clear image history"
-msgstr "이미지 기록 지우기"
+msgid "Clear image &history"
+msgstr "이미지 기록 지우기(&H)"
 
 msgid "Create..."
 msgstr "만들기..."
@@ -1328,6 +1346,9 @@ msgstr "Null 드라이버"
 
 msgid "NIC %1 (%2) %3"
 msgstr "NIC %1 (%2) %3"
+
+msgid "&NIC %1 (%2) %3"
+msgstr "&NIC %1 (%2) %3"
 
 msgid "Render behavior"
 msgstr "렌더링 동작"
@@ -1434,8 +1455,8 @@ msgstr "직렬 포트 패스스루 3"
 msgid "Serial port passthrough 4"
 msgstr "직렬 포트 패스스루 4"
 
-msgid "Renderer options..."
-msgstr "렌더러 옵션..."
+msgid "Renderer &options..."
+msgstr "렌더러 옵션...(&O)"
 
 msgid "PC/XT Keyboard"
 msgstr ""

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -63,7 +63,7 @@ msgstr "Open&GL (3.0 Core)"
 msgid "&VNC"
 msgstr "&VNC"
 
-msgid "Specify dimensions..."
+msgid "Specify &dimensions..."
 msgstr "Afmetingen opgeven..."
 
 msgid "F&orce 4:3 display ratio"
@@ -102,7 +102,7 @@ msgstr "&7x"
 msgid "&8x"
 msgstr "&8x"
 
-msgid "Filter method"
+msgid "Fi&lter method"
 msgstr "Filtermethode"
 
 msgid "&Nearest"
@@ -675,6 +675,9 @@ msgstr "Snelheid"
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr "%1 MB (CHS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "Floppy %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "&Floppy %1 (%2): %3"
+
 msgid "Advanced sector images"
 msgstr "Geavanceerde sector-images"
 
@@ -881,6 +887,9 @@ msgstr "Kan GhostPCL niet initialiseren"
 
 msgid "MO %1 (%2): %3"
 msgstr "MO %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "&MO %1 (%2): %3"
 
 msgid "MO images"
 msgstr "MO-images"
@@ -966,11 +975,17 @@ msgstr "Doorgaan"
 msgid "Cassette: %1"
 msgstr "Cassette: %1"
 
+msgid "C&assette: %1"
+msgstr "C&assette: %1"
+
 msgid "Cassette images"
 msgstr "Cassette-images"
 
 msgid "Cartridge %1: %2"
 msgstr "Cartridge %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "Car&tridge %1: %2"
 
 msgid "Cartridge images"
 msgstr "Cartridge-images"
@@ -992,6 +1007,9 @@ msgstr "Harde reset"
 
 msgid "ACPI shutdown"
 msgstr "ACPI uitschakeling"
+
+msgid "ACP&I shutdown"
+msgstr "ACP&I uitschakeling"
 
 msgid "Hard disk (%1)"
 msgstr "Harde schijf (%1)"
@@ -1140,6 +1158,9 @@ msgstr "ATAPI"
 msgid "CD-ROM %1 (%2): %3"
 msgstr "CD-ROM %1 (%2): %3"
 
+msgid "&CD-ROM %1 (%2): %3"
+msgstr "&CD-ROM %1 (%2): %3"
+
 msgid "160 KB"
 msgstr "160 KB"
 
@@ -1278,41 +1299,41 @@ msgstr "MCA-apparaten"
 msgid "List of MCA devices:"
 msgstr "Lijst van MCA-apparaten:"
 
-msgid "Tablet tool"
+msgid "&Tablet tool"
 msgstr "Tablet-hulpmiddel"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "Over Qt"
+msgid "About &Qt"
+msgstr "Over &Qt"
 
-msgid "MCA devices..."
+msgid "&MCA devices..."
 msgstr "MCA-apparaten..."
 
-msgid "Show non-primary monitors"
+msgid "Show non-&primary monitors"
 msgstr "Toon niet-primaire monitors"
 
-msgid "Open screenshots folder..."
+msgid "Open screenshots &folder..."
 msgstr "Map met schermafbeeldingen openen..."
 
-msgid "Apply fullscreen stretch mode when maximized"
+msgid "Appl&y fullscreen stretch mode when maximized"
 msgstr "Schakel de volledig scherm-uitrekmodus in bij maximaliseren"
 
-msgid "Cursor/Puck"
-msgstr "Cursor/Puck"
+msgid "&Cursor/Puck"
+msgstr "&Cursor/Puck"
 
-msgid "Pen"
-msgstr "Pen"
+msgid "&Pen"
+msgstr "&Pen"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "Host cd/dvd-station (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "&Host cd/dvd-station (%1:)"
 
 msgid "&Connected"
 msgstr "&Verbonden"
 
-msgid "Clear image history"
-msgstr "Imagegeschiedenis verwijderen"
+msgid "Clear image &history"
+msgstr "Imagegeschiedenis verwijderen(&H)"
 
 msgid "Create..."
 msgstr "Creëer..."
@@ -1328,6 +1349,9 @@ msgstr "Null Driver"
 
 msgid "NIC %1 (%2) %3"
 msgstr "NIC %1 (%2) %3"
+
+msgid "&NIC %1 (%2) %3"
+msgstr "&NIC %1 (%2) %3"
 
 msgid "Render behavior"
 msgstr "Rendergedrag"
@@ -1434,7 +1458,7 @@ msgstr "Seriële poort doorvoer 3"
 msgid "Serial port passthrough 4"
 msgstr "Seriële poort doorvoer 4"
 
-msgid "Renderer options..."
+msgid "Renderer &options..."
 msgstr "Renderer-opties..."
 
 msgid "PC/XT Keyboard"

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -63,7 +63,7 @@ msgstr "Open&GL (3.0 Core)"
 msgid "&VNC"
 msgstr "&VNC"
 
-msgid "Specify dimensions..."
+msgid "Specify &dimensions..."
 msgstr "Określ wymiary..."
 
 msgid "F&orce 4:3 display ratio"
@@ -102,7 +102,7 @@ msgstr "&7x"
 msgid "&8x"
 msgstr "&8x"
 
-msgid "Filter method"
+msgid "Fi&lter method"
 msgstr "Metoda filtrowania"
 
 msgid "&Nearest"
@@ -675,6 +675,9 @@ msgstr "Szybkość"
 msgid "Removable disk %1 (%2): %3"
 msgstr "Dysk wymienny %1 (%2): %3"
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr "Dysk &wymienny %1 (%2): %3"
+
 msgid "Removable disk images"
 msgstr "Obrazy dysków wymiennych"
 
@@ -861,6 +864,9 @@ msgstr "%1 MB (CHS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "Dyskietka %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "&Dyskietka %1 (%2): %3"
+
 msgid "Advanced sector images"
 msgstr "Zaawansowane obrazy sektorów"
 
@@ -881,6 +887,9 @@ msgstr "Nie można zainicjować GhostPCL"
 
 msgid "MO %1 (%2): %3"
 msgstr "MO %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "&MO %1 (%2): %3"
 
 msgid "MO images"
 msgstr "Obrazy MO"
@@ -966,11 +975,17 @@ msgstr "Kontynuuj"
 msgid "Cassette: %1"
 msgstr "Kaseta: %1"
 
+msgid "C&assette: %1"
+msgstr "K&aseta: %1"
+
 msgid "Cassette images"
 msgstr "Obrazy kaset"
 
 msgid "Cartridge %1: %2"
 msgstr "Kartridż %1: %2"
+
+msgid "Cart&ridge %1: %2"
+msgstr "Kar&tridż %1: %2"
 
 msgid "Cartridge images"
 msgstr "Obrazy kartridżów"
@@ -992,6 +1007,9 @@ msgstr "Twardy reset"
 
 msgid "ACPI shutdown"
 msgstr "Wyłączenie ACPI"
+
+msgid "ACP&I shutdown"
+msgstr "Wyłączenie ACP&I"
 
 msgid "Hard disk (%1)"
 msgstr "Dysk twardy (%1)"
@@ -1140,6 +1158,9 @@ msgstr "ATAPI"
 msgid "CD-ROM %1 (%2): %3"
 msgstr "CD-ROM %1 (%2): %3"
 
+msgid "&CD-ROM %1 (%2): %3"
+msgstr "&CD-ROM %1 (%2): %3"
+
 msgid "160 KB"
 msgstr "160 KB"
 
@@ -1278,41 +1299,41 @@ msgstr "Urządzenia MCA"
 msgid "List of MCA devices:"
 msgstr "Lista urządzeń MCA:"
 
-msgid "Tablet tool"
+msgid "&Tablet tool"
 msgstr "Narzędzie do tabletów"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "O Qt"
+msgid "About &Qt"
+msgstr "O &Qt"
 
-msgid "MCA devices..."
+msgid "&MCA devices..."
 msgstr "Urządzenia MCA..."
 
-msgid "Show non-primary monitors"
+msgid "Show non-&primary monitors"
 msgstr "Pokaż monitory inne niż podstawowe"
 
-msgid "Open screenshots folder..."
+msgid "Open screenshots &folder..."
 msgstr "Otwórz folder zrzutów ekranu..."
 
-msgid "Apply fullscreen stretch mode when maximized"
+msgid "Appl&y fullscreen stretch mode when maximized"
 msgstr "Zastosowanie trybu rozciągania na pełnym ekranie w stanie zmaksymalizowanym"
 
-msgid "Cursor/Puck"
-msgstr "Kursor/krążek"
+msgid "&Cursor/Puck"
+msgstr "&Kursor/krążek"
 
-msgid "Pen"
-msgstr "Pióro"
+msgid "&Pen"
+msgstr "P&ióro"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "Napęd CD/DVD hosta (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "&Napęd CD/DVD hosta (%1:)"
 
 msgid "&Connected"
 msgstr "&Podłączone"
 
-msgid "Clear image history"
-msgstr "Wyczyść historię obrazów"
+msgid "Clear image &history"
+msgstr "Wyczyść historię obrazów(&H)"
 
 msgid "Create..."
 msgstr "Stwórz..."
@@ -1328,6 +1349,9 @@ msgstr "Null Driver"
 
 msgid "NIC %1 (%2) %3"
 msgstr "NIC %1 (%2) %3"
+
+msgid "&NIC %1 (%2) %3"
+msgstr "&NIC %1 (%2) %3"
 
 msgid "Render behavior"
 msgstr "Zachowanie renderowania"
@@ -1434,7 +1458,7 @@ msgstr "Przelotka portu szeregowego 3"
 msgid "Serial port passthrough 4"
 msgstr "Przelotka portu szeregowego 4"
 
-msgid "Renderer options..."
+msgid "Renderer &options..."
 msgstr "Opcje renderowania..."
 
 msgid "PC/XT Keyboard"

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -63,7 +63,7 @@ msgstr "Open&GL (Núcleo 3.0)"
 msgid "&VNC"
 msgstr "&VNC"
 
-msgid "Specify dimensions..."
+msgid "Specify &dimensions..."
 msgstr "Especificar as dimensões..."
 
 msgid "F&orce 4:3 display ratio"
@@ -102,7 +102,7 @@ msgstr "&7x"
 msgid "&8x"
 msgstr "&8x"
 
-msgid "Filter method"
+msgid "Fi&lter method"
 msgstr "Método de filtragem"
 
 msgid "&Nearest"
@@ -675,6 +675,9 @@ msgstr "Velocidade"
 msgid "Removable disk %1 (%2): %3"
 msgstr "Disco removível %1 (%2): %3"
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr "Disco &removível %1 (%2): %3"
+
 msgid "Removable disk images"
 msgstr "Imagens de disco removível"
 
@@ -861,6 +864,9 @@ msgstr "%1 MB (CCS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "Disquete %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "&Disquete %1 (%2): %3"
+
 msgid "Advanced sector images"
 msgstr "Imagens de setor avançado"
 
@@ -881,6 +887,9 @@ msgstr "Não foi possível inicializar o GhostPCL"
 
 msgid "MO %1 (%2): %3"
 msgstr "Magneto-óptico %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "&Magneto-óptico %1 (%2): %3"
 
 msgid "MO images"
 msgstr "Imagens magneto-ópticas"
@@ -966,11 +975,17 @@ msgstr "Continuar"
 msgid "Cassette: %1"
 msgstr "Cassete: %1"
 
+msgid "C&assette: %1"
+msgstr "C&assete: %1"
+
 msgid "Cassette images"
 msgstr "Imagens de cassete"
 
 msgid "Cartridge %1: %2"
 msgstr "Cartucho %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "Car&tucho %1: %2"
 
 msgid "Cartridge images"
 msgstr "Imagens de cartucho"
@@ -992,6 +1007,9 @@ msgstr "Reinicialização completa"
 
 msgid "ACPI shutdown"
 msgstr "Desligamento por ACPI"
+
+msgid "ACP&I shutdown"
+msgstr "Desligamento por ACP&I"
 
 msgid "Hard disk (%1)"
 msgstr "Disco rígido (%1)"
@@ -1140,6 +1158,9 @@ msgstr "ATAPI"
 msgid "CD-ROM %1 (%2): %3"
 msgstr "CD-ROM %1 (%2): %3"
 
+msgid "&CD-ROM %1 (%2): %3"
+msgstr "&CD-ROM %1 (%2): %3"
+
 msgid "160 KB"
 msgstr "160 KB"
 
@@ -1278,41 +1299,41 @@ msgstr "Dispositivos MCA"
 msgid "List of MCA devices:"
 msgstr "Lista de dispositivos MCA:"
 
-msgid "Tablet tool"
+msgid "&Tablet tool"
 msgstr "Ferramenta para tablet"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "Sobre o Qt"
+msgid "About &Qt"
+msgstr "Sobre o &Qt"
 
-msgid "MCA devices..."
+msgid "&MCA devices..."
 msgstr "Dispositivos MCA..."
 
-msgid "Show non-primary monitors"
+msgid "Show non-&primary monitors"
 msgstr "Mostrar monitores não primários"
 
-msgid "Open screenshots folder..."
+msgid "Open screenshots &folder..."
 msgstr "Abrir pasta de capturas de tela..."
 
-msgid "Apply fullscreen stretch mode when maximized"
+msgid "Appl&y fullscreen stretch mode when maximized"
 msgstr "Aplicar modo de ampliação em tela cheia quando maximizado"
 
-msgid "Cursor/Puck"
-msgstr "Cursor/Puck"
+msgid "&Cursor/Puck"
+msgstr "&Cursor/Puck"
 
-msgid "Pen"
-msgstr "Caneta"
+msgid "&Pen"
+msgstr "C&aneta"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "Unidade de CD/DVD do anfitrião (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "&Unidade de CD/DVD do anfitrião (%1:)"
 
 msgid "&Connected"
 msgstr "&Conectado"
 
-msgid "Clear image history"
-msgstr "Limpar histórico de imagens"
+msgid "Clear image &history"
+msgstr "Limpar histórico de imagens(&H)"
 
 msgid "Create..."
 msgstr "Criar..."
@@ -1328,6 +1349,9 @@ msgstr "Driver nulo"
 
 msgid "NIC %1 (%2) %3"
 msgstr "NIC %1 (%2) %3"
+
+msgid "&NIC %1 (%2) %3"
+msgstr "&NIC %1 (%2) %3"
 
 msgid "Render behavior"
 msgstr "Comportamento de renderização"
@@ -1434,7 +1458,7 @@ msgstr "Passagem de porta serial 3"
 msgid "Serial port passthrough 4"
 msgstr "Passagem de porta serial 4"
 
-msgid "Renderer options..."
+msgid "Renderer &options..."
 msgstr "Opções do renderizador..."
 
 msgid "PC/XT Keyboard"

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -63,7 +63,7 @@ msgstr "Open&GL (Núcleo 3.0)"
 msgid "&VNC"
 msgstr "&VNC"
 
-msgid "Specify dimensions..."
+msgid "Specify &dimensions..."
 msgstr "&Especificar dimensões..."
 
 msgid "F&orce 4:3 display ratio"
@@ -102,7 +102,7 @@ msgstr "&7x"
 msgid "&8x"
 msgstr "&8x"
 
-msgid "Filter method"
+msgid "Fi&lter method"
 msgstr "Método de filtragem"
 
 msgid "&Nearest"
@@ -675,6 +675,9 @@ msgstr "Velocidade"
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr "%1 MB (CCS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "Disquete %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "&Disquete %1 (%2): %3"
+
 msgid "Advanced sector images"
 msgstr "Imagens avançadas de sector"
 
@@ -881,6 +887,9 @@ msgstr "Não foi possível inicializar o GhostPCL"
 
 msgid "MO %1 (%2): %3"
 msgstr "Magneto-óptico %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "&Magneto-óptico %1 (%2): %3"
 
 msgid "MO images"
 msgstr "Imagens magneto-ópticas"
@@ -966,11 +975,17 @@ msgstr "Continuar"
 msgid "Cassette: %1"
 msgstr "Cassete: %1"
 
+msgid "C&assette: %1"
+msgstr "C&assete: %1"
+
 msgid "Cassette images"
 msgstr "Imagens de cassete"
 
 msgid "Cartridge %1: %2"
 msgstr "Cartucho %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "Car&tucho %1: %2"
 
 msgid "Cartridge images"
 msgstr "Imagens de cartucho"
@@ -992,6 +1007,9 @@ msgstr "Reinicialização completa"
 
 msgid "ACPI shutdown"
 msgstr "Encerramento ACPI"
+
+msgid "ACP&I shutdown"
+msgstr "Encerramento ACP&I"
 
 msgid "Hard disk (%1)"
 msgstr "Disco rígido (%1)"
@@ -1140,6 +1158,9 @@ msgstr "ATAPI"
 msgid "CD-ROM %1 (%2): %3"
 msgstr "CD-ROM %1 (%2): %3"
 
+msgid "&CD-ROM %1 (%2): %3"
+msgstr "&CD-ROM %1 (%2): %3"
+
 msgid "160 KB"
 msgstr "160 KB"
 
@@ -1278,41 +1299,41 @@ msgstr "Dispositivos MCA"
 msgid "List of MCA devices:"
 msgstr "Lista de dispositivos MCA:"
 
-msgid "Tablet tool"
+msgid "&Tablet tool"
 msgstr "Ferramenta para tablet"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "Acerca do Qt"
+msgid "About &Qt"
+msgstr "Acerca do &Qt"
 
-msgid "MCA devices..."
+msgid "&MCA devices..."
 msgstr "Dispositivos MCA..."
 
-msgid "Show non-primary monitors"
+msgid "Show non-&primary monitors"
 msgstr "Mostrar monitores não primários"
 
-msgid "Open screenshots folder..."
+msgid "Open screenshots &folder..."
 msgstr "Abrir a pasta de capturas de ecrã..."
 
-msgid "Apply fullscreen stretch mode when maximized"
+msgid "Appl&y fullscreen stretch mode when maximized"
 msgstr "Aplicar o modo de estiramento na tela cheia quando maximizado"
 
-msgid "Cursor/Puck"
-msgstr "Cursor/Puck"
+msgid "&Cursor/Puck"
+msgstr "&Cursor/Puck"
 
-msgid "Pen"
-msgstr "Caneta"
+msgid "&Pen"
+msgstr "C&aneta"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "Unidade de CD/DVD do anfitrião (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "&Unidade de CD/DVD do anfitrião (%1:)"
 
 msgid "&Connected"
 msgstr "&Conectado"
 
-msgid "Clear image history"
-msgstr "Limpar o histórico de imagens"
+msgid "Clear image &history"
+msgstr "Limpar o histórico de imagens(&H)"
 
 msgid "Create..."
 msgstr "Criar..."
@@ -1328,6 +1349,9 @@ msgstr "Condutor nulo"
 
 msgid "NIC %1 (%2) %3"
 msgstr "NIC %1 (%2) %3"
+
+msgid "&NIC %1 (%2) %3"
+msgstr "&NIC %1 (%2) %3"
 
 msgid "Render behavior"
 msgstr "Comportamento de renderização"
@@ -1434,7 +1458,7 @@ msgstr "Passagem da porta de série 3"
 msgid "Serial port passthrough 4"
 msgstr "Passagem da porta de série 4"
 
-msgid "Renderer options..."
+msgid "Renderer &options..."
 msgstr "Opções do renderizador..."
 
 msgid "PC/XT Keyboard"

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -63,7 +63,7 @@ msgstr "Open&GL (3.0 Core)"
 msgid "&VNC"
 msgstr "&VNC"
 
-msgid "Specify dimensions..."
+msgid "Specify &dimensions..."
 msgstr "&Указать размеры главного окна..."
 
 msgid "F&orce 4:3 display ratio"
@@ -102,8 +102,8 @@ msgstr "&7x"
 msgid "&8x"
 msgstr "&8x"
 
-msgid "Filter method"
-msgstr "Метод фильтрации"
+msgid "Fi&lter method"
+msgstr "Метод &фильтрации"
 
 msgid "&Nearest"
 msgstr "&Ближайший"
@@ -675,6 +675,9 @@ msgstr "Скорость"
 msgid "Removable disk %1 (%2): %3"
 msgstr "Съёмный диск %1 (%2): %3"
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr "&Съёмный диск %1 (%2): %3"
+
 msgid "Removable disk images"
 msgstr "Образы съёмных дисков"
 
@@ -861,6 +864,9 @@ msgstr "%1 МБ (CHS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "Дисковод %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "&Дисковод %1 (%2): %3"
+
 msgid "Advanced sector images"
 msgstr "Расширенные образы секторов"
 
@@ -881,6 +887,9 @@ msgstr "Невозможно инициализировать GhostPCL"
 
 msgid "MO %1 (%2): %3"
 msgstr "Магнитооптический %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "&Магнитооптический %1 (%2): %3"
 
 msgid "MO images"
 msgstr "Образы магнитооптических дисков"
@@ -966,11 +975,17 @@ msgstr "Продолжить"
 msgid "Cassette: %1"
 msgstr "Кассета: %1"
 
+msgid "C&assette: %1"
+msgstr "&Кассета: %1"
+
 msgid "Cassette images"
 msgstr "Образы кассет"
 
 msgid "Cartridge %1: %2"
 msgstr "Картридж %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "Кар&тридж %1: %2"
 
 msgid "Cartridge images"
 msgstr "Образы картриджей"
@@ -992,6 +1007,9 @@ msgstr "Холодная перезагрузка"
 
 msgid "ACPI shutdown"
 msgstr "Сигнал завершения ACPI"
+
+msgid "ACP&I shutdown"
+msgstr "Сигнал завершения ACP&I"
 
 msgid "Hard disk (%1)"
 msgstr "Жёсткий диск (%1)"
@@ -1140,6 +1158,9 @@ msgstr "ATAPI"
 msgid "CD-ROM %1 (%2): %3"
 msgstr "CD-ROM %1 (%2): %3"
 
+msgid "&CD-ROM %1 (%2): %3"
+msgstr "&CD-ROM %1 (%2): %3"
+
 msgid "160 KB"
 msgstr "160 КБ"
 
@@ -1278,41 +1299,41 @@ msgstr "Устройства MCA"
 msgid "List of MCA devices:"
 msgstr "Список устройств MCA:"
 
-msgid "Tablet tool"
-msgstr "Планшетный инструмент"
+msgid "&Tablet tool"
+msgstr "Планшетный &инструмент"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "О Qt"
+msgid "About &Qt"
+msgstr "О &Qt"
 
-msgid "MCA devices..."
-msgstr "Устройства MCA..."
+msgid "&MCA devices..."
+msgstr "Устройства &MCA..."
 
-msgid "Show non-primary monitors"
+msgid "Show non-&primary monitors"
 msgstr "&Показывать неосновные мониторы"
 
-msgid "Open screenshots folder..."
-msgstr "Открыть папку скриншотов..."
+msgid "Open screenshots &folder..."
+msgstr "Открыть папку &скриншотов..."
 
-msgid "Apply fullscreen stretch mode when maximized"
-msgstr "Применить полноэкранный режим растяжения при разворачивании окна"
+msgid "Appl&y fullscreen stretch mode when maximized"
+msgstr "Применить полно&экранный режим растяжения при разворачивании окна"
 
-msgid "Cursor/Puck"
-msgstr "Курсор/шайба"
+msgid "&Cursor/Puck"
+msgstr "&Курсор/шайба"
 
-msgid "Pen"
-msgstr "Ручка"
+msgid "&Pen"
+msgstr "&Ручка"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "CD/DVD Привод хоста (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "CD/DVD Привод &хоста (%1:)"
 
 msgid "&Connected"
 msgstr "&Кабель подключен"
 
-msgid "Clear image history"
-msgstr "Очистить историю образов"
+msgid "Clear image &history"
+msgstr "Очистить &историю образов"
 
 msgid "Create..."
 msgstr "Создать..."
@@ -1328,6 +1349,9 @@ msgstr "Нулевой драйвер"
 
 msgid "NIC %1 (%2) %3"
 msgstr "NIC %1 (%2) %3"
+
+msgid "&NIC %1 (%2) %3"
+msgstr "&NIC %1 (%2) %3"
 
 msgid "Render behavior"
 msgstr "Режим рендеринга"
@@ -1434,8 +1458,8 @@ msgstr "Сквозной последовательный порт COM3"
 msgid "Serial port passthrough 4"
 msgstr "Сквозной последовательный порт COM4"
 
-msgid "Renderer options..."
-msgstr "Параметры рендеринга..."
+msgid "Renderer &options..."
+msgstr "Параметры &рендеринга..."
 
 msgid "PC/XT Keyboard"
 msgstr "Клавиатура PC/XT"

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -63,7 +63,7 @@ msgstr "Open&GL (3.0 Core)"
 msgid "&VNC"
 msgstr "&VNC"
 
-msgid "Specify dimensions..."
+msgid "Specify &dimensions..."
 msgstr "&Zadať veľkosť..."
 
 msgid "F&orce 4:3 display ratio"
@@ -102,7 +102,7 @@ msgstr "&7x"
 msgid "&8x"
 msgstr "&8x"
 
-msgid "Filter method"
+msgid "Fi&lter method"
 msgstr "Spôsob &filtrovania"
 
 msgid "&Nearest"
@@ -675,6 +675,9 @@ msgstr "Rýchlosť"
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr "%1 MB (CHS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "Disketová mechanika %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "&Disketová mechanika %1 (%2): %3"
+
 msgid "Advanced sector images"
 msgstr "Rozšírené sektorové obrazy"
 
@@ -881,6 +887,9 @@ msgstr "Nastala chyba pri inicializácii knižnice GhostPCL"
 
 msgid "MO %1 (%2): %3"
 msgstr "MO %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "&MO %1 (%2): %3"
 
 msgid "MO images"
 msgstr "Obrazy MO"
@@ -966,11 +975,17 @@ msgstr "Pokračovať"
 msgid "Cassette: %1"
 msgstr "Kazeta: %1"
 
+msgid "C&assette: %1"
+msgstr "K&azeta: %1"
+
 msgid "Cassette images"
 msgstr "Kazetové nahrávky"
 
 msgid "Cartridge %1: %2"
 msgstr "Cartridge %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "Car&tridge %1: %2"
 
 msgid "Cartridge images"
 msgstr "Obrazy cartridge"
@@ -992,6 +1007,9 @@ msgstr "Resetovať"
 
 msgid "ACPI shutdown"
 msgstr "Vypnúť cez rozhranie ACPI"
+
+msgid "ACP&I shutdown"
+msgstr "Vypnúť cez rozhranie ACP&I"
 
 msgid "Hard disk (%1)"
 msgstr "Pevný disk (%1)"
@@ -1278,40 +1296,40 @@ msgstr "Zariadenia MCA"
 msgid "List of MCA devices:"
 msgstr "Zoznam zariadení MCA:"
 
-msgid "Tablet tool"
+msgid "&Tablet tool"
 msgstr "Nástroj pre tablety"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "O Qt"
+msgid "About &Qt"
+msgstr "O &Qt"
 
-msgid "MCA devices..."
+msgid "&MCA devices..."
 msgstr "Zariadenia MCA..."
 
-msgid "Show non-primary monitors"
+msgid "Show non-&primary monitors"
 msgstr "Zobrazenie iných ako primárnych monitorov"
 
-msgid "Open screenshots folder..."
+msgid "Open screenshots &folder..."
 msgstr "Otvorte priečinok so snímkami obrazovky..."
 
-msgid "Apply fullscreen stretch mode when maximized"
+msgid "Appl&y fullscreen stretch mode when maximized"
 msgstr "Použitie režimu roztiahnutia na celú obrazovku pri maximalizácii"
 
-msgid "Cursor/Puck"
-msgstr "Kurzor/Puck"
+msgid "&Cursor/Puck"
+msgstr "&Kurzor/Puck"
 
-msgid "Pen"
-msgstr "Pero"
+msgid "&Pen"
+msgstr "&Pero"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "Hostiteľská jednotka CD/DVD (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "&Hostiteľská jednotka CD/DVD (%1:)"
 
 msgid "&Connected"
 msgstr ""
 
-msgid "Clear image history"
+msgid "Clear image &history"
 msgstr "Vymazanie histórie obrázkov"
 
 msgid "Create..."
@@ -1434,7 +1452,7 @@ msgstr "Priechod sériového portu 3"
 msgid "Serial port passthrough 4"
 msgstr "Priechod cez sériový port 4"
 
-msgid "Renderer options..."
+msgid "Renderer &options..."
 msgstr "Možnosti vykresľovača..."
 
 msgid "PC/XT Keyboard"

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -63,7 +63,7 @@ msgstr "Open&GL (jedro 3.0)"
 msgid "&VNC"
 msgstr "&VNC"
 
-msgid "Specify dimensions..."
+msgid "Specify &dimensions..."
 msgstr "&Določi velikost..."
 
 msgid "F&orce 4:3 display ratio"
@@ -102,7 +102,7 @@ msgstr "&7x"
 msgid "&8x"
 msgstr "&8x"
 
-msgid "Filter method"
+msgid "Fi&lter method"
 msgstr "&Vrsta filtriranja"
 
 msgid "&Nearest"
@@ -675,6 +675,9 @@ msgstr "Hitrost"
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr "%1 MB (CHS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "Disketa %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "&Disketa %1 (%2): %3"
+
 msgid "Advanced sector images"
 msgstr "Napredne sektorske slike"
 
@@ -881,6 +887,9 @@ msgstr "GhostPCL-ja ni bilo mogoče inicializirati"
 
 msgid "MO %1 (%2): %3"
 msgstr "MO %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "&MO %1 (%2): %3"
 
 msgid "MO images"
 msgstr "Slike MO"
@@ -966,11 +975,17 @@ msgstr "Nadaljuj"
 msgid "Cassette: %1"
 msgstr "Kaseta: %1"
 
+msgid "C&assette: %1"
+msgstr "K&aseta: %1"
+
 msgid "Cassette images"
 msgstr "Slike kaset"
 
 msgid "Cartridge %1: %2"
 msgstr "Spominski vložek %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "S&pominski vložek %1: %2"
 
 msgid "Cartridge images"
 msgstr "Slike spominskega vložka"
@@ -992,6 +1007,9 @@ msgstr "Ponovni zagon"
 
 msgid "ACPI shutdown"
 msgstr "Zaustavitev ACPI"
+
+msgid "ACP&I shutdown"
+msgstr "Zaustavitev ACP&I"
 
 msgid "Hard disk (%1)"
 msgstr "Trdi disk (%1)"
@@ -1278,40 +1296,40 @@ msgstr "Naprave MCA"
 msgid "List of MCA devices:"
 msgstr "Seznam naprav MCA:"
 
-msgid "Tablet tool"
+msgid "&Tablet tool"
 msgstr "Orodje za tablico"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "O programu Qt"
+msgid "About &Qt"
+msgstr "O programu &Qt"
 
-msgid "MCA devices..."
+msgid "&MCA devices..."
 msgstr "Naprave MCA..."
 
-msgid "Show non-primary monitors"
+msgid "Show non-&primary monitors"
 msgstr "Prikaži neprimarne monitorje"
 
-msgid "Open screenshots folder..."
+msgid "Open screenshots &folder..."
 msgstr "Odprite mapo s posnetki zaslona..."
 
-msgid "Apply fullscreen stretch mode when maximized"
+msgid "Appl&y fullscreen stretch mode when maximized"
 msgstr "Uporabi način celozaslonskega raztezanja v maksimiranem stanju"
 
-msgid "Cursor/Puck"
-msgstr "Kazalec/ključ"
+msgid "&Cursor/Puck"
+msgstr "&Kazalec/ključ"
 
-msgid "Pen"
-msgstr "Pisalo"
+msgid "&Pen"
+msgstr "&Pisalo"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "Gostiteljski pogon CD/DVD (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "&Gostiteljski pogon CD/DVD (%1:)"
 
 msgid "&Connected"
 msgstr "&Povezan"
 
-msgid "Clear image history"
+msgid "Clear image &history"
 msgstr "Počisti zgodovino slik"
 
 msgid "Create..."
@@ -1434,7 +1452,7 @@ msgstr "Prepust za serijska vrata 3"
 msgid "Serial port passthrough 4"
 msgstr "Prepust za serijska vrata 4"
 
-msgid "Renderer options..."
+msgid "Renderer &options..."
 msgstr "Možnosti sistema za upodabljanje..."
 
 msgid "PC/XT Keyboard"

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -63,7 +63,7 @@ msgstr "Open&GL (3.0 Core)"
 msgid "&VNC"
 msgstr "&VNC"
 
-msgid "Specify dimensions..."
+msgid "Specify &dimensions..."
 msgstr "Ange mått..."
 
 msgid "F&orce 4:3 display ratio"
@@ -102,7 +102,7 @@ msgstr "&7x"
 msgid "&8x"
 msgstr "&8x"
 
-msgid "Filter method"
+msgid "Fi&lter method"
 msgstr "Filtermetod"
 
 msgid "&Nearest"
@@ -675,6 +675,9 @@ msgstr "Hastighet"
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr "%1 MB (CHS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "Diskett %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "&Diskett %1 (%2): %3"
+
 msgid "Advanced sector images"
 msgstr "Avancerade sektoravbildningar"
 
@@ -881,6 +887,9 @@ msgstr "Ej möjligt att initialisera GhostPCL"
 
 msgid "MO %1 (%2): %3"
 msgstr "MO %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "&MO %1 (%2): %3"
 
 msgid "MO images"
 msgstr "MO-avbildningar"
@@ -966,11 +975,17 @@ msgstr "Fortsätt"
 msgid "Cassette: %1"
 msgstr "Kassettband: %1"
 
+msgid "C&assette: %1"
+msgstr "K&assettband: %1"
+
 msgid "Cassette images"
 msgstr "Kassettbandsavbildningar"
 
 msgid "Cartridge %1: %2"
 msgstr "Kassett %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "Ka&ssett %1: %2"
 
 msgid "Cartridge images"
 msgstr "Kassettavbildningar"
@@ -992,6 +1007,9 @@ msgstr "Hård omstart"
 
 msgid "ACPI shutdown"
 msgstr "ACPI-avstängning"
+
+msgid "ACP&I shutdown"
+msgstr "ACP&I-avstängning"
 
 msgid "Hard disk (%1)"
 msgstr "Hårddisk (%1)"
@@ -1278,40 +1296,40 @@ msgstr "MCA-enheter"
 msgid "List of MCA devices:"
 msgstr "Lista på MCA-enheter:"
 
-msgid "Tablet tool"
+msgid "&Tablet tool"
 msgstr "Plattverktyg"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "Om Qt"
+msgid "About &Qt"
+msgstr "Om &Qt"
 
-msgid "MCA devices..."
+msgid "&MCA devices..."
 msgstr "MCA-enheter..."
 
-msgid "Show non-primary monitors"
+msgid "Show non-&primary monitors"
 msgstr "Visa icke-primära skärmar"
 
-msgid "Open screenshots folder..."
+msgid "Open screenshots &folder..."
 msgstr "Öppna skärmbildsmappen..."
 
-msgid "Apply fullscreen stretch mode when maximized"
+msgid "Appl&y fullscreen stretch mode when maximized"
 msgstr "Tillämpa sträckläge för helskärm när den är maximerad"
 
-msgid "Cursor/Puck"
-msgstr "Pekare/puck"
+msgid "&Cursor/Puck"
+msgstr "&Pekare/puck"
 
-msgid "Pen"
-msgstr "Penna"
+msgid "&Pen"
+msgstr "P&enna"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "Värdenhet för CD/DVD (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "&Värdenhet för CD/DVD (%1:)"
 
 msgid "&Connected"
 msgstr "&Ansluten"
 
-msgid "Clear image history"
+msgid "Clear image &history"
 msgstr "Rensa historik för avbildningar"
 
 msgid "Create..."
@@ -1434,7 +1452,7 @@ msgstr "Serieport passthrough 3"
 msgid "Serial port passthrough 4"
 msgstr "Serieport passthrough 4"
 
-msgid "Renderer options..."
+msgid "Renderer &options..."
 msgstr "Renderingsalternativ..."
 
 msgid "PC/XT Keyboard"

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -63,7 +63,7 @@ msgstr "OpenG&L (Sürüm 3.0)"
 msgid "&VNC"
 msgstr "&VNC"
 
-msgid "Specify dimensions..."
+msgid "Specify &dimensions..."
 msgstr "Pencere &boyutunu belirle..."
 
 msgid "F&orce 4:3 display ratio"
@@ -102,7 +102,7 @@ msgstr "&7x"
 msgid "&8x"
 msgstr "&8x"
 
-msgid "Filter method"
+msgid "Fi&lter method"
 msgstr "&Filtreleme yöntemi"
 
 msgid "&Nearest"
@@ -675,6 +675,9 @@ msgstr "Hız"
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr "%1 MB (CHS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "Disket %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "&Disket %1 (%2): %3"
+
 msgid "Advanced sector images"
 msgstr "Gelişmiş sektör imajları"
 
@@ -881,6 +887,9 @@ msgstr "GhostPCL başlatılamadı"
 
 msgid "MO %1 (%2): %3"
 msgstr "MO %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "&MO %1 (%2): %3"
 
 msgid "MO images"
 msgstr "MO imajları"
@@ -966,11 +975,17 @@ msgstr "Devam et"
 msgid "Cassette: %1"
 msgstr "Kaset: %1"
 
+msgid "C&assette: %1"
+msgstr "K&aset: %1"
+
 msgid "Cassette images"
 msgstr "Kaset imajları"
 
 msgid "Cartridge %1: %2"
 msgstr "Kartuş %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "Kar&tuş %1: %2"
 
 msgid "Cartridge images"
 msgstr "Kartuş imajları"
@@ -992,6 +1007,9 @@ msgstr "Makineyi yeniden başlat"
 
 msgid "ACPI shutdown"
 msgstr "Makineyi ACPI kullanarak kapat"
+
+msgid "ACP&I shutdown"
+msgstr "Makineyi ACP&I kullanarak kapat"
 
 msgid "Hard disk (%1)"
 msgstr "Hard disk (%1)"
@@ -1278,40 +1296,40 @@ msgstr "MCA cihazları"
 msgid "List of MCA devices:"
 msgstr "MCA cihazlarının listesi:"
 
-msgid "Tablet tool"
+msgid "&Tablet tool"
 msgstr "Tablet aracı"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "Qt hakkında"
+msgid "About &Qt"
+msgstr "&Qt hakkında"
 
-msgid "MCA devices..."
+msgid "&MCA devices..."
 msgstr "MCA cihazları..."
 
-msgid "Show non-primary monitors"
+msgid "Show non-&primary monitors"
 msgstr "Birincil olmayan monitörleri göster"
 
-msgid "Open screenshots folder..."
+msgid "Open screenshots &folder..."
 msgstr "Ekran görüntüsü klasörünü aç..."
 
-msgid "Apply fullscreen stretch mode when maximized"
+msgid "Appl&y fullscreen stretch mode when maximized"
 msgstr "Büyütüldüğünde tam ekran germe modunu uygula"
 
-msgid "Cursor/Puck"
-msgstr "İmleç/Puck"
+msgid "&Cursor/Puck"
+msgstr "&İmleç/Puck"
 
-msgid "Pen"
-msgstr "Kalem"
+msgid "&Pen"
+msgstr "&Kalem"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "Ana Sistemin CD/DVD Sürücüsü (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "&Ana Sistemin CD/DVD Sürücüsü (%1:)"
 
 msgid "&Connected"
 msgstr "&Bağlı"
 
-msgid "Clear image history"
+msgid "Clear image &history"
 msgstr "İmaj geçmişini temizle"
 
 msgid "Create..."
@@ -1434,7 +1452,7 @@ msgstr "3. Seri Port geçişi"
 msgid "Serial port passthrough 4"
 msgstr "4. Seri Port geçişi"
 
-msgid "Renderer options..."
+msgid "Renderer &options..."
 msgstr "Derleyici seçenekleri..."
 
 msgid "PC/XT Keyboard"

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -63,7 +63,7 @@ msgstr "Open&GL (3.0)"
 msgid "&VNC"
 msgstr "&VNC"
 
-msgid "Specify dimensions..."
+msgid "Specify &dimensions..."
 msgstr "&Вказати розміри..."
 
 msgid "F&orce 4:3 display ratio"
@@ -102,7 +102,7 @@ msgstr "&7x"
 msgid "&8x"
 msgstr "&8x"
 
-msgid "Filter method"
+msgid "Fi&lter method"
 msgstr "Метод фільтрації"
 
 msgid "&Nearest"
@@ -675,6 +675,9 @@ msgstr "Швидкість"
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr "%1 МБ (CHS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "Дисковод %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "&Дисковод %1 (%2): %3"
+
 msgid "Advanced sector images"
 msgstr "Розширені образи секторів"
 
@@ -881,6 +887,9 @@ msgstr "Неможливо ініціалізувати GhostPCL"
 
 msgid "MO %1 (%2): %3"
 msgstr "Магнітооптичний %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "&Магнітооптичний %1 (%2): %3"
 
 msgid "MO images"
 msgstr "Образи магнітооптичних дисків"
@@ -966,11 +975,17 @@ msgstr "Продовжити"
 msgid "Cassette: %1"
 msgstr "Касета: %1"
 
+msgid "C&assette: %1"
+msgstr "К&асета: %1"
+
 msgid "Cassette images"
 msgstr "Образи касет"
 
 msgid "Cartridge %1: %2"
 msgstr "Картридж %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "Кар&тридж %1: %2"
 
 msgid "Cartridge images"
 msgstr "Образи картриджів"
@@ -992,6 +1007,9 @@ msgstr "Холодне перезавантаження"
 
 msgid "ACPI shutdown"
 msgstr "Сигнал завершення ACPI"
+
+msgid "ACP&I shutdown"
+msgstr "Сигнал завершення ACP&I"
 
 msgid "Hard disk (%1)"
 msgstr "Жорсткий диск (%1)"
@@ -1281,40 +1299,40 @@ msgstr "Пристрої MCA"
 msgid "List of MCA devices:"
 msgstr "Список пристроїв MCA:"
 
-msgid "Tablet tool"
+msgid "&Tablet tool"
 msgstr "Інструмент для планшета"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "Про Qt"
+msgid "About &Qt"
+msgstr "Про &Qt"
 
-msgid "MCA devices..."
-msgstr "Пристрої MCA..."
+msgid "&MCA devices..."
+msgstr "Пристрої &MCA..."
 
-msgid "Show non-primary monitors"
+msgid "Show non-&primary monitors"
 msgstr "Показати неосновні монітори"
 
-msgid "Open screenshots folder..."
+msgid "Open screenshots &folder..."
 msgstr "Відкрийте папку скріншотів..."
 
-msgid "Apply fullscreen stretch mode when maximized"
+msgid "Appl&y fullscreen stretch mode when maximized"
 msgstr "Застосовувати розстягування у повноекранному режимі у максимізованому стані"
 
-msgid "Cursor/Puck"
-msgstr "Курсор/шайба"
+msgid "&Cursor/Puck"
+msgstr "&Курсор/шайба"
 
-msgid "Pen"
-msgstr "Ручка"
+msgid "&Pen"
+msgstr "&Ручка"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "CD/DVD привід хоста (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "CD/DVD &привід хоста (%1:)"
 
 msgid "&Connected"
 msgstr "&Підключено"
 
-msgid "Clear image history"
+msgid "Clear image &history"
 msgstr "Очистити історію образів"
 
 msgid "Create..."
@@ -1437,7 +1455,7 @@ msgstr "Пропуск послідовного порту 3"
 msgid "Serial port passthrough 4"
 msgstr "Пропуск послідовного порту 4"
 
-msgid "Renderer options..."
+msgid "Renderer &options..."
 msgstr "Параметри рендерингу..."
 
 msgid "PC/XT Keyboard"

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -63,7 +63,7 @@ msgstr "Open&GL (3.0 Core)"
 msgid "&VNC"
 msgstr "&VNC"
 
-msgid "Specify dimensions..."
+msgid "Specify &dimensions..."
 msgstr "Tự nhập độ &phân giải..."
 
 msgid "F&orce 4:3 display ratio"
@@ -102,7 +102,7 @@ msgstr "&7x"
 msgid "&8x"
 msgstr "&8x"
 
-msgid "Filter method"
+msgid "Fi&lter method"
 msgstr "&Bộ lọc hình ảnh"
 
 msgid "&Nearest"
@@ -675,6 +675,9 @@ msgstr "Vận tốc"
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr "%1 MB (CHS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "Đĩa mềm %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "Đĩa &mềm %1 (%2): %3"
+
 msgid "Advanced sector images"
 msgstr "Ảnh (đĩa) sector nâng cao"
 
@@ -881,6 +887,9 @@ msgstr "Không thể khởi tạo GhostPCL"
 
 msgid "MO %1 (%2): %3"
 msgstr "MO %1 (%2): %3"
+
+msgid "M&O %1 (%2): %3"
+msgstr "M&O %1 (%2): %3"
 
 msgid "MO images"
 msgstr "Ảnh đĩa MO"
@@ -966,11 +975,17 @@ msgstr "Tiếp tục"
 msgid "Cassette: %1"
 msgstr "Cassette: %1"
 
+msgid "C&assette: %1"
+msgstr "C&assette: %1"
+
 msgid "Cassette images"
 msgstr "Ảnh đĩa Cassette"
 
 msgid "Cartridge %1: %2"
 msgstr "Băng cartridge %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "Băng car&tridge %1: %2"
 
 msgid "Cartridge images"
 msgstr "Ảnh đĩa băng cartridge"
@@ -992,6 +1007,9 @@ msgstr "Buộc khởi động lại"
 
 msgid "ACPI shutdown"
 msgstr "Tắt máy theo ACPI"
+
+msgid "ACP&I shutdown"
+msgstr "Tắt máy theo ACP&I"
 
 msgid "Hard disk (%1)"
 msgstr "Ổ cứng (%1)"
@@ -1278,40 +1296,40 @@ msgstr "Thiết bị MCA"
 msgid "List of MCA devices:"
 msgstr "Danh sách các thiết bị MCA:"
 
-msgid "Tablet tool"
+msgid "&Tablet tool"
 msgstr "Công cụ bảng nhập liệu"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "QT (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "Về qt"
+msgid "About &Qt"
+msgstr "Về &qt"
 
-msgid "MCA devices..."
+msgid "&MCA devices..."
 msgstr "Thiết bị MCA..."
 
-msgid "Show non-primary monitors"
+msgid "Show non-&primary monitors"
 msgstr "Hiển thị các màn hình phụ"
 
-msgid "Open screenshots folder..."
+msgid "Open screenshots &folder..."
 msgstr "Mở thư mục ảnh chụp màn hình..."
 
-msgid "Apply fullscreen stretch mode when maximized"
+msgid "Appl&y fullscreen stretch mode when maximized"
 msgstr "Co giãn toàn màn hình khi cực đại hóa cửa sổ"
 
-msgid "Cursor/Puck"
-msgstr "Con trỏ/puck"
+msgid "&Cursor/Puck"
+msgstr "&Con trỏ/puck"
 
-msgid "Pen"
-msgstr "Bút"
+msgid "&Pen"
+msgstr "&Bút"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "Máy chủ CD/DVD ổ đĩa (%1 :)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "&Máy chủ CD/DVD ổ đĩa (%1 :)"
 
 msgid "&Connected"
 msgstr "&Đã kết nối"
 
-msgid "Clear image history"
+msgid "Clear image &history"
 msgstr "Xóa lịch sử ảnh đĩa"
 
 msgid "Create..."
@@ -1434,7 +1452,7 @@ msgstr "Thông qua cổng serial 3"
 msgid "Serial port passthrough 4"
 msgstr "Thông qua cổng serial 4"
 
-msgid "Renderer options..."
+msgid "Renderer &options..."
 msgstr "Tùy chọn kết xuất ..."
 
 msgid "PC/XT Keyboard"

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -63,8 +63,8 @@ msgstr "OpenGL (3.0 Core)(&G)"
 msgid "&VNC"
 msgstr "VNC(&V)"
 
-msgid "Specify dimensions..."
-msgstr "指定窗口大小..."
+msgid "Specify &dimensions..."
+msgstr "指定窗口大小...(&D)"
 
 msgid "F&orce 4:3 display ratio"
 msgstr "强制 4:3 显示比例(&O)"
@@ -102,8 +102,8 @@ msgstr "7x(&7)"
 msgid "&8x"
 msgstr "8x(&8)"
 
-msgid "Filter method"
-msgstr "过滤方式"
+msgid "Fi&lter method"
+msgstr "过滤方式(&L)"
 
 msgid "&Nearest"
 msgstr "邻近(&N)"
@@ -675,6 +675,9 @@ msgstr "速度"
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr "%1 MB (CHS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "软盘 %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "软盘 %1 (%2): %3(&F)"
+
 msgid "Advanced sector images"
 msgstr "高级扇区映像"
 
@@ -881,6 +887,9 @@ msgstr "无法初始化 GhostPCL"
 
 msgid "MO %1 (%2): %3"
 msgstr "磁光盘 %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "磁光盘 %1 (%2): %3(&M)"
 
 msgid "MO images"
 msgstr "磁光盘映像"
@@ -966,11 +975,17 @@ msgstr "继续"
 msgid "Cassette: %1"
 msgstr "磁带: %1"
 
+msgid "C&assette: %1"
+msgstr "磁带: %1(&A)"
+
 msgid "Cassette images"
 msgstr "磁带映像"
 
 msgid "Cartridge %1: %2"
 msgstr "卡带 %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "卡带 %1: %2(&A)"
 
 msgid "Cartridge images"
 msgstr "卡带映像"
@@ -992,6 +1007,9 @@ msgstr "硬重置"
 
 msgid "ACPI shutdown"
 msgstr "ACPI 关机"
+
+msgid "ACP&I shutdown"
+msgstr "ACP&I 关机"
 
 msgid "Hard disk (%1)"
 msgstr "硬盘 (%1)"
@@ -1278,41 +1296,41 @@ msgstr "MCA 设备"
 msgid "List of MCA devices:"
 msgstr "MCA 设备清单："
 
-msgid "Tablet tool"
-msgstr "平板工具"
+msgid "&Tablet tool"
+msgstr "平板工具(&T)"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt（OpenGL &ES）"
 
-msgid "About Qt"
-msgstr "关于 Qt"
+msgid "About &Qt"
+msgstr "关于 &Qt"
 
-msgid "MCA devices..."
-msgstr "MCA 设备..."
+msgid "&MCA devices..."
+msgstr "&MCA 设备..."
 
-msgid "Show non-primary monitors"
-msgstr "显示非主要显示器"
+msgid "Show non-&primary monitors"
+msgstr "显示非主要显示器(&P)"
 
-msgid "Open screenshots folder..."
-msgstr "打开屏幕截图文件夹..."
+msgid "Open screenshots &folder..."
+msgstr "打开屏幕截图文件夹...(&F)"
 
-msgid "Apply fullscreen stretch mode when maximized"
-msgstr "最大化时应用全屏拉伸模式"
+msgid "Appl&y fullscreen stretch mode when maximized"
+msgstr "最大化时应用全屏拉伸模式(&Y)"
 
-msgid "Cursor/Puck"
-msgstr "光标/冰球"
+msgid "&Cursor/Puck"
+msgstr "光标/冰球(&C)"
 
-msgid "Pen"
-msgstr "笔"
+msgid "&Pen"
+msgstr "笔(&P)"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "主机 CD/DVD 驱动器 (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "主机 CD/DVD 驱动器 (%1:) (&H)"
 
 msgid "&Connected"
 msgstr "已连接(&C)"
 
-msgid "Clear image history"
-msgstr "清除映像历史记录"
+msgid "Clear image &history"
+msgstr "清除映像历史记录(&H)"
 
 msgid "Create..."
 msgstr "创建..."
@@ -1434,8 +1452,8 @@ msgstr "串行端口直通 3"
 msgid "Serial port passthrough 4"
 msgstr "串行端口直通 4"
 
-msgid "Renderer options..."
-msgstr "渲染器选项..."
+msgid "Renderer &options..."
+msgstr "渲染器选项...(&O)"
 
 msgid "PC/XT Keyboard"
 msgstr ""

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -63,8 +63,8 @@ msgstr "OpenGL (3.0 Core)(&G)"
 msgid "&VNC"
 msgstr "VNC(&V)"
 
-msgid "Specify dimensions..."
-msgstr "指定視窗大小..."
+msgid "Specify &dimensions..."
+msgstr "指定視窗大小...(&D)"
 
 msgid "F&orce 4:3 display ratio"
 msgstr "強制 4:3 顯示比例(&O)"
@@ -102,8 +102,8 @@ msgstr "7x(&7)"
 msgid "&8x"
 msgstr "8x(&8)"
 
-msgid "Filter method"
-msgstr "過濾方式"
+msgid "Fi&lter method"
+msgstr "過濾方式(&L)"
 
 msgid "&Nearest"
 msgstr "鄰近(&N)"
@@ -675,6 +675,9 @@ msgstr "速度"
 msgid "Removable disk %1 (%2): %3"
 msgstr ""
 
+msgid "&Removable disk %1 (%2): %3"
+msgstr ""
+
 msgid "Removable disk images"
 msgstr ""
 
@@ -861,6 +864,9 @@ msgstr "%1 MB (CHS: %2, %3, %4)"
 msgid "Floppy %1 (%2): %3"
 msgstr "軟碟 %1 (%2): %3"
 
+msgid "&Floppy %1 (%2): %3"
+msgstr "軟碟 %1 (%2): %3(&F)"
+
 msgid "Advanced sector images"
 msgstr "進階磁區映像"
 
@@ -881,6 +887,9 @@ msgstr "無法初始化 GhostPCL"
 
 msgid "MO %1 (%2): %3"
 msgstr "磁光碟 %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "磁光碟 %1 (%2): %3(&M)"
 
 msgid "MO images"
 msgstr "磁光碟映像"
@@ -966,11 +975,17 @@ msgstr "繼續"
 msgid "Cassette: %1"
 msgstr "磁帶: %1"
 
+msgid "C&assette: %1"
+msgstr "磁帶: %1(&A)"
+
 msgid "Cassette images"
 msgstr "磁帶映像"
 
 msgid "Cartridge %1: %2"
 msgstr "卡帶 %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "卡帶 %1: %2(&A)"
 
 msgid "Cartridge images"
 msgstr "卡帶映像"
@@ -992,6 +1007,9 @@ msgstr "硬重設"
 
 msgid "ACPI shutdown"
 msgstr "ACPI 關機"
+
+msgid "ACP&I shutdown"
+msgstr "ACP&I 關機"
 
 msgid "Hard disk (%1)"
 msgstr "硬碟 (%1)"
@@ -1278,41 +1296,41 @@ msgstr "MCA 裝置"
 msgid "List of MCA devices:"
 msgstr "MCA 裝置清單："
 
-msgid "Tablet tool"
-msgstr "平板工具"
+msgid "&Tablet tool"
+msgstr "平板工具(&T)"
 
 msgid "Qt (OpenGL &ES)"
 msgstr "Qt (OpenGL &ES)"
 
-msgid "About Qt"
-msgstr "關於 Qt"
+msgid "About &Qt"
+msgstr "關於 &Qt"
 
-msgid "MCA devices..."
-msgstr "MCA 裝置..."
+msgid "&MCA devices..."
+msgstr "&MCA 裝置..."
 
-msgid "Show non-primary monitors"
-msgstr "顯示非主要顯示器"
+msgid "Show non-&primary monitors"
+msgstr "顯示非主要顯示器(&P)"
 
-msgid "Open screenshots folder..."
-msgstr "開啟螢幕截圖資料夾..."
+msgid "Open screenshots &folder..."
+msgstr "開啟螢幕截圖資料夾...(&F)"
 
-msgid "Apply fullscreen stretch mode when maximized"
-msgstr "最大化時套用全螢幕拉伸模式"
+msgid "Appl&y fullscreen stretch mode when maximized"
+msgstr "最大化時套用全螢幕拉伸模式(&Y)"
 
-msgid "Cursor/Puck"
-msgstr "游標/球棒"
+msgid "&Cursor/Puck"
+msgstr "游標/球棒(&C)"
 
-msgid "Pen"
-msgstr "筆"
+msgid "&Pen"
+msgstr "筆(&P)"
 
-msgid "Host CD/DVD Drive (%1:)"
-msgstr "主機 CD/DVD 光碟機 (%1:)"
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "主機 CD/DVD 光碟機 (%1:) (&H)"
 
 msgid "&Connected"
 msgstr "已連線"
 
-msgid "Clear image history"
-msgstr "清除映像歷史記錄"
+msgid "Clear image &history"
+msgstr "清除映像歷史記錄(&H)"
 
 msgid "Create..."
 msgstr "建立..."
@@ -1434,8 +1452,8 @@ msgstr "序列埠的直通 3"
 msgid "Serial port passthrough 4"
 msgstr "序列埠的直通 4"
 
-msgid "Renderer options..."
-msgstr "渲染器選項..."
+msgid "Renderer &options..."
+msgstr "渲染器選項...(&O)"
 
 msgid "PC/XT Keyboard"
 msgstr ""

--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -630,7 +630,7 @@ MachineStatus::refresh(QStatusBar *sbar)
         connect((ClickableLabel *) d->cassette.label.get(), &ClickableLabel::dropped, [](QString str) {
             MediaMenu::ptr->cassetteMount(str, false);
         });
-        d->cassette.label->setToolTip(MediaMenu::ptr->cassetteMenu->title());
+        d->cassette.label->setToolTip(MediaMenu::ptr->cassetteMenu->toolTip());
         d->cassette.label->setAcceptDrops(true);
         sbar->addWidget(d->cassette.label.get());
     }
@@ -646,7 +646,7 @@ MachineStatus::refresh(QStatusBar *sbar)
             connect((ClickableLabel *) d->cartridge[i].label.get(), &ClickableLabel::dropped, [i](QString str) {
                 MediaMenu::ptr->cartridgeMount(i, str);
             });
-            d->cartridge[i].label->setToolTip(MediaMenu::ptr->cartridgeMenus[i]->title());
+            d->cartridge[i].label->setToolTip(MediaMenu::ptr->cartridgeMenus[i]->toolTip());
             d->cartridge[i].label->setAcceptDrops(true);
             sbar->addWidget(d->cartridge[i].label.get());
         }
@@ -678,7 +678,7 @@ MachineStatus::refresh(QStatusBar *sbar)
         connect((ClickableLabel *) d->fdd[i].label.get(), &ClickableLabel::dropped, [i](QString str) {
             MediaMenu::ptr->floppyMount(i, str, false);
         });
-        d->fdd[i].label->setToolTip(MediaMenu::ptr->floppyMenus[i]->title());
+        d->fdd[i].label->setToolTip(MediaMenu::ptr->floppyMenus[i]->toolTip());
         d->fdd[i].label->setAcceptDrops(true);
         sbar->addWidget(d->fdd[i].label.get());
     });
@@ -695,7 +695,7 @@ MachineStatus::refresh(QStatusBar *sbar)
         connect((ClickableLabel *) d->cdrom[i].label.get(), &ClickableLabel::dropped, [i](QString str) {
             MediaMenu::ptr->cdromMount(i, str);
         });
-        d->cdrom[i].label->setToolTip(MediaMenu::ptr->cdromMenus[i]->title());
+        d->cdrom[i].label->setToolTip(MediaMenu::ptr->cdromMenus[i]->toolTip());
         d->cdrom[i].label->setAcceptDrops(true);
         sbar->addWidget(d->cdrom[i].label.get());
     });
@@ -718,7 +718,7 @@ MachineStatus::refresh(QStatusBar *sbar)
         connect((ClickableLabel *) d->rdisk[i].label.get(), &ClickableLabel::dropped, [i](QString str) {
             MediaMenu::ptr->rdiskMount(i, str, false);
         });
-        d->rdisk[i].label->setToolTip(MediaMenu::ptr->rdiskMenus[i]->title());
+        d->rdisk[i].label->setToolTip(MediaMenu::ptr->rdiskMenus[i]->toolTip());
         d->rdisk[i].label->setAcceptDrops(true);
         sbar->addWidget(d->rdisk[i].label.get());
     });
@@ -741,7 +741,7 @@ MachineStatus::refresh(QStatusBar *sbar)
         connect((ClickableLabel *) d->mo[i].label.get(), &ClickableLabel::dropped, [i](QString str) {
             MediaMenu::ptr->moMount(i, str, false);
         });
-        d->mo[i].label->setToolTip(MediaMenu::ptr->moMenus[i]->title());
+        d->mo[i].label->setToolTip(MediaMenu::ptr->moMenus[i]->toolTip());
         d->mo[i].label->setAcceptDrops(true);
         sbar->addWidget(d->mo[i].label.get());
     });
@@ -752,7 +752,7 @@ MachineStatus::refresh(QStatusBar *sbar)
         d->net[i].setActive(false);
         d->net[i].setWriteActive(false);
         d->net[i].refresh();
-        d->net[i].label->setToolTip(MediaMenu::ptr->netMenus[i]->title());
+        d->net[i].label->setToolTip(MediaMenu::ptr->netMenus[i]->toolTip());
         connect((ClickableLabel *) d->net[i].label.get(), &ClickableLabel::clicked, [i](QPoint pos) {
             MediaMenu::ptr->netMenus[i]->popup(pos - QPoint(0, MediaMenu::ptr->netMenus[i]->sizeHint().height()));
         });
@@ -910,27 +910,27 @@ MachineStatus::updateTip(int tag)
     switch (category) {
         case SB_CASSETTE:
             if (d->cassette.label && MediaMenu::ptr->cassetteMenu)
-                d->cassette.label->setToolTip(MediaMenu::ptr->cassetteMenu->title());
+                d->cassette.label->setToolTip(MediaMenu::ptr->cassetteMenu->toolTip());
             break;
         case SB_CARTRIDGE:
             if (d->cartridge[item].label && MediaMenu::ptr->cartridgeMenus[item])
-                d->cartridge[item].label->setToolTip(MediaMenu::ptr->cartridgeMenus[item]->title());
+                d->cartridge[item].label->setToolTip(MediaMenu::ptr->cartridgeMenus[item]->toolTip());
             break;
         case SB_FLOPPY:
             if (d->fdd[item].label && MediaMenu::ptr->floppyMenus[item])
-                d->fdd[item].label->setToolTip(MediaMenu::ptr->floppyMenus[item]->title());
+                d->fdd[item].label->setToolTip(MediaMenu::ptr->floppyMenus[item]->toolTip());
             break;
         case SB_CDROM:
             if (d->cdrom[item].label && MediaMenu::ptr->cdromMenus[item])
-                d->cdrom[item].label->setToolTip(MediaMenu::ptr->cdromMenus[item]->title());
+                d->cdrom[item].label->setToolTip(MediaMenu::ptr->cdromMenus[item]->toolTip());
             break;
         case SB_RDISK:
             if (d->rdisk[item].label && MediaMenu::ptr->rdiskMenus[item])
-                d->rdisk[item].label->setToolTip(MediaMenu::ptr->rdiskMenus[item]->title());
+                d->rdisk[item].label->setToolTip(MediaMenu::ptr->rdiskMenus[item]->toolTip());
             break;
         case SB_MO:
             if (d->mo[item].label && MediaMenu::ptr->moMenus[item])
-                d->mo[item].label->setToolTip(MediaMenu::ptr->moMenus[item]->title());
+                d->mo[item].label->setToolTip(MediaMenu::ptr->moMenus[item]->toolTip());
             break;
         case SB_HDD:
             break;

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -585,7 +585,11 @@ main(int argc, char *argv[])
     }
 
     if (!vmm_enabled)
+#ifdef Q_OS_MACOS
         qt_set_sequence_auto_mnemonic(false);
+#else
+        qt_set_sequence_auto_mnemonic(!!kbd_req_capture);
+#endif
     app.setStyle(new StyleOverride());
 
     bool startMaximized = window_remember && monitor_settings[0].mon_window_maximized;

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -85,7 +85,7 @@ private slots:
     void on_actionCtrl_Alt_Esc_triggered();
     void on_actionHard_Reset_triggered();
     void on_actionRight_CTRL_is_left_ALT_triggered();
-    static void on_actionKeyboard_requires_capture_triggered();
+    void on_actionKeyboard_requires_capture_triggered();
     void on_actionResizable_window_triggered(bool checked);
     void on_actionInverted_VGA_monitor_triggered();
     void on_action0_5x_triggered();

--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -63,7 +63,7 @@
     </property>
     <widget class="QMenu" name="menuTablet_tool">
      <property name="title">
-      <string>Tablet tool</string>
+      <string>&amp;Tablet tool</string>
      </property>
      <addaction name="actionPen"/>
      <addaction name="actionCursor_Puck"/>
@@ -142,7 +142,7 @@
     </widget>
     <widget class="QMenu" name="menuFilter_method">
      <property name="title">
-      <string>Filter method</string>
+      <string>Fi&amp;lter method</string>
      </property>
      <addaction name="actionNearest"/>
      <addaction name="actionLinear"/>
@@ -420,7 +420,7 @@
   </action>
   <action name="actionSpecify_dimensions">
    <property name="text">
-    <string>Specify dimensions...</string>
+    <string>Specify &amp;dimensions...</string>
    </property>
   </action>
   <action name="actionForce_4_3_display_ratio">
@@ -665,7 +665,7 @@
   </action>
   <action name="actionAbout_Qt">
    <property name="text">
-    <string>About Qt</string>
+    <string>About &amp;Qt</string>
    </property>
    <property name="visible">
     <bool>false</bool>
@@ -763,7 +763,7 @@
      <normaloff>:/menuicons/qt/icons/acpi_shutdown.ico</normaloff>:/menuicons/qt/icons/acpi_shutdown.ico</iconset>
    </property>
    <property name="text">
-    <string>ACPI shutdown</string>
+    <string>ACP&amp;I shutdown</string>
    </property>
    <property name="toolTip">
     <string>ACPI shutdown</string>
@@ -802,7 +802,7 @@
   </action>
   <action name="actionRenderer_options">
    <property name="text">
-    <string>Renderer options...</string>
+    <string>Renderer &amp;options...</string>
    </property>
    <property name="menuRole">
     <enum>QAction::NoRole</enum>
@@ -821,7 +821,7 @@
   </action>
   <action name="actionMCA_devices">
    <property name="text">
-    <string>MCA devices...</string>
+    <string>&amp;MCA devices...</string>
    </property>
   </action>
   <action name="actionShow_non_primary_monitors">
@@ -829,7 +829,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Show non-primary monitors</string>
+    <string>Show non-&amp;primary monitors</string>
    </property>
   </action>
   <action name="actionVNC">
@@ -837,7 +837,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>VNC</string>
+    <string>&amp;VNC</string>
    </property>
    <property name="vid_api" stdset="0">
     <number>3</number>
@@ -845,7 +845,7 @@
   </action>
   <action name="actionOpen_screenshots_folder">
    <property name="text">
-    <string>Open screenshots folder...</string>
+    <string>Open screenshots &amp;folder...</string>
    </property>
   </action>
   <action name="actionApply_fullscreen_stretch_mode_when_maximized">
@@ -853,7 +853,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Apply fullscreen stretch mode when maximized</string>
+    <string>Appl&amp;y fullscreen stretch mode when maximized</string>
    </property>
   </action>
   <action name="actionCursor_Puck">
@@ -861,7 +861,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Cursor/Puck</string>
+    <string>&amp;Cursor/Puck</string>
    </property>
   </action>
   <action name="actionPen">
@@ -869,7 +869,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Pen</string>
+    <string>&amp;Pen</string>
    </property>
   </action>
  </widget>

--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -177,7 +177,7 @@ MediaMenu::refresh(QMenu *parentMenu)
         for (const auto &letter : driveLetters) {
             auto drive = QString("%1:\\").arg(letter);
             if (GetDriveType(drive.toUtf8().constData()) == DRIVE_CDROM)
-                menu->addAction(QIcon(":/settings/qt/icons/cdrom_host.ico"), tr("Host CD/DVD Drive (%1:)").arg(letter), [this, i, letter] { cdromMount(i, 2, QString(R"(\\.\%1:)").arg(letter)); })->setCheckable(false);
+                menu->addAction(QIcon(":/settings/qt/icons/cdrom_host.ico"), tr("&Host CD/DVD Drive (%1:)").arg(letter), [this, i, letter] { cdromMount(i, 2, QString(R"(\\.\%1:)").arg(letter)); })->setCheckable(false);
         }
         menu->addSeparator();
 #endif // Q_OS_WINDOWS
@@ -236,7 +236,7 @@ MediaMenu::refresh(QMenu *parentMenu)
         netMenus[i] = menu;
         nicUpdateMenu(i);
     });
-    parentMenu->addAction(tr("Clear image history"), [this]() { clearImageHistory(); });
+    parentMenu->addAction(tr("Clear image &history"), [this]() { clearImageHistory(); });
 }
 
 void
@@ -340,7 +340,8 @@ MediaMenu::cassetteUpdateMenu()
     recordMenu->setChecked(isSaving);
     playMenu->setChecked(!isSaving);
 
-    cassetteMenu->setTitle(tr("Cassette: %1").arg(name.isEmpty() ? tr("(empty)") : name));
+    cassetteMenu->setTitle(tr("C&assette: %1").arg(name.isEmpty() ? tr("(empty)") : name));
+    cassetteMenu->setToolTip(tr("Cassette: %1").arg(name.isEmpty() ? tr("(empty)") : name));
 
     for (int slot = 0; slot < MAX_PREV_IMAGES; slot++) {
         updateImageHistory(0, slot, ui::MediaType::Cassette);
@@ -407,7 +408,8 @@ MediaMenu::cartridgeUpdateMenu(int i)
     auto   *ejectMenu = dynamic_cast<QAction *>(childs[cartridgeEjectPos]);
     ejectMenu->setEnabled(!name.isEmpty());
     ejectMenu->setText(name.isEmpty() ? tr("E&ject") : tr("E&ject %1").arg(fi.fileName()));
-    menu->setTitle(tr("Cartridge %1: %2").arg(QString::number(i + 1), name.isEmpty() ? tr("(empty)") : name));
+    menu->setTitle(tr("Car&tridge %1: %2").arg(QString::number(i + 1), name.isEmpty() ? tr("(empty)") : name));
+    menu->setToolTip(tr("Cartridge %1: %2").arg(QString::number(i + 1), name.isEmpty() ? tr("(empty)") : name));
 
     for (int slot = 0; slot < MAX_PREV_IMAGES; slot++) {
         updateImageHistory(i, slot, ui::MediaType::Cartridge);
@@ -524,7 +526,8 @@ MediaMenu::floppyUpdateMenu(int i)
     }
 
     int type = fdd_get_type(i);
-    floppyMenus[i]->setTitle(tr("Floppy %1 (%2): %3").arg(QString::number(i + 1), fdd_getname(type), name.isEmpty() ? tr("(empty)") : name));
+    floppyMenus[i]->setTitle(tr("&Floppy %1 (%2): %3").arg(QString::number(i + 1), fdd_getname(type), name.isEmpty() ? tr("(empty)") : name));
+    floppyMenus[i]->setToolTip(tr("Floppy %1 (%2): %3").arg(QString::number(i + 1), fdd_getname(type), name.isEmpty() ? tr("(empty)") : name));
 
 }
 
@@ -765,6 +768,11 @@ MediaMenu::updateImageHistory(int index, int slot, ui::MediaType type)
             break;
     }
 
+#ifndef Q_OS_MACOS
+    if ((slot >= 0) && (slot <= 9))
+        imageHistoryUpdatePos->setText(menu_item_name.prepend("&%1 ").arg((slot == 9) ? 0 : (slot + 1)));
+    else
+#endif
     imageHistoryUpdatePos->setText(menu_item_name);
 
     if (fn.left(8) == "ioctl://")
@@ -841,7 +849,8 @@ MediaMenu::cdromUpdateMenu(int i)
             break;
     }
 
-    menu->setTitle(tr("CD-ROM %1 (%2): %3").arg(QString::number(i+1), busName, name.isEmpty() ? tr("(empty)") : name2));
+    menu->setTitle(tr("&CD-ROM %1 (%2): %3").arg(QString::number(i+1), busName, name.isEmpty() ? tr("(empty)") : name2));
+    menu->setToolTip(tr("CD-ROM %1 (%2): %3").arg(QString::number(i+1), busName, name.isEmpty() ? tr("(empty)") : name2));
 }
 
 void
@@ -980,7 +989,8 @@ MediaMenu::moUpdateMenu(int i)
             break;
     }
 
-    menu->setTitle(tr("MO %1 (%2): %3").arg(QString::number(i + 1), busName, name.isEmpty() ? tr("(empty)") : name));
+    menu->setTitle(tr("&MO %1 (%2): %3").arg(QString::number(i + 1), busName, name.isEmpty() ? tr("(empty)") : name));
+    menu->setToolTip(tr("MO %1 (%2): %3").arg(QString::number(i + 1), busName, name.isEmpty() ? tr("(empty)") : name));
 
     for (int slot = 0; slot < MAX_PREV_IMAGES; slot++)
         updateImageHistory(i, slot, ui::MediaType::Mo);
@@ -1013,7 +1023,8 @@ MediaMenu::rdiskUpdateMenu(int i)
             break;
     }
 
-    menu->setTitle(tr("Removable disk %1 (%2): %3").arg(QString::number(i + 1), busName, name.isEmpty() ? tr("(empty)") : name));
+    menu->setTitle(tr("&Removable disk %1 (%2): %3").arg(QString::number(i + 1), busName, name.isEmpty() ? tr("(empty)") : name));
+    menu->setToolTip(tr("Removable disk %1 (%2): %3").arg(QString::number(i + 1), busName, name.isEmpty() ? tr("(empty)") : name));
 
     for (int slot = 0; slot < MAX_PREV_IMAGES; slot++)
         updateImageHistory(i, slot, ui::MediaType::RDisk);
@@ -1179,7 +1190,8 @@ MediaMenu::nicUpdateMenu(int i)
     auto *connectedAction = dynamic_cast<QAction *>(childs[netDisconnPos]);
     connectedAction->setChecked(network_is_connected(i));
 
-    menu->setTitle(tr("NIC %1 (%2) %3").arg(QString::number(i + 1), netType, devName));
+    menu->setTitle(tr("&NIC %1 (%2) %3").arg(QString::number(i + 1), netType, devName));
+    menu->setToolTip(tr("NIC %1 (%2) %3").arg(QString::number(i + 1), netType, devName));
 }
 
 QString

--- a/src/qt/qt_styleoverride.cpp
+++ b/src/qt/qt_styleoverride.cpp
@@ -24,6 +24,7 @@
 
 extern "C" {
 #include <86box/86box.h>
+#include <86box/plat.h>
 }
 
 #ifdef Q_OS_WINDOWS
@@ -41,7 +42,7 @@ StyleOverride::styleHint(
     QStyleHintReturn   *returnData) const
 {
     /* Disable using menu with alt key */
-    if (!vmm_enabled && (hint == QStyle::SH_MenuBar_AltKeyNavigation))
+    if (!vmm_enabled && (!kbd_req_capture || mouse_capture) && (hint == QStyle::SH_MenuBar_AltKeyNavigation))
         return 0;
 
     return QProxyStyle::styleHint(hint, option, widget, returnData);


### PR DESCRIPTION
Summary
=======
Makes keyboard navigation accelerators/mnemonics on actually usable when "Keyboard requires capture" is enabled and mouse is not captured. Adds mnemonics to all menu entries that were missing them (for English and languages that use English mnemonics). Media history entries are now numbered to accommodate the accelerators. Windows and non-Mac *nix only.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A