### PR TITLE
SCSI Tape: fixed transfer length of the request block address command (0x02)

### DIFF
--- a/src/scsi/scsi_tape.c
+++ b/src/scsi/scsi_tape.c
@@ -1502,6 +1502,8 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
             tape_set_phase(dev, SCSI_PHASE_DATA_IN);
 
             max_len = MIN(3, cdb[4]);
+            if (!max_len)
+                max_len = 3;
 
             tape_buf_alloc(dev, 3);
             memset(dev->buffer, 0, 3);
@@ -2601,10 +2603,10 @@ tape_close(void)
 
                 if (dev->rec_buf)
                     free(dev->rec_buf);
-    
+
                 if (dev->tf)
                     free(dev->tf);
-    
+
                 if (dev->log != NULL) {
                     tape_log(dev->log, "Log closed\n");
                     log_close(dev->log);


### PR DESCRIPTION
Summary
=======
If cdb[4] is 0 (transfer length) then make sure the default 3 bytes are used in the length. Fixes writing to tape backups.

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
