### PR TITLE
Manager: Implement defaults for manager config

### DIFF
--- a/src/qt/qt_vmmanager_config.cpp
+++ b/src/qt/qt_vmmanager_config.cpp
@@ -18,7 +18,17 @@
 
 extern "C" {
 #include <86box/plat.h>
+#include <86box/version.h>
 }
+
+QVariantHash VMManagerConfig::generalDefaults = {
+    { "hide_tool_bar",   0 },
+    { "regex_search",    0 },
+#if EMU_BUILD_NUM != 0
+    { "update_check",    1 },
+#endif
+    { "window_remember", 0 }
+};
 
 VMManagerConfig::VMManagerConfig(const ConfigType type, const QString &section)
 {
@@ -36,6 +46,8 @@ VMManagerConfig::VMManagerConfig(const ConfigType type, const QString &section)
     settings->setFallbacksEnabled(false);
     if (type == ConfigType::System && !section.isEmpty()) {
         settings->beginGroup(section);
+    } else {
+        settings->beginGroup("");
     }
 }
 
@@ -47,7 +59,10 @@ VMManagerConfig::~VMManagerConfig()
 QString
 VMManagerConfig::getStringValue(const QString &key) const
 {
-    const auto value = settings->value(key);
+    auto defaultValue = QVariant();
+    if ((config_type == ConfigType::General) && (generalDefaults.contains(key)))
+        defaultValue = generalDefaults[key];
+    const auto value = settings->value(key, defaultValue);
     // An invalid QVariant with toString will give a default QString value which is blank.
     // Therefore any variables that do not exist will return blank strings
     return value.toString();

--- a/src/qt/qt_vmmanager_config.hpp
+++ b/src/qt/qt_vmmanager_config.hpp
@@ -35,6 +35,8 @@ public:
 
     void sync() const;
 
+    static QVariantHash generalDefaults;
+
     QSettings *settings;
     ConfigType config_type;
     QString    system_name;

--- a/src/qt/qt_vmmanager_mainwindow.cpp
+++ b/src/qt/qt_vmmanager_mainwindow.cpp
@@ -109,8 +109,6 @@ VMManagerMainWindow::
         ui->actionHide_tool_bar->setChecked(!!config->getStringValue("hide_tool_bar").toInt());
         if (ui->actionHide_tool_bar->isChecked())
             ui->toolBar->setVisible(false);
-        else
-            config->setStringValue("hide_tool_bar", "0");
         if (!!config->getStringValue("window_remember").toInt()) {
             QString coords = config->getStringValue("window_coordinates");
             if (!coords.isEmpty()) {

--- a/src/qt/qt_vmmanager_preferences.cpp
+++ b/src/qt/qt_vmmanager_preferences.cpp
@@ -59,7 +59,6 @@ VMManagerPreferences::
     }
     ui->comboBoxLanguage->model()->sort(Qt::AscendingOrder);
 
-    // TODO: Defaults
 #if EMU_BUILD_NUM != 0
     const auto configUpdateCheck = config->getStringValue("update_check").toInt();
     ui->updateCheckBox->setChecked(configUpdateCheck);


### PR DESCRIPTION

Summary
=======
Implement defaults for the manager's configuration system. Update checker is now enabled by default.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set

References
==========
N/A