### PR TITLE
SCSI tape read fixes

### DIFF
--- a/src/include/86box/scsi_tape.h
+++ b/src/include/86box/scsi_tape.h
@@ -37,7 +37,7 @@ typedef struct tape_type_t {
 
 #define KNOWN_TAPE_TYPES 3
 static const tape_type_t tape_types[KNOWN_TAPE_TYPES] = {
-    { "QIC-150",  157286400, 512, 0x0F },
+    { "QIC-150",  157286400, 512, 0x10 },
     { "QIC-525",  549978112, 512, 0x11 },
     { "QIC-1000", 1073741824, 512, 0x12 },
 };
@@ -52,8 +52,8 @@ typedef struct tape_drive_type_t {
 
 #define KNOWN_TAPE_DRIVE_TYPES 2
 static const tape_drive_type_t tape_drive_types[KNOWN_TAPE_DRIVE_TYPES] = {
-    { "86BOX",   "SCSI TAPE",  "1.00", { 1, 1, 1 } },
-    { "ARCHIVE", "VIPER 150",  "2.10", { 1, 0, 0 } },
+    { "86BOX",   "SCSI TAPE",        "1.00", { 1, 1, 1 } },
+    { "ARCHIVE", "VIPER 150 21247",  "2.10", { 1, 0, 0 } },
 };
 
 enum {

--- a/src/scsi/scsi_tape.c
+++ b/src/scsi/scsi_tape.c
@@ -14,8 +14,6 @@
  *          Copyright 2025-2026 Plamen Ivanov.
  */
 #define _GNU_SOURCE
-#define ENABLE_TAPE_LOG 1
-#define TAPE_FILE_LOG   1
 #include <inttypes.h>
 #include <stdarg.h>
 #include <stdint.h>
@@ -1309,8 +1307,9 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
             tape_log(dev->log, "READ BLOCK LIMITS\n");
             tape_set_phase(dev, SCSI_PHASE_DATA_IN);
 
-            tape_buf_alloc(dev, 6);
-            memset(dev->buffer, 0, 6);
+            len = 6;
+            tape_buf_alloc(dev, len);
+            memset(dev->buffer, 0, len);
 
             /* Byte 0: reserved */
             /* Bytes 1-3: maximum block length (32KB = 0x008000) */
@@ -1321,8 +1320,10 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
             dev->buffer[4] = 0x02;
             dev->buffer[5] = 0x00;
 
+            tape_set_buf_len(dev, BufLen, &len);
+
             tape_log(dev->log, "Block limits: min=512, max=32768\n");
-            tape_data_command_finish(dev, 6, 6, 6, 0);
+            tape_data_command_finish(dev, len, len, len, 0);
             break;
 
         case GPCMD_REQUEST_SENSE:
@@ -1488,6 +1489,7 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
                         tape_log(dev->log, "  filemark after %u blocks, "
                                  "deferring filemark to next read\n", blocks_read);
                         dev->filemark_pending = 1;
+                        tape_set_buf_len(dev, BufLen, (int32_t *) &total_bytes);
                         tape_data_command_finish(dev, bytes_read, dev->block_size,
                                                  bytes_read, 0);
                         ui_sb_update_icon(SB_TAPE | dev->id, 1);
@@ -1503,6 +1505,7 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
                         tape_log(dev->log, "  EOD after %u blocks, "
                                  "deferring EOD to next read\n", blocks_read);
                         dev->eot = 1;
+                        tape_set_buf_len(dev, BufLen, (int32_t *) &total_bytes);
                         tape_data_command_finish(dev, bytes_read, dev->block_size,
                                                  bytes_read, 0);
                         ui_sb_update_icon(SB_TAPE | dev->id, 1);


### PR DESCRIPTION
Summary
=======
1. Read Block Limits now has the len variable set instead of directly using a magic number, as well as setting the buflen pointer.
2. On some SCSI controllers, the buffer length isn't automatic (so it gets set to -1 until being allocated and set again properly) so adjust the read 6 command to set the total bytes as the allocated buffer length when fixed block mode is set as well as when either filemark or eod are set. This fixes hang ups when using some SCSI controllers with the Archive tape drive.


Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
[Archive Viper SCSI](https://dn721506.ca.archive.org/0/items/bitsavers_archive2132150SProductManualJun88_7488625/21391-001_Viper_SCSI_2060S_2150S_Product_Manual_Jun88.pdf)
