### PR TITLE
Settings dialog, network page: Rename tabs from "Network Card #n" to "Adapter n"

### DIFF
--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -1785,16 +1785,16 @@ msgstr ""
 msgid "GiB"
 msgstr ""
 
-msgid "Network Card #1"
+msgid "Adapter 1"
 msgstr ""
 
-msgid "Network Card #2"
+msgid "Adapter 2"
 msgstr ""
 
-msgid "Network Card #3"
+msgid "Adapter 3"
 msgstr ""
 
-msgid "Network Card #4"
+msgid "Adapter 4"
 msgstr ""
 
 msgid "Mode:"

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -1785,17 +1785,17 @@ msgstr "MiB"
 msgid "GiB"
 msgstr "GiB"
 
-msgid "Network Card #1"
-msgstr "Targeta de xarxa 1"
+msgid "Adapter 1"
+msgstr "Adaptador 1"
 
-msgid "Network Card #2"
-msgstr "Targeta de xarxa 2"
+msgid "Adapter 2"
+msgstr "Adaptador 2"
 
-msgid "Network Card #3"
-msgstr "Targeta de xarxa 3"
+msgid "Adapter 3"
+msgstr "Adaptador 3"
 
-msgid "Network Card #4"
-msgstr "Targeta de xarxa 4"
+msgid "Adapter 4"
+msgstr "Adaptador 4"
 
 msgid "Mode:"
 msgstr "Modalitat:"

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -1788,17 +1788,17 @@ msgstr "MiB"
 msgid "GiB"
 msgstr "GiB"
 
-msgid "Network Card #1"
-msgstr "Síťový adaptér 1"
+msgid "Adapter 1"
+msgstr "Adaptér 1"
 
-msgid "Network Card #2"
-msgstr "Síťový adaptér 2"
+msgid "Adapter 2"
+msgstr "Adaptér 2"
 
-msgid "Network Card #3"
-msgstr "Síťový adaptér 3"
+msgid "Adapter 3"
+msgstr "Adaptér 3"
 
-msgid "Network Card #4"
-msgstr "Síťový adaptér 4"
+msgid "Adapter 4"
+msgstr "Adaptér 4"
 
 msgid "Mode:"
 msgstr "Režim:"

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -1785,17 +1785,17 @@ msgstr "MiB"
 msgid "GiB"
 msgstr "GiB"
 
-msgid "Network Card #1"
-msgstr "Netzwerkkarte 1"
+msgid "Adapter 1"
+msgstr "Adapter 1"
 
-msgid "Network Card #2"
-msgstr "Netzwerkkarte 2"
+msgid "Adapter 2"
+msgstr "Adapter 2"
 
-msgid "Network Card #3"
-msgstr "Netzwerkkarte 3"
+msgid "Adapter 3"
+msgstr "Adapter 3"
 
-msgid "Network Card #4"
-msgstr "Netzwerkkarte 4"
+msgid "Adapter 4"
+msgstr "Adapter 4"
 
 msgid "Mode:"
 msgstr "Modus:"

--- a/src/qt/languages/el-GR.po
+++ b/src/qt/languages/el-GR.po
@@ -1822,17 +1822,17 @@ msgstr "MiB"
 msgid "GiB"
 msgstr "GiB"
 
-msgid "Network Card #1"
-msgstr "Κάρτα δικτύου #1"
+msgid "Adapter 1"
+msgstr "Προσαρμογέας 1"
 
-msgid "Network Card #2"
-msgstr "Κάρτα δικτύου #2"
+msgid "Adapter 2"
+msgstr "Προσαρμογέας 2"
 
-msgid "Network Card #3"
-msgstr "Κάρτα δικτύου #3"
+msgid "Adapter 3"
+msgstr "Προσαρμογέας 3"
 
-msgid "Network Card #4"
-msgstr "Κάρτα δικτύου #4"
+msgid "Adapter 4"
+msgstr "Προσαρμογέας 4"
 
 msgid "Mode:"
 msgstr "Λειτουργία:"

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -1785,17 +1785,17 @@ msgstr "MiB"
 msgid "GiB"
 msgstr "GiB"
 
-msgid "Network Card #1"
-msgstr "Tarjeta de red 1"
+msgid "Adapter 1"
+msgstr "Adaptador 1"
 
-msgid "Network Card #2"
-msgstr "Tarjeta de red 2"
+msgid "Adapter 2"
+msgstr "Adaptador 2"
 
-msgid "Network Card #3"
-msgstr "Tarjeta de red 3"
+msgid "Adapter 3"
+msgstr "Adaptador 3"
 
-msgid "Network Card #4"
-msgstr "Tarjeta de red 4"
+msgid "Adapter 4"
+msgstr "Adaptador 4"
 
 msgid "Mode:"
 msgstr "Modalidad:"

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -1786,17 +1786,17 @@ msgstr ""
 msgid "GiB"
 msgstr ""
 
-msgid "Network Card #1"
-msgstr "Verkkokortti 1"
+msgid "Adapter 1"
+msgstr "Sovitin 1"
 
-msgid "Network Card #2"
-msgstr "Verkkokortti 2"
+msgid "Adapter 2"
+msgstr "Sovitin 2"
 
-msgid "Network Card #3"
-msgstr "Verkkokortti 3"
+msgid "Adapter 3"
+msgstr "Sovitin 3"
 
-msgid "Network Card #4"
-msgstr "Verkkokortti 4"
+msgid "Adapter 4"
+msgstr "Sovitin 4"
 
 msgid "Mode:"
 msgstr "Tila:"

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -1785,17 +1785,17 @@ msgstr "Mio"
 msgid "GiB"
 msgstr "Gio"
 
-msgid "Network Card #1"
-msgstr "Carte réseau 1"
+msgid "Adapter 1"
+msgstr "Adaptateur 1"
 
-msgid "Network Card #2"
-msgstr "Carte réseau 2"
+msgid "Adapter 2"
+msgstr "Adaptateur 2"
 
-msgid "Network Card #3"
-msgstr "Carte réseau 3"
+msgid "Adapter 3"
+msgstr "Adaptateur 3"
 
-msgid "Network Card #4"
-msgstr "Carte réseau 4"
+msgid "Adapter 4"
+msgstr "Adaptateur 4"
 
 msgid "Mode:"
 msgstr "Mode :"

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -1788,17 +1788,17 @@ msgstr "MiB"
 msgid "GiB"
 msgstr "GiB"
 
-msgid "Network Card #1"
-msgstr "Mrežna kartica 1"
+msgid "Adapter 1"
+msgstr "Adapter 1"
 
-msgid "Network Card #2"
-msgstr "Mrežna kartica 2"
+msgid "Adapter 2"
+msgstr "Adapter 2"
 
-msgid "Network Card #3"
-msgstr "Mrežna kartica 3"
+msgid "Adapter 3"
+msgstr "Adapter 3"
 
-msgid "Network Card #4"
-msgstr "Mrežna kartica 4"
+msgid "Adapter 4"
+msgstr "Adapter 4"
 
 msgid "Mode:"
 msgstr "Način:"

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -1865,17 +1865,17 @@ msgstr "MiB"
 msgid "GiB"
 msgstr "GiB"
 
-msgid "Network Card #1"
-msgstr "Scheda di rete #1"
+msgid "Adapter 1"
+msgstr "Adattatore 1"
 
-msgid "Network Card #2"
-msgstr "Scheda di rete #2"
+msgid "Adapter 2"
+msgstr "Adattatore 2"
 
-msgid "Network Card #3"
-msgstr "Scheda di rete #3"
+msgid "Adapter 3"
+msgstr "Adattatore 3"
 
-msgid "Network Card #4"
-msgstr "Scheda di rete #4"
+msgid "Adapter 4"
+msgstr "Adattatore 4"
 
 msgid "Mode:"
 msgstr "Modalità:"

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -1786,17 +1786,17 @@ msgstr "MiB"
 msgid "GiB"
 msgstr "GiB"
 
-msgid "Network Card #1"
-msgstr "ネットワークカード 1"
+msgid "Adapter 1"
+msgstr "アダプター 1"
 
-msgid "Network Card #2"
-msgstr "ネットワークカード 2"
+msgid "Adapter 2"
+msgstr "アダプター 2"
 
-msgid "Network Card #3"
-msgstr "ネットワークカード 3"
+msgid "Adapter 3"
+msgstr "アダプター 3"
 
-msgid "Network Card #4"
-msgstr "ネットワークカード 4"
+msgid "Adapter 4"
+msgstr "アダプター 4"
 
 msgid "Mode:"
 msgstr "モード:"

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -1786,17 +1786,17 @@ msgstr "MiB"
 msgid "GiB"
 msgstr "GiB"
 
-msgid "Network Card #1"
-msgstr "네트워크 카드 1"
+msgid "Adapter 1"
+msgstr "어댑터 1"
 
-msgid "Network Card #2"
-msgstr "네트워크 카드 2"
+msgid "Adapter 2"
+msgstr "어댑터 2"
 
-msgid "Network Card #3"
-msgstr "네트워크 카드 3"
+msgid "Adapter 3"
+msgstr "어댑터 3"
 
-msgid "Network Card #4"
-msgstr "네트워크 카드 4"
+msgid "Adapter 4"
+msgstr "어댑터 4"
 
 msgid "Mode:"
 msgstr "모드:"

--- a/src/qt/languages/nb-NO.po
+++ b/src/qt/languages/nb-NO.po
@@ -1786,17 +1786,17 @@ msgstr "MiB"
 msgid "GiB"
 msgstr "GiB"
 
-msgid "Network Card #1"
-msgstr "Nettverkskort #1"
+msgid "Adapter 1"
+msgstr "Adapter 1"
 
-msgid "Network Card #2"
-msgstr "Nettverkskort #2"
+msgid "Adapter 2"
+msgstr "Adapter 2"
 
-msgid "Network Card #3"
-msgstr "Nettverkskort #3"
+msgid "Adapter 3"
+msgstr "Adapter 3"
 
-msgid "Network Card #4"
-msgstr "Nettverkskort #4"
+msgid "Adapter 4"
+msgstr "Adapter 4"
 
 msgid "Mode:"
 msgstr "Modus:"

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -1785,17 +1785,17 @@ msgstr "MiB"
 msgid "GiB"
 msgstr "GiB"
 
-msgid "Network Card #1"
-msgstr "Netwerkkaart #1"
+msgid "Adapter 1"
+msgstr "Adapter 1"
 
-msgid "Network Card #2"
-msgstr "Netwerkkaart #2"
+msgid "Adapter 2"
+msgstr "Adapter 2"
 
-msgid "Network Card #3"
-msgstr "Netwerkkaart #3"
+msgid "Adapter 3"
+msgstr "Adapter 3"
 
-msgid "Network Card #4"
-msgstr "Netwerkkaart #4"
+msgid "Adapter 4"
+msgstr "Adapter 4"
 
 msgid "Mode:"
 msgstr "Modus:"

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -1786,17 +1786,17 @@ msgstr "MiB"
 msgid "GiB"
 msgstr "GiB"
 
-msgid "Network Card #1"
-msgstr "Karta sieciowa nr 1"
+msgid "Adapter 1"
+msgstr "Adapter 1"
 
-msgid "Network Card #2"
-msgstr "Karta sieciowa nr 2"
+msgid "Adapter 2"
+msgstr "Adapter 2"
 
-msgid "Network Card #3"
-msgstr "Karta sieciowa nr 3"
+msgid "Adapter 3"
+msgstr "Adapter 3"
 
-msgid "Network Card #4"
-msgstr "Karta sieciowa nr 4"
+msgid "Adapter 4"
+msgstr "Adapter 4"
 
 msgid "Mode:"
 msgstr "Tryb:"

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -1786,17 +1786,17 @@ msgstr "MiB"
 msgid "GiB"
 msgstr "GiB"
 
-msgid "Network Card #1"
-msgstr "Placa de rede nº 1"
+msgid "Adapter 1"
+msgstr "Adaptador 1"
 
-msgid "Network Card #2"
-msgstr "Placa de rede nº 2"
+msgid "Adapter 2"
+msgstr "Adaptador 2"
 
-msgid "Network Card #3"
-msgstr "Placa de rede nº 3"
+msgid "Adapter 3"
+msgstr "Adaptador 3"
 
-msgid "Network Card #4"
-msgstr "Placa de rede nº 4"
+msgid "Adapter 4"
+msgstr "Adaptador 4"
 
 msgid "Mode:"
 msgstr "Modo:"

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -1786,17 +1786,17 @@ msgstr "MiB"
 msgid "GiB"
 msgstr "GiB"
 
-msgid "Network Card #1"
-msgstr "Placa de rede 1"
+msgid "Adapter 1"
+msgstr "Adaptador 1"
 
-msgid "Network Card #2"
-msgstr "Placa de rede 2"
+msgid "Adapter 2"
+msgstr "Adaptador 2"
 
-msgid "Network Card #3"
-msgstr "Placa de rede 3"
+msgid "Adapter 3"
+msgstr "Adaptador 3"
 
-msgid "Network Card #4"
-msgstr "Placa de rede 4"
+msgid "Adapter 4"
+msgstr "Adaptador 4"
 
 msgid "Mode:"
 msgstr "Modo:"

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -1798,17 +1798,17 @@ msgstr "МиБ"
 msgid "GiB"
 msgstr "ГиБ"
 
-msgid "Network Card #1"
-msgstr "Сетевая карта № 1"
+msgid "Adapter 1"
+msgstr "Адаптер 1"
 
-msgid "Network Card #2"
-msgstr "Сетевая карта № 2"
+msgid "Adapter 2"
+msgstr "Адаптер 2"
 
-msgid "Network Card #3"
-msgstr "Сетевая карта № 3"
+msgid "Adapter 3"
+msgstr "Адаптер 3"
 
-msgid "Network Card #4"
-msgstr "Сетевая карта № 4"
+msgid "Adapter 4"
+msgstr "Адаптер 4"
 
 msgid "Mode:"
 msgstr "Режим:"

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -1786,17 +1786,17 @@ msgstr "MiB"
 msgid "GiB"
 msgstr "GiB"
 
-msgid "Network Card #1"
-msgstr "Sieťová karta 1"
+msgid "Adapter 1"
+msgstr "Adaptér 1"
 
-msgid "Network Card #2"
-msgstr "Sieťová karta 2"
+msgid "Adapter 2"
+msgstr "Adaptér 2"
 
-msgid "Network Card #3"
-msgstr "Sieťová karta 3"
+msgid "Adapter 3"
+msgstr "Adaptér 3"
 
-msgid "Network Card #4"
-msgstr "Sieťová karta 4"
+msgid "Adapter 4"
+msgstr "Adaptér 4"
 
 msgid "Mode:"
 msgstr "Režim:"

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -1787,17 +1787,17 @@ msgstr "MiB"
 msgid "GiB"
 msgstr "GiB"
 
-msgid "Network Card #1"
-msgstr "Omrežna kartica 1"
+msgid "Adapter 1"
+msgstr "Mrežna kartica 1"
 
-msgid "Network Card #2"
-msgstr "Omrežna kartica 2"
+msgid "Adapter 2"
+msgstr "Mrežna kartica 2"
 
-msgid "Network Card #3"
-msgstr "Omrežna kartica 3"
+msgid "Adapter 3"
+msgstr "Mrežna kartica 3"
 
-msgid "Network Card #4"
-msgstr "Omrežna kartica 4"
+msgid "Adapter 4"
+msgstr "Mrežna kartica 4"
 
 msgid "Mode:"
 msgstr "Način:"

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -1786,17 +1786,17 @@ msgstr "MiB"
 msgid "GiB"
 msgstr "GiB"
 
-msgid "Network Card #1"
-msgstr "Nätverkskort #1"
+msgid "Adapter 1"
+msgstr "Adapter 1"
 
-msgid "Network Card #2"
-msgstr "Nätverkskort #2"
+msgid "Adapter 2"
+msgstr "Adapter 2"
 
-msgid "Network Card #3"
-msgstr "Nätverkskort #3"
+msgid "Adapter 3"
+msgstr "Adapter 3"
 
-msgid "Network Card #4"
-msgstr "Nätverkskort #4"
+msgid "Adapter 4"
+msgstr "Adapter 4"
 
 msgid "Mode:"
 msgstr "Läge:"

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -1831,17 +1831,17 @@ msgstr "MiB"
 msgid "GiB"
 msgstr "GiB"
 
-msgid "Network Card #1"
-msgstr "1. Ağ Kartı"
+msgid "Adapter 1"
+msgstr "Adaptör 1"
 
-msgid "Network Card #2"
-msgstr "2. Ağ Kartı"
+msgid "Adapter 2"
+msgstr "Adaptör 2"
 
-msgid "Network Card #3"
-msgstr "3. Ağ Kartı"
+msgid "Adapter 3"
+msgstr "Adaptör 3"
 
-msgid "Network Card #4"
-msgstr "4. Ağ Kartı"
+msgid "Adapter 4"
+msgstr "Adaptör 4"
 
 msgid "Mode:"
 msgstr "Mod:"

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -1787,17 +1787,17 @@ msgstr "МіБ"
 msgid "GiB"
 msgstr "GiB"
 
-msgid "Network Card #1"
-msgstr "Мережева карта 1"
+msgid "Adapter 1"
+msgstr "Адаптер 1"
 
-msgid "Network Card #2"
-msgstr "Мережева карта 2"
+msgid "Adapter 2"
+msgstr "Адаптер 2"
 
-msgid "Network Card #3"
-msgstr "Мережева карта 3"
+msgid "Adapter 3"
+msgstr "Адаптер 3"
 
-msgid "Network Card #4"
-msgstr "Мережева карта 4"
+msgid "Adapter 4"
+msgstr "Адаптер 4"
 
 msgid "Mode:"
 msgstr "Режим:"

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -1786,17 +1786,17 @@ msgstr "MiB"
 msgid "GiB"
 msgstr "GiB"
 
-msgid "Network Card #1"
-msgstr "Thẻ mạng 1"
+msgid "Adapter 1"
+msgstr "Bộ chuyển đổi 1"
 
-msgid "Network Card #2"
-msgstr "Thẻ mạng 2"
+msgid "Adapter 2"
+msgstr "Bộ chuyển đổi 2"
 
-msgid "Network Card #3"
-msgstr "Thẻ mạng 3"
+msgid "Adapter 3"
+msgstr "Bộ chuyển đổi 3"
 
-msgid "Network Card #4"
-msgstr "Thẻ mạng 4"
+msgid "Adapter 4"
+msgstr "Bộ chuyển đổi 4"
 
 msgid "Mode:"
 msgstr "Chế độ:"

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -1786,17 +1786,17 @@ msgstr "兆字节"
 msgid "GiB"
 msgstr "吉字节"
 
-msgid "Network Card #1"
-msgstr "网卡 1"
+msgid "Adapter 1"
+msgstr "适配器 1"
 
-msgid "Network Card #2"
-msgstr "网卡 2"
+msgid "Adapter 2"
+msgstr "适配器 2"
 
-msgid "Network Card #3"
-msgstr "网卡 3"
+msgid "Adapter 3"
+msgstr "适配器 3"
 
-msgid "Network Card #4"
-msgstr "网卡 4"
+msgid "Adapter 4"
+msgstr "适配器 4"
 
 msgid "Mode:"
 msgstr "模式:"

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -1786,17 +1786,17 @@ msgstr "MiB"
 msgid "GiB"
 msgstr "GiB"
 
-msgid "Network Card #1"
-msgstr "網路卡 1"
+msgid "Adapter 1"
+msgstr "配接器 1"
 
-msgid "Network Card #2"
-msgstr "網路卡 2"
+msgid "Adapter 2"
+msgstr "配接器 2"
 
-msgid "Network Card #3"
-msgstr "網路卡 3"
+msgid "Adapter 3"
+msgstr "配接器 3"
 
-msgid "Network Card #4"
-msgstr "網路卡 4"
+msgid "Adapter 4"
+msgstr "配接器 4"
 
 msgid "Mode:"
 msgstr "模式:"

--- a/src/qt/qt_settingsnetwork.ui
+++ b/src/qt/qt_settingsnetwork.ui
@@ -38,7 +38,7 @@
         <normaloff>:/settings/qt/icons/network.ico</normaloff>:/settings/qt/icons/network.ico</iconset>
       </attribute>
       <attribute name="title">
-       <string>Network Card #1</string>
+       <string>Adapter 1</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayoutNet1">
        <item row="0" column="0">
@@ -241,7 +241,7 @@
         <normaloff>:/settings/qt/icons/network.ico</normaloff>:/settings/qt/icons/network.ico</iconset>
       </attribute>
       <attribute name="title">
-       <string>Network Card #2</string>
+       <string>Adapter 2</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayoutNet2">
        <item row="0" column="0">
@@ -444,7 +444,7 @@
         <normaloff>:/settings/qt/icons/network.ico</normaloff>:/settings/qt/icons/network.ico</iconset>
       </attribute>
       <attribute name="title">
-       <string>Network Card #3</string>
+       <string>Adapter 3</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayoutNet3">
        <item row="0" column="0">
@@ -647,7 +647,7 @@
         <normaloff>:/settings/qt/icons/network.ico</normaloff>:/settings/qt/icons/network.ico</iconset>
       </attribute>
       <attribute name="title">
-       <string>Network Card #4</string>
+       <string>Adapter 4</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayoutNet4">
        <item row="0" column="0">


### PR DESCRIPTION
Summary
=======
Renames the tabs on the network page of the Settings dialog to make tabs fit better and accommodate PLIP and modem.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set

References
==========
N/A