### PR TITLE
sound: derive WTBUFLEN from WT_FREQ

### DIFF
--- a/src/include/86box/sound.h
+++ b/src/include/86box/sound.h
@@ -39,7 +39,7 @@ extern int sound_gain;
 #define CD_BUFLEN   (CD_FREQ / 10)
 
 #define WT_FREQ     FREQ_44100
-#define WTBUFLEN    (MUSIC_FREQ / 45)
+#define WTBUFLEN    (WT_FREQ / 45)
 
 enum {
     SOUND_NONE = 0,


### PR DESCRIPTION

Summary
=======
fix `WTBUFLEN` so the wavetable buffer length is derived from `WT_FREQ` instead of `MUSIC_FREQ`.

the old code mixed two different subsystems:

```c
#define MUSIC_FREQ  FREQ_49716
#define MUSICBUFLEN (MUSIC_FREQ / 36)

#define WT_FREQ     FREQ_44100
#define WTBUFLEN    (MUSIC_FREQ / 45)
```

that meant the wavetable path declared a 44.1 khz rate, but sized its buffer as if it were running at 49.716 khz. this changes the batching threshold from `1104` samples to `980` samples and makes the wavetable path internally inconsistent.

this pull request changes it to:

```c
#define WTBUFLEN    (WT_FREQ / 45)
```

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
- `/src/include/86box/sound.h`
- local verification in a windows 98 gaming pc workload showed no obvious regression after correcting the constant

