### PR TITLE
YMF7xx SBPro DSP fixes

### DIFF
--- a/src/include/86box/snd_sb_dsp.h
+++ b/src/include/86box/snd_sb_dsp.h
@@ -12,8 +12,9 @@
 #define SB_SUBTYPE_CLONE_AZT2316R_0X12 4 /* Aztech Sound Galaxy Pro 16 II */
 #define SB_SUBTYPE_CLONE_AZT2320_0X13  5 /* Aztech AZT2320 */
 #define SB_SUBTYPE_MVD201              6 /* Mediavision MVD201, found on the thunderboard and PAS16 */
-#define SB_SUBTYPE_ESS_ES688           7 /* ESS Technology ES688 */
-#define SB_SUBTYPE_ESS_ES1688          8 /* ESS Technology ES1688 */
+#define SB_SUBTYPE_YMF7XX              7 /* Yamaha YMF-701/71x */
+#define SB_SUBTYPE_ESS_ES688           8 /* ESS Technology ES688 */
+#define SB_SUBTYPE_ESS_ES1688          9 /* ESS Technology ES1688 */
 
 /* ESS-related */
 #define IS_ESS(dsp) ((dsp)->sb_subtype >= SB_SUBTYPE_ESS_ES688)    /* Check for future ESS cards here */
@@ -184,6 +185,9 @@ typedef struct sb_dsp_t {
     int8_t    espcm_sample_buffer[19]; /* used for ESPCM_4 recording */
     uint8_t   espcm_table_index;       /* used for ESPCM_3 */
     uint8_t   espcm_last_value;        /* used for ESPCM_3 */
+
+    /* OPL3-SA switchable DSP version */
+    uint8_t   opl3sa_dsp_ver;
 
     mpu_t *mpu;
 } sb_dsp_t;

--- a/src/sound/snd_sb_dsp.c
+++ b/src/sound/snd_sb_dsp.c
@@ -1779,6 +1779,28 @@ sb_exec_command(sb_dsp_t *dsp)
                 }
                 break;
             }
+            if (dsp->sb_subtype == SB_SUBTYPE_YMF7XX) {
+                switch (dsp->opl3sa_dsp_ver) {
+                    case 0x00: /* DSP ver 0.00 */
+                        sb_add_data(dsp, 0x0);
+                        sb_add_data(dsp, 0x0);
+                        break;
+                    case 0x01: /* DSP ver 1.05 */
+                        sb_add_data(dsp, 0x1);
+                        sb_add_data(dsp, 0x5);
+                        break;
+                    case 0x02: /* DSP ver 2.01 */
+                        sb_add_data(dsp, 0x2);
+                        sb_add_data(dsp, 0x1);
+                        break;
+                    case 0x03: /* DSP ver 3.01 */
+                    default:
+                        sb_add_data(dsp, 0x3);
+                        sb_add_data(dsp, 0x1);
+                        break;
+                }
+                break;
+            }
             sb_add_data(dsp, sb_dsp_versions[dsp->sb_type] >> 8);
             sb_add_data(dsp, sb_dsp_versions[dsp->sb_type] & 0xff);
             break;
@@ -2116,6 +2138,8 @@ sb_read(uint16_t addr, void *priv)
                 sb_dsp_log("SB Read Data Aztech read %02X, Read RP = %d, Read WP = %d\n",
                            (dsp->sb_read_rp == dsp->sb_read_wp) ? 0x00 : 0x80, dsp->sb_read_rp, dsp->sb_read_wp);
                 ret = (dsp->sb_read_rp == dsp->sb_read_wp) ? 0x00 : 0x80;
+            } else if ((dsp->state == DSP_S_RESET) && (dsp->sb_subtype == SB_SUBTYPE_YMF7XX)) {
+                ret = 0x00; /* Newer OPL3-SA drivers check that all bits are clear during reset */
             } else {
                 sb_dsp_log("SB Read Data Creative read %02X\n", (dsp->sb_read_rp == dsp->sb_read_wp) ? 0x7f : 0xff);
                 if ((dsp->sb_type < SB16_DSP_404) && IS_NOT_ESS(dsp))

--- a/src/sound/snd_ymf701.c
+++ b/src/sound/snd_ymf701.c
@@ -319,7 +319,9 @@ ymf701_reg_write(uint16_t addr, uint8_t val, void *priv)
                         mpu401_setirq(ymf701->mpu, ymf701->cur_mpu401_irq);
                         gameport_remap(ymf701->gameport, (ymf701->regs[3] & 0x1) ? 0x200 : 0x00);
                         break;
-                    case 0x04: /* LSI Version Register, on a real Intel Ruby board this is always 0 */
+                    case 0x04: /* LSI Version Register, bit 0 sets SB DSP version */
+                        ymf701->regs[0x04] = val & 0x01;
+                        ymf701->sb->dsp.opl3sa_dsp_ver = (ymf701->regs[0x04] & 0x01) ? 2 : 3;
                         break;
                     default:
                         break;
@@ -419,11 +421,12 @@ ymf701_init(const device_t *info)
     ymf701->sb->opl_enabled = 1;
 
     sb_dsp_set_real_opl(&ymf701->sb->dsp, 1);
-    sb_dsp_init(&ymf701->sb->dsp, SBPRO_DSP_302, SB_SUBTYPE_DEFAULT, ymf701);
+    sb_dsp_init(&ymf701->sb->dsp, SBPRO_DSP_301, SB_SUBTYPE_YMF7XX, ymf701);
     sb_dsp_setaddr(&ymf701->sb->dsp, ymf701->cur_sb_addr);
     sb_dsp_setirq(&ymf701->sb->dsp, ymf701->cur_sb_irq);
     sb_dsp_setdma8(&ymf701->sb->dsp, ymf701->cur_sb_dma);
     sb_ct1345_mixer_reset(ymf701->sb);
+    ymf701->sb->dsp.opl3sa_dsp_ver = 3;
 
     ymf701->sb->opl_mixer = ymf701;
     ymf701->sb->opl_mix   = ymf701_filter_opl;

--- a/src/sound/snd_ymf71x.c
+++ b/src/sound/snd_ymf71x.c
@@ -266,6 +266,20 @@ ymf71x_reg_write(uint16_t addr, uint8_t val, void *priv)
                         break;
                     case 0x02: /* System Control */
                         ymf71x->regs[0x02] = val;
+                        switch ((ymf71x->regs[0x02] & 0x06) >> 1) { /* Set SBPro DSP version */
+                            case 0x00: /* DSP ver 3.01 */
+                                ymf71x->sb->dsp.opl3sa_dsp_ver = 3;
+                                break;
+                            case 0x01: /* DSP ver 2.01 */
+                                ymf71x->sb->dsp.opl3sa_dsp_ver = 2;
+                                break;
+                            case 0x02: /* DSP ver 1.05 */
+                                ymf71x->sb->dsp.opl3sa_dsp_ver = 1;
+                                break;
+                            case 0x03: /* DSP ver 0.00 */
+                                ymf71x->sb->dsp.opl3sa_dsp_ver = 0;
+                                break;
+                        }
                         break;
                     case 0x03: /* Interrupt Channel Config */
                         ymf71x->regs[0x03] = val;
@@ -712,8 +726,9 @@ ymf71x_init(const device_t *info)
     ymf71x->sb->opl_enabled = 1;
 
     sb_dsp_set_real_opl(&ymf71x->sb->dsp, 1);
-    sb_dsp_init(&ymf71x->sb->dsp, SBPRO_DSP_302, SB_SUBTYPE_DEFAULT, ymf71x);
+    sb_dsp_init(&ymf71x->sb->dsp, SBPRO_DSP_301, SB_SUBTYPE_YMF7XX, ymf71x);
     sb_ct1345_mixer_reset(ymf71x->sb);
+    ymf71x->sb->dsp.opl3sa_dsp_ver = 3;
 
     ymf71x->sb->opl_mixer = ymf71x;
     ymf71x->sb->opl_mix   = ymf71x_filter_opl;


### PR DESCRIPTION
Summary
=======
Fix a few issues with the YMF-7xx cards:
- Correct the (default) SBPro DSP version to 3.01
- The SBPro DSP on YMF-7xx cards return 0x00 when reading the Read Data Ready port during DSP reset
- Implement DSP version switching on both YMF-7xx chip families. Along with the Read Data Ready port change this fixes the SoftSynth on newer Win3.x/Win9x drivers.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
