### PR TITLE
[V20] Tulip PC Compact 2 always has 640 KB of RAM

### DIFF
--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -2475,9 +2475,9 @@ const machine_t machines[] = {
         .bus_flags = MACHINE_PC,
         .flags     = MACHINE_FLAGS_NONE,
         .ram       = {
-            .min  = 64,
+            .min  = 640,
             .max  = 640,
-            .step = 64
+            .step = 640
         },
         .nvrmask                  = 63,
         .jumpered_ecp_dma         = 0,


### PR DESCRIPTION
Summary
=======
It was set to 64-640 KB range before and setup didn't work below 512 KB RAM.

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set

References
==========
https://theretroweb.com/motherboard/manual/pc-compact-2-61eef8fd0aae7296031251.pdf