### PR TITLE
Minor GUS/ESS follow-up changes

### DIFF
--- a/src/include/86box/snd_sb.h
+++ b/src/include/86box/snd_sb.h
@@ -207,9 +207,9 @@ typedef struct sb_t {
 
     uint8_t  ess_scr_locked;
     uint8_t  es1688_rsk_enable;
-    uint8_t  es188x_readseq_state;
-    uint8_t  es188x_readseq_mode;
-    uint16_t es188x_dsp_addr;
+    uint8_t  ess_readseq_state;
+    uint8_t  ess_readseq_mode;
+    uint16_t ess_dsp_addr;
     uint16_t es186x_ctrl_addr;
     uint8_t  es186x_id_state;
     uint8_t  es186x_ctrl_regs[8];

--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -1728,8 +1728,6 @@ gus_extreme_init(UNUSED(const device_t *info))
     sound_add_handler(sb_get_buffer_ess, gus->ess);
     music_add_handler(sb_get_music_buffer_ess, gus->ess);
     sound_set_cd_audio_filter(ess_filter_cd_audio, gus->ess);
-    if (device_get_config_int("control_pc_speaker"))
-        sound_set_pc_speaker_filter(ess_filter_pc_speaker, gus->ess);
 
     if (device_get_config_int("receive_input"))
         midi_in_handler(1, sb_dsp_input_msg, sb_dsp_input_sysex, &gus->ess->dsp);
@@ -1739,9 +1737,6 @@ gus_extreme_init(UNUSED(const device_t *info))
      * It will be later initialized by the guest OS's drivers. */
     mpu401_init(gus->ess->mpu, 0, -1, M_UART, device_get_config_int("receive_input401"));
     sb_dsp_set_mpu(&gus->ess->dsp, gus->ess->mpu);
-
-    if (device_get_config_int("control_midi"))
-        sound_set_midi_filter(ess_filter_midi, gus->ess);
 
     gus->ess->gameport      = gameport_add(&gameport_200_device);
     gus->ess->gameport_addr = 0x200;
@@ -2061,28 +2056,6 @@ static const device_config_t gus_extreme_config[] = {
             { .description = "1 MB",   .value = 2 },
             { NULL                                }
         },
-        .bios           = { { 0 } }
-    },
-    {
-        .name           = "control_pc_speaker",
-        .description    = "Control PC speaker",
-        .type           = CONFIG_BINARY,
-        .default_string = NULL,
-        .default_int    = 0,
-        .file_filter    = NULL,
-        .spinner        = { 0 },
-        .selection      = { { 0 } },
-        .bios           = { { 0 } }
-    },
-    {
-        .name           = "control_midi",
-        .description    = "Control MIDI volume",
-        .type           = CONFIG_BINARY,
-        .default_string = NULL,
-        .default_int    = 0,
-        .file_filter    = NULL,
-        .spinner        = { 0 },
-        .selection      = { { 0 } },
         .bios           = { { 0 } }
     },
     {

--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -1772,13 +1772,6 @@ gus_extreme_init(UNUSED(const device_t *info))
 
     gus->jumper = 0x06;
 
-    for (int i = 0; i < GUS_ICS2101_MAX; i++) {
-        gus->ics2101.channels[i].level[0] = gus->ics2101.channels[i].level[1] = 1.0;
-        gus->ics2101.channels[i].ctrl[0] = 1;
-        gus->ics2101.channels[i].ctrl[1] = 2;
-        gus->ics2101.channels[i].pan = 7;
-    }
-
     gus->base = 0x240;
 
     io_sethandler(gus->base, 0x0010, gus_read, NULL, NULL, gus_write, NULL, NULL, gus);

--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -1616,7 +1616,10 @@ gus_init(UNUSED(const device_t *info))
     uint8_t gus_ram = device_get_config_int("gus_ram");
     gus_t  *gus     = calloc(1, sizeof(gus_t));
 
-    gus->gus_end_ram = 1 << (18 + gus_ram);
+    if ((info->local == GUS_CLASSIC) || (info->local == GUS_CLASSIC_37))
+        gus->gus_end_ram = gus_ram * 262144;
+    else
+        gus->gus_end_ram = 1 << (18 + gus_ram);
     gus->ram         = (uint8_t *) calloc(1, gus->gus_end_ram);
 
     for (c = 0; c < 32; c++) {
@@ -1844,13 +1847,14 @@ static const device_config_t gus_config[] = {
         .description    = "Memory size",
         .type           = CONFIG_SELECTION,
         .default_string = NULL,
-        .default_int    = 0,
+        .default_int    = 1,
         .file_filter    = NULL,
         .spinner        = { 0 },
         .selection      = {
-            { .description = "256 KB", .value = 0 },
-            { .description = "512 KB", .value = 1 },
-            { .description = "1 MB",   .value = 2 },
+            { .description = "256 KB", .value = 1 },
+            { .description = "512 KB", .value = 2 },
+            { .description = "768 KB", .value = 3 },
+            { .description = "1 MB",   .value = 4 },
             { NULL                                }
         },
         .bios           = { { 0 } }
@@ -1907,13 +1911,14 @@ static const device_config_t gus_v37_config[] = {
         .description    = "Memory size",
         .type           = CONFIG_SELECTION,
         .default_string = NULL,
-        .default_int    = 0,
+        .default_int    = 1,
         .file_filter    = NULL,
         .spinner        = { 0 },
         .selection      = {
-            { .description = "256 KB", .value = 0 },
-            { .description = "512 KB", .value = 1 },
-            { .description = "1 MB",   .value = 2 },
+            { .description = "256 KB", .value = 1 },
+            { .description = "512 KB", .value = 2 },
+            { .description = "768 KB", .value = 3 },
+            { .description = "1 MB",   .value = 4 },
             { NULL                                }
         },
         .bios           = { { 0 } }

--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -1744,8 +1744,8 @@ gus_extreme_init(UNUSED(const device_t *info))
     gus->ess->gameport      = gameport_add(&gameport_200_device);
     gus->ess->gameport_addr = 0x200;
 
-    gus->ess->es188x_readseq_state = 0;
-    gus->ess->es188x_dsp_addr      = 0;
+    gus->ess->ess_readseq_state = 0;
+    gus->ess->ess_dsp_addr      = 0;
     ess_rsk_reset(gus->ess);
 
     /* Init GF1 section */

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -2500,7 +2500,7 @@ ess_rsk_reset(void *priv)
         io_sethandler(0x3b8, 0x0001, ess_rsk_read, NULL, NULL, NULL, NULL, NULL, ess);
     }
 
-    ess->es188x_readseq_state = 0;
+    ess->ess_readseq_state = 0;
 }
 
 static uint8_t
@@ -2509,108 +2509,108 @@ ess_rsk_read(uint16_t addr, void *priv)
     sb_t *ess = (sb_t *) priv;
     uint8_t ret = 0xff;
 
-    switch (ess->es188x_readseq_state) {
+    switch (ess->ess_readseq_state) {
         case 0:
             if (addr == 0x229) {
-                ess->es188x_readseq_state = 1;
-                ess->es188x_readseq_mode = 0;
+                ess->ess_readseq_state = 1;
+                ess->ess_readseq_mode = 0;
                 return ret;
             } else if ((addr == 0x22b) && (ess->dsp.sb_subtype >= SB_SUBTYPE_ESS_ES1887)) {
-                ess->es188x_readseq_state = 1;
-                ess->es188x_readseq_mode = 1;
+                ess->ess_readseq_state = 1;
+                ess->ess_readseq_mode = 1;
                 return ret;
             }
             break;
         case 1:
             if (addr == 0x229) {
-                ess->es188x_readseq_state = 2;
+                ess->ess_readseq_state = 2;
                 return ret;
             }
             break;
         case 2:
-            if ((addr == 0x229) || ((addr == 0x22f) && ess->es188x_readseq_mode)) {
-                ess->es188x_readseq_state = 3;
+            if ((addr == 0x229) || ((addr == 0x22f) && ess->ess_readseq_mode)) {
+                ess->ess_readseq_state = 3;
                 return ret;
             }
             break;
         case 3:
-            if ((addr == 0x22b) || ((addr == 0x22d) && ess->es188x_readseq_mode)) {
-                ess->es188x_readseq_state = 4;
+            if ((addr == 0x22b) || ((addr == 0x22d) && ess->ess_readseq_mode)) {
+                ess->ess_readseq_state = 4;
                 return ret;
             }
             break;
         case 4:
-            if ((addr == 0x229) || ((addr == 0x22d) && ess->es188x_readseq_mode)) {
-                ess->es188x_readseq_state = 5;
+            if ((addr == 0x229) || ((addr == 0x22d) && ess->ess_readseq_mode)) {
+                ess->ess_readseq_state = 5;
                 return ret;
             }
             break;
         case 5:
-            if ((addr == 0x22b) || ((addr == 0x22f) && ess->es188x_readseq_mode)) {
-                ess->es188x_readseq_state = 6;
+            if ((addr == 0x22b) || ((addr == 0x22f) && ess->ess_readseq_mode)) {
+                ess->ess_readseq_state = 6;
                 return ret;
             }
             break;
         case 6:
             if (addr == 0x229) {
-                ess->es188x_readseq_state = 7;
+                ess->ess_readseq_state = 7;
                 return ret;
             }
             break;
         case 7:
-            if ((addr == 0x229) && !ess->es188x_readseq_mode) {
-                ess->es188x_readseq_state = 8;
+            if ((addr == 0x229) && !ess->ess_readseq_mode) {
+                ess->ess_readseq_state = 8;
                 return ret;
-            } else if (ess->es188x_readseq_mode && ((addr == 0x220) || (addr == 0x230) || (addr == 0x240) || (addr == 0x250))) {
-                ess->es188x_dsp_addr = addr;
-                sb_log("ES1887 Read-Sequence-Key: new DSP addr = %04X\n", ess->es188x_dsp_addr);
-                ess->es188x_readseq_state = 8;
+            } else if (ess->ess_readseq_mode && ((addr == 0x220) || (addr == 0x230) || (addr == 0x240) || (addr == 0x250))) {
+                ess->ess_dsp_addr = addr;
+                sb_log("ES1887 Read-Sequence-Key: new DSP addr = %04X\n", ess->ess_dsp_addr);
+                ess->ess_readseq_state = 8;
                 return ret;
             }
             break;
         case 8:
-            if ((addr == 0x22b) && !ess->es188x_readseq_mode) {
-                ess->es188x_readseq_state = 9;
+            if ((addr == 0x22b) && !ess->ess_readseq_mode) {
+                ess->ess_readseq_state = 9;
                 return ret;
-            } else if (ess->es188x_readseq_mode && ((addr >= 0x200) && (addr <= 0x203))) {
+            } else if (ess->ess_readseq_mode && ((addr >= 0x200) && (addr <= 0x203))) {
                 ess->gameport_addr = addr;
                 sb_log("ES1887 Read-Sequence-Key: new gameport addr = %04X\n", ess->gameport_addr);
-                ess->es188x_readseq_state = 9;
+                ess->ess_readseq_state = 9;
                 return ret;
-            } else if (ess->es188x_readseq_mode) {
+            } else if (ess->ess_readseq_mode) {
                 ess->gameport_addr = 0;
                 sb_log("ES1887 Read-Sequence-Key: new gameport addr = %04X\n", ess->gameport_addr);
-                ess->es188x_readseq_state = 9;
+                ess->ess_readseq_state = 9;
                 return ret;
             }
             break;
         case 9:
             if (addr == 0x229) {
-                ess->es188x_readseq_state = 10;
+                ess->ess_readseq_state = 10;
                 return ret;
-            } else if (ess->es188x_readseq_mode && ((addr == 0x388) || (addr == 0x398) || (addr == 0x3a8) || (addr == 0x3b8))) {
+            } else if (ess->ess_readseq_mode && ((addr == 0x388) || (addr == 0x398) || (addr == 0x3a8) || (addr == 0x3b8))) {
                 ess->opl_pnp_addr = addr;
                 sb_log("ES1887 Read-Sequence-Key: new OPL addr = %04X\n", ess->opl_pnp_addr);
-                ess->es188x_readseq_state = 11;
-            } else if (ess->es188x_readseq_mode) {
+                ess->ess_readseq_state = 11;
+            } else if (ess->ess_readseq_mode) {
                 ess->opl_pnp_addr = 0x388;
                 sb_log("ES1887 Read-Sequence-Key: new OPL addr = %04X\n", ess->opl_pnp_addr);
-                ess->es188x_readseq_state = 11;
+                ess->ess_readseq_state = 11;
             }
             break;
         case 10:
             if ((addr == 0x220) || (addr == 0x230) || (addr == 0x240) || (addr == 0x250)) {
-                ess->es188x_readseq_state = 11;
-                ess->es188x_dsp_addr = addr;
-                sb_log("ESS Read-Sequence-Key complete, new addr = %04X\n", ess->es188x_dsp_addr);
+                ess->ess_readseq_state = 11;
+                ess->ess_dsp_addr = addr;
+                sb_log("ESS Read-Sequence-Key complete, new addr = %04X\n", ess->ess_dsp_addr);
             }
             break;
         default:
-            ess->es188x_readseq_state = 0;
+            ess->ess_readseq_state = 0;
             break;
     }
 
-    if (ess->es188x_readseq_state != 11)
+    if (ess->ess_readseq_state != 11)
         return ret;
     else {
         io_removehandler(0x220, 0x0001, ess_rsk_read, NULL, NULL, NULL, NULL, NULL, ess);
@@ -2629,34 +2629,34 @@ ess_rsk_read(uint16_t addr, void *priv)
             io_removehandler(0x3a8, 0x0001, ess_rsk_read, NULL, NULL, NULL, NULL, NULL, ess);
             io_removehandler(0x3b8, 0x0001, ess_rsk_read, NULL, NULL, NULL, NULL, NULL, ess);
         }
-        io_sethandler(ess->es188x_dsp_addr, 0x0004,
+        io_sethandler(ess->ess_dsp_addr, 0x0004,
                       ess->opl.read, NULL, NULL,
                       ess->opl.write, NULL, NULL,
                       ess->opl.priv);
-        io_sethandler(ess->es188x_dsp_addr + 8, 0x0002,
+        io_sethandler(ess->ess_dsp_addr + 8, 0x0002,
                       ess->opl.read, NULL, NULL,
                       ess->opl.write, NULL, NULL,
                       ess->opl.priv);
-        io_sethandler(ess->es188x_dsp_addr + 8, 0x0002,
+        io_sethandler(ess->ess_dsp_addr + 8, 0x0002,
                       ess_fm_midi_read, NULL, NULL,
                       ess_fm_midi_write, NULL, NULL,
                       ess);
-        io_sethandler(ess->es188x_dsp_addr + 4, 0x0002,
+        io_sethandler(ess->ess_dsp_addr + 4, 0x0002,
                       ess_mixer_read, NULL, NULL,
                       ess_mixer_write, NULL, NULL,
                       ess);
 
-        sb_dsp_setaddr(&ess->dsp, ess->es188x_dsp_addr);
-        sb_log("ESS DSP set to addr %04X\n", ess->es188x_dsp_addr);
-        io_sethandler(ess->es188x_dsp_addr + 2, 0x0003,
+        sb_dsp_setaddr(&ess->dsp, ess->ess_dsp_addr);
+        sb_log("ESS DSP set to addr %04X\n", ess->ess_dsp_addr);
+        io_sethandler(ess->ess_dsp_addr + 2, 0x0003,
                       ess_base_read, NULL, NULL,
                       ess_base_write, NULL, NULL,
                       ess);
-        io_sethandler(ess->es188x_dsp_addr + 6, 0x0001,
+        io_sethandler(ess->ess_dsp_addr + 6, 0x0001,
                       ess_base_read, NULL, NULL,
                       ess_base_write, NULL, NULL,
                       ess);
-        io_sethandler(ess->es188x_dsp_addr + 0x0a, 0x0006,
+        io_sethandler(ess->ess_dsp_addr + 0x0a, 0x0006,
                       ess_base_read, NULL, NULL,
                       ess_base_write, NULL, NULL,
                       ess);
@@ -2668,7 +2668,7 @@ ess_rsk_read(uint16_t addr, void *priv)
                       ess_fm_midi_read, NULL, NULL,
                       ess_fm_midi_write, NULL, NULL,
                       ess);
-        ess->es188x_readseq_state = 12;
+        ess->ess_readseq_state = 12;
         if (ess->dsp.sb_subtype >= SB_SUBTYPE_ESS_ES1887)
             gameport_remap(ess->gameport, ess->gameport_addr);
     }
@@ -5766,15 +5766,15 @@ ess_1x88_onboard_init(const device_t *info)
         ess->gameport_addr = 0x200;
     }
 
-    /* ES1788/188x System Configuration Register ports */
+    /* ES1688/1788/188x System Configuration Register ports */
     io_sethandler(0xe0, 0x0002, NULL, NULL, NULL, ess_scr_write, NULL, NULL, ess);
     io_sethandler(0xf9, 0x0001, NULL, NULL, NULL, ess_scr_write, NULL, NULL, ess);
     io_sethandler(0xfb, 0x0001, NULL, NULL, NULL, ess_scr_write, NULL, NULL, ess);
     ess->ess_scr_locked = 1;
 
-    /* ES1788/188x Read-Sequence-Key mode */
-    ess->es188x_readseq_state = 0;
-    ess->es188x_dsp_addr      = 0;
+    /* ES1688/1788/188x Read-Sequence-Key mode */
+    ess->ess_readseq_state = 0;
+    ess->ess_dsp_addr      = 0;
     io_sethandler(0x220, 0x0001, ess_rsk_read, NULL, NULL, NULL, NULL, NULL, ess);
     io_sethandler(0x229, 0x0001, ess_rsk_read, NULL, NULL, NULL, NULL, NULL, ess);
     io_sethandler(0x22b, 0x0001, ess_rsk_read, NULL, NULL, NULL, NULL, NULL, ess);


### PR DESCRIPTION
Summary
=======
Make the following changes to the GUS and ESS:
- Remove the Control MIDI and Control PC Speaker checkboxes from the newly-added GUS Extreme: The real card does not have a wavetable header or PC Speaker connection
- Remove the ICS2101 variable init from the GUS Extreme's init: This GUS variant does not have an ICS2101
- Add a 768KB RAM configuration to the GUS Classic
- Correct some variable names and comments in the ESS code

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
- TRW page for the GUS Extreme: https://theretroweb.com/expansioncards/s/gravis-ultrasound-extreme-rev3p0