### PR TITLE
cdrom_aaru: Get rid of unnecessary prompts

### DIFF
--- a/src/cdrom/cdrom_aaru.c
+++ b/src/cdrom/cdrom_aaru.c
@@ -17,6 +17,8 @@
  *          Copyright 2026 Cacodemon345.
  */
 
+/* Format identification code (C) Natalia Portillo, licensed under LGPLv2.1+. */
+
 #include <aaruformat.h>
 
 #define __STDC_FORMAT_MACROS
@@ -755,10 +757,37 @@ cleanup_error:
     return NULL;
 }
 
+static int aaruf_identify_local(const char *filename)
+{
+    if (filename == NULL)
+        return EINVAL;
+
+    FILE *stream = NULL;
+
+    stream = fopen(filename, "rb");
+
+    if (stream == NULL)
+        return errno;
+
+    AaruHeader header;
+
+    size_t ret = fread(&header, sizeof(AaruHeader), 1, stream);
+
+    if(ret != 1) {
+        fclose(stream);
+        return 0;
+    }
+
+    if((header.identifier == DIC_MAGIC || header.identifier == AARU_MAGIC) && header.imageMajorVersion <= AARUF_VERSION)
+        ret = 100;
+
+    fclose(stream);
+
+    return ret;
+}
+
 int
 cdrom_image_is_aaru(const char *fn)
 {
-    if (!ensure_libaaruformat())
-        return 0;
-    return (f_aaruf_identify(fn) == 100);
+    return (aaruf_identify_local(fn) == 100);
 }

--- a/src/cdrom/cdrom_aaru.c
+++ b/src/cdrom/cdrom_aaru.c
@@ -34,6 +34,7 @@
 #include <string.h>
 #include <wchar.h>
 #include <zlib.h>
+#include <errno.h>
 #include <limits.h>
 #include <sys/stat.h>
 #ifndef _WIN32


### PR DESCRIPTION
Summary
=======
Gets rid of unnecessary prompts if the library isn't found when loading any images.

Closes #7444.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
