### PR TITLE
Fix AIX PS/2 1.3 crashing with IBM PS/2 ESDI controller

### DIFF
--- a/src/disk/hdc_esdi_mca.c
+++ b/src/disk/hdc_esdi_mca.c
@@ -616,7 +616,7 @@ esdi_callback(void *priv)
                 return;
             }
 
-            if ((dev->rba + dev->sector_count) > hdd_image_get_last_sector(drive->hdd_num)) {
+            if (dev->rba >= hdd_image_get_last_sector(drive->hdd_num)) {
                 rba_out_of_range(dev);
                 return;
             }


### PR DESCRIPTION
Summary
=======
Cleanup RBA range calculation for Seek command, fix AIX crashing on IBM ESDI adapter.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
DASD Storage Interface Specification Micro Channel (REV 2.2): https://www.ardent-tool.com/docs/pdf/j_mcspec.pdf
