### PR TITLE
qt: Avoid duplicate mouse capture requests

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -388,7 +388,12 @@ MainWindow::MainWindow(QWidget *parent)
     emit updateMenuResizeOptions();
 
     connect(this, &MainWindow::setMouseCapture, this, [this](bool state) {
+        const int old_mouse_capture = mouse_capture;
         mouse_capture = state ? 1 : 0;
+
+        if (mouse_capture == old_mouse_capture)
+            return;
+
         qt_mouse_capture(mouse_capture);
         if (mouse_capture) {
             if (hook_enabled)


### PR DESCRIPTION
Summary
=======
Repeated fullscreen toggles on Qt6/Wayland can re-enter mouse capture while the pointer is already locked, which ends in the Wayland protocol error about the surface already being constrained.

**This crashes 86Box so badly on my machine that 86Box.cfg is overwritten with defaults for some reason.**

It started after 7ea6e9ce69 began capturing the mouse on every fullscreen entry.
The Qt handler behind `setMouseCapture` was not idempotent, so duplicate requests still ran the backend capture path.

Fix it by treating mouse capture as a real state transition and ignoring requests that do not change the stored capture state.

Checklist
=========
* [x] Closes N/A
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [x] This pull request doesn't require changes to the ROM set
* [x] This pull request doesn't require changes to the asset set