### PR TITLE
ES1688 improvements

### DIFF
--- a/src/include/86box/snd_sb.h
+++ b/src/include/86box/snd_sb.h
@@ -205,6 +205,7 @@ typedef struct sb_t {
     uint16_t gameport_addr;
 
     uint8_t  ess_scr_locked;
+    uint8_t  es1688_rsk_enable;
     uint8_t  es188x_readseq_state;
     uint8_t  es188x_readseq_mode;
     uint16_t es188x_dsp_addr;

--- a/src/include/86box/snd_sb_dsp.h
+++ b/src/include/86box/snd_sb_dsp.h
@@ -196,6 +196,9 @@ typedef struct sb_dsp_t {
     /* ESS ES188x IRQ mode */
     uint8_t  es188x_irq_mode;
 
+    /* ChipChat */
+    uint8_t  is_chipchat;
+
     mpu_t *mpu;
 } sb_dsp_t;
 

--- a/src/include/86box/sound.h
+++ b/src/include/86box/sound.h
@@ -238,6 +238,7 @@ extern const device_t ess_688_device;
 extern const device_t ess_ess0100_pnp_device;
 extern const device_t ess_ess0968_pnp_688_device;
 extern const device_t ess_1688_device;
+extern const device_t ess_1688_compaq_device;
 extern const device_t ess_ess0102_pnp_device;
 extern const device_t ess_ess0968_pnp_device;
 extern const device_t ess_soundpiper_16_mca_device;

--- a/src/machine/m_at_socket3_pci.c
+++ b/src/machine/m_at_socket3_pci.c
@@ -1234,7 +1234,7 @@ machine_at_pl4600c_init(const machine_t *model)
         device_add(&gd5430_onboard_pci_device);
 
     if (sound_card_current[0] == SOUND_INTERNAL)
-        device_add(&ess_1688_device);
+        machine_snd = device_add(machine_get_snd_device(machine));
 
     if (fdc_current[0] == FDC_INTERNAL) {
         fdd_set_turbo(0, 1);

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -12175,7 +12175,7 @@ const machine_t machines[] = {
         .kbd_device               = NULL,
         .fdc_device               = NULL,
         .vid_device               = &gd5430_onboard_pci_device,
-        .snd_device               = &ess_1688_device, /* Onboard variant not yet emulated */
+        .snd_device               = &ess_1688_compaq_device,
         .net_device               = NULL,
         .aliases                  = { "MiTAC/Trigon PL4600C", "" }
     },
@@ -14871,7 +14871,7 @@ const machine_t machines[] = {
         .kbd_device               = NULL,
         .fdc_device               = NULL,
         .vid_device               = &s3_trio64_onboard_pci_device,
-        .snd_device               = &ess_1688_device, /* Onboard variant not yet emulated */
+        .snd_device               = &ess_1688_compaq_device,
         .net_device               = NULL,
         .aliases                  = { "MiTAC/Trigon PL5600D-I", "" }
     },

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -3739,7 +3739,7 @@ ess_chipchat_mca_write(const uint16_t port, uint8_t val, void *priv)
 {
     sb_t *ess = (sb_t *) priv;
 
-    if (port < 0x102)
+    if ((port < 0x102) || (port == 0x103))
         return;
 
     sb_log("ess_chipchat_mca_write: port=%04x val=%02x\n", port, val);
@@ -5382,6 +5382,8 @@ ess_x688_mca_init(UNUSED(const device_t *info))
         mca_add(ess_x688_mca_read, ess_chipchat_mca_write, sb_mcv_feedb, NULL, ess);
         ess->pos_regs[0] = 0x50;
         ess->pos_regs[1] = 0x51;
+        ess->pos_regs[3] = 0x50;
+        ess->dsp.is_chipchat = 1;
     } else {
         mca_add(ess_x688_mca_read, ess_soundpiper_mca_write, sb_mcv_feedb, NULL, ess);
         ess->pos_regs[0] = 0x30;

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -1986,7 +1986,7 @@ ess_mixer_write(uint16_t addr, uint8_t val, void *priv)
 
                 case 0x40:
                     if (ess->dsp.sb_subtype >= SB_SUBTYPE_ESS_ES1688) {
-                        if ((ess->dsp.sb_subtype >= SB_SUBTYPE_ESS_ES1788) && (val & 0x04)) {
+                        if (((ess->dsp.sb_subtype >= SB_SUBTYPE_ESS_ES1788) || ess->es1688_rsk_enable) && (val & 0x04)) {
                             mixer->regs[0x40] = val & 0xfb;
                             ess_rsk_reset(ess);
                             break;
@@ -5138,6 +5138,7 @@ ess_x688_init(UNUSED(const device_t *info))
     const uint16_t ide_base = ide_ctrl & 0x0fff;
     const uint16_t ide_side = ide_base + 0x0206;
     const uint16_t ide_irq  = ide_ctrl >> 12;
+    const uint8_t  is_compaq = (info->local >> 4);
 
     fm_driver_get(info->local ? FM_ESFM : FM_YMF262, &ess->opl);
 
@@ -5151,46 +5152,49 @@ ess_x688_init(UNUSED(const device_t *info))
     ess_mixer_reset(ess);
 
     /* DSP I/O handler is activated in sb_dsp_setaddr */
-    io_sethandler(addr, 0x0004,
-                  ess->opl.read, NULL, NULL,
-                  ess->opl.write, NULL, NULL,
-                  ess->opl.priv);
-    io_sethandler(addr + 8, 0x0002,
-                  ess->opl.read, NULL, NULL,
-                  ess->opl.write, NULL, NULL,
-                  ess->opl.priv);
-    io_sethandler(addr + 8, 0x0002,
-                  ess_fm_midi_read, NULL, NULL,
-                  ess_fm_midi_write, NULL, NULL,
-                  ess);
-    io_sethandler(0x0388, 0x0004,
-                  ess->opl.read, NULL, NULL,
-                  ess->opl.write, NULL, NULL,
-                  ess->opl.priv);
-    io_sethandler(0x0388, 0x0004,
-                  ess_fm_midi_read, NULL, NULL,
-                  ess_fm_midi_write, NULL, NULL,
-                  ess);
+    if (!is_compaq) {
+        io_sethandler(addr, 0x0004,
+                      ess->opl.read, NULL, NULL,
+                      ess->opl.write, NULL, NULL,
+                      ess->opl.priv);
+        io_sethandler(addr + 8, 0x0002,
+                      ess->opl.read, NULL, NULL,
+                      ess->opl.write, NULL, NULL,
+                      ess->opl.priv);
+        io_sethandler(addr + 8, 0x0002,
+                      ess_fm_midi_read, NULL, NULL,
+                      ess_fm_midi_write, NULL, NULL,
+                      ess);
+        io_sethandler(0x0388, 0x0004,
+                      ess->opl.read, NULL, NULL,
+                      ess->opl.write, NULL, NULL,
+                      ess->opl.priv);
+        io_sethandler(0x0388, 0x0004,
+                      ess_fm_midi_read, NULL, NULL,
+                      ess_fm_midi_write, NULL, NULL,
+                      ess);
 
-    io_sethandler(addr + 2, 0x0004,
-                  ess_base_read, NULL, NULL,
-                  ess_base_write, NULL, NULL,
-                  ess);
-    io_sethandler(addr + 6, 0x0001,
-                  ess_base_read, NULL, NULL,
-                  ess_base_write, NULL, NULL,
-                  ess);
-    io_sethandler(addr + 0x0a, 0x0006,
-                  ess_base_read, NULL, NULL,
-                  ess_base_write, NULL, NULL,
-                  ess);
+        io_sethandler(addr + 2, 0x0004,
+                      ess_base_read, NULL, NULL,
+                      ess_base_write, NULL, NULL,
+                      ess);
+        io_sethandler(addr + 6, 0x0001,
+                      ess_base_read, NULL, NULL,
+                      ess_base_write, NULL, NULL,
+                      ess);
+        io_sethandler(addr + 0x0a, 0x0006,
+                      ess_base_read, NULL, NULL,
+                      ess_base_write, NULL, NULL,
+                      ess);
+    }
 
     ess->mixer_enabled = 1;
     ess->mixer_ess.regs[0x40] = 0x0a;
-    io_sethandler(addr + 4, 0x0002,
-                  ess_mixer_read, NULL, NULL,
-                  ess_mixer_write, NULL, NULL,
-                  ess);
+    if (!is_compaq)
+        io_sethandler(addr + 4, 0x0002,
+                      ess_mixer_read, NULL, NULL,
+                      ess_mixer_write, NULL, NULL,
+                      ess);
     sound_add_handler(sb_get_buffer_ess, ess);
     music_add_handler(sb_get_music_buffer_ess, ess);
     sound_set_cd_audio_filter(ess_filter_cd_audio, ess);
@@ -5223,6 +5227,22 @@ ess_x688_init(UNUSED(const device_t *info))
         other_ide_present++;
 
         ess->has_ide = 1;
+    }
+
+    if (is_compaq) { /* Enable Read-Sequence-Key mode */
+        ess->opl_pnp_addr = 0x388;
+        ess->es188x_readseq_state = 0;
+        ess->es188x_dsp_addr      = 0;
+        ess->es1688_rsk_enable    = 1;
+        sb_dsp_setaddr(&ess->dsp, 0);
+        io_sethandler(0x220, 0x0001, ess_rsk_read, NULL, NULL, NULL, NULL, NULL, ess);
+        io_sethandler(0x229, 0x0001, ess_rsk_read, NULL, NULL, NULL, NULL, NULL, ess);
+        io_sethandler(0x22b, 0x0001, ess_rsk_read, NULL, NULL, NULL, NULL, NULL, ess);
+        io_sethandler(0x22d, 0x0001, ess_rsk_read, NULL, NULL, NULL, NULL, NULL, ess);
+        io_sethandler(0x22f, 0x0001, ess_rsk_read, NULL, NULL, NULL, NULL, NULL, ess);
+        io_sethandler(0x230, 0x0001, ess_rsk_read, NULL, NULL, NULL, NULL, NULL, ess);
+        io_sethandler(0x240, 0x0001, ess_rsk_read, NULL, NULL, NULL, NULL, NULL, ess);
+        io_sethandler(0x250, 0x0001, ess_rsk_read, NULL, NULL, NULL, NULL, NULL, ess);
     }
 
     return ess;
@@ -8108,6 +8128,20 @@ const device_t ess_1688_device = {
     .internal_name = "ess_es1688",
     .flags         = DEVICE_ISA16,
     .local         = 1,
+    .init          = ess_x688_init,
+    .close         = sb_close,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = sb_speed_changed,
+    .force_redraw  = NULL,
+    .config        = ess_1688_config
+};
+
+const device_t ess_1688_compaq_device = {
+    .name          = "ESS AudioDrive ES1688 (Compaq)",
+    .internal_name = "ess_es1688_compaq",
+    .flags         = DEVICE_ISA16,
+    .local         = 0x11,
     .init          = ess_x688_init,
     .close         = sb_close,
     .reset         = NULL,

--- a/src/sound/snd_sb_dsp.c
+++ b/src/sound/snd_sb_dsp.c
@@ -1136,7 +1136,7 @@ sb_ess_write_reg(sb_dsp_t *dsp, const uint8_t reg, uint8_t data)
 
         case 0xB1:                                              /* Legacy Audio Interrupt Control */
             ESSreg(reg) = (ESSreg(reg) & 0x0F) + (data & 0xF0); // lower 4 bits not writeable
-            if (!dsp->es188x_irq_mode || dsp->sb_subtype <= SB_SUBTYPE_ESS_ES1788) {
+            if ((!dsp->es188x_irq_mode || dsp->sb_subtype <= SB_SUBTYPE_ESS_ES1788) && !dsp->is_chipchat) {
                 switch (data & 0x0C) {
                     default:
                         break;
@@ -1160,21 +1160,23 @@ sb_ess_write_reg(sb_dsp_t *dsp, const uint8_t reg, uint8_t data)
         case 0xB2: /* DRQ Control */
             chg         = ESSreg(reg) ^ data;
             ESSreg(reg) = (ESSreg(reg) & 0x0F) + (data & 0xF0); // lower 4 bits not writeable
-            switch (data & 0x0C) {
-                default:
-                    break;
-                case 0x00:
-                    dsp->sb_8_dmanum = -1;
-                    break;
-                case 0x04:
-                    dsp->sb_8_dmanum = 0;
-                    break;
-                case 0x08:
-                    dsp->sb_8_dmanum = 1;
-                    break;
-                case 0x0C:
-                    dsp->sb_8_dmanum = 3;
-                    break;
+            if (!dsp->is_chipchat) {
+                switch (data & 0x0C) {
+                    default:
+                        break;
+                    case 0x00:
+                        dsp->sb_8_dmanum = -1;
+                        break;
+                    case 0x04:
+                        dsp->sb_8_dmanum = 0;
+                        break;
+                    case 0x08:
+                        dsp->sb_8_dmanum = 1;
+                        break;
+                    case 0x0C:
+                        dsp->sb_8_dmanum = 3;
+                        break;
+                }
             }
             sb_dsp_log("Legacy Audio DRQ control=%d, chg=%02x.\n", dsp->sb_8_dmanum, chg);
             sb_ess_update_irq_drq_readback_regs(dsp, false);


### PR DESCRIPTION
Summary
=======
Make the following improvements to the ES1688:
- Implement a variant with Read-Sequence-Key software base I/O configuration and give it to the Compaq Presario 7100 machines making the audio I/O port selection in the CMOS setup functional
- On the ChipChat card make POS register 3 return a value of 50h and make the ESS DSP commands B1/B2h (set IRQ/DMA) not change the IRQ or DMA (they are fixed values on this card) fixing the Windows 3.1 drivers (both the 1.55 drivers from 1996 and the newer 1997 drivers)

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
- ESS AudioDrive ES1688 Product Brief: http://hackipedia.org/browse.cgi/Computer/Platform/PC%2c%20IBM%20compatible/Sound%20and%20Music/Creative%20Labs/Sound%20Blaster/ESS%20AudioDrive%20%28compatible%29/ES1688%20AudioDrive%20%28Product%20Brief%29%2epdf