### PR TITLE
Floppy and hard disk fixes for IBM PS/2 model 30-286

### DIFF
--- a/src/device/kbc_at.c
+++ b/src/device/kbc_at.c
@@ -2184,7 +2184,7 @@ read_p1(atkbc_t *dev)
                                                                             -----------------
        IBM PS/1:                                                                     xxxxxxxx
        IBM PS/2 MCA:                                                                 xxxxx1xx
-       IBM PS/2 Model 30-286:                                                        xxxxx1xx
+       IBM PS/2 Model 30-286:                                                        x0xxx1xx
        Intel AMI Pentium BIOS'es with AMI MegaKey KB-5 keyboard controller:          x1x1xxxx
        Acer:                                                                         xxxxx0xx
        Packard Bell PB450:                                                           xxxxx1xx
@@ -2199,7 +2199,8 @@ read_p1(atkbc_t *dev)
        Acer:                    Pull down bit 6 if primary display is MDA.
                                 Pull down bit 2 always (must be so to enable CMOS Setup).
        IBM PS/1:                Pull down bit 6 if current floppy drive is 3.5".
-       IBM PS/2 Model 30-286:   Pull down bits 5 and 4 based on planar memory size.
+       IBM PS/2 Model 30-286:   Pull down bit 6 always (for 1.44M floppy).
+                                Pull down bits 5 and 4 based on planar memory size.
        Epson Action Tower 2600: Pull down bit 3 always (for Epson logo).
        NCR:                     Pull down bit 5 always (power-on default speed = high).
                                 Pull down bit 3 if there is no FPU.
@@ -2215,6 +2216,7 @@ read_p1(atkbc_t *dev)
        Bit 6: Mostly, display: 0 = CGA, 1 = MDA, inverted on Xi8088 and Acer KBC's;
               Intel AMI MegaKey KB-5: Used for green features, SMM handler expects it to be set;
               IBM PS/1 Model 2011: 0 = current FDD is 3.5", 1 = current FDD is 5.25";
+              IBM PS/2 Model 30-286: 0 = drive A is 1.44M, 1 = drive A is 720k;
               Compaq: 0 = Compaq dual-scan display, 1 = non-Compaq display.
        Bit 5: Mostly, manufacturing jumper: 0 = installed (infinite loop at POST), 1 = not installed;
               NCR: power-on default speed: 0 = high, 1 = low;

--- a/src/disk/hdc_xta_ps1.c
+++ b/src/disk/hdc_xta_ps1.c
@@ -937,9 +937,6 @@ do_send:
             break;
 
         case CMD_WRITE_VERIFY:
-            no_data = 1;
-            fallthrough;
-
         case CMD_WRITE_SECTORS:
             if (!drive->present) {
                 dev->ssb.not_ready = 1;

--- a/src/machine/m_ps2_isa.c
+++ b/src/machine/m_ps2_isa.c
@@ -264,18 +264,18 @@ machine_ps2_isa_p1_handler(void)
 
     switch (mem_size / 1024) {
         case 0: /*256Kx2*/
-            mem_p1 = 0xf0;
+            mem_p1 = 0xb0;
             break;       
         case 1: /*256Kx4*/
-            mem_p1 = 0xe0;
+            mem_p1 = 0xa0;
             break;
         case 2: /*1Mx2*/
         case 3: 
-            mem_p1 = 0xd0;
+            mem_p1 = 0x90;
             break;
         case 4: /*1Mx4*/
         default:
-            mem_p1 = 0xc0;
+            mem_p1 = 0x80;
             break;
     }
 


### PR DESCRIPTION
Summary
=======
This PR makes the following changes to the IBM PS/2 model 30-286:

- Pull down keyboard input port pin 6 to allow PS/2 model 30-286 rev. 0 BIOS to recognize drive A as 1.44M floppy
- WRITE VERIFY command in IBM PS/1 XTA disk controller should write data to disk (unlike READ VERIFY command), fixes NetWare 2.2 ZTEST and COMPSURF failing to verify disk for bad sectors

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
IBM PS/2 model 30-286 schematics: https://www.ardent-tool.com/docs/pdf/schematics/m30-286_sch.pdf
