### PR TITLE
cmake presets: fix wrong value type

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,9 +11,9 @@
             "cacheVariables": {
                 "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/artifacts",
                 "CMAKE_EXPORT_COMPILE_COMMANDS": true,
-                "DEV_BRANCH": "OFF",
-                "NEW_DYNAREC": "OFF",
-                "QT": "ON"
+                "DEV_BRANCH": false,
+                "NEW_DYNAREC": false,
+                "QT": true
             },
             "generator": "Ninja",
             "hidden": true
@@ -43,7 +43,7 @@
             "name": "development",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",
-                "DEV_BRANCH": "ON"
+                "DEV_BRANCH": true
             },
             "inherits": "base"
         },
@@ -51,7 +51,7 @@
             "name": "dev_debug",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
-                "DEV_BRANCH": "ON"
+                "DEV_BRANCH": true
             },
             "inherits": "base"
         },
@@ -59,7 +59,7 @@
             "name": "ultra_debug",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "UltraDebug",
-                "DEV_BRANCH": "ON"
+                "DEV_BRANCH": true
             },
             "inherits": "base"
         },
@@ -70,9 +70,9 @@
             "binaryDir": "${sourceDir}/out/build/${presetName}",
             "cacheVariables": {
                 "CMAKE_TOOLCHAIN_FILE": "cmake/llvm-macos-aarch64.cmake",
-                "NEW_DYNAREC": "ON",
-                "QT": "ON",
-                "USE_QT6": "OFF",
+                "NEW_DYNAREC": true,
+                "QT": true,
+                "USE_QT6": false,
                 "Qt5_DIR": "/opt/homebrew/opt/qt@5/lib/cmake/Qt5",
                 "MOLTENVK_DIR": "/opt/homebrew/opt/molten-vk",
                 "Qt5LinguistTools_DIR": "/opt/homebrew/opt/qt@5/lib/cmake/Qt5LinguistTools",
@@ -88,9 +88,9 @@
             "binaryDir": "${sourceDir}/out/build/${presetName}",
             "cacheVariables": {
                 "CMAKE_TOOLCHAIN_FILE": "cmake/llvm-macos-aarch64.cmake",
-                "NEW_DYNAREC": "ON",
-                "QT": "ON",
-                "USE_QT6": "OFF",
+                "NEW_DYNAREC": true,
+                "QT": true,
+                "USE_QT6": false,
                 "Qt5_DIR": "/opt/homebrew/opt/qt@5/lib/cmake/Qt5",
                 "MOLTENVK_DIR": "/opt/homebrew/opt/molten-vk",
                 "Qt5LinguistTools_DIR": "/opt/homebrew/opt/qt@5/lib/cmake/Qt5LinguistTools",
@@ -108,7 +108,7 @@
             "generator": "Ninja",
             "binaryDir": "${sourceDir}/out/build/${presetName}",
             "cacheVariables": {
-                "NEW_DYNAREC": "ON",
+                "NEW_DYNAREC": true,
                 "CMAKE_BUILD_TYPE": "Debug",
                 "CMAKE_TOOLCHAIN_FILE": "cmake/flags-gcc-aarch64.cmake",
                 "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
@@ -124,7 +124,7 @@
             "generator": "Ninja",
             "binaryDir": "${sourceDir}/out/build/${presetName}",
             "cacheVariables": {
-                "NEW_DYNAREC": "ON",
+                "NEW_DYNAREC": true,
                 "CMAKE_BUILD_TYPE": "Release",
                 "CMAKE_TOOLCHAIN_FILE": "cmake/flags-gcc-aarch64.cmake",
                 "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}"


### PR DESCRIPTION
Summary
=======
CMakePresets.json incorrectly sets variable types to strings when it should be a bool, this ensures correct behavior in CMake GUI

Checklist
=========
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already

References
==========
No references needed, but feel free to see cmake documentation
