### PR TITLE
Manager: Use UTF-8 when reading/writing INI files

### DIFF
--- a/src/qt/qt_vmmanager_config.cpp
+++ b/src/qt/qt_vmmanager_config.cpp
@@ -33,6 +33,7 @@ VMManagerConfig::VMManagerConfig(const ConfigType type, const QString& section)
     config_type = type;
 
     settings = new QSettings(configFile, QSettings::IniFormat, this);
+    settings->setIniCodec("UTF-8");
     settings->setFallbacksEnabled(false);
     if(type == ConfigType::System && !section.isEmpty()) {
         settings->beginGroup(section);

--- a/src/qt/qt_vmmanager_system.cpp
+++ b/src/qt/qt_vmmanager_system.cpp
@@ -234,6 +234,7 @@ VMManagerSystem::loadSettings()
     }
     // qInfo() << "Loaded "<< config_file.filePath() << "status:" << settings.status();
 
+    settings.setIniCodec("UTF-8");
     // Clear out the config hash in case the config is reloaded
     for (const auto &outer_key : config_hash.keys()) {
         config_hash[outer_key].clear();


### PR DESCRIPTION
Summary
=======
Manager: Explicitly set UTF-8 encoding when reading/writing INI files, to avoid non-ASCII text being saved as escape sequences.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A