### PR TITLE
S3 928 and icd2061 mode rework (September 15th, 2025)

### DIFF
--- a/src/include/86box/vid_clockgen_icd2061.h
+++ b/src/include/86box/vid_clockgen_icd2061.h
@@ -1,0 +1,38 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          ICD2061 clock generator emulation.
+ *          Also emulates the ICS9161 which is the same as the ICD2016,
+ *          but without the need for tuning (which is irrelevant in
+ *          emulation anyway).
+ *
+ *          Used by ET4000w32/p (Diamond Stealth 32) and the S3
+ *          Vision964 family.
+ *
+ *
+ *
+ * Authors: Miran Grca, <mgrca8@gmail.com>
+ *
+ *          Copyright 2016-2018 Miran Grca.
+ */
+#ifndef VIDEO_CLOCKGEN_ICD2061_H
+#define VIDEO_CLOCKGEN_ICD2061_H
+
+typedef struct icd2061_t {
+    float freq[3];
+    float ref_clock;
+
+    int      count;
+    int      bit_count;
+    int      unlocked;
+    int      state;
+    uint32_t data;
+    uint32_t ctrl;
+} icd2061_t;
+
+#endif // VIDEO_CLOCKGEN_ICD2061_H

--- a/src/include/86box/vid_svga.h
+++ b/src/include/86box/vid_svga.h
@@ -142,6 +142,9 @@ typedef struct svga_t {
     int start_retrace_latch;
     int vga_mode;
     int half_pixel;
+    int clock_multiplier;
+    int true_color_bypass;
+    int multiplexing_rate;
 
     /*The three variables below allow us to implement memory maps like that seen on a 1MB Trio64 :
       0MB-1MB - VRAM
@@ -450,7 +453,7 @@ extern void    ibm_rgb528_ramdac_set_ref_clock(void *priv, svga_t *svga, float r
 
 extern void  icd2061_write(void *priv, int val);
 extern float icd2061_getclock(int clock, void *priv);
-extern void  icd2061_set_ref_clock(void *priv, svga_t *svga, float ref_clock);
+extern void  icd2061_set_ref_clock(void *priv, float ref_clock);
 
 /* The code is the same, the #define's are so that the correct name can be used. */
 #    define ics9161_write    icd2061_write

--- a/src/video/clockgen/vid_clockgen_icd2061.c
+++ b/src/video/clockgen/vid_clockgen_icd2061.c
@@ -33,19 +33,8 @@
 #include <86box/timer.h>
 #include <86box/video.h>
 #include <86box/vid_svga.h>
+#include <86box/vid_clockgen_icd2061.h>
 #include <86box/plat_unused.h>
-
-typedef struct icd2061_t {
-    float    freq[3];
-    float    ref_clock;
-
-    int      count;
-    int      bit_count;
-    int      unlocked;
-    int      state;
-    uint32_t data;
-    uint32_t ctrl;
-} icd2061_t;
 
 #ifdef ENABLE_ICD2061_LOG
 int icd2061_do_log = ENABLE_ICD2061_LOG;
@@ -155,14 +144,12 @@ icd2061_getclock(int clock, void *priv)
 }
 
 void
-icd2061_set_ref_clock(void *priv, svga_t *svga, float ref_clock)
+icd2061_set_ref_clock(void *priv, float ref_clock)
 {
     icd2061_t *icd2061 = (icd2061_t *) priv;
 
-    if (icd2061)
+    if (icd2061 != NULL)
         icd2061->ref_clock = ref_clock;
-
-    svga_recalctimings(svga);
 }
 
 static void *

--- a/src/video/ramdac/vid_ramdac_sc1502x.c
+++ b/src/video/ramdac/vid_ramdac_sc1502x.c
@@ -44,6 +44,7 @@ static void
 sc1502x_ramdac_bpp(sc1502x_ramdac_t *ramdac, svga_t *svga)
 {
     int oldbpp = svga->bpp;
+    //pclog("BPP Val=%02x, truecolortype=%02x.\n", ramdac->ctrl, ramdac->regs[0x10] & 0x01);
     if (ramdac->ctrl & 0x80) {
         if (ramdac->ctrl & 0x40) {
             svga->bpp = 16;
@@ -60,6 +61,7 @@ sc1502x_ramdac_bpp(sc1502x_ramdac_t *ramdac, svga_t *svga)
         } else
             svga->bpp = 8;
     }
+    //pclog("SVGA BPP=%d.\n", svga->bpp);
     if (oldbpp != svga->bpp)
         svga_recalctimings(svga);
 }
@@ -135,9 +137,11 @@ sc1502x_rs2_ramdac_out(uint16_t addr, int rs2, uint8_t val, void *priv, svga_t *
     uint8_t rs = (addr & 0x03);
     rs |= ((!!rs2) << 2);
 
+    //pclog("RS=%02x, Write=%02x.\n", rs, val);
     switch (rs) {
         case 0x00:
             if (ramdac->ctrl & 0x10) {
+                //pclog("RAMDAC IDX=%02x, Write=%02x.\n", ramdac->idx, val);
                 switch (ramdac->idx) {
                     case 8:
                         ramdac->regs[8] = val;

--- a/src/video/vid_et4000w32.c
+++ b/src/video/vid_et4000w32.c
@@ -2845,6 +2845,8 @@ et4000w32p_init(const device_t *info)
             et4000->svga.ramdac    = device_add(&stg_ramdac_device);
             et4000->svga.clock_gen = device_add(&icd2061_device);
             et4000->svga.getclock  = icd2061_getclock;
+            icd2061_set_ref_clock(et4000->svga.ramdac, 14318184.0f);
+            svga_recalctimings(&et4000->svga);
             break;
 
         default:


### PR DESCRIPTION
Summary
=======
The rework resolves around implementing the clock multiplier and multiplexing rate of the bt485 ramdac alongside existing additional flags for eventual fixes (like cr31 bit 1) as well as the true color bypass (for 16-bit and true color modes). These, together, allow proper rendering of the generic VESA S3 drivers alongside non-VESA ELSA OEM drivers on various guests.


Checklist
=========
* [ ] Closes #xxx
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
