### PR TITLE
Fix untranslated strings

### DIFF
--- a/src/qt/qt_updatedetails.cpp
+++ b/src/qt/qt_updatedetails.cpp
@@ -26,7 +26,7 @@ UpdateDetails::
 UpdateDetails(const UpdateCheck::UpdateResult &updateResult, QWidget *parent) : QDialog(parent), ui(new Ui::UpdateDetails)
 {
     ui->setupUi(this);
-    ui->updateTitle->setText("<b>An update to 86Box is available!</b>");
+    ui->updateTitle->setText(tr(("<b>An update to 86Box is available!</b>"));
     QString currentVersionText;
     QString releaseType = updateResult.channel == UpdateCheck::UpdateChannel::Stable ? tr("version") : tr("build");
     if(!updateResult.currentVersion.isEmpty()) {

--- a/src/qt/qt_vmmanager_addmachine.cpp
+++ b/src/qt/qt_vmmanager_addmachine.cpp
@@ -346,7 +346,7 @@ NameAndLocationPage::isComplete() const
     } else if (const auto dir = QDir(systemLocation->text()); !dir.exists()) {
         systemLocationValidation->setText(tr("Directory does not exist"));
     } else {
-        systemLocationValidation->setText("A new directory for the system will be created in the selected directory above");
+        systemLocationValidation->setText(tr("A new directory for the system will be created in the selected directory above"));
         locationValid = true;
     }
 

--- a/src/qt/qt_vmmanager_preferences.cpp
+++ b/src/qt/qt_vmmanager_preferences.cpp
@@ -65,7 +65,7 @@ void
 VMManagerPreferences::chooseDirectoryLocation()
 {
     // TODO: FIXME: This is pulling in the CLI directory! Needs to be set properly elsewhere
-    const auto directory = QFileDialog::getExistingDirectory(this, "Choose directory", QDir(vmm_path).path());
+    const auto directory = QFileDialog::getExistingDirectory(this, tr("Choose directory"), QDir(vmm_path).path());
     ui->systemDirectory->setText(QDir::toNativeSeparators(directory));
 }
 


### PR DESCRIPTION
Summary
=======
This PR fixes some strings that aren't translatable in the VM Manager and Update checker.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.