### PR TITLE
IDE: Overlap image reads with emulated command delays

### DIFF
--- a/src/disk/hdc_ide.c
+++ b/src/disk/hdc_ide.c
@@ -45,6 +45,7 @@
 #include <86box/hdc_ide.h>
 #include <86box/hdd.h>
 #include <86box/rdisk.h>
+#include <86box/thread.h>
 #include <86box/version.h>
 
 /* Bits of 'atastat' */
@@ -234,6 +235,147 @@ static uint8_t ide_qua_pnp_rom[] = {
 };
 
 ide_t *ide_drives[IDE_NUM] = { 0 };
+
+/*
+ * Host image reads are independent of guest-visible IDE state until the
+ * emulated command-completion callback consumes their result.  Starting the
+ * read when the command is issued lets host I/O overlap the emulated seek and
+ * transfer delay without changing task-file, DMA, or IRQ ordering.
+ *
+ * Keep this state outside ide_t: that structure is shared with controller and
+ * chipset code, while the worker is an implementation detail of this module.
+ */
+typedef struct ide_async_read_s {
+    ide_t    *ide;
+    thread_t *thread;
+    event_t  *request_event;
+    event_t  *complete_event;
+    volatile int running;
+    int          pending;
+    int          result;
+    uint32_t     sector;
+    uint32_t     count;
+} ide_async_read_t;
+
+static ide_async_read_t ide_async_reads[IDE_NUM];
+
+static void
+ide_async_read_worker(void *priv)
+{
+    ide_async_read_t *state = (ide_async_read_t *) priv;
+
+    while (state->running) {
+        thread_wait_event(state->request_event, -1);
+        thread_reset_event(state->request_event);
+
+        if (!state->running)
+            break;
+
+        state->result = hdd_image_read(state->ide->hdd_num, state->sector,
+                                       state->count, state->ide->sector_buffer);
+        thread_set_event(state->complete_event);
+    }
+}
+
+static void
+ide_async_read_init(ide_t *ide)
+{
+    ide_async_read_t *state;
+
+    if ((ide == NULL) || (ide->channel < 0) || (ide->channel >= IDE_NUM))
+        return;
+
+    state = &ide_async_reads[ide->channel];
+    if (state->thread != NULL)
+        return;
+
+    memset(state, 0, sizeof(*state));
+    state->ide            = ide;
+    state->request_event  = thread_create_event();
+    state->complete_event = thread_create_event();
+    state->running        = 1;
+    state->thread         = thread_create_named(ide_async_read_worker, state, "ide-read");
+}
+
+static void
+ide_async_read_start(ide_t *ide, uint32_t sector, uint32_t count)
+{
+    ide_async_read_t *state;
+
+    if ((ide == NULL) || (ide->channel < 0) || (ide->channel >= IDE_NUM))
+        return;
+
+    state = &ide_async_reads[ide->channel];
+    if ((state->thread == NULL) || state->pending || (count == 0))
+        return;
+
+    state->sector  = sector;
+    state->count   = count;
+    state->result  = -1;
+    state->pending = 1;
+    thread_reset_event(state->complete_event);
+    thread_set_event(state->request_event);
+}
+
+/* Return non-zero when an asynchronous result was consumed. */
+static int
+ide_async_read_finish(ide_t *ide, int *result)
+{
+    ide_async_read_t *state;
+
+    if ((ide == NULL) || (ide->channel < 0) || (ide->channel >= IDE_NUM))
+        return 0;
+
+    state = &ide_async_reads[ide->channel];
+    if ((state->thread == NULL) || !state->pending)
+        return 0;
+
+    thread_wait_event(state->complete_event, -1);
+    thread_reset_event(state->complete_event);
+    state->pending = 0;
+    if (result != NULL)
+        *result = state->result;
+
+    return 1;
+}
+
+static void
+ide_async_read_discard(ide_t *ide)
+{
+    (void) ide_async_read_finish(ide, NULL);
+}
+
+static void
+ide_async_read_close(ide_t *ide)
+{
+    ide_async_read_t *state;
+
+    if ((ide == NULL) || (ide->channel < 0) || (ide->channel >= IDE_NUM))
+        return;
+
+    state = &ide_async_reads[ide->channel];
+    if (state->thread == NULL)
+        return;
+
+    ide_async_read_discard(ide);
+    state->running = 0;
+    thread_set_event(state->request_event);
+    thread_wait(state->thread);
+    thread_destroy_event(state->complete_event);
+    thread_destroy_event(state->request_event);
+    memset(state, 0, sizeof(*state));
+}
+
+void
+ide_wait_for_async_reads(void)
+{
+    for (int channel = 0; channel < IDE_NUM; channel++) {
+        ide_async_read_t *state = &ide_async_reads[channel];
+
+        if ((state->thread != NULL) && state->pending)
+            ide_async_read_discard(state->ide);
+    }
+}
 
 static void ide_atapi_callback(ide_t *ide);
 static void ide_callback(void *priv);
@@ -769,6 +911,26 @@ ide_get_last_sector(ide_t *ide)
         return (((((off64_t) ide->tf->cylinder * heads) + (off64_t) ide->tf->head) * sectors) +
                 (off64_t) sector) + (off64_t) add;
     }
+}
+
+static void
+ide_async_read_start_current(ide_t *ide)
+{
+    uint32_t count;
+    off64_t  sector;
+
+    if ((ide == NULL) || (ide->type != IDE_HDD) ||
+        ((!ide->tf->lba) && (ide->cfg_spt == 0)) ||
+        ((ide->command == WIN_READ_MULTIPLE) && (ide->blocksize == 0)))
+        return;
+
+    sector = ide_get_sector(ide);
+    if ((sector < 0) || (sector > hdd_image_get_last_sector(ide->hdd_num)) ||
+        (ide_get_last_sector(ide) > hdd_image_get_last_sector(ide->hdd_num)))
+        return;
+
+    count = ide->tf->secount ? ide->tf->secount : 256;
+    ide_async_read_start(ide, (uint32_t) sector, count);
 }
 
 static off64_t
@@ -1544,6 +1706,7 @@ ide_writel(uint16_t addr, uint32_t val, void *priv)
 static void
 dev_reset(ide_t *ide)
 {
+    ide_async_read_discard(ide);
     ide_set_signature(ide);
 
     if ((ide->type == IDE_ATAPI) && ide->stop)
@@ -1854,9 +2017,10 @@ ide_writeb(uint16_t addr, uint8_t val, void *priv)
                             double xfer_time = ide_get_xfer_time(ide, 512 * sec_count);
                             wait_time        = seek_time > xfer_time ? seek_time : xfer_time;
                         } else if ((val == WIN_READ_MULTIPLE) && (hdd[ide->hdd_num].speed_preset == 0)) {
-                           ide_set_callback(ide, 200.0 * IDE_TIME);
-                           ide->do_initial_read = 1;
-                           break;
+                            ide_set_callback(ide, 200.0 * IDE_TIME);
+                            ide->do_initial_read = 1;
+                            ide_async_read_start_current(ide);
+                            break;
                         } else if ((val == WIN_READ_MULTIPLE) && (ide->blocksize > 0)) {
                             sec_count = ide->tf->secount ? ide->tf->secount : 256;
                             if (sec_count > ide->blocksize)
@@ -1878,6 +2042,7 @@ ide_writeb(uint16_t addr, uint8_t val, void *priv)
                     } else
                         ide_set_callback(ide, 200.0 * IDE_TIME);
                     ide->do_initial_read = 1;
+                    ide_async_read_start_current(ide);
                     break;
 
                 case WIN_WRITE_MULTIPLE:
@@ -2437,8 +2602,9 @@ ide_callback(void *priv)
                 if (ide->do_initial_read) {
                     ide->do_initial_read = 0;
                     ide->sector_pos      = 0;
-                    ret = hdd_image_read(ide->hdd_num, ide_get_sector(ide),
-                                         ide->tf->secount ? ide->tf->secount : 256, ide->sector_buffer);
+                    if (!ide_async_read_finish(ide, &ret))
+                        ret = hdd_image_read(ide->hdd_num, ide_get_sector(ide),
+                                             ide->tf->secount ? ide->tf->secount : 256, ide->sector_buffer);
                 } else
                     ret = 0;
 
@@ -2478,7 +2644,14 @@ ide_callback(void *priv)
 
                 ide->tf->pos = 0;
 
-                if (hdd_image_read(ide->hdd_num, ide_get_sector(ide), ide->sector_pos, ide->sector_buffer) < 0) {
+                if (ide->do_initial_read) {
+                    ide->do_initial_read = 0;
+                    if (!ide_async_read_finish(ide, &ret))
+                        ret = hdd_image_read(ide->hdd_num, ide_get_sector(ide), ide->sector_pos, ide->sector_buffer);
+                } else
+                    ret = 0;
+
+                if (ret < 0) {
                     ide_log("IDE %i: DMA read aborted (image read error)\n", ide->channel);
                     err = UNC_ERR;
                 } else if (!ide_boards[ide->board]->force_ata3 && bm->dma) {
@@ -2526,8 +2699,9 @@ ide_callback(void *priv)
                 if (ide->do_initial_read) {
                     ide->do_initial_read = 0;
                     ide->sector_pos      = 0;
-                    ret = hdd_image_read(ide->hdd_num, ide_get_sector(ide),
-                                         ide->tf->secount ? ide->tf->secount : 256, ide->sector_buffer);
+                    if (!ide_async_read_finish(ide, &ret))
+                        ret = hdd_image_read(ide->hdd_num, ide_get_sector(ide),
+                                             ide->tf->secount ? ide->tf->secount : 256, ide->sector_buffer);
                 } else {
                     ret = 0;
                 }
@@ -2944,6 +3118,8 @@ ide_board_close(int board)
         dev = ide_drives[c];
 
         if (dev != NULL) {
+            ide_async_read_close(dev);
+
             if ((dev->type == IDE_HDD) && (dev->hdd_num != -1))
                 hdd_image_close(dev->hdd_num);
 
@@ -2999,6 +3175,8 @@ ide_board_setup(const int board)
             loadhd(ide_drives[ch], d, hdd[d].fn);
             if (ide_drives[ch]->sector_buffer == NULL)
                 ide_drives[ch]->sector_buffer = (uint8_t *) calloc(1, 256 * 512);
+            if (ide_drives[ch]->type == IDE_HDD)
+                ide_async_read_init(ide_drives[ch]);
             if (++c >= 2)
                 break;
         }
@@ -3318,6 +3496,8 @@ static void
 ide_drive_reset(int d)
 {
     ide_log("Resetting IDE drive %i...\n", d);
+
+    ide_async_read_discard(ide_drives[d]);
 
     if ((d & 1) && (ide_drives[d]->type == IDE_NONE) && (ide_drives[d ^ 1]->type != IDE_NONE)) {
         ide_drives[d]->type = ide_drives[d ^ 1]->type | IDE_SHADOW;

--- a/src/include/86box/hdc_ide.h
+++ b/src/include/86box/hdc_ide.h
@@ -232,6 +232,7 @@ extern uint8_t ide_read_ali_75(void);
 extern uint8_t ide_read_ali_76(void);
 
 extern void    ide_hard_reset(void);
+extern void    ide_wait_for_async_reads(void);
 
 /* Legacy #define's. */
 #define ide_irq_raise(ide) ide_irq(ide, 1, 1)

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -150,6 +150,7 @@ extern "C" {
 #include <86box/mem.h>
 #include <86box/rom.h>
 #include <86box/config.h>
+#include <86box/hdc_ide.h>
 #include <86box/hdd.h>
 #include <86box/ui.h>
 #ifdef DISCORD
@@ -799,6 +800,7 @@ plat_power_off(void)
     plat_mouse_capture(0);
     plat_clean_up();
     confirm_exit_cmdl = 0;
+    ide_wait_for_async_reads();
     hdd_image_sync_all();
     nvr_save();
 

--- a/src/unix/sdl_plat.c
+++ b/src/unix/sdl_plat.c
@@ -18,6 +18,7 @@
 #include <86box/timer.h>
 #include <86box/nvr.h>
 #include <86box/config.h>
+#include <86box/hdc_ide.h>
 #include <86box/hdd.h>
 #include <86box/path.h>
 #include <86box/plat.h>
@@ -340,6 +341,7 @@ void
 plat_power_off(void)
 {
     confirm_exit_cmdl = 0;
+    ide_wait_for_async_reads();
     hdd_image_sync_all();
     nvr_save();
     config_save();


### PR DESCRIPTION
## Summary

allows host HDD image reads to overlap the existing emulated IDE seek and transfer delays.

The host read begins when a supported command is issued. Its result is consumed by the original IDE completion callback before any guest-visible state is updated.

No IDE timing constants are changed.

## Supported commands

The asynchronous path applies to HDD execution of:

- `READ SECTORS`
- `READ SECTORS NO RETRY`
- `READ MULTIPLE`
- `READ DMA`
- Alternate `READ DMA`

ATAPI and write commands are unchanged.

## Implementation

A persistent read worker is created for each configured IDE HDD.

When a supported command is issued:

1. The existing command validation calculates the sector range.
2. The host read is submitted to that drive's worker.
3. The existing emulated seek and transfer callback remains scheduled.
4. The callback waits for the host result if it is not already complete.
5. The callback performs the original task-file, DMA, status, and IRQ updates.

If no asynchronous operation is available, the callback uses the existing synchronous read path.

## Threading model

Only `hdd_image_read()` and its private request state execute on the worker.

The worker does not modify:

- IDE task-file registers.
- IDE status flags.
- DMA controller state.
- IRQ state.
- Emulated command timers.

Only one read can be pending for each drive. The existing IDE callback consumes the result before using the sector buffer.

## Reset and shutdown

Pending reads are drained during:

- Device reset.
- Drive reset.
- IDE board teardown.
- Application power-off.
- HDD image synchronization.

The worker is joined before its events, sector buffer, or HDD image can be released.

Checklist
=========

* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request
* [ ] This pull request adds, changes or removes an external dependency
- [ ] I have opened a docs pull request
