### PR TITLE
Implement Voodoo alpha planes and alpha mask support

### DIFF
--- a/src/include/86box/vid_voodoo_regs.h
+++ b/src/include/86box/vid_voodoo_regs.h
@@ -366,11 +366,14 @@ enum {
     FBZ_DEPTH_WMASK = (1 << 10),
     FBZ_DITHER_2x2  = (1 << 11),
 
+    FBZ_ALPHA_MASK = (1 << 13),
+
     FBZ_DRAW_FRONT = 0x0000,
     FBZ_DRAW_BACK  = 0x4000,
     FBZ_DRAW_MASK  = 0xc000,
 
     FBZ_DEPTH_BIAS = (1 << 16),
+    FBZ_ALPHA_ENABLE = (1 << 18), 
     FBZ_DITHER_SUB = (1 << 19),
 
     FBZ_DEPTH_SOURCE = (1 << 20),
@@ -655,6 +658,8 @@ enum {
 
 #define src_afunc               ((params->alphaMode >> 8) & 0xf)
 #define dest_afunc              ((params->alphaMode >> 12) & 0xf)
+#define src_aafunc              ((params->alphaMode >> 16) & 0xf)
+#define dest_aafunc             ((params->alphaMode >> 20) & 0xf)
 #define alpha_func              ((params->alphaMode >> 1) & 7)
 #define a_ref                   (params->alphaMode >> 24)
 #define depth_op                ((params->fbzMode >> 5) & 7)


### PR DESCRIPTION
Summary
=======
Implement Voodoo alpha planes and alpha mask support.

Fallback to interpreter if alpha planes are used for now.

Fixes transparent textures in Lands of Lore III.

Checklist
=========
* [X] Closes https://github.com/86Box/86Box/issues/5067
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
