### PR TITLE
P6BXT-A+'s Revision 5.6 BIOS + Bravo MS BIOSes Renames

### DIFF
--- a/src/machine/m_at_slot1_socket370.c
+++ b/src/machine/m_at_slot1_socket370.c
@@ -45,7 +45,7 @@ static const device_config_t prosignias31x_config[] = {
         .name           = "bios",
         .description    = "BIOS Version",
         .type           = CONFIG_BIOS,
-        .default_string = "prosignias31x_bx",
+        .default_string = "p6bxt",
         .default_int    = 0,
         .file_filter    = NULL,
         .spinner        = { 0 },
@@ -53,7 +53,7 @@ static const device_config_t prosignias31x_config[] = {
         .bios           = {
             {
                 .name          = "Award Modular BIOS v4.51PG - Revision 5.3",
-                .internal_name = "p6bxt",
+                .internal_name = "p6bxt_53",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
                 .local         = 0,
@@ -68,6 +68,15 @@ static const device_config_t prosignias31x_config[] = {
                 .local         = 0,
                 .size          = 262144,
                 .files         = { "roms/machines/prosignias31x_bx/p6bxt-ap-092600.bin", "" }
+            },
+            {
+                .name          = "Award Modular BIOS v4.51PG - Revision 5.6",
+                .internal_name = "p6bxt",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 262144,
+                .files         = { "roms/machines/prosignias31x_bx/p6bxt-a-56-6990cdf1659c7829277668.bin", "" }
             },
             {
                 .name          = "Phoenix - AwardBIOS v6.00PG - Unofficial Version 6.0 (by rushieda)",

--- a/src/machine/m_at_socket5.c
+++ b/src/machine/m_at_socket5.c
@@ -1186,7 +1186,7 @@ static const device_config_t bravoms586_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "AST BIOS version 1.03 (November 1994)",
+                .name          = "Award AST BIOS - Revision 1.03 (November 1994)",
                 .internal_name = "bravoms586_103",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1195,7 +1195,7 @@ static const device_config_t bravoms586_config[] = {
                 .files         = { "roms/machines/bravoms586/asttest.bin", "" }
             },
             {
-                .name          = "AST BIOS version 2.02 (December 1995)",
+                .name          = "Award AST BIOS - Revision 2.02 (December 1995)",
                 .internal_name = "bravoms586",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -14381,7 +14381,7 @@ const machine_t machines[] = {
     /* This has AST KBC firmware, likely a Phoenix variant since the BIOS */
     /* calls KBC command D5h to read the KBC revision. */
     {
-        .name              = "[VLSI SuperCore] AST Bravo MS P/90",
+        .name              = "[VLSI SuperCore] AST Bravo MS/MS-T/MS-L (Rattler)",
         .internal_name     = "bravoms586",
         .type              = MACHINE_TYPE_SOCKET5,
         .chipset           = MACHINE_CHIPSET_VLSI_SUPERCORE,


### PR DESCRIPTION
Summary
=======
Recently, The Retro Web added the revision 5.6 BIOS to ECS P6BXT-A+. This PR adds that and make it as default BIOS for that machine.

Also, this PR renames the AST Socket 5 machine as "AST Bravo MS/MS-T/MS-L (Rattler)", and corrected its BIOSes' names to match other machines' BIOS names.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/471
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
[Two](https://theretroweb.com/motherboards/s/ast-bravo-ms,-ms-t,-ms-l-pentium-rattler-20) [entries](https://theretroweb.com/motherboards/s/ecs-p6bxt-a-rev-2-2x) on The Retro Web
