### PR TITLE
wl_mouse: Add NULL checks in display_global_remove

### DIFF
--- a/src/qt/wl_mouse.cpp
+++ b/src/qt/wl_mouse.cpp
@@ -71,12 +71,18 @@ display_global_remove(void *data, struct wl_registry *wl_registry, uint32_t name
         zwp_keyboard_shortcuts_inhibitor_v1_destroy(kbd_inhibitor);
         kbd_inhibitor = nullptr;
     }
-    zwp_keyboard_shortcuts_inhibit_manager_v1_destroy(kbd_manager);
-    zwp_relative_pointer_manager_v1_destroy(rel_manager);
-    zwp_pointer_constraints_v1_destroy(conf_pointer_interface);
-    rel_manager            = nullptr;
-    conf_pointer_interface = nullptr;
-    kbd_manager            = nullptr;
+    if (kbd_manager) {
+        zwp_keyboard_shortcuts_inhibit_manager_v1_destroy(kbd_manager);
+        kbd_manager = nullptr;
+    }
+    if (rel_manager) {
+        zwp_relative_pointer_manager_v1_destroy(rel_manager);
+        rel_manager = nullptr;
+    }
+    if (conf_pointer_interface) {
+        zwp_pointer_constraints_v1_destroy(conf_pointer_interface);
+        conf_pointer_interface = nullptr;
+    }
 }
 
 static const struct wl_registry_listener registry_listener = {


### PR DESCRIPTION
Summary
=======
Follow-up to #6935. Same missing NULL checks in `display_global_remove`.

Fixes intermittent crashing on Plasma 6/Wayland

Checklist
=========
* [ ] Closes N/A
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set

References
==========
None.