### PR TITLE
Sound card list sortout + forgotten onboard change

### DIFF
--- a/src/include/86box/sound.h
+++ b/src/include/86box/sound.h
@@ -131,8 +131,6 @@ extern const device_t ad1816_device;
 
 /* Aztech Sound Galaxy 16 */
 extern const device_t azt2316a_device;
-extern const device_t acermagic_s20_device;
-extern const device_t mirosound_pcm10_device;
 extern const device_t azt1605_device;
 extern const device_t aztpr16_device;
 
@@ -231,6 +229,8 @@ extern const device_t entertainer_device;
 extern const device_t mmb_device;
 
 /* OPTi 82c93x */
+extern const device_t acermagic_s20_device;
+extern const device_t mirosound_pcm10_device;
 extern const device_t opti_82c930_device;
 extern const device_t opti_82c931_device;
 

--- a/src/machine/m_pcjr.c
+++ b/src/machine/m_pcjr.c
@@ -848,7 +848,7 @@ static const device_config_t pcjr_config[] = {
 };
 
 const device_t pcjr_device = {
-    .name          = "IBM PCjr",
+    .name          = "IBM PCjr (Video)",
     .internal_name = "pcjr",
     .flags         = 0,
     .local         = 0,

--- a/src/sound/sound.c
+++ b/src/sound/sound.c
@@ -123,12 +123,10 @@ static const SOUND_CARD sound_cards[] = {
     { &ess_ess0968_pnp_device       },
     { &ssi2001_device               },
     { &mmb_device                   },
+#ifdef USE_LIBSERIALPORT /*The following devices required LIBSERIALPORT*/
+    { &opl2board_device             },
+#endif
     { &pasplus_device               },
-    { &voicemasterkey_device        },
-    { &soundmasterplus_device       },
-    { &soundman_device              },
-    { &isadacr0_device              },
-    { &isadacr1_device              },
     { &sb_1_device                  },
     { &sb_15_device                 },
     { &sb_2_device                  },
@@ -137,11 +135,13 @@ static const SOUND_CARD sound_cards[] = {
     { &entertainer_device           },
     { &pssj_isa_device              },
     { &tndy_device                  },
-#ifdef USE_LIBSERIALPORT /*The following devices required LIBSERIALPORT*/
-    { &opl2board_device             },
-#endif
     /* ISA/Sidecar */
     { &adlib_device                 },
+    { &soundmasterplus_device       },
+    { &voicemasterkey_device        },
+    { &isadacr0_device              },
+    { &isadacr1_device              },
+    { &soundman_device              },
     /* ISA16 */
     { &acermagic_s20_device         },
     { &ad1816_device                },


### PR DESCRIPTION
Summary
=======
This PR sorts the sound card list alphabetization out properly.

Also, this PR added the forgotten `(Video)` name to the IBM PCjr configuration.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
