### PR TITLE
Machine table: Memory fixes (August 5)

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -6458,7 +6458,7 @@ const machine_t machines[] = {
         .flags = MACHINE_APM, 
         .ram = { 
             .min = 1024, 
-            .max = 49152, 
+            .max = 65536, 
             .step = 1024 
         }, 
         .nvrmask = 127, 
@@ -8324,7 +8324,7 @@ const machine_t machines[] = {
         .flags = MACHINE_SUPER_IO | MACHINE_IDE | MACHINE_APM, 
         .ram = { 
             .min = 1024, 
-            .max = 32768, 
+            .max = 131072, 
             .step = 1024 
         }, 
         .nvrmask = 127, 
@@ -8365,7 +8365,7 @@ const machine_t machines[] = {
         .flags = MACHINE_APM, 
         .ram = { 
             .min = 1024, 
-            .max = 40960, 
+            .max = 131072,
             .step = 1024 
         }, 
         .nvrmask = 127, 
@@ -8704,8 +8704,8 @@ const machine_t machines[] = {
         .bus_flags = MACHINE_PS2, 
         .flags = MACHINE_SUPER_IO | MACHINE_IDE | MACHINE_APM, /* Has onboard video: C&T F65545 */ 
         .ram = { 
-            .min = 1024, 
-            .max = 32768, 
+            .min = 8192, 
+            .max = 73728, 
             .step = 1024 
         }, 
         .nvrmask = 255, 


### PR DESCRIPTION
Summary
=======
According to their official manuals (except for AP-4100AA, which does not have a manual on The Retro Web), this fixes the memory configuration on four machines:

1. DataExpert EXP4349: Increase maximum memory from 48mb to 64mb
2. Lanner Electronics AP-4100AA: Increase maximum memory from 32mb to 128mb (assumed)
3. A-Trend ATC-1762: Increase maximum memory from 40mb to 128mb
4. Acrosser AR-B1476: Increase minimum memory from 1mb to 8mb (the motherboard has 8mb memory onboard), and increase maximum memory from 32mb to 72mb

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[Manual for DataExpert EXP4349](https://theretroweb.com/motherboard/manual/dataexpert-expertboard-exp4349-users-manual-62028f11175ef640491931.pdf)
[Manual for A-Trend ATC-1762](https://theretroweb.com/motherboard/manual/ali-deep-green-486wb-67c97066bd2f6475638248.pdf)
[Manual for Acrosser AR-B1476](https://theretroweb.com/motherboard/manual/1476v152-636ebfd89bde6225222566.pdf)
