### PR TITLE
Add missing string in POT, PO files

### DIFF
--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -2921,6 +2921,9 @@ msgstr ""
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr ""
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr ""
 

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -2937,6 +2937,9 @@ msgstr "Error en inicialitzar el renderitzador Vulkan."
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr ""
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr ""
 

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -2979,6 +2979,9 @@ msgstr "Selhala inicializace rendereru Vulkan."
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr ""
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr ""
 

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -2937,6 +2937,9 @@ msgstr "Fehler bei der Initialisierung des Vulkan-Renderers."
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr ""
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr ""
 

--- a/src/qt/languages/el-GR.po
+++ b/src/qt/languages/el-GR.po
@@ -2971,6 +2971,9 @@ msgstr "Αποτυχία αρχικοποίησης απεικονιστή Vulka
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr "Αποτυχία δημιουργίας στιγμιότυπου Vulkan 1.3."
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr "Δεν βρέθηκαν φυσικές συσκευές με δυνατότητα Vulkan."
 

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -2938,6 +2938,9 @@ msgstr "Error al inicializar el renderizador Vulkan."
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr ""
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr ""
 

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -2941,6 +2941,9 @@ msgstr "Vulkan-rendereriä ei voitu alustaa."
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr ""
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr ""
 

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -2955,6 +2955,9 @@ msgstr "Impossible d’initialiser le moteur de rendu Vulkan."
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr ""
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr ""
 

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -2944,6 +2944,9 @@ msgstr "Nije uspjelo inicijaliziranje renderera Vulkan."
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr ""
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr ""
 

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -2991,6 +2991,9 @@ msgstr "Impossibile inizializzare il renderizzatore Vulkan."
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr ""
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr ""
 

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -2933,6 +2933,9 @@ msgstr "Vulkanレンダラーの初期化に失敗しました。"
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr ""
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr ""
 

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -2999,6 +2999,9 @@ msgstr "Vulkan 렌더러 초기화 실패."
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr ""
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr ""
 

--- a/src/qt/languages/nb-NO.po
+++ b/src/qt/languages/nb-NO.po
@@ -2938,6 +2938,9 @@ msgstr "Kunne ikke initialisere Vulkan-gjengiver."
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr ""
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr ""
 

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -2932,6 +2932,9 @@ msgstr "Initialisatie van de Vulkan-renderer is mislukt."
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr ""
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr ""
 

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -2943,6 +2943,9 @@ msgstr "Nie udało się zainicjować renderera Vulkan."
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr ""
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr ""
 

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -2939,6 +2939,9 @@ msgstr "Falha ao inicializar o renderizador Vulkan."
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr "Falha ao criar instância Vulkan 1.3."
 
+msgid "No usable Vulkan physical devices found."
+msgstr "Nenhum dispositivo Vulkan utilizável encontrado."
+
 msgid "No Vulkan-capable physical devices found."
 msgstr "Nenhum dispositivo físico compatível com Vulkan foi encontrado."
 

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -2940,6 +2940,9 @@ msgstr "Falha na inicialização do renderizador Vulkan."
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr ""
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr ""
 

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -2950,6 +2950,9 @@ msgstr "Не удалось инициализировать рендерер Vu
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr "Не удалось создать экземпляр Vulkan 1.3."
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr "Не найдены физические устройства, поддерживающие Vulkan."
 

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -2943,6 +2943,9 @@ msgstr "Inicializácia renderera Vulkan zlyhala."
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr ""
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr ""
 

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -2949,6 +2949,9 @@ msgstr "Inicializacija upodobljevalnika Vulkan ni uspela."
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr ""
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr ""
 

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -2937,6 +2937,9 @@ msgstr "Kunde inte initialisera Vulkan-renderaren."
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr ""
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr ""
 

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -2991,6 +2991,9 @@ msgstr "Vulkan derleyicisi başlatılamadı."
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr "Vulkan 1.3 instance'ı oluşturulamadı."
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr "Vulkan uyumlu fiziksel cihaz bulunamadı."
 

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -2945,6 +2945,9 @@ msgstr "Не вдалося ініціалізувати рендеринг Vulk
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr ""
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr ""
 

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -2933,6 +2933,9 @@ msgstr "Không thể khởi tạo renderer Vulkan."
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr ""
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr ""
 

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -2937,6 +2937,9 @@ msgstr "Vulkan 渲染器初始化失败。"
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr "无法创建 Vulkan 1.3 实例。"
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr "未找到支持 Vulkan 的物理设备。"
 

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -2946,6 +2946,9 @@ msgstr "初始化 Vulkan 渲染器失敗。"
 msgid "Failed to create Vulkan 1.3 instance."
 msgstr "Vulkan 1.3 執行體創建失敗。"
 
+msgid "No usable Vulkan physical devices found."
+msgstr ""
+
 msgid "No Vulkan-capable physical devices found."
 msgstr "未發現支援 Vulkan 的實體設備。"
 


### PR DESCRIPTION
Summary
=======
This PR adds the following missing string in the template file and the PO files for translators.
https://github.com/86Box/86Box/blob/e4ace38145dca72af6ad2c77c71f657281d26b7e/src/qt/qt_vulkanwindowrenderer.cpp#L1363 

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
