### PR TITLE
Add the beta evaluation BIOS for the MiTAC 6110Zu and set the R804 retail BIOS as the default

### DIFF
--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -1431,20 +1431,20 @@ static const device_config_t vei8_config[] = {
         .name           = "bios",
         .description    = "BIOS Version",
         .type           = CONFIG_BIOS,
-        .default_string = "vei8",
+        .default_string = "6110zu",
         .default_int    = 0,
         .file_filter    = NULL,
         .spinner        = { 0 },
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision QHW.10.01 (HP Sherwood-B)",
-                .internal_name = "vei8",
+                .name          = "Award Modular BIOS v6.00PG - Revision 61100003 (beta)",
+                .internal_name = "6110zu0003",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
                 .local         = 0,
                 .size          = 262144,
-                .files         = { "roms/machines/vei8/QHW1001.BIN", "" }
+                .files         = { "roms/machines/vei8/61100003.BIN", "" }
             },
             {
                 .name          = "Award Modular BIOS v6.00PG - Revision R804",
@@ -1454,6 +1454,15 @@ static const device_config_t vei8_config[] = {
                 .local         = 0,
                 .size          = 262144,
                 .files         = { "roms/machines/vei8/r804.bin", "" }
+            },
+            {
+                .name          = "Award Modular BIOS v6.00PG - Revision QHW.10.01 (HP Sherwood-B)",
+                .internal_name = "vei8",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 262144,
+                .files         = { "roms/machines/vei8/QHW1001.BIN", "" }
             },
             { .files_no = 0 }
         }


### PR DESCRIPTION
Description
=========
Add the beta evaluation BIOS (revision 61100003) for the MiTAC 6110Zu motherboard and set the retail BIOS revision R804 as the default (instead of the HP OEM BIOS revision QHW.10.01).

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/453
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
https://theretroweb.com/motherboards/s/mitac-trigon-6110zu