### PR TITLE
Add missing string for translation

### DIFF
--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -2999,6 +2999,9 @@ msgstr ""
 msgid "Toggle on-screen display"
 msgstr ""
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr ""
 

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -3015,6 +3015,9 @@ msgstr "Alterna silenci"
 msgid "Toggle on-screen display"
 msgstr ""
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr "Fitxers de text"
 

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -3057,6 +3057,9 @@ msgstr "Přepnout ztišení"
 msgid "Toggle on-screen display"
 msgstr ""
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr "Textové soubory"
 

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -3015,6 +3015,9 @@ msgstr "Stummschaltung umschalten"
 msgid "Toggle on-screen display"
 msgstr ""
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr "Textdateien"
 

--- a/src/qt/languages/el-GR.po
+++ b/src/qt/languages/el-GR.po
@@ -3057,6 +3057,9 @@ msgstr "Εναλλαγή σίγασης"
 msgid "Toggle on-screen display"
 msgstr "Ενεργοποίηση απεικόνισης στην οθόνη"
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr "Αρχεία κειμένου"
 

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -3016,6 +3016,9 @@ msgstr "Alternar silencio"
 msgid "Toggle on-screen display"
 msgstr ""
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr "Archivos de texto"
 

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -3019,6 +3019,9 @@ msgstr "Mykistä"
 msgid "Toggle on-screen display"
 msgstr ""
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr "Tekstitiedostot"
 

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -3033,6 +3033,9 @@ msgstr "Activer/désactiver le mode silencieux"
 msgid "Toggle on-screen display"
 msgstr ""
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr "Fichiers texte"
 

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -3022,6 +3022,9 @@ msgstr "Uključi/isključi zvuk"
 msgid "Toggle on-screen display"
 msgstr ""
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr "Tekstualne datoteke"
 

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -3081,6 +3081,9 @@ msgstr "Attiva/disattiva audio"
 msgid "Toggle on-screen display"
 msgstr ""
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr "File di testo"
 

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -3011,6 +3011,9 @@ msgstr "ミュートを切り替える"
 msgid "Toggle on-screen display"
 msgstr ""
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr "テキストファイル"
 

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -3080,6 +3080,9 @@ msgstr "음소거 켜기/끄기"
 msgid "Toggle on-screen display"
 msgstr "화면 정보 표시 켜기/끄기"
 
+msgid "Toggle &on-screen display"
+msgstr "화면 정보 표시 켜기/끄기(&O)"
+
 msgid "Text files"
 msgstr "텍스트 파일"
 

--- a/src/qt/languages/nb-NO.po
+++ b/src/qt/languages/nb-NO.po
@@ -3016,6 +3016,9 @@ msgstr "Veksle lyd av/på"
 msgid "Toggle on-screen display"
 msgstr ""
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr "Tekstfiler"
 

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -3010,6 +3010,9 @@ msgstr "Geluiddemping omschakelen"
 msgid "Toggle on-screen display"
 msgstr ""
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr "Tekstbestanden"
 

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -3021,6 +3021,9 @@ msgstr "Przełącz wyciszenie"
 msgid "Toggle on-screen display"
 msgstr "Przełącz menu ekranowe"
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr "Pliki tekstowe"
 

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -3017,6 +3017,9 @@ msgstr "Alternar mudo"
 msgid "Toggle on-screen display"
 msgstr "Alternar exibição do OSD"
 
+msgid "Toggle &on-screen display"
+msgstr "Alternar exibição do &OSD"
+
 msgid "Text files"
 msgstr "Arquivos de texto"
 

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -3018,6 +3018,9 @@ msgstr "Alternar o estado silenciado"
 msgid "Toggle on-screen display"
 msgstr ""
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr "Ficheiros de texto"
 

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -3028,6 +3028,9 @@ msgstr "Выключить/включить звук"
 msgid "Toggle on-screen display"
 msgstr "Показать/скрыть экранное меню"
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr "Текстовые файлы"
 

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -3021,6 +3021,9 @@ msgstr "Prepnúť stlmenie"
 msgid "Toggle on-screen display"
 msgstr ""
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr "Textové súbory"
 

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -3027,6 +3027,9 @@ msgstr "Preklopti tišino"
 msgid "Toggle on-screen display"
 msgstr ""
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr "Datoteke z besedilom"
 

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -3015,6 +3015,9 @@ msgstr "Tysta"
 msgid "Toggle on-screen display"
 msgstr ""
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr "Textfiler"
 

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -3049,6 +3049,9 @@ msgstr "Sessize almayı ayarla"
 msgid "Toggle on-screen display"
 msgstr "Ekran üstü göstergeyi ayarla"
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr "Metin dosyaları"
 

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -3023,6 +3023,9 @@ msgstr "Переключити беззвучний режим"
 msgid "Toggle on-screen display"
 msgstr ""
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr "Текстові файли"
 

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -3011,6 +3011,9 @@ msgstr "Bật/tắt tiếng"
 msgid "Toggle on-screen display"
 msgstr "Bật/tắt thông tin trên màn hình"
 
+msgid "Toggle &on-screen display"
+msgstr ""
+
 msgid "Text files"
 msgstr "Tập tin văn bản"
 

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -3015,6 +3015,9 @@ msgstr "切换静音"
 msgid "Toggle on-screen display"
 msgstr "切换屏幕显示 (OSD)"
 
+msgid "Toggle &on-screen display"
+msgstr "切换屏幕显示 (OSD)(&O)"
+
 msgid "Text files"
 msgstr "文本文件"
 

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -3024,6 +3024,9 @@ msgstr "切換靜音"
 msgid "Toggle on-screen display"
 msgstr "切換 OSD"
 
+msgid "Toggle &on-screen display"
+msgstr "切換 OSD(&O)"
+
 msgid "Text files"
 msgstr "文字檔案"
 


### PR DESCRIPTION
Summary
=======
This PR adds the missing string for translation in the POT and PO files for the Toggle on-screen display main menu accelerator  item added by PR #7205

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
