### PR TITLE
Change Machine name AX 286 to AX286D machine_table.c

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -3589,7 +3589,7 @@ const machine_t machines[] = {
     },
     /* Has unknown KBC firmware. */
     {
-        .name = "[ISA] Sharp AX 286",
+        .name = "[ISA] Sharp AX286D",
         .internal_name = "ax286",
         .type = MACHINE_TYPE_286,
         .chipset = MACHINE_CHIPSET_DISCRETE,


### PR DESCRIPTION
The dump is from Sharp AX286D
there are other portable model.
ax286n
src:

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
ax286n
https://www.facebook.com/groups/280993058608704/posts/8592062164168377/

