### PR TITLE
MPU-401: Don't clear queues on reset

### DIFF
--- a/src/sound/snd_mpu401.c
+++ b/src/sound/snd_mpu401.c
@@ -316,7 +316,6 @@ MPU401_Reset(mpu_t *mpu)
             mpu->ch_toref[i]                        = 4; /* Dummy reftable. */
     }
 
-    MPU401_ClrQueue(mpu);
     mpu->state.data_onoff                           = -1;
 
     mpu->state.req_mask                             = 0;


### PR DESCRIPTION
Summary
=======
MPU-401: Don't clear queues on reset.

Backported from DOSBox SVN revision r4492 and said to be verified on real hardware.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
