### PR TITLE
Fix refresh rate display if Voodoo 1/2 Graphics is active

### DIFF
--- a/src/video/vid_voodoo_display.c
+++ b/src/video/vid_voodoo_display.c
@@ -645,6 +645,8 @@ skip_draw:
 
             if (voodoo->dirty_line_high > voodoo->dirty_line_low || force_blit)
                 svga_doblit(voodoo->h_disp, voodoo->v_disp - 1, voodoo->svga);
+            else if (voodoo->svga->override)
+                voodoo->svga->monitor->mon_renderedframes++;
             if (voodoo->clutData_dirty) {
                 voodoo->clutData_dirty = 0;
                 voodoo_calc_clutData(voodoo);


### PR DESCRIPTION
Summary
=======
Fix refresh rate display if Voodoo 1/2 Graphics is active.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
