### PR TITLE
Recalculate `svga->fast` on Voodoo 3/Banshee packed Chain4 mode toggles 

### DIFF
--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -330,7 +330,9 @@ svga_out(uint16_t addr, uint8_t val, void *priv)
                 case 4:
                     svga->chain2_write = !(val & 4);
                     svga->chain4       = (svga->chain4 & ~8) | (val & 8);
-                    svga->fast         = (svga->gdcreg[8] == 0xff && !(svga->gdcreg[3] & 0x18) && !svga->gdcreg[1]) && ((svga->chain4 && (svga->packed_chain4 || svga->force_old_addr)) || svga->fb_only) && !(svga->adv_flags & FLAG_ADDR_BY8);
+                    svga->fast         = (svga->gdcreg[8] == 0xff && !(svga->gdcreg[3] & 0x18) && !svga->gdcreg[1]) &&
+                                        ((svga->chain4 && (svga->packed_chain4 || svga->force_old_addr)) || svga->fb_only) &&
+                                        !(svga->adv_flags & FLAG_ADDR_BY8);
                     break;
 
                 default:
@@ -431,7 +433,9 @@ svga_out(uint16_t addr, uint8_t val, void *priv)
                     break;
             }
             svga->gdcreg[svga->gdcaddr & 15] = val;
-            svga->fast                       = (svga->gdcreg[8] == 0xff && !(svga->gdcreg[3] & 0x18) && !svga->gdcreg[1]) && ((svga->chain4 && (svga->packed_chain4 || svga->force_old_addr)) || svga->fb_only);
+            svga->fast                       = (svga->gdcreg[8] == 0xff && !(svga->gdcreg[3] & 0x18) && !svga->gdcreg[1]) &&
+                                               ((svga->chain4 && (svga->packed_chain4 || svga->force_old_addr)) || svga->fb_only) &&
+                                                !(svga->adv_flags & FLAG_ADDR_BY8);;
             if (((svga->gdcaddr & 15) == 5 && (val ^ o) & 0x70) || ((svga->gdcaddr & 15) == 6 && (val ^ o) & 1)) {
                 svga_log("GDCADDR%02x recalc.\n", svga->gdcaddr & 0x0f);
                 svga_recalctimings(svga);

--- a/src/video/vid_voodoo_banshee.c
+++ b/src/video/vid_voodoo_banshee.c
@@ -876,6 +876,9 @@ banshee_ext_outl(uint16_t addr, uint32_t val, void *priv)
             svga->write_bank    = (val & 0x3ff) << 15;
             svga->read_bank     = ((val >> 10) & 0x3ff) << 15;
             svga->packed_chain4 = !!(val & 0x00100000);
+            svga->fast          = (svga->gdcreg[8] == 0xff && !(svga->gdcreg[3] & 0x18) && !svga->gdcreg[1]) &&
+                                  ((svga->chain4 && (svga->packed_chain4 || svga->force_old_addr)) || svga->fb_only) &&
+                                  !(svga->adv_flags & FLAG_ADDR_BY8);;
             break;
 
         case PLL_pllCtrl0:

--- a/src/video/vid_voodoo_banshee.c
+++ b/src/video/vid_voodoo_banshee.c
@@ -3436,16 +3436,6 @@ banshee_init_common(const device_t *info, char *fn, int has_sgram, int type, int
               banshee_overlay_draw);
     banshee->svga.vsync_callback = banshee_vsync_callback;
 
-    /* This is apparently needed for Tie Fighter to work correctly. */
-    banshee->svga.read = svga_read;
-    banshee->svga.readw = NULL;
-    banshee->svga.readl = NULL;
-    banshee->svga.write = svga_write;
-    banshee->svga.writew = NULL;
-    banshee->svga.writel = NULL;
-    mem_mapping_set_handler(&banshee->svga.mapping, svga_read, NULL, NULL,
-                    svga_write, NULL, NULL);
-
     mem_mapping_add(&banshee->linear_mapping, 0, 0, banshee_read_linear,
                     banshee_read_linear_w,
                     banshee_read_linear_l,


### PR DESCRIPTION
Summary
=======
Recalculate `svga->fast` on Voodoo 3/Banshee packed Chain4 mode toggles.

Fixes Star Wars TIE Fighter 256-color screens after switching back from high-res modes.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
