### PR TITLE
Correct RAM memory step for HP Ruby (Pavilion 73xx/74xx)

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -14757,7 +14757,7 @@ const machine_t machines[] = {
         .ram       = {
             .min  = 8192,
             .max  = 131072,
-            .step = 8192
+            .step = 4096
         },
         .nvrmask                  = 255,
         .jumpered_ecp_dma         = MACHINE_DMA_DISABLED | MACHINE_DMA_1 | MACHINE_DMA_3,


### PR DESCRIPTION
Summary
=======
According to Intel Advanced/RU's specs, this supports 4MB RAM memory, so this PR corrects the memory step for that machine.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
[Intel Advanced/RU specs](https://theretroweb.com/motherboards/s/intel-advanced-ru-ruby)
