### PR TITLE
Use the correct BIOS for Orchid KELVIN 64-VLB (Cirrus Logic GD5434)

### DIFF
--- a/src/video/vid_cl54xx.c
+++ b/src/video/vid_cl54xx.c
@@ -5457,7 +5457,7 @@ const device_t gd5430_vlb_device = {
 };
 
 const device_t gd5430_onboard_vlb_device = {
-    .name          = "Cirrus Logic GD5430 (On-Board)",
+    .name          = "Cirrus Logic GD5430 (VLB) (On-Board)",
     .internal_name = "cl_gd5430_onboard_vlb",
     .flags         = DEVICE_VLB,
     .local         = CIRRUS_ID_CLGD5430 | 0x200,


### PR DESCRIPTION
Summary
=======
This PR title says at all. Also added the **Orchid KELVIN EZ** name to the GD5430 VLB card.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/467
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
[ORCHID TECHNOLOGY KELVIN EZ-VLB at The Retro Web](https://theretroweb.com/expansioncards/s/orchid-technology-kelvin-ez-vlb)
[ORCHID TECHNOLOGY KELVIN 64-VLB at The Retro Web](https://theretroweb.com/expansioncards/s/orchid-technology-kelvin-64-vlb)
