### PR TITLE
Remove title and scroll area background from manager UI

### DIFF
--- a/src/qt/qt_vmmanager_details.cpp
+++ b/src/qt/qt_vmmanager_details.cpp
@@ -32,8 +32,8 @@ extern "C" {
 #else
 #    define TOOLBUTTON_STYLESHEET_DARK "QToolButton {background: transparent; border: none; padding: 5px} QToolButton:hover {background: palette(dark)} QToolButton:pressed {background: palette(mid)}"
 #endif
-#define SCROLLAREA_STYLESHEET_LIGHT  "QWidget {background-color: palette(light)} QScrollBar{ background-color: none }"
-#define SYSTEMLABEL_STYLESHEET_LIGHT "background-color: palette(midlight);"
+#define SCROLLAREA_STYLESHEET_LIGHT  ""
+#define SYSTEMLABEL_STYLESHEET_LIGHT ""
 
 using namespace VMManager;
 


### PR DESCRIPTION
Summary
=======
Blanking out the background for consistency and looks.

Examples from Linux build.

Confirmed on Discord it looked fine for Windows as well. May need a Mac OS test.

<img width="1495" height="950" alt="image" src="https://github.com/user-attachments/assets/c8d8b07e-e02d-4f6c-902b-487446d3a20a" />
<img width="1495" height="950" alt="image" src="https://github.com/user-attachments/assets/884329fa-6080-434e-b48b-c7c37bc1a5e8" />
<img width="1495" height="950" alt="image" src="https://github.com/user-attachments/assets/d519baeb-f139-4ed3-bd85-8b0831b870c4" />
<img width="1495" height="950" alt="image" src="https://github.com/user-attachments/assets/a227dc6f-b4b8-4584-ab89-024a8a101e3c" />


Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/


