### PR TITLE
Added additional firmware version of CR-563 CD-ROM drive (0.74)

### DIFF
--- a/src/include/86box/cdrom.h
+++ b/src/include/86box/cdrom.h
@@ -239,7 +239,8 @@ static const struct cdrom_drive_types_s {
     { "MATSHITA", "CR-562",           "0.75", "cr562",          BUS_TYPE_MKE , 0,  2,  0, 0, 0, { -1, -1, -1, -1 } },
     { "MATSHITA", "CR-562",           "0.76", "cr562_076",      BUS_TYPE_MKE , 0,  2,  0, 0, 0, { -1, -1, -1, -1 } },
     { "MATSHITA", "CR-562",           "0.80", "cr562_080",      BUS_TYPE_MKE , 0,  2,  0, 0, 0, { -1, -1, -1, -1 } },
-    { "MATSHITA", "CR-563",           "0.75", "cr563",          BUS_TYPE_MKE , 0,  2,  0, 0, 0, { -1, -1, -1, -1 } },
+    { "MATSHITA", "CR-563",           "0.74", "cr563",          BUS_TYPE_MKE , 0,  2,  0, 0, 0, { -1, -1, -1, -1 } },
+    { "MATSHITA", "CR-563",           "0.75", "cr563_075",      BUS_TYPE_MKE , 0,  2,  0, 0, 0, { -1, -1, -1, -1 } },
     { "MATSHITA", "CR-563",           "0.80", "cr563_080",      BUS_TYPE_MKE , 0,  2,  0, 0, 0, { -1, -1, -1, -1 } },
     { "",         "",                 "",     "",               BUS_TYPE_NONE, 0, -1,  0, 0, 0, { -1, -1, -1, -1 } }
 };


### PR DESCRIPTION
This is based on the image seen on this Vogons Wiki page:

https://www.vogonswiki.com/index.php/Matsushita_MKE

https://www.vogonswiki.com/images/d/df/Matsushita_MKE_driver_screenshot.png

Summary
=======
This pull request adds an additional firmware version of CR-563 CD-ROM drive (0.74).

<img width="2406" height="1783" alt="image" src="https://github.com/user-attachments/assets/4cf52835-87de-4e59-a4a4-5a8e20a50d09" />

<img width="2166" height="1483" alt="image" src="https://github.com/user-attachments/assets/1e46ef39-a631-4873-8ef3-6e4f44721a06" />

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
https://www.vogonswiki.com/index.php/Matsushita_MKE

https://www.vogonswiki.com/images/d/df/Matsushita_MKE_driver_screenshot.png
