### PR TITLE
PAS Plus/16 bugfixes

### DIFF
--- a/src/sound/snd_pas16.c
+++ b/src/sound/snd_pas16.c
@@ -2012,8 +2012,8 @@ pasplus_get_music_buffer(int32_t *buffer, int len, void *priv)
     double             bass_treble;
 
     for (int c = 0; c < len * 2; c += 2) {
-        double out_l = (((double) opl_buf[c]) * mixer->fm_l) * 0.7171630859375;
-        double out_r = (((double) opl_buf[c + 1]) * mixer->fm_r) * 0.7171630859375;
+        double out_l = (((double) opl_buf[c]) * mixer->fm_l) * 7.7171630859375;
+        double out_r = (((double) opl_buf[c + 1]) * mixer->fm_r) * 7.7171630859375;
 
         /* TODO: recording CD, Mic with AGC or line in. Note: mic volume does not affect recording. */
         out_l *= mixer->master_l;
@@ -2137,11 +2137,11 @@ pas16_get_buffer(int32_t *buffer, int len, void *priv)
 
         if (pas16->filter) {
             /* We divide by 3 to get the volume down to normal. */
-            out_l += (low_fir_pas16(0, (double) pas16->pcm_buffer[0][c >> 1]) * mixer->pcm_l) / 3.0;
-            out_r += (low_fir_pas16(1, (double) pas16->pcm_buffer[1][c >> 1]) * mixer->pcm_r) / 3.0;
+            out_l += (low_fir_pas16(0, (double) pas16->pcm_buffer[0][c >> 1]) * mixer->pcm_l);
+            out_r += (low_fir_pas16(1, (double) pas16->pcm_buffer[1][c >> 1]) * mixer->pcm_r);
         } else {
-            out_l += (((double) pas16->pcm_buffer[0][c >> 1]) * mixer->pcm_l) / 3.0;
-            out_r += (((double) pas16->pcm_buffer[1][c >> 1]) * mixer->pcm_r) / 3.0;
+            out_l += (((double) pas16->pcm_buffer[0][c >> 1]) * mixer->pcm_l);
+            out_r += (((double) pas16->pcm_buffer[1][c >> 1]) * mixer->pcm_r);
         }
 
         out_l *= mixer->master_l;


### PR DESCRIPTION
Summary
=======
- Correct DMA tick counts on the PAS16 when not in native mode, fixes bad audio in NeXTSTEP 3.1, PAS16 Customer Diagnostics and likely other applications when playing 16-bit stereo audio using a low (8-bit) DMA channel
- Do not reset registers on PAS Plus/16 when PCM playback is enabled (setting bit 5 of port B8Ah/Audio Filter Control), fixes failure to start DAC playback in Impulse Tracker and Doom II.
- Increase output volumes for the FM synth and DAC

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
