### PR TITLE
Sort out the IRQ/INT enabling/disabling stuff of the 5380/53c80 chip.

### DIFF
--- a/src/include/86box/scsi_ncr5380.h
+++ b/src/include/86box/scsi_ncr5380.h
@@ -84,6 +84,7 @@ typedef struct ncr_t {
     int   (*dma_send_ext)(void *priv, void *ext_priv);
     int   (*dma_initiator_receive_ext)(void *priv, void *ext_priv);
     void  (*timer)(void *ext_priv, double period);
+    int   (*irq_ena)(void *priv, void *ext_priv, int state);
 
     scsi_bus_t scsibus;
 } ncr_t;


### PR DESCRIPTION
Summary
=======
Allowing proper operation of the IRQ in the 53c400 and, at the same time, recognizing the RTASPI10.SYS driver of the Rancho RT1000B. Code based on the 53c400 manual and MAME.
TODO: Verify the Trantor T128 scheme.


Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
[NCR 53c400 manual](https://theretroweb.com/chip/documentation/ncr-53c400-661c3111e293c019575320.pdf)
[Relevant NCR 53c400 part of MAME](https://github.com/mamedev/mame/commit/1065b39dfc2099daa178f7514afa973698a6c12a#diff-351b04f64b42f480d27ff213fdd3eacc388366d5dd1188b9d7ec72916677ad42)
