### PR TITLE
MM58167 register index 0x0 and 0x5 are also half-registers

### DIFF
--- a/src/device/isartc.c
+++ b/src/device/isartc.c
@@ -410,11 +410,16 @@ mm67_read(uint16_t port, void *priv)
             break;
 
         case MM67_AL_MSEC:
+        case MM67_MSEC:
             ret                = dev->nvr.regs[reg] & 0xf0;
             break;
 
         case MM67_AL_DOW:
             ret                = dev->nvr.regs[reg] & 0x0f;
+            break;
+
+        case MM67_DOW:
+            ret                = dev->nvr.regs[reg] & 0x07;
             break;
 
         default:


### PR DESCRIPTION
Summary
=======

Related to https://github.com/86Box/86Box/issues/3347, the corresponding registers in the low bank also have some bits not implemented, always reading as 0.

- `0x0` and `0x8` low nibbles are always `0` (`& 0xf0`)
- `0x5` high 5 bits are always `0` (`& 0x07`)
- `0xd` high nibble is always `0` (`& 0x0f`)

Checklist
=========
* [ ] Closes (n/a)
* [x] I have discussed this with core contributors already (jriwanek)
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
Page 4 of MM58167 datasheet:

https://www.alldatasheet.com/datasheet-pdf/view/9283/NSC/MM58167.html

Example of write/reads on real hardware showing out of range bits cleared:

<img width="422" height="652" alt="image" src="https://github.com/user-attachments/assets/a329e3d2-5122-4d42-8a05-7e4a8bcaee98" />

Example of current 86Box behavior:

<img width="256" height="388" alt="image" src="https://github.com/user-attachments/assets/97390def-3cb2-4e89-bd7a-885b46dfbebe" />


