### PR TITLE
Update debian/rules with current icon sizes

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -26,7 +26,7 @@ override_dh_auto_test:
 
 override_dh_auto_install:
 	dh_auto_install --buildsystem cmake+ninja
-	for i in 48x48 64x64 72x72 96x96 128x128 192x192 256x256 512x512 ; do \
+	for i in 16x16 20x20 24x24 32x32 40x40 48x48 64x64 72x72 128x128 256x256; do \
 		install -Dm644 src/unix/assets/$$i/net.86box.86Box.png -t debian/86box/usr/share/icons/hicolor/$$i/apps ; \
 	done
 	mkdir debian/86box/usr/share/applications


### PR DESCRIPTION
Summary
=======
Update debian/rules with the current icon sizes.

Checklist
=========
* [ :x: ] Closes #xxx
* [ :white_check_mark: ] I have tested my changes locally and validated that the functionality works as intended
* [ :x: ] I have discussed this with core contributors already
* [ :x: ] This pull request requires changes to the ROM set
  * [ :x: ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ :x: ] This pull request requires changes to the asset set
  * [ :x: ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========

Running `dpkg-buildpackage -uc -b`, prior to this change, fails at the end:

````
[0/1] Install the project...
-- Install configuration: "None"
-- Installing: /workspace/nroach44/auto-packages/86Box/debian/86box/usr/bin/86Box
for i in 48x48 64x64 72x72 96x96 128x128 192x192 256x256 512x512 ; do \
	install -Dm644 src/unix/assets/$i/net.86box.86Box.png -t debian/86box/usr/share/icons/hicolor/$i/apps ; \
done
install: cannot stat 'src/unix/assets/96x96/net.86box.86Box.png': No such file or directory
install: cannot stat 'src/unix/assets/192x192/net.86box.86Box.png': No such file or directory
install: cannot stat 'src/unix/assets/512x512/net.86box.86Box.png': No such file or directory
make[1]: Leaving directory '/workspace/nroach44/auto-packages/86Box'
make[1]: *** [debian/rules:29: override_dh_auto_install] Error 1
make: *** [debian/rules:17: binary] Error 2
dpkg-buildpackage: error: debian/rules binary subprocess returned exit status 2
````

This is because the folder only contains these resolutions: ` 16x16 20x20 24x24 32x32 40x40 48x48 64x64 72x72 128x128 256x256`

That's missing 96, 192, 512, so the build fails.