### PR TITLE
Memory detection fixes for IBM PS/2 machines

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -3105,7 +3105,7 @@ const machine_t machines[] = {
         .flags     = MACHINE_XTA | MACHINE_VIDEO_FIXED,
         .ram       = {
             .min  = 512,
-            .max  = 16384,
+            .max  = 4096,
             .step = 512
         },
         .nvrmask                  = 127,
@@ -4959,7 +4959,7 @@ const machine_t machines[] = {
         .flags     = MACHINE_VIDEO,
         .ram       = {
             .min  = 1024,
-            .max  = 10240,
+            .max  = 12288,
             .step = 1024
         },
         .nvrmask                  = 63,


### PR DESCRIPTION
Summary
=======
IBM uses special 30-pin SIMM with presence detection pins on ISA PS/2 Model 30-286 and the MCA PS/2 Model 50/60 machines, and use I/O port 103h to report installed SIMM types on PS/2 Model 50/60. This commit fixes 164 errors using original reference disk for Model 50/60 with 1MB memory. I/O port 103h information comes from PS/2 model 50 schematics.

Checklist
=========
* [x] Closes #5984
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[IBM PS/2 30-pin SIMM Pinout](https://www.ardent-tool.com/IBM_SCSI/SIMM_30_Mod.html)
[IBM PS/2 model 50 Schematics](https://www.ardent-tool.com/docs/pdf/schematics/m50_sch.pdf)
[IBM PS/2 model 30-286 Schematics](https://www.ardent-tool.com/docs/pdf/schematics/m30-286_sch.pdf)
[IBM PS/2 model 30-286 Announcement Letter](https://www.ardent-tool.com/8530/189-091.txt)
