### PR TITLE
Fix Voodoo1/2 LFB readback slowdown by removing FIFO busy-wait loop

### DIFF
--- a/src/video/vid_voodoo.c
+++ b/src/video/vid_voodoo.c
@@ -168,10 +168,8 @@ voodoo_readw(uint32_t addr, void *priv)
         }
 
         voodoo->flush = 1;
-        while (!FIFO_EMPTY) {
+        if (!FIFO_EMPTY)
             voodoo_wake_fifo_thread_now(voodoo);
-            thread_wait_event(voodoo->fifo_not_full_event, 1);
-        }
         voodoo_wait_for_render_thread_idle(voodoo);
         voodoo->flush = 0;
 


### PR DESCRIPTION
Summary
=======
This PR fixes a slowdown that appears in Hardball 6 when using Voodoo 1 or Voodoo 2.
The game performs very frequent framebuffer readbacks during gameplay. On Voodoo 1/2, each readback triggers a heavy internal wait for the FIFO and render thread to become idle.

Because Hardball 6 repeats this constantly, the emulator gets stuck waiting and drops to about 15% speed.

The update reduces the amount of waiting performed during readback, while keeping behavior correct. With the change applied, the game runs at full speed again and shows no graphical issues. Other Voodoo cards are unaffected.

Checklist
=========
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
