### PR TITLE
Mitsumi: MS-DOS drivers now work

### DIFF
--- a/src/cdrom/cdrom_mitsumi.c
+++ b/src/cdrom/cdrom_mitsumi.c
@@ -319,7 +319,7 @@ mitsumi_cdrom_in(uint16_t port, void *priv)
                 if (!dev->buf_count)
                     mitsumi_cdrom_read_sector(dev, 0);
 
-                pclog("Read port 0 data\n");
+                //pclog("Read port 0 data\n");
                 return ret;
             } else if (dev->cmdbuf_count) {
                 dev->cmdbuf_count--;

--- a/src/cdrom/cdrom_mitsumi.c
+++ b/src/cdrom/cdrom_mitsumi.c
@@ -53,6 +53,7 @@ enum {
     CMD_GET_INFO   = 0x10,
     CMD_DISC_INFO  = 0x11,
     CMD_GET_Q      = 0x20,
+    CMD_REQ_SENSE  = 0x30,
     CMD_GET_STAT   = 0x40,
     CMD_SET_MODE   = 0x50,
     CMD_SOFT_RESET = 0x60,
@@ -120,6 +121,7 @@ typedef struct mcd_t {
     int      newstat;
 
     uint8_t  cur_control;
+    uint8_t  cur_sense;
 
     uint8_t  temp_buf[0x10000];
 
@@ -169,6 +171,7 @@ mitsumi_print_cmd(mcd_t* dev, uint8_t command) {
         CASE(CMD_GET_INFO)
         CASE(CMD_DISC_INFO)
         CASE(CMD_GET_Q)
+        CASE(CMD_REQ_SENSE)
         CASE(CMD_GET_STAT)
         CASE(CMD_SET_MODE)
         CASE(CMD_SOFT_RESET)
@@ -277,10 +280,13 @@ mitsumi_cdrom_read_sector(mcd_t *dev, int first)
     cdrom_stop(dev->cdrom_dev);
     cdrom_seek(dev->cdrom_dev, MSFtoLBA((dev->readmsf >> 16) & 0xff, (dev->readmsf >> 8) & 0xff, dev->readmsf & 0xff) - 150, 0);
     dev->cur_toc_track = INT32_MIN;
-    ret = cdrom_readsector_raw(dev->cdrom_dev, dev->buf, dev->cdrom_dev->seek_pos, 0, 0, (dev->mode & 0x80) ? 0xF8 : 0x10, (int *) &dev->readbuflen, 0);
+    if (dev->cdrom_dev->seek_pos > dev->cdrom_dev->cdrom_capacity) {
+        return -2;
+    }
+    ret = cdrom_readsector_raw(dev->cdrom_dev, dev->buf, dev->cdrom_dev->seek_pos, 0, (dev->smode == 2) ? 3 : 2, (dev->mode & 0x80) ? 0xF8 : 0x10, (int *) &dev->readbuflen, 0);
     pclog("Mitsumi read sector: Read sector @ %u, ret = %d, readlen = %u, blocklen = %u\n", dev->cdrom_dev->seek_pos, ret, dev->readbuflen, dev->dmalen + 1);
     if (ret <= 0)
-        return -1;
+        return ret == 0 ? -1 : -3;
     dev->readmsf   = cdrom_lba_to_msf_accurate(dev->cdrom_dev->seek_pos + 1);
     dev->buf_count = dev->dmalen + 1;
     dev->buf_idx   = 0;
@@ -463,7 +469,11 @@ mitsumi_cdrom_out(uint16_t port, uint8_t val, void *priv)
                                     } while ((read_res = mitsumi_cdrom_read_sector(dev, 0)) > 0);
                                 }
                                 dev->cmdbuf_count = 1;
-                                dev->cmdbuf[0]    = (read_res < 0) ? STAT_CMD_CHECK : (STAT_SPIN | STAT_READY);
+                                if (read_res < 0) {
+                                    dev->cur_sense = abs(read_res);
+                                    pclog("Read error: %d\n", dev->cur_sense);
+                                }
+                                dev->cmdbuf[0] = (read_res < 0) ? (STAT_ERROR | STAT_CMD_CHECK | STAT_SPIN | STAT_READY) : (STAT_SPIN | STAT_READY);
                                 break;
                             case 1:
                                 dev->readcount |= (val << 8);
@@ -496,6 +506,10 @@ mitsumi_cdrom_out(uint16_t port, uint8_t val, void *priv)
             dev->cmdbuf[0]    = mitsumi_cdrom_is_ready(dev) ? (STAT_READY | (dev->change ? STAT_CHANGE : 0)) : 0;
             dev->data         = 0;
             switch (val) {
+                case CMD_REQ_SENSE:
+                    dev->cmdbuf[1]    = dev->cur_sense;
+                    dev->cmdbuf_count = 2;
+                    break;
                 case CMD_DISC_INFO:
                     if (mitsumi_cdrom_is_ready(dev)) {
                         mitsumi_read_multisess(dev, &dev->cmdbuf[1]);

--- a/src/cdrom/cdrom_mitsumi.c
+++ b/src/cdrom/cdrom_mitsumi.c
@@ -206,6 +206,7 @@ mitsumi_cdrom_reset(mcd_t *dev)
     dev->data          = 0;
     dev->smode         = 1;
     dev->cur_control   = 0x0c;
+    cdrom_stop(dev->cdrom_dev);
 }
 
 /* Lifted from FreeBSD */
@@ -257,6 +258,7 @@ mitsumi_cdrom_read_sector(mcd_t *dev, int first)
 {
     uint8_t  status;
     int      ret = 0;
+    dev->data    = 0;
 
     if (dev->drvmode == DRV_MODE_CDDA) {
         status = cdrom_mitsumi_audio_play(dev->cdrom_dev, dev->readmsf, MSFtoLBA(CD_DCB((dev->readcount >> 16) & 0xff), CD_DCB((dev->readcount >> 8) & 0xff), CD_DCB(dev->readcount & 0xff)) - 150);
@@ -274,7 +276,6 @@ mitsumi_cdrom_read_sector(mcd_t *dev, int first)
         cdrom_seek(dev->cdrom_dev, MSFtoLBA((dev->readmsf >> 16) & 0xff, (dev->readmsf >> 8) & 0xff, dev->readmsf & 0xff) - 150, 0);
         pclog("Mitsumi read sector: Seek to sector %u.\n", dev->cdrom_dev->seek_pos);
         dev->cur_toc_track = INT32_MIN;
-        dev->data = 0;
         return 0;
     }
     cdrom_stop(dev->cdrom_dev);
@@ -311,14 +312,14 @@ mitsumi_cdrom_in(uint16_t port, void *priv)
 
     switch (port & 3) {
         case 0:
-            if (dev->buf_count && dev->cur_control == 0x04) {
+            if (dev->buf_count) {
                 ret = (dev->buf_idx < ((dev->mode & 0x80) ? RAW_SECTOR_SIZE : 2048)) ? dev->buf[dev->buf_idx] : 0;
                 dev->buf_idx++;
                 dev->buf_count--;
                 if (!dev->buf_count)
                     mitsumi_cdrom_read_sector(dev, 0);
 
-                //pclog("Read port 0: ret = %02x\n", ret);
+                pclog("Read port 0 data\n");
                 return ret;
             } else if (dev->cmdbuf_count) {
                 dev->cmdbuf_count--;
@@ -333,6 +334,9 @@ mitsumi_cdrom_in(uint16_t port, void *priv)
                 ret |= FLAG_NODATA;
             if (!dev->cmdbuf_count || !dev->newstat)
                 ret |= FLAG_NOSTAT;
+            if (!(ret & FLAG_NODATA) && !(ret & FLAG_NOSTAT))
+                ret |= FLAG_NOSTAT;
+
             pclog("Read port 1: ret = %02x\n", ret | FLAG_UNK | 1);
             return ret | FLAG_UNK | 1;
         case 2:
@@ -597,10 +601,14 @@ mitsumi_cdrom_out(uint16_t port, uint8_t val, void *priv)
             mitsumi_print_cmd(dev, val);
             break;
         case 1:
-            mitsumi_cdrom_reset(dev);
+            dev->cmdbuf_count = 1;
+            dev->cmdbuf[0]    = dev->stat;
             break;
         case 2:
-            dev->cur_control = val;
+            dev->cur_control  = val;
+            break;
+        case 3:
+            mitsumi_cdrom_reset(dev);
             break;
         default:
             break;


### PR DESCRIPTION
Summary
=======
Mitsumi: MS-DOS drivers now work.

Also fix a long freeze issue on NT 4.0 built-in drivers.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
