### PR TITLE
Renamed the Acculogic XT IDE card

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -232,6 +232,14 @@ device_set_context(device_context_t *ctx, const device_t *dev, int inst)
         void *      old_sec    = config_find_section("ST-50X Fixed Disk Controller (PC5086)");
         if ((sec == NULL) && (old_sec != NULL))
             config_rename_section(old_sec, ctx->name);
+    } else if (!strcmp(dev->name, "Acculogic sIDE-1/16 (IDE)")) {
+        sprintf(ctx->name, "%s", dev->name);
+
+        /* Migrate the old "Acculogic XT IDE" section */
+        const void *sec        = config_find_section(ctx->name);
+        void *      old_sec    = config_find_section("Acculogic XT IDE");
+        if ((sec == NULL) && (old_sec != NULL))
+            config_rename_section(old_sec, ctx->name);    
     } else
         sprintf(ctx->name, "%s", dev->name);
 }

--- a/src/disk/hdc_xtide.c
+++ b/src/disk/hdc_xtide.c
@@ -459,7 +459,7 @@ const device_t xtide_at_2ch_device = {
 };
 
 const device_t xtide_acculogic_device = {
-    .name          = "Acculogic XT IDE",
+    .name          = "Acculogic sIDE-1/16 (IDE)",
     .internal_name = "xtide_acculogic",
     .flags         = DEVICE_ISA,
     .local         = 0,


### PR DESCRIPTION
Summary
=======
Renamed it to the actual product name.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
https://ibm-pc.org/firmware/other/acculogic/acculogic.htm
