### PR TITLE
Properly fix the workaround for OpenGL 3.0-3.1

### DIFF
--- a/src/qt/qt_openglrenderer.cpp
+++ b/src/qt/qt_openglrenderer.cpp
@@ -42,6 +42,8 @@ extern MainWindow* main_window;
 #include <QImage>
 
 #include <cmath>
+#include <cstdarg>
+#define HAVE_STDARG_H
 
 #include "qt_openglrenderer.hpp"
 #include "qt_openglshadermanagerdialog.hpp"
@@ -152,7 +154,7 @@ ogl3_log(const char *fmt, ...)
 
     if (ogl3_do_log) {
         va_start(ap, fmt);
-        ogl3_log_ex(fmt, ap);
+        pclog_ex(fmt, ap);
         va_end(ap);
     }
 }
@@ -219,10 +221,7 @@ OpenGLRenderer::compile_shader(GLenum shader_type, const char *prepend, const ch
         snprintf(version, 49, "%s\n", versionRegex.match(progSource).captured(1).toLatin1().data());
         progSource.remove(versionRegex);
     } else {
-        version_loc = ((char *) this->glslVersion.toLatin1().data()) + 9;
-        char glsl_ver[4] = { 0 };
-        memcpy(glsl_ver, version_loc, 3);
-        int ver = atoi((char *) glsl_ver);
+        int ver = gl_version[0] * 100 + gl_version[1] * 10;
         if (ver == 300)
             ver = 130;
         else if (ver == 310)
@@ -875,11 +874,11 @@ OpenGLRenderer::initialize()
         glw.initializeOpenGLFunctions();
 
         ogl3_log("OpenGL information: [%s] %s (%s)\n", glw.glGetString(GL_VENDOR), glw.glGetString(GL_RENDERER), glw.glGetString(GL_VERSION));
-        glsl_version[0] = glsl_version[1] = -1;
-        glw.glGetIntegerv(GL_MAJOR_VERSION, &glsl_version[0]);
-        glw.glGetIntegerv(GL_MINOR_VERSION, &glsl_version[1]);
-        if (glsl_version[0] < 3) {
-            throw opengl_init_error(tr("OpenGL version 3.0 or greater is required. Current GLSL version is %1.%2").arg(glsl_version[0]).arg(glsl_version[1]));
+        gl_version[0] = gl_version[1] = -1;
+        glw.glGetIntegerv(GL_MAJOR_VERSION, &gl_version[0]);
+        glw.glGetIntegerv(GL_MINOR_VERSION, &gl_version[1]);
+        if (gl_version[0] < 3) {
+            throw opengl_init_error(tr("OpenGL version 3.0 or greater is required. Current GLSL version is %1.%2").arg(gl_version[0]).arg(gl_version[1]));
         }
         ogl3_log("Using OpenGL %s\n", glw.glGetString(GL_VERSION));
         ogl3_log("Using Shading Language %s\n", glw.glGetString(GL_SHADING_LANGUAGE_VERSION));

--- a/src/qt/qt_openglrenderer.hpp
+++ b/src/qt/qt_openglrenderer.hpp
@@ -102,7 +102,7 @@ private:
 
     void *unpackBuffer = nullptr;
 
-    int glsl_version[2] = { 0, 0 };
+    int gl_version[2] = { 0, 0 };
 
     void initialize();
     void initializeExtensions();


### PR DESCRIPTION
Summary
=======
Fix the GLSL version workaround for OpenGL 3.0-3.1-only hosts not working due to incorrectly checking the GLSL version instead of the OpenGL version; rename the variable holding the OpenGL version appropriately.

Drive-by: Fix broken logging in qt_openglrenderer.cpp.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
<https://github.com/sarah-walker-pcem/pcem/blob/dev/src/wx-ui/wx-sdl2-video-gl3.c#L717-L720>