### PR TITLE
Attempt to avoid macOS App Nap kicking in while the emulator is unpaused

### DIFF
--- a/src/qt/macos_event_filter.mm
+++ b/src/qt/macos_event_filter.mm
@@ -1,6 +1,7 @@
 // #include "86box/plat.h"
 #include "cocoa_mouse.hpp"
 #import <AppKit/AppKit.h>
+#import <Cocoa/Cocoa.h>
 extern "C" {
 #include <86box/86box.h>
 #include <86box/keyboard.h>
@@ -88,4 +89,29 @@ CocoaEventFilter::nativeEventFilter(const QByteArray &eventType, void *message, 
         }
     }
     return false;
+}
+
+static bool         pause_entered = true;
+static id<NSObject> process_activity = nil;
+
+void enter_pause(void)
+{
+    if (pause_entered)
+        return;
+    
+    [[NSProcessInfo processInfo] endActivity: process_activity];
+    process_activity = nil;
+    pause_entered = true;
+}
+
+void exit_pause(void)
+{
+    if (!pause_entered)
+        return;
+
+    // NSActivityUserInteractive is a bitwise OR of NSActivityUserInitiated and NSActivityLatencyCritical.
+    // However, allow the system to sleep if needed by using NSActivityUserInitiatedAllowingIdleSystemSleep instead of NSActivityUserInitiated.
+    // And allow the system to terminate it as needed.
+    process_activity = [[NSProcessInfo processInfo] beginActivityWithOptions: ((NSActivityUserInitiatedAllowingIdleSystemSleep &~ (NSActivitySuddenTerminationDisabled | NSActivityAutomaticTerminationDisabled)) | NSActivityLatencyCritical) reason:@"Unpaused."];
+    pause_entered = false;
 }

--- a/src/qt/qt_main.cpp
+++ b/src/qt/qt_main.cpp
@@ -100,11 +100,17 @@ extern "C" {
 #include <86box/timer.h>
 #include <86box/nvr.h>
 extern int  qt_nvr_save(void);
+#ifndef Q_OS_MACOS
 extern void exit_pause(void);
+#endif
 
 bool cpu_thread_running = false;
 bool fast_forward = false;
 }
+
+#ifdef Q_OS_MACOS
+extern void exit_pause(void);
+#endif
 
 #include <locale.h>
 
@@ -758,6 +764,10 @@ main(int argc, char *argv[])
 
 #ifdef DISCORD
     discord_load();
+#endif
+
+#ifdef Q_OS_MACOS
+    exit_pause();
 #endif
 
 #ifdef Q_OS_WINDOWS

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -129,6 +129,11 @@ private:
     int   s;
 };
 
+#ifdef Q_OS_MACOS
+extern void exit_pause(void);
+extern void enter_pause(void);
+#endif
+
 extern "C" {
 #ifdef Q_OS_WINDOWS
 #    include <86box/win.h>
@@ -759,7 +764,7 @@ plat_pause(int p)
     if ((p == 0) && (time_sync & TIME_SYNC_ENABLED))
         nvr_time_sync();
 
-#ifdef Q_OS_WINDOWS
+#if defined(Q_OS_WINDOWS) || defined(Q_OS_MACOS)
     if (p)
         enter_pause();
     else


### PR DESCRIPTION
Summary
=======
Attempt to avoid macOS App Nap kicking in while the emulator is unpaused.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
