### PR TITLE
Refresh rate and acceleration fixes and cleanups for displays.

### DIFF
--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -3322,29 +3322,28 @@ mach_recalctimings(svga_t *svga)
         if (!svga->scrblank && svga->attr_palette_enable) {
             mach_log("GDCREG5=%02x, ATTR10=%02x, ATI B0 bit 5=%02x, ON=%d.\n",
                      svga->gdcreg[5] & 0x60, svga->attrregs[0x10] & 0x40, mach->regs[0xb0] & 0x20, dev->on);
-            if (ATI_MACH32)
-                svga->clock = (cpuclock * (double) (1ULL << 32)) / svga->getclock(clock_sel, svga->clock_gen);
-            else
-                svga->clock = (cpuclock * (double) (1ULL << 32)) / svga->getclock(clock_sel ^ 0x08, svga->clock_gen);
-
-            switch ((mach->regs[0xb8] >> 6) & 3) {
-                case 0:
-                default:
-                    break;
-                case 1:
-                    svga->clock *= 2.0;
-                    break;
-                case 2:
-                    svga->clock *= 3.0;
-                    break;
-                case 3:
-                    svga->clock *= 4.0;
-                    break;
-            }
 
             mach_log("VGA clock sel=%02x, divide reg=%02x, miscout bits2-3=%x, machregbe bit4=%02x, machregb9 bit1=%02x, charwidth=%d, htotal=%02x, hdisptime=%02x, seqregs1 bit 3=%02x.\n", clock_sel, (mach->regs[0xb8] >> 6) & 3, svga->miscout & 0x0c, mach->regs[0xbe] & 0x10, mach->regs[0xb9] & 0x02, svga->char_width, svga->htotal, svga->hdisp_time, svga->seqregs[1] & 8);
             if ((svga->gdcreg[6] & 0x01) || (svga->attrregs[0x10] & 0x01)) {
                 if ((svga->gdcreg[5] & 0x40) || (svga->attrregs[0x10] & 0x40) || (mach->regs[0xb0] & 0x20)) {
+                    if (ATI_MACH32)
+                        svga->clock = (cpuclock * (double) (1ULL << 32)) / svga->getclock(clock_sel, svga->clock_gen);
+                    else
+                        svga->clock = (cpuclock * (double) (1ULL << 32)) / svga->getclock(clock_sel ^ 0x08, svga->clock_gen);
+
+                    switch ((mach->regs[0xb8] >> 6) & 3) {
+                        case 1:
+                            svga->clock *= 2.0;
+                            break;
+                        case 2:
+                            svga->clock *= 3.0;
+                            break;
+                        case 3:
+                            svga->clock *= 4.0;
+                            break;
+                        default:
+                            break;
+                    }
                     svga->map8 = svga->pallook;
                     mach_log("Lowres=%x, seqreg[1]bit3=%x.\n", svga->lowres, svga->seqregs[1] & 8);
                     if (svga->lowres)
@@ -3356,6 +3355,26 @@ mach_recalctimings(svga_t *svga)
                             svga->rowoffset <<= 1;
                         }
                     }
+                }
+            } else {
+                if (ATI_MACH32)
+                    svga->clock = (cpuclock * (double) (1ULL << 32)) / svga->getclock(clock_sel, svga->clock_gen);
+                else
+                    svga->clock = (cpuclock * (double) (1ULL << 32)) / svga->getclock(clock_sel ^ 0x08, svga->clock_gen);
+
+                switch ((mach->regs[0xb8] >> 6) & 3) {
+                    case 0:
+                    default:
+                        break;
+                    case 1:
+                        svga->clock *= 2.0;
+                        break;
+                    case 2:
+                        svga->clock *= 3.0;
+                        break;
+                    case 3:
+                        svga->clock *= 4.0;
+                        break;
                 }
             }
         }


### PR DESCRIPTION
Summary
=======
1. Some fixes to the S3 refresh rates using the bt48x ramdac as well as 32bpp acceleration (actually pixtrans reads) fixes, which are actually one single dword rather than two words. (This fixes some graphical bugs in 32bpp mode using OS/2 Warp with the Elsa 928 drivers).
2. Add undocumented ports 0x82ec and 0x82ed, needed by the Elsa OS/2 928/805i cards to operate correctly and not getting stuck at a blank screen.
3. Workaround a read select register issue when reading back the accelerated height (0xbee8 index 0x0f bits 3-0 returning a non-height index, in this case, 0x0e) so that the height is not zeroed on writes after the first reads, allowing text and fonts to be displayed on OS/2 Warp 3's built-in S3 864 drivers in every bpp.
4. Don't run the mach8/32 specific clock if we're in plain VGA text mode.
5. Some cleanups to the et4000w32 chip series, including a clock (refresh rate) fix for OS/2's built-in drivers and the extended crtc parameters to be run only on graphics modes.


Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
