### PR TITLE
Some rework on the 53c9x-based SCSI controllers: see below.

### DIFF
--- a/src/scsi/scsi_pcscsi.c
+++ b/src/scsi/scsi_pcscsi.c
@@ -112,6 +112,7 @@ enum ESPASCMode {
 #define CMD_SELATNS      0x43
 #define CMD_ENSEL        0x44
 #define CMD_DISSEL       0x45
+#define CMD_SELATN3      0x46
 
 #define STAT_DO          0x00
 #define STAT_DI          0x01
@@ -317,11 +318,9 @@ esp_irq(esp_t *dev, int level)
     if (dev->mca) {
         if (level) {
             picintlevel(1 << dev->irq, &dev->irq_state);
-            dev->dma_86c01.mode |= 0x40;
             esp_log("Raising IRQ...\n");
         } else {
             picintclevel(1 << dev->irq, &dev->irq_state);
-            dev->dma_86c01.mode &= ~0x40;
             esp_log("Lowering IRQ...\n");
         }
     } else {
@@ -350,7 +349,12 @@ esp_raise_irq(esp_t *dev)
 {
     if (!(dev->rregs[ESP_RSTAT] & STAT_INT)) {
         dev->rregs[ESP_RSTAT] |= STAT_INT;
-        esp_irq(dev, 1);
+        if (dev->mca) {
+            dev->dma_86c01.status |= 0x01;
+            if (dev->dma_86c01.mode & 0x40)
+                esp_irq(dev, 1);
+        } else
+            esp_irq(dev, 1);
     }
 }
 
@@ -359,6 +363,9 @@ esp_lower_irq(esp_t *dev)
 {
     if (dev->rregs[ESP_RSTAT] & STAT_INT) {
         dev->rregs[ESP_RSTAT] &= ~STAT_INT;
+        if (dev->mca)
+            dev->dma_86c01.status &= ~0x01;
+
         esp_irq(dev, 0);
     }
 }
@@ -483,6 +490,8 @@ esp_transfer_data(esp_t *dev)
             case (CMD_SEL | CMD_DMA):
             case CMD_SELATN:
             case (CMD_SELATN | CMD_DMA):
+            case CMD_SELATN3:
+            case (CMD_SELATN3 | CMD_DMA):
                 /*
                  * Initial incoming data xfer is complete for sequencer command
                  * so raise deferred bus service and function complete interrupt
@@ -680,7 +689,8 @@ esp_hard_reset(esp_t *dev)
 static int
 esp_cdb_ready(esp_t *dev)
 {
-    int len = fifo8_num_used(&dev->cmdfifo) - dev->cmdfifo_cdb_offset;
+    int limit = dev->cmdfifo_cdb_offset + 1;
+    int len = fifo8_num_used(&dev->cmdfifo);
     const uint8_t *pbuf;
     uint32_t n;
     int cdblen;
@@ -689,7 +699,7 @@ esp_cdb_ready(esp_t *dev)
         return 0;
 
     pbuf = fifo8_peek_bufptr(&dev->cmdfifo, len, &n);
-    if (n < len) {
+    if (n < limit) {
         /*
          * In normal use the cmdfifo should never wrap, but include this check
          * to prevent a malicious guest from reading past the end of the
@@ -718,6 +728,7 @@ esp_do_dma(esp_t *dev)
     scsi_device_t *sd  = &scsi_devices[dev->bus][dev->id];
     uint8_t  buf[ESP_CMDFIFO_SZ];
     uint32_t len;
+    int      msg_bytes = 0;
 
     len = esp_get_tc(dev);
 
@@ -746,13 +757,15 @@ esp_do_dma(esp_t *dev)
 
             switch (dev->rregs[ESP_CMD]) {
                 case (CMD_SELATN | CMD_DMA):
-                    if (fifo8_num_used(&dev->cmdfifo) >= 1) {
+                case (CMD_SELATN3 | CMD_DMA):
+                    msg_bytes = (dev->rregs[ESP_CMD] == (CMD_SELATN3 | CMD_DMA)) ? 3 : 1;
+                    if (fifo8_num_used(&dev->cmdfifo) >= msg_bytes) {
                         /* First byte received, switch to command phase */
                         esp_set_phase(dev, STAT_CD);
                         dev->rregs[ESP_RSEQ] = SEQ_CD;
-                        dev->cmdfifo_cdb_offset = 1;
+                        dev->cmdfifo_cdb_offset = msg_bytes;
 
-                        if (fifo8_num_used(&dev->cmdfifo) > 1) {
+                        if (fifo8_num_used(&dev->cmdfifo) > msg_bytes) {
                             /* Process any additional command phase data */
                             esp_do_dma(dev);
                         }
@@ -1043,26 +1056,29 @@ esp_do_nodma(esp_t *dev)
     scsi_device_t *sd  = &scsi_devices[dev->bus][dev->id];
     uint8_t buf[ESP_FIFO_SZ];
     int len;
+    int msg_bytes;
 
     esp_log("No DMA phase=%x.\n", esp_get_phase(dev));
     switch (esp_get_phase(dev)) {
         case STAT_MO:
             switch (dev->rregs[ESP_CMD]) {
                 case CMD_SELATN:
+                case CMD_SELATN3:
                     /* Copy FIFO into cmdfifo */
+                    msg_bytes = (dev->rregs[ESP_CMD] == CMD_SELATN3) ? 3 : 1;
                     len = esp_fifo_pop_buf(dev, buf, fifo8_num_used(&dev->fifo));
                     len = MIN(fifo8_num_free(&dev->cmdfifo), len);
                     esp_log("ESP Message Out CMD SelAtn len=%d.\n", len);
                     fifo8_push_all(&dev->cmdfifo, buf, len);
 
                     esp_log("ESP Message Out CMD SelAtn FIFO num used=%d.\n", fifo8_num_used(&dev->cmdfifo));
-                    if (fifo8_num_used(&dev->cmdfifo) >= 1) {
+                    if (fifo8_num_used(&dev->cmdfifo) >= msg_bytes) {
                         /* First byte received, switch to command phase */
                         esp_set_phase(dev, STAT_CD);
                         dev->rregs[ESP_RSEQ] = SEQ_CD;
-                        dev->cmdfifo_cdb_offset = 1;
+                        dev->cmdfifo_cdb_offset = msg_bytes;
 
-                        if (fifo8_num_used(&dev->cmdfifo) > 1) {
+                        if (fifo8_num_used(&dev->cmdfifo) > msg_bytes) {
                             /* Process any additional command phase data */
                             esp_do_nodma(dev);
                         }
@@ -1139,6 +1155,7 @@ esp_do_nodma(esp_t *dev)
 
                 case (CMD_SEL | CMD_DMA):
                 case (CMD_SELATN | CMD_DMA):
+                case (CMD_SELATN3 | CMD_DMA):
                     /* Copy FIFO into cmdfifo */
                     len = esp_fifo_pop_buf(dev, buf, fifo8_num_used(&dev->fifo));
                     len = MIN(fifo8_num_free(&dev->cmdfifo), len);
@@ -1153,6 +1170,7 @@ esp_do_nodma(esp_t *dev)
 
                 case CMD_SEL:
                 case CMD_SELATN:
+                case CMD_SELATN3:
                     /* FIFO already contain entire CDB: copy to cmdfifo and execute */
                     len = esp_fifo_pop_buf(dev, buf, fifo8_num_used(&dev->fifo));
                     len = MIN(fifo8_num_free(&dev->cmdfifo), len);
@@ -1248,6 +1266,8 @@ esp_command_complete(void *priv, uint32_t status)
         case (CMD_SEL | CMD_DMA):
         case CMD_SELATN:
         case (CMD_SELATN | CMD_DMA):
+        case CMD_SELATN3:
+        case (CMD_SELATN3 | CMD_DMA):
             /*
              * Switch to status phase. For non-DMA transfers from the target the last
              * byte is still in the FIFO
@@ -1502,7 +1522,6 @@ esp_reg_write(esp_t *dev, uint32_t saddr, uint32_t val)
                 esp_raise_irq(dev);
                 break;
             }
-
             if (val & CMD_DMA) {
                 dev->dma = 1;
                 /* Reload DMA counter.  */
@@ -1565,6 +1584,7 @@ esp_reg_write(esp_t *dev, uint32_t saddr, uint32_t val)
                     handle_s_without_atn(dev);
                     break;
                 case CMD_SELATN:
+                case CMD_SELATN3:
                     handle_satn(dev);
                     break;
                 case CMD_SELATNS:
@@ -2007,9 +2027,10 @@ esp_pci_read(UNUSED(int func), int addr, int len, void *priv)
     switch (addr) {
         case 0x00:
             // esp_log("ESP PCI: Read DO line = %02x\n", dev->eeprom.out);
-            if (!dev->has_bios || dev->local)
+            if (!dev->has_bios || dev->local) {
+                esp_log("Local=%d.\n", dev->local);
                 return 0x22;
-            else {
+            } else {
                 uint8_t ret = 0x22;
 
                 if (len == 1) {
@@ -2338,14 +2359,13 @@ ncr53c9x_in(uint16_t port, void *priv)
         switch (port) {
             case 0x02:
                 ret = dev->dma_86c01.mode;
+
+                if (ret & 0x40)
+                    dev->dma_86c01.status &= ~0x01;
+
                 break;
 
             case 0x0c:
-                if (dev->dma_86c01.mode & 0x40)
-                    dev->dma_86c01.status |= 0x01;
-                else
-                    dev->dma_86c01.status &= ~0x01;
-
                 if (dev->dma_enabled)
                     dev->dma_86c01.status |= 0x02;
                 else
@@ -2492,7 +2512,7 @@ ncr53c9x_mca_init(const device_t *info)
     fifo8_create(&dev->fifo, ESP_FIFO_SZ);
     fifo8_create(&dev->cmdfifo, ESP_CMDFIFO_SZ);
 
-    dev->pos_regs[0] = 0x4d; /* MCA board ID */
+    dev->pos_regs[0] = 0x4f; /* MCA board ID */
     dev->pos_regs[1] = 0x7f;
     mca_add(ncr53c9x_mca_read, ncr53c9x_mca_write, ncr53c9x_mca_feedb, NULL, dev);
 


### PR DESCRIPTION
Summary
=======
1. Change the MCA board id from 0x4d to 0x4f again (though need to see an option rom for this, damn).
2. Reworked the way IRQ's are issued in the 53c9x MCA side.
3. Implemented Selection and ATN 3 command (0x46), which uses 3 message bytes rather than just 1. Fixes boot issues with the PCSCSI drivers for NT 3.1.
4. Ported the latest qemu commits based on this chip.

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
[AMD PCscsi manual (non-A counts too)](https://theretroweb.com/chip/documentation/am53c974a-665896ecb6501350650532.pdf)
