### PR TITLE
Fix AIX PS/2 1.3 crashing with IBM PS/2 ESDI controller

### DIFF
--- a/src/disk/hdc_esdi_mca.c
+++ b/src/disk/hdc_esdi_mca.c
@@ -734,7 +734,7 @@ esdi_callback(void *priv)
                 dev->status_data[2] = drive->sectors & 0xffff;
                 dev->status_data[3] = drive->sectors >> 16;
                 dev->status_data[4] = drive->tracks;
-                dev->status_data[5] = drive->hpc | (drive->spt << 16);
+                dev->status_data[5] = drive->hpc | (drive->spt << 8);
             }
             esdi_mca_log("CMD_GET_DEV_CONFIG %i  %04x %04x %04x %04x %04x %04x\n",
                 drive->sectors,


### PR DESCRIPTION
Summary
=======
Bit 5 of Device Configuration Status Block shifts too high, causing AIX PS/2 1.3 to crash.

Checklist
=========
* [x] Closes #4938
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
DASD Storage Interface Specification Micro Channel (REV 2.2): https://www.ardent-tool.com/docs/pdf/j_mcspec.pdf
