### PR TITLE
partial fix of BSD builds

### DIFF
--- a/src/cdrom/CMakeLists.txt
+++ b/src/cdrom/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(cdrom OBJECT
     cdrom_image_viso.c
     cdrom_mke.c
 )
+target_include_directories(86Box PRIVATE PkgConfig::SNDFILE)
 target_link_libraries(86Box PkgConfig::SNDFILE)
 
 if(CDROM_MITSUMI)


### PR DESCRIPTION
Summary
=======
A partial fix of the build system to start fixing builds on FreeBSD and DragonFly BSD. This resolves the issue with them not being able to locate `sndfile.h` as `/usr/local/include` is not part of the default includes for clang. Note that this just restores the build to the point that it was prior to the MDF/MDS parser inclusion and does not result in a completed build as that is a separate issue.
