### PR TITLE
Lucky Star LS-486E: minimum 2 MB RAM

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -11572,7 +11572,7 @@ const machine_t machines[] = {
         .bus_flags = MACHINE_PCI,
         .flags     = MACHINE_PS2_KBC | MACHINE_IDE_DUAL | MACHINE_APM,
         .ram       = {
-            .min  = 1024,
+            .min  = 2048,
             .max  = 131072,
             .step = 1024
         },


### PR DESCRIPTION
Summary
=======
BIOS beeps indefinitely if there's only one 1 MB RAM.

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set