### PR TITLE
Add Tulip DGA alias to [ISA] Yamaha V6355D

### DIFF
--- a/src/video/vid_cga_v6355.c
+++ b/src/video/vid_cga_v6355.c
@@ -1068,5 +1068,6 @@ const device_t v6355d_device = {
     .available     = NULL,
     .speed_changed = v6355_speed_changed,
     .force_redraw  = NULL,
-    .config        = v6355_config
+    .config        = v6355_config,
+    .alias         = "Tulip DGA"
 };


### PR DESCRIPTION
Summary
=======
It's the graphics card from [V20] Tulip PC Compact 2. Figuring out it's this card required either looking at source code or searching online.

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set