### PR TITLE
MKE CD-ROM audio and data fixes.

### DIFF
--- a/src/cdrom/cdrom_mke.c
+++ b/src/cdrom/cdrom_mke.c
@@ -531,7 +531,6 @@ mke_command(mke_t *mke, uint8_t value)
     uint16_t     i;
     /* This is wasteful handling of buffers for compatibility, but will optimize later. */
     uint8_t      x[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-    int          old_cd_status;
 
     if (mke->command_buffer_pending) {
         mke->command_buffer[6 - mke->command_buffer_pending + 1] = value;
@@ -769,7 +768,6 @@ mke_command(mke_t *mke, uint8_t value)
                 }
                 break;
             case CMD1_SEEK:
-                old_cd_status = mke->cdrom_dev->cd_status;
                 fifo8_reset(&mke->info_fifo);
                 CHECK_READY_READ();
                 /* TODO: DOES THIS IMPACT CURRENT PLAY LENGTH? */
@@ -782,10 +780,6 @@ mke_command(mke_t *mke, uint8_t value)
                 /* Note for self: Panasonic/MKE drives send seek commands in MSF format. */
                 cdrom_seek(mke->cdrom_dev, MSFtoLBA(mke->command_buffer[1], mke->command_buffer[2],
                            mke->command_buffer[3]) - 150, 0);
-                if ((old_cd_status == CD_STATUS_PLAYING) || (old_cd_status == CD_STATUS_PAUSED)) {
-                    cdrom_audio_play(mke->cdrom_dev, mke->cdrom_dev->seek_pos, -1, 0);
-                    cdrom_audio_pause_resume(mke->cdrom_dev, old_cd_status == CD_STATUS_PLAYING);
-                }
                 fifo8_push(&mke->info_fifo, mke_cdrom_status(mke->cdrom_dev, mke));
                 break;
             case CMD1_SESSINFO:
@@ -832,6 +826,9 @@ mke_command(mke_t *mke, uint8_t value)
                 break;
             default:
                 mke_log("MKE: Unknown Commnad [%02x]\n", mke->command_buffer[0]);
+                fifo8_reset(&mke->info_fifo);
+                fifo8_push_all(&mke->info_fifo, x, 6);
+                fifo8_push(&mke->info_fifo, mke_cdrom_status(mke->cdrom_dev, mke));
                 break;
         }
     } else if (!mke->command_buffer_pending) {


### PR DESCRIPTION
Summary
=======
1. On unknown commands just return a fine data push, fixes the OS/2 built-in MKE cdrom driver being unrecognized.
2. Okay, but I don't know if it's right, but don't play audio on the seek command, fixes actual audio stop when prompted to, (Audio still works fine if you actually want to play from a CD player).

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
