### PR TITLE
Rename "Sony Vaio PCV-90" to "Sony Vaio PCV-70/90/100/120"

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -14511,7 +14511,7 @@ const machine_t machines[] = {
        Command 0xA0 copyright string: (C)1994 AMI .
        Yes, this is an Intel AMI BIOS with a fancy splash screen. */
     {
-        .name              = "[i430HX] Sony Vaio PCV-90",
+        .name              = "[i430HX] Sony Vaio PCV-70/90/100/120",
         .internal_name     = "pcv90",
         .type              = MACHINE_TYPE_SOCKET7,
         .chipset           = MACHINE_CHIPSET_INTEL_430HX,


### PR DESCRIPTION
Summary
=======
The machine name "Sony Vaio PCV-90" will be renamed to "Sony Vaio PCV-70/90/100/120".

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://theretroweb.com/motherboards/s/intel-ag430hx-agate
