### PR TITLE
Fixes missing translations in EDID UI

### DIFF
--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -2962,7 +2962,7 @@ msgid "Export..."
 msgstr ""
 
 msgid "Export EDID"
-msgid ""
+msgstr ""
 
 msgid "EDID file \"%ls\" is too large."
 msgstr ""

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -2955,5 +2955,14 @@ msgstr "&CGA:n komposiittiasetukset..."
 msgid "CGA composite settings"
 msgstr "CGA:n komposiittiasetukset"
 
+msgid "Monitor EDID"
+msgstr "Monitorin EDID"
+
+msgid "Export..."
+msgstr "Viedä..."
+
+msgid "Export EDID"
+msgstr "Vie EDID"
+
 msgid "EDID file \"%ls\" is too large."
 msgstr "EDID-tiedosto \"%ls\" on liian suuri."

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -2955,5 +2955,14 @@ msgstr "Réglages du mode composite &CGA..."
 msgid "CGA composite settings"
 msgstr "Réglages du mode composite CGA"
 
+msgid "Monitor EDID"
+msgstr "Surveiller EDID"
+
+msgid "Export..."
+msgstr "Exporter..."
+
+msgid "Export EDID"
+msgstr "Exporter l'EDID"
+
 msgid "EDID file \"%ls\" is too large."
 msgstr "Le fichier EDID \"%ls\" est trop volumineux."

--- a/src/qt/qt_settingsdisplay.cpp
+++ b/src/qt/qt_settingsdisplay.cpp
@@ -339,7 +339,7 @@ void SettingsDisplay::on_radioButtonCustom_clicked()
 
 void SettingsDisplay::on_pushButtonExportDefault_clicked()
 {
-    auto str = QFileDialog::getSaveFileName(this, tr("Export EDID..."));
+    auto str = QFileDialog::getSaveFileName(this, tr("Export EDID"));
     if (!str.isEmpty()) {
         QFile file(str);
         if (file.open(QFile::WriteOnly)) {


### PR DESCRIPTION
Summary
=======
This PR fixes a broken translatable string in the new EDID UI and adds missing translations to fi-FI and fr-FR (machine translated)

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
