### PR TITLE
MSI 6199VA/6318 OEM BIOS renames

### DIFF
--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -1699,7 +1699,7 @@ static const device_config_t ms6199va_config[] = {
                 .files         = { "roms/machines/ms6199va/w6199vms.350", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 2.0 (Compaq OEM)",
+                .name          = "Award Modular BIOS v4.51PG - Revision 2.0 (Compaq ProSignia/Deskpro 693A)",
                 .internal_name = "ms6199va_200",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1708,7 +1708,7 @@ static const device_config_t ms6199va_config[] = {
                 .files         = { "roms/machines/ms6199va/W6199VC8.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 2.0 (Compaq OEM) [Patched for larger drives]",
+                .name          = "Award Modular BIOS v4.51PG - Revision 2.0 (Compaq ProSignia/Deskpro 693A) [Patched for larger drives]",
                 .internal_name = "ms6199va_200p",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1717,7 +1717,7 @@ static const device_config_t ms6199va_config[] = {
                 .files         = { "roms/machines/ms6199va/W6199VC8.PCD", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 3.7 (Packard Bell OEM)",
+                .name          = "Award Modular BIOS v4.51PG - Revision 3.7 (Packard Bell Phoenix)",
                 .internal_name = "ms6199va_370",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,

--- a/src/machine/m_at_socket370.c
+++ b/src/machine/m_at_socket370.c
@@ -512,7 +512,7 @@ static const device_config_t ms6318_config[] = {
                 .files         = { "roms/machines/ms6318/ms-6318-ver5.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision 1.8 (HP OEM)",
+                .name          = "Award Modular BIOS v6.00PG - Revision 1.8 (HP Pavilion A7xx)",
                 .internal_name = "ms6318_180",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -521,7 +521,7 @@ static const device_config_t ms6318_config[] = {
                 .files         = { "roms/machines/ms6318/med2000v2.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision 1.9 (HP OEM)",
+                .name          = "Award Modular BIOS v6.00PG - Revision 1.9 (HP Pavilion A8xx)",
                 .internal_name = "ms6318_190",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -530,7 +530,7 @@ static const device_config_t ms6318_config[] = {
                 .files         = { "roms/machines/ms6318/med2000.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision 2.02 (HP OEM)",
+                .name          = "Award Modular BIOS v6.00PG - Revision 2.02 (HP Medion 2000A)",
                 .internal_name = "ms6318_202",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -539,7 +539,7 @@ static const device_config_t ms6318_config[] = {
                 .files         = { "roms/machines/ms6318/ms6318hp.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision 1.3 (Medion OEM)",
+                .name          = "Award Modular BIOS v6.00PG - Revision 1.3 (Medion MED 2000)",
                 .internal_name = "ms6318_130",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -548,7 +548,7 @@ static const device_config_t ms6318_config[] = {
                 .files         = { "roms/machines/ms6318/ms6318.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision 7.51 (Medion OEM)",
+                .name          = "Award Modular BIOS v6.00PG - Revision 7.51 (Medion MD6318)",
                 .internal_name = "ms6318_751",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,


### PR DESCRIPTION
Summary
=======
This PR renames some of OEM BIOSes on MS-6199VA and MS-6318 precisely to match other OEM rebrands of these motherboards.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
The Retro Web's entries on [MS-6199VA](https://theretroweb.com/motherboards/s/msi-ms-6199va) and MS-6318 (revisions [3.x](https://theretroweb.com/motherboards/s/msi-ms-6318-v3.x-va6) and [5.x](https://theretroweb.com/motherboards/s/msi-ms-6318-v5.x-va6), and [Medion](https://theretroweb.com/motherboards/s/medion-med-2000-ver-1) [OEM](https://theretroweb.com/motherboards/s/medion-med-2000-ver-2))
