### PR TITLE
A small fix for Gateway Lucas

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -16524,7 +16524,7 @@ const machine_t machines[] = {
             .max_bus     = 100000000,
             .min_voltage = 1300,
             .max_voltage = 3520,
-            .min_multi   = 2.0,
+            .min_multi   = 1.5,
             .max_multi   = 5.5
         },
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,


### PR DESCRIPTION
Summary
=======
This just fixes minimum multiplier on Gateway Lucas and change it back to 1.5x.
This brings back some CPU speeds that were lost (via #6319) on that machine.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
