### PR TITLE
YMF-7xx SBPro fixes

### DIFF
--- a/src/sound/snd_sb_dsp.c
+++ b/src/sound/snd_sb_dsp.c
@@ -519,7 +519,10 @@ sb_dsp_reset(sb_dsp_t *dsp)
     dsp->sb_command = 0;
 
     dsp->sb_8_length  = 0xffff;
-    dsp->sb_8_autolen = 0x7fff;
+    if (dsp->sb_subtype == SB_SUBTYPE_YMF7XX)
+        dsp->sb_8_autolen = 0x3fff;
+    else
+        dsp->sb_8_autolen = 0x7fff;
 
     dsp->sb_irq8     = 0;
     dsp->sb_irq16    = 0;

--- a/src/sound/snd_ymf71x.c
+++ b/src/sound/snd_ymf71x.c
@@ -689,7 +689,8 @@ ymf71x_init(const device_t *info)
     ymf71x->regs[0x00] = 0xFF;
     ymf71x->regs[0x01] = 0x00;
     ymf71x->regs[0x02] = 0x00;
-    ymf71x->regs[0x03] = 0x69; /* IRQ-A = WSS + OPL3, IRQ-B = SB+MPU401 */
+    ymf71x->regs[0x03] = 0x0f; /* Datasheet specifies 0x69 as default power-on value but this is what the Win9x drivers expect */
+                               /* and the AN430TX BIOS sets this value after writing the PnP resource data */
     ymf71x->regs[0x04] = 0x00;
     ymf71x->regs[0x05] = 0x00;
     ymf71x->regs[0x06] = 0x61; /* DMA-A = WSS Playback, DMA-B = WSS Capture + SBPro */


### PR DESCRIPTION
Summary
=======
Fix two issues with the SBPro side of the Yamaha YMF-7xx cards:
- Lower the default auto-init DMA length, fixes an "SB Check failed" message in SETUPSA after rebooting into MS-DOS mode from Win9x
- Change the power-on default value of the Interrupt Channel Configuration register on YMF-71x cards to put all devices on IRQ-A, fixes multiple sound issues in Duke Nukem 3D and Ultimate Doom under Windows 9x. The datasheet specifies a default value that puts the SBPro and MPU-401 onto a second IRQ but neither standalone card nor the AN430TX PnP resource data supports a second IRQ.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
