### PR TITLE
Add the ESS AudioDrive ES1788/ES1698 to the sound card list

### DIFF
--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -8528,7 +8528,7 @@ const device_t ess_chipchat_16_mca_device = {
 };
 
 const device_t ess_1788_device = {
-    .name          = "ESS AudioDrive ES1788",
+    .name          = "ESS AudioDrive ES1788/ES1698", /* ES1698 is a rebadged ES1788 */
     .internal_name = "ess_es1788",
     .flags         = DEVICE_ISA16,
     .local         = 1,

--- a/src/sound/sound.c
+++ b/src/sound/sound.c
@@ -185,6 +185,7 @@ static const SOUND_CARD sound_cards[] = {
     { &ess_1688_device              },
     { &ess_ess0102_pnp_device       },
     { &ess_ess0968_pnp_device       },
+    { &ess_1788_device              },
     { &ess_1868_device              },
     { &ess_1869_device              },
     { &gus_device                   },


### PR DESCRIPTION
Summary
=======
Add the ESS AudioDrive ES1788/ES1698 to the sound card list: at least one ISA sound card exists with the ES1698 chip (a rebadged ES1788).

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
