### PR TITLE
Reflect language and color scheme changes in global config in manager and all its VMs

### DIFF
--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -515,6 +515,10 @@ main_thread_fn()
 
 static std::thread *main_thread;
 
+#ifdef Q_OS_WINDOWS
+WindowsDarkModeFilter* vmm_dark_mode_filter = nullptr;
+#endif
+
 int
 main(int argc, char *argv[])
 {
@@ -657,6 +661,8 @@ main(int argc, char *argv[])
             const auto vmm_main_window = new VMManagerMainWindow();
 #ifdef Q_OS_WINDOWS
             darkModeFilter.get()->setWindow(vmm_main_window);
+            // HACK
+            vmm_dark_mode_filter = darkModeFilter.get();
 #endif
             vmm_main_window->show();
         });
@@ -843,6 +849,7 @@ main(int argc, char *argv[])
         });
         QObject::connect(main_window, &MainWindow::vmmRunningStateChanged, &manager_socket, &VMManagerClientSocket::clientRunningStateChanged);
         QObject::connect(main_window, &MainWindow::vmmConfigurationChanged, &manager_socket, &VMManagerClientSocket::configurationChanged);
+        QObject::connect(main_window, &MainWindow::vmmGlobalConfigurationChanged, &manager_socket, &VMManagerClientSocket::globalConfigurationChanged);
         main_window->installEventFilter(&manager_socket);
 
         manager_socket.sendWinIdMessage(main_window->winId());

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -2244,7 +2244,9 @@ void
 MainWindow::on_actionPreferences_triggered()
 {
     ProgSettings progsettings(this);
-    progsettings.exec();
+    if (progsettings.exec() == QDialog::Accepted) {
+        emit vmmGlobalConfigurationChanged();
+    }
 }
 
 void

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -68,6 +68,7 @@ signals:
 
     void vmmRunningStateChanged(VMManagerProtocol::RunningState state);
     void vmmConfigurationChanged();
+    void vmmGlobalConfigurationChanged();
 public slots:
     void showSettings();
     void hardReset();

--- a/src/qt/qt_progsettings.cpp
+++ b/src/qt/qt_progsettings.cpp
@@ -138,6 +138,7 @@ ProgSettings::accept()
     connect(main_window, &MainWindow::updateStatusBarTip, main_window->status.get(), &MachineStatus::updateTip);
     connect(main_window, &MainWindow::statusBarMessage, main_window->status.get(), &MachineStatus::message, Qt::QueuedConnection);
     mouse_sensitivity = mouseSensitivity;
+    config_save_global();
     QDialog::accept();
 }
 

--- a/src/qt/qt_vmmanager_clientsocket.cpp
+++ b/src/qt/qt_vmmanager_clientsocket.cpp
@@ -23,6 +23,7 @@
 
 extern "C" {
 #include "86box/plat.h"
+#include "86box/config.h"
 }
 
 VMManagerClientSocket::VMManagerClientSocket(QObject* obj) : server_connected(false)
@@ -183,6 +184,15 @@ VMManagerClientSocket::jsonReceived(const QJsonObject &json)
         case VMManagerProtocol::ManagerMessage::RequestStatus:
             qDebug("Status request command received from manager");
             break;
+        case VMManagerProtocol::ManagerMessage::GlobalConfigurationChanged:
+            {
+                config_load_global();
+#ifdef Q_OS_WINDOWS
+                void selectDarkMode();
+                selectDarkMode();
+#endif
+                break;
+            }
         default:
             qDebug("Unknown client message type received:");
             qDebug() << json;
@@ -246,6 +256,12 @@ VMManagerClientSocket::clientRunningStateChanged(VMManagerProtocol::RunningState
     }
     extra_object["status"] = static_cast<int>(state);
     sendMessageWithObject(VMManagerProtocol::ClientMessage::RunningStateChanged, extra_object);
+}
+
+void
+VMManagerClientSocket::globalConfigurationChanged() const
+{
+    sendMessage(VMManagerProtocol::ClientMessage::GlobalConfigurationChanged);
 }
 
 void

--- a/src/qt/qt_vmmanager_clientsocket.hpp
+++ b/src/qt/qt_vmmanager_clientsocket.hpp
@@ -45,6 +45,7 @@ signals:
 public slots:
     void clientRunningStateChanged(VMManagerProtocol::RunningState state) const;
     void configurationChanged() const;
+    void globalConfigurationChanged() const;
 
 private:
     QString server_name;

--- a/src/qt/qt_vmmanager_main.cpp
+++ b/src/qt/qt_vmmanager_main.cpp
@@ -31,9 +31,12 @@
 #include <atomic>
 
 #include "qt_vmmanager_main.hpp"
+#include "qt_vmmanager_mainwindow.hpp"
 #include "ui_qt_vmmanager_main.h"
 #include "qt_vmmanager_model.hpp"
 #include "qt_vmmanager_addmachine.hpp"
+
+extern VMManagerMainWindow* vmm_main_window;
 
 // https://stackoverflow.com/a/36460740
 bool copyPath(QString sourceDir, QString destinationDir, bool overWriteDirectory)
@@ -348,6 +351,10 @@ illegal_chars:
         }
     });
 
+    connect(vm_model, &VMManagerModel::globalConfigurationChanged, this, [this] () {
+        vmm_main_window->updateSettings();
+    });
+
     // Initial default details view
     vm_details = new VMManagerDetails(ui->detailsArea);
     ui->detailsArea->layout()->addWidget(vm_details);
@@ -398,6 +405,12 @@ illegal_chars:
 VMManagerMain::~VMManagerMain() {
     delete ui;
     delete vm_model;
+}
+
+void
+VMManagerMain::updateGlobalSettings()
+{
+    vmm_main_window->updateSettings();
 }
 
 void
@@ -767,6 +780,10 @@ VMManagerMain::onPreferencesUpdated()
     regexSearch = config->getStringValue("regex_search").toInt();
     if (oldRegexSearch != regexSearch) {
         ui->searchBar->clear();
+    }
+
+    if (vm_model) {
+        vm_model->sendGlobalConfigurationChanged();
     }
 }
 

--- a/src/qt/qt_vmmanager_main.hpp
+++ b/src/qt/qt_vmmanager_main.hpp
@@ -70,6 +70,7 @@ public slots:
     void shutdownForceButtonPressed() const;
     void searchSystems(const QString &text) const;
     void newMachineWizard();
+    void updateGlobalSettings();
     void deleteSystem(VMManagerSystem *sysconfig);
     void addNewSystem(const QString &name, const QString &dir, const QString &displayName = QString(), const QString &configFile = {});
 #if __GNUC__ >= 11

--- a/src/qt/qt_vmmanager_mainwindow.hpp
+++ b/src/qt/qt_vmmanager_mainwindow.hpp
@@ -34,6 +34,7 @@ class VMManagerMainWindow final : public QMainWindow
 public:
     explicit VMManagerMainWindow(QWidget *parent = nullptr);
     ~VMManagerMainWindow() override;
+    void updateSettings();
 signals:
     void preferencesUpdated();
     void languageUpdated();

--- a/src/qt/qt_vmmanager_model.cpp
+++ b/src/qt/qt_vmmanager_model.cpp
@@ -23,6 +23,7 @@ VMManagerModel::VMManagerModel() {
     for ( const auto& each_config : machines_vec) {
         machines.append(each_config);
         connect(each_config, &VMManagerSystem::itemDataChanged, this, &VMManagerModel::modelDataChanged);
+        connect(each_config, &VMManagerSystem::globalConfigurationChanged, this, &VMManagerModel::globalConfigurationChanged);
     }
 }
 
@@ -138,6 +139,7 @@ VMManagerModel::addConfigToModel(VMManagerSystem *system_config)
     beginInsertRows(QModelIndex(), this->rowCount(QModelIndex()), this->rowCount(QModelIndex()));
     machines.append(system_config);
     connect(system_config, &VMManagerSystem::itemDataChanged, this, &VMManagerModel::modelDataChanged);
+    connect(system_config, &VMManagerSystem::globalConfigurationChanged, this, &VMManagerModel::globalConfigurationChanged);
     endInsertRows();
 }
 
@@ -175,6 +177,16 @@ VMManagerModel::getProcessStats()
         stats[system->getProcessStatus()] += 1;
     }
     return stats;
+}
+
+void
+VMManagerModel::sendGlobalConfigurationChanged()
+{
+    for (auto& system: machines) {
+        if (system->getProcessStatus() != VMManagerSystem::ProcessStatus::Stopped) {
+            system->sendGlobalConfigurationChanged();
+        }
+    }
 }
 
 int

--- a/src/qt/qt_vmmanager_model.hpp
+++ b/src/qt/qt_vmmanager_model.hpp
@@ -60,8 +60,10 @@ public:
     QMap<VMManagerSystem::ProcessStatus, int> getProcessStats();
     int getActiveMachineCount();
     void refreshConfigs();
+    void sendGlobalConfigurationChanged();
 signals:
     void systemDataChanged();
+    void globalConfigurationChanged();
 
 private:
     QVector<VMManagerSystem *> machines;

--- a/src/qt/qt_vmmanager_preferences.cpp
+++ b/src/qt/qt_vmmanager_preferences.cpp
@@ -24,6 +24,11 @@
 #include "qt_vmmanager_config.hpp"
 #include "ui_qt_vmmanager_preferences.h"
 
+#ifdef Q_OS_WINDOWS
+#include "qt_vmmanager_windarkmodefilter.hpp"
+extern WindowsDarkModeFilter* vmm_dark_mode_filter;
+#endif
+
 extern "C" {
 #include <86box/86box.h>
 #include <86box/config.h>
@@ -66,7 +71,13 @@ VMManagerPreferences(QWidget *parent) : ui(new Ui::VMManagerPreferences)
     const auto useRegexSearch = config->getStringValue("regex_search").toInt();
     ui->regexSearchCheckBox->setChecked(useRegexSearch);
 
+    ui->radioButtonSystem->setChecked(color_scheme == 0);
+    ui->radioButtonLight->setChecked(color_scheme == 1);
+    ui->radioButtonDark->setChecked(color_scheme == 2);
 
+#ifndef Q_OS_WINDOWS
+    ui->groupBoxColorScheme->setHidden(true);
+#endif
 }
 
 VMManagerPreferences::~
@@ -95,6 +106,7 @@ VMManagerPreferences::accept()
 
     strncpy(vmm_path_cfg, QDir::cleanPath(ui->systemDirectory->text()).toUtf8().constData(), sizeof(vmm_path_cfg) - 1);
     lang_id = ui->comboBoxLanguage->currentData().toInt();
+    color_scheme = (ui->radioButtonSystem->isChecked()) ? 0 : (ui->radioButtonLight->isChecked() ? 1 : 2);
     config_save_global();
 
 #if EMU_BUILD_NUM != 0

--- a/src/qt/qt_vmmanager_preferences.ui
+++ b/src/qt/qt_vmmanager_preferences.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>475</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -104,9 +104,39 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBoxColorScheme">
+     <property name="title">
+      <string>Color scheme</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QRadioButton" name="radioButtonSystem">
+        <property name="text">
+         <string>System</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radioButtonLight">
+        <property name="text">
+         <string>Light</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="radioButtonDark">
+        <property name="text">
+         <string>Dark</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -119,10 +149,10 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/qt/qt_vmmanager_protocol.cpp
+++ b/src/qt/qt_vmmanager_protocol.cpp
@@ -95,6 +95,8 @@ VMManagerProtocol::getClientMessageType(const QJsonObject &json_document)
         return VMManagerProtocol::ClientMessage::ConfigurationChanged;
     } else if (message_type == "WinIdMessage") {
         return VMManagerProtocol::ClientMessage::WinIdMessage;
+    } else if (message_type == "GlobalConfigurationChanged") {
+        return VMManagerProtocol::ClientMessage::GlobalConfigurationChanged;
     }
     return VMManagerProtocol::ClientMessage::UnknownMessage;
 }
@@ -119,6 +121,8 @@ VMManagerProtocol::getManagerMessageType(const QJsonObject &json_document)
         return VMManagerProtocol::ManagerMessage::RequestShutdown;
     } if (message_type == "ForceShutdown") {
         return VMManagerProtocol::ManagerMessage::ForceShutdown;
+    } if (message_type == "GlobalConfigurationChanged") {
+        return VMManagerProtocol::ManagerMessage::GlobalConfigurationChanged;
     }
     return VMManagerProtocol::ManagerMessage::UnknownMessage;
 }

--- a/src/qt/qt_vmmanager_protocol.hpp
+++ b/src/qt/qt_vmmanager_protocol.hpp
@@ -43,6 +43,7 @@ public:
         ResetVM,
         RequestShutdown,
         ForceShutdown,
+        GlobalConfigurationChanged,
         UnknownMessage,
     };
 
@@ -56,6 +57,7 @@ public:
         RunningStateChanged,
         ConfigurationChanged,
         WinIdMessage,
+        GlobalConfigurationChanged,
         UnknownMessage,
     };
     Q_ENUM(ClientMessage);

--- a/src/qt/qt_vmmanager_serversocket.cpp
+++ b/src/qt/qt_vmmanager_serversocket.cpp
@@ -189,6 +189,10 @@ VMManagerServerSocket::jsonReceived(const QJsonObject &json)
             qDebug("Configuration change received from client");
             emit configurationChanged();
             break;
+        case VMManagerProtocol::ClientMessage::GlobalConfigurationChanged:
+            qDebug("Global configuration change received from client");
+            emit globalConfigurationChanged();
+            break;
         default:
             qDebug("Unknown client message type received:");
             qDebug() << json;

--- a/src/qt/qt_vmmanager_serversocket.hpp
+++ b/src/qt/qt_vmmanager_serversocket.hpp
@@ -76,6 +76,7 @@ signals:
     void windowStatusChanged(int status);
     void runningStatusChanged(VMManagerProtocol::RunningState state);
     void configurationChanged();
+    void globalConfigurationChanged();
     void winIdReceived(WId id);
 
 

--- a/src/qt/qt_vmmanager_system.cpp
+++ b/src/qt/qt_vmmanager_system.cpp
@@ -1081,6 +1081,7 @@ VMManagerSystem::startServer() {
         connect(socket_server, &VMManagerServerSocket::windowStatusChanged, this, &VMManagerSystem::windowStatusChangeReceived);
         connect(socket_server, &VMManagerServerSocket::runningStatusChanged, this, &VMManagerSystem::runningStatusChangeReceived);
         connect(socket_server, &VMManagerServerSocket::configurationChanged, this, &VMManagerSystem::configurationChangeReceived);
+        connect(socket_server, &VMManagerServerSocket::globalConfigurationChanged, this, &VMManagerSystem::globalConfigurationChanged);
         connect(socket_server, &VMManagerServerSocket::winIdReceived, this, [this] (WId id) { this->id = id; });
         return true;
     } else {
@@ -1122,6 +1123,12 @@ QString
 VMManagerSystem::getDisplayValue(Display::Name key)
 {
     return (display_table.contains(key)) ? display_table[key] : "";
+}
+
+void
+VMManagerSystem::sendGlobalConfigurationChanged()
+{
+    socket_server->serverSendMessage(VMManagerProtocol::ManagerMessage::GlobalConfigurationChanged);
 }
 
 void

--- a/src/qt/qt_vmmanager_system.hpp
+++ b/src/qt/qt_vmmanager_system.hpp
@@ -129,6 +129,7 @@ public slots:
     void shutdownForceButtonPressed();
     void cadButtonPressed();
     void reloadConfig();
+    void sendGlobalConfigurationChanged();
 public:
     QDateTime timestamp();
     void setIcon(const QString &newIcon);
@@ -157,6 +158,7 @@ signals:
     void itemDataChanged();
     void clientProcessStatusChanged();
     void configurationChanged(const QString &uuid);
+    void globalConfigurationChanged();
 
 private:
     void loadSettings();

--- a/src/qt/qt_vmmanager_windarkmodefilter.cpp
+++ b/src/qt/qt_vmmanager_windarkmodefilter.cpp
@@ -39,6 +39,48 @@
 static bool NewDarkMode = FALSE;
 
 void
+WindowsDarkModeFilter::reselectDarkMode()
+{
+    bool OldDarkMode = NewDarkMode;
+
+    if (!util::isWindowsLightTheme()) {
+        QFile f(":qdarkstyle/dark/darkstyle.qss");
+
+        if (!f.exists())
+            printf("Unable to set stylesheet, file not found\n");
+        else {
+            f.open(QFile::ReadOnly | QFile::Text);
+            QTextStream ts(&f);
+            qApp->setStyleSheet(ts.readAll());
+        }
+        QPalette palette(qApp->palette());
+        palette.setColor(QPalette::Link, Qt::white);
+        palette.setColor(QPalette::LinkVisited, Qt::lightGray);
+        qApp->setPalette(palette);
+        window->resize(window->size());
+
+        NewDarkMode = TRUE;
+    } else {
+        qApp->setStyleSheet("");
+        QPalette palette(qApp->palette());
+        palette.setColor(QPalette::Link, Qt::blue);
+        palette.setColor(QPalette::LinkVisited, Qt::magenta);
+        qApp->setPalette(palette);
+        window->resize(window->size());
+        NewDarkMode = FALSE;
+    }
+    window->updateDarkMode();
+
+    if (NewDarkMode != OldDarkMode)  QTimer::singleShot(1000, [this] () {
+            BOOL DarkMode = NewDarkMode;
+            DwmSetWindowAttribute((HWND) window->winId(),
+                                  DWMWA_USE_IMMERSIVE_DARK_MODE,
+                                  (LPCVOID) &DarkMode,
+                                  sizeof(DarkMode));
+        });
+}
+
+void
 WindowsDarkModeFilter::setWindow(VMManagerMainWindow *window)
 {
     this->window = window;
@@ -54,44 +96,7 @@ WindowsDarkModeFilter::nativeEventFilter(const QByteArray &eventType, void *mess
             if ((((void *) msg->lParam) != nullptr) &&
                 (wcscmp(L"ImmersiveColorSet", (wchar_t*)msg->lParam) == 0) &&
                 color_scheme == 0) {
-
-                bool OldDarkMode = NewDarkMode;
-
-                if (!util::isWindowsLightTheme()) {
-                    QFile f(":qdarkstyle/dark/darkstyle.qss");
-
-                    if (!f.exists())
-                        printf("Unable to set stylesheet, file not found\n");
-                    else {
-                        f.open(QFile::ReadOnly | QFile::Text);
-                        QTextStream ts(&f);
-                        qApp->setStyleSheet(ts.readAll());
-                    }
-                    QPalette palette(qApp->palette());
-                    palette.setColor(QPalette::Link, Qt::white);
-                    palette.setColor(QPalette::LinkVisited, Qt::lightGray);
-                    qApp->setPalette(palette);
-                    window->resize(window->size());
-
-                    NewDarkMode = TRUE;
-                } else {
-                    qApp->setStyleSheet("");
-                    QPalette palette(qApp->palette());
-                    palette.setColor(QPalette::Link, Qt::blue);
-                    palette.setColor(QPalette::LinkVisited, Qt::magenta);
-                    qApp->setPalette(palette);
-                    window->resize(window->size());
-                    NewDarkMode = FALSE;
-                }
-                window->updateDarkMode();
-
-                if (NewDarkMode != OldDarkMode)  QTimer::singleShot(1000, [this] () {
-                    BOOL DarkMode = NewDarkMode;
-                    DwmSetWindowAttribute((HWND) window->winId(),
-                                          DWMWA_USE_IMMERSIVE_DARK_MODE,
-                                          (LPCVOID) &DarkMode,
-                                          sizeof(DarkMode));
-                });
+                reselectDarkMode();
             }
         }
     }

--- a/src/qt/qt_vmmanager_windarkmodefilter.hpp
+++ b/src/qt/qt_vmmanager_windarkmodefilter.hpp
@@ -39,6 +39,7 @@ public:
     WindowsDarkModeFilter() = default;
     void setWindow(VMManagerMainWindow *window);
     bool nativeEventFilter(const QByteArray &eventType, void *message, result_t *result) override;
+    void reselectDarkMode();
 
 private:
     VMManagerMainWindow *window;


### PR DESCRIPTION
Summary
=======
Reflect language and color scheme changes in global config in manager and all its VMs.


Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
