### PR TITLE
Device config dialog improvements

### DIFF
--- a/src/chipset/laserxt.c
+++ b/src/chipset/laserxt.c
@@ -348,6 +348,21 @@ static const device_config_t laserxt_config[] = {
         .bios           = { { 0 } }
     },
     {
+        .name           = "ems_1_mem_size",
+        .description    = "EMS 1 Memory Size",
+        .type           = CONFIG_SPINNER,
+        .default_string = NULL,
+        .default_int    = 0,
+        .file_filter    = NULL,
+        .spinner = {
+            .min  =    0,
+            .max  =  512,
+            .step =   32
+        },
+        .selection      = { { 0 } },
+        .bios           = { { 0 } }
+    },
+    {
         .name           = "ems_2_base",
         .description    = "EMS 2 Address",
         .type           = CONFIG_HEX16,
@@ -366,21 +381,6 @@ static const device_config_t laserxt_config[] = {
             { .description = "0x2E8",    .value = 0x2e8 },
             { .description = ""                         }
         },
-        .bios           = { { 0 } }
-    },
-    {
-        .name           = "ems_1_mem_size",
-        .description    = "EMS 1 Memory Size",
-        .type           = CONFIG_SPINNER,
-        .default_string = NULL,
-        .default_int    = 0,
-        .file_filter    = NULL,
-        .spinner = {
-            .min  =    0,
-            .max  =  512,
-            .step =   32
-        },
-        .selection      = { { 0 } },
         .bios           = { { 0 } }
     },
     {

--- a/src/qt/qt_deviceconfig.cpp
+++ b/src/qt/qt_deviceconfig.cpp
@@ -354,6 +354,8 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                     lineEdit->setObjectName(config->name);
                     lineEdit->setCursor(Qt::IBeamCursor);
                     lineEdit->setText(selected);
+                    lineEdit->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Preferred);
+                    lineEdit->setMinimumWidth(150);
                     this->ui->formLayout->addRow(tr(config->description).append(colon), lineEdit);
                     break;
                 }

--- a/src/qt/qt_deviceconfig.cpp
+++ b/src/qt/qt_deviceconfig.cpp
@@ -444,12 +444,12 @@ DeviceConfig::ConfigureDevice(const _device_ *device, int instance, Settings *se
     bios_rows    = 0;
 
     DeviceConfig dc(settings);
-    dc.setWindowTitle(tr("%1 Device Configuration").arg(tr(device->name)));
+    dc.setWindowTitle(tr("%1 Device Configuration").arg(DeviceName(device, device->internal_name, -1)));
 
     device_context_t device_context;
     device_set_context(&device_context, device, instance);
 
-    const auto device_label = new QLabel(tr(device->name));
+    const auto device_label = new QLabel(DeviceName(device, device->internal_name, -1));
     device_label->setAlignment(Qt::AlignCenter);
     dc.ui->formLayout->addRow(device_label);
     const auto line = new QFrame;

--- a/src/qt/qt_deviceconfig.cpp
+++ b/src/qt/qt_deviceconfig.cpp
@@ -48,6 +48,7 @@ extern "C" {
 #include "qt_filefield.hpp"
 #include "qt_models_common.hpp"
 #include "qt_util.hpp"
+#include "qt_preferences.hpp"
 #ifdef Q_OS_WINDOWS
 #    define WIN32_LEAN_AND_MEAN
 #    include <windows.h>
@@ -136,6 +137,7 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
     auto         *device_context = static_cast<device_context_t *>(dc);
     const auto   *config         = static_cast<const _device_config_ *>(c);
     const QString blank          = "";
+    const QString colon          = (Preferences::languageIdToCode(lang_id).startsWith("fr-") ? " :" : ":");
     int           bios           = -1;
     int           p;
     int           q;
@@ -188,7 +190,7 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                     auto *cbox = new QCheckBox();
                     cbox->setObjectName(config->name);
                     cbox->setChecked(value > 0);
-                    this->ui->formLayout->addRow(tr(config->description), cbox);
+                    this->ui->formLayout->addRow(tr(config->description).append(colon), cbox);
                     break;
                 }
 #ifdef USE_RTMIDI
@@ -207,7 +209,7 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                         if (i == value)
                             currentIndex = i;
                     }
-                    this->ui->formLayout->addRow(tr(config->description), cbox);
+                    this->ui->formLayout->addRow(tr(config->description).append(colon), cbox);
                     cbox->setCurrentIndex(currentIndex);
                     break;
                 }
@@ -226,7 +228,7 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                         if (i == value)
                             currentIndex = i;
                     }
-                    this->ui->formLayout->addRow(tr(config->description), cbox);
+                    this->ui->formLayout->addRow(tr(config->description).append(colon), cbox);
                     cbox->setCurrentIndex(currentIndex);
                     break;
                 }
@@ -249,7 +251,7 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                         if (sel->value == value)
                             currentIndex = row;
                     }
-                    this->ui->formLayout->addRow(tr(config->description), cbox);
+                    this->ui->formLayout->addRow(tr(config->description).append(colon), cbox);
                     cbox->setCurrentIndex(currentIndex);
                     if (!strcmp(config->name, "memory")) {
                         cbox_memory = cbox;
@@ -290,7 +292,7 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
 
                     bios_rows = rows;
                     if (rows > 1)
-                        this->ui->formLayout->addRow(tr(config->description), cbox);
+                        this->ui->formLayout->addRow(tr(config->description).append(colon), cbox);
 
                     bios = currentIndex;
                     cbox->setCurrentIndex(currentIndex);
@@ -308,7 +310,7 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                     if (config->spinner.step > 0)
                         spinBox->setSingleStep(config->spinner.step);
                     spinBox->setValue(value);
-                    this->ui->formLayout->addRow(tr(config->description), spinBox);
+                    this->ui->formLayout->addRow(tr(config->description).append(colon), spinBox);
                     break;
                 }
             case CONFIG_FNAME:
@@ -343,7 +345,7 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                         extensionList[i] = re.match(extensionList[i]).captured(1);
 #endif
                     fileField->setFilter(tr(description.toUtf8().constData()) % util::DlgFilter(extensionList) % tr("All files") % util::DlgFilter({ "*" }, true));
-                    this->ui->formLayout->addRow(tr(config->description), fileField);
+                    this->ui->formLayout->addRow(tr(config->description).append(colon), fileField);
                     break;
                 }
             case CONFIG_STRING:
@@ -352,7 +354,7 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                     lineEdit->setObjectName(config->name);
                     lineEdit->setCursor(Qt::IBeamCursor);
                     lineEdit->setText(selected);
-                    this->ui->formLayout->addRow(tr(config->description), lineEdit);
+                    this->ui->formLayout->addRow(tr(config->description).append(colon), lineEdit);
                     break;
                 }
             case CONFIG_SERPORT:
@@ -378,7 +380,7 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                             currentIndex = row;
                     }
 
-                    this->ui->formLayout->addRow(tr(config->description), cbox);
+                    this->ui->formLayout->addRow(tr(config->description).append(colon), cbox);
                     cbox->setCurrentIndex(currentIndex);
                     break;
                 }
@@ -411,7 +413,7 @@ DeviceConfig::ProcessConfig(void *dc, const void *c, const bool is_dep)
                     });
                     hboxLayout->addWidget(lineEdit);
                     hboxLayout->addWidget(generateButton);
-                    this->ui->formLayout->addRow(tr(config->description), hboxLayout);
+                    this->ui->formLayout->addRow(tr(config->description).append(colon), hboxLayout);
                     break;
                 }
         }

--- a/src/qt/qt_deviceconfig.cpp
+++ b/src/qt/qt_deviceconfig.cpp
@@ -626,6 +626,9 @@ DeviceConfig::DeviceName(const _device_ *device, const char *internalName, const
     else if (device == nullptr)
         return "";
     else {
+        if (internalName == nullptr)
+            internalName = device->internal_name;
+
         char        temp[512];
         const char *tempbus;
         if (bus == 1) {

--- a/src/qt/qt_deviceconfig.hpp
+++ b/src/qt/qt_deviceconfig.hpp
@@ -25,7 +25,7 @@ public:
 
     static int     ConfigureDevice(const _device_ *device, int instance = 0,
                                    Settings *settings = qobject_cast<Settings *>(Settings::settings));
-    static QString DeviceName(const _device_ *device, const char *internalName, int bus);
+    static QString DeviceName(const _device_ *device, const char *internalName = nullptr, int bus = 0);
 
 private:
     Ui::DeviceConfig * ui;


### PR DESCRIPTION
Summary
=======
* Append colons to control labels;
* Display device names as shown in the settings dialog, sans the bus mention;
* Enlarge text fields (`CONFIG_STRING`);
* Drive-by: Reorder the options of the VTech Laser Turbo XT.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set

References
==========
N/A