### PR TITLE
Implement EGA/VGA/SVGA VSync interrupts for ISA/VLB/MCA cards

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -194,6 +194,7 @@ int      voodoo_enabled                         = 0;              /* (C) video o
 int      ibm8514_standalone_enabled             = 0;              /* (C) video option */
 int      xga_standalone_enabled                 = 0;              /* (C) video option */
 int      da2_standalone_enabled                 = 0;              /* (C) video option */
+int      vga_irq_enabled                        = 0;              /* (C) video option */
 uint32_t mem_size                               = 0;              /* (C) memory size (Installed on
                                                                          system board)*/
 uint32_t isa_mem_size                           = 0;              /* (C) memory size (ISA Memory Cards) */

--- a/src/config.c
+++ b/src/config.c
@@ -714,6 +714,7 @@ load_video(void)
     da2_standalone_enabled           = !!ini_section_get_int(cat, "da2", 0);
     show_second_monitors             = !!ini_section_get_int(cat, "show_second_monitors", 1);
     video_fullscreen_scale_maximized = !!ini_section_get_int(cat, "video_fullscreen_scale_maximized", 0);
+    vga_irq_enabled                  = !!ini_section_get_int(cat, "vga_irq_enabled", 1);
 
     vid_cga_comp_brightness = ini_section_get_int(cat, "vid_cga_comp_brightness", 0);
     vid_cga_comp_sharpness  = ini_section_get_int(cat, "vid_cga_comp_sharpness", 0);
@@ -3189,6 +3190,11 @@ save_video(void)
         ini_section_delete_var(cat, "video_fullscreen_scale_maximized");
     else
         ini_section_set_int(cat, "video_fullscreen_scale_maximized", video_fullscreen_scale_maximized);
+
+    if (vga_irq_enabled == 1) 
+        ini_section_delete_var(cat, "vga_irq_enabled");
+    else
+        ini_section_set_int(cat, "vga_irq_enabled", vga_irq_enabled);
 
     ini_delete_section_if_empty(config, cat);
 }

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -210,6 +210,7 @@ extern int      voodoo_enabled;             /* (C) video option */
 extern int      ibm8514_standalone_enabled; /* (C) video option */
 extern int      xga_standalone_enabled;     /* (C) video option */
 extern int      da2_standalone_enabled;     /* (C) video option */
+extern int      vga_irq_enabled;            /* (C) video option */
 extern uint32_t mem_size;                   /* (C) memory size (Installed on system board) */
 extern uint32_t isa_mem_size;               /* (C) memory size (ISA Memory Cards) */
 extern int      cpu;                        /* (C) cpu type */

--- a/src/include/86box/vid_ega.h
+++ b/src/include/86box/vid_ega.h
@@ -147,6 +147,7 @@ typedef struct ega_t {
     void *     priv_parent;
 
     uint8_t    alt_addr; /* 0 for 0x3XX range, 1 for 0x2XX range */
+    uint8_t    vertirq_state;
 } ega_t;
 #endif
 

--- a/src/include/86box/vid_svga.h
+++ b/src/include/86box/vid_svga.h
@@ -314,6 +314,7 @@ typedef struct svga_t {
 
     char svga_internal_name[128];
     uint8_t vertirq_state;
+    uint8_t vertirq_enabled;
 
     /* Enable LUT mapping of >= 24 bpp modes. */
     int lut_map;

--- a/src/include/86box/vid_svga.h
+++ b/src/include/86box/vid_svga.h
@@ -272,6 +272,7 @@ typedef struct svga_t {
     uint8_t color_2bpp;
     uint8_t ksc5601_sbyte_mask;
     uint8_t ksc5601_udc_area_msb[2];
+    uint8_t oldcrtc11;
 
     int      ksc5601_swap_mode;
     uint16_t ksc5601_english_font_type;
@@ -310,6 +311,9 @@ typedef struct svga_t {
 
     /* Pointer to monitor */
     monitor_t *monitor;
+
+    char svga_internal_name[128];
+    uint8_t vertirq_state;
 
     /* Enable LUT mapping of >= 24 bpp modes. */
     int lut_map;

--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -3062,3 +3062,6 @@ msgstr ""
 
 msgid "Use EDC/ECC emulation"
 msgstr ""
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -3069,3 +3069,6 @@ msgstr "Dispositiu de sortida de so:"
 
 msgid "System Default"
 msgstr "Per defecte del sistema"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -3073,3 +3073,6 @@ msgstr "Výstupní zvukové zařízení:"
 
 msgid "System Default"
 msgstr "Výchozí nastavení systému"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -3069,3 +3069,6 @@ msgstr "Audio-Ausgabegerät:"
 
 msgid "System Default"
 msgstr "Systemstandard"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/el-GR.po
+++ b/src/qt/languages/el-GR.po
@@ -3131,3 +3131,6 @@ msgstr "Συσκευή εξόδου ήχου:"
 
 msgid "System Default"
 msgstr "Προεπιλογή Συστήματος"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -3068,3 +3068,6 @@ msgstr "Dispositivo de salida de audio:"
 
 msgid "System Default"
 msgstr "Por defecto del sistema"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -3070,3 +3070,6 @@ msgstr "Äänen ulostulolaite:"
 
 msgid "System Default"
 msgstr "Järjestelmän oletus"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -3069,3 +3069,6 @@ msgstr "Périphérique de sortie audio :"
 
 msgid "System Default"
 msgstr "Défaut du système"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -3072,3 +3072,6 @@ msgstr "Uređaj za izlaz zvuka:"
 
 msgid "System Default"
 msgstr "Zadana postavka operativnog sustava"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -3177,3 +3177,6 @@ msgstr "Dispositivo di uscita audio:"
 
 msgid "System Default"
 msgstr "Predefinito del sistema"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -3070,3 +3070,6 @@ msgstr "音声出力デバイス:"
 
 msgid "System Default"
 msgstr "システム既定値"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -3072,3 +3072,6 @@ msgstr "오디오 출력 장치:"
 
 msgid "System Default"
 msgstr "시스템 기본값"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/nb-NO.po
+++ b/src/qt/languages/nb-NO.po
@@ -3070,3 +3070,6 @@ msgstr "Lydutdataenhet:"
 
 msgid "System Default"
 msgstr "Systemstandard"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -3069,3 +3069,6 @@ msgstr "Audio-uitvoerapparaat:"
 
 msgid "System Default"
 msgstr "Systeemstandaard"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -3070,3 +3070,6 @@ msgstr "Urządzenie wyjściowe dźwięku:"
 
 msgid "System Default"
 msgstr "Domyślne ustawienie systemowe"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -3069,3 +3069,6 @@ msgstr "Dispositivo de saída de áudio:"
 
 msgid "System Default"
 msgstr "Padrão do sistema"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -3069,3 +3069,6 @@ msgstr "Dispositivo de saída de áudio:"
 
 msgid "System Default"
 msgstr "Padrão do sistema"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -3081,3 +3081,6 @@ msgstr "Устройство вывода звука:"
 
 msgid "System Default"
 msgstr "Системный"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -3070,3 +3070,6 @@ msgstr "Výstupné zvukové zariadenie:"
 
 msgid "System Default"
 msgstr "Predvolené nastavenie systému"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -3071,3 +3071,6 @@ msgstr "Naprava za zvočni izhod:"
 
 msgid "System Default"
 msgstr "Sistemsko privzeto"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -3070,3 +3070,6 @@ msgstr "Ljudutdataenhet:"
 
 msgid "System Default"
 msgstr "Systemstandard"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -3120,3 +3120,6 @@ msgstr "Ses çıkış aygıtı:"
 
 msgid "System Default"
 msgstr "Sistem Varsayılanı"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -3071,3 +3071,6 @@ msgstr "Пристрій виведення звуку:"
 
 msgid "System Default"
 msgstr "Системний"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -3070,3 +3070,6 @@ msgstr "Thiết bị đầu ra âm thanh:"
 
 msgid "System Default"
 msgstr "Mặc định hệ thống"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -3069,3 +3069,6 @@ msgstr "音频输出设备:"
 
 msgid "System Default"
 msgstr "系统默认"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -3070,3 +3070,6 @@ msgstr "音訊輸出裝置:"
 
 msgid "System Default"
 msgstr "系統預設"
+
+msgid "(S)VGA ISA/VLB/MCA VSync interrupt"
+msgstr ""

--- a/src/qt/qt_settingsdisplay.cpp
+++ b/src/qt/qt_settingsdisplay.cpp
@@ -75,6 +75,7 @@ SettingsDisplay::SettingsDisplay(QWidget *parent)
 
     ui->checkBoxOverscan->setChecked(enable_overscan);
     ui->checkBoxContrast->setChecked(vid_cga_contrast);
+    ui->checkBoxVSyncIrq->setChecked(vga_irq_enabled);
 
     ui->checkBoxInverted->setChecked(invert_display);
 
@@ -104,6 +105,7 @@ SettingsDisplay::changed()
     has_changed  |= (xga_standalone_enabled     != (ui->checkBoxXga->isChecked() ? 1 : 0));
     has_changed  |= (da2_standalone_enabled     != (ui->checkBoxDa2->isChecked() ? 1 : 0));
     has_changed  |= (monitor_edid               != (ui->radioButtonCustom->isChecked() ? 1 : 0));
+    has_changed  |= (vga_irq_enabled            != (ui->checkBoxVSyncIrq->isChecked() ? 1 : 0));
 
     has_changed  |= strcmp(monitor_edid_path, ui->lineEditCustomEDID->fileName().toUtf8().data());
 
@@ -139,6 +141,7 @@ SettingsDisplay::save()
     xga_standalone_enabled     = ui->checkBoxXga->isChecked() ? 1 : 0;
     da2_standalone_enabled     = ui->checkBoxDa2->isChecked() ? 1 : 0;
     monitor_edid               = ui->radioButtonCustom->isChecked() ? 1 : 0;
+    vga_irq_enabled            = ui->checkBoxVSyncIrq->isChecked() ? 1 : 0;
 
     strncpy(monitor_edid_path, ui->lineEditCustomEDID->fileName().toUtf8().data(), sizeof(monitor_edid_path) - 1);
 

--- a/src/qt/qt_settingsdisplay.ui
+++ b/src/qt/qt_settingsdisplay.ui
@@ -200,6 +200,13 @@
             </property>
            </widget>
           </item>
+          <item row="6" column="0" colspan="2">
+           <widget class="QCheckBox" name="checkBoxVSyncIrq">
+            <property name="text">
+             <string>(S)VGA ISA/VLB/MCA VSync interrupt</string>
+            </property>
+           </widget>
+          </item>
 
          </layout>
         </widget>
@@ -443,6 +450,7 @@
   <tabstop>pushButtonConfigureXga</tabstop>
   <tabstop>checkBoxDa2</tabstop>
   <tabstop>pushButtonConfigureDa2</tabstop>
+  <tabstop>checkBoxVSyncIrq</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/video/vid_ati28800.c
+++ b/src/video/vid_ati28800.c
@@ -333,6 +333,9 @@ ati28800_in(uint16_t addr, void *priv)
                 temp = 0;
             else
                 temp = 0x10;
+
+            if (svga->vertirq_state)
+                temp |= 0x80;
             break;
 
         case 0x3C6:

--- a/src/video/vid_cl54xx.c
+++ b/src/video/vid_cl54xx.c
@@ -29,6 +29,7 @@
 #include <86box/mca.h>
 #include <86box/mem.h>
 #include <86box/pci.h>
+#include <86box/pic.h>
 #include <86box/rom.h>
 #include <86box/device.h>
 #include <86box/machine.h>
@@ -534,8 +535,16 @@ gd54xx_vga_vsync_enabled(gd54xx_t *gd54xx)
 static void
 gd54xx_update_irqs(gd54xx_t *gd54xx)
 {
-    if (!gd54xx->pci)
+    if (!gd54xx->pci) {
+        if (!vga_irq_enabled)
+            return;
+
+        if ((gd54xx->vblank_irq > 0) && gd54xx_vga_vsync_enabled(gd54xx))
+            picintlevel(1 << 2, &gd54xx->irq_state);
+        else
+            picintclevel(1 << 2, &gd54xx->irq_state);
         return;
+    }
 
     if ((gd54xx->vblank_irq > 0) && gd54xx_vga_vsync_enabled(gd54xx))
         pci_set_irq(gd54xx->pci_slot, PCI_INTA, &gd54xx->irq_state);
@@ -1290,7 +1299,7 @@ gd54xx_in(uint16_t addr, void *priv)
 
     switch (addr) {
         case 0x3c2:
-            ret = svga_in(addr, svga);
+            ret = svga_in(addr, svga) & ~0x80;
             ret |= gd54xx->vblank_irq > 0 ? 0x80 : 0x00;
             break;
 
@@ -4485,6 +4494,9 @@ gd54xx_init(const device_t *info)
                   gd54xx_recalctimings, gd54xx_in, gd54xx_out,
                   gd54xx_hwcursor_draw, NULL);
     }
+    /* Disable the common VSync handler unconditionally. At least all non-PCI cards are able to do VSync interrupts. */
+    svga->vertirq_enabled = 0;
+
     svga->vblank_start = gd54xx_vblank_start;
     svga->ven_write    = gd54xx_write_modes45;
     if ((vram == 1) || (vram >= 256 && vram <= 1024))

--- a/src/video/vid_cl54xx.c
+++ b/src/video/vid_cl54xx.c
@@ -540,9 +540,9 @@ gd54xx_update_irqs(gd54xx_t *gd54xx)
             return;
 
         if ((gd54xx->vblank_irq > 0) && gd54xx_vga_vsync_enabled(gd54xx))
-            picintlevel(1 << 2, &gd54xx->irq_state);
+            picint(1 << 2);
         else
-            picintclevel(1 << 2, &gd54xx->irq_state);
+            picintc(1 << 2);
         return;
     }
 

--- a/src/video/vid_ega.c
+++ b/src/video/vid_ega.c
@@ -320,7 +320,7 @@ ega_out(uint16_t addr, uint8_t val, void *priv)
                         ega_recalctimings(ega);
                         if (!(ega->crtc[0x11] & 0x10)) {
                             ega->vertirq_state = 0;
-                            picintc(1 << 9);
+                            picintc(1 << 2);
                         }
                     }
                 }
@@ -854,7 +854,7 @@ ega_handle_reset(void* priv)
 
     ega->crtc[0x11] |= 0x20;
     ega->vertirq_state = 0;
-    picintc(1 << 9);
+    picintc(1 << 2);
 }
 
 void
@@ -1006,7 +1006,7 @@ ega_poll(void *priv)
 
             if (!ega->vertirq_state && (ega->crtc[0x11] & 0x30) == 0x10) {
                 ega->vertirq_state = 1;
-                picint(1 << 9);
+                picint(1 << 2);
             }
             if (ega->interlace && !ega->oddeven)
                 ega->lastline++;

--- a/src/video/vid_ega.c
+++ b/src/video/vid_ega.c
@@ -318,6 +318,10 @@ ega_out(uint16_t addr, uint8_t val, void *priv)
                     } else {
                         ega->fullchange = changeframecount;
                         ega_recalctimings(ega);
+                        if (!(ega->crtc[0x11] & 0x10)) {
+                            ega->vertirq_state = 0;
+                            picintc(1 << 9);
+                        }
                     }
                 }
             }
@@ -844,6 +848,16 @@ ega_dot_poll(void *priv)
 }
 
 void
+ega_handle_reset(void* priv)
+{
+    ega_t* ega = priv;
+
+    ega->crtc[0x11] |= 0x20;
+    ega->vertirq_state = 0;
+    picintc(1 << 9);
+}
+
+void
 ega_poll(void *priv)
 {
     ega_t   *ega = (ega_t *) priv;
@@ -990,6 +1004,10 @@ ega_poll(void *priv)
 #endif
 //            x = ega->hdisp;
 
+            if (!ega->vertirq_state && (ega->crtc[0x11] & 0x30) == 0x10) {
+                ega->vertirq_state = 1;
+                picint(1 << 9);
+            }
             if (ega->interlace && !ega->oddeven)
                 ega->lastline++;
             if (ega->interlace && ega->oddeven)
@@ -1565,6 +1583,8 @@ ega_init(ega_t *ega, int monitor_type, int is_mono)
     ega->crtc[0] = 63;
     ega->crtc[6] = 255;
 
+    ega->crtc[0x11] = 0x20;
+
     ega->render_override = NULL;
 
     timer_add(&ega->timer, ega_poll, ega, 1);
@@ -1887,7 +1907,7 @@ const device_t ega_device = {
     .local         = EGA_IBM,
     .init          = ega_standalone_init,
     .close         = ega_close,
-    .reset         = NULL,
+    .reset         = ega_handle_reset,
     .available     = ega_standalone_available,
     .speed_changed = ega_speed_changed,
     .force_redraw  = NULL,
@@ -1901,7 +1921,7 @@ const device_t cpqega_device = {
     .local         = EGA_COMPAQ,
     .init          = ega_standalone_init,
     .close         = ega_close,
-    .reset         = NULL,
+    .reset         = ega_handle_reset,
     .available     = cpqega_standalone_available,
     .speed_changed = ega_speed_changed,
     .force_redraw  = NULL,
@@ -1915,7 +1935,7 @@ const device_t sega_device = {
     .local         = EGA_SUPEREGA,
     .init          = ega_standalone_init,
     .close         = ega_close,
-    .reset         = NULL,
+    .reset         = ega_handle_reset,
     .available     = sega_standalone_available,
     .speed_changed = ega_speed_changed,
     .force_redraw  = NULL,
@@ -1929,7 +1949,7 @@ const device_t atiega800p_device = {
     .local         = EGA_ATI800P,
     .init          = ega_standalone_init,
     .close         = ega_close,
-    .reset         = NULL,
+    .reset         = ega_handle_reset,
     .available     = atiega800p_standalone_available,
     .speed_changed = ega_speed_changed,
     .force_redraw  = NULL,
@@ -1943,7 +1963,7 @@ const device_t iskra_ega_device = {
     .local         = EGA_ISKRA,
     .init          = ega_standalone_init,
     .close         = ega_close,
-    .reset         = NULL,
+    .reset         = ega_handle_reset,
     .available     = iskra_ega_standalone_available,
     .speed_changed = ega_speed_changed,
     .force_redraw  = NULL,
@@ -1957,7 +1977,7 @@ const device_t et2000_device = {
     .local         = EGA_TSENG,
     .init          = ega_standalone_init,
     .close         = ega_close,
-    .reset         = NULL,
+    .reset         = ega_handle_reset,
     .available     = et2000_standalone_available,
     .speed_changed = ega_speed_changed,
     .force_redraw  = NULL,

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -35,6 +35,7 @@
 #include <86box/pit.h>
 #include <86box/mem.h>
 #include <86box/rom.h>
+#include <86box/pic.h>
 #include <86box/plat.h>
 #include <86box/ui.h>
 #include <86box/video.h>
@@ -57,6 +58,7 @@ uint8_t svga_rotate[8][256];
 /*Primary SVGA device. As multiple video cards are not yet supported this is the
   only SVGA device.*/
 static svga_t *svga_pri;
+static device_t svga_gen_dev[MONITORS_NUM];
 
 #ifdef ENABLE_SVGA_LOG
 int svga_do_log = ENABLE_SVGA_LOG;
@@ -75,6 +77,37 @@ svga_log(const char *fmt, ...)
 #else
 #    define svga_log(fmt, ...)
 #endif
+
+void
+svga_raise_vertirq(svga_t* svga)
+{
+    if (!svga->vertirq_state && (svga->crtc[0x11] & 0x30) == 0x10) {
+        svga->vertirq_state = 1;
+        picint(1 << 9);
+    }
+}
+
+void
+svga_handle_reset(void* priv)
+{
+    svga_t* svga = priv;
+
+    svga->crtc[0x11] |= 0x20;
+    svga->vertirq_state = 0;
+    picintc(1 << 9);
+}
+
+void*
+svga_handle_init(const device_t* info)
+{
+    return &svga_gen_dev[info->local];
+}
+
+void
+svga_handle_close(void* priv)
+{
+    // no-op
+}
 
 svga_t *
 svga_get_pri(void)
@@ -516,6 +549,10 @@ svga_in(uint16_t addr, void *priv)
                     ret = 0;
                 else
                     ret = 0x10;
+
+                if (svga->vertirq_state) {
+                    ret |= 0x80;
+                }
             /* Monitor is not connected to the planar VGA if the PS/55 Display Adapter is installed. */
             } else {
                 /*
@@ -756,6 +793,13 @@ svga_recalctimings(svga_t *svga)
     svga->hdisp = svga->crtc[1];
     if (svga->crtc[1] & 1)
         svga->hdisp++;
+
+    if (!(svga->crtc[0x11] & 0x10) && ((svga->oldcrtc11 ^ svga->crtc[0x11]) & 0x10)) {
+        svga->vertirq_state = 0;
+        picintc(1 << 9);
+    }
+
+    svga->oldcrtc11 = svga->crtc[0x11];
 
     svga->htotal = svga->crtc[0];
     /* +5 has been verified by Sergi to be correct - +6 must have been an off by one error. */
@@ -1606,6 +1650,7 @@ svga_poll(void *priv)
                 svga->vsync_callback(svga);
 
             svga->start_retrace_latch = svga->crtc[0x4];
+            svga_raise_vertirq(svga); 
         }
 #if 0
         if (svga->vc == lines_num) {
@@ -1697,6 +1742,8 @@ svga_init(const device_t *info, svga_t *svga, void *priv, int memsize,
 
     svga->crtc[0]           = 63;
     svga->crtc[6]           = 255;
+    svga->crtc[0x11]        = 0x20;
+    svga->oldcrtc11         = 0x20;
     svga->dispontime        = 1000ULL << 32;
     svga->dispofftime       = 1000ULL << 32;
     svga->bpp               = 8;
@@ -1769,6 +1816,17 @@ svga_init(const device_t *info, svga_t *svga, void *priv, int memsize,
     svga->ramdac_type = RAMDAC_6BIT;
 
     svga->map8            = svga->pallook;
+
+    svga->svga_internal_name[0] = 0;
+    snprintf(svga->svga_internal_name, 128, "%s_svga_%d", info->internal_name, monitor_index_global);
+    memset(&svga_gen_dev[monitor_index_global], 0, sizeof(svga_gen_dev[0]));
+    svga_gen_dev[monitor_index_global].name = svga->svga_internal_name;
+    svga_gen_dev[monitor_index_global].internal_name = svga->svga_internal_name;
+    svga_gen_dev[monitor_index_global].init = svga_handle_init;
+    svga_gen_dev[monitor_index_global].close = svga_handle_close;
+    svga_gen_dev[monitor_index_global].flags = info->flags & ~(DEVICE_ONBOARD | DEVICE_PIT);
+    svga_gen_dev[monitor_index_global].local = monitor_index_global;
+    device_add(&svga_gen_dev[monitor_index_global]);
 
     return 0;
 }

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -83,7 +83,7 @@ svga_raise_vertirq(svga_t* svga)
 {
     if (!svga->vertirq_state && (svga->crtc[0x11] & 0x30) == 0x10) {
         svga->vertirq_state = 1;
-        picint(1 << 9);
+        picint(1 << 2);
     }
 }
 
@@ -94,7 +94,7 @@ svga_handle_reset(void* priv)
 
     svga->crtc[0x11] |= 0x20;
     svga->vertirq_state = 0;
-    picintc(1 << 9);
+    picintc(1 << 2);
 }
 
 void*
@@ -796,7 +796,7 @@ svga_recalctimings(svga_t *svga)
 
     if (!(svga->crtc[0x11] & 0x10) && ((svga->oldcrtc11 ^ svga->crtc[0x11]) & 0x10)) {
         svga->vertirq_state = 0;
-        picintc(1 << 9);
+        picintc(1 << 2);
     }
 
     svga->oldcrtc11 = svga->crtc[0x11];

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -552,9 +552,8 @@ svga_in(uint16_t addr, void *priv)
                 else
                     ret = 0x10;
 
-                if (svga->vertirq_state) {
+                if (svga->vertirq_state)
                     ret |= 0x80;
-                }
             /* Monitor is not connected to the planar VGA if the PS/55 Display Adapter is installed. */
             } else {
                 /*
@@ -1772,9 +1771,8 @@ svga_init(const device_t *info, svga_t *svga, void *priv, int memsize,
     svga->cable_connected = 1;
     svga->ksc5601_english_font_type = 0;
     svga->vertirq_enabled = !!vga_irq_enabled;
-    if (info->flags & (DEVICE_PCI | DEVICE_AGP | DEVICE_CARDBUS)) {
+    if (info->flags & (DEVICE_PCI | DEVICE_AGP | DEVICE_CARDBUS))
         svga->vertirq_enabled = 0;
-    }
 
     /* TODO: Move DEVICE_MCA to 16-bit once the device flags have been appropriately corrected. */
     if ((info->flags & DEVICE_MCA) || (info->flags & DEVICE_MCA32) ||

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -1771,7 +1771,7 @@ svga_init(const device_t *info, svga_t *svga, void *priv, int memsize,
 
     svga->cable_connected = 1;
     svga->ksc5601_english_font_type = 0;
-    svga->vertirq_enabled = 1;
+    svga->vertirq_enabled = !!vga_irq_enabled;
     if (info->flags & (DEVICE_PCI | DEVICE_AGP | DEVICE_CARDBUS)) {
         svga->vertirq_enabled = 0;
     }

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -83,7 +83,8 @@ svga_raise_vertirq(svga_t* svga)
 {
     if (!svga->vertirq_state && (svga->crtc[0x11] & 0x30) == 0x10) {
         svga->vertirq_state = 1;
-        picint(1 << 2);
+        if (svga->vertirq_enabled)
+            picint(1 << 2);
     }
 }
 
@@ -94,7 +95,8 @@ svga_handle_reset(void* priv)
 
     svga->crtc[0x11] |= 0x20;
     svga->vertirq_state = 0;
-    picintc(1 << 2);
+    if (svga->vertirq_enabled)
+        picintc(1 << 2);
 }
 
 void*
@@ -796,7 +798,8 @@ svga_recalctimings(svga_t *svga)
 
     if (!(svga->crtc[0x11] & 0x10) && ((svga->oldcrtc11 ^ svga->crtc[0x11]) & 0x10)) {
         svga->vertirq_state = 0;
-        picintc(1 << 2);
+        if (svga->vertirq_enabled)
+            picintc(1 << 2);
     }
 
     svga->oldcrtc11 = svga->crtc[0x11];
@@ -1768,6 +1771,10 @@ svga_init(const device_t *info, svga_t *svga, void *priv, int memsize,
 
     svga->cable_connected = 1;
     svga->ksc5601_english_font_type = 0;
+    svga->vertirq_enabled = 1;
+    if (info->flags & (DEVICE_PCI | DEVICE_AGP | DEVICE_CARDBUS)) {
+        svga->vertirq_enabled = 0;
+    }
 
     /* TODO: Move DEVICE_MCA to 16-bit once the device flags have been appropriately corrected. */
     if ((info->flags & DEVICE_MCA) || (info->flags & DEVICE_MCA32) ||


### PR DESCRIPTION
Summary
=======
This PR implements EGA/VGA/SVGA VSync interrupts for ISA/VLB/MCA cards.

VGA/SVGA VSync interrupts can be disabled by configuration. EGA VSync interrupts are controlled entirely by software.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
