### PR TITLE
Correct Packard Bell PB300/PB320's name in `m_at_386sx.c`

### DIFF
--- a/src/machine/m_at_386sx.c
+++ b/src/machine/m_at_386sx.c
@@ -134,7 +134,7 @@ static const device_config_t pbl300sx_config[] = {
 };
 
 const device_t pbl300sx_device = {
-    .name          = "Packard Bell Legend 300SX",
+    .name          = "Packard Bell PB300/PB320",
     .internal_name = "pbl300sx_device",
     .flags         = 0,
     .local         = 0,


### PR DESCRIPTION
Summary
=======
This PR corrects the machine name on Packacrd Bell PB300/PB320's BIOS selector in `m_at_386sx.c` to match the name in `machine_table.c.`

It needs a machine name config migration (probably).

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
