### PR TITLE
Further improve QIC-117 compatibility

### DIFF
--- a/src/floppy/fdd_tape.c
+++ b/src/floppy/fdd_tape.c
@@ -7,8 +7,8 @@
  *          This file is part of the 86Box distribution.
  *
  *          Emulation of a QIC-117 "floppy tape" drive, modelled after a
- *          Colorado QIC-40 drive ("Colorado 120", implying 60MB tapes,
- *          up to 120MB compressed).
+ *          Colorado QIC-80 drive ("Colorado 250", implying 120MB tapes,
+ *          up to 250MB compressed).
  *
  *          These drives share the floppy ribbon cable with the regular
  *          floppy drives and occupy one of the four drive select lines.
@@ -79,6 +79,7 @@ enum {
     QIC_ENTER_DIAGNOSTIC_1     = 28,
     QIC_ENTER_DIAGNOSTIC_2     = 29,
     QIC_ENTER_PRIMARY_MODE     = 30,
+    QIC_CMS_COMMAND_31         = 31,
     QIC_REPORT_VENDOR_ID       = 32,
     QIC_REPORT_TAPE_STATUS     = 33,
     QIC_SKIP_EXTENDED_REVERSE  = 34,
@@ -110,10 +111,10 @@ enum {
 
 /*
    Rate codes, as they appear in bits 4-3 of the drive configuration and as
-   the argument to Select Rate. A QIC-40 drive runs at 250 Kbps by default, so
-   that is what it reports and calibrates to; 500 Kbps is accepted too, and
-   the transfer clock (tape_byte_period()) follows whichever the host actually
-   programs into the controller.
+   the argument to Select Rate. A QIC-80 drive runs at 500 Kbps by default, so
+   that is what it reports and calibrates to; the transfer clock
+   (tape_byte_period()) follows whichever the host actually programs into the
+   controller.
  */
 #define QIC_RATE_250                 0
 #define QIC_RATE_2000                1
@@ -123,9 +124,7 @@ enum {
 /*
    Arguments to Select Rate above the rate codes name a tape format instead,
    as (Tape Format * 4) + Increment, where increment 1 is standard quarter
-   inch media and 3 is 8 mm wide tape. This QIC-40 drive works QIC-40 media on
-   standard quarter-inch cartridges; the QIC-80 code is tolerated but nothing
-   past it.
+   inch media and 3 is 8 mm wide tape.
  */
 #define QIC_FORMAT_QIC40             ((1 << 2) | 1)
 #define QIC_FORMAT_QIC80             ((2 << 2) | 1)
@@ -185,7 +184,7 @@ enum {
 
 /* Manufacturer-specific signature handed back by command 9 while in
    diagnostic mode (observed on a real Colorado 120 drive). */
-#define QIC_CMS_DIAG_STATUS          0xc
+#define QIC_CMS_DIAG_STATUS          0x4
 
 /* The head parks at cylinder 0 while idle, so TRACK 0 doubles as the
    result line. Bits are handed back one at a time, framed by a leading
@@ -798,15 +797,8 @@ tape_finish_parameters(void)
                wants.
              */
             switch (tape.param[0]) {
-                case QIC_RATE_250:
                 case QIC_RATE_500:
-                    /*
-                       250 Kbps is this QIC-40 drive's native rate; 500 Kbps is
-                       accepted too so a host probing rates sees no hard
-                       refusal. Either selection is reported back as-is, and a
-                       host that asks for one and reads back the other takes the
-                       drive to have failed the request.
-                     */
+                case QIC_RATE_1000:
                     tape.rate_code = tape.param[0];
                     break;
 
@@ -817,14 +809,18 @@ tape_finish_parameters(void)
                     break;
 
                 default:
-                    /* 1 and 2 Mbps, the QIC-3010 and QIC-3020 formats, and
-                       8 mm wide media are all beyond a QIC-40 drive. */
                     tape_set_error(QIC_ERROR_RATE_SELECTION, tape.param_cmd);
                     break;
             }
             break;
 
         case QIC_EXT_SELECT_RATE:
+
+            if (tape.diag_mode == 1) {
+                tape_start_report(0x34, 8);
+                return;
+            }
+
             /* The extended form only names rates beyond this drive's reach. */
             tape_set_error(QIC_ERROR_RATE_SELECTION, tape.param_cmd);
             break;
@@ -1058,7 +1054,7 @@ tape_command(uint8_t command)
                or sets it again (cmd 37).
              */
             tape.rate_code       = QIC_RATE_500;
-            tape.format_code     = QIC_FORMAT_QIC40;
+            tape.format_code     = QIC_FORMAT_QIC80;
             tape.format_segments = 0;
             /*
                A reset is itself an error condition (cmd 1, 3.2): the drive
@@ -1091,7 +1087,7 @@ tape_command(uint8_t command)
             /* The only rate the drive will accept is the only one it can
                ever be running at, so the selected rate is the live one. */
             tape_start_report((tape.rate_code << QIC_CONFIG_RATE_SHIFT) |
-                              QIC_CONFIG_LONG, 8);
+                              QIC_CONFIG_LONG | QIC_CONFIG_80, 8);
             return;
         }
 
@@ -1118,7 +1114,7 @@ tape_command(uint8_t command)
                 tape_set_error(QIC_ERROR_NO_CARTRIDGE, command);
                 break;
             }
-            tape_start_report(QIC_TAPE_QIC40 | QIC_TAPE_307FT, 8);
+            tape_start_report(QIC_TAPE_QIC80 | QIC_TAPE_307FT, 8);
             return;
 
         case QIC_REPORT_FORMAT_SEGMENTS:
@@ -1253,6 +1249,13 @@ tape_command(uint8_t command)
             tape.format_mode = 0;
             tape.verify_mode = 0;
             tape.diag_mode   = 0;
+            break;
+
+        case QIC_CMS_COMMAND_31:
+            if (tape.diag_mode == 1) {
+                tape_start_report(0x4a, 8);
+                return;
+            }
             break;
 
         /*
@@ -2242,7 +2245,7 @@ fdd_tape_init(void)
     tape.segs_per_cyl  = FDD_TAPE_SEGS_PER_CYL;
     tape.segs_per_head = FDD_TAPE_SEGS_PER_HEAD;
     tape.rate_code     = QIC_RATE_500;
-    tape.format_code   = QIC_FORMAT_QIC40;
+    tape.format_code   = QIC_FORMAT_QIC80;
     tape.status     = QIC_STATUS_READY;
     tape.report_pos = TAPE_REPORT_IDLE;
     tape.error_cmd  = QIC_NO_COMMAND;

--- a/src/floppy/fdd_tape.c
+++ b/src/floppy/fdd_tape.c
@@ -6,9 +6,8 @@
  *
  *          This file is part of the 86Box distribution.
  *
- *          Emulation of a QIC-117 "floppy tape" drive, modelled after a
- *          Colorado QIC-80 drive ("Colorado 250", implying 120MB tapes,
- *          up to 250MB compressed).
+ *          Emulation of a QIC-117 "floppy tape" drive, namely a drive that
+ *          accepts a QIC-80 or QIC-80XL cartridge.
  *
  *          These drives share the floppy ribbon cable with the regular
  *          floppy drives and occupy one of the four drive select lines.
@@ -89,6 +88,7 @@ enum {
     QIC_CALIBRATE_TAPE_LENGTH  = 36,
     QIC_REPORT_FORMAT_SEGMENTS = 37,
     QIC_SET_FORMAT_SEGMENTS    = 38,
+    QIC_CONNER_CMD_40          = 40,
     QIC_PHANTOM_SELECT         = 46,
     QIC_PHANTOM_DESELECT       = 47,
     QIC_EXT_SELECT_RATE        = 50,
@@ -175,18 +175,34 @@ enum {
 #define QIC_IGNORE_ABOVE             QIC_REPORT_VENDOR_ID
 
 /*
-   Vendor ID and ROM version, pulled from a real Colorado 120 drive.
+   Vendor ID and ROM version.
+   0x5 = Conner
+   0x47 = Colorado
+
+   Emulating a Conner drive seems to be more compatible across various
+   host software, whereas emulating a Colorado drive makes the host
+   software dive deeper into Colorado-specific diagnostics that have not
+   yet been reverse-engineered.
  */
-#define QIC_VENDOR_ID                0x0047
+#define QIC_VENDOR_ID                0x5
 #define QIC_ROM_VERSION              0x58
 
-/* Manufacturer-specific signature handed back by command 37 while in
-   diagnostic mode (observed on a real Colorado 120 drive). */
+/* Colorado-specific signature handed back by command 37 while in
+   diagnostic mode (observed on a real Colorado 250 drive). */
 #define QIC_CMS_SIGNATURE            0xa5
 
-/* Manufacturer-specific signature handed back by command 9 while in
-   diagnostic mode (observed on a real Colorado 120 drive). */
+/* Colorado-specific signature handed back by command 9 while in
+   diagnostic mode. */
 #define QIC_CMS_DIAG_STATUS          0x4
+
+/* Conner-specific signature handed back by command 40 while in
+   diagnostic mode, to determine the drive model. Possible values
+   seem to be:
+   0x1 - Conner 120 (QIC-40)
+   0x4 - Conner 250 (QIC-80)
+   0x100 - Conner 700 (QIC-3010)
+   */
+#define QIC_CONNER_DIAG_STATUS       0x4
 
 /* The head parks at cylinder 0 while idle, so TRACK 0 doubles as the
    result line. Bits are handed back one at a time, framed by a leading
@@ -842,6 +858,7 @@ tape_command_defined(uint8_t command)
         case QIC_PHANTOM_DESELECT:
         case QIC_EXT_SELECT_RATE:
         case QIC_EXT_REPORT_DRIVE_CONFIG:
+        case QIC_CONNER_CMD_40:
             return 1;
 
         default:
@@ -1100,6 +1117,15 @@ tape_command(uint8_t command)
                 tape_start_report(QIC_CMS_SIGNATURE, 8);
             else
                 tape_start_report(QIC_ROM_VERSION, 8);
+            return;
+
+        case QIC_CONNER_CMD_40:
+            /*
+               This is a Conner-specific diagnostic command that expects a 16-bit
+               response that the host software uses to determine the drive model.
+            */
+            if (tape.diag_mode == 1)
+                tape_start_report(QIC_CONNER_DIAG_STATUS, 16);
             return;
 
         case QIC_REPORT_VENDOR_ID:
@@ -2308,10 +2334,9 @@ fdd_tape_init(void)
      */
     tape.status &= ~QIC_STATUS_NEW_CARTRIDGE;
 
-    /*
-       To investigate: do we need to initialize the drive with a power-on reset error?
+    /* Initialize the drive with a power-on-reset error, which must be
+       cleared by the host software before proceeding. */
     tape_set_init_error(QIC_ERROR_POWER_ON_RESET);
-    */
 }
 
 void

--- a/src/floppy/fdd_tape.c
+++ b/src/floppy/fdd_tape.c
@@ -191,10 +191,10 @@ enum {
    acknowledge bit and a trailing stop bit. */
 #define TAPE_REPORT_IDLE             (-1)
 
-/* A blank cartridge holds this many segments (QIC-40, 307.5 ft extended
-   length, 20 tracks of 102 segments), the layout this QIC-40 drive presents. */
-#define TAPE_SEGMENTS_PER_TRACK      102
-#define TAPE_TRACKS                  20
+/* A blank cartridge holds this many segments (QIC-80, 307.5 ft extended
+   length, 28 tracks of 150 segments), the layout this QIC-80 drive presents. */
+#define TAPE_SEGMENTS_PER_TRACK      150
+#define TAPE_TRACKS                  28
 #define TAPE_TOTAL_SEGMENTS          (TAPE_SEGMENTS_PER_TRACK * TAPE_TRACKS)
 
 /* Transfer states of the read/write engine. */
@@ -461,7 +461,7 @@ tape_head_segment(void)
 }
 
 /* Segments per tape track. The real figure lives in the cartridge's header
-   segment, which only the host has read, so this is the QIC-40 default
+   segment, which only the host has read, so this is the QIC-80 default
    unless the host has told us otherwise. */
 static int
 tape_segments_per_track(void)
@@ -739,7 +739,7 @@ tape_finish_parameters(void)
         case QIC_SEEK_HEAD_TO_TRACK:
             /*
                The track number must be valid for the format in effect. A
-               QIC-40 cartridge has 20 tracks; anything beyond that is an
+               QIC-80 cartridge has 28 tracks; anything beyond that is an
                "illegal track address specified for seek" (cmd 13, error 7),
                and the head stays where it is.
              */
@@ -1133,7 +1133,7 @@ tape_command(uint8_t command)
             /*
                Zero until the host calibrates the tape or sets the count
                explicitly - the value is only meaningful after one of those
-               (cmd 37). Internal geometry falls back to the QIC-40 default
+               (cmd 37). Internal geometry falls back to the QIC-80 default
                separately, in tape_segments_per_track().
              */
             tape_start_report(tape.format_segments, 16);
@@ -1292,10 +1292,12 @@ tape_command(uint8_t command)
                 break;
             }
 
+            /*
             if (tape.format_mode == 0) {
                 tape_set_error(QIC_ERROR_ILLEGAL_IN_PRIMARY, command);
                 break;
             }
+            */
 
             if (tape.image_size == 0)
                 tape.image_size = 1;
@@ -1310,7 +1312,7 @@ tape_command(uint8_t command)
         case QIC_CALIBRATE_TAPE_LENGTH:
             /*
                Calibrate determines the number of segments per track the tape
-               can hold (cmd 36). This fixed-geometry QIC-40 extended-length
+               can hold (cmd 36). This fixed-geometry QIC-80 extended-length
                cartridge has a known count, so record it; Report Format
                Segments reads it back afterwards, having returned zero until
                now (cmd 37).
@@ -1415,8 +1417,8 @@ tape_sector_offset(int track, int side, int sector, uint32_t *offset)
     /*
        The head field is not a physical head here, just the high digits of
        the segment number, so it ranges well beyond the two a floppy has:
-       a full QIC-40 cartridge holds a couple of thousand segments, which is
-       head 2 at 1020 segments per head.
+       a full QIC-80 cartridge holds a few thousand segments, which is
+       head 4 at 1020 segments per head.
      */
     if ((track < 0) || (track > FDD_TAPE_MAX_TRACK) || (side < 0) || (side > 0xff))
         return 0;

--- a/src/floppy/fdd_tape.c
+++ b/src/floppy/fdd_tape.c
@@ -1080,10 +1080,11 @@ tape_command(uint8_t command)
             return;
 
         case QIC_REPORT_DRIVE_CONFIG: {
-            /* The only rate the drive will accept is the only one it can
-               ever be running at, so the selected rate is the live one. */
-            tape_start_report((tape.rate_code << QIC_CONFIG_RATE_SHIFT) |
-                              QIC_CONFIG_80, 8);
+            uint8_t config = (tape.rate_code << QIC_CONFIG_RATE_SHIFT) | QIC_CONFIG_80;
+            if (tape_has_cartridge())
+                config |= QIC_CONFIG_LONG;
+
+            tape_start_report(config, 8);
             return;
         }
 

--- a/src/floppy/fdd_tape.c
+++ b/src/floppy/fdd_tape.c
@@ -790,24 +790,18 @@ tape_finish_parameters(void)
             break;
 
         case QIC_SELECT_RATE:
-            /*
-               The one argument selects either a data rate or a tape format.
-               Whatever the drive cannot do has to be refused rather than
-               quietly ignored: a host that asks for something and gets no
-               complaint will read the configuration back, find nothing
-               changed, and conclude the drive cannot reach the capacity it
-               wants.
-             */
+            if (tape.param[0] >= 6) {
+                /* Reverse-engineered from an actual ROM: the drive actually
+                   reports error 8 for any rate code >= 6, which is technically
+                   against the spec.
+                */
+                tape_set_error(QIC_ERROR_ILLEGAL_IN_REPORT, tape.param_cmd);
+                break;
+            }
             switch (tape.param[0]) {
                 case QIC_RATE_500:
                 case QIC_RATE_1000:
                     tape.rate_code = tape.param[0];
-                    break;
-
-                case QIC_FORMAT_QIC40:
-                case QIC_FORMAT_QIC80:
-                    /* Only consulted when the host goes on to format. */
-                    tape.format_code = tape.param[0];
                     break;
 
                 default:
@@ -2312,6 +2306,11 @@ fdd_tape_init(void)
        latched for good.
      */
     tape.status &= ~QIC_STATUS_NEW_CARTRIDGE;
+
+    /*
+       To investigate: do we need to initialize the drive with a power-on reset error?
+    tape_set_init_error(QIC_ERROR_POWER_ON_RESET);
+    */
 }
 
 void

--- a/src/floppy/fdd_tape.c
+++ b/src/floppy/fdd_tape.c
@@ -6,9 +6,8 @@
  *
  *          This file is part of the 86Box distribution.
  *
- *          Emulation of a QIC-117 "floppy tape" drive, modelled after a
- *          Colorado QIC-80 drive ("Colorado 250", implying 120MB tapes,
- *          up to 250MB compressed).
+ *          Emulation of a QIC-117 "floppy tape" drive, namely a drive that
+ *          accepts a QIC-80 or QIC-80XL cartridge.
  *
  *          These drives share the floppy ribbon cable with the regular
  *          floppy drives and occupy one of the four drive select lines.
@@ -89,6 +88,7 @@ enum {
     QIC_CALIBRATE_TAPE_LENGTH  = 36,
     QIC_REPORT_FORMAT_SEGMENTS = 37,
     QIC_SET_FORMAT_SEGMENTS    = 38,
+    QIC_CONNER_CMD_40          = 40,
     QIC_PHANTOM_SELECT         = 46,
     QIC_PHANTOM_DESELECT       = 47,
     QIC_EXT_SELECT_RATE        = 50,
@@ -175,18 +175,31 @@ enum {
 #define QIC_IGNORE_ABOVE             QIC_REPORT_VENDOR_ID
 
 /*
-   Vendor ID and ROM version, pulled from a real Colorado 120 drive.
+   Vendor ID and ROM version.
+   0x5 = Conner
+   0x47 = Colorado
+
+   Emulating a Conner drive seems to be more compatible across various
+   host software, whereas emulating a Colorado drive makes the host
+   software dive deeper into Colorado-specific diagnostics that have not
+   yet been reverse-engineered.
  */
-#define QIC_VENDOR_ID                0x0047
+#define QIC_VENDOR_ID                0x5
 #define QIC_ROM_VERSION              0x58
 
-/* Manufacturer-specific signature handed back by command 37 while in
-   diagnostic mode (observed on a real Colorado 120 drive). */
+/* Colorado-specific signature handed back by command 37 while in
+   diagnostic mode (observed on a real Colorado 250 drive). */
 #define QIC_CMS_SIGNATURE            0xa5
 
-/* Manufacturer-specific signature handed back by command 9 while in
-   diagnostic mode (observed on a real Colorado 120 drive). */
+/* Colorado-specific signature handed back by command 9 while in
+   diagnostic mode. */
 #define QIC_CMS_DIAG_STATUS          0x4
+
+/* Conner-specific signature handed back by command 40 while in
+   diagnostic mode. A return value of 0x4 satisfies the host software
+   to believe that this is a Conner 250 drive. If we ever want to
+   upgrade to QIC-3010,  */
+#define QIC_CONNER_DIAG_STATUS       0x4
 
 /* The head parks at cylinder 0 while idle, so TRACK 0 doubles as the
    result line. Bits are handed back one at a time, framed by a leading
@@ -842,6 +855,7 @@ tape_command_defined(uint8_t command)
         case QIC_PHANTOM_DESELECT:
         case QIC_EXT_SELECT_RATE:
         case QIC_EXT_REPORT_DRIVE_CONFIG:
+        case QIC_CONNER_CMD_40:
             return 1;
 
         default:
@@ -1100,6 +1114,15 @@ tape_command(uint8_t command)
                 tape_start_report(QIC_CMS_SIGNATURE, 8);
             else
                 tape_start_report(QIC_ROM_VERSION, 8);
+            return;
+
+        case QIC_CONNER_CMD_40:
+            /*
+               This is a Conner-specific diagnostic command that expects a 16-bit
+               response that the host software uses to determine the drive model.
+            */
+            if (tape.diag_mode == 1)
+                tape_start_report(QIC_CONNER_DIAG_STATUS, 16);
             return;
 
         case QIC_REPORT_VENDOR_ID:
@@ -2308,10 +2331,9 @@ fdd_tape_init(void)
      */
     tape.status &= ~QIC_STATUS_NEW_CARTRIDGE;
 
-    /*
-       To investigate: do we need to initialize the drive with a power-on reset error?
+    /* Initialize the drive with a power-on-reset error, which must be
+       cleared by the host software before proceeding. */
     tape_set_init_error(QIC_ERROR_POWER_ON_RESET);
-    */
 }
 
 void

--- a/src/floppy/fdd_tape.c
+++ b/src/floppy/fdd_tape.c
@@ -827,12 +827,6 @@ tape_finish_parameters(void)
             break;
 
         case QIC_EXT_SELECT_RATE:
-
-            if (tape.diag_mode == 1) {
-                tape_start_report(0x34, 8);
-                return;
-            }
-
             /* The extended form only names rates beyond this drive's reach. */
             tape_set_error(QIC_ERROR_RATE_SELECTION, tape.param_cmd);
             break;
@@ -1320,7 +1314,7 @@ tape_command(uint8_t command)
                 break;
             }
 
-            /*
+            /* in case we need to send back an error in this case:
             if (tape.format_mode == 0) {
                 tape_set_error(QIC_ERROR_ILLEGAL_IN_PRIMARY, command);
                 break;

--- a/src/floppy/fdd_tape.c
+++ b/src/floppy/fdd_tape.c
@@ -23,8 +23,10 @@
  *
  *          The cartridge is a flat image addressed by segment. A segment
  *          is 32 sectors of 1024 bytes and is mapped onto the controller's
- *          C/H/R space at four segments per cylinder, 1020 segments per
- *          head - the same fixed geometry the QIC-40/80 format specifies.
+ *          C/H/R space at four segments per cylinder; the host states its
+ *          cylinders per head in the cartridge header (150 for QIC-80, 255
+ *          for QIC-40), so the "head" digit runs well past the two a floppy
+ *          has.
  *
  * Authors: Dmitry Brant, <me@dmitrybrant.com>
  *
@@ -1087,7 +1089,7 @@ tape_command(uint8_t command)
             /* The only rate the drive will accept is the only one it can
                ever be running at, so the selected rate is the live one. */
             tape_start_report((tape.rate_code << QIC_CONFIG_RATE_SHIFT) |
-                              QIC_CONFIG_LONG | QIC_CONFIG_80, 8);
+                              QIC_CONFIG_80, 8);
             return;
         }
 
@@ -1238,6 +1240,11 @@ tape_command(uint8_t command)
             }
             tape.format_mode = 1;
             tape.verify_mode = 0;
+            /* Settle the C/H/R mapping before the format writes arrive: a
+               blank cartridge takes the mapping of the format the host just
+               selected (Select Rate sets format_code first), and a
+               reformatted one re-reads its existing header. */
+            tape_read_geometry();
             break;
 
         case QIC_ENTER_VERIFY_MODE:
@@ -1418,7 +1425,7 @@ tape_sector_offset(int track, int side, int sector, uint32_t *offset)
        The head field is not a physical head here, just the high digits of
        the segment number, so it ranges well beyond the two a floppy has:
        a full QIC-80 cartridge holds a few thousand segments, which is
-       head 4 at 1020 segments per head.
+       head 6 at 600 segments per head.
      */
     if ((track < 0) || (track > FDD_TAPE_MAX_TRACK) || (side < 0) || (side > 0xff))
         return 0;
@@ -2114,8 +2121,18 @@ tape_read_geometry(void)
 {
     uint8_t hdr[FDD_TAPE_SECTOR_SIZE];
 
+    /*
+       With no header to read - a blank cartridge about to be formatted - fall
+       back to the mapping the selected format is laid down with, so the format
+       writes land in the same C/H/R space the host later reads them back from.
+       A QIC-80 cartridge is packed at 150 cylinders per head, a QIC-40 one at
+       255; getting this wrong scatters the host's writes across a sparse,
+       oversized image.
+     */
     tape.segs_per_cyl  = FDD_TAPE_SEGS_PER_CYL;
-    tape.segs_per_head = FDD_TAPE_SEGS_PER_HEAD;
+    tape.segs_per_head = (tape.format_code == QIC_FORMAT_QIC40)
+                             ? FDD_TAPE_SEGS_PER_HEAD_QIC40
+                             : FDD_TAPE_SEGS_PER_HEAD_QIC80;
 
     if (tape.fp == NULL)
         return;

--- a/src/floppy/fdd_tape.c
+++ b/src/floppy/fdd_tape.c
@@ -154,6 +154,7 @@ enum {
 #define QIC_ERROR_ILLEGAL_IN_REPORT  8
 #define QIC_ERROR_ILLEGAL_DIAG_ENTRY 9
 #define QIC_ERROR_NEW_CARTRIDGE      13
+#define QIC_ERROR_ILLEGAL_IN_PRIMARY 14
 #define QIC_ERROR_ILLEGAL_IN_FORMAT  15
 #define QIC_ERROR_NOT_REFERENCED     19
 #define QIC_ERROR_POWER_ON_RESET     26
@@ -1288,12 +1289,10 @@ tape_command(uint8_t command)
                 break;
             }
 
-            /* in case we need to send back an error in this case:
             if (tape.format_mode == 0) {
-                tape_set_error(QIC_ERROR_ILLEGAL_IN_FORMAT, command);
+                tape_set_error(QIC_ERROR_ILLEGAL_IN_PRIMARY, command);
                 break;
             }
-            */
 
             if (tape.image_size == 0)
                 tape.image_size = 1;
@@ -1519,9 +1518,6 @@ tape_command_timeout(UNUSED(void *priv))
     /* A bare Report Next Bit was already answered as its pulses arrived. */
     if ((steps == QIC_REPORT_NEXT_BIT) && presented)
         return;
-
-    fdd_tape_log("Tape: pulse train complete, %i pulse(s), fdc rate %i kbps\n",
-                 steps, (tape_fdc != NULL) ? tape_fdc->bit_rate : -1);
 
     tape_step_pulses(steps);
 }

--- a/src/include/86box/fdd_tape.h
+++ b/src/include/86box/fdd_tape.h
@@ -40,12 +40,17 @@
 #define FDD_TAPE_SECTORS_PER_SEG 32
 #define FDD_TAPE_SEGMENT_SIZE    (FDD_TAPE_SECTOR_SIZE * FDD_TAPE_SECTORS_PER_SEG)
 /*
-   Defaults only. The cartridge's own header segment states the mapping it
-   was formatted with, and a QIC-80 tape typically uses 150 cylinders per
-   head rather than the 255 these defaults imply.
+   Blank-cartridge defaults, keyed on the format being laid down. A formatted
+   cartridge states its true mapping in its own header segment, which the
+   loader reads and which overrides these. The host packs a QIC-80 cartridge
+   at 150 cylinders per head and a QIC-40 one at 255, both at four segments
+   per cylinder - the values observed in the headers it writes.
  */
-#define FDD_TAPE_SEGS_PER_CYL    4
-#define FDD_TAPE_SEGS_PER_HEAD   1020
+#define FDD_TAPE_SEGS_PER_CYL         4
+#define FDD_TAPE_SEGS_PER_HEAD_QIC80  600   /* 150 cylinders per head */
+#define FDD_TAPE_SEGS_PER_HEAD_QIC40  1020  /* 255 cylinders per head */
+/* Default before the host has selected a format: this is a QIC-80 drive. */
+#define FDD_TAPE_SEGS_PER_HEAD        FDD_TAPE_SEGS_PER_HEAD_QIC80
 
 /* Highest cylinder a data transfer may name in the C/H/R address space. */
 #define FDD_TAPE_MAX_TRACK       255


### PR DESCRIPTION
Summary
=======
- Now usable in first-party Colorado and Conner utilities for MS-DOS, as well as Windows 3.1.
- Improved stability in Microsoft Backup in Windows 95 and NT 4.
- This is now back to emulating a proper QIC-80 drive (instead of QIC-40), with 120MB cartridge sizes.

Remaining known issues:
- Not yet working in MS Backup for Windows 98. The drive is detected and installed successfully, but then MS Backup refuses to communicate with it. Continuing to investigate.
- Not fully compatible with first-party Colorado Backup tools for Windows 95.
- Some minor cosmetic issues in Microsoft Backup in Windows 95: After finishing a backup or a format, it might lose connection with the drive, but this is fixed by selecting "Redetect tape drive" from the menu. Some amount of communication issues with these drives is actually period-correct, since the QIC-117 protocol itself is rather hacky and extremely sensitive to timings.

<img width="1024" height="768" alt="Monitor_1_20260806-102808-214" src="https://github.com/user-attachments/assets/63e0dfae-6084-4ea7-85c1-a2d112fb449c" />

Checklist
=========
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/
