### PR TITLE
Fix conflicting mnemonic

### DIFF
--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -952,7 +952,7 @@ msgid "Internal device"
 msgstr "Dispositivo integrado"
 
 msgid "&File"
-msgstr "&Ficheiro"
+msgstr "F&icheiro"
 
 msgid "&New machine..."
 msgstr "&Nova máquina"


### PR DESCRIPTION
Summary
=======
Fix conflicting mnemonic for pt-PT language in VM manager

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
