### PR TITLE
S3 ViRGE: Move sign bit 1 bit further to the right for K2 scaler registers

### DIFF
--- a/src/video/vid_s3_virge.c
+++ b/src/video/vid_s3_virge.c
@@ -1952,9 +1952,9 @@ s3_virge_mmio_write_l(uint32_t addr, uint32_t val, void *priv)
                 break;
             case 0x8190:
                 virge->streams.sec_ctrl              = val;
-                virge->streams.dda_horiz_accumulator = val & 0xfff;
-                if (val & 0x1000)
-                    virge->streams.dda_horiz_accumulator |= ~0xfff;
+                virge->streams.dda_horiz_accumulator = val & 0x7ff;
+                if (val & 0x800)
+                    virge->streams.dda_horiz_accumulator |= ~0x7ff;
 
                 virge->streams.sdif = (val >> 24) & 7;
                 break;
@@ -2030,9 +2030,9 @@ s3_virge_mmio_write_l(uint32_t addr, uint32_t val, void *priv)
                     virge->streams.k2_vert_scale |= ~0x7ff;
                 break;
             case 0x81e8:
-                virge->streams.dda_vert_accumulator = val & 0xfff;
-                if (val & 0x1000)
-                    virge->streams.dda_vert_accumulator |= ~0xfff;
+                virge->streams.dda_vert_accumulator = val & 0x7ff;
+                if (val & 0x800)
+                    virge->streams.dda_vert_accumulator |= ~0x7ff;
 
                 svga_recalctimings(svga);
                 svga->fullchange = changeframecount;

--- a/src/video/vid_s3_virge.c
+++ b/src/video/vid_s3_virge.c
@@ -1963,13 +1963,13 @@ s3_virge_mmio_write_l(uint32_t addr, uint32_t val, void *priv)
                 break;
             case 0x8198:
                 virge->streams.sec_filter     = val;
-                virge->streams.k1_horiz_scale = val & 0x7ff;
-                if (val & 0x800)
-                    virge->streams.k1_horiz_scale |= ~0x7ff;
+                virge->streams.k1_horiz_scale = val & 0x3ff;
+                if (val & 0x400)
+                    virge->streams.k1_horiz_scale |= ~0x3ff;
 
-                virge->streams.k2_horiz_scale = (val >> 16) & 0x7ff;
-                if ((val >> 16) & 0x800)
-                    virge->streams.k2_horiz_scale |= ~0x7ff;
+                virge->streams.k2_horiz_scale = (val >> 16) & 0x3ff;
+                if ((val >> 16) & 0x400)
+                    virge->streams.k2_horiz_scale |= ~0x3ff;
 
                 svga_recalctimings(svga);
                 svga->fullchange = changeframecount;
@@ -2020,14 +2020,14 @@ s3_virge_mmio_write_l(uint32_t addr, uint32_t val, void *priv)
                 virge->streams.overlay_ctrl = val;
                 break;
             case 0x81e0:
-                virge->streams.k1_vert_scale = val & 0x7ff;
-                if (val & 0x800)
-                    virge->streams.k1_vert_scale |= ~0x7ff;
+                virge->streams.k1_vert_scale = val & 0x3ff;
+                if (val & 0x400)
+                    virge->streams.k1_vert_scale |= ~0x3ff;
                 break;
             case 0x81e4:
-                virge->streams.k2_vert_scale = val & 0x7ff;
-                if (val & 0x800)
-                    virge->streams.k2_vert_scale |= ~0x7ff;
+                virge->streams.k2_vert_scale = val & 0x3ff;
+                if (val & 0x400)
+                    virge->streams.k2_vert_scale |= ~0x3ff;
                 break;
             case 0x81e8:
                 virge->streams.dda_vert_accumulator = val & 0x7ff;

--- a/src/video/vid_s3_virge.c
+++ b/src/video/vid_s3_virge.c
@@ -1963,9 +1963,9 @@ s3_virge_mmio_write_l(uint32_t addr, uint32_t val, void *priv)
                 break;
             case 0x8198:
                 virge->streams.sec_filter     = val;
-                virge->streams.k1_horiz_scale = val & 0x3ff;
-                if (val & 0x400)
-                    virge->streams.k1_horiz_scale |= ~0x3ff;
+                virge->streams.k1_horiz_scale = val & 0x7ff;
+                if (val & 0x800)
+                    virge->streams.k1_horiz_scale |= ~0x7ff;
 
                 virge->streams.k2_horiz_scale = (val >> 16) & 0x3ff;
                 if ((val >> 16) & 0x400)
@@ -2020,9 +2020,9 @@ s3_virge_mmio_write_l(uint32_t addr, uint32_t val, void *priv)
                 virge->streams.overlay_ctrl = val;
                 break;
             case 0x81e0:
-                virge->streams.k1_vert_scale = val & 0x3ff;
-                if (val & 0x400)
-                    virge->streams.k1_vert_scale |= ~0x3ff;
+                virge->streams.k1_vert_scale = val & 0x7ff;
+                if (val & 0x800)
+                    virge->streams.k1_vert_scale |= ~0x7ff;
                 break;
             case 0x81e4:
                 virge->streams.k2_vert_scale = val & 0x3ff;


### PR DESCRIPTION
Summary
=======
S3 ViRGE: Move sign bit 1 bit further to the right for K2 scaler registers

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
