### PR TITLE
Replace hard reset keybind with Ctrl+Shift+F12

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -292,7 +292,7 @@ struct accelKey def_acc_keys[NUM_ACCELS] = {
     {
         .name="hard_reset",
         .desc="Hard reset",
-        .seq="Ctrl+Alt+R"
+        .seq="Ctrl+Shift+F12"
     },
     {
         .name="pause",


### PR DESCRIPTION
Summary
=======
https://github.com/86Box/86Box/pull/7588#issuecomment-5165493876

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
