### PR TITLE
ESC/P 2: Use correct unit for underline

### DIFF
--- a/src/printer/prt_escp.c
+++ b/src/printer/prt_escp.c
@@ -2000,9 +2000,9 @@ handle_char(escp_t *dev, uint8_t ch)
         line_y = PIXY;
 
         if (dev->font_style & STYLE_UNDERLINE)
-            line_y = (PIXY + (uint16_t) (dev->fontface->size->metrics.height * 0.9));
+            line_y = (PIXY + (uint16_t) (dev->fontface->size->metrics.y_ppem * 0.9));
         if (dev->font_style & STYLE_STRIKETHROUGH)
-            line_y = (PIXY + (uint16_t) (dev->fontface->size->metrics.height * 0.45));
+            line_y = (PIXY + (uint16_t) (dev->fontface->size->metrics.y_ppem * 0.45));
         if (dev->font_style & STYLE_OVERSCORE)
             line_y = PIXY - ((dev->font_score == SCORE_DOUBLE || dev->font_score == SCORE_DOUBLEBROKEN) ? 5 : 0);
 


### PR DESCRIPTION
Summary
=======
The field used before was in multiples of 26.6 pixels (wherever this comes from in FreeType), the one I changed to is in pixels.

Checklist
=========
* [X] Closes #7172
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
