### PR TITLE
8514/A: Fix first NVRAM initialization on MCA bus version made by ATI

### DIFF
--- a/src/video/vid_ati_eeprom.c
+++ b/src/video/vid_ati_eeprom.c
@@ -56,7 +56,6 @@ ati_eeprom_load_mach8(ati_eeprom_t *eeprom, char *fn, int mca)
     size = 128;
     if (!fp) {
         if (mca) {
-            (void) fseek(fp, 2L, SEEK_SET);
             memset(eeprom->data + 2, 0xff, size - 2);
             fp = nvr_fopen(eeprom->fn, "wb");
             fwrite(eeprom->data, 1, size, fp);


### PR DESCRIPTION
Prior to this change it was not possible to start the emulated machine with this graphics adapter installed on any operating system different from Windows, causing crash with exit code 11.

Summary
=======
Remove unneeded `fseek` operation on invalid file pointer.

Checklist
=========
* [x] Closes [none]
 - No issues were referencing this crash.
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set

References
==========
- Recent post in the [PVS-Studio blog](https://pvs-studio.com/en/blog/posts/cpp/1304/) covering this exact problem
- They also link to code from [ATI Mach8 NVRAM loading routine](https://github.com/86Box/86Box/blob/v5.2/src/video/vid_ati_eeprom.c#L86) opening NVRAM file straight away without seeking the invalid file pointer

Other
==========
- The [previous article](https://pvs-studio.com/en/blog/posts/cpp/1289/) from PVS-Studio blog was about 86Box v5.0 code overview via their static analyzer also backed by datasheets. Might be also worth to look at it for hardware-specific emulation bugs or misfires?