### PR TITLE
Expand file selector to all the officially-recognized Aaru extensions

### DIFF
--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -657,7 +657,7 @@ MediaMenu::cdromMount(int i, int dir, const QString &arg)
     else {
         filename = QFileDialog::getOpenFileName(parentWidget, QString(),
                                                 getMediaOpenDirectory(),
-                                                tr("CD-ROM images") % util::DlgFilter({ "iso", "cue", "mds", "mdx", "aaruf" }) % tr("All files") % util::DlgFilter({ "*" }, true));
+                                                tr("CD-ROM images") % util::DlgFilter({ "iso", "cue", "mds", "mdx", "aaruf", "aaruformat", "aif" }) % tr("All files") % util::DlgFilter({ "*" }, true));
     }
 
     if (filename.isEmpty())


### PR DESCRIPTION
Summary
=======
From <https://www.aaru.app/quickstart.md>, Aaru recognizes *.aaruformat, *.aaruf, and *.aif as file name extensions to its own dump format.

Related, before I found this document I was naming my files with *.aaru -- it seemed like the obvious choice.  Should I add that to the list as well, or am I just an odd one out there?

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/