### PR TITLE
Resize renderer view back on Windows on language selection changes

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -2306,7 +2306,14 @@ MainWindow::changeEvent(QEvent *event)
 {
 #ifdef Q_OS_WINDOWS
     if (event->type() == QEvent::LanguageChange) {
+        auto size = this->centralWidget()->size();
         QApplication::setFont(QFont(ProgSettings::getFontName(lang_id), 9));
+        QApplication::processEvents();
+        main_window->centralWidget()->setFixedSize(size);
+        QApplication::processEvents();
+        if (vid_resize == 1) {
+            main_window->centralWidget()->setFixedSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
+        }
     }
 #endif
     QWidget::changeEvent(event);

--- a/src/qt/qt_progsettings.cpp
+++ b/src/qt/qt_progsettings.cpp
@@ -20,6 +20,7 @@
 #include "ui_qt_mainwindow.h"
 #include "qt_machinestatus.hpp"
 
+#include <QTimer>
 #include <QMap>
 #include <QDir>
 #include <QFile>
@@ -36,6 +37,7 @@ extern "C" {
 #include <86box/plat.h>
 #include <86box/mem.h>
 #include <86box/rom.h>
+#include <86box/video.h>
 }
 
 extern MainWindow            *main_window;
@@ -107,6 +109,7 @@ ProgSettings::ProgSettings(QWidget *parent)
 void
 ProgSettings::accept()
 {
+    auto size               = main_window->centralWidget()->size();
     lang_id                 = ui->comboBoxLanguage->currentData().toInt();
     open_dir_usr_path       = ui->openDirUsrPath->isChecked() ? 1 : 0;
     confirm_exit            = ui->checkBoxConfirmExit->isChecked() ? 1 : 0;
@@ -137,6 +140,13 @@ ProgSettings::accept()
     connect(main_window, &MainWindow::statusBarMessage, main_window->status.get(), &MachineStatus::message, Qt::QueuedConnection);
     mouse_sensitivity = mouseSensitivity;
     config_save_global();
+    QTimer::singleShot(200, [size] () {
+        main_window->centralWidget()->setFixedSize(size);
+        QApplication::processEvents();
+        if (vid_resize == 1) {
+            main_window->centralWidget()->setFixedSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
+        }
+    });
     QDialog::accept();
 }
 


### PR DESCRIPTION
Summary
=========
Resize renderer view back on Windows on language selection changes

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None.
