### PR TITLE
Save processed screenshots without an alpha channel

### DIFF
--- a/src/qt/qt_openglrenderer.cpp
+++ b/src/qt/qt_openglrenderer.cpp
@@ -1708,20 +1708,15 @@ OpenGLRenderer::render()
         plat_tempfile(fn, NULL, (char*)".png");
         strcat(path, fn);
 
-        unsigned char *rgba = (unsigned char *) calloc(1, (size_t) width * height * 4);
+        unsigned char *rgb = (unsigned char *) calloc(1, (size_t) width * height * 3);
         
         glw.glFinish();
-        glw.glReadPixels(window_rect.x, window_rect.y, width, height, GL_RGBA, GL_UNSIGNED_BYTE, rgba);
+        glw.glReadPixels(window_rect.x, window_rect.y, width, height, GL_RGB, GL_UNSIGNED_BYTE, rgb);
 
-        for (uint32_t idx = 0; idx < (uint32_t)(width * height); idx++)
-        {
-            rgba[idx * 4] = 255;
-        }
-
-        QImage image(rgba, width, height, QImage::Format_RGBA8888);
+        QImage image(rgb, width, height, QImage::Format_RGB888);
         image.mirrored(false, true).save(path, "png");
         monitors[r_monitor_index].mon_screenshots--;
-        free(rgba);
+        free(rgb);
     }
 
     glw.glDisable(GL_FRAMEBUFFER_SRGB);


### PR DESCRIPTION
Summary
=======
Save processed screenshots without an alpha channel.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
