### PR TITLE
Added option "Auto-capture mouse"

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -353,8 +353,9 @@ load_general(void)
 
     sound_gain = ini_section_get_int(cat, "sound_gain", 0);
 
-    kbd_req_capture = ini_section_get_int(cat, "kbd_req_capture", 0);
-    hide_status_bar = ini_section_get_int(cat, "hide_status_bar", 0);
+    kbd_req_capture    = ini_section_get_int(cat, "kbd_req_capture", 0);
+    auto_capture_mouse = ini_section_get_int(cat, "auto_capture_mouse", 0);
+    hide_status_bar    = ini_section_get_int(cat, "hide_status_bar", 0);
     hide_tool_bar   = ini_section_get_int(cat, "hide_tool_bar", 0);
     sound_muted     = ini_section_get_int(cat, "sound_muted", 0);
 
@@ -2616,6 +2617,7 @@ config_load(void)
         cpu   = 0;
 
         kbd_req_capture      = 0;
+        auto_capture_mouse   = 0;
         hide_status_bar      = 0;
         hide_tool_bar        = 0;
         scale                = 1;
@@ -2958,6 +2960,8 @@ save_general(void)
         ini_section_set_int(cat, "kbd_req_capture", kbd_req_capture);
     else
         ini_section_delete_var(cat, "kbd_req_capture");
+
+    ini_section_set_int(cat, "auto_capture_mouse", auto_capture_mouse);
 
     if (hide_status_bar != 0)
         ini_section_set_int(cat, "hide_status_bar", hide_status_bar);

--- a/src/include/86box/plat.h
+++ b/src/include/86box/plat.h
@@ -116,6 +116,7 @@ extern int      rctrl_is_lalt;
 extern int      update_icons;
 
 extern int kbd_req_capture;
+extern int auto_capture_mouse;
 extern int hide_status_bar;
 extern int hide_tool_bar;
 extern int fullscreen_ui_visible;

--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -12,6 +12,9 @@ msgstr ""
 msgid "&Keyboard requires capture"
 msgstr ""
 
+msgid "&Auto capture mouse"
+msgstr ""
+
 msgid "&Right CTRL is left ALT"
 msgstr ""
 

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -19,6 +19,9 @@ msgstr "&Действие"
 msgid "&Keyboard requires capture"
 msgstr "&Клавиатура требует захвата"
 
+msgid "&Auto capture mouse"
+msgstr "&Автозахват мыши"
+
 msgid "&Right CTRL is left ALT"
 msgstr "П&равый CTRL - это левый ALT"
 

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -476,6 +476,7 @@ MainWindow::MainWindow(QWidget *parent)
     connect(this, &MainWindow::statusBarMessage, status.get(), &MachineStatus::message, Qt::QueuedConnection);
 
     ui->actionKeyboard_requires_capture->setChecked(kbd_req_capture);
+    ui->actionAuto_capture_mouse->setChecked(auto_capture_mouse);
     ui->actionRight_CTRL_is_left_ALT->setChecked(rctrl_is_lalt);
     ui->actionResizable_window->setChecked(vid_resize == 1);
     ui->actionRemember_size_and_position->setChecked(window_remember);
@@ -770,6 +771,24 @@ MainWindow::MainWindow(QWidget *parent)
 
     if (!vnc_enabled)
         video_setblit(qt_blit);
+
+
+connect(ui->stackedWidget, &RendererStack::blitToRenderer, this, [this]() {
+    static bool first_capture_done = false;
+
+    if (first_capture_done)
+        return;
+
+    if (!auto_capture_mouse)
+        return;
+
+    first_capture_done = true;
+
+    QTimer::singleShot(100, this, [this]() {
+        if (!mouse_capture)
+            emit setMouseCapture(true);
+    });
+});
 
     if (start_in_fullscreen) {
         connect(ui->stackedWidget, &RendererStack::blitToRenderer, this, [this]() {
@@ -1181,6 +1200,13 @@ MainWindow::on_actionKeyboard_requires_capture_triggered()
 }
 
 void
+MainWindow::on_actionAuto_capture_mouse_triggered()
+{
+    auto_capture_mouse ^= 1;
+    config_changed = 1;
+}
+
+void
 MainWindow::on_actionRight_CTRL_is_left_ALT_triggered()
 {
     rctrl_is_lalt ^= 1;
@@ -1189,6 +1215,7 @@ MainWindow::on_actionRight_CTRL_is_left_ALT_triggered()
 void
 MainWindow::on_actionHard_Reset_triggered()
 {
+	recapture_after_reset = mouse_capture;
     if (confirm_reset) {
         QMessageBox questionbox(QMessageBox::Icon::Question, EMU_NAME, tr("Are you sure you want to hard reset the emulated machine?"), QMessageBox::Yes | QMessageBox::No, this);
         const auto chkbox    = new QCheckBox(tr("Don't show this message again"));
@@ -1206,12 +1233,25 @@ MainWindow::on_actionHard_Reset_triggered()
     }
     config_changed = 2;
     pc_reset_hard();
+
+QTimer::singleShot(500, this, [this]() {
+    if (recapture_after_reset)
+        emit setMouseCapture(true);
+});
+
 }
 
 void
 MainWindow::on_actionCtrl_Alt_Del_triggered()
 {
+    recapture_after_reset = mouse_capture;
+
     pc_send_cad();
+
+    QTimer::singleShot(500, this, [this]() {
+        if (recapture_after_reset)
+            emit setMouseCapture(true);
+    });
 }
 
 void

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -93,6 +93,7 @@ private slots:
     void on_actionHard_Reset_triggered();
     void on_actionRight_CTRL_is_left_ALT_triggered();
     void on_actionKeyboard_requires_capture_triggered();
+    void on_actionAuto_capture_mouse_triggered();
     void on_actionResizable_window_triggered(bool checked);
     void on_action0_5x_triggered();
     void on_action1x_triggered();
@@ -173,6 +174,7 @@ private:
     Ui::MainWindow                *ui;
     std::unique_ptr<MachineStatus> status;
     std::shared_ptr<MediaMenu>     mm;
+    bool recapture_after_reset = false;
 
     void updateShortcuts();
     void processKeyboardInput(bool down, uint32_t keycode);

--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -71,6 +71,7 @@
     <addaction name="menuTablet_tool"/>
     <addaction name="separator"/>
     <addaction name="actionKeyboard_requires_capture"/>
+    <addaction name="actionAuto_capture_mouse"/>
     <addaction name="actionRight_CTRL_is_left_ALT"/>
     <addaction name="separator"/>
     <addaction name="actionUpdate_mouse_every_CPU_frame"/>
@@ -316,6 +317,14 @@
    </property>
    <property name="text">
     <string>&amp;Keyboard requires capture</string>
+   </property>
+  </action>
+  <action name="actionAuto_capture_mouse">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Auto capture mouse</string>
    </property>
   </action>
   <action name="actionRight_CTRL_is_left_ALT">

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -158,8 +158,9 @@ int          fixed_size_x    = 640;
 int          fixed_size_y    = 480;
 int          rctrl_is_lalt   = 0;
 int          update_icons    = 1;
-int          kbd_req_capture = 0;
-int          hide_status_bar = 0;
+int          kbd_req_capture     = 0;
+int          auto_capture_mouse  = 0;
+int          hide_status_bar     = 0;
 int          hide_tool_bar   = 0;
 
 int


### PR DESCRIPTION
Added option "Auto-capture mouse"

Summary
=======
Added the "Auto-capture mouse" option to the Action menu with enabling/disabling the checkbox and saving this setting in 86Box.cfg for each VM. The "Auto-capture mouse" option is disabled by default. Added translation of this option to ru-RU.po and updated 86Box.pot. Tested when running the VM in a windowed mode, switching to fullscreen mode and back, with "Toggle UI in fullscreen", when running the VM immediately in fullscreen mode (86Box.exe -f).

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
