### PR TITLE
cdrom_aaru: Fix reading of DVD disc images

### DIFF
--- a/src/cdrom/cdrom_aaru.c
+++ b/src/cdrom/cdrom_aaru.c
@@ -255,7 +255,7 @@ aaru_image_read_sector(const void *local, UNUSED(uint8_t *buffer), UNUSED(uint32
         length = 2352;
         // Just read the audio sector. Errors can be ignored here.
         (void)f_aaruf_read_sector(ioctl->aaruf_context, lba, false, buffer, &length, &sector_status);
-    } else if (f_aaruf_read_sector_long(ioctl->aaruf_context, lba, false, buffer, &length, &sector_status)) {
+    } else if (ioctl->is_dvd || f_aaruf_read_sector_long(ioctl->aaruf_context, lba, false, buffer, &length, &sector_status)) {
         length = 2048;
         if (!f_aaruf_read_sector(ioctl->aaruf_context, lba, false, buffer, &length, &sector_status))
             goto generate_headers;


### PR DESCRIPTION
Summary
=======
cdrom_aaru: Fix reading of DVD disc images.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
