### PR TITLE
osd: fix file explorer scaling issues

### DIFF
--- a/src/osd/osd_core.cpp
+++ b/src/osd/osd_core.cpp
@@ -120,14 +120,9 @@ float osd_core_layout_scale_for_output(int output_w, int output_h)
     return clamp_output_scale(std::min(x_scale, y_scale));
 }
 
-static float osd_scaled(float value)
+float osd_core_scaled(float value)
 {
     return (value > 0.0f) ? (value * osd_layout_scale) : value;
-}
-
-static ImVec2 osd_scaled_size(float width, float height)
-{
-    return ImVec2(osd_scaled(width), osd_scaled(height));
 }
 
 static void apply_layout_scale(void)
@@ -565,7 +560,7 @@ static bool draw_menu(void)
         activate_menu_item(menu_sel, &close_osd);
 
     ImGui::SetNextWindowPos(ImGui::GetMainViewport()->GetCenter(), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
-    ImGui::SetNextWindowSize(osd_scaled_size(320.0f, 0.0f), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(ImVec2(osd_core_scaled(320.0f), osd_core_scaled(0.0f)), ImGuiCond_Always);
 
     ImGui::Begin("86Box OSD", nullptr,
                  ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
@@ -642,7 +637,7 @@ static bool draw_log(void)
         show_main_menu();
 
     ImGui::SetNextWindowPos(ImGui::GetMainViewport()->GetCenter(), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
-    ImGui::SetNextWindowSize(osd_scaled_size(560.0f, 340.0f), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(ImVec2(osd_core_scaled(560.0f), osd_core_scaled(340.0f)), ImGuiCond_Always);
     ImGui::Begin("Log", nullptr,
                  ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
                  ImGuiWindowFlags_NoMove     | ImGuiWindowFlags_NoNav);

--- a/src/osd/osd_core.hpp
+++ b/src/osd/osd_core.hpp
@@ -19,6 +19,8 @@ typedef struct osd_host_t {
 
 void osd_core_set_host(const osd_host_t *host);
 
+float osd_core_scaled(float value);
+
 float osd_core_layout_scale_for_output(int output_w, int output_h);
 
 /* Shared OSD layout scale. Frontends may supply a backend-specific hint. */

--- a/src/osd/osd_explorer.cpp
+++ b/src/osd/osd_explorer.cpp
@@ -8,6 +8,8 @@
 
 #include "imgui.h"
 
+#include "osd_core.hpp"
+
 #ifdef USE_STD_FILESYSTEM
 #include <filesystem>
 namespace fs = std::filesystem;
@@ -226,7 +228,7 @@ OsdExplorer::Draw()
 
     ImGui::SetNextWindowPos(ImGui::GetMainViewport()->GetCenter(), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
 
-    ImGui::SetNextWindowSize(ImVec2(560, 380), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(ImVec2(osd_core_scaled(560.0f), osd_core_scaled(380.0f)), ImGuiCond_Always);
 
     const bool enter = ImGui::IsKeyPressed(ImGuiKey_Enter, false)
                     || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter, false);
@@ -235,12 +237,15 @@ OsdExplorer::Draw()
                  ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
                  ImGuiWindowFlags_NoMove);
 
-    const float label_column_width = 96.0f;
+    ImGui::BeginTable("##inputs", 2, ImGuiTableFlags_SizingStretchSame);
+    ImGui::TableSetupColumn("Label", ImGuiTableColumnFlags_WidthFixed);
+    ImGui::TableSetupColumn("Input", ImGuiTableColumnFlags_WidthStretch);
 
+    ImGui::TableNextRow();
+    ImGui::TableNextColumn();
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted("Filename");
-    ImGui::SameLine();
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (label_column_width - ImGui::CalcTextSize("Filename").x));
+    ImGui::TableNextColumn();
     ImGui::SetNextItemWidth(-FLT_MIN);
     if (focus_filename_input_ && focused_slot_ == FocusSlot::Filename) {
         ImGui::SetKeyboardFocusHere();
@@ -248,6 +253,7 @@ OsdExplorer::Draw()
     }
     if (ImGui::InputText("##filename", filename_input_.data(), filename_input_.size(), ImGuiInputTextFlags_EnterReturnsTrue)) {
         if (TryHandleFilenameInput(&result)) {
+            ImGui::EndTable();
             ImGui::End();
             return result;
         }
@@ -271,10 +277,11 @@ OsdExplorer::Draw()
     else
         snprintf(current_path_text.data(), current_path_text.size(), "%s", current_path_.string().c_str());
 
+    ImGui::TableNextRow();
+    ImGui::TableNextColumn();
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted("Current path");
-    ImGui::SameLine();
-    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (label_column_width - ImGui::CalcTextSize("Current path").x));
+    ImGui::TableNextColumn();
     ImGui::SetNextItemWidth(-FLT_MIN);
     if (focus_current_path_input_ && focused_slot_ == FocusSlot::CurrentPath) {
         ImGui::SetKeyboardFocusHere();
@@ -283,6 +290,8 @@ OsdExplorer::Draw()
     ImGui::InputText("##current_path", current_path_text.data(), current_path_text.size(), ImGuiInputTextFlags_ReadOnly);
     if (!tab && ImGui::IsItemFocused())
         focused_slot_ = FocusSlot::CurrentPath;
+
+    ImGui::EndTable();
 
     if (has_show_all_files_checkbox) {
         if (focus_show_all_files_ && focused_slot_ == FocusSlot::ShowAllFiles) {


### PR DESCRIPTION
Summary
=======
Scaling was not properly implemented in OSD File Explorer, making it hard to use depending on the resolution.
This PR fixes that.

**Before:**

<img width="1280" height="1099" alt="image" src="https://github.com/user-attachments/assets/9b1ebcb0-18f9-40be-8673-f4e2e49e45b9" />

**After:**

<img width="1280" height="1099" alt="image" src="https://github.com/user-attachments/assets/3ff56b00-0490-44a4-8f5c-66166b8bfb4e" />

Checklist
=========
* [x] Closes N/A
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [x] This pull request doesn't require changes to the ROM set
* [x] This pull request doesn't require changes to the asset set