### PR TITLE
More machine and SIO fixes

### DIFF
--- a/src/machine/m_at_socket3_pci.c
+++ b/src/machine/m_at_socket3_pci.c
@@ -277,7 +277,7 @@ machine_at_ms4145_init(const machine_t *model)
     pci_register_slot(0x06, PCI_CARD_NORMAL,      4, 1, 2, 3);
 
     device_add(&ali1489_device);
-    device_add_params(&w837x7_device, (void *) (W83787F | W837X7_KEY_89));
+    device_add_params(&w837x7_device, (void *) (W83787F | W837X7_KEY_88));
 
     device_add_params(machine_get_kbc_device(machine), (void *) model->kbc_params);
 

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -9371,7 +9371,7 @@ const machine_t machines[] = {
             .max_multi = 0
         },
         .bus_flags = MACHINE_PCI,
-        .flags = MACHINE_IDE_DUAL | MACHINE_APM,
+        .flags = MACHINE_PS2_KBC | MACHINE_IDE_DUAL | MACHINE_APM,
         .ram = {
             .min = 1024,
             .max = 65536,

--- a/src/sio/sio_um866x.c
+++ b/src/sio/sio_um866x.c
@@ -108,25 +108,27 @@ um866x_lpt_handler(um866x_t *dev)
     int enabled = (dev->regs[0] & 0x08);
 
     lpt_port_remove(dev->lpt);
-    switch(dev->regs[1] & 0xc0) {
-        case 0x00:
-            enabled = 0;
-            break;
-        case 0x40:
-            lpt_set_epp(dev->lpt, 1);
-            lpt_set_ecp(dev->lpt, 0);
-            lpt_set_ext(dev->lpt, 0);
-            break;
-        case 0x80:
-            lpt_set_epp(dev->lpt, 0);
-            lpt_set_ecp(dev->lpt, 0);
-            lpt_set_ext(dev->lpt, 1);
-            break;
-        case 0xc0:
-            lpt_set_epp(dev->lpt, 0);
-            lpt_set_ecp(dev->lpt, 1);
-            lpt_set_ext(dev->lpt, 0);
-            break;
+    if (dev->max_reg != 0x00) {
+        switch(dev->regs[1] & 0xc0) {
+            case 0x00:
+                enabled = 0;
+                break;
+            case 0x40:
+                lpt_set_epp(dev->lpt, 1);
+                lpt_set_ecp(dev->lpt, 0);
+                lpt_set_ext(dev->lpt, 0);
+                break;
+            case 0x80:
+                lpt_set_epp(dev->lpt, 0);
+                lpt_set_ecp(dev->lpt, 0);
+                lpt_set_ext(dev->lpt, 1);
+                break;
+            case 0xc0:
+                lpt_set_epp(dev->lpt, 0);
+                lpt_set_ecp(dev->lpt, 1);
+                lpt_set_ext(dev->lpt, 0);
+                break;
+        }
     }
     if (enabled) {
         switch ((dev->regs[1] >> 3) & 0x01) {

--- a/src/sio/sio_w837x7.c
+++ b/src/sio/sio_w837x7.c
@@ -390,7 +390,7 @@ w837x7_reset(w837x7_t *dev)
 
     if (dev->has_ide == 0x02)
         dev->regs[0x00] = 0x90;
-    else if (dev->has_ide == 0x01)
+    else
         dev->regs[0x00] = 0xd0;
 
     if (dev->ide_start)


### PR DESCRIPTION
Summary
=======
Fixes for the following:
- Winbond W837x7 Super I/O: Set register 00h to D0h on non-IDE configurations as well like the old code from before the rewrite did, fixes the MSI MS-4144, MS-4145 and MS-5119 reporting a FDC failure during POST
- UMC UM866x Super I/O: Don't check register C1h in the LPT handler if the register doesn't exist, fixes missing parallel port on the two machines with a UM82c862F Super I/O (Packard Bell Legend 300SX and CAF C747)
- MSI MS-4145: Correct the W837x7 key parameter and give the machine a PS/2 KBC to fix keyboard input in Windows for Workgroups 3.11

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
