### PR TITLE
CDROM: Implement checksumming for Subchannel Q on sector reads

### DIFF
--- a/src/cdrom/cdrom.c
+++ b/src/cdrom/cdrom.c
@@ -31,9 +31,11 @@
 #include <86box/cdrom_mitsumi.h>
 #endif
 #include <86box/cdrom_mke.h>
+#include <86box/crc.h>
 #include <86box/log.h>
 #include <86box/plat.h>
 #include <86box/plat_cdrom_ioctl.h>
+#include <86box/bswap.h>
 #include <86box/scsi.h>
 #include <86box/scsi_device.h>
 #include <86box/scsi_cdrom.h>
@@ -46,6 +48,8 @@
 #define MAX_SEEK           333333
 
 cdrom_t cdrom[CDROM_NUM] = { 0 };
+
+uint16_t subq_crc16_table[256] = { 0 };
 
 int cdrom_interface_current;
 int cdrom_assigned_letters = 0;
@@ -355,6 +359,37 @@ cdrom_check_for_formed_mode2(cdrom_t *dev, const uint8_t *b)
     }
 }
 
+// CRC16-CCITT
+unsigned short
+cdrom_crc16(unsigned short crc, const unsigned char *buf, size_t len)
+{
+    crc_t res;
+    res.word = ~crc;
+    for (int i = 0; i < len; i++) {
+        crc16_calc(subq_crc16_table, buf[i], &res);
+    }
+    res.word = ~res.word;
+    return res.word;
+}
+
+static void
+cdrom_deinterleave_subch(uint8_t *d, const uint8_t *s)
+{
+    for (int i = 0; i < 8 * 12; i++) {
+        int dmask = 0x80;
+        int smask = 1 << (7 - (i / 12));
+
+        (*d) = 0;
+
+        for (int j = 0; j < 8; j++) {
+            (*d) |= (s[(i % 12) * 8 + j] & smask) ? dmask : 0;
+            dmask >>= 1;
+        }
+
+        d++;
+    }
+}
+
 static int
 cdrom_is_sector_good(cdrom_t *dev, const uint8_t *b, const uint8_t mode2, const uint8_t form)
 {
@@ -382,6 +417,13 @@ cdrom_is_sector_good(cdrom_t *dev, const uint8_t *b, const uint8_t mode2, const 
             ret = ret && !memcmp(dev->p_parity, &(b[2076]), 172);
             ret = ret && !memcmp(dev->q_parity, &(b[2248]), 104);
         }
+    }
+
+    if (!dev->no_check && (dev->cd_status != CD_STATUS_DVD)) {
+        uint8_t deinterleaved_subch[96] = { };
+        cdrom_deinterleave_subch(deinterleaved_subch, &b[2352]);
+        uint16_t q_sub_crc16 = cdrom_crc16(0xffff, &deinterleaved_subch[12], 10);
+        ret = ret && (q_sub_crc16 == bswap16(*(uint16_t*)&deinterleaved_subch[12 + 10]));
     }
 
     return ret;
@@ -1016,24 +1058,6 @@ process_c2(cdrom_t *dev, const int cdrom_sector_flags, uint8_t *b)
         cdrom_log(dev->log, "Full error flags\n");
         memcpy(b + dev->cdrom_sector_size, dev->extra_buffer, 296);
         dev->cdrom_sector_size += 296;
-    }
-}
-
-static void
-cdrom_deinterleave_subch(uint8_t *d, const uint8_t *s)
-{
-    for (int i = 0; i < 8 * 12; i++) {
-        int dmask = 0x80;
-        int smask = 1 << (7 - (i / 12));
-
-        (*d) = 0;
-
-        for (int j = 0; j < 8; j++) {
-            (*d) |= (s[(i % 12) * 8 + j] & smask) ? dmask : 0;
-            dmask >>= 1;
-        }
-
-        d++;
     }
 }
 
@@ -3146,6 +3170,9 @@ cdrom_global_init(void)
 {
     /* Clear the global data. */
     memset(cdrom, 0x00, sizeof(cdrom));
+
+    /* Initialize the CRC16-CCITT table */
+    crc16_setup(subq_crc16_table, 0x1021);
 
     for (uint8_t i = 0; i < CDROM_NUM; i++) {
         cdrom[i].cached_sector = -1;

--- a/src/cdrom/cdrom_aaru.c
+++ b/src/cdrom/cdrom_aaru.c
@@ -38,6 +38,7 @@
 #endif
 #include <86box/86box.h>
 #include <86box/plat.h>
+#include <86box/bswap.h>
 #include <86box/cdrom.h>
 #include <86box/cdrom_image.h>
 #include <86box/plat_dynld.h>
@@ -478,6 +479,7 @@ generate_subchannel:
         buffer[2352 + 7] = bin2bcd(m);
         buffer[2352 + 8] = bin2bcd(s);
         buffer[2352 + 9] = bin2bcd(f);
+        *(uint16_t*)&buffer[2352 + 10] = bswap16(cdrom_crc16(0xffff, &buffer[2352], 10));
         for (int i = 11; i >= 0; i--)
             for (int j = 7; j >= 0; j--)
                 buffer[2352 + (i * 8) + j] = ((buffer[2352 + i] >> (7 - j)) & 0x01) << 6;

--- a/src/cdrom/cdrom_chd.c
+++ b/src/cdrom/cdrom_chd.c
@@ -51,6 +51,7 @@
 #include <86box/nvr.h>
 #include <86box/path.h>
 #include <86box/plat.h>
+#include <86box/bswap.h>
 #include <86box/cdrom.h>
 #include <86box/cdrom_image.h>
 #include <86box/cdrom_image_viso.h>
@@ -657,6 +658,7 @@ chd_image_read_sector(const void *local, UNUSED(uint8_t *buffer), UNUSED(uint32_
     buffer[2352 + 7] = bin2bcd(m);
     buffer[2352 + 8] = bin2bcd(s);
     buffer[2352 + 9] = bin2bcd(f);
+    *(uint16_t*)&buffer[2352 + 10] = bswap16(cdrom_crc16(0xffff, &buffer[2352], 10));
     for (int i = 11; i >= 0; i--)
         for (int j = 7; j >= 0; j--)
             buffer[2352 + (i * 8) + j] = ((buffer[2352 + i] >> (7 - j)) & 0x01) << 6;

--- a/src/cdrom/cdrom_image.c
+++ b/src/cdrom/cdrom_image.c
@@ -37,6 +37,7 @@
 #include <86box/nvr.h>
 #include <86box/path.h>
 #include <86box/plat.h>
+#include <86box/bswap.h>
 #include <86box/cdrom.h>
 #include <86box/cdrom_image.h>
 #include <86box/cdrom_image_viso.h>
@@ -2896,6 +2897,8 @@ image_read_sector(const void *local, uint8_t *buffer,
                     q[7] = bin2bcd(m & 0xff);
                     q[8] = bin2bcd(s & 0xff);
                     q[9] = bin2bcd(f & 0xff);
+
+                    *(uint16_t*)(&q[10]) = bswap16(cdrom_crc16(0xffff, q, 10));
                 }
 
                 /* Construct raw subchannel data from Q only. */

--- a/src/include/86box/cdrom.h
+++ b/src/include/86box/cdrom.h
@@ -613,6 +613,8 @@ extern void            cdrom_compute_ecc_block(cdrom_t *dev, uint8_t *parity, co
                                                uint32_t major_mult, uint32_t minor_inc, int m2f1);
 extern unsigned long   cdrom_crc32(unsigned long crc, const unsigned char *buf,
                                    size_t len);
+extern unsigned short  cdrom_crc16(unsigned short crc, const unsigned char *buf,
+                                   size_t len);
 
 extern int             cdrom_image_is_aaru(const char *fn);
 extern int             cdrom_image_is_chd(const char *fn);


### PR DESCRIPTION
Summary
=======
CDROM: Implement checksumming for Subchannel Q on sector reads.

SecuROM 4.6 apparently relies on this.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
https://pure.royalholloway.ac.uk/ws/files/45181607/2022HassanMdRmPhil.pdf, page 40.

```
To differentiate between a copied material versus an original copy: (version 4.6) used
by Sony utilises the q-channel of the disc. Within the disc, nine specific locations of the
q-channel are broken by purpose, which acts as a flag or a marker. This is done using a
vendor-specific key which can calculate and determine the exact locations. A calculation
function is then injected, which will verify later if the disc is a genuine or a fake copy. The
function is triggered when the game is launched: if the function is unable to read the specific
nine broken sections when the game is being played, it returns a ‘True’ value. This ‘True’
value is a token of genuine authenticity confirmation. On the contrary, if the function is
able to read any of the specified locations, the resulting verdict would be negative or ‘False’
and would mean, the user has a fake copy.
```
