### PR TITLE
Make sure the libxcb-cursor0 library is bundled in the AppImage

### DIFF
--- a/.ci/AppImageBuilder.yml
+++ b/.ci/AppImageBuilder.yml
@@ -65,6 +65,7 @@ AppDir:
     - libx11-6 # if QT:BOOL=ON
     - libx11-xcb1 # if QT:BOOL=ON
     - libxcb1 # if QT:BOOL=ON
+    - libxcb-cursor0 # if QT:BOOL=ON
     - libxcb-render0 # if QT:BOOL=ON
     - libxcb-shape0 # if QT:BOOL=ON
     - libxcb-shm0 # if QT:BOOL=ON


### PR DESCRIPTION
Summary
=======
Make sure the libxcb-cursor0 library is bundled in the AppImage.

Qt6 since 6.5 requires it for X11

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
