### PR TITLE
Mitsumi: Switch to correct behaviour again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,11 @@ if(WIN32 AND NOT QT)
     set(FLUIDSYNTH OFF CACHE BOOL "FluidSynth" FORCE)
 endif()
 
+if(WIN32 AND GDBSTUB)
+    # Force console subsystem when building with GDBSTUB
+    set(CMAKE_WIN32_EXECUTABLE OFF CACHE BOOL "Build a Windows GUI executable" FORCE)
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
     SET(CMAKE_EXE_LINKER_FLAGS "-Wl,-z,wxneeded")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,13 @@ if(WIN32 AND GDBSTUB)
     set(CMAKE_WIN32_EXECUTABLE OFF CACHE BOOL "Build a Windows GUI executable" FORCE)
 endif()
 
+if(GDBSTUB)
+    if(NOT (ARCH STREQUAL "arm64"))
+        set(NEW_DYNAREC OFF CACHE BOOL "Use the PCem v15 (\"new\") dynamic recompiler" OFF)
+    endif()
+    set(DYNAREC OFF CACHE BOOL "Dynamic Recompiler" FORCE)
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
     SET(CMAKE_EXE_LINKER_FLAGS "-Wl,-z,wxneeded")
 endif()

--- a/src/cdrom/cdrom_mitsumi.c
+++ b/src/cdrom/cdrom_mitsumi.c
@@ -339,7 +339,7 @@ mitsumi_cdrom_in(uint16_t port, void *priv)
                     mitsumi_cdrom_read_sector(dev, 0);
                 }
 
-                pclog("Read port 0 data\n");
+                //pclog("Read port 0 data\n");
                 return ret;
             } else if (dev->cmdbuf_count && !(mitsumi_cdrom_get_flags(dev) & FLAG_NOSTAT)) {
                 dev->cmdbuf_count--;

--- a/src/cdrom/cdrom_mitsumi.c
+++ b/src/cdrom/cdrom_mitsumi.c
@@ -270,6 +270,7 @@ mitsumi_cdrom_read_sector(mcd_t *dev, int first)
             dev->drvmode = DRV_MODE_READ;
     }
 
+    pclog("IRQSET = 0x%X\n", dev->enable_irq);
     if ((dev->enable_irq & IRQ_DATACOMP) && !first) {
         picint(1 << dev->irq);
     }
@@ -333,16 +334,12 @@ mitsumi_cdrom_in(uint16_t port, void *priv)
                 ret = (dev->buf_idx < ((dev->mode & 0x80) ? RAW_SECTOR_SIZE : 2048)) ? dev->buf[dev->buf_idx] : 0;
                 dev->buf_idx++;
                 dev->buf_count--;
-                if (!dev->buf_count)
+                if (!dev->buf_count) {
+                    pclog("buf_idx = %d\n", dev->buf_idx);
                     mitsumi_cdrom_read_sector(dev, 0);
-
-                if (!dev->buf_count && dev->early_status) {
-                    dev->cmdbuf[0] = STAT_SPIN | STAT_READY | dev->stat;
-                    dev->cmdbuf_idx = 0;
-                    dev->cmdbuf_count = 1;
                 }
 
-                //pclog("Read port 0 data\n");
+                pclog("Read port 0 data\n");
                 return ret;
             } else if (dev->cmdbuf_count && !(mitsumi_cdrom_get_flags(dev) & FLAG_NOSTAT)) {
                 dev->cmdbuf_count--;
@@ -355,7 +352,7 @@ mitsumi_cdrom_in(uint16_t port, void *priv)
             picintc(1 << dev->irq);
             ret = mitsumi_cdrom_get_flags(dev);
 
-            pclog("Read port 1: ret = %02x\n", ret);
+            //pclog("Read port 1: ret = %02x\n", ret);
             return ret;
         case 2:
             return 0xFF;
@@ -420,6 +417,7 @@ mitsumi_cdrom_out(uint16_t port, uint8_t val, void *priv)
 {
     mcd_t   *dev      = (mcd_t *) priv;
     int      read_res = -1;
+    int      do_fix   = 0;
 
     pclog("Mitsumi CD-ROM OUT=%03x, val=%02x\n", port, val);
     switch (port & 3) {
@@ -495,9 +493,15 @@ mitsumi_cdrom_out(uint16_t port, uint8_t val, void *priv)
                         switch (dev->cmdrd_count) {
                             case 0:
                                 dev->readcount |= val;
-                                if (!dev->readcount && dev->early_status)
+                                do_fix = 0;
+                                if (!dev->readcount && dev->early_status) {
                                     dev->readcount = 1;
+                                    do_fix = 1;
+                                }
                                 read_res = mitsumi_cdrom_read_sector(dev, 1);
+                                if (read_res > 0 && do_fix) {
+                                    dev->buf_count++;
+                                }
                                 if (dev->enable_dma && read_res > 0) {
                                     do {
                                         while (dev->buf_count) {
@@ -521,6 +525,8 @@ mitsumi_cdrom_out(uint16_t port, uint8_t val, void *priv)
                             case 2:
                                 dev->readcount    = ((val & 0x0f) << 16);
                                 dev->early_status = ((val & 0xf0) == 0xf0);
+                                if (dev->early_status)
+                                    pclog("Early Status Read\n");
                                 break;
                             case 5:
                                 dev->readmsf = 0;

--- a/src/cdrom/cdrom_mitsumi.c
+++ b/src/cdrom/cdrom_mitsumi.c
@@ -352,7 +352,7 @@ mitsumi_cdrom_in(uint16_t port, void *priv)
             picintc(1 << dev->irq);
             ret = mitsumi_cdrom_get_flags(dev);
 
-            //pclog("Read port 1: ret = %02x\n", ret);
+            pclog("Read port 1: ret = %02x\n", ret);
             return ret;
         case 2:
             return 0xFF;
@@ -496,7 +496,7 @@ mitsumi_cdrom_out(uint16_t port, uint8_t val, void *priv)
                                 do_fix = 0;
                                 if (!dev->readcount && dev->early_status) {
                                     dev->readcount = 1;
-                                    do_fix = 1;
+                                    do_fix = 0;
                                 }
                                 read_res = mitsumi_cdrom_read_sector(dev, 1);
                                 if (read_res > 0 && do_fix) {

--- a/src/gdbstub.c
+++ b/src/gdbstub.c
@@ -37,7 +37,9 @@
 #define HAVE_STDARG_H
 #include <86box/86box.h>
 #include "cpu.h"
+#include "x86.h"
 #include "x86seg.h"
+#include "x86seg_common.h"
 #include "x87_sf.h"
 #include "x87.h"
 #include "x87_ops_conv.h"
@@ -750,6 +752,9 @@ gdbstub_client_packet(gdbstub_client_t *client)
     uint8_t buf[10] = { 0 };
     char   *p;
 
+    int     orig_cpu_abrt        = cpu_state.abrt;
+    int     orig_cpu_abrt_reason = abrt_error;
+
     /* Validate checksum. */
     client->packet_pos -= 2;
 #ifdef GDBSTUB_CHECK_CHECKSUM
@@ -882,23 +887,67 @@ e22:
             cpl_override = 1;
             if (is386) {
                 for (; i < (k & ~7); i += 8) {
+                    orig_cpu_abrt        = cpu_state.abrt;
+                    orig_cpu_abrt_reason = abrt_error;
                     *((uint64_t *) buf) = readmemql(j);
+                    if (cpu_state.abrt != orig_cpu_abrt) {
+                        if (cpu_state.abrt == ABRT_PF) {
+                            cpu_state.abrt = orig_cpu_abrt;
+                            abrt_error     = orig_cpu_abrt_reason;
+                            cpl_override   = 0;
+                            FAST_RESPONSE("E06");
+                            break;
+                        }
+                    }
                     j += 8;
                     gdbstub_client_respond_hex(client, buf, 8);
                 }
                 for (; i < (k & ~3); i += 4) {
+                    orig_cpu_abrt        = cpu_state.abrt;
+                    orig_cpu_abrt_reason = abrt_error;
                     *((uint32_t *) buf) = readmemll(j);
+                    if (cpu_state.abrt != orig_cpu_abrt) {
+                        if (cpu_state.abrt == ABRT_PF) {
+                            cpu_state.abrt = orig_cpu_abrt;
+                            abrt_error     = orig_cpu_abrt_reason;
+                            cpl_override   = 0;
+                            FAST_RESPONSE("E06");
+                            break;
+                        }
+                    }
                     j += 4;
                     gdbstub_client_respond_hex(client, buf, 4);
                 }
             }
             for (; i < (k & ~1); i += 2) {
+                orig_cpu_abrt        = cpu_state.abrt;
+                orig_cpu_abrt_reason = abrt_error;
                 *((uint16_t *) buf) = readmemwl(j);
+                if (cpu_state.abrt != orig_cpu_abrt) {
+                    if (cpu_state.abrt == ABRT_PF) {
+                        cpu_state.abrt = orig_cpu_abrt;
+                        abrt_error     = orig_cpu_abrt_reason;
+                        cpl_override   = 0;
+                        FAST_RESPONSE("E06");
+                        break;
+                    }
+                }
                 j += 2;
                 gdbstub_client_respond_hex(client, buf, 2);
             }
             for (; i < k; i++) {
+                orig_cpu_abrt        = cpu_state.abrt;
+                orig_cpu_abrt_reason = abrt_error;
                 buf[0] = readmembl(j++);
+                if (cpu_state.abrt != orig_cpu_abrt) {
+                    if (cpu_state.abrt == ABRT_PF) {
+                        cpu_state.abrt = orig_cpu_abrt;
+                        abrt_error     = orig_cpu_abrt_reason;
+                        cpl_override   = 0;
+                        FAST_RESPONSE("E06");
+                        break;
+                    }
+                }
                 gdbstub_client_respond_hex(client, buf, 1);
             }
             cpl_override = 0;
@@ -939,23 +988,67 @@ e22:
             cpl_override = 1;
             if (is386) {
                 for (; i < (k & ~7); i += 8) {
+                    orig_cpu_abrt        = cpu_state.abrt;
+                    orig_cpu_abrt_reason = abrt_error;
                     writememql(j, *((uint64_t *) p));
+                    if (cpu_state.abrt != orig_cpu_abrt) {
+                        if (cpu_state.abrt == ABRT_PF) {
+                            cpu_state.abrt = orig_cpu_abrt;
+                            abrt_error     = orig_cpu_abrt_reason;
+                            cpl_override   = 0;
+                            FAST_RESPONSE("E06");
+                            break;
+                        }
+                    }
                     j += 8;
                     p += 8;
                 }
                 for (; i < (k & ~3); i += 4) {
+                    orig_cpu_abrt        = cpu_state.abrt;
+                    orig_cpu_abrt_reason = abrt_error;
                     writememll(j, *((uint32_t *) p));
+                    if (cpu_state.abrt != orig_cpu_abrt) {
+                        if (cpu_state.abrt == ABRT_PF) {
+                            cpu_state.abrt = orig_cpu_abrt;
+                            abrt_error     = orig_cpu_abrt_reason;
+                            cpl_override   = 0;
+                            FAST_RESPONSE("E06");
+                            break;
+                        }
+                    }
                     j += 4;
                     p += 4;
                 }
             }
             for (; i < (k & ~1); i += 2) {
+                orig_cpu_abrt        = cpu_state.abrt;
+                orig_cpu_abrt_reason = abrt_error;
                 writememwl(j, *((uint16_t *) p));
+                if (cpu_state.abrt != orig_cpu_abrt) {
+                    if (cpu_state.abrt == ABRT_PF) {
+                        cpu_state.abrt = orig_cpu_abrt;
+                        abrt_error     = orig_cpu_abrt_reason;
+                        cpl_override   = 0;
+                        FAST_RESPONSE("E06");
+                        break;
+                    }
+                }
                 j += 2;
                 p += 2;
             }
             for (; i < k; i++) {
+                orig_cpu_abrt        = cpu_state.abrt;
+                orig_cpu_abrt_reason = abrt_error;
                 writemembl(j++, p[0]);
+                if (cpu_state.abrt != orig_cpu_abrt) {
+                    if (cpu_state.abrt == ABRT_PF) {
+                        cpu_state.abrt = orig_cpu_abrt;
+                        abrt_error     = orig_cpu_abrt_reason;
+                        cpl_override   = 0;
+                        FAST_RESPONSE("E06");
+                        break;
+                    }
+                }
                 p++;
             }
             cpl_override = 0;

--- a/src/gdbstub.c
+++ b/src/gdbstub.c
@@ -1953,6 +1953,10 @@ gdbstub_close(void)
     int               socket;
     while (client) {
         socket         = client->socket;
+        if (client->waiting_stop) {
+            FAST_RESPONSE("W00");
+            gdbstub_client_respond(client);
+        }
         client->socket = -1;
         close(socket);
         client = client->next;


### PR DESCRIPTION
Summary
=======
Mitsumi: Switch to correct behaviour again.

Drive-by: Make sure reads from/writes to memory by GDBSTUB do not trigger unintended exceptions.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
