### PR TITLE
Refactor percentage update code

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -353,8 +353,6 @@ int efscrnsz_y = SCREEN_RES_Y;
 
 __thread int is_cpu_thread = 0;
 
-static char mouse_msg[3][200];
-
 static ATOMIC_INT do_pause_ack = 0;
 static ATOMIC_INT pause_ack = 0;
 
@@ -1871,44 +1869,10 @@ pc_reset_hard_init(void)
     cycles_main = 0;
 #endif
 
-    update_mouse_msg();
-
     if (test_mode)
         pc_test_mode_entry_point();
 
     ui_hard_reset_completed();
-}
-
-void
-update_mouse_msg(void)
-{
-#ifdef USE_SDL_UI
-    char  cpufamily[128];
-    char *cp;
-
-    if (!cpu_override)
-        strncpy(cpufamily, cpu_f->name, sizeof(cpufamily) - 1);
-    else
-        snprintf(cpufamily, sizeof(cpufamily), "[U] %s", cpu_f->name);
-
-    cp = strchr(cpufamily, '(');
-    if (cp) /* remove parentheses */
-        *(cp - 1) = '\0';
-    snprintf(mouse_msg[0], sizeof(mouse_msg[0]), "%s v%s - %%i%%%% - %s - %s/%s - %s",
-             EMU_NAME, EMU_VERSION_FULL, machine_getname(machine), cpufamily, cpu_s->name,
-             plat_get_string(STRING_MOUSE_CAPTURE));
-    snprintf(mouse_msg[1], sizeof(mouse_msg[1]), "%s v%s - %%i%%%% - %s - %s/%s - %s",
-             EMU_NAME, EMU_VERSION_FULL, machine_getname(machine), cpufamily, cpu_s->name,
-             (mouse_get_buttons() > 2) ? plat_get_string(STRING_MOUSE_RELEASE) : plat_get_string(STRING_MOUSE_RELEASE_MMB));
-    snprintf(mouse_msg[2], sizeof(mouse_msg[2]), "%s v%s - %%i%%%% - %s - %s/%s",
-             EMU_NAME, EMU_VERSION_FULL, machine_getname(machine), cpufamily, cpu_s->name);
-#else
-    snprintf(mouse_msg[0], sizeof(mouse_msg[0]), "%%i%%%% - %s",
-             plat_get_string(STRING_MOUSE_CAPTURE));
-    snprintf(mouse_msg[1], sizeof(mouse_msg[1]), "%%i%%%% - %s",
-             (mouse_get_buttons() > 2) ? plat_get_string(STRING_MOUSE_RELEASE) : plat_get_string(STRING_MOUSE_RELEASE_MMB));
-    strncpy(mouse_msg[2], "%i%%", sizeof(mouse_msg[2]));
-#endif
 }
 
 void
@@ -1980,10 +1944,9 @@ pc_close(UNUSED(thread_t *ptr))
 
 #ifdef __APPLE__
 static void
-_ui_window_title(void *s)
+_ui_emu_status(void *s)
 {
-    ui_window_title((char *) s);
-    free(s);
+    ui_emu_status(*((int *) s));
 }
 #endif
 
@@ -1999,9 +1962,6 @@ ack_pause(void)
 void
 pc_run(void)
 {
-    int  mouse_msg_idx;
-    char temp[200];
-
     /* Trigger a hard reset if one is pending. */
     if (hard_reset_pending) {
         hard_reset_pending = 0;
@@ -2040,7 +2000,6 @@ pc_run(void)
         uint32_t elapsed_ms;
         int64_t  numerator;
 
-        mouse_msg_idx = ((mouse_type == MOUSE_TYPE_NONE) || (mouse_input_mode >= 1)) ? 2 : !!mouse_capture;
         target_fps    = force_10ms ? 100 : 1000;
         elapsed_ms    = fps_sample_elapsed_ms ? fps_sample_elapsed_ms : 1;
 
@@ -2058,12 +2017,11 @@ pc_run(void)
         speed_percent = (int) ((numerator + ((int64_t) elapsed_ms * target_fps / 2)) /
                                ((int64_t) elapsed_ms * target_fps));
 
-        snprintf(temp, sizeof(temp), mouse_msg[mouse_msg_idx], speed_percent);
 #ifdef __APPLE__
         /* Needed due to modifying the UI on the non-main thread is a big no-no. */
-        dispatch_async_f(dispatch_get_main_queue(), strdup((const char *) temp), _ui_window_title);
+        dispatch_async_f(dispatch_get_main_queue(), &speed_percent, _ui_emu_status);
 #else
-        ui_window_title(temp);
+        ui_emu_status(speed_percent);
 #endif
         title_update = 0;
     }

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -287,7 +287,6 @@ extern void set_screen_size_monitor(int x, int y, int monitor_index);
 extern void reset_screen_size(void);
 extern void reset_screen_size_monitor(int monitor_index);
 extern void set_screen_size_natural(void);
-extern void update_mouse_msg(void);
 extern int  pc_init_roms(void);
 extern int  pc_init_modules(void);
 extern int  pc_init(int argc, char *argv[]);

--- a/src/include/86box/plat.h
+++ b/src/include/86box/plat.h
@@ -28,9 +28,6 @@
 
 /* String ID numbers. */
 enum {
-    STRING_MOUSE_CAPTURE,             /* "Click to capture mouse" */
-    STRING_MOUSE_RELEASE,             /* "Press %1 to release mouse" */
-    STRING_MOUSE_RELEASE_MMB,         /* "Press %1 or middle button to release mouse" */
     STRING_NET_ERROR,                 /* "Failed to initialize network driver..." */
     STRING_PCAP_ERROR_NO_DEVICES,     /* "No PCap devices found..." */
     STRING_PCAP_ERROR_INVALID_DEVICE, /* "Invalid PCap device..." */

--- a/src/include/86box/ui.h
+++ b/src/include/86box/ui.h
@@ -48,7 +48,7 @@ extern int ui_msgbox_header(int flags, char *header, char *message);
 #define SB_SOUND      0x90
 #define SB_TEXT       0xA0
 
-extern char *ui_window_title(char *s);
+extern void  ui_emu_status(int speed_percent);
 extern void  ui_hard_reset_completed(void);
 extern void  ui_init_monitor(int monitor_index);
 extern void  ui_deinit_monitor(int monitor_index);

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -906,6 +906,7 @@ main(int argc, char *argv[])
         NewDarkMode = util::isWindowsLightTheme();
 #endif
         pc_reset_hard_init();
+        main_window->updateMouseStrings();
 
         /* Set the PAUSE mode depending on the renderer. */
 #ifdef USE_VNC

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -339,6 +339,7 @@ MainWindow::MainWindow(QWidget *parent)
     connect(this, &MainWindow::hardResetCompleted, this, [this]() {
         ui->actionMCA_devices->setVisible(machine_has_bus(machine, MACHINE_BUS_MCA));
         ui_update_force_interpreter();
+        updateMouseStrings();
         num_label->setVisible(machine_has_bus(machine, MACHINE_BUS_PS2_PORTS | MACHINE_BUS_AT_KBD));
         scroll_label->setVisible(machine_has_bus(machine, MACHINE_BUS_PS2_PORTS | MACHINE_BUS_AT_KBD));
         caps_label->setVisible(machine_has_bus(machine, MACHINE_BUS_PS2_PORTS | MACHINE_BUS_AT_KBD));
@@ -1047,6 +1048,13 @@ MainWindow::updateShortcuts()
     accID = FindAccelerator("force_interpretation");
     seq   = QKeySequence::fromString(acc_keys[accID].seq);
     ui->actionForce_interpretation->setShortcut(seq);
+}
+
+void
+MainWindow::updateMouseStrings()
+{
+    mouseStringCaptured = tr(mouse_get_buttons() > 2 ? "Press %1 to release mouse" : "Press %1 or middle button to release mouse").arg(QKeySequence(acc_keys[FindAccelerator("release_mouse")].seq, QKeySequence::PortableText).toString(QKeySequence::NativeText));
+    mouseStringUncaptured = tr("Click to capture mouse");
 }
 
 void

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -42,6 +42,10 @@ public:
     QShortcut   *windowedShortcut;
     QKeySequence FindAcceleratorSeq(const char *name);
 
+    QString mouseStringUncaptured;
+    QString mouseStringCaptured;
+    void    updateMouseStrings();
+
     std::array<std::unique_ptr<RendererStack>, 8> renderers;
 signals:
     void paint(const QImage &image);

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -835,9 +835,6 @@ void
 Preferences::reloadStrings()
 {
     translatedstrings.clear();
-    translatedstrings[STRING_MOUSE_CAPTURE]             = QCoreApplication::translate("", "Click to capture mouse").toUtf8();
-    translatedstrings[STRING_MOUSE_RELEASE]             = QCoreApplication::translate("", "Press %1 to release mouse").arg(QKeySequence(acc_keys[FindAccelerator("release_mouse")].seq, QKeySequence::PortableText).toString(QKeySequence::NativeText)).toUtf8();
-    translatedstrings[STRING_MOUSE_RELEASE_MMB]         = QCoreApplication::translate("", "Press %1 or middle button to release mouse").arg(QKeySequence(acc_keys[FindAccelerator("release_mouse")].seq, QKeySequence::PortableText).toString(QKeySequence::NativeText)).toUtf8();
     translatedstrings[STRING_PCAP_ERROR_NO_DEVICES]     = QCoreApplication::translate("", "No PCap devices found. Make sure %1 is installed and that you are on a %1-compatible network connection.").arg(LIB_NAME_PCAP).toUtf8();
     translatedstrings[STRING_PCAP_ERROR_INVALID_DEVICE] = QCoreApplication::translate("", "Invalid PCap device. Make sure %1 is installed and that you are on a %1-compatible network connection.").arg(LIB_NAME_PCAP).toUtf8();
     translatedstrings[STRING_GHOSTSCRIPT_ERROR]         = QCoreApplication::translate("", "Unable to initialize Ghostscript. %1 is required for automatic conversion of PostScript files to PDF.\n\nAny documents sent to the generic PostScript printer will be saved as PostScript (.ps) files.").arg(LIB_NAME_GS).toUtf8();

--- a/src/qt/qt_preferences.cpp
+++ b/src/qt/qt_preferences.cpp
@@ -198,6 +198,8 @@ Preferences::save()
     emulator->save();
     input->save();
     key_bindings->save();
+
+    main_window->updateMouseStrings();
 }
 
 void

--- a/src/qt/qt_preferencesemulator.cpp
+++ b/src/qt/qt_preferencesemulator.cpp
@@ -103,7 +103,6 @@ PreferencesEmulator::save()
 
     Preferences::loadTranslators(QCoreApplication::instance());
     Preferences::reloadStrings();
-    update_mouse_msg();
     main_window->ui->retranslateUi(main_window);
     QString vmname(vm_name);
     if (vmname.at(vmname.size() - 1) == '"' || vmname.at(vmname.size() - 1) == '\'')

--- a/src/qt/qt_ui.cpp
+++ b/src/qt/qt_ui.cpp
@@ -22,6 +22,7 @@
 
 #include <QStatusBar>
 #include <QApplication>
+#include <QStringBuilder>
 
 #include "qt_mainwindow.hpp"
 #include "qt_machinestatus.hpp"
@@ -70,16 +71,18 @@ plat_delay_ms(uint32_t count)
 #endif
 }
 
-char *
-ui_window_title(char *str)
+void
+ui_emu_status(int speed_percent)
 {
-    if (str == nullptr) {
-        QString title = main_window->getTitle();
-        str = title.toUtf8().data();
-    } else
-        emit main_window->setTitle(QString::fromUtf8(str));
+    QString str;
+    if ((mouse_type == MOUSE_TYPE_NONE) || (mouse_input_mode >= 1))
+        str = QString::number(speed_percent) % QStringLiteral("%");
+    else if (mouse_capture == 1)
+        str = QString::number(speed_percent) % QStringLiteral("% - ") % main_window->mouseStringCaptured;
+    else
+        str = QString::number(speed_percent) % QStringLiteral("% - ") % main_window->mouseStringUncaptured;
 
-    return str;
+    emit main_window->setTitle(str);
 }
 
 void

--- a/src/unix/sdl_main.c
+++ b/src/unix/sdl_main.c
@@ -570,7 +570,6 @@ check_flags:
             sdl_blit(params.x, params.y, params.w, params.h);
         }
         if (title_set) {
-            extern void ui_window_title_real(void);
             ui_window_title_real();
         }
         if (video_fullscreen && keyboard_isfsexit()) {

--- a/src/unix/sdl_plat.c
+++ b/src/unix/sdl_plat.c
@@ -21,6 +21,8 @@
 #include <86box/version.h>
 #include "cpu.h"
 
+#include "sdl_render.h"
+
 /*
  * File system manipulation
  */
@@ -91,12 +93,6 @@ char *
 plat_get_string(int i)
 {
     switch (i) {
-        case STRING_MOUSE_CAPTURE:
-            return "Click to capture mouse";
-        case STRING_MOUSE_RELEASE:
-            return "Press CTRL-END to release mouse";
-        case STRING_MOUSE_RELEASE_MMB:
-            return "Press CTRL-END or middle button to release mouse";
         case STRING_PCAP_ERROR_NO_DEVICES:
             return "No PCap devices found. Make sure libpcap is installed and that you are on a libpcap-compatible network connection.";
         case STRING_PCAP_ERROR_INVALID_DEVICE:

--- a/src/unix/sdl_render.c
+++ b/src/unix/sdl_render.c
@@ -14,6 +14,7 @@
 #include <86box/plat.h>
 #include <86box/plat_dynld.h>
 #include <86box/video.h>
+#include <86box/mouse.h>
 #include <86box/ui.h>
 #include <86box/version.h>
 #include <86box/ini.h>
@@ -22,6 +23,7 @@
 #include "sdl_render.h"
 #include "sdl_osd.h"
 #include "sdl_shader.h"
+#include "cpu.h"
 
 #define RENDERER_FULL_SCREEN 1
 #define RENDERER_HARDWARE    2
@@ -59,6 +61,8 @@ int                 resize_pending    = 0;
 int                 resize_w          = 0;
 int                 resize_h          = 0;
 static void        *pixeldata         = NULL;
+static char         mouse_msg[3][300];
+
 
 void sdl_reinit_texture(void);
 
@@ -595,6 +599,30 @@ plat_resize(int w, int h, UNUSED(int monitor_index))
     SDL_UnlockMutex(sdl_mutex);
 }
 
+void
+update_mouse_msg(void)
+{
+    char  cpufamily[128];
+    char *cp;
+
+    if (!cpu_override)
+        strncpy(cpufamily, cpu_f->name, sizeof(cpufamily) - 1);
+    else
+        snprintf(cpufamily, sizeof(cpufamily), "[U] %s", cpu_f->name);
+
+    cp = strchr(cpufamily, '(');
+    if (cp) /* remove parentheses */
+        *(cp - 1) = '\0';
+    snprintf(mouse_msg[0], sizeof(mouse_msg[0]), "%s v%s - %%i%%%% - %s - %s/%s - %s",
+             EMU_NAME, EMU_VERSION_FULL, machine_getname(machine), cpufamily, cpu_s->name,
+             "Click to capture mouse");
+    snprintf(mouse_msg[1], sizeof(mouse_msg[1]), "%s v%s - %%i%%%% - %s - %s/%s - %s",
+             EMU_NAME, EMU_VERSION_FULL, machine_getname(machine), cpufamily, cpu_s->name,
+             (mouse_get_buttons() > 2) ? "Press CTRL-END to release mouse" : "Press CTRL-END or middle button to release mouse");
+    snprintf(mouse_msg[2], sizeof(mouse_msg[2]), "%s v%s - %%i%%%% - %s - %s/%s",
+             EMU_NAME, EMU_VERSION_FULL, machine_getname(machine), cpufamily, cpu_s->name);
+}
+
 char    sdl_win_title[512] = EMU_NAME;
 SDL_mutex *titlemtx           = NULL;
 
@@ -628,6 +656,15 @@ ui_window_title(char *str)
     title_set = 1;
 #endif
     return str;
+}
+
+void
+ui_emu_status(int speed_percent)
+{
+    int mouse_msg_idx = ((mouse_type == MOUSE_TYPE_NONE) || (mouse_input_mode >= 1)) ? 2 : !!mouse_capture;
+    char temp[200];
+    snprintf(temp, sizeof(temp), mouse_msg[mouse_msg_idx], speed_percent);
+    ui_window_title(temp);
 }
 
 void

--- a/src/unix/sdl_render.h
+++ b/src/unix/sdl_render.h
@@ -1,14 +1,16 @@
 #ifndef _UNIX_SDL_H
 #define _UNIX_SDL_H
 
-extern void sdl_close(void);
-extern int  sdl_inits(void);
-extern int  sdl_inith(void);
-extern int  sdl_initho(void);
-extern int  sdl_pause(void);
-extern void sdl_resize(int x, int y);
-extern void sdl_enable(int enable);
-extern void sdl_set_fs(int fs);
-extern void sdl_reload(void);
+extern void  sdl_close(void);
+extern int   sdl_inits(void);
+extern int   sdl_inith(void);
+extern int   sdl_initho(void);
+extern int   sdl_pause(void);
+extern void  sdl_resize(int x, int y);
+extern void  sdl_enable(int enable);
+extern void  sdl_set_fs(int fs);
+extern void  sdl_reload(void);
+extern char *ui_window_title(char *s);
+extern void  ui_window_title_real(void);
 
 #endif /*_UNIX_SDL_H*/

--- a/src/unix/sdl_ui.c
+++ b/src/unix/sdl_ui.c
@@ -115,10 +115,11 @@ ui_sb_mt32lcd(UNUSED(char *str))
     /* No-op. */
 }
 
+extern void update_mouse_msg(void);
 void
 ui_hard_reset_completed(void)
 {
-    /* No-op. */
+    update_mouse_msg();
 }
 
 void


### PR DESCRIPTION
Summary
=======
Replace `ui_window_title()` (which has been a partial misnomer ever since the speed percentage and the mouse capture message were moved to the toolbar) with `ui_emu_status()` that sends just the speed percentage to the frontend, with frontends handling the rest of the window title (SDL) or toolbar label (Qt) themselves.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set

References
==========
N/A