### PR TITLE
Translations update from 86Box Weblate

### DIFF
--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2025-12-06 18:56+0000\n"
+"PO-Revision-Date: 2025-12-29 09:54+0000\n"
 "Last-Translator: Daniel Gurney <daniel@gurney.dev>\n"
 "Language-Team: Finnish <https://weblate.86box.net/projects/86box/86box/fi/>\n"
 "Language: fi-FI\n"
@@ -211,13 +211,13 @@ msgid "Take s&creenshot"
 msgstr "Ota &kuvakaappaus"
 
 msgid "Take &raw screenshot"
-msgstr "Ota &raaka kuvakaapus"
+msgstr "Ota &raaka kuvakaappaus"
 
 msgid "C&opy screenshot"
-msgstr "K&opia kuvakaapaus"
+msgstr "K&opioi kuvakaappaus"
 
 msgid "Copy r&aw screenshot"
-msgstr "Kopia r&aaka kuvakaapaus"
+msgstr "Kopioi r&aaka kuvakaappaus"
 
 msgid "S&ound"
 msgstr "&Ääni"


### PR DESCRIPTION
Translations update from [86Box Weblate](https://weblate.86box.net) for [86Box/86Box](https://weblate.86box.net/projects/86box/86box/).



Current translation status:

![Weblate translation status](https://weblate.86box.net/widget/86box/86box/horizontal-auto.svg)