### PR TITLE
Manager: Add an option to delete VMs to Trash/Recycle Bin

### DIFF
--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -1228,6 +1228,9 @@ msgstr ""
 msgid "Use regular expressions in search box"
 msgstr ""
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] ""
@@ -1400,7 +1403,10 @@ msgstr ""
 msgid "&Delete"
 msgstr ""
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr ""
+
+msgid "This action cannot be undone!"
 msgstr ""
 
 msgid "Show &config file"

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -1238,6 +1238,9 @@ msgstr "No fou possible obrir el fitxer de configuració seleccionat per llegir:
 msgid "Use regular expressions in search box"
 msgstr "Utilitzeu expressions regulars a la caixa de cerca"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "%n màquina és activa en aquest moment. Segur que voleu sortir de l'administrador de MV?"
@@ -1411,8 +1414,11 @@ msgstr "Finalitzar forçosament la màquina virtual pot causar la pèrdua de dad
 msgid "&Delete"
 msgstr "&Suprimir"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "Realment voleu suprimir la màquina virtual \"%1\" i tots els seus fitxers? Aquesta acció no es pot desfer!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "Realment voleu suprimir la màquina virtual \"%1\" i tots els seus fitxers?"
+
+msgid "This action cannot be undone!"
+msgstr "Aquesta acció no es pot desfer!"
 
 msgid "Show &config file"
 msgstr "Mostra fitxer de &configuració"

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -1264,6 +1264,9 @@ msgstr "Nebylo možné otevřít vybraný konfigurační soubor pro čtení: %1"
 msgid "Use regular expressions in search box"
 msgstr "Použít ve vyhledávacím poli regulární výrazy"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "%n počítač je stále aktivní. Opravdu chcete ukončit správce virtuálních počítačů?"
@@ -1439,8 +1442,11 @@ msgstr "Ukončení virtuálního počítače může způsobit ztrátu dat. Prove
 msgid "&Delete"
 msgstr "&Odstranit"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "Opravdu chcete odstranit virtuální počítač \"%1\" a všechny jeho soubory? Tuto akci nelze vrátit zpět!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "Opravdu chcete odstranit virtuální počítač \"%1\" a všechny jeho soubory?"
+
+msgid "This action cannot be undone!"
+msgstr "Tuto akci nelze vrátit zpět!"
 
 msgid "Show &config file"
 msgstr "Zobrazit &konfigurační soubor"

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -1238,6 +1238,9 @@ msgstr "Die ausgewählte Konfigurationsdatei konnte nicht eingelesen werden: %1"
 msgid "Use regular expressions in search box"
 msgstr "Benutze reguläre Ausdrücke in der Suche"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "%n Maschine ist aktuell aktiv. Bist du sicher, dass du den VM Manager trotzdem schließen möchtest?"
@@ -1411,8 +1414,11 @@ msgstr "Das Erzwingen des Beendens einer virtuellen Maschine kann zu Datenverlus
 msgid "&Delete"
 msgstr "&Löschen"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "Bist du sicher das du die virtuelle Maschine inklusive all ihrer Dateien löschen möchtest? Diese Aktion kann nicht rückgängig gemacht werden!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "Bist du sicher das du die virtuelle Maschine inklusive all ihrer Dateien löschen möchtest?"
+
+msgid "This action cannot be undone!"
+msgstr "Diese Aktion kann nicht rückgängig gemacht werden!"
 
 msgid "Show &config file"
 msgstr "&Konfigurationsdatei anzeigen"

--- a/src/qt/languages/el-GR.po
+++ b/src/qt/languages/el-GR.po
@@ -1249,6 +1249,9 @@ msgstr "Αδυναμία ανοίγματος επιλεγμένου αρχεί�
 msgid "Use regular expressions in search box"
 msgstr "Χρήση συχνών εκφράσεων στην αναζήτηση"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "%n μηχανή είναι εν ενεργεία. Είστε σίγουγος για την έξοδο απο το VM manager;"
@@ -1422,10 +1425,11 @@ msgstr "Ο εξαναγκαστικός τέρματισμός της εικον
 msgid "&Delete"
 msgstr "&Διαγραφή"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr ""
-"Επιθυμείτε σίγουρα να διαγράψετε την εικονική μηχανή \"%1\" και όλα τα "
-"αρχεία της; Αυτή η ενέργεια είναι ανεπανόρθωτη!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "Επιθυμείτε σίγουρα να διαγράψετε την εικονική μηχανή \"%1\" και όλα τα αρχεία της;"
+
+msgid "This action cannot be undone!"
+msgstr "Αυτή η ενέργεια είναι ανεπανόρθωτη!"
 
 msgid "Show &config file"
 msgstr "Εμφάνιση αρχείου &προσαρμογής"

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -1238,6 +1238,9 @@ msgstr "No fúe posible abrir el archivo de configuración seleccionado para lee
 msgid "Use regular expressions in search box"
 msgstr "Utilizar expresiones regulares en la caja de búsqueda"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "%n máquina es activa en este momento. ¿Está seguro de que quiere salir del administrador de MV?"
@@ -1411,8 +1414,11 @@ msgstr "Terminar forzadamente a la máquina virtual puede cusar la pérdida de d
 msgid "&Delete"
 msgstr "&Borrar"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "¿De verdad quiere borrar la máquina virtual \"%1\" y todos sus archivos? ¡Esta acción no se puede deshacer!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "¿De verdad quiere borrar la máquina virtual \"%1\" y todos sus archivos?"
+
+msgid "This action cannot be undone!"
+msgstr "¡Esta acción no se puede deshacer!"
 
 msgid "Show &config file"
 msgstr "Mostrar archivo de &configuración"

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -1238,6 +1238,9 @@ msgstr "Valittua määritystä ei voitu avata: %1"
 msgid "Use regular expressions in search box"
 msgstr "Käytä säännöllisiä lausekkeita (regex) hakukentässä"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] ""
@@ -1415,8 +1418,11 @@ msgstr "Virtuaalikoneen pakkopysäytys saattaa johtaa datan menettämiseen. Tee 
 msgid "&Delete"
 msgstr "&Poista"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "Haluatko varmasti poistaa \"%1\"-virtuaalikoneen ja kaikki sen tiedostot? Poistamista ei voi perua!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "Haluatko varmasti poistaa \"%1\"-virtuaalikoneen ja kaikki sen tiedostot?"
+
+msgid "This action cannot be undone!"
+msgstr "Poistamista ei voi perua!"
 
 msgid "Show &config file"
 msgstr "Näytä &määritystiedosto"

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -1254,6 +1254,9 @@ msgstr "Impossible d'ouvrir le fichier de configuration sélectionné pour lectu
 msgid "Use regular expressions in search box"
 msgstr "Utilisez des expressions régulières dans le champ de recherche"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "%n machine est actuellement active. Êtes-vous sûr de vouloir quitter le gestionnaire de machines virtuelles malgré tout ?"
@@ -1427,8 +1430,11 @@ msgstr "La fermeture forcée d'une machine virtuelle peut entraîner une perte d
 msgid "&Delete"
 msgstr "&Supprimer"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "Voulez-vous vraiment supprimer la machine virtuelle « %1 » et tous ses fichiers ? Cette action ne peut pas être annulée !"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "Voulez-vous vraiment supprimer la machine virtuelle « %1 » et tous ses fichiers ?"
+
+msgid "This action cannot be undone!"
+msgstr "Cette action ne peut pas être annulée !"
 
 msgid "Show &config file"
 msgstr "Afficher le fichier de &configuration"

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -1244,6 +1244,9 @@ msgstr "Nije moguće otvoriti odabranu konfiguracijsku datoteku za čitanje: %1"
 msgid "Use regular expressions in search box"
 msgstr "U polju za pretraživanje koristite regularne izraze"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "%n računalo je trenutno aktivno. Jeste li sigurni da ipak želite izaći iz upravitelja virtualnih sistema?"
@@ -1418,8 +1421,11 @@ msgstr "Prisilno prekidanje virtualnog stroja može uzrokovati gubitak podataka.
 msgid "&Delete"
 msgstr "&Izbriši"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "Želite li zaista izbrisati virtualni stroj \"%1\" i sve njegove datoteke? Ovu radnju nije moguće poništiti!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "Želite li zaista izbrisati virtualni stroj \"%1\" i sve njegove datoteke?"
+
+msgid "This action cannot be undone!"
+msgstr "Ovu radnju nije moguće poništiti!"
 
 msgid "Show &config file"
 msgstr "Prikaži &konfiguracijsku datoteku"

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -1270,6 +1270,9 @@ msgstr "Impossibile aprire il file di configurazione selezionato per la lettura:
 msgid "Use regular expressions in search box"
 msgstr "Utilizza espressioni regolari nella casella di ricerca"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "È attualmente attiva %n macchina. Vuoi comunque uscire dal gestore delle macchine virtuali?"
@@ -1449,8 +1452,11 @@ msgstr ""
 msgid "&Delete"
 msgstr "&Elimina"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "Vuoi davvero eliminare la macchina virtuale \"%1\" e tutti i suoi file? Questa operazione è irreversibile!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "Vuoi davvero eliminare la macchina virtuale \"%1\" e tutti i suoi file?"
+
+msgid "This action cannot be undone!"
+msgstr "Questa operazione è irreversibile!"
 
 msgid "Show &config file"
 msgstr "Mostra file di &configurazione"

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -1235,6 +1235,9 @@ msgstr "選択した設定ファイルを読み込むことができませんで
 msgid "Use regular expressions in search box"
 msgstr "検索ボックスで正規表現を使用する"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "現在、%n台の仮想マシンがアクティブです。それでもVMマネージャーを終了しますか？"
@@ -1407,8 +1410,11 @@ msgstr "仮想マシンを強制終了すると、データが失われる可能
 msgid "&Delete"
 msgstr "削除(&D)"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "本当に仮想マシン「%1」とそのすべてのファイルを削除しますか？ この操作は元に戻せません！"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "本当に仮想マシン「%1」とそのすべてのファイルを削除しますか？"
+
+msgid "This action cannot be undone!"
+msgstr "この操作は元に戻せません！"
 
 msgid "Show &config file"
 msgstr "設定ファイルを表示する(&C)"

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -1272,6 +1272,9 @@ msgstr "선택한 구성 파일을 읽기 위해 열 수 없습니다: %1"
 msgid "Use regular expressions in search box"
 msgstr "검색 상자에 정규 표현식 사용"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "현재 실행 중인 머신이 %n개 있습니다. 그래도 VM 관리자를 종료하시겠습니까?"
@@ -1444,8 +1447,11 @@ msgstr "가상 머신을 강제 종료하면 데이터 손실이 발생할 수 �
 msgid "&Delete"
 msgstr "삭제(&D)"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "정말 가상 머신 \"%1\"과 모든 파일을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "정말 가상 머신 \"%1\"과 모든 파일을 삭제하시겠습니까?"
+
+msgid "This action cannot be undone!"
+msgstr "이 작업은 되돌릴 수 없습니다!"
 
 msgid "Show &config file"
 msgstr "구성 파일 표시(&C)"

--- a/src/qt/languages/nb-NO.po
+++ b/src/qt/languages/nb-NO.po
@@ -1239,6 +1239,9 @@ msgstr "Kan ikke åpne valgt konfigurasjonsfil for lesing: %1"
 msgid "Use regular expressions in search box"
 msgstr "Bruk regulære uttrykk i søkeboksen"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "%n maskin er for øyeblikket aktive. Er du sikker på at du vil avslutte VM-administratoren uansett?"
@@ -1412,8 +1415,11 @@ msgstr "Å avslutte en virtuell maskin kan føre til datatap. Gjør dette kun hv
 msgid "&Delete"
 msgstr "&Slett"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "Vil du virkelig slette den virtuelle maskinen \"%1\" og alle dens filer? Denne handlingen kan ikke angres!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "Vil du virkelig slette den virtuelle maskinen \"%1\" og alle dens filer?"
+
+msgid "This action cannot be undone!"
+msgstr "Denne handlingen kan ikke angres!"
 
 msgid "Show &config file"
 msgstr "Vis &konfigurasjonsfil"

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -1238,6 +1238,9 @@ msgstr "Openen van geselecteerd configuratiebestand voor lezen niet mogelijk: %1
 msgid "Use regular expressions in search box"
 msgstr "Gebruik reguliere expressies in zoekveld"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "%n machine is nu actief. Weet je zeker dat je de VM manager wil afsluiten?"
@@ -1411,8 +1414,11 @@ msgstr "Gedwongen beëindiging van een virtuele machine kan dataverlies veroorza
 msgid "&Delete"
 msgstr "&Verwijderen"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "Weet je zeker dat je de virtuele machine \"%1\" en al haar bestanden wil verwijderen? Deze actie kan niet ongedaan gemaakt worden!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "Weet je zeker dat je de virtuele machine \"%1\" en al haar bestanden wil verwijderen?"
+
+msgid "This action cannot be undone!"
+msgstr "Deze actie kan niet ongedaan gemaakt worden!"
 
 msgid "Show &config file"
 msgstr "Toon &configuratiebestand"

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -1243,6 +1243,9 @@ msgstr "Nie udało się otworzyć wybranego pliku konfiguracyjnego do odczytu: %
 msgid "Use regular expressions in search box"
 msgstr "Użyj wyrażeń regularnych w polu wyszukiwania"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "%n maszyna jest obecnie aktywna. Czy mimo to chcesz wyjść z menedżera maszyn wirtualnych?"
@@ -1417,8 +1420,11 @@ msgstr "Zabicie maszyny wirtualnej może spowodować utratę danych. Zrób to ty
 msgid "&Delete"
 msgstr "&Usuń"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "Czy na pewno chcesz usunąć maszynę wirtualną „%1” i jej wszystkie pliki? Tej operacji nie można cofnąć!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "Czy na pewno chcesz usunąć maszynę wirtualną „%1” i jej wszystkie pliki?"
+
+msgid "This action cannot be undone!"
+msgstr "Tej operacji nie można cofnąć!"
 
 msgid "Show &config file"
 msgstr "&Pokaż plik konfiguracyjny"

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -1239,6 +1239,9 @@ msgstr "Não foi possível abrir o arquivo de configuração selecionado para le
 msgid "Use regular expressions in search box"
 msgstr "Usar expressões regulares na caixa de pesquisa"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "%n máquina está ativa no momento. Tem certeza de que deseja sair do gerenciador de MVs mesmo assim?"
@@ -1412,8 +1415,11 @@ msgstr "Forçar o encerramento de uma máquina virtual pode causar perda de dado
 msgid "&Delete"
 msgstr "&Apagar"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "Deseja realmente apagar a máquina virtual \"%1\" e todos os seus arquivos? Essa ação não pode ser desfeita!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "Deseja realmente apagar a máquina virtual \"%1\" e todos os seus arquivos?"
+
+msgid "This action cannot be undone!"
+msgstr "Essa ação não pode ser desfeita!"
 
 msgid "Show &config file"
 msgstr "Mostrar arquivo de &configuração"

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -1239,6 +1239,9 @@ msgstr "Não foi possível abrir o ficheir de configurção seleccionado para le
 msgid "Use regular expressions in search box"
 msgstr "Usa expressões regulares na caixa de procura"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "%n máquina está actualmente activas. Quer mesmo sair do gerenciador de MVs?"
@@ -1412,8 +1415,11 @@ msgstr "Terminar uma máquina virtual pode causar a perdida de dados. Faça-o s�
 msgid "&Delete"
 msgstr "&Apagar"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "Tem certeza de que quiser apagar a máquina virtual \"%1\" e todos os seus ficheiros? Esta ação não pode ser desfeita!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "Tem certeza de que quiser apagar a máquina virtual \"%1\" e todos os seus ficheiros?"
+
+msgid "This action cannot be undone!"
+msgstr "Esta ação não pode ser desfeita!"
 
 msgid "Show &config file"
 msgstr "Mostrar ficheiro de &configuração"

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -1255,6 +1255,9 @@ msgstr "Невозможно открыть выбранный файл конф
 msgid "Use regular expressions in search box"
 msgstr "Использовать регулярные выражения в поле поиска"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr "Удалять виртуальные машины в Корзину"
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "%n машина в настоящее время активна. Вы уверены, что всё равно хотите выйти из менеджера виртуальных машин?"
@@ -1429,8 +1432,11 @@ msgstr "Принудительное завершение процесса ви�
 msgid "&Delete"
 msgstr "&Удалить"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "Вы действительно хотите удалить виртуальную машину «%1» и все её файлы? Это действие не может быть отменено!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "Вы действительно хотите удалить виртуальную машину «%1» и все её файлы?"
+
+msgid "This action cannot be undone!"
+msgstr "Это действие не может быть отменено!"
 
 msgid "Show &config file"
 msgstr "Показать файл &конфигурации"

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -1242,6 +1242,9 @@ msgstr "Nie je možné otvoriť vybraný konfiguračný súbor na čítanie: %1"
 msgid "Use regular expressions in search box"
 msgstr "Použiť v poli vyhľadávania regulárne výrazy"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "%n počítač je stále aktívny. Naozaj chcete ukončiť správcu virtuálnych počítačov?"
@@ -1416,8 +1419,11 @@ msgstr "Ukončenie virtuálneho počítača môže spôsobiť stratu údajov. Uk
 msgid "&Delete"
 msgstr "&Odstrániť"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "Naozaj chcete odstrániť virtuálny počítač \"%1\" a všetky jeho súbory? Táto akcia sa nedá vrátiť späť!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "Naozaj chcete odstrániť virtuálny počítač \"%1\" a všetky jeho súbory?"
+
+msgid "This action cannot be undone!"
+msgstr "Táto akcia sa nedá vrátiť späť!"
 
 msgid "Show &config file"
 msgstr "Zobraziť &konfiguračný súbor"

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -1248,6 +1248,9 @@ msgstr "Ni bilo mogože odpreti izbrane datoteke z nastavitvami za branje: %1"
 msgid "Use regular expressions in search box"
 msgstr "V iskalnem polju uporabi regularne ekspresije"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "Trenutno je dejavna %n naprava. Ali vseeno želite izstopiti iz upravitelja navideznih naprav?"
@@ -1423,8 +1426,11 @@ msgstr "Prisilno končanje navidezne naprave lahko povzroči izgubo podatkov. To
 msgid "&Delete"
 msgstr "Iz&briši"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "Ali res želite izbrisati navidezno napravo \"%1\" in vse njene datoteke? Preklic teka dejanja ni mogoč!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "Ali res želite izbrisati navidezno napravo \"%1\" in vse njene datoteke?"
+
+msgid "This action cannot be undone!"
+msgstr "Preklic teka dejanja ni mogoč!"
 
 msgid "Show &config file"
 msgstr "Prikaži datoteko z &nastavitvami"

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -1238,6 +1238,9 @@ msgstr "Kunde inte läsa den valda konfigurationsfilen: %1"
 msgid "Use regular expressions in search box"
 msgstr "Använd vanliga uttryck i sökfältet"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "%n maskin är aktiva. Är du säker på att du vill avsluta VM-hanteraren ändå?"
@@ -1411,8 +1414,11 @@ msgstr "Att döda en virtuell maskin kan orsaka dataförlust. Gör detta endast 
 msgid "&Delete"
 msgstr "&Ta bort"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "Vill du verkligen ta bort virtuella maskinen \"%1\" och alla dess filer? Denna handling kan inte ångras!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "Vill du verkligen ta bort virtuella maskinen \"%1\" och alla dess filer?"
+
+msgid "This action cannot be undone!"
+msgstr "Denna handling kan inte ångras!"
 
 msgid "Show &config file"
 msgstr "Visa &konfigurationsfil"

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -1258,6 +1258,9 @@ msgstr "Seçili yapılandırma dosyası okunmak için açılamıyor: %1"
 msgid "Use regular expressions in search box"
 msgstr "Arama kutusunda düzenli ifadeler kullan"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "%n makine şu anda aktif. Yine de sanal makine yöneticisinden çıkmak istediğinize emin misiniz?"
@@ -1435,10 +1438,11 @@ msgstr ""
 msgid "&Delete"
 msgstr "&Sil"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr ""
-"Gerçekten \"%1\" sanal makinesini tüm dosyalarıyla birlikte silmek istiyor "
-"musunuz? Bu işlem geri alınamaz!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "Gerçekten \"%1\" sanal makinesini tüm dosyalarıyla birlikte silmek istiyor musunuz?"
+
+msgid "This action cannot be undone!"
+msgstr "Bu işlem geri alınamaz!"
 
 msgid "Show &config file"
 msgstr "Yap&ılandırma dosyasını göster"

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -1244,6 +1244,9 @@ msgstr "Неможливо відкрити вибраний файл конфі
 msgid "Use regular expressions in search box"
 msgstr "Використовувати регулярні вирази в полі пошуку"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "%n машина наразі активна. Ви впевнені, що все одно хочете вийти з менеджера віртуальних машин?"
@@ -1418,8 +1421,11 @@ msgstr "Примусове завершення процесу віртуаль�
 msgid "&Delete"
 msgstr "&Видалити"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "Ви дійсно хочете видалити віртуальну машину «%1» і всі її файли? Цю дію не можна скасувати!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "Ви дійсно хочете видалити віртуальну машину «%1» і всі її файли?"
+
+msgid "This action cannot be undone!"
+msgstr "Цю дію не можна скасувати!"
 
 msgid "Show &config file"
 msgstr "Показати файл &конфігурації"

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -1235,6 +1235,9 @@ msgstr "Không thể mở cấu hình đã chọn để đọc: %1"
 msgid "Use regular expressions in search box"
 msgstr "Dùng regex trong hộp tìm kiếm"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "%n máy hiện vẫn đang chạy. Bạn có muốn thoát trình quản lý máy ảo không?"
@@ -1407,8 +1410,11 @@ msgstr "Buộc một máy ảo dừng có thể gây ra mất mát dữ liệu. 
 msgid "&Delete"
 msgstr "Xóa"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "Bạn có thật sự muốn xóa máy ảo \"%1\" và tất cả các tập tin của nó không? Thao tác này không thể được phục hồi!"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "Bạn có thật sự muốn xóa máy ảo \"%1\" và tất cả các tập tin của nó không?"
+
+msgid "This action cannot be undone!"
+msgstr "Thao tác này không thể được phục hồi!"
 
 msgid "Show &config file"
 msgstr "Hiện tập tin cấu hình"

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -1235,6 +1235,9 @@ msgstr "无法打开选定的配置文件进行读取：%1"
 msgid "Use regular expressions in search box"
 msgstr "在搜索框中使用正则表达式"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "%n 个计算机当前处于活动状态。您确定要退出虚拟机管理器吗？"
@@ -1407,8 +1410,11 @@ msgstr "强制终止虚拟机可能导致数据丢失。仅在86Box进程卡住�
 msgid "&Delete"
 msgstr "删除(&D)"
 
-msgid "Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!"
-msgstr "你真的想删除虚拟机 \"%1\" 及其所有文件吗？此操作无法撤消！"
+msgid "Do you really want to delete the virtual machine \"%1\" and all its files?"
+msgstr "你真的想删除虚拟机 \"%1\" 及其所有文件吗？"
+
+msgid "This action cannot be undone!"
+msgstr "此操作无法撤消！"
 
 msgid "Show &config file"
 msgstr "显示配置文件(&C)"

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -1240,6 +1240,9 @@ msgstr "無法開啟選取的組態檔進行讀取: %1"
 msgid "Use regular expressions in search box"
 msgstr "在搜尋欄中使用正規表示式"
 
+msgid "Delete virtual machines to Recycle Bin"
+msgstr ""
+
 msgid "%n machine(s) are currently active. Are you sure you want to exit the VM manager anyway?"
 msgid_plural "%n machines are currently active. Are you sure you want to exit the VM manager anyway?"
 msgstr[0] "%n 台機器目前處於活動狀態。您確定要退出虛擬機器管理員嗎？"

--- a/src/qt/qt_vmmanager_config.cpp
+++ b/src/qt/qt_vmmanager_config.cpp
@@ -24,6 +24,9 @@ extern "C" {
 QVariantHash VMManagerConfig::generalDefaults = {
     { "hide_tool_bar",   0 },
     { "regex_search",    0 },
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    { "delete_to_trash", 0 },
+#endif
 #if EMU_BUILD_NUM != 0
     { "update_check",    1 },
 #endif

--- a/src/qt/qt_vmmanager_main.cpp
+++ b/src/qt/qt_vmmanager_main.cpp
@@ -20,6 +20,7 @@
 #include <QDesktopServices>
 #include <QMenu>
 #include <QMessageBox>
+#include <QStringBuilder>
 #include <QStringListModel>
 #include <QTimer>
 #include <QProgressDialog>
@@ -772,15 +773,34 @@ VMManagerMain::addNewSystem(const QString &name, const QString &dir, const QStri
 void
 VMManagerMain::deleteSystem(VMManagerSystem *sysconfig)
 {
-    QMessageBox msgbox(QMessageBox::Icon::Warning, tr("Warning"), tr("Do you really want to delete the virtual machine \"%1\" and all its files? This action cannot be undone!").arg(sysconfig->displayName), QMessageBox::StandardButton::Yes | QMessageBox::StandardButton::No, qobject_cast<QWidget *>(this->parent()));
+    auto config = new VMManagerConfig(VMManagerConfig::ConfigType::General);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    int trash = config->getStringValue("delete_to_trash").toInt();
+#endif
+    QString msgboxText = tr("Do you really want to delete the virtual machine \"%1\" and all its files?").arg(sysconfig->displayName);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    if (!trash)
+#endif
+        msgboxText.append(QStringLiteral(" ") % tr("This action cannot be undone!"));
+    QMessageBox msgbox(QMessageBox::Icon::Warning, tr("Warning"), msgboxText, QMessageBox::StandardButton::Yes | QMessageBox::StandardButton::No, qobject_cast<QWidget *>(this->parent()));
     msgbox.exec();
     if (msgbox.result() == QMessageBox::Yes) {
-        auto qrmdir = new QDir(sysconfig->config_dir);
-        if (const bool rmdirResult = qrmdir->removeRecursively(); !rmdirResult) {
+        bool rmdirResult;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+        if (trash) {
+            auto qrmdir = new QFile(sysconfig->config_dir);
+            rmdirResult = qrmdir->moveToTrash();
+        } else
+#endif
+        {
+            auto qrmdir = new QDir(sysconfig->config_dir);
+            rmdirResult = qrmdir->removeRecursively();
+        }
+
+        if (!rmdirResult) {
             QMessageBox::critical(this, tr("Remove directory failed"), tr("Some files in the machine's directory were unable to be deleted. Please delete them manually."));
             return;
         }
-        auto config = new VMManagerConfig(VMManagerConfig::ConfigType::General);
         config->remove(sysconfig->uuid);
         vm_model->removeConfigFromModel(sysconfig);
         delete sysconfig;

--- a/src/qt/qt_vmmanager_preferences.cpp
+++ b/src/qt/qt_vmmanager_preferences.cpp
@@ -77,6 +77,12 @@ VMManagerPreferences::
     ui->regexSearchCheckBox->setChecked(useRegexSearch);
     const auto rememberSizePosition = config->getStringValue("window_remember").toInt();
     ui->rememberSizePositionCheckBox->setChecked(rememberSizePosition);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    const auto deleteToTrash = config->getStringValue("delete_to_trash").toInt();
+    ui->deleteToTrashCheckBox->setChecked(deleteToTrash);
+#else
+    ui->deleteToTrashCheckBox->setVisible(false);
+#endif
 
     ui->radioButtonSystem->setChecked(color_scheme == 0);
     ui->radioButtonLight->setChecked(color_scheme == 1);
@@ -128,6 +134,9 @@ VMManagerPreferences::accept()
 #endif
     config->setStringValue("window_remember", ui->rememberSizePositionCheckBox->isChecked() ? "1" : "0");
     config->setStringValue("regex_search", ui->regexSearchCheckBox->isChecked() ? "1" : "0");
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    config->setStringValue("delete_to_trash", ui->deleteToTrashCheckBox->isChecked() ? "1" : "0");
+#endif
     QDialog::accept();
 }
 

--- a/src/qt/qt_vmmanager_preferences.ui
+++ b/src/qt/qt_vmmanager_preferences.ui
@@ -144,6 +144,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="deleteToTrashCheckBox">
+     <property name="text">
+      <string>Delete virtual machines to Recycle Bin</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupBoxColorScheme">
      <property name="title">
       <string>Color scheme</string>
@@ -206,6 +213,10 @@
   <tabstop>rememberSizePositionCheckBox</tabstop>
   <tabstop>updateCheckBox</tabstop>
   <tabstop>regexSearchCheckBox</tabstop>
+  <tabstop>deleteToTrashCheckBox</tabstop>
+  <tabstop>radioButtonSystem</tabstop>
+  <tabstop>radioButtonLight</tabstop>
+  <tabstop>radioButtonDark</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
Summary
=======
Add an option to move virtual machines to Trash/Recycle Bin when deleting them. It relies on Qt's `QFile::moveToTrash()` and therefore should work on Windows, Mac, and Linux/Unix with the Freedesktop trash specification implemented.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set
* [ ] This pull request adds, changes or removes an external dependency

References
==========
N/A