### PR TITLE
ESS bugfixes

### DIFF
--- a/src/include/86box/snd_sb_dsp.h
+++ b/src/include/86box/snd_sb_dsp.h
@@ -191,6 +191,9 @@ typedef struct sb_dsp_t {
     uint8_t   espcm_table_index;       /* used for ESPCM_3 */
     uint8_t   espcm_last_value;        /* used for ESPCM_3 */
 
+    /* ESS ES1688 switchable DSP version */
+    uint8_t   ess_dsp_v2_mode;
+
     /* OPL3-SA switchable DSP version */
     uint8_t   opl3sa_dsp_ver;
 

--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -1925,7 +1925,7 @@ gus_extreme_init(UNUSED(const device_t *info))
     ess_mixer_reset(gus->ess);
 
     gus->ess->mixer_enabled = 1;
-    gus->ess->mixer_ess.regs[0x40] = 0x0a;
+    gus->ess->mixer_ess.regs[0x40] = 0x02;
     sound_add_handler(sb_get_buffer_ess, gus->ess);
     music_add_handler(sb_get_music_buffer_ess, gus->ess);
     sound_set_cd_audio_filter(ess_filter_cd_audio, gus->ess);

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -5455,6 +5455,9 @@ ess_x688_init(UNUSED(const device_t *info))
     sb_dsp_setdma16_supported(&ess->dsp, 0);
     ess_mixer_reset(ess);
 
+    if ((ess->dsp.sb_subtype == SB_SUBTYPE_ESS_ES1688) && (device_get_config_int("dspver") == 1))
+        ess->dsp.ess_dsp_v2_mode = 1;
+
     /* DSP I/O handler is activated in sb_dsp_setaddr */
     io_sethandler(addr, 0x0004,
                   ess->opl.read, NULL, NULL,
@@ -7820,6 +7823,21 @@ static const device_config_t ess_1688_config[] = {
             { .description = "0x168, IRQ 9",  .value = 0x9168 },
             { .description = "0x168, IRQ 10", .value = 0xa168 },
             { .description = ""                               }
+        },
+        .bios           = { { 0 } }
+    },
+    {
+        .name           = "dspver",
+        .description    = "DSP Version",
+        .type           = CONFIG_SELECTION,
+        .default_string = NULL,
+        .default_int    = 0,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .selection      = {
+            { .description = "3.01",  .value =  0 },
+            { .description = "2.01",  .value =  1 },
+            { .description = ""                   }
         },
         .bios           = { { 0 } }
     },

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -5491,7 +5491,7 @@ ess_x688_init(UNUSED(const device_t *info))
                   ess);
 
     ess->mixer_enabled = 1;
-    ess->mixer_ess.regs[0x40] = 0x0a;
+    ess->mixer_ess.regs[0x40] = 0x02;
     io_sethandler(addr + 4, 0x0002,
                   ess_mixer_read, NULL, NULL,
                   ess_mixer_write, NULL, NULL,
@@ -5738,7 +5738,7 @@ ess_1x88_onboard_init(const device_t *info)
     /* ES1788/1888/1887 starts in a disabled state */
 
     ess->mixer_enabled = 1;
-    ess->mixer_ess.regs[0x40] = 0x0a;
+    ess->mixer_ess.regs[0x40] = 0x02;
     sound_add_handler(sb_get_buffer_ess, ess);
     music_add_handler(sb_get_music_buffer_ess, ess);
     sound_set_cd_audio_filter(ess_filter_cd_audio, ess);

--- a/src/sound/snd_sb_dsp.c
+++ b/src/sound/snd_sb_dsp.c
@@ -882,6 +882,8 @@ sb_ess_update_irq_drq_readback_regs(sb_dsp_t *dsp, bool legacy)
     if (legacy) {
         t |= 0x80;
     }
+    if (dsp->sb_irqnum != 0)
+        t |= 0x10;
     switch (dsp->sb_irqnum) {
         default:
             break;
@@ -951,7 +953,9 @@ sb_dsp_setirq(sb_dsp_t *dsp, int irq)
     if (IS_ESS(dsp)) {
         sb_ess_update_irq_drq_readback_regs(dsp, true);
 
-        ESSreg(0xB1) = (ESSreg(0xB1) & 0xEF) | 0x10;
+        ESSreg(0xB1) = (ESSreg(0xB1) & 0xEF);
+        if (dsp->sb_irqnum != 0)
+            ESSreg(0xB1) |= 0x10;
     }
 }
 

--- a/src/sound/snd_sb_dsp.c
+++ b/src/sound/snd_sb_dsp.c
@@ -1776,8 +1776,14 @@ sb_exec_command(sb_dsp_t *dsp)
                    0x03 0x01 (Sound Blaster Pro compatibility) confirmed by both the
                    ES1888 datasheet and the probing of the real ES688 and ES1688 cards.
                  */
-                sb_add_data(dsp, 0x3);
-                sb_add_data(dsp, 0x1);
+                /* Some ES1688 ISA cards have a jumper to set DSP version 2.01 */
+                if (dsp->ess_dsp_v2_mode == 1) {
+                    sb_add_data(dsp, 0x2);
+                    sb_add_data(dsp, 0x1);
+                } else {
+                    sb_add_data(dsp, 0x3);
+                    sb_add_data(dsp, 0x1);
+                }
                 break;
             }
             if (IS_AZTECH(dsp)) {


### PR DESCRIPTION
Summary
=======
Make the following changes to the ESS chips:
- Correct the default MPU401 port to match real hardware (bit 3 of mixer register 40h should not be set at power-on)
- Only set the IRQ enable bit of register B1h when a valid IRQ is set fixing an IRQ conflict message that appears on Read-Sequence-Key configured ES1x88 chips when running ESSCFG
- Implemented the DSP version jumper as seen on some ES1688 cards

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
