### PR TITLE
Guard added

### DIFF
--- a/src/codegen_new/codegen_allocator.c
+++ b/src/codegen_new/codegen_allocator.c
@@ -86,9 +86,21 @@ static uint8_t    *mem_block_alloc = NULL;
 
 int codegen_allocator_usage = 0;
 
+/* Matches the per-arch direct-branch ranges the header comment above
+   documents (128MB on ARMv8, 2GB on x86) - same arch check already used
+   elsewhere in this codebase (cpu.h, 386_common.h). */
+#if defined(__aarch64__) || defined(_M_ARM64)
+#    define CODEGEN_ALLOCATOR_MAX_POOL_BYTES (128ull * 1024 * 1024)
+#else
+#    define CODEGEN_ALLOCATOR_MAX_POOL_BYTES (2ull * 1024 * 1024 * 1024)
+#endif
+
 void
 codegen_allocator_init(void)
 {
+    _Static_assert((uint64_t) MEM_BLOCK_NR * MEM_BLOCK_SIZE <= CODEGEN_ALLOCATOR_MAX_POOL_BYTES,
+                    "MEM_BLOCK_NR * MEM_BLOCK_SIZE exceeds this architecture's direct-branch range");
+
     uint8_t large = 0;
     mem_block_alloc = plat_mmap(MEM_BLOCK_NR * MEM_BLOCK_SIZE, 1, &large);
 


### PR DESCRIPTION
Summary
=======
I'm creating a side project for 86box, a layer to build it bare metal on a Raspberry Pi Zero 2 and Pi 4 (and Pi 5 when I'll buy it...)

I need to be able to change the new dynarec size from an external makefile because a raspi zero cannot allocate 128 mb for it.

Since I'm working hard to avoid touching the 86box code for this, the only point where I can't do nothing is this one.

I don't want to disrupt anything, this should be invisibile for everyone.

Cheers,
Valerio