### PR TITLE
Translations update from 86Box Weblate

### DIFF
--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2026-01-23 17:57+0000\n"
+"PO-Revision-Date: 2026-02-11 06:30+0000\n"
 "Last-Translator: BlueRain-debug <bluerain.debug@gmail.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://weblate.86box.net/"
 "projects/86box/86box/zh_Hans/>\n"
@@ -2840,7 +2840,7 @@ msgid "Remote Switch"
 msgstr "远程交换机"
 
 msgid "Shared secret:"
-msgstr "共享秘密："
+msgstr "共享密钥："
 
 msgid "Hub Mode"
 msgstr "集线器模式"


### PR DESCRIPTION
Translations update from [86Box Weblate](https://weblate.86box.net) for [86Box/86Box](https://weblate.86box.net/projects/86box/86box/).



Current translation status:

![Weblate translation status](https://weblate.86box.net/widget/86box/86box/horizontal-auto.svg)