### PR TITLE
Headland chipset/Tandy 1000 RSX fixes

### DIFF
--- a/src/chipset/headland.c
+++ b/src/chipset/headland.c
@@ -284,9 +284,11 @@ memmap_state_update(headland_t *dev)
             mem_mapping_set_exec(&dev->mid_mapping, ram + 0xA0000);
             mem_mapping_disable(&dev->mid_mapping);
             if (mem_size > 1024) {
-                mem_set_mem_state((mem_size << 10), 0x60000, MEM_READ_INTERNAL | MEM_WRITE_INTERNAL);
+                mem_set_mem_state((mem_size << 10), 0x60000, MEM_READ_EXTANY | MEM_WRITE_EXTANY);
                 mem_mapping_set_addr(&dev->high_mapping, 0x100000, (mem_size - 1024) << 10);
                 mem_mapping_set_exec(&dev->high_mapping, ram + 0x100000);
+            } else if ((mem_size > 640) && (mem_size <=1024)) {
+                mem_set_mem_state(0x100000, (mem_size - 640) << 10, MEM_READ_EXTANY | MEM_WRITE_EXTANY);
             }
         } else {
             /* 1 MB - 1 MB + 384k: RAM pointing to A0000-FFFFF
@@ -296,9 +298,11 @@ memmap_state_update(headland_t *dev)
             mem_mapping_set_exec(&dev->mid_mapping, ram + 0xA0000);
             if (mem_size > 1024) {
                 /* We have ram above 1 MB, we need to relocate that. */
-                mem_set_mem_state((mem_size << 10), 0x60000, MEM_READ_EXTANY | MEM_WRITE_EXTANY);
+                mem_set_mem_state((mem_size << 10), 0x60000, MEM_READ_INTERNAL | MEM_WRITE_INTERNAL);
                 mem_mapping_set_addr(&dev->high_mapping, 0x160000, (mem_size - 1024) << 10);
                 mem_mapping_set_exec(&dev->high_mapping, ram + 0x100000);
+            } else if ((mem_size > 640) && (mem_size <=1024)) {
+                mem_set_mem_state(0x100000, (mem_size - 640) << 10, MEM_READ_INTERNAL | MEM_WRITE_INTERNAL);
             }
         }
     }


### PR DESCRIPTION
Summary
=======
Fix two issues with the Headland chipset code:
- Fixed incorrect memory bank handling: resolves the issue where the Tandy 1000 RSX would hang on POST 03 when using 9MB of RAM
- Fixed incorrect usage of mem_set_mem_state and added remap handling for 640-1024K RAM configs: Resolves the Tandy 1000 RSX and Arche AMA-932 being unable to enable 384K remap.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
- Headland HT18 datasheet: https://theretroweb.com/chip/documentation/ht18a-b-c-64512ff1a6398435658181.pdf
- Headland HT21 datasheet: https://theretroweb.com/chip/documentation/ht21p-datasheet-64512a7179e9d102017984.pdf