### PR TITLE
AD1816 fixes

### DIFF
--- a/src/sound/snd_ad1816.c
+++ b/src/sound/snd_ad1816.c
@@ -129,12 +129,12 @@ ad1816_update_mastervol(void *priv)
     if (ad1816->iregs[14] & 0x8000)
         ad1816->master_l = 0;
     else
-        ad1816->master_l = ad1816_vols_5bits[(ad1816->iregs[14] >> 8) & 0x1f] / 65536.0;
+        ad1816->master_l = ad1816_vols_5bits[((ad1816->iregs[14] >> 8) & 0x1f) >> 1] / 65536.0;
 
     if (ad1816->iregs[14] & 0x0080)
         ad1816->master_r = 0;
     else
-        ad1816->master_r = ad1816_vols_5bits[(ad1816->iregs[14]) & 0x1f] / 65536.0;
+        ad1816->master_r = ad1816_vols_5bits[((ad1816->iregs[14]) & 0x1f) >> 1] / 65536.0;
 }
 
 void
@@ -327,12 +327,12 @@ ad1816_poll(void *priv)
         if (ad1816->iregs[4] & 0x8000)
             ad1816->out_l = 0;
         else
-            ad1816->out_l = (int16_t) ((ad1816->out_l * ad1816_vols_6bits[(ad1816->iregs[4] >> 8) & 0x3f]) >> 16);
+            ad1816->out_l = (int16_t) ((ad1816->out_l * ad1816_vols_6bits[((ad1816->iregs[4] >> 8) & 0x3f) >> 1]) >> 16);
 
         if (ad1816->iregs[4] & 0x0080)
             ad1816->out_r = 0;
         else
-            ad1816->out_r = (int16_t) ((ad1816->out_r * ad1816_vols_6bits[ad1816->iregs[4] & 0x3f]) >> 16);
+            ad1816->out_r = (int16_t) ((ad1816->out_r * ad1816_vols_6bits[(ad1816->iregs[4] & 0x3f) >> 1]) >> 16);
 
         if (ad1816->count < 0) {
             ad1816->count     = ad1816->iregs[8];


### PR DESCRIPTION
Summary
=======
Make the following changes to the AD1816:
- Don't reset playback_pos (byte counter) when sample count drops below 0, fixes some playback glitches on the Windows 3.1 drivers
- Right shift the wave and master volume values by 1 to make wave output audible on Windows 3.1 with the default mixer volume values. Also makes the mid-point wave volume setting usable on other drivers.

Checklist
=========
* [x] Closes #6626
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
