### PR TITLE
Added F1 BIOS to GA-686BX

### DIFF
--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -790,7 +790,16 @@ static const device_config_t ga686_config[] = {
                 .files         = { "roms/machines/686bx/31nologo.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision F2a",
+                .name          = "Award Modular BIOS v4.51PG - Revision F1 (Latest)",
+                .internal_name = "686bx",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 262144,
+                .files         = { "roms/machines/686bx/6BX.F1", "" }
+            },
+            {
+                .name          = "Award Modular BIOS v4.51PG - Revision F2a (Beta)",
                 .internal_name = "686bx",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,


### PR DESCRIPTION
Summary
=======
Added the F1 BIOS to the Gigabyte GA-686BX machine.  BIOS file already exists in the ROMS git.

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
https://theretroweb.com/motherboards/s/gigabyte-ga-686bx-rev-1.x
