### PR TITLE
CD-ROM: Add handling for .SBI files

### DIFF
--- a/src/cdrom/cdrom.c
+++ b/src/cdrom/cdrom.c
@@ -17,6 +17,7 @@
 #include <stdarg.h>
 #endif
 #include <stdint.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -372,7 +373,7 @@ cdrom_crc16(unsigned short crc, const unsigned char *buf, size_t len)
     return res.word;
 }
 
-static void
+void
 cdrom_deinterleave_subch(uint8_t *d, const uint8_t *s)
 {
     for (int i = 0; i < 8 * 12; i++) {
@@ -1074,9 +1075,16 @@ process_c2_and_subch(cdrom_t *dev, const int cdrom_sector_flags,
                 2352, 96);
          dev->cdrom_sector_size += 96;
      } else if ((cdrom_sector_flags & 0x700) == 0x200) {
+         uint8_t deinterleaved_subch[96] = { };
          cdrom_log(dev->log, "Q subchannel data\n");
-         memcpy(b + dev->cdrom_sector_size, dev->raw_buffer[dev->cur_buf] +
-                2352, 16);
+         cdrom_deinterleave_subch(deinterleaved_subch,
+                                  dev->raw_buffer[dev->cur_buf] + 2352);
+         bool p_bit = !!deinterleaved_subch[0]; // all P bits in a subchannel are either 0 or 1.
+         memcpy(b + dev->cdrom_sector_size, deinterleaved_subch + 12, 12);
+         *(b + dev->cdrom_sector_size + 12) = 0;
+         *(b + dev->cdrom_sector_size + 13) = 0;
+         *(b + dev->cdrom_sector_size + 14) = 0;
+         *(b + dev->cdrom_sector_size + 15) = ((uint8_t)p_bit) << 7;
          dev->cdrom_sector_size += 16;
      } else if ((cdrom_sector_flags & 0x700) == 0x400) {
          cdrom_log(dev->log, "R/W subchannel data\n");

--- a/src/cdrom/cdrom_image.c
+++ b/src/cdrom/cdrom_image.c
@@ -60,6 +60,16 @@
 static char temp_keyword[1024];
 static char temp_file[260]     = { 0 };
 
+#pragma pack(push, 1)
+struct sbi_replacement_ent
+{
+  uint8_t m, s, f; // all in BCD.
+  uint8_t type;
+  uint8_t q[10]; // Q-subchannel data.
+};
+typedef struct sbi_replacement_ent sbi_replacement_ent;
+#pragma pack(pop)
+
 #define INDEX_SPECIAL -2 /* Track A0h onwards. */
 #define INDEX_NONE    -1 /* Empty block. */
 #define INDEX_ZERO     0 /* Block not in the file, return all 0x00's. */
@@ -130,6 +140,9 @@ typedef struct cd_image_t {
     track_t      *tracks;
     uint32_t     *bad_sectors;
     dstruct_t     dstruct;
+
+    sbi_replacement_ent* sector_subs;
+    uint64_t sector_subs_size;
 } cd_image_t;
 
 typedef enum
@@ -1898,6 +1911,46 @@ image_load_cue(cd_image_t *img, const char *cuefile)
         warning(plat_get_string(STRING_CDROM_OPEN_CUE_ERROR), cuefile);
 #endif
 
+    if (success) {
+        char ident[4] = { 0, 0, 0, 0 };
+        // Look for .SBI sidecar files.
+        char* sbifile = strdup(cuefile);
+        sbifile[strlen(sbifile) - 3] = 's';
+        sbifile[strlen(sbifile) - 2] = 'b';
+        sbifile[strlen(sbifile) - 1] = 'i';
+
+        FILE* sbi_handle = plat_fopen(sbifile, "rb");
+        if (sbi_handle) {
+            goto process_sbi;
+        } else {
+            sbifile[strlen(sbifile) - 3] = 'S';
+            sbifile[strlen(sbifile) - 2] = 'B';
+            sbifile[strlen(sbifile) - 1] = 'I';
+            
+            sbi_handle = plat_fopen(sbifile, "rb");
+            if (sbi_handle) {
+process_sbi:
+                (void)fread(ident, 1, 4, sbi_handle);
+                if (!memcmp(ident, "SBI", 4)) { // null character is implicit
+                    fseek(sbi_handle, 0, SEEK_END);
+                    long len = ftell(sbi_handle);
+                    fseek(sbi_handle, 4, SEEK_SET);
+                    if (!((len - 4) % sizeof(sbi_replacement_ent))) {
+                        img->sector_subs = (sbi_replacement_ent*)calloc(1, len - 4);
+                        if (!fread(img->sector_subs, 1, len - 4, sbi_handle)) {
+                            free(img->sector_subs);
+                            img->sector_subs = NULL;
+                        } else {
+                            img->sector_subs_size = (len - 4) / sizeof(sbi_replacement_ent);
+                        }
+                    }
+                }
+            }
+        }
+
+        free(sbifile);
+    }
+
     return success;
 }
 
@@ -2905,6 +2958,25 @@ image_read_sector(const void *local, uint8_t *buffer,
                 for (int i = 0; i < 12; i++)
                      for (int j = 0; j < 8; j++)
                           buffer[2352 + (i << 3) + j] = ((q[i] >> (7 - j)) & 0x01) << 6;
+            }
+        }
+
+        if (img->sector_subs) {
+            uint8_t deinterleaved_subch[96] = {};
+            FRAMES_TO_MSF(lba + 150, &m, &s, &f);
+            cdrom_deinterleave_subch(deinterleaved_subch, &buffer[2352]);
+
+            for (int i = 0; i < img->sector_subs_size; i++) {
+                if (img->sector_subs[i].m == bin2bcd(m)
+                && img->sector_subs[i].s == bin2bcd(s)
+                && img->sector_subs[i].f == bin2bcd(f)
+                && img->sector_subs[i].type == 0x01) {
+                    memcpy(&deinterleaved_subch[12], img->sector_subs[i].q, 10);
+
+                    *(uint16_t*)(&deinterleaved_subch[12 + 10]) = ~bswap16(cdrom_crc16(0xffff, img->sector_subs[i].q, 10));
+                    cdrom_interleave_subch(&buffer[2352], deinterleaved_subch);
+                    break;
+                }
             }
         }
     }

--- a/src/include/86box/cdrom.h
+++ b/src/include/86box/cdrom.h
@@ -550,6 +550,7 @@ extern int             cdrom_get_type(const int model);
 
 extern int             cdrom_lba_to_msf_accurate(const int lba);
 extern void            cdrom_interleave_subch(uint8_t *d, const uint8_t *s);
+extern void            cdrom_deinterleave_subch(uint8_t *d, const uint8_t *s);
 extern double          cdrom_seek_time(const cdrom_t *dev);
 extern void            cdrom_stop(cdrom_t *dev);
 extern void            cdrom_seek(cdrom_t *dev, const uint32_t pos, const uint8_t vendor_type);


### PR DESCRIPTION
Summary
=======
CD-ROM: Add handling for .SBI files

Drive-by: Correctly return P and Q subchannels for 2368-byte reads.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
None.
