### PR TITLE
Add 3 more BIOSes for Gigabyte GA-686BX machine

### DIFF
--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -718,8 +718,35 @@ static const device_config_t ga686_config[] = {
                 .files         = { "roms/machines/686bx/31nologo.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision F2a",
+                .name          = "Award Modular BIOS v4.51PG - Revision 2.9",
+                .internal_name = "686bx_29",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 262144,
+                .files         = { "roms/machines/686bx/6BX.29", "" }
+            },
+            {
+                .name          = "Award Modular BIOS v4.51PG - Revision 3.1a",
+                .internal_name = "686bx_31a",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 262144,
+                .files         = { "roms/machines/686bx/6BX.31a", "" }
+            },
+            {
+                .name          = "Award Modular BIOS v4.51PG - Revision F1",
                 .internal_name = "686bx",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 262144,
+                .files         = { "roms/machines/686bx/6BX.F1", "" }
+            },
+            {
+                .name          = "Award Modular BIOS v4.51PG - Revision F2a",
+                .internal_name = "686bx_f2a",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
                 .local         = 0,


### PR DESCRIPTION
Summary
=======
This pull request adds more BIOSes for Gigabyte GA-686BX machine:

- Revision 2.9 (10 February 1999)
- Revision 3.1a (6 September 1999)
- Revision F1 (5 February 2001)

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
[GA-686BX BIOSes F1 and F2a Notes on The Retro Web](https://theretroweb.com/motherboards/s/gigabyte-ga-686bx-rev-2.x)
