### PR TITLE
CMS and SAAYM: Rebalance the audio

### DIFF
--- a/src/sound/snd_cms.c
+++ b/src/sound/snd_cms.c
@@ -119,7 +119,7 @@ cms_get_buffer(int32_t *buffer, const uint16_t len, void *priv)
     cms_update(cms);
 
     for (uint16_t c = 0; c < len * 2; c++)
-        buffer[c] += cms->buffer[c];
+        buffer[c] += cms->buffer[c] * 2.5;
 
     cms->pos = 0;
 }

--- a/src/sound/snd_saaym.c
+++ b/src/sound/snd_saaym.c
@@ -107,8 +107,8 @@ saaym_get_ym2151_buffer(int32_t *buffer, uint16_t len, void *priv)
         double out_l = 0.0;
         double out_r = 0.0;
 
-        out_l = ((double) opm_buf[c]);
-        out_r = ((double) opm_buf[c + 1]);
+        out_l = ((double) opm_buf[c] * 0.5);
+        out_r = ((double) opm_buf[c + 1] * 0.5);
 
         buffer[c] += (int32_t) out_l;
         buffer[c + 1] += (int32_t) out_r;


### PR DESCRIPTION
Summary
=======
Rebalance the audio on the SAAYM by increasing the CMS volume (which was in general somewhat quiet) and decreasing the YM2151 volume.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
