### PR TITLE
Add the onboard sound and hardware monitor of the Micronics Thunderbolt

### DIFF
--- a/src/machine/m_at_socket7.c
+++ b/src/machine/m_at_socket7.c
@@ -1544,6 +1544,9 @@ machine_at_thunderbolt_init(const machine_t *model)
     device_add(&intel_flash_bxt_device);
     spd_register(SPD_TYPE_SDRAM, 0x3, 128);
 
+    if (sound_card_current[0] == SOUND_INTERNAL)
+        machine_snd = device_add(machine_get_snd_device(machine));
+
     return ret;
 }
 

--- a/src/machine/m_at_socket7.c
+++ b/src/machine/m_at_socket7.c
@@ -1542,6 +1542,7 @@ machine_at_thunderbolt_init(const machine_t *model)
     device_add(&piix4_device);
     device_add_params(&fdc37c93x_device, (void *) (FDC37XXX5 | FDC37C93X_NORMAL | FDC37C93X_NO_NVR));
     device_add(&intel_flash_bxt_device);
+    device_add(&lm78_device); /* no reporting in BIOS */    
     spd_register(SPD_TYPE_SDRAM, 0x3, 128);
 
     if (sound_card_current[0] == SOUND_INTERNAL)

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -18105,8 +18105,7 @@ const machine_t machines[] = {
         .aliases                  = { "Intel Yamamoto", "" }
     },
     /*
-       PhoenixBIOS 4.0 Rel 6.0 for 430TX, has onboard Yamaha YMF701 which
-       is not emulated yet.
+       PhoenixBIOS 4.0 Rel 6.0 for 430TX.
 
        Has a SM(S)C FDC37C935 Super I/O chip with on-chip KBC with Phoenix
        MultiKey/42 (version 1.38) KBC firmware.
@@ -18132,8 +18131,7 @@ const machine_t machines[] = {
             .max_multi   = 3.5
         },
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
-        /* Machine has internal sound: Yamaha YMF701-S */
-        .flags     = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_GAMEPORT | MACHINE_USB,
+        .flags     = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_SOUND | MACHINE_GAMEPORT | MACHINE_USB,
         .ram       = {
             .min  = 8192,
             .max  = 262144,
@@ -18155,7 +18153,7 @@ const machine_t machines[] = {
         .kbd_device               = NULL,
         .fdc_device               = NULL,
         .vid_device               = NULL,
-        .snd_device               = NULL,
+        .snd_device               = &ymf701_device,
         .net_device               = NULL,
         .aliases                  = { "" }
     },


### PR DESCRIPTION
Summary
=======
Add the onboard Yamaha YMF-701 sound and LM78 hardware monitor of the Micronics Thunderbolt machine.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
https://theretroweb.com/motherboard/manual/thundblt-5f7b847add7da981504587.pdf
