### PR TITLE
Translations update from 86Box Weblate

### DIFF
--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2025-12-07 13:33+0000\n"
+"PO-Revision-Date: 2025-12-30 13:56+0000\n"
 "Last-Translator: Alexander Babikov <lemondrops358@gmail.com>\n"
 "Language-Team: Russian <https://weblate.86box.net/projects/86box/86box/ru/>\n"
 "Language: ru-RU\n"
@@ -212,13 +212,13 @@ msgid "Take s&creenshot"
 msgstr "Сделать с&криншот"
 
 msgid "Take &raw screenshot"
-msgstr "Сделать &сырой скриншот"
+msgstr "Сделать н&еобработанный скриншот"
 
 msgid "C&opy screenshot"
-msgstr "С&копировать скриншот"
+msgstr "Ско&пировать скриншот"
 
 msgid "Copy r&aw screenshot"
-msgstr "Скопировать с&ырой скриншот"
+msgstr "Скопировать необработанный скрин&шот"
 
 msgid "S&ound"
 msgstr "&Звук"


### PR DESCRIPTION
Translations update from [86Box Weblate](https://weblate.86box.net) for [86Box/86Box](https://weblate.86box.net/projects/86box/86box/).



Current translation status:

![Weblate translation status](https://weblate.86box.net/widget/86box/86box/horizontal-auto.svg)