### PR TITLE
Translations update from 86Box Weblate

### DIFF
--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2026-07-31 15:40+0000\n"
+"PO-Revision-Date: 2026-08-10 21:47+0000\n"
 "Last-Translator: Alexander Babikov <lemondrops358@gmail.com>\n"
 "Language-Team: Russian <https://weblate.86box.net/projects/86box/86box/ru/>\n"
 "Language: ru-RU\n"
@@ -842,7 +842,7 @@ msgid "Ports (COM & LPT)"
 msgstr "Порты (COM и LPT)"
 
 msgid "Port"
-msgstr ""
+msgstr "Порт"
 
 msgid "Ports"
 msgstr "Порты"
@@ -2258,7 +2258,7 @@ msgid "Host ID"
 msgstr "Идентификатор хоста"
 
 msgid "Host"
-msgstr ""
+msgstr "Хост"
 
 msgid "FDC Address"
 msgstr "Адрес FDC"


### PR DESCRIPTION
Translations update from [86Box Weblate](https://weblate.86box.net) for [86Box/86Box](https://weblate.86box.net/projects/86box/86box/).



Current translation status:

![Weblate translation status](https://weblate.86box.net/widget/86box/86box/horizontal-auto.svg)