### PR TITLE
Buslogic-specific fix: when there's no target ID present, make sure the data reply is still there.

### DIFF
--- a/src/scsi/scsi_buslogic.c
+++ b/src/scsi/scsi_buslogic.c
@@ -604,6 +604,7 @@ BuslogicSCSIBIOSRequestSetup(x54x_t *dev, uint8_t *CmdBuf, uint8_t *DataInBuf, u
     if ((ESCSICmd->TargetId > 15) || (ESCSICmd->LogicalUnit > 7)) {
         DataInBuf[2] = CCB_INVALID_CCB;
         DataInBuf[3] = SCSI_STATUS_OK;
+        dev->DataReplyLeft = DataReply;
         return;
     }
 
@@ -615,6 +616,7 @@ BuslogicSCSIBIOSRequestSetup(x54x_t *dev, uint8_t *CmdBuf, uint8_t *DataInBuf, u
         buslogic_log("SCSI Target ID %i has no device attached\n", ESCSICmd->TargetId);
         DataInBuf[2] = CCB_SELECTION_TIMEOUT;
         DataInBuf[3] = SCSI_STATUS_OK;
+        dev->DataReplyLeft = DataReply;
         return;
     } else {
         buslogic_log("SCSI Target ID %i detected and working\n", ESCSICmd->TargetId);


### PR DESCRIPTION
Summary
=======
For the device IDs to be scanned properly within the BIOS of the SCSI controllers based on the buslogic chip. (This fixes hangs when scanning such IDs).

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
