### PR TITLE
A few various changes

### DIFF
--- a/src/disk/hdd.c
+++ b/src/disk/hdd.c
@@ -48,22 +48,11 @@ hdd_string_to_bus(char *str, int cdrom)
     if (!strcmp(str, "none"))
         return HDD_BUS_DISABLED;
 
-    if (!strcmp(str, "mfm")) {
-        if (cdrom) {
-no_cdrom:
-            ui_msgbox_header(MBX_ERROR, plat_get_string(STRING_INVALID_CONFIG), plat_get_string(STRING_NO_ST506_ESDI_CDROM));
-            return 0;
-        }
-
+    if (!strcmp(str, "mfm") && !cdrom)
         return HDD_BUS_MFM;
-    }
 
-    if (!strcmp(str, "esdi")) {
-        if (cdrom)
-            goto no_cdrom;
-
+    if (!strcmp(str, "esdi") && !cdrom)
         return HDD_BUS_ESDI;
-    }
 
     if (!strcmp(str, "ide"))
         return HDD_BUS_IDE;
@@ -77,38 +66,28 @@ no_cdrom:
     if (!strcmp(str, "scsi"))
         return HDD_BUS_SCSI;
     
-    if (!strcmp(str, "mitsumi"))
+    if (!strcmp(str, "mitsumi") && cdrom)
         return CDROM_BUS_MITSUMI;
 
-    if (!strcmp(str, "mke"))
+    if (!strcmp(str, "mke") && cdrom)
         return CDROM_BUS_MKE;
 
-    return 0;
+    return HDD_BUS_DISABLED;
 }
 
 char *
-hdd_bus_to_string(int bus, UNUSED(int cdrom))
+hdd_bus_to_string(int bus, int cdrom)
 {
     char *s = "none";
 
     switch (bus) {
         default:
-        if (cdrom) {
-            switch (bus) {
-                case CDROM_BUS_MITSUMI:
-                    s = "mitsumi";
-                    break;
-                case CDROM_BUS_MKE:
-                    s = "mke";
-                    break;
-            }
-            break;
-        }
         case HDD_BUS_DISABLED:
             break;
 
         case HDD_BUS_MFM:
-            s = "mfm";
+            if (!cdrom)
+                s = "mfm";
             break;
 
         case HDD_BUS_XTA:
@@ -116,7 +95,8 @@ hdd_bus_to_string(int bus, UNUSED(int cdrom))
             break;
 
         case HDD_BUS_ESDI:
-            s = "esdi";
+            if (!cdrom)
+                s = "esdi";
             break;
 
         case HDD_BUS_IDE:
@@ -129,6 +109,16 @@ hdd_bus_to_string(int bus, UNUSED(int cdrom))
 
         case HDD_BUS_SCSI:
             s = "scsi";
+            break;
+
+        case CDROM_BUS_MITSUMI:
+            if (cdrom)
+                s = "mitsumi";
+            break;
+
+        case CDROM_BUS_MKE:
+            if (cdrom)
+                s = "mke";
             break;
     }
 

--- a/src/include/86box/plat.h
+++ b/src/include/86box/plat.h
@@ -31,8 +31,6 @@ enum {
     STRING_MOUSE_CAPTURE,             /* "Click to capture mouse" */
     STRING_MOUSE_RELEASE,             /* "Press %1 to release mouse" */
     STRING_MOUSE_RELEASE_MMB,         /* "Press %1 or middle button to release mouse" */
-    STRING_INVALID_CONFIG,            /* "Invalid configuration" */
-    STRING_NO_ST506_ESDI_CDROM,       /* "MFM/RLL or ESDI CD-ROM drives never existed" */
     STRING_NET_ERROR,                 /* "Failed to initialize network driver" */
     STRING_NET_ERROR_DESC,            /* "The network configuration will be switched..." */
     STRING_PCAP_ERROR_NO_DEVICES,     /* "No PCap devices found" */

--- a/src/include/86box/plat.h
+++ b/src/include/86box/plat.h
@@ -43,7 +43,6 @@ enum {
     STRING_HW_NOT_AVAILABLE_VIDEO,    /* "Video card \"%s\" is not available..." */
     STRING_HW_NOT_AVAILABLE_VIDEO2,   /* "Video card #2 \"%s\" is not available..." */
     STRING_HW_NOT_AVAILABLE_DEVICE,   /* "Device \"%s\" is not available..." */
-    STRING_MONITOR_SLEEP,             /* "Monitor in sleep mode" */
     STRING_GHOSTPCL_ERROR_TITLE,      /* "Unable to initialize GhostPCL" */
     STRING_GHOSTPCL_ERROR_DESC,       /* "gpcl6dll32.dll/gpcl6dll64.dll/libgpcl6 is required..." */
     STRING_ESCP_ERROR_TITLE,          /* "Unable to find Dot-Matrix fonts" */

--- a/src/include/86box/vid_svga.h
+++ b/src/include/86box/vid_svga.h
@@ -268,7 +268,6 @@ typedef struct svga_t {
     uint8_t dac_mask;
     uint8_t dac_status;
     uint8_t dpms;
-    uint8_t dpms_ui;
     uint8_t color_2bpp;
     uint8_t ksc5601_sbyte_mask;
     uint8_t ksc5601_udc_area_msb[2];

--- a/src/include/86box/video.h
+++ b/src/include/86box/video.h
@@ -156,6 +156,7 @@ typedef struct monitor_t {
     int                      mon_vid_type;
     atomic_bool              mon_interlace;
     atomic_bool              mon_composite;
+    atomic_bool              mon_dpms;
     struct blit_data_struct *mon_blit_data_ptr;
 } monitor_t;
 

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -219,11 +219,17 @@ MainWindow::MainWindow(QWidget *parent)
     frameRateTimer->setInterval(1000);
     frameRateTimer->setSingleShot(false);
     connect(frameRateTimer, &QTimer::timeout, [hertz_label] {
-        auto hz = monitors[0].mon_actualrenderedframes.load();
+        if (monitors[0].mon_dpms) {
+            hertz_label->setText(tr("Monitor in sleep mode"));
+            hertz_label->setToolTip(tr("Monitor in sleep mode"));
+        } else {
+            auto hz = monitors[0].mon_actualrenderedframes.load();
 #ifdef SCREENSHOT_MODE
-        hz = ((hz + 2) / 5) * 5;
+            hz = ((hz + 2) / 5) * 5;
 #endif
-        hertz_label->setText(tr("%1 Hz").arg(QString::number(hz) + (monitors[0].mon_interlace ? "i" : "")));
+            hertz_label->setText(tr("%1 Hz").arg(QString::number(hz) + (monitors[0].mon_interlace ? "i" : "")));
+            hertz_label->setToolTip(tr("Refresh rate"));
+        }
     });
     statusBar()->addPermanentWidget(hertz_label);
     frameRateTimer->start(1000);

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -845,7 +845,6 @@ Preferences::reloadStrings()
     translatedstrings[STRING_HW_NOT_AVAILABLE_VIDEO2]   = QCoreApplication::translate("", "Video card #2 \"%s\" is not available due to missing ROMs in the roms/video directory. Disabling the second video card.").toUtf8();
     translatedstrings[STRING_HW_NOT_AVAILABLE_DEVICE]   = QCoreApplication::translate("", "Device \"%s\" is not available due to missing ROMs. Ignoring the device.").toUtf8();
     translatedstrings[STRING_HW_NOT_AVAILABLE_TITLE]    = QCoreApplication::translate("", "Hardware not available").toUtf8();
-    translatedstrings[STRING_MONITOR_SLEEP]             = QCoreApplication::translate("", "Monitor in sleep mode").toUtf8();
     translatedstrings[STRING_NET_ERROR]                 = QCoreApplication::translate("", "Failed to initialize network driver").toUtf8();
     translatedstrings[STRING_NET_ERROR_DESC]            = QCoreApplication::translate("", "The network configuration will be switched to the null driver").toUtf8();
     translatedstrings[STRING_ESCP_ERROR_TITLE]          = QCoreApplication::translate("", "Unable to find Dot-Matrix fonts").toUtf8();

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -833,8 +833,6 @@ Preferences::reloadStrings()
     translatedstrings[STRING_MOUSE_CAPTURE]             = QCoreApplication::translate("", "Click to capture mouse").toUtf8();
     translatedstrings[STRING_MOUSE_RELEASE]             = QCoreApplication::translate("", "Press %1 to release mouse").arg(QKeySequence(acc_keys[FindAccelerator("release_mouse")].seq, QKeySequence::PortableText).toString(QKeySequence::NativeText)).toUtf8();
     translatedstrings[STRING_MOUSE_RELEASE_MMB]         = QCoreApplication::translate("", "Press %1 or middle button to release mouse").arg(QKeySequence(acc_keys[FindAccelerator("release_mouse")].seq, QKeySequence::PortableText).toString(QKeySequence::NativeText)).toUtf8();
-    translatedstrings[STRING_INVALID_CONFIG]            = QCoreApplication::translate("", "Invalid configuration").toUtf8();
-    translatedstrings[STRING_NO_ST506_ESDI_CDROM]       = QCoreApplication::translate("", "MFM/RLL or ESDI CD-ROM drives never existed").toUtf8();
     translatedstrings[STRING_PCAP_ERROR_NO_DEVICES]     = QCoreApplication::translate("", "No PCap devices found").toUtf8();
     translatedstrings[STRING_PCAP_ERROR_INVALID_DEVICE] = QCoreApplication::translate("", "Invalid PCap device").toUtf8();
     translatedstrings[STRING_PCAP_ERROR_DESC]           = QCoreApplication::translate("", "Make sure %1 is installed and that you are on a %1-compatible network connection.").arg(LIB_NAME_PCAP).toUtf8();

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -126,7 +126,7 @@ RendererStack::RendererStack(QWidget *parent, int monitor_index)
         frameRateTimer->setSingleShot(false);
         frameRateTimer->setInterval(1000);
         connect(frameRateTimer, &QTimer::timeout, [this] {
-            this->setWindowTitle(QObject::tr("86Box Monitor #%1").arg(m_monitor_index + 1) + QString(" - ") + tr("%1 Hz").arg(QString::number(monitors[m_monitor_index].mon_actualrenderedframes.load()) + (monitors[m_monitor_index].mon_interlace ? "i" : "")));
+            this->setWindowTitle(QObject::tr("86Box Monitor #%1").arg(m_monitor_index + 1) + QString(" - ") + (monitors[m_monitor_index].mon_dpms ? tr("Monitor in sleep mode") : tr("%1 Hz").arg(QString::number(monitors[m_monitor_index].mon_actualrenderedframes.load()) + (monitors[m_monitor_index].mon_interlace ? "i" : ""))));
         });
         frameRateTimer->start(1000);
     }

--- a/src/qt/qt_settingsdisplay.cpp
+++ b/src/qt/qt_settingsdisplay.cpp
@@ -14,6 +14,7 @@
  */
 #include <QDebug>
 #include <QFileDialog>
+#include <QMessageBox>
 #include <QStringBuilder>
 #include <QLineEdit>
 
@@ -60,6 +61,14 @@ SettingsDisplay::SettingsDisplay(QWidget *parent)
         videoCard[i] = gfxcard[i];
 
     ui->lineEditCustomEDID->setFilter(tr("EDID") % util::DlgFilter({ "bin", "dat", "edid", "txt" }) % tr("All files") % util::DlgFilter({ "*" }, true));
+    connect(ui->lineEditCustomEDID, &FileField::fileSelected, [this](const QString &fileName) {
+        QFileInfo edidFile(fileName);
+        if (edidFile.isFile() && edidFile.size() > 256) {
+            QMessageBox::critical(this, "EDID", tr("EDID file \"%s\" is too large.").replace("%s", "%1").arg(fileName));
+            this->ui->lineEditCustomEDID->setFileName(this->previousEDIDPath);
+        } else
+            this->previousEDIDPath = fileName;
+    });
 
     ui->comboBoxScreenType->addItem(tr("RGB Color"), 0);
     ui->comboBoxScreenType->addItem(tr("RGB Grayscale"), 1);
@@ -222,6 +231,7 @@ SettingsDisplay::onCurrentMachineChanged(int machineId)
     ui->radioButtonCustom->setChecked(monitor_edid == 1);
     ui->lineEditCustomEDID->setFileName(monitor_edid_path);
     ui->lineEditCustomEDID->setEnabled(monitor_edid == 1);
+    previousEDIDPath = ui->lineEditCustomEDID->fileName();
 }
 
 void

--- a/src/qt/qt_settingsdisplay.hpp
+++ b/src/qt/qt_settingsdisplay.hpp
@@ -62,6 +62,8 @@ private:
     int                  machineId                = 0;
     int                  videoCard[VIDEOCARD_MAX] = { 0, 0 };
 
+    QString previousEDIDPath;
+
     void updateDisplay();
 
     int cga_hue, cga_saturation, cga_sharpness, cga_brightness, cga_contrast;

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -306,8 +306,6 @@ plat_get_string(int i)
             return "Video card \"%s\" is not available due to missing ROMs in the roms/video directory. Switching to an available video card.";
         case STRING_HW_NOT_AVAILABLE_TITLE:
             return "Hardware not available";
-        case STRING_MONITOR_SLEEP:
-            return "Monitor in sleep mode";
         case STRING_EDID_TOO_LARGE:
             return "EDID file \"%s\" is too large.";
     }

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -286,10 +286,6 @@ plat_get_string(int i)
             return "Press CTRL-END to release mouse";
         case STRING_MOUSE_RELEASE_MMB:
             return "Press CTRL-END or middle button to release mouse";
-        case STRING_INVALID_CONFIG:
-            return "Invalid configuration";
-        case STRING_NO_ST506_ESDI_CDROM:
-            return "MFM/RLL or ESDI CD-ROM drives never existed";
         case STRING_PCAP_ERROR_NO_DEVICES:
             return "No PCap devices found";
         case STRING_PCAP_ERROR_INVALID_DEVICE:

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -1215,7 +1215,7 @@ svga_recalctimings(svga_t *svga)
 
     /* Inform the user interface of any DPMS mode changes. */
     if (svga->dpms) {
-        if (!svga->dpms_ui) {
+        if (!svga->monitor->mon_dpms) {
             /* Make sure to black out the entire screen to avoid lingering image. */
             int y_add   = enable_overscan ? svga->monitor->mon_overscan_y : 0;
             int x_add   = enable_overscan ? svga->monitor->mon_overscan_x : 0;
@@ -1225,13 +1225,10 @@ svga_recalctimings(svga_t *svga)
             memset(svga->monitor->target_buffer->dat, 0, (size_t) svga->monitor->target_buffer->w * svga->monitor->target_buffer->h * 4);
             video_blit_memtoscreen_monitor(x_start, y_start, svga->monitor->mon_xsize + x_add, svga->monitor->mon_ysize + y_add, svga->monitor_index);
             video_wait_for_buffer_monitor(svga->monitor_index);
-            svga->dpms_ui = 1;
-            ui_sb_set_text(plat_get_string(STRING_MONITOR_SLEEP));
+            svga->monitor->mon_dpms = 1;
         }
-    } else if (svga->dpms_ui) {
-        svga->dpms_ui = 0;
-        ui_sb_set_text(NULL);
-    }
+    } else if (svga->monitor->mon_dpms)
+        svga->monitor->mon_dpms = 0;
 
     if (enable_overscan && (svga->monitor->mon_overscan_x != old_monitor_overscan_x || svga->monitor->mon_overscan_y != old_monitor_overscan_y))
         video_force_resize_set_monitor(1, svga->monitor_index);
@@ -1779,8 +1776,8 @@ svga_close(svga_t *svga)
     free(svga->changedvram);
     free(svga->vram);
 
-    if (svga->dpms_ui)
-        ui_sb_set_text(NULL);
+    if ((svga->monitor != NULL) && (svga->monitor->mon_dpms))
+        svga->monitor->mon_dpms = 0;
 
     svga_pri = NULL;
 }

--- a/src/video/video.c
+++ b/src/video/video.c
@@ -812,6 +812,7 @@ video_monitor_init(int index)
     monitors[index].mon_cga_palette                      = calloc(1, sizeof(int));
     monitors[index].mon_force_resize                     = 1;
     monitors[index].mon_vid_type                         = VIDEO_FLAG_TYPE_NONE;
+    monitors[index].mon_dpms                             = 0;
     atomic_init(&doresize_monitors[index], 0);
     atomic_init(&monitors[index].mon_screenshots, 0);
     atomic_init(&monitors[index].mon_screenshots_clipboard, 0);


### PR DESCRIPTION
Summary
=======
* Remove the "MFM/RLL or ESDI CD-ROM drives never existed" error message; invalid combinations of bus and storage device type now silently set the bus to "Disabled"; this behavior is extended to HDDs on MKE/Mitsumi controller buses
* Make the "Monitor in sleep mode" message replace the refresh rate counter instead of the current status bar message; this also extends to the second monitor in SVGA multi-monitor configurations
* Too big EDIDs are now rejected early, in the settings dialog


Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set

References
==========
N/A