### PR TITLE
CMake: Require Vulkan-enabled Qt for MoltenVK

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -48,6 +48,24 @@ set(CMAKE_FIND_PACKAGE_PREFER_CONFIG OFF)
 find_package(Threads REQUIRED)
 find_package(Qt${QT_MAJOR} COMPONENTS Core Widgets Network OpenGL Gui REQUIRED)
 find_package(Qt${QT_MAJOR}LinguistTools REQUIRED NO_CMAKE_FIND_ROOT_PATH)
+
+if(APPLE AND MOLTENVK)
+    include(CheckCXXSourceCompiles)
+    set(CMAKE_REQUIRED_LIBRARIES Qt${QT_MAJOR}::Gui)
+    unset(QT_HAS_VULKAN CACHE)
+    check_cxx_source_compiles("#include <QtGui/qtguiglobal.h>
+#if !QT_CONFIG(vulkan)
+#error Qt was built without Vulkan support
+#endif
+int main() { return 0; }
+" QT_HAS_VULKAN)
+    unset(CMAKE_REQUIRED_LIBRARIES)
+
+    if(NOT QT_HAS_VULKAN)
+        message(FATAL_ERROR "MOLTENVK requires Qt to be built with Vulkan support (QT_CONFIG(vulkan)). Rebuild Qt with Vulkan enabled or configure with -DMOLTENVK=OFF.")
+    endif()
+endif()
+
 if(USE_QT6)
     set(QT_NO_PRIVATE_MODULE_WARNING ON)
     find_package(Qt6 COMPONENTS GuiPrivate)


### PR DESCRIPTION
Summary
=======
GPT 5.6 Sol finding: it was possible for cmake with moltenvk enabled to pass with a QT that does not have vulkan support. There is no other scenario where moltenvk gets used, so this guard is appropriate. 

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
