### PR TITLE
Add WindsorPOST 1.5 XT/PC Diagnostic ROM

### DIFF
--- a/src/machine/m_xt.c
+++ b/src/machine/m_xt.c
@@ -141,6 +141,15 @@ static const device_config_t ibmpc_config[] = {
                 .size          = 40960,
                 .files         = { "roms/machines/diagnostic/xtramtest_8k.bin", "" }
             },
+            {
+                .name          = "WindsorPOST",
+                .internal_name = "diag_windsorpost",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 40960,
+                .files         = { "roms/machines/diagnostic/windsorpost_8k.bin", "" }
+            },            
             { .files_no = 0 }
         }
     },
@@ -310,6 +319,15 @@ static const device_config_t ibmpc82_config[] = {
                 .local         = 0,
                 .size          = 40960,
                 .files         = { "roms/machines/diagnostic/xtramtest_8k.bin", "" }
+            },
+            {
+                .name          = "WindsorPOST",
+                .internal_name = "diag_windsorpost",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 40960,
+                .files         = { "roms/machines/diagnostic/windsorpost_8k.bin", "" }
             },
             { .files_no = 0 }
         }
@@ -498,6 +516,15 @@ static const device_config_t ibmxt_config[] = {
                 .files         = { "roms/machines/diagnostic/xtramtest_32k.bin",
                                    "roms/machines/ibmxt/BIOS_5160_08NOV82_U19_5000027.BIN", "" }
             },
+            {
+                .name          = "WindsorPOST",
+                .internal_name = "diag_windsorpost",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 40960,
+                .files         = { "roms/machines/diagnostic/windsorpost_8k.bin", "" }
+            },            
             { .files_no = 0 }
         }
     },
@@ -686,7 +713,15 @@ static const device_config_t ibmxt86_config[] = {
                 .size          = 65536,
                 .files         = { "roms/machines/diagnostic/xtramtest_32k.bin", "roms/machines/ibmxt86/BIOS_5160_09MAY86_U19_62X0819_68X4370_27256_F000.BIN", "" }
             },
-
+            {
+                .name          = "WindsorPOST",
+                .internal_name = "diag_windsorpost",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 40960,
+                .files         = { "roms/machines/diagnostic/windsorpost_8k.bin", "" }
+            },
             { .files_no = 0 }
         },
     },


### PR DESCRIPTION
Summary
=======
Add a diagnostic ROM called WindsorPOST V1.5 for use with PC/XT class machines

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/506
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
