### PR TITLE
cdrom_aaru: Fix alignment of members in AaruHeader and TrackEntry str…

### DIFF
--- a/src/cdrom/cdrom_aaru.c
+++ b/src/cdrom/cdrom_aaru.c
@@ -74,6 +74,7 @@ typedef struct ImageInfo
     uint8_t  MetadataMediaType;
 } ImageInfo;
 
+#pragma pack(push, 1)
 typedef struct TrackEntry
 {
     uint8_t  sequence;
@@ -99,6 +100,7 @@ typedef struct AaruHeader
     int64_t  creationTime;
     int64_t  lastWrittenTime;
 } AaruHeader;
+#pragma pack(pop)
 
 typedef enum
 {


### PR DESCRIPTION
Summary
=======
cdrom_aaru: Fix alignment of members in AaruHeader and TrackEntry structs.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
