### PR TITLE
NE2000/RTL8019AS: Move two cards to the network list's ISA section

### DIFF
--- a/src/network/network.c
+++ b/src/network/network.c
@@ -93,6 +93,8 @@ static const NETWORK_CARD net_cards[] = {
     { &ne1000_compat_device       },
     { &ne2000_compat_8bit_device  },
     { &ne1000_device              },
+    { &ne2000_device              },
+    { &rtl8019as_pnp_device       },
     { &wd8003e_device             },
     { &wd8003eb_device            },
     { &wd8013ebt_device           },
@@ -105,9 +107,7 @@ static const NETWORK_CARD net_cards[] = {
     { &pcnet_am79c961_device      },
     { &de220p_device              },
     { &ne2000_compat_device       },
-    { &ne2000_device              },
     { &pcnet_am79c960_eb_device   },
-    { &rtl8019as_pnp_device       },
     /* MCA */
     { &ethernext_mc_device        },
     { &wd8003ea_device            },


### PR DESCRIPTION
Summary
=======
This PR moves Novell NE2000 and Realtek RTL8019AS to the network list's ISA8 section. This PR was made because they are 8-bit compatible, according to latest NE2000 changes.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
