### PR TITLE
Make MEM_BLOCK_NR externally configurable

### DIFF
--- a/src/codegen_new/codegen_allocator.h
+++ b/src/codegen_new/codegen_allocator.h
@@ -17,7 +17,9 @@
   instruction. ARMv8 is limited to +/- 128 MB, x86 to
   +/- 2GB. It was 32 MB on ARMv7 before we removed it*/
 
+#ifndef MEM_BLOCK_NR
 #define MEM_BLOCK_NR 131072
+#endif
 
 
 #define MEM_BLOCK_MASK (MEM_BLOCK_NR - 1)


### PR DESCRIPTION
Summary
=======
I'm creating a side project for 86box, a layer to build it bare metal on a Raspberry Pi Zero 2 and Pi 4 (and Pi 5 when I'll buy it...)

I need to be able to change the new dynarec size from an external makefile because a raspi zero cannot allocate 128 mb for it.

Since I'm working hard to avoid touching the 86box code for this, the only point where I can't do nothing is this one.

I don't want to disrupt anything, this should be invisibile for everyone.

Cheers,
Valerio