### PR TITLE
Fix Gateway 2000 Tigereye machine type.

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -15049,7 +15049,7 @@ const machine_t machines[] = {
     {
         .name = "[i430VX] Gateway 2000 Tigereye",
         .internal_name = "gw2kte",
-        .type = MACHINE_TYPE_SOCKET7_3V,
+        .type = MACHINE_TYPE_SOCKET7,
         .chipset = MACHINE_CHIPSET_INTEL_430VX,
         .init = machine_at_gw2kte_init,
         .p1_handler = machine_generic_p1_handler,


### PR DESCRIPTION
Summary
=======
This PR fixes the machine type from the Gateway 2000 Tigereye.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
