### PR TITLE
cdrom_aaru: Add missing copyright header

### DIFF
--- a/src/cdrom/cdrom_aaru.c
+++ b/src/cdrom/cdrom_aaru.c
@@ -1,3 +1,22 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          Support for Aaru format images via libaaruformat.
+ *
+ * Authors: TheCollector1995, <mariogplayer@gmail.com>,
+ *          Miran Grca, <mgrca8@gmail.com>
+ *          Cacodemon345
+ *
+ *          Copyright 2023 TheCollector1995.
+ *          Copyright 2023 Miran Grca.
+ *          Copyright 2026 Cacodemon345.
+ */
+
 #include <aaruformat.h>
 
 #define __STDC_FORMAT_MACROS


### PR DESCRIPTION
Summary
=======
cdrom_aaru: Add missing copyright header.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
