### PR TITLE
LP64-related cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,14 @@ project(86Box
     HOMEPAGE_URL "https://86box.net"
     LANGUAGES C CXX)
 
+if (NOT (CMAKE_SIZEOF_VOID_P STREQUAL "8"))
+    message(FATAL_ERROR "Only 64-bit builds are supported.")
+endif()
+
+if (CMAKE_C_BYTE_ORDER STREQUAL "BIG_ENDIAN")
+    message(FATAL_ERROR "Big-endian builds are not supported.")
+endif()
+
 include(CPack)
 include(CMakeDependentOption)
 include(FetchContent)

--- a/src/cpu/386_common.h
+++ b/src/cpu/386_common.h
@@ -539,11 +539,7 @@ fastreadl_fetch(uint32_t a)
             pccache2 = t;
             pccache  = a >> 12;
         }
-#    if (defined __amd64__ || defined _M_X64 || defined __aarch64__ || defined _M_ARM64 || (defined(__riscv) && (__SIZEOF_POINTER__ == 8)) || defined(__loongarch_lp64))
         return *((uint32_t *) (((uintptr_t) &pccache2[a] & 0x00000000ffffffffULL) | ((uintptr_t) &pccache2[0] & 0xffffffff00000000ULL)));
-#    else
-        return AS_U32(pccache2[a]);
-#    endif
     }
     val = fastreadw_fetch(a);
     if (opcode_length[val & 0xff] > 2)

--- a/src/include/shathree.h
+++ b/src/include/shathree.h
@@ -22,6 +22,8 @@
 #include <string.h>
 #include <stdarg.h>
 
+#define SHA3_BYTEORDER 1234
+
 /******************************************************************************
 ** The Hash Engine
 */


### PR DESCRIPTION
Summary
=======
LP64-related cleanups:

1. In `386_common.h`, remove the legacy 32-bit path.
2. `shathree.h` now always uses little-endian byte ordering.
3. Block builds for non-64-bit and big-endian architectures.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
