### PR TITLE
IBM PS/1 XTA controller fixes

### DIFF
--- a/src/disk/hdc_xta_ps1.c
+++ b/src/disk/hdc_xta_ps1.c
@@ -1184,6 +1184,7 @@ hdc_read(uint16_t port, void *priv)
             break;
 
         case 4: /* ISR */
+            dev->status &= ~ASR_INT_REQ;
             ret          = dev->intstat;
             dev->intstat = 0x00;
             break;
@@ -1225,6 +1226,7 @@ hdc_write(uint16_t port, uint8_t val, void *priv)
                     /* We got all the data we need. */
                     dev->status &= ~ASR_DATA_REQ;
                     dev->state = STATE_IDLE;
+                    set_intr(dev, 1);
 
                     /* If we were receiving a CCB, execute it. */
                     if (dev->attn & ATT_CCB) {
@@ -1256,7 +1258,6 @@ hdc_write(uint16_t port, uint8_t val, void *priv)
                 /* Schedule command execution. */
                 timer_set_delay_u64(&dev->timer, HDC_TIME);
             }
-
             break;
 
         case 4: /* ATTN */
@@ -1295,7 +1296,6 @@ hdc_write(uint16_t port, uint8_t val, void *priv)
 
                 dev->state = STATE_RDATA;
                 dev->status |= ASR_DATA_REQ;
-                set_intr(dev, 1);
             }
             break;
 


### PR DESCRIPTION
Summary
=======
This PR makes the following changes to the IBM PS/1 XTA controller:

- Clear Interrupt Request bit in Attachment Status Register after reading Interrupt Status Register per the manual
- Raise interrupt only after all Command Control Block bytes are received, fixes IBM OS/2 1.1-1.3 not recognizing any partition on the disk (previously only IBM OS/2 1.30.2 works)

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
IBM PS/1 Technical Reference Section 8 Drives: https://www.mediafire.com/download/ecok59mrc8sclzb/Section_8._Drives.pdf
