### PR TITLE
sio_um8669f: Always use `intptr_t` for the cast

### DIFF
--- a/src/sio/sio_um8669f.c
+++ b/src/sio/sio_um8669f.c
@@ -225,11 +225,7 @@ um8669f_pnp_config_changed(uint8_t ld, isapnp_device_config_t *config, void *pri
 
             if (dev->ide < IDE_BUS_MAX) {
                 config->io[1].base = config->io[0].base + 0x206; /* status port apparently fixed */
-#if (defined __amd64__ || defined _M_X64 || defined __aarch64__ || defined _M_ARM64 || (defined(__riscv) && (__SIZEOF_POINTER__ == 8)) || defined(__loongarch_lp64))
-                ide_pnp_config_changed(0, config, (void *) (int64_t) dev->ide);
-#else
-                ide_pnp_config_changed(0, config, (void *) (int) dev->ide);
-#endif
+                ide_pnp_config_changed(0, config, (void *) (intptr_t) dev->ide);
             }
             break;
 


### PR DESCRIPTION
Summary
=======
sio_um8669f: Always use `intptr_t` for the cast.

This type is 64-bit on 64-bit architectures.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
