### PR TITLE
Change the P6SBA sensor readings, fixes BIOS setup hang on Leadtek 8000BX

### DIFF
--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -1039,11 +1039,8 @@ machine_at_p6sba_init(const machine_t *model)
     device_add_params(&w83977_device, (void *) (W83977TF | W83977_AMI | W83977_NO_NVR));
     device_add(&intel_flash_bxt_device);
     spd_register(SPD_TYPE_SDRAM, 0x7, 256);
-    device_add(&w83781d_device);    /* fans: CPU1, CPU2, Thermal Control; temperatures: unused, CPU1, CPU2? */
-    hwm_values.fans[1]         = 0; /* no CPU2 fan */
-    hwm_values.temperatures[0] = 0; /* unused */
-    hwm_values.temperatures[2] = 0; /* CPU2? */
-    /* no CPU2 voltage */
+    device_add(&w83781d_device);    /* fans: CPU1, CPU2, Thermal Control; temperatures: unused, CPU1, CPU2 */
+    hwm_values.voltages[1] = 3300; /* Seems to be the I/O voltage, reported as "CPUi/o" in the Leadtek BIOS and "CPU2" in the SuperMicro BIOS */
 
     return ret;
 }


### PR DESCRIPTION
Summary
=======
Change the hardware monitor sensor readings in the P6SBA machine table entry to fix the hang while entering Chipset Features Menu in the BIOS Setup of the Leadtek 8000BX.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
Results of my own testing with different sensor values.