### PR TITLE
Change flags to DEVICE_ISA16 for Oki vga/h-2 and spaced. vid_jega.c

### DIFF
--- a/src/video/vid_jega.c
+++ b/src/video/vid_jega.c
@@ -912,9 +912,9 @@ const device_t jega_device = {
 };
 
 const device_t jvga_device = {
-    .name          = "OKIVGA/H-2 (JVGA/H)",
+    .name          = "OKI VGA/H-2 (JVGA/H)",
     .internal_name = "jvga",
-    .flags         = DEVICE_ISA,
+    .flags         = DEVICE_ISA16,
     .local         = 0,
     .init          = jvga_standalone_init,
     .close         = jega_close,


### PR DESCRIPTION
has isa 16 slot.
src: https://x.com/konekodensetsu/status/1804920614794440854

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
src: https://x.com/konekodensetsu/status/1804920614794440854
