### PR TITLE
Allow FluidSynth backend to be enabled on SDL Win32 builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,9 +169,6 @@ endif()
 if(WIN32 AND NOT QT)
     # Force console subsystem when building the SDL frontend
     set(CMAKE_WIN32_EXECUTABLE OFF CACHE BOOL "Build a Windows GUI executable" FORCE)
-
-    # FluidSynth pulls in SDL3 - disable for now
-    set(FLUIDSYNTH OFF CACHE BOOL "FluidSynth" FORCE)
 endif()
 
 if(WIN32 AND GDBSTUB)


### PR DESCRIPTION
Summary
=======
Allow FluidSynth backend to be enabled on SDL Win32 builds.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
