### PR TITLE
Fix Voodoo dirty_line index mismatch in non-SLI single buffer mode

### DIFF
--- a/src/video/vid_voodoo_render.c
+++ b/src/video/vid_voodoo_render.c
@@ -1389,8 +1389,11 @@ skip_pixel:
         voodoo->texel_count[odd_even] += state->texel_count;
         voodoo->fbiPixelsIn += state->pixel_count;
 
-        if (voodoo->params.draw_offset == voodoo->params.front_offset && (real_y >> 1) < 2048)
-            voodoo->dirty_line[real_y >> 1] = 1;
+        if (voodoo->params.draw_offset == voodoo->params.front_offset) {
+            int dirty_idx = SLI_ENABLED ? (real_y >> 1) : real_y;
+            if (dirty_idx < 2048)
+                voodoo->dirty_line[dirty_idx] = 1;
+        }
 
 next_line:
         if (SLI_ENABLED) {


### PR DESCRIPTION
Summary
=======
Fix dirty_line index mismatch in Voodoo render thread causing display corruption in single buffer mode.
When rendering to the front buffer in non-SLI mode, the render thread was marking `dirty_line[real_y >> 1]` (line divided by 2), but the display thread was looking for `dirty_line[line]` (undivided line). This caused rendered lines to never be properly displayed, resulting in stale content (previous frame) being shown on parts of the screen.
The fix uses the correct index based on SLI mode:

- SLI enabled: `dirty_line[real_y >> 1]` (each Voodoo handles alternate lines)
- SLI disabled: `dirty_line[real_y]` (standard single-card mode)

This was most visible in 3DMark99 with Voodoo 1/2 in single buffer mode, where the lower portion of the screen would show the previous frame's content instead of being updated.

Root Cause
=======
The render thread in `vid_voodoo_render.c` unconditionally used `dirty_line[real_y >> 1]` to mark lines as dirty, which is only correct for SLI mode where each Voodoo card handles alternate scanlines. In non-SLI mode, the display thread (`vid_voodoo_display.c`) reads `dirty_line[draw_line]` where `draw_line = voodoo->line` (not divided by 2).
This index mismatch meant that when rendering line 100, the render thread marked `dirty_line[50]` as dirty, but the display thread looking at line 100 checked `dirty_line[100]` which was never set, causing that line to never be refreshed on screen.

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========

