### PR TITLE
Fix building on Haiku

### DIFF
--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -25,6 +25,11 @@
 #include <stdarg.h>
 #endif
 
+#if defined(__HAIKU__)
+/* Doesn't compile on Haiku without this include */
+#include <stdlib.h>
+#endif
+
 /* Configuration values. */
 #define GFXCARD_MAX  2
 #define SERIAL_MAX   8


### PR DESCRIPTION
Summary
=======
Various build issues on Haiku, mostly involving system headers having fields clobbered by cpu-related defines, can be fixed simply by including stdlib.h at the top of 86box.h.

Checklist
=========
* [ ] ~~Closes #xxx~~
* [ ] ~~I have discussed this with core contributors already~~
* [ ] ~~This pull request requires changes to the ROM set~~
  * [ ] ~~I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/~~

References
==========
N/A