### PR TITLE
Fix dynamic recompiler tooltip capitalization

### DIFF
--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -417,7 +417,7 @@ msgstr ""
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr ""
 
-msgid "Dynamic Recompiler"
+msgid "Dynamic recompiler"
 msgstr ""
 
 msgid "CPU frame size"

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -424,7 +424,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Utilitzeu l'intèrpret 486 per a processadors 286 i 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Recompilador dinàmic"
+msgstr "Recompilador Dinàmic"
 
 msgid "CPU frame size"
 msgstr "Mida de blocs de la CPU"

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -424,7 +424,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Utilitzeu l'intèrpret 486 per a processadors 286 i 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Recompilador Dinàmic"
+msgstr "Recompilador dinàmic"
 
 msgid "CPU frame size"
 msgstr "Mida de blocs de la CPU"

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -423,7 +423,7 @@ msgstr "Activat (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Utilitzeu l'intèrpret 486 per a processadors 286 i 386"
 
-msgid "Dynamic Recompiler"
+msgid "Dynamic recompiler"
 msgstr "Recompilador dinàmic"
 
 msgid "CPU frame size"

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -423,7 +423,7 @@ msgstr "Zapnuta (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Použít interpreter 486 pro procesory 286 a 386"
 
-msgid "Dynamic Recompiler"
+msgid "Dynamic recompiler"
 msgstr "Dynamický překladač"
 
 msgid "CPU frame size"

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -424,7 +424,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Použít interpreter 486 pro procesory 286 a 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Dynamický překladač"
+msgstr "Dynamický Překladač"
 
 msgid "CPU frame size"
 msgstr "Velikost CPU rámců"

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -424,7 +424,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Použít interpreter 486 pro procesory 286 a 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Dynamický Překladač"
+msgstr "Dynamický překladač"
 
 msgid "CPU frame size"
 msgstr "Velikost CPU rámců"

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -424,7 +424,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Verwende den 486-Interpreter für 286- und 386-Prozessoren"
 
 msgid "Dynamic recompiler"
-msgstr "Dynamischer recompiler"
+msgstr "Dynamischer Recompiler"
 
 msgid "CPU frame size"
 msgstr "CPU-Framegröße"

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -423,8 +423,8 @@ msgstr "Eingeschaltet (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Verwende den 486-Interpreter für 286- und 386-Prozessoren"
 
-msgid "Dynamic Recompiler"
-msgstr "Dynamischer Recompiler"
+msgid "Dynamic recompiler"
+msgstr "Dynamischer recompiler"
 
 msgid "CPU frame size"
 msgstr "CPU-Framegröße"

--- a/src/qt/languages/el-GR.po
+++ b/src/qt/languages/el-GR.po
@@ -423,8 +423,8 @@ msgstr "Ενεργό (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Χρησιμοποιήστε τον διερμηνέα 486 για επεξεργαστές 286 και 386"
 
-msgid "Dynamic Recompiler"
-msgstr "Δυναμικός Αναμεταγλωττιστής"
+msgid "Dynamic recompiler"
+msgstr "Δυναμικός αναμεταγλωττιστής"
 
 msgid "CPU frame size"
 msgstr "Μέγεθος πλαισίου CPU"

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -423,7 +423,7 @@ msgstr "Habilitado (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Utilizar el interpretador 486 para los procesadores 286 y 386"
 
-msgid "Dynamic Recompiler"
+msgid "Dynamic recompiler"
 msgstr "Recompilador dinámico"
 
 msgid "CPU frame size"

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -424,7 +424,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Utilizar el interpretador 486 para los procesadores 286 y 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Recompilador dinámico"
+msgstr "Recompilador Dinámico"
 
 msgid "CPU frame size"
 msgstr "Tamaño de blocos de CPU"

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -424,7 +424,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Utilizar el interpretador 486 para los procesadores 286 y 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Recompilador Dinámico"
+msgstr "Recompilador dinámico"
 
 msgid "CPU frame size"
 msgstr "Tamaño de blocos de CPU"

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -424,7 +424,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Käytä 486-tulkintaa 286- ja 386-prosessoreille"
 
 msgid "Dynamic Recompiler"
-msgstr "Dynaaminen Uudelleenkääntäjä"
+msgstr "Dynaaminen uudelleenkääntäjä"
 
 msgid "CPU frame size"
 msgstr "CPU frame-koko"

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -424,7 +424,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Käytä 486-tulkintaa 286- ja 386-prosessoreille"
 
 msgid "Dynamic Recompiler"
-msgstr "Dynaaminen uudelleenkääntäjä"
+msgstr "Dynaaminen Uudelleenkääntäjä"
 
 msgid "CPU frame size"
 msgstr "CPU frame-koko"

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -423,7 +423,7 @@ msgstr "Käytössä (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Käytä 486-tulkintaa 286- ja 386-prosessoreille"
 
-msgid "Dynamic Recompiler"
+msgid "Dynamic recompiler"
 msgstr "Dynaaminen uudelleenkääntäjä"
 
 msgid "CPU frame size"

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -424,7 +424,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Employer l'interprète 486 pour les processeurs 286 et 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Recompilateur dynamique"
+msgstr "Recompilateur Dynamique"
 
 msgid "CPU frame size"
 msgstr "Taille du bloc de processeur"

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -424,7 +424,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Employer l'interprète 486 pour les processeurs 286 et 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Recompilateur Dynamique"
+msgstr "Recompilateur dynamique"
 
 msgid "CPU frame size"
 msgstr "Taille du bloc de processeur"

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -423,7 +423,7 @@ msgstr "Activé (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Employer l'interprète 486 pour les processeurs 286 et 386"
 
-msgid "Dynamic Recompiler"
+msgid "Dynamic recompiler"
 msgstr "Recompilateur dynamique"
 
 msgid "CPU frame size"

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -425,7 +425,7 @@ msgstr "Uključeno (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Koristi interpretator za 486 i za procesore 286 i 386"
 
-msgid "Dynamic Recompiler"
+msgid "Dynamic recompiler"
 msgstr "Dinamički rekompilator"
 
 msgid "CPU frame size"

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -426,7 +426,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Koristi interpretator za 486 i za procesore 286 i 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Dinamički rekompilator"
+msgstr "Dinamički Rekompilator"
 
 msgid "CPU frame size"
 msgstr "Veličina blokova procesora"

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -426,7 +426,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Koristi interpretator za 486 i za procesore 286 i 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Dinamički Rekompilator"
+msgstr "Dinamički rekompilator"
 
 msgid "CPU frame size"
 msgstr "Veličina blokova procesora"

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -426,7 +426,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Utilizza l'interprete 486 per i processori 286 e 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Ricompilatore Dinamico"
+msgstr "Ricompilatore dinamico"
 
 msgid "CPU frame size"
 msgstr "Dimensione blocchi CPU"

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -425,7 +425,7 @@ msgstr "Abilitato (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Utilizza l'interprete 486 per i processori 286 e 386"
 
-msgid "Dynamic Recompiler"
+msgid "Dynamic recompiler"
 msgstr "Ricompilatore dinamico"
 
 msgid "CPU frame size"

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -426,7 +426,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Utilizza l'interprete 486 per i processori 286 e 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Ricompilatore dinamico"
+msgstr "Ricompilatore Dinamico"
 
 msgid "CPU frame size"
 msgstr "Dimensione blocchi CPU"

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -424,7 +424,7 @@ msgstr "有効(UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "286および386プロセッサには486インタプリタを使用する"
 
-msgid "Dynamic Recompiler"
+msgid "Dynamic recompiler"
 msgstr "動的再コンパイル"
 
 msgid "CPU frame size"

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -423,7 +423,7 @@ msgstr "사용 (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "286/386 프로세서에 486 인터프리터 사용"
 
-msgid "Dynamic Recompiler"
+msgid "Dynamic recompiler"
 msgstr "동적 리컴파일러"
 
 msgid "CPU frame size"

--- a/src/qt/languages/nb-NO.po
+++ b/src/qt/languages/nb-NO.po
@@ -425,7 +425,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Bruk 486-tolken for 286- og 386-prosessorer"
 
 msgid "Dynamic Recompiler"
-msgstr "Dynamisk Recompilator"
+msgstr "Dynamisk recompilator"
 
 msgid "CPU frame size"
 msgstr "CPU-rammestørrelse"

--- a/src/qt/languages/nb-NO.po
+++ b/src/qt/languages/nb-NO.po
@@ -424,7 +424,7 @@ msgstr "Aktivert (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Bruk 486-tolken for 286- og 386-prosessorer"
 
-msgid "Dynamic Recompiler"
+msgid "Dynamic recompiler"
 msgstr "Dynamisk recompilator"
 
 msgid "CPU frame size"

--- a/src/qt/languages/nb-NO.po
+++ b/src/qt/languages/nb-NO.po
@@ -425,7 +425,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Bruk 486-tolken for 286- og 386-prosessorer"
 
 msgid "Dynamic Recompiler"
-msgstr "Dynamisk recompilator"
+msgstr "Dynamisk Recompilator"
 
 msgid "CPU frame size"
 msgstr "CPU-rammestørrelse"

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -423,8 +423,8 @@ msgstr "Ingeschakeld (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Gebruik de 486-interpreter voor 286- en 386-processors"
 
-msgid "Dynamic Recompiler"
-msgstr "Dynamische Recompiler"
+msgid "Dynamic recompiler"
+msgstr "Dynamische recompiler"
 
 msgid "CPU frame size"
 msgstr "CPU framegrootte"

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -425,7 +425,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Użyj interpretera 486 dla procesorów 286 i 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Dynamiczny Rekompilator"
+msgstr "Dynamiczny rekompilator"
 
 msgid "CPU frame size"
 msgstr "Rozmiar ramki CPU"

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -424,7 +424,7 @@ msgstr "Włączona (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Użyj interpretera 486 dla procesorów 286 i 386"
 
-msgid "Dynamic Recompiler"
+msgid "Dynamic recompiler"
 msgstr "Dynamiczny rekompilator"
 
 msgid "CPU frame size"

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -425,7 +425,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Użyj interpretera 486 dla procesorów 286 i 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Dynamiczny rekompilator"
+msgstr "Dynamiczny Rekompilator"
 
 msgid "CPU frame size"
 msgstr "Rozmiar ramki CPU"

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -425,7 +425,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Usar o interpretador 486 para processadores 286 e 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Recompilador Dinâmico"
+msgstr "Recompilador dinâmico"
 
 msgid "CPU frame size"
 msgstr "Tamanho do quadro da CPU"

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -425,7 +425,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Usar o interpretador 486 para processadores 286 e 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Recompilador dinâmico"
+msgstr "Recompilador Dinâmico"
 
 msgid "CPU frame size"
 msgstr "Tamanho do quadro da CPU"

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -424,7 +424,7 @@ msgstr "Ativar (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Usar o interpretador 486 para processadores 286 e 386"
 
-msgid "Dynamic Recompiler"
+msgid "Dynamic recompiler"
 msgstr "Recompilador dinâmico"
 
 msgid "CPU frame size"

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -424,7 +424,7 @@ msgstr "Ativada (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Utilizar o interpetador 486 para os processadores 286 e 386"
 
-msgid "Dynamic Recompiler"
+msgid "Dynamic recompiler"
 msgstr "Recompilador dinâmico"
 
 msgid "CPU frame size"

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -425,7 +425,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Utilizar o interpetador 486 para os processadores 286 e 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Recompilador dinâmico"
+msgstr "Recompilador Dinâmico"
 
 msgid "CPU frame size"
 msgstr "Tamanho de blocos do CPU"

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -425,7 +425,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Utilizar o interpetador 486 para os processadores 286 e 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Recompilador Dinâmico"
+msgstr "Recompilador dinâmico"
 
 msgid "CPU frame size"
 msgstr "Tamanho de blocos do CPU"

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -424,7 +424,7 @@ msgstr "Включено (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Использовать интерпретатор 486 для процессоров 286 и 386"
 
-msgid "Dynamic Recompiler"
+msgid "Dynamic recompiler"
 msgstr "Динамический рекомпилятор"
 
 msgid "CPU frame size"

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -423,7 +423,7 @@ msgstr "Zapnutá (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Použi interpret 486 pre procesory 286 a 386"
 
-msgid "Dynamic Recompiler"
+msgid "Dynamic recompiler"
 msgstr "Dynamický prekladač"
 
 msgid "CPU frame size"

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -424,7 +424,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Použi interpret 486 pre procesory 286 a 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Dynamický prekladač"
+msgstr "Dynamický Prekladač"
 
 msgid "CPU frame size"
 msgstr "Veľkosť rámcov CPU"

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -424,7 +424,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Použi interpret 486 pre procesory 286 a 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Dynamický Prekladač"
+msgstr "Dynamický prekladač"
 
 msgid "CPU frame size"
 msgstr "Veľkosť rámcov CPU"

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -426,7 +426,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Uporabi interpreter za 486 tudi za procesorje 286 in 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Dinamični prevajalnik"
+msgstr "Dinamični Prevajalnik"
 
 msgid "CPU frame size"
 msgstr "Velikost blokov procesorja"

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -426,7 +426,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Uporabi interpreter za 486 tudi za procesorje 286 in 386"
 
 msgid "Dynamic Recompiler"
-msgstr "Dinamični Prevajalnik"
+msgstr "Dinamični prevajalnik"
 
 msgid "CPU frame size"
 msgstr "Velikost blokov procesorja"

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -425,7 +425,7 @@ msgstr "Omogočeno (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Uporabi interpreter za 486 tudi za procesorje 286 in 386"
 
-msgid "Dynamic Recompiler"
+msgid "Dynamic recompiler"
 msgstr "Dinamični prevajalnik"
 
 msgid "CPU frame size"

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -423,7 +423,7 @@ msgstr "Aktiverad (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Använd 486-programtolk för 286- och 386-processorer"
 
-msgid "Dynamic Recompiler"
+msgid "Dynamic recompiler"
 msgstr "Dynamisk omkompilator"
 
 msgid "CPU frame size"

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -424,7 +424,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Använd 486-programtolk för 286- och 386-processorer"
 
 msgid "Dynamic Recompiler"
-msgstr "Dynamisk Omkompilator"
+msgstr "Dynamisk omkompilator"
 
 msgid "CPU frame size"
 msgstr "Ramstorlek för processor"

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -424,7 +424,7 @@ msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Använd 486-programtolk för 286- och 386-processorer"
 
 msgid "Dynamic Recompiler"
-msgstr "Dynamisk omkompilator"
+msgstr "Dynamisk Omkompilator"
 
 msgid "CPU frame size"
 msgstr "Ramstorlek för processor"

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -423,8 +423,8 @@ msgstr "Etkin (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "286 ve 386 işlemcilerde 486 yorumlayıcısını kullan"
 
-msgid "Dynamic Recompiler"
-msgstr "Dinamik Derleyici"
+msgid "Dynamic recompiler"
+msgstr "Dinamik derleyici"
 
 msgid "CPU frame size"
 msgstr "İşlemci kare boyutu"

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -425,7 +425,7 @@ msgstr "Увімкнути (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Використовувати інтерпретатор 486 для процесорів 286 і 386"
 
-msgid "Dynamic Recompiler"
+msgid "Dynamic recompiler"
 msgstr "Динамічний рекомпілятор"
 
 msgid "CPU frame size"

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -424,8 +424,8 @@ msgstr "Bật (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "Sử dụng trình thông dịch 486 cho các bộ xử lý 286 và 386"
 
-msgid "Dynamic Recompiler"
-msgstr "Bộ tái biên dịch động (Dynamic Recompiler)"
+msgid "Dynamic recompiler"
+msgstr "Bộ tái biên dịch động (Dynamic recompiler)"
 
 msgid "CPU frame size"
 msgstr "Cỡ khung CPU"

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -424,7 +424,7 @@ msgstr "启用 (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "为286及386处理器应用486解释器"
 
-msgid "Dynamic Recompiler"
+msgid "Dynamic recompiler"
 msgstr "动态重编译器"
 
 msgid "CPU frame size"

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -424,7 +424,7 @@ msgstr "啟用 (UTC)"
 msgid "Use the 486 interpreter for 286 and 386 processors"
 msgstr "啟用 486 直譯器於 286 及 386 處理器"
 
-msgid "Dynamic Recompiler"
+msgid "Dynamic recompiler"
 msgstr "動態重編譯器"
 
 msgid "CPU frame size"

--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -1049,7 +1049,7 @@ MachineStatus::refresh(QStatusBar *sbar)
 
     d->dynarec = std::make_unique<QLabel>();
     d->dynarec->setPixmap(!is_dynarec_active() ? d->pixmaps.dynarec.disabled : d->pixmaps.dynarec.normal);
-    d->dynarec->setToolTip(tr("Dynamic recompiler"));
+    d->dynarec->setToolTip(tr("Dynamic Recompiler"));
     sbar->addWidget(d->dynarec.get());
 
     d->text = std::make_unique<QLabel>();

--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -1049,7 +1049,7 @@ MachineStatus::refresh(QStatusBar *sbar)
 
     d->dynarec = std::make_unique<QLabel>();
     d->dynarec->setPixmap(!is_dynarec_active() ? d->pixmaps.dynarec.disabled : d->pixmaps.dynarec.normal);
-    d->dynarec->setToolTip(tr("Dynamic Recompiler"));
+    d->dynarec->setToolTip(tr("Dynamic recompiler"));
     sbar->addWidget(d->dynarec.get());
 
     d->text = std::make_unique<QLabel>();

--- a/src/qt/qt_settingsmachine.ui
+++ b/src/qt/qt_settingsmachine.ui
@@ -481,7 +481,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>Dynamic Recompiler</string>
+           <string>Dynamic recompiler</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
Summary
=======
This PR corrects the capitalization of the Dynamic Recompiler status bar tooltip added by PR #7687 to allow its translation, as well as correcting the capitalization of some translations.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.