### PR TITLE
Add ability to get list of physical disks to use in existing HDD dialog

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -282,6 +282,10 @@ add_library(ui STATIC
     qt_cgasettingsdialog.hpp
     qt_cgasettingsdialog.cpp
     qt_cgasettingsdialog.ui
+
+    qt_physdiskdialog.cpp
+    qt_physdiskdialog.hpp
+    qt_physdiskdialog.ui
 )
 
 # Build the Qt ImGui backend separately so AUTOMOC skips it.

--- a/src/qt/qt_harddiskdialog.cpp
+++ b/src/qt/qt_harddiskdialog.cpp
@@ -17,6 +17,12 @@
 #include "qt_harddiskdialog.hpp"
 #include "ui_qt_harddiskdialog.h"
 
+#include "qt_physdiskdialog.hpp"
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 extern "C" {
 #ifdef __unix__
 #    include <unistd.h>
@@ -107,6 +113,33 @@ HarddiskDialog::HarddiskDialog(bool existing, QWidget *parent)
         ui->comboBoxFormat->hide();
         ui->labelFormat->hide();
 
+#ifndef _WIN32
+        ui->pushButtonPhysDisk->setHidden(true);
+        ui->labelElevated->setHidden(true);
+#else
+        bool elevated = false;
+        HANDLE hToken = INVALID_HANDLE_VALUE;
+        
+        if (OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &hToken)) {
+            TOKEN_ELEVATION elevation;
+            DWORD size_data;
+
+            if (GetTokenInformation(hToken, TokenElevation, &elevation, sizeof(elevation), &size_data)) {
+                elevated = elevation.TokenIsElevated;
+            }
+        }
+
+        ui->pushButtonPhysDisk->setEnabled(elevated);
+        ui->labelElevated->setHidden(elevated);
+#endif
+
+        connect(ui->pushButtonPhysDisk, &QPushButton::clicked, this, [this]()
+        {
+            auto dialog = new PhysicalHddDialog(this);
+            dialog->setAttribute(Qt::WA_DeleteOnClose, true);
+            dialog->exec();
+        });
+
         connect(ui->fileField, &FileField::fileSelected, this, &HarddiskDialog::onExistingFileSelected);
     } else {
         ui->fileField->setFilter(filters.join(";;"));
@@ -129,6 +162,9 @@ HarddiskDialog::HarddiskDialog(bool existing, QWidget *parent)
         // so the currentIndexChanged signal can do what is needed
         ui->comboBoxFormat->setCurrentIndex(DEFAULT_DISK_FORMAT);
         ui->fileField->setselectedFilter(filters.value(DEFAULT_DISK_FORMAT));
+
+        ui->pushButtonPhysDisk->setHidden(true);
+        ui->labelElevated->setHidden(true);
     }
 }
 

--- a/src/qt/qt_harddiskdialog.ui
+++ b/src/qt/qt_harddiskdialog.ui
@@ -32,46 +32,6 @@
    <string>Dialog</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="labelFileName">
-     <property name="text">
-      <string>File name:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1" colspan="5">
-    <widget class="FileField" name="fileField" native="true"/>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="labelCylinders">
-     <property name="text">
-      <string>Cylinders:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="lineEditCylinders">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>64</width>
-       <height>16777215</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
-    <widget class="QLabel" name="labelHeads">
-     <property name="text">
-      <string>Heads:</string>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="3">
     <widget class="QLineEdit" name="lineEditHeads">
      <property name="sizePolicy">
@@ -98,6 +58,50 @@
      </property>
     </widget>
    </item>
+   <item row="3" column="4">
+    <widget class="QLabel" name="labelChannel">
+     <property name="text">
+      <string>Channel:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="labelFileName">
+     <property name="text">
+      <string>File name:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="3">
+    <widget class="QComboBox" name="comboBoxBus">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="3" colspan="3">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="6">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item row="1" column="5">
     <widget class="QLineEdit" name="lineEditSectors">
      <property name="sizePolicy">
@@ -117,10 +121,54 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="labelSize">
+   <item row="6" column="0">
+    <widget class="QLabel" name="labelBlockSize">
      <property name="text">
-      <string>Size (MB):</string>
+      <string>Block Size:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0" colspan="2">
+    <widget class="QPushButton" name="pushButtonPhysDisk">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Physical disks...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="labelCylinders">
+     <property name="text">
+      <string>Cylinders:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="labelBus">
+     <property name="text">
+      <string>Bus:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="6">
+    <widget class="QProgressBar" name="progressBar">
+     <property name="visible">
+      <bool>false</bool>
+     </property>
+     <property name="value">
+      <number>0</number>
+     </property>
+     <property name="textVisible">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="labelSpeed">
+     <property name="text">
+      <string>Model:</string>
      </property>
     </widget>
    </item>
@@ -140,41 +188,6 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
-    <widget class="QLabel" name="labelType">
-     <property name="text">
-      <string>Type:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="3" colspan="3">
-    <widget class="QComboBox" name="comboBoxType">
-     <property name="maxVisibleItems">
-      <number>30</number>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="labelBus">
-     <property name="text">
-      <string>Bus:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="3">
-    <widget class="QComboBox" name="comboBoxBus">
-     <property name="maxVisibleItems">
-      <number>30</number>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="4">
-    <widget class="QLabel" name="labelChannel">
-     <property name="text">
-      <string>Channel:</string>
-     </property>
-    </widget>
-   </item>
    <item row="3" column="5">
     <widget class="QComboBox" name="comboBoxChannel">
      <property name="maxVisibleItems">
@@ -182,15 +195,45 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="labelSpeed">
-     <property name="text">
-      <string>Model:</string>
+   <item row="5" column="1" colspan="5">
+    <widget class="QComboBox" name="comboBoxFormat">
+     <property name="maxVisibleItems">
+      <number>30</number>
      </property>
     </widget>
    </item>
-   <item row="4" column="1" colspan="5">
-    <widget class="QComboBox" name="comboBoxSpeed">
+   <item row="2" column="0">
+    <widget class="QLabel" name="labelSize">
+     <property name="text">
+      <string>Size (MB):</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="lineEditCylinders">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>64</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1" colspan="5">
+    <widget class="QComboBox" name="comboBoxBlockSize">
+     <property name="maxVisibleItems">
+      <number>30</number>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="3" colspan="3">
+    <widget class="QComboBox" name="comboBoxType">
      <property name="maxVisibleItems">
       <number>30</number>
      </property>
@@ -203,60 +246,34 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1" colspan="5">
-    <widget class="QComboBox" name="comboBoxFormat">
+   <item row="4" column="1" colspan="5">
+    <widget class="QComboBox" name="comboBoxSpeed">
      <property name="maxVisibleItems">
       <number>30</number>
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="labelBlockSize">
+   <item row="1" column="2">
+    <widget class="QLabel" name="labelHeads">
      <property name="text">
-      <string>Block Size:</string>
+      <string>Heads:</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="1" colspan="5">
-    <widget class="QComboBox" name="comboBoxBlockSize">
-     <property name="maxVisibleItems">
-      <number>30</number>
+   <item row="0" column="1" colspan="5">
+    <widget class="FileField" name="fileField" native="true"/>
+   </item>
+   <item row="2" column="2">
+    <widget class="QLabel" name="labelType">
+     <property name="text">
+      <string>Type:</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="0" colspan="6">
-    <widget class="QProgressBar" name="progressBar">
-     <property name="visible">
-      <bool>false</bool>
-     </property>
-     <property name="value">
-      <number>0</number>
-     </property>
-     <property name="textVisible">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0" colspan="6">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="9" column="0" colspan="6">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   <item row="10" column="0" colspan="2">
+    <widget class="QLabel" name="labelElevated">
+     <property name="text">
+      <string>86Box is not elevated.</string>
      </property>
     </widget>
    </item>

--- a/src/qt/qt_physdiskdialog.cpp
+++ b/src/qt/qt_physdiskdialog.cpp
@@ -1,0 +1,98 @@
+#ifdef _WIN32
+#include <initguid.h>
+#endif
+#include "qt_physdiskdialog.hpp"
+#include "ui_qt_physdiskdialog.h"
+#include <QDebug>
+#include <QMenu>
+#include <QLineEdit>
+#include <QClipboard>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <setupapi.h>
+#endif
+
+PhysicalHddDialog::PhysicalHddDialog(QWidget* parent)
+    : QDialog(parent)
+    , ui(new Ui::PhysicalHddDialog)
+{
+    ui->setupUi(this);
+    ui->tableWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+    ui->tableWidget->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+    ui->tableWidget->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+#ifdef _WIN32
+    SP_DEVICE_INTERFACE_DETAIL_DATA_A* devIntData = nullptr;
+    auto classDevs = SetupDiGetClassDevsA(&GUID_DEVINTERFACE_DISK, nullptr, nullptr, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+    if (classDevs != INVALID_HANDLE_VALUE) {
+        SP_DEVINFO_DATA devInfo = { .cbSize = sizeof(SP_DEVINFO_DATA) };
+        for (int i = 0; SetupDiEnumDeviceInfo(classDevs, i, &devInfo); i++) {
+            wchar_t device_friendly_name[1024] = { 0 };
+            DWORD dataType = 0;
+            DWORD reqSizeStr = 0;
+            SP_DEVICE_INTERFACE_DATA intData = { .cbSize = sizeof(SP_DEVICE_INTERFACE_DATA) };
+            if (!SetupDiGetDeviceRegistryPropertyW(classDevs, &devInfo, SPDRP_FRIENDLYNAME, &dataType, (PBYTE)device_friendly_name, sizeof(device_friendly_name), &reqSizeStr)) {
+                wcsncpy(device_friendly_name, tr("Generic Disk Device").toStdWString().c_str(), 1024);
+            }
+            for (int j = 0; SetupDiEnumDeviceInterfaces(classDevs, &devInfo, &GUID_DEVINTERFACE_DISK, j, &intData); j++) {
+                DWORD reqSize = 0;
+                auto res = SetupDiGetDeviceInterfaceDetailA(classDevs, &intData, nullptr, 0, &reqSize, &devInfo);
+                if (!res) {
+                    if (!reqSize)
+                        continue;
+
+                    devIntData = (SP_DEVICE_INTERFACE_DETAIL_DATA_A*)realloc(devIntData, reqSize * 2 + sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_A));
+                    devIntData->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_A);
+                    res = SetupDiGetDeviceInterfaceDetailA(classDevs, &intData, devIntData, reqSize, &reqSize, &devInfo);
+                    if (res) {
+                        auto handle = CreateFileA(devIntData->DevicePath, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
+                        if (handle != INVALID_HANDLE_VALUE) {
+                            DWORD bytesRet = 0;
+                            STORAGE_DEVICE_NUMBER storage_num;
+                            if (DeviceIoControl(handle, IOCTL_STORAGE_GET_DEVICE_NUMBER, nullptr, 0, &storage_num, sizeof(STORAGE_DEVICE_NUMBER), &bytesRet, nullptr)) {
+                                uint64_t disk_size = 0;
+                                QString physDiskStr = QString::asprintf("\\\\.\\PhysicalDrive%lld", (long long)storage_num.DeviceNumber);
+                                GET_LENGTH_INFORMATION lengthInfo;
+                                if (DeviceIoControl(handle, IOCTL_DISK_GET_LENGTH_INFO, NULL, 0, &lengthInfo, sizeof(lengthInfo), &bytesRet, NULL)) {
+                                    disk_size = (uint64_t)lengthInfo.Length.QuadPart;
+                                }
+                                ui->tableWidget->setRowCount(ui->tableWidget->rowCount() + 1);
+                                auto pathWidget = new QTableWidgetItem(physDiskStr);
+                                pathWidget->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+                                ui->tableWidget->setItem(ui->tableWidget->rowCount() - 1, 0, pathWidget);
+                                auto nameWidget = new QTableWidgetItem(QString::fromWCharArray(device_friendly_name));
+                                nameWidget->setFlags(Qt::NoItemFlags);
+                                ui->tableWidget->setItem(ui->tableWidget->rowCount() - 1, 1, nameWidget);
+                                QTableWidgetItem* sizeWidget = nullptr;
+                                sizeWidget = new QTableWidgetItem(QString("%1 %2").arg(disk_size / (1024. * 1024.)).arg(tr("MB")));
+                                sizeWidget->setFlags(Qt::NoItemFlags);
+                                ui->tableWidget->setItem(ui->tableWidget->rowCount() - 1, 2, sizeWidget);
+                            }
+                            CloseHandle(handle);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    free(devIntData);
+
+    ui->tableWidget->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(ui->tableWidget, &QWidget::customContextMenuRequested, this, [this](const QPoint &pos)
+    {
+        const auto indexAt = ui->tableWidget->itemAt(pos);
+        if (ui->tableWidget->columnAt(pos.x()) == 0) {
+            QMenu contextMenu("", ui->tableWidget);
+            contextMenu.addAction(QLineEdit::tr("&Copy"), [this, indexAt] {
+                QApplication::clipboard()->setText(indexAt->text());
+            });
+            contextMenu.exec(ui->tableWidget->viewport()->mapToGlobal(pos));
+        }
+    });
+#endif
+}
+
+PhysicalHddDialog::~PhysicalHddDialog()
+{
+    delete ui;
+}

--- a/src/qt/qt_physdiskdialog.hpp
+++ b/src/qt/qt_physdiskdialog.hpp
@@ -1,0 +1,17 @@
+#include <QDialog>
+#include <QString>
+
+namespace Ui {
+class PhysicalHddDialog;
+}
+
+class PhysicalHddDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    PhysicalHddDialog(QWidget* parent);
+    ~PhysicalHddDialog();
+
+private:
+    Ui::PhysicalHddDialog *ui;
+};

--- a/src/qt/qt_physdiskdialog.ui
+++ b/src/qt/qt_physdiskdialog.ui
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PhysicalHddDialog</class>
+ <widget class="QDialog" name="PhysicalHddDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>712</width>
+    <height>437</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetFixedSize</enum>
+   </property>
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="physicalHddGroupBox">
+     <property name="title">
+      <string>Physical disks</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetFixedSize</enum>
+      </property>
+      <item row="0" column="0">
+       <widget class="QTableWidget" name="tableWidget">
+        <property name="sizeAdjustPolicy">
+         <enum>QAbstractScrollArea::AdjustToContents</enum>
+        </property>
+        <property name="alternatingRowColors">
+         <bool>true</bool>
+        </property>
+        <property name="selectionMode">
+         <enum>QAbstractItemView::SingleSelection</enum>
+        </property>
+        <property name="selectionBehavior">
+         <enum>QAbstractItemView::SelectRows</enum>
+        </property>
+        <property name="sortingEnabled">
+         <bool>true</bool>
+        </property>
+        <column>
+         <property name="text">
+          <string>Path</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Name</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Size</string>
+         </property>
+        </column>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>PhysicalHddDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>PhysicalHddDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
Summary
=======
Add ability to get list of physical disks to use in existing HDD dialog.

Windows only.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
