### PR TITLE
Software renderer no longer uses QRasterWindow

### DIFF
--- a/src/qt/qt_openglrenderer.cpp
+++ b/src/qt/qt_openglrenderer.cpp
@@ -1223,6 +1223,9 @@ OpenGLRenderer::resizeEvent(QResizeEvent *event)
         destination.y(),
         destination.width(),
         destination.height());
+    
+    if (video_framerate == -1)
+        render();
 }
 
 void

--- a/src/qt/qt_softwarerenderer.cpp
+++ b/src/qt/qt_softwarerenderer.cpp
@@ -105,6 +105,7 @@ SoftwareRenderer::resizeEvent(QResizeEvent *event)
 #else
     QWindow::resizeEvent(event);
     m_backingStore->resize(event->size());
+    render();
 #endif
 }
 

--- a/src/qt/qt_softwarerenderer.cpp
+++ b/src/qt/qt_softwarerenderer.cpp
@@ -21,6 +21,7 @@
 #include "qt_softwarerenderer.hpp"
 #include <QApplication>
 #include <QPainter>
+#include <QResizeEvent>
 
 extern "C" {
 #include <86box/86box.h>
@@ -31,7 +32,7 @@ SoftwareRenderer::SoftwareRenderer(QWidget *parent)
 #ifdef __HAIKU__
     : QWidget(parent)
 #else
-    : QRasterWindow(parent->windowHandle())
+    : QWindow(parent->windowHandle()), m_backingStore(new QBackingStore(this))
 #endif
 {
     RendererCommon::parentWidget = parent;
@@ -47,11 +48,29 @@ SoftwareRenderer::SoftwareRenderer(QWidget *parent)
 #endif
 }
 
+#ifdef __HAIKU__
 void
 SoftwareRenderer::paintEvent(QPaintEvent *event)
 {
     (void) event;
     onPaint(this);
+}
+#endif
+
+void
+SoftwareRenderer::render()
+{
+    if (!isExposed())
+        return;
+
+    QRect rect(0, 0, width(), height());
+    m_backingStore->beginPaint(rect);
+
+    QPaintDevice *device = m_backingStore->paintDevice();
+    onPaint(device);
+
+    m_backingStore->endPaint();
+    m_backingStore->flush(rect);
 }
 
 void
@@ -70,7 +89,11 @@ SoftwareRenderer::onBlit(int buf_idx, int x, int y, int w, int h)
 
     if (source != origSource)
         onResize(this->width(), this->height());
+#ifdef __HAIKU__
     update();
+#else
+    render();
+#endif
 }
 
 void
@@ -80,7 +103,8 @@ SoftwareRenderer::resizeEvent(QResizeEvent *event)
 #ifdef __HAIKU__
     QWidget::resizeEvent(event);
 #else
-    QRasterWindow::resizeEvent(event);
+    QWindow::resizeEvent(event);
+    m_backingStore->resize(event->size());
 #endif
 }
 
@@ -92,7 +116,7 @@ SoftwareRenderer::event(QEvent *event)
 #ifdef __HAIKU__
         return QWidget::event(event);
 #else
-        return QRasterWindow::event(event);
+        return QWindow::event(event);
 #endif
     return res;
 }
@@ -112,6 +136,9 @@ SoftwareRenderer::onPaint(QPaintDevice *device)
 #endif
     painter.setCompositionMode(QPainter::CompositionMode_Plus);
     painter.drawImage(destination, *images[cur_image], source);
+#ifndef __HAIKU__
+    painter.end();
+#endif
 }
 
 std::vector<std::tuple<uint8_t *, std::atomic_flag *>>

--- a/src/qt/qt_softwarerenderer.hpp
+++ b/src/qt/qt_softwarerenderer.hpp
@@ -2,8 +2,10 @@
 #define SOFTWARERENDERER_HPP
 
 #include <QWidget>
-#include <QRasterWindow>
+#include <QWindow>
 #include <QPaintDevice>
+#include <QScopedPointer>
+#include <QBackingStore>
 #include <array>
 #include <atomic>
 #include "qt_renderercommon.hpp"
@@ -12,14 +14,16 @@ class SoftwareRenderer :
 #ifdef __HAIKU__
     public QWidget,
 #else
-    public QRasterWindow,
+    public QWindow,
 #endif
     public RendererCommon {
     Q_OBJECT
 public:
     explicit SoftwareRenderer(QWidget *parent = nullptr);
 
+#ifdef __HAIKU__
     void paintEvent(QPaintEvent *event) override;
+#endif
 
     std::vector<std::tuple<uint8_t *, std::atomic_flag *>> getBuffers() override;
 
@@ -33,6 +37,10 @@ protected:
     void onPaint(QPaintDevice *device);
     void resizeEvent(QResizeEvent *event) override;
     bool event(QEvent *event) override;
+
+    void render();
+
+    QScopedPointer<QBackingStore> m_backingStore;
 };
 
 #endif // SOFTWARERENDERER_HPP


### PR DESCRIPTION
Summary
=======
Software renderer no longer uses QRasterWindow, instead using QWindow and QBackingStore.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
