### PR TITLE
Block incompatible WinChip CPUs on the HP Ruby USB machine

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -14788,7 +14788,7 @@ const machine_t machines[] = {
         .cpu               = {
             .package     = CPU_PKG_SOCKET5_7,
             .block       = CPU_BLOCK(CPU_K5, CPU_5K86, CPU_K6, CPU_K6_2, CPU_K6_2C, CPU_K6_3, CPU_K6_2P,
-                               CPU_K6_3P, CPU_Cx6x86, CPU_Cx6x86MX, CPU_Cx6x86L),
+                               CPU_K6_3P, CPU_Cx6x86, CPU_Cx6x86MX, CPU_Cx6x86L, CPU_WINCHIP, CPU_WINCHIP2),
             .min_bus     = 50000000,
             .max_bus     = 66666667,
             .min_voltage = 2800,


### PR DESCRIPTION
Summary
=======
Block incompatible WinChip CPUs on the HP Ruby USB (Pavilion 73xx/74xx)

Checklist
=========
* [x] Closes #6636
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
