### PR TITLE
Abort GitHub release check on empty/invalid JSON

### DIFF
--- a/src/qt/qt_updatecheck.cpp
+++ b/src/qt/qt_updatecheck.cpp
@@ -104,6 +104,7 @@ UpdateCheck::githubDownloadComplete(const QString &filename, const QVariant &var
     QString    latestVersion           = "0.0";
     if (!githubReleaseListResult.has_value() || githubReleaseListResult.value().isEmpty()) {
         generalDownloadError(generalError);
+        return;
     }
     auto githubReleaseList = githubReleaseListResult.value();
     // Warning: this check (using the tag name) relies on a consistent naming scheme: "v<number>"


### PR DESCRIPTION
Summary
=======
Yesterday, during a GitHub outage (an increasingly common occurrence), I had 86Box (v5.3) crash just after startup, right after it reported the following:

```
void Downloader::onResult() Downloaded complete: file written to  "/tmp/github_releases.json"
Update check failed with the following error: "Unable to determine release information"
```

I forgot to check what were the actual contents of the JSON file, but I managed to reproduce the crash and traced the issue to `UpdateCheck::githubDownloadComplete`. 

When the JSON is not really JSON, it crashed at `auto githubReleaseList = githubReleaseListResult.value();`. 

When the JSON array is empty, the crash occurs at `first()` in: `latestVersion = githubReleaseList.first().tag_name.replace("v", "");`

Now it will just return from the function after emitting the error message.

(I have no experience with QT but it didn't look like there was anything to clean up or notify)

Checklist
=========
* [ ] ~~Closes #xxx~~
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] ~~This pull request requires changes to the ROM set~~
  * [ ] ~~I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/~~
* [ ] ~~This pull request requires changes to the asset set~~
  * [ ] ~~I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/~~

References
==========
N/A
