### PR TITLE
Fix minor typos

### DIFF
--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -2593,7 +2593,7 @@ msgid "Generic Text Printer"
 msgstr "汎用テキスト・プリンタ"
 
 msgid "Generic ESC/P 2 Dot-Matrix Printer"
-msgstr "汎用ESC/Pドットマトリクスプリンタ"
+msgstr "汎用ESC/P 2ドットマトリクスプリンタ"
 
 msgid "Generic PostScript Printer"
 msgstr "汎用ポストスクリプトプリンタ"
@@ -2695,7 +2695,7 @@ msgid "Unable to find Dot-Matrix fonts"
 msgstr "ドットマトリクスフォントが見つかりません"
 
 msgid "TrueType fonts in the \"roms/printer/fonts\" directory are required for the emulation of the Generic ESC/P 2 Dot-Matrix Printer."
-msgstr "汎用ESC/Pドットマトリクスプリンタのエミュレーションには、roms/printer/fontsディレクトリ内のTrueTypeフォントが必要です。"
+msgstr "汎用ESC/P 2ドットマトリクスプリンタのエミュレーションには、roms/printer/fontsディレクトリ内のTrueTypeフォントが必要です。"
 
 msgid "Inhibit multimedia keys"
 msgstr "マルチメディアキーを無効にする"

--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -942,7 +942,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>&amp;Square pixels (keep ratio)</string>
+    <string>&amp;Square pixels (Keep ratio)</string>
    </property>
   </action>
   <action name="action_Integer_scale_gl">


### PR DESCRIPTION
Summary
=======
Fixes a minor typo that causes a string to not be translated added by commit 18cdab5
Fixes a missing change from commit 72ecf1d

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
