### PR TITLE
53c9x changes of the night (August 11th, 2025)

### DIFF
--- a/src/include/86box/scsi_pcscsi.h
+++ b/src/include/86box/scsi_pcscsi.h
@@ -26,6 +26,7 @@
 #define SCSI_PCSCSI_H
 
 extern const device_t am53c974_pci_device;
+extern const device_t am53c974a_pci_device;
 extern const device_t dc390_pci_device;
 extern const device_t ncr53c90a_mca_device;
 

--- a/src/scsi/scsi.c
+++ b/src/scsi/scsi.c
@@ -84,6 +84,7 @@ static SCSI_CARD scsi_cards[] = {
     { &buslogic_445c_device,     },
     /* PCI */
     { &am53c974_pci_device,      },
+    { &am53c974a_pci_device,     },
     { &buslogic_958d_pci_device, },
     { &ncr53c810_pci_device,     },
     { &ncr53c815_pci_device,     },


### PR DESCRIPTION
Summary
=======
1. Add the original AMD 53c974 (AMD bios only and revision 0x00 compared to the A revision which is 0x10 in the PCI regs) as well as correcting the SCSI bus reset when prompted (ESP CMD 0x03), the latter fixes DawiControl 53c974 drivers on win9x.
2. Check if DMA length is not 0 for DMA transfers.
3. More logs for possible problem diagnostics.


Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[AMD 53c974A revision manual](https://theretroweb.com/chip/documentation/am53c974a-665896ecb6501350650532.pdf)
[AMD 53c974 original manual](https://bitsavers.computerhistory.org/components/amd/_dataSheets/1993_53c974_PCscsi.pdf)
