### PR TITLE
Revert a MS-6106 memory change and added note

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -17433,7 +17433,7 @@ const machine_t machines[] = {
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
         .flags     = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_USB, /* Machine has internal SCSI: Adaptec AIC-7880U */
         .ram       = {
-            .min  = 8192,
+            .min  = 40960, /* does not POST with lower than 40MB; Award and AMI retail BIOSes not affected(?) */
             .max  = 524288,
             .step = 8192
         },


### PR DESCRIPTION
Summary
=======
This fixes the POST failure (black screen with beeps) due to a memory error when using memory lower than 40MB. For now, revert back to 40MB and add a note about its AMIBIOS and AwardBIOS retail versions are not affected.

Addresses #6347 

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
