### PR TITLE
Implement 5480 specific XY and Command Lists mode extensions bits

### DIFF
--- a/src/video/vid_cl54xx.c
+++ b/src/video/vid_cl54xx.c
@@ -141,6 +141,9 @@
 #define CIRRUS_BLT_AUTOSTART 0x80
 
 /* control 0x33 */
+#define CIRRUS_BLTMODEEXT_COMMAND_LIST     0x80
+#define CIRRUS_BLTMODEEXT_XY_POSITION_SPEC 0x40
+#define CIRRUS_BLTMODEEXT_CLIP_RECTANGLE   0x20
 #define CIRRUS_BLTMODEEXT_BACKGROUNDONLY   0x08
 #define CIRRUS_BLTMODEEXT_SOLIDFILL        0x04
 #define CIRRUS_BLTMODEEXT_COLOREXPINV      0x02
@@ -183,40 +186,70 @@ typedef struct gd54xx_t {
 
     struct {
         uint16_t width;
+        uint16_t width_backup;
+        uint16_t x_max_xy;
         uint16_t height;
+        uint16_t height_backup;
         uint16_t dst_pitch;
+        uint16_t dst_pitch_backup;
+        uint16_t dst_start_x;
+        uint16_t dst_start_y;
+        uint16_t src_start_x;
+        uint16_t src_start_y;
         uint16_t src_pitch;
+        uint16_t src_pitch_backup;
         uint16_t trans_col;
         uint16_t trans_mask;
         uint16_t height_internal;
         uint16_t msd_buf_pos;
         uint16_t msd_buf_cnt;
+        uint16_t clip_start_x;
+        uint16_t clip_start_y;
+        uint16_t clip_end_x;
+        uint16_t clip_end_y;
 
         uint8_t status;
         uint8_t mask;
         uint8_t mode;
+        uint8_t mode_backup;
         uint8_t rop;
+        uint8_t rop_backup;
         uint8_t modeext;
+        uint8_t modeext_backup;
         uint8_t ms_is_dest;
         uint8_t msd_buf[32];
 
         uint32_t fg_col;
         uint32_t bg_col;
+        uint32_t dst_xy;
+        uint32_t src_xy;
         uint32_t dst_addr_backup;
         uint32_t src_addr_backup;
+        uint32_t dst_addr_xy;
+        uint32_t src_addr_xy;
         uint32_t dst_addr;
         uint32_t src_addr;
+        uint32_t src_addr_last;
         uint32_t sys_src32;
         uint32_t sys_cnt;
+        uint32_t cmd_list;
+        uint32_t cmd_list_dword[4];
+        uint32_t cmd_list_backup;
+        uint32_t width_xy;
 
         /* Internal state */
         int pixel_width;
         int pattern_x;
+        int src_x_pos;
+        int dst_x_pos;
+        int src_y_pos;
+        int dst_y_pos;
         int x_count;
         int y_count;
         int xx_count;
         int dir;
         int unlock_special;
+        int blit_list_continue;
     } blt;
 
     struct {
@@ -312,7 +345,11 @@ gd543x_recalc_mapping(gd54xx_t *gd54xx);
 static void
 gd54xx_reset_blit(gd54xx_t *gd54xx);
 static void
+gd54xx_command_list_blit(uint32_t count, gd54xx_t *gd54xx, svga_t *svga);
+static void
 gd54xx_start_blit(uint32_t cpu_dat, uint32_t count, gd54xx_t *gd54xx, svga_t *svga);
+static void
+gd54xx_normal_blit(uint32_t count, gd54xx_t *gd54xx, svga_t *svga);
 
 #define CLAMP(x)                      \
     do {                              \
@@ -1132,6 +1169,70 @@ gd54xx_out(uint16_t addr, uint8_t val, void *priv)
                         gd543x_mmio_write(0xb8021, val, gd54xx);
                         break;
 
+                    case 0x40:
+                        gd543x_mmio_write(0xb8028, val, gd54xx);
+                        break;
+
+                    case 0x41:
+                        gd543x_mmio_write(0xb8029, val, gd54xx);
+                        break;
+
+                    case 0x42:
+                        gd543x_mmio_write(0xb802a, val, gd54xx);
+                        break;
+
+                    case 0x43:
+                        gd543x_mmio_write(0xb802b, val, gd54xx);
+                        break;
+
+                    case 0x44:
+                        gd543x_mmio_write(0xb802c, val, gd54xx);
+                        break;
+
+                    case 0x45:
+                        gd543x_mmio_write(0xb802d, val, gd54xx);
+                        break;
+
+                    case 0x46:
+                        gd543x_mmio_write(0xb802e, val, gd54xx);
+                        break;
+
+                    case 0x47:
+                        gd543x_mmio_write(0xb802f, val, gd54xx);
+                        break;
+
+                    case 0x48:
+                        gd543x_mmio_write(0xb8030, val, gd54xx);
+                        break;
+
+                    case 0x49:
+                        gd543x_mmio_write(0xb8031, val, gd54xx);
+                        break;
+
+                    case 0x4a:
+                        gd543x_mmio_write(0xb8032, val, gd54xx);
+                        break;
+
+                    case 0x4b:
+                        gd543x_mmio_write(0xb8033, val, gd54xx);
+                        break;
+
+                    case 0x4c:
+                        gd543x_mmio_write(0xb8034, val, gd54xx);
+                        break;
+
+                    case 0x4d:
+                        gd543x_mmio_write(0xb8035, val, gd54xx);
+                        break;
+
+                    case 0x4e:
+                        gd543x_mmio_write(0xb8036, val, gd54xx);
+                        break;
+
+                    case 0x4f:
+                        gd543x_mmio_write(0xb8037, val, gd54xx);
+                        break;
+
                     default:
                         break;
                 }
@@ -1622,6 +1723,7 @@ gd54xx_in(uint16_t addr, void *priv)
                         case 0x3f:
                             if (svga->crtc[0x27] == CIRRUS_ID_CLGD5446)
                                 gd54xx->vportsync = !gd54xx->vportsync;
+
                             ret = gd54xx->vportsync ? 0x80 : 0x00;
                             break;
 
@@ -1789,12 +1891,9 @@ gd543x_recalc_mapping(gd54xx_t *gd54xx)
             }
         } else if (gd54xx->pci) {
             base = gd54xx->lfb_base;
-#if 0
             if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
                 size = 32 * 1024 * 1024;
-            else
-#endif
-            if (svga->crtc[0x27] >= CIRRUS_ID_CLGD5436)
+            else if (svga->crtc[0x27] >= CIRRUS_ID_CLGD5436)
                 size = 16 * 1024 * 1024;
             else
                 size = 4 * 1024 * 1024;
@@ -1849,37 +1948,40 @@ gd54xx_recalctimings(svga_t *svga)
     int             d = 0;
     int             n = 0;
 
-    svga->hblankstart = svga->crtc[2];
+    if (svga->crtc[0x27] != CIRRUS_ID_CLGD5480) {
+        svga->hblankstart = svga->crtc[2];
 
-    if (svga->crtc[0x1b] & ((svga->crtc[0x27] >= CIRRUS_ID_CLGD5424) ? 0xa0 : 0x20)) {
-        /*
-           Special blanking mode: the blank start and end become components
-           of the window generator, and the actual blanking comes from the
-           display enable signal.
+        if (svga->crtc[0x1b] & ((svga->crtc[0x27] >= CIRRUS_ID_CLGD5424) ? 0xa0 : 0x20)) {
+            /*
+               Special blanking mode: the blank start and end become components
+               of the window generator, and the actual blanking comes from the
+               display enable signal.
 
-           This means blanking during overscan, we already calculate it that
-           way, so just use the same calculation and force otvercan to 0.
-         */
-        svga->hblank_end_val = (svga->crtc[3] & 0x1f) | ((svga->crtc[5] & 0x80) ? 0x20 : 0x00) |
-                               (((svga->crtc[0x1a] >> 4) & 3) << 6);
+               This means blanking during overscan, we already calculate it that
+               way, so just use the same calculation and force otvercan to 0.
+             */
+            svga->hblank_end_val = (svga->crtc[3] & 0x1f) | ((svga->crtc[5] & 0x80) ? 0x20 : 0x00) |
+                                   (((svga->crtc[0x1a] >> 4) & 3) << 6);
 
-        svga->hblank_end_mask = 0x000000ff;
+            svga->hblank_end_mask = 0x000000ff;
 
-        if (svga->crtc[0x1b] & 0x20) {
-            svga->hblankstart = svga->crtc[1]/* + ((svga->crtc[3] >> 5) & 3) + 1*/;
-            svga->hblank_end_val = svga->htotal - 1 /* + ((svga->crtc[3] >> 5) & 3)*/;
+            if (svga->crtc[0x1b] & 0x20) {
+                svga->hblankstart = svga->crtc[1]/* + ((svga->crtc[3] >> 5) & 3) + 1*/;
+                svga->hblank_end_val = svga->htotal - 1 /* + ((svga->crtc[3] >> 5) & 3)*/;
 
-            /* In this mode, the dots per clock are always 8 or 16, never 9 or 18. */
-	    if (!svga->scrblank && svga->attr_palette_enable)
-                svga->dots_per_clock = (svga->seqregs[1] & 8) ? 16 : 8;
+                /* In this mode, the dots per clock are always 8 or 16, never 9 or 18. */
+            if (!svga->scrblank && svga->attr_palette_enable)
+                    svga->dots_per_clock = (svga->seqregs[1] & 8) ? 16 : 8;
 
-            svga->monitor->mon_overscan_y = 0;
-            svga->monitor->mon_overscan_x = 0;
+                svga->monitor->mon_overscan_y = 0;
+                svga->monitor->mon_overscan_x = 0;
 
-            /* Also make sure vertical blanking starts on display end. */
-            svga->vblankstart = svga->dispend;
+                /* Also make sure vertical blanking starts on display end. */
+                svga->vblankstart = svga->dispend;
+            }
         }
-    }
+    } else
+        svga->hoverride = 1;
 
     svga->rowoffset = (svga->crtc[0x13]) | (((int) (uint32_t) (svga->crtc[0x1b] & 0x10)) << 4);
 
@@ -1909,7 +2011,6 @@ gd54xx_recalctimings(svga_t *svga)
                     if (!gd54xx_is_5434(svga))
                         freq /= 3.0F;
                     break;
-
                 default:
                     break;
             }
@@ -1925,10 +2026,13 @@ gd54xx_recalctimings(svga_t *svga)
         else {
             svga->render = svga_render_8bpp_highres;
             if ((svga->dispend == 512) && !svga->interlace && gd54xx_is_5434(svga)) {
-                svga->hdisp <<= 1;
-                svga->dots_per_clock <<= 1;
-                svga->clock *= 2.0;
+                if (svga->crtc[0x27] != CIRRUS_ID_CLGD5480) {
+                    svga->hdisp <<= 1;
+                    svga->dots_per_clock <<= 1;
+                    svga->clock *= 2.0;
+                }
             }
+            //pclog("GD5480 Clocking: %02x, interlace=%x, clocksel=%d, hdisp=%d.\n", svga->seqregs[0x07] & (gd54xx_is_5434(svga) ? 0xe : 6), svga->interlace, clocksel, svga->hdisp);
         }
     } else if (svga->gdcreg[5] & 0x40)
         svga->render = svga_render_8bpp_lowres;
@@ -1942,14 +2046,15 @@ gd54xx_recalctimings(svga_t *svga)
         svga->memaddr_latch |= ((svga->crtc[0x1b] & 0x08) << 15);
     if (svga->crtc[0x27] >= CIRRUS_ID_CLGD5430)
         svga->memaddr_latch |= ((svga->crtc[0x1d] & 0x80) << 12);
+
     svga->memaddr_latch  += ((svga->crtc[8] & 0x60) >> 5);
 
     if (gd54xx->ramdac.ctrl & 0x80) {
         if (gd54xx->ramdac.ctrl & 0x40) {
             if ((svga->crtc[0x27] >= CIRRUS_ID_CLGD5428) || (svga->crtc[0x27] == CIRRUS_ID_CLGD5426))
-                rdmask = 0xf;
+                rdmask = 0x0f;
             else
-                rdmask = 0x7;
+                rdmask = 0x07;
 
             switch (gd54xx->ramdac.ctrl & rdmask) {
                 case 0:
@@ -2094,6 +2199,30 @@ gd54xx_recalctimings(svga_t *svga)
             svga->render = svga_render_text_40;
         else
             svga->render = svga_render_text_80;
+    } else {
+        if (svga->seqregs[0x07] & CIRRUS_SR7_BPP_SVGA) {
+            switch (svga->seqregs[0x07] & (gd54xx_is_5434(svga) ? 0xe : 6)) {
+                case 4:
+                    if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480) {
+                        if (svga->bpp == 24) {
+                            if (svga->dispend == 1024) {
+                                svga->clock /= 2.0;
+                            }
+                        }
+                    }
+                    break;
+                case 6:
+                    if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480) {
+                        if (svga->bpp == 8) {
+                            svga->hdisp <<= 1;
+                            svga->dots_per_clock <<= 1;
+                        }
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
     }
 
     if (!(svga->seqregs[0x07] & CIRRUS_SR7_BPP_SVGA) && (((svga->gdcreg[6] >> 2) & 0x03) != 0x01)) {
@@ -3007,6 +3136,53 @@ gd54xx_readl(uint32_t addr, void *priv)
     return svga_readl_linear(addr, svga);
 }
 
+static void
+gd54xx_command_list_blit(uint32_t count, gd54xx_t *gd54xx, svga_t *svga)
+{
+    gd54xx->blt.width = gd54xx->blt.cmd_list_dword[0] & 0x1fff;
+    gd54xx->blt.height = (gd54xx->blt.cmd_list_dword[0] >> 16) & 0x07ff;
+
+    gd54xx->blt.dst_start_x = gd54xx->blt.cmd_list_dword[1] & 0xffff;
+    gd54xx->blt.dst_start_y = (gd54xx->blt.cmd_list_dword[1] >> 16) & 0xffff;
+
+    gd54xx->blt.src_addr = gd54xx->blt.cmd_list_dword[2] & 0x3fffff;
+
+    switch ((gd54xx->blt.cmd_list_dword[0] >> 28) & 0x03) {
+        case 0x00:
+            gd54xx->blt.dst_pitch = gd54xx->blt.cmd_list_dword[3] & 0x1fff;
+            gd54xx->blt.src_pitch = (gd54xx->blt.cmd_list_dword[3] >> 16) & 0x1fff;
+            break;
+        case 0x01:
+            gd54xx->blt.mode = gd54xx->blt.cmd_list_dword[3] & 0xff;
+            gd543x_recalc_mapping(gd54xx);
+
+            gd54xx->blt.rop = (gd54xx->blt.cmd_list_dword[3] >> 16) & 0xff;
+            gd54xx->blt.modeext = (gd54xx->blt.cmd_list_dword[3] >> 24) & 0xff;
+            break;
+
+        default:
+            break;
+    }
+
+    gd54xx_normal_blit(-1, gd54xx, svga);
+}
+
+static void
+gd54xx_last_command_params(gd54xx_t *gd54xx, svga_t *svga)
+{
+    gd54xx->blt.width = gd54xx->blt.width_backup;
+    gd54xx->blt.height = gd54xx->blt.height_backup;
+
+    gd54xx->blt.src_addr = gd54xx->blt.src_addr_last;
+
+    gd54xx->blt.dst_pitch = gd54xx->blt.dst_pitch_backup;
+    gd54xx->blt.src_pitch = gd54xx->blt.src_pitch_backup;
+
+    gd54xx->blt.mode = gd54xx->blt.mode_backup;
+    gd54xx->blt.rop = gd54xx->blt.rop_backup;
+    gd54xx->blt.modeext = gd54xx->blt.modeext_backup;
+}
+
 static int
 gd543x_do_mmio(svga_t *svga, uint32_t addr)
 {
@@ -3076,6 +3252,8 @@ gd543x_mmio_write(uint32_t addr, uint8_t val, void *priv)
                     gd54xx->blt.width &= 0x1fff;
                 else
                     gd54xx->blt.width &= 0x07ff;
+
+                gd54xx->blt.width_backup = gd54xx->blt.width;
                 break;
             case 0x0a:
                 gd54xx->blt.height = (gd54xx->blt.height & 0xff00) | val;
@@ -3086,6 +3264,8 @@ gd543x_mmio_write(uint32_t addr, uint8_t val, void *priv)
                     gd54xx->blt.height &= 0x07ff;
                 else
                     gd54xx->blt.height &= 0x03ff;
+
+                gd54xx->blt.height_backup = gd54xx->blt.height;
                 break;
             case 0x0c:
                 gd54xx->blt.dst_pitch = (gd54xx->blt.dst_pitch & 0xff00) | val;
@@ -3093,6 +3273,8 @@ gd543x_mmio_write(uint32_t addr, uint8_t val, void *priv)
             case 0x0d:
                 gd54xx->blt.dst_pitch = (gd54xx->blt.dst_pitch & 0x00ff) | (val << 8);
                 gd54xx->blt.dst_pitch &= 0x1fff;
+
+                gd54xx->blt.dst_pitch_backup = gd54xx->blt.dst_pitch;
                 break;
             case 0x0e:
                 gd54xx->blt.src_pitch = (gd54xx->blt.src_pitch & 0xff00) | val;
@@ -3100,6 +3282,8 @@ gd543x_mmio_write(uint32_t addr, uint8_t val, void *priv)
             case 0x0f:
                 gd54xx->blt.src_pitch = (gd54xx->blt.src_pitch & 0x00ff) | (val << 8);
                 gd54xx->blt.src_pitch &= 0x1fff;
+
+                gd54xx->blt.src_pitch_backup = gd54xx->blt.src_pitch;
                 break;
 
             case 0x10:
@@ -3115,11 +3299,42 @@ gd543x_mmio_write(uint32_t addr, uint8_t val, void *priv)
                 else
                     gd54xx->blt.dst_addr &= 0x1fffff;
 
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480) {
+                    if (gd54xx->blt.modeext & CIRRUS_BLTMODEEXT_COMMAND_LIST) {
+                        gd54xx->blt.cmd_list = 0x3c0000;
+                        gd54xx->blt.cmd_list |= (((val >> 6) & 0x03) << 8);
+                    }
+                }
                 if ((svga->crtc[0x27] >= CIRRUS_ID_CLGD5436) &&
                     (gd54xx->blt.status & CIRRUS_BLT_AUTOSTART) &&
                     !(gd54xx->blt.status & CIRRUS_BLT_BUSY)) {
-                    gd54xx->blt.status |= CIRRUS_BLT_BUSY;
-                    gd54xx_start_blit(0, 0xffffffff, gd54xx, svga);
+                    if (!(gd54xx->blt.modeext & CIRRUS_BLTMODEEXT_XY_POSITION_SPEC)) {
+                        gd54xx->blt.status |= CIRRUS_BLT_BUSY;
+                        //pclog("Normal AutoStart.\n");
+                        gd54xx_start_blit(0, 0xffffffff, gd54xx, svga);
+                    }
+                }
+                break;
+            case 0x13:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480) {
+                    if (gd54xx->blt.modeext & CIRRUS_BLTMODEEXT_COMMAND_LIST) {
+                        gd54xx->blt.cmd_list |= (val << 10);
+                        gd54xx->blt.cmd_list &= 0x3fff00;
+                        gd54xx->blt.cmd_list_backup = gd54xx->blt.cmd_list;
+
+                        uint8_t *vram = svga->vram;
+
+                        gd54xx->blt.cmd_list_dword[0] = *(uint32_t *)&vram[gd54xx->blt.cmd_list_backup & gd54xx->vram_mask];
+                        gd54xx->blt.cmd_list_dword[1] = *(uint32_t *)&vram[(gd54xx->blt.cmd_list_backup + 4) & gd54xx->vram_mask];
+                        gd54xx->blt.cmd_list_dword[2] = *(uint32_t *)&vram[(gd54xx->blt.cmd_list_backup + 8) & gd54xx->vram_mask];
+                        gd54xx->blt.cmd_list_dword[3] = *(uint32_t *)&vram[(gd54xx->blt.cmd_list_backup + 12) & gd54xx->vram_mask];
+                        gd54xx->blt.blit_list_continue = !(gd54xx->blt.cmd_list_dword[0] & (1 << 31));
+
+                        gd54xx_command_list_blit(-1, gd54xx, svga);
+
+                        //pclog("CMDList=%08x, val=%02x, autostart=%02x, dword0=%08x.\n", gd54xx->blt.cmd_list_backup, val, gd54xx->blt.status & CIRRUS_BLT_AUTOSTART, gd54xx->blt.cmd_list_dword[0]);
+                        //pclog(".\n");
+                    }
                 }
                 break;
 
@@ -3135,6 +3350,8 @@ gd543x_mmio_write(uint32_t addr, uint8_t val, void *priv)
                     gd54xx->blt.src_addr &= 0x3fffff;
                 else
                     gd54xx->blt.src_addr &= 0x1fffff;
+
+                gd54xx->blt.src_addr_last = gd54xx->blt.src_addr;
                 break;
 
             case 0x17:
@@ -3143,15 +3360,25 @@ gd543x_mmio_write(uint32_t addr, uint8_t val, void *priv)
             case 0x18:
                 gd54xx->blt.mode = val;
                 gd543x_recalc_mapping(gd54xx);
+                gd54xx->blt.mode_backup = gd54xx->blt.mode;
                 break;
 
             case 0x1a:
                 gd54xx->blt.rop = val;
+                gd54xx->blt.rop_backup = gd54xx->blt.rop;
                 break;
 
             case 0x1b:
-                if (svga->crtc[0x27] >= CIRRUS_ID_CLGD5436)
+                if (svga->crtc[0x27] >= CIRRUS_ID_CLGD5436) {
                     gd54xx->blt.modeext = val;
+                    if (!(gd54xx->blt.modeext & CIRRUS_BLTMODEEXT_COMMAND_LIST)) {
+                        gd54xx->blt.cmd_list_dword[0] = 0x00000000;
+                        gd54xx->blt.cmd_list_dword[1] = 0x00000000;
+                        gd54xx->blt.cmd_list_dword[2] = 0x00000000;
+                        gd54xx->blt.cmd_list_dword[3] = 0x00000000;
+                    }
+                    gd54xx->blt.modeext_backup = gd54xx->blt.modeext;
+                }
                 break;
 
             case 0x1c:
@@ -3166,6 +3393,94 @@ gd543x_mmio_write(uint32_t addr, uint8_t val, void *priv)
                 break;
             case 0x21:
                 gd54xx->blt.trans_mask = (gd54xx->blt.trans_mask & 0x00ff) | (val << 8);
+                break;
+
+            case 0x28:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    gd54xx->blt.dst_start_x = (gd54xx->blt.dst_start_x & 0xff00) | val;
+                break;
+            case 0x29:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480) {
+                    gd54xx->blt.dst_start_x = (gd54xx->blt.dst_start_x & 0x00ff) | (val << 8);
+                    //pclog("MMIO Write DSTX=%d, modeext=%02x.\n", gd54xx->blt.dst_start_x, gd54xx->blt.modeext);
+                }
+                break;
+
+            case 0x2a:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    gd54xx->blt.dst_start_y = (gd54xx->blt.dst_start_y & 0xff00) | val;
+                break;
+            case 0x2b:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480) {
+                    gd54xx->blt.dst_start_y = (gd54xx->blt.dst_start_y & 0x00ff) | (val << 8);
+                    //pclog("MMIO Write DSTY=%d.\n", gd54xx->blt.dst_start_y);
+
+                    if ((gd54xx->blt.modeext & CIRRUS_BLTMODEEXT_XY_POSITION_SPEC) &&
+                        (gd54xx->blt.status & CIRRUS_BLT_AUTOSTART) &&
+                        !(gd54xx->blt.status & CIRRUS_BLT_BUSY)) {
+                        //pclog("DEST XY Start dword0=%08x, modeext=%02x.\n", gd54xx->blt.cmd_list_dword[0], gd54xx->blt.modeext);
+                        gd54xx->blt.status |= CIRRUS_BLT_BUSY;
+                        if (!gd54xx->blt.blit_list_continue)
+                            gd54xx_last_command_params(gd54xx, svga);
+
+                        gd54xx_start_blit(0, -1, gd54xx, svga);
+                        //pclog(".\n");
+                    }
+                }
+                break;
+
+            case 0x2c:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    gd54xx->blt.src_start_x = (gd54xx->blt.src_start_x & 0xff00) | val;
+                break;
+            case 0x2d:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    gd54xx->blt.src_start_x = (gd54xx->blt.src_start_x & 0x00ff) | (val << 8);
+                break;
+
+            case 0x2e:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    gd54xx->blt.src_start_y = (gd54xx->blt.src_start_y & 0xff00) | val;
+                break;
+            case 0x2f:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    gd54xx->blt.src_start_y = (gd54xx->blt.src_start_y & 0x00ff) | (val << 8);
+                break;
+
+            case 0x30:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    gd54xx->blt.clip_start_x = (gd54xx->blt.clip_start_x & 0xff00) | val;
+                break;
+            case 0x31:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    gd54xx->blt.clip_start_x = (gd54xx->blt.clip_start_x & 0x00ff) | (val << 8);
+                break;
+
+            case 0x32:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    gd54xx->blt.clip_start_y = (gd54xx->blt.clip_start_y & 0xff00) | val;
+                break;
+            case 0x33:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    gd54xx->blt.clip_start_y = (gd54xx->blt.clip_start_y & 0x00ff) | (val << 8);
+                break;
+
+            case 0x34:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    gd54xx->blt.clip_end_x = (gd54xx->blt.clip_end_x & 0xff00) | val;
+                break;
+            case 0x35:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    gd54xx->blt.clip_end_x = (gd54xx->blt.clip_end_x & 0x00ff) | (val << 8);
+                break;
+
+            case 0x36:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    gd54xx->blt.clip_end_y = (gd54xx->blt.clip_end_y & 0xff00) | val;
+                break;
+            case 0x37:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    gd54xx->blt.clip_end_y = (gd54xx->blt.clip_end_y & 0x00ff) | (val << 8);
                 break;
 
             case 0x40:
@@ -3331,6 +3646,13 @@ gd543x_mmio_read(uint32_t addr, void *priv)
                     ret = (gd54xx->blt.dst_addr >> 16) & 0x3f;
                 else
                     ret = (gd54xx->blt.dst_addr >> 16) & 0x1f;
+
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    ret |= (((gd54xx->blt.cmd_list >> 8) & 0x03) << 6);
+                break;
+            case 0x13:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    ret = (gd54xx->blt.cmd_list >> 10) & 0xff;
                 break;
 
             case 0x14:
@@ -3374,6 +3696,78 @@ gd543x_mmio_read(uint32_t addr, void *priv)
                 break;
             case 0x21:
                 ret = (gd54xx->blt.trans_mask >> 8) & 0xff;
+                break;
+
+            case 0x28:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    ret = gd54xx->blt.dst_start_x & 0xff;
+                break;
+            case 0x29:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    ret = (gd54xx->blt.dst_start_x >> 8) & 0xff;
+                break;
+
+            case 0x2a:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    ret = gd54xx->blt.dst_start_y & 0xff;
+                break;
+            case 0x2b:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    ret = (gd54xx->blt.dst_start_y >> 8) & 0xff;
+                break;
+
+            case 0x2c:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    ret = gd54xx->blt.src_start_x & 0xff;
+                break;
+            case 0x2d:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    ret = (gd54xx->blt.src_start_x >> 8) & 0xff;
+                break;
+
+            case 0x2e:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    ret = gd54xx->blt.src_start_y & 0xff;
+                break;
+            case 0x2f:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    ret = (gd54xx->blt.src_start_y >> 8) & 0xff;
+                break;
+
+            case 0x30:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    ret = gd54xx->blt.clip_start_x & 0xff;
+                break;
+            case 0x31:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    ret = (gd54xx->blt.clip_start_x >> 8) & 0xff;
+                break;
+
+            case 0x32:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    ret = gd54xx->blt.clip_start_y & 0xff;
+                break;
+            case 0x33:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    ret = (gd54xx->blt.clip_start_y >> 8) & 0xff;
+                break;
+
+            case 0x34:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    ret = gd54xx->blt.clip_end_x & 0xff;
+                break;
+            case 0x35:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    ret = (gd54xx->blt.clip_end_x >> 8) & 0xff;
+                break;
+
+            case 0x36:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    ret = gd54xx->blt.clip_end_y & 0xff;
+                break;
+            case 0x37:
+                if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
+                    ret = (gd54xx->blt.clip_end_y >> 8) & 0xff;
                 break;
 
             case 0x40:
@@ -3504,7 +3898,6 @@ gd5480_vgablt_readw(uint32_t addr, void *priv)
         ret = gd5480_vgablt_read(addr, priv);
         ret |= (gd5480_vgablt_read(addr + 1, priv) << 8);
     }
-
     return ret;
 }
 
@@ -3521,7 +3914,6 @@ gd5480_vgablt_readl(uint32_t addr, void *priv)
         ret = gd5480_vgablt_readw(addr, priv);
         ret |= (gd5480_vgablt_readw(addr + 2, priv) << 16);
     }
-
     return ret;
 }
 
@@ -3645,7 +4037,13 @@ gd54xx_pattern_copy(gd54xx_t *gd54xx)
     if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND)
         pattern_pitch = 1;
 
-    dsta = gd54xx->blt.dst_addr & gd54xx->vram_mask;
+    if (gd54xx->blt.modeext & CIRRUS_BLTMODEEXT_XY_POSITION_SPEC) {
+        gd54xx->blt.dst_x_pos = gd54xx->blt.dst_start_x * gd54xx->blt.pixel_width;
+        gd54xx->blt.dst_y_pos = gd54xx->blt.dst_start_y;
+        dsta = gd54xx->blt.dst_addr + (gd54xx->blt.dst_y_pos * gd54xx->blt.dst_pitch);
+    } else
+        dsta = gd54xx->blt.dst_addr & gd54xx->vram_mask;
+
     /* The vertical offset is in the three low-order bits of the Source Address register. */
     pattern_y = gd54xx->blt.src_addr & 0x07;
 
@@ -3661,37 +4059,122 @@ gd54xx_pattern_copy(gd54xx_t *gd54xx)
     /* The boundary has to be equal to the size of the pattern. */
     srca = (gd54xx->blt.src_addr & ~0x07) & gd54xx->vram_mask;
 
-    for (uint16_t y = 0; y <= gd54xx->blt.height; y++) {
+    if (gd54xx->blt.modeext & CIRRUS_BLTMODEEXT_XY_POSITION_SPEC) {
+        uint32_t clip_l = gd54xx->blt.clip_start_x;
+        uint32_t clip_r = gd54xx->blt.clip_end_x * gd54xx->blt.pixel_width;
+        uint32_t clip_t = gd54xx->blt.clip_start_y;
+        uint32_t clip_b = gd54xx->blt.clip_end_y;
+        int xx = 0;
+        uint16_t x = 0;
+        uint16_t y = 0;
+
         /* Go to the correct pattern line. */
         srca2 = srca + (pattern_y * pattern_pitch);
         pixel = 0;
-        for (uint16_t x = 0; x <= gd54xx->blt.width; x += gd54xx->blt.pixel_width) {
+        gd54xx->blt.width_xy = gd54xx->blt.width * gd54xx->blt.pixel_width;
+
+        while (y <= gd54xx->blt.height) {
             if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND) {
                 if (gd54xx->blt.modeext & CIRRUS_BLTMODEEXT_SOLIDFILL)
                     bitmask = 1;
                 else
                     bitmask = svga->vram[srca2 & gd54xx->vram_mask] & (0x80 >> pixel);
             }
-            for (int xx = 0; xx < gd54xx->blt.pixel_width; xx++) {
-                if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND)
-                    src = gd54xx_color_expand(gd54xx, bitmask, xx);
-                else {
-                    src     = svga->vram[(srca2 + (x % (gd54xx->blt.pixel_width << 3)) + xx) & gd54xx->vram_mask];
-                    bitmask = gd54xx_transparent_comp(gd54xx, xx, src);
+            while (xx < gd54xx->blt.pixel_width) {
+                if (gd54xx->blt.modeext & CIRRUS_BLTMODEEXT_CLIP_RECTANGLE) {
+                    if (((gd54xx->blt.dst_x_pos + xx) >= clip_l) && ((gd54xx->blt.dst_x_pos + xx) <= clip_r) &&
+                        (gd54xx->blt.dst_y_pos >= clip_t) && (gd54xx->blt.dst_y_pos <= clip_b)) {
+                        if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND)
+                            src = gd54xx_color_expand(gd54xx, bitmask, xx);
+                        else {
+                            src     = svga->vram[(srca2 + (x % (gd54xx->blt.pixel_width << 3)) + xx) & gd54xx->vram_mask];
+                            bitmask = gd54xx_transparent_comp(gd54xx, xx, src);
+                        }
+                        dst    = &(svga->vram[(dsta + gd54xx->blt.dst_x_pos + xx) & gd54xx->vram_mask]);
+                        target = *dst;
+                        gd54xx_rop(gd54xx, &target, &target, &src);
+                        if (gd54xx->blt.pixel_width == 3)
+                            gd54xx_blit(gd54xx, bitmask, dst, target, ((x + xx) < gd54xx->blt.pattern_x));
+                        else
+                            gd54xx_blit(gd54xx, bitmask, dst, target, (x < gd54xx->blt.pattern_x));
+                    }
+                } else {
+                    if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND)
+                        src = gd54xx_color_expand(gd54xx, bitmask, xx);
+                    else {
+                        src     = svga->vram[(srca2 + (x % (gd54xx->blt.pixel_width << 3)) + xx) & gd54xx->vram_mask];
+                        bitmask = gd54xx_transparent_comp(gd54xx, xx, src);
+                    }
+                    dst    = &(svga->vram[(dsta + gd54xx->blt.dst_x_pos + xx) & gd54xx->vram_mask]);
+                    target = *dst;
+                    gd54xx_rop(gd54xx, &target, &target, &src);
+                    if (gd54xx->blt.pixel_width == 3)
+                        gd54xx_blit(gd54xx, bitmask, dst, target, ((x + xx) < gd54xx->blt.pattern_x));
+                    else
+                        gd54xx_blit(gd54xx, bitmask, dst, target, (x < gd54xx->blt.pattern_x));
                 }
-                dst    = &(svga->vram[(dsta + x + xx) & gd54xx->vram_mask]);
-                target = *dst;
-                gd54xx_rop(gd54xx, &target, &target, &src);
-                if (gd54xx->blt.pixel_width == 3)
-                    gd54xx_blit(gd54xx, bitmask, dst, target, ((x + xx) < gd54xx->blt.pattern_x));
-                else
-                    gd54xx_blit(gd54xx, bitmask, dst, target, (x < gd54xx->blt.pattern_x));
+                xx++;
+                if (xx == gd54xx->blt.pixel_width) {
+                    xx = 0;
+                    break;
+                }
             }
-            pixel                                                   = (pixel + 1) & 7;
-            svga->changedvram[((dsta + x) & gd54xx->vram_mask) >> 12] = changeframecount;
+            pixel = (pixel + 1) & 7;
+            gd54xx->blt.dst_x_pos += gd54xx->blt.pixel_width;
+            svga->changedvram[((dsta + gd54xx->blt.dst_x_pos) & gd54xx->vram_mask) >> 12] = changeframecount;
+
+            x += gd54xx->blt.pixel_width;
+            if (x > gd54xx->blt.width_xy) {
+                x = 0;
+
+                pattern_y = (pattern_y + 1) & 7;
+
+                /* Go to the correct pattern line. */
+                srca2 = srca + (pattern_y * pattern_pitch);
+                pixel = 0;
+
+                gd54xx->blt.dst_x_pos = gd54xx->blt.dst_start_x * gd54xx->blt.pixel_width;
+                gd54xx->blt.dst_y_pos++;
+                dsta = gd54xx->blt.dst_addr + (gd54xx->blt.dst_y_pos * gd54xx->blt.dst_pitch);
+
+                y++;
+                if (y > gd54xx->blt.height)
+                    break;
+            }
         }
-        pattern_y = (pattern_y + 1) & 7;
-        dsta += gd54xx->blt.dst_pitch;
+    } else {
+        for (uint16_t y = 0; y <= gd54xx->blt.height; y++) {
+            /* Go to the correct pattern line. */
+            srca2 = srca + (pattern_y * pattern_pitch);
+            pixel = 0;
+            for (uint16_t x = 0; x <= gd54xx->blt.width; x += gd54xx->blt.pixel_width) {
+                if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND) {
+                    if (gd54xx->blt.modeext & CIRRUS_BLTMODEEXT_SOLIDFILL)
+                        bitmask = 1;
+                    else
+                        bitmask = svga->vram[srca2 & gd54xx->vram_mask] & (0x80 >> pixel);
+                }
+                for (int xx = 0; xx < gd54xx->blt.pixel_width; xx++) {
+                    if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND)
+                        src = gd54xx_color_expand(gd54xx, bitmask, xx);
+                    else {
+                        src     = svga->vram[(srca2 + (x % (gd54xx->blt.pixel_width << 3)) + xx) & gd54xx->vram_mask];
+                        bitmask = gd54xx_transparent_comp(gd54xx, xx, src);
+                    }
+                    dst    = &(svga->vram[(dsta + x + xx) & gd54xx->vram_mask]);
+                    target = *dst;
+                    gd54xx_rop(gd54xx, &target, &target, &src);
+                    if (gd54xx->blt.pixel_width == 3)
+                        gd54xx_blit(gd54xx, bitmask, dst, target, ((x + xx) < gd54xx->blt.pattern_x));
+                    else
+                        gd54xx_blit(gd54xx, bitmask, dst, target, (x < gd54xx->blt.pattern_x));
+                }
+                pixel                                                   = (pixel + 1) & 7;
+                svga->changedvram[((dsta + x) & gd54xx->vram_mask) >> 12] = changeframecount;
+            }
+            pattern_y = (pattern_y + 1) & 7;
+            dsta += gd54xx->blt.dst_pitch;
+        }
     }
 }
 
@@ -3707,12 +4190,19 @@ gd54xx_reset_blit(gd54xx_t *gd54xx)
 static void
 gd54xx_mem_sys_src(gd54xx_t *gd54xx, uint32_t cpu_dat, uint32_t count)
 {
-    uint8_t *dst;
+    uint8_t *dst = NULL;
     uint8_t  exp;
     uint8_t  target;
     int      mask_shift;
-    uint32_t byte_pos;
+    int      xx = 0;
+    int      xxx = (gd54xx->blt.pixel_width == 3) ? 1 : gd54xx->blt.pixel_width;
+    int      x_width = (gd54xx->blt.pixel_width == 3) ? gd54xx->blt.pixel_width : 1;
+    uint32_t byte_pos = 0;
     uint32_t bitmask = 0;
+    uint32_t clip_l = gd54xx->blt.clip_start_x;
+    uint32_t clip_r = gd54xx->blt.clip_end_x * gd54xx->blt.pixel_width;
+    uint32_t clip_t = gd54xx->blt.clip_start_y;
+    uint32_t clip_b = gd54xx->blt.clip_end_y;
     svga_t  *svga = &gd54xx->svga;
 
     gd54xx->blt.ms_is_dest = 0;
@@ -3727,6 +4217,15 @@ gd54xx_mem_sys_src(gd54xx_t *gd54xx, uint32_t cpu_dat, uint32_t count)
         gd54xx->countminusone                      = 1;
         gd54xx->blt.sys_src32                      = 0x00000000;
         gd54xx->blt.sys_cnt                        = 0;
+        if ((svga->crtc[0x27] == CIRRUS_ID_CLGD5480) &&
+            (gd54xx->blt.modeext & CIRRUS_BLTMODEEXT_XY_POSITION_SPEC)) {
+            gd54xx->blt.dst_x_pos = gd54xx->blt.dst_start_x * gd54xx->blt.pixel_width;
+            gd54xx->blt.dst_y_pos = gd54xx->blt.dst_start_y;
+
+            gd54xx->blt.dst_addr_xy = gd54xx->blt.dst_addr + (gd54xx->blt.dst_y_pos * gd54xx->blt.dst_pitch);
+            gd54xx->blt.width_xy = 0;
+            gd54xx->blt.x_max_xy = 0;
+        }
     } else if (gd54xx->countminusone) {
         if (!(gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND) ||
             (gd54xx->blt.modeext & CIRRUS_BLTMODEEXT_DWORDGRANULARITY)) {
@@ -3734,62 +4233,175 @@ gd54xx_mem_sys_src(gd54xx_t *gd54xx, uint32_t cpu_dat, uint32_t count)
                 byte_pos = (((gd54xx->blt.mask >> 5) & 3) << 3);
             else
                 byte_pos = 0;
+
             mask_shift = 31 - byte_pos;
             if (!(gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND))
                 cpu_dat >>= byte_pos;
         } else
             mask_shift = 7;
 
-        while (mask_shift > -1) {
-            if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND) {
-                bitmask = (cpu_dat >> mask_shift) & 0x01;
-                exp     = gd54xx_color_expand(gd54xx, bitmask, gd54xx->blt.xx_count);
-            } else {
-                exp     = cpu_dat & 0xff;
-                bitmask = gd54xx_transparent_comp(gd54xx, gd54xx->blt.xx_count, exp);
-            }
+        if ((svga->crtc[0x27] == CIRRUS_ID_CLGD5480) &&
+            (gd54xx->blt.modeext & CIRRUS_BLTMODEEXT_XY_POSITION_SPEC)) {
+            while (mask_shift > -1) {
+                while (xx < xxx) {
+                    if (gd54xx->blt.modeext & CIRRUS_BLTMODEEXT_CLIP_RECTANGLE) {
+                        if (((gd54xx->blt.dst_x_pos + xx) >= clip_l) && ((gd54xx->blt.dst_x_pos + xx) <= clip_r) &&
+                            (gd54xx->blt.dst_y_pos >= clip_t) && (gd54xx->blt.dst_y_pos <= clip_b)) {
+                            if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND) {
+                                bitmask = (cpu_dat >> mask_shift) & 0x01;
+                                exp = gd54xx_color_expand(gd54xx, bitmask, gd54xx->blt.xx_count);
+                            } else {
+                                exp = (cpu_dat >> (xx << 3)) & 0xff;
+                                bitmask = gd54xx_transparent_comp(gd54xx, gd54xx->blt.xx_count, exp);
+                            }
 
-            dst    = &(svga->vram[gd54xx->blt.dst_addr_backup & gd54xx->vram_mask]);
-            target = *dst;
-            gd54xx_rop(gd54xx, &target, &target, &exp);
-            if ((gd54xx->blt.pixel_width == 3) && (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND))
-                gd54xx_blit(gd54xx, bitmask, dst, target,
-                            ((gd54xx->blt.x_count + gd54xx->blt.xx_count) < gd54xx->blt.pattern_x));
-            else
-                gd54xx_blit(gd54xx, bitmask, dst, target, (gd54xx->blt.x_count < gd54xx->blt.pattern_x));
+                            dst = &(svga->vram[(gd54xx->blt.dst_addr_xy + gd54xx->blt.dst_x_pos + xx) & gd54xx->vram_mask]);
+                            target = *dst;
+                            gd54xx_rop(gd54xx, &target, &target, &exp);
+                            if ((gd54xx->blt.pixel_width == 3) && (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND))
+                                gd54xx_blit(gd54xx, bitmask, dst, target,
+                                            ((gd54xx->blt.x_count + gd54xx->blt.xx_count) < gd54xx->blt.pattern_x));
+                            else
+                                gd54xx_blit(gd54xx, bitmask, dst, target, (gd54xx->blt.x_count < gd54xx->blt.pattern_x));
 
-            gd54xx->blt.dst_addr_backup += gd54xx->blt.dir;
+                            svga->changedvram[((gd54xx->blt.dst_addr_xy + gd54xx->blt.dst_x_pos + xx) & gd54xx->vram_mask) >> 12] = changeframecount;
+                        }
+                    } else {
+                        if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND) {
+                            bitmask = (cpu_dat >> mask_shift) & 0x01;
+                            exp = gd54xx_color_expand(gd54xx, bitmask, gd54xx->blt.xx_count);
+                        } else {
+                            exp = (cpu_dat >> (xx << 3)) & 0xff;
+                            bitmask = gd54xx_transparent_comp(gd54xx, gd54xx->blt.xx_count, exp);
+                        }
 
-            if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND)
-                gd54xx->blt.xx_count = (gd54xx->blt.xx_count + 1) % gd54xx->blt.pixel_width;
+                        dst = &(svga->vram[(gd54xx->blt.dst_addr_xy + gd54xx->blt.dst_x_pos + xx) & gd54xx->vram_mask]);
+                        target = *dst;
+                        gd54xx_rop(gd54xx, &target, &target, &exp);
+                        if ((gd54xx->blt.pixel_width == 3) && (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND))
+                            gd54xx_blit(gd54xx, bitmask, dst, target,
+                                        ((gd54xx->blt.x_count + gd54xx->blt.xx_count) < gd54xx->blt.pattern_x));
+                        else {
+                            gd54xx_blit(gd54xx, bitmask, dst, target, (gd54xx->blt.x_count < gd54xx->blt.pattern_x));
+                        }
+                        svga->changedvram[((gd54xx->blt.dst_addr_xy + gd54xx->blt.dst_x_pos + xx) & gd54xx->vram_mask) >> 12] = changeframecount;
+                    }
+                    xx++;
+                    if (xx == xxx) {
+                        xx = 0;
+                        break;
+                    }
+                }
 
-            svga->changedvram[(gd54xx->blt.dst_addr_backup & gd54xx->vram_mask) >> 12] = changeframecount;
-
-            if (!gd54xx->blt.xx_count) {
-                /* 1 mask bit = 1 blitted pixel */
-                if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND)
-                    mask_shift--;
-                else {
-                    cpu_dat >>= 8;
-                    mask_shift -= 8;
+                if ((gd54xx->blt.pixel_width == 3) && !(gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND)) {
+                    if (gd54xx->blt.dir == -1)
+                        gd54xx->blt.dst_x_pos -= gd54xx->blt.dir;
+                    else
+                        gd54xx->blt.dst_x_pos += gd54xx->blt.dir;
+                } else {
+                    if (gd54xx->blt.dir == -1)
+                        gd54xx->blt.dst_x_pos -= xxx;
+                    else
+                        gd54xx->blt.dst_x_pos += xxx;
                 }
 
                 if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND)
-                    gd54xx->blt.x_count = (gd54xx->blt.x_count + gd54xx->blt.pixel_width) % (gd54xx->blt.width + 1);
-                else
-                    gd54xx->blt.x_count = (gd54xx->blt.x_count + 1) % (gd54xx->blt.width + 1);
+                    gd54xx->blt.xx_count = (gd54xx->blt.xx_count + 1) % gd54xx->blt.pixel_width;
 
-                if (!gd54xx->blt.x_count) {
-                    gd54xx->blt.y_count = (gd54xx->blt.y_count + 1) % (gd54xx->blt.height + 1);
-                    if (gd54xx->blt.y_count)
-                        gd54xx->blt.dst_addr_backup = gd54xx->blt.dst_addr +
-                                                      (gd54xx->blt.dst_pitch * gd54xx->blt.y_count *
-                                                       gd54xx->blt.dir);
+                if (!gd54xx->blt.xx_count) {
+                    /* 1 mask bit = 1 blitted pixel */
+                    if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND)
+                        mask_shift--;
+                    else {
+                        if (gd54xx->blt.pixel_width != 4)
+                            cpu_dat >>= (xxx << 3);
+
+                        mask_shift -= (xxx << 3);
+                    }
+
+                    if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND)
+                        gd54xx->blt.x_count = (gd54xx->blt.x_count + gd54xx->blt.pixel_width) % (gd54xx->blt.width + 1);
                     else
-                        /* If we're here, the blit is over, reset. */
-                        gd54xx_reset_blit(gd54xx);
-                    /* Stop blitting and request new data if end of line reached. */
-                    break;
+                        gd54xx->blt.x_count = (gd54xx->blt.x_count + 1) % ((gd54xx->blt.width + 1) * x_width);
+
+                    if ((gd54xx->blt.pixel_width == 3) && !(gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND)) {
+                        gd54xx->blt.x_max_xy++;
+                        if (gd54xx->blt.x_max_xy == gd54xx->blt.pixel_width) {
+                            gd54xx->blt.width_xy++;
+                            gd54xx->blt.x_max_xy = 0;
+                        }
+                    } else
+                        gd54xx->blt.width_xy++;
+
+                    if (gd54xx->blt.width_xy > gd54xx->blt.width) {
+                        gd54xx->blt.width_xy = 0;
+                        gd54xx->blt.x_max_xy = 0;
+                        gd54xx->blt.y_count = (gd54xx->blt.y_count + 1) % (gd54xx->blt.height + 1);
+                        if (gd54xx->blt.y_count) {
+                            gd54xx->blt.dst_x_pos = gd54xx->blt.dst_start_x * gd54xx->blt.pixel_width;
+
+                            gd54xx->blt.dst_y_pos += gd54xx->blt.dir;
+
+                            gd54xx->blt.dst_addr_xy = gd54xx->blt.dst_addr + (gd54xx->blt.dst_y_pos * gd54xx->blt.dst_pitch);
+                        } else
+                            gd54xx_reset_blit(gd54xx);
+
+                        break;
+                    }
+                }
+            }
+        } else {
+            while (mask_shift > -1) {
+                if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND) {
+                    bitmask = (cpu_dat >> mask_shift) & 0x01;
+                    exp     = gd54xx_color_expand(gd54xx, bitmask, gd54xx->blt.xx_count);
+                } else {
+                    exp     = cpu_dat & 0xff;
+                    bitmask = gd54xx_transparent_comp(gd54xx, gd54xx->blt.xx_count, exp);
+                }
+
+                dst    = &(svga->vram[gd54xx->blt.dst_addr_backup & gd54xx->vram_mask]);
+                target = *dst;
+                gd54xx_rop(gd54xx, &target, &target, &exp);
+                if ((gd54xx->blt.pixel_width == 3) && (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND))
+                    gd54xx_blit(gd54xx, bitmask, dst, target,
+                                ((gd54xx->blt.x_count + gd54xx->blt.xx_count) < gd54xx->blt.pattern_x));
+                else
+                    gd54xx_blit(gd54xx, bitmask, dst, target, (gd54xx->blt.x_count < gd54xx->blt.pattern_x));
+
+                gd54xx->blt.dst_addr_backup += gd54xx->blt.dir;
+
+                if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND)
+                    gd54xx->blt.xx_count = (gd54xx->blt.xx_count + 1) % gd54xx->blt.pixel_width;
+
+                svga->changedvram[(gd54xx->blt.dst_addr_backup & gd54xx->vram_mask) >> 12] = changeframecount;
+
+                if (!gd54xx->blt.xx_count) {
+                    /* 1 mask bit = 1 blitted pixel */
+                    if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND)
+                        mask_shift--;
+                    else {
+                        cpu_dat >>= 8;
+                        mask_shift -= 8;
+                    }
+
+                    if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND)
+                        gd54xx->blt.x_count = (gd54xx->blt.x_count + gd54xx->blt.pixel_width) % (gd54xx->blt.width + 1);
+                    else
+                        gd54xx->blt.x_count = (gd54xx->blt.x_count + 1) % (gd54xx->blt.width + 1);
+
+                    if (!gd54xx->blt.x_count) {
+                        gd54xx->blt.y_count = (gd54xx->blt.y_count + 1) % (gd54xx->blt.height + 1);
+                        if (gd54xx->blt.y_count)
+                            gd54xx->blt.dst_addr_backup = gd54xx->blt.dst_addr +
+                                                          (gd54xx->blt.dst_pitch * gd54xx->blt.y_count *
+                                                           gd54xx->blt.dir);
+                        else
+                            /* If we're here, the blit is over, reset. */
+                            gd54xx_reset_blit(gd54xx);
+                        /* Stop blitting and request new data if end of line reached. */
+                        break;
+                    }
                 }
             }
         }
@@ -3799,12 +4411,19 @@ gd54xx_mem_sys_src(gd54xx_t *gd54xx, uint32_t cpu_dat, uint32_t count)
 static void
 gd54xx_normal_blit(uint32_t count, gd54xx_t *gd54xx, svga_t *svga)
 {
+    uint8_t *vram = svga->vram;
     uint8_t  src   = 0;
     uint8_t  dst;
     uint16_t width = gd54xx->blt.width;
+    uint16_t clip_l = gd54xx->blt.clip_start_x * gd54xx->blt.pixel_width;
+    uint16_t clip_r = (gd54xx->blt.clip_end_x * gd54xx->blt.pixel_width) + gd54xx->blt.pixel_width - 1;
+    uint16_t clip_t = gd54xx->blt.clip_start_y;
+    uint16_t clip_b = gd54xx->blt.clip_end_y;
+    uint16_t x_width = 0;
     int      x_max = 0;
     int      shift = 0;
-    int      mask = 0;
+    uint32_t mask = 0;
+    int      xx = 0;
     uint32_t src_addr = gd54xx->blt.src_addr;
     uint32_t dst_addr = gd54xx->blt.dst_addr;
 
@@ -3816,79 +4435,225 @@ gd54xx_normal_blit(uint32_t count, gd54xx_t *gd54xx, svga_t *svga)
     gd54xx->blt.x_count         = 0;
     gd54xx->blt.y_count         = 0;
 
-    while (count) {
-        src  = 0;
-        mask = 0;
+    if ((svga->crtc[0x27] == CIRRUS_ID_CLGD5480) &&
+        (gd54xx->blt.modeext & CIRRUS_BLTMODEEXT_XY_POSITION_SPEC)) {
+        gd54xx->blt.src_x_pos = gd54xx->blt.src_start_x * gd54xx->blt.pixel_width;
+        gd54xx->blt.src_y_pos = gd54xx->blt.src_start_y;
+        gd54xx->blt.dst_x_pos = gd54xx->blt.dst_start_x * gd54xx->blt.pixel_width;
+        gd54xx->blt.dst_y_pos = gd54xx->blt.dst_start_y;
+        gd54xx->blt.src_addr_xy = gd54xx->blt.src_addr + (gd54xx->blt.src_y_pos * gd54xx->blt.src_pitch);
+        gd54xx->blt.dst_addr_xy = gd54xx->blt.dst_addr + (gd54xx->blt.dst_y_pos * gd54xx->blt.dst_pitch);
+        //pclog("Normal blit: SRCPitch=%d, DSTPitch=%d, width=%d, height=%d, dx=%d, dy=%d, cx=%d, cy=%d, cl=%d, cr=%d, dir=%d.\n", gd54xx->blt.src_pitch, gd54xx->blt.dst_pitch, gd54xx->blt.width, gd54xx->blt.height, gd54xx->blt.dst_x_pos, gd54xx->blt.dst_y_pos, gd54xx->blt.src_x_pos, gd54xx->blt.src_y_pos, clip_l, clip_r, gd54xx->blt.dir);
 
-        if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND) {
-            mask  = svga->vram[src_addr & gd54xx->vram_mask] & (0x80 >> (gd54xx->blt.x_count / gd54xx->blt.pixel_width));
-            shift = (gd54xx->blt.x_count % gd54xx->blt.pixel_width);
-            src   = gd54xx_color_expand(gd54xx, mask, shift);
-        } else {
-            src = svga->vram[src_addr & gd54xx->vram_mask];
-            src_addr += gd54xx->blt.dir;
-            mask = 1;
-        }
-        count--;
-
-        dst                                                   = svga->vram[dst_addr & gd54xx->vram_mask];
-        svga->changedvram[(dst_addr & gd54xx->vram_mask) >> 12] = changeframecount;
-
-        gd54xx_rop(gd54xx, &dst, &dst, (const uint8_t *) &src);
-
-        if ((gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND) && (gd54xx->blt.modeext & CIRRUS_BLTMODEEXT_COLOREXPINV))
-            mask = !mask;
-
-        /* This handles 8bpp and 16bpp non-color-expanding transparent comparisons. */
-        if ((gd54xx->blt.mode & CIRRUS_BLTMODE_TRANSPARENTCOMP) &&
-            !(gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND) &&
-            ((gd54xx->blt.mode & CIRRUS_BLTMODE_PIXELWIDTHMASK) <= CIRRUS_BLTMODE_PIXELWIDTH16) &&
-            (src != ((gd54xx->blt.trans_mask >> (shift << 3)) & 0xff)))
+        while (count) {
+            src  = 0;
             mask = 0;
 
-        if (((gd54xx->blt.width - width) >= gd54xx->blt.pattern_x) &&
-            !((gd54xx->blt.mode & CIRRUS_BLTMODE_TRANSPARENTCOMP) && !mask))
-            svga->vram[dst_addr & gd54xx->vram_mask] = dst;
+            count--;
+            while (xx < gd54xx->blt.pixel_width) {
+                if (gd54xx->blt.modeext & CIRRUS_BLTMODEEXT_CLIP_RECTANGLE) {
+                    //pclog("XY Clipping Blit: pix=%d, DSTX=%d, DSTY=%d, SRCX=%d, SRCY=%d, cl=%d, cr=%d, xcount=%d, xx=%d, width=%d, height=%d, modeext=%02x.\n", gd54xx->blt.pixel_width, gd54xx->blt.dst_x_pos, gd54xx->blt.dst_y_pos, gd54xx->blt.src_x_pos, gd54xx->blt.src_y_pos, clip_l, clip_r, gd54xx->blt.x_count, xx, width, gd54xx->blt.height_internal, gd54xx->blt.modeext);
+                    if (((gd54xx->blt.dst_x_pos + xx) >= clip_l) && ((gd54xx->blt.dst_x_pos + xx) <= clip_r) &&
+                        (gd54xx->blt.dst_y_pos >= clip_t) && (gd54xx->blt.dst_y_pos <= clip_b)) {
+                        if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND) {
+                            mask  = svga->vram[src_addr & gd54xx->vram_mask] & (0x80 >> ((gd54xx->blt.x_count + xx) / gd54xx->blt.pixel_width));
+                            shift = ((gd54xx->blt.x_count + xx) % gd54xx->blt.pixel_width);
+                            src = gd54xx_color_expand(gd54xx, mask, shift);
+                        } else {
+                            src = svga->vram[(gd54xx->blt.src_addr_xy + gd54xx->blt.src_x_pos + xx) & gd54xx->vram_mask];
+                            mask = 1;
+                        }
 
-        dst_addr += gd54xx->blt.dir;
-        gd54xx->blt.x_count++;
+                        dst = svga->vram[(gd54xx->blt.dst_addr_xy + gd54xx->blt.dst_x_pos + xx) & gd54xx->vram_mask];
+                        svga->changedvram[((gd54xx->blt.dst_addr_xy + gd54xx->blt.dst_x_pos) & gd54xx->vram_mask) >> 12] = changeframecount;
+                        gd54xx_rop(gd54xx, &dst, &dst, (const uint8_t *) &src);
 
-        if (gd54xx->blt.x_count == x_max) {
-            gd54xx->blt.x_count = 0;
-            if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND)
-                src_addr++;
+                        if ((gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND) && (gd54xx->blt.modeext & CIRRUS_BLTMODEEXT_COLOREXPINV))
+                            mask = !mask;
+
+                        /* This handles 8bpp and 16bpp non-color-expanding transparent comparisons. */
+                        if ((gd54xx->blt.mode & CIRRUS_BLTMODE_TRANSPARENTCOMP) &&
+                            !(gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND) &&
+                            ((gd54xx->blt.mode & CIRRUS_BLTMODE_PIXELWIDTHMASK) <= CIRRUS_BLTMODE_PIXELWIDTH16) &&
+                            (src != ((gd54xx->blt.trans_mask >> (shift << 3)) & 0xff)))
+                            mask = 0;
+
+                        if (((gd54xx->blt.width - width) >= gd54xx->blt.pattern_x) &&
+                            !((gd54xx->blt.mode & CIRRUS_BLTMODE_TRANSPARENTCOMP) && !mask))
+                            svga->vram[(gd54xx->blt.dst_addr_xy + gd54xx->blt.dst_x_pos + xx) & gd54xx->vram_mask] = dst;
+                    }
+                } else {
+                    if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND) {
+                        mask  = svga->vram[src_addr & gd54xx->vram_mask] & (0x80 >> ((gd54xx->blt.x_count + xx) / gd54xx->blt.pixel_width));
+                        shift = ((gd54xx->blt.x_count + xx) % gd54xx->blt.pixel_width);
+                        src = gd54xx_color_expand(gd54xx, mask, shift);
+                    } else {
+                        src = svga->vram[(gd54xx->blt.src_addr_xy + gd54xx->blt.src_x_pos + xx) & gd54xx->vram_mask];
+                        mask = 1;
+                    }
+
+                    dst = svga->vram[(gd54xx->blt.dst_addr_xy + gd54xx->blt.dst_x_pos + xx) & gd54xx->vram_mask];
+                    svga->changedvram[((gd54xx->blt.dst_addr_xy + gd54xx->blt.dst_x_pos) & gd54xx->vram_mask) >> 12] = changeframecount;
+                    gd54xx_rop(gd54xx, &dst, &dst, (const uint8_t *) &src);
+
+                    if ((gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND) && (gd54xx->blt.modeext & CIRRUS_BLTMODEEXT_COLOREXPINV))
+                        mask = !mask;
+
+                    /* This handles 8bpp and 16bpp non-color-expanding transparent comparisons. */
+                    if ((gd54xx->blt.mode & CIRRUS_BLTMODE_TRANSPARENTCOMP) &&
+                        !(gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND) &&
+                        ((gd54xx->blt.mode & CIRRUS_BLTMODE_PIXELWIDTHMASK) <= CIRRUS_BLTMODE_PIXELWIDTH16) &&
+                        (src != ((gd54xx->blt.trans_mask >> (shift << 3)) & 0xff)))
+                        mask = 0;
+
+                    if (((gd54xx->blt.width - width) >= gd54xx->blt.pattern_x) &&
+                        !((gd54xx->blt.mode & CIRRUS_BLTMODE_TRANSPARENTCOMP) && !mask))
+                        svga->vram[(gd54xx->blt.dst_addr_xy + gd54xx->blt.dst_x_pos + xx) & gd54xx->vram_mask] = dst;
+                }
+                xx++;
+                if (xx == gd54xx->blt.pixel_width) {
+                    xx = 0;
+                    break;
+                }
+            }
+
+            if (gd54xx->blt.dir == -1) {
+                gd54xx->blt.src_x_pos -= gd54xx->blt.pixel_width;
+                gd54xx->blt.dst_x_pos -= gd54xx->blt.pixel_width;
+            } else {
+                gd54xx->blt.src_x_pos += gd54xx->blt.pixel_width;
+                gd54xx->blt.dst_x_pos += gd54xx->blt.pixel_width;
+            }
+
+            gd54xx->blt.x_count += gd54xx->blt.pixel_width;
+
+            if (gd54xx->blt.x_count == x_max) {
+                gd54xx->blt.x_count = 0;
+                if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND)
+                    src_addr++;
+            }
+
+            width--;
+            x_width++;
+            if (x_width > gd54xx->blt.width) {
+                width = gd54xx->blt.width;
+                x_width = 0;
+                gd54xx->blt.y_count = (gd54xx->blt.y_count + gd54xx->blt.dir) & 7;
+
+                gd54xx->blt.dst_x_pos = gd54xx->blt.dst_start_x * gd54xx->blt.pixel_width;
+                gd54xx->blt.src_x_pos = gd54xx->blt.src_start_x * gd54xx->blt.pixel_width;
+
+                gd54xx->blt.dst_y_pos += gd54xx->blt.dir;
+                gd54xx->blt.src_y_pos += gd54xx->blt.dir;
+
+                gd54xx->blt.dst_addr_xy = gd54xx->blt.dst_addr + (gd54xx->blt.dst_y_pos * gd54xx->blt.dst_pitch);
+                gd54xx->blt.src_addr_xy = gd54xx->blt.src_addr + (gd54xx->blt.src_y_pos * gd54xx->blt.src_pitch);
+
+                if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND) {
+                    if (gd54xx->blt.x_count != 0)
+                        src_addr++;
+                } else
+                    src_addr = gd54xx->blt.src_addr_backup = gd54xx->blt.src_addr_backup +
+                                                             (gd54xx->blt.src_pitch * gd54xx->blt.dir);
+
+                src_addr &= gd54xx->vram_mask;
+                gd54xx->blt.src_addr_backup &= gd54xx->vram_mask;
+
+                gd54xx->blt.x_count = 0;
+
+                gd54xx->blt.height_internal--;
+                if (gd54xx->blt.height_internal == 0xffff)
+                    break;
+            }
         }
-
-        width--;
-        if (width == 0xffff) {
-            width    = gd54xx->blt.width;
-            dst_addr = gd54xx->blt.dst_addr_backup = gd54xx->blt.dst_addr_backup +
-                                                     (gd54xx->blt.dst_pitch * gd54xx->blt.dir);
-            gd54xx->blt.y_count                    = (gd54xx->blt.y_count + gd54xx->blt.dir) & 7;
+    } else {
+        while (count) {
+            src  = 0;
+            mask = 0;
 
             if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND) {
-                if (gd54xx->blt.x_count != 0)
+                mask  = svga->vram[src_addr & gd54xx->vram_mask] & (0x80 >> (gd54xx->blt.x_count / gd54xx->blt.pixel_width));
+                shift = (gd54xx->blt.x_count % gd54xx->blt.pixel_width);
+                src   = gd54xx_color_expand(gd54xx, mask, shift);
+            } else {
+                src = svga->vram[src_addr & gd54xx->vram_mask];
+                src_addr += gd54xx->blt.dir;
+                mask = 1;
+            }
+            count--;
+
+            dst                                                   = svga->vram[dst_addr & gd54xx->vram_mask];
+            svga->changedvram[(dst_addr & gd54xx->vram_mask) >> 12] = changeframecount;
+
+            gd54xx_rop(gd54xx, &dst, &dst, (const uint8_t *) &src);
+
+            if ((gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND) && (gd54xx->blt.modeext & CIRRUS_BLTMODEEXT_COLOREXPINV))
+                mask = !mask;
+
+            /* This handles 8bpp and 16bpp non-color-expanding transparent comparisons. */
+            if ((gd54xx->blt.mode & CIRRUS_BLTMODE_TRANSPARENTCOMP) &&
+                !(gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND) &&
+                ((gd54xx->blt.mode & CIRRUS_BLTMODE_PIXELWIDTHMASK) <= CIRRUS_BLTMODE_PIXELWIDTH16) &&
+                (src != ((gd54xx->blt.trans_mask >> (shift << 3)) & 0xff)))
+                mask = 0;
+
+            if (((gd54xx->blt.width - width) >= gd54xx->blt.pattern_x) &&
+                !((gd54xx->blt.mode & CIRRUS_BLTMODE_TRANSPARENTCOMP) && !mask))
+                svga->vram[dst_addr & gd54xx->vram_mask] = dst;
+
+            dst_addr += gd54xx->blt.dir;
+            gd54xx->blt.x_count++;
+
+            if (gd54xx->blt.x_count == x_max) {
+                gd54xx->blt.x_count = 0;
+                if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND)
                     src_addr++;
-            } else
-                src_addr = gd54xx->blt.src_addr_backup = gd54xx->blt.src_addr_backup +
-                                                         (gd54xx->blt.src_pitch * gd54xx->blt.dir);
+            }
 
-            dst_addr &= gd54xx->vram_mask;
-            gd54xx->blt.dst_addr_backup &= gd54xx->vram_mask;
-            src_addr &= gd54xx->vram_mask;
-            gd54xx->blt.src_addr_backup &= gd54xx->vram_mask;
+            width--;
+            if (width == 0xffff) {
+                width    = gd54xx->blt.width;
+                dst_addr = gd54xx->blt.dst_addr_backup = gd54xx->blt.dst_addr_backup +
+                                                         (gd54xx->blt.dst_pitch * gd54xx->blt.dir);
+                gd54xx->blt.y_count                    = (gd54xx->blt.y_count + gd54xx->blt.dir) & 7;
 
-            gd54xx->blt.x_count = 0;
+                if (gd54xx->blt.mode & CIRRUS_BLTMODE_COLOREXPAND) {
+                    if (gd54xx->blt.x_count != 0)
+                        src_addr++;
+                } else
+                    src_addr = gd54xx->blt.src_addr_backup = gd54xx->blt.src_addr_backup +
+                                                             (gd54xx->blt.src_pitch * gd54xx->blt.dir);
 
-            gd54xx->blt.height_internal--;
-            if (gd54xx->blt.height_internal == 0xffff) {
-                break;
+                dst_addr &= gd54xx->vram_mask;
+                gd54xx->blt.dst_addr_backup &= gd54xx->vram_mask;
+                src_addr &= gd54xx->vram_mask;
+                gd54xx->blt.src_addr_backup &= gd54xx->vram_mask;
+
+                gd54xx->blt.x_count = 0;
+
+                gd54xx->blt.height_internal--;
+                if (gd54xx->blt.height_internal == 0xffff)
+                    break;
             }
         }
     }
 
     /* Count exhausted, stuff still left to blit. */
     gd54xx_reset_blit(gd54xx);
+
+    if ((svga->crtc[0x27] == CIRRUS_ID_CLGD5480) &&
+        ((gd54xx->blt.modeext & (CIRRUS_BLTMODEEXT_XY_POSITION_SPEC | CIRRUS_BLTMODEEXT_COMMAND_LIST)) == (CIRRUS_BLTMODEEXT_XY_POSITION_SPEC | CIRRUS_BLTMODEEXT_COMMAND_LIST))) {
+        if (gd54xx->blt.blit_list_continue) {
+            gd54xx->blt.cmd_list_backup += 0x10;
+            gd54xx->blt.cmd_list_dword[0] = *(uint32_t *)&vram[gd54xx->blt.cmd_list_backup & gd54xx->vram_mask];
+            gd54xx->blt.cmd_list_dword[1] = *(uint32_t *)&vram[(gd54xx->blt.cmd_list_backup + 4) & gd54xx->vram_mask];
+            gd54xx->blt.cmd_list_dword[2] = *(uint32_t *)&vram[(gd54xx->blt.cmd_list_backup + 8) & gd54xx->vram_mask];
+            gd54xx->blt.cmd_list_dword[3] = *(uint32_t *)&vram[(gd54xx->blt.cmd_list_backup + 12) & gd54xx->vram_mask];
+            gd54xx->blt.blit_list_continue = !(gd54xx->blt.cmd_list_dword[0] & (1 << 31));
+
+            gd54xx_command_list_blit(-1, gd54xx, svga);
+        }
+    }
 }
 
 static void
@@ -4115,10 +4880,11 @@ cl_pci_write(UNUSED(int func), int addr, UNUSED(int len), uint8_t val, void *pri
             if ((val & PCI_COMMAND_MEM) && (gd54xx->vgablt_base != 0x00000000) && (gd54xx->vgablt_base < 0xfff00000))
                 mem_mapping_set_addr(&gd54xx->vgablt_mapping, gd54xx->vgablt_base, 0x1000);
             if ((gd54xx->pci_regs[PCI_REG_COMMAND] & PCI_COMMAND_MEM) && (gd54xx->pci_regs[0x30] & 0x01)) {
-                uint32_t addr = (gd54xx->pci_regs[0x32] << 16) | (gd54xx->pci_regs[0x33] << 24);
-                mem_mapping_set_addr(&gd54xx->bios_rom.mapping, addr, 0x8000);
+                uint32_t biosaddr = (gd54xx->pci_regs[0x32] << 16) | (gd54xx->pci_regs[0x33] << 24);
+                mem_mapping_set_addr(&gd54xx->bios_rom.mapping, biosaddr, 0x8000);
             } else
                 mem_mapping_disable(&gd54xx->bios_rom.mapping);
+
             gd543x_recalc_mapping(gd54xx);
             break;
 
@@ -4129,6 +4895,7 @@ cl_pci_write(UNUSED(int func), int addr, UNUSED(int len), uint8_t val, void *pri
              */
             if (svga->crtc[0x27] == CIRRUS_ID_CLGD5480)
                 val &= 0xfe;
+
             gd54xx->lfb_base = val << 24;
             gd543x_recalc_mapping(gd54xx);
             break;
@@ -4330,7 +5097,7 @@ gd54xx_init(const device_t *info)
 
         case CIRRUS_ID_CLGD5422:
             if (local & 0x100) {
-                romfn1 = BIOS_GD5422_BOCA_ISA_PATH_1; 
+                romfn1 = BIOS_GD5422_BOCA_ISA_PATH_1;
                 romfn2 = BIOS_GD5422_BOCA_ISA_PATH_2;
             }
             else


### PR DESCRIPTION
Summary
=======
This fixes buggy graphics with Windows 9x 5480 drivers.

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
[Cirrus GD5480 manual](https://dn710208.ca.archive.org/0/items/gd-5480-tr/GD5480TR.PDF)
