### PR TITLE
CodeQL: Disable alerts for "Uncontrolled data used in path expression"

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,3 +3,7 @@ name: "86Box CodeQL config"
 queries:
   - uses: security-extended
 #  - uses: security-and-quality
+
+query-filters:
+  - exclude:
+      id: cpp/path-injection


### PR DESCRIPTION
Summary
=======
Disables alerts for "Uncontrolled data used in path expression".

Avoids false-positive alerts as the scanner is not always able to determine the correct intent, and may even falsely flag such code.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
