### PR TITLE
Fix the PB286 for real

### DIFF
--- a/src/machine/m_at_286.c
+++ b/src/machine/m_at_286.c
@@ -456,7 +456,7 @@ machine_at_pb286_init(const machine_t *model)
     int ret;
 
     ret = bios_load_interleaved("roms/machines/pb286/LB_V332P.BIN",
-                                "roms/machines/pb286/LB_V332P.BIN",
+                                "roms/machines/pb286/HB_V332P.BIN",
                                 0x000f0000, 65536, 0);
 
     if (bios_only || !ret)


### PR DESCRIPTION
Summary
=======
Actually fix the PB286, as it's an interleaved ROM
Checklist
=========
* [X] Closes #5969
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
