### PR TITLE
Further minor ESS AudioDrive changes

### DIFF
--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -1876,19 +1876,11 @@ ess_mixer_write(uint16_t addr, uint8_t val, void *priv)
                             mixer->input_selector = INPUT_MIC;
                             break;
                     }
-                    /* Filter is always enabled on ES1688 and later, per the datasheet these bits have no effect */
-                    /* TODO: Investigate ES688 behavior */
-                    if (ess->dsp.sb_subtype <= SB_SUBTYPE_ESS_ES688) {
-                        mixer->input_filter   = !(mixer->regs[0xC] & 0x20);
-                        mixer->in_filter_freq = ((mixer->regs[0xC] & 0x8) == 0) ? 3200 : 8800;
-                    }
+                    /* Filter is always enabled on ES688 and later, per the datasheets the filter control bits have no effect */
                     break;
 
                 case 0x0E:
-                    /* Filter is always enabled on ES1688 and later, per the datasheet this bit has no effect */
-                    /* TODO: Investigate ES688 behavior */
-                    if (ess->dsp.sb_subtype <= SB_SUBTYPE_ESS_ES688)
-                        mixer->output_filter = !(mixer->regs[0xE] & 0x20);
+                    /* Filter is always enabled on ES688 and later, per the datasheets the filter control bit has no effect */
                     mixer->stereo        = mixer->regs[0xE] & 2;
                     sb_dsp_set_stereo(&ess->dsp, val & 2);
                     break;
@@ -5509,11 +5501,9 @@ ess_x688_init(UNUSED(const device_t *info))
     if (device_get_config_int("dspver") == 1)
         ess->dsp.ess_dsp_v2_mode = 1;
 
-    /* Filters are always enabled on ES1688. TODO: What about ES688? */
-    if (ess->dsp.sb_subtype == SB_SUBTYPE_ESS_ES1688) {
-        ess->mixer_ess.input_filter = 1;
-        ess->mixer_ess.output_filter = 1;
-    }
+    /* Filters are always enabled on ES688/1688. */
+    ess->mixer_ess.input_filter = 1;
+    ess->mixer_ess.output_filter = 1;
 
     /* DSP I/O handler is activated in sb_dsp_setaddr */
     io_sethandler(addr, 0x0004,
@@ -5628,11 +5618,9 @@ ess_x688_pnp_init(UNUSED(const device_t *info))
     sb_dsp_setdma16_supported(&ess->dsp, 0);
     ess_mixer_reset(ess);
 
-    /* Filters are always enabled on ES1688. TODO: What about ES688? */
-    if (ess->dsp.sb_subtype == SB_SUBTYPE_ESS_ES1688) {
-        ess->mixer_ess.input_filter = 1;
-        ess->mixer_ess.output_filter = 1;
-    }
+    /* Filters are always enabled on ES688/1688. */
+    ess->mixer_ess.input_filter = 1;
+    ess->mixer_ess.output_filter = 1;
 
     ess->mixer_enabled = 1;
     sound_add_handler(sb_get_buffer_ess, ess);
@@ -5723,11 +5711,9 @@ ess_x688_mca_init(UNUSED(const device_t *info))
     sb_dsp_setdma16_supported(&ess->dsp, 0);
     ess_mixer_reset(ess);
 
-    /* Filters are always enabled on ES1688. TODO: What about ES688? */
-    if (ess->dsp.sb_subtype == SB_SUBTYPE_ESS_ES1688) {
-        ess->mixer_ess.input_filter = 1;
-        ess->mixer_ess.output_filter = 1;
-    }
+    /* Filters are always enabled on ES688/1688. */
+    ess->mixer_ess.input_filter = 1;
+    ess->mixer_ess.output_filter = 1;
 
     ess->mixer_enabled = 1;
     sound_add_handler(sb_get_buffer_ess, ess);

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -1821,16 +1821,15 @@ ess_mixer_write(uint16_t addr, uint8_t val, void *priv)
             /* Reset */
             mixer->regs[0x0a] = mixer->regs[0x0c] = 0x00;
             mixer->regs[0x0e]                     = 0x00;
-            /* Changed default from -11dB to 0dB */
-            mixer->regs[0x04] = mixer->regs[0x22] = 0xee;
-            mixer->regs[0x26] = mixer->regs[0x28] = 0xee;
-            mixer->regs[0x2e]                     = 0x00;
+            mixer->regs[0x04] = mixer->regs[0x22] = 0x88;
+            mixer->regs[0x26]                     = 0x88;
+            mixer->regs[0x28] = mixer->regs[0x2e] = 0x00;
 
-            /* Initialize ESS regs
-             * Defaulting to 0dB instead of the standard -11dB. */
-            mixer->regs[0x14] = mixer->regs[0x32] = 0xff;
-            mixer->regs[0x36] = mixer->regs[0x38] = 0xff;
-            mixer->regs[0x3a]                     = 0x00;
+            /* Initialize ESS regs */
+            mixer->regs[0x1a]                     = 0x00;
+            mixer->regs[0x14] = mixer->regs[0x32] = 0x88;
+            mixer->regs[0x36]                     = 0x88;
+            mixer->regs[0x38] = mixer->regs[0x3a] = 0x00;
             mixer->regs[0x3c]                     = 0x05;
             mixer->regs[0x3e]                     = 0x00;
 


### PR DESCRIPTION
Summary
=======
Make the following changes to the ESS AudioDrive chips:
- Make the power-on/reset mixer volume control values match the available datasheets
- Always enable the filter on ES688 (per real hardware testing this chip has the same behavior as later chips)

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
ES688 hardware testing: https://www.vogons.org/viewtopic.php?t=91976
ES1888 datasheet: http://hackipedia.org/browse.cgi/Computer/Platform/PC%2c%20IBM%20compatible/Sound%20and%20Music/Creative%20Labs/Sound%20Blaster/ESS%20AudioDrive%20%28compatible%29/ES1888%20AudioDrive%20Design%20Guide%20%281995%2d10%29%20revision%20C%2epdf