### PR TITLE
Cirrus VBIOS fixes part deux

### DIFF
--- a/src/include/86box/video.h
+++ b/src/include/86box/video.h
@@ -384,6 +384,7 @@ extern const device_t gd5424_onboard_device;
 extern const device_t gd5426_isa_device;
 extern const device_t gd5426_diamond_speedstar_pro_a1_isa_device;
 extern const device_t gd5426_vlb_device;
+extern const device_t gd5426_onboard_isa_device;
 extern const device_t gd5426_onboard_device;
 extern const device_t gd5428_isa_device;
 extern const device_t gd5428_vlb_onboard_device;

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -7779,7 +7779,7 @@ const machine_t machines[] = {
         .kbd_device               = NULL,
         .fdc_device               = NULL,
         .sio_device               = NULL, /*Has SIO (sorta): VLSI VL82C113A SCAMP Combination I/O*/
-        .vid_device               = &gd5428_onboard_device,
+        .vid_device               = &gd5426_onboard_isa_device,
         .snd_device               = NULL,
         .net_device               = NULL
     },

--- a/src/video/vid_cl54xx.c
+++ b/src/video/vid_cl54xx.c
@@ -4317,7 +4317,10 @@ gd54xx_init(const device_t *info)
 
         case CIRRUS_ID_CLGD5426:
             if (info->local & 0x200)
-                romfn = NULL;
+                if (machines[machine].init == machine_at_vect486vl_init)
+                    romfn = BIOS_GD5428_ISA_PATH;
+                else
+                    romfn = NULL;
             else {
                 if (info->local & 0x100)
                     romfn = BIOS_GD5426_DIAMOND_A1_ISA_PATH;
@@ -4334,9 +4337,7 @@ gd54xx_init(const device_t *info)
 
         case CIRRUS_ID_CLGD5428:
             if (info->local & 0x200) {
-                if (machines[machine].init == machine_at_vect486vl_init)
-                    romfn = BIOS_GD5428_ISA_PATH;
-                else if (machines[machine].init == machine_at_d824_init)
+                if (machines[machine].init == machine_at_d824_init)
                     romfn = BIOS_GD5428_ISA_PATH;
                 else if (machines[machine].init == machine_at_acera1g_init)
                     romfn = BIOS_GD5428_ONBOARD_ACER_PATH;
@@ -4444,7 +4445,7 @@ gd54xx_init(const device_t *info)
         if (id <= CIRRUS_ID_CLGD5428) {
             if ((id == CIRRUS_ID_CLGD5428) && (info->local & 0x200) && (info->local & 0x1000))
                 vram = 1024;
-            else if ((id == CIRRUS_ID_CLGD5426) && (info->local & 0x200))
+            else if ((id == CIRRUS_ID_CLGD5426) && (info->local & 0x200) && (info->local & 0x1000))
                 vram = 1024;
             else if (id == CIRRUS_ID_CLGD5401)
                 vram = 256;
@@ -5193,11 +5194,25 @@ const device_t gd5426_vlb_device = {
     .config        = gd5426_config
 };
 
+const device_t gd5426_onboard_isa_device = {
+    .name          = "Cirrus Logic GD5426 (ISA) (On-Board)",
+    .internal_name = "cl_gd5426_onboard",
+    .flags         = DEVICE_ISA16,
+    .local         = CIRRUS_ID_CLGD5426 | 0x200,
+    .init          = gd54xx_init,
+    .close         = gd54xx_close,
+    .reset         = gd54xx_reset,
+    .available     = gd5428_isa_available,
+    .speed_changed = gd54xx_speed_changed,
+    .force_redraw  = gd54xx_force_redraw,
+    .config        = gd542x_config
+};
+
 const device_t gd5426_onboard_device = {
     .name          = "Cirrus Logic GD5426 (VLB) (On-Board)",
     .internal_name = "cl_gd5426_onboard",
     .flags         = DEVICE_VLB,
-    .local         = CIRRUS_ID_CLGD5426 | 0x200,
+    .local         = CIRRUS_ID_CLGD5426 | 0x200 | 0x1000,
     .init          = gd54xx_init,
     .close         = gd54xx_close,
     .reset         = gd54xx_reset,


### PR DESCRIPTION
Summary
=======
Two fixes for Cirrus onboard video:
- Revert to the old VBIOS loading behavior for the HP Vectra 486VL and Siemens-Nixdorf D824 machines resolving issues with the Windows 3.1 drivers
- Give the HP Vectra 486VL the correct ISA CL-GD5426 onboard video (instead of the 5428)

Checklist
=========
* [x] Closes https://github.com/86Box/86Box/issues/6820
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
TheRetroWeb page for the Vectra 486VL: https://theretroweb.com/motherboards/s/hp-vectra-486vl-pc-series-d3021,d3025