### PR TITLE
Query UI font from system on Windows

### DIFF
--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -622,7 +622,7 @@ main(int argc, char *argv[])
     fprintf(stderr, "Qt: version %s, platform \"%s\"\n", qVersion(), QApplication::platformName().toUtf8().data());
     ProgSettings::loadTranslators(&app);
 #ifdef Q_OS_WINDOWS
-    QApplication::setFont(QFont(ProgSettings::getFontName(lang_id), 9));
+    QApplication::setFont(ProgSettings::getUIFont());
     SetCurrentProcessExplicitAppUserModelID(L"86Box.86Box");
 #endif
 

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -2431,7 +2431,7 @@ MainWindow::changeEvent(QEvent *event)
 #ifdef Q_OS_WINDOWS
     if (event->type() == QEvent::LanguageChange) {
         auto size = this->centralWidget()->size();
-        QApplication::setFont(QFont(ProgSettings::getFontName(lang_id), 9));
+        QApplication::setFont(ProgSettings::getUIFont());
         QApplication::processEvents();
         main_window->centralWidget()->setFixedSize(size);
         QApplication::processEvents();

--- a/src/qt/qt_progsettings.hpp
+++ b/src/qt/qt_progsettings.hpp
@@ -15,7 +15,7 @@ public:
     explicit ProgSettings(QWidget *parent = nullptr);
     ~ProgSettings();
 #ifdef Q_OS_WINDOWS
-    static QString getFontName(int langId);
+    static QFont getUIFont();
 #endif
     static int     languageCodeToId(QString langCode);
     static QString languageIdToCode(int id);

--- a/src/qt/qt_vmmanager_details.cpp
+++ b/src/qt/qt_vmmanager_details.cpp
@@ -165,7 +165,7 @@ VMManagerDetails::VMManagerDetails(QWidget *parent)
     connect(this, &VMManagerDetails::styleUpdated, portsSection, &VMManagerDetailSection::updateStyle);
     connect(this, &VMManagerDetails::styleUpdated, otherSection, &VMManagerDetailSection::updateStyle);
 
-    QApplication::setFont(QFont(ProgSettings::getFontName(lang_id), 9));
+    QApplication::setFont(ProgSettings::getUIFont());
 #endif
 
     sysconfig = new VMManagerSystem();

--- a/src/qt/qt_vmmanager_mainwindow.cpp
+++ b/src/qt/qt_vmmanager_mainwindow.cpp
@@ -269,7 +269,7 @@ VMManagerMainWindow::changeEvent(QEvent *event)
 {
 #ifdef Q_OS_WINDOWS
     if (event->type() == QEvent::LanguageChange) {
-        QApplication::setFont(QFont(ProgSettings::getFontName(lang_id), 9));
+        QApplication::setFont(QFont(ProgSettings::getUIFont()));
     }
 #endif
     QWidget::changeEvent(event);


### PR DESCRIPTION
Summary
=======
Previously, we determined the UI font from a predefined set of fonts each mapped to a language. This works well if the user doesn't change their Windows UI font, but if one does, they will get the default UI font associated with their language instead of the one the set.

This commit replaces ProgSettings::getFontName with ProgSettings::getUIFont, which uses the SystemParametersInfo API to query the message font from the system, which will allow users to have a custom font. It will also not interfere with different languages, as the message font will be appropriately set by default there.

Before the patch:
<img width="908" height="627" alt="image" src="https://github.com/user-attachments/assets/70bb6ec6-c475-4480-9a6c-15764f3c786b" />

After the patch:
<img width="908" height="627" alt="image" src="https://github.com/user-attachments/assets/fae201d6-1139-4460-bd40-d53a5c6f3d0c" />

Also confirmed to work on hi-DPI:
<img width="1167" height="829" alt="image" src="https://github.com/user-attachments/assets/e2ad4322-8e38-4564-ae32-5ad7ef1f6fe2" />


Checklist
=========
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
