### PR TITLE
Fix: Mouse capture with Vulkan and OpenGL under Gnome with wayland under QT6

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -405,8 +405,14 @@ MainWindow::MainWindow(QWidget *parent)
         if (mouse_capture) {
             if (hook_enabled)
                 this->grabKeyboard();
-            if (ui->stackedWidget->mouse_capture_func)
+            if (ui->stackedWidget->mouse_capture_func) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                auto *win = ui->stackedWidget->captureWindow();
+                ui->stackedWidget->mouse_capture_func(win ? win : this->windowHandle());
+#else
                 ui->stackedWidget->mouse_capture_func(this->windowHandle());
+#endif
+            }
         } else {
             this->releaseKeyboard();
             if (ui->stackedWidget->mouse_uncapture_func) {

--- a/src/qt/qt_rendererstack.hpp
+++ b/src/qt/qt_rendererstack.hpp
@@ -7,6 +7,9 @@
 #include <QLayout>
 #include <QBoxLayout>
 #include <QWidget>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#    include <QWindow>
+#endif
 #include <QCursor>
 #include <QScreen>
 
@@ -106,6 +109,13 @@ public:
     void (*mouse_uncapture_func)()              = nullptr;
 
     void (*mouse_exit_func)() = nullptr;
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    /* OpenGL/Vulkan renderers ARE QWindows; dynamic_cast returns the QWindow
+     * for pointer capture (Wayland, xinput2). Software renderer returns nullptr
+     * and the caller falls back to the main window. */
+    QWindow *captureWindow() const { return dynamic_cast<QWindow *>(rendererWindow); }
+#endif
 
 signals:
     void blitToRenderer(int buf_idx, int x, int y, int w, int h);


### PR DESCRIPTION
Same as https://github.com/86Box/86Box/pull/7490 but only available for QT6 to avoid issues that caused the revert https://github.com/86Box/86Box/pull/7493

Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [x] Closes https://github.com/86Box/86Box/issues/7203
* [x] I have tested my changes locally and validated that the functionality works as intended. QT5 uses the previous implementation and QT6 the new one.

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
