### PR TITLE
New machine wizard: Fix validation regex not being used

### DIFF
--- a/src/qt/qt_vmmanager_addmachine.cpp
+++ b/src/qt/qt_vmmanager_addmachine.cpp
@@ -181,17 +181,16 @@ WithExistingConfigPage::isComplete() const
 NameAndLocationPage::
     NameAndLocationPage(QWidget *parent)
 {
+#ifdef Q_OS_WINDOWS
+    dirValidate = QRegularExpression(R"(^[^\\/:*?"<>|]+$)");
+#elif defined(Q_OS_MACOS)
+    dirValidate = QRegularExpression(R"(^[^/:]+$)");
+#else
+    dirValidate = QRegularExpression(R"(^[^/]+$)");
+#endif
+
 #ifdef CUSTOM_SYSTEM_LOCATION
     setTitle(tr("System name and location"));
-
-#    if defined(_WIN32)
-    dirValidate = QRegularExpression(R"(^[^\\/:*?"<>|]+$)");
-#    elif defined(__APPLE__)
-    dirValidate = QRegularExpression(R"(^[^/:]+$)");
-#    else
-    dirValidate = QRegularExpression(R"(^[^/]+$)");
-#    endif
-
     setSubTitle(tr("Enter the name of the system and choose the location"));
 #else
     setTitle(tr("System name"));

--- a/src/qt/qt_vmmanager_addmachine.hpp
+++ b/src/qt/qt_vmmanager_addmachine.hpp
@@ -89,9 +89,9 @@ private:
 #endif
     QLineEdit *displayName;
     QLabel    *systemNameValidation;
+    QRegularExpression dirValidate;
 #ifdef CUSTOM_SYSTEM_LOCATION
     QLabel            *systemLocationValidation;
-    QRegularExpression dirValidate;
 private slots:
     void chooseDirectoryLocation();
 #endif


### PR DESCRIPTION
Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set

References
==========
N/A