### PR TITLE
Use lock emoji to indicate write-protected recent disk images.

### DIFF
--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -668,7 +668,7 @@ MediaMenu::updateImageHistory(int index, int slot, ui::MediaType type)
             else
                 fi.setFile(fn);
             if (!fi.fileName().isEmpty() && (fn.left(5) == "wp://")) {
-                menu_item_name = fi.fileName().isEmpty() ? tr("Reload previous image") : fn.right(fn.length() - 5);
+                menu_item_name = fi.fileName().isEmpty() ? tr("Reload previous image") : "🔒 " + fn.right(fn.length() - 5);
                 imageHistoryUpdatePos->setIcon(getIconWithIndicator(menu_icon, pixmap_size, QIcon::Normal, WriteProtected));
             } else {
                 menu_item_name = fi.fileName().isEmpty() ? tr("Reload previous image") : fn;
@@ -696,7 +696,7 @@ MediaMenu::updateImageHistory(int index, int slot, ui::MediaType type)
             else
                 fi.setFile(fn);
             if (!fi.fileName().isEmpty() && (fn.left(5) == "wp://")) {
-                menu_item_name = fi.fileName().isEmpty() ? tr("Reload previous image") : fn.right(fn.length() - 5);
+                menu_item_name = fi.fileName().isEmpty() ? tr("Reload previous image") : "🔒 " + fn.right(fn.length() - 5);
                 imageHistoryUpdatePos->setIcon(getIconWithIndicator(menu_icon, pixmap_size, QIcon::Normal, WriteProtected));
             } else {
                 menu_item_name = fi.fileName().isEmpty() ? tr("Reload previous image") : fn;
@@ -735,7 +735,7 @@ MediaMenu::updateImageHistory(int index, int slot, ui::MediaType type)
             else
                 fi.setFile(fn);
             if (!fi.fileName().isEmpty() && (fn.left(5) == "wp://")) {
-                menu_item_name = fi.fileName().isEmpty() ? tr("Reload previous image") : fn.right(fn.length() - 5);
+                menu_item_name = fi.fileName().isEmpty() ? tr("Reload previous image") : "🔒 " + fn.right(fn.length() - 5);
                 imageHistoryUpdatePos->setIcon(getIconWithIndicator(menu_icon, pixmap_size, QIcon::Normal, WriteProtected));
             } else {
                 menu_item_name = fi.fileName().isEmpty() ? tr("Reload previous image") : fn;
@@ -754,7 +754,7 @@ MediaMenu::updateImageHistory(int index, int slot, ui::MediaType type)
             else
                 fi.setFile(fn);
             if (!fi.fileName().isEmpty() && (fn.left(5) == "wp://")) {
-                menu_item_name = fi.fileName().isEmpty() ? tr("Reload previous image") : fn.right(fn.length() - 5);
+                menu_item_name = fi.fileName().isEmpty() ? tr("Reload previous image") : "🔒 " + fn.right(fn.length() - 5);
                 imageHistoryUpdatePos->setIcon(getIconWithIndicator(menu_icon, pixmap_size, QIcon::Normal, WriteProtected));
             } else {
                 menu_item_name = fi.fileName().isEmpty() ? tr("Reload previous image") : fn;


### PR DESCRIPTION
Summary
=======
This makes the menu look a little more visually distinct and obvious when a recent disk image item is set to write-protected mode.  While an icon does exist, I have found it to be small and visually indistinguisable enough that I didn't even know it existed before I dug into the code.

This prefixes image names with U+1F512 LOCK (🔒).  My first iteration also added U+1F513 OPEN LOCK (🔓) to read-write image names, but I quickly found that to be too visually distracting and confusing next to the write-protect symbols, so I have opted to only keep the first one.

This might have a caveat that the symbol will fail to show up on systems without the lock emoji somewhere in their font set, but these days, I expect pretty much everyone to be on OSes that come with the full set of emoji fonts anyhow.

![86box-lock-emoji](https://github.com/user-attachments/assets/5d17ae18-d6db-4ae0-b96f-e26abf50c221)

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
