### PR TITLE
Bump GLSL version of default shaders to 1.50

### DIFF
--- a/src/qt/qt_openglrenderer.cpp
+++ b/src/qt/qt_openglrenderer.cpp
@@ -75,11 +75,7 @@ extern int video_focus_dim;
 extern int video_refresh_rate;
 
 const char* vertex_shader_default_tex_src =
-#ifdef __APPLE__
         "#version 150\n"
-#else
-        "#version 130\n"
-#endif
         "\n"
         "in vec4 VertexCoord;\n"
         "in vec2 TexCoord;\n"
@@ -93,11 +89,7 @@ const char* vertex_shader_default_tex_src =
         "}\n";
 
 const char* fragment_shader_default_tex_src =
-#ifdef __APPLE__
         "#version 150\n"
-#else
-        "#version 130\n"
-#endif
         "\n"
         "in vec2 texCoord;\n"
         "uniform sampler2D Texture;\n"
@@ -111,11 +103,7 @@ const char* fragment_shader_default_tex_src =
         "}\n";
 
 const char* vertex_shader_default_color_src =
-#ifdef __APPLE__
         "#version 150\n"
-#else
-        "#version 130\n"
-#endif
         "\n"
         "in vec4 VertexCoord;\n"
         "in vec4 Color;\n"
@@ -129,11 +117,7 @@ const char* vertex_shader_default_color_src =
         "}\n";
 
 const char* fragment_shader_default_color_src =
-#ifdef __APPLE__
         "#version 150\n"
-#else
-        "#version 130\n"
-#endif
         "\n"
         "in vec4 color;\n"
         "\n"


### PR DESCRIPTION
Summary
=======
Bump GLSL version of default shaders to 1.50.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
