### PR TITLE
Use correct BIOSes for Intel Advanced/MA (Monaco)

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -959,8 +959,11 @@ extern int             machine_at_vectra54_init(const machine_t *);
 extern const device_t  thor_device;
 #endif
 extern int             machine_at_thor_init(const machine_t *);
+extern uint32_t        machine_at_monaco_gpio_handler(uint8_t write, uint32_t val);
+extern int             machine_at_monaco_init(const machine_t *);
 extern uint32_t        machine_at_endeavor_gpio_handler(uint8_t write, uint32_t val);
 extern int             machine_at_endeavor_init(const machine_t *);
+extern int             machine_at_atlantis_init(const machine_t *);
 extern int             machine_at_monaco_init(const machine_t *);
 extern int             machine_at_ms5119_init(const machine_t *);
 extern int             machine_at_pb640_init(const machine_t *);

--- a/src/machine/m_at_socket7_3v.c
+++ b/src/machine/m_at_socket7_3v.c
@@ -427,6 +427,80 @@ machine_at_endeavor_gpio_handler(uint8_t write, uint32_t val)
     return ret;
 }
 
+static void
+machine_at_monaco_gpio_init(void)
+{
+    uint32_t gpio = 0xffffe0cf;
+    uint16_t addr;
+
+    /* Return to this after CS4232 PnP is working. */
+    /* Register 0x0078 (Undocumented): */
+    /* Bit 5,4: Vibra 16S base address: 0 = 220h, 1 = 260h, 2 = 240h, 3 = 280h. */
+    /*device_context(machine_get_snd_device(machine));
+    addr = device_get_config_hex16("base");
+    switch (addr) {
+        case 0x0220:
+            gpio |= 0xffff00cf;
+            break;
+        case 0x0240:
+            gpio |= 0xffff00ef;
+            break;
+        case 0x0260:
+            gpio |= 0xffff00df;
+            break;
+        case 0x0280:
+            gpio |= 0xffff00ff;
+            break;
+    }
+    device_context_restore();*/
+
+    /* Register 0x0079: */
+    /* Bit 7: 0 = Clear password, 1 = Keep password. */
+    /* Bit 6: 0 = NVRAM cleared by jumper, 1 = NVRAM normal. */
+    /* Bit 5: 0 = CMOS Setup disabled, 1 = CMOS Setup enabled. */
+    /* Bit 4: External CPU clock (Switch 8). */
+    /* Bit 3: External CPU clock (Switch 7). */
+    /*        50 MHz: Switch 7 = Off, Switch 8 = Off. */
+    /*        60 MHz: Switch 7 = On, Switch 8 = Off. */
+    /*        66 MHz: Switch 7 = Off, Switch 8 = On. */
+    /* Bit 2: 0 = On-board audio absent, 1 = On-board audio present. */
+    /* Bit 1: 0 = Soft-off capable power supply present, 1 = Soft-off capable power supply absent. */
+    /* Bit 0: 0 = 2x multiplier, 1 = 1.5x multiplier (Switch 6). */
+    /* NOTE: A bit is read as 1 if switch is off, and as 0 if switch is on. */
+    if (cpu_busspeed <= 50000000)
+        gpio |= 0xffff0000;
+    else if ((cpu_busspeed > 50000000) && (cpu_busspeed <= 60000000))
+        gpio |= 0xffff0800;
+    else if (cpu_busspeed > 60000000)
+        gpio |= 0xffff1000;
+
+    if (sound_card_current[0] == SOUND_INTERNAL)
+        gpio |= 0xffff0400;
+
+    if (cpu_dmulti <= 1.5)
+        gpio |= 0xffff0100;
+    else
+        gpio |= 0xffff0000;
+
+    machine_set_gpio_default(gpio);
+}
+
+uint32_t
+machine_at_monaco_gpio_handler(uint8_t write, uint32_t val)
+{
+    uint32_t ret = machine_get_gpio_default();
+
+    if (write) {
+        ret &= ((val & 0xffffffcf) | 0xffff0000);
+        ret |= (val & 0x00000030);
+
+        machine_set_gpio(ret);
+    } else
+        ret = machine_get_gpio();
+
+    return ret;
+}
+
 int
 machine_at_endeavor_init(const machine_t *model)
 {
@@ -465,14 +539,13 @@ machine_at_endeavor_init(const machine_t *model)
     return ret;
 }
 
-
 int
-machine_at_monaco_init(const machine_t *model)
+machine_at_atlantis_init(const machine_t *model)
 {
     int ret;
 
-    ret = bios_load_linear_combined("roms/machines/monaco/1007CL0_.BIO",
-                                    "roms/machines/monaco/1007CL0_.BI1",
+    ret = bios_load_linear_combined("roms/machines/atlantis/1007CL0_.BIO",
+                                    "roms/machines/atlantis/1007CL0_.BI1",
                                     0x20000, 128);
 
     if (bios_only || !ret)
@@ -502,6 +575,43 @@ machine_at_monaco_init(const machine_t *model)
 
     return ret;
 }
+
+int
+machine_at_monaco_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear_combined("roms/machines/monaco/1007BU0_.BIO",
+                                    "roms/machines/monaco/1007BU0_.BI1",
+                                    0x20000, 128);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_common_init_ex(model, 2);
+    machine_at_monaco_gpio_init();
+
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x0B, PCI_CARD_VIDEO,       1, 2, 3, 4);
+    pci_register_slot(0x11, PCI_CARD_NORMAL,      1, 3, 2, 4);
+    pci_register_slot(0x13, PCI_CARD_NORMAL,      2, 1, 3, 4);
+
+    if (gfxcard[0] == VID_INTERNAL)
+        device_add(machine_get_vid_device(machine));
+
+    if (sound_card_current[0] == SOUND_INTERNAL)
+        machine_snd = device_add(machine_get_snd_device(machine));
+
+    device_add(&i430fx_device);
+    device_add(&piix_device);
+    device_add_params(&pc87306_device, (void *) PCX730X_AMI);
+    device_add(&intel_flash_bxt_ami_device);
+
+    return ret;
+}
+
 int
 machine_at_ms5119_init(const machine_t *model)
 {

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -13428,13 +13428,59 @@ const machine_t machines[] = {
        PC87306 Super I/O chip, command 0xA1 returns '5'.
        Command 0xA0 copyright string: (C)1994 AMI . */
     {
+        .name              = "[i430FX] Intel Advanced/AS (Atlantis)",
+        .internal_name     = "atlantis",
+        .type              = MACHINE_TYPE_SOCKET7_3V,
+        .chipset           = MACHINE_CHIPSET_INTEL_430FX,
+        .init              = machine_at_atlantis_init,
+        .p1_handler        = machine_generic_p1_handler,
+        .gpio_handler      = NULL,
+        .available_flag    = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu               = {
+            .package     = CPU_PKG_SOCKET5_7,
+            .block       = CPU_BLOCK(CPU_K5, CPU_5K86, CPU_Cx6x86),
+            .min_bus     = 50000000,
+            .max_bus     = 66666667,
+            .min_voltage = 3380,
+            .max_voltage = 3520,
+            .min_multi   = 1.5,
+            .max_multi   = 3.0
+        },
+        .bus_flags = MACHINE_PS2_PCI,
+        .flags     = MACHINE_IDE_DUAL | MACHINE_VIDEO | MACHINE_APM,  /* Machine has onboard sound: Crystal CS4232-KQ */
+        .ram       = {
+            .min  = 8192,
+            .max  = 131072,
+            .step = 8192
+        },
+        .nvrmask                  = 255,
+        .jumpered_ecp_dma         = MACHINE_DMA_3,
+        .default_jumpered_ecp_dma = 3,
+        .kbc_device               = NULL,
+        .kbc_params               = 0x00000000,
+        .kbc_p1                   = 0x000044f0,
+        .gpio                     = 0xffffffff,
+        .gpio_acpi                = 0xffffffff,
+        .device                   = NULL,
+        .kbd_device               = NULL,
+        .fdc_device               = NULL,
+        .sio_device               = NULL,
+        .vid_device               = &mach64ct_device_onboard,
+        .snd_device               = NULL,
+        .net_device               = NULL
+    },
+    /* According to tests from real hardware: This has AMI MegaKey KBC firmware on the
+       PC87306 Super I/O chip, command 0xA1 returns '5'.
+       Command 0xA0 copyright string: (C)1994 AMI . */
+    {
         .name              = "[i430FX] Intel Advanced/MA (Monaco)",
         .internal_name     = "monaco",
         .type              = MACHINE_TYPE_SOCKET7_3V,
         .chipset           = MACHINE_CHIPSET_INTEL_430FX,
         .init              = machine_at_monaco_init,
         .p1_handler        = machine_generic_p1_handler,
-        .gpio_handler      = NULL,
+        .gpio_handler      = machine_at_monaco_gpio_handler,
         .available_flag    = MACHINE_AVAILABLE,
         .gpio_acpi_handler = NULL,
         .cpu               = {


### PR DESCRIPTION
Summary
=======
Use correct BIOSes for Intel Advanced/MA (Monaco)

Existing one is renamed to Intel Advanced/AS (Atlantis)

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [X] This pull request requires changes to the ROM set
  * [X] I have opened a roms pull request - https://github.com/86Box/roms/pull/404/

References
==========
None.
