### PR TITLE
cdrom_image_ccd: Fix wrong uppercase extension name for SUB files

### DIFF
--- a/src/cdrom/cdrom_image_ccd.c
+++ b/src/cdrom/cdrom_image_ccd.c
@@ -353,9 +353,9 @@ ccd_image_open(cdrom_t *dev, const char *path)
     img_path[strlen(img_path) - 3] = 's';
     img->sub_file = plat_fopen(img_path, "rb");
     if (!img->sub_file) {
-        img_path[strlen(img_path) - 1] = 'b';
-        img_path[strlen(img_path) - 2] = 'u';
-        img_path[strlen(img_path) - 3] = 'b';
+        img_path[strlen(img_path) - 1] = 'B';
+        img_path[strlen(img_path) - 2] = 'U';
+        img_path[strlen(img_path) - 3] = 'S';
         img->sub_file = plat_fopen(img_path, "rb");
     }
 


### PR DESCRIPTION
Summary
=======
cdrom_image_ccd: Fix wrong uppercase extension name for SUB files.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
