### PR TITLE
Two minor sound fixes

### DIFF
--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -252,6 +252,8 @@ typedef struct gus_t {
     uint8_t  gus_reloc_latch;
     uint8_t  gus_reloc_state;
 
+    uint16_t cur_codec_addr;
+
     void *   log; /* New logging system */
 } gus_t;
 
@@ -866,12 +868,15 @@ gus_write(uint16_t addr, uint8_t val, void *priv)
                     val |= 0x20;
                 gus->max_ctrl = (val >> 6) & 1;
                 if (val & 0x40) {
-                    if ((val & 0xF) != ((addr >> 4) & 0xF)) {
-                        csioport = 0x30c | ((addr >> 4) & 0xf);
+                    if ((val & 0xF) != ((gus->cur_codec_addr >> 4) & 0xF)) {
+                        csioport = 0x30c | (gus->cur_codec_addr & 0xf0);
+                        gus_log(gus->log, "Removing handler for codec on addr %04X\n", csioport);
                         io_removehandler(csioport, 4,
                                          ad1848_read, NULL, NULL,
                                          ad1848_write, NULL, NULL, &gus->ad1848);
                         csioport = 0x30c | ((val & 0xf) << 4);
+                        gus->cur_codec_addr = csioport;
+                        gus_log(gus->log, "Setting handler for codec on addr %04X\n", csioport);
                         io_sethandler(csioport, 4,
                                       ad1848_read, NULL, NULL,
                                       ad1848_write, NULL, NULL, &gus->ad1848);
@@ -1795,6 +1800,7 @@ gus_init(UNUSED(const device_t *info))
         ad1848_set_cd_audio_channel(&gus->ad1848, AD1848_AUX2);
         ad1848_setirq(&gus->ad1848, 5);
         ad1848_setdma(&gus->ad1848, 3);
+        gus->cur_codec_addr = gus->base + 0x10C;
         io_sethandler(0x10C + gus->base, 4,
                       ad1848_read, NULL, NULL, ad1848_write, NULL, NULL, &gus->ad1848);
     }

--- a/src/sound/snd_sb_dsp.c
+++ b/src/sound/snd_sb_dsp.c
@@ -2104,7 +2104,7 @@ sb_read(uint16_t addr, void *priv)
                     if (dsp->wb_full || (dsp->busy_count & 2))
                         dsp->wb_full = timer_is_enabled(&dsp->wb_timer);
 
-                    const uint8_t busy_flag   = dsp->wb_full ? 0x80 : 0x00;
+                    const uint8_t busy_flag   = (dsp->wb_full || (dsp->busy_count & 2)) ? 0x80 : 0x00;
                     const uint8_t data_rdy    = (dsp->sb_read_rp == dsp->sb_read_wp) ? 0x00 : 0x40;
                     const uint8_t fifo_full   = 0; /* Unimplemented */
                     const uint8_t fifo_empty  = 0; /* (this is for the 256-byte extended mode FIFO, */


### PR DESCRIPTION
Summary
=======
Two minor sound changes:
- Fix the CS4231 I/O base relocation on GUS MAX. The old code was improperly calculating the current base and calling io_removehandler with an incorrect address range.
- Correct the handling of the ESS DSP busy flag when reading the write data ready port (2xCh), this fixes a hang in Zone 66.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
