### PR TITLE
Fixes for most video cards, ramdacs and clock generators

### DIFF
--- a/src/video/clockgen/vid_clockgen_ics90c64a.c
+++ b/src/video/clockgen/vid_clockgen_ics90c64a.c
@@ -25,7 +25,7 @@
 #include <86box/device.h>
 
 typedef struct ics90c64a_t {
-    float freq[32];
+    float freq[17];
 } ics90c64a_t;
 
 #ifdef ENABLE_ICS90C64A_LOG
@@ -51,21 +51,10 @@ ics90c64a_vclk_getclock(int clock, void *priv)
 {
     const ics90c64a_t *ics90c64a = (ics90c64a_t *) priv;
 
-    if (clock > 15)
-        clock = 15;
+    if (clock > 16)
+        clock = 16;
 
     return ics90c64a->freq[clock];
-}
-
-float
-ics90c64a_mclk_getclock(int clock, void *priv)
-{
-    const ics90c64a_t *ics90c64a = (ics90c64a_t *) priv;
-
-    if (clock > 7)
-        clock = 7;
-
-    return ics90c64a->freq[clock + 0x10];
 }
 
 static void *
@@ -76,32 +65,24 @@ ics90c64a_init(const device_t *info)
 
     switch (info->local) {
         case 903:
-            /* ICS90C64A-903 for PVGA chip series */
-            ics90c64a->freq[0x0] = 30000000.0;
-            ics90c64a->freq[0x1] = 77250000.0;
-            ics90c64a->freq[0x2] = 0.0;
-            ics90c64a->freq[0x3] = 80000000.0;
-            ics90c64a->freq[0x4] = 31500000.0;
-            ics90c64a->freq[0x5] = 36000000.0;
-            ics90c64a->freq[0x6] = 75000000.0;
-            ics90c64a->freq[0x7] = 50000000.0;
-            ics90c64a->freq[0x8] = 40000000.0;
-            ics90c64a->freq[0x9] = 50000000.0;
-            ics90c64a->freq[0xa] = 32000000.0;
-            ics90c64a->freq[0xb] = 44900000.0;
-            ics90c64a->freq[0xc] = 25175000.0;
-            ics90c64a->freq[0xd] = 28322000.0;
-            ics90c64a->freq[0xe] = 65000000.0;
-            ics90c64a->freq[0xf] = 36000000.0;
-
-            ics90c64a->freq[0x10] = 33000000.0;
-            ics90c64a->freq[0x11] = 49218000.0;
-            ics90c64a->freq[0x12] = 60000000.0;
-            ics90c64a->freq[0x13] = 30500000.0;
-            ics90c64a->freq[0x14] = 41612000.0;
-            ics90c64a->freq[0x15] = 37500000.0;
-            ics90c64a->freq[0x16] = 36000000.0;
-            ics90c64a->freq[0x17] = 44296000.0;
+            /* ICS90C64A-903 for PVGA chip series, also per debian svgatext mode textconfig */
+            ics90c64a->freq[0] = 25175000.0;
+            ics90c64a->freq[1] = 28322000.0;
+            ics90c64a->freq[2] = 65000000.0;
+            ics90c64a->freq[3] = 36000000.0;
+            ics90c64a->freq[4] = 40000000.0;
+            ics90c64a->freq[5] = 50000000.0;
+            ics90c64a->freq[6] = 32000000.0;
+            ics90c64a->freq[7] = 45000000.0;
+            ics90c64a->freq[8] = 31500000.0;
+            ics90c64a->freq[9] = 35500000.0;
+            ics90c64a->freq[0x0a] = 74500000.0;
+            ics90c64a->freq[0x0b] = 72000000.0;
+            ics90c64a->freq[0x0c] = 30000000.0;
+            ics90c64a->freq[0x0d] = 77000000.0;
+            ics90c64a->freq[0x0e] = 86000000.0;
+            ics90c64a->freq[0x0f] = 80000000.0;
+            ics90c64a->freq[0x10] = 60000000.0;
             break;
 
         default:

--- a/src/video/ramdac/vid_ramdac_bt48x.c
+++ b/src/video/ramdac/vid_ramdac_bt48x.c
@@ -56,9 +56,9 @@ bt48x_set_bpp(bt48x_ramdac_t *ramdac, svga_t *svga)
 {
     if ((!(ramdac->cmd_r2 & 0x20)) || ((ramdac->type >= BT485A) && ((ramdac->cmd_r3 & 0x60) == 0x60)))
         svga->bpp = 8;
-    else if ((ramdac->type >= BT485A) && ((ramdac->cmd_r3 & 0x60) == 0x40))
+    else if ((ramdac->type >= BT485A) && ((ramdac->cmd_r3 & 0x60) == 0x20))
         svga->bpp = 24;
-    else
+    else {
         switch (ramdac->cmd_r1 & 0x60) {
             case 0x00:
                 svga->bpp = 32;
@@ -71,14 +71,18 @@ bt48x_set_bpp(bt48x_ramdac_t *ramdac, svga_t *svga)
                 break;
             case 0x40:
                 svga->bpp = 8;
+                svga->gdcreg[5] &= ~0x60;
+                svga->gdcreg[5] |= 0x40;
                 break;
             case 0x60:
                 svga->bpp = 4;
+                svga->gdcreg[5] &= ~0x60;
                 break;
 
             default:
                 break;
         }
+    }
     svga_recalctimings(svga);
 }
 

--- a/src/video/vid_ati_mach64.c
+++ b/src/video/vid_ati_mach64.c
@@ -4996,6 +4996,7 @@ mach64ct_init(const device_t *info)
     mem_mapping_disable(&mach64->bios_rom.mapping);
 
     svga->vblank_start = mach64_vblank_start;
+    svga->adv_flags |= FLAG_PANNING_ATI;
 
     return mach64;
 }

--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -3114,7 +3114,7 @@ mach_recalctimings(svga_t *svga)
             svga->ati_4color = 0;
     }
 
-    mach_log("ON=%d, override=%d, gelo=%04x, gehi=%04x, crtlo=%04x, crthi=%04x, vgahdisp=%d.\n", dev->on, svga->override, mach->accel.ge_offset_lo, mach->accel.ge_offset_hi, mach->accel.crt_offset_lo, mach->accel.crt_offset_hi, svga->hdisp);
+    mach_log("ON=%d, override=%d, gelo=%04x, gehi=%04x, crtlo=%04x, crthi=%04x, vgahdisp=%d, ibmon=%x, ation=%x, graph1=%x.\n", dev->on, svga->override, mach->accel.ge_offset_lo, mach->accel.ge_offset_hi, mach->accel.crt_offset_lo, mach->accel.crt_offset_hi, svga->hdisp, dev->accel.advfunc_cntl & 0x01, mach->accel.clock_sel & 0x01, svga->gdcreg[6] & 0x01);
 
     if (dev->on) {
         dev->memaddr_latch              = 0; /*(mach->accel.crt_offset_lo | (mach->accel.crt_offset_hi << 16)) << 2;*/
@@ -4065,6 +4065,10 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             }
             if (!(dev->accel.advfunc_cntl & 0x01))
                 dev->on = mach->accel.clock_sel & 0x01;
+            else {
+                if (!(mach->regs[0xb0] & 0x20) && !(mach->accel.clock_sel & 0x01))
+                    dev->on = 0;
+            }
 
             dev->vendor_mode = 1;
             dev->mode = ATI_MODE;

--- a/src/video/vid_et4000.c
+++ b/src/video/vid_et4000.c
@@ -667,8 +667,12 @@ et4000_recalctimings(svga_t *svga)
     }
 
     svga->clock = (cpuclock * (double) (1ULL << 32)) / svga->getclock(clk_sel, svga->clock_gen);
-    if (clk_sel < 2)
+    if (!(svga->gdcreg[6] & 1) && !(svga->attrregs[0x10] & 1)) {
         svga->clock *= 2.0;
+    } else {
+        if ((svga->bpp <= 8) || ((svga->gdcreg[5] & 0x60) <= 0x20))
+            svga->clock *= 2.0;
+    }
 
     switch (svga->bpp) {
         case 15:

--- a/src/video/vid_paradise.c
+++ b/src/video/vid_paradise.c
@@ -487,6 +487,7 @@ void
 paradise_recalctimings(svga_t *svga)
 {
     paradise_t *paradise = (paradise_t *) svga->priv;
+    int clk_sel = 0;
 
     svga->lowres = !(svga->gdcreg[0x0e] & 0x01);
 
@@ -526,6 +527,11 @@ paradise_recalctimings(svga_t *svga)
                 break;
         }
     } else {
+        clk_sel = ((svga->miscout >> 2) & 0x03);
+        if (!(svga->gdcreg[0x0c] & 0x02))
+            clk_sel |= 0x04;
+
+        svga->clock = (cpuclock * (double) (1ULL << 32)) / svga->getclock(clk_sel, svga->clock_gen);
         if ((svga->gdcreg[6] & 1) || (svga->attrregs[0x10] & 1)) {
             if ((svga->bpp >= 8) && !svga->lowres) {
                 if (svga->bpp == 16) {
@@ -777,6 +783,8 @@ paradise_init(const device_t *info, uint32_t memory)
             paradise->vram_mask = (memory << 10) - 1;
             svga->decode_mask   = (memory << 10) - 1;
             svga->ramdac        = device_add(&sc11487_ramdac_device); /*Actually a Winbond W82c487-80, probably a clone.*/
+            svga->clock_gen     = device_add(&ics90c64a_903_device);
+            svga->getclock      = ics90c64a_vclk_getclock;
             break;
 
         default:

--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -4702,8 +4702,8 @@ s3_recalctimings(svga_t *svga)
                 svga->read_bank = 0;
             }
             /*In non-enhanced/IBM VGA modes, reset the misc index registers.*/
-            s3->accel.multifunc[0xd] = 0xd000;
-            s3->accel.multifunc[0xe] = 0xe000;
+            s3->accel.multifunc[0xd] = 0x000;
+            s3->accel.multifunc[0xe] = 0x000;
         }
     }
 
@@ -5306,6 +5306,7 @@ s3_accel_in(uint16_t port, void *priv)
         case 0x9949:
         case 0x9ae9:
             temp = 0;
+            s3_log("FIFO=%x, cmd=%d, sy=%d.\n", s3_enable_fifo(s3), s3->accel.cmd >> 13, s3->accel.sy);
             if (s3_enable_fifo(s3)) {
                 if (!s3->blitter_busy)
                     wake_fifo_thread(s3);
@@ -5332,17 +5333,26 @@ s3_accel_in(uint16_t port, void *priv)
                 else {
                     switch (s3->accel.cmd >> 13) { /*Some drivers may not set FIFO on but may still turn on FIFO empty bits!*/
                         case 0:
-                            if (!s3->accel.ssv_len)
+                            if (s3->accel.cmd & 0x100) {
+                                if (!s3->accel.ssv_len)
+                                    temp |= 0x04;
+                            } else
                                 temp |= 0x04;
                             break;
                         case 1:
-                            if (!s3->accel.sy)
+                            if (s3->accel.cmd & 0x100) {
+                                if (!s3->accel.sy)
+                                    temp |= 0x04;
+                            } else
                                 temp |= 0x04;
                             break;
                         case 2:
                         case 6:
                         case 7:
-                            if (s3->accel.sy < 0)
+                            if (s3->accel.cmd & 0x100) {
+                                if (s3->accel.sy < 0)
+                                    temp |= 0x04;
+                            } else
                                 temp |= 0x04;
                             break;
 

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -1672,19 +1672,10 @@ svga_init(const device_t *info, svga_t *svga, void *priv, int memsize,
           void (*hwcursor_draw)(struct svga_t *svga, int displine),
           void (*overlay_draw)(struct svga_t *svga, int displine))
 {
-    int e;
-
     svga->priv          = priv;
     svga->monitor_index = monitor_index_global;
     svga->monitor       = &monitors[svga->monitor_index];
 
-    for (int c = 0; c < 256; c++) {
-        e = c;
-        for (int d = 0; d < 8; d++) {
-            svga_rotate[d][c] = e;
-            e                 = (e >> 1) | ((e & 1) ? 0x80 : 0);
-        }
-    }
     svga->readmode = 0;
 
     svga->attrregs[0x11] = 0;


### PR DESCRIPTION
Summary
=======
1. Actually place the correct clocks in the PVGA-based ICS90c64a (see sources).
2. Make sure the difference between 4bpp and 8bpp in the BT484/5 ramdac is actually seen and done.
3. Forgot the ATI panning flag for the plain Mach64GX cards.
4. Fix standard VGA graphics mode for Japanese text in the Mach32 so that it's rendered correctly (if bit 5 of ati 0xb0 and bit 0 of 0x4aee clock select are 0).
5. Normalize ET4000AX clocks.
6. ET4000W32 series: fix some hwcursor issues in win3.1/winos2 (in non-24bpp modes) as well as well as the chips' clocks. Cleanup of the modes too.
7. Video7  HT208 cards: Add the 7.04 HP OEM bios and implement the clocks according to its manual (HT208, below).
8. More fixes of the stalls caused by FIFO stuff in non-FIFO modes (S3 stuff).
9. Remove unused code in vid_svga.c (vga core layer)

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [X] This pull request requires changes to the ROM set
  * [X] I have opened a roms pull request - https://github.com/86Box/roms/pull/438/

References
==========
[Debian TextConfig clocks](https://sources.debian.org/src/svgatextmode/1.8-5.2/TextConfig/)
[Video7 1988 datasheet](http://www.bitsavers.org/components/video7/700-0242_V7_VGA_Technical_Reference_Manual_Jun88.pdf)
