### PR TITLE
qt: Grab the mouse for XInput2 capture

### DIFF
--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -161,7 +161,16 @@ RendererStack::RendererStack(QWidget *parent, int monitor_index)
     if (!stricmp(mousedata.mouse_type, "xinput2")) {
         extern void xinput2_init();
         extern void xinput2_exit();
+        extern void xinput2_set_grab_widget(QWidget *widget);
+        extern void xinput2_mouse_capture(QWindow *window);
+        extern void xinput2_mouse_uncapture();
         xinput2_init();
+        if (monitor_index == 0) {
+            setAttribute(Qt::WA_NativeWindow, true);
+            xinput2_set_grab_widget(this);
+        }
+        this->mouse_capture_func = xinput2_mouse_capture;
+        this->mouse_uncapture_func = xinput2_mouse_uncapture;
         this->mouse_exit_func = xinput2_exit;
     }
 #endif

--- a/src/qt/xinput2_mouse.cpp
+++ b/src/qt/xinput2_mouse.cpp
@@ -19,6 +19,9 @@
 #include <QProcess>
 #include <QApplication>
 #include <QAbstractNativeEventFilter>
+#include <QCursor>
+#include <QWidget>
+#include <QWindow>
 
 #include "qt_mainwindow.hpp"
 extern MainWindow *main_window;
@@ -43,6 +46,7 @@ extern "C" {
 
 static Display            *disp       = nullptr;
 static QThread            *procThread = nullptr;
+static QWidget            *grab_widget = nullptr;
 static XIEventMask         ximask;
 static std::atomic<bool>   exitfromthread  = false;
 static std::atomic<double> xi2_mouse_abs_x = 0, xi2_mouse_abs_y = 0;
@@ -241,11 +245,36 @@ common_motion:
 void
 xinput2_exit()
 {
+    if (grab_widget)
+        grab_widget->releaseMouse();
     if (!exitthread) {
         exitthread = true;
-        procThread->wait(5000);
-        procThread->terminate();
+        if (procThread) {
+            procThread->wait(5000);
+            procThread->terminate();
+        }
     }
+}
+
+void
+xinput2_set_grab_widget(QWidget *widget)
+{
+    grab_widget = widget;
+}
+
+void
+xinput2_mouse_capture(QWindow *window)
+{
+    Q_UNUSED(window);
+    if (grab_widget)
+        grab_widget->grabMouse(QCursor(Qt::BlankCursor));
+}
+
+void
+xinput2_mouse_uncapture()
+{
+    if (grab_widget)
+        grab_widget->releaseMouse();
 }
 
 void


### PR DESCRIPTION
Summary
=======
Fix XInput2 mouse capture on X11 by synchronizing 86Box's internal mouse capture state with a real Qt mouse grab.

The XInput2 backend already handled relative mouse movement through XI2 raw motion events and repeatedly warped the host pointer back to the emulator window. However, it did not also grab the pointer at the Qt/X11 windowing layer. This meant that 86Box could be in its internal `mouse_capture` state while the host desktop still owned the real pointer. In that state, the pointer could still move outside the emulator window, trigger hover state in host applications, and send clicks to windows behind or next to 86Box.

This change registers the primary `RendererStack` widget with the XInput2 backend and wires the backend into the existing `mouse_capture_func` / `mouse_uncapture_func` callbacks. When 86Box enters mouse capture, the backend now calls `QWidget::grabMouse()` with a blank cursor. When capture is released, or when the XInput2 backend exits, it calls `releaseMouse()`.

The grab is intentionally not acquired at XInput2 initialization time. It is only acquired when 86Box enters mouse capture, and released when 86Box leaves mouse capture. This keeps the existing capture lifecycle intact and avoids grabbing the host pointer while the emulator is not captured.

The original symptom was easiest to observe in a HiDPI X11 setup, where the host pointer could visibly escape or interact with host windows while the guest was supposed to own mouse input. This patch does not add any extra HiDPI coordinate conversion or otherwise change the existing mouse coordinate path. Once the actual capture semantics are fixed at the Qt/X11 layer, the issue is resolved without changing the XInput2 raw motion scaling or the existing pointer warp coordinates.

The change is intentionally small:

* XInput2 capture now uses `grabMouse(QCursor(Qt::BlankCursor))`.
* XInput2 uncapture and exit now release the Qt mouse grab.
* The XInput2 backend keeps the existing raw motion and pointer warp behavior.
* A null check was added before waiting on `procThread`, preserving the existing exit behavior while avoiding a null dereference if initialization exits early.

AI assistance was used while preparing this change. GPT-5.5 was used to implement the patch, and Claude Opus 4.6 was used for code review.

Checklist
=========
* [x] Closes #7253
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
Issue report:

* https://github.com/86Box/86Box/issues/7253

Relevant Qt API:

* https://doc.qt.io/qt-6/qwidget.html#grabMouse
* https://doc.qt.io/qt-6/qwidget.html#releaseMouse
