### PR TITLE
Fix Qt 6 deprecation warnings

### DIFF
--- a/src/qt/qt_downloader.cpp
+++ b/src/qt/qt_downloader.cpp
@@ -31,7 +31,11 @@ Downloader(const DownloadLocation downloadLocation, QObject *parent)
     : QObject(parent)
     , file(nullptr)
     , reply(nullptr)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    , variantData(QMetaType(QMetaType::UnknownType))
+#else
     , variantData(QVariant::Invalid)
+#endif
 {
     char PATHBUF[256];
     switch (downloadLocation) {

--- a/src/qt/qt_machinestatus.hpp
+++ b/src/qt/qt_machinestatus.hpp
@@ -28,8 +28,13 @@ signals:
     void dropped(QString);
 
 protected:
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    void mousePressEvent(QMouseEvent *event) override { emit clicked(event->globalPosition().toPoint()); }
+    void mouseDoubleClickEvent(QMouseEvent *event) override { emit doubleClicked(event->globalPosition().toPoint()); }
+#else
     void mousePressEvent(QMouseEvent *event) override { emit clicked(event->globalPos()); }
     void mouseDoubleClickEvent(QMouseEvent *event) override { emit doubleClicked(event->globalPos()); }
+#endif
     void dragEnterEvent(QDragEnterEvent *event) override
     {
         if (event->mimeData()->hasUrls() && event->mimeData()->urls().size() == 1) {

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -736,7 +736,11 @@ MainWindow::MainWindow(QWidget *parent)
 
     setContextMenuPolicy(Qt::PreventContextMenu);
     /* Remove default Shift+F10 handler, which unfocuses keyboard input even with no context menu. */
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    connect(new QShortcut(QKeySequence(Qt::SHIFT | Qt::Key_F10), this), &QShortcut::activated, this, [](){});
+#else
     connect(new QShortcut(QKeySequence(Qt::SHIFT + Qt::Key_F10), this), &QShortcut::activated, this, [](){});
+#endif
 
     connect(this, &MainWindow::initRendererMonitor, this, &MainWindow::initRendererMonitorSlot);
     connect(this, &MainWindow::initRendererMonitorForNonQtThread, this, &MainWindow::initRendererMonitorSlot, Qt::BlockingQueuedConnection);

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -183,7 +183,11 @@ RendererStack::mouseReleaseEvent(QMouseEvent *event)
     rw_hwnd        = (HWND) this->winId();                
 #endif
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    if (!dopause && this->geometry().contains(m_monitor_index >= 1 ? event->globalPosition().toPoint() : event->position().toPoint()) &&
+#else
     if (!dopause && this->geometry().contains(m_monitor_index >= 1 ? event->globalPos() : event->pos()) &&
+#endif
         (event->button() == Qt::LeftButton) && !mouse_capture &&
         (isMouseDown & 1) && (kbd_req_capture || (mouse_get_buttons() != 0)) &&
         (mouse_input_mode == 0)) {
@@ -506,8 +510,13 @@ RendererStack::event(QEvent* event)
 
         if (m_monitor_index >= 1) {
             if (mouse_input_mode >= 1) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                mouse_x_abs       = (mouse_event->position().x()) / (double)width();
+                mouse_y_abs       = (mouse_event->position().y()) / (double)height();
+#else
                 mouse_x_abs       = (mouse_event->localPos().x()) / (double)width();
                 mouse_y_abs       = (mouse_event->localPos().y()) / (double)height();
+#endif
                 if (!mouse_tablet_in_proximity)
                     mouse_tablet_in_proximity = mousedata.mouse_tablet_in_proximity;
                 mouse_x_abs -= rendererWindow->destinationF.left();
@@ -527,8 +536,13 @@ RendererStack::event(QEvent* event)
 
 #ifdef Q_OS_WINDOWS
         if (mouse_input_mode == 0) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            mouse_x_abs           = (mouse_event->position().x()) / (double)width();
+            mouse_y_abs           = (mouse_event->position().y()) / (double)height();
+#else
             mouse_x_abs           = (mouse_event->localPos().x()) / (double)width();
             mouse_y_abs           = (mouse_event->localPos().y()) / (double)height();
+#endif
             mouse_x_abs          -= rendererWindow->destinationF.left();
             mouse_y_abs          -= rendererWindow->destinationF.top();
 
@@ -544,8 +558,13 @@ RendererStack::event(QEvent* event)
         }
 #endif
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        mouse_x_abs               = (mouse_event->position().x()) / (double)width();
+        mouse_y_abs               = (mouse_event->position().y()) / (double)height();
+#else
         mouse_x_abs               = (mouse_event->localPos().x()) / (double)width();
         mouse_y_abs               = (mouse_event->localPos().y()) / (double)height();
+#endif
         mouse_x_abs              -= rendererWindow->destinationF.left();
         mouse_y_abs              -= rendererWindow->destinationF.top();
 

--- a/src/qt/qt_settings.cpp
+++ b/src/qt/qt_settings.cpp
@@ -50,7 +50,11 @@ public:
     SettingsModel(QObject *parent)
         : QAbstractListModel(parent)
     {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        fontHeight = QFontMetrics(qApp->font()).height();
+#else
         fontHeight = QApplication::fontMetrics().height();
+#endif
     }
 
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;

--- a/src/qt/qt_vmmanager_system.cpp
+++ b/src/qt/qt_vmmanager_system.cpp
@@ -253,7 +253,11 @@ VMManagerSystem::loadSettings()
             QString setting_value;
             // QSettings will interpret lines with commas as QStringList.
             // Check for it and join them back to a string.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            if (settings.value(key_name).typeId() == QMetaType::QStringList) {
+#else
             if (settings.value(key_name).type() == QVariant::StringList) {
+#endif
                 setting_value = settings.value(key_name).toStringList().join(", ");
             } else {
                 setting_value = settings.value(key_name).toString();


### PR DESCRIPTION
Summary
=======
Fix the remaining Qt 6 deprecation warnings (at least for Linux).

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A