### PR TITLE
Fix: Mouse capture with Vulkan and OpenGL under Gnome with wayland

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -405,8 +405,10 @@ MainWindow::MainWindow(QWidget *parent)
         if (mouse_capture) {
             if (hook_enabled)
                 this->grabKeyboard();
-            if (ui->stackedWidget->mouse_capture_func)
-                ui->stackedWidget->mouse_capture_func(this->windowHandle());
+            if (ui->stackedWidget->mouse_capture_func) {
+                auto *win = ui->stackedWidget->captureWindow();
+                ui->stackedWidget->mouse_capture_func(win ? win : this->windowHandle());
+            }
         } else {
             this->releaseKeyboard();
             if (ui->stackedWidget->mouse_uncapture_func) {

--- a/src/qt/qt_rendererstack.hpp
+++ b/src/qt/qt_rendererstack.hpp
@@ -7,6 +7,7 @@
 #include <QLayout>
 #include <QBoxLayout>
 #include <QWidget>
+#include <QWindow>
 #include <QCursor>
 #include <QScreen>
 
@@ -106,6 +107,11 @@ public:
     void (*mouse_uncapture_func)()              = nullptr;
 
     void (*mouse_exit_func)() = nullptr;
+
+    /* OpenGL/Vulkan renderers ARE QWindows; dynamic_cast returns the QWindow
+     * for pointer capture (Wayland, xinput2). Software renderer returns nullptr
+     * and the caller falls back to the main window. */
+    QWindow *captureWindow() const { return dynamic_cast<QWindow *>(rendererWindow); }
 
 signals:
     void blitToRenderer(int buf_idx, int x, int y, int w, int h);


### PR DESCRIPTION
Summary
=======
This code fixes the mouse capture under Gnome + Wayland + QT6.

### Problem

 Under Gnome with Wayland, mouse pointer constraints (via `zwp_pointer_constraints_v1_lock_pointer`) operate on
 `wl_surface` objects — and each `QWindow` has its own surface. When using OpenGL or Vulkan renderers, the actual
 rendering happens in a separate `QWindow` (`OpenGLRenderer` / `VulkanWindowRenderer`), but the mouse capture code was
 passing the main window's `windowHandle()` to the capture callback. Wayland then locked the wrong surface, and
 pointer constraints silently failed — the cursor escaped the window.

 ### Fix

 `OpenGLRenderer` and `VulkanWindowRenderer` both inherit from `QWindow` (via class OpenGLRenderer : public QWindow,
 public RendererCommon). The existing `rendererWindow` member already points to these objects, so a
 `dynamic_cast<QWindow*>(rendererWindow)` gives us the correct window for pointer capture.

 Added a small accessor in `RendererStack`:

 ```cpp
   QWindow *captureWindow() const { return dynamic_cast<QWindow *>(rendererWindow); }
 ```

 For software rendering, dynamic_cast returns nullptr (SoftwareRenderer inherits from QWidget, not QWindow), and
 the caller falls back to this->windowHandle() — preserving the original behaviour.

Checklist
=========
* [x] Closes [#7203](https://github.com/86Box/86Box/issues/7203)
* [x] I have tested my changes locally and validated that the functionality works as intended
