### PR TITLE
Mitsumi: Allow reset port to work

### DIFF
--- a/src/cdrom/cdrom_mitsumi.c
+++ b/src/cdrom/cdrom_mitsumi.c
@@ -718,7 +718,7 @@ mitsumi_cdrom_init(UNUSED(const device_t *info))
     dev->irq  = device_get_config_int("irq");
     dev->dma  = device_get_config_int("dma");
 
-    io_sethandler(base, 3,
+    io_sethandler(base, 4,
                   mitsumi_cdrom_in, NULL, NULL, mitsumi_cdrom_out, NULL, NULL, dev);
 
     mitsumi_cdrom_reset(dev);


### PR DESCRIPTION
Summary
=======
Mitsumi: Allow reset port to work.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
