### PR TITLE
Change the max. RAM limit on HP Ruby USB and AOpen AP61

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -14756,7 +14756,7 @@ const machine_t machines[] = {
         .flags     = MACHINE_IDE_DUAL | MACHINE_VIDEO | MACHINE_SOUND | MACHINE_GAMEPORT | MACHINE_APM | MACHINE_USB,
         .ram       = {
             .min  = 8192,
-            .max  = 131072,
+            .max  = 524288,
             .step = 4096
         },
         .nvrmask                  = 255,
@@ -17299,7 +17299,7 @@ const machine_t machines[] = {
         .flags     = MACHINE_IDE_DUAL | MACHINE_APM,
         .ram       = {
             .min  = 8192,
-            .max  = 524288,
+            .max  = 262144,
             .step = 8192
         },
         .nvrmask                  = 127,


### PR DESCRIPTION
Summary
=======
* Changes the max. RAM limit on HP Pavilion 73xx/74xx (Ruby USB) from 128 MB to 512 MB
* Changes the max. RAM limit on AOpen AP61 from 512 MB to 256 MB as it cannot detect more than that amount

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
* https://theretroweb.com/motherboards/s/intel-advanced-ru-ruby (despite the official limit being 128 MB the machine chipset and RAM slot amount allow for 512 MB)
* My own testing
