### PR TITLE
Preferences: Don't resize the main window if fullscreen or language isn't changed

### DIFF
--- a/src/qt/qt_preferences.cpp
+++ b/src/qt/qt_preferences.cpp
@@ -205,17 +205,20 @@ Preferences::save()
 void
 Preferences::accept()
 {
-    auto size               = main_window->centralWidget()->size();
+    int lang_changed = emulator->changed();
 
     save();
     config_save_global();
-    QTimer::singleShot(200, [size] () {
-        main_window->centralWidget()->setFixedSize(size);
-        QApplication::processEvents();
-        if (vid_resize == 1) {
-            main_window->centralWidget()->setFixedSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
-        }
-    });
+    if (!video_fullscreen && lang_changed) {
+        auto size = main_window->centralWidget()->size();
+        QTimer::singleShot(200, [size] () {
+            main_window->centralWidget()->setFixedSize(size);
+            QApplication::processEvents();
+            if (vid_resize == 1) {
+                main_window->centralWidget()->setFixedSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
+            }
+        });
+    }
     QDialog::accept();
 }
 

--- a/src/qt/qt_preferencesemulator.cpp
+++ b/src/qt/qt_preferencesemulator.cpp
@@ -86,6 +86,13 @@ PreferencesEmulator::~PreferencesEmulator()
     delete ui;
 }
 
+int
+PreferencesEmulator::changed()
+{
+    return ((lang_id != ui->comboBoxLanguage->currentData().toInt()) ? 1 : 0);
+}
+
+
 void
 PreferencesEmulator::save()
 {

--- a/src/qt/qt_preferencesemulator.hpp
+++ b/src/qt/qt_preferencesemulator.hpp
@@ -20,6 +20,7 @@ public:
     explicit PreferencesEmulator(QWidget *parent = nullptr);
     ~PreferencesEmulator();
 
+    int  changed();
     void save();
 
 private slots:


### PR DESCRIPTION
Summary
=======
Don't adjust the main window size after accepting changes in the preferences dialog if 86Box is currently in fullscreen mode or the language wasn't changed; fixes fullscreen mode breaking after exiting the preferences dialog.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set

References
==========
N/A