### PR TITLE
Add the TexElec SAAYM sound card

### DIFF
--- a/src/include/86box/snd_cms.h
+++ b/src/include/86box/snd_cms.h
@@ -27,6 +27,7 @@ typedef struct cms_t {
 } cms_t;
 
 extern void    cms_update(cms_t *cms);
+extern void    cms_get_buffer(int32_t *buffer, int len, void *priv);
 extern void    cms_write(uint16_t addr, uint8_t val, void *priv);
 extern uint8_t cms_read(uint16_t addr, void *priv);
 

--- a/src/include/86box/snd_saaym.h
+++ b/src/include/86box/snd_saaym.h
@@ -1,0 +1,33 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          Texelec Saaym Emulation.
+ *
+ * Authors: Jasmine Iwanek, <jriwanek@gmail.com>
+ *
+ *          Copyright 2024-2026 Jasmine Iwanek.
+ */
+#ifndef SOUND_SAAYM_H
+#define SOUND_SAAYM_H
+
+#include <86box/snd_opl.h>
+#include <86box/log.h>
+
+typedef struct saaym_t {
+    int     addr;
+
+    uint8_t latched_data;
+
+    cms_t   cms;
+
+    fm_drv_t opm;
+
+    void * log;
+} saaym_t;
+
+#endif /*SOUND_SAAYM_H*/

--- a/src/include/86box/sound.h
+++ b/src/include/86box/sound.h
@@ -262,6 +262,9 @@ extern const device_t tndy_device;
 /* Tandy Sensation */
 extern const device_t sensationaud_device;
 
+/* Texelec SAAYM */
+extern const device_t saaym_device;
+
 /* Windows Sound System */
 extern const device_t wss_device;
 extern const device_t ncr_business_audio_device;

--- a/src/include/86box/sound.h
+++ b/src/include/86box/sound.h
@@ -262,7 +262,7 @@ extern const device_t tndy_device;
 /* Tandy Sensation */
 extern const device_t sensationaud_device;
 
-/* Texelec SAAYM */
+/* TexElec SAAYM */
 extern const device_t saaym_device;
 
 /* Windows Sound System */

--- a/src/sound/CMakeLists.txt
+++ b/src/sound/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(snd OBJECT
     snd_mmb.c
     snd_mpu401.c
     snd_pas16.c
+    snd_saaym.c
     snd_sn76489.c
     snd_ssi2001.c
     snd_wss.c

--- a/src/sound/snd_saaym.c
+++ b/src/sound/snd_saaym.c
@@ -68,7 +68,6 @@ saaym_write(uint16_t addr, uint8_t val, void *priv)
             break;
 
         default:
-            cms_write(addr, val, &saaym->cms);
             break;
     }
 
@@ -91,7 +90,6 @@ saaym_read(uint16_t addr, void *priv)
             break;
 
         default:
-            ret = cms_read(addr, (void *) &saaym->cms);
             break;
     }
     saaym_log(saaym->log, "SAAYM read: port = %04X, ret = %02X\n", addr, ret);
@@ -123,16 +121,17 @@ saaym_get_music_buffer(int32_t *buffer, int len, void *priv)
 void *
 saaym_init(UNUSED(const device_t *info))
 {
-    saaym_t *saaym = malloc(sizeof(saaym_t));
-    memset(saaym, 0, sizeof(saaym_t));
+    saaym_t *saaym = calloc(1, sizeof(saaym_t));
 
     memset(&saaym->cms, 0, sizeof(cms_t));
 
     saaym->log = log_open("SAAYM");
 
     uint16_t addr = device_get_config_hex16("base");
-    /* Do this properly and pass through the CMS */
-    io_sethandler(addr, 0x0010, saaym_read, NULL, NULL, saaym_write, NULL, NULL, saaym);
+    io_sethandler(addr, 0x0008, cms_read, NULL, NULL, cms_write, NULL, NULL, &saaym->cms);
+    io_sethandler(addr + 0x08, 0x02, saaym_read, NULL, NULL, saaym_write, NULL, NULL, saaym);
+    io_sethandler(addr + 0x0a, 0x02, cms_read, NULL, NULL, cms_write, NULL, NULL, &saaym->cms);
+    io_sethandler(addr + 0x0c, 0x04, saaym_read, NULL, NULL, saaym_write, NULL, NULL, saaym);
     sound_add_handler(cms_get_buffer, &saaym->cms);
 
     /* OPM init */

--- a/src/sound/snd_saaym.c
+++ b/src/sound/snd_saaym.c
@@ -9,6 +9,7 @@
  *          Texelec Saaym Emulation.
  *
  * Authors: Jasmine Iwanek, <jriwanek@gmail.com>
+ *          win2kgamer
  *
  *          Copyright 2024-2026 Jasmine Iwanek.
  *          Copyright 2026 win2kgamer
@@ -86,8 +87,7 @@ saaym_read(uint16_t addr, void *priv)
             ret = saaym->latched_data;
             break;
         case 0xe: /* YM2151 Register Select Port */
-            /* TODO: Can the YM2151 be read? */
-            ret = saaym->opm.read(addr + 2, saaym->opm.priv);
+            ret = saaym->opm.read(addr + 1, saaym->opm.priv);
             break;
 
         default:

--- a/src/sound/snd_saaym.c
+++ b/src/sound/snd_saaym.c
@@ -6,7 +6,7 @@
  *
  *          This file is part of the 86Box distribution.
  *
- *          Texelec Saaym Emulation.
+ *          TexElec Saaym Emulation.
  *
  * Authors: Jasmine Iwanek, <jriwanek@gmail.com>
  *          win2kgamer
@@ -28,8 +28,6 @@
 #include <86box/snd_saaym.h>
 #include <86box/sound.h>
 #include <86box/plat_unused.h>
-
-#define ENABLE_SAAYM_LOG 1
 
 #ifdef ENABLE_SAAYM_LOG
 int saaym_do_log = ENABLE_SAAYM_LOG;
@@ -54,11 +52,11 @@ saaym_write(uint16_t addr, uint8_t val, void *priv)
     saaym_t *saaym = (saaym_t *) priv;
 
     switch (addr & 0xf) {
-        case 0xe: /* SAAYM Register Select Port */
+        case 0xe: /* YM2151 Register Select Port */
             saaym->opm.write(addr, val, saaym->opm.priv);
             break;
 
-        case 0xf: /* SAAYM Data Port */
+        case 0xf: /* YM2151 Data Port */
             saaym->opm.write(addr, val, saaym->opm.priv);
             break;
 
@@ -85,7 +83,7 @@ saaym_read(uint16_t addr, void *priv)
         case 0xd: /* SAAYM Read Port */
             ret = saaym->latched_data;
             break;
-        case 0xe: /* YM2151 Register Select Port */
+        case 0xe: /* YM2151 Status Port */
             ret = saaym->opm.read(addr + 1, saaym->opm.priv);
             break;
 
@@ -108,8 +106,8 @@ saaym_get_music_buffer(int32_t *buffer, int len, void *priv)
         double out_l = 0.0;
         double out_r = 0.0;
 
-        out_l = ((double) opm_buf[c]) * 1;
-        out_r = ((double) opm_buf[c + 1]) * 1;
+        out_l = ((double) opm_buf[c]);
+        out_r = ((double) opm_buf[c + 1]);
 
         buffer[c] += (int32_t) out_l;
         buffer[c + 1] += (int32_t) out_r;
@@ -207,7 +205,7 @@ static const device_config_t saaym_config[] = {
 };
 
 const device_t saaym_device = {
-    .name          = "Texelec SAAYM",
+    .name          = "TexElec SAAYM",
     .internal_name = "saaym",
     .flags         = DEVICE_ISA,
     .local         = 0,

--- a/src/sound/snd_saaym.c
+++ b/src/sound/snd_saaym.c
@@ -1,0 +1,222 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          Texelec Saaym Emulation.
+ *
+ * Authors: Jasmine Iwanek, <jriwanek@gmail.com>
+ *
+ *          Copyright 2024-2026 Jasmine Iwanek.
+ *          Copyright 2026 win2kgamer
+ */
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+#define HAVE_STDARG_H
+#include <86box/86box.h>
+#include <86box/device.h>
+#include <86box/io.h>
+#include <86box/snd_cms.h>
+#include <86box/snd_saaym.h>
+#include <86box/sound.h>
+#include <86box/plat_unused.h>
+
+#define ENABLE_SAAYM_LOG 1
+
+#ifdef ENABLE_SAAYM_LOG
+int saaym_do_log = ENABLE_SAAYM_LOG;
+
+static void
+saaym_log(void *priv, const char *fmt, ...)
+{
+    if (saaym_do_log) {
+        va_list ap;
+        va_start(ap, fmt);
+        log_out(priv, fmt, ap);
+        va_end(ap);
+    }
+}
+#else
+#    define saaym_log(fmt, ...)
+#endif
+
+void
+saaym_write(uint16_t addr, uint8_t val, void *priv)
+{
+    saaym_t *saaym = (saaym_t *) priv;
+
+    switch (addr & 0xf) {
+        case 0xe: /* SAAYM Register Select Port */
+            saaym->opm.write(addr, val, saaym->opm.priv);
+            break;
+
+        case 0xf: /* SAAYM Data Port */
+            saaym->opm.write(addr, val, saaym->opm.priv);
+            break;
+
+        case 0x8: /* SAAYM Write Port */
+        case 0x9: /* SAAYM Write Port */
+            saaym->latched_data = val;
+            break;
+
+        default:
+            cms_write(addr, val, &saaym->cms);
+            break;
+    }
+
+    saaym_log(saaym->log, "SAAYM write: port = %04X, val = %02X\n", addr, val);
+}
+
+uint8_t
+saaym_read(uint16_t addr, void *priv)
+{
+    const saaym_t *saaym = (saaym_t *) priv;
+    uint8_t ret = 0xff;
+
+    switch (addr & 0xf) {
+        case 0xc: /* SAAYM Read Port */
+        case 0xd: /* SAAYM Read Port */
+            ret = saaym->latched_data;
+            break;
+        case 0xe: /* YM2151 Register Select Port */
+            /* TODO: Can the YM2151 be read? */
+            ret = saaym->opm.read(addr + 2, saaym->opm.priv);
+            break;
+
+        default:
+            ret = cms_read(addr, (void *) &saaym->cms);
+            break;
+    }
+    saaym_log(saaym->log, "SAAYM read: port = %04X, ret = %02X\n", addr, ret);
+    return ret;
+}
+
+static void
+saaym_get_music_buffer(int32_t *buffer, int len, void *priv)
+{
+    const saaym_t *saaym   = (const saaym_t *) priv;
+    const int32_t *opm_buf = NULL;
+
+    opm_buf = saaym->opm.update(saaym->opm.priv);
+
+    for (int c = 0; c < len * 2; c += 2) {
+        double out_l = 0.0;
+        double out_r = 0.0;
+
+        out_l = ((double) opm_buf[c]) * 1;
+        out_r = ((double) opm_buf[c + 1]) * 1;
+
+        buffer[c] += (int32_t) out_l;
+        buffer[c + 1] += (int32_t) out_r;
+    }
+
+    saaym->opm.reset_buffer(saaym->opm.priv);
+}
+
+void *
+saaym_init(UNUSED(const device_t *info))
+{
+    saaym_t *saaym = malloc(sizeof(saaym_t));
+    memset(saaym, 0, sizeof(saaym_t));
+
+    memset(&saaym->cms, 0, sizeof(cms_t));
+
+    saaym->log = log_open("SAAYM");
+
+    uint16_t addr = device_get_config_hex16("base");
+    /* Do this properly and pass through the CMS */
+    io_sethandler(addr, 0x0010, saaym_read, NULL, NULL, saaym_write, NULL, NULL, saaym);
+    sound_add_handler(cms_get_buffer, &saaym->cms);
+
+    /* OPM init */
+    fm_driver_get(FM_YM2151, &saaym->opm);
+    music_add_handler(saaym_get_music_buffer, saaym);
+
+    return saaym;
+}
+
+void
+saaym_close(void *priv)
+{
+    saaym_t *saaym = (saaym_t *) priv;
+
+    if (saaym->log != NULL) {
+        log_close(saaym->log);
+        saaym->log = NULL;
+    }
+
+    free(saaym);
+}
+
+static const device_config_t saaym_config[] = {
+  // clang-format off
+    {
+        .name = "base",
+        .description = "Address",
+        .type = CONFIG_HEX16,
+        .default_string = "",
+        .default_int = 0x220,
+        .file_filter = "",
+        .spinner = { 0 },
+        .selection = {
+            {
+                .description = "0x200",
+                .value = 0x200
+            },
+            {
+                .description = "0x210",
+                .value = 0x210
+            },
+            {
+                .description = "0x220",
+                .value = 0x220
+            },
+            {
+                .description = "0x230",
+                .value = 0x230
+            },
+            {
+                .description = "0x240",
+                .value = 0x240
+            },
+            {
+                .description = "0x250",
+                .value = 0x250
+            },
+            {
+                .description = "0x260",
+                .value = 0x260
+            },
+            {
+                .description = "0x270",
+                .value = 0x270
+            },
+            {
+                .description = ""
+            }
+        }
+    },
+    { .name = "", .description = "", .type = CONFIG_END }
+  // clang-format on
+};
+
+const device_t saaym_device = {
+    .name          = "Texelec SAAYM",
+    .internal_name = "saaym",
+    .flags         = DEVICE_ISA,
+    .local         = 0,
+    .init          = saaym_init,
+    .close         = saaym_close,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = saaym_config
+};

--- a/src/sound/sound.c
+++ b/src/sound/sound.c
@@ -131,6 +131,7 @@ static const SOUND_CARD sound_cards[] = {
     { &sb_pro_v2_device             },
     { &entertainer_device           },
     { &pssj_isa_device              },
+    { &saaym_device                 },
     { &tndy_device                  },
     /* ISA/Sidecar */
     { &adlib_device                 },


### PR DESCRIPTION
Summary
=======
Add the TexElec SAAYM sound card. This is a modern clone of the Creative Music System/Game Blaster that adds a YM2151/OPM FM synth.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
TexElec SAAYM manual: https://texelec.com/wp-content/uploads/2019/12/TexElec-SAAYM-Manual.pdf