### PR TITLE
Translations update from 86Box Weblate

### DIFF
--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2026-01-20 03:58+0000\n"
+"PO-Revision-Date: 2026-01-21 07:40+0000\n"
 "Last-Translator: David Hrdlička <hrdlickadavid@outlook.com>\n"
 "Language-Team: Czech <https://weblate.86box.net/projects/86box/86box/cs/>\n"
 "Language: cs-CZ\n"
@@ -3016,7 +3016,7 @@ msgid "&Allow recompilation"
 msgstr "&Povolit rekompilaci"
 
 msgid "&Fast forward"
-msgstr ""
+msgstr "&Zrychlit"
 
 msgid "Fast forward"
 msgstr "Zrychlit"


### PR DESCRIPTION
Translations update from [86Box Weblate](https://weblate.86box.net) for [86Box/86Box](https://weblate.86box.net/projects/86box/86box/).



Current translation status:

![Weblate translation status](https://weblate.86box.net/widget/86box/86box/horizontal-auto.svg)