### PR TITLE
cdrom_chd: fix reading from seek position

### DIFF
--- a/src/cdrom/cdrom_chd.c
+++ b/src/cdrom/cdrom_chd.c
@@ -451,24 +451,24 @@ chd_image_read_sector(const void *local, UNUSED(uint8_t *buffer), UNUSED(uint32_
     bool                    in_pregap = false;
 
     if (track == -1) {
-        pclog("No tracks found for sector %u\n", sector);
+        pclog("No tracks found for sector %u\n", lba);
         return 0;
     }
 
     memset(buffer, 0, 2448);
 
-    if (!chd_track->pregap_exists_in_file && sector < (chd_track->start + chd_track->pregap)) {
+    if (!chd_track->pregap_exists_in_file && lba < (chd_track->start + chd_track->pregap)) {
         in_pregap = true;
     }
 
-    if (sector >= ((chd_track->end + 1) - chd_track->postgap)) {
+    if (lba >= ((chd_track->end + 1) - chd_track->postgap)) {
         in_pregap = true;
         sector_track_type = ~0u;
         sector_sector_size = 0;
         subchannel_exists = false;
     }
 
-    if (sector < (chd_track->start + chd_track->pregap)) {
+    if (lba < (chd_track->start + chd_track->pregap)) {
         sector_track_type = chd_track->track_type_pg;
         sector_sector_size = chd_track->sector_size_pg;
         subchannel_exists = chd_track->subcode_type_pg;
@@ -477,9 +477,9 @@ chd_image_read_sector(const void *local, UNUSED(uint8_t *buffer), UNUSED(uint32_
 
     uint64_t chd_offset = 0;
     if (chd_track->pregap_exists_in_file) {
-        chd_offset = (sector - chd_track->start) * 2448 + chd_track->chd_start;
+        chd_offset = (lba - chd_track->start) * 2448 + chd_track->chd_start;
     } else {
-        chd_offset = (sector - (chd_track->start + chd_track->pregap)) * 2448 + chd_track->chd_start;
+        chd_offset = (lba - (chd_track->start + chd_track->pregap)) * 2448 + chd_track->chd_start;
     }
 
     int64_t hunk_to_use = (chd_offset / 2448) / ioctl->sectors_per_hunk;

--- a/src/cdrom/cdrom_chd.c
+++ b/src/cdrom/cdrom_chd.c
@@ -451,7 +451,6 @@ chd_image_read_sector(const void *local, UNUSED(uint8_t *buffer), UNUSED(uint32_
     bool                    in_pregap = false;
 
     if (track == -1) {
-        pclog("No tracks found for sector %u\n", lba);
         return 0;
     }
 


### PR DESCRIPTION
Summary
=======
cdrom_chd: fix reading from seek position.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
