### PR TITLE
VM Manager: prevent single-click activation from starting VM in some environments

### DIFF
--- a/src/qt/qt_vmmanager_main.cpp
+++ b/src/qt/qt_vmmanager_main.cpp
@@ -23,6 +23,7 @@
 #include <QStringListModel>
 #include <QTimer>
 #include <QProgressDialog>
+#include <QShortcut>
 
 #include <thread>
 #include <atomic>
@@ -404,7 +405,12 @@ illegal_chars:
         ui->listView->setCurrentIndex(first_index);
     }
 
-    connect(ui->listView, &QListView::activated, this, &VMManagerMain::startButtonPressed);
+    // Connect double-click to start VM
+    connect(ui->listView, &QListView::doubleClicked, this, &VMManagerMain::startButtonPressed);
+
+    // Connect Enter key to start VM
+    auto enterShortcut = new QShortcut(QKeySequence(Qt::Key_Return), ui->listView);
+    connect(enterShortcut, &QShortcut::activated, this, &VMManagerMain::startButtonPressed);
 
     // Load and apply settings
     loadSettings();


### PR DESCRIPTION
Summary
=======
Fixes a regression introduced in commit 75499ad.

On some platforms (Qt 5.15 / Wayland), QListView::activated() triggers on a single click,
causing virtual machines to start unintentionally. This change replaces the use of
`activated()` with:

- Single click → no VM start (fixes unintended activation)
- Double click → starts VM (classic behavior)
- Enter → starts VM (new feature)


Checklist
=========
* [x] I have tested my changes locally and validated that the functionality works as intended

Testing
=========
- Single click on a VM → nothing happens
- Double click on a VM → VM starts
- Press Enter while VM selected → VM starts
- Verified on Wayland + Qt 5.15.18


References
==========
- Regression commit: https://github.com/86Box/86Box/commit/75499ad
- GDB backtrace confirming the original issue:
[gdb.txt](https://github.com/user-attachments/files/24169458/gdb.txt)
