### PR TITLE
Fix MegaEM 3.x on GUS MAX

### DIFF
--- a/src/include/86box/snd_ad1848.h
+++ b/src/include/86box/snd_ad1848.h
@@ -48,6 +48,7 @@ typedef struct ad1848_t {
     uint8_t opti930_mode2;
 
     int     count;
+    int     rec_count;
     uint8_t trd;
     uint8_t mce;
     uint8_t wten : 1;
@@ -63,8 +64,10 @@ typedef struct ad1848_t {
     uint8_t wave_vol_mask;
 
     uint8_t enable : 1;
+    uint8_t rec_enable : 1;
     uint8_t irq    : 4;
     uint8_t dma    : 3;
+    uint8_t dma2   : 3;
     int     adpcm_predictor[2];
     int16_t adpcm_step_index[2];
     int     freq;
@@ -75,6 +78,7 @@ typedef struct ad1848_t {
     uint32_t dma_data;
 
     pc_timer_t timer_count;
+    pc_timer_t rec_timer_count;
     uint64_t   timer_latch;
 
     pc_timer_t cs4231a_irq_timer;
@@ -89,6 +93,7 @@ typedef struct ad1848_t {
 
 extern void ad1848_setirq(ad1848_t *ad1848, int irq);
 extern void ad1848_setdma(ad1848_t *ad1848, int dma);
+extern void ad1848_setdma2(ad1848_t *ad1848, int dma);
 extern void ad1848_updatevolmask(ad1848_t *ad1848);
 
 extern uint8_t ad1848_read(uint16_t addr, void *priv);

--- a/src/sound/snd_ad1848.c
+++ b/src/sound/snd_ad1848.c
@@ -88,6 +88,13 @@ ad1848_setdma(ad1848_t *ad1848, int newdma)
 }
 
 void
+ad1848_setdma2(ad1848_t *ad1848, int newdma)
+{
+    ad1848_log("AD1848: setdma2(%d)\n", newdma);
+    ad1848->dma2 = newdma;
+}
+
+void
 ad1848_updatevolmask(ad1848_t *ad1848)
 {
     if ((ad1848->type == AD1848_TYPE_CS4236B) && !(ad1848->xregs[4] & 0x10) && !ad1848->wten)
@@ -333,10 +340,23 @@ ad1848_write(uint16_t addr, uint8_t val, void *priv)
                             timer_set_delay_u64(&ad1848->timer_count, TIMER_USEC);
                     }
                     ad1848->enable = ((val & 0x41) == 0x01);
+                    if (!ad1848->rec_enable && (val & 0x42) == 0x02) {
+                        ad1848->adpcm_pos = 0;
+                        ad1848->adpcm_predictor[0] = ad1848->adpcm_predictor[1] = 0;
+                        ad1848->adpcm_step_index[0] = ad1848->adpcm_step_index[1] = 0;
+                        ad1848->dma_ff = 0;
+                        if (ad1848->timer_latch)
+                            timer_set_delay_u64(&ad1848->rec_timer_count, ad1848->timer_latch);
+                        else
+                            timer_set_delay_u64(&ad1848->rec_timer_count, TIMER_USEC);
+                    }
+                    ad1848->rec_enable = ((val & 0x42) == 0x02);
                     if (!ad1848->enable) {
                         timer_disable(&ad1848->timer_count);
                         ad1848->out_l = ad1848->out_r = 0;
                     }
+                    if (!ad1848->rec_enable)
+                        timer_disable(&ad1848->rec_timer_count);
                     break;
 
                 case 11:
@@ -356,6 +376,9 @@ ad1848_write(uint16_t addr, uint8_t val, void *priv)
 
                 case 14:
                     ad1848->count = ad1848->regs[15] | (val << 8);
+                    /* Record and playback counters are shared in MODE1 */
+                    if ((!((ad1848->regs[12] & 0x40) && (ad1848->type >= AD1848_TYPE_CS4231)) && !((ad1848->type == AD1848_TYPE_OPTI930) && (ad1848->opti930_mode2))) || (ad1848->regs[9] & 0x04))
+                        ad1848->rec_count = ad1848->count;
                     break;
 
                 case 16:
@@ -531,6 +554,10 @@ readonly_x:
                         goto readonly_i;
                     break;
 
+                case 30:
+                    ad1848->rec_count = ad1848->regs[31] | (val << 8);
+                    break;
+
                 default:
                     break;
             }
@@ -671,6 +698,159 @@ ad1848_process_adpcm(ad1848_t *ad1848, int channel)
     ad1848->adpcm_step_index[channel] = step_index;
 
     return (int16_t) predictor;
+}
+
+static void
+ad1848_input_poll(void *priv)
+{
+    ad1848_t *ad1848 = (ad1848_t *) priv;
+
+    uint8_t mode2_en   = ((ad1848->regs[12] & 0x40) && (ad1848->type >= AD1848_TYPE_CS4231)) || ((ad1848->type == AD1848_TYPE_OPTI930) && (ad1848->opti930_mode2));
+    uint8_t fullduplex = mode2_en && !(ad1848->regs[9] & 0x04);
+    uint8_t channel    = fullduplex ? ad1848->dma2 : ad1848->dma;
+    uint8_t rec_format = mode2_en ? (ad1848->regs[28] & ad1848->fmt_mask) : (ad1848->regs[8] & ad1848->fmt_mask);
+
+    if (ad1848->timer_latch)
+        timer_advance_u64(&ad1848->rec_timer_count, ad1848->timer_latch);
+    else
+        timer_advance_u64(&ad1848->rec_timer_count, TIMER_USEC * 1000);
+
+    if (ad1848->rec_enable) {
+
+        switch (rec_format) {
+            case 0x00: /* Mono, 8-bit PCM */
+                if (channel >= 4)
+                    dma_channel_write(channel, 0x0000);
+                else
+                    dma_channel_write(channel, 0x00);
+                break;
+
+            case 0x10: /* Stereo, 8-bit PCM */
+                if (channel >= 4)
+                    dma_channel_write(channel, 0x0000);
+                else {
+                    dma_channel_write(channel, 0x00);
+                    dma_channel_write(channel, 0x00);
+                }
+                break;
+
+            case 0x20: /* Mono, 8-bit Mu-Law */
+                if (channel >= 4)
+                    dma_channel_write(channel, 0x0000);
+                else
+                    dma_channel_write(channel, 0x00);
+                break;
+
+            case 0x30: /* Stereo, 8-bit Mu-Law */
+                if (channel >= 4)
+                    dma_channel_write(channel, 0x0000);
+                else {
+                    dma_channel_write(channel, 0x00);
+                    dma_channel_write(channel, 0x00);
+                }
+                break;
+
+            case 0x40: /* Mono, 16-bit PCM little endian */
+                if (channel >= 4)
+                    dma_channel_write(channel, 0x0000);
+                else {
+                    dma_channel_write(channel, 0x00);
+                    dma_channel_write(channel, 0x00);
+                }
+                break;
+
+            case 0x50: /* Stereo, 16-bit PCM little endian */
+                if (channel >= 4) {
+                    dma_channel_write(channel, 0x0000);
+                    dma_channel_write(channel, 0x0000);
+                } else {
+                    dma_channel_write(channel, 0x00);
+                    dma_channel_write(channel, 0x00);
+                    dma_channel_write(channel, 0x00);
+                    dma_channel_write(channel, 0x00);
+                }
+                break;
+
+            case 0x60: /* Mono, 8-bit A-Law */
+                if (channel >= 4)
+                    dma_channel_write(channel, 0x0000);
+                else
+                    dma_channel_write(channel, 0x00);
+                break;
+
+            case 0x70: /* Stereo, 8-bit A-Law */
+                if (channel >= 4)
+                    dma_channel_write(channel, 0x0000);
+                else {
+                    dma_channel_write(channel, 0x00);
+                    dma_channel_write(channel, 0x00);
+                }
+                break;
+
+                /* 0x80 and 0x90 reserved */
+
+            case 0xa0: /* Mono, 4-bit ADPCM */
+                if (channel >= 4)
+                    dma_channel_write(channel, 0x0000);
+                else
+                    dma_channel_write(channel, 0x00);
+                break;
+
+            case 0xb0: /* Stereo, 4-bit ADPCM */
+                if (channel >= 4)
+                    dma_channel_write(channel, 0x0000);
+                else {
+                    dma_channel_write(channel, 0x00);
+                    dma_channel_write(channel, 0x00);
+                }
+                break;
+
+            case 0xc0: /* Mono, 16-bit PCM big endian */
+                if (channel >= 4)
+                    dma_channel_write(channel, 0x0000);
+                else {
+                    dma_channel_write(channel, 0x00);
+                    dma_channel_write(channel, 0x00);
+                }
+                break;
+
+            case 0xd0: /* Stereo, 16-bit PCM big endian */
+                if (channel >= 4) {
+                    dma_channel_write(channel, 0x0000);
+                    dma_channel_write(channel, 0x0000);
+                } else {
+                    dma_channel_write(channel, 0x00);
+                    dma_channel_write(channel, 0x00);
+                    dma_channel_write(channel, 0x00);
+                    dma_channel_write(channel, 0x00);
+                }
+                break;
+
+                /* 0xe0 and 0xf0 reserved */
+
+            default:
+                break;
+        }
+
+        if (ad1848->rec_count < 0) {
+            if (fullduplex)
+                ad1848->rec_count = ad1848->regs[31] | (ad1848->regs[30] << 8);
+            else
+                ad1848->rec_count = ad1848->regs[15] | (ad1848->regs[14] << 8);
+            ad1848->adpcm_pos = 0;
+            if (!(ad1848->status & 0x01)) {
+                ad1848->status |= 0x01;
+                ad1848->regs[24] |= 0x20;
+            }
+            if (ad1848->regs[10] & 2)
+                picint(1 << ad1848->irq);
+            else
+                picintc(1 << ad1848->irq);
+        }
+
+        if (!(ad1848->adpcm_pos & 7)) /* ADPCM counts down every 4 bytes */
+            ad1848->rec_count--;
+    }
 }
 
 static void
@@ -965,6 +1145,7 @@ ad1848_init(ad1848_t *ad1848, uint8_t type)
     ad1848->type = type;
 
     timer_add(&ad1848->timer_count, ad1848_poll, ad1848, 0);
+    timer_add(&ad1848->rec_timer_count, ad1848_input_poll, ad1848, 0);
 
     if ((ad1848->type != AD1848_TYPE_DEFAULT) && (ad1848->type != AD1848_TYPE_CS4248))
         sound_set_cd_audio_filter(ad1848_filter_cd_audio, ad1848);

--- a/src/sound/snd_azt2316a.c
+++ b/src/sound/snd_azt2316a.c
@@ -195,8 +195,9 @@ aztech_log(void *priv, const char *fmt, ...)
 /*e80, 11, 1 - 530=22*/
 /*f40, 11, 1 - 530=22*/
 
-static int azt2316a_wss_dma[4] = { 0, 0, 1, 3 };
-static int azt2316a_wss_irq[8] = { 5, 7, 9, 10, 11, 12, 14, 15 }; /* W95 only uses 7-10, others may be wrong */
+static int azt2316a_wss_dma[4]  = { 0, 0, 1, 3 };
+static int azt2316a_wss_dma2[4] = { 1, 1, 0, 0 };
+static int azt2316a_wss_irq[8]  = { 5, 7, 9, 10, 11, 12, 14, 15 }; /* W95 only uses 7-10, others may be wrong */
 #if 0
 static uint16_t azt2316a_wss_addr[4] = {0x530, 0x604, 0xe80, 0xf40};
 #endif
@@ -318,6 +319,15 @@ azt2316a_wss_write(UNUSED(uint16_t addr), uint8_t val, void *priv)
     azt2316a->cur_wss_irq = azt2316a_wss_irq[(val >> 3) & 7];
     ad1848_setdma(&azt2316a->ad1848, azt2316a_wss_dma[val & 3]);
     ad1848_setirq(&azt2316a->ad1848, azt2316a_wss_irq[(val >> 3) & 7]);
+
+    /* AZT2316 supports full-duplex mode */
+    if (val & 0x04) {
+        aztech_log(azt2316a->log, "Aztech WSS: Full-duplex mode enabled\n");
+        ad1848_setdma2(&azt2316a->ad1848, azt2316a_wss_dma2[val & 3]);
+    } else {
+        aztech_log(azt2316a->log, "Aztech WSS: Full-duplex mode disabled\n");
+        ad1848_setdma2(&azt2316a->ad1848, 4);
+    }
 
     if (interrupt) {
         if (azt2316a->wss_config & 0x40) {

--- a/src/sound/snd_azt2320.c
+++ b/src/sound/snd_azt2320.c
@@ -179,6 +179,7 @@ azt2320_pnp_config_changed(uint8_t ld, isapnp_device_config_t *config, void *pri
             sb_dsp_setirq(&azt2320->sb->dsp, 0);
 
             ad1848_setdma(&azt2320->ad1848, 0);
+            ad1848_setdma2(&azt2320->ad1848, 0);
             sb_dsp_setdma8(&azt2320->sb->dsp, 0);
 
             if (config->activate) {
@@ -213,6 +214,10 @@ azt2320_pnp_config_changed(uint8_t ld, isapnp_device_config_t *config, void *pri
                     sb_dsp_setdma8(&azt2320->sb->dsp, azt2320->cur_dma);
                     ad1848_setdma(&azt2320->ad1848, azt2320->cur_wss_dma);
                     azt2320_log(azt2320->log, "Updated WSS Playback/SB DMA to %04X\n", azt2320->cur_dma);
+                }
+                if (config->dma[1].dma != ISAPNP_DMA_DISABLED) {
+                    ad1848_setdma2(&azt2320->ad1848, config->dma[1].dma);
+                    azt2320_log(azt2320->log, "Updated WSS Capture DMA to %04X\n", config->dma[1].dma);
                 }
             }
             break;

--- a/src/sound/snd_cs423x.c
+++ b/src/sound/snd_cs423x.c
@@ -755,6 +755,7 @@ cs423x_pnp_config_changed(uint8_t ld, isapnp_device_config_t *config, void *priv
             sb_dsp_setirq(&dev->sb->dsp, 0);
 
             ad1848_setdma(&dev->ad1848, 0);
+            ad1848_setdma2(&dev->ad1848, 0);
             sb_dsp_setdma8(&dev->sb->dsp, 0);
 
             if (config->activate) {
@@ -787,6 +788,8 @@ cs423x_pnp_config_changed(uint8_t ld, isapnp_device_config_t *config, void *priv
                     ad1848_setdma(&dev->ad1848, config->dma[0].dma);
                     sb_dsp_setdma8(&dev->sb->dsp, config->dma[0].dma);
                 }
+                if (config->dma[1].dma != ISAPNP_DMA_DISABLED)
+                    ad1848_setdma2(&dev->ad1848, config->dma[1].dma);
             }
             break;
 

--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -810,8 +810,11 @@ gus_write(uint16_t addr, uint8_t val, void *priv)
                         gus_log(gus->log, "GUS DMA changed: New DMA1 = %i, New DMA2 = %i\n", gus->dma, gus->dma2);
                         gus_log(gus->log, "GUS DMA register val = %02X\n", val);
 
-                        if (gus->type == GUS_MAX)
+                        if (gus->type == GUS_MAX) {
                             ad1848_setdma(&gus->ad1848, gus->dma2);
+                            if (gus->dma2 != gus->dma)
+                                ad1848_setdma2(&gus->ad1848, gus->dma);
+                        }
 
                         /* Bit 7 of this register fires/clears the secondary IRQ when in combine IRQs mode */
                         if (val & 0x80)

--- a/src/sound/snd_optimc.c
+++ b/src/sound/snd_optimc.c
@@ -62,7 +62,8 @@ optimc_log(void *priv, const char *fmt, ...)
 #    define optimc_log(fmt, ...)
 #endif
 
-static int optimc_wss_dma[4] = { 0, 0, 1, 3 };
+static int optimc_wss_dma[4]  = { 0, 0, 1, 3 };
+static int optimc_wss_dma2[4] = { 1, 1, 0, 0 };
 static int optimc_wss_irq[8] = { 5, 7, 9, 10, 11, 12, 14, 15 };
 static int opti930_wss_irq[8] = { 0, 7, 9, 10, 11, 5, 0, 0 };
 static double opti930_vols_5bits[32];
@@ -224,6 +225,15 @@ optimc_wss_write(UNUSED(uint16_t addr), uint8_t val, void *priv)
         ad1848_setirq(&optimc->ad1848, optimc_wss_irq[(val >> 3) & 7]);
     else
         ad1848_setirq(&optimc->ad1848, opti930_wss_irq[(val >> 3) & 7]);
+
+    /* OPTi 929/93x supports full-duplex mode */
+    if (val & 0x04) {
+        optimc_log(optimc->log, "OPTi WSS: Full-duplex mode enabled\n");
+        ad1848_setdma2(&optimc->ad1848, optimc_wss_dma2[val & 3]);
+    } else {
+        optimc_log(optimc->log, "OPTi WSS: Full-duplex mode disabled\n");
+        ad1848_setdma2(&optimc->ad1848, 4);
+    }
 }
 
 static void
@@ -411,6 +421,15 @@ opti930_reg_write(uint16_t addr, uint8_t val, void *priv)
                     /* The OPTi 82c930 driver on the NEC Ready preloads requires this to function properly */
                     ad1848_setdma(&optimc->ad1848, optimc_wss_dma[val & 3]);
                     ad1848_setirq(&optimc->ad1848, opti930_wss_irq[(val >> 3) & 7]);
+
+                    /* OPTi 929/93x supports full-duplex mode */
+                    if (val & 0x04) {
+                        optimc_log(optimc->log, "OPTi WSS: Full-duplex mode enabled\n");
+                        ad1848_setdma2(&optimc->ad1848, optimc_wss_dma2[val & 3]);
+                    } else {
+                        optimc_log(optimc->log, "OPTi WSS: Full-duplex mode disabled\n");
+                        ad1848_setdma2(&optimc->ad1848, 4);
+                    }
                 }
                 break;
             case 3: /* MC4 */
@@ -941,6 +960,7 @@ opti931_pnp_config_changed(uint8_t ld, isapnp_device_config_t *config, void *pri
             sb_dsp_setirq(&optimc->sb->dsp, 0);
 
             ad1848_setdma(&optimc->ad1848, 0);
+            ad1848_setdma2(&optimc->ad1848, 0);
             sb_dsp_setdma8(&optimc->sb->dsp, 0);
 
             if (config->activate) {
@@ -981,6 +1001,10 @@ opti931_pnp_config_changed(uint8_t ld, isapnp_device_config_t *config, void *pri
                     sb_dsp_setdma8(&optimc->sb->dsp, optimc->cur_dma);
                     ad1848_setdma(&optimc->ad1848, optimc->cur_wss_dma);
                     optimc_log(optimc->log, "Updated WSS Playback/SB DMA to %04X\n", optimc->cur_dma);
+                }
+                if (config->dma[1].dma != ISAPNP_DMA_DISABLED) {
+                    ad1848_setdma2(&optimc->ad1848, config->dma[1].dma);
+                    optimc_log(optimc->log, "Updated WSS Capture DMA to %04X\n", config->dma[1].dma);
                 }
             }
             break;

--- a/src/sound/snd_ymf701.c
+++ b/src/sound/snd_ymf701.c
@@ -57,8 +57,9 @@ ymf701_log(void *priv, const char *fmt, ...)
 #    define ymf701_log(fmt, ...)
 #endif
 
-static int ymf701_wss_dma[4] = { 0, 0, 1, 3 };
-static int ymf701_wss_irq[8] = { 0, 7, 9, 10, 11, 0, 0, 0 };
+static int ymf701_wss_dma[4]  = { 0, 0, 1, 3 };
+static int ymf701_wss_dma2[4] = { 1, 1, 0, 0 };
+static int ymf701_wss_irq[8]  = { 0, 7, 9, 10, 11, 0, 0, 0 };
 
 typedef struct ymf701_t {
     uint8_t type;
@@ -140,6 +141,15 @@ ymf701_wss_write(uint16_t addr, uint8_t val, void *priv)
             ad1848_setirq(&ymf701->ad1848, ymf701_wss_irq[(val >> 3) & 7]);
             ymf701_log(ymf701->log, "Set IRQ to %02X\n", ymf701->cur_wss_irq);
             ymf701_log(ymf701->log, "Set DMA to %02X\n", ymf701->cur_wss_dma);
+
+            /* YMF701 supports full-duplex mode */
+            if (val & 0x04) {
+                ymf701_log(ymf701->log, "WSS: Full-duplex mode enabled\n");
+                ad1848_setdma2(&ymf701->ad1848, ymf701_wss_dma2[val & 3]);
+            } else {
+                ymf701_log(ymf701->log, "WSS: Full-duplex mode disabled\n");
+                ad1848_setdma2(&ymf701->ad1848, 4);
+            }
             break;
         default:
             break;

--- a/src/sound/snd_ymf71x.c
+++ b/src/sound/snd_ymf71x.c
@@ -432,6 +432,7 @@ ymf71x_pnp_config_changed(uint8_t ld, isapnp_device_config_t *config, void *priv
             sb_dsp_setirq(&ymf71x->sb->dsp, 0);
 
             ad1848_setdma(&ymf71x->ad1848, 0);
+            ad1848_setdma2(&ymf71x->ad1848, 0);
             sb_dsp_setdma8(&ymf71x->sb->dsp, 0);
 
             if (config->activate) {
@@ -510,7 +511,11 @@ ymf71x_pnp_config_changed(uint8_t ld, isapnp_device_config_t *config, void *priv
                     if (ymf71x->regs[0x06] & 0x01) {
                         ad1848_setdma(&ymf71x->ad1848, config->dma[0].dma);
                         ymf71x->cur_wss_dma = config->dma[0].dma;
-                        ymf71x_log(ymf71x->log, "Setting WSS DMA to DMA-A (%04X)\n", ymf71x->cur_wss_dma);
+                        ymf71x_log(ymf71x->log, "Setting WSS playback DMA to DMA-A (%04X)\n", ymf71x->cur_wss_dma);
+                    }
+                    if (ymf71x->regs[0x06] & 0x02) {
+                        ad1848_setdma2(&ymf71x->ad1848, config->dma[0].dma);
+                        ymf71x_log(ymf71x->log, "Setting WSS capture DMA to DMA-A (%04X)\n", config->dma[0].dma);
                     }
                     if (ymf71x->regs[0x06] & 0x04) {
                         sb_dsp_setdma8(&ymf71x->sb->dsp, config->dma[0].dma);
@@ -523,7 +528,11 @@ ymf71x_pnp_config_changed(uint8_t ld, isapnp_device_config_t *config, void *priv
                     if (ymf71x->regs[0x06] & 0x10) {
                         ad1848_setdma(&ymf71x->ad1848, config->dma[1].dma);
                         ymf71x->cur_wss_dma = config->dma[1].dma;
-                        ymf71x_log(ymf71x->log, "Setting WSS DMA to DMA-B (%04X)\n", ymf71x->cur_wss_dma);
+                        ymf71x_log(ymf71x->log, "Setting WSS playback DMA to DMA-B (%04X)\n", ymf71x->cur_wss_dma);
+                    }
+                    if (ymf71x->regs[0x06] & 0x20) {
+                        ad1848_setdma2(&ymf71x->ad1848, config->dma[1].dma);
+                        ymf71x_log(ymf71x->log, "Setting WSS capture DMA to DMA-B (%04X)\n", config->dma[1].dma);
                     }
                     if (ymf71x->regs[0x06] & 0x40) {
                         sb_dsp_setdma8(&ymf71x->sb->dsp, config->dma[1].dma);


### PR DESCRIPTION
Summary
=======
Implement an ADC/audio capture stub for AD1848/CS423x-based sound cards: This fixes the DMA conflict message when running MegaEM 3.x on a GUS MAX.

Also implement secondary DMA configuration on full-duplex capable WSS-based sound cards.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
