### PR TITLE
Fix bad HDD types display in Japanese translation [skip ci]

### DIFF
--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -910,7 +910,7 @@ msgid "None"
 msgstr "なし"
 
 msgid "%1 MB (CHS: %2, %3, %4)"
-msgstr "%u MB (CHS値: %i、%i、%i)"
+msgstr "%1 MB (CHS値: %2、%3、%4)"
 
 msgid "Floppy %1 (%2): %3"
 msgstr "フロッピー %1 (%2): %3"


### PR DESCRIPTION
Summary
=======
Fix bad HDD types display in Japanese translation.

Closes #6038.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
