### PR TITLE
Use 512k+512k memory spilt for CS8220 chipset

### DIFF
--- a/src/chipset/cs8220.c
+++ b/src/chipset/cs8220.c
@@ -218,37 +218,27 @@ cs8220_init(UNUSED(const device_t *info))
             dev->ram_banks[0].virt = 0x00000000;
             dev->ram_banks[0].phys = 0x00000000;
             dev->ram_banks[0].size = 0x00080000;
-            dev->ram_banks[1].virt = 0x00080000;
-            dev->ram_banks[1].phys = 0x00080000;
-            dev->ram_banks[1].size = 0x00020000;
-            /* Pretend there's a 128k expansion. */
-            dev->ram_banks[2].virt = 0x00100000;
-            dev->ram_banks[2].phys = 0x00080000;
-            dev->ram_banks[2].size = 0x00020000;
-            break;
-        case 896:
-            dev->ram_banks[0].virt = 0x00000000;
-            dev->ram_banks[0].phys = 0x00000000;
-            dev->ram_banks[0].size = 0x00080000;
-            dev->ram_banks[1].virt = 0x00080000;
-            dev->ram_banks[1].phys = 0x00080000;
-            dev->ram_banks[1].size = 0x00020000;
             /* Pretend there's a 256k expansion. */
             dev->ram_banks[2].virt = 0x00100000;
             dev->ram_banks[2].phys = 0x00080000;
             dev->ram_banks[2].size = 0x00040000;
             break;
-        case 1024:
+        case 896:
             dev->ram_banks[0].virt = 0x00000000;
             dev->ram_banks[0].phys = 0x00000000;
             dev->ram_banks[0].size = 0x00080000;
-            dev->ram_banks[1].virt = 0x00080000;
-            dev->ram_banks[1].phys = 0x00080000;
-            dev->ram_banks[1].size = 0x00020000;
             /* Pretend there's a 384k expansion. */
             dev->ram_banks[2].virt = 0x00100000;
             dev->ram_banks[2].phys = 0x00080000;
             dev->ram_banks[2].size = 0x00060000;
+            break;
+        case 1024:
+            dev->ram_banks[0].virt = 0x00000000;
+            dev->ram_banks[0].phys = 0x00000000;
+            dev->ram_banks[0].size = 0x00080000;
+            dev->ram_banks[1].virt = 0x00100000;
+            dev->ram_banks[1].phys = 0x00080000;
+            dev->ram_banks[1].size = 0x00080000;
             break;
     }
 


### PR DESCRIPTION
Use 512k base memory for CS8220 chipset if memory larger than 640k, fix some BIOS not recognizing extended memory.

Summary
=======
CS8220 supports 1024KB memory to spilt into 512KB base + 512KB extended memory only, and if using 640KB base + 384KB extended memory spilt, some BIOSes will not recognize extended memory. This commit fixes 768KB, 896KB and 1024KB memory configuration for machines using CS8220 chipset.

Checklist
=========
* [x] Closes #6444
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://www.os2museum.com/wp/another-strange-286-board/
