### PR TITLE
Add proper clock generators to the V7 cards.

### DIFF
--- a/src/include/86box/vid_svga.h
+++ b/src/include/86box/vid_svga.h
@@ -449,6 +449,8 @@ extern void    ibm_rgb528_hwcursor_draw(svga_t *svga, int displine);
 extern float   ibm_rgb528_getclock(int clock, void *priv);
 extern void    ibm_rgb528_ramdac_set_ref_clock(void *priv, svga_t *svga, float ref_clock);
 
+extern float icd2047_getclock(int clock, void *priv);
+
 extern void  icd2061_write(void *priv, int val);
 extern float icd2061_getclock(int clock, void *priv);
 extern void  icd2061_set_ref_clock(void *priv, float ref_clock);
@@ -457,7 +459,12 @@ extern void  icd2061_set_ref_clock(void *priv, float ref_clock);
 #    define ics9161_write    icd2061_write
 #    define ics9161_getclock icd2061_getclock
 
+extern float ics1494_getclock(int clock, void *priv);
+
 extern float ics2494_getclock(int clock, void *priv);
+
+extern float ics90c64a_vclk_getclock(int clock, void *priv);
+extern float ics90c64a_mclk_getclock(int clock, void *priv);
 
 extern void   ics2595_write(void *priv, int strobe, int dat);
 extern double ics2595_getclock(void *priv);
@@ -507,6 +514,8 @@ extern const device_t att20c505_ramdac_device;
 extern const device_t bt485a_ramdac_device;
 extern const device_t gendac_ramdac_device;
 extern const device_t ibm_rgb528_ramdac_device;
+extern const device_t ics1494m_540_device;
+extern const device_t ics1494m_540_radius_ht209_device;
 extern const device_t ics2494an_305_device;
 extern const device_t ics2494an_324_device;
 extern const device_t ati18810_28800_device;
@@ -516,7 +525,9 @@ extern const device_t ati18810_mach32_device;
 extern const device_t ati18811_0_mach32_device;
 extern const device_t ati18811_1_mach32_device;
 extern const device_t ics2595_device;
+extern const device_t icd2047_20_device;
 extern const device_t icd2061_device;
+extern const device_t ics90c64a_903_device;
 extern const device_t ics9161_device;
 extern const device_t sc11483_ramdac_device;
 extern const device_t sc11487_ramdac_device;

--- a/src/video/CMakeLists.txt
+++ b/src/video/CMakeLists.txt
@@ -38,9 +38,12 @@ add_library(vid OBJECT
 
     # Clock generator chips 
     clockgen/vid_clockgen_av9194.c 
+    clockgen/vid_clockgen_icd2047.c
     clockgen/vid_clockgen_icd2061.c
+    clockgen/vid_clockgen_ics1494.c 
     clockgen/vid_clockgen_ics2494.c 
     clockgen/vid_clockgen_ics2595.c
+    clockgen/vid_clockgen_ics90c64a.c
 
     # DDC / monitor identification stuff
     vid_ddc.c

--- a/src/video/clockgen/vid_clockgen_icd2047.c
+++ b/src/video/clockgen/vid_clockgen_icd2047.c
@@ -1,0 +1,131 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          ICD2047 clock generator emulation.
+ *
+ *          Used by the V7 chips.
+ *
+ * Authors: TheCollector1995.
+ *
+ *          Copyright 2025 TheCollector1995.
+ */
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+#define HAVE_STDARG_H
+#include <86box/86box.h>
+#include <86box/device.h>
+
+typedef struct icd2047_t {
+    float freq[32];
+} icd2047_t;
+
+#ifdef ENABLE_ICD2047_LOG
+int icd2047_do_log = ENABLE_ICD2047_LOG;
+
+static void
+icd2047_log(const char *fmt, ...)
+{
+    va_list ap;
+
+    if (icd2047_do_log) {
+        va_start(ap, fmt);
+        pclog_ex(fmt, ap);
+        va_end(ap);
+    }
+}
+#else
+#    define icd2047_log(fmt, ...)
+#endif
+
+float
+icd2047_getclock(int clock, void *priv)
+{
+    const icd2047_t *icd2047 = (icd2047_t *) priv;
+
+    if (clock > 31)
+        clock = 31;
+
+    return icd2047->freq[clock];
+}
+
+static void *
+icd2047_init(const device_t *info)
+{
+    icd2047_t *icd2047 = (icd2047_t *) malloc(sizeof(icd2047_t));
+    memset(icd2047, 0, sizeof(icd2047_t));
+
+    switch (info->local) {
+        case 20:
+            /* ICD2047-20 for Headland series */
+            icd2047->freq[0x00] = 25175000.0;
+            icd2047->freq[0x01] = 28322000.0;
+            icd2047->freq[0x02] = 40000000.0;
+            icd2047->freq[0x03] = 32500000.0;
+            icd2047->freq[0x04] = 50350000.0;
+            icd2047->freq[0x05] = 65000000.0;
+            icd2047->freq[0x06] = 38000000.0;
+            icd2047->freq[0x07] = 44900000.0;
+            icd2047->freq[0x08] = 25175000.0;
+            icd2047->freq[0x09] = 28322000.0;
+            icd2047->freq[0x0a] = 80000000.0;
+            icd2047->freq[0x0b] = 32500000.0;
+            icd2047->freq[0x0c] = 50350000.0;
+            icd2047->freq[0x0d] = 65000000.0;
+            icd2047->freq[0x0e] = 76000000.0;
+            icd2047->freq[0x0f] = 44900000.0;
+            icd2047->freq[0x10] = 25175000.0;
+            icd2047->freq[0x11] = 44900000.0;
+            icd2047->freq[0x12] = 28322000.0;
+            icd2047->freq[0x13] = 38000000.0;
+            icd2047->freq[0x14] = 40000000.0;
+            icd2047->freq[0x15] = 46000000.0;
+            icd2047->freq[0x16] = 48000000.0;
+            icd2047->freq[0x17] = 60000000.0;
+            icd2047->freq[0x18] = 65000000.0;
+            icd2047->freq[0x19] = 72000000.0;
+            icd2047->freq[0x1a] = 74000000.0;
+            icd2047->freq[0x1b] = 76000000.0;
+            icd2047->freq[0x1c] = 78000000.0;
+            icd2047->freq[0x1d] = 80000000.0;
+            icd2047->freq[0x1e] = 100000000.0;
+            icd2047->freq[0x1f] = 110000000.0;
+            break;
+
+        default:
+            break;
+    }
+
+    return icd2047;
+}
+
+static void
+icd2047_close(void *priv)
+{
+    icd2047_t *icd2047 = (icd2047_t *) priv;
+
+    if (icd2047)
+        free(icd2047);
+}
+
+const device_t icd2047_20_device = {
+    .name          = "ICD2047-20 Clock Generator",
+    .internal_name = "icd2047_20",
+    .flags         = 0,
+    .local         = 20,
+    .init          = icd2047_init,
+    .close         = icd2047_close,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = NULL
+};

--- a/src/video/clockgen/vid_clockgen_ics1494.c
+++ b/src/video/clockgen/vid_clockgen_ics1494.c
@@ -1,0 +1,157 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          ICS1494 clock generator emulation.
+ *
+ *          Used by the V7 and PVGA chips.
+ *
+ * Authors: TheCollector1995.
+ *
+ *          Copyright 2025 TheCollector1995.
+ */
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+#define HAVE_STDARG_H
+#include <86box/86box.h>
+#include <86box/device.h>
+
+typedef struct ics1494_t {
+    float freq[32];
+} ics1494_t;
+
+#ifdef ENABLE_ICS1494_LOG
+int ics1494_do_log = ENABLE_ICS1494_LOG;
+
+static void
+ics1494_log(const char *fmt, ...)
+{
+    va_list ap;
+
+    if (ics1494_do_log) {
+        va_start(ap, fmt);
+        pclog_ex(fmt, ap);
+        va_end(ap);
+    }
+}
+#else
+#    define ics1494_log(fmt, ...)
+#endif
+
+float
+ics1494_getclock(int clock, void *priv)
+{
+    const ics1494_t *ics1494 = (ics1494_t *) priv;
+
+    if (clock > 31)
+        clock = 31;
+
+    return ics1494->freq[clock];
+}
+
+static void *
+ics1494_init(const device_t *info)
+{
+    ics1494_t *ics1494 = (ics1494_t *) malloc(sizeof(ics1494_t));
+    memset(ics1494, 0, sizeof(ics1494_t));
+
+    switch (info->local) {
+        case 540:
+            /* ICS1494(M)-540 for Radius series */
+            ics1494->freq[0x00] = 57283000.0;
+            ics1494->freq[0x01] = 12273000.0;
+            ics1494->freq[0x02] = 14500000.0;
+            ics1494->freq[0x03] = 15667000.0;
+            ics1494->freq[0x04] = 112000000.0;
+            ics1494->freq[0x05] = 126000000.0;
+            ics1494->freq[0x06] = 30240000.0;
+            ics1494->freq[0x07] = 91200000.0;
+            ics1494->freq[0x08] = 120000000.0;
+            ics1494->freq[0x09] = 48000000.0;
+            ics1494->freq[0x0a] = 50675000.0;
+            ics1494->freq[0x0b] = 55300000.0;
+            ics1494->freq[0x0c] = 64000000.0;
+            ics1494->freq[0x0d] = 68750000.0;
+            ics1494->freq[0x0e] = 88500000.0;
+            ics1494->freq[0x0f] = 51270000.0;
+            ics1494->freq[0x10] = 100000000.0;
+            ics1494->freq[0x11] = 95200000.0;
+            ics1494->freq[0x12] = 55000000.0;
+            ics1494->freq[0x13] = 60000000.0;
+            ics1494->freq[0x14] = 63000000.0;
+            ics1494->freq[0x15] = 99522000.0;
+            ics1494->freq[0x16] = 130000000.0;
+            ics1494->freq[0x17] = 80000000.0;
+            ics1494->freq[0x18] = 25175000.0;
+            ics1494->freq[0x19] = 28322000.0;
+            ics1494->freq[0x1a] = 48000000.0;
+            ics1494->freq[0x1b] = 76800000.0;
+            ics1494->freq[0x1c] = 38400000.0;
+            ics1494->freq[0x1d] = 43200000.0;
+            ics1494->freq[0x1e] = 61440000.0;
+            ics1494->freq[0x1f] = 0.0;
+            break;
+
+        case 541:
+            /* ICS1494(M)-540 for Radius HT209 */
+            ics1494->freq[0x00] = 25175000.0;
+            ics1494->freq[0x01] = 28322000.0;
+            ics1494->freq[0x02] = 61440000.0; /*FCLK*/
+            ics1494->freq[0x03] = 74000000.0; /*XRESM*/
+            ics1494->freq[0x04] = 50350000.0;
+            ics1494->freq[0x05] = 65000000.0;
+            ics1494->freq[0x06] = 37575000.0; /*FCLK*/
+            ics1494->freq[0x07] = 40000000.0;
+            break;
+
+        default:
+            break;
+    }
+
+    return ics1494;
+}
+
+static void
+ics1494_close(void *priv)
+{
+    ics1494_t *ics1494 = (ics1494_t *) priv;
+
+    if (ics1494)
+        free(ics1494);
+}
+
+const device_t ics1494m_540_device = {
+    .name          = "ICS2494M-540 Clock Generator",
+    .internal_name = "ics1494m_540",
+    .flags         = 0,
+    .local         = 540,
+    .init          = ics1494_init,
+    .close         = ics1494_close,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = NULL
+};
+
+const device_t ics1494m_540_radius_ht209_device = {
+    .name          = "ICS2494M-540 (Radius HT209) Clock Generator",
+    .internal_name = "ics1494m_540_radius_ht209",
+    .flags         = 0,
+    .local         = 541,
+    .init          = ics1494_init,
+    .close         = ics1494_close,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = NULL
+};

--- a/src/video/clockgen/vid_clockgen_ics90c64a.c
+++ b/src/video/clockgen/vid_clockgen_ics90c64a.c
@@ -1,0 +1,135 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          ICS90C64A clock generator emulation.
+ *
+ *          Used by the PVGA chips.
+ *
+ * Authors: TheCollector1995.
+ *
+ *          Copyright 2025 TheCollector1995.
+ */
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+#define HAVE_STDARG_H
+#include <86box/86box.h>
+#include <86box/device.h>
+
+typedef struct ics90c64a_t {
+    float freq[32];
+} ics90c64a_t;
+
+#ifdef ENABLE_ICS90C64A_LOG
+int ics90c64a_do_log = ENABLE_ICS90C64A_LOG;
+
+static void
+ics90c64a_log(const char *fmt, ...)
+{
+    va_list ap;
+
+    if (ics90c64a_do_log) {
+        va_start(ap, fmt);
+        pclog_ex(fmt, ap);
+        va_end(ap);
+    }
+}
+#else
+#    define ics90c64a_log(fmt, ...)
+#endif
+
+float
+ics90c64a_vclk_getclock(int clock, void *priv)
+{
+    const ics90c64a_t *ics90c64a = (ics90c64a_t *) priv;
+
+    if (clock > 15)
+        clock = 15;
+
+    return ics90c64a->freq[clock];
+}
+
+float
+ics90c64a_mclk_getclock(int clock, void *priv)
+{
+    const ics90c64a_t *ics90c64a = (ics90c64a_t *) priv;
+
+    if (clock > 7)
+        clock = 7;
+
+    return ics90c64a->freq[clock + 0x10];
+}
+
+static void *
+ics90c64a_init(const device_t *info)
+{
+    ics90c64a_t *ics90c64a = (ics90c64a_t *) malloc(sizeof(ics90c64a_t));
+    memset(ics90c64a, 0, sizeof(ics90c64a_t));
+
+    switch (info->local) {
+        case 903:
+            /* ICS90C64A-903 for PVGA chip series */
+            ics90c64a->freq[0x0] = 30000000.0;
+            ics90c64a->freq[0x1] = 77250000.0;
+            ics90c64a->freq[0x2] = 0.0;
+            ics90c64a->freq[0x3] = 80000000.0;
+            ics90c64a->freq[0x4] = 31500000.0;
+            ics90c64a->freq[0x5] = 36000000.0;
+            ics90c64a->freq[0x6] = 75000000.0;
+            ics90c64a->freq[0x7] = 50000000.0;
+            ics90c64a->freq[0x8] = 40000000.0;
+            ics90c64a->freq[0x9] = 50000000.0;
+            ics90c64a->freq[0xa] = 32000000.0;
+            ics90c64a->freq[0xb] = 44900000.0;
+            ics90c64a->freq[0xc] = 25175000.0;
+            ics90c64a->freq[0xd] = 28322000.0;
+            ics90c64a->freq[0xe] = 65000000.0;
+            ics90c64a->freq[0xf] = 36000000.0;
+
+            ics90c64a->freq[0x10] = 33000000.0;
+            ics90c64a->freq[0x11] = 49218000.0;
+            ics90c64a->freq[0x12] = 60000000.0;
+            ics90c64a->freq[0x13] = 30500000.0;
+            ics90c64a->freq[0x14] = 41612000.0;
+            ics90c64a->freq[0x15] = 37500000.0;
+            ics90c64a->freq[0x16] = 36000000.0;
+            ics90c64a->freq[0x17] = 44296000.0;
+            break;
+
+        default:
+            break;
+    }
+
+    return ics90c64a;
+}
+
+static void
+ics90c64a_close(void *priv)
+{
+    ics90c64a_t *ics90c64a = (ics90c64a_t *) priv;
+
+    if (ics90c64a)
+        free(ics90c64a);
+}
+
+const device_t ics90c64a_903_device = {
+    .name          = "ICS90C64A-903 Clock Generator",
+    .internal_name = "ics90c64a_903",
+    .flags         = 0,
+    .local         = 903,
+    .init          = ics90c64a_init,
+    .close         = ics90c64a_close,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = NULL
+};


### PR DESCRIPTION
Summary
=======
1. Add a variant of the ICS1494 clock generator specifically for the Radius HT209 card.
2. Add the ICD2047 clock generator to the HT216-32 card.
3. Add the previously missing 7.00 BIOS revision of the VGA 1024i HT208 card.

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [X] This pull request requires changes to the ROM set
  * [X] I have opened a roms pull request - https://github.com/86Box/roms/pull/419/

References
==========
[HT208 datasheet (Video 7 VGA 1024i)](http://www.bitsavers.org/components/video7/700-0242_V7_VGA_Technical_Reference_Manual_Jun88.pdf)
[HT209 datasheet](https://theretroweb.com/chip/documentation/ht209-databook-68573ec356899415256408.pdf)
[HT216-32 datasheet](https://theretroweb.com/chip/documentation/lsi-ht216-32-6845c790cb72f222021575.pdf)
[ICS Databook from 1995](https://www.rsp-italy.it/Electronics/Databooks/Integrated%20Circuit%20Systems/_contents/Integrated%20Circuit%20Systems%20Data%20Book%201995.pdf)
[ICS90c64A datasheet](http://www.bitsavers.org/components/westernDigital/_dataBooks/1992_SystemLogic_Imaging_Storage/11_ICS90C64.pdf)
