### PR TITLE
Translations update from 86Box Weblate

### DIFF
--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2026-08-03 18:03+0000\n"
+"PO-Revision-Date: 2026-08-11 05:09+0000\n"
 "Last-Translator: bozoscum <bozoscum@users.noreply.weblate.86box.net>\n"
 "Language-Team: Chinese (Traditional Han script) <https://weblate.86box.net/"
 "projects/86box/86box/zh_Hant/>\n"
@@ -847,7 +847,7 @@ msgid "Ports (COM & LPT)"
 msgstr "連接埠 (COM 和 LPT)"
 
 msgid "Port"
-msgstr ""
+msgstr "英語 (美國)"
 
 msgid "Ports"
 msgstr "連接埠"
@@ -2252,7 +2252,7 @@ msgid "Host ID"
 msgstr "主機 ID"
 
 msgid "Host"
-msgstr ""
+msgstr "主機"
 
 msgid "FDC Address"
 msgstr "FDC 位址"


### PR DESCRIPTION
Translations update from [86Box Weblate](https://weblate.86box.net) for [86Box/86Box](https://weblate.86box.net/projects/86box/86box/).



Current translation status:

![Weblate translation status](https://weblate.86box.net/widget/86box/86box/horizontal-auto.svg)