### PR TITLE
Set video timings for Compaq CGA card

### DIFF
--- a/src/video/vid_cga_compaq.c
+++ b/src/video/vid_cga_compaq.c
@@ -60,6 +60,8 @@ compaq_cga_log(const char *fmt, ...)
 #    define compaq_cga_log(fmt, ...)
 #endif
 
+static video_timings_t timing_compaq_cga = { .type = VIDEO_ISA, .write_b = 8, .write_w = 16, .write_l = 32, .read_b = 8, .read_w = 16, .read_l = 32 };
+
 static void
 compaq_cga_recalctimings(cga_t *dev)
 {
@@ -410,6 +412,8 @@ compaq_cga_init(const device_t *info)
     dev->snow_enabled   = device_get_config_int("snow_enabled");
 
     dev->vram           = calloc(1, 0x4000);
+
+    video_inform(VIDEO_FLAG_TYPE_CGA, &timing_compaq_cga);
 
     cga_comp_init(dev->revision);
     timer_add(&dev->timer, compaq_cga_poll, dev, 1);


### PR DESCRIPTION
Summary
=======
Minor change to call video_inform with CGA timings for the Compaq CGA card (aka Compaq VDU). The goal was to make sure SW1 video mode switches could be read correctly for an alternate BIOS.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
