### PR TITLE
Softfloat x87: Fixed FXTRACT when the tag empty side is -1.

### DIFF
--- a/src/cpu/x87_ops_sf_trans.h
+++ b/src/cpu/x87_ops_sf_trans.h
@@ -140,17 +140,14 @@ sf_FXTRACT(uint32_t fetchdat)
     struct softfloat_status_t   status;
     floatx80                    a;
     floatx80                    b;
-#if 0
     const floatx80              floatx80_default_nan = packFloatx80(0, floatx80_default_nan_exp, floatx80_default_nan_fraction);
-#endif
 
     FP_ENTER();
     FPU_check_pending_exceptions();
     cpu_state.pc++;
     clear_C1();
 
-#if 0 // TODO
-    if ((IS_TAG_EMPTY(0) || IS_TAG_EMPTY(-1))) {
+    if ((IS_TAG_EMPTY(0) || !IS_TAG_EMPTY(-1))) {
         if (IS_TAG_EMPTY(0))
             FPU_exception(fetchdat, FPU_EX_Stack_Underflow, 0);
         else
@@ -164,7 +161,6 @@ sf_FXTRACT(uint32_t fetchdat)
         }
         goto next_ins;
     }
-#endif
 
     status = i387cw_to_softfloat_status_word(i387_get_control_word());
     a      = FPU_read_regi(0);
@@ -175,9 +171,7 @@ sf_FXTRACT(uint32_t fetchdat)
         FPU_save_regi(a, 0); // fraction
     }
 
-#if 0 // TODO.
 next_ins:
-#endif
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fxtract) : (x87_timings.fxtract * cpu_multi));
     CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fxtract) : (x87_concurrency.fxtract * cpu_multi));
     return 0;


### PR DESCRIPTION
Summary
=======
And it cost a ton of time to figure out when it was under my nose. Still retains solid 100% on all FPU tests when softfloat is on.

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
