### PR TITLE
Aztech config improvements

### DIFF
--- a/src/sound/snd_azt2316a.c
+++ b/src/sound/snd_azt2316a.c
@@ -1639,8 +1639,8 @@ azt_init(const device_t *info)
             fatal("AZT2316A: invalid mpu401 irq in config word %08X\n", azt2316a->config_word);
 
         /* these are not present on the EEPROM */
-        azt2316a->cur_wss_irq = device_get_config_int("wss_irq");
-        azt2316a->cur_wss_dma = device_get_config_int("wss_dma");
+        azt2316a->cur_wss_irq = 10;
+        azt2316a->cur_wss_dma = 0;
         azt2316a->cur_mode    = 0;
     } else if (azt2316a->type == SB_SUBTYPE_CLONE_AZT1605_0X0C) {
         azt2316a->config_word = read_eeprom[12] + (read_eeprom[13] << 8) + (read_eeprom[14] << 16);
@@ -1717,8 +1717,8 @@ azt_init(const device_t *info)
 
         // these are not present on the EEPROM
         azt2316a->cur_dma     = 1;
-        azt2316a->cur_wss_irq = device_get_config_int("wss_irq");
-        azt2316a->cur_wss_dma = device_get_config_int("wss_dma");
+        azt2316a->cur_wss_irq = 10;
+        azt2316a->cur_wss_dma = 0;
         azt2316a->cur_mode    = 0;
     } else if (azt2316a->type == SB_SUBTYPE_CLONE_AZTPR16_0X09) {
         azt2316a->config_word = read_eeprom[32] + (read_eeprom[33] << 8) + (read_eeprom[34] << 16) + (read_eeprom[35] << 24);
@@ -2166,38 +2166,6 @@ static const device_config_t azt1605_config[] = {
         .bios           = { { 0 } }
     },
     {
-        .name           = "wss_irq",
-        .description    = "WSS IRQ",
-        .type           = CONFIG_SELECTION,
-        .default_string = NULL,
-        .default_int    = 10,
-        .file_filter    = NULL,
-        .spinner        = { 0 },
-        .selection      = {
-            { .description = "IRQ 11", .value = 11 },
-            { .description = "IRQ 10", .value = 10 },
-            { .description = "IRQ 7",  .value =  7 },
-            { .description = ""                    }
-        },
-        .bios           = { { 0 } }
-    },
-    {
-        .name           = "wss_dma",
-        .description    = "WSS DMA",
-        .type           = CONFIG_SELECTION,
-        .default_string = NULL,
-        .default_int    = 0,
-        .file_filter    = NULL,
-        .spinner        = { 0 },
-        .selection      = {
-            { .description = "DMA 0", .value = 0 },
-            { .description = "DMA 1", .value = 1 },
-            { .description = "DMA 3", .value = 3 },
-            { .description = ""                  }
-        },
-        .bios           = { { 0 } }
-    },
-    {
         .name           = "opl",
         .description    = "Enable OPL",
         .type           = CONFIG_BINARY,
@@ -2268,38 +2236,6 @@ static const device_config_t azt2316a_config[] = {
         .bios           = { { 0 } }
     },
     {
-        .name           = "wss_irq",
-        .description    = "WSS IRQ",
-        .type           = CONFIG_SELECTION,
-        .default_string = NULL,
-        .default_int    = 10,
-        .file_filter    = NULL,
-        .spinner        = { 0 },
-        .selection      = {
-            { .description = "IRQ 11", .value = 11 },
-            { .description = "IRQ 10", .value = 10 },
-            { .description = "IRQ 7",  .value =  7 },
-            { .description = ""                    }
-        },
-        .bios           = { { 0 } }
-    },
-    {
-        .name           = "wss_dma",
-        .description    = "WSS DMA",
-        .type           = CONFIG_SELECTION,
-        .default_string = NULL,
-        .default_int    = 0,
-        .file_filter    = NULL,
-        .spinner        = { 0 },
-        .selection      = {
-            { .description = "DMA 0", .value = 0 },
-            { .description = "DMA 1", .value = 1 },
-            { .description = "DMA 3", .value = 3 },
-            { .description = ""                  }
-        },
-        .bios           = { { 0 } }
-    },
-    {
         .name           = "opl",
         .description    = "Enable OPL",
         .type           = CONFIG_BINARY,
@@ -2351,38 +2287,6 @@ static const device_config_t azt2316r_config[] = {
             { .description = "0x240",              .value = 0x240 },
             { .description = "Use EEPROM setting", .value =     0 },
             { .description = ""                                   }
-        },
-        .bios           = { { 0 } }
-    },
-    {
-        .name           = "wss_irq",
-        .description    = "WSS IRQ",
-        .type           = CONFIG_SELECTION,
-        .default_string = NULL,
-        .default_int    = 10,
-        .file_filter    = NULL,
-        .spinner        = { 0 },
-        .selection      = {
-            { .description = "IRQ 11", .value = 11 },
-            { .description = "IRQ 10", .value = 10 },
-            { .description = "IRQ 7",  .value =  7 },
-            { .description = ""                    }
-        },
-        .bios           = { { 0 } }
-    },
-    {
-        .name           = "wss_dma",
-        .description    = "WSS DMA",
-        .type           = CONFIG_SELECTION,
-        .default_string = NULL,
-        .default_int    = 0,
-        .file_filter    = NULL,
-        .spinner        = { 0 },
-        .selection      = {
-            { .description = "DMA 0", .value = 0 },
-            { .description = "DMA 1", .value = 1 },
-            { .description = "DMA 3", .value = 3 },
-            { .description = ""                  }
         },
         .bios           = { { 0 } }
     },

--- a/src/sound/snd_azt2316a.c
+++ b/src/sound/snd_azt2316a.c
@@ -1716,7 +1716,7 @@ azt_init(const device_t *info)
             azt2316a->cur_wss_enabled = 0;
 
         // these are not present on the EEPROM
-        azt2316a->cur_dma     = device_get_config_int("sb_dma8");
+        azt2316a->cur_dma     = 1;
         azt2316a->cur_wss_irq = device_get_config_int("wss_irq");
         azt2316a->cur_wss_dma = device_get_config_int("wss_dma");
         azt2316a->cur_mode    = 0;
@@ -2162,22 +2162,6 @@ static const device_config_t azt1605_config[] = {
             { .description = "0x240",              .value = 0x240 },
             { .description = "Use EEPROM setting", .value =     0 },
             { .description = ""                                   }
-        },
-        .bios           = { { 0 } }
-    },
-    {
-        .name           = "sb_dma8",
-        .description    = "SB low DMA",
-        .type           = CONFIG_SELECTION,
-        .default_string = NULL,
-        .default_int    = 1,
-        .file_filter    = NULL,
-        .spinner        = { 0 },
-        .selection      = {
-            { .description = "DMA 0", .value = 0 },
-            { .description = "DMA 1", .value = 1 },
-            { .description = "DMA 3", .value = 3 },
-            { .description = ""                  }
         },
         .bios           = { { 0 } }
     },

--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -1,3 +1,65 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          Gravis UltraSound emulation.
+ *
+ * Authors: Sarah Walker, <https://pcem-emulator.co.uk/>
+ *          Miran Grca, <mgrca8@gmail.com>
+ *          win2kgamer
+ *
+ *          Copyright 2010-2020 Sarah Walker.
+ *          Copyright 2016-2025 Miran Grca.
+ *          Copyright      2026 win2kgamer
+ */
+
+/*
+ * Known issues:
+ * - MegaEM will sometimes hang when playing audio (this is known to
+ *   occur in Hoyle Classic Card games when speech plays and in the
+ *   TIE Fighter setup utility when playing music). This is due to
+ *   the DMA Terminal Count IRQ status bit not being cleared by the
+ *   program. The documented method of clearing this bit is to
+ *   read the DMA Control register (index 41h) but there may be an
+ *   unknown mechanism that automatically clears this bit that MegaEM
+ *   relies on.
+ * - SBOS does not play audio: This is due to the Adlib/SB control bits
+ *   being cleared when SBOS attempts to clear pending IRQs by writing
+ *   zeroes to the DMA Control and Timer Control (index 45h) registers.
+ * - If the above control bit issue is hacked around any attempt to play
+ *   back digital SB audio results in a large section of the GUS sample
+ *   RAM being played back instead of just the SB sample. This appears
+ *   to be due to undocumented behavior of the voice start address
+ *   register. SBOS appears to zero out the start address but expect
+ *   playback to still start at a higher address?
+ * - Gravis UltraSound Extreme is misdetected as a GUS Classic by the
+ *   Windows 3.1 drviers due the the currently used card ID of 70h.
+ *   The Win95 drivers for this card include a version of Ultramix
+ *   that appears to exepect the current ID and writes SBPro-style
+ *   mixer index/data values to the GUS mixer ports.
+ */
+
+/*
+ * TODO:
+ * - Verify the proper card ID for the Gravis UltraSound Extreme. The
+ *   ViperMAX ID is known and documented in the source code from Utopia
+ *   Sound Division.
+ * - Find any alternate methods real GUS cards use to clear the DMA TC
+ *   IRQ status bit.
+ * - Find out the proper behavior of the GUS Adlib/SB control bits (this shares
+ *   a register index with the Timer Control but likely has some undocumented
+ *   behavior that is not yet emulated).
+ * - Find any info on possible undocumented behavior of the voice start address
+ *   register and sample playback.
+ * - Implement the 16-bit recording daughterboard for the GUS Classic: this has
+ *   a CS4231 codec and can be jumpered for the following addresses: 530h, 604h,
+ *   E80h or F40h. IRQ (3/4/5/6/7/9) and DMA (1/2/3) are also jumpered.
+ */
+
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
Summary
=======
Make the following Aztech config changes:
- Remove the AZT1605 config option for the SB DMA: On a real card this is hardwired to DMA 1. There is no jumper or software setting to change this.
- Remove the AZT1605 and AZT2316A/R config options for WSS IRQ and WSS DMA: On a real card these are configured in software via the WSS-compatible configuration register

Drive-by change: Add a standard 86Box copyright header, known issue list and TODO list to snd_gus.c.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
