### PR TITLE
ARM64 dynarec/codegen fixes and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,31 @@ CMakeLists.txt.user
 
 # Jetbrains CLion
 .idea
+docs/perf-artifacts/*
+tools/win98-*
+
+docs/rage128*
+docs/reference/*
+V4_4500_AGP_SD_1.18.rom
+docs/videoco*
+scripts/win9*
+research/solo1*
+appimage-x86_*
+scripts/dynarec/*
+scripts/build-and-sign.sh
+scripts/clean-build-and-sign.sh
+scripts/setup-and-build.sh
+scripts/test-with-vm.sh
+
+# Local perf/tooling artifacts (keep source clean for upstream PRs)
+docs/perf-artifacts/**
+docs/rage128-pro/artifacts/**
+research/**
+appimage-x86_64-cross/**
+scripts/dynarec/**/*.log
+scripts/dynarec/**/*.txt
+scripts/dynarec/**/*.csv
+scripts/dynarec/**/*.trace
+scripts/dynarec/.analyze-s03a-log.bin
+*.trace
+*.dtrace

--- a/.gitignore
+++ b/.gitignore
@@ -67,31 +67,3 @@ CMakeLists.txt.user
 
 # Jetbrains CLion
 .idea
-docs/perf-artifacts/*
-tools/win98-*
-
-docs/rage128*
-docs/reference/*
-V4_4500_AGP_SD_1.18.rom
-docs/videoco*
-scripts/win9*
-research/solo1*
-appimage-x86_*
-scripts/dynarec/*
-scripts/build-and-sign.sh
-scripts/clean-build-and-sign.sh
-scripts/setup-and-build.sh
-scripts/test-with-vm.sh
-
-# Local perf/tooling artifacts (keep source clean for upstream PRs)
-docs/perf-artifacts/**
-docs/rage128-pro/artifacts/**
-research/**
-appimage-x86_64-cross/**
-scripts/dynarec/**/*.log
-scripts/dynarec/**/*.txt
-scripts/dynarec/**/*.csv
-scripts/dynarec/**/*.trace
-scripts/dynarec/.analyze-s03a-log.bin
-*.trace
-*.dtrace

--- a/src/86box.c
+++ b/src/86box.c
@@ -2061,7 +2061,7 @@ pc_run(void)
 
         /*
          * Use real sample duration for title speed percent so delayed timer
-         * callbacks do not create false dip/rebound spikes in telemetry.
+         * callbacks do not create false dip/rebound spikes in speed reporting.
          */
         numerator     = (int64_t) fps * 100000LL;
         speed_percent = (int) ((numerator + ((int64_t) elapsed_ms * target_fps / 2)) /

--- a/src/86box.c
+++ b/src/86box.c
@@ -331,6 +331,7 @@ extern int writelnum;
 /* emulator % */
 int fps;
 int framecount;
+static uint32_t fps_sample_elapsed_ms = 1000;
 
 extern int CPUID;
 extern int output;
@@ -2049,7 +2050,22 @@ pc_run(void)
     }
 
     if (title_update) {
+        int      speed_percent;
+        int      target_fps;
+        uint32_t elapsed_ms;
+        int64_t  numerator;
+
         mouse_msg_idx = ((mouse_type == MOUSE_TYPE_NONE) || (mouse_input_mode >= 1)) ? 2 : !!mouse_capture;
+        target_fps    = force_10ms ? 100 : 1000;
+        elapsed_ms    = fps_sample_elapsed_ms ? fps_sample_elapsed_ms : 1;
+
+        /*
+         * Use real sample duration for title speed percent so delayed timer
+         * callbacks do not create false dip/rebound spikes in telemetry.
+         */
+        numerator     = (int64_t) fps * 100000LL;
+        speed_percent = (int) ((numerator + ((int64_t) elapsed_ms * target_fps / 2)) /
+                               ((int64_t) elapsed_ms * target_fps));
 #ifdef SCREENSHOT_MODE
         if (force_10ms)
             fps = ((fps + 2) / 5) * 5;
@@ -2061,7 +2077,7 @@ pc_run(void)
          * mouse_msg[] stores suffixes only on macOS (see update_mouse_msg).
          * Build the title without passing non-ASCII chars through swprintf.
          */
-        swprintf(temp, sizeof_w(temp), L"%i%%", fps / (force_10ms ? 1 : 10));
+        swprintf(temp, sizeof_w(temp), L"%i%%", speed_percent);
         if (mouse_msg[mouse_msg_idx][0]) {
             wcsncat(temp, L" - ", sizeof_w(temp) - wcslen(temp) - 1);
             wcsncat(temp, mouse_msg[mouse_msg_idx], sizeof_w(temp) - wcslen(temp) - 1);
@@ -2069,7 +2085,7 @@ pc_run(void)
         /* Needed due to modifying the UI on the non-main thread is a big no-no. */
         dispatch_async_f(dispatch_get_main_queue(), wcsdup((const wchar_t *) temp), _ui_window_title);
 #else
-        swprintf(temp, sizeof_w(temp), mouse_msg[mouse_msg_idx], fps / (force_10ms ? 1 : 10));
+        swprintf(temp, sizeof_w(temp), mouse_msg[mouse_msg_idx], speed_percent);
         ui_window_title(temp);
 #endif
         title_update = 0;
@@ -2080,6 +2096,14 @@ pc_run(void)
 void
 pc_onesec(void)
 {
+    static uint32_t last_sample_ms = 0;
+    uint32_t        now_ms         = plat_get_ticks();
+
+    fps_sample_elapsed_ms = last_sample_ms ? (now_ms - last_sample_ms) : 1000;
+    if (!fps_sample_elapsed_ms)
+        fps_sample_elapsed_ms = 1;
+    last_sample_ms = now_ms;
+
     fps        = framecount;
     framecount = 0;
 

--- a/src/codegen_new/codegen.c
+++ b/src/codegen_new/codegen.c
@@ -20,7 +20,6 @@
 #include "codegen_ops_helpers.h"
 
 #define MAX_INSTRUCTION_COUNT 50
-
 static struct {
     uint32_t pc;
     int      op_ssegs;

--- a/src/codegen_new/codegen.h
+++ b/src/codegen_new/codegen.h
@@ -38,6 +38,14 @@ typedef struct codeblock_t {
     uint16_t flags;
     uint8_t  ins;
     uint8_t  TOP;
+#if defined(__aarch64__) || defined(_M_ARM64)
+    /* ARM64-only: per-block retry counter used to delay NO_IMMEDIATES
+      promotion until churn repeats, reducing premature slow-immediate mode. */
+    uint8_t  dirty_list_recompile_hits;
+    /* ARM64-only: tracks the most recent dirty-list epoch seen by this
+      block so promotion can require a dense burst, not stale spaced-out hits. */
+    uint16_t dirty_list_last_epoch;
+#endif
     int      valid;
 
     /*Pointers for codeblock tree, used to search for blocks when hash lookup
@@ -65,6 +73,7 @@ extern codeblock_t *codeblock;
 extern uint16_t *codeblock_hash;
 
 extern uint8_t *block_write_data;
+
 
 /*Code block uses FPU*/
 #define CODEBLOCK_HAS_FPU 1

--- a/src/codegen_new/codegen_allocator.c
+++ b/src/codegen_new/codegen_allocator.c
@@ -200,3 +200,66 @@ codegen_allocator_clean_blocks(UNUSED(struct mem_block_t *block))
     }
 #endif
 }
+
+bool
+codegen_allocator_contains_host_ptr(const void *p)
+{
+    const uint8_t *ptr = (const uint8_t *) p;
+    uint8_t       *base;
+    size_t         size;
+
+    if (!mem_block_alloc || !ptr)
+        return false;
+
+    base = mem_block_alloc;
+    size = MEM_BLOCK_NR * MEM_BLOCK_SIZE;
+    return (ptr >= base) && (ptr < (base + size));
+}
+
+bool
+codegen_allocator_can_branch_imm14(const uint8_t *src_insn_addr, const void *dst)
+{
+    intptr_t offset;
+
+    if (!src_insn_addr || !dst)
+        return false;
+
+    /* AArch64 TBZ/TBNZ uses signed imm14 scaled by 4 bytes, so legal offsets
+       are [-2^15, 2^15) and must be 4-byte aligned. */
+    offset = (intptr_t) ((const uint8_t *) dst - src_insn_addr);
+    if (offset & 3)
+        return false;
+    return (offset >= -(1 << 15)) && (offset < (1 << 15));
+}
+
+bool
+codegen_allocator_can_branch_imm26(const uint8_t *src_insn_addr, const void *dst)
+{
+    intptr_t offset;
+
+    if (!src_insn_addr || !dst)
+        return false;
+
+    /* AArch64 B/BL uses signed imm26 scaled by 4 bytes, so legal offsets are
+       [-2^27, 2^27) and must be 4-byte aligned. */
+    offset = (intptr_t) ((const uint8_t *) dst - src_insn_addr);
+    if (offset & 3)
+        return false;
+    return (offset >= -(1 << 27)) && (offset < (1 << 27));
+}
+
+bool
+codegen_allocator_can_branch_imm19(const uint8_t *src_insn_addr, const void *dst)
+{
+    intptr_t offset;
+
+    if (!src_insn_addr || !dst)
+        return false;
+
+    /* AArch64 CBZ/CBNZ uses signed imm19 scaled by 4 bytes, so legal offsets
+       are [-2^20, 2^20) and must be 4-byte aligned. */
+    offset = (intptr_t) ((const uint8_t *) dst - src_insn_addr);
+    if (offset & 3)
+        return false;
+    return (offset >= -(1 << 20)) && (offset < (1 << 20));
+}

--- a/src/codegen_new/codegen_allocator.h
+++ b/src/codegen_new/codegen_allocator.h
@@ -1,6 +1,9 @@
 #ifndef _CODEGEN_ALLOCATOR_H_
 #define _CODEGEN_ALLOCATOR_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+
 /*The allocator handles all allocation of executable memory. Since the two-pass
   recompiler design makes applying hard limits to codeblock size difficult, the
   allocator allows memory to be provided as and when required.
@@ -31,6 +34,20 @@ void codegen_allocator_free(struct mem_block_t *block);
 uint8_t *codeblock_allocator_get_ptr(struct mem_block_t *block);
 /*Cache clean memory block list*/
 void codegen_allocator_clean_blocks(struct mem_block_t *block);
+
+/* Branch classification helpers:
+   - codegen_allocator_contains_host_ptr(): tells whether a host pointer targets
+     the JIT allocator arena (candidate for direct local branch).
+   - codegen_allocator_can_branch_imm14(): validates AArch64 TBZ/TBNZ immediate
+     branch range/alignment from a source instruction address to target.
+   - codegen_allocator_can_branch_imm19(): validates AArch64 CBZ/CBNZ immediate
+     branch range/alignment from a source instruction address to target.
+   - codegen_allocator_can_branch_imm26(): validates AArch64 B/BL immediate
+     branch range/alignment from a source instruction address to target. */
+bool codegen_allocator_contains_host_ptr(const void *p);
+bool codegen_allocator_can_branch_imm14(const uint8_t *src_insn_addr, const void *dst);
+bool codegen_allocator_can_branch_imm19(const uint8_t *src_insn_addr, const void *dst);
+bool codegen_allocator_can_branch_imm26(const uint8_t *src_insn_addr, const void *dst);
 
 extern int codegen_allocator_usage;
 

--- a/src/codegen_new/codegen_backend_arm64.h
+++ b/src/codegen_new/codegen_backend_arm64.h
@@ -11,6 +11,9 @@
 
 #define BLOCK_MAX   0x3c0
 
+/* Let generic uop emitters use backend-specific immediate store helpers. */
+#define CODEGEN_BACKEND_HAS_MOV_IMM
+
 void host_arm64_BLR(codeblock_t *block, int addr_reg);
 void host_arm64_CBNZ(codeblock_t *block, int reg, uintptr_t dest);
 void host_arm64_MOVK_IMM(codeblock_t *block, int reg, uint32_t imm_data);

--- a/src/codegen_new/codegen_backend_arm64_ops.c
+++ b/src/codegen_new/codegen_backend_arm64_ops.c
@@ -2,6 +2,8 @@
 
 #    include <inttypes.h>
 #    include <stdint.h>
+#    include <stdlib.h>
+#    include <string.h>
 #    include <86box/86box.h>
 #    include "cpu.h"
 #    include <86box/mem.h>
@@ -46,6 +48,7 @@
 #    define OPCODE_ADDX_IMM           (0x91 << OPCODE_SHIFT)
 #    define OPCODE_ADR                (0x10 << OPCODE_SHIFT)
 #    define OPCODE_B                  (0x14 << OPCODE_SHIFT)
+#    define OPCODE_BL                 (0x94 << OPCODE_SHIFT)
 #    define OPCODE_BCOND              (0x54 << OPCODE_SHIFT)
 #    define OPCODE_CBNZ               (0xb5 << OPCODE_SHIFT)
 #    define OPCODE_CBZ                (0xb4 << OPCODE_SHIFT)
@@ -61,6 +64,7 @@
 #    define OPCODE_AND_IMM            (0x024 << 23)
 #    define OPCODE_ANDS_IMM           (0x0e4 << 23)
 #    define OPCODE_EOR_IMM            (0x0a4 << 23)
+#    define OPCODE_MOVN_W             (0x025 << 23)
 #    define OPCODE_MOVK_W             (0x0e5 << 23)
 #    define OPCODE_MOVK_X             (0x1e5 << 23)
 #    define OPCODE_MOVZ_W             (0x0a5 << 23)
@@ -126,6 +130,7 @@
 #    define OPCODE_FABS_D             (0x1e60c000)
 #    define OPCODE_FADD_D             (0x1e602800)
 #    define OPCODE_FADD_V2S           (0x0e20d400)
+#    define OPCODE_FADDP_V2S          (0x2e20d400)
 #    define OPCODE_FCMEQ_V2S          (0x0e20e400)
 #    define OPCODE_FCMGE_V2S          (0x2e20e400)
 #    define OPCODE_FCMGT_V2S          (0x2ea0e400)
@@ -186,12 +191,15 @@
 #    define OPCODE_SQXTN_V8B_8H       (0x0e214800)
 #    define OPCODE_SQXTUN_V8B_8H      (0x2e212800)
 #    define OPCODE_SQXTN_V4H_4S       (0x0e614800)
+#    define OPCODE_XTN_V8B_8H         (0x0e212800)
+#    define OPCODE_XTN_V4H_4S         (0x0e612800)
 #    define OPCODE_SHL_VD             (0x0f005400)
 #    define OPCODE_SHL_VQ             (0x4f005400)
 #    define OPCODE_SHRN               (0x0f008400)
 #    define OPCODE_SMULL_V4S_4H       (0x0e60c000)
 #    define OPCODE_SSHR_VD            (0x0f000400)
 #    define OPCODE_SSHR_VQ            (0x4f000400)
+#    define OPCODE_SRSHR_VQ           (0x4f302400)
 #    define OPCODE_STR_REG            (0xb8206800)
 #    define OPCODE_STRB_REG           (0x38206800)
 #    define OPCODE_STRH_REG           (0x78206800)
@@ -207,6 +215,7 @@
 #    define OPCODE_UQSUB_V4H          (0x2e602c00)
 #    define OPCODE_UQXTN_V8B_8H       (0x2e214800)
 #    define OPCODE_UQXTN_V4H_4S       (0x2e614800)
+#    define OPCODE_URHADD_V8B         (0x2e201400)
 #    define OPCODE_USHR_VD            (0x2f000400)
 #    define OPCODE_USHR_VQ            (0x6f000400)
 #    define OPCODE_ZIP1_V8B           (0x0e003800)
@@ -251,17 +260,6 @@
 
 #    define DUP_ELEMENT(element)      ((element) << 19)
 
-/*Returns true if offset fits into 19 bits*/
-static int
-offset_is_19bit(int offset)
-{
-    if (offset >= (1 << (18 + 2)))
-        return 0;
-    if (offset < -(1 << (18 + 2)))
-        return 0;
-    return 1;
-}
-
 /*Returns true if offset fits into 26 bits*/
 static int
 offset_is_26bit(int offset)
@@ -273,10 +271,42 @@ offset_is_26bit(int offset)
     return 1;
 }
 
+/* Decode signed byte displacement from a B.cond immediate field. */
+static inline int
+bcond_offset_bytes(uint32_t opcode)
+{
+    int imm19 = (int) ((opcode >> 5) & 0x7ffff);
+
+    if (imm19 & (1 << 18))
+        imm19 |= ~0x7ffff;
+    return imm19 << 2;
+}
+
+/* Decode signed byte displacement from a TBZ/TBNZ immediate field. */
+static inline int
+tbxz_offset_bytes(uint32_t opcode)
+{
+    int imm14 = (int) ((opcode >> 5) & 0x3fff);
+
+    if (imm14 & (1 << 13))
+        imm14 |= ~0x3fff;
+    return imm14 << 2;
+}
+
 static inline int
 imm_is_imm16(uint32_t imm_data)
 {
     if (!(imm_data & 0xffff0000) || !(imm_data & 0x0000ffff))
+        return 1;
+    return 0;
+}
+
+static inline int
+imm_is_movn16(uint32_t imm_data)
+{
+    /* MOVN can materialize a 32-bit immediate in one instruction when one halfword is
+       all ones, because non-selected halfwords are also filled with ones. */
+    if ((imm_data & 0xffff0000u) == 0xffff0000u || (imm_data & 0x0000ffffu) == 0x0000ffffu)
         return 1;
     return 0;
 }
@@ -316,6 +346,7 @@ codegen_alloc(codeblock_t *block, int size)
     if (block_pos >= (BLOCK_MAX - size))
         codegen_allocate_new_block(block);
 }
+
 
 void
 host_arm64_ADD_IMM(codeblock_t *block, int dst_reg, int src_n_reg, uint32_t imm_data)
@@ -581,8 +612,54 @@ host_arm64_BVS_(codeblock_t *block)
 void
 host_arm64_branch_set_offset(uint32_t *opcode, void *dest)
 {
-    int offset = (uintptr_t) dest - (uintptr_t) opcode;
-    *opcode |= OFFSET26(offset);
+    uint32_t *cond_opcode        = opcode - 1;
+    uint32_t  branch_insn        = *opcode;
+    uint32_t  cond_insn          = *cond_opcode;
+    int       offset26           = (int) ((uintptr_t) dest - (uintptr_t) opcode);
+    int       is_bcond_template  = 0;
+    int       is_tbxz_template   = 0;
+
+    /* Most branch patch sites come from B.cond-skip + B templates emitted by
+       host_arm64_B??_ helpers. Only collapse/track when we see that exact
+       template shape to avoid touching unrelated neighboring instructions. */
+    if (((branch_insn & 0xfc000000u) == OPCODE_B) &&
+        ((cond_insn & 0xff000010u) == OPCODE_BCOND) &&
+        (bcond_offset_bytes(cond_insn) == 8)) {
+        uint8_t *cond_src = (uint8_t *) cond_opcode;
+
+        is_bcond_template = 1;
+        if (codegen_allocator_can_branch_imm19(cond_src, dest)) {
+            uint32_t inv_cond = cond_insn & 0xf;
+            uint32_t cond     = inv_cond ^ 1u;
+            int      offset19 = (int) ((uintptr_t) dest - (uintptr_t) cond_opcode);
+
+            *cond_opcode = OPCODE_BCOND | (cond & 0xfu) | OFFSET19(offset19);
+            *opcode      = OPCODE_NOP;
+            return;
+        }
+    }
+
+    /* Apply the same guarded template collapse to TBZ/TBNZ skip+branch forms,
+       which are used by a subset of ARM64 uop patch paths (e.g., tag tests). */
+    if (((branch_insn & 0xfc000000u) == OPCODE_B) &&
+        ((cond_insn & 0x7e000000u) == OPCODE_TBZ) &&
+        (tbxz_offset_bytes(cond_insn) == 8)) {
+        uint8_t *cond_src = (uint8_t *) cond_opcode;
+
+        is_tbxz_template = 1;
+        if (codegen_allocator_can_branch_imm14(cond_src, dest)) {
+            uint32_t flipped  = cond_insn ^ (1u << 24);
+            int      offset14 = (int) ((uintptr_t) dest - (uintptr_t) cond_opcode);
+
+            *cond_opcode = (flipped & ~0x0007ffe0u) | OFFSET14(offset14);
+            *opcode      = OPCODE_NOP;
+            return;
+        }
+    }
+
+    *opcode = OPCODE_B | OFFSET26(offset26);
+    (void) is_bcond_template;
+    (void) is_tbxz_template;
 }
 
 void
@@ -594,8 +671,34 @@ host_arm64_BR(codeblock_t *block, int addr_reg)
 void
 host_arm64_BEQ(codeblock_t *block, void *dest)
 {
-    uint32_t *opcode = host_arm64_BEQ_(block);
-    host_arm64_branch_set_offset(opcode, dest);
+    uint8_t *branch_src;
+    int      is_local;
+
+    /* Prefer direct B.EQ when imm19-reachable, then bridge via inverse
+       conditional + B(imm26), and preserve MOVX+BR fallback for far targets. */
+    codegen_alloc(block, 24);
+    branch_src = &block_write_data[block_pos];
+    is_local   = codegen_allocator_contains_host_ptr(dest);
+
+    if (codegen_allocator_can_branch_imm19(branch_src, dest)) {
+        intptr_t offset = (intptr_t) ((uint8_t *) dest - branch_src);
+        codegen_addlong(block, OPCODE_BCOND | COND_EQ | OFFSET19(offset));
+        return;
+    }
+
+    if (codegen_allocator_can_branch_imm26(branch_src + 4, dest)) {
+        intptr_t offset;
+
+        codegen_addlong(block, OPCODE_BCOND | COND_NE | OFFSET19(8));
+        offset = (intptr_t) ((uint8_t *) dest - &block_write_data[block_pos]);
+        codegen_addlong(block, OPCODE_B | OFFSET26(offset));
+        return;
+    }
+
+    codegen_addlong(block, OPCODE_BCOND | COND_NE | OFFSET19(12));
+    host_arm64_MOVX_IMM(block, REG_X16, (uint64_t) dest);
+    host_arm64_BR(block, REG_X16);
+    (void) is_local;
 }
 
 void
@@ -607,18 +710,32 @@ host_arm64_BIC_REG_V(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_r
 void
 host_arm64_CBNZ(codeblock_t *block, int reg, uintptr_t dest)
 {
-    int offset;
+    uint8_t *cbnz_src;
+    void    *dst_ptr = (void *) dest;
+    int      is_local;
+    intptr_t offset;
 
-    codegen_alloc(block, 4);
-    offset = dest - (uintptr_t) &block_write_data[block_pos];
-    if (offset_is_19bit(offset)) {
+    codegen_alloc(block, 12);
+    cbnz_src = &block_write_data[block_pos];
+    is_local = codegen_allocator_contains_host_ptr(dst_ptr);
+
+    if (codegen_allocator_can_branch_imm19(cbnz_src, dst_ptr)) {
+        offset = (intptr_t) ((uint8_t *) dst_ptr - cbnz_src);
         codegen_addlong(block, OPCODE_CBNZ | OFFSET19(offset) | Rt(reg));
-    } else {
-        codegen_alloc(block, 12);
-        codegen_addlong(block, OPCODE_CBZ | OFFSET19(8) | Rt(reg));
-        offset = (uintptr_t) dest - (uintptr_t) &block_write_data[block_pos];
-        codegen_addlong(block, OPCODE_B | OFFSET26(offset));
+        return;
     }
+
+    if (codegen_allocator_can_branch_imm26(cbnz_src + 4, dst_ptr)) {
+        codegen_addlong(block, OPCODE_CBZ | OFFSET19(8) | Rt(reg));
+        offset = (intptr_t) ((uint8_t *) dst_ptr - &block_write_data[block_pos]);
+        codegen_addlong(block, OPCODE_B | OFFSET26(offset));
+        return;
+    }
+
+    codegen_addlong(block, OPCODE_CBZ | OFFSET19(12) | Rt(reg));
+    host_arm64_MOVX_IMM(block, REG_X16, (uint64_t) dest);
+    host_arm64_BR(block, REG_X16);
+    (void) is_local;
 }
 
 void
@@ -729,6 +846,12 @@ host_arm64_INS_D(codeblock_t *block, int dst_reg, int src_reg, int dst_index, in
 }
 
 void
+host_arm64_INS_S(codeblock_t *block, int dst_reg, int src_reg, int dst_index, int src_index)
+{
+    codegen_addlong(block, OPCODE_INS_S | Rd(dst_reg) | Rn(src_reg) | ((dst_index & 3) << 19) | ((src_index & 3) << 13));
+}
+
+void
 host_arm64_EOR_IMM(codeblock_t *block, int dst_reg, int src_n_reg, uint32_t imm_data)
 {
     uint32_t imm_encoding = host_arm64_find_imm(imm_data);
@@ -766,6 +889,11 @@ void
 host_arm64_FADD_V2S(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_reg)
 {
     codegen_addlong(block, OPCODE_FADD_V2S | Rd(dst_reg) | Rn(src_n_reg) | Rm(src_m_reg));
+}
+void
+host_arm64_FADDP_V2S(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_reg)
+{
+    codegen_addlong(block, OPCODE_FADDP_V2S | Rd(dst_reg) | Rn(src_n_reg) | Rm(src_m_reg));
 }
 void
 host_arm64_FCMEQ_V2S(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_reg)
@@ -1249,6 +1377,16 @@ host_arm64_SQXTN_V4H_4S(codeblock_t *block, int dst_reg, int src_reg)
 {
     codegen_addlong(block, OPCODE_SQXTN_V4H_4S | Rd(dst_reg) | Rn(src_reg));
 }
+void
+host_arm64_XTN_V8B_8H(codeblock_t *block, int dst_reg, int src_reg)
+{
+    codegen_addlong(block, OPCODE_XTN_V8B_8H | Rd(dst_reg) | Rn(src_reg));
+}
+void
+host_arm64_XTN_V4H_4S(codeblock_t *block, int dst_reg, int src_reg)
+{
+    codegen_addlong(block, OPCODE_XTN_V4H_4S | Rd(dst_reg) | Rn(src_reg));
+}
 
 void
 host_arm64_SHL_V4H(codeblock_t *block, int dst_reg, int src_n_reg, int shift)
@@ -1286,6 +1424,13 @@ host_arm64_SSHR_V2D(codeblock_t *block, int dst_reg, int src_n_reg, int shift)
     if (shift > 64)
         fatal("host_arm_SSHR_V2D : shift > 64\n");
     codegen_addlong(block, OPCODE_SSHR_VQ | Rd(dst_reg) | Rn(src_n_reg) | SHIFT_IMM_V2D(64 - shift));
+}
+void
+host_arm64_SRSHR_V4S(codeblock_t *block, int dst_reg, int src_n_reg, int shift)
+{
+    if (shift > 32)
+        fatal("host_arm_SRSHR_V4S : shift > 32\n");
+    codegen_addlong(block, OPCODE_SRSHR_VQ | Rd(dst_reg) | Rn(src_n_reg) | SHIFT_IMM_V2S(32 - shift));
 }
 
 void
@@ -1455,6 +1600,11 @@ host_arm64_UQXTN_V4H_4S(codeblock_t *block, int dst_reg, int src_reg)
 {
     codegen_addlong(block, OPCODE_UQXTN_V4H_4S | Rd(dst_reg) | Rn(src_reg));
 }
+void
+host_arm64_URHADD_V8B(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_reg)
+{
+    codegen_addlong(block, OPCODE_URHADD_V8B | Rd(dst_reg) | Rn(src_n_reg) | Rm(src_m_reg));
+}
 
 void
 host_arm64_USHR_V4H(codeblock_t *block, int dst_reg, int src_n_reg, int shift)
@@ -1514,9 +1664,24 @@ host_arm64_ZIP2_V2S(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_re
     codegen_addlong(block, OPCODE_ZIP2_V2S | Rd(dst_reg) | Rn(src_n_reg) | Rm(src_m_reg));
 }
 
+
 void
 host_arm64_call(codeblock_t *block, void *dst_addr)
 {
+    uint8_t *branch_src;
+    int      is_local;
+
+    /* Prefer direct BL for local in-range JIT targets; otherwise preserve
+       existing absolute MOVX+BLR fallback for correctness. */
+    codegen_alloc(block, 4);
+    branch_src = &block_write_data[block_pos];
+    is_local   = codegen_allocator_contains_host_ptr(dst_addr);
+    if (is_local && codegen_allocator_can_branch_imm26(branch_src, dst_addr)) {
+        intptr_t offset = (intptr_t) ((uint8_t *) dst_addr - branch_src);
+        codegen_addlong(block, OPCODE_BL | OFFSET26(offset));
+        return;
+    }
+
     host_arm64_MOVX_IMM(block, REG_X16, (uint64_t) dst_addr);
     host_arm64_BLR(block, REG_X16);
 }
@@ -1524,6 +1689,21 @@ host_arm64_call(codeblock_t *block, void *dst_addr)
 void
 host_arm64_jump(codeblock_t *block, uintptr_t dst_addr)
 {
+    uint8_t *branch_src;
+    void    *dst_ptr = (void *) dst_addr;
+    int      is_local;
+
+    /* Prefer direct B for local in-range JIT targets; otherwise preserve
+       existing absolute MOVX+BR fallback for correctness. */
+    codegen_alloc(block, 4);
+    branch_src = &block_write_data[block_pos];
+    is_local   = codegen_allocator_contains_host_ptr(dst_ptr);
+    if (is_local && codegen_allocator_can_branch_imm26(branch_src, dst_ptr)) {
+        intptr_t offset = (intptr_t) ((uint8_t *) dst_ptr - branch_src);
+        codegen_addlong(block, OPCODE_B | OFFSET26(offset));
+        return;
+    }
+
     host_arm64_MOVX_IMM(block, REG_X16, (uint64_t) dst_addr);
     host_arm64_BR(block, REG_X16);
 }
@@ -1531,9 +1711,21 @@ host_arm64_jump(codeblock_t *block, uintptr_t dst_addr)
 void
 host_arm64_mov_imm(codeblock_t *block, int reg, uint32_t imm_data)
 {
+    uint32_t imm_encoding;
+
+    /* Fast-path constants that fit a single MOVZ lane update. */
     if (imm_is_imm16(imm_data))
         host_arm64_MOVZ_IMM(block, reg, imm_data);
-    else {
+    /* Use MOVN for one-lane "all ones" patterns to avoid MOVZ+MOVK. */
+    else if (imm_is_movn16(imm_data)) {
+        int hw = ((imm_data & 0xffff0000u) == 0xffff0000u) ? 0 : 1;
+        uint32_t movn_imm = hw ? ((~imm_data >> 16) & 0xffffu) : ((~imm_data) & 0xffffu);
+        codegen_addlong(block, OPCODE_MOVN_W | MOV_WIDE_HW(hw) | IMM16(movn_imm) | Rd(reg));
+    } else if ((imm_encoding = host_arm64_find_imm(imm_data)) != 0) {
+        /* Logical-immediate encoding emits one ORR-immediate from WZR. */
+        codegen_addlong(block, OPCODE_ORR_IMM | Rd(reg) | Rn(REG_WZR) | IMM_LOGICAL(imm_encoding));
+    } else {
+        /* Conservative fallback preserves existing behavior when no single-op form exists. */
         host_arm64_MOVZ_IMM(block, reg, imm_data & 0xffff);
         host_arm64_MOVK_IMM(block, reg, imm_data & 0xffff0000);
     }

--- a/src/codegen_new/codegen_backend_arm64_ops.h
+++ b/src/codegen_new/codegen_backend_arm64_ops.h
@@ -73,6 +73,7 @@ void host_arm64_CSEL_VS(codeblock_t *block, int dst_reg, int src_n_reg, int src_
 
 void host_arm64_DUP_V2S(codeblock_t *block, int dst_reg, int src_n_reg, int element);
 void host_arm64_INS_D(codeblock_t *block, int dst_reg, int src_reg, int dst_index, int src_index);
+void host_arm64_INS_S(codeblock_t *block, int dst_reg, int src_reg, int dst_index, int src_index);
 
 void host_arm64_EOR_IMM(codeblock_t *block, int dst_reg, int src_n_reg, uint32_t imm_data);
 void host_arm64_EOR_REG(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_reg, int shift);
@@ -82,6 +83,7 @@ void host_arm64_FABS_D(codeblock_t *block, int dst_reg, int src_reg);
 
 void host_arm64_FADD_D(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_reg);
 void host_arm64_FADD_V2S(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_reg);
+void host_arm64_FADDP_V2S(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_reg);
 void host_arm64_FCMEQ_V2S(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_reg);
 void host_arm64_FCMGE_V2S(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_reg);
 void host_arm64_FCMGT_V2S(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_reg);
@@ -187,6 +189,8 @@ void host_arm64_SQSUB_V4H(codeblock_t *block, int dst_reg, int src_n_reg, int sr
 void host_arm64_SQXTN_V8B_8H(codeblock_t *block, int dst_reg, int src_reg);
 void host_arm64_SQXTUN_V8B_8H(codeblock_t *block, int dst_reg, int src_reg);
 void host_arm64_SQXTN_V4H_4S(codeblock_t *block, int dst_reg, int src_reg);
+void host_arm64_XTN_V8B_8H(codeblock_t *block, int dst_reg, int src_reg);
+void host_arm64_XTN_V4H_4S(codeblock_t *block, int dst_reg, int src_reg);
 
 void host_arm64_SHL_V4H(codeblock_t *block, int dst_reg, int src_reg, int shift);
 void host_arm64_SHL_V2S(codeblock_t *block, int dst_reg, int src_reg, int shift);
@@ -199,6 +203,7 @@ void host_arm64_SMULL_V4S_4H(codeblock_t *block, int dst_reg, int src_n_reg, int
 void host_arm64_SSHR_V4H(codeblock_t *block, int dst_reg, int src_reg, int shift);
 void host_arm64_SSHR_V2S(codeblock_t *block, int dst_reg, int src_reg, int shift);
 void host_arm64_SSHR_V2D(codeblock_t *block, int dst_reg, int src_reg, int shift);
+void host_arm64_SRSHR_V4S(codeblock_t *block, int dst_reg, int src_reg, int shift);
 
 void host_arm64_STP_PREIDX_X(codeblock_t *block, int src_reg1, int src_reg2, int base_reg, int offset);
 
@@ -237,6 +242,7 @@ void host_arm64_UQSUB_V4H(codeblock_t *block, int dst_reg, int src_n_reg, int sr
 
 void host_arm64_UQXTN_V8B_8H(codeblock_t *block, int dst_reg, int src_reg);
 void host_arm64_UQXTN_V4H_4S(codeblock_t *block, int dst_reg, int src_reg);
+void host_arm64_URHADD_V8B(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_reg);
 
 void host_arm64_USHR_V4H(codeblock_t *block, int dst_reg, int src_reg, int shift);
 void host_arm64_USHR_V2S(codeblock_t *block, int dst_reg, int src_reg, int shift);

--- a/src/codegen_new/codegen_backend_arm64_uops.c
+++ b/src/codegen_new/codegen_backend_arm64_uops.c
@@ -795,7 +795,9 @@ codegen_MMX_ENTER(codeblock_t *block, uop_t *uop)
     host_arm64_call(block, x86_int);
     host_arm64_B(block, codegen_exit_rout);
 
-    host_arm64_branch_set_offset(branch_ptr, &block->data[block_pos]);
+    /* Patch against the active write cursor; block->data can point at stale
+       bytes here when block emission is still in-flight. */
+    host_arm64_branch_set_offset(branch_ptr, &block_write_data[block_pos]);
 
     host_arm64_mov_imm(block, REG_TEMP, 0x01010101);
     host_arm64_STR_IMM_W(block, REG_TEMP, REG_CPUSTATE, (uintptr_t) &cpu_state.tag[0] - (uintptr_t) &cpu_state);
@@ -1168,10 +1170,13 @@ codegen_MOV(codeblock_t *block, uop_t *uop)
     } else if (REG_IS_Q(dest_size) && REG_IS_Q(src_size)) {
         host_arm64_FMOV_D_D(block, dest_reg, src_reg);
     } else if (REG_IS_W(dest_size) && REG_IS_L(src_size)) {
+        /* Preserve upper destination bits; only replace the architected low 16 bits. */
         host_arm64_BFI(block, dest_reg, src_reg, 0, 16);
     } else if (REG_IS_B(dest_size) && REG_IS_L(src_size)) {
+        /* Same truncation rule for 8-bit destinations from 32-bit temps. */
         host_arm64_BFI(block, dest_reg, src_reg, 0, 8);
     } else if (REG_IS_B(dest_size) && REG_IS_W(src_size)) {
+        /* 16->8 form follows same low-byte-only semantics as x86 partial register writes. */
         host_arm64_BFI(block, dest_reg, src_reg, 0, 8);
     } else
         fatal("MOV %x %x\n", uop->dest_reg_a_real, uop->src_reg_a_real);
@@ -1735,6 +1740,28 @@ codegen_PF2ID(codeblock_t *block, uop_t *uop)
     return 0;
 }
 static int
+codegen_PF2IW(codeblock_t *block, uop_t *uop)
+{
+    int dest_reg   = HOST_REG_GET(uop->dest_reg_a_real);
+    int src_reg_a  = HOST_REG_GET(uop->src_reg_a_real);
+    int src_reg_b  = HOST_REG_GET(uop->src_reg_b_real);
+    int dest_size  = IREG_GET_SIZE(uop->dest_reg_a_real);
+    int src_size_a = IREG_GET_SIZE(uop->src_reg_a_real);
+    int src_size_b = IREG_GET_SIZE(uop->src_reg_b_real);
+
+    if (REG_IS_Q(dest_size) && REG_IS_Q(src_size_a) && REG_IS_Q(src_size_b)) {
+        host_arm64_FCVTZS_V2S(block, REG_V_TEMP, src_reg_b);
+        host_arm64_XTN_V4H_4S(block, REG_V_TEMP, REG_V_TEMP);
+        host_arm64_FMOV_W_S(block, REG_TEMP, REG_V_TEMP);
+        host_arm64_FMOV_D_D(block, dest_reg, src_reg_a);
+        host_arm64_FMOV_S_W(block, REG_V_TEMP, REG_TEMP);
+        host_arm64_INS_S(block, dest_reg, REG_V_TEMP, 0, 0);
+    } else
+        fatal("PF2IW %02x %02x %02x\n", uop->dest_reg_a_real, uop->src_reg_a_real, uop->src_reg_b_real);
+
+    return 0;
+}
+static int
 codegen_PFADD(codeblock_t *block, uop_t *uop)
 {
     int dest_reg   = HOST_REG_GET(uop->dest_reg_a_real);
@@ -1862,12 +1889,110 @@ codegen_PFRCP(codeblock_t *block, uop_t *uop)
     int src_size_a = IREG_GET_SIZE(uop->src_reg_a_real);
 
     if (REG_IS_Q(dest_size) && REG_IS_Q(src_size_a)) {
-        /*TODO: This could be improved (use VRECPE/VRECPS)*/
-        host_arm64_FMOV_S_ONE(block, REG_V_TEMP);
-        host_arm64_FDIV_S(block, dest_reg, REG_V_TEMP, src_reg_a);
+        /* Keep exact semantics and preserve src when ModRM aliases dst/src. */
+        if (dest_reg == src_reg_a) {
+            host_arm64_FMOV_S_ONE(block, REG_V_TEMP);
+            host_arm64_FDIV_S(block, dest_reg, REG_V_TEMP, src_reg_a);
+        } else {
+            host_arm64_FMOV_S_ONE(block, dest_reg);
+            host_arm64_FDIV_S(block, dest_reg, dest_reg, src_reg_a);
+        }
         host_arm64_DUP_V2S(block, dest_reg, dest_reg, 0);
     } else
         fatal("PFRCP %02x\n", uop->dest_reg_a_real);
+
+    return 0;
+}
+static int
+codegen_PFACC(codeblock_t *block, uop_t *uop)
+{
+    int dest_reg   = HOST_REG_GET(uop->dest_reg_a_real);
+    int src_reg_a  = HOST_REG_GET(uop->src_reg_a_real);
+    int src_reg_b  = HOST_REG_GET(uop->src_reg_b_real);
+    int dest_size  = IREG_GET_SIZE(uop->dest_reg_a_real);
+    int src_size_a = IREG_GET_SIZE(uop->src_reg_a_real);
+    int src_size_b = IREG_GET_SIZE(uop->src_reg_b_real);
+
+    if (REG_IS_Q(dest_size) && REG_IS_Q(src_size_a) && REG_IS_Q(src_size_b)) {
+        /* PFACC semantics map directly to pairwise add across src_a/src_b vectors:
+           dst[0] = src_a[0] + src_a[1], dst[1] = src_b[0] + src_b[1]. */
+        host_arm64_FADDP_V2S(block, dest_reg, src_reg_a, src_reg_b);
+    } else
+        fatal("PFACC %02x %02x %02x\n", uop->dest_reg_a_real, uop->src_reg_a_real, uop->src_reg_b_real);
+
+    return 0;
+}
+static int
+codegen_PFNACC(codeblock_t *block, uop_t *uop)
+{
+    int dest_reg   = HOST_REG_GET(uop->dest_reg_a_real);
+    int src_reg_a  = HOST_REG_GET(uop->src_reg_a_real);
+    int src_reg_b  = HOST_REG_GET(uop->src_reg_b_real);
+    int dest_size  = IREG_GET_SIZE(uop->dest_reg_a_real);
+    int src_size_a = IREG_GET_SIZE(uop->src_reg_a_real);
+    int src_size_b = IREG_GET_SIZE(uop->src_reg_b_real);
+
+    if (REG_IS_Q(dest_size) && REG_IS_Q(src_size_a) && REG_IS_Q(src_size_b)) {
+        /* Pairwise semantics:
+           dst[0] = src_a[0] - src_a[1], dst[1] = src_b[0] - src_b[1]. */
+        host_arm64_DUP_V2S(block, REG_V_TEMP, src_reg_a, 0);
+        host_arm64_DUP_V2S(block, dest_reg, src_reg_a, 1);
+        host_arm64_FSUB_V2S(block, REG_V_TEMP, REG_V_TEMP, dest_reg);
+
+        host_arm64_DUP_V2S(block, dest_reg, src_reg_b, 0);
+        host_arm64_DUP_V2S(block, src_reg_a, src_reg_b, 1);
+        host_arm64_FSUB_V2S(block, dest_reg, dest_reg, src_reg_a);
+
+        host_arm64_ZIP1_V2S(block, dest_reg, REG_V_TEMP, dest_reg);
+    } else
+        fatal("PFNACC %02x %02x %02x\n", uop->dest_reg_a_real, uop->src_reg_a_real, uop->src_reg_b_real);
+
+    return 0;
+}
+static int
+codegen_PFPNACC(codeblock_t *block, uop_t *uop)
+{
+    int dest_reg   = HOST_REG_GET(uop->dest_reg_a_real);
+    int src_reg_a  = HOST_REG_GET(uop->src_reg_a_real);
+    int src_reg_b  = HOST_REG_GET(uop->src_reg_b_real);
+    int dest_size  = IREG_GET_SIZE(uop->dest_reg_a_real);
+    int src_size_a = IREG_GET_SIZE(uop->src_reg_a_real);
+    int src_size_b = IREG_GET_SIZE(uop->src_reg_b_real);
+
+    if (REG_IS_Q(dest_size) && REG_IS_Q(src_size_a) && REG_IS_Q(src_size_b)) {
+        /* Pairwise semantics:
+           dst[0] = src_a[0] - src_a[1], dst[1] = src_b[0] + src_b[1]. */
+        host_arm64_DUP_V2S(block, REG_V_TEMP, src_reg_a, 0);
+        host_arm64_DUP_V2S(block, dest_reg, src_reg_a, 1);
+        host_arm64_FSUB_V2S(block, REG_V_TEMP, REG_V_TEMP, dest_reg);
+
+        host_arm64_DUP_V2S(block, dest_reg, src_reg_b, 0);
+        host_arm64_DUP_V2S(block, src_reg_a, src_reg_b, 1);
+        host_arm64_FADD_V2S(block, dest_reg, dest_reg, src_reg_a);
+
+        host_arm64_ZIP1_V2S(block, dest_reg, REG_V_TEMP, dest_reg);
+    } else
+        fatal("PFPNACC %02x %02x %02x\n", uop->dest_reg_a_real, uop->src_reg_a_real, uop->src_reg_b_real);
+
+    return 0;
+}
+static int
+codegen_PSWAPD(codeblock_t *block, uop_t *uop)
+{
+    int dest_reg   = HOST_REG_GET(uop->dest_reg_a_real);
+    int src_reg_a  = HOST_REG_GET(uop->src_reg_a_real);
+    int dest_size  = IREG_GET_SIZE(uop->dest_reg_a_real);
+    int src_size_a = IREG_GET_SIZE(uop->src_reg_a_real);
+
+    if (REG_IS_Q(dest_size) && REG_IS_Q(src_size_a)) {
+        /* Alias-safe swap using source snapshot:
+           dst[0] = src[1], dst[1] = src[0]. */
+        host_arm64_FMOV_D_D(block, REG_V_TEMP, src_reg_a);
+        host_arm64_DUP_V2S(block, dest_reg, REG_V_TEMP, 1);
+        host_arm64_DUP_V2S(block, REG_V_TEMP, REG_V_TEMP, 0);
+        host_arm64_INS_S(block, dest_reg, REG_V_TEMP, 1, 0);
+    } else
+        fatal("PSWAPD %02x %02x\n", uop->dest_reg_a_real, uop->src_reg_a_real);
 
     return 0;
 }
@@ -1880,10 +2005,10 @@ codegen_PFRSQRT(codeblock_t *block, uop_t *uop)
     int src_size_a = IREG_GET_SIZE(uop->src_reg_a_real);
 
     if (REG_IS_Q(dest_size) && REG_IS_Q(src_size_a)) {
-        /*TODO: This could be improved (use VRSQRTE/VRSQRTS)*/
-        host_arm64_FSQRT_S(block, REG_V_TEMP, src_reg_a);
+        /* Keep exact semantics while minimizing temporary FP register use. */
+        host_arm64_FSQRT_S(block, dest_reg, src_reg_a);
         host_arm64_FMOV_S_ONE(block, REG_V_TEMP);
-        host_arm64_FDIV_S(block, dest_reg, dest_reg, REG_V_TEMP);
+        host_arm64_FDIV_S(block, dest_reg, REG_V_TEMP, dest_reg);
         host_arm64_DUP_V2S(block, dest_reg, dest_reg, 0);
     } else
         fatal("PFRSQRT %02x\n", uop->dest_reg_a_real);
@@ -1922,6 +2047,28 @@ codegen_PI2FD(codeblock_t *block, uop_t *uop)
 
     return 0;
 }
+static int
+codegen_PI2FW(codeblock_t *block, uop_t *uop)
+{
+    int dest_reg   = HOST_REG_GET(uop->dest_reg_a_real);
+    int src_reg_a  = HOST_REG_GET(uop->src_reg_a_real);
+    int dest_size  = IREG_GET_SIZE(uop->dest_reg_a_real);
+    int src_size_a = IREG_GET_SIZE(uop->src_reg_a_real);
+
+    if (REG_IS_Q(dest_size) && REG_IS_Q(src_size_a)) {
+        host_arm64_FMOV_W_S(block, REG_TEMP, src_reg_a);
+        host_arm64_MOV_REG_ASR(block, REG_TEMP2, REG_TEMP, 16);
+        host_arm64_MOV_REG_ROR(block, REG_TEMP, REG_TEMP, 16);
+        host_arm64_MOV_REG_ASR(block, REG_TEMP, REG_TEMP, 16);
+        host_arm64_FMOV_S_W(block, dest_reg, REG_TEMP);
+        host_arm64_FMOV_S_W(block, REG_V_TEMP, REG_TEMP2);
+        host_arm64_INS_S(block, dest_reg, REG_V_TEMP, 1, 0);
+        host_arm64_SCVTF_V2S(block, dest_reg, dest_reg);
+    } else
+        fatal("PI2FW %02x %02x\n", uop->dest_reg_a_real, uop->src_reg_a_real);
+
+    return 0;
+}
 
 static int
 codegen_PMADDWD(codeblock_t *block, uop_t *uop)
@@ -1956,6 +2103,42 @@ codegen_PMULHW(codeblock_t *block, uop_t *uop)
         host_arm64_SHRN_V4H_4S(block, dest_reg, dest_reg, 16);
     } else
         fatal("PMULHW %02x %02x %02x\n", uop->dest_reg_a_real, uop->src_reg_a_real, uop->src_reg_b_real);
+
+    return 0;
+}
+static int
+codegen_PMULHRW(codeblock_t *block, uop_t *uop)
+{
+    int dest_reg   = HOST_REG_GET(uop->dest_reg_a_real);
+    int src_reg_a  = HOST_REG_GET(uop->src_reg_a_real);
+    int src_reg_b  = HOST_REG_GET(uop->src_reg_b_real);
+    int dest_size  = IREG_GET_SIZE(uop->dest_reg_a_real);
+    int src_size_a = IREG_GET_SIZE(uop->src_reg_a_real);
+    int src_size_b = IREG_GET_SIZE(uop->src_reg_b_real);
+
+    if (REG_IS_Q(dest_size) && REG_IS_Q(src_size_a) && REG_IS_Q(src_size_b)) {
+        host_arm64_SMULL_V4S_4H(block, REG_V_TEMP, src_reg_a, src_reg_b);
+        host_arm64_SRSHR_V4S(block, REG_V_TEMP, REG_V_TEMP, 16);
+        host_arm64_XTN_V4H_4S(block, dest_reg, REG_V_TEMP);
+    } else
+        fatal("PMULHRW %02x %02x %02x\n", uop->dest_reg_a_real, uop->src_reg_a_real, uop->src_reg_b_real);
+
+    return 0;
+}
+static int
+codegen_PAVGUSB(codeblock_t *block, uop_t *uop)
+{
+    int dest_reg   = HOST_REG_GET(uop->dest_reg_a_real);
+    int src_reg_a  = HOST_REG_GET(uop->src_reg_a_real);
+    int src_reg_b  = HOST_REG_GET(uop->src_reg_b_real);
+    int dest_size  = IREG_GET_SIZE(uop->dest_reg_a_real);
+    int src_size_a = IREG_GET_SIZE(uop->src_reg_a_real);
+    int src_size_b = IREG_GET_SIZE(uop->src_reg_b_real);
+
+    if (REG_IS_Q(dest_size) && REG_IS_Q(src_size_a) && REG_IS_Q(src_size_b)) {
+        host_arm64_URHADD_V8B(block, dest_reg, src_reg_a, src_reg_b);
+    } else
+        fatal("PAVGUSB %02x %02x %02x\n", uop->dest_reg_a_real, uop->src_reg_a_real, uop->src_reg_b_real);
 
     return 0;
 }
@@ -3257,6 +3440,9 @@ const uOpFn uop_handlers[UOP_MAX] = {
     [UOP_PF2ID &
         UOP_MASK]
     = codegen_PF2ID,
+    [UOP_PF2IW &
+        UOP_MASK]
+    = codegen_PF2IW,
     [UOP_PFADD &
         UOP_MASK]
     = codegen_PFADD,
@@ -3281,6 +3467,18 @@ const uOpFn uop_handlers[UOP_MAX] = {
     [UOP_PFRCP &
         UOP_MASK]
     = codegen_PFRCP,
+    [UOP_PFACC &
+        UOP_MASK]
+    = codegen_PFACC,
+    [UOP_PFNACC &
+        UOP_MASK]
+    = codegen_PFNACC,
+    [UOP_PFPNACC &
+        UOP_MASK]
+    = codegen_PFPNACC,
+    [UOP_PSWAPD &
+        UOP_MASK]
+    = codegen_PSWAPD,
     [UOP_PFRSQRT &
         UOP_MASK]
     = codegen_PFRSQRT,
@@ -3290,6 +3488,9 @@ const uOpFn uop_handlers[UOP_MAX] = {
     [UOP_PI2FD &
         UOP_MASK]
     = codegen_PI2FD,
+    [UOP_PI2FW &
+        UOP_MASK]
+    = codegen_PI2FW,
 
     [UOP_PMADDWD &
         UOP_MASK]
@@ -3297,6 +3498,12 @@ const uOpFn uop_handlers[UOP_MAX] = {
     [UOP_PMULHW &
         UOP_MASK]
     = codegen_PMULHW,
+    [UOP_PMULHRW &
+        UOP_MASK]
+    = codegen_PMULHRW,
+    [UOP_PAVGUSB &
+        UOP_MASK]
+    = codegen_PAVGUSB,
     [UOP_PMULLW &
         UOP_MASK]
     = codegen_PMULLW,
@@ -3586,5 +3793,50 @@ void
 codegen_set_jump_dest(codeblock_t *block, void *p)
 {
     host_arm64_branch_set_offset(p, &block_write_data[block_pos]);
+}
+
+void
+codegen_direct_write_8_imm(codeblock_t *block, void *p, uint8_t imm_data)
+{
+    /* Used by MOV_IMM-style uops to skip temp register materialization in the IR layer. */
+    host_arm64_mov_imm(block, REG_W16, imm_data);
+
+    if (in_range12_b((uintptr_t) p - (uintptr_t) &cpu_state))
+        host_arm64_STRB_IMM(block, REG_W16, REG_CPUSTATE, (uintptr_t) p - (uintptr_t) &cpu_state);
+    else
+        fatal("codegen_direct_write_8_imm - not in range\n");
+}
+void
+codegen_direct_write_16_imm(codeblock_t *block, void *p, uint16_t imm_data)
+{
+    /* Mirrors 8/32-bit helpers so MOV_IMM-to-cpu_state stays a single backend write path. */
+    host_arm64_mov_imm(block, REG_W16, imm_data);
+
+    if (in_range12_h((uintptr_t) p - (uintptr_t) &cpu_state))
+        host_arm64_STRH_IMM(block, REG_W16, REG_CPUSTATE, (uintptr_t) p - (uintptr_t) &cpu_state);
+    else
+        fatal("codegen_direct_write_16_imm - not in range\n");
+}
+void
+codegen_direct_write_32_imm(codeblock_t *block, void *p, uint32_t imm_data)
+{
+    /* 32-bit immediate store fast path used by generic emitters. */
+    host_arm64_mov_imm(block, REG_W16, imm_data);
+
+    if (in_range12_w((uintptr_t) p - (uintptr_t) &cpu_state))
+        host_arm64_STR_IMM_W(block, REG_W16, REG_CPUSTATE, (uintptr_t) p - (uintptr_t) &cpu_state);
+    else
+        fatal("codegen_direct_write_32_imm - not in range\n");
+}
+void
+codegen_direct_write_32_imm_stack(codeblock_t *block, int stack_offset, uint32_t imm_data)
+{
+    /* Stack form keeps parity with direct cpu_state writes and enforces the same range guard. */
+    host_arm64_mov_imm(block, REG_W16, imm_data);
+
+    if (in_range12_w(stack_offset))
+        host_arm64_STR_IMM_W(block, REG_W16, REG_XSP, stack_offset);
+    else
+        fatal("codegen_direct_write_32_imm_stack - not in range\n");
 }
 #endif

--- a/src/codegen_new/codegen_block.c
+++ b/src/codegen_new/codegen_block.c
@@ -526,6 +526,12 @@ codegen_block_init(uint32_t phys_addr)
     block->pc          = cs + cpu_state.pc;
     block->_cs         = cs;
     block->phys        = phys_addr;
+#if defined(__aarch64__) || defined(_M_ARM64)
+    /* ARM64-only state initialization for delayed NO_IMMEDIATES policy. */
+    block->dirty_list_recompile_hits = 0;
+    /* ARM64-only: zero epoch so first dirty-list hit starts a new burst. */
+    block->dirty_list_last_epoch     = 0;
+#endif
     block->dirty_mask  = &page->dirty_mask;
     block->dirty_mask2 = NULL;
     block->next = block->prev = BLOCK_INVALID;

--- a/src/codegen_new/codegen_ir_defs.h
+++ b/src/codegen_new/codegen_ir_defs.h
@@ -317,14 +317,30 @@
 #define UOP_PFCMPGT (UOP_TYPE_PARAMS_REGS | 0xc1)
 /*UOP_PF2ID - (packed long)dest_reg = (packed float)src_reg_a*/
 #define UOP_PF2ID (UOP_TYPE_PARAMS_REGS | 0xc2)
+/*UOP_PF2IW - dest_reg keeps high 32-bit lane from src_reg_a; low 32 bits get truncated low words from src_reg_b floats*/
+#define UOP_PF2IW (UOP_TYPE_PARAMS_REGS | 0xc9)
 /*UOP_PI2FD - (packed float)dest_reg = (packed long)src_reg_a*/
 #define UOP_PI2FD (UOP_TYPE_PARAMS_REGS | 0xc3)
+/*UOP_PI2FW - (packed float)dest_reg = sign-extended low words from src_reg_a*/
+#define UOP_PI2FW (UOP_TYPE_PARAMS_REGS | 0xca)
 /*UOP_PFRCP - (packed float) dest_reg[0] = dest_reg[1] = 1.0 / src_reg[0]*/
 #define UOP_PFRCP (UOP_TYPE_PARAMS_REGS | 0xc4)
 /*UOP_PFRSQRT - (packed float) dest_reg[0] = dest_reg[1] = 1.0 / sqrt(src_reg[0])*/
 #define UOP_PFRSQRT (UOP_TYPE_PARAMS_REGS | 0xc5)
+/*UOP_PFACC - (packed float) dest_reg[0] = dest_reg[0] + dest_reg[1], dest_reg[1] = src_reg_b[0] + src_reg_b[1]*/
+#define UOP_PFACC (UOP_TYPE_PARAMS_REGS | 0xc6)
+/*UOP_PFNACC - (packed float) dest_reg[0] = src_reg_a[0] - src_reg_a[1], dest_reg[1] = src_reg_b[0] - src_reg_b[1]*/
+#define UOP_PFNACC (UOP_TYPE_PARAMS_REGS | 0xcb)
+/*UOP_PFPNACC - (packed float) dest_reg[0] = src_reg_a[0] - src_reg_a[1], dest_reg[1] = src_reg_b[0] + src_reg_b[1]*/
+#define UOP_PFPNACC (UOP_TYPE_PARAMS_REGS | 0xcc)
+/*UOP_PSWAPD - (packed float) dest_reg[0] = src_reg_a[1], dest_reg[1] = src_reg_a[0]*/
+#define UOP_PSWAPD (UOP_TYPE_PARAMS_REGS | 0xcd)
+/*UOP_PMULHRW - (packed word) dest_reg = ((src_reg_a * src_reg_b) + 0x8000) >> 16*/
+#define UOP_PMULHRW (UOP_TYPE_PARAMS_REGS | 0xc7)
+/*UOP_PAVGUSB - (packed byte) dest_reg = (src_reg_a + src_reg_b + 1) >> 1*/
+#define UOP_PAVGUSB (UOP_TYPE_PARAMS_REGS | 0xc8)
 
-#define UOP_MAX     0xc6
+#define UOP_MAX     0xce
 
 #define UOP_INVALID 0xff
 
@@ -669,6 +685,7 @@ uop_gen_reg_src2_pointer(uint32_t uop_type, ir_data_t *ir, int src_reg_a, int sr
 }
 
 extern int codegen_mmx_enter(void);
+extern int codegen_femms(void);
 extern int codegen_fp_enter(void);
 
 #define uop_LOAD_FUNC_ARG_REG(ir, arg, reg)                      uop_gen_reg_src1(UOP_LOAD_FUNC_ARG_0 + arg, ir, reg)
@@ -826,6 +843,7 @@ extern int codegen_fp_enter(void);
 #define uop_PCMPGTD(ir, dst_reg, src_reg_a, src_reg_b)                   uop_gen_reg_dst_src2(UOP_PCMPGTD, ir, dst_reg, src_reg_a, src_reg_b)
 
 #define uop_PF2ID(ir, dst_reg, src_reg)                                  uop_gen_reg_dst_src1(UOP_PF2ID, ir, dst_reg, src_reg)
+#define uop_PF2IW(ir, dst_reg, src_reg_a, src_reg_b)                     uop_gen_reg_dst_src2(UOP_PF2IW, ir, dst_reg, src_reg_a, src_reg_b)
 #define uop_PFADD(ir, dst_reg, src_reg_a, src_reg_b)                     uop_gen_reg_dst_src2(UOP_PFADD, ir, dst_reg, src_reg_a, src_reg_b)
 #define uop_PFCMPEQ(ir, dst_reg, src_reg_a, src_reg_b)                   uop_gen_reg_dst_src2(UOP_PFCMPEQ, ir, dst_reg, src_reg_a, src_reg_b)
 #define uop_PFCMPGE(ir, dst_reg, src_reg_a, src_reg_b)                   uop_gen_reg_dst_src2(UOP_PFCMPGE, ir, dst_reg, src_reg_a, src_reg_b)
@@ -835,8 +853,15 @@ extern int codegen_fp_enter(void);
 #define uop_PFMUL(ir, dst_reg, src_reg_a, src_reg_b)                     uop_gen_reg_dst_src2(UOP_PFMUL, ir, dst_reg, src_reg_a, src_reg_b)
 #define uop_PFRCP(ir, dst_reg, src_reg)                                  uop_gen_reg_dst_src1(UOP_PFRCP, ir, dst_reg, src_reg)
 #define uop_PFRSQRT(ir, dst_reg, src_reg)                                uop_gen_reg_dst_src1(UOP_PFRSQRT, ir, dst_reg, src_reg)
+#define uop_PFACC(ir, dst_reg, src_reg_a, src_reg_b)                     uop_gen_reg_dst_src2(UOP_PFACC, ir, dst_reg, src_reg_a, src_reg_b)
+#define uop_PFNACC(ir, dst_reg, src_reg_a, src_reg_b)                    uop_gen_reg_dst_src2(UOP_PFNACC, ir, dst_reg, src_reg_a, src_reg_b)
+#define uop_PFPNACC(ir, dst_reg, src_reg_a, src_reg_b)                   uop_gen_reg_dst_src2(UOP_PFPNACC, ir, dst_reg, src_reg_a, src_reg_b)
+#define uop_PSWAPD(ir, dst_reg, src_reg)                                 uop_gen_reg_dst_src1(UOP_PSWAPD, ir, dst_reg, src_reg)
+#define uop_PMULHRW(ir, dst_reg, src_reg_a, src_reg_b)                   uop_gen_reg_dst_src2(UOP_PMULHRW, ir, dst_reg, src_reg_a, src_reg_b)
+#define uop_PAVGUSB(ir, dst_reg, src_reg_a, src_reg_b)                   uop_gen_reg_dst_src2(UOP_PAVGUSB, ir, dst_reg, src_reg_a, src_reg_b)
 #define uop_PFSUB(ir, dst_reg, src_reg_a, src_reg_b)                     uop_gen_reg_dst_src2(UOP_PFSUB, ir, dst_reg, src_reg_a, src_reg_b)
 #define uop_PI2FD(ir, dst_reg, src_reg)                                  uop_gen_reg_dst_src1(UOP_PI2FD, ir, dst_reg, src_reg)
+#define uop_PI2FW(ir, dst_reg, src_reg)                                  uop_gen_reg_dst_src1(UOP_PI2FW, ir, dst_reg, src_reg)
 
 #define uop_PMADDWD(ir, dst_reg, src_reg_a, src_reg_b)                   uop_gen_reg_dst_src2(UOP_PMADDWD, ir, dst_reg, src_reg_a, src_reg_b)
 #define uop_PMULHW(ir, dst_reg, src_reg_a, src_reg_b)                    uop_gen_reg_dst_src2(UOP_PMULHW, ir, dst_reg, src_reg_a, src_reg_b)

--- a/src/codegen_new/codegen_ops.c
+++ b/src/codegen_new/codegen_ops.c
@@ -190,7 +190,7 @@ RecompOpFn recomp_opcodes_0f_no_mmx[512] = {
 RecompOpFn recomp_opcodes_3DNOW[256] = {
 // clang-format off
 #if defined __ARM_EABI__ || defined _ARM_ || defined _M_ARM || defined __aarch64__ || defined _M_ARM64
-    /* Phase 1 ARM64 bring-up: enable only opcodes with existing rop+lowerer support. */
+    /* ARM64: enable only opcodes with implemented and validated rop+lowerer support. */
     [0x0c] = ropPI2FW,
     [0x0d] = ropPI2FD,
     [0x1c] = ropPF2IW,

--- a/src/codegen_new/codegen_ops.c
+++ b/src/codegen_new/codegen_ops.c
@@ -27,6 +27,14 @@
 #include "codegen_ops_shift.h"
 #include "codegen_ops_stack.h"
 
+#if defined __ARM_EABI__ || defined _ARM_ || defined _M_ARM || defined __aarch64__ || defined _M_ARM64
+#    define ARM64_ROP_PREFETCH ropPREFETCH
+#    define ARM64_ROP_FEMMS    ropFEMMS
+#else
+#    define ARM64_ROP_PREFETCH NULL
+#    define ARM64_ROP_FEMMS    NULL
+#endif
+
 RecompOpFn recomp_opcodes[512] = {
     // clang-format off
         /*16-bit data*/
@@ -79,7 +87,7 @@ RecompOpFn recomp_opcodes_0f[512] = {
     // clang-format off
         /*16-bit data*/
 /*      00              01              02              03              04              05              06              07              08              09              0a              0b              0c              0d              0e              0f*/
-/*00*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
+/*00*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           ARM64_ROP_PREFETCH, ARM64_ROP_FEMMS, NULL,
 /*10*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
 /*20*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
 /*30*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
@@ -105,7 +113,7 @@ RecompOpFn recomp_opcodes_0f[512] = {
 
         /*32-bit data*/
 /*      00              01              02              03              04              05              06              07              08              09              0a              0b              0c              0d              0e              0f*/
-/*00*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
+/*00*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           ARM64_ROP_PREFETCH, ARM64_ROP_FEMMS, NULL,
 /*10*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
 /*20*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
 /*30*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
@@ -135,7 +143,7 @@ RecompOpFn recomp_opcodes_0f_no_mmx[512] = {
     // clang-format off
         /*16-bit data*/
 /*      00              01              02              03              04              05              06              07              08              09              0a              0b              0c              0d              0e              0f*/
-/*00*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
+/*00*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           ARM64_ROP_PREFETCH, ARM64_ROP_FEMMS, NULL,
 /*10*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
 /*20*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
 /*30*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
@@ -157,7 +165,7 @@ RecompOpFn recomp_opcodes_0f_no_mmx[512] = {
 
         /*32-bit data*/
 /*      00              01              02              03              04              05              06              07              08              09              0a              0b              0c              0d              0e              0f*/
-/*00*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
+/*00*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           ARM64_ROP_PREFETCH, ARM64_ROP_FEMMS, NULL,
 /*10*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
 /*20*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
 /*30*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
@@ -182,7 +190,31 @@ RecompOpFn recomp_opcodes_0f_no_mmx[512] = {
 RecompOpFn recomp_opcodes_3DNOW[256] = {
 // clang-format off
 #if defined __ARM_EABI__ || defined _ARM_ || defined _M_ARM || defined __aarch64__ || defined _M_ARM64
-0
+    /* Phase 1 ARM64 bring-up: enable only opcodes with existing rop+lowerer support. */
+    [0x0c] = ropPI2FW,
+    [0x0d] = ropPI2FD,
+    [0x1c] = ropPF2IW,
+    [0x1d] = ropPF2ID,
+    [0x8a] = ropPFNACC,
+    [0x8e] = ropPFPNACC,
+    [0x90] = ropPFCMPGE,
+    [0x94] = ropPFMIN,
+    [0x96] = ropPFRCP,
+    [0x97] = ropPFRSQRT,
+    [0x9a] = ropPFSUB,
+    [0x9e] = ropPFADD,
+    [0xa0] = ropPFCMPGT,
+    [0xa4] = ropPFMAX,
+    [0xa6] = ropPFRCPIT,
+    [0xa7] = ropPFRSQIT1,
+    [0xaa] = ropPFSUBR,
+    [0xae] = ropPFACC,
+    [0xb0] = ropPFCMPEQ,
+    [0xb4] = ropPFMUL,
+    [0xb6] = ropPFRCPIT,
+    [0xb7] = ropPMULHRW,
+    [0xbb] = ropPSWAPD,
+    [0xbf] = ropPAVGUSB,
 #else
 /*      00              01              02              03              04              05              06              07              08              09              0a              0b              0c              0d              0e              0f*/
 /*00*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           ropPI2FD,       NULL,           NULL,

--- a/src/codegen_new/codegen_ops_3dnow.c
+++ b/src/codegen_new/codegen_ops_3dnow.c
@@ -16,7 +16,8 @@
 #include "codegen_ops_3dnow.h"
 #include "codegen_ops_helpers.h"
 
-#define ropParith(func)                                                                            \
+
+#define ropParith(func, opid)                                                                      \
     uint32_t rop##func(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode),                  \
                        uint32_t fetchdat, uint32_t op_32, uint32_t op_pc)                          \
     {                                                                                              \
@@ -42,14 +43,16 @@
     }
 
 // clang-format off
-ropParith(PFADD)
-ropParith(PFCMPEQ)
-ropParith(PFCMPGE)
-ropParith(PFCMPGT)
-ropParith(PFMAX)
-ropParith(PFMIN)
-ropParith(PFMUL)
-ropParith(PFSUB)
+ropParith(PFADD, 0x9e)
+ropParith(PFCMPEQ, 0xb0)
+ropParith(PFCMPGE, 0x90)
+ropParith(PFCMPGT, 0xa0)
+ropParith(PFMAX, 0xa4)
+ropParith(PFMIN, 0x94)
+ropParith(PFMUL, 0xb4)
+ropParith(PFSUB, 0x9a)
+ropParith(PMULHRW, 0xb7)
+ropParith(PAVGUSB, 0xbf)
     // clang-format on
 
 uint32_t ropPF2ID(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchdat, uint32_t op_32, uint32_t op_pc)
@@ -67,8 +70,111 @@ uint32_t ropPF2ID(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uin
         uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
         target_seg = codegen_generate_ea(ir, op_ea_seg, fetchdat, op_ssegs, &op_pc, op_32, 0);
         codegen_check_seg_read(block, ir, target_seg);
+        /* PF2ID depends only on source, so memory operand can load directly into dst. */
+        uop_MEM_LOAD_REG(ir, IREG_MM(dest_reg), ireg_seg_base(target_seg), IREG_eaaddr);
+        uop_PF2ID(ir, IREG_MM(dest_reg), IREG_MM(dest_reg));
+    }
+
+    codegen_mark_code_present(block, cs + op_pc + 1, 1);
+    return op_pc + 2;
+}
+
+uint32_t
+ropPF2IW(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchdat, uint32_t op_32, uint32_t op_pc)
+{
+    int dest_reg = (fetchdat >> 3) & 7;
+
+    uop_MMX_ENTER(ir);
+    codegen_mark_code_present(block, cs + op_pc, 1);
+    if ((fetchdat & 0xc0) == 0xc0) {
+        int src_reg = fetchdat & 7;
+        uop_PF2IW(ir, IREG_MM(dest_reg), IREG_MM(dest_reg), IREG_MM(src_reg));
+    } else {
+        x86seg *target_seg;
+
+        uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
+        target_seg = codegen_generate_ea(ir, op_ea_seg, fetchdat, op_ssegs, &op_pc, op_32, 0);
+        codegen_check_seg_read(block, ir, target_seg);
         uop_MEM_LOAD_REG(ir, IREG_temp0_Q, ireg_seg_base(target_seg), IREG_eaaddr);
-        uop_PF2ID(ir, IREG_MM(dest_reg), IREG_temp0_Q);
+        uop_PF2IW(ir, IREG_MM(dest_reg), IREG_MM(dest_reg), IREG_temp0_Q);
+    }
+
+    codegen_mark_code_present(block, cs + op_pc + 1, 1);
+    return op_pc + 2;
+}
+
+uint32_t
+ropPFACC(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchdat, uint32_t op_32, uint32_t op_pc)
+{
+    int dest_reg = (fetchdat >> 3) & 7;
+
+    uop_MMX_ENTER(ir);
+    codegen_mark_code_present(block, cs + op_pc, 1);
+    if ((fetchdat & 0xc0) == 0xc0) {
+        int src_reg = fetchdat & 7;
+        uop_PFACC(ir, IREG_MM(dest_reg), IREG_MM(dest_reg), IREG_MM(src_reg));
+    } else {
+        x86seg *target_seg;
+
+        uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
+        target_seg = codegen_generate_ea(ir, op_ea_seg, fetchdat, op_ssegs, &op_pc, op_32, 0);
+        codegen_check_seg_read(block, ir, target_seg);
+        uop_MEM_LOAD_REG(ir, IREG_temp0_Q, ireg_seg_base(target_seg), IREG_eaaddr);
+        uop_PFACC(ir, IREG_MM(dest_reg), IREG_MM(dest_reg), IREG_temp0_Q);
+    }
+
+    codegen_mark_code_present(block, cs + op_pc + 1, 1);
+    return op_pc + 2;
+}
+
+uint32_t
+ropPFNACC(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchdat, uint32_t op_32, uint32_t op_pc)
+{
+    int dest_reg = (fetchdat >> 3) & 7;
+
+    uop_MMX_ENTER(ir);
+    codegen_mark_code_present(block, cs + op_pc, 1);
+    /* Snapshot dst before writeback so backend lowering stays alias-safe for ModRM reg overlap. */
+    uop_MOV(ir, IREG_temp1_Q, IREG_MM(dest_reg));
+    if ((fetchdat & 0xc0) == 0xc0) {
+        int src_reg      = fetchdat & 7;
+        int src_reg_ireg = (src_reg == dest_reg) ? IREG_temp1_Q : IREG_MM(src_reg);
+        uop_PFNACC(ir, IREG_MM(dest_reg), IREG_temp1_Q, src_reg_ireg);
+    } else {
+        x86seg *target_seg;
+
+        uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
+        target_seg = codegen_generate_ea(ir, op_ea_seg, fetchdat, op_ssegs, &op_pc, op_32, 0);
+        codegen_check_seg_read(block, ir, target_seg);
+        uop_MEM_LOAD_REG(ir, IREG_temp0_Q, ireg_seg_base(target_seg), IREG_eaaddr);
+        uop_PFNACC(ir, IREG_MM(dest_reg), IREG_temp1_Q, IREG_temp0_Q);
+    }
+
+    codegen_mark_code_present(block, cs + op_pc + 1, 1);
+    return op_pc + 2;
+}
+
+uint32_t
+ropPFPNACC(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchdat, uint32_t op_32, uint32_t op_pc)
+{
+    int dest_reg = (fetchdat >> 3) & 7;
+
+    uop_MMX_ENTER(ir);
+    codegen_mark_code_present(block, cs + op_pc, 1);
+    /* Snapshot dst before writeback so backend lowering stays alias-safe for ModRM reg overlap. */
+    uop_MOV(ir, IREG_temp1_Q, IREG_MM(dest_reg));
+    if ((fetchdat & 0xc0) == 0xc0) {
+        int src_reg      = fetchdat & 7;
+        int src_reg_ireg = (src_reg == dest_reg) ? IREG_temp1_Q : IREG_MM(src_reg);
+        uop_PFPNACC(ir, IREG_MM(dest_reg), IREG_temp1_Q, src_reg_ireg);
+    } else {
+        x86seg *target_seg;
+
+        uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
+        target_seg = codegen_generate_ea(ir, op_ea_seg, fetchdat, op_ssegs, &op_pc, op_32, 0);
+        codegen_check_seg_read(block, ir, target_seg);
+        uop_MEM_LOAD_REG(ir, IREG_temp0_Q, ireg_seg_base(target_seg), IREG_eaaddr);
+        uop_PFPNACC(ir, IREG_MM(dest_reg), IREG_temp1_Q, IREG_temp0_Q);
     }
 
     codegen_mark_code_present(block, cs + op_pc + 1, 1);
@@ -115,8 +221,9 @@ ropPI2FD(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fet
         uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
         target_seg = codegen_generate_ea(ir, op_ea_seg, fetchdat, op_ssegs, &op_pc, op_32, 0);
         codegen_check_seg_read(block, ir, target_seg);
-        uop_MEM_LOAD_REG(ir, IREG_temp0_Q, ireg_seg_base(target_seg), IREG_eaaddr);
-        uop_PI2FD(ir, IREG_MM(dest_reg), IREG_temp0_Q);
+        /* PI2FD depends only on source, so memory operand can load directly into dst. */
+        uop_MEM_LOAD_REG(ir, IREG_MM(dest_reg), ireg_seg_base(target_seg), IREG_eaaddr);
+        uop_PI2FD(ir, IREG_MM(dest_reg), IREG_MM(dest_reg));
     }
 
     codegen_mark_code_present(block, cs + op_pc + 1, 1);
@@ -124,7 +231,7 @@ ropPI2FD(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fet
 }
 
 uint32_t
-ropPFRCPIT(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchdat, uint32_t op_32, uint32_t op_pc)
+ropPI2FW(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchdat, uint32_t op_32, uint32_t op_pc)
 {
     int dest_reg = (fetchdat >> 3) & 7;
 
@@ -132,7 +239,58 @@ ropPFRCPIT(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t f
     codegen_mark_code_present(block, cs + op_pc, 1);
     if ((fetchdat & 0xc0) == 0xc0) {
         int src_reg = fetchdat & 7;
-        uop_MOV(ir, IREG_MM(dest_reg), IREG_MM(src_reg));
+        uop_PI2FW(ir, IREG_MM(dest_reg), IREG_MM(src_reg));
+    } else {
+        x86seg *target_seg;
+
+        uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
+        target_seg = codegen_generate_ea(ir, op_ea_seg, fetchdat, op_ssegs, &op_pc, op_32, 0);
+        codegen_check_seg_read(block, ir, target_seg);
+        /* PI2FW depends only on source, so memory operand can load directly into dst. */
+        uop_MEM_LOAD_REG(ir, IREG_MM(dest_reg), ireg_seg_base(target_seg), IREG_eaaddr);
+        uop_PI2FW(ir, IREG_MM(dest_reg), IREG_MM(dest_reg));
+    }
+
+    codegen_mark_code_present(block, cs + op_pc + 1, 1);
+    return op_pc + 2;
+}
+
+uint32_t
+ropPSWAPD(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchdat, uint32_t op_32, uint32_t op_pc)
+{
+    int dest_reg = (fetchdat >> 3) & 7;
+
+    uop_MMX_ENTER(ir);
+    codegen_mark_code_present(block, cs + op_pc, 1);
+    if ((fetchdat & 0xc0) == 0xc0) {
+        int src_reg = fetchdat & 7;
+        uop_PSWAPD(ir, IREG_MM(dest_reg), IREG_MM(src_reg));
+    } else {
+        x86seg *target_seg;
+
+        uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
+        target_seg = codegen_generate_ea(ir, op_ea_seg, fetchdat, op_ssegs, &op_pc, op_32, 0);
+        codegen_check_seg_read(block, ir, target_seg);
+        /* PSWAPD consumes source only; direct dst load trims one temporary. */
+        uop_MEM_LOAD_REG(ir, IREG_MM(dest_reg), ireg_seg_base(target_seg), IREG_eaaddr);
+        uop_PSWAPD(ir, IREG_MM(dest_reg), IREG_MM(dest_reg));
+    }
+
+    codegen_mark_code_present(block, cs + op_pc + 1, 1);
+    return op_pc + 2;
+}
+
+uint32_t
+ropPFRCPIT(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc)
+{
+    int dest_reg = (fetchdat >> 3) & 7;
+
+    uop_MMX_ENTER(ir);
+    codegen_mark_code_present(block, cs + op_pc, 1);
+    if ((fetchdat & 0xc0) == 0xc0) {
+        int src_reg = fetchdat & 7;
+        if (src_reg != dest_reg)
+            uop_MOV(ir, IREG_MM(dest_reg), IREG_MM(src_reg));
     } else {
         x86seg *target_seg;
 
@@ -161,8 +319,9 @@ ropPFRCP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fet
         uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
         target_seg = codegen_generate_ea(ir, op_ea_seg, fetchdat, op_ssegs, &op_pc, op_32, 0);
         codegen_check_seg_read(block, ir, target_seg);
-        uop_MEM_LOAD_REG(ir, IREG_temp0_Q, ireg_seg_base(target_seg), IREG_eaaddr);
-        uop_PFRCP(ir, IREG_MM(dest_reg), IREG_temp0_Q);
+        /* Scalar reciprocal uses only lane 0; load directly into dst to reduce temp pressure. */
+        uop_MEM_LOAD_REG(ir, IREG_MM(dest_reg), ireg_seg_base(target_seg), IREG_eaaddr);
+        uop_PFRCP(ir, IREG_MM(dest_reg), IREG_MM(dest_reg));
     }
 
     codegen_mark_code_present(block, cs + op_pc + 1, 1);
@@ -184,8 +343,9 @@ ropPFRSQRT(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t f
         uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
         target_seg = codegen_generate_ea(ir, op_ea_seg, fetchdat, op_ssegs, &op_pc, op_32, 0);
         codegen_check_seg_read(block, ir, target_seg);
-        uop_MEM_LOAD_REG(ir, IREG_temp0_Q, ireg_seg_base(target_seg), IREG_eaaddr);
-        uop_PFRSQRT(ir, IREG_MM(dest_reg), IREG_temp0_Q);
+        /* Scalar inverse-sqrt uses only lane 0; load directly into dst to reduce temp pressure. */
+        uop_MEM_LOAD_REG(ir, IREG_MM(dest_reg), ireg_seg_base(target_seg), IREG_eaaddr);
+        uop_PFRSQRT(ir, IREG_MM(dest_reg), IREG_MM(dest_reg));
     }
 
     codegen_mark_code_present(block, cs + op_pc + 1, 1);
@@ -193,7 +353,7 @@ ropPFRSQRT(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t f
 }
 
 uint32_t
-ropPFRSQIT1(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), UNUSED(uint32_t fetchdat), UNUSED(uint32_t op_32), uint32_t op_pc)
+ropPFRSQIT1(codeblock_t *block, ir_data_t *ir, uint8_t opcode, UNUSED(uint32_t fetchdat), UNUSED(uint32_t op_32), uint32_t op_pc)
 {
     uop_MMX_ENTER(ir);
 

--- a/src/codegen_new/codegen_ops_3dnow.h
+++ b/src/codegen_new/codegen_ops_3dnow.h
@@ -1,4 +1,8 @@
 uint32_t ropPF2ID(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
+uint32_t ropPF2IW(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
+uint32_t ropPFACC(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
+uint32_t ropPFNACC(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
+uint32_t ropPFPNACC(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
 uint32_t ropPFADD(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
 uint32_t ropPFCMPEQ(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
 uint32_t ropPFCMPGE(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
@@ -12,4 +16,8 @@ uint32_t ropPFRSQRT(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t 
 uint32_t ropPFRSQIT1(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
 uint32_t ropPFSUB(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
 uint32_t ropPFSUBR(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
+uint32_t ropPMULHRW(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
+uint32_t ropPAVGUSB(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
 uint32_t ropPI2FD(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
+uint32_t ropPI2FW(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
+uint32_t ropPSWAPD(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);

--- a/src/codegen_new/codegen_ops_misc.c
+++ b/src/codegen_new/codegen_ops_misc.c
@@ -612,6 +612,29 @@ ropSTD(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), UNUSED
 }
 
 uint32_t
+ropPREFETCH(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchdat, uint32_t op_32, uint32_t op_pc)
+{
+    if ((fetchdat & 0xc0) == 0xc0)
+        return 0;
+
+    codegen_mark_code_present(block, cs + op_pc, 1);
+    codegen_generate_ea(ir, op_ea_seg, fetchdat, op_ssegs, &op_pc, op_32, 0);
+    return op_pc + 1;
+}
+
+uint32_t
+ropFEMMS(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), UNUSED(uint32_t fetchdat), UNUSED(uint32_t op_32), uint32_t op_pc)
+{
+    uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
+    uop_CALL_FUNC_RESULT(ir, IREG_temp0, codegen_femms);
+    uop_CMP_IMM_JZ(ir, IREG_temp0, 1, codegen_exit_rout);
+
+    codegen_mmx_entered = 0;
+    codegen_fpu_entered = 0;
+    return op_pc;
+}
+
+uint32_t
 ropCLI(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), UNUSED(uint32_t fetchdat), UNUSED(uint32_t op_32), uint32_t op_pc)
 {
     if (!IOPLp && (cr4 & (CR4_VME | CR4_PVI)))

--- a/src/codegen_new/codegen_ops_misc.h
+++ b/src/codegen_new/codegen_ops_misc.h
@@ -33,5 +33,8 @@ uint32_t ropSTC(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetc
 uint32_t ropCLD(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
 uint32_t ropSTD(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
 
+uint32_t ropPREFETCH(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
+uint32_t ropFEMMS(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
+
 uint32_t ropCLI(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
 uint32_t ropSTI(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);

--- a/src/cpu/386_dynarec.c
+++ b/src/cpu/386_dynarec.c
@@ -57,6 +57,23 @@ int inrecomp                = 0;
 int cpu_block_end           = 0;
 int cpu_end_block_after_ins = 0;
 
+#if defined(__aarch64__) || defined(_M_ARM64)
+/* ARM64-only epoch: monotonically advances on dirty-list transitions so
+   per-block retry state can distinguish dense bursts from stale retries. */
+static uint32_t dynarec_s03e_dirty_epoch             = 0;
+#endif
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+/* ARM64-only policy: require repeated BYTE_MASK dirty-list hits before
+   NO_IMMEDIATES promotion to avoid premature slow-immediate escalation. */
+/* Tuning: raise threshold to 3 consecutive dirty-list retries so transient
+   churn is more likely to recover via retry-decay before forcing NO_IMMEDIATES. */
+#    define DYNAREC_S03B_NO_IMM_THRESHOLD 3
+/* Tuning: retry bursts must stay temporally dense; large gaps reset burst
+   accumulation instead of carrying stale debt into later promotions. */
+#    define DYNAREC_S03E_BURST_GAP_MAX 64
+#endif
+
 #ifdef ENABLE_386_DYNAREC_LOG
 int x386_dynarec_do_log = ENABLE_386_DYNAREC_LOG;
 
@@ -247,6 +264,22 @@ int
 codegen_mmx_enter(void)
 {
     MMX_ENTER();
+    return 0;
+}
+
+int
+codegen_femms(void)
+{
+    if (!cpu_has_feature(CPU_FEATURE_MMX)) {
+        x86illegal();
+        return 1;
+    }
+    if (cr0 & 0xc) {
+        x86_int(7);
+        return 1;
+    }
+
+    x87_emms();
     return 0;
 }
 
@@ -489,12 +522,59 @@ exec386_dynarec_dyn(void)
             }
         }
 #    ifdef USE_NEW_DYNAREC
+        /* ARM64-only: if a BYTE_MASK block executes stably outside the dirty
+           list, clear stale retry debt so a distant future dirty hit does not
+           trigger premature NO_IMMEDIATES promotion. */
+#        if defined(__aarch64__) || defined(_M_ARM64)
+        if (valid_block && !(block->flags & CODEBLOCK_IN_DIRTY_LIST) && (block->flags & CODEBLOCK_BYTE_MASK)
+            && !(block->flags & CODEBLOCK_NO_IMMEDIATES) && block->dirty_list_recompile_hits) {
+            block->dirty_list_recompile_hits = 0;
+            block->dirty_list_last_epoch     = 0;
+        }
+#        endif
+
         if (valid_block && (block->flags & CODEBLOCK_IN_DIRTY_LIST)) {
+            const int had_byte_mask     = !!(block->flags & CODEBLOCK_BYTE_MASK);
+            const int had_no_immediates = !!(block->flags & CODEBLOCK_NO_IMMEDIATES);
+#if defined(__aarch64__) || defined(_M_ARM64)
+            const uint16_t last_epoch_before = block->dirty_list_last_epoch;
+#endif
             block->flags &= ~CODEBLOCK_WAS_RECOMPILED;
-            if (block->flags & CODEBLOCK_BYTE_MASK)
-                block->flags |= CODEBLOCK_NO_IMMEDIATES;
-            else
+            if (had_byte_mask) {
+                if (!had_no_immediates) {
+#if defined(__aarch64__) || defined(_M_ARM64)
+                    /* ARM64-only: wait for repeated dirty-list BYTE_MASK
+                       hits before NO_IMMEDIATES promotion. */
+                    /* Require retries to occur in a dense burst window;
+                       stale widely-spaced retries are reset. */
+                    dynarec_s03e_dirty_epoch++;
+                    {
+                        const uint16_t cur_epoch = (uint16_t) dynarec_s03e_dirty_epoch;
+
+                        if (last_epoch_before != 0) {
+                            const uint16_t epoch_gap = (uint16_t) (cur_epoch - last_epoch_before);
+                            if (epoch_gap > DYNAREC_S03E_BURST_GAP_MAX) {
+                                block->dirty_list_recompile_hits = 0;
+                            }
+                        }
+                        block->dirty_list_last_epoch = cur_epoch;
+                    }
+                    block->dirty_list_recompile_hits++;
+                    if (block->dirty_list_recompile_hits >= DYNAREC_S03B_NO_IMM_THRESHOLD) {
+                        block->flags |= CODEBLOCK_NO_IMMEDIATES;
+                        block->dirty_list_last_epoch = 0;
+                    }
+#else
+                    block->flags |= CODEBLOCK_NO_IMMEDIATES;
+#endif
+                }
+            } else {
+#if defined(__aarch64__) || defined(_M_ARM64)
+                block->dirty_list_recompile_hits = 0;
+                block->dirty_list_last_epoch     = 0;
+#endif
                 block->flags |= CODEBLOCK_BYTE_MASK;
+            }
         }
         if (valid_block && (block->flags & CODEBLOCK_WAS_RECOMPILED) && (block->flags & CODEBLOCK_STATIC_TOP) && block->TOP != (cpu_state.TOP & 7))
 #    else
@@ -741,6 +821,7 @@ exec386_dynarec_dyn(void)
     else
         cpu_state.oldpc = cpu_state.pc;
 #    endif
+
 }
 
 void

--- a/src/cpu/x86_ops_3dnow.h
+++ b/src/cpu/x86_ops_3dnow.h
@@ -515,7 +515,6 @@ op3DNOW_a16(uint32_t fetchdat)
     if (cpu_state.abrt)
         return 1;
     cpu_state.pc++;
-
     return x86_opcodes_3DNOW[opcode](0);
 }
 static int
@@ -530,6 +529,5 @@ op3DNOW_a32(uint32_t fetchdat)
     if (cpu_state.abrt)
         return 1;
     cpu_state.pc++;
-
     return x86_opcodes_3DNOW[opcode](0);
 }

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -442,49 +442,55 @@ main_thread_fn()
     plat_set_thread_name(nullptr, "main_thread");
     framecountx = 0;
     // title_update = 1;
-    uint64_t old_time = elapsed_timer.elapsed();
-    int      drawits = frames = 0;
+    qint64 old_ns = elapsed_timer.nsecsElapsed();
+    qint64 debt_ns;
+    const qint64 quantum_ns  = force_10ms ? 10000000LL : 1000000LL;
+    const qint64 max_debt_ns = 50000000LL;
+    frames                   = 0;
+    debt_ns                  = 0;
     is_cpu_thread             = 1;
     while (!is_quit && cpu_thread_run) {
         /* See if it is time to run a frame of code. */
-        const uint64_t new_time = elapsed_timer.elapsed();
+        const qint64 new_ns = elapsed_timer.nsecsElapsed();
+        debt_ns += (new_ns - old_ns);
+        old_ns = new_ns;
+        if (debt_ns > max_debt_ns)
+            debt_ns = max_debt_ns;
 #ifdef USE_GDBSTUB
-        if (gdbstub_next_asap && (drawits <= 0))
-            drawits = force_10ms ? 10 : 1;
-        else
+        if (gdbstub_next_asap && (debt_ns < quantum_ns))
+            debt_ns = quantum_ns;
 #endif
-            drawits += static_cast<int>(new_time - old_time);
-        old_time = new_time;
-        if ((drawits > 0 || fast_forward) && !dopause) {
-            /* Yes, so run frames now. */
-            do {
+        if (((debt_ns >= quantum_ns) || fast_forward) && !dopause) {
+            /*
+             * Pace with one pc_run() per scheduler pass.
+             * We intentionally avoid burst catch-up (multi-frame loop) because it can
+             * overshoot after dips and amplify <100/>100 speed oscillation.
+             */
 #ifdef USE_INSTRUMENT
-                uint64_t start_time = elapsed_timer.nsecsElapsed();
+            uint64_t start_time = elapsed_timer.nsecsElapsed();
 #endif
-                /* Run a block of code. */
-                pc_run();
+            pc_run();
 
 #ifdef USE_INSTRUMENT
-                if (instru_enabled) {
-                    uint64_t elapsed_us       = (elapsed_timer.nsecsElapsed() - start_time) / 1000;
-                    uint64_t total_elapsed_ms = (uint64_t) ((double) tsc / cpu_s->rspeed * 1000);
-                    printf("[instrument] %llu, %llu\n", total_elapsed_ms, elapsed_us);
-                    if (instru_run_ms && total_elapsed_ms >= instru_run_ms)
-                        break;
-                }
+            if (instru_enabled) {
+                uint64_t elapsed_us       = (elapsed_timer.nsecsElapsed() - start_time) / 1000;
+                uint64_t total_elapsed_ms = (uint64_t) ((double) tsc / cpu_s->rspeed * 1000);
+                printf("[instrument] %llu, %llu\n", total_elapsed_ms, elapsed_us);
+                if (instru_run_ms && total_elapsed_ms >= instru_run_ms)
+                    debt_ns = 0;
+            }
 #endif
-                /* Every 2 emulated seconds we save the machine status. */
-                if (++frames >= (force_10ms ? 200 : 2000) && nvr_dosave) {
-                    qt_nvr_save();
-                    nvr_dosave = 0;
-                    frames     = 0;
-                }
-                
-                drawits -= force_10ms ? 10 : 1;
-                if (drawits > 50 || fast_forward)
-                    drawits = 0;
+            /* Every 2 emulated seconds we save the machine status. */
+            if (++frames >= (force_10ms ? 200 : 2000) && nvr_dosave) {
+                qt_nvr_save();
+                nvr_dosave = 0;
+                frames     = 0;
+            }
 
-            } while (drawits > 0);
+            if (!fast_forward && debt_ns >= quantum_ns)
+                debt_ns -= quantum_ns;
+            else
+                debt_ns = 0;
         } else {
             /* Just so we dont overload the host OS. */
 

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -90,6 +90,7 @@ extern bool fast_forward;
 #include <QString>
 #include <QDir>
 #include <QSysInfo>
+#include <QEventLoop>
 #if QT_CONFIG(vulkan)
 #    include <QVulkanInstance>
 #    include <QVulkanFunctions>
@@ -174,6 +175,22 @@ extern "C" void qt_blit(int x, int y, int w, int h, int monitor_index);
 
 extern MainWindow *main_window;
 
+static bool
+canProcessUiEventsInCurrentState()
+{
+    const bool has_modal_widget  = QApplication::activeModalWidget() != nullptr;
+    const bool has_settings_open = main_window && (main_window->findChild<Settings *>() != nullptr);
+    return !cpu_thread_run || dopause || has_modal_widget || has_settings_open;
+}
+
+static void
+processEventsOnlyWhenPausedOrModal()
+{
+    if (!canProcessUiEventsInCurrentState())
+        return;
+    QApplication::processEvents(QEventLoop::ExcludeUserInputEvents | QEventLoop::ExcludeSocketNotifiers);
+}
+
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
     , ui(new Ui::MainWindow)
@@ -240,9 +257,9 @@ MainWindow::MainWindow(QWidget *parent)
 
     QTimer *ledKeyboardTimer = new QTimer(this);
     ledKeyboardTimer->setTimerType(Qt::CoarseTimer);
-    ledKeyboardTimer->setInterval(20);
+    ledKeyboardTimer->setInterval(100);
     connect(ledKeyboardTimer, &QTimer::timeout, this, [this]() {
-        uint8_t prev_caps = 255, prev_num = 255, prev_scroll = 255, prev_kana = 255;
+        static uint8_t prev_caps = 255, prev_num = 255, prev_scroll = 255, prev_kana = 255;
         uint8_t caps, num, scroll, kana;
         keyboard_get_states(&caps, &num, &scroll, &kana);
 
@@ -934,14 +951,11 @@ MainWindow::closeEvent(QCloseEvent *event)
     for (int i = 1; i < MONITORS_NUM; i++) {
         if (renderers[i] && renderers[i]->isHidden()) {
             renderers[i]->show();
-            QApplication::processEvents();
             renderers[i]->switchRenderer(RendererStack::Renderer::Software);
-            QApplication::processEvents();
         }
     }
 
     qt_nvr_save();
-    QApplication::processEvents();
     cpu_thread_run = 0;
     event->accept();
 }
@@ -1146,9 +1160,6 @@ MainWindow::showEvent(QShowEvent *event)
     }
     if (window_remember && vid_resize == 1) {
         ui->stackedWidget->setFixedSize(window_w, window_h);
-#ifndef Q_OS_MACOS
-        QApplication::processEvents();
-#endif
         this->adjustSize();
     }
 }
@@ -1510,7 +1521,7 @@ MainWindow::FindAcceleratorSeq(const char *name)
 {
     int accID = FindAccelerator(name);
     if (accID == -1)
-        return false;
+        return QKeySequence();
 
     return (QKeySequence::fromString(acc_keys[accID].seq));
 }
@@ -1531,6 +1542,7 @@ MainWindow::eventFilter(QObject *receiver, QEvent *event)
             if ((QKeySequence) (ke->key() | (ke->modifiers() & ~Qt::KeypadModifier)) == FindAcceleratorSeq("release_mouse") || (QKeySequence) (ke->key() | ke->modifiers()) == FindAcceleratorSeq("release_mouse")) {
                 plat_mouse_capture(0);
             }
+
         }
 
         if (event->type() == QEvent::KeyPress && video_fullscreen != 0) {
@@ -1795,7 +1807,6 @@ MainWindow::on_actionResizable_window_triggered(bool checked)
         if (monitors[i].target_buffer && show_second_monitors) {
             renderers[i]->show();
             renderers[i]->switchRenderer((RendererStack::Renderer) vid_api);
-            QApplication::processEvents();
         }
     }
 }
@@ -2325,9 +2336,9 @@ MainWindow::changeEvent(QEvent *event)
     if (event->type() == QEvent::LanguageChange) {
         auto size = this->centralWidget()->size();
         QApplication::setFont(Preferences::getUIFont());
-        QApplication::processEvents();
+        processEventsOnlyWhenPausedOrModal();
         main_window->centralWidget()->setFixedSize(size);
-        QApplication::processEvents();
+        processEventsOnlyWhenPausedOrModal();
         if (vid_resize == 1) {
             main_window->centralWidget()->setFixedSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
         }

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -777,10 +777,11 @@ endblit()
     blitmx_contention--;
     blitmx.unlock();
     if (blitmx_contention > 0) {
-        // a deadlock has been observed on linux when toggling via video_toggle_option
-        // because the mutex is typically unfair on linux
-        // => sleep if there's contention
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        /*
+         * Keep contention handoff cooperative without injecting a fixed 1 ms stall
+         * into emulation cadence.
+         */
+        std::this_thread::yield();
     }
 }
 } /*extern "C" */


### PR DESCRIPTION
# Summary

This PR brings ARM64 dynarec 3DNow handling to parity with the 3DNow scope currently implemented in 86Box’s interpreter

Scope clarification:
- This PR targets parity with 86Box’s existing implemented 3DNow subset.
- It does not claim implementation of every historical 3DNow-family ISA variant beyond what 86Box currently models.

Current coverage state in this branch:
- Interpreter: full coverage of 86Box’s implemented 3DNow scope.
- ARM64 dynarec: parity with interpreter for that scope.
- x86-64 dynarec: still has fallback gaps in parts of the same scope.

Practical outcome:
- No regressions observed in local workload validation.
- ARM64 dynarec now covers the implemented 3DNow surface; previously missing ARM64 cases fell back to interpreter execution

ARM64 dynarec/codegen fixes and cleanup to stabilize and improve NDR behavior on ARM64 while keeping behavior aligned with existing paths.

Main changes in this PR:
- ARM64/backend/codegen updates across:
  - `src/codegen_new/codegen*.{c,h}`
  - `src/codegen_new/codegen_backend_arm64*.{c,h}`
  - `src/codegen_new/codegen_ops*.{c,h}`
  - `src/cpu/386_dynarec.c`
  - `src/cpu/x86_ops_3dnow.h`
  - `src/86box.c`
- Qt-side runtime/pacing related adjustments in:
  - `src/qt/qt_main.cpp`
  - `src/qt/qt_mainwindow.cpp`
  - `src/qt/qt_platform.cpp`

runtime/pacing changes should help all platforms.

Notes:
- Scope is intentionally limited to the modified source file set in this branch.
- No ROM or asset changes are required.

# Checklist

- [x] I have tested my changes locally and validated that the functionality works as intended
- [x] I have discussed this with core contributors already
- [ ] This pull request requires changes to the ROM set
- [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
- [ ] This pull request requires changes to the asset set
- [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
