### PR TITLE
RZ1000: Only initialize secondary IDE BARs on dual-channel variants

### DIFF
--- a/src/disk/hdc_ide_rz1000.c
+++ b/src/disk/hdc_ide_rz1000.c
@@ -217,10 +217,12 @@ rz1000_reset(void *priv)
     dev->regs[0x11] = 0x01;
     dev->regs[0x14] = 0xf5;
     dev->regs[0x15] = 0x03;
-    dev->regs[0x18] = 0x71;
-    dev->regs[0x19] = 0x01;
-    dev->regs[0x1c] = 0x75;
-    dev->regs[0x1d] = 0x03;
+    if (dev->channels & 0x02) {
+        dev->regs[0x18] = 0x71;
+        dev->regs[0x19] = 0x01;
+        dev->regs[0x1c] = 0x75;
+        dev->regs[0x1d] = 0x03;
+    }
 
     dev->irq_mode[0] = dev->irq_mode[1] = 0;
     dev->irq_pin                        = PCI_INTA;


### PR DESCRIPTION
Summary
=======
Change rz1000_reset to only initialize the secondary IDE BARs on dual-channel versions of the chip. This fixes resource conflicts in Windows 95 on the Intel Premiere/PCI boards.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
