### PR TITLE
S3 clock rate changes of the night (August 18th, 2025)

### DIFF
--- a/src/video/ramdac/vid_ramdac_bt48x.c
+++ b/src/video/ramdac/vid_ramdac_bt48x.c
@@ -365,8 +365,11 @@ bt48x_recalctimings(void *priv, svga_t *svga)
     const bt48x_ramdac_t *ramdac = (bt48x_ramdac_t *) priv;
 
     svga->interlace = ramdac->cmd_r2 & 0x08;
-    if (ramdac->cmd_r3 & 0x08)
-        svga->hdisp *= 2; /* x2 clock multiplier */
+    if (ramdac->cmd_r3 & 0x08) {
+        svga->hdisp <<= 1; /* x2 clock multiplier */
+        svga->dots_per_clock <<= 1;
+        svga->clock *= 2.0;
+    }
 }
 
 void


### PR DESCRIPTION
Summary
=======
1. Correct the clock chip of the S3 928 (Metheus Premier 928) to use a ics2494 one (a board picture shows the CH9294, a clone of the ics2494/av9194).
2. Correct the 8bpp and high color refresh rates of the Metheus Premier 928 when either bt48x x2 clock multiplier is enabled or when hitting high color.

Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[Metheus Premier 928 board picture](https://www.vgamuseum.info/images/vlask/s3/928fb.jpg)
