### PR TITLE
PCjr: Fix inverted horizontal screen movement

### DIFF
--- a/src/video/vid_pcjr.c
+++ b/src/video/vid_pcjr.c
@@ -269,7 +269,7 @@ vid_get_h_overscan_delta(pcjr_t *pcjr)
             break;
     }
 
-    ret = pcjr->crtc[0x02] - def;
+    ret = def - pcjr->crtc[0x02];
 
     if (ret < -8)
         ret = -8;


### PR DESCRIPTION
Summary
=======
The IBM PCjr allows for horizontal screen movement using the `Ctrl + Alt + Left/Right Arrow Keys` shortcut.
Currently, it's inverted:
- `Ctrl + Alt + Left` moves the screen right (should move left)
- `Ctrl + Alt + Right` moves the screen left (should move right)

The section “Centering Information on the Screen” in the [IBM PCjr Guide To Operations](https://archive.org/details/ibm-pcjr-guide-to-operations/page/n67/mode/2up) confirms the intended behavior.
Also, increasing the value in the R2 register of the CRTC should shift the display left, and decreasing it should shift it right. If you look at the register values while shifting the screen, you'll see that the current calculation does the opposite.

This PR fixes the issue.

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
