### PR TITLE
Add top-level Makefile to ease in building the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ CMakeUserPresets.json
 CMakeCache.txt
 CMakeFiles
 /build
-Makefile
 *.a
 /src/*.exe
 /src/86Box

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+qt?=5
+dynarec?=
+CMAKE_FLAGS?=
+CMAKE_EXTRA:=
+
+ifeq ($(qt),6)
+	CMAKE_EXTRA += -DUSE_QT6=ON
+endif
+
+ifeq ($(dynarec),new)
+	CMAKE_EXTRA += -DNEW_DYNAREC=ON
+endif
+
+define do_configure
+	cmake --preset $(1) $(CMAKE_EXTRA) $(CMAKE_FLAGS)
+endef
+
+define do_build
+	$(call do_configure,$(1))
+	cmake --build build/$(1)
+endef
+
+.PHONY: all debug development dev_debug optimized regular clean
+
+all: regular
+
+regular:
+	$(call do_build,regular)
+
+optimized:
+	$(call do_build,optimized)
+
+debug:
+	$(call do_build,debug)
+
+dev_debug:
+	$(call do_build,dev_debug)
+
+development:
+	$(call do_build,development)
+
+clean:
+	$(RM) -r build


### PR DESCRIPTION
Summary
=======
Instead of having to memorize cmake commands, this should make it as easy as typing `make`.  Two provisions are made for changing the Qt version and choosing the new dynamic recompiler, under the `qt` and `dynarec` environment variables.

The default build target is “regular”: you may also use the `debug`, `dev_debug`, `development`, and `optimized` targets to build those cmake presets specifically.

To build with default options, simply run:
    make

To build with Qt 6, the new dynamic recompiler, and debug run:
    make qt=6 dynarec=new debug

The CMAKE_FLAGS environment variable is also usable for setting arbitrary cmake settings.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
