### PR TITLE
Fix PCM audio in Gloriana on 16-bit SoundBlaster cards

### DIFF
--- a/src/sound/snd_sb_dsp.c
+++ b/src/sound/snd_sb_dsp.c
@@ -2775,6 +2775,7 @@ pollsb(void *priv)
                 dsp->ess_dma_counter += 4;
                 break;
             case 0x30: /* Stereo signed */
+            case 0x36:
                 data[0] = dsp->dma_readw(dsp->dma_priv);
                 data[1] = dsp->dma_readw(dsp->dma_priv);
                 if ((data[0] == DMA_NODATA) || (data[1] == DMA_NODATA))


### PR DESCRIPTION
Summary
=======
Treat format/mode 36h as an alias for 30h when performing 16-bit playback. Fixes PCM audio in Gloriana/Elisabeth I.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
