### PR TITLE
Fix Matrox Millennium II AGP identified as PCI variant

### DIFF
--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -38,11 +38,12 @@
 #include <86box/vid_svga.h>
 #include <86box/vid_svga_render.h>
 
-#define ROM_MILLENNIUM    "roms/video/matrox/matrox2064wr2.BIN"
-#define ROM_MILLENNIUM_II "roms/video/matrox/matrox2164wpc.BIN"
-#define ROM_MYSTIQUE      "roms/video/matrox/MYSTIQUE.VBI"
-#define ROM_MYSTIQUE_220  "roms/video/matrox/Myst220_66-99mhz.vbi"
-#define ROM_G100          "roms/video/matrox/productiva8mbsdr.BIN"
+#define ROM_MILLENNIUM        "roms/video/matrox/matrox2064wr2.BIN"
+#define ROM_MILLENNIUM_II     "roms/video/matrox/matrox2164wpc.BIN"
+#define ROM_MILLENNIUM_II_AGP "roms/video/matrox/877-3.bin"
+#define ROM_MYSTIQUE          "roms/video/matrox/MYSTIQUE.VBI"
+#define ROM_MYSTIQUE_220      "roms/video/matrox/Myst220_66-99mhz.vbi"
+#define ROM_G100              "roms/video/matrox/productiva8mbsdr.BIN"
 
 #define FIFO_SIZE        65536
 #define FIFO_MASK        (FIFO_SIZE - 1)
@@ -6361,7 +6362,7 @@ mystique_pci_read(UNUSED(int func), int addr, UNUSED(int len), void *priv)
                 if (mystique->type == MGA_G100)
                     ret = 0x01;
                 else
-                    ret = (mystique->type == MGA_2164W) ? 0x1b : ((mystique->type == MGA_2064W) ? 0x19 : 0x1a);
+                    ret = (mystique->type == MGA_2164W) ? (mystique->is_agp ? 0x1f : 0x1b) : ((mystique->type == MGA_2064W) ? 0x19 : 0x1a);
                 break; /*MGA*/
             case 0x03:
                 if (mystique->type == MGA_G100)
@@ -6790,7 +6791,7 @@ mystique_init(const device_t *info)
     if (mystique->type == MGA_2064W)
         romfn = ROM_MILLENNIUM;
     else if (mystique->type == MGA_2164W)
-        romfn = ROM_MILLENNIUM_II;
+        romfn = mystique->is_agp ? ROM_MILLENNIUM_II_AGP : ROM_MILLENNIUM_II;
     else if (mystique->type == MGA_1064SG)
         romfn = ROM_MYSTIQUE;
     else if (mystique->type == MGA_G100)
@@ -6971,6 +6972,12 @@ millennium_ii_available(void)
     return rom_present(ROM_MILLENNIUM_II);
 }
 
+static int
+millennium_ii_agp_available(void)
+{
+    return rom_present(ROM_MILLENNIUM_II_AGP);
+}
+
 #ifdef USE_G100
 static int
 matrox_g100_available(void)
@@ -7103,7 +7110,7 @@ const device_t millennium_ii_agp_device = {
     .init          = mystique_init,
     .close         = mystique_close,
     .reset         = NULL,
-    .available     = millennium_ii_available,
+    .available     = millennium_ii_agp_available,
     .speed_changed = mystique_speed_changed,
     .force_redraw  = mystique_force_redraw,
     .config        = millennium_ii_config


### PR DESCRIPTION
Summary
=======

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/492
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
https://theretroweb.com/drivers/1779 (Includes ROM)
