### PR TITLE
Make internal floppy disk controller the default

### DIFF
--- a/src/floppy/fdc.c
+++ b/src/floppy/fdc.c
@@ -77,7 +77,7 @@ int         lastbyte = 0;
 int floppymodified[4];
 int floppyrate[4];
 
-int fdc_current[FDC_MAX] = { 0, 0 };
+int fdc_current[FDC_MAX] = { FDC_INTERNAL, 0 };
 
 volatile int fdcinited = 0;
 


### PR DESCRIPTION
Summary
=======
Make internal floppy disk controller the default.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
