### PR TITLE
Fixes FDC/FDD recalibration not working correctly with audio profiles

### DIFF
--- a/src/floppy/fdc.c
+++ b/src/floppy/fdc.c
@@ -1142,7 +1142,7 @@ fdc_write(uint16_t addr, uint8_t val, void *priv)
                                     timer_set_delay_u64(&fdc->timer, 1000 * TIMER_USEC);
                                 else
                                     timer_set_delay_u64(&fdc->timer, 256 * TIMER_USEC);
-                                break;
+                                break;                                
                             default:
                                 timer_set_delay_u64(&fdc->timer, 256 * TIMER_USEC);
                                 break;
@@ -1882,13 +1882,17 @@ fdc_callback(void *priv)
             fdc->st0                     = 0x20 | (fdc->params[0] & 3);
             if (!fdd_track0(drive_num))
                 fdc->st0 |= 0x50;
-            if (fdc->flags & FDC_FLAG_PCJR) {
-                fdc->fintr     = 1;
-                fdc->interrupt = -4;
-            } else
-                fdc->interrupt = -3;
-            timer_set_delay_u64(&fdc->timer, 2048 * TIMER_USEC);
             fdc->stat = 0x10 | (1 << fdc->rw_drive);
+            if (fdd_get_turbo(drive_num)) {
+                if (fdc->flags & FDC_FLAG_PCJR) {
+                    fdc->fintr     = 1;
+                    fdc->interrupt = -4;
+                } else {
+                    fdc->interrupt = -3;
+                }
+                timer_set_delay_u64(&fdc->timer, 2048 * TIMER_USEC);
+            }
+            /* Interrupts and callbacks in the fdd callback function (fdc_seek_complete_interrupt) */
             return;
         case 0x0d: /*Format track*/
             if (fdc->format_state == 1) {

--- a/src/floppy/fdd.c
+++ b/src/floppy/fdd.c
@@ -419,19 +419,14 @@ fdd_seek(int drive, int track_diff)
 
     fdd_changed[drive] = 0;
 
-    if (fdd[drive].turbo)
+    if (fdd[drive].turbo) {
         fdd_do_seek(drive, fdd[drive].track);
-    else {
+    } else {
         /* Trigger appropriate audio for track movements */
         int actual_track_diff = abs(old_track - fdd[drive].track);
         if (actual_track_diff > 0) {
             /* Multi-track seek */
             fdd_audio_play_multi_track_seek(drive, old_track, fdd[drive].track);
-        }
-
-        if (old_track + track_diff < 0) {
-            fdd_do_seek(drive, fdd[drive].track);
-            return;
         }
 
         fdd_seek_in_progress[drive] = 1;


### PR DESCRIPTION
Summary
=======
Fixes FDC/FDD recalibration not working correctly with audio profiles, even when audio profile was set to "None". 

In the previous FDD/FDC implementation it was not taken to account that recalibration should not return immediadely, but let the FDD do the recalibration seek first and after it completes, then next command is allowed. The recalibration sequence follows now same path as the normal seek does where FDD calls the "fdc seek complete" function when seek is finished.

This fixes issue, when e.g. when installed MS-DOS 6.22 and after reboot BIOS displayed floppy disk error (40). The problem was that MS-DOS installation left the FDD to upper part of the tracks and then during the boot, BIOS would try to recalibrate head back to track 0, but the FDC returned the seek "complete" immediadely to the BIOS, even when the FDD had seek timer ongoing. This created a situation where the next FDD POST test seek command was sent from BIOS before the recalibration seek was done and the FDD/FDC were left to "undefined" state and resulted the error status in the BIOS.

This also fixes the issue where recalibration seeks were not played by the fdd audio.

Tested with PCjr, IBM PC 1981, IBM PS/1 and 1995ish AMIBIOS. Used MS-DOS 6.22, OS/2 and Debian Linux 0.9 installation disks.  Tested also that Turbo mode still works correclty.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/