### PR TITLE
More GUS Extreme improvements

### DIFF
--- a/src/include/86box/snd_sb.h
+++ b/src/include/86box/snd_sb.h
@@ -276,6 +276,7 @@ extern void sb_speed_changed(void *priv);
 
 extern void ess_mixer_reset(sb_t *ess);
 extern void ess_rsk_reset(void *priv);
+extern void ess_mixer_write(uint16_t addr, uint8_t val, void *priv);
 
 extern void sb_get_buffer_ess(int32_t *buffer, uint16_t len, void *priv);
 extern void sb_get_music_buffer_ess(int32_t *buffer, uint16_t len, void *priv);

--- a/src/include/86box/sound.h
+++ b/src/include/86box/sound.h
@@ -276,6 +276,7 @@ extern const device_t gus_v37_device;
 extern const device_t gus_max_device;
 extern const device_t gus_ace_device;
 extern const device_t gus_extreme_device;
+extern const device_t gus_vipermax_device;
 
 /* IBM Music Feature Card */
 extern const device_t imfc_device;

--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -1837,12 +1837,7 @@ gus_extreme_init(UNUSED(const device_t *info))
 
     gus->jumper = 0x06;
 
-    gus->base = 0x240;
-
-    io_sethandler(gus->base, 0x0010, gus_read, NULL, NULL, gus_write, NULL, NULL, gus);
-    io_sethandler(0x0102 + gus->base, 0x000e, gus_read, NULL, NULL, gus_write, NULL, NULL, gus);
-    io_sethandler(0x0506 + gus->base, 0x0001, gus_read, NULL, NULL, gus_write, NULL, NULL, gus);
-    io_sethandler(0x0388, 0x0002, gus_read, NULL, NULL, gus_write, NULL, NULL, gus);
+    gus->base = 0;
 
     timer_add(&gus->samp_timer, gus_poll_wave, gus, 1);
     timer_add(&gus->timer_1, gus_poll_timer_1, gus, 1);

--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -801,6 +801,9 @@ gus_write(uint16_t addr, uint8_t val, void *priv)
                         break;
                 }
                 break;
+            } else if (gus->type == GUS_EXTREME) {
+                ess_mixer_write(gus->ess->ess_dsp_addr + 4, val, gus->ess);
+                break;
             }
             fallthrough;
         case 0x706:
@@ -824,7 +827,8 @@ gus_write(uint16_t addr, uint8_t val, void *priv)
                                       ad1848_write, NULL, NULL, &gus->ad1848);
                     }
                 }
-            }
+            } else if (gus->type == GUS_EXTREME)
+                ess_mixer_write(gus->ess->ess_dsp_addr + 5, val, gus->ess);
             break;
 
         default:

--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -1781,7 +1781,7 @@ gus_extreme_init(UNUSED(const device_t *info))
 
     sb_dsp_init(&gus->ess->dsp, SBPRO_DSP_301, SB_SUBTYPE_ESS_ES1688, gus->ess);
     gus->ess->es1688_rsk_enable = 1;
-    sb_dsp_setaddr(&gus->ess->dsp, 0x220);
+    sb_dsp_setaddr(&gus->ess->dsp, 0);
     sb_dsp_setirq(&gus->ess->dsp, 0);
     sb_dsp_setdma8(&gus->ess->dsp, ISAPNP_DMA_DISABLED);
     sb_dsp_setdma16_8(&gus->ess->dsp, ISAPNP_DMA_DISABLED);

--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -68,7 +68,8 @@ enum {
     GUS_CLASSIC_37 = 1,
     GUS_MAX        = 2,
     GUS_ACE        = 3,
-    GUS_EXTREME    = 4
+    GUS_VIPERMAX   = 4,
+    GUS_EXTREME    = 5
 };
 
 enum {
@@ -716,7 +717,7 @@ gus_write(uint16_t addr, uint8_t val, void *priv)
                     break;
                 case 6:
                     if (gus->type > GUS_CLASSIC) {
-                        if ((gus->type != GUS_ACE) && (gus->type != GUS_EXTREME)) {
+                        if ((gus->type != GUS_ACE) && (gus->type != GUS_EXTREME) && (gus->type != GUS_VIPERMAX)) {
                             if (!(val & 0x2) && (gus->jumper & 0x2))
                                 io_removehandler(0x0100 + gus->base, 0x0002, gus_read, NULL, NULL, gus_write, NULL, NULL, gus);
                             else if ((val & 0x2) && !(gus->jumper & 0x2))
@@ -1028,8 +1029,10 @@ gus_read(uint16_t addr, void *priv)
                 val = 0x0a; /* GUS MAX */
             else if (gus->type == GUS_ACE)
                 val = 0x30; /* GUS ACE */
+            else if (gus->type == GUS_VIPERMAX)
+                val = 0x50; /* Synergy Vipermax */
             else if (gus->type == GUS_EXTREME)
-                val = 0x50; /* GUS Extreme */
+                val = 0x70; /* GUS Extreme */
             else
                 val = 0xff; /* Pre 3.7 - no mixer */
             break;
@@ -1078,7 +1081,7 @@ gus_read(uint16_t addr, void *priv)
             return gus->sb_2xe;
 
         case 0x388:
-            if (((gus->type == GUS_ACE) && !device_get_config_int("adlib_ports")) || (gus->type == GUS_EXTREME))
+            if (((gus->type == GUS_ACE) && !device_get_config_int("adlib_ports")) || (gus->type == GUS_EXTREME) || (gus->type == GUS_VIPERMAX))
                 break;
             fallthrough;
         case 0x208:
@@ -1099,7 +1102,7 @@ gus_read(uint16_t addr, void *priv)
             val = gus->ad_data;
             break;
         case 0x389:
-            if (((gus->type != GUS_ACE) || device_get_config_int("adlib_ports")) && (gus->type != GUS_EXTREME))
+            if (((gus->type != GUS_ACE) || device_get_config_int("adlib_ports")) && (gus->type != GUS_EXTREME) && (gus->type != GUS_VIPERMAX))
                 val = gus->ad_data;
             break;
 
@@ -2196,6 +2199,20 @@ const device_t gus_ace_device = {
     .speed_changed = gus_speed_changed,
     .force_redraw  = NULL,
     .config        = gus_ace_config
+};
+
+const device_t gus_vipermax_device = {
+    .name          = "Gravis/Synergy Vipermax",
+    .internal_name = "gusvipermax",
+    .flags         = DEVICE_ISA16,
+    .local         = GUS_VIPERMAX,
+    .init          = gus_extreme_init,
+    .close         = gus_close,
+    .reset         = gus_reset,
+    .available     = NULL,
+    .speed_changed = gus_speed_changed,
+    .force_redraw  = NULL,
+    .config        = gus_extreme_config
 };
 
 const device_t gus_extreme_device = {

--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -23,6 +23,24 @@
 #include <86box/snd_sb_dsp.h>
 #include <86box/plat_fallthrough.h>
 #include <86box/plat_unused.h>
+#include <86box/log.h>
+
+#ifdef ENABLE_GUS_LOG
+int gus_do_log = ENABLE_GUS_LOG;
+
+static void
+gus_log(void *priv, const char *fmt, ...)
+{
+    if (gus_do_log) {
+        va_list ap;
+        va_start(ap, fmt);
+        log_out(priv, fmt, ap);
+        va_end(ap);
+    }
+}
+#else
+#    define gus_log(fmt, ...)
+#endif
 
 enum {
     MIDI_INT_RECEIVE  = 0x01,
@@ -184,6 +202,8 @@ typedef struct gus_t {
     uint16_t gus_new_base;
     uint8_t  gus_reloc_latch;
     uint8_t  gus_reloc_state;
+
+    void *   log; /* New logging system */
 } gus_t;
 
 static int gus_gf1_irqs[8]  = { -1, 2, 5, 3, 7, 11, 12, 15 };
@@ -305,6 +325,8 @@ gus_write(uint16_t addr, uint8_t val, void *priv)
     ics2101_t *ics2101 = &gus->ics2101;
     uint8_t    mixer_ch;
     uint8_t    mixer_lr;
+
+    gus_log(gus->log, "GUS write: port = %04X, val = %02X\n", addr, val);
 
     if ((addr == 0x388) || (addr == 0x389))
         port = addr;
@@ -844,12 +866,14 @@ gus_read(uint16_t addr, void *priv)
             break;
 
         case 0x200:
+            gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, 0);
             return 0;
 
         case 0x206: /*IRQ status*/
             val = gus->irqstatus & ~0x10;
             if (gus->ad_status & 0x19)
                 val |= 0x10;
+            gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, val);
             return val;
 
         case 0x20F:
@@ -860,23 +884,30 @@ gus_read(uint16_t addr, void *priv)
             break;
 
         case 0x302:
+            gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, gus->voice);
             return gus->voice;
 
         case 0x303:
+            gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, gus->global);
             return gus->global;
 
         case 0x304: /*Global low*/
             switch (gus->global) {
                 case 0x82: /*Start addr high*/
+                    gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, gus->start[gus->voice] >> 16);
                     return gus->start[gus->voice] >> 16;
                 case 0x83: /*Start addr low*/
+                    gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, gus->start[gus->voice] & 0xFF);
                     return gus->start[gus->voice] & 0xFF;
 
                 case 0x89: /*Current volume*/
+                    gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, gus->rcur[gus->voice] >> 6);
                     return gus->rcur[gus->voice] >> 6;
                 case 0x8A: /*Current addr high*/
+                    gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, gus->cur[gus->voice] >> 16);
                     return gus->cur[gus->voice] >> 16;
                 case 0x8B: /*Current addr low*/
+                    gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, gus->cur[gus->voice] & 0xFF);
                     return gus->cur[gus->voice] & 0xFF;
 
                 case 0x8F: /*IRQ status*/
@@ -884,6 +915,7 @@ gus_read(uint16_t addr, void *priv)
                     gus->rampirqs[gus->irqstatus2 & 0x1F] = 0;
                     gus->waveirqs[gus->irqstatus2 & 0x1F] = 0;
                     gus_update_int_status(gus);
+                    gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, val);
                     return val;
 
                 case 0x00:
@@ -912,25 +944,33 @@ gus_read(uint16_t addr, void *priv)
         case 0x305: /*Global high*/
             switch (gus->global) {
                 case 0x80: /*Voice control*/
+                    gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, gus->ctrl[gus->voice] | (gus->waveirqs[gus->voice] ? 0x80 : 0));
                     return gus->ctrl[gus->voice] | (gus->waveirqs[gus->voice] ? 0x80 : 0);
 
                 case 0x82: /*Start addr high*/
+                    gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, gus->start[gus->voice] >> 24);
                     return gus->start[gus->voice] >> 24;
                 case 0x83: /*Start addr low*/
+                    gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, gus->start[gus->voice] >> 8);
                     return gus->start[gus->voice] >> 8;
 
                 case 0x89: /*Current volume*/
+                    gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, gus->rcur[gus->voice] >> 14);
                     return gus->rcur[gus->voice] >> 14;
 
                 case 0x8A: /*Current addr high*/
+                    gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, gus->cur[gus->voice] >> 24);
                     return gus->cur[gus->voice] >> 24;
                 case 0x8B: /*Current addr low*/
+                    gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, gus->cur[gus->voice] >> 8);
                     return gus->cur[gus->voice] >> 8;
 
                 case 0x8C: /*Pan*/
+                    gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, gus->pan_r[gus->voice]);
                     return gus->pan_r[gus->voice];
 
                 case 0x8D:
+                    gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, gus->rctrl[gus->voice] | (gus->rampirqs[gus->voice] ? 0x80 : 0));
                     return gus->rctrl[gus->voice] | (gus->rampirqs[gus->voice] ? 0x80 : 0);
 
                 case 0x8F: /*IRQ status*/
@@ -938,18 +978,23 @@ gus_read(uint16_t addr, void *priv)
                     gus->rampirqs[gus->irqstatus2 & 0x1F] = 0;
                     gus->waveirqs[gus->irqstatus2 & 0x1F] = 0;
                     gus_update_int_status(gus);
+                    gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, val);
                     return val;
 
                 case 0x41: /*DMA control*/
                     val = gus->dmactrl | ((gus->irqstatus & 0x80) ? 0x40 : 0);
                     gus->irqstatus &= ~0x80;
+                    gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, val);
                     return val;
                 case 0x45: /*Timer control*/
+                    gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, gus->tctrl);
                     return gus->tctrl;
                 case 0x49: /*Sampling control*/
+                    gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, 0);
                     return 0;
 
                 case 0x4B: /*Joystick trim DAC*/
+                    gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, gus->joy_trim);
                     return gus->joy_trim;
 
                 case 0x00:
@@ -995,8 +1040,10 @@ gus_read(uint16_t addr, void *priv)
                 val = gus->ram[gus->addr];
             else
                 val = 0;
+            gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, val);
             return val;
         case 0x309:
+            gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, 0);
             return 0;
 
         case 0x20b:
@@ -1027,6 +1074,7 @@ gus_read(uint16_t addr, void *priv)
                 gus->sb_2xc &= 0x80;
             break;
         case 0x20e:
+            gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, gus->sb_2xe);
             return gus->sb_2xe;
 
         case 0x388:
@@ -1062,6 +1110,9 @@ gus_read(uint16_t addr, void *priv)
         default:
             break;
     }
+
+    gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, val);
+
     return val;
 }
 
@@ -1616,6 +1667,8 @@ gus_init(UNUSED(const device_t *info))
     uint8_t gus_ram = device_get_config_int("gus_ram");
     gus_t  *gus     = calloc(1, sizeof(gus_t));
 
+    gus->log = log_open("GUS");
+
     if ((info->local == GUS_CLASSIC) || (info->local == GUS_CLASSIC_37))
         gus->gus_end_ram = gus_ram * 262144;
     else
@@ -1708,6 +1761,8 @@ gus_extreme_init(UNUSED(const device_t *info))
     double  out     = 1.0;
     gus_t  *gus     = calloc(1, sizeof(gus_t));
     uint8_t gus_ram = device_get_config_int("gus_ram");
+
+    gus->log = log_open("GUS");
 
     /* Init ES1688 section */
     gus->ess = calloc(1, sizeof(sb_t));
@@ -1802,6 +1857,11 @@ void
 gus_close(void *priv)
 {
     gus_t *gus = (gus_t *) priv;
+
+    if (gus->log != NULL) {
+        log_close(gus->log);
+        gus->log = NULL;
+    }
 
     free(gus->ram);
     free(gus);

--- a/src/sound/sound.c
+++ b/src/sound/sound.c
@@ -192,6 +192,7 @@ static const SOUND_CARD sound_cards[] = {
     { &gus_v37_device               },
     { &gus_max_device               },
     { &gus_ace_device               },
+    { &gus_vipermax_device          },
     { &gus_extreme_device           },
     { &mirosound_pcm10_device       },
     { &opti_82c930_device           },


### PR DESCRIPTION
Summary
=======
Make the following improvements to the GUS Extreme:
- Implement the GUS Extreme and Synergy Vipermax as separate devices: the card IDs actually differ and the DOS drivers rely on this
- Implement the GUS Extreme-specific mixer ports: Two ports in the GUS I/O range are used by DOS Ultramix to access the ES1688's mixer
- Properly initialize the ES1688 and GF1 portions of the GUS Extreme and Synergy Vipermax as disabled at power-on.

Also implemented debug logging for all GUS cards

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
