### PR TITLE
Fix "port" spinner selection option in FujiNet BoIP device

### DIFF
--- a/src/char/char_fujinet.c
+++ b/src/char/char_fujinet.c
@@ -251,10 +251,10 @@ static const device_config_t char_fujinet_config[] = {
     {
         .name        = "port",
         .description = "Port",
-        .type        = CONFIG_INT,
+        .type        = CONFIG_SPINNER,
         .default_int = FUJINET_DEFAULT_PORT,
         .file_filter = NULL,
-        .spinner     = { .min = 1, .max = 65535, .step = 1 },
+        .spinner     = { .min = 1, .max = 32767, .step = 1 },
         .selection   = { { 0 } },
         .bios        = { { 0 } }
     },


### PR DESCRIPTION
Summary
=======
Fix "port" spinner selection option in FujiNet BoIP device.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
