### PR TITLE
Implement Force 4:3 option for resizable windows with fullscreen behaviour

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -936,11 +936,8 @@ MainWindow::closeEvent(QCloseEvent *event)
         const bool wasMax = isMaximized();
         QRect normal = wasMax ? this->normalGeometry() : this->geometry();
         // Save WINDOW size (not the content widget’s 4:3 box)
-        const int chromeHeight = geometry().height() - ui->stackedWidget->height();
         window_w = normal.width();
-        window_h = normal.height() - chromeHeight;
-        if (window_h < 0)
-            window_h = 0;
+        window_h = normal.height();
         if (!QApplication::platformName().contains("wayland")) {
             window_x = normal.x();
             window_y = normal.y();

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -84,7 +84,6 @@ extern bool cpu_thread_running;
 #include <QMenuBar>
 #include <QCheckBox>
 #include <QActionGroup>
-#include <QSize>
 #include <QOpenGLContext>
 #include <QScreen>
 #include <QString>
@@ -171,6 +170,8 @@ extern void     qt_mouse_capture(int);
 extern "C" void qt_blit(int x, int y, int w, int h, int monitor_index);
 
 extern MainWindow *main_window;
+
+bool MainWindow::s_adjustingForce43 = false;
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
@@ -932,15 +933,11 @@ MainWindow::closeEvent(QCloseEvent *event)
         }
     }
     if (window_remember) {
-        // If maximized, persist the normal (restorable) geometry
-        const bool wasMax = isMaximized();
-        QRect normal = wasMax ? this->normalGeometry() : this->geometry();
-        // Save WINDOW size (not the content widget’s 4:3 box)
-        window_w = normal.width();
-        window_h = normal.height();
+        window_w = ui->stackedWidget->width();
+        window_h = ui->stackedWidget->height();
         if (!QApplication::platformName().contains("wayland")) {
-            window_x = normal.x();
-            window_y = normal.y();
+            window_x = this->geometry().x();
+            window_y = this->geometry().y();
         }
         for (int i = 1; i < MONITORS_NUM; i++) {
             if (renderers[i]) {
@@ -1024,56 +1021,65 @@ void MainWindow::updateShortcuts()
 	seq = QKeySequence::fromString(acc_keys[accID].seq);
 	ui->actionMute_Unmute->setShortcut(seq);
 }
-
-void
-MainWindow::applyContentLayoutForCurrentState()
+		
+void 
+MainWindow::adjustForForce43(const QSize &newWinSize)
 {
-    auto applyFill = [this](const QRect& r){
-        ui->stackedWidget->setGeometry(r);
-        ui->stackedWidget->onResize(r.width(), r.height());
-        if (monitors[0].mon_scrnsz_x != r.width() || monitors[0].mon_scrnsz_y != r.height()) {
-            monitors[0].mon_scrnsz_x = r.width();
-            monitors[0].mon_scrnsz_y = r.height();
-            plat_resize_request(r.width(), r.height(), 0);
-        }
-    };
+    // Only act in resizable mode with Force 4:3 enabled and not fullscreen
+    if (!(vid_resize == 1 && force_43 > 0) || video_fullscreen || s_adjustingForce43)
+        return;
 
-    auto apply43 = [this](const QRect& area){
-        int areaW = area.width();
-        int areaH = area.height();
-        if (areaW <= 0 || areaH <= 0) return;
+    s_adjustingForce43 = true;
 
-        int targetW = areaW;
-        int targetH = (areaW * 3) / 4;
-        if (targetH > areaH) {
-            targetH = areaH;
-            targetW = (areaH * 4) / 3;
-        }
+    // Height consumed by menu/status/toolbars
+    int chromeH = menuBar()->height()
+                + (hide_status_bar ? 0 : statusBar()->height())
+                + (hide_tool_bar   ? 0 : ui->toolBar->height());
 
-        const int x = area.x() + (areaW - targetW) / 2;
-        const int y = area.y() + (areaH - targetH) / 2;
+    // Compute client area size in device‑independent pixels
+    double dpr = (!dpi_scale ? util::screenOfWidget(this)->devicePixelRatio() : 1.0);
+    int winW = newWinSize.width();
+    int winH = newWinSize.height();
+    int clientW = static_cast<int>(winW / dpr);
+    int clientH = static_cast<int>((winH - chromeH) / dpr);
 
-        ui->stackedWidget->setGeometry(x, y, targetW, targetH);
-        ui->stackedWidget->onResize(targetW, targetH);
+    if (clientW <= 0 || clientH <= 0) {
+        s_adjustingForce43 = false;
+        return;
+    }
 
-        if (monitors[0].mon_scrnsz_x != targetW || monitors[0].mon_scrnsz_y != targetH) {
-            monitors[0].mon_scrnsz_x = targetW;
-            monitors[0].mon_scrnsz_y = targetH;
-            plat_resize_request(targetW, targetH, 0);
-        }
-    };
+    // Decide which dimension the user changed most – adjust the other
+    int curW = static_cast<int>(width() / dpr);
+    int curH = static_cast<int>((height() - chromeH) / dpr);
+    bool widthChanged = std::abs(clientW - curW) >= std::abs(clientH - curH);
 
-    QWidget *cw = this->centralWidget();
-    if (!cw) return;
+    int targetW, targetH;
+    if (widthChanged) {
+        // user dragged width – compute matching height for 4:3
+        targetW = clientW;
+        targetH = (clientW * 3) / 4;
+    } else {
+        // user dragged height – compute matching width for 4:3
+        targetH = clientH;
+        targetW = (clientH * 4) / 3;
+    }
 
-    const QRect area = cw->contentsRect();
+    // Convert back to window size including chrome and apply
+    int newW = static_cast<int>(targetW * dpr);
+    int newH = static_cast<int>(targetH * dpr) + chromeH;
+    if (newW != winW || newH != winH)
+        resize(newW, newH);
 
-    // Fullscreen always fills (legacy behavior)
-    if (video_fullscreen) { applyFill(area); return; }
+    // Update emulator framebuffer size and notify platform
+    monitors[0].mon_scrnsz_x = targetW;
+    monitors[0].mon_scrnsz_y = targetH;
+    plat_resize_request(targetW, targetH, 0);
 
-    // Windowed: enforce 4:3 only when requested, otherwise fill
-    if (force_43 > 0) apply43(area);
-    else              applyFill(area);
+    // Allow renderer widget to grow and recompute scaling
+    ui->stackedWidget->setFixedSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
+    ui->stackedWidget->onResize(width(), height());
+
+    s_adjustingForce43 = false;
 }
 
 void
@@ -1082,10 +1088,26 @@ MainWindow::resizeEvent(QResizeEvent *event)
     //qDebug() << pos().x() + event->size().width();
     //qDebug() << pos().y() + event->size().height();
 	
-    // Always let QMainWindow do its layout first
-    QMainWindow::resizeEvent(event);
+    // Enforce 4:3 aspect ratio in resizable mode when the option is set
+    adjustForForce43(event->size());
+	
+    if (vid_resize == 1 || video_fullscreen)
+        return;
 
-    applyContentLayoutForCurrentState();
+    int newX = pos().x();
+    int newY = pos().y();
+
+    if (((frameGeometry().x() + event->size().width() + 1) > util::screenOfWidget(this)->availableGeometry().right())) {
+        //move(util::screenOfWidget(this)->availableGeometry().right() - size().width() - 1, pos().y());
+        newX = util::screenOfWidget(this)->availableGeometry().right() - frameGeometry().width() - 1;
+        if (newX < 1) newX = 1;
+    }
+
+    if (((frameGeometry().y() + event->size().height() + 1) > util::screenOfWidget(this)->availableGeometry().bottom())) {
+        newY = util::screenOfWidget(this)->availableGeometry().bottom() - frameGeometry().height() - 1;
+        if (newY < 1) newY = 1;
+    }
+    move(newX, newY);
 }
 
 void
@@ -1179,25 +1201,12 @@ MainWindow::showEvent(QShowEvent *event)
         monitors[0].mon_scrnsz_y = fixed_size_y;
     }
     if (window_remember && vid_resize == 1) {
-        const QSize target(window_w, window_h);
-        const QSize prevMin = ui->stackedWidget->minimumSize();
-        const QSize prevMax = ui->stackedWidget->maximumSize();
-
-        ui->stackedWidget->setMinimumSize(target);
-        ui->stackedWidget->setMaximumSize(target);
+        ui->stackedWidget->setFixedSize(window_w, window_h);
 #ifndef Q_OS_MACOS
         QApplication::processEvents();
 #endif
         this->adjustSize();
-
-        ui->stackedWidget->setMinimumSize(prevMin);
-        ui->stackedWidget->setMaximumSize(prevMax);
-        ui->stackedWidget->resize(target);
     }
-
-    QTimer::singleShot(0, this, [this]{
-        applyContentLayoutForCurrentState();
-    });
 }
 
 void
@@ -1500,7 +1509,6 @@ MainWindow::on_actionFullscreen_triggered()
 {
     if (video_fullscreen > 0) {
         showNormal();
-        QTimer::singleShot(0, this, [this]{ applyContentLayoutForCurrentState(); });
         ui->menubar->show();
         if (!hide_status_bar)
             ui->statusbar->show();
@@ -2138,7 +2146,16 @@ MainWindow::on_actionForce_4_3_display_ratio_triggered()
 {
     video_toggle_option(ui->actionForce_4_3_display_ratio, &force_43);
 
-    QTimer::singleShot(0, this, [this]{ applyContentLayoutForCurrentState(); });
+    // When turning on Force 4:3 in resizable mode, immediately snap to 4:3
+    if (vid_resize == 1 && !video_fullscreen) {
+        ui->stackedWidget->setFixedSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
+        if (force_43 > 0) {
+            adjustForForce43(size());
+        } else {
+            // Turning off: refresh renderer scaling
+            ui->stackedWidget->onResize(width(), height());
+        }
+    }
 }
 
 void
@@ -2507,3 +2524,4 @@ void MainWindow::on_actionCGA_composite_settings_triggered()
     isNonPause = false;
     config_save();
 }
+

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -2079,6 +2079,15 @@ void
 MainWindow::on_actionForce_4_3_display_ratio_triggered()
 {
     video_toggle_option(ui->actionForce_4_3_display_ratio, &force_43);
+    if (vid_resize) {
+        const auto widget = ui->stackedWidget->currentWidget();
+        ui->stackedWidget->onResize(widget->width(), widget->height());
+
+        for (int i = 1; i < MONITORS_NUM; i++) {
+            if (renderers[i])
+                renderers[i]->onResize(renderers[i]->width(), renderers[i]->height());
+        }
+    }
 }
 
 void

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -1020,71 +1020,11 @@ void MainWindow::updateShortcuts()
 	ui->actionMute_Unmute->setShortcut(seq);
 }
 		
-void 
-MainWindow::adjustToForce43(int suggestedW, int suggestedH)
-{
-    // Only in resizable window mode with Force 4:3, and not fullscreen
-    if (!(vid_resize == 1 && force_43 > 0) || video_fullscreen)
-        return;
-
-    static bool inAdjust = false;          // prevent recursion
-    if (inAdjust) return;
-    inAdjust = true;
-
-    // Make sure the render widget is allowed to stretch in resizable mode.
-    // (Normally this is done once via resizeContents, but that path is skipped in vid_resize==1.)
-    ui->stackedWidget->setFixedSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
-
-    const int frameExtra =
-        menuBar()->height() +
-        (hide_status_bar ? 0 : statusBar()->height()) +
-        (hide_tool_bar   ? 0 : ui->toolBar->height());
-
-    // Window size we’re trying to honor (may come from the QResizeEvent)
-    int winW = (suggestedW >= 0) ? suggestedW : width();
-    int winH = (suggestedH >= 0) ? suggestedH : height();
-
-    // Work in logical pixels consistent with the rest of the file
-    const double dpr = (!dpi_scale ? util::screenOfWidget(this)->devicePixelRatio() : 1.0);
-    int clientW = static_cast<int>(winW / dpr);
-    int clientH = static_cast<int>((winH - frameExtra) / dpr);
-    if (clientH < 1) clientH = 1;  // safety
-
-    // Fit a 4:3 box INSIDE the dragged rectangle
-    const int wForH = (clientH * 4) / 3;
-    const int hForW = (clientW * 3) / 4;
-    if (wForH <= clientW) clientW = wForH; else clientH = hForW;
-
-    // Convert back to window size (device pixels + chrome)
-    const int newWinW = static_cast<int>(clientW * dpr);
-    const int newWinH = static_cast<int>(clientH * dpr) + frameExtra;
-
-    if (newWinW != winW || newWinH != winH)
-        this->resize(newWinW, newWinH);
-
-    // Keep the emulator’s notion of the requested screen size in sync
-    monitors[0].mon_scrnsz_x = clientW;
-    monitors[0].mon_scrnsz_y = clientH;
-
-    // Notify both paths used elsewhere
-    ui->stackedWidget->onResize(width(), height());     // re-compute scale in the renderer
-    plat_resize_request(clientW, clientH, /*monitor_index=*/0);
-
-    inAdjust = false;
-}
-		
 void
 MainWindow::resizeEvent(QResizeEvent *event)
 {
     //qDebug() << pos().x() + event->size().width();
     //qDebug() << pos().y() + event->size().height();
-	
-    // Enforce 4:3 while dragging in resizable mode
-    if (vid_resize == 1 && force_43 > 0 && !video_fullscreen) {
-        adjustToForce43(event->size().width(), event->size().height());
-        return; // we’ve already applied the corrected size & notified core
-    }
-	
     if (vid_resize == 1 || video_fullscreen)
         return;
 
@@ -2139,18 +2079,6 @@ void
 MainWindow::on_actionForce_4_3_display_ratio_triggered()
 {
     video_toggle_option(ui->actionForce_4_3_display_ratio, &force_43);
-
-    if (vid_resize == 1 && !video_fullscreen) {
-        // Ensure the render widget can stretch in resizable mode
-        ui->stackedWidget->setFixedSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
-        if (force_43 > 0) {
-            // Snap to 4:3 now
-            adjustToForce43(); // uses current window size
-        } else {
-            // Turning OFF: reflow the renderer to current window size
-            ui->stackedWidget->onResize(width(), height());
-        }
-    }
 }
 
 void

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -178,9 +178,7 @@ private:
     std::unique_ptr<MachineStatus> status;
     std::shared_ptr<MediaMenu>     mm;
 
-    static bool s_adjustingForce43; // guard against recursion
-	void adjustForForce43(const QSize &newWinSize);
-    
+    void adjustToForce43(int suggestedW = -1, int suggestedH = -1);
 	void updateShortcuts();
     void     processKeyboardInput(bool down, uint32_t keycode);
 #ifdef Q_OS_MACOS

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -179,8 +179,8 @@ private:
     std::shared_ptr<MediaMenu>     mm;
 
     static bool s_adjustingForce43; // guard against recursion
-    void applyContentLayoutForCurrentState();
-
+	void adjustForForce43(const QSize &newWinSize);
+    
 	void updateShortcuts();
     void     processKeyboardInput(bool down, uint32_t keycode);
 #ifdef Q_OS_MACOS

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -178,7 +178,6 @@ private:
     std::unique_ptr<MachineStatus> status;
     std::shared_ptr<MediaMenu>     mm;
 
-    void adjustToForce43(int suggestedW = -1, int suggestedH = -1);
 	void updateShortcuts();
     void     processKeyboardInput(bool down, uint32_t keycode);
 #ifdef Q_OS_MACOS

--- a/src/qt/qt_renderercommon.cpp
+++ b/src/qt/qt_renderercommon.cpp
@@ -129,9 +129,10 @@ RendererCommon::onResize(int width, int height)
     width = round(pixelRatio * width);
     height = round(pixelRatio * height);
 
-    if (is_fs && (video_fullscreen_scale_maximized ? (parent_max && main_is_max) : 1))
+    if (is_fs && (video_fullscreen_scale_maximized ? (parent_max && main_is_max) : 1) && !(force_43 && vid_resize))
         destination.setRect(0, 0, width, height);
     else {
+        auto   temp_fullscreen_scale = video_fullscreen_scale;
         double dx;
         double dy;
         double dw;
@@ -144,13 +145,18 @@ RendererCommon::onResize(int width, int height)
         double gh  = source.height();
         double hsr = hw / hh;
         double r43 = 4.0 / 3.0;
+        
+        if (force_43 && is_fs && vid_resize) {
+            if (!video_fullscreen_scale_maximized || (video_fullscreen_scale_maximized && parent_max && main_is_max))
+                temp_fullscreen_scale = FULLSCR_SCALE_43;
+        }
 
-        switch (video_fullscreen_scale) {
+        switch (temp_fullscreen_scale) {
             case FULLSCR_SCALE_INT:
             case FULLSCR_SCALE_INT43:
                 gsr = gw / gh;
 
-                if (video_fullscreen_scale == FULLSCR_SCALE_INT43) {
+                if (temp_fullscreen_scale == FULLSCR_SCALE_INT43) {
                     gh = gw / r43;
 //                  gw = gw;
 
@@ -174,7 +180,7 @@ RendererCommon::onResize(int width, int height)
                 break;
             case FULLSCR_SCALE_43:
             case FULLSCR_SCALE_KEEPRATIO:
-                if (video_fullscreen_scale == FULLSCR_SCALE_43)
+                if (temp_fullscreen_scale == FULLSCR_SCALE_43)
                     gsr = r43;
                 else
                     gsr = gw / gh;


### PR DESCRIPTION
Summary
=======
Implement Force 4:3 option for resizable windows with fullscreen stretching behaviour.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
