### PR TITLE
Restore FIFO wait loop in Voodoo LFB readback to avoid regressions

### DIFF
--- a/src/video/vid_voodoo.c
+++ b/src/video/vid_voodoo.c
@@ -168,7 +168,7 @@ voodoo_readw(uint32_t addr, void *priv)
         }
 
         voodoo->flush = 1;
-        if (!FIFO_EMPTY)
+        while (!FIFO_EMPTY)
             voodoo_wake_fifo_thread_now(voodoo);
         voodoo_wait_for_render_thread_idle(voodoo);
         voodoo->flush = 0;


### PR DESCRIPTION
Summary
=======
The previous revision replaced the FIFO loop with an as a workaround for a slowdown in Hardball 6.
Since the loop is required for accurate Voodoo FIFO emulation (and used to fix Unreal in PCem), the original behavior has been restored. ```if``` to ```while```

Tested again with Hardball 6 and Unreal — all run normally without slowdowns or regressions.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
