### PR TITLE
Play/record indicators for cassette

### DIFF
--- a/src/device/cassette.c
+++ b/src/device/cassette.c
@@ -500,7 +500,10 @@ pc_cas_set_motor(pc_cassette_t *cas, unsigned char val)
     else
         timer_disable(&cas->timer);
 
-    ui_sb_update_icon(SB_CASSETTE, !!val);
+    if (!cas->save)
+        ui_sb_update_icon(SB_CASSETTE, !!val);
+    else
+        ui_sb_update_icon_write(SB_CASSETTE, !!val);
 }
 
 unsigned char
@@ -665,8 +668,12 @@ cassette_callback(void *priv)
 
     pc_cas_clock(cas, 8);
 
-    if (cas->motor)
-        ui_sb_update_icon(SB_CASSETTE, 1);
+    if (cas->motor) {
+        if (cas->pcm && cas->save)
+            ui_sb_update_icon_write(SB_CASSETTE, 1);
+        else
+            ui_sb_update_icon(SB_CASSETTE, 1);
+    }
 
     timer_advance_u64(&cas->timer, 8ULL * PITCONST);
 }

--- a/src/qt/qt_iconindicators.cpp
+++ b/src/qt/qt_iconindicators.cpp
@@ -14,6 +14,8 @@ getIndicatorIcon(IconIndicator indicator)
             return QIcon(":/settings/qt/icons/active.ico");
         case WriteActive:
             return QIcon(":/settings/qt/icons/write_active.ico");
+        case Record:
+            return QIcon(":/settings/qt/icons/record.ico");
         case Disabled:
             return QIcon(":/settings/qt/icons/disabled.ico");
         case WriteProtected:
@@ -41,17 +43,21 @@ getIconWithIndicator(const QIcon &icon, const QSize &size, QIcon::Mode iconMode,
 
     auto painter         = QPainter(&iconPixmap);
     auto indicatorPixmap = getIndicatorIcon((indicator == ReadWriteActive || indicator == WriteProtectedActive
-                                            || indicator == PlayActive || indicator == PauseActive)? Active : indicator)
-                                            .pixmap((indicator == Play || indicator == Pause) ? size / 2. : size);
+                                            || indicator == PlayActive || indicator == PauseActive) ? Active :
+                                            (indicator == RecordWriteActive) ? Record : indicator)
+                                            .pixmap((indicator == Play || indicator == Pause || indicator == Record || indicator == RecordWriteActive) ? size / 2. : size);
 
     if (indicator == WriteProtectedBrowse)
         indicatorPixmap = getIndicatorIcon(WriteProtected).pixmap(size);
 
-    painter.drawPixmap(0, (indicator == Play || indicator == Pause) ? (size.height() / 2) : 0, indicatorPixmap);
+    if (indicator == Record || indicator == RecordWriteActive)
+        painter.drawPixmap(size.width() / 2, size.height() / 2, indicatorPixmap);
+    else
+        painter.drawPixmap(0, (indicator == Play || indicator == Pause) ? (size.height() / 2) : 0, indicatorPixmap);
     if (indicator == PlayActive || indicator == PauseActive) {
         auto playPauseIndicatorPixmap = getIndicatorIcon(indicator == PlayActive ? Play : Pause).pixmap(size / 2.);
         painter.drawPixmap(0, size.height() / 2, playPauseIndicatorPixmap);
-    } else if ((indicator == ReadWriteActive) || (indicator == WriteProtectedActive)) {
+    } else if ((indicator == ReadWriteActive) || (indicator == WriteProtectedActive) || (indicator == RecordWriteActive)) {
         auto writeIndicatorPixmap = getIndicatorIcon(indicator == WriteProtectedActive ? WriteProtected : WriteActive).pixmap(size);
         painter.drawPixmap(0, 0, writeIndicatorPixmap);
     } else if (indicator == WriteProtectedBrowse) {

--- a/src/qt/qt_iconindicators.hpp
+++ b/src/qt/qt_iconindicators.hpp
@@ -20,7 +20,9 @@ enum IconIndicator {
     Play,
     Pause,
     PlayActive,
-    PauseActive
+    PauseActive,
+    Record,
+    RecordWriteActive
 };
 
 QPixmap getIconWithIndicator(const QIcon &icon, const QSize &size, QIcon::Mode iconMode, IconIndicator indicator);


### PR DESCRIPTION
Summary
=======
Play/record indicators for cassette.
<img width="642" height="501" alt="image" src="https://github.com/user-attachments/assets/7b3a3724-69cc-426a-a822-4125cf5b47b1" />


Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
