### PR TITLE
Add the HP Pavilion 52xx/53xx/71xx/72xx (BCM FM562)

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -1026,6 +1026,7 @@ extern int             machine_at_amis727_init(const machine_t *);
 extern const device_t  ap5s_device;
 #endif
 extern int             machine_at_ap5s_init(const machine_t *);
+extern int             machine_at_fm562_init(const machine_t *);
 extern int             machine_at_pc140_6260_init(const machine_t *);
 #ifdef EMU_DEVICE_H
 extern const device_t  ms5124_device;

--- a/src/machine/m_at_socket7_3v.c
+++ b/src/machine/m_at_socket7_3v.c
@@ -1597,6 +1597,37 @@ machine_at_ap5s_init(const machine_t *model)
 }
 
 int
+machine_at_fm562_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/fm562/PR11_US.ROM",
+                           0x000e0000, 131072, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_common_init_ex(model, 2);
+
+    pci_init(PCI_CONFIG_TYPE_1 | FLAG_TRC_CONTROLS_CPURST);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 1, 2, 3, 4);
+    pci_register_slot(0x01, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x11, PCI_CARD_NORMAL,      1, 3, 2, 4);
+    pci_register_slot(0x13, PCI_CARD_NORMAL,      2, 1, 3, 4);
+    pci_register_slot(0x0B, PCI_CARD_VIDEO,       0, 0, 0, 0); /* Onboard video */
+
+    if (sound_card_current[0] == SOUND_INTERNAL)
+        machine_snd = device_add(machine_get_snd_device(machine));
+
+    device_add(&sis_5511_device);
+    device_add_params(machine_get_kbc_device(machine), (void *) model->kbc_params);
+    device_add_params(&fdc37c669_device, (void *) 0);
+    device_add(&intel_flash_bxt_device);
+
+    return ret;
+}
+
+int
 machine_at_pc140_6260_init(const machine_t *model)
 {
     int ret;

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -14323,6 +14323,50 @@ const machine_t machines[] = {
         .snd_device               = NULL,
         .net_device               = NULL
     },
+    /* Has AMIKey H KBC firmware (AMIKey-2). */
+    {
+        .name              = "[SiS 5511] HP Pavilion 52xx/53xx/71xx/72xx (BCM FM562)",
+        .internal_name     = "fm562",
+        .type              = MACHINE_TYPE_SOCKET7_3V,
+        .chipset           = MACHINE_CHIPSET_SIS_5511,
+        .init              = machine_at_fm562_init,
+        .p1_handler        = machine_generic_p1_handler,
+        .gpio_handler      = NULL,
+        .available_flag    = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu               = {
+            .package     = CPU_PKG_SOCKET5_7,
+            .block       = CPU_BLOCK(CPU_Cx6x86, CPU_Cx6x86L, CPU_Cx6x86MX),
+            .min_bus     = 50000000,
+            .max_bus     = 66666667,
+            .min_voltage = 3380,
+            .max_voltage = 3520,
+            .min_multi   = 1.5,
+            .max_multi   = 2.5
+        },
+        .bus_flags = MACHINE_PS2_PCI,
+        .flags     = MACHINE_IDE_DUAL | MACHINE_SOUND | MACHINE_GAMEPORT | MACHINE_APM, /* Machine has internal sound: Crystal CS4232-KQ, and video: SiS 6205 (not yet emulated) */
+        .ram       = {
+            .min  = 8192,
+            .max  = 524288,
+            .step = 8192
+        },
+        .nvrmask                  = 127,
+        .jumpered_ecp_dma         = 0,
+        .default_jumpered_ecp_dma = -1,
+        .kbc_device               = &kbc_at_device,
+        .kbc_params               = KBC_VEN_AMI | 0x00004800,
+        .kbc_p1                   = 0x00000cf0,
+        .gpio                     = 0xffffffff,
+        .gpio_acpi                = 0xffffffff,
+        .device                   = NULL,
+        .kbd_device               = NULL,
+        .fdc_device               = NULL,
+        .sio_device               = NULL,
+        .vid_device               = NULL,
+        .snd_device               = &cs4232_onboard_device,
+        .net_device               = NULL
+    },
     /* Has an SMC FDC37C669QF Super I/O. */
     {
         .name              = "[SiS 5511] IBM PC 140 (type 6260)",


### PR DESCRIPTION
Summary
=======
Add the HP Pavilion 52xx/53xx/71xx/72xx (BCM FM562) machine with SiS 5511 chipset for Socket 7 (Single Voltage)

**NOTE:** The machine has a BIOS bug that causes it to hang while booting if an HDD partition exceeding 2015 MB is present, even when booting from an external medium (like a floppy or CD drive).

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/433

References
==========
https://theretroweb.com/motherboards/s/bcm-fm562
