### PR TITLE
Manager: Replace system location in the new machine wizard with display name

### DIFF
--- a/src/qt/qt_vmmanager_addmachine.cpp
+++ b/src/qt/qt_vmmanager_addmachine.cpp
@@ -261,6 +261,12 @@ NameAndLocationPage(QWidget *parent)
     systemLocationValidation->setWordWrap(true);
 #endif
 
+    const auto displayNameLabel = new QLabel(tr("Display Name (optional)"));
+    displayName           = new QLineEdit();
+    // Special event filter to override enter key
+    displayName->installEventFilter(this);
+    registerField("displayName*", displayName);
+
     const auto layout = new QGridLayout();
     layout->addWidget(topLabel, 0, 0, 1, -1);
     // Spacer row
@@ -282,6 +288,11 @@ NameAndLocationPage(QWidget *parent)
     layout->addWidget(systemLocationValidation, 6, 0, 1, -1);
     layout->setRowMinimumHeight(6, 20);
 #endif
+
+    // Another spacer
+    layout->setRowMinimumHeight(7, 20);
+    layout->addWidget(displayNameLabel, 8, 0);
+    layout->addWidget(displayName, 8, 1);
 
     setLayout(layout);
 
@@ -382,6 +393,10 @@ ConclusionPage(QWidget *parent)
     systemLocation      = new QLabel();
 #endif
 
+    displayNameLabel                = new QLabel(tr("Display name:"));
+    displayNameLabel->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
+    displayName                     = new QLabel();
+
     const auto layout = new QGridLayout();
     layout->addWidget(topLabel, 0, 0, 1, -1);
     layout->setRowMinimumHeight(1, 20);
@@ -391,6 +406,8 @@ ConclusionPage(QWidget *parent)
     layout->addWidget(systemLocationLabel, 3, 0);
     layout->addWidget(systemLocation, 3, 1);
 #endif
+    layout->addWidget(displayNameLabel, 4, 0);
+    layout->addWidget(displayName, 4, 1);
 
     setLayout(layout);
 }
@@ -404,9 +421,16 @@ ConclusionPage::initializePage()
     const auto nativePath = QDir::toNativeSeparators(finalPath);
 #endif
     const auto systemNameDisplay = field("systemName").toString();
+    const auto displayNameDisplay = field("displayName").toString();
 
     systemName->setText(systemNameDisplay);
 #ifdef CUSTOM_SYSTEM_LOCATION
     systemLocation->setText(nativePath);
 #endif
+    if (!displayNameDisplay.isEmpty())
+        displayName->setText(displayNameDisplay);
+    else {
+        displayNameLabel->setVisible(false);
+        displayName->setVisible(false);
+    }
 }

--- a/src/qt/qt_vmmanager_addmachine.hpp
+++ b/src/qt/qt_vmmanager_addmachine.hpp
@@ -93,6 +93,7 @@ private:
 #ifdef CUSTOM_SYSTEM_LOCATION
     QLineEdit *systemLocation;
 #endif
+    QLineEdit *displayName;
     QLabel    *systemNameValidation;
 #ifdef CUSTOM_SYSTEM_LOCATION
     QLabel    *systemLocationValidation;
@@ -116,6 +117,8 @@ private:
 #ifdef CUSTOM_SYSTEM_LOCATION
     QLabel *systemLocation;
 #endif
+    QLabel *displayNameLabel;
+    QLabel *displayName;
 protected:
     void initializePage() override;
 };

--- a/src/qt/qt_vmmanager_main.cpp
+++ b/src/qt/qt_vmmanager_main.cpp
@@ -355,12 +355,13 @@ VMManagerMain::newMachineWizard()
         const auto systemDir      = QDir(vmm_path).path();
 #endif
         const auto existingConfiguration = wizard->field("existingConfiguration").toString();
-        addNewSystem(newName, systemDir, existingConfiguration);
+        const auto displayName           = wizard->field("displayName").toString();
+        addNewSystem(newName, systemDir, displayName, existingConfiguration);
     }
 }
 
 void
-VMManagerMain::addNewSystem(const QString &name, const QString &dir, const QString &configFile)
+VMManagerMain::addNewSystem(const QString &name, const QString &dir, const QString &displayName, const QString &configFile)
 {
     const auto newSytemDirectory = QDir(QDir::cleanPath(dir + "/" + name));
 
@@ -423,6 +424,8 @@ VMManagerMain::addNewSystem(const QString &name, const QString &dir, const QStri
                     delete new_system;
                     return;
                 }
+                auto added_system = vm_model->getConfigObjectForIndex(created_object);
+                added_system->setDisplayName(displayName);
                 // Get the index of the newly-created system and select it
                 const QModelIndex mapped_index = proxy_model->mapFromSource(created_object);
                 ui->listView->setCurrentIndex(mapped_index);

--- a/src/qt/qt_vmmanager_main.hpp
+++ b/src/qt/qt_vmmanager_main.hpp
@@ -70,7 +70,7 @@ public slots:
     void shutdownForceButtonPressed() const;
     void searchSystems(const QString &text) const;
     void newMachineWizard();
-    void addNewSystem(const QString &name, const QString &dir, const QString &configFile = {});
+    void addNewSystem(const QString &name, const QString &dir, const QString &displayName = QString(), const QString &configFile = {});
 #if __GNUC__ >= 11
     [[nodiscard]] QStringList getSearchCompletionList() const;
 #else


### PR DESCRIPTION
Summary
=======
Disable the "system location" field in the new machine wizard until support is implemented for running machines outside the system directory. Allow to specify machine's display name instead.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A