### PR TITLE
Actually enable the 8514/A/XGA side when prompted to when going to port 0x3c3 of the VGA

### DIFF
--- a/src/include/86box/vid_8514a.h
+++ b/src/include/86box/vid_8514a.h
@@ -214,6 +214,8 @@ typedef struct ibm8514_t {
     int      split;
     int      h_disp;
     int      h_total;
+    int      h_total_back;
+    int      vga_htotal;
     int      h_sync_start;
     int      h_sync_width;
     int      h_disp_time;
@@ -254,12 +256,11 @@ typedef struct ibm8514_t {
     int     vsyncwidth;
     int     vtotal;
     int     v_disp;
-    int     v_disp2;
     int     vdisp;
     int     vdisp2;
     int     disp_cntl;
     int     disp_change;
-    int     ext_mode_inc;
+    int     extended_mode;
     int     interlace;
     int     disp_cntl_interlace;
     int     disp_cntl_double_scan;

--- a/src/include/86box/vid_ati_mach8.h
+++ b/src/include/86box/vid_ati_mach8.h
@@ -37,6 +37,7 @@ typedef struct mach_t {
     int pci_bus;
     int vlb_bus;
     int has_bios;
+    int bus_width_8bit;
 
     uint8_t regs[256];
     uint8_t pci_regs[256];
@@ -182,6 +183,8 @@ typedef struct mach_t {
 
     atomic_int force_busy;
     atomic_int fifo_test_idx;
+
+    uint16_t ctl;
 } mach_t;
 
 #endif /*VIDEO_ATI_MACH8_H*/

--- a/src/include/86box/vid_svga.h
+++ b/src/include/86box/vid_svga.h
@@ -30,7 +30,7 @@
 #    define FLAG_NO_SHIFT3    1024 /* Needed for Bochs VBE. */
 #    define FLAG_PRECISETIME  2048 /* Needed for Copper demo if on dynarec. */
 #    define FLAG_PANNING_ATI  4096
-#    define FLAG_EXT_AR       8192
+#    define FLAG_EXT_AR 8192
 struct monitor_t;
 
 typedef struct hwcursor_t {
@@ -96,6 +96,7 @@ typedef struct svga_t {
     int hdisp;
     int hdisp_old;
     int htotal;
+    int h_total;
     int hdisp_time;
     int rowoffset;
     int dispon;
@@ -244,6 +245,9 @@ typedef struct svga_t {
     /* The PS/55 POST BIOS has a special monitor detection for its internal VGA
        when the monitor is connected to the Display Adapter. */
     int cable_connected;
+
+    uint8_t genena;
+    uint8_t genvs;
 
     uint8_t  crtc[256];
     uint8_t  gdcreg[256];

--- a/src/include/86box/vid_vga.h
+++ b/src/include/86box/vid_vga.h
@@ -33,8 +33,8 @@ extern uint8_t vga_in(uint16_t addr, void *priv);
 
 extern void    vga_init(const device_t *info, vga_t *vga, int enabled);
 
-extern void    vga_disable(void* p);
-extern void    vga_enable(void* p);
+extern void    vga_disable(void* p, uint16_t port);
+extern void    vga_enable(void* p, uint16_t port);
 
 extern int     vga_isenabled(void* p);
 

--- a/src/machine/m_ps2_mca.c
+++ b/src/machine/m_ps2_mca.c
@@ -65,6 +65,8 @@
 #include <86box/port_92.h>
 #include <86box/serial.h>
 #include <86box/video.h>
+#include <86box/vid_8514a.h>
+#include <86box/vid_xga.h>
 #include <86box/vid_svga.h>
 #include <86box/vid_vga.h>
 #include <86box/machine.h>
@@ -974,9 +976,9 @@ ps2_mca_write(const uint16_t port, uint8_t val, UNUSED(void *priv))
             else if (!(ps2.setup & PS2_SETUP_VGA)) {
                 if (ps2.mb_vga) {
                     if (vga_isenabled(ps2.mb_vga))
-                        vga_disable(ps2.mb_vga);
-                    if (val & 1)
-                        vga_enable(ps2.mb_vga);
+                        vga_disable(ps2.mb_vga, port);
+                    if (val & 0x01)
+                        vga_enable(ps2.mb_vga, port);
                 }
                 ps2.pos_vga = val;
             } else if (ps2.adapter_setup & PS2_ADAPTER_SETUP)
@@ -1018,19 +1020,42 @@ ps2_mca_write(const uint16_t port, uint8_t val, UNUSED(void *priv))
     }
 }
 
-static void
-ps2_mca_vga_write(UNUSED(uint16_t addr), uint8_t val, UNUSED(void *priv))
+static uint8_t
+ps2_mca_vga_read(UNUSED(uint16_t addr), UNUSED(void *priv))
 {
-    if (!ps2.mb_vga) {
-        return;
+    vga_t *vga = ps2.mb_vga;
+    uint8_t ret = 0x01;
+
+    if (vga == NULL)
+        return ret;
+
+    svga_t *svga = &vga->svga;
+    ibm8514_t *dev = (ibm8514_t *) svga->dev8514;
+    xga_t   *xga = (xga_t *) svga->xga;
+
+    if (xga_active && xga) {
+        if (xga->on)
+            ret = 0x00;
     }
+    if (ibm8514_active && dev) {
+        if (dev->on)
+            ret = 0x00;
+    }
+    return ret;
+}
+
+static void
+ps2_mca_vga_write(uint16_t addr, uint8_t val, UNUSED(void *priv))
+{
+    if (!ps2.mb_vga)
+        return;
 
     if (val & 0x01) {
         if (!vga_isenabled(ps2.mb_vga))
-            vga_enable(ps2.mb_vga);
+            vga_enable(ps2.mb_vga, addr);
     } else {
         if (vga_isenabled(ps2.mb_vga))
-            vga_disable(ps2.mb_vga);
+            vga_disable(ps2.mb_vga, addr);
     }
 }
 
@@ -1041,7 +1066,7 @@ ps2_mca_board_common_init(void)
     io_sethandler(0x0094, 0x0001, ps2_mca_read, NULL, NULL, ps2_mca_write, NULL, NULL, NULL);
     io_sethandler(0x0096, 0x0001, ps2_mca_read, NULL, NULL, ps2_mca_write, NULL, NULL, NULL);
     io_sethandler(0x0100, 0x0008, ps2_mca_read, NULL, NULL, ps2_mca_write, NULL, NULL, NULL);
-    io_sethandler(0x03c3, 0x0001, NULL, NULL, NULL, ps2_mca_vga_write, NULL, NULL, NULL);
+    io_sethandler(0x03c3, 0x0001, ps2_mca_vga_read, NULL, NULL, ps2_mca_vga_write, NULL, NULL, NULL);
 
     device_add(&port_6x_ps2_device);
     device_add(&port_92_device);
@@ -1233,7 +1258,7 @@ ps2_mca_board_model_60_init(void)
     switch (mem_size / 1024) {
         case 0: /*256Kx2*/
             ps2.option[1] = 0xf0;
-            break;       
+            break;
         case 1: /*256Kx4*/
             ps2.option[1] = 0xf4;
             break;
@@ -1246,7 +1271,7 @@ ps2_mca_board_model_60_init(void)
             ps2.option[1] = 0xfc;
             break;
     }
-    
+
     /* Enable password function */
     ps2.option[1] |= 0x02;
 
@@ -1574,7 +1599,7 @@ ps2_mca_board_model_80_type2_init(void)
 
     ps2.mem_regs[1] = 2;
     /* Note: Based on the information on ardent-tool.com website,
-       IBM PS/2 model 80 type 2 supports 1/2/4 MB memory cards on 
+       IBM PS/2 model 80 type 2 supports 1/2/4 MB memory cards on
        real machines, so memory encodings should be set as is. */
     switch (mem_size / 1024) {
         case 1: /* empty + 1 MB card */

--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -122,11 +122,18 @@ CLAMP(int16_t in, int16_t min, int16_t max)
         temp |= (dev->vram[(dev->accel.dest + (cx) + (n + 1)) & dev->vram_mask] << 8);              \
     }                                                                                               \
 
-#define READ(addr, dat)                               \
-    if (dev->bpp)                                     \
-        dat = vram_w[(addr) & (dev->vram_mask >> 1)]; \
-    else                                              \
-        dat = (dev->vram[(addr) & (dev->vram_mask)]); \
+#define READ(addr, dat)                                         \
+    if (ATI_MACH32) {                                           \
+        if (dev->bpp)                                           \
+            dat = vga_vram_w[(addr) & (svga->vram_mask >> 1)];  \
+        else                                                    \
+            dat = (svga->vram[(addr) & (svga->vram_mask)]);     \
+    } else {                                                    \
+        if (dev->bpp)                                           \
+            dat = vram_w[(addr) & (dev->vram_mask >> 1)];       \
+        else                                                    \
+            dat = (dev->vram[(addr) & (dev->vram_mask)]);       \
+    }
 
 #define READ_HIGH(addr, dat)                            \
     dat |= (dev->vram[(addr) & (dev->vram_mask)] << 8);
@@ -244,13 +251,23 @@ CLAMP(int16_t in, int16_t min, int16_t max)
         }                                                                                              \
     }
 
-#define WRITE(addr, dat)                                                                                  \
-    if (dev->bpp) {                                                                                       \
-        vram_w[((addr)) & (dev->vram_mask >> 1)]                   = dat;                                 \
-        dev->changedvram[(((addr)) & (dev->vram_mask >> 1)) >> 11] = svga->monitor->mon_changeframecount; \
-    } else {                                                                                              \
-        dev->vram[((addr)) & (dev->vram_mask)]                = dat;                                      \
-        dev->changedvram[(((addr)) & (dev->vram_mask)) >> 12] = svga->monitor->mon_changeframecount;      \
+#define WRITE(addr, dat)                                                                                        \
+    if (ATI_MACH32) {                                                                                           \
+        if (dev->bpp) {                                                                                         \
+            vga_vram_w[((addr)) & (svga->vram_mask >> 1)]           = dat;                                      \
+            dev->changedvram[(((addr)) & (dev->vram_mask >> 1)) >> 11] = svga->monitor->mon_changeframecount;   \
+        } else {                                                                                                \
+            svga->vram[((addr)) & (svga->vram_mask)]                = dat;                                      \
+            svga->changedvram[(((addr)) & (svga->vram_mask)) >> 12] = svga->monitor->mon_changeframecount;      \
+        }                                                                                                       \
+    } else {                                                                                                    \
+        if (dev->bpp) {                                                                                         \
+            vram_w[((addr)) & (dev->vram_mask >> 1)]                   = dat;                                   \
+            dev->changedvram[(((addr)) & (dev->vram_mask >> 1)) >> 11] = svga->monitor->mon_changeframecount;   \
+        } else {                                                                                                \
+            dev->vram[((addr)) & (dev->vram_mask)]                = dat;                                        \
+            dev->changedvram[(((addr)) & (dev->vram_mask)) >> 12] = svga->monitor->mon_changeframecount;        \
+        }                                                                                                       \
     }
 
 int ibm8514_active = 0;
@@ -1100,6 +1117,7 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
 {
     ibm8514_t *dev     = (ibm8514_t *) svga->dev8514;
     uint16_t  *vram_w  = (uint16_t *) dev->vram;
+    uint16_t  *vga_vram_w = (uint16_t *) svga->vram;
     uint16_t   src_dat = 0;
     uint16_t   dest_dat;
     uint16_t   old_dest_dat;
@@ -1308,7 +1326,7 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
 
     old_mix_dat = mix_dat;
 
-    ibm8514_log(dev->log,"CMD=%d, full=%04x, pixcntl=%d, filling=%02x, ssvdraw=%02x.\n", cmd, dev->accel.cmd, pixcntl, dev->accel.multifunc[0x0a] & 0x06, dev->accel.ssv_draw);
+    ibm8514_log(dev->log,"CMD=%d, full=%04x, pixcntl=%d, filling=%02x, ssvdraw=%02x, rw=%d.\n", cmd, dev->accel.cmd, pixcntl, dev->accel.multifunc[0x0a] & 0x06, dev->accel.ssv_draw, dev->accel.cmd & 0x01);
 
     /*Bit 4 of the Command register is the draw yes bit, which enables writing to memory/reading from memory when enabled.
       When this bit is disabled, no writing to memory/reading from memory is allowed. (This bit is almost meaningless on
@@ -2126,6 +2144,9 @@ ibm8514_accel_start(int count, int cpu_input, uint32_t mix_dat, uint32_t cpu_dat
                                     if (dev->accel.cmd & 0x04) {
                                         dev->accel.output = 1;
                                         dev->accel.sx -= 2;
+                                    } else {
+                                        if (!(dev->accel.maj_axis_pcnt & 0x01))
+                                            dev->accel.output3 = 1;
                                     }
                                 }
 
@@ -3559,18 +3580,34 @@ ibm8514_render_blank(svga_t *svga)
 {
     ibm8514_t *dev = (ibm8514_t *) svga->dev8514;
 
-    if ((dev->displine + svga->y_add) < 0)
-        return;
+    if (ATI_MACH32) {
+        if ((svga->displine + svga->y_add) < 0)
+            return;
 
-    if (dev->firstline_draw == 2000)
-        dev->firstline_draw = dev->displine;
-    dev->lastline_draw = dev->displine;
+        if (svga->firstline_draw == 2000)
+            svga->firstline_draw = svga->displine;
 
-    uint32_t *line_ptr   = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
-    uint32_t  line_width = (uint32_t)(dev->h_disp) * sizeof(uint32_t);
+        svga->lastline_draw = svga->displine;
 
-    if (dev->h_disp > 0)
-        memset(line_ptr, 0, line_width);
+        uint32_t *line_ptr   = &buffer32->line[svga->displine + svga->y_add][svga->x_add];
+        uint32_t  line_width = (uint32_t)(dev->h_disp) * sizeof(uint32_t);
+
+        if (dev->h_disp > 0)
+            memset(line_ptr, 0, line_width);
+    } else {
+        if ((dev->displine + svga->y_add) < 0)
+            return;
+
+        if (dev->firstline_draw == 2000)
+            dev->firstline_draw = dev->displine;
+        dev->lastline_draw = dev->displine;
+
+        uint32_t *line_ptr   = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
+        uint32_t  line_width = (uint32_t)(dev->h_disp) * sizeof(uint32_t);
+
+        if (dev->h_disp > 0)
+            memset(line_ptr, 0, line_width);
+    }
 }
 
 void
@@ -3580,33 +3617,64 @@ ibm8514_render_8bpp(svga_t *svga)
     uint32_t  *p;
     uint32_t   dat;
 
-    if ((dev->displine + svga->y_add) < 0)
-        return;
+    if (ATI_MACH32) {
+        if ((svga->displine + svga->y_add) < 0)
+            return;
 
-    if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
-        p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
+        if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->fullchange) {
+            p = &buffer32->line[svga->displine + svga->y_add][svga->x_add];
 
-        if (dev->firstline_draw == 2000)
-            dev->firstline_draw = dev->displine;
-        dev->lastline_draw = dev->displine;
+            if (svga->firstline_draw == 2000)
+                svga->firstline_draw = svga->displine;
+            svga->lastline_draw = svga->displine;
 
-        for (int x = 0; x <= dev->h_disp; x += 8) {
-            dat  = *(uint32_t *) (&dev->vram[dev->memaddr & dev->vram_mask]);
-            p[0] = dev->pallook[dat & dev->dac_mask & 0xff];
-            p[1] = dev->pallook[(dat >> 8) & dev->dac_mask & 0xff];
-            p[2] = dev->pallook[(dat >> 16) & dev->dac_mask & 0xff];
-            p[3] = dev->pallook[(dat >> 24) & dev->dac_mask & 0xff];
+            for (int x = 0; x <= dev->h_disp; x += 8) {
+                dat  = *(uint32_t *) (&svga->vram[svga->memaddr & svga->vram_mask]);
+                p[0] = dev->pallook[dat & dev->dac_mask & 0xff];
+                p[1] = dev->pallook[(dat >> 8) & dev->dac_mask & 0xff];
+                p[2] = dev->pallook[(dat >> 16) & dev->dac_mask & 0xff];
+                p[3] = dev->pallook[(dat >> 24) & dev->dac_mask & 0xff];
 
-            dat  = *(uint32_t *) (&dev->vram[(dev->memaddr + 4) & dev->vram_mask]);
-            p[4] = dev->pallook[dat & dev->dac_mask & 0xff];
-            p[5] = dev->pallook[(dat >> 8) & dev->dac_mask & 0xff];
-            p[6] = dev->pallook[(dat >> 16) & dev->dac_mask & 0xff];
-            p[7] = dev->pallook[(dat >> 24) & dev->dac_mask & 0xff];
+                dat  = *(uint32_t *) (&svga->vram[(svga->memaddr + 4) & svga->vram_mask]);
+                p[4] = dev->pallook[dat & dev->dac_mask & 0xff];
+                p[5] = dev->pallook[(dat >> 8) & dev->dac_mask & 0xff];
+                p[6] = dev->pallook[(dat >> 16) & dev->dac_mask & 0xff];
+                p[7] = dev->pallook[(dat >> 24) & dev->dac_mask & 0xff];
 
-            dev->memaddr += 8;
-            p += 8;
+                svga->memaddr += 8;
+                p += 8;
+            }
+            svga->memaddr &= svga->vram_mask;
         }
-        dev->memaddr &= dev->vram_mask;
+    } else {
+        if ((dev->displine + svga->y_add) < 0)
+            return;
+
+        if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
+            p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
+
+            if (dev->firstline_draw == 2000)
+                dev->firstline_draw = dev->displine;
+            dev->lastline_draw = dev->displine;
+
+            for (int x = 0; x <= dev->h_disp; x += 8) {
+                dat  = *(uint32_t *) (&dev->vram[dev->memaddr & dev->vram_mask]);
+                p[0] = dev->pallook[dat & dev->dac_mask & 0xff];
+                p[1] = dev->pallook[(dat >> 8) & dev->dac_mask & 0xff];
+                p[2] = dev->pallook[(dat >> 16) & dev->dac_mask & 0xff];
+                p[3] = dev->pallook[(dat >> 24) & dev->dac_mask & 0xff];
+
+                dat  = *(uint32_t *) (&dev->vram[(dev->memaddr + 4) & dev->vram_mask]);
+                p[4] = dev->pallook[dat & dev->dac_mask & 0xff];
+                p[5] = dev->pallook[(dat >> 8) & dev->dac_mask & 0xff];
+                p[6] = dev->pallook[(dat >> 16) & dev->dac_mask & 0xff];
+                p[7] = dev->pallook[(dat >> 24) & dev->dac_mask & 0xff];
+
+                dev->memaddr += 8;
+                p += 8;
+            }
+            dev->memaddr &= dev->vram_mask;
+        }
     }
 }
 
@@ -3618,35 +3686,68 @@ ibm8514_render_15bpp(svga_t *svga)
     uint32_t  *p;
     uint32_t   dat;
 
-    if ((dev->displine + svga->y_add) < 0)
-        return;
+    if (ATI_MACH32) {
+        if ((svga->displine + svga->y_add) < 0)
+            return;
 
-    if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
-        p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
+        if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->fullchange) {
+            p = &buffer32->line[svga->displine + svga->y_add][svga->x_add];
 
-        if (dev->firstline_draw == 2000)
-            dev->firstline_draw = dev->displine;
-        dev->lastline_draw = dev->displine;
+            if (svga->firstline_draw == 2000)
+                svga->firstline_draw = svga->displine;
+            svga->lastline_draw = svga->displine;
 
-        for (x = 0; x <= dev->h_disp; x += 8) {
-            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1)) & dev->vram_mask]);
-            p[x]     = video_15to32[dat & 0xffff];
-            p[x + 1] = video_15to32[dat >> 16];
+            for (x = 0; x <= dev->h_disp; x += 8) {
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1)) & svga->vram_mask]);
+                p[x]     = video_15to32[dat & 0xffff];
+                p[x + 1] = video_15to32[dat >> 16];
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1) + 4) & dev->vram_mask]);
-            p[x + 2] = video_15to32[dat & 0xffff];
-            p[x + 3] = video_15to32[dat >> 16];
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 4) & svga->vram_mask]);
+                p[x + 2] = video_15to32[dat & 0xffff];
+                p[x + 3] = video_15to32[dat >> 16];
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1) + 8) & dev->vram_mask]);
-            p[x + 4] = video_15to32[dat & 0xffff];
-            p[x + 5] = video_15to32[dat >> 16];
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 8) & svga->vram_mask]);
+                p[x + 4] = video_15to32[dat & 0xffff];
+                p[x + 5] = video_15to32[dat >> 16];
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1) + 12) & dev->vram_mask]);
-            p[x + 6] = video_15to32[dat & 0xffff];
-            p[x + 7] = video_15to32[dat >> 16];
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 12) & svga->vram_mask]);
+                p[x + 6] = video_15to32[dat & 0xffff];
+                p[x + 7] = video_15to32[dat >> 16];
+            }
+            svga->memaddr += (x << 1);
+            svga->memaddr &= svga->vram_mask;
         }
-        dev->memaddr += (x << 1);
-        dev->memaddr &= dev->vram_mask;
+    } else {
+        if ((dev->displine + svga->y_add) < 0)
+            return;
+
+        if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
+            p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
+
+            if (dev->firstline_draw == 2000)
+                dev->firstline_draw = dev->displine;
+            dev->lastline_draw = dev->displine;
+
+            for (x = 0; x <= dev->h_disp; x += 8) {
+                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1)) & dev->vram_mask]);
+                p[x]     = video_15to32[dat & 0xffff];
+                p[x + 1] = video_15to32[dat >> 16];
+
+                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1) + 4) & dev->vram_mask]);
+                p[x + 2] = video_15to32[dat & 0xffff];
+                p[x + 3] = video_15to32[dat >> 16];
+
+                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1) + 8) & dev->vram_mask]);
+                p[x + 4] = video_15to32[dat & 0xffff];
+                p[x + 5] = video_15to32[dat >> 16];
+
+                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1) + 12) & dev->vram_mask]);
+                p[x + 6] = video_15to32[dat & 0xffff];
+                p[x + 7] = video_15to32[dat >> 16];
+            }
+            dev->memaddr += (x << 1);
+            dev->memaddr &= dev->vram_mask;
+        }
     }
 }
 
@@ -3658,35 +3759,68 @@ ibm8514_render_16bpp(svga_t *svga)
     uint32_t  *p;
     uint32_t   dat;
 
-    if ((dev->displine + svga->y_add) < 0)
-        return;
+    if (ATI_MACH32) {
+        if ((svga->displine + svga->y_add) < 0)
+            return;
 
-    if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
-        p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
+        if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->fullchange) {
+            p = &buffer32->line[svga->displine + svga->y_add][svga->x_add];
 
-        if (dev->firstline_draw == 2000)
-            dev->firstline_draw = dev->displine;
-        dev->lastline_draw = dev->displine;
+            if (svga->firstline_draw == 2000)
+                svga->firstline_draw = svga->displine;
+            svga->lastline_draw = svga->displine;
 
-        for (x = 0; x <= dev->h_disp; x += 8) {
-            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1)) & dev->vram_mask]);
-            p[x]     = video_16to32[dat & 0xffff];
-            p[x + 1] = video_16to32[dat >> 16];
+            for (x = 0; x <= dev->h_disp; x += 8) {
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1)) & svga->vram_mask]);
+                p[x]     = video_16to32[dat & 0xffff];
+                p[x + 1] = video_16to32[dat >> 16];
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1) + 4) & dev->vram_mask]);
-            p[x + 2] = video_16to32[dat & 0xffff];
-            p[x + 3] = video_16to32[dat >> 16];
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 4) & svga->vram_mask]);
+                p[x + 2] = video_16to32[dat & 0xffff];
+                p[x + 3] = video_16to32[dat >> 16];
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1) + 8) & dev->vram_mask]);
-            p[x + 4] = video_16to32[dat & 0xffff];
-            p[x + 5] = video_16to32[dat >> 16];
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 8) & svga->vram_mask]);
+                p[x + 4] = video_16to32[dat & 0xffff];
+                p[x + 5] = video_16to32[dat >> 16];
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1) + 12) & dev->vram_mask]);
-            p[x + 6] = video_16to32[dat & 0xffff];
-            p[x + 7] = video_16to32[dat >> 16];
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 1) + 12) & svga->vram_mask]);
+                p[x + 6] = video_16to32[dat & 0xffff];
+                p[x + 7] = video_16to32[dat >> 16];
+            }
+            svga->memaddr += (x << 1);
+            svga->memaddr &= svga->vram_mask;
         }
-        dev->memaddr += (x << 1);
-        dev->memaddr &= dev->vram_mask;
+    } else {
+        if ((dev->displine + svga->y_add) < 0)
+            return;
+
+        if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
+            p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
+
+            if (dev->firstline_draw == 2000)
+                dev->firstline_draw = dev->displine;
+            dev->lastline_draw = dev->displine;
+
+            for (x = 0; x <= dev->h_disp; x += 8) {
+                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1)) & dev->vram_mask]);
+                p[x]     = video_16to32[dat & 0xffff];
+                p[x + 1] = video_16to32[dat >> 16];
+
+                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1) + 4) & dev->vram_mask]);
+                p[x + 2] = video_16to32[dat & 0xffff];
+                p[x + 3] = video_16to32[dat >> 16];
+
+                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1) + 8) & dev->vram_mask]);
+                p[x + 4] = video_16to32[dat & 0xffff];
+                p[x + 5] = video_16to32[dat >> 16];
+
+                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 1) + 12) & dev->vram_mask]);
+                p[x + 6] = video_16to32[dat & 0xffff];
+                p[x + 7] = video_16to32[dat >> 16];
+            }
+            dev->memaddr += (x << 1);
+            dev->memaddr &= dev->vram_mask;
+        }
     }
 }
 
@@ -3700,29 +3834,56 @@ ibm8514_render_24bpp(svga_t *svga)
     if ((dev->displine + svga->y_add) < 0)
         return;
 
-    if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
-        p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
+    if (ATI_MACH32) {
+        if (svga->changedvram[dev->memaddr >> 12] || svga->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
+            p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
 
-        if (dev->firstline_draw == 2000)
-            dev->firstline_draw = dev->displine;
-        dev->lastline_draw = dev->displine;
+            if (dev->firstline_draw == 2000)
+                dev->firstline_draw = dev->displine;
+            dev->lastline_draw = dev->displine;
 
-        for (int x = 0; x <= dev->h_disp; x += 4) {
-            dat  = *(uint32_t *) (&dev->vram[dev->memaddr & dev->vram_mask]);
-            p[x] = dat & 0xffffff;
+            for (int x = 0; x <= dev->h_disp; x += 4) {
+                dat  = *(uint32_t *) (&svga->vram[dev->memaddr & svga->vram_mask]);
+                p[x] = dat & 0xffffff;
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 3) & dev->vram_mask]);
-            p[x + 1] = dat & 0xffffff;
+                dat      = *(uint32_t *) (&svga->vram[(dev->memaddr + 3) & svga->vram_mask]);
+                p[x + 1] = dat & 0xffffff;
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 6) & dev->vram_mask]);
-            p[x + 2] = dat & 0xffffff;
+                dat      = *(uint32_t *) (&svga->vram[(dev->memaddr + 6) & svga->vram_mask]);
+                p[x + 2] = dat & 0xffffff;
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 9) & dev->vram_mask]);
-            p[x + 3] = dat & 0xffffff;
+                dat      = *(uint32_t *) (&svga->vram[(dev->memaddr + 9) & svga->vram_mask]);
+                p[x + 3] = dat & 0xffffff;
 
-            dev->memaddr += 12;
+                dev->memaddr += 12;
+            }
+            dev->memaddr &= svga->vram_mask;
         }
-        dev->memaddr &= dev->vram_mask;
+    } else {
+        if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
+            p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
+
+            if (dev->firstline_draw == 2000)
+                dev->firstline_draw = dev->displine;
+            dev->lastline_draw = dev->displine;
+
+            for (int x = 0; x <= dev->h_disp; x += 4) {
+                dat  = *(uint32_t *) (&dev->vram[dev->memaddr & dev->vram_mask]);
+                p[x] = dat & 0xffffff;
+
+                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 3) & dev->vram_mask]);
+                p[x + 1] = dat & 0xffffff;
+
+                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 6) & dev->vram_mask]);
+                p[x + 2] = dat & 0xffffff;
+
+                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 9) & dev->vram_mask]);
+                p[x + 3] = dat & 0xffffff;
+
+                dev->memaddr += 12;
+            }
+            dev->memaddr &= dev->vram_mask;
+        }
     }
 }
 
@@ -3736,29 +3897,56 @@ ibm8514_render_BGR(svga_t *svga)
     if ((dev->displine + svga->y_add) < 0)
         return;
 
-    if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
-        p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
+    if (ATI_MACH32) {
+        if (svga->changedvram[dev->memaddr >> 12] || svga->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
+            p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
 
-        if (dev->firstline_draw == 2000)
-            dev->firstline_draw = dev->displine;
-        dev->lastline_draw = dev->displine;
+            if (dev->firstline_draw == 2000)
+                dev->firstline_draw = dev->displine;
+            dev->lastline_draw = dev->displine;
 
-        for (int x = 0; x <= dev->h_disp; x += 4) {
-            dat  = *(uint32_t *) (&dev->vram[dev->memaddr & dev->vram_mask]);
-            p[x] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
+            for (int x = 0; x <= dev->h_disp; x += 4) {
+                dat  = *(uint32_t *) (&svga->vram[dev->memaddr & svga->vram_mask]);
+                p[x] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 3) & dev->vram_mask]);
-            p[x + 1] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
+                dat      = *(uint32_t *) (&svga->vram[(dev->memaddr + 3) & svga->vram_mask]);
+                p[x + 1] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 6) & dev->vram_mask]);
-            p[x + 2] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
+                dat      = *(uint32_t *) (&svga->vram[(dev->memaddr + 6) & svga->vram_mask]);
+                p[x + 2] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
 
-            dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 9) & dev->vram_mask]);
-            p[x + 3] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
+                dat      = *(uint32_t *) (&svga->vram[(dev->memaddr + 9) & svga->vram_mask]);
+                p[x + 3] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
 
-            dev->memaddr += 12;
+                dev->memaddr += 12;
+            }
+            dev->memaddr &= svga->vram_mask;
         }
-        dev->memaddr &= dev->vram_mask;
+    } else {
+        if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
+            p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
+
+            if (dev->firstline_draw == 2000)
+                dev->firstline_draw = dev->displine;
+            dev->lastline_draw = dev->displine;
+
+            for (int x = 0; x <= dev->h_disp; x += 4) {
+                dat  = *(uint32_t *) (&dev->vram[dev->memaddr & dev->vram_mask]);
+                p[x] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
+
+                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 3) & dev->vram_mask]);
+                p[x + 1] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
+
+                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 6) & dev->vram_mask]);
+                p[x + 2] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
+
+                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 9) & dev->vram_mask]);
+                p[x + 3] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
+
+                dev->memaddr += 12;
+            }
+            dev->memaddr &= dev->vram_mask;
+        }
     }
 }
 
@@ -3773,19 +3961,36 @@ ibm8514_render_ABGR8888(svga_t *svga)
     if ((dev->displine + svga->y_add) < 0)
         return;
 
-    if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
-        p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
+    if (ATI_MACH32) {
+        if (svga->changedvram[dev->memaddr >> 12] || svga->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
+            p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
 
-        if (dev->firstline_draw == 2000)
-            dev->firstline_draw = dev->displine;
-        dev->lastline_draw = dev->displine;
+            if (dev->firstline_draw == 2000)
+                dev->firstline_draw = dev->displine;
+            dev->lastline_draw = dev->displine;
 
-        for (x = 0; x <= dev->h_disp; x++) {
-            dat  = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 2)) & dev->vram_mask]);
-            *p++ = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
+            for (x = 0; x <= dev->h_disp; x++) {
+                dat  = *(uint32_t *) (&svga->vram[(dev->memaddr + (x << 2)) & svga->vram_mask]);
+                *p++ = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
+            }
+            dev->memaddr += (x * 4);
+            dev->memaddr &= svga->vram_mask;
         }
-        dev->memaddr += (x * 4);
-        dev->memaddr &= dev->vram_mask;
+    } else {
+        if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
+            p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
+
+            if (dev->firstline_draw == 2000)
+                dev->firstline_draw = dev->displine;
+            dev->lastline_draw = dev->displine;
+
+            for (x = 0; x <= dev->h_disp; x++) {
+                dat  = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 2)) & dev->vram_mask]);
+                *p++ = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
+            }
+            dev->memaddr += (x * 4);
+            dev->memaddr &= dev->vram_mask;
+        }
     }
 }
 
@@ -3800,33 +4005,61 @@ ibm8514_render_32bpp(svga_t *svga)
     if ((dev->displine + svga->y_add) < 0)
         return;
 
-    if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || dev->changedvram[(dev->memaddr >> 12) + 2] || svga->fullchange) {
-        p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
+    if (ATI_MACH32) {
+        if (svga->changedvram[dev->memaddr >> 12] || svga->changedvram[(dev->memaddr >> 12) + 1] || svga->changedvram[(dev->memaddr >> 12) + 2] || svga->fullchange) {
+            p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
 
-        if (dev->firstline_draw == 2000)
-            dev->firstline_draw = dev->displine;
-        dev->lastline_draw = dev->displine;
+            if (dev->firstline_draw == 2000)
+                dev->firstline_draw = dev->displine;
+            dev->lastline_draw = dev->displine;
 
-        for (x = 0; x <= dev->h_disp; x++) {
-            dat  = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 2)) & dev->vram_mask]);
-            p[x] = dat & 0xffffff;
+            for (x = 0; x <= dev->h_disp; x++) {
+                dat  = *(uint32_t *) (&svga->vram[(dev->memaddr + (x << 2)) & svga->vram_mask]);
+                p[x] = dat & 0xffffff;
+            }
+            dev->memaddr += (x * 4);
+            dev->memaddr &= svga->vram_mask;
         }
-        dev->memaddr += (x * 4);
-        dev->memaddr &= dev->vram_mask;
+    } else {
+        if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || dev->changedvram[(dev->memaddr >> 12) + 2] || svga->fullchange) {
+            p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
+
+            if (dev->firstline_draw == 2000)
+                dev->firstline_draw = dev->displine;
+            dev->lastline_draw = dev->displine;
+
+            for (x = 0; x <= dev->h_disp; x++) {
+                dat  = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 2)) & dev->vram_mask]);
+                p[x] = dat & 0xffffff;
+            }
+            dev->memaddr += (x * 4);
+            dev->memaddr &= dev->vram_mask;
+        }
     }
 }
 
 static void
 ibm8514_render_overscan_left(ibm8514_t *dev, svga_t *svga)
 {
-    if ((dev->displine + svga->y_add) < 0)
-        return;
+    if (ATI_MACH32) {
+        if ((svga->displine + svga->y_add) < 0)
+            return;
 
-    if (svga->scrblank || (dev->h_disp == 0))
-        return;
+        if (svga->scrblank || (svga->hdisp == 0))
+            return;
 
-    for (int i = 0; i < svga->x_add; i++)
-        buffer32->line[dev->displine + svga->y_add][i] = svga->overscan_color;
+        for (int i = 0; i < svga->x_add; i++)
+            buffer32->line[svga->displine + svga->y_add][i] = svga->overscan_color;
+    } else {
+        if ((dev->displine + svga->y_add) < 0)
+            return;
+
+        if (svga->scrblank || (dev->h_disp == 0))
+            return;
+
+        for (int i = 0; i < svga->x_add; i++)
+            buffer32->line[dev->displine + svga->y_add][i] = svga->overscan_color;
+    }
 }
 
 static void
@@ -3834,15 +4067,27 @@ ibm8514_render_overscan_right(ibm8514_t *dev, svga_t *svga)
 {
     int right;
 
-    if ((dev->displine + svga->y_add) < 0)
-        return;
+    if (ATI_MACH32) {
+        if ((svga->displine + svga->y_add) < 0)
+            return;
 
-    if (svga->scrblank || (dev->h_disp == 0))
-        return;
+        if (svga->scrblank || (svga->hdisp == 0))
+            return;
 
-    right = (overscan_x >> 1);
-    for (int i = 0; i < right; i++)
-        buffer32->line[dev->displine + svga->y_add][svga->x_add + dev->h_disp + i] = svga->overscan_color;
+        right = (overscan_x >> 1);
+        for (int i = 0; i < right; i++)
+            buffer32->line[svga->displine + svga->y_add][svga->x_add + svga->hdisp + i] = svga->overscan_color;
+    } else {
+        if ((dev->displine + svga->y_add) < 0)
+            return;
+
+        if (svga->scrblank || (dev->h_disp == 0))
+            return;
+
+        right = (overscan_x >> 1);
+        for (int i = 0; i < right; i++)
+            buffer32->line[dev->displine + svga->y_add][svga->x_add + dev->h_disp + i] = svga->overscan_color;
+    }
 }
 
 void
@@ -3857,6 +4102,7 @@ ibm8514_poll(void *priv)
     svga_t *svga = (svga_t *)priv;
     ibm8514_t *dev = (ibm8514_t *)svga->dev8514;
     uint32_t x;
+    uint32_t blink_delay;
     int      wx;
     int      wy;
 
@@ -3865,7 +4111,209 @@ ibm8514_poll(void *priv)
         ibm8514_log(dev->log,"ON!\n");
         if (svga->override)
             svga_set_poll(svga);
-        else {
+        else if (ATI_MACH32) {
+            if (!svga->linepos) {
+                if (svga->displine == ((svga->hwcursor_latch.y < 0) ? 0 : svga->hwcursor_latch.y) && svga->hwcursor_latch.ena) {
+                    svga->hwcursor_on      = svga->hwcursor_latch.cur_ysize - svga->hwcursor_latch.yoff;
+                    svga->hwcursor_oddeven = 0;
+                }
+
+                if (svga->displine == (((svga->hwcursor_latch.y < 0) ? 0 : svga->hwcursor_latch.y) + 1) && svga->hwcursor_latch.ena && svga->interlace) {
+                    svga->hwcursor_on      = svga->hwcursor_latch.cur_ysize - (svga->hwcursor_latch.yoff + 1);
+                    svga->hwcursor_oddeven = 1;
+                }
+
+                timer_advance_u64(&svga->timer, svga->dispofftime);
+                svga->cgastat |= 1;
+                svga->linepos = 1;
+
+                if (svga->dispon) {
+                    svga->hdisp_on = 1;
+
+                    svga->memaddr &= svga->vram_display_mask;
+                    if (svga->firstline == 2000) {
+                        svga->firstline = svga->displine;
+                        video_wait_for_buffer_monitor(svga->monitor_index);
+                    }
+
+                    if (svga->hwcursor_on)
+                        svga->changedvram[svga->memaddr >> 12] = svga->changedvram[(svga->memaddr >> 12) + 1] = svga->interlace ? 3 : 2;
+
+                    svga->render8514(svga);
+
+                    svga->x_add = svga->left_overscan;
+                    ibm8514_render_overscan_left(dev, svga);
+                    ibm8514_render_overscan_right(dev, svga);
+                    svga->x_add = svga->left_overscan;
+
+                    if (svga->hwcursor_on) {
+                        if (svga->hwcursor_draw)
+                            svga->hwcursor_draw(svga, (svga->displine + svga->y_add + ((svga->hwcursor_latch.y >= 0) ? 0 : svga->hwcursor_latch.y)) & 2047);
+
+                        svga->hwcursor_on--;
+                        if (svga->hwcursor_on && svga->interlace)
+                            svga->hwcursor_on--;
+                    }
+
+                    if (svga->lastline < svga->displine)
+                        svga->lastline = svga->displine;
+                }
+
+                svga->displine++;
+                video_lightpen_check_trigger_strobe(svga->x_add, svga->displine, 0, svga->firstline, 1. / (svga->clock / (cpuclock * (double) (1ULL << 32))), svga->monitor_index);
+                if (svga->interlace)
+                    svga->displine++;
+                if ((svga->cgastat & 8) && ((svga->displine & 15) == (svga->crtc[0x11] & 15)) && svga->vslines)
+                    svga->cgastat &= ~8;
+                svga->vslines++;
+                if (svga->displine > 2000)
+                    svga->displine = 0;
+            } else {
+                timer_advance_u64(&svga->timer, svga->dispontime);
+                video_lightpen_hsync();
+
+                if (svga->dispon)
+                    svga->cgastat &= ~1;
+                svga->hdisp_on = 0;
+
+                svga->linepos = 0;
+                if ((svga->scanline == (svga->crtc[11] & 31)) || (svga->scanline == svga->rowcount))
+                    svga->cursorvisible = 0;
+                if (svga->dispon) {
+                    /* TODO: Verify real hardware behaviour for out-of-range fine vertical scroll
+                       - S3 Trio64V2/DX: scanline == rowcount, wrapping 5-bit counter. */
+                    if (svga->linedbl && !svga->linecountff) {
+                        svga->linecountff = 1;
+                        svga->memaddr          = svga->memaddr_backup;
+                    } else if (svga->scanline == svga->rowcount) {
+                        svga->linecountff = 0;
+                        svga->scanline          = 0;
+
+                        svga->memaddr_backup += (svga->rowoffset << 3);
+                        if (svga->interlace)
+                            svga->memaddr_backup += (svga->rowoffset << 3);
+
+                        svga->memaddr_backup &= svga->vram_display_mask;
+                        svga->memaddr = svga->memaddr_backup;
+                    } else {
+                        svga->linecountff = 0;
+                        svga->scanline++;
+                        svga->scanline &= 0x1f;
+                        svga->memaddr = svga->memaddr_backup;
+                    }
+                }
+
+                svga->hsync_divisor ^= 1;
+
+                if (svga->hsync_divisor && (svga->crtc[0x17] & 4))
+                    return;
+
+                dev->vc++;
+                dev->vc &= 0xfff;
+
+                if (dev->vc == svga->split) {
+                    if (svga->interlace && svga->oddeven)
+                        svga->memaddr = svga->memaddr_backup = (svga->rowoffset << 1);
+                    else
+                        svga->memaddr = svga->memaddr_backup = 0;
+
+                    svga->memaddr     = (svga->memaddr << 2);
+                    svga->memaddr_backup = (svga->memaddr_backup << 2);
+
+                    svga->scanline = 0;
+                    if (svga->attrregs[0x10] & 0x20) {
+                        svga->scrollcache   = 0;
+                        svga->half_pixel    = 0;
+                        svga->x_add         = svga->left_overscan;
+                    }
+                }
+                if (dev->vc == svga->dispend) {
+                    dev->vblank_start(svga);
+                    svga->dispon = 0;
+                    blink_delay  = (svga->crtc[11] & 0x60) >> 5;
+                    if (svga->crtc[10] & 0x20)
+                        svga->cursoron = 0;
+                    else if (blink_delay == 2)
+                        svga->cursoron = ((svga->blink % 96) >= 48);
+                    else
+                        svga->cursoron = svga->blink & (16 + (16 * blink_delay));
+
+                    if (!(svga->blink & 15))
+                        svga->fullchange = 2;
+
+                    svga->blink = (svga->blink + 1) & 0x7f;
+
+                    for (x = 0; x < ((svga->vram_mask + 1) >> 12); x++) {
+                        if (svga->changedvram[x])
+                            svga->changedvram[x]--;
+                    }
+
+                    if (svga->fullchange)
+                        svga->fullchange--;
+                }
+                if (dev->vc == svga->vsyncstart) {
+                    svga->dispon = 0;
+                    svga->cgastat |= 8;
+                    x = svga->hdisp;
+
+                    if (svga->interlace && !svga->oddeven)
+                        svga->lastline++;
+                    if (svga->interlace && svga->oddeven)
+                        svga->firstline--;
+
+                    wx = x;
+                    wy = svga->lastline - svga->firstline;
+                    svga->vdisp = wy + 1;
+                    svga_doblit(wx, wy, svga);
+
+                    svga->firstline = 2000;
+                    svga->lastline  = 0;
+
+                    svga->firstline_draw = 2000;
+                    svga->lastline_draw  = 0;
+
+                    svga->oddeven ^= 1;
+
+                    svga->monitor->mon_changeframecount = svga->interlace ? 3 : 2;
+                    svga->vslines                       = 0;
+
+                    if (svga->interlace && svga->oddeven)
+                        svga->memaddr = svga->memaddr_backup = svga->memaddr_latch + (svga->rowoffset << 1);
+                    else
+                        svga->memaddr = svga->memaddr_backup = svga->memaddr_latch;
+
+                    svga->cursoraddr     = ((svga->crtc[0xe] << 8) | svga->crtc[0xf]) + ((svga->crtc[0xb] & 0x60) >> 5) + svga->ca_adj;
+                    svga->memaddr     = (svga->memaddr << 2);
+                    svga->memaddr_backup = (svga->memaddr_backup << 2);
+                    svga->cursoraddr     = (svga->cursoraddr << 2);
+
+                    if (svga->vsync_callback)
+                        svga->vsync_callback(svga);
+
+                    video_lightpen_vsync();
+
+                    svga->start_retrace_latch = svga->crtc[0x4];
+                }
+                if (dev->vc == svga->vtotal) {
+                    dev->vc       = 0;
+                    svga->scanline       = (svga->crtc[0x8] & 0x1f);
+                    svga->dispon   = 1;
+                    svga->displine = (svga->interlace && svga->oddeven) ? 1 : 0;
+
+                    svga->scrollcache = 0;
+                    svga->half_pixel  = 0;
+
+                    svga->x_add = svga->left_overscan;
+
+                    svga->linecountff = 0;
+
+                    svga->hwcursor_on    = 0;
+                    svga->hwcursor_latch = svga->hwcursor;
+                }
+                if (svga->scanline == (svga->crtc[10] & 31))
+                    svga->cursorvisible = 1;
+            }
+        } else {
             if (!dev->linepos) {
                 if ((dev->displine == ((dev->hwcursor_latch.y < 0) ? 0 : dev->hwcursor_latch.y)) && dev->hwcursor_latch.ena) {
                     dev->hwcursor_on      = dev->hwcursor_latch.cur_ysize - dev->hwcursor_latch.yoff;
@@ -3904,6 +4352,7 @@ ibm8514_poll(void *priv)
                     if (dev->hwcursor_on) {
                         if (svga->hwcursor_draw)
                             svga->hwcursor_draw(svga, (dev->displine + svga->y_add + ((dev->hwcursor_latch.y >= 0) ? 0 : dev->hwcursor_latch.y)) & 2047);
+
                         dev->hwcursor_on--;
                         if (dev->hwcursor_on && dev->interlace)
                             dev->hwcursor_on--;
@@ -3915,7 +4364,6 @@ ibm8514_poll(void *priv)
 
                 dev->displine++;
                 video_lightpen_check_trigger_strobe(svga->x_add, dev->displine, 0, dev->firstline, 1. / (svga->clock / (svga->clock_8514 * (double) (1ULL << 32))), svga->monitor_index);
-
                 if (dev->interlace)
                     dev->displine++;
                 if ((svga->cgastat & 8) && ((dev->displine & 0x0f) == (svga->crtc[0x11] & 0x0f)) && svga->vslines)
@@ -3926,6 +4374,7 @@ ibm8514_poll(void *priv)
             } else {
                 timer_advance_u64(&svga->timer, dev->dispontime);
                 video_lightpen_hsync();
+
                 if (dev->dispon)
                     svga->cgastat &= ~1;
                 dev->hdisp_on = 0;
@@ -3939,6 +4388,7 @@ ibm8514_poll(void *priv)
                             dev->memaddr_backup += (dev->rowoffset << 3);
 
                         dev->memaddr_backup &= dev->vram_mask;
+
                         dev->memaddr = dev->memaddr_backup;
                     } else {
                         dev->scanline++;
@@ -3995,6 +4445,7 @@ ibm8514_poll(void *priv)
 
                     dev->memaddr     = (dev->memaddr << 2);
                     dev->memaddr_backup = (dev->memaddr_backup << 2);
+
                     video_lightpen_vsync();
                 }
                 if (dev->vc == dev->v_total) {

--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -120,47 +120,72 @@ mach_log(void *priv, const char *format, ...)
 
 #define READ_PIXTRANS_BYTE_IO(cx, n) \
     if ((mach->accel.cmd_type == 2) || (mach->accel.cmd_type == 5)) { \
-        if (dev->bpp) {                                                                                             \
-            if (n == 0)                                                                                             \
-                mach->accel.pix_trans[(n)] = vram_w[(dev->accel.dest + (cx) + (n)) & (dev->vram_mask >> 1)] & 0xff; \
-            else                                                                                                    \
-                mach->accel.pix_trans[(n)] = vram_w[(dev->accel.dest + (cx) + (n)) & (dev->vram_mask >> 1)] >> 8;   \
-        } else                                                                                                      \
-            mach->accel.pix_trans[(n)] = dev->vram[(dev->accel.dest + (cx) + (n)) & dev->vram_mask];                \
+        if (dev->bpp) {                                                                                                     \
+            if (n == 0)                                                                                                     \
+                mach->accel.pix_trans[(n)] = vga_vram_w[(dev->accel.dest + (cx) + (n)) & (svga->vram_mask >> 1)] & 0xff;    \
+            else                                                                                                            \
+                mach->accel.pix_trans[(n)] = vga_vram_w[(dev->accel.dest + (cx) + (n)) & (svga->vram_mask >> 1)] >> 8;      \
+        } else                                                                                                              \
+            if (ATI_MACH32)                                                                                                 \
+                mach->accel.pix_trans[(n)] = svga->vram[(dev->accel.dest + (cx) + (n)) & svga->vram_mask];                  \
+            else                                                                                                            \
+                mach->accel.pix_trans[(n)] = dev->vram[(dev->accel.dest + (cx) + (n)) & dev->vram_mask];                    \
     }
 
-#define READ_PIXTRANS_WORD(cx, n)                                                                                                          \
-    if ((cmd == 0) || (cmd == 1) || (cmd == 5) || ((mach->accel.cmd_type == -1) && (cmd != 2))) {                                                          \
-        if (dev->bpp)                                                                                                                      \
-            temp = vram_w[((dev->accel.cy * dev->pitch) + (cx) + (n)) & (dev->vram_mask >> 1)];                                            \
-        else {                                                                                                                             \
-            temp = dev->vram[((dev->accel.cy * dev->pitch) + (cx) + (n)) & dev->vram_mask];                                                \
-            temp |= (dev->vram[((dev->accel.cy * dev->pitch) + (cx) + (n + 1)) & dev->vram_mask] << 8);                                    \
-        }                                                                                                                                  \
-    } else if (((cmd == 2) && (mach->accel.cmd_type == -1)) || (mach->accel.cmd_type == 2) || (mach->accel.cmd_type == 5)) {                                                               \
-        if (dev->bpp)                                                                                                                      \
-            temp = vram_w[((dev->accel.dest) + (cx) + (n)) & (dev->vram_mask >> 1)];                                                       \
-        else {                                                                                                                             \
-            temp = dev->vram[((dev->accel.dest) + (cx) + (n)) & dev->vram_mask];                                                           \
-            temp |= (dev->vram[((dev->accel.dest) + (cx) + (n + 1)) & dev->vram_mask] << 8);                                               \
-        }                                                                                                                                  \
-    } else if ((mach->accel.cmd_type == 3) || (mach->accel.cmd_type == 4)) {                                                               \
-        if (dev->bpp)                                                                                                                      \
-            temp = vram_w[(mach->accel.dst_ge_offset + ((dev->accel.cy) * (mach->accel.dst_pitch)) + (cx) + (n)) & (dev->vram_mask >> 1)];         \
-        else {                                                                                                                             \
-            temp = dev->vram[(mach->accel.dst_ge_offset + ((dev->accel.cy) * (mach->accel.dst_pitch)) + (cx) + (n)) & dev->vram_mask];             \
-            temp |= (dev->vram[(mach->accel.dst_ge_offset + ((dev->accel.cy) * (mach->accel.dst_pitch)) + (cx) + (n + 1)) & dev->vram_mask] << 8); \
-        }                                                                                                                                  \
+#define READ_PIXTRANS_WORD(cx, n)                                                                                                               \
+    if ((cmd == 0) || (cmd == 1) || (cmd == 5) || ((mach->accel.cmd_type == -1) && (cmd != 2))) {                                               \
+        if (dev->bpp)                                                                                                                           \
+            temp = vga_vram_w[((dev->accel.cy * dev->pitch) + (cx) + (n)) & (svga->vram_mask >> 1)];                                            \
+        else {                                                                                                                                  \
+            if (ATI_MACH32) {                                                                                                                   \
+                temp = svga->vram[((dev->accel.cy * dev->pitch) + (cx) + (n)) & svga->vram_mask];                                               \
+                temp |= (svga->vram[((dev->accel.cy * dev->pitch) + (cx) + (n + 1)) & svga->vram_mask] << 8);                                   \
+            } else {                                                                                                                            \
+                temp = dev->vram[((dev->accel.cy * dev->pitch) + (cx) + (n)) & dev->vram_mask];                                                 \
+                temp |= (dev->vram[((dev->accel.cy * dev->pitch) + (cx) + (n + 1)) & dev->vram_mask] << 8);                                     \
+            }                                                                                                                                   \
+        }                                                                                                                                       \
+    } else if (((cmd == 2) && (mach->accel.cmd_type == -1)) || (mach->accel.cmd_type == 2) || (mach->accel.cmd_type == 5)) {                    \
+        if (dev->bpp)                                                                                                                           \
+            temp = vga_vram_w[((dev->accel.dest) + (cx) + (n)) & (svga->vram_mask >> 1)];                                                       \
+        else {                                                                                                                                  \
+            if (ATI_MACH32) {                                                                                                                   \
+                temp = svga->vram[((dev->accel.dest) + (cx) + (n)) & svga->vram_mask];                                                          \
+                temp |= (svga->vram[((dev->accel.dest) + (cx) + (n + 1)) & svga->vram_mask] << 8);                                              \
+            } else {                                                                                                                            \
+                temp = dev->vram[((dev->accel.dest) + (cx) + (n)) & dev->vram_mask];                                                            \
+                temp |= (dev->vram[((dev->accel.dest) + (cx) + (n + 1)) & dev->vram_mask] << 8);                                                \
+            }                                                                                                                                   \
+        }                                                                                                                                       \
+    } else if ((mach->accel.cmd_type == 3) || (mach->accel.cmd_type == 4)) {                                                                    \
+        if (dev->bpp)                                                                                                                           \
+            temp = vga_vram_w[(mach->accel.dst_ge_offset + ((dev->accel.cy) * (mach->accel.dst_pitch)) + (cx) + (n)) & (svga->vram_mask >> 1)]; \
+        else {                                                                                                                                  \
+            if (ATI_MACH32) {                                                                                                                   \
+                temp = svga->vram[(mach->accel.dst_ge_offset + ((dev->accel.cy) * (mach->accel.dst_pitch)) + (cx) + (n)) & svga->vram_mask];                \
+                temp |= (svga->vram[(mach->accel.dst_ge_offset + ((dev->accel.cy) * (mach->accel.dst_pitch)) + (cx) + (n + 1)) & svga->vram_mask] << 8);    \
+            } else {                                                                                                                                        \
+                temp = dev->vram[(mach->accel.dst_ge_offset + ((dev->accel.cy) * (mach->accel.dst_pitch)) + (cx) + (n)) & dev->vram_mask];                  \
+                temp |= (dev->vram[(mach->accel.dst_ge_offset + ((dev->accel.cy) * (mach->accel.dst_pitch)) + (cx) + (n + 1)) & dev->vram_mask] << 8);      \
+            }                                                                                                                                               \
+        }                                                                                                                                                   \
     }
 
-#define READ(addr, dat)                               \
-    if (dev->bpp)                                     \
-        dat = vram_w[(addr) & (dev->vram_mask >> 1)]; \
-    else                                              \
-        dat = (dev->vram[(addr) & (dev->vram_mask)]);
+#define READ(addr, dat)                                     \
+    if (dev->bpp)                                           \
+        dat = vga_vram_w[(addr) & (svga->vram_mask >> 1)];  \
+    else {                                                  \
+        if (ATI_MACH32)                                     \
+            dat = (svga->vram[(addr) & (svga->vram_mask)]); \
+        else                                                \
+            dat = (dev->vram[(addr) & (dev->vram_mask)]);   \
+    }
 
-#define READ_HIGH(addr, dat)                            \
-    dat |= (dev->vram[(addr) & (dev->vram_mask)] << 8);
+#define READ_HIGH(addr, dat)                                    \
+    if (ATI_MACH32)                                             \
+        dat |= (svga->vram[(addr) & (svga->vram_mask)] << 8);   \
+    else                                                        \
+        dat |= (dev->vram[(addr) & (dev->vram_mask)] << 8);
 
 #define MIX(mixmode, dest_dat, src_dat)                                                               \
     {                                                                                                 \
@@ -276,13 +301,18 @@ mach_log(void *priv, const char *format, ...)
     }
 
 
-#define WRITE(addr, dat)                                                               \
-    if (dev->bpp) {                                                                    \
-        vram_w[((addr)) & (dev->vram_mask >> 1)]                    = dat;             \
-        dev->changedvram[(((addr)) & (dev->vram_mask >> 1)) >> 11] = svga->monitor->mon_changeframecount; \
-    } else {                                                                           \
-        dev->vram[((addr)) & (dev->vram_mask)]                = dat;                   \
-        dev->changedvram[(((addr)) & (dev->vram_mask)) >> 12] = svga->monitor->mon_changeframecount;      \
+#define WRITE(addr, dat)                                                                                    \
+    if (dev->bpp) {                                                                                         \
+        vga_vram_w[((addr)) & (svga->vram_mask >> 1)]                    = dat;                             \
+        svga->changedvram[(((addr)) & (svga->vram_mask >> 1)) >> 11] = svga->monitor->mon_changeframecount; \
+    } else {                                                                                                \
+        if (ATI_MACH32) {                                                                                   \
+            svga->vram[((addr)) & (svga->vram_mask)]                = dat;                                  \
+            svga->changedvram[(((addr)) & (svga->vram_mask)) >> 12] = svga->monitor->mon_changeframecount;  \
+        } else {                                                                                            \
+            dev->vram[((addr)) & (dev->vram_mask)]                = dat;                                    \
+            dev->changedvram[(((addr)) & (dev->vram_mask)) >> 12] = svga->monitor->mon_changeframecount;    \
+        }                                                                                                   \
     }
 
 static int
@@ -320,7 +350,7 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
     uint16_t      src_dat  = 0;
     uint16_t      dest_dat = 0;
     uint16_t      old_dest_dat;
-    uint16_t     *vram_w    = (uint16_t *) dev->vram;
+    uint16_t     *vga_vram_w = (uint16_t *) svga->vram;
     uint16_t      mix       = 0;
     uint32_t      mono_dat0 = 0;
     uint32_t      mono_dat1 = 0;
@@ -1198,12 +1228,6 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
                     cpu_dat >>= 16;
                 else
                     cpu_dat >>= 8;
-
-                if (mach->accel.dp_config == 0x2071)
-                    mach_log(mach->log,"FontBlit: SX=%d, C(%d,%d), SRCWidth=%d, frgdmix=%d, bkgdmix=%d, rdmask=%04x, D(%d,%d), geoffset=%x, addr=%08x, 8bppdata=%02x, 16bppdata=%04x, vgabase=%06x.\n",
-                             mach->accel.sx, dev->accel.cx, dev->accel.cy, mach->accel.src_width, dev->accel.frgd_mix & 0x1f,
-                             dev->accel.bkgd_mix & 0x1f, rd_mask, dev->accel.dx, dev->accel.dy, dev->accel.ge_offset,
-                             (dev->accel.src + dev->accel.cx) & dev->vram_mask, dev->vram[(dev->accel.src + dev->accel.cx) & dev->vram_mask], vram_w[(dev->accel.src + dev->accel.cx) & (dev->vram_mask >> 1)], svga->mapping.base);
 
                 if ((mono_src == 3) || (frgd_sel == 3) || (bkgd_sel == 3) || (mach->accel.dp_config & 0x02)) {
                     dev->accel.cx += mach->accel.src_stepx;
@@ -2172,7 +2196,6 @@ mach_accel_start(int cmd_type, int cpu_input, int count, uint32_t mix_dat, uint3
 
                         if (mach->accel.dp_config & 0x10) {
                             WRITE(dev->accel.dest + dev->accel.dx, dest_dat);
-                            mach_log(mach->log,"WriteSCANTOX: DX=%d, DY=%d, destdat=%04x, compare_mode=%x.\n", dev->accel.dx, dev->accel.dy, dest_dat, compare_mode);
                         }
                     }
                 }
@@ -2338,24 +2361,22 @@ mach_out(uint16_t addr, uint8_t val, void *priv)
                     break;
                 case 0xb0:
                     if ((old ^ val) & 0x60) {
-                        mach_log(mach->log,"ExtModeINC=%d, VGA mode on=%x.\n", dev->ext_mode_inc, dev->mode);
-                        if (dev->ext_mode_inc) {
-                            if (!(mach->accel.clock_sel & 0x01)) {
-                                if ((val & 0x20) && !(old & 0x20)) {
-                                    dev->on = 1;
-                                    dev->vendor_mode = !!(ATI_MACH32);
-                                    mach_set_resolution(mach, svga);
-                                    mach32_updatemapping(mach, svga);
-                                } else if (!(val & 0x20) && (old & 0x20)) {
-                                    dev->on = 0;
-                                    dev->vendor_mode = 0;
-                                    mach_set_resolution(mach, svga);
-                                    mach32_updatemapping(mach, svga);
-                                }
+                        mach_log(mach->log, "Extended VGA mode on=%x, Accel BPP=%d, val=%02x, old=%02x, 8514htotal=%02x, vgahtotal=%02x.\n", dev->mode, dev->accel_bpp, val & 0x20, old & 0x20, dev->h_total_back, svga->crtc[0] + 5);
+                        /*FIXME: Some software uses this ATI register to enable 256+ color mode on the extended ATI 8514/A modes, not just plain ATI (S)VGA.*/
+                        if (ATI_MACH32 && dev->h_total_back && !dev->vga_htotal) {
+                            if (!(val & 0x20) && (old & 0x20)) {
+                                dev->on &= ~0x01;
+                                dev->vendor_mode = 0;
+                                mach_set_resolution(mach, svga);
+                                mach32_updatemapping(mach, svga);
+                            } else if ((val & 0x20) && !(old & 0x20)) {
+                                dev->on |= 0x01;
+                                dev->vendor_mode = 1;
+                                mach_set_resolution(mach, svga);
+                                mach32_updatemapping(mach, svga);
                             }
-                        } else
-                            svga_recalctimings(svga);
-
+                        }
+                        svga_recalctimings(svga);
                         mach_log(mach->log,"ATI B0 bits 5-6: old=%02x, val=%02x, on=%d, bpp=%d, hires=%x, vgahires=%02x, base=%05x.\n",
                               old & 0x60, val & 0x60, dev->on, dev->accel_bpp, dev->accel.advfunc_cntl & 0x04, svga->gdcreg[5] & 0x60, svga->mapping.base);
                     }
@@ -2540,6 +2561,12 @@ mach_out(uint16_t addr, uint8_t val, void *priv)
                         svga->fullchange = 3;
                         svga->memaddr_latch   = ((svga->crtc[0xc] << 8) | svga->crtc[0xd]) + ((svga->crtc[8] & 0x60) >> 5);
                     } else {
+                        if (ATI_MACH32) {
+                            if (svga->crtcreg == 0) {
+                                dev->h_total_back = 0;
+                                dev->vga_htotal = 1;
+                            }
+                        }
                         svga->fullchange = svga->monitor->mon_changeframecount;
                         svga_recalctimings(svga);
                     }
@@ -2579,7 +2606,22 @@ mach_in(uint16_t addr, void *priv)
         case 0x1cf:
             switch (mach->index) {
                 case 0xa0:
-                    temp = mach->regs[0xa0] | 0x10;
+                    /* 2026-07-26: this project confirmed via live comrade session against a real
+                       ATI Graphics Ultra (ATI_38800_TYPE) card that bit 0x10 reads back clear on
+                       real silicon (live read 0x4D) - the unconditional forcing below was
+                       previously always-on regardless of card variant. Scoped the real-hardware-
+                       confirmed behavior to ATI_GRAPHICS_ULTRA only; Mach32 (ATI_68800_TYPE) keeps
+                       the original forced behavior since nobody has verified that variant against
+                       real hardware yet - see INBOARD_86BOX_PORT_PLAN.md for the full register
+                       survey (0xA0/0xB0/0xBD all showed this same pattern; 0xAA, not forced,
+                       matched real hardware exactly, confirming the methodology). */
+                    temp = mach->regs[0xa0];
+                    if (!ATI_GRAPHICS_ULTRA)
+                        temp |= 0x10;
+                    else {
+                        if (mach->bus_width_8bit == 16)
+                            temp |= 0x10;
+                    }
                     break;
                 case 0xa8:
                     temp = (svga->vc >> 8) & 3;
@@ -2588,28 +2630,49 @@ mach_in(uint16_t addr, void *priv)
                     temp = svga->vc & 0xff;
                     break;
                 case 0xaa:
-                    if (ATI_GRAPHICS_ULTRA)
+                    if (ATI_GRAPHICS_ULTRA) {
                         temp = 0x06;
-                    else
+                        if (mach->bus_width_8bit == 16)
+                            temp |= 0x10;
+                    } else
                         temp = 0x00;
                     break;
                 case 0xb0:
-                    temp = mach->regs[0xb0] | 0x80;
-                    temp &= ~0x18;
-                    if (ATI_MACH32) { /*Mach32 VGA 1MB memory*/
-                        temp |= 0x08;
-                    } else { /*ATI 28800 VGA 512kB memory*/
-                        temp |= 0x10;
+                    /* 2026-07-26: same real-hardware finding as 0xA0 above - live read 0x12, bit
+                       0x80 clear on the real ATI Graphics Ultra card. Scoped the same way. */
+                    temp = mach->regs[0xb0];
+                    if (!ATI_GRAPHICS_ULTRA)
+                        temp |= 0x80;
+                    else {
+                        if (mach->bus_width_8bit == 16)
+                            temp |= 0x80;
                     }
+
+                    temp &= ~0x18;
+                    if (ATI_MACH32) /*Mach32 VGA 1MB memory*/
+                        temp |= 0x08;
+                    else /*ATI 28800 VGA 512kB memory*/
+                        temp |= 0x10;
                     break;
                 case 0xb7:
                     temp = mach->regs[0xb7] & ~0x08;
                     if (ati_eeprom_read(&mach->eeprom))
                         temp |= 0x08;
+
+                    if (mach->bus_width_8bit == 16)
+                        temp |= 0x01;
                     break;
 
                 case 0xbd:
-                    temp = mach->regs[0xbd] | 0x10;
+                    /* 2026-07-26: same real-hardware finding as 0xA0/0xB0 above - live read 0x90,
+                       bit 0x10 clear on the real ATI Graphics Ultra card. Scoped the same way. */
+                    temp = mach->regs[0xbd];
+                    if (!ATI_GRAPHICS_ULTRA)
+                        temp |= 0x10;
+                    else {
+                        if (mach->bus_width_8bit == 16)
+                            temp |= 0x10;
+                    }
                     break;
 
                 default:
@@ -2643,7 +2706,6 @@ mach_in(uint16_t addr, void *priv)
             else
                 temp = svga->crtc[svga->crtcreg];
             break;
-
         default:
             temp = svga_in(addr, svga);
             break;
@@ -2688,50 +2750,51 @@ ati_render_24bpp(svga_t *svga)
     uint32_t *p;
     uint32_t  dat;
 
-    if ((dev->displine + svga->y_add) < 0)
+    if ((svga->displine + svga->y_add) < 0)
         return;
 
-    if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || svga->fullchange) {
-        p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
+    if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->fullchange) {
+        p = &buffer32->line[svga->displine + svga->y_add][svga->x_add];
 
-        if (dev->firstline_draw == 2000)
-            dev->firstline_draw = dev->displine;
-        dev->lastline_draw = dev->displine;
+        if (svga->firstline_draw == 2000)
+            svga->firstline_draw = svga->displine;
+
+        svga->lastline_draw = svga->displine;
 
         if (mach->accel.ext_ge_config & 0x400) { /*BGR, Blue-(23:16), Green-(15:8), Red-(7:0)*/
             for (int x = 0; x <= dev->h_disp; x += 4) {
-                dat  = *(uint32_t *) (&dev->vram[dev->memaddr & dev->vram_mask]);
+                dat  = *(uint32_t *) (&svga->vram[svga->memaddr & svga->vram_mask]);
                 p[x] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
 
-                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 3) & dev->vram_mask]);
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + 3) & svga->vram_mask]);
                 p[x + 1] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
 
-                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 6) & dev->vram_mask]);
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + 6) & svga->vram_mask]);
                 p[x + 2] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
 
-                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 9) & dev->vram_mask]);
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + 9) & svga->vram_mask]);
                 p[x + 3] = ((dat & 0xff0000) >> 16) | (dat & 0x00ff00) | ((dat & 0x0000ff) << 16);
 
-                dev->memaddr += 12;
+                svga->memaddr += 12;
             }
         } else { /*RGB, Red-(23:16), Green-(15:8), Blue-(7:0)*/
             for (int x = 0; x <= dev->h_disp; x += 4) {
-                dat  = *(uint32_t *) (&dev->vram[dev->memaddr & dev->vram_mask]);
+                dat  = *(uint32_t *) (&svga->vram[svga->memaddr & svga->vram_mask]);
                 p[x] = dat & 0xffffff;
 
-                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 3) & dev->vram_mask]);
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + 3) & svga->vram_mask]);
                 p[x + 1] = dat & 0xffffff;
 
-                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 6) & dev->vram_mask]);
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + 6) & svga->vram_mask]);
                 p[x + 2] = dat & 0xffffff;
 
-                dat      = *(uint32_t *) (&dev->vram[(dev->memaddr + 9) & dev->vram_mask]);
+                dat      = *(uint32_t *) (&svga->vram[(svga->memaddr + 9) & svga->vram_mask]);
                 p[x + 3] = dat & 0xffffff;
 
-                dev->memaddr += 12;
+                svga->memaddr += 12;
             }
         }
-        dev->memaddr &= dev->vram_mask;
+        svga->memaddr &= svga->vram_mask;
     }
 }
 
@@ -2744,49 +2807,57 @@ ati_render_32bpp(svga_t *svga)
     uint32_t  *p;
     uint32_t   dat;
 
-    if ((dev->displine + svga->y_add) < 0)
+    if ((svga->displine + svga->y_add) < 0)
         return;
 
-    if (dev->changedvram[dev->memaddr >> 12] || dev->changedvram[(dev->memaddr >> 12) + 1] || dev->changedvram[(dev->memaddr >> 12) + 2] || svga->fullchange) {
-        p = &buffer32->line[dev->displine + svga->y_add][svga->x_add];
+    if (svga->changedvram[svga->memaddr >> 12] || svga->changedvram[(svga->memaddr >> 12) + 1] || svga->changedvram[(svga->memaddr >> 12) + 2] || svga->fullchange) {
+        p = &buffer32->line[svga->displine + svga->y_add][svga->x_add];
 
-        if (dev->firstline_draw == 2000)
-            dev->firstline_draw = dev->displine;
-        dev->lastline_draw = dev->displine;
+        if (svga->firstline_draw == 2000)
+            svga->firstline_draw = svga->displine;
+        svga->lastline_draw = svga->displine;
 
         if (mach->accel.ext_ge_config & 0x400) { /*BGR, Blue-(23:16), Green-(15:8), Red-(7:0)*/
             for (x = 0; x <= dev->h_disp; x++) {
-                dat  = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 2)) & dev->vram_mask]);
+                dat  = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 2)) & svga->vram_mask]);
                 *p++ = ((dat & 0x00ff0000) >> 16) | (dat & 0x0000ff00) | ((dat & 0x000000ff) << 16);
             }
         } else { /*RGB, Red-(31:24), Green-(23:16), Blue-(15:8)*/
             for (x = 0; x <= dev->h_disp; x++) {
-                dat  = *(uint32_t *) (&dev->vram[(dev->memaddr + (x << 2)) & dev->vram_mask]);
+                dat  = *(uint32_t *) (&svga->vram[(svga->memaddr + (x << 2)) & svga->vram_mask]);
                 *p++ = ((dat & 0xffffff00) >> 8);
             }
         }
-        dev->memaddr += (x * 4);
-        dev->memaddr &= dev->vram_mask;
+        svga->memaddr += (x * 4);
+        svga->memaddr &= svga->vram_mask;
     }
 }
 
 static void
-mach_set_crt_params(ibm8514_t *dev)
+mach_set_crt_params(ibm8514_t *dev, svga_t *svga)
 {
     if (dev->htotal)
         dev->h_total = dev->htotal + 1;
 
-    mach_log(mach->log, "HTOTAL=%d.\n", dev->htotal);
+    mach_log(mach->log, "HTOTAL=%02x. H_TOTAL=%02x.\n", dev->htotal, dev->h_total);
 
     dev->hdisp = (dev->hdisped + 1) << 3;
     mach_log(mach->log, "HDISP=%d.\n", dev->hdisp);
-    if (dev->hdisp == 8)
-        dev->hdisp = 1024;
+    if (dev->hdisp == 8) {
+        if (dev->accel.advfunc_cntl & 0x04)
+            dev->hdisp = 1024;
+        else
+            dev->hdisp = 640;
+    }
 
     dev->vdisp = (dev->v_disp + 1) >> 1;
     mach_log(mach->log, "VDISP=%d.\n", dev->vdisp);
-    if (dev->vdisp == 0)
-        dev->vdisp = 768;
+    if (dev->vdisp == 0) {
+        if (dev->accel.advfunc_cntl & 0x04)
+            dev->vdisp = 768;
+        else
+            dev->vdisp = 480;
+    }
 
     if ((dev->vdisp == 478) || (dev->vdisp == 598) || (dev->vdisp == 766) || (dev->vdisp == 898) || (dev->vdisp == 1022))
         dev->vdisp += 2;
@@ -2816,16 +2887,13 @@ mach_set_crt_params(ibm8514_t *dev)
     }
 }
 
-/*The situation is the following:
-  When ATI (0x4aee) mode is selected, allow complete auto-detection.
-  When 8514/A (0x4ae8) mode is selected, allow detection based on the shadow register sets.
-*/
 static void
 mach_set_resolution(mach_t *mach, svga_t *svga)
 {
     ibm8514_t    *dev = (ibm8514_t *) svga->dev8514;
+    int ret           = 0x00;
 
-    mach_set_crt_params(dev);
+    mach_set_crt_params(dev, svga);
 
     mach->accel.clock_sel_mode = 0;
 
@@ -2900,12 +2968,38 @@ mach_set_resolution(mach_t *mach, svga_t *svga)
         svga_recalctimings(svga);
     } else {
         if (!(mach->shadow_cntl & 0x3f)) {
-            if (((dev->hdisp == 640) && (dev->vdisp == 480) && ((dev->disp_cntl & 0x60) == 0x20)) ||
-                ((dev->hdisp == 1024) && (dev->vdisp == 768) && !(dev->accel.advfunc_cntl & 0x04) && ((dev->disp_cntl & 0x60) >= 0x40))) {
+            if (ATI_MACH32) {
+                if ((dev->hdisp == 640) && (dev->vdisp == 480)) {
+                    ret = 0x01;
+                } else if ((dev->hdisp == 800) && (dev->vdisp == 600)) {
+                    ret = 0x02;
+                } else if ((dev->hdisp == 1024) && (dev->vdisp == 768)) {
+                    ret = 0x03;
+                } else if ((dev->hdisp == 1280) && (dev->vdisp == 1024)) {
+                    ret = 0x04;
+                }
+            } else {
+                mach_log(mach->log, "Advanced Function Control on ATI Mach8 Graphics Ultra=%02x, Clock Select bit 0=%02x, hdisp=%d, vdisp=%d.\n", dev->accel.advfunc_cntl & 0x05, mach->accel.clock_sel & 0x01, dev->hdisp, dev->vdisp);
+                if (dev->accel.advfunc_cntl & 0x04) {
+                    if ((dev->hdisp == 800) && (dev->vdisp == 600))
+                        ret = 0x02;
+                    else if ((dev->hdisp == 1024) && (dev->vdisp == 768))
+                        ret = 0x03;
+                } else {
+                    if ((dev->hdisp == 1024) && (dev->vdisp == 768) &&
+                        (mach->accel.clock_sel & 0x01))
+                        ret = 0x03;
+                    else
+                        ret = 0x01;
+                }
+            }
+
+            if (ret == 0x01) {
                 dev->hdisp = 640;
                 dev->vdisp = 480;
-                mach_log(mach->log,"EEPROM 640x480: %04x.\n", mach->eeprom.data[7]);
+                mach_log(mach->log, "EEPROM 640x480: %04x.\n", mach->eeprom.data[7]);
                 if (!(mach->accel.clock_sel & 0xfe)) {
+                    dev->disp_cntl_interlace = 0;
                     switch (mach->eeprom.data[7] & 0xff) {
                         case 0x00: /*640x480 60Hz Non-interlaced*/
                         default:
@@ -2928,17 +3022,20 @@ mach_set_resolution(mach_t *mach, svga_t *svga)
                             break;
                     }
                 }
-            } else if ((dev->hdisp == 800) && (dev->vdisp == 600)) {
-                mach_log(mach->log,"EEPROM 800x600: %04x.\n", mach->eeprom.data[8]);
+            } else if (ret == 0x02) {
+                mach_log(mach->log, "EEPROM 800x600: %04x.\n", mach->eeprom.data[8]);
                 if (!(mach->accel.clock_sel & 0xfe)) {
+                    dev->disp_cntl_interlace = 0;
                     switch (mach->eeprom.data[8] & 0xff) {
                         case 0x01: /*800x600 95Hz Interlaced*/
+                            dev->disp_cntl_interlace = 1;
                             dev->h_total = 0x85;
                             dev->v_total = 0x0581;
                             dev->v_syncstart = 0x04c3;
                             mach->accel.clock_sel_mode = 0x0c;
                             break;
                         case 0x02: /*800x600 89Hz Interlaced*/
+                            dev->disp_cntl_interlace = 1;
                             dev->h_total = 0x85;
                             dev->v_total = 0x0581;
                             dev->v_syncstart = 0x04c3;
@@ -2977,13 +3074,12 @@ mach_set_resolution(mach_t *mach, svga_t *svga)
                             break;
                     }
                 }
-            } else if (((dev->hdisp == 1024) && (dev->vdisp == 768)) ||
-                    ((dev->hdisp == 640) && (dev->vdisp == 480) &&
-                    (dev->accel.advfunc_cntl & 0x04))) {
+            } else if (ret == 0x03) {
                 dev->hdisp = 1024;
                 dev->vdisp = 768;
                 mach_log(mach->log, "EEPROM 1024x768: %04x.\n", mach->eeprom.data[9]);
                 if (!(mach->accel.clock_sel & 0xfe)) {
+                    dev->disp_cntl_interlace = 0;
                     switch (mach->eeprom.data[9] & 0xff) {
                         case 0x00: /*1024x768 76Hz Non-interlaced*/
                             dev->h_total = 0xa3;
@@ -2993,6 +3089,7 @@ mach_set_resolution(mach_t *mach, svga_t *svga)
                             break;
                         case 0x01: /*1024x768 87Hz Interlaced*/
                         default:
+                            dev->disp_cntl_interlace = 1;
                             dev->h_total = 0x9e;
                             dev->v_total = 0x0669;
                             dev->v_syncstart = 0x0601;
@@ -3024,18 +3121,21 @@ mach_set_resolution(mach_t *mach, svga_t *svga)
                             break;
                     }
                 }
-            } else if ((dev->hdisp == 1280) && (dev->vdisp == 1024)) {
+            } else if (ret == 0x04) {
                 mach_log(mach->log, "EEPROM 1280x1024: %04x.\n", mach->eeprom.data[0x0a]);
                 if (!(mach->accel.clock_sel & 0xfe)) {
+                    dev->disp_cntl_interlace = 0;
                     switch (mach->eeprom.data[0x0a] & 0xff) {
                         case 0x81: /*1280x1024 87Hz Interlaced*/
                         default:
+                            dev->disp_cntl_interlace = 1;
                             dev->h_total = 0xc8;
                             dev->v_total = 0x08f9;
                             dev->v_syncstart = 0x0862;
                             mach->accel.clock_sel_mode = 0x2c;
                             break;
                         case 0x82: /*1280x1024 95Hz Interlaced*/
+                            dev->disp_cntl_interlace = 1;
                             dev->h_total = 0xc8;
                             dev->v_total = 0x0839;
                             dev->v_syncstart = 0x0812;
@@ -3068,7 +3168,7 @@ mach_set_resolution(mach_t *mach, svga_t *svga)
 }
 
 static int
-mach_set_clock_mode(ibm8514_t *dev, mach_t *mach)
+mach_set_clock_mode(ibm8514_t *dev, svga_t *svga, mach_t *mach)
 {
     int _8514_modes = 0;
 
@@ -3078,7 +3178,11 @@ mach_set_clock_mode(ibm8514_t *dev, mach_t *mach)
                 case 0x50:
                 case 0x24:
                 case 0x6c:
-                    dev->interlace = 0;
+                    if (ATI_MACH32)
+                        svga->interlace = 0;
+                    else
+                        dev->interlace = 0;
+
                     _8514_modes = 2;
                     break;
                 default:
@@ -3089,9 +3193,16 @@ mach_set_clock_mode(ibm8514_t *dev, mach_t *mach)
                 case 0x50:
                 case 0x24:
                 case 0x6c:
-                    dev->interlace = 0;
+                    if (ATI_MACH32)
+                        svga->interlace = 0;
+                    else
+                        dev->interlace = 0;
                     break;
                 default:
+                    if (ATI_MACH32)
+                        svga->interlace = 0;
+                    else
+                        dev->interlace = 0;
                     break;
             }
         }
@@ -3102,15 +3213,28 @@ mach_set_clock_mode(ibm8514_t *dev, mach_t *mach)
                 case 0x14:
                 case 0x1c:
                 case 0x30:
-                    dev->interlace = 0;
+                    if (ATI_MACH32)
+                        svga->interlace = 0;
+                    else
+                        dev->interlace = 0;
+
                     _8514_modes = 2;
                     break;
                 case 0x0c:
-                    dev->interlace = (dev->h_total == 0x85) ? 1 : 0;
-                    _8514_modes = (dev->h_total == 0x85) ? 1 : 2;
+                    if (ATI_MACH32) {
+                        svga->interlace = (svga->htotal == 0x85) ? 1 : 0;
+                        _8514_modes = (svga->htotal == 0x85) ? 1 : 2;
+                    } else {
+                        dev->interlace = (dev->h_total == 0x85) ? 1 : 0;
+                        _8514_modes = (dev->h_total == 0x85) ? 1 : 2;
+                    }
                     break;
                 case 0x7c:
-                    dev->interlace = 1;
+                    if (ATI_MACH32)
+                        svga->interlace = 1;
+                    else
+                        dev->interlace = 1;
+
                     _8514_modes = 1;
                     break;
                 default:
@@ -3122,15 +3246,28 @@ mach_set_clock_mode(ibm8514_t *dev, mach_t *mach)
                 case 0x14:
                 case 0x1c:
                 case 0x30:
-                    dev->interlace = 0;
+                    if (ATI_MACH32)
+                        svga->interlace = 0;
+                    else
+                        dev->interlace = 0;
                     break;
                 case 0x0c:
-                    dev->interlace = (dev->h_total == 0x85) ? 1 : 0;
+                    if (ATI_MACH32)
+                        svga->interlace = (svga->htotal == 0x85) ? 1 : 0;
+                    else
+                        dev->interlace = (dev->h_total == 0x85) ? 1 : 0;
                     break;
                 case 0x7c:
-                    dev->interlace = 1;
+                    if (ATI_MACH32)
+                        svga->interlace = 1;
+                    else
+                        dev->interlace = 1;
                     break;
                 default:
+                    if (ATI_MACH32)
+                        svga->interlace = 0;
+                    else
+                        dev->interlace = 0;
                     break;
             }
         }
@@ -3140,11 +3277,19 @@ mach_set_clock_mode(ibm8514_t *dev, mach_t *mach)
                 case 0x2c:
                 case 0x38:
                 case 0x3c:
-                    dev->interlace = 0;
+                    if (ATI_MACH32)
+                        svga->interlace = 0;
+                    else
+                        dev->interlace = 0;
+
                     _8514_modes = 2;
                     break;
                 case 0x1c:
-                    dev->interlace = 1;
+                    if (ATI_MACH32)
+                        svga->interlace = 1;
+                    else
+                        dev->interlace = 1;
+
                     _8514_modes = 1;
                     break;
                 default:
@@ -3155,10 +3300,16 @@ mach_set_clock_mode(ibm8514_t *dev, mach_t *mach)
                 case 0x2c:
                 case 0x38:
                 case 0x3c:
-                    dev->interlace = 0;
+                    if (ATI_MACH32)
+                        svga->interlace = 0;
+                    else
+                        dev->interlace = 0;
                     break;
                 case 0x1c:
-                    dev->interlace = 1;
+                    if (ATI_MACH32)
+                        svga->interlace = 1;
+                    else
+                        dev->interlace = 1;
                     break;
                 default:
                     break;
@@ -3170,11 +3321,19 @@ mach_set_clock_mode(ibm8514_t *dev, mach_t *mach)
                 case 0x04:
                 case 0x20:
                 case 0x28:
-                    dev->interlace = 0;
+                    if (ATI_MACH32)
+                        svga->interlace = 0;
+                    else
+                        dev->interlace = 0;
+
                     _8514_modes = 2;
                     break;
                 case 0x2c:
-                    dev->interlace = 1;
+                    if (ATI_MACH32)
+                        svga->interlace = 1;
+                    else
+                        dev->interlace = 1;
+
                     _8514_modes = 1;
                     break;
                 default:
@@ -3185,10 +3344,16 @@ mach_set_clock_mode(ibm8514_t *dev, mach_t *mach)
                 case 0x04:
                 case 0x20:
                 case 0x28:
-                    dev->interlace = 0;
+                    if (ATI_MACH32)
+                        svga->interlace = 0;
+                    else
+                        dev->interlace = 0;
                     break;
                 case 0x2c:
-                    dev->interlace = 1;
+                    if (ATI_MACH32)
+                        svga->interlace = 1;
+                    else
+                        dev->interlace = 1;
                     break;
                 default:
                     break;
@@ -3225,7 +3390,7 @@ ati8514_recalctimings(svga_t *svga)
             dev->vdisp = dev->dispend;
         }
 
-        _8514_modes = mach_set_clock_mode(dev, mach);
+        _8514_modes = mach_set_clock_mode(dev, svga, mach);
 
         if (_8514_modes)
             dev->ven_clock = mach->accel.clock_sel_mode & 0x7c;
@@ -3247,6 +3412,7 @@ ati8514_recalctimings(svga_t *svga)
         mach_log(mach->log,"8514/A ON, pitch=%d, GE offset=%08x.\n", ((mach->accel.ge_pitch & 0xff) << 3), dev->accel.ge_offset);
 
         dev->h_disp_time = dev->h_disp >> 3;
+        svga->render8514 = ibm8514_render_blank;
 
         svga->clock_8514 = (cpuclock * (double) (1ULL << 32)) / svga->getclock8514((dev->ven_clock >> 2) & 0x0f, svga->clock_gen8514) / 2.0;
         if (dev->ven_clock & 0x40)
@@ -3275,72 +3441,41 @@ ati8514_recalctimings(svga_t *svga)
 }
 
 static void
-mach_recalctimings(svga_t *svga)
+mach_disable(void *p)
+{
+    mach_t *mach  = (mach_t *) p;
+    svga_t *svga = &mach->svga;
+
+    io_removehandler(0x03a0, 0x0040, mach_in, NULL, NULL, mach_out, NULL, NULL, mach);
+    mem_mapping_disable(&svga->mapping);
+    svga->vga_enabled = 0;
+}
+
+static void
+mach_enable(void *p)
+{
+    mach_t *mach  = (mach_t *) p;
+    svga_t *svga = &mach->svga;
+
+    io_sethandler(0x03c0, 0x0020, mach_in, NULL, NULL, mach_out, NULL, NULL, mach);
+    if (!(svga->miscout & 1))
+        io_sethandler(0x03a0, 0x0020, mach_in, NULL, NULL, mach_out, NULL, NULL, mach);
+
+    mem_mapping_enable(&svga->mapping);
+    svga->vga_enabled = 1;
+}
+
+static void
+mach8_recalctimings(svga_t *svga)
 {
     mach_t       *mach = (mach_t *) svga->priv;
     ibm8514_t    *dev  = (ibm8514_t *) svga->dev8514;
     int           clock_sel = 0x00;
     int           _8514_modes = 0;
 
-    if (mach->regs[0xad] & 0x08)
-        svga->hblankstart    = ((mach->regs[0x0d] >> 2) << 8) + svga->crtc[2];
-
-    if (svga->miscout & 0x04)
-        clock_sel |= 0x01;
-    if (svga->miscout & 0x08)
-        clock_sel |= 0x02;
-    if (mach->regs[0xb9] & 0x02)
-        clock_sel |= 0x04;
-    if (mach->regs[0xbe] & 0x10)
-        clock_sel |= 0x08;
-
-    svga->interlace = !!(mach->regs[0xbe] & 0x02);
-    if (svga->interlace)
-        svga->dispend >>= 1;
-
-    if (ATI_MACH32) {
-        if (mach->regs[0xad] & 0x04)
-            svga->memaddr_latch |= 0x40000;
-
-        if (mach->regs[0xad] & 0x08)
-            svga->memaddr_latch |= 0x80000;
-    }
-
-    if (mach->regs[0xa3] & 0x10)
-        svga->memaddr_latch |= 0x10000;
-
-    if (mach->regs[0xb0] & 0x40)
-        svga->memaddr_latch |= 0x20000;
-
-    if ((mach->regs[0xb6] & 0x18) >= 0x10) {
-        svga->hdisp <<= 1;
-        svga->htotal <<= 1;
-        svga->dots_per_clock <<= 1;
-        svga->rowoffset <<= 1;
-    }
-
-    if (mach->regs[0xb0] & 0x20) {
-        if ((mach->regs[0xb6] & 0x18) >= 0x10)
-            svga->packed_4bpp = 1;
-        else
-            svga->packed_4bpp = 0;
-    } else
-        svga->packed_4bpp = 0;
-
-    if (!ATI_MACH32) {
-        if ((mach->regs[0xb6] & 0x18) == 0x08) {
-            svga->hdisp <<= 1;
-            svga->htotal <<= 1;
-            svga->dots_per_clock <<= 1;
-            svga->ati_4color = 1;
-        } else
-            svga->ati_4color = 0;
-    }
-
     mach_log(mach->log,"ON=%d, override=%d, gelo=%04x, gehi=%04x, crtlo=%04x, crthi=%04x, vgahdisp=%d, ibmon=%x, ation=%x, graph1=%x.\n", dev->on, svga->override, mach->accel.ge_offset_lo, mach->accel.ge_offset_hi, mach->accel.crt_offset_lo, mach->accel.crt_offset_hi, svga->hdisp, dev->accel.advfunc_cntl & 0x01, mach->accel.clock_sel & 0x01, svga->gdcreg[6] & 0x01);
 
     if (dev->on) {
-        dev->memaddr_latch              = 0; /*(mach->accel.crt_offset_lo | (mach->accel.crt_offset_hi << 16)) << 2;*/
         dev->interlace                  = dev->disp_cntl_interlace;
         dev->pitch                      = dev->ext_pitch;
         dev->rowoffset                  = dev->ext_crt_pitch;
@@ -3362,22 +3497,19 @@ mach_recalctimings(svga_t *svga)
             dev->vdisp = dev->dispend;
         }
 
-        _8514_modes = mach_set_clock_mode(dev, mach);
+        _8514_modes = mach_set_clock_mode(dev, svga, mach);
 
+        mach_log(mach->log, "Interlace=%d, 8514/A mode selection=%02x.\n", dev->interlace, _8514_modes);
         if (_8514_modes)
             dev->ven_clock = mach->accel.clock_sel_mode & 0x7c;
         else
             dev->ven_clock = mach->accel.clock_sel & 0x7c;
 
-        if (ATI_MACH32) {
-            mach_log(mach->log, "Mach32: Clock=%02x, double=%02x, h_total=%02x.\n", (dev->ven_clock >> 2) & 0x0f, dev->ven_clock & 0x40, dev->h_total);
-            svga->clock_8514 = (cpuclock * (double) (1ULL << 32)) / svga->getclock8514((dev->ven_clock >> 2) & 0x0f, svga->clock_gen8514) / 2.0;
-        } else {
-            mach_log(mach->log,"Mach8: Clock=%02x, double=%02x, h_total=%02x, selmode=%02x.\n", (dev->ven_clock >> 2) & 0x0f, dev->ven_clock & 0x40, dev->h_total, mach->accel.clock_sel_mode);
-            svga->clock_8514 = (cpuclock * (double) (1ULL << 32)) / svga->getclock8514((dev->ven_clock >> 2) & 0x0f, svga->clock_gen8514) / 2.0;
-            if ((((dev->ven_clock >> 2) & 0x0f) == 0x09) && (dev->h_total == 0x6b))
-                svga->clock_8514 /= 2.0;
-        }
+        mach_log(mach->log,"Mach8: Clock=%02x, double=%02x, h_total=%02x, selmode=%02x.\n", (dev->ven_clock >> 2) & 0x0f, dev->ven_clock & 0x40, dev->h_total, mach->accel.clock_sel_mode);
+        svga->clock_8514 = (cpuclock * (double) (1ULL << 32)) / svga->getclock8514((dev->ven_clock >> 2) & 0x0f, svga->clock_gen8514) / 2.0;
+        if ((((dev->ven_clock >> 2) & 0x0f) == 0x09) && (dev->h_total == 0x6b))
+            svga->clock_8514 /= 2.0;
+
         if (dev->ven_clock & 0x40)
             svga->clock_8514 *= 2.0;
 
@@ -3389,11 +3521,6 @@ mach_recalctimings(svga_t *svga)
             mach->accel.crt_offset <<= 2;
         }
 
-        if (ATI_MACH32 && !dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
-            dev->accel.ge_offset <<= 1;
-            mach->accel.crt_offset <<= 1;
-        }
-
         dev->accel.ge_offset           -= mach->accel.crt_offset;
 
         mach_log(mach->log,"RowCount=%x, rowoffset=%x, pitch=%d, geoffset=%x, crtoffset=%x.\n", dev->rowcount, dev->rowoffset, dev->pitch, dev->accel.ge_offset, mach->accel.crt_offset);
@@ -3402,6 +3529,7 @@ mach_recalctimings(svga_t *svga)
                  mach->accel.clock_sel & 0xfe, dev->interlace);
 
         dev->h_disp_time = dev->h_disp >> 3;
+        svga->render8514 = ibm8514_render_blank;
 
         mach_log(mach->log,"8514/A modes=%d, clocksel=%02x, clkselmode=%02x, divide reg ibm=%02x, divide reg vga=%02x, vgainterlace=%x, interlace=%x, htotal=%02x.\n", _8514_modes, mach->accel.clock_sel & 0xfe, mach->accel.clock_sel_mode & 0xfe, mach->accel.clock_sel & 0x40, mach->regs[0xb8] & 0x40, svga->interlace, dev->interlace, dev->htotal);
 
@@ -3409,136 +3537,79 @@ mach_recalctimings(svga_t *svga)
             dev->dispend >>= 1;
             svga->clock_8514 /= 2.0;
         }
+        mach->accel.src_pitch = dev->pitch;
+        mach->accel.dst_pitch = dev->pitch;
+        mach->accel.src_ge_offset = (mach->accel.ge_offset_lo | (mach->accel.ge_offset_hi << 16));
+        mach->accel.dst_ge_offset = (mach->accel.ge_offset_lo | (mach->accel.ge_offset_hi << 16));
+        mach->accel.src_ge_offset <<= 2;
+        mach->accel.dst_ge_offset <<= 2;
+        mach->accel.src_ge_offset -= mach->accel.crt_offset;
+        mach->accel.dst_ge_offset -= mach->accel.crt_offset;
 
-        if (ATI_MACH32) {
-            switch ((mach->shadow_set >> 8) & 0x03) {
-                case 0x00:
-                    mach->accel.src_pitch = dev->pitch;
-                    mach->accel.dst_pitch = dev->pitch;
-                    mach->accel.src_ge_offset = (mach->accel.ge_offset_lo | (mach->accel.ge_offset_hi << 16));
-                    mach->accel.dst_ge_offset = (mach->accel.ge_offset_lo | (mach->accel.ge_offset_hi << 16));
-                    if (dev->bpp) {
-                        mach->accel.src_ge_offset <<= 1;
-                        mach->accel.dst_ge_offset <<= 1;
-                    } else {
-                        mach->accel.src_ge_offset <<= 2;
-                        mach->accel.dst_ge_offset <<= 2;
-                    }
-                    if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
-                        mach->accel.src_ge_offset <<= 1;
-                        mach->accel.dst_ge_offset <<= 1;
-                    }
-                    mach->accel.src_ge_offset -= mach->accel.crt_offset;
-                    mach->accel.dst_ge_offset -= mach->accel.crt_offset;
-                    dev->accel.src_pitch = mach->accel.src_pitch;
-                    dev->accel.dst_pitch = mach->accel.dst_pitch;
-                    dev->accel.src_ge_offset = mach->accel.src_ge_offset;
-                    dev->accel.dst_ge_offset = mach->accel.dst_ge_offset;
-                    break;
-                case 0x01:
-                    mach->accel.dst_pitch = dev->pitch;
-                    mach->accel.dst_ge_offset = (mach->accel.ge_offset_lo | (mach->accel.ge_offset_hi << 16));
-                    if (dev->bpp)
-                        mach->accel.dst_ge_offset <<= 1;
-                    else
-                        mach->accel.dst_ge_offset <<= 2;
-
-                    if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00))
-                        mach->accel.dst_ge_offset <<= 1;
-
-                    mach->accel.dst_ge_offset -= mach->accel.crt_offset;
-                    dev->accel.dst_pitch = mach->accel.dst_pitch;
-                    dev->accel.dst_ge_offset = mach->accel.dst_ge_offset;
-                    break;
-                case 0x02:
-                    mach->accel.src_pitch = dev->pitch;
-                    mach->accel.src_ge_offset = (mach->accel.ge_offset_lo | (mach->accel.ge_offset_hi << 16));
-                    if (dev->bpp)
-                        mach->accel.src_ge_offset <<= 1;
-                    else
-                        mach->accel.src_ge_offset <<= 2;
-
-                    if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00))
-                        mach->accel.src_ge_offset <<= 1;
-
-                    mach->accel.src_ge_offset -= mach->accel.crt_offset;
-                    dev->accel.src_pitch = mach->accel.src_pitch;
-                    dev->accel.src_ge_offset = mach->accel.src_ge_offset;
-                    break;
-                default:
-                    break;
-            }
-            mach_log(mach->log,"cntl=%d, clksel=%x, hv(%d,%d), pitch=%d, rowoffset=%d, gextconfig=%03x, shadow=%x interlace=%d, vgahdisp=%d.\n",
-                     dev->accel.advfunc_cntl & 0x04, mach->accel.clock_sel & 0x01, dev->h_disp, dev->dispend, dev->pitch, dev->rowoffset,
-                     mach->accel.ext_ge_config & 0xcec0, mach->shadow_set & 3, dev->interlace, svga->hdisp);
-            mach_log(mach->log,"EXTGECONFIG bits 11-15=%04x.\n", mach->accel.ext_ge_config & 0x8800);
-            if ((mach->accel.ext_ge_config & 0x800) || (!(mach->accel.ext_ge_config & 0x8000) && !(mach->accel.ext_ge_config & 0x800))) {
-                mach_log(mach->log,"hv=%d,%d, pitch=%d, rowoffset=%d, gextconfig=%03x, bpp=%d, shadow=%x, vgahdisp=%d.\n",
-                         dev->h_disp, dev->dispend, dev->pitch, dev->ext_crt_pitch, mach->accel.ext_ge_config & 0xcec0,
-                         dev->accel_bpp, mach->shadow_set & 0x03, svga->hdisp);
-
-                switch (dev->accel_bpp) {
-                    case 8:
-                        if ((mach->accel.ext_ge_config & 0x30) == 0x00) {
-                            if (dev->vram_512k_8514) {
-                                if (dev->h_disp == 640)
-                                    dev->pitch = 640;
-                                else
-                                    dev->pitch = 1024;
-                            }
-                        }
-                        svga->render8514 = ibm8514_render_8bpp;
-                        break;
-                    case 15:
-                        svga->render8514 = ibm8514_render_15bpp;
-                        break;
-                    case 16:
-                        svga->render8514 = ibm8514_render_16bpp;
-                        break;
-                    case 24:
-                        mach_log(mach->log,"GEConfig24bpp: %03x.\n", mach->accel.ext_ge_config & 0x600);
-                        svga->render8514 = ati_render_24bpp;
-                        break;
-                    case 32:
-                        mach_log(mach->log,"GEConfig32bpp: %03x.\n", mach->accel.ext_ge_config & 0x600);
-                        svga->render8514 = ati_render_32bpp;
-                        break;
-
-                    default:
-                        break;
-                }
-            }
-        } else {
-            mach->accel.src_pitch = dev->pitch;
-            mach->accel.dst_pitch = dev->pitch;
-            mach->accel.src_ge_offset = (mach->accel.ge_offset_lo | (mach->accel.ge_offset_hi << 16));
-            mach->accel.dst_ge_offset = (mach->accel.ge_offset_lo | (mach->accel.ge_offset_hi << 16));
-            mach->accel.src_ge_offset <<= 2;
-            mach->accel.dst_ge_offset <<= 2;
-            mach->accel.src_ge_offset -= mach->accel.crt_offset;
-            mach->accel.dst_ge_offset -= mach->accel.crt_offset;
-
-            mach_log(mach->log,"cntl=%d, clksel=%x, hv(%d,%d), pitch=%d, rowoffset=%d, gextconfig=%03x, shadow=%x interlace=%d, vgahdisp=%d.\n",
-                     dev->accel.advfunc_cntl & 0x04, mach->accel.clock_sel & 0x01, dev->h_disp, dev->dispend, dev->pitch, dev->rowoffset,
-                     mach->accel.ext_ge_config & 0xcec0, mach->shadow_set & 0x03, dev->interlace, svga->hdisp);
-            if (dev->vram_512k_8514) {
-                if (dev->h_disp == 640)
-                    dev->pitch = 640;
-                else
-                    dev->pitch = 1024;
-            }
-            dev->accel_bpp = 8;
-            svga->render8514 = ibm8514_render_8bpp;
+        mach_log(mach->log,"cntl=%d, clksel=%x, hv(%d,%d), pitch=%d, rowoffset=%d, gextconfig=%03x, shadow=%x interlace=%d, vgahdisp=%d.\n",
+                 dev->accel.advfunc_cntl & 0x04, mach->accel.clock_sel & 0x01, dev->h_disp, dev->dispend, dev->pitch, dev->rowoffset,
+                 mach->accel.ext_ge_config & 0xcec0, mach->shadow_set & 0x03, dev->interlace, svga->hdisp);
+        if (dev->vram_512k_8514) {
+            if (dev->h_disp == 640)
+                dev->pitch = 640;
+            else
+                dev->pitch = 1024;
         }
+        dev->accel_bpp = 8;
+        svga->render8514 = ibm8514_render_8bpp;
     } else {
+        /*Standard/ATI VGA mode, not 8514/A mode*/
         dev->mode = VGA_MODE;
+        if (mach->regs[0xad] & 0x08)
+            svga->hblankstart    = ((mach->regs[0x0d] >> 2) << 8) + svga->crtc[2];
+
+        if (svga->miscout & 0x04)
+            clock_sel |= 0x01;
+        if (svga->miscout & 0x08)
+            clock_sel |= 0x02;
+        if (mach->regs[0xb9] & 0x02)
+            clock_sel |= 0x04;
+        if (mach->regs[0xbe] & 0x10)
+            clock_sel |= 0x08;
+
+        svga->interlace = !!(mach->regs[0xbe] & 0x02);
+        if (svga->interlace)
+            svga->dispend >>= 1;
+
+        if (mach->regs[0xa3] & 0x10)
+            svga->memaddr_latch |= 0x10000;
+
+        if (mach->regs[0xb0] & 0x40)
+            svga->memaddr_latch |= 0x20000;
+
+        if ((mach->regs[0xb6] & 0x18) >= 0x10) {
+            svga->hdisp <<= 1;
+            svga->htotal <<= 1;
+            svga->dots_per_clock <<= 1;
+            svga->rowoffset <<= 1;
+        }
+
+        if (mach->regs[0xb0] & 0x20) {
+            if ((mach->regs[0xb6] & 0x18) >= 0x10)
+                svga->packed_4bpp = 1;
+            else
+                svga->packed_4bpp = 0;
+        } else
+            svga->packed_4bpp = 0;
+
+        if ((mach->regs[0xb6] & 0x18) == 0x08) {
+            svga->hdisp <<= 1;
+            svga->htotal <<= 1;
+            svga->dots_per_clock <<= 1;
+            svga->ati_4color = 1;
+        } else
+            svga->ati_4color = 0;
+
         if (!svga->scrblank && svga->attr_palette_enable) {
             mach_log(mach->log,"GDCREG5=%02x, ATTR10=%02x, ATI B0 bit 5=%02x, ON=%d, char_width=%d, seqreg1 bit 3=%x, clk_sel=%02x.\n",
                      svga->gdcreg[5] & 0x60, svga->attrregs[0x10] & 0x40, mach->regs[0xb0] & 0x20, dev->on, svga->char_width, svga->seqregs[1] & 0x08, clock_sel);
-            if (ATI_MACH32)
-                svga->clock = (cpuclock * (double) (1ULL << 32)) / svga->getclock(clock_sel, svga->clock_gen);
-            else
-                svga->clock = (cpuclock * (double) (1ULL << 32)) / svga->getclock(clock_sel ^ 0x08, svga->clock_gen);
+
+            svga->clock = (cpuclock * (double) (1ULL << 32)) / svga->getclock(clock_sel ^ 0x08, svga->clock_gen);
 
             switch ((mach->regs[0xb8] >> 6) & 0x03) {
                 case 0x01:
@@ -3572,11 +3643,264 @@ mach_recalctimings(svga_t *svga)
                         }
                     }
                 }
-            } else
-                dev->ext_mode_inc = 0;
+            }
         }
     }
 
+    svga->hoverride = 1;
+}
+
+static void
+mach32_recalctimings(svga_t *svga)
+{
+    mach_t       *mach = (mach_t *) svga->priv;
+    ibm8514_t    *dev  = (ibm8514_t *) svga->dev8514;
+    int           clock_sel = 0x00;
+    int           _8514_modes = 0;
+
+    mach_log(mach->log,"ON=%d, override=%d, gelo=%04x, gehi=%04x, crtlo=%04x, crthi=%04x, vgahdisp=%d, ibmon=%x, ation=%x, graph1=%x.\n", dev->on, svga->override, mach->accel.ge_offset_lo, mach->accel.ge_offset_hi, mach->accel.crt_offset_lo, mach->accel.crt_offset_hi, svga->hdisp, dev->accel.advfunc_cntl & 0x01, mach->accel.clock_sel & 0x01, svga->gdcreg[6] & 0x01);
+
+    if (dev->on) {
+        svga->interlace                  = dev->disp_cntl_interlace;
+        dev->pitch                      = dev->ext_pitch;
+        svga->rowoffset                 = dev->ext_crt_pitch;
+        svga->rowcount                  = dev->disp_cntl_double_scan;
+        dev->accel.ge_offset            = (mach->accel.ge_offset_lo | (mach->accel.ge_offset_hi << 16));
+        mach->accel.crt_offset          = (mach->accel.crt_offset_lo | (mach->accel.crt_offset_hi << 16));
+        svga->split                     = 0xffffff;
+
+        dev->h_disp = dev->hdisp;
+        dev->dispend = dev->vdisp;
+        if (dev->dispend == 959) { /*FIXME: vertical resolution mess on EEPROM tests on Mach8*/
+            dev->dispend++;
+            dev->dispend >>= 1;
+            dev->vdisp = dev->dispend;
+        } else if (dev->dispend == 600) {
+            dev->h_disp = 800;
+            dev->hdisp = dev->h_disp;
+        } else if (dev->h_disp == 640) {
+            dev->dispend = 480;
+            dev->vdisp = dev->dispend;
+        }
+
+        _8514_modes = mach_set_clock_mode(dev, svga, mach);
+
+        svga->htotal = dev->h_total;
+        svga->hdisp = dev->h_disp;
+        svga->dispend = dev->dispend;
+        svga->vblankstart = svga->dispend;
+        svga->vtotal = dev->v_total;
+        svga->vsyncstart = dev->v_syncstart;
+
+        mach_log(mach->log, "Interlace=%d, 8514/A mode selection=%02x, 8514/A hdisp=%d.\n", svga->interlace, _8514_modes, dev->h_disp);
+        if (_8514_modes)
+            dev->ven_clock = mach->accel.clock_sel_mode & 0x7c;
+        else
+            dev->ven_clock = mach->accel.clock_sel & 0x7c;
+
+        mach_log(mach->log, "Mach32: Clock=%02x, double=%02x, h_total=%02x.\n", (dev->ven_clock >> 2) & 0x0f, dev->ven_clock & 0x40, dev->h_total);
+        svga->clock = (cpuclock * (double) (1ULL << 32)) / svga->getclock((dev->ven_clock >> 2) & 0x0f, svga->clock_gen) / 2.0;
+
+        if (dev->ven_clock & 0x40)
+            svga->clock *= 2.0;
+
+        if (dev->bpp) {
+            dev->accel.ge_offset <<= 1;
+            mach->accel.crt_offset <<= 1;
+        } else {
+            dev->accel.ge_offset <<= 2;
+            mach->accel.crt_offset <<= 2;
+        }
+
+        if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
+            dev->accel.ge_offset <<= 1;
+            mach->accel.crt_offset <<= 1;
+        }
+
+        dev->accel.ge_offset -= mach->accel.crt_offset;
+
+        svga->hdisp_time = svga->hdisp >> 3;
+        svga->render8514 = ibm8514_render_blank;
+
+        if (svga->interlace) {
+            svga->dispend >>= 1;
+            svga->clock /= 2.0;
+        }
+
+        switch ((mach->shadow_set >> 8) & 0x03) { /*Per documentation*/
+            case 0x00:
+                mach->accel.src_pitch = dev->pitch;
+                mach->accel.dst_pitch = dev->pitch;
+                mach->accel.src_ge_offset = (mach->accel.ge_offset_lo | (mach->accel.ge_offset_hi << 16));
+                mach->accel.dst_ge_offset = (mach->accel.ge_offset_lo | (mach->accel.ge_offset_hi << 16));
+                if (dev->bpp) {
+                    mach->accel.src_ge_offset <<= 1;
+                    mach->accel.dst_ge_offset <<= 1;
+                } else {
+                    mach->accel.src_ge_offset <<= 2;
+                    mach->accel.dst_ge_offset <<= 2;
+                }
+                if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
+                    mach->accel.src_ge_offset <<= 1;
+                    mach->accel.dst_ge_offset <<= 1;
+                }
+                mach->accel.src_ge_offset -= mach->accel.crt_offset;
+                mach->accel.dst_ge_offset -= mach->accel.crt_offset;
+                dev->accel.src_pitch = mach->accel.src_pitch;
+                dev->accel.dst_pitch = mach->accel.dst_pitch;
+                dev->accel.src_ge_offset = mach->accel.src_ge_offset;
+                dev->accel.dst_ge_offset = mach->accel.dst_ge_offset;
+                break;
+            case 0x01:
+                mach->accel.dst_pitch = dev->pitch;
+                mach->accel.dst_ge_offset = (mach->accel.ge_offset_lo | (mach->accel.ge_offset_hi << 16));
+                if (dev->bpp)
+                    mach->accel.dst_ge_offset <<= 1;
+                else
+                    mach->accel.dst_ge_offset <<= 2;
+
+                if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00))
+                    mach->accel.dst_ge_offset <<= 1;
+
+                mach->accel.dst_ge_offset -= mach->accel.crt_offset;
+                dev->accel.dst_pitch = mach->accel.dst_pitch;
+                dev->accel.dst_ge_offset = mach->accel.dst_ge_offset;
+                break;
+            case 0x02:
+                mach->accel.src_pitch = dev->pitch;
+                mach->accel.src_ge_offset = (mach->accel.ge_offset_lo | (mach->accel.ge_offset_hi << 16));
+                if (dev->bpp)
+                    mach->accel.src_ge_offset <<= 1;
+                else
+                    mach->accel.src_ge_offset <<= 2;
+
+                if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00))
+                    mach->accel.src_ge_offset <<= 1;
+
+                mach->accel.src_ge_offset -= mach->accel.crt_offset;
+                dev->accel.src_pitch = mach->accel.src_pitch;
+                dev->accel.src_ge_offset = mach->accel.src_ge_offset;
+                break;
+            default:
+                break;
+        }
+        if ((mach->accel.ext_ge_config & 0x800) || (!(mach->accel.ext_ge_config & 0x8000) && !(mach->accel.ext_ge_config & 0x800))) {
+            switch (dev->accel_bpp) {
+                case 8:
+                    if ((mach->accel.ext_ge_config & 0x30) == 0x00) {
+                        if (dev->vram_512k_8514) {
+                            if (svga->hdisp == 640)
+                                dev->pitch = 640;
+                            else
+                                dev->pitch = 1024;
+                        }
+                    }
+                    svga->render8514 = ibm8514_render_8bpp;
+                    break;
+                case 15:
+                    svga->render8514 = ibm8514_render_15bpp;
+                    break;
+                case 16:
+                    svga->render8514 = ibm8514_render_16bpp;
+                    break;
+                case 24:
+                    mach_log(mach->log,"GEConfig24bpp: %03x.\n", mach->accel.ext_ge_config & 0x600);
+                    svga->render8514 = ati_render_24bpp;
+                    break;
+                case 32:
+                    mach_log(mach->log,"GEConfig32bpp: %03x.\n", mach->accel.ext_ge_config & 0x600);
+                    svga->render8514 = ati_render_32bpp;
+                    break;
+
+                default:
+                    break;
+            }
+        }
+    } else {
+        if (mach->regs[0xad] & 0x08)
+            svga->hblankstart    = ((mach->regs[0x0d] >> 2) << 8) + svga->crtc[2];
+
+        if (svga->miscout & 0x04)
+            clock_sel |= 0x01;
+        if (svga->miscout & 0x08)
+            clock_sel |= 0x02;
+        if (mach->regs[0xb9] & 0x02)
+            clock_sel |= 0x04;
+        if (mach->regs[0xbe] & 0x10)
+            clock_sel |= 0x08;
+
+        svga->interlace = !!(mach->regs[0xbe] & 0x02);
+        if (svga->interlace)
+            svga->dispend >>= 1;
+
+        if (mach->regs[0xad] & 0x04)
+            svga->memaddr_latch |= 0x40000;
+
+        if (mach->regs[0xad] & 0x08)
+            svga->memaddr_latch |= 0x80000;
+
+        if (mach->regs[0xa3] & 0x10)
+            svga->memaddr_latch |= 0x10000;
+
+        if (mach->regs[0xb0] & 0x40)
+            svga->memaddr_latch |= 0x20000;
+
+        if ((mach->regs[0xb6] & 0x18) >= 0x10) {
+            svga->hdisp <<= 1;
+            svga->htotal <<= 1;
+            svga->dots_per_clock <<= 1;
+            svga->rowoffset <<= 1;
+        }
+
+        if (mach->regs[0xb0] & 0x20) {
+            if ((mach->regs[0xb6] & 0x18) >= 0x10)
+                svga->packed_4bpp = 1;
+            else
+                svga->packed_4bpp = 0;
+        } else
+            svga->packed_4bpp = 0;
+
+        if (!svga->scrblank && svga->attr_palette_enable) {
+            mach_log(mach->log,"GDCREG5=%02x, ATTR10=%02x, ATI B0 bit 5=%02x, ON=%d, char_width=%d, seqreg1 bit 3=%x, clk_sel=%02x.\n",
+                     svga->gdcreg[5] & 0x60, svga->attrregs[0x10] & 0x40, mach->regs[0xb0] & 0x20, dev->on, svga->char_width, svga->seqregs[1] & 0x08, clock_sel);
+
+            svga->clock = (cpuclock * (double) (1ULL << 32)) / svga->getclock(clock_sel, svga->clock_gen);
+
+            switch ((mach->regs[0xb8] >> 6) & 0x03) {
+                case 0x01:
+                    svga->clock *= 2.0;
+                    break;
+                case 0x02:
+                    svga->clock *= 3.0;
+                    break;
+                case 0x03:
+                    svga->clock *= 4.0;
+                    break;
+                default:
+                    break;
+            }
+
+            if (svga->interlace)
+                svga->clock /= 2.0;
+
+            mach_log(mach->log,"VGA clock sel=%02x, divide reg=%02x, miscout bits2-3=%x, machregbe bit4=%02x, machregb9 bit1=%02x, charwidth=%d, htotal=%02x, hdisptime=%02x, seqregs1 bit 3=%02x.\n", clock_sel, (mach->regs[0xb8] >> 6) & 3, svga->miscout & 0x0c, mach->regs[0xbe] & 0x10, mach->regs[0xb9] & 0x02, svga->char_width, svga->htotal, svga->hdisp_time, svga->seqregs[1] & 8);
+            if ((svga->gdcreg[6] & 0x01) || (svga->attrregs[0x10] & 0x01)) {
+                if ((svga->gdcreg[5] & 0x40) || (svga->attrregs[0x10] & 0x40) || (mach->regs[0xb0] & 0x20)) {
+                    svga->map8 = svga->pallook;
+                    mach_log(mach->log,"Lowres=%x, seqreg[1]bit3=%x.\n", svga->lowres, svga->seqregs[1] & 8);
+                    if (svga->lowres)
+                        svga->render = svga_render_8bpp_lowres;
+                    else {
+                        svga->render = svga_render_8bpp_highres;
+                        if (!svga->packed_4bpp) {
+                            svga->memaddr_latch <<= 1;
+                            svga->rowoffset <<= 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
     svga->hoverride = 1;
 }
 
@@ -3586,6 +3910,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
     int frgd_sel;
     int bkgd_sel;
     int mono_src;
+    int ret = 0x00;
 
     if (port & 0x8000) {
         if ((port & 0x06) != 0x06) {
@@ -3596,23 +3921,56 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
         }
     }
 
+    switch (port & 0xfffe) {
+        case 0x2e8:
+        case 0x6e8:
+        case 0xae8:
+        case 0xee8:
+        case 0x12e8:
+        case 0x16e8:
+        case 0x1ae8:
+        case 0x1ee8:
+        case 0x22e8:
+            if (ATI_MACH32) {
+                if (mach->accel.clock_sel & 0x01)
+                    ret = 0x01;
+                else if (dev->accel.advfunc_cntl & 0x01) {
+                    if (!(mach->regs[0xb0] & 0x20)) {
+                        if (!dev->on)
+                            ret = 0x01;
+                    }
+                } else if (!(mach->accel.clock_sel & 0x01) && !(dev->accel.advfunc_cntl & 0x01))
+                    ret = 0x01;
+                else if (!dev->on)
+                    ret = 0x01;
+            } else {
+                if (mach->accel.clock_sel & 0x01)
+                    ret = 0x01;
+                else if (!dev->on)
+                    ret = 0x01;
+            }
+            break;
+    }
+
     mach_log(mach->log, "[%04X:%08X]: Port FIFO OUT=%04x, val=%04x, len=%d.\n", CS, cpu_state.pc, port, val, len);
 
     switch (port) {
         case 0x2e8:
             mach_log(mach->log,"HTOTAL=%04x, len=%d, ATI mode bit=%x, set=%x, shadow cntl=%02x.\n", val, len, mach->accel.clock_sel & 0x01, mach->shadow_set & 0x03, mach->shadow_cntl);
-            if ((mach->accel.clock_sel & 0x01) || !dev->on || dev->ext_mode_inc) {
+            if (ret) {
                 if (!(mach->shadow_cntl & 0x04)) {
-                    if (val)
+                    if (val >= 0x63) {
                         dev->htotal = val;
-
+                        dev->vga_htotal = 0;
+                        dev->h_total_back = dev->htotal + 1;
+                    }
                     mach_set_resolution(mach, svga);
                 }
             }
             break;
 
         case 0xae8:
-            if ((mach->accel.clock_sel & 0x01) || !dev->on || dev->ext_mode_inc) { /*For 8514/A mode, take the shadow sets into account.*/
+            if (ret) {
                 if (!(mach->shadow_cntl & 0x04)) {
                     WRITE8(port, dev->hsync_start, val);
                     mach_set_resolution(mach, svga);
@@ -3621,7 +3979,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             break;
 
         case 0xee8:
-            if ((mach->accel.clock_sel & 0x01) || !dev->on || dev->ext_mode_inc) { /*For 8514/A mode, take the shadow sets into account.*/
+            if (ret) {
                 if (!(mach->shadow_cntl & 0x04)) {
                     WRITE8(port, dev->hsync_width, val);
                     mach_set_resolution(mach, svga);
@@ -3631,11 +3989,14 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
 
         case 0x6e8:
             if (len == 2) {
-                mach_log(mach->log,"HDISP and HTOTAL=%04x, len=%d, ATI mode bit=%x, set=%x, shadow cntl=%02x.\n", val, len, mach->accel.clock_sel & 0x01, mach->shadow_set & 0x03, mach->shadow_cntl);
-                if ((mach->accel.clock_sel & 0x01) || !dev->on || dev->ext_mode_inc) { /*For 8514/A mode, take the shadow sets into account.*/
+                mach_log(mach->log, "HDISP and HTOTAL=%04x, len=%d, ATI mode bit=%x, set=%x, shadow cntl=%02x.\n", val, len, mach->accel.clock_sel & 0x01, mach->shadow_set & 0x03, mach->shadow_cntl);
+                if (ret) {
                     if (!(mach->shadow_cntl & 0x04)) {
-                        if ((val >> 8) & 0xff)
+                        if (((val >> 8) & 0xff) >= 0x63) {
                             dev->htotal = (val >> 8) & 0xff;
+                            dev->vga_htotal = 0;
+                            dev->h_total_back = dev->htotal + 1;
+                        }
                     }
 
                     if (!(mach->shadow_cntl & 0x08)) {
@@ -3649,8 +4010,8 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                         mach_set_resolution(mach, svga);
                 }
             } else {
-                mach_log(mach->log,"HDISP and HTOTAL=%02x, len=%d, ATI mode bit=%x, set=%x, shadow cntl=%02x.\n", val, len, mach->accel.clock_sel & 0x01, mach->shadow_set & 0x03, mach->shadow_cntl);
-                if ((mach->accel.clock_sel & 0x01) || !dev->on || dev->ext_mode_inc) { /*For 8514/A mode, take the shadow sets into account.*/
+                mach_log(mach->log,"HDISP and HTOTAL=%02x, len=%d, ATI mode bit=%x, IBM mode bit=%x, set=%x, shadow cntl=%02x, on air=%d.\n", val, len, mach->accel.clock_sel & 0x01, dev->accel.advfunc_cntl & 0x01, mach->shadow_set & 0x03, mach->shadow_cntl, dev->on);
+                if (ret) {
                     if (!(mach->shadow_cntl & 0x08)) {
                         if (val)
                             dev->hdisped = val;
@@ -3667,11 +4028,13 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
         case 0x6e9:
             if (len == 1) {
                 mach_log(mach->log,"HDISP and HTOTAL+1=%02x, len=%d, ATI mode bit=%x, set=%x.\n", val, len, mach->accel.clock_sel & 0x01, mach->shadow_set & 0x03);
-                if ((mach->accel.clock_sel & 0x01) || !dev->on || dev->ext_mode_inc) { /*For 8514/A mode, take the shadow sets into account.*/
+                if (ret) {
                     if (!(mach->shadow_cntl & 0x04)) {
-                        if (val)
+                        if (val >= 0x63) {
                             dev->htotal = val;
-
+                            dev->vga_htotal = 0;
+                            dev->h_total_back = dev->htotal + 1;
+                        }
                         mach_set_resolution(mach, svga);
                     }
                 }
@@ -3680,7 +4043,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
 
         case 0x12e8:
             if (len == 2) {
-                if ((mach->accel.clock_sel & 0x01) || !dev->on || dev->ext_mode_inc) { /*For 8514/A mode, take the shadow sets into account.*/
+                if (ret) {
                     if (!(mach->shadow_cntl & 0x10)) {
                         if (val & 0x1fff) {
                             dev->v_total_reg = val;
@@ -3690,7 +4053,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                     }
                 }
             } else {
-                if ((mach->accel.clock_sel & 0x01) || !dev->on || dev->ext_mode_inc) { /*For 8514/A mode, take the shadow sets into account.*/
+                if (ret) {
                     if (!(mach->shadow_cntl & 0x10)) {
                         if (val & 0xff) {
                             WRITE8(port, dev->v_total_reg, val);
@@ -3705,7 +4068,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
 
         case 0x12e9:
             if (len == 1) {
-                if ((mach->accel.clock_sel & 0x01) || !dev->on || dev->ext_mode_inc) {
+                if (ret) {
                     if (!(mach->shadow_cntl & 0x10)) {
                         if ((val >> 8) & 0xff) {
                             WRITE8(port, dev->v_total_reg, val >> 8);
@@ -3720,7 +4083,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
 
         case 0x16e8:
             if (len == 2) {
-                if ((mach->accel.clock_sel & 0x01) || !dev->on || dev->ext_mode_inc) { /*For 8514/A mode, take the shadow sets into account.*/
+                if (ret) {
                     if (!(mach->shadow_cntl & 0x20)) {
                         if (val & 0x1fff) {
                             dev->v_disp = val;
@@ -3729,10 +4092,9 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                         mach_set_resolution(mach, svga);
                     }
                 }
-                mach_log(mach->log,"ATI 8514/A: V_DISP write 16E8=%d, vdisp2=%d.\n", dev->v_disp, dev->v_disp2);
                 mach_log(mach->log,"ATI 8514/A: (0x%04x): vdisp=0x%02x.\n", port, val);
             } else {
-                if ((mach->accel.clock_sel & 0x01) || !dev->on || dev->ext_mode_inc) { /*For 8514/A mode, take the shadow sets into account.*/
+                if (ret) {
                     if (!(mach->shadow_cntl & 0x20)) {
                         if (val & 0xff) {
                             WRITE8(port, dev->v_disp, val);
@@ -3745,7 +4107,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             break;
         case 0x16e9:
             if (len == 1) {
-                if ((mach->accel.clock_sel & 0x01) || !dev->on || dev->ext_mode_inc) { /*For 8514/A mode, take the shadow sets into account.*/
+                if (ret) {
                     if (!(mach->shadow_cntl & 0x20)) {
                         if ((val >> 8) & 0xff) {
                             WRITE8(port, dev->v_disp, val >> 8);
@@ -3754,14 +4116,13 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                         mach_set_resolution(mach, svga);
                     }
                 }
-                mach_log(mach->log,"ATI 8514/A: V_DISP write 16E8=%d, vdisp2=%d.\n", dev->v_disp, dev->v_disp2);
                 mach_log(mach->log,"ATI 8514/A: (0x%04x): vdisp=0x%02x.\n", port, val);
             }
             break;
 
         case 0x1ae8:
             if (len == 2) {
-                if ((mach->accel.clock_sel & 0x01) || !dev->on || dev->ext_mode_inc) { /*For 8514/A mode, take the shadow sets into account.*/
+                if (ret) {
                     if (!(mach->shadow_cntl & 0x10)) {
                         if (val & 0x1fff) {
                             dev->v_sync_start = val;
@@ -3773,7 +4134,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                 mach_log(mach->log,"ATI 8514/A: V_SYNCSTART write 1AE8 = %d\n", dev->v_syncstart);
                 mach_log(mach->log,"ATI 8514/A: (0x%04x): vsyncstart=0x%02x.\n", port, val);
             } else {
-                if ((mach->accel.clock_sel & 0x01) || !dev->on || dev->ext_mode_inc) { /*For 8514/A mode, take the shadow sets into account.*/
+                if (ret) {
                     if (!(mach->shadow_cntl & 0x10)) {
                         if (val & 0xff) {
                             WRITE8(port, dev->v_sync_start, val);
@@ -3786,7 +4147,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             break;
         case 0x1ae9:
             if (len == 1) {
-                if ((mach->accel.clock_sel & 0x01) || !dev->on || dev->ext_mode_inc) { /*For 8514/A mode, take the shadow sets into account.*/
+                if (ret) {
                     if (!(mach->shadow_cntl & 0x10)) {
                         if ((val >> 8) & 0xff) {
                             WRITE8(port, dev->v_sync_start, val >> 8);
@@ -3802,7 +4163,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
 
         case 0x1ee8:
         case 0x1ee9:
-            if ((mach->accel.clock_sel & 0x01) || !dev->on || dev->ext_mode_inc) {
+            if (ret) {
                 if (!(mach->shadow_cntl & 0x10)) {
                     mach_set_resolution(mach, svga);
                 }
@@ -3810,7 +4171,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             break;
 
         case 0x22e8:
-            if ((mach->accel.clock_sel & 0x01) || !dev->on || dev->ext_mode_inc) {
+            if (ret) {
                 if (!(mach->shadow_cntl & 0x01)) {
                     dev->disp_cntl = val;
                     dev->disp_cntl_interlace = !!(val & 0x10);
@@ -3819,9 +4180,8 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                     mach_set_resolution(mach, svga);
                 }
             }
-
-            mach_log(mach->log,"ATI 8514/A: DISP_CNTL write %04x=%02x, written=%02x, interlace=%02x, shadowset=%02x, shadowcntl=%02x.\n",
-                     port, val, dev->disp_cntl & 0x70, dev->disp_cntl & 0x10, mach->shadow_set & 0x03, mach->shadow_cntl & 0x03);
+            mach_log(mach->log,"ATI 8514/A: %04X:%08X: DISP_CNTL write %04x=%02x, written=%02x, interlace=%02x, shadowset=%02x, shadowcntl=%02x.\n",
+                     CS, cpu_state.pc, port, val, dev->disp_cntl & 0x70, dev->disp_cntl & 0x10, mach->shadow_set & 0x03, mach->shadow_cntl & 0x03);
             break;
 
         case 0x42e8:
@@ -3840,32 +4200,28 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             }
             break;
 
-        case 0x46e8:
-        case 0x46e9:
-            mach_log(mach->log,"0x%04x write: VGA subsystem enable add-on=%02x.\n", port, val);
-            break;
-
         case 0x4ae8:
         case 0x4ae9:
             WRITE8(port, dev->accel.advfunc_cntl, val);
             if (len == 2) {
                 WRITE8(port + 1, dev->accel.advfunc_cntl, val >> 8);
             }
-
+            dev->mode = IBM_MODE;
             dev->on = dev->accel.advfunc_cntl & 0x01;
             dev->vendor_mode = 0;
-            if (dev->ext_mode_inc) {
+            if (ATI_MACH32) {
                 if (mach->regs[0xb0] & 0x20) {
-                    dev->on = 1;
-                    dev->vendor_mode = !!(ATI_MACH32);
+                    if (!dev->on) {
+                        dev->on |= 0x01;
+                        dev->vendor_mode = 1;
+                    }
                 }
             }
 
-            dev->mode = IBM_MODE;
-            mach_log(mach->log, "[%04X:%08X]: ATI 8514/A: (0x%04x): ON=%d, valxor=%x, shadow crt=%x, hdisp=%d, vdisp=%d, extmode=%02x, accelbpp=%d, crt=%d, change=%d.\n",
-                     CS, cpu_state.pc, port, val & 0x01, dev->on, dev->accel.advfunc_cntl & 0x04, dev->hdisp, dev->vdisp, mach->regs[0xb0] & 0x20, dev->accel_bpp, dev->ext_mode_inc, dev->disp_change);
+            mach_log(mach->log,"[%04X:%08X]: ATI 8514/A: (0x%04x): ON=%d, valxor=%x, shadow crt=%x, hdisp=%d, vdisp=%d, extmode=%02x, accelbpp=%d, crt=%d, change=%d.\n",
+                     CS, cpu_state.pc, port, val & 0x01, dev->on, dev->accel.advfunc_cntl & 0x04, dev->hdisp, dev->vdisp, mach->regs[0xb0] & 0x20, dev->accel_bpp, dev->extended_mode, dev->disp_change);
 
-            mach_log(mach->log,"Vendor IBM mode set %s resolution.\n", (dev->accel.advfunc_cntl & 0x04) ? "2: 1024x768" : "1: 640x480");
+            mach_log(mach->log,"IBM 8514/A mode set %s resolution.\n", (dev->accel.advfunc_cntl & 0x04) ? "2: 1024x768" : "1: 640x480");
 
             if (ATI_MACH32) {
                 if (dev->disp_change) {
@@ -3990,6 +4346,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                                 break;
 
                             mach_log(mach->log,"IBM transfer.\n");
+
                             if (dev->accel.output3) {
                                 ibm8514_accel_out_pixtrans(svga, port, val & 0xff, len);
                                 ibm8514_accel_out_pixtrans(svga, port, (val >> 8) & 0xff, len);
@@ -4121,9 +4478,9 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                 WRITE8(port + 1, mach->cursor_offset_lo_reg, val >> 8);
             }
             mach->cursor_offset_lo = mach->cursor_offset_lo_reg;
-            dev->hwcursor.addr = ((mach->cursor_offset_lo | (mach->cursor_offset_hi << 16)) << 2);
+            svga->hwcursor.addr = ((mach->cursor_offset_lo | (mach->cursor_offset_hi << 16)) << 2);
             if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00))
-                dev->hwcursor.addr <<= 1;
+                svga->hwcursor.addr <<= 1;
             break;
 
         case 0xeee:
@@ -4132,11 +4489,11 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             if (len == 2) {
                 WRITE8(port + 1, mach->cursor_offset_hi_reg, val >> 8);
             }
-            dev->hwcursor.ena = !!(mach->cursor_offset_hi_reg & 0x8000);
+            svga->hwcursor.ena = !!(mach->cursor_offset_hi_reg & 0x8000);
             mach->cursor_offset_hi = mach->cursor_offset_hi_reg & 0x0f;
-            dev->hwcursor.addr = ((mach->cursor_offset_lo | (mach->cursor_offset_hi << 16)) << 2);
+            svga->hwcursor.addr = ((mach->cursor_offset_lo | (mach->cursor_offset_hi << 16)) << 2);
             if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00))
-                dev->hwcursor.addr <<= 1;
+                svga->hwcursor.addr <<= 1;
             break;
 
         case 0x12ee:
@@ -4145,7 +4502,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             if (len == 2) {
                 WRITE8(port + 1, mach->cursor_x, val >> 8);
             }
-            dev->hwcursor.x = mach->cursor_x & 0x7ff;
+            svga->hwcursor.x = mach->cursor_x & 0x7ff;
             break;
 
         case 0x16ee:
@@ -4154,7 +4511,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             if (len == 2) {
                 WRITE8(port + 1, mach->cursor_y, val >> 8);
             }
-            dev->hwcursor.y = mach->cursor_y & 0xfff;
+            svga->hwcursor.y = mach->cursor_y & 0xfff;
             break;
 
         case 0x1aee:
@@ -4175,8 +4532,8 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             if (len == 2) {
                 WRITE8(port + 1, mach->cursor_vh_offset, val >> 8);
             }
-            dev->hwcursor.xoff = mach->cursor_vh_offset & 0x3f;
-            dev->hwcursor.yoff = (mach->cursor_vh_offset >> 8) & 0x3f;
+            svga->hwcursor.xoff = mach->cursor_vh_offset & 0x3f;
+            svga->hwcursor.yoff = (mach->cursor_vh_offset >> 8) & 0x3f;
             break;
 
         case 0x22ee:
@@ -4198,12 +4555,12 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                 dev->ext_crt_pitch = mach->accel.crt_pitch & 0xff;
             else {
                 /*Workaround for environments that don't use Mach8/32 acceleration but uses Mach8/32 native mode (remove this block of code if real hardware doesn't match this).*/
-                if (!dev->hwcursor.ena) {
+                if (!svga->hwcursor.ena) {
                     mach->cursor_col_0 = 0x00;
                     mach->cursor_col_1 = 0xff;
                 }
             }
-            mach_log(mach->log, "CRT Pitch=%04x, accel_bpp=%d, accel_crt_pitch=%04x.\n", dev->ext_crt_pitch, dev->accel_bpp, mach->accel.crt_pitch);
+            mach_log(mach->log,"CRT Pitch=%04x, accel_bpp=%d, accel_crt_pitch=%04x, len=%d.\n", dev->ext_crt_pitch, dev->accel_bpp, mach->accel.crt_pitch, len);
             if (dev->accel_bpp > 8) {
                 if (mach->accel.crt_pitch & 0xff) {
                     if (dev->accel_bpp == 24) {
@@ -4215,11 +4572,17 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                 }
             }
 
-            dev->ext_mode_inc = 1;
-            if (len == 2) {
-                if (!(dev->accel.advfunc_cntl & 0x01) && ATI_MACH32) {
-                    dev->on = 1;
-                    dev->vendor_mode = 1;
+            if (ATI_MACH32) {
+                if (!dev->on) {
+                    if (dev->mode == IBM_MODE) {
+                        if (dev->h_total_back && !dev->vga_htotal) {
+                            dev->on |= 0x01;
+                            dev->vendor_mode = 1;
+                        } else if (dev->vga_htotal) {
+                            dev->on &= ~0x01;
+                            dev->vendor_mode = 0;
+                        }
+                    }
                 }
             }
 
@@ -4264,12 +4627,9 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
         case 0x36ee:
         case 0x36ef:
             if (len == 2) {
-                if (ATI_MACH32)
-                    mach->misc = val;
+                mach->misc = val;
             } else {
-                if (ATI_MACH32) {
-                    WRITE8(port, mach->misc, val);
-                }
+                WRITE8(port, mach->misc, val);
             }
             mach->misc &= 0xfff0;
             break;
@@ -4325,17 +4685,17 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
             if (len == 2) {
                 WRITE8(port + 1, mach->accel.clock_sel, val >> 8);
             }
-            if (!(dev->accel.advfunc_cntl & 0x01))
-                dev->on = mach->accel.clock_sel & 0x01;
-            else {
-                if (!(mach->regs[0xb0] & 0x20) && !(mach->accel.clock_sel & 0x01))
-                    dev->on = 0;
-            }
 
-            dev->vendor_mode = 1;
             dev->mode = ATI_MODE;
-
-            mach_log(mach->log, "[%04X:%08X]: ATI 8514/A: (0x%04x): ON=%d, val=%04x, xor=%d, hdisp=%d, vdisp=%d, accelbpp=%d.\n",
+            dev->on = mach->accel.clock_sel & 0x01;
+            dev->vendor_mode = 1;
+            if (ATI_MACH32) {
+                if (mach->regs[0xb0] & 0x20) {
+                    if (!dev->on)
+                        dev->on |= 0x01;
+                }
+            }
+            mach_log(mach->log,"[%04X:%08X]: ATI 8514/A: (0x%04x): ON=%d, val=%04x, xor=%d, hdisp=%d, vdisp=%d, accelbpp=%d.\n",
                      CS, cpu_state.pc, port, mach->accel.clock_sel & 0x01, val, dev->on, dev->hdisp, dev->vdisp, dev->accel_bpp);
             mach_log(mach->log,"Vendor ATI mode set %s resolution.\n",
                      (dev->accel.advfunc_cntl & 0x04) ? "2: 1024x768" : "1: 640x480");
@@ -4440,8 +4800,23 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                 WRITE8(port, mach->accel.ge_pitch, val);
             }
             dev->ext_pitch = ((mach->accel.ge_pitch & 0xff) << 3);
+
             mach_log(mach->log,"ATI 8514/A: (0x%04x) GE Pitch val=0x%02x.\n", port, val);
-            svga_recalctimings(svga);
+            if (ATI_MACH32) {
+                if (dev->mode == IBM_MODE) {
+                    if (dev->h_total_back && !dev->vga_htotal) {
+                        dev->on |= 0x01;
+                        dev->vendor_mode = 1;
+                    } else if (dev->vga_htotal) {
+                        dev->on &= ~0x01;
+                        dev->vendor_mode = 0;
+                    }
+                }
+                mach_set_resolution(mach, svga);
+                svga_recalctimings(svga);
+                mach32_updatemapping(mach, svga);
+            } else
+                svga_recalctimings(svga);
             break;
 
         case 0x7aee:
@@ -4496,7 +4871,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                         break;
                 }
                 svga_set_ramdac_type(svga, !!(mach->accel.ext_ge_config & 0x4000));
-                mach_log(mach->log, "ATI 8514/A: (0x%04x) Extended Configuration=%04x, val=%04x.\n", port, mach->accel.ext_ge_config, val);
+                mach_log(mach->log,"ATI 8514/A: (0x%04x) Extended Configuration=%04x, val=%04x, extcrt=%d.\n", port, mach->accel.ext_ge_config, val, dev->extended_mode);
                 if (dev->mode != VGA_MODE) {
                     dev->disp_change = 0;
                     if (!(mach->accel.ext_ge_config & 0x8000) && !(mach->accel.ext_ge_config & 0x800))
@@ -4507,8 +4882,8 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                 svga_recalctimings(svga);
                 mach32_updatemapping(mach, svga);
             } else {
-                if (mach->accel.ext_ge_config & 0x80)
-                    ati_eeprom_write(&mach->eeprom, !!(mach->accel.ext_ge_config & 0x04), !!(mach->accel.ext_ge_config & 0x02), !!(mach->accel.ext_ge_config & 0x01));
+                if (mach->accel.ext_ge_config & 0x8000)
+                    ati_eeprom_write(&mach->eeprom, !!(mach->accel.ext_ge_config & 0x4000), !!(mach->accel.ext_ge_config & 0x2000), !!(mach->accel.ext_ge_config & 0x1000));
             }
             break;
 
@@ -4689,7 +5064,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
                 dev->data_available  = 0;
                 dev->data_available2 = 0;
                 mach->accel.cmd_type = 5; /*Horizontal Raster Draw from scan_to_x register (0xcaee)*/
-                mach_log(mach->log,"ScanToX len=%d.\n", val);
+                mach_log(mach_log, "ScanToX len=%d, DX=%d, DY=%d.\n", val, dev->accel.cur_x, dev->accel.cur_y);
                 mach_log(mach->log,".\n");
 
                 frgd_sel = (mach->accel.dp_config >> 13) & 7;
@@ -4842,7 +5217,7 @@ mach_accel_out_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, u
 static uint16_t
 mach_accel_in_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, int len)
 {
-    const uint16_t *vram_w = (uint16_t *) dev->vram;
+    const uint16_t *vga_vram_w = (uint16_t *) svga->vram;
     uint16_t        temp = 0x0000;
     int             cmd;
     int             frgd_sel;
@@ -5045,7 +5420,8 @@ mach_accel_in_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, in
                             dev->force_busy = 1;
                             dev->data_available = 1;
                         }
-                        mach_log(mach->log,"%04X:%08X: Opcode=%d, Len=%d, port=%04x, input=%d, temp=%04x, fullcmd=%04x, crx=%d, cry=%d, frgdsel=%x, bkgdsel=%x.\n", CS, cpu_state.pc, cmd, len, port, dev->accel.input, temp, dev->accel.cmd, dev->accel.cx, dev->accel.cy, dev->accel.frgd_sel, dev->accel.bkgd_sel);
+
+                        mach_log(mach->log, "%04X:%08X: Opcode=%d, Len=%d, port=%04x, input=%d, temp=%04x, fullcmd=%04x, crx=%d, cry=%d, frgdsel=%x, bkgdsel=%x.\n", CS, cpu_state.pc, cmd, len, port, dev->accel.input, temp, dev->accel.cmd, dev->accel.cx, dev->accel.cy, dev->accel.frgd_sel, dev->accel.bkgd_sel);
 
                         if (dev->accel.input || dev->accel.input3) {
                             ibm8514_accel_out_pixtrans(svga, port, temp & 0xff, len);
@@ -5164,7 +5540,7 @@ mach_accel_in_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, in
 
                 dev->fifo_idx = 0;
 
-                mach_log(mach->log,"9AEE read: Extended FIFO Status=%04x, fifoidx=%d.\n", temp, dev->fifo_idx);
+                mach_log(mach->log,"%04X:%08X: 9AEE read: Extended FIFO Status=%04x, fifoidx=%d.\n", CS, cpu_state.pc, temp, dev->fifo_idx);
             }
             break;
 
@@ -5313,7 +5689,7 @@ mach_accel_in_fifo(mach_t *mach, svga_t *svga, ibm8514_t *dev, uint16_t port, in
             break;
     }
 
-    mach_log(mach->log, "[%04X:%08X]: Port FIFO IN=%04x, temp=%04x, len=%d.\n", CS, cpu_state.pc, port, temp, len);
+    mach_log(mach->log, "%04X:%08X: Port FIFO IN=%04x, temp=%04x, len=%d.\n", CS, cpu_state.pc, port, temp, len);
 
     return temp;
 }
@@ -5346,8 +5722,10 @@ mach_accel_in_call(uint16_t port, mach_t *mach, svga_t *svga, ibm8514_t *dev)
         case 0x42e8:
         case 0x42e9:
             if (!(port & 1)) {
-                if ((dev->subsys_cntl & INT_VSY) && !(dev->subsys_stat & INT_VSY) && (dev->vc == dev->dispend))
-                    temp |= INT_VSY;
+                if ((dev->subsys_cntl & INT_VSY) && !(dev->subsys_stat & INT_VSY)) {
+                    if (dev->vc == dev->dispend)
+                        temp |= INT_VSY;
+                }
 
                 if (mach->accel.cmd_type == -1) {
                     if (cmd == 6) {
@@ -5410,7 +5788,7 @@ mach_accel_in_call(uint16_t port, mach_t *mach, svga_t *svga, ibm8514_t *dev)
                 else
                     temp |= 0x20;
 
-                mach_log(mach->log,"0x%04x read: Subsystem Status=%02x, monitoralias=%02x.\n", port, temp, mach->accel.ext_ge_config & 0x07);
+                mach_log(mach->log, "%04X:%08X: 0x%04x read: Subsystem Status=%02x, monitoralias=%02x.\n", CS, cpu_state.pc, port, temp, mach->accel.ext_ge_config & 0x07);
             }
             break;
 
@@ -5448,24 +5826,26 @@ mach_accel_in_call(uint16_t port, mach_t *mach, svga_t *svga, ibm8514_t *dev)
 
         case 0x36ee:
         case 0x36ef:
-            if (ATI_MACH32) {
-                READ8(port, mach->misc);
-                if (!(port & 1)) {
-                    temp &= ~0x0c;
-                    switch (dev->vram_amount) {
-                        case 1024:
-                            temp |= 0x04;
-                            break;
-                        case 2048:
-                            temp |= 0x08;
-                            break;
-                        case 4096:
-                            temp |= 0x0c;
-                            break;
+            READ8(port, mach->misc);
+            if (!(port & 1)) {
+                temp &= ~0x0c;
+                switch (dev->vram_amount) {
+                    case 1024:
+                        temp |= 0x04;
+                        break;
+                    case 2048:
+                        temp |= 0x08;
+                        break;
+                    case 4096:
+                        temp |= 0x0c;
+                        break;
 
-                        default:
-                            break;
-                    }
+                    default:
+                        break;
+                }
+                if (ATI_GRAPHICS_ULTRA) {
+                    if (mach->bus_width_8bit == 16)
+                        temp |= 0x02;
                 }
             }
             break;
@@ -5560,7 +5940,7 @@ mach_accel_in_call(uint16_t port, mach_t *mach, svga_t *svga, ibm8514_t *dev)
         default:
             break;
     }
-    mach_log(mach->log,"[%04X:%08X]: Port NORMAL IN=%04x, temp=%04x.\n", CS, cpu_state.pc, port, temp);
+    mach_log(mach->log,"%04X:%08X: Port NORMAL IN=%04x, temp=%04x.\n", CS, cpu_state.pc, port, temp);
 
     return temp;
 }
@@ -5832,28 +6212,28 @@ mach32_write_common(uint32_t addr, uint8_t val, int linear, mach_t *mach, svga_t
         if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00))
             addr <<= 1;
 
-        addr &= dev->vram_mask;
-        dev->changedvram[addr >> 12] = svga->monitor->mon_changeframecount;
+        addr &= svga->vram_mask;
+        svga->changedvram[addr >> 12] = svga->monitor->mon_changeframecount;
         if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
             switch (addr & 0x06) {
                 case 0x00:
                 case 0x06:
-                    dev->vram[addr] = val & 0x0f;
-                    dev->vram[addr + 1] = (val >> 4) & 0x0f;
+                    svga->vram[addr] = val & 0x0f;
+                    svga->vram[addr + 1] = (val >> 4) & 0x0f;
                     break;
                 case 0x02:
-                    dev->vram[addr + 2] = val & 0x0f;
-                    dev->vram[addr + 3] = (val >> 4) & 0x0f;
+                    svga->vram[addr + 2] = val & 0x0f;
+                    svga->vram[addr + 3] = (val >> 4) & 0x0f;
                     break;
                 case 0x04:
-                    dev->vram[addr - 2] = val & 0x0f;
-                    dev->vram[addr - 1] = (val >> 4) & 0x0f;
+                    svga->vram[addr - 2] = val & 0x0f;
+                    svga->vram[addr - 1] = (val >> 4) & 0x0f;
                     break;
                 default:
                     break;
             }
         } else
-            dev->vram[addr] = val;
+            svga->vram[addr] = val;
 
         return;
     }
@@ -5870,11 +6250,11 @@ mach32_write_common(uint32_t addr, uint8_t val, int linear, mach_t *mach, svga_t
             writemask2 <<= 1;
 
         addr &= ~1;
-        addr &= dev->vram_mask;
+        addr &= svga->vram_mask;
     } else {
         writemask2 = 1 << (addr & 3);
         addr &= ~3;
-        addr &= dev->vram_mask;
+        addr &= svga->vram_mask;
     }
     addr &= svga->decode_mask;
 
@@ -5883,8 +6263,8 @@ mach32_write_common(uint32_t addr, uint8_t val, int linear, mach_t *mach, svga_t
         return;
     }
 
-    addr &= dev->vram_mask;
-    dev->changedvram[addr >> 12] = svga->monitor->mon_changeframecount;
+    addr &= svga->vram_mask;
+    svga->changedvram[addr >> 12] = svga->monitor->mon_changeframecount;
 
     switch (svga->writemode) {
         case 0:
@@ -5892,7 +6272,7 @@ mach32_write_common(uint32_t addr, uint8_t val, int linear, mach_t *mach, svga_t
             if ((svga->gdcreg[8] == 0xff) && !(svga->gdcreg[3] & 0x18) && (!svga->gdcreg[1] || svga->set_reset_disabled)) {
                 for (i = 0; i < 4; i++) {
                     if (writemask2 & (1 << i))
-                        dev->vram[addr | i] = val;
+                        svga->vram[addr | i] = val;
                 }
                 return;
             } else {
@@ -5907,7 +6287,7 @@ mach32_write_common(uint32_t addr, uint8_t val, int linear, mach_t *mach, svga_t
         case 1:
             for (i = 0; i < 4; i++) {
                 if (writemask2 & (1 << i))
-                    dev->vram[addr | i] = dev->latch.b[i];
+                    svga->vram[addr | i] = dev->latch.b[i];
             }
             return;
         case 2:
@@ -5917,7 +6297,7 @@ mach32_write_common(uint32_t addr, uint8_t val, int linear, mach_t *mach, svga_t
             if (!(svga->gdcreg[3] & 0x18) && (!svga->gdcreg[1] || svga->set_reset_disabled)) {
                 for (i = 0; i < 4; i++) {
                     if (writemask2 & (1 << i))
-                        dev->vram[addr | i] = (vall.b[i] & svga->gdcreg[8]) | (dev->latch.b[i] & ~svga->gdcreg[8]);
+                        svga->vram[addr | i] = (vall.b[i] & svga->gdcreg[8]) | (dev->latch.b[i] & ~svga->gdcreg[8]);
                 }
                 return;
             }
@@ -5940,25 +6320,25 @@ mach32_write_common(uint32_t addr, uint8_t val, int linear, mach_t *mach, svga_t
         case 0x00: /* Set */
             for (i = 0; i < 4; i++) {
                 if (writemask2 & (1 << i))
-                    dev->vram[addr | i] = (vall.b[i] & svga->gdcreg[8]) | (dev->latch.b[i] & ~svga->gdcreg[8]);
+                    svga->vram[addr | i] = (vall.b[i] & svga->gdcreg[8]) | (dev->latch.b[i] & ~svga->gdcreg[8]);
             }
             break;
         case 0x08: /* AND */
             for (i = 0; i < 4; i++) {
                 if (writemask2 & (1 << i))
-                    dev->vram[addr | i] = (vall.b[i] | ~svga->gdcreg[8]) & dev->latch.b[i];
+                    svga->vram[addr | i] = (vall.b[i] | ~svga->gdcreg[8]) & dev->latch.b[i];
             }
             break;
         case 0x10: /* OR */
             for (i = 0; i < 4; i++) {
                 if (writemask2 & (1 << i))
-                    dev->vram[addr | i] = (vall.b[i] & svga->gdcreg[8]) | dev->latch.b[i];
+                    svga->vram[addr | i] = (vall.b[i] & svga->gdcreg[8]) | dev->latch.b[i];
             }
             break;
         case 0x18: /* XOR */
             for (i = 0; i < 4; i++) {
                 if (writemask2 & (1 << i))
-                    dev->vram[addr | i] = (vall.b[i] & svga->gdcreg[8]) ^ dev->latch.b[i];
+                    svga->vram[addr | i] = (vall.b[i] & svga->gdcreg[8]) ^ dev->latch.b[i];
             }
             break;
 
@@ -6306,22 +6686,22 @@ mach32_writew_linear(uint32_t addr, uint16_t val, mach_t *mach)
     if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00))
         addr <<= 1;
 
-    addr &= dev->vram_mask;
-    dev->changedvram[addr >> 12] = svga->monitor->mon_changeframecount;
+    addr &= svga->vram_mask;
+    svga->changedvram[addr >> 12] = svga->monitor->mon_changeframecount;
     if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
         if (addr & 0x04) {
-            dev->vram[addr - 2] = val & 0x0f;
-            dev->vram[addr - 1] = (val >> 4) & 0x0f;
-            dev->vram[addr + 2] = (val >> 8) & 0x0f;
-            dev->vram[addr + 3] = (val >> 12) & 0x0f;
+            svga->vram[addr - 2] = val & 0x0f;
+            svga->vram[addr - 1] = (val >> 4) & 0x0f;
+            svga->vram[addr + 2] = (val >> 8) & 0x0f;
+            svga->vram[addr + 3] = (val >> 12) & 0x0f;
         } else {
-            dev->vram[addr] = val & 0x0f;
-            dev->vram[addr + 1] = (val >> 4) & 0x0f;
-            dev->vram[addr + 4] = (val >> 8) & 0x0f;
-            dev->vram[addr + 5] = (val >> 12) & 0x0f;
+            svga->vram[addr] = val & 0x0f;
+            svga->vram[addr + 1] = (val >> 4) & 0x0f;
+            svga->vram[addr + 4] = (val >> 8) & 0x0f;
+            svga->vram[addr + 5] = (val >> 12) & 0x0f;
         }
     } else
-        *(uint16_t *) &dev->vram[addr] = val;
+        *(uint16_t *) &svga->vram[addr] = val;
 }
 
 static __inline void
@@ -6335,19 +6715,19 @@ mach32_writel_linear(uint32_t addr, uint32_t val, mach_t *mach)
     if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00))
         addr <<= 1;
 
-    addr &= dev->vram_mask;
-    dev->changedvram[addr >> 12] = svga->monitor->mon_changeframecount;
+    addr &= svga->vram_mask;
+    svga->changedvram[addr >> 12] = svga->monitor->mon_changeframecount;
     if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
-        dev->vram[addr] = val & 0x0f;
-        dev->vram[addr + 1] = (val >> 4) & 0x0f;
-        dev->vram[addr + 4] = (val >> 8) & 0x0f;
-        dev->vram[addr + 5] = (val >> 12) & 0x0f;
-        dev->vram[addr + 2] = (val >> 16) & 0x0f;
-        dev->vram[addr + 3] = (val >> 20) & 0x0f;
-        dev->vram[addr + 6] = (val >> 24) & 0x0f;
-        dev->vram[addr + 7] = (val >> 28) & 0x0f;
+        svga->vram[addr] = val & 0x0f;
+        svga->vram[addr + 1] = (val >> 4) & 0x0f;
+        svga->vram[addr + 4] = (val >> 8) & 0x0f;
+        svga->vram[addr + 5] = (val >> 12) & 0x0f;
+        svga->vram[addr + 2] = (val >> 16) & 0x0f;
+        svga->vram[addr + 3] = (val >> 20) & 0x0f;
+        svga->vram[addr + 6] = (val >> 24) & 0x0f;
+        svga->vram[addr + 7] = (val >> 28) & 0x0f;
     } else
-        *(uint32_t *) &dev->vram[addr] = val;
+        *(uint32_t *) &svga->vram[addr] = val;
 }
 
 static __inline uint8_t
@@ -6366,27 +6746,27 @@ mach32_read_common(uint32_t addr, int linear, mach_t *mach, svga_t *svga)
         if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00))
             addr <<= 1;
 
-        addr &= dev->vram_mask;
+        addr &= svga->vram_mask;
         if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
             switch ((addr & 0x06) >> 1) {
                 case 0x00:
                 case 0x03:
-                    ret = dev->vram[addr] & 0x0f;
-                    ret |= (dev->vram[addr + 1] << 4);
+                    ret = svga->vram[addr] & 0x0f;
+                    ret |= (svga->vram[addr + 1] << 4);
                     break;
                 case 0x01:
-                    ret = dev->vram[addr + 2] & 0x0f;
-                    ret |= (dev->vram[addr + 3] << 4);
+                    ret = svga->vram[addr + 2] & 0x0f;
+                    ret |= (svga->vram[addr + 3] << 4);
                     break;
                 case 0x02:
-                    ret = dev->vram[addr - 2] & 0x0f;
-                    ret |= (dev->vram[addr - 1] << 4);
+                    ret = svga->vram[addr - 2] & 0x0f;
+                    ret |= (svga->vram[addr - 1] << 4);
                     break;
                 default:
                     break;
             }
         } else
-            ret = dev->vram[addr];
+            ret = svga->vram[addr];
 
         return ret;
     }
@@ -6402,26 +6782,26 @@ mach32_read_common(uint32_t addr, int linear, mach_t *mach, svga_t *svga)
             mach_log(mach->log,"ReadOver! (chain4) %x.\n", addr);
             return 0xff;
         }
-        latch_addr = (addr & dev->vram_mask) & ~3;
+        latch_addr = (addr & svga->vram_mask) & ~3;
         for (uint8_t i = 0; i < count; i++)
-            dev->latch.b[i] = dev->vram[latch_addr | i];
-        return dev->vram[addr & dev->vram_mask];
+            dev->latch.b[i] = svga->vram[latch_addr | i];
+        return svga->vram[addr & svga->vram_mask];
     } else if (svga->chain2_read) {
         readplane = (readplane & 2) | (addr & 1);
         addr &= ~1;
-        addr &= dev->vram_mask;
+        addr &= svga->vram_mask;
     } else {
         addr &= svga->decode_mask;
         if (addr >= dev->vram_size) {
             mach_log(mach->log,"ReadOver! (normal) %x.\n", addr);
             return 0xff;
         }
-        latch_addr = (addr & dev->vram_mask) & ~3;
+        latch_addr = (addr & svga->vram_mask) & ~3;
         for (uint8_t i = 0; i < count; i++)
-            dev->latch.b[i] = dev->vram[latch_addr | i];
+            dev->latch.b[i] = svga->vram[latch_addr | i];
 
-        mach_log(mach->log,"Read (normal) addr=%06x, ret=%02x.\n", addr, dev->vram[addr & dev->vram_mask]);
-        return dev->vram[addr & dev->vram_mask];
+        mach_log(mach->log,"Read (normal) addr=%06x, ret=%02x.\n", addr, svga->vram[addr & svga->vram_mask]);
+        return svga->vram[addr & svga->vram_mask];
     }
 
     addr &= svga->decode_mask;
@@ -6432,10 +6812,10 @@ mach32_read_common(uint32_t addr, int linear, mach_t *mach, svga_t *svga)
         for (uint8_t i = 0; i < count; i++)
             dev->latch.b[i] = 0xff;
     } else {
-        latch_addr &= dev->vram_mask;
+        latch_addr &= svga->vram_mask;
 
         for (uint8_t i = 0; i < count; i++)
-            dev->latch.b[i] = dev->vram[latch_addr | i];
+            dev->latch.b[i] = svga->vram[latch_addr | i];
     }
 
     if (addr >= dev->vram_size) {
@@ -6443,7 +6823,7 @@ mach32_read_common(uint32_t addr, int linear, mach_t *mach, svga_t *svga)
         return 0xff;
     }
 
-    addr &= dev->vram_mask;
+    addr &= svga->vram_mask;
 
     if (svga->readmode) {
         temp = 0xff;
@@ -6460,7 +6840,7 @@ mach32_read_common(uint32_t addr, int linear, mach_t *mach, svga_t *svga)
 
         ret = temp;
     } else
-        ret = dev->vram[addr | readplane];
+        ret = svga->vram[addr | readplane];
 
     mach_log(mach->log,"ReadMode=%02x, addr=%06x, ret=%02x.\n", svga->readmode, addr, ret);
     return ret;
@@ -6576,20 +6956,20 @@ mach32_readw_linear(uint32_t addr, mach_t *mach)
     cycles -= svga->monitor->mon_video_timing_read_w;
     if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
         addr <<= 1;
-        addr &= dev->vram_mask;
+        addr &= svga->vram_mask;
         if (addr & 0x04) {
-            ret = dev->vram[addr - 2] & 0x0f;
-            ret |= (dev->vram[addr - 1] << 4);
-            ret |= (dev->vram[addr + 2] << 8);
-            ret |= (dev->vram[addr + 3] << 12);
+            ret = svga->vram[addr - 2] & 0x0f;
+            ret |= (svga->vram[addr - 1] << 4);
+            ret |= (svga->vram[addr + 2] << 8);
+            ret |= (svga->vram[addr + 3] << 12);
         } else {
-            ret = dev->vram[addr] & 0x0f;
-            ret |= (dev->vram[addr + 1] << 4);
-            ret |= (dev->vram[addr + 4] << 8);
-            ret |= (dev->vram[addr + 5] << 12);
+            ret = svga->vram[addr] & 0x0f;
+            ret |= (svga->vram[addr + 1] << 4);
+            ret |= (svga->vram[addr + 4] << 8);
+            ret |= (svga->vram[addr + 5] << 12);
         }
     } else
-        ret = *(uint16_t *) &dev->vram[addr & dev->vram_mask];
+        ret = *(uint16_t *) &svga->vram[addr & svga->vram_mask];
 
     return ret;
 }
@@ -6604,17 +6984,17 @@ mach32_readl_linear(uint32_t addr, mach_t *mach)
     cycles -= svga->monitor->mon_video_timing_read_l;
     if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00)) {
         addr <<= 1;
-        addr &= dev->vram_mask;
-        ret = dev->vram[addr] & 0x0f;
-        ret |= (dev->vram[addr + 1] << 4);
-        ret |= (dev->vram[addr + 4] << 8);
-        ret |= (dev->vram[addr + 5] << 12);
-        ret |= (dev->vram[addr + 2] << 16);
-        ret |= (dev->vram[addr + 3] << 20);
-        ret |= (dev->vram[addr + 6] << 24);
-        ret |= (dev->vram[addr + 7] << 28);
+        addr &= svga->vram_mask;
+        ret = svga->vram[addr] & 0x0f;
+        ret |= (svga->vram[addr + 1] << 4);
+        ret |= (svga->vram[addr + 4] << 8);
+        ret |= (svga->vram[addr + 5] << 12);
+        ret |= (svga->vram[addr + 2] << 16);
+        ret |= (svga->vram[addr + 3] << 20);
+        ret |= (svga->vram[addr + 6] << 24);
+        ret |= (svga->vram[addr + 7] << 28);
     } else
-        ret = *(uint32_t *) &dev->vram[addr & dev->vram_mask];
+        ret = *(uint32_t *) &svga->vram[addr & svga->vram_mask];
 
     return ret;
 }
@@ -6898,7 +7278,7 @@ mach32_hwcursor_draw(svga_t *svga, int displine)
     int           y_pos;
     int           shift = 0;
 
-    offset = dev->hwcursor_latch.x - dev->hwcursor_latch.xoff;
+    offset = svga->hwcursor_latch.x - svga->hwcursor_latch.xoff;
     if (!dev->vram_512k_8514 && ((mach->accel.ext_ge_config & 0x30) == 0x00))
         shift = 1;
 
@@ -6908,7 +7288,7 @@ mach32_hwcursor_draw(svga_t *svga, int displine)
         case 8:
             color0 = dev->pallook[mach->cursor_col_0];
             color1 = dev->pallook[mach->cursor_col_1];
-            mach_log(mach->log,"4/8BPP: Color0=%08x, Color1=%08x, interlace=%x, oddeven=%d.\n", color0, color1, dev->interlace, dev->hwcursor_oddeven);
+            mach_log(mach->log,"4/8BPP: Color0=%08x, Color1=%08x, interlace=%x, oddeven=%d.\n", color0, color1, svga->interlace, svga->hwcursor_oddeven);
             break;
         case 15:
             color0 = video_15to32[((mach->ext_cur_col_0_r << 16) | (mach->ext_cur_col_0_g << 8) | mach->cursor_col_0) & 0xffff];
@@ -6926,19 +7306,19 @@ mach32_hwcursor_draw(svga_t *svga, int displine)
             break;
     }
 
-    if (dev->interlace && dev->hwcursor_oddeven)
-        dev->hwcursor_latch.addr += (16 >> shift);
+    if (svga->interlace && svga->hwcursor_oddeven)
+        svga->hwcursor_latch.addr += (16 >> shift);
 
     for (int x = 0; x < 64; x += (8 >> shift)) {
         if (shift) {
-            dat = dev->vram[(dev->hwcursor_latch.addr) & dev->vram_mask] & 0x0f;
-            dat |= (dev->vram[(dev->hwcursor_latch.addr + 1) & dev->vram_mask] << 4);
-            dat |= (dev->vram[(dev->hwcursor_latch.addr + 2) & dev->vram_mask] << 8);
-            dat |= (dev->vram[(dev->hwcursor_latch.addr + 3) & dev->vram_mask] << 12);
+            dat = svga->vram[(svga->hwcursor_latch.addr) & svga->vram_mask] & 0x0f;
+            dat |= (svga->vram[(svga->hwcursor_latch.addr + 1) & svga->vram_mask] << 4);
+            dat |= (svga->vram[(svga->hwcursor_latch.addr + 2) & svga->vram_mask] << 8);
+            dat |= (svga->vram[(svga->hwcursor_latch.addr + 3) & svga->vram_mask] << 12);
             mach_log(mach->log,"4bpp Data=%04x.\n", dat);
         } else {
-            dat = dev->vram[dev->hwcursor_latch.addr & dev->vram_mask];
-            dat |= (dev->vram[(dev->hwcursor_latch.addr + 1) & dev->vram_mask] << 8);
+            dat = svga->vram[svga->hwcursor_latch.addr & svga->vram_mask];
+            dat |= (svga->vram[(svga->hwcursor_latch.addr + 1) & svga->vram_mask] << 8);
             mach_log(mach->log,"8bppplus Data=%04x.\n", dat);
         }
         for (int xx = 0; xx < (8 >> shift); xx++) {
@@ -6948,7 +7328,7 @@ mach32_hwcursor_draw(svga_t *svga, int displine)
             x_pos = offset + svga->x_add;
             p     = buffer32->line[y_pos];
 
-            if (offset >= dev->hwcursor_latch.x) {
+            if (offset >= svga->hwcursor_latch.x) {
                 mach_log(mach->log,"COMB=%d.\n", comb);
                 switch (comb) {
                     case 0:
@@ -6967,11 +7347,11 @@ mach32_hwcursor_draw(svga_t *svga, int displine)
             }
             offset++;
         }
-        dev->hwcursor_latch.addr += 2;
+        svga->hwcursor_latch.addr += 2;
     }
 
-    if (dev->interlace && !dev->hwcursor_oddeven)
-        dev->hwcursor_latch.addr += (16 >> shift);
+    if (svga->interlace && !svga->hwcursor_oddeven)
+        svga->hwcursor_latch.addr += (16 >> shift);
 }
 
 static void
@@ -7637,7 +8017,6 @@ mach_reset(void *priv)
     if (reset_state != NULL) {
         dev->on = 0;
         dev->vendor_mode = 0;
-        dev->ext_mode_inc = 0;
         mach_disable_handlers(mach);
         mach->force_busy      = 0;
         dev->force_busy       = 0;
@@ -7752,15 +8131,12 @@ mach8_init(const device_t *info)
     if (ATI_MACH32) {
         mach->log = log_open("ATI Mach32");
         svga_init(info, svga, mach, dev->vram_amount << 10, /*default: 2MB for Mach32*/
-                      mach_recalctimings,
+                      mach32_recalctimings,
                       mach_in, mach_out,
                       mach32_hwcursor_draw,
                       NULL);
         dev->vram_size   = dev->vram_amount << 10;
-        dev->vram        = calloc(dev->vram_size, 1);
-        dev->changedvram = calloc((dev->vram_size >> 12) + 1, 1);
-        dev->vram_mask   = dev->vram_size - 1;
-        dev->hwcursor.cur_ysize = 64;
+        svga->hwcursor.cur_ysize = 64;
         mach->config1 = 0x20;
         if (mach->pci_bus && (mach->ramdac_type == ATI_68860))
             svga->ramdac = device_add(&ati68860_ramdac_device);
@@ -7803,7 +8179,7 @@ mach8_init(const device_t *info)
     } else {
         mach->log = log_open("ATI Mach8 (Graphics Ultra)");
         svga_init(info, svga, mach, (512 << 10), /*default: 512kB VGA for 28800-6 + 1MB for Mach8*/
-                      mach_recalctimings,
+                      mach8_recalctimings,
                       mach_in, mach_out,
                       NULL,
                       NULL);
@@ -7812,17 +8188,25 @@ mach8_init(const device_t *info)
         dev->changedvram = calloc((dev->vram_size >> 12) + 1, 1);
         dev->vram_mask   = dev->vram_size - 1;
         video_inform(VIDEO_FLAG_TYPE_8514, &timing_gfxultra_isa);
-        mach->config1 = 0x01 | 0x08;
+        mach->bus_width_8bit = device_get_config_int("bus_width");
+        mach->config1 = 0x01 | 0x08 | 0x80;
         if (dev->vram_amount >= 1024)
             mach->config1 |= 0x20;
 
-        mach->config2 = 0x02;
+        mach->config2 = 0x02 | 0x08 | 0x10;
         svga->clock_gen = device_add(&ati18811_1_mach32_device);
+        if (mach->bus_width_8bit == 16) {
+            mach->config1 |= 0x02;
+            mach->bios_rom.rom[0x791e]++;
+            mach->bios_rom.rom[0x7fff]--;
+        }
     }
-    dev->bpp            = 0;
-    svga->getclock      = ics2494_getclock;
-    svga->clock_gen8514 = svga->clock_gen;
-    svga->getclock8514  = svga->getclock;
+    dev->bpp = 0;
+    svga->getclock = ics2494_getclock;
+    if (!ATI_MACH32) {
+        svga->clock_gen8514 = svga->clock_gen;
+        svga->getclock8514  = svga->getclock;
+    }
 
     dev->on = 0;
     dev->pitch = 1024;
@@ -7842,6 +8226,7 @@ mach8_init(const device_t *info)
     dev->accel.cmd_back = 1;
     dev->mode = IBM_MODE;
     mach->accel.src_y_dir = 0x01;
+    svga->vga_enabled = 0;
 
     if (ATI_MACH32) {
         svga->decode_mask     = (4 << 20) - 1;
@@ -7907,7 +8292,7 @@ ati8514_init(svga_t *svga, void *ext8514, void *dev8514)
     mach->accel.cmd_type = -2;
     mach->mca_bus = !!(dev->type & DEVICE_MCA);
 
-    mach->config1 = 0x08;
+    mach->config1 = 0x02 | 0x08;
 
     if (mach->mca_bus)
         mach->config1 |= 0x04;
@@ -8012,6 +8397,34 @@ static const device_config_t mach8_config[] = {
             { .description = "512 KB", .value =  512 },
             { .description = "1 MB",   .value = 1024 },
             { .description = ""                      }
+        },
+        .bios           = { { 0 } }
+    },
+    /* 2026-07-26: JU1 and JU3, per the real card's documented jumper block
+       (https://www.dosdays.co.uk/topics/Manufacturers/ati/ati_mach8.php, user-supplied
+       reference) - neither was modeled at all before this. JU1 ("bottom two pins closed =
+       16-bit coprocessor bus I/O, top two pins closed = 8-bit coprocessor bus I/O") is
+       required set to 8-bit for a real 5160 XT's 8-bit-only slots; the user has reported
+       directly, more than once, that leaving a real card in 16-bit mode on this class of
+       machine causes a real Sound Blaster conflict, resolved once set correctly. JU3 is a
+       separate IRQ enable/disable jumper for the 8514-compatible drawing engine's
+       "command complete" interrupt - `mach_t` already carries `int_line`/`irq_state` fields
+       used by the MCA/PCI variants, but the plain ISA `mach8_vga_isa_device` never wires up
+       or raises this IRQ line at all, matching JU3-off (irq disabled) as the safe default -
+       still added here for documentation/fidelity completeness and as a real hook for a
+       future IRQ implementation, defaulting to the user's real card's actual setting. */
+    {
+        .name           = "bus_width",
+        .description    = "Coprocessor bus I/O width (JU1)",
+        .type           = CONFIG_SELECTION,
+        .default_string = NULL,
+        .default_int    = 8,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .selection      = {
+            { .description = "8-bit (top pins closed - required for XT-class 8-bit slots)",     .value =  8 },
+            { .description = "16-bit (bottom pins closed - AT-class 16-bit slots only)",        .value = 16 },
+            { .description = ""                                                                             }
         },
         .bios           = { { 0 } }
     },

--- a/src/video/vid_svga.c
+++ b/src/video/vid_svga.c
@@ -242,6 +242,7 @@ svga_out(uint16_t addr, uint8_t val, void *priv)
                 o                                   = svga->attrregs[svga->attraddr & 0x1f];
                 if (((svga->attraddr & 0x1f) > 0x14) && !(svga->adv_flags & FLAG_EXT_AR))
                     val = o;
+
                 svga->attrregs[svga->attraddr & 0x1f] = val;
                 if (svga->attraddr < 0x10)
                     svga->fullchange = svga->monitor->mon_changeframecount;
@@ -1124,8 +1125,12 @@ svga_recalctimings(svga_t *svga)
 
     crtcconst = svga->clock * (double) svga->char_width;
     if (ibm8514_active && (svga->dev8514 != NULL)) {
-        if (dev->on)
-            crtcconst8514 = svga->clock_8514 * 8;
+        if (dev->on) {
+            if (!ATI_MACH32)
+                crtcconst8514 = svga->clock_8514 * 8;
+            else
+                crtcconst = svga->clock * 8;
+        }
     }
     if (xga_active && (svga->xga != NULL)) {
         if (xga->on)
@@ -1171,8 +1176,10 @@ svga_recalctimings(svga_t *svga)
 
     if (ibm8514_active && (svga->dev8514 != NULL)) {
         if (dev->on) {
-            disptime8514 = (double) (uint32_t) dev->h_total;
-            _dispontime8514 = (double) (uint32_t) dev->h_disp_time;
+            if (!ATI_MACH32) {
+                disptime8514 = (double) (uint32_t) dev->h_total;
+                _dispontime8514 = (double) (uint32_t) dev->h_disp_time;
+            }
         }
     }
 
@@ -1186,6 +1193,15 @@ svga_recalctimings(svga_t *svga)
     if (svga->seqregs[1] & 8) {
         disptime *= 2.0;
         _dispontime *= 2.0;
+
+        if (ibm8514_active && (svga->dev8514 != NULL)) {
+            if (dev->on) {
+                if (ATI_MACH32) {
+                    disptime /= 2.0;
+                    _dispontime /= 2.0;
+                }
+            }
+        }
     }
 
     _dispofftime = disptime - _dispontime;
@@ -1213,18 +1229,19 @@ svga_recalctimings(svga_t *svga)
 
         case 1: /*Plus 8514/A*/
             if (dev->on) {
-                _dispofftime8514 = disptime8514 - _dispontime8514;
-                svga_log("DISPTIME8514=%lf, off=%lf, DISPONTIME8514=%lf, CRTCCONST8514=%lf.\n", disptime8514, _dispofftime8514, _dispontime8514, crtcconst8514);
-                _dispontime8514 *= crtcconst8514;
-                _dispofftime8514 *= crtcconst8514;
+                if (!ATI_MACH32) {
+                    _dispofftime8514 = disptime8514 - _dispontime8514;
+                    svga_log("DISPTIME8514=%lf, off=%lf, DISPONTIME8514=%lf, CRTCCONST8514=%lf.\n", disptime8514, _dispofftime8514, _dispontime8514, crtcconst8514);
+                    _dispontime8514 *= crtcconst8514;
+                    _dispofftime8514 *= crtcconst8514;
 
-                dev->dispontime  = (uint64_t) (int64_t) round(_dispontime8514);
-                dev->dispofftime = (uint64_t) (int64_t) round(_dispofftime8514);
-                if (dev->dispontime < TIMER_USEC)
-                    dev->dispontime = TIMER_USEC;
-                if (dev->dispofftime < TIMER_USEC)
-                    dev->dispofftime = TIMER_USEC;
-
+                    dev->dispontime  = (uint64_t) (int64_t) round(_dispontime8514);
+                    dev->dispofftime = (uint64_t) (int64_t) round(_dispofftime8514);
+                    if (dev->dispontime < TIMER_USEC)
+                        dev->dispontime = TIMER_USEC;
+                    if (dev->dispofftime < TIMER_USEC)
+                        dev->dispofftime = TIMER_USEC;
+                }
                 ibm8514_set_poll(svga);
             } else
                 svga_set_poll(svga);
@@ -1250,17 +1267,20 @@ svga_recalctimings(svga_t *svga)
 
         case 3: /*Plus 8514/A and XGA*/
             if (dev->on) {
-                _dispofftime8514 = disptime8514 - _dispontime8514;
-                _dispontime8514 *= crtcconst8514;
-                _dispofftime8514 *= crtcconst8514;
+                if (!ATI_MACH32) {
+                    _dispofftime8514 = disptime8514 - _dispontime8514;
+                    _dispontime8514 *= crtcconst8514;
+                    _dispofftime8514 *= crtcconst8514;
 
-                dev->dispontime  = (uint64_t) (int64_t) round(_dispontime8514);
-                dev->dispofftime = (uint64_t) (int64_t) round(_dispofftime8514);
-                if (dev->dispontime < TIMER_USEC)
-                    dev->dispontime = TIMER_USEC;
-                if (dev->dispofftime < TIMER_USEC)
-                    dev->dispofftime = TIMER_USEC;
+                    dev->dispontime  = (uint64_t) (int64_t) round(_dispontime8514);
+                    dev->dispofftime = (uint64_t) (int64_t) round(_dispofftime8514);
+                    if (dev->dispontime < TIMER_USEC)
+                        dev->dispontime = TIMER_USEC;
+                    if (dev->dispofftime < TIMER_USEC)
+                        dev->dispofftime = TIMER_USEC;
 
+
+                }
                 ibm8514_set_poll(svga);
             } else if (xga->on) {
                 _dispofftime_xga = disptime_xga - _dispontime_xga;
@@ -1332,7 +1352,7 @@ svga_recalctimings(svga_t *svga)
                 svga->monitor->mon_interlace = !!svga->interlace;
                 break;
             case 1: /*Plus 8514/A*/
-                if (dev->on)
+                if (dev->on && !ATI_MACH32)
                     svga->monitor->mon_interlace = !!dev->interlace;
                 else
                     svga->monitor->mon_interlace = !!svga->interlace;
@@ -1344,7 +1364,7 @@ svga_recalctimings(svga_t *svga)
                     svga->monitor->mon_interlace = !!svga->interlace;
                 break;
             case 3: /*Plus 8514/A and XGA*/
-                if (dev->on)
+                if (dev->on && !ATI_MACH32)
                     svga->monitor->mon_interlace = !!dev->interlace;
                 else if (xga->on)
                     svga->monitor->mon_interlace = !!xga->interlace;
@@ -1483,17 +1503,8 @@ svga_poll(void *priv)
             if (svga->lastline < svga->displine)
                 svga->lastline = svga->displine;
         }
-#if 0
-        {
-            /* TODO: Revisit this after fixing HSync problems. */
 
-            uint32_t hsyncstart = svga->crtc[4] + ((svga->crtc[5] >> 5) & 3);
-            uint32_t hsyncend = hsyncstart + (svga->crtc[5] & 0x1f) + 1;
-            video_lightpen_check_trigger_strobe(svga->x_add, svga->displine, (svga->htotal - hsyncend) * svga->char_width, svga->firstline, 1. / (svga->clock / (cpuclock * (double) (1ULL << 32))), svga->monitor_index);
-        }
-#endif
         video_lightpen_check_trigger_strobe(svga->x_add, svga->displine, 0, svga->firstline, 1. / (svga->clock / (cpuclock * (double) (1ULL << 32))), svga->monitor_index);
-
         svga->displine++;
         if (svga->interlace)
             svga->displine++;

--- a/src/video/vid_vga.c
+++ b/src/video/vid_vga.c
@@ -27,6 +27,8 @@
 #include <86box/machine.h>
 #include <86box/timer.h>
 #include <86box/video.h>
+#include <86box/vid_8514a.h>
+#include <86box/vid_xga.h>
 #include <86box/vid_svga.h>
 #include <86box/vid_vga.h>
 #include "cpu.h"
@@ -36,8 +38,8 @@ video_timings_t        timing_vga = { .type = VIDEO_ISA, .write_b = 8, .write_w 
 static video_timings_t timing_ps1_svga_isa = { .type = VIDEO_ISA, .write_b = 6, .write_w = 8, .write_l = 16, .read_b = 6, .read_w = 8, .read_l = 16 };
 static video_timings_t timing_ps1_svga_mca = { .type = VIDEO_MCA, .write_b = 6, .write_w = 8, .write_l = 16, .read_b = 6, .read_w = 8, .read_l = 16 };
 
-extern void    vga_disable(void *p);
-extern void    vga_enable(void *p);
+extern void    vga_disable(void *p, uint16_t port);
+extern void    vga_enable(void *p, uint16_t port);
 
 void
 vga_out(uint16_t addr, uint8_t val, void *priv)
@@ -56,10 +58,10 @@ vga_out(uint16_t addr, uint8_t val, void *priv)
             vga->port_102 = val;
 
             if ((old ^ val) & 0x01) {
-                vga_disable(priv);
+                vga_disable(priv, addr);
 
                 if ((val & 0x01) && (vga->ctl & 0x0008))
-                    vga_enable(priv);
+                    vga_enable(priv, addr);
             }
             return;
         case 0x3D4:
@@ -102,10 +104,10 @@ vga_outw(uint16_t addr, uint16_t val, void *priv)
     vga->ctl = val;
 
     if ((old ^ val) & 0x0008) {
-        vga_disable(priv);
+        vga_disable(priv, addr);
 
         if ((vga->port_102 & 0x01) && (val & 0x0008))
-            vga_enable(priv);
+            vga_enable(priv, addr);
     }
 }
 
@@ -150,21 +152,36 @@ vga_inw(uint16_t addr, void *priv)
 }
 
 void
-vga_disable(void *p)
+vga_disable(void *p, uint16_t port)
 {
     vga_t * vga  = (vga_t *) p;
     svga_t *svga = &vga->svga;
+    ibm8514_t *dev = (ibm8514_t *) svga->dev8514;
+    xga_t   *xga = (xga_t *) svga->xga;
 
     io_removehandler(0x03a0, 0x0040, vga_in, NULL, NULL, vga_out, NULL, NULL, vga);
     mem_mapping_disable(&svga->mapping);
     svga->vga_enabled = 0;
+    if (port == 0x03c3) {
+        if (ibm8514_active) {
+            if (dev != NULL)
+                dev->on = 1;
+        }
+        if (xga_active) {
+            if (xga != NULL)
+                xga->on = 1;
+        }
+        svga_recalctimings(svga);
+    }
 }
 
 void
-vga_enable(void *p)
+vga_enable(void *p, uint16_t port)
 {
     vga_t * vga  = (vga_t *) p;
     svga_t *svga = &vga->svga;
+    ibm8514_t *dev = (ibm8514_t *) svga->dev8514;
+    xga_t   *xga = (xga_t *) svga->xga;
 
     io_sethandler(0x03c0, 0x0020, vga_in, NULL, NULL, vga_out, NULL, NULL, vga);
     if (!(svga->miscout & 1))
@@ -172,6 +189,17 @@ vga_enable(void *p)
 
     mem_mapping_enable(&svga->mapping);
     svga->vga_enabled = 1;
+    if (port == 0x03c3) {
+        if (ibm8514_active) {
+            if (dev != NULL)
+                dev->on = 0;
+        }
+        if (xga_active) {
+            if (xga != NULL)
+                xga->on = 0;
+        }
+        svga_recalctimings(svga);
+    }
 }
 
 int vga_isenabled(void* p)
@@ -215,7 +243,7 @@ vga_standalone_init(const device_t *info)
         io_sethandler(0x0102, 0x0001, vga_in, NULL, NULL, vga_out, NULL, NULL, vga);
         io_sethandler(0x46e8, 0x0001, NULL, vga_inw, NULL, NULL, vga_outw, NULL, vga);
 
-        vga_disable(vga);
+        vga_disable(vga, 0x0102);
     }
 
     return vga;


### PR DESCRIPTION
Summary
=======
1. This fixes out of bounds refresh rates and the enables the 8514/A (or XGA) rendering when prompted to (MCA too).
2. Made the ATI Mach32 use the integrated VGA core for the accelerator as the chip itself shares the memory between the VGA and coprocessor.
3. Fixed a small issue with the 8514/A accelerator when using Chess under OS/2 Warp 3 (when not all pixels were processed).
4. Backported the Mach8 stuff from the inboard fork and improvements upon it with a new Mach8 Graphics Ultra ROM from said fork.
5. Now 16-bit ATI 8514/A add-on is available.

Checklist
=========
* [X] Closes #7722
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [X] This pull request requires changes to the ROM set
  * [X] I have opened a roms pull request - https://github.com/86Box/roms/pull/521/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
