### PR TITLE
Mitsumi: Don't leave STAT_CHANGE flag enabled after reporting status

### DIFF
--- a/src/cdrom/cdrom_mitsumi.c
+++ b/src/cdrom/cdrom_mitsumi.c
@@ -537,15 +537,16 @@ mitsumi_cdrom_out(uint16_t port, uint8_t val, void *priv)
                         break;
                 }
                 if (!dev->cmdrd_count)
-                    dev->stat = mitsumi_cdrom_is_ready(dev) ? (STAT_READY | (dev->change ? STAT_CHANGE : 0)) : 0;
+                    dev->stat = mitsumi_cdrom_is_ready(dev) ? (STAT_READY | (dev->change ? STAT_CHANGE : 0) | STAT_SPIN) : 0;
                 return;
             }
             dev->cmd          = val;
             dev->cmdbuf_idx   = 0;
             dev->cmdrd_count  = 0;
             dev->cmdbuf_count = 1;
-            dev->stat         = mitsumi_cdrom_is_ready(dev) ? (STAT_READY | (dev->change ? STAT_CHANGE : 0)) : 0;
+            dev->stat         = mitsumi_cdrom_is_ready(dev) ? (STAT_READY | (dev->change ? STAT_CHANGE : 0) | STAT_SPIN) : 0;
             dev->cmdbuf[0]    = dev->stat;
+            dev->change       = 0;
             if (dev->cdrom_dev->cd_status == CD_STATUS_PLAYING)
                 dev->stat |= STAT_PLAY_CDDA;
             dev->data         = 0;


### PR DESCRIPTION
Summary
=======
Mitsumi: Don't leave STAT_CHANGE flag enabled after reporting status.

This should fix the Mitsumi NT 3.1 miniport drivers used during text-mode setup.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
