### PR TITLE
Add name migration for Plantronics Colorplus

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -244,6 +244,7 @@ device_set_context(device_context_t *ctx, const device_t *dev, int inst)
         { .old = "Cirrus Logic GD5426 (MCA) (Reply Video Adapter)", .new = "Cirrus Logic GD5426 (MCA)" },
         { .old = "3dfx Voodoo3 2000 (On-Board 8MB SGRAM)", .new = "3dfx Voodoo3 2000 (On-Board)" },
         { .old = "Gravis/Synergy Vipermax", .new = "Synergy ViperMAX" },
+        { .old = "Colorplus", .new = "Plantronics Colorplus" },
         { 0 }
     };
 


### PR DESCRIPTION
Summary
=======
This PR title says at all. This fixes the configuration error(?).

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
https://github.com/86Box/86Box/pull/7673
