### PR TITLE
Add X25 and X24 registers per the datasheet to allow drivers to load

### DIFF
--- a/src/sound/snd_ad1848.c
+++ b/src/sound/snd_ad1848.c
@@ -270,6 +270,13 @@ ad1848_read(uint16_t addr, void *priv)
                         return ret;
                     }
                     break;
+                    
+                case 24:
+                    ret = ad1848->regs[ad1848->index];
+                    break;
+                case 25:
+                    ret = ad1848->xregs[ad1848->index];
+                    break;  
 
                 default:
                     break;


### PR DESCRIPTION
Summary
=======
_Briefly describe what you are submitting._
Fixes the issue in ticket #6771.
Checklist
=========
* [ *] Closes #6771
* [* ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
https://theretroweb.com/chip/documentation/ad1848k-656257163ec73854266197.pdf
https://theretroweb.com/chip/documentation/cs4235-datasheet-692609f2c9f0b859173783.pdf