### PR TITLE
Add SCSI tape image creation

### DIFF
--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -270,6 +270,8 @@ MediaMenu::refresh(QMenu *parentMenu)
     MachineStatus::iterateTape([this, parentMenu](int i) {
         auto *menu     = parentMenu->addMenu("");
         QIcon img_icon = QIcon(":/settings/qt/icons/tape_image.ico");
+        menu->addAction(getIconWithIndicator(img_icon, pixmap_size, QIcon::Normal, New), tr("&New image…"), [this, i]() { tapeNewImage(i); });
+        menu->addSeparator();
         menu->addAction(getIconWithIndicator(img_icon, pixmap_size, QIcon::Normal, Browse), tr("&Existing image…"), [this, i]() { tapeSelectImage(i, false); });
         menu->addAction(getIconWithIndicator(img_icon, pixmap_size, QIcon::Normal, WriteProtectedBrowse), tr("Existing image (&Write-protected)…"), [this, i]() { tapeSelectImage(i, true); });
         menu->addSeparator();
@@ -1224,6 +1226,20 @@ MediaMenu::moReload(int index, int slot)
     moMount(index, filename, false);
     moUpdateMenu(index);
     ui_sb_update_tip(SB_MO | index);
+}
+
+void
+MediaMenu::tapeNewImage(int i)
+{
+    NewFloppyDialog dialog(NewFloppyDialog::MediaType::Tape, parentWidget);
+    switch (dialog.exec()) {
+        default:
+            break;
+        case QDialog::Accepted:
+            QByteArray filename = dialog.fileName().toUtf8();
+            tapeMount(i, filename, false);
+            break;
+    }
 }
 
 void

--- a/src/qt/qt_mediamenu.hpp
+++ b/src/qt/qt_mediamenu.hpp
@@ -67,6 +67,7 @@ public:
     void moReload(int index, int slot);
     void moUpdateMenu(int i);
 
+    void tapeNewImage(int i);
     void tapeSelectImage(int i, bool wp);
     void tapeMount(int i, const QString &filename, bool wp);
     void tapeEject(int i);

--- a/src/qt/qt_newfloppydialog.cpp
+++ b/src/qt/qt_newfloppydialog.cpp
@@ -30,6 +30,7 @@ extern "C" {
 #include <86box/disksizes.h>
 #include <86box/rdisk.h>
 #include <86box/mo.h>
+#include <86box/scsi_tape.h>
 }
 
 #include <cstdio>
@@ -89,6 +90,14 @@ static const QStringList moTypes = {
     "5.25\" 1.3 GB",
 };
 
+static const QStringList tapeTypes = {
+    "QIC-150",
+#if 0
+    "QIC-525",
+    "QIC-1000",
+#endif
+};
+
 NewFloppyDialog::NewFloppyDialog(MediaType type, QWidget *parent)
     : QDialog(parent)
     , ui(new Ui::NewFloppyDialog)
@@ -104,14 +113,14 @@ NewFloppyDialog::NewFloppyDialog(MediaType type, QWidget *parent)
                 Models::AddEntry(model, tr(floppyTypes[i].toUtf8().data()), i);
             }
             ui->fileField->setFilter(
-                tr("All images") % util::DlgFilter({ "86f", "dsk", "flp", "im?", "img", "*fd?" }) % tr("Basic sector images") % util::DlgFilter({ "dsk", "flp", "im?", "img", "*fd?" }) % tr("Surface images") % util::DlgFilter({ "86f" }, true));
+                tr("All images") % util::DlgFilter({ "86f", "dsk", "flp", "im?", "img", "*fd?" }) % tr("Basic sector images") % util::DlgFilter({ "dsk", "flp", "im?", "img", "*fd?" }) % tr("Surface images") % util::DlgFilter({ "86f" }) % tr("All files") % util::DlgFilter({ "*" }, true));
 
             break;
         case MediaType::RDisk:
             for (int i = 0; i < rdiskTypes.size(); ++i) {
                 Models::AddEntry(model, tr(rdiskTypes[i].toUtf8().data()), i);
             }
-            ui->fileField->setFilter(tr("Removable disk images") % util::DlgFilter({ "im?", "img", "rdi", "zdi" }, true));
+            ui->fileField->setFilter(tr("Removable disk images") % util::DlgFilter({ "im?", "img", "rdi", "zdi" }) % tr("All files") % util::DlgFilter({ "*" }, true));
             break;
         case MediaType::Mo:
             for (int i = 0; i < moTypes.size(); ++i) {
@@ -119,7 +128,16 @@ NewFloppyDialog::NewFloppyDialog(MediaType type, QWidget *parent)
             }
             ui->fileField->setFilter(tr("MO images") % util::DlgFilter({ "im?", "img", "mdi" }) % tr("All files") % util::DlgFilter({ "*" }, true));
             break;
+        case MediaType::Tape:
+            for (int i = 0; i < tapeTypes.size(); ++i) {
+                Models::AddEntry(model, tr(tapeTypes[i].toUtf8().data()), i);
+            }
+            ui->fileField->setFilter(tr("Tape images") % util::DlgFilter({ "tap" }) % tr("All files") % util::DlgFilter({ "*" }, true));
+            break;
     }
+
+    if (model->rowCount() <= 1)
+        ui->comboBoxSize->setEnabled(false);
 
     model = ui->comboBoxRpm->model();
     for (int i = 0; i < rpmModes.size(); ++i) {
@@ -204,6 +222,20 @@ NewFloppyDialog::onCreate()
                 std::atomic_bool res;
                 std::thread      t([this, &res, filename, fileType, &progress] {
                     res = createMoSectorImage(filename, ui->comboBoxSize->currentIndex(), fileType, progress);
+                });
+                progress.exec();
+                t.join();
+
+                if (res) {
+                    return;
+                }
+            }
+            break;
+        case MediaType::Tape:
+            {
+                std::atomic_bool res;
+                std::thread      t([this, &res, filename, &progress] {
+                    res = createTapeSectorImage(filename, ui->comboBoxSize->currentIndex(), progress);
                 });
                 progress.exec();
                 t.join();
@@ -783,6 +815,19 @@ NewFloppyDialog::createMoSectorImage(const QString &filename, int8_t disk_size, 
         stream.writeRawData(extra_bytes.data(), total_size2);
     }
     fileProgress(blocks_num);
+
+    return true;
+}
+
+bool
+NewFloppyDialog::createTapeSectorImage(const QString &filename, UNUSED(int8_t disk_size), QProgressDialog &pbar)
+{
+    QFile file(filename);
+    if (!file.open(QIODevice::WriteOnly)) {
+        return false;
+    }
+    pbar.setMaximum(1);
+    fileProgress(1);
 
     return true;
 }

--- a/src/qt/qt_newfloppydialog.hpp
+++ b/src/qt/qt_newfloppydialog.hpp
@@ -20,6 +20,7 @@ public:
         Floppy,
         RDisk,
         Mo,
+        Tape,
     };
     enum class FileType {
         Img,
@@ -47,6 +48,7 @@ private:
     bool createSectorImage(const QString &filename, const disk_size_t &disk_size, FileType type);
     bool createRDiskSectorImage(const QString &filename, uint32_t total_sectors, FileType type, QProgressDialog &pbar);
     bool createMoSectorImage(const QString &filename, int8_t disk_size, FileType type, QProgressDialog &pbar);
+    bool createTapeSectorImage(const QString &filename, int8_t disk_size, QProgressDialog &pbar);
 };
 
 #endif // QT_NEWFLOPPYDIALOG_HPP


### PR DESCRIPTION
Summary
=======
Add an ability to create new SCSI/ATAPI tape images. Currently creates blank files - can be expanded later.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set
* [ ] This pull request adds, changes or removes an external dependency

References
==========
N/A