### PR TITLE
Fix text EDID dumps being rejected

### DIFF
--- a/src/include/86box/plat.h
+++ b/src/include/86box/plat.h
@@ -38,7 +38,8 @@ enum {
     STRING_HW_NOT_AVAILABLE_DEVICE,   /* "Device \"%s\" is not available..." */
     STRING_GHOSTPCL_ERROR,            /* "Unable to initialize GhostPCL..." */
     STRING_ESCP_ERROR,                /* "Unable to find Dot-Matrix fonts..." */
-    STRING_EDID_TOO_LARGE,            /* "EDID file \"%s\" is too large (%lld bytes)." */
+    STRING_EDID_READ_ERROR,           /* "EDID file \"%s\" is invalid." */
+    STRING_EDID_TOO_LARGE,            /* "EDID file \"%s\" is too large." */
     STRING_CDROM_OPEN_ISO_ERROR,      /* "Unable to open image or folder \"%s\"" */
     STRING_CDROM_OPEN_CUE_ERROR,      /* "Unable to open Cue sheet \"%s\"" */
     STRING_CDROM_OPEN_MDS_ERROR,      /* "Unable to open MDS file \"%s\"" */

--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -3153,6 +3153,9 @@ msgstr ""
 msgid "Export EDID"
 msgstr ""
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr ""
 

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -3170,6 +3170,9 @@ msgstr "Exporta…"
 msgid "Export EDID"
 msgstr "Exporta l'EDID"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "El fitxer EDID \"%s\" és massa gran."
 

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -3213,6 +3213,9 @@ msgstr "Exportovat…"
 msgid "Export EDID"
 msgstr "Exportovat EDID"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "Soubor EDID \"%s\" je příliš velký."
 

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -3170,6 +3170,9 @@ msgstr "Exportieren…"
 msgid "Export EDID"
 msgstr "EDID exportieren"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "Die EDID-Datei \"%s\" ist zu groß."
 

--- a/src/qt/languages/el-GR.po
+++ b/src/qt/languages/el-GR.po
@@ -3228,6 +3228,9 @@ msgstr "Εξαγωγή…"
 msgid "Export EDID"
 msgstr "Εξαγωγή EDID"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "Το αρχείο EDID \"%s\" είναι πολύ μεγάλο."
 

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -3171,6 +3171,9 @@ msgstr "Exportar…"
 msgid "Export EDID"
 msgstr "Exportar el EDID"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "El archivo EDID \"%s\" es demasiado grande."
 

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -3174,6 +3174,9 @@ msgstr "Vie…"
 msgid "Export EDID"
 msgstr "Vie EDID"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "EDID-tiedosto \"%s\" on liian suuri."
 

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -3188,6 +3188,9 @@ msgstr "Exporter…"
 msgid "Export EDID"
 msgstr "Exporter l'EDID"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "Le fichier EDID « %s » est trop volumineux."
 

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -3178,6 +3178,9 @@ msgstr "Izvoz…"
 msgid "Export EDID"
 msgstr "Izvoz EDID-a"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "EDID datoteka \"%s\" je prevelika."
 

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -3252,6 +3252,9 @@ msgstr "Esporta…"
 msgid "Export EDID"
 msgstr "Esporta EDID"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "Il file EDID \"%s\" è troppo grande."
 

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -3165,6 +3165,9 @@ msgstr "エクスポート…"
 msgid "Export EDID"
 msgstr "EDIDのエクスポート"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "EDIDファイル「%s」が大きすぎます。"
 

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -3239,6 +3239,9 @@ msgstr "내보내기…"
 msgid "Export EDID"
 msgstr "EDID 내보내기"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "EDID 파일 \"%s\"가 너무 큽니다."
 

--- a/src/qt/languages/nb-NO.po
+++ b/src/qt/languages/nb-NO.po
@@ -3171,6 +3171,9 @@ msgstr "Eksporter…"
 msgid "Export EDID"
 msgstr "Eksporter EDID"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "EDID-filen \"%s\" er for stor."
 

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -3165,6 +3165,9 @@ msgstr "Exporteren…"
 msgid "Export EDID"
 msgstr "EDID exporteren"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "Het EDID-bestand \"%s\" is te groot."
 

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -3177,6 +3177,9 @@ msgstr "Eksportuj…"
 msgid "Export EDID"
 msgstr "Eksportuj EDID"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "Plik EDID „%s” jest zbyt duży."
 

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -3172,6 +3172,9 @@ msgstr "Exportar…"
 msgid "Export EDID"
 msgstr "Exportar EDID"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "O arquivo EDID \"%s\" é muito grande."
 

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -3173,6 +3173,9 @@ msgstr "Exportar…"
 msgid "Export EDID"
 msgstr "Exportar EDID"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "O ficheiro EDID \"%s\" é demasiado grande."
 

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -3184,6 +3184,9 @@ msgstr "Экспорт…"
 msgid "Export EDID"
 msgstr "Экспорт EDID"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr "Файл EDID «%s» некорректен."
+
 msgid "EDID file \"%s\" is too large."
 msgstr "Файл EDID «%s» слишком велик."
 

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -3177,6 +3177,9 @@ msgstr "Exportovať…"
 msgid "Export EDID"
 msgstr "Exportovať EDID"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "Súbor EDID \"%s\" je príliš veľký."
 

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -3184,6 +3184,9 @@ msgstr "Izvoz…"
 msgid "Export EDID"
 msgstr "Izvoz EDID"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "Datoteka EDID \"%s\" je prevelika."
 

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -3170,6 +3170,9 @@ msgstr "Exportera…"
 msgid "Export EDID"
 msgstr "Exportera EDID"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "EDID-filen \"%s\" är för stor."
 

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -3206,6 +3206,9 @@ msgstr "Dışa aktar…"
 msgid "Export EDID"
 msgstr "EDID'i dışa aktar"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "EDID dosyası \"%s\" çok büyük."
 

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -3179,6 +3179,9 @@ msgstr "Експорт…"
 msgid "Export EDID"
 msgstr "Експорт EDID"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "Файл EDID «%s» занадто великий."
 

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -3165,6 +3165,9 @@ msgstr "Xuất ra file…"
 msgid "Export EDID"
 msgstr "Xuất ra file EDID"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "Tệp EDID \"%s\" quá lớn."
 

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -3169,6 +3169,9 @@ msgstr "导出…"
 msgid "Export EDID"
 msgstr "导出EDID"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "EDID文件 \"%s\" 过大。"
 

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -3183,6 +3183,9 @@ msgstr "匯出…"
 msgid "Export EDID"
 msgstr "匯出 EDID"
 
+msgid "EDID file \"%s\" is invalid."
+msgstr ""
+
 msgid "EDID file \"%s\" is too large."
 msgstr "EDID 檔案 \"%s\" 太大。"
 

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -846,6 +846,7 @@ Preferences::reloadStrings()
     translatedstrings[STRING_HW_NOT_AVAILABLE_TITLE]    = QCoreApplication::translate("", "Hardware not available").toUtf8();
     translatedstrings[STRING_NET_ERROR]                 = QCoreApplication::translate("", "Failed to initialize network driver:\n\n%s\n\nThe network configuration will be switched to the null driver.").toUtf8();
     translatedstrings[STRING_ESCP_ERROR]                = QCoreApplication::translate("", "Unable to find Dot-Matrix fonts. TrueType fonts in the \"roms/printer/fonts\" directory are required for the emulation of the Generic ESC/P 2 Dot-Matrix Printer.").toUtf8();
+    translatedstrings[STRING_EDID_READ_ERROR]           = QCoreApplication::translate("", "EDID file \"%s\" is invalid.").toUtf8();
     translatedstrings[STRING_EDID_TOO_LARGE]            = QCoreApplication::translate("", "EDID file \"%s\" is too large.").toUtf8();
     translatedstrings[STRING_CDROM_OPEN_ISO_ERROR]      = QCoreApplication::translate("", "Unable to open image or folder \"%s\".").toUtf8();
     translatedstrings[STRING_CDROM_OPEN_CUE_ERROR]      = QCoreApplication::translate("", "Unable to open cue sheet \"%s\".").toUtf8();

--- a/src/qt/qt_settingsdisplay.cpp
+++ b/src/qt/qt_settingsdisplay.cpp
@@ -64,8 +64,8 @@ SettingsDisplay::SettingsDisplay(QWidget *parent)
     connect(ui->lineEditCustomEDID, &FileField::fileSelected, [this](const QString &fileName) {
         uint8_t dummyBuffer[384] = { 0 };
         size_t size = ddc_load_edid(fileName.toUtf8().data(), dummyBuffer, sizeof(dummyBuffer));
-        if (size > 256) {
-            QMessageBox::critical(this, "EDID", tr("EDID file \"%s\" is too large.").replace("%s", "%1").arg(fileName));
+        if ((size == 0) || (size > 256)) {
+            QMessageBox::critical(this, "EDID", tr((size == 0) ? "EDID file \"%s\" is invalid." : "EDID file \"%s\" is too large.").replace("%s", "%1").arg(fileName));
             this->ui->lineEditCustomEDID->setFileName(this->previousEDIDPath);
         } else
             this->previousEDIDPath = fileName;

--- a/src/qt/qt_settingsdisplay.cpp
+++ b/src/qt/qt_settingsdisplay.cpp
@@ -62,8 +62,9 @@ SettingsDisplay::SettingsDisplay(QWidget *parent)
 
     ui->lineEditCustomEDID->setFilter(tr("EDID") % util::DlgFilter({ "bin", "dat", "edid", "txt" }) % tr("All files") % util::DlgFilter({ "*" }, true));
     connect(ui->lineEditCustomEDID, &FileField::fileSelected, [this](const QString &fileName) {
-        QFileInfo edidFile(fileName);
-        if (edidFile.isFile() && edidFile.size() > 256) {
+        uint8_t dummyBuffer[384] = { 0 };
+        size_t size = ddc_load_edid(fileName.toUtf8().data(), dummyBuffer, sizeof(dummyBuffer));
+        if (size > 256) {
             QMessageBox::critical(this, "EDID", tr("EDID file \"%s\" is too large.").replace("%s", "%1").arg(fileName));
             this->ui->lineEditCustomEDID->setFileName(this->previousEDIDPath);
         } else

--- a/src/unix/sdl_plat.c
+++ b/src/unix/sdl_plat.c
@@ -113,6 +113,8 @@ plat_get_string(int i)
             return "Failed to initialize network driver:\n\n%s\n\nThe network configuration will be switched to the null driver.";
         case STRING_ESCP_ERROR:
             return "Unable to find Dot-Matrix fonts. TrueType fonts in the \"roms/printer/fonts\" directory are required for the emulation of the Generic ESC/P 2 Dot-Matrix Printer.";
+        case STRING_EDID_READ_ERROR:
+            return "EDID file \"%s\" is invalid.";
         case STRING_EDID_TOO_LARGE:
             return "EDID file \"%s\" is too large.";
         case STRING_CDROM_OPEN_ISO_ERROR:

--- a/src/video/vid_ddc.c
+++ b/src/video/vid_ddc.c
@@ -235,13 +235,11 @@ ddc_init_with_custom_edid(char *edid_path, void *i2c)
     uint8_t buffer[384] = { 0 };
     size_t  size        = ddc_load_edid(edid_path, buffer, sizeof(buffer));
 
-    if (size > 256) {
+    if ((size == 0) || (size > 256)) {
         char errmsg[2048] = { 0 };
-        snprintf(errmsg, sizeof(errmsg), plat_get_string(STRING_EDID_TOO_LARGE), monitor_edid_path);
+        snprintf(errmsg, sizeof(errmsg), plat_get_string((size == 0) ? STRING_EDID_READ_ERROR : STRING_EDID_TOO_LARGE), monitor_edid_path);
         ui_msgbox_header(MBX_ERROR, "EDID", errmsg);
 
-        return NULL;
-    } else if (size == 0) {
         return NULL;
     } else if (size < 128) {
         size = 128;


### PR DESCRIPTION
Summary
=======
Fix text EDID dumps (edid-decode output) being rejected as too large, and show an error message if trying to load malformed dumps.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set

References
==========
N/A