### PR TITLE
Headland: Make ROMCS Disable bit only affect E0000-EFFFF per the datasheet

### DIFF
--- a/src/chipset/headland.c
+++ b/src/chipset/headland.c
@@ -220,9 +220,10 @@ memmap_state_default(headland_t *dev, uint8_t ht_romcs)
     mem_mapping_disable(&dev->mid_mapping);
 
     if (ht_romcs)
-        mem_set_mem_state(0x0e0000, 0x20000, MEM_READ_ROMCS | MEM_WRITE_ROMCS);
+        mem_set_mem_state(0x0e0000, 0x10000, MEM_READ_ROMCS | MEM_WRITE_ROMCS);
     else
-        mem_set_mem_state(0x0e0000, 0x20000, MEM_READ_EXTERNAL | MEM_WRITE_EXTERNAL);
+        mem_set_mem_state(0x0e0000, 0x10000, MEM_READ_EXTERNAL | MEM_WRITE_EXTERNAL);
+    mem_set_mem_state(0x0f0000, 0x10000, MEM_READ_ROMCS | MEM_WRITE_ROMCS);
     mem_set_mem_state(0xfe0000, 0x20000, MEM_READ_ROMCS | MEM_WRITE_ROMCS);
 
     mem_mapping_disable(&dev->shadow_mapping[0]);


### PR DESCRIPTION
Summary
=======
Make the ROMCS Disable bit of CR4 only affect E0000-EFFFF per the HT18 datasheet.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
Headland HT18 datasheet: https://theretroweb.com/chip/documentation/ht18a-b-c-64512ff1a6398435658181.pdf
Headland HT21 datasheet: https://theretroweb.com/chip/documentation/ht21-64513049ae9d4734313407.pdf