### PR TITLE
Tape drive UI fixes

### DIFF
--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -841,12 +841,12 @@ MachineStatus::refresh(QStatusBar *sbar)
     iterateMO([this, sbar](int i) {
         d->mo[i].label = std::make_unique<ClickableLabel>();
         d->mo[i].setEmpty(QString(mo_drives[i].image_path).isEmpty());
-        if (QString(rdisk_drives[i].image_path).isEmpty())
+        if (QString(mo_drives[i].image_path).isEmpty())
             d->mo[i].setWriteProtected(false);
-        else if (QString(rdisk_drives[i].image_path).left(5) == "wp://")
+        else if (QString(mo_drives[i].image_path).left(5) == "wp://")
             d->mo[i].setWriteProtected(true);
         else
-            d->mo[i].setWriteProtected(rdisk_drives[i].read_only);
+            d->mo[i].setWriteProtected(mo_drives[i].read_only);
         d->mo[i].setActive(false);
         d->mo[i].setWriteActive(false);
         d->mo[i].refresh();


### PR DESCRIPTION
Summary
=======
* Fix tape drives not being removed from the status bar after being disabled/removed
* Fix wp:// not working with tape drives
* Drive-by: Fix MO drive logic incorrectly checking removable drives when determining write-protection

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set

References
==========
N/A