### PR TITLE
Move the auto-pause options to global config

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -149,7 +149,7 @@ uint64_t instru_run_ms                          = 0;
 #endif
 int      clear_flash                            = 0;
 int      auto_paused                            = 0;
-int      auto_diag_paused                       = 0;
+int      auto_dialog_paused                     = 0;
 
 /* Configuration values. */
 int      window_remember;
@@ -204,9 +204,9 @@ int      open_dir_usr_path                      = 0;              /* (G) default
                                                                          of usr_path */
 int      video_fullscreen_scale_maximized       = 0;              /* (C) Whether fullscreen scaling settings
                                                                          also apply when maximized. */
-int      do_auto_pause                          = 0;              /* (C) Auto-pause the emulator on focus
+int      do_auto_pause                          = 0;              /* (G) Auto-pause the emulator on focus
                                                                          loss */
-int      do_auto_diag_pause                     = 0;              /* (C) Auto-pause the emulator on dialog boxes */
+int      do_auto_dialog_pause                   = 0;              /* (G) Auto-pause the emulator on dialog boxes */
 int      force_constant_mouse                   = 0;              /* (C) Force constant updating of the mouse */
 int      hook_enabled                           = 1;              /* (C) Keyboard hook is enabled */
 int      test_mode                              = 0;              /* (C) Test mode */

--- a/src/config.c
+++ b/src/config.c
@@ -142,6 +142,9 @@ load_global_emulator(void)
 
     open_dir_usr_path = ini_section_get_int(cat, "open_dir_usr_path", 0);
 
+    do_auto_pause        = ini_section_get_int(cat, "do_auto_pause", 0);
+    do_auto_dialog_pause = ini_section_get_int(cat, "do_auto_dialog_pause", 0);
+
     confirm_reset = ini_section_get_int(cat, "confirm_reset", 1);
     confirm_exit  = ini_section_get_int(cat, "confirm_exit", 1);
     confirm_save  = ini_section_get_int(cat, "confirm_save", 1);
@@ -377,8 +380,6 @@ load_general(void)
         ini_section_delete_var(cat, "window_coordinates");
     }
 
-    do_auto_pause = ini_section_get_int(cat, "do_auto_pause", 0);
-    do_auto_diag_pause = ini_section_get_int(cat, "do_auto_diag_pause", 0);
     force_constant_mouse = ini_section_get_int(cat, "force_constant_mouse", 0);
     fdd_sounds_enabled = ini_section_get_int(cat, "fdd_sounds_enabled", 1);
 
@@ -2627,7 +2628,7 @@ config_load(void)
         machine              = machine_get_machine_from_internal_name("ibmpc");
         dpi_scale            = 1;
         do_auto_pause        = 0;
-        do_auto_diag_pause   = 0;
+        do_auto_dialog_pause = 0;
         force_constant_mouse = 0;
 
         cpu_override_interpreter = 0;
@@ -2755,6 +2756,16 @@ save_global_emulator(void)
         ini_section_set_int(cat, "open_dir_usr_path", open_dir_usr_path);
     else
         ini_section_delete_var(cat, "open_dir_usr_path");
+
+    if (do_auto_pause)
+        ini_section_set_int(cat, "do_auto_pause", do_auto_pause);
+    else
+        ini_section_delete_var(cat, "do_auto_pause");
+
+    if (do_auto_dialog_pause)
+        ini_section_set_int(cat, "do_auto_dialog_pause", do_auto_dialog_pause);
+    else
+        ini_section_delete_var(cat, "do_auto_dialog_pause");
 
     if (confirm_reset != 1)
         ini_section_set_int(cat, "confirm_reset", confirm_reset);
@@ -2988,16 +2999,6 @@ save_general(void)
         ini_section_set_int(cat, "video_gl_vsync", video_vsync);
     else
         ini_section_delete_var(cat, "video_gl_vsync");
-
-    if (do_auto_pause)
-        ini_section_set_int(cat, "do_auto_pause", do_auto_pause);
-    else
-        ini_section_delete_var(cat, "do_auto_pause");
-
-    if (do_auto_diag_pause)
-        ini_section_set_int(cat, "do_auto_diag_pause", do_auto_diag_pause);
-    else
-        ini_section_delete_var(cat, "do_auto_diag_pause");
 
     if (video_gl_input_scale != 1.0) {
         ini_section_set_double(cat, "video_gl_input_scale", video_gl_input_scale);

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -230,8 +230,8 @@ extern int    hard_reset_pending;
 extern int    fixed_size_x;
 extern int    fixed_size_y;
 extern int    sound_muted;                  /* (C) Is sound muted? */
-extern int    do_auto_pause;                /* (C) Auto-pause the emulator on focus loss */
-extern int    do_auto_diag_pause;           /* (C) Auto-pause the emulator on dialog boxes */
+extern int    do_auto_pause;                /* (G) Auto-pause the emulator on focus loss */
+extern int    do_auto_dialog_pause;         /* (G) Auto-pause the emulator on dialog boxes */
 extern int    auto_paused;
 extern int    force_constant_mouse;         /* (C) Force constant updating of the mouse */
 extern double mouse_sensitivity;            /* (G) Mouse sensitivity scale */

--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -1700,7 +1700,10 @@ msgstr ""
 msgid "Fast"
 msgstr ""
 
-msgid "&Auto-pause on focus loss"
+msgid "Auto-pause on focus loss"
+msgstr ""
+
+msgid "Auto-pause on dialog boxes"
 msgstr ""
 
 msgid "WinBox is no longer supported"

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -1716,8 +1716,11 @@ msgstr "Lenta"
 msgid "Fast"
 msgstr "Rápida"
 
-msgid "&Auto-pause on focus loss"
-msgstr "Pa&usa automàtica en perdre el focus"
+msgid "Auto-pause on focus loss"
+msgstr "Pausa automàtica en perdre el focus"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "El WinBox ja no és suportat"

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -1752,8 +1752,11 @@ msgstr "Pomalý"
 msgid "Fast"
 msgstr "Rychlý"
 
-msgid "&Auto-pause on focus loss"
-msgstr "&Automatická pauza při ztrátě zaměření okna"
+msgid "Auto-pause on focus loss"
+msgstr "Automatická pauza při ztrátě zaměření okna"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "WinBox již není podporován"

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -1716,8 +1716,8 @@ msgstr "Langsam"
 msgid "Fast"
 msgstr "Schnell"
 
-msgid "&Auto-pause on focus loss"
-msgstr "&Auto-Pause bei Fokusverlust"
+msgid "Auto-pause on focus loss"
+msgstr "Auto-Pause bei Fokusverlust"
 
 msgid "WinBox is no longer supported"
 msgstr "Der WinBox Manager wird nicht mehr unterstützt"

--- a/src/qt/languages/el-GR.po
+++ b/src/qt/languages/el-GR.po
@@ -1730,8 +1730,11 @@ msgstr "Αργό"
 msgid "Fast"
 msgstr "Γρήγορο"
 
-msgid "&Auto-pause on focus loss"
-msgstr "&Αυτόματο-πάγωμα σε απώλεια εστίασης"
+msgid "Auto-pause on focus loss"
+msgstr "Αυτόματο-πάγωμα σε απώλεια εστίασης"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "Το WinBox δεν υποστηρίζεται πλέον"

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -1717,8 +1717,11 @@ msgstr "Lenta"
 msgid "Fast"
 msgstr "Rápida"
 
-msgid "&Auto-pause on focus loss"
-msgstr "Pa&usa automática al perder el foco"
+msgid "Auto-pause on focus loss"
+msgstr "Pausa automática al perder el foco"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "WinBox ya no recibe soporte"

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -1720,8 +1720,11 @@ msgstr "Hidas"
 msgid "Fast"
 msgstr "Nopea"
 
-msgid "&Auto-pause on focus loss"
-msgstr "&Automaattinen tauko tarkennuksen hävitessä"
+msgid "Auto-pause on focus loss"
+msgstr "Automaattinen tauko tarkennuksen hävitessä"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "WinBoxia ei enää tueta"

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -1734,8 +1734,11 @@ msgstr "Lent"
 msgid "Fast"
 msgstr "Rapide"
 
-msgid "&Auto-pause on focus loss"
-msgstr "Pa&use automatique à perte de focus"
+msgid "Auto-pause on focus loss"
+msgstr "Pause automatique à perte de focus"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "WinBox n'est plus pris en charge"

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -1723,8 +1723,11 @@ msgstr "Spori"
 msgid "Fast"
 msgstr "Brzi"
 
-msgid "&Auto-pause on focus loss"
-msgstr "&Automatska pauza pri gubitku fokusa"
+msgid "Auto-pause on focus loss"
+msgstr "Automatska pauza pri gubitku fokusa"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "WinBox seviše ne podržava"

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -1754,8 +1754,11 @@ msgstr "Lenta"
 msgid "Fast"
 msgstr "Veloce"
 
-msgid "&Auto-pause on focus loss"
-msgstr "Pa&usa automatica se in secondo piano"
+msgid "Auto-pause on focus loss"
+msgstr "Pausa automatica se in secondo piano"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "WinBox non è più supportato"

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -1712,8 +1712,11 @@ msgstr "遅い"
 msgid "Fast"
 msgstr "速い"
 
-msgid "&Auto-pause on focus loss"
-msgstr "フォーカスが奪われると自動停止(&A)"
+msgid "Auto-pause on focus loss"
+msgstr "フォーカスが奪われると自動停止"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "WinBoxはサポート終了"

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -1760,8 +1760,11 @@ msgstr "느림"
 msgid "Fast"
 msgstr "빠름"
 
-msgid "&Auto-pause on focus loss"
-msgstr "창 포커스를 잃으면 자동 일시 중지(&A)"
+msgid "Auto-pause on focus loss"
+msgstr "창 포커스를 잃으면 자동 일시 중지"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "WinBox는 더 이상 지원되지 않습니다"

--- a/src/qt/languages/nb-NO.po
+++ b/src/qt/languages/nb-NO.po
@@ -1717,8 +1717,11 @@ msgstr "Sakte"
 msgid "Fast"
 msgstr "Rask"
 
-msgid "&Auto-pause on focus loss"
-msgstr "&Automatisk pause ved tap av fokus"
+msgid "Auto-pause on focus loss"
+msgstr "Automatisk pause ved tap av fokus"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "WinBox støttes ikke lenger"

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -1711,8 +1711,11 @@ msgstr "Langzaam"
 msgid "Fast"
 msgstr "Snel"
 
-msgid "&Auto-pause on focus loss"
-msgstr "&Autopauze bij focusverlies"
+msgid "Auto-pause on focus loss"
+msgstr "Autopauze bij focusverlies"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "WinBox wordt niet langer ondersteund"

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -1722,8 +1722,11 @@ msgstr "Powolny"
 msgid "Fast"
 msgstr "Szybki"
 
-msgid "&Auto-pause on focus loss"
-msgstr "&Automatyczna pauza po utracie fokusu"
+msgid "Auto-pause on focus loss"
+msgstr "Automatyczna pauza po utracie fokusu"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "WinBox nie jest już wspierany"

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -1718,8 +1718,11 @@ msgstr "Lento"
 msgid "Fast"
 msgstr "Rápido"
 
-msgid "&Auto-pause on focus loss"
-msgstr "Pa&usa automática ao perder o foco"
+msgid "Auto-pause on focus loss"
+msgstr "Pausa automática ao perder o foco"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "O WinBox não é mais suportado"

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -1719,8 +1719,11 @@ msgstr "Lento"
 msgid "Fast"
 msgstr "Rápido"
 
-msgid "&Auto-pause on focus loss"
-msgstr "Pa&usa automática na perda de focagem"
+msgid "Auto-pause on focus loss"
+msgstr "Pausa automática na perda de focagem"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "O WinBox não é mais suportado"

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -1729,8 +1729,11 @@ msgstr "Медленный"
 msgid "Fast"
 msgstr "Быстрый"
 
-msgid "&Auto-pause on focus loss"
-msgstr "&Автопауза при потере фокуса"
+msgid "Auto-pause on focus loss"
+msgstr "Автопауза при потере фокуса"
+
+msgid "Auto-pause on dialog boxes"
+msgstr "Автопауза при показе диалоговых окон"
 
 msgid "WinBox is no longer supported"
 msgstr "WinBox больше не поддерживается"

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -1722,8 +1722,11 @@ msgstr "Pomalý"
 msgid "Fast"
 msgstr "Rýchly"
 
-msgid "&Auto-pause on focus loss"
-msgstr "&Automatická pauza pri strate fokusu okna"
+msgid "Auto-pause on focus loss"
+msgstr "Automatická pauza pri strate fokusu okna"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "WinBox už nie je podporovaný"

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -1728,8 +1728,11 @@ msgstr "Počasni"
 msgid "Fast"
 msgstr "Hitri"
 
-msgid "&Auto-pause on focus loss"
-msgstr "&Samodejni premor ob izgubi fokusa"
+msgid "Auto-pause on focus loss"
+msgstr "Samodejni premor ob izgubi fokusa"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "WinBox ni več podprt"

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -1716,8 +1716,11 @@ msgstr "Långsam"
 msgid "Fast"
 msgstr "Snabb"
 
-msgid "&Auto-pause on focus loss"
-msgstr "&Pausa automatiskt när fokus tappas"
+msgid "Auto-pause on focus loss"
+msgstr "Pausa automatiskt när fokus tappas"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "WinBox stöds inte längre"

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -1728,8 +1728,11 @@ msgstr "Yavaş"
 msgid "Fast"
 msgstr "Hızlı"
 
-msgid "&Auto-pause on focus loss"
-msgstr "Pencereye &odaklanmıyorken duraklat"
+msgid "Auto-pause on focus loss"
+msgstr "Pencereye odaklanmıyorken duraklat"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "WinBox artık desteklenmemektedir"

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -1724,8 +1724,11 @@ msgstr "Повільний"
 msgid "Fast"
 msgstr "Швидкий"
 
-msgid "&Auto-pause on focus loss"
-msgstr "&Автопауза при втраті фокусу"
+msgid "Auto-pause on focus loss"
+msgstr "Автопауза при втраті фокусу"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "WinBox більше не підтримується"

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -1712,8 +1712,11 @@ msgstr "Chậm"
 msgid "Fast"
 msgstr "Nhanh"
 
-msgid "&Auto-pause on focus loss"
-msgstr "&Tự tạm dừng giả lập khi không tập trung ở cửa sổ"
+msgid "Auto-pause on focus loss"
+msgstr "Tự tạm dừng giả lập khi không tập trung ở cửa sổ"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "WinBox không còn được hỗ trợ"

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -1716,8 +1716,11 @@ msgstr "慢"
 msgid "Fast"
 msgstr "快"
 
-msgid "&Auto-pause on focus loss"
-msgstr "失去焦点时自动暂停(&A)"
+msgid "Auto-pause on focus loss"
+msgstr "失去焦点时自动暂停"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "WinBox 不再受支持"

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -1720,8 +1720,11 @@ msgstr "慢"
 msgid "Fast"
 msgstr "快"
 
-msgid "&Auto-pause on focus loss"
-msgstr "失去焦點時自動暫停(&A)"
+msgid "Auto-pause on focus loss"
+msgstr "失去焦點時自動暫停"
+
+msgid "Auto-pause on dialog boxes"
+msgstr ""
 
 msgid "WinBox is no longer supported"
 msgstr "不再支援 WinBox"

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -772,12 +772,6 @@ MainWindow::MainWindow(QWidget *parent)
     if (force_43 > 0) {
         ui->actionForce_4_3_display_ratio->setChecked(true);
     }
-    if (do_auto_pause > 0) {
-        ui->actionAuto_pause->setChecked(true);
-    }
-    if (do_auto_diag_pause > 0) {
-        ui->actionAutoDiag_pause->setChecked(true);
-    }
     if (force_constant_mouse > 0) {
         ui->actionUpdate_mouse_every_CPU_frame->setChecked(true);
     }
@@ -1674,7 +1668,7 @@ MainWindow::eventFilter(QObject *receiver, QEvent *event)
         }
     }
 
-    if (receiver == this && do_auto_diag_pause > 0) {
+    if (receiver == this && do_auto_dialog_pause > 0) {
         static auto curdopause = dopause;
         if (event->type() == QEvent::WindowBlocked) {
             window_blocked = true;
@@ -2102,22 +2096,6 @@ MainWindow::on_actionForce_4_3_display_ratio_triggered()
                 renderers[i]->onResize(renderers[i]->width(), renderers[i]->height());
         }
     }
-    config_save();
-}
-
-void
-MainWindow::on_actionAuto_pause_triggered()
-{
-    do_auto_pause ^= 1;
-    ui->actionAuto_pause->setChecked(do_auto_pause > 0 ? true : false);
-    config_save();
-}
-
-void
-MainWindow::on_actionAutoDiag_pause_triggered()
-{
-    do_auto_diag_pause ^= 1;
-    ui->actionAutoDiag_pause->setChecked(do_auto_diag_pause > 0 ? true : false);
     config_save();
 }
 

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -1668,19 +1668,22 @@ MainWindow::eventFilter(QObject *receiver, QEvent *event)
         }
     }
 
-    if (receiver == this && do_auto_dialog_pause > 0) {
+    if (receiver == this) {
         static auto curdopause = dopause;
         if (event->type() == QEvent::WindowBlocked) {
             window_blocked = true;
-            curdopause     = dopause;
             mouse_was_captured = (mouse_capture != 0);
-            plat_pause(isNonPause ? dopause : (isShowMessage ? 2 : 1));
+            if (do_auto_dialog_pause > 0) {
+                curdopause = dopause;
+                plat_pause(isNonPause ? dopause : (isShowMessage ? 2 : 1));
+            }
             if (mouse_was_captured)
                 emit setMouseCapture(false);
             releaseKeyboard();
         } else if (event->type() == QEvent::WindowUnblocked) {
             window_blocked = false;
-            plat_pause(curdopause);
+            if (do_auto_dialog_pause > 0)
+                plat_pause(curdopause);
             if (mouse_was_captured) {
                 emit setMouseCapture(true);
             }

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -88,8 +88,6 @@ private slots:
     void on_actionFullscreen_triggered();
     void on_actionSettings_triggered();
     void on_actionExit_triggered();
-    void on_actionAuto_pause_triggered();
-    void on_actionAutoDiag_pause_triggered();
     void on_actionUpdate_mouse_every_CPU_frame_triggered();
     void on_actionPause_triggered();
     void on_actionToggle_OSD_triggered();

--- a/src/qt/qt_mainwindow.ui
+++ b/src/qt/qt_mainwindow.ui
@@ -75,8 +75,6 @@
     <addaction name="separator"/>
     <addaction name="actionUpdate_mouse_every_CPU_frame"/>
     <addaction name="separator"/>
-    <addaction name="actionAuto_pause"/>
-    <addaction name="actionAutoDiag_pause" />
     <addaction name="actionPause"/>
     <addaction name="separator"/>
     <addaction name="actionFullscreen"/>
@@ -303,22 +301,6 @@
    <property name="text">
     <string>&amp;Update mouse every CPU frame</string>
    </property>
-  </action>
-  <action name="actionAuto_pause">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>&amp;Auto-pause on focus loss</string>
-   </property>
-  </action>
-  <action name="actionAutoDiag_pause">
-    <property name="checkable">
-      <bool>true</bool>
-    </property>
-    <property name="text">
-      <string>Auto-pause on &amp;dialog boxes</string>
-    </property>
   </action>
   <action name="actionKeyboard_requires_capture">
    <property name="checkable">

--- a/src/qt/qt_preferencesemulator.cpp
+++ b/src/qt/qt_preferencesemulator.cpp
@@ -64,6 +64,8 @@ PreferencesEmulator::PreferencesEmulator(QWidget *parent)
     ui->comboBoxLanguage->model()->sort(Qt::AscendingOrder);
 
     ui->openDirUsrPath->setChecked(open_dir_usr_path > 0);
+    ui->checkBoxAutoPause->setChecked(do_auto_pause);
+    ui->checkBoxAutoDialogPause->setChecked(do_auto_dialog_pause);
     ui->checkBoxConfirmExit->setChecked(confirm_exit);
     ui->checkBoxConfirmSave->setChecked(confirm_save);
     ui->checkBoxConfirmHardReset->setChecked(confirm_reset);
@@ -90,6 +92,8 @@ PreferencesEmulator::save()
     auto size               = main_window->centralWidget()->size();
     lang_id                 = ui->comboBoxLanguage->currentData().toInt();
     open_dir_usr_path       = ui->openDirUsrPath->isChecked() ? 1 : 0;
+    do_auto_pause           = ui->checkBoxAutoPause->isChecked() ? 1 : 0;
+    do_auto_dialog_pause    = ui->checkBoxAutoDialogPause->isChecked() ? 1 : 0;
     confirm_exit            = ui->checkBoxConfirmExit->isChecked() ? 1 : 0;
     confirm_save            = ui->checkBoxConfirmSave->isChecked() ? 1 : 0;
     confirm_reset           = ui->checkBoxConfirmHardReset->isChecked() ? 1 : 0;

--- a/src/qt/qt_preferencesemulator.ui
+++ b/src/qt/qt_preferencesemulator.ui
@@ -88,27 +88,41 @@
       </widget>
      </item>
      <item row="2" column="0" colspan="2">
+      <widget class="QCheckBox" name="checkBoxAutoPause">
+       <property name="text">
+        <string>Auto-pause on focus loss</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0" colspan="2">
+      <widget class="QCheckBox" name="checkBoxAutoDialogPause">
+       <property name="text">
+        <string>Auto-pause on dialog boxes</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0" colspan="2">
       <widget class="QCheckBox" name="checkBoxConfirmSave">
        <property name="text">
         <string>Ask for confirmation before saving settings</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="0" colspan="2">
+     <item row="5" column="0" colspan="2">
       <widget class="QCheckBox" name="checkBoxConfirmExit">
        <property name="text">
         <string>Ask for confirmation before quitting</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="0" colspan="2">
+     <item row="6" column="0" colspan="2">
       <widget class="QCheckBox" name="checkBoxConfirmHardReset">
        <property name="text">
         <string>Ask for confirmation before hard resetting</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="0" colspan="2">
+     <item row="7" column="0" colspan="2">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
           <widget class="QGroupBox" name="groupBox">

--- a/src/qt/qt_vmmanager_listviewdelegate.cpp
+++ b/src/qt/qt_vmmanager_listviewdelegate.cpp
@@ -73,13 +73,13 @@ VMManagerListViewDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     QIcon status_icon;
     switch (process_status) {
         case VMManagerSystem::ProcessStatus::Running:
+        case VMManagerSystem::ProcessStatus::RunningWaiting:
             status_icon = running_icon;
             break;
         case VMManagerSystem::ProcessStatus::Stopped:
             status_icon = stopped_icon;
             break;
         case VMManagerSystem::ProcessStatus::PausedWaiting:
-        case VMManagerSystem::ProcessStatus::RunningWaiting:
         case VMManagerSystem::ProcessStatus::Paused:
             status_icon = paused_icon;
             break;

--- a/src/qt/qt_vmmanager_system.cpp
+++ b/src/qt/qt_vmmanager_system.cpp
@@ -1217,8 +1217,9 @@ VMManagerSystem::processStatusToString(VMManagerSystem::ProcessStatus status)
         case VMManagerSystem::ProcessStatus::Paused:
             return tr("Paused");
         case VMManagerSystem::ProcessStatus::PausedWaiting:
-        case VMManagerSystem::ProcessStatus::RunningWaiting:
             return QString("%1 (%2)").arg(tr("Paused"), tr("Waiting"));
+        case VMManagerSystem::ProcessStatus::RunningWaiting:
+            return QString("%1 (%2)").arg(tr("Running"), tr("Waiting"));
         default:
             return tr("Unknown Status");
     }


### PR DESCRIPTION
Summary
=======
Move the two auto-pause options from the menu and machine configs to the preferences dialog and the global config.

Drive-by: Fix machine status in the manager showing up as "Paused (Waiting)" when auto-pause on dialogs is disabled, as well as getting stuck in "Waiting" state after the machine is unpaused if auto-pause on dialogs is disabled.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set

References
==========
N/A