### PR TITLE
CD: Use a XOR of 0x8001 instead of 0xFFFF for SBI subchannels

### DIFF
--- a/src/cdrom/cdrom_image.c
+++ b/src/cdrom/cdrom_image.c
@@ -2975,7 +2975,7 @@ image_read_sector(const void *local, uint8_t *buffer,
                 && img->sector_subs[i].type == 0x01) {
                     memcpy(&deinterleaved_subch[12], img->sector_subs[i].q, 10);
 
-                    *(uint16_t*)(&deinterleaved_subch[12 + 10]) = ~bswap16(cdrom_crc16(0xffff, img->sector_subs[i].q, 10));
+                    *(uint16_t*)(&deinterleaved_subch[12 + 10]) = bswap16(cdrom_crc16(0xffff, img->sector_subs[i].q, 10) ^ 0x8001);
                     cdrom_interleave_subch(&buffer[2352], deinterleaved_subch);
                     break;
                 }


### PR DESCRIPTION
Summary
=======
CD: Use a XOR of 0x8001 instead of 0xFFFF for SBI subchannels.

SecuROM uses this per DiscImageCreator.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
