### PR TITLE
Correct the internal name of on-board ATI Mach64CT device

### DIFF
--- a/src/video/vid_ati_mach64.c
+++ b/src/video/vid_ati_mach64.c
@@ -5225,7 +5225,7 @@ const device_t mach64ct_device = {
 
 const device_t mach64ct_device_onboard = {
     .name          = "ATI Mach64CT (On-Board)",
-    .internal_name = "mach64ct",
+    .internal_name = "mach64ct_onboard",
     .flags         = DEVICE_PCI,
     .local         = MACH64_CT | (1 << 19),
     .init          = mach64ct_init,


### PR DESCRIPTION
Summary
=======
Correct the internal name of on-board ATI Mach64CT device.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
