### PR TITLE
Introduce uncapped mode that does not sync CPU to everything else using Deksor's patches

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -315,6 +315,9 @@ struct accelKey def_acc_keys[NUM_ACCELS] = {
 char vmm_path[1024] = { '\0' }; /* VM manager path to scan for VMs */
 int  start_vmm = 1;
 
+int cpu_uncapped = 0;
+int cpu_uncapped_init = 0;
+
 /* Statistics. */
 extern int mmuflush;
 
@@ -1890,6 +1893,8 @@ pc_reset_hard_init(void)
     cycles_main = 0;
 #endif
 
+    cpu_uncapped_init = 0;
+
     if (test_mode)
         pc_test_mode_entry_point();
 
@@ -1997,7 +2002,48 @@ pc_run(void)
 
     /* Run a block of code. */
     startblit();
-    cpu_exec((int32_t) cpu_s->rspeed / (force_10ms ? 100 : 1000));
+    if (cpu_uncapped) {
+        /* Wall-clock-driven virtual time: advance tsc based on real elapsed
+           time, not on how many instructions cpu_exec managed to run.
+           This decouples the PIT/RTC/audio timers from CPU throughput so
+           they always fire at real-world rates — exactly like real hardware
+           where the PIT crystal runs independently of CPU speed.  The CPU
+           simply executes fewer instructions between timer IRQs on a slow
+           host, which is identical to running the same software on a slower
+           real CPU. */
+        static uint64_t uncapped_last_ns = 0;
+
+        uint64_t now_ns = plat_get_ns();
+
+        if (!cpu_uncapped_init) {
+            uncapped_last_ns = now_ns;
+            cpu_uncapped_init    = 1;
+        }
+
+        uint64_t elapsed_ns = now_ns - uncapped_last_ns;
+        if (elapsed_ns > 50000000ULL)
+            elapsed_ns = 50000000ULL; /* cap at 50 ms after long pauses */
+        uncapped_last_ns = now_ns;
+
+        /* Give cpu_exec the standard fixed quantum (rspeed/1000) so the
+           correct number of instructions always runs between timer callbacks —
+           this is what keeps audio DMA buffers filled correctly.
+           The tsc_target uses nanosecond wall time so clocks stay accurate
+           even when the host is slow, without the CPU budget being affected. */
+        const int32_t fixed_cycles = (int32_t) cpu_s->rspeed / (force_10ms ? 100 : 1000);
+        uint64_t tsc_target = tsc + (uint64_t) ((double) cpu_s->rspeed * (double) elapsed_ns * 1e-9);
+
+        cpu_exec(fixed_cycles);
+
+        /* If the CPU fell short of the wall-clock target, push tsc forward
+           and fire any timers that are now due (PIT, RTC, DMA, etc.). */
+        if (tsc < tsc_target) {
+            tsc = tsc_target;
+            timer_process();
+        }
+    } else
+        cpu_exec((int32_t) cpu_s->rspeed / (force_10ms ? 100 : 1000));
+
     ack_pause();
 #ifdef USE_GDBSTUB /* avoid a KBC FIFO overflow when CPU emulation is stalled */
     if (gdbstub_step == GDBSTUB_EXEC) {

--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -312,6 +312,7 @@ extern codegen_timing_t codegen_timing_winchip2;
 extern codegen_timing_t codegen_timing_k5;
 extern codegen_timing_t codegen_timing_k6;
 extern codegen_timing_t codegen_timing_p6;
+extern codegen_timing_t codegen_timing_uncapped;
 
 void codegen_timing_set(codegen_timing_t *timing);
 

--- a/src/codegen_new/codegen.h
+++ b/src/codegen_new/codegen.h
@@ -355,6 +355,7 @@ extern codegen_timing_t codegen_timing_winchip2;
 extern codegen_timing_t codegen_timing_k5;
 extern codegen_timing_t codegen_timing_k6;
 extern codegen_timing_t codegen_timing_p6;
+extern codegen_timing_t codegen_timing_uncapped;
 
 void codegen_timing_set(codegen_timing_t *timing);
 

--- a/src/config.c
+++ b/src/config.c
@@ -326,6 +326,8 @@ load_general(void)
 
     force_10ms = !!ini_section_get_int(cat, "force_10ms", 0);
 
+    cpu_uncapped = !!ini_section_get_int(cat, "cpu_uncapped", 0);
+
     rctrl_is_lalt = ini_section_get_int(cat, "rctrl_is_lalt", 0);
     update_icons  = ini_section_get_int(cat, "update_icons", 1);
 
@@ -2933,6 +2935,10 @@ save_general(void)
     ini_section_set_int(cat, "vid_resize", vid_resize);
     if (vid_resize == 0)
         ini_section_delete_var(cat, "vid_resize");
+
+    ini_section_set_int(cat, "cpu_uncapped", cpu_uncapped);
+    if (!cpu_uncapped)
+        ini_section_delete_var(cat, "cpu_uncapped");
 
     va_name = plat_vidapi_name(vid_api);
     if (!strcmp(va_name, "default"))

--- a/src/cpu/CMakeLists.txt
+++ b/src/cpu/CMakeLists.txt
@@ -56,6 +56,7 @@ if(DYNAREC)
         codegen_timing_p6.c
         codegen_timing_winchip.c
         codegen_timing_winchip2.c
+        codegen_timing_uncapped.c
     )
 endif()
 

--- a/src/cpu/codegen_timing_uncapped.c
+++ b/src/cpu/codegen_timing_uncapped.c
@@ -1,0 +1,87 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          Fictional high-IPC 686-class CPU timing model.
+ *
+ *          Every instruction costs exactly 1 cycle with no pairing
+ *          logic, no AGI stalls, and no decode delays. This removes
+ *          all artificial CPU speed throttling while keeping the
+ *          guest's timer/scheduler accurate (the emulated clock still
+ *          ticks at the configured MHz, every instruction just
+ *          completes in one tick instead of many).
+ *
+ *          Designed for Socket 370 / Slot 1 boards when you want the
+ *          guest to run at the maximum speed the host can sustain.
+ *
+ * Authors: Deksor
+ *
+ *          Copyright 2026 Deksor.
+ */
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <wchar.h>
+#include <86box/86box.h>
+#include "cpu.h"
+#include <86box/mem.h>
+#include <86box/plat_unused.h>
+
+#include "x86.h"
+#include "x86_ops.h"
+#include "x87_sf.h"
+#include "x87.h"
+#include "codegen.h"
+#include "codegen_timing_common.h"
+
+static void
+codegen_timing_uncapped_block_start(void)
+{
+    /* Nothing to initialise per block */
+}
+
+static void
+codegen_timing_uncapped_start(void)
+{
+    /* Nothing to initialise per instruction */
+}
+
+static void
+codegen_timing_uncapped_prefix(UNUSED(uint8_t prefix), UNUSED(uint32_t fetchdat))
+{
+    /* All prefixes are free – no decode delay */
+}
+
+static void
+codegen_timing_uncapped_opcode(UNUSED(uint8_t opcode), UNUSED(uint32_t fetchdat),
+                               UNUSED(int op_32), UNUSED(uint32_t op_pc))
+{
+    /*
+     * Every instruction costs exactly 1 cycle.
+     * No pairing, no stalls, no per-instruction look-up tables.
+     * The guest OS still sees correct elapsed time because the
+     * configured clock speed determines how many real-time
+     * nanoseconds each cycle represents; we just remove the
+     * artificial extra stalls that accurate timing would add.
+     */
+    codegen_block_cycles++;
+}
+
+static void
+codegen_timing_uncapped_block_end(void)
+{
+    /* Nothing to flush at block end */
+}
+
+codegen_timing_t codegen_timing_uncapped = {
+    codegen_timing_uncapped_start,
+    codegen_timing_uncapped_prefix,
+    codegen_timing_uncapped_opcode,
+    codegen_timing_uncapped_block_start,
+    codegen_timing_uncapped_block_end,
+    NULL
+};

--- a/src/cpu/cpu.c
+++ b/src/cpu/cpu.c
@@ -1827,6 +1827,11 @@ cpu_set(void)
             fatal("cpu_set : unknown CPU type %" PRIu64 "\n", cpu_s->cpu_type);
     }
 
+#ifdef USE_DYNAREC
+    if (cpu_uncapped)
+        codegen_timing_set(&codegen_timing_uncapped);
+#endif
+
     switch (fpu_type) {
         case FPU_NONE:
             break;

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -325,6 +325,8 @@ extern void do_pause(int p);
 extern double isa_timing;
 extern int    io_delay;
 extern int    framecountx;
+extern int    cpu_uncapped;
+extern int    cpu_uncapped_init;
 
 extern volatile int     cpu_thread_run;
 extern          uint8_t postcard_codes[POSTCARDS_NUM];

--- a/src/include/86box/plat.h
+++ b/src/include/86box/plat.h
@@ -148,6 +148,7 @@ extern int      plat_file_check(const char *path);
 extern int      plat_dir_create(char *path);
 extern void    *plat_mmap(size_t size, uint8_t executable);
 extern void     plat_munmap(void *ptr, size_t size);
+extern uint64_t plat_get_ns(void);
 extern uint64_t plat_timer_read(void);
 extern uint32_t plat_get_ticks(void);
 extern void     plat_delay_ms(uint32_t count);

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -491,7 +491,7 @@ main_thread_fn()
                 frames     = 0;
             }
 
-            if (!cpu_uncapped && !fast_forward && debt_ns >= quantum_ns)
+            if (!fast_forward && debt_ns >= quantum_ns)
                 debt_ns -= quantum_ns;
             else
                 debt_ns = 0;
@@ -508,8 +508,7 @@ main_thread_fn()
             if (dopause)
                 ack_pause();
 
-            if (!cpu_uncapped)
-                plat_delay_ms(1);
+            plat_delay_ms(1);
         }
     }
 

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -508,7 +508,8 @@ main_thread_fn()
             if (dopause)
                 ack_pause();
 
-            plat_delay_ms(1);
+            if (!cpu_uncapped)
+                plat_delay_ms(1);
         }
     }
 

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -491,7 +491,7 @@ main_thread_fn()
                 frames     = 0;
             }
 
-            if (!fast_forward && debt_ns >= quantum_ns)
+            if (!cpu_uncapped && !fast_forward && debt_ns >= quantum_ns)
                 debt_ns -= quantum_ns;
             else
                 debt_ns = 0;

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -777,6 +777,12 @@ plat_language_code(char *langcode)
     return Preferences::languageCodeToId(QString(langcode));
 }
 
+uint64_t
+plat_get_ns(void)
+{
+    return (uint64_t)elapsed_timer.nsecsElapsed();
+}
+
 /* Converts the numeric language ID to a language code string */
 void
 plat_language_code_r(int id, char *outbuf, int len)

--- a/src/unix/sdl_plat.c
+++ b/src/unix/sdl_plat.c
@@ -314,6 +314,27 @@ plat_get_ticks_common(void)
     return elapsed_microseconds;
 }
 
+uint64_t
+plat_get_ns(void)
+{
+    static int first_use = 1;
+    static uint64_t starting_time;
+    static uint64_t frequency;
+
+    uint64_t ending_time;
+    uint64_t elapsed_nanoseconds;
+
+    if (first_use) {
+        frequency     = SDL_GetPerformanceFrequency();
+        starting_time = SDL_GetPerformanceCounter();
+        first_use     = 0;
+    }
+    ending_time          = SDL_GetPerformanceCounter();
+    elapsed_nanoseconds = ((ending_time - starting_time) * 1000000000ull) / frequency;
+
+    return elapsed_nanoseconds;
+}
+
 uint32_t
 plat_get_ticks(void)
 {


### PR DESCRIPTION
Summary
=======
Introduce uncapped mode that does not sync CPU to everything else using Deksor's patches.

All credit goes to Deksor for the original branch. I applied some fixes to minimize performance issues.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
