### PR TITLE
Rename Sanyo MBC-17 to MBC-17PLUS machine_table.c

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -3546,7 +3546,7 @@ const machine_t machines[] = {
     },
     /* Has unknown KBC firmware. */
     {
-        .name = "[ISA] Sanyo MBC-17",
+        .name = "[ISA] Sanyo MBC-17PLUS",
         .internal_name = "mbc17",
         .type = MACHINE_TYPE_286,
         .chipset = MACHINE_CHIPSET_DISCRETE,


### PR DESCRIPTION
There are other model
Sanyo MBC-17Plus
Sanyo MBC-17LT3 - Portable
the dump was from
MBC-17JH40C
https://www.okqubit.net/machines/sanyo.html
 no internal ide found
only the controller card
https://www.okqubit.net/machines/img/sanyo_mbc-17jh40c_ide-100.jpg the mainboard is similar to
https://theretroweb.com/motherboards/s/sanyo-mbc-17plus

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
https://www.okqubit.net/machines/img/sanyo_mbc-17jh40c_ide-100.jpg the mainboard is similar to
https://theretroweb.com/motherboards/s/sanyo-mbc-17plus
