### PR TITLE
Some small fixes for codegen-new

### DIFF
--- a/src/codegen_new/codegen_backend_arm64_uops.c
+++ b/src/codegen_new/codegen_backend_arm64_uops.c
@@ -1167,6 +1167,12 @@ codegen_MOV(codeblock_t *block, uop_t *uop)
         host_arm64_FMOV_D_D(block, dest_reg, src_reg);
     } else if (REG_IS_Q(dest_size) && REG_IS_Q(src_size)) {
         host_arm64_FMOV_D_D(block, dest_reg, src_reg);
+    } else if (REG_IS_W(dest_size) && REG_IS_L(src_size)) {
+        host_arm64_BFI(block, dest_reg, src_reg, 0, 16);
+    } else if (REG_IS_B(dest_size) && REG_IS_L(src_size)) {
+        host_arm64_BFI(block, dest_reg, src_reg, 0, 8);
+    } else if (REG_IS_B(dest_size) && REG_IS_W(src_size)) {
+        host_arm64_BFI(block, dest_reg, src_reg, 0, 8);
     } else
         fatal("MOV %x %x\n", uop->dest_reg_a_real, uop->src_reg_a_real);
 

--- a/src/codegen_new/codegen_backend_x86-64.c
+++ b/src/codegen_new/codegen_backend_x86-64.c
@@ -129,6 +129,9 @@ build_load_routine(codeblock_t *block, int size, int is_float)
     host_x86_SUB64_REG_IMM(block, REG_RSP, 0x20);
     // host_x86_MOV32_REG_REG(block, REG_ECX, uop->imm_data);
 #    else
+    /* Align RSP to 16: entry RSP%16=8 (after CALL from JIT block), two PUSHes
+       leave it at 8; subtract 8 more to satisfy the SysV ABI before calling C. */
+    host_x86_SUB64_REG_IMM(block, REG_RSP, 0x8);
     host_x86_MOV32_REG_REG(block, REG_EDI, REG_ECX);
 #    endif
     if (size == 1 && !is_float) {
@@ -150,6 +153,8 @@ build_load_routine(codeblock_t *block, int size, int is_float)
     }
 #    if _WIN64
     host_x86_ADD64_REG_IMM(block, REG_RSP, 0x20);
+#    else
+    host_x86_ADD64_REG_IMM(block, REG_RSP, 0x8);
 #    endif
     host_x86_POP(block, REG_RDX);
     host_x86_POP(block, REG_RAX);

--- a/src/codegen_new/codegen_ops_arith.c
+++ b/src/codegen_new/codegen_ops_arith.c
@@ -14,11 +14,12 @@
 #include "codegen_ops.h"
 #include "codegen_ops_arith.h"
 #include "codegen_ops_helpers.h"
+#include "codegen_ops_jit_wrappers.h"
 
 static inline void
 get_cf(ir_data_t *ir, int dest_reg)
 {
-    uop_CALL_FUNC_RESULT(ir, dest_reg, CF_SET);
+    uop_CALL_FUNC_RESULT(ir, dest_reg, jit_CF_SET);
 }
 
 uint32_t
@@ -2288,7 +2289,7 @@ rebuild_c(ir_data_t *ir)
     }
 
     if (needs_rebuild) {
-        uop_CALL_FUNC(ir, flags_rebuild_c);
+        uop_CALL_FUNC(ir, jit_flags_rebuild_c);
     }
 }
 

--- a/src/codegen_new/codegen_ops_branch.c
+++ b/src/codegen_new/codegen_ops_branch.c
@@ -14,6 +14,7 @@
 #include "codegen_ir.h"
 #include "codegen_ops.h"
 #include "codegen_ops_helpers.h"
+#include "codegen_ops_jit_wrappers.h"
 #include "codegen_ops_mov.h"
 
 static int
@@ -56,7 +57,7 @@ ropJO_common(UNUSED(codeblock_t *block), ir_data_t *ir, uint32_t dest_addr, UNUS
 
         case FLAGS_UNKNOWN:
         default:
-            uop_CALL_FUNC_RESULT(ir, IREG_temp0, VF_SET);
+            uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_VF_SET);
             jump_uop = uop_CMP_IMM_JZ_DEST(ir, IREG_temp0, 0);
             break;
     }
@@ -96,7 +97,7 @@ ropJNO_common(UNUSED(codeblock_t *block), ir_data_t *ir, uint32_t dest_addr, UNU
 
         case FLAGS_UNKNOWN:
         default:
-            uop_CALL_FUNC_RESULT(ir, IREG_temp0, VF_SET);
+            uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_VF_SET);
             jump_uop = uop_CMP_IMM_JNZ_DEST(ir, IREG_temp0, 0);
             break;
     }
@@ -142,7 +143,7 @@ ropJB_common(codeblock_t *block, ir_data_t *ir, uint32_t dest_addr, uint32_t nex
 
         case FLAGS_UNKNOWN:
         default:
-            uop_CALL_FUNC_RESULT(ir, IREG_temp0, CF_SET);
+            uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_CF_SET);
             if (do_unroll)
                 jump_uop = uop_CMP_IMM_JNZ_DEST(ir, IREG_temp0, 0);
             else
@@ -192,7 +193,7 @@ ropJNB_common(codeblock_t *block, ir_data_t *ir, uint32_t dest_addr, uint32_t ne
 
         case FLAGS_UNKNOWN:
         default:
-            uop_CALL_FUNC_RESULT(ir, IREG_temp0, CF_SET);
+            uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_CF_SET);
             if (do_unroll)
                 jump_uop = uop_CMP_IMM_JZ_DEST(ir, IREG_temp0, 0);
             else
@@ -214,7 +215,7 @@ ropJE_common(codeblock_t *block, ir_data_t *ir, uint32_t dest_addr, uint32_t nex
 #ifdef ENABLE_UNROLL
     if (ZF_SET() && codegen_can_unroll(block, ir, next_pc, dest_addr)) {
         if (!codegen_flags_changed || !flags_res_valid()) {
-            uop_CALL_FUNC_RESULT(ir, IREG_temp0, ZF_SET);
+            uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_ZF_SET);
             jump_uop = uop_CMP_IMM_JNZ_DEST(ir, IREG_temp0, 0);
         } else {
             jump_uop = uop_CMP_IMM_JZ_DEST(ir, IREG_flags_res, 0);
@@ -227,7 +228,7 @@ ropJE_common(codeblock_t *block, ir_data_t *ir, uint32_t dest_addr, uint32_t nex
 #endif
     {
         if (!codegen_flags_changed || !flags_res_valid()) {
-            uop_CALL_FUNC_RESULT(ir, IREG_temp0, ZF_SET);
+            uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_ZF_SET);
             jump_uop = uop_CMP_IMM_JZ_DEST(ir, IREG_temp0, 0);
         } else {
             jump_uop = uop_CMP_IMM_JNZ_DEST(ir, IREG_flags_res, 0);
@@ -246,7 +247,7 @@ ropJNE_common(codeblock_t *block, ir_data_t *ir, uint32_t dest_addr, uint32_t ne
 #ifdef ENABLE_UNROLL
     if (!ZF_SET() && codegen_can_unroll(block, ir, next_pc, dest_addr)) {
         if (!codegen_flags_changed || !flags_res_valid()) {
-            uop_CALL_FUNC_RESULT(ir, IREG_temp0, ZF_SET);
+            uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_ZF_SET);
             jump_uop = uop_CMP_IMM_JZ_DEST(ir, IREG_temp0, 0);
         } else {
             jump_uop = uop_CMP_IMM_JNZ_DEST(ir, IREG_flags_res, 0);
@@ -259,7 +260,7 @@ ropJNE_common(codeblock_t *block, ir_data_t *ir, uint32_t dest_addr, uint32_t ne
 #endif
     {
         if (!codegen_flags_changed || !flags_res_valid()) {
-            uop_CALL_FUNC_RESULT(ir, IREG_temp0, ZF_SET);
+            uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_ZF_SET);
             jump_uop = uop_CMP_IMM_JNZ_DEST(ir, IREG_temp0, 0);
         } else {
             jump_uop = uop_CMP_IMM_JZ_DEST(ir, IREG_flags_res, 0);
@@ -311,14 +312,14 @@ ropJBE_common(codeblock_t *block, ir_data_t *ir, uint32_t dest_addr, uint32_t ne
         case FLAGS_UNKNOWN:
         default:
             if (do_unroll) {
-                uop_CALL_FUNC_RESULT(ir, IREG_temp0, CF_SET);
+                uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_CF_SET);
                 jump_uop2 = uop_CMP_IMM_JNZ_DEST(ir, IREG_temp0, 0);
-                uop_CALL_FUNC_RESULT(ir, IREG_temp0, ZF_SET);
+                uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_ZF_SET);
                 jump_uop = uop_CMP_IMM_JNZ_DEST(ir, IREG_temp0, 0);
             } else {
-                uop_CALL_FUNC_RESULT(ir, IREG_temp0, CF_SET);
+                uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_CF_SET);
                 jump_uop2 = uop_CMP_IMM_JNZ_DEST(ir, IREG_temp0, 0);
-                uop_CALL_FUNC_RESULT(ir, IREG_temp0, ZF_SET);
+                uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_ZF_SET);
                 jump_uop = uop_CMP_IMM_JZ_DEST(ir, IREG_temp0, 0);
             }
             break;
@@ -379,14 +380,14 @@ ropJNBE_common(codeblock_t *block, ir_data_t *ir, uint32_t dest_addr, uint32_t n
         case FLAGS_UNKNOWN:
         default:
             if (do_unroll) {
-                uop_CALL_FUNC_RESULT(ir, IREG_temp0, CF_SET);
+                uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_CF_SET);
                 jump_uop2 = uop_CMP_IMM_JNZ_DEST(ir, IREG_temp0, 0);
-                uop_CALL_FUNC_RESULT(ir, IREG_temp0, ZF_SET);
+                uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_ZF_SET);
                 jump_uop = uop_CMP_IMM_JZ_DEST(ir, IREG_temp0, 0);
             } else {
-                uop_CALL_FUNC_RESULT(ir, IREG_temp0, CF_SET);
+                uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_CF_SET);
                 jump_uop = uop_CMP_IMM_JNZ_DEST(ir, IREG_temp0, 0);
-                uop_CALL_FUNC_RESULT(ir, IREG_temp0, ZF_SET);
+                uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_ZF_SET);
                 jump_uop2 = uop_CMP_IMM_JNZ_DEST(ir, IREG_temp0, 0);
             }
             break;
@@ -459,7 +460,7 @@ ropJS_common(codeblock_t *block, ir_data_t *ir, uint32_t dest_addr, uint32_t nex
 
         case FLAGS_UNKNOWN:
         default:
-            uop_CALL_FUNC_RESULT(ir, IREG_temp0, NF_SET);
+            uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_NF_SET);
             if (do_unroll)
                 jump_uop = uop_CMP_IMM_JNZ_DEST(ir, IREG_temp0, 0);
             else
@@ -522,7 +523,7 @@ ropJNS_common(codeblock_t *block, ir_data_t *ir, uint32_t dest_addr, uint32_t ne
 
         case FLAGS_UNKNOWN:
         default:
-            uop_CALL_FUNC_RESULT(ir, IREG_temp0, NF_SET);
+            uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_NF_SET);
             if (do_unroll)
                 jump_uop = uop_CMP_IMM_JZ_DEST(ir, IREG_temp0, 0);
             else
@@ -540,7 +541,7 @@ ropJP_common(UNUSED(codeblock_t *block), ir_data_t *ir, uint32_t dest_addr, UNUS
 {
     int jump_uop;
 
-    uop_CALL_FUNC_RESULT(ir, IREG_temp0, PF_SET);
+    uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_PF_SET);
     jump_uop = uop_CMP_IMM_JZ_DEST(ir, IREG_temp0, 0);
     uop_MOV_IMM(ir, IREG_pc, dest_addr);
     uop_JMP(ir, codegen_exit_rout);
@@ -552,7 +553,7 @@ ropJNP_common(UNUSED(codeblock_t *block), ir_data_t *ir, uint32_t dest_addr, UNU
 {
     int jump_uop;
 
-    uop_CALL_FUNC_RESULT(ir, IREG_temp0, PF_SET);
+    uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_PF_SET);
     jump_uop = uop_CMP_IMM_JNZ_DEST(ir, IREG_temp0, 0);
     uop_MOV_IMM(ir, IREG_pc, dest_addr);
     uop_JMP(ir, codegen_exit_rout);
@@ -728,13 +729,13 @@ ropJLE_common(codeblock_t *block, ir_data_t *ir, uint32_t dest_addr, uint32_t ne
         case FLAGS_UNKNOWN:
         default:
             if (do_unroll) {
-                uop_CALL_FUNC_RESULT(ir, IREG_temp0, ZF_SET);
+                uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_ZF_SET);
                 jump_uop2 = uop_CMP_IMM_JNZ_DEST(ir, IREG_temp0, 0);
                 uop_CALL_FUNC_RESULT(ir, IREG_temp0, NF_SET_01);
                 uop_CALL_FUNC_RESULT(ir, IREG_temp1, VF_SET_01);
                 jump_uop = uop_CMP_JNZ_DEST(ir, IREG_temp0, IREG_temp1);
             } else {
-                uop_CALL_FUNC_RESULT(ir, IREG_temp0, ZF_SET);
+                uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_ZF_SET);
                 jump_uop2 = uop_CMP_IMM_JNZ_DEST(ir, IREG_temp0, 0);
                 uop_CALL_FUNC_RESULT(ir, IREG_temp0, NF_SET_01);
                 uop_CALL_FUNC_RESULT(ir, IREG_temp1, VF_SET_01);
@@ -791,13 +792,13 @@ ropJNLE_common(codeblock_t *block, ir_data_t *ir, uint32_t dest_addr, uint32_t n
         case FLAGS_UNKNOWN:
         default:
             if (do_unroll) {
-                uop_CALL_FUNC_RESULT(ir, IREG_temp0, ZF_SET);
+                uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_ZF_SET);
                 jump_uop2 = uop_CMP_IMM_JNZ_DEST(ir, IREG_temp0, 0);
                 uop_CALL_FUNC_RESULT(ir, IREG_temp0, NF_SET_01);
                 uop_CALL_FUNC_RESULT(ir, IREG_temp1, VF_SET_01);
                 jump_uop = uop_CMP_JZ_DEST(ir, IREG_temp0, IREG_temp1);
             } else {
-                uop_CALL_FUNC_RESULT(ir, IREG_temp0, ZF_SET);
+                uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_ZF_SET);
                 jump_uop2 = uop_CMP_IMM_JNZ_DEST(ir, IREG_temp0, 0);
                 uop_CALL_FUNC_RESULT(ir, IREG_temp0, NF_SET_01);
                 uop_CALL_FUNC_RESULT(ir, IREG_temp1, VF_SET_01);
@@ -974,7 +975,7 @@ ropLOOPE(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), UNUSED(uint3
         jump_uop = uop_CMP_IMM_JZ_DEST(ir, IREG_CX, 0);
     }
     if (!codegen_flags_changed || !flags_res_valid()) {
-        uop_CALL_FUNC_RESULT(ir, IREG_temp0, ZF_SET);
+        uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_ZF_SET);
         jump_uop2 = uop_CMP_IMM_JZ_DEST(ir, IREG_temp0, 0);
     } else {
         jump_uop2 = uop_CMP_IMM_JNZ_DEST(ir, IREG_flags_res, 0);
@@ -1007,7 +1008,7 @@ ropLOOPNE(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), UNUSED(uint
         jump_uop = uop_CMP_IMM_JZ_DEST(ir, IREG_CX, 0);
     }
     if (!codegen_flags_changed || !flags_res_valid()) {
-        uop_CALL_FUNC_RESULT(ir, IREG_temp0, ZF_SET);
+        uop_CALL_FUNC_RESULT(ir, IREG_temp0, jit_ZF_SET);
         jump_uop2 = uop_CMP_IMM_JNZ_DEST(ir, IREG_temp0, 0);
     } else {
         jump_uop2 = uop_CMP_IMM_JZ_DEST(ir, IREG_flags_res, 0);

--- a/src/codegen_new/codegen_ops_jit_wrappers.h
+++ b/src/codegen_new/codegen_ops_jit_wrappers.h
@@ -1,0 +1,68 @@
+/*
+ * codegen_ops_jit_wrappers.h — noinline wrappers for JIT function pointers
+ *
+ * GCC on ARM64 may merge or eliminate out-of-line copies of static __inline
+ * functions. When the address of such a function is taken and stored as a
+ * JIT uop operand (via uop_CALL_FUNC / uop_CALL_FUNC_RESULT), the emitted
+ * code ends up calling a merged symbol that may point to the wrong function
+ * or may be eliminated entirely.
+ *
+ * Every static __inline function whose address is passed to uop_CALL_FUNC*
+ * MUST have an noinline wrapper here.  The wrapper is what the JIT calls at
+ * runtime — the real inline body is still available for normal C call sites.
+ *
+ * Include this header in each codegen_ops_*.c that needs one of the wrappers.
+ * The including .c file MUST already include x86_flags.h before this header.
+ */
+#ifndef CODEGEN_OPS_JIT_WRAPPERS_H
+#define CODEGEN_OPS_JIT_WRAPPERS_H
+
+#define JIT_WRAPPER __attribute__((noinline, used))
+
+/* --- flags_rebuild family (void → void) --- */
+
+static JIT_WRAPPER void
+jit_flags_rebuild(void)
+{
+    flags_rebuild();
+}
+
+static JIT_WRAPPER void
+jit_flags_rebuild_c(void)
+{
+    flags_rebuild_c();
+}
+
+/* --- individual flag test functions (void → int) --- */
+
+static JIT_WRAPPER int
+jit_CF_SET(void)
+{
+    return CF_SET();
+}
+
+static JIT_WRAPPER int
+jit_NF_SET(void)
+{
+    return NF_SET();
+}
+
+static JIT_WRAPPER int
+jit_PF_SET(void)
+{
+    return PF_SET();
+}
+
+static JIT_WRAPPER int
+jit_VF_SET(void)
+{
+    return VF_SET();
+}
+
+static JIT_WRAPPER int
+jit_ZF_SET(void)
+{
+    return ZF_SET();
+}
+
+#endif /* CODEGEN_OPS_JIT_WRAPPERS_H */

--- a/src/codegen_new/codegen_ops_misc.c
+++ b/src/codegen_new/codegen_ops_misc.c
@@ -13,6 +13,7 @@
 #include "codegen_ir.h"
 #include "codegen_ops.h"
 #include "codegen_ops_helpers.h"
+#include "codegen_ops_jit_wrappers.h"
 #include "codegen_ops_misc.h"
 
 uint32_t
@@ -276,7 +277,7 @@ rebuild_c(ir_data_t *ir)
     }
 
     if (needs_rebuild) {
-        uop_CALL_FUNC(ir, flags_rebuild_c);
+        uop_CALL_FUNC(ir, jit_flags_rebuild_c);
     }
 }
 
@@ -578,21 +579,21 @@ ropLxS(LSS, &cpu_state.seg_ss)
 uint32_t
 ropCLC(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), UNUSED(uint32_t fetchdat), UNUSED(uint32_t op_32), uint32_t op_pc)
 {
-    uop_CALL_FUNC(ir, flags_rebuild);
+    uop_CALL_FUNC(ir, jit_flags_rebuild);
     uop_AND_IMM(ir, IREG_flags, IREG_flags, ~C_FLAG);
     return op_pc;
 }
 uint32_t
 ropCMC(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), UNUSED(uint32_t fetchdat), UNUSED(uint32_t op_32), uint32_t op_pc)
 {
-    uop_CALL_FUNC(ir, flags_rebuild);
+    uop_CALL_FUNC(ir, jit_flags_rebuild);
     uop_XOR_IMM(ir, IREG_flags, IREG_flags, C_FLAG);
     return op_pc;
 }
 uint32_t
 ropSTC(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), UNUSED(uint32_t fetchdat), UNUSED(uint32_t op_32), uint32_t op_pc)
 {
-    uop_CALL_FUNC(ir, flags_rebuild);
+    uop_CALL_FUNC(ir, jit_flags_rebuild);
     uop_OR_IMM(ir, IREG_flags, IREG_flags, C_FLAG);
     return op_pc;
 }

--- a/src/codegen_new/codegen_ops_shift.c
+++ b/src/codegen_new/codegen_ops_shift.c
@@ -14,6 +14,7 @@
 #include "codegen_ir.h"
 #include "codegen_ops.h"
 #include "codegen_ops_helpers.h"
+#include "codegen_ops_jit_wrappers.h"
 #include "codegen_ops_shift.h"
 
 static uint32_t
@@ -24,14 +25,14 @@ shift_common_8(ir_data_t *ir, uint32_t fetchdat, uint32_t op_pc, x86seg *target_
 
         switch (fetchdat & 0x38) {
             case 0x00: /*ROL*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROL_IMM(ir, IREG_8(dest_reg), IREG_8(dest_reg), count);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROL8);
                 uop_MOVZX(ir, IREG_flags_res, IREG_8(dest_reg));
                 break;
 
             case 0x08: /*ROR*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROR_IMM(ir, IREG_8(dest_reg), IREG_8(dest_reg), count);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROR8);
                 uop_MOVZX(ir, IREG_flags_res, IREG_8(dest_reg));
@@ -68,7 +69,7 @@ shift_common_8(ir_data_t *ir, uint32_t fetchdat, uint32_t op_pc, x86seg *target_
     } else {
         switch (fetchdat & 0x38) {
             case 0x00: /*ROL*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROL_IMM(ir, IREG_temp0_B, IREG_temp0_B, count);
                 uop_MEM_STORE_REG(ir, ireg_seg_base(target_seg), IREG_eaaddr, IREG_temp0_B);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROL8);
@@ -76,7 +77,7 @@ shift_common_8(ir_data_t *ir, uint32_t fetchdat, uint32_t op_pc, x86seg *target_
                 break;
 
             case 0x08: /*ROR*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROR_IMM(ir, IREG_temp0_B, IREG_temp0_B, count);
                 uop_MEM_STORE_REG(ir, ireg_seg_base(target_seg), IREG_eaaddr, IREG_temp0_B);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROR8);
@@ -128,14 +129,14 @@ shift_common_16(ir_data_t *ir, uint32_t fetchdat, uint32_t op_pc, x86seg *target
 
         switch (fetchdat & 0x38) {
             case 0x00: /*ROL*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROL_IMM(ir, IREG_16(dest_reg), IREG_16(dest_reg), count);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROL16);
                 uop_MOVZX(ir, IREG_flags_res, IREG_16(dest_reg));
                 break;
 
             case 0x08: /*ROR*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROR_IMM(ir, IREG_16(dest_reg), IREG_16(dest_reg), count);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROR16);
                 uop_MOVZX(ir, IREG_flags_res, IREG_16(dest_reg));
@@ -172,7 +173,7 @@ shift_common_16(ir_data_t *ir, uint32_t fetchdat, uint32_t op_pc, x86seg *target
     } else {
         switch (fetchdat & 0x38) {
             case 0x00: /*ROL*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROL_IMM(ir, IREG_temp0_W, IREG_temp0_W, count);
                 uop_MEM_STORE_REG(ir, ireg_seg_base(target_seg), IREG_eaaddr, IREG_temp0_W);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROL16);
@@ -180,7 +181,7 @@ shift_common_16(ir_data_t *ir, uint32_t fetchdat, uint32_t op_pc, x86seg *target
                 break;
 
             case 0x08: /*ROR*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROR_IMM(ir, IREG_temp0_W, IREG_temp0_W, count);
                 uop_MEM_STORE_REG(ir, ireg_seg_base(target_seg), IREG_eaaddr, IREG_temp0_W);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROR16);
@@ -231,14 +232,14 @@ shift_common_32(ir_data_t *ir, uint32_t fetchdat, uint32_t op_pc, x86seg *target
 
         switch (fetchdat & 0x38) {
             case 0x00: /*ROL*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROL_IMM(ir, IREG_32(dest_reg), IREG_32(dest_reg), count);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROL32);
                 uop_MOV(ir, IREG_flags_res, IREG_32(dest_reg));
                 break;
 
             case 0x08: /*ROR*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROR_IMM(ir, IREG_32(dest_reg), IREG_32(dest_reg), count);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROR32);
                 uop_MOV(ir, IREG_flags_res, IREG_32(dest_reg));
@@ -275,7 +276,7 @@ shift_common_32(ir_data_t *ir, uint32_t fetchdat, uint32_t op_pc, x86seg *target
     } else {
         switch (fetchdat & 0x38) {
             case 0x00: /*ROL*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROL_IMM(ir, IREG_temp0, IREG_temp0, count);
                 uop_MEM_STORE_REG(ir, ireg_seg_base(target_seg), IREG_eaaddr, IREG_temp0);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROL32);
@@ -283,7 +284,7 @@ shift_common_32(ir_data_t *ir, uint32_t fetchdat, uint32_t op_pc, x86seg *target
                 break;
 
             case 0x08: /*ROR*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROR_IMM(ir, IREG_temp0, IREG_temp0, count);
                 uop_MEM_STORE_REG(ir, ireg_seg_base(target_seg), IREG_eaaddr, IREG_temp0);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROR32);
@@ -335,14 +336,14 @@ shift_common_variable_32(ir_data_t *ir, uint32_t fetchdat, uint32_t op_pc, x86se
 
         switch (fetchdat & 0x38) {
             case 0x00: /*ROL*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROL(ir, IREG_32(dest_reg), IREG_32(dest_reg), count_reg);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROL32);
                 uop_MOV(ir, IREG_flags_res, IREG_32(dest_reg));
                 break;
 
             case 0x08: /*ROR*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROR(ir, IREG_32(dest_reg), IREG_32(dest_reg), count_reg);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROR32);
                 uop_MOV(ir, IREG_flags_res, IREG_32(dest_reg));
@@ -379,7 +380,7 @@ shift_common_variable_32(ir_data_t *ir, uint32_t fetchdat, uint32_t op_pc, x86se
     } else {
         switch (fetchdat & 0x38) {
             case 0x00: /*ROL*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROL(ir, IREG_temp0, IREG_temp0, count_reg);
                 uop_MEM_STORE_REG(ir, ireg_seg_base(target_seg), IREG_eaaddr, IREG_temp0);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROL32);
@@ -387,7 +388,7 @@ shift_common_variable_32(ir_data_t *ir, uint32_t fetchdat, uint32_t op_pc, x86se
                 break;
 
             case 0x08: /*ROR*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROR(ir, IREG_temp0, IREG_temp0, count_reg);
                 uop_MEM_STORE_REG(ir, ireg_seg_base(target_seg), IREG_eaaddr, IREG_temp0);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROR32);
@@ -587,14 +588,14 @@ ropD2(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchd
 
         switch (fetchdat & 0x38) {
             case 0x00: /*ROL*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROL(ir, IREG_8(dest_reg), IREG_8(dest_reg), IREG_temp2);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROL8);
                 uop_MOVZX(ir, IREG_flags_res, IREG_8(dest_reg));
                 break;
 
             case 0x08: /*ROR*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROR(ir, IREG_8(dest_reg), IREG_8(dest_reg), IREG_temp2);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROR8);
                 uop_MOVZX(ir, IREG_flags_res, IREG_8(dest_reg));
@@ -638,7 +639,7 @@ ropD2(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchd
 
         switch (fetchdat & 0x38) {
             case 0x00: /*ROL*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROL(ir, IREG_temp0_B, IREG_temp0_B, IREG_temp2);
                 uop_MEM_STORE_REG(ir, ireg_seg_base(target_seg), IREG_eaaddr, IREG_temp0_B);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROL8);
@@ -646,7 +647,7 @@ ropD2(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchd
                 break;
 
             case 0x08: /*ROR*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROR(ir, IREG_temp0_B, IREG_temp0_B, IREG_temp2);
                 uop_MEM_STORE_REG(ir, ireg_seg_base(target_seg), IREG_eaaddr, IREG_temp0_B);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROR8);
@@ -707,14 +708,14 @@ ropD3_w(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetc
 
         switch (fetchdat & 0x38) {
             case 0x00: /*ROL*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROL(ir, IREG_16(dest_reg), IREG_16(dest_reg), IREG_temp2);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROL16);
                 uop_MOVZX(ir, IREG_flags_res, IREG_16(dest_reg));
                 break;
 
             case 0x08: /*ROR*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROR(ir, IREG_16(dest_reg), IREG_16(dest_reg), IREG_temp2);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROR16);
                 uop_MOVZX(ir, IREG_flags_res, IREG_16(dest_reg));
@@ -758,7 +759,7 @@ ropD3_w(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetc
 
         switch (fetchdat & 0x38) {
             case 0x00: /*ROL*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROL(ir, IREG_temp0_W, IREG_temp0_W, IREG_temp2);
                 uop_MEM_STORE_REG(ir, ireg_seg_base(target_seg), IREG_eaaddr, IREG_temp0_W);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROL16);
@@ -766,7 +767,7 @@ ropD3_w(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetc
                 break;
 
             case 0x08: /*ROR*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROR(ir, IREG_temp0_W, IREG_temp0_W, IREG_temp2);
                 uop_MEM_STORE_REG(ir, ireg_seg_base(target_seg), IREG_eaaddr, IREG_temp0_W);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROR16);
@@ -827,14 +828,14 @@ ropD3_l(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetc
 
         switch (fetchdat & 0x38) {
             case 0x00: /*ROL*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROL(ir, IREG_32(dest_reg), IREG_32(dest_reg), IREG_temp2);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROL32);
                 uop_MOV(ir, IREG_flags_res, IREG_32(dest_reg));
                 break;
 
             case 0x08: /*ROR*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROR(ir, IREG_32(dest_reg), IREG_32(dest_reg), IREG_temp2);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROR32);
                 uop_MOV(ir, IREG_flags_res, IREG_32(dest_reg));
@@ -878,7 +879,7 @@ ropD3_l(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetc
 
         switch (fetchdat & 0x38) {
             case 0x00: /*ROL*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROL(ir, IREG_temp0, IREG_temp0, IREG_temp2);
                 uop_MEM_STORE_REG(ir, ireg_seg_base(target_seg), IREG_eaaddr, IREG_temp0);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROL32);
@@ -886,7 +887,7 @@ ropD3_l(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetc
                 break;
 
             case 0x08: /*ROR*/
-                uop_CALL_FUNC(ir, flags_rebuild);
+                uop_CALL_FUNC(ir, jit_flags_rebuild);
                 uop_ROR(ir, IREG_temp0, IREG_temp0, IREG_temp2);
                 uop_MEM_STORE_REG(ir, ireg_seg_base(target_seg), IREG_eaaddr, IREG_temp0);
                 uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ROR32);

--- a/src/codegen_new/codegen_ops_stack.c
+++ b/src/codegen_new/codegen_ops_stack.c
@@ -13,6 +13,7 @@
 #include "codegen_ir.h"
 #include "codegen_ops.h"
 #include "codegen_ops_helpers.h"
+#include "codegen_ops_jit_wrappers.h"
 #include "codegen_ops_misc.h"
 
 uint32_t
@@ -388,7 +389,7 @@ ropPUSHF(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), UNUS
         return 0;
 
     uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
-    uop_CALL_FUNC(ir, flags_rebuild);
+    uop_CALL_FUNC(ir, jit_flags_rebuild);
     sp_reg = LOAD_SP_WITH_OFFSET(ir, -2);
     uop_AND_IMM(ir, IREG_flags, IREG_flags, 0x7fd5);
     uop_OR_IMM(ir, IREG_flags, IREG_flags, 0x0002);
@@ -406,7 +407,7 @@ ropPUSHFD(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), UNU
         return 0;
 
     uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
-    uop_CALL_FUNC(ir, flags_rebuild);
+    uop_CALL_FUNC(ir, jit_flags_rebuild);
 
     uop_AND_IMM(ir, IREG_flags, IREG_flags, 0x7fd5);
     uop_OR_IMM(ir, IREG_flags, IREG_flags, 0x0002);


### PR DESCRIPTION
Summary
=======
Fixes the following issues I have encountered while using the codegen-new:
* [stack misalignment in JIT load slow-path on Linux](https://github.com/86Box/86Box/commit/7439eabcd99de85f2ecf5f549d2db80e0daf3326)
* [missing truncation paths to codegen_MOV](https://github.com/86Box/86Box/commit/f0a4dba5a1d3dd77246da113bc379c3601c9ba88)
* [linker optimization issues](https://github.com/86Box/86Box/commit/59819458863ffce0a42b14ed8dad11840b979c05)

I ran into the linker optimization issues (function inlined, stale pointer) when compiling with lto=auto on GCC.
GCC 15.2.0 also aligns differently, causing stack misalignment bug in JIT load, crashing the game "Incoming" on startup.

Checklist
=========
* [x] Closes N/A
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [x] This pull request doesn't require changes to the ROM set
* [x] This pull request doesn't require changes to the asset set
 
