### PR TITLE
VISO mount fixes

### DIFF
--- a/src/cdrom/cdrom_image_viso.c
+++ b/src/cdrom/cdrom_image_viso.c
@@ -1046,7 +1046,13 @@ next_dir:
     }
 
     /* Get root directory basename for the volume ID. */
-    const char *basename = path_get_filename(viso->root_dir->path);
+    char  *volume_path    = viso->root_dir->path;
+    size_t path_len       = strlen(volume_path);
+    while ((path_len > 0) && ((volume_path[path_len - 1] == '/') || (volume_path[path_len - 1] == '\\')))
+        path_len--;
+    char saved_trailer    = volume_path[path_len];
+    volume_path[path_len] = '\0';
+    const char *basename  = path_get_filename(volume_path);
     if (!basename || !basename[0])
         basename = EMU_NAME;
 
@@ -1192,6 +1198,7 @@ next_dir:
             fwrite(data, viso->sector_size, 1, viso->tf.fp);
         }
     }
+    volume_path[path_len] = saved_trailer;
 
     /* Fill terminator. */
     p = data;

--- a/src/osd/osd_core.cpp
+++ b/src/osd/osd_core.cpp
@@ -242,6 +242,7 @@ static void mount_path(const char *path)
             floppy_mount(0, (char *) path, 0);
             break;
         case VIEW_FILE_CD:
+        case VIEW_CD_FOLDER:
             cdrom_mount(0, (char *) path);
             break;
         case VIEW_FILE_RDISK:

--- a/src/osd/osd_explorer.cpp
+++ b/src/osd/osd_explorer.cpp
@@ -650,6 +650,11 @@ OsdExplorer::ResolveTypedPath(fs::path *path, bool *is_directory, bool *is_file)
 
     std::string typed = filename_input_.data();
 
+    /* Don't accept ".." as target directory to mount */
+    if (config_.mode == OsdExplorerMode::Directory)
+        if (typed == "..")
+            return false;
+
     const fs::path typed_path(typed);
     fs::path       resolved_path = typed_path;
     if (!typed_path.is_absolute())
@@ -746,6 +751,15 @@ OsdExplorer::BuildAcceptedPath(fs::path *path) const
             if (entry->kind == EntryKind::Directory || entry->kind == EntryKind::Drive) {
                 *path = entry->path;
                 return true;
+            }
+
+            /* Selecting ".." should not mount the parent */
+            if (entry->kind == EntryKind::Parent) {
+                if (!current_path_.empty()) {
+                    *path = current_path_;
+                    return true;
+                }
+                return false;
             }
         }
 


### PR DESCRIPTION
Summary
=======
[OSD: Fix VISO mount not working](https://github.com/86Box/86Box/commit/bee7d498d38e3951aca0a0031b2291ae2b4c62f7)
[OSD: Fix VISO mounting parent dir as "__" when selecting directory and then clicking mount](https://github.com/86Box/86Box/commit/6c33ee1a0ab554e72021390af03a6bcf476d822c)
[VISO: Fix volume ID always displayed as "86BOX"](https://github.com/86Box/86Box/commit/6e5acacd6147438adba9004775e4763ce8eb3235)

Checklist
=========
* [x] Closes N/A
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [x] This pull request doesn't require changes to the ROM set
* [x] This pull request doesn't require changes to the asset set