### PR TITLE
Add forgotten notes for ASUS ISA-386SIQ

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -669,7 +669,7 @@ extern int             machine_at_opti495_init(const machine_t *);
 extern int             machine_at_asus3863364k_init(const machine_t *);
 extern int             machine_at_asus386_init(const machine_t *);
 
-/* SiS 461 */
+/* SiS 460 */
 extern int             machine_at_asus386siq_init(const machine_t *);
 
 /* m_at_386dx_486.c */

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -7851,6 +7851,7 @@ const machine_t machines[] = {
         .net_device               = NULL,
         .aliases                  = { "" }
     },
+    /* Has AMIKey F KBC firmware. */
     {
         .name              = "[SiS 460] ASUS ISA-386SIQ",
         .internal_name     = "asus386siq",
@@ -9794,7 +9795,7 @@ const machine_t machines[] = {
         .net_device               = NULL,
         .aliases                  = { "" }
     },
-    /* Has early Phoenix DragonBIOS 4.00. */
+    /* Uses an Intel KBC with Phoenix MultiKey 2.03 KBC firmware and has a early PhoenixBIOS (known as Phoenix DragonBIOS) 4.00. */
     {
         .name              = "[SiS 461] Auva Compter CAM/SG0",
         .internal_name     = "auvacam",


### PR DESCRIPTION
Summary
=======
This PR title says at all. This also slightly changes notes for the Auva Computer CAM/SG0, and and corrects line 672 (ASUS ISA-386SIQ was mistaken as a SiS 461 machine) on 'machine.h'.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
