### PR TITLE
Fix GDBSTUB not working when machine is started from manager

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -1363,8 +1363,6 @@ usage:
     if (lang_init)
         lang_id = lang_init;
 
-    gdbstub_init();
-
     /* All good! */
     return 1;
 }

--- a/src/machine/machine.c
+++ b/src/machine/machine.c
@@ -39,6 +39,7 @@
 #include <86box/isamem.h>
 #include <86box/isarom.h>
 #include <86box/pci.h>
+#include <86box/gdbstub.h>
 #include <86box/plat_unused.h>
 
 int bios_only = 0;
@@ -143,6 +144,15 @@ machine_init(void)
 
     machine_set_p1_default(machines[machine].kbc_p1);
     machine_set_ps2();
+
+    /* Create the GDB Stub socket before gdbstub_cpu_init looks for it.
+       This is done outside of machine_init_ex so we only occupy the socket
+       if we're actually starting a machine. */
+    static int gdbstub_started = 0;
+    if (!gdbstub_started) {
+        gdbstub_started = 1;
+        gdbstub_init();
+    }
 
     (void) machine_init_ex(machine);
 }


### PR DESCRIPTION
Summary
=======
GDBSTUB was broken when a machine is started from the VMManager (see discussion in https://github.com/86Box/86Box/discussions/7090)
The root cause was `gdbstub_init` getting invoked regardless of whether a machine is being run, which made VMManager listen to the stub port before any machine can start  
This PR fixes the issue by making sure `gdbstub_init` is only invoked if a machine is actually being started. The call is moved to `machine_init`, which is only invoked by `pc_reset_hard_init` while a machine is starting up

Checklist
=========
* [X] Closes issue mentioned in https://github.com/86Box/86Box/discussions/7090#discussioncomment-16792646
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
Claude Opus 4.8 assisted in discovering the root cause & initial patch, I then refined the fix to its current state