### PR TITLE
Settings: Disable Tab key navigation inside tables

### DIFF
--- a/src/qt/qt_settingsfloppycdrom.ui
+++ b/src/qt/qt_settingsfloppycdrom.ui
@@ -56,6 +56,9 @@
      <property name="selectionBehavior">
       <enum>QAbstractItemView::SelectRows</enum>
      </property>
+     <property name="tabKeyNavigation">
+      <bool>false</bool>
+     </property>
      <property name="showGrid">
       <bool>false</bool>
      </property>
@@ -141,6 +144,9 @@
      </property>
      <property name="selectionBehavior">
       <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="tabKeyNavigation">
+      <bool>false</bool>
      </property>
      <property name="showGrid">
       <bool>false</bool>

--- a/src/qt/qt_settingsharddisks.ui
+++ b/src/qt/qt_settingsharddisks.ui
@@ -37,6 +37,9 @@
      <property name="selectionBehavior">
       <enum>QAbstractItemView::SelectRows</enum>
      </property>
+     <property name="tabKeyNavigation">
+      <bool>false</bool>
+     </property>
      <property name="showGrid">
       <bool>false</bool>
      </property>

--- a/src/qt/qt_settingsotherremovable.ui
+++ b/src/qt/qt_settingsotherremovable.ui
@@ -56,6 +56,9 @@
      <property name="selectionBehavior">
       <enum>QAbstractItemView::SelectRows</enum>
      </property>
+     <property name="tabKeyNavigation">
+      <bool>false</bool>
+     </property>
      <property name="showGrid">
       <bool>false</bool>
      </property>
@@ -141,6 +144,9 @@
      </property>
      <property name="selectionBehavior">
       <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="tabKeyNavigation">
+      <bool>false</bool>
      </property>
      <property name="showGrid">
       <bool>false</bool>


### PR DESCRIPTION
Summary
=======
Disable Tab key navigation inside `QTableView`s in the settings dialog so that the Tab key could be used to navigate to controls past them. Selecting individual cells is still possible with arrow keys, even though it makes little sense since `QTableView`s are effectively used as `QListView`s with multi-column formatting.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set

References
==========
N/A