### PR TITLE
Add 7 GB Ditto Max tapes support for the Ditto emulated drive

### DIFF
--- a/src/device/lpt_ditto.c
+++ b/src/device/lpt_ditto.c
@@ -262,6 +262,7 @@ static const ditto_model_t ditto_models[] = {
 #define DITTO_CAPACITY_2GB 2
 #define DITTO_CAPACITY_3GB 3
 #define DITTO_CAPACITY_5GB 5
+#define DITTO_CAPACITY_7GB 7
 
 #define DITTO_CART_QIC80_205  10
 #define DITTO_CART_QIC80_307  11
@@ -313,6 +314,7 @@ typedef struct ditto_cartridge_t {
     X("Ditto 2 GB",  DITTO_CAPACITY_2GB, 72,  502, DITTO_ST_DITTO, FT_FMT_VAR) \
     X("Ditto 3 GB",  DITTO_CAPACITY_3GB, 72,  753, DITTO_ST_DITTO, FT_FMT_VAR) \
     X("Ditto 5 GB",  DITTO_CAPACITY_5GB, 72, 1256, DITTO_ST_DITTO, FT_FMT_BIG) \
+    X("Ditto Max 7 GB",  DITTO_CAPACITY_7GB, 72, 1758, DITTO_ST_DITTO, FT_FMT_BIG) \
     /* Tier one. */                                                            \
     X("QIC-80, DC-2080 (205 ft)",   DITTO_CART_QIC80_205,  28, 100,            \
       QIC_TAPE_QIC80 | QIC_TAPE_205FT,         FT_FMT_NORMAL)                  \

--- a/src/video/vid_voodoo.c
+++ b/src/video/vid_voodoo.c
@@ -1649,6 +1649,7 @@ static const device_config_t voodoo_config[] = {
         .selection      = {
             { .description = "2 MB", .value = 2 },
             { .description = "4 MB", .value = 4 },
+            { .description = "8 MB", .value = 8 },
             { .description = ""                 }
         },
         .bios           = { { 0 } }

--- a/src/video/vid_voodoo.c
+++ b/src/video/vid_voodoo.c
@@ -1649,7 +1649,6 @@ static const device_config_t voodoo_config[] = {
         .selection      = {
             { .description = "2 MB", .value = 2 },
             { .description = "4 MB", .value = 4 },
-            { .description = "8 MB", .value = 8 },
             { .description = ""                 }
         },
         .bios           = { { 0 } }


### PR DESCRIPTION
Summary
=======
Add support for the 7GB Ditto Max cartridges (Tapes must be created using this program which I modified to add support for the Ditto Max 7GB https://github.com/NexGenDriven/ftape/blob/master/blanktapes/mkqictape.py)

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
