### PR TITLE
Setting default seek time (10ms) for fdd seeks

### DIFF
--- a/src/floppy/fdd.c
+++ b/src/floppy/fdd.c
@@ -365,7 +365,7 @@ void
 fdd_seek(int drive, int track_diff)
 {
     fdd_log("fdd_seek(drive=%d, track_diff=%d)\n", drive, track_diff);
-    if (!track_diff)
+    if (track_diff == 0)
         return;
 
     if (fdd_seek_in_progress[drive]) {
@@ -411,6 +411,10 @@ fdd_seek(int drive, int track_diff)
 
         /* Get seek timings from audio profile configuration with direction awareness */
         double   seek_time_us = fdd_audio_get_seek_time(drive, actual_track_diff, is_seek_down);
+        if (seek_time_us < 1) {
+            seek_time_us = DEFAULT_SEEK_TIME_MS * 1000;
+        }
+
         fdd_log("Seek timing for drive %d: %.2f µs (%s)\n", 
                 drive, seek_time_us, is_seek_down ? "DOWN" : "UP");
         uint64_t seek_delay_us = seek_time_us * TIMER_USEC;

--- a/src/floppy/fdd_audio.c
+++ b/src/floppy/fdd_audio.c
@@ -291,7 +291,7 @@ fdd_audio_load_profiles(void)
 void
 load_profile_samples(int profile_id)
 {
-    if (profile_id <= 0 || profile_id >= audio_profile_count)
+    if (profile_id < 0 || profile_id >= audio_profile_count)
         return;
 
     fdd_audio_profile_config_t *config  = &audio_profiles[profile_id];
@@ -444,7 +444,7 @@ double
 fdd_audio_get_seek_time(int drive, int track_count, int is_seek_down)
 {
     int profile_id = fdd_get_audio_profile(drive);
-    if (profile_id <= 0 || profile_id >= audio_profile_count) {
+    if (profile_id < 0 || profile_id >= audio_profile_count) {
         return 0;
     }
 

--- a/src/include/86box/fdd.h
+++ b/src/include/86box/fdd.h
@@ -24,6 +24,7 @@
 #define FDD_NUM              4
 #define FLOPPY_IMAGE_HISTORY 10
 #define SEEK_RECALIBRATE     -999
+#define DEFAULT_SEEK_TIME_MS 10.0
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Summary
=======
Setting 10ms default seek time for FDD seeks, when FDD audio profile not present or "none" selected. Added also support to have per-track-seek-values in the first "None"-profile.

Fixes issue with Debian 0.94 installation root-disk.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/