### PR TITLE
YMF71x bugfixes

### DIFF
--- a/src/sound/snd_ymf71x.c
+++ b/src/sound/snd_ymf71x.c
@@ -162,6 +162,13 @@ ymf71x_config_write(uint16_t addr, uint8_t val, void *priv)
             ymf71x->ramwrite_enable = 0;
             isapnp_update_card_rom(ymf71x->pnp_card, &ymf71x->ram_data[0], 512);
         }
+        if ((ymf71x->configidx == 0x21) && (val & 0x02)) {
+            ymf71x_log(ymf71x->log, "Disable PnP key\n");
+            isapnp_enable_card(ymf71x->pnp_card, ISAPNP_CARD_NO_KEY);
+        } else if ((ymf71x->configidx == 0x21) && ((val & 0x02) == 0x00)) {
+            ymf71x_log(ymf71x->log, "Enable PnP key\n");
+            isapnp_enable_card(ymf71x->pnp_card, ISAPNP_CARD_ENABLE);
+        }
         if ((ymf71x->configidx == 0x20) && (ymf71x->ramwrite_enable == 0x01)) {
             ymf71x_log(ymf71x->log, "Write to internal RAM addr %04X, val %02X\n", ymf71x->ram_addr, val);
             ymf71x->ram_data[ymf71x->ram_addr++] = val;

--- a/src/sound/snd_ymf71x.c
+++ b/src/sound/snd_ymf71x.c
@@ -153,10 +153,13 @@ ymf71x_config_write(uint16_t addr, uint8_t val, void *priv)
     if (addr == 0xA79) {
         if ((ymf71x->configidx == 0x21) && (val & 0x01)) {
             ymf71x_log(ymf71x->log, "Enable internal RAM write\n");
+            if (ymf71x->ramwrite_enable == 0)
+                ymf71x->ram_addr = 0;
             ymf71x->ramwrite_enable = 1;
         }
-        if ((ymf71x->configidx == 0x21) && (val == 0x00)) {
+        if ((ymf71x->configidx == 0x21) && ((val & 0x01) == 0x00) && ymf71x->ramwrite_enable) {
             ymf71x_log(ymf71x->log, "Disable internal RAM write\n");
+            ymf71x->ramwrite_enable = 0;
             isapnp_update_card_rom(ymf71x->pnp_card, &ymf71x->ram_data[0], 512);
         }
         if ((ymf71x->configidx == 0x20) && (ymf71x->ramwrite_enable == 0x01)) {


### PR DESCRIPTION
Summary
=======
Fix some incorrect internal RAM write enable/disable behavior (and a related segfault) as well as implement the IKD bit to disable the PnP initialization key on the YMF-71x chips.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
