### PR TITLE
cdrom_aaru: fix library loading on *nix and macOS

### DIFF
--- a/src/cdrom/cdrom_aaru.c
+++ b/src/cdrom/cdrom_aaru.c
@@ -62,7 +62,13 @@ ensure_libaaruformat(void)
     if (load_failed)
         return false;
     if (!libaaruformat_handle) {
+#ifdef __APPLE__
+        libaaruformat_handle = dynld_module("libaaruformat.dylib", aaruf_imports);
+#elif defined __unix__
+        libaaruformat_handle = dynld_module("libaaruformat.so", aaruf_imports);
+#else
         libaaruformat_handle = dynld_module("libaaruformat.dll", aaruf_imports);
+#endif
         if (!libaaruformat_handle) {
             warning("Failed to load libaaruformat library.");
             load_failed = true;


### PR DESCRIPTION
Summary
=======
cdrom_aaru: fix library loading on *nix and macOS.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
