### PR TITLE
Fix BIOS loading address of IBM PS/2 ESDI adapter

### DIFF
--- a/src/disk/hdc_esdi_mca.c
+++ b/src/disk/hdc_esdi_mca.c
@@ -1220,6 +1220,12 @@ esdi_mca_write(int port, uint8_t val, void *priv)
 
     if (!(dev->pos_regs[3] & 8)) {
         switch (dev->pos_regs[3] & 7) {
+            case 0:
+                dev->bios = 0xc0000;
+                break;
+            case 1:
+                dev->bios = 0xc4000;
+                break;
             case 2:
                 dev->bios = 0xc8000;
                 break;


### PR DESCRIPTION
Summary
=======
Add missing BIOS loading address for IBM PS/2 ESDI adapter, fix issue with stock adf on the reference disk.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://www.ardent-tool.com/docs/pdf/ibm_esdi_trm.pdf#page=17
