### PR TITLE
Vulkan: Fix crashes on slangp_parse

### DIFF
--- a/src/qt/qt_vulkanshadermanagerdialog.cpp
+++ b/src/qt/qt_vulkanshadermanagerdialog.cpp
@@ -46,12 +46,16 @@ slang_shader* slangp_parse(const char* path)
         char *errmsg = nullptr;
 #ifndef LIBRASHADER_STATIC
         librashader_inst.error_write(err, &errmsg);
-        QMessageBox::critical(main_window, QObject::tr("Error"), QString::fromUtf8(path) + "\n\n" + errmsg);
+        auto msgBox = new QMessageBox(QMessageBox::Critical, QObject::tr("Error"), QString::fromUtf8(path) + "\n\n" + errmsg, QMessageBox::Ok, main_window);
+        msgBox->setAttribute(Qt::WA_DeleteOnClose);
+        msgBox->show();
         librashader_inst.error_free_string(&errmsg);
         librashader_inst.error_free(&err);
 #else
         libra_error_write(err, &errmsg);
-        QMessageBox::critical(main_window, QObject::tr("Error"), QString::fromUtf8(path) + "\n\n" + errmsg);
+        auto msgBox = new QMessageBox(QMessageBox::Critical, QObject::tr("Error"), QString::fromUtf8(path) + "\n\n" + errmsg, QMessageBox::Ok, main_window);
+        msgBox->setAttribute(Qt::WA_DeleteOnClose);
+        msgBox->show();
         libra_error_free_string(&errmsg);
         libra_error_free(&err);
 #endif


### PR DESCRIPTION
Summary
=======
Fix crashes on slangp_parse.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
