### PR TITLE
Support for PCjr keyboard IR reciever option

### DIFF
--- a/src/include/86box/m_pcjr.h
+++ b/src/include/86box/m_pcjr.h
@@ -68,6 +68,7 @@ typedef struct pcjr_s {
     uint8_t    pb;
 
     uint8_t    option_fdc;
+    uint8_t    option_ir;
 
     pc_timer_t send_delay_timer;
 

--- a/src/machine/m_pcjr.c
+++ b/src/machine/m_pcjr.c
@@ -667,6 +667,8 @@ kbd_read(uint16_t port, void *priv)
             ret |= (pcjr->data ? 0x40 : 0);
             if (pcjr->data)
                 ret |= 0x40;
+            if (pcjr->option_ir)
+                ret |= 0x80; /* Keyboard cable not connected */
             break;
 
         case 0xa0:
@@ -816,6 +818,19 @@ static const device_config_t pcjr_config[] = {
         .selection      = { { 0 } },
         .bios           = { { 0 } }
     },
+#if 0
+    {
+        .name           = "ir_reciever",
+        .description    = "Enable IR Reciever",
+        .type           = CONFIG_BINARY,
+        .default_string = NULL,
+        .default_int    = 0,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .selection      = { { 0 } },
+        .bios           = { { 0 } }
+    },
+#endif
     { .name = "", .description = "", .type = CONFIG_END }
     // clang-format on
 };
@@ -850,6 +865,11 @@ machine_pcjr_init(UNUSED(const machine_t *model))
     pcjr = calloc(1, sizeof(pcjr_t));
 
     pcjr->option_fdc = 0;
+#if 0
+    pcjr->option_ir  = device_get_config_int("ir_reciever");
+#else
+    pcjr->option_ir  = 0;
+#endif
 
     is_pcjr = 1;
 


### PR DESCRIPTION

Summary
=======
Support for PCjr keyboard IR reciever option
Currently disabled as it Error B's

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None