### PR TITLE
Fix DMQS not working on MCA version of IBM XGA-2 Display Adapter

### DIFF
--- a/src/machine/m_ps2_mca.c
+++ b/src/machine/m_ps2_mca.c
@@ -857,7 +857,7 @@ ps2_mca_read(const uint16_t port, UNUSED(void *priv))
             if (!(ps2.setup & PS2_SETUP_IO))
                 temp = ps2.planar_read(port);
             else if (!(ps2.setup & PS2_SETUP_VGA))
-                temp = 0xfd;
+                temp = (ps2.pos_vga & 1) ? 0xfd : 0xff;
             else if (ps2.adapter_setup & PS2_ADAPTER_SETUP)
                 temp = mca_read(port);
             else
@@ -867,7 +867,7 @@ ps2_mca_read(const uint16_t port, UNUSED(void *priv))
             if (!(ps2.setup & PS2_SETUP_IO))
                 temp = ps2.planar_read(port);
             else if (!(ps2.setup & PS2_SETUP_VGA))
-                temp = 0xef;
+                temp = (ps2.pos_vga & 1) ? 0xef : 0xff;
             else if (ps2.adapter_setup & PS2_ADAPTER_SETUP)
                 temp = mca_read(port);
             else
@@ -1019,17 +1019,35 @@ ps2_mca_write(const uint16_t port, uint8_t val, UNUSED(void *priv))
 }
 
 static void
+ps2_mca_vga_write(UNUSED(uint16_t addr), uint8_t val, UNUSED(void *priv))
+{
+    if (!ps2.mb_vga) {
+        return;
+    }
+
+    if (val & 0x01) {
+        if (!vga_isenabled(ps2.mb_vga))
+            vga_enable(ps2.mb_vga);
+    } else {
+        if (vga_isenabled(ps2.mb_vga))
+            vga_disable(ps2.mb_vga);
+    }
+}
+
+static void
 ps2_mca_board_common_init(void)
 {
     io_sethandler(0x0091, 0x0001, ps2_mca_read, NULL, NULL, ps2_mca_write, NULL, NULL, NULL);
     io_sethandler(0x0094, 0x0001, ps2_mca_read, NULL, NULL, ps2_mca_write, NULL, NULL, NULL);
     io_sethandler(0x0096, 0x0001, ps2_mca_read, NULL, NULL, ps2_mca_write, NULL, NULL, NULL);
     io_sethandler(0x0100, 0x0008, ps2_mca_read, NULL, NULL, ps2_mca_write, NULL, NULL, NULL);
+    io_sethandler(0x03c3, 0x0001, NULL, NULL, NULL, ps2_mca_vga_write, NULL, NULL, NULL);
 
     device_add(&port_6x_ps2_device);
     device_add(&port_92_device);
 
     ps2.setup = 0xff;
+    ps2.pos_vga = 0x01;
 
     lpt_port_setup(ps2.lpt, LPT_MDA_ADDR);
 }

--- a/src/video/vid_xga.c
+++ b/src/video/vid_xga.c
@@ -241,29 +241,10 @@ xga_updatemapping(svga_t *svga)
                         mem_mapping_disable(&xga->linear_mapping);
 
                     xga->test_stage = 0;
-                    mem_mapping_set_handler(&svga->mapping, svga->read, svga->readw, svga->readl, svga->write, svga->writew, svga->writel);
-                    switch (svga->gdcreg[6] & 0xc) {
-                        case 0x0: /*128k at A0000*/
-                            mem_mapping_set_addr(&svga->mapping, 0xa0000, 0x20000);
-                            svga->banked_mask = 0xffff;
-                            break;
-                        case 0x4: /*64k at A0000*/
-                            mem_mapping_set_addr(&svga->mapping, 0xa0000, 0x10000);
-                            svga->banked_mask = 0xffff;
-                            break;
-                        case 0x8: /*32k at B0000*/
-                            mem_mapping_set_addr(&svga->mapping, 0xb0000, 0x08000);
-                            svga->banked_mask = 0x7fff;
-                            break;
-                        case 0xC: /*32k at B8000*/
-                            mem_mapping_set_addr(&svga->mapping, 0xb8000, 0x08000);
-                            svga->banked_mask = 0x7fff;
-                            break;
-
-                        default:
-                            break;
-                    }
-                    xga->mapping_base = svga->mapping.base;
+                    /* In extended graphics mode with no 64KB aperture, the
+                       VGA-compatible A0000/B0000 window is not exposed. */
+                    mem_mapping_disable(&svga->mapping);
+                    xga->mapping_base = 0;
                     break;
                 case 1:
                     mem_mapping_disable(&xga->linear_mapping);
@@ -427,6 +408,9 @@ xga_ext_out_reg(xga_t *xga, svga_t *svga, uint8_t idx, uint8_t val)
     uint8_t index;
 
     switch (idx) {
+        case 0x00:
+            xga_updatemapping(svga);
+            break;
         case 0x10:
             xga->htotal = (xga->htotal & 0xff00) | val;
             break;
@@ -569,6 +553,7 @@ xga_ext_out_reg(xga_t *xga, svga_t *svga, uint8_t idx, uint8_t val)
             xga->disp_cntl_2 = val;
             xga->on          = ((val & 0x07) >= 0x02);
             svga_recalctimings(svga);
+            xga_updatemapping(svga);
             break;
 
         case 0x54:
@@ -689,6 +674,7 @@ xga_ext_outb(uint16_t addr, uint8_t val, void *priv)
         case 0:
             xga_log("[%04X:%08X]: EXT OUTB = %02x, val = %02x\n", CS, cpu_state.pc, addr, val);
             xga->op_mode = val;
+            xga_updatemapping(svga);
             break;
         case 1:
             xga_log("[%04X:%08X]: EXT OUTB = %02x, val = %02x\n", CS, cpu_state.pc, addr, val);
@@ -3791,6 +3777,7 @@ xga_init(const device_t *info)
     xga->vram_mask             = xga->vram_size - 1;
     xga->vram                  = calloc(xga->vram_size, 1);
     xga->changedvram           = calloc((xga->vram_size >> 12) + 1, 1);
+    xga->op_mode               = 0x01; /* VGA mode enabled (bit 0) for instance scan */
     xga->on                    = 0;
     xga->hwcursor.cur_xsize    = 64;
     xga->hwcursor.cur_ysize    = 64;


### PR DESCRIPTION
Summary
=======
This PR fixes IBM XGA-2 MCA BIOS refusing to load properly, which causes programs thinking DMQS not supported and glitch in 800x600 resolution with IBM XGA-2 adapter on IBM MCA machines. Also black screen with XGAKIT demo program fixed.

Checklist
=========
* [x] Closes #3983
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
[XGA/XGA-2 manual](https://archive.org/details/bitsavers_ibmpccardseferenceManualMay92_1756350)