### PR TITLE
Run as many frames as possible without "pinging" the host timers

### DIFF
--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -459,32 +459,34 @@ main_thread_fn()
             drawits += static_cast<int>(new_time - old_time);
         old_time = new_time;
         if (drawits > 0 && !dopause) {
-            /* Yes, so do one frame now. */
-            drawits -= force_10ms ? 10 : 1;
-            if (drawits > 50)
-                drawits = 0;
+            /* Yes, so run frames now. */
+            do {
+#ifdef USE_INSTRUMENT
+                uint64_t start_time = elapsed_timer.nsecsElapsed();
+#endif
+                /* Run a block of code. */
+                pc_run();
 
 #ifdef USE_INSTRUMENT
-            uint64_t start_time = elapsed_timer.nsecsElapsed();
+                if (instru_enabled) {
+                    uint64_t elapsed_us       = (elapsed_timer.nsecsElapsed() - start_time) / 1000;
+                    uint64_t total_elapsed_ms = (uint64_t) ((double) tsc / cpu_s->rspeed * 1000);
+                    printf("[instrument] %llu, %llu\n", total_elapsed_ms, elapsed_us);
+                    if (instru_run_ms && total_elapsed_ms >= instru_run_ms)
+                        break;
+                }
 #endif
-            /* Run a block of code. */
-            pc_run();
-
-#ifdef USE_INSTRUMENT
-            if (instru_enabled) {
-                uint64_t elapsed_us       = (elapsed_timer.nsecsElapsed() - start_time) / 1000;
-                uint64_t total_elapsed_ms = (uint64_t) ((double) tsc / cpu_s->rspeed * 1000);
-                printf("[instrument] %llu, %llu\n", total_elapsed_ms, elapsed_us);
-                if (instru_run_ms && total_elapsed_ms >= instru_run_ms)
-                    break;
-            }
-#endif
-            /* Every 2 emulated seconds we save the machine status. */
-            if (++frames >= (force_10ms ? 200 : 2000) && nvr_dosave) {
-                qt_nvr_save();
-                nvr_dosave = 0;
-                frames     = 0;
-            }
+                /* Every 2 emulated seconds we save the machine status. */
+                if (++frames >= (force_10ms ? 200 : 2000) && nvr_dosave) {
+                    qt_nvr_save();
+                    nvr_dosave = 0;
+                    frames     = 0;
+                }
+                
+                drawits -= force_10ms ? 10 : 1;
+                if (drawits > 50)
+                    drawits = 0;
+            } while (drawits > 0);
         } else {
             /* Just so we dont overload the host OS. */
 


### PR DESCRIPTION
Summary
=======
Run as many frames as possible without "pinging" the host timers if the CPU thread experiences lagging.

It should improve performance for certain Intel/AMD platforms with botched HPET/TSC implementations.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
