### PR TITLE
DECpc LPV corrections + two misc. changes

### DIFF
--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -115,13 +115,13 @@ static const device_config_t p6kdi_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "AMIBIOS 6 (071595) - Revision 3.0",
-                .internal_name = "p6kdi",
+                .name          = "AMIBIOS 6 (071595) - Revision 1.0Y",
+                .internal_name = "p6kdi10y",
                 .bios_type     = BIOS_NORMAL, 
                 .files_no      = 1,
                 .local         = 0,
                 .size          = 262144,
-                .files         = { "roms/machines/p6kdi/P6KDI_~2.BIN", "" }
+                .files         = { "roms/machines/p6kdi/p6kdi10y.rom", "" }
             },
             {
                 .name          = "AMIBIOS 6 (071595) - Revision 2.0Y",
@@ -133,13 +133,13 @@ static const device_config_t p6kdi_config[] = {
                 .files         = { "roms/machines/p6kdi/p6kdi20y.rom", "" }
             },
             {
-                .name          = "AMIBIOS 6 (071595) - Revision 1.0Y",
-                .internal_name = "p6kdi10y",
+                .name          = "AMIBIOS 6 (071595) - Revision 3.0",
+                .internal_name = "p6kdi",
                 .bios_type     = BIOS_NORMAL, 
                 .files_no      = 1,
                 .local         = 0,
                 .size          = 262144,
-                .files         = { "roms/machines/p6kdi/p6kdi10y.rom", "" }
+                .files         = { "roms/machines/p6kdi/P6KDI_~2.BIN", "" }
             },
             { .files_no = 0 }
         },

--- a/src/machine/m_at_socket5.c
+++ b/src/machine/m_at_socket5.c
@@ -1211,7 +1211,7 @@ static const device_config_t bravoms586_config[] = {
 };
 
 const device_t bravoms586_device = {
-    .name          = "AST Bravo MS P/90",
+    .name          = "AST Bravo MS/MS-T/MS-L (Rattler)",
     .internal_name = "bravoms586_device",
     .flags         = 0,
     .local         = 0,

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -8212,7 +8212,7 @@ const machine_t machines[] = {
     },
     /* Uses an Intel KBC with Phoenix MultiKey KBC firmware. */
     {
-        .name              = "[SiS 461] DEC DECpc LPV",
+        .name              = "[SiS 461] DEC DECpc LPV+",
         .internal_name     = "decpclpv",
         .type              = MACHINE_TYPE_486,
         .chipset           = MACHINE_CHIPSET_SIS_461,
@@ -8235,7 +8235,7 @@ const machine_t machines[] = {
         .flags     = MACHINE_IDE | MACHINE_VIDEO | MACHINE_APM,
         .ram       = {
             .min  = 1024,
-            .max  = 32768,
+            .max  = 65536,
             .step = 1024
         },
         .nvrmask                  = 127,


### PR DESCRIPTION
Summary
=======
1. Increase DEC DECpc LPV's maximum memory into 64MB and rename it as "DEC DECpc LPV+" since it uses LPV+ BIOS.
2. Forgotten a name change for AST Bravo MS/MS-T/MS-L in the "m_at_socket5.c" code.
3. Sortout the BIOSes selection on Advanced Integration Research (AIR) P6KDI.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
[DECpc LPV's entry (and official manual) on The Retro Web](https://theretroweb.com/motherboards/s/dec-decpc-lpv)
