### PR TITLE
Add the Revision F1 BIOS to Gigabyte GA-686BX

### DIFF
--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -691,8 +691,17 @@ static const device_config_t ga686_config[] = {
                 .files         = { "roms/machines/686bx/31nologo.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision F2a",
+                .name          = "Award Modular BIOS v4.51PG - Revision F1",
                 .internal_name = "686bx",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 262144,
+                .files         = { "roms/machines/686bx/6BX.F1", "" }
+            },
+            {
+                .name          = "Award Modular BIOS v4.51PG - Revision F2a",
+                .internal_name = "686bx_f2a",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
                 .local         = 0,


### PR DESCRIPTION
Summary
=======
This pull request adds the Revision F1 BIOS to Gigabyte GA-686BX which tested 100%.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
