### PR TITLE
Update GLaTICK ROM links

### DIFF
--- a/src/device/isartc.c
+++ b/src/device/isartc.c
@@ -92,8 +92,8 @@
 #define ISARTC_MPLUS2  5
 #define ISARTC_MM58167 10
 
-#define ISARTC_ROM_MM58167_1 "roms/rtc/glatick/GLaTICK_0.8.5_NS_RP.ROM"
-#define ISARTC_ROM_MM58167_2 "roms/rtc/glatick/GLaTICK_0.8.5_86B.ROM"
+#define ISARTC_ROM_MM58167_1 "roms/rtc/glatick/GLaTICK_0.8.8_NS_86B.ROM"  /* Generic 58167, AST or EV-170 */
+#define ISARTC_ROM_MM58167_2 "roms/rtc/glatick/GLaTICK_0.8.8_NS_86B2.ROM" /* PII-147 */
 
 #define ISARTC_DEBUG  0
 


### PR DESCRIPTION
Updates GLaTICK 0.8.8/86B version to use same year register as 86Box time synchronization.

Summary
=======
Default GLaTICK MM58167 uses register `0AH` to store year (compatible with AST `ASTCLOCK.COM`), whereas 86Box time sync uses register `0EH` to store year. This version uses `0EH` so year is also correctly read.

Checklist
=========
* [ ] Closes #n/a
* [X] I have discussed this with core contributors already (@jriwanek)
* [X] This pull request requires changes to the ROM set
  * [X] I have opened a roms pull request - https://github.com/86Box/roms/pull/360

References
==========
n/a
