### PR TITLE
Correct CS4231 indirect register 23 behavior

### DIFF
--- a/src/sound/snd_ad1848.c
+++ b/src/sound/snd_ad1848.c
@@ -488,6 +488,8 @@ readonly_x:
                         ad1848_log("AD1848: write(X%d, %02X)\n", ad1848->xindex, val);
                         return;
                     }
+                    if (ad1848->type == AD1848_TYPE_CS4231) /* I23 is reserved and read-only on CS4231 non-A */
+                        goto readonly_i;
                     break;
 
                 case 24:


### PR DESCRIPTION
Summary
=======
Makes CS4231 indirect register 23 read-only. The datasheet for the CS4231 (non-A, which is what 86Box emulates) marks this as a reserved register and the Linux OSS ad1848.c WSS driver relies on this register being read-only to correctly detect the codec type and set the sample rate for audio playback. This fixes digital audio playback on CS4231-based sound cards (such as the OPTi 929/AcerMagic S20 and Yamaha YMF-701) on Mandrake Linux 8.0 (kernel 2.4.3).

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
- Crystal CS4231 datasheet: http://www.datasheet.hk/view_download.php?id=1629286&file=0316%5Ccs4231-kq_1442620.pdf
- Linux ad1848.c WSS driver: https://android.googlesource.com/kernel/msm/+/android-o-preview-4_r0.6/sound/oss/ad1848.c