### PR TITLE
qt: fix missing osd shutdown when switching renderers

### DIFF
--- a/src/qt/qt_osd.cpp
+++ b/src/qt/qt_osd.cpp
@@ -134,7 +134,6 @@ ensure_fonts(void)
     unsigned char *px = nullptr;
     int w = 0, h = 0;
     io.Fonts->GetTexDataAsRGBA32(&px, &w, &h);
-    io.Fonts->SetTexID((ImTextureID) (intptr_t) 1);
     g_fonts_ready = true;
 }
 

--- a/src/qt/qt_softwarerenderer.cpp
+++ b/src/qt/qt_softwarerenderer.cpp
@@ -48,6 +48,12 @@ SoftwareRenderer::SoftwareRenderer(QWidget *parent)
 }
 
 void
+SoftwareRenderer::finalize()
+{
+    qt_osd_shutdown();
+}
+
+void
 SoftwareRenderer::paintEvent(QPaintEvent *event)
 {
     (void) event;

--- a/src/qt/qt_softwarerenderer.hpp
+++ b/src/qt/qt_softwarerenderer.hpp
@@ -16,6 +16,7 @@ class SoftwareRenderer :
     Q_OBJECT
 public:
     explicit SoftwareRenderer(QWidget *parent = nullptr);
+    void finalize() override final;
 
     void paintEvent(QPaintEvent *event) override;
 

--- a/src/qt/qt_vulkanwindowrenderer.cpp
+++ b/src/qt/qt_vulkanwindowrenderer.cpp
@@ -44,6 +44,7 @@
 #    include <stdexcept>
 
 #    include "qt_mainwindow.hpp"
+#    include "qt_osd.hpp"
 #    include "qt_vulkanrenderer.hpp"
 
 extern "C" {
@@ -838,6 +839,12 @@ VulkanWindowRenderer::VulkanWindowRenderer(QWidget *parent)
     setFlags(Flag::PersistentResources);
     buf_usage = std::vector<std::atomic_flag>(1);
     buf_usage[0].clear();
+}
+
+void
+VulkanWindowRenderer::finalize()
+{
+    qt_osd_shutdown();
 }
 
 QVulkanWindowRenderer *

--- a/src/qt/qt_vulkanwindowrenderer.hpp
+++ b/src/qt/qt_vulkanwindowrenderer.hpp
@@ -13,6 +13,7 @@ class VulkanWindowRenderer : public QVulkanWindow, public RendererCommon {
     Q_OBJECT
 public:
     VulkanWindowRenderer(QWidget *parent);
+    void finalize() override final;
 public slots:
     void onBlit(int buf_idx, int x, int y, int w, int h);
 signals:


### PR DESCRIPTION
Summary
=======
I forgot to call `qt_osd_shutdown` :man_facepalming: 

Checklist
=========
* [x] Closes N/A
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [x] This pull request doesn't require changes to the ROM set
* [x] This pull request doesn't require changes to the asset set