### PR TITLE
Renamed WD1003 and V86P's controller

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -128,7 +128,7 @@ device_set_context(device_context_t *ctx, const device_t *dev, int inst)
         void *      old_sec    = config_find_section("Western Digital WD1007V-SE1 (ESDI)");
         if ((sec == NULL) && (old_sec != NULL))
             config_rename_section(old_sec, ctx->name);
-    } else if (!strcmp(dev->name, "WD1003 AT (MFM/RLL)")) {
+    } else if (!strcmp(dev->name, "WD1003-WAH (MFM/RLL)")) {
         sprintf(ctx->name, "%s", dev->name);
 
         /* Migrate the old "WD1003 AT MFM/RLL Controller" section */
@@ -192,7 +192,7 @@ device_set_context(device_context_t *ctx, const device_t *dev, int inst)
         void *      old_sec    = config_find_section("WD1004a-27X RLL Fixed Disk Adapter");
         if ((sec == NULL) && (old_sec != NULL))
             config_rename_section(old_sec, ctx->name);
-    } else if (!strcmp(dev->name, "Victor V86P (RLL)")) {
+    } else if (!strcmp(dev->name, "Victor V86P Fixed Disk Adapter (RLL)")) {
         sprintf(ctx->name, "%s", dev->name);
 
         /* Migrate the old "Victor V86P RLL Fixed Disk Adapter" section */

--- a/src/disk/hdc_st506_at.c
+++ b/src/disk/hdc_st506_at.c
@@ -810,7 +810,7 @@ mfm_close(void *priv)
 }
 
 const device_t st506_at_wd1003_device = {
-    .name          = "WD1003 AT (MFM/RLL)",
+    .name          = "WD1003-WAH (MFM/RLL)",
     .internal_name = "st506_at",
     .flags         = DEVICE_ISA16,
     .local         = 0,

--- a/src/disk/hdc_st506_xt.c
+++ b/src/disk/hdc_st506_xt.c
@@ -1791,7 +1791,7 @@ st506_init(const device_t *info)
             dev->bios_addr = device_get_config_hex20("bios_addr");
             break;
 
-        case ST506_XT_TYPE_VICTOR_V86P: /* Victor V86P (RLL) */
+        case ST506_XT_TYPE_VICTOR_V86P: /* Victor V86P Fixed Disk Adapter (RLL) */
             fn = VICTOR_V86P_BIOS_FILE;
             break;
 
@@ -2450,7 +2450,7 @@ const device_t st506_xt_wd1004a_27x_device = {
 };
 
 const device_t st506_xt_victor_v86p_device = {
-    .name          = "Victor V86P (RLL)",
+    .name          = "Victor V86P Fixed Disk Adapter (RLL)",
     .internal_name = "st506_xt_victor_v86p",
     .flags         = DEVICE_ISA,
     .local         = (HDD_BUS_MFM << 8) | ST506_XT_TYPE_VICTOR_V86P,


### PR DESCRIPTION
Summary
=======
Renamed WD1003 to the actual product model.
I hadn't noticed that V86P is a machine and mistook it for an ISA card model. Added back "Fixed Disk Adapter" to denote it's related to that machine.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========

