### PR TITLE
Implement portable mode

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -1112,6 +1112,10 @@ usage:
     pclog("#\n# %ls v%ls logfile, created %s\n#\n",
           EMU_NAME_W, EMU_VERSION_FULL_W, temp);
 
+    if (portable_mode) {
+        pclog("# Portable mode enabled.\n");
+    }
+
     pclog("# Emulator path: %s\n", exe_path);
     pclog("# Global configuration file: %s\n", global_cfg_path);
 

--- a/src/86box.c
+++ b/src/86box.c
@@ -755,6 +755,7 @@ pc_init(int argc, char *argv[])
         path_get_dirname(exe_path, p);
 #endif
 
+    path_normalize(exe_path);
     path_slash(exe_path);
 
     /*

--- a/src/86box.c
+++ b/src/86box.c
@@ -228,6 +228,8 @@ int      other_scsi_present = 0;                                  /* SCSI contro
                                                                      present */
 
 int      is_pcjr = 0;                                             /* The current machine is PCjr. */
+int      portable_mode = 0;                                       /* We are running in portable mode
+                                                                     (global dirs = exe path) */
 
 // Accelerator key array
 struct accelKey acc_keys[NUM_ACCELS];

--- a/src/86box.c
+++ b/src/86box.c
@@ -758,6 +758,22 @@ pc_init(int argc, char *argv[])
     path_slash(exe_path);
 
     /*
+     * Determine if we are running in portable mode.
+     *
+     * We enable portable mode if the EXE path
+     * contains the global config file.
+     */
+    path_append_filename(global, exe_path, GLOBAL_CONFIG_FILE);
+
+    FILE *fp = fopen(global, "r");
+    if (fp) {
+        portable_mode = 1;
+        fclose(fp);
+    }
+
+    global = NULL;
+
+    /*
      * Get the current working directory.
      *
      * This is normally the directory from where the

--- a/src/86box.c
+++ b/src/86box.c
@@ -763,15 +763,13 @@ pc_init(int argc, char *argv[])
      * We enable portable mode if the EXE path
      * contains the global config file.
      */
-    path_append_filename(global, exe_path, GLOBAL_CONFIG_FILE);
+    path_append_filename(temp, exe_path, GLOBAL_CONFIG_FILE);
 
-    FILE *fp = fopen(global, "r");
+    FILE *fp = fopen(temp, "r");
     if (fp) {
         portable_mode = 1;
         fclose(fp);
     }
-
-    global = NULL;
 
     /*
      * Get the current working directory.

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -42,6 +42,8 @@
 #define GLOBAL_CONFIG_FILE "86box_global.cfg"
 #define NVR_PATH           "nvr"
 #define SCREENSHOT_PATH    "screenshots"
+#define VMM_PATH		   "Virtual Machines"
+#define VMM_PATH_WINDOWS   "86Box VMs"
 
 /* Recently used images */
 #define MAX_PREV_IMAGES    10
@@ -188,14 +190,17 @@ extern int    hook_enabled;                 /* (C) Keyboard hook is enabled */
 extern int    vmm_disabled;                 /* (G) disable built-in manager */
 extern char   vmm_path_cfg[1024];           /* (G) VMs path (unless -E is used) */
 
-extern char exe_path[2048];     /* path (dir) of executable */
-extern char usr_path[1024];     /* path (dir) of user data */
-extern char cfg_path[1024];     /* full path of config file */
+extern char exe_path[2048];        /* path (dir) of executable */
+extern char usr_path[1024];        /* path (dir) of user data */
+extern char cfg_path[1024];        /* full path of config file */
 extern char global_cfg_path[1024]; /* full path of global config file */
-extern int  open_dir_usr_path;  /* default file open dialog directory of usr_path */
-extern char uuid[MAX_UUID_LEN]; /* UUID or machine identifier */
-extern char vmm_path[1024];       /* VM Manager path to scan */
-extern int  start_vmm;
+extern int  open_dir_usr_path;     /* default file open dialog directory of usr_path */
+extern char uuid[MAX_UUID_LEN];    /* UUID or machine identifier */
+extern char vmm_path[1024];        /* VM Manager path to scan */
+extern int  start_vmm;             /* the current execution will start the manager */
+extern int  portable_mode          /* we are running in portable mode 
+                                      (global dirs = exe path) */
+
 #ifndef USE_NEW_DYNAREC
 extern FILE *stdlog; /* file to log output to */
 #endif

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -198,7 +198,7 @@ extern int  open_dir_usr_path;     /* default file open dialog directory of usr_
 extern char uuid[MAX_UUID_LEN];    /* UUID or machine identifier */
 extern char vmm_path[1024];        /* VM Manager path to scan */
 extern int  start_vmm;             /* the current execution will start the manager */
-extern int  portable_mode          /* we are running in portable mode 
+extern int  portable_mode;         /* we are running in portable mode 
                                       (global dirs = exe path) */
 
 #ifndef USE_NEW_DYNAREC

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -668,25 +668,37 @@ plat_chdir(char *path)
 void
 plat_get_global_config_dir(char *outbuf, const size_t len)
 {
-    const auto dir = QDir(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation));
-    if (!dir.exists()) {
-        if (!dir.mkpath(".")) {
-            qWarning("Failed to create global configuration directory %s", dir.absolutePath().toUtf8().constData());
+    if (portable_mode) {
+        strncpy(outbuf, exe_path, len);
+    } else {
+        const auto dir = QDir(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation));
+        if (!dir.exists()) {
+            if (!dir.mkpath(".")) {
+                qWarning("Failed to create global configuration directory %s", dir.absolutePath().toUtf8().constData());
+            }
         }
+        strncpy(outbuf, dir.canonicalPath().toUtf8().constData(), len);
     }
-    strncpy(outbuf, dir.canonicalPath().toUtf8().constData(), len);
+
+    path_slash(outbuf);
 }
 
 void
 plat_get_global_data_dir(char *outbuf, const size_t len)
 {
-    const auto dir = QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
-    if (!dir.exists()) {
-        if (!dir.mkpath(".")) {
-            qWarning("Failed to create global data directory %s", dir.absolutePath().toUtf8().constData());
+    if (portable_mode) {
+        strncpy(outbuf, exe_path, len);
+    } else {
+        const auto dir = QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
+        if (!dir.exists()) {
+            if (!dir.mkpath(".")) {
+                qWarning("Failed to create global data directory %s", dir.absolutePath().toUtf8().constData());
+            }
         }
+        strncpy(outbuf, dir.canonicalPath().toUtf8().constData(), len);
     }
-    strncpy(outbuf, dir.canonicalPath().toUtf8().constData(), len);
+
+    path_slash(outbuf);
 }
 
 void
@@ -694,17 +706,26 @@ plat_get_temp_dir(char *outbuf, const uint8_t len)
 {
     const auto dir = QDir(QStandardPaths::writableLocation(QStandardPaths::TempLocation));
     strncpy(outbuf, dir.canonicalPath().toUtf8().constData(), len);
+    path_slash(outbuf);
 }
 
 void
 plat_get_vmm_dir(char *outbuf, const size_t len)
 {
+    QString path;
+
+    if (portable_mode) {
+        path = QDir(exe_path).filePath(VMM_PATH);
+    } else {
 #ifdef Q_OS_WINDOWS
-    const auto path = QDir::home().filePath("86Box VMs");
+        path = QDir::home().filePath(VMM_PATH_WINDOWS);
 #else
-    const auto path = QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)).filePath("Virtual Machines");
+        path = QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)).filePath(VMM_PATH);
 #endif
+    }
+
     strncpy(outbuf, path.toUtf8().constData(), len);
+    path_slash(outbuf);
 }
 
 void

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -875,19 +875,21 @@ plat_init_rom_paths(void)
 void
 plat_get_global_config_dir(char *outbuf, const size_t len)
 {
-    char *prefPath = SDL_GetPrefPath(NULL, "86Box");
-    strncpy(outbuf, prefPath, len);
-    path_slash(outbuf);
-    SDL_free(prefPath);
+    return plat_get_global_data_dir(outbuf, len);
 }
 
 void
 plat_get_global_data_dir(char *outbuf, const size_t len)
 {
-    char *prefPath = SDL_GetPrefPath(NULL, "86Box");
-    strncpy(outbuf, prefPath, len);
+    if (portable_mode) {
+        strncpy(outbuf, exe_path, len);
+    } else {
+        char *prefPath = SDL_GetPrefPath(NULL, "86Box");
+        strncpy(outbuf, prefPath, len);
+        SDL_free(prefPath);
+    }
+
     path_slash(outbuf);
-    SDL_free(prefPath);
 }
 
 void


### PR DESCRIPTION
Summary
=======
This PR implements a portable mode, which can be enabled by having a `86box_global.cfg` file in the same directory as the 86Box executable.

In this mode, 86Box does not retrieve global configuration (including any virtual machines configured in the built-in manager) from `%LOCALAPPDATA%`, `$XDG_CONFIG_HOME`, or equivalent but strictly from the EXE directory.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
