### PR TITLE
Fix untranslated string

### DIFF
--- a/src/qt/qt_vmmanager_main.cpp
+++ b/src/qt/qt_vmmanager_main.cpp
@@ -390,7 +390,7 @@ illegal_chars:
         } else {
             QMenu contextMenu(tr("Context Menu"), ui->listView);
 
-            QAction newMachineAction(tr("New machine..."));
+            QAction newMachineAction(tr("&New machine..."));
             contextMenu.addAction(&newMachineAction);
             connect(&newMachineAction, &QAction::triggered, this, &VMManagerMain::newMachineWizard);
 


### PR DESCRIPTION
Summary
=======
Fix for a untranslated string in the context menu of the machine list in the VM manager.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
