### PR TITLE
EMU8K reset and performance improvements - Take 2

### DIFF
--- a/src/include/86box/snd_emu8k.h
+++ b/src/include/86box/snd_emu8k.h
@@ -405,6 +405,7 @@ typedef struct emu8k_t {
 void emu8k_change_addr(emu8k_t *emu8k, uint16_t emu_addr);
 void emu8k_init(emu8k_t *emu8k, uint16_t emu_addr, int onboard_ram);
 void emu8k_close(emu8k_t *emu8k);
+void emu8k_reset_buffer(emu8k_t *emu8k);
 
 void emu8k_update(emu8k_t *emu8k);
 

--- a/src/sound/snd_emu8k.c
+++ b/src/sound/snd_emu8k.c
@@ -1761,14 +1761,22 @@ emu8k_update(emu8k_t *emu8k)
     if (emu8k->pos >= wavetable_pos_global)
         return;
 
+    const int      num_samples = wavetable_pos_global - emu8k->pos;
     int32_t       *buf;
     emu8k_voice_t *emu_voice;
     int            pos;
+    int            num_active = 0;
 
     /* Voices section  */
     for (uint8_t c = 0; c < 32; c++) {
         emu_voice = &emu8k->voice[c];
         buf       = &emu8k->buffer[emu8k->pos * 2];
+
+        /* Skip entirely idle voices — no sound output and no envelope to process. */
+        if (!emu_voice->env_engine_on && !emu_voice->cvcf_curr_volume)
+            continue;
+
+        num_active++;
 
         for (pos = emu8k->pos; pos < wavetable_pos_global; pos++) {
             int32_t dat;
@@ -2110,13 +2118,16 @@ emu8k_update(emu8k_t *emu8k)
 #endif
     }
 
-    buf = &emu8k->buffer[emu8k->pos * 2];
-    emu8k_work_reverb(&emu8k->reverb_in_buffer[emu8k->pos], buf, &emu8k->reverb_engine, wavetable_pos_global - emu8k->pos);
-    emu8k_work_chorus(&emu8k->chorus_in_buffer[emu8k->pos], buf, &emu8k->chorus_engine, wavetable_pos_global - emu8k->pos);
-    emu8k_work_eq(buf, wavetable_pos_global - emu8k->pos);
+    /* Only run reverb/chorus/EQ when at least one voice was active. */
+    if (num_active > 0) {
+        buf = &emu8k->buffer[emu8k->pos * 2];
+        emu8k_work_reverb(&emu8k->reverb_in_buffer[emu8k->pos], buf, &emu8k->reverb_engine, num_samples);
+        emu8k_work_chorus(&emu8k->chorus_in_buffer[emu8k->pos], buf, &emu8k->chorus_engine, num_samples);
+        emu8k_work_eq(buf, num_samples);
+    }
 
     /* Update EMU clock. */
-    emu8k->wc += (wavetable_pos_global - emu8k->pos);
+    emu8k->wc += num_samples;
 
     emu8k->pos = wavetable_pos_global;
 }

--- a/src/sound/snd_emu8k.c
+++ b/src/sound/snd_emu8k.c
@@ -1765,12 +1765,6 @@ emu8k_update(emu8k_t *emu8k)
     emu8k_voice_t *emu_voice;
     int            pos;
 
-    /* Clean the buffers since we will accumulate into them. */
-    buf = &emu8k->buffer[emu8k->pos * 2];
-    memset(buf, 0, 2 * (wavetable_pos_global - emu8k->pos) * sizeof(emu8k->buffer[0]));
-    memset(&emu8k->chorus_in_buffer[emu8k->pos], 0, (wavetable_pos_global - emu8k->pos) * sizeof(emu8k->chorus_in_buffer[0]));
-    memset(&emu8k->reverb_in_buffer[emu8k->pos], 0, (wavetable_pos_global - emu8k->pos) * sizeof(emu8k->reverb_in_buffer[0]));
-
     /* Voices section  */
     for (uint8_t c = 0; c < 32; c++) {
         emu_voice = &emu8k->voice[c];
@@ -2128,6 +2122,15 @@ emu8k_update(emu8k_t *emu8k)
 }
 
 void
+emu8k_reset_buffer(emu8k_t *emu8k)
+{
+    emu8k->pos = 0;
+    memset(emu8k->buffer, 0, sizeof(emu8k->buffer));
+    memset(emu8k->chorus_in_buffer, 0, sizeof(emu8k->chorus_in_buffer));
+    memset(emu8k->reverb_in_buffer, 0, sizeof(emu8k->reverb_in_buffer));
+}
+
+void
 emu8k_change_addr(emu8k_t *emu8k, uint16_t emu_addr)
 {
     if (emu8k->addr) {
@@ -2196,6 +2199,8 @@ emu8k_init(emu8k_t *emu8k, uint16_t emu_addr, int onboard_ram)
     for (; j < 0x100; j++) {
         emu8k->ram_pointers[j] = emu8k->empty;
     }
+
+    emu8k_reset_buffer(emu8k);
 
     emu8k_change_addr(emu8k, emu_addr);
 

--- a/src/sound/snd_emu8k.c
+++ b/src/sound/snd_emu8k.c
@@ -1772,11 +1772,8 @@ emu8k_update(emu8k_t *emu8k)
         emu_voice = &emu8k->voice[c];
         buf       = &emu8k->buffer[emu8k->pos * 2];
 
-        /* Skip entirely idle voices — no sound output and no envelope to process. */
-        if (!emu_voice->env_engine_on && !emu_voice->cvcf_curr_volume)
-            continue;
-
-        num_active++;
+        if (emu_voice->env_engine_on || emu_voice->cvcf_curr_volume)
+            num_active++;
 
         for (pos = emu8k->pos; pos < wavetable_pos_global; pos++) {
             int32_t dat;

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -600,7 +600,7 @@ sb_get_wavetable_buffer_goldfinch(int32_t *buffer, const uint16_t len, void *pri
         buffer[c + 1] += (int32_t) out_r;
     }
 
-    goldfinch->emu8k.pos = 0;
+    emu8k_reset_buffer(&goldfinch->emu8k);
 }
 
 static void
@@ -664,7 +664,7 @@ sb_get_wavetable_buffer_sb16_awe32(int32_t *buffer, const uint16_t len, void *pr
         buffer[c + 1] += (int32_t) (out_r * mixer->output_gain_R);
     }
 
-    sb->emu8k.pos = 0;
+    emu8k_reset_buffer(&sb->emu8k);
 }
 
 void


### PR DESCRIPTION
Summary
=======
Apparently, I avoided too much work when no voices are active in #7351 😅.

My changes essentially froze the register states when no voices are active, but that's not what real EMU8K does and games like Ultim@te Race Pro rely on those register states even for inactive voices.

This PR contains the commits from #7351 plus the fix:

[EMU8K: Fix silent voices stalling guest-visible playback position](https://github.com/86Box/86Box/commit/31d2d3fa51965ced09ff714722c46ff285af6d01)

I've reproduced the issue with Ultim@te Race Pro and can confirm the game works as expected with the fix, both the retail version and Patch version 1.5.

Checklist
=========
* [x] Closes N/A
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [x] This pull request doesn't require changes to the ROM set
* [x] This pull request doesn't require changes to the asset set