### PR TITLE
Machine Table Fixes (August 2)

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -1818,7 +1818,7 @@ const machine_t machines[] = {
             .min_multi = 0, 
             .max_multi = 0 
         }, 
-        .bus_flags = MACHINE_PS2, 
+        .bus_flags = MACHINE_PC | MACHINE_BUS_PS2, 
         .flags = MACHINE_FLAGS_NONE, 
         .ram = { 
             .min = 64, 
@@ -16705,48 +16705,6 @@ const machine_t machines[] = {
         .snd_device = NULL, 
         .net_device = NULL 
     }, 
-    /* Has a National Semiconductors PC87309 Super I/O chip with on-chip KBC 
-       with most likely AMIKey-2 KBC firmware. */ 
-    { 
-        .name = "[i440BX] Tyan Tsunami ATX", 
-        .internal_name = "s1846", 
-        .type = MACHINE_TYPE_SLOT1, 
-        .chipset = MACHINE_CHIPSET_INTEL_440BX, 
-        .init = machine_at_s1846_init, 
-        .p1_handler = NULL, 
-        .gpio_handler = NULL, 
-        .available_flag = MACHINE_AVAILABLE, 
-        .gpio_acpi_handler = NULL, 
-        .cpu = { 
-            .package = CPU_PKG_SLOT1, 
-            .block = CPU_BLOCK_NONE, 
-            .min_bus = 66666667, 
-            .max_bus = 112121212, 
-            .min_voltage = 1800, 
-            .max_voltage = 3500, 
-            .min_multi = 1.5, 
-            .max_multi = 8.0 
-        }, 
-        .bus_flags = MACHINE_PS2_AGP | MACHINE_BUS_USB, 
-        .flags = MACHINE_IDE_DUAL | MACHINE_SOUND | MACHINE_APM | MACHINE_ACPI | MACHINE_USB, /* Machine has internal sound: Ensoniq ES1371 */ 
-        .ram = { 
-            .min = 8192, 
-            .max = 786432, 
-            .step = 8192 
-        }, 
-        .nvrmask = 255, 
-        .kbc_device = NULL, 
-        .kbc_p1 = 0xff, 
-        .gpio = 0xffffffff, 
-        .gpio_acpi = 0xffffffff, 
-        .device = NULL, 
-        .kbd_device = NULL, 
-        .fdc_device = NULL, 
-        .sio_device = NULL, 
-        .vid_device = NULL, 
-        .snd_device = &es1371_onboard_device, 
-        .net_device = NULL 
-    }, 
     /* Has a Winbond W83977TF Super I/O chip with on-chip KBC with AMIKey-2 KBC 
        firmware. */ 
     { 
@@ -16787,6 +16745,48 @@ const machine_t machines[] = {
         .sio_device = NULL, 
         .vid_device = NULL, 
         .snd_device = NULL, 
+        .net_device = NULL 
+    }, 
+    /* Has a National Semiconductors PC87309 Super I/O chip with on-chip KBC 
+       with most likely AMIKey-2 KBC firmware. */ 
+    { 
+        .name = "[i440BX] Tyan Tsunami ATX", 
+        .internal_name = "s1846", 
+        .type = MACHINE_TYPE_SLOT1, 
+        .chipset = MACHINE_CHIPSET_INTEL_440BX, 
+        .init = machine_at_s1846_init, 
+        .p1_handler = NULL, 
+        .gpio_handler = NULL, 
+        .available_flag = MACHINE_AVAILABLE, 
+        .gpio_acpi_handler = NULL, 
+        .cpu = { 
+            .package = CPU_PKG_SLOT1, 
+            .block = CPU_BLOCK_NONE, 
+            .min_bus = 66666667, 
+            .max_bus = 112121212, 
+            .min_voltage = 1800, 
+            .max_voltage = 3500, 
+            .min_multi = 1.5, 
+            .max_multi = 8.0 
+        }, 
+        .bus_flags = MACHINE_PS2_AGP | MACHINE_BUS_USB, 
+        .flags = MACHINE_IDE_DUAL | MACHINE_SOUND | MACHINE_APM | MACHINE_ACPI | MACHINE_USB, /* Machine has internal sound: Ensoniq ES1371 */ 
+        .ram = { 
+            .min = 8192, 
+            .max = 786432, 
+            .step = 8192 
+        }, 
+        .nvrmask = 255, 
+        .kbc_device = NULL, 
+        .kbc_p1 = 0xff, 
+        .gpio = 0xffffffff, 
+        .gpio_acpi = 0xffffffff, 
+        .device = NULL, 
+        .kbd_device = NULL, 
+        .fdc_device = NULL, 
+        .sio_device = NULL, 
+        .vid_device = NULL, 
+        .snd_device = &es1371_onboard_device, 
         .net_device = NULL 
     }, 
  


### PR DESCRIPTION
Summary
=======
-The Xi8088 machine had no ISA16 expansion slots according to the image of Monotech NuXT V2.0 (which the BIOS is located on the motherboard) on The Retro Web
-Move i440BX Supermicro machine to be above Tyan Tsunami ATX in alphabetical order.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[Monotech NuXT V2.0 (Xi8088) page on The Retro Web](https://theretroweb.com/motherboards/s/monotech-nuxt-v2.0)
