### PR TITLE
Last-minute manager improvements

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -230,6 +230,7 @@ int      other_scsi_present = 0;                                  /* SCSI contro
 int      is_pcjr = 0;                                             /* The current machine is PCjr. */
 int      portable_mode = 0;                                       /* We are running in portable mode
                                                                      (global dirs = exe path) */
+int      global_cfg_overridden = 0;                               /* Global config file was overriden on command line */
 
 int      monitor_edid = 0;                                        /* (C) Which EDID to use. 0=default, 1=custom. */
 char     monitor_edid_path[1024] = { 0 };                         /* (C) Path to custom EDID */
@@ -852,6 +853,7 @@ usage:
             if ((c + 1) == argc || plat_dir_check(argv[c + 1]))
                 goto usage;
 
+            global_cfg_overridden = 1;
             global = argv[++c];
         } else if (!strcasecmp(argv[c], "--image") || !strcasecmp(argv[c], "-I")) {
             if ((c + 1) == argc)

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -202,6 +202,7 @@ extern char vmm_path[1024];        /* VM Manager path to scan */
 extern int  start_vmm;             /* the current execution will start the manager */
 extern int  portable_mode;         /* we are running in portable mode 
                                       (global dirs = exe path) */
+extern int global_cfg_overridden;  /* global config file was overriden on command line */
 
 extern int  monitor_edid;                   /* (C) Which EDID to use. 0=default, 1=custom. */
 extern char monitor_edid_path[1024];        /* (C) Path to custom EDID */

--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -51,6 +51,9 @@ msgstr ""
 msgid "R&emember size && position"
 msgstr ""
 
+msgid "Remember size && position"
+msgstr ""
+
 msgid "Re&nderer"
 msgstr ""
 

--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -15,7 +15,7 @@ msgstr ""
 msgid "&Right CTRL is left ALT"
 msgstr ""
 
-msgid "&Hard Reset..."
+msgid "&Hard reset"
 msgstr ""
 
 msgid "&Ctrl+Alt+Del"
@@ -1075,6 +1075,12 @@ msgid "Force shutdown"
 msgstr ""
 
 msgid "Start"
+msgstr ""
+
+msgid "&Force shutdown"
+msgstr ""
+
+msgid "&Start"
 msgstr ""
 
 msgid "Not running"

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -15,7 +15,7 @@ msgstr "&Klávesnice vyžaduje záběr myši"
 msgid "&Right CTRL is left ALT"
 msgstr "&Pravý Ctrl je levý Alt"
 
-msgid "&Hard Reset..."
+msgid "&Hard reset"
 msgstr "&Resetovat"
 
 msgid "&Ctrl+Alt+Del"
@@ -1076,6 +1076,12 @@ msgstr "Vynutit vypnutí"
 
 msgid "Start"
 msgstr "Spustit"
+
+msgid "&Force shutdown"
+msgstr "&Vynutit vypnutí"
+
+msgid "&Start"
+msgstr "&Spustit"
 
 msgid "Not running"
 msgstr "Neběží"

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -51,6 +51,9 @@ msgstr "&Měnitelná velikost okna"
 msgid "R&emember size && position"
 msgstr "&Pamatovat velikost a pozici"
 
+msgid "Remember size && position"
+msgstr "Pamatovat velikost a pozici"
+
 msgid "Re&nderer"
 msgstr "&Renderer"
 

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -15,8 +15,8 @@ msgstr "&Tastatur benötigt das Einfangen des Mauszeigers"
 msgid "&Right CTRL is left ALT"
 msgstr "&Die rechte Strg-Taste ist die linke Alt-Taste"
 
-msgid "&Hard Reset..."
-msgstr "&Kaltstart..."
+msgid "&Hard reset"
+msgstr "&Kaltstart"
 
 msgid "&Ctrl+Alt+Del"
 msgstr "&Strg+Alt+Entf"
@@ -1076,6 +1076,12 @@ msgstr "Abschaltung erzwingen"
 
 msgid "Start"
 msgstr "Einschalten"
+
+msgid "&Force shutdown"
+msgstr "&Abschaltung erzwingen"
+
+msgid "&Start"
+msgstr "&Einschalten"
 
 msgid "Not running"
 msgstr "Läuft nicht"

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -51,6 +51,9 @@ msgstr "G&rößenverstellbares Fenster"
 msgid "R&emember size && position"
 msgstr "Größe && &Position merken"
 
+msgid "Remember size && position"
+msgstr "Größe && Position merken"
+
 msgid "Re&nderer"
 msgstr "Re&nderer"
 

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -51,6 +51,9 @@ msgstr "Ven&tana redimensionable"
 msgid "R&emember size && position"
 msgstr "&Recordar tamaño y posición"
 
+msgid "Remember size && position"
+msgstr "Recordar tamaño y posición"
+
 msgid "Re&nderer"
 msgstr "Re&nderizador"
 

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -15,8 +15,8 @@ msgstr "&Teclado requiere captura"
 msgid "&Right CTRL is left ALT"
 msgstr "CTRL &derecho es ALT izquierdo"
 
-msgid "&Hard Reset..."
-msgstr "&Hard Reset..."
+msgid "&Hard reset"
+msgstr "&Hard reset"
 
 msgid "&Ctrl+Alt+Del"
 msgstr "&Ctrl+Alt+Del"
@@ -1076,6 +1076,12 @@ msgstr "Apagqar forzadamente"
 
 msgid "Start"
 msgstr "Iniciar"
+
+msgid "&Force shutdown"
+msgstr "&Apagqar forzadamente"
+
+msgid "&Start"
+msgstr "&Iniciar"
 
 msgid "Not running"
 msgstr "No en ejecución"

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -15,8 +15,8 @@ msgstr "&Vaadi näppäimistön kaappaus"
 msgid "&Right CTRL is left ALT"
 msgstr "&Oikea CTRL on vasen ALT"
 
-msgid "&Hard Reset..."
-msgstr "&Uudelleenkäynnistys (kylmä)..."
+msgid "&Hard reset"
+msgstr "&Uudelleenkäynnistys (kylmä)"
 
 msgid "&Ctrl+Alt+Del"
 msgstr "&Ctrl+Alt+Del"
@@ -1076,6 +1076,12 @@ msgstr "Pakota sammutus"
 
 msgid "Start"
 msgstr "Käynnistä"
+
+msgid "&Force shutdown"
+msgstr "&Pakota sammutus"
+
+msgid "&Start"
+msgstr "&Käynnistä"
 
 msgid "Not running"
 msgstr "Ei käynnissä"

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -51,6 +51,9 @@ msgstr "&Salli koon muuttaminen"
 msgid "R&emember size && position"
 msgstr "&Muista koko ja sijainti"
 
+msgid "Remember size && position"
+msgstr "Muista koko ja sijainti"
+
 msgid "Re&nderer"
 msgstr "&Renderöijä"
 

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -51,6 +51,9 @@ msgstr "Fenêtre &redimensionnable"
 msgid "R&emember size && position"
 msgstr "S&auvegarder taille && position"
 
+msgid "Remember size && position"
+msgstr "Sauvegarder taille && position"
+
 msgid "Re&nderer"
 msgstr "Moteur de re&ndu vidéo"
 

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -15,8 +15,8 @@ msgstr "C&apturer le clavier"
 msgid "&Right CTRL is left ALT"
 msgstr "CTRL &Droite devient ALT Gauche"
 
-msgid "&Hard Reset..."
-msgstr "&Hard Reset..."
+msgid "&Hard reset"
+msgstr "&Hard reset"
 
 msgid "&Ctrl+Alt+Del"
 msgstr "&Ctrl+Alt+Suppr"
@@ -1076,6 +1076,12 @@ msgstr "Arrêt forcé"
 
 msgid "Start"
 msgstr "Démarrer"
+
+msgid "&Force shutdown"
+msgstr "&Arrêt forcé"
+
+msgid "&Start"
+msgstr "&Démarrer"
 
 msgid "Not running"
 msgstr "Inactive"

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -15,8 +15,8 @@ msgstr "&Tipkovnica zahtijeva hvatanje miša"
 msgid "&Right CTRL is left ALT"
 msgstr "&Desni CTRL je lijevi ALT"
 
-msgid "&Hard Reset..."
-msgstr "&Ponovno pokretanje..."
+msgid "&Hard reset"
+msgstr "&Ponovno pokretanje"
 
 msgid "&Ctrl+Alt+Del"
 msgstr "&Ctrl+Alt+Del"
@@ -1076,6 +1076,12 @@ msgstr "Prisilno isključi"
 
 msgid "Start"
 msgstr "Pokreni"
+
+msgid "&Force shutdown"
+msgstr "Prisilno &isključi"
+
+msgid "&Start"
+msgstr "&Pokreni"
 
 msgid "Not running"
 msgstr "Se ne pokreće"

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -51,6 +51,9 @@ msgstr "&Prozor s promjenjivim veličinama"
 msgid "R&emember size && position"
 msgstr "&Zapamtite veličinu i položaj"
 
+msgid "Remember size && position"
+msgstr "Zapamtite veličinu i položaj"
+
 msgid "Re&nderer"
 msgstr "&Renderer"
 

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -15,8 +15,8 @@ msgstr "&Tastiera richiede la cattura"
 msgid "&Right CTRL is left ALT"
 msgstr "CTRL &destro è ALT sinistro"
 
-msgid "&Hard Reset..."
-msgstr "&Riavvia..."
+msgid "&Hard reset"
+msgstr "&Riavvia"
 
 msgid "&Ctrl+Alt+Del"
 msgstr "&Ctrl+Alt+Canc"
@@ -1076,6 +1076,12 @@ msgstr "Forza arresto"
 
 msgid "Start"
 msgstr "Avvia"
+
+msgid "&Force shutdown"
+msgstr "&Forza arresto"
+
+msgid "&Start"
+msgstr "&Avvia"
 
 msgid "Not running"
 msgstr "Inattivo"

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -51,6 +51,9 @@ msgstr "&Finestra ridimensionabile"
 msgid "R&emember size && position"
 msgstr "R&icorda dimensioni e posizione"
 
+msgid "Remember size && position"
+msgstr "Ricorda dimensioni e posizione"
+
 msgid "Re&nderer"
 msgstr "Re&nderizzatore"
 

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -15,8 +15,8 @@ msgstr "キーボードはキャプチャが必要(&K)"
 msgid "&Right CTRL is left ALT"
 msgstr "右CTRLを左ALTへ変換(&R)"
 
-msgid "&Hard Reset..."
-msgstr "ハード リセット(&H)..."
+msgid "&Hard reset"
+msgstr "ハード リセット(&H)"
 
 msgid "&Ctrl+Alt+Del"
 msgstr "Ctrl+Alt+Del(&C)"
@@ -1076,6 +1076,12 @@ msgstr "強制終了"
 
 msgid "Start"
 msgstr "スタート"
+
+msgid "&Force shutdown"
+msgstr "強制終了(&F)"
+
+msgid "&Start"
+msgstr "スタート(&S)"
 
 msgid "Not running"
 msgstr "停止した"

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -51,6 +51,9 @@ msgstr "ウィンドウのサイズを変更可能(&R)"
 msgid "R&emember size && position"
 msgstr "ウィンドウのサイズと位置を保存(&E)"
 
+msgid "Remember size && position"
+msgstr "ウィンドウのサイズと位置を保存"
+
 msgid "Re&nderer"
 msgstr "レンダラー(&N)"
 

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -51,6 +51,9 @@ msgstr "창 크기 조절 가능하게 하기(&R)"
 msgid "R&emember size && position"
 msgstr "창 크기와 위치를 기억하기(&E)"
 
+msgid "Remember size && position"
+msgstr "창 크기와 위치를 기억하기"
+
 msgid "Re&nderer"
 msgstr "렌더러(&N)"
 

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -15,8 +15,8 @@ msgstr "키보드는 캡쳐가 필요함(&K)"
 msgid "&Right CTRL is left ALT"
 msgstr "우측CTRL로 좌측ALT 입력(&R)"
 
-msgid "&Hard Reset..."
-msgstr "재시작(&H)..."
+msgid "&Hard reset"
+msgstr "재시작(&H)"
 
 msgid "&Ctrl+Alt+Del"
 msgstr "Ctrl+Alt+Del(&C)"
@@ -1076,6 +1076,12 @@ msgstr "강제 종료"
 
 msgid "Start"
 msgstr "시작"
+
+msgid "&Force shutdown"
+msgstr "강제 종료(&F)"
+
+msgid "&Start"
+msgstr "시작(&S)"
 
 msgid "Not running"
 msgstr "실행 중이 아닙니다"

--- a/src/qt/languages/nb-NO.po
+++ b/src/qt/languages/nb-NO.po
@@ -51,6 +51,9 @@ msgstr "&Justerbart vindu"
 msgid "R&emember size && position"
 msgstr "H&usk størrelse &og plassering"
 
+msgid "Remember size && position"
+msgstr "Husk størrelse og plassering"
+
 msgid "Re&nderer"
 msgstr "Re&nderer"
 

--- a/src/qt/languages/nb-NO.po
+++ b/src/qt/languages/nb-NO.po
@@ -15,8 +15,8 @@ msgstr "&Tastatur krever opptak"
 msgid "&Right CTRL is left ALT"
 msgstr "&Høyre CTRL er venstre ALT"
 
-msgid "&Hard Reset..."
-msgstr "&Hard tilbakestilling..."
+msgid "&Hard reset"
+msgstr "&Hard tilbakestilling"
 
 msgid "&Ctrl+Alt+Del"
 msgstr "&Ctrl+Alt+Del"
@@ -1076,6 +1076,12 @@ msgstr "Tvangsavslutt"
 
 msgid "Start"
 msgstr "Start"
+
+msgid "&Force shutdown"
+msgstr "&Tvangsavslutt"
+
+msgid "&Start"
+msgstr "&Start"
 
 msgid "Not running"
 msgstr "Ikke kjørende"

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -51,6 +51,9 @@ msgstr "&Venster met aanpasbare grootte"
 msgid "R&emember size && position"
 msgstr "&Onthoud grootte && positie"
 
+msgid "Remember size && position"
+msgstr "Onthoud grootte && positie"
+
 msgid "Re&nderer"
 msgstr "Re&nderer"
 

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -15,8 +15,8 @@ msgstr "&Keyboard vereist vastleggen"
 msgid "&Right CTRL is left ALT"
 msgstr "&Rechtse CTRL is linkse ALT"
 
-msgid "&Hard Reset..."
-msgstr "&Harde Reset..."
+msgid "&Hard reset"
+msgstr "&Harde reset"
 
 msgid "&Ctrl+Alt+Del"
 msgstr "&Ctrl+Alt+Del"
@@ -1076,6 +1076,12 @@ msgstr "Forceer afsluiten"
 
 msgid "Start"
 msgstr "Start"
+
+msgid "&Force shutdown"
+msgstr "&Forceer afsluiten"
+
+msgid "&Start"
+msgstr "&Start"
 
 msgid "Not running"
 msgstr "Niet actied"

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -51,6 +51,9 @@ msgstr "&Okno o zmiennym rozmiarze"
 msgid "R&emember size && position"
 msgstr "P&amiętaj rozmiar i pozycję"
 
+msgid "Remember size && position"
+msgstr "Pamiętaj rozmiar i pozycję"
+
 msgid "Re&nderer"
 msgstr "Re&nderer"
 

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -15,8 +15,8 @@ msgstr "&Klawiatura wymaga przechwytu myszy"
 msgid "&Right CTRL is left ALT"
 msgstr "Prawy C&TRL to lewy ALT"
 
-msgid "&Hard Reset..."
-msgstr "Twardy &reset..."
+msgid "&Hard reset"
+msgstr "Twardy &reset"
 
 msgid "&Ctrl+Alt+Del"
 msgstr "&Ctrl+Alt+Del"
@@ -1076,6 +1076,12 @@ msgstr "Wymuś zamknięcie"
 
 msgid "Start"
 msgstr "Uruchom"
+
+msgid "&Force shutdown"
+msgstr "&Wymuś zamknięcie"
+
+msgid "&Start"
+msgstr "&Uruchom"
 
 msgid "Not running"
 msgstr "Wyłączona"

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -51,6 +51,9 @@ msgstr "&Janela redimensionável"
 msgid "R&emember size && position"
 msgstr "&Lembrar tamanho e posição"
 
+msgid "Remember size && position"
+msgstr "Lembrar tamanho e posição"
+
 msgid "Re&nderer"
 msgstr "&Renderizador"
 

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -15,8 +15,8 @@ msgstr "O &teclado requer captura"
 msgid "&Right CTRL is left ALT"
 msgstr "CTR&L direito é o ALT esquerdo"
 
-msgid "&Hard Reset..."
-msgstr "&Reinicialização completa..."
+msgid "&Hard reset"
+msgstr "&Reinicialização completa"
 
 msgid "&Ctrl+Alt+Del"
 msgstr "Ctrl+Alt+&Del"
@@ -1076,6 +1076,12 @@ msgstr "Forçar desligamento"
 
 msgid "Start"
 msgstr "Iniciar"
+
+msgid "&Force shutdown"
+msgstr "&Forçar desligamento"
+
+msgid "&Start"
+msgstr "&Iniciar"
 
 msgid "Not running"
 msgstr "Parado"

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -51,6 +51,9 @@ msgstr "&Janela redimensionável"
 msgid "R&emember size && position"
 msgstr "&Lembrar tamanho e posição"
 
+msgid "Remember size && position"
+msgstr "Lembrar tamanho e posição"
+
 msgid "Re&nderer"
 msgstr "&Renderizador"
 

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -15,8 +15,8 @@ msgstr "&Teclado requere captura"
 msgid "&Right CTRL is left ALT"
 msgstr "CTRL &direito é ALT esquerdo"
 
-msgid "&Hard Reset..."
-msgstr "&Reinicialização completa..."
+msgid "&Hard reset"
+msgstr "&Reinicialização completa"
 
 msgid "&Ctrl+Alt+Del"
 msgstr "&Ctrl+Alt+Del"
@@ -1076,6 +1076,12 @@ msgstr "Desligamento forçado"
 
 msgid "Start"
 msgstr "Iniciar"
+
+msgid "&Force shutdown"
+msgstr "&Desligamento forçado"
+
+msgid "&Start"
+msgstr "&Iniciar"
 
 msgid "Not running"
 msgstr "Não em execução"

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -15,8 +15,8 @@ msgstr "&Клавиатура требует захвата"
 msgid "&Right CTRL is left ALT"
 msgstr "&Правый CTRL - это левый ALT"
 
-msgid "&Hard Reset..."
-msgstr "&Холодная перезагрузка..."
+msgid "&Hard reset"
+msgstr "&Холодная перезагрузка"
 
 msgid "&Ctrl+Alt+Del"
 msgstr "&Ctrl+Alt+Del"
@@ -1076,6 +1076,12 @@ msgstr "Принудительное завершение работы"
 
 msgid "Start"
 msgstr "Пуск"
+
+msgid "&Force shutdown"
+msgstr "Принудительное &завершение работы"
+
+msgid "&Start"
+msgstr "&Пуск"
 
 msgid "Not running"
 msgstr "Не работает"

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -51,6 +51,9 @@ msgstr "&Изменяемый размер окна"
 msgid "R&emember size && position"
 msgstr "&Запомнить размер и положение"
 
+msgid "Remember size && position"
+msgstr "Запомнить размер и положение"
+
 msgid "Re&nderer"
 msgstr "&Рендеринг"
 

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -51,6 +51,9 @@ msgstr "&Premenná veľkosť okna"
 msgid "R&emember size && position"
 msgstr "&Pamätať si veľkosť a polohu"
 
+msgid "Remember size && position"
+msgstr "Pamätať si veľkosť a polohu"
+
 msgid "Re&nderer"
 msgstr "&Renderer"
 

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -15,7 +15,7 @@ msgstr "&Klávesnica vyžaduje záber"
 msgid "&Right CTRL is left ALT"
 msgstr "&Pravý Ctrl je ľavý Alt"
 
-msgid "&Hard Reset..."
+msgid "&Hard reset"
 msgstr "&Resetovať"
 
 msgid "&Ctrl+Alt+Del"
@@ -1076,6 +1076,12 @@ msgstr "Vynútiť vypnutie"
 
 msgid "Start"
 msgstr "Spustiť"
+
+msgid "&Force shutdown"
+msgstr "&Vynútiť vypnutie"
+
+msgid "&Start"
+msgstr "&Spustiť"
 
 msgid "Not running"
 msgstr "Nebeží"

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -15,8 +15,8 @@ msgstr "&Tipkovnica potrebuje zajem"
 msgid "&Right CTRL is left ALT"
 msgstr "&Desni CTRL je levi ALT"
 
-msgid "&Hard Reset..."
-msgstr "&Ponovni zagon..."
+msgid "&Hard reset"
+msgstr "&Ponovni zagon"
 
 msgid "&Ctrl+Alt+Del"
 msgstr "&Ctrl+Alt+Del"
@@ -1076,6 +1076,12 @@ msgstr "Prisilno prekini"
 
 msgid "Start"
 msgstr "Zaženi"
+
+msgid "&Force shutdown"
+msgstr "&Prisilno prekini"
+
+msgid "&Start"
+msgstr "&Zaženi"
 
 msgid "Not running"
 msgstr "Se ne izvaja"

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -51,6 +51,9 @@ msgstr "S&premenljiva velikost okna"
 msgid "R&emember size && position"
 msgstr "&Zapomni si velikost in položaj"
 
+msgid "Remember size && position"
+msgstr "Zapomni si velikost in položaj"
+
 msgid "Re&nderer"
 msgstr "&Upodabljanje"
 

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -15,8 +15,8 @@ msgstr "&Tangentbord behöver uppfångas"
 msgid "&Right CTRL is left ALT"
 msgstr "&Höger CTRL är vänster ALT"
 
-msgid "&Hard Reset..."
-msgstr "&Hård omstart..."
+msgid "&Hard reset"
+msgstr "&Hård omstart"
 
 msgid "&Ctrl+Alt+Del"
 msgstr "&Ctrl+Alt+Del"
@@ -1076,6 +1076,12 @@ msgstr "Tvinga avstängning"
 
 msgid "Start"
 msgstr "Starta"
+
+msgid "&Force shutdown"
+msgstr "&Tvinga avstängning"
+
+msgid "&Start"
+msgstr "&Starta"
 
 msgid "Not running"
 msgstr "Körs ej"

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -51,6 +51,9 @@ msgstr "&Ändringsbar fönsterstorlek"
 msgid "R&emember size && position"
 msgstr "K&om ihåg storlek && position"
 
+msgid "Remember size && position"
+msgstr "Kom ihåg storlek && position"
+
 msgid "Re&nderer"
 msgstr "Re&nderare"
 

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -51,6 +51,9 @@ msgstr "&Boyutlandırılabilir pencere"
 msgid "R&emember size && position"
 msgstr "&Pencere boyut ve pozisyonunu kaydet"
 
+msgid "Remember size && position"
+msgstr "Pencere boyut ve pozisyonunu kaydet"
+
 msgid "Re&nderer"
 msgstr "Derley&ici"
 

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -15,8 +15,8 @@ msgstr "&Klavye sadece fare yakalandığında çalışsın"
 msgid "&Right CTRL is left ALT"
 msgstr "&Sağ CTRL tuşunu sol ALT tuşu olarak ayarla"
 
-msgid "&Hard Reset..."
-msgstr "Yeniden başlamaya &zorla..."
+msgid "&Hard reset"
+msgstr "Yeniden başlamaya &zorla"
 
 msgid "&Ctrl+Alt+Del"
 msgstr "&Ctrl+Alt+Del"
@@ -1076,6 +1076,12 @@ msgstr "Kapatmaya zorla"
 
 msgid "Start"
 msgstr "Başlat"
+
+msgid "&Force shutdown"
+msgstr "&Kapatmaya zorla"
+
+msgid "&Start"
+msgstr "&Başlat"
 
 msgid "Not running"
 msgstr "Çalışmıyor"

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -51,6 +51,9 @@ msgstr "&Змінний розмір вікна"
 msgid "R&emember size && position"
 msgstr "&Запам'ятати розмір і становище"
 
+msgid "Remember size && position"
+msgstr "Запам'ятати розмір і становище"
+
 msgid "Re&nderer"
 msgstr "&Рендеринг"
 

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -15,8 +15,8 @@ msgstr "&Клавіатура потребує захвату"
 msgid "&Right CTRL is left ALT"
 msgstr "&Правий CTRL - це лівий ALT"
 
-msgid "&Hard Reset..."
-msgstr "&Холодне перезавантаження..."
+msgid "&Hard reset"
+msgstr "&Холодне перезавантаження"
 
 msgid "&Ctrl+Alt+Del"
 msgstr "&Ctrl+Alt+Del"
@@ -1076,6 +1076,12 @@ msgstr "Примусове завершення роботи"
 
 msgid "Start"
 msgstr "Пуск"
+
+msgid "&Force shutdown"
+msgstr "Примусове &завершення роботи"
+
+msgid "&Start"
+msgstr "&Пуск"
 
 msgid "Not running"
 msgstr "Не працює"

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -15,7 +15,7 @@ msgstr "Bàn phím &hoạt động cần 'bắt' chuột"
 msgid "&Right CTRL is left ALT"
 msgstr "Gắn ALT trái vào CTRL ph&ải"
 
-msgid "&Hard Reset..."
+msgid "&Hard reset"
 msgstr "Buộc khởi độn&g lại"
 
 msgid "&Ctrl+Alt+Del"
@@ -1076,6 +1076,12 @@ msgstr "Buộc tắt nguồn máy"
 
 msgid "Start"
 msgstr "Khởi động"
+
+msgid "&Force shutdown"
+msgstr "&Buộc tắt nguồn máy"
+
+msgid "&Start"
+msgstr "&Khởi động"
 
 msgid "Not running"
 msgstr "Đang không chạy"

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -51,6 +51,9 @@ msgstr "Tùy chỉnh cỡ cử&a sổ"
 msgid "R&emember size && position"
 msgstr "Ghi nhớ vị trí và kíc&h thước cửa sổ"
 
+msgid "Remember size && position"
+msgstr "Ghi nhớ vị trí và kích thước cửa sổ"
+
 msgid "Re&nderer"
 msgstr "Re&nderer"
 

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -15,8 +15,8 @@ msgstr "键盘需要捕捉(&K)"
 msgid "&Right CTRL is left ALT"
 msgstr "将右 CTRL 键映射为左 ALT 键(&R)"
 
-msgid "&Hard Reset..."
-msgstr "硬重置(&H)..."
+msgid "&Hard reset"
+msgstr "硬重置(&H)"
 
 msgid "&Ctrl+Alt+Del"
 msgstr "Ctrl+Alt+Del(&C)"
@@ -1076,6 +1076,12 @@ msgstr "强制关机"
 
 msgid "Start"
 msgstr "启动"
+
+msgid "&Force shutdown"
+msgstr "强制关机(&F)"
+
+msgid "&Start"
+msgstr "启动(&S)"
 
 msgid "Not running"
 msgstr "未在运行"

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -51,6 +51,9 @@ msgstr "窗口大小可调(&R)"
 msgid "R&emember size && position"
 msgstr "记住窗口大小和位置(&E)"
 
+msgid "Remember size && position"
+msgstr "记住窗口大小和位置"
+
 msgid "Re&nderer"
 msgstr "渲染器(&N)"
 

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -51,6 +51,9 @@ msgstr "視窗大小可調(&R)"
 msgid "R&emember size && position"
 msgstr "記住視窗大小和位置(&E)"
 
+msgid "Remember size && position"
+msgstr "記住視窗大小和位置"
+
 msgid "Re&nderer"
 msgstr "渲染器(&N)"
 

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -15,8 +15,8 @@ msgstr "鍵盤需要捕捉(&K)"
 msgid "&Right CTRL is left ALT"
 msgstr "將右 CTRL 鍵映射為左 ALT 鍵(&R)"
 
-msgid "&Hard Reset..."
-msgstr "硬重設(&H)..."
+msgid "&Hard reset"
+msgstr "硬重設(&H)"
 
 msgid "&Ctrl+Alt+Del"
 msgstr "Ctrl+Alt+Del(&C)"
@@ -1076,6 +1076,12 @@ msgstr "強制關機"
 
 msgid "Start"
 msgstr "開始"
+
+msgid "&Force shutdown"
+msgstr "強制關機(&F)"
+
+msgid "&Start"
+msgstr "開始(&S)"
 
 msgid "Not running"
 msgstr "未執行"

--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -340,7 +340,7 @@
      <normaloff>:/menuicons/qt/icons/hard_reset.ico</normaloff>:/menuicons/qt/icons/hard_reset.ico</iconset>
    </property>
    <property name="text">
-    <string>&amp;Hard Reset...</string>
+    <string>&amp;Hard reset</string>
    </property>
    <property name="iconVisibleInMenu">
     <bool>false</bool>

--- a/src/qt/qt_vmmanager_detailsection.cpp
+++ b/src/qt/qt_vmmanager_detailsection.cpp
@@ -161,7 +161,8 @@ VMManagerDetailSection::setupMainLayout()
 void
 VMManagerDetailSection::setSections()
 {
-    int row = 0;
+    int row    = 0;
+    bool empty = true;
 
     for (const auto& section : sections) {
         QStringList sectionsToAdd = section.value.split(sectionSeparator);
@@ -189,12 +190,13 @@ VMManagerDetailSection::setSections()
 
             const auto hSpacer = new QSpacerItem(0, 0, QSizePolicy::Expanding, QSizePolicy::Minimum);
             frameGridLayout->addItem(hSpacer, row, 2);
+            empty = false;
             row++;
         }
     }
 
     collapseButton->setContent(ui->detailFrame);
-    if (sections.size())
+    if (!empty)
         setVisible(true);
 }
 void

--- a/src/qt/qt_vmmanager_main.cpp
+++ b/src/qt/qt_vmmanager_main.cpp
@@ -740,6 +740,18 @@ VMManagerMain::machineCountString(QString states) const
     return tr("VMs: %1").arg(states);
 }
 
+QList<int>
+VMManagerMain::getPaneSizes() const
+{
+    return ui->splitter->sizes();
+}
+
+void
+VMManagerMain::setPaneSizes(const QList<int> &sizes)
+{
+    ui->splitter->setSizes(sizes);
+}
+
 void
 VMManagerMain::modelDataChange()
 {

--- a/src/qt/qt_vmmanager_main.cpp
+++ b/src/qt/qt_vmmanager_main.cpp
@@ -109,6 +109,53 @@ VMManagerMain::VMManagerMain(QWidget *parent) :
         if (indexAt.isValid()) {
             QMenu contextMenu(tr("Context Menu"), ui->listView);
 
+            QAction startAction(tr("&Start"));
+            contextMenu.addAction(&startAction);
+            connect(&startAction, &QAction::triggered, [this] {
+                selected_sysconfig->startButtonPressed();
+            });
+            startAction.setEnabled(selected_sysconfig->process->state() == QProcess::NotRunning);
+            startAction.setVisible(selected_sysconfig->process->state() == QProcess::NotRunning);
+
+            QAction pauseAction(tr("&Pause"));
+            contextMenu.addAction(&pauseAction);
+            connect(&pauseAction, &QAction::triggered, [this] {
+                selected_sysconfig->pauseButtonPressed();
+            });
+            pauseAction.setEnabled(selected_sysconfig->process->state() == QProcess::Running);
+            pauseAction.setVisible(selected_sysconfig->process->state() == QProcess::Running);
+            if (selected_sysconfig->getProcessStatus() != VMManagerSystem::ProcessStatus::Running)
+                pauseAction.setText(tr("Re&sume"));
+
+            QAction resetAction(tr("&Hard reset"));
+            contextMenu.addAction(&resetAction);
+            connect(&resetAction, &QAction::triggered, [this] {
+                selected_sysconfig->restartButtonPressed();
+            });
+            resetAction.setEnabled(selected_sysconfig->process->state() == QProcess::Running);
+
+            QAction forceShutdownAction(tr("&Force shutdown"));
+            contextMenu.addAction(&forceShutdownAction);
+            connect(&forceShutdownAction, &QAction::triggered, [this] {
+                selected_sysconfig->shutdownForceButtonPressed();
+            });
+            forceShutdownAction.setEnabled(selected_sysconfig->process->state() == QProcess::Running);
+
+            QAction cadAction(tr("&Ctrl+Alt+Del"));
+            contextMenu.addAction(&cadAction);
+            connect(&cadAction, &QAction::triggered, [this] {
+                selected_sysconfig->cadButtonPressed();
+            });
+            cadAction.setEnabled(selected_sysconfig->process->state() == QProcess::Running);
+
+            contextMenu.addSeparator();
+
+            QAction settingsAction(tr("&Settings..."));
+            contextMenu.addAction(&settingsAction);
+            connect(&settingsAction, &QAction::triggered, [this] {
+                selected_sysconfig->launchSettings();
+            });
+
             QAction nameChangeAction(tr("Change &display name..."));
             contextMenu.addAction(&nameChangeAction);
             // Use a lambda to call a function so indexAt can be passed

--- a/src/qt/qt_vmmanager_main.hpp
+++ b/src/qt/qt_vmmanager_main.hpp
@@ -87,6 +87,9 @@ public slots:
     void onConfigUpdated(const QString &uuid);
     int  getActiveMachineCount();
 
+    QList<int> getPaneSizes() const;
+    void       setPaneSizes(const QList<int> &sizes);
+
 private:
     Ui::VMManagerMain *ui;
 

--- a/src/qt/qt_vmmanager_mainwindow.cpp
+++ b/src/qt/qt_vmmanager_mainwindow.cpp
@@ -151,10 +151,20 @@ VMManagerMainWindow(QWidget *parent)
             if (!!config->getStringValue("window_maximized").toInt()) {
                 setWindowState(windowState() | Qt::WindowMaximized);
             }
+
+            list = config->getStringValue("window_splitter").split(',');
+            for (auto& cur : list) {
+                cur = cur.trimmed();
+            }
+            QList<int> paneSizes;
+            paneSizes.append(list[0].toInt());
+            paneSizes.append(list[1].toInt());
+            vmm->setPaneSizes(paneSizes);
         } else {
             config->setStringValue("window_remember", "");
             config->setStringValue("window_coordinates", "");
             config->setStringValue("window_maximized", "");
+            config->setStringValue("window_splitter", "");
         }
         delete config;
     }
@@ -218,10 +228,12 @@ VMManagerMainWindow::saveSettings() const
     if (ui->actionRemember_size_and_position->isChecked()) {
         config->setStringValue("window_coordinates", QString::asprintf("%i, %i, %i, %i", this->geometry().x(), this->geometry().y(), this->geometry().width(), this->geometry().height()));
         config->setStringValue("window_maximized", this->isMaximized() ? "1" : "");
+        config->setStringValue("window_splitter", QString::asprintf("%i, %i", vmm->getPaneSizes()[0], vmm->getPaneSizes()[1]));
     } else {
         config->setStringValue("window_remember", "");
         config->setStringValue("window_coordinates", "");
         config->setStringValue("window_maximized", "");
+        config->setStringValue("window_splitter", "");
     }
     // Sometimes required to ensure the settings save before the app exits
     config->sync();

--- a/src/qt/qt_vmmanager_mainwindow.cpp
+++ b/src/qt/qt_vmmanager_mainwindow.cpp
@@ -135,33 +135,39 @@ VMManagerMainWindow(QWidget *parent)
 
     {
         auto config = new VMManagerConfig(VMManagerConfig::ConfigType::General);
-        this->ui->actionRemember_size_and_position->setChecked(!!config->getStringValue("window_remember").toInt());
-        if (ui->actionRemember_size_and_position->isChecked()) {
-            QStringList list = config->getStringValue("window_coordinates").split(',');
-            for (auto& cur : list) {
-                cur = cur.trimmed();
-            }
-            QRect geom;
-            geom.setX(list[0].toInt());
-            geom.setY(list[1].toInt());
-            geom.setWidth(list[2].toInt());
-            geom.setHeight(list[3].toInt());
+        if (!!config->getStringValue("window_remember").toInt()) {
+            QString coords = config->getStringValue("window_coordinates");
+            if (!coords.isEmpty()) {
+                QStringList list = coords.split(',');
+                for (auto& cur : list) {
+                    cur = cur.trimmed();
+                }
+                QRect geom;
+                geom.setX(list[0].toInt());
+                geom.setY(list[1].toInt());
+                geom.setWidth(list[2].toInt());
+                geom.setHeight(list[3].toInt());
 
-            setGeometry(geom);
+                setGeometry(geom);
+            }
+
             if (!!config->getStringValue("window_maximized").toInt()) {
                 setWindowState(windowState() | Qt::WindowMaximized);
             }
 
-            list = config->getStringValue("window_splitter").split(',');
-            for (auto& cur : list) {
-                cur = cur.trimmed();
+            QString splitter = config->getStringValue("window_splitter");
+            if (!splitter.isEmpty()) {
+                QStringList list = splitter.split(',');
+                for (auto& cur : list) {
+                    cur = cur.trimmed();
+                }
+                QList<int> paneSizes;
+                paneSizes.append(list[0].toInt());
+                paneSizes.append(list[1].toInt());
+
+                vmm->setPaneSizes(paneSizes);
             }
-            QList<int> paneSizes;
-            paneSizes.append(list[0].toInt());
-            paneSizes.append(list[1].toInt());
-            vmm->setPaneSizes(paneSizes);
         } else {
-            config->setStringValue("window_remember", "");
             config->setStringValue("window_coordinates", "");
             config->setStringValue("window_maximized", "");
             config->setStringValue("window_splitter", "");
@@ -224,13 +230,11 @@ VMManagerMainWindow::saveSettings() const
     const auto currentSelection = vmm->getCurrentSelection();
     const auto config = new VMManagerConfig(VMManagerConfig::ConfigType::General);
     config->setStringValue("last_selection", currentSelection);
-    config->setStringValue("window_remember", QString::number(ui->actionRemember_size_and_position->isChecked()));
-    if (ui->actionRemember_size_and_position->isChecked()) {
+    if (!!config->getStringValue("window_remember").toInt()) {
         config->setStringValue("window_coordinates", QString::asprintf("%i, %i, %i, %i", this->geometry().x(), this->geometry().y(), this->geometry().width(), this->geometry().height()));
         config->setStringValue("window_maximized", this->isMaximized() ? "1" : "");
         config->setStringValue("window_splitter", QString::asprintf("%i, %i", vmm->getPaneSizes()[0], vmm->getPaneSizes()[1]));
     } else {
-        config->setStringValue("window_remember", "");
         config->setStringValue("window_coordinates", "");
         config->setStringValue("window_maximized", "");
         config->setStringValue("window_splitter", "");

--- a/src/qt/qt_vmmanager_mainwindow.ui
+++ b/src/qt/qt_vmmanager_mainwindow.ui
@@ -28,7 +28,6 @@
      <string>&amp;Tools</string>
     </property>
     <addaction name="actionPreferences"/>
-    <addaction name="actionRemember_size_and_position"/>
     <addaction name="actionCheck_for_updates"/>
    </widget>
    <widget class="QMenu" name="menuFile">
@@ -185,14 +184,6 @@
    </property>
    <property name="toolTip">
     <string>New machine...</string>
-   </property>
-  </action>
-  <action name="actionRemember_size_and_position">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>R&amp;emember size &amp;&amp; position</string>
    </property>
   </action>
   <action name="actionPreferences">

--- a/src/qt/qt_vmmanager_mainwindow.ui
+++ b/src/qt/qt_vmmanager_mainwindow.ui
@@ -98,6 +98,9 @@
    <property name="text">
     <string>&amp;Start</string>
    </property>
+   <property name="toolTip">
+    <string>Start</string>
+   </property>
    <property name="iconVisibleInMenu">
     <bool>false</bool>
    </property>
@@ -108,7 +111,10 @@
      <normaloff>:/menuicons/qt/icons/hard_reset.ico</normaloff>:/menuicons/qt/icons/hard_reset.ico</iconset>
    </property>
    <property name="text">
-    <string>&amp;Hard Reset...</string>
+    <string>&amp;Hard reset</string>
+   </property>
+   <property name="toolTip">
+    <string>Hard reset</string>
    </property>
    <property name="iconVisibleInMenu">
     <bool>false</bool>
@@ -166,6 +172,9 @@
    </property>
    <property name="text">
     <string>&amp;Settings...</string>
+   </property>
+   <property name="toolTip">
+    <string>Settings...</string>
    </property>
    <property name="menuRole">
     <enum>QAction::NoRole</enum>

--- a/src/qt/qt_vmmanager_preferences.cpp
+++ b/src/qt/qt_vmmanager_preferences.cpp
@@ -70,6 +70,8 @@ VMManagerPreferences(QWidget *parent) : ui(new Ui::VMManagerPreferences)
 #endif
     const auto useRegexSearch = config->getStringValue("regex_search").toInt();
     ui->regexSearchCheckBox->setChecked(useRegexSearch);
+    const auto rememberSizePosition = config->getStringValue("window_remember").toInt();
+    ui->rememberSizePositionCheckBox->setChecked(rememberSizePosition);
 
     ui->radioButtonSystem->setChecked(color_scheme == 0);
     ui->radioButtonLight->setChecked(color_scheme == 1);
@@ -112,6 +114,7 @@ VMManagerPreferences::accept()
 #if EMU_BUILD_NUM != 0
     config->setStringValue("update_check", ui->updateCheckBox->isChecked() ? "1" : "0");
 #endif
+    config->setStringValue("window_remember", ui->rememberSizePositionCheckBox->isChecked() ? "1" : "0");
     config->setStringValue("regex_search", ui->regexSearchCheckBox->isChecked() ? "1" : "0");
     QDialog::accept();
 }

--- a/src/qt/qt_vmmanager_preferences.ui
+++ b/src/qt/qt_vmmanager_preferences.ui
@@ -93,6 +93,13 @@
     </layout>
    </item>
    <item>
+    <widget class="QCheckBox" name="rememberSizePositionCheckBox">
+     <property name="text">
+      <string>Remember size &amp;&amp; position</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QCheckBox" name="updateCheckBox">
      <property name="text">
       <string>Check for updates on startup</string>
@@ -165,6 +172,7 @@
   <tabstop>dirSelectButton</tabstop>
   <tabstop>comboBoxLanguage</tabstop>
   <tabstop>pushButtonLanguage</tabstop>
+  <tabstop>rememberSizePositionCheckBox</tabstop>
   <tabstop>updateCheckBox</tabstop>
   <tabstop>regexSearchCheckBox</tabstop>
  </tabstops>

--- a/src/qt/qt_vmmanager_system.cpp
+++ b/src/qt/qt_vmmanager_system.cpp
@@ -725,7 +725,7 @@ VMManagerSystem::setupVars() {
     }
 
     static auto floppy_match = QRegularExpression("fdd_\\d\\d_type", QRegularExpression::CaseInsensitiveOption);
-    static auto cdrom_match  = QRegularExpression("cdrom_\\d\\d_type", QRegularExpression::CaseInsensitiveOption);
+    static auto cdrom_match  = QRegularExpression("cdrom_\\d\\d_parameters", QRegularExpression::CaseInsensitiveOption);
     for(const auto& key: floppy_cdrom_config.keys()) {
         if(key.contains(floppy_match)) {
             // auto device_number = key.split("_").at(1);
@@ -741,22 +741,23 @@ VMManagerSystem::setupVars() {
         }
         if(key.contains(cdrom_match)) {
             auto device_number = key.split("_").at(1);
-            auto cdrom_internal_name = QString(floppy_cdrom_config[key]);
+            auto cdrom_parameters = QString(floppy_cdrom_config[key]);
+            auto cdrom_bus = cdrom_parameters.split(",").at(1).trimmed().toUpper();
+
+            auto cdrom_type_key = QString("cdrom_%1_type").arg(device_number);
+            auto cdrom_internal_name = QString(floppy_cdrom_config[cdrom_type_key]);
+            if (cdrom_internal_name.isEmpty())
+                cdrom_internal_name = "86cd";
             auto cdrom_type = cdrom_get_from_internal_name(cdrom_internal_name.toUtf8().data());
 
             auto cdrom_speed_key = QString("cdrom_%1_speed").arg(device_number);
-            auto cdrom_parameters_key = QString("cdrom_%1_parameters").arg(device_number);
             auto cdrom_speed = QString(floppy_cdrom_config[cdrom_speed_key]);
-            auto cdrom_parameters = QString(floppy_cdrom_config[cdrom_parameters_key]);
-            auto cdrom_bus = cdrom_parameters.split(",").at(1).trimmed().toUpper();
+            if (cdrom_speed.isEmpty())
+                cdrom_speed = "8";
 
-            if(cdrom_type != -1) {
-                if(!cdrom_speed.isEmpty()) {
-                    cdrom_speed = QString("%1x ").arg(cdrom_speed);
-                }
-                if(!cdrom_bus.isEmpty()) {
-                    cdrom_bus = QString(" (%1)").arg(cdrom_bus);
-                }
+            if ((cdrom_bus != "NONE") && (cdrom_type != -1)) {
+                cdrom_speed = QString("%1x ").arg(cdrom_speed);
+                cdrom_bus = QString(" (%1)").arg(cdrom_bus);
                 cdromDevices.append(QString("%1%2 %3 %4%5").arg(cdrom_speed, cdrom_drive_types[cdrom_type].vendor, cdrom_drive_types[cdrom_type].model, cdrom_drive_types[cdrom_type].revision, cdrom_bus));
             }
         }

--- a/src/qt/qt_vmmanager_system.cpp
+++ b/src/qt/qt_vmmanager_system.cpp
@@ -425,6 +425,16 @@ VMManagerSystem::launchMainProcess() {
     QStringList args;
     args << "--vmpath" << config_dir;
     args << "--vmname" << displayName;
+    if (rom_path[0] != '\0')
+        args << "--rompath" << QString(rom_path);
+    if (global_cfg_overridden)
+        args << "--global" << QString(global_cfg_path);
+    if (!hook_enabled)
+        args << "--nohook";
+    if (start_in_fullscreen)
+        args << "--fullscreen";
+    if (!confirm_exit_cmdl)
+        args << "--noconfirm";
     process->setProgram(program);
     process->setArguments(args);
     qDebug() << Q_FUNC_INFO << " Full Command:" << process->program() << " " << process->arguments();
@@ -481,6 +491,10 @@ VMManagerSystem::launchSettings() {
     QStringList open_command_args;
     QStringList args;
     args << "--vmpath" << config_dir << "--settings";
+    if (rom_path[0] != '\0')
+        args << "--rompath" << QString(rom_path);
+    if (global_cfg_overridden)
+        args << "--global" << QString(global_cfg_path);
     process->setProgram(program);
     process->setArguments(args);
     qDebug() << Q_FUNC_INFO << " Full Command:" << process->program() << " " << process->arguments();


### PR DESCRIPTION
Summary
=======
* When command-line arguments `--rompath`, `--global`, `--fullscreen`, `--noconfirm` and `--nohook` are passed to 86Box when starting the manager, pass them to the VMs started by it
* Fix detail pane sections that have only empty entries (which are hidden) not being hidden themselves
* Fix the 86B_CD 3.50 CD-ROM model and 8x CD-ROM speed not showing up in the manager's details pane
* Remember the width of the machine list in addition to window size and position
* Move the "Remember size & position" option to a checkbox in the Preferences dialog
* Add machine actions (start/pause/resume, hard reset, force shutdown, Ctrl+Alt+Del, open settings) to machine context menu

Checklist
=========
* [x] Closes #6076
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
N/A