### PR TITLE
Fix segfault on riscv64

### DIFF
--- a/src/cpu/386_common.h
+++ b/src/cpu/386_common.h
@@ -539,7 +539,7 @@ fastreadl_fetch(uint32_t a)
             pccache2 = t;
             pccache  = a >> 12;
         }
-#    if (defined __amd64__ || defined _M_X64 || defined __aarch64__ || defined _M_ARM64)
+#    if (defined __amd64__ || defined _M_X64 || defined __aarch64__ || defined _M_ARM64 || (defined __riscv && __riscv_xlen == 64))
         return *((uint32_t *) (((uintptr_t) &pccache2[a] & 0x00000000ffffffffULL) | ((uintptr_t) &pccache2[0] & 0xffffffff00000000ULL)));
 #    else
         return AS_U32(pccache2[a]);


### PR DESCRIPTION
Summary
=======
It looks like the only thing stopping 86Box from working on riscv64 was a check in `src/cpu/386_common.h` that was checking if the host was 64-bit by looking for a fixed list of architectures. This just adds riscv64 to that list.

I tested this by installing Windows 95 RTM on an emulated 486SX-25 on both a riscv64 host (which now works) and an amd64 host (to make sure it still works). Dynarec was off on amd64 and is not supported on riscv64. I did not encounter any issues during the installation.

It might not be a bad idea to make the 64-bit check more generic so that it doesn't have to check against a fixed list like it currently does, but I'm not really skilled enough to be able to figure out a way to do that. If it was made more generic somehow, then 86Box would probably work on most if not all 64-bit little-endian ISAs.

No AI was used in the code change or in this message, I swear. I just write like that sometimes.

Checklist
=========
* [x] Closes #7325
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already (see [discussion 7326](https://github.com/86Box/86Box/discussions/7326))
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
(no references were needed)
