### PR TITLE
Manager: Add machine deletion

### DIFF
--- a/src/qt/qt_vmmanager_main.hpp
+++ b/src/qt/qt_vmmanager_main.hpp
@@ -70,6 +70,7 @@ public slots:
     void shutdownForceButtonPressed() const;
     void searchSystems(const QString &text) const;
     void newMachineWizard();
+    void deleteSystem(VMManagerSystem *sysconfig);
     void addNewSystem(const QString &name, const QString &dir, const QString &displayName = QString(), const QString &configFile = {});
 #if __GNUC__ >= 11
     [[nodiscard]] QStringList getSearchCompletionList() const;

--- a/src/qt/qt_vmmanager_model.cpp
+++ b/src/qt/qt_vmmanager_model.cpp
@@ -140,6 +140,18 @@ VMManagerModel::addConfigToModel(VMManagerSystem *system_config)
     connect(system_config, &VMManagerSystem::itemDataChanged, this, &VMManagerModel::modelDataChanged);
     endInsertRows();
 }
+
+void
+VMManagerModel::removeConfigFromModel(VMManagerSystem *system_config)
+{
+    const QModelIndex index = getIndexForConfigFile(system_config->config_file);
+    disconnect(system_config, &VMManagerSystem::itemDataChanged, this, &VMManagerModel::modelDataChanged);
+    beginRemoveRows(QModelIndex(), index.row(), index.row());
+    machines.remove(index.row());
+    endRemoveRows();
+    emit systemDataChanged();
+}
+
 void
 VMManagerModel::modelDataChanged()
 {

--- a/src/qt/qt_vmmanager_model.hpp
+++ b/src/qt/qt_vmmanager_model.hpp
@@ -51,6 +51,7 @@ public:
     [[nodiscard]] QVariant headerData(int section, Qt::Orientation orientation,
                         int role) const override;
     void addConfigToModel(VMManagerSystem *system_config);
+    void removeConfigFromModel(VMManagerSystem *system_config);
 
     [[nodiscard]] VMManagerSystem * getConfigObjectForIndex(const QModelIndex &index) const;
     QModelIndex getIndexForConfigFile(const QFileInfo& config_file);

--- a/src/qt/qt_vmmanager_system.hpp
+++ b/src/qt/qt_vmmanager_system.hpp
@@ -136,6 +136,7 @@ public:
     QProcess *process = new QProcess();
 
     bool window_obscured;
+    bool config_signal_connected = false;
 
     QString getDisplayValue(VMManager::Display::Name key);
     QFileInfoList getScreenshots();


### PR DESCRIPTION
Summary
=======
Add a way to delete machines in manager (along with all their files) to the context menu.

Checklist
=========
* [x] Closes #5873
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A