### PR TITLE
Provide AC97 codec for MSI MS-6147

### DIFF
--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -893,7 +893,7 @@ machine_at_ms6147_init(const machine_t *model)
 
     if (sound_card_current[0] == SOUND_INTERNAL) {
         device_add(machine_get_snd_device(machine));
-        device_add(&es1371_onboard_device);
+        device_add(&ct1297_device);
     }
 
     return ret;


### PR DESCRIPTION
Summary
=======
Provide AC97 codec for MSI MS-6147.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
