### PR TITLE
PS55DA2: Fixed some issues

### DIFF
--- a/src/video/vid_ps55da2.c
+++ b/src/video/vid_ps55da2.c
@@ -263,7 +263,7 @@
 #define LG_SET_RESET_2          0x10
 
 #ifndef RELEASE_BUILD
-#define ENABLE_DA2_LOG 1
+// #define ENABLE_DA2_LOG 1
 #endif
 
 #ifdef ENABLE_DA2_LOG
@@ -3228,6 +3228,13 @@ da2_reset_ioctl(da2_t *da2)
     da2->ioctl[LS_RESET] = 0x00;     /* Bit 0: Reset sequencer */
     da2_outw(LS_INDEX, 0x0302, da2); /* Index 02, Bit 1: VGA passthrough, Bit 0: Character Mode */
     da2_outw(LS_INDEX, 0x0008, da2); /* Index 08, Bit 0: Enable MMIO */
+    /* Set default color palette (Windows 3.1 display driver won't reset palette regs) */
+    for (uint16_t i = 0; i < 256; i++) {
+        da2->vgapal[i].r = ps55_palette_color[i & 0x3F][0];
+        da2->vgapal[i].g = ps55_palette_color[i & 0x3F][1];
+        da2->vgapal[i].b = ps55_palette_color[i & 0x3F][2];
+        da2->pallook[i]  = makecol32((da2->vgapal[i].r & 0x3f) * 4, (da2->vgapal[i].g & 0x3f) * 4, (da2->vgapal[i].b & 0x3f) * 4);
+    }
 }
 
 static void
@@ -3255,13 +3262,6 @@ da2_reset(void *priv)
     da2->attrc[LV_CURSOR_CONTROL]  = 0x13; /* cursor options */
     da2->attr_palette_enable       = 0;    /* disable attribute generator */
 
-    /* Set default color palette (Windows 3.1 display driver won't reset palette) */
-    for (uint16_t i = 0; i < 256; i++) {
-        da2->vgapal[i].r = ps55_palette_color[i & 0x3F][0];
-        da2->vgapal[i].g = ps55_palette_color[i & 0x3F][1];
-        da2->vgapal[i].b = ps55_palette_color[i & 0x3F][2];
-        da2->pallook[i]  = makecol32((da2->vgapal[i].r & 0x3f) * 4, (da2->vgapal[i].g & 0x3f) * 4, (da2->vgapal[i].b & 0x3f) * 4);
-    }
     da2_log("da2_reset done.\n");
 }
 


### PR DESCRIPTION
Summary
=======
* Corrected the height of the screen.
* Corrected the monitor timing to match the description in the IBM PS/55 5550-S/T/V Technical Reference.
* Added a pixel clock source for IBM 8515 monitor.
* Removed the OldLSI (DA-2) flag because I found the DA-3 has monitor detection capability and thats the difference between them.
* Changed 16/256 color mode determination to fix an issue in Windows 3.1 16 color display driver with IBM 8515 monitor.
* Fixed an issue that the color palette remains changed after Windows 3.1 restarted with 1024x768 16 color mode.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
