### PR TITLE
Qt: Move the colon in "&Host CD/DVD Drive (%1:)" out of the translations

### DIFF
--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -1686,7 +1686,7 @@ msgstr ""
 msgid "&Pen"
 msgstr ""
 
-msgid "&Host CD/DVD Drive (%1:)"
+msgid "&Host CD/DVD Drive (%1)"
 msgstr ""
 
 msgid "&Connected"

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -1693,8 +1693,8 @@ msgstr "&Cursor/Puck"
 msgid "&Pen"
 msgstr "&Llapis"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "&Unitat de CD/DVD de l'amfitrió (%1:)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "&Unitat de CD/DVD de l'amfitrió (%1)"
 
 msgid "&Connected"
 msgstr "&Connectat"

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -1693,8 +1693,8 @@ msgstr "&Kurzor/Puk"
 msgid "&Pen"
 msgstr "&Pero"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "&Jednotka CD/DVD hostitele (%1:)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "&Jednotka CD/DVD hostitele (%1)"
 
 msgid "&Connected"
 msgstr "&Připojeno"

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -1693,8 +1693,8 @@ msgstr "&Mauszeiger/Puck"
 msgid "&Pen"
 msgstr "&Stift"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "&Host-CD/DVD-Laufwerk (%1:)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "&Host-CD/DVD-Laufwerk (%1)"
 
 msgid "&Connected"
 msgstr "&Verbunden"

--- a/src/qt/languages/el-GR.po
+++ b/src/qt/languages/el-GR.po
@@ -1719,8 +1719,8 @@ msgstr "&Cursor/Puck"
 msgid "&Pen"
 msgstr "&Γραφίδα"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "&Host CD/DVD Drive (%1:)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "&Host CD/DVD Drive (%1)"
 
 msgid "&Connected"
 msgstr "&Συνδεδεμένο"

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -1693,8 +1693,8 @@ msgstr "&Cursor/Puck"
 msgid "&Pen"
 msgstr "&Bolígrafo"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "&Unidad de CD/DVD anfitriona (%1:)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "&Unidad de CD/DVD anfitriona (%1)"
 
 msgid "&Connected"
 msgstr "&Conectrado"

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -1693,8 +1693,8 @@ msgstr "&Kursori/Kiekko"
 msgid "&Pen"
 msgstr "K&ynä"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "&Isäntä CD/DVD-asema (%1:)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "&Isäntä CD/DVD-asema (%1)"
 
 msgid "&Connected"
 msgstr "&Yhdistetty"

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -1693,8 +1693,8 @@ msgstr "&Curseur/Palette"
 msgid "&Pen"
 msgstr "&Stylo"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "&Lecteur CD/DVD hôte (%1:)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "&Lecteur CD/DVD hôte (%1)"
 
 msgid "&Connected"
 msgstr "&Connecté"

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -1695,8 +1695,8 @@ msgstr "&Kursor/Pak"
 msgid "&Pen"
 msgstr "&Olovka"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "CD/DVD pogon &nositelja (%1:)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "CD/DVD pogon &nositelja (%1)"
 
 msgid "&Connected"
 msgstr "&Povezan"

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -1763,8 +1763,8 @@ msgstr "&Cursore/Puck"
 msgid "&Pen"
 msgstr "&Penna"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "&Unità CD/DVD host (%1:)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "&Unità CD/DVD host (%1)"
 
 msgid "&Connected"
 msgstr "&Connesso"

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -1694,8 +1694,8 @@ msgstr "カーソル/パック(&C)"
 msgid "&Pen"
 msgstr "ペン(&P)"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "ホスト CD/DVD ドライブ (%1:) (&H)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "ホスト CD/DVD ドライブ (%1) (&H)"
 
 msgid "&Connected"
 msgstr "コネクテッド"

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -1693,8 +1693,8 @@ msgstr "커서/퍽(&P)"
 msgid "&Pen"
 msgstr "펜(&P)"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "호스트 CD/DVD 드라이브(%1:) (&H)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "호스트 CD/DVD 드라이브 (%1) (&H)"
 
 msgid "&Connected"
 msgstr "&커넥티드"

--- a/src/qt/languages/nb-NO.po
+++ b/src/qt/languages/nb-NO.po
@@ -1694,8 +1694,8 @@ msgstr "&Markør/pekeplate"
 msgid "&Pen"
 msgstr "&Penn"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "&Vert CD/DVD-stasjon (%1:)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "&Vert CD/DVD-stasjon (%1)"
 
 msgid "&Connected"
 msgstr "&Koblet til"

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -1692,8 +1692,8 @@ msgstr "&Cursor/Puck"
 msgid "&Pen"
 msgstr "&Pen"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "&Host CD/DVD-station (%1:)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "&Host CD/DVD-station (%1)"
 
 msgid "&Connected"
 msgstr "&Verbonden"

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -1694,8 +1694,8 @@ msgstr "&Kursor/krążek"
 msgid "&Pen"
 msgstr "P&ióro"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "&Napęd CD/DVD hosta (%1:)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "&Napęd CD/DVD hosta (%1)"
 
 msgid "&Connected"
 msgstr "&Podłączone"

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -1694,8 +1694,8 @@ msgstr "&Cursor/Puck"
 msgid "&Pen"
 msgstr "C&aneta"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "&Unidade de CD/DVD do anfitrião (%1:)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "&Unidade de CD/DVD do anfitrião (%1)"
 
 msgid "&Connected"
 msgstr "&Conectado"

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -1693,8 +1693,8 @@ msgstr "&Cursor/Disco"
 msgid "&Pen"
 msgstr "C&aneta"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "&Unidade de CD/DVD do anfitrião (%1:)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "&Unidade de CD/DVD do anfitrião (%1)"
 
 msgid "&Connected"
 msgstr "&Conectado"

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -1705,8 +1705,8 @@ msgstr "&Курсор/шайба"
 msgid "&Pen"
 msgstr "&Ручка"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "CD/DVD привод &хоста (%1:)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "CD/DVD привод &хоста (%1)"
 
 msgid "&Connected"
 msgstr "&Кабель подключен"

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -1693,8 +1693,8 @@ msgstr "&Kurzor/Puck"
 msgid "&Pen"
 msgstr "&Pero"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "&Hostiteľská jednotka CD/DVD (%1:)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "&Hostiteľská jednotka CD/DVD (%1)"
 
 msgid "&Connected"
 msgstr "&Pripojené"

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -1695,8 +1695,8 @@ msgstr "&Kazalec/ključ"
 msgid "&Pen"
 msgstr "&Pisalo"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "&Gostiteljski pogon CD/DVD (%1:)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "&Gostiteljski pogon CD/DVD (%1)"
 
 msgid "&Connected"
 msgstr "&Povezan"

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -1693,8 +1693,8 @@ msgstr "&Pekare/puck"
 msgid "&Pen"
 msgstr "P&enna"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "&Värdenhet för CD/DVD (%1:)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "&Värdenhet för CD/DVD (%1)"
 
 msgid "&Connected"
 msgstr "&Ansluten"

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -1693,8 +1693,8 @@ msgstr "&İmleç/Puck"
 msgid "&Pen"
 msgstr "&Kalem"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "&Ana Sistemin CD/DVD Sürücüsü (%1:)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "&Ana Sistemin CD/DVD Sürücüsü (%1)"
 
 msgid "&Connected"
 msgstr "&Bağlı"

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -1695,8 +1695,8 @@ msgstr "&Курсор/шайба"
 msgid "&Pen"
 msgstr "&Ручка"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "CD/DVD &привід хоста (%1:)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "CD/DVD &привід хоста (%1)"
 
 msgid "&Connected"
 msgstr "&Підключено"

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -1694,8 +1694,8 @@ msgstr "&Con trỏ/puck"
 msgid "&Pen"
 msgstr "&Bút"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "&Máy chủ CD/DVD ổ đĩa (%1 :)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "&Máy chủ CD/DVD ổ đĩa (%1)"
 
 msgid "&Connected"
 msgstr "&Đã kết nối"

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -1694,8 +1694,8 @@ msgstr "光标/冰球(&C)"
 msgid "&Pen"
 msgstr "笔(&P)"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "主机 CD/DVD 驱动器 (%1:) (&H)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "主机 CD/DVD 驱动器 (%1) (&H)"
 
 msgid "&Connected"
 msgstr "已连接(&C)"

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -1694,8 +1694,8 @@ msgstr "數位板標定器(&C)"
 msgid "&Pen"
 msgstr "筆(&P)"
 
-msgid "&Host CD/DVD Drive (%1:)"
-msgstr "主機 CD/DVD 光碟機 (%1:)(&H)"
+msgid "&Host CD/DVD Drive (%1)"
+msgstr "主機 CD/DVD 光碟機 (%1)(&H)"
 
 msgid "&Connected"
 msgstr "已連線(&C)"

--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -178,7 +178,7 @@ MediaMenu::refresh(QMenu *parentMenu)
             auto drive = QString("%1:\\").arg(letter);
             /* Check if the letter is a CD-ROM drive. */
             if (GetDriveTypeA(drive.toUtf8().constData()) == DRIVE_CDROM)
-                menu->addAction(QIcon(":/settings/qt/icons/cdrom_host.ico"), tr("&Host CD/DVD Drive (%1:)").arg(letter), [this, i, letter] { cdromMount(i, 2, QString(R"(\\.\%1:)").arg(letter)); })->setCheckable(false);
+                menu->addAction(QIcon(":/settings/qt/icons/cdrom_host.ico"), tr("&Host CD/DVD Drive (%1)").arg(QString(letter).append(':')), [this, i, letter] { cdromMount(i, 2, QString(R"(\\.\%1:)").arg(letter)); })->setCheckable(false);
         }
         menu->addSeparator();
 #elif defined(Q_OS_LINUX)


### PR DESCRIPTION
Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
N/A