### PR TITLE
Voodoo misc. fixes

### DIFF
--- a/src/video/vid_voodoo_banshee.c
+++ b/src/video/vid_voodoo_banshee.c
@@ -129,6 +129,7 @@ typedef struct banshee_t {
     uint32_t agpHostAddressLow;
     uint32_t agpGraphicsAddress;
     uint32_t agpGraphicsStride;
+    uint32_t agpMoveCMD;
 
     int overlay_pix_fmt;
 
@@ -1372,6 +1373,10 @@ banshee_cmd_read(banshee_t *banshee, uint32_t addr)
             ret = banshee->agpReqSize;
             break;
 
+        case Agp_agpMoveCMD:
+            ret = banshee->agpMoveCMD;
+            break;
+
         case cmdBaseAddr0:
             ret = voodoo->cmdfifo_base >> 12;
 #if 0
@@ -1694,6 +1699,7 @@ banshee_cmd_write(void *priv, uint32_t addr, uint32_t val)
 #if 0
             banshee_log("AGP: %d bytes W%d from %08x S%d to %d:%08x S%d\n", src_end - src_addr, src_width, src_addr, src_stride, (val >> 3) & 3, dest_addr, dest_stride);
 #endif
+            banshee->agpMoveCMD = val;
             switch ((val >> 3) & 3) {
                 case 0: /*Linear framebuffer (Banshee)*/
                 case 1: /*Planar YUV*/

--- a/src/video/vid_voodoo_fb.c
+++ b/src/video/vid_voodoo_fb.c
@@ -373,7 +373,6 @@ voodoo_fb_writel(uint32_t addr, uint32_t val, void *priv)
             colour_data[0].b = val & 0xff;
             colour_data[0].g = (val >> 8) & 0xff;
             colour_data[0].r = (val >> 16) & 0xff;
-            alpha_data[0]    = 0xff;
             write_mask       = LFB_WRITE_COLOUR;
             addr >>= 1;
             break;
@@ -383,12 +382,14 @@ voodoo_fb_writel(uint32_t addr, uint32_t val, void *priv)
             depth_data[0]  = val >> 16;
             write_mask     = LFB_WRITE_BOTH;
             count          = 1;
+            addr >>= 1;
             break;
         case LFB_FORMAT_DEPTH_RGB555:
             colour_data[0] = argb1555[val & 0xffff];
             depth_data[0]  = val >> 16;
             write_mask     = LFB_WRITE_BOTH;
             count          = 1;
+            addr >>= 1;
             break;
         case LFB_FORMAT_DEPTH_ARGB1555:
             colour_data[0] = argb1555[val & 0xffff];
@@ -396,6 +397,7 @@ voodoo_fb_writel(uint32_t addr, uint32_t val, void *priv)
             depth_data[0]  = val >> 16;
             write_mask     = LFB_WRITE_BOTH;
             count          = 1;
+            addr >>= 1;
             break;
 
         case LFB_FORMAT_DEPTH:


### PR DESCRIPTION
Summary
=======
1. Allow agpMoveCMD register reads.
2. Fix bad depth + 16-bit RGB565 writes.

Checklist
=========
* [X] Closes #6461
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
