### PR TITLE
MItsumi: Try to implement early status reads

### DIFF
--- a/src/cdrom/cdrom_mitsumi.c
+++ b/src/cdrom/cdrom_mitsumi.c
@@ -112,6 +112,7 @@ typedef struct mcd_t {
     uint8_t  conf;
     uint8_t  enable_irq;
     uint8_t  enable_dma;
+    uint8_t  early_status;
     uint16_t dmalen;
     uint32_t readmsf;
     uint32_t readcount;
@@ -335,7 +336,7 @@ mitsumi_cdrom_in(uint16_t port, void *priv)
             if (!dev->cmdbuf_count || !dev->newstat)
                 ret |= FLAG_NOSTAT;
             if (!(ret & FLAG_NODATA) && !(ret & FLAG_NOSTAT))
-                ret |= FLAG_NOSTAT;
+                ret |= dev->early_status ? FLAG_NODATA : FLAG_NOSTAT;
 
             pclog("Read port 1: ret = %02x\n", ret | FLAG_UNK | 1);
             return ret | FLAG_UNK | 1;
@@ -499,7 +500,8 @@ mitsumi_cdrom_out(uint16_t port, uint8_t val, void *priv)
                                 dev->readcount |= (val << 8);
                                 break;
                             case 2:
-                                dev->readcount = (val << 16);
+                                dev->readcount    = ((val & 0x0f) << 16);
+                                dev->early_status = ((val & 0xf0) == 0xf0);
                                 break;
                             case 5:
                                 dev->readmsf = 0;


### PR DESCRIPTION
Summary
=======
MItsumi: Try to implement early status reads.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
