### PR TITLE
Add the OTI068 clocks to the OTI OAK chips.

### DIFF
--- a/src/video/vid_oak_oti.c
+++ b/src/video/vid_oak_oti.c
@@ -203,6 +203,10 @@ oti_out(uint16_t addr, uint8_t val, void *priv)
                     }
                     break;
 
+                case 0x0e:
+                    svga_recalctimings(svga);
+                    break;
+
                 case 0x11:
                     svga->read_bank  = (val & 0xf) * 65536;
                     svga->write_bank = (val >> 4) * 65536;
@@ -377,7 +381,7 @@ oti_pos_in(UNUSED(uint16_t addr), void *priv)
 }
 
 static float
-oti_getclock(int clock)
+oti068_getclock(int clock)
 {
     float ret = 0.0;
 
@@ -389,14 +393,23 @@ oti_getclock(int clock)
         case 1:
             ret = 28322000.0;
             break;
+        case 2:
+            ret = 65000000.0;
+            break;
+        case 3:
+            ret = 44900000.0;
+            break;
         case 4:
-            ret = 14318000.0;
+            ret = 28322000.0;
             break;
         case 5:
-            ret = 16257000.0;
+            ret = 36000000.0;
+            break;
+        case 6:
+            ret = 40000000.0;
             break;
         case 7:
-            ret = 35500000.0;
+            ret = 36000000.0;
             break;
     }
 
@@ -409,7 +422,7 @@ oti_recalctimings(svga_t *svga)
     const oti_t *oti     = (oti_t *) svga->priv;
     int          clk_sel = ((svga->miscout >> 2) & 3) | ((oti->regs[0x0d] & 0x20) >> 3);
 
-    svga->clock = (cpuclock * (double) (1ULL << 32)) / oti_getclock(clk_sel);
+    svga->clock = (cpuclock * (double) (1ULL << 32)) / oti068_getclock(clk_sel);
 
     if (oti->chip_id > 0) {
         if (oti->regs[0x14] & 0x08)
@@ -424,7 +437,17 @@ oti_recalctimings(svga_t *svga)
         if (oti->regs[0x14] & 0x04)
             svga->vsyncstart += 0x400;
 
-        svga->interlace = oti->regs[0x14] & 0x80;
+        svga->interlace = !!(oti->regs[0x14] & 0x80);
+
+        if (!svga->scrblank && svga->attr_palette_enable) {
+            if (!(svga->gdcreg[6] & 1) && !(svga->attrregs[0x10] & 1))
+                svga->interlace = 0;
+        }
+
+        if (oti->regs[0x0e] & 0x80) {
+            svga->write_bank = 0;
+            svga->read_bank = 0;
+        }
     }
 
     if ((oti->regs[0x0d] & 0x0c) && !(oti->regs[0x0d] & 0x10))
@@ -519,10 +542,10 @@ oti_init(const device_t *info)
 
     if (oti->chip_id == OTI_077_ACER100T) {
         /*
-           josephillips: Required to show all BIOS 
+           josephillips: Required to show all BIOS
            information on Acer 100T only
         */
-        video_inform(0x1, &timing_oti);   
+        video_inform(0x1, &timing_oti);
     } else
         video_inform(VIDEO_FLAG_TYPE_SPECIAL, &timing_oti);
 
@@ -538,7 +561,7 @@ oti_init(const device_t *info)
 
     oti->svga.miscout       = 1;
     oti->svga.packed_chain4 = 1;
-    
+
     return oti;
 }
 


### PR DESCRIPTION
Summary
=======
1. This fixes wrong refresh rates of the Oak VGA chips.
2. VGA mode bit 7 (oak reg 0x0e) when in text mode should clear the banking if so desired (assuming VGA mode means non-extended modes) (this fixes garbled command prompts, but report any regressions please if any).

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
[OAK OTI068 clock databook](https://www.brutaldeluxe.fr/documentation/secondsight/secondsight_oti068_databook.pdf)
