### PR TITLE
Two machine name changes + 2 misc. changes (October 11)

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -12432,7 +12432,7 @@ const machine_t machines[] = {
         .net_device               = NULL
     },
     {
-        .name = "[i430FX] IBM PC 330/350 type 65x6 (Intel Advanced/MN OEM)",
+        .name = "[i430FX] IBM PC 3x0 (type 65x6) (Morrison64)",
         .internal_name = "pc330_65x6",
         .type = MACHINE_TYPE_SOCKET5,
         .chipset = MACHINE_CHIPSET_INTEL_430FX,
@@ -13061,7 +13061,7 @@ const machine_t machines[] = {
     },
     /* Has a VIA KBC chip */
     {
-        .name              = "[VLSI SuperCore] DFI G586VPM Rev C",
+        .name              = "[VLSI SuperCore] DFI G586VPM (rev. C)",
         .internal_name     = "g586vpmc",
         .type              = MACHINE_TYPE_SOCKET5,
         .chipset           = MACHINE_CHIPSET_VLSI_SUPERCORE,
@@ -16520,14 +16520,14 @@ const machine_t machines[] = {
         .cpu               = {
             .package     = CPU_PKG_SOCKET5_7,
             .block       = CPU_BLOCK_NONE,
-            .min_bus     = 66666667,
+            .min_bus     = 60000000,
             .max_bus     = 100000000,
-            .min_voltage = 2000,
+            .min_voltage = 1300,
             .max_voltage = 3520,
-            .min_multi   = 1.5,
+            .min_multi   = 2.0,
             .max_multi   = 5.5
         },
-        .bus_flags = MACHINE_PS2_PCIONLY | MACHINE_BUS_USB,
+        .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags     = MACHINE_IDE_DUAL | MACHINE_SOUND | MACHINE_APM | MACHINE_ACPI | MACHINE_GAMEPORT | MACHINE_USB, /* Has internal video: ATI 3D Rage Pro Turbo AGP and sound: Ensoniq ES1373 */
         .ram       = {
             .min  = 8192,
@@ -16776,6 +16776,51 @@ const machine_t machines[] = {
         .snd_device               = NULL,
         .net_device               = NULL
     },
+    /* Has the VIA VT82C586B southbridge with on-chip KBC identical to the VIA
+       VT82C42N. */
+    {
+        .name              = "[VIA MVP3] DFI K6BV3+ (rev. A+)",
+        .internal_name     = "k6bv3p_a",
+        .type              = MACHINE_TYPE_SOCKETS7,
+        .chipset           = MACHINE_CHIPSET_VIA_APOLLO_MVP3,
+        .init              = machine_at_k6bv3p_a_init,
+        .p1_handler        = machine_generic_p1_handler,
+        .gpio_handler      = NULL,
+        .available_flag    = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu               = {
+            .package     = CPU_PKG_SOCKET5_7,
+            .block       = CPU_BLOCK_NONE,
+            .min_bus     = 66666667,
+            .max_bus     = 100000000,
+            .min_voltage = 2000,
+            .max_voltage = 3500,
+            .min_multi   = 1.5,
+            .max_multi   = 5.5
+        },
+        .bus_flags = MACHINE_PS2_AGP | MACHINE_BUS_USB,
+        .flags     = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
+        .ram       = {
+            .min  = 16384,
+            .max  = 786432,
+            .step = 16384
+        },
+        .nvrmask                  = 255,
+        .jumpered_ecp_dma         = 0,
+        .default_jumpered_ecp_dma = -1,
+        .kbc_device               = NULL,
+        .kbc_params               = 0x00000000,
+        .kbc_p1                   = 0x00000cf0,
+        .gpio                     = 0xffffffff,
+        .gpio_acpi                = 0xffffffff,
+        .device                   = NULL,
+        .kbd_device               = NULL,
+        .fdc_device               = NULL,
+        .sio_device               = NULL,
+        .vid_device               = NULL,
+        .snd_device               = NULL,
+        .net_device               = NULL
+    },
     /* Has the VIA VT82C596A southbridge with on-chip KBC identical to the VIA
        VT82C42N. Sadly likely abuses cache on Cyrix 6x86MX and MII CPUs (Cyrix MII being what most socket 7 eMachines PCs used) , so they are blocked and it's thus named after the only known eMachines with an AMD K6-2 CPU here */
     {
@@ -16939,51 +16984,6 @@ const machine_t machines[] = {
             .min  = 8192,
             .max  = 786432,
             .step = 8192
-        },
-        .nvrmask                  = 255,
-        .jumpered_ecp_dma         = 0,
-        .default_jumpered_ecp_dma = -1,
-        .kbc_device               = NULL,
-        .kbc_params               = 0x00000000,
-        .kbc_p1                   = 0x00000cf0,
-        .gpio                     = 0xffffffff,
-        .gpio_acpi                = 0xffffffff,
-        .device                   = NULL,
-        .kbd_device               = NULL,
-        .fdc_device               = NULL,
-        .sio_device               = NULL,
-        .vid_device               = NULL,
-        .snd_device               = NULL,
-        .net_device               = NULL
-    },
-    /* Has the VIA VT82C586B southbridge with on-chip KBC identical to the VIA
-       VT82C42N. */
-    {
-        .name              = "[VIA MVP3] DFI K6BV3+ (rev. A+)",
-        .internal_name     = "k6bv3p_a",
-        .type              = MACHINE_TYPE_SOCKETS7,
-        .chipset           = MACHINE_CHIPSET_VIA_APOLLO_MVP3,
-        .init              = machine_at_k6bv3p_a_init,
-        .p1_handler        = machine_generic_p1_handler,
-        .gpio_handler      = NULL,
-        .available_flag    = MACHINE_AVAILABLE,
-        .gpio_acpi_handler = NULL,
-        .cpu               = {
-            .package     = CPU_PKG_SOCKET5_7,
-            .block       = CPU_BLOCK_NONE,
-            .min_bus     = 66666667,
-            .max_bus     = 100000000,
-            .min_voltage = 2000,
-            .max_voltage = 3500,
-            .min_multi   = 1.5,
-            .max_multi   = 5.5
-        },
-        .bus_flags = MACHINE_PS2_AGP | MACHINE_BUS_USB,
-        .flags     = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
-        .ram       = {
-            .min  = 16384,
-            .max  = 786432,
-            .step = 16384
         },
         .nvrmask                  = 255,
         .jumpered_ecp_dma         = 0,


### PR DESCRIPTION
Summary
=======
1. Slightly changed the name for the IBM PC 3x0 (type 65x6), with the addition of its codename
2. Slightly changed the revision name to the DFI G586VPM
3. Corrected the configuration for Gateway Lucas according to MSI MS-5185's manual, as well as bringing the ISA slot to it (despite Lucas not having a ISA slot, it can be installed to it)
4. Alphabetize the DFI K6BV3+

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[MSI MS-5185 User's Manual](https://theretroweb.com/motherboard/manual/ms-5185-user-manual-605d9d25153be767942938.pdf)
