### PR TITLE
Make renderer window a native widget

### DIFF
--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -1053,7 +1053,7 @@
  <customwidgets>
   <customwidget>
    <class>RendererStack</class>
-   <extends>QStackedWidget</extends>
+   <extends>QWidget</extends>
    <header>qt_rendererstack.hpp</header>
    <container>1</container>
   </customwidget>

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -88,10 +88,16 @@ HWND   rw_hwnd;
 #endif
 
 RendererStack::RendererStack(QWidget *parent, int monitor_index)
-    : QStackedWidget(parent)
+    : QWidget(parent)
+    , boxLayout(new QBoxLayout(QBoxLayout::TopToBottom, this))
     , ui(new Ui::RendererStack)
 {
+    boxLayout->setContentsMargins(0, 0, 0, 0);
     setAttribute(Qt::WA_AcceptTouchEvents, true);
+#ifdef Q_OS_WINDOWS
+    setAttribute(Qt::WA_NativeWindow, true);
+    (void)winId();
+#endif
     rendererTakesScreenshots = false;
 #ifdef Q_OS_WINDOWS
     int raw = 1;
@@ -187,6 +193,7 @@ RendererStack::mouseReleaseEvent(QMouseEvent *event)
     rw_hwnd        = (HWND) this->winId();                
 #endif
 
+    event->accept();
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     if (!dopause && this->geometry().contains(m_monitor_index >= 1 ? event->globalPosition().toPoint() : event->position().toPoint()) &&
 #else
@@ -346,7 +353,7 @@ RendererStack::switchRenderer(Renderer renderer)
     switchInProgress = true;
     if (current) {
         rendererWindow->finalize();
-        removeWidget(current.get());
+        boxLayout->removeWidget(current.get());
         disconnect(this, &RendererStack::blitToRenderer, nullptr, nullptr);
 
         /* Create new renderer only after previous is destroyed! */
@@ -442,9 +449,9 @@ RendererStack::createRenderer(Renderer renderer)
     current->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     current->setStyleSheet("background-color: black");
     current->setAttribute(Qt::WA_AlwaysStackOnTop);
-    addWidget(current.get());
 
     this->setStyleSheet("background-color: black");
+    boxLayout->addWidget(current.get());
 
     rendererWindow->r_monitor_index = m_monitor_index;
 
@@ -536,7 +543,7 @@ RendererStack::event(QEvent* event)
                 if (mouse_x_abs > 1) mouse_x_abs = 1;
                 if (mouse_y_abs > 1) mouse_y_abs = 1;
             }
-            return QStackedWidget::event(event);
+            return QWidget::event(event);
         }
 
 #ifdef Q_OS_WINDOWS
@@ -559,7 +566,7 @@ RendererStack::event(QEvent* event)
 
             if (mouse_x_abs > 1) mouse_x_abs = 1;
             if (mouse_y_abs > 1) mouse_y_abs = 1;
-            return QStackedWidget::event(event);
+            return QWidget::event(event);
         }
 #endif
 
@@ -679,10 +686,10 @@ RendererStack::event(QEvent* event)
         }
 
         default:
-            return QStackedWidget::event(event);
+            return QWidget::event(event);
     }
 
-    return QStackedWidget::event(event);
+    return QWidget::event(event);
 }
 
 void

--- a/src/qt/qt_rendererstack.hpp
+++ b/src/qt/qt_rendererstack.hpp
@@ -4,7 +4,8 @@
 #include <QDialog>
 #include <QEvent>
 #include <QKeyEvent>
-#include <QStackedWidget>
+#include <QLayout>
+#include <QBoxLayout>
 #include <QWidget>
 #include <QCursor>
 #include <QScreen>
@@ -29,7 +30,7 @@ extern "C"
 }
 
 class RendererCommon;
-class RendererStack : public QStackedWidget {
+class RendererStack : public QWidget {
     Q_OBJECT
 
 public:
@@ -98,6 +99,8 @@ public:
     void setFocusRenderer();
     void onResize(int width, int height);
 
+    QWidget* currentWidget() { return current.get(); }
+
     void (*mouse_capture_func)(QWindow *window) = nullptr;
     void (*mouse_uncapture_func)()              = nullptr;
 
@@ -135,6 +138,8 @@ private:
 
     std::atomic_bool rendererTakesScreenshots;
     std::atomic_bool switchInProgress{false};
+
+    QBoxLayout* boxLayout = nullptr;
 
     char auto_mouse_type[16];
 };

--- a/src/qt/qt_rendererstack.ui
+++ b/src/qt/qt_rendererstack.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>RendererStack</class>
- <widget class="QStackedWidget" name="RendererStack">
+ <widget class="QWidget" name="RendererStack">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>StackedWidget</string>
+   <string>RendererWidget</string>
   </property>
  </widget>
  <resources/>


### PR DESCRIPTION
Summary
=======
Make renderer window a native widget

Remove QStackedWidget usage, switch to normal QWidget

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
