### PR TITLE
Add TriGem Como 440EX machine

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -1205,6 +1205,7 @@ extern int             machine_at_ma30d_init(const machine_t *);
 /* i440EX */
 extern int             machine_at_brio83xx_init(const machine_t *);
 extern int             machine_at_p6i440e2_init(const machine_t *);
+extern int             machine_at_como_init(const machine_t *);
 
 /* i440BX */
 extern int             machine_at_bf6_init(const machine_t *);

--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -384,6 +384,39 @@ machine_at_brio83xx_init(const machine_t *model)
 }
 
 int
+machine_at_como_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/como/COMO.ROM",
+                           0x000c0000, 262144, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_common_init_ex(model, 2);
+
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x01, PCI_CARD_AGPBRIDGE,   1, 2, 3, 4);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 4);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x12, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x13, PCI_CARD_NORMAL,      1, 2, 3, 4);
+
+    device_add(&i440ex_device);
+    device_add(&piix4e_device);
+    device_add_params(&fdc37m60x_device, (void*)(FDC37XXX2 | FDC37C93X_NO_NVR | FDC37XXXX_370));
+    device_add(&intel_flash_bxt_device);
+    device_add(&lm78_device);
+
+    if (sound_card_current[0] == SOUND_INTERNAL)
+        device_add(&cs4235_onboard_device);
+
+    return ret;
+}
+
+int
 machine_at_p6i440e2_init(const machine_t *model)
 {
     int ret;

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -18360,6 +18360,52 @@ const machine_t machines[] = {
         .net_device               = NULL
     },
 
+    /* Has a SMC FDC37M60x Super I/O chip with on-chip KBC with AMIKey-2 KBC
+       firmware. */
+    {
+        .name              = "[i440EX] TriGem Como",
+        .internal_name     = "como",
+        .type              = MACHINE_TYPE_SLOT1,
+        .chipset           = MACHINE_CHIPSET_INTEL_440EX,
+        .init              = machine_at_como_init,
+        .p1_handler        = machine_generic_p1_handler,
+        .gpio_handler      = machine_ap440fx_vs440fx_gpio_handler,
+        .available_flag    = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu               = {
+            .package     = CPU_PKG_SLOT1,
+            .block       = CPU_BLOCK(CPU_CYRIX3S),
+            .min_bus     = 66666667,
+            .max_bus     = 83333333,
+            .min_voltage = 2050,
+            .max_voltage = 3100,
+            .min_multi   = 3.5,
+            .max_multi   = 5.0
+        },
+        .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
+        .flags     = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
+        .ram       = {
+            .min  = 8192,
+            .max  = 262144,
+            .step = 8192
+        },
+        .nvrmask                  = 255,
+        .jumpered_ecp_dma         = 0,
+        .default_jumpered_ecp_dma = -1,
+        .kbc_device               = NULL,
+        .kbc_params               = 0x00000000,
+        .kbc_p1                   = 0x00000cf0,
+        .gpio                     = 0xffffffff,
+        .gpio_acpi                = 0xffffffff,
+        .device                   = NULL,
+        .kbd_device               = NULL,
+        .fdc_device               = NULL,
+        .sio_device               = NULL,
+        .vid_device               = NULL,
+        .snd_device               = &cs4235_onboard_device,
+        .net_device               = NULL
+    },
+
     /* 440BX */
     /* Has a Winbond W83977EF Super I/O chip with on-chip KBC with AMIKey-2 KBC
        firmware. */

--- a/src/video/vid_cl54xx.c
+++ b/src/video/vid_cl54xx.c
@@ -768,6 +768,8 @@ gd54xx_out(uint16_t addr, uint8_t val, void *priv)
                             svga->seqregs[6] = 0x0f;
                         if (svga->crtc[0x27] < CIRRUS_ID_CLGD5429)
                             gd54xx->unlocked = (svga->seqregs[6] == 0x12);
+                        else
+                            gd54xx->unlocked = 1;
                         break;
                     case 0x08:
                         if (gd54xx->i2c)
@@ -1642,6 +1644,10 @@ gd54xx_in(uint16_t addr, void *priv)
                         break;
                     case 0x24: /*Attribute controller toggle readback (R)*/
                         ret = svga->attrff << 7;
+                        break;
+                    case 0x25: /* Part ID */
+                        if (svga->crtc[0x27] == CIRRUS_ID_CLGD5434)
+                            ret = 0xb0;
                         break;
                     case 0x26: /*Attribute controller index readback (R)*/
                         ret = svga->attraddr & 0x3f;


### PR DESCRIPTION
Summary
=======
Add TriGem Como 440EX machine.

Drive-by: Emulate Revision E of the CL-GD5434 chip.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [X] This pull request requires changes to the ROM set
  * [X] I have opened a roms pull request - https://github.com/86Box/roms/pull/448/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
