### PR TITLE
Remove the Elonex, Fujitsu-Siemens and newer Medion BIOS from the MS-6318 as it was found out they use APIC

### DIFF
--- a/src/machine/m_at_socket370.c
+++ b/src/machine/m_at_socket370.c
@@ -494,24 +494,6 @@ static const device_config_t ms6318_config[] = {
                 .files         = { "roms/machines/ms6318/w6318vms.120", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision 7.1B5E (Elonex OEM)",
-                .internal_name = "ms6318_715",
-                .bios_type     = BIOS_NORMAL,
-                .files_no      = 1,
-                .local         = 0,
-                .size          = 262144,
-                .files         = { "roms/machines/ms6318/w6318ve1.715", "" }
-            },
-            {
-                .name          = "Award Modular BIOS v6.00PG - Revision 1.0B9 (Fujitsu-Siemens OEM)",
-                .internal_name = "ms6318_109",
-                .bios_type     = BIOS_NORMAL,
-                .files_no      = 1,
-                .local         = 0,
-                .size          = 262144,
-                .files         = { "roms/machines/ms6318/ms-6318-ver5.bin", "" }
-            },
-            {
                 .name          = "Award Modular BIOS v6.00PG - Revision 1.8 (HP Pavilion A7xx)",
                 .internal_name = "ms6318_180",
                 .bios_type     = BIOS_NORMAL,
@@ -546,15 +528,6 @@ static const device_config_t ms6318_config[] = {
                 .local         = 0,
                 .size          = 262144,
                 .files         = { "roms/machines/ms6318/ms6318.bin", "" }
-            },
-            {
-                .name          = "Award Modular BIOS v6.00PG - Revision 7.51 (Medion MD6318)",
-                .internal_name = "ms6318_751",
-                .bios_type     = BIOS_NORMAL,
-                .files_no      = 1,
-                .local         = 0,
-                .size          = 262144,
-                .files         = { "roms/machines/ms6318/bios.rom", "" }
             },
             { .files_no = 0 }
         }


### PR DESCRIPTION
Summary
=======
This removes the OEM BIOS revisions from the MSI MS-6318 machine listed below as it was found out they belong to the newer PCB revisions (VER:3 and VER:5) that use APIC, which we do not emulate at the time, resulting in hanging in the Windows XP setup and other possible issues.

- Revision 7.1B5E (Elonex OEM)
- Revision 1.0B9 (Fujitsu-Siemens OEM)
- Revision 7.51 (Medion MD6318)

**NOTE:** Revision 1.3 (Medion MD2000) was kept as it belongs to an older PCB revision (VER:1) that does not use APIC and therefore doesn't have such problems.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/452
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
Special thanks to @Cacodemon345 for bringing this to my attention.
