### PR TITLE
ESC/P 2: Fix behaviour on Windows 1.03

### DIFF
--- a/src/include/86box/prt_papersizes.h
+++ b/src/include/86box/prt_papersizes.h
@@ -28,27 +28,27 @@
 #define LEDGER_PAGE_HEIGHT  17.0
 
 /* Standard A0 */
-#define A0_PAGE_WIDTH   33.125
-#define A0_PAGE_HEIGHT  46.75
+#define A0_PAGE_WIDTH   33.110236
+#define A0_PAGE_HEIGHT  46.811023
 
 /* Standard A1 */
-#define A1_PAGE_WIDTH   23.375
-#define A1_PAGE_HEIGHT  33.125
+#define A1_PAGE_WIDTH   23.385826
+#define A1_PAGE_HEIGHT  33.110236
 
 /* Standard A2 */
-#define A2_PAGE_WIDTH   16.5
-#define A2_PAGE_HEIGHT  23.375
+#define A2_PAGE_WIDTH   16.535433
+#define A2_PAGE_HEIGHT  23.385826
 
 /* Standard A3 */
-#define A3_PAGE_WIDTH   11.75
-#define A3_PAGE_HEIGHT  16.5
+#define A3_PAGE_WIDTH   11.692913
+#define A3_PAGE_HEIGHT  16.535433
 
 /* Standard A4 */
-#define A4_PAGE_WIDTH   8.25
-#define A4_PAGE_HEIGHT  11.75
+#define A4_PAGE_WIDTH   8.267716
+#define A4_PAGE_HEIGHT  11.692913
 
 /* Standard B4 */
-#define B4_PAGE_WIDTH   9.875
-#define B4_PAGE_HEIGHT  13.875
+#define B4_PAGE_WIDTH   9.8425197
+#define B4_PAGE_HEIGHT  13.897637
 
 #endif /*EMU_PLAT_FALLTHROUGH_H*/

--- a/src/printer/prt_escp.c
+++ b/src/printer/prt_escp.c
@@ -542,7 +542,7 @@ init_codepage(escp_t *dev, uint16_t num)
 static void
 reset_printer(escp_t *dev)
 {
-    dev->top_margin = dev->left_margin = 0.0;
+    dev->top_margin = dev->left_margin = 1.0 / 36.0;
     dev->right_margin         = dev->page_width;
     switch (dev->paper_size) {
         case PAPER_A4:
@@ -558,7 +558,7 @@ reset_printer(escp_t *dev)
         default:
             dev->page_height = LETTER_PAGE_HEIGHT;
     }
-    dev->bottom_margin = dev->page_height;
+    dev->bottom_margin = dev->page_height - 1.0 / 36.0;
     /* TODO: these should be configurable. */
     dev->color  = COLOR_BLACK;
     dev->curr_x = dev->curr_y = 0.0;


### PR DESCRIPTION
Summary
=======
_This is an alt text for the image at the end._

This PR changes three things, related to how printing works on Windows 1.03:
* A switch Auto LF is introduced, which is a DIP switch in Epsons. I thought this was the issue with how nothing could be printed but it seemed not to be the case - letters in a line had 1/6" vertical holes in the middle caused by erroneous LFs.
* European paper sizes were set as exactly as the double type allows. A4 was too large.
* Set margins to 1/36" from each side, which is the least common multiple of 1/180" (24-pin) and 1/216" (9-pin).

The way this version of Windows handles pages is, instead of using FF (0x12) at the end of the page like Epson recommends, spamming ESC J until it thinks it goes out of page. It misses a bit (vertical position ends up on 11.680(5)" instead of around 11.693"), so, to help a bit, I set the tiniest margins so it ends at 11.736", which causes the printer to finish a page.

<img width="1984" height="2806" alt="The text above, printed in Helv font from Windows 1.03." src="https://github.com/user-attachments/assets/6f11ff5d-b63e-459e-806f-d1195d359089" />

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set
