### PR TITLE
Use Realtek OID for RTL8139C+ [skip-ci]

### DIFF
--- a/src/network/net_rtl8139.c
+++ b/src/network/net_rtl8139.c
@@ -3257,14 +3257,9 @@ nic_init(const device_t *info)
     eep_data[1] = 0x10EC;
     eep_data[2] = 0x8139;
 
-    /* XXX: Get proper MAC addresses from real EEPROM dumps. OID taken from net_ne2000.c */
-#ifdef USE_REALTEK_OID
+    /* XXX: Get proper MAC addresses from real EEPROM dumps. OID is generic Realtek */
     eep_data[7] = 0xe000;
     eep_data[8] = 0x124c;
-#else
-    eep_data[7] = 0x1400;
-    eep_data[8] = 0x122a;
-#endif
     eep_data[9] = 0x1413;
 
     mac_bytes = (uint8_t *) &(eep_data[7]);


### PR DESCRIPTION
Summary
=======
Use Realtek OID for RTL8139C+, no reason why we shouldn't

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
None
