### PR TITLE
Restore earlier OPL4 identification method

### DIFF
--- a/src/sound/ymfm/ymfm_opl.cpp
+++ b/src/sound/ymfm/ymfm_opl.cpp
@@ -1717,14 +1717,8 @@ uint8_t ymf278b::read_data_pcm()
 {
 	// read from PCM
 	if (bitfield(m_address, 9) != 0)
-	{
-		uint8_t result = m_pcm.read(m_address & 0xff);
-		if ((m_address & 0xff) == 0x02)
-			result |= 0x20;
-
-		return result;
-	}
-	return 0;
+		return m_pcm.read(m_address & 0xff);
+    return 0;
 }
 
 

--- a/src/sound/ymfm/ymfm_pcm.cpp
+++ b/src/sound/ymfm/ymfm_pcm.cpp
@@ -46,6 +46,7 @@ namespace ymfm
 void pcm_registers::reset()
 {
 	std::fill_n(&m_regdata[0], REGISTERS, 0);
+    m_regdata[0x02] = 0x20;
 	m_regdata[0xf8] = 0x1b;
 }
 


### PR DESCRIPTION
Summary
=======
Restore earlier OPL4 identification method.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
