### PR TITLE
Correct CRTC register for the early et4000 revision clock.

### DIFF
--- a/src/video/vid_et4000.c
+++ b/src/video/vid_et4000.c
@@ -675,7 +675,7 @@ et4000_recalctimings(svga_t *svga)
 
     if (svga->getclock == NULL) {
         /* Assume it has the same timings as the ET3000AX. */
-        switch (((svga->miscout >> 2) & 3) | ((svga->crtc[0x24] << 1) & 4)) {
+        switch (((svga->miscout >> 2) & 3) | ((svga->crtc[0x34] << 1) & 4)) {
             case 0:
             case 1:
                 break;


### PR DESCRIPTION
Summary
=======
Fixes some abnormal refresh rates on the early steppings of the ET4000AX.

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
