### PR TITLE
cdrom_image_viso: Fix more non-Windows breakage

### DIFF
--- a/src/include/86box/plat_dir.h
+++ b/src/include/86box/plat_dir.h
@@ -427,6 +427,7 @@ typedef struct {
     size_t         path_len;
     DIR           *find;
     struct dirent *data;
+    struct dirent  root_data;
     struct stat    stats;
     uint8_t        stats_valid;
 } plat_dir_t;
@@ -445,14 +446,19 @@ plat_dir_open(plat_dir_t *context, const char *path)
         return 0;
     }
 
-    /* First entry is always . so we pre-load it for the default entry behavior. */
-    context->stats_valid = 0xff;
-    context->data        = readdir(context->find);
-    if (!context->data) {
+    context->stats_valid = !stat(path, &context->stats);
+    if (!context->stats_valid || !S_ISDIR(context->stats.st_mode)) {
         closedir(context->find);
         free(context->path);
         return 0;
     }
+
+    /* Represent the base directory as a synthetic '.' entry. d_type is left
+     * DT_UNKNOWN (zeroed by memset) since stats is already valid and all
+     * plat_dir_is_* macros fall through to the stat path when d_type is unknown. */
+    memset(&context->root_data, 0, sizeof(context->root_data));
+    strcpy(context->root_data.d_name, ".");
+    context->data = &context->root_data;
     return 1;
 }
 
@@ -467,6 +473,9 @@ static inline int
 plat_dir_rewind(plat_dir_t *context)
 {
     rewinddir(context->find);
+    context->path[context->path_dir_len] = '\0';
+    context->data                        = &context->root_data;
+    context->stats_valid                 = 1;
     return 1;
 }
 
@@ -481,7 +490,7 @@ plat_dir_count_children(plat_dir_t *context)
             continue;
         ret++;
     }
-    rewinddir(context->find);
+    plat_dir_rewind(context);
     return ret;
 }
 
@@ -551,6 +560,8 @@ static inline const char *
 plat_dir_get_path(plat_dir_t *context)
 {
     if (context->path[context->path_dir_len])
+        return context->path;
+    if (plat_dir_is_special_entry(plat_dir_get_name(context)))
         return context->path;
     size_t len = context->path_dir_len + strlen(plat_dir_get_name(context)) + 2;
     if (len > context->path_len) {


### PR DESCRIPTION
Summary
=======
The latest VISO commits broke that functionality on Linux.

Commit `198db451a` changed VISO root directory stat population to read from `plat_dir_t`'s current entry instead of calling `stat()` directly. macOS already exposed the base directory as the initial current entry (via `fgetattrlist`), but the POSIX backend pre-loaded the first *child* entry instead, causing `plat_dir_is_dir()` to return false for the root and aborting the VISO mount.

Fix: stat the base directory path before entering the readdir loop and expose it as a synthetic `"."` current entry. `plat_dir_read()` advances past it normally. `plat_dir_rewind()` and `plat_dir_count_children()` restore the same state. No change to Windows or macOS backends; no change to callers.

Checklist
=========
* [x] Closes N/A
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [x] This pull request doesn't require changes to the ROM set
* [x] This pull request doesn't require changes to the asset set