### PR TITLE
add Multitech PC-900 BIOS ROM V2.07B and V3.01B

### DIFF
--- a/src/machine/m_at_286.c
+++ b/src/machine/m_at_286.c
@@ -367,7 +367,26 @@ static const device_config_t pc900_config[] = {
                 .local          = 0,
                 .size           = 32768,
                 .files          = { "roms/machines/pc900/cbm_pc40_v207a_xc.bin", "" }
-            }
+            },
+            {
+                .name           = "BIOS V2.07B",
+                .internal_name  = "pc900_v207b",
+                .bios_type      = BIOS_NORMAL,
+                .files_no       = 1,
+                .local          = 0,
+                .size           = 32768,
+                .files          = { "roms/machines/pc900/mpf_pc900_v207b.bin", "" }
+            },
+            {
+                .name           = "BIOS V3.01B",
+                .internal_name  = "pc900_v301b",
+                .bios_type      = BIOS_NORMAL,
+                .files_no       = 1,
+                .local          = 0,
+                .size           = 32768,
+                .files          = { "roms/machines/pc900/cbm_pc40_v301b.bin", "" }
+            },
+            { .files_no = 0 }
         },
     },
     { .name = "", .description = "", .type = CONFIG_END }


### PR DESCRIPTION
Summary
=======
add Multitech PC-900 / Commodore PC 40 BIOS ROM V2.07B and V3.01B

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/413#issue-3516859354

References
==========
[zimmers.net](https://www.zimmers.net/anonftp/pub/cbm-pc/ALLFILES.html)