### PR TITLE
Cleanup unused functions for pregap checking

### DIFF
--- a/src/cdrom/cdrom.c
+++ b/src/cdrom/cdrom.c
@@ -1475,15 +1475,6 @@ cdrom_seek(cdrom_t *dev, const uint32_t pos, const uint8_t vendor_type)
     dev->cached_sector = -1;
 }
 
-int
-cdrom_is_pre(const cdrom_t *dev, const uint32_t lba)
-{
-    if (dev->ops && dev->ops->is_track_pre)
-        return dev->ops->is_track_pre(dev->local, lba);
-
-    return 0;
-}
-
 #include <86box/filters.h>
 
 static void

--- a/src/cdrom/cdrom_image.c
+++ b/src/cdrom/cdrom_image.c
@@ -2772,25 +2772,6 @@ image_get_raw_track_info(const void *local, int *num, uint8_t *buffer)
 }
 
 static int
-image_is_track_pre(const void *local, const uint32_t sector)
-{
-    const cd_image_t *img   = (const cd_image_t *) local;
-    int               ret   = 0;
-
-    if (img->has_audio) {
-        const int track = image_get_track(img, sector);
-
-        if (track >= 0) {
-            const track_t *trk = &(img->tracks[track]);
-
-            ret = !!(trk->attr & 0x01);
-        }
-    }
-
-    return ret;
-}
-
-static int
 image_read_sector(const void *local, uint8_t *buffer,
                   const uint32_t sector)
 {
@@ -3045,7 +3026,6 @@ image_close(void *local)
 static const cdrom_ops_t image_ops = {
     image_get_track_info,
     image_get_raw_track_info,
-    image_is_track_pre,
     image_read_sector,
     image_get_track_type,
     image_get_last_block,

--- a/src/include/86box/cdrom.h
+++ b/src/include/86box/cdrom.h
@@ -402,7 +402,6 @@ typedef struct cdrom_ops_t {
                                const int end, track_info_t *ti);
     void     (*get_raw_track_info)(const void *local, int *num,
                                    uint8_t *rti);
-    int      (*is_track_pre)(const void *local, const uint32_t sector);
     int      (*read_sector)(const void *local, uint8_t *buffer,
                             const uint32_t sector);
     uint8_t  (*get_track_type)(const void *local, const uint32_t sector);

--- a/src/qt/dummy_cdrom_ioctl.c
+++ b/src/qt/dummy_cdrom_ioctl.c
@@ -93,20 +93,6 @@ ioctl_get_raw_track_info(UNUSED(const void *local), int *num, uint8_t *rti)
 }
 
 static int
-ioctl_is_track_pre(const void *local, UNUSED(const uint32_t sector))
-{
-    ioctl_t *ioctl = (ioctl_t *) local;
-
-    ioctl_read_toc(ioctl);
-
-    const int ret = 0;
-
-    ioctl_log("ioctl_is_track_audio(%08X): %i\n", sector, ret);
-
-    return ret;
-}
-
-static int
 ioctl_read_sector(const void *local, UNUSED(uint8_t *buffer), UNUSED(uint32_t const sector))
 {
     ioctl_t *ioctl = (ioctl_t *) local;
@@ -205,7 +191,6 @@ ioctl_load(const void *local)
 static const cdrom_ops_t ioctl_ops = {
     ioctl_get_track_info,
     ioctl_get_raw_track_info,
-    ioctl_is_track_pre,
     ioctl_read_sector,
     ioctl_get_track_type,
     ioctl_get_last_block,

--- a/src/qt/win_cdrom_ioctl.c
+++ b/src/qt/win_cdrom_ioctl.c
@@ -381,25 +381,6 @@ ioctl_get_raw_track_info(const void *local, int *num, uint8_t *rti)
 }
 
 static int
-ioctl_is_track_pre(const void *local, const uint32_t sector)
-{
-    const ioctl_t          *ioctl   = (const ioctl_t *) local;
-    const raw_track_info_t *rti     = (const raw_track_info_t *) ioctl->cur_rti;
-    int                     ret     = 0;
-
-    if (ioctl->has_audio && !ioctl->is_dvd) {
-        const int track   = ioctl_get_track(ioctl, sector);
-        const int control = rti[track].adr_ctl;
-
-        ret     = control & 0x01;
-
-        ioctl_log(ioctl->log, "ioctl_is_track_pre(%08X, %02X): %i\n", sector, track, ret);
-    }
-
-    return ret;
-}
-
-static int
 ioctl_read_sector(const void *local, uint8_t *buffer, uint32_t const sector)
 {
     typedef struct SCSI_PASS_THROUGH_DIRECT_BUF {
@@ -808,7 +789,6 @@ ioctl_load(const void *local)
 static const cdrom_ops_t ioctl_ops = {
     ioctl_get_track_info,
     ioctl_get_raw_track_info,
-    ioctl_is_track_pre,
     ioctl_read_sector,
     ioctl_get_track_type,
     ioctl_get_last_block,

--- a/src/unix/dummy_cdrom_ioctl.c
+++ b/src/unix/dummy_cdrom_ioctl.c
@@ -93,20 +93,6 @@ ioctl_get_raw_track_info(UNUSED(const void *local), int *num, uint8_t *rti)
 }
 
 static int
-ioctl_is_track_pre(const void *local, UNUSED(const uint32_t sector))
-{
-    ioctl_t *ioctl = (ioctl_t *) local;
-
-    ioctl_read_toc(ioctl);
-
-    const int ret = 0;
-
-    ioctl_log("ioctl_is_track_audio(%08X): %i\n", sector, ret);
-
-    return ret;
-}
-
-static int
 ioctl_read_sector(const void *local, UNUSED(uint8_t *buffer), UNUSED(uint32_t const sector))
 {
     ioctl_t *ioctl = (ioctl_t *) local;
@@ -205,7 +191,6 @@ ioctl_load(const void *local)
 static const cdrom_ops_t ioctl_ops = {
     ioctl_get_track_info,
     ioctl_get_raw_track_info,
-    ioctl_is_track_pre,
     ioctl_read_sector,
     ioctl_get_track_type,
     ioctl_get_last_block,

--- a/src/unix/linux_cdrom_ioctl.c
+++ b/src/unix/linux_cdrom_ioctl.c
@@ -453,25 +453,6 @@ ioctl_get_raw_track_info(const void *local, int *num, uint8_t *rti)
 }
 
 static int
-ioctl_is_track_pre(const void *local, const uint32_t sector)
-{
-    const ioctl_t          *ioctl = (const ioctl_t *) local;
-    const raw_track_info_t *rti   = (const raw_track_info_t *) ioctl->cur_rti;
-    int                     ret   = 0;
-
-    if (ioctl->has_audio && !ioctl->is_dvd) {
-        const int track   = ioctl_get_track(ioctl, sector);
-        const int control = rti[track].adr_ctl;
-
-        ret = control & 0x01;
-
-        ioctl_log(ioctl->log, "ioctl_is_track_pre(%08X, %02X): %i\n", sector, track, ret);
-    }
-
-    return ret;
-}
-
-static int
 ioctl_read_sector(const void *local, uint8_t *buffer, uint32_t const sector)
 {
     const ioctl_t          *ioctl   = (const ioctl_t *) local;
@@ -829,7 +810,6 @@ ioctl_load(const void *local)
 static const cdrom_ops_t ioctl_ops = {
     ioctl_get_track_info,
     ioctl_get_raw_track_info,
-    ioctl_is_track_pre,
     ioctl_read_sector,
     ioctl_get_track_type,
     ioctl_get_last_block,


### PR DESCRIPTION
Summary
=======
Cleanup some unused functions for pregap checking.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
