### PR TITLE
Remove bogus memory size option for ATi Mach32

### DIFF
--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -7691,10 +7691,8 @@ static const device_config_t mach32_config[] = {
         .file_filter    = NULL,
         .spinner        = { 0 },
         .selection      = {
-            { .description = "512 KB", .value =  512 },
             { .description = "1 MB",   .value = 1024 },
             { .description = "2 MB",   .value = 2048 },
-            { .description = "4 MB",   .value = 4096 },
             { .description = ""                      }
         },
         .bios           = { { 0 } }
@@ -7727,10 +7725,8 @@ static const device_config_t mach32_pci_config[] = {
         .file_filter    = NULL,
         .spinner        = { 0 },
         .selection      = {
-            { .description = "512 KB", .value =  512 },
             { .description = "1 MB",   .value = 1024 },
             { .description = "2 MB",   .value = 2048 },
-            { .description = "4 MB",   .value = 4096 },
             { .description = ""                      }
         },
         .bios           = { { 0 } }


### PR DESCRIPTION
Summary
=======
Remove 512KB and 4MB memory size option for ATi Mach32, since all Mach32 cards ship with 1MB or 2MB memory onboard.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
[ATi Mach32 on Vogons Wiki](https://www.vogonswiki.com/index.php/ATI#Mach_32)
