### PR TITLE
Vulkan: Always do RGB correction on Windows

### DIFF
--- a/src/qt/qt_vulkanwindowrenderer.cpp
+++ b/src/qt/qt_vulkanwindowrenderer.cpp
@@ -900,7 +900,7 @@ VulkanWindowRenderer::onBlit(int buf_idx, int x, int y, int w, int h)
         strcat(path, fn);
 
         QImage image = this->grab();
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0) && !defined(Q_OS_WINDOWS)
         image.save(path, "png");
 #else
         image.rgbSwapped().save(path, "png");


### PR DESCRIPTION
Summary
=======
Vulkan: Always do RGB correction on Windows.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
