### PR TITLE
Fix warnings on Clang

### DIFF
--- a/src/utils/log.c
+++ b/src/utils/log.c
@@ -291,7 +291,7 @@ log_fatal(void *priv, const char *fmt, ...)
     va_start(ap, fmt);
     vsprintf(temp, fmt2, ap);
     va_end(ap);
-    fatal(temp);
+    fatal("%s", temp);
     exit(-1);
 }
 

--- a/src/utils/log.c
+++ b/src/utils/log.c
@@ -317,7 +317,7 @@ log_warning(void *priv, const char *fmt, ...)
     va_start(ap, fmt);
     vsprintf(temp, fmt2, ap);
     va_end(ap);
-    warning(temp, ap);
+    warning("%s", temp);
 }
 
 static void *


### PR DESCRIPTION
Summary
=======
Fix warnings on Clang.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
