### PR TITLE
Manager: Expand types of hardware displayed in the details view

### DIFF
--- a/src/qt/qt_vmmanager_details.cpp
+++ b/src/qt/qt_vmmanager_details.cpp
@@ -261,6 +261,7 @@ VMManagerDetails::updateConfig(VMManagerSystem *passed_sysconfig) {
 
     // Input
     inputSection->clear();
+    inputSection->addSection(tr("Keyboard"), passed_sysconfig->getDisplayValue(Display::Name::Keyboard));
     inputSection->addSection(tr("Mouse"), passed_sysconfig->getDisplayValue(Display::Name::Mouse));
     inputSection->addSection(tr("Joystick"), passed_sysconfig->getDisplayValue(Display::Name::Joystick));
 

--- a/src/qt/qt_vmmanager_details.cpp
+++ b/src/qt/qt_vmmanager_details.cpp
@@ -267,8 +267,8 @@ VMManagerDetails::updateConfig(VMManagerSystem *passed_sysconfig) {
 
     // Ports
     portsSection->clear();
-    portsSection->addSection(tr("Serial Ports"), passed_sysconfig->getDisplayValue(Display::Name::Serial));
-    portsSection->addSection(tr("Parallel Ports"), passed_sysconfig->getDisplayValue(Display::Name::Parallel));
+    portsSection->addSection(tr("Serial ports"), passed_sysconfig->getDisplayValue(Display::Name::Serial));
+    portsSection->addSection(tr("Parallel ports"), passed_sysconfig->getDisplayValue(Display::Name::Parallel));
 
 }
 

--- a/src/qt/qt_vmmanager_details.cpp
+++ b/src/qt/qt_vmmanager_details.cpp
@@ -245,6 +245,8 @@ VMManagerDetails::updateConfig(VMManagerSystem *passed_sysconfig) {
     storageSection->addSection("Disks", passed_sysconfig->getDisplayValue(Display::Name::Disks));
     storageSection->addSection("Floppy", passed_sysconfig->getDisplayValue(Display::Name::Floppy));
     storageSection->addSection("CD-ROM", passed_sysconfig->getDisplayValue(Display::Name::CD));
+    storageSection->addSection("Removable disks", passed_sysconfig->getDisplayValue(Display::Name::RDisk));
+    storageSection->addSection("MO", passed_sysconfig->getDisplayValue(Display::Name::MO));
     storageSection->addSection("SCSI", passed_sysconfig->getDisplayValue(Display::Name::SCSIController));
 
     // Audio

--- a/src/qt/qt_vmmanager_details.cpp
+++ b/src/qt/qt_vmmanager_details.cpp
@@ -67,6 +67,9 @@ VMManagerDetails::VMManagerDetails(QWidget *parent) :
     portsSection = new VMManagerDetailSection(tr("Ports", "Header for Input section in VM Manager Details"));
     ui->leftColumn->layout()->addWidget(portsSection);
 
+    otherSection = new VMManagerDetailSection(tr("Other devices", "Header for Other devices section in VM Manager Details"));
+    ui->leftColumn->layout()->addWidget(otherSection);
+
     // This is like adding a spacer
     leftColumnLayout->addStretch();
 
@@ -270,6 +273,11 @@ VMManagerDetails::updateConfig(VMManagerSystem *passed_sysconfig) {
     portsSection->addSection(tr("Serial ports"), passed_sysconfig->getDisplayValue(Display::Name::Serial));
     portsSection->addSection(tr("Parallel ports"), passed_sysconfig->getDisplayValue(Display::Name::Parallel));
 
+    // Other devices
+    otherSection->clear();
+    otherSection->addSection(tr("ISA RTC"), passed_sysconfig->getDisplayValue(Display::Name::IsaRtc));
+    otherSection->addSection(tr("ISA RAM"), passed_sysconfig->getDisplayValue(Display::Name::IsaMem));
+    otherSection->addSection(tr("ISA ROM"), passed_sysconfig->getDisplayValue(Display::Name::IsaRom));
 }
 
 void

--- a/src/qt/qt_vmmanager_details.cpp
+++ b/src/qt/qt_vmmanager_details.cpp
@@ -248,6 +248,7 @@ VMManagerDetails::updateConfig(VMManagerSystem *passed_sysconfig) {
     storageSection->addSection("Removable disks", passed_sysconfig->getDisplayValue(Display::Name::RDisk));
     storageSection->addSection("MO", passed_sysconfig->getDisplayValue(Display::Name::MO));
     storageSection->addSection("SCSI", passed_sysconfig->getDisplayValue(Display::Name::SCSIController));
+    storageSection->addSection("Controllers", passed_sysconfig->getDisplayValue(Display::Name::StorageController));
 
     // Audio
     audioSection->clear();

--- a/src/qt/qt_vmmanager_details.hpp
+++ b/src/qt/qt_vmmanager_details.hpp
@@ -55,6 +55,7 @@ private:
     VMManagerDetailSection *networkSection;
     VMManagerDetailSection *inputSection;
     VMManagerDetailSection *portsSection;
+    VMManagerDetailSection *otherSection;
 
     QFileInfoList screenshots;
     int           screenshotIndex = 0;

--- a/src/qt/qt_vmmanager_system.cpp
+++ b/src/qt/qt_vmmanager_system.cpp
@@ -545,17 +545,39 @@ VMManagerSystem::setupVars() {
     }
     display_table[Display::Name::Machine] = machine_name;
 
-    // CPU: Combine name with speed
-    auto cpu_name = QString();
+    // CPU: Combine name with speed and FPU
+    QString cpu_name = "Unknown";
     while (cpu_families[i].package != 0) {
         if (cpu_families[i].internal_name == machine_config["cpu_family"]) {
+            int j = 0;
             cpu_name = QString("%1 %2").arg(cpu_families[i].manufacturer, cpu_families[i].name);
+            while (cpu_families[i].cpus[j].cpu_type != 0) {
+                if (cpu_families[i].cpus[j].rspeed == machine_config["cpu_speed"].toUInt()) {
+                    auto cpu_speed = QString(cpu_families[i].cpus[j].name).split("/").at(0).split(" (").at(0);
+                    cpu_name.append(cpu_speed.prepend(" / "));
+                    cpu_name.append(QCoreApplication::translate("", "MHz").prepend(' '));
+                    if (machine_config.contains("fpu_type") && (machine_config["fpu_type"] != QString("none")) && (machine_config["fpu_type"] != QString("internal"))) {
+                        int k = 0;
+                        while (cpu_families[i].cpus[j].fpus[k].internal_name != nullptr) {
+                            if (QString(cpu_families[i].cpus[j].fpus[k].internal_name) == machine_config["fpu_type"]) {
+                                cpu_name.append(QString(cpu_families[i].cpus[j].fpus[k].name).prepend(", "));
+                                cpu_name.append(QCoreApplication::translate("", "FPU").prepend(' '));
+                                break;
+                            }
+                            k++;
+                        }
+                    }
+                    break;
+                }
+                j++;
+            }
+            break;
         }
         i++;
     }
-    int speed_display = machine_config["cpu_speed"].toInt() / 1000000;
-    cpu_name.append(QString::number(speed_display).prepend(" / "));
-    cpu_name.append(QCoreApplication::translate("", "MHz").prepend(' '));
+//    int speed_display = machine_config["cpu_speed"].toInt() / 1000000;
+//    cpu_name.append(QString::number(speed_display).prepend(" / "));
+//    cpu_name.append(QCoreApplication::translate("", "MHz").prepend(' '));
     display_table[Display::Name::CPU] = cpu_name;
 
     // Memory

--- a/src/qt/qt_vmmanager_system.cpp
+++ b/src/qt/qt_vmmanager_system.cpp
@@ -682,19 +682,19 @@ VMManagerSystem::setupVars() {
         }
         int diskSizeRaw = (cylinders.toInt() * heads.toInt() * sectors.toInt()) >> 11;
         QString diskSizeFinal;
-        QString unit = "MiB";
+        QString unit = tr("MiB");
         if(diskSizeRaw > 1000) {
-            unit = "GiB";
+            unit = tr("GiB");
             diskSizeFinal = QString::number(diskSizeRaw * 1.0 / 1000, 'f', 1);
         } else {
             diskSizeFinal = QString::number(diskSizeRaw);
         }
         // Only prefix each disk when there are multiple disks
-        QString diskNumberDisplay = disks.count() > 1 ? QString("Disk %1: ").arg(disk_number) : "";
+        QString diskNumberDisplay = disks.count() > 1 ? tr("Disk %1: ").arg(disk_number) : "";
         new_disk_display.append(QString("%1%2 %3 (%4)").arg(diskNumberDisplay, diskSizeFinal, unit, bus_type.toUpper()));
     }
     if(new_disk_display.isEmpty()) {
-        new_disk_display = "No disks";
+        new_disk_display = tr("No disks");
     }
     display_table[Display::Name::Disks] = new_disk_display;
 
@@ -796,7 +796,7 @@ VMManagerSystem::setupVars() {
             auto scsi_internal_name = QString(storage_config[key]);
             auto scsi_id = scsi_card_get_from_internal_name(scsi_internal_name.toUtf8().data());
             auto scsi_device = scsi_card_getdevice(scsi_id);
-            auto scsi_name = QString(scsi_device->name);
+            auto scsi_name = DeviceConfig::DeviceName(scsi_device, scsi_card_get_internal_name(scsi_id), 1);
             if(!scsi_name.isEmpty()) {
                 scsiControllers.append(scsi_name);
             }
@@ -946,14 +946,15 @@ VMManagerSystem::setupVars() {
     // Input (Mouse)
     auto mouse_internal_name = input_config["mouse_type"];
     auto mouse_dev = mouse_get_from_internal_name(mouse_internal_name.toUtf8().data());
-    auto mouse_dev_name = mouse_get_name(mouse_dev);
+    auto mouse_dev_name = DeviceConfig::DeviceName(mouse_get_device(mouse_dev), mouse_get_internal_name(mouse_dev), 0);
     display_table[Display::Name::Mouse] = mouse_dev_name;
 
     // Input (joystick)
     QString joystickDevice;
-    if(auto joystick_internal = QString(input_config["joystick_type"]); !joystick_internal.isEmpty()) {
+    if(input_config.contains("joystick_type")) {
+        auto joystick_internal = QString(input_config["joystick_type"]);
         auto joystick_dev = joystick_get_from_internal_name(joystick_internal.toUtf8().data());
-        if (auto joystickName = QString(joystick_get_name(joystick_dev)); !joystickName.isEmpty()) {
+        if (auto joystickName = tr(joystick_get_name(joystick_dev)); !joystickName.isEmpty()) {
             joystickDevice = joystickName;
         }
     }

--- a/src/qt/qt_vmmanager_system.cpp
+++ b/src/qt/qt_vmmanager_system.cpp
@@ -591,10 +591,40 @@ VMManagerSystem::setupVars() {
     int video_int = video_get_video_from_internal_name(video_config["gfxcard"].toUtf8().data());
     const device_t* video_dev = video_card_getdevice(video_int);
     display_table[Display::Name::Video] = DeviceConfig::DeviceName(video_dev, video_get_internal_name(video_int), 1);
-    if (!video_config["voodoo"].isEmpty()) {
-        // FIXME: Come back to this later to add more for secondary video
-//        display_table[Display::Name::Video].append(" (with voodoo)");
-        display_table[Display::Name::Voodoo] = "Voodoo enabled";
+
+    // Secondary video
+    if (video_config.contains("gfxcard_2")) {
+        int video2_int = video_get_video_from_internal_name(video_config["gfxcard_2"].toUtf8().data());
+        const device_t* video2_dev = video_card_getdevice(video2_int);
+        display_table[Display::Name::Video].append(DeviceConfig::DeviceName(video2_dev, video_get_internal_name(video2_int), 1).prepend(VMManagerDetailSection::sectionSeparator));
+    }
+
+    // Add-on video that's not Voodoo
+    if (video_config.contains("8514a") && (video_config["8514a"] != 0))
+        display_table[Display::Name::Video].append(tr("IBM 8514/A Graphics").prepend(VMManagerDetailSection::sectionSeparator));
+    if (video_config.contains("xga") && (video_config["xga"] != 0))
+        display_table[Display::Name::Video].append(tr("XGA Graphics").prepend(VMManagerDetailSection::sectionSeparator));
+    if (video_config.contains("da2") && (video_config["da2"] != 0))
+        display_table[Display::Name::Video].append(tr("IBM PS/55 Display Adapter Graphics").prepend(VMManagerDetailSection::sectionSeparator));
+
+    // Voodoo
+    if (video_config.contains("voodoo") && (video_config["voodoo"] != 0)) {
+        auto voodoo_config = getCategory(DeviceConfig::DeviceName(&voodoo_device, "voodoo", 0));
+        int voodoo_type = voodoo_config["type"].toInt();
+        QString voodoo_name;
+        switch (voodoo_type) {
+            case 0:
+            default:
+                voodoo_name = tr("3Dfx Voodoo Graphics");
+                break;
+            case 1:
+                voodoo_name = tr("Obsidian SB50 + Amethyst (2 TMUs)");
+                break;
+            case 2:
+                voodoo_name = tr("3Dfx Voodoo 2");
+                break;
+        }
+        display_table[Display::Name::Voodoo] = voodoo_name;
     }
 
     // Drives

--- a/src/qt/qt_vmmanager_system.cpp
+++ b/src/qt/qt_vmmanager_system.cpp
@@ -688,6 +688,12 @@ VMManagerSystem::setupVars() {
     // Floppy & CD-ROM
     QStringList floppyDevices;
     QStringList cdromDevices;
+    // Special case: first two 5.25" 360k FDDs which don't get saved to the .cfg
+    for (int i = 0; i < 2; i++) {
+        if (!floppy_cdrom_config.contains(QString("fdd_0%1_type").arg(i + 1)))
+            floppyDevices.append(QString(fdd_getname(fdd_get_from_internal_name((char *) "525_2dd"))));
+    }
+
     static auto floppy_match = QRegularExpression("fdd_\\d\\d_type", QRegularExpression::CaseInsensitiveOption);
     static auto cdrom_match  = QRegularExpression("cdrom_\\d\\d_type", QRegularExpression::CaseInsensitiveOption);
     for(const auto& key: floppy_cdrom_config.keys()) {

--- a/src/qt/qt_vmmanager_system.cpp
+++ b/src/qt/qt_vmmanager_system.cpp
@@ -61,6 +61,7 @@ extern "C" {
 #include <86box/gameport.h>
 #include <86box/midi.h>
 #include <86box/network.h>
+#include <86box/keyboard.h>
 #include <86box/mouse.h>
 }
 
@@ -928,6 +929,14 @@ VMManagerSystem::setupVars() {
         nicList.append(tr("None"));
     }
     display_table[Display::Name::NIC] = nicList.join(VMManagerDetailSection::sectionSeparator);
+
+    // Input (Keyboard)
+    if (input_config.contains("keyboard_type")) {
+        auto keyboard_internal_name = input_config["keyboard_type"];
+        auto keyboard_dev = keyboard_get_from_internal_name(keyboard_internal_name.toUtf8().data());
+        auto keyboard_dev_name = DeviceConfig::DeviceName(keyboard_get_device(keyboard_dev), keyboard_get_internal_name(keyboard_dev), 0);
+        display_table[Display::Name::Keyboard] = keyboard_dev_name;
+    }
 
     // Input (Mouse)
     auto mouse_internal_name = input_config["mouse_type"];

--- a/src/qt/qt_vmmanager_system.cpp
+++ b/src/qt/qt_vmmanager_system.cpp
@@ -59,6 +59,7 @@ extern "C" {
 #include <86box/fdc_ext.h>
 #include <86box/hdc.h>
 #include <86box/gameport.h>
+#include <86box/lpt.h>
 #include <86box/midi.h>
 #include <86box/network.h>
 #include <86box/keyboard.h>
@@ -996,15 +997,25 @@ VMManagerSystem::setupVars() {
             break;
     }
     portIndex = 0;
+    bool hasLptDevices = false;
     while (true) {
-        if (lpt_enabled[portIndex])
-            lptFinal.append(QString("LPT%1").arg(portIndex + 1));
+        if (lpt_enabled[portIndex]) {
+            auto lpt_device_key = QString("lpt%1_device").arg(portIndex + 1);
+            QString lpt_device_name = "";
+            if (ports_config.contains(lpt_device_key)) {
+                auto lpt_internal_name = QString(ports_config[lpt_device_key]);
+                auto lpt_id = lpt_device_get_from_internal_name(lpt_internal_name.toUtf8().data());
+                lpt_device_name = " (" + tr(lpt_device_get_name(lpt_id)) + ")";
+                hasLptDevices = true;
+            }
+            lptFinal.append(QString("LPT%1%2").arg(portIndex + 1).arg(lpt_device_name));
+        }
         ++portIndex;
         if (portIndex == PARALLEL_MAX)
             break;
     }
-    display_table[Display::Name::Serial]   = serialFinal.empty() ?  tr("None") : serialFinal.join(", ");
-    display_table[Display::Name::Parallel] = lptFinal.empty()    ?  tr("None") : lptFinal.join(", ");
+    display_table[Display::Name::Serial]   = (serialFinal.empty() ?  tr("None") : serialFinal.join(", "));
+    display_table[Display::Name::Parallel] = (lptFinal.empty()    ?  tr("None") : lptFinal.join((hasLptDevices ? VMManagerDetailSection::sectionSeparator : ", ")));
 
 }
 

--- a/src/qt/qt_vmmanager_system.hpp
+++ b/src/qt/qt_vmmanager_system.hpp
@@ -46,6 +46,8 @@ enum class Name {
     Disks,
     Floppy,
     CD,
+    RDisk,
+    MO,
     SCSIController,
     MidiOut,
     Joystick,

--- a/src/qt/qt_vmmanager_system.hpp
+++ b/src/qt/qt_vmmanager_system.hpp
@@ -49,6 +49,7 @@ enum class Name {
     RDisk,
     MO,
     SCSIController,
+    StorageController,
     MidiOut,
     Joystick,
     Serial,

--- a/src/qt/qt_vmmanager_system.hpp
+++ b/src/qt/qt_vmmanager_system.hpp
@@ -57,6 +57,7 @@ enum class Name {
     Audio,
     Voodoo,
     NIC,
+    Keyboard,
     Mouse,
     Unknown
 };

--- a/src/qt/qt_vmmanager_system.hpp
+++ b/src/qt/qt_vmmanager_system.hpp
@@ -59,6 +59,9 @@ enum class Name {
     NIC,
     Keyboard,
     Mouse,
+    IsaRtc,
+    IsaMem,
+    IsaRom,
     Unknown
 };
 Q_ENUM_NS(Name)


### PR DESCRIPTION
Summary
=======
The following hardware types are now displayed in the details view:
* FPU (non-integrated);
* Secondary video card, graphics accelerator cards other than Voodoo, and Voodoo 1/2 type;
* Removable disk and MO drives;
* External storage controllers (floppy, HDD, CD-ROM), in addition to SCSI;
* Sound cards beyond the first one and standalone MPU-401;
* Keyboard type;
* Devices connected to parallel ports;
* ISA RTC, ROM and memory expansion cards.

Compatibility with 4.2.x configs for ZIP drives and hard drive controllers (including tertiary/quaternary IDE) is present.

Additionally:
* Non-integer CPU clocks are now displayed correctly;
* 5¼" 360 KB floppy drives are now displayed correctly;
* Network types are now correctly capitalized;
* Translated device names will now be used, if available.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A