### PR TITLE
video: fix portable mask and offsetof expressions

### DIFF
--- a/src/include/86box/vid_voodoo_codegen_x86-64.h
+++ b/src/include/86box/vid_voodoo_codegen_x86-64.h
@@ -64,6 +64,12 @@ static int next_block_to_write[4] = { 0, 0 };
         block_pos += 8;                             \
     } while (0)
 
+#define VOODOO_OFFSETOF_ARRAY(type, field, index) \
+    (offsetof(type, field[0]) + ((index) * sizeof(((type *) 0)->field[0])))
+
+#define VOODOO_OFFSETOF_ARRAY_MEMBER(type, field, index, member) \
+    (offsetof(type, field[0].member) + ((index) * sizeof(((type *) 0)->field[0])))
+
 static __m128i xmm_01_w; // = 0x0001000100010001ull;
 static __m128i xmm_ff_w; // = 0x00ff00ff00ff00ffull;
 static __m128i xmm_ff_b; // = 0x00000000ffffffffull;
@@ -164,21 +170,21 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
         addbyte(0xd0);
         addbyte(0x03); /*ADD EAX, state->lod*/
         addbyte(0x87);
-        addlong(offsetof(voodoo_state_t, tmu[tmu].lod));
+        addlong(VOODOO_OFFSETOF_ARRAY_MEMBER(voodoo_state_t, tmu, tmu, lod));
         addbyte(0x3b); /*CMP EAX, state->lod_min*/
         addbyte(0x87);
-        addlong(offsetof(voodoo_state_t, lod_min[tmu]));
+        addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_min, tmu));
         addbyte(0x0f); /*CMOVL EAX, state->lod_min*/
         addbyte(0x4c);
         addbyte(0x87);
-        addlong(offsetof(voodoo_state_t, lod_min[tmu]));
+        addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_min, tmu));
         addbyte(0x3b); /*CMP EAX, state->lod_max*/
         addbyte(0x87);
-        addlong(offsetof(voodoo_state_t, lod_max[tmu]));
+        addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_max, tmu));
         addbyte(0x0f); /*CMOVNL EAX, state->lod_max*/
         addbyte(0x4d);
         addbyte(0x87);
-        addlong(offsetof(voodoo_state_t, lod_max[tmu]));
+        addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_max, tmu));
         addbyte(0xc1); /*SHR EAX, 8*/
         addbyte(0xe8);
         addbyte(8);
@@ -200,7 +206,7 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
         addbyte(28);
         addbyte(0x8b); /*MOV EBX, state->lod_min*/
         addbyte(0x9f);
-        addlong(offsetof(voodoo_state_t, lod_min[tmu]));
+        addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_min, tmu));
         addbyte(0x48); /*SHR RCX, 28*/
         addbyte(0xc1);
         addbyte(0xe9);
@@ -313,7 +319,7 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
             addbyte(0x8b);
             addbyte(0xac);
             addbyte(0xcf);
-            addlong(offsetof(voodoo_state_t, tex[tmu]));
+            addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, tex, tmu));
             addbyte(0x88); /*MOV CL, DL*/
             addbyte(0xd1);
             addbyte(0x89); /*MOV EDX, EBX*/
@@ -321,7 +327,7 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
             if (!state->clamp_s[tmu]) {
                 addbyte(0x23); /*AND EAX, params->tex_w_mask[ESI]*/
                 addbyte(0x86);
-                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu));
             }
             addbyte(0x83); /*ADD EDX, 1*/
             addbyte(0xc2);
@@ -333,11 +339,11 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
                 addbyte(0x12);
                 addbyte(0x3b); /*CMP EDX, params->tex_h_mask[ESI]*/
                 addbyte(0x96);
-                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
                 addbyte(0x0f); /*CMOVA EDX, params->tex_h_mask[ESI]*/
                 addbyte(0x47);
                 addbyte(0x96);
-                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
                 addbyte(0x85); /*TEST EBX,EBX*/
                 addbyte(0xdb);
                 addbyte(0x41); /*CMOVS EBX, R10(alookup[0](zero))*/
@@ -346,18 +352,18 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
                 addbyte(0x1a);
                 addbyte(0x3b); /*CMP EBX, params->tex_h_mask[ESI]*/
                 addbyte(0x9e);
-                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
                 addbyte(0x0f); /*CMOVA EBX, params->tex_h_mask[ESI]*/
                 addbyte(0x47);
                 addbyte(0x9e);
-                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
             } else {
                 addbyte(0x23); /*AND EDX, params->tex_h_mask[ESI]*/
                 addbyte(0x96);
-                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
                 addbyte(0x23); /*AND EBX, params->tex_h_mask[ESI]*/
                 addbyte(0x9e);
-                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
             }
             /*EAX = S, EBX = T0, EDX = T1*/
             addbyte(0xd3); /*SHL EBX, CL*/
@@ -377,7 +383,7 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
             if (state->clamp_s[tmu]) {
                 addbyte(0x8b); /*MOV EBP, params->tex_w_mask[ESI]*/
                 addbyte(0xae);
-                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu));
                 addbyte(0x85); /*TEST EAX, EAX*/
                 addbyte(0xc0);
                 addbyte(0x8b); /*MOV ebp_store2, RSI*/
@@ -399,7 +405,7 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
             } else {
                 addbyte(0x3b); /*CMP EAX, params->tex_w_mask[ESI] - is S at texture edge (ie will wrap/clamp)?*/
                 addbyte(0x86);
-                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu));
                 addbyte(0x8b); /*MOV ebp_store2, ESI*/
                 addbyte(0xb7);
                 addlong(offsetof(voodoo_state_t, ebp_store));
@@ -551,7 +557,7 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
             addbyte(0x8b);
             addbyte(0xac);
             addbyte(0xcf);
-            addlong(offsetof(voodoo_state_t, tex[tmu]));
+            addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, tex, tmu));
             addbyte(0x28); /*SUB DL, CL*/
             addbyte(0xca);
             addbyte(0x80); /*ADD CL, 4*/
@@ -594,18 +600,18 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
                 addbyte(0x3b); /*CMP EAX, params->tex_w_mask[ESI+ECX*4]*/
                 addbyte(0x84);
                 addbyte(0x8e);
-                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]) - 0x10);
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu) - 0x10);
                 addbyte(0x0f); /*CMOVAE EAX, params->tex_w_mask[ESI+ECX*4]*/
                 addbyte(0x43);
                 addbyte(0x84);
                 addbyte(0x8e);
-                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]) - 0x10);
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu) - 0x10);
 
             } else {
                 addbyte(0x23); /*AND EAX, params->tex_w_mask-0x10[ESI+ECX*4]*/
                 addbyte(0x84);
                 addbyte(0x8e);
-                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]) - 0x10);
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu) - 0x10);
             }
             if (state->clamp_t[tmu]) {
                 addbyte(0x85); /*TEST EBX, EBX*/
@@ -617,17 +623,17 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
                 addbyte(0x3b); /*CMP EBX, params->tex_h_mask[ESI+ECX*4]*/
                 addbyte(0x9c);
                 addbyte(0x8e);
-                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]) - 0x10);
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu) - 0x10);
                 addbyte(0x0f); /*CMOVAE EBX, params->tex_h_mask[ESI+ECX*4]*/
                 addbyte(0x43);
                 addbyte(0x9c);
                 addbyte(0x8e);
-                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]) - 0x10);
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu) - 0x10);
             } else {
                 addbyte(0x23); /*AND EBX, params->tex_h_mask-0x10[ESI+ECX*4]*/
                 addbyte(0x9c);
                 addbyte(0x8e);
-                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]) - 0x10);
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu) - 0x10);
             }
             addbyte(0x88); /*MOV CL, DL*/
             addbyte(0xd1);

--- a/src/include/86box/vid_voodoo_codegen_x86.h
+++ b/src/include/86box/vid_voodoo_codegen_x86.h
@@ -60,6 +60,12 @@ static int next_block_to_write[4] = { 0, 0 };
         block_pos += 8;                             \
     } while (0)
 
+#define VOODOO_OFFSETOF_ARRAY(type, field, index) \
+    (offsetof(type, field[0]) + ((index) * sizeof(((type *) 0)->field[0])))
+
+#define VOODOO_OFFSETOF_ARRAY_MEMBER(type, field, index, member) \
+    (offsetof(type, field[0].member) + ((index) * sizeof(((type *) 0)->field[0])))
+
 static __m128i xmm_01_w; // = 0x0001000100010001ull;
 static __m128i xmm_ff_w; // = 0x00ff00ff00ff00ffull;
 static __m128i xmm_ff_b; // = 0x00000000ffffffffull;
@@ -132,21 +138,21 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
         addbyte(0xd8);
         addbyte(0x03); /*ADD EAX, state->lod*/
         addbyte(0x87);
-        addlong(offsetof(voodoo_state_t, tmu[tmu].lod));
+        addlong(VOODOO_OFFSETOF_ARRAY_MEMBER(voodoo_state_t, tmu, tmu, lod));
         addbyte(0x3b); /*CMP EAX, state->lod_min*/
         addbyte(0x87);
-        addlong(offsetof(voodoo_state_t, lod_min[tmu]));
+        addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_min, tmu));
         addbyte(0x0f); /*CMOVL EAX, state->lod_min*/
         addbyte(0x4c);
         addbyte(0x87);
-        addlong(offsetof(voodoo_state_t, lod_min[tmu]));
+        addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_min, tmu));
         addbyte(0x3b); /*CMP EAX, state->lod_max*/
         addbyte(0x87);
-        addlong(offsetof(voodoo_state_t, lod_max[tmu]));
+        addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_max, tmu));
         addbyte(0x0f); /*CMOVNL EAX, state->lod_max*/
         addbyte(0x4d);
         addbyte(0x87);
-        addlong(offsetof(voodoo_state_t, lod_max[tmu]));
+        addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_max, tmu));
         addbyte(0x0f); /*MOVZX EBX, AL*/
         addbyte(0xb6);
         addbyte(0xd8);
@@ -155,7 +161,7 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
         addbyte(8);
         addbyte(0x89); /*MOV state->lod_frac[tmu], EBX*/
         addbyte(0x9f);
-        addlong(offsetof(voodoo_state_t, lod_frac[tmu]));
+        addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_frac, tmu));
         addbyte(0x89); /*MOV state->lod, EAX*/
         addbyte(0x87);
         addlong(offsetof(voodoo_state_t, lod));
@@ -172,11 +178,11 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
         addlong(tmu ? offsetof(voodoo_state_t, tmu1_t) : offsetof(voodoo_state_t, tmu0_t));
         addbyte(0xc7); /*MOV state->lod[tmu], 0*/
         addbyte(0x87);
-        addlong(offsetof(voodoo_state_t, lod_frac[tmu]));
+        addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_frac, tmu));
         addlong(0);
         addbyte(0x8b); /*MOV EAX, state->lod_min*/
         addbyte(0x87);
-        addlong(offsetof(voodoo_state_t, lod_min[tmu]));
+        addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_min, tmu));
         addbyte(0x66); /*SHRQ XMM4, 28*/
         addbyte(0x0f);
         addbyte(0x73);
@@ -205,7 +211,7 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
         addlong(offsetof(voodoo_state_t, tex_t));
         addbyte(0x89); /*MOV state->lod_frac[tmu], EBX*/
         addbyte(0x9f);
-        addlong(offsetof(voodoo_state_t, lod_frac[tmu]));
+        addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, lod_frac, tmu));
         addbyte(0x89); /*MOV state->lod, EAX*/
         addbyte(0x87);
         addlong(offsetof(voodoo_state_t, lod));
@@ -215,7 +221,7 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
         if (voodoo->bilinear_enabled && (params->textureMode[tmu] & 6)) {
             addbyte(0x8b); /*MOV ECX, state->tex_lod[tmu]*/
             addbyte(0x8f);
-            addlong(offsetof(voodoo_state_t, tex_lod[tmu]));
+            addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, tex_lod, tmu));
             addbyte(0xb2); /*MOV DL, 8*/
             addbyte(8);
             addbyte(0x8b); /*MOV ECX, [ECX+EAX*4]*/
@@ -295,7 +301,7 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
             addbyte(0x8b); /*MOV EBP, state->tex[EDI+ECX*4]*/
             addbyte(0xac);
             addbyte(0x8f);
-            addlong(offsetof(voodoo_state_t, tex[tmu]));
+            addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, tex, tmu));
             addbyte(0x88); /*MOV CL, DL*/
             addbyte(0xd1);
             addbyte(0x89); /*MOV EDX, EBX*/
@@ -303,7 +309,7 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
             if (!state->clamp_s[tmu]) {
                 addbyte(0x23); /*AND EAX, params->tex_w_mask[ESI]*/
                 addbyte(0x86);
-                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu));
             }
             addbyte(0x83); /*ADD EDX, 1*/
             addbyte(0xc2);
@@ -315,11 +321,11 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
                 addlong((uint32_t) &zero);
                 addbyte(0x3b); /*CMP EDX, params->tex_h_mask[ESI]*/
                 addbyte(0x96);
-                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
                 addbyte(0x0f); /*CMOVA EDX, params->tex_h_mask[ESI]*/
                 addbyte(0x47);
                 addbyte(0x96);
-                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
                 addbyte(0x85); /*TEST EBX,EBX*/
                 addbyte(0xdb);
                 addbyte(0x0f); /*CMOVS EBX, zero*/
@@ -328,18 +334,18 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
                 addlong((uint32_t) &zero);
                 addbyte(0x3b); /*CMP EBX, params->tex_h_mask[ESI]*/
                 addbyte(0x9e);
-                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
                 addbyte(0x0f); /*CMOVA EBX, params->tex_h_mask[ESI]*/
                 addbyte(0x47);
                 addbyte(0x9e);
-                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
             } else {
                 addbyte(0x23); /*AND EDX, params->tex_h_mask[ESI]*/
                 addbyte(0x96);
-                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
                 addbyte(0x23); /*AND EBX, params->tex_h_mask[ESI]*/
                 addbyte(0x9e);
-                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu));
             }
             /*EAX = S, EBX = T0, EDX = T1*/
             addbyte(0xd3); /*SHL EBX, CL*/
@@ -357,7 +363,7 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
             if (state->clamp_s[tmu]) {
                 addbyte(0x8b); /*MOV EBP, params->tex_w_mask[ESI]*/
                 addbyte(0xae);
-                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu));
                 addbyte(0x85); /*TEST EAX, EAX*/
                 addbyte(0xc0);
                 addbyte(0x8b); /*MOV ESI, ebp_store*/
@@ -379,7 +385,7 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
             } else {
                 addbyte(0x3b); /*CMP EAX, params->tex_w_mask[ESI] - is S at texture edge (ie will wrap/clamp)?*/
                 addbyte(0x86);
-                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]));
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu));
                 addbyte(0x8b); /*MOV ESI, ebp_store*/
                 addbyte(0xb7);
                 addlong(offsetof(voodoo_state_t, ebp_store));
@@ -521,7 +527,7 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
         } else {
             addbyte(0x8b); /*MOV ECX, state->tex_lod[tmu]*/
             addbyte(0x8f);
-            addlong(offsetof(voodoo_state_t, tex_lod[tmu]));
+            addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, tex_lod, tmu));
             addbyte(0xb2); /*MOV DL, 8*/
             addbyte(8);
             addbyte(0x8b); /*MOV ECX, [ECX+EAX*4]*/
@@ -530,7 +536,7 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
             addbyte(0x8b); /*MOV EBP, state->tex[EDI+ECX*4]*/
             addbyte(0xac);
             addbyte(0x8f);
-            addlong(offsetof(voodoo_state_t, tex[tmu]));
+            addlong(VOODOO_OFFSETOF_ARRAY(voodoo_state_t, tex, tmu));
             addbyte(0x28); /*SUB DL, CL*/
             addbyte(0xca);
             addbyte(0x80); /*ADD CL, 4*/
@@ -573,18 +579,18 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
                 addbyte(0x3b); /*CMP EAX, params->tex_w_mask[ESI+ECX*4]*/
                 addbyte(0x84);
                 addbyte(0x8e);
-                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]) - 0x10);
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu) - 0x10);
                 addbyte(0x0f); /*CMOVAE EAX, params->tex_w_mask[ESI+ECX*4]*/
                 addbyte(0x43);
                 addbyte(0x84);
                 addbyte(0x8e);
-                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]) - 0x10);
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu) - 0x10);
 
             } else {
                 addbyte(0x23); /*AND EAX, params->tex_w_mask-0x10[ESI+ECX*4]*/
                 addbyte(0x84);
                 addbyte(0x8e);
-                addlong(offsetof(voodoo_params_t, tex_w_mask[tmu]) - 0x10);
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_w_mask, tmu) - 0x10);
             }
             if (state->clamp_t[tmu]) {
                 addbyte(0x85); /*TEST EBX, EBX*/
@@ -596,17 +602,17 @@ codegen_texture_fetch(uint8_t *code_block, voodoo_t *voodoo, voodoo_params_t *pa
                 addbyte(0x3b); /*CMP EBX, params->tex_h_mask[ESI+ECX*4]*/
                 addbyte(0x9c);
                 addbyte(0x8e);
-                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]) - 0x10);
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu) - 0x10);
                 addbyte(0x0f); /*CMOVAE EBX, params->tex_h_mask[ESI+ECX*4]*/
                 addbyte(0x43);
                 addbyte(0x9c);
                 addbyte(0x8e);
-                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]) - 0x10);
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu) - 0x10);
             } else {
                 addbyte(0x23); /*AND EBX, params->tex_h_mask-0x10[ESI+ECX*4]*/
                 addbyte(0x9c);
                 addbyte(0x8e);
-                addlong(offsetof(voodoo_params_t, tex_h_mask[tmu]) - 0x10);
+                addlong(VOODOO_OFFSETOF_ARRAY(voodoo_params_t, tex_h_mask, tmu) - 0x10);
             }
             addbyte(0x88); /*MOV CL, DL*/
             addbyte(0xd1);

--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -46,7 +46,7 @@
 
 #define FIFO_SIZE        65536
 #define FIFO_MASK        (FIFO_SIZE - 1)
-#define FIFO_ENTRY_SIZE  (1 << 31)
+#define FIFO_ENTRY_SIZE  (UINT32_C(1) << 31)
 #define FIFO_THRESHOLD   0xe000
 
 #define WAKE_DELAY       (100 * TIMER_USEC) /* 100us */
@@ -336,7 +336,7 @@
 #define MACCESS_FOGEN                 (1 << 26)
 #define MACCESS_TLUTLOAD              (1 << 29)
 #define MACCESS_NODITHER              (1 << 30)
-#define MACCESS_DIT555                (1 << 31)
+#define MACCESS_DIT555                (UINT32_C(1) << 31)
 
 #define PITCH_MASK                    0xfe0
 #define PITCH_YLIN                    (1 << 15)
@@ -385,7 +385,7 @@
 #define TEXCTL_CLAMPU                 (1 << 28)
 #define TEXCTL_TMODULATE              (1 << 29)
 #define TEXCTL_STRANS                 (1 << 30)
-#define TEXCTL_ITRANS                 (1 << 31)
+#define TEXCTL_ITRANS                 (UINT32_C(1) << 31)
 
 #define TEXHEIGHT_TH_MASK             (0x3f << 0)
 #define TEXHEIGHT_THMASK_SHIFT        (18)
@@ -3804,7 +3804,7 @@ blit_iload_iload(mystique_t *mystique, uint32_t data, int size)
 
                 case DWGCTRL_BLTMOD_BMONOWF:
                     data      = (data >> 24) | ((data & 0x00ff0000) >> 8) | ((data & 0x0000ff00) << 8) | (data << 24);
-                    data_mask = (1 << 31);
+                    data_mask = (UINT32_C(1) << 31);
                 case DWGCTRL_BLTMOD_BMONOLEF:
                     while (size) {
                         if (mystique->dwgreg.xdst >= mystique->dwgreg.cxleft && mystique->dwgreg.xdst <= mystique->dwgreg.cxright && mystique->dwgreg.ydst_lin >= mystique->dwgreg.ytop && mystique->dwgreg.ydst_lin <= mystique->dwgreg.ybot && ((data & data_mask) || !(mystique->dwgreg.dwgctrl_running & DWGCTRL_TRANSC)) && trans[mystique->dwgreg.xdst & 3]) {


### PR DESCRIPTION
This PR contains two small video portability fixes.

- Build MGA bit-31 masks from `UINT32_C(1)` instead of shifting a signed `int` into the sign bit.
- Replace runtime-indexed `offsetof(type, field[index])` expressions in the Voodoo x86 code generators with helpers that compute the offset from `field[0]` plus an element stride.
