### PR TITLE
net_i8255x.c: multiple fixes based on the manual

### DIFF
--- a/src/network/net_i8255x.c
+++ b/src/network/net_i8255x.c
@@ -334,7 +334,7 @@ static const e100_device_info_t eepro100_devices[] = {
         .desc = "Intel i82559C Ethernet",
         .device = i82559C,
         .device_id = 0x1229,
-        .revision = 0x0c,
+        .revision = 0x08,
         .subsystem_vendor_id = 0x8086,
         .subsystem_id = 0x0040,
         .stats_size = 80,
@@ -827,7 +827,10 @@ action_command(eepro100_t *s)
             break;
         case CmdTx:
             if (bit_nc) {
-                i8255x_log("CmdTx: NC = 0\n");
+                i8255x_log("CmdTx: NC = 1\n");
+                /* 0: CRC and Source Address are inserted by the controller.
+                   1: CRC and Source Address are not inserted by the controller
+                   and are assumed to come from memory. */
                 ok_status = 0;
                 break;
             }
@@ -1919,6 +1922,7 @@ e100_pci_reset(eepro100_t *s, e100_device_info_t *info)
         /* TODO: check TCO Statistical Counters bit. Documentation not clear. */
         if (s->configuration[6] & BIT(2)) {
             /* TCO statistical counters. */
+            s->stats_size = 96;
         } else {
             if (s->configuration[6] & BIT(5)) {
                 /* No extended statistical counters, i82557 compatible. */


### PR DESCRIPTION


Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
https://www.intel.com/content/dam/doc/manual/8255x-10-100-mbps-ethernet-controller-software-dev-manual.pdf
Table 2. Device and Revision ID
<img width="660" height="382" alt="image" src="https://github.com/user-attachments/assets/ccbd4c46-db02-4581-9807-2fff35c2cc3c" />
<img width="658" height="218" alt="image" src="https://github.com/user-attachments/assets/fa15c828-512b-413f-a3a2-7726ffc8c395" />
Figure 19. Transmit Command Format
Table 45. Extended Statistics Functionality
<img width="882" height="247" alt="image" src="https://github.com/user-attachments/assets/a2262126-51b6-4942-ab08-ca3fef53159d" />
