### PR TITLE
Remove incorrect port additions on the Covox Sound Master Plus

### DIFF
--- a/src/sound/snd_covox.c
+++ b/src/sound/snd_covox.c
@@ -285,10 +285,6 @@ static const device_config_t soundmasterplus_config[] = {
         .file_filter    = NULL,
         .spinner        = { 0 },
         .selection      = {
-            { .description = "0x220", .value = 0x220 },
-            { .description = "0x240", .value = 0x240 },
-            { .description = "0x280", .value = 0x280 },
-            { .description = "0x2c0", .value = 0x2c0 },
             { .description = "0x330", .value = 0x330 },
             { .description = "0x338", .value = 0x338 },
             { .description = ""                      }


### PR DESCRIPTION
Summary
=======
Remove incorrect port additions on the Covox Sound Master Plus

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
