### PR TITLE
QIC-117: Fix a few other compatibility quirks in NT 3.5.

### DIFF
--- a/src/floppy/fdd_tape.c
+++ b/src/floppy/fdd_tape.c
@@ -183,18 +183,18 @@ enum {
  */
 #define QIC_VENDOR_ID_CONNER         0x014e
 #define QIC_VENDOR_ID_CONNER_OLD     0x5
-#define QIC_VENDOR_ID_CMS            0x0047
+#define QIC_VENDOR_ID_COLORADO       0x0047
 
 #define QIC_ROM_VERSION_CONNER       0x2
-#define QIC_ROM_VERSION_CMS          0x58
+#define QIC_ROM_VERSION_COLORADO     0x58
 
 /* Colorado-specific signature handed back by command 9 while in
    diagnostic mode (observed on a real Colorado 250 drive). */
-#define QIC_CMS_SIGNATURE            0xa5
+#define QIC_COLORADO_SIGNATURE       0xa5
 
 /* Colorado-specific signature handed back by command 37 while in
    diagnostic mode. */
-#define QIC_CMS_DIAG_STATUS          0x4
+#define QIC_COLORADO_DIAG_STATUS     0x4
 
 /* Conner-specific signature handed back by command 40 while in
    diagnostic mode, to determine the drive model. */
@@ -803,11 +803,12 @@ tape_finish_parameters(void)
 
         case QIC_SELECT_RATE:
             if (tape.param[0] >= 6) {
-                /* Reverse-engineered from an actual ROM: the drive actually
+                /* If we want to emulate a Colorado drive: the drive actually
                    reports error 8 for any rate code >= 6, which is technically
                    against the spec.
+                   tape_set_error(QIC_ERROR_ILLEGAL_IN_REPORT, tape.param_cmd);
                 */
-                tape_set_error(QIC_ERROR_ILLEGAL_IN_REPORT, tape.param_cmd);
+                tape_set_error(QIC_ERROR_RATE_SELECTION, tape.param_cmd);
                 break;
             }
             switch (tape.param[0]) {
@@ -1098,7 +1099,7 @@ tape_command(uint8_t command)
         case QIC_REPORT_ROM_VERSION:
             if (tape.diag_mode == 1) {
                 /* Colorado-specific response when in diagnostic mode. */
-                tape_start_report(QIC_CMS_SIGNATURE, 8);
+                tape_start_report(QIC_COLORADO_SIGNATURE, 8);
             } else {
                 tape_start_report(QIC_ROM_VERSION_CONNER, 8);
             }
@@ -1126,7 +1127,7 @@ tape_command(uint8_t command)
         case QIC_REPORT_FORMAT_SEGMENTS:
             if (tape.diag_mode) {
                 /* Colorado-specific response when in diagnostic mode. */
-                tape_start_report(QIC_CMS_DIAG_STATUS, 8);
+                tape_start_report(QIC_COLORADO_DIAG_STATUS, 8);
                 return;
             }
 

--- a/src/floppy/fdd_tape.c
+++ b/src/floppy/fdd_tape.c
@@ -176,33 +176,29 @@ enum {
 
 /*
    Vendor ID and ROM version.
-   0x5 = Conner
-   0x47 = Colorado
-
    Emulating a Conner drive seems to be more compatible across various
    host software, whereas emulating a Colorado drive makes the host
    software dive deeper into Colorado-specific diagnostics that have not
    yet been reverse-engineered.
  */
-#define QIC_VENDOR_ID                0x5
-#define QIC_ROM_VERSION              0x58
+#define QIC_VENDOR_ID_CONNER         0x014e
+#define QIC_VENDOR_ID_CONNER_OLD     0x5
+#define QIC_VENDOR_ID_CMS            0x0047
 
-/* Colorado-specific signature handed back by command 37 while in
+#define QIC_ROM_VERSION_CONNER       0x2
+#define QIC_ROM_VERSION_CMS          0x58
+
+/* Colorado-specific signature handed back by command 9 while in
    diagnostic mode (observed on a real Colorado 250 drive). */
 #define QIC_CMS_SIGNATURE            0xa5
 
-/* Colorado-specific signature handed back by command 9 while in
+/* Colorado-specific signature handed back by command 37 while in
    diagnostic mode. */
 #define QIC_CMS_DIAG_STATUS          0x4
 
 /* Conner-specific signature handed back by command 40 while in
-   diagnostic mode, to determine the drive model. Possible values
-   seem to be:
-   0x1 - Conner 120 (QIC-40)
-   0x4 - Conner 250 (QIC-80)
-   0x100 - Conner 700 (QIC-3010)
-   */
-#define QIC_CONNER_DIAG_STATUS       0x4
+   diagnostic mode, to determine the drive model. */
+#define QIC_CONNER_DIAG_STATUS       0x4c1c
 
 /* The head parks at cylinder 0 while idle, so TRACK 0 doubles as the
    result line. Bits are handed back one at a time, framed by a leading
@@ -1100,30 +1096,23 @@ tape_command(uint8_t command)
         }
 
         case QIC_REPORT_ROM_VERSION:
-            /*
-               In diagnostic mode this command hands back the manufacturer's
-               signature rather than the ROM version - it is how a host
-               confirms it really is talking to a Colorado/CMS drive. A host
-               that gets anything else treats the drive as an unknown make
-               and refuses to use it.
-             */
-            if (tape.diag_mode == 1)
+            if (tape.diag_mode == 1) {
+                /* Colorado-specific response when in diagnostic mode. */
                 tape_start_report(QIC_CMS_SIGNATURE, 8);
-            else
-                tape_start_report(QIC_ROM_VERSION, 8);
+            } else {
+                tape_start_report(QIC_ROM_VERSION_CONNER, 8);
+            }
             return;
 
         case QIC_CONNER_CMD_40:
-            /*
-               This is a Conner-specific diagnostic command that expects a 16-bit
-               response that the host software uses to determine the drive model.
-            */
-            if (tape.diag_mode == 1)
+            if (tape.diag_mode == 1) {
+                /* Conner-specific response when in diagnostic mode. */
                 tape_start_report(QIC_CONNER_DIAG_STATUS, 16);
+            }
             return;
 
         case QIC_REPORT_VENDOR_ID:
-            tape_start_report(QIC_VENDOR_ID & 0xffff, 16);
+            tape_start_report(QIC_VENDOR_ID_CONNER & 0xffff, 16);
             return;
 
         case QIC_REPORT_TAPE_STATUS:
@@ -1135,14 +1124,8 @@ tape_command(uint8_t command)
             return;
 
         case QIC_REPORT_FORMAT_SEGMENTS:
-            /*
-               Diagnostic mode redefines this code as manufacturer
-               territory: it hands back an eight bit status rather than the
-               sixteen bit segment count. The host wants a valid answer -
-               silence times it out and a report marked invalid makes it
-               retry - and reads the make and model out of the value.
-             */
             if (tape.diag_mode) {
+                /* Colorado-specific response when in diagnostic mode. */
                 tape_start_report(QIC_CMS_DIAG_STATUS, 8);
                 return;
             }


### PR DESCRIPTION
Summary
=======
* Just a bit more chipping-away of compatibility quirks in Microsoft Backup for Windows NT 3.5, as well as NT 4.
  *  (In NT 3.5, you need to explicitly install the tape drive manually by going to Windows NT Setup, then Options -> Add Tape Drive -> QIC80 drive, etc.)

<img width="1024" height="768" alt="Monitor_1_20260807-140804-821" src="https://github.com/user-attachments/assets/09a13b4a-ba23-48ea-a407-daadef4ce02d" />

Checklist
=========
* [x] I have tested my changes locally and validated that the functionality works as intended
