### PR TITLE
Fix 15/16-bpp mode refresh rates on S3 ViRGEs (pre-GX2 and non-VX)

### DIFF
--- a/src/video/vid_s3_virge.c
+++ b/src/video/vid_s3_virge.c
@@ -911,6 +911,7 @@ s3_virge_recalctimings(svga_t *svga)
                     if ((virge->chip != S3_VIRGEVX) && (virge->chip < S3_VIRGEGX2)) {
                         svga->hdisp >>= 1;
                         svga->dots_per_clock >>= 1;
+                        svga->clock /= 2.0;
                     }
                     break;
                 case 16:
@@ -918,6 +919,7 @@ s3_virge_recalctimings(svga_t *svga)
                     if ((virge->chip != S3_VIRGEVX) && (virge->chip < S3_VIRGEGX2)) {
                         svga->hdisp >>= 1;
                         svga->dots_per_clock >>= 1;
+                        svga->clock /= 2.0;
                     }
                     break;
                 case 24:
@@ -1010,9 +1012,13 @@ s3_virge_recalctimings(svga_t *svga)
                     break;
                 case 3: /*KRGB-16 (1.5.5.5)*/
                     svga->render = svga_render_15bpp_highres;
+                    if (virge->chip != S3_VIRGEVX)
+                        svga->clock /= 2.0;
                     break;
                 case 5: /*RGB-16 (5.6.5)*/
                     svga->render = svga_render_16bpp_highres;
+                    if (virge->chip != S3_VIRGEVX)
+                        svga->clock /= 2.0;
                     break;
                 case 6: /*RGB-24 (8.8.8)*/
                     svga->render = svga_render_24bpp_highres;


### PR DESCRIPTION
Summary
=======
Fix 15/16-bpp mode refresh rates on S3 ViRGEs (pre-GX2 and non-VX).

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
