### PR TITLE
Change ibm cga to v6355d  for the zenith z184

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -2167,7 +2167,7 @@ const machine_t machines[] = {
         .kbd_device               = &keyboard_pc_xt_device,
         .fdc_device               = NULL,
         .sio_device               = NULL,
-        .vid_device               = &cga_device,
+        .vid_device               = &v6355d_device,
         .snd_device               = NULL,
         .net_device               = NULL
     },


### PR DESCRIPTION
Summary
=======

has v6355d-f
the v6355d emulation was implemented in build 7505. 
idk what origin of bios dump and which model is? since there are two different board using the same video chipset. 

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
only mainboard picture for references.
https://www.reddit.com/r/retrocomputing/comments/1i3k7p4/zenith_supersport_zwl18402_ram_failure/ https://retrocomputingforum.com/t/zenith-data-systems-80c88-laptop-from-circa-1985/1454
