### PR TITLE
Add the Fujitsu ErgoPro e368 BIOS for MS-6147

### DIFF
--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -594,7 +594,7 @@ static const device_config_t ax6bc_config[] = {
                 .files         = { "roms/machines/ax6bc/ax6bc110.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.60PGMA - Revision R2.20 (RM Accelerator 350P2XB/450P3XB)",
+                .name          = "RM Accelerator 350P2XB/450P3XB (BIOS R2.20)",
                 .internal_name = "ax6bc_rm",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -603,7 +603,7 @@ static const device_config_t ax6bc_config[] = {
                 .files         = { "roms/machines/ax6bc/ax6bc220.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.60PGMA - Revision R2.59",
+                .name          = "Award Modular BIOS v4.60PGM - Revision R2.59",
                 .internal_name = "ax6bc",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,


### PR DESCRIPTION
Summary
=======
Recently, the Fujitsu ErgoPro e368 OEM BIOS (revision 1.2) for MSI MS-6147 has added into its The Retro Web entry. This PR adds it.

This PR also corrects the RM Accelerator BIOS name on AOpen AX6BC to match other machines' BIOS names.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/431

References
==========
[MSI MS-6147 TRW entry](https://theretroweb.com/motherboards/s/msi-ms-6147-bx7)
[e368 Specialist Handbook](https://theretroweb.com/motherboard/manual/ergopro-e368-6916ee5333ffa818961920.pdf)