### PR TITLE
Add AST Advantage! 8100P.

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -910,6 +910,7 @@ extern int             machine_at_tek932_init(const machine_t *);
 /* i430FX */
 extern int             machine_at_acerv30_init(const machine_t *);
 extern int             machine_at_apollo_init(const machine_t *);
+extern int             machine_at_advantage8100p_init(const machine_t *);
 extern int             machine_at_optiplexgxl_init(const machine_t *);
 extern int             machine_at_pt2000_init(const machine_t *);
 extern int             machine_at_zappa_init(const machine_t *);

--- a/src/machine/m_at_socket5.c
+++ b/src/machine/m_at_socket5.c
@@ -322,6 +322,35 @@ machine_at_apollo_init(const machine_t *model)
 }
 
 int
+machine_at_advantage8100p_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear_combined("roms/machines/advantage8100p/1006bs0_.bio",
+                                    "roms/machines/advantage8100p/1006bs0_.bi1",
+                                    0x20000, 128);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_common_init_ex(model, 2);
+    machine_at_zappa_gpio_init();
+
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x0D, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x0E, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x0F, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 0);
+    device_add(&i430fx_device);
+    device_add(&piix_device);
+    device_add_params(&pc87306_device, (void *) PCX730X_AMI);
+    device_add(&intel_flash_bxt_ami_device);
+
+    return ret;
+}
+
+int
 machine_at_optiplexgxl_init(const machine_t *model)
 {
     int ret;

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -12165,6 +12165,50 @@ const machine_t machines[] = {
         .snd_device = NULL,
         .net_device = NULL
     },
+    /* The AST Advantage! 8100P is based on Intel MN430FX. */
+    {
+        .name = "[i430FX] AST Advantage! 8100P",
+        .internal_name = "advantage8100p",
+        .type = MACHINE_TYPE_SOCKET5,
+        .chipset = MACHINE_CHIPSET_INTEL_430FX,
+        .init = machine_at_advantage8100p_init,
+        .p1_handler = machine_generic_p1_handler,
+        .gpio_handler = NULL,
+        .available_flag = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu = {
+            .package = CPU_PKG_SOCKET5_7,
+            .block = CPU_BLOCK(CPU_K5, CPU_5K86, CPU_Cx6x86),
+            .min_bus = 50000000,
+            .max_bus = 66666667,
+            .min_voltage = 3380,
+            .max_voltage = 3520,
+            .min_multi = 1.5,
+            .max_multi = 2.0
+        },
+        .bus_flags = MACHINE_PS2_PCI,
+        .flags = MACHINE_IDE_DUAL | MACHINE_APM,
+        .ram = {
+            .min = 8192,
+            .max = 131072,
+            .step = 8192
+        },
+        .nvrmask = 255,
+        .jumpered_ecp_dma = MACHINE_DMA_DISABLED | MACHINE_DMA_1 | MACHINE_DMA_3,
+        .default_jumpered_ecp_dma = 3,
+        .kbc_device = NULL,
+        .kbc_params = 0x00000000,
+        .kbc_p1 = 0x000044f0,
+        .gpio = 0xffffffff,
+        .gpio_acpi = 0xffffffff,
+        .device = NULL,
+        .kbd_device = NULL,
+        .fdc_device = NULL,
+        .sio_device = NULL,
+        .vid_device = NULL,
+        .snd_device = NULL,
+        .net_device = NULL
+    },
     /* Has Dell KBC firmware. */
     {
         .name = "[i430FX] Dell OptiPlex GXL/GXM",


### PR DESCRIPTION
Summary
=======
This Pull Request adds the AST Advantage! 8100P ROM.
It was based on Intel Advanced/MN (Morrison32).

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [X] This pull request requires changes to the ROM set
  * [X] I have opened a roms pull request - https://github.com/86Box/roms/pull/375

References
==========
https://theretroweb.com/motherboards/s/intel-advanced-mn-morrison32