### PR TITLE
Adjust `scsi_common_t` structure definition to match the rest

### DIFF
--- a/src/include/86box/scsi_device.h
+++ b/src/include/86box/scsi_device.h
@@ -388,6 +388,7 @@ typedef struct scsi_common_s {
     void *             log;
 
     uint8_t *          temp_buffer;
+    size_t             temp_buffer_sz;
     /*
        This is atapi_cdb in ATAPI-supporting devices,
        and pad in SCSI-only devices.


### PR DESCRIPTION
Summary
=======
Adjust `scsi_common_t` structure definition to match the rest

Checklist
=========
* [X] Closes #6131
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
