### PR TITLE
Fixes and cleanup for IBM ST506 MFM Adapter emulation

### DIFF
--- a/src/disk/hdc_st506_mca.c
+++ b/src/disk/hdc_st506_mca.c
@@ -109,7 +109,7 @@
 #include "cpu.h"
 
 #define MFM_TIME         (10 * TIMER_USEC)
-#define MFM_SECTOR_TIME  (250 * TIMER_USEC)
+#define MFM_SECTOR_TIME  (500 * TIMER_USEC)
 
 enum {
     STATE_IDLE = 0,
@@ -705,15 +705,6 @@ hdc_callback(void *priv)
     uint8_t  cmd = ccb->cmd & 0x0f;
 #endif
 
-    /* If we are returning from a RESET, handle this first. */
-    if (dev->reset) {
-        st506_mca_log("ST506 reset.\n");
-        dev->status &= ~ASR_BUSY;
-        dev->reset = 0;
-        do_finish(dev);
-        return;
-    }
-
     /* Abort last command if requested. */
     if (dev->abort) {
         st506_mca_log("ST506 command abort.\n");
@@ -741,6 +732,16 @@ hdc_callback(void *priv)
     dev->ssb.ecc_crc_err    = 0;
     dev->ssb.ecc_crc_field  = 0;
     dev->ssb.valid          = 1;
+
+    /* If we are returning from a RESET, handle this first. */
+    if (dev->reset) {
+        st506_mca_log("ST506 reset.\n");
+        dev->status &= ~ASR_BUSY;
+        dev->ssb.valid = 0;
+        dev->reset = 0;
+        do_finish(dev);
+        return;
+    }
 
     st506_mca_log("hdc_callback(): %02X\n", cmd);
 
@@ -940,6 +941,7 @@ do_send:
         case CMD_RECALIBRATE: /* RECALIBRATE */
             if (drive->present) {
                 dev->track = drive->cur_cyl = 0;
+                dev->ssb.seek_end = 1;
             } else {
                 dev->ssb.not_ready = 1;
                 dev->intstat |= ISR_TERMINATION;
@@ -958,7 +960,7 @@ do_send:
 
             if (!(dev->ready | ccb->no_data)) {
                 /* Delay a bit, transfer not ready. */
-                timer_advance_u64(&dev->timer, MFM_TIME);
+                timer_advance_u64(&dev->timer, MFM_SECTOR_TIME);
                 return;
             }
 
@@ -1110,8 +1112,6 @@ do_recv:
 static void
 hdc_send_ssb(mfm_t *dev)
 {
-    const drive_t *drive;
-
     if (!dev->ssb.valid) {
         /* Create a valid SSB. */
         memset(&dev->ssb, 0x00, sizeof(dev->ssb));
@@ -1309,6 +1309,13 @@ mfm_write(uint16_t port, uint8_t val, void *priv)
             }
 
             if (val & ATT_CSB) {
+                if (dev->attn & ATT_CCB) {
+                    /* Hey now, we're still busy for you! */
+                    dev->intstat |= ISR_INVALID_CMD;
+                    set_intr(dev, 1);
+                    break;
+                }
+
                 /* OK, prepare for receiving a CSB. */
                 dev->attn |= ATT_CSB;
 
@@ -1410,7 +1417,8 @@ mfm_writew(uint16_t port, uint16_t val, void *priv)
                             dev->status |= ASR_BUSY;
 
                         /* Schedule command execution. */
-                        timer_set_delay_u64(&dev->timer, MFM_TIME);
+                        timer_set_delay_u64(&dev->timer, 
+                            (dev->ccb.cmd == 0x02 | dev->ccb.cmd == 0x08) ? MFM_TIME : MFM_SECTOR_TIME);
                     }
                 }
             }
@@ -1516,6 +1524,7 @@ mfm_init(UNUSED(const device_t *info))
     dev->dma  = 3;
 
     /* Load any disks for this device class. */
+    c = 0;
     for (uint8_t i = 0; i < HDD_NUM; i++) {
         if (hdd[i].bus_type == HDD_BUS_MFM) {
             drive = &dev->drives[hdd[i].mfm_channel];
@@ -1524,7 +1533,7 @@ mfm_init(UNUSED(const device_t *info))
                 drive->present = 0;
                 continue;
             }
-            drive->id = i;
+            drive->id = c;
 
             /* These are the "hardware" parameters (from the image.) */
             drive->cfg_spt    = (uint8_t) (hdd[i].spt & 0xff);
@@ -1545,6 +1554,9 @@ mfm_init(UNUSED(const device_t *info))
 
             st506_mca_log("ST506: drive%d: cyl=%d,hd=%d,spt=%d, disk %d\n",
                            hdd[i].mfm_channel, drive->tracks, drive->hpc, drive->spt, i);
+            
+            if (++c > 1)
+                break;
         }
     }
 

--- a/src/disk/hdc_xta_ps1.c
+++ b/src/disk/hdc_xta_ps1.c
@@ -135,7 +135,7 @@ enum {
 #define ASR_DATA_REQ 0x10 /* data request */
 
 /* Attachment Control register (2W) values (IBM PS/1 2011.) */
-#define ACR_DMA_EN 0x01 /* DMA enable */
+#define ACR_DMA_EN 0x01 /* DMA transfer enable */
 #define ACR_INT_EN 0x02 /* interrupt enable */
 #define ACR_RESET  0x80 /* reset */
 
@@ -727,15 +727,6 @@ hdc_callback(void *priv)
     uint8_t  cmd = ccb->cmd & 0x0f;
 #endif
 
-    /* If we are returning from a RESET, handle this first. */
-    if (dev->reset) {
-        ps1_hdc_log("XTA reset.\n");
-        dev->status &= ~ASR_BUSY;
-        dev->reset = 0;
-        do_finish(dev);
-        return;
-    }
-
     /* Abort last command if requested. */
     if (dev->abort) {
         ps1_hdc_log("XTA command abort.\n");
@@ -761,6 +752,16 @@ hdc_callback(void *priv)
     /* We really only support one drive, but ohwell. */
     drive = &dev->drives[0];
 
+    /* If we are returning from a RESET, handle this first. */
+    if (dev->reset) {
+        ps1_hdc_log("XTA reset.\n");
+        dev->status &= ~ASR_BUSY;
+        dev->ssb.valid = 0;
+        dev->reset = 0;
+        do_finish(dev);
+        return;
+    }
+
     ps1_hdc_log("hdc_callback(): %02X\n", cmd);
 
     switch (ccb->cmd) {
@@ -778,7 +779,7 @@ hdc_callback(void *priv)
 
             if (!(dev->ready | ccb->no_data)) {
                 /* Delay a bit, transfer not ready. */
-                timer_advance_u64(&dev->timer, HDC_TIME);
+                timer_advance_u64(&dev->timer, HDC_SECTOR_TIME);
                 return;
             }
 
@@ -959,6 +960,7 @@ do_send:
         case CMD_RECALIBRATE: /* RECALIBRATE */
             if (drive->present) {
                 dev->track = drive->cur_cyl = 0;
+                dev->ssb.seek_end = 1;
             } else {
                 dev->ssb.not_ready = 1;
                 dev->intstat |= ISR_TERMINATION;
@@ -977,7 +979,7 @@ do_send:
 
             if (!(dev->ready | ccb->no_data)) {
                 /* Delay a bit, transfer not ready. */
-                timer_advance_u64(&dev->timer, HDC_TIME);
+                timer_advance_u64(&dev->timer, HDC_SECTOR_TIME);
                 return;
             }
 


### PR DESCRIPTION
Summary
=======

- Unbreak Xenix again and fix random crashes on slow CPU (16MHz)
- Clear Sense Summary Block after adapter reset
- Some code cleanup

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
IBM PS/1 Technical Reference Section 8 Drives: https://www.mediafire.com/download/ecok59mrc8sclzb/Section_8._Drives.pdf
