### PR TITLE
Increase the Lucky Star 5AVP3's max. RAM limit to 1 GB

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -19088,7 +19088,8 @@ const machine_t machines[] = {
         .net_device               = NULL,
         .aliases                  = { "" }
     },
-
+    /* Has the VIA VT82C586B southbridge with on-chip KBC identical to the VIA
+       VT82C42N. */
     {
         .name              = "[VIA VP3] Lucky Star 5AVP3",
         .internal_name     = "5avp3",
@@ -19113,7 +19114,7 @@ const machine_t machines[] = {
         .flags     = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_USB,
         .ram       = {
             .min  = 8192,
-            .max  = 524288,
+            .max  = 1048576,
             .step = 8192
         },
         .nvrmask                  = 127,
@@ -19136,7 +19137,6 @@ const machine_t machines[] = {
         .net_device               = NULL,
         .aliases                  = { "" }
     },
-    
     /* Has the VIA VT82C586B southbridge with on-chip KBC identical to the VIA
        VT82C42N. */
     {


### PR DESCRIPTION
Summary
=======
Increase the Lucky Star 5AVP3's max. RAM limit to 1 GB as (unofficially) supported by its chipset, and also add the necessary internal note for its KBC.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
https://theretroweb.com/motherboards/s/lucky-star-5avp3 (to check the RAM slots)
