### PR TITLE
Fix native file dialog blocking folder selection

### DIFF
--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -654,8 +654,13 @@ MediaMenu::cdromMount(int i, int dir, const QString &arg)
 
     if (dir > 1)
         filename = QString::asprintf(R"(ioctl://%s)", arg.toUtf8().data());
-    else if (dir == 1)
-        filename = QFileDialog::getExistingDirectory(parentWidget, QString(), getMediaOpenDirectory(), QFileDialog::ShowDirsOnly | QFileDialog::DontUseNativeDialog);
+    else if (dir == 1) {
+        QFileDialog::Options options = QFileDialog::ShowDirsOnly;
+#ifdef Q_OS_LINUX
+        options |= QFileDialog::DontUseNativeDialog;
+#endif
+        filename = QFileDialog::getExistingDirectory(parentWidget, QString(), getMediaOpenDirectory(), options);
+    }
     else {
         filename = QFileDialog::getOpenFileName(parentWidget, QString(),
                                                 getMediaOpenDirectory(),

--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -655,7 +655,7 @@ MediaMenu::cdromMount(int i, int dir, const QString &arg)
     if (dir > 1)
         filename = QString::asprintf(R"(ioctl://%s)", arg.toUtf8().data());
     else if (dir == 1)
-        filename = QFileDialog::getExistingDirectory(parentWidget, QString(), getMediaOpenDirectory());
+        filename = QFileDialog::getExistingDirectory(parentWidget, QString(), getMediaOpenDirectory(), QFileDialog::ShowDirsOnly | QFileDialog::DontUseNativeDialog);
     else {
         filename = QFileDialog::getOpenFileName(parentWidget, QString(),
                                                 getMediaOpenDirectory(),

--- a/src/qt/qt_vmmanager_addmachine.cpp
+++ b/src/qt/qt_vmmanager_addmachine.cpp
@@ -265,7 +265,11 @@ NameAndLocationPage::nextId() const
 void
 NameAndLocationPage::chooseDirectoryLocation()
 {
-    const auto directory = QFileDialog::getExistingDirectory(this, "Choose directory", QDir(vmm_path).path(), QFileDialog::ShowDirsOnly | QFileDialog::DontUseNativeDialog);
+    QFileDialog::Options options = QFileDialog::ShowDirsOnly;
+#ifdef Q_OS_LINUX
+    options |= QFileDialog::DontUseNativeDialog;
+#endif
+    const auto directory = QFileDialog::getExistingDirectory(this, "Choose directory", QDir(vmm_path).path(), options);
     systemLocation->setText(QDir::toNativeSeparators(directory));
     emit completeChanged();
 }

--- a/src/qt/qt_vmmanager_addmachine.cpp
+++ b/src/qt/qt_vmmanager_addmachine.cpp
@@ -265,7 +265,7 @@ NameAndLocationPage::nextId() const
 void
 NameAndLocationPage::chooseDirectoryLocation()
 {
-    const auto directory = QFileDialog::getExistingDirectory(this, "Choose directory", QDir(vmm_path).path());
+    const auto directory = QFileDialog::getExistingDirectory(this, "Choose directory", QDir(vmm_path).path(), QFileDialog::ShowDirsOnly | QFileDialog::DontUseNativeDialog);
     systemLocation->setText(QDir::toNativeSeparators(directory));
     emit completeChanged();
 }

--- a/src/qt/qt_vmmanager_preferences.cpp
+++ b/src/qt/qt_vmmanager_preferences.cpp
@@ -100,7 +100,11 @@ VMManagerPreferences::~VMManagerPreferences()
 void
 VMManagerPreferences::chooseDirectoryLocation()
 {
-    const auto directory = QFileDialog::getExistingDirectory(this, tr("Choose directory"), ui->systemDirectory->text(), QFileDialog::ShowDirsOnly | QFileDialog::DontUseNativeDialog);
+    QFileDialog::Options options = QFileDialog::ShowDirsOnly;
+#ifdef Q_OS_LINUX
+    options |= QFileDialog::DontUseNativeDialog;
+#endif
+    const auto directory = QFileDialog::getExistingDirectory(this, tr("Choose directory"), ui->systemDirectory->text(), options);
     if (!directory.isEmpty())
         ui->systemDirectory->setText(QDir::toNativeSeparators(directory));
 }

--- a/src/qt/qt_vmmanager_preferences.cpp
+++ b/src/qt/qt_vmmanager_preferences.cpp
@@ -100,7 +100,7 @@ VMManagerPreferences::~VMManagerPreferences()
 void
 VMManagerPreferences::chooseDirectoryLocation()
 {
-    const auto directory = QFileDialog::getExistingDirectory(this, tr("Choose directory"), ui->systemDirectory->text());
+    const auto directory = QFileDialog::getExistingDirectory(this, tr("Choose directory"), ui->systemDirectory->text(), QFileDialog::ShowDirsOnly | QFileDialog::DontUseNativeDialog);
     if (!directory.isEmpty())
         ui->systemDirectory->setText(QDir::toNativeSeparators(directory));
 }


### PR DESCRIPTION
Summary
=======
On a KDE 6 environment, when QT uses the function `QFileDialog::getExistingDirectory` to prompt the user to **select a folder** (e.g. when trying to mount a folder as a CD-ROM drive), it actually invokes an 'Open File' prompt, entirely preventing the user from selecting a folder.

There are 3 calls to the `getExistingDirectory` fron the UI: one in the CD-ROM mount routine and two in the GUI VM manager. This fix appends the two `QFileDialog::ShowDirsOnly` and `QFileDialog::DontUseNativeDialog` flags to the calls in order to skip the incriminated system dialog and to use Qt's own implementation which doesn't enable this behavior when the host runs Linux.

Checklist
=========
* [x] Closes N/A
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
https://doc.qt.io/qt-6/qfiledialog.html
