### PR TITLE
Fix AppImages using system Qt6 libraries

### DIFF
--- a/.ci/AppImageBuilder.yml
+++ b/.ci/AppImageBuilder.yml
@@ -53,9 +53,9 @@ AppDir:
     - libgomp1
     - libgs10
     - libpng16-16
-    - libqt5core5a # if QT:BOOL=ON
-    - libqt5gui5 # if QT:BOOL=ON
-    - libqt5widgets5 # if QT:BOOL=ON
+    - libqt6core6t64 # if QT:BOOL=ON
+    - libqt6gui6 # if QT:BOOL=ON
+    - libqt6widgets6 # if QT:BOOL=ON
     - libsixel1 # if CLI:BOOL=ON
     - libslirp0
     - libsndfile1
@@ -71,7 +71,8 @@ AppDir:
     - libxcb-xfixes0 # if QT:BOOL=ON
     - libxi6 # if QT:BOOL=ON
     - libxkbcommon-x11-0 # if QT:BOOL=ON
-    - qtwayland5 # if QT:BOOL=ON
+    - qt6-wayland # if QT:BOOL=ON
+    - libqt6waylandclient6 # if QT:BOOL=ON
     - zlib1g
     - libserialport0
   files:


### PR DESCRIPTION
Summary
=======
Fix AppImages using system Qt6 libraries.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
