### PR TITLE
Huge overhaul of DMA, PIT and 808x emulation subsystems that brings 8088/8086 emulation to essentially perfect cycle accuracy.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(86Box
     pci_dummy.c
     pic.c
     pit.c
+    pit_exact.c
     pit_fast.c
     port_6x.c
     port_92.c

--- a/src/cpu/808x.c
+++ b/src/cpu/808x.c
@@ -41,6 +41,7 @@
 #include <86box/plat_fallthrough.h>
 #include <86box/plat_unused.h>
 #include "vx0_biu.h"
+#include "808x_marty_86box.h"
 
 /* Is the CPU 8088 or 8086. */
 int is8086 = 0;
@@ -175,42 +176,56 @@ static void set_pzs(int bits);
 void
 prefetch_queue_set_pos(int pos)
 {
+    if (m808x_86box_active()) { m808x_86box_pfq_set_pos(pos); return; }
+
     pfq_pos = pos;
 }
 
 void
 prefetch_queue_set_ip(uint16_t ip)
 {
+    if (m808x_86box_active()) { m808x_86box_pfq_set_ip(ip); return; }
+
     pfq_ip = ip;
 }
 
 void
 prefetch_queue_set_prefetching(int p)
 {
+    if (m808x_86box_active()) { m808x_86box_pfq_set_prefetching(p); return; }
+
     prefetching = p;
 }
 
 int
 prefetch_queue_get_pos(void)
 {
+    if (m808x_86box_active()) return m808x_86box_pfq_get_pos();
+
     return pfq_pos;
 }
 
 uint16_t
 prefetch_queue_get_ip(void)
 {
+    if (m808x_86box_active()) return m808x_86box_pfq_get_ip();
+
     return pfq_ip;
 }
 
 int
 prefetch_queue_get_prefetching(void)
 {
+    if (m808x_86box_active()) return m808x_86box_pfq_get_prefetching();
+
     return prefetching;
 }
 
 int
 prefetch_queue_get_size(void)
 {
+    if (m808x_86box_active()) return m808x_86box_pfq_get_size();
+
     return pfq_size;
 }
 static void set_if(int cond);
@@ -256,6 +271,11 @@ fetch_and_bus(int c, int bus)
 static void
 wait_cycs(int c, int bus)
 {
+    if (m808x_86box_active()) {
+        m808x_86box_wait(c, bus);
+        return;
+    }
+
     if (is_new_biu)
         wait_vx0(c);
     else {
@@ -268,6 +288,11 @@ wait_cycs(int c, int bus)
 void
 sub_cycles(int c)
 {
+    if (m808x_86box_active()) {
+        m808x_86box_external_sub_cycles(c);
+        return;
+    }
+
     if (c <= 0)
         return;
 
@@ -706,6 +731,11 @@ static void i8080_port_out(UNUSED(void* priv), uint8_t port, uint8_t val)
 void
 reset_808x(int hard)
 {
+    if (m808x_86box_should_use()) {
+        m808x_86box_reset(hard);
+        return;
+    }
+
     is_new_biu = 0;
     biu_cycles = 0;
     in_rep     = 0;
@@ -766,6 +796,11 @@ set_ip(uint16_t new_ip)
 void
 refreshread(void)
 {
+    if (m808x_86box_active()) {
+        m808x_86box_refresh();
+        return;
+    }
+
     refresh++;
 }
 
@@ -1892,6 +1927,78 @@ cpu_outw(uint16_t port, uint16_t val)
     }
 
     resub_cycles(old_cycles);
+}
+
+
+
+/* MARTY808X_86BOX_INTEGRATION: retain 86Box's established 8087 operation
+ * tables while the replacement EU/BIU core owns CPU clocks and prefetch. */
+bool
+m808x_86box_fpu_busy(void)
+{
+    /* 86Box's current 8087 implementations execute synchronously.  Pending
+     * unmasked exceptions are still delivered by their existing code path. */
+    return false;
+}
+
+void
+m808x_86box_fpu_exec(uint8_t op, uint8_t modrm, uint16_t ea, uint8_t segment_index)
+{
+    const uint8_t saved_opcode = opcode;
+    const uint32_t saved_rmdat = rmdat;
+    const uint32_t saved_easeg = easeg;
+    const int32_t saved_rm_data = cpu_state.rm_data.rm_mod_reg_data;
+    const uint16_t saved_pc = cpu_state.pc;
+
+    opcode = op;
+    rmdat = modrm;
+    cpu_mod = (modrm >> 6) & 3;
+    cpu_reg = (modrm >> 3) & 7;
+    cpu_rm = modrm & 7;
+    cpu_state.eaaddr = ea;
+
+    switch (segment_index) {
+        case 0: easeg = es; break;
+        case 1: easeg = cs; break;
+        case 2: easeg = ss; break;
+        case 3: easeg = ds; break;
+        default: easeg = ds; break;
+    }
+
+    if (!hasfpu) {
+        if (cpu_mod != 3)
+            (void) readmemw(easeg, ea);
+    } else if (fpu_softfloat) {
+        switch (op) {
+            case 0xd8: ops_sf_fpu_8087_d8[(modrm >> 3) & 0x1f](modrm); break;
+            case 0xd9: ops_sf_fpu_8087_d9[modrm](modrm); break;
+            case 0xda: ops_sf_fpu_8087_da[modrm](modrm); break;
+            case 0xdb: ops_sf_fpu_8087_db[modrm](modrm); break;
+            case 0xdc: ops_sf_fpu_8087_dc[(modrm >> 3) & 0x1f](modrm); break;
+            case 0xdd: ops_sf_fpu_8087_dd[modrm](modrm); break;
+            case 0xde: ops_sf_fpu_8087_de[modrm](modrm); break;
+            case 0xdf: ops_sf_fpu_8087_df[modrm](modrm); break;
+            default: break;
+        }
+    } else {
+        switch (op) {
+            case 0xd8: ops_fpu_8087_d8[(modrm >> 3) & 0x1f](modrm); break;
+            case 0xd9: ops_fpu_8087_d9[modrm](modrm); break;
+            case 0xda: ops_fpu_8087_da[modrm](modrm); break;
+            case 0xdb: ops_fpu_8087_db[modrm](modrm); break;
+            case 0xdc: ops_fpu_8087_dc[(modrm >> 3) & 0x1f](modrm); break;
+            case 0xdd: ops_fpu_8087_dd[modrm](modrm); break;
+            case 0xde: ops_fpu_8087_de[modrm](modrm); break;
+            case 0xdf: ops_fpu_8087_df[modrm](modrm); break;
+            default: break;
+        }
+    }
+
+    cpu_state.pc = saved_pc;
+    cpu_state.rm_data.rm_mod_reg_data = saved_rm_data;
+    easeg = saved_easeg;
+    rmdat = saved_rmdat;
+    opcode = saved_opcode;
 }
 
 void
@@ -3350,6 +3457,11 @@ execx86_instruction(void)
 void
 execx86(int cycs)
 {
+    if (m808x_86box_should_use()) {
+        m808x_86box_exec(cycs);
+        return;
+    }
+
     cycles += cycs;
 
     while (cycles > 0) {

--- a/src/cpu/808x_marty_86box.c
+++ b/src/cpu/808x_marty_86box.c
@@ -60,6 +60,7 @@
 #include <86box/nmi.h>
 #include <86box/pic.h>
 #include <86box/timer.h>
+#include <86box/video.h>
 
 #include "cpu.h"
 #include "x86.h"
@@ -854,6 +855,31 @@ static void m808x_dma_tick(m808x_cpu_t *cpu)
     }
 }
 
+/*
+ * NOCONA_CGA_PREWAIT_808X_UPDATE_V1
+ *
+ * IBM CGA VRAM is available only in fixed slots of the 14.31818 MHz
+ * motherboard clock.  Determine the slot during CPU T2 and preload the
+ * measured READY delay before the memory callback is allowed to run.
+ *
+ * This is important for snow: invoking cga_read()/cga_write() first and only
+ * then converting their cycle deduction into Tw states commits the VRAM/snow
+ * side effect at the initial T3 instead of the terminal Tw.
+ */
+static unsigned
+m808x_cga_wait_clocks(const m808x_cpu_t *cpu)
+{
+    /* MartyPC's 16 master-clock phases converted to 4.77 MHz CPU clocks. */
+    static const uint8_t waits[16] = {
+        5, 5, 4, 4, 4, 3, 8, 8,
+        8, 7, 7, 7, 6, 6, 6, 5
+    };
+
+    const unsigned master_phase =
+        (unsigned)((cpu->cycle_num * 3u + 1u) & 0x0fu);
+    return waits[master_phase];
+}
+
 static void biu_cycle_i(m808x_cpu_t *cpu, uint16_t mc_line, const char *comment)
 {
     m808x_biu_t *b = &cpu->biu;
@@ -907,6 +933,20 @@ static void biu_cycle_i(m808x_cpu_t *cpu, uint16_t mc_line, const char *comment)
                          b->bus_status_latch == BUS_IOW) &&
                         b->wait_remaining == 0u)
                         b->wait_remaining = 1u;
+
+                    /*
+                     * CGA READY is phase-dependent.  Precharge it in T2 so the
+                     * device callback and snow side effects occur only on the
+                     * final T3/Tw data-transfer edge.
+                     */
+                    if ((b->bus_status_latch == BUS_CODE ||
+                         b->bus_status_latch == BUS_MEMR ||
+                         b->bus_status_latch == BUS_MEMW) &&
+                        b->address_latch >= 0xb8000u &&
+                        b->address_latch <= 0xbffffu &&
+                        video_is_cga()) {
+                        b->wait_remaining += m808x_cga_wait_clocks(cpu);
+                    }
 
                     if (b->final_transfer) {
                         biu_make_fetch_decision(cpu);

--- a/src/cpu/808x_marty_86box.c
+++ b/src/cpu/808x_marty_86box.c
@@ -1,0 +1,4313 @@
+/*
+ * 808x EU/BIU execution-flow model
+ *
+ * This is a ground-up replacement for the original standalone timing probe.
+ * The externally visible bus follows Intel's T1/T2/T3/Tw/T4 description,
+ * while the overlapped address pipeline (Tr/Ts/T0), queue policy, fetch aborts,
+ * SUSP/CORR/FLUSH flow, RNI preload, and EU bus arbitration follow the model
+ * used by MartyPC's cpu_808x core.
+ *
+ * MartyPC is MIT-licensed:
+ *   https://github.com/dbalsom/martypc
+ * Copyright 2022-2026 Daniel Balsom
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This file remains a self-contained validation core, but now decodes and
+ * executes the complete 8086/8088 primary opcode map, including the original
+ * group encodings and documented/undocumented aliases. Instruction bodies are
+ * expressed as queue reads, EU cycles, microcode-line cycles, and BIU accesses;
+ * there is no aggregate fallback timing path.
+ *
+ * Scope boundary: this models CPU execution/bus flow, not board-level analog
+ * behavior. 86Box's existing 8087 operation tables remain authoritative for
+ * ESC instructions and are called through the companion bridge in 808x.c.
+ * XT refresh requests enter a clocked DREQ/HRQ/HOLDA/AEN/DACK scheduler.
+ * Other 86Box DMA peripherals retain the existing synchronous device API and
+ * are intentionally not misrepresented as pin-complete 8237 transfers.
+ */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <86box/86box.h>
+#include <86box/gdbstub.h>
+#include <86box/io.h>
+#include <86box/machine.h>
+#include <86box/mem.h>
+#include <86box/nmi.h>
+#include <86box/pic.h>
+#include <86box/timer.h>
+
+#include "cpu.h"
+#include "x86.h"
+#include "808x_marty_86box.h"
+
+/* cpu.h exposes the architectural registers as preprocessor aliases.  This
+ * translation unit uses the same short names for the private core state. */
+#undef AX
+#undef AL
+#undef AH
+#undef CX
+#undef CL
+#undef CH
+#undef DX
+#undef DL
+#undef DH
+#undef BX
+#undef BL
+#undef BH
+#undef SP
+#undef BP
+#undef SI
+#undef DI
+#undef cycles
+
+#define PFQ_MAX  6u
+#define MC_NONE  0xffffu
+#define MC_JUMP  0xfffeu
+#define MC_CORR  0xfffdu
+#define MC_RNI   0xfffcu
+
+#ifndef ARRAY_LEN
+# define ARRAY_LEN(a) (sizeof(a) / sizeof((a)[0]))
+#endif
+
+/* C/P/A/Z/T/I/D/V are supplied by cpu.h.  86Box calls the sign bit N_FLAG. */
+#define S_FLAG N_FLAG
+
+/* Prefix bits. */
+#define PFX_LOCK  0x01u
+#define PFX_REPNE 0x02u
+#define PFX_REPE  0x04u
+#define PFX_SEG   0x08u
+
+typedef enum {
+    SEG_ES = 0,
+    SEG_CS,
+    SEG_SS,
+    SEG_DS,
+    SEG_NONE
+} m808x_segment_t;
+
+typedef enum {
+    BUS_PASSIVE = 0,
+    BUS_CODE,
+    BUS_IOR,
+    BUS_IOW,
+    BUS_MEMR,
+    BUS_MEMW,
+    BUS_INTA,
+    BUS_HALT
+} m808x_bus_status_t;
+
+typedef enum {
+    T_INIT = 0,
+    T_I,
+    T_1,
+    T_2,
+    T_3,
+    T_W,
+    T_4
+} m808x_t_cycle_t;
+
+typedef enum {
+    TA_DONE = 0,
+    TA_TR,
+    TA_TS,
+    TA_T0,
+    TA_ABORT
+} m808x_ta_cycle_t;
+
+typedef enum {
+    FETCH_NORMAL = 0,
+    FETCH_PAUSED_FULL,
+    FETCH_DELAYED,
+    FETCH_SUSPENDED,
+    FETCH_HALTED
+} m808x_fetch_kind_t;
+
+typedef enum {
+    PENDING_NONE = 0,
+    PENDING_EU_EARLY,
+    PENDING_EU_LATE
+} m808x_pending_t;
+
+typedef enum {
+    XFER_BYTE = 1,
+    XFER_WORD = 2
+} m808x_transfer_size_t;
+
+typedef enum {
+    OPERAND_8 = 1,
+    OPERAND_16 = 2
+} m808x_operand_size_t;
+
+typedef enum {
+    QOP_IDLE = 0,
+    QOP_FIRST,
+    QOP_SUBSEQUENT,
+    QOP_FLUSH
+} m808x_queue_op_t;
+
+typedef union {
+    uint16_t x;
+    struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+        uint8_t l;
+        uint8_t h;
+#else
+        uint8_t h;
+        uint8_t l;
+#endif
+    } b;
+} m808x_reg_t;
+
+typedef struct {
+    uint8_t data[PFQ_MAX];
+    unsigned head;
+    unsigned len;
+    unsigned capacity;
+    unsigned policy_len;
+    bool preload_valid;
+    uint8_t preload_byte;
+    int was_read;
+    m808x_queue_op_t op;
+    m808x_queue_op_t last_op;
+} m808x_pfq_t;
+
+typedef struct {
+    m808x_fetch_kind_t kind;
+    unsigned delay;
+} m808x_fetch_state_t;
+
+typedef struct {
+    m808x_t_cycle_t t_cycle;
+    m808x_ta_cycle_t ta_cycle;
+
+    m808x_bus_status_t bus_status;       /* pin-visible status; passive from T3 */
+    m808x_bus_status_t bus_status_latch; /* operation retained through T4 */
+    m808x_bus_status_t pl_status;        /* address-pipeline status */
+    m808x_pending_t pending;
+    m808x_fetch_state_t fetch;
+
+    m808x_segment_t bus_segment;
+    uint32_t address_bus;
+    uint32_t address_latch;
+    uint16_t data_bus;
+
+    m808x_transfer_size_t transfer_size;
+    m808x_operand_size_t operand_size;
+    unsigned transfer_n;
+    bool final_transfer;
+    bool bhe;
+    bool ale;
+    bool transfer_done;
+    unsigned wait_remaining;
+
+    m808x_pfq_t queue;
+} m808x_biu_t;
+
+typedef struct {
+    uint8_t opcode;
+    uint8_t prefixes;
+    m808x_segment_t segment_override;
+    bool has_segment_override;
+    bool has_modrm;
+    uint8_t modrm;
+    uint8_t mod;
+    uint8_t reg;
+    uint8_t rm;
+    uint16_t ea;
+    m808x_segment_t ea_segment;
+    uint16_t instruction_ip;
+} m808x_instruction_t;
+
+typedef struct {
+    bool is_8086;
+    bool trace;
+    bool stop_on_halt;
+    bool fatal;
+    bool halted;
+    bool waiting;
+    bool test_pin;
+    bool intr_pin;
+    bool nmi_pin;
+    uint8_t interrupt_vector;
+    unsigned interrupt_shadow;
+    unsigned trap_shadow;
+    unsigned trap_disable_delay;
+
+    uint64_t cycle_num;
+    uint64_t instruction_count;
+    uint64_t cycle_limit;
+    unsigned configured_wait_states;
+
+    uint16_t flags;
+    uint16_t segs[4];
+    m808x_reg_t regs[8];
+    uint16_t pc; /* next instruction byte to fetch, not architectural IP */
+
+    uint16_t ea_addr;
+    m808x_segment_t ea_seg;
+    uint16_t cpu_data;
+
+    bool nx;
+    bool rni;
+    bool in_lock;
+    uint8_t rep_prefix;
+
+    uint16_t mc_line;
+    const char *trace_comment;
+
+    m808x_instruction_t ins;
+    m808x_biu_t biu;
+} m808x_cpu_t;
+
+
+void m808x_86box_export_arch_state(const m808x_cpu_t *cpu);
+void m808x_86box_import_register_state(m808x_cpu_t *cpu);
+
+#define AX cpu->regs[0].x
+#define AL cpu->regs[0].b.l
+#define AH cpu->regs[0].b.h
+#define CX cpu->regs[1].x
+#define CL cpu->regs[1].b.l
+#define CH cpu->regs[1].b.h
+#define DX cpu->regs[2].x
+#define DL cpu->regs[2].b.l
+#define DH cpu->regs[2].b.h
+#define BX cpu->regs[3].x
+#define BL cpu->regs[3].b.l
+#define BH cpu->regs[3].b.h
+#define SP cpu->regs[4].x
+#define BP cpu->regs[5].x
+#define SI cpu->regs[6].x
+#define DI cpu->regs[7].x
+
+static const char *const segment_name[] = {"ES", "CS", "SS", "DS", "--"};
+static const char *const bus_name[] = {"PASV", "CODE", "IOR ", "IOW ", "MEMR", "MEMW", "INTA", "HALT"};
+static const char *const t_name[] = {"T*", "Ti", "T1", "T2", "T3", "Tw", "T4"};
+static const char *const ta_name[] = {"Td", "Tr", "Ts", "T0", "Ta"};
+static const char *const qop_name[] = {"--", "F ", "S ", "FL"};
+
+static void m808x_host_cycle(void);
+
+/* NOCONA_M808X_DMA_READY_CONSOLIDATED_V3
+ *
+ * The PC/XT motherboard does not stop the 8088 BIU through its HOLD input.
+ * Board logic grants the 8237 independently and stalls an overlapping CPU bus
+ * cycle through READY/DMAWAIT. Therefore HRQ/HOLDA must never suppress an
+ * internal BIU request; the request is allowed to enter T1/T2/T3 and then wait
+ * for READY exactly as the processor would on the motherboard.
+ */
+bool m808x_86box_dma_try_request_ex(unsigned wait_clocks,
+                                    void (*ack_callback)(void *opaque),
+                                    void *opaque);
+bool m808x_86box_dma_cancel_request_ex(void (*ack_callback)(void *opaque),
+                                       void *opaque);
+uint64_t m808x_86box_cycle_number(void);
+
+/* 86Box device handlers historically observe the cycle counter after the
+ * complete four-clock access has been charged.  The pin-level core invokes
+ * the data callback at the end of T3/final Tw, two clocks earlier than that
+ * legacy observation point.  Present the established phase to contention
+ * models while converting any cycle deduction into actual Tw states. */
+#define M808X_HOST_CALLBACK_PHASE_BIAS 2
+static bool m808x_in_host_bus_callback = false;
+/* Only the legacy cycle-budget view is biased for compatibility with
+ * contention handlers.  TSC and timers remain at the physical T3/final-Tw
+ * transfer edge; advancing them here would deliver PIT/DMA edges early. */
+#ifdef M808X_86BOX_TESTING
+static uint64_t m808x_test_captured_wait_clocks = 0;
+static uint64_t m808x_test_tw_clocks = 0;
+static void (*m808x_test_cycle_hook)(const m808x_cpu_t *cpu) = NULL;
+#endif
+static bool m808x_host_override_vector(uint8_t vector, uint16_t *ip, uint16_t *segp);
+
+static uint32_t linear_address(uint16_t seg, uint16_t off)
+{
+    return ((((uint32_t)seg << 4) + off) & 0xfffffu);
+}
+
+static bool bus_is_active(m808x_bus_status_t status)
+{
+    return status != BUS_PASSIVE && status != BUS_HALT;
+}
+
+static bool fetch_enabled(const m808x_cpu_t *cpu)
+{
+    return cpu->biu.fetch.kind != FETCH_SUSPENDED &&
+           cpu->biu.fetch.kind != FETCH_HALTED;
+}
+
+static unsigned queue_effective_len(const m808x_pfq_t *q)
+{
+    return q->len + (q->preload_valid ? 1u : 0u);
+}
+
+static void queue_reset(m808x_pfq_t *q, bool is_8086)
+{
+    memset(q, 0, sizeof(*q));
+    q->capacity = is_8086 ? 6u : 4u;
+    q->policy_len = is_8086 ? 4u : 3u;
+    q->was_read = -1;
+}
+
+static bool queue_push(m808x_pfq_t *q, uint8_t value)
+{
+    if (q->len >= q->capacity) {
+        return false;
+    }
+    q->data[(q->head + q->len) % PFQ_MAX] = value;
+    q->len++;
+    return true;
+}
+
+static uint8_t queue_pop(m808x_pfq_t *q)
+{
+    assert(q->len > 0u);
+    const uint8_t value = q->data[q->head];
+    q->head = (q->head + 1u) % PFQ_MAX;
+    q->len--;
+    return value;
+}
+
+static void queue_flush(m808x_pfq_t *q)
+{
+    q->head = 0u;
+    q->len = 0u;
+    q->preload_valid = false;
+    q->op = QOP_FLUSH;
+}
+
+static bool queue_has_room_for_fetch(const m808x_cpu_t *cpu)
+{
+    /* Reserve the physical fetch width, not merely the number of bytes that
+     * an odd-address 8086 fetch will eventually enqueue. */
+    return cpu->is_8086 ? cpu->biu.queue.len <= 4u
+                        : cpu->biu.queue.len <= 3u;
+}
+
+static bool queue_at_policy_len(const m808x_cpu_t *cpu)
+{
+    const m808x_pfq_t *q = &cpu->biu.queue;
+    if (!cpu->is_8086) return q->len == 3u;
+    return q->len == 3u || q->len == 4u;
+}
+
+static bool queue_at_policy_threshold_before_read(const m808x_cpu_t *cpu)
+{
+    (void)cpu;
+    return cpu->biu.queue.len == 3u;
+}
+
+static uint16_t architectural_ip(const m808x_cpu_t *cpu)
+{
+    return (uint16_t)(cpu->pc - queue_effective_len(&cpu->biu.queue));
+}
+
+static char hex_digit(unsigned n)
+{
+    return (char)(n < 10u ? ('0' + n) : ('A' + (n - 10u)));
+}
+
+static void format_queue(const m808x_pfq_t *q, char *out, size_t out_size)
+{
+    const size_t chars = q->capacity * 2u;
+    if (out_size < chars + 1u) {
+        if (out_size != 0u) {
+            out[0] = '\0';
+        }
+        return;
+    }
+    memset(out, ' ', chars);
+    out[chars] = '\0';
+    for (unsigned i = 0; i < q->len; i++) {
+        const uint8_t value = q->data[(q->head + i) % PFQ_MAX];
+        out[i * 2u] = hex_digit(value >> 4);
+        out[i * 2u + 1u] = hex_digit(value & 0x0fu);
+    }
+}
+
+static void trace_cycle(m808x_cpu_t *cpu)
+{
+    if (!cpu->trace) {
+        cpu->trace_comment = NULL;
+        return;
+    }
+
+    const m808x_biu_t *b = &cpu->biu;
+    char queue[PFQ_MAX * 2u + 1u];
+    char data[5] = "    ";
+    const bool transfer = (b->t_cycle == T_3 || b->t_cycle == T_W) &&
+                          bus_is_active(b->bus_status_latch);
+    format_queue(&b->queue, queue, sizeof(queue));
+
+    if (transfer) {
+        data[0] = hex_digit((b->data_bus >> 12) & 0x0fu);
+        data[1] = hex_digit((b->data_bus >> 8) & 0x0fu);
+        data[2] = hex_digit((b->data_bus >> 4) & 0x0fu);
+        data[3] = hex_digit(b->data_bus & 0x0fu);
+    }
+
+    const char *rw = "   ";
+    switch (b->bus_status_latch) {
+        case BUS_MEMR:
+        case BUS_IOR:
+        case BUS_CODE:
+        case BUS_INTA:
+            rw = "r->";
+            break;
+        case BUS_MEMW:
+        case BUS_IOW:
+            rw = "<-w";
+            break;
+        default:
+            break;
+    }
+
+    printf("%7" PRIu64 " | %c | %05" PRIX32 " | %s | %-4s | %-2s | %-2s | %-3s | %s | %-12s | %-2s | ",
+           cpu->cycle_num,
+           b->ale ? 'A' : '-',
+           b->address_latch & 0xfffffu,
+           segment_name[b->bus_segment],
+           bus_name[b->bus_status_latch],
+           t_name[b->t_cycle],
+           ta_name[b->ta_cycle],
+           rw,
+           data,
+           queue,
+           qop_name[b->queue.op]);
+
+    if (cpu->mc_line == MC_NONE) {
+        printf("----");
+    } else if (cpu->mc_line == MC_JUMP) {
+        printf("JUMP");
+    } else if (cpu->mc_line == MC_CORR) {
+        printf("CORR");
+    } else if (cpu->mc_line == MC_RNI) {
+        printf("RNI ");
+    } else {
+        printf("%03X ", cpu->mc_line);
+    }
+
+    if (b->queue.was_read >= 0) {
+        printf(" | q->%02X", (unsigned)b->queue.was_read);
+        cpu->biu.queue.was_read = -1;
+    } else {
+        printf(" |      ");
+    }
+    if (cpu->trace_comment != NULL) {
+        printf(" | %s", cpu->trace_comment);
+    }
+    putchar('\n');
+    cpu->trace_comment = NULL;
+}
+
+static void biu_make_fetch_decision(m808x_cpu_t *cpu);
+static void biu_fetch_start(m808x_cpu_t *cpu);
+static void biu_bus_begin_fetch(m808x_cpu_t *cpu);
+
+static void biu_address_start(m808x_cpu_t *cpu, m808x_bus_status_t status)
+{
+    m808x_biu_t *b = &cpu->biu;
+    b->ta_cycle = (b->ta_cycle == TA_ABORT) ? TA_TS : TA_TR;
+    b->pl_status = status;
+}
+
+static void biu_fetch_abort(m808x_cpu_t *cpu)
+{
+    cpu->trace_comment = "ABORT";
+    cpu->biu.ta_cycle = TA_ABORT;
+}
+
+static void biu_fetch_start(m808x_cpu_t *cpu)
+{
+    m808x_biu_t *b = &cpu->biu;
+
+
+    if (b->pending == PENDING_EU_EARLY || b->pl_status == BUS_CODE) {
+        return;
+    }
+    if (b->fetch.kind == FETCH_DELAYED) {
+        return;
+    }
+    b->fetch.kind = FETCH_NORMAL;
+    biu_address_start(cpu, BUS_CODE);
+}
+
+static void biu_make_fetch_decision(m808x_cpu_t *cpu)
+{
+    m808x_biu_t *b = &cpu->biu;
+
+
+    if (!queue_has_room_for_fetch(cpu)) {
+        b->fetch.kind = FETCH_PAUSED_FULL;
+        return;
+    }
+
+    if (b->pending == PENDING_EU_EARLY || !fetch_enabled(cpu)) {
+        return;
+    }
+
+    if (queue_at_policy_len(cpu) && b->bus_status_latch == BUS_CODE) {
+        if (b->ta_cycle == TA_DONE) {
+            b->fetch.kind = FETCH_DELAYED;
+            b->fetch.delay = 3u;
+        }
+    } else if (b->ta_cycle == TA_DONE) {
+        biu_fetch_start(cpu);
+    }
+}
+
+
+static void biu_fetch_on_queue_read(m808x_cpu_t *cpu)
+{
+    m808x_biu_t *b = &cpu->biu;
+
+
+    if (b->bus_status == BUS_PASSIVE && queue_has_room_for_fetch(cpu)) {
+        if (b->fetch.kind == FETCH_SUSPENDED || b->fetch.kind == FETCH_PAUSED_FULL) {
+            if (b->t_cycle == T_I || b->fetch.kind == FETCH_SUSPENDED) {
+                b->ta_cycle = TA_DONE;
+                biu_fetch_start(cpu);
+            }
+        }
+    }
+}
+
+static void biu_do_bus_transfer(m808x_cpu_t *cpu)
+{
+    m808x_biu_t *b = &cpu->biu;
+    const uint32_t addr = b->address_latch & 0xfffffu;
+    in_lock = cpu->in_lock ? 1 : 0;
+
+    if (b->transfer_done)
+        return;
+
+    /* A large amount of 86Box hardware, notably IBM CGA, expresses READY
+     * stretching by subtracting directly from the global cycle counter in
+     * its memory callback.  Capture that delta and restore the scheduler
+     * budget: the same number of clocks are then emitted below as physical
+     * Tw states.  This also catches handlers that call sub_cycles(). */
+    const int host_cycles_before = cpu_state._cycles;
+    cpu_state._cycles -= M808X_HOST_CALLBACK_PHASE_BIAS;
+
+    m808x_in_host_bus_callback = true;
+
+    switch (b->bus_status_latch) {
+        case BUS_CODE:
+            if (b->transfer_size == XFER_WORD) {
+                const uint32_t even = addr & ~1u;
+                b->data_bus = read_mem_w(even);
+            } else {
+                b->data_bus = read_mem_b(addr);
+            }
+            break;
+
+        case BUS_MEMR:
+            if (b->transfer_size == XFER_WORD) {
+                b->data_bus = read_mem_w(addr & ~1u);
+            } else {
+                const uint8_t byte = read_mem_b(addr);
+                b->data_bus = b->bhe ? (uint16_t)((uint16_t)byte << 8) : (uint16_t)byte;
+            }
+            break;
+
+        case BUS_MEMW:
+            if (b->transfer_size == XFER_WORD) {
+                write_mem_w(addr, b->data_bus);
+            } else {
+                write_mem_b(addr, b->bhe ? (uint8_t)(b->data_bus >> 8) : (uint8_t)b->data_bus);
+            }
+            if (addr >= 0xf0000u && addr <= 0xfffffu)
+                last_addr = (uint16_t)addr;
+            break;
+
+        case BUS_IOR:
+            if (b->transfer_size == XFER_WORD)
+                b->data_bus = inw((uint16_t)addr);
+            else
+                b->data_bus = inb((uint16_t)addr);
+            break;
+
+        case BUS_IOW:
+            if (b->transfer_size == XFER_WORD)
+                outw((uint16_t)addr, b->data_bus);
+            else
+                outb((uint16_t)addr, (uint8_t)b->data_bus);
+            break;
+
+        case BUS_INTA:
+            /* 808x performs two physical acknowledge cycles.  The second
+             * return value is the vector used by the interrupt microflow. */
+            cpu->interrupt_vector = (uint8_t)pic_irq_ack();
+            b->data_bus = cpu->interrupt_vector;
+            break;
+
+        case BUS_PASSIVE:
+        case BUS_HALT:
+            break;
+    }
+
+    m808x_in_host_bus_callback = false;
+    const int charged_from_phase = host_cycles_before - M808X_HOST_CALLBACK_PHASE_BIAS;
+    const int charged_clocks = charged_from_phase - cpu_state._cycles;
+    cpu_state._cycles = host_cycles_before;
+
+    if (charged_clocks > 0) {
+        const unsigned charge = (unsigned)charged_clocks;
+#ifdef M808X_86BOX_TESTING
+        m808x_test_captured_wait_clocks += charge;
+#endif
+        if (UINT_MAX - b->wait_remaining < charge) {
+            cpu->fatal = true;
+            return;
+        }
+        b->wait_remaining += charge;
+    }
+    b->transfer_done = true;
+}
+
+static void biu_finish_code_fetch(m808x_cpu_t *cpu)
+{
+    m808x_biu_t *b = &cpu->biu;
+    m808x_pfq_t *q = &b->queue;
+
+    if (b->transfer_size == XFER_BYTE) {
+        if (queue_push(q, (uint8_t)b->data_bus)) {
+            cpu->pc = (uint16_t)(cpu->pc + 1u);
+        }
+        return;
+    }
+
+    if (cpu->pc & 1u) {
+        if (queue_push(q, (uint8_t)(b->data_bus >> 8))) {
+            cpu->pc = (uint16_t)(cpu->pc + 1u);
+        }
+    } else {
+        unsigned pushed = 0u;
+        if (queue_push(q, (uint8_t)b->data_bus)) {
+            pushed++;
+        }
+        if (queue_push(q, (uint8_t)(b->data_bus >> 8))) {
+            pushed++;
+        }
+        cpu->pc = (uint16_t)(cpu->pc + pushed);
+    }
+}
+
+static void biu_bus_begin_fetch(m808x_cpu_t *cpu)
+{
+    m808x_biu_t *b = &cpu->biu;
+
+    /* The TA_T0 caller also keeps the pipeline parked while this is true. */
+
+    if (!queue_has_room_for_fetch(cpu)) {
+        b->fetch.kind = FETCH_PAUSED_FULL;
+        return;
+    }
+
+    b->fetch.kind = FETCH_NORMAL;
+    b->pl_status = BUS_PASSIVE;
+    b->bus_status = BUS_CODE;
+    b->bus_status_latch = BUS_CODE;
+    b->bus_segment = SEG_CS;
+    b->t_cycle = T_INIT;
+    b->address_bus = linear_address(cpu->segs[SEG_CS], cpu->pc);
+    b->address_latch = b->address_bus;
+    b->ale = true;
+    b->data_bus = 0u;
+    b->transfer_size = cpu->is_8086 ? XFER_WORD : XFER_BYTE;
+    b->operand_size = cpu->is_8086 ? OPERAND_16 : OPERAND_8;
+    b->transfer_n = 1u;
+    b->final_transfer = true;
+    b->wait_remaining = 0u;
+    b->transfer_done = false;
+    b->bhe = cpu->is_8086 && ((cpu->pc & 1u) != 0u);
+}
+
+static void biu_bus_end(m808x_cpu_t *cpu)
+{
+    cpu->biu.ale = false;
+}
+
+/* IBM PC/XT DRAM refresh bus arbitration.  This is the measured 8088/8237
+ * handshake used by MartyPC: DREQ -> HRQ -> HOLDA -> five controller
+ * operating clocks, with READY stretched for six effective clocks.  The EU
+ * may continue while the BIU is not requesting the bus; an active bus cycle
+ * is stretched through Tw exactly as on hardware. */
+typedef enum m808x_dma_state_t {
+    M808X_DMA_IDLE = 0,
+    M808X_DMA_DREQ,
+    M808X_DMA_HRQ,
+    M808X_DMA_HOLDA,
+    M808X_DMA_OPERATING
+} m808x_dma_state_t;
+
+static m808x_dma_state_t m808x_dma_state = M808X_DMA_IDLE;
+static bool m808x_dma_req = false;
+static bool m808x_dma_holda = false;
+static bool m808x_dma_ack = false;
+static bool m808x_dma_aen = false;
+static unsigned m808x_dma_operating_cycle = 0u;
+static unsigned m808x_dma_wait_states = 0u;
+static unsigned m808x_dma_wait_target = 6u;
+typedef void (*m808x_dma_ack_callback_t)(void *opaque);
+static m808x_dma_ack_callback_t m808x_dma_ack_callback = NULL;
+static void *m808x_dma_ack_opaque = NULL;
+
+static void m808x_dma_tick(m808x_cpu_t *cpu)
+{
+    m808x_biu_t *b = &cpu->biu;
+
+    switch (m808x_dma_state) {
+        case M808X_DMA_IDLE:
+            if (m808x_dma_req)
+                m808x_dma_state = M808X_DMA_DREQ;
+            break;
+
+        case M808X_DMA_DREQ:
+            /* The 8237 raises HRQ one controller clock after observing DREQ. */
+            m808x_dma_state = M808X_DMA_HRQ;
+            break;
+
+        case M808X_DMA_HRQ:
+            /* The PC motherboard generates HOLDA when the bus status is
+             * passive (S0=S1=1), or late enough in the current transfer that
+             * it can complete normally. LOCK suppresses the grant. */
+            if (!cpu->in_lock &&
+                (b->bus_status == BUS_PASSIVE ||
+                 b->t_cycle == T_3 || b->t_cycle == T_W || b->t_cycle == T_4)) {
+                m808x_dma_holda = true;
+                m808x_dma_state = M808X_DMA_HOLDA;
+            }
+            break;
+
+        case M808X_DMA_HOLDA:
+            /* One clock of hold acknowledge precedes 8237 S1/AEN. */
+            if (b->wait_remaining < 2u) {
+                m808x_dma_aen = true;
+                m808x_dma_operating_cycle = 0u;
+                m808x_dma_state = M808X_DMA_OPERATING;
+            }
+            break;
+
+        case M808X_DMA_OPERATING:
+            ++m808x_dma_operating_cycle;
+            switch (m808x_dma_operating_cycle) {
+                case 1u:
+                    /* DMAWAIT after S1.  Seven is decremented at the end of
+                     * this clock, leaving six effective READY-low clocks. */
+                    m808x_dma_wait_states = m808x_dma_wait_target + 1u;
+                    break;
+                case 2u:
+                    /* DACK is asserted after S2.  Execute the controller's
+                     * transfer callback at the same pin phase, not at the PIT
+                     * edge that originally raised DREQ. */
+                    m808x_dma_req = false;
+                    m808x_dma_ack = true;
+                    if (m808x_dma_ack_callback != NULL) {
+                        m808x_dma_ack_callback_t callback = m808x_dma_ack_callback;
+                        void *opaque = m808x_dma_ack_opaque;
+                        m808x_dma_ack_callback = NULL;
+                        m808x_dma_ack_opaque = NULL;
+                        callback(opaque);
+                    }
+                    break;
+                case 4u:
+                    m808x_dma_holda = false;
+                    break;
+                case 5u:
+                    m808x_dma_aen = false;
+                    m808x_dma_ack = false;
+                    m808x_dma_operating_cycle = 0u;
+                    m808x_dma_state = M808X_DMA_IDLE;
+                    break;
+                default:
+                    break;
+            }
+            break;
+    }
+}
+
+static void biu_cycle_i(m808x_cpu_t *cpu, uint16_t mc_line, const char *comment)
+{
+    m808x_biu_t *b = &cpu->biu;
+    /* READY for this T3/Tw is sampled before m808x_dma_tick() changes the
+     * DMAWAIT level for the following physical clock. */
+    const unsigned dma_wait_this_cycle = m808x_dma_wait_states;
+
+    if (cpu->cycle_num >= cpu->cycle_limit) {
+        cpu->fatal = true;
+        return;
+    }
+
+    cpu->mc_line = mc_line;
+    cpu->trace_comment = comment;
+
+    if (b->t_cycle == T_INIT) {
+        b->t_cycle = T_1;
+    }
+
+    switch (b->bus_status_latch) {
+        case BUS_PASSIVE:
+            if (b->fetch.kind == FETCH_DELAYED && b->fetch.delay == 0u) {
+                b->fetch.kind = FETCH_NORMAL;
+                biu_make_fetch_decision(cpu);
+            } else if (b->fetch.kind == FETCH_PAUSED_FULL && queue_has_room_for_fetch(cpu)) {
+                biu_make_fetch_decision(cpu);
+            } else if (b->t_cycle == T_I) {
+                biu_make_fetch_decision(cpu);
+            }
+            break;
+
+        case BUS_CODE:
+        case BUS_IOR:
+        case BUS_IOW:
+        case BUS_MEMR:
+        case BUS_MEMW:
+        case BUS_INTA:
+            switch (b->t_cycle) {
+                case T_1:
+                    break;
+                case T_2:
+                    b->ale = false;
+                    b->wait_remaining = cpu->configured_wait_states;
+
+                    /* NOCONA_M808X_IO_WAIT_CONSOLIDATED_V1
+                     * IBM 5150/5160 motherboard READY logic imposes at least
+                     * one Tw on every processor-generated I/O bus cycle. Use
+                     * max(configured, 1), because clone wait configuration may
+                     * already include it. */
+                    if ((b->bus_status_latch == BUS_IOR ||
+                         b->bus_status_latch == BUS_IOW) &&
+                        b->wait_remaining == 0u)
+                        b->wait_remaining = 1u;
+
+                    if (b->final_transfer) {
+                        biu_make_fetch_decision(cpu);
+                    }
+                    break;
+                case T_3:
+                    b->bus_status = BUS_PASSIVE;
+                    if (b->wait_remaining == 0u &&
+                        dma_wait_this_cycle == 0u &&
+                        !b->transfer_done) {
+                        biu_do_bus_transfer(cpu);
+                    }
+                    break;
+                case T_W:
+                    if (b->wait_remaining <= 1u &&
+                        dma_wait_this_cycle == 0u &&
+                        !b->transfer_done) {
+                        biu_do_bus_transfer(cpu);
+                    }
+                    break;
+                case T_4:
+                    if (b->bus_status_latch == BUS_CODE) {
+                        biu_finish_code_fetch(cpu);
+                    }
+                    if (b->final_transfer) {
+                        biu_make_fetch_decision(cpu);
+                    }
+                    break;
+                case T_INIT:
+                case T_I:
+                    break;
+            }
+            break;
+
+        case BUS_HALT:
+            break;
+    }
+
+#ifdef M808X_86BOX_TESTING
+    if (b->t_cycle == T_W)
+        m808x_test_tw_clocks++;
+    if (m808x_test_cycle_hook != NULL)
+        m808x_test_cycle_hook(cpu);
+#endif
+    trace_cycle(cpu);
+
+    /* Clock the XT 8237 arbitration logic on every physical CPU clock. */
+    m808x_dma_tick(cpu);
+
+    if (b->fetch.kind == FETCH_DELAYED && b->t_cycle != T_W && b->fetch.delay > 0u) {
+        b->fetch.delay--;
+    }
+
+    switch (b->ta_cycle) {
+        case TA_TR:
+            b->ta_cycle = TA_TS;
+            break;
+        case TA_TS:
+            b->ta_cycle = TA_T0;
+            break;
+        case TA_T0:
+            if (b->pl_status == BUS_CODE) {
+                if (b->pending == PENDING_NONE) {
+                    if ((b->t_cycle == T_I || b->t_cycle == T_4) &&
+                        fetch_enabled(cpu)) {
+                        biu_bus_begin_fetch(cpu);
+                        b->ta_cycle = TA_DONE;
+                    }
+                } else if (b->pending == PENDING_EU_LATE) {
+                    if (b->t_cycle == T_I || b->t_cycle == T_4) {
+                        biu_fetch_abort(cpu);
+                    }
+                }
+            } else if (b->t_cycle == T_I || b->t_cycle == T_4) {
+                b->ta_cycle = TA_DONE;
+            }
+            break;
+        case TA_DONE:
+        case TA_ABORT:
+            break;
+    }
+
+    switch (b->t_cycle) {
+        case T_INIT:
+            b->t_cycle = T_1;
+            break;
+        case T_I:
+            if (b->bus_status_latch == BUS_PASSIVE) {
+                b->t_cycle = T_I;
+            } else if (b->bus_status_latch == BUS_HALT) {
+                b->bus_status = BUS_PASSIVE;
+                b->bus_status_latch = BUS_PASSIVE;
+                b->ale = false;
+                b->t_cycle = T_I;
+            } else {
+                b->t_cycle = T_1;
+            }
+            break;
+        case T_1:
+            if (b->bus_status_latch == BUS_HALT) {
+                b->bus_status = BUS_PASSIVE;
+                b->bus_status_latch = BUS_PASSIVE;
+                b->ale = false;
+                b->t_cycle = T_I;
+            } else {
+                b->t_cycle = T_2;
+            }
+            break;
+        case T_2:
+            b->t_cycle = T_3;
+            break;
+        case T_3:
+            if (b->wait_remaining > 0u || dma_wait_this_cycle > 0u) {
+                b->t_cycle = T_W;
+            } else {
+                biu_bus_end(cpu);
+                b->t_cycle = T_4;
+            }
+            break;
+        case T_W:
+            if (b->wait_remaining <= 1u && dma_wait_this_cycle == 0u) {
+                b->wait_remaining = 0u;
+                biu_bus_end(cpu);
+                b->t_cycle = T_4;
+            } else {
+                if (b->wait_remaining > 0u)
+                    --b->wait_remaining;
+                b->t_cycle = T_W;
+            }
+            break;
+        case T_4:
+            b->bus_status = BUS_PASSIVE;
+            b->bus_status_latch = BUS_PASSIVE;
+            b->t_cycle = T_I;
+            break;
+    }
+
+    b->queue.last_op = b->queue.op;
+    b->queue.op = QOP_IDLE;
+    if (m808x_dma_wait_states > 0u)
+        --m808x_dma_wait_states;
+    cpu->cycle_num++;
+    m808x_host_cycle();
+}
+
+static void biu_cycle(m808x_cpu_t *cpu)
+{
+    biu_cycle_i(cpu, MC_NONE, NULL);
+}
+
+static void cycles_mc(m808x_cpu_t *cpu, const uint16_t *lines, size_t count)
+{
+    for (size_t i = 0; i < count && !cpu->fatal; i++) {
+        biu_cycle_i(cpu, lines[i], NULL);
+    }
+}
+
+#define CYCLES_MC(cpu_ptr, ...) \
+    do { \
+        const uint16_t _mc_lines[] = {__VA_ARGS__}; \
+        cycles_mc((cpu_ptr), _mc_lines, ARRAY_LEN(_mc_lines)); \
+    } while (0)
+
+static void biu_bus_wait_finish(m808x_cpu_t *cpu)
+{
+    m808x_biu_t *b = &cpu->biu;
+    if (!bus_is_active(b->bus_status_latch)) {
+        return;
+    }
+    while (b->t_cycle != T_4 && !cpu->fatal) {
+        biu_cycle(cpu);
+    }
+}
+
+static bool biu_is_terminal_transfer_state(const m808x_biu_t *b)
+{
+    return (b->t_cycle == T_3 &&
+            b->wait_remaining == 0u &&
+            m808x_dma_wait_states == 0u) ||
+           (b->t_cycle == T_W &&
+            b->wait_remaining <= 1u &&
+            m808x_dma_wait_states == 0u);
+}
+
+static void biu_bus_wait_until_tx(m808x_cpu_t *cpu)
+{
+    m808x_biu_t *b = &cpu->biu;
+    if (!bus_is_active(b->bus_status_latch)) {
+        return;
+    }
+    while (!biu_is_terminal_transfer_state(b) && !cpu->fatal) {
+        biu_cycle(cpu);
+    }
+}
+
+static void biu_bus_wait_address(m808x_cpu_t *cpu)
+{
+    while (cpu->biu.ta_cycle != TA_DONE && cpu->biu.ta_cycle != TA_ABORT && !cpu->fatal) {
+        biu_cycle(cpu);
+    }
+}
+
+static bool biu_bus_wait_delay(m808x_cpu_t *cpu)
+{
+    m808x_biu_t *b = &cpu->biu;
+    bool delayed = false;
+    if (b->fetch.kind == FETCH_DELAYED) {
+        delayed = true;
+        while (b->fetch.kind == FETCH_DELAYED && b->fetch.delay > 0u && !cpu->fatal) {
+            biu_cycle(cpu);
+        }
+        b->ta_cycle = TA_ABORT;
+    }
+    return delayed;
+}
+
+static void biu_bus_begin(m808x_cpu_t *cpu,
+                          m808x_bus_status_t status,
+                          m808x_segment_t segment,
+                          uint32_t address,
+                          uint16_t data,
+                          m808x_transfer_size_t size,
+                          m808x_operand_size_t operand_size,
+                          bool first)
+{
+    m808x_biu_t *b = &cpu->biu;
+    assert(status != BUS_CODE);
+
+    bool fetch_abort = false;
+
+    switch (b->t_cycle) {
+        case T_I:
+            biu_address_start(cpu, status);
+            break;
+        case T_INIT:
+        case T_1:
+        case T_2:
+            b->pending = PENDING_EU_EARLY;
+            if (b->ta_cycle == TA_DONE) {
+                biu_address_start(cpu, status);
+            }
+            break;
+        case T_3:
+        case T_W:
+        case T_4:
+            if (b->pl_status == BUS_CODE) {
+                b->pending = PENDING_EU_LATE;
+                fetch_abort = true;
+            } else if (!b->final_transfer) {
+                b->pending = PENDING_EU_EARLY;
+            }
+            break;
+    }
+
+    biu_bus_wait_finish(cpu);
+    const bool was_delayed = biu_bus_wait_delay(cpu);
+    biu_bus_wait_address(cpu);
+
+    if (was_delayed || fetch_abort) {
+        biu_address_start(cpu, status);
+        biu_bus_wait_address(cpu);
+    }
+
+    if (b->t_cycle == T_4 && b->bus_status_latch != BUS_CODE) {
+        biu_cycle(cpu);
+    }
+
+    if (size == XFER_WORD) {
+        b->transfer_n = 1u;
+        b->final_transfer = true;
+    } else if (first) {
+        b->transfer_n = 1u;
+        b->final_transfer = operand_size == OPERAND_8;
+    } else {
+        b->transfer_n = 2u;
+        b->final_transfer = true;
+    }
+
+    b->bhe = cpu->is_8086 && (size == XFER_WORD || (address & 1u) != 0u);
+    b->pending = PENDING_NONE;
+    b->pl_status = BUS_PASSIVE;
+    b->bus_status = status;
+    b->bus_status_latch = status;
+    b->bus_segment = segment;
+    b->t_cycle = T_INIT;
+    b->address_bus = address & 0xfffffu;
+    b->address_latch = b->address_bus;
+    b->ale = true;
+    b->data_bus = data;
+    b->transfer_size = size;
+    b->operand_size = operand_size;
+    b->wait_remaining = 0u;
+    b->transfer_done = false;
+
+    if (b->bhe && size == XFER_BYTE) {
+        b->data_bus <<= 8;
+    }
+}
+
+static uint8_t biu_read_u8(m808x_cpu_t *cpu, m808x_segment_t segment, uint16_t offset)
+{
+    const uint32_t address = segment == SEG_NONE ? offset : linear_address(cpu->segs[segment], offset);
+    biu_bus_begin(cpu, BUS_MEMR, segment, address, 0u, XFER_BYTE, OPERAND_8, true);
+    biu_bus_wait_finish(cpu);
+    return cpu->biu.bhe ? (uint8_t)(cpu->biu.data_bus >> 8) : (uint8_t)cpu->biu.data_bus;
+}
+
+static void biu_write_u8(m808x_cpu_t *cpu, m808x_segment_t segment, uint16_t offset, uint8_t value)
+{
+    const uint32_t address = segment == SEG_NONE ? offset : linear_address(cpu->segs[segment], offset);
+    biu_bus_begin(cpu, BUS_MEMW, segment, address, value, XFER_BYTE, OPERAND_8, true);
+    biu_bus_wait_until_tx(cpu);
+}
+
+static uint16_t biu_read_u16(m808x_cpu_t *cpu, m808x_segment_t segment, uint16_t offset)
+{
+    if (cpu->is_8086 && (offset & 1u) == 0u) {
+        const uint32_t address = segment == SEG_NONE ? offset : linear_address(cpu->segs[segment], offset);
+        biu_bus_begin(cpu, BUS_MEMR, segment, address, 0u, XFER_WORD, OPERAND_16, true);
+        biu_bus_wait_finish(cpu);
+        return cpu->biu.data_bus;
+    }
+
+    /* A word read on the 8088 is one indivisible operand transfer made of
+     * two byte bus cycles.  The first byte is not a final transfer and may
+     * not admit an intervening prefetch. */
+    const uint32_t address0 = segment == SEG_NONE ? offset : linear_address(cpu->segs[segment], offset);
+    biu_bus_begin(cpu, BUS_MEMR, segment, address0, 0u, XFER_BYTE, OPERAND_16, true);
+    biu_bus_wait_finish(cpu);
+    const uint8_t lo = cpu->biu.bhe ? (uint8_t)(cpu->biu.data_bus >> 8) : (uint8_t)cpu->biu.data_bus;
+
+    const uint16_t offset1 = (uint16_t)(offset + 1u);
+    const uint32_t address1 = segment == SEG_NONE ? offset1 : linear_address(cpu->segs[segment], offset1);
+    biu_bus_begin(cpu, BUS_MEMR, segment, address1, 0u, XFER_BYTE, OPERAND_16, false);
+    biu_bus_wait_finish(cpu);
+    const uint8_t hi = cpu->biu.bhe ? (uint8_t)(cpu->biu.data_bus >> 8) : (uint8_t)cpu->biu.data_bus;
+    return (uint16_t)(lo | ((uint16_t)hi << 8));
+}
+
+static void biu_write_u16(m808x_cpu_t *cpu, m808x_segment_t segment, uint16_t offset, uint16_t value)
+{
+    if (cpu->is_8086 && (offset & 1u) == 0u) {
+        const uint32_t address = segment == SEG_NONE ? offset : linear_address(cpu->segs[segment], offset);
+        biu_bus_begin(cpu, BUS_MEMW, segment, address, value, XFER_WORD, OPERAND_16, true);
+        biu_bus_wait_until_tx(cpu);
+        return;
+    }
+
+    const uint32_t address0 = segment == SEG_NONE ? offset : linear_address(cpu->segs[segment], offset);
+    biu_bus_begin(cpu, BUS_MEMW, segment, address0, value & 0xffu, XFER_BYTE, OPERAND_16, true);
+    biu_bus_wait_finish(cpu);
+
+    const uint16_t offset1 = (uint16_t)(offset + 1u);
+    const uint32_t address1 = segment == SEG_NONE ? offset1 : linear_address(cpu->segs[segment], offset1);
+    biu_bus_begin(cpu, BUS_MEMW, segment, address1, value >> 8, XFER_BYTE, OPERAND_16, false);
+    biu_bus_wait_until_tx(cpu);
+}
+
+static uint8_t biu_io_read_u8(m808x_cpu_t *cpu, uint16_t port)
+{
+    biu_bus_begin(cpu, BUS_IOR, SEG_NONE, port, 0u, XFER_BYTE, OPERAND_8, true);
+    biu_bus_wait_finish(cpu);
+    return (uint8_t)cpu->biu.data_bus;
+}
+
+static uint16_t biu_io_read_u16(m808x_cpu_t *cpu, uint16_t port)
+{
+    if (cpu->is_8086 && (port & 1u) == 0u) {
+        biu_bus_begin(cpu, BUS_IOR, SEG_NONE, port, 0u, XFER_WORD, OPERAND_16, true);
+        biu_bus_wait_finish(cpu);
+        return cpu->biu.data_bus;
+    }
+
+    biu_bus_begin(cpu, BUS_IOR, SEG_NONE, port, 0u, XFER_BYTE, OPERAND_16, true);
+    biu_bus_wait_finish(cpu);
+    const uint8_t lo = (uint8_t)cpu->biu.data_bus;
+    biu_bus_begin(cpu, BUS_IOR, SEG_NONE, (uint16_t)(port + 1u), 0u, XFER_BYTE, OPERAND_16, false);
+    biu_bus_wait_finish(cpu);
+    const uint8_t hi = (uint8_t)cpu->biu.data_bus;
+    return (uint16_t)(lo | ((uint16_t)hi << 8));
+}
+
+static void biu_io_write_u8(m808x_cpu_t *cpu, uint16_t port, uint8_t value)
+{
+    biu_bus_begin(cpu, BUS_IOW, SEG_NONE, port, value, XFER_BYTE, OPERAND_8, true);
+    biu_bus_wait_until_tx(cpu);
+}
+
+static void biu_io_write_u16(m808x_cpu_t *cpu, uint16_t port, uint16_t value)
+{
+    if (cpu->is_8086 && (port & 1u) == 0u) {
+        biu_bus_begin(cpu, BUS_IOW, SEG_NONE, port, value, XFER_WORD, OPERAND_16, true);
+        biu_bus_wait_until_tx(cpu);
+        return;
+    }
+
+    biu_bus_begin(cpu, BUS_IOW, SEG_NONE, port, value & 0xffu, XFER_BYTE, OPERAND_16, true);
+    biu_bus_wait_finish(cpu);
+    biu_bus_begin(cpu, BUS_IOW, SEG_NONE, (uint16_t)(port + 1u), value >> 8, XFER_BYTE, OPERAND_16, false);
+    biu_bus_wait_until_tx(cpu);
+}
+
+static void biu_fetch_suspend(m808x_cpu_t *cpu)
+{
+    m808x_biu_t *b = &cpu->biu;
+    b->fetch.kind = FETCH_SUSPENDED;
+    if (b->bus_status_latch == BUS_CODE) {
+        biu_bus_wait_finish(cpu);
+    }
+    b->ta_cycle = TA_DONE;
+    b->pl_status = BUS_PASSIVE;
+}
+
+static void biu_queue_flush(m808x_cpu_t *cpu)
+{
+    queue_flush(&cpu->biu.queue);
+    cpu->biu.fetch.kind = FETCH_NORMAL;
+    cpu->biu.fetch.delay = 0u;
+    cpu->biu.ta_cycle = TA_DONE;
+    cpu->biu.pl_status = BUS_PASSIVE;
+    biu_fetch_start(cpu);
+}
+
+static void biu_fetch_halt(m808x_cpu_t *cpu)
+{
+    cpu->biu.fetch.kind = FETCH_HALTED;
+}
+
+static void biu_halt(m808x_cpu_t *cpu)
+{
+    m808x_biu_t *b = &cpu->biu;
+    b->fetch.kind = FETCH_HALTED;
+    biu_bus_wait_finish(cpu);
+    if (b->t_cycle == T_4) {
+        biu_cycle(cpu);
+    }
+    b->t_cycle = T_I;
+    biu_cycle(cpu);
+
+    b->bus_status = BUS_HALT;
+    b->bus_status_latch = BUS_HALT;
+    b->bus_segment = SEG_CS;
+    b->t_cycle = T_1;
+    b->ale = true;
+    b->data_bus = 0u;
+    b->transfer_size = cpu->is_8086 ? XFER_WORD : XFER_BYTE;
+    b->operand_size = OPERAND_8;
+    b->transfer_n = 1u;
+    b->final_transfer = true;
+    biu_cycle_i(cpu, MC_NONE, "HALT");
+}
+
+static void biu_bus_wait_halt(m808x_cpu_t *cpu)
+{
+    m808x_biu_t *b = &cpu->biu;
+    if (bus_is_active(b->bus_status_latch) && (b->t_cycle == T_INIT || b->t_cycle == T_1)) {
+        biu_cycle(cpu);
+    }
+}
+
+static void biu_cancel_fetch_delay_before_queue_read(m808x_cpu_t *cpu)
+{
+    m808x_biu_t *b = &cpu->biu;
+    if (b->fetch.kind == FETCH_DELAYED && queue_at_policy_threshold_before_read(cpu))
+        b->fetch.delay = 0u;
+}
+
+static uint8_t queue_read(m808x_cpu_t *cpu, bool first)
+{
+    m808x_pfq_t *q = &cpu->biu.queue;
+    uint8_t value;
+    const bool was_empty = !q->preload_valid && q->len == 0u;
+
+    /* Delay cancellation is evaluated from the pre-read queue length. */
+    biu_cancel_fetch_delay_before_queue_read(cpu);
+
+    if (q->preload_valid) {
+        value = q->preload_byte;
+        q->preload_valid = false;
+        q->last_op = QOP_FIRST;
+        q->was_read = value;
+        cpu->nx = false;
+        biu_fetch_on_queue_read(cpu);
+        return value;
+    }
+
+    while (q->len == 0u && !cpu->fatal) {
+        biu_cycle(cpu);
+    }
+    if (cpu->fatal) {
+        return 0u;
+    }
+
+    value = queue_pop(q);
+    q->op = first ? QOP_FIRST : QOP_SUBSEQUENT;
+    q->was_read = value;
+    /* If this read had to wait for an empty queue, the hardware does not
+     * immediately issue FOQR again after consuming the just-fetched byte. */
+    if (!was_empty) biu_fetch_on_queue_read(cpu);
+    biu_cycle(cpu);
+    return value;
+}
+
+static void biu_fetch_next(m808x_cpu_t *cpu)
+{
+    m808x_pfq_t *q = &cpu->biu.queue;
+    unsigned timeout = 0u;
+
+    while (q->len == 0u && !cpu->fatal) {
+        if (cpu->nx) {
+            cpu->nx = false;
+            cpu->rni = false;
+        }
+        biu_cycle_i(cpu, MC_RNI, "FETCH_NEXT");
+        if (++timeout > 64u) {
+            fprintf(stderr, "prefetch timeout at %04X:%04X\n", cpu->segs[SEG_CS], architectural_ip(cpu));
+            cpu->fatal = true;
+            return;
+        }
+    }
+
+    q->preload_byte = queue_pop(q);
+    q->preload_valid = true;
+    q->op = QOP_FIRST;
+    biu_fetch_on_queue_read(cpu);
+    biu_cycle_i(cpu, MC_RNI, "RNI preload");
+}
+
+static void corr(m808x_cpu_t *cpu)
+{
+    cpu->pc = architectural_ip(cpu);
+    biu_cycle_i(cpu, MC_CORR, "PC -= Q");
+}
+
+static void reljmp2(m808x_cpu_t *cpu, int16_t rel, bool jump_into)
+{
+    if (jump_into) {
+        biu_cycle_i(cpu, MC_JUMP, "RELJMP entry");
+    }
+    biu_fetch_suspend(cpu);
+    CYCLES_MC(cpu, 0x0d2u, 0x0d3u);
+    corr(cpu);
+    cpu->pc = (uint16_t)(cpu->pc + rel);
+    biu_cycle_i(cpu, 0x0d4u, NULL);
+    biu_queue_flush(cpu);
+    biu_cycle_i(cpu, 0x0d5u, NULL);
+}
+
+static void push_u16(m808x_cpu_t *cpu, uint16_t value)
+{
+    SP = (uint16_t)(SP - 2u);
+    biu_write_u16(cpu, SEG_SS, SP, value);
+}
+
+static void interrupt_ack(m808x_cpu_t *cpu)
+{
+    biu_bus_begin(cpu, BUS_INTA, SEG_NONE, 0u, 0u, XFER_BYTE, OPERAND_16, true);
+    biu_bus_wait_finish(cpu);
+    biu_bus_begin(cpu, BUS_INTA, SEG_NONE, 0u, cpu->interrupt_vector, XFER_BYTE, OPERAND_16, false);
+    biu_bus_wait_finish(cpu);
+}
+
+static void interrupt_routine(m808x_cpu_t *cpu, uint8_t vector, bool skip_first);
+
+static void hardware_interrupt(m808x_cpu_t *cpu, bool acknowledge)
+{
+    uint8_t vector = cpu->interrupt_vector;
+    if (cpu->halted) {
+        cpu->halted = false;
+        cpu->biu.fetch.kind = FETCH_SUSPENDED;
+    }
+
+    if (acknowledge) {
+        interrupt_ack(cpu);
+        vector = cpu->interrupt_vector;
+        biu_fetch_suspend(cpu);
+        CYCLES_MC(cpu, 0x19bu, 0x19cu);
+        interrupt_routine(cpu, vector, false);
+        cpu->intr_pin = false;
+    } else {
+        CYCLES_MC(cpu, 0x199u, MC_JUMP);
+        interrupt_routine(cpu, vector, true);
+        cpu->nmi_pin = false;
+    }
+}
+
+/* Effective-address timings split around displacement fetch, preserving the
+ * known 8086 EA microflow used by the original probe. */
+static const uint8_t ea_pre[0xc0] = {
+    [0x00] = 4, [0x01] = 5, [0x02] = 5, [0x03] = 4,
+    [0x04] = 2, [0x05] = 2, [0x06] = 0, [0x07] = 2,
+    [0x40] = 4, [0x41] = 5, [0x42] = 5, [0x43] = 4,
+    [0x44] = 2, [0x45] = 2, [0x46] = 2, [0x47] = 2,
+    [0x80] = 4, [0x81] = 5, [0x82] = 5, [0x83] = 4,
+    [0x84] = 2, [0x85] = 2, [0x86] = 2, [0x87] = 2
+};
+
+static const uint8_t ea_post[0xc0] = {
+    [0x06] = 1,
+    [0x40] = 3, [0x41] = 3, [0x42] = 3, [0x43] = 3,
+    [0x44] = 3, [0x45] = 3, [0x46] = 3, [0x47] = 3,
+    [0x80] = 2, [0x81] = 2, [0x82] = 2, [0x83] = 2,
+    [0x84] = 2, [0x85] = 2, [0x86] = 2, [0x87] = 2
+};
+
+static bool opcode_has_modrm(uint8_t opcode)
+{
+    if (opcode <= 0x3bu && (opcode & 0x04u) == 0u) {
+        return true;
+    }
+    if (opcode >= 0x80u && opcode <= 0x8fu) {
+        return true;
+    }
+    if (opcode >= 0xc4u && opcode <= 0xc7u) {
+        return true;
+    }
+    if (opcode >= 0xd0u && opcode <= 0xd3u) {
+        return true;
+    }
+    if (opcode >= 0xd8u && opcode <= 0xdfu) {
+        return true;
+    }
+    return opcode == 0xf6u || opcode == 0xf7u || opcode == 0xfeu || opcode == 0xffu;
+}
+
+static void decode_modrm(m808x_cpu_t *cpu)
+{
+    m808x_instruction_t *ins = &cpu->ins;
+    ins->modrm = queue_read(cpu, false);
+    ins->mod = ins->modrm >> 6;
+    ins->reg = (ins->modrm >> 3) & 7u;
+    ins->rm = ins->modrm & 7u;
+    ins->has_modrm = true;
+
+    if (ins->mod == 3u) {
+        return;
+    }
+
+    biu_cycle_i(cpu, MC_NONE, "MODRM decode");
+    const uint8_t timing_index = (uint8_t)((ins->modrm & 0xc0u) | ins->rm);
+    for (unsigned i = 0; i < ea_pre[timing_index]; i++) {
+        biu_cycle_i(cpu, MC_NONE, "EA pre");
+    }
+
+    int16_t disp = 0;
+    if (ins->mod == 0u && ins->rm == 6u) {
+        const uint8_t lo = queue_read(cpu, false);
+        const uint8_t hi = queue_read(cpu, false);
+        disp = (int16_t)(uint16_t)(lo | ((uint16_t)hi << 8));
+    } else if (ins->mod == 1u) {
+        disp = (int8_t)queue_read(cpu, false);
+    } else if (ins->mod == 2u) {
+        const uint8_t lo = queue_read(cpu, false);
+        const uint8_t hi = queue_read(cpu, false);
+        disp = (int16_t)(uint16_t)(lo | ((uint16_t)hi << 8));
+    }
+
+    uint16_t base = 0u;
+    bool use_ss = false;
+    switch (ins->rm) {
+        case 0: base = (uint16_t)(BX + SI); break;
+        case 1: base = (uint16_t)(BX + DI); break;
+        case 2: base = (uint16_t)(BP + SI); use_ss = true; break;
+        case 3: base = (uint16_t)(BP + DI); use_ss = true; break;
+        case 4: base = SI; break;
+        case 5: base = DI; break;
+        case 6:
+            if (ins->mod == 0u) {
+                base = 0u;
+            } else {
+                base = BP;
+                use_ss = true;
+            }
+            break;
+        case 7: base = BX; break;
+        default: break;
+    }
+
+    ins->ea = (uint16_t)(base + disp);
+    ins->ea_segment = ins->has_segment_override ? ins->segment_override : (use_ss ? SEG_SS : SEG_DS);
+    cpu->ea_addr = ins->ea;
+    cpu->ea_seg = ins->ea_segment;
+
+    for (unsigned i = 0; i < ea_post[timing_index]; i++) {
+        biu_cycle_i(cpu, MC_NONE, "EA post");
+    }
+}
+
+static bool decode_prefix(m808x_cpu_t *cpu, uint8_t opcode)
+{
+    m808x_instruction_t *ins = &cpu->ins;
+    switch (opcode) {
+        case 0x26u:
+        case 0x2eu:
+        case 0x36u:
+        case 0x3eu:
+            ins->segment_override = (m808x_segment_t)((opcode >> 3) & 3u);
+            ins->has_segment_override = true;
+            ins->prefixes |= PFX_SEG;
+            return true;
+        case 0xf0u:
+        case 0xf1u: /* F1 aliases LOCK on original 8086/8088 decode */
+            ins->prefixes |= PFX_LOCK;
+            cpu->in_lock = true;
+            return true;
+        case 0xf2u:
+            ins->prefixes |= PFX_REPNE;
+            cpu->rep_prefix = 1u;
+            return true;
+        case 0xf3u:
+            ins->prefixes |= PFX_REPE;
+            cpu->rep_prefix = 2u;
+            return true;
+        default:
+            return false;
+    }
+}
+
+static bool decode_instruction(m808x_cpu_t *cpu)
+{
+    memset(&cpu->ins, 0, sizeof(cpu->ins));
+    cpu->ins.segment_override = SEG_DS;
+    cpu->ins.ea_segment = SEG_DS;
+    cpu->ins.instruction_ip = architectural_ip(cpu);
+    cpu->in_lock = false;
+    cpu->rep_prefix = 0u;
+
+    uint8_t opcode = queue_read(cpu, true);
+    while (decode_prefix(cpu, opcode)) {
+        biu_cycle_i(cpu, MC_NONE, "PREFIX");
+        opcode = queue_read(cpu, true);
+    }
+    cpu->ins.opcode = opcode;
+
+    if (opcode_has_modrm(opcode)) {
+        decode_modrm(cpu);
+    }
+
+    if (cpu->trace) {
+        printf("-------- instruction %" PRIu64 " @ %04X:%04X opcode=%02X --------\n",
+               cpu->instruction_count,
+               cpu->segs[SEG_CS],
+               cpu->ins.instruction_ip,
+               cpu->ins.opcode);
+    }
+    return !cpu->fatal;
+}
+
+static bool condition_true(const m808x_cpu_t *cpu, uint8_t opcode)
+{
+    const bool cf = (cpu->flags & C_FLAG) != 0u;
+    const bool pf = (cpu->flags & P_FLAG) != 0u;
+    const bool zf = (cpu->flags & Z_FLAG) != 0u;
+    const bool sf = (cpu->flags & S_FLAG) != 0u;
+    const bool of = (cpu->flags & V_FLAG) != 0u;
+
+    switch (opcode & 0x0fu) {
+        case 0x0: return of;
+        case 0x1: return !of;
+        case 0x2: return cf;
+        case 0x3: return !cf;
+        case 0x4: return zf;
+        case 0x5: return !zf;
+        case 0x6: return cf || zf;
+        case 0x7: return !cf && !zf;
+        case 0x8: return sf;
+        case 0x9: return !sf;
+        case 0xa: return pf;
+        case 0xb: return !pf;
+        case 0xc: return sf != of;
+        case 0xd: return sf == of;
+        case 0xe: return zf || (sf != of);
+        case 0xf: return !zf && (sf == of);
+        default: return false;
+    }
+}
+
+static uint16_t read_queue_u16(m808x_cpu_t *cpu)
+{
+    const uint8_t lo = queue_read(cpu, false);
+    const uint8_t hi = queue_read(cpu, false);
+    return (uint16_t)(lo | ((uint16_t)hi << 8));
+}
+
+typedef enum {
+    ALU_ADD = 0,
+    ALU_OR,
+    ALU_ADC,
+    ALU_SBB,
+    ALU_AND,
+    ALU_SUB,
+    ALU_XOR,
+    ALU_CMP
+} alu_kind_t;
+
+static bool parity_even8(uint8_t value)
+{
+    value ^= (uint8_t)(value >> 4);
+    value &= 0x0fu;
+    return ((0x6996u >> value) & 1u) == 0u;
+}
+
+static void set_flag_state(m808x_cpu_t *cpu, uint16_t flag, bool state)
+{
+    if (state) {
+        cpu->flags |= flag;
+    } else {
+        cpu->flags &= (uint16_t)~flag;
+    }
+}
+
+static void set_szp8(m808x_cpu_t *cpu, uint8_t value)
+{
+    set_flag_state(cpu, S_FLAG, (value & 0x80u) != 0u);
+    set_flag_state(cpu, Z_FLAG, value == 0u);
+    set_flag_state(cpu, P_FLAG, parity_even8(value));
+}
+
+static void set_szp16(m808x_cpu_t *cpu, uint16_t value)
+{
+    set_flag_state(cpu, S_FLAG, (value & 0x8000u) != 0u);
+    set_flag_state(cpu, Z_FLAG, value == 0u);
+    set_flag_state(cpu, P_FLAG, parity_even8((uint8_t)value));
+}
+
+static uint16_t alu_binary(m808x_cpu_t *cpu, alu_kind_t kind, uint16_t lhs, uint16_t rhs, bool word)
+{
+    const uint32_t mask = word ? 0xffffu : 0xffu;
+    const uint32_t sign = word ? 0x8000u : 0x80u;
+    const uint32_t a = lhs & mask;
+    const uint32_t b = rhs & mask;
+    const uint32_t carry_in = (cpu->flags & C_FLAG) != 0u ? 1u : 0u;
+    uint32_t result = 0u;
+    bool carry = false;
+    bool overflow = false;
+    bool aux = false;
+
+    switch (kind) {
+        case ALU_ADD:
+        case ALU_ADC: {
+            const uint32_t cin = kind == ALU_ADC ? carry_in : 0u;
+            const uint32_t wide = a + b + cin;
+            result = wide & mask;
+            carry = wide > mask;
+            aux = ((a ^ b ^ result) & 0x10u) != 0u;
+            overflow = ((~(a ^ b) & (a ^ result)) & sign) != 0u;
+            break;
+        }
+        case ALU_SUB:
+        case ALU_CMP:
+        case ALU_SBB: {
+            const uint32_t bin = kind == ALU_SBB ? carry_in : 0u;
+            const uint32_t subtrahend = b + bin;
+            result = (a - subtrahend) & mask;
+            carry = a < subtrahend;
+            aux = ((a ^ b ^ result) & 0x10u) != 0u;
+            overflow = (((a ^ b) & (a ^ result)) & sign) != 0u;
+            break;
+        }
+        case ALU_OR:
+            result = a | b;
+            break;
+        case ALU_AND:
+            result = a & b;
+            break;
+        case ALU_XOR:
+            result = a ^ b;
+            break;
+    }
+
+    if (kind == ALU_OR || kind == ALU_AND || kind == ALU_XOR) {
+        set_flag_state(cpu, C_FLAG, false);
+        set_flag_state(cpu, V_FLAG, false);
+        set_flag_state(cpu, A_FLAG, false);
+    } else {
+        set_flag_state(cpu, C_FLAG, carry);
+        set_flag_state(cpu, V_FLAG, overflow);
+        set_flag_state(cpu, A_FLAG, aux);
+    }
+
+    if (word) {
+        set_szp16(cpu, (uint16_t)result);
+    } else {
+        set_szp8(cpu, (uint8_t)result);
+    }
+    return (uint16_t)result;
+}
+
+static uint16_t alu_incdec(m808x_cpu_t *cpu, uint16_t value, bool decrement, bool word)
+{
+    const bool carry = (cpu->flags & C_FLAG) != 0u;
+    const uint16_t result = alu_binary(cpu, decrement ? ALU_SUB : ALU_ADD, value, 1u, word);
+    set_flag_state(cpu, C_FLAG, carry);
+    return result;
+}
+
+static uint8_t get_reg8(const m808x_cpu_t *cpu, unsigned index)
+{
+    index &= 7u;
+    if (index < 4u) {
+        return cpu->regs[index].b.l;
+    }
+    return cpu->regs[index - 4u].b.h;
+}
+
+static void set_reg8(m808x_cpu_t *cpu, unsigned index, uint8_t value)
+{
+    index &= 7u;
+    if (index < 4u) {
+        cpu->regs[index].b.l = value;
+    } else {
+        cpu->regs[index - 4u].b.h = value;
+    }
+}
+
+static uint16_t get_reg16(const m808x_cpu_t *cpu, unsigned index)
+{
+    return cpu->regs[index & 7u].x;
+}
+
+static void set_reg16(m808x_cpu_t *cpu, unsigned index, uint16_t value)
+{
+    cpu->regs[index & 7u].x = value;
+}
+
+static bool rm_is_memory(const m808x_cpu_t *cpu)
+{
+    return cpu->ins.has_modrm && cpu->ins.mod != 3u;
+}
+
+static void ea_load_return(m808x_cpu_t *cpu)
+{
+    CYCLES_MC(cpu, 0x1e2u, MC_JUMP);
+}
+
+static void ea_done_return(m808x_cpu_t *cpu)
+{
+    CYCLES_MC(cpu, 0x1e3u, MC_JUMP);
+}
+
+static uint16_t read_rm(m808x_cpu_t *cpu, bool word)
+{
+    if (!rm_is_memory(cpu))
+        return word ? get_reg16(cpu, cpu->ins.rm) : get_reg8(cpu, cpu->ins.rm);
+    const uint16_t value = word ? biu_read_u16(cpu, cpu->ins.ea_segment, cpu->ins.ea)
+                                : biu_read_u8(cpu, cpu->ins.ea_segment, cpu->ins.ea);
+    ea_load_return(cpu);
+    return value;
+}
+
+static void write_rm(m808x_cpu_t *cpu, bool word, uint16_t value)
+{
+    if (!rm_is_memory(cpu)) {
+        if (word) {
+            set_reg16(cpu, cpu->ins.rm, value);
+        } else {
+            set_reg8(cpu, cpu->ins.rm, (uint8_t)value);
+        }
+        return;
+    }
+    if (word) {
+        biu_write_u16(cpu, cpu->ins.ea_segment, cpu->ins.ea, value);
+    } else {
+        biu_write_u8(cpu, cpu->ins.ea_segment, cpu->ins.ea, (uint8_t)value);
+    }
+}
+
+static uint16_t read_reg_field(const m808x_cpu_t *cpu, bool word)
+{
+    return word ? get_reg16(cpu, cpu->ins.reg) : get_reg8(cpu, cpu->ins.reg);
+}
+
+static void write_reg_field(m808x_cpu_t *cpu, bool word, uint16_t value)
+{
+    if (word) {
+        set_reg16(cpu, cpu->ins.reg, value);
+    } else {
+        set_reg8(cpu, cpu->ins.reg, (uint8_t)value);
+    }
+}
+
+static uint16_t segment_value(const m808x_cpu_t *cpu, unsigned index)
+{
+    return cpu->segs[index & 3u];
+}
+
+static void set_segment_value(m808x_cpu_t *cpu, unsigned index, uint16_t value)
+{
+    const unsigned seg = index & 3u;
+    cpu->segs[seg] = value;
+    if (seg == SEG_SS) {
+        cpu->interrupt_shadow = 1u;
+        cpu->trap_shadow = 1u;
+    }
+    if (seg == SEG_CS) {
+        biu_fetch_suspend(cpu);
+        corr(cpu);
+        biu_queue_flush(cpu);
+    }
+}
+
+static uint16_t pop_u16(m808x_cpu_t *cpu)
+{
+    const uint16_t value = biu_read_u16(cpu, SEG_SS, SP);
+    SP = (uint16_t)(SP + 2u);
+    return value;
+}
+
+static void push_reg16(m808x_cpu_t *cpu, unsigned reg)
+{
+    reg &= 7u;
+    CYCLES_MC(cpu, 0x028u, 0x029u, 0x02au);
+    SP = (uint16_t)(SP - 2u);
+    const uint16_t value = reg == 4u ? SP : get_reg16(cpu, reg);
+    biu_write_u16(cpu, SEG_SS, SP, value);
+}
+
+static void pop_reg16(m808x_cpu_t *cpu, unsigned reg)
+{
+    reg &= 7u;
+    const uint16_t value = biu_read_u16(cpu, SEG_SS, SP);
+    if (reg == 4u) {
+        SP = value;
+    } else {
+        SP = (uint16_t)(SP + 2u);
+        set_reg16(cpu, reg, value);
+    }
+}
+
+static void push_segment(m808x_cpu_t *cpu, unsigned seg)
+{
+    CYCLES_MC(cpu, 0x02cu, 0x02du, 0x02eu);
+    push_u16(cpu, segment_value(cpu, seg));
+}
+
+static void pop_segment(m808x_cpu_t *cpu, unsigned seg)
+{
+    const uint16_t value = pop_u16(cpu);
+    set_segment_value(cpu, seg, value);
+}
+
+static void pop_flags(m808x_cpu_t *cpu)
+{
+    const bool old_if = (cpu->flags & I_FLAG) != 0u;
+    const bool old_tf = (cpu->flags & T_FLAG) != 0u;
+    const uint16_t value = pop_u16(cpu);
+    cpu->flags = (uint16_t)((value & 0x0fd5u) | 0xf002u);
+    if (!old_if && (cpu->flags & I_FLAG) != 0u) {
+        cpu->interrupt_shadow = 1u;
+    }
+    if (!old_tf && (cpu->flags & T_FLAG) != 0u) {
+        cpu->trap_shadow = 1u;
+    }
+    if (old_tf && (cpu->flags & T_FLAG) == 0u) {
+        cpu->trap_disable_delay = 1u;
+    }
+}
+
+static void nearcall(m808x_cpu_t *cpu, uint16_t new_ip)
+{
+    const uint16_t return_ip = cpu->pc;
+    biu_cycle_i(cpu, MC_JUMP, "NEARCALL");
+    cpu->pc = new_ip;
+    biu_queue_flush(cpu);
+    CYCLES_MC(cpu, 0x077u, 0x078u, 0x079u);
+    push_u16(cpu, return_ip);
+}
+
+static void farcall(m808x_cpu_t *cpu, uint16_t new_cs, uint16_t new_ip, bool jump_into)
+{
+    if (jump_into) {
+        biu_cycle_i(cpu, MC_JUMP, "FARCALL entry");
+    }
+    biu_fetch_suspend(cpu);
+    CYCLES_MC(cpu, 0x06bu, 0x06cu);
+    corr(cpu);
+    biu_cycle_i(cpu, 0x06du, NULL);
+    push_u16(cpu, cpu->segs[SEG_CS]);
+    cpu->segs[SEG_CS] = new_cs;
+    CYCLES_MC(cpu, 0x06eu, 0x06fu);
+    nearcall(cpu, new_ip);
+}
+
+static void farret(m808x_cpu_t *cpu, bool far_return)
+{
+    biu_cycle_i(cpu, MC_JUMP, "FARRET entry");
+    cpu->pc = pop_u16(cpu);
+    biu_fetch_suspend(cpu);
+    CYCLES_MC(cpu, 0x0c3u, 0x0c4u);
+    if (far_return) {
+        biu_cycle_i(cpu, MC_JUMP, NULL);
+        cpu->segs[SEG_CS] = pop_u16(cpu);
+        biu_queue_flush(cpu);
+        CYCLES_MC(cpu, 0x0c7u, MC_JUMP);
+    } else {
+        biu_queue_flush(cpu);
+        CYCLES_MC(cpu, 0x0c5u, MC_JUMP);
+    }
+}
+
+static void interrupt_routine(m808x_cpu_t *cpu, uint8_t vector, bool skip_first)
+{
+    if (!skip_first) {
+        biu_cycle_i(cpu, 0x19du, NULL);
+    }
+    CYCLES_MC(cpu, 0x19eu, 0x19fu);
+    const uint16_t table = (uint16_t)((uint16_t)vector * 4u);
+    uint16_t new_ip = biu_read_u16(cpu, SEG_NONE, table);
+    biu_cycle_i(cpu, 0x1a1u, NULL);
+    uint16_t new_cs = biu_read_u16(cpu, SEG_NONE, (uint16_t)(table + 2u));
+    (void)m808x_host_override_vector(vector, &new_ip, &new_cs);
+    biu_fetch_suspend(cpu);
+    CYCLES_MC(cpu, 0x1a3u, 0x1a4u, 0x1a5u);
+    push_u16(cpu, cpu->flags);
+    cpu->flags &= (uint16_t)~(I_FLAG | T_FLAG);
+    biu_cycle_i(cpu, 0x1a6u, NULL);
+    CYCLES_MC(cpu, MC_JUMP, 0x06cu);
+    corr(cpu);
+    biu_cycle_i(cpu, 0x06du, NULL);
+    push_u16(cpu, cpu->segs[SEG_CS]);
+    cpu->segs[SEG_CS] = new_cs;
+    CYCLES_MC(cpu, 0x06eu, 0x06fu);
+    nearcall(cpu, new_ip);
+}
+
+static void software_interrupt(m808x_cpu_t *cpu, uint8_t vector)
+{
+    interrupt_routine(cpu, vector, false);
+}
+
+static void divide_interrupt(m808x_cpu_t *cpu)
+{
+    CYCLES_MC(cpu, 0x1a7u, MC_JUMP);
+    interrupt_routine(cpu, 0u, true);
+}
+
+static uint16_t shift_rotate(m808x_cpu_t *cpu, unsigned operation, uint16_t value, uint8_t count, bool word)
+{
+    const uint16_t mask = word ? 0xffffu : 0x00ffu;
+    const uint16_t sign = word ? 0x8000u : 0x0080u;
+    const unsigned op = operation & 7u;
+    uint16_t result = value & mask;
+
+    /* D2/D3 with CL==0 performs the microcode path but the ALU leaves both
+     * the operand and every flag unchanged. */
+    if (count == 0u) {
+        return result;
+    }
+
+    /* Original NMOS decode: /6 is SETMO for D0/D1 and SETMOC for D2/D3.
+     * SETMOC differs only in that a zero CL is a no-op, handled above. */
+    if (op == 6u) {
+        result = mask;
+        set_flag_state(cpu, C_FLAG, false);
+        set_flag_state(cpu, A_FLAG, false);
+        set_flag_state(cpu, V_FLAG, false);
+        if (word) {
+            set_szp16(cpu, result);
+        } else {
+            set_szp8(cpu, (uint8_t)result);
+        }
+        return result;
+    }
+
+    const uint16_t original = result;
+    bool cf = (cpu->flags & C_FLAG) != 0u;
+    bool of = (cpu->flags & V_FLAG) != 0u;
+
+    /* Keep the already-perfect D0/D1 rotate path explicit.  This is also the
+     * correct path for D2/D3 when CL==1.  No undefined non-C/O flags move. */
+    if (count == 1u && op < 4u) {
+        switch (op) {
+            case 0u: { /* ROL */
+                const bool outgoing = (result & sign) != 0u;
+                result = (uint16_t)(((result << 1) | (outgoing ? 1u : 0u)) & mask);
+                cf = outgoing;
+                of = cf != ((result & sign) != 0u);
+                break;
+            }
+            case 1u: { /* ROR */
+                const bool outgoing = (result & 1u) != 0u;
+                result = (uint16_t)((result >> 1) | (outgoing ? sign : 0u));
+                cf = outgoing;
+                of = ((result & sign) != 0u) != ((result & (sign >> 1)) != 0u);
+                break;
+            }
+            case 2u: { /* RCL */
+                const bool incoming = cf;
+                const bool outgoing = (result & sign) != 0u;
+                result = (uint16_t)(((result << 1) | (incoming ? 1u : 0u)) & mask);
+                cf = outgoing;
+                of = cf != ((result & sign) != 0u);
+                break;
+            }
+            case 3u: { /* RCR */
+                const bool incoming = cf;
+                const bool outgoing = (result & 1u) != 0u;
+                result = (uint16_t)((result >> 1) | (incoming ? sign : 0u));
+                cf = outgoing;
+                of = ((result & sign) != 0u) != ((result & (sign >> 1)) != 0u);
+                break;
+            }
+            default:
+                break;
+        }
+        set_flag_state(cpu, C_FLAG, cf);
+        set_flag_state(cpu, V_FLAG, of);
+        return result;
+    }
+
+    /* Direct transcription of MartyPC's current NMOS ALU iteration.  OF is
+     * the value produced by the final physical micro-iteration, even where
+     * Intel documents it as undefined for counts greater than one. */
+    for (unsigned i = 0; i < count; i++) {
+        switch (op) {
+            case 0u: { /* ROL */
+                const bool outgoing = (result & sign) != 0u;
+                result = (uint16_t)(((result << 1) | (outgoing ? 1u : 0u)) & mask);
+                cf = outgoing;
+                of = cf != ((result & sign) != 0u);
+                break;
+            }
+            case 1u: { /* ROR */
+                const bool outgoing = (result & 1u) != 0u;
+                result >>= 1;
+                of = outgoing != ((result & (sign >> 1)) != 0u);
+                result = (uint16_t)(result | (outgoing ? sign : 0u));
+                cf = outgoing;
+                break;
+            }
+            case 2u: { /* RCL */
+                const bool incoming = cf;
+                const bool outgoing = (result & sign) != 0u;
+                result = (uint16_t)((result << 1) & mask);
+                result = (uint16_t)(result | (incoming ? 1u : 0u));
+                cf = outgoing;
+                of = cf != ((result & sign) != 0u);
+                break;
+            }
+            case 3u: { /* RCR */
+                const bool incoming = cf;
+                const bool outgoing = (result & 1u) != 0u;
+                result >>= 1;
+                of = incoming != ((result & (sign >> 1)) != 0u);
+                result = (uint16_t)(result | (incoming ? sign : 0u));
+                cf = outgoing;
+                break;
+            }
+            case 4u: { /* SHL/SAL */
+                const bool outgoing = (result & sign) != 0u;
+                result = (uint16_t)((result << 1) & mask);
+                cf = outgoing;
+                of = cf != ((result & sign) != 0u);
+                break;
+            }
+            case 5u: { /* SHR */
+                cf = (result & 1u) != 0u;
+                result >>= 1;
+                break;
+            }
+            case 7u: { /* SAR */
+                cf = (result & 1u) != 0u;
+                result = (uint16_t)((result >> 1) | (result & sign));
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+    set_flag_state(cpu, C_FLAG, cf);
+    switch (op) {
+        case 0u:
+        case 1u:
+        case 2u:
+        case 3u:
+            set_flag_state(cpu, V_FLAG, of);
+            break;
+
+        case 4u:
+            /* NMOS SHL exposes AF as bit 4 of the final shifted result. */
+            set_flag_state(cpu, V_FLAG, of);
+            set_flag_state(cpu, A_FLAG, (result & 0x10u) != 0u);
+            if (word) set_szp16(cpu, result); else set_szp8(cpu, (uint8_t)result);
+            break;
+
+        case 5u:
+            set_flag_state(cpu, V_FLAG, count == 1u && (original & sign) != 0u);
+            set_flag_state(cpu, A_FLAG, false);
+            if (word) set_szp16(cpu, result); else set_szp8(cpu, (uint8_t)result);
+            break;
+
+        case 7u:
+            set_flag_state(cpu, V_FLAG, false);
+            set_flag_state(cpu, A_FLAG, false);
+            if (word) set_szp16(cpu, result); else set_szp8(cpu, (uint8_t)result);
+            break;
+
+        default:
+            break;
+    }
+    return result;
+}
+
+static void do_daa(m808x_cpu_t *cpu)
+{
+    const uint8_t old_al = AL;
+    const bool old_cf = (cpu->flags & C_FLAG) != 0u;
+    const bool old_af = (cpu->flags & A_FLAG) != 0u;
+    const uint8_t al_check = old_af ? 0x9fu : 0x99u;
+
+    /* Undefined OF is stable on the NMOS 8088 and is part of the V2 oracle. */
+    set_flag_state(cpu, V_FLAG,
+                   old_cf ? (old_al >= 0x1au && old_al <= 0x7fu)
+                          : (old_al >= 0x7au && old_al <= 0x7fu));
+
+    set_flag_state(cpu, C_FLAG, false);
+    if ((old_al & 0x0fu) > 9u || old_af) {
+        AL = (uint8_t)(AL + 6u);
+        set_flag_state(cpu, A_FLAG, true);
+    } else {
+        set_flag_state(cpu, A_FLAG, false);
+    }
+
+    if (old_al > al_check || old_cf) {
+        AL = (uint8_t)(AL + 0x60u);
+        set_flag_state(cpu, C_FLAG, true);
+    }
+    set_szp8(cpu, AL);
+}
+
+static void do_das(m808x_cpu_t *cpu)
+{
+    const uint8_t old_al = AL;
+    const bool old_cf = (cpu->flags & C_FLAG) != 0u;
+    const bool old_af = (cpu->flags & A_FLAG) != 0u;
+    const uint8_t al_check = old_af ? 0x9fu : 0x99u;
+    bool of = false;
+
+    if (!old_af && !old_cf) {
+        of = old_al >= 0x9au && old_al <= 0xdfu;
+    } else if (old_af && !old_cf) {
+        of = (old_al >= 0x80u && old_al <= 0x85u) ||
+             (old_al >= 0xa0u && old_al <= 0xe5u);
+    } else if (!old_af && old_cf) {
+        of = old_al >= 0x80u && old_al <= 0xdfu;
+    } else {
+        of = old_al >= 0x80u && old_al <= 0xe5u;
+    }
+    set_flag_state(cpu, V_FLAG, of);
+
+    set_flag_state(cpu, C_FLAG, false);
+    if ((old_al & 0x0fu) > 9u || old_af) {
+        AL = (uint8_t)(AL - 6u);
+        set_flag_state(cpu, A_FLAG, true);
+    } else {
+        set_flag_state(cpu, A_FLAG, false);
+    }
+
+    if (old_al > al_check || old_cf) {
+        AL = (uint8_t)(AL - 0x60u);
+        set_flag_state(cpu, C_FLAG, true);
+    }
+    set_szp8(cpu, AL);
+}
+
+static void do_aaa(m808x_cpu_t *cpu)
+{
+    const uint8_t old_al = AL;
+    uint8_t new_al;
+
+    CYCLES_MC(cpu, 0x148u, 0x149u, 0x14au, 0x14bu, 0x14cu, 0x14du);
+    if ((old_al & 0x0fu) > 9u || (cpu->flags & A_FLAG) != 0u) {
+        AH = (uint8_t)(AH + 1u);
+        new_al = (uint8_t)(old_al + 6u);
+        AL = (uint8_t)(new_al & 0x0fu);
+        set_flag_state(cpu, A_FLAG, true);
+        set_flag_state(cpu, C_FLAG, true);
+    } else {
+        new_al = old_al;
+        AL = (uint8_t)(old_al & 0x0fu);
+        set_flag_state(cpu, A_FLAG, false);
+        set_flag_state(cpu, C_FLAG, false);
+        biu_cycle_i(cpu, MC_JUMP, NULL);
+    }
+
+    set_flag_state(cpu, Z_FLAG, new_al == 0u);
+    set_flag_state(cpu, P_FLAG, parity_even8(new_al));
+    set_flag_state(cpu, V_FLAG, old_al >= 0x7au && old_al <= 0x7fu);
+    set_flag_state(cpu, S_FLAG, old_al >= 0x7au && old_al <= 0xf9u);
+}
+
+static void do_aas(m808x_cpu_t *cpu)
+{
+    const uint8_t old_al = AL;
+    const bool old_af = (cpu->flags & A_FLAG) != 0u;
+    uint8_t new_al;
+
+    CYCLES_MC(cpu, 0x148u, 0x149u, 0x14au, 0x14bu, MC_JUMP, 0x14du);
+    if ((old_al & 0x0fu) > 9u || old_af) {
+        new_al = (uint8_t)(old_al - 6u);
+        AH = (uint8_t)(AH - 1u);
+        AL = (uint8_t)(new_al & 0x0fu);
+        set_flag_state(cpu, A_FLAG, true);
+        set_flag_state(cpu, C_FLAG, true);
+    } else {
+        new_al = old_al;
+        AL = (uint8_t)(old_al & 0x0fu);
+        set_flag_state(cpu, A_FLAG, false);
+        set_flag_state(cpu, C_FLAG, false);
+        biu_cycle_i(cpu, MC_JUMP, NULL);
+    }
+
+    set_flag_state(cpu, V_FLAG, old_af && old_al >= 0x80u && old_al <= 0x85u);
+    set_flag_state(cpu, S_FLAG,
+                   (!old_af && old_al >= 0x80u) ||
+                   (old_af && (old_al <= 0x05u || old_al >= 0x86u)));
+    set_flag_state(cpu, Z_FLAG, new_al == 0u);
+    set_flag_state(cpu, P_FLAG, parity_even8(new_al));
+}
+
+static uint16_t width_mask(unsigned bits)
+{
+    return bits == 8u ? 0x00ffu : 0xffffu;
+}
+
+static uint16_t width_neg(uint16_t value, unsigned bits, bool *carry)
+{
+    const uint16_t mask = width_mask(bits);
+    value &= mask;
+    *carry = value != 0u;
+    return (uint16_t)((0u - value) & mask);
+}
+
+static uint16_t width_rcr1(uint16_t value, unsigned bits, bool carry_in, bool *carry_out)
+{
+    const uint16_t mask = width_mask(bits);
+    const uint16_t sign = bits == 8u ? 0x0080u : 0x8000u;
+    value &= mask;
+    *carry_out = (value & 1u) != 0u;
+    return (uint16_t)(((value >> 1) | (carry_in ? sign : 0u)) & mask);
+}
+
+static uint16_t width_add(uint16_t lhs, uint16_t rhs, unsigned bits, bool *carry)
+{
+    const uint32_t mask = width_mask(bits);
+    const uint32_t sum = (uint32_t)(lhs & mask) + (uint32_t)(rhs & mask);
+    *carry = sum > mask;
+    return (uint16_t)(sum & mask);
+}
+
+typedef struct {
+    uint16_t a;
+    uint16_t b;
+    uint16_t c;
+    bool carry;
+    bool negate;
+} mul_tmp_t;
+
+static mul_tmp_t mul_cor_negate_cycles(m808x_cpu_t *cpu,
+                                       unsigned bits,
+                                       uint16_t tmpa,
+                                       uint16_t tmpb,
+                                       uint16_t tmpc,
+                                       bool negate,
+                                       bool skip)
+{
+    bool carry = false;
+    uint16_t sigma = 0u;
+
+    if (!skip) {
+        /* NEGATE's tmpa/tmpb/tmpc datapath is the physical 16-bit ALU even
+         * when CORX itself is operating on bytes.  Keeping the sign-extended
+         * upper byte is architecturally invisible in AX, but IMULCOF exposes
+         * it through its otherwise-undefined S/Z/P/A flags. */
+        sigma = (uint16_t)(0u - tmpc);
+        carry = tmpc != 0u;
+        tmpc = sigma;
+        if (carry) {
+            sigma = (uint16_t)~tmpa;
+            CYCLES_MC(cpu, 0x1b6u, 0x1b7u, 0x1b8u, MC_JUMP, 0x1bau);
+        } else {
+            sigma = (uint16_t)(0u - tmpa);
+            CYCLES_MC(cpu, 0x1b6u, 0x1b7u, 0x1b8u, 0x1b9u, 0x1bau);
+        }
+        tmpa = sigma;
+        negate = !negate;
+    }
+
+    const uint16_t sign = bits == 8u ? 0x0080u : 0x8000u;
+    carry = (tmpb & sign) != 0u;
+    sigma = (uint16_t)(0u - tmpb);
+    CYCLES_MC(cpu, 0x1bbu, 0x1bcu, 0x1bdu);
+    if (!carry) {
+        CYCLES_MC(cpu, MC_JUMP, 0x1bfu, MC_JUMP);
+    } else {
+        tmpb = sigma;
+        negate = !negate;
+        CYCLES_MC(cpu, 0x1beu, MC_JUMP);
+    }
+
+    return (mul_tmp_t){tmpa, tmpb, tmpc, carry, negate};
+}
+
+static mul_tmp_t mul_corx_cycles(m808x_cpu_t *cpu,
+                                  unsigned bits,
+                                  uint16_t tmpb,
+                                  uint16_t tmpc,
+                                  bool carry)
+{
+    uint16_t tmpa = 0u;
+    tmpc = width_rcr1(tmpc, bits, carry, &carry);
+    unsigned counter = bits - 1u;
+    CYCLES_MC(cpu, 0x17fu, 0x180u);
+
+    for (;;) {
+        biu_cycle_i(cpu, 0x181u, NULL);
+        if (carry) {
+            const uint16_t lhs = (uint16_t)(tmpa & width_mask(bits));
+            const uint16_t rhs = (uint16_t)(tmpb & width_mask(bits));
+            tmpa = width_add(lhs, rhs, bits, &carry);
+            const uint16_t sign = bits == 8u ? 0x0080u : 0x8000u;
+            const bool overflow = (((lhs ^ tmpa) & (rhs ^ tmpa) & sign) != 0u);
+            const bool aux = (((lhs ^ rhs ^ tmpa) & 0x10u) != 0u);
+            /* 183 is F-marked.  MUL later overwrites these flags in MULCOF/
+             * IMULCOF, but AAD intentionally exposes C/A/O from the final
+             * CORX addition while replacing only S/Z/P from its AL result. */
+            set_flag_state(cpu, C_FLAG, carry);
+            set_flag_state(cpu, V_FLAG, overflow);
+            set_flag_state(cpu, A_FLAG, aux);
+            if (bits == 8u) set_szp8(cpu, (uint8_t)tmpa); else set_szp16(cpu, tmpa);
+            CYCLES_MC(cpu, 0x182u, 0x183u);
+        } else {
+            biu_cycle_i(cpu, MC_JUMP, NULL);
+        }
+
+        tmpa = width_rcr1(tmpa, bits, carry, &carry);
+        tmpc = width_rcr1(tmpc, bits, carry, &carry);
+        CYCLES_MC(cpu, 0x184u, 0x185u, 0x186u);
+
+        if (counter == 0u) {
+            break;
+        }
+        counter--;
+        biu_cycle_i(cpu, MC_JUMP, NULL);
+    }
+    CYCLES_MC(cpu, 0x187u, MC_JUMP);
+    return (mul_tmp_t){tmpa, tmpb, tmpc, carry, false};
+}
+
+static void mul_microcode_cycles(m808x_cpu_t *cpu,
+                                 unsigned bits,
+                                 uint16_t accumulator,
+                                 uint16_t operand,
+                                 bool signed_op,
+                                 bool negate)
+{
+    const uint16_t mask = width_mask(bits);
+    const uint16_t sign = bits == 8u ? 0x0080u : 0x8000u;
+    const uint16_t entry0 = bits == 8u ? 0x150u : 0x158u;
+    const uint16_t entry1 = bits == 8u ? 0x151u : 0x159u;
+    const uint16_t call_corx = bits == 8u ? 0x152u : 0x15au;
+    const uint16_t post_corx = bits == 8u ? 0x153u : 0x15bu;
+    const uint16_t cof_entry = bits == 8u ? 0x154u : 0x15cu;
+    const uint16_t move_low = bits == 8u ? 0x155u : 0x15du;
+    const uint16_t call_mulcof = bits == 8u ? 0x156u : 0x15eu;
+
+    uint16_t tmpa = 0u;
+    uint16_t tmpb = operand & mask;
+    uint16_t tmpc = accumulator & mask;
+    bool carry = (tmpc & sign) != 0u;
+
+    CYCLES_MC(cpu, entry0, entry1);
+
+    if (signed_op) {
+        /* PREIMUL also negates the 16-bit temporary, not an 8-bit-truncated
+         * value.  CORX consumes only the selected width later. */
+        const uint16_t sigma = (uint16_t)(0u - tmpc);
+        CYCLES_MC(cpu, MC_JUMP, 0x1c0u, 0x1c1u);
+        if (carry) {
+            tmpc = sigma;
+            negate = !negate;
+            CYCLES_MC(cpu, 0x1c2u, 0x1c3u, MC_JUMP);
+        } else {
+            biu_cycle_i(cpu, MC_JUMP, NULL);
+        }
+        const mul_tmp_t n = mul_cor_negate_cycles(cpu, bits, 0u, tmpb, tmpc, negate, true);
+        tmpb = n.b;
+        tmpc = n.c;
+        carry = n.carry;
+        negate = n.negate;
+    }
+
+    CYCLES_MC(cpu, call_corx, MC_JUMP);
+
+    const mul_tmp_t corx = mul_corx_cycles(cpu, bits, tmpb, tmpc, carry);
+    tmpa = corx.a;
+    tmpc = corx.c;
+    carry = corx.carry;
+
+    biu_cycle_i(cpu, post_corx, NULL);
+    if (negate) {
+        biu_cycle_i(cpu, MC_JUMP, NULL);
+        const mul_tmp_t n = mul_cor_negate_cycles(cpu, bits, tmpa, tmpb, tmpc, negate, false);
+        tmpa = n.a;
+        tmpc = n.c;
+    }
+
+    biu_cycle_i(cpu, cof_entry, NULL);
+    if (signed_op) {
+        biu_cycle_i(cpu, MC_JUMP, NULL);
+        const bool sign_low = (tmpc & sign) != 0u;
+        const uint16_t addend = sign_low ? 1u : 0u;
+        /* IMULCOF feeds tmpa through the 16-bit ALU for both byte and word
+         * multiplication.  Do not mask the byte form before its flags are
+         * latched. */
+        const uint16_t sigma = (uint16_t)(tmpa + addend);
+        const bool aux = ((tmpa ^ addend ^ sigma) & 0x10u) != 0u;
+        CYCLES_MC(cpu, 0x1cdu, 0x1ceu, 0x1cfu);
+        set_flag_state(cpu, A_FLAG, aux);
+        /* IMULCOF's SIGMA flags are generated by the 16-bit ALU even for
+         * the byte form; the V2 vectors expose those undefined bits. */
+        set_szp16(cpu, sigma);
+        if (sigma == 0u) {
+            CYCLES_MC(cpu, 0x1d0u, MC_JUMP, 0x1ccu, MC_JUMP);
+        } else {
+            CYCLES_MC(cpu, 0x1d0u, 0x1d1u, MC_JUMP);
+        }
+        CYCLES_MC(cpu, move_low, MC_JUMP);
+    } else {
+        CYCLES_MC(cpu, move_low, call_mulcof, MC_JUMP, 0x1d2u, 0x1d3u, MC_JUMP);
+        if (tmpa == 0u) {
+            CYCLES_MC(cpu, 0x1d0u, MC_JUMP, 0x1ccu, MC_JUMP);
+        } else {
+            CYCLES_MC(cpu, 0x1d0u, 0x1d1u, MC_JUMP);
+        }
+    }
+}
+static uint16_t width_rcl1(uint16_t value, unsigned bits, bool carry_in, bool *carry_out)
+{
+    const uint16_t mask = width_mask(bits);
+    const uint16_t sign = bits == 8u ? 0x0080u : 0x8000u;
+    value &= mask;
+    *carry_out = (value & sign) != 0u;
+    return (uint16_t)(((value << 1) | (carry_in ? 1u : 0u)) & mask);
+}
+
+static uint16_t width_sub(uint16_t lhs,
+                          uint16_t rhs,
+                          unsigned bits,
+                          bool *carry,
+                          bool *overflow,
+                          bool *aux)
+{
+    const uint16_t mask = width_mask(bits);
+    const uint16_t sign = bits == 8u ? 0x0080u : 0x8000u;
+    lhs &= mask;
+    rhs &= mask;
+    const uint16_t result = (uint16_t)((lhs - rhs) & mask);
+    *carry = lhs < rhs;
+    *overflow = (((lhs ^ rhs) & (lhs ^ result) & sign) != 0u);
+    *aux = (((lhs ^ rhs ^ result) & 0x10u) != 0u);
+    return result;
+}
+
+static void set_width_sub_flags(m808x_cpu_t *cpu,
+                                unsigned bits,
+                                uint16_t result,
+                                bool carry,
+                                bool overflow,
+                                bool aux)
+{
+    set_flag_state(cpu, C_FLAG, carry);
+    set_flag_state(cpu, V_FLAG, overflow);
+    set_flag_state(cpu, A_FLAG, aux);
+    if (bits == 8u) set_szp8(cpu, (uint8_t)result); else set_szp16(cpu, result);
+}
+
+typedef struct {
+    uint16_t a;
+    uint16_t c;
+    bool carry;
+    bool ok;
+} m808x_cord_result_t;
+
+static m808x_cord_result_t cord_cycles(m808x_cpu_t *cpu,
+                                 unsigned bits,
+                                 uint16_t tmpa,
+                                 uint16_t tmpb,
+                                 uint16_t tmpc)
+{
+    const uint16_t mask = width_mask(bits);
+    tmpa &= mask;
+    tmpb &= mask;
+    tmpc &= mask;
+    bool carry = false, overflow = false, aux = false;
+    uint16_t sigma = width_sub(tmpa, tmpb, bits, &carry, &overflow, &aux);
+    set_width_sub_flags(cpu, bits, sigma, carry, overflow, aux);
+    unsigned counter = bits;
+    CYCLES_MC(cpu, 0x188u, 0x189u, 0x18au);
+    if (!carry) {
+        biu_cycle_i(cpu, MC_JUMP, NULL);
+        return (m808x_cord_result_t){tmpa, tmpc, carry, false};
+    }
+
+    while (counter > 0u && !cpu->fatal) {
+        tmpc = width_rcl1(tmpc, bits, carry, &carry);
+        tmpa = width_rcl1(tmpa, bits, carry, &carry);
+        CYCLES_MC(cpu, 0x18bu, 0x18cu, 0x18du, 0x18eu);
+
+        if (carry) {
+            CYCLES_MC(cpu, MC_JUMP, 0x195u, 0x196u);
+            carry = false;
+            bool ignored_carry = false, ignored_overflow = false, ignored_aux = false;
+            tmpa = width_sub(tmpa, tmpb, bits, &ignored_carry, &ignored_overflow, &ignored_aux);
+            counter--;
+            if (counter > 0u) {
+                biu_cycle_i(cpu, MC_JUMP, NULL);
+                continue;
+            }
+            CYCLES_MC(cpu, 0x197u, MC_JUMP);
+        } else {
+            sigma = width_sub(tmpa, tmpb, bits, &carry, &overflow, &aux);
+            set_width_sub_flags(cpu, bits, sigma, carry, overflow, aux);
+            CYCLES_MC(cpu, 0x18fu, 0x190u);
+            if (!carry) {
+                CYCLES_MC(cpu, MC_JUMP, 0x196u);
+                tmpa = sigma;
+                counter--;
+                if (counter > 0u) {
+                    biu_cycle_i(cpu, MC_JUMP, NULL);
+                    continue;
+                }
+                CYCLES_MC(cpu, 0x197u, MC_JUMP);
+            } else {
+                biu_cycle_i(cpu, 0x191u, NULL);
+                counter--;
+                if (counter > 0u) {
+                    biu_cycle_i(cpu, MC_JUMP, NULL);
+                    continue;
+                }
+            }
+        }
+    }
+
+    tmpc = width_rcl1(tmpc, bits, carry, &carry);
+    CYCLES_MC(cpu, 0x192u, 0x193u);
+    (void)width_rcl1(tmpc, bits, carry, &carry);
+    set_flag_state(cpu, C_FLAG, carry);
+    CYCLES_MC(cpu, 0x194u, MC_JUMP);
+    return (m808x_cord_result_t){tmpa, tmpc, carry, true};
+}
+
+static mul_tmp_t pre_idiv_cycles(m808x_cpu_t *cpu,
+                                 unsigned bits,
+                                 uint16_t tmpa,
+                                 uint16_t tmpb,
+                                 uint16_t tmpc,
+                                 bool negate)
+{
+    bool carry = false;
+    (void)width_rcl1(tmpa, bits, false, &carry);
+    CYCLES_MC(cpu, 0x1b4u, 0x1b5u);
+    if (!carry) {
+        biu_cycle_i(cpu, MC_JUMP, NULL);
+        return mul_cor_negate_cycles(cpu, bits, tmpa, tmpb, tmpc, negate, true);
+    }
+    return mul_cor_negate_cycles(cpu, bits, tmpa, tmpb, tmpc, negate, false);
+}
+
+static m808x_cord_result_t post_idiv_cycles(m808x_cpu_t *cpu,
+                                      unsigned bits,
+                                      uint16_t tmpa,
+                                      uint16_t tmpb,
+                                      uint16_t tmpc,
+                                      bool carry,
+                                      bool negate)
+{
+    const uint16_t mask = width_mask(bits);
+    biu_cycle_i(cpu, 0x1c4u, NULL);
+    if (!carry) {
+        biu_cycle_i(cpu, MC_JUMP, NULL);
+        return (m808x_cord_result_t){tmpa, tmpc, carry, false};
+    }
+
+    bool divisor_negative = false;
+    (void)width_rcl1(tmpb, bits, false, &divisor_negative);
+    bool ignored = false;
+    uint16_t sigma = width_neg(tmpa, bits, &ignored);
+    CYCLES_MC(cpu, 0x1c5u, 0x1c6u, 0x1c7u);
+    if (!divisor_negative) {
+        biu_cycle_i(cpu, MC_JUMP, NULL);
+    } else {
+        tmpa = sigma;
+        biu_cycle_i(cpu, 0x1c8u, NULL);
+    }
+
+    sigma = (uint16_t)((tmpc + 1u) & mask);
+    CYCLES_MC(cpu, 0x1c9u, 0x1cau);
+    if (!negate) {
+        sigma = (uint16_t)(~tmpc & mask);
+        biu_cycle_i(cpu, 0x1cbu, NULL);
+    } else {
+        biu_cycle_i(cpu, MC_JUMP, NULL);
+    }
+    cpu->flags &= (uint16_t)~(C_FLAG | V_FLAG);
+    CYCLES_MC(cpu, 0x1ccu, MC_JUMP);
+    return (m808x_cord_result_t){tmpa, sigma, false, true};
+}
+
+static bool div_microcode_cycles(m808x_cpu_t *cpu,
+                                 unsigned bits,
+                                 uint32_t dividend,
+                                 uint16_t divisor,
+                                 bool signed_op,
+                                 bool negate)
+{
+    const uint16_t mask = width_mask(bits);
+    uint16_t tmpa = bits == 8u ? (uint16_t)((dividend >> 8) & 0xffu)
+                               : (uint16_t)(dividend >> 16);
+    uint16_t tmpc = (uint16_t)(dividend & mask);
+    uint16_t tmpb = divisor & mask;
+    CYCLES_MC(cpu,
+              bits == 8u ? 0x160u : 0x168u,
+              bits == 8u ? 0x161u : 0x169u,
+              bits == 8u ? 0x162u : 0x16au);
+
+    if (signed_op) {
+        biu_cycle_i(cpu, MC_JUMP, NULL);
+        const mul_tmp_t pre = pre_idiv_cycles(cpu, bits, tmpa, tmpb, tmpc, negate);
+        tmpa = pre.a;
+        tmpb = pre.b;
+        tmpc = pre.c;
+        negate = pre.negate;
+    }
+
+    CYCLES_MC(cpu, bits == 8u ? 0x163u : 0x16bu, MC_JUMP);
+    m808x_cord_result_t cord = cord_cycles(cpu, bits, tmpa, tmpb, tmpc);
+    if (!cord.ok) return false;
+    tmpa = cord.a;
+    tmpc = cord.c;
+
+    const uint16_t original_hi = bits == 8u ? (uint16_t)((dividend >> 8) & 0xffu)
+                                            : (uint16_t)(dividend >> 16);
+    CYCLES_MC(cpu, bits == 8u ? 0x164u : 0x16cu,
+              bits == 8u ? 0x165u : 0x16du);
+    if (signed_op) {
+        biu_cycle_i(cpu, MC_JUMP, NULL);
+        cord = post_idiv_cycles(cpu, bits, tmpa, original_hi, tmpc, cord.carry, negate);
+        if (!cord.ok) return false;
+    }
+    return !cpu->fatal;
+}
+static bool rep_interrupt_pending(const m808x_cpu_t *cpu)
+{
+    return cpu->nmi_pin || (cpu->intr_pin && (cpu->flags & I_FLAG) != 0u) || (cpu->flags & T_FLAG) != 0u;
+}
+
+static void rep_interrupt_rewind(m808x_cpu_t *cpu)
+{
+    biu_fetch_suspend(cpu);
+    CYCLES_MC(cpu, 0x118u, 0x119u);
+    corr(cpu);
+    biu_cycle_i(cpu, 0x11au, NULL);
+    biu_queue_flush(cpu);
+    cpu->pc = (uint16_t)(cpu->pc - 2u);
+}
+
+static void string_one(m808x_cpu_t *cpu, uint8_t opcode)
+{
+    const bool word = (opcode & 1u) != 0u;
+    const uint16_t delta = word ? 2u : 1u;
+    const bool backwards = (cpu->flags & D_FLAG) != 0u;
+    const m808x_segment_t src_seg = cpu->ins.has_segment_override ? cpu->ins.segment_override : SEG_DS;
+
+    switch (opcode & 0xfeu) {
+        case 0xa4u: { /* MOVS */
+            const uint16_t value = word ? biu_read_u16(cpu, src_seg, SI) : biu_read_u8(cpu, src_seg, SI);
+            biu_cycle_i(cpu, 0x12eu, NULL);
+            if (word) biu_write_u16(cpu, SEG_ES, DI, value); else biu_write_u8(cpu, SEG_ES, DI, (uint8_t)value);
+            SI = backwards ? (uint16_t)(SI - delta) : (uint16_t)(SI + delta);
+            DI = backwards ? (uint16_t)(DI - delta) : (uint16_t)(DI + delta);
+            break;
+        }
+        case 0xa6u: { /* CMPS */
+            biu_cycle_i(cpu, 0x121u, NULL);
+            const uint16_t lhs = word ? biu_read_u16(cpu, src_seg, SI) : biu_read_u8(cpu, src_seg, SI);
+            CYCLES_MC(cpu, 0x123u, 0x124u);
+            const uint16_t rhs = word ? biu_read_u16(cpu, SEG_ES, DI) : biu_read_u8(cpu, SEG_ES, DI);
+            CYCLES_MC(cpu, 0x126u, 0x127u, 0x128u);
+            (void)alu_binary(cpu, ALU_CMP, lhs, rhs, word);
+            SI = backwards ? (uint16_t)(SI - delta) : (uint16_t)(SI + delta);
+            DI = backwards ? (uint16_t)(DI - delta) : (uint16_t)(DI + delta);
+            break;
+        }
+        case 0xaau: /* STOS */
+            if (word) biu_write_u16(cpu, SEG_ES, DI, AX); else biu_write_u8(cpu, SEG_ES, DI, AL);
+            DI = backwards ? (uint16_t)(DI - delta) : (uint16_t)(DI + delta);
+            break;
+        case 0xacu: { /* LODS */
+            const uint16_t value = word ? biu_read_u16(cpu, src_seg, SI) : biu_read_u8(cpu, src_seg, SI);
+            if (word) AX = value; else AL = (uint8_t)value;
+            SI = backwards ? (uint16_t)(SI - delta) : (uint16_t)(SI + delta);
+            break;
+        }
+        case 0xaeu: { /* SCAS */
+            CYCLES_MC(cpu, 0x121u, MC_JUMP);
+            const uint16_t rhs = word ? biu_read_u16(cpu, SEG_ES, DI) : biu_read_u8(cpu, SEG_ES, DI);
+            CYCLES_MC(cpu, 0x126u, 0x127u, 0x128u);
+            (void)alu_binary(cpu, ALU_CMP, word ? AX : AL, rhs, word);
+            DI = backwards ? (uint16_t)(DI - delta) : (uint16_t)(DI + delta);
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+static void execute_string(m808x_cpu_t *cpu, uint8_t opcode)
+{
+    const uint8_t family = opcode & 0xfeu;
+    const bool compare = family == 0xa6u || family == 0xaeu;
+    const bool rep = cpu->rep_prefix != 0u;
+    const uint16_t entry = family == 0xaau ? 0x11cu : compare ? 0x120u : 0x12cu;
+    biu_cycle_i(cpu, entry, NULL);
+
+    if (!rep) {
+        string_one(cpu, opcode);
+        if (family == 0xaau) {
+            CYCLES_MC(cpu, 0x11du, 0x11eu, MC_JUMP);
+        } else if (family == 0xa4u) {
+            CYCLES_MC(cpu, 0x12fu, 0x130u, MC_JUMP);
+        } else if (family == 0xacu) {
+            CYCLES_MC(cpu, 0x12eu, MC_JUMP, 0x1f8u);
+        } else if (compare) {
+            biu_cycle_i(cpu, MC_JUMP, NULL);
+        }
+        return;
+    }
+
+    CYCLES_MC(cpu, MC_JUMP, 0x112u, 0x113u, 0x114u);
+    if (CX == 0u) {
+        return;
+    }
+    CYCLES_MC(cpu, MC_JUMP, 0x116u, MC_JUMP);
+
+    while (CX != 0u && !cpu->fatal) {
+        string_one(cpu, opcode);
+
+        if (family == 0xaau) { /* STOS: interrupt test precedes CX decrement. */
+            CYCLES_MC(cpu, 0x11du, 0x11eu);
+            biu_cycle_i(cpu, 0x11fu, NULL);
+            if (rep_interrupt_pending(cpu)) {
+                biu_cycle_i(cpu, MC_JUMP, NULL);
+                rep_interrupt_rewind(cpu);
+                return;
+            }
+            biu_cycle_i(cpu, 0x1f0u, NULL);
+            CX = (uint16_t)(CX - 1u);
+            if (CX != 0u) biu_cycle_i(cpu, MC_JUMP, "REP STOS");
+            continue;
+        }
+
+        if (family == 0xa4u) { /* MOVS: decrement, then interrupt test. */
+            CYCLES_MC(cpu, 0x12fu, 0x130u);
+            CX = (uint16_t)(CX - 1u);
+            if (rep_interrupt_pending(cpu)) {
+                CYCLES_MC(cpu, 0x131u, MC_JUMP);
+                rep_interrupt_rewind(cpu);
+                return;
+            }
+            CYCLES_MC(cpu, 0x131u, 0x132u);
+            if (CX != 0u) biu_cycle_i(cpu, MC_JUMP, "REP MOVS");
+            continue;
+        }
+
+        if (family == 0xacu) { /* LODS follows the alternate 12cb entry path. */
+            CYCLES_MC(cpu, 0x12eu, MC_JUMP, 0x1f8u, MC_JUMP, 0x131u);
+            CX = (uint16_t)(CX - 1u);
+            if (rep_interrupt_pending(cpu)) {
+                biu_cycle_i(cpu, MC_JUMP, NULL);
+                rep_interrupt_rewind(cpu);
+                return;
+            }
+            biu_cycle_i(cpu, 0x132u, NULL);
+            if (CX != 0u) biu_cycle_i(cpu, MC_JUMP, "REP LODS");
+            continue;
+        }
+
+        /* CMPS/SCAS: decrement and test Z condition before interrupt/CX termination. */
+        biu_cycle_i(cpu, 0x129u, NULL);
+        CX = (uint16_t)(CX - 1u);
+        const bool zf = (cpu->flags & Z_FLAG) != 0u;
+        const bool repeat_condition = cpu->rep_prefix == 1u ? !zf : zf;
+        if (!repeat_condition) {
+            biu_cycle_i(cpu, MC_JUMP, NULL);
+            break;
+        }
+        biu_cycle_i(cpu, 0x12au, NULL);
+        if (rep_interrupt_pending(cpu)) {
+            biu_cycle_i(cpu, MC_JUMP, NULL);
+            rep_interrupt_rewind(cpu);
+            return;
+        }
+        biu_cycle_i(cpu, 0x12bu, NULL);
+        if (CX != 0u) biu_cycle_i(cpu, MC_JUMP, "REP compare");
+    }
+}
+
+static alu_kind_t alu_kind_from_index(unsigned index)
+{
+    static const alu_kind_t kinds[8] = {
+        ALU_ADD, ALU_OR, ALU_ADC, ALU_SBB, ALU_AND, ALU_SUB, ALU_XOR, ALU_CMP
+    };
+    return kinds[index & 7u];
+}
+
+static void execute_alu_rm_reg(m808x_cpu_t *cpu, uint8_t opcode)
+{
+    const bool word = (opcode & 1u) != 0u;
+    const bool direction = (opcode & 2u) != 0u;
+    const alu_kind_t kind = alu_kind_from_index(opcode >> 3);
+    const uint16_t dst = direction ? read_reg_field(cpu, word) : read_rm(cpu, word);
+    const uint16_t src = direction ? read_rm(cpu, word) : read_reg_field(cpu, word);
+    biu_cycle_i(cpu, 0x008u, NULL);
+    const uint16_t result = alu_binary(cpu, kind, dst, src, word);
+    if (kind == ALU_CMP) {
+        return;
+    }
+    if (!direction && rm_is_memory(cpu)) {
+        CYCLES_MC(cpu, 0x009u, 0x00au);
+    }
+    if (direction) {
+        write_reg_field(cpu, word, result);
+    } else {
+        write_rm(cpu, word, result);
+    }
+}
+
+static void execute_alu_acc_imm(m808x_cpu_t *cpu, uint8_t opcode)
+{
+    const bool word = (opcode & 1u) != 0u;
+    const alu_kind_t kind = alu_kind_from_index(opcode >> 3);
+    const uint16_t imm = word ? read_queue_u16(cpu) : queue_read(cpu, false);
+    if (!word) {
+        biu_cycle_i(cpu, MC_JUMP, NULL);
+    }
+    const uint16_t dst = word ? AX : AL;
+    const uint16_t result = alu_binary(cpu, kind, dst, imm, word);
+    if (kind != ALU_CMP) {
+        if (word) AX = result; else AL = (uint8_t)result;
+    }
+}
+
+static void execute_group1(m808x_cpu_t *cpu, uint8_t opcode)
+{
+    const bool word = opcode == 0x81u || opcode == 0x83u;
+    const uint16_t dst = read_rm(cpu, word);
+    uint16_t imm;
+    if (opcode == 0x81u) {
+        imm = read_queue_u16(cpu);
+    } else {
+        const uint8_t b = queue_read(cpu, false);
+        imm = opcode == 0x83u ? (uint16_t)(int16_t)(int8_t)b : b;
+        biu_cycle_i(cpu, MC_JUMP, NULL);
+    }
+    const alu_kind_t kind = alu_kind_from_index(cpu->ins.reg);
+    const uint16_t result = alu_binary(cpu, kind, dst, imm, word);
+    if (rm_is_memory(cpu)) {
+        biu_cycle_i(cpu, 0x00eu, NULL);
+    }
+    if (kind != ALU_CMP) {
+        write_rm(cpu, word, result);
+    }
+}
+
+static void execute_mov_rm_reg(m808x_cpu_t *cpu, uint8_t opcode)
+{
+    const bool word = (opcode & 1u) != 0u;
+    const bool direction = (opcode & 2u) != 0u;
+    const uint16_t value = direction ? read_rm(cpu, word) : read_reg_field(cpu, word);
+    if (!direction && rm_is_memory(cpu)) {
+        ea_done_return(cpu);
+        CYCLES_MC(cpu, 0x000u, 0x001u);
+    }
+    if (direction) {
+        write_reg_field(cpu, word, value);
+    } else {
+        write_rm(cpu, word, value);
+    }
+}
+
+static void execute_shift_group(m808x_cpu_t *cpu, uint8_t opcode)
+{
+    const bool word = (opcode & 1u) != 0u;
+    const bool from_cl = (opcode & 2u) != 0u;
+    const uint8_t count = from_cl ? CL : 1u;
+    const uint16_t value = read_rm(cpu, word);
+    if (from_cl) {
+        CYCLES_MC(cpu, 0x08cu, 0x08du, 0x08eu, MC_JUMP, 0x090u, 0x091u);
+        for (unsigned i = 0; i < count; i++) {
+            CYCLES_MC(cpu, MC_JUMP, 0x08fu, 0x090u, 0x091u);
+        }
+        if (rm_is_memory(cpu)) {
+            biu_cycle_i(cpu, 0x092u, NULL);
+        }
+    } else if (rm_is_memory(cpu)) {
+        CYCLES_MC(cpu, 0x088u, 0x089u);
+    }
+    const uint16_t result = shift_rotate(cpu, cpu->ins.reg, value, count, word);
+    write_rm(cpu, word, result);
+}
+
+static void execute_group3(m808x_cpu_t *cpu, uint8_t opcode)
+{
+    const bool word = (opcode & 1u) != 0u;
+    const unsigned subop = cpu->ins.reg;
+    const uint16_t operand = read_rm(cpu, word);
+
+    switch (subop) {
+        case 0u:
+        case 1u: {
+            const uint16_t imm = word ? read_queue_u16(cpu) : queue_read(cpu, false);
+            if (!word) biu_cycle_i(cpu, MC_JUMP, NULL);
+            biu_cycle_i(cpu, 0x09au, NULL);
+            (void)alu_binary(cpu, ALU_AND, operand, imm, word);
+            break;
+        }
+        case 2u: {
+            const uint16_t result = (uint16_t)~operand;
+            if (rm_is_memory(cpu)) CYCLES_MC(cpu, 0x04cu, 0x04du); else biu_cycle_i(cpu, 0x04cu, NULL);
+            write_rm(cpu, word, result);
+            break;
+        }
+        case 3u: {
+            const uint16_t result = alu_binary(cpu, ALU_SUB, 0u, operand, word);
+            if (rm_is_memory(cpu)) CYCLES_MC(cpu, 0x050u, 0x051u); else biu_cycle_i(cpu, 0x050u, NULL);
+            write_rm(cpu, word, result);
+            break;
+        }
+        case 4u:
+        case 5u: {
+            const bool signed_op = subop == 5u;
+            if (word) {
+                const uint16_t accumulator = AX;
+                mul_microcode_cycles(cpu, 16u, accumulator, operand, signed_op, cpu->rep_prefix != 0u);
+                int64_t product;
+                if (signed_op) {
+                    product = (int32_t)(int16_t)AX * (int32_t)(int16_t)operand;
+                } else {
+                    product = (uint32_t)AX * (uint32_t)operand;
+                }
+                if (cpu->rep_prefix != 0u) product = -product;
+                AX = (uint16_t)product;
+                DX = (uint16_t)((uint64_t)product >> 16);
+                const bool overflow = signed_op ? ((int32_t)product != (int32_t)(int16_t)AX) : DX != 0u;
+                set_flag_state(cpu, C_FLAG, overflow);
+                set_flag_state(cpu, V_FLAG, overflow);
+                if (!signed_op) {
+                    set_szp16(cpu, DX);
+                    set_flag_state(cpu, A_FLAG, false);
+                }
+            } else {
+                const uint16_t accumulator = AL;
+                mul_microcode_cycles(cpu, 8u, accumulator, operand, signed_op, cpu->rep_prefix != 0u);
+                int32_t product;
+                if (signed_op) {
+                    product = (int16_t)(int8_t)AL * (int16_t)(int8_t)operand;
+                } else {
+                    product = (uint16_t)AL * (uint16_t)(uint8_t)operand;
+                }
+                if (cpu->rep_prefix != 0u) product = -product;
+                AX = (uint16_t)product;
+                const bool overflow = signed_op ? ((int16_t)product != (int16_t)(int8_t)AL) : AH != 0u;
+                set_flag_state(cpu, C_FLAG, overflow);
+                set_flag_state(cpu, V_FLAG, overflow);
+                if (!signed_op) {
+                    set_szp8(cpu, AH);
+                    set_flag_state(cpu, A_FLAG, false);
+                }
+            }
+            if (!rm_is_memory(cpu)) biu_cycle(cpu);
+            break;
+        }
+        case 6u:
+        case 7u: {
+            const bool signed_op = subop == 7u;
+            if (!rm_is_memory(cpu)) biu_cycle(cpu);
+            const uint32_t dividend = word ? (((uint32_t)DX << 16) | AX) : AX;
+            if (!div_microcode_cycles(cpu, word ? 16u : 8u, dividend, operand,
+                                      signed_op, cpu->rep_prefix != 0u)) {
+                divide_interrupt(cpu);
+                return;
+            }
+            if (operand == 0u) {
+                divide_interrupt(cpu);
+                return;
+            }
+            if (word) {
+                if (signed_op) {
+                    const int32_t dividend = (int32_t)(((uint32_t)DX << 16) | AX);
+                    const int32_t divisor = (int16_t)operand;
+                    if (divisor == 0 || (dividend == INT32_MIN && divisor == -1)) {
+                        divide_interrupt(cpu);
+                        return;
+                    }
+                    int32_t q = dividend / divisor;
+                    int32_t r = dividend % divisor;
+                    if (cpu->rep_prefix != 0u) q = -q;
+                    if (q < INT16_MIN || q > INT16_MAX) {
+                        divide_interrupt(cpu);
+                        return;
+                    }
+                    AX = (uint16_t)(int16_t)q;
+                    DX = (uint16_t)(int16_t)r;
+                } else {
+                    const uint32_t dividend = ((uint32_t)DX << 16) | AX;
+                    uint32_t q = dividend / operand;
+                    const uint32_t r = dividend % operand;
+                    if (cpu->rep_prefix != 0u) q = (uint16_t)(-(int32_t)q);
+                    if (q > 0xffffu) {
+                        divide_interrupt(cpu);
+                        return;
+                    }
+                    AX = (uint16_t)q;
+                    DX = (uint16_t)r;
+                }
+            } else {
+                if (signed_op) {
+                    const int16_t dividend = (int16_t)AX;
+                    const int16_t divisor = (int8_t)operand;
+                    if (divisor == 0 || (dividend == INT16_MIN && divisor == -1)) {
+                        divide_interrupt(cpu);
+                        return;
+                    }
+                    int16_t q = (int16_t)(dividend / divisor);
+                    const int16_t r = (int16_t)(dividend % divisor);
+                    if (cpu->rep_prefix != 0u) q = (int16_t)-q;
+                    if (q < INT8_MIN || q > INT8_MAX) {
+                        divide_interrupt(cpu);
+                        return;
+                    }
+                    AL = (uint8_t)(int8_t)q;
+                    AH = (uint8_t)(int8_t)r;
+                } else {
+                    uint16_t q = (uint16_t)(AX / (uint8_t)operand);
+                    const uint16_t r = (uint16_t)(AX % (uint8_t)operand);
+                    if (cpu->rep_prefix != 0u) q = (uint8_t)(-(int16_t)q);
+                    if (q > 0xffu) {
+                        divide_interrupt(cpu);
+                        return;
+                    }
+                    AL = (uint8_t)q;
+                    AH = (uint8_t)r;
+                }
+            }
+            break;
+        }
+    }
+}
+
+static void execute_group45(m808x_cpu_t *cpu, uint8_t opcode)
+{
+    const bool word = opcode == 0xffu;
+    const unsigned subop = cpu->ins.reg;
+    uint16_t operand = 0u;
+
+    /* Far CALL/JMP consume a 32-bit pointer and must not perform the generic
+     * eager r/m read first.  All other group-4/5 operations use one operand. */
+    if (subop != 3u && subop != 5u)
+        operand = read_rm(cpu, word);
+
+    switch (subop) {
+        case 0u:
+        case 1u: {
+            const uint16_t result = alu_incdec(cpu, operand, subop == 1u, word);
+            biu_cycle_i(cpu, 0x020u, NULL);
+            if (rm_is_memory(cpu)) biu_cycle_i(cpu, 0x021u, NULL);
+            write_rm(cpu, word, result);
+            break;
+        }
+        case 2u: { /* near call */
+            if (!rm_is_memory(cpu)) biu_cycle_i(cpu, 0x074u, NULL);
+            biu_fetch_suspend(cpu);
+            CYCLES_MC(cpu, 0x074u, 0x075u);
+            corr(cpu);
+            biu_cycle_i(cpu, 0x076u, NULL);
+            const uint16_t return_ip = cpu->pc;
+            cpu->pc = operand;
+            biu_queue_flush(cpu);
+            CYCLES_MC(cpu, 0x077u, 0x078u, 0x079u);
+            if (word) push_u16(cpu, return_ip); else { SP = (uint16_t)(SP - 2u); biu_write_u8(cpu, SEG_SS, SP, (uint8_t)return_ip); }
+            break;
+        }
+        case 3u: { /* far call */
+            uint16_t off;
+            uint16_t seg;
+            if (rm_is_memory(cpu)) {
+                off = read_rm(cpu, true);
+                biu_cycle_i(cpu, 0x068u, NULL);
+                seg = biu_read_u16(cpu, cpu->ins.ea_segment, (uint16_t)(cpu->ins.ea + 2u));
+            } else {
+                const m808x_segment_t default_seg = cpu->ins.has_segment_override ? cpu->ins.segment_override : SEG_DS;
+                biu_cycle_i(cpu, 0x069u, NULL);
+                off = 0x0004u;
+                seg = biu_read_u16(cpu, default_seg, off);
+                biu_cycle_i(cpu, 0x06au, NULL);
+            }
+            farcall(cpu, seg, off, true);
+            break;
+        }
+        case 4u: { /* near jump */
+            if (!rm_is_memory(cpu)) biu_cycle(cpu);
+            biu_fetch_suspend(cpu);
+            biu_cycle_i(cpu, 0x0d8u, NULL);
+            cpu->pc = operand;
+            biu_queue_flush(cpu);
+            break;
+        }
+        case 5u: { /* far jump */
+            uint16_t off;
+            uint16_t seg;
+            if (rm_is_memory(cpu)) {
+                off = read_rm(cpu, true);
+                biu_cycle_i(cpu, 0x0dcu, NULL);
+                biu_fetch_suspend(cpu);
+                biu_cycle_i(cpu, 0x0ddu, NULL);
+                seg = biu_read_u16(cpu, cpu->ins.ea_segment, (uint16_t)(cpu->ins.ea + 2u));
+            } else {
+                const m808x_segment_t default_seg = cpu->ins.has_segment_override ? cpu->ins.segment_override : SEG_DS;
+                biu_cycle(cpu);
+                biu_fetch_suspend(cpu);
+                biu_cycle(cpu);
+                off = 0x0004u;
+                seg = biu_read_u16(cpu, default_seg, off);
+            }
+            cpu->segs[SEG_CS] = seg;
+            cpu->pc = off;
+            biu_queue_flush(cpu);
+            break;
+        }
+        case 6u:
+        case 7u: { /* PUSH, /7 alias */
+            CYCLES_MC(cpu, 0x024u, 0x025u, 0x026u);
+            SP = (uint16_t)(SP - 2u);
+            /* On the original 8086/8088, every encoding that reads SP as the
+             * source of PUSH observes it after the predecrement.  The generic
+             * r/m read happened earlier, so repair FF /6 and its /7 alias here. */
+            const uint16_t pushed = word && !rm_is_memory(cpu) && cpu->ins.rm == 4u ? SP : operand;
+            if (word) biu_write_u16(cpu, SEG_SS, SP, pushed); else biu_write_u8(cpu, SEG_SS, SP, (uint8_t)pushed);
+            break;
+        }
+    }
+}
+
+
+static bool execute_instruction(m808x_cpu_t *cpu)
+{
+    const uint8_t opcode = cpu->ins.opcode;
+
+    if (cpu->nx) {
+        biu_cycle_i(cpu, MC_RNI, "loaded RNI");
+        cpu->nx = false;
+    } else if (cpu->biu.queue.last_op == QOP_FIRST) {
+        biu_cycle(cpu);
+    }
+
+    if ((opcode <= 0x3du) && ((opcode & 7u) <= 5u)) {
+        if ((opcode & 7u) <= 3u) {
+            execute_alu_rm_reg(cpu, opcode);
+        } else {
+            execute_alu_acc_imm(cpu, opcode);
+        }
+        return !cpu->fatal;
+    }
+
+    if (opcode >= 0x40u && opcode <= 0x4fu) {
+        const unsigned reg = opcode & 7u;
+        set_reg16(cpu, reg, alu_incdec(cpu, get_reg16(cpu, reg), opcode >= 0x48u, true));
+        return true;
+    }
+
+    if (opcode >= 0x50u && opcode <= 0x57u) {
+        push_reg16(cpu, opcode & 7u);
+        return !cpu->fatal;
+    }
+
+    if (opcode >= 0x58u && opcode <= 0x5fu) {
+        pop_reg16(cpu, opcode & 7u);
+        return !cpu->fatal;
+    }
+
+    if (opcode >= 0x60u && opcode <= 0x7fu) {
+        const bool taken = condition_true(cpu, opcode);
+        const int8_t rel = (int8_t)queue_read(cpu, false);
+        biu_cycle_i(cpu, 0x0e9u, NULL);
+        if (taken) {
+            reljmp2(cpu, rel, true);
+        }
+        return !cpu->fatal;
+    }
+
+    if (opcode >= 0xb0u && opcode <= 0xb7u) {
+        const uint8_t imm = queue_read(cpu, false);
+        biu_cycle_i(cpu, MC_JUMP, NULL);
+        set_reg8(cpu, opcode & 7u, imm);
+        return true;
+    }
+
+    if (opcode >= 0xb8u && opcode <= 0xbfu) {
+        set_reg16(cpu, opcode & 7u, read_queue_u16(cpu));
+        return true;
+    }
+
+    switch (opcode) {
+        case 0x06u: push_segment(cpu, SEG_ES); return !cpu->fatal;
+        case 0x07u: pop_segment(cpu, SEG_ES); return !cpu->fatal;
+        case 0x0eu: push_segment(cpu, SEG_CS); return !cpu->fatal;
+        case 0x0fu: pop_segment(cpu, SEG_CS); return !cpu->fatal;
+        case 0x16u: push_segment(cpu, SEG_SS); return !cpu->fatal;
+        case 0x17u: pop_segment(cpu, SEG_SS); return !cpu->fatal;
+        case 0x1eu: push_segment(cpu, SEG_DS); return !cpu->fatal;
+        case 0x1fu: pop_segment(cpu, SEG_DS); return !cpu->fatal;
+
+        case 0x27u:
+            CYCLES_MC(cpu, 0x144u, 0x145u);
+            do_daa(cpu);
+            return true;
+        case 0x2fu:
+            CYCLES_MC(cpu, 0x144u, 0x145u);
+            do_das(cpu);
+            return true;
+        case 0x37u: do_aaa(cpu); return true;
+        case 0x3fu: do_aas(cpu); return true;
+
+        case 0x80u:
+        case 0x81u:
+        case 0x82u:
+        case 0x83u:
+            execute_group1(cpu, opcode);
+            return !cpu->fatal;
+
+        case 0x84u:
+        case 0x85u: {
+            const bool word = (opcode & 1u) != 0u;
+            const uint16_t lhs = read_rm(cpu, word);
+            const uint16_t rhs = read_reg_field(cpu, word);
+            (void)alu_binary(cpu, ALU_AND, lhs, rhs, word);
+            biu_cycle_i(cpu, 0x094u, NULL);
+            return !cpu->fatal;
+        }
+
+        case 0x86u:
+        case 0x87u: {
+            const bool word = (opcode & 1u) != 0u;
+            const uint16_t rm_value = read_rm(cpu, word);
+            const uint16_t reg_value = read_reg_field(cpu, word);
+            CYCLES_MC(cpu, 0x0a4u, 0x0a5u);
+            if (rm_is_memory(cpu)) {
+                cpu->in_lock = true;
+                CYCLES_MC(cpu, 0x0a6u, 0x0a7u);
+            }
+            write_reg_field(cpu, word, rm_value);
+            write_rm(cpu, word, reg_value);
+            return !cpu->fatal;
+        }
+
+        case 0x88u:
+        case 0x89u:
+        case 0x8au:
+        case 0x8bu:
+            execute_mov_rm_reg(cpu, opcode);
+            return !cpu->fatal;
+
+        case 0x8cu: {
+            const uint16_t value = segment_value(cpu, cpu->ins.reg);
+            if (rm_is_memory(cpu)) { ea_done_return(cpu); biu_cycle_i(cpu, 0x0ecu, NULL); }
+            write_rm(cpu, true, value);
+            return !cpu->fatal;
+        }
+
+        case 0x8du:
+            if (rm_is_memory(cpu)) ea_done_return(cpu);
+            write_reg_field(cpu, true, rm_is_memory(cpu) ? cpu->ins.ea : cpu->ea_addr);
+            return true;
+
+        case 0x8eu: {
+            const uint16_t value = read_rm(cpu, true);
+            set_segment_value(cpu, cpu->ins.reg, value);
+            return !cpu->fatal;
+        }
+
+        case 0x8fu: {
+            if (rm_is_memory(cpu)) ea_done_return(cpu);
+            biu_cycle_i(cpu, 0x040u, NULL);
+            const uint16_t value = pop_u16(cpu);
+            biu_cycle_i(cpu, 0x042u, NULL);
+            if (rm_is_memory(cpu)) CYCLES_MC(cpu, 0x043u, 0x044u);
+            write_rm(cpu, true, value);
+            return !cpu->fatal;
+        }
+
+        case 0x90u: case 0x91u: case 0x92u: case 0x93u:
+        case 0x94u: case 0x95u: case 0x96u: case 0x97u: {
+            const unsigned reg = opcode & 7u;
+            const uint16_t old_ax = AX;
+            const uint16_t old_reg = get_reg16(cpu, reg);
+            biu_cycle_i(cpu, 0x084u, NULL);
+            AX = old_reg;
+            set_reg16(cpu, reg, old_ax);
+            return true;
+        }
+
+        case 0x98u:
+            AH = (AL & 0x80u) != 0u ? 0xffu : 0u;
+            return true;
+
+        case 0x99u:
+            CYCLES_MC(cpu, 0x058u, 0x059u, 0x05au);
+            if ((AX & 0x8000u) != 0u) {
+                biu_cycle_i(cpu, MC_JUMP, NULL);
+                DX = 0xffffu;
+            } else {
+                DX = 0u;
+            }
+            return true;
+
+        case 0x9au: {
+            const uint16_t off = read_queue_u16(cpu);
+            const uint16_t seg = read_queue_u16(cpu);
+            farcall(cpu, seg, off, true);
+            return !cpu->fatal;
+        }
+
+        case 0x9bu:
+            CYCLES_MC(cpu, 0x0f8u, 0x0f9u, 0x0fau);
+            if (cpu->test_pin) cpu->waiting = true;
+            return true;
+
+        case 0x9cu:
+            CYCLES_MC(cpu, 0x030u, 0x031u, 0x032u);
+            push_u16(cpu, cpu->flags);
+            return !cpu->fatal;
+
+        case 0x9du:
+            pop_flags(cpu);
+            return !cpu->fatal;
+
+        case 0x9eu:
+            CYCLES_MC(cpu, 0x100u, 0x101u);
+            cpu->flags = (uint16_t)((cpu->flags & 0xff02u) | (AH & 0xd5u));
+            return true;
+
+        case 0x9fu:
+            AH = (uint8_t)((cpu->flags & 0xd5u) | 0x02u);
+            return true;
+
+        case 0xa0u:
+        case 0xa1u: {
+            const bool word = (opcode & 1u) != 0u;
+            const uint16_t off = read_queue_u16(cpu);
+            const m808x_segment_t seg = cpu->ins.has_segment_override ? cpu->ins.segment_override : SEG_DS;
+            if (word) AX = biu_read_u16(cpu, seg, off); else AL = biu_read_u8(cpu, seg, off);
+            return !cpu->fatal;
+        }
+
+        case 0xa2u:
+        case 0xa3u: {
+            const bool word = (opcode & 1u) != 0u;
+            const uint16_t off = read_queue_u16(cpu);
+            biu_cycle_i(cpu, 0x064u, NULL);
+            const m808x_segment_t seg = cpu->ins.has_segment_override ? cpu->ins.segment_override : SEG_DS;
+            if (word) biu_write_u16(cpu, seg, off, AX); else biu_write_u8(cpu, seg, off, AL);
+            return !cpu->fatal;
+        }
+
+        case 0xa4u: case 0xa5u: case 0xa6u: case 0xa7u:
+        case 0xaau: case 0xabu: case 0xacu: case 0xadu:
+        case 0xaeu: case 0xafu:
+            execute_string(cpu, opcode);
+            return !cpu->fatal;
+
+        case 0xa8u:
+        case 0xa9u: {
+            const bool word = (opcode & 1u) != 0u;
+            const uint16_t imm = word ? read_queue_u16(cpu) : queue_read(cpu, false);
+            if (!word) biu_cycle_i(cpu, MC_JUMP, NULL);
+            (void)alu_binary(cpu, ALU_AND, word ? AX : AL, imm, word);
+            return true;
+        }
+
+        case 0xc0u:
+        case 0xc2u:
+        case 0xc8u:
+        case 0xcau: {
+            const uint16_t release = read_queue_u16(cpu);
+            farret(cpu, (opcode & 8u) != 0u);
+            biu_cycle_i(cpu, 0x0ceu, NULL);
+            SP = (uint16_t)(SP + release);
+            return !cpu->fatal;
+        }
+
+        case 0xc1u:
+        case 0xc3u: {
+            cpu->pc = pop_u16(cpu);
+            biu_fetch_suspend(cpu);
+            biu_cycle_i(cpu, 0x0bdu, NULL);
+            biu_queue_flush(cpu);
+            CYCLES_MC(cpu, 0x0beu, 0x0bfu);
+            return !cpu->fatal;
+        }
+
+        case 0xc4u:
+        case 0xc5u: {
+            uint16_t off;
+            uint16_t seg;
+            if (rm_is_memory(cpu)) {
+                /* EALOAD has already obtained the offset word before the LES/LDS
+                 * micro-routine; only the segment word at EA+2 is read here. */
+                off = read_rm(cpu, true);
+                CYCLES_MC(cpu, opcode == 0xc4u ? 0x0f0u : 0x0f4u,
+                               opcode == 0xc4u ? 0x0f1u : 0x0f5u);
+                seg = biu_read_u16(cpu, cpu->ins.ea_segment, (uint16_t)(cpu->ins.ea + 2u));
+            } else {
+                /* Invalid register form follows the uninitialised IND path.
+                 * A fresh core has last-EA zero; retain ea_addr as that latch. */
+                CYCLES_MC(cpu, opcode == 0xc4u ? 0x0f0u : 0x0f4u,
+                               opcode == 0xc4u ? 0x0f1u : 0x0f5u);
+                const m808x_segment_t dseg = cpu->ins.has_segment_override ? cpu->ins.segment_override : SEG_DS;
+                off = biu_read_u16(cpu, dseg, cpu->ea_addr);
+                seg = biu_read_u16(cpu, dseg, (uint16_t)(cpu->ea_addr + 2u));
+            }
+            write_reg_field(cpu, true, off);
+            cpu->segs[opcode == 0xc4u ? SEG_ES : SEG_DS] = seg;
+            return !cpu->fatal;
+        }
+
+        case 0xc6u:
+        case 0xc7u: {
+            const bool word = (opcode & 1u) != 0u;
+            /* Write-only ModR/M operands take EADONE before the immediate
+             * bytes are consumed by the instruction micro-routine. */
+            if (rm_is_memory(cpu)) ea_done_return(cpu);
+            const uint16_t imm = word ? read_queue_u16(cpu) : queue_read(cpu, false);
+            if (!word) biu_cycle_i(cpu, MC_JUMP, NULL);
+            if (rm_is_memory(cpu)) biu_cycle_i(cpu, 0x016u, NULL);
+            write_rm(cpu, word, imm);
+            return !cpu->fatal;
+        }
+
+        case 0xc9u:
+        case 0xcbu:
+            biu_cycle_i(cpu, 0x0c0u, NULL);
+            farret(cpu, true);
+            return !cpu->fatal;
+
+        case 0xccu:
+            CYCLES_MC(cpu, 0x1b1u, 0x1b2u, MC_JUMP);
+            software_interrupt(cpu, 3u);
+            return !cpu->fatal;
+
+        case 0xcdu: {
+            const uint8_t vector = queue_read(cpu, false);
+            software_interrupt(cpu, vector);
+            return !cpu->fatal;
+        }
+
+        case 0xceu:
+            if ((cpu->flags & V_FLAG) != 0u) {
+                CYCLES_MC(cpu, 0x1acu, 0x1adu, MC_JUMP, 0x1afu);
+                software_interrupt(cpu, 4u);
+            } else {
+                CYCLES_MC(cpu, 0x1acu, 0x1adu);
+            }
+            return !cpu->fatal;
+
+        case 0xcfu:
+            biu_cycle_i(cpu, 0x0c8u, NULL);
+            farret(cpu, true);
+            pop_flags(cpu);
+            biu_cycle_i(cpu, 0x0cau, NULL);
+            m808x_86box_iret_complete();
+            return !cpu->fatal;
+
+        case 0xd0u:
+        case 0xd1u:
+        case 0xd2u:
+        case 0xd3u:
+            execute_shift_group(cpu, opcode);
+            return !cpu->fatal;
+
+        case 0xd4u: {
+            const uint8_t base = queue_read(cpu, false);
+            CYCLES_MC(cpu, 0x175u, 0x176u, MC_JUMP);
+            const m808x_cord_result_t aam_cord = cord_cycles(cpu, 8u, 0u, base, AL);
+            if (!aam_cord.ok) {
+                divide_interrupt(cpu);
+                return !cpu->fatal;
+            }
+            AH = (uint8_t)(AL / base);
+            AL = (uint8_t)(AL % base);
+            biu_cycle_i(cpu, 0x177u, NULL);
+            set_szp8(cpu, AL);
+            cpu->flags &= (uint16_t)~(A_FLAG | C_FLAG | V_FLAG);
+            return true;
+        }
+
+        case 0xd5u: {
+            const uint8_t base = queue_read(cpu, false);
+            CYCLES_MC(cpu, 0x170u, 0x171u, MC_JUMP);
+            const mul_tmp_t aad_product = mul_corx_cycles(cpu, 8u, AH, base, false);
+            /* AAD's final ADD is F-marked.  It replaces CORX's C/A/O with
+             * those from AL + product, then the following microflow leaves
+             * S/Z/P from the final AL value. */
+            AL = (uint8_t)alu_binary(cpu, ALU_ADD, AL, aad_product.c, false);
+            AH = 0u;
+            CYCLES_MC(cpu, 0x172u, 0x173u);
+            set_szp8(cpu, AL);
+            return true;
+        }
+
+        case 0xd6u:
+            biu_cycle_i(cpu, 0x0a0u, NULL);
+            if ((cpu->flags & C_FLAG) != 0u) {
+                biu_cycle_i(cpu, MC_JUMP, NULL);
+                AL = 0xffu;
+            } else {
+                AL = 0u;
+            }
+            return true;
+
+        case 0xd7u: {
+            const m808x_segment_t seg = cpu->ins.has_segment_override ? cpu->ins.segment_override : SEG_DS;
+            CYCLES_MC(cpu, 0x10cu, 0x10du, 0x10eu);
+            AL = biu_read_u8(cpu, seg, (uint16_t)(BX + AL));
+            return !cpu->fatal;
+        }
+
+        case 0xd8u: case 0xd9u: case 0xdau: case 0xdbu:
+        case 0xdcu: case 0xddu: case 0xdeu: case 0xdfu:
+            if (rm_is_memory(cpu)) (void)read_rm(cpu, true);
+            m808x_86box_export_arch_state(cpu);
+            m808x_86box_fpu_exec(opcode, cpu->ins.modrm, cpu->ins.ea,
+                                 (uint8_t)cpu->ins.ea_segment);
+            m808x_86box_import_register_state(cpu);
+            return !cpu->fatal;
+
+        case 0xe0u:
+        case 0xe1u: {
+            CX = (uint16_t)(CX - 1u);
+            CYCLES_MC(cpu, 0x138u, 0x139u);
+            const int8_t rel = (int8_t)queue_read(cpu, false);
+            const bool is_loope = (opcode & 1u) != 0u;
+            const bool zf = (cpu->flags & Z_FLAG) != 0u;
+            if (is_loope != zf) {
+                biu_cycle_i(cpu, MC_JUMP, NULL);
+            } else if (CX != 0u) {
+                biu_cycle_i(cpu, 0x13bu, NULL);
+                reljmp2(cpu, rel, true);
+            }
+            return !cpu->fatal;
+        }
+
+        case 0xe2u: {
+            CX = (uint16_t)(CX - 1u);
+            CYCLES_MC(cpu, 0x140u, 0x141u);
+            const int8_t rel = (int8_t)queue_read(cpu, false);
+            if (CX != 0u) reljmp2(cpu, rel, true); else biu_cycle(cpu);
+            return !cpu->fatal;
+        }
+
+        case 0xe3u: {
+            CYCLES_MC(cpu, 0x134u, 0x135u);
+            const int8_t rel = (int8_t)queue_read(cpu, false);
+            if (CX != 0u) biu_cycle_i(cpu, MC_JUMP, NULL); else { biu_cycle_i(cpu, 0x137u, NULL); reljmp2(cpu, rel, true); }
+            return !cpu->fatal;
+        }
+
+        case 0xe4u:
+        case 0xe5u: {
+            const uint8_t port = queue_read(cpu, false);
+            biu_cycle_i(cpu, 0x0adu, NULL);
+            if (opcode & 1u) AX = biu_io_read_u16(cpu, port); else AL = biu_io_read_u8(cpu, port);
+            return !cpu->fatal;
+        }
+
+        case 0xe6u:
+        case 0xe7u: {
+            const uint8_t port = queue_read(cpu, false);
+            CYCLES_MC(cpu, 0x0b1u, 0x0b2u);
+            if (opcode & 1u) biu_io_write_u16(cpu, port, AX); else biu_io_write_u8(cpu, port, AL);
+            return !cpu->fatal;
+        }
+
+        case 0xe8u: {
+            const int16_t rel = (int16_t)read_queue_u16(cpu);
+            biu_fetch_suspend(cpu);
+            CYCLES_MC(cpu, 0x07eu, 0x07fu);
+            corr(cpu);
+            biu_cycle_i(cpu, 0x080u, NULL);
+            const uint16_t return_ip = cpu->pc;
+            cpu->pc = (uint16_t)(cpu->pc + rel);
+            biu_queue_flush(cpu);
+            CYCLES_MC(cpu, 0x081u, 0x082u, MC_JUMP);
+            push_u16(cpu, return_ip);
+            return !cpu->fatal;
+        }
+
+        case 0xe9u:
+            reljmp2(cpu, (int16_t)read_queue_u16(cpu), false);
+            return !cpu->fatal;
+
+        case 0xeau: {
+            const uint16_t off = read_queue_u16(cpu);
+            const uint16_t seg = read_queue_u16(cpu);
+            biu_fetch_suspend(cpu);
+            CYCLES_MC(cpu, 0x0e4u, 0x0e5u);
+            cpu->segs[SEG_CS] = seg;
+            cpu->pc = off;
+            biu_queue_flush(cpu);
+            biu_cycle_i(cpu, 0x0e6u, NULL);
+            return !cpu->fatal;
+        }
+
+        case 0xebu:
+            reljmp2(cpu, (int8_t)queue_read(cpu, false), true);
+            return !cpu->fatal;
+
+        case 0xecu:
+        case 0xedu:
+            if (opcode & 1u) AX = biu_io_read_u16(cpu, DX); else AL = biu_io_read_u8(cpu, DX);
+            return !cpu->fatal;
+
+        case 0xeeu:
+        case 0xefu:
+            biu_cycle_i(cpu, 0x0b8u, NULL);
+            if (opcode & 1u) biu_io_write_u16(cpu, DX, AX); else biu_io_write_u8(cpu, DX, AL);
+            return !cpu->fatal;
+
+        case 0xf4u:
+            biu_bus_wait_halt(cpu);
+            biu_fetch_halt(cpu);
+            biu_bus_wait_finish(cpu);
+            if (cpu->intr_pin && (cpu->flags & I_FLAG) != 0u) {
+                CYCLES_MC(cpu, MC_JUMP, 0x1f0u);
+            } else {
+                cpu->halted = true;
+                biu_halt(cpu);
+            }
+            return !cpu->fatal;
+
+        case 0xf5u: cpu->flags ^= C_FLAG; return true;
+
+        case 0xf6u:
+        case 0xf7u:
+            execute_group3(cpu, opcode);
+            return !cpu->fatal;
+
+        case 0xf8u: cpu->flags &= (uint16_t)~C_FLAG; return true;
+        case 0xf9u: cpu->flags |= C_FLAG; return true;
+        case 0xfau: cpu->flags &= (uint16_t)~I_FLAG; return true;
+        case 0xfbu:
+            cpu->flags |= I_FLAG;
+            cpu->interrupt_shadow = 1u;
+            return true;
+        case 0xfcu: cpu->flags &= (uint16_t)~D_FLAG; return true;
+        case 0xfdu: cpu->flags |= D_FLAG; return true;
+
+        case 0xfeu:
+        case 0xffu:
+            execute_group45(cpu, opcode);
+            return !cpu->fatal;
+
+        default:
+            fprintf(stderr, "internal decode hole for opcode %02X at %04X:%04X\n",
+                    opcode, cpu->segs[SEG_CS], cpu->ins.instruction_ip);
+            cpu->fatal = true;
+            return false;
+    }
+}
+
+
+static void finish_instruction(m808x_cpu_t *cpu)
+{
+    bool interrupt_blocked = false;
+    bool trap_blocked = false;
+    if (cpu->interrupt_shadow > 0u) {
+        cpu->interrupt_shadow--;
+        interrupt_blocked = true;
+    }
+    if (cpu->trap_shadow > 0u) {
+        cpu->trap_shadow--;
+        trap_blocked = true;
+    }
+    const bool trap_pending = !trap_blocked &&
+        (((cpu->flags & T_FLAG) != 0u) || cpu->trap_disable_delay != 0u);
+    if (cpu->trap_disable_delay > 0u) {
+        cpu->trap_disable_delay--;
+    }
+
+    if (cpu->nmi_pin) {
+        cpu->interrupt_vector = 2u;
+        hardware_interrupt(cpu, false);
+    } else if (cpu->intr_pin && (cpu->flags & I_FLAG) != 0u && !interrupt_blocked) {
+        hardware_interrupt(cpu, true);
+    } else if (trap_pending) {
+        CYCLES_MC(cpu, 0x198u, MC_JUMP);
+        interrupt_routine(cpu, 1u, true);
+    } else if (!cpu->halted && !cpu->waiting) {
+        biu_fetch_next(cpu);
+    }
+
+    cpu->in_lock = false;
+    cpu->rep_prefix = 0u;
+}
+
+static void reset_cpu(m808x_cpu_t *cpu)
+{
+    memset(cpu->regs, 0, sizeof(cpu->regs));
+    cpu->flags = 0xf002u;
+    cpu->segs[SEG_ES] = 0u;
+    cpu->segs[SEG_CS] = 0xffffu;
+    cpu->segs[SEG_SS] = 0u;
+    cpu->segs[SEG_DS] = 0u;
+    cpu->pc = 0u;
+    cpu->ea_seg = SEG_DS;
+    cpu->mc_line = MC_NONE;
+
+    memset(&cpu->biu, 0, sizeof(cpu->biu));
+    cpu->biu.t_cycle = T_I;
+    cpu->biu.ta_cycle = TA_DONE;
+    cpu->biu.bus_status = BUS_PASSIVE;
+    cpu->biu.bus_status_latch = BUS_PASSIVE;
+    cpu->biu.pl_status = BUS_PASSIVE;
+    cpu->biu.bus_segment = SEG_NONE;
+    cpu->biu.fetch.kind = FETCH_SUSPENDED;
+    queue_reset(&cpu->biu.queue, cpu->is_8086);
+
+    /* Intel specifies RESET high for at least four clocks. The two additional
+     * internal clocks retain the original test harness's measured startup
+     * sequence before FLUSH launches the first reset-vector fetch. */
+    for (unsigned i = 0; i < 6u; i++) {
+        biu_cycle_i(cpu, MC_NONE, "RESET");
+    }
+    biu_queue_flush(cpu);
+}
+
+
+/* -------------------------------------------------------------------------
+ * 86Box ABI adapter
+ * ------------------------------------------------------------------------- */
+
+static m808x_cpu_t m808x_cpu;
+static bool m808x_initialized = false;
+static bool m808x_suppress_host_cycles = false;
+static int m808x_restore_pfq_pos = -1;
+static uint16_t m808x_restore_pfq_ip = 0u;
+static bool m808x_restore_pfq_ip_valid = false;
+
+static uint16_t m808x_arch_ip(void)
+{
+    return architectural_ip(&m808x_cpu);
+}
+
+bool m808x_86box_should_use(void)
+{
+    static int cached = -1;
+    if (cached < 0) {
+        const char *legacy = getenv("86BOX_LEGACY_808X");
+        cached = (legacy && *legacy && strcmp(legacy, "0") != 0) ? 0 : 1;
+    }
+    return cached != 0 && !is186 && !is_nec;
+}
+
+bool m808x_86box_active(void)
+{
+    return m808x_initialized && m808x_86box_should_use();
+}
+
+static void m808x_host_cycle(void)
+{
+    if (m808x_suppress_host_cycles)
+        return;
+
+    cpu_state._cycles--;
+    tsc += ((uint64_t)xt_cpu_multi >> 32ULL);
+    if (TIMER_VAL_LESS_THAN_VAL(timer_target, (uint64_t)tsc))
+        timer_process();
+}
+
+static bool m808x_host_override_vector(uint8_t vector, uint16_t *ip, uint16_t *seg)
+{
+    if (vector == 2u && use_custom_nmi_vector) {
+        *ip = (uint16_t)(custom_nmi_vector & 0xffffu);
+        *seg = (uint16_t)(custom_nmi_vector >> 16);
+        return true;
+    }
+    return false;
+}
+
+static void m808x_set_seg(x86seg *dst, uint16_t selector)
+{
+    dst->seg = selector;
+    dst->base = (uint32_t)selector << 4;
+    dst->limit = 0xffffu;
+    dst->limit_low = 0u;
+    dst->limit_high = 0xffffu;
+    dst->access = 0;
+    dst->ar_high = 0;
+    dst->checked = 1;
+}
+
+void m808x_86box_export_arch_state(const m808x_cpu_t *cpu)
+{
+    for (unsigned i = 0; i < 8u; ++i)
+        cpu_state.regs[i].w = cpu->regs[i].x;
+
+    cpu_state.flags = (uint16_t)((cpu->flags & 0x0fd7u) | 0x0002u);
+    m808x_set_seg(&cpu_state.seg_es, cpu->segs[SEG_ES]);
+    m808x_set_seg(&cpu_state.seg_cs, cpu->segs[SEG_CS]);
+    m808x_set_seg(&cpu_state.seg_ss, cpu->segs[SEG_SS]);
+    m808x_set_seg(&cpu_state.seg_ds, cpu->segs[SEG_DS]);
+    cpu_state.pc = architectural_ip(cpu);
+    cpu_state.eaaddr = cpu->ea_addr;
+    in_lock = cpu->in_lock ? 1 : 0;
+    pfq_pos = (int)queue_effective_len(&cpu->biu.queue);
+}
+
+void m808x_86box_import_register_state(m808x_cpu_t *cpu)
+{
+    for (unsigned i = 0; i < 8u; ++i)
+        cpu->regs[i].x = cpu_state.regs[i].w;
+    cpu->flags = (uint16_t)((cpu_state.flags & 0x0fd7u) | 0xf002u);
+}
+
+static void m808x_import_arch_state(void)
+{
+    m808x_86box_import_register_state(&m808x_cpu);
+    m808x_cpu.segs[SEG_ES] = cpu_state.seg_es.seg;
+    m808x_cpu.segs[SEG_CS] = cpu_state.seg_cs.seg;
+    m808x_cpu.segs[SEG_SS] = cpu_state.seg_ss.seg;
+    m808x_cpu.segs[SEG_DS] = cpu_state.seg_ds.seg;
+
+    const uint16_t external_ip = cpu_state.pc;
+    if (external_ip != m808x_arch_ip()) {
+        m808x_cpu.pc = external_ip;
+        biu_fetch_suspend(&m808x_cpu);
+        biu_queue_flush(&m808x_cpu);
+    }
+}
+
+static void m808x_update_input_pins(void)
+{
+    m808x_cpu.intr_pin = pic.int_pending != 0;
+    m808x_cpu.nmi_pin = nmi && nmi_enable && nmi_mask;
+    m808x_cpu.test_pin = m808x_86box_fpu_busy();
+}
+
+static void m808x_consume_host_nmi(void)
+{
+    nmi_enable = 0;
+#ifndef OLD_NMI_BEHAVIOR
+    nmi = 0;
+#endif
+}
+
+void m808x_86box_reset(int hard)
+{
+    (void)hard;
+    memset(&m808x_cpu, 0, sizeof(m808x_cpu));
+    m808x_cpu.cycle_limit = UINT64_MAX;
+    m808x_cpu.is_8086 = is8086 != 0;
+    m808x_cpu.trace = false;
+    m808x_cpu.stop_on_halt = false;
+    m808x_cpu.interrupt_vector = 8u;
+    m808x_cpu.configured_wait_states = is_mazovia ? 1u : 0u;
+
+    m808x_in_host_bus_callback = false;
+#ifdef M808X_86BOX_TESTING
+    m808x_test_captured_wait_clocks = 0;
+    m808x_test_tw_clocks = 0;
+#endif
+
+    /* reset_cpu() emits internal clocks; clear stale external DMA state first. */
+    m808x_dma_state = M808X_DMA_IDLE;
+    m808x_dma_req = false;
+    m808x_dma_holda = false;
+    m808x_dma_ack = false;
+    m808x_dma_aen = false;
+    m808x_dma_operating_cycle = 0u;
+    m808x_dma_wait_states = 0u;
+    m808x_dma_wait_target = 6u;
+    m808x_dma_ack_callback = NULL;
+    m808x_dma_ack_opaque = NULL;
+
+    m808x_suppress_host_cycles = true;
+    reset_cpu(&m808x_cpu);
+    m808x_suppress_host_cycles = false;
+    m808x_cpu.cycle_num = 0u;
+    m808x_cpu.instruction_count = 0u;
+    m808x_restore_pfq_pos = -1;
+    m808x_restore_pfq_ip = 0u;
+    m808x_restore_pfq_ip_valid = false;
+    m808x_initialized = true;
+
+    rammask = 0xfffffu;
+    use_custom_nmi_vector = 0u;
+    custom_nmi_vector = 0u;
+    m808x_86box_export_arch_state(&m808x_cpu);
+}
+
+void m808x_86box_wait(int clocks, int bus)
+{
+    (void)bus;
+    if (!m808x_86box_active() || clocks <= 0)
+        return;
+    for (int i = 0; i < clocks; ++i)
+        biu_cycle(&m808x_cpu);
+}
+
+void m808x_86box_external_sub_cycles(int clocks)
+{
+    if (clocks <= 0)
+        return;
+
+    if (m808x_in_host_bus_callback) {
+        /* biu_do_bus_transfer() captures this deduction and converts it to
+         * clocked Tw states, so do not also advance TSC here. */
+        cpu_state._cycles -= clocks;
+        return;
+    }
+
+    /* This path is retained for the rare out-of-band caller.  Bus callbacks
+     * use the captured path above, including handlers that modify cycles
+     * directly rather than calling sub_cycles(). */
+    cpu_state._cycles -= clocks;
+    tsc += (uint64_t)clocks * ((uint64_t)xt_cpu_multi >> 32ULL);
+    if (TIMER_VAL_LESS_THAN_VAL(timer_target, (uint64_t)tsc))
+        timer_process();
+}
+
+bool
+m808x_86box_dma_try_request_ex(unsigned wait_clocks,
+                               void (*ack_callback)(void *opaque),
+                               void *opaque)
+{
+    if (!m808x_86box_active() || wait_clocks == 0u)
+        return false;
+
+    /* Before DACK, req/callback identify the current level request and suppress
+     * duplicate PIT edges. DACK clears both before invoking the callback, so a
+     * new edge during S3/S4/release is a valid pending request. */
+    if (m808x_dma_req || m808x_dma_ack_callback != NULL)
+        return false;
+
+    m808x_dma_wait_target = wait_clocks;
+    m808x_dma_ack_callback = ack_callback;
+    m808x_dma_ack_opaque = opaque;
+    m808x_dma_req = true;
+    return true;
+}
+
+bool
+m808x_86box_dma_cancel_request_ex(void (*ack_callback)(void *opaque),
+                                  void *opaque)
+{
+    if (!m808x_86box_active())
+        return false;
+    if (m808x_dma_ack || m808x_dma_holda || !m808x_dma_req)
+        return false;
+    if (m808x_dma_ack_callback != ack_callback ||
+        m808x_dma_ack_opaque != opaque)
+        return false;
+
+    m808x_dma_req = false;
+    m808x_dma_ack_callback = NULL;
+    m808x_dma_ack_opaque = NULL;
+    m808x_dma_wait_target = 6u;
+    if (m808x_dma_state == M808X_DMA_DREQ ||
+        m808x_dma_state == M808X_DMA_HRQ)
+        m808x_dma_state = M808X_DMA_IDLE;
+    return true;
+}
+
+void m808x_86box_dma_request_ex(unsigned wait_clocks,
+                                void (*ack_callback)(void *opaque),
+                                void *opaque)
+{
+    (void)m808x_86box_dma_try_request_ex(wait_clocks, ack_callback, opaque);
+}
+
+void m808x_86box_dma_request(unsigned wait_clocks)
+{
+    m808x_86box_dma_request_ex(wait_clocks, NULL, NULL);
+}
+
+void m808x_86box_refresh(void)
+{
+    /* Measured PC/XT refresh DMAWAIT is six effective clocks. */
+    m808x_86box_dma_request(6u);
+}
+
+uint64_t
+m808x_86box_cycle_number(void)
+{
+    return m808x_86box_active() ? m808x_cpu.cycle_num : 0u;
+}
+
+void m808x_86box_iret_complete(void)
+{
+    nmi_enable = 1;
+}
+
+void m808x_86box_exec(int32_t cycs)
+{
+    if (!m808x_initialized)
+        m808x_86box_reset(1);
+
+    cpu_state._cycles += cycs;
+    m808x_import_arch_state();
+
+    while (cpu_state._cycles > 0 && !m808x_cpu.fatal) {
+        m808x_update_input_pins();
+
+        if (m808x_cpu.waiting) {
+            if (!m808x_cpu.test_pin) {
+                m808x_cpu.waiting = false;
+            } else {
+                biu_cycle_i(&m808x_cpu, 0x0fbu, "WAIT idle");
+                m808x_86box_export_arch_state(&m808x_cpu);
+                continue;
+            }
+        }
+
+        if (m808x_cpu.halted) {
+            if (m808x_cpu.nmi_pin) {
+                /* Unlike the normal instruction-boundary path, HLT wake-up
+                 * bypasses finish_instruction(), so set the architectural NMI
+                 * vector here instead of reusing a stale INTR/software vector. */
+                m808x_cpu.interrupt_vector = 2u;
+                hardware_interrupt(&m808x_cpu, false);
+                m808x_consume_host_nmi();
+                biu_fetch_next(&m808x_cpu);
+            } else if (m808x_cpu.intr_pin && (m808x_cpu.flags & I_FLAG) != 0u) {
+                hardware_interrupt(&m808x_cpu, true);
+                biu_fetch_next(&m808x_cpu);
+            } else {
+                biu_cycle_i(&m808x_cpu, MC_NONE, "HALTED");
+            }
+            m808x_86box_export_arch_state(&m808x_cpu);
+            continue;
+        }
+
+        cpu_state.oldpc = m808x_arch_ip();
+        if (!decode_instruction(&m808x_cpu))
+            break;
+        opcode = m808x_cpu.ins.opcode;
+        if (!execute_instruction(&m808x_cpu))
+            break;
+        ++m808x_cpu.instruction_count;
+
+        const bool nmi_was_pending = m808x_cpu.nmi_pin;
+        finish_instruction(&m808x_cpu);
+        if (nmi_was_pending && !m808x_cpu.nmi_pin)
+            m808x_consume_host_nmi();
+        m808x_86box_export_arch_state(&m808x_cpu);
+
+#ifdef USE_GDBSTUB
+        if (gdbstub_instruction())
+            break;
+#endif
+    }
+
+    m808x_86box_export_arch_state(&m808x_cpu);
+}
+
+void m808x_86box_interrupt(uint16_t vector)
+{
+    if (!m808x_86box_active())
+        return;
+    software_interrupt(&m808x_cpu, (uint8_t)vector);
+    m808x_86box_export_arch_state(&m808x_cpu);
+}
+
+static void m808x_rebuild_saved_prefetch_queue(void)
+{
+    if (!m808x_86box_active() || m808x_restore_pfq_pos < 0 || !m808x_restore_pfq_ip_valid)
+        return;
+
+    const unsigned max_len = m808x_cpu.is_8086 ? 6u : 4u;
+    const unsigned len = (unsigned)m808x_restore_pfq_pos > max_len
+        ? max_len : (unsigned)m808x_restore_pfq_pos;
+    uint16_t arch_ip = cpu_state.pc;
+
+    /* A normal queue snapshot satisfies fetch_ip - architectural_ip == len.
+     * If an older state file did not restore PC first, derive the start from
+     * the two queue fields instead. */
+    if ((uint16_t)(m808x_restore_pfq_ip - arch_ip) != (uint16_t)len)
+        arch_ip = (uint16_t)(m808x_restore_pfq_ip - (uint16_t)len);
+
+    queue_flush(&m808x_cpu.biu.queue);
+    for (unsigned i = 0; i < len; ++i) {
+        const uint32_t addr = linear_address(m808x_cpu.segs[SEG_CS], (uint16_t)(arch_ip + i));
+        (void)queue_push(&m808x_cpu.biu.queue, read_mem_b(addr));
+    }
+    m808x_cpu.pc = m808x_restore_pfq_ip;
+}
+
+void m808x_86box_pfq_set_pos(int pos)
+{
+    if (!m808x_86box_active())
+        return;
+    m808x_restore_pfq_pos = pos < 0 ? 0 : pos;
+    m808x_rebuild_saved_prefetch_queue();
+}
+
+void m808x_86box_pfq_set_ip(uint16_t ip)
+{
+    if (!m808x_86box_active())
+        return;
+    m808x_restore_pfq_ip = ip;
+    m808x_restore_pfq_ip_valid = true;
+    m808x_cpu.pc = ip;
+    m808x_rebuild_saved_prefetch_queue();
+}
+
+void m808x_86box_pfq_set_prefetching(int enabled)
+{
+    if (!m808x_86box_active())
+        return;
+    m808x_cpu.biu.fetch.kind = enabled ? FETCH_NORMAL : FETCH_SUSPENDED;
+}
+
+int m808x_86box_pfq_get_pos(void)
+{
+    return m808x_86box_active() ? (int)queue_effective_len(&m808x_cpu.biu.queue) : 0;
+}
+
+uint16_t m808x_86box_pfq_get_ip(void)
+{
+    return m808x_86box_active() ? m808x_cpu.pc : 0u;
+}
+
+int m808x_86box_pfq_get_prefetching(void)
+{
+    return m808x_86box_active() && fetch_enabled(&m808x_cpu);
+}
+
+int m808x_86box_pfq_get_size(void)
+{
+    return m808x_cpu.is_8086 ? 6 : 4;
+}
+
+#ifdef M808X_86BOX_TESTING
+bool m808x_86box_test_halted(void)
+{
+    return m808x_86box_active() && m808x_cpu.halted;
+}
+
+uint64_t m808x_86box_test_captured_wait_clocks(void)
+{
+    return m808x_test_captured_wait_clocks;
+}
+
+uint64_t m808x_86box_test_tw_clocks(void)
+{
+    return m808x_test_tw_clocks;
+}
+
+unsigned m808x_86box_test_dma_state(void)
+{
+    return (unsigned)m808x_dma_state;
+}
+
+unsigned m808x_86box_test_dma_wait_states(void)
+{
+    return m808x_dma_wait_states;
+}
+
+bool m808x_86box_test_dma_holda(void)
+{
+    return m808x_dma_holda;
+}
+
+bool m808x_86box_test_dma_ack(void)
+{
+    return m808x_dma_ack;
+}
+
+bool m808x_86box_test_dma_aen(void)
+{
+    return m808x_dma_aen;
+}
+
+unsigned m808x_86box_test_t_cycle(void)
+{
+    return (unsigned)m808x_cpu.biu.t_cycle;
+}
+
+unsigned m808x_86box_test_bus_status(void)
+{
+    return (unsigned)m808x_cpu.biu.bus_status;
+}
+#endif

--- a/src/cpu/808x_marty_86box.h
+++ b/src/cpu/808x_marty_86box.h
@@ -1,0 +1,56 @@
+#ifndef EMU_808X_MARTY_86BOX_H
+#define EMU_808X_MARTY_86BOX_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+bool m808x_86box_should_use(void);
+bool m808x_86box_active(void);
+
+void m808x_86box_reset(int hard);
+void m808x_86box_exec(int32_t cycs);
+void m808x_86box_refresh(void);
+void m808x_86box_dma_request(unsigned wait_clocks);
+void m808x_86box_dma_request_ex(unsigned wait_clocks,
+                                void (*ack_callback)(void *opaque),
+                                void *opaque);
+bool m808x_86box_dma_try_request_ex(unsigned wait_clocks,
+                                    void (*ack_callback)(void *opaque),
+                                    void *opaque);
+bool m808x_86box_dma_cancel_request_ex(void (*ack_callback)(void *opaque),
+                                       void *opaque);
+uint64_t m808x_86box_cycle_number(void);
+void m808x_86box_wait(int clocks, int bus);
+void m808x_86box_external_sub_cycles(int clocks);
+void m808x_86box_interrupt(uint16_t vector);
+void m808x_86box_iret_complete(void);
+
+void m808x_86box_pfq_set_pos(int pos);
+void m808x_86box_pfq_set_ip(uint16_t ip);
+void m808x_86box_pfq_set_prefetching(int enabled);
+int m808x_86box_pfq_get_pos(void);
+uint16_t m808x_86box_pfq_get_ip(void);
+int m808x_86box_pfq_get_prefetching(void);
+int m808x_86box_pfq_get_size(void);
+
+#ifdef M808X_86BOX_TESTING
+bool m808x_86box_test_halted(void);
+uint64_t m808x_86box_test_captured_wait_clocks(void);
+uint64_t m808x_86box_test_tw_clocks(void);
+unsigned m808x_86box_test_dma_state(void);
+unsigned m808x_86box_test_dma_wait_states(void);
+bool m808x_86box_test_dma_holda(void);
+bool m808x_86box_test_dma_ack(void);
+bool m808x_86box_test_dma_aen(void);
+unsigned m808x_86box_test_t_cycle(void);
+unsigned m808x_86box_test_bus_status(void);
+#endif
+
+/* Implemented in 86Box's legacy 808x translation unit so the existing 8087
+ * operation tables remain available while CPU timing is supplied by the new
+ * EU/BIU core. */
+void m808x_86box_fpu_exec(uint8_t opcode, uint8_t modrm,
+                           uint16_t ea, uint8_t segment_index);
+bool m808x_86box_fpu_busy(void);
+
+#endif

--- a/src/cpu/CMakeLists.txt
+++ b/src/cpu/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(cpu OBJECT
     cpu_table.c
     fpu.c x86.c
     808x.c
+    808x_marty_86box.c
     vx0.c
     vx0_biu.c
     386.c

--- a/src/dma.c
+++ b/src/dma.c
@@ -19,6 +19,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <string.h>
 #include <wchar.h>
 #define HAVE_STDARG_H
@@ -31,6 +32,7 @@
 #include <86box/io.h>
 #include <86box/pic.h>
 #include <86box/dma.h>
+#include "808x_marty_86box.h"
 #include <86box/plat_unused.h>
 
 dma_t   dma[8];
@@ -60,6 +62,251 @@ static struct dma_ps2_t {
     int is_ps2;
 } dma_ps2;
 
+/* 86BOX_XT8237_EXACT_INSTALLER_V1
+ * NOCONA_XT_DMA_CONSOLIDATED_V1
+ *
+ * Cycle-aware Intel 8237 path for 8088/8086 PC/XT-class machines.
+ *
+ * The public 86Box DMA API is peripheral-pull rather than pin-clocked, so the
+ * controller cannot expose every intermediate S0-S4 bus state. This state
+ * machine nevertheless preserves the externally observable 8237 semantics:
+ * request arbitration, fixed/rotating priority, demand/single/block service,
+ * software requests, terminal count, EOP, auto-init, verify, address wrapping,
+ * masks, status, the temporary register, and XT bus occupancy.
+ */
+typedef struct dma_xt8237_state_t {
+    uint8_t sw_request;
+    uint8_t demand_active;
+    uint8_t block_active;
+    uint8_t external_eop;
+    uint8_t last_service;
+    uint8_t temp;
+    uint8_t dack;
+    uint8_t in_mem_to_mem;
+} dma_xt8237_state_t;
+
+static dma_xt8237_state_t dma_xt8237;
+
+/* 86BOX_MACHINE_EXACT_V1: PIT1 request latch, cleared by DACK0. */
+static bool dma_xt_refresh_queued = false;
+static bool dma_xt_refresh_scheduled = false;
+static void dma_xt_refresh_try_schedule(void);
+static void dma_xt_refresh_reconcile(void);
+
+static int dma_xt8237_mem_to_mem(void);
+
+static int
+dma_xt8237_active(void)
+{
+    return !dma_at && !dma_advanced && !dma_ps2.is_ps2;
+}
+
+static uint8_t
+dma_xt8237_raw_requests(void)
+{
+    return (dma_stat_rq_pc | dma_xt8237.sw_request) & 0x0f;
+}
+
+static uint8_t
+dma_xt8237_service_requests(void)
+{
+    return (dma_xt8237_raw_requests() |
+            dma_xt8237.demand_active |
+            dma_xt8237.block_active) & 0x0f;
+}
+
+static int
+dma_xt8237_priority_pick(uint8_t requests)
+{
+    int i;
+    uint8_t owner;
+
+    requests &= (uint8_t) ~(dma_m & 0x0f);
+    requests &= dma_e & 0x0f;
+
+    if (!requests || (dma_command[0] & 0x04))
+        return -1;
+
+    owner = requests &
+            (dma_xt8237.demand_active | dma_xt8237.block_active);
+    if (owner) {
+        for (i = 0; i < 4; i++) {
+            if (owner & (1 << i))
+                return i;
+        }
+    }
+
+    if (dma_command[0] & 0x10) {
+        for (i = 1; i <= 4; i++) {
+            int channel = (dma_xt8237.last_service + i) & 3;
+            if (requests & (1 << channel))
+                return channel;
+        }
+    } else {
+        for (i = 0; i < 4; i++) {
+            if (requests & (1 << i))
+                return i;
+        }
+    }
+
+    return -1;
+}
+
+static int
+dma_xt8237_can_service(int channel)
+{
+    uint8_t requests;
+
+    if ((channel < 0) || (channel > 3))
+        return 0;
+    if (dma_command[0] & 0x04)
+        return 0;
+    if (!(dma_e & (1 << channel)))
+        return 0;
+    if (dma_m & (1 << channel))
+        return 0;
+
+    requests = dma_xt8237_service_requests();
+
+    /*
+     * Channel 0 refresh is the only request whose arbitration and DACK phase
+     * are driven by the clocked Marty 8088 adapter. Existing 86Box devices
+     * still use a synchronous peripheral-pull API: by the time a floppy,
+     * sound, or storage device calls dma_channel_read/write(), that call
+     * already represents its effective DACK/data phase and cannot be rejected
+     * and retried later.
+     *
+     * Do not let another queued hardware request (especially PIT refresh on
+     * channel 0) make a synchronous channel 1-3 callback return DMA_NODATA.
+     * Software requests retain actual 8237 priority arbitration.
+     */
+    if ((channel != 0) && !dma_req_is_soft)
+        requests &= (uint8_t) (1u << channel);
+
+    if (!(requests & (1u << channel)))
+        return 0;
+    if (((dma[channel].mode >> 6) & 3) == 3)
+        return 0;
+
+    return dma_xt8237_priority_pick(requests) == channel;
+}
+
+static void
+dma_xt8237_release_owner(int channel)
+{
+    uint8_t bit = 1 << channel;
+
+    dma_xt8237.demand_active &= ~bit;
+    dma_xt8237.block_active &= ~bit;
+    dma_xt8237.dack &= ~bit;
+
+    if (dma_command[0] & 0x10)
+        dma_xt8237.last_service = channel;
+}
+
+static void
+dma_xt8237_begin_service(int channel)
+{
+    uint8_t bit = 1 << channel;
+    int service_mode = (dma[channel].mode >> 6) & 3;
+
+    dma_xt8237.dack = bit;
+
+    if (service_mode == 0)
+        dma_xt8237.demand_active |= bit;
+    else if (service_mode == 2)
+        dma_xt8237.block_active |= bit;
+}
+
+static void
+dma_xt8237_charge_bus(int channel)
+{
+    if (channel == 0) {
+        /* The exact Marty adapter owns HOLD/HLDA and DMAWAIT. Calling
+         * refreshread() here would add a second fixed four-clock charge. */
+        if (!m808x_86box_active())
+            is_nec ? refreshread_vx0() : refreshread();
+    } else {
+        /* Peripheral APIs remain synchronous. Preserve their established
+         * occupancy until their data phases can be deferred to DACK. */
+        sub_cycles((dma_command[0] & 0x08) ? 4 : 5);
+    }
+}
+
+
+static void
+dma_xt8237_advance_address(int channel)
+{
+    dma_t *dma_c = &dma[channel];
+
+    if (dma_c->mode & 0x20)
+        dma_c->ac = (dma_c->ac & 0xffff0000 & dma_mask) |
+                    ((dma_c->ac - 1) & 0xffff);
+    else
+        dma_c->ac = (dma_c->ac & 0xffff0000 & dma_mask) |
+                    ((dma_c->ac + 1) & 0xffff);
+}
+
+static int
+dma_xt8237_finish_transfer(int channel)
+{
+    dma_t *dma_c = &dma[channel];
+    uint8_t bit = 1 << channel;
+    int service_mode = (dma_c->mode >> 6) & 3;
+    int terminal = 0;
+
+    dma_c->cc--;
+    if (dma_c->cc < 0)
+        terminal = 1;
+    if (dma_xt8237.external_eop & bit)
+        terminal = 1;
+
+    if (terminal) {
+        dma_stat |= bit;
+        dma_xt8237.sw_request &= ~bit;
+        dma_xt8237.external_eop &= ~bit;
+        dma_stat_adv_pend &= ~bit;
+
+        if (dma_c->mode & 0x10) {
+            dma_c->cc = dma_c->cb;
+            dma_c->ac = dma_c->ab;
+        } else {
+            dma_m |= bit;
+        }
+
+        dma_xt8237_release_owner(channel);
+        return 1;
+    }
+
+    if (service_mode == 1) {
+        dma_xt8237.dack &= ~bit;
+        if (dma_command[0] & 0x10)
+            dma_xt8237.last_service = channel;
+    }
+
+    return 0;
+}
+
+static void
+dma_xt8237_master_clear(void)
+{
+    dma_wp[0] = 0;
+    dma_command[0] = 0;
+    dma_stat &= 0xf0;
+    dma_stat_rq &= 0xf0;
+    dma_stat_adv_pend &= 0xf0;
+    dma_m |= 0x0f;
+
+    memset(&dma_xt8237, 0, sizeof(dma_xt8237));
+    dma_xt8237.last_service = 3;
+
+    /* Master clear resets the 8237, not external DREQ pins. Keep the physical
+     * request bitmap and PIT1 latch intact; the caller reconciles/cancels any
+     * pre-DACK CPU arbitration after masks and command state have changed. */
+    if (dma_xt_refresh_queued)
+        dma_stat_rq_pc |= 0x01;
+}
+
 #define DMA_PS2_IOA            (1 << 0)
 #define DMA_PS2_AUTOINIT       (1 << 1)
 #define DMA_PS2_XFER_MEM_TO_IO (1 << 2)
@@ -88,18 +335,53 @@ dma_log(const char *fmt, ...)
 
 static void dma_ps2_run(int channel);
 
+
 int
 dma_get_drq(int channel)
 {
+    if ((channel < 0) || (channel > 7))
+        return 0;
     return !!(dma_stat_rq_pc & (1 << channel));
 }
+
 
 void
 dma_set_drq(int channel, int set)
 {
-    dma_stat_rq_pc &= ~(1 << channel);
+    uint8_t bit;
+
+    if ((channel < 0) || (channel > 7))
+        return;
+
+    bit = 1 << channel;
+    dma_stat_rq_pc &= ~bit;
     if (set)
-        dma_stat_rq_pc |= (1 << channel);
+        dma_stat_rq_pc |= bit;
+
+    if (dma_xt8237_active() && (channel < 4) && !set &&
+        (dma_xt8237.demand_active & bit)) {
+        dma_xt8237_release_owner(channel);
+    }
+
+    /* A request/owner change may make refresh serviceable or invalidate a
+     * pre-DACK schedule. Reconcile both directions, not only retries. */
+    if (dma_xt8237_active() && dma_xt_refresh_queued)
+        dma_xt_refresh_reconcile();
+}
+
+void
+dma_set_eop(int channel, int set)
+{
+    uint8_t bit;
+
+    if ((channel < 0) || (channel > 3))
+        return;
+
+    bit = 1 << channel;
+    if (set)
+        dma_xt8237.external_eop |= bit;
+    else
+        dma_xt8237.external_eop &= ~bit;
 }
 
 static int
@@ -419,7 +701,7 @@ dma_ext_mode_write(uint16_t addr, uint8_t val, UNUSED(void *priv))
 
     dma[channel].ext_mode = val & 0x7c;
 
-    switch ((val > 2) & 0x03) {
+    switch ((val >> 2) & 0x03) {
         case 0x00:
             dma[channel].transfer_mode = 0x0101;
             break;
@@ -447,14 +729,129 @@ dma_sg_int_status_read(UNUSED(uint16_t addr), UNUSED(void *priv))
 
     for (uint8_t i = 0; i < 8; i++) {
         if (i != 4)
-            ret = (!!(dma[i].sg_status & 8)) << i;
+            ret |= (!!(dma[i].sg_status & 8)) << i;
     }
 
     return ret;
 }
 
+
+static uint8_t dma_read_legacy(uint16_t addr, void *priv);
+static void dma_write_legacy(uint16_t addr, uint8_t val, void *priv);
+
 static uint8_t
-dma_read(uint16_t addr, UNUSED(void *priv))
+dma_read(uint16_t addr, void *priv)
+{
+    uint8_t ret;
+
+    if (!dma_xt8237_active())
+        return dma_read_legacy(addr, priv);
+
+    switch (addr & 0x0f) {
+        case 0x08:
+            ret = (dma_xt8237_raw_requests() << 4) | (dma_stat & 0x0f);
+            dma_stat &= ~0x0f;
+            return ret;
+
+        case 0x0d:
+            return dma_xt8237.temp;
+
+        default:
+            return dma_read_legacy(addr, priv);
+    }
+}
+
+static void
+dma_write(uint16_t addr, uint8_t val, void *priv)
+{
+    int channel;
+    uint8_t bit;
+
+    if (!dma_xt8237_active()) {
+        dma_write_legacy(addr, val, priv);
+        return;
+    }
+
+    dmaregs[0][addr & 0x0f] = val;
+
+    switch (addr & 0x0f) {
+        case 0x08:
+            dma_command[0] = val;
+            if (val & 0x04) {
+                dma_xt8237.demand_active = 0;
+                dma_xt8237.block_active = 0;
+                dma_xt8237.dack = 0;
+            }
+            break;
+
+        case 0x09:
+            channel = val & 3;
+            bit = (uint8_t)(1u << channel);
+            if (val & 4) {
+                dma_xt8237.sw_request |= bit;
+                if ((channel == 0) && (dma_command[0] & 0x01))
+                    (void)dma_xt8237_mem_to_mem();
+                else
+                    dma_block_transfer(channel);
+            } else {
+                dma_xt8237.sw_request &= (uint8_t)~bit;
+                if (dma_xt8237.demand_active & bit)
+                    dma_xt8237_release_owner(channel);
+            }
+            break;
+
+        case 0x0a:
+            channel = val & 3;
+            bit = (uint8_t)(1u << channel);
+            if (val & 4) {
+                dma_m |= bit;
+                dma_xt8237_release_owner(channel);
+            } else {
+                dma_m &= (uint8_t)~bit;
+            }
+            break;
+
+        case 0x0b:
+            channel = val & 3;
+            bit = (uint8_t)(1u << channel);
+            dma[channel].mode = val;
+            dma_xt8237.demand_active &= (uint8_t)~bit;
+            dma_xt8237.block_active &= (uint8_t)~bit;
+            dma_xt8237.external_eop &= (uint8_t)~bit;
+            dma_xt8237.dack &= (uint8_t)~bit;
+            break;
+
+        case 0x0c:
+            dma_wp[0] = 0;
+            break;
+
+        case 0x0d:
+            dma_xt8237_master_clear();
+            break;
+
+        case 0x0e:
+            dma_m &= 0xf0;
+            break;
+
+        case 0x0f:
+            dma_m = (dma_m & 0xf0) | (val & 0x0f);
+            dma_xt8237.demand_active &= (uint8_t)~dma_m;
+            dma_xt8237.block_active &= (uint8_t)~dma_m;
+            dma_xt8237.dack &= (uint8_t)~dma_m;
+            break;
+
+        default:
+            dma_write_legacy(addr, val, priv);
+            break;
+    }
+
+    /* The previous dispatcher returned from every arm, so its refresh retry
+     * was unreachable. Reconcile after every programming write. */
+    dma_xt_refresh_reconcile();
+}
+
+static uint8_t
+dma_read_legacy(uint16_t addr, UNUSED(void *priv))
 {
     int     channel = (addr >> 1) & 3;
     int     count;
@@ -505,7 +902,7 @@ dma_read(uint16_t addr, UNUSED(void *priv))
 }
 
 static void
-dma_write(uint16_t addr, uint8_t val, UNUSED(void *priv))
+dma_write_legacy(uint16_t addr, uint8_t val, UNUSED(void *priv))
 {
     int channel = (addr >> 1) & 3;
 
@@ -1071,8 +1468,8 @@ dma_high_page_write(uint16_t addr, uint8_t val, UNUSED(void *priv))
     if (addr < 8) {
         dma[addr].page_h = val;
 
-        dma[addr].ab = ((dma[addr].ab & 0xffffff) | (dma[addr].page << 24)) & dma_mask;
-        dma[addr].ac = ((dma[addr].ac & 0xffffff) | (dma[addr].page << 24)) & dma_mask;
+        dma[addr].ab = ((dma[addr].ab & 0xffffff) | (dma[addr].page_h << 24)) & dma_mask;
+        dma[addr].ac = ((dma[addr].ac & 0xffffff) | (dma[addr].page_h << 24)) & dma_mask;
     }
 }
 
@@ -1120,7 +1517,7 @@ dma_set_at(uint8_t at)
 }
 
 void
-dma_reset(void)
+dma_reset_legacy(void)
 {
     int c;
 
@@ -1220,6 +1617,22 @@ dma_high_page_init(void)
 {
     io_sethandler(0x0480, 8,
                   dma_high_page_read, NULL, NULL, dma_high_page_write, NULL, NULL, NULL);
+}
+
+
+void
+dma_reset(void)
+{
+    dma_reset_legacy();
+
+    dma_command[0] = dma_command[1] = 0;
+    memset(&dma_xt8237, 0, sizeof(dma_xt8237));
+    dma_xt8237.last_service = 3;
+    dma_xt_refresh_queued = false;
+    dma_xt_refresh_scheduled = false;
+
+    if (!dma_at)
+        dma_m = (dma_m & 0xf0) | 0x0f;
 }
 
 void
@@ -1433,7 +1846,7 @@ dma_retreat(dma_t *dma_c)
 {
     int as = dma_c->transfer_mode >> 8;
 
-    if (dma->sg_status & 1) {
+    if (dma_c->sg_status & 1) {
         dma_c->ac = (dma_c->ac - as) & dma_mask;
 
         dma_c->page = dma_c->page_l = (dma_c->ac >> 16) & 0xff;
@@ -1449,7 +1862,7 @@ dma_advance(dma_t *dma_c)
 {
     int as = dma_c->transfer_mode >> 8;
 
-    if (dma->sg_status & 1) {
+    if (dma_c->sg_status & 1) {
         dma_c->ac = (dma_c->ac + as) & dma_mask;
 
         dma_c->page = dma_c->page_l = (dma_c->ac >> 16) & 0xff;
@@ -1460,8 +1873,304 @@ dma_advance(dma_t *dma_c)
         dma_c->ac = ((dma_c->ac & 0xffff0000) & dma_mask) | ((dma_c->ac + as) & 0xffff);
 }
 
+
+static int dma_channel_readable_legacy(int channel);
+static int dma_channel_read_only_legacy(int channel);
+static int dma_channel_advance_legacy(int channel);
+static int dma_channel_read_legacy(int channel);
+static int dma_channel_write_legacy(int channel, uint16_t val);
+
+static int
+dma_xt8237_mem_to_mem(void)
+{
+    dma_t *source = &dma[0];
+    dma_t *dest = &dma[1];
+    int terminal = 0;
+
+    if (dma_xt8237.in_mem_to_mem)
+        return 0;
+    if (!(dma_command[0] & 0x01))
+        return 0;
+    if (!dma_xt8237_can_service(0))
+        return 0;
+
+    dma_xt8237.in_mem_to_mem = 1;
+    dma_xt8237_begin_service(0);
+
+    do {
+        sub_cycles((dma_command[0] & 0x08) ? 8 : 10);
+        dma_xt8237.temp = _dma_read(source->ac, source);
+        _dma_write(dest->ac, dma_xt8237.temp, dest);
+
+        if (!(dma_command[0] & 0x02))
+            dma_xt8237_advance_address(0);
+        dma_xt8237_advance_address(1);
+
+        dest->cc--;
+        if ((dest->cc < 0) || (dma_xt8237.external_eop & 0x02)) {
+            terminal = 1;
+            dma_stat |= 0x02;
+            dma_xt8237.external_eop &= ~0x02;
+            dma_xt8237.sw_request &= ~0x01;
+
+            if (dest->mode & 0x10) {
+                dest->cc = dest->cb;
+                dest->ac = dest->ab;
+                source->ac = source->ab;
+            } else {
+                dma_m |= 0x02;
+            }
+
+            dma_xt8237_release_owner(0);
+        }
+    } while (!terminal &&
+             (((source->mode >> 6) & 3) == 2) &&
+             dma_xt8237_can_service(0));
+
+    if (((source->mode >> 6) & 3) == 1)
+        dma_xt8237_release_owner(0);
+
+    dma_xt8237.in_mem_to_mem = 0;
+    return terminal;
+}
+
 int
 dma_channel_readable(int channel)
+{
+    int type;
+
+    if (!dma_xt8237_active())
+        return dma_channel_readable_legacy(channel);
+
+    if (!dma_xt8237_can_service(channel))
+        return 0;
+
+    type = dma[channel].mode & 0x0c;
+    return (type == 0x08) || (type == 0x00);
+}
+
+
+/* Execute the channel-0 address-only refresh transfer at physical DACK0. */
+static void
+dma_xt_refresh_dack(void *opaque)
+{
+    (void)opaque;
+
+    if (!m808x_86box_active()) {
+        /* Legacy CPU paths receive their established refresh charge through
+         * dma_channel_read(0). */
+        (void)dma_channel_read(0);
+    } else {
+        /* PC/XT DRAM refresh is RAS/address-only. The Marty CPU already owns
+         * HOLD/HLDA/DMAWAIT; do not perform a fake host memory read or charge
+         * a second synthetic bus delay. */
+        if (dma_stat_adv_pend & 0x01)
+            (void)dma_channel_advance(0);
+
+        dma_xt8237_begin_service(0);
+        dma_xt8237_advance_address(0);
+        dma_stat_rq |= 0x01;
+        dma_stat_adv_pend &= (uint8_t)~0x01;
+        (void)dma_xt8237_finish_transfer(0);
+    }
+
+    /* DACK0 resets the external request latch. Clear queue state before the
+     * DRQ helper reconciles, so the falling edge cannot resubmit this transfer. */
+    dma_xt_refresh_queued = false;
+    dma_xt_refresh_scheduled = false;
+    dma_set_drq(0, 0);
+}
+
+static void
+dma_xt_refresh_try_schedule(void)
+{
+    if (!dma_xt_refresh_queued || dma_xt_refresh_scheduled)
+        return;
+    if (!dma_xt8237_active() || !dma_xt8237_can_service(0))
+        return;
+
+    if (m808x_86box_active()) {
+        if (m808x_86box_dma_try_request_ex(6u, dma_xt_refresh_dack, NULL))
+            dma_xt_refresh_scheduled = true;
+    } else {
+        dma_xt_refresh_scheduled = true;
+        dma_xt_refresh_dack(NULL);
+    }
+}
+
+static void
+dma_xt_refresh_reconcile(void)
+{
+    const bool serviceable = dma_xt_refresh_queued &&
+                             dma_xt8237_active() &&
+                             dma_xt8237_can_service(0);
+
+    if (dma_xt_refresh_scheduled && !serviceable &&
+        m808x_86box_active()) {
+        if (m808x_86box_dma_cancel_request_ex(dma_xt_refresh_dack, NULL))
+            dma_xt_refresh_scheduled = false;
+    }
+
+    if (serviceable && !dma_xt_refresh_scheduled)
+        dma_xt_refresh_try_schedule();
+}
+
+void
+dma_xt_refresh_request(void)
+{
+    /* PIT1 sets an external request latch; DACK0 clears it. Repeated PIT edges
+     * while the latch is already set do not accumulate transfers. */
+    if (!dma_xt_refresh_queued) {
+        dma_xt_refresh_queued = true;
+        /* dma_set_drq() performs the first reconciliation. */
+        dma_set_drq(0, 1);
+    } else {
+        dma_xt_refresh_reconcile();
+    }
+}
+
+int
+dma_channel_read_only(int channel)
+{
+    dma_t *dma_c;
+    int temp;
+    int type;
+
+    if (!dma_xt8237_active())
+        return dma_channel_read_only_legacy(channel);
+
+    if (!dma_xt8237_can_service(channel))
+        return DMA_NODATA;
+
+    type = dma[channel].mode & 0x0c;
+    if ((type != 0x08) && (type != 0x00))
+        return DMA_NODATA;
+
+    if (dma_stat_adv_pend & (1 << channel))
+        (void) dma_channel_advance(channel);
+
+    dma_c = &dma[channel];
+    dma_xt8237_begin_service(channel);
+    dma_xt8237_charge_bus(channel);
+
+    if (type == 0x00)
+        temp = DMA_VERIFY;
+    else
+        temp = _dma_read(dma_c->ac, dma_c);
+
+    dma_xt8237_advance_address(channel);
+    dma_stat_rq |= 1 << channel;
+    dma_stat_adv_pend |= 1 << channel;
+
+    return temp;
+}
+
+int
+dma_channel_advance(int channel)
+{
+    int tc = 0;
+
+    if (!dma_xt8237_active())
+        return dma_channel_advance_legacy(channel);
+
+    if ((channel < 0) || (channel > 3))
+        return 0;
+
+    if (dma_stat_adv_pend & (1 << channel)) {
+        dma_stat_adv_pend &= ~(1 << channel);
+        tc = dma_xt8237_finish_transfer(channel);
+    }
+
+    if ((channel != 0) && dma_xt_refresh_queued)
+        dma_xt_refresh_reconcile();
+
+    return tc;
+}
+
+int
+dma_channel_read(int channel)
+{
+    dma_t *dma_c;
+    int temp;
+    int type;
+    int tc;
+
+    if (!dma_xt8237_active())
+        return dma_channel_read_legacy(channel);
+
+    if ((channel < 0) || (channel > 3))
+        return DMA_NODATA;
+
+    if (dma_stat_adv_pend & (1 << channel))
+        (void) dma_channel_advance(channel);
+
+    if (!dma_xt8237_can_service(channel))
+        return DMA_NODATA;
+
+    type = dma[channel].mode & 0x0c;
+    if ((type != 0x08) && (type != 0x00))
+        return DMA_NODATA;
+
+    dma_c = &dma[channel];
+    dma_xt8237_begin_service(channel);
+    dma_xt8237_charge_bus(channel);
+
+    if (type == 0x00)
+        temp = DMA_VERIFY;
+    else
+        temp = _dma_read(dma_c->ac, dma_c);
+
+    dma_xt8237_advance_address(channel);
+    dma_stat_rq |= 1 << channel;
+    tc = dma_xt8237_finish_transfer(channel);
+
+    if ((channel != 0) && dma_xt_refresh_queued)
+        dma_xt_refresh_reconcile();
+
+    if (tc)
+        return temp | DMA_OVER;
+    return temp;
+}
+
+int
+dma_channel_write(int channel, uint16_t val)
+{
+    dma_t *dma_c;
+    int type;
+    int tc;
+
+    if (!dma_xt8237_active())
+        return dma_channel_write_legacy(channel, val);
+
+    if ((channel < 0) || (channel > 3))
+        return DMA_NODATA;
+    if (!dma_xt8237_can_service(channel))
+        return DMA_NODATA;
+
+    type = dma[channel].mode & 0x0c;
+    if ((type != 0x04) && (type != 0x00))
+        return DMA_NODATA;
+
+    dma_c = &dma[channel];
+    dma_xt8237_begin_service(channel);
+    dma_xt8237_charge_bus(channel);
+
+    if (type == 0x04)
+        _dma_write(dma_c->ac, val & 0xff, dma_c);
+
+    dma_xt8237_advance_address(channel);
+    dma_stat_rq |= 1 << channel;
+    dma_stat_adv_pend &= ~(1 << channel);
+    tc = dma_xt8237_finish_transfer(channel);
+
+    if ((channel != 0) && dma_xt_refresh_queued)
+        dma_xt_refresh_reconcile();
+
+    return tc ? DMA_OVER : 0;
+}
+
+int
+dma_channel_readable_legacy(int channel)
 {
     dma_t   *dma_c = &dma[channel];
     int      ret = 1;
@@ -1485,7 +2194,7 @@ dma_channel_readable(int channel)
 }
 
 int
-dma_channel_read_only(int channel)
+dma_channel_read_only_legacy(int channel)
 {
     dma_t   *dma_c = &dma[channel];
     uint16_t temp;
@@ -1556,7 +2265,7 @@ dma_channel_read_only(int channel)
 }
 
 int
-dma_channel_advance(int channel)
+dma_channel_advance_legacy(int channel)
 {
     dma_t   *dma_c = &dma[channel];
     int      tc = 0;
@@ -1591,7 +2300,7 @@ dma_channel_advance(int channel)
 }
 
 int
-dma_channel_read(int channel)
+dma_channel_read_legacy(int channel)
 {
     dma_t   *dma_c = &dma[channel];
     uint16_t temp;
@@ -1686,7 +2395,7 @@ dma_channel_read(int channel)
 }
 
 int
-dma_channel_write(int channel, uint16_t val)
+dma_channel_write_legacy(int channel, uint16_t val)
 {
     dma_t *dma_c = &dma[channel];
 
@@ -1733,7 +2442,6 @@ dma_channel_write(int channel, uint16_t val)
                 dma_retreat(dma_c);
             else
                 dma_c->ac = (dma_c->ac & 0xfffe0000 & dma_mask) | ((dma_c->ac - 2) & 0x1ffff);
-            dma_c->ac = (dma_c->ac & 0xfffe0000 & dma_mask) | ((dma_c->ac - 2) & 0x1ffff);
         } else {
             if (dma_ps2.is_ps2)
                 dma_c->ac += 2;

--- a/src/include/86box/dma.h
+++ b/src/include/86box/dma.h
@@ -93,6 +93,7 @@ extern void writedma2(uint8_t temp);
 
 extern int  dma_get_drq(int channel);
 extern void dma_set_drq(int channel, int set);
+extern void dma_set_eop(int channel, int set);
 
 extern int dma_channel_read_only(int channel);
 extern int dma_channel_advance(int channel);
@@ -119,5 +120,7 @@ void dma_remove_sg(void);
 void dma_set_sg_base(uint8_t sg_base);
 
 extern int dma_channel_readable(int channel);
+
+extern void dma_xt_refresh_request(void);
 
 #endif /*EMU_DMA_H*/

--- a/src/include/86box/pit.h
+++ b/src/include/86box/pit.h
@@ -16,6 +16,8 @@
 #ifndef EMU_PIT_H
 #define EMU_PIT_H
 
+#include <86box/pit_exact.h>
+
 #define NUM_COUNTERS 3
 
 typedef struct ctr_t {
@@ -66,6 +68,7 @@ typedef struct PIT {
     int        flags;
     int        clock;
     pc_timer_t callback_timer;
+    pitx_device_t exact; /* pin-clocked 8253/8254 state */
 
     ctr_t counters[NUM_COUNTERS];
 

--- a/src/include/86box/pit_exact.h
+++ b/src/include/86box/pit_exact.h
@@ -1,0 +1,72 @@
+/*
+ * Derived from Intel 8253/8254 documentation
+ */
+#ifndef EMU_PIT_EXACT_H
+#define EMU_PIT_EXACT_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef enum pitx_type_t {
+    PITX_8253 = 0,
+    PITX_8254 = 1
+} pitx_type_t;
+
+typedef enum pitx_state_t {
+    PITX_WAIT_COUNT = 0,
+    PITX_WAIT_TRIGGER,
+    PITX_WAIT_GATE,
+    PITX_LOAD_NEXT,
+    PITX_COUNTING,
+    PITX_RELOAD_NEXT,
+    PITX_STROBE_RECOVER,
+    PITX_DONE
+} pitx_state_t;
+
+typedef struct pitx_channel_t {
+    pitx_type_t type;
+    uint8_t control;
+    uint8_t mode_raw;
+    uint8_t mode;
+    uint8_t rw_mode;
+    bool bcd;
+
+    uint8_t write_phase;
+    uint8_t read_phase;
+    bool count_latched;
+    bool status_latched;
+    uint16_t output_latch;
+    uint8_t status_latch;
+
+    uint16_t count_register;
+    uint32_t counting_element; /* 0x10000 represents binary zero reload. */
+    bool null_count;
+    bool gate;
+    bool output;
+    bool armed;
+    bool initial_load;
+    bool incomplete_reload;
+    bool ce_undefined;
+    bool toggle_on_reload;
+    pitx_state_t state;
+    uint64_t clocks;
+} pitx_channel_t;
+
+typedef struct pitx_device_t {
+    pitx_type_t type;
+    pitx_channel_t channel[3];
+    uint8_t last_control;
+} pitx_device_t;
+
+void pitx_init(pitx_device_t *pit, pitx_type_t type);
+void pitx_reset(pitx_device_t *pit, pitx_type_t type);
+void pitx_control_write(pitx_device_t *pit, uint8_t value);
+void pitx_data_write(pitx_device_t *pit, unsigned channel, uint8_t value);
+uint8_t pitx_data_read(pitx_device_t *pit, unsigned channel);
+void pitx_set_gate(pitx_device_t *pit, unsigned channel, bool gate);
+void pitx_tick(pitx_device_t *pit);
+void pitx_tick_channel(pitx_device_t *pit, unsigned channel);
+uint16_t pitx_get_count(const pitx_device_t *pit, unsigned channel);
+bool pitx_get_output(const pitx_device_t *pit, unsigned channel);
+
+#endif

--- a/src/pit.c
+++ b/src/pit.c
@@ -18,6 +18,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 #include <wchar.h>
@@ -111,323 +112,115 @@ ctr_set_out(ctr_t *ctr, int out, void *priv)
     ctr->out = out;
 }
 
-static void
-ctr_decrease_count(ctr_t *ctr)
+
+/* 86BOX_MACHINE_EXACT_V1
+ * NOCONA_PIT_EXACT_CONSOLIDATED_V1
+ * Bridge the public PIT API to the pin-clocked core. */
+static pitx_type_t
+pit_exact_type(const pit_t *pit)
 {
-    if (ctr->bcd) {
-        ctr->units--;
-        if (ctr->units == -1) {
-            ctr->units = -7;
-            ctr->tens--;
-            if (ctr->tens == -1) {
-                ctr->tens = -7;
-                ctr->hundreds--;
-                if (ctr->hundreds == -1) {
-                    ctr->hundreds = -7;
-                    ctr->thousands--;
-                    if (ctr->thousands == -1) {
-                        ctr->thousands = -7;
-                        ctr->myriads--;
-                        if (ctr->myriads == -1)
-                            ctr->myriads = -7; /* 0 - 1 should wrap around to 9999. */
-                    }
-                }
-            }
-        }
-    } else
-        ctr->count = (ctr->count - 1) & 0xffff;
+    return (pit->flags & PIT_8254) ? PITX_8254 : PITX_8253;
+}
+
+static unsigned
+pit_exact_index(const pit_t *pit, const ctr_t *ctr)
+{
+    const ptrdiff_t index = ctr - pit->counters;
+    return (index >= 0 && index < NUM_COUNTERS) ? (unsigned)index : 0u;
+}
+
+static int
+pit_exact_bcd_count(uint16_t value)
+{
+    if (value == 0)
+        return 10000;
+    return ((value >> 12) & 0x0f) * 1000 +
+           ((value >> 8) & 0x0f) * 100 +
+           ((value >> 4) & 0x0f) * 10 + (value & 0x0f);
 }
 
 static void
-ctr_load_count(ctr_t *ctr)
+pit_exact_sync_channel(pit_t *pit, unsigned index)
 {
-    int l = ctr->l ? ctr->l : 0x10000;
+    pitx_channel_t *x = &pit->exact.channel[index];
+    ctr_t *ctr = &pit->counters[index];
+    const int new_out = x->output ? 1 : 0;
+    ctr->ctrl = x->control;
+    ctr->m = x->mode;
+    ctr->bcd = x->bcd ? 1 : 0;
+    ctr->l = x->count_register;
+    ctr->lback = ctr->lback2 = ctr->l;
+    ctr->count = (x->counting_element == 0x10000u) ? 0x10000 : (int)x->counting_element;
+    ctr->null_count = x->null_count ? 1 : 0;
+    ctr->gate = x->gate ? 1 : 0;
+    ctr->state = (int)x->state;
+    ctr->rm = (int)x->rw_mode | (x->read_phase ? 0x80 : 0);
+    ctr->wm = (int)x->rw_mode | (x->write_phase ? 0x80 : 0);
+    ctr->rl = x->output_latch;
+    ctr->latched = x->count_latched ? ((x->rw_mode == 3u) ? (x->read_phase ? 1 : 2) : 1) : 0;
+    ctr->read_status = x->status_latch;
+    ctr->do_read_status = x->status_latched ? 1 : 0;
+    ctr->incomplete = x->incomplete_reload ? 1 : 0;
+    if (ctr->out != new_out)
+        ctr_set_out(ctr, new_out, pit);
+}
 
-    ctr->count = l;
-    pit_log("ctr->count = %i\n", l);
-    ctr->null_count = 0;
-    ctr->newcount   = !!(l & 1);
+static void
+pit_exact_sync_all(pit_t *pit)
+{
+    for (unsigned i = 0; i < NUM_COUNTERS; ++i)
+        pit_exact_sync_channel(pit, i);
+}
 
-    /* Undocumented feature - writing MSB after reload after writing LSB causes an instant reload. */
-    ctr->incomplete = !!(ctr->wm & 0x80);
+static void
+pit_exact_notify_load(pit_t *pit, unsigned index)
+{
+    ctr_t *ctr = &pit->counters[index];
+    const pitx_channel_t *x = &pit->exact.channel[index];
+    if (ctr->load_func == NULL)
+        return;
+    const int count = x->bcd ? pit_exact_bcd_count(x->count_register)
+                             : (x->count_register ? x->count_register : 0x10000);
+    ctr->load_func(x->mode, count);
 }
 
 static void
 ctr_tick(ctr_t *ctr, void *priv)
 {
     pit_t *pit = (pit_t *)priv;
-    uint8_t state = ctr->state;
-
-    if ((state & 0x03) == 0x01) {
-        /* This is true for all modes */
-        ctr_load_count(ctr);
-        ctr->state++;
-        if (((ctr->m & 0x07) == 0x01) && (ctr->state == 2))
-            ctr_set_out(ctr, 0, pit);
-    } else  switch (ctr->m & 0x07) {
-        case 0:
-            /* Interrupt on terminal count */
-            switch (state) {
-                case 2:
-                    if (ctr->gate && (ctr->count >= 1)) {
-                        ctr_decrease_count(ctr);
-                        if (ctr->count < 1) {
-                            ctr->state = 3;
-                            ctr_set_out(ctr, 1, pit);
-                        }
-                    }
-                    break;
-                case 3:
-                    ctr_decrease_count(ctr);
-                    break;
-
-                default:
-                    break;
-            }
-            break;
-        case 1:
-            /* Hardware retriggerable one-shot */
-            switch (state) {
-                case 2:
-                    if (ctr->count >= 1) {
-                        ctr_decrease_count(ctr);
-                        if (ctr->count < 1) {
-                            ctr->state = 3;
-                            ctr_set_out(ctr, 1, pit);
-                        }
-                    }
-                    break;
-                case 3:
-                case 6:
-                    ctr_decrease_count(ctr);
-                    break;
-
-                default:
-                    break;
-            }
-            break;
-        case 2:
-        case 6:
-            /* Rate generator */
-            switch (state) {
-                case 3:
-                    ctr_load_count(ctr);
-                    ctr->state = 2;
-                    ctr_set_out(ctr, 1, pit);
-                    break;
-                case 2:
-                    if (ctr->gate == 0)
-                        break;
-                    else if (ctr->count >= 2) {
-                        ctr_decrease_count(ctr);
-                        if (ctr->count < 2) {
-                            ctr->state = 3;
-                            ctr_set_out(ctr, 0, pit);
-                        }
-                    }
-                    break;
-
-                default:
-                    break;
-            }
-            break;
-        case 3:
-        case 7:
-            /* Square wave mode */
-            switch (state) {
-                case 2:
-                    if (ctr->gate == 0)
-                        break;
-                    else if (ctr->count >= 0) {
-                        if (ctr->bcd) {
-                            ctr_decrease_count(ctr);
-                            if (!ctr->newcount)
-                                ctr_decrease_count(ctr);
-                        } else
-                            ctr->count -= (ctr->newcount ? 1 : 2);
-                        if (ctr->count == 0) {
-                            ctr_set_out(ctr, 0, pit);
-                            ctr_load_count(ctr);
-                            ctr->state = 3;
-                        } else if (ctr->newcount)
-                            ctr->newcount = 0;
-                    }
-                    break;
-                case 3:
-                    if (ctr->gate == 0)
-                        break;
-                    else if (ctr->count >= 0) {
-                        if (ctr->bcd) {
-                            ctr_decrease_count(ctr);
-                            ctr_decrease_count(ctr);
-                            if (ctr->newcount)
-                                ctr_decrease_count(ctr);
-                        } else
-                            ctr->count -= (ctr->newcount ? 3 : 2);
-                        if (ctr->count == 0) {
-                            ctr_set_out(ctr, 1, pit);
-                            ctr_load_count(ctr);
-                            ctr->state = 2;
-                        } else if (ctr->newcount)
-                            ctr->newcount = 0;
-                    }
-                    break;
-
-                default:
-                    break;
-            }
-            break;
-        case 4:
-        case 5:
-            /* Software triggered strobe */
-            /* Hardware triggered strobe */
-            if ((ctr->gate != 0) || (ctr->m != 4)) {
-                switch (state) {
-                    case 0:
-                    case 6:
-                        ctr_decrease_count(ctr);
-                        break;
-                    case 2:
-                        if (ctr->count >= 1) {
-                            ctr_decrease_count(ctr);
-                            if (ctr->count < 1) {
-                                ctr->state = 3;
-                                ctr_set_out(ctr, 0, pit);
-                            }
-                        }
-                        break;
-                    case 3:
-                        ctr->state = 0;
-                        ctr_set_out(ctr, 1, pit);
-                        break;
-
-                    default:
-                        break;
-                }
-            }
-            break;
-        default:
-            break;
-    }
+    const unsigned index = pit_exact_index(pit, ctr);
+    pitx_tick_channel(&pit->exact, index);
+    pit_exact_sync_channel(pit, index);
 }
+
 
 void
 ctr_clock(void *data, int counter_id)
 {
-    pit_t *pit = (pit_t *) data;
+    pit_t *pit = (pit_t *)data;
     ctr_t *ctr = &pit->counters[counter_id];
-
-    /* FIXME: Is this even needed? */
-    if ((ctr->state == 3) && (ctr->m != 2) && (ctr->m != 3))
-        return;
-
     if (ctr->using_timer)
         return;
-
-    ctr_tick(ctr, pit);
+    pitx_tick_channel(&pit->exact, (unsigned)counter_id);
+    pit_exact_sync_channel(pit, (unsigned)counter_id);
 }
 
-static void
-ctr_set_state_1(ctr_t *ctr)
-{
-    uint8_t mode = (ctr->m & 0x03);
-    int do_reload = !!ctr->incomplete || (mode == 0) || (ctr->state == 0);
- 
-    ctr->incomplete = 0;
-
-    if (do_reload)
-        ctr->state = 1 + ((mode == 1) << 2);
-}
-
-static void
-ctr_load(ctr_t *ctr)
-{
-    if (ctr->l == 1) {
-        /* Count of 1 is illegal in modes 2 and 3. What happens here was
-           determined experimentally. */
-        if (ctr->m == 2)
-            ctr->l = 2;
-        else if (ctr->m == 3)
-            ctr->l = 0;
-    }
-
-    if (ctr->using_timer)
-        ctr->latch = 1;
-    else
-        ctr_set_state_1(ctr);
-
-    if (ctr->load_func != NULL) {
-        uint32_t count = ctr->l ? ctr->l : 0x10000;
-        if (ctr->bcd) {
-            uint32_t bcd_count = (((count >> 16) & 0xf) * 10000) |
-                                 (((count >> 12) & 0xf) * 1000 ) |
-                                 (((count >> 8 ) & 0xf) * 100  ) |
-                                 (((count >> 4 ) & 0xf) * 10   ) |
-                                 (count & 0xf);
-            ctr->load_func(ctr->m, bcd_count);
-        } else
-            ctr->load_func(ctr->m, ctr->l ? ctr->l : 0x10000);
-    }
-
-    pit_log("Counter loaded, state = %i, gate = %i, latch = %i\n", ctr->state, ctr->gate, ctr->latch);
-}
-
-static __inline void
-ctr_latch_status(ctr_t *ctr)
-{
-    ctr->read_status    = (ctr->ctrl & 0x3f) | (ctr->out ? 0x80 : 0) | (ctr->null_count ? 0x40 : 0);
-    ctr->do_read_status = 1;
-}
-
-static __inline void
-ctr_latch_count(ctr_t *ctr)
-{
-    int count = (ctr->latch || (ctr->state == 1)) ? ctr->l : ctr->count;
-
-    switch (ctr->rm & 0x03) {
-        case 0x00:
-            /* This should never happen. */
-            break;
-        case 0x01:
-            /* Latch bits 0-7 only. */
-            ctr->rl      = ((count << 8) & 0xff00) | (count & 0xff);
-            ctr->latched = 1;
-            break;
-        case 0x02:
-            /* Latch bit 8-15 only. */
-            ctr->rl      = (count & 0xff00) | ((count >> 8) & 0xff);
-            ctr->latched = 1;
-            break;
-        case 0x03:
-            /* Latch all 16 bits. */
-            ctr->rl      = count;
-            ctr->latched = 2;
-            break;
-
-        default:
-            break;
-    }
-
-    pit_log("rm = %x, latched counter = %04X\n", ctr->rm & 0x03, ctr->rl & 0xffff);
-}
 
 uint16_t
 pit_ctr_get_count(void *data, int counter_id)
 {
-    const pit_t *pit = (pit_t *) data;
-    const ctr_t *ctr = &pit->counters[counter_id];
-
-    return (uint16_t) ctr->l;
+    const pit_t *pit = (const pit_t *)data;
+    return pit->exact.channel[counter_id].count_register;
 }
+
 
 int
 pit_ctr_get_outlevel(void *data, int counter_id)
 {
-    const pit_t *pit = (pit_t *) data;
-    const ctr_t *ctr = &pit->counters[counter_id];
-
-    return (int) ctr->out;
+    const pit_t *pit = (const pit_t *)data;
+    return pitx_get_output(&pit->exact, (unsigned)counter_id) ? 1 : 0;
 }
+
 
 void
 pit_ctr_set_load_func(void *data, int counter_id, void (*func)(uint8_t new_m, int new_count))
@@ -456,69 +249,24 @@ pit_ctr_set_out_func(void *data, int counter_id, void (*func)(int new_out, int o
 void
 pit_ctr_set_gate(void *data, int counter_id, int gate)
 {
-    pit_t *pit = (pit_t *) data;
-    ctr_t *ctr = &pit->counters[counter_id];
-
-    int     old  = ctr->gate;
-    uint8_t mode = ctr->m & 3;
-
-    switch (mode) {
-        case 1:
-        case 2:
-        case 3:
-        case 5:
-        case 6:
-        case 7:
-            if (!old && gate) {
-                /* Here we handle the rising edges. */
-                if (mode & 1) {
-                    if (mode != 1)
-                        ctr_set_out(ctr, 1, pit);
-                    ctr->state = 1;
-                } else if (mode == 2)
-                    ctr->state = 3;
-            } else if (old && !gate) {
-                /* Here we handle the lowering edges. */
-                if (mode & 2)
-                    ctr_set_out(ctr, 1, pit);
-            }
-            break;
-
-        default:
-            break;
-    }
-
-    ctr->gate = gate;
+    pit_t *pit = (pit_t *)data;
+    if (pit == NULL || counter_id < 0 || counter_id >= NUM_COUNTERS)
+        return;
+    pitx_set_gate(&pit->exact, (unsigned)counter_id, gate != 0);
+    pit_exact_sync_channel(pit, (unsigned)counter_id);
 }
+
 
 static __inline void
 pit_ctr_set_clock_common(ctr_t *ctr, int clock, void *priv)
 {
     pit_t *pit = (pit_t *)priv;
-    int old = ctr->clock;
-
+    const int old = ctr->clock;
     ctr->clock = clock;
-
-    if (ctr->using_timer && ctr->latch) {
-        if (old && !ctr->clock) {
-            ctr_set_state_1(ctr);
-            ctr->latch = 0;
-        }
-    } else if (ctr->using_timer && !ctr->latch) {
-        if (ctr->state == 1) {
-            if (!old && ctr->clock)
-                ctr->s1_det = 1; /* Rising edge. */
-            else if (old && !ctr->clock) {
-                ctr->s1_det++; /* Falling edge. */
-                if (ctr->s1_det >= 2) {
-                    ctr->s1_det = 0;
-                    ctr_tick(ctr, pit);
-                }
-            }
-        } else if (old && !ctr->clock)
-            ctr_tick(ctr, pit);
-    }
+    if (ctr->using_timer && old && !clock)
+        ctr_tick(ctr, pit);
 }
+
 
 void
 pit_ctr_set_clock(ctr_t *ctr, int clock, void *priv)
@@ -552,144 +300,23 @@ pit_timer_over(void *priv)
 static void
 pit_write(uint16_t addr, uint8_t val, void *priv)
 {
-    pit_t *dev = (pit_t *) priv;
-    int    t   = (addr & 3);
-    ctr_t *ctr;
-
-    if ((dev->flags & (PIT_8254 | PIT_EXT_IO))) {
-        pit_log("[%04X:%08X] pit_write(%04X, %02X, %016" PRIX64 ")\n",
-                CS, cpu_state.pc, addr, val, (uint64_t) (uintptr_t) priv);
+    pit_t *dev = (pit_t *)priv;
+    const unsigned port = addr & 3u;
+    if (port == 3u) {
+        dev->ctrl = val;
+        pitx_control_write(&dev->exact, val);
+        pit_exact_sync_all(dev);
+        return;
     }
-
-    switch (addr & 3) {
-        case 3: /* control */
-            t = val >> 6;
-
-            if (t == 3) {
-                if (dev->flags & PIT_8254) {
-                    /* This is 8254-only. */
-                    if (!(val & 0x20)) {
-                        if (val & 2)
-                            ctr_latch_count(&dev->counters[0]);
-                        if (val & 4)
-                            ctr_latch_count(&dev->counters[1]);
-                        if (val & 8)
-                            ctr_latch_count(&dev->counters[2]);
-                        if ((dev->flags & (PIT_8254 | PIT_EXT_IO))) {
-                            pit_log("PIT %i: Initiated readback command\n", t);
-                        }
-                    }
-                    if (!(val & 0x10)) {
-                        if (val & 2)
-                            ctr_latch_status(&dev->counters[0]);
-                        if (val & 4)
-                            ctr_latch_status(&dev->counters[1]);
-                        if (val & 8)
-                            ctr_latch_status(&dev->counters[2]);
-                    }
-                }
-            } else {
-                dev->ctrl = val;
-                ctr       = &dev->counters[t];
-
-                if (!(dev->ctrl & 0x30)) {
-                    ctr_latch_count(ctr);
-                    if ((dev->flags & (PIT_8254 | PIT_EXT_IO))) {
-                        pit_log("PIT %i: Initiated latched read, %i bytes latched\n",
-                            t, ctr->latched);
-                    }
-                } else {
-                    ctr->ctrl = val;
-                    ctr->rm = ctr->wm = (ctr->ctrl >> 4) & 3;
-                    ctr->m            = (val >> 1) & 7;
-                    if (ctr->m > 5)
-                        ctr->m &= 3;
-                    ctr->null_count = 1;
-                    ctr->bcd        = (ctr->ctrl & 0x01);
-                    ctr_set_out(ctr, !!ctr->m, dev);
-                    ctr->state = 0;
-                    if (ctr->latched) {
-                        if ((dev->flags & (PIT_8254 | PIT_EXT_IO))) {
-                            pit_log("PIT %i: Reload while counter is latched\n", t);
-                        }
-                        ctr->rl--;
-                    }
-
-                    if ((dev->flags & (PIT_8254 | PIT_EXT_IO))) {
-                        pit_log("PIT %i: M = %i, RM/WM = %i, State = %i, Out = %i\n", t, ctr->m, ctr->rm, ctr->state, ctr->out);
-                    }
-                }
-            }
-            break;
-
-        case 0:
-        case 1:
-        case 2: /* the actual timers */
-            ctr = &dev->counters[t];
-
-            switch (ctr->wm) {
-                case 0:
-                    /* This should never happen. */
-                    break;
-                case 1:
-                    ctr->l = val;
-                    ctr->lback = ctr->l;
-                    ctr->lback2 = ctr->l;
-                    if ((dev->flags & (PIT_8254 | PIT_EXT_IO))) {
-                        pit_log("PIT %i (1): Written byte %02X, latch now %04X\n", t, val, ctr->l);
-                    }
-                    if (ctr->m == 0)
-                        ctr_set_out(ctr, 0, dev);
-                    ctr_load(ctr);
-                    break;
-                case 2:
-                    ctr->l = (val << 8);
-                    ctr->lback = ctr->l;
-                    ctr->lback2 = ctr->l;
-                    if ((dev->flags & (PIT_8254 | PIT_EXT_IO))) {
-                        pit_log("PIT %i (2): Written byte %02X, latch now %04X\n", t, val, ctr->l);
-                    }
-                    if (ctr->m == 0)
-                        ctr_set_out(ctr, 0, dev);
-                    ctr_load(ctr);
-                    break;
-                case 3:
-                case 0x83:
-                    if (ctr->wm & 0x80) {
-                        ctr->l = (ctr->l & 0x00ff) | (val << 8);
-                        ctr->lback = ctr->l;
-                        ctr->lback2 = ctr->l;
-                        if ((dev->flags & (PIT_8254 | PIT_EXT_IO))) {
-                            pit_log("PIT %i (0x83): Written high byte %02X, latch now %04X\n", t, val, ctr->l);
-                        }
-                        ctr_load(ctr);
-                    } else {
-                        ctr->l = (ctr->l & 0xff00) | val;
-                        ctr->lback = ctr->l;
-                        ctr->lback2 = ctr->l;
-                        if ((dev->flags & (PIT_8254 | PIT_EXT_IO))) {
-                            pit_log("PIT %i (3): Written low byte %02X, latch now %04X\n", t, val, ctr->l);
-                        }
-                        if (ctr->m == 0) {
-                            ctr->state = 0;
-                            ctr_set_out(ctr, 0, dev);
-                        }
-                    }
-                    if (ctr->wm & 0x80)
-                        ctr->wm &= ~0x80;
-                    else
-                        ctr->wm |= 0x80;
-                    break;
-
-                default:
-                    break;
-            }
-            break;
-
-        default:
-            break;
-    }
+    pitx_channel_t *x = &dev->exact.channel[port];
+    const uint8_t rw = x->rw_mode;
+    const uint8_t old_phase = x->write_phase;
+    pitx_data_write(&dev->exact, port, val);
+    pit_exact_sync_channel(dev, port);
+    if (rw == 1u || rw == 2u || (rw == 3u && old_phase == 1u))
+        pit_exact_notify_load(dev, port);
 }
+
 
 extern uint8_t *ram;
 
@@ -732,86 +359,15 @@ pit_read_reg(void *priv, uint8_t reg)
 static uint8_t
 pit_read(uint16_t addr, void *priv)
 {
-    pit_t  *dev = (pit_t *) priv;
-    uint8_t ret = 0xff;
-    int     count;
-    int     t = (addr & 3);
-    ctr_t  *ctr;
-
-    switch (addr & 3) {
-        case 3: /* Control. */
-            /* This is 8254-only, 8253 returns 0x00. */
-            ret = (dev->flags & PIT_8254) ? dev->ctrl : 0x00;
-            break;
-
-        case 0:
-        case 1:
-        case 2: /* The actual timers. */
-            ctr = &dev->counters[t];
-
-            if (ctr->do_read_status) {
-                ctr->do_read_status = 0;
-                ret                 = ctr->read_status;
-                break;
-            }
-
-            count = (ctr->state == 1) ? ctr->l : ctr->count;
-
-            if (ctr->latched) {
-                ret = (ctr->rl) >> ((ctr->rm & 0x80) ? 8 : 0);
-
-                if (ctr->rm & 0x80)
-                    ctr->rm &= ~0x80;
-                else
-                    ctr->rm |= 0x80;
-
-                ctr->latched--;
-            } else
-                switch (ctr->rm) {
-                    case 0:
-                    case 0x80:
-                        ret = 0x00;
-                        break;
-
-                    case 1:
-                        ret = count & 0xff;
-                        break;
-
-                    case 2:
-                        ret = count >> 8;
-                        break;
-
-                    case 3:
-                    case 0x83:
-                        /* Yes, wm is correct here - this is to ensure correct readout while the
-                           count is being written. */
-                        if (ctr->wm & 0x80)
-                            ret = ~(ctr->l & 0xff);
-                        else
-                            ret = count >> ((ctr->rm & 0x80) ? 8 : 0);
-
-                        if (ctr->rm & 0x80)
-                            ctr->rm &= ~0x80;
-                        else
-                            ctr->rm |= 0x80;
-                        break;
-
-                    default:
-                        break;
-                }
-            break;
-
-        default:
-            break;
-    }
-
-    if ((dev->flags & (PIT_8254 | PIT_EXT_IO))) {
-        pit_log("[%04X:%08X] pit_read(%04X, %016" PRIX64 ") = %02X\n",
-                CS, cpu_state.pc, addr, (uint64_t) (uintptr_t) priv, ret);
-    }
-
-    return ret;
+    pit_t *dev = (pit_t *)priv;
+    const unsigned port = addr & 3u;
+    if (port == 3u)
+        return (dev->flags & PIT_8254) ? dev->ctrl : 0x00;
+    const uint8_t value = pitx_data_read(&dev->exact, port);
+    pit_exact_sync_channel(dev, port);
+    return value;
 }
+
 
 void
 pit_irq0_timer_ps2(int new_out, int old_out, UNUSED(void *priv))
@@ -828,12 +384,14 @@ pit_irq0_timer_ps2(int new_out, int old_out, UNUSED(void *priv))
         pit_devs[1].ctr_clock(pit_devs[1].data, 0);
 }
 
+
 void
 pit_refresh_timer_xt(int new_out, int old_out, UNUSED(void *priv))
 {
     if (new_out && !old_out)
-        dma_channel_read(0);
+        dma_xt_refresh_request();
 }
+
 
 void
 pit_refresh_timer_at(int new_out, int old_out, UNUSED(void *priv))
@@ -892,24 +450,26 @@ void
 pit_device_reset(pit_t *dev)
 {
     dev->clock = 0;
-
     for (uint8_t i = 0; i < NUM_COUNTERS; i++)
         ctr_reset(&dev->counters[i]);
+    pitx_reset(&dev->exact, pit_exact_type(dev));
+    pit_exact_sync_all(dev);
 }
+
 
 void
 pit_reset(pit_t *dev)
 {
-    memset(dev, 0, sizeof(pit_t));
-
+    /* Preserve out/load callbacks, timer registration, flags and device-private
+     * wiring installed by the machine. Only counter state is reset. */
     dev->clock = 0;
-
     for (uint8_t i = 0; i < NUM_COUNTERS; i++)
         ctr_reset(&dev->counters[i]);
-
-    /* Disable speaker gate. */
-    dev->counters[2].gate = 0;
+    pitx_reset(&dev->exact, pit_exact_type(dev));
+    pitx_set_gate(&dev->exact, 2u, false);
+    pit_exact_sync_all(dev);
 }
+
 
 void
 pit_handler(int set, uint16_t base, int size, void *priv)
@@ -949,28 +509,24 @@ pit_close(void *priv)
 static void *
 pit_init(const device_t *info)
 {
-    pit_t *dev = (pit_t *) calloc(1, sizeof(pit_t));
-
-    pit_reset(dev);
-
-    pit_set_pit_const(dev, PITCONST);
-
+    pit_t *dev = (pit_t *)calloc(1, sizeof(pit_t));
+    if (dev == NULL)
+        return NULL;
     dev->flags = info->local;
-
+    pit_reset(dev);
+    pit_set_pit_const(dev, PITCONST);
     if (!(dev->flags & PIT_PS2) && !(dev->flags & PIT_CUSTOM_CLOCK)) {
-        timer_add(&dev->callback_timer, pit_timer_over, (void *) dev, 0);
+        timer_add(&dev->callback_timer, pit_timer_over, (void *)dev, 0);
         timer_set_delay_u64(&dev->callback_timer, dev->pit_const >> 1ULL);
     }
-
     dev->dev_priv = NULL;
-
     if (!(dev->flags & PIT_EXT_IO)) {
         io_sethandler((dev->flags & PIT_SECONDARY) ? 0x0048 : 0x0040, 0x0004,
                       pit_read, NULL, NULL, pit_write, NULL, NULL, dev);
     }
-
     return dev;
 }
+
 
 const device_t i8253_device = {
     .name          = "Intel 8253/8253-5 Programmable Interval Timer",

--- a/src/pit_exact.c
+++ b/src/pit_exact.c
@@ -1,0 +1,502 @@
+/*
+ * Intel 8253/8254 edge-state core.
+ *
+ * Portions of the state model are derived from MartyPC's MIT-licensed PIT
+ * implementation, Copyright 2022-2026 Daniel Balsom.
+ */
+#include <86box/pit_exact.h>
+
+#include <assert.h>
+#include <string.h>
+
+static uint8_t canonical_mode(uint8_t raw)
+{
+    raw &= 7u;
+    return raw > 5u ? (uint8_t)(raw & 3u) : raw;
+}
+
+static uint32_t reload_value(const pitx_channel_t *c)
+{
+    if (c->bcd)
+        return c->count_register ? c->count_register : 0x10000u;
+    return c->count_register ? c->count_register : 0x10000u;
+}
+
+static uint16_t visible_count(uint32_t value)
+{
+    return value == 0x10000u ? 0u : (uint16_t)value;
+}
+
+static void update_live_latch(pitx_channel_t *c)
+{
+    if (!c->count_latched)
+        c->output_latch = visible_count(c->counting_element);
+}
+
+static uint32_t bcd_decrement(uint32_t value)
+{
+    if (value == 0u || value == 0x10000u)
+        return 0x9999u;
+
+    if ((value & 0x000fu) != 0u)
+        return (value - 1u) & 0xffffu;
+    if ((value & 0x00f0u) != 0u)
+        return (value - 0x0007u) & 0xffffu;
+    if ((value & 0x0f00u) != 0u)
+        return (value - 0x0067u) & 0xffffu;
+    return (value - 0x0667u) & 0xffffu;
+}
+
+static void decrement(pitx_channel_t *c)
+{
+    if (c->bcd)
+        c->counting_element = bcd_decrement(c->counting_element);
+    else if (c->counting_element == 0u)
+        c->counting_element = 0xffffu;
+    else if (c->counting_element == 0x10000u)
+        c->counting_element = 0xffffu;
+    else
+        c->counting_element = (c->counting_element - 1u) & 0xffffu;
+    update_live_latch(c);
+}
+
+static void decrement_n(pitx_channel_t *c, unsigned n)
+{
+    while (n--)
+        decrement(c);
+}
+
+static void set_output(pitx_channel_t *c, bool output)
+{
+    c->output = output;
+}
+
+static void load_counting_element(pitx_channel_t *c)
+{
+    uint32_t load = reload_value(c);
+    if (c->type == PITX_8254 && c->mode == 3u && (c->count_register & 1u))
+        load &= 0xfffeu;
+    c->counting_element = load;
+    c->null_count = false;
+    c->ce_undefined = false;
+    if (c->rw_mode == 3u && c->write_phase == 1u)
+        c->incomplete_reload = true;
+    update_live_latch(c);
+
+    switch (c->mode) {
+        case 0:
+            set_output(c, false);
+            c->state = PITX_COUNTING;
+            break;
+        case 1:
+            set_output(c, false);
+            c->state = PITX_COUNTING;
+            break;
+        case 2:
+            set_output(c, true);
+            c->state = c->gate ? PITX_COUNTING : PITX_WAIT_GATE;
+            break;
+        case 3:
+            if (c->toggle_on_reload) {
+                set_output(c, !c->output);
+                c->toggle_on_reload = false;
+            } else if (c->state != PITX_RELOAD_NEXT) {
+                set_output(c, true);
+            }
+            c->state = c->gate ? PITX_COUNTING : PITX_WAIT_GATE;
+            break;
+        case 4:
+            set_output(c, true);
+            c->state = PITX_COUNTING;
+            break;
+        case 5:
+            set_output(c, true);
+            c->state = PITX_COUNTING;
+            break;
+        default:
+            assert(0);
+    }
+}
+
+static void reset_channel(pitx_channel_t *c, pitx_type_t type)
+{
+    memset(c, 0, sizeof(*c));
+    c->type = type;
+    c->rw_mode = 1u;
+    c->initial_load = true;
+    c->null_count = true;
+    c->state = PITX_WAIT_COUNT;
+    /* Power-on mode, count and OUT are electrically undefined.  False is a
+     * deterministic safe value that avoids a spurious IRQ0 during POST. */
+    c->output = false;
+}
+
+void pitx_init(pitx_device_t *pit, pitx_type_t type)
+{
+    pitx_reset(pit, type);
+}
+
+void pitx_reset(pitx_device_t *pit, pitx_type_t type)
+{
+    memset(pit, 0, sizeof(*pit));
+    pit->type = type;
+    for (unsigned i = 0; i < 3u; ++i)
+        reset_channel(&pit->channel[i], type);
+}
+
+static void latch_count(pitx_channel_t *c)
+{
+    /* Intel explicitly specifies that a second latch command is ignored until
+     * the first latched count has been fully read. */
+    if (c->count_latched)
+        return;
+    c->output_latch = visible_count(c->counting_element);
+    c->count_latched = true;
+    c->read_phase = 0u;
+}
+
+static void latch_status(pitx_channel_t *c)
+{
+    if (c->status_latched)
+        return;
+    c->status_latch = (uint8_t)((c->output ? 0x80u : 0u) |
+                                (c->null_count ? 0x40u : 0u) |
+                                (c->control & 0x3fu));
+    c->status_latched = true;
+}
+
+static void program_mode(pitx_channel_t *c, uint8_t control)
+{
+    c->control = control;
+    c->mode_raw = (uint8_t)((control >> 1u) & 7u);
+    c->mode = canonical_mode(c->mode_raw);
+    c->rw_mode = (uint8_t)((control >> 4u) & 3u);
+    c->bcd = (control & 1u) != 0u;
+    c->write_phase = 0u;
+    c->read_phase = 0u;
+    c->count_latched = false;
+    c->status_latched = false;
+    c->null_count = true;
+    c->armed = false;
+    c->initial_load = true;
+    c->incomplete_reload = false;
+    c->ce_undefined = true;
+    c->toggle_on_reload = false;
+    c->state = PITX_WAIT_COUNT;
+    set_output(c, c->mode != 0u);
+}
+
+void pitx_control_write(pitx_device_t *pit, uint8_t value)
+{
+    unsigned select = value >> 6u;
+    pit->last_control = value;
+
+    if (select == 3u) {
+        if (pit->type != PITX_8254)
+            return;
+        /* 8254 read-back. D5/D4 are active low; D3..D1 select counters. */
+        for (unsigned i = 0; i < 3u; ++i) {
+            if ((value & (uint8_t)(2u << i)) == 0u)
+                continue;
+            if ((value & 0x20u) == 0u)
+                latch_count(&pit->channel[i]);
+            if ((value & 0x10u) == 0u)
+                latch_status(&pit->channel[i]);
+        }
+        return;
+    }
+
+    pitx_channel_t *c = &pit->channel[select];
+    if ((value & 0x30u) == 0u) {
+        latch_count(c);
+        return;
+    }
+    program_mode(c, value);
+}
+
+static void finalize_write(pitx_channel_t *c)
+{
+    /* Empirically observed NMOS 8253 behavior for illegal divisor 1. */
+    if (c->count_register == 1u) {
+        if (c->mode == 2u)
+            c->count_register = 2u;
+        else if (c->mode == 3u)
+            c->count_register = 0u;
+    }
+
+    c->null_count = true;
+    c->armed = true;
+
+    if (c->initial_load) {
+        c->initial_load = false;
+        if (c->mode == 1u || c->mode == 5u)
+            c->state = PITX_WAIT_TRIGGER;
+        else
+            c->state = PITX_LOAD_NEXT;
+        return;
+    }
+
+    /* Mode 0 and 4 accept a new count on the next clock. Periodic and
+     * hardware-triggered modes retain the current CE until terminal count or
+     * the next GATE trigger.  An interrupted LSB/MSB sequence is the measured
+     * exception and forces a reload. */
+    if (c->incomplete_reload || c->mode == 0u || c->mode == 4u)
+        c->state = PITX_LOAD_NEXT;
+    c->incomplete_reload = false;
+}
+
+void pitx_data_write(pitx_device_t *pit, unsigned channel, uint8_t value)
+{
+    if (channel >= 3u)
+        return;
+    pitx_channel_t *c = &pit->channel[channel];
+
+    switch (c->rw_mode) {
+        case 1u:
+            c->count_register = value;
+            finalize_write(c);
+            break;
+        case 2u:
+            c->count_register = (uint16_t)value << 8u;
+            finalize_write(c);
+            break;
+        case 3u:
+            if (c->write_phase == 0u) {
+                c->count_register = (uint16_t)((c->count_register & 0xff00u) | value);
+                c->write_phase = 1u;
+                /* In mode 0, the first byte immediately stops counting and
+                 * drives OUT low even before the MSB arrives. */
+                if (c->mode == 0u) {
+                    c->state = PITX_WAIT_COUNT;
+                    set_output(c, false);
+                }
+            } else {
+                c->count_register = (uint16_t)((c->count_register & 0x00ffu) |
+                                               ((uint16_t)value << 8u));
+                c->write_phase = 0u;
+                finalize_write(c);
+            }
+            break;
+        default:
+            break;
+    }
+}
+
+uint8_t pitx_data_read(pitx_device_t *pit, unsigned channel)
+{
+    if (channel >= 3u)
+        return 0xffu;
+    pitx_channel_t *c = &pit->channel[channel];
+
+    if (c->status_latched) {
+        c->status_latched = false;
+        return c->status_latch;
+    }
+
+    uint16_t value = c->count_latched ? c->output_latch : visible_count(c->counting_element);
+
+    /* NMOS 8253/compatible undocumented bus behavior: during an unfinished
+     * LSB/MSB write, a live read returns the inverted pending LSB. */
+    if (!c->count_latched && c->rw_mode == 3u && c->write_phase == 1u)
+        return (uint8_t)~(c->count_register & 0xffu);
+
+    switch (c->rw_mode) {
+        case 1u:
+            c->count_latched = false;
+            return (uint8_t)value;
+        case 2u:
+            c->count_latched = false;
+            return (uint8_t)(value >> 8u);
+        case 3u:
+            if (c->read_phase == 0u) {
+                c->read_phase = 1u;
+                return (uint8_t)value;
+            }
+            c->read_phase = 0u;
+            c->count_latched = false;
+            return (uint8_t)(value >> 8u);
+        default:
+            return 0u;
+    }
+}
+
+void pitx_set_gate(pitx_device_t *pit, unsigned channel, bool gate)
+{
+    if (channel >= 3u)
+        return;
+    pitx_channel_t *c = &pit->channel[channel];
+    bool old = c->gate;
+    c->gate = gate;
+
+    if (!old && gate) {
+        switch (c->mode) {
+            case 1u:
+            case 5u:
+                if (c->state != PITX_WAIT_COUNT) {
+                    c->armed = true;
+                    c->state = PITX_LOAD_NEXT;
+                }
+                break;
+            case 2u:
+            case 3u:
+                if (c->state != PITX_WAIT_COUNT)
+                    c->state = PITX_LOAD_NEXT;
+                break;
+            default:
+                break;
+        }
+    } else if (old && !gate) {
+        switch (c->mode) {
+            case 2u:
+            case 3u:
+                set_output(c, true);
+                if (c->state != PITX_WAIT_COUNT)
+                    c->state = PITX_WAIT_GATE;
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+static void count_mode3(pitx_channel_t *c)
+{
+    const bool odd = (c->count_register & 1u) != 0u;
+
+    if (odd && c->type == PITX_8254) {
+        /* The 8254 masks an odd divisor to an even CE. On the high half,
+         * terminal count defers the toggle/reload by one clock; the low half
+         * toggles and reloads immediately. This preserves the (N+1)/2 high,
+         * (N-1)/2 low duty cycle while exposing the correct live count. */
+        decrement_n(c, 2u);
+        if (visible_count(c->counting_element) == 0u) {
+            if (c->output) {
+                c->toggle_on_reload = true;
+                c->state = PITX_RELOAD_NEXT;
+            } else {
+                set_output(c, true);
+                c->counting_element = reload_value(c) & 0xfffeu;
+                update_live_latch(c);
+            }
+        }
+        return;
+    }
+
+    /* NMOS 8253: odd values enter CE. The first high count decrements by one
+     * and the first low count by three, then normal -2 counting resumes. */
+    if (odd && (c->counting_element & 1u) != 0u)
+        decrement_n(c, c->output ? 1u : 3u);
+    else
+        decrement_n(c, 2u);
+
+    if (visible_count(c->counting_element) == 0u) {
+        set_output(c, !c->output);
+        c->counting_element = reload_value(c);
+        update_live_latch(c);
+    }
+}
+
+void pitx_tick_channel(pitx_device_t *pit, unsigned channel)
+{
+    if (channel >= 3u)
+        return;
+    pitx_channel_t *c = &pit->channel[channel];
+    ++c->clocks;
+
+    switch (c->state) {
+        case PITX_LOAD_NEXT:
+            load_counting_element(c);
+            return;
+        case PITX_RELOAD_NEXT:
+            load_counting_element(c);
+            return;
+        case PITX_STROBE_RECOVER:
+            set_output(c, true);
+            c->state = PITX_COUNTING;
+            return;
+        case PITX_WAIT_TRIGGER:
+            /* Hardware-triggered modes expose an undefined CE before the
+             * first trigger. NMOS measurements consistently show 0003h. */
+            if (c->ce_undefined && c->armed) {
+                c->counting_element = 3u;
+                update_live_latch(c);
+            }
+            return;
+        case PITX_WAIT_COUNT:
+        case PITX_WAIT_GATE:
+        case PITX_DONE:
+            return;
+        case PITX_COUNTING:
+            break;
+    }
+
+    switch (c->mode) {
+        case 0u:
+            if (c->gate) {
+                decrement(c);
+                if (visible_count(c->counting_element) == 0u)
+                    set_output(c, true);
+            }
+            break;
+        case 1u:
+            decrement(c);
+            if (visible_count(c->counting_element) == 0u) {
+                if (c->armed)
+                    set_output(c, true);
+                c->armed = false;
+                /* CE keeps free-running after terminal count; only OUT is
+                 * latched high until another GATE trigger. */
+            }
+            break;
+        case 2u:
+            if (c->gate) {
+                decrement(c);
+                if (visible_count(c->counting_element) == 1u) {
+                    set_output(c, false);
+                    c->state = PITX_RELOAD_NEXT;
+                }
+            }
+            break;
+        case 3u:
+            if (c->gate)
+                count_mode3(c);
+            break;
+        case 4u:
+            if (c->gate) {
+                decrement(c);
+                if (visible_count(c->counting_element) == 0u) {
+                    set_output(c, false);
+                    c->state = PITX_STROBE_RECOVER;
+                }
+            }
+            break;
+        case 5u:
+            decrement(c);
+            if (visible_count(c->counting_element) == 0u) {
+                set_output(c, false);
+                c->armed = false;
+                c->state = PITX_STROBE_RECOVER;
+            }
+            break;
+        default:
+            break;
+    }
+}
+
+void pitx_tick(pitx_device_t *pit)
+{
+    for (unsigned i = 0; i < 3u; ++i)
+        pitx_tick_channel(pit, i);
+}
+
+uint16_t pitx_get_count(const pitx_device_t *pit, unsigned channel)
+{
+    if (channel >= 3u)
+        return 0u;
+    return visible_count(pit->channel[channel].counting_element);
+}
+
+bool pitx_get_output(const pitx_device_t *pit, unsigned channel)
+{
+    return channel < 3u && pit->channel[channel].output;
+}

--- a/src/video/vid_cga.c
+++ b/src/video/vid_cga.c
@@ -24,6 +24,7 @@
 #include <math.h>
 #include <86box/86box.h>
 #include "cpu.h"
+#include "808x_marty_86box.h"
 #include <86box/io.h>
 #include <86box/timer.h>
 #include <86box/pit.h>
@@ -203,11 +204,23 @@ cga_pravetz_in(UNUSED(uint16_t addr), void *priv)
 void
 cga_waitstates(UNUSED(void *priv))
 {
-    int ws_array[16] = { 3, 4, 5, 6, 7, 8, 4, 5, 6, 7, 8, 4, 5, 6, 7, 8 };
-    int ws;
+    /*
+     * NOCONA_CGA_WAIT_PHASE_808X_UPDATE_V1
+     *
+     * The Marty-derived CPU has already selected the physical CGA slot in T2
+     * and emitted the corresponding Tw clocks before invoking this callback.
+     * Charging the legacy countdown here would double the delay and, more
+     * importantly, would put VRAM/snow side effects back on the wrong edge.
+     */
+    static const uint8_t legacy_waits[16] = {
+        3, 4, 5, 6, 7, 8, 4, 5,
+        6, 7, 8, 4, 5, 6, 7, 8
+    };
 
-    ws = ws_array[cycles & 0xf];
-    cycles -= ws;
+    if (m808x_86box_active())
+        return;
+
+    cycles -= legacy_waits[cycles & 0x0f];
 }
 
 void
@@ -536,6 +549,107 @@ cga_blit_memtoscreen(int x, int y, int w, int h, int double_type)
     video_blit_memtoscreen(x, y, w, h);
 }
 
+/*
+ * NOCONA_CGA_PRESENT_GEOMETRY_LATCH_V1
+ *
+ * Timing-sensitive software can move VSYNC or terminate a frame early while
+ * the CRT beam is active.  That changes the raw firstline/lastline extent for
+ * the affected frame, but it must not immediately resize the host window.
+ *
+ * A real monitor retains its physical raster geometry through a transient bad
+ * frame.  Require a new geometry to repeat for several complete frames before
+ * presenting it as a genuine mode change.
+ */
+#define CGA_PRESENT_GEOMETRY_CONFIRM_FRAMES 3u
+#define CGA_PRESENT_GEOMETRY_SLOTS          2u
+
+typedef struct cga_present_geometry_latch_t {
+    cga_t   *owner;
+    int      candidate_x;
+    int      candidate_y;
+    unsigned candidate_frames;
+} cga_present_geometry_latch_t;
+
+static cga_present_geometry_latch_t
+    cga_present_geometry_latches[CGA_PRESENT_GEOMETRY_SLOTS];
+
+static cga_present_geometry_latch_t *
+cga_present_geometry_latch(cga_t *cga)
+{
+    cga_present_geometry_latch_t *free_slot = NULL;
+
+    for (unsigned i = 0; i < CGA_PRESENT_GEOMETRY_SLOTS; ++i) {
+        cga_present_geometry_latch_t *slot =
+            &cga_present_geometry_latches[i];
+
+        if (slot->owner == cga)
+            return slot;
+        if (slot->owner == NULL && free_slot == NULL)
+            free_slot = slot;
+    }
+
+    if (free_slot == NULL)
+        free_slot = &cga_present_geometry_latches[0];
+
+    memset(free_slot, 0, sizeof(*free_slot));
+    free_slot->owner = cga;
+    return free_slot;
+}
+
+static void
+cga_present_geometry_release(cga_t *cga)
+{
+    for (unsigned i = 0; i < CGA_PRESENT_GEOMETRY_SLOTS; ++i) {
+        cga_present_geometry_latch_t *slot =
+            &cga_present_geometry_latches[i];
+
+        if (slot->owner == cga) {
+            memset(slot, 0, sizeof(*slot));
+            return;
+        }
+    }
+}
+
+static int
+cga_present_geometry_should_commit(cga_t *cga, int new_x, int new_y,
+                                   int force_resize)
+{
+    cga_present_geometry_latch_t *slot =
+        cga_present_geometry_latch(cga);
+
+    if (force_resize || xsize <= 0 || ysize <= 0) {
+        slot->candidate_x = 0;
+        slot->candidate_y = 0;
+        slot->candidate_frames = 0;
+        return 1;
+    }
+
+    if (new_x == xsize && new_y == ysize) {
+        slot->candidate_x = 0;
+        slot->candidate_y = 0;
+        slot->candidate_frames = 0;
+        return 0;
+    }
+
+    if (new_x != slot->candidate_x || new_y != slot->candidate_y) {
+        slot->candidate_x = new_x;
+        slot->candidate_y = new_y;
+        slot->candidate_frames = 1;
+        return 0;
+    }
+
+    if (slot->candidate_frames < CGA_PRESENT_GEOMETRY_CONFIRM_FRAMES)
+        ++slot->candidate_frames;
+
+    if (slot->candidate_frames < CGA_PRESENT_GEOMETRY_CONFIRM_FRAMES)
+        return 0;
+
+    slot->candidate_x = 0;
+    slot->candidate_y = 0;
+    slot->candidate_frames = 0;
+    return 1;
+}
+
 void
 cga_do_blit(int vid_xsize, int firstline, int lastline, int double_type)
 {
@@ -703,13 +817,24 @@ cga_poll(void *priv)
                         if (!enable_overscan)
                             xs_temp -= 16;
 
-                        if ((cga->cgamode & CGA_MODE_FLAG_VIDEO_ENABLE) && ((xs_temp != xsize) ||
-                            (ys_temp != ysize) || video_force_resize_get())) {
+                        /*
+                         * Keep raw beam timing separate from host presentation
+                         * geometry.  Beam-racing software may create one short
+                         * frame; Qt must not magnify that frame to fill a newly
+                         * shortened window.
+                         */
+                        const int force_resize = video_force_resize_get();
+
+                        if ((cga->cgamode & CGA_MODE_FLAG_VIDEO_ENABLE) &&
+                            cga_present_geometry_should_commit(
+                                cga, xs_temp, ys_temp, force_resize)) {
                             xsize = xs_temp;
                             ysize = ys_temp;
-                            set_screen_size(xsize, ysize + (enable_overscan ? 16 : 0));
+                            set_screen_size(xsize,
+                                            ysize +
+                                                (enable_overscan ? 16 : 0));
 
-                            if (video_force_resize_get())
+                            if (force_resize)
                                 video_force_resize_set(0);
                         }
 
@@ -830,6 +955,7 @@ cga_close(void *priv)
 {
     cga_t *cga = (cga_t *) priv;
 
+    cga_present_geometry_release(cga);
     free(cga->vram);
     free(cga);
 }


### PR DESCRIPTION
Summary
=======
_Briefly describe what you are submitting._
This entire PR overhauls the DMA, PIT, and 808x emulation subsystem, the 808x portion of which is to my knowledge, as accurate as MartyPC's. I am not claiming definitive 100% all software works the same way type of proof, notably due to other emulator subsystems not being all accounted for, for the newer systems. From my testing, everything still works as is, though I will be sure to check even more.


Checklist
=========
* [ ] Closes #xxx
* [ *] I have tested my changes locally and validated that the functionality works as intended
* [ *] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
