### PR TITLE
Add Two Baud Rates

### DIFF
--- a/src/network/net_modem.c
+++ b/src/network/net_modem.c
@@ -1566,6 +1566,8 @@ static const device_config_t modem_config[] = {
             { .description =  "57600", .value =  57600 },
             { .description =  "56000", .value =  56000 },
             { .description =  "38400", .value =  38400 },
+            { .description =  "33600", .value =  33600 },
+            { .description =  "28800", .value =  28800 },
             { .description =  "19200", .value =  19200 },
             { .description =  "14400", .value =  14400 },
             { .description =   "9600", .value =   9600 },


### PR DESCRIPTION
Summary
=======
This adds two forgotten baud rates (28.8k and 33.6k), according to Windows 98's modem setup.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
