### PR TITLE
Mitsumi: Implement ability to fetch sectors indefinitely if needed

### DIFF
--- a/src/cdrom/cdrom_mitsumi.c
+++ b/src/cdrom/cdrom_mitsumi.c
@@ -270,7 +270,6 @@ mitsumi_cdrom_read_sector(mcd_t *dev, int first)
             dev->drvmode = DRV_MODE_READ;
     }
 
-    pclog("IRQSET = 0x%X\n", dev->enable_irq);
     if ((dev->enable_irq & IRQ_DATACOMP) && !first) {
         picint(1 << dev->irq);
     }
@@ -417,7 +416,6 @@ mitsumi_cdrom_out(uint16_t port, uint8_t val, void *priv)
 {
     mcd_t   *dev      = (mcd_t *) priv;
     int      read_res = -1;
-    int      do_fix   = 0;
 
     pclog("Mitsumi CD-ROM OUT=%03x, val=%02x\n", port, val);
     switch (port & 3) {
@@ -493,15 +491,10 @@ mitsumi_cdrom_out(uint16_t port, uint8_t val, void *priv)
                         switch (dev->cmdrd_count) {
                             case 0:
                                 dev->readcount |= val;
-                                do_fix = 0;
                                 if (!dev->readcount && dev->early_status) {
-                                    dev->readcount = 1;
-                                    do_fix = 0;
+                                    dev->readcount = 0xFFFFFFFF; // keep fetching sectors indefinitely.
                                 }
                                 read_res = mitsumi_cdrom_read_sector(dev, 1);
-                                if (read_res > 0 && do_fix) {
-                                    dev->buf_count++;
-                                }
                                 if (dev->enable_dma && read_res > 0) {
                                     do {
                                         while (dev->buf_count) {


### PR DESCRIPTION
Summary
=======
Mitsumi: Implement ability to fetch sectors indefinitely if needed.

Appears to do the job on NT 3.1 non-miniport drivers.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
