### PR TITLE
CD-ROM: Remove Q-subchannel CRC checking altogether

### DIFF
--- a/src/cdrom/cdrom.c
+++ b/src/cdrom/cdrom.c
@@ -488,9 +488,7 @@ cdrom_get_subchannel(cdrom_t *dev, const uint32_t lba, const int cooked)
 
     if (dev->subc_sector == -1) {
         subchannel_t *subc  = &dev->cached_subc;
-        uint8_t       q[16]    = { 0 };
-        uint8_t       adr      = 0x00;
-        int           crc_good = 1;
+        uint8_t       q[16] = { 0 };
 
         (void) read_data(dev, lba, 0);
 
@@ -498,14 +496,6 @@ cdrom_get_subchannel(cdrom_t *dev, const uint32_t lba, const int cooked)
             for (int j = 0; j < 8; j++)
                 q[i] |= ((dev->raw_buffer[dev->cur_buf][RAW_SECTOR_SIZE +
                                           (i << 3) + j] >> 6) & 0x01) << (7 - j);
-
-        adr = q[0] & 0x0f;
-
-        if (!dev->no_check && (dev->cd_status != CD_STATUS_DVD) &&
-            ((q[12] & 0x0f) >= 0x01) && ((q[12] & 0x0f) <= 0x05)) {
-            const uint16_t q_sub_crc16 = cdrom_crc16(0xffff, q, 10);
-            crc_good = crc_good && (q_sub_crc16 == bswap16(*(uint16_t *) &q[10]));
-        }
 
         if (cooked) {
             uint8_t temp = (q[0] >> 4) | ((q[0] & 0xf) << 4);
@@ -517,8 +507,7 @@ cdrom_get_subchannel(cdrom_t *dev, const uint32_t lba, const int cooked)
             }
         }
 
-        if (crc_good && (adr == 0x01))
-            memcpy(subc, q, 10);
+        memcpy(subc, q, 10);
 
         dev->subc_sector = dev->cached_sector;
     }


### PR DESCRIPTION
Summary
=======
CD-ROM: Remove Q-subchannel CRC checking altogether.

The paper I found appears to have fell for a red herring altogether.

The SBI subchannel substitution still exists because SecuROM still reads the Q subchannel data.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
https://github.com/joncampbell123/dosbox-x/issues/211#issuecomment-1364789022
