### PR TITLE
Fix several FXSAVE/FXRSTOR x87/MMX state bugs (Pentium II Deschutes / D3DIM)

### DIFF
--- a/src/cpu/x86_ops_i686.h
+++ b/src/cpu/x86_ops_i686.h
@@ -187,6 +187,7 @@ fx_save_stor_common(uint32_t fetchdat, int bits)
     uint64_t fraction;
     uint8_t  jm;
     uint8_t  valid;
+    uint8_t  phys_reg;
     /* Exp_all_1 Exp_all_0 Frac_all_0 J M FTW_Valid  |  Ent
        ----------------------------------------------+------ */
     uint8_t ftw_table_idx;
@@ -274,7 +275,9 @@ fx_save_stor_common(uint32_t fetchdat, int bits)
         cpu_state.npxc = (cpu_state.npxc & ~FPU_CW_Reserved_Bits) | 0x0040;
         codegen_set_rounding_mode((cpu_state.npxc >> 10) & 3);
         cpu_state.TOP = (fpus >> 11) & 7;
-        cpu_state.npxs &= fpus & ~0x3800;
+        /* Restore the full status word, like FRSTOR does (the previous AND-in
+           dropped status bits the guest had set). */
+        cpu_state.npxs = fpus;
 
         if (bits == 32)
             x87_pc_off = readmeml(easeg, cpu_state.eaaddr + 8);
@@ -297,15 +300,24 @@ fx_save_stor_common(uint32_t fetchdat, int bits)
             fraction         = mant & 0x7fffffffffffffffULL;
             exp              = readmemw(easeg, cpu_state.eaaddr + 8);
             jm               = (mant >> 62) & 0x03;
-            valid            = !(ftwb & (1 << i));
+            /* FXSAVE stores the abridged FTW valid bits in physical-register order,
+               while data slot i holds ST(i) = physical register (TOP+i)&7. Index the
+               valid bit and the reconstructed tag by that physical register. */
+            phys_reg         = (cpu_state.TOP + i) & 7;
+            /* Abridged bit is 1 == non-empty (see pack_FPU_TW), and the ftw_table
+               FTW_Valid column (bit 0) is likewise 1 == non-empty, so `valid` must
+               EQUAL the bit, not its negation. */
+            valid            = !!(ftwb & (1 << phys_reg));
 
-            ftw_table_idx = (!!(exp == 0x1111)) << 5;
+            /* "exponent all ones" (NaN/Inf/MMX), masking the sign bit. Was a 0x1111
+               typo that never matched; compare the MMX heuristic below which uses 0xffff. */
+            ftw_table_idx = (!!((exp & 0x7fff) == 0x7fff)) << 5;
             ftw_table_idx |= (!!(exp == 0x0000)) << 4;
             ftw_table_idx |= (!!(fraction == 0x0000000000000000ULL)) << 3;
             ftw_table_idx |= (jm << 1);
             ftw_table_idx |= valid;
 
-            rec_ftw |= (ftw_table[ftw_table_idx] << (i << 1));
+            rec_ftw |= (ftw_table[ftw_table_idx] << (phys_reg << 1));
 
             if (exp == 0xffff)
                 mmx_tags++;
@@ -354,7 +366,9 @@ fx_save_stor_common(uint32_t fetchdat, int bits)
             ftwb |= 0x80;
 
         writememw(easeg, cpu_state.eaaddr, cpu_state.npxc);
-        writememw(easeg, cpu_state.eaaddr + 2, cpu_state.npxs);
+        /* Fold the current TOP into the stored status word, like FSAVE does;
+           cpu_state.npxs alone can hold a stale TOP field. */
+        writememw(easeg, cpu_state.eaaddr + 2, (cpu_state.npxs & ~(7 << 11)) | ((cpu_state.TOP & 7) << 11));
         writememb(easeg, cpu_state.eaaddr + 4, ftwb);
 
         writememw(easeg, cpu_state.eaaddr + 6, x87_op);

--- a/src/cpu/x87_ops.h
+++ b/src/cpu/x87_ops.h
@@ -334,13 +334,17 @@ x87_ld_frstor(int reg)
     cpu_state.MM[reg].q  = readmemq(easeg, cpu_state.eaaddr);
     cpu_state.MM_w4[reg] = readmemw(easeg, cpu_state.eaaddr + 8);
 
+    /* The 0x5555 pseudo-exponent is written by x87_st_fsave ONLY for a
+       TAG_UINT64 (FILD'd int64) register, and no legitimate float or MMX save
+       produces it (x87_st80 caps finite doubles near 0x43FF, NaN/Inf use 0x7fff,
+       x87_stmmx writes 0xffff). So the sentinel alone is a reliable marker.
+       Gating on it directly makes FXRSTOR round-trip the exact integer the same
+       way FNSAVE/FRSTOR does; the previous `tag == 2` condition depended on a
+       correctly-reconstructed abridged tag, which FXRSTOR cannot guarantee. */
+    if (cpu_state.MM_w4[reg] == 0x5555) {
 #ifdef USE_NEW_DYNAREC
-    if ((cpu_state.MM_w4[reg] == 0x5555) && (cpu_state.tag[reg] & TAG_UINT64))
+        cpu_state.tag[reg] = TAG_VALID | TAG_UINT64;
 #else
-    if ((cpu_state.MM_w4[reg] == 0x5555) && (cpu_state.tag[reg] == 2))
-#endif
-    {
-#ifndef USE_NEW_DYNAREC
         cpu_state.tag[reg] = TAG_UINT64;
 #endif
         cpu_state.ST[reg] = (double) cpu_state.MM[reg].q;

--- a/src/cpu/x87_ops.h
+++ b/src/cpu/x87_ops.h
@@ -158,7 +158,12 @@ x87_pop(void)
 #ifdef USE_NEW_DYNAREC
     cpu_state.TOP++;
 #else
-    cpu_state.tag[cpu_state.TOP & 7] |= TAG_UINT64;
+    /* Old-dynarec "empty" is packed tag 3 (see FINIT's 0x0303... and the dynarec's
+       FP_POP, which writes 3). The previous `|= TAG_UINT64` left the vacated slot
+       tagged as a live 64-bit integer (x87_gettag maps TAG_UINT64 -> non-empty 2),
+       diverging from the dynarec and causing FXSAVE to serialize a stale MM.q with
+       the 0x5555 sentinel. Mark it empty like FP_POP/FINIT do. */
+    cpu_state.tag[cpu_state.TOP & 7] = 3;
     cpu_state.TOP = (cpu_state.TOP + 1) & 7;
 #endif
     return t;


### PR DESCRIPTION
## Background

While chasing a crash in The Sims (invalid page fault in `D3DIM.DLL`) that happens on a Pentium II Deschutes but never on a Klamath, we traced it into the host-FPU `FXSAVE`/`FXRSTOR` path and found a handful of genuine correctness bugs. The Deschutes-only behavior makes sense: Deschutes advertises `FXSR`, so Win98 uses `FXSAVE`/`FXRSTOR` for FPU context switches, while Klamath uses `FNSAVE`/`FRSTOR`, so this code path is only exercised on FXSR-capable CPUs. This PR is just some correctness fixes. See "What this does not fix" below. This doesn't resolve the crash on its own, but it was needed to do so.

## The fixes

All in `fx_save_stor_common` (`x86_ops_i686.h`) and `x87_ld_frstor` / `x87_pop` (`x87_ops.h`):

1. **Inverted abridged-tag valid bit.** `valid = !(ftwb & …)` should be `!!(…)`. The abridged FTW bit is `1 = non-empty` (matching `pack_FPU_TW`), and the `ftw_table` FTW_Valid column is likewise `1 = non-empty`, so every live x87 register was being reconstructed as EMPTY and vice-versa.
2. **`exp == 0x1111` typo.** Changed to `(exp & 0x7fff) == 0x7fff` for the "exponent all ones" case. `0x1111` never matched; the `mmx_tags` check just below uses `0xffff`, confirming intent. NaN/Inf were mis-tagged on restore.
3. **FTW valid bit and reconstructed tag indexed by loop counter `i`.** Data slot `i` holds `ST(i)` = physical register `(TOP+i)&7`, so both should index by the physical register. This matters when `TOP != 0`.
4. **FXRSTOR ANDed the saved status word** (`npxs &= …`) instead of loading it. The AND could only clear bits, dropping flags the guest had set. Load it fully like `FRSTOR`.
5. **FXSAVE stored a stale TOP in the status word.** Fold in the current `TOP`, like `FSAVE`.
6. **FILD'd int64 lost across FXRSTOR.** Such a register is saved with a `0x5555` pseudo-exponent sentinel and restored exactly only if recognized as `TAG_UINT64`. Since FXRSTOR reconstructs the tag (lossily) instead of storing it, the old `tag == 2` gate failed and the exact integer came back as a garbage 80-bit float. Gate the integer-restore on the `MM_w4 == 0x5555` sentinel directly. Nothing legitimate emits `0x5555` (`x87_st80` caps finite doubles near `0x43FF`, NaN/Inf use `0x7fff`, MMX uses `0xffff`).
7. **`x87_pop` marked the vacated slot `TAG_UINT64`** (value 4) instead of empty. This diverged from the dynarec's own `FP_POP` and from `FINIT`, both of which use packed tag `3`, and it let FXSAVE serialize a just-popped slot as a live integer.

`FNSAVE`/`FRSTOR` (the Klamath path) store and restore the full 2-bit tag word verbatim. That is why most of these, all of which stem from the abridged-tag reconstruction, don't affect Klamath. The softfloat handler (`sf_fx_save_stor_common`) already does the right thing and is untouched.

## What this does not fix

These are real bugs, but they do not by themselves resolve the D3DIM crash. The crash appears to have a deeper root. The fast core keeps MMX and x87 in two separate arrays (`MM[]` and `ST[]`) coordinated by a single `ismmx` flag, and that state can drift and can't be reconstructed unambiguously from an FXSAVE image (there's no field for `ismmx`, and MMX data versus an x87 NaN are byte-identical). `FNSAVE`'s post-save reinitialization scrubs this every context switch on Klamath, while `FXSAVE` correctly doesn't, so it accumulates on Deschutes. Fixing it means the two representations can't be allowed to disagree, which is a register-model decision I'll leave to you. Softfloat already avoids the problem by keeping true 80-bit registers.

## Testing / how it was found

- Verified register data round-trips cleanly across `FXSAVE`/`FXRSTOR` (instrumented re-marshal-and-compare, 0 mismatches over millions of saves), so these are tag/state bugs, not data-precision bugs.
- Confirmed it's not the recompiler (interpreter mode crashes identically) and not the memory `readlookup2`/`writelookup2` cache (fresh-walk comparison, 0 stale mappings).
- Each fix was cross-checked against the store side and the `FNSAVE`/`FRSTOR` and softfloat equivalents for consistency.
- Built and run on a Win98SE + Deschutes VM. No regressions observed on Klamath or with softfloat enabled.
