### PR TITLE
DMA: Implement PS/2 MCA central arbitration and fix transfer handling

### DIFF
--- a/src/dma.c
+++ b/src/dma.c
@@ -59,6 +59,9 @@ static struct dma_ps2_t {
     int xfr_channel;
     int byte_ptr;
 
+    uint8_t arb_control;
+    uint8_t arb_status;
+
     int is_ps2;
 } dma_ps2;
 
@@ -350,6 +353,76 @@ dma_log(const char *fmt, ...)
 #endif
 
 static void dma_ps2_run(int channel);
+
+static uint8_t
+dma_ps2_arb_level(int channel)
+{
+    /* Only channels 0 and 4 have programmable arbitration levels. */
+    return ((channel & 3) == 0) ? (dma[channel].arb_level & 0x0f) : channel;
+}
+
+static void
+dma_ps2_master_clear(void)
+{
+    dma_wp[0] = dma_wp[1] = 0;
+    dma_ps2.byte_ptr       = 0;
+    dma_m                  = 0xff;
+    dma_stat               = 0;
+    dma_stat_rq            = 0;
+    dma_stat_adv_pend      = 0;
+    dma_req_is_soft        = 0;
+    dma_command[0]          = 0;
+    dma_command[1]          = 0;
+}
+
+static void
+dma_ps2_request(int request_channel)
+{
+    const uint8_t level = dma_ps2_arb_level(request_channel);
+    uint8_t       matched = 0;
+
+    dma_ps2.arb_status = (dma_ps2.arb_status & 0x60) | level;
+
+    /* The Model 80 firmware uses reserved function B4 to request channel 4's
+       arbitration level.  Every enabled DMA channel at that level is serviced
+       in channel order.  MCA channel 4 remains a normal DMA channel, unlike
+       the AT cascade input. */
+    for (int channel = 0; channel < 8; channel++) {
+        if (!(dma_m & (1 << channel)) && (dma_ps2_arb_level(channel) == level)) {
+            matched = 1;
+            dma_ps2_run(channel);
+        }
+    }
+
+    if (!matched) {
+        /* If neither an internal DMA channel nor an external bus master
+           accepts the granted level, central arbitration times out. */
+        dma_ps2.arb_status = 0x60 | level;
+        if (dma_ps2.arb_control & 0x80)
+            nmi_raise();
+    }
+}
+
+static uint8_t
+dma_ps2_arb_read(UNUSED(uint16_t addr), UNUSED(void *priv))
+{
+    const uint8_t ret = (dma_ps2.arb_control & 0x80) | dma_ps2.arb_status;
+
+    if (dma_ps2.arb_status & 0x20)
+        dma_ps2.arb_status &= ~0x40;
+
+    return ret;
+}
+
+static void
+dma_ps2_arb_write(UNUSED(uint16_t addr), uint8_t val, UNUSED(void *priv))
+{
+    dma_ps2.arb_control = val & 0xa0;
+
+    /* Clearing the arbitration mask acknowledges a bus-timeout NMI. */
+    if (!(val & 0x40))
+        dma_ps2.arb_status &= 0x0f;
+}
 
 
 int
@@ -898,10 +971,16 @@ dma_read_legacy(uint16_t addr, UNUSED(void *priv))
             break;
 
         case 8: /*Status register*/
-            ret = dma_stat_rq_pc & 0xf;
-            ret <<= 4;
-            ret |= dma_stat & 0xf;
-            dma_stat &= ~0xf;
+            if (dma_ps2.is_ps2) {
+                ret = (dma_stat_rq & 0x0f) << 4;
+                ret |= dma_stat & 0x0f;
+                dma_stat &= ~0x0f;
+                dma_stat_rq &= ~0x0f;
+            } else {
+                ret = (dma_stat_rq_pc & 0x0f) << 4;
+                ret |= dma_stat & 0x0f;
+                dma_stat &= ~0x0f;
+            }
             break;
 
         case 0xd: /*Temporary register*/
@@ -983,13 +1062,16 @@ dma_write_legacy(uint16_t addr, uint8_t val, UNUSED(void *priv))
             channel           = (val & 3);
             dma[channel].mode = val;
             if (dma_ps2.is_ps2) {
-                dma[channel].ps2_mode &= ~0x1c;
+                dma[channel].ps2_mode = 0;
+                dma[channel].size     = 0;
+                if (val & 0x10)
+                    dma[channel].ps2_mode |= DMA_PS2_AUTOINIT;
                 if (val & 0x20)
-                    dma[channel].ps2_mode |= 0x10;
+                    dma[channel].ps2_mode |= DMA_PS2_DEC2;
                 if ((val & 0xc) == 8)
-                    dma[channel].ps2_mode |= 4;
+                    dma[channel].ps2_mode |= DMA_PS2_XFER_MEM_TO_IO;
                 else if ((val & 0xc) == 4)
-                    dma[channel].ps2_mode |= 0xc;
+                    dma[channel].ps2_mode |= DMA_PS2_XFER_IO_TO_MEM;
             }
             return;
 
@@ -1025,19 +1107,29 @@ dma_ps2_read(uint16_t addr, UNUSED(void *priv))
     switch (addr) {
         case 0x1a:
             switch (dma_ps2.xfr_command) {
+                case 0: /*I/O address*/
+                    if (dma_ps2.byte_ptr)
+                        temp = (dma_c->io_addr >> 8) & 0xff;
+                    else
+                        temp = dma_c->io_addr & 0xff;
+                    dma_ps2.byte_ptr = (dma_ps2.byte_ptr + 1) & 1;
+                    break;
+
                 case 2: /*Address*/
-                case 3:
+                case 3: {
+                    const uint32_t address = (dma_ps2.xfr_command == 2) ? dma_c->ab : dma_c->ac;
+
                     switch (dma_ps2.byte_ptr) {
                         case 0:
-                            temp             = dma_c->ac & 0xff;
+                            temp             = address & 0xff;
                             dma_ps2.byte_ptr = 1;
                             break;
                         case 1:
-                            temp             = (dma_c->ac >> 8) & 0xff;
+                            temp             = (address >> 8) & 0xff;
                             dma_ps2.byte_ptr = 2;
                             break;
                         case 2:
-                            temp             = (dma_c->ac >> 16) & 0xff;
+                            temp             = (address >> 16) & 0xff;
                             dma_ps2.byte_ptr = 0;
                             break;
 
@@ -1045,15 +1137,19 @@ dma_ps2_read(uint16_t addr, UNUSED(void *priv))
                             break;
                     }
                     break;
+                }
 
                 case 4: /*Count*/
-                case 5:
+                case 5: {
+                    const uint16_t count = (dma_ps2.xfr_command == 4) ? dma_c->cb : dma_c->cc;
+
                     if (dma_ps2.byte_ptr)
-                        temp = dma_c->cc >> 8;
+                        temp = count >> 8;
                     else
-                        temp = dma_c->cc & 0xff;
+                        temp = count & 0xff;
                     dma_ps2.byte_ptr = (dma_ps2.byte_ptr + 1) & 1;
                     break;
+                }
 
                 case 6: /*Read DMA status*/
                     if (dma_ps2.byte_ptr) {
@@ -1061,7 +1157,7 @@ dma_ps2_read(uint16_t addr, UNUSED(void *priv))
                         dma_stat &= ~0xf0;
                         dma_stat_rq &= ~0xf0;
                     } else {
-                        temp = (dma_stat_rq & 0xf) | ((dma_stat & 0xf) << 4);
+                        temp = (dma_stat_rq & 0x0f) | ((dma_stat & 0x0f) << 4);
                         dma_stat &= ~0xf;
                         dma_stat_rq &= ~0xf;
                     }
@@ -1073,15 +1169,8 @@ dma_ps2_read(uint16_t addr, UNUSED(void *priv))
                     break;
 
                 case 8: /*Arbitration Level*/
-                    temp = dma_c->arb_level;
-                    break;
-
-                case 9: /*Set DMA mask*/
-                    dma_m |= (1 << dma_ps2.xfr_channel);
-                    break;
-
-                case 0xa: /*Reset DMA mask*/
-                    dma_m &= ~(1 << dma_ps2.xfr_channel);
+                    if ((dma_ps2.xfr_channel == 0) || (dma_ps2.xfr_channel == 4))
+                        temp = dma_ps2_arb_level(dma_ps2.xfr_channel);
                     break;
 
                 case 0xb:
@@ -1090,7 +1179,8 @@ dma_ps2_read(uint16_t addr, UNUSED(void *priv))
                     break;
 
                 default:
-                    fatal("Bad XFR Read command %i channel %i\n", dma_ps2.xfr_command, dma_ps2.xfr_channel);
+                    /* Direct and reserved commands have no data phase. */
+                    break;
             }
             break;
 
@@ -1103,7 +1193,7 @@ dma_ps2_read(uint16_t addr, UNUSED(void *priv))
 static void
 dma_ps2_write(uint16_t addr, uint8_t val, UNUSED(void *priv))
 {
-    dma_t  *dma_c = &dma[dma_ps2.xfr_channel];
+    dma_t  *dma_c;
     uint8_t mode;
 
     switch (addr) {
@@ -1123,6 +1213,15 @@ dma_ps2_write(uint16_t addr, uint8_t val, UNUSED(void *priv))
                 case 0xb:
                     if (!(dma_m & (1 << dma_ps2.xfr_channel)))
                         dma_ps2_run(dma_ps2.xfr_channel);
+                    else
+                        dma_ps2_request(dma_ps2.xfr_channel);
+                    break;
+
+                case 0xc: /*Reset software DMA request*/
+                    break;
+
+                case 0xd: /*Master clear*/
+                    dma_ps2_master_clear();
                     break;
 
                 default:
@@ -1131,6 +1230,7 @@ dma_ps2_write(uint16_t addr, uint8_t val, UNUSED(void *priv))
             break;
 
         case 0x1a:
+            dma_c = &dma[dma_ps2.xfr_channel];
             switch (dma_ps2.xfr_command) {
                 case 0: /*I/O address*/
                     if (dma_ps2.byte_ptr)
@@ -1180,7 +1280,7 @@ dma_ps2_write(uint16_t addr, uint8_t val, UNUSED(void *priv))
                         mode |= 8;
                     else if ((val & DMA_PS2_XFER_MASK) == DMA_PS2_XFER_IO_TO_MEM)
                         mode |= 4;
-                    dma_c->mode = (dma_c->mode & ~0x2c) | mode;
+                    dma_c->mode = (dma_c->mode & ~0x3c) | mode;
                     if (val & DMA_PS2_AUTOINIT)
                         dma_c->mode |= 0x10;
                     dma_c->ps2_mode = val;
@@ -1188,15 +1288,8 @@ dma_ps2_write(uint16_t addr, uint8_t val, UNUSED(void *priv))
                     break;
 
                 case 8: /*Arbitration Level*/
-                    dma_c->arb_level = val;
-                    break;
-
-                case 9: /*Set DMA mask*/
-                    dma_m |= (1 << dma_ps2.xfr_channel);
-                    break;
-
-                case 0xa: /*Reset DMA mask*/
-                    dma_m &= ~(1 << dma_ps2.xfr_channel);
+                    if ((dma_ps2.xfr_channel == 0) || (dma_ps2.xfr_channel == 4))
+                        dma[dma_ps2.xfr_channel].arb_level = val & 0x0f;
                     break;
 
                 case 0xb:
@@ -1205,7 +1298,8 @@ dma_ps2_write(uint16_t addr, uint8_t val, UNUSED(void *priv))
                     break;
 
                 default:
-                    fatal("Bad XFR command %i channel %i val %02x\n", dma_ps2.xfr_command, dma_ps2.xfr_channel, val);
+                    /* Direct and reserved commands have no data phase. */
+                    break;
             }
             break;
 
@@ -1258,9 +1352,16 @@ dma16_read(uint16_t addr, UNUSED(void *priv))
             break;
 
         case 8: /*Status register*/
-            ret = (dma_stat_rq_pc & 0xf0);
-            ret |= dma_stat >> 4;
-            dma_stat &= ~0xf0;
+            if (dma_ps2.is_ps2) {
+                ret = dma_stat_rq & 0xf0;
+                ret |= (dma_stat & 0xf0) >> 4;
+                dma_stat &= ~0xf0;
+                dma_stat_rq &= ~0xf0;
+            } else {
+                ret = dma_stat_rq_pc & 0xf0;
+                ret |= dma_stat >> 4;
+                dma_stat &= ~0xf0;
+            }
             break;
 
         default:
@@ -1338,13 +1439,16 @@ dma16_write(uint16_t addr, uint8_t val, UNUSED(void *priv))
             channel           = (val & 3) + 4;
             dma[channel].mode = val;
             if (dma_ps2.is_ps2) {
-                dma[channel].ps2_mode &= ~0x1c;
+                dma[channel].ps2_mode = DMA_PS2_SIZE16;
+                dma[channel].size     = DMA_PS2_SIZE16;
+                if (val & 0x10)
+                    dma[channel].ps2_mode |= DMA_PS2_AUTOINIT;
                 if (val & 0x20)
-                    dma[channel].ps2_mode |= 0x10;
+                    dma[channel].ps2_mode |= DMA_PS2_DEC2;
                 if ((val & 0xc) == 8)
-                    dma[channel].ps2_mode |= 4;
+                    dma[channel].ps2_mode |= DMA_PS2_XFER_MEM_TO_IO;
                 else if ((val & 0xc) == 4)
-                    dma[channel].ps2_mode |= 0xc;
+                    dma[channel].ps2_mode |= DMA_PS2_XFER_IO_TO_MEM;
             }
             return;
 
@@ -1547,6 +1651,7 @@ dma_reset_legacy(void)
 
     for (c = 0; c < 8; c++) {
         memset(&(dma[c]), 0x00, sizeof(dma_t));
+        dma[c].ps2_mode      = (dma_ps2.is_ps2 && (c & 4)) ? DMA_PS2_SIZE16 : 0;
         dma[c].size          = (c & 4) ? 1 : 0;
         dma[c].transfer_mode = (c & 4) ? 0x0202 : 0x0101;
     }
@@ -1647,6 +1752,15 @@ dma_reset(void)
     dma_xt_refresh_queued = false;
     dma_xt_refresh_scheduled = false;
 
+    if (dma_ps2.is_ps2) {
+        dma_m               = 0xff;
+        dma_ps2.byte_ptr    = 0;
+        dma_ps2.arb_control = 0;
+        dma_ps2.arb_status  = 0;
+        dma[0].arb_level    = 0;
+        dma[4].arb_level    = 4;
+    }
+
     if (!dma_at)
         dma_m = (dma_m & 0xf0) | 0x0f;
 }
@@ -1654,13 +1768,13 @@ dma_reset(void)
 void
 dma_init(void)
 {
+    dma_ps2.is_ps2 = 0;
     dma_reset();
 
     io_sethandler(0x0000, 16,
                   dma_read, NULL, NULL, dma_write, NULL, NULL, NULL);
     io_sethandler(0x0080, 8,
                   dma_page_read, NULL, NULL, dma_page_write, NULL, NULL, NULL);
-    dma_ps2.is_ps2 = 0;
 }
 
 void
@@ -1721,13 +1835,15 @@ dma_alias_remove_piix(void)
 void
 ps2_dma_init(void)
 {
+    dma_ps2.is_ps2 = 1;
     dma_reset();
 
     io_sethandler(0x0018, 1,
                   dma_ps2_read, NULL, NULL, dma_ps2_write, NULL, NULL, NULL);
     io_sethandler(0x001a, 1,
                   dma_ps2_read, NULL, NULL, dma_ps2_write, NULL, NULL, NULL);
-    dma_ps2.is_ps2 = 1;
+    io_sethandler(0x0090, 1,
+                  dma_ps2_arb_read, NULL, NULL, dma_ps2_arb_write, NULL, NULL, NULL);
 }
 
 extern void dma_bm_read(uint32_t PhysAddress, uint8_t *DataRead, uint32_t TotalSize, int TransferSize);
@@ -2544,7 +2660,11 @@ dma_channel_write_legacy(int channel, uint16_t val)
 static void
 dma_ps2_run(int channel)
 {
-    dma_t *dma_c = &dma[channel];
+    dma_t         *dma_c   = &dma[channel];
+    const uint16_t io_addr = ((dma_c->ps2_mode & DMA_PS2_IOA) ? dma_c->io_addr : 0) &
+                             (dma_c->size ? 0xfffe : 0xffff);
+
+    dma_stat_rq |= (1 << channel);
 
     switch (dma_c->ps2_mode & DMA_PS2_XFER_MASK) {
         case DMA_PS2_XFER_MEM_TO_IO:
@@ -2552,7 +2672,7 @@ dma_ps2_run(int channel)
                 if (!dma_c->size) {
                     uint8_t temp = _dma_read(dma_c->ac, dma_c);
 
-                    outb(dma_c->io_addr, temp);
+                    outb(io_addr, temp);
 
                     if (dma_c->ps2_mode & DMA_PS2_DEC2)
                         dma_c->ac--;
@@ -2561,7 +2681,7 @@ dma_ps2_run(int channel)
                 } else {
                     uint16_t temp = _dma_readw(dma_c->ac, dma_c);
 
-                    outw(dma_c->io_addr, temp);
+                    outw(io_addr, temp);
 
                     if (dma_c->ps2_mode & DMA_PS2_DEC2)
                         dma_c->ac -= 2;
@@ -2569,9 +2689,8 @@ dma_ps2_run(int channel)
                         dma_c->ac += 2;
                 }
 
-                dma_stat_rq |= (1 << channel);
                 dma_c->cc--;
-            } while (dma_c->cc > 0);
+            } while (dma_c->cc >= 0);
 
             dma_stat |= (1 << channel);
             break;
@@ -2579,7 +2698,7 @@ dma_ps2_run(int channel)
         case DMA_PS2_XFER_IO_TO_MEM:
             do {
                 if (!dma_c->size) {
-                    uint8_t temp = inb(dma_c->io_addr);
+                    uint8_t temp = inb(io_addr);
 
                     _dma_write(dma_c->ac, temp, dma_c);
 
@@ -2588,7 +2707,7 @@ dma_ps2_run(int channel)
                     else
                         dma_c->ac++;
                 } else {
-                    uint16_t temp = inw(dma_c->io_addr);
+                    uint16_t temp = inw(io_addr);
 
                     _dma_writew(dma_c->ac, temp, dma_c);
 
@@ -2598,9 +2717,8 @@ dma_ps2_run(int channel)
                         dma_c->ac += 2;
                 }
 
-                dma_stat_rq |= (1 << channel);
                 dma_c->cc--;
-            } while (dma_c->cc > 0);
+            } while (dma_c->cc >= 0);
 
             ps2_cache_clean();
             dma_stat |= (1 << channel);
@@ -2620,13 +2738,18 @@ dma_ps2_run(int channel)
                         dma_c->ac += 2;
                 }
 
-                dma_stat_rq |= (1 << channel);
-                dma->cc--;
-            } while (dma->cc > 0);
+                dma_c->cc--;
+            } while (dma_c->cc >= 0);
 
             dma_stat |= (1 << channel);
             break;
     }
+
+    if (dma_c->ps2_mode & DMA_PS2_AUTOINIT) {
+        dma_c->cc = dma_c->cb;
+        dma_c->ac = dma_c->ab;
+    } else
+        dma_m |= (1 << channel);
 }
 
 int


### PR DESCRIPTION
Summary
=======
This pull request implements Central Arbitration and 16-bit DMA register handling for MCA systems in `src/dma.c`, fixing POST Error 104 and diagnostic self-test failures across all PS/2 MCA models.

### Changes:
* **Central Arbitration (Port `0x0090`)**: Implemented port 0x90 read/write, programmable arbitration levels for channels 0 & 4, and timeout reporting via NMI.
* **Extended Registers (Ports `0x0018` / `0x001A`)**: Supported 24-bit address, 16-bit count, mode, arb level, and master clear commands. Reserved commands are treated as no-ops instead of crashing.
* **Transfer Execution (`dma_ps2_run`)**: Fixed byte count loop condition (`cc >= 0`), added Auto-initialization, and corrected 16-bit I/O address masking.
* **Status Register**: Isolated PS/2 DMA status register handling from PC/AT.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/
