### PR TITLE
Add aliases for PC-900 and SL386SX-16

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -3778,7 +3778,7 @@ const machine_t machines[] = {
         .vid_device               = NULL,
         .snd_device               = NULL,
         .net_device               = NULL,
-        .aliases                  = { "Commodore PC 40", "NBI 4200", "" }
+        .aliases                  = { "Commodore PC 40", "Commodore PC-900-II", "NBI 4200", "" }
     },
     /* Has IBM AT KBC firmware. */
     {
@@ -6242,7 +6242,7 @@ const machine_t machines[] = {
         .vid_device               = NULL,
         .snd_device               = NULL,
         .net_device               = NULL,
-        .aliases                  = { "" }
+        .aliases                  = { "DTK PPM-1660C", "DTK PPM-2060C", "" }
     },
     /* Has IBM AT KBC firmware. */
     {


### PR DESCRIPTION
Summary
=======
This PR title says at all.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
Found on The Retro Web entries on [DTK
 PPM-1660C](https://theretroweb.com/motherboards/s/dtk-ppm-1660c) and [Multitech 900](https://theretroweb.com/motherboards/s/multi-tech-syste-900)
