### PR TITLE
Qt: Replace QTableViews with QTreeViews

### DIFF
--- a/src/qt/qt_preferenceskeybindings.cpp
+++ b/src/qt/qt_preferenceskeybindings.cpp
@@ -55,15 +55,14 @@ PreferencesKeyBindings::PreferencesKeyBindings(QWidget *parent)
 
     model->setHeaderData(0, Qt::Horizontal, tr("Action"));
     model->setHeaderData(1, Qt::Horizontal, tr("Keybind"));
-    ui->tableKeys->setModel(model);
+    ui->treeViewKeys->setModel(model);
 
     model->insertRows(0, NUM_ACCELS);
-    ui->tableKeys->setColumnWidth(0, 200);
-    ui->tableKeys->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+    ui->treeViewKeys->header()->setSectionResizeMode(0, QHeaderView::Stretch);
 
-    connect(ui->tableKeys->selectionModel(), &QItemSelectionModel::currentRowChanged,
+    connect(ui->treeViewKeys->selectionModel(), &QItemSelectionModel::currentRowChanged,
             this, &PreferencesKeyBindings::onKeyBindingsRowChanged);
-    ui->tableKeys->setCurrentIndex(model->index(0, 0));
+    ui->treeViewKeys->setCurrentIndex(model->index(0, 0));
 
     // Make a working copy of acc_keys so we can check for dupes later without getting
     // confused
@@ -90,16 +89,15 @@ PreferencesKeyBindings::save()
 void
 PreferencesKeyBindings::refreshInputList()
 {
-    auto *model = ui->tableKeys->model();
+    auto *model = ui->treeViewKeys->model();
 
     for (int x = 0; x < NUM_ACCELS; x++) {
-        ui->tableKeys->setRowHeight(x, 25);
         QModelIndex idx = model->index(x, 0);
         model->setData(idx, tr(acc_keys[x].desc));
         model->setData(idx, QString(acc_keys[x].name), Qt::UserRole);
         model->setData(idx.siblingAtColumn(1), QKeySequence(acc_keys_t[x].seq, QKeySequence::PortableText).toString(QKeySequence::NativeText));
     }
-    ui->tableKeys->resizeColumnToContents(0);
+    ui->treeViewKeys->resizeColumnToContents(0);
 }
 
 void
@@ -115,13 +113,13 @@ PreferencesKeyBindings::onKeyBindingsRowChanged(const QModelIndex &current)
 }
 
 void
-PreferencesKeyBindings::on_tableKeys_doubleClicked(const QModelIndex &idx)
+PreferencesKeyBindings::on_treeViewKeys_doubleClicked(const QModelIndex &idx)
 {
     // Edit bind
     if (!idx.isValid())
         return;
 
-    auto        *model      = ui->tableKeys->model();
+    auto        *model      = ui->treeViewKeys->model();
     QString      keyseqText = model->data(idx.siblingAtColumn(1)).toString();
     QKeySequence keyseq     = KeyBinder::BindKey(this, keyseqText);
     if (keyseq != false) {
@@ -160,22 +158,22 @@ void
 PreferencesKeyBindings::on_pushButtonBind_clicked()
 {
     // Edit bind
-    auto idx = ui->tableKeys->selectionModel()->currentIndex();
+    auto idx = ui->treeViewKeys->selectionModel()->currentIndex();
     if (!idx.isValid())
         return;
 
-    on_tableKeys_doubleClicked(idx);
+    on_treeViewKeys_doubleClicked(idx);
 }
 
 void
 PreferencesKeyBindings::on_pushButtonClearBind_clicked()
 {
     // Wipe bind
-    auto idx = ui->tableKeys->selectionModel()->currentIndex();
+    auto idx = ui->treeViewKeys->selectionModel()->currentIndex();
     if (!idx.isValid())
         return;
 
-    auto *model = ui->tableKeys->model();
+    auto *model = ui->treeViewKeys->model();
     model->setData(idx.siblingAtColumn(1), "");
 
     // Find the correct accelerator key entry

--- a/src/qt/qt_preferenceskeybindings.cpp
+++ b/src/qt/qt_preferenceskeybindings.cpp
@@ -18,6 +18,7 @@
 #include "qt_mainwindow.hpp"
 
 #include <QDialog>
+#include <QStandardItemModel>
 #include <QTranslator>
 #include <QDebug>
 #include <QKeySequence>
@@ -41,8 +42,6 @@ extern "C" {
 
 extern MainWindow *main_window;
 
-accelKey org_acc_keys_t[NUM_ACCELS];
-
 // Temporary working copy of key list
 accelKey acc_keys_t[NUM_ACCELS];
 
@@ -52,36 +51,24 @@ PreferencesKeyBindings::PreferencesKeyBindings(QWidget *parent)
 {
     ui->setupUi(this);
 
-    QStringList horizontalHeader;
-    QStringList verticalHeader;
+    QAbstractItemModel *model = new QStandardItemModel(0, 2, this);
 
-    horizontalHeader.append(tr("Action"));
-    horizontalHeader.append(tr("Keybind"));
+    model->setHeaderData(0, Qt::Horizontal, tr("Action"));
+    model->setHeaderData(1, Qt::Horizontal, tr("Keybind"));
+    ui->tableKeys->setModel(model);
 
-    QTableWidget *keyTable = ui->tableKeys;
-    keyTable->setRowCount(NUM_ACCELS);
-    for (int i = 0; i < NUM_ACCELS; i++)
-        keyTable->setRowHeight(i, 25);
-    keyTable->setColumnCount(3);
-    keyTable->setColumnHidden(2, true);
-    keyTable->setColumnWidth(0, 200);
-    keyTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
-    QStringList headers;
-    // headers << "Action" << "Bound key";
-    keyTable->setHorizontalHeaderLabels(horizontalHeader);
-    keyTable->verticalHeader()->setVisible(false);
-    keyTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
-    keyTable->setSelectionBehavior(QAbstractItemView::SelectRows);
-    keyTable->setSelectionMode(QAbstractItemView::SingleSelection);
-    keyTable->setShowGrid(true);
+    model->insertRows(0, NUM_ACCELS);
+    ui->tableKeys->setColumnWidth(0, 200);
+    ui->tableKeys->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+
+    connect(ui->tableKeys->selectionModel(), &QItemSelectionModel::currentRowChanged,
+            this, &PreferencesKeyBindings::onKeyBindingsRowChanged);
+    ui->tableKeys->setCurrentIndex(model->index(0, 0));
 
     // Make a working copy of acc_keys so we can check for dupes later without getting
     // confused
-    for (int x = 0; x < NUM_ACCELS; x++) {
-        strcpy(acc_keys_t[x].name, acc_keys[x].name);
-        strcpy(acc_keys_t[x].desc, acc_keys[x].desc);
+    for (int x = 0; x < NUM_ACCELS; x++)
         strcpy(acc_keys_t[x].seq, acc_keys[x].seq);
-    }
 
     refreshInputList();
 }
@@ -95,30 +82,30 @@ void
 PreferencesKeyBindings::save()
 {
     // Copy accelerators from working set to global set
-    for (int x = 0; x < NUM_ACCELS; x++) {
-        strcpy(acc_keys[x].name, acc_keys_t[x].name);
-        strcpy(acc_keys[x].desc, acc_keys_t[x].desc);
+    for (int x = 0; x < NUM_ACCELS; x++)
         strcpy(acc_keys[x].seq, acc_keys_t[x].seq);
-    }
     Preferences::reloadStrings();
 }
 
 void
 PreferencesKeyBindings::refreshInputList()
 {
+    auto *model = ui->tableKeys->model();
+
     for (int x = 0; x < NUM_ACCELS; x++) {
-        ui->tableKeys->setItem(x, 0, new QTableWidgetItem(tr(acc_keys_t[x].desc)));
-        ui->tableKeys->setItem(x, 1, new QTableWidgetItem(QKeySequence(acc_keys_t[x].seq, QKeySequence::PortableText).toString(QKeySequence::NativeText)));
-        ui->tableKeys->setItem(x, 2, new QTableWidgetItem(acc_keys_t[x].name));
+        ui->tableKeys->setRowHeight(x, 25);
+        QModelIndex idx = model->index(x, 0);
+        model->setData(idx, tr(acc_keys[x].desc));
+        model->setData(idx, QString(acc_keys[x].name), Qt::UserRole);
+        model->setData(idx.siblingAtColumn(1), QKeySequence(acc_keys_t[x].seq, QKeySequence::PortableText).toString(QKeySequence::NativeText));
     }
+    ui->tableKeys->resizeColumnToContents(0);
 }
 
 void
-PreferencesKeyBindings::on_tableKeys_currentCellChanged(int currentRow, int currentColumn, int previousRow, int previousColumn)
+PreferencesKeyBindings::onKeyBindingsRowChanged(const QModelIndex &current)
 {
-    // Enable/disable bind/clear buttons if user clicked valid row
-    QTableWidgetItem *cell = ui->tableKeys->item(currentRow, 1);
-    if (!cell) {
+    if (!current.isValid()) {
         ui->pushButtonBind->setEnabled(false);
         ui->pushButtonClearBind->setEnabled(false);
     } else {
@@ -128,40 +115,42 @@ PreferencesKeyBindings::on_tableKeys_currentCellChanged(int currentRow, int curr
 }
 
 void
-PreferencesKeyBindings::on_tableKeys_cellDoubleClicked(int row, int col)
+PreferencesKeyBindings::on_tableKeys_doubleClicked(const QModelIndex &idx)
 {
     // Edit bind
-    QTableWidgetItem *cell = ui->tableKeys->item(row, 1);
-    if (!cell)
+    if (!idx.isValid())
         return;
 
-    QKeySequence keyseq = KeyBinder::BindKey(this, cell->text());
+    auto        *model      = ui->tableKeys->model();
+    QString      keyseqText = model->data(idx.siblingAtColumn(1)).toString();
+    QKeySequence keyseq     = KeyBinder::BindKey(this, keyseqText);
     if (keyseq != false) {
         // If no change was made, don't change anything.
-        if (keyseq.toString(QKeySequence::NativeText) == cell->text())
+        if (keyseq.toString(QKeySequence::NativeText) == keyseqText)
             return;
 
         // Otherwise, check for conflicts.
         // Check against the *working* copy - NOT the one in use by the app,
         // so we don't test against shortcuts the user already changed.
         for (int x = 0; x < NUM_ACCELS; x++) {
-            if (QString::fromStdString(acc_keys_t[x].seq) == keyseq.toString(QKeySequence::PortableText)) {
+            if (QString(acc_keys_t[x].seq) == keyseq.toString(QKeySequence::PortableText)) {
                 // That key is already in use
                 QMessageBox::warning(this, tr("Bind conflict"), tr("This key combo is already in use."), QMessageBox::StandardButton::Ok);
                 return;
             }
         }
+
         // If we made it here, there were no conflicts.
         // Go ahead and apply the bind.
 
         // Find the correct accelerator key entry
-        int accKeyID = FindAccelerator(ui->tableKeys->item(row, 2)->text().toUtf8().constData());
+        int accKeyID = FindAccelerator(model->data(idx.siblingAtColumn(0), Qt::UserRole).toString().toUtf8().constData());
         if (accKeyID < 0)
             return; // this should never happen
 
         // Make the change
-        cell->setText(keyseq.toString(QKeySequence::NativeText));
-        strcpy(acc_keys_t[accKeyID].seq, keyseq.toString(QKeySequence::PortableText).toUtf8().constData());
+        model->setData(idx.siblingAtColumn(1), keyseq.toString(QKeySequence::NativeText));
+        strncpy(acc_keys_t[accKeyID].seq, keyseq.toString(QKeySequence::PortableText).toUtf8().constData(), sizeof(acc_keys_t[accKeyID].seq) - 1);
 
         refreshInputList();
     }
@@ -171,28 +160,29 @@ void
 PreferencesKeyBindings::on_pushButtonBind_clicked()
 {
     // Edit bind
-    QTableWidgetItem *cell = ui->tableKeys->currentItem();
-    if (!cell)
+    auto idx = ui->tableKeys->selectionModel()->currentIndex();
+    if (!idx.isValid())
         return;
 
-    on_tableKeys_cellDoubleClicked(cell->row(), cell->column());
+    on_tableKeys_doubleClicked(idx);
 }
 
 void
 PreferencesKeyBindings::on_pushButtonClearBind_clicked()
 {
     // Wipe bind
-    QTableWidgetItem *cell = ui->tableKeys->item(ui->tableKeys->currentRow(), 1);
-    if (!cell)
+    auto idx = ui->tableKeys->selectionModel()->currentIndex();
+    if (!idx.isValid())
         return;
 
-    cell->setText("");
+    auto *model = ui->tableKeys->model();
+    model->setData(idx.siblingAtColumn(1), "");
+
     // Find the correct accelerator key entry
-    int accKeyID = FindAccelerator(ui->tableKeys->item(cell->row(), 2)->text().toUtf8().constData());
+    int accKeyID = FindAccelerator(model->data(idx.siblingAtColumn(0), Qt::UserRole).toString().toUtf8().constData());
     if (accKeyID < 0)
         return; // this should never happen
 
     // Make the change
-    cell->setText("");
     strcpy(acc_keys_t[accKeyID].seq, "");
 }

--- a/src/qt/qt_preferenceskeybindings.hpp
+++ b/src/qt/qt_preferenceskeybindings.hpp
@@ -18,7 +18,7 @@ public:
 
 private slots:
     void onKeyBindingsRowChanged(const QModelIndex &current);
-    void on_tableKeys_doubleClicked(const QModelIndex &idx);
+    void on_treeViewKeys_doubleClicked(const QModelIndex &idx);
 
     void on_pushButtonClearBind_clicked();
     void on_pushButtonBind_clicked();

--- a/src/qt/qt_preferenceskeybindings.hpp
+++ b/src/qt/qt_preferenceskeybindings.hpp
@@ -2,12 +2,6 @@
 #define QT_PREFERENCESKEYBINDINGS_HPP
 
 #include <QWidget>
-#include <QtGui/QStandardItemModel>
-#include <QtGui/QStandardItem>
-#include <QItemDelegate>
-#include <QPainter>
-#include <QVariant>
-#include <QTableWidget>
 
 namespace Ui {
 class PreferencesKeyBindings;
@@ -23,8 +17,8 @@ public:
     void save();
 
 private slots:
-    void on_tableKeys_cellDoubleClicked(int row, int col);
-    void on_tableKeys_currentCellChanged(int currentRow, int currentColumn, int previousRow, int previousColumn);
+    void onKeyBindingsRowChanged(const QModelIndex &current);
+    void on_tableKeys_doubleClicked(const QModelIndex &idx);
 
     void on_pushButtonClearBind_clicked();
     void on_pushButtonBind_clicked();

--- a/src/qt/qt_preferenceskeybindings.ui
+++ b/src/qt/qt_preferenceskeybindings.ui
@@ -40,26 +40,26 @@
       <number>0</number>
      </property>
      <item row="0" column="0" colspan="3">
-      <widget class="QTableView" name="tableKeys">
+      <widget class="QTreeView" name="treeViewKeys">
        <property name="editTriggers">
         <set>QAbstractItemView::NoEditTriggers</set>
        </property>
        <property name="selectionMode">
         <enum>QAbstractItemView::SingleSelection</enum>
        </property>
-       <property name="selectionBehavior">
-        <enum>QAbstractItemView::SelectRows</enum>
-       </property>
-       <property name="tabKeyNavigation">
-        <bool>false</bool>
-       </property>
-       <property name="showGrid">
-        <bool>true</bool>
-       </property>
        <attribute name="verticalHeaderVisible">
         <bool>false</bool>
        </attribute>
        <property name="alternatingRowColors">
+        <bool>true</bool>
+       </property>
+       <property name="tabKeyNavigation">
+        <bool>false</bool>
+       </property>
+       <property name="rootIsDecorated">
+        <bool>false</bool>
+       </property>
+       <property name="allColumnsShowFocus">
         <bool>true</bool>
        </property>
       </widget>

--- a/src/qt/qt_preferenceskeybindings.ui
+++ b/src/qt/qt_preferenceskeybindings.ui
@@ -40,21 +40,27 @@
       <number>0</number>
      </property>
      <item row="0" column="0" colspan="3">
-      <widget class="QTableWidget" name="tableKeys">
+      <widget class="QTableView" name="tableKeys">
        <property name="editTriggers">
         <set>QAbstractItemView::NoEditTriggers</set>
+       </property>
+       <property name="selectionMode">
+        <enum>QAbstractItemView::SingleSelection</enum>
+       </property>
+       <property name="selectionBehavior">
+        <enum>QAbstractItemView::SelectRows</enum>
        </property>
        <property name="tabKeyNavigation">
         <bool>false</bool>
        </property>
-       <property name="showDropIndicator" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="alternatingRowColors">
+       <property name="showGrid">
         <bool>true</bool>
        </property>
-       <property name="selectionBehavior">
-        <enum>QAbstractItemView::SelectRows</enum>
+       <attribute name="verticalHeaderVisible">
+        <bool>false</bool>
+       </attribute>
+       <property name="alternatingRowColors">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -75,9 +81,6 @@
        </item>
        <item>
         <widget class="QPushButton" name="pushButtonClearBind">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
          <property name="minimumSize">
           <size>
            <width>100</width>
@@ -91,9 +94,6 @@
        </item>
        <item>
         <widget class="QPushButton" name="pushButtonBind">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
          <property name="minimumSize">
           <size>
            <width>100</width>

--- a/src/qt/qt_settingsfloppycdrom.cpp
+++ b/src/qt/qt_settingsfloppycdrom.cpp
@@ -144,7 +144,7 @@ SettingsFloppyCDROM::SettingsFloppyCDROM(QWidget *parent)
     }
 
     model = new QStandardItemModel(0, 3, this);
-    ui->tableViewFloppy->setModel(model);
+    ui->treeViewFloppy->setModel(model);
     model->setHeaderData(0, Qt::Horizontal, tr("Type"));
     model->setHeaderData(1, Qt::Horizontal, tr("Turbo"));
     model->setHeaderData(2, Qt::Horizontal, tr("Check BPB"));
@@ -152,7 +152,6 @@ SettingsFloppyCDROM::SettingsFloppyCDROM(QWidget *parent)
     model->insertRows(0, FDD_NUM);
     /* Floppy drives category */
     for (int i = 0; i < FDD_NUM; i++) {
-        ui->tableViewFloppy->setRowHeight(i, 25);
         auto idx  = model->index(i, 0);
         int  type = fdd_get_type(i);
         setFloppyType(model, idx, type);
@@ -166,10 +165,10 @@ SettingsFloppyCDROM::SettingsFloppyCDROM(QWidget *parent)
 #endif
     }
 
-    ui->tableViewFloppy->resizeColumnsToContents();
-    ui->tableViewFloppy->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+    for (int i = 0; i < model->columnCount(); i++)
+        ui->treeViewFloppy->resizeColumnToContents(i);
 
-    connect(ui->tableViewFloppy->selectionModel(), &QItemSelectionModel::currentRowChanged,
+    connect(ui->treeViewFloppy->selectionModel(), &QItemSelectionModel::currentRowChanged,
             this, &SettingsFloppyCDROM::onFloppyRowChanged);
 
 #ifndef DISABLE_FDD_AUDIO
@@ -191,7 +190,7 @@ SettingsFloppyCDROM::SettingsFloppyCDROM(QWidget *parent)
 #endif
 
     // Set initial selection and trigger the row changed event to update controls
-    ui->tableViewFloppy->setCurrentIndex(model->index(0, 0));
+    ui->treeViewFloppy->setCurrentIndex(model->index(0, 0));
     // Manually trigger the row changed event to ensure audio selection is updated
     onFloppyRowChanged(model->index(0, 0));
 
@@ -206,13 +205,12 @@ SettingsFloppyCDROM::SettingsFloppyCDROM(QWidget *parent)
     Models::AddEntry(model, tr("Turbo"), 99);
 
     model = new QStandardItemModel(0, 3, this);
-    ui->tableViewCDROM->setModel(model);
+    ui->treeViewCDROM->setModel(model);
     model->setHeaderData(0, Qt::Horizontal, tr("Bus"));
     model->setHeaderData(1, Qt::Horizontal, tr("Speed"));
     model->setHeaderData(2, Qt::Horizontal, tr("Type"));
     model->insertRows(0, CDROM_NUM);
     for (int i = 0; i < CDROM_NUM; i++) {
-        ui->tableViewCDROM->setRowHeight(i, 25);
         auto idx  = model->index(i, 0);
         int  type = cdrom_get_type(i);
         setCDROMBus(model, idx, cdrom[i].bus_type, type, cdrom[i].res);
@@ -232,15 +230,15 @@ SettingsFloppyCDROM::SettingsFloppyCDROM(QWidget *parent)
             Harddrives::busTrackClass->device_track(1, DEV_CDROM, cdrom[i].bus_type, 0);
         inc[i] = cdrom[i].no_check;
     }
-    ui->tableViewCDROM->resizeColumnsToContents();
-    ui->tableViewCDROM->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Stretch);
+    for (int i = 0; i < model->columnCount(); i++)
+        ui->treeViewCDROM->resizeColumnToContents(i);
 
-    connect(ui->tableViewCDROM->selectionModel(), &QItemSelectionModel::currentRowChanged,
+    connect(ui->treeViewCDROM->selectionModel(), &QItemSelectionModel::currentRowChanged,
             this, &SettingsFloppyCDROM::onCDROMRowChanged);
-    ui->tableViewCDROM->setCurrentIndex(model->index(0, 0));
+    ui->treeViewCDROM->setCurrentIndex(model->index(0, 0));
 
     uint8_t bus_type = ui->comboBoxBus->currentData().toUInt();
-    int     cdromIdx = ui->tableViewCDROM->selectionModel()->currentIndex().data().toInt();
+    int     cdromIdx = ui->treeViewCDROM->selectionModel()->currentIndex().data().toInt();
 
     auto *modelType  = ui->comboBoxCDROMType->model();
     int   removeRows = modelType->rowCount();
@@ -280,7 +278,7 @@ SettingsFloppyCDROM::changed()
     int has_changed  = 0;
     int soft_changed = 0;
 
-    auto *model = ui->tableViewFloppy->model();
+    auto *model = ui->treeViewFloppy->model();
     for (int i = 0; i < FDD_NUM; i++) {
         has_changed  |= (fdd_get_type(i)          != model->index(i, 0).data(Qt::UserRole).toInt());
         has_changed  |= (fdd_get_turbo(i)         != (model->index(i, 1).data() == tr("On") ? 1 : 0));
@@ -291,7 +289,7 @@ SettingsFloppyCDROM::changed()
     }
 
     /* Removable devices category */
-    model = ui->tableViewCDROM->model();
+    model = ui->treeViewCDROM->model();
     for (int i = 0; i < CDROM_NUM; i++) {
         has_changed  |= (cdrom[i].bus_type        != model->index(i, 0).data(Qt::UserRole).toUInt());
         has_changed  |= (cdrom[i].res             != model->index(i, 0).data(Qt::UserRole + 1).toUInt());
@@ -318,7 +316,7 @@ SettingsFloppyCDROM::save(int soft)
         return;
     }
 
-    auto *model = ui->tableViewFloppy->model();
+    auto *model = ui->treeViewFloppy->model();
     for (int i = 0; i < FDD_NUM; i++) {
         fdd_set_type(i, model->index(i, 0).data(Qt::UserRole).toInt());
         fdd_set_turbo(i, model->index(i, 1).data() == tr("On") ? 1 : 0);
@@ -329,7 +327,7 @@ SettingsFloppyCDROM::save(int soft)
     }
 
     /* Removable devices category */
-    model = ui->tableViewCDROM->model();
+    model = ui->treeViewCDROM->model();
     for (int i = 0; i < CDROM_NUM; i++) {
         cdrom[i].priv        = NULL;
         cdrom[i].ops         = NULL;
@@ -477,30 +475,31 @@ SettingsFloppyCDROM::onCDROMRowChanged(const QModelIndex &current)
 void
 SettingsFloppyCDROM::on_checkBoxTurboTimings_stateChanged(int arg1)
 {
-    auto idx = ui->tableViewFloppy->selectionModel()->currentIndex();
-    ui->tableViewFloppy->model()->setData(idx.siblingAtColumn(1), arg1 == Qt::Checked ? tr("On") : tr("Off"));
+    auto idx = ui->treeViewFloppy->selectionModel()->currentIndex();
+    ui->treeViewFloppy->model()->setData(idx.siblingAtColumn(1), arg1 == Qt::Checked ? tr("On") : tr("Off"));
 }
 
 void
 SettingsFloppyCDROM::on_checkBoxCheckBPB_stateChanged(int arg1)
 {
-    auto idx = ui->tableViewFloppy->selectionModel()->currentIndex();
-    ui->tableViewFloppy->model()->setData(idx.siblingAtColumn(2), arg1 == Qt::Checked ? tr("On") : tr("Off"));
+    auto idx = ui->treeViewFloppy->selectionModel()->currentIndex();
+    ui->treeViewFloppy->model()->setData(idx.siblingAtColumn(2), arg1 == Qt::Checked ? tr("On") : tr("Off"));
 }
 
 void
 SettingsFloppyCDROM::on_checkBoxErrorCheck_stateChanged(int arg1)
 {
-    auto idx = ui->tableViewFloppy->selectionModel()->currentIndex();
+    auto idx = ui->treeViewFloppy->selectionModel()->currentIndex();
     inc[idx.row()] = (arg1 != Qt::Checked);
 }
 
 void
 SettingsFloppyCDROM::on_comboBoxFloppyType_activated(int index)
 {
-    auto currentIndex = ui->tableViewFloppy->selectionModel()->currentIndex();
+    auto currentIndex = ui->treeViewFloppy->selectionModel()->currentIndex();
     auto typeIndex    = currentIndex.siblingAtColumn(0);
-    setFloppyType(ui->tableViewFloppy->model(), typeIndex, index);
+    setFloppyType(ui->treeViewFloppy->model(), typeIndex, index);
+    ui->treeViewFloppy->resizeColumnToContents(0);
 
     // Trigger row changed to rebuild audio profile list
     onFloppyRowChanged(currentIndex);
@@ -509,7 +508,7 @@ SettingsFloppyCDROM::on_comboBoxFloppyType_activated(int index)
 void
 SettingsFloppyCDROM::on_comboBoxFloppyAudio_activated(int)
 {
-    auto    idx  = ui->tableViewFloppy->selectionModel()->currentIndex();
+    auto    idx  = ui->treeViewFloppy->selectionModel()->currentIndex();
     int     prof = ui->comboBoxFloppyAudio->currentData().toInt();
 
 #ifndef DISABLE_FDD_AUDIO
@@ -546,18 +545,19 @@ SettingsFloppyCDROM::on_comboBoxBus_currentIndexChanged(int index)
 void
 SettingsFloppyCDROM::on_comboBoxSpeed_activated(int index)
 {
-    auto idx = ui->tableViewCDROM->selectionModel()->currentIndex();
-    setCDROMSpeed(ui->tableViewCDROM->model(), idx.siblingAtColumn(1), index + 1);
+    auto idx = ui->treeViewCDROM->selectionModel()->currentIndex();
+    setCDROMSpeed(ui->treeViewCDROM->model(), idx.siblingAtColumn(1), index + 1);
+    ui->treeViewCDROM->resizeColumnToContents(1);
 }
 
 void
 SettingsFloppyCDROM::on_comboBoxBus_activated(int)
 {
-    auto    i        = ui->tableViewCDROM->selectionModel()->currentIndex().siblingAtColumn(0);
+    auto    i        = ui->treeViewCDROM->selectionModel()->currentIndex().siblingAtColumn(0);
     uint8_t bus_type = ui->comboBoxBus->currentData().toUInt();
-    int     cdromIdx = ui->tableViewCDROM->selectionModel()->currentIndex().data().toInt();
+    int     cdromIdx = ui->treeViewCDROM->selectionModel()->currentIndex().data().toInt();
 
-    Harddrives::busTrackClass->device_track(0, DEV_CDROM, ui->tableViewCDROM->model()->data(i, Qt::UserRole).toInt(), ui->tableViewCDROM->model()->data(i, Qt::UserRole + 1).toInt());
+    Harddrives::busTrackClass->device_track(0, DEV_CDROM, ui->treeViewCDROM->model()->data(i, Qt::UserRole).toInt(), ui->treeViewCDROM->model()->data(i, Qt::UserRole + 1).toInt());
     if (bus_type == CDROM_BUS_MKE)
         ui->comboBoxChannel->setCurrentIndex(Harddrives::busTrackClass->next_free_mke_channel());
     else if (bus_type == CDROM_BUS_ATAPI)
@@ -567,11 +567,11 @@ SettingsFloppyCDROM::on_comboBoxBus_activated(int)
     else if (bus_type == CDROM_BUS_MITSUMI)
         ui->comboBoxChannel->setCurrentIndex(0);
 
-    setCDROMBus(ui->tableViewCDROM->model(),
-                ui->tableViewCDROM->selectionModel()->currentIndex(),
+    setCDROMBus(ui->treeViewCDROM->model(),
+                ui->treeViewCDROM->selectionModel()->currentIndex(),
                 bus_type, cdrom[cdromIdx].type,
                 ui->comboBoxChannel->currentData().toUInt());
-    Harddrives::busTrackClass->device_track(1, DEV_CDROM, ui->tableViewCDROM->model()->data(i, Qt::UserRole).toInt(), ui->tableViewCDROM->model()->data(i, Qt::UserRole + 1).toInt());
+    Harddrives::busTrackClass->device_track(1, DEV_CDROM, ui->treeViewCDROM->model()->data(i, Qt::UserRole).toInt(), ui->treeViewCDROM->model()->data(i, Qt::UserRole + 1).toInt());
 
     auto *modelType  = ui->comboBoxCDROMType->model();
     int   removeRows = modelType->rowCount();
@@ -596,8 +596,8 @@ SettingsFloppyCDROM::on_comboBoxBus_activated(int)
     ui->comboBoxCDROMType->setCurrentIndex(-1);
     ui->comboBoxCDROMType->setCurrentIndex(selectedTypeRow);
 
-    setCDROMType(ui->tableViewCDROM->model(),
-                 ui->tableViewCDROM->selectionModel()->currentIndex(),
+    setCDROMType(ui->treeViewCDROM->model(),
+                 ui->treeViewCDROM->selectionModel()->currentIndex(),
                  ui->comboBoxCDROMType->currentData().toUInt());
 
     int speed = cdrom_get_speed(ui->comboBoxCDROMType->currentData().toUInt());
@@ -610,9 +610,11 @@ SettingsFloppyCDROM::on_comboBoxBus_activated(int)
             speed = 0;
     }
     ui->comboBoxSpeed->setCurrentIndex(speed == 0 ? 7 : speed - 1);
-    setCDROMSpeed(ui->tableViewCDROM->model(),
-                  ui->tableViewCDROM->selectionModel()->currentIndex(),
+    setCDROMSpeed(ui->treeViewCDROM->model(),
+                  ui->treeViewCDROM->selectionModel()->currentIndex(),
                   speed);
+    for (int i = 0; i < ui->treeViewCDROM->model()->columnCount(); i++)
+        ui->treeViewCDROM->resizeColumnToContents(i);
     ui->checkBoxErrorCheck->setEnabled(bus_type != CDROM_BUS_DISABLED);
     emit cdromChannelChanged();
 }
@@ -630,14 +632,15 @@ SettingsFloppyCDROM::enableCurrentlySelectedChannel()
 void
 SettingsFloppyCDROM::on_comboBoxChannel_activated(int)
 {
-    auto i = ui->tableViewCDROM->selectionModel()->currentIndex().siblingAtColumn(0);
+    auto i = ui->treeViewCDROM->selectionModel()->currentIndex().siblingAtColumn(0);
     int type = ui->comboBoxCDROMType->currentData().toUInt();
-    Harddrives::busTrackClass->device_track(0, DEV_CDROM, ui->tableViewCDROM->model()->data(i, Qt::UserRole).toInt(), ui->tableViewCDROM->model()->data(i, Qt::UserRole + 1).toInt());
-    setCDROMBus(ui->tableViewCDROM->model(),
-                ui->tableViewCDROM->selectionModel()->currentIndex(),
+    Harddrives::busTrackClass->device_track(0, DEV_CDROM, ui->treeViewCDROM->model()->data(i, Qt::UserRole).toInt(), ui->treeViewCDROM->model()->data(i, Qt::UserRole + 1).toInt());
+    setCDROMBus(ui->treeViewCDROM->model(),
+                ui->treeViewCDROM->selectionModel()->currentIndex(),
                 ui->comboBoxBus->currentData().toUInt(), type,
                 ui->comboBoxChannel->currentData().toUInt());
-    Harddrives::busTrackClass->device_track(1, DEV_CDROM, ui->tableViewCDROM->model()->data(i, Qt::UserRole).toInt(), ui->tableViewCDROM->model()->data(i, Qt::UserRole + 1).toInt());
+    ui->treeViewCDROM->resizeColumnToContents(0);
+    Harddrives::busTrackClass->device_track(1, DEV_CDROM, ui->treeViewCDROM->model()->data(i, Qt::UserRole).toInt(), ui->treeViewCDROM->model()->data(i, Qt::UserRole + 1).toInt());
     emit cdromChannelChanged();
 }
 
@@ -646,11 +649,10 @@ SettingsFloppyCDROM::on_comboBoxCDROMType_activated(int)
 {
     int type = ui->comboBoxCDROMType->currentData().toUInt();
 
-    setCDROMType(ui->tableViewCDROM->model(),
-                 ui->tableViewCDROM->selectionModel()->currentIndex(),
+    setCDROMType(ui->treeViewCDROM->model(),
+                 ui->treeViewCDROM->selectionModel()->currentIndex(),
                  type);
-    ui->tableViewCDROM->resizeColumnsToContents();
-    ui->tableViewCDROM->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+    ui->treeViewCDROM->resizeColumnToContents(2);
 
     int speed = cdrom_get_speed(type);
     if (speed == -1) {
@@ -660,11 +662,11 @@ SettingsFloppyCDROM::on_comboBoxCDROMType_activated(int)
         ui->comboBoxSpeed->setEnabled(false);
     ui->comboBoxSpeed->setCurrentIndex(speed == 0 ? 7 : speed - 1);
 
-    auto idx = ui->tableViewCDROM->selectionModel()->currentIndex();
-    setCDROMSpeed(ui->tableViewCDROM->model(), idx.siblingAtColumn(1), speed);
+    auto idx = ui->treeViewCDROM->selectionModel()->currentIndex();
+    setCDROMSpeed(ui->treeViewCDROM->model(), idx.siblingAtColumn(1), speed);
 
-    setCDROMBus(ui->tableViewCDROM->model(),
-                ui->tableViewCDROM->selectionModel()->currentIndex(),
+    setCDROMBus(ui->treeViewCDROM->model(),
+                ui->treeViewCDROM->selectionModel()->currentIndex(),
                 ui->comboBoxBus->currentData().toUInt(), type,
                 ui->comboBoxChannel->currentData().toUInt());
 }

--- a/src/qt/qt_settingsfloppycdrom.ui
+++ b/src/qt/qt_settingsfloppycdrom.ui
@@ -43,7 +43,7 @@
       <layout class="QVBoxLayout" name="verticalLayoutFloppy">
 
        <item>
-        <widget class="QTableView" name="tableViewFloppy">
+        <widget class="QTreeView" name="treeViewFloppy">
          <property name="editTriggers">
           <set>QAbstractItemView::NoEditTriggers</set>
          </property>
@@ -56,12 +56,12 @@
          <property name="tabKeyNavigation">
           <bool>false</bool>
          </property>
-         <property name="showGrid">
+         <property name="rootIsDecorated">
           <bool>false</bool>
          </property>
-         <attribute name="verticalHeaderVisible">
-          <bool>false</bool>
-         </attribute>
+         <property name="allColumnsShowFocus">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
        <item>
@@ -138,7 +138,7 @@
       <layout class="QVBoxLayout" name="verticalLayoutCDROM">
 
        <item>
-        <widget class="QTableView" name="tableViewCDROM">
+        <widget class="QTreeView" name="treeViewCDROM">
          <property name="editTriggers">
           <set>QAbstractItemView::NoEditTriggers</set>
          </property>
@@ -151,12 +151,12 @@
          <property name="tabKeyNavigation">
           <bool>false</bool>
          </property>
-         <property name="showGrid">
+         <property name="rootIsDecorated">
           <bool>false</bool>
          </property>
-         <attribute name="verticalHeaderVisible">
-          <bool>false</bool>
-         </attribute>
+         <property name="allColumnsShowFocus">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
        <item>
@@ -261,12 +261,12 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>tableViewFloppy</tabstop>
+  <tabstop>treeViewFloppy</tabstop>
   <tabstop>comboBoxFloppyType</tabstop>
   <tabstop>checkBoxTurboTimings</tabstop>
   <tabstop>checkBoxCheckBPB</tabstop>
   <tabstop>comboBoxFloppyAudio</tabstop>
-  <tabstop>tableViewCDROM</tabstop>
+  <tabstop>treeViewCDROM</tabstop>
   <tabstop>comboBoxBus</tabstop>
   <tabstop>comboBoxChannel</tabstop>
   <tabstop>comboBoxSpeed</tabstop>

--- a/src/qt/qt_settingsharddisks.cpp
+++ b/src/qt/qt_settingsharddisks.cpp
@@ -117,7 +117,6 @@ SettingsHarddisks::addRow(QAbstractItemModel *model, void *priv)
     model->setData(speedIndex, QObject::tr(hdd_preset_getname(hd->speed_preset)));
     model->setData(speedIndex, hd->speed_preset, Qt::UserRole);
    
-    ui->tableView->setRowHeight(row, 25);
 }
 
 SettingsHarddisks::SettingsHarddisks(QWidget *parent)
@@ -135,7 +134,7 @@ SettingsHarddisks::SettingsHarddisks(QWidget *parent)
     model->setHeaderData(ColumnFilename, Qt::Horizontal, tr("File"));
     model->setHeaderData(ColumnGeometry, Qt::Horizontal, tr("Geometry"));
     model->setHeaderData(ColumnSpeed, Qt::Horizontal, tr("Model"));
-    ui->tableView->setModel(model);
+    ui->treeView->setModel(model);
 
     org_rows = 0;
     for (int i = 0; i < HDD_NUM; i++) {
@@ -148,10 +147,10 @@ SettingsHarddisks::SettingsHarddisks(QWidget *parent)
         ui->pushButtonNew->setEnabled(false);
         ui->pushButtonExisting->setEnabled(false);
     }
-    ui->tableView->resizeColumnsToContents();
-    ui->tableView->horizontalHeader()->setSectionResizeMode(ColumnBus, QHeaderView::Stretch);
+    for (int i = 0; i < model->columnCount(); i++)
+        ui->treeView->resizeColumnToContents(i);
 
-    auto *tableSelectionModel = ui->tableView->selectionModel();
+    auto *tableSelectionModel = ui->treeView->selectionModel();
     connect(tableSelectionModel, &QItemSelectionModel::currentRowChanged, this, &SettingsHarddisks::onTableRowChanged);
     onTableRowChanged(QModelIndex());
 
@@ -160,7 +159,7 @@ SettingsHarddisks::SettingsHarddisks(QWidget *parent)
     on_comboBoxBus_currentIndexChanged(0);
 
     if (model->rowCount() > 0)
-        ui->tableView->selectRow(0);
+        ui->treeView->setCurrentIndex(model->index(0, 0));
 }
 
 SettingsHarddisks::~SettingsHarddisks()
@@ -175,7 +174,7 @@ SettingsHarddisks::changed()
 {
     int has_changed = 0;
 
-    auto *model = ui->tableView->model();
+    auto *model = ui->treeView->model();
     int   rows  = model->rowCount();
 
     has_changed |= (rows != org_rows);
@@ -210,7 +209,7 @@ SettingsHarddisks::save(int soft)
 
     memset(hdd, 0, sizeof(hdd));
 
-    auto *model = ui->tableView->model();
+    auto *model = ui->treeView->model();
     int   rows  = model->rowCount();
     for (int i = 0; i < rows; ++i) {
         auto idx             = model->index(i, ColumnBus);
@@ -244,9 +243,9 @@ SettingsHarddisks::on_comboBoxBus_currentIndexChanged(int index)
         return;
 
     buschangeinprogress = true;
-    auto idx            = ui->tableView->selectionModel()->currentIndex();
+    auto idx            = ui->treeView->selectionModel()->currentIndex();
     if (idx.isValid()) {
-        auto *model = ui->tableView->model();
+        auto *model = ui->treeView->model();
         auto  col   = idx.siblingAtColumn(ColumnBus);
         model->setData(col, ui->comboBoxBus->currentData(Qt::UserRole), DataBus);
         model->setData(col, busChannelName(col), Qt::DisplayRole);
@@ -278,11 +277,12 @@ SettingsHarddisks::on_comboBoxBus_currentIndexChanged(int index)
     }
 
     if (idx.isValid()) {
-        auto *model = ui->tableView->model();
+        auto *model = ui->treeView->model();
         auto  col   = idx.siblingAtColumn(ColumnBus);
         model->setData(col, chanIdx, DataBusChannelPrevious);
     }
     ui->comboBoxChannel->setCurrentIndex(chanIdx);
+    ui->treeView->resizeColumnToContents(ColumnBus);
     buschangeinprogress = false;
 }
 
@@ -292,9 +292,9 @@ SettingsHarddisks::on_comboBoxChannel_currentIndexChanged(int index)
     if (index < 0)
         return;
 
-    auto idx = ui->tableView->selectionModel()->currentIndex();
+    auto idx = ui->treeView->selectionModel()->currentIndex();
     if (idx.isValid()) {
-        auto *model = ui->tableView->model();
+        auto *model = ui->treeView->model();
         auto  col   = idx.siblingAtColumn(ColumnBus);
         model->setData(col, ui->comboBoxChannel->currentData(Qt::UserRole), DataBusChannel);
         model->setData(col, busChannelName(col), Qt::DisplayRole);
@@ -302,6 +302,7 @@ SettingsHarddisks::on_comboBoxChannel_currentIndexChanged(int index)
             Harddrives::busTrackClass->device_track(0, DEV_HDD, model->data(col, DataBus).toInt(), model->data(col, DataBusChannelPrevious).toUInt());
         Harddrives::busTrackClass->device_track(1, DEV_HDD, model->data(col, DataBus).toInt(), model->data(col, DataBusChannel).toUInt());
         model->setData(col, ui->comboBoxChannel->currentData(Qt::UserRole), DataBusChannelPrevious);
+        ui->treeView->resizeColumnToContents(ColumnBus);
         emit driveChannelChanged();
     }
 }
@@ -322,15 +323,16 @@ SettingsHarddisks::on_comboBoxSpeed_currentIndexChanged(int index)
     if (index < 0)
         return;
 
-    auto idx = ui->tableView->selectionModel()->currentIndex();
+    auto idx = ui->treeView->selectionModel()->currentIndex();
     if (idx.isValid()) {
-        auto *model = ui->tableView->model();
+        auto *model = ui->treeView->model();
         auto  col   = idx.siblingAtColumn(ColumnSpeed);
         model->setData(col, ui->comboBoxSpeed->currentData(Qt::UserRole), Qt::UserRole);
         model->setData(col, QObject::tr(hdd_preset_getname(ui->comboBoxSpeed->currentData(Qt::UserRole).toUInt())));
         
         /* Reset audio profile to None when speed/model changes */
         ia[idx.row()] = 0;
+        ui->treeView->resizeColumnToContents(ColumnSpeed);
     }
     
     /* Repopulate audio profiles based on the selected speed preset's RPM */
@@ -367,7 +369,7 @@ SettingsHarddisks::on_comboBoxAudio_currentIndexChanged(int index)
     if (index < 0)
         return;
 
-    auto idx = ui->tableView->selectionModel()->currentIndex();
+    auto idx = ui->treeView->selectionModel()->currentIndex();
 
     if (idx.isValid())
         ia[idx.row()] = ui->comboBoxAudio->currentData(Qt::UserRole).toInt();
@@ -433,10 +435,10 @@ SettingsHarddisks::addDriveFromDialog(Ui::SettingsHarddisks *ui, const HarddiskD
     strncpy(hd.fn, fn.data(), sizeof(hd.fn) - 1);
     hd.speed_preset = dlg.speed();
 
-    addRow(ui->tableView->model(), &hd);
-    ui->tableView->resizeColumnsToContents();
-    ui->tableView->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
-    if (ui->tableView->model()->rowCount() == HDD_NUM) {
+    addRow(ui->treeView->model(), &hd);
+    for (int i = 0; i < ui->treeView->model()->columnCount(); i++)
+        ui->treeView->resizeColumnToContents(i);
+    if (ui->treeView->model()->rowCount() == HDD_NUM) {
         ui->pushButtonNew->setEnabled(false);
         ui->pushButtonExisting->setEnabled(false);
     }
@@ -469,11 +471,11 @@ SettingsHarddisks::on_pushButtonExisting_clicked()
 void
 SettingsHarddisks::on_pushButtonRemove_clicked()
 {
-    auto idx = ui->tableView->selectionModel()->currentIndex();
+    auto idx = ui->treeView->selectionModel()->currentIndex();
     if (!idx.isValid())
         return;
 
-    auto      *model = ui->tableView->model();
+    auto      *model = ui->treeView->model();
     const auto col   = idx.siblingAtColumn(ColumnBus);
     Harddrives::busTrackClass->device_track(0, DEV_HDD, model->data(col, DataBus).toInt(), model->data(col, DataBusChannel).toInt());
     ic[idx.row()] = 0;
@@ -483,4 +485,6 @@ SettingsHarddisks::on_pushButtonRemove_clicked()
     model->removeRow(idx.row());
     ui->pushButtonNew->setEnabled(true);
     ui->pushButtonExisting->setEnabled(true);
+    for (int i = 0; i < ui->treeView->model()->columnCount(); i++)
+        ui->treeView->resizeColumnToContents(i);
 }

--- a/src/qt/qt_settingsharddisks.ui
+++ b/src/qt/qt_settingsharddisks.ui
@@ -28,7 +28,7 @@
    </property>
 
    <item>
-    <widget class="QTableView" name="tableView">
+    <widget class="QTreeView" name="treeView">
      <property name="editTriggers">
       <set>QAbstractItemView::NoEditTriggers</set>
      </property>
@@ -41,12 +41,12 @@
      <property name="tabKeyNavigation">
       <bool>false</bool>
      </property>
-     <property name="showGrid">
+     <property name="rootIsDecorated">
       <bool>false</bool>
      </property>
-     <attribute name="verticalHeaderVisible">
-      <bool>false</bool>
-     </attribute>
+     <property name="allColumnsShowFocus">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item>

--- a/src/qt/qt_settingsotherremovable.cpp
+++ b/src/qt/qt_settingsotherremovable.cpp
@@ -200,22 +200,22 @@ SettingsOtherRemovable::SettingsOtherRemovable(QWidget *parent)
     }
 
     model = new QStandardItemModel(0, 2, this);
-    ui->tableViewMO->setModel(model);
+    ui->treeViewMO->setModel(model);
     model->setHeaderData(0, Qt::Horizontal, tr("Bus"));
     model->setHeaderData(1, Qt::Horizontal, tr("Type"));
     model->insertRows(0, MO_NUM);
     for (int i = 0; i < MO_NUM; i++) {
-        ui->tableViewMO->setRowHeight(i, 25);
         auto idx = model->index(i, 0);
         setMOBus(model, idx, mo_drives[i].bus_type, mo_drives[i].res);
         setMOType(model, idx.siblingAtColumn(1), mo_drives[i].type);
         Harddrives::busTrackClass->device_track(1, DEV_MO, mo_drives[i].bus_type, mo_drives[i].bus_type == MO_BUS_ATAPI ? mo_drives[i].ide_channel : mo_drives[i].scsi_device_id);
     }
-    ui->tableViewMO->resizeColumnsToContents();
-    ui->tableViewMO->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
 
-    connect(ui->tableViewMO->selectionModel(), &QItemSelectionModel::currentRowChanged, this, &SettingsOtherRemovable::onMORowChanged);
-    ui->tableViewMO->setCurrentIndex(model->index(0, 0));
+    for (int i = 0; i < model->columnCount(); i++)
+        ui->treeViewMO->resizeColumnToContents(i);
+
+    connect(ui->treeViewMO->selectionModel(), &QItemSelectionModel::currentRowChanged, this, &SettingsOtherRemovable::onMORowChanged);
+    ui->treeViewMO->setCurrentIndex(model->index(0, 0));
 
     rdisk_disabled_icon = QIcon(":/settings/qt/icons/rdisk_disabled.ico");
     rdisk_icon          = QIcon(":/settings/qt/icons/rdisk.ico");
@@ -231,22 +231,23 @@ SettingsOtherRemovable::SettingsOtherRemovable(QWidget *parent)
     }
 
     model = new QStandardItemModel(0, 2, this);
-    ui->tableViewRDisk->setModel(model);
+    ui->treeViewRDisk->setModel(model);
     model->setHeaderData(0, Qt::Horizontal, tr("Bus"));
     model->setHeaderData(1, Qt::Horizontal, tr("Type"));
     model->insertRows(0, RDISK_NUM);
     for (int i = 0; i < RDISK_NUM; i++) {
-        ui->tableViewRDisk->setRowHeight(i, 25);
         auto idx = model->index(i, 0);
         setRDiskBus(model, idx, rdisk_drives[i].bus_type, rdisk_drives[i].type, rdisk_drives[i].res);
         setRDiskType(model, idx.siblingAtColumn(1), rdisk_drives[i].bus_type, rdisk_drives[i].type);
         Harddrives::busTrackClass->device_track(1, DEV_MO, rdisk_drives[i].bus_type, rdisk_drives[i].bus_type == RDISK_BUS_ATAPI ? rdisk_drives[i].ide_channel : rdisk_drives[i].scsi_device_id);
     }
-    ui->tableViewRDisk->resizeColumnsToContents();
-    ui->tableViewRDisk->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
 
-    connect(ui->tableViewRDisk->selectionModel(), &QItemSelectionModel::currentRowChanged, this, &SettingsOtherRemovable::onRDiskRowChanged);
-    ui->tableViewRDisk->setCurrentIndex(model->index(0, 0));
+
+    for (int i = 0; i < model->columnCount(); i++)
+        ui->treeViewRDisk->resizeColumnToContents(i);
+
+    connect(ui->treeViewRDisk->selectionModel(), &QItemSelectionModel::currentRowChanged, this, &SettingsOtherRemovable::onRDiskRowChanged);
+    ui->treeViewRDisk->setCurrentIndex(model->index(0, 0));
 
     tape_disabled_icon = QIcon(":/settings/qt/icons/tape_disabled.ico");
     tape_icon          = QIcon(":/settings/qt/icons/tape.ico");
@@ -261,22 +262,22 @@ SettingsOtherRemovable::SettingsOtherRemovable(QWidget *parent)
     }
 
     model = new QStandardItemModel(0, 2, this);
-    ui->tableViewTape->setModel(model);
+    ui->treeViewTape->setModel(model);
     model->setHeaderData(0, Qt::Horizontal, tr("Bus"));
     model->setHeaderData(1, Qt::Horizontal, tr("Type"));
     model->insertRows(0, TAPE_NUM);
     for (int i = 0; i < TAPE_NUM; i++) {
-        ui->tableViewTape->setRowHeight(i, 25);
         auto idx = model->index(i, 0);
         setTapeBus(model, idx, tape_drives[i].bus_type, tape_drives[i].res);
         setTapeType(model, idx.siblingAtColumn(1), tape_drives[i].type);
         Harddrives::busTrackClass->device_track(1, DEV_TAPE, tape_drives[i].bus_type, tape_drives[i].bus_type == TAPE_BUS_ATAPI ? tape_drives[i].ide_channel : tape_drives[i].scsi_device_id);
     }
-    ui->tableViewTape->resizeColumnsToContents();
-    ui->tableViewTape->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
 
-    connect(ui->tableViewTape->selectionModel(), &QItemSelectionModel::currentRowChanged, this, &SettingsOtherRemovable::onTapeRowChanged);
-    ui->tableViewTape->setCurrentIndex(model->index(0, 0));
+    for (int i = 0; i < model->columnCount(); i++)
+        ui->treeViewTape->resizeColumnToContents(i);
+
+    connect(ui->treeViewTape->selectionModel(), &QItemSelectionModel::currentRowChanged, this, &SettingsOtherRemovable::onTapeRowChanged);
+    ui->treeViewTape->setCurrentIndex(model->index(0, 0));
 }
 
 SettingsOtherRemovable::~SettingsOtherRemovable()
@@ -294,21 +295,21 @@ SettingsOtherRemovable::changed()
 {
     int has_changed = 0;
 
-    const auto *model = ui->tableViewMO->model();
+    const auto *model = ui->treeViewMO->model();
     for (uint8_t i = 0; i < MO_NUM; i++) {
         has_changed |= (mo_drives[i].bus_type != model->index(i, 0).data(Qt::UserRole).toUInt());
         has_changed |= (mo_drives[i].res      != model->index(i, 0).data(Qt::UserRole + 1).toUInt());
         has_changed |= (mo_drives[i].type     != model->index(i, 1).data(Qt::UserRole).toUInt());
     }
 
-    model = ui->tableViewRDisk->model();
+    model = ui->treeViewRDisk->model();
     for (uint8_t i = 0; i < RDISK_NUM; i++) {
         has_changed |= (rdisk_drives[i].bus_type != model->index(i, 0).data(Qt::UserRole).toUInt());
         has_changed |= (rdisk_drives[i].res      != model->index(i, 0).data(Qt::UserRole + 1).toUInt());
         has_changed |= (rdisk_drives[i].type     != model->index(i, 1).data(Qt::UserRole).toUInt());
     }
 
-    model = ui->tableViewTape->model();
+    model = ui->treeViewTape->model();
     for (uint8_t i = 0; i < TAPE_NUM; i++) {
         has_changed |= (tape_drives[i].bus_type != model->index(i, 0).data(Qt::UserRole).toUInt());
         has_changed |= (tape_drives[i].res      != model->index(i, 0).data(Qt::UserRole + 1).toUInt());
@@ -329,7 +330,7 @@ SettingsOtherRemovable::save(int soft)
     if (soft)
         return;
 
-    const auto *model = ui->tableViewMO->model();
+    const auto *model = ui->treeViewMO->model();
     for (uint8_t i = 0; i < MO_NUM; i++) {
         mo_drives[i].fp       = NULL;
         mo_drives[i].priv     = NULL;
@@ -338,7 +339,7 @@ SettingsOtherRemovable::save(int soft)
         mo_drives[i].type     = model->index(i, 1).data(Qt::UserRole).toUInt();
     }
 
-    model = ui->tableViewRDisk->model();
+    model = ui->treeViewRDisk->model();
     for (uint8_t i = 0; i < RDISK_NUM; i++) {
         rdisk_drives[i].fp       = NULL;
         rdisk_drives[i].priv     = NULL;
@@ -347,7 +348,7 @@ SettingsOtherRemovable::save(int soft)
         rdisk_drives[i].type     = model->index(i, 1).data(Qt::UserRole).toUInt();
     }
 
-    model = ui->tableViewTape->model();
+    model = ui->treeViewTape->model();
     for (uint8_t i = 0; i < TAPE_NUM; i++) {
         tape_drives[i].fp       = NULL;
         tape_drives[i].priv     = NULL;
@@ -446,42 +447,40 @@ SettingsOtherRemovable::on_comboBoxRDiskBus_currentIndexChanged(int index)
 void
 SettingsOtherRemovable::on_comboBoxMOBus_activated(int)
 {
-    auto i = ui->tableViewMO->selectionModel()->currentIndex().siblingAtColumn(0);
-    Harddrives::busTrackClass->device_track(0, DEV_MO, ui->tableViewMO->model()->data(i, Qt::UserRole).toInt(), ui->tableViewMO->model()->data(i, Qt::UserRole + 1).toInt());
+    auto i = ui->treeViewMO->selectionModel()->currentIndex().siblingAtColumn(0);
+    Harddrives::busTrackClass->device_track(0, DEV_MO, ui->treeViewMO->model()->data(i, Qt::UserRole).toInt(), ui->treeViewMO->model()->data(i, Qt::UserRole + 1).toInt());
     ui->comboBoxMOChannel->setCurrentIndex(ui->comboBoxMOBus->currentData().toUInt() == MO_BUS_ATAPI ? Harddrives::busTrackClass->next_free_ide_channel() : Harddrives::busTrackClass->next_free_scsi_id());
-    ui->tableViewMO->model()->data(i, Qt::UserRole + 1);
-    setMOBus(ui->tableViewMO->model(),
-             ui->tableViewMO->selectionModel()->currentIndex(),
+    ui->treeViewMO->model()->data(i, Qt::UserRole + 1);
+    setMOBus(ui->treeViewMO->model(),
+             ui->treeViewMO->selectionModel()->currentIndex(),
              ui->comboBoxMOBus->currentData().toUInt(),
              ui->comboBoxMOChannel->currentData().toUInt());
-    setMOType(ui->tableViewMO->model(),
-              ui->tableViewMO->selectionModel()->currentIndex(),
+    setMOType(ui->treeViewMO->model(),
+              ui->treeViewMO->selectionModel()->currentIndex(),
               ui->comboBoxMOType->currentData().toUInt());
-    ui->tableViewMO->resizeColumnsToContents();
-    ui->tableViewMO->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
-    Harddrives::busTrackClass->device_track(1, DEV_MO, ui->tableViewMO->model()->data(i, Qt::UserRole).toInt(), ui->tableViewMO->model()->data(i, Qt::UserRole + 1).toInt());
+    ui->treeViewMO->resizeColumnToContents(0);
+    Harddrives::busTrackClass->device_track(1, DEV_MO, ui->treeViewMO->model()->data(i, Qt::UserRole).toInt(), ui->treeViewMO->model()->data(i, Qt::UserRole + 1).toInt());
     emit moChannelChanged();
 }
 
 void
 SettingsOtherRemovable::on_comboBoxRDiskBus_activated(int)
 {
-    auto i = ui->tableViewRDisk->selectionModel()->currentIndex().siblingAtColumn(0);
-    Harddrives::busTrackClass->device_track(0, DEV_RDISK, ui->tableViewRDisk->model()->data(i, Qt::UserRole).toInt(), ui->tableViewRDisk->model()->data(i, Qt::UserRole + 1).toInt());
+    auto i = ui->treeViewRDisk->selectionModel()->currentIndex().siblingAtColumn(0);
+    Harddrives::busTrackClass->device_track(0, DEV_RDISK, ui->treeViewRDisk->model()->data(i, Qt::UserRole).toInt(), ui->treeViewRDisk->model()->data(i, Qt::UserRole + 1).toInt());
     ui->comboBoxRDiskChannel->setCurrentIndex(ui->comboBoxRDiskBus->currentData().toUInt() == RDISK_BUS_ATAPI ? Harddrives::busTrackClass->next_free_ide_channel() : Harddrives::busTrackClass->next_free_scsi_id());
-    ui->tableViewRDisk->model()->data(i, Qt::UserRole + 1);
-    setRDiskBus(ui->tableViewRDisk->model(),
-                ui->tableViewRDisk->selectionModel()->currentIndex(),
+    ui->treeViewRDisk->model()->data(i, Qt::UserRole + 1);
+    setRDiskBus(ui->treeViewRDisk->model(),
+                ui->treeViewRDisk->selectionModel()->currentIndex(),
                 ui->comboBoxRDiskBus->currentData().toUInt(),
                 ui->comboBoxRDiskType->currentData().toUInt(),
                 ui->comboBoxRDiskChannel->currentData().toUInt());
-    setRDiskType(ui->tableViewRDisk->model(),
-                 ui->tableViewRDisk->selectionModel()->currentIndex(),
+    setRDiskType(ui->treeViewRDisk->model(),
+                 ui->treeViewRDisk->selectionModel()->currentIndex(),
                  ui->comboBoxRDiskBus->currentData().toUInt(),
                  ui->comboBoxRDiskType->currentData().toUInt());
-    ui->tableViewRDisk->resizeColumnsToContents();
-    ui->tableViewRDisk->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
-    Harddrives::busTrackClass->device_track(1, DEV_RDISK, ui->tableViewRDisk->model()->data(i, Qt::UserRole).toInt(), ui->tableViewRDisk->model()->data(i, Qt::UserRole + 1).toInt());
+    ui->treeViewRDisk->resizeColumnToContents(0);
+    Harddrives::busTrackClass->device_track(1, DEV_RDISK, ui->treeViewRDisk->model()->data(i, Qt::UserRole).toInt(), ui->treeViewRDisk->model()->data(i, Qt::UserRole + 1).toInt());
     emit rdiskChannelChanged();
 }
 
@@ -507,50 +506,50 @@ SettingsOtherRemovable::enableCurrentlySelectedChannel_RDisk()
 void
 SettingsOtherRemovable::on_comboBoxMOChannel_activated(int)
 {
-    auto i = ui->tableViewMO->selectionModel()->currentIndex().siblingAtColumn(0);
-    Harddrives::busTrackClass->device_track(0, DEV_MO, ui->tableViewMO->model()->data(i, Qt::UserRole).toInt(), ui->tableViewMO->model()->data(i, Qt::UserRole + 1).toInt());
-    setMOBus(ui->tableViewMO->model(),
-             ui->tableViewMO->selectionModel()->currentIndex(),
+    auto i = ui->treeViewMO->selectionModel()->currentIndex().siblingAtColumn(0);
+    Harddrives::busTrackClass->device_track(0, DEV_MO, ui->treeViewMO->model()->data(i, Qt::UserRole).toInt(), ui->treeViewMO->model()->data(i, Qt::UserRole + 1).toInt());
+    setMOBus(ui->treeViewMO->model(),
+             ui->treeViewMO->selectionModel()->currentIndex(),
              ui->comboBoxMOBus->currentData().toUInt(),
              ui->comboBoxMOChannel->currentData().toUInt());
-    Harddrives::busTrackClass->device_track(1, DEV_MO, ui->tableViewMO->model()->data(i, Qt::UserRole).toInt(), ui->tableViewMO->model()->data(i, Qt::UserRole + 1).toInt());
+    Harddrives::busTrackClass->device_track(1, DEV_MO, ui->treeViewMO->model()->data(i, Qt::UserRole).toInt(), ui->treeViewMO->model()->data(i, Qt::UserRole + 1).toInt());
+    ui->treeViewMO->resizeColumnToContents(0);
     emit moChannelChanged();
 }
 
 void
 SettingsOtherRemovable::on_comboBoxRDiskChannel_activated(int)
 {
-    auto i = ui->tableViewRDisk->selectionModel()->currentIndex().siblingAtColumn(0);
-    Harddrives::busTrackClass->device_track(0, DEV_RDISK, ui->tableViewRDisk->model()->data(i, Qt::UserRole).toInt(), ui->tableViewRDisk->model()->data(i, Qt::UserRole + 1).toInt());
-    setRDiskBus(ui->tableViewRDisk->model(),
-                ui->tableViewRDisk->selectionModel()->currentIndex(),
+    auto i = ui->treeViewRDisk->selectionModel()->currentIndex().siblingAtColumn(0);
+    Harddrives::busTrackClass->device_track(0, DEV_RDISK, ui->treeViewRDisk->model()->data(i, Qt::UserRole).toInt(), ui->treeViewRDisk->model()->data(i, Qt::UserRole + 1).toInt());
+    setRDiskBus(ui->treeViewRDisk->model(),
+                ui->treeViewRDisk->selectionModel()->currentIndex(),
                 ui->comboBoxRDiskBus->currentData().toUInt(),
                 ui->comboBoxRDiskType->currentData().toUInt(),
                 ui->comboBoxRDiskChannel->currentData().toUInt());
-    Harddrives::busTrackClass->device_track(1, DEV_RDISK, ui->tableViewRDisk->model()->data(i, Qt::UserRole).toInt(),
-                                            ui->tableViewRDisk->model()->data(i, Qt::UserRole + 1).toInt());
+    Harddrives::busTrackClass->device_track(1, DEV_RDISK, ui->treeViewRDisk->model()->data(i, Qt::UserRole).toInt(),
+                                            ui->treeViewRDisk->model()->data(i, Qt::UserRole + 1).toInt());
+    ui->treeViewRDisk->resizeColumnToContents(0);
     emit rdiskChannelChanged();
 }
 
 void
 SettingsOtherRemovable::on_comboBoxMOType_activated(int)
 {
-    setMOType(ui->tableViewMO->model(),
-              ui->tableViewMO->selectionModel()->currentIndex(),
+    setMOType(ui->treeViewMO->model(),
+              ui->treeViewMO->selectionModel()->currentIndex(),
               ui->comboBoxMOType->currentData().toUInt());
-    ui->tableViewMO->resizeColumnsToContents();
-    ui->tableViewMO->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+    ui->treeViewMO->resizeColumnToContents(0);
 }
 
 void
 SettingsOtherRemovable::on_comboBoxRDiskType_activated(int)
 {
-    setRDiskType(ui->tableViewRDisk->model(),
-                 ui->tableViewRDisk->selectionModel()->currentIndex(),
+    setRDiskType(ui->treeViewRDisk->model(),
+                 ui->treeViewRDisk->selectionModel()->currentIndex(),
                  ui->comboBoxRDiskBus->currentData().toUInt(),
                  ui->comboBoxRDiskType->currentData().toUInt());
-    ui->tableViewRDisk->resizeColumnsToContents();
-    ui->tableViewRDisk->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+    ui->treeViewRDisk->resizeColumnToContents(1);
 }
 
 void
@@ -599,20 +598,19 @@ SettingsOtherRemovable::on_comboBoxTapeBus_currentIndexChanged(int index)
 void
 SettingsOtherRemovable::on_comboBoxTapeBus_activated(int)
 {
-    auto i = ui->tableViewTape->selectionModel()->currentIndex().siblingAtColumn(0);
-    Harddrives::busTrackClass->device_track(0, DEV_TAPE, ui->tableViewTape->model()->data(i, Qt::UserRole).toInt(), ui->tableViewTape->model()->data(i, Qt::UserRole + 1).toInt());
+    auto i = ui->treeViewTape->selectionModel()->currentIndex().siblingAtColumn(0);
+    Harddrives::busTrackClass->device_track(0, DEV_TAPE, ui->treeViewTape->model()->data(i, Qt::UserRole).toInt(), ui->treeViewTape->model()->data(i, Qt::UserRole + 1).toInt());
     ui->comboBoxTapeChannel->setCurrentIndex(ui->comboBoxTapeBus->currentData().toUInt() == TAPE_BUS_ATAPI ? Harddrives::busTrackClass->next_free_ide_channel() : Harddrives::busTrackClass->next_free_scsi_id());
-    ui->tableViewTape->model()->data(i, Qt::UserRole + 1);
-    setTapeBus(ui->tableViewTape->model(),
-               ui->tableViewTape->selectionModel()->currentIndex(),
+    ui->treeViewTape->model()->data(i, Qt::UserRole + 1);
+    setTapeBus(ui->treeViewTape->model(),
+               ui->treeViewTape->selectionModel()->currentIndex(),
                ui->comboBoxTapeBus->currentData().toUInt(),
                ui->comboBoxTapeChannel->currentData().toUInt());
-    setTapeType(ui->tableViewTape->model(),
-                ui->tableViewTape->selectionModel()->currentIndex(),
+    setTapeType(ui->treeViewTape->model(),
+                ui->treeViewTape->selectionModel()->currentIndex(),
                 ui->comboBoxTapeType->currentData().toUInt());
-    ui->tableViewTape->resizeColumnsToContents();
-    ui->tableViewTape->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
-    Harddrives::busTrackClass->device_track(1, DEV_TAPE, ui->tableViewTape->model()->data(i, Qt::UserRole).toInt(), ui->tableViewTape->model()->data(i, Qt::UserRole + 1).toInt());
+    ui->treeViewTape->resizeColumnToContents(0);
+    Harddrives::busTrackClass->device_track(1, DEV_TAPE, ui->treeViewTape->model()->data(i, Qt::UserRole).toInt(), ui->treeViewTape->model()->data(i, Qt::UserRole + 1).toInt());
     emit tapeChannelChanged();
 }
 
@@ -629,22 +627,22 @@ SettingsOtherRemovable::enableCurrentlySelectedChannel_Tape()
 void
 SettingsOtherRemovable::on_comboBoxTapeChannel_activated(int)
 {
-    auto i = ui->tableViewTape->selectionModel()->currentIndex().siblingAtColumn(0);
-    Harddrives::busTrackClass->device_track(0, DEV_TAPE, ui->tableViewTape->model()->data(i, Qt::UserRole).toInt(), ui->tableViewTape->model()->data(i, Qt::UserRole + 1).toInt());
-    setTapeBus(ui->tableViewTape->model(),
-               ui->tableViewTape->selectionModel()->currentIndex(),
+    auto i = ui->treeViewTape->selectionModel()->currentIndex().siblingAtColumn(0);
+    Harddrives::busTrackClass->device_track(0, DEV_TAPE, ui->treeViewTape->model()->data(i, Qt::UserRole).toInt(), ui->treeViewTape->model()->data(i, Qt::UserRole + 1).toInt());
+    setTapeBus(ui->treeViewTape->model(),
+               ui->treeViewTape->selectionModel()->currentIndex(),
                ui->comboBoxTapeBus->currentData().toUInt(),
                ui->comboBoxTapeChannel->currentData().toUInt());
-    Harddrives::busTrackClass->device_track(1, DEV_TAPE, ui->tableViewTape->model()->data(i, Qt::UserRole).toInt(), ui->tableViewTape->model()->data(i, Qt::UserRole + 1).toInt());
+    Harddrives::busTrackClass->device_track(1, DEV_TAPE, ui->treeViewTape->model()->data(i, Qt::UserRole).toInt(), ui->treeViewTape->model()->data(i, Qt::UserRole + 1).toInt());
+    ui->treeViewTape->resizeColumnToContents(0);
     emit tapeChannelChanged();
 }
 
 void
 SettingsOtherRemovable::on_comboBoxTapeType_activated(int)
 {
-    setTapeType(ui->tableViewTape->model(),
-                ui->tableViewTape->selectionModel()->currentIndex(),
+    setTapeType(ui->treeViewTape->model(),
+                ui->treeViewTape->selectionModel()->currentIndex(),
                 ui->comboBoxTapeType->currentData().toUInt());
-    ui->tableViewTape->resizeColumnsToContents();
-    ui->tableViewTape->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+    ui->treeViewTape->resizeColumnToContents(1);
 }

--- a/src/qt/qt_settingsotherremovable.ui
+++ b/src/qt/qt_settingsotherremovable.ui
@@ -44,7 +44,7 @@
       <layout class="QVBoxLayout" name="verticalLayoutMO">
 
        <item>
-        <widget class="QTableView" name="tableViewMO">
+        <widget class="QTreeView" name="treeViewMO">
          <property name="editTriggers">
           <set>QAbstractItemView::NoEditTriggers</set>
          </property>
@@ -57,12 +57,12 @@
          <property name="tabKeyNavigation">
           <bool>false</bool>
          </property>
-         <property name="showGrid">
+         <property name="rootIsDecorated">
           <bool>false</bool>
          </property>
-         <attribute name="verticalHeaderVisible">
-          <bool>false</bool>
-         </attribute>
+         <property name="allColumnsShowFocus">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
        <item>
@@ -145,7 +145,7 @@
       <layout class="QVBoxLayout" name="verticalLayoutRDisk">
 
        <item>
-        <widget class="QTableView" name="tableViewRDisk">
+        <widget class="QTreeView" name="treeViewRDisk">
          <property name="editTriggers">
           <set>QAbstractItemView::NoEditTriggers</set>
          </property>
@@ -158,12 +158,12 @@
          <property name="tabKeyNavigation">
           <bool>false</bool>
          </property>
-         <property name="showGrid">
+         <property name="rootIsDecorated">
           <bool>false</bool>
          </property>
-         <attribute name="verticalHeaderVisible">
-          <bool>false</bool>
-         </attribute>
+         <property name="allColumnsShowFocus">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
        <item>
@@ -246,7 +246,7 @@
       <layout class="QVBoxLayout" name="verticalLayoutTape">
 
        <item>
-        <widget class="QTableView" name="tableViewTape">
+        <widget class="QTreeView" name="treeViewTape">
          <property name="editTriggers">
           <set>QAbstractItemView::NoEditTriggers</set>
          </property>
@@ -259,12 +259,12 @@
          <property name="tabKeyNavigation">
           <bool>false</bool>
          </property>
-         <property name="showGrid">
+         <property name="rootIsDecorated">
           <bool>false</bool>
          </property>
-         <attribute name="verticalHeaderVisible">
-          <bool>false</bool>
-         </attribute>
+         <property name="allColumnsShowFocus">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
        <item>
@@ -342,15 +342,15 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>tableViewMO</tabstop>
+  <tabstop>treeViewMO</tabstop>
   <tabstop>comboBoxMOBus</tabstop>
   <tabstop>comboBoxMOChannel</tabstop>
   <tabstop>comboBoxMOType</tabstop>
-  <tabstop>tableViewRDisk</tabstop>
+  <tabstop>treeViewRDisk</tabstop>
   <tabstop>comboBoxRDiskBus</tabstop>
   <tabstop>comboBoxRDiskChannel</tabstop>
   <tabstop>comboBoxRDiskType</tabstop>
-  <tabstop>tableViewTape</tabstop>
+  <tabstop>treeViewTape</tabstop>
   <tabstop>comboBoxTapeBus</tabstop>
   <tabstop>comboBoxTapeChannel</tabstop>
   <tabstop>comboBoxTapeType</tabstop>


### PR DESCRIPTION
Summary
=======
Replace `QTableView`s with `QTreeView`s in the settings and preferences dialog, as the "tables" where they're used are really multi-column lists; all columns now resize properly, horizontal scrolling is now smooth, the excess padding is gone; on Windows the look is now much closer to the old Win32 UI.

Drive-by: Rewrite the key bindings table to use a backing model instead of directly modifying cells.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set

References
==========
N/A