### PR TITLE
Translations update from 86Box Weblate

### DIFF
--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2026-08-05 08:40+0000\n"
-"Last-Translator: BlueRain-debug <bluerain.debug@gmail.com>\n"
+"PO-Revision-Date: 2026-08-11 07:15+0000\n"
+"Last-Translator: Canadew <chun-awa@outlook.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://weblate.86box.net/"
 "projects/86box/86box/zh_Hans/>\n"
 "Language: zh-CN\n"
@@ -842,7 +842,7 @@ msgid "Ports (COM & LPT)"
 msgstr "端口 (COM 和 LPT)"
 
 msgid "Port"
-msgstr ""
+msgstr "端口"
 
 msgid "Ports"
 msgstr "端口"
@@ -2245,7 +2245,7 @@ msgid "Host ID"
 msgstr "主机 ID"
 
 msgid "Host"
-msgstr ""
+msgstr "主机"
 
 msgid "FDC Address"
 msgstr "FDC 地址"


### PR DESCRIPTION
Translations update from [86Box Weblate](https://weblate.86box.net) for [86Box/86Box](https://weblate.86box.net/projects/86box/86box/).



Current translation status:

![Weblate translation status](https://weblate.86box.net/widget/86box/86box/horizontal-auto.svg)