### PR TITLE
Attempt to make the timings more accurate on the Trantor T128.

### DIFF
--- a/src/scsi/scsi_t128.c
+++ b/src/scsi/scsi_t128.c
@@ -75,7 +75,7 @@ t128_write(uint32_t addr, uint8_t val, void *priv)
     if ((addr >= 0x1800) && (addr < 0x1880))
         t128->ext_ram[addr & 0x7f] = val;
     else if ((addr >= 0x1c00) && (addr < 0x1c20)) {
-        t128_log("T128 ctrl write=%02x, mode=%02x.\n", val & 0x10, ncr->mode & MODE_DMA);
+        t128_log("%04X:%08X: T128 ctrl write=%02x, mode=%02x, ID=%d.\n", CS, cpu_state.pc, val & 0x10, ncr->mode & MODE_DMA, scsi_bus->target_id);
         t128->ctrl = val;
     } else if ((addr >= 0x1d00) && (addr < 0x1e00))
         ncr5380_write((addr - 0x1d00) >> 5, val, ncr);
@@ -85,12 +85,12 @@ t128_write(uint32_t addr, uint8_t val, void *priv)
             t128->buffer[t128->host_pos] = val;
             t128->host_pos++;
 
-            t128_log("T128 Write transfer: pos=%i, addr=%x.\n",
-                    t128->host_pos, addr & 0x1ff);
+            //t128_log("T128 Write transfer: pos=%i, addr=%x.\n",
+            //        t128->host_pos, addr & 0x1ff);
 
             if (t128->host_pos == MIN(512, dev->buffer_length)) {
-                t128_log("T128 Transfer busy write, status=%02x, period=%lf, enabled=%d, loaded=%d.\n",
-                        t128->status, scsi_bus->period, timer_is_enabled(&t128->timer), t128->block_loaded);
+                //t128_log("T128 Transfer busy write, status=%02x, period=%lf, enabled=%d, loaded=%d.\n",
+                //        t128->status, scsi_bus->period, timer_is_enabled(&t128->timer), t128->block_loaded);
 
                 t128->status &= ~0x04;
                 timer_on_auto(&t128->timer, 1.0);
@@ -108,7 +108,7 @@ t128_read(uint32_t addr, void *priv)
     ncr_t         *ncr     = &t128->ncr;
     scsi_bus_t    *scsi_bus = &ncr->scsibus;
     scsi_device_t *dev     = &scsi_devices[ncr->bus][scsi_bus->target_id];
-    uint8_t        ret     = 0xff;
+    uint8_t        ret     = 0x00;
 
     addr &= 0x3fff;
     if (t128->bios_enabled && (addr >= 0) && (addr < 0x1800))
@@ -117,10 +117,10 @@ t128_read(uint32_t addr, void *priv)
         ret = t128->ext_ram[addr & 0x7f];
     else if ((addr >= 0x1c00) && (addr < 0x1c20)) {
         ret = t128->ctrl;
-        t128_log("T128 ctrl read=%02x, dma=%02x, load=%d, cnt=%d.\n", ret, ncr->mode & MODE_DMA, t128->block_loaded, t128->block_count);
+        t128_log("%04X:%08X: T128 ctrl read=%02x, dma=%02x, load=%d, cnt=%d, ID=%d.\n", CS, cpu_state.pc, ret, ncr->mode & MODE_DMA, t128->block_loaded, t128->block_count, scsi_bus->target_id);
     } else if ((addr >= 0x1c20) && (addr < 0x1c40)) {
         ret = t128->status;
-        t128_log("T128 status read=%02x, dma=%02x, blockload=%d, timer=%d.\n", ret, ncr->mode & MODE_DMA, t128->block_loaded, timer_is_enabled(&t128->timer));
+        t128_log("%04X:%08X: T128 status read=%02x, dma=%02x, blockload=%d, timer=%d, ID=%d.\n", CS, cpu_state.pc, ret, ncr->mode & MODE_DMA, t128->block_loaded, timer_is_enabled(&t128->timer), scsi_bus->target_id);
     } else if ((addr >= 0x1d00) && (addr < 0x1e00))
         ret = ncr5380_read((addr - 0x1d00) >> 5, ncr);
     else if (addr >= 0x1e00 && addr < 0x2000) {
@@ -174,7 +174,7 @@ t128_dma_mode_ext(void *priv, void *ext_priv, uint8_t val)
             ncr->tcr &= ~TCR_LAST_BYTE_SENT;
             ncr->isr &= ~STATUS_END_OF_DMA;
             scsi_bus->tx_mode = PIO_TX_BUS;
-            t128_log("End of DMA.\n");
+            t128_log("%04X:%08X: End of DMA, ID=%d.\n", CS, cpu_state.pc, scsi_bus->target_id);
         }
     }
 }
@@ -187,8 +187,8 @@ t128_dma_send_ext(void *priv, void *ext_priv)
     scsi_bus_t      *scsi_bus = &ncr->scsibus;
     scsi_device_t   *dev    = &scsi_devices[ncr->bus][scsi_bus->target_id];
 
+    t128_log("%04X:%08X: T128 DMA OUT, len=%d, ID=%d.\n", CS, cpu_state.pc, dev->buffer_length, scsi_bus->target_id);
     if ((ncr->mode & MODE_DMA) && (dev->buffer_length > 0)) {
-        t128_log("T128 DMA OUT, len=%d.\n", dev->buffer_length);
         memset(t128->buffer, 0, MIN(512, dev->buffer_length));
         t128->host_pos = 0;
 
@@ -206,8 +206,8 @@ t128_dma_initiator_receive_ext(void *priv, void *ext_priv)
     scsi_bus_t      *scsi_bus = &ncr->scsibus;
     scsi_device_t   *dev    = &scsi_devices[ncr->bus][scsi_bus->target_id];
 
+    t128_log("%04X:%08X: T128 DMA IN, len=%d, ID=%d.\n", CS, cpu_state.pc, dev->buffer_length, scsi_bus->target_id);
     if ((ncr->mode & MODE_DMA) && (dev->buffer_length > 0)) {
-        t128_log("T128 DMA IN, len=%d.\n", dev->buffer_length);
         memset(t128->buffer, 0, MIN(512, dev->buffer_length));
         t128->host_pos = MIN(512, dev->buffer_length);
 
@@ -240,7 +240,7 @@ t128_callback(void *priv)
     uint8_t         c;
     uint8_t         temp;
     uint8_t         status;
-    double          period     = scsi_bus->period / 60.0;
+    double          period     = scsi_bus->period / ((dev->buffer_length > 2048) ? 60.0 : 3.0);
 
     if (scsi_bus->tx_mode != PIO_TX_BUS) {
         if (period >= 10.0)
@@ -284,14 +284,14 @@ t128_callback(void *priv)
                 scsi_bus_update(scsi_bus, bus & ~BUS_ACK);
 
                 t128->pos++;
-                t128_log("T128 Buffer pos for writing = %d\n", t128->pos);
+                //t128_log("T128 Buffer pos for writing = %d\n", t128->pos);
 
                 if (t128->pos == MIN(512, dev->buffer_length)) {
                     t128->status |= 0x04;
                     t128->status &= ~0x02;
                     t128->pos = 0;
                     t128->host_pos = 0;
-                    t128_log("T128 Remaining blocks to be written=%d\n", t128->block_count);
+                    //t128_log("T128 Remaining blocks to be written=%d\n", t128->block_count);
                     if (scsi_bus->data_pos >= dev->buffer_length) {
                         t128->block_loaded = 0;
                         ncr->tcr |= TCR_LAST_BYTE_SENT;
@@ -333,7 +333,7 @@ t128_callback(void *priv)
                 scsi_bus_update(scsi_bus, bus & ~BUS_ACK);
 
                 t128->buffer[t128->pos++] = temp;
-                t128_log("T128 Buffer pos for reading = %d\n", t128->pos);
+                //t128_log("T128 Buffer pos for reading = %d\n", t128->pos);
 
                 if (t128->pos == MIN(512, dev->buffer_length)) {
                     t128->status |= 0x04;
@@ -344,8 +344,7 @@ t128_callback(void *priv)
                     if (scsi_bus->data_pos >= dev->buffer_length) {
                         scsi_bus->bus_out |= BUS_REQ;
                         t128->block_loaded = 0;
-                        timer_on_auto(&t128->timer, 10.0);
-                        t128_log("IO End of read transfer\n");
+                        t128_log("%04X:%08X: IO End of read transfer\n", CS, cpu_state.pc);
                     }
                     break;
                 }


### PR DESCRIPTION
Summary
=======
This makes sure that if the CD speed on QuickTime tests is not out of bounds and reflects the settings of the emulator more or less without breaking existing stuff (if the buffer length of the SCSI transfer is greater than 2048 bytes, stay as is, but if equal or less than 2048, adjust accordingly.

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
