### PR TITLE
Update machine_table.c

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -15142,7 +15142,7 @@ const machine_t machines[] = {
        PC87306 Super I/O chip, command 0xA1 returns '5'.
        Command 0xA0 copyright string: (C)1994 AMI . */
     {
-        .name              = "[i430VX] Packard Bell Multimedia C110 (PB680/PB682/PB685)",
+        .name              = "[i430VX] Packard Bell PB680/PB682/PB685",
         .internal_name     = "pb680",
         .type              = MACHINE_TYPE_SOCKET7,
         .chipset           = MACHINE_CHIPSET_INTEL_430VX,
@@ -15188,7 +15188,7 @@ const machine_t machines[] = {
     /* Has a SM(S)C FDC37C935 Super I/O chip with on-chip KBC with Phoenix
        MultiKey/42 (version 1.38) KBC firmware. */
     {
-        .name              = "[i430VX] Packard Bell Multimedia M415 (PB810)",
+        .name              = "[i430VX] Packard Bell PB810/820 (GVC/BCM FM530)",
         .internal_name     = "pb810",
         .type              = MACHINE_TYPE_SOCKET7,
         .chipset           = MACHINE_CHIPSET_INTEL_430VX,


### PR DESCRIPTION
Rename Packard Bell motherboards to be in line with the actual board names. Currently 86box is using model numbers of machines they were found in, but this list is not all inclusive, and so this is a more accurate way to describe each board.

Summary
=======
_Briefly describe what you are submitting._ See Above

Checklist
=========
* [ ] Closes #5601 
* [ ] I have tested my changes locally and validated that the functionality works as intended
References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
Just renamed text contents.