### PR TITLE
Translations update from 86Box Weblate

### DIFF
--- a/src/qt/languages/el-GR.po
+++ b/src/qt/languages/el-GR.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2026-06-07 22:01+0000\n"
+"PO-Revision-Date: 2026-06-13 14:23+0000\n"
 "Last-Translator: DimMan88 <dimman88@hotmail.com>\n"
 "Language-Team: Greek <https://weblate.86box.net/projects/86box/86box/el/>\n"
 "Language: el-GR\n"
@@ -1734,7 +1734,7 @@ msgid "Auto-pause on focus loss"
 msgstr "Αυτόματο-πάγωμα σε απώλεια εστίασης"
 
 msgid "Auto-pause on dialog boxes"
-msgstr ""
+msgstr "Αυτόματη παύση στα παράθυρα διαλόγου"
 
 msgid "WinBox is no longer supported"
 msgstr "Το WinBox δεν υποστηρίζεται πλέον"


### PR DESCRIPTION
Translations update from [86Box Weblate](https://weblate.86box.net) for [86Box/86Box](https://weblate.86box.net/projects/86box/86box/).



Current translation status:

![Weblate translation status](https://weblate.86box.net/widget/86box/86box/horizontal-auto.svg)