### PR TITLE
Qt: Display names of internal sound/video devices when possible

### DIFF
--- a/src/qt/qt_settingsdisplay.cpp
+++ b/src/qt/qt_settingsdisplay.cpp
@@ -106,6 +106,9 @@ SettingsDisplay::onCurrentMachineChanged(int machineId)
         }
 
         if (video_card_available(c) && device_is_valid(video_dev, machineId)) {
+            if (c == 1 && machine_get_vid_device(machineId)) {
+                name += QString(" (%1)").arg(DeviceConfig::DeviceName(machine_get_vid_device(machineId), machine_get_vid_device(machineId)->internal_name, 0));
+            }
             int row = Models::AddEntry(model, name, c);
             if (c == curVideoCard) {
                 selectedRow = row - removeRows;

--- a/src/qt/qt_settingssound.cpp
+++ b/src/qt/qt_settingssound.cpp
@@ -89,8 +89,8 @@ SettingsSound::onCurrentMachineChanged(const int machineId)
 
     c = 0;
     while (true) {
-        const QString name = DeviceConfig::DeviceName(sound_card_getdevice(c),
-                                                      sound_card_get_internal_name(c), 1);
+        QString name = DeviceConfig::DeviceName(sound_card_getdevice(c),
+                                                sound_card_get_internal_name(c), 1);
 
         if (name.isEmpty())
             break;
@@ -99,6 +99,9 @@ SettingsSound::onCurrentMachineChanged(const int machineId)
             if (device_is_valid(sound_card_getdevice(c), machineId)) {
                 for (uint8_t i = 0; i < SOUND_CARD_MAX; ++i) {
                     if ((c != 1) || ((i == 0) && m_has_snd)) {
+                        if (i == 0 && c == 1 && m_has_snd && machine_get_snd_device(machineId)) {
+                            name += QString(" (%1)").arg(DeviceConfig::DeviceName(machine_get_snd_device(machineId), machine_get_snd_device(machineId)->internal_name, 0));
+                        }
                         int row = Models::AddEntry(models[i], name, c);
 
                         if (c == sound_card_current[i])


### PR DESCRIPTION
Summary
=======
Qt: Display names of internal sound/video devices when possible.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
