### PR TITLE
Add configurable VM debug snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,34 @@ Building
 ---------
 For instructions on how to build 86Box from source, see the [build guide](https://86box.readthedocs.io/en/latest/dev/buildguide.html).
 
+VM debug snapshots
+------------------
+
+This development branch includes a VM debug snapshot facility intended to make paused emulator state easier to inspect and share during debugging.
+
+When the VM is paused, use the VM debug snapshot action to create a timestamped directory under the VM path:
+
+```
+debug_snapshots/snapshot_YYYYMMDD_HHMMSS/
+```
+
+The snapshot contents can be configured from the snapshot contents dialog. The currently selectable core data is:
+
+* CPU registers and bytes around CS:IP
+* Conventional RAM dump, capped at 640 KB and reduced automatically when the configured machine RAM is smaller
+* Recent I/O port trace
+* Active device list
+* Detailed dumps for active devices that expose snapshot support
+
+The manifest records the configured RAM size and the exact number of conventional RAM bytes written, so machines with less than 640 KB are represented accurately.
+
+Detailed device snapshot support is currently implemented for:
+
+* IBM EGA and compatible EGA variants, producing `ega.txt` and `ega_vram.bin`
+* IBM CGA and Pravetz VDC-2, producing `cga.txt` and `cga_vram.bin`
+
+The mechanism is intentionally extensible. Devices can opt in by filling the optional `debug_snapshot` callback in their `device_t` definition. Once a device exposes that callback and is active in the VM, it appears automatically in the snapshot contents dialog and can be enabled or disabled by the user.
+
 Licensing
 ---------
 

--- a/src/device.c
+++ b/src/device.c
@@ -1221,12 +1221,10 @@ device_debug_snapshot_provider_set_enabled(int idx, int enabled)
 void
 device_debug_snapshot(debug_snapshot_writer_t *w, int include_list, int include_details)
 {
-    char path[1024];
     FILE *f = NULL;
 
     if (include_list) {
-        path_append_filename(path, w->devices_dir, "devices.txt");
-        f = fopen(path, "wb");
+        f = debug_snapshot_fopen_write(w->devices_dir, "devices.txt");
         if (f) {
             fprintf(f, "[DEVICES]\r\n");
             fprintf(f, "count=%d\r\n\r\n", DEVICE_MAX);
@@ -1248,14 +1246,15 @@ device_debug_snapshot(debug_snapshot_writer_t *w, int include_list, int include_
         }
 
         if (include_details && devices[c]->debug_snapshot && device_priv[c] && device_debug_snapshot_enabled[c]) {
-            const char *internal = devices[c]->internal_name ? devices[c]->internal_name : "unknown";
+            char internal[256];
             char dev_dir[1024];
+            debug_snapshot_sanitize_component(internal, sizeof(internal), devices[c]->internal_name);
             path_append_filename(dev_dir, w->devices_dir, internal);
             plat_dir_create(dev_dir);
 
             debug_snapshot_writer_t dev_w;
-            strncpy(dev_w.dir,         w->dir,    sizeof(dev_w.dir) - 1);
-            strncpy(dev_w.devices_dir, dev_dir,   sizeof(dev_w.devices_dir) - 1);
+            snprintf(dev_w.dir,         sizeof(dev_w.dir),         "%s", w->dir);
+            snprintf(dev_w.devices_dir, sizeof(dev_w.devices_dir), "%s", dev_dir);
             devices[c]->debug_snapshot(&dev_w, device_priv[c]);
         }
     }

--- a/src/device.c
+++ b/src/device.c
@@ -51,10 +51,12 @@
 #include <86box/device.h>
 #include <86box/machine.h>
 #include <86box/mem.h>
+#include <86box/path.h>
 #include <86box/plat.h>
 #include <86box/rom.h>
 #include <86box/sound.h>
 #include <86box/ui.h>
+#include <86box/debug_snapshot.h>
 
 #define DEVICE_MAX 256 /* max # of devices */
 
@@ -63,6 +65,7 @@ static void            *device_priv[DEVICE_MAX];
 static device_context_t device_current;
 static device_context_t device_prev;
 static void            *device_common_priv;
+static uint8_t          device_debug_snapshot_enabled[DEVICE_MAX];
 
 #ifdef ENABLE_DEVICE_LOG
 int device_do_log = ENABLE_DEVICE_LOG;
@@ -87,6 +90,7 @@ void
 device_init(void)
 {
     memset(devices, 0x00, sizeof(devices));
+    memset(device_debug_snapshot_enabled, 0x01, sizeof(device_debug_snapshot_enabled));
 }
 
 void
@@ -1143,5 +1147,119 @@ const device_t device_internal = {
     .available     = NULL,
     .speed_changed = NULL,
     .force_redraw  = NULL,
-    .config        = NULL
+    .config        = NULL,
+    .debug_snapshot = NULL
 };
+
+static int
+device_debug_snapshot_slot_from_index(int idx)
+{
+    int n = 0;
+
+    for (int c = 0; c < DEVICE_MAX; c++) {
+        if (!devices[c] || !device_priv[c] || !devices[c]->debug_snapshot)
+            continue;
+
+        if (n == idx)
+            return c;
+        n++;
+    }
+
+    return -1;
+}
+
+int
+device_debug_snapshot_provider_count(void)
+{
+    int count = 0;
+
+    for (int c = 0; c < DEVICE_MAX; c++) {
+        if (devices[c] && device_priv[c] && devices[c]->debug_snapshot)
+            count++;
+    }
+
+    return count;
+}
+
+const char *
+device_debug_snapshot_provider_name(int idx)
+{
+    static char name[256];
+    int         c = device_debug_snapshot_slot_from_index(idx);
+
+    if (c < 0)
+        return "";
+
+    snprintf(name, sizeof(name), "%s (%s)",
+             devices[c]->name ? devices[c]->name : "unknown",
+             devices[c]->internal_name ? devices[c]->internal_name : "unknown");
+    return name;
+}
+
+int
+device_debug_snapshot_provider_enabled(int idx)
+{
+    int c = device_debug_snapshot_slot_from_index(idx);
+
+    if (c < 0)
+        return 0;
+
+    return device_debug_snapshot_enabled[c];
+}
+
+void
+device_debug_snapshot_provider_set_enabled(int idx, int enabled)
+{
+    int c = device_debug_snapshot_slot_from_index(idx);
+
+    if (c < 0)
+        return;
+
+    device_debug_snapshot_enabled[c] = enabled ? 1 : 0;
+}
+
+void
+device_debug_snapshot(debug_snapshot_writer_t *w, int include_list, int include_details)
+{
+    char path[1024];
+    FILE *f = NULL;
+
+    if (include_list) {
+        path_append_filename(path, w->devices_dir, "devices.txt");
+        f = fopen(path, "wb");
+        if (f) {
+            fprintf(f, "[DEVICES]\r\n");
+            fprintf(f, "count=%d\r\n\r\n", DEVICE_MAX);
+        }
+    }
+
+    for (int c = 0; c < DEVICE_MAX; c++) {
+        if (!devices[c])
+            continue;
+        if (f) {
+            fprintf(f, "[DEVICE_%d]\r\n", c);
+            fprintf(f, "name=%s\r\n", devices[c]->name ? devices[c]->name : "unknown");
+            fprintf(f, "internal_name=%s\r\n", devices[c]->internal_name ? devices[c]->internal_name : "");
+            fprintf(f, "flags=%08X\r\n", (unsigned) devices[c]->flags);
+            fprintf(f, "has_priv=%d\r\n", device_priv[c] != NULL ? 1 : 0);
+            fprintf(f, "has_debug_snapshot=%d\r\n", devices[c]->debug_snapshot != NULL ? 1 : 0);
+            fprintf(f, "debug_snapshot_enabled=%d\r\n", device_debug_snapshot_enabled[c] ? 1 : 0);
+            fprintf(f, "\r\n");
+        }
+
+        if (include_details && devices[c]->debug_snapshot && device_priv[c] && device_debug_snapshot_enabled[c]) {
+            const char *internal = devices[c]->internal_name ? devices[c]->internal_name : "unknown";
+            char dev_dir[1024];
+            path_append_filename(dev_dir, w->devices_dir, internal);
+            plat_dir_create(dev_dir);
+
+            debug_snapshot_writer_t dev_w;
+            strncpy(dev_w.dir,         w->dir,    sizeof(dev_w.dir) - 1);
+            strncpy(dev_w.devices_dir, dev_dir,   sizeof(dev_w.devices_dir) - 1);
+            devices[c]->debug_snapshot(&dev_w, device_priv[c]);
+        }
+    }
+
+    if (f)
+        fclose(f);
+}

--- a/src/include/86box/debug_snapshot.h
+++ b/src/include/86box/debug_snapshot.h
@@ -49,6 +49,11 @@ extern const char *debug_snapshot_option_name(int idx);
 extern int         debug_snapshot_option_enabled(int idx);
 extern void        debug_snapshot_option_set_enabled(int idx, int enabled);
 
+/* Snapshot file/path helpers. */
+extern FILE       *debug_snapshot_fopen_write(const char *dir, const char *filename);
+extern void        debug_snapshot_sanitize_component(char *dest, size_t dest_size,
+                                                     const char *src);
+
 /* Category flags for UI grouping */
 #define SNAPSHOT_CAT_CORE    0 /* cpu.txt, ram640.bin, io_trace.txt, devices.txt (always active) */
 #define SNAPSHOT_CAT_DEVICE  1 /* Device-specific data (toggleable) */

--- a/src/include/86box/debug_snapshot.h
+++ b/src/include/86box/debug_snapshot.h
@@ -1,0 +1,91 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          VM debug snapshot: capture reproducible emulator state for
+ *          offline analysis when the VM is paused.
+ */
+#ifndef EMU_DEBUG_SNAPSHOT_H
+#define EMU_DEBUG_SNAPSHOT_H
+
+#include <stdint.h>
+#include <stdio.h>
+
+/* ------------------------------------------------------------------ */
+/* Provider API                                                         */
+/* ------------------------------------------------------------------ */
+
+typedef struct debug_snapshot_writer_t {
+    char dir[1024];         /* snapshot root directory              */
+    char devices_dir[1024]; /* <dir>/devices/                       */
+} debug_snapshot_writer_t;
+
+typedef void (*debug_snapshot_provider_fn)(debug_snapshot_writer_t *w, void *priv);
+
+/* Register an optional device provider (called at device init time). */
+extern void debug_snapshot_register_provider(const char              *name,
+                                             debug_snapshot_provider_fn fn,
+                                             void                    *priv);
+
+/* Provider enumeration and enable/disable (UI use). */
+extern int         debug_snapshot_provider_count(void);
+extern const char *debug_snapshot_provider_name(int idx);
+extern int         debug_snapshot_provider_enabled(int idx);
+extern void        debug_snapshot_provider_set_enabled(int idx, int enabled);
+
+/* Core snapshot options controlled by the UI. */
+#define DEBUG_SNAPSHOT_OPT_CPU            0
+#define DEBUG_SNAPSHOT_OPT_RAM640         1
+#define DEBUG_SNAPSHOT_OPT_IO_TRACE       2
+#define DEBUG_SNAPSHOT_OPT_DEVICE_LIST    3
+#define DEBUG_SNAPSHOT_OPT_DEVICE_DETAILS 4
+#define DEBUG_SNAPSHOT_OPT_COUNT          5
+
+extern const char *debug_snapshot_option_name(int idx);
+extern int         debug_snapshot_option_enabled(int idx);
+extern void        debug_snapshot_option_set_enabled(int idx, int enabled);
+
+/* Category flags for UI grouping */
+#define SNAPSHOT_CAT_CORE    0 /* cpu.txt, ram640.bin, io_trace.txt, devices.txt (always active) */
+#define SNAPSHOT_CAT_DEVICE  1 /* Device-specific data (toggleable) */
+#define SNAPSHOT_CAT_CUSTOM  2 /* Manual providers registered by code (toggleable) */
+
+/*
+ * Trigger a full snapshot.  Must be called while the VM is paused.
+ * Returns a pointer to a static string with the snapshot directory
+ * path on success, or NULL on failure.
+ */
+extern const char *debug_snapshot_dump_now(void);
+
+/* ------------------------------------------------------------------ */
+/* IO trace ring buffer                                                 */
+/* ------------------------------------------------------------------ */
+
+#define VM_DEBUG_IO_TRACE_LEN 4096 /* must be a power of two */
+
+typedef struct {
+    uint32_t seq;    /* monotone sequence number (1-based; 0 = empty slot) */
+    uint16_t cs_sel; /* CS selector at time of access                       */
+    uint32_t ip_off; /* IP (offset) at time of access                       */
+    uint32_t phys_ip;/* linear CS:IP                                        */
+    uint8_t  dir;    /* 0 = IN, 1 = OUT                                     */
+    uint16_t port;
+    uint8_t  width;  /* 1, 2, or 4 bytes                                    */
+    uint32_t value;
+    uint16_t ax, bx, cx, dx;
+    uint16_t eflags; /* cpu_state.flags at time of access                   */
+} io_trace_entry_t;
+
+extern io_trace_entry_t      io_trace_buf[VM_DEBUG_IO_TRACE_LEN];
+extern volatile unsigned int io_trace_head; /* index of NEXT write slot    */
+extern volatile unsigned int io_trace_seq;  /* last sequence number used   */
+
+/* Called from inb/outb/inw/outw/inl/outl in io.c. */
+extern void io_trace_record(uint8_t dir, uint16_t port, uint8_t width,
+                            uint32_t value);
+
+#endif /* EMU_DEBUG_SNAPSHOT_H */

--- a/src/include/86box/device.h
+++ b/src/include/86box/device.h
@@ -181,6 +181,9 @@ typedef struct _device_ {
     const char *alias;
     const char *machine;
     const device_config_t *config;
+
+    /* Optional debug snapshot callback (called when VM is paused). */
+    void (*debug_snapshot)(void *w, void *priv);
 } device_t;
 
 typedef struct device_context_t {
@@ -222,6 +225,13 @@ extern void  device_get_name(const device_t *dev, int bus, char *name);
 extern int   device_has_config(const device_t *dev);
 
 extern const char *device_get_bios_name(const device_t *dev, const char *internal_name);
+
+struct debug_snapshot_writer_t;
+extern int         device_debug_snapshot_provider_count(void);
+extern const char *device_debug_snapshot_provider_name(int idx);
+extern int         device_debug_snapshot_provider_enabled(int idx);
+extern void        device_debug_snapshot_provider_set_enabled(int idx, int enabled);
+extern void        device_debug_snapshot(struct debug_snapshot_writer_t *w, int include_list, int include_details);
 extern uint8_t     device_get_bios_type(const device_t *dev, const char *internal_name);
 extern uint8_t     device_get_bios_num_files(const device_t *dev, const char *internal_name);
 extern uint32_t    device_get_bios_local(const device_t *dev, const char *internal_name);

--- a/src/io.c
+++ b/src/io.c
@@ -23,6 +23,7 @@
 #include <wchar.h>
 #define HAVE_STDARG_H
 #include <86box/86box.h>
+#include <86box/debug_snapshot.h>
 #include <86box/io.h>
 #include <86box/timer.h>
 #include "cpu.h"
@@ -391,6 +392,7 @@ inb(uint16_t port)
 #endif
 
     io_log("[%04X:%08X] (%i, %i, %04i) in b(%04X) = %02X\n", CS, cpu_state.pc, in_smm, found, qfound, port, ret);
+    io_trace_record(0, port, 1, ret);
 
     return ret;
 }
@@ -448,6 +450,7 @@ outb(uint16_t port, uint8_t val)
     }
 
     io_log("[%04X:%08X] (%i, %i, %04i) outb(%04X, %02X)\n", CS, cpu_state.pc, in_smm, found, qfound, port, val);
+    io_trace_record(1, port, 1, val);
 
     return;
 }
@@ -528,6 +531,7 @@ inw(uint16_t port)
         cycles -= io_delay;
 
     io_log("[%04X:%08X] (%i, %i, %04i) in w(%04X) = %04X\n", CS, cpu_state.pc, in_smm, found, qfound, port, ret);
+    io_trace_record(0, port, 2, ret);
 
     return ret;
 }
@@ -600,6 +604,7 @@ outw(uint16_t port, uint16_t val)
     }
 
     io_log("[%04X:%08X] (%i, %i, %04i) outw(%04X, %04X)\n", CS, cpu_state.pc, in_smm, found, qfound, port, val);
+    io_trace_record(1, port, 2, val);
 
     return;
 }
@@ -712,6 +717,7 @@ inl(uint16_t port)
         cycles -= io_delay;
 
     io_log("[%04X:%08X] (%i, %i, %04i) in l(%04X) = %08X\n", CS, cpu_state.pc, in_smm, found, qfound, port, ret);
+    io_trace_record(0, port, 4, ret);
 
     return ret;
 }
@@ -801,6 +807,7 @@ outl(uint16_t port, uint32_t val)
     }
 
     io_log("[%04X:%08X] (%i, %i, %04i) outl(%04X, %08X)\n", CS, cpu_state.pc, in_smm, found, qfound, port, val);
+    io_trace_record(1, port, 4, val);
 
     return;
 }

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -55,6 +55,7 @@ extern "C" {
 #include <86box/nvr.h>
 #include <86box/acpi.h>
 #include <86box/renderdefs.h>
+#include <86box/debug_snapshot.h>
 
 #ifdef USE_VNC
 #    include <86box/vnc.h>
@@ -70,6 +71,12 @@ extern bool cpu_thread_running;
 extern bool fast_forward;
 };
 
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QListWidget>
+#include <QVBoxLayout>
 #include <QGuiApplication>
 #include <QWindow>
 #include <QTimer>
@@ -2262,6 +2269,7 @@ MainWindow::updateUiPauseState()
     ui->actionPause->setIcon(pause_icon);
     ui->actionPause->setToolTip(tooltip_text);
     ui->actionPause->setText(menu_text);
+    ui->actionDump_VM_Debug_Snapshot->setEnabled(dopause != 0);
     emit vmmRunningStateChanged(static_cast<VMManagerProtocol::RunningState>(window_blocked ? (dopause ? VMManagerProtocol::RunningState::PausedWaiting : VMManagerProtocol::RunningState::RunningWaiting) : (VMManagerProtocol::RunningState) dopause));
 }
 
@@ -2398,6 +2406,135 @@ MainWindow::on_actionMCA_devices_triggered()
 {
     if (const auto dlg = new MCADeviceList(this))
         dlg->exec();
+}
+
+void
+MainWindow::on_actionDump_VM_Debug_Snapshot_triggered()
+{
+    const char *dir = debug_snapshot_dump_now();
+    if (dir)
+        emit statusBarMessage(tr("VM debug snapshot saved to: %1").arg(QString::fromLocal8Bit(dir)));
+    else
+        emit statusBarMessage(tr("VM debug snapshot failed (VM must be paused)."));
+}
+
+void
+MainWindow::on_actionConfigure_Snapshot_Providers_triggered()
+{
+    enum {
+        SnapshotItemCore = 1,
+        SnapshotItemDevice,
+        SnapshotItemCustom
+    };
+
+    int device_count = device_debug_snapshot_provider_count();
+    int custom_count = debug_snapshot_provider_count();
+
+    QDialog dlg(this);
+    dlg.setWindowTitle(tr("VM Snapshot Contents"));
+    dlg.setMinimumWidth(430);
+
+    auto *list = new QListWidget(&dlg);
+
+    auto *coreLabel = new QListWidgetItem("--- Core Data ---", list);
+    coreLabel->setFlags(coreLabel->flags() & ~(Qt::ItemIsSelectable | Qt::ItemIsEnabled));
+    coreLabel->setBackground(QBrush(QColor(240, 240, 240)));
+
+    for (int i = 0; i < DEBUG_SNAPSHOT_OPT_COUNT; i++) {
+        auto *item = new QListWidgetItem(QString::fromUtf8(debug_snapshot_option_name(i)), list);
+        item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+        item->setCheckState(debug_snapshot_option_enabled(i) ? Qt::Checked : Qt::Unchecked);
+        item->setData(Qt::UserRole, SnapshotItemCore);
+        item->setData(Qt::UserRole + 1, i);
+    }
+
+    auto *devLabel = new QListWidgetItem("--- Active Device Dumps ---", list);
+    devLabel->setFlags(devLabel->flags() & ~(Qt::ItemIsSelectable | Qt::ItemIsEnabled));
+    devLabel->setBackground(QBrush(QColor(240, 240, 240)));
+
+    if (device_count > 0) {
+        for (int i = 0; i < device_count; i++) {
+            auto *item = new QListWidgetItem(QString::fromUtf8(device_debug_snapshot_provider_name(i)), list);
+            item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+            item->setCheckState(device_debug_snapshot_provider_enabled(i) ? Qt::Checked : Qt::Unchecked);
+            item->setData(Qt::UserRole, SnapshotItemDevice);
+            item->setData(Qt::UserRole + 1, i);
+        }
+    } else {
+        auto *item = new QListWidgetItem(tr("No active devices expose detailed snapshot data"), list);
+        item->setFlags(item->flags() & ~(Qt::ItemIsSelectable | Qt::ItemIsEnabled));
+    }
+
+    if (custom_count > 0) {
+        auto *customLabel = new QListWidgetItem("--- Custom Providers ---", list);
+        customLabel->setFlags(customLabel->flags() & ~(Qt::ItemIsSelectable | Qt::ItemIsEnabled));
+        customLabel->setBackground(QBrush(QColor(240, 240, 240)));
+
+        for (int i = 0; i < custom_count; i++) {
+            auto *item = new QListWidgetItem(QString::fromUtf8(debug_snapshot_provider_name(i)), list);
+            item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+            item->setCheckState(debug_snapshot_provider_enabled(i) ? Qt::Checked : Qt::Unchecked);
+            item->setData(Qt::UserRole, SnapshotItemCustom);
+            item->setData(Qt::UserRole + 1, i);
+        }
+    }
+
+    auto *selectAll  = new QPushButton(tr("Select all"), &dlg);
+    auto *selectNone = new QPushButton(tr("Select none"), &dlg);
+    auto *buttons    = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dlg);
+
+    connect(selectAll, &QPushButton::clicked, [list]() {
+        for (int i = 0; i < list->count(); i++) {
+            auto *item = list->item(i);
+            if (item->flags() & Qt::ItemIsUserCheckable)
+                item->setCheckState(Qt::Checked);
+        }
+    });
+    connect(selectNone, &QPushButton::clicked, [list]() {
+        for (int i = 0; i < list->count(); i++) {
+            auto *item = list->item(i);
+            if (item->flags() & Qt::ItemIsUserCheckable)
+                item->setCheckState(Qt::Unchecked);
+        }
+    });
+    connect(buttons, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
+
+    auto *btnRow = new QHBoxLayout;
+    btnRow->addWidget(selectAll);
+    btnRow->addWidget(selectNone);
+    btnRow->addStretch();
+    btnRow->addWidget(buttons);
+
+    auto *layout = new QVBoxLayout(&dlg);
+    layout->addWidget(new QLabel(tr("Select data to include in the next VM debug snapshot:"), &dlg));
+    layout->addWidget(list);
+    layout->addLayout(btnRow);
+
+    if (dlg.exec() == QDialog::Accepted) {
+        for (int i = 0; i < list->count(); i++) {
+            auto *item = list->item(i);
+            if (item->flags() & Qt::ItemIsUserCheckable) {
+                int type    = item->data(Qt::UserRole).toInt();
+                int idx     = item->data(Qt::UserRole + 1).toInt();
+                int enabled = item->checkState() == Qt::Checked ? 1 : 0;
+
+                switch (type) {
+                    case SnapshotItemCore:
+                        debug_snapshot_option_set_enabled(idx, enabled);
+                        break;
+                    case SnapshotItemDevice:
+                        device_debug_snapshot_provider_set_enabled(idx, enabled);
+                        break;
+                    case SnapshotItemCustom:
+                        debug_snapshot_provider_set_enabled(idx, enabled);
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+    }
 }
 
 void

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -138,6 +138,8 @@ private slots:
     void getTitle_(wchar_t *title);
 
     void on_actionMCA_devices_triggered();
+    void on_actionDump_VM_Debug_Snapshot_triggered();
+    void on_actionConfigure_Snapshot_Providers_triggered();
 
 protected:
     void keyPressEvent(QKeyEvent *event) override;

--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -120,6 +120,9 @@
     <addaction name="actionBegin_trace"/>
     <addaction name="actionEnd_trace"/>
     <addaction name="separator"/>
+    <addaction name="actionDump_VM_Debug_Snapshot"/>
+    <addaction name="actionConfigure_Snapshot_Providers"/>
+    <addaction name="separator"/>
     <addaction name="actionMCA_devices"/>
     <addaction name="separator"/>
     <addaction name="actionOpen_printer_tray"/>
@@ -979,6 +982,25 @@
    </property>
    <property name="toolTip">
     <string>Fast forward</string>
+   </property>
+  </action>
+  <action name="actionDump_VM_Debug_Snapshot">
+   <property name="text">
+    <string>Dump VM debug snapshot</string>
+   </property>
+   <property name="toolTip">
+    <string>Dump VM debug snapshot while paused</string>
+   </property>
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+  </action>
+  <action name="actionConfigure_Snapshot_Providers">
+   <property name="text">
+    <string>Configure snapshot providers...</string>
+   </property>
+   <property name="toolTip">
+    <string>Enable or disable optional device providers for VM debug snapshots</string>
    </property>
   </action>
  </widget>

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(utils OBJECT
     cJSON.c
     crc.c
     crc32.c
+    debug_snapshot.c
     fifo.c
     fifo8.c
     ini.c

--- a/src/utils/debug_snapshot.c
+++ b/src/utils/debug_snapshot.c
@@ -1,0 +1,463 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          VM debug snapshot: capture reproducible emulator state for
+ *          offline analysis when the VM is paused.
+ *
+ *          Generates under <usr_path>/debug_snapshots/snapshot_YYYYMMDD_HHMMSS/:
+ *            manifest.txt   – metadata
+ *            cpu.txt        – registers, segments, hexdump around CS:IP
+ *            cpu_code.bin   – raw bytes around CS:IP
+ *            ram640.bin     – conventional memory 0x00000–0x9FFFF
+ *            io_trace.txt   – last VM_DEBUG_IO_TRACE_LEN port accesses
+ *            devices/       – optional per-device files (provider API)
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <86box/86box.h>
+#include <86box/path.h>
+#include <86box/plat.h>
+#include <86box/mem.h>
+#include <86box/machine.h>
+#include <86box/device.h>
+#include <86box/debug_snapshot.h>
+
+/* cpu.h lives in src/cpu/ which is added to the include path by CMake */
+#include "cpu.h"
+
+/* ------------------------------------------------------------------ */
+/* IO trace ring buffer (written by io.c via io_trace_record)          */
+/* ------------------------------------------------------------------ */
+
+io_trace_entry_t      io_trace_buf[VM_DEBUG_IO_TRACE_LEN];
+volatile unsigned int io_trace_head = 0;
+volatile unsigned int io_trace_seq  = 0;
+
+void
+io_trace_record(uint8_t dir, uint16_t port, uint8_t width, uint32_t value)
+{
+    unsigned int      idx = io_trace_head & (VM_DEBUG_IO_TRACE_LEN - 1);
+    io_trace_entry_t *e   = &io_trace_buf[idx];
+
+    e->seq     = ++io_trace_seq;
+    e->cs_sel  = CS;
+    e->ip_off  = cpu_state.pc;
+    e->phys_ip = (uint32_t) (cpu_state.seg_cs.base + cpu_state.pc);
+    e->dir     = dir;
+    e->port    = port;
+    e->width   = width;
+    e->value   = value;
+    e->ax      = AX;
+    e->bx      = BX;
+    e->cx      = CX;
+    e->dx      = DX;
+    e->eflags  = cpu_state.flags;
+
+    io_trace_head = (io_trace_head + 1) & (VM_DEBUG_IO_TRACE_LEN - 1);
+}
+
+/* ------------------------------------------------------------------ */
+/* Provider registry                                                    */
+/* ------------------------------------------------------------------ */
+
+#define MAX_PROVIDERS 32
+
+typedef struct {
+    char                       name[64];
+    debug_snapshot_provider_fn fn;
+    void                      *priv;
+    int                        enabled; /* 1 = include in snapshot (default) */
+} provider_entry_t;
+
+static provider_entry_t providers[MAX_PROVIDERS];
+static int              provider_count = 0;
+static int              snapshot_options[DEBUG_SNAPSHOT_OPT_COUNT] = {
+    1, 1, 1, 1, 1
+};
+
+void
+debug_snapshot_register_provider(const char *name, debug_snapshot_provider_fn fn,
+                                  void *priv)
+{
+    if (provider_count >= MAX_PROVIDERS)
+        return;
+    strncpy(providers[provider_count].name, name,
+            sizeof(providers[provider_count].name) - 1);
+    providers[provider_count].fn      = fn;
+    providers[provider_count].priv    = priv;
+    providers[provider_count].enabled = 1;
+    provider_count++;
+}
+
+int
+debug_snapshot_provider_count(void)
+{
+    return provider_count;
+}
+
+const char *
+debug_snapshot_provider_name(int idx)
+{
+    if (idx < 0 || idx >= provider_count)
+        return "";
+    return providers[idx].name;
+}
+
+int
+debug_snapshot_provider_enabled(int idx)
+{
+    if (idx < 0 || idx >= provider_count)
+        return 0;
+    return providers[idx].enabled;
+}
+
+void
+debug_snapshot_provider_set_enabled(int idx, int enabled)
+{
+    if (idx < 0 || idx >= provider_count)
+        return;
+    providers[idx].enabled = enabled ? 1 : 0;
+}
+
+const char *
+debug_snapshot_option_name(int idx)
+{
+    switch (idx) {
+        case DEBUG_SNAPSHOT_OPT_CPU:
+            return "CPU registers and code";
+        case DEBUG_SNAPSHOT_OPT_RAM640:
+            return "Conventional RAM (up to 640 KB)";
+        case DEBUG_SNAPSHOT_OPT_IO_TRACE:
+            return "IO port trace";
+        case DEBUG_SNAPSHOT_OPT_DEVICE_LIST:
+            return "Device list";
+        case DEBUG_SNAPSHOT_OPT_DEVICE_DETAILS:
+            return "Detailed active device dumps";
+        default:
+            return "";
+    }
+}
+
+int
+debug_snapshot_option_enabled(int idx)
+{
+    if (idx < 0 || idx >= DEBUG_SNAPSHOT_OPT_COUNT)
+        return 0;
+    return snapshot_options[idx];
+}
+
+void
+debug_snapshot_option_set_enabled(int idx, int enabled)
+{
+    if (idx < 0 || idx >= DEBUG_SNAPSHOT_OPT_COUNT)
+        return;
+    snapshot_options[idx] = enabled ? 1 : 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                              */
+/* ------------------------------------------------------------------ */
+
+static FILE *
+open_in_dir(const char *dir, const char *filename)
+{
+    char path[1024];
+    path_append_filename(path, dir, filename);
+    return fopen(path, "wb");
+}
+
+/* Simple hex dump: 16 bytes per row, annotated with ASCII. */
+static void
+hexdump(FILE *f, const uint8_t *buf, size_t len, uint32_t base_addr)
+{
+    for (size_t i = 0; i < len; i += 16) {
+        fprintf(f, "%08X  ", (unsigned) (base_addr + i));
+        for (size_t j = 0; j < 16; j++) {
+            if (i + j < len)
+                fprintf(f, "%02X ", buf[i + j]);
+            else
+                fprintf(f, "   ");
+            if (j == 7)
+                fputc(' ', f);
+        }
+        fputs(" |", f);
+        for (size_t j = 0; j < 16 && i + j < len; j++) {
+            uint8_t c = buf[i + j];
+            fputc((c >= 0x20 && c < 0x7f) ? c : '.', f);
+        }
+        fputs("|\n", f);
+    }
+}
+
+static void
+read_phys_block(uint8_t *dest, uint32_t addr, uint32_t size)
+{
+    for (uint32_t i = 0; i < size; i++)
+        dest[i] = mem_readb_phys(addr + i);
+}
+
+static uint32_t
+snapshot_conventional_ram_size(void)
+{
+    uint32_t ram_kb = mem_size;
+
+    if (ram_kb > 640)
+        ram_kb = 640;
+
+    return ram_kb << 10;
+}
+
+/* ------------------------------------------------------------------ */
+/* Individual dump functions                                            */
+/* ------------------------------------------------------------------ */
+
+static void
+write_manifest(const char *snap_dir, const char *timestamp)
+{
+    FILE *f = open_in_dir(snap_dir, "manifest.txt");
+    if (!f)
+        return;
+
+    fprintf(f, "[SNAPSHOT]\r\n");
+    fprintf(f, "version=1\r\n");
+    fprintf(f, "timestamp_local=%s\r\n", timestamp);
+    fprintf(f, "paused=1\r\n");
+    fprintf(f, "86box_version=%s\r\n", emu_version[0] ? emu_version : "unknown");
+    fprintf(f, "machine=%s\r\n",
+            (machine >= 0) ? machine_getname(machine) : "unknown");
+
+    /* Extract config file leaf name from full cfg_path. */
+    char cfg_copy[1024];
+    strncpy(cfg_copy, cfg_path, sizeof(cfg_copy) - 1);
+    fprintf(f, "config_name=%s\r\n", path_get_filename(cfg_copy));
+
+    fprintf(f, "\r\n[FILES]\r\n");
+    if (debug_snapshot_option_enabled(DEBUG_SNAPSHOT_OPT_CPU)) {
+        fprintf(f, "cpu=cpu.txt\r\n");
+        fprintf(f, "cpu_code=cpu_code.bin\r\n");
+    }
+    if (debug_snapshot_option_enabled(DEBUG_SNAPSHOT_OPT_RAM640))
+        fprintf(f, "ram640=ram640.bin\r\n");
+    if (debug_snapshot_option_enabled(DEBUG_SNAPSHOT_OPT_IO_TRACE))
+        fprintf(f, "io_trace=io_trace.txt\r\n");
+    if (debug_snapshot_option_enabled(DEBUG_SNAPSHOT_OPT_DEVICE_LIST) ||
+        debug_snapshot_option_enabled(DEBUG_SNAPSHOT_OPT_DEVICE_DETAILS))
+        fprintf(f, "devices=devices/\r\n");
+
+    fprintf(f, "\r\n[RAM]\r\n");
+    fprintf(f, "configured_kb=%u\r\n", mem_size);
+    fprintf(f, "conventional_dump_limit_kb=640\r\n");
+    fprintf(f, "conventional_dump_bytes=%u\r\n", snapshot_conventional_ram_size());
+
+    fclose(f);
+}
+
+static void
+write_cpu(const char *snap_dir)
+{
+    FILE *f = open_in_dir(snap_dir, "cpu.txt");
+    if (!f)
+        return;
+
+    uint32_t cs_base = cpu_state.seg_cs.base;
+    uint32_t ip      = cpu_state.pc;
+    uint32_t phys_ip = cs_base + ip;
+
+    fprintf(f, "[CPU]\r\n");
+    fprintf(f, "CS:IP=%04X:%04X\r\n", CS, (unsigned) (ip & 0xFFFF));
+    fprintf(f, "PHYS_IP=%08X\r\n", phys_ip);
+    fprintf(f, "AX=%04X BX=%04X CX=%04X DX=%04X\r\n", AX, BX, CX, DX);
+    fprintf(f, "SI=%04X DI=%04X BP=%04X SP=%04X\r\n", SI, DI, BP, SP);
+    fprintf(f, "DS=%04X ES=%04X SS=%04X FLAGS=%04X\r\n", DS, ES, SS,
+            cpu_state.flags);
+
+    fprintf(f, "\r\n[SEGMENTS]\r\n");
+    fprintf(f, "CS_BASE=%08X\r\n", cs_base);
+    fprintf(f, "DS_BASE=%08X\r\n", (uint32_t) cpu_state.seg_ds.base);
+    fprintf(f, "ES_BASE=%08X\r\n", (uint32_t) cpu_state.seg_es.base);
+    fprintf(f, "SS_BASE=%08X\r\n", (uint32_t) cpu_state.seg_ss.base);
+
+    /* Clamp bytes_before so we don't underflow the segment. */
+    uint32_t bytes_before = (ip >= 32) ? 32 : ip;
+    uint32_t bytes_total  = bytes_before + 96;
+    uint32_t start_phys   = cs_base + ip - bytes_before;
+
+    fprintf(f, "\r\n[CPU_CODE]\r\n");
+    fprintf(f, "start_phys=%08X\r\n", start_phys);
+    fprintf(f, "bytes_before_ip=%u\r\n", bytes_before);
+    fprintf(f, "bytes_after_ip=96\r\n");
+
+    /* Inline hexdump around CS:IP */
+    uint8_t buf[128];
+    read_phys_block(buf, start_phys, bytes_total);
+    fprintf(f, "\r\n[HEXDUMP]\r\n");
+    hexdump(f, buf, bytes_total, start_phys);
+
+    fclose(f);
+}
+
+static void
+write_cpu_code(const char *snap_dir)
+{
+    uint32_t cs_base      = cpu_state.seg_cs.base;
+    uint32_t ip           = cpu_state.pc;
+    uint32_t bytes_before = (ip >= 32) ? 32 : ip;
+    uint32_t bytes_total  = bytes_before + 96;
+    uint32_t start_phys   = cs_base + ip - bytes_before;
+
+    uint8_t buf[128];
+    read_phys_block(buf, start_phys, bytes_total);
+
+    FILE *f = open_in_dir(snap_dir, "cpu_code.bin");
+    if (!f)
+        return;
+    fwrite(buf, 1, bytes_total, f);
+    fclose(f);
+}
+
+static void
+write_ram640(const char *snap_dir)
+{
+#define RAM_CHUNK 0x10000u /* 64 KiB */
+
+    FILE *f = open_in_dir(snap_dir, "ram640.bin");
+    if (!f)
+        return;
+
+    uint32_t ram_size = snapshot_conventional_ram_size();
+
+    uint8_t *chunk = (uint8_t *) malloc(RAM_CHUNK);
+    if (!chunk) {
+        fclose(f);
+        return;
+    }
+
+    for (uint32_t addr = 0; addr < ram_size; addr += RAM_CHUNK) {
+        uint32_t sz = RAM_CHUNK;
+        if (addr + sz > ram_size)
+            sz = ram_size - addr;
+        read_phys_block(chunk, addr, sz);
+        fwrite(chunk, 1, sz, f);
+    }
+
+    free(chunk);
+    fclose(f);
+
+#undef RAM_CHUNK
+}
+
+static void
+write_io_trace(const char *snap_dir)
+{
+    FILE *f = open_in_dir(snap_dir, "io_trace.txt");
+    if (!f)
+        return;
+
+    fprintf(f, "[IO_TRACE]\r\n");
+    fprintf(f,
+            "columns=seq cs ip phys_ip dir port width value ax bx cx dx flags\r\n");
+
+    /*
+     * Walk the ring buffer from oldest to newest entry.
+     * io_trace_head points at the slot that will be overwritten NEXT,
+     * so it is also the oldest slot when the buffer is full.
+     */
+    unsigned int start = io_trace_head & (VM_DEBUG_IO_TRACE_LEN - 1);
+    for (unsigned int i = 0; i < VM_DEBUG_IO_TRACE_LEN; i++) {
+        unsigned int          idx = (start + i) & (VM_DEBUG_IO_TRACE_LEN - 1);
+        const io_trace_entry_t *e = &io_trace_buf[idx];
+
+        if (e->seq == 0)
+            continue; /* never written */
+
+        fprintf(f, "%08X %04X %04X %08X %s %04X %u %0*X %04X %04X %04X %04X %04X\r\n",
+                e->seq,
+                e->cs_sel,
+                (unsigned) (e->ip_off & 0xFFFF),
+                e->phys_ip,
+                e->dir ? "OUT" : "IN ",
+                e->port,
+                e->width,
+                e->width * 2, /* hex digits */
+                e->value,
+                e->ax, e->bx, e->cx, e->dx,
+                e->eflags);
+    }
+
+    fclose(f);
+}
+
+/* ------------------------------------------------------------------ */
+/* Public entry point                                                   */
+/* ------------------------------------------------------------------ */
+
+static char last_snap_dir[1024];
+
+const char *
+debug_snapshot_dump_now(void)
+{
+    if (!dopause)
+        return NULL;
+
+    /* Build timestamp string. */
+    time_t     now = time(NULL);
+    struct tm *tm  = localtime(&now);
+    char       ts_dir[32];   /* snapshot_YYYYMMDD_HHMMSS */
+    char       ts_human[32]; /* YYYY-MM-DD HH:MM:SS      */
+    strftime(ts_dir,   sizeof(ts_dir),   "snapshot_%Y%m%d_%H%M%S", tm);
+    strftime(ts_human, sizeof(ts_human), "%Y-%m-%d %H:%M:%S",      tm);
+
+    /* Ensure <usr_path>/debug_snapshots/ exists. */
+    char snapshots_root[1024];
+    path_append_filename(snapshots_root, usr_path, "debug_snapshots");
+    plat_dir_create(snapshots_root);
+
+    /* Create the per-snapshot directory. */
+    char snap_dir[1024];
+    path_append_filename(snap_dir, snapshots_root, ts_dir);
+    if (plat_dir_create(snap_dir) != 0)
+        return NULL;
+
+    /* Create devices/ subdirectory for optional providers. */
+    char devices_dir[1024];
+    path_append_filename(devices_dir, snap_dir, "devices");
+    plat_dir_create(devices_dir);
+
+    /* Write core files. */
+    write_manifest(snap_dir, ts_human);
+    if (debug_snapshot_option_enabled(DEBUG_SNAPSHOT_OPT_CPU)) {
+        write_cpu(snap_dir);
+        write_cpu_code(snap_dir);
+    }
+    if (debug_snapshot_option_enabled(DEBUG_SNAPSHOT_OPT_RAM640))
+        write_ram640(snap_dir);
+    if (debug_snapshot_option_enabled(DEBUG_SNAPSHOT_OPT_IO_TRACE))
+        write_io_trace(snap_dir);
+
+    /* Call device snapshots and registered providers. */
+    debug_snapshot_writer_t w;
+    strncpy(w.dir,         snap_dir,    sizeof(w.dir) - 1);
+    strncpy(w.devices_dir, devices_dir, sizeof(w.devices_dir) - 1);
+
+    device_debug_snapshot(&w,
+                          debug_snapshot_option_enabled(DEBUG_SNAPSHOT_OPT_DEVICE_LIST),
+                          debug_snapshot_option_enabled(DEBUG_SNAPSHOT_OPT_DEVICE_DETAILS));
+
+    for (int i = 0; i < provider_count; i++) {
+        if (providers[i].enabled)
+            providers[i].fn(&w, providers[i].priv);
+    }
+
+    strncpy(last_snap_dir, snap_dir, sizeof(last_snap_dir) - 1);
+    return last_snap_dir;
+}

--- a/src/utils/debug_snapshot.c
+++ b/src/utils/debug_snapshot.c
@@ -23,6 +23,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#ifndef _WIN32
+#    include <fcntl.h>
+#    include <sys/stat.h>
+#    include <sys/types.h>
+#    include <unistd.h>
+#endif
 
 #include <86box/86box.h>
 #include <86box/path.h>
@@ -91,8 +97,8 @@ debug_snapshot_register_provider(const char *name, debug_snapshot_provider_fn fn
 {
     if (provider_count >= MAX_PROVIDERS)
         return;
-    strncpy(providers[provider_count].name, name,
-            sizeof(providers[provider_count].name) - 1);
+    snprintf(providers[provider_count].name,
+             sizeof(providers[provider_count].name), "%s", name ? name : "");
     providers[provider_count].fn      = fn;
     providers[provider_count].priv    = priv;
     providers[provider_count].enabled = 1;
@@ -171,9 +177,65 @@ debug_snapshot_option_set_enabled(int idx, int enabled)
 static FILE *
 open_in_dir(const char *dir, const char *filename)
 {
+    return debug_snapshot_fopen_write(dir, filename);
+}
+
+FILE *
+debug_snapshot_fopen_write(const char *dir, const char *filename)
+{
     char path[1024];
+
+    if (!dir || !filename || !filename[0])
+        return NULL;
+    if (strchr(filename, '/') || strchr(filename, '\\'))
+        return NULL;
+
     path_append_filename(path, dir, filename);
-    return fopen(path, "wb");
+
+#ifdef _WIN32
+    return plat_fopen(path, "wb");
+#else
+    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+    if (fd < 0)
+        return NULL;
+    FILE *f = fdopen(fd, "wb");
+    if (!f)
+        close(fd);
+    return f;
+#endif
+}
+
+void
+debug_snapshot_sanitize_component(char *dest, size_t dest_size, const char *src)
+{
+    size_t pos = 0;
+
+    if (!dest || !dest_size)
+        return;
+
+    if (!src || !src[0])
+        src = "unknown";
+
+    while (*src && pos + 1 < dest_size) {
+        unsigned char ch = (unsigned char) *src++;
+
+        if ((ch >= 'A' && ch <= 'Z') ||
+            (ch >= 'a' && ch <= 'z') ||
+            (ch >= '0' && ch <= '9') ||
+            ch == '_' || ch == '-' || ch == '.')
+            dest[pos++] = (char) ch;
+        else
+            dest[pos++] = '_';
+    }
+
+    if (!pos) {
+        snprintf(dest, dest_size, "%s", "unknown");
+        return;
+    }
+
+    dest[pos] = '\0';
+    if (!strcmp(dest, ".") || !strcmp(dest, ".."))
+        snprintf(dest, dest_size, "%s", "unknown");
 }
 
 /* Simple hex dump: 16 bytes per row, annotated with ASCII. */
@@ -238,7 +300,7 @@ write_manifest(const char *snap_dir, const char *timestamp)
 
     /* Extract config file leaf name from full cfg_path. */
     char cfg_copy[1024];
-    strncpy(cfg_copy, cfg_path, sizeof(cfg_copy) - 1);
+    snprintf(cfg_copy, sizeof(cfg_copy), "%s", cfg_path);
     fprintf(f, "config_name=%s\r\n", path_get_filename(cfg_copy));
 
     fprintf(f, "\r\n[FILES]\r\n");
@@ -410,10 +472,19 @@ debug_snapshot_dump_now(void)
         return NULL;
 
     /* Build timestamp string. */
-    time_t     now = time(NULL);
-    struct tm *tm  = localtime(&now);
+    time_t    now = time(NULL);
+    struct tm time_buf;
+    struct tm *tm;
     char       ts_dir[32];   /* snapshot_YYYYMMDD_HHMMSS */
     char       ts_human[32]; /* YYYY-MM-DD HH:MM:SS      */
+#ifdef _WIN32
+    tm = (localtime_s(&time_buf, &now) == 0) ? &time_buf : NULL;
+#else
+    tm = localtime_r(&now, &time_buf);
+#endif
+    if (!tm)
+        return NULL;
+
     strftime(ts_dir,   sizeof(ts_dir),   "snapshot_%Y%m%d_%H%M%S", tm);
     strftime(ts_human, sizeof(ts_human), "%Y-%m-%d %H:%M:%S",      tm);
 
@@ -446,8 +517,8 @@ debug_snapshot_dump_now(void)
 
     /* Call device snapshots and registered providers. */
     debug_snapshot_writer_t w;
-    strncpy(w.dir,         snap_dir,    sizeof(w.dir) - 1);
-    strncpy(w.devices_dir, devices_dir, sizeof(w.devices_dir) - 1);
+    snprintf(w.dir,         sizeof(w.dir),         "%s", snap_dir);
+    snprintf(w.devices_dir, sizeof(w.devices_dir), "%s", devices_dir);
 
     device_debug_snapshot(&w,
                           debug_snapshot_option_enabled(DEBUG_SNAPSHOT_OPT_DEVICE_LIST),
@@ -458,6 +529,6 @@ debug_snapshot_dump_now(void)
             providers[i].fn(&w, providers[i].priv);
     }
 
-    strncpy(last_snap_dir, snap_dir, sizeof(last_snap_dir) - 1);
+    snprintf(last_snap_dir, sizeof(last_snap_dir), "%s", snap_dir);
     return last_snap_dir;
 }

--- a/src/video/vid_cga.c
+++ b/src/video/vid_cga.c
@@ -29,7 +29,9 @@
 #include <86box/pit.h>
 #include <86box/mem.h>
 #include <86box/rom.h>
+#include <86box/path.h>
 #include <86box/device.h>
+#include <86box/debug_snapshot.h>
 #include <86box/video.h>
 #include <86box/vid_cga.h>
 #include <86box/vid_cga_comp.h>
@@ -69,6 +71,78 @@ static uint8_t interp_lut[2][256][256];
 static video_timings_t timing_cga = { .type = VIDEO_ISA, .write_b = 8, .write_w = 16, .write_l = 32, .read_b = 8, .read_w = 16, .read_l = 32 };
 
 void cga_recalctimings(cga_t *cga);
+
+static void
+cga_debug_snapshot_write_u8_array(FILE *f, const char *name, const uint8_t *data, int count)
+{
+    fprintf(f, "%s=", name);
+    for (int i = 0; i < count; i++)
+        fprintf(f, "%s%02X", i ? " " : "", data[i]);
+    fprintf(f, "\r\n");
+}
+
+static void
+cga_debug_snapshot(void *w_ptr, void *priv)
+{
+    debug_snapshot_writer_t *w   = (debug_snapshot_writer_t *) w_ptr;
+    cga_t                   *cga = (cga_t *) priv;
+    char                     path[1024];
+    FILE                    *f;
+
+    if (!w || !cga)
+        return;
+
+    path_append_filename(path, w->devices_dir, "cga.txt");
+    f = fopen(path, "wb");
+    if (f) {
+        fprintf(f, "[CGA]\r\n");
+        fprintf(f, "vram_bytes=%u\r\n", DEVICE_VRAM);
+        fprintf(f, "revision=%d\r\n", cga->revision);
+        fprintf(f, "composite=%d\r\n", cga->composite);
+        fprintf(f, "snow_enabled=%d\r\n", cga->snow_enabled);
+        fprintf(f, "rgb_type=%d\r\n", cga->rgb_type);
+        fprintf(f, "double_type=%d\r\n", cga->double_type);
+
+        fprintf(f, "\r\n[REGISTERS]\r\n");
+        fprintf(f, "crtcreg=%02X\r\n", cga->crtcreg & 0xff);
+        cga_debug_snapshot_write_u8_array(f, "CRTC[00..1F]", cga->crtc, CGA_NUM_CRTC_REGS);
+        fprintf(f, "cgamode=%02X\r\n", cga->cgamode);
+        fprintf(f, "cgacol=%02X\r\n", cga->cgacol);
+        fprintf(f, "cgastat=%02X\r\n", cga->cgastat);
+        fprintf(f, "lp_strobe=%02X\r\n", cga->lp_strobe);
+
+        fprintf(f, "\r\n[STATE]\r\n");
+        fprintf(f, "memaddr=%04X\r\n", cga->memaddr);
+        fprintf(f, "memaddr_backup=%04X\r\n", cga->memaddr_backup);
+        fprintf(f, "fontbase=%d\r\n", cga->fontbase);
+        fprintf(f, "linepos=%d\r\n", cga->linepos);
+        fprintf(f, "displine=%d\r\n", cga->displine);
+        fprintf(f, "scanline=%d\r\n", cga->scanline);
+        fprintf(f, "vc=%d\r\n", cga->vc);
+        fprintf(f, "cgadispon=%d\r\n", cga->cgadispon);
+        fprintf(f, "cursorvisible=%d\r\n", cga->cursorvisible);
+        fprintf(f, "cursoron=%d\r\n", cga->cursoron);
+        fprintf(f, "cgablink=%d\r\n", cga->cgablink);
+        fprintf(f, "vsynctime=%d\r\n", cga->vsynctime);
+        fprintf(f, "vadj=%d\r\n", cga->vadj);
+        fprintf(f, "oddeven=%d\r\n", cga->oddeven);
+        fprintf(f, "firstline=%d\r\n", cga->firstline);
+        fprintf(f, "lastline=%d\r\n", cga->lastline);
+        fprintf(f, "drawcursor=%d\r\n", cga->drawcursor);
+        fprintf(f, "fullchange=%d\r\n", cga->fullchange);
+        fprintf(f, "dispontime=%llu\r\n", (unsigned long long) cga->dispontime);
+        fprintf(f, "dispofftime=%llu\r\n", (unsigned long long) cga->dispofftime);
+
+        fclose(f);
+    }
+
+    path_append_filename(path, w->devices_dir, "cga_vram.bin");
+    f = fopen(path, "wb");
+    if (f) {
+        fwrite(cga->vram, 1, DEVICE_VRAM, f);
+        fclose(f);
+    }
+}
 
 static void
 cga_update_latch(cga_t *cga)
@@ -952,7 +1026,8 @@ const device_t cga_device = {
     .available     = NULL,
     .speed_changed = cga_speed_changed,
     .force_redraw  = NULL,
-    .config        = cga_config
+    .config        = cga_config,
+    .debug_snapshot = cga_debug_snapshot
 };
 
 const device_t cga_pravetz_device = {
@@ -966,5 +1041,6 @@ const device_t cga_pravetz_device = {
     .available     = NULL,
     .speed_changed = cga_speed_changed,
     .force_redraw  = NULL,
-    .config        = cga_config
+    .config        = cga_config,
+    .debug_snapshot = cga_debug_snapshot
 };

--- a/src/video/vid_cga.c
+++ b/src/video/vid_cga.c
@@ -29,7 +29,6 @@
 #include <86box/pit.h>
 #include <86box/mem.h>
 #include <86box/rom.h>
-#include <86box/path.h>
 #include <86box/device.h>
 #include <86box/debug_snapshot.h>
 #include <86box/video.h>
@@ -86,14 +85,12 @@ cga_debug_snapshot(void *w_ptr, void *priv)
 {
     debug_snapshot_writer_t *w   = (debug_snapshot_writer_t *) w_ptr;
     cga_t                   *cga = (cga_t *) priv;
-    char                     path[1024];
     FILE                    *f;
 
     if (!w || !cga)
         return;
 
-    path_append_filename(path, w->devices_dir, "cga.txt");
-    f = fopen(path, "wb");
+    f = debug_snapshot_fopen_write(w->devices_dir, "cga.txt");
     if (f) {
         fprintf(f, "[CGA]\r\n");
         fprintf(f, "vram_bytes=%u\r\n", DEVICE_VRAM);
@@ -136,8 +133,7 @@ cga_debug_snapshot(void *w_ptr, void *priv)
         fclose(f);
     }
 
-    path_append_filename(path, w->devices_dir, "cga_vram.bin");
-    f = fopen(path, "wb");
+    f = debug_snapshot_fopen_write(w->devices_dir, "cga_vram.bin");
     if (f) {
         fwrite(cga->vram, 1, DEVICE_VRAM, f);
         fclose(f);

--- a/src/video/vid_ega.c
+++ b/src/video/vid_ega.c
@@ -29,7 +29,9 @@
 #include <86box/pit.h>
 #include <86box/mem.h>
 #include <86box/rom.h>
+#include <86box/path.h>
 #include <86box/device.h>
+#include <86box/debug_snapshot.h>
 #include <86box/video.h>
 #include <86box/vid_ati_eeprom.h>
 #include <86box/vid_ega.h>
@@ -1596,6 +1598,102 @@ ega_set_type(void *priv, uint32_t local)
     }
 }
 
+static void
+ega_debug_snapshot_write_u8_array(FILE *f, const char *name, const uint8_t *data, int count)
+{
+    fprintf(f, "%s=", name);
+    for (int i = 0; i < count; i++)
+        fprintf(f, "%02X%s", (unsigned) data[i], (i + 1) < count ? " " : "\r\n");
+}
+
+static void
+ega_debug_snapshot(void *w_ptr, void *priv)
+{
+    debug_snapshot_writer_t *w   = (debug_snapshot_writer_t *) w_ptr;
+    ega_t                   *ega = (ega_t *) priv;
+    char                     path[1024];
+    FILE                    *f;
+
+    if (!w || !ega)
+        return;
+
+    path_append_filename(path, w->devices_dir, "ega.txt");
+    f = fopen(path, "wb");
+    if (f) {
+        fprintf(f, "[EGA]\r\n");
+        fprintf(f, "actual_type=%d\r\n", ega->actual_type);
+        fprintf(f, "chipset=%d\r\n", ega->chipset);
+        fprintf(f, "mono_display=%d\r\n", ega->mono_display);
+        fprintf(f, "vram_limit=%08X\r\n", (unsigned) ega->vram_limit);
+        fprintf(f, "vrammask=%08X\r\n", (unsigned) ega->vrammask);
+        fprintf(f, "miscout=%02X\r\n", (unsigned) ega->miscout);
+        fprintf(f, "crtcreg=%02X\r\n", (unsigned) ega->crtcreg);
+        fprintf(f, "seqaddr=%02X\r\n", (unsigned) ega->seqaddr);
+        fprintf(f, "gdcaddr=%02X\r\n", (unsigned) ega->gdcaddr);
+        fprintf(f, "attraddr=%02X\r\n", (unsigned) ega->attraddr);
+        fprintf(f, "attrff=%02X\r\n", (unsigned) ega->attrff);
+        fprintf(f, "attr_palette_enable=%02X\r\n", (unsigned) ega->attr_palette_enable);
+        fprintf(f, "status=%02X\r\n", (unsigned) ega->status);
+
+        fprintf(f, "\r\n[REGISTERS]\r\n");
+        ega_debug_snapshot_write_u8_array(f, "CRTC[00..18]", ega->crtc, 0x19);
+        ega_debug_snapshot_write_u8_array(f, "SEQ[00..04]", ega->seqregs, 0x05);
+        ega_debug_snapshot_write_u8_array(f, "GDC[00..08]", ega->gdcreg, 0x09);
+        ega_debug_snapshot_write_u8_array(f, "ATTR[00..14]", ega->attrregs, 0x15);
+        ega_debug_snapshot_write_u8_array(f, "EGAPAL[00..0F]", ega->egapal, 0x10);
+
+        fprintf(f, "\r\n[STATE]\r\n");
+        fprintf(f, "memaddr=%08X\r\n", (unsigned) ega->memaddr);
+        fprintf(f, "memaddr_latch=%08X\r\n", (unsigned) ega->memaddr_latch);
+        fprintf(f, "memaddr_backup=%08X\r\n", (unsigned) ega->memaddr_backup);
+        fprintf(f, "cca=%08X\r\n", (unsigned) ega->cca);
+        fprintf(f, "cursoraddr=%08X\r\n", (unsigned) ega->cursoraddr);
+        fprintf(f, "rowoffset=%04X\r\n", (unsigned) ega->rowoffset);
+        fprintf(f, "scanline=%04X\r\n", (unsigned) ega->scanline);
+        fprintf(f, "displine=%04X\r\n", (unsigned) ega->displine);
+        fprintf(f, "vc=%04X\r\n", (unsigned) ega->vc);
+        fprintf(f, "real_vc=%04X\r\n", (unsigned) ega->real_vc);
+        fprintf(f, "linepos=%04X\r\n", (unsigned) ega->linepos);
+        fprintf(f, "vslines=%04X\r\n", (unsigned) ega->vslines);
+        fprintf(f, "dispon=%04X\r\n", (unsigned) ega->dispon);
+        fprintf(f, "hdisp_on=%04X\r\n", (unsigned) ega->hdisp_on);
+        fprintf(f, "vtotal=%04X\r\n", (unsigned) ega->vtotal);
+        fprintf(f, "dispend=%04X\r\n", (unsigned) ega->dispend);
+        fprintf(f, "vsyncstart=%04X\r\n", (unsigned) ega->vsyncstart);
+        fprintf(f, "vblankstart=%04X\r\n", (unsigned) ega->vblankstart);
+        fprintf(f, "split=%04X\r\n", (unsigned) ega->split);
+        fprintf(f, "hdisp=%04X\r\n", (unsigned) ega->hdisp);
+        fprintf(f, "htotal=%04X\r\n", (unsigned) ega->htotal);
+        fprintf(f, "scrollcache=%04X\r\n", (unsigned) ega->scrollcache);
+        fprintf(f, "linecountff=%04X\r\n", (unsigned) ega->linecountff);
+        fprintf(f, "oddeven=%04X\r\n", (unsigned) ega->oddeven);
+        fprintf(f, "lowres=%04X\r\n", (unsigned) ega->lowres);
+        fprintf(f, "interlace=%04X\r\n", (unsigned) ega->interlace);
+        fprintf(f, "linedbl=%04X\r\n", (unsigned) ega->linedbl);
+        fprintf(f, "lindebl=%04X\r\n", (unsigned) ega->lindebl);
+        fprintf(f, "vres=%04X\r\n", (unsigned) ega->vres);
+        fprintf(f, "vidclock=%04X\r\n", (unsigned) ega->vidclock);
+
+        fprintf(f, "\r\n[DERIVED]\r\n");
+        fprintf(f, "start_addr=%04X\r\n", (unsigned) (((uint32_t) ega->crtc[0x0c] << 8) | ega->crtc[0x0d]));
+        fprintf(f, "cursor_start=%04X\r\n", (unsigned) (((uint32_t) ega->crtc[0x0e] << 8) | ega->crtc[0x0f]));
+        fprintf(f, "offset=%02X\r\n", (unsigned) ega->crtc[0x13]);
+        fprintf(f, "vertical_displayed=%02X\r\n", (unsigned) ega->crtc[0x12]);
+        fprintf(f, "max_scanline=%02X\r\n", (unsigned) (ega->crtc[0x09] & 0x1f));
+        fprintf(f, "line_compare_raw=%02X\r\n", (unsigned) ega->crtc[0x18]);
+
+        fclose(f);
+    }
+
+    path_append_filename(path, w->devices_dir, "ega_vram.bin");
+    f = fopen(path, "wb");
+    if (f) {
+        if (ega->vram && ega->vram_limit)
+            fwrite(ega->vram, 1, ega->vram_limit, f);
+        fclose(f);
+    }
+}
+
 static void *
 ega_standalone_init(const device_t *info)
 {
@@ -1891,7 +1989,8 @@ const device_t ega_device = {
     .available     = ega_standalone_available,
     .speed_changed = ega_speed_changed,
     .force_redraw  = NULL,
-    .config        = ega_ibm_config
+    .config        = ega_ibm_config,
+    .debug_snapshot = ega_debug_snapshot
 };
 
 const device_t cpqega_device = {
@@ -1905,7 +2004,8 @@ const device_t cpqega_device = {
     .available     = cpqega_standalone_available,
     .speed_changed = ega_speed_changed,
     .force_redraw  = NULL,
-    .config        = ega_config
+    .config        = ega_config,
+    .debug_snapshot = ega_debug_snapshot
 };
 
 const device_t sega_device = {
@@ -1919,7 +2019,8 @@ const device_t sega_device = {
     .available     = sega_standalone_available,
     .speed_changed = ega_speed_changed,
     .force_redraw  = NULL,
-    .config        = ega_config
+    .config        = ega_config,
+    .debug_snapshot = ega_debug_snapshot
 };
 
 const device_t atiega800p_device = {
@@ -1933,7 +2034,8 @@ const device_t atiega800p_device = {
     .available     = atiega800p_standalone_available,
     .speed_changed = ega_speed_changed,
     .force_redraw  = NULL,
-    .config        = atiega800p_config
+    .config        = atiega800p_config,
+    .debug_snapshot = ega_debug_snapshot
 };
 
 const device_t iskra_ega_device = {
@@ -1947,7 +2049,8 @@ const device_t iskra_ega_device = {
     .available     = iskra_ega_standalone_available,
     .speed_changed = ega_speed_changed,
     .force_redraw  = NULL,
-    .config        = ega_config
+    .config        = ega_config,
+    .debug_snapshot = ega_debug_snapshot
 };
 
 const device_t et2000_device = {
@@ -1961,5 +2064,6 @@ const device_t et2000_device = {
     .available     = et2000_standalone_available,
     .speed_changed = ega_speed_changed,
     .force_redraw  = NULL,
-    .config        = ega_config
+    .config        = ega_config,
+    .debug_snapshot = ega_debug_snapshot
 };

--- a/src/video/vid_ega.c
+++ b/src/video/vid_ega.c
@@ -29,7 +29,6 @@
 #include <86box/pit.h>
 #include <86box/mem.h>
 #include <86box/rom.h>
-#include <86box/path.h>
 #include <86box/device.h>
 #include <86box/debug_snapshot.h>
 #include <86box/video.h>
@@ -1611,14 +1610,12 @@ ega_debug_snapshot(void *w_ptr, void *priv)
 {
     debug_snapshot_writer_t *w   = (debug_snapshot_writer_t *) w_ptr;
     ega_t                   *ega = (ega_t *) priv;
-    char                     path[1024];
     FILE                    *f;
 
     if (!w || !ega)
         return;
 
-    path_append_filename(path, w->devices_dir, "ega.txt");
-    f = fopen(path, "wb");
+    f = debug_snapshot_fopen_write(w->devices_dir, "ega.txt");
     if (f) {
         fprintf(f, "[EGA]\r\n");
         fprintf(f, "actual_type=%d\r\n", ega->actual_type);
@@ -1685,8 +1682,7 @@ ega_debug_snapshot(void *w_ptr, void *priv)
         fclose(f);
     }
 
-    path_append_filename(path, w->devices_dir, "ega_vram.bin");
-    f = fopen(path, "wb");
+    f = debug_snapshot_fopen_write(w->devices_dir, "ega_vram.bin");
     if (f) {
         if (ega->vram && ega->vram_limit)
             fwrite(ega->vram, 1, ega->vram_limit, f);


### PR DESCRIPTION
Summary
=======

Add a paused-VM debug snapshot facility for collecting emulator state into timestamped directories under the VM path.

The snapshot contents are configurable from the UI and currently include:

* CPU registers and bytes around CS:IP
* Conventional RAM dump, capped at 640 KB and reduced when the configured machine RAM is smaller
* Recent I/O port trace
* Active device list
* Detailed device dumps through an optional `device_t` callback

Detailed device snapshot support is currently implemented for:

* IBM EGA and compatible EGA variants (`ega.txt`, `ega_vram.bin`)
* IBM CGA and Pravetz VDC-2 (`cga.txt`, `cga_vram.bin`)

This is intended to make paused emulator state easier to inspect and share when debugging hardware-specific issues, while keeping the mechanism extensible for additional devices.

Checklist
=========

* [x] Closes N/A
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] This pull request does not require changes to the ROM set
* [x] This pull request does not require changes to the asset set

References
==========

The initial use case for this feature is comparing paused emulator state while improving compatibility in MiSTer PC/XT-family FPGA cores and derived projects. The snapshot output makes it easier to compare CPU state, conventional RAM, I/O activity, and video adapter state against 86Box.

Related projects:

* https://github.com/MiSTer-devel/PCXT_MiSTer
* https://github.com/MiSTer-devel/Tandy1000_MiSTer
* https://github.com/MiSTer-devel/PCjr_MiSTer

No ROM or asset changes are required.