### PR TITLE
SVGA: Fix overflow crashes in certain cases

### DIFF
--- a/src/video/vid_svga_render.c
+++ b/src/video/vid_svga_render.c
@@ -155,7 +155,7 @@ svga_render_text_40(svga_t *svga)
     svga->lastline_draw = svga->displine;
 
     if (svga->fullchange) {
-        p    = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
+        p    = &svga->monitor->target_buffer->line[(svga->displine + svga->y_add) & 2047][(svga->x_add) & 2047];
         xinc = (svga->seqregs[1] & 1) ? 16 : 18;
 
         for (int x = 0; x < (svga->hdisp + svga->scrollcache); x += xinc) {
@@ -238,7 +238,7 @@ svga_render_text_80(svga_t *svga)
     svga->lastline_draw = svga->displine;
 
     if (svga->fullchange) {
-        p    = &svga->monitor->target_buffer->line[svga->displine + svga->y_add][svga->x_add];
+        p    = &svga->monitor->target_buffer->line[(svga->displine + svga->y_add) & 2047][(svga->x_add) & 2047];
         xinc = (svga->seqregs[1] & 1) ? 8 : 9;
 
         static uint32_t col = 0x00000000;


### PR DESCRIPTION
Summary
=======
SVGA: Fix overflow crashes in certain cases.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
