### PR TITLE
Media History: stored write-protected media removed when machine starts

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3311,8 +3311,6 @@ save_image_file(char *cat, char *var, char *src)
     else
         sprintf(temp, "%s%s", prefix, src);
 
-    fprintf(stderr, "temp: %s\n", temp);
-
     ini_section_set_string(cat, var, temp);
 
     if (above3 != NULL)


### PR DESCRIPTION
Summary
=======
write-protected media other than which located in the machine folder being removed by Media History Manager due to 'wp://' is not positioned at the beginning of stored path in the machine configuration file.

eg. stored as ../../wp://disk/floppy.img instead of wp://../../disk/floppy.img

all the codes expect the beginning 5 character to be 'wp://' for write-protected but not in the middle of the path string

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
N/A