### PR TITLE
Add secondary monitor support for some video cards

### DIFF
--- a/src/video/vid_table.c
+++ b/src/video/vid_table.c
@@ -181,14 +181,14 @@ video_cards[] = {
     { .device = &mystique_220_device,                           .flags = VIDEO_FLAG_TYPE_NONE      },
     { .device = &s3_86c928_pci_device,                          .flags = VIDEO_FLAG_TYPE_NONE      },
     { .device = &s3_trio32_pci_device,                          .flags = VIDEO_FLAG_TYPE_NONE      },
-    { .device = &s3_trio3d2x_pci_device,                        .flags = VIDEO_FLAG_TYPE_NONE      },
+    { .device = &s3_trio3d2x_pci_device,                        .flags = VIDEO_FLAG_TYPE_SECONDARY },
     { .device = &s3_trio64_pci_device,                          .flags = VIDEO_FLAG_TYPE_NONE      },
     { .device = &s3_trio64vplus_pci_device,                     .flags = VIDEO_FLAG_TYPE_NONE      },
     { .device = &s3_trio64v2dx_pci_device,                      .flags = VIDEO_FLAG_TYPE_NONE      },
     { .device = &s3_virge_pci_device,                           .flags = VIDEO_FLAG_TYPE_NONE      },
     { .device = &s3_virge_dx_pci_device,                        .flags = VIDEO_FLAG_TYPE_NONE      },
     { .device = &s3_virge_gx_pci_device,                        .flags = VIDEO_FLAG_TYPE_NONE      },
-    { .device = &s3_virge_gx2_pci_device,                       .flags = VIDEO_FLAG_TYPE_NONE      },
+    { .device = &s3_virge_gx2_pci_device,                       .flags = VIDEO_FLAG_TYPE_SECONDARY },
     { .device = &s3_virge_vx_pci_device,                        .flags = VIDEO_FLAG_TYPE_NONE      },
     { .device = &s3_vision864_pci_device,                       .flags = VIDEO_FLAG_TYPE_NONE      },
     { .device = &s3_vision964_pci_device,                       .flags = VIDEO_FLAG_TYPE_NONE      },
@@ -208,8 +208,8 @@ video_cards[] = {
 #ifdef USE_G100
     { .device = &productiva_g100_device,                        .flags = VIDEO_FLAG_TYPE_SPECIAL   },
 #endif /*USE_G100 */
-    { .device = &s3_trio3d2x_agp_device,                        .flags = VIDEO_FLAG_TYPE_NONE      },
-    { .device = &s3_virge_gx2_agp_device,                       .flags = VIDEO_FLAG_TYPE_NONE      },
+    { .device = &s3_trio3d2x_agp_device,                        .flags = VIDEO_FLAG_TYPE_SECONDARY },
+    { .device = &s3_virge_gx2_agp_device,                       .flags = VIDEO_FLAG_TYPE_SECONDARY },
     { .device = NULL,                                           .flags = VIDEO_FLAG_TYPE_NONE      }
   // clang-format on
 };


### PR DESCRIPTION
Summary
=======
This PR enables `VIDEO_FLAG_TYPE_SECONDARY` on PCI/AGP S3 Trio3D/2X and S3 ViRGE/GX2.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
