### PR TITLE
Add other BIOS variants for the Acrosser AR-B1479 and also fix its RAM size limit

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -878,6 +878,9 @@ extern int             machine_at_itoxstar_init(const machine_t *);
 
 /* STPC Consumer-II */
 extern int             machine_at_arb1423c_init(const machine_t *);
+#ifdef EMU_DEVICE_H
+extern const device_t  arb1479_device;
+#endif
 extern int             machine_at_arb1479_init(const machine_t *);
 extern int             machine_at_iach488_init(const machine_t *);
 

--- a/src/machine/m_at_486_misc.c
+++ b/src/machine/m_at_486_misc.c
@@ -106,16 +106,98 @@ machine_at_arb1423c_init(const machine_t *model)
     return ret;
 }
 
+static const device_config_t arb1479_config[] = {
+    // clang-format off
+    {
+        .name           = "bios",
+        .description    = "BIOS Version",
+        .type           = CONFIG_BIOS,
+        .default_string = "arb1479",
+        .default_int    = 0,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .selection      = { { 0 } },
+        .bios           = {
+            {
+                .name          = "AMIBIOS 7 (040201) - Revision 1.0 (AR-B1479A)",
+                .internal_name = "arb1479a10",
+                .bios_type     = BIOS_NORMAL, 
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 262144,
+                .files         = { "roms/machines/arb1479/A1479Av10.rom", "" }
+            },
+            {
+                .name          = "AMIBIOS 7 (040201) - Revision 1.01 (AR-B1479A)",
+                .internal_name = "arb1479",
+                .bios_type     = BIOS_NORMAL, 
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 262144,
+                .files         = { "roms/machines/arb1479/1479A.rom", "" }
+            },
+            {
+                .name          = "AMIBIOS 7 (040201) - Revision 1.0 (AR-B1479B)",
+                .internal_name = "arb1479b10",
+                .bios_type     = BIOS_NORMAL, 
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 262144,
+                .files         = { "roms/machines/arb1479/A1479Bv10.rom", "" }
+            },
+            {
+                .name          = "AMIBIOS 7 (040201) - Revision 1.01 (AR-B1479B)",
+                .internal_name = "arb1479b101",
+                .bios_type     = BIOS_NORMAL, 
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 262144,
+                .files         = { "roms/machines/arb1479/1479b.rom", "" }
+            },
+            {
+                .name          = "Phoenix - AwardBIOS v6.00PG - Revision 1.2 (AR-B1479D)",
+                .internal_name = "arb1479d12",
+                .bios_type     = BIOS_NORMAL, 
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 262144,
+                .files         = { "roms/machines/arb1479/W1479D.v12", "" }
+            },
+            { .files_no = 0 }
+        },
+    },
+    { .name = "", .description = "", .type = CONFIG_END }
+    // clang-format on
+};
+
+const device_t arb1479_device = {
+    .name          = "Acrosser AR-B1479",
+    .internal_name = "arb1479_device",
+    .flags         = 0,
+    .local         = 0,
+    .init          = NULL,
+    .close         = NULL,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = arb1479_config
+};
+
 int
 machine_at_arb1479_init(const machine_t *model)
 {
-    int ret;
+    int         ret = 0;
+    const char *fn;
 
-    ret = bios_load_linear("roms/machines/arb1479/1479A.rom",
-                           0x000c0000, 262144, 0);
-
-    if (bios_only || !ret)
+    /* No ROMs available */
+    if (!device_available(model->device))
         return ret;
+
+    device_context(model->device);
+    fn  = device_get_bios_file(machine_get_device(machine), device_get_config_bios("bios"), 0);
+    ret = bios_load_linear(fn, 0x000c0000, 262144, 0);
+    device_context_restore();
 
     machine_at_common_init(model);
 

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -12501,7 +12501,7 @@ const machine_t machines[] = {
             /* 32 MB soldered SDRAM, neither upgradable nor other known configurations exist. */
             .min  = 32768,
             .max  = 32768,
-            .step = 0
+            .step = 32768
         },
         .nvrmask                  = 255,
         .jumpered_ecp_dma         = 0,

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -12496,11 +12496,12 @@ const machine_t machines[] = {
             .max_multi   = 2.0
         },
         .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
-        .flags     = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_PCI_INTERNAL | MACHINE_USB, /* Machine has internal video: ST STPC Atlas */
+        .flags     = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_PCI_INTERNAL | MACHINE_USB, /* Machine has internal video: ST STPC Atlas, NIC: Realtek RTL8100B */
         .ram       = {
-            .min  = 8192,
-            .max  = 131072,
-            .step = 8192
+            /* 32 MB soldered SDRAM, neither upgradable nor other known configurations exist. */
+            .min  = 32768,
+            .max  = 32768,
+            .step = 0
         },
         .nvrmask                  = 255,
         .jumpered_ecp_dma         = 0,
@@ -12514,7 +12515,7 @@ const machine_t machines[] = {
         .kbc_p1                   = 0x00000cf0,
         .gpio                     = 0xffffffff,
         .gpio_acpi                = 0xffffffff,
-        .device                   = NULL,
+        .device                   = &arb1479_device,
         .kbd_device               = NULL,
         .fdc_device               = NULL,
         .vid_device               = NULL,


### PR DESCRIPTION
Summary
=======
This adds the following BIOS variants for the Acrosser AR-B1479 machine (aside from AMIBIOS 7 - Revision 1.01 for the B1479A, which is the default):
* AMIBIOS 7 (040201) - Revision 1.0 (AR-B1479A)
* AMIBIOS 7 (040201) - Revision 1.0 (AR-B1479B)
* AMIBIOS 7 (040201) - Revision 1.01 (AR-B1479B)
* Phoenix - AwardBIOS v6.00PG - Revision 1.2 (AR-B1479D)

As the machine seemingly only shipped with 32 MB of soldered SDRAM, I also changed both the minimum and maximum RAM limit to 32 MB.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/482
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
https://theretroweb.com/motherboards/s/acrosser-ar-b1479a
https://www.manualslib.com/manual/1344506/Acrosser-Technology-Ar-B1479.html

Special thanks
==========
Special thanks to explorerexe (chrdotexe) for finding the AwardBIOS v6.00PG V1.2 ROM for the AR-B1479D
