### PR TITLE
Only show the translocation warning when trying to load a config from EXE path

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -746,10 +746,6 @@ pc_init(int argc, char *argv[])
         p                = path_get_filename(exe_path);
         *p               = '\0';
     }
-    if (!strncmp(exe_path, "/private/var/folders/", 21)) {
-        ui_msgbox_header(MBX_FATAL, L"App Translocation", EMU_NAME_W L" cannot determine the emulated machine's location due to a macOS security feature. Please move the " EMU_NAME_W L" app to another folder (not /Applications), or make a copy of it and open that copy instead.");
-        return 0;
-    }
 #elif !defined(_WIN32)
     /* Grab the actual path if we are an AppImage. */
     p = getenv("APPIMAGE");
@@ -1107,10 +1103,16 @@ usage:
 
     /* Determine whether to start the VM manager. */
 #ifndef USE_SDL_UI
-    if (vmm_disabled)
+    if (vmm_disabled && start_vmm)
 #endif
     {
         start_vmm = 0;
+#ifdef __APPLE__
+        if (!strncmp(exe_path, "/private/var/folders/", 21)) {
+            ui_msgbox_header(MBX_FATAL, L"App Translocation", EMU_NAME_W L" cannot determine the emulated machine's location due to a macOS security feature. Please move the " EMU_NAME_W L" app to another folder (not /Applications), or make a copy of it and open that copy instead.");
+            return 0;
+        }
+#endif
     }
 
 #ifndef USE_SDL_UI


### PR DESCRIPTION
Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
