### PR TITLE
Fix OS/2 1.1 format on IBM PS/1 XTA and PS/2 ST506 adapters

### DIFF
--- a/src/disk/hdc_st506_mca.c
+++ b/src/disk/hdc_st506_mca.c
@@ -108,7 +108,7 @@
 #include <86box/machine.h>
 #include "cpu.h"
 
-#define MFM_TIME          (10 * TIMER_USEC)
+#define MFM_TIME          (100 * TIMER_USEC)
 #define MFM_SECTOR_TIME   (500 * TIMER_USEC)
 #define MFM_TYPE_USER 255 /* user drive type */
 
@@ -550,6 +550,22 @@ set_intr(mfm_t *dev, int raise)
     }
 }
 
+static void
+clear_unused_format(mfm_t *dev, int count)
+{
+    if (count == 0xff) /* OS/2 format */
+        if (CS != 0xe000) /* ROM POST */
+            dev->status &= ~ASR_BUSY;
+}
+
+static void
+clear_unused_delay(mfm_t *dev, int cmd)
+{
+    if ((cmd == 0x02) || (cmd == 0x08))
+        if (CS == 0xe000) /* ROM POST */
+            dev->status &= ~ASR_INT_REQ;
+}
+
 /* Get the logical (block) address of a CHS triplet. */
 static int
 get_sector(mfm_t *dev, drive_t *drive, off64_t *addr)
@@ -797,7 +813,6 @@ st506_callback(void *priv)
     /* If we are returning from a RESET, handle this first. */
     if (dev->reset) {
         st506_mca_log("ST506 reset.\n");
-        dev->status &= ~ASR_BUSY;
         dev->ssb.valid = 0;
         dev->reset = 0;
         do_finish(dev);
@@ -864,7 +879,6 @@ do_send:
 
                     /* Ready to transfer the data out. */
                     dev->state   = STATE_SDATA;
-                    dev->status |= ASR_TX_EN;
                     dev->buf_idx = 0;
                     if (ccb->no_data) {
                         /* Delay a bit, no actual transfer. */
@@ -1051,7 +1065,6 @@ do_send:
 do_recv:
                     /* Ready to transfer the data in. */
                     dev->state   = STATE_RDATA;
-                    dev->status |= ASR_TX_EN;
                     dev->buf_idx = 0;
                     if (ccb->no_data) {
                         /* Delay a bit, no actual transfer. */
@@ -1104,7 +1117,6 @@ do_recv:
                     if (get_sector(dev, drive, &addr)) {
                         /* De-activate the status icon. */
                         ui_sb_update_icon_write(SB_HDD | HDD_BUS_MFM, 0);
-
                         do_finish(dev);
                         return;
                     }
@@ -1295,6 +1307,7 @@ mfm_write(uint16_t port, uint8_t val, void *priv)
                             dev->status |= ASR_BUSY;
 
                         /* Schedule command execution. */
+                        clear_unused_format(dev, dev->ccb.count);
                         timer_set_delay_u64(&dev->timer, MFM_SECTOR_TIME);
                     }
                 }
@@ -1368,7 +1381,7 @@ mfm_write(uint16_t port, uint8_t val, void *priv)
             }
 
             if (val & ATT_CCB) {
-                if (dev->attn & ATT_CCB)
+                if (val & ATT_DATA)
                     /* Hey now, we're still busy for you! */
                     break;
 
@@ -1410,7 +1423,7 @@ mfm_readw(uint16_t port, void *priv)
                     st506_mca_log("ST506: read with empty buffer!\n");
                     dev->state = STATE_IDLE;
                     dev->intstat |= ISR_INVALID_CMD;
-                    dev->status &= (ASR_TX_EN | ASR_DATA_REQ | ASR_DIR);
+                    dev->status &= ~(ASR_TX_EN | ASR_DATA_REQ | ASR_DIR);
                     set_intr(dev, 1);
                     break;
                 }
@@ -1479,8 +1492,9 @@ mfm_writew(uint16_t port, uint16_t val, void *priv)
                             dev->status |= ASR_BUSY;
 
                         /* Schedule command execution. */
-                        timer_set_delay_u64(&dev->timer, 
-                            ((dev->ccb.cmd == 0x02) || (dev->ccb.cmd == 0x08)) ? MFM_TIME : MFM_SECTOR_TIME);
+                        clear_unused_delay(dev, dev->ccb.cmd);
+                        clear_unused_format(dev, dev->ccb.count);
+                        timer_set_delay_u64(&dev->timer, MFM_SECTOR_TIME);
                     }
                 }
             }
@@ -1618,7 +1632,7 @@ mfm_init(UNUSED(const device_t *info))
             st506_mca_log("ST506: drive%d (type %d: cyl=%d,hd=%d,spt=%d), disk %d\n",
                           hdd[i].mfm_channel, drive->type,
                           drive->tracks, drive->hpc, drive->spt, i);
-            
+
             if (++c > 1)
                 break;
         }

--- a/src/disk/hdc_xta_ps1.c
+++ b/src/disk/hdc_xta_ps1.c
@@ -11,7 +11,7 @@
  *          also named ATA - AT Attachment.)  The basic ideas was to
  *          put the actual drive controller electronics onto the drive
  *          itself, and have the host machine just talk to that using
- *          a simpe, standardized I/O path- hence the name IDE, for
+ *          a simple, standardized I/O path- hence the name IDE, for
  *          Integrated Drive Electronics.
  *
  *          In the ATA version of IDE, the programming interface of
@@ -28,7 +28,7 @@
  *          mark them as being for this XTBUS variant.
  *
  *          So, XTA and ATA try to do the same thing, but they use
- *          different ways to achive their goal.
+ *          different ways to achieve their goal.
  *
  *          Also, XTA is **not** the same as XTIDE.  XTIDE is a modern
  *          variant of ATA-IDE, but retro-fitted for use on 8bit XT
@@ -147,8 +147,8 @@ enum {
 #define ISR_TERMINATION 0x80 /* termination error */
 
 /* Attention register (4W) values (IBM PS/1 2011.) */
-#define ATT_ABRT 0x01 /* abort command */
-#define ATT_DATA 0x10 /* data request */
+#define ATT_ABRT 0x01 /* abort last command */
+#define ATT_DATA 0x10 /* data request enable */
 #define ATT_SSB  0x20 /* sense summary block */
 #define ATT_CSB  0x40 /* command specify block */
 #define ATT_CCB  0x80 /* command control block */
@@ -511,6 +511,14 @@ set_intr(hdc_t *dev, int raise)
     }
 }
 
+static void
+clear_unused_format(hdc_t *dev, int count)
+{
+    if (count == 0x11) /* OS/2 format */
+        if (CS != 0xe000) /* ROM POST */
+            dev->status &= ~ASR_BUSY;
+}
+
 /* Get the logical (block) address of a CHS triplet. */
 static int
 get_sector(hdc_t *dev, drive_t *drive, off64_t *addr)
@@ -755,7 +763,6 @@ hdc_callback(void *priv)
     /* If we are returning from a RESET, handle this first. */
     if (dev->reset) {
         ps1_hdc_log("XTA reset.\n");
-        dev->status &= ~ASR_BUSY;
         dev->ssb.valid = 0;
         dev->reset = 0;
         do_finish(dev);
@@ -822,7 +829,6 @@ do_send:
 
                     /* Ready to transfer the data out. */
                     dev->state   = STATE_SDATA;
-                    dev->status |= ASR_TX_EN;
                     dev->buf_idx = 0;
                     if (ccb->no_data) {
                         /* Delay a bit, no actual transfer. */
@@ -1009,7 +1015,6 @@ do_send:
 do_recv:
                     /* Ready to transfer the data in. */
                     dev->state   = STATE_RDATA;
-                    dev->status |= ASR_TX_EN;
                     dev->buf_idx = 0;
                     if (ccb->no_data) {
                         /* Delay a bit, no actual transfer. */
@@ -1062,7 +1067,6 @@ do_recv:
                     if (get_sector(dev, drive, &addr)) {
                         /* De-activate the status icon. */
                         ui_sb_update_icon_write(SB_HDD | HDD_BUS_XTA, 0);
-
                         do_finish(dev);
                         return;
                     }
@@ -1262,6 +1266,7 @@ hdc_write(uint16_t port, uint8_t val, void *priv)
                             dev->status |= ASR_BUSY;
 
                         /* Schedule command execution. */
+                        clear_unused_format(dev, dev->ccb.count);
                         timer_set_delay_u64(&dev->timer, HDC_SECTOR_TIME);
                     }
                 }
@@ -1315,7 +1320,7 @@ hdc_write(uint16_t port, uint8_t val, void *priv)
             }
 
             if (val & ATT_CCB) {
-                if (dev->attn & ATT_CCB)
+                if (val & ATT_DATA)
                     /* Hey now, we're still busy for you! */
                     break;
 


### PR DESCRIPTION
Summary
=======
OS/2 1.1 takes extremely long time formatting disk on IBM PS/1 XTA controller and hangs up on IBM PS/2 ST506 disk adapter. This PR fixes these issues by taking out some flags in the status registers to speed up format in OS/2 1.1.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
IBM PS/1 Technical Reference Section 8 Drives: https://www.mediafire.com/download/ecok59mrc8sclzb/Section_8._Drives.pdf
