### PR TITLE
Translations update from 86Box Weblate

### DIFF
--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2026-04-05 18:51+0000\n"
-"Last-Translator: Alexander Babikov <lemondrops358@gmail.com>\n"
+"PO-Revision-Date: 2026-05-04 00:00+0000\n"
+"Last-Translator: Daniel Gurney <daniel@gurney.dev>\n"
 "Language-Team: Finnish <https://weblate.86box.net/projects/86box/86box/fi/>\n"
 "Language: fi-FI\n"
 "MIME-Version: 1.0\n"
@@ -356,10 +356,10 @@ msgid "Machine type:"
 msgstr "Tietokoneen tyyppi:"
 
 msgid "[1989] i486 (Socket 168 and 1)"
-msgstr ""
+msgstr "[1989] i486 (Socket 168 ja 1)"
 
 msgid "[1994] i486 (Miscellaneous)"
-msgstr ""
+msgstr "[1994] i486 (Sekalaiset)"
 
 msgid "[1995] Socket 7 (Single Voltage)"
 msgstr ""
@@ -368,7 +368,7 @@ msgid "[1996] Socket 7 (Dual Voltage)"
 msgstr ""
 
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Sekalaiset"
 
 msgid "Machine:"
 msgstr "Tietokone:"
@@ -2808,10 +2808,10 @@ msgid "Could not load file %1"
 msgstr "Tiedostoa %1 ei voitu ladata"
 
 msgid "Emulator"
-msgstr ""
+msgstr "Emulaattori"
 
 msgid "Input"
-msgstr ""
+msgstr "Syöte"
 
 msgid "Key bindings"
 msgstr "Pikanäppäimet"
@@ -3063,7 +3063,7 @@ msgid "Raw"
 msgstr "Raaka"
 
 msgid "Use EDC/ECC emulation"
-msgstr ""
+msgstr "Käytä EDC/ECC-emulaatiota"
 
 msgid "Audio output device:"
 msgstr "Äänen ulostulolaite:"


### PR DESCRIPTION
Translations update from [86Box Weblate](https://weblate.86box.net) for [86Box/86Box](https://weblate.86box.net/projects/86box/86box/).



Current translation status:

![Weblate translation status](https://weblate.86box.net/widget/86box/86box/horizontal-auto.svg)