### PR TITLE
Minor sound changes

### DIFF
--- a/src/sound/snd_azt2320.c
+++ b/src/sound/snd_azt2320.c
@@ -273,7 +273,7 @@ azt2320_init(UNUSED(const device_t *info))
     azt2320->sb->opl_enabled = device_get_config_int("opl");
 
     if (azt2320->sb->opl_enabled)
-        fm_driver_get_cs(FM_YMF262, &azt2320->sb->opl);
+        fm_driver_get_cs(FM_YMF289B, &azt2320->sb->opl);
 
     sb_dsp_set_real_opl(&azt2320->sb->dsp, 1);
     sb_dsp_init(&azt2320->sb->dsp, SBPRO_DSP_302, SB_SUBTYPE_CLONE_AZT2320_0X13, azt2320);

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -5182,13 +5182,14 @@ sb_awe32_init(UNUSED(const device_t *info))
     uint16_t mpu_addr    = device_get_config_hex16("base401");
     uint16_t emu_addr    = device_get_config_hex16("emu_base");
     int      onboard_ram = device_get_config_int("onboard_ram");
+    const uint8_t  dspver = device_get_config_int("dspver");
 
     sb->opl_enabled = device_get_config_int("opl");
     if (sb->opl_enabled)
         fm_driver_get_cs(FM_YMF262, &sb->opl);
 
     sb_dsp_set_real_opl(&sb->dsp, 1);
-    sb_dsp_init(&sb->dsp, SBAWE32_DSP_412, SB_SUBTYPE_DEFAULT, sb);
+    sb_dsp_init(&sb->dsp, dspver, SB_SUBTYPE_DEFAULT, sb);
     sb_dsp_setaddr(&sb->dsp, addr);
     sb_dsp_setirq(&sb->dsp, device_get_config_int("irq"));
     sb_dsp_setdma8(&sb->dsp, device_get_config_int("dma"));
@@ -7353,6 +7354,21 @@ static const device_config_t sb_awe32_config[] = {
         .file_filter    = NULL,
         .spinner        = { 0 },
         .selection      = { { 0 } },
+        .bios           = { { 0 } }
+    },
+    {
+        .name           = "dspver",
+        .description    = "DSP Version",
+        .type           = CONFIG_SELECTION,
+        .default_string = NULL,
+        .default_int    = SBAWE32_DSP_412,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .selection      = {
+            { .description = "4.12", .value = SBAWE32_DSP_412 },
+            { .description = "4.13", .value = SBAWE32_DSP_413 },
+            { .description = ""                               }
+        },
         .bios           = { { 0 } }
     },
     { .name = "", .description = "", .type = CONFIG_END }


### PR DESCRIPTION
Summary
=======
Make the following minor sound-related changes:
- Make the Aztech AZT2320 use the correct YMF289B variant of the OPL3
- Add a DSP version selector for the non-PnP AWE32 with options for DSP v4.12 (as seen on launch CT2760s) and v4.13 (as seen on later CT2760s and the CT3900).

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
