### PR TITLE
Add the Packard Bell PB400 and PB430/440

### DIFF
--- a/src/chipset/opti495.c
+++ b/src/chipset/opti495.c
@@ -328,6 +328,8 @@ opti495_recalc(opti495_t *dev)
         if ((dev->regs[0x22] & ((base >= 0xe0000) ? 0x20 : 0x40)) && (dev->regs[0x23] & (1 << i))) {
             shflags = MEM_READ_INTERNAL;
             shflags |= (dev->regs[0x22] & ((base >= 0xe0000) ? 0x08 : 0x10)) ? MEM_WRITE_DISABLED : MEM_WRITE_INTERNAL;
+        } else if ((dev->regs[0x22] & 0x20) && (base >= 0xe0000) && (!(dev->regs[0x23] & (1 << i)))) {
+            shflags = MEM_READ_EXTERNAL | MEM_WRITE_EXTERNAL;
         } else {
             if (dev->regs[0x26] & 0x40) {
                 shflags = MEM_READ_EXTANY;

--- a/src/device/phoenix_486_jumper.c
+++ b/src/device/phoenix_486_jumper.c
@@ -60,6 +60,18 @@
     Bit 2 = CMOS clear: 1 = normal, 0 = clear CMOS
 */
 
+/*
+    PB400 bit meanings:
+    Bit 7 = ????
+    Bit 6 = ????
+    Bit 5 = ????
+    Bit 4 = ????
+    Bit 3 = Graphics card: 1 = on-board, 0 = standalone
+    Bit 2 = On-board graphics mode: 0 = normal, 1 = VESA
+    Bit 1 = ????
+    Bit 0 = ????
+*/
+
 typedef struct phoenix_486_jumper_t {
     uint8_t type;
     uint8_t jumper;
@@ -70,6 +82,7 @@ enum {
     PHOENIX_JUMPER_PCI     = 1,
     PHOENIX_JUMPER_PB600   = 2,
     PHOENIX_JUMPER_MONSOON = 3,
+    PHOENIX_JUMPER_PB400   = 4
 };
 
 #ifdef ENABLE_PHOENIX_486_JUMPER_LOG
@@ -103,7 +116,9 @@ phoenix_486_jumper_write(UNUSED(uint16_t addr), uint8_t val, void *priv)
         dev->jumper = ((val & 0xef) | 0x2c);
         if (gfxcard[0] != 0x01)
             dev->jumper |= 0x10;
-    } else
+    } else if (dev->type == PHOENIX_JUMPER_PB400)
+        dev->jumper = val & 0xfb;
+    else
         dev->jumper = val;
 }
 
@@ -129,6 +144,10 @@ phoenix_486_jumper_reset(void *priv)
         dev->jumper = 0x2c;
         if (gfxcard[0] != 0x01)
             dev->jumper |= 0x10;
+    } else if (dev->type == PHOENIX_JUMPER_PB400) {
+        dev->jumper = 0xfb;
+        if (gfxcard[0] != 0x01)
+            dev->jumper &= 0xf3;
     } else {
         dev->jumper = 0x9f;
         if (gfxcard[0] != 0x01)
@@ -214,3 +233,16 @@ const device_t phoenix_486_jumper_monsoon_device = {
     .config        = NULL
 };
 
+const device_t phoenix_486_jumper_pb400_device = {
+    .name          = "Phoenix 486 Jumper Readout (PB400)",
+    .internal_name = "phoenix_486_jumper_pb400",
+    .flags         = 0,
+    .local         = PHOENIX_JUMPER_PB400,
+    .init          = phoenix_486_jumper_init,
+    .close         = phoenix_486_jumper_close,
+    .reset         = phoenix_486_jumper_reset,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = NULL
+};

--- a/src/device/phoenix_486_jumper.c
+++ b/src/device/phoenix_486_jumper.c
@@ -82,7 +82,8 @@ enum {
     PHOENIX_JUMPER_PCI     = 1,
     PHOENIX_JUMPER_PB600   = 2,
     PHOENIX_JUMPER_MONSOON = 3,
-    PHOENIX_JUMPER_PB400   = 4
+    PHOENIX_JUMPER_PB400   = 4,
+    PHOENIX_JUMPER_PB430   = 5
 };
 
 #ifdef ENABLE_PHOENIX_486_JUMPER_LOG
@@ -118,6 +119,8 @@ phoenix_486_jumper_write(UNUSED(uint16_t addr), uint8_t val, void *priv)
             dev->jumper |= 0x10;
     } else if (dev->type == PHOENIX_JUMPER_PB400)
         dev->jumper = val & 0xfb;
+    else if (dev->type == PHOENIX_JUMPER_PB430)
+        dev->jumper = (val & 0xdf) | 0x9f;
     else
         dev->jumper = val;
 }
@@ -148,6 +151,10 @@ phoenix_486_jumper_reset(void *priv)
         dev->jumper = 0xfb;
         if (gfxcard[0] != 0x01)
             dev->jumper &= 0xf3;
+    } else if (dev->type == PHOENIX_JUMPER_PB430) {
+        dev->jumper = 0x9f;
+        if (gfxcard[0] != 0x01)
+            dev->jumper |= 0x40;
     } else {
         dev->jumper = 0x9f;
         if (gfxcard[0] != 0x01)
@@ -246,3 +253,18 @@ const device_t phoenix_486_jumper_pb400_device = {
     .force_redraw  = NULL,
     .config        = NULL
 };
+
+const device_t phoenix_486_jumper_pb430_device = {
+    .name          = "Phoenix 486 Jumper Readout (PB430)",
+    .internal_name = "phoenix_486_jumper_pb430",
+    .flags         = 0,
+    .local         = PHOENIX_JUMPER_PB430,
+    .init          = phoenix_486_jumper_init,
+    .close         = phoenix_486_jumper_close,
+    .reset         = phoenix_486_jumper_reset,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = NULL
+};
+

--- a/src/device/phoenix_486_jumper.c
+++ b/src/device/phoenix_486_jumper.c
@@ -65,6 +65,13 @@ typedef struct phoenix_486_jumper_t {
     uint8_t jumper;
 } phoenix_486_jumper_t;
 
+enum {
+    PHOENIX_JUMPER_DEFAULT = 0,
+    PHOENIX_JUMPER_PCI     = 1,
+    PHOENIX_JUMPER_PB600   = 2,
+    PHOENIX_JUMPER_MONSOON = 3,
+};
+
 #ifdef ENABLE_PHOENIX_486_JUMPER_LOG
 int phoenix_486_jumper_do_log = ENABLE_PHOENIX_486_JUMPER_LOG;
 
@@ -88,11 +95,11 @@ phoenix_486_jumper_write(UNUSED(uint16_t addr), uint8_t val, void *priv)
 {
     phoenix_486_jumper_t *dev = (phoenix_486_jumper_t *) priv;
     phoenix_486_jumper_log("Phoenix 486 Jumper: Write %02x\n", val);
-    if (dev->type == 1)
+    if (dev->type == PHOENIX_JUMPER_PCI)
         dev->jumper = val & 0xbf;
-    else if (dev->type == 2) /* PB600 */
+    else if (dev->type == PHOENIX_JUMPER_PB600) /* PB600 */
         dev->jumper = ((val & 0xbf) | 0x02);
-    else if (dev->type == 3) { /* Intel Monsoon */
+    else if (dev->type == PHOENIX_JUMPER_MONSOON) { /* Intel Monsoon */
         dev->jumper = ((val & 0xef) | 0x2c);
         if (gfxcard[0] != 0x01)
             dev->jumper |= 0x10;
@@ -114,11 +121,11 @@ phoenix_486_jumper_reset(void *priv)
 {
     phoenix_486_jumper_t *dev = (phoenix_486_jumper_t *) priv;
 
-    if (dev->type == 1)
+    if (dev->type == PHOENIX_JUMPER_PCI)
         dev->jumper = 0x00;
-    else if (dev->type == 2) /* PB600 */
+    else if (dev->type == PHOENIX_JUMPER_PB600) /* PB600 */
         dev->jumper = 0x02;
-    else if (dev->type == 3) { /* Intel Monsoon */
+    else if (dev->type == PHOENIX_JUMPER_MONSOON) { /* Intel Monsoon */
         dev->jumper = 0x2c;
         if (gfxcard[0] != 0x01)
             dev->jumper |= 0x10;
@@ -155,7 +162,7 @@ const device_t phoenix_486_jumper_device = {
     .name          = "Phoenix 486 Jumper Readout",
     .internal_name = "phoenix_486_jumper",
     .flags         = 0,
-    .local         = 0,
+    .local         = PHOENIX_JUMPER_DEFAULT,
     .init          = phoenix_486_jumper_init,
     .close         = phoenix_486_jumper_close,
     .reset         = phoenix_486_jumper_reset,
@@ -169,7 +176,7 @@ const device_t phoenix_486_jumper_pci_device = {
     .name          = "Phoenix 486 Jumper Readout (PCI machines)",
     .internal_name = "phoenix_486_jumper_pci",
     .flags         = 0,
-    .local         = 1,
+    .local         = PHOENIX_JUMPER_PCI,
     .init          = phoenix_486_jumper_init,
     .close         = phoenix_486_jumper_close,
     .reset         = phoenix_486_jumper_reset,
@@ -183,7 +190,7 @@ const device_t phoenix_486_jumper_pci_pb600_device = {
     .name          = "Phoenix 486 Jumper Readout (PB600)",
     .internal_name = "phoenix_486_jumper_pci_pb600",
     .flags         = 0,
-    .local         = 2,
+    .local         = PHOENIX_JUMPER_PB600,
     .init          = phoenix_486_jumper_init,
     .close         = phoenix_486_jumper_close,
     .reset         = phoenix_486_jumper_reset,
@@ -197,7 +204,7 @@ const device_t phoenix_486_jumper_monsoon_device = {
     .name          = "Phoenix 486 Jumper Readout (Monsoon)",
     .internal_name = "phoenix_486_jumper_monsoon",
     .flags         = 0,
-    .local         = 3,
+    .local         = PHOENIX_JUMPER_MONSOON,
     .init          = phoenix_486_jumper_init,
     .close         = phoenix_486_jumper_close,
     .reset         = phoenix_486_jumper_reset,

--- a/src/include/86box/chipset.h
+++ b/src/include/86box/chipset.h
@@ -241,6 +241,7 @@ extern const device_t phoenix_486_jumper_pci_device;
 extern const device_t phoenix_486_jumper_pci_pb600_device;
 extern const device_t phoenix_486_jumper_monsoon_device;
 extern const device_t phoenix_486_jumper_pb400_device;
+extern const device_t phoenix_486_jumper_pb430_device;
 
 extern const device_t ast_readout_device;
 extern const device_t ast_nvr_device;

--- a/src/include/86box/chipset.h
+++ b/src/include/86box/chipset.h
@@ -240,6 +240,7 @@ extern const device_t phoenix_486_jumper_device;
 extern const device_t phoenix_486_jumper_pci_device;
 extern const device_t phoenix_486_jumper_pci_pb600_device;
 extern const device_t phoenix_486_jumper_monsoon_device;
+extern const device_t phoenix_486_jumper_pb400_device;
 
 extern const device_t ast_readout_device;
 extern const device_t ast_nvr_device;

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -697,6 +697,9 @@ extern int             machine_at_vantage4865c_init(const machine_t *);
 /* OPTi 493 */
 extern int             machine_at_svc486wb_init(const machine_t *);
 
+/* OPTi 495SX */
+extern int             machine_at_pb400_init(const machine_t *);
+
 /* OPTi 498 */
 extern int             machine_at_mvi486_init(const machine_t *);
 

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -771,6 +771,9 @@ extern int             machine_at_martin_init(const machine_t *);
 extern int             machine_at_sensation2_init(const machine_t *);
 
 /* m_at_socket3.c */
+/* ACC 2168 */
+extern int             machine_at_pb430_init(const machine_t *);
+
 /* ALi M1429G */
 extern int             machine_at_atc1762_init(const machine_t *);
 extern int             machine_at_ecsal486_init(const machine_t *);

--- a/src/include/86box/video.h
+++ b/src/include/86box/video.h
@@ -494,6 +494,7 @@ extern const device_t oti067_device;
 extern const device_t oti067_acer386_device;
 extern const device_t oti067_ama932j_device;
 extern const device_t oti077_acer100t_device;
+extern const device_t oti077_pb400_device;
 extern const device_t oti077_pcs44c_device;
 extern const device_t oti077_device;
 

--- a/src/machine/m_at_socket1.c
+++ b/src/machine/m_at_socket1.c
@@ -144,6 +144,32 @@ machine_at_svc486wb_init(const machine_t *model)
     return ret;
 }
 
+/* OPTi 495SX */
+int
+machine_at_pb400_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/pb400/PB_400_SYSTEM_VGA_BIOS.BIN",
+                           0x000e0000, 131072, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_common_init(model);
+    device_add(&opti495sx_device);
+
+    device_add(&phoenix_486_jumper_pb400_device);
+    device_add_params(&um866x_device, (void *) (UM82C862F | UM866X_IDE_PRI));
+
+    device_add_params(machine_get_kbc_device(machine), (void *) model->kbc_params);
+
+    if (gfxcard[0] == VID_INTERNAL)
+        device_add(machine_get_vid_device(machine));
+
+    return ret;
+}
+
 /* OPTi 498 */
 int
 machine_at_mvi486_init(const machine_t *model)

--- a/src/machine/m_at_socket3.c
+++ b/src/machine/m_at_socket3.c
@@ -48,6 +48,33 @@
 #include <86box/plat_unused.h>
 #include <86box/sound.h>
 
+/* ACC 2168 */
+int
+machine_at_pb430_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/pb430/PB430-Dump-2.bin",
+                           0x000e0000, 131072, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_common_ide_init(model);
+
+    device_add_params(machine_get_kbc_device(machine), (void *) model->kbc_params);
+
+    device_add(&acc3221_device);
+    device_add(&acc2168_device);
+
+    device_add(&phoenix_486_jumper_pb430_device);
+
+    if (gfxcard[0] == VID_INTERNAL)
+        device_add(machine_get_vid_device(machine));
+
+    return ret;
+}
+
 /* ALi M1429G */
 int
 machine_at_atc1762_init(const machine_t *model)

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -8339,6 +8339,54 @@ const machine_t machines[] = {
         .net_device               = NULL,
         .aliases                  = { "" }
     },
+    /* Uses Phoenix keyboard controller firmware. */
+    {
+        .name              = "[OPTi 495SX] Packard Bell PB400",
+        .internal_name     = "pb400",
+        .type              = MACHINE_TYPE_486,
+        .chipset           = MACHINE_CHIPSET_OPTI_495SX,
+        .init              = machine_at_pb400_init,
+        .p1_handler        = machine_generic_p1_handler,
+        .gpio_handler      = NULL,
+        .available_flag    = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu               = {
+            .package     = CPU_PKG_SOCKET1,
+            .block       = CPU_BLOCK_NONE,
+            .min_bus     = 16000000,
+            .max_bus     = 33333333,
+            .min_voltage = 5000,
+            .max_voltage = 5000,
+            .min_multi   = 0,
+            .max_multi   = 0
+        },
+        .bus_flags = MACHINE_PS2,
+        .flags     = MACHINE_IDE | MACHINE_VIDEO,
+        .ram       = {
+            .min  = 4096,
+            .max  = 20480,
+            .step = 1024
+        },
+        .nvrmask                  = 127,
+        .jumpered_ecp_dma         = 0,
+        .default_jumpered_ecp_dma = -1,
+        .kbc_device               = &kbc_at_device,
+        .kbc_params               = KBC_VEN_PHOENIX | 0x00012900,
+        .nvr_device               = &nvr_at_device,
+        .nvr_params               = NVR_AT,
+        .sio_device               = NULL,
+        .sio_params               = 0x00000000,
+        .kbc_p1                   = 0x000004f0,
+        .gpio                     = 0xffffffff,
+        .gpio_acpi                = 0xffffffff,
+        .device                   = NULL,
+        .kbd_device               = NULL,
+        .fdc_device               = NULL,
+        .vid_device               = &oti077_pb400_device,
+        .snd_device               = NULL,
+        .net_device               = NULL,
+        .aliases                  = { "Packard Bell PB401T", "" }
+    },
     /* Uses some variant of Phoenix MultiKey/42 as the Intel 8242 chip has a Phoenix
        copyright. */
     {

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -9802,6 +9802,55 @@ const machine_t machines[] = {
 
     /* 486 machines - Socket 3 */
     /* 486 machines with just the ISA slot */
+    /* Uses some variant of Phoenix MultiKey/42 as the BIOS sends keyboard controller
+       command C7 (OR input byte with received data byte). */
+    {
+        .name              = "[ACC 2168] Packard Bell PB430",
+        .internal_name     = "pb430",
+        .type              = MACHINE_TYPE_486_S3,
+        .chipset           = MACHINE_CHIPSET_ACC_2168,
+        .init              = machine_at_pb430_init,
+        .p1_handler        = machine_generic_p1_handler,
+        .gpio_handler      = NULL,
+        .available_flag    = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu               = {
+            .package     = CPU_PKG_SOCKET3,
+            .block       = CPU_BLOCK_NONE,
+            .min_bus     = 20000000,
+            .max_bus     = 33333333,
+            .min_voltage = 3300,
+            .max_voltage = 5000,
+            .min_multi   = 0,
+            .max_multi   = 0
+        },
+        .bus_flags = MACHINE_PS2,
+        .flags     = MACHINE_IDE | MACHINE_VIDEO | MACHINE_GAMEPORT,
+        .ram       = {
+            .min  = 4096,
+            .max  = 65536,
+            .step = 1024
+        },
+        .nvrmask                  = 127,
+        .jumpered_ecp_dma         = 0,
+        .default_jumpered_ecp_dma = -1,
+        .kbc_device               = &kbc_at_device,
+        .kbc_params               = KBC_VEN_PHOENIX | 0x00012900 /* Guess. */,
+        .nvr_device               = &nvr_at_device,
+        .nvr_params               = NVR_AT,
+        .sio_device               = NULL,
+        .sio_params               = 0x00000000,
+        .kbc_p1                   = 0x00000cf0,
+        .gpio                     = 0xffffffff,
+        .gpio_acpi                = 0xffffffff,
+        .device                   = NULL,
+        .kbd_device               = NULL,
+        .fdc_device               = NULL,
+        .vid_device               = &gd5424_onboard_device,
+        .snd_device               = NULL,
+        .net_device               = NULL,
+        .aliases                  = { "Packard Bell PB440", "Packard Bell PB440T", "" }
+    },
     /* JETKey V5.0 */
     {
         .name              = "[ALi M1429G] A-Trend ATC-1762",

--- a/src/video/vid_cl54xx.c
+++ b/src/video/vid_cl54xx.c
@@ -5134,8 +5134,10 @@ gd54xx_init(const device_t *info)
             break;
 
         case CIRRUS_ID_CLGD5424:
-            if (local & 0x200)
-                romfn = /*NULL*/ "roms/machines/advantage40xxd/AST101.09A";
+            if ((local & 0x200) && (machines[machine].init == machine_at_advantage40xxd_init))
+                romfn = "roms/machines/advantage40xxd/AST101.09A";
+            else if (local & 0x200)
+                romfn = NULL;
             else
                 romfn = BIOS_GD5422_PATH;
             break;

--- a/src/video/vid_oak_oti.c
+++ b/src/video/vid_oak_oti.c
@@ -37,6 +37,7 @@
 #define BIOS_077_PATH         "roms/video/oti/oti077.vbi"
 #define BIOS_077_ACER100T_PATH "roms/machines/acer100t/oti077_acer100t.BIN"
 #define BIOS_077_PCS44C_PATH  "roms/machines/pcs44c/V032004G.25"
+#define BIOS_077_PB400_PATH   "roms/machines/pb400/PB_400_SYSTEM_VGA_BIOS.BIN"
 
 enum {
     OTI_037C         = 0,
@@ -46,7 +47,8 @@ enum {
     OTI_067_M300     = 4,
     OTI_077          = 5,
     OTI_077_ACER100T = 6,
-    OTI_077_PCS44C   = 7
+    OTI_077_PCS44C   = 7,
+    OTI_077_PB400    = 8
 };
 
 typedef struct {
@@ -105,7 +107,7 @@ oti_out(uint16_t addr, uint8_t val, void *priv)
         case 0x3c8:
         case 0x3c9:
             if ((oti->chip_id == OTI_077) || (oti->chip_id == OTI_077_ACER100T) ||
-                (oti->chip_id == OTI_077_PCS44C))
+                (oti->chip_id == OTI_077_PCS44C) || (oti->chip_id == OTI_077_PB400))
                 sc1148x_ramdac_out(addr, 0, val, svga->ramdac, svga);
             else
                 svga_out(addr, val, svga);
@@ -168,7 +170,7 @@ oti_out(uint16_t addr, uint8_t val, void *priv)
                         else
                             mem_mapping_enable(&svga->mapping);
                     } else if ((oti->chip_id == OTI_077) || (oti->chip_id == OTI_077_ACER100T) ||
-                               (oti->chip_id == OTI_077_PCS44C)) {
+                               (oti->chip_id == OTI_077_PCS44C) || (oti->chip_id == OTI_077_PB400)) {
                         svga->vram_display_mask = (val & 0x0c) ? oti->vram_mask : 0x3ffff;
 
                         switch ((val & 0xc0) >> 6) {
@@ -258,7 +260,7 @@ oti_in(uint16_t addr, void *priv)
         case 0x3c8:
         case 0x3c9:
             if ((oti->chip_id == OTI_077) || (oti->chip_id == OTI_077_ACER100T) ||
-                (oti->chip_id == OTI_077_PCS44C))
+                (oti->chip_id == OTI_077_PCS44C) || (oti->chip_id == OTI_077_PB400))
                 temp = sc1148x_ramdac_in(addr, 0, svga->ramdac, svga);
             else
                 temp = svga_in(addr, svga);
@@ -528,6 +530,12 @@ oti_init(const device_t *info)
             oti->pos = 0x08; /* Tell the BIOS the I/O ports are already enabled to avoid a double I/O handler mess. */
             io_sethandler(0x46e8, 1, oti_pos_in, NULL, NULL, oti_pos_out, NULL, NULL, oti);
             break;
+        case OTI_077_PB400:
+            romfn          = NULL;
+            oti->vram_size = device_get_config_int("memory");
+            oti->pos = 0x08; /* Tell the BIOS the I/O ports are already enabled to avoid a double I/O handler mess. */
+            io_sethandler(0x46e8, 1, oti_pos_in, NULL, NULL, oti_pos_out, NULL, NULL, oti);
+            break;
 
         default:
             break;
@@ -552,7 +560,7 @@ oti_init(const device_t *info)
               oti_recalctimings, oti_in, oti_out, NULL, NULL);
 
     if ((oti->chip_id == OTI_077) || (oti->chip_id == OTI_077_ACER100T) ||
-        (oti->chip_id == OTI_077_PCS44C))
+        (oti->chip_id == OTI_077_PCS44C) || (oti->chip_id == OTI_077_PB400))
         oti->svga.ramdac = device_add(&sc11487_ramdac_device); /*Actually a 82c487, probably a clone.*/
 
     io_sethandler(0x03c0, 32,
@@ -612,6 +620,12 @@ static int
 oti077_pcs44c_available(void)
 {
     return (rom_present(BIOS_077_PCS44C_PATH));
+}
+
+static int
+oti077_pb400_available(void)
+{
+    return (rom_present(BIOS_077_PB400_PATH));
 }
 
 static int
@@ -822,5 +836,19 @@ const device_t oti077_pcs44c_device = {
     .speed_changed = oti_speed_changed,
     .force_redraw  = oti_force_redraw,
     .machine       = "Olivetti PCS 44/C",
+    .config        = oti077_acer100t_config
+};
+
+const device_t oti077_pb400_device = {
+    .name          = "Oak OTI-077 On-Board (Packard Bell PB400)",
+    .internal_name = "oti077_pb400",
+    .flags         = DEVICE_ISA,
+    .local         = 8,
+    .init          = oti_init,
+    .close         = oti_close,
+    .reset         = NULL,
+    .available     = oti077_pb400_available,
+    .speed_changed = oti_speed_changed,
+    .force_redraw  = oti_force_redraw,
     .config        = oti077_acer100t_config
 };


### PR DESCRIPTION
Summary
=======
Add the Packard Bell PB400 (Socket 1 OPTi 495 with onboard OAK OTI-077 video) and Packard Bell PB430/440 (Socket 3 ACC 2168 with onboard Cirrus 5424 video) machines. Also clean up the Phoenix jumper code a bit and fix a shadow RAM/ROMCS# edge case in the OPTi 495 chipset.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/501
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
OPTi 82C495XLC datasheet: https://bitsavers.org/components/opti/dataSheets/82C495XLC_82C206_PC_AT_Chip_Set_199410.pdf