### PR TITLE
Alphabetize AB-BE6-II & Intel PRO/100 (incl. shorten Inboard 386/PC name)

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -191,6 +191,7 @@ device_set_context(device_context_t *ctx, const device_t *dev, int inst)
         { .old = "IBM XT Model 286", .new = "IBM XT model 286" },
         { .old = "Packard Bell Legend 300SX", .new = "Packard Bell PB300" },
         { .old = "Packard Bell PB300/PB320", .new = "Packard Bell PB300" }, /* 6.0 pre-release */
+        { .old = "IBM XT (1982) w/ Intel Inboard 386/PC", .new = "IBM XT (Inboard 386/PC)" },
         { .old = "DataExpert SX495", .new = "DataExpert OPTI-495SX" },
         { .old = "Packard Bell PB410/PB410A/PB420/PB420T", .new = "Packard Bell PB410A" }, /* 6.0 pre-release */
         { .old = "Intel Premiere/PCI (Batman)", .new = "Intel Premiere/PCI" },
@@ -225,6 +226,7 @@ device_set_context(device_context_t *ctx, const device_t *dev, int inst)
         { .old = "ATI 28800-6 (ATI VGA Wonder 1024D XL Plus)", .new = "ATI 28800-6" },
         { .old = "DEC DE-500A Fast Ethernet (DECchip 21143 \"Tulip\")", .new = "DECchip 21143 \"Tulip\"" },
         { .old = "DEC DE-435 EtherWorks Turbo (DECchip 21040 \"Tulip\")", .new = "DECchip 21040 \"Tulip\"" },
+        { .old = "Intel PRO/100", .new = "Intel EtherExpress PRO/100B" },
         { .old = "SMC EtherPower II 9432 (SMC 83C170 \"EPIC/100\")", .new = "SMC 83C170 \"EPIC/100\"" },
         { .old = "Aztech Sound Galaxy Pro 16 II (AZT2316R)", .new = "Aztech Sound Galaxy Pro 16 II" },
         { .old = "Aztech Sound Galaxy Pro 16 AB (Washington)", .new = "Aztech Sound Galaxy Pro 16 AB" },

--- a/src/device.c
+++ b/src/device.c
@@ -226,7 +226,6 @@ device_set_context(device_context_t *ctx, const device_t *dev, int inst)
         { .old = "ATI 28800-6 (ATI VGA Wonder 1024D XL Plus)", .new = "ATI 28800-6" },
         { .old = "DEC DE-500A Fast Ethernet (DECchip 21143 \"Tulip\")", .new = "DECchip 21143 \"Tulip\"" },
         { .old = "DEC DE-435 EtherWorks Turbo (DECchip 21040 \"Tulip\")", .new = "DECchip 21040 \"Tulip\"" },
-        { .old = "Intel PRO/100", .new = "Intel EtherExpress PRO/100B" },
         { .old = "SMC EtherPower II 9432 (SMC 83C170 \"EPIC/100\")", .new = "SMC 83C170 \"EPIC/100\"" },
         { .old = "Aztech Sound Galaxy Pro 16 II (AZT2316R)", .new = "Aztech Sound Galaxy Pro 16 II" },
         { .old = "Aztech Sound Galaxy Pro 16 AB (Washington)", .new = "Aztech Sound Galaxy Pro 16 AB" },

--- a/src/machine/m_xt.c
+++ b/src/machine/m_xt.c
@@ -624,7 +624,7 @@ machine_ibmxt_init(const machine_t *model)
    8088 - same real BIOS ROM chips, same base XT platform, plus the Inboard's own wait-state/
    A20/ROM-shadow hardware. */
 const device_t ibmxt_inboard386_device = {
-    .name          = "IBM XT (1982) w/ Intel Inboard 386/PC",
+    .name          = "IBM XT (Inboard 386/PC)",
     .internal_name = "ibmxt_inboard386",
     .flags         = 0,
     .local         = 0,

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -7379,7 +7379,7 @@ const machine_t machines[] = {
        second/slave 8259 PIC exists on this hardware - it's a genuine XT platform underneath,
        just with a 386-class CPU bolted on via a daughtercard. */
     {
-        .name              = "[386DX] IBM XT (1982) w/ Intel Inboard 386/PC",
+        .name              = "[386DX] IBM XT (Inboard 386/PC)",
         .internal_name     = "ibmxt_inboard386",
         .type              = MACHINE_TYPE_386DX,
         .chipset           = MACHINE_CHIPSET_DISCRETE,
@@ -7389,10 +7389,10 @@ const machine_t machines[] = {
         .available_flag    = MACHINE_AVAILABLE,
         .gpio_acpi_handler = NULL,
         .cpu               = {
-            /* The Inboard's own CPU socket accepts any 386SX-pinout-compatible upgrade chip
+            /* The Inboard's own CPU socket accepts any 386DX-pinout-compatible upgrade chip
                of the era (PGA132 and pin-compatible packages), not one specific part - OR
                together every compatible family so a user with a different chip on their card
-               (stock 386SX, Cyrix 486DLC/486SLC, IBM 386SLC/486SLC, etc.) can select their own
+               (stock 386DX, Cyrix 486DLC, IBM 486BL, etc.) can select their own
                from the normal CPU dropdown instead of being locked to one. */
             .package     = CPU_PKG_386DX | CPU_PKG_486BL | CPU_PKG_486DLC,
             .block       = CPU_BLOCK_NONE,
@@ -22259,55 +22259,6 @@ const machine_t machines[] = {
 
     /* 440BX */
     /* Has a Winbond W83977EF Super I/O chip with on-chip KBC with AMIKey-2 KBC
-       firmware. */
-    {
-        .name              = "[i440BX] ABIT AB-BF6",
-        .internal_name     = "bf6",
-        .type              = MACHINE_TYPE_SLOT1,
-        .chipset           = MACHINE_CHIPSET_INTEL_440BX,
-        .init              = machine_at_bf6_init,
-        .p1_handler        = machine_generic_p1_handler,
-        .gpio_handler      = NULL,
-        .available_flag    = MACHINE_AVAILABLE,
-        .gpio_acpi_handler = NULL,
-        .cpu               = {
-            .package     = CPU_PKG_SLOT1,
-            .block       = CPU_BLOCK_NONE,
-            .min_bus     = 66666667,
-            .max_bus     = 133333333,
-            .min_voltage = 1800,
-            .max_voltage = 3500,
-            .min_multi   = 1.5,
-            .max_multi   = 8.0
-        },
-        .bus_flags = MACHINE_PS2_AGP | MACHINE_BUS_USB,
-        .flags     = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
-        .ram       = {
-            .min  = 8192,
-            .max  = 786432,
-            .step = 8192
-        },
-        .nvrmask                  = 255,
-        .jumpered_ecp_dma         = 0,
-        .default_jumpered_ecp_dma = -1,
-        .kbc_device               = NULL,
-        .kbc_params               = 0x00000000,
-        .nvr_device               = NULL,
-        .nvr_params               = 0x00000000,
-        .sio_device               = NULL,
-        .sio_params               = 0x00000000,
-        .kbc_p1                   = 0x00000cf0,
-        .gpio                     = 0xffffffff,
-        .gpio_acpi                = 0xffffffff,
-        .device                   = NULL,
-        .kbd_device               = NULL,
-        .fdc_device               = NULL,
-        .vid_device               = NULL,
-        .snd_device               = NULL,
-        .net_device               = NULL,
-        .aliases                  = { "" }
-    },
-    /* Has a Winbond W83977EF Super I/O chip with on-chip KBC with AMIKey-2 KBC
        firmware and an on-board HighPoint HPT366 IDE controller. */
     {
         .name              = "[i440BX] ABIT AB-BE6-II",
@@ -22349,6 +22300,55 @@ const machine_t machines[] = {
         .gpio                     = 0xffffffff,
         .gpio_acpi                = 0xffffffff,
         .device                   = &be6ii_device,
+        .kbd_device               = NULL,
+        .fdc_device               = NULL,
+        .vid_device               = NULL,
+        .snd_device               = NULL,
+        .net_device               = NULL,
+        .aliases                  = { "" }
+    },
+    /* Has a Winbond W83977EF Super I/O chip with on-chip KBC with AMIKey-2 KBC
+       firmware. */
+    {
+        .name              = "[i440BX] ABIT AB-BF6",
+        .internal_name     = "bf6",
+        .type              = MACHINE_TYPE_SLOT1,
+        .chipset           = MACHINE_CHIPSET_INTEL_440BX,
+        .init              = machine_at_bf6_init,
+        .p1_handler        = machine_generic_p1_handler,
+        .gpio_handler      = NULL,
+        .available_flag    = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu               = {
+            .package     = CPU_PKG_SLOT1,
+            .block       = CPU_BLOCK_NONE,
+            .min_bus     = 66666667,
+            .max_bus     = 133333333,
+            .min_voltage = 1800,
+            .max_voltage = 3500,
+            .min_multi   = 1.5,
+            .max_multi   = 8.0
+        },
+        .bus_flags = MACHINE_PS2_AGP | MACHINE_BUS_USB,
+        .flags     = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
+        .ram       = {
+            .min  = 8192,
+            .max  = 786432,
+            .step = 8192
+        },
+        .nvrmask                  = 255,
+        .jumpered_ecp_dma         = 0,
+        .default_jumpered_ecp_dma = -1,
+        .kbc_device               = NULL,
+        .kbc_params               = 0x00000000,
+        .nvr_device               = NULL,
+        .nvr_params               = 0x00000000,
+        .sio_device               = NULL,
+        .sio_params               = 0x00000000,
+        .kbc_p1                   = 0x00000cf0,
+        .gpio                     = 0xffffffff,
+        .gpio_acpi                = 0xffffffff,
+        .device                   = NULL,
         .kbd_device               = NULL,
         .fdc_device               = NULL,
         .vid_device               = NULL,

--- a/src/network/net_i8255x.c
+++ b/src/network/net_i8255x.c
@@ -2385,7 +2385,7 @@ static const device_config_t i8255xp_config[] = {
 // clang-format on
 
 const device_t i82557_device = {
-    .name          = "Intel PRO/100",
+    .name          = "Intel EtherExpress PRO/100B",
     .internal_name = "i82557",
     .flags         = DEVICE_PCI,
     .local         = 0xff,

--- a/src/network/net_i8255x.c
+++ b/src/network/net_i8255x.c
@@ -2385,7 +2385,7 @@ static const device_config_t i8255xp_config[] = {
 // clang-format on
 
 const device_t i82557_device = {
-    .name          = "Intel EtherExpress PRO/100B",
+    .name          = "Intel PRO/100",
     .internal_name = "i82557",
     .flags         = DEVICE_PCI,
     .local         = 0xff,
@@ -2395,7 +2395,8 @@ const device_t i82557_device = {
     .available     = NULL,
     .speed_changed = NULL,
     .force_redraw  = NULL,
-    .config        = i82557_config
+    .config        = i82557_config,
+    .alias         = "Intel EtherExpress PRO/100B"
 };
 
 const device_t i82558_device = {

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -121,11 +121,11 @@ static const NETWORK_CARD net_cards[] = {
     { &dec_tulip_21040_device     },
     { &dec_tulip_21140_device     },
     { &dec_tulip_device           },
+    { &i82557_device              },
+    { &i82558_device              },
     { &rtl8029as_device           },
     { &rtl8139c_plus_device       },
     { &smc_epic100_device         },
-    { &i82557_device              },
-    { &i82558_device              },
     { NULL                        }
     // clang-format on
 };


### PR DESCRIPTION
Summary
=======
This PR makes the following:
1. Shortened the name for IBM XT (Inboard 386/PC) and correct the notes.
2. Alphabetize ABit AB-BE6-II.
3. Alphabetize Intel PRO/100 series of network cards.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
