### PR TITLE
Set sysx-in-finished to 1 (true) on MPU401_Reset

### DIFF
--- a/src/sound/snd_mpu401.c
+++ b/src/sound/snd_mpu401.c
@@ -278,6 +278,7 @@ MPU401_Reset(mpu_t *mpu)
     mpu->state.midi_mask                            = 0xffff;
     mpu->state.command_byte                         = 0;
     mpu->state.block_ack                            = 0;
+    mpu->state.sysex_in_finished                    = 1; // Initialize in finished state
     mpu->clock.tempo = mpu->clock.old_tempo         = 100;
     mpu->clock.timebase = mpu->clock.old_timebase   = 120;
     mpu->clock.tempo_rel = mpu->clock.old_tempo_rel = 0x40;


### PR DESCRIPTION
Enables MPU-401 (MPU-IPC-T) to receive MIDI in messages

Summary
=======
Explicitly set sysex_in_finished to 1 (true) of mpu_t instance in MPU401_Reset function. This makes sure the sysex_in_finished value does not depend on whatever is in memory without initialization (or reset). Now MIDI-in messages are no longer discarded if sysex_in_finished is 0 (false) after init or reset.

Checklist
=========
Tested MIDI-in with DOS6.22, Cakewalk 4.0 (UART mode IRQ2,330h) compiled for Windows. Used USB MIDI in device.

References
==========

