### PR TITLE
Allow finer control of shader parameters

### DIFF
--- a/src/qt/qt_openglshaderconfig.cpp
+++ b/src/qt/qt_openglshaderconfig.cpp
@@ -27,6 +27,7 @@ OpenGLShaderConfig::OpenGLShaderConfig(QWidget *parent, glslp_t* shader)
 
     for (int i = 0; i < currentShader->num_parameters; i++) {
         auto spinBox = new QDoubleSpinBox;
+        spinBox->setDecimals(3);
         spinBox->setObjectName(currentShader->parameters[i].id);
         spinBox->setRange(currentShader->parameters[i].min, currentShader->parameters[i].max);
         spinBox->setValue(currentShader->parameters[i].value);


### PR DESCRIPTION
Summary
=======
Changed the default 2 decimal places to 3 decimal places for shaders requiring that level of control.

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
NA
