### PR TITLE
qt: Make automatic dialog box pauses user-configurable

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -149,6 +149,7 @@ uint64_t instru_run_ms                          = 0;
 #endif
 int      clear_flash                            = 0;
 int      auto_paused                            = 0;
+int      auto_diag_paused                       = 0;
 
 /* Configuration values. */
 int      window_remember;
@@ -205,6 +206,7 @@ int      video_fullscreen_scale_maximized       = 0;              /* (C) Whether
                                                                          also apply when maximized. */
 int      do_auto_pause                          = 0;              /* (C) Auto-pause the emulator on focus
                                                                          loss */
+int      do_auto_diag_pause                     = 0;              /* (C) Auto-pause the emulator on dialog boxes */
 int      force_constant_mouse                   = 0;              /* (C) Force constant updating of the mouse */
 int      hook_enabled                           = 1;              /* (C) Keyboard hook is enabled */
 int      test_mode                              = 0;              /* (C) Test mode */

--- a/src/config.c
+++ b/src/config.c
@@ -378,6 +378,7 @@ load_general(void)
     }
 
     do_auto_pause = ini_section_get_int(cat, "do_auto_pause", 0);
+    do_auto_diag_pause = ini_section_get_int(cat, "do_auto_diag_pause", 0);
     force_constant_mouse = ini_section_get_int(cat, "force_constant_mouse", 0);
     fdd_sounds_enabled = ini_section_get_int(cat, "fdd_sounds_enabled", 1);
 
@@ -2626,6 +2627,7 @@ config_load(void)
         machine              = machine_get_machine_from_internal_name("ibmpc");
         dpi_scale            = 1;
         do_auto_pause        = 0;
+        do_auto_diag_pause   = 0;
         force_constant_mouse = 0;
 
         cpu_override_interpreter = 0;
@@ -2991,6 +2993,11 @@ save_general(void)
         ini_section_set_int(cat, "do_auto_pause", do_auto_pause);
     else
         ini_section_delete_var(cat, "do_auto_pause");
+
+    if (do_auto_diag_pause)
+        ini_section_set_int(cat, "do_auto_diag_pause", do_auto_diag_pause);
+    else
+        ini_section_delete_var(cat, "do_auto_diag_pause");
 
     if (video_gl_input_scale != 1.0) {
         ini_section_set_double(cat, "video_gl_input_scale", video_gl_input_scale);

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -231,6 +231,7 @@ extern int    fixed_size_x;
 extern int    fixed_size_y;
 extern int    sound_muted;                  /* (C) Is sound muted? */
 extern int    do_auto_pause;                /* (C) Auto-pause the emulator on focus loss */
+extern int    do_auto_diag_pause;           /* (C) Auto-pause the emulator on dialog boxes */
 extern int    auto_paused;
 extern int    force_constant_mouse;         /* (C) Force constant updating of the mouse */
 extern double mouse_sensitivity;            /* (G) Mouse sensitivity scale */

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -775,6 +775,9 @@ MainWindow::MainWindow(QWidget *parent)
     if (do_auto_pause > 0) {
         ui->actionAuto_pause->setChecked(true);
     }
+    if (do_auto_diag_pause > 0) {
+        ui->actionAutoDiag_pause->setChecked(true);
+    }
     if (force_constant_mouse > 0) {
         ui->actionUpdate_mouse_every_CPU_frame->setChecked(true);
     }
@@ -1671,7 +1674,7 @@ MainWindow::eventFilter(QObject *receiver, QEvent *event)
         }
     }
 
-    if (receiver == this) {
+    if (receiver == this && do_auto_diag_pause > 0) {
         static auto curdopause = dopause;
         if (event->type() == QEvent::WindowBlocked) {
             window_blocked = true;
@@ -2107,6 +2110,14 @@ MainWindow::on_actionAuto_pause_triggered()
 {
     do_auto_pause ^= 1;
     ui->actionAuto_pause->setChecked(do_auto_pause > 0 ? true : false);
+    config_save();
+}
+
+void
+MainWindow::on_actionAutoDiag_pause_triggered()
+{
+    do_auto_diag_pause ^= 1;
+    ui->actionAutoDiag_pause->setChecked(do_auto_diag_pause > 0 ? true : false);
     config_save();
 }
 

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -89,6 +89,7 @@ private slots:
     void on_actionSettings_triggered();
     void on_actionExit_triggered();
     void on_actionAuto_pause_triggered();
+    void on_actionAutoDiag_pause_triggered();
     void on_actionUpdate_mouse_every_CPU_frame_triggered();
     void on_actionPause_triggered();
     void on_actionToggle_OSD_triggered();

--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -76,6 +76,7 @@
     <addaction name="actionUpdate_mouse_every_CPU_frame"/>
     <addaction name="separator"/>
     <addaction name="actionAuto_pause"/>
+    <addaction name="actionAutoDiag_pause" />
     <addaction name="actionPause"/>
     <addaction name="separator"/>
     <addaction name="actionFullscreen"/>
@@ -310,6 +311,14 @@
    <property name="text">
     <string>&amp;Auto-pause on focus loss</string>
    </property>
+  </action>
+  <action name="actionAutoDiag_pause">
+    <property name="checkable">
+      <bool>true</bool>
+    </property>
+    <property name="text">
+      <string>Auto-pause on &amp;dialog boxes</string>
+    </property>
   </action>
   <action name="actionKeyboard_requires_capture">
    <property name="checkable">


### PR DESCRIPTION
Summary
=======
The automatic pause for dialog boxes (including file selectors, sound gain, reset confirmation) is made user configurable here, especially if stopping the VM’s time is undesired, and that can be critical for certain server tasks.

Translatable UI strings aren't included here, and I'm open for the menu item to be renamed anyway.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/