### PR TITLE
Add support for READ CD-DA and READ CD-DA MSF commands

### DIFF
--- a/src/cdrom/cdrom.c
+++ b/src/cdrom/cdrom.c
@@ -2639,12 +2639,9 @@ cdrom_readsector_raw(cdrom_t *dev, uint8_t *buffer, const int sector, const int 
                     }
 
                     if ((cdrom_sector_flags & 0xff) == 0 && ((cdrom_sector_flags >> 8) & 7)) {
-                        dev->cdrom_sector_size = 96;
-                        memcpy(b, dev->raw_buffer[dev->cur_buf] + 2352, 96);
-                        *len = dev->cdrom_sector_size;
-                        return ret;
+                        dev->cdrom_sector_size = 0;
                     } else {
-                        dev->cdrom_sector_size = 2352; // Let the common code run.
+                        dev->cdrom_sector_size = 2352;
                     }
                 }
             } else if ((cdrom_sector_type > 1) && audio &&

--- a/src/cdrom/cdrom.c
+++ b/src/cdrom/cdrom.c
@@ -2632,10 +2632,19 @@ cdrom_readsector_raw(cdrom_t *dev, uint8_t *buffer, const int sector, const int 
             return 0;
         } else {
             if (cdrom_sector_flags & CD_SECTOR_FLAG_SCRAMBLED) {
-                ret = read_audio(dev, lba, temp_b);
+                ret = read_data(dev, lba, 0);
                 if (ret > 0 && !audio) {
                     for (int i = 0; i < 2352; i++) {
-                        buffer[i] ^= cdrom_scramble_table[i];
+                        dev->raw_buffer[dev->cur_buf][i] ^= cdrom_scramble_table[i];
+                    }
+
+                    if ((cdrom_sector_flags & 0xff) == 0 && ((cdrom_sector_flags >> 8) & 7)) {
+                        dev->cdrom_sector_size = 96;
+                        memcpy(b, dev->raw_buffer[dev->cur_buf] + 2352, 96);
+                        *len = dev->cdrom_sector_size;
+                        return ret;
+                    } else {
+                        dev->cdrom_sector_size = 2352; // Let the common code run.
                     }
                 }
             } else if ((cdrom_sector_type > 1) && audio &&

--- a/src/cdrom/cdrom.c
+++ b/src/cdrom/cdrom.c
@@ -2637,12 +2637,13 @@ cdrom_readsector_raw(cdrom_t *dev, uint8_t *buffer, const int sector, const int 
                     for (int i = 0; i < 2352; i++) {
                         dev->raw_buffer[dev->cur_buf][i] ^= cdrom_scramble_table[i];
                     }
+                }
 
-                    if ((cdrom_sector_flags & 0xff) == 0 && ((cdrom_sector_flags >> 8) & 7)) {
-                        dev->cdrom_sector_size = 0;
-                    } else {
-                        dev->cdrom_sector_size = 2352;
-                    }
+                if ((cdrom_sector_flags & 0xff) == 0 && ((cdrom_sector_flags >> 8) & 7)) {
+                    dev->cdrom_sector_size = 0;
+                } else {
+                    memcpy(temp_b, dev->raw_buffer[dev->cur_buf], 2352);
+                    dev->cdrom_sector_size = 2352;
                 }
             } else if ((cdrom_sector_type > 1) && audio &&
                 (dev->cd_status & CD_STATUS_HAS_AUDIO)) {

--- a/src/cdrom/cdrom.c
+++ b/src/cdrom/cdrom.c
@@ -2631,7 +2631,14 @@ cdrom_readsector_raw(cdrom_t *dev, uint8_t *buffer, const int sector, const int 
                       "type from an image\n");
             return 0;
         } else {
-            if ((cdrom_sector_type > 1) && audio &&
+            if (cdrom_sector_flags & CD_SECTOR_FLAG_SCRAMBLED) {
+                ret = read_audio(dev, lba, temp_b);
+                if (ret > 0 && !audio) {
+                    for (int i = 0; i < 2352; i++) {
+                        buffer[i] ^= cdrom_scramble_table[i];
+                    }
+                }
+            } else if ((cdrom_sector_type > 1) && audio &&
                 (dev->cd_status & CD_STATUS_HAS_AUDIO)) {
                 cdrom_log(dev->log, "[%s] Attempting to read a data sector "
                           "from an audio track\n",

--- a/src/include/86box/cdrom.h
+++ b/src/include/86box/cdrom.h
@@ -33,6 +33,8 @@
 #define CD_STATUS_HAS_AUDIO         0xc
 #define CD_STATUS_MASK              0x1f
 
+#define CD_SECTOR_FLAG_SCRAMBLED    0x80000000
+
 /* Medium changed flag. */
 #define CD_STATUS_TRANSITION     0x40
 #define CD_STATUS_MEDIUM_CHANGED 0x80

--- a/src/include/86box/scsi_device.h
+++ b/src/include/86box/scsi_device.h
@@ -160,6 +160,7 @@
 #define GPCMD_STOP_PIONEER                            0xcb /* Pioneer Vendor Unique command */
 #define GPCMD_PLAYBACK_STATUS_PIONEER                 0xcc /* Pioneer Vendor Unique command */
 #define GPCMD_SCAN_PIONEER                            0xcd /* Should be equivalent to 0xba */
+#define GPCMD_READ_CDDA_NEC                           0xd4 /* NEC Vendor Unique command */
 #define GPCMD_READ_CD_MSF_OLD                         0xd5 /* Should be equivalent to 0xb9 */
 #define GPCMD_READ_CDDA                               0xd8
 #define GPCMD_AUDIO_TRACK_SEARCH_NEC                  0xd8 /* NEC Vendor Unique command */

--- a/src/include/86box/scsi_device.h
+++ b/src/include/86box/scsi_device.h
@@ -161,7 +161,9 @@
 #define GPCMD_PLAYBACK_STATUS_PIONEER                 0xcc /* Pioneer Vendor Unique command */
 #define GPCMD_SCAN_PIONEER                            0xcd /* Should be equivalent to 0xba */
 #define GPCMD_READ_CD_MSF_OLD                         0xd5 /* Should be equivalent to 0xb9 */
+#define GPCMD_READ_CDDA                               0xd8
 #define GPCMD_AUDIO_TRACK_SEARCH_NEC                  0xd8 /* NEC Vendor Unique command */
+#define GPCMD_READ_CDDA_MSF                           0xd9
 #define GPCMD_PLAY_AUDIO_NEC                          0xd9 /* NEC Vendor Unique command */
 #define GPCMD_SET_SPEED_ALT                           0xda /* Should be equivalent to 0xbb */
 #define GPCMD_STILL_NEC                               0xda /* NEC Vendor Unique command */

--- a/src/include/86box/scsi_device.h
+++ b/src/include/86box/scsi_device.h
@@ -173,6 +173,7 @@
 #define GPCMD_CADDY_EJECT_NEC                         0xdc /* NEC Vendor Unique command */
 #define GPCMD_READ_SUBCODEQ_PLAYING_STATUS_NEC        0xdd /* NEC Vendor Unique command */
 #define GPCMD_READ_DISC_INFORMATION_NEC               0xde /* NEC Vendor Unique command */
+#define GPCMD_READ_ALL_SUBCODES_PIONEER               0xdf /* Pioneer Vendor Unique command */
 #define GPCMD_DRIVE_STATUS_PIONEER                    0xe0 /* Pioneer Vendor Unique command */
 #define GPCMD_PLAY_AUDIO_12_MATSUSHITA                0xe5 /* Matsushita Vendor Unique command */
 #define GPCMD_PLAY_AUDIO_TRACK_RELATIVE_12_MATSUSHITA 0xe9 /* Matsushita Vendor Unique command */

--- a/src/include/86box/scsi_device.h
+++ b/src/include/86box/scsi_device.h
@@ -168,6 +168,7 @@
 #define GPCMD_SET_SPEED_ALT                           0xda /* Should be equivalent to 0xbb */
 #define GPCMD_STILL_NEC                               0xda /* NEC Vendor Unique command */
 #define GPCMD_SET_STOP_TIME_NEC                       0xdb /* NEC Vendor Unique command */
+#define GPCMD_READ_CDXA_PIONEER                       0xdb /* Pioneer Vendor Unique command */
 #define GPCMD_CADDY_EJECT_NEC                         0xdc /* NEC Vendor Unique command */
 #define GPCMD_READ_SUBCODEQ_PLAYING_STATUS_NEC        0xdd /* NEC Vendor Unique command */
 #define GPCMD_READ_DISC_INFORMATION_NEC               0xde /* NEC Vendor Unique command */

--- a/src/scsi/scsi_cdrom.c
+++ b/src/scsi/scsi_cdrom.c
@@ -1109,6 +1109,7 @@ static int
 scsi_cdrom_read_blocks(scsi_cdrom_t *dev)
 {
     int     ret      = 1;
+    int     handled  = 0;
     int     type     = dev->sector_type;
     int     flags    = dev->sector_flags;
     uint8_t ven_type = dev->vendor_type;
@@ -1117,28 +1118,8 @@ scsi_cdrom_read_blocks(scsi_cdrom_t *dev)
                 dev->requested_blocks : 1;
 #endif
 
-    switch (dev->current_cdb[0]) {
-        case GPCMD_READ_CD_MSF_OLD:
-        case GPCMD_READ_CD_MSF:
-            /*
-               No setting of MSF because the position is already converted
-               to LBA in scsi_cdrom_command().
-
-               Just force the vendor type 0x00 to avoid any BCD conversion.
-             */
-            ven_type = 0x00;
-            fallthrough;
-        case GPCMD_PLAY_CD:
-        case GPCMD_READ_CD_OLD:
-        case GPCMD_READ_CD:
-            type     = (dev->current_cdb[1] >> 2) & 7;
-            flags    = dev->current_cdb[9] | (((uint32_t) dev->current_cdb[10]) << 8);
-            break;
-        case GPCMD_READ_HEADER:
-        case GPCMD_READ_HEADER_SONY:
-            type     = 0x00;
-            flags    = 0x20;
-            break;
+    if (dev->drv->is_plextor) {
+        switch (dev->current_cdb[0]) {
         case GPCMD_READ_CDDA_MSF:
             ven_type = 0x00;
             fallthrough;
@@ -1160,7 +1141,33 @@ scsi_cdrom_read_blocks(scsi_cdrom_t *dev)
                     break;
             }
 
-            flags |= CD_SECTOR_FLAG_SCRAMBLED | ((dev->current_cdb[10] != 3) ? 0xb8 : 0x00);
+            flags |= CD_SECTOR_FLAG_SCRAMBLED | 0xb8;
+            handled = 1;
+            break;
+        }
+    }
+
+    if (!handled) switch (dev->current_cdb[0]) {
+        case GPCMD_READ_CD_MSF_OLD:
+        case GPCMD_READ_CD_MSF:
+            /*
+               No setting of MSF because the position is already converted
+               to LBA in scsi_cdrom_command().
+
+               Just force the vendor type 0x00 to avoid any BCD conversion.
+             */
+            ven_type = 0x00;
+            fallthrough;
+        case GPCMD_PLAY_CD:
+        case GPCMD_READ_CD_OLD:
+        case GPCMD_READ_CD:
+            type     = (dev->current_cdb[1] >> 2) & 7;
+            flags    = dev->current_cdb[9] | (((uint32_t) dev->current_cdb[10]) << 8);
+            break;
+        case GPCMD_READ_HEADER:
+        case GPCMD_READ_HEADER_SONY:
+            type     = 0x00;
+            flags    = 0x20;
             break;
         default:
             if (dev->sector_type == 0xff) {
@@ -1541,6 +1548,93 @@ scsi_cdrom_set_speed(scsi_cdrom_t *dev, const uint8_t *cdb)
         dev->drv->cur_speed = dev->drv->real_speed;
     scsi_cdrom_set_phase(dev, SCSI_PHASE_STATUS);
     scsi_cdrom_command_complete(dev);
+}
+
+static uint8_t
+scsi_cdrom_command_plextor(void *sc, const uint8_t *cdb, UNUSED(int32_t *BufLen))
+{
+    scsi_cdrom_t *dev                    = (scsi_cdrom_t *) sc;
+    uint8_t       cmd_stat               = 0x00;
+    uint32_t      alloc_length           = 0;
+    int           pos                    = dev->drv->seek_pos;
+
+    switch (cdb[0]) {
+        case GPCMD_READ_CDDA:
+        case GPCMD_READ_CDDA_MSF:
+            cmd_stat = 1;
+            if (dev->current_cdb[0] == GPCMD_READ_CDDA_MSF) {
+                dev->sector_len = MSFtoLBA(cdb[7], cdb[8], cdb[9]) - 150;
+                dev->sector_pos = MSFtoLBA(cdb[3], cdb[4], cdb[5]) - 150;
+
+                dev->sector_len -= dev->sector_pos;
+                dev->sector_len++;
+            } else if (dev->current_cdb[0] == GPCMD_READ_CDDA) {
+                dev->sector_len = (cdb[6] << 24) | (cdb[7] << 16) | (cdb[8] << 8) | cdb[9];
+                dev->sector_pos = (cdb[2] << 24) | (cdb[3] << 16) | (cdb[4] << 8) | cdb[5];
+            }
+
+            if (dev->current_cdb[0] == GPCMD_READ_CDDA || dev->current_cdb[0] == GPCMD_READ_CDDA_MSF) {
+                if (cdb[10] > 0x3) {
+                    /* Illegal mode */
+                    scsi_cdrom_invalid_field(dev, cdb[9]);
+                    break;
+                }
+            }
+            if (dev->sector_len > 0) {
+                uint32_t max_len      = dev->sector_len;
+                dev->requested_blocks = max_len;
+
+                dev->packet_len = max_len * alloc_length;
+                scsi_cdrom_buf_alloc(dev, dev->packet_len);
+
+                dev->drv->seek_diff = ABS((int) (pos - dev->sector_pos));
+                dev->drv->seek_pos  = dev->sector_pos;
+
+                /* Any of these commands stop the audio playing. */
+                cdrom_stop(dev->drv);
+
+                if (dev->use_cdb_9 && ((dev->current_cdb[0] == GPCMD_READ_10) || (dev->current_cdb[0] == GPCMD_READ_12)))
+                    dev->vendor_type = cdb[9] & 0xc0;
+                else
+                    dev->vendor_type = 0x00;
+
+                dev->block_len  = 0xffffffff;
+                dev->buffer_pos = 0x00000000;
+
+                int ret      = scsi_cdrom_read_blocks(dev);
+                alloc_length = dev->requested_blocks * dev->block_len;
+
+                if (ret > 0) {
+                    dev->packet_len = alloc_length;
+
+                    scsi_cdrom_set_buf_len(dev, BufLen,
+                                           (int32_t *) &dev->packet_len);
+
+                    scsi_cdrom_data_command_finish(dev, alloc_length,
+                                                   dev->block_len,
+                                                   alloc_length, 0);
+
+                    if (dev->packet_status != PHASE_COMPLETE)
+                        ui_sb_update_icon(SB_CDROM | dev->id, 1);
+                    else
+                        ui_sb_update_icon(SB_CDROM | dev->id, 0);
+                } else {
+                    scsi_cdrom_set_phase(dev, SCSI_PHASE_STATUS);
+                    dev->packet_status = (ret < 0) ? PHASE_ERROR : PHASE_COMPLETE;
+                    dev->callback      = 20.0 * CDROM_TIME;
+                    scsi_cdrom_set_callback(dev);
+                }
+            } else {
+                scsi_cdrom_set_phase(dev, SCSI_PHASE_STATUS);
+                /* scsi_cdrom_log(dev->log, "All done - callback set\n"); */
+                dev->packet_status = PHASE_COMPLETE;
+                dev->callback      = 20.0 * CDROM_TIME;
+                scsi_cdrom_set_callback(dev);
+            }
+            break;
+    }
+
+    return cmd_stat;
 }
 
 static uint8_t
@@ -2711,22 +2805,9 @@ scsi_cdrom_command(scsi_common_t *sc, const uint8_t *cdb)
                 case GPCMD_PLAY_CD:
                 case GPCMD_READ_CD_OLD:
                 case GPCMD_READ_CD:
-                case GPCMD_READ_CDDA:
-                case GPCMD_READ_CDDA_MSF:
                     alloc_length    = 2856;
 
-                    if (dev->current_cdb[0] == GPCMD_READ_CDDA_MSF) {
-                        dev->sector_len = MSFtoLBA(cdb[7], cdb[8], cdb[9]) - 150;
-                        dev->sector_pos = MSFtoLBA(cdb[3], cdb[4], cdb[5]) - 150;
-
-                        dev->sector_len -= dev->sector_pos;
-                        dev->sector_len++;
-                    } else if (dev->current_cdb[0] == GPCMD_READ_CDDA) {
-                        dev->sector_len = (cdb[6] << 24) | (cdb[7] << 16) |
-                                          (cdb[8] << 8) | cdb[9];
-                        dev->sector_pos = (cdb[2] << 24) | (cdb[3] << 16) |
-                                          (cdb[4] << 8) | cdb[5];
-                    } else if (msf) {
+                    if (msf) {
                         dev->sector_len = MSFtoLBA(cdb[6], cdb[7], cdb[8]) - 150;
                         dev->sector_pos = MSFtoLBA(cdb[3], cdb[4], cdb[5]) - 150;
 
@@ -4011,7 +4092,9 @@ scsi_cdrom_drive_reset(const int c)
         dev->ms_pages_default      = scsi_cdrom_ms_pages_default_scsi;
         dev->ms_pages_changeable   = scsi_cdrom_ms_pages_changeable_scsi;
 
-        if (dev->drv->is_chinon)
+        if (dev->drv->is_plextor)
+            dev->ven_cmd               = scsi_cdrom_command_plextor;
+        else if (dev->drv->is_chinon)
             dev->ven_cmd               = scsi_cdrom_command_chinon;
         else if (dev->drv->is_sony) {
             dev->ven_cmd               = scsi_cdrom_command_dec_sony_texel;

--- a/src/scsi/scsi_cdrom.c
+++ b/src/scsi/scsi_cdrom.c
@@ -1139,6 +1139,29 @@ scsi_cdrom_read_blocks(scsi_cdrom_t *dev)
             type     = 0x00;
             flags    = 0x20;
             break;
+        case GPCMD_READ_CDDA_MSF:
+            ven_type = 0x00;
+            fallthrough;
+        case GPCMD_READ_CDDA:
+            type     = 0x01;
+
+            switch (dev->current_cdb[10]) {
+                case 0:
+                    flags = 0x000;
+                    break;
+                case 1:
+                    flags = 0x400;
+                    break;
+                case 2:
+                    flags = 0x200;
+                    break;
+                case 3:
+                    flags = 0x100;
+                    break;
+            }
+
+            flags |= CD_SECTOR_FLAG_SCRAMBLED | ((dev->current_cdb[10] != 3) ? 0xb8 : 0x00);
+            break;
         default:
             if (dev->sector_type == 0xff) {
                 scsi_cdrom_illegal_mode(dev);
@@ -2626,6 +2649,8 @@ scsi_cdrom_command(scsi_common_t *sc, const uint8_t *cdb)
         case GPCMD_READ_CD_MSF_OLD:
         case GPCMD_READ_CD:
         case GPCMD_READ_CD_MSF:
+        case GPCMD_READ_CDDA:
+        case GPCMD_READ_CDDA_MSF:
             scsi_cdrom_set_phase(dev, SCSI_PHASE_DATA_IN);
             dev->was_cached = 0;
 
@@ -2686,9 +2711,22 @@ scsi_cdrom_command(scsi_common_t *sc, const uint8_t *cdb)
                 case GPCMD_PLAY_CD:
                 case GPCMD_READ_CD_OLD:
                 case GPCMD_READ_CD:
+                case GPCMD_READ_CDDA:
+                case GPCMD_READ_CDDA_MSF:
                     alloc_length    = 2856;
 
-                    if (msf) {
+                    if (dev->current_cdb[0] == GPCMD_READ_CDDA_MSF) {
+                        dev->sector_len = MSFtoLBA(cdb[7], cdb[8], cdb[9]) - 150;
+                        dev->sector_pos = MSFtoLBA(cdb[3], cdb[4], cdb[5]) - 150;
+
+                        dev->sector_len -= dev->sector_pos;
+                        dev->sector_len++;
+                    } else if (dev->current_cdb[0] == GPCMD_READ_CDDA) {
+                        dev->sector_len = (cdb[6] << 24) | (cdb[7] << 16) |
+                                          (cdb[8] << 8) | cdb[9];
+                        dev->sector_pos = (cdb[2] << 24) | (cdb[3] << 16) |
+                                          (cdb[4] << 8) | cdb[5];
+                    } else if (msf) {
                         dev->sector_len = MSFtoLBA(cdb[6], cdb[7], cdb[8]) - 150;
                         dev->sector_pos = MSFtoLBA(cdb[3], cdb[4], cdb[5]) - 150;
 
@@ -2700,7 +2738,13 @@ scsi_cdrom_command(scsi_common_t *sc, const uint8_t *cdb)
                                           (cdb[4] << 8) | cdb[5];
                     }
 
-                    if (((cdb[9] & 0xf8) == 0x08) || ((cdb[9] == 0x00) &&
+                    if (dev->current_cdb[0] == GPCMD_READ_CDDA || dev->current_cdb[0] == GPCMD_READ_CDDA_MSF) {
+                        if (cdb[10] > 0x3) {
+                            /* Illegal mode */
+                            scsi_cdrom_invalid_field(dev, cdb[9]);
+                            ret = 0;
+                        }
+                    } else if (((cdb[9] & 0xf8) == 0x08) || ((cdb[9] == 0x00) &&
                         ((cdb[10] & 0x07) != 0x00))) {
                         /* Illegal mode */
                         scsi_cdrom_invalid_field(dev, cdb[9]);

--- a/src/scsi/scsi_cdrom.c
+++ b/src/scsi/scsi_cdrom.c
@@ -1137,6 +1137,11 @@ scsi_cdrom_read_blocks(scsi_cdrom_t *dev)
             }
             break;
         }
+        }
+    }
+
+    if (dev->drv->is_sony || dev->drv->is_pioneer) {
+        switch (dev->current_cdb[0]) {
         case GPCMD_READ_CDDA_MSF:
             ven_type = 0x00;
             fallthrough;
@@ -1161,59 +1166,6 @@ scsi_cdrom_read_blocks(scsi_cdrom_t *dev)
             flags |= CD_SECTOR_FLAG_SCRAMBLED;
             if (dev->current_cdb[10] != 3)
                 flags |= 0xF8;
-            handled = 1;
-            break;
-        }
-    }
-
-    if (dev->drv->is_sony) {
-        switch (dev->current_cdb[0]) {
-        case GPCMD_READ_CDDA:
-            type     = 0x01;
-
-            switch (dev->current_cdb[10]) {
-                case 0:
-                    flags = 0x000;
-                    break;
-                case 1:
-                    flags = 0x200;
-                    break;
-                case 2:
-                    flags = 0x100;
-                    break;
-                case 3:
-                    flags = 0x100;
-                    break;
-            }
-
-            flags |= CD_SECTOR_FLAG_SCRAMBLED;
-            if (dev->current_cdb[10] != 3)
-                flags |= 0xF8;
-            handled = 1;
-            break;
-        case GPCMD_READ_CDDA_MSF:
-            ven_type = 0x00;
-            type     = 0x01;
-
-            switch (dev->current_cdb[10]) {
-                case 0:
-                    flags = 0x000;
-                    break;
-                case 1:
-                    flags = 0x200;
-                    break;
-                case 2:
-                    flags = 0x400;
-                    break;
-                case 3:
-                case 8:
-                    flags = 0x100;
-                    break;
-            }
-
-            flags |= CD_SECTOR_FLAG_SCRAMBLED | 0xF8;
-            if (dev->current_cdb[10] == 8)
-                flags |= 2;
             handled = 1;
             break;
         }
@@ -1665,6 +1617,7 @@ scsi_cdrom_command_plextor(void *sc, const uint8_t *cdb, UNUSED(int32_t *BufLen)
     switch (cdb[0]) {
         case GPCMD_READ_CDDA:
         case GPCMD_READ_CDDA_MSF:
+            alloc_length = 2852;
             cmd_stat = 1;
             if (dev->current_cdb[0] == GPCMD_READ_CDDA_MSF) {
                 dev->sector_len = MSFtoLBA(cdb[7], cdb[8], cdb[9]) - 150;
@@ -1849,6 +1802,7 @@ scsi_cdrom_command_dec_sony_texel(void *sc, const uint8_t *cdb, int32_t *BufLen)
         case GPCMD_READ_CDDA:
         case GPCMD_READ_CDDA_MSF:
             cmd_stat = 1;
+            alloc_length = 2852;
             if (dev->current_cdb[0] == GPCMD_READ_CDDA_MSF) {
                 dev->sector_len = MSFtoLBA(cdb[7], cdb[8], cdb[9]) - 150;
                 dev->sector_pos = MSFtoLBA(cdb[3], cdb[4], cdb[5]) - 150;
@@ -2400,6 +2354,7 @@ scsi_cdrom_command_pioneer(void *sc, const uint8_t *cdb, int32_t *BufLen)
         case GPCMD_READ_CDDA_MSF:
         case GPCMD_READ_CDXA_PIONEER:
             cmd_stat = 1;
+            alloc_length = 2852;
             if (dev->current_cdb[0] == GPCMD_READ_CDDA_MSF) {
                 dev->sector_len = MSFtoLBA(cdb[7], cdb[8], cdb[9]) - 150;
                 dev->sector_pos = MSFtoLBA(cdb[3], cdb[4], cdb[5]) - 150;

--- a/src/scsi/scsi_cdrom.c
+++ b/src/scsi/scsi_cdrom.c
@@ -110,8 +110,10 @@ uint8_t scsi_cdrom_command_flags[0x100] = {
     [0xbd]          = IMPLEMENTED,
     [0xbe ... 0xbf] = IMPLEMENTED | CHECK_READY,
     [0xc0 ... 0xcd] = IMPLEMENTED | CHECK_READY | SCSI_ONLY,
+    [0xd4]          = IMPLEMENTED | CHECK_READY | SCSI_ONLY,
     [0xd5]          = IMPLEMENTED | CHECK_READY,
     [0xd8 ... 0xde] = IMPLEMENTED | CHECK_READY | SCSI_ONLY,
+    [0xdf]          = IMPLEMENTED | CHECK_READY | SCSI_ONLY,
     [0xe0 ... 0xe1] = IMPLEMENTED | CHECK_READY | SCSI_ONLY,
     [0xe3 ... 0xe9] = IMPLEMENTED | CHECK_READY | SCSI_ONLY,
     [0xeb]          = IMPLEMENTED | CHECK_READY | SCSI_ONLY,
@@ -1117,6 +1119,17 @@ scsi_cdrom_read_blocks(scsi_cdrom_t *dev)
     int num   = (dev->drv->bus_type == CDROM_BUS_SCSI) ?
                 dev->requested_blocks : 1;
 #endif
+
+    if (dev->drv->is_nec) {
+        switch (dev->current_cdb[0]) {
+            case GPCMD_READ_CDDA_NEC:
+            {
+                type = 0;
+                flags = CD_SECTOR_FLAG_SCRAMBLED | 0xf8;
+                break;
+            }
+        }
+    }
 
     if (dev->drv->is_pioneer) {
         switch (dev->current_cdb[0]) {
@@ -2210,6 +2223,65 @@ scsi_cdrom_command_nec(void *sc, const uint8_t *cdb, int32_t *BufLen)
         default:
             break;
 
+        case GPCMD_READ_CDDA_NEC:
+            cmd_stat = 1;
+            alloc_length = 2852;
+            dev->sector_len = (cdb[7] << 8) | cdb[8];
+            dev->sector_pos = (cdb[2] << 24) | (cdb[3] << 16) | (cdb[4] << 8) | cdb[5];
+
+            if (dev->sector_len > 0) {
+                uint32_t max_len      = dev->sector_len;
+                dev->requested_blocks = max_len;
+
+                dev->packet_len = max_len * alloc_length;
+                scsi_cdrom_buf_alloc(dev, dev->packet_len);
+
+                dev->drv->seek_diff = ABS((int) (pos - dev->sector_pos));
+                dev->drv->seek_pos  = dev->sector_pos;
+
+                /* Any of these commands stop the audio playing. */
+                cdrom_stop(dev->drv);
+
+                if (dev->use_cdb_9 && ((dev->current_cdb[0] == GPCMD_READ_10) || (dev->current_cdb[0] == GPCMD_READ_12)))
+                    dev->vendor_type = cdb[9] & 0xc0;
+                else
+                    dev->vendor_type = 0x00;
+
+                dev->block_len  = 0xffffffff;
+                dev->buffer_pos = 0x00000000;
+
+                int ret      = scsi_cdrom_read_blocks(dev);
+                alloc_length = dev->requested_blocks * dev->block_len;
+
+                if (ret > 0) {
+                    dev->packet_len = alloc_length;
+
+                    scsi_cdrom_set_buf_len(dev, BufLen,
+                                           (int32_t *) &dev->packet_len);
+
+                    scsi_cdrom_data_command_finish(dev, alloc_length,
+                                                   dev->block_len,
+                                                   alloc_length, 0);
+
+                    if (dev->packet_status != PHASE_COMPLETE)
+                        ui_sb_update_icon(SB_CDROM | dev->id, 1);
+                    else
+                        ui_sb_update_icon(SB_CDROM | dev->id, 0);
+                } else {
+                    scsi_cdrom_set_phase(dev, SCSI_PHASE_STATUS);
+                    dev->packet_status = (ret < 0) ? PHASE_ERROR : PHASE_COMPLETE;
+                    dev->callback      = 20.0 * CDROM_TIME;
+                    scsi_cdrom_set_callback(dev);
+                }
+            } else {
+                scsi_cdrom_set_phase(dev, SCSI_PHASE_STATUS);
+                /* scsi_cdrom_log(dev->log, "All done - callback set\n"); */
+                dev->packet_status = PHASE_COMPLETE;
+                dev->callback      = 20.0 * CDROM_TIME;
+                scsi_cdrom_set_callback(dev);
+            }
+            break;
+
         case GPCMD_NO_OPERATION_NEC:
             scsi_cdrom_set_phase(dev, SCSI_PHASE_STATUS);
             scsi_cdrom_command_complete(dev);
@@ -2368,12 +2440,6 @@ scsi_cdrom_command_pioneer(void *sc, const uint8_t *cdb, int32_t *BufLen)
 
             if (dev->current_cdb[0] == GPCMD_READ_CDDA || dev->current_cdb[0] == GPCMD_READ_CDDA_MSF) {
                 if (cdb[10] > 0x3) {
-                    /* Illegal mode */
-                    scsi_cdrom_invalid_field(dev, cdb[9]);
-                    break;
-                }
-            } else {
-                if (cdb[6] != 0x00 && cdb[6] != 0x0F && cdb[6] != 0x1F) {
                     /* Illegal mode */
                     scsi_cdrom_invalid_field(dev, cdb[9]);
                     break;

--- a/src/scsi/scsi_cdrom.c
+++ b/src/scsi/scsi_cdrom.c
@@ -1120,6 +1120,23 @@ scsi_cdrom_read_blocks(scsi_cdrom_t *dev)
 
     if (dev->drv->is_pioneer) {
         switch (dev->current_cdb[0]) {
+        case GPCMD_READ_CDXA_PIONEER:
+        {
+            ven_type = 0x00;
+            flags = 0x00;
+            switch (dev->current_cdb[6]) {
+                case 0x00:
+                    flags = 0x10;
+                    break;
+                case 0x0F:
+                    flags = 0xF8;
+                    break;
+                case 0x1F:
+                    flags = 0xFA;
+                    break;
+            }
+            break;
+        }
         case GPCMD_READ_CDDA_MSF:
             ven_type = 0x00;
             fallthrough;
@@ -1143,7 +1160,7 @@ scsi_cdrom_read_blocks(scsi_cdrom_t *dev)
 
             flags |= CD_SECTOR_FLAG_SCRAMBLED;
             if (dev->current_cdb[10] != 3)
-                flags |= 0xb8;
+                flags |= 0xF8;
             handled = 1;
             break;
         }
@@ -1171,7 +1188,7 @@ scsi_cdrom_read_blocks(scsi_cdrom_t *dev)
 
             flags |= CD_SECTOR_FLAG_SCRAMBLED;
             if (dev->current_cdb[10] != 3)
-                flags |= 0xb8;
+                flags |= 0xF8;
             handled = 1;
             break;
         case GPCMD_READ_CDDA_MSF:
@@ -1194,7 +1211,7 @@ scsi_cdrom_read_blocks(scsi_cdrom_t *dev)
                     break;
             }
 
-            flags |= CD_SECTOR_FLAG_SCRAMBLED | 0xb8;
+            flags |= CD_SECTOR_FLAG_SCRAMBLED | 0xF8;
             if (dev->current_cdb[10] == 8)
                 flags |= 2;
             handled = 1;
@@ -2381,6 +2398,7 @@ scsi_cdrom_command_pioneer(void *sc, const uint8_t *cdb, int32_t *BufLen)
     switch (cdb[0]) {
         case GPCMD_READ_CDDA:
         case GPCMD_READ_CDDA_MSF:
+        case GPCMD_READ_CDXA_PIONEER:
             cmd_stat = 1;
             if (dev->current_cdb[0] == GPCMD_READ_CDDA_MSF) {
                 dev->sector_len = MSFtoLBA(cdb[7], cdb[8], cdb[9]) - 150;
@@ -2388,13 +2406,19 @@ scsi_cdrom_command_pioneer(void *sc, const uint8_t *cdb, int32_t *BufLen)
 
                 dev->sector_len -= dev->sector_pos;
                 dev->sector_len++;
-            } else if (dev->current_cdb[0] == GPCMD_READ_CDDA) {
+            } else {
                 dev->sector_len = (cdb[6] << 24) | (cdb[7] << 16) | (cdb[8] << 8) | cdb[9];
                 dev->sector_pos = (cdb[2] << 24) | (cdb[3] << 16) | (cdb[4] << 8) | cdb[5];
             }
 
             if (dev->current_cdb[0] == GPCMD_READ_CDDA || dev->current_cdb[0] == GPCMD_READ_CDDA_MSF) {
                 if (cdb[10] > 0x3) {
+                    /* Illegal mode */
+                    scsi_cdrom_invalid_field(dev, cdb[9]);
+                    break;
+                }
+            } else {
+                if (cdb[6] != 0x00 && cdb[6] != 0x0F && cdb[6] != 0x1F) {
                     /* Illegal mode */
                     scsi_cdrom_invalid_field(dev, cdb[9]);
                     break;

--- a/src/scsi/scsi_cdrom.c
+++ b/src/scsi/scsi_cdrom.c
@@ -2743,8 +2743,6 @@ scsi_cdrom_command(scsi_common_t *sc, const uint8_t *cdb)
         case GPCMD_READ_CD_MSF_OLD:
         case GPCMD_READ_CD:
         case GPCMD_READ_CD_MSF:
-        case GPCMD_READ_CDDA:
-        case GPCMD_READ_CDDA_MSF:
             scsi_cdrom_set_phase(dev, SCSI_PHASE_DATA_IN);
             dev->was_cached = 0;
 
@@ -2819,13 +2817,7 @@ scsi_cdrom_command(scsi_common_t *sc, const uint8_t *cdb)
                                           (cdb[4] << 8) | cdb[5];
                     }
 
-                    if (dev->current_cdb[0] == GPCMD_READ_CDDA || dev->current_cdb[0] == GPCMD_READ_CDDA_MSF) {
-                        if (cdb[10] > 0x3) {
-                            /* Illegal mode */
-                            scsi_cdrom_invalid_field(dev, cdb[9]);
-                            ret = 0;
-                        }
-                    } else if (((cdb[9] & 0xf8) == 0x08) || ((cdb[9] == 0x00) &&
+                    if (((cdb[9] & 0xf8) == 0x08) || ((cdb[9] == 0x00) &&
                         ((cdb[10] & 0x07) != 0x00))) {
                         /* Illegal mode */
                         scsi_cdrom_invalid_field(dev, cdb[9]);

--- a/src/scsi/scsi_cdrom.c
+++ b/src/scsi/scsi_cdrom.c
@@ -1118,6 +1118,90 @@ scsi_cdrom_read_blocks(scsi_cdrom_t *dev)
                 dev->requested_blocks : 1;
 #endif
 
+    if (dev->drv->is_pioneer) {
+        switch (dev->current_cdb[0]) {
+        case GPCMD_READ_CDDA_MSF:
+            ven_type = 0x00;
+            fallthrough;
+        case GPCMD_READ_CDDA:
+            type     = 0x01;
+
+            switch (dev->current_cdb[10]) {
+                case 0:
+                    flags = 0x000;
+                    break;
+                case 1:
+                    flags = 0x200;
+                    break;
+                case 2:
+                    flags = 0x100;
+                    break;
+                case 3:
+                    flags = 0x100;
+                    break;
+            }
+
+            flags |= CD_SECTOR_FLAG_SCRAMBLED;
+            if (dev->current_cdb[10] != 3)
+                flags |= 0xb8;
+            handled = 1;
+            break;
+        }
+    }
+
+    if (dev->drv->is_sony) {
+        switch (dev->current_cdb[0]) {
+        case GPCMD_READ_CDDA:
+            type     = 0x01;
+
+            switch (dev->current_cdb[10]) {
+                case 0:
+                    flags = 0x000;
+                    break;
+                case 1:
+                    flags = 0x200;
+                    break;
+                case 2:
+                    flags = 0x100;
+                    break;
+                case 3:
+                    flags = 0x100;
+                    break;
+            }
+
+            flags |= CD_SECTOR_FLAG_SCRAMBLED;
+            if (dev->current_cdb[10] != 3)
+                flags |= 0xb8;
+            handled = 1;
+            break;
+        case GPCMD_READ_CDDA_MSF:
+            ven_type = 0x00;
+            type     = 0x01;
+
+            switch (dev->current_cdb[10]) {
+                case 0:
+                    flags = 0x000;
+                    break;
+                case 1:
+                    flags = 0x200;
+                    break;
+                case 2:
+                    flags = 0x400;
+                    break;
+                case 3:
+                case 8:
+                    flags = 0x100;
+                    break;
+            }
+
+            flags |= CD_SECTOR_FLAG_SCRAMBLED | 0xb8;
+            if (dev->current_cdb[10] == 8)
+                flags |= 2;
+            handled = 1;
+            break;
+        }
+    }
+
     if (dev->drv->is_plextor) {
         switch (dev->current_cdb[0]) {
         case GPCMD_READ_CDDA_MSF:
@@ -1735,12 +1819,88 @@ scsi_cdrom_command_dec_sony_texel(void *sc, const uint8_t *cdb, int32_t *BufLen)
     scsi_cdrom_t *dev                    = (scsi_cdrom_t *) sc;
     int           ret                    = 1;
     uint8_t       cmd_stat               = 0x00;
+    uint32_t      pos                    = dev->drv->seek_pos;
+    int           alloc_length           = 0;
     int           msf;
     int           len;
     int           max_len;
 
     switch (cdb[0]) {
         default:
+            break;
+
+        case GPCMD_READ_CDDA:
+        case GPCMD_READ_CDDA_MSF:
+            cmd_stat = 1;
+            if (dev->current_cdb[0] == GPCMD_READ_CDDA_MSF) {
+                dev->sector_len = MSFtoLBA(cdb[7], cdb[8], cdb[9]) - 150;
+                dev->sector_pos = MSFtoLBA(cdb[3], cdb[4], cdb[5]) - 150;
+
+                dev->sector_len -= dev->sector_pos;
+                dev->sector_len++;
+            } else if (dev->current_cdb[0] == GPCMD_READ_CDDA) {
+                dev->sector_len = (cdb[6] << 24) | (cdb[7] << 16) | (cdb[8] << 8) | cdb[9];
+                dev->sector_pos = (cdb[2] << 24) | (cdb[3] << 16) | (cdb[4] << 8) | cdb[5];
+            }
+
+            if (dev->current_cdb[0] == GPCMD_READ_CDDA || dev->current_cdb[0] == GPCMD_READ_CDDA_MSF) {
+                if (cdb[10] > 0x3) {
+                    /* Illegal mode */
+                    scsi_cdrom_invalid_field(dev, cdb[9]);
+                    break;
+                }
+            }
+            if (dev->sector_len > 0) {
+                uint32_t max_len      = dev->sector_len;
+                dev->requested_blocks = max_len;
+
+                dev->packet_len = max_len * alloc_length;
+                scsi_cdrom_buf_alloc(dev, dev->packet_len);
+
+                dev->drv->seek_diff = ABS((int) (pos - dev->sector_pos));
+                dev->drv->seek_pos  = dev->sector_pos;
+
+                /* Any of these commands stop the audio playing. */
+                cdrom_stop(dev->drv);
+
+                if (dev->use_cdb_9 && ((dev->current_cdb[0] == GPCMD_READ_10) || (dev->current_cdb[0] == GPCMD_READ_12)))
+                    dev->vendor_type = cdb[9] & 0xc0;
+                else
+                    dev->vendor_type = 0x00;
+
+                dev->block_len  = 0xffffffff;
+                dev->buffer_pos = 0x00000000;
+
+                int ret      = scsi_cdrom_read_blocks(dev);
+                alloc_length = dev->requested_blocks * dev->block_len;
+
+                if (ret > 0) {
+                    dev->packet_len = alloc_length;
+
+                    scsi_cdrom_set_buf_len(dev, BufLen,
+                                           (int32_t *) &dev->packet_len);
+
+                    scsi_cdrom_data_command_finish(dev, alloc_length,
+                                                   dev->block_len,
+                                                   alloc_length, 0);
+
+                    if (dev->packet_status != PHASE_COMPLETE)
+                        ui_sb_update_icon(SB_CDROM | dev->id, 1);
+                    else
+                        ui_sb_update_icon(SB_CDROM | dev->id, 0);
+                } else {
+                    scsi_cdrom_set_phase(dev, SCSI_PHASE_STATUS);
+                    dev->packet_status = (ret < 0) ? PHASE_ERROR : PHASE_COMPLETE;
+                    dev->callback      = 20.0 * CDROM_TIME;
+                    scsi_cdrom_set_callback(dev);
+                }
+            } else {
+                scsi_cdrom_set_phase(dev, SCSI_PHASE_STATUS);
+                /* scsi_cdrom_log(dev->log, "All done - callback set\n"); */
+                dev->packet_status = PHASE_COMPLETE;
+                dev->callback      = 20.0 * CDROM_TIME;
+                scsi_cdrom_set_callback(dev);
+            }
             break;
 
         case GPCMD_SET_ADDRESS_FORMAT_SONY:
@@ -2219,6 +2379,80 @@ scsi_cdrom_command_pioneer(void *sc, const uint8_t *cdb, int32_t *BufLen)
     int           alloc_length;
 
     switch (cdb[0]) {
+        case GPCMD_READ_CDDA:
+        case GPCMD_READ_CDDA_MSF:
+            cmd_stat = 1;
+            if (dev->current_cdb[0] == GPCMD_READ_CDDA_MSF) {
+                dev->sector_len = MSFtoLBA(cdb[7], cdb[8], cdb[9]) - 150;
+                dev->sector_pos = MSFtoLBA(cdb[3], cdb[4], cdb[5]) - 150;
+
+                dev->sector_len -= dev->sector_pos;
+                dev->sector_len++;
+            } else if (dev->current_cdb[0] == GPCMD_READ_CDDA) {
+                dev->sector_len = (cdb[6] << 24) | (cdb[7] << 16) | (cdb[8] << 8) | cdb[9];
+                dev->sector_pos = (cdb[2] << 24) | (cdb[3] << 16) | (cdb[4] << 8) | cdb[5];
+            }
+
+            if (dev->current_cdb[0] == GPCMD_READ_CDDA || dev->current_cdb[0] == GPCMD_READ_CDDA_MSF) {
+                if (cdb[10] > 0x3) {
+                    /* Illegal mode */
+                    scsi_cdrom_invalid_field(dev, cdb[9]);
+                    break;
+                }
+            }
+            if (dev->sector_len > 0) {
+                uint32_t max_len      = dev->sector_len;
+                dev->requested_blocks = max_len;
+
+                dev->packet_len = max_len * alloc_length;
+                scsi_cdrom_buf_alloc(dev, dev->packet_len);
+
+                dev->drv->seek_diff = ABS((int) (pos - dev->sector_pos));
+                dev->drv->seek_pos  = dev->sector_pos;
+
+                /* Any of these commands stop the audio playing. */
+                cdrom_stop(dev->drv);
+
+                if (dev->use_cdb_9 && ((dev->current_cdb[0] == GPCMD_READ_10) || (dev->current_cdb[0] == GPCMD_READ_12)))
+                    dev->vendor_type = cdb[9] & 0xc0;
+                else
+                    dev->vendor_type = 0x00;
+
+                dev->block_len  = 0xffffffff;
+                dev->buffer_pos = 0x00000000;
+
+                int ret      = scsi_cdrom_read_blocks(dev);
+                alloc_length = dev->requested_blocks * dev->block_len;
+
+                if (ret > 0) {
+                    dev->packet_len = alloc_length;
+
+                    scsi_cdrom_set_buf_len(dev, BufLen,
+                                           (int32_t *) &dev->packet_len);
+
+                    scsi_cdrom_data_command_finish(dev, alloc_length,
+                                                   dev->block_len,
+                                                   alloc_length, 0);
+
+                    if (dev->packet_status != PHASE_COMPLETE)
+                        ui_sb_update_icon(SB_CDROM | dev->id, 1);
+                    else
+                        ui_sb_update_icon(SB_CDROM | dev->id, 0);
+                } else {
+                    scsi_cdrom_set_phase(dev, SCSI_PHASE_STATUS);
+                    dev->packet_status = (ret < 0) ? PHASE_ERROR : PHASE_COMPLETE;
+                    dev->callback      = 20.0 * CDROM_TIME;
+                    scsi_cdrom_set_callback(dev);
+                }
+            } else {
+                scsi_cdrom_set_phase(dev, SCSI_PHASE_STATUS);
+                /* scsi_cdrom_log(dev->log, "All done - callback set\n"); */
+                dev->packet_status = PHASE_COMPLETE;
+                dev->callback      = 20.0 * CDROM_TIME;
+                scsi_cdrom_set_callback(dev);
+            }
+            break;
+
         default:
             break;
 

--- a/src/scsi/scsi_cdrom.c
+++ b/src/scsi/scsi_cdrom.c
@@ -1131,17 +1131,20 @@ scsi_cdrom_read_blocks(scsi_cdrom_t *dev)
                     flags = 0x000;
                     break;
                 case 1:
-                    flags = 0x400;
-                    break;
-                case 2:
                     flags = 0x200;
                     break;
+                case 2:
+                    flags = 0x400;
+                    break;
                 case 3:
+                case 8:
                     flags = 0x100;
                     break;
             }
 
             flags |= CD_SECTOR_FLAG_SCRAMBLED | 0xb8;
+            if (dev->current_cdb[10] == 8)
+                flags |= 2;
             handled = 1;
             break;
         }

--- a/src/scsi/scsi_cdrom.c
+++ b/src/scsi/scsi_cdrom.c
@@ -1812,6 +1812,80 @@ scsi_cdrom_command_dec_sony_texel(void *sc, const uint8_t *cdb, int32_t *BufLen)
         default:
             break;
 
+        case GPCMD_READ_ALL_SUBCODES_PIONEER:
+            cmd_stat = 1;
+            alloc_length = 2852;
+            
+            if (dev->drv->cd_status <= CD_STATUS_DVD) {
+                scsi_cdrom_illegal_mode(dev);
+                break;
+            }
+
+            dev->sector_len = (cdb[6] << 24) | (cdb[7] << 16) | (cdb[8] << 8) | cdb[9];
+            dev->sector_pos = dev->drv->seek_pos;
+            dev->sector_type = 1;
+            dev->sector_flags = 0x100;
+
+            if (dev->current_cdb[0] == GPCMD_READ_CDDA || dev->current_cdb[0] == GPCMD_READ_CDDA_MSF) {
+                if (cdb[10] > 0x3) {
+                    /* Illegal mode */
+                    scsi_cdrom_invalid_field(dev, cdb[9]);
+                    break;
+                }
+            }
+            if (dev->sector_len > 0) {
+                uint32_t max_len      = dev->sector_len;
+                dev->requested_blocks = max_len;
+
+                dev->packet_len = max_len * alloc_length;
+                scsi_cdrom_buf_alloc(dev, dev->packet_len);
+
+                dev->drv->seek_diff = ABS((int) (pos - dev->sector_pos));
+                dev->drv->seek_pos  = dev->sector_pos;
+
+                /* Any of these commands stop the audio playing. */
+                cdrom_stop(dev->drv);
+
+                if (dev->use_cdb_9 && ((dev->current_cdb[0] == GPCMD_READ_10) || (dev->current_cdb[0] == GPCMD_READ_12)))
+                    dev->vendor_type = cdb[9] & 0xc0;
+                else
+                    dev->vendor_type = 0x00;
+
+                dev->block_len  = 0xffffffff;
+                dev->buffer_pos = 0x00000000;
+
+                int ret      = scsi_cdrom_read_blocks(dev);
+                alloc_length = dev->requested_blocks * dev->block_len;
+
+                if (ret > 0) {
+                    dev->packet_len = alloc_length;
+
+                    scsi_cdrom_set_buf_len(dev, BufLen,
+                                           (int32_t *) &dev->packet_len);
+
+                    scsi_cdrom_data_command_finish(dev, alloc_length,
+                                                   dev->block_len,
+                                                   alloc_length, 0);
+
+                    if (dev->packet_status != PHASE_COMPLETE)
+                        ui_sb_update_icon(SB_CDROM | dev->id, 1);
+                    else
+                        ui_sb_update_icon(SB_CDROM | dev->id, 0);
+                } else {
+                    scsi_cdrom_set_phase(dev, SCSI_PHASE_STATUS);
+                    dev->packet_status = (ret < 0) ? PHASE_ERROR : PHASE_COMPLETE;
+                    dev->callback      = 20.0 * CDROM_TIME;
+                    scsi_cdrom_set_callback(dev);
+                }
+            } else {
+                scsi_cdrom_set_phase(dev, SCSI_PHASE_STATUS);
+                /* scsi_cdrom_log(dev->log, "All done - callback set\n"); */
+                dev->packet_status = PHASE_COMPLETE;
+                dev->callback      = 20.0 * CDROM_TIME;
+                scsi_cdrom_set_callback(dev);
+            }
+            break;
+
         case GPCMD_READ_CDDA:
         case GPCMD_READ_CDDA_MSF:
             cmd_stat = 1;
@@ -2422,6 +2496,80 @@ scsi_cdrom_command_pioneer(void *sc, const uint8_t *cdb, int32_t *BufLen)
     int           alloc_length;
 
     switch (cdb[0]) {
+        case GPCMD_READ_ALL_SUBCODES_PIONEER:
+            cmd_stat = 1;
+            alloc_length = 2852;
+            
+            if (dev->drv->cd_status <= CD_STATUS_DVD) {
+                scsi_cdrom_illegal_mode(dev);
+                break;
+            }
+
+            dev->sector_len = (cdb[6] << 24) | (cdb[7] << 16) | (cdb[8] << 8) | cdb[9];
+            dev->sector_pos = dev->drv->seek_pos;
+            dev->sector_type = 1;
+            dev->sector_flags = 0x100;
+
+            if (dev->current_cdb[0] == GPCMD_READ_CDDA || dev->current_cdb[0] == GPCMD_READ_CDDA_MSF) {
+                if (cdb[10] > 0x3) {
+                    /* Illegal mode */
+                    scsi_cdrom_invalid_field(dev, cdb[9]);
+                    break;
+                }
+            }
+            if (dev->sector_len > 0) {
+                uint32_t max_len      = dev->sector_len;
+                dev->requested_blocks = max_len;
+
+                dev->packet_len = max_len * alloc_length;
+                scsi_cdrom_buf_alloc(dev, dev->packet_len);
+
+                dev->drv->seek_diff = ABS((int) (pos - dev->sector_pos));
+                dev->drv->seek_pos  = dev->sector_pos;
+
+                /* Any of these commands stop the audio playing. */
+                cdrom_stop(dev->drv);
+
+                if (dev->use_cdb_9 && ((dev->current_cdb[0] == GPCMD_READ_10) || (dev->current_cdb[0] == GPCMD_READ_12)))
+                    dev->vendor_type = cdb[9] & 0xc0;
+                else
+                    dev->vendor_type = 0x00;
+
+                dev->block_len  = 0xffffffff;
+                dev->buffer_pos = 0x00000000;
+
+                int ret      = scsi_cdrom_read_blocks(dev);
+                alloc_length = dev->requested_blocks * dev->block_len;
+
+                if (ret > 0) {
+                    dev->packet_len = alloc_length;
+
+                    scsi_cdrom_set_buf_len(dev, BufLen,
+                                           (int32_t *) &dev->packet_len);
+
+                    scsi_cdrom_data_command_finish(dev, alloc_length,
+                                                   dev->block_len,
+                                                   alloc_length, 0);
+
+                    if (dev->packet_status != PHASE_COMPLETE)
+                        ui_sb_update_icon(SB_CDROM | dev->id, 1);
+                    else
+                        ui_sb_update_icon(SB_CDROM | dev->id, 0);
+                } else {
+                    scsi_cdrom_set_phase(dev, SCSI_PHASE_STATUS);
+                    dev->packet_status = (ret < 0) ? PHASE_ERROR : PHASE_COMPLETE;
+                    dev->callback      = 20.0 * CDROM_TIME;
+                    scsi_cdrom_set_callback(dev);
+                }
+            } else {
+                scsi_cdrom_set_phase(dev, SCSI_PHASE_STATUS);
+                /* scsi_cdrom_log(dev->log, "All done - callback set\n"); */
+                dev->packet_status = PHASE_COMPLETE;
+                dev->callback      = 20.0 * CDROM_TIME;
+                scsi_cdrom_set_callback(dev);
+            }
+            break;
+
         case GPCMD_READ_CDDA:
         case GPCMD_READ_CDDA_MSF:
         case GPCMD_READ_CDXA_PIONEER:

--- a/src/scsi/scsi_cdrom.c
+++ b/src/scsi/scsi_cdrom.c
@@ -1208,7 +1208,7 @@ scsi_cdrom_read_blocks(scsi_cdrom_t *dev)
                     break;
             }
 
-            flags |= CD_SECTOR_FLAG_SCRAMBLED | 0xb8;
+            flags |= CD_SECTOR_FLAG_SCRAMBLED | 0xf8;
             if (dev->current_cdb[10] == 8)
                 flags |= 2;
             handled = 1;
@@ -1843,13 +1843,7 @@ scsi_cdrom_command_dec_sony_texel(void *sc, const uint8_t *cdb, int32_t *BufLen)
                 dev->drv->seek_diff = ABS((int) (pos - dev->sector_pos));
                 dev->drv->seek_pos  = dev->sector_pos;
 
-                /* Any of these commands stop the audio playing. */
-                cdrom_stop(dev->drv);
-
-                if (dev->use_cdb_9 && ((dev->current_cdb[0] == GPCMD_READ_10) || (dev->current_cdb[0] == GPCMD_READ_12)))
-                    dev->vendor_type = cdb[9] & 0xc0;
-                else
-                    dev->vendor_type = 0x00;
+                dev->vendor_type = 0x00;
 
                 dev->block_len  = 0xffffffff;
                 dev->buffer_pos = 0x00000000;
@@ -2526,14 +2520,7 @@ scsi_cdrom_command_pioneer(void *sc, const uint8_t *cdb, int32_t *BufLen)
 
                 dev->drv->seek_diff = ABS((int) (pos - dev->sector_pos));
                 dev->drv->seek_pos  = dev->sector_pos;
-
-                /* Any of these commands stop the audio playing. */
-                cdrom_stop(dev->drv);
-
-                if (dev->use_cdb_9 && ((dev->current_cdb[0] == GPCMD_READ_10) || (dev->current_cdb[0] == GPCMD_READ_12)))
-                    dev->vendor_type = cdb[9] & 0xc0;
-                else
-                    dev->vendor_type = 0x00;
+                dev->vendor_type = 0x00;
 
                 dev->block_len  = 0xffffffff;
                 dev->buffer_pos = 0x00000000;


### PR DESCRIPTION
Summary
=======
Add support for READ CD-DA and READ CD-DA MSF commands

These commands are able to return raw scrambled data for data tracks on some Plextor drives.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
https://www.ardent-tool.com/storage/cdrom-faq.txt
http://bitsavers.informatik.uni-stuttgart.de/pdf/pioneer/cdrom/OB-U0077C_CD-ROM_SCSI-2_Command_Set_V3.1_19970626.pdf
Disc
https://www.t10.org/ftp/t10/document.95/95-104r0.pdf

