### PR TITLE
Added XGA-2 PLL-based clock

### DIFF
--- a/src/include/86box/vid_xga.h
+++ b/src/include/86box/vid_xga.h
@@ -64,6 +64,7 @@ typedef struct xga_t {
     uint8_t  disp_cntl_2;
     uint8_t  clk_sel_1;
     uint8_t  clk_sel_2;
+    uint8_t  pll_program;
     uint8_t  hwc_control;
     uint8_t  bus_arb;
     uint8_t  isa_pos_enable;

--- a/src/video/vid_xga.c
+++ b/src/video/vid_xga.c
@@ -310,6 +310,38 @@ xga_render_blank(svga_t *svga)
         memset(line_ptr, 0, line_width);
 }
 
+static float
+xga2_getclock(svga_t *svga)
+{
+    xga_t *xga = (xga_t *) svga->xga;
+
+    int freq_range = (xga->pll_program >> 6) & 0x03;
+    int freq_idx = xga->pll_program & 0x3f;
+    float pel_freq;
+    float factor;
+    float freq;
+
+    xga_log("FREQIDX=%02x, FREQRange=%d.\n", freq_idx, freq_range);
+    switch (freq_range) {
+        case 0x00:
+        default:
+            pel_freq = 16250000.0f;
+            factor = 250000.0f;
+            break;
+        case 0x01:
+            pel_freq = 32500000.0f;
+            factor = 500000.0f;
+            break;
+        case 0x02:
+            pel_freq = 65000000.0f;
+            factor = 1000000.0f;
+            break;
+    }
+
+    freq = (pel_freq + ((float) (freq_idx * factor)));
+    return freq;
+}
+
 void
 xga_recalctimings(svga_t *svga)
 {
@@ -343,24 +375,28 @@ xga_recalctimings(svga_t *svga)
         xga->memaddr_latch = xga->disp_start_addr;
 
         xga_log("XGA ClkSel1 = %d, ClkSel2 = %02x, dispcntl2=%02x.\n", (xga->clk_sel_1 >> 2) & 3, xga->clk_sel_2 & 0x80, xga->disp_cntl_2 & 0xc0);
-        switch ((xga->clk_sel_1 >> 2) & 3) {
-            case 0:
-                xga_log("HDISP VGA0 = %d, XGA = %d.\n", svga->hdisp, xga->h_disp);
-                if (xga->clk_sel_2 & 0x80)
-                    svga->clock_xga = (cpuclock * (double) (1ULL << 32)) / 41539000.0;
-                else
-                    svga->clock_xga = (cpuclock * (double) (1ULL << 32)) / 25175000.0;
-                break;
-            case 1:
-                xga_log("HDISP VGA1 = %d, XGA = %d.\n", svga->hdisp, xga->h_disp);
-                svga->clock_xga = (cpuclock * (double) (1ULL << 32)) / 28322000.0;
-                break;
-            case 3:
-                svga->clock_xga = (cpuclock * (double) (1ULL << 32)) / 44900000.0;
-                break;
+        if ((xga->clk_sel_1 & 0x80) && xga->type) {
+            svga->clock_xga = (cpuclock * (double) (1ULL << 32)) / xga2_getclock(svga);
+        } else {
+            switch ((xga->clk_sel_1 >> 2) & 3) {
+                case 0:
+                    xga_log("HDISP VGA0 = %d, XGA = %d.\n", svga->hdisp, xga->h_disp);
+                    if (xga->clk_sel_2 & 0x80)
+                        svga->clock_xga = (cpuclock * (double) (1ULL << 32)) / 41539000.0;
+                    else
+                        svga->clock_xga = (cpuclock * (double) (1ULL << 32)) / 25175000.0;
+                    break;
+                case 1:
+                    xga_log("HDISP VGA1 = %d, XGA = %d.\n", svga->hdisp, xga->h_disp);
+                    svga->clock_xga = (cpuclock * (double) (1ULL << 32)) / 28322000.0;
+                    break;
+                case 3:
+                    svga->clock_xga = (cpuclock * (double) (1ULL << 32)) / 44900000.0;
+                    break;
 
-            default:
-                break;
+                default:
+                    break;
+            }
         }
 
         svga->render_xga = xga_render_blank;
@@ -541,6 +577,11 @@ xga_ext_out_reg(xga_t *xga, svga_t *svga, uint8_t idx, uint8_t val)
 
         case 0x55:
             xga->border_color = val;
+            break;
+
+        case 0x58:
+            xga->pll_program = val;
+            svga_recalctimings(svga);
             break;
 
         case 0x59:
@@ -867,6 +908,10 @@ xga_ext_inb(uint16_t addr, void *priv)
                     break;
                 case 0x55:
                     ret = xga->border_color;
+                    break;
+
+                case 0x58:
+                    ret = xga->pll_program;
                     break;
 
                 case 0x59:


### PR DESCRIPTION
Summary
=======
Fixes incorrect clocks using these specific clocks when enabled.

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
[XGA/XGA-2 manual](https://archive.org/details/bitsavers_ibmpccardseferenceManualMay92_1756350)
