### PR TITLE
Fix some crashes on hard reset if cassette is enabled

### DIFF
--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -542,7 +542,7 @@ void
 MachineStatus::refreshIcons()
 {
     /* Always show record/play statuses of cassette even if icon updates are disabled, since it's important to indicate play/record modes. */
-    if (cassette_enable) {
+    if (cassette_enable && cassette) {
         d->cassette.setRecord(!!cassette->save);
         d->cassette.setPlay(!cassette->save);
     }


### PR DESCRIPTION
Summary
=======
Fix some crashes on hard reset if cassette is enabled.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
