### PR TITLE
NEC Mate NX MA23C & MA30D have no ISA slot, and update MA30D's note

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -14283,7 +14283,7 @@ const machine_t machines[] = {
             .min_multi = 1.5, 
             .max_multi = 3.5 
         }, 
-        .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB, 
+        .bus_flags = MACHINE_PS2_PCIONLY | MACHINE_BUS_USB, 
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB, /* Machine has internal video: Cirrus Logic CL-GD5465 and internal sound: Yamaha YMF715 */
         .ram = { 
             .min = 8192, 
@@ -16346,7 +16346,7 @@ const machine_t machines[] = {
             .min_multi = 1.5, 
             .max_multi = 8.0 
         }, 
-        .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB, /* Has internal video: SGS Thompson Riva 128 AGP, network: NEC PK-UG-X006 (Intel 82558B chip) and sound: OAK Audia 3D (OTI-610) */ 
+        .bus_flags = MACHINE_PS2_PCIONLY | MACHINE_BUS_USB, /* Has internal video: SGS Thompson Riva 128 AGP, network: NEC PK-UG-X006 (Intel 82558B chip) and sound: OAK Audia 3D (OTI-610) for MA23D or YAMAHA YMF724 for MA30D */ 
         .flags = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB, 
         .ram = { 
             .min = 8192, 


### PR DESCRIPTION
Summary
=======
According a manual about MA30D & MA23C, the actual machines have PCI slots only, without any ISA slot. The YMF724 onboard sound chip is also mentioned in this manual.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
(https://support.nec-lavie.jp/e-manual/m/nx/ma/pg980518/hw/dnt4/v1/mst/mapcomn1.pdf)
PCI slots on Page 71, and YMF724 on Page 142.
