### PR TITLE
Make sure input device option isn't falsely enabled

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -366,6 +366,8 @@ MainWindow::MainWindow(QWidget *parent)
                 if (mouse_input_mode > 0)
                     mouse_input_mode = 0;
             }
+
+            ui->menuSelect_Input_Device->setEnabled(mouse_type || tablet_type);    
         }
 
         if (mouse_input_mode >= 1 && QApplication::overrideCursor())


### PR DESCRIPTION
Summary
=======
Make sure input device option isn't falsely enabled.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
