### PR TITLE
Overhaul loading Qt base translations

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -575,7 +575,6 @@ foreach(po_file ${po_files})
         string(REGEX MATCH "[A-Z]+$" PO_COUNTRY ${PO_FILE_NAME})
 
         # Find the base Qt translation for the language and country
-        set(qt_translation_file_dest "qt_${PO_LANGUAGE}_${PO_COUNTRY}.qm")
         if (EXISTS "${QT_TRANSLATIONS_DIR}/qtbase_${PO_LANGUAGE}_${PO_COUNTRY}.qm")
             set(qt_translation_file "qtbase_${PO_LANGUAGE}_${PO_COUNTRY}.qm")
         # Fall back to just the language if country isn't found
@@ -594,13 +593,9 @@ foreach(po_file ${po_files})
         # Copy the translation file to the build directory
         if (qt_translation_file)
             file(COPY "${QT_TRANSLATIONS_DIR}/${qt_translation_file}" DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-            if (NOT (qt_translation_file STREQUAL qt_translation_file_dest))
-                # Rename the file for consistency
-                file(RENAME "${CMAKE_CURRENT_BINARY_DIR}/${qt_translation_file}" "${CMAKE_CURRENT_BINARY_DIR}/${qt_translation_file_dest}")
-            endif()
             # Add the file to the translations list
-            string(APPEND QT_TRANSLATIONS_LIST "        <file>${qt_translation_file_dest}</file>\n")
-            list(APPEND QM_FILES "${CMAKE_CURRENT_BINARY_DIR}/${qt_translation_file_dest}")
+            string(APPEND QT_TRANSLATIONS_LIST "        <file>${qt_translation_file}</file>\n")
+            list(APPEND QM_FILES "${CMAKE_CURRENT_BINARY_DIR}/${qt_translation_file}")
         endif()
     endif()
 

--- a/src/qt/qt_progsettings.hpp
+++ b/src/qt/qt_progsettings.hpp
@@ -49,6 +49,7 @@ private slots:
 
 private:
     Ui::ProgSettings *ui;
+    static bool loadQtTranslations(const QString name);
 
     friend class MainWindow;
     double mouseSensitivity;


### PR DESCRIPTION
Summary
=======
Overhaul loading Qt base translation files:
- Now comprehensively handles all possible locations (system-wide location, translations folder next to executable, embedded into executable if available) and filenames (`qtbase_` and `qt_`, with or without country specified)
- Embedded translation files don't have to be renamed anymore during building
- Fixed Qt 6 deprecation warnings

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A