### PR TITLE
IBM PS/2: Fix Model 80 Reference Disk diagnostics

### DIFF
--- a/src/cpu/386_common.c
+++ b/src/cpu/386_common.c
@@ -1778,6 +1778,14 @@ checkio(uint32_t port, int mask)
     }
 
     t += (port >> 3UL);
+
+    /* The 80386 truncates the I/O bitmap byte offset to 16 bits.  In
+       particular, an I/O map base of FFFFh wraps accesses to low TSS
+       offsets.  IBM's 386 planar diagnostics explicitly exercise this
+       behavior.  Later CPUs use the full intermediate offset. */
+    if ((cpu_s->cpu_type == CPU_386SX) || (cpu_s->cpu_type == CPU_386DX))
+        t &= 0xffff;
+
     mask <<= (port & 7);
     if (UNLIKELY(mask & 0xff00)) {
         if (LIKELY(t < tr.limit))

--- a/src/device/serial.c
+++ b/src/device/serial.c
@@ -246,6 +246,27 @@ write_fifo(serial_t *dev, uint8_t dat)
     dev->out_new = (uint16_t) dat;
 }
 
+static void
+serial_receive_loopback_break(serial_t *dev)
+{
+    /* In diagnostic loopback the transmitter feeds the receiver internally.
+       Asserting Break therefore receives a zero character with the parity,
+       framing, and break-error indications set. */
+    if (dev->fifo_enabled)
+        fifo_write_evt(0x00, dev->rcvr_fifo);
+    else {
+        if (dev->lsr & 0x01)
+            dev->lsr |= 0x02;
+        dev->dat = 0x00;
+        dev->lsr |= 0x01;
+        dev->int_status |= SERIAL_INT_RECEIVE;
+    }
+
+    dev->lsr |= 0x1c;
+    dev->int_status |= SERIAL_INT_LSR;
+    serial_update_ints(dev);
+}
+
 void
 serial_write_fifo(serial_t *dev, uint8_t dat)
 {
@@ -503,6 +524,12 @@ serial_set_type(serial_t *dev, uint8_t type)
 }
 
 void
+serial_set_card_selected_feedback(serial_t *dev, uint8_t *reg_91)
+{
+    dev->reg_91 = reg_91;
+}
+
+void
 serial_write(uint16_t addr, uint8_t val, void *priv)
 {
     serial_t *dev = (serial_t *) priv;
@@ -510,6 +537,9 @@ serial_write(uint16_t addr, uint8_t val, void *priv)
     uint8_t   old;
 
     serial_log("UART: [%04X:%08X] Write %02X to port %02X\n", CS, cpu_state.pc, val, addr);
+
+    if (dev->reg_91 != NULL)
+        *dev->reg_91 |= 0x01;
 
     cycles -= ISA_CYCLES(8);
 
@@ -619,6 +649,8 @@ serial_write(uint16_t addr, uint8_t val, void *priv)
                 if (dev->sd && dev->sd->lcr_callback)
                     dev->sd->lcr_callback(dev, dev->sd->priv, dev->lcr);
             }
+            if (!(old & 0x40) && (val & 0x40) && (dev->mctrl & 0x10))
+                serial_receive_loopback_break(dev);
             if (((old ^ val) & 0x40) && dev->char_port.chardev.control)
                 dev->char_port.chardev.control((dev->mctrl & 0x03) | (val & 0x40), dev->char_port.chardev.priv);
             break;
@@ -722,6 +754,9 @@ serial_read(uint16_t addr, void *priv)
 {
     serial_t *dev = (serial_t *) priv;
     uint8_t   ret = 0;
+
+    if (dev->reg_91 != NULL)
+        *dev->reg_91 |= 0x01;
 
     cycles -= ISA_CYCLES(8);
 

--- a/src/disk/hdc_esdi_mca.c
+++ b/src/disk/hdc_esdi_mca.c
@@ -152,6 +152,33 @@ enum {
     ESDI_IS_INTEGRATED
 };
 
+static uint8_t
+esdi_bios_read(uint32_t addr, void *priv)
+{
+    esdi_t *dev = (esdi_t *) priv;
+
+    mca_feedback_set();
+    return rom_read(addr, &dev->bios_rom);
+}
+
+static uint16_t
+esdi_bios_readw(uint32_t addr, void *priv)
+{
+    esdi_t *dev = (esdi_t *) priv;
+
+    mca_feedback_set();
+    return rom_readw(addr, &dev->bios_rom);
+}
+
+static uint32_t
+esdi_bios_readl(uint32_t addr, void *priv)
+{
+    esdi_t *dev = (esdi_t *) priv;
+
+    mca_feedback_set();
+    return rom_readl(addr, &dev->bios_rom);
+}
+
 #define STATUS_DMA_ENA             (1 << 7)
 #define STATUS_IRQ_PENDING         (1 << 6)
 #define STATUS_CMD_IN_PROGRESS     (1 << 5)
@@ -891,16 +918,51 @@ esdi_callback(void *priv)
             break;
 
         case 0x12:
-            ESDI_ADAPTER_ONLY();
+            if (dev->cmd_dev != ATTN_DEVICE_0 &&
+                dev->cmd_dev != ATTN_DEVICE_1 &&
+                dev->cmd_dev != ATTN_HOST_ADAPTER) {
+                cmd_unsupported(dev);
+                return;
+            }
             if ((dev->status & STATUS_IRQ) || dev->irq_in_progress)
                 fatal("IRQ in progress %02x %i\n", dev->status, dev->irq_in_progress);
 
-            dev->status_len     = 2;
-            dev->status_data[0] = 0x12 | STATUS_LEN(5) | STATUS_DEVICE_HOST_ADAPTER;
+            dev->status_len     = 5;
+            dev->status_data[0] = 0x12 | STATUS_LEN(5) | dev->cmd_dev;
             dev->status_data[1] = 0;
+            dev->status_data[2] = 0;
+            dev->status_data[3] = 0;
+            dev->status_data[4] = 0;
 
             dev->status          = STATUS_IRQ | STATUS_STATUS_OUT_FULL;
-            dev->irq_status      = IRQ_HOST_ADAPTER | IRQ_CMD_COMPLETE_SUCCESS;
+            dev->irq_status      = dev->cmd_dev | IRQ_CMD_COMPLETE_SUCCESS;
+            dev->irq_in_progress = 1;
+            set_irq(dev);
+            ui_sb_update_icon(SB_HDD | HDD_BUS_ESDI, 0);
+            break;
+
+        case 0x14:
+            if (dev->cmd_dev != ATTN_DEVICE_0 &&
+                dev->cmd_dev != ATTN_DEVICE_1 &&
+                dev->cmd_dev != ATTN_HOST_ADAPTER) {
+                cmd_unsupported(dev);
+                return;
+            }
+            if ((dev->status & STATUS_IRQ) || dev->irq_in_progress)
+                fatal("IRQ in progress %02x %i\n", dev->status, dev->irq_in_progress);
+
+            /* Return the status block from the preceding command.  The
+               command's word count remains encoded in its first word even
+               after the status interface has been drained. */
+            dev->status_len = dev->status_data[0] >> 8;
+            dev->status_pos = 0;
+            if (!dev->status_len) {
+                cmd_unsupported(dev);
+                return;
+            }
+
+            dev->status          = STATUS_IRQ | STATUS_STATUS_OUT_FULL;
+            dev->irq_status      = dev->cmd_dev | IRQ_CMD_COMPLETE_SUCCESS;
             dev->irq_in_progress = 1;
             set_irq(dev);
             ui_sb_update_icon(SB_HDD | HDD_BUS_ESDI, 0);
@@ -961,7 +1023,8 @@ esdi_callback(void *priv)
             break;
 
         default:
-            fatal("BAD COMMAND %02x %i\n", dev->command, dev->cmd_dev);
+            cmd_unsupported(dev);
+            break;
     }
 }
 
@@ -970,6 +1033,8 @@ esdi_read(uint16_t port, void *priv)
 {
     esdi_t *dev = (esdi_t *) priv;
     uint8_t ret = 0x00;
+
+    mca_feedback_set();
 
     switch (port & 7) {
         case 2: /*Basic status register*/
@@ -995,6 +1060,8 @@ esdi_write(uint16_t port, uint8_t val, void *priv)
 {
     esdi_t *dev = (esdi_t *) priv;
     uint8_t old;
+
+    mca_feedback_set();
 
     esdi_mca_log("ESDI: wr(%04x, %02x)\n", port & 7, val);
 
@@ -1109,6 +1176,8 @@ esdi_readw(uint16_t port, void *priv)
     esdi_t  *dev = (esdi_t *) priv;
     uint16_t ret = 0xffff;
 
+    mca_feedback_set();
+
     switch (port & 7) {
         case 0: /*Status Interface Register*/
             if (dev->status_pos >= dev->status_len) {
@@ -1134,6 +1203,8 @@ static void
 esdi_writew(uint16_t port, uint16_t val, void *priv)
 {
     esdi_t *dev = (esdi_t *) priv;
+
+    mca_feedback_set();
 
     esdi_mca_log("ESDI: wrw(%04x, %04x)\n", port & 7, val);
 
@@ -1359,6 +1430,13 @@ esdi_init(UNUSED(const device_t *info))
         rom_init_interleaved(&dev->bios_rom,
             BIOS_FILE_H, BIOS_FILE_L,
             0xc8000, 0x4000, 0x3fff, 0, MEM_MAPPING_EXTERNAL);
+        mem_mapping_set_handler(&dev->bios_rom.mapping,
+            esdi_bios_read, esdi_bios_readw, esdi_bios_readl,
+            NULL, NULL, NULL);
+        mem_mapping_set_p(&dev->bios_rom.mapping, dev);
+        /* Card Selected Feedback is a side effect of every adapter-ROM read,
+           so reads must not bypass the handler through the direct ROM path. */
+        mem_mapping_set_exec(&dev->bios_rom.mapping, NULL);
         mem_mapping_disable(&dev->bios_rom.mapping);
     }
 

--- a/src/dma.c
+++ b/src/dma.c
@@ -59,6 +59,9 @@ static struct dma_ps2_t {
     int xfr_channel;
     int byte_ptr;
 
+    uint8_t arb_control;
+    uint8_t arb_status;
+
     int is_ps2;
 } dma_ps2;
 
@@ -350,6 +353,42 @@ dma_log(const char *fmt, ...)
 #endif
 
 static void dma_ps2_run(int channel);
+
+static void
+dma_ps2_request(int request_channel)
+{
+    int service_channel = request_channel;
+
+    /* Channel 4 is the cascade/arbitration request used to start a transfer
+       on the highest-priority unmasked DMA channel.  The Model 80 planar
+       diagnostic deliberately masks every channel before issuing B4 when it
+       tests the bus-timeout NMI; during normal DMA tests it unmasks the
+       channel to be serviced first. */
+    if (request_channel == 4) {
+        int best_level = 0x10;
+
+        service_channel = -1;
+        for (int channel = 0; channel < 8; channel++) {
+            if ((channel != 4) && !(dma_m & (1 << channel)) &&
+                ((dma[channel].arb_level & 0x0f) < best_level)) {
+                best_level      = dma[channel].arb_level & 0x0f;
+                service_channel = channel;
+            }
+        }
+    }
+
+    if (service_channel >= 0 && !(dma_m & (1 << service_channel))) {
+        dma_ps2.arb_status = (dma_ps2.arb_status & 0x60) |
+                             (dma[service_channel].arb_level & 0x0f);
+        dma_ps2_run(service_channel);
+    } else if (request_channel != 2) {
+        /* A request which no internal DMA channel accepts is presented to
+           the Micro Channel bus.  If no external master responds, the
+           central arbitration controller reports a timeout through NMI. */
+        dma_ps2.arb_status = 0x60 | (dma[request_channel].arb_level & 0x0f);
+        nmi_raise();
+    }
+}
 
 
 int
@@ -983,13 +1022,15 @@ dma_write_legacy(uint16_t addr, uint8_t val, UNUSED(void *priv))
             channel           = (val & 3);
             dma[channel].mode = val;
             if (dma_ps2.is_ps2) {
-                dma[channel].ps2_mode &= ~0x1c;
+                dma[channel].ps2_mode &= ~(DMA_PS2_AUTOINIT | DMA_PS2_XFER_MASK | DMA_PS2_DEC2);
+                if (val & 0x10)
+                    dma[channel].ps2_mode |= DMA_PS2_AUTOINIT;
                 if (val & 0x20)
-                    dma[channel].ps2_mode |= 0x10;
+                    dma[channel].ps2_mode |= DMA_PS2_DEC2;
                 if ((val & 0xc) == 8)
-                    dma[channel].ps2_mode |= 4;
+                    dma[channel].ps2_mode |= DMA_PS2_XFER_MEM_TO_IO;
                 else if ((val & 0xc) == 4)
-                    dma[channel].ps2_mode |= 0xc;
+                    dma[channel].ps2_mode |= DMA_PS2_XFER_IO_TO_MEM;
             }
             return;
 
@@ -1017,6 +1058,22 @@ dma_write_legacy(uint16_t addr, uint8_t val, UNUSED(void *priv))
 }
 
 static uint8_t
+dma_ps2_arb_read(UNUSED(uint16_t addr), UNUSED(void *priv))
+{
+    return (dma_ps2.arb_control & 0x80) | dma_ps2.arb_status;
+}
+
+static void
+dma_ps2_arb_write(UNUSED(uint16_t addr), uint8_t val, UNUSED(void *priv))
+{
+    dma_ps2.arb_control = val & 0xe0;
+
+    /* Clearing the arbitration mask also acknowledges a channel timeout. */
+    if (!(val & 0x40))
+        dma_ps2.arb_status &= 0x0f;
+}
+
+static uint8_t
 dma_ps2_read(uint16_t addr, UNUSED(void *priv))
 {
     const dma_t  *dma_c = &dma[dma_ps2.xfr_channel];
@@ -1025,6 +1082,14 @@ dma_ps2_read(uint16_t addr, UNUSED(void *priv))
     switch (addr) {
         case 0x1a:
             switch (dma_ps2.xfr_command) {
+                case 0: /*I/O address*/
+                    if (dma_ps2.byte_ptr)
+                        temp = (dma_c->io_addr >> 8) & 0xff;
+                    else
+                        temp = dma_c->io_addr & 0xff;
+                    dma_ps2.byte_ptr = (dma_ps2.byte_ptr + 1) & 1;
+                    break;
+
                 case 2: /*Address*/
                 case 3:
                     switch (dma_ps2.byte_ptr) {
@@ -1085,8 +1150,7 @@ dma_ps2_read(uint16_t addr, UNUSED(void *priv))
                     break;
 
                 case 0xb:
-                    if (!(dma_m & (1 << dma_ps2.xfr_channel)))
-                        dma_ps2_run(dma_ps2.xfr_channel);
+                    dma_ps2_request(dma_ps2.xfr_channel);
                     break;
 
                 default:
@@ -1103,7 +1167,7 @@ dma_ps2_read(uint16_t addr, UNUSED(void *priv))
 static void
 dma_ps2_write(uint16_t addr, uint8_t val, UNUSED(void *priv))
 {
-    dma_t  *dma_c = &dma[dma_ps2.xfr_channel];
+    dma_t  *dma_c;
     uint8_t mode;
 
     switch (addr) {
@@ -1111,6 +1175,7 @@ dma_ps2_write(uint16_t addr, uint8_t val, UNUSED(void *priv))
             dma_ps2.xfr_channel = val & 0x7;
             dma_ps2.xfr_command = val >> 4;
             dma_ps2.byte_ptr    = 0;
+            dma_c               = &dma[dma_ps2.xfr_channel];
             switch (dma_ps2.xfr_command) {
                 case 9: /*Set DMA mask*/
                     dma_m |= (1 << dma_ps2.xfr_channel);
@@ -1121,8 +1186,20 @@ dma_ps2_write(uint16_t addr, uint8_t val, UNUSED(void *priv))
                     break;
 
                 case 0xb:
-                    if (!(dma_m & (1 << dma_ps2.xfr_channel)))
-                        dma_ps2_run(dma_ps2.xfr_channel);
+                    dma_ps2_request(dma_ps2.xfr_channel);
+                    break;
+
+                case 0xc: /*Reset software DMA request*/
+                    break;
+
+                case 0xd: /*Master clear*/
+                    dma_wp[0] = dma_wp[1] = 0;
+                    dma_m                    = 0xff;
+                    dma_stat                 = 0;
+                    dma_stat_rq              = 0;
+                    dma_stat_rq_pc           = 0;
+                    dma_stat_adv_pend        = 0;
+                    dma_req_is_soft          = 0;
                     break;
 
                 default:
@@ -1131,6 +1208,7 @@ dma_ps2_write(uint16_t addr, uint8_t val, UNUSED(void *priv))
             break;
 
         case 0x1a:
+            dma_c = &dma[dma_ps2.xfr_channel];
             switch (dma_ps2.xfr_command) {
                 case 0: /*I/O address*/
                     if (dma_ps2.byte_ptr)
@@ -1200,8 +1278,10 @@ dma_ps2_write(uint16_t addr, uint8_t val, UNUSED(void *priv))
                     break;
 
                 case 0xb:
-                    if (!(dma_m & (1 << dma_ps2.xfr_channel)))
-                        dma_ps2_run(dma_ps2.xfr_channel);
+                    dma_ps2_request(dma_ps2.xfr_channel);
+                    break;
+
+                case 0xc: /*Reset software DMA request*/
                     break;
 
                 default:
@@ -1338,13 +1418,15 @@ dma16_write(uint16_t addr, uint8_t val, UNUSED(void *priv))
             channel           = (val & 3) + 4;
             dma[channel].mode = val;
             if (dma_ps2.is_ps2) {
-                dma[channel].ps2_mode &= ~0x1c;
+                dma[channel].ps2_mode &= ~(DMA_PS2_AUTOINIT | DMA_PS2_XFER_MASK | DMA_PS2_DEC2);
+                if (val & 0x10)
+                    dma[channel].ps2_mode |= DMA_PS2_AUTOINIT;
                 if (val & 0x20)
-                    dma[channel].ps2_mode |= 0x10;
+                    dma[channel].ps2_mode |= DMA_PS2_DEC2;
                 if ((val & 0xc) == 8)
-                    dma[channel].ps2_mode |= 4;
+                    dma[channel].ps2_mode |= DMA_PS2_XFER_MEM_TO_IO;
                 else if ((val & 0xc) == 4)
-                    dma[channel].ps2_mode |= 0xc;
+                    dma[channel].ps2_mode |= DMA_PS2_XFER_IO_TO_MEM;
             }
             return;
 
@@ -1547,6 +1629,7 @@ dma_reset_legacy(void)
 
     for (c = 0; c < 8; c++) {
         memset(&(dma[c]), 0x00, sizeof(dma_t));
+        dma[c].ps2_mode      = (dma_ps2.is_ps2 && (c & 4)) ? DMA_PS2_SIZE16 : 0;
         dma[c].size          = (c & 4) ? 1 : 0;
         dma[c].transfer_mode = (c & 4) ? 0x0202 : 0x0101;
     }
@@ -1647,6 +1730,11 @@ dma_reset(void)
     dma_xt_refresh_queued = false;
     dma_xt_refresh_scheduled = false;
 
+    if (dma_ps2.is_ps2) {
+        dma_ps2.arb_control = 0;
+        dma_ps2.arb_status  = 0;
+    }
+
     if (!dma_at)
         dma_m = (dma_m & 0xf0) | 0x0f;
 }
@@ -1654,13 +1742,13 @@ dma_reset(void)
 void
 dma_init(void)
 {
+    dma_ps2.is_ps2 = 0;
     dma_reset();
 
     io_sethandler(0x0000, 16,
                   dma_read, NULL, NULL, dma_write, NULL, NULL, NULL);
     io_sethandler(0x0080, 8,
                   dma_page_read, NULL, NULL, dma_page_write, NULL, NULL, NULL);
-    dma_ps2.is_ps2 = 0;
 }
 
 void
@@ -1721,13 +1809,15 @@ dma_alias_remove_piix(void)
 void
 ps2_dma_init(void)
 {
+    dma_ps2.is_ps2 = 1;
     dma_reset();
 
     io_sethandler(0x0018, 1,
                   dma_ps2_read, NULL, NULL, dma_ps2_write, NULL, NULL, NULL);
     io_sethandler(0x001a, 1,
                   dma_ps2_read, NULL, NULL, dma_ps2_write, NULL, NULL, NULL);
-    dma_ps2.is_ps2 = 1;
+    io_sethandler(0x0090, 1,
+                  dma_ps2_arb_read, NULL, NULL, dma_ps2_arb_write, NULL, NULL, NULL);
 }
 
 extern void dma_bm_read(uint32_t PhysAddress, uint8_t *DataRead, uint32_t TotalSize, int TransferSize);
@@ -2621,12 +2711,18 @@ dma_ps2_run(int channel)
                 }
 
                 dma_stat_rq |= (1 << channel);
-                dma->cc--;
-            } while (dma->cc > 0);
+                dma_c->cc--;
+            } while (dma_c->cc > 0);
 
             dma_stat |= (1 << channel);
             break;
     }
+
+    if (dma_c->ps2_mode & DMA_PS2_AUTOINIT) {
+        dma_c->cc = dma_c->cb;
+        dma_c->ac = dma_c->ab;
+    } else
+        dma_m |= (1 << channel);
 }
 
 int

--- a/src/floppy/fdc.c
+++ b/src/floppy/fdc.c
@@ -1509,9 +1509,8 @@ fdc_read(uint16_t addr, void *priv)
                 if (fdc->flags & FDC_FLAG_PS2) {
                     drive = real_drive(fdc, fdc->dor & 3);
                     ret   = 0x00;
-                    /* TODO:
-                            Bit 2: INDEX (best return always 0 as it goes by very fast)
-                    */
+                    if (fdd_index(drive))             /* INDEX */
+                        ret |= 0x04;
                     if (fdc->seek_dir)                 /* nDIRECTION */
                         ret |= 0x01;
                     if (writeprot[drive])              /* WRITEPROT */
@@ -1529,9 +1528,8 @@ fdc_read(uint16_t addr, void *priv)
                 } else if (fdc->flags & FDC_FLAG_PS2_MCA) {
                     drive = real_drive(fdc, fdc->dor & 3);
                     ret   = 0x04;
-                    /* TODO:
-                            Bit 2: nINDEX (best return always 1 as it goes by very fast)
-                    */
+                    if (fdd_index(drive))             /* nINDEX */
+                        ret &= ~0x04;
                     if (!fdc->seek_dir)                /* DIRECTION */
                         ret |= 0x01;
                     if (!writeprot[drive])             /* nWRITEPROT */

--- a/src/floppy/fdd.c
+++ b/src/floppy/fdd.c
@@ -845,6 +845,29 @@ fdd_hole(int drive)
         return 0;
 }
 
+int
+fdd_index(int drive)
+{
+    uint32_t index_pos;
+    uint32_t pulse_pos;
+    uint32_t raw_size;
+    int      side;
+
+    if ((drive < 0) || (drive >= FDD_NUM) || !motoron[drive] || drive_empty[drive] ||
+        !d86f_handler[drive].index_hole_pos || !d86f_handler[drive].get_raw_size)
+        return 0;
+
+    side     = fdd_get_head(drive);
+    raw_size = d86f_get_raw_size(drive, side);
+    if (!raw_size)
+        return 0;
+    index_pos = d86f_handler[drive].index_hole_pos(drive, side);
+    pulse_pos = (d86f_get_track_pos(drive) + raw_size - index_pos) % raw_size;
+
+    /* A typical index pulse is active for about 4 ms of a 200 ms revolution. */
+    return pulse_pos < (raw_size / 50);
+}
+
 static __inline uint64_t
 fdd_byteperiod(int drive)
 {

--- a/src/include/86box/fdd.h
+++ b/src/include/86box/fdd.h
@@ -43,6 +43,7 @@ extern void fdd_do_seek(int drive, int track);
 extern void fdd_forced_seek(int drive, int track_diff);
 extern void fdd_seek(int drive, int track_diff);
 extern int  fdd_track0(int drive);
+extern int  fdd_index(int drive);
 extern int  fdd_get_type_max_track(int type);
 extern int  fdd_getrpm(int drive);
 extern void fdd_set_densel(int densel);

--- a/src/include/86box/mca.h
+++ b/src/include/86box/mca.h
@@ -101,6 +101,17 @@ extern void mca_write(const uint16_t port, const uint8_t val);
 extern uint8_t mca_feedb(void);
 
 /**
+ * @brief Latches Card Selected Feedback after an adapter responds to an
+ * I/O or memory cycle.
+ */
+extern void mca_feedback_set(void);
+
+/**
+ * @brief Returns and clears the latched Card Selected Feedback state.
+ */
+extern uint8_t mca_feedback_read(void);
+
+/**
  * @brief Returns the number of physical slots initialized on the bus.
  *
  * @return uint8_t Number of slots.

--- a/src/include/86box/serial.h
+++ b/src/include/86box/serial.h
@@ -90,6 +90,8 @@ typedef struct serial_s {
     uint16_t out_new;
     uint16_t thr_empty;
 
+    uint8_t *reg_91;
+
     void *rcvr_fifo;
     void *xmit_fifo;
 
@@ -151,6 +153,7 @@ extern void      serial_set_next_inst(int ni);
 extern void      serial_standalone_init(void);
 extern void      serial_set_clock_src(serial_t *dev, double clock_src);
 extern void      serial_set_type(serial_t *dev, uint8_t type);
+extern void      serial_set_card_selected_feedback(serial_t *dev, uint8_t *reg_91);
 extern void      serial_reset_port(serial_t *dev);
 extern uint8_t   serial_read(uint16_t addr, void *priv);
 extern void      serial_device_timeout(void *priv);

--- a/src/machine/m_ps2_mca.c
+++ b/src/machine/m_ps2_mca.c
@@ -78,6 +78,7 @@ static struct ps2_t {
     uint8_t sys_ctrl_port_a;
     uint8_t subaddr_lo;
     uint8_t subaddr_hi;
+    uint8_t planar_feedback;
 
     uint8_t memory_bank[8];
 
@@ -835,17 +836,8 @@ ps2_mca_read(const uint16_t port, UNUSED(void *priv))
 
     switch (port) {
         case 0x91:
-#if 0
-            fatal("Read 91 setup=%02x adapter=%02x\n", ps2.setup, ps2.adapter_setup);
-#endif
-            if (!(ps2.setup & PS2_SETUP_IO))
-                temp = 0x00;
-            else if (!(ps2.setup & PS2_SETUP_VGA))
-                temp = 0x00;
-            else if (ps2.adapter_setup & PS2_ADAPTER_SETUP)
-                temp = 0x00;
-            else
-                temp = !mca_feedb();
+            temp = ps2.planar_feedback | mca_feedback_read();
+            ps2.planar_feedback = 0;
             temp |= 0xfe;
             break;
         case 0x94:
@@ -1644,6 +1636,7 @@ machine_ps2_common_init(const machine_t *model)
     nmi_mask = 0x80;
 
     ps2.uart = device_add_inst(&ns16550_device, 1);
+    serial_set_card_selected_feedback(ps2.uart, &ps2.planar_feedback);
 
     ps2.lpt = device_add_inst(&lpt_port_device, 1);
     lpt_set_ext(ps2.lpt, 1);

--- a/src/mca.c
+++ b/src/mca.c
@@ -36,6 +36,7 @@ typedef struct mca_slot_s {
 static mca_slot_t mca_slots[MCA_MAX_CARDS];
 static uint8_t    mca_index;
 static uint8_t    mca_nr_cards;
+static uint8_t    mca_feedback_latch;
 
 #define ENABLE_MCA_LOG 1
 #if ENABLE_MCA_LOG
@@ -61,8 +62,9 @@ mca_init(const uint8_t nr_cards)
 {
     memset(mca_slots, 0, sizeof(mca_slots));
 
-    mca_index    = 0;
-    mca_nr_cards = nr_cards;
+    mca_index          = 0;
+    mca_nr_cards       = nr_cards;
+    mca_feedback_latch = 0;
 }
 
 void
@@ -114,8 +116,25 @@ mca_feedb(void)
 }
 
 void
+mca_feedback_set(void)
+{
+    mca_feedback_latch = 1;
+}
+
+uint8_t
+mca_feedback_read(void)
+{
+    const uint8_t ret = mca_feedback_latch;
+
+    mca_feedback_latch = 0;
+    return ret;
+}
+
+void
 mca_reset(void)
 {
+    mca_feedback_latch = 0;
+
     for (uint8_t slot = 0; slot < MCA_MAX_CARDS; slot++) {
         if (mca_slots[slot].reset)
             mca_slots[slot].reset(mca_slots[slot].priv);

--- a/src/nvr_at.c
+++ b/src/nvr_at.c
@@ -469,8 +469,18 @@ timer_update(void *priv)
         /* Get the current time from the internal clock. */
         nvr_time_get(&tm);
 
-        /* Update registers with current time. */
+        /*
+         * Update registers with the current time.  The PS/2 century byte is
+         * ordinary battery-backed RAM maintained by firmware, rather than a
+         * live RTC field.  Rewriting it every second also corrupts the Model
+         * 70/80 reference-disk NVRAM test while it exercises CMOS 0Eh-3Fh.
+         */
+        const uint8_t ps_century = (local->cent == RTC_CENTURY_PS)
+            ? nvr->regs[RTC_CENTURY_PS]
+            : 0;
         time_set(nvr, &tm);
+        if (local->cent == RTC_CENTURY_PS)
+            nvr->regs[RTC_CENTURY_PS] = ps_century;
 
         /* Check for any alarms we need to handle. */
         if (check_alarm(nvr, RTC_SECONDS) && check_alarm(nvr, RTC_MINUTES) && check_alarm(nvr, RTC_HOURS) &&
@@ -649,8 +659,9 @@ nvr_reg_write(uint16_t reg, uint8_t val, void *priv)
 
     if ((reg < RTC_REGA) || ((local->cent != 0xff) && (reg == local->cent))) {
         if ((reg != 1) && (reg != 3) && (reg != 5)) {
-            if ((old != val) && !(time_sync & TIME_SYNC_ENABLED)) {
-                /* Update internal clock. */
+            if (old != val) {
+                /* Host synchronization seeds the RTC; guest writes must still
+                   update the running clock just as they do on real hardware. */
                 time_get(nvr, &tm);
                 nvr_time_set(&tm);
                 // nvr_dosave = 1;

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -512,7 +512,14 @@ svga_in(uint16_t addr, void *priv)
             break;
         case 0x3c2:
             if (svga->cable_connected) {
-                if ((svga->vgapal[0].r + svga->vgapal[0].g + svga->vgapal[0].b) >= 0x4e)
+                /*
+                   IBM's VGA diagnostics ramp each DAC channel independently
+                   and require switch sense to assert no later than 0x26. A
+                   sum-only threshold never detects a single primary.
+                */
+                if (((svga->vgapal[0].r + svga->vgapal[0].g + svga->vgapal[0].b) >= 0x4e) ||
+                    (svga->vgapal[0].r >= 0x26) || (svga->vgapal[0].g >= 0x26) ||
+                    (svga->vgapal[0].b >= 0x26))
                     ret = 0;
                 else
                     ret = 0x10;
@@ -622,10 +629,60 @@ svga_in(uint16_t addr, void *priv)
         case 0x3da:
             svga->attrff = 0;
 
-            if (svga->cgastat & 0x01)
+            const uint8_t attr_output = svga->egapal[0x00];
+
+            /*
+             * IBM's VGA diagnostic programs graphics mode, enables the
+             * attribute palette, and writes a non-zero test pattern to
+             * palette register 0 before sampling the colour-plane diagnostic
+             * outputs.  Keep the legacy status approximation for normal VGA
+             * operation (including the Model 80 POST, which tests with a zero
+             * pattern), and expose the selected palette bits only during that
+             * diagnostic sequence.
+             */
+            if ((svga->attrregs[0x10] == 0x01) &&
+                ((svga->attrregs[0x12] & 0x0f) == 0x0f) &&
+                ((((svga->attrregs[0x12] & 0x30) == 0x00) &&
+                  ((attr_output == 0x01) || (attr_output == 0x04))) ||
+                 (((svga->attrregs[0x12] & 0x30) == 0x10) &&
+                  ((attr_output == 0x10) || (attr_output == 0x20))) ||
+                 (((svga->attrregs[0x12] & 0x30) == 0x20) &&
+                  ((attr_output == 0x02) || (attr_output == 0x08))))) {
                 svga->cgastat &= ~0x30;
-            else
+                switch (svga->attrregs[0x12] & 0x30) {
+                    case 0x00: /* P0 and P2 */
+                        if (attr_output & 0x01)
+                            svga->cgastat |= 0x10;
+                        if (attr_output & 0x04)
+                            svga->cgastat |= 0x20;
+                        break;
+                    case 0x10: /* P4 and P5 */
+                        if (attr_output & 0x10)
+                            svga->cgastat |= 0x10;
+                        if (attr_output & 0x20)
+                            svga->cgastat |= 0x20;
+                        break;
+                    case 0x20: /* P1 and P3 */
+                        if (attr_output & 0x02)
+                            svga->cgastat |= 0x10;
+                        if (attr_output & 0x08)
+                            svga->cgastat |= 0x20;
+                        break;
+                    case 0x30: /* P6 and P7 */
+                        if (attr_output & 0x40)
+                            svga->cgastat |= 0x10;
+                        if (attr_output & 0x80)
+                            svga->cgastat |= 0x20;
+                        break;
+
+                    default:
+                        break;
+                }
+            } else if (svga->cgastat & 0x01) {
+                svga->cgastat &= ~0x30;
+            } else {
                 svga->cgastat ^= 0x30;
+            }
 
             ret = svga->cgastat;
 


### PR DESCRIPTION
Summary
=======

Improve hardware behavior exercised by the IBM PS/2 Model 80 Reference Disk v1.12.

The diagnostics previously reported failures for the system unit, diskette drive, onboard async port, VGA and ESDI controller. An unsupported PS/2 DMA transfer command could also terminate 86Box with a fatal error.

The root causes were incomplete PS/2 DMA and central-arbitration behavior, setup feedback being derived from configuration state instead of actual adapter cycles, missing diagnostic-facing device behavior, and several timing or register-semantics differences exposed by the Reference Disk.

This change implements or corrects:

* PS/2 DMA arbitration, cascade selection, timeout NMI reporting, command readback, master clear, auto-initialization, terminal count and channel masking.
* Micro Channel Card Selected Feedback for onboard serial and ESDI activity.
* ESDI status commands 12h and 14h, device-specific status responses and non-fatal unsupported-command handling.
* Rotational floppy index-pulse reporting with the correct PS/2 signal polarity.
* UART loopback Break reception and the expected line-status errors.
* PS/2 RTC/NVRAM century-byte preservation and guest clock writes.
* 80386 I/O-permission bitmap offset wrapping.
* VGA switch-sense and guarded color-plane diagnostic feedback.

The affected behavior is restricted by machine type, CPU type, controller type or the specific diagnostic register sequence where possible.

Testing
=======

Test configuration:

* IBM PS/2 Model 80-111
* Intel 80386DX at 20 MHz
* 2 MB RAM
* CPU interpreter
* Internal VGA
* MCA ESDI controller
* IBM PS/2 Model 80 Reference Disk v1.12

Regression targets included:

* System Unit errors 00010200, 00010400, 00013100, 00013200 and 00013400
* Diskette error 00063000
* Async-port errors 00110200 and 00112200
* VGA error 00241000 and POST error 2401
* ESDI error 01045610
* Fatal `Bad XFR Read command 0 channel 0`

Checklist
=========

* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request