### PR TITLE
Machine & SIO changes (26/06/2026)

### DIFF
--- a/src/disk/hdc.c
+++ b/src/disk/hdc.c
@@ -97,13 +97,16 @@ static const struct {
     { &ide_vlb_device                       },
     { &ide_vlb_2ch_device                   },
     { &ide_opti611_vlb_device               },
+    { &ide_w83769f_vlb_device               }, /* TODO: to add implement W83759 IDE controller */
     /* PCI */
     { &ide_cmd640_pci_device                },
     { &ide_cmd646_ter_qua_device            },
     { &ide_cmd648_ter_qua_device            },
     { &ide_cmd649_ter_qua_device            },
+    { &ide_pc87410_device                   }, /* Found on Tekram DC-290N, a PCI IDE expansion card */
     { &ide_pci_device                       },
     { &ide_pci_2ch_device                   },
+    { &ide_w83769f_pci_device               }, /* PCI variant? TODO: to add implement W83759 IDE controller */
     { NULL                                  }
     // clang-format on
 };

--- a/src/disk/hdc.c
+++ b/src/disk/hdc.c
@@ -103,7 +103,6 @@ static const struct {
     { &ide_cmd646_ter_qua_device            },
     { &ide_cmd648_ter_qua_device            },
     { &ide_cmd649_ter_qua_device            },
-    { &ide_pc87410_device                   }, /* Found on Tekram DC-290N, a PCI IDE expansion card */
     { &ide_pci_device                       },
     { &ide_pci_2ch_device                   },
     { &ide_w83769f_pci_device               }, /* PCI variant? TODO: to add implement W83759 IDE controller */

--- a/src/disk/hdc_ide_pc87410.c
+++ b/src/disk/hdc_ide_pc87410.c
@@ -254,7 +254,7 @@ pc87410_init(const device_t *info)
 }
 
 const device_t ide_pc87410_device = {
-    .name          = "National Semiconductor PC87410 PCI IDE",
+    .name          = "National Semiconductor PC87410 PCI",
     .internal_name = "ide_pc87410",
     .flags         = DEVICE_PCI,
     .local         = 0,

--- a/src/disk/hdc_ide_pc87410.c
+++ b/src/disk/hdc_ide_pc87410.c
@@ -254,7 +254,7 @@ pc87410_init(const device_t *info)
 }
 
 const device_t ide_pc87410_device = {
-    .name          = "National Semiconductor PC87410 PCI",
+    .name          = "National Semiconductor PC87410 PCI IDE",
     .internal_name = "ide_pc87410",
     .flags         = DEVICE_PCI,
     .local         = 0,

--- a/src/floppy/fdc.c
+++ b/src/floppy/fdc.c
@@ -118,8 +118,10 @@ static fdc_cards_t fdc_cards[] = {
     { &fdc_monster_device        },
     { &fdc_at_device             },
     { &fdc_at_nsc_dp8473_device  },
-    { &fdc_at_nsc_device         }, /* TODO: PC87311 SIO & floppy controller */
+    { &fdc_at_nsc_device         },
+    { &fdc_at_nsc_pc87310_device }, /* TODO: PC87311/PC87312 SIO & floppy controller */
     { &fdc_at_smc_device         },
+    { &fdc_at_smc_661_device     }, /* TODO: FDC37C66xGT SIO & floppy controller */
     { &fdc_at_winbond_device     },
     { &fdc_xt_device             },
     { &fdc_xt_umc_um8398_device  },
@@ -2904,7 +2906,7 @@ const device_t fdc_at_actlow_device = {
 };
 
 const device_t fdc_at_smc_661_device = {
-    .name          = "PC/AT FDC (SM(s)C FDC37C661/2)",
+    .name          = "PC/AT FDC (SM(s)C FDC37C66x)",
     .internal_name = "fdc_at_smc",
     .flags         = 0,
     .local         = FDC_FLAG_AT | FDC_FLAG_SUPERIO | FDC_FLAG_SMC661,

--- a/src/floppy/fdc.c
+++ b/src/floppy/fdc.c
@@ -117,11 +117,12 @@ static fdc_cards_t fdc_cards[] = {
 #endif
     { &fdc_monster_device        },
     { &fdc_at_device             },
+    { &fdc_at_ali_device         }, /* No expansion cards use this chip but what if it's used as a standalone SIO/floppy controller? */
     { &fdc_at_nsc_dp8473_device  },
     { &fdc_at_nsc_device         },
-    { &fdc_at_nsc_pc87310_device }, /* TODO: PC87311/PC87312 SIO & floppy controller */
+    { &fdc_at_nsc_pc87310_device }, /* TODO: PC87311/PC87312 SIO/floppy controller */
     { &fdc_at_smc_device         },
-    { &fdc_at_smc_661_device     }, /* TODO: FDC37C66xGT SIO & floppy controller */
+    { &fdc_at_smc_661_device     }, /* TODO: FDC37C66xGT SIO/floppy controller */
     { &fdc_at_winbond_device     },
     { &fdc_xt_device             },
     { &fdc_xt_umc_um8398_device  },
@@ -2908,7 +2909,7 @@ const device_t fdc_at_actlow_device = {
 const device_t fdc_at_smc_661_device = {
     .name          = "PC/AT FDC (SM(s)C FDC37C66x)",
     .internal_name = "fdc_at_smc",
-    .flags         = 0,
+    .flags         = DEVICE_ISA,
     .local         = FDC_FLAG_AT | FDC_FLAG_SUPERIO | FDC_FLAG_SMC661,
     .init          = fdc_init,
     .close         = fdc_close,
@@ -2936,7 +2937,7 @@ const device_t fdc_at_smc_device = {
 const device_t fdc_at_ali_device = {
     .name          = "PC/AT FDC (ALi M512x/M1543C)",
     .internal_name = "fdc_at_ali",
-    .flags         = 0,
+    .flags         = DEVICE_ISA,
     .local         = FDC_FLAG_AT | FDC_FLAG_SUPERIO | FDC_FLAG_ALI,
     .init          = fdc_init,
     .close         = fdc_close,
@@ -2976,7 +2977,7 @@ const device_t fdc_at_nsc_device = {
 };
 
 const device_t fdc_at_nsc_pc87310_device = {
-    .name          = "PC/AT FDC (NSC PC87310)",
+    .name          = "PC/AT FDC (NSC PC8731x)",
     .internal_name = "fdc_at_nsc",
     .flags         = DEVICE_ISA,
     .local         = FDC_FLAG_AT | FDC_FLAG_MORE_TRACKS | FDC_FLAG_NSC | FDC_FLAG_NO_TDR,

--- a/src/floppy/fdc.c
+++ b/src/floppy/fdc.c
@@ -117,7 +117,7 @@ static fdc_cards_t fdc_cards[] = {
 #endif
     { &fdc_monster_device        },
     { &fdc_at_device             },
-    { &fdc_at_ali_device         }, /* No expansion cards use this chip but what if it's used as a standalone SIO/floppy controller? */
+    { &fdc_at_ali_device         }, /* No expansion cards use this chip but what if it's used for expansion cards as a standalone? */
     { &fdc_at_nsc_dp8473_device  },
     { &fdc_at_nsc_device         },
     { &fdc_at_nsc_pc87310_device }, /* TODO: PC87311/PC87312 SIO/floppy controller */

--- a/src/machine/m_at_slot2.c
+++ b/src/machine/m_at_slot2.c
@@ -80,21 +80,12 @@ static const device_config_t s2dge_config[] = {
         .name           = "bios",
         .description    = "BIOS Version",
         .type           = CONFIG_BIOS,
-        .default_string = "s2dge",
+        .default_string = "s2dge_rev16",
         .default_int    = 0,
         .file_filter    = NULL,
         .spinner        = { 0 },
         .selection      = { { 0 } },
         .bios           = {
-            {
-                .name          = "AMIBIOS 6 (063100) - Revision 1.6",
-                .internal_name = "s2dge_rev16",
-                .bios_type     = BIOS_NORMAL,
-                .files_no      = 1,
-                .local         = 0,
-                .size          = 262144,
-                .files         = { "roms/machines/s2dge/2gu2241.rom", "" }
-            },
             {
                 .name          = "AMIBIOS 6 (063100) - Revision 1.0",
                 .internal_name = "s2dge",
@@ -103,6 +94,15 @@ static const device_config_t s2dge_config[] = {
                 .local         = 0,
                 .size          = 262144,
                 .files         = { "roms/machines/s2dge/2gu7301.rom", "" }
+            },
+            {
+                .name          = "AMIBIOS 6 (063100) - Revision 1.6",
+                .internal_name = "s2dge_rev16",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 262144,
+                .files         = { "roms/machines/s2dge/2gu2241.rom", "" }
             },
             { .files_no = 0 }
         },

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -11252,7 +11252,7 @@ const machine_t machines[] = {
         .vid_device               = NULL,
         .snd_device               = NULL,
         .net_device               = NULL,
-        .aliases                  = { "Intel Ninja", "" }
+        .aliases                  = { "Intel Ninja", "Intel Classic/PCI Expandable Desktop", "" }
     },
     /* According to another string seen on the UH19 website, this has AMI 'H' KBC. */
     {
@@ -13110,7 +13110,7 @@ const machine_t machines[] = {
         .vid_device               = NULL,
         .snd_device               = NULL,
         .net_device               = NULL,
-        .aliases                  = { "" }
+        .aliases                  = { "Gigabyte GA-5IS", "" }
     },
     /* Has IBM PS/2 Type 1 KBC firmware. */
     {
@@ -13254,7 +13254,7 @@ const machine_t machines[] = {
         .vid_device               = NULL,
         .snd_device               = NULL,
         .net_device               = NULL,
-        .aliases                  = { "Intel Batman's Revenge", "" }
+        .aliases                  = { "Intel Batman's Revenge", "Intel Premiere/PCI Expandable Desktop", "" }
     },
     /* The M5Pi appears to have a Phoenix MultiKey KBC firmware according to photos. */
     {

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -13381,7 +13381,7 @@ const machine_t machines[] = {
         .flags     = MACHINE_IDE,
         .ram       = {
             .min  = 2048,
-            .max  = 131072,
+            .max  = 131072, /* Second POST screen has 64MB only, possibly a error? */
             .step = 2048
         },
         .nvrmask                  = 127,

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -17993,8 +17993,8 @@ const machine_t machines[] = {
         .device                   = NULL,
         .kbd_device               = NULL,
         .fdc_device               = NULL,
-        .vid_device               = &s3_trio64vplus_onboard_pci_device,
-        .snd_device               = NULL,
+        .vid_device               = &s3_trio64vplus_onboard_pci_device, /* Machine has also internal video: S3 ViRGE */
+        .snd_device               = NULL, /* Machine has Crystal CS4236-KQ onboard sound but it's unpopulated */
         .net_device               = NULL,
         .aliases                  = { "Packard Bell Orlando", "Packard Bell 2D", "Packard Bell 3D", "Packard Bell MMX", "Packard Bell R501", "Intel NV430VX", "Intel Orlando", "Intel Tampa", "" }
     },

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -13089,7 +13089,7 @@ const machine_t machines[] = {
         .flags     = MACHINE_FLAGS_NONE,
         .ram       = {
             .min  = 2048,
-            .max  = 131072,
+            .max  = 196608,
             .step = 2048
         },
         .nvrmask                  = 127,
@@ -13381,7 +13381,7 @@ const machine_t machines[] = {
         .flags     = MACHINE_IDE,
         .ram       = {
             .min  = 2048,
-            .max  = 65536,
+            .max  = 131072,
             .step = 2048
         },
         .nvrmask                  = 127,
@@ -14728,7 +14728,7 @@ const machine_t machines[] = {
         .vid_device               = NULL,
         .snd_device               = NULL,
         .net_device               = NULL,
-        .aliases                  = { "" }
+        .aliases                  = { "TriGem GEM4530", "" }
     },
 
     /* SiS 85C50x */
@@ -14841,7 +14841,7 @@ const machine_t machines[] = {
         .gpio_acpi_handler = NULL,
         .cpu               = {
             .package     = CPU_PKG_SOCKET5_7,
-        CPU_BLOCK(CPU_PENTIUMMMX),
+            .block       = CPU_BLOCK(CPU_PENTIUMMMX),
             .min_bus     = 50000000,
             .max_bus     = 66666667,
             .min_voltage = 3520,
@@ -14889,7 +14889,7 @@ const machine_t machines[] = {
         .gpio_acpi_handler = NULL,
         .cpu               = {
             .package     = CPU_PKG_SOCKET5_7,
-        CPU_BLOCK(CPU_PENTIUMMMX),
+            .block       = CPU_BLOCK(CPU_PENTIUMMMX),
             .min_bus     = 50000000,
             .max_bus     = 66666667,
             .min_voltage = 3520,
@@ -14937,7 +14937,7 @@ const machine_t machines[] = {
         .gpio_acpi_handler = NULL,
         .cpu               = {
             .package     = CPU_PKG_SOCKET5_7,
-        CPU_BLOCK(CPU_PENTIUMMMX),
+            .block       = CPU_BLOCK(CPU_PENTIUMMMX),
             .min_bus     = 50000000,
             .max_bus     = 66666667,
             .min_voltage = 3520,
@@ -17651,7 +17651,7 @@ const machine_t machines[] = {
         .vid_device               = &s3_trio64v2dx_onboard_pci_device,
         .snd_device               = &ess_1887_device,
         .net_device               = NULL,
-        .aliases                  = { "MiTAC/Trigon SNIPER", "" }
+        .aliases                  = { "MiTAC/Trigon SNIPER", "MiTAC/Trigon TITAN-R", "" }
     },
     /* Has a SM(S)C FDC37C932FR Super I/O chip with on-chip KBC with AMI
        MegaKey (revision '5') KBC firmware. */
@@ -21309,7 +21309,7 @@ const machine_t machines[] = {
         .vid_device               = NULL, /* Onboard video not yet emulated: ATi Rage IIc AGP */
         .snd_device               = &cs4235_onboard_device,
         .net_device               = NULL,
-        .aliases                  = { "Olivetti M24KD", "Olivetti M3000 MT/DT", "" }
+        .aliases                  = { "TriGem Como-3", "Olivetti M24KD", "Olivetti M3000 MT/DT", "eMachines eTower 333i", "Sotec Micro PC Station 3__", "" }
     },
 
     /* 440BX */
@@ -21899,7 +21899,7 @@ const machine_t machines[] = {
         .vid_device               = &voodoo_3_2000_agp_onboard_8m_device,
         .snd_device               = &es1373_onboard_device,
         .net_device               = NULL,
-        .aliases                  = { "" }
+        .aliases                  = { "Packard Bell Bora", "" }
     },
     /* Has a Winbond W83977EF Super I/O chip with on-chip KBC with AMIKey-2 KBC
        firmware. */


### PR DESCRIPTION
Summary
=======
This PR changes the following SIO & machines:
1. Added the standalone [Winbond W83769F](https://theretroweb.com/chips/4796) (both PCI & VLB) IDE device. W83769F is a superset of [W83759](https://theretroweb.com/chips/5157) (will add its standalone variant later).
2. Added standalone variants of NSC PC8731x, SMSC FDC37C66x, and ALi M512x (the latter not being a standalone chip; all motherboards use this chip (not expansion cards) but what if it is used for expansion cards as a standalone chip) and renamed them.
3. Reorderd the S2DGE BIOS revisions properly and make its revision 1.6 a default BIOS.
4. Increased the maximum memory for Gigabyte GA-5IS & AMI S75 to 192mb & 128mb respectively (the latter has a note added regarding its maximum memory).
5. Added more aliases for some machines.
6. Fixed the .CPU_BLOCK formatting for two Socket 5 SiS-based machines.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
The Retro Web's entries on these chips:
*[ALi M5123](https://theretroweb.com/chips/4736)
*[ALi M5125](https://theretroweb.com/chips/4737)
*[NSC PC87311](https://theretroweb.com/chips/4743)
*[NSC PC87312](https://theretroweb.com/chips/5938)
*[SMSC FDC37C664](https://theretroweb.com/chips/4749)
*[SMSC FDC37C665](https://theretroweb.com/chips/4534)
*[SMSC FDC37C666GT](https://theretroweb.com/chips/4750)
and entries on these two machines:
*[AMI EXCALIBUR VLB PENTIUM (S75)](https://theretroweb.com/motherboards/s/ami-excalibur-vlb-pentium-s75)
*[Gigabyte GA-586IS](https://theretroweb.com/motherboards/s/gigabyte-ga-586is)

Notes
==========
This PR was originally going to add NSC PC87410 PCI IDE device as a standalone controller, but I found out BIOS won't detect HDD with this device, so it will not be added.

More IDE & floppy controllers (via SIO, such as [UM82C](https://theretroweb.com/chips/6236)[86xF](https://theretroweb.com/chips/5274) and [Prime3C](https://theretroweb.com/chips/4740)) will be coming soon.