### PR TITLE
Fix CGA lightpen position if Force 4:3 is enabled

### DIFF
--- a/src/video/vid_cga.c
+++ b/src/video/vid_cga.c
@@ -300,7 +300,7 @@ cga_is_in_lightpen(cga_t *cga, int x, int y)
     mouse_get_abs_coords(&abs_x, &abs_y);
 
     abs_x *= monitors[cga->monitor_used].mon_unscaled_size_x - 1;
-    abs_y *= monitors[cga->monitor_used].mon_unscaled_size_y - 1;
+    abs_y *= monitors[cga->monitor_used].mon_efscrnsz_y - 1;
     x -= 8;
     y -= cga->double_type ? cga->firstline * 2 : cga->firstline;
     


### PR DESCRIPTION
Summary
=======
Fix CGA lightpen position if Force 4:3 is enabled.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
