### PR TITLE
Qt: Fix media file picker location persistence

### DIFF
--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -592,10 +592,10 @@ MediaMenu::cdromMount(int i, int dir, const QString &arg)
     if (dir > 1)
         filename = QString::asprintf(R"(ioctl://%s)", arg.toUtf8().data());
     else if (dir == 1)
-        filename = QFileDialog::getExistingDirectory(parentWidget);
+        filename = QFileDialog::getExistingDirectory(parentWidget, QString(), getMediaOpenDirectory());
     else {
         filename = QFileDialog::getOpenFileName(parentWidget, QString(),
-                                                QString(),
+                                                getMediaOpenDirectory(),
                                                 tr("CD-ROM images") % util::DlgFilter({ "iso", "cue", "mds", "mdx" }) % tr("All files") % util::DlgFilter({ "*" }, true));
     }
 
@@ -1199,10 +1199,13 @@ MediaMenu::nicUpdateMenu(int i)
 QString
 MediaMenu::getMediaOpenDirectory()
 {
-    QString openDirectory;
+    static bool firstCall = true;
+    QString     openDirectory;
 
-    if (open_dir_usr_path > 0)
+    if (open_dir_usr_path > 0 && firstCall) {
         openDirectory = QString::fromUtf8(usr_path);
+        firstCall     = false;
+    }
 
     return openDirectory;
 }


### PR DESCRIPTION
Summary
  This PR fixes an issue where media file pickers (Floppy, CD, etc.) would reset to the 86Box home folder every time
  they were opened. This was particularly annoying during disk swaps for multi-disk installations, as it forced users to
  navigate back to their images directory repeatedly.

  Changes:
   - Updated MediaMenu::getMediaOpenDirectory() to return the home folder only on the first invocation. Subsequent calls
     return an empty string, allowing the native file dialog to persist its last visited location.
   - Updated MediaMenu::cdromMount to use getMediaOpenDirectory() for consistency across all media pickers.


  Checklist
   * [ ] Closes #xxx
   * [x] I have tested my changes locally and validated that the functionality works as intended
   * [ ] I have discussed this with core contributors already
   * [ ] This pull request requires changes to the ROM set
   * [ ] This pull request requires changes to the asset set


  References
  N/A
