### PR TITLE
Add the MACHINE_SOUND flag to the TriGem Como

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -18517,7 +18517,7 @@ const machine_t machines[] = {
             .max_multi   = 5.0
         },
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
-        .flags     = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
+        .flags     = MACHINE_IDE_DUAL | MACHINE_SOUND | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
         .ram       = {
             .min  = 8192,
             .max  = 262144,


### PR DESCRIPTION
Summary
=======
Add the MACHINE_SOUND flag to the TriGem Como machine, fixes the internal Crystal sound card option not appearing for this machine

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended

References
==========
https://theretroweb.com/motherboards/s/trigem-como
