### PR TITLE
Add Freetech/Flexus 486F55 Machine

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -902,6 +902,7 @@ extern int             machine_at_ms4144_init(const machine_t *);
 extern int             machine_at_r418_init(const machine_t *);
 extern int             machine_at_4saw2_init(const machine_t *);
 extern int             machine_at_4dps_init(const machine_t *);
+extern int             machine_at_486f55_init(const machine_t *);
 
 /* UMC 8881 */
 extern int             machine_at_atc1415_init(const machine_t *);

--- a/src/machine/m_at_socket3_pci.c
+++ b/src/machine/m_at_socket3_pci.c
@@ -1005,6 +1005,31 @@ machine_at_acerp3_init(const machine_t *model)
 }
 
 int
+machine_at_486f55_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/486f55/55XS_G.BIN",
+                           0x000e0000, 131072, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_common_init(model);
+
+    machine_at_sis_85c496_common_init(model);
+    device_add(&sis_85c496_ls486e_device);
+
+    pci_register_slot(0x03, PCI_CARD_NORMAL, 1, 2, 3, 4);
+    pci_register_slot(0x0D, PCI_CARD_NORMAL, 2, 3, 4, 1);
+    pci_register_slot(0x0F, PCI_CARD_NORMAL, 3, 4, 1, 2);
+
+    device_add_params(&w837x7_device, (void *) (W83787F | W837X7_KEY_89));
+
+    return ret;
+}
+
+int
 machine_at_486sp3c_init(const machine_t *model)
 {
     int ret;

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -12449,6 +12449,54 @@ const machine_t machines[] = {
         .net_device               = NULL,
         .aliases                  = { "" }
     },
+    /* Freetech 486F55 */
+    {
+        .name              = "[SiS 496] Freetech 486F55",
+        .internal_name     = "486f55",
+        .type              = MACHINE_TYPE_SOCKET3_PCI,
+        .chipset           = MACHINE_CHIPSET_SIS_496,
+        .init              = machine_at_486f55_init,
+        .p1_handler        = machine_generic_p1_handler,
+        .gpio_handler      = NULL,
+        .available_flag    = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu               = {
+            .package     = CPU_PKG_SOCKET3,
+            .block       = CPU_BLOCK_NONE,
+            .min_bus     = 25000000,
+            .max_bus     = 40000000, /* boards own FSB list tops out at 40MHz */
+            .min_voltage = 3300,
+            .max_voltage = 5000,
+            .min_multi   = 0,
+            .max_multi   = 0
+        },
+        .bus_flags = MACHINE_PCI,
+        .flags     = MACHINE_SUPER_IO | MACHINE_IDE_DUAL | MACHINE_APM,
+        .ram       = {
+            .min  = 1024,
+            .max  = 261120,
+            .step = 1024
+        },
+        .nvrmask                  = 255,
+        .jumpered_ecp_dma         = MACHINE_DMA_DISABLED | MACHINE_DMA_1 | MACHINE_DMA_3,
+        .default_jumpered_ecp_dma = 3,
+        .kbc_device               = &kbc_at_device,
+        .kbc_params               = KBC_VEN_AMI | 0x00004800,
+        .nvr_device               = NULL,
+        .nvr_params               = 0x00000000,
+        .sio_device               = NULL,
+        .sio_params               = 0x00000000,
+        .kbc_p1                   = 0x000004f0,
+        .gpio                     = 0xffffffff,
+        .gpio_acpi                = 0xffffffff,
+        .device                   = NULL,
+        .kbd_device               = NULL,
+        .fdc_device               = NULL,
+        .vid_device               = NULL,
+        .snd_device               = NULL,
+        .net_device               = NULL,
+        .aliases                  = { "" }
+    },
     /* This has an AMIKey-2, which is type 'H'. */
     {
         .name              = "[SiS 496] ASUS PVI-486SP3",


### PR DESCRIPTION
Summary
=======
Add the Freetech/Flexus 486F55 Machine with Socket 3 socket and SiS 496 chipset!
Tested with MS-DOS 6.22, PCI video card (S3 Trio64) and ISA sound card (SB16)

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [X] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/526
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
https://theretroweb.com/motherboards/s/freetech-flexus-486f55
