### PR TITLE
Actually fix the IBM Multistation 5550 keyboard after warm reset

### DIFF
--- a/src/machine/m_xt_ibm5550.c
+++ b/src/machine/m_xt_ibm5550.c
@@ -1700,6 +1700,17 @@ kbd_write(uint16_t port, uint8_t val, void *priv)
         case 0x61: /* Keyboard Control Register (aka Port B) */
             kbd->pb = val;
 
+            if (val == 0x00) {
+                /* The IPL writes 0x00 to port B at the start of the keyboard
+                   test to disable the keyboard. Discard any leftover keydata
+                   (e.g. the tail of a Ctrl+Alt+Del scancode that the ROM did 
+                   not consume before reset) so the clock-poll that follows 
+                   sees an idle line. */
+                key_queue_start        = key_queue_end = 0;
+                kbd->kbd_readdata_step = 16;
+                kbd->want_irq          = 0;
+            }
+
             if ((val & 0x18) == 0x08) {
                 new_clock = !(val & 0x04);
                 /* Trigger kbd reset after the clk line is reset to a high level */


### PR DESCRIPTION
Summary
=======
This PR cleans up leftover data in keyboard buffer when pressing Ctrl-Alt-Delete in IBM Multistation 5550, which fixes A1D1 error completely after warm reboot.

Checklist
=========
* [x] Closes #7332
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
https://github.com/martinlindhe/dos-software-decoding/blob/master/ibm-pc/ibm5550/ipl5550.asm