### PR TITLE
Use the correct onboard ViRGE device for the TC430HX

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -14413,7 +14413,7 @@ const machine_t machines[] = {
         .kbd_device               = NULL,
         .fdc_device               = NULL,
         .sio_device               = NULL,
-        .vid_device               = &s3_virge_375_pci_device,
+        .vid_device               = &s3_virge_375_onboard_pci_device,
         .snd_device               = &ymf701_device,
         .net_device               = NULL
     },


### PR DESCRIPTION
Summary
=======
Use the correct onboard variant of the S3 ViRGE/DX on the TC430HX machines. This allows the onboard video to use the correct PCI slot and also resolves the Toshiba Infinia 7xx1 starting up in 16-color VGA mode on first boot (due to it needing to redetect the ViRGE) after using the recovery CD.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
