### PR TITLE
Fix black/white dot glitches in Voodoo 2

### DIFF
--- a/src/video/vid_voodoo_blitter.c
+++ b/src/video/vid_voodoo_blitter.c
@@ -233,7 +233,7 @@ skip_pixel_blit:
                 } else
                     dst = (uint16_t *) &voodoo->fb_mem[dst_base_addr + dst_y * dst_stride];
 
-                for (int x = 0; x <= size_x; x++) {
+                for (int x = 0; x < size_x; x++) {
                     if (voodoo->bltCommand & BLIT_CLIPPING_ENABLED) {
                         if (dst_x < voodoo->bltClipLeft || dst_x >= voodoo->bltClipRight || dst_y < voodoo->bltClipLowY || dst_y >= voodoo->bltClipHighY)
                             goto skip_pixel_fill;


### PR DESCRIPTION
Summary
=======
Fix black/white dot glitches in Voodoo 2.

Fixes Grim Fandango display.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
