### PR TITLE
Split off ROM set checking from pc_init_modules()

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -1184,11 +1184,10 @@ pc_full_speed(void)
 
 /* Initialize modules, ran once, after pc_init. */
 int
-pc_init_modules(void)
+pc_init_roms(void)
 {
     int     c;
     int     m;
-    wchar_t temp[512];
     char    tempc[512];
 
     if (dump_missing) {
@@ -1226,6 +1225,16 @@ pc_init_modules(void)
         return 0;
     }
     pc_log("A total of %d ROM sets have been loaded.\n", c);
+
+    return 1;
+}
+
+int
+pc_init_modules(void)
+{
+    int     c;
+    wchar_t temp[512];
+    char    tempc[512];
 
     /* Load the ROMs for the selected machine. */
     if (!machine_available(machine)) {

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -214,6 +214,7 @@ extern void update_mouse_msg(void);
 #if 0
 extern void pc_reload(wchar_t *fn);
 #endif
+extern int  pc_init_roms(void);
 extern int  pc_init_modules(void);
 extern int  pc_init(int argc, char *argv[]);
 extern void pc_close(void *threadid);

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -616,7 +616,7 @@ main(int argc, char *argv[])
 #    endif
 #endif
 
-    if (!pc_init_modules()) {
+    if (!pc_init_roms()) {
         QMessageBox fatalbox(QMessageBox::Icon::Critical, QObject::tr("No ROMs found"),
                              QObject::tr("86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."),
                              QMessageBox::Ok);
@@ -624,6 +624,9 @@ main(int argc, char *argv[])
         fatalbox.exec();
         return 6;
     }
+
+    if (!vmm_enabled)
+        pc_init_modules();
 
     if (vmm_enabled) {
         // VMManagerMain vmm;

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -1228,11 +1228,12 @@ main(int argc, char **argv)
     ret = pc_init(argc, argv);
     if (ret == 0)
         return 0;
-    if (!pc_init_modules()) {
+    if (!pc_init_roms()) {
         ui_msgbox_header(MBX_FATAL, L"No ROMs found.", L"86Box could not find any usable ROM images.\n\nPlease download a ROM set and extract it into the \"roms\" directory.");
         SDL_Quit();
         return 6;
     }
+    pc_init_modules();
 
     for (uint8_t i = 1; i < GFXCARD_MAX; i++)
         gfxcard[i]  = 0;


### PR DESCRIPTION
Summary
=======
Split off ROM set checking from pc_init_modules() into a separate function and make the original pc_init_modules() only get called when not starting the manager, skipping unneeded initialization of stuff not needed for the manager, including starting a blit thread.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A