### PR TITLE
Fix building on MSYS2 with QT6

### DIFF
--- a/src/qt/qt_mediahistorymanager.cpp
+++ b/src/qt/qt_mediahistorymanager.cpp
@@ -381,7 +381,7 @@ MediaHistoryManager::removeMissingImages(device_index_list_t &device_history)
 
 #ifdef Q_OS_WINDOWS
         if (new_fi.filePath().left(8) == "ioctl://")
-            file_exists = (GetDriveType(new_fi.filePath().right(2).toUtf8().data()) == DRIVE_CDROM);
+            file_exists = (GetDriveTypeA(new_fi.filePath().right(2).toUtf8().data()) == DRIVE_CDROM);
 #endif
 
         if (!file_exists) {

--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -31,7 +31,6 @@
 extern "C" {
 #ifdef Q_OS_WINDOWS
 #define BITMAP WINDOWS_BITMAP
-#undef UNICODE
 #include <windows.h>
 #include <windowsx.h>
 #undef BITMAP
@@ -176,7 +175,7 @@ MediaMenu::refresh(QMenu *parentMenu)
            it's a CDROM */
         for (const auto &letter : driveLetters) {
             auto drive = QString("%1:\\").arg(letter);
-            if (GetDriveType(drive.toUtf8().constData()) == DRIVE_CDROM)
+            if (GetDriveTypeA(drive.toUtf8().constData()) == DRIVE_CDROM)
                 menu->addAction(QIcon(":/settings/qt/icons/cdrom_host.ico"), tr("&Host CD/DVD Drive (%1:)").arg(letter), [this, i, letter] { cdromMount(i, 2, QString(R"(\\.\%1:)").arg(letter)); })->setCheckable(false);
         }
         menu->addSeparator();

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -62,6 +62,10 @@
 #    include <CoreGraphics/CoreGraphics.h>
 #endif
 
+#ifdef Q_OS_WINDOWS
+#    include <windows.h>
+#endif
+
 extern "C" {
 #include <86box/86box.h>
 #include <86box/config.h>


### PR DESCRIPTION
Summary
=======
Buildfix for MSYS2 with USE_QT6=ON.
Use `GetDriveTypeA` specifically to workaround type mismatch (it is a drive letter in pure ASCII anyway) instead of `#undef UNICODE` globally. 

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
