### PR TITLE
Update MITSUMI CRMC-FX810T4 firmware revisions to 'a01'

### DIFF
--- a/src/include/86box/cdrom.h
+++ b/src/include/86box/cdrom.h
@@ -165,7 +165,7 @@ static const struct cdrom_drive_types_s {
     { "MATSHITA", "CR-572",           "1.0j", "matshita_572",   BUS_TYPE_IDE,  0,  4, 36, 0, 0, {  0, -1, -1, -1 } },
     { "MITSUMI",  "CRMC-FX4820T",     "D02A", "mitsumi_4820t",  BUS_TYPE_IDE,  0, 48, 36, 0, 0, {  4,  2,  2,  2 } },
     /* TODO: Find an IDENTIFY and/or INQUIRY dump. */
-    { "MITSUMI",  "CRMC-FX810T4",     "????", "mitsumi_810t4",  BUS_TYPE_IDE,  0,  8, 36, 0, 0, {  4,  2,  2, -1 } },
+    { "MITSUMI",  "CRMC-FX810T4",     "a01 ", "mitsumi_810t4",  BUS_TYPE_IDE,  0,  8, 36, 0, 0, {  4,  2,  2, -1 } },
     { "NEC",      "CD-ROM DRIVE:260", "1.00", "nec_260_early",  BUS_TYPE_IDE,  1,  2, 36, 1, 0, {  0, -1, -1, -1 } },
     { "NEC",      "CD-ROM DRIVE:260", "1.01", "nec_260",        BUS_TYPE_IDE,  1,  4, 36, 1, 0, {  0, -1, -1, -1 } },
     { "NEC",      "CD-ROM DRIVE:273", "4.20", "nec_273",        BUS_TYPE_IDE,  0,  4, 36, 0, 0, {  0, -1, -1, -1 } },


### PR DESCRIPTION
Summary
=======
Known firmware revisions range from "a01 to "a03".

Here's a screenshot with revision "a01":

![a01](https://github.com/user-attachments/assets/50e7b24a-d898-4379-8b69-43e6924c2e0f)
credits to @MicJeRon for finding this!

Sources for FX810T4 drives with firmware revision "a03" were mentioned at:
- https://tools.dosforum.de/cdbq/DRIVES.TXT
- http://web.archive.org/web/19991012213832/http://support.microsoft.com/support/kb/articles/Q228/9/90.ASP

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/