### PR TITLE
Another 'machine_table' changes (12/05/2026)

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -10133,7 +10133,7 @@ const machine_t machines[] = {
         .vid_device               = NULL,
         .snd_device               = NULL,
         .net_device               = NULL,
-        .aliases                  = { "AOpen Vi15G" }
+        .aliases                  = { "AOpen Vi15G", "" }
     },
     /* This has an AMIKey-2, which is an updated version of type 'H'. */
     {
@@ -12837,14 +12837,14 @@ const machine_t machines[] = {
             .package     = CPU_PKG_SOCKET4,
             .block       = CPU_BLOCK_NONE,
             .min_bus     = 60000000,
-            .max_bus     = 66666667,
+            .max_bus     = 60000000,
             .min_voltage = 5000,
             .max_voltage = 5000,
             .min_multi   = MACHINE_MULTIPLIER_FIXED,
             .max_multi   = MACHINE_MULTIPLIER_FIXED
         },
         .bus_flags = MACHINE_PS2_PCI,
-        .flags     = MACHINE_IDE | MACHINE_APM,
+        .flags     = MACHINE_IDE | MACHINE_APM, /* Machine has internal video: Cirrus Logic GD5430 */
         .ram       = {
             .min  = 2048,
             .max  = 131072,
@@ -12933,7 +12933,7 @@ const machine_t machines[] = {
             .package     = CPU_PKG_SOCKET4,
             .block       = CPU_BLOCK_NONE,
             .min_bus     = 60000000,
-            .max_bus     = 66666667,
+            .max_bus     = 60000000,
             .min_voltage = 5000,
             .max_voltage = 5000,
             .min_multi   = MACHINE_MULTIPLIER_FIXED,

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -8821,7 +8821,7 @@ const machine_t machines[] = {
         .vid_device               = &gd5426_onboard_device,
         .snd_device               = NULL,
         .net_device               = NULL,
-        .aliases                  = { "" }
+        .aliases                  = { "Tulip TC38", "" }
     },
     /* Has Award KBC firmware. */
     {
@@ -10005,7 +10005,7 @@ const machine_t machines[] = {
         .cpu               = {
             .package     = CPU_PKG_SOCKET3,
             .block       = CPU_BLOCK(CPU_Cx5x86),
-            .min_bus     = 25000000,
+            .min_bus     = 20000000,
             .max_bus     = 40000000,
             .min_voltage = 5000,
             .max_voltage = 5000,
@@ -10053,7 +10053,7 @@ const machine_t machines[] = {
         .cpu               = {
             .package     = CPU_PKG_SOCKET3,
             .block       = CPU_BLOCK_NONE,
-            .min_bus     = 25000000,
+            .min_bus     = 20000000,
             .max_bus     = 40000000,
             .min_voltage = 3300,
             .max_voltage = 5000,
@@ -10101,7 +10101,7 @@ const machine_t machines[] = {
         .cpu               = {
             .package     = CPU_PKG_SOCKET3,
             .block       = CPU_BLOCK_NONE,
-            .min_bus     = 25000000,
+            .min_bus     = 20000000,
             .max_bus     = 50000000,
             .min_voltage = 3300,
             .max_voltage = 5000,
@@ -10199,7 +10199,7 @@ const machine_t machines[] = {
             .block       = CPU_BLOCK_NONE,
             .min_bus     = 25000000,
             .max_bus     = 40000000,
-            .min_voltage = 5000,
+            .min_voltage = 3300,
             .max_voltage = 5000,
             .min_multi   = 0,
             .max_multi   = 0
@@ -12080,12 +12080,12 @@ const machine_t machines[] = {
         .vid_device               = &tgui9440_onboard_pci_device,
         .snd_device               = NULL,
         .net_device               = NULL,
-        .aliases                  = { "" }
+        .aliases                  = { "Epson ActionPC 5500", "Epson Endeavor II", "TriGem SanJose" "TriGem TG486AP", "" }
     },
     /* This has the UMC 88xx on-chip KBC. All the copies of the BIOS string I can find, end in
        in -H, so the UMC on-chip KBC likely emulates the AMI 'H' KBC firmware. */
     {
-        .name              = "[UMC 8881] Epson ActionTower 8400",
+        .name              = "[UMC 8881] Epson ActionTower 7x00",
         .internal_name     = "actiontower8400",
         .type              = MACHINE_TYPE_486_S3_PCI,
         .chipset           = MACHINE_CHIPSET_UMC_UM8881,
@@ -12129,7 +12129,7 @@ const machine_t machines[] = {
         .vid_device               = &gd5430_onboard_pci_device,
         .snd_device               = NULL,
         .net_device               = NULL,
-        .aliases                  = { "" }
+        .aliases                  = { "Epson ActionTower 7300", "Epson ActionTower 7500", "Epson ActionTower 8400", "" }
     },
     /* This has the UMC 88xx on-chip KBC. All the copies of the BIOS string I can find, end in
        in -H, so the UMC on-chip KBC likely emulates the AMI 'H' KBC firmware. */
@@ -17310,7 +17310,7 @@ const machine_t machines[] = {
         .vid_device               = NULL,
         .snd_device               = NULL,
         .net_device               = NULL,
-        .aliases                  = { "Intel Hannibal+" }
+        .aliases                  = { "Intel Hannibal+", "" }
     },
     /* Has AMIKey H KBC firmware (AMIKey-2). */
     {

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -10089,7 +10089,7 @@ const machine_t machines[] = {
     },
     /* Has AMIKey-2 'H' keyboard BIOS. */
     {
-        .name              = "[SiS 471] AOpen Vi15G",
+        .name              = "[SiS 471] Acer Vi15G",
         .internal_name     = "vi15g",
         .type              = MACHINE_TYPE_486_S3,
         .chipset           = MACHINE_CHIPSET_SIS_471,
@@ -10133,7 +10133,7 @@ const machine_t machines[] = {
         .vid_device               = NULL,
         .snd_device               = NULL,
         .net_device               = NULL,
-        .aliases                  = { "" }
+        .aliases                  = { "AOpen Vi15G" }
     },
     /* This has an AMIKey-2, which is an updated version of type 'H'. */
     {


### PR DESCRIPTION
Summary
=======
1. Added Tulip TC38 alias
2. Correct the minimum voltages for AH4/AH4T & Vi15G according to their TRW entries & manuals
3. Make DEC Venturis 4xx to support 3.3v according to their manual
4. Rename the manufacturer name from AOpen to Acer for Vi15G
5. Added the aliases to two Epson Socket 3 machines (including the ActionTower rename)
6. Fixed CPUs for Dell OptiPlex 560/L & IBM PS/ValuePoint P60 to only 60MHz according to their names and (possibly?) manuals
7. Added a note abut internal video (which is already emulated) on OptiPlex 560/L
8. Fixed the alias to Dell Hannibal+, fixes a crash (forgotten commit)

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
Found on The Retro Web's entries on [AB-AH4](https://theretroweb.com/motherboards/s/abit-ab-ah4), [AB-AH4T](https://theretroweb.com/motherboards/s/abit-ab-ah4t), [Vi15G](https://theretroweb.com/motherboards/s/acer-vi15g), [ActionPC 7x00](https://theretroweb.com/motherboards/s/epson-actionpc-7000-series), [ActionTower 2600](https://theretroweb.com/motherboards/s/trigem-sanjose), [OptiPlex 560/L](https://theretroweb.com/motherboards/s/dell-optiplex-560-l), and [PS/ValuePoint P60](https://theretroweb.com/motherboards/s/intel-premiere-pci-lp-lpx-robin-ace).
[DEC Venturis 4xx's manual (it has "VENTURIS 4100" and "VENTURIS FP4100" on it, meaning it supports 3.3v).](https://theretroweb.com/motherboard/manual/a0813svb-6084331110792528340680.pdf)