### PR TITLE
Revert recent NDR memory block changes

### DIFF
--- a/src/codegen_new/codegen_allocator.c
+++ b/src/codegen_new/codegen_allocator.c
@@ -7,7 +7,6 @@
 #    include <windows.h>
 #endif
 
-#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -19,59 +18,6 @@
 
 #include "codegen.h"
 #include "codegen_allocator.h"
-#include "codegen_backend.h"
-
-struct mem_code_block_t;
-
-typedef struct mem_code_block_t
-{
-    struct mem_code_block_t* prev;
-    struct mem_code_block_t* next;
-
-    int number;
-} mem_code_block_t;
-
-static bool valid_code_blocks[BLOCK_SIZE];
-static mem_code_block_t mem_code_blocks[BLOCK_SIZE];
-static mem_code_block_t* mem_code_block_head = NULL;
-static mem_code_block_t* mem_code_block_tail = NULL;
-
-static void
-remove_from_block_list(mem_code_block_t* block)
-{
-    valid_code_blocks[block->number] = 0;
-    if (block->prev) {
-        block->prev->next = block->next;
-        if (block->next) {
-            block->next->prev = block->prev;
-        } else {
-            mem_code_block_tail = block->prev;
-        }
-    } else if (block->next) {
-        mem_code_block_head = block->next;
-        if (mem_code_block_head && mem_code_block_head->next) {
-            mem_code_block_head->next->prev = mem_code_block_head;
-        }
-    } else if (block == mem_code_block_head) {
-        mem_code_block_head = mem_code_block_tail = NULL;
-    }
-    block->next = block->prev = NULL;
-}
-
-static void
-add_to_block_list(int code_block)
-{
-    if (!mem_code_block_head) {
-        mem_code_block_head = &mem_code_blocks[code_block];
-        mem_code_block_head->number = code_block;
-        mem_code_block_tail = mem_code_block_head;
-    } else {
-        mem_code_block_tail->next = &mem_code_blocks[code_block];
-        mem_code_blocks[code_block].prev = mem_code_block_tail;
-        mem_code_block_tail = &mem_code_blocks[code_block];
-        mem_code_blocks[code_block].number = code_block;
-    }
-}
 
 typedef struct mem_block_t {
     uint32_t offset; /*Offset into mem_block_alloc*/
@@ -107,26 +53,15 @@ codegen_allocator_allocate(mem_block_t *parent, int code_block)
     mem_block_t *block;
     uint32_t     block_nr;
 
-    if (!mem_block_free_list) {
-        if (mem_code_block_head == mem_code_block_tail) {
-            fatal("Out of memory blocks!\n");
-        } else {
-            mem_code_block_t* mem_code_block = mem_code_block_head;
-            while (mem_code_block) {
-                if (code_block != mem_code_block->number) {
-                    codegen_delete_block(&codeblock[mem_code_block->number]);
-                }
-                mem_code_block = mem_code_block->next;
-            }
+    while (!mem_block_free_list) {
+        /*Pick a random memory block and free the owning code block*/
+        block_nr = rand() & MEM_BLOCK_MASK;
+        block    = &mem_blocks[block_nr];
 
-            if (mem_block_free_list)
-                goto block_allocate;
-
-            fatal("Out of memory blocks!\n");
-        }
+        if (block->code_block && block->code_block != code_block)
+            codegen_delete_block(&codeblock[block->code_block]);
     }
 
-block_allocate:
     /*Remove from free list*/
     block_nr            = mem_block_free_list;
     block               = &mem_blocks[block_nr - 1];
@@ -137,14 +72,8 @@ block_allocate:
         /*Add to parent list*/
         block->next  = parent->next;
         parent->next = block_nr;
-    } else {
+    } else
         block->next = 0;
-        
-        if (!valid_code_blocks[code_block]) {
-            valid_code_blocks[code_block] = 1;
-            add_to_block_list(code_block);
-        }
-    }
 
     codegen_allocator_usage++;
     return block;
@@ -153,9 +82,6 @@ void
 codegen_allocator_free(mem_block_t *block)
 {
     int block_nr = (((uintptr_t) block - (uintptr_t) mem_blocks) / sizeof(mem_block_t)) + 1;
-
-    if (valid_code_blocks[block->code_block])
-        remove_from_block_list(&mem_code_blocks[block->code_block]);
 
     while (1) {
         int next_block_nr = block->next;

--- a/src/codegen_new/codegen_block.c
+++ b/src/codegen_new/codegen_block.c
@@ -559,10 +559,6 @@ codegen_block_start_recompile(codeblock_t *block)
         fatal("Recompile to used block!\n");
 #endif
 
-    if (block->head_mem_block) {
-        codegen_allocator_free(block->head_mem_block);
-        block->head_mem_block = NULL;
-    }
     block->head_mem_block = codegen_allocator_allocate(NULL, block_current);
     block->data           = codeblock_allocator_get_ptr(block->head_mem_block);
 


### PR DESCRIPTION
Summary
=======
Revert "Merge pull request #6017 from Cacodemon345/ndr-memory-blocks"

This reverts commit cc46ea4d8eb3f32019a4fe9f315cfa573187fd9c, reversing changes made to a2056d7fd86b47b5dc657fa7c427bb9e3a9d31c1.

Needs more work for 6.0.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
