### PR TITLE
Fix some more abnormal refresh rates in the early stepping of the et4000ax

### DIFF
--- a/src/video/vid_et4000.c
+++ b/src/video/vid_et4000.c
@@ -646,7 +646,10 @@ static void
 et4000_recalctimings(svga_t *svga)
 {
     const et4000_t *dev = (et4000_t *) svga->priv;
-    int clk_sel = ((svga->miscout >> 2) & 0x03) | ((svga->crtc[0x34] << 1) & 0x04) | ((svga->crtc[0x31] >> 3) & 0x08);
+    int clk_sel = ((svga->miscout >> 2) & 0x03) | ((svga->crtc[0x34] << 1) & 0x04);
+
+    if (svga->getclock != NULL)
+        clk_sel |= ((svga->crtc[0x31] >> 3) & 0x08);
 
     svga->memaddr_latch |= (svga->crtc[0x33] & 3) << 16;
 
@@ -674,19 +677,25 @@ et4000_recalctimings(svga_t *svga)
     }
 
     if (svga->getclock == NULL) {
-        /* Assume it has the same timings as the ET3000AX. */
-        switch (((svga->miscout >> 2) & 3) | ((svga->crtc[0x34] << 1) & 4)) {
+        switch (clk_sel) {
             case 0:
             case 1:
                 break;
             case 3:
                 svga->clock = (cpuclock * (double) (1ULL << 32)) / 40000000.0;
                 break;
-            case 5:
-                svga->clock = (cpuclock * (double) (1ULL << 32)) / 65000000.0;
-                break;
-            default:
+            case 4:
                 svga->clock = (cpuclock * (double) (1ULL << 32)) / 36000000.0;
+                break;
+            case 5:
+                svga->clock = (cpuclock * (double) (1ULL << 32)) / 45000000.0;
+                break;
+            case 6:
+                svga->clock = (cpuclock * (double) (1ULL << 32)) / 31000000.0;
+                break;
+            case 7:
+                svga->clock = (cpuclock * (double) (1ULL << 32)) / 38000000.0;
+            default:
                 break;
         }
     } else


### PR DESCRIPTION
Summary
=======
Actually using MAME's et4000 clocks for it, now the refresh rates are saner in, e.g., Windows 3.x.

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
