### PR TITLE
Add an option to define a keybind to exit the emulator

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -310,6 +310,12 @@ struct accelKey def_acc_keys[NUM_ACCELS] = {
         .desc="Toggle on-screen display",
         .seq="Ctrl+Alt+O"
     }
+,
+    {
+        .name="exit",
+        .desc="Exit",
+        .seq=""
+    }
 };
 
 char vmm_path[1024] = { '\0' }; /* VM manager path to scan for VMs */

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -336,7 +336,7 @@ struct accelKey {
 	char desc[64];
 	char seq[64];
 };
-#define NUM_ACCELS 15
+#define NUM_ACCELS 16
 extern struct accelKey acc_keys[NUM_ACCELS];
 extern struct accelKey def_acc_keys[NUM_ACCELS];
 extern int FindAccelerator(const char *name);

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -1705,7 +1705,7 @@ MainWindow::eventFilter(QObject *receiver, QEvent *event)
                 plat_pause(isNonPause ? dopause : (isShowMessage ? 2 : 1));
             }
             if (mouse_was_captured)
-                emit setMouseCapture(false);
+                plat_mouse_capture(0);
             releaseKeyboard();
             main_window_blocked = 1;
         } else if (event->type() == QEvent::WindowUnblocked) {
@@ -1713,7 +1713,7 @@ MainWindow::eventFilter(QObject *receiver, QEvent *event)
             if (do_auto_dialog_pause > 0)
                 plat_pause(curdopause);
             if (mouse_was_captured) {
-                emit setMouseCapture(true);
+                plat_mouse_capture(1);
             }
             main_window_blocked = 0;
         } else if (event->type() == QEvent::WindowStateChange) {

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -177,6 +177,7 @@ extern "C" void qt_blit(int x, int y, int w, int h, int monitor_index);
 extern MainWindow *main_window;
 
 int                main_window_blocked = 0;
+int                exiting_manually    = 0;
 
 #ifdef Q_OS_WINDOWS
 static bool
@@ -930,10 +931,11 @@ MainWindow::MainWindow(QWidget *parent)
 void
 MainWindow::closeEvent(QCloseEvent *event)
 {
-    if (mouse_capture) {
+    if (!exiting_manually && mouse_capture) {
         event->ignore();
         return;
     }
+    exiting_manually = 0;
 
     if (confirm_exit && confirm_exit_cmdl && cpu_thread_run) {
         QMessageBox questionbox(QMessageBox::Icon::Question, "86Box", tr("Are you sure you want to exit 86Box?"), QMessageBox::Yes | QMessageBox::No, this);
@@ -1005,13 +1007,19 @@ MainWindow::updateShortcuts()
     // First we need to wipe all existing accelerators, otherwise Qt will
     // run into conflicts with old ones.
     ui->actionTake_screenshot->setShortcut(QKeySequence());
+    ui->actionTake_raw_screenshot->setShortcut(QKeySequence());
+    ui->actionCopy_screenshot->setShortcut(QKeySequence());
+    ui->actionCopy_raw_screenshot->setShortcut(QKeySequence());
     ui->actionCtrl_Alt_Del->setShortcut(QKeySequence());
     ui->actionCtrl_Alt_Esc->setShortcut(QKeySequence());
     ui->actionHard_Reset->setShortcut(QKeySequence());
+    ui->actionFast_forward->setShortcut(QKeySequence());
+    ui->actionFullscreen->setShortcut(QKeySequence());
     ui->actionPause->setShortcut(QKeySequence());
     ui->actionMute_Unmute->setShortcut(QKeySequence());
     ui->actionForce_interpretation->setShortcut(QKeySequence());
     ui->actionToggle_OSD->setShortcut(QKeySequence());
+    ui->actionExit->setShortcut(QKeySequence());
 
     int          accID;
     QKeySequence seq;
@@ -1067,6 +1075,10 @@ MainWindow::updateShortcuts()
     accID = FindAccelerator("toggle_osd");
     seq   = QKeySequence::fromString(acc_keys[accID].seq);
     ui->actionToggle_OSD->setShortcut(seq);
+
+    accID = FindAccelerator("exit");
+    seq   = QKeySequence::fromString(acc_keys[accID].seq);
+    ui->actionExit->setShortcut(seq);
 }
 
 void
@@ -1272,6 +1284,7 @@ MainWindow::on_actionToggle_OSD_triggered()
 void
 MainWindow::on_actionExit_triggered()
 {
+    exiting_manually = 1;
     close();
 }
 
@@ -1664,6 +1677,10 @@ MainWindow::eventFilter(QObject *receiver, QEvent *event)
                 || (QKeySequence) (ke->key() | ke->modifiers()) == FindAcceleratorSeq("mute")) {
                 ui->actionMute_Unmute->trigger();
             }
+            if ((QKeySequence) (ke->key() | (ke->modifiers() & ~Qt::KeypadModifier)) == FindAcceleratorSeq("exit")
+                || (QKeySequence) (ke->key() | ke->modifiers()) == FindAcceleratorSeq("exit")) {
+                ui->actionExit->trigger();
+            }
             if ((QKeySequence) (ke->key() | (ke->modifiers() & ~Qt::KeypadModifier)) == FindAcceleratorSeq("toggle_ui_fullscreen")
                 || (QKeySequence) (ke->key() | ke->modifiers()) == FindAcceleratorSeq("toggle_ui_fullscreen")) {
                 toggleFullscreenUI();
@@ -1674,6 +1691,7 @@ MainWindow::eventFilter(QObject *receiver, QEvent *event)
     }
 
     if (!main_window_blocked && !dopause && (!kbd_req_capture || mouse_capture)) {
+#if 0
         if (event->type() == QEvent::Shortcut) {
             auto shortcutEvent = (QShortcutEvent *) event;
             if (shortcutEvent->key() == ui->actionExit->shortcut()) {
@@ -1681,6 +1699,7 @@ MainWindow::eventFilter(QObject *receiver, QEvent *event)
                 return true;
             }
         }
+#endif
         if (event->type() == QEvent::KeyPress) {
             event->accept();
 


### PR DESCRIPTION
Summary
=======
Add an (unset by default) keybind to exit 86Box.

Drive-by: Fix cursor occasionally showing up on Windows when rapidly moving the mouse while the mouse is captured after a dialog window has interrupted the mouse capture.

Checklist
=========
* [x] Closes #7324
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set

References
==========
N/A