### PR TITLE
Clear screen to black on software renderer after it starts

### DIFF
--- a/src/qt/qt_softwarerenderer.cpp
+++ b/src/qt/qt_softwarerenderer.cpp
@@ -74,6 +74,12 @@ SoftwareRenderer::render()
 }
 
 void
+SoftwareRenderer::exposeEvent(QExposeEvent* event)
+{
+    render();
+}
+
+void
 SoftwareRenderer::onBlit(int buf_idx, int x, int y, int w, int h)
 {
     /* TODO: should look into deleteLater() */

--- a/src/qt/qt_softwarerenderer.hpp
+++ b/src/qt/qt_softwarerenderer.hpp
@@ -25,6 +25,8 @@ public:
     void paintEvent(QPaintEvent *event) override;
 #endif
 
+    void exposeEvent(QExposeEvent* event) override;
+
     std::vector<std::tuple<uint8_t *, std::atomic_flag *>> getBuffers() override;
 
 public slots:


### PR DESCRIPTION
Summary
=======
Clear screen to black on software renderer after it starts.

Checklist
=========
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
