### PR TITLE
Auto-load `gm.dls` on Windows if FluidSynth 2.5.0 or later is detecte…

### DIFF
--- a/src/include/86box/plat.h
+++ b/src/include/86box/plat.h
@@ -151,6 +151,9 @@ extern void     plat_resize_request(int x, int y, int monitor_index);
 extern int      plat_language_code(char *langcode);
 extern void     plat_language_code_r(int id, char *outbuf, int len);
 extern void     plat_get_cpu_string(char *outbuf, uint8_t len);
+#ifdef _WIN32
+extern void     plat_get_system_directory(char *outbuf);
+#endif
 extern void     plat_set_thread_name(void *thread, const char *name);
 extern void     plat_break(void);
 extern void     plat_send_to_clipboard(unsigned char *rgb, int width, int height);

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -752,6 +752,16 @@ plat_chdir(char *path)
     return QDir::setCurrent(QString(path)) ? 0 : -1;
 }
 
+#ifdef _WIN32
+void plat_get_system_directory(char *outbuf)
+{
+    wchar_t wc[512];
+    GetSystemWindowsDirectoryW(wc, 512);
+    QString str = QString::fromWCharArray(wc);
+    strcpy(outbuf, str.toUtf8());
+}
+#endif
+
 void
 plat_get_global_config_dir(char *outbuf, const size_t len)
 {

--- a/src/sound/midi_fluidsynth.c
+++ b/src/sound/midi_fluidsynth.c
@@ -16,6 +16,7 @@
 #include <86box/thread.h>
 #include <86box/sound.h>
 #include <86box/plat_unused.h>
+#include <86box/plat.h>
 
 #define RENDER_RATE                100
 #define BUFFER_SEGMENTS            10
@@ -154,6 +155,7 @@ fluidsynth_init(UNUSED(const device_t *info))
 {
     fluidsynth_t  *data = &fsdev;
     midi_device_t *dev;
+    char           path[4096] = { 0 };
 
     memset(data, 0, sizeof(fluidsynth_t));
 
@@ -170,6 +172,17 @@ fluidsynth_init(UNUSED(const device_t *info))
     if (!sound_font || sound_font[0] == 0)
         sound_font = (access("/usr/share/sounds/sf2/FluidR3_GM.sf2", F_OK) == 0 ? "/usr/share/sounds/sf2/FluidR3_GM.sf2" :
                       (access("/usr/share/soundfonts/default.sf2", F_OK) == 0 ? "/usr/share/soundfonts/default.sf2" : ""));
+#elif defined _WIN32
+    if (!sound_font || sound_font[0] == 0) {
+        // FluidSynth 2.5.x and later supports DLS without libinstpatch.
+        int major, minor, patch;
+        fluid_version(&major, &minor, &patch);
+        if ((major == 2 && minor >= 5) || (major >= 3)) {
+            plat_get_system_directory(path);
+            strcat(path, "\\system32\\drivers\\gm.dls");
+            sound_font = plat_file_check(path) ? path : "";
+        }
+    }
 #endif
     data->sound_font = fluid_synth_sfload(data->synth, sound_font, 1);
 


### PR DESCRIPTION
Summary
=======
Auto-load `gm.dls` on Windows if FluidSynth 2.5.0 or later is detected.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
