### PR TITLE
CPU: Restrict allowed opcodes in INC/DEC Grp4

### DIFF
--- a/src/cpu/x86_ops_inc_dec.h
+++ b/src/cpu/x86_ops_inc_dec.h
@@ -56,16 +56,23 @@ opINCDEC_b_a16(uint32_t fetchdat)
     if (cpu_state.abrt)
         return 1;
 
-    if (rmdat & 0x38) {
-        seteab(temp - 1);
-        if (cpu_state.abrt)
-            return 1;
-        setsub8nc(temp, 1);
-    } else {
-        seteab(temp + 1);
-        if (cpu_state.abrt)
-            return 1;
-        setadd8nc(temp, 1);
+    switch (rmdat & 0x38) {
+        case 0: /* INC r/m8 */
+            seteab(temp + 1);
+            if (cpu_state.abrt)
+                return 1;
+            setadd8nc(temp, 1);
+            break;
+        case 0x8: /* DEC r/m8 */
+            seteab(temp - 1);
+            if (cpu_state.abrt)
+                return 1;
+            setsub8nc(temp, 1);
+            break;
+        default:
+            cpu_state.pc = cpu_state.oldpc;
+            x86illegal();
+            break;
     }
     CLOCK_CYCLES((cpu_mod == 3) ? timing_rr : timing_mm);
     PREFETCH_RUN((cpu_mod == 3) ? timing_rr : timing_mm, 2, rmdat, (cpu_mod == 3) ? 0 : 1, 0, (cpu_mod == 3) ? 0 : 1, 0, 0);
@@ -83,16 +90,23 @@ opINCDEC_b_a32(uint32_t fetchdat)
     if (cpu_state.abrt)
         return 1;
 
-    if (rmdat & 0x38) {
-        seteab(temp - 1);
-        if (cpu_state.abrt)
-            return 1;
-        setsub8nc(temp, 1);
-    } else {
-        seteab(temp + 1);
-        if (cpu_state.abrt)
-            return 1;
-        setadd8nc(temp, 1);
+    switch (rmdat & 0x38) {
+        case 0: /* INC r/m8 */
+            seteab(temp + 1);
+            if (cpu_state.abrt)
+                return 1;
+            setadd8nc(temp, 1);
+            break;
+        case 0x8: /* DEC r/m8 */
+            seteab(temp - 1);
+            if (cpu_state.abrt)
+                return 1;
+            setsub8nc(temp, 1);
+            break;
+        default:
+            cpu_state.pc = cpu_state.oldpc;
+            x86illegal();
+            break;
     }
     CLOCK_CYCLES((cpu_mod == 3) ? timing_rr : timing_mm);
     PREFETCH_RUN((cpu_mod == 3) ? timing_rr : timing_mm, 2, rmdat, (cpu_mod == 3) ? 0 : 1, 0, (cpu_mod == 3) ? 0 : 1, 0, 1);


### PR DESCRIPTION
Summary
=======
This fixes an issue in the `FE` opcode (referred in Intel docs as "INC/DEC Grp 4") where any ModR/M Opcode bits other than 000 act as `DEC r/m8`. All other values than 000 or 001 are invalid and should throw `#UD` on processors that support that.

This also shows on actual hardware: similarly-configured Cyrix 5x86 and 486DX systems throw a `#UD` exception, but not in 86Box. (Thanks to @goshhhy for testing this!)

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
[_Intel® 64 and IA-32 Architectures Software Developer's Manual Combined Volumes 2A, 2B, 2C, and 2D_](https://cdrdv2.intel.com/v1/dl/getContent/671110), Appendix A.4.2.

Tested using the boot sector program here: https://datagirl.xyz/pub/grp4test.bin (source code: https://datagirl.xyz/pub/grp4test.asm)