### PR TITLE
ESS ES186x: DSP DRQ Control register's lower nibble is read-only

### DIFF
--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -2022,7 +2022,7 @@ ess_mixer_write(uint16_t addr, uint8_t val, void *priv)
                                 ess->ess_dac2_freq = (int) (397700UL / (128ul - val));
                         } else {
                             if (val & 0x80)
-                                ess->ess_dac2_freq = (int) (768000UL / (128ul - val));
+                                ess->ess_dac2_freq = (int) (768000UL / (256ul - val));
                             else
                                 ess->ess_dac2_freq = (int) (793800UL / (128ul - val));
                         }

--- a/src/sound/snd_sb_dsp.c
+++ b/src/sound/snd_sb_dsp.c
@@ -1138,7 +1138,7 @@ sb_ess_write_reg(sb_dsp_t *dsp, const uint8_t reg, uint8_t data)
         case 0xB2: /* DRQ Control */
             chg         = ESSreg(reg) ^ data;
             ESSreg(reg) = (ESSreg(reg) & 0x0F) + (data & 0xF0); // lower 4 bits not writeable
-            if (!dsp->is_chipchat) {
+            if (!dsp->is_chipchat && (dsp->sb_subtype < SB_SUBTYPE_ESS_ES1868)) {
                 switch (data & 0x0C) {
                     default:
                         break;

--- a/src/sound/snd_sb_dsp.c
+++ b/src/sound/snd_sb_dsp.c
@@ -1058,7 +1058,7 @@ sb_ess_write_reg(sb_dsp_t *dsp, const uint8_t reg, uint8_t data)
                 ESSreg(reg) = data;
                 if ((dsp->sb_subtype == SB_SUBTYPE_ESS_ES1869) && dsp->es1869_divider_mode) {
                     if (data & 0x80)
-                        dsp->sb_freq = (int) (768000UL / (128ul - data));
+                        dsp->sb_freq = (int) (768000UL / (256ul - data));
                     else
                         dsp->sb_freq = (int) (793800UL / (128ul - data));
                 } else {


### PR DESCRIPTION
Summary
=======
Make the ESS AudioDrive ES1868/1869 DSP's DRQ Control (B2h) register's lower nibble read-only matching the datasheet. This fixes Impulse Tracker failing to start playback on these cards.

Also fix incorrect sample rate calculation on the ES1869 when using the 768KHz clock source.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
