### PR TITLE
plat_mmap: Allocate large pages whenever possible

### DIFF
--- a/src/codegen/codegen_x86-64.c
+++ b/src/codegen/codegen_x86-64.c
@@ -62,7 +62,7 @@ void
 codegen_init(void)
 {
     codeblock      = plat_mmap(BLOCK_SIZE * sizeof(codeblock_t), 1);
-    codeblock_hash = calloc(1, HASH_SIZE * sizeof(codeblock_t *));
+    codeblock_hash = plat_mmap(HASH_SIZE * sizeof(codeblock_t *), 0);
 
     memset(codeblock, 0, BLOCK_SIZE * sizeof(codeblock_t));
 

--- a/src/codegen_new/codegen_backend_arm64.c
+++ b/src/codegen_new/codegen_backend_arm64.c
@@ -5,6 +5,7 @@
 #    include <86box/86box.h>
 #    include "cpu.h"
 #    include <86box/mem.h>
+#    include <86box/plat.h>
 
 #    include "codegen.h"
 #    include "codegen_allocator.h"
@@ -285,8 +286,8 @@ codegen_backend_init(void)
 {
     codeblock_t *block;
 
-    codeblock      = calloc(BLOCK_SIZE, sizeof(codeblock_t));
-    codeblock_hash = calloc(HASH_SIZE, sizeof(codeblock_t *));
+    codeblock      = plat_mmap(BLOCK_SIZE * sizeof(codeblock_t), 0);
+    codeblock_hash = plat_mmap(HASH_SIZE * sizeof(codeblock_t *), 0);
 
     for (int c = 0; c < BLOCK_SIZE; c++) {
         codeblock[c].valid = 0;

--- a/src/codegen_new/codegen_backend_x86-64.c
+++ b/src/codegen_new/codegen_backend_x86-64.c
@@ -5,6 +5,7 @@
 #    include <86box/86box.h>
 #    include "cpu.h"
 #    include <86box/mem.h>
+#    include <86box/plat.h>
 
 #    include "codegen.h"
 #    include "codegen_allocator.h"
@@ -293,8 +294,8 @@ codegen_backend_init(void)
     codeblock_t *block;
     int          c;
 
-    codeblock      = calloc(BLOCK_SIZE, sizeof(codeblock_t));
-    codeblock_hash = calloc(HASH_SIZE, sizeof(codeblock_t *));
+    codeblock      = plat_mmap(BLOCK_SIZE * sizeof(codeblock_t), 0);
+    codeblock_hash = plat_mmap(HASH_SIZE * sizeof(codeblock_t *), 0);
 
     for (c = 0; c < BLOCK_SIZE; c++)
         codeblock[c].valid = 0;

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -11,10 +11,12 @@
  * Authors: Joakim L. Gilje <jgilje@jgilje.net>
  *          Cacodemon345
  *          Teemu Korhonen
+ *          gdwnldsKSC
  *
  *          Copyright 2021 Joakim L. Gilje
  *          Copyright 2021-2022 Cacodemon345
  *          Copyright 2021-2022 Teemu Korhonen
+ *          Copyright 2026 gdwnldsKSC
  */
 #ifdef __HAIKU__
 #    include <OS.h>
@@ -619,6 +621,27 @@ void *
 plat_mmap(size_t size, uint8_t executable)
 {
 #if defined Q_OS_WINDOWS
+    static bool priv_tried = false;
+    if (!priv_tried) {
+        priv_tried = true;
+        HANDLE tok;
+        if (OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &tok)) {
+            TOKEN_PRIVILEGES tp = { };
+            tp.PrivilegeCount   = 1;
+            if (LookupPrivilegeValueW(nullptr, L"SeLockMemoryPrivilege", &tp.Privileges[0].Luid)) {
+                tp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
+                AdjustTokenPrivileges(tok, FALSE, &tp, 0, nullptr, nullptr);
+            }
+            CloseHandle(tok);
+        }
+    }
+    const size_t lp = GetLargePageMinimum();
+    if (lp) {
+        const size_t rounded = (size + lp - 1) & ~(lp - 1);
+        void* p = VirtualAlloc(nullptr, rounded, MEM_RESERVE | MEM_COMMIT | MEM_LARGE_PAGES, executable ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE);
+        if (p)
+            return p;
+    }
     return VirtualAlloc(NULL, size, MEM_COMMIT, executable ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE);
 #elif defined Q_OS_UNIX
 #    if defined Q_OS_DARWIN && defined MAP_JIT
@@ -629,6 +652,10 @@ plat_mmap(size_t size, uint8_t executable)
         mprotect(ret, size, PROT_READ | PROT_WRITE | (executable ? PROT_EXEC : 0));
 #    else
     void *ret = mmap(0, size, PROT_READ | PROT_WRITE | (executable ? PROT_EXEC : 0), MAP_ANON | MAP_PRIVATE, -1, 0);
+#       ifdef MADV_HUGEPAGE
+    if (ret)
+        (void)madvise(ret, size, MADV_HUGEPAGE);
+#       endif
 #    endif
     return (ret == MAP_FAILED) ? nullptr : ret;
 #endif

--- a/src/unix/sdl_plat_unix.c
+++ b/src/unix/sdl_plat_unix.c
@@ -367,6 +367,10 @@ plat_mmap(size_t size, uint8_t executable)
     void *ret = mmap(0, size, PROT_MPROTECT(PROT_READ | PROT_WRITE | (executable ? PROT_EXEC : 0)), MAP_ANON | MAP_PRIVATE, -1, 0);
 #    else
     void *ret = mmap(0, size, PROT_READ | PROT_WRITE | (executable ? PROT_EXEC : 0), MAP_ANON | MAP_PRIVATE, -1, 0);
+#       ifdef MADV_HUGEPAGE
+    if (ret)
+        (void)madvise(ret, size, MADV_HUGEPAGE);
+#       endif
 #    endif
     return (ret == MAP_FAILED) ? NULL : ret;
 }

--- a/src/unix/sdl_plat_win.c
+++ b/src/unix/sdl_plat_win.c
@@ -1,5 +1,7 @@
 #include <stdio.h>
 #include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
 
 #include <windows.h>
 
@@ -223,6 +225,28 @@ plat_get_block_device_size(UNUSED(const char *path))
 void *
 plat_mmap(size_t size, uint8_t executable)
 {
+    static bool priv_tried = false;
+    if (!priv_tried) {
+        priv_tried = true;
+        HANDLE tok;
+        if (OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &tok)) {
+            TOKEN_PRIVILEGES tp;
+            memset((void*)&tp, 0, sizeof(TOKEN_PRIVILEGES));
+            tp.PrivilegeCount   = 1;
+            if (LookupPrivilegeValueW(NULL, L"SeLockMemoryPrivilege", &tp.Privileges[0].Luid)) {
+                tp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
+                AdjustTokenPrivileges(tok, FALSE, &tp, 0, NULL, NULL);
+            }
+            CloseHandle(tok);
+        }
+    }
+    size_t lp = GetLargePageMinimum();
+    if (lp) {
+        size_t rounded = (size + lp - 1) & ~(lp - 1);
+        void* p = VirtualAlloc(NULL, rounded, MEM_RESERVE | MEM_COMMIT | MEM_LARGE_PAGES, executable ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE);
+        if (p)
+            return p;
+    }
     return VirtualAlloc(NULL, size, MEM_COMMIT, executable ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE);
 }
 


### PR DESCRIPTION
Summary
=======
plat_mmap: Allocate large pages whenever possible.

Also switch to using plat_mmap for dynamic recompiler structures.

(Windows requires "Lock pages in memory" option enabled under Local Security Policy (secpol.msc) -> User Rights Management -> Lock pages in memory for it to work)


Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
