### PR TITLE
Fix AIX 1.3 PTF0024 on Adaptec AHA-154xC SCSI adapters

### DIFF
--- a/src/scsi/scsi_x54x.c
+++ b/src/scsi/scsi_x54x.c
@@ -1352,9 +1352,9 @@ x54x_in(uint16_t port, void *priv)
                             ret = 'P';
                             break;
                     }
-                    ret ^= 1;
                     dev->Geometry++;
                     dev->Geometry &= 0x03;
+                    dev->Status = STAT_IDLE | STAT_INIT;
                 } else
                     ret = 0xff;
                 break;


### PR DESCRIPTION
Summary
=======
AIX 1.3 PTF0024 update adds support for Adaptec SCSI adapter on the ISA bus, but doesn't work with emulated Adaptec AHA-154xC SCSI adapters in 86Box. This PR fixes ADAP signature and status flag reporting on Adaptec AHA-154xC adapters based on findings by rakslice and is verified with AIX 1.3 PTF0024 update installation.

Checklist
=========
* [x] Closes #4938 
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
Findings of AHA-154xC with AIX 1.3 PTF0024 by rakslice: https://github.com/86Box/86Box/discussions/4938#discussioncomment-11137370
