### PR TITLE
String-related fixes and improvements, part 1

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -2029,6 +2029,12 @@ pc_run(void)
         target_fps    = force_10ms ? 100 : 1000;
         elapsed_ms    = fps_sample_elapsed_ms ? fps_sample_elapsed_ms : 1;
 
+#ifdef SCREENSHOT_MODE
+        if (force_10ms)
+            fps = ((fps + 2) / 5) * 5;
+        else
+            fps = ((fps + 20) / 50) * 50;
+#endif
         /*
          * Use real sample duration for title speed percent so delayed timer
          * callbacks do not create false dip/rebound spikes in speed reporting.
@@ -2036,17 +2042,12 @@ pc_run(void)
         numerator     = (int64_t) fps * 100000LL;
         speed_percent = (int) ((numerator + ((int64_t) elapsed_ms * target_fps / 2)) /
                                ((int64_t) elapsed_ms * target_fps));
-#ifdef SCREENSHOT_MODE
-        if (force_10ms)
-            fps = ((fps + 2) / 5) * 5;
-        else
-            fps = ((fps + 20) / 50) * 50;
-#endif
+
+        snprintf(temp, sizeof(temp), mouse_msg[mouse_msg_idx], speed_percent);
 #ifdef __APPLE__
         /* Needed due to modifying the UI on the non-main thread is a big no-no. */
         dispatch_async_f(dispatch_get_main_queue(), strdup((const char *) temp), _ui_window_title);
 #else
-        snprintf(temp, sizeof(temp), mouse_msg[mouse_msg_idx], speed_percent);
         ui_window_title(temp);
 #endif
         title_update = 0;

--- a/src/86box.c
+++ b/src/86box.c
@@ -352,7 +352,7 @@ int efscrnsz_y = SCREEN_RES_Y;
 
 __thread int is_cpu_thread = 0;
 
-static wchar_t mouse_msg[3][200];
+static char mouse_msg[3][200];
 
 static ATOMIC_INT do_pause_ack = 0;
 static ATOMIC_INT pause_ack = 0;
@@ -506,7 +506,7 @@ fatal(const char *fmt, ...)
 
     do_pause(2);
 
-    ui_msgbox(MBX_ERROR | MBX_FATAL | MBX_ANSI, temp);
+    ui_msgbox(MBX_ERROR | MBX_FATAL, temp);
 
     /* Cleanly terminate all of the emulator's components so as
        to avoid things like threads getting stuck. */
@@ -548,7 +548,7 @@ fatal_ex(const char *fmt, va_list ap)
 
     do_pause(2);
 
-    ui_msgbox(MBX_ERROR | MBX_FATAL | MBX_ANSI, temp);
+    ui_msgbox(MBX_ERROR | MBX_FATAL, temp);
 
     /* Cleanly terminate all of the emulator's components so as
        to avoid things like threads getting stuck. */
@@ -589,7 +589,7 @@ warning(const char *fmt, ...)
 
     do_pause(2);
 
-    ui_msgbox(MBX_ERROR | MBX_ANSI, temp);
+    ui_msgbox(MBX_ERROR, temp);
 
     fflush(stdlog);
 
@@ -621,7 +621,7 @@ warning_ex(const char *fmt, va_list ap)
 
     do_pause(2);
 
-    ui_msgbox(MBX_ERROR | MBX_ANSI, temp);
+    ui_msgbox(MBX_ERROR, temp);
 
     fflush(stdlog);
 
@@ -746,7 +746,7 @@ pc_show_usage(void)
             "\nA config file can be specified. If none is, the default file will be used.\n");
 
 #ifdef _WIN32
-    ui_msgbox(MBX_ANSI | MBX_INFO, p);
+    ui_msgbox(MBX_INFO, p);
 #else
     always_log("%s", p);
 #endif
@@ -1235,8 +1235,8 @@ usage:
     else
         strcpy(temp, "unknown");
 
-    pclog("#\n# %ls v%ls logfile, created %s\n#\n",
-          EMU_NAME_W, EMU_VERSION_FULL_W, temp);
+    pclog("#\n# %s v%s logfile, created %s\n#\n",
+          EMU_NAME, EMU_VERSION_FULL, temp);
 
     if (portable_mode) {
         pclog("# Portable mode enabled.\n");
@@ -1264,7 +1264,7 @@ usage:
         start_vmm = 0;
 #ifdef __APPLE__
         if (!strncmp(exe_path, "/private/var/folders/", 21)) {
-            ui_msgbox_header(MBX_FATAL, L"App Translocation", EMU_NAME_W L" cannot determine the emulated machine's location due to a macOS security feature. Please move the " EMU_NAME_W L" app to another folder (not /Applications), or make a copy of it and open that copy instead.");
+            ui_msgbox_header(MBX_FATAL, "App Translocation", EMU_NAME " cannot determine the emulated machine's location due to a macOS security feature. Please move the " EMU_NAME " app to another folder (not /Applications), or make a copy of it and open that copy instead.");
             return 0;
         }
 #endif
@@ -1418,13 +1418,13 @@ pc_init_roms(void)
 int
 pc_init_modules(void)
 {
-    int     c;
-    wchar_t temp[512];
-    char    tempc[512];
+    int  c;
+    char temp[512];
+    char tempc[512];
 
     /* Load the ROMs for the selected machine. */
     if (!machine_available(machine)) {
-        swprintf(temp, sizeof_w(temp), plat_get_string(STRING_HW_NOT_AVAILABLE_MACHINE), machine_getname(machine));
+        snprintf(temp, sizeof(temp), plat_get_string(STRING_HW_NOT_AVAILABLE_MACHINE), machine_getname(machine));
         c       = 0;
         machine = -1;
         while (machine_get_internal_name_ex(c) != NULL) {
@@ -1446,7 +1446,7 @@ pc_init_modules(void)
     if (!video_card_available(gfxcard[0])) {
         memset(tempc, 0, sizeof(tempc));
         device_get_name(video_card_getdevice(gfxcard[0]), 0, tempc);
-        swprintf(temp, sizeof_w(temp), plat_get_string(STRING_HW_NOT_AVAILABLE_VIDEO), tempc);
+        snprintf(temp, sizeof(temp), plat_get_string(STRING_HW_NOT_AVAILABLE_VIDEO), tempc);
         c = 0;
         while (video_get_internal_name(c) != NULL) {
             gfxcard[0] = -1;
@@ -1467,9 +1467,9 @@ pc_init_modules(void)
     // TODO
     for (uint8_t i = 1; i < GFXCARD_MAX; i ++) {
         if (!video_card_available(gfxcard[i])) {
-            char tempc[512] = { 0 };
+            memset(tempc, 0, sizeof(tempc));
             device_get_name(video_card_getdevice(gfxcard[i]), 0, tempc);
-            swprintf(temp, sizeof_w(temp), plat_get_string(STRING_HW_NOT_AVAILABLE_VIDEO2), tempc);
+            snprintf(temp, sizeof_w(temp), plat_get_string(STRING_HW_NOT_AVAILABLE_VIDEO2), tempc);
             ui_msgbox_header(MBX_INFO, plat_get_string(STRING_HW_NOT_AVAILABLE_TITLE), temp);
             gfxcard[i] = 0;
         }
@@ -1868,58 +1868,31 @@ void
 update_mouse_msg(void)
 {
 #ifdef USE_SDL_UI
-    wchar_t  wcpufamily[2048];
-    wchar_t  wcpu[2048];
-    wchar_t  wmachine[2048];
-    wchar_t *wcp;
-
-    mbstowcs(wmachine, machine_getname(machine), strlen(machine_getname(machine)) + 1);
+    char  cpufamily[128];
+    char *cp;
 
     if (!cpu_override)
-        mbstowcs(wcpufamily, cpu_f->name, strlen(cpu_f->name) + 1);
+        strncpy(cpufamily, cpu_f->name, sizeof(cpufamily) - 1);
     else
-        swprintf(wcpufamily, sizeof_w(wcpufamily), L"[U] %hs", cpu_f->name);
+        snprintf(cpufamily, sizeof(cpufamily), "[U] %s", cpu_f->name);
 
-    wcp = wcschr(wcpufamily, L'(');
-    if (wcp) /* remove parentheses */
-        *(wcp - 1) = L'\0';
-    mbstowcs(wcpu, cpu_s->name, strlen(cpu_s->name) + 1);
-    swprintf(mouse_msg[0], sizeof_w(mouse_msg[0]), L"%ls v%ls - %%i%%%% - %ls - %ls/%ls - %ls",
-             EMU_NAME_W, EMU_VERSION_FULL_W, wmachine, wcpufamily, wcpu,
+    cp = strchr(cpufamily, '(');
+    if (cp) /* remove parentheses */
+        *(cp - 1) = '\0';
+    snprintf(mouse_msg[0], sizeof(mouse_msg[0]), "%s v%s - %%i%%%% - %s - %s/%s - %s",
+             EMU_NAME, EMU_VERSION_FULL, machine_getname(machine), cpufamily, cpu_s->name,
              plat_get_string(STRING_MOUSE_CAPTURE));
-    swprintf(mouse_msg[1], sizeof_w(mouse_msg[1]), L"%ls v%ls - %%i%%%% - %ls - %ls/%ls - %ls",
-             EMU_NAME_W, EMU_VERSION_FULL_W, wmachine, wcpufamily, wcpu,
+    snprintf(mouse_msg[1], sizeof(mouse_msg[1]), "%s v%s - %%i%%%% - %s - %s/%s - %s",
+             EMU_NAME, EMU_VERSION_FULL, machine_getname(machine), cpufamily, cpu_s->name,
              (mouse_get_buttons() > 2) ? plat_get_string(STRING_MOUSE_RELEASE) : plat_get_string(STRING_MOUSE_RELEASE_MMB));
-    swprintf(mouse_msg[2], sizeof_w(mouse_msg[2]), L"%ls v%ls - %%i%%%% - %ls - %ls/%ls",
-             EMU_NAME_W, EMU_VERSION_FULL_W, wmachine, wcpufamily, wcpu);
+    snprintf(mouse_msg[2], sizeof(mouse_msg[2]), "%s v%s - %%i%%%% - %s - %s/%s",
+             EMU_NAME, EMU_VERSION_FULL, machine_getname(machine), cpufamily, cpu_s->name);
 #else
-#ifdef __APPLE__
-    /*
-     * On macOS, BSD swprintf fails (returns -1) when the format string
-     * or a %ls argument contains non-ASCII wide characters (e.g. the
-     * native key symbols ⌘ U+2318, ⌫ U+232B) and the C locale is
-     * active.  Store just the message suffixes here; the title update
-     * path in pc_render_monitor_dispatch() builds the full string
-     * without swprintf.
-     */
-    wcsncpy(mouse_msg[0], plat_get_string(STRING_MOUSE_CAPTURE), sizeof_w(mouse_msg[0]) - 1);
-    mouse_msg[0][sizeof_w(mouse_msg[0]) - 1] = L'\0';
-
-    {
-        wchar_t *rel = (mouse_get_buttons() > 2) ? plat_get_string(STRING_MOUSE_RELEASE)
-                                                  : plat_get_string(STRING_MOUSE_RELEASE_MMB);
-        wcsncpy(mouse_msg[1], rel, sizeof_w(mouse_msg[1]) - 1);
-        mouse_msg[1][sizeof_w(mouse_msg[1]) - 1] = L'\0';
-    }
-
-    mouse_msg[2][0] = L'\0';
-#else
-    swprintf(mouse_msg[0], sizeof_w(mouse_msg[0]), L"%%i%%%% - %ls",
+    snprintf(mouse_msg[0], sizeof(mouse_msg[0]), "%%i%%%% - %s",
              plat_get_string(STRING_MOUSE_CAPTURE));
-    swprintf(mouse_msg[1], sizeof_w(mouse_msg[1]), L"%%i%%%% - %ls",
+    snprintf(mouse_msg[1], sizeof(mouse_msg[1]), "%%i%%%% - %s",
              (mouse_get_buttons() > 2) ? plat_get_string(STRING_MOUSE_RELEASE) : plat_get_string(STRING_MOUSE_RELEASE_MMB));
-    wcsncpy(mouse_msg[2], L"%i%%", sizeof_w(mouse_msg[2]));
-#endif
+    strncpy(mouse_msg[2], "%i%%", sizeof(mouse_msg[2]));
 #endif
 }
 
@@ -1994,7 +1967,7 @@ pc_close(UNUSED(thread_t *ptr))
 static void
 _ui_window_title(void *s)
 {
-    ui_window_title((wchar_t *) s);
+    ui_window_title((char *) s);
     free(s);
 }
 #endif
@@ -2011,8 +1984,8 @@ ack_pause(void)
 void
 pc_run(void)
 {
-    int     mouse_msg_idx;
-    wchar_t temp[200];
+    int  mouse_msg_idx;
+    char temp[200];
 
     /* Trigger a hard reset if one is pending. */
     if (hard_reset_pending) {
@@ -2070,19 +2043,10 @@ pc_run(void)
             fps = ((fps + 20) / 50) * 50;
 #endif
 #ifdef __APPLE__
-        /*
-         * mouse_msg[] stores suffixes only on macOS (see update_mouse_msg).
-         * Build the title without passing non-ASCII chars through swprintf.
-         */
-        swprintf(temp, sizeof_w(temp), L"%i%%", speed_percent);
-        if (mouse_msg[mouse_msg_idx][0]) {
-            wcsncat(temp, L" - ", sizeof_w(temp) - wcslen(temp) - 1);
-            wcsncat(temp, mouse_msg[mouse_msg_idx], sizeof_w(temp) - wcslen(temp) - 1);
-        }
         /* Needed due to modifying the UI on the non-main thread is a big no-no. */
-        dispatch_async_f(dispatch_get_main_queue(), wcsdup((const wchar_t *) temp), _ui_window_title);
+        dispatch_async_f(dispatch_get_main_queue(), strdup((const char *) temp), _ui_window_title);
 #else
-        swprintf(temp, sizeof_w(temp), mouse_msg[mouse_msg_idx], speed_percent);
+        snprintf(temp, sizeof(temp), mouse_msg[mouse_msg_idx], speed_percent);
         ui_window_title(temp);
 #endif
         title_update = 0;

--- a/src/cdrom/cdrom.c
+++ b/src/cdrom/cdrom.c
@@ -1359,13 +1359,11 @@ cdrom_get_from_name(const char *s)
 
     if (!found) {
         if (strcmp(s, "none")) {
-            wchar_t tempmsg[2048];
             sprintf(n, "WARNING: CD-ROM \"%s\" not found - contact 86Box support\n", s);
-            swprintf(tempmsg, sizeof_w(tempmsg), L"%hs", n);
             pclog("%s", n);
             ui_msgbox_header(MBX_INFO,
                              plat_get_string(STRING_HW_NOT_AVAILABLE_TITLE),
-                             tempmsg);
+                             n);
         }
         c = -1;
     }

--- a/src/char/char_file.c
+++ b/src/char/char_file.c
@@ -166,7 +166,7 @@ char_file_init(const device_t *info)
         char_file_log(dev->log, "%s output file [%s]\n", dev->file_out ? "Opened" : "Could not open", path);
         if (!dev->file_out) {
             snprintf(msg, sizeof(msg), "%s: Could not connect to %s: %s", dev->port->name, path, fmt);
-            ui_msgbox(MBX_ERROR | MBX_ANSI, msg);
+            ui_msgbox(MBX_ERROR, msg);
         }
     } else {
         char_file_log(dev->log, "No output file specified\n");
@@ -186,7 +186,7 @@ char_file_init(const device_t *info)
         char_file_log(dev->log, "%s input file [%s]\n", dev->file_in ? "Opened" : "Could not open", path);
         if (!dev->file_in) {
             snprintf(msg, sizeof(msg), "%s: Could not connect to %s: %s", dev->port->name, path, fmt);
-            ui_msgbox(MBX_ERROR | MBX_ANSI, msg);
+            ui_msgbox(MBX_ERROR, msg);
         }
     } else {
         char_file_log(dev->log, "No input file specified\n");

--- a/src/char/char_pipe.c
+++ b/src/char/char_pipe.c
@@ -184,7 +184,7 @@ client:
                     goto errmsg;
                 }
                 if (startup)
-                    ui_msgbox(MBX_ERROR | MBX_ANSI, msg);
+                    ui_msgbox(MBX_ERROR, msg);
                 else
                     char_pipe_log(dev->log, "%s\n", msg);
             }
@@ -211,7 +211,7 @@ client:
                 char_pipe_log(dev->log, "PTY open failed (%d)\n", err);
 
                 snprintf(msg, sizeof(msg), "%s: Could not connect to %s: %s", dev->port->name, dev->path_out, strerror(err));
-                ui_msgbox(MBX_ERROR | MBX_ANSI, msg);
+                ui_msgbox(MBX_ERROR, msg);
                 dev->path_out[dev->path_len] = prev;
                 goto errmsg;
             }
@@ -270,7 +270,7 @@ client:
             for (int j = 0; j <= 1; j++) {
                 snprintf(msg, sizeof(msg), (j == 0) ? "%s: Could not connect to %s: %s" : "%s: Could not create %s: %s", dev->port->name, path, strerror(err));
                 if (startup)
-                    ui_msgbox(MBX_ERROR | MBX_ANSI, msg);
+                    ui_msgbox(MBX_ERROR, msg);
                 else
                     char_pipe_log(dev->log, "%s\n", msg);
                 err = create_err;
@@ -291,7 +291,7 @@ errmsg:
     char_pipe_disconnect(dev, 0); /* just update status */
     if (msg[0]) {
         if (startup)
-            ui_msgbox(MBX_ERROR | MBX_ANSI, msg);
+            ui_msgbox(MBX_ERROR, msg);
         else
             char_pipe_log(dev->log, "%s\n", msg);
     }

--- a/src/char/char_serial.c
+++ b/src/char/char_serial.c
@@ -331,7 +331,7 @@ char_serial_connect(char_serial_t *dev, int startup)
 errmsg:
     char_serial_disconnect(dev);
     if (startup)
-        ui_msgbox(MBX_ERROR | MBX_ANSI, msg);
+        ui_msgbox(MBX_ERROR, msg);
     else
         char_serial_log(dev->log, "%s\n", msg);
     return 0;

--- a/src/char/char_stdio.c
+++ b/src/char/char_stdio.c
@@ -287,7 +287,7 @@ char_stdio_init(const device_t *info)
             char_stdio_log(dev->log, "Standard input/output already claimed by %s\n", stdio_claimed_by);
 
             snprintf(msg, sizeof(msg), "%s: Virtual console already in use by %s", dev->port->name, stdio_claimed_by);
-            ui_msgbox(MBX_INFO | MBX_ANSI, msg);
+            ui_msgbox(MBX_INFO, msg);
 
             dev->fd_in = dev->fd_out =
 #ifdef _WIN32
@@ -367,7 +367,7 @@ char_stdio_init(const device_t *info)
 
                         if (mode == CHAR_STDIO_MODE_PTY) {
                             snprintf(msg, sizeof(msg), "%s: Attached to %s", dev->port->name, pty);
-                            ui_msgbox(MBX_INFO | MBX_ANSI, msg);
+                            ui_msgbox(MBX_INFO, msg);
                         } else {
                             /* Build environment variables. */
                             static const char *pipe_cmd = "PIPECMD="
@@ -427,7 +427,7 @@ char_stdio_init(const device_t *info)
             char_stdio_log(dev->log, "posix_openpt failed (%d)\n", err);
 errmsg:
             snprintf(msg, sizeof(msg), "%s: Could not create pseudoterminal: %s", dev->port->name, strerror(err));
-            ui_msgbox(MBX_ERROR | MBX_ANSI, msg);
+            ui_msgbox(MBX_ERROR, msg);
             close(dev->fd_out);
             dev->fd_out = -1;
         }

--- a/src/config.c
+++ b/src/config.c
@@ -1689,7 +1689,7 @@ load_hard_disks(void)
 
 #if defined(ENABLE_CONFIG_LOG) && (ENABLE_CONFIG_LOG == 2)
         if (*p != '\0')
-            config_log("HDD%d: %ls\n", c, hdd[c].fn);
+            config_log("HDD%d: %s\n", c, hdd[c].fn);
 #endif
 
         sprintf(temp, "hdd_%02i_vhd_blocksize", c + 1);
@@ -1781,7 +1781,7 @@ load_floppy_and_cdrom_drives(void)
 
 #if defined(ENABLE_CONFIG_LOG) && (ENABLE_CONFIG_LOG == 2)
         if (*p != '\0')
-            config_log("Floppy%d: %ls\n", c, floppyfns[c]);
+            config_log("Floppy%d: %s\n", c, floppyfns[c]);
 #endif
 
         sprintf(temp, "fdd_%02i_turbo", c + 1);
@@ -1954,7 +1954,7 @@ load_floppy_and_cdrom_drives(void)
 
 #if defined(ENABLE_CONFIG_LOG) && (ENABLE_CONFIG_LOG == 2)
         if (*p != '\0')
-            config_log("CD-ROM%d: %ls\n", c, cdrom[c].image_path);
+            config_log("CD-ROM%d: %s\n", c, cdrom[c].image_path);
 #endif
 
         for (int i = 0; i < MAX_PREV_IMAGES; i++) {

--- a/src/device.c
+++ b/src/device.c
@@ -318,8 +318,8 @@ device_add_common(const device_t *dev, void *p, void *params, int inst)
         return NULL;
 
     if (!device_available(dev)) {
-        wchar_t temp[512] = { 0 };
-        swprintf(temp, sizeof_w(temp),
+        char temp[512] = { 0 };
+        snprintf(temp, sizeof(temp),
                  plat_get_string(STRING_HW_NOT_AVAILABLE_DEVICE),
                  dev->name);
         ui_msgbox_header(MBX_INFO,

--- a/src/floppy/fdd_86f.c
+++ b/src/floppy/fdd_86f.c
@@ -3196,7 +3196,7 @@ d86f_writeback(int drive)
         /* The image is compressed. */
 
         /* Open the original, compressed file. */
-        cf = plat_fopen(dev->original_file_name, L"wb");
+        cf = plat_fopen(dev->original_file_name, "wb");
 
         /* Write the header to the original file. */
         fwrite(header, 1, header_size, cf);

--- a/src/include/86box/plat.h
+++ b/src/include/86box/plat.h
@@ -41,16 +41,16 @@ enum {
     STRING_GHOSTSCRIPT_ERROR_TITLE,   /* "Unable to initialize Ghostscript" */
     STRING_GHOSTSCRIPT_ERROR_DESC,    /* "gsdll32.dll/gsdll64.dll/libgs is required..." */
     STRING_HW_NOT_AVAILABLE_TITLE,    /* "Hardware not available" */
-    STRING_HW_NOT_AVAILABLE_MACHINE,  /* "Machine \"%hs\" is not available..." */
-    STRING_HW_NOT_AVAILABLE_VIDEO,    /* "Video card \"%hs\" is not available..." */
-    STRING_HW_NOT_AVAILABLE_VIDEO2,   /* "Video card #2 \"%hs\" is not available..." */
-    STRING_HW_NOT_AVAILABLE_DEVICE,   /* "Device \"%hs\" is not available..." */
+    STRING_HW_NOT_AVAILABLE_MACHINE,  /* "Machine \"%s\" is not available..." */
+    STRING_HW_NOT_AVAILABLE_VIDEO,    /* "Video card \"%s\" is not available..." */
+    STRING_HW_NOT_AVAILABLE_VIDEO2,   /* "Video card #2 \"%s\" is not available..." */
+    STRING_HW_NOT_AVAILABLE_DEVICE,   /* "Device \"%s\" is not available..." */
     STRING_MONITOR_SLEEP,             /* "Monitor in sleep mode" */
     STRING_GHOSTPCL_ERROR_TITLE,      /* "Unable to initialize GhostPCL" */
     STRING_GHOSTPCL_ERROR_DESC,       /* "gpcl6dll32.dll/gpcl6dll64.dll/libgpcl6 is required..." */
     STRING_ESCP_ERROR_TITLE,          /* "Unable to find Dot-Matrix fonts" */
     STRING_ESCP_ERROR_DESC,           /* "TrueType fonts in the \"roms/printer/fonts\" directory..." */
-    STRING_EDID_TOO_LARGE,            /* "EDID file \"%ls\" is too large (%lld bytes)." */
+    STRING_EDID_TOO_LARGE,            /* "EDID file \"%s\" is too large (%lld bytes)." */
 };
 
 /* The Win32 API uses _wcsicmp. */
@@ -160,7 +160,7 @@ extern void     plat_send_to_clipboard(unsigned char *rgb, int width, int height
 extern int      plat_run_command(const char *cmd, const char **env, const char *title);
 
 /* Resource management. */
-extern wchar_t *plat_get_string(int id);
+extern char *plat_get_string(int id);
 
 /* Emulator start/stop support functions. */
 extern void do_start(void);

--- a/src/include/86box/plat_dir.h
+++ b/src/include/86box/plat_dir.h
@@ -15,8 +15,8 @@
 #ifndef PLAT_DIR_H
 #define PLAT_DIR_H
 
-/* Windows and Termux needs the POSIX re-implementations */
-#if defined(_WIN32) || defined(__TERMUX__)
+/* Windows (non-MinGW) and Termux need the POSIX re-implementations */
+#if (defined(_WIN32) && !defined(__MINGW32__)) || defined(__TERMUX__)
 #    ifdef _MAX_FNAME
 #        define MAXNAMLEN _MAX_FNAME
 #    else
@@ -28,11 +28,7 @@ struct dirent {
     long           d_ino;
     unsigned short d_reclen;
     unsigned short d_off;
-#    ifdef UNICODE
-    wchar_t d_name[MAXNAMLEN + 1];
-#    else
-    char d_name[MAXNAMLEN + 1];
-#    endif
+    char           d_name[MAXNAMLEN + 1];
 };
 #    define d_namlen d_reclen
 
@@ -42,11 +38,7 @@ typedef struct DIR_t {
     long  handle; /* open handle to Win32 system */
     short sts;    /* last known status code */
     char *dta;    /* internal work data */
-#    ifdef UNICODE
-    wchar_t dir[MAXDIRLEN + 1]; /* open dir */
-#    else
-    char dir[MAXDIRLEN + 1]; /* open dir */
-#    endif
+    char  dir[MAXDIRLEN + 1]; /* open dir */
     struct dirent dent; /* actual directory entry */
 } DIR;
 
@@ -64,7 +56,7 @@ extern int            closedir(DIR *);
 
 #    define rewinddir(dirp) seekdir(dirp, 0L)
 #else
-/* On linux and macOS, use the standard functions and types */
+/* On MinGW, Linux and macOS, use the standard functions and types */
 #    include <dirent.h>
 #endif
 

--- a/src/include/86box/ui.h
+++ b/src/include/86box/ui.h
@@ -30,12 +30,9 @@ extern "C" {
 #define MBX_QMARK       0x10
 #define MBX_WARNING     0x20
 #define MBX_FATAL       0x40
-#define MBX_ANSI        0x80
-#define MBX_LINKS       0x100
-#define MBX_DONTASK     0x200
 
-extern int ui_msgbox(int flags, void *message);
-extern int ui_msgbox_header(int flags, void *header, void *message);
+extern int ui_msgbox(int flags, char *message);
+extern int ui_msgbox_header(int flags, char *header, char *message);
 
 /* Status Bar functions. */
 #define SB_ICON_WIDTH 24
@@ -51,22 +48,21 @@ extern int ui_msgbox_header(int flags, void *header, void *message);
 #define SB_SOUND      0x90
 #define SB_TEXT       0xA0
 
-extern wchar_t *ui_window_title(wchar_t *s);
-extern void     ui_hard_reset_completed(void);
-extern void     ui_init_monitor(int monitor_index);
-extern void     ui_deinit_monitor(int monitor_index);
-extern void     ui_sb_set_ready(int ready);
-extern void     ui_sb_update_panes(void);
-extern void     ui_sb_update_text(void);
-extern void     ui_sb_update_tip(int meaning);
-extern void     ui_sb_update_icon(int tag, int active);
-extern void     ui_sb_update_icon_write(int tag, int write);
-extern void     ui_sb_update_icon_state(int tag, int state);
-extern void     ui_sb_update_icon_wp(int tag, int state);
-extern void     ui_sb_set_text_w(wchar_t *wstr);
-extern void     ui_sb_set_text(char *str);
-extern void     ui_sb_bugui(char *str);
-extern void     ui_sb_mt32lcd(char *str);
+extern char *ui_window_title(char *s);
+extern void  ui_hard_reset_completed(void);
+extern void  ui_init_monitor(int monitor_index);
+extern void  ui_deinit_monitor(int monitor_index);
+extern void  ui_sb_set_ready(int ready);
+extern void  ui_sb_update_panes(void);
+extern void  ui_sb_update_text(void);
+extern void  ui_sb_update_tip(int meaning);
+extern void  ui_sb_update_icon(int tag, int active);
+extern void  ui_sb_update_icon_write(int tag, int write);
+extern void  ui_sb_update_icon_state(int tag, int state);
+extern void  ui_sb_update_icon_wp(int tag, int state);
+extern void  ui_sb_set_text(char *str);
+extern void  ui_sb_bugui(char *str);
+extern void  ui_sb_mt32lcd(char *str);
 
 extern void     ui_update_force_interpreter(void);
 

--- a/src/include/86box/vnc.h
+++ b/src/include/86box/vnc.h
@@ -26,7 +26,7 @@ extern int  vnc_pause(void);
 
 extern void vnc_kbinput(int, int);
 
-extern void vnc_take_screenshot(wchar_t *fn);
+extern void vnc_take_screenshot(char *fn);
 
 #ifdef __cplusplus
 }

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -482,7 +482,7 @@ network_attach(void *card_drv, uint8_t *mac, NETRXCB rx, NETSETLINKSTATE set_lin
     card->byte_period     = NET_PERIOD_10M;
 
     char net_drv_error[NET_DRV_ERRBUF_SIZE];
-    wchar_t tempmsg[NET_DRV_ERRBUF_SIZE * 2];
+    char tempmsg[NET_DRV_ERRBUF_SIZE * 2];
 
     for (int i = 0; i < NET_QUEUE_COUNT; i++) {
         network_queue_init(&card->queues[i]);
@@ -533,7 +533,7 @@ network_attach(void *card_drv, uint8_t *mac, NETRXCB rx, NETSETLINKSTATE set_lin
 
         if(net_cards_conf[net_card_current].net_type != NET_TYPE_NONE) {
             // We're here because of a failure
-            swprintf(tempmsg, sizeof_w(tempmsg), L"%ls:\n\n%s\n\n%ls", plat_get_string(STRING_NET_ERROR), net_drv_error, plat_get_string(STRING_NET_ERROR_DESC));
+            snprintf(tempmsg, sizeof(tempmsg), "%s:\n\n%s\n\n%s", plat_get_string(STRING_NET_ERROR), net_drv_error, plat_get_string(STRING_NET_ERROR_DESC));
             ui_msgbox(MBX_ERROR, tempmsg);
             net_cards_conf[net_card_current].net_type = NET_TYPE_NONE;
         }

--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -768,16 +768,16 @@ msgstr ""
 msgid "Surface images"
 msgstr ""
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
 msgstr ""
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
 msgstr ""
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
 msgstr ""
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
 msgstr ""
 
 msgid "Machine"
@@ -3018,7 +3018,7 @@ msgstr ""
 msgid "Export EDID"
 msgstr ""
 
-msgid "EDID file \"%ls\" is too large."
+msgid "EDID file \"%s\" is too large."
 msgstr ""
 
 msgid "OpenGL input scale"

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -768,17 +768,17 @@ msgstr "Imatges bàsiques de sector"
 msgid "Surface images"
 msgstr "Imatges de superfície"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "La màquina \"%hs\" no està disponible a causa de les ROMs faltants al directori roms/machines. Canviant a una màquina disponible."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "La màquina \"%s\" no està disponible a causa de les ROMs faltants al directori roms/machines. Canviant a una màquina disponible."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "La tarjeta de vídeo \"%hs\" no està disponible a causa de les ROMs faltants al directori roms/video. Canviant a una tarjeta de video disponible."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "La tarjeta de vídeo \"%s\" no està disponible a causa de les ROMs faltants al directori roms/video. Canviant a una tarjeta de video disponible."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "La tarjeta de vídeo 2 \"%hs\" no està disponible a causa de les ROMs faltants al directori roms/video. Desactivant la segona targeta de vídeo."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "La tarjeta de vídeo 2 \"%s\" no està disponible a causa de les ROMs faltants al directori roms/video. Desactivant la segona targeta de vídeo."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "El dispositiu \"%hs\" no està disponible a causa de les ROMs faltants. Ignorant el dispositiu."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "El dispositiu \"%s\" no està disponible a causa de les ROMs faltants. Ignorant el dispositiu."
 
 msgid "Machine"
 msgstr "Màquina"
@@ -3019,8 +3019,8 @@ msgstr "Exporta…"
 msgid "Export EDID"
 msgstr "Exporta l'EDID"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "El fitxer EDID \"%ls\" és massa gran."
+msgid "EDID file \"%s\" is too large."
+msgstr "El fitxer EDID \"%s\" és massa gran."
 
 msgid "OpenGL input scale"
 msgstr "Escala de entrada de l'OpenGL"

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -768,17 +768,17 @@ msgstr "Základní sektorové obrazy"
 msgid "Surface images"
 msgstr "Obrazy povrchu"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "Počítač \"%hs\" není dostupný, jelikož chybí obraz jeho paměti ROM ve složce \"roms/machines\". Konfigurace se přepne na jiný dostupný počítač."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "Počítač \"%s\" není dostupný, jelikož chybí obraz jeho paměti ROM ve složce \"roms/machines\". Konfigurace se přepne na jiný dostupný počítač."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "Video adaptér \"%hs\" není dostupný, jelikož chybí obraz jeho paměti ROM ve složce \"roms/video\". Konfigurace se přepne na jiný dostupný adaptér."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "Video adaptér \"%s\" není dostupný, jelikož chybí obraz jeho paměti ROM ve složce \"roms/video\". Konfigurace se přepne na jiný dostupný adaptér."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "Video adaptér 2 \"%hs\" není dostupný, jelikož chybí obraz jeho paměti ROM ve složce \"roms/video\". Druhá grafická karta se zakáže."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "Video adaptér 2 \"%s\" není dostupný, jelikož chybí obraz jeho paměti ROM ve složce \"roms/video\". Druhá grafická karta se zakáže."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "Zařízení \"%hs\" není dostupné, jelikož chybí obraz jeho paměti ROM. Zařízení je ignorováno."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "Zařízení \"%s\" není dostupné, jelikož chybí obraz jeho paměti ROM. Zařízení je ignorováno."
 
 msgid "Machine"
 msgstr "Počítač"
@@ -3021,8 +3021,8 @@ msgstr "Exportovat…"
 msgid "Export EDID"
 msgstr "Exportovat EDID"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "Soubor EDID \"%ls\" je příliš velký."
+msgid "EDID file \"%s\" is too large."
+msgstr "Soubor EDID \"%s\" je příliš velký."
 
 msgid "OpenGL input scale"
 msgstr "Měřítko vstupu OpenGL"

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -768,17 +768,17 @@ msgstr "Basissektorabbilder"
 msgid "Surface images"
 msgstr "Oberflächenabbilder"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "Das System \"%hs\" ist aufgrund von fehlenden ROMs im Verzeichnis roms/machines nicht verfügbar. Es wird auf ein verfügbares System gewechselt."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "Das System \"%s\" ist aufgrund von fehlenden ROMs im Verzeichnis roms/machines nicht verfügbar. Es wird auf ein verfügbares System gewechselt."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "Die Videokarte \"%hs\" ist aufgrund von fehlenden ROMs im Verzeichnis roms/video nicht verfügbar. Es wird auf eine verfügbare Videokarte gewechselt."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "Die Videokarte \"%s\" ist aufgrund von fehlenden ROMs im Verzeichnis roms/video nicht verfügbar. Es wird auf eine verfügbare Videokarte gewechselt."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "Die Videokarte 2 \"%hs\" ist aufgrund von fehlenden ROMs im Verzeichnis roms/video nicht verfügbar. Es wird deaktiviert."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "Die Videokarte 2 \"%s\" ist aufgrund von fehlenden ROMs im Verzeichnis roms/video nicht verfügbar. Es wird deaktiviert."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "Das Gerät \"%hs\" ist aufgrund von fehlenden ROMs nicht verfügbar. Es wird ignoriert."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "Das Gerät \"%s\" ist aufgrund von fehlenden ROMs nicht verfügbar. Es wird ignoriert."
 
 msgid "Machine"
 msgstr "System"
@@ -3019,8 +3019,8 @@ msgstr "Exportieren…"
 msgid "Export EDID"
 msgstr "EDID exportieren"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "Die EDID-Datei \"%ls\" ist zu groß."
+msgid "EDID file \"%s\" is too large."
+msgstr "Die EDID-Datei \"%s\" ist zu groß."
 
 msgid "OpenGL input scale"
 msgstr "Eingabeskala von OpenGL"

--- a/src/qt/languages/el-GR.po
+++ b/src/qt/languages/el-GR.po
@@ -769,17 +769,17 @@ msgstr "Εικόνες βασικού τόμου"
 msgid "Surface images"
 msgstr "Εικόνες επιφάνειας"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "Το σύστημα \"%hs\" δεν είναι διαθέσιμο λόγω έλλειψης των ROMs στον κατάλογο roms/machines. Αλλάξτε σε διαθέσιμο σύστημα."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "Το σύστημα \"%s\" δεν είναι διαθέσιμο λόγω έλλειψης των ROMs στον κατάλογο roms/machines. Αλλάξτε σε διαθέσιμο σύστημα."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "Η κάρτα γραφικών \"%hs\" δεν είναι διαθέσιμη λόγω έλλειψης των ROMs στον κατάλογο roms/video. Αλλάξτε σε διαθέσιμη κάρτα γραφικών."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "Η κάρτα γραφικών \"%s\" δεν είναι διαθέσιμη λόγω έλλειψης των ROMs στον κατάλογο roms/video. Αλλάξτε σε διαθέσιμη κάρτα γραφικών."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "Η κάρτα γραφικών #2 \"%hs\" δεν είναι διαθέσιμη λόγω έλλειψης των ROMs στον κατάλογο roms/video. Αλλάξτε σε διαθέσιμη κάρτα γραφικών."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "Η κάρτα γραφικών #2 \"%s\" δεν είναι διαθέσιμη λόγω έλλειψης των ROMs στον κατάλογο roms/video. Αλλάξτε σε διαθέσιμη κάρτα γραφικών."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "Η συσκευή \"%hs\" δεν είναι διαθέσιμη λόγω έλλειψης των ROMs. Παράκαμψη συσκευής."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "Η συσκευή \"%s\" δεν είναι διαθέσιμη λόγω έλλειψης των ROMs. Παράκαμψη συσκευής."
 
 msgid "Machine"
 msgstr "Σύστημα"
@@ -3081,8 +3081,8 @@ msgstr "Εξαγωγή…"
 msgid "Export EDID"
 msgstr "Εξαγωγή EDID"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "Το αρχείο EDID \"%ls\" είναι πολύ μεγάλο."
+msgid "EDID file \"%s\" is too large."
+msgstr "Το αρχείο EDID \"%s\" είναι πολύ μεγάλο."
 
 msgid "OpenGL input scale"
 msgstr "Κλίμακα εισόδου OpenGL"

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -768,17 +768,17 @@ msgstr "Imágenes básicas de sector"
 msgid "Surface images"
 msgstr "Imágenes de superficie"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "La máquina \"%hs\" no está disponible debido a ROMs faltantes en el directorio roms/machines. Cambiando a una máquina disponible."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "La máquina \"%s\" no está disponible debido a ROMs faltantes en el directorio roms/machines. Cambiando a una máquina disponible."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "La tarjeta de vídeo \"%hs\" no está disponible debido a ROMs faltantes en el directorio roms/video. Cambiando a una tarjeta de vídeo disponible."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "La tarjeta de vídeo \"%s\" no está disponible debido a ROMs faltantes en el directorio roms/video. Cambiando a una tarjeta de vídeo disponible."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "La tarjeta de vídeo 2 \"%hs\" no está disponible debido a ROMs faltantes en el directorio roms/video. Deshabilitanto la segunda tarjeta de vídeo."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "La tarjeta de vídeo 2 \"%s\" no está disponible debido a ROMs faltantes en el directorio roms/video. Deshabilitanto la segunda tarjeta de vídeo."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "El dispositivo \"%hs\" no está disponible debido a ROMs faltantes. Ignorando el dispositivo."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "El dispositivo \"%s\" no está disponible debido a ROMs faltantes. Ignorando el dispositivo."
 
 msgid "Machine"
 msgstr "Máquina"
@@ -3018,8 +3018,8 @@ msgstr "Exportar…"
 msgid "Export EDID"
 msgstr "Exportar el EDID"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "El archivo EDID \"%ls\" es demasiado grande."
+msgid "EDID file \"%s\" is too large."
+msgstr "El archivo EDID \"%s\" es demasiado grande."
 
 msgid "OpenGL input scale"
 msgstr "Escala de entrada de OpenGL"

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -769,17 +769,17 @@ msgstr "Perussektorilevykuvat"
 msgid "Surface images"
 msgstr "Pintalevykuvat"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "Konetta \"%hs\" ei voida käyttää, koska roms/machines-hakemistosta puuttuu ROM-tiedostoja. Vaihdetaan käyttökelpoiseen koneeseen."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "Konetta \"%s\" ei voida käyttää, koska roms/machines-hakemistosta puuttuu ROM-tiedostoja. Vaihdetaan käyttökelpoiseen koneeseen."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "Näytönohjainta \"%hs\" ei voida käyttää, koska roms/video-hakemistosta puuttuu ROM-tiedostoja. Vaihdetaan käyttökelpoiseen näytönohjaimeen."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "Näytönohjainta \"%s\" ei voida käyttää, koska roms/video-hakemistosta puuttuu ROM-tiedostoja. Vaihdetaan käyttökelpoiseen näytönohjaimeen."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "Toista näytönohjainta \"%hs\" ei voida käyttää, koska roms/video-hakemistosta puuttuu ROM-tiedostoja. Toinen näytönohjain poistetaan käytöstä."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "Toista näytönohjainta \"%s\" ei voida käyttää, koska roms/video-hakemistosta puuttuu ROM-tiedostoja. Toinen näytönohjain poistetaan käytöstä."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "Laitetta \"%hs\" ei voida käyttää puuttuvien ROM-tiedostojen vuoksi. Laite jätetään huomiotta."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "Laitetta \"%s\" ei voida käyttää puuttuvien ROM-tiedostojen vuoksi. Laite jätetään huomiotta."
 
 msgid "Machine"
 msgstr "Tietokone"
@@ -3020,8 +3020,8 @@ msgstr "Vie…"
 msgid "Export EDID"
 msgstr "Vie EDID"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "EDID-tiedosto \"%ls\" on liian suuri."
+msgid "EDID file \"%s\" is too large."
+msgstr "EDID-tiedosto \"%s\" on liian suuri."
 
 msgid "OpenGL input scale"
 msgstr "OpenGL-syötteen skaalaus"

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -768,17 +768,17 @@ msgstr "Images secteur basique"
 msgid "Surface images"
 msgstr "Images de la surface"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "La machine « %hs » n'est pas disponible en raison de l'absence de ROMs dans le répertoire roms/machines. Basculer vers une machine disponible."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "La machine « %s » n'est pas disponible en raison de l'absence de ROMs dans le répertoire roms/machines. Basculer vers une machine disponible."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "La carte vidéo « %hs » n'est pas disponible en raison de l'absence de ROMs dans le répertoire roms/video. Basculer vers une carte vidéo disponible."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "La carte vidéo « %s » n'est pas disponible en raison de l'absence de ROMs dans le répertoire roms/video. Basculer vers une carte vidéo disponible."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "La carte vidéo 2 « %hs » n'est pas disponible en raison de l'absence de ROMs dans le répertoire roms/video. Désactiver la deuxième carte vidéo."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "La carte vidéo 2 « %s » n'est pas disponible en raison de l'absence de ROMs dans le répertoire roms/video. Désactiver la deuxième carte vidéo."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "Le dispositif « %hs » n'est pas disponible en raison de l'absence de ROMs. Ignorer le dispositif."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "Le dispositif « %s » n'est pas disponible en raison de l'absence de ROMs. Ignorer le dispositif."
 
 msgid "Machine"
 msgstr "Machine"
@@ -3019,8 +3019,8 @@ msgstr "Exporter…"
 msgid "Export EDID"
 msgstr "Exporter l'EDID"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "Le fichier EDID « %ls » est trop volumineux."
+msgid "EDID file \"%s\" is too large."
+msgstr "Le fichier EDID « %s » est trop volumineux."
 
 msgid "OpenGL input scale"
 msgstr "Échelle d'entrée d'OpenGL"

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -771,17 +771,17 @@ msgstr "BOsnovne sektorske slike"
 msgid "Surface images"
 msgstr "Površinske slike"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "Sistem \"%hs\" nije dostupan jer ne postoje potrebni ROM-ovi u mapu roms/machines. Prebacivanje na dostupno računalo."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "Sistem \"%s\" nije dostupan jer ne postoje potrebni ROM-ovi u mapu roms/machines. Prebacivanje na dostupno računalo."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "Video kartica \"%hs\" nije dostupna jer ne postoje potrebni ROM-ovi u mapu roms/video. Prebacivanje na dostupnu video karticu."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "Video kartica \"%s\" nije dostupna jer ne postoje potrebni ROM-ovi u mapu roms/video. Prebacivanje na dostupnu video karticu."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "Video kartica 2 \"%hs\" nije dostupna jer ne postoje potrebni ROM-ovi u mapu roms/video. Isključivanje druge video karice."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "Video kartica 2 \"%s\" nije dostupna jer ne postoje potrebni ROM-ovi u mapu roms/video. Isključivanje druge video karice."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "Uređaj \"%hs\" nije dostupan jer ne postoje potrebni ROM-ovi. Ignoriranje uređaja."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "Uređaj \"%s\" nije dostupan jer ne postoje potrebni ROM-ovi. Ignoriranje uređaja."
 
 msgid "Machine"
 msgstr "Sistem"
@@ -3022,8 +3022,8 @@ msgstr "Izvoz…"
 msgid "Export EDID"
 msgstr "Izvoz EDID-a"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "EDID datoteka \"%ls\" je prevelika."
+msgid "EDID file \"%s\" is too large."
+msgstr "EDID datoteka \"%s\" je prevelika."
 
 msgid "OpenGL input scale"
 msgstr "Ulazna skala OpenGL-a"

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -776,17 +776,17 @@ msgstr "Immagini di settori base"
 msgid "Surface images"
 msgstr "Immagini di superficie"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "La macchina \"%hs\" non è disponibile a causa di immagini ROM mancanti nella directory roms/machines. Passaggio ad una macchina disponibile."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "La macchina \"%s\" non è disponibile a causa di immagini ROM mancanti nella directory roms/machines. Passaggio ad una macchina disponibile."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "La scheda video \"%hs\" non è disponibile a causa di immagini ROM mancanti nella directory roms/video. Passaggio ad una scheda video disponibile."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "La scheda video \"%s\" non è disponibile a causa di immagini ROM mancanti nella directory roms/video. Passaggio ad una scheda video disponibile."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "La scheda video 2 \"%hs\" non è disponibile a causa di immagini ROM mancanti nella directory roms/video. Disabilitazione della seconda scheda video."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "La scheda video 2 \"%s\" non è disponibile a causa di immagini ROM mancanti nella directory roms/video. Disabilitazione della seconda scheda video."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "Il dispositivo \"%hs\" non è disponibile a causa di immagini ROM mancanti. Dispositivo ignorato."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "Il dispositivo \"%s\" non è disponibile a causa di immagini ROM mancanti. Dispositivo ignorato."
 
 msgid "Machine"
 msgstr "Macchina"
@@ -3127,8 +3127,8 @@ msgstr "Esporta…"
 msgid "Export EDID"
 msgstr "Esporta EDID"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "Il file EDID \"%ls\" è troppo grande."
+msgid "EDID file \"%s\" is too large."
+msgstr "Il file EDID \"%s\" è troppo grande."
 
 msgid "OpenGL input scale"
 msgstr "Scala ingresso OpenGL"

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -769,17 +769,17 @@ msgstr "ベーシック セクター イメージ"
 msgid "Surface images"
 msgstr "サーフェス イメージ"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "roms/machines ディレクトリにROMがないため、マシン「%hs」は使用できません。使用可能なマシンに切り替えます。"
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "roms/machines ディレクトリにROMがないため、マシン「%s」は使用できません。使用可能なマシンに切り替えます。"
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "roms/video ディレクトリにROMがないため、ビデオ カード「%hs」は使用できません。使用可能なビデオカードに切り替えます。"
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "roms/video ディレクトリにROMがないため、ビデオ カード「%s」は使用できません。使用可能なビデオカードに切り替えます。"
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "roms/video ディレクトリにROMがないため、ビデオ カード2「%hs」は使用できません。2枚目のビデオカードを無効にします。"
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "roms/video ディレクトリにROMがないため、ビデオ カード2「%s」は使用できません。2枚目のビデオカードを無効にします。"
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "ROMがないため、デバイス「%hs」は使用できません。装置を無視する。"
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "ROMがないため、デバイス「%s」は使用できません。装置を無視する。"
 
 msgid "Machine"
 msgstr "マシン"
@@ -3020,8 +3020,8 @@ msgstr "エクスポート…"
 msgid "Export EDID"
 msgstr "EDIDのエクスポート"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "EDIDファイル「%ls」が大きすぎます。"
+msgid "EDID file \"%s\" is too large."
+msgstr "EDIDファイル「%s」が大きすぎます。"
 
 msgid "OpenGL input scale"
 msgstr "OpenGLの入力スケール"

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -769,17 +769,17 @@ msgstr "기본 섹터 이미지"
 msgid "Surface images"
 msgstr "표면 이미지"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "roms/machines 디렉토리에 필요한 롬파일이 없어 기종 \"%hs\"을(를) 사용할 수 없습니다. 사용 가능한 기종으로 변경합니다."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "roms/machines 디렉토리에 필요한 롬파일이 없어 기종 \"%s\"을(를) 사용할 수 없습니다. 사용 가능한 기종으로 변경합니다."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "roms/video 디렉토리에 필요한 롬파일이 없어 비디오 카드 \"%hs\"을(를) 사용할 수 없습니다. 사용 가능한 기종으로 변경합니다."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "roms/video 디렉토리에 필요한 롬파일이 없어 비디오 카드 \"%s\"을(를) 사용할 수 없습니다. 사용 가능한 기종으로 변경합니다."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "roms/video 디렉토리에 필요한 롬파일이 없어 비디오 카드 2 \"%hs\"을(를) 사용할 수 없습니다. 두 번째 비디오 카드를 비활성화합니다."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "roms/video 디렉토리에 필요한 롬파일이 없어 비디오 카드 2 \"%s\"을(를) 사용할 수 없습니다. 두 번째 비디오 카드를 비활성화합니다."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "필요한 롬파일이 없어 장치 \"%hs\"을(를) 사용할 수 없습니다. 장치를 무시합니다."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "필요한 롬파일이 없어 장치 \"%s\"을(를) 사용할 수 없습니다. 장치를 무시합니다."
 
 msgid "Machine"
 msgstr "기종"
@@ -3022,8 +3022,8 @@ msgstr "수출…"
 msgid "Export EDID"
 msgstr "EDID 내보내기"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "EDID 파일 \"%ls\"가 너무 큽니다."
+msgid "EDID file \"%s\" is too large."
+msgstr "EDID 파일 \"%s\"가 너무 큽니다."
 
 msgid "OpenGL input scale"
 msgstr "OpenGL 입력 스케일"

--- a/src/qt/languages/nb-NO.po
+++ b/src/qt/languages/nb-NO.po
@@ -769,17 +769,17 @@ msgstr "Basis sektorfiler"
 msgid "Surface images"
 msgstr "Surface-diskfiler"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "Maskin \"%hs\" er ikke tilgjengelig på grunn av manglende ROM-er i roms/machines-mappen. Bytter til en tilgjengelig maskin."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "Maskin \"%s\" er ikke tilgjengelig på grunn av manglende ROM-er i roms/machines-mappen. Bytter til en tilgjengelig maskin."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "Grafikkort \"%hs\" er ikke tilgjengelig på grunn av manglende ROM-er i roms/video-mappen. Bytter til et tilgjengelig grafikkort."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "Grafikkort \"%s\" er ikke tilgjengelig på grunn av manglende ROM-er i roms/video-mappen. Bytter til et tilgjengelig grafikkort."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "Grafikkort #2 \"%hs\" er ikke tilgjengelig på grunn av manglende ROM-er i roms/video-mappen. Deaktiverer det andre grafikkortet."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "Grafikkort #2 \"%s\" er ikke tilgjengelig på grunn av manglende ROM-er i roms/video-mappen. Deaktiverer det andre grafikkortet."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "Enhet \"%hs\" er ikke tilgjengelig på grunn av manglende ROM-er. Ignorerer enheten."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "Enhet \"%s\" er ikke tilgjengelig på grunn av manglende ROM-er. Ignorerer enheten."
 
 msgid "Machine"
 msgstr "Maskin"
@@ -3020,8 +3020,8 @@ msgstr "Eksporter…"
 msgid "Export EDID"
 msgstr "Eksporter EDID"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "EDID-filen \"%ls\" er for stor."
+msgid "EDID file \"%s\" is too large."
+msgstr "EDID-filen \"%s\" er for stor."
 
 msgid "OpenGL input scale"
 msgstr "Inngangsskala for OpenGL"

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -768,17 +768,17 @@ msgstr "Basissectorimages"
 msgid "Surface images"
 msgstr "Oppervlakte-images"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "Machine \"%hs\" is niet beschikbaar door ontbrekende ROMs in de map roms/machines. Er wordt overgeschakeld naar een beschikbare machine."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "Machine \"%s\" is niet beschikbaar door ontbrekende ROMs in de map roms/machines. Er wordt overgeschakeld naar een beschikbare machine."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "Videokaart \"%hs\" is niet beschikbaar door ontbrekende ROMs in de map roms/video. Er wordt overgeschakeld naar een beschikbare videokaart."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "Videokaart \"%s\" is niet beschikbaar door ontbrekende ROMs in de map roms/video. Er wordt overgeschakeld naar een beschikbare videokaart."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "Videokaart #2 \"%hs\" is niet beschikbaar door ontbrekende ROMs in de map roms/video. De tweede videokaart wordt uitgeschakeld."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "Videokaart #2 \"%s\" is niet beschikbaar door ontbrekende ROMs in de map roms/video. De tweede videokaart wordt uitgeschakeld."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "Het apparaat \"%hs\" is niet beschikbaar door ontbrekende ROMs. Het apparaat wordt genegeerd."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "Het apparaat \"%s\" is niet beschikbaar door ontbrekende ROMs. Het apparaat wordt genegeerd."
 
 msgid "Machine"
 msgstr "Machine"
@@ -3019,8 +3019,8 @@ msgstr "Exporteren…"
 msgid "Export EDID"
 msgstr "EDID exporteren"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "Het EDID-bestand \"%ls\" is te groot."
+msgid "EDID file \"%s\" is too large."
+msgstr "Het EDID-bestand \"%s\" is te groot."
 
 msgid "OpenGL input scale"
 msgstr "Invoerschaal van OpenGL"

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -769,17 +769,17 @@ msgstr "Podstawowe obrazy sektorów"
 msgid "Surface images"
 msgstr "Obrazy powierzchni"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "Maszyna „%hs” nie jest dostępna, ponieważ brakuje ROM-ów w katalogu roms/machines. Przełączanie na dostępną maszynę."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "Maszyna „%s” nie jest dostępna, ponieważ brakuje ROM-ów w katalogu roms/machines. Przełączanie na dostępną maszynę."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "Karta wideo „%hs” nie jest dostępna, ponieważ brakuje ROM-ów w katalogu roms/video. Przełączanie na dostępną kartę graficzną."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "Karta wideo „%s” nie jest dostępna, ponieważ brakuje ROM-ów w katalogu roms/video. Przełączanie na dostępną kartę graficzną."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "Karta wideo 2 „%hs” nie jest dostępna, ponieważ brakuje ROM-ów w katalogu roms/video. Wyłączenie drugiej karty graficznej."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "Karta wideo 2 „%s” nie jest dostępna, ponieważ brakuje ROM-ów w katalogu roms/video. Wyłączenie drugiej karty graficznej."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "Urządzenie „%hs” nie jest dostępne, ponieważ brakuje ROM-ów. Ignorowanie urządzenia."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "Urządzenie „%s” nie jest dostępne, ponieważ brakuje ROM-ów. Ignorowanie urządzenia."
 
 msgid "Machine"
 msgstr "Maszyna"
@@ -3020,8 +3020,8 @@ msgstr "Eksportuj…"
 msgid "Export EDID"
 msgstr "Eksportuj EDID"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "Plik EDID „%ls” jest zbyt duży."
+msgid "EDID file \"%s\" is too large."
+msgstr "Plik EDID „%s” jest zbyt duży."
 
 msgid "OpenGL input scale"
 msgstr "Skala wejścia OpenGL"

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -769,17 +769,17 @@ msgstr "Imagens de setores básicos"
 msgid "Surface images"
 msgstr "Imagens de superfície"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "A máquina \"%hs\" não está disponível devido à falta de ROMs no diretório roms/machines. Mudando para uma máquina disponível."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "A máquina \"%s\" não está disponível devido à falta de ROMs no diretório roms/machines. Mudando para uma máquina disponível."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "A placa de vídeo \"%hs\" não está disponível devido à falta de ROMs no diretório roms/video. Mudando para uma placa de vídeo disponível."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "A placa de vídeo \"%s\" não está disponível devido à falta de ROMs no diretório roms/video. Mudando para uma placa de vídeo disponível."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "A placa de vídeo 2 \"%hs\" não está disponível devido à falta de ROMs no diretório roms/video. Desativando a segunda placa de vídeo."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "A placa de vídeo 2 \"%s\" não está disponível devido à falta de ROMs no diretório roms/video. Desativando a segunda placa de vídeo."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "O dispositivo \"%hs\" não está disponível devido à falta de ROMs. Ignorando o dispositivo."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "O dispositivo \"%s\" não está disponível devido à falta de ROMs. Ignorando o dispositivo."
 
 msgid "Machine"
 msgstr "Máquina"
@@ -3019,8 +3019,8 @@ msgstr "Exportar…"
 msgid "Export EDID"
 msgstr "Exportar EDID"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "O arquivo EDID \"%ls\" é muito grande."
+msgid "EDID file \"%s\" is too large."
+msgstr "O arquivo EDID \"%s\" é muito grande."
 
 msgid "OpenGL input scale"
 msgstr "Escala de entrada do OpenGL"

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -769,17 +769,17 @@ msgstr "Imagens básicas de sector"
 msgid "Surface images"
 msgstr "Imagens de superfície"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "A máquina \"%hs\" não está disponível devido à falta de ROMs na pasta roms/machines. A mudar para uma máquina disponível."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "A máquina \"%s\" não está disponível devido à falta de ROMs na pasta roms/machines. A mudar para uma máquina disponível."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "A placa vídeo \"%hs\" não está disponível devido à falta de ROMs na pasta roms/video. A mudar para uma placa vídeo disponível."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "A placa vídeo \"%s\" não está disponível devido à falta de ROMs na pasta roms/video. A mudar para uma placa vídeo disponível."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "A placa vídeo 2 \"%hs\" não está disponível devido à falta de ROMs na pasta roms/video. A desativar a segunda placa vídeo."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "A placa vídeo 2 \"%s\" não está disponível devido à falta de ROMs na pasta roms/video. A desativar a segunda placa vídeo."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "O dispositivo \"%hs\" não está disponível devido à falta de ROMs A ignorar o dispositivo."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "O dispositivo \"%s\" não está disponível devido à falta de ROMs A ignorar o dispositivo."
 
 msgid "Machine"
 msgstr "Máquina"
@@ -3019,8 +3019,8 @@ msgstr "Exportar…"
 msgid "Export EDID"
 msgstr "Exportar EDID"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "O ficheiro EDID \"%ls\" é demasiado grande."
+msgid "EDID file \"%s\" is too large."
+msgstr "O ficheiro EDID \"%s\" é demasiado grande."
 
 msgid "OpenGL input scale"
 msgstr "Escala de entrada do OpenGL"

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -769,17 +769,17 @@ msgstr "Простые посекторные образы"
 msgid "Surface images"
 msgstr "Образы поверхности"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "Системная плата «%hs» недоступна из-за отсутствия файла её ПЗУ в каталоге roms/machines. Переключение на доступную системную плату."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "Системная плата «%s» недоступна из-за отсутствия файла её ПЗУ в каталоге roms/machines. Переключение на доступную системную плату."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "Видеокарта «%hs» недоступна из-за отсутствия файла её ПЗУ в каталоге roms/video. Переключение на доступную видеокарту."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "Видеокарта «%s» недоступна из-за отсутствия файла её ПЗУ в каталоге roms/video. Переключение на доступную видеокарту."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "Видеокарта 2 «%hs» недоступна из-за отсутствия файла её ПЗУ в каталоге roms/video. Вторая видеокарта отключена."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "Видеокарта 2 «%s» недоступна из-за отсутствия файла её ПЗУ в каталоге roms/video. Вторая видеокарта отключена."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "Устройство «%hs» недоступно из-за отсутствия файла его ПЗУ. Устройство проигнорировано."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "Устройство «%s» недоступно из-за отсутствия файла его ПЗУ. Устройство проигнорировано."
 
 msgid "Machine"
 msgstr "Компьютер"
@@ -3031,8 +3031,8 @@ msgstr "Экспорт…"
 msgid "Export EDID"
 msgstr "Экспорт EDID"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "Файл EDID «%ls» слишком велик."
+msgid "EDID file \"%s\" is too large."
+msgstr "Файл EDID «%s» слишком велик."
 
 msgid "OpenGL input scale"
 msgstr "Масштаб ввода OpenGL"

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -769,17 +769,17 @@ msgstr "Základné sektorové obrazy"
 msgid "Surface images"
 msgstr "Obrazy povrchu"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "Počítač \"%hs\" ie je dostupný, pretože chýba obraz jeho pamäte ROM v zložke \"roms/machines\". Konfigurácia sa prepne na iný dostupný počítač."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "Počítač \"%s\" ie je dostupný, pretože chýba obraz jeho pamäte ROM v zložke \"roms/machines\". Konfigurácia sa prepne na iný dostupný počítač."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "Video adaptér \"%hs\" nie je dostupný, pretože chýba obraz jeho pamäte ROM v zložke \"roms/video\". Konfigurácia sa prepne na iný dostupný adaptér."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "Video adaptér \"%s\" nie je dostupný, pretože chýba obraz jeho pamäte ROM v zložke \"roms/video\". Konfigurácia sa prepne na iný dostupný adaptér."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "Video adaptér 2 \"%hs\" nie je dostupný, pretože chýba obraz jeho pamäte ROM v zložke \"roms/video\". Druhá grafická karta sa zakáže."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "Video adaptér 2 \"%s\" nie je dostupný, pretože chýba obraz jeho pamäte ROM v zložke \"roms/video\". Druhá grafická karta sa zakáže."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "Zariadenie \"%hs\" nie je dostupné, pretože chýba obraz jeho pamäte ROM. Zariadenie sa ignoruje."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "Zariadenie \"%s\" nie je dostupné, pretože chýba obraz jeho pamäte ROM. Zariadenie sa ignoruje."
 
 msgid "Machine"
 msgstr "Počítač"
@@ -3020,8 +3020,8 @@ msgstr "Exportovať…"
 msgid "Export EDID"
 msgstr "Exportovať EDID"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "Súbor EDID \"%ls\" je príliš veľký."
+msgid "EDID file \"%s\" is too large."
+msgstr "Súbor EDID \"%s\" je príliš veľký."
 
 msgid "OpenGL input scale"
 msgstr "Vstupná stupnica OpenGL"

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -770,17 +770,17 @@ msgstr "Osnovne sektorske slike"
 msgid "Surface images"
 msgstr "Površinske slike"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "Sistem \"%hs\" ni na voljo zaradi manjkajočih ROM-ov v mapi roms/machines. Preklapljam na drug sistem, ki je na voljo."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "Sistem \"%s\" ni na voljo zaradi manjkajočih ROM-ov v mapi roms/machines. Preklapljam na drug sistem, ki je na voljo."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "Grafična kartica \"%hs\" ni na voljo zaradi manjkajočih ROM-ov v mapi roms/video. Preklapljam na drugo grafično kartico, ki je na voljo."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "Grafična kartica \"%s\" ni na voljo zaradi manjkajočih ROM-ov v mapi roms/video. Preklapljam na drugo grafično kartico, ki je na voljo."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "Grafična kartica 2 \"%hs\" ni na voljo zaradi manjkajočih ROM-ov v mapi roms/video. Onemogočam drugo grafično kartico."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "Grafična kartica 2 \"%s\" ni na voljo zaradi manjkajočih ROM-ov v mapi roms/video. Onemogočam drugo grafično kartico."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "Naprava \"%hs\" ni na voljo zaradi manjkajočih ROM-ov. Preziram napravo."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "Naprava \"%s\" ni na voljo zaradi manjkajočih ROM-ov. Preziram napravo."
 
 msgid "Machine"
 msgstr "Sistem"
@@ -3021,8 +3021,8 @@ msgstr "Izvoz…"
 msgid "Export EDID"
 msgstr "Izvoz EDID"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "Datoteka EDID \"%ls\" je prevelika."
+msgid "EDID file \"%s\" is too large."
+msgstr "Datoteka EDID \"%s\" je prevelika."
 
 msgid "OpenGL input scale"
 msgstr "Vhodna lestvica OpenGL"

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -769,17 +769,17 @@ msgstr "Grundläggande sektoravbildningar"
 msgid "Surface images"
 msgstr "Ytavbildningar"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "Maskinen \"%hs\" är inte tillgänglig på grund av saknade ROM-avbildningar i mappen roms/machines. Byter till en tillgänglig maskin."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "Maskinen \"%s\" är inte tillgänglig på grund av saknade ROM-avbildningar i mappen roms/machines. Byter till en tillgänglig maskin."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "Bildskärmskortet \"%hs\" är inte tillgängligt på grund av saknade ROM-avbildningar i mappen roms/video. Byter till ett tillgängligt bildskärmskort."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "Bildskärmskortet \"%s\" är inte tillgängligt på grund av saknade ROM-avbildningar i mappen roms/video. Byter till ett tillgängligt bildskärmskort."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "Bildskärmskort #2 \"%hs\" är inte tillgängligt på grund av saknade ROM-avbildningar i mappen roms/video. Avaktiverar det andra bildskärmskortet."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "Bildskärmskort #2 \"%s\" är inte tillgängligt på grund av saknade ROM-avbildningar i mappen roms/video. Avaktiverar det andra bildskärmskortet."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "Enheten \"%hs\" är inte tillgänglig på grund av saknade ROM-avbildningar. Ignorerar enheten."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "Enheten \"%s\" är inte tillgänglig på grund av saknade ROM-avbildningar. Ignorerar enheten."
 
 msgid "Machine"
 msgstr "Maskin"
@@ -3020,8 +3020,8 @@ msgstr "Exportera…"
 msgid "Export EDID"
 msgstr "Exportera EDID"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "EDID-filen \"%ls\" är för stor."
+msgid "EDID file \"%s\" is too large."
+msgstr "EDID-filen \"%s\" är för stor."
 
 msgid "OpenGL input scale"
 msgstr "Inmatningsskala för OpenGL"

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -768,17 +768,17 @@ msgstr "Basit sektör görüntüleri"
 msgid "Surface images"
 msgstr "Yüzey görüntüleri"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "\"%hs\" anakartı roms/machines klasöründe gerekli ROM dosyalarının mevcut olmaması nedeniyle kullanılamıyor. Kullanılabilen başka bir anakarta geçiş yapılacaktır."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "\"%s\" anakartı roms/machines klasöründe gerekli ROM dosyalarının mevcut olmaması nedeniyle kullanılamıyor. Kullanılabilen başka bir anakarta geçiş yapılacaktır."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "\"%hs\" ekran kartı roms/video klasöründe gerekli ROM dosyalarının mevcut olmaması nedeniyle kullanılamıyor. Kullanılabilen başka bir ekran kartına geçiş yapılacaktır."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "\"%s\" ekran kartı roms/video klasöründe gerekli ROM dosyalarının mevcut olmaması nedeniyle kullanılamıyor. Kullanılabilen başka bir ekran kartına geçiş yapılacaktır."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "\"%hs\" ikincil ekran kartı roms/video klasöründe gerekli ROM dosyalarının mevcut olmaması nedeniyle kullanılamıyor. Bu cihaz devre dışı bırakılacaktır."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "\"%s\" ikincil ekran kartı roms/video klasöründe gerekli ROM dosyalarının mevcut olmaması nedeniyle kullanılamıyor. Bu cihaz devre dışı bırakılacaktır."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "\"%hs\" cihazı gerekli ROM dosyalarının mevcut olmaması nedeniyle kullanılamıyor. Bu cihaz yok sayılacaktır."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "\"%s\" cihazı gerekli ROM dosyalarının mevcut olmaması nedeniyle kullanılamıyor. Bu cihaz yok sayılacaktır."
 
 msgid "Machine"
 msgstr "Anakart"
@@ -3070,8 +3070,8 @@ msgstr "Dışa aktar…"
 msgid "Export EDID"
 msgstr "EDID'i dışa aktar"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "EDID dosyası \"%ls\" çok büyük."
+msgid "EDID file \"%s\" is too large."
+msgstr "EDID dosyası \"%s\" çok büyük."
 
 msgid "OpenGL input scale"
 msgstr "OpenGL giriş ölçeği"

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -770,17 +770,17 @@ msgstr "Прості посекторні образи"
 msgid "Surface images"
 msgstr "Образ поверхні"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "Системна плата «%hs» недоступна через відсутність файлу її ПЗУ в каталозі roms/machines. Переключення на доступну системну плату."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "Системна плата «%s» недоступна через відсутність файлу її ПЗУ в каталозі roms/machines. Переключення на доступну системну плату."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "Відеокарта «%hs» недоступна через відсутність файлу її ПЗУ в каталозі roms/video. Переключення на доступну відеокарту."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "Відеокарта «%s» недоступна через відсутність файлу її ПЗУ в каталозі roms/video. Переключення на доступну відеокарту."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "Відеокарта 2 «%hs» недоступна через відсутність файлу її ПЗУ в каталозі roms/video. Відключення другої відеокарти."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "Відеокарта 2 «%s» недоступна через відсутність файлу її ПЗУ в каталозі roms/video. Відключення другої відеокарти."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "Пристрій «%hs» недоступний через відсутність файлу його ПЗУ. Ігнорування пристрою."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "Пристрій «%s» недоступний через відсутність файлу його ПЗУ. Ігнорування пристрою."
 
 msgid "Machine"
 msgstr "Комп'ютер"
@@ -3021,8 +3021,8 @@ msgstr "Експорт…"
 msgid "Export EDID"
 msgstr "Експорт EDID"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "Файл EDID «%ls» занадто великий."
+msgid "EDID file \"%s\" is too large."
+msgstr "Файл EDID «%s» занадто великий."
 
 msgid "OpenGL input scale"
 msgstr "Шкала введення OpenGL"

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -769,17 +769,17 @@ msgstr "Ảnh sector cơ bản"
 msgid "Surface images"
 msgstr "Ảnh bề mặt"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "Mẫu máy \"%hs\" không giả lập được do thiếu file ROM tương ứng trong thư mục roms/machines. Hãy chọn mẫu máy khác."
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "Mẫu máy \"%s\" không giả lập được do thiếu file ROM tương ứng trong thư mục roms/machines. Hãy chọn mẫu máy khác."
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "Card đồ họa \"%hs\" không giả lập được do thiếu file ROM tương ứng trong thư mục roms/video. Hãy chọn card đồ họa khác."
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "Card đồ họa \"%s\" không giả lập được do thiếu file ROM tương ứng trong thư mục roms/video. Hãy chọn card đồ họa khác."
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "Card đồ họa 2 \"%hs\" không giả lập được do thiếu file ROM tương ứng trong mục roms/video. Vô hiệu hóa card đồ họa thứ hai."
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "Card đồ họa 2 \"%s\" không giả lập được do thiếu file ROM tương ứng trong mục roms/video. Vô hiệu hóa card đồ họa thứ hai."
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "Thiết bị \"%hs\" không giả lập được do thiếu file ROM. Bỏ qua thiết bị."
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "Thiết bị \"%s\" không giả lập được do thiếu file ROM. Bỏ qua thiết bị."
 
 msgid "Machine"
 msgstr "Mẫu máy"
@@ -3020,8 +3020,8 @@ msgstr "Xuất ra file…"
 msgid "Export EDID"
 msgstr "Xuất ra file EDID"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "Tệp EDID \"%ls\" quá lớn."
+msgid "EDID file \"%s\" is too large."
+msgstr "Tệp EDID \"%s\" quá lớn."
 
 msgid "OpenGL input scale"
 msgstr "Độ phân giải đầu vào của OpenGL"

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -769,17 +769,17 @@ msgstr "基本扇区映像"
 msgid "Surface images"
 msgstr "表面映像"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "由于 roms/machines 文件夹中缺少合适的 ROM，机型 \"%hs\" 不可用。将切换到其他可用机型。"
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "由于 roms/machines 文件夹中缺少合适的 ROM，机型 \"%s\" 不可用。将切换到其他可用机型。"
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "由于 roms/video 文件夹中缺少合适的 ROM，显卡 \"%hs\" 不可用。将切换到其他可用显卡。"
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "由于 roms/video 文件夹中缺少合适的 ROM，显卡 \"%s\" 不可用。将切换到其他可用显卡。"
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "由于 roms/video 文件夹中缺少合适的 ROM，显卡 2 \"%hs\" 不可用。禁用第二块显卡。"
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "由于 roms/video 文件夹中缺少合适的 ROM，显卡 2 \"%s\" 不可用。禁用第二块显卡。"
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "由于缺少合适的 ROM，设备 \"%hs\" 不可用。忽略设备。"
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "由于缺少合适的 ROM，设备 \"%s\" 不可用。忽略设备。"
 
 msgid "Machine"
 msgstr "机型"
@@ -3019,8 +3019,8 @@ msgstr "导出…"
 msgid "Export EDID"
 msgstr "导出EDID"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "EDID文件 \"%ls\" 过大。"
+msgid "EDID file \"%s\" is too large."
+msgstr "EDID文件 \"%s\" 过大。"
 
 msgid "OpenGL input scale"
 msgstr "OpenGL的输入比例"

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -769,17 +769,17 @@ msgstr "基本磁區影像"
 msgid "Surface images"
 msgstr "表面影像"
 
-msgid "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
-msgstr "由於 roms/machines 資料夾中缺少合適的 ROM，機型 \"%hs\" 不可用。將切換到其他可用機型。"
+msgid "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine."
+msgstr "由於 roms/machines 資料夾中缺少合適的 ROM，機型 \"%s\" 不可用。將切換到其他可用機型。"
 
-msgid "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
-msgstr "由於 roms/video 資料夾中缺少合適的 ROM，顯示卡 \"%hs\" 不可用。將切換到其他可用顯示卡。"
+msgid "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card."
+msgstr "由於 roms/video 資料夾中缺少合適的 ROM，顯示卡 \"%s\" 不可用。將切換到其他可用顯示卡。"
 
-msgid "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
-msgstr "由於 roms/video 資料夾中缺少合適的 ROM，顯示卡 2 \"%hs\" 不可用。禁用第二張顯示卡。"
+msgid "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card."
+msgstr "由於 roms/video 資料夾中缺少合適的 ROM，顯示卡 2 \"%s\" 不可用。禁用第二張顯示卡。"
 
-msgid "Device \"%hs\" is not available due to missing ROMs. Ignoring the device."
-msgstr "由於缺少合適的 ROM，裝置 \"%hs\" 不可用。忽略裝置。"
+msgid "Device \"%s\" is not available due to missing ROMs. Ignoring the device."
+msgstr "由於缺少合適的 ROM，裝置 \"%s\" 不可用。忽略裝置。"
 
 msgid "Machine"
 msgstr "機型"
@@ -3020,8 +3020,8 @@ msgstr "匯出…"
 msgid "Export EDID"
 msgstr "匯出 EDID"
 
-msgid "EDID file \"%ls\" is too large."
-msgstr "EDID 檔案 \"%ls\" 太大。"
+msgid "EDID file \"%s\" is too large."
+msgstr "EDID 檔案 \"%s\" 太大。"
 
 msgid "OpenGL input scale"
 msgstr "OpenGL 的輸入比例"

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -369,7 +369,6 @@ MainWindow::MainWindow(QWidget *parent)
             toolbar_text = title;
         toolbar_label->setText(toolbar_label->fontMetrics().elidedText(toolbar_text, Qt::ElideRight, toolbar_label->width()));
     });
-    connect(this, &MainWindow::getTitleForNonQtThread, this, &MainWindow::getTitle_, Qt::BlockingQueuedConnection);
 
     connect(this, &MainWindow::updateMenuResizeOptions, [this]() {
         ui->actionResizable_window->setEnabled(vid_resize != 2);
@@ -1500,20 +1499,10 @@ MainWindow::on_actionFullscreen_triggered()
     ui->stackedWidget->onResize(ui->stackedWidget->width(), ui->stackedWidget->height());
 }
 
-void
-MainWindow::getTitle_(wchar_t *title)
+QString
+MainWindow::getTitle()
 {
-    this->windowTitle().toWCharArray(title);
-}
-
-void
-MainWindow::getTitle(wchar_t *title)
-{
-    if (QThread::currentThread() == this->thread()) {
-        getTitle_(title);
-    } else {
-        emit getTitleForNonQtThread(title);
-    }
+    return toolbar_label->text();
 }
 
 // Helper to find an accelerator key and return it's sequence

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -363,8 +363,6 @@ MainWindow::MainWindow(QWidget *parent)
     connect(this, &MainWindow::setTitle, this, [this](const QString &title) {
         if (hide_tool_bar)
             return;
-        if (dopause)
-            toolbar_text += tr(" - PAUSED");
         else
             toolbar_text = title;
         toolbar_label->setText(toolbar_label->fontMetrics().elidedText(toolbar_text, Qt::ElideRight, toolbar_label->width()));

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -34,7 +34,7 @@ public:
     ~MainWindow();
 
     void         showMessage(int flags, const QString &header, const QString &message, bool richText);
-    void         getTitle(wchar_t *title);
+    QString      getTitle();
     void         blitToWidget(int x, int y, int w, int h, int monitor_index);
     QSize        getRenderWidgetSize();
     void         setSendKeyboardInput(bool enabled);
@@ -66,7 +66,6 @@ signals:
     void setMouseCapture(bool state);
 
     void showMessageForNonQtThread(int flags, const QString &header, const QString &message, bool richText, std::atomic_bool *done);
-    void getTitleForNonQtThread(wchar_t *title);
 
     void vmmRunningStateChanged(VMManagerProtocol::RunningState state);
     void vmmConfigurationChanged();
@@ -135,7 +134,6 @@ private slots:
 
     void refreshMediaMenu();
     void showMessage_(int flags, const QString &header, const QString &message, bool richText, std::atomic_bool *done = nullptr);
-    void getTitle_(wchar_t *title);
 
     void on_actionMCA_devices_triggered();
 

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -824,42 +824,43 @@ c16stombs(char dst[], const uint16_t src[], int len)
 #    define LIB_NAME_PCAP "libpcap"
 #endif
 
-QMap<int, std::wstring> Preferences::translatedstrings;
+QMap<int, QByteArray> Preferences::translatedstrings;
 
 void
 Preferences::reloadStrings()
 {
     translatedstrings.clear();
-    translatedstrings[STRING_MOUSE_CAPTURE]             = QCoreApplication::translate("", "Click to capture mouse").toStdWString();
-    translatedstrings[STRING_MOUSE_RELEASE]             = QCoreApplication::translate("", "Press %1 to release mouse").arg(QKeySequence(acc_keys[FindAccelerator("release_mouse")].seq, QKeySequence::PortableText).toString(QKeySequence::NativeText)).toStdWString();
-    translatedstrings[STRING_MOUSE_RELEASE_MMB]         = QCoreApplication::translate("", "Press %1 or middle button to release mouse").arg(QKeySequence(acc_keys[FindAccelerator("release_mouse")].seq, QKeySequence::PortableText).toString(QKeySequence::NativeText)).toStdWString();
-    translatedstrings[STRING_INVALID_CONFIG]            = QCoreApplication::translate("", "Invalid configuration").toStdWString();
-    translatedstrings[STRING_NO_ST506_ESDI_CDROM]       = QCoreApplication::translate("", "MFM/RLL or ESDI CD-ROM drives never existed").toStdWString();
-    translatedstrings[STRING_PCAP_ERROR_NO_DEVICES]     = QCoreApplication::translate("", "No PCap devices found").toStdWString();
-    translatedstrings[STRING_PCAP_ERROR_INVALID_DEVICE] = QCoreApplication::translate("", "Invalid PCap device").toStdWString();
-    translatedstrings[STRING_PCAP_ERROR_DESC]           = QCoreApplication::translate("", "Make sure %1 is installed and that you are on a %1-compatible network connection.").arg(LIB_NAME_PCAP).toStdWString();
-    translatedstrings[STRING_GHOSTSCRIPT_ERROR_TITLE]   = QCoreApplication::translate("", "Unable to initialize Ghostscript").toStdWString();
-    translatedstrings[STRING_GHOSTSCRIPT_ERROR_DESC]    = QCoreApplication::translate("", "%1 is required for automatic conversion of PostScript files to PDF.\n\nAny documents sent to the generic PostScript printer will be saved as PostScript (.ps) files.").arg(LIB_NAME_GS).toStdWString();
-    translatedstrings[STRING_GHOSTPCL_ERROR_TITLE]      = QCoreApplication::translate("", "Unable to initialize GhostPCL").toStdWString();
-    translatedstrings[STRING_GHOSTPCL_ERROR_DESC]       = QCoreApplication::translate("", "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files.").arg(LIB_NAME_GPCL).toStdWString();
-    translatedstrings[STRING_HW_NOT_AVAILABLE_MACHINE]  = QCoreApplication::translate("", "Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine.").toStdWString();
-    translatedstrings[STRING_HW_NOT_AVAILABLE_VIDEO]    = QCoreApplication::translate("", "Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card.").toStdWString();
-    translatedstrings[STRING_HW_NOT_AVAILABLE_VIDEO2]   = QCoreApplication::translate("", "Video card #2 \"%hs\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card.").toStdWString();
-    translatedstrings[STRING_HW_NOT_AVAILABLE_DEVICE]   = QCoreApplication::translate("", "Device \"%hs\" is not available due to missing ROMs. Ignoring the device.").toStdWString();
-    translatedstrings[STRING_HW_NOT_AVAILABLE_TITLE]    = QCoreApplication::translate("", "Hardware not available").toStdWString();
-    translatedstrings[STRING_MONITOR_SLEEP]             = QCoreApplication::translate("", "Monitor in sleep mode").toStdWString();
-    translatedstrings[STRING_NET_ERROR]                 = QCoreApplication::translate("", "Failed to initialize network driver").toStdWString();
-    translatedstrings[STRING_NET_ERROR_DESC]            = QCoreApplication::translate("", "The network configuration will be switched to the null driver").toStdWString();
-    translatedstrings[STRING_ESCP_ERROR_TITLE]          = QCoreApplication::translate("", "Unable to find Dot-Matrix fonts").toStdWString();
-    translatedstrings[STRING_ESCP_ERROR_DESC]           = QCoreApplication::translate("", "TrueType fonts in the \"roms/printer/fonts\" directory are required for the emulation of the Generic ESC/P 2 Dot-Matrix Printer.").toStdWString();
-    translatedstrings[STRING_EDID_TOO_LARGE]            = QCoreApplication::translate("", "EDID file \"%ls\" is too large.").toStdWString();
+    translatedstrings[STRING_MOUSE_CAPTURE]             = QCoreApplication::translate("", "Click to capture mouse").toUtf8();
+    translatedstrings[STRING_MOUSE_RELEASE]             = QCoreApplication::translate("", "Press %1 to release mouse").arg(QKeySequence(acc_keys[FindAccelerator("release_mouse")].seq, QKeySequence::PortableText).toString(QKeySequence::NativeText)).toUtf8();
+    translatedstrings[STRING_MOUSE_RELEASE_MMB]         = QCoreApplication::translate("", "Press %1 or middle button to release mouse").arg(QKeySequence(acc_keys[FindAccelerator("release_mouse")].seq, QKeySequence::PortableText).toString(QKeySequence::NativeText)).toUtf8();
+    translatedstrings[STRING_INVALID_CONFIG]            = QCoreApplication::translate("", "Invalid configuration").toUtf8();
+    translatedstrings[STRING_NO_ST506_ESDI_CDROM]       = QCoreApplication::translate("", "MFM/RLL or ESDI CD-ROM drives never existed").toUtf8();
+    translatedstrings[STRING_PCAP_ERROR_NO_DEVICES]     = QCoreApplication::translate("", "No PCap devices found").toUtf8();
+    translatedstrings[STRING_PCAP_ERROR_INVALID_DEVICE] = QCoreApplication::translate("", "Invalid PCap device").toUtf8();
+    translatedstrings[STRING_PCAP_ERROR_DESC]           = QCoreApplication::translate("", "Make sure %1 is installed and that you are on a %1-compatible network connection.").arg(LIB_NAME_PCAP).toUtf8();
+    translatedstrings[STRING_GHOSTSCRIPT_ERROR_TITLE]   = QCoreApplication::translate("", "Unable to initialize Ghostscript").toUtf8();
+    translatedstrings[STRING_GHOSTSCRIPT_ERROR_DESC]    = QCoreApplication::translate("", "%1 is required for automatic conversion of PostScript files to PDF.\n\nAny documents sent to the generic PostScript printer will be saved as PostScript (.ps) files.").arg(LIB_NAME_GS).toUtf8();
+    translatedstrings[STRING_GHOSTPCL_ERROR_TITLE]      = QCoreApplication::translate("", "Unable to initialize GhostPCL").toUtf8();
+    translatedstrings[STRING_GHOSTPCL_ERROR_DESC]       = QCoreApplication::translate("", "%1 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files.").arg(LIB_NAME_GPCL).toUtf8();
+    translatedstrings[STRING_HW_NOT_AVAILABLE_MACHINE]  = QCoreApplication::translate("", "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine.").toUtf8();
+    translatedstrings[STRING_HW_NOT_AVAILABLE_VIDEO]    = QCoreApplication::translate("", "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card.").toUtf8();
+    translatedstrings[STRING_HW_NOT_AVAILABLE_VIDEO2]   = QCoreApplication::translate("", "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card.").toUtf8();
+    translatedstrings[STRING_HW_NOT_AVAILABLE_DEVICE]   = QCoreApplication::translate("", "Device \"%s\" is not available due to missing ROMs. Ignoring the device.").toUtf8();
+    translatedstrings[STRING_HW_NOT_AVAILABLE_TITLE]    = QCoreApplication::translate("", "Hardware not available").toUtf8();
+    translatedstrings[STRING_MONITOR_SLEEP]             = QCoreApplication::translate("", "Monitor in sleep mode").toUtf8();
+    translatedstrings[STRING_NET_ERROR]                 = QCoreApplication::translate("", "Failed to initialize network driver").toUtf8();
+    translatedstrings[STRING_NET_ERROR_DESC]            = QCoreApplication::translate("", "The network configuration will be switched to the null driver").toUtf8();
+    translatedstrings[STRING_ESCP_ERROR_TITLE]          = QCoreApplication::translate("", "Unable to find Dot-Matrix fonts").toUtf8();
+    translatedstrings[STRING_ESCP_ERROR_DESC]           = QCoreApplication::translate("", "TrueType fonts in the \"roms/printer/fonts\" directory are required for the emulation of the Generic ESC/P 2 Dot-Matrix Printer.").toUtf8();
+    translatedstrings[STRING_EDID_TOO_LARGE]            = QCoreApplication::translate("", "EDID file \"%s\" is too large.").toUtf8();
 }
 
-wchar_t *
+char *
 plat_get_string(int i)
 {
     if (Preferences::translatedstrings.empty())
         Preferences::reloadStrings();
+
     return Preferences::translatedstrings[i].data();
 }
 

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -639,10 +639,6 @@ exit_pause(void)
 void
 plat_pause(int p)
 {
-    static wchar_t oldtitle[512];
-    wchar_t        title[1024];
-    wchar_t        paused_msg[512];
-
     if (!cpu_thread_running && p == 1) {
         p = 2;
     }
@@ -672,15 +668,11 @@ plat_pause(int p)
     if (p) {
         if (mouse_capture)
             plat_mouse_capture(0);
-
-        wcsncpy(oldtitle, ui_window_title(NULL), sizeof_w(oldtitle) - 1);
-        wcscpy(title, oldtitle);
-        paused_msg[QObject::tr(" - PAUSED").toWCharArray(paused_msg)] = 0;
-        wcscat(title, paused_msg);
-        ui_window_title(title);
-    } else {
-        ui_window_title(oldtitle);
     }
+
+    QString title      = main_window->getTitle();
+    QString pausedText = QObject::tr(" - PAUSED");
+    emit main_window->setTitle(p ? title.append(pausedText) : title.left(title.indexOf(pausedText)));
 
 #ifdef DISCORD
     discord_update_activity(dopause);

--- a/src/qt/qt_preferences.hpp
+++ b/src/qt/qt_preferences.hpp
@@ -46,7 +46,7 @@ protected:
     static CustomTranslator                *translator;
     static QTranslator                     *qtTranslator;
     static QVector<QPair<QString, QString>> languages;
-    static QMap<int, std::wstring>          translatedstrings;
+    static QMap<int, QByteArray>            translatedstrings;
 protected slots:
     void accept() override;
 

--- a/src/qt/qt_ui.cpp
+++ b/src/qt/qt_ui.cpp
@@ -74,10 +74,8 @@ wchar_t *
 ui_window_title(wchar_t *str)
 {
     if (str == nullptr) {
-        static wchar_t title[512] = { 0 };
-
-        main_window->getTitle(title);
-        str = title;
+        QString title = main_window->getTitle();
+        title.toWCharArray(str);
     } else
         emit main_window->setTitle(QString::fromWCharArray(str));
 

--- a/src/qt/qt_ui.cpp
+++ b/src/qt/qt_ui.cpp
@@ -70,14 +70,14 @@ plat_delay_ms(uint32_t count)
 #endif
 }
 
-wchar_t *
-ui_window_title(wchar_t *str)
+char *
+ui_window_title(char *str)
 {
     if (str == nullptr) {
         QString title = main_window->getTitle();
-        title.toWCharArray(str);
+        str = title.toUtf8().data();
     } else
-        emit main_window->setTitle(QString::fromWCharArray(str));
+        emit main_window->setTitle(QString::fromUtf8(str));
 
     return str;
 }
@@ -150,10 +150,10 @@ plat_mouse_capture(int on)
 }
 
 int
-ui_msgbox_header(int flags, void *header, void *message)
+ui_msgbox_header(int flags, char *header, char *message)
 {
-    const auto hdr = (flags & MBX_ANSI) ? QString(static_cast<char *>(header)) : QString::fromWCharArray(static_cast<const wchar_t *>(header));
-    const auto msg = (flags & MBX_ANSI) ? QString(static_cast<char *>(message)) : QString::fromWCharArray(static_cast<const wchar_t *>(message));
+    const auto hdr = QString::fromUtf8(header);
+    const auto msg = QString::fromUtf8(message);
 
     // any error in early init
     if (main_window == nullptr) {
@@ -192,7 +192,7 @@ ui_deinit_monitor(int monitor_index)
 }
 
 int
-ui_msgbox(int flags, void *message)
+ui_msgbox(int flags, char *message)
 {
     return ui_msgbox_header(flags, nullptr, message);
 }
@@ -208,13 +208,6 @@ void
 ui_sb_mt32lcd(char *str)
 {
     sb_mt32lcdtext = QString(str);
-    ui_sb_update_text();
-}
-
-void
-ui_sb_set_text_w(wchar_t *wstr)
-{
-    sb_text = QString::fromWCharArray(wstr);
     ui_sb_update_text();
 }
 

--- a/src/scsi/scsi_aha154x.c
+++ b/src/scsi/scsi_aha154x.c
@@ -835,7 +835,7 @@ aha_setmcode(x54x_t *dev)
         return;
 
     /* Open the microcode image file and make sure it exists. */
-    aha_log("%s: loading microcode from '%ls'\n", dev->name, dev->bios_path);
+    aha_log("%s: loading microcode from '%s'\n", dev->name, dev->bios_path);
     if ((fp = rom_fopen(dev->mcode_path, "rb")) == NULL) {
         aha_log("%s: microcode ROM not found!\n", dev->name);
         return;

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -84,7 +84,7 @@ bool            fast_forward = false;
 int             fixed_size_x = 640;
 int             fixed_size_y = 480;
 extern int      title_set;
-extern wchar_t  sdl_win_title[512];
+extern char     sdl_win_title[512];
 SDL_mutex      *blitmtx;
 SDL_threadID    eventthread;
 static int      exit_event         = 0;
@@ -276,46 +276,46 @@ dynld_close(void *handle)
     dlclose(handle);
 }
 
-wchar_t *
+char *
 plat_get_string(int i)
 {
     switch (i) {
         case STRING_MOUSE_CAPTURE:
-            return L"Click to capture mouse";
+            return "Click to capture mouse";
         case STRING_MOUSE_RELEASE:
-            return L"Press CTRL-END to release mouse";
+            return "Press CTRL-END to release mouse";
         case STRING_MOUSE_RELEASE_MMB:
-            return L"Press CTRL-END or middle button to release mouse";
+            return "Press CTRL-END or middle button to release mouse";
         case STRING_INVALID_CONFIG:
-            return L"Invalid configuration";
+            return "Invalid configuration";
         case STRING_NO_ST506_ESDI_CDROM:
-            return L"MFM/RLL or ESDI CD-ROM drives never existed";
+            return "MFM/RLL or ESDI CD-ROM drives never existed";
         case STRING_PCAP_ERROR_NO_DEVICES:
-            return L"No PCap devices found";
+            return "No PCap devices found";
         case STRING_PCAP_ERROR_INVALID_DEVICE:
-            return L"Invalid PCap device";
+            return "Invalid PCap device";
         case STRING_GHOSTSCRIPT_ERROR_DESC:
-            return L"libgs is required for automatic conversion of PostScript files to PDF.\n\nAny documents sent to the generic PostScript printer will be saved as PostScript (.ps) files.";
+            return "libgs is required for automatic conversion of PostScript files to PDF.\n\nAny documents sent to the generic PostScript printer will be saved as PostScript (.ps) files.";
         case STRING_PCAP_ERROR_DESC:
-            return L"Make sure libpcap is installed and that you are on a libpcap-compatible network connection.";
+            return "Make sure libpcap is installed and that you are on a libpcap-compatible network connection.";
         case STRING_GHOSTSCRIPT_ERROR_TITLE:
-            return L"Unable to initialize Ghostscript";
+            return "Unable to initialize Ghostscript";
         case STRING_GHOSTPCL_ERROR_TITLE:
-            return L"Unable to initialize GhostPCL";
+            return "Unable to initialize GhostPCL";
         case STRING_GHOSTPCL_ERROR_DESC:
-            return L"libgpcl6 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files.";
+            return "libgpcl6 is required for automatic conversion of PCL files to PDF.\n\nAny documents sent to the generic PCL printer will be saved as Printer Command Language (.pcl) files.";
         case STRING_HW_NOT_AVAILABLE_MACHINE:
-            return L"Machine \"%hs\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine.";
+            return "Machine \"%s\" is not available due to missing ROMs in the roms/machines directory. Switching to an available machine.";
         case STRING_HW_NOT_AVAILABLE_VIDEO:
-            return L"Video card \"%hs\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card.";
+            return "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card.";
         case STRING_HW_NOT_AVAILABLE_TITLE:
-            return L"Hardware not available";
+            return "Hardware not available";
         case STRING_MONITOR_SLEEP:
-            return L"Monitor in sleep mode";
+            return "Monitor in sleep mode";
         case STRING_EDID_TOO_LARGE:
-            return L"EDID file \"%ls\" is too large.";
+            return "EDID file \"%s\" is too large.";
     }
-    return L"";
+    return "";
 }
 
 FILE *
@@ -637,7 +637,7 @@ path_get_dirname(char *dest, const char *path)
 }
 
 void
-ui_sb_set_text_w(UNUSED(wchar_t *wstr))
+ui_sb_set_text(UNUSED(char *str))
 {
     /* No-op. */
 }
@@ -763,23 +763,19 @@ do_stop(void)
 }
 
 int
-ui_msgbox(int flags, void *message)
+ui_msgbox(int flags, char *message)
 {
     return ui_msgbox_header(flags, NULL, message);
 }
 
 int
-ui_msgbox_header(int flags, void *header, void *message)
+ui_msgbox_header(int flags, char *header, char *message)
 {
     SDL_MessageBoxData       msgdata;
     SDL_MessageBoxButtonData msgbtn;
 
-    if (!header) {
-        if (flags & MBX_ANSI)
-            header = (void *) EMU_NAME;
-        else
-            header = (void *) EMU_NAME_W;
-    }
+    if (!header)
+        header = EMU_NAME;
 
     msgbtn.buttonid = 1;
     msgbtn.text     = "OK";
@@ -795,25 +791,11 @@ ui_msgbox_header(int flags, void *header, void *message)
     else
         msgflags |= SDL_MESSAGEBOX_INFORMATION;
     msgdata.flags = msgflags;
-    if (flags & MBX_ANSI) {
-        int button      = 0;
-        msgdata.title   = header;
-        msgdata.message = message;
-        SDL_ShowMessageBox(&msgdata, &button);
-        return button;
-    } else {
-        int   button    = 0;
-        char *res       = SDL_iconv_string("UTF-8", sizeof(wchar_t) == 2 ? "UTF-16LE" : "UTF-32LE", (char *) message, wcslen(message) * sizeof(wchar_t) + sizeof(wchar_t));
-        char *res2      = SDL_iconv_string("UTF-8", sizeof(wchar_t) == 2 ? "UTF-16LE" : "UTF-32LE", (char *) header, wcslen(header) * sizeof(wchar_t) + sizeof(wchar_t));
-        msgdata.message = res;
-        msgdata.title   = res2;
-        SDL_ShowMessageBox(&msgdata, &button);
-        free(res);
-        free(res2);
-        return button;
-    }
-
-    return 0;
+    int button      = 0;
+    msgdata.title   = header;
+    msgdata.message = message;
+    SDL_ShowMessageBox(&msgdata, &button);
+    return button;
 }
 
 void
@@ -886,8 +868,8 @@ local_strsep(char **str, const char *sep)
 void
 plat_pause(int p)
 {
-    static wchar_t oldtitle[512];
-    wchar_t        title[512];
+    static char oldtitle[512];
+    char        title[512];
 
     if ((!!p) == dopause)
         return;
@@ -897,9 +879,9 @@ plat_pause(int p)
 
     do_pause(p);
     if (p) {
-        wcsncpy(oldtitle, ui_window_title(NULL), sizeof_w(oldtitle) - 1);
-        wcscpy(title, oldtitle);
-        wcscat(title, L" - PAUSED");
+        strncpy(oldtitle, ui_window_title(NULL), sizeof(oldtitle) - 1);
+        strcpy(title, oldtitle);
+        strcat(title, " - PAUSED");
         ui_window_title(title);
     } else {
         ui_window_title(oldtitle);
@@ -1458,7 +1440,7 @@ main(int argc, char **argv)
     if (ret == 0)
         return 0;
     if (!pc_init_roms()) {
-        ui_msgbox_header(MBX_FATAL, L"No ROMs found.", EMU_NAME_W L" could not find any usable ROM images.\n\nPlease download a ROM set and extract it into the \"roms\" directory.");
+        ui_msgbox_header(MBX_FATAL, "No ROMs found.", EMU_NAME " could not find any usable ROM images.\n\nPlease download a ROM set and extract it into the \"roms\" directory.");
         SDL_Quit();
         return 6;
     }

--- a/src/unix/unix_osd.c
+++ b/src/unix/unix_osd.c
@@ -44,8 +44,7 @@ extern SDL_mutex          *sdl_mutex;
 extern void unix_executeLine(char *line);
 
 // interface to the currently set window title, this can't be seen normally in a fullscreen setup
-extern wchar_t sdl_win_title[512];
-char sdl_win_title_mb[512] = "";
+extern char sdl_win_title[512];
 
 /* Private software renderer for OSD drawing (no dependency on main window renderer). */
 static SDL_Surface  *osd_surface  = NULL;
@@ -181,8 +180,7 @@ void draw_menu(SDL_Renderer *renderer, int selected)
 
     draw_text(renderer, "MAIN MENU", x0 + 20, y0 + 5, (SDL_Color){255,255,255,255});
 
-    wcstombs(sdl_win_title_mb, sdl_win_title, 256);
-    draw_text(renderer, sdl_win_title_mb, x0 + 120, y0 + 5, (SDL_Color){255,255,255,255});
+    draw_text(renderer, sdl_win_title, x0 + 120, y0 + 5, (SDL_Color){255,255,255,255});
 
     for (int i = 0; i < MENU_ITEMS; i++)
     {

--- a/src/unix/unix_osd_new.cpp
+++ b/src/unix/unix_osd_new.cpp
@@ -42,7 +42,7 @@
 extern "C" {
 extern SDL_Window  *sdl_win;
 extern SDL_Renderer *sdl_render;
-extern wchar_t      sdl_win_title[512];
+extern char         sdl_win_title[512];
 extern void         unix_executeLine(char *line);
 }
 
@@ -81,8 +81,6 @@ static bool      mouse_was_captured = false;
 
 static char      files[OSD_FILE_CAPACITY][OSD_PATH_CAPACITY];
 static int       file_count     = 0;
-
-static char      sdl_win_title_mb[512] = "";
 
 /* ------------------------------------------------------------------ */
 /*  Log ring buffer                                                    */
@@ -633,8 +631,6 @@ static bool draw_menu(void)
     const bool enter = ImGui::IsKeyPressed(ImGuiKey_Enter,       false)
                     || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter, false);
 
-    wcstombs(sdl_win_title_mb, sdl_win_title, sizeof(sdl_win_title_mb) - 1);
-
     menu_normalize_selection();
 
     bool close_osd = false;
@@ -662,8 +658,8 @@ static bool draw_menu(void)
                  ImGuiWindowFlags_NoNav);
 
     /* Show window title (machine info) */
-    if (sdl_win_title_mb[0]) {
-        ImGui::TextDisabled("%s", sdl_win_title_mb);
+    if (sdl_win_title[0]) {
+        ImGui::TextDisabled("%s", sdl_win_title);
         ImGui::Separator();
     }
 

--- a/src/unix/unix_sdl.c
+++ b/src/unix/unix_sdl.c
@@ -612,30 +612,21 @@ plat_resize(int w, int h, UNUSED(int monitor_index))
     SDL_UnlockMutex(sdl_mutex);
 }
 
-wchar_t    sdl_win_title[512] = { L'8', L'6', L'B', L'o', L'x', 0 };
+char    sdl_win_title[512] = EMU_NAME;
 SDL_mutex *titlemtx           = NULL;
 
 void
 ui_window_title_real(void)
 {
-    char *res;
-    if (sizeof(wchar_t) == 1) {
-        SDL_SetWindowTitle(sdl_win, (char *) sdl_win_title);
-        return;
-    }
-    res = SDL_iconv_string("UTF-8", sizeof(wchar_t) == 2 ? "UTF-16LE" : "UTF-32LE", (char *) sdl_win_title, wcslen(sdl_win_title) * sizeof(wchar_t) + sizeof(wchar_t));
-    if (res) {
-        SDL_SetWindowTitle(sdl_win, res);
-        SDL_free((void *) res);
-    }
+    SDL_SetWindowTitle(sdl_win, sdl_win_title);
     title_set = 0;
 }
 extern SDL_threadID eventthread;
 
 /* Only activate threading path on macOS, otherwise it will softlock Xorg.
    Wayland doesn't seem to have this issue. */
-wchar_t *
-ui_window_title(wchar_t *str)
+char *
+ui_window_title(char *str)
 {
     if (!str)
         return sdl_win_title;
@@ -644,13 +635,13 @@ ui_window_title(wchar_t *str)
 #endif
     {
         memset(sdl_win_title, 0, sizeof(sdl_win_title));
-        wcsncpy(sdl_win_title, str, 512);
+        strncpy(sdl_win_title, str, sizeof(sdl_win_title) - 1);
         ui_window_title_real();
         return str;
     }
 #ifdef __APPLE__
     memset(sdl_win_title, 0, sizeof(sdl_win_title));
-    wcsncpy(sdl_win_title, str, 512);
+    strncpy(sdl_win_title, str, sizeof(sdl_win_title) - 1);
     title_set = 1;
 #endif
     return str;

--- a/src/video/vid_ddc.c
+++ b/src/video/vid_ddc.c
@@ -236,16 +236,9 @@ ddc_init_with_custom_edid(char *edid_path, void *i2c)
     size_t  size        = ddc_load_edid(edid_path, buffer, sizeof(buffer));
 
     if (size > 256) {
-        wchar_t errmsg[2048] = { 0 };
-        wchar_t path[2048]   = { 0 };
-
-#ifdef _WIN32
-        mbstoc16s(path, monitor_edid_path, sizeof_w(path));
-#else
-        mbstowcs(path, monitor_edid_path, sizeof_w(path));
-#endif
-        swprintf(errmsg, sizeof_w(errmsg), plat_get_string(STRING_EDID_TOO_LARGE), path);
-        ui_msgbox_header(MBX_ERROR, L"EDID", errmsg);
+        char errmsg[2048] = { 0 };
+        snprintf(errmsg, sizeof(errmsg), plat_get_string(STRING_EDID_TOO_LARGE), monitor_edid_path);
+        ui_msgbox_header(MBX_ERROR, "EDID", errmsg);
 
         return NULL;
     } else if (size == 0) {

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -1226,11 +1226,11 @@ svga_recalctimings(svga_t *svga)
             video_blit_memtoscreen_monitor(x_start, y_start, svga->monitor->mon_xsize + x_add, svga->monitor->mon_ysize + y_add, svga->monitor_index);
             video_wait_for_buffer_monitor(svga->monitor_index);
             svga->dpms_ui = 1;
-            ui_sb_set_text_w(plat_get_string(STRING_MONITOR_SLEEP));
+            ui_sb_set_text(plat_get_string(STRING_MONITOR_SLEEP));
         }
     } else if (svga->dpms_ui) {
         svga->dpms_ui = 0;
-        ui_sb_set_text_w(NULL);
+        ui_sb_set_text(NULL);
     }
 
     if (enable_overscan && (svga->monitor->mon_overscan_x != old_monitor_overscan_x || svga->monitor->mon_overscan_y != old_monitor_overscan_y))
@@ -1780,7 +1780,7 @@ svga_close(svga_t *svga)
     free(svga->vram);
 
     if (svga->dpms_ui)
-        ui_sb_set_text_w(NULL);
+        ui_sb_set_text(NULL);
 
     svga_pri = NULL;
 }

--- a/src/vnc.c
+++ b/src/vnc.c
@@ -304,7 +304,7 @@ vnc_pause(void)
 }
 
 void
-vnc_take_screenshot(UNUSED(wchar_t *fn))
+vnc_take_screenshot(UNUSED(char *fn))
 {
     vnc_log("VNC: take_screenshot\n");
 }

--- a/src/vnc.c
+++ b/src/vnc.c
@@ -29,6 +29,7 @@
 #include <86box/plat.h>
 #include <86box/ui.h>
 #include <86box/vnc.h>
+#include <86box/version.h>
 
 #define VNC_MIN_X 320
 #define VNC_MAX_X 2048
@@ -195,7 +196,7 @@ vnc_blit(int x, int y, int w, int h, int monitor_index)
 int
 vnc_init(UNUSED(void *arg))
 {
-    static char    title[128];
+    static char    title[1536];
     rfbPixelFormat rpf = {
         /*
          * Screen format:
@@ -213,7 +214,7 @@ vnc_init(UNUSED(void *arg))
     cgapal_rebuild_monitor(0);
 
     if (rfb == NULL) {
-        wcstombs(title, ui_window_title(NULL), sizeof(title));
+        snprintf(title, sizeof(title), "%s - " EMU_NAME " " EMU_VERSION_FULL, vm_name);
         updatingSize = 0;
         allowedX     = scrnsz_x;
         allowedY     = scrnsz_y;


### PR DESCRIPTION
Summary
=======
- Fix `MainWindow::getTitle()` no longer returning what was intended to be returned
- VNC: Don't rely on `ui_window_title()`, its return value is UI-dependent and may not be what is expected
- Fix occasional doubled "PAUSED" text appearing in the toolbar
- Complete the UTF-8 rewrite from 2021 by replacing most uses of wide strings with narrow ones, especially in the `plat_` and `ui_` APIs

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set

References
==========
N/A