### PR TITLE
S3 ViRGE: Add cycle timing to MMIO read functions to fix polling performance issue

### DIFF
--- a/src/video/vid_s3_virge.c
+++ b/src/video/vid_s3_virge.c
@@ -24,6 +24,7 @@
 #include <stdatomic.h>
 #define HAVE_STDARG_H
 #include <86box/86box.h>
+#include "cpu.h"
 #include <86box/io.h>
 #include <86box/timer.h>
 #include <86box/dma.h>
@@ -1191,6 +1192,9 @@ s3_virge_mmio_read(uint32_t addr, void *priv)
     virge_t *virge = (virge_t *) priv;
     uint8_t  ret;
 
+    /* Add wait states for MMIO reads to prevent excessive polling */
+    cycles -= virge->svga.monitor->mon_video_timing_read_b;
+
     switch (addr & 0xffff) {
         case 0x8504:
             if (!virge->virge_busy)
@@ -1242,6 +1246,9 @@ s3_virge_mmio_read_w(uint32_t addr, void *priv)
     virge_t *virge = (virge_t *) priv;
     uint16_t ret;
 
+    /* Add wait states for MMIO reads to prevent excessive polling */
+    cycles -= virge->svga.monitor->mon_video_timing_read_w;
+
     switch (addr & 0xfffe) {
         case 0x8504:
             ret = 0xc000;
@@ -1274,6 +1281,9 @@ s3_virge_mmio_read_l(uint32_t addr, void *priv)
 {
     virge_t *virge = (virge_t *) priv;
     uint32_t ret   = 0xffffffff;
+
+    /* Add wait states for MMIO reads to prevent excessive polling */
+    cycles -= virge->svga.monitor->mon_video_timing_read_l;
 
     switch (addr & 0xfffc) {
         case 0x8180:


### PR DESCRIPTION
Summary
=======
Games that poll the S3 ViRGE status registers via MMIO (such as Star Trek: Generations) experience extreme slowdowns, particularly with the GX2 variant. Profiling revealed that  and related functions were consuming ~25% of CPU time due to tight polling loops executing millions of iterations per second. s3_virge_mmio_read.

Root Cause
=======

The MMIO read functions were missing cycle timing, so any polling loop on the status registers would run at unrealistic speeds. The palette fading in Raptor probably hammers those registers waiting for the GPU to be ready, causing the same issue. This fix adds proper wait states to all MMIO reads, which should resolve it.



Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
