### PR TITLE
Manager: show a message box if a VM crashes

### DIFF
--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -1266,9 +1266,6 @@ msgstr ""
 msgid "Error adding system"
 msgstr ""
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr ""
-
 msgid "Remove directory failed"
 msgstr ""
 

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -1266,9 +1266,6 @@ msgstr ""
 msgid "Error adding system"
 msgstr ""
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr ""
-
 msgid "Remove directory failed"
 msgstr ""
 
@@ -2924,6 +2921,9 @@ msgstr ""
 
 msgid "Release notes:"
 msgstr ""
+
+msgid "%1 Hz"
+msgstr "%1 Hz"
 
 msgid "Virtual machine crash"
 msgstr ""

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -1266,9 +1266,6 @@ msgstr "Nebylo možné otevřít konfigurační soubor %1 pro zápis"
 msgid "Error adding system"
 msgstr "Chyba při přidávání systému"
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr "Abnormální ukončení programu při vytváření nového systému: kód ukončení %1, stav ukončení %2.\n\nSystém nebude přidán."
-
 msgid "Remove directory failed"
 msgstr "Odstranění adresáře se nezdařilo"
 

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -1266,9 +1266,6 @@ msgstr ""
 msgid "Error adding system"
 msgstr ""
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr ""
-
 msgid "Remove directory failed"
 msgstr ""
 
@@ -2924,6 +2921,9 @@ msgstr ""
 
 msgid "Release notes:"
 msgstr ""
+
+msgid "%1 Hz"
+msgstr "%1 Hz"
 
 msgid "Virtual machine crash"
 msgstr ""

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -1266,9 +1266,6 @@ msgstr "No fué posible abrir el archivo de configuración en %1 para escribir"
 msgid "Error adding system"
 msgstr "Error al añadir el sistema"
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr "Terminación abnormal del programa al crear el nuevo sistema: código de salida %1, estado de salida %2.\n\nEl sistema no será añadido."
-
 msgid "Remove directory failed"
 msgstr "Error al remover el directório"
 
@@ -2924,6 +2921,9 @@ msgstr "Actualización de 86Box"
 
 msgid "Release notes:"
 msgstr "Notas de versión:"
+
+msgid "%1 Hz"
+msgstr "%1 Hz"
 
 msgid "Virtual machine crash"
 msgstr "Terminación inesperada de la máquina virtual"

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -1266,9 +1266,6 @@ msgstr ""
 msgid "Error adding system"
 msgstr ""
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr ""
-
 msgid "Remove directory failed"
 msgstr ""
 
@@ -2924,6 +2921,9 @@ msgstr ""
 
 msgid "Release notes:"
 msgstr ""
+
+msgid "%1 Hz"
+msgstr "%1 Hz"
 
 msgid "Virtual machine crash"
 msgstr ""

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -1266,9 +1266,6 @@ msgstr ""
 msgid "Error adding system"
 msgstr ""
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr ""
-
 msgid "Remove directory failed"
 msgstr ""
 
@@ -2924,6 +2921,9 @@ msgstr ""
 
 msgid "Release notes:"
 msgstr ""
+
+msgid "%1 Hz"
+msgstr "%1 Hz"
 
 msgid "Virtual machine crash"
 msgstr ""

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -1266,9 +1266,6 @@ msgstr ""
 msgid "Error adding system"
 msgstr ""
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr ""
-
 msgid "Remove directory failed"
 msgstr ""
 
@@ -2924,6 +2921,9 @@ msgstr ""
 
 msgid "Release notes:"
 msgstr ""
+
+msgid "%1 Hz"
+msgstr "%1 Hz"
 
 msgid "Virtual machine crash"
 msgstr ""

--- a/src/qt/languages/hu-HU.po
+++ b/src/qt/languages/hu-HU.po
@@ -1266,9 +1266,6 @@ msgstr ""
 msgid "Error adding system"
 msgstr ""
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr ""
-
 msgid "Remove directory failed"
 msgstr ""
 
@@ -2924,6 +2921,9 @@ msgstr ""
 
 msgid "Release notes:"
 msgstr ""
+
+msgid "%1 Hz"
+msgstr "%1 Hz"
 
 msgid "Virtual machine crash"
 msgstr ""

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -1266,9 +1266,6 @@ msgstr "Impossibile aprire il file di configurazione in %1 per la scrittura"
 msgid "Error adding system"
 msgstr "Errore durante l'aggiunta del sistema"
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr "Il programma è stato terminato in modo anomalo durante la creazione del nuovo sistema: codice di uscita %1, stato di uscita %2.\n\nIl sistema non verrà aggiunto."
-
 msgid "Remove directory failed"
 msgstr "Rimozione directory non riuscita"
 
@@ -2925,6 +2922,9 @@ msgstr "Aggiornamento di 86Box"
 msgid "Release notes:"
 msgstr "Note di rilascio:"
 
+msgid "%1 Hz"
+msgstr "%1 Hz"
+
 msgid "Virtual machine crash"
 msgstr "Arresto anomalo della macchina virtuale"
 
@@ -2932,7 +2932,7 @@ msgid "The virtual machine \"%1\"'s process has unexpectedly terminated with exi
 msgstr "Il processo della macchina virtuale \"%1\" è terminato inaspettatamente con il codice di uscita %2."
 
 msgid "The system will not be added."
-msgstr "Il sistema non sarà aggiunto."
+msgstr "Il sistema non verrà aggiunto."
 
 #~ msgid "HD Controller:"
 #~ msgstr "Controller HD:"

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -1266,9 +1266,6 @@ msgstr ""
 msgid "Error adding system"
 msgstr ""
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr ""
-
 msgid "Remove directory failed"
 msgstr ""
 
@@ -2924,6 +2921,9 @@ msgstr ""
 
 msgid "Release notes:"
 msgstr ""
+
+msgid "%1 Hz"
+msgstr "%1 Hz"
 
 msgid "Virtual machine crash"
 msgstr ""

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -1266,9 +1266,6 @@ msgstr ""
 msgid "Error adding system"
 msgstr ""
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr ""
-
 msgid "Remove directory failed"
 msgstr ""
 
@@ -2924,6 +2921,9 @@ msgstr ""
 
 msgid "Release notes:"
 msgstr ""
+
+msgid "%1 Hz"
+msgstr "%1 Hz"
 
 msgid "Virtual machine crash"
 msgstr ""

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -1266,9 +1266,6 @@ msgstr "Openen van configuratiebestand %1 voor wegschrijven niet mogelijk"
 msgid "Error adding system"
 msgstr "Fout bij toevoegen van systeem"
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr "Onverwachte beëindiging van programma tijdens het aanmaken van nieuw systeem: afsluitcode %1, afsluitstatus %2.\n\nHet systeem wordt niet toegevoegd."
-
 msgid "Remove directory failed"
 msgstr "Verwijderen map mislukt"
 
@@ -2925,6 +2922,9 @@ msgstr "86Box Update"
 msgid "Release notes:"
 msgstr "Release-opmerkingen:"
 
+msgid "%1 Hz"
+msgstr "%1 Hz"
+
 msgid "Virtual machine crash"
 msgstr ""
 
@@ -2932,7 +2932,7 @@ msgid "The virtual machine \"%1\"'s process has unexpectedly terminated with exi
 msgstr ""
 
 msgid "The system will not be added."
-msgstr ""
+msgstr "Het systeem wordt niet toegevoegd."
 
 #~ msgid "HD Controller:"
 #~ msgstr "HD-controller:"

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -1266,9 +1266,6 @@ msgstr ""
 msgid "Error adding system"
 msgstr ""
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr ""
-
 msgid "Remove directory failed"
 msgstr ""
 
@@ -2924,6 +2921,9 @@ msgstr ""
 
 msgid "Release notes:"
 msgstr ""
+
+msgid "%1 Hz"
+msgstr "%1 Hz"
 
 msgid "Virtual machine crash"
 msgstr ""

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -1266,9 +1266,6 @@ msgstr "Impossível abrir o arquivo de configuração %1 para escrita"
 msgid "Error adding system"
 msgstr "Erro adicionando sistema"
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr "Término anormal do programa ao criar novo sistema: código de saída %1, estado de saída %2.\n\nO sistema não será adicionado."
-
 msgid "Remove directory failed"
 msgstr "Falha ao remover diretório"
 
@@ -2924,6 +2921,9 @@ msgstr "Atualização do 86Box"
 
 msgid "Release notes:"
 msgstr "Notas de lançamento:"
+
+msgid "%1 Hz"
+msgstr "%1 Hz"
 
 msgid "Virtual machine crash"
 msgstr "Falha da máquina virtual"

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -1266,9 +1266,6 @@ msgstr "Não foi possível abrir o ficheiro de configuração em %1 para a escri
 msgid "Error adding system"
 msgstr "Error ao adicionar o sistema"
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr "Terminação abnormal do programa em criar o novo sistema: código de saída %1, código de estado %2.\n\nO sistema não será adicionado."
-
 msgid "Remove directory failed"
 msgstr "Falha na remoção do directório"
 
@@ -2924,6 +2921,9 @@ msgstr "Atualização do 86Box"
 
 msgid "Release notes:"
 msgstr "Notas da versão:"
+
+msgid "%1 Hz"
+msgstr "%1 Hz"
 
 msgid "Virtual machine crash"
 msgstr "Falecimento da máquina virtual"

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -1266,9 +1266,6 @@ msgstr "Невозможно открыть файл конфигурации в
 msgid "Error adding system"
 msgstr "Ошибка добавления системы"
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr "Аномальное прекращение программы при создании новой системы: выходной код %1, состояние выхода %2.\n\nСистема не будет добавлена."
-
 msgid "Remove directory failed"
 msgstr "Сбой при удалении папки"
 
@@ -2449,7 +2446,7 @@ msgid "Composite"
 msgstr "Композитное видео"
 
 msgid "True color"
-msgstr ""
+msgstr "True Color"
 
 msgid "Old"
 msgstr "Старый"

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -1266,9 +1266,6 @@ msgstr ""
 msgid "Error adding system"
 msgstr ""
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr ""
-
 msgid "Remove directory failed"
 msgstr ""
 
@@ -2924,6 +2921,9 @@ msgstr ""
 
 msgid "Release notes:"
 msgstr ""
+
+msgid "%1 Hz"
+msgstr "%1 Hz"
 
 msgid "Virtual machine crash"
 msgstr ""

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -1266,9 +1266,6 @@ msgstr "Napaka pri odpiranju datoteke z nastavitvami %1 za pisanje"
 msgid "Error adding system"
 msgstr "Napaka pri dodajanju sistema"
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr "Med ustvarjanjem novega sistema je prišlo do nenavadne prekinitev: izhodna koda %1, izhodni status %2.\n\nSistem ne bo dodan."
-
 msgid "Remove directory failed"
 msgstr "Napaka pri odstranjevanju imenika"
 
@@ -2924,6 +2921,9 @@ msgstr "Posodobitev programa 86Box"
 
 msgid "Release notes:"
 msgstr "Opombe različice:"
+
+msgid "%1 Hz"
+msgstr "%1 Hz"
 
 msgid "Virtual machine crash"
 msgstr "Sesutje navidezne naprave"

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -1266,9 +1266,6 @@ msgstr ""
 msgid "Error adding system"
 msgstr ""
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr ""
-
 msgid "Remove directory failed"
 msgstr ""
 
@@ -2924,6 +2921,9 @@ msgstr ""
 
 msgid "Release notes:"
 msgstr ""
+
+msgid "%1 Hz"
+msgstr "%1 Hz"
 
 msgid "Virtual machine crash"
 msgstr ""

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -1266,9 +1266,6 @@ msgstr ""
 msgid "Error adding system"
 msgstr ""
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr ""
-
 msgid "Remove directory failed"
 msgstr ""
 
@@ -2924,6 +2921,9 @@ msgstr ""
 
 msgid "Release notes:"
 msgstr ""
+
+msgid "%1 Hz"
+msgstr "%1 Hz"
 
 msgid "Virtual machine crash"
 msgstr ""

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -1266,9 +1266,6 @@ msgstr ""
 msgid "Error adding system"
 msgstr ""
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr ""
-
 msgid "Remove directory failed"
 msgstr ""
 
@@ -2927,6 +2924,9 @@ msgstr ""
 
 msgid "Release notes:"
 msgstr ""
+
+msgid "%1 Hz"
+msgstr "%1 Гц"
 
 msgid "Virtual machine crash"
 msgstr ""

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -1266,9 +1266,6 @@ msgstr ""
 msgid "Error adding system"
 msgstr ""
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr ""
-
 msgid "Remove directory failed"
 msgstr ""
 
@@ -2924,6 +2921,9 @@ msgstr ""
 
 msgid "Release notes:"
 msgstr ""
+
+msgid "%1 Hz"
+msgstr "%1 Hz"
 
 msgid "Virtual machine crash"
 msgstr ""

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -1266,9 +1266,6 @@ msgstr ""
 msgid "Error adding system"
 msgstr ""
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr ""
-
 msgid "Remove directory failed"
 msgstr ""
 
@@ -2924,6 +2921,9 @@ msgstr "86Box 更新"
 
 msgid "Release notes:"
 msgstr "发行版说明"
+
+msgid "%1 Hz"
+msgstr "%1 Hz"
 
 msgid "Virtual machine crash"
 msgstr ""

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -1266,9 +1266,6 @@ msgstr ""
 msgid "Error adding system"
 msgstr ""
 
-msgid "Abnormal program termination while creating new system: exit code %1, exit status %2.\n\nThe system will not be added."
-msgstr ""
-
 msgid "Remove directory failed"
 msgstr ""
 
@@ -2924,6 +2921,9 @@ msgstr ""
 
 msgid "Release notes:"
 msgstr ""
+
+msgid "%1 Hz"
+msgstr "%1 Hz"
 
 msgid "Virtual machine crash"
 msgstr ""

--- a/src/qt/qt_vmmanager_main.cpp
+++ b/src/qt/qt_vmmanager_main.cpp
@@ -586,17 +586,17 @@ VMManagerMain::newMachineWizard()
 void
 VMManagerMain::addNewSystem(const QString &name, const QString &dir, const QString &displayName, const QString &configFile)
 {
-    const auto newSytemDirectory = QDir(QDir::cleanPath(dir + "/" + name));
+    const auto newSystemDirectory = QDir(QDir::cleanPath(dir + "/" + name));
 
     // qt replaces `/` with native separators
-    const auto newSystemConfigFile = QFileInfo(newSytemDirectory.path() + "/" + "86box.cfg");
-    if (newSystemConfigFile.exists() || newSytemDirectory.exists()) {
+    const auto newSystemConfigFile = QFileInfo(newSystemDirectory.path() + "/" + "86box.cfg");
+    if (newSystemConfigFile.exists() || newSystemDirectory.exists()) {
         QMessageBox::critical(this, tr("Directory in use"), tr("The selected directory is already in use. Please select a different directory."));
         return;
     }
     // Create the directory
     const QDir qmkdir;
-    if (const bool mkdirResult = qmkdir.mkdir(newSytemDirectory.path()); !mkdirResult) {
+    if (const bool mkdirResult = qmkdir.mkdir(newSystemDirectory.path()); !mkdirResult) {
         QMessageBox::critical(this, tr("Create directory failed"), tr("Unable to create the directory for the new system"));
         return;
     }
@@ -635,7 +635,7 @@ VMManagerMain::addNewSystem(const QString &name, const QString &dir, const QStri
                     // No config file which means the cancel button was pressed in the settings dialog
                     // Attempt to clean up the directory that was created
                     const QDir qrmdir;
-                    if (const bool result = qrmdir.rmdir(newSytemDirectory.path()); !result) {
+                    if (const bool result = qrmdir.rmdir(newSystemDirectory.path()); !result) {
                         qWarning() << "Error cleaning up the old directory for canceled operation. Continuing anyway.";
                     }
                     fail = true;

--- a/src/qt/qt_vmmanager_system.cpp
+++ b/src/qt/qt_vmmanager_system.cpp
@@ -26,6 +26,7 @@
 #include <QCryptographicHash>
 #include <QtNetwork>
 #include <QElapsedTimer>
+#include <QMessageBox>
 #include <QProgressDialog>
 #include <QWindow>
 #include "qt_util.hpp"
@@ -445,6 +446,8 @@ VMManagerSystem::launchMainProcess() {
     [=](const int exitCode, const QProcess::ExitStatus exitStatus){
         if (exitCode != 0 || exitStatus != QProcess::NormalExit) {
             qInfo().nospace().noquote() << "Abnormal program termination while launching main process: exit code " <<  exitCode << ", exit status " << exitStatus;
+            QMessageBox::critical(this, tr("Virtual machine crash"),
+                                        tr("The virtual machine \"%1\"'s process has unexpectedly terminated with exit code %2.").arg(displayName, QString::number(exitCode)));
             return;
         }
     });
@@ -498,6 +501,8 @@ VMManagerSystem::launchSettings() {
     [=](const int exitCode, const QProcess::ExitStatus exitStatus){
         if (exitCode != 0 || exitStatus != QProcess::NormalExit) {
             qInfo().nospace().noquote() << "Abnormal program termination while launching settings: exit code " <<  exitCode << ", exit status " << exitStatus;
+            QMessageBox::critical(this, tr("Virtual machine crash"),
+                                        tr("The virtual machine \"%1\"'s process has unexpectedly terminated with exit code %2.").arg(displayName, QString::number(exitCode)));
             return;
         }
 


### PR DESCRIPTION
Summary
=======
Show a message box if a VM process unexpectedly terminates. Update the existing message box for when the settings dialog's process crashes during creation of a new machine too.

Drive-by: fix the empty VM directory not being cleaned up when the process crashes during machine creation, aborting it; update some translations.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A