### PR TITLE
Add open printer tray to tools dropdown

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -2271,6 +2271,13 @@ MainWindow::on_actionOpen_screenshots_folder_triggered()
 }
 
 void
+MainWindow::on_actionOpen_printer_tray_triggered()
+{
+    static_cast<void>(QDir(QString(usr_path) + QString("/printer/")).mkpath("."));
+    QDesktopServices::openUrl(QUrl(QString("file:///") + usr_path + QString("/printer/")));
+}
+
+void
 MainWindow::on_actionApply_fullscreen_stretch_mode_when_maximized_triggered(bool checked)
 {
     video_fullscreen_scale_maximized = checked;

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -163,6 +163,8 @@ private slots:
 
     void on_actionOpen_screenshots_folder_triggered();
 
+    void on_actionOpen_printer_tray_triggered();
+
     void on_actionApply_fullscreen_stretch_mode_when_maximized_triggered(bool checked);
 
 private:

--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -111,6 +111,7 @@
     <addaction name="actionMCA_devices"/>
     <addaction name="separator"/>
     <addaction name="actionOpen_screenshots_folder"/>
+    <addaction name="actionOpen_printer_tray"/>
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
@@ -846,6 +847,11 @@
   <action name="actionOpen_screenshots_folder">
    <property name="text">
     <string>Open screenshots &amp;folder...</string>
+   </property>
+  </action>
+  <action name="actionOpen_printer_tray">
+   <property name="text">
+    <string>Open &amp;printer tray...</string>
    </property>
   </action>
   <action name="actionApply_fullscreen_stretch_mode_when_maximized">


### PR DESCRIPTION
Summary
=======
Add open printer tray to tools dropdown
We already had it in the manager, makes sense to have it in the app too.

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
