### PR TITLE
YMF71x: Minor fixes

### DIFF
--- a/src/sound/snd_ymf71x.c
+++ b/src/sound/snd_ymf71x.c
@@ -152,15 +152,15 @@ ymf71x_config_write(uint16_t addr, uint8_t val, void *priv)
     }
     if (addr == 0xA79) {
         if ((ymf71x->configidx == 0x21) && (val & 0x01)) {
-            ymf71x_log(ymf71x->log, "Enable internal RAM write");
+            ymf71x_log(ymf71x->log, "Enable internal RAM write\n");
             ymf71x->ramwrite_enable = 1;
         }
         if ((ymf71x->configidx == 0x21) && (val == 0x00)) {
-            ymf71x_log(ymf71x->log, "Disable internal RAM write");
+            ymf71x_log(ymf71x->log, "Disable internal RAM write\n");
             isapnp_update_card_rom(ymf71x->pnp_card, &ymf71x->ram_data[0], 512);
         }
         if ((ymf71x->configidx == 0x20) && (ymf71x->ramwrite_enable == 0x01)) {
-            ymf71x_log(ymf71x->log, "Write to internal RAM addr %04X, val %02X", ymf71x->ram_addr, val);
+            ymf71x_log(ymf71x->log, "Write to internal RAM addr %04X, val %02X\n", ymf71x->ram_addr, val);
             ymf71x->ram_data[ymf71x->ram_addr++] = val;
         }
     }
@@ -765,6 +765,8 @@ ymf71x_init(const device_t *info)
 
     io_sethandler(0x0279, 0x0001, NULL, NULL, NULL, ymf71x_config_write, NULL, NULL, ymf71x);
     io_sethandler(0x0A79, 0x0001, NULL, NULL, NULL, ymf71x_config_write, NULL, NULL, ymf71x);
+
+    ymf71x_update_mastervol(ymf71x);
 
     return ymf71x;
 }


### PR DESCRIPTION
Summary
=======
Make the YMF-71x call the master volume update function during init as well. This fixes at least one corner case (the Sony Vaio PCV-130/150 boot chime) where audio playback is performed before the master volume registers are written to. Also corrects some missing newlines in debug logging.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
