### PR TITLE
cdrom_aaru: Add support for DVD structures

### DIFF
--- a/src/cdrom/cdrom_aaru.c
+++ b/src/cdrom/cdrom_aaru.c
@@ -384,7 +384,50 @@ static int
 aaru_image_read_dvd_structure(UNUSED(const void *local), UNUSED(const uint8_t layer), UNUSED(const uint8_t format),
                               UNUSED(uint8_t *buffer), UNUSED(uint32_t *info))
 {
-    // FIXME: How to do this?
+    aaru_image_t *img = (aaru_image_t *) local;
+    if (img->is_dvd) {
+        uint8_t res[2052] = { };
+        uint32_t length = 2052;
+        switch (format) {
+            case 0x00:  /* Physical Format Information (PFI). */
+            {
+                if (!f_aaruf_read_media_tag(img->aaruf_context, res, layer ? kMediaTagDvdPfi2ndLayer : kMediaTagDvdPfi, &length)) {
+                    if (length == 2048) {
+                        memcpy(buffer + 4, res, 2048);
+                        return 2048 + 2;
+                    } else if (length == 2052) {
+                        memcpy(buffer, res, 2052);
+                        return 2048 + 2;
+                    }
+                }
+                
+                break;
+            }
+            case 0x01: /* DVD copyright information (CMI). */
+            {
+                length = 8;
+                if (!f_aaruf_read_media_tag(img->aaruf_context, res, kMediaTagDvdCmi, &length)) {
+                    if (length == 8) {
+                        memcpy(buffer, res, 8);
+                        return 4 + 2;
+                    }
+                }
+
+                break;
+            }
+            case 0x04: /* DVD disc manufacturing information (DMI). */
+            {
+                if (!f_aaruf_read_media_tag(img->aaruf_context, res, kMediaTagDvdDmi, &length)) {
+                    if (length == 2052) {
+                        memcpy(buffer, res, 2052);
+                        return 2048 + 2;
+                    }
+                }
+
+                break;
+            }
+        }
+    }
     return 0;
 }
 

--- a/src/cdrom/cdrom_image.c
+++ b/src/cdrom/cdrom_image.c
@@ -2969,15 +2969,15 @@ image_read_dvd_structure(const void *local, const uint8_t layer, const uint8_t f
 
     if ((img->has_dstruct > 0) && ((layer + 1) > img->has_dstruct)) {
         switch (format) {
-            case 0x00:
+            case 0x00: /* Physical Format Information (PFI). */
                 memcpy(buffer + 4, img->dstruct.layers[layer].f0, 2048);
                 ret = 2048 + 2;
                 break;
-            case 0x01:
+            case 0x01: /* DVD copyright information */
                 memcpy(buffer + 4, img->dstruct.layers[layer].f1, 4);
                 ret = 4 + 2;
                 break;
-            case 0x04:
+            case 0x04: /* DVD disc manufacturing information. */
                 memcpy(buffer + 4, img->dstruct.layers[layer].f4, 2048);
                 ret = 2048 + 2;
                 break;


### PR DESCRIPTION
Summary
=======
cdrom_aaru: Add support for DVD structures.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
