### PR TITLE
Fix IBM 5153 palette color 8: dark gray instead of bright red

### DIFF
--- a/src/video/video.c
+++ b/src/video/video.c
@@ -612,7 +612,7 @@ cgapal_rebuild_monitor(int monitor_index)
         palette_lookup[0x15] = 0xffc400c4;
         palette_lookup[0x16] = 0xffc47e00;
         palette_lookup[0x17] = 0xffc4c4c4;
-        palette_lookup[0x18] = 0x0ffe4e4e;
+        palette_lookup[0x18] = 0xff4e4e4e;
         palette_lookup[0x19] = 0xff4e4edc;
         palette_lookup[0x1a] = 0xff4edc4e;
         palette_lookup[0x1b] = 0xff4ef3f3;


### PR DESCRIPTION
Summary
=======
This PR fixes a typo in the IBM 5153 color palette definition.

**Issue:**
Color 8 (dark gray) was incorrectly defined with a bright red value instead of the proper dark gray color.

**Fix:**
Updated color 8 to the correct dark gray value as per the IBM 5153 CGA monitor specification.

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

