### PR TITLE
Add ATi WinCharger (ATi Mach64CT) emulation

### DIFF
--- a/src/include/86box/video.h
+++ b/src/include/86box/video.h
@@ -332,6 +332,7 @@ extern void da2_device_add(void);
 extern const device_t mach64gx_isa_device;
 extern const device_t mach64gx_vlb_device;
 extern const device_t mach64gx_pci_device;
+extern const device_t mach64ct_device;
 extern const device_t mach64vt2_device;
 
 /* ATi 18800 */

--- a/src/video/vid_ati_mach64.c
+++ b/src/video/vid_ati_mach64.c
@@ -48,6 +48,7 @@
 #define BIOS_ROM_PATH     "roms/video/mach64/bios.bin"
 #define BIOS_ISA_ROM_PATH "roms/video/mach64/M64-1994.VBI"
 #define BIOS_VLB_ROM_PATH "roms/video/mach64/mach64_vlb_vram.bin"
+#define BIOS_ROMCT_PATH   "roms/video/mach64/mach64-68b110b8cddfd546595673.bin"
 #define BIOS_ROMVT2_PATH  "roms/video/mach64/atimach64vt2pci.bin"
 
 #define FIFO_SIZE         65536
@@ -75,6 +76,7 @@ typedef struct fifo_entry_t {
 
 enum {
     MACH64_GX = 0,
+    MACH64_CT,
     MACH64_VT2
 };
 
@@ -2580,7 +2582,7 @@ mach64_ext_readb(uint32_t addr, void *priv)
 
             case 0xc7:
                 READ8(addr, mach64->dac_cntl);
-                if (mach64->type >= MACH64_VT2) {
+                if (mach64->type >= MACH64_CT) {
                     ret &= 0xf9;
                     if (i2c_gpio_get_scl(mach64->i2c))
                         ret |= 0x04;
@@ -2600,7 +2602,7 @@ mach64_ext_readb(uint32_t addr, void *priv)
             case 0xdd:
             case 0xde:
             case 0xdf:
-                if (mach64->type == MACH64_GX)
+                if (mach64->type != MACH64_VT2)
                     mach64->config_cntl = (mach64->config_cntl & ~0x3ff0) | ((mach64->linear_base >> 22) << 4);
                 else
                     mach64->config_cntl = (mach64->config_cntl & ~0x3ff0) | ((mach64->linear_base >> 24) << 4);
@@ -4703,19 +4705,19 @@ mach64_pci_read(UNUSED(int func), int addr, void *priv)
             return mach64->linear_base >> 24;
 
         case 0x14:
-            if (mach64->type >= MACH64_VT2)
+            if (mach64->type >= MACH64_CT)
                 return 0x01; /*Block decoded IO address*/
             return 0x00;
         case 0x15:
-            if (mach64->type >= MACH64_VT2)
+            if (mach64->type >= MACH64_CT)
                 return mach64->block_decoded_io >> 8;
             return 0x00;
         case 0x16:
-            if (mach64->type >= MACH64_VT2)
+            if (mach64->type >= MACH64_CT)
                 return mach64->block_decoded_io >> 16;
             return 0x00;
         case 0x17:
-            if (mach64->type >= MACH64_VT2)
+            if (mach64->type >= MACH64_CT)
                 return mach64->block_decoded_io >> 24;
             return 0x00;
 
@@ -4759,7 +4761,7 @@ mach64_pci_write(UNUSED(int func), int addr, uint8_t val, void *priv)
             break;
 
         case 0x12:
-            if (mach64->type >= MACH64_VT2)
+            if (mach64->type >= MACH64_CT)
                 val = 0;
             mach64->linear_base = (mach64->linear_base & 0xff000000) | ((val & 0x80) << 16);
             mach64_updatemapping(mach64);
@@ -4770,7 +4772,7 @@ mach64_pci_write(UNUSED(int func), int addr, uint8_t val, void *priv)
             break;
 
         case 0x15:
-            if (mach64->type >= MACH64_VT2) {
+            if (mach64->type >= MACH64_CT) {
                 if (mach64->pci_regs[PCI_REG_COMMAND] & PCI_COMMAND_IO)
                     mach64_io_remove(mach64);
                 mach64->block_decoded_io = (mach64->block_decoded_io & 0xffff0000) | ((val & 0xff) << 8);
@@ -4779,7 +4781,7 @@ mach64_pci_write(UNUSED(int func), int addr, uint8_t val, void *priv)
             }
             break;
         case 0x16:
-            if (mach64->type >= MACH64_VT2) {
+            if (mach64->type >= MACH64_CT) {
                 if (mach64->pci_regs[PCI_REG_COMMAND] & PCI_COMMAND_IO)
                     mach64_io_remove(mach64);
                 mach64->block_decoded_io = (mach64->block_decoded_io & 0xff00fc00) | (val << 16);
@@ -4788,7 +4790,7 @@ mach64_pci_write(UNUSED(int func), int addr, uint8_t val, void *priv)
             }
             break;
         case 0x17:
-            if (mach64->type >= MACH64_VT2) {
+            if (mach64->type >= MACH64_CT) {
                 if (mach64->pci_regs[PCI_REG_COMMAND] & PCI_COMMAND_IO)
                     mach64_io_remove(mach64);
                 mach64->block_decoded_io = (mach64->block_decoded_io & 0x00fffc00) | (val << 24);
@@ -4820,7 +4822,7 @@ mach64_pci_write(UNUSED(int func), int addr, uint8_t val, void *priv)
             if (mach64->pci_regs[PCI_REG_COMMAND] & PCI_COMMAND_IO)
                 mach64_io_remove(mach64);
             mach64->io_base = val & 0x03;
-            if (mach64->type >= MACH64_VT2)
+            if (mach64->type >= MACH64_CT)
                 mach64->use_block_decoded_io = val & 0x04;
             if (mach64->pci_regs[PCI_REG_COMMAND] & PCI_COMMAND_IO)
                 mach64_io_set(mach64);
@@ -4841,7 +4843,7 @@ mach64_common_init(const device_t *info)
     svga = &mach64->svga;
 
     mach64->type = info->local & 0xff;
-    mach64->vram_size = (info->local & (1 << 20)) ? 4 : device_get_config_int("memory");
+    mach64->vram_size = (mach64->type == MACH64_CT) ? 2 : ((info->local & (1 << 20)) ? 4 : device_get_config_int("memory"));
     mach64->vram_mask = (mach64->vram_size << 20) - 1;
 
     if (mach64->type > MACH64_GX)
@@ -4932,6 +4934,37 @@ mach64gx_init(const device_t *info)
     return mach64;
 }
 static void *
+mach64ct_init(const device_t *info)
+{
+    mach64_t *mach64 = mach64_common_init(info);
+    svga_t   *svga   = &mach64->svga;
+
+    svga->dac_hwcursor_draw = NULL;
+
+    svga->hwcursor.cur_ysize = 64;
+    svga->hwcursor.cur_xsize = 64;
+
+    video_inform(VIDEO_FLAG_TYPE_SPECIAL, &timing_mach64_pci);
+
+    mach64->pci                  = 1;
+    mach64->vlb                  = 0;
+    mach64->pci_id               = 'T' | ('C' << 8);
+    mach64->config_chip_id       = mach64->pci_id;
+    mach64->dac_cntl             = 1 << 16; /*Internal 24-bit DAC*/
+    mach64->config_stat0         = 4;
+    mach64->use_block_decoded_io = 4;
+
+    ati_eeprom_load(&mach64->eeprom, "mach64ct.nvr", 1);
+
+    rom_init(&mach64->bios_rom, BIOS_ROMCT_PATH, 0xc0000, 0x8000, 0x7fff, 0, MEM_MAPPING_EXTERNAL);
+
+    mem_mapping_disable(&mach64->bios_rom.mapping);
+
+    svga->vblank_start = mach64_vblank_start;
+
+    return mach64;
+}
+static void *
 mach64vt2_init(const device_t *info)
 {
     mach64_t *mach64 = mach64_common_init(info);
@@ -4977,6 +5010,11 @@ int
 mach64gx_vlb_available(void)
 {
     return rom_present(BIOS_VLB_ROM_PATH);
+}
+int
+mach64ct_available(void)
+{
+    return rom_present(BIOS_ROMCT_PATH);
 }
 int
 mach64vt2_available(void)
@@ -5100,6 +5138,20 @@ const device_t mach64gx_pci_device = {
     .speed_changed = mach64_speed_changed,
     .force_redraw  = mach64_force_redraw,
     .config        = mach64gx_config
+};
+
+const device_t mach64ct_device = {
+    .name          = "ATI WinCharger (ATI Mach64CT)",
+    .internal_name = "mach64ct",
+    .flags         = DEVICE_PCI,
+    .local         = MACH64_CT,
+    .init          = mach64ct_init,
+    .close         = mach64_close,
+    .reset         = NULL,
+    .available     = mach64ct_available,
+    .speed_changed = mach64_speed_changed,
+    .force_redraw  = mach64_force_redraw,
+    .config        = NULL
 };
 
 const device_t mach64vt2_device = {

--- a/src/video/vid_table.c
+++ b/src/video/vid_table.c
@@ -185,6 +185,7 @@ video_cards[] = {
     { .device = &mach32_pci_device,                             .flags = VIDEO_FLAG_TYPE_8514 },
     { .device = &mach64gx_pci_device,                           .flags = VIDEO_FLAG_TYPE_NONE },
     { .device = &mach64vt2_device,                              .flags = VIDEO_FLAG_TYPE_NONE },
+    { .device = &mach64ct_device,                               .flags = VIDEO_FLAG_TYPE_NONE },
     { .device = &bochs_svga_device,                             .flags = VIDEO_FLAG_TYPE_NONE },
     { .device = &chips_69000_device,                            .flags = VIDEO_FLAG_TYPE_NONE },
     { .device = &gd5430_pci_device,                             .flags = VIDEO_FLAG_TYPE_NONE },


### PR DESCRIPTION
Summary
=======
Add ATi WinCharger (ATi Mach64CT) emulation.

Tested with July 1996 drivers for Windows 95.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [X] This pull request requires changes to the ROM set
  * [X] I have opened a roms pull request - https://github.com/86Box/roms/pull/399/

References
==========
None.
