### PR TITLE
Last minute changes for the IDE hdd (September 12th, 2025)

### DIFF
--- a/src/disk/hdc_ide.c
+++ b/src/disk/hdc_ide.c
@@ -812,7 +812,7 @@ ide_set_signature(ide_t *ide)
     ide->tf->sector   = 1;
     ide->tf->head     = 0;
     ide->tf->secount  = 1;
-    ide->tf->cylinder = ide_signatures[ide->type & ~IDE_SHADOW];
+    ide->tf->cylinder = (ide->type == IDE_ATAPI_SHADOW) ? 0x0000 : ide_signatures[ide->type & ~IDE_SHADOW];
 
     if (ide->type == IDE_HDD)
         ide->drive = 0;
@@ -1581,7 +1581,7 @@ ide_reset_registers(ide_t *ide)
     ide->tf->atastat  = DRDY_STAT | DSC_STAT;
     ide->tf->error    = 1;
     ide->tf->secount  = 1;
-    ide->tf->cylinder = ide_signatures[ide->type & ~IDE_SHADOW];
+    ide->tf->cylinder = (ide->type == IDE_ATAPI_SHADOW) ? 0x0000 : ide_signatures[ide->type & ~IDE_SHADOW];
     ide->tf->sector   = 1;
     ide->tf->head     = 0;
 


### PR DESCRIPTION
Summary
=======
When a secondary slave is shadowed by an ATAPI secondary master, make sure the signature (and on reset too) doesn't make it "recognized" (0xeb14) in the cylinder register (as in, 0x0000'ing it)


Checklist
=========
* [X] Closes #6153
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
