### PR TITLE
Qt: Always change floppy type's first column on changing type

### DIFF
--- a/src/qt/qt_settingsfloppycdrom.cpp
+++ b/src/qt/qt_settingsfloppycdrom.cpp
@@ -434,7 +434,8 @@ void
 SettingsFloppyCDROM::on_comboBoxFloppyType_activated(int index)
 {
     auto currentIndex = ui->tableViewFloppy->selectionModel()->currentIndex();
-    setFloppyType(ui->tableViewFloppy->model(), currentIndex, index);
+    auto typeIndex    = currentIndex.siblingAtColumn(0);
+    setFloppyType(ui->tableViewFloppy->model(), typeIndex, index);
 
     // Trigger row changed to rebuild audio profile list
     onFloppyRowChanged(currentIndex);


### PR DESCRIPTION
Thanks to DFXThomas on Discord for pointing out this bug.

Summary
=======
In the UI settings, changing the floppy type affected the column selected rather than the Type column.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

