### PR TITLE
Headland: Fix shadow RAM enable

### DIFF
--- a/src/chipset/headland.c
+++ b/src/chipset/headland.c
@@ -273,7 +273,7 @@ memmap_state_update(headland_t *dev)
         }
     }
 
-    switch (ht_cr0) {
+    switch (ht_cr0 & 0x18) {
         case 0x18:
             if ((mem_size << 10) > 0xe0000) {
                 mem_set_mem_state(0x0e0000, 0x20000, MEM_READ_INTERNAL | MEM_WRITE_DISABLED);


### PR DESCRIPTION
Summary
=======
Fix shadow RAM enable on the Headland chipsets (correct a switch statement to only check bits 4-3 of CR0).

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
Headland HT18 datasheet: https://theretroweb.com/chip/documentation/ht18a-b-c-64512ff1a6398435658181.pdf