### PR TITLE
SB16: Return more accurate mixer register 82h values

### DIFF
--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -1463,8 +1463,12 @@ sb_ct1745_mixer_read(uint16_t addr, void *priv)
                 /* http://the.earth.li/~tfm/oldpage/sb_mixer.html - 0x10, 0x20, 0x80. */
                 const uint8_t temp = ((sb->dsp.sb_irq8) ? 1 : 0) | ((sb->dsp.sb_irq16) ? 2 : 0) |
                                      ((sb->dsp.sb_irq401) ? 4 : 0);
-                if (sb->dsp.sb_type >= SBAWE32_DSP_412)
+                if (sb->dsp.sb_type >= SB16_DSP_411)
                     ret = temp | 0x80;
+                else if (sb->dsp.sb_type == SB16_DSP_405)
+                    ret = temp | 0x20;
+                else if (sb->dsp.sb_type == SB16_DSP_404)
+                    ret = temp | 0x10;
                 else
                     ret = temp | 0x40;
                 break;


### PR DESCRIPTION
Summary
=======
Make SB16 mixer register 82h return more accurate values based on disassembly of a 1993 version of TESTSB16.EXE, probing of a real DSP 4.11 SB16 and available documentation. This fixes 1993 TESTSB16.EXE on DSPs 4.04 and 4.05 (this version fails with an error about the card version on a real DSP 4.11 SB16).

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
- https://the.earth.li/~tfm/oldpage/sb_mixer.html