### PR TITLE
Revert MS-6117 memory change

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -49,7 +49,7 @@ const machine_filter_t machine_types[] = {
     { "[1992] 486SLC",                    MACHINE_TYPE_486SLC     },
     { "[1985] i386DX",                    MACHINE_TYPE_386DX      },
     { "[1989] i386DX/i486",               MACHINE_TYPE_386DX_486  },
-    { "[1992] i486 (Socket 168 and 1)",   MACHINE_TYPE_486        },
+    { "[1989] i486 (Socket 168 and 1)",   MACHINE_TYPE_486        },
     { "[1992] i486 (Socket 2)",           MACHINE_TYPE_486_S2     },
     { "[1994] i486 (Socket 3)",           MACHINE_TYPE_486_S3     },
     { "[1994] i486 (Socket 3 PCI)",       MACHINE_TYPE_486_S3_PCI },
@@ -18244,7 +18244,7 @@ const machine_t machines[] = {
         .flags     = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_USB,
         .ram       = {
             .min  = 8192,
-            .max  = 1048576,
+            .max  = 786432, /* Manual thinks the maximum memory is 1024MB (256x4MB), but there is no 4th memory slot */
             .step = 8192
         },
         .nvrmask                  = 255,


### PR DESCRIPTION
Summary
=======
Although this works with 1024MB (256x4MB), there is no 4th memory slot on the real board, so I reverted MS-6117's memory from 1024MB to 768MB, per the discussion at #6709. The notes have been added.

Also correct the year for the i486 (S168/S1) machines.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
[The Retro Web's page on MS-6117](https://theretroweb.com/motherboards/s/msi-ms-6117-lx6)
