### PR TITLE
Add DFI K6BV3+ (rev. A+) motherboard

### DIFF
--- a/src/include/86box/flash.h
+++ b/src/include/86box/flash.h
@@ -29,6 +29,7 @@ extern const device_t sst_flash_29ee020_device;
 
 extern const device_t winbond_flash_w29c512_device;
 extern const device_t winbond_flash_w29c010_device;
+extern const device_t winbond_flash_w29c011a_device;
 extern const device_t winbond_flash_w29c020_device;
 extern const device_t winbond_flash_w29c040_device;
 

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -1110,6 +1110,7 @@ extern int             machine_at_delhi3_init(const machine_t *);
 extern int             machine_at_mvp3_init(const machine_t *);
 extern int             machine_at_ficva503a_init(const machine_t *);
 extern int             machine_at_5emapro_init(const machine_t *);
+extern int             machine_at_k6bv3p_a_init(const machine_t *);
 
 /* SiS 5591 */
 extern int             machine_at_5sg100_init(const machine_t *);

--- a/src/machine/m_at_sockets7.c
+++ b/src/machine/m_at_sockets7.c
@@ -430,6 +430,37 @@ machine_at_5emapro_init(const machine_t *model)
     return ret;
 }
 
+int
+machine_at_k6bv3p_a_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/k6bv3p_a/KB3A0805.BIN",
+                           0x000e0000, 131072, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_common_init_ex(model, 2);
+
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 1, 2, 3, 5);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 5);
+    pci_register_slot(0x08, PCI_CARD_NORMAL,      1, 2, 3, 5);
+    pci_register_slot(0x09, PCI_CARD_NORMAL,      2, 3, 5, 1);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL,      3, 5, 1, 2);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL,      5, 1, 2, 3);
+    pci_register_slot(0x01, PCI_CARD_AGPBRIDGE,   1, 2, 3, 5);
+
+    device_add(&via_mvp3_device);
+    device_add(&via_vt82c586b_device);
+    device_add_params(&fdc37c669_device, (void *) 0); /* jmi2k: what's that param? */
+    device_add(&winbond_flash_w29c011a_device);
+    spd_register(SPD_TYPE_SDRAM, 0x7, 256);
+
+    return ret;
+}
+
 /* SiS 5591 */
 int
 machine_at_5sg100_init(const machine_t *model)

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -11578,7 +11578,7 @@ const machine_t machines[] = {
         .snd_device               = NULL,
         .net_device               = NULL
     },
-    /* The M5Pi appears to have a Phoenix MultiKey KBC firmware according to photos. */	
+    /* The M5Pi appears to have a Phoenix MultiKey KBC firmware according to photos. */
     {
         .name              = "[i430LX] Micronics M5Pi",
         .internal_name     = "m5pi",
@@ -12999,7 +12999,7 @@ const machine_t machines[] = {
             .min  = 4096,
             .max  = 131072,
             .step = 4096
-        }, 
+        },
         .nvrmask = 127,
         .jumpered_ecp_dma = MACHINE_DMA_USE_CONFIG,
         .default_jumpered_ecp_dma = -1,
@@ -16896,6 +16896,51 @@ const machine_t machines[] = {
             .min  = 8192,
             .max  = 786432,
             .step = 8192
+        },
+        .nvrmask                  = 255,
+        .jumpered_ecp_dma         = 0,
+        .default_jumpered_ecp_dma = -1,
+        .kbc_device               = NULL,
+        .kbc_params               = 0x00000000,
+        .kbc_p1                   = 0x00000cf0,
+        .gpio                     = 0xffffffff,
+        .gpio_acpi                = 0xffffffff,
+        .device                   = NULL,
+        .kbd_device               = NULL,
+        .fdc_device               = NULL,
+        .sio_device               = NULL,
+        .vid_device               = NULL,
+        .snd_device               = NULL,
+        .net_device               = NULL
+    },
+    /* Has the VIA VT82C586B southbridge with on-chip KBC identical to the VIA
+       VT82C42N. */
+    {
+        .name              = "[VIA MVP3] DFI K6BV3+ (rev. A+)",
+        .internal_name     = "k6bv3p_a",
+        .type              = MACHINE_TYPE_SOCKETS7,
+        .chipset           = MACHINE_CHIPSET_VIA_APOLLO_MVP3,
+        .init              = machine_at_k6bv3p_a_init,
+        .p1_handler        = machine_generic_p1_handler,
+        .gpio_handler      = NULL,
+        .available_flag    = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu               = {
+            .package     = CPU_PKG_SOCKET5_7,
+            .block       = CPU_BLOCK_NONE,
+            .min_bus     = 66666667,
+            .max_bus     = 100000000,
+            .min_voltage = 2000,
+            .max_voltage = 3500,
+            .min_multi   = 1.5,
+            .max_multi   = 5.5
+        },
+        .bus_flags = MACHINE_PS2_AGP | MACHINE_BUS_USB,
+        .flags     = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
+        .ram       = {
+            .min  = 16384,
+            .max  = 786432,
+            .step = 16384
         },
         .nvrmask                  = 255,
         .jumpered_ecp_dma         = 0,

--- a/src/mem/sst_flash.c
+++ b/src/mem/sst_flash.c
@@ -127,6 +127,7 @@ static char flash_path[1024];
 #define WINBOND     0xda /* Winbond Manufacturer's ID */
 #define W29C512     0xc800
 #define W29C010     0xc100
+#define W29C011A    0xc100
 #define W29C020     0x4500
 #define W29C040     0x4600
 
@@ -613,6 +614,20 @@ const device_t winbond_flash_w29c010_device = {
     .internal_name = "winbond_flash_w29c010",
     .flags         = 0,
     .local         = WINBOND | W29C010 | SIZE_1M,
+    .init          = sst_init,
+    .close         = sst_close,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = NULL
+};
+
+const device_t winbond_flash_w29c011a_device = {
+    .name          = "Winbond W29C011A Flash BIOS",
+    .internal_name = "winbond_flash_w29c011a",
+    .flags         = 0,
+    .local         = WINBOND | W29C011A | SIZE_1M,
     .init          = sst_init,
     .close         = sst_close,
     .reset         = NULL,


### PR DESCRIPTION
Summary
=======
This PR adds support for the DFI K6BV3+ (rev. A) motherboard, a Super Socket 7 board.

Checklist
=========
* [ ] ~Closes #xxx~
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - [https://github.com/86Box/roms/pull/408/](https://github.com/86Box/roms/pull/408/)

References
==========
[Entry on The Retro Web](https://theretroweb.com/motherboards/s/dfi-k6bv3-rev.a)
