### PR TITLE
mem: Invalidate page-crossing code blocks on writes to their second page

### DIFF
--- a/src/mem/mem.c
+++ b/src/mem/mem.c
@@ -606,11 +606,15 @@ addwritelookup(uint32_t virt, uint32_t phys)
         writelookup2[writelookup[writelnext]] = LOOKUP_INV;
     }
 
+    /* A page holds code not only when a block starts in it (block) but also
+       when a block crossing a page boundary ends in it (block_2). Writes to
+       such a page must take the tracked page_lookup path, or self-modifying
+       code in the second page never invalidates the spanning block. */
 #ifdef USE_NEW_DYNAREC
 #    ifdef USE_DYNAREC
-    if (pages[phys >> 12].block || (phys & ~0xfff) == recomp_page) {
+    if (pages[phys >> 12].block || pages[phys >> 12].block_2 || (phys & ~0xfff) == recomp_page) {
 #    else
-    if (pages[phys >> 12].block) {
+    if (pages[phys >> 12].block || pages[phys >> 12].block_2) {
 #    endif
 #else
 #    ifdef USE_DYNAREC


### PR DESCRIPTION
Summary
=======
Fixes the MS Bob NOTEBOOK/HOME invalid page faults under the new dynarec
reported in #6971 (the crash half of that ticket; the Voodoo3 speech-balloon
rendering is a separate 2D issue, not addressed here).

`addwritelookup()` chooses between the tracked write path (`page_lookup`,
which sets dirty bits so stale code blocks get invalidated) and the untracked
fast path (`writelookup2`, raw host pointer). The gate only checks whether a
block *starts* in the target page (`page->block`) and ignores blocks whose
code crosses a page boundary and ends there (`page->block_2`). A page holding
only the tail of a page-crossing block is judged code-free, so writes to it
never set dirty bits and the spanning block is never invalidated.

MS Bob's blitter emits self-modifying code straddling a page boundary and
patches it per blit, mostly in the tail page. The stale block re-executed
with outdated instruction boundaries and read misaligned immediates from the
rewritten bytes (a neighboring 0x66 prefix absorbed into `add edi, imm32`),
producing the corrupted EDI in the crash dialog. This also explains the
reporter's acceleration-slider correlation: higher GDI acceleration offloads
the blit to the video card and sidesteps the self-modifying CPU blitter.

The fix adds `page->block_2` to the gate, in the new dynarec variant only.
The old recompiler's variant of the gate shares the same shape, but the
issue reports the crash does not reproduce under ODR, and arm64 hosts force
`NEW_DYNAREC` on so I cannot test that path; it is left untouched rather
than shipping an untested change.

Verified on macOS arm64: the crash was deterministic per Scrapbook open
before the fix and gone after, across repeated opens and boots. The
mechanism was confirmed before patching: a debug knob rejecting reuse of
only page-crossing cached blocks (block shapes unchanged) eliminated the
crash. Regression-tested with full Win98SE boots and a sustained
multi-hundred-MB in-guest file copy; no faults or visible slowdown.

Checklist
=========
* [ ] Closes #xxx (partially addresses #6971 - the dynarec crash; the
      rendering issue remains)
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set
* [ ] This pull request adds, changes or removes an external dependency

References
==========
_Root cause analysis above; no external documentation involved._