### PR TITLE
fix the fix so Win32 doesn't break

### DIFF
--- a/src/cdrom/CMakeLists.txt
+++ b/src/cdrom/CMakeLists.txt
@@ -25,7 +25,9 @@ add_library(cdrom OBJECT
     cdrom_image_viso.c
     cdrom_mke.c
 )
-target_include_directories(86Box PRIVATE PkgConfig::SNDFILE)
+if(NOT WIN32)
+	target_include_directories(86Box PRIVATE PkgConfig::SNDFILE)
+endif()
 target_link_libraries(86Box PkgConfig::SNDFILE)
 
 if(CDROM_MITSUMI)


### PR DESCRIPTION
Summary
=======
Lemondrops reports that the build breaks on Win32 with CMake not expanding the one variable, lets wrap the setup in if(NOT WIN32) as suggested.
