### PR TITLE
cdrom_aaru: Read Full TOC metadata in the correct position

### DIFF
--- a/src/cdrom/cdrom_aaru.c
+++ b/src/cdrom/cdrom_aaru.c
@@ -678,11 +678,11 @@ aaru_image_open(cdrom_t *dev, const char *path)
             res = f_aaruf_read_media_tag(img->aaruf_context, NULL, kMediaTagFullToc, &length);
 
             if (res == AARUF_ERROR_BUFFER_TOO_SMALL && length != 0) {
-                img->full_toc = calloc(1, length);
-                res           = f_aaruf_read_media_tag(img->aaruf_context, img->full_toc,
+                img->full_toc = calloc(1, length + 2);
+                res           = f_aaruf_read_media_tag(img->aaruf_context, img->full_toc + 2,
                                                        kMediaTagFullToc, &length);
                 if (!res) {
-                    img->full_toc_size = length;
+                    img->full_toc_size = length + 2;
                     goto toc_skip;
                 }
             }


### PR DESCRIPTION
Summary
=======
cdrom_aaru: Read Full TOC metadata in the correct position.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
