### PR TITLE
Mitsumi: Reads now work on NT 4.0 builtin drivers

### DIFF
--- a/src/cdrom/cdrom.c
+++ b/src/cdrom/cdrom.c
@@ -2321,15 +2321,22 @@ cdrom_get_track_buffer(cdrom_t *dev, uint8_t *buf)
     buf[8] = 0x00;
 }
 
-void
-cdrom_get_q(cdrom_t *dev, uint8_t *buf, int *curtoctrk, uint8_t mode)
+int compare_points(const void* a, const void* b)
 {
-    int               num;
+    const raw_track_info_t* arg1 = (const raw_track_info_t*)a;
+    const raw_track_info_t* arg2 = (const raw_track_info_t*)b;
+
+    if (arg1->point < arg2->point) return -1;
+    if (arg1->point > arg2->point) return 1;
+    return 0;
+}
+
+int
+cdrom_get_q(cdrom_t *dev, uint8_t *buf, int curtoctrk, uint8_t mode)
+{
+    int               num = 0;
     uint8_t           rti[65536]  = { 0 };
     raw_track_info_t *t        = (raw_track_info_t *) rti;
-    int               first = 0;
-    int               last = 0;
-    memset(buf, 0x00, 10);
 
     if (!mode) {    
         const subchannel_t *subc = &dev->cached_subc;
@@ -2345,45 +2352,38 @@ cdrom_get_q(cdrom_t *dev, uint8_t *buf, int *curtoctrk, uint8_t mode)
         buf[7] = subc->abs_m;
         buf[8] = subc->abs_s;
         buf[9] = subc->abs_f;
-        return;
+        return curtoctrk;
     }
 
     dev->ops->get_raw_track_info(dev->local, &num, rti);
 
-    if (*curtoctrk < 0)
-        *curtoctrk = 0;
+    if (curtoctrk < 0)
+        curtoctrk = 0;
+    
+    if (curtoctrk > num)
+        curtoctrk = 0;
 
     // Mitsumi encodes points in BCD format, always.
-    int i = 0;
-    while (t[*curtoctrk].point > 99) {
-        (void)*curtoctrk++;
-        i++;
+    qsort(rti, num, sizeof(raw_track_info_t), compare_points);
 
-        if (*curtoctrk > num) {
-            *curtoctrk = 0;
-        }
-        if (i == num)
-            break;
-    }
-
-    buf[0] = (t[*curtoctrk].adr_ctl >> 4) | ((t[*curtoctrk].adr_ctl & 0xf) << 4);
+    buf[0] = (t[curtoctrk].adr_ctl >> 4) | ((t[curtoctrk].adr_ctl & 0xf) << 4);
     buf[1] = 0;
-    buf[2] = bin2bcd(t[*curtoctrk].point);
-    buf[3] = bin2bcd(t[*curtoctrk].m);
-    buf[4] = bin2bcd(t[*curtoctrk].s);
-    buf[5] = bin2bcd(t[*curtoctrk].f);
-    buf[6] = bin2bcd(t[*curtoctrk].zero);
-    buf[7] = bin2bcd(t[*curtoctrk].pm);
-    buf[8] = bin2bcd(t[*curtoctrk].ps);
-    buf[9] = bin2bcd(t[*curtoctrk].pf);
+    buf[2] = bin2bcd(t[curtoctrk].point);
+    buf[3] = bin2bcd(t[curtoctrk].m);
+    buf[4] = bin2bcd(t[curtoctrk].s);
+    buf[5] = bin2bcd(t[curtoctrk].f);
+    buf[6] = bin2bcd(t[curtoctrk].zero);
+    buf[7] = bin2bcd(t[curtoctrk].pm);
+    buf[8] = bin2bcd(t[curtoctrk].ps);
+    buf[9] = bin2bcd(t[curtoctrk].pf);
 
-    (void)*curtoctrk++;
+    curtoctrk++;
 
-    if (*curtoctrk > num) {
-        *curtoctrk = 0;
+    if (t[curtoctrk].point > 99) {
+        curtoctrk = 0;
     }
 
-    return;
+    return curtoctrk;
 }
 
 uint8_t

--- a/src/cdrom/cdrom_mitsumi.c
+++ b/src/cdrom/cdrom_mitsumi.c
@@ -100,7 +100,7 @@ typedef struct mcd_t {
     uint8_t  buf[RAW_SECTOR_SIZE];
     int      buf_count;
     int      buf_idx;
-    uint8_t  cmdbuf[16];
+    uint8_t  cmdbuf[32];
     int      cmdbuf_count;
     int      cmdrd_count;
     int      cmdbuf_idx;
@@ -242,7 +242,7 @@ mitsumi_disc_info(mcd_t *mcd, unsigned char *b)
     b[5] = bin2bcd(track_type_buf[2]);
     b[6] = bin2bcd(track_type_buf[3]);
     b[7] = bin2bcd(track_type_buf[4]);
-    uint32_t lo = cdrom_lba_to_msf_accurate(dev->cdrom_capacity);
+    uint32_t lo = cdrom_lba_to_msf_accurate(dev->cdrom_capacity + 1);
     b[2] = bin2bcd((lo >> 16) & 0xff);
     b[3] = bin2bcd((lo >> 8) & 0xff);
     b[4] = bin2bcd(lo & 0xff);
@@ -312,7 +312,7 @@ mitsumi_cdrom_in(uint16_t port, void *priv)
                 if (!dev->buf_count)
                     mitsumi_cdrom_read_sector(dev, 0);
 
-                pclog("Read port 0: ret = %02x\n", ret);
+                //pclog("Read port 0: ret = %02x\n", ret);
                 return ret;
             } else if (dev->cmdbuf_count) {
                 dev->cmdbuf_count--;
@@ -519,12 +519,13 @@ mitsumi_cdrom_out(uint16_t port, uint8_t val, void *priv)
                     break;
                 case CMD_GET_Q:
                     if (mitsumi_cdrom_is_ready(dev)) {
-                        cdrom_get_q(dev->cdrom_dev, &(dev->cmdbuf[1]), &dev->cur_toc_track, dev->mode & MODE_GET_TOC);
-                        dev->cmdbuf_count = 11;
-                        dev->readcount    = 0;
+                        dev->cur_toc_track = cdrom_get_q(dev->cdrom_dev, &dev->cmdbuf[1], dev->cur_toc_track, dev->mode & MODE_GET_TOC);
+                        dev->cmdbuf_count  = 11;
+                        dev->readcount     = 0;
+                        dev->cmdbuf[0]     = dev->stat;
                     } else {
-                        dev->cmdbuf_count = 1;
-                        dev->cmdbuf[0]    = STAT_CMD_CHECK | dev->stat;
+                        dev->cmdbuf_count  = 1;
+                        dev->cmdbuf[0]     = STAT_CMD_CHECK | dev->stat;
                     }
                     break;
                 case CMD_GET_STAT:

--- a/src/include/86box/cdrom.h
+++ b/src/include/86box/cdrom.h
@@ -581,7 +581,7 @@ extern int             cdrom_read_toc_sony(const cdrom_t *dev, uint8_t *b, const
                                            const int msf, const int max_len);
 #ifdef USE_CDROM_MITSUMI
 extern void            cdrom_get_track_buffer(cdrom_t *dev, uint8_t *buf);
-extern void            cdrom_get_q(cdrom_t *dev, uint8_t *buf, int *curtoctrk, uint8_t mode);
+extern int             cdrom_get_q(cdrom_t *dev, uint8_t *buf, int curtoctrk, uint8_t mode);
 extern uint8_t         cdrom_mitsumi_audio_play(cdrom_t *dev, uint32_t pos, uint32_t len);
 #endif
 extern uint8_t         cdrom_read_disc_info_toc(cdrom_t *dev, uint8_t *b,


### PR DESCRIPTION
Summary
=======
Mitsumi: Reads now work on NT 4.0 builtin drivers.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
