### PR TITLE
Restore Finnish translations

### DIFF
--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -1,0 +1,2959 @@
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Language: fi_FI\n"
+"X-Source-Language: en_US\n"
+
+msgid "&Action"
+msgstr "&Toiminto"
+
+msgid "&Keyboard requires capture"
+msgstr "&Vaadi näppäimistön kaappaus"
+
+msgid "&Right CTRL is left ALT"
+msgstr "&Oikea CTRL on vasen ALT"
+
+msgid "&Hard Reset..."
+msgstr "&Uudelleenkäynnistys (kylmä)..."
+
+msgid "&Ctrl+Alt+Del"
+msgstr "&Ctrl+Alt+Del"
+
+msgid "Ctrl+Alt+&Esc"
+msgstr "Ctrl+Alt+&Esc"
+
+msgid "&Pause"
+msgstr "&Tauko"
+
+msgid "Pause"
+msgstr ""
+
+msgid "Re&sume"
+msgstr ""
+
+msgid "E&xit"
+msgstr "&Poistu"
+
+msgid "&View"
+msgstr "&Näytä"
+
+msgid "&Hide status bar"
+msgstr "&Piilota tilapalkki"
+
+msgid "Hide &toolbar"
+msgstr "Piilota &työkalupalkki"
+
+msgid "&Resizeable window"
+msgstr "&Salli koon muuttaminen"
+
+msgid "R&emember size && position"
+msgstr "&Muista koko ja sijainti"
+
+msgid "Re&nderer"
+msgstr "&Renderöijä"
+
+msgid "&Qt (Software)"
+msgstr "&Qt (ohjelmistopohjainen)"
+
+msgid "Open&GL (3.0 Core)"
+msgstr "Open&GL (3.0 Core)"
+
+msgid "&VNC"
+msgstr "&VNC"
+
+msgid "Specify &dimensions..."
+msgstr "&Määritä koko..."
+
+msgid "Force &4:3 display ratio"
+msgstr "Pakota &4:3-kuvasuhde"
+
+msgid "&Window scale factor"
+msgstr "&Ikkunan kokokerroin"
+
+msgid "&0.5x"
+msgstr "&0.5x"
+
+msgid "&1x"
+msgstr "&1x"
+
+msgid "1.&5x"
+msgstr "1.&5x"
+
+msgid "&2x"
+msgstr "&2x"
+
+msgid "&3x"
+msgstr "&3x"
+
+msgid "&4x"
+msgstr "&4x"
+
+msgid "&5x"
+msgstr "&5x"
+
+msgid "&6x"
+msgstr "&6x"
+
+msgid "&7x"
+msgstr "&7x"
+
+msgid "&8x"
+msgstr "&8x"
+
+msgid "Fi&lter method"
+msgstr "&Suodatusmetodi"
+
+msgid "&Nearest"
+msgstr "&Lähin naapuri"
+
+msgid "&Linear"
+msgstr "Li&neaarinen interpolaatio"
+
+msgid "Hi&DPI scaling"
+msgstr "&Suuri DPI-skaalaus"
+
+msgid "&Fullscreen"
+msgstr "&Koko näytön tila"
+
+msgid "Fullscreen &stretch mode"
+msgstr "Koko näytön &skaalaustila"
+
+msgid "&Full screen stretch"
+msgstr "&Venytä koko näyttöön"
+
+msgid "&4:3"
+msgstr "&4:3"
+
+msgid "&Square pixels (Keep ratio)"
+msgstr "&Tasasivuiset kuvapisteet (säilytä kuvasuhde)"
+
+msgid "&Integer scale"
+msgstr "&Kokonaislukuskaalaus"
+
+msgid "4:&3 Integer scale"
+msgstr "4:&3 Kokonaislukuskaalaus"
+
+msgid "EGA/(S)&VGA settings"
+msgstr "&EGA/(S)VGA-asetukset"
+
+msgid "&Inverted VGA monitor"
+msgstr "&VGA-näyttö käänteisillä väreillä"
+
+msgid "VGA screen &type"
+msgstr "VGA-näytön &tyyppi"
+
+msgid "RGB &Color"
+msgstr "RGB, &värit"
+
+msgid "RGB (no brown)"
+msgstr "RGB (ei ruskeaa)"
+
+msgid "&RGB Grayscale"
+msgstr "&RGB, harmaasävy"
+
+msgid "Generic RGBI color monitor"
+msgstr ""
+
+msgid "&Amber monitor"
+msgstr "&Meripihkanvärinen"
+
+msgid "&Green monitor"
+msgstr "V&ihreä"
+
+msgid "&White monitor"
+msgstr "V&alkoinen"
+
+msgid "Grayscale &conversion type"
+msgstr "&Harmaasävymuunnoksen tyyppi"
+
+msgid "BT&601 (NTSC/PAL)"
+msgstr "BT&601 (NTSC/PAL)"
+
+msgid "BT&709 (HDTV)"
+msgstr "BT&709 (HDTV)"
+
+msgid "&Average"
+msgstr "&Keskiarvo"
+
+msgid "CGA/PCjr/Tandy/E&GA/(S)VGA overscan"
+msgstr "CGA/PCjr/Tandy/E&GA/(S)VGA-&yliskannaus"
+
+msgid "Change contrast for &monochrome display"
+msgstr "&Muuta harmaavärinäytön kontrastia"
+
+msgid "&Media"
+msgstr "&Media"
+
+msgid "&Tools"
+msgstr "Työ&kalut"
+
+msgid "&Settings..."
+msgstr "&Asetukset..."
+
+msgid "Settings..."
+msgstr "Asetukset..."
+
+msgid "&Update status bar icons"
+msgstr "&Päivitä tilapalkin kuvakkeita"
+
+msgid "Take s&creenshot"
+msgstr "Ota &kuvakaappaus"
+
+msgid "S&ound"
+msgstr "&Ääni"
+
+msgid "&Preferences..."
+msgstr "&Sovellusasetukset..."
+
+msgid "Enable &Discord integration"
+msgstr "&Discord-integraatio"
+
+msgid "Sound &gain..."
+msgstr "&Äänitasot..."
+
+msgid "Begin trace"
+msgstr "Aloita jäljitys"
+
+msgid "End trace"
+msgstr "Lopeta jäljitys"
+
+msgid "&Help"
+msgstr "&Ohje"
+
+msgid "&Documentation..."
+msgstr "&Ohjekirja..."
+
+msgid "&About 86Box..."
+msgstr "&Tietoja 86Boxista..."
+
+msgid "&New image..."
+msgstr "&Uusi levykuva..."
+
+msgid "&Existing image..."
+msgstr "&Olemassaoleva levykuva..."
+
+msgid "Existing image (&Write-protected)..."
+msgstr "Olemassaoleva levykuva (&kirjoitussuojattu)..."
+
+msgid "&Record"
+msgstr "&Nauhoita"
+
+msgid "&Play"
+msgstr "&Toista"
+
+msgid "&Rewind to the beginning"
+msgstr "Kelaa &alkuun"
+
+msgid "&Fast forward to the end"
+msgstr "Kelaa &loppuun"
+
+msgid "E&ject"
+msgstr "&Irrota"
+
+msgid "&Image..."
+msgstr "&Levykuva..."
+
+msgid "E&xport to 86F..."
+msgstr "&Vie 86F-tiedostoon..."
+
+msgid "&Mute"
+msgstr "&Mykistä"
+
+msgid "E&mpty"
+msgstr "&Tyhjä"
+
+msgid "Reload previous image"
+msgstr "Lataa edellinen levykuva uudelleen"
+
+msgid "&Folder..."
+msgstr "&Kansio..."
+
+msgid "Target &framerate"
+msgstr "&Kuvataajuustavoite"
+
+msgid "&Sync with video"
+msgstr "&Synkronisoi videoon"
+
+msgid "&25 fps"
+msgstr "&25 ruutua/s"
+
+msgid "&30 fps"
+msgstr "&30 ruutua/s"
+
+msgid "&50 fps"
+msgstr "&50 ruutua/s"
+
+msgid "&60 fps"
+msgstr "&60 ruutua/s"
+
+msgid "&75 fps"
+msgstr "&75 ruutua/s"
+
+msgid "&VSync"
+msgstr "&VSync"
+
+msgid "&Select shader..."
+msgstr "Valitse varjostin&ohjelma..."
+
+msgid "&Remove shader"
+msgstr "&Poista varjostinohjelma"
+
+msgid "Preferences"
+msgstr "Sovellusasetukset"
+
+msgid "Sound Gain"
+msgstr "Äänen taso"
+
+msgid "New Image"
+msgstr "Uusi levykuva"
+
+msgid "Settings"
+msgstr "Kokoonpano"
+
+msgid "Specify Main Window Dimensions"
+msgstr "Määritä pääikkunan koko"
+
+msgid "OK"
+msgstr "OK"
+
+msgid "Cancel"
+msgstr "Peruuta"
+
+msgid "&Default"
+msgstr "&Oletus"
+
+msgid "Language:"
+msgstr "Kieli:"
+
+msgid "Gain"
+msgstr "Taso"
+
+msgid "File name:"
+msgstr "Tiedostonimi:"
+
+msgid "Disk size:"
+msgstr "Levyn koko:"
+
+msgid "RPM mode:"
+msgstr "Kierroslukutila:"
+
+msgid "Progress:"
+msgstr "Edistyminen:"
+
+msgid "Width:"
+msgstr "Leveys:"
+
+msgid "Height:"
+msgstr "Korkeus:"
+
+msgid "Lock to this size"
+msgstr "Lukitse tähän kokoon"
+
+msgid "Machine type:"
+msgstr "Tietokoneen tyyppi:"
+
+msgid "Machine:"
+msgstr "Tietokone:"
+
+msgid "Configure"
+msgstr "Määritys"
+
+msgid "CPU:"
+msgstr ""
+
+msgid "CPU type:"
+msgstr "Suorittimen tyyppi:"
+
+msgid "Speed:"
+msgstr "Nopeus:"
+
+msgid "Frequency:"
+msgstr "Taajuus:"
+
+msgid "FPU:"
+msgstr "Apusuoritin:"
+
+msgid "Wait states:"
+msgstr "Odotustilat:"
+
+msgid "MB"
+msgstr "Mt"
+
+msgid "Memory:"
+msgstr "Muisti:"
+
+msgid "Time synchronization"
+msgstr "Kellon synkronointi"
+
+msgid "Disabled"
+msgstr "Ei käytössä"
+
+msgid "Enabled (local time)"
+msgstr "Käytössä (paikallinen)"
+
+msgid "Enabled (UTC)"
+msgstr "Käytössä (UTC)"
+
+msgid "Dynamic Recompiler"
+msgstr "Dynaaminen uudelleenkääntäjä"
+
+msgid "CPU frame size"
+msgstr "CPU frame-koko"
+
+msgid "Larger frames (less smooth)"
+msgstr "Suuret framet (vähemmän sulava)"
+
+msgid "Smaller frames (smoother)"
+msgstr "Pienemmät framet (sulavampi)"
+
+msgid "Video:"
+msgstr "Näytönohjain:"
+
+msgid "Video #2:"
+msgstr "Toinen näytönohjain:"
+
+msgid "Voodoo 1 or 2 Graphics"
+msgstr "Voodoo 1 tai 2-grafiikkasuoritin"
+
+msgid "IBM 8514/A Graphics"
+msgstr "IBM 8514/A-grafiikkasuoritin"
+
+msgid "XGA Graphics"
+msgstr "XGA-grafiikkasuoritin"
+
+msgid "IBM PS/55 Display Adapter Graphics"
+msgstr "IBM PS/55-näyttöadapteri"
+
+msgid "Keyboard:"
+msgstr "Näppäimistö:"
+
+msgid "Keyboard"
+msgstr "Näppäimistö"
+
+msgid "Mouse:"
+msgstr "Hiiri:"
+
+msgid "Mouse"
+msgstr ""
+
+msgid "Joystick:"
+msgstr "Peliohjain:"
+
+msgid "Joystick"
+msgstr ""
+
+msgid "Joystick 1..."
+msgstr "Peliohjain 1..."
+
+msgid "Joystick 2..."
+msgstr "Peliohjain 2..."
+
+msgid "Joystick 3..."
+msgstr "Peliohjain 3..."
+
+msgid "Joystick 4..."
+msgstr "Peliohjain 4..."
+
+msgid "Sound card #1:"
+msgstr "Äänikortti 1:"
+
+msgid "Sound card #2:"
+msgstr "Äänikortti 2:"
+
+msgid "Sound card #3:"
+msgstr "Äänikortti 3:"
+
+msgid "Sound card #4:"
+msgstr "Äänikortti 4:"
+
+msgid "MIDI Out Device:"
+msgstr "MIDI-ulostulo:"
+
+msgid "MIDI In Device:"
+msgstr "MIDI-sisääntulo:"
+
+msgid "MIDI Out:"
+msgstr "MIDI-ulostulo:"
+
+msgid "Standalone MPU-401"
+msgstr "Erillinen MPU-401"
+
+msgid "Use FLOAT32 sound"
+msgstr "Käytä FLOAT32-ääntä"
+
+msgid "FM synth driver"
+msgstr "FM-syntetisaattoriohjain"
+
+msgid "Nuked (more accurate)"
+msgstr "Nuked (tarkempi)"
+
+msgid "YMFM (faster)"
+msgstr "YMFM (nopeampi)"
+
+msgid "COM1 Device:"
+msgstr "COM1-laite:"
+
+msgid "COM2 Device:"
+msgstr "COM2-laite:"
+
+msgid "COM3 Device:"
+msgstr "COM3-laite:"
+
+msgid "COM4 Device:"
+msgstr "COM4-laite:"
+
+msgid "LPT1 Device:"
+msgstr "LPT1-laite:"
+
+msgid "LPT2 Device:"
+msgstr "LPT2-laite:"
+
+msgid "LPT3 Device:"
+msgstr "LPT3-laite:"
+
+msgid "LPT4 Device:"
+msgstr "LPT4-laite:"
+
+msgid "Internal LPT ECP DMA:"
+msgstr "Sisäisen LPT:n ECP DMA:"
+
+msgid "Serial port 1"
+msgstr "Sarjaportti 1"
+
+msgid "Serial port 2"
+msgstr "Sarjaportti 2"
+
+msgid "Serial port 3"
+msgstr "Sarjaportti 3"
+
+msgid "Serial port 4"
+msgstr "Sarjaportti 4"
+
+msgid "Parallel port 1"
+msgstr "Rinnakkaisportti 1"
+
+msgid "Parallel port 2"
+msgstr "Rinnakkaisportti 2"
+
+msgid "Parallel port 3"
+msgstr "Rinnakkaisportti 3"
+
+msgid "Parallel port 4"
+msgstr "Rinnakkaisportti 4"
+
+msgid "FD Controller:"
+msgstr "Levykeohjain:"
+
+msgid "CD-ROM Controller:"
+msgstr "CD-ohjain:"
+
+msgid "Tertiary IDE Controller"
+msgstr "Kolmas IDE-ohjain"
+
+msgid "Quaternary IDE Controller"
+msgstr "Neljäs IDE-ohjain"
+
+msgid "Hard disk"
+msgstr "Kiintolevy"
+
+msgid "SCSI"
+msgstr "SCSI"
+
+msgid "Controller 1:"
+msgstr "Ohjain 1:"
+
+msgid "Controller 2:"
+msgstr "Ohjain 2:"
+
+msgid "Controller 3:"
+msgstr "Ohjain 3:"
+
+msgid "Controller 4:"
+msgstr "Ohjain 4:"
+
+msgid "Cassette"
+msgstr "Kasettiasema"
+
+msgid "Hard disks:"
+msgstr "Kiintolevyt:"
+
+msgid "Firmware Version"
+msgstr "Laiteohjelmiston versio"
+
+msgid "&New..."
+msgstr "&Uusi..."
+
+msgid "&Existing..."
+msgstr "&Olemassaoleva..."
+
+msgid "&Remove"
+msgstr "&Poista"
+
+msgid "Bus:"
+msgstr "Väylä:"
+
+msgid "Channel:"
+msgstr "Kanava:"
+
+msgid "ID:"
+msgstr "ID:"
+
+msgid "&Specify..."
+msgstr "&Määritä..."
+
+msgid "Sectors:"
+msgstr "Sektorit:"
+
+msgid "Heads:"
+msgstr "Lukupäät:"
+
+msgid "Cylinders:"
+msgstr "Sylinterit:"
+
+msgid "Size (MB):"
+msgstr "Koko (Mt):"
+
+msgid "Type:"
+msgstr "Tyyppi:"
+
+msgid "Image Format:"
+msgstr "Tiedostomuoto:"
+
+msgid "Block Size:"
+msgstr "Lohkon koko:"
+
+msgid "Floppy drives:"
+msgstr "Levykeasemat:"
+
+msgid "Turbo timings"
+msgstr "Turbo-ajoitukset"
+
+msgid "Check BPB"
+msgstr "Tarkista BPB"
+
+msgid "CD-ROM drives:"
+msgstr "CD-ROM-asemat:"
+
+msgid "MO drives:"
+msgstr "Magneettisoptiset asemat (MO):"
+
+msgid "MO:"
+msgstr ""
+
+msgid "Removable disks:"
+msgstr "Irrotettavat levyt:"
+
+msgid "Removable disk drives:"
+msgstr "Irrotettavat levyasemat:"
+
+msgid "ZIP 250"
+msgstr "ZIP 250"
+
+msgid "ISA RTC:"
+msgstr "ISA-RTC (kello):"
+
+msgid "ISA Memory Expansion"
+msgstr "ISA-muistilaajennus"
+
+msgid "ISA ROM Cards"
+msgstr "ISA ROM-kortit"
+
+msgid "Card 1:"
+msgstr "Kortti 1:"
+
+msgid "Card 2:"
+msgstr "Kortti 2:"
+
+msgid "Card 3:"
+msgstr "Kortti 3:"
+
+msgid "Card 4:"
+msgstr "Kortti 4:"
+
+msgid "Generic ISA ROM Board"
+msgstr ""
+
+msgid "Generic Dual ISA ROM Board"
+msgstr ""
+
+msgid "Generic Quad ISA ROM Board"
+msgstr ""
+
+msgid "ISABugger device"
+msgstr "ISABugger-laite"
+
+msgid "POST card"
+msgstr "POST-kortti"
+
+msgid "86Box"
+msgstr "86Box"
+
+msgid "Error"
+msgstr "Virhe"
+
+msgid "Fatal error"
+msgstr "Vakava virhe"
+
+msgid " - PAUSED"
+msgstr " - TAUKO"
+
+msgid "Speed"
+msgstr "Nopeus"
+
+msgid "Removable disk %1 (%2): %3"
+msgstr "Irrotettava levy %1 (%2): %3"
+
+msgid "&Removable disk %1 (%2): %3"
+msgstr "&Irrotettava levy %1 (%2): %3"
+
+msgid "Removable disk images"
+msgstr "Irrotettavat levykuvat"
+
+msgid "Image %1"
+msgstr "Levykuva %1"
+
+msgid "86Box could not find any usable ROM images.\n\nPlease <a href=\"https://github.com/86Box/roms/releases/latest\">download</a> a ROM set and extract it into the \"roms\" directory."
+msgstr "86Box ei löytänyt käyttökelpoisia ROM-tiedostoja.\n\nVoit <a href=\"https://github.com/86Box/roms/releases/latest\">ladata</a> ROM-paketin ja purkaa sen \"roms\"-hakemistoon."
+
+msgid "(empty)"
+msgstr "(tyhjä)"
+
+msgid "All files"
+msgstr "Kaikki tiedostot"
+
+msgid "Turbo"
+msgstr "Turbo"
+
+msgid "On"
+msgstr "Päällä"
+
+msgid "Off"
+msgstr "Pois"
+
+msgid "All images"
+msgstr "Kaikki levykuvat"
+
+msgid "Basic sector images"
+msgstr "Perussektorilevykuvat"
+
+msgid "Surface images"
+msgstr "Pintalevykuvat"
+
+msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "Konetta \"%hs\" ei voida käyttää, koska roms/machines-hakemistosta puuttuu ROM-tiedostoja. Vaihdetaan käyttökelpoiseen koneeseen."
+
+msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "Näytönohjainta \"%hs\" ei voida käyttää, koska roms/video-hakemistosta puuttuu ROM-tiedostoja. Vaihdetaan käyttökelpoiseen näytönohjaimeen."
+
+msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "Toista näytönohjainta \"%hs\" ei voida käyttää, koska roms/video-hakemistosta puuttuu ROM-tiedostoja. Toinen näytönohjain poistetaan käytöstä."
+
+msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
+msgstr "Laitetta \"%hs\" ei voida käyttää puuttuvien ROM-tiedostojen vuoksi. Laite jätetään huomiotta."
+
+msgid "Machine"
+msgstr "Tietokone"
+
+msgid "Display"
+msgstr "Näyttö"
+
+msgid "Input devices"
+msgstr "Syöttölaitteet"
+
+msgid "Sound"
+msgstr "Ääni"
+
+msgid "Network"
+msgstr "Verkko"
+
+msgid "Ports (COM & LPT)"
+msgstr "Portit (COM & LPT)"
+
+msgid "Ports"
+msgstr "Portit"
+
+msgid "Serial ports"
+msgstr "Sarjaportit"
+
+msgid "Parallel ports"
+msgstr "Rinnakkaisportit"
+
+msgid "Storage controllers"
+msgstr "Tallennusohjaimet"
+
+msgid "Hard disks"
+msgstr "Kiintolevyt"
+
+msgid "Disks:"
+msgstr "Levyt:"
+
+msgid "Floppy:"
+msgstr "Levyke:"
+
+msgid "Controllers:"
+msgstr "Ohjaimet:"
+
+msgid "Floppy & CD-ROM drives"
+msgstr "Levyke- ja CD-ROM-asemat"
+
+msgid "Other removable devices"
+msgstr "Muut irrotettavat laitteet"
+
+msgid "Other peripherals"
+msgstr "Muut oheislaitteet"
+
+msgid "Other devices"
+msgstr "Muut laitteet"
+
+msgid "Click to capture mouse"
+msgstr "Kaappaa hiiri klikkaamalla"
+
+msgid "Press %1 to release mouse"
+msgstr "Paina %1 vapauttaaksesi hiiren"
+
+msgid "Press %1 or middle button to release mouse"
+msgstr "Paina %1 tai keskipainiketta vapauttaaksesi hiiren"
+
+msgid "Bus"
+msgstr "Väylä"
+
+msgid "File"
+msgstr "Tiedosto"
+
+msgid "C"
+msgstr "C"
+
+msgid "H"
+msgstr "H"
+
+msgid "S"
+msgstr "S"
+
+msgid "KB"
+msgstr "Kt"
+
+msgid "Default"
+msgstr "Oletus"
+
+msgid "%1 Wait state(s)"
+msgstr "%1 odotustilaa"
+
+msgid "Type"
+msgstr "Tyyppi"
+
+msgid "No PCap devices found"
+msgstr "PCap-laitteita ei löytynyt"
+
+msgid "Invalid PCap device"
+msgstr "Virheellinen PCap-laite"
+
+msgid "2-axis, 2-button joystick(s)"
+msgstr "2-akseliset 2-painikkeiset peliohjaimet"
+
+msgid "2-axis, 4-button joystick"
+msgstr "2-akselinen 4-painikkeinen peliohjain"
+
+msgid "2-axis, 6-button joystick"
+msgstr "2-akselinen 6-painikkeinen peliohjain"
+
+msgid "2-axis, 8-button joystick"
+msgstr "2-akselinen 8-painikkeinen peliohjain"
+
+msgid "3-axis, 2-button joystick"
+msgstr "3-akselinen 2-painikkeinen peliohjain"
+
+msgid "3-axis, 4-button joystick"
+msgstr "3-akselinen 4-painikkeinen peliohjain"
+
+msgid "4-axis, 4-button joystick"
+msgstr "4-akselinen 4-painikkeinen peliohjain"
+
+msgid "CH Flightstick Pro"
+msgstr "CH Flightstick Pro"
+
+msgid "CH Flightstick Pro + CH Pedals"
+msgstr ""
+
+msgid "Microsoft SideWinder Pad"
+msgstr "Microsoft SideWinder Pad"
+
+msgid "Thrustmaster Flight Control System"
+msgstr "Thrustmaster Flight Control System"
+
+msgid "Thrustmaster FCS + Rudder Control System"
+msgstr ""
+
+msgid "2-button gamepad(s)"
+msgstr "2-painikkeiset peliohjaimet"
+
+msgid "2-button flight yoke"
+msgstr "2-painikkeinen lento-ohjain"
+
+msgid "4-button gamepad"
+msgstr "4-painikkeinen peliohjain"
+
+msgid "4-button flight yoke"
+msgstr "4-painikkeinen lento-ohjain"
+
+msgid "2-button flight yoke with throttle"
+msgstr "2-painikkeinen lento-ohjain kaasuvivulla"
+
+msgid "4-button flight yoke with throttle"
+msgstr "4-painikkeinen lento-ohjain kaasuvivulla"
+
+msgid "Win95 Steering Wheel (3-axis, 4-button)"
+msgstr "Win95-ratti (3-akselinen, 4-painikkeinen)"
+
+msgid "None"
+msgstr "Ei mikään"
+
+msgid "%1 MB (CHS: %2, %3, %4)"
+msgstr "%1 Mt (CHS: %2, %3, %4)"
+
+msgid "Floppy %1 (%2): %3"
+msgstr "Levyke %1 (%2): %3"
+
+msgid "&Floppy %1 (%2): %3"
+msgstr "&Levyke %1 (%2): %3"
+
+msgid "Advanced sector images"
+msgstr "Kehittyneet sektorilevykuvat"
+
+msgid "Flux images"
+msgstr "Flux-levykuvat"
+
+msgid "Are you sure you want to hard reset the emulated machine?"
+msgstr "Haluatko varmasti käynnistää emuloidun tietokoneen uudelleen?"
+
+msgid "Are you sure you want to exit 86Box?"
+msgstr "Haluatko varmasti sulkea 86Boxin?"
+
+msgid "Unable to initialize Ghostscript"
+msgstr "Ghostscriptin alustus epäonnistui"
+
+msgid "Unable to initialize GhostPCL"
+msgstr "GhostPCLin alustus epäonnistui"
+
+msgid "MO %1 (%2): %3"
+msgstr "MO %1 (%2): %3"
+
+msgid "&MO %1 (%2): %3"
+msgstr "&MO %1 (%2): %3"
+
+msgid "MO images"
+msgstr "MO-levykuvat"
+
+msgid "Welcome to 86Box!"
+msgstr "Tervetuloa 86Boxiin!"
+
+msgid "Internal device"
+msgstr "Sisäinen laite"
+
+msgid "&File"
+msgstr "&Tiedosto"
+
+msgid "&New machine..."
+msgstr "&Uusi kone..."
+
+msgid "&Check for updates..."
+msgstr "T&arkista päivitykset..."
+
+msgid "Exit"
+msgstr "Poistu"
+
+msgid "No ROMs found"
+msgstr "ROM-tiedostoja ei löytynyt"
+
+msgid "Do you want to save the settings?"
+msgstr "Tallennetaanko asetukset?"
+
+msgid "This will hard reset the emulated machine."
+msgstr "Tämä käynnistää emuloidun tietokoneen uudelleen."
+
+msgid "Save"
+msgstr "Tallenna"
+
+msgid "About 86Box"
+msgstr "Tietoja 86Box:sta"
+
+msgid "86Box v"
+msgstr "86Box v"
+
+msgid "An emulator of old computers\n\nAuthors: Miran Grča (OBattler), RichardG867, Jasmine Iwanek, TC1995, coldbrewed, Teemu Korhonen (Manaatti), Joakim L. Gilje, Adrien Moulin (elyosh), Daniel Balsom (gloriouscow), Cacodemon345, Fred N. van Kempen (waltje), Tiseno100, reenigne, and others.\n\nWith previous core contributions from Sarah Walker, leilei, JohnElliott, greatpsycho, and others.\n\nReleased under the GNU General Public License version 2 or later. See LICENSE for more information."
+msgstr "Vanhojen tietokoneiden emulaattori\n\nTekijät: Miran Grča (OBattler), RichardG867, Jasmine Iwanek, TC1995, coldbrewed, Teemu Korhonen (Manaatti), Joakim L. Gilje, Adrien Moulin (elyosh), Daniel Balsom (gloriouscow), Cacodemon345, Fred N. van Kempen (waltje), Tiseno100, reenigne ja muut.\n\nSisältää Sarah Walkerin, leilein, JohnElliottin, greatpsychon ja muiden aiemmat keskeiset työpanokset.\n\nJulkaistu GNU General Public License 2. version tai myöhemmän alaisena. Tarkempia tietoja LICENSE-tiedostossa."
+
+msgid "Hardware not available"
+msgstr "Laitteisto ei ole saatavilla"
+
+msgid "Make sure %1 is installed and that you are on a %1-compatible network connection."
+msgstr "Varmista, että %1 on asennettu ja että verkkoyhteytesi on %1-yhteensopiva."
+
+msgid "Invalid configuration"
+msgstr "Virheellinen määritys"
+
+msgid "%1 is required for automatic conversion of PostScript files to PDF.\n\nAny documents sent to the generic PostScript printer will be saved as PostScript (.ps) files."
+msgstr "%1 vaaditaan PostScript-tiedostojen automaattiseen muuntamiseen PDF-tiedostoiksi.\n\nKaikki geneeriselle PostScript-tulostimelle lähetetyt asiakirjat tallennetaan PostScript (.ps) -tiedostoina."
+
+msgid "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files."
+msgstr "%1 vaaditaan PCL-tiedostojen automaattiseen muuntamiseen PDF-tiedostoiksi.\n\nKaikki geneeriselle PCL-tulostimelle lähetetyt asiakirjat tallennetaan Printer Command Language (.ps) -tiedostoina."
+
+msgid "Don't show this message again"
+msgstr "Älä näytä tätä viestiä uudelleen"
+
+msgid "Don't exit"
+msgstr "Älä poistu"
+
+msgid "Reset"
+msgstr "Käynnistä uudelleen"
+
+msgid "Don't reset"
+msgstr "Älä käynnistä uudelleen"
+
+msgid "CD-ROM images"
+msgstr "CD-ROM-levykuvat"
+
+msgid "%1 Device Configuration"
+msgstr "%1 - Laitteen määritykset"
+
+msgid "Monitor in sleep mode"
+msgstr "Näyttö lepotilassa"
+
+msgid "GLSL shaders"
+msgstr "GLSL-varjostinohjelmat"
+
+msgid "You are loading an unsupported configuration"
+msgstr "Olet lataamassa ei-tuettua määritystä"
+
+msgid "CPU type filtering based on selected machine is disabled for this emulated machine.\n\nThis makes it possible to choose a CPU that is otherwise incompatible with the selected machine. However, you may run into incompatibilities with the machine BIOS or other software.\n\nEnabling this setting is not officially supported and any bug reports filed may be closed as invalid."
+msgstr "Valittuun tietokoneeseen perustuva suoritintyypin suodatus ei ole käytössä tällä emuloidulla koneella.\n\nTämä mahdollistaa muutoin yhteensopimattoman suorittimen valinnan kyseisen tietokoneen kanssa. Voit kuitenkin kohdata ongelmia tietokoneen BIOS:in tai muun ohjelmiston kanssa.\n\nTämän asetuksen käyttö ei ole virallisesti tuettua ja kaikki tehdyt virheraportit voidaan sulkea epäpätevinä."
+
+msgid "Continue"
+msgstr "Jatka"
+
+msgid "Cassette: %1"
+msgstr "Kasetti: %1"
+
+msgid "C&assette: %1"
+msgstr "K&asetti: %1"
+
+msgid "Cassette images"
+msgstr "Kasettitiedostot"
+
+msgid "Cartridge %1: %2"
+msgstr "ROM-moduuli %1: %2"
+
+msgid "Car&tridge %1: %2"
+msgstr "R&OM-moduuli %1: %2"
+
+msgid "Cartridge images"
+msgstr "ROM-moduulikuvat"
+
+msgid "Resume execution"
+msgstr "Jatka suoritusta"
+
+msgid "Pause execution"
+msgstr "Pysäytä suoritus"
+
+msgid "Ctrl+Alt+Del"
+msgstr ""
+
+msgid "Press Ctrl+Alt+Del"
+msgstr "Paina Ctrl+Alt+Del"
+
+msgid "Press Ctrl+Alt+Esc"
+msgstr "Paina Ctrl+Alt+Esc"
+
+msgid "Hard reset"
+msgstr "Kylmä uudelleenkäynnistys"
+
+msgid "Force shutdown"
+msgstr "Pakota sammutus"
+
+msgid "Start"
+msgstr "Käynnistä"
+
+msgid "Not running"
+msgstr "Ei käynnissä"
+
+msgid "Running"
+msgstr "Käynnissä"
+
+msgid "Paused"
+msgstr "Pysäytetty"
+
+msgid "Waiting"
+msgstr "Odottaa"
+
+msgid "Powered Off"
+msgstr "Sammutettu"
+
+msgid "%n running"
+msgstr "%n käynnissä"
+
+msgid "%n paused"
+msgstr "%n pysäytetty"
+
+msgid "%n waiting"
+msgstr "%n odottaa"
+
+msgid "%1 total"
+msgstr "yhteensä %1"
+
+msgid "VMs: %1"
+msgstr "Virtuaalikoneita: %1"
+
+msgid "System Directory:"
+msgstr "Konekansio:"
+
+msgid "Choose directory"
+msgstr "Valitse kansio"
+
+msgid "Choose configuration file"
+msgstr "Valitse konemääritystiedosto"
+
+msgid "86Box configuration files (86box.cfg)"
+msgstr "86Box-konemääritystiedostot (86box.cfg)"
+
+msgid "Configuration read failed"
+msgstr "Määrityksen lukeminen epäonnistui"
+
+msgid "Unable to open the selected configuration file for reading: %1"
+msgstr "Valittua määritystä ei voitu avata: %1"
+
+msgid "Use regular expressions in search box"
+msgstr "Käytä säännöllisiä lausekkeita (regex) hakukentässä"
+
+msgid "%1 machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
+msgstr "%1 konetta on tällä hetkellä aktiivisena. Haluatko silti sulkea virtuaalikoneiden hallinnan?"
+
+msgid "Add new system wizard"
+msgstr "Koneenlisäysohjelma"
+
+msgid "Introduction"
+msgstr "Johdanto"
+
+msgid "This will help you add a new system to 86Box."
+msgstr "Tämä ohjelma auttaa sinua lisäämään uuden koneen 86Boxiin."
+
+msgid "New configuration"
+msgstr "Uusi määritys"
+
+msgid "Complete"
+msgstr "Valmis"
+
+msgid "The wizard will now launch the configuration for the new system."
+msgstr "Ohjelma käynnistää koneen määrityksen."
+
+msgid "Use existing configuration"
+msgstr "Käytä olemassaolevaa määritystä"
+
+msgid "Type some notes here"
+msgstr "Kirjoita muistiinpanoja"
+
+msgid "Paste the contents of the existing configuration file into the box below."
+msgstr "Liitä olemassaolevan määrityksen sisälto alla olevaan tekstikenttään."
+
+msgid "Load configuration from file"
+msgstr "Lataa määritys tiedostosta"
+
+msgid "System name"
+msgstr "Koneen nimi"
+
+msgid "System name:"
+msgstr "Koneen nimi:"
+
+msgid "System name cannot contain certain characters"
+msgstr "Koneen nimi ei voi sisältää joitakin merkkejä"
+
+msgid "System name already exists"
+msgstr "Koneen nimi on jo olemassa"
+
+msgid "Please enter a directory for the system"
+msgstr "Anna kansio koneelle"
+
+msgid "Directory does not exist"
+msgstr "Kansiota ei ole olemassa"
+
+msgid "A new directory for the system will be created in the selected directory above"
+msgstr "Koneelle luodaan uusi kansio valittuun kansioon"
+
+msgid "System location:"
+msgstr "Koneen sijainti:"
+
+msgid "System name and location"
+msgstr "Koneen nimi ja sijainti:"
+
+msgid "Enter the name of the system and choose the location"
+msgstr "Anna koneen nimi ja valitse sijainti"
+
+msgid "Enter the name of the system"
+msgstr "Kirjoita koneen nimi"
+
+msgid "Please enter a system name"
+msgstr "Anna koneelle nimi"
+
+msgid "Display name (optional):"
+msgstr "Valinnainen näyttönimi:"
+
+msgid "Display name:"
+msgstr "Näyttönimi:"
+
+msgid "Set display name"
+msgstr "Aseta näyttönimi"
+
+msgid "Enter the new display name (blank to reset)"
+msgstr "Anna uusi näyttönimi tai poista se"
+
+msgid "Change &display name..."
+msgstr "Vaihda &näyttönimi"
+
+msgid "Context Menu"
+msgstr "Kontekstivalikko"
+
+msgid "&Open folder..."
+msgstr "&Avaa kansio..."
+
+msgid "Open p&rinter tray..."
+msgstr "Avaa &tulostimen lokero..."
+
+msgid "Set &icon..."
+msgstr "Aseta &kuvake..."
+
+msgid "Select an icon"
+msgstr "Valitse kuvake"
+
+msgid "C&lone..."
+msgstr "K&loonaa..."
+
+msgid "Virtual machine \"%1\" (%2) will be cloned into:"
+msgstr "Virtuaalikone \"%1\" (%2) kloonataan tänne:"
+
+msgid "Directory %1 already exists"
+msgstr "Hakemisto %1 on jo olemassa"
+
+msgid "You cannot use the following characters in the name: %1"
+msgstr "Et voi käyttää seuraavia merkkejä nimessä: %1"
+
+msgid "Clone"
+msgstr "Kloonaa"
+
+msgid "Failed to create directory for cloned VM"
+msgstr "Kloonatulle virtuaalikoneelle ei voitu luoda hakemistoa"
+
+msgid "Failed to clone VM."
+msgstr "Virtuaalikoneen kloonaus epäonnistui."
+
+msgid "Directory in use"
+msgstr "Hakemisto käytössä"
+
+msgid "The selected directory is already in use. Please select a different directory."
+msgstr "Valittu hakemisto on jo käytössä. Valitse toinen hakemisto."
+
+msgid "Create directory failed"
+msgstr "Hakemiston luominen epäonnistui"
+
+msgid "Unable to create the directory for the new system"
+msgstr "Uudelle koneelle ei voitu luoda hakemistoa"
+
+msgid "Configuration write failed"
+msgstr "Määrityksen kirjoitus epäonnistui"
+
+msgid "Unable to open the configuration file at %1 for writing"
+msgstr "Asetustiedostoa %1 ei voitu avata kirjoittamista varten"
+
+msgid "Error adding system"
+msgstr "Koneenlisäysvirhe"
+
+msgid "Remove directory failed"
+msgstr "Hakemiston poistaminen epäonnistui"
+
+msgid "Some files in the machine's directory were unable to be deleted. Please delete them manually."
+msgstr "Joitakin konehakemiston tiedostoista ei voitu poistaa. Poista ne käsin."
+
+msgid "Build"
+msgstr "Käännös"
+
+msgid "Version"
+msgstr "Versio"
+
+msgid "An update to 86Box is available: %1 %2"
+msgstr "86Box-päivitys on saatavilla: %1 %2"
+
+msgid "An error has occurred while checking for updates: %1"
+msgstr "Päivityksiä ei voitu tarkistaa: %1"
+
+msgid "<b>An update to 86Box is available!</b>"
+msgstr "<b>86Box-päivitys on saatavilla!</b>"
+
+msgid "Warning"
+msgstr "Varoitus"
+
+msgid "&Kill"
+msgstr "P&akkopysäytä"
+
+msgid "Killing a virtual machine can cause data loss. Only do this if the 86Box process gets stuck.\n\nDo you really wish to kill the virtual machine \"%1\"?"
+msgstr "Virtuaalikoneen pakkopysäytys saattaa johtaa datan menettämiseen. Tee niin ainoastaan jos 86Box-prosessi on jumissa.\n\nHaluatko varmasti pakkopysäyttää \"%1\"-virtuaalikoneen?"
+
+msgid "&Delete"
+msgstr "&Poista"
+
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
+msgstr "Haluatko varmasti poistaa \"%1\"-virtuaalikoneen ja kaikki sen tiedostot? Poistamista ei voi perua!"
+
+msgid "Show &config file"
+msgstr "Näytä &määritystiedosto"
+
+msgid "No screenshot"
+msgstr "Ei kuvakaappausta"
+
+msgid "Search"
+msgstr "Hae"
+
+msgid "Searching for VMs..."
+msgstr "Haetaan virtuaalikoneita..."
+
+msgid "Found %1"
+msgstr "%1 löydetty"
+
+msgid "System"
+msgstr "Kone"
+
+msgid "Storage"
+msgstr "Tallennus"
+
+msgid "Disk %1: "
+msgstr "Levy %1: "
+
+msgid "No disks"
+msgstr "Ei levyjä"
+
+msgid "Audio"
+msgstr "Ääni"
+
+msgid "Audio:"
+msgstr "Ääni:"
+
+msgid "ACPI shutdown"
+msgstr "ACPI-sammutus"
+
+msgid "ACP&I shutdown"
+msgstr "ACP&I-sammutus"
+
+msgid "Hard disk (%1)"
+msgstr "Kiintolevy (%1)"
+
+msgid "MFM/RLL or ESDI CD-ROM drives never existed"
+msgstr "MFM/RLL- tai ESDI-CD-ROM-asemia ei ole koskaan ollut olemassa"
+
+msgid "Custom..."
+msgstr "Mukautettu..."
+
+msgid "Custom (large)..."
+msgstr "Mukautettu (suuri)..."
+
+msgid "Add New Hard Disk"
+msgstr "Lisää uusi kiintolevy"
+
+msgid "Add Existing Hard Disk"
+msgstr "Lisää olemassaoleva kiintolevy"
+
+msgid "HDI disk images cannot be larger than 4 GB."
+msgstr "HDI-levykuvan suurin mahdollinen koko on 4 Gt."
+
+msgid "Disk images cannot be larger than 127 GB."
+msgstr "Levykuvien suurin mahdollinen koko on 127 Gt."
+
+msgid "Hard disk images"
+msgstr "Kiintolevykuvat"
+
+msgid "Unable to read file"
+msgstr "Tiedostoa ei voitu lukea"
+
+msgid "Unable to write file"
+msgstr "Tiedostoa ei voitu kirjoittaa"
+
+msgid "HDI or HDX images with a sector size other than 512 are not supported."
+msgstr "HDI- ja HDX-levykuvien ainoa tuettu sektorikoko on 512"
+
+msgid "Disk image file already exists"
+msgstr "Levykuva on jo olemassa"
+
+msgid "Please specify a valid file name."
+msgstr "Anna kelvollinen tiedostonimi."
+
+msgid "Disk image created"
+msgstr "Levykuva luotu"
+
+msgid "Make sure the file exists and is readable."
+msgstr "Varmista, että tiedosto on olemassa ja lukukelpoinen"
+
+msgid "Make sure the file is being saved to a writable directory."
+msgstr "Varmista, että tiedoston tallennuskansioon pystyy kirjoittamaan."
+
+msgid "Disk image too large"
+msgstr "Liian suuri levykuva"
+
+msgid "Remember to partition and format the newly-created drive."
+msgstr "Muista osioida ja alustaa juuri luomasi asema."
+
+msgid "The selected file will be overwritten. Are you sure you want to use it?"
+msgstr "Valittu tiedosto korvataan. Oletko varma, että haluat käyttää sitä?"
+
+msgid "Unsupported disk image"
+msgstr "Levykuvaa ei tueta"
+
+msgid "Overwrite"
+msgstr "Korvaa"
+
+msgid "Don't overwrite"
+msgstr "Älä korvaa"
+
+msgid "Raw image"
+msgstr "Raaka levykuva"
+
+msgid "HDI image"
+msgstr "HDI-levykuva"
+
+msgid "HDX image"
+msgstr "HDX-levykuva"
+
+msgid "Fixed-size VHD"
+msgstr "Kiinteä VHD"
+
+msgid "Dynamic-size VHD"
+msgstr "Dynaaminen VHD"
+
+msgid "Differencing VHD"
+msgstr "Differentiaalinen VHD"
+
+msgid "(N/A)"
+msgstr "(Ei mikään)"
+
+msgid "Raw image (.img)"
+msgstr "Raaka levykuva (.img)"
+
+msgid "HDI image (.hdi)"
+msgstr "HDI-levykuva (.hdi)"
+
+msgid "HDX image (.hdx)"
+msgstr "HDX-levykuva (.hdx)"
+
+msgid "Fixed-size VHD (.vhd)"
+msgstr "Kiinteä VHD (.vhd)"
+
+msgid "Dynamic-size VHD (.vhd)"
+msgstr "Dynaaminen VHD (.vhd)"
+
+msgid "Differencing VHD (.vhd)"
+msgstr "Differentiaalinen VHD (.vhd)"
+
+msgid "Large blocks (2 MB)"
+msgstr "Suuret lohkot (2 Mt)"
+
+msgid "Small blocks (512 KB)"
+msgstr "Pienet lohkot (512 kt)"
+
+msgid "VHD files"
+msgstr "VHD-tiedostot"
+
+msgid "Select the parent VHD"
+msgstr "Valitse ylätason VHD"
+
+msgid "This could mean that the parent image was modified after the differencing image was created.\n\nIt can also happen if the image files were moved or copied, or by a bug in the program that created this disk.\n\nDo you want to fix the timestamps?"
+msgstr "Tämä saattaa tarkoittaa, että ylätason levykuvaa on muokattu differentiaalisen levykuvan luonnin jälkeen.\n\nNäin voi käydä myös, jos levykuvatiedostoja on siirretty tai kopioitu. Lisäksi syynä voi olla levyn luoneessa sovelluksessa oleva ohjelmistovirhe.\n\nKorjataanko aikaleimat?"
+
+msgid "Parent and child disk timestamps do not match"
+msgstr "Ylä- ja alatason levyjen aikaleimat eivät täsmää"
+
+msgid "Could not fix VHD timestamp."
+msgstr "VHD:n aikaleimaa ei pystytty korjaamaan."
+
+msgid "MFM/RLL"
+msgstr "MFM/RLL"
+
+msgid "XTA"
+msgstr "XTA"
+
+msgid "ESDI"
+msgstr "ESDI"
+
+msgid "IDE"
+msgstr "IDE"
+
+msgid "ATAPI"
+msgstr "ATAPI"
+
+msgid "CD-ROM %1 (%2): %3"
+msgstr "CD-ROM %1 (%2): %3"
+
+msgid "&CD-ROM %1 (%2): %3"
+msgstr "&CD-ROM %1 (%2): %3"
+
+msgid "160 KB"
+msgstr "160 Kt"
+
+msgid "180 KB"
+msgstr "180 Kt"
+
+msgid "320 KB"
+msgstr "320 Kt"
+
+msgid "360 KB"
+msgstr "360 Kt"
+
+msgid "640 KB"
+msgstr "640 Kt"
+
+msgid "720 KB"
+msgstr "720 Kt"
+
+msgid "1.2 MB"
+msgstr "1.2 Mt"
+
+msgid "1.25 MB"
+msgstr "1.25 Mt"
+
+msgid "1.44 MB"
+msgstr "1.44 Mt"
+
+msgid "DMF (cluster 1024)"
+msgstr "DMF (lohko 1024)"
+
+msgid "DMF (cluster 2048)"
+msgstr "DMF (lohko 2048)"
+
+msgid "2.88 MB"
+msgstr "2.88 Mt"
+
+msgid "ZIP 100"
+msgstr "ZIP 100"
+
+msgid "3.5\" 128 MB (ISO 10090)"
+msgstr "3.5\" 128 Mt (ISO 10090)"
+
+msgid "3.5\" 230 MB (ISO 13963)"
+msgstr "3.5\" 230 Mt (ISO 13963)"
+
+msgid "3.5\" 540 MB (ISO 15498)"
+msgstr "3.5\" 540 Mt (ISO 15498)"
+
+msgid "3.5\" 640 MB (ISO 15498)"
+msgstr "3.5\" 640 Mt (ISO 15498)"
+
+msgid "3.5\" 1.3 GB (GigaMO)"
+msgstr "3.5\" 1.3 Gt (GigaMO)"
+
+msgid "3.5\" 2.3 GB (GigaMO 2)"
+msgstr "3.5\" 2.3 Gt (GigaMO 2)"
+
+msgid "5.25\" 600 MB"
+msgstr "5.25\" 600 Mt"
+
+msgid "5.25\" 650 MB"
+msgstr "5.25\" 650 Mt"
+
+msgid "5.25\" 1 GB"
+msgstr "5.25\" 1 Gt"
+
+msgid "5.25\" 1.3 GB"
+msgstr "5.25\" 1.3 Gt"
+
+msgid "Perfect RPM"
+msgstr "Täydellinen RPM"
+
+msgid "1% below perfect RPM"
+msgstr "1% alle täydellisen RPM:n"
+
+msgid "1.5% below perfect RPM"
+msgstr "1.5% alle täydellisen RPM:n"
+
+msgid "2% below perfect RPM"
+msgstr "2% alle täydellisen RPM:n"
+
+msgid "(System Default)"
+msgstr "(Järjestelmän oletus)"
+
+msgid "Failed to initialize network driver"
+msgstr "Verkkoajurin alustaminen epäonnistui"
+
+msgid "The network configuration will be switched to the null driver"
+msgstr "Verkkokokoonpano vaihtuu nolla-ajuriin"
+
+msgid "Mouse sensitivity:"
+msgstr "Hiiren herkkyys:"
+
+msgid "Select media images from program working directory"
+msgstr "Valitse levykuvat ohjelman työhakemistosta"
+
+msgid "PIT mode:"
+msgstr "PIT-tila:"
+
+msgid "Auto"
+msgstr "Automaattinen"
+
+msgid "Slow"
+msgstr "Hidas"
+
+msgid "Fast"
+msgstr "Nopea"
+
+msgid "&Auto-pause on focus loss"
+msgstr "&Automaattinen tauko tarkennuksen hävitessä"
+
+msgid "WinBox is no longer supported"
+msgstr "WinBoxia ei enää tueta"
+
+msgid "Development of the WinBox manager stopped in 2022 due to a lack of maintainers. As we direct our efforts towards making 86Box even better, we have made the decision to no longer support WinBox as a manager.\n\nNo further updates will be provided through WinBox, and you may encounter incorrect behavior should you continue using it with newer versions of 86Box. Any bug reports related to WinBox behavior will be closed as invalid.\n\nGo to 86box.net for a list of other managers you can use."
+msgstr "WinBox-managerin kehitys lopetettiin vuonna 2022, koska ylläpitäjiä ei ollut riittävästi. Koska suuntaamme ponnistuksemme 86Boxin parantamiseen entisestään, olemme päättäneet olla enää tukematta WinBoxia managerina.\n\nWinBoxin kautta ei enää toimiteta päivityksiä, ja saatat kohdata virheellistä käyttäytymistä, jos jatkat sen käyttöä 86Boxin uudemmissa versioissa. Kaikki WinBoxin käyttäytymiseen liittyvät vikailmoitukset suljetaan virheellisinä.\n\nSiirry osoitteeseen 86box.net saadaksesi luettelon muista hallintaohjelmista."
+
+msgid "Generate"
+msgstr "Luo"
+
+msgid "Joystick configuration"
+msgstr "Peliohjaimen määritys"
+
+msgid "Device"
+msgstr "Laite"
+
+msgid "%1 (X axis)"
+msgstr "%1 (X-akseli)"
+
+msgid "%1 (Y axis)"
+msgstr "%1 (Y-akseli)"
+
+msgid "MCA devices"
+msgstr "MCA-laitteet"
+
+msgid "List of MCA devices:"
+msgstr "Luettelo MCA-laitteista:"
+
+msgid "&Tablet tool"
+msgstr "Tablettityökalu"
+
+msgid "About &Qt"
+msgstr "Tietoja &Qt:sta"
+
+msgid "&MCA devices..."
+msgstr "MCA-laitteet..."
+
+msgid "Show non-&primary monitors"
+msgstr "Näytä muut kuin ensisijaiset näytöt"
+
+msgid "Open screenshots &folder..."
+msgstr "Avaa kuvakaappaukset-kansio..."
+
+msgid "Appl&y fullscreen stretch mode when maximized"
+msgstr "Sovella koko näytön venytystilaa maksimoidessa"
+
+msgid "&Cursor/Puck"
+msgstr "&Kursori/Kiekko"
+
+msgid "&Pen"
+msgstr "K&ynä"
+
+msgid "&Host CD/DVD Drive (%1:)"
+msgstr "&Isäntä CD/DVD-asema (%1:)"
+
+msgid "&Connected"
+msgstr "&Yhdistetty"
+
+msgid "Clear image &history"
+msgstr "Tyhjennä levykuva&historia"
+
+msgid "Create..."
+msgstr "Luo..."
+
+msgid "Host CD/DVD Drive (%1)"
+msgstr "Isännän CD/DVD-asema (%1)"
+
+msgid "Unknown Bus"
+msgstr "Tuntematon väylä"
+
+msgid "Null Driver"
+msgstr "Nolla-ajuri"
+
+msgid "NIC:"
+msgstr "Verkkokortti:"
+
+msgid "NIC %1 (%2) %3"
+msgstr "Verkkokortti %1 (%2) %3"
+
+msgid "&NIC %1 (%2) %3"
+msgstr "&Verkkokortti %1 (%2) %3"
+
+msgid "Render behavior"
+msgstr "Renderöintikäyttäytyminen"
+
+msgid "Use target framerate:"
+msgstr "Kuvataajuustavoite:"
+
+msgid " fps"
+msgstr " ruutua/s"
+
+msgid "VSync"
+msgstr "VSync"
+
+msgid "Synchronize with video"
+msgstr "Synkronisoi videoon"
+
+msgid "Shaders"
+msgstr "Varjostinohjelmat"
+
+msgid "Remove"
+msgstr "Poista"
+
+msgid "Browse..."
+msgstr "Selaa..."
+
+msgid "Couldn't create OpenGL context."
+msgstr "OpenGL-kontekstia ei voitu luoda."
+
+msgid "Couldn't switch to OpenGL context."
+msgstr "Ei voitu siirtyä OpenGL-kontekstiin."
+
+msgid "OpenGL version 3.0 or greater is required. Current version is %1.%2"
+msgstr "Tarvitaan OpenGL-versio 3.0 tai uudempi. Nykyinen versio on %1.%2"
+
+msgid "Error initializing OpenGL"
+msgstr "Virhe OpenGL:n alustamisessa"
+
+msgid "\nFalling back to software rendering."
+msgstr "\nPalataan ohjelmistopohjaiseen renderöintiin."
+
+msgid "<html><head/><body><p>When selecting media images (CD-ROM, floppy, etc.) the open dialog will start in the same directory as the 86Box configuration file. This setting will likely only make a difference on macOS.</p></body></html>"
+msgstr "<html><head/><body><p>Kun valitset levykuvia (CD-ROM, levykkeet jne.), avausikkuna aukeaa 86Boxin määritystiedoston hakemistoon. Tällä asetuksella on todennäköisesti merkitystä vain macOS-käyttöjärjestelmässä.</p></body></html>"
+
+msgid "This machine might have been moved or copied."
+msgstr "Kone on saatettu siirtää tai kopioida."
+
+msgid "In order to ensure proper networking functionality, 86Box needs to know if this machine was moved or copied.\n\nSelect \"I Copied It\" if you are not sure."
+msgstr "Varmistaakseen asianmukaisen verkkotoiminnan 86Boxin on tiedettävä, onko tämä kone siirretty vai kopioitu.\n\nValitse \"Kopioin sen\", jos et ole varma."
+
+msgid "I Moved It"
+msgstr "Siirsin sen"
+
+msgid "I Copied It"
+msgstr "Kopioin sen"
+
+msgid "86Box Monitor #"
+msgstr "86Box Monitor "
+
+msgid "No MCA devices."
+msgstr "Ei MCA-laitteita."
+
+msgid "MiB"
+msgstr ""
+
+msgid "GiB"
+msgstr ""
+
+msgid "Network Card #1"
+msgstr "Verkkokortti 1"
+
+msgid "Network Card #2"
+msgstr "Verkkokortti 2"
+
+msgid "Network Card #3"
+msgstr "Verkkokortti 3"
+
+msgid "Network Card #4"
+msgstr "Verkkokortti 4"
+
+msgid "Mode:"
+msgstr "Tila:"
+
+msgid "Interface:"
+msgstr "Liitäntä:"
+
+msgid "Adapter:"
+msgstr "Sovitin:"
+
+msgid "VDE Socket:"
+msgstr "VDE-socket:"
+
+msgid "86Box Unit Tester"
+msgstr "86Box Unit Tester"
+
+msgid "Novell NetWare 2.x Key Card"
+msgstr "Novell NetWare 2.x-avainkortti"
+
+msgid "Serial port passthrough 1"
+msgstr "Sarjaportin läpivienti 1"
+
+msgid "Serial port passthrough 2"
+msgstr "Sarjaportin läpivienti 2"
+
+msgid "Serial port passthrough 3"
+msgstr "Sarjaportin läpivienti 3"
+
+msgid "Serial port passthrough 4"
+msgstr "Sarjaportin läpivienti 4"
+
+msgid "Renderer &options..."
+msgstr "Renderöijän &asetukset..."
+
+msgid "PC/XT Keyboard"
+msgstr "PC/XT-näppäimistö"
+
+msgid "AT Keyboard"
+msgstr "AT-näppäimistö"
+
+msgid "AX Keyboard"
+msgstr "AX-näppäimistö"
+
+msgid "PS/2 Keyboard"
+msgstr "PS/2-näppäimistö"
+
+msgid "PS/55 Keyboard"
+msgstr "PS/55-näppäimistö"
+
+msgid "Keys"
+msgstr "Näppäimet"
+
+msgid "Logitech/Microsoft Bus Mouse"
+msgstr "Logitech/Microsoft-väylähiiri"
+
+msgid "Microsoft Bus Mouse (InPort)"
+msgstr "Microsoft-väylähiiri (InPort)"
+
+msgid "Mouse Systems Serial Mouse"
+msgstr "Mouse Systems-sarjahiiri"
+
+msgid "Mouse Systems Bus Mouse"
+msgstr ""
+
+msgid "Microsoft Serial Mouse"
+msgstr "Microsoft-sarjahiiri"
+
+msgid "Microsoft Serial BallPoint"
+msgstr ""
+
+msgid "Logitech Serial Mouse"
+msgstr "Logitech-sarjahiiri"
+
+msgid "PS/2 Mouse"
+msgstr "PS/2-hiiri"
+
+msgid "PS/2 QuickPort Mouse"
+msgstr "PS/2 QuickPort-hiiri"
+
+msgid "3M MicroTouch (Serial)"
+msgstr "3M MicroTouch (sarja)"
+
+msgid "Default Baud rate"
+msgstr "Oletussiirtonopeus"
+
+msgid "[COM] Standard Hayes-compliant Modem"
+msgstr "[COM] Tavallinen Hayes-yhteensopiva modeemi"
+
+msgid "Roland MT-32 Emulation"
+msgstr "Roland MT-32-emulointi"
+
+msgid "Roland MT-32 (New) Emulation"
+msgstr "Roland MT-32 (uusi)-emulointi"
+
+msgid "Roland CM-32L Emulation"
+msgstr "Roland CM-32L-emulointi"
+
+msgid "Roland CM-32LN Emulation"
+msgstr "Roland CM-32LN-emulointi"
+
+msgid "OPL4-ML Daughterboard"
+msgstr "OPL4-ML-tytärlevy"
+
+msgid "System MIDI"
+msgstr "Järjestelmän MIDI"
+
+msgid "MIDI Input Device"
+msgstr "MIDI-syöttölaite"
+
+msgid "BIOS file"
+msgstr "BIOS-tiedosto"
+
+msgid "BIOS file (ROM #1)"
+msgstr "BIOS-tiedosto (ROM #1)"
+
+msgid "BIOS file (ROM #2)"
+msgstr "BIOS-tiedosto (ROM #2)"
+
+msgid "BIOS file (ROM #3)"
+msgstr "BIOS-tiedosto (ROM #3)"
+
+msgid "BIOS file (ROM #4)"
+msgstr "BIOS-tiedosto (ROM #4)"
+
+msgid "BIOS address"
+msgstr "BIOS-osoite"
+
+msgid "BIOS address (ROM #1)"
+msgstr "BIOS-osoite (ROM #1)"
+
+msgid "BIOS address (ROM #2)"
+msgstr "BIOS-osoite (ROM #2)"
+
+msgid "BIOS address (ROM #3)"
+msgstr "BIOS-osoite (ROM #3)"
+
+msgid "BIOS address (ROM #4)"
+msgstr "BIOS-osoite (ROM #4)"
+
+msgid "Enable BIOS extension ROM Writes"
+msgstr "Salli BIOS-laajennuksen ROM-kirjoitukset"
+
+msgid "Enable BIOS extension ROM Writes (ROM #1)"
+msgstr "Salli BIOS-laajennuksen ROM-kirjoitukset (ROM #1)"
+
+msgid "Enable BIOS extension ROM Writes (ROM #2)"
+msgstr "Salli BIOS-laajennuksen ROM-kirjoitukset (ROM #2)"
+
+msgid "Enable BIOS extension ROM Writes (ROM #3)"
+msgstr "Salli BIOS-laajennuksen ROM-kirjoitukset (ROM #3)"
+
+msgid "Enable BIOS extension ROM Writes (ROM #4)"
+msgstr "Salli BIOS-laajennuksen ROM-kirjoitukset (ROM #4)"
+
+msgid "Linear framebuffer base"
+msgstr ""
+
+msgid "Address"
+msgstr "Osoite"
+
+msgid "IRQ"
+msgstr "IRQ"
+
+msgid "Serial port IRQ"
+msgstr "Sarjaportin IRQ"
+
+msgid "Parallel port IRQ"
+msgstr "Rinnakkaisportin IRQ"
+
+msgid "BIOS Revision"
+msgstr "BIOS-versio"
+
+msgid "BIOS Version"
+msgstr "BIOS-versio"
+
+msgid "BIOS Language"
+msgstr "BIOS-kieli"
+
+msgid "IBM 5161 Expansion Unit"
+msgstr "IBM 5161-laajennusyksikkö"
+
+msgid "IBM Cassette Basic"
+msgstr ""
+
+msgid "Translate 26 -> 17"
+msgstr "Muunna 26 -> 17"
+
+msgid "Language"
+msgstr "Kieli"
+
+msgid "Enable backlight"
+msgstr "Taustavalo"
+
+msgid "Invert colors"
+msgstr "Käänteiset värit"
+
+msgid "BIOS size"
+msgstr "BIOS:in koko"
+
+msgid "BIOS size (ROM #1)"
+msgstr "BIOS:in koko (ROM #1)"
+
+msgid "BIOS size (ROM #2)"
+msgstr "BIOS:in koko (ROM #2)"
+
+msgid "BIOS size (ROM #3)"
+msgstr "BIOS:in koko (ROM #3)"
+
+msgid "BIOS size (ROM #4)"
+msgstr "BIOS:in koko (ROM #4)"
+
+msgid "Map C0000-C7FFF as UMB"
+msgstr "Kartoita C0000-C7FFF UMB:nä"
+
+msgid "Map C8000-CFFFF as UMB"
+msgstr "Kartoita C8000-CFFFF UMB:nä"
+
+msgid "Map D0000-D7FFF as UMB"
+msgstr "Kartoita D0000-D7FFF UMB:nä"
+
+msgid "Map D8000-DFFFF as UMB"
+msgstr "Kartoita D8000-DFFFF UMB:nä"
+
+msgid "Map E0000-E7FFF as UMB"
+msgstr "Kartoita E0000-E7FFF UMB:nä"
+
+msgid "Map E8000-EFFFF as UMB"
+msgstr "Kartoita E8000-EFFFF UMB:nä"
+
+msgid "JS9 Jumper (JIM)"
+msgstr "JS9-jumpperi (JIM)"
+
+msgid "MIDI Output Device"
+msgstr "MIDI-lähtölaite"
+
+msgid "MIDI Real time"
+msgstr "Reaaliaikainen MIDI"
+
+msgid "MIDI Thru"
+msgstr "MIDI-läpivienti"
+
+msgid "MIDI Clockout"
+msgstr "MIDI-kellon ulostulo"
+
+msgid "SoundFont"
+msgstr "SoundFont"
+
+msgid "Output Gain"
+msgstr "Lähtötaso"
+
+msgid "Chorus"
+msgstr ""
+
+msgid "Chorus Voices"
+msgstr ""
+
+msgid "Chorus Level"
+msgstr ""
+
+msgid "Chorus Speed"
+msgstr ""
+
+msgid "Chorus Depth"
+msgstr ""
+
+msgid "Chorus Waveform"
+msgstr ""
+
+msgid "Reverb"
+msgstr "Jälkikaiunta"
+
+msgid "Reverb Room Size"
+msgstr ""
+
+msgid "Reverb Damping"
+msgstr ""
+
+msgid "Reverb Width"
+msgstr ""
+
+msgid "Reverb Level"
+msgstr ""
+
+msgid "Interpolation Method"
+msgstr "Interpolointimenetelmä"
+
+msgid "Dynamic Sample Loading"
+msgstr "Dynaaminen näytteiden lataus"
+
+msgid "Reverb Output Gain"
+msgstr "Jälkikaiunnan lähtötaso"
+
+msgid "Reversed stereo"
+msgstr "Käänteinen stereo"
+
+msgid "Nice ramp"
+msgstr ""
+
+msgid "Hz"
+msgstr "Hz"
+
+msgid "Buttons"
+msgstr "Painikkeet"
+
+msgid "Serial Port"
+msgstr "Sarjaportti"
+
+msgid "RTS toggle"
+msgstr ""
+
+msgid "Revision"
+msgstr "Versio"
+
+msgid "Controller"
+msgstr "Ohjain"
+
+msgid "Show Crosshair"
+msgstr "Näytä tähtäin"
+
+msgid "DMA"
+msgstr "DMA"
+
+msgid "MAC Address"
+msgstr "MAC-osoite"
+
+msgid "MAC Address OUI"
+msgstr "MAC-osoitteen OUI"
+
+msgid "Enable BIOS"
+msgstr "BIOS"
+
+msgid "Baud Rate"
+msgstr "Baudinopeus"
+
+msgid "TCP/IP listening port"
+msgstr "TCP/IP-kuunteluportti"
+
+msgid "Phonebook File"
+msgstr "Puhelinluettelotiedosto"
+
+msgid "Telnet emulation"
+msgstr "Telnet-emulointi"
+
+msgid "RAM Address"
+msgstr "RAM-osoite"
+
+msgid "RAM size"
+msgstr "RAM-koko"
+
+msgid "Initial RAM size"
+msgstr "RAM-muistin alkukoko"
+
+msgid "Serial Number"
+msgstr "Sarjanumero"
+
+msgid "Host ID"
+msgstr "Isännän ID"
+
+msgid "FDC Address"
+msgstr "FDC-osoite"
+
+msgid "MPU-401 Address"
+msgstr "MPU-401-osoite"
+
+msgid "MPU-401 IRQ"
+msgstr "MPU-401-IRQ"
+
+msgid "Receive MIDI input"
+msgstr "Vastaanota MIDI-tulo"
+
+msgid "Low DMA"
+msgstr "Matala DMA"
+
+msgid "Enable Game port"
+msgstr "Peliportti"
+
+msgid "SID Model"
+msgstr "SID-malli"
+
+msgid "SID Filter Strength"
+msgstr "SID-filtterin vahvuus"
+
+msgid "Surround module"
+msgstr "Surround-moduuli"
+
+msgid "CODEC"
+msgstr "CODEC"
+
+msgid "Raise CODEC interrupt on CODEC setup (needed by some drivers)"
+msgstr "CODEC-keskeytys CODEC-asennuksen yhteydessä (jotkut ohjaimet tarvitsevat sitä)"
+
+msgid "SB Address"
+msgstr "SB-osoite"
+
+msgid "Adlib Address"
+msgstr "Adlib-osoite"
+
+msgid "Use EEPROM setting"
+msgstr "Käytä EEPROM-asetusta"
+
+msgid "WSS IRQ"
+msgstr "WSS-IRQ"
+
+msgid "WSS DMA"
+msgstr "WSS-DMA"
+
+msgid "Enable OPL"
+msgstr "OPL"
+
+msgid "Receive MIDI input (MPU-401)"
+msgstr "Vastaanota MIDI-tulo (MPU-401)"
+
+msgid "SB low DMA"
+msgstr "Matala SB-DMA"
+
+msgid "6CH variant (6-channel)"
+msgstr "6CH-versio (6-kanavainen)"
+
+msgid "Enable CMS"
+msgstr "CMS"
+
+msgid "Mixer"
+msgstr "Mikseri"
+
+msgid "High DMA"
+msgstr "Korkea DMA"
+
+msgid "Control PC speaker"
+msgstr "Ohjaa PC-kaiutinta"
+
+msgid "Memory size"
+msgstr "Muistin koko"
+
+msgid "EMU8000 Address"
+msgstr "EMU8000-osoite"
+
+msgid "IDE Controller"
+msgstr "IDE-ohjain"
+
+msgid "Codec"
+msgstr "Koodekki"
+
+msgid "GUS type"
+msgstr "GUS-tyyppi"
+
+msgid "Enable 0x04 \"Exit 86Box\" command"
+msgstr "Salli 0x04-komento \"Sulje 86Box\""
+
+msgid "Display type"
+msgstr "Näytön tyyppi"
+
+msgid "Composite type"
+msgstr "Komposiittityyppi"
+
+msgid "RGB type"
+msgstr "RGB-tyyppi"
+
+msgid "Line doubling type"
+msgstr "Linjan kaksinkertaistamistyyppi"
+
+msgid "Snow emulation"
+msgstr "Lumiemulointi"
+
+msgid "Monitor type"
+msgstr "Näytön tyyppi"
+
+msgid "Character set"
+msgstr "Merkistö"
+
+msgid "XGA type"
+msgstr "XGA-tyyppi"
+
+msgid "Instance"
+msgstr "Instanssi"
+
+msgid "MMIO Address"
+msgstr "MMIO-osoite"
+
+msgid "RAMDAC type"
+msgstr "RAMDAC-tyyppi"
+
+msgid "Blend"
+msgstr "Sekoita"
+
+msgid "Font"
+msgstr "Fontti"
+
+msgid "Bilinear filtering"
+msgstr "Bilineaarinen suodatus"
+
+msgid "Video chroma-keying"
+msgstr "Videon väriavainnus"
+
+msgid "Dithering"
+msgstr "Sekoitussävytys"
+
+msgid "Enable NMI for CGA emulation"
+msgstr "NMI CGA-emulointia varten"
+
+msgid "Voodoo type"
+msgstr "Voodoo-tyyppi"
+
+msgid "Framebuffer memory size"
+msgstr "Framebuffer-muistin koko"
+
+msgid "Texture memory size"
+msgstr "Tekstuurimuistin koko"
+
+msgid "Dither subtraction"
+msgstr "Sekoitussävytyksen vähennys"
+
+msgid "Screen Filter"
+msgstr "Näyttösuodatin"
+
+msgid "Render threads"
+msgstr "Renderöintisäikeet"
+
+msgid "SLI"
+msgstr "SLI"
+
+msgid "Start Address"
+msgstr "Aloitusosoite"
+
+msgid "Contiguous Size"
+msgstr "Vierekkäinen koko"
+
+msgid "I/O Width"
+msgstr "I/O-leveys"
+
+msgid "Transfer Speed"
+msgstr "Siirtonopeus"
+
+msgid "EMS mode"
+msgstr "EMS-tila"
+
+msgid "EMS Address"
+msgstr "EMS-osoite"
+
+msgid "EMS 1 Address"
+msgstr "EMS 1-osoite"
+
+msgid "EMS 2 Address"
+msgstr "EMS 2-osoite"
+
+msgid "EMS Memory Size"
+msgstr "EMS-muistin koko"
+
+msgid "EMS 1 Memory Size"
+msgstr "EMS 1-muistin koko"
+
+msgid "EMS 2 Memory Size"
+msgstr "EMS 2-muistin koko"
+
+msgid "Enable EMS"
+msgstr "EMS"
+
+msgid "Enable EMS 1"
+msgstr "EMS 1"
+
+msgid "Enable EMS 2"
+msgstr "EMS 2"
+
+msgid "Address for > 2 MB"
+msgstr "> 2 Mt-osoite"
+
+msgid "Frame Address"
+msgstr "Kehyksen osoite"
+
+msgid "USA"
+msgstr "USA"
+
+msgid "Danish"
+msgstr "Tanskalainen"
+
+msgid "Always at selected speed"
+msgstr "Aina valitulla nopeudella"
+
+msgid "BIOS setting + Hotkeys (off during POST)"
+msgstr "BIOS-asetus + pikanäppäimet (pois päältä POST:in aikana)"
+
+msgid "64 KB starting from F0000"
+msgstr "64 Kt alkaen F0000:sta"
+
+msgid "128 KB starting from E0000 (address MSB inverted, last 64 KB first)"
+msgstr "128 Kt alkaen E0000:sta (osoitteen käänteinen MSB, viimeiset 64 Kt ensin)"
+
+msgid "Sine"
+msgstr "Sini"
+
+msgid "Triangle"
+msgstr "Kolmio"
+
+msgid "Linear"
+msgstr "Lineaarinen"
+
+msgid "4th Order"
+msgstr ""
+
+msgid "7th Order"
+msgstr ""
+
+msgid "Non-timed (original)"
+msgstr "Ajastamaton (alkuperäinen)"
+
+msgid "45 Hz (JMP2 not populated)"
+msgstr "45 Hz (JMP2 ei käytössä)"
+
+msgid "Two"
+msgstr "Kaksi"
+
+msgid "Three"
+msgstr "Kolme"
+
+msgid "Wheel"
+msgstr "Rulla"
+
+msgid "Five + Wheel"
+msgstr "Viisi + rulla"
+
+msgid "Five + 2 Wheels"
+msgstr "Viisi + kaksi rullaa"
+
+msgid "A3 - SMT2 Serial / SMT3(R)V"
+msgstr "A3 - SMT2 sarja / SMT3(R)V"
+
+msgid "Q1 - SMT3(R) Serial"
+msgstr "Q1 - SMT3(R) sarja"
+
+msgid "8 KB"
+msgstr "8 Kt"
+
+msgid "32 KB"
+msgstr "32 Kt"
+
+msgid "16 KB"
+msgstr "16 Kt"
+
+msgid "64 KB"
+msgstr "64 Kt"
+
+msgid "Disable BIOS"
+msgstr "BIOS pois käytöstä"
+
+msgid "512 KB"
+msgstr "512 Kt"
+
+msgid "2 MB"
+msgstr "2 Mt"
+
+msgid "8 MB"
+msgstr "8 Mt"
+
+msgid "28 MB"
+msgstr "28 Mt"
+
+msgid "1 MB"
+msgstr "1 Mt"
+
+msgid "4 MB"
+msgstr "4 Mt"
+
+msgid "12 MB"
+msgstr "12 Mt"
+
+msgid "16 MB"
+msgstr "16 Mt"
+
+msgid "20 MB"
+msgstr "20 Mt"
+
+msgid "24 MB"
+msgstr "24 Mt"
+
+msgid "SigmaTel STAC9721T (stereo)"
+msgstr "SigmaTel STAC9721T (stereo)"
+
+msgid "Classic"
+msgstr "Klassinen"
+
+msgid "256 KB"
+msgstr "256 Kt"
+
+msgid "Composite"
+msgstr "Komposiitti"
+
+msgid "True color"
+msgstr ""
+
+msgid "Old"
+msgstr "Vanha"
+
+msgid "New"
+msgstr "Uusi"
+
+msgid "Color (generic)"
+msgstr "Väri (yleinen)"
+
+msgid "Green Monochrome"
+msgstr "Vihreä yksivärinen"
+
+msgid "Amber Monochrome"
+msgstr "Meripihkan värinen yksivärinen"
+
+msgid "Gray Monochrome"
+msgstr "Harmaa yksivärinen"
+
+msgid "Color (no brown)"
+msgstr "Väri (ei ruskeaa)"
+
+msgid "Color (IBM 5153)"
+msgstr "Väri (IBM 5153)"
+
+msgid "Simple doubling"
+msgstr "Yksinkertainen kaksinkertaistaminen"
+
+msgid "sRGB interpolation"
+msgstr "sRGB-interpolointi"
+
+msgid "Linear interpolation"
+msgstr "Lineaarinen interpolointi"
+
+msgid "Has secondary 8x8 character set"
+msgstr ""
+
+msgid "Has Quadcolor II daughter board"
+msgstr ""
+
+msgid "Alternate monochrome contrast"
+msgstr "Vaihtoehtoinen yksivärikontrasti"
+
+msgid "128 KB"
+msgstr "128 Kt"
+
+msgid "Monochrome (5151/MDA) (white)"
+msgstr "Yksivärinen (5151/MDA) (valkoinen)"
+
+msgid "Monochrome (5151/MDA) (green)"
+msgstr "Yksivärinen (5151/MDA) (vihreä)"
+
+msgid "Monochrome (5151/MDA) (amber)"
+msgstr "Yksivärinen (5151/MDA) (keltainen)"
+
+msgid "Color 40x25 (5153/CGA)"
+msgstr "Väri 40x25 (5153/CGA)"
+
+msgid "Color 80x25 (5153/CGA)"
+msgstr "Väri 80x25 (5153/CGA)"
+
+msgid "Enhanced Color - Normal Mode (5154/ECD)"
+msgstr "Parannettu väri - Normaali tila (5154/ECD)"
+
+msgid "Enhanced Color - Enhanced Mode (5154/ECD)"
+msgstr "Parannettu väri - Parannettu tila (5154/ECD)"
+
+msgid "Green"
+msgstr "Vihreä"
+
+msgid "Amber"
+msgstr "Meripihka"
+
+msgid "Gray"
+msgstr "Harmaa"
+
+msgid "Grayscale"
+msgstr "Harmaasävy"
+
+msgid "Color"
+msgstr "Väri"
+
+msgid "U.S. English"
+msgstr "Amerikanenglanti"
+
+msgid "Scandinavian"
+msgstr "Skandinaavinen"
+
+msgid "Other languages"
+msgstr "Muut kielet"
+
+msgid "Bochs latest"
+msgstr "Uusin Bochs"
+
+msgid "Apply overscan deltas"
+msgstr ""
+
+msgid "Mono Interlaced"
+msgstr "Lomitettu yksivärinen"
+
+msgid "Mono Non-Interlaced"
+msgstr "Ei-lomitettu yksivärinen"
+
+msgid "Color Interlaced"
+msgstr "Lomitettu väri"
+
+msgid "Color Non-Interlaced"
+msgstr "Ei-lomitettu väri"
+
+msgid "3Dfx Voodoo Graphics"
+msgstr "3dfx Voodoo-grafiikkasuoritin"
+
+msgid "3Dfx Voodoo 2"
+msgstr ""
+
+msgid "Obsidian SB50 + Amethyst (2 TMUs)"
+msgstr "Obsidian SB50 + Amethyst (2 TMU:ta)"
+
+msgid "8-bit"
+msgstr "8-bittinen"
+
+msgid "16-bit"
+msgstr "16-bittinen"
+
+msgid "Standard (150ns)"
+msgstr "Vakio (150ns)"
+
+msgid "High-Speed (120ns)"
+msgstr "Nopea (120ns)"
+
+msgid "Enabled"
+msgstr "Käytössä"
+
+msgid "Standard"
+msgstr "Vakio"
+
+msgid "High-Speed"
+msgstr "Nopea"
+
+msgid "Stereo LPT DAC"
+msgstr "Stereo-LPT-DAC"
+
+msgid "Generic Text Printer"
+msgstr "Yleinen tekstitulostin"
+
+msgid "Generic ESC/P Dot-Matrix Printer"
+msgstr "Yleinen ESC/P pistematriisitulostin"
+
+msgid "Generic PostScript Printer"
+msgstr "Yleinen PostScript-tulostin"
+
+msgid "Generic PCL5e Printer"
+msgstr "Yleinen PCL5e-tulostin"
+
+msgid "Parallel Line Internet Protocol"
+msgstr "Rinnakkaislinjan Internet-protokolla"
+
+msgid "Protection Dongle for Savage Quest"
+msgstr "Savage Questin suojausdongle"
+
+msgid "Serial Passthrough Device"
+msgstr "Sarjaportin läpivientilaite"
+
+msgid "Passthrough Mode"
+msgstr "Läpivientitila"
+
+msgid "Host Serial Device"
+msgstr "Isäntäkoneen sarjalaiten"
+
+msgid "Name of pipe"
+msgstr "Putken nimi"
+
+msgid "Data bits"
+msgstr "Databitit"
+
+msgid "Stop bits"
+msgstr "Pysäytysbitit"
+
+msgid "Baud Rate of Passthrough"
+msgstr "Läpiviennin baudinopeus"
+
+msgid "Named Pipe (Server)"
+msgstr "Nimetty putki (palvelin)"
+
+msgid "Named Pipe (Client)"
+msgstr "Nimettu putki (päätelaite)"
+
+msgid "Host Serial Passthrough"
+msgstr "Isännän sarjaportin läpivienti"
+
+msgid "E&ject %1"
+msgstr "&Poista %1"
+
+msgid "&Unmute"
+msgstr "&Poista mykistys"
+
+msgid "Softfloat FPU"
+msgstr "Softfloat-FPU"
+
+msgid "High performance impact"
+msgstr "Merkittävä vaikutus suorituskykyyn"
+
+msgid "[Generic] RAM Disk (max. speed)"
+msgstr "[Yleinen] RAM-levy (maksiminopeus)"
+
+msgid "[Generic] 1989 (3500 RPM)"
+msgstr "[Yleinen] 1989 (3500 RPM)"
+
+msgid "[Generic] 1992 (3600 RPM)"
+msgstr "[Yleinen] 1992 (3600 RPM)"
+
+msgid "[Generic] 1994 (4500 RPM)"
+msgstr "[Yleinen] 1994 (4500 RPM)"
+
+msgid "[Generic] 1996 (5400 RPM)"
+msgstr "[Yleinen] 1996 (5400 RPM)"
+
+msgid "[Generic] 1997 (5400 RPM)"
+msgstr "[Yleinen] 1997 (5400 RPM)"
+
+msgid "[Generic] 1998 (5400 RPM)"
+msgstr "[Yleinen] 1998 (5400 RPM)"
+
+msgid "[Generic] 2000 (7200 RPM)"
+msgstr "[Yleinen] 2000 (7200 RPM)"
+
+msgid "IBM 8514/A clone (ISA)"
+msgstr "IBM 8514/A-klooni (ISA)"
+
+msgid "Vendor"
+msgstr "Valmistaja"
+
+msgid "30 Hz (JMP2 = 1)"
+msgstr ""
+
+msgid "60 Hz (JMP2 = 2)"
+msgstr ""
+
+msgid "Generic PC/XT Memory Expansion"
+msgstr "Yleinen PC/XT-muistilaajennus"
+
+msgid "Generic PC/AT Memory Expansion"
+msgstr "Yleinen PC/AT-muistilaajennus"
+
+msgid "Unable to find Dot-Matrix fonts"
+msgstr "Pistematriisifontteja ei löydy"
+
+msgid "TrueType fonts in the \"roms/printer/fonts\" directory are required for the emulation of the Generic ESC/P Dot-Matrix Printer."
+msgstr "\"roms/printer/fonts\"-hakemiston TrueType-fontteja vaaditaan ESC/P-pistematriisitulostimen emulointiin."
+
+msgid "Inhibit multimedia keys"
+msgstr "Estä multimedianäppäimet"
+
+msgid "Ask for confirmation before saving settings"
+msgstr "Kysy varmistusta ennen asetusten tallentamista"
+
+msgid "Ask for confirmation before hard resetting"
+msgstr "Kysy varmistusta ennen uudelleenkäynnistystä"
+
+msgid "Ask for confirmation before quitting"
+msgstr "Kysy varmistusta ennen lopettamista"
+
+msgid "Options"
+msgstr "Asetukset"
+
+msgid "Model"
+msgstr "Malli"
+
+msgid "Model:"
+msgstr "Malli:"
+
+msgid "Failed to initialize Vulkan renderer."
+msgstr "Vulkan-rendereriä ei voitu alustaa."
+
+msgid "GLSL Error"
+msgstr "GLSL-virhe"
+
+msgid "Could not load shader: %1"
+msgstr "Varjostinta %1 ei voitu ladata"
+
+msgid "OpenGL version 3.0 or greater is required. Current GLSL version is %1.%2"
+msgstr "Vähintään OpenGL-versio 3.0 vaaditaan. Tämänhetkinen GLSL-versio on %1.%2"
+
+msgid "Could not load texture: %1"
+msgstr "Tekstuuria ei voitu ladata: %1"
+
+msgid "Could not compile shader:\n\n%1"
+msgstr "Varjostinta ei voitu kääntää:\n\n%1"
+
+msgid "Program not linked:\n\n%1"
+msgstr "Ohjelmaa ei linkitetty:\n\n%1"
+
+msgid "Shader Manager"
+msgstr "Varjostinhallinta"
+
+msgid "Shader Configuration"
+msgstr "Varjostinasetukset"
+
+msgid "Add"
+msgstr "Lisää"
+
+msgid "Move up"
+msgstr "Siirrä ylös"
+
+msgid "Move down"
+msgstr "Siirrä alas"
+
+msgid "Could not load file %1"
+msgstr "Tiedostoa %1 ei voitu ladata"
+
+msgid "Key Bindings:"
+msgstr "Pikanäppäimet:"
+
+msgid "Action"
+msgstr "Toiminto"
+
+msgid "Keybind"
+msgstr "Pikanäppäin"
+
+msgid "Clear binding"
+msgstr "Tyhjennä pikanäppäin"
+
+msgid "Bind"
+msgstr "Määritä"
+
+msgid "Bind Key"
+msgstr "Määritä pikanäppäin"
+
+msgid "Enter key combo:"
+msgstr "Anna näppäinyhdistelmä:"
+
+msgid "Bind conflict"
+msgstr "Pikanäppäinkonflikti"
+
+msgid "This key combo is already in use."
+msgstr "Näppäinyhdistelmä on jo käytössä."
+
+msgid "Send Control+Alt+Del"
+msgstr "Läheta Control+Alt+Del"
+
+msgid "Send Control+Alt+Escape"
+msgstr "Lähetä Control+Alt+Escape"
+
+msgid "Toggle fullscreen"
+msgstr "Koko näyttö"
+
+msgid "Screenshot"
+msgstr "Kuvakaappaus"
+
+msgid "Release mouse pointer"
+msgstr "Vapauta hiiren osoitin"
+
+msgid "Toggle pause"
+msgstr "Pysäytä"
+
+msgid "Toggle mute"
+msgstr "Mykistä"
+
+msgid "Text files"
+msgstr "Tekstitiedostot"
+
+msgid "ROM files"
+msgstr "ROM-tiedostot"
+
+msgid "SoundFont files"
+msgstr "SoundFont-tiedostot"
+
+msgid "Local Switch"
+msgstr "Paikallinen kytkin"
+
+msgid "Remote Switch"
+msgstr "Etäkytkin"
+
+msgid "Switch:"
+msgstr "Kytkin:"
+
+msgid "Hub Mode"
+msgstr "Hubitila"
+
+msgid "Isäntänimi:"
+msgstr ""
+
+msgid "ISA RTC"
+msgstr ""
+
+msgid "ISA RAM"
+msgstr ""
+
+msgid "ISA ROM"
+msgstr ""
+
+msgid "&Wipe NVRAM"
+msgstr "&Tyhjennä NVRAM"
+
+msgid "This will delete all NVRAM (and related) files of the virtual machine located in the \"nvr\" subdirectory. You'll have to reconfigure the BIOS (and possibly other devices inside the VM) settings again if applicable.\n\nAre you sure you want to wipe all NVRAM contents of the virtual machine \"%1\"?"
+msgstr "Tämä poistaa kaikki NVRAM:iin liittyvät tiedostot \"nvr\"-kansiossa. Joudut määrittämään BIOS:in ja mahdollisesti muut laitteet uudelleen.\n\nHaluatko varmasti tyhjentää \"%1\"-virtuaalikoneen kaiken NVRAM-sisällön?"
+
+msgid "Success"
+msgstr "Onnistui"
+
+msgid "Successfully wiped the NVRAM contents of the virtual machine \"%1\""
+msgstr "\"%1\"-virtuaalikoneen NVRAM-sisällön tyhjentäminen onnistui"
+
+msgid "An error occurred trying to wipe the NVRAM contents of the virtual machine \"%1\""
+msgstr "\"%1\"-virtuaalikoneen NVRAM-sisällön tyhjentäminen epäonnistui"
+
+msgid "%1 VM Manager"
+msgstr "%1 - virtuaalikoneiden hallinta"
+
+msgid "%n disk(s)"
+msgstr "%n levy(ä)"
+
+msgid "Unknown Status"
+msgstr "Tuntematon tila"
+
+msgid "No Machines Found!"
+msgstr "Koneita ei löytynyt!"
+
+msgid "Check for updates on startup"
+msgstr "Tarkista päivitykset käynnistyksen yhteydessä"
+
+msgid "Unable to determine release information"
+msgstr "Julkaisutietoja ei voitu hakea"
+
+msgid "There was an error checking for updates:\n\n%1\n\nPlease try again later."
+msgstr "Päivitystenhakuvirhe:\n\n%1\n\nYritä uudelleen myöhemmin."
+
+msgid "Update check complete"
+msgstr "Päivitystarkastus on valmis"
+
+msgid "stable"
+msgstr "vakaa"
+
+msgid "beta"
+msgstr ""
+
+msgid "You are running the latest %1 version of 86Box: %2"
+msgstr "Sinulla on käytössä uusin %1-versio 86Boxista: %2"
+
+msgid "version"
+msgstr "versio"
+
+msgid "build"
+msgstr "käännös"
+
+msgid "You are currently running version <b>%1</b>."
+msgstr "Käytät versiota <b>%1</b>."
+
+msgid "<b>Version %1</b> is now available."
+msgstr "<b>Versio %1</b> on nyt saatavilla."
+
+msgid "You are currently running build <b>%1</b>."
+msgstr "Käytät käännöstä <b>%1</b>"
+
+msgid "<b>Build %1</b> is now available."
+msgstr "<b>Käännös %1</b> on nyt saatavilla."
+
+msgid "Would you like to visit the download page?"
+msgstr "Haluatko siirtyä lataussivulle?"
+
+msgid "Visit download page"
+msgstr "Siirry lataussivulle"
+
+msgid "Update check"
+msgstr "Päivitystarkistus"
+
+msgid "Checking for updates..."
+msgstr "Tarkistetaan päivityksiä..."
+
+msgid "86Box Update"
+msgstr "86Box-päivitys"
+
+msgid "Release notes:"
+msgstr "Julkaisutiedot:"
+
+msgid "%1 Hz"
+msgstr "%1 Hz"
+
+msgid "Virtual machine crash"
+msgstr "Virtuaalikone kaatui"
+
+msgid "The virtual machine \"%1\"'s process has unexpectedly terminated with exit code %2."
+msgstr "\"%1\"-virtuaalikoneen prosessi kaatui yllättäen. Poistumiskoodi %2."
+
+msgid "The system will not be added."
+msgstr "Konetta ei lisätä."
+
+msgid "&Update mouse every CPU frame"
+msgstr "&Päivitä hiiri jokaisen CPU framen yhteydessä"
+
+msgid "Hue"
+msgstr "Sävy"
+
+msgid "Saturation"
+msgstr "Värikylläisyys"
+
+msgid "Contrast"
+msgstr "Kontrasti"
+
+msgid "Brightness"
+msgstr "Kirkkaus"
+
+msgid "Sharpness"
+msgstr "Terävyys"
+
+msgid "&CGA composite settings..."
+msgstr "&CGA:n komposiittiasetukset..."
+
+msgid "CGA composite settings"
+msgstr "CGA:n komposiittiasetukset"

--- a/src/qt/qt_progsettings.cpp
+++ b/src/qt/qt_progsettings.cpp
@@ -54,6 +54,7 @@ QVector<QPair<QString, QString>> ProgSettings::languages = {
     { "de-DE",  "German (Germany)"         },
     { "en-GB",  "English (United Kingdom)" },
     { "en-US",  "English (United States)"  },
+    { "fi-FI",  "Finnish (Finland)"        },
     { "fr-FR",  "French (France)"          },
     { "it-IT",  "Italian (Italy)"          },
     { "ja-JP",  "Japanese (Japan)"         },

--- a/src/qt/qt_translations.qrc.in
+++ b/src/qt/qt_translations.qrc.in
@@ -5,6 +5,7 @@
         <file>86box_en-US.qm</file>
         <file>86box_en-GB.qm</file>
         <file>86box_es-ES.qm</file>
+        <file>86box_fi-FI.qm</file>
         <file>86box_fr-FR.qm</file>
         <file>86box_hr-HR.qm</file>
         <file>86box_it-IT.qm</file>


### PR DESCRIPTION
From what I have tested, the translation is now more sensible than the previous machine and human translation mix.

Some translations were intentionally left empty, either because they made no sense to translate, or if I didn't know what a reasonable translation would be.

Includes previous translations from ts-korhonen and ziplantil, as well as probably still some machine translations that were valid.

Any discovered issues should be reported as an issue or in Discord message.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
