### PR TITLE
Machine table fixes for DEC Celebris 5xx; Siemens D943 and OP47

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -13526,7 +13526,7 @@ const machine_t machines[] = {
             .max_multi   = 2.0
         },
         .bus_flags = MACHINE_PS2_PCI,
-        .flags     = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_VIDEO,
+        .flags     = MACHINE_IDE_DUAL | MACHINE_APM,
         .ram       = {
             .min  = 4096,
             .max  = 262144,
@@ -15842,7 +15842,7 @@ const machine_t machines[] = {
             .block       = CPU_BLOCK_NONE,
             .min_bus     = 50000000,
             .max_bus     = 66666667,
-            .min_voltage = 2800,
+            .min_voltage = 3380,
             .max_voltage = 3520,
             .min_multi   = 1.5,
             .max_multi   = 3.0
@@ -15890,17 +15890,13 @@ const machine_t machines[] = {
             .block       = CPU_BLOCK_NONE,
             .min_bus     = 50000000,
             .max_bus     = 66666667,
-            .min_voltage = 2800,
+            .min_voltage = 3380,
             .max_voltage = 3520,
             .min_multi   = 1.5,
             .max_multi   = 3.0
         },
         .bus_flags = MACHINE_PS2_PCI,
-        /*
-           It has on-board video but the only high-resolution screenshot available
-           has a sticker over the video chip.
-         */
-        .flags     = MACHINE_IDE_DUAL | MACHINE_GAMEPORT | MACHINE_APM,
+        .flags     = MACHINE_IDE_DUAL | MACHINE_APM, /* Machine has onboard video: C&T F65548 (not yet implemented) */
         .ram       = {
             .min  = 8192,
             .max  = 65536,


### PR DESCRIPTION
Summary
=======
* Remove the unused MACHINE_VIDEO flag on the Celebris
* Fix the min. voltages on both Siemens machines
* Remove the unused MACHINE_GAMEPORT flag on the OP47, along with the inaccurate internal note

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
N/A
