### PR TITLE
IBM PS/1 XTA controller fixes

### DIFF
--- a/src/disk/hdc_xta_ps1.c
+++ b/src/disk/hdc_xta_ps1.c
@@ -381,6 +381,7 @@ typedef struct hdc_t {
     pc_timer_t timer;
     int8_t     state; /* controller state */
     int8_t     reset; /* reset state counter */
+    int8_t     ready; /* ready state counter */
 
     /* Data transfer. */
     int16_t buf_idx; /* buffer index and pointer */
@@ -723,6 +724,15 @@ hdc_callback(void *priv)
     uint8_t  cmd = ccb->cmd & 0x0f;
 #endif
 
+    /* If we are returning from a RESET, handle this first. */
+    if (dev->reset) {
+        ps1_hdc_log("XTA reset.\n");
+        dev->status &= ~ASR_BUSY;
+        dev->reset = 0;
+        do_finish(dev);
+        return;
+    }
+
     /* Clear the SSB error bits. */
     dev->ssb.track_0        = 0;
     dev->ssb.cylinder_err   = 0;
@@ -751,6 +761,12 @@ hdc_callback(void *priv)
             if (!drive->present) {
                 dev->ssb.not_ready = 1;
                 do_finish(dev);
+                return;
+            }
+
+            if (!(dev->ready | no_data)) {
+                /* Delay a bit, transfer not ready. */
+                timer_advance_u64(&dev->timer, HDC_TIME);
                 return;
             }
 
@@ -941,6 +957,12 @@ do_send:
             if (!drive->present) {
                 dev->ssb.not_ready = 1;
                 do_finish(dev);
+                return;
+            }
+
+            if (!(dev->ready | no_data)) {
+                /* Delay a bit, transfer not ready. */
+                timer_advance_u64(&dev->timer, HDC_TIME);
                 return;
             }
 
@@ -1228,24 +1250,21 @@ hdc_write(uint16_t port, uint8_t val, void *priv)
             if (val & ACR_INT_EN)
                 set_intr(dev, 0); /* clear IRQ */
 
-            if (dev->reset != 0) {
-                if (++dev->reset == 3) {
-                    dev->reset = 0;
-
-                    set_intr(dev, 1);
-                }
-                break;
+            if (val & ACR_RESET) {
+                dev->reset = 1;
+                dev->status |= ASR_BUSY;
+                /* Schedule command execution. */
+                timer_set_delay_u64(&dev->timer, HDC_TIME);
             }
 
-            if (val & ACR_RESET)
-                dev->reset = 1;
             break;
 
         case 4: /* ATTN */
             dev->status &= ~ASR_INT_REQ;
-            if (val & ATT_DATA) {
-                /* Dunno. Start PIO/DMA now? */
-            }
+            if (val & ATT_DATA)
+                dev->ready = 1;
+            else
+                dev->ready = 0;
 
             if (val & ATT_SSB) {
                 if (dev->attn & ATT_CCB) {


### PR DESCRIPTION
Summary
=======
This PR makes the following changes to the IBM PS/1 XTA controller:

- Refactor IBM PS/1 XTA controller reset logic, fixes NetWare 2.15 and 2.2 failing to reset IBM PS/1 XTA controller
- Implement Attention Register data request bit handling, fixes IBM OS/2 1.3 hanging on disk partitioning in setup

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
IBM PS/1 Technical Reference Section 8 Drives: https://www.mediafire.com/download/ecok59mrc8sclzb/Section_8._Drives.pdf
