### PR TITLE
Translations update from 86Box Weblate

### DIFF
--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2026-03-10 09:50+0000\n"
+"PO-Revision-Date: 2026-03-27 18:35+0000\n"
 "Last-Translator: Nelson Kerber Hennemann Filho <nelsonhf@outlook.com>\n"
 "Language-Team: Portuguese (Brazil) <https://weblate.86box.net/projects/86box/"
 "86box/pt_BR/>\n"
@@ -1060,7 +1060,6 @@ msgstr "%1 é necessário para a conversão automática de arquivos PCL para PDF
 msgid "Don't show this message again"
 msgstr "Não exibir esta mensagem novamente"
 
-#, fuzzy
 msgid "Reset"
 msgstr "Reiniciar"
 


### PR DESCRIPTION
Translations update from [86Box Weblate](https://weblate.86box.net) for [86Box/86Box](https://weblate.86box.net/projects/86box/86box/).



Current translation status:

![Weblate translation status](https://weblate.86box.net/widget/86box/86box/horizontal-auto.svg)