### PR TITLE
Fix IBM PS/2 Model 25 diagnostic failures

### DIFF
--- a/src/device/kbc_ps2_m25.c
+++ b/src/device/kbc_ps2_m25.c
@@ -25,6 +25,7 @@
 #include <86box/io.h>
 #include <86box/keyboard.h>
 #include <86box/machine.h>
+#include <86box/nmi.h>
 #include <86box/pic.h>
 #include <86box/plat_unused.h>
 #include <86box/timer.h>
@@ -218,6 +219,11 @@ ps2_m25_kbc_write(uint16_t addr, uint8_t val, void *priv)
             dev->port_69 = val;
             break;
 
+        case 0x00a0:
+            /* Bit 7 is the documented global NMI enable. */
+            nmi_mask = val & 0x80;
+            break;
+
         default:
             break;
     }
@@ -282,6 +288,8 @@ ps2_m25_kbc_reset(void *priv)
         picintc(dev->diagnostic_irqs);
     dev->diagnostic_irqs = 0;
     dev->irq_source = 0;
+    /* The system-board NMI latch powers up enabled. */
+    nmi_mask = 0x80;
     memset(dev->tx_ready, 0x00, sizeof(dev->tx_ready));
     memset(dev->rx_data, 0x00, sizeof(dev->rx_data));
     picintc(1 << 1);

--- a/src/disk/hdc_xta_ps1.c
+++ b/src/disk/hdc_xta_ps1.c
@@ -4,7 +4,8 @@
  *          using the ISA,EISA,VLB,MCA  and PCI system buses, roughly
  *          spanning the era between 1981 and 1995.
  *
- *          Implementation of the PS/1 Model 2011 disk controller.
+ *          Implementation of the IBM DBA fixed-disk attachment used by the
+ *          PS/1 Model 2011 and selected PS/2 systems.
  *
  *          XTA is the acronym for 'XT-Attached', which was basically
  *          the XT-counterpart to what we know now as IDE (which is
@@ -101,6 +102,20 @@
 #define HDC_TIME         (100 * TIMER_USEC)
 #define HDC_SECTOR_TIME  (250 * TIMER_USEC)
 #define HDC_TYPE_USER 47 /* user drive type */
+
+#define HDC_SECTOR_SIZE       512
+#define HDC_CHECK_SIZE          6
+#define HDC_EXTENDED_SIZE     (HDC_SECTOR_SIZE + HDC_CHECK_SIZE)
+#define HDC_CODEWORD_BITS     (HDC_EXTENDED_SIZE * 8)
+
+#define HDC_ECC48_MASK UINT64_C(0x0000ffffffffffff)
+#define HDC_ECC48_POLY UINT64_C(0x0000102100011021)
+#define HDC_ECC48_INIT UINT64_C(0x0000752f00008ad0)
+
+enum {
+    HDC_VARIANT_PS1 = 0,
+    HDC_VARIANT_PS2_M25
+};
 
 enum {
     STATE_IDLE = 0,
@@ -368,10 +383,22 @@ typedef struct drive_t {
     uint16_t cfg_tracks;
 } drive_t;
 
+/*
+ * Flat sector images do not contain the six raw CRC/ECC bytes present on
+ * the media.  Remember only sectors whose check field differs from the
+ * normal 48-bit ECC generated from their data (normally after WRITE EXT).
+ */
+typedef struct raw_check_t {
+    off64_t             addr;
+    uint8_t             bytes[HDC_CHECK_SIZE];
+    struct raw_check_t *next;
+} raw_check_t;
+
 typedef struct hdc_t {
     uint16_t base; /* controller base I/O address */
     int8_t   irq;  /* controller IRQ channel */
     int8_t   dma;  /* controller DMA channel */
+    uint8_t  variant;
 
     /* Registers. */
     uint8_t attn;    /* ATTENTION register */
@@ -403,8 +430,10 @@ typedef struct hdc_t {
 
     drive_t drives[XTA_NUM]; /* the attached drive(s) */
 
-    uint8_t data[512];       /* data buffer */
-    uint8_t sector_buf[512]; /* sector buffer */
+    raw_check_t *raw_checks;
+
+    uint8_t data[HDC_EXTENDED_SIZE];       /* data buffer */
+    uint8_t sector_buf[HDC_EXTENDED_SIZE]; /* sector buffer */
 } hdc_t;
 
 /*
@@ -484,6 +513,281 @@ ps1_hdc_log(const char *fmt, ...)
 #    define ps1_hdc_log(fmt, ...)
 #endif
 
+/*
+ * The IBM DBA drive uses the 48-bit generator
+ *
+ *   x^48 + x^44 + x^37 + x^32 + x^16 + x^12 + x^5 + 1
+ *
+ * and sends the remainder most-significant byte first.  The non-zero
+ * initial state includes the contribution of the on-disk framing that is
+ * outside the 512-byte sector exposed to the host.
+ */
+static uint64_t
+ecc48_generate(const uint8_t *data)
+{
+    uint64_t rem = HDC_ECC48_INIT;
+
+    for (unsigned i = 0; i < HDC_SECTOR_SIZE; i++) {
+        rem ^= (uint64_t) data[i] << 40;
+        for (unsigned bit = 0; bit < 8; bit++) {
+            const int carry = !!(rem & UINT64_C(0x0000800000000000));
+
+            rem = (rem << 1) & HDC_ECC48_MASK;
+            if (carry)
+                rem ^= HDC_ECC48_POLY;
+        }
+    }
+
+    return rem;
+}
+
+static uint16_t
+crc16_generate(const uint8_t *data)
+{
+    uint16_t rem = 0xffff;
+
+    /* CRC sectors append two zero bytes before taking the remainder. */
+    for (unsigned i = 0; i < HDC_SECTOR_SIZE + 2; i++) {
+        const uint8_t byte = (i < HDC_SECTOR_SIZE) ? data[i] : 0;
+
+        rem ^= (uint16_t) byte << 8;
+        for (unsigned bit = 0; bit < 8; bit++)
+            rem = (rem & 0x8000) ? (uint16_t) ((rem << 1) ^ 0x1021)
+                                 : (uint16_t) (rem << 1);
+    }
+
+    return rem;
+}
+
+static void
+make_check_bytes(const uint8_t *data, const int ecc, uint8_t bytes[HDC_CHECK_SIZE])
+{
+    memset(bytes, 0, HDC_CHECK_SIZE);
+
+    if (ecc) {
+        const uint64_t value = ecc48_generate(data);
+
+        for (unsigned i = 0; i < HDC_CHECK_SIZE; i++)
+            bytes[i] = (uint8_t) (value >> (40 - (i * 8)));
+    } else {
+        const uint16_t value = crc16_generate(data);
+
+        bytes[0] = (uint8_t) (value >> 8);
+        bytes[1] = (uint8_t) value;
+    }
+}
+
+static raw_check_t **
+find_raw_check(hdc_t *dev, const off64_t addr)
+{
+    raw_check_t **link = &dev->raw_checks;
+
+    while ((*link != NULL) && ((*link)->addr != addr))
+        link = &(*link)->next;
+
+    return link;
+}
+
+static void
+remove_raw_check(hdc_t *dev, const off64_t addr)
+{
+    raw_check_t **link = find_raw_check(dev, addr);
+
+    if (*link != NULL) {
+        raw_check_t *entry = *link;
+
+        *link = entry->next;
+        free(entry);
+    }
+}
+
+static int
+set_raw_check(hdc_t *dev, const off64_t addr, const uint8_t *data,
+              const uint8_t bytes[HDC_CHECK_SIZE])
+{
+    uint8_t       normal[HDC_CHECK_SIZE];
+    raw_check_t **link;
+
+    /* A normal ECC field can always be reconstructed from the image. */
+    make_check_bytes(data, 1, normal);
+    if (!memcmp(bytes, normal, HDC_CHECK_SIZE)) {
+        remove_raw_check(dev, addr);
+        return 1;
+    }
+
+    link = find_raw_check(dev, addr);
+    if (*link == NULL) {
+        *link = calloc(1, sizeof(raw_check_t));
+        if (*link == NULL)
+            return 0;
+        (*link)->addr = addr;
+    }
+
+    memcpy((*link)->bytes, bytes, HDC_CHECK_SIZE);
+    return 1;
+}
+
+static void
+get_raw_check(hdc_t *dev, const off64_t addr, const uint8_t *data,
+              uint8_t bytes[HDC_CHECK_SIZE])
+{
+    raw_check_t **link = find_raw_check(dev, addr);
+
+    if (*link != NULL)
+        memcpy(bytes, (*link)->bytes, HDC_CHECK_SIZE);
+    else
+        make_check_bytes(data, 1, bytes);
+}
+
+static void
+remove_raw_check_range(hdc_t *dev, const off64_t first, const off64_t count)
+{
+    raw_check_t **link = &dev->raw_checks;
+    const off64_t end  = first + count;
+
+    while (*link != NULL) {
+        raw_check_t *entry = *link;
+
+        if ((entry->addr >= first) && (entry->addr < end)) {
+            *link = entry->next;
+            free(entry);
+        } else {
+            link = &entry->next;
+        }
+    }
+}
+
+static void
+free_raw_checks(hdc_t *dev)
+{
+    raw_check_t *entry = dev->raw_checks;
+
+    while (entry != NULL) {
+        raw_check_t *next = entry->next;
+
+        free(entry);
+        entry = next;
+    }
+    dev->raw_checks = NULL;
+}
+
+static uint32_t
+rotate_right_32(const uint32_t value, const unsigned count)
+{
+    return count ? ((value >> count) | (value << (32 - count))) : value;
+}
+
+/*
+ * The generator factors as (x^32 + 1)(x^16 + x^12 + x^5 + 1), a
+ * single-burst Fire code.  Reducing the syndrome modulo x^32 + 1 reveals
+ * the error pattern and its position modulo 32; the full syndrome then
+ * locates a unique burst of up to 16 bits in the 4144-bit codeword.
+ */
+static int
+ecc48_correct(uint8_t *data, const uint64_t syndrome)
+{
+    static uint64_t x_power[HDC_CODEWORD_BITS];
+    static int      powers_ready = 0;
+    uint32_t        folded;
+    uint32_t        found_pattern = 0;
+    unsigned        found_pos = 0;
+    unsigned        matches = 0;
+
+    if (!powers_ready) {
+        x_power[0] = 1;
+        for (unsigned i = 1; i < HDC_CODEWORD_BITS; i++) {
+            const uint64_t prev = x_power[i - 1];
+
+            x_power[i] = (prev << 1) & HDC_ECC48_MASK;
+            if (prev & UINT64_C(0x0000800000000000))
+                x_power[i] ^= HDC_ECC48_POLY;
+        }
+        powers_ready = 1;
+    }
+
+    folded = (uint32_t) syndrome ^ (uint32_t) (syndrome >> 32);
+
+    for (unsigned residue_pos = 0; residue_pos < 32; residue_pos++) {
+        const uint32_t pattern = rotate_right_32(folded, residue_pos);
+        unsigned       burst_len;
+
+        if ((pattern == 0) || (pattern & 0xffff0000U) || !(pattern & 1))
+            continue;
+
+        burst_len = 16;
+        while (!(pattern & (UINT32_C(1) << (burst_len - 1))))
+            burst_len--;
+
+        for (unsigned pos = residue_pos;
+             (pos + burst_len) <= HDC_CODEWORD_BITS; pos += 32) {
+            uint64_t candidate = 0;
+
+            for (unsigned bit = 0; bit < burst_len; bit++)
+                if (pattern & (UINT32_C(1) << bit))
+                    candidate ^= x_power[pos + bit];
+
+            if (candidate == syndrome) {
+                found_pattern = pattern;
+                found_pos     = pos;
+                if (++matches > 1)
+                    return 0;
+            }
+        }
+    }
+
+    if (matches != 1)
+        return 0;
+
+    for (unsigned bit = 0; bit < 16; bit++) {
+        const unsigned exponent = found_pos + bit;
+
+        if (!(found_pattern & (UINT32_C(1) << bit)))
+            continue;
+
+        /* Exponents 47 through 0 are the six check bytes, not data. */
+        if (exponent >= 48) {
+            const unsigned stream_bit = (HDC_CODEWORD_BITS - 1) - exponent;
+
+            if (stream_bit < (HDC_SECTOR_SIZE * 8))
+                data[stream_bit >> 3] ^= (uint8_t) (0x80U >> (stream_bit & 7));
+        }
+    }
+
+    return 1;
+}
+
+/* Return 0 for clean data, 1 for corrected data, and -1 if uncorrectable. */
+static int
+check_sector_data(hdc_t *dev, const off64_t addr, uint8_t *data, const int ecc)
+{
+    uint8_t stored[HDC_CHECK_SIZE];
+    uint8_t expected[HDC_CHECK_SIZE];
+
+    get_raw_check(dev, addr, data, stored);
+    make_check_bytes(data, ecc, expected);
+
+    if (!memcmp(stored, expected, ecc ? HDC_CHECK_SIZE : 2))
+        return 0;
+
+    if (ecc) {
+        uint64_t stored_value   = 0;
+        uint64_t expected_value = 0;
+
+        for (unsigned i = 0; i < HDC_CHECK_SIZE; i++) {
+            stored_value   = (stored_value << 8) | stored[i];
+            expected_value = (expected_value << 8) | expected[i];
+        }
+
+        if (ecc48_correct(data, stored_value ^ expected_value)) {
+            make_check_bytes(data, 1, expected);
+            if (!memcmp(stored, expected, HDC_CHECK_SIZE))
+                return 1;
+        }
+    }
+
+    return -1;
+}
+
 /* FIXME: we should use the disk/hdd_table.c code with custom tables! */
 static int
 ibm_drive_type(drive_t *drive)
@@ -513,9 +817,16 @@ set_intr(hdc_t *dev, int raise)
 }
 
 static void
-clear_unused_format(hdc_t *dev, int count)
+clear_unused_format(hdc_t *dev)
 {
-    if (count == 0x11) /* OS/2 format */
+    /*
+     * A count of 11h is also a normal full-track transfer on 17-sector
+     * drives.  The OS/2 format workaround must never complete a READ
+     * VERIFY command early.
+     */
+    if (((dev->ccb.cmd == CMD_FORMAT_DRIVE) ||
+         (dev->ccb.cmd == CMD_FORMAT_TRACK)) &&
+        (dev->ccb.count == 0x11)) /* OS/2 format */
         if (CS != 0xe000) /* ROM POST */
             dev->status &= ~ASR_BUSY;
 }
@@ -537,8 +848,8 @@ get_sector(hdc_t *dev, drive_t *drive, off64_t *addr)
         return 1;
     }
 
-    if (dev->sector > drive->spt) {
-        ps1_hdc_log("HDC: get_sector: past end of sectors\n");
+    if ((dev->sector == 0) || (dev->sector > drive->spt)) {
+        ps1_hdc_log("HDC: get_sector: invalid sector %u\n", dev->sector);
         dev->ssb.mark_not_found = 1;
         return 1;
     }
@@ -569,6 +880,9 @@ next_sector(hdc_t *dev, drive_t *drive)
 static void
 do_finish(hdc_t *dev)
 {
+    /* A completed, aborted, or rejected command no longer owns DMA 3. */
+    dma_set_drq(dev->dma, 0);
+
     dev->state = STATE_IDLE;
 
     dev->attn &= ~(ATT_CCB | ATT_DATA);
@@ -617,11 +931,22 @@ do_format(hdc_t *dev, drive_t *drive, ccb_t *ccb)
 
     switch (dev->state) {
         case STATE_IDLE:
+            ;
+            const unsigned fcb_len = (unsigned) ccb->count * sizeof(fcb_t);
+
+            /* Reject malformed FCB transfers before they can overrun data[]. */
+            if ((fcb_len == 0) ||
+                (((fcb_len + 1) & ~1U) > sizeof(dev->data))) {
+                dev->intstat |= ISR_CMD_REJECT;
+                do_finish(dev);
+                return;
+            }
+
             /* Ready to transfer the FCB data in. */
             dev->state   = STATE_RDATA;
             dev->buf_idx = 0;
             dev->buf_ptr = dev->data;
-            dev->buf_len = ccb->count * sizeof(fcb_t);
+            dev->buf_len = (int16_t) fcb_len;
             if (dev->buf_len & 1)
                 dev->buf_len++; /* must be even */
 
@@ -703,6 +1028,26 @@ do_fmt:
             hdd_image_zero(drive->hdd_num, addr, drive->spt);
 #endif
 
+            if (ccb->ec_p) {
+                remove_raw_check_range(dev, addr, drive->spt);
+            } else {
+                uint8_t check_bytes[HDC_CHECK_SIZE];
+
+                memset(dev->sector_buf, 0, HDC_SECTOR_SIZE);
+                make_check_bytes(dev->sector_buf, 0, check_bytes);
+                for (val = 0; val < drive->spt; val++) {
+                    if (!set_raw_check(dev, addr + val, dev->sector_buf,
+                                       check_bytes)) {
+                        dev->intstat |= ISR_EQUIP_CHECK | ISR_TERMINATION;
+                        dev->ssb.need_reset = 1;
+                        intr = 1;
+                        break;
+                    }
+                }
+                if (intr)
+                    break;
+            }
+
             /* Done with this track. */
             dev->state = STATE_FDONE;
             fallthrough;
@@ -744,7 +1089,9 @@ hdc_callback(void *priv)
     hdc_t   *dev = (hdc_t *) priv;
     ccb_t   *ccb = &dev->ccb;
     drive_t *drive;
+    uint8_t  check_bytes[HDC_CHECK_SIZE];
     off64_t  addr;
+    int      ecc_result;
     int      val;
 #ifdef ENABLE_PS1_HDC_LOG
     uint8_t  cmd = ccb->cmd & 0x0f;
@@ -758,19 +1105,23 @@ hdc_callback(void *priv)
         return;
     }
 
-    /* Clear the SSB error bits. */
-    dev->ssb.track_0        = 0;
-    dev->ssb.cylinder_err   = 0;
-    dev->ssb.write_fault    = 0;
-    dev->ssb.seek_end       = 0;
-    dev->ssb.not_ready      = 0;
-    dev->ssb.id_not_found   = 0;
-    dev->ssb.wrong_cyl      = 0;
-    dev->ssb.all_bit_set    = 0;
-    dev->ssb.mark_not_found = 0;
-    dev->ssb.ecc_crc_err    = 0;
-    dev->ssb.ecc_crc_field  = 0;
-    dev->ssb.valid          = 1;
+    /* Clear command status once, not again during later transfer states. */
+    if (dev->state == STATE_IDLE) {
+        dev->ssb.track_0        = 0;
+        dev->ssb.cylinder_err   = 0;
+        dev->ssb.write_fault    = 0;
+        dev->ssb.seek_end       = 0;
+        dev->ssb.not_ready      = 0;
+        dev->ssb.id_not_found   = 0;
+        dev->ssb.wrong_cyl      = 0;
+        dev->ssb.all_bit_set    = 0;
+        dev->ssb.mark_not_found = 0;
+        dev->ssb.ecc_crc_err    = 0;
+        dev->ssb.ecc_crc_field  = 0;
+        dev->ssb.sect_corr      = 0;
+        dev->ssb.retries        = 0;
+        dev->ssb.valid          = 1;
+    }
 
     /* We really only support one drive, but ohwell. */
     drive = &dev->drives[0];
@@ -779,6 +1130,8 @@ hdc_callback(void *priv)
     if (dev->reset) {
         ps1_hdc_log("XTA reset.\n");
         dev->ssb.valid = 0;
+        /* Reset completion must not report a preceding command's ISR bits. */
+        dev->intstat = 0;
         dev->reset = 0;
         dma_set_drq(dev->dma, 0);
         do_finish(dev);
@@ -788,12 +1141,13 @@ hdc_callback(void *priv)
     ps1_hdc_log("hdc_callback(0): %02X\n", cmd);
 
     switch (ccb->cmd) {
+        case CMD_READ_EXT:
         case CMD_READ_VERIFY:
-            ccb->no_data = 1;
-            ccb->count = 1;
-            fallthrough;
-
         case CMD_READ_SECTORS:
+            if (ccb->cmd == CMD_READ_VERIFY) {
+                ccb->no_data = 1;
+            }
+
             if (!drive->present) {
                 dev->ssb.not_ready = 1;
                 do_finish(dev);
@@ -820,8 +1174,11 @@ hdc_callback(void *priv)
                     dev->sector = ccb->sector;
 
                     /* Get sector count and size. */
-                    dev->count   = (int) ccb->count;
-                    dev->buf_len = (128 << dev->ssb.sect_size);
+                    dev->count = (ccb->cmd == CMD_READ_EXT) ? 1
+                                                            : (int) ccb->count;
+                    dev->buf_len = (ccb->cmd == CMD_READ_EXT)
+                                     ? HDC_EXTENDED_SIZE
+                                     : (128 << dev->ssb.sect_size);
 
                     dev->state = STATE_SEND;
                     fallthrough;
@@ -842,6 +1199,29 @@ do_send:
                     /* Read the block from the image. */
                     hdd_image_read(drive->hdd_num, addr, 1,
                                    (uint8_t *) dev->sector_buf);
+
+                    if (ccb->cmd == CMD_READ_EXT) {
+                        /* READ EXT bypasses checking and returns all six bytes. */
+                        get_raw_check(dev, addr, dev->sector_buf,
+                                      &dev->sector_buf[HDC_SECTOR_SIZE]);
+                    } else {
+                        ecc_result = check_sector_data(dev, addr,
+                                                       dev->sector_buf,
+                                                       ccb->ec_p);
+                        if (ecc_result < 0) {
+                            ui_sb_update_icon(SB_HDD | HDD_BUS_XTA, 0);
+                            dev->intstat |= ISR_ERP_INVOKED | ISR_TERMINATION;
+                            dev->ssb.ecc_crc_err = 1;
+                            dev->ssb.cmd_syndrome = 0x74;
+                            dev->ssb.seek_end = 1;
+                            do_finish(dev);
+                            return;
+                        }
+                        if (ecc_result > 0) {
+                            dev->intstat |= ISR_ERP_INVOKED;
+                            dev->ssb.sect_corr++;
+                        }
+                    }
 
                     /* Ready to transfer the data out. */
                     dev->state   = STATE_SDATA;
@@ -914,7 +1294,8 @@ do_send:
                             dma_set_drq(dev->dma, 0);
                         else
                             dev->status &= ~(ASR_DATA_REQ | ASR_DIR);
-                        dev->ssb.cmd_syndrome = 0xD4;
+                        dev->ssb.cmd_syndrome = dev->ssb.sect_corr ? 0xF4
+                                                                   : 0xD4;
                         dev->ssb.seek_end = 1;
                         do_finish(dev);
                         return;
@@ -983,17 +1364,6 @@ do_send:
             }
             break;
 
-        case CMD_READ_EXT: /* READ_EXT */
-            if (!drive->present) {
-                dev->ssb.not_ready = 1;
-                do_finish(dev);
-                return;
-            }
-
-            dev->intstat |= ISR_INVALID_CMD;
-            do_finish(dev);
-            break;
-
         case CMD_RECALIBRATE: /* RECALIBRATE */
             if (drive->present) {
                 dev->track = drive->cur_cyl = 0;
@@ -1006,6 +1376,7 @@ do_send:
             do_finish(dev);
             break;
 
+        case CMD_WRITE_EXT:
         case CMD_WRITE_VERIFY:
         case CMD_WRITE_SECTORS:
             if (!drive->present) {
@@ -1034,8 +1405,11 @@ do_send:
                     dev->sector = ccb->sector;
 
                     /* Get sector count and size. */
-                    dev->count   = (int) ccb->count;
-                    dev->buf_len = (128 << dev->ssb.sect_size);
+                    dev->count = (ccb->cmd == CMD_WRITE_EXT) ? 1
+                                                             : (int) ccb->count;
+                    dev->buf_len = (ccb->cmd == CMD_WRITE_EXT)
+                                     ? HDC_EXTENDED_SIZE
+                                     : (128 << dev->ssb.sect_size);
 
                     dev->state = STATE_RECV;
                     fallthrough;
@@ -1114,7 +1488,36 @@ do_recv:
                         return;
                     }
 
-                    /* Write the block to the image. */
+                    /*
+                     * WRITE EXT supplies the six physical check bytes and
+                     * deliberately bypasses error checking.  Normal ECC
+                     * writes return the image sector to its implicit,
+                     * reconstructible check field.
+                     */
+                    if (ccb->cmd == CMD_WRITE_EXT) {
+                        if (!set_raw_check(dev, addr, dev->sector_buf,
+                                           &dev->sector_buf[HDC_SECTOR_SIZE])) {
+                            ui_sb_update_icon_write(SB_HDD | HDD_BUS_XTA, 0);
+                            dev->intstat |= ISR_EQUIP_CHECK | ISR_TERMINATION;
+                            dev->ssb.need_reset = 1;
+                            do_finish(dev);
+                            return;
+                        }
+                    } else if (ccb->ec_p) {
+                        remove_raw_check(dev, addr);
+                    } else {
+                        make_check_bytes(dev->sector_buf, 0, check_bytes);
+                        if (!set_raw_check(dev, addr, dev->sector_buf,
+                                           check_bytes)) {
+                            ui_sb_update_icon_write(SB_HDD | HDD_BUS_XTA, 0);
+                            dev->intstat |= ISR_EQUIP_CHECK | ISR_TERMINATION;
+                            dev->ssb.need_reset = 1;
+                            do_finish(dev);
+                            return;
+                        }
+                    }
+
+                    /* Flat images contain the 512-byte data field only. */
                     hdd_image_write(drive->hdd_num, addr, 1,
                                     (uint8_t *) dev->sector_buf);
 
@@ -1223,14 +1626,14 @@ hdc_read(uint16_t port, void *priv)
     hdc_t  *dev = (hdc_t *) priv;
     uint8_t ret = 0xff;
 
-    /* TRM: tell system board we are alive. */
-    if (is286)
+    /* PS/1 and Model 30 use the register 91h card-selected feedback path. */
+    if (dev->reg_91 != NULL)
         *dev->reg_91 |= 0x01;
 
     switch (port & 7) {
         case 0: /* DATA register */
             if (dev->state == STATE_SDATA) {
-                if (dev->buf_idx > dev->buf_len) {
+                if (dev->buf_idx >= dev->buf_len) {
                     ps1_hdc_log("HDC: read with empty buffer!\n");
                     dev->state = STATE_IDLE;
                     dev->intstat |= ISR_INVALID_CMD;
@@ -1276,8 +1679,8 @@ hdc_write(uint16_t port, uint8_t val, void *priv)
 
     ps1_hdc_log("[%04X:%08X] [W] %04X = %02X\n", CS, cpu_state.pc, port, val);
 
-    /* TRM: tell system board we are alive. */
-    if (is286)
+    /* PS/1 and Model 30 use the register 91h card-selected feedback path. */
+    if (dev->reg_91 != NULL)
         *dev->reg_91 |= 0x01;
 
     switch (port & 7) {
@@ -1313,7 +1716,7 @@ hdc_write(uint16_t port, uint8_t val, void *priv)
                             dev->status |= ASR_BUSY;
 
                         /* Schedule command execution. */
-                        clear_unused_format(dev, dev->ccb.count);
+                        clear_unused_format(dev);
                         timer_set_delay_u64(&dev->timer, HDC_SECTOR_TIME);
                     }
                 }
@@ -1400,7 +1803,7 @@ ps1_hdc_handler(void *priv, const int set)
 }
 
 static void *
-ps1_hdc_init(UNUSED(const device_t *info))
+ps1_hdc_init(const device_t *info)
 {
     drive_t *drive;
     hdc_t   *dev;
@@ -1409,10 +1812,10 @@ ps1_hdc_init(UNUSED(const device_t *info))
     /* Allocate and initialize device block. */
     dev = calloc(1, sizeof(hdc_t));
 
-    /* Set up controller parameters for PS/1 2011. */
-    dev->base = 0x0320;
-    dev->irq  = is286 ? 14 : 5;
-    dev->dma  = 3;
+    dev->variant = info->local;
+    dev->base    = 0x0320;
+    dev->irq     = (dev->variant == HDC_VARIANT_PS2_M25) ? 5 : 14;
+    dev->dma     = 3;
 
     ps1_hdc_log("HDC: initializing (I/O=%04X, IRQ=%d, DMA=%d)\n",
                 dev->base, dev->irq, dev->dma);
@@ -1471,6 +1874,12 @@ ps1_hdc_close(void *priv)
     hdc_t         *dev = (hdc_t *) priv;
     const drive_t *drive;
 
+    timer_disable(&dev->timer);
+    dma_set_drq(dev->dma, 0);
+    set_intr(dev, 0);
+    ui_sb_update_icon(SB_HDD | HDD_BUS_XTA, 0);
+    ui_sb_update_icon_write(SB_HDD | HDD_BUS_XTA, 0);
+
     /* Remove the I/O handler. */
     io_removehandler(dev->base, 5,
                      hdc_read, NULL, NULL, hdc_write, NULL, NULL, dev);
@@ -1483,6 +1892,8 @@ ps1_hdc_close(void *priv)
             hdd_image_close(drive->hdd_num);
     }
 
+    free_raw_checks(dev);
+
     /* Release the device. */
     free(dev);
 }
@@ -1491,7 +1902,21 @@ const device_t ps1_hdc_device = {
     .name          = "PS/1 2011 Fixed Disk Controller",
     .internal_name = "ps1_hdc",
     .flags         = DEVICE_ISA,
-    .local         = 0,
+    .local         = HDC_VARIANT_PS1,
+    .init          = ps1_hdc_init,
+    .close         = ps1_hdc_close,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = NULL
+};
+
+const device_t ps2_m25_hdc_device = {
+    .name          = "IBM PS/2 Model 25 Fixed Disk Controller",
+    .internal_name = "ps2_m25_hdc",
+    .flags         = DEVICE_ISA | DEVICE_ONBOARD,
+    .local         = HDC_VARIANT_PS2_M25,
     .init          = ps1_hdc_init,
     .close         = ps1_hdc_close,
     .reset         = NULL,

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -1488,6 +1488,7 @@ extern int             machine_ps1_m2121_init(const machine_t *);
 #ifdef EMU_DEVICE_H
 extern void            ps1_hdc_inform(void *, uint8_t *);
 extern const device_t  ps1_hdc_device;
+extern const device_t  ps2_m25_hdc_device;
 #endif
 
 /* m_ps2_isa.c */

--- a/src/machine/m_ps2_isa.c
+++ b/src/machine/m_ps2_isa.c
@@ -224,7 +224,7 @@ ps2_m25_write(uint16_t port, uint8_t val, void *priv)
             break;
 
         case 0x006b:
-            /* Bit 7 is a parity-failure status bit, not RAM control. */
+            /* Bit 7 is the read-only parity-check bank pointer. */
             dev->ram_control = val & 0x7f;
             ps2_m25_update_ram(dev);
             break;
@@ -571,11 +571,11 @@ machine_ps2_8086_init(const machine_t *model)
 
     machine_common_init(model);
     /*
-     * Unlike an XT, the Model 25 has no global NMI mask at port A0h. Its
-     * system-board NMI sources are masked individually by port 61h, so keep
-     * the CPU NMI input enabled and leave A0h to the I/O-support gate array.
+     * Port A0h bit 7 is the global NMI enable. The latch powers up enabled;
+     * IBM's system-board diagnostic relies on that reset state when it
+     * exercises the diagnostic NMI path through ports 69h and 63h.
      */
-    nmi_mask = 1;
+    nmi_mask = 0x80;
 
     dev = (ps2_m25_t *) calloc(1, sizeof(ps2_m25_t));
 
@@ -619,7 +619,7 @@ machine_ps2_8086_init(const machine_t *model)
 
     /* Enable the builtin HDC. */
     if (hdc_current[0] == HDC_INTERNAL)
-        dev->hdc = device_add(&ps1_hdc_device);
+        dev->hdc = device_add(&ps2_m25_hdc_device);
 
     if (gfxcard[0] == VID_INTERNAL)
         dev->mcga = device_add(&mcga_device);

--- a/src/video/vid_mcga.c
+++ b/src/video/vid_mcga.c
@@ -394,6 +394,10 @@ mcga_io_write(uint16_t addr, uint8_t val, void *priv)
 
     switch (addr) {
         case 0x03c6:
+            /*
+             * Type 8525 latches this register, but IBM documents that PEL
+             * mask operations are not supported; do not apply it to pixels.
+             */
             dev->dac_mask = val;
             break;
 


### PR DESCRIPTION
## Summary

- add a Model 25-specific IBM DBA fixed-disk controller variant
- implement Read/Write Extended, 48-bit ECC correction, CRC/check-field handling, and diagnostic status behavior
- preserve full-track Read Verify sector counts and restrict the OS/2 workaround to format commands
- model the Model 25 NMI-enable latch and clear stale controller ISR status on reset

## Root cause

The Model 25 was using the PS/1 controller path without the DBA extended-sector and ECC behavior expected by IBM diagnostics. Read Verify also collapsed a 17-sector request to one sector, while a count-based format workaround prematurely completed non-format commands. Controller reset could then surface an older ISR error when diagnostics returned to the control program.

## Impact

IBM Model 25 Starter and Advanced Diagnostics can exercise the fixed disk, ECC, full-disk Read Verify, and module-exit reset paths without false 1701 failures. The PS/1 controller remains a separate device variant.

Checklist
=========

* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/
