### PR TITLE
Fix wrong name of SDL3 package for MacPorts

### DIFF
--- a/.ci/dependencies_macports.txt
+++ b/.ci/dependencies_macports.txt
@@ -2,7 +2,7 @@ cmake
 pkgconfig
 ninja
 freetype
-libsdl3
+SDL3
 libpng
 openal-soft
 rtmidi


### PR DESCRIPTION
Summary
=======
Fix wrong name of SDL3 package for MacPorts.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
