### PR TITLE
Translations update from 86Box Weblate

### DIFF
--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -1,8 +1,15 @@
 msgid ""
 msgstr ""
+"PO-Revision-Date: 2025-11-30 18:56+0000\n"
+"Last-Translator: Lili Kurek <lili@lili.lgbt>\n"
+"Language-Team: Polish <https://weblate.86box.net/projects/86box/86box/pl/>\n"
+"Language: pl-PL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2;\n"
+"X-Generator: Weblate 5.12.2\n"
 "X-Language: pl_PL\n"
 "X-Source-Language: en_US\n"
 
@@ -1819,7 +1826,7 @@ msgid "VDE Socket:"
 msgstr "Gniazdo VDE:"
 
 msgid "TAP Bridge Device:"
-msgstr ""
+msgstr "Urządzenie mostka TAP:"
 
 msgid "86Box Unit Tester"
 msgstr "Tester urządzeń 86Box"
@@ -2212,16 +2219,16 @@ msgid "WSS DMA"
 msgstr "WSS DMA"
 
 msgid "RTC IRQ"
-msgstr ""
+msgstr "IRQ RTC"
 
 msgid "RTC Port Address"
-msgstr ""
+msgstr "Adres portu RTC"
 
 msgid "Onboard RTC"
-msgstr ""
+msgstr "Wbudowane RTC"
 
 msgid "Not installed"
-msgstr ""
+msgstr "Niezainstalowane"
 
 msgid "Enable OPL"
 msgstr "Włącz OPL"
@@ -2845,7 +2852,7 @@ msgid "Toggle fullscreen"
 msgstr "Przełącz pełny ekran"
 
 msgid "Toggle UI in fullscreen"
-msgstr ""
+msgstr "Przełącz UI w pełnym ekranie"
 
 msgid "Screenshot"
 msgstr "Zrzut ekranu"


### PR DESCRIPTION
Translations update from [86Box Weblate](https://weblate.86box.net) for [86Box/86Box](https://weblate.86box.net/projects/86box/86box/).



Current translation status:

![Weblate translation status](https://weblate.86box.net/widget/86box/86box/horizontal-auto.svg)