### PR TITLE
x87: honor 24-bit precision control; fix FBLD a32 in the softfloat FPU

### DIFF
--- a/src/codegen/codegen_ops_x86-64.h
+++ b/src/codegen/codegen_ops_x86-64.h
@@ -4180,6 +4180,24 @@ FP_LOAD_REG_INT_Q(int reg, int *host_reg1, UNUSED(int *host_reg2))
 #define FPU_SUB  2
 #define FPU_SUBR 3
 
+/* x87 precision control = 24: round the double result in xmm_reg to
+   single and back. npxc is fixed for the block (CPU_STATUS_FPU_PC24 is in
+   the block key), so the test resolves at compile time. */
+static __inline void
+FP_ROUND_PC(int xmm_reg)
+{
+    if (cpu_state.npxc & 0x300)
+        return;
+    addbyte(0xf2); /*CVTSD2SS xmm_reg, xmm_reg*/
+    addbyte(0x0f);
+    addbyte(0x5a);
+    addbyte(0xc0 | (xmm_reg << 3) | xmm_reg);
+    addbyte(0xf3); /*CVTSS2SD xmm_reg, xmm_reg*/
+    addbyte(0x0f);
+    addbyte(0x5a);
+    addbyte(0xc0 | (xmm_reg << 3) | xmm_reg);
+}
+
 static __inline void
 FP_OP_REG(int op, int dst, int src)
 {
@@ -4274,6 +4292,7 @@ FP_OP_REG(int op, int dst, int src)
             addbyte((uint8_t) cpu_state_offset(ST));
             break;
     }
+    FP_ROUND_PC(0);
     addbyte(0x66); /*MOVQ [RSI+RAX*8], XMM0*/
     addbyte(0x0f);
     addbyte(0xd6);
@@ -4339,6 +4358,7 @@ FP_OP_MEM(int op)
             break;
     }
     if (op == FPU_DIVR || op == FPU_SUBR) {
+        FP_ROUND_PC(1);
         addbyte(0x66); /*MOVQ ST[RAX*8], XMM1*/
         addbyte(0x0f);
         addbyte(0xd6);
@@ -4346,6 +4366,7 @@ FP_OP_MEM(int op)
         addbyte(0xc5);
         addbyte((uint8_t) cpu_state_offset(ST));
     } else {
+        FP_ROUND_PC(0);
         addbyte(0x66); /*MOVQ ST[RAX*8], XMM0*/
         addbyte(0x0f);
         addbyte(0xd6);

--- a/src/codegen_new/codegen_backend_arm64_uops.c
+++ b/src/codegen_new/codegen_backend_arm64_uops.c
@@ -639,6 +639,22 @@ codegen_FSQRT(codeblock_t *block, uop_t *uop)
     return 0;
 }
 static int
+codegen_FROUND_S(codeblock_t *block, uop_t *uop)
+{
+    int dest_reg   = HOST_REG_GET(uop->dest_reg_a_real);
+    int src_reg_a  = HOST_REG_GET(uop->src_reg_a_real);
+    int dest_size  = IREG_GET_SIZE(uop->dest_reg_a_real);
+    int src_size_a = IREG_GET_SIZE(uop->src_reg_a_real);
+
+    if (REG_IS_D(dest_size) && REG_IS_D(src_size_a)) {
+        host_arm64_FCVT_S_D(block, REG_V_TEMP, src_reg_a);
+        host_arm64_FCVT_D_S(block, dest_reg, REG_V_TEMP);
+    } else
+        fatal("codegen_FROUND_S %02x %02x\n", uop->dest_reg_a_real, uop->src_reg_a_real);
+
+    return 0;
+}
+static int
 codegen_FTST(codeblock_t *block, uop_t *uop)
 {
     int dest_reg   = HOST_REG_GET(uop->dest_reg_a_real);
@@ -3382,6 +3398,9 @@ const uOpFn uop_handlers[UOP_MAX] = {
     [UOP_FSQRT &
         UOP_MASK]
     = codegen_FSQRT,
+    [UOP_FROUND_S &
+        UOP_MASK]
+    = codegen_FROUND_S,
     [UOP_FTST &
         UOP_MASK]
     = codegen_FTST,

--- a/src/codegen_new/codegen_backend_x86-64_uops.c
+++ b/src/codegen_new/codegen_backend_x86-64_uops.c
@@ -665,6 +665,24 @@ codegen_FSQRT(codeblock_t *block, uop_t *uop)
     return 0;
 }
 static int
+codegen_FROUND_S(codeblock_t *block, uop_t *uop)
+{
+    int dest_reg   = HOST_REG_GET(uop->dest_reg_a_real);
+    int src_reg_a  = HOST_REG_GET(uop->src_reg_a_real);
+    int dest_size  = IREG_GET_SIZE(uop->dest_reg_a_real);
+    int src_size_a = IREG_GET_SIZE(uop->src_reg_a_real);
+
+    if (REG_IS_D(dest_size) && REG_IS_D(src_size_a)) {
+        host_x86_CVTSD2SS_XREG_XREG(block, REG_XMM_TEMP, src_reg_a);
+        host_x86_CVTSS2SD_XREG_XREG(block, dest_reg, REG_XMM_TEMP);
+    }
+#    ifdef RECOMPILER_DEBUG
+    else
+        fatal("codegen_FROUND_S %02x %02x\n", uop->dest_reg_a_real, uop->src_reg_a_real);
+#    endif
+    return 0;
+}
+static int
 codegen_FTST(codeblock_t *block, uop_t *uop)
 {
     int dest_reg   = HOST_REG_GET(uop->dest_reg_a_real);
@@ -3149,6 +3167,9 @@ const uOpFn uop_handlers[UOP_MAX] = {
     [UOP_FSQRT &
         UOP_MASK]
     = codegen_FSQRT,
+    [UOP_FROUND_S &
+        UOP_MASK]
+    = codegen_FROUND_S,
     [UOP_FTST &
         UOP_MASK]
     = codegen_FTST,

--- a/src/codegen_new/codegen_ir_defs.h
+++ b/src/codegen_new/codegen_ir_defs.h
@@ -213,6 +213,8 @@
 #define UOP_FTST (UOP_TYPE_PARAMS_REGS | 0x88)
 /*UOP_FSQRT - dest_reg = fsqrt(src_reg_a)*/
 #define UOP_FSQRT (UOP_TYPE_PARAMS_REGS | 0x89)
+/*UOP_FROUND_S - dest_reg = (double)(float)src_reg_a (x87 precision control = 24)*/
+#define UOP_FROUND_S (UOP_TYPE_PARAMS_REGS | 0x8a)
 
 /*UOP_MMX_ENTER - must be called before any MMX registers accessed*/
 #define UOP_MMX_ENTER (UOP_TYPE_PARAMS_IMM | 0x90 | UOP_TYPE_BARRIER)
@@ -750,6 +752,7 @@ extern int codegen_fp_enter(void);
 #define uop_FABS(ir, dst_reg, src_reg)                           uop_gen_reg_dst_src1(UOP_FABS, ir, dst_reg, src_reg)
 #define uop_FCHS(ir, dst_reg, src_reg)                           uop_gen_reg_dst_src1(UOP_FCHS, ir, dst_reg, src_reg)
 #define uop_FSQRT(ir, dst_reg, src_reg)                          uop_gen_reg_dst_src1(UOP_FSQRT, ir, dst_reg, src_reg)
+#define uop_FROUND_S(ir, dst_reg, src_reg)                       uop_gen_reg_dst_src1(UOP_FROUND_S, ir, dst_reg, src_reg)
 #define uop_FTST(ir, dst_reg, src_reg)                           uop_gen_reg_dst_src1(UOP_FTST, ir, dst_reg, src_reg)
 
 #if defined __ARM_EABI__ || defined _ARM_ || defined _M_ARM || defined __aarch64__ || defined _M_ARM64

--- a/src/codegen_new/codegen_ops_fpu_arith.c
+++ b/src/codegen_new/codegen_ops_fpu_arith.c
@@ -18,6 +18,15 @@
 #include "codegen_ops_fpu_arith.h"
 #include "codegen_ops_helpers.h"
 
+/* Precision control 24-bit: the chip rounds every ADD/SUB/MUL/DIV/SQRT
+   result to single. npxc is fixed for the block (CPU_STATUS_FPU_PC24 is
+   part of the block key), so this resolves at compile time. */
+#define uop_FROUND_PC(ir, reg)                \
+    do {                                      \
+        if (!(cpu_state.npxc & 0x300))        \
+            uop_FROUND_S(ir, reg, reg);       \
+    } while (0)
+
 uint32_t
 ropFADD(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchdat, UNUSED(uint32_t op_32), uint32_t op_pc)
 {
@@ -25,6 +34,7 @@ ropFADD(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uint3
 
     uop_FP_ENTER(ir);
     uop_FADD(ir, IREG_ST(0), IREG_ST(0), IREG_ST(src_reg));
+    uop_FROUND_PC(ir, IREG_ST(0));
     uop_MOV_IMM(ir, IREG_tag(0), TAG_VALID);
 
     return op_pc;
@@ -36,6 +46,7 @@ ropFADDr(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uint
 
     uop_FP_ENTER(ir);
     uop_FADD(ir, IREG_ST(dest_reg), IREG_ST(dest_reg), IREG_ST(0));
+    uop_FROUND_PC(ir, IREG_ST(dest_reg));
     uop_MOV_IMM(ir, IREG_tag(dest_reg), TAG_VALID);
 
     return op_pc;
@@ -47,6 +58,7 @@ ropFADDP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fet
 
     uop_FP_ENTER(ir);
     uop_FADD(ir, IREG_ST(dest_reg), IREG_ST(dest_reg), IREG_ST(0));
+    uop_FROUND_PC(ir, IREG_ST(dest_reg));
     uop_MOV_IMM(ir, IREG_tag(dest_reg), TAG_VALID);
     fpu_POP(block, ir);
 
@@ -97,6 +109,7 @@ ropFDIV(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uint3
 
     uop_FP_ENTER(ir);
     uop_FDIV(ir, IREG_ST(0), IREG_ST(0), IREG_ST(src_reg));
+    uop_FROUND_PC(ir, IREG_ST(0));
     uop_MOV_IMM(ir, IREG_tag(0), TAG_VALID);
 
     return op_pc;
@@ -108,6 +121,7 @@ ropFDIVR(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uint
 
     uop_FP_ENTER(ir);
     uop_FDIV(ir, IREG_ST(0), IREG_ST(src_reg), IREG_ST(0));
+    uop_FROUND_PC(ir, IREG_ST(0));
     uop_MOV_IMM(ir, IREG_tag(0), TAG_VALID);
 
     return op_pc;
@@ -119,6 +133,7 @@ ropFDIVr(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uint
 
     uop_FP_ENTER(ir);
     uop_FDIV(ir, IREG_ST(dest_reg), IREG_ST(dest_reg), IREG_ST(0));
+    uop_FROUND_PC(ir, IREG_ST(dest_reg));
     uop_MOV_IMM(ir, IREG_tag(dest_reg), TAG_VALID);
 
     return op_pc;
@@ -130,6 +145,7 @@ ropFDIVRr(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uin
 
     uop_FP_ENTER(ir);
     uop_FDIV(ir, IREG_ST(dest_reg), IREG_ST(0), IREG_ST(dest_reg));
+    uop_FROUND_PC(ir, IREG_ST(dest_reg));
     uop_MOV_IMM(ir, IREG_tag(dest_reg), TAG_VALID);
 
     return op_pc;
@@ -141,6 +157,7 @@ ropFDIVP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fet
 
     uop_FP_ENTER(ir);
     uop_FDIV(ir, IREG_ST(dest_reg), IREG_ST(dest_reg), IREG_ST(0));
+    uop_FROUND_PC(ir, IREG_ST(dest_reg));
     uop_MOV_IMM(ir, IREG_tag(dest_reg), TAG_VALID);
     fpu_POP(block, ir);
 
@@ -153,6 +170,7 @@ ropFDIVRP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fe
 
     uop_FP_ENTER(ir);
     uop_FDIV(ir, IREG_ST(dest_reg), IREG_ST(0), IREG_ST(dest_reg));
+    uop_FROUND_PC(ir, IREG_ST(dest_reg));
     uop_MOV_IMM(ir, IREG_tag(dest_reg), TAG_VALID);
     fpu_POP(block, ir);
 
@@ -166,6 +184,7 @@ ropFMUL(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uint3
 
     uop_FP_ENTER(ir);
     uop_FMUL(ir, IREG_ST(0), IREG_ST(0), IREG_ST(src_reg));
+    uop_FROUND_PC(ir, IREG_ST(0));
     uop_MOV_IMM(ir, IREG_tag(0), TAG_VALID);
 
     return op_pc;
@@ -177,6 +196,7 @@ ropFMULr(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uint
 
     uop_FP_ENTER(ir);
     uop_FMUL(ir, IREG_ST(dest_reg), IREG_ST(dest_reg), IREG_ST(0));
+    uop_FROUND_PC(ir, IREG_ST(dest_reg));
     uop_MOV_IMM(ir, IREG_tag(dest_reg), TAG_VALID);
 
     return op_pc;
@@ -188,6 +208,7 @@ ropFMULP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fet
 
     uop_FP_ENTER(ir);
     uop_FMUL(ir, IREG_ST(dest_reg), IREG_ST(dest_reg), IREG_ST(0));
+    uop_FROUND_PC(ir, IREG_ST(dest_reg));
     uop_MOV_IMM(ir, IREG_tag(dest_reg), TAG_VALID);
     fpu_POP(block, ir);
 
@@ -201,6 +222,7 @@ ropFSUB(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uint3
 
     uop_FP_ENTER(ir);
     uop_FSUB(ir, IREG_ST(0), IREG_ST(0), IREG_ST(src_reg));
+    uop_FROUND_PC(ir, IREG_ST(0));
     uop_MOV_IMM(ir, IREG_tag(0), TAG_VALID);
 
     return op_pc;
@@ -212,6 +234,7 @@ ropFSUBR(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uint
 
     uop_FP_ENTER(ir);
     uop_FSUB(ir, IREG_ST(0), IREG_ST(src_reg), IREG_ST(0));
+    uop_FROUND_PC(ir, IREG_ST(0));
     uop_MOV_IMM(ir, IREG_tag(0), TAG_VALID);
 
     return op_pc;
@@ -223,6 +246,7 @@ ropFSUBr(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uint
 
     uop_FP_ENTER(ir);
     uop_FSUB(ir, IREG_ST(dest_reg), IREG_ST(dest_reg), IREG_ST(0));
+    uop_FROUND_PC(ir, IREG_ST(dest_reg));
     uop_MOV_IMM(ir, IREG_tag(dest_reg), TAG_VALID);
 
     return op_pc;
@@ -234,6 +258,7 @@ ropFSUBRr(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uin
 
     uop_FP_ENTER(ir);
     uop_FSUB(ir, IREG_ST(dest_reg), IREG_ST(0), IREG_ST(dest_reg));
+    uop_FROUND_PC(ir, IREG_ST(dest_reg));
     uop_MOV_IMM(ir, IREG_tag(dest_reg), TAG_VALID);
 
     return op_pc;
@@ -245,6 +270,7 @@ ropFSUBP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fet
 
     uop_FP_ENTER(ir);
     uop_FSUB(ir, IREG_ST(dest_reg), IREG_ST(dest_reg), IREG_ST(0));
+    uop_FROUND_PC(ir, IREG_ST(dest_reg));
     uop_MOV_IMM(ir, IREG_tag(dest_reg), TAG_VALID);
     fpu_POP(block, ir);
 
@@ -257,6 +283,7 @@ ropFSUBRP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fe
 
     uop_FP_ENTER(ir);
     uop_FSUB(ir, IREG_ST(dest_reg), IREG_ST(0), IREG_ST(dest_reg));
+    uop_FROUND_PC(ir, IREG_ST(dest_reg));
     uop_MOV_IMM(ir, IREG_tag(dest_reg), TAG_VALID);
     fpu_POP(block, ir);
 
@@ -315,6 +342,7 @@ ropFUCOMPP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), UNUSED(uin
         codegen_check_seg_read(block, ir, target_seg);                                         \
         load_uop(ir, IREG_temp0_D, ireg_seg_base(target_seg), IREG_eaaddr);                    \
         uop_FADD(ir, IREG_ST(0), IREG_ST(0), IREG_temp0_D);                                    \
+        uop_FROUND_PC(ir, IREG_ST(0));                                                         \
         uop_MOV_IMM(ir, IREG_tag(0), TAG_VALID);                                               \
                                                                                                \
         return op_pc + 1;                                                                      \
@@ -366,6 +394,7 @@ ropFUCOMPP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), UNUSED(uin
         codegen_check_seg_read(block, ir, target_seg);                                         \
         load_uop(ir, IREG_temp0_D, ireg_seg_base(target_seg), IREG_eaaddr);                    \
         uop_FDIV(ir, IREG_ST(0), IREG_ST(0), IREG_temp0_D);                                    \
+        uop_FROUND_PC(ir, IREG_ST(0));                                                         \
         uop_MOV_IMM(ir, IREG_tag(0), TAG_VALID);                                               \
                                                                                                \
         return op_pc + 1;                                                                      \
@@ -382,6 +411,7 @@ ropFUCOMPP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), UNUSED(uin
         codegen_check_seg_read(block, ir, target_seg);                                         \
         load_uop(ir, IREG_temp0_D, ireg_seg_base(target_seg), IREG_eaaddr);                    \
         uop_FDIV(ir, IREG_ST(0), IREG_temp0_D, IREG_ST(0));                                    \
+        uop_FROUND_PC(ir, IREG_ST(0));                                                         \
         uop_MOV_IMM(ir, IREG_tag(0), TAG_VALID);                                               \
                                                                                                \
         return op_pc + 1;                                                                      \
@@ -398,6 +428,7 @@ ropFUCOMPP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), UNUSED(uin
         codegen_check_seg_read(block, ir, target_seg);                                         \
         load_uop(ir, IREG_temp0_D, ireg_seg_base(target_seg), IREG_eaaddr);                    \
         uop_FMUL(ir, IREG_ST(0), IREG_ST(0), IREG_temp0_D);                                    \
+        uop_FROUND_PC(ir, IREG_ST(0));                                                         \
         uop_MOV_IMM(ir, IREG_tag(0), TAG_VALID);                                               \
                                                                                                \
         return op_pc + 1;                                                                      \
@@ -414,6 +445,7 @@ ropFUCOMPP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), UNUSED(uin
         codegen_check_seg_read(block, ir, target_seg);                                         \
         load_uop(ir, IREG_temp0_D, ireg_seg_base(target_seg), IREG_eaaddr);                    \
         uop_FSUB(ir, IREG_ST(0), IREG_ST(0), IREG_temp0_D);                                    \
+        uop_FROUND_PC(ir, IREG_ST(0));                                                         \
         uop_MOV_IMM(ir, IREG_tag(0), TAG_VALID);                                               \
                                                                                                \
         return op_pc + 1;                                                                      \
@@ -430,6 +462,7 @@ ropFUCOMPP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), UNUSED(uin
         codegen_check_seg_read(block, ir, target_seg);                                         \
         load_uop(ir, IREG_temp0_D, ireg_seg_base(target_seg), IREG_eaaddr);                    \
         uop_FSUB(ir, IREG_ST(0), IREG_temp0_D, IREG_ST(0));                                    \
+        uop_FROUND_PC(ir, IREG_ST(0));                                                         \
         uop_MOV_IMM(ir, IREG_tag(0), TAG_VALID);                                               \
                                                                                                \
         return op_pc + 1;                                                                      \
@@ -454,6 +487,7 @@ ropF_arith_mem(d, uop_MEM_LOAD_DOUBLE)
         uop_MEM_LOAD_REG(ir, temp_reg, ireg_seg_base(target_seg), IREG_eaaddr);                \
         uop_MOV_DOUBLE_INT(ir, IREG_temp0_D, temp_reg);                                        \
         uop_FADD(ir, IREG_ST(0), IREG_ST(0), IREG_temp0_D);                                    \
+        uop_FROUND_PC(ir, IREG_ST(0));                                                         \
         uop_MOV_IMM(ir, IREG_tag(0), TAG_VALID);                                               \
                                                                                                \
         return op_pc + 1;                                                                      \
@@ -508,6 +542,7 @@ ropF_arith_mem(d, uop_MEM_LOAD_DOUBLE)
         uop_MEM_LOAD_REG(ir, temp_reg, ireg_seg_base(target_seg), IREG_eaaddr);                \
         uop_MOV_DOUBLE_INT(ir, IREG_temp0_D, temp_reg);                                        \
         uop_FDIV(ir, IREG_ST(0), IREG_ST(0), IREG_temp0_D);                                    \
+        uop_FROUND_PC(ir, IREG_ST(0));                                                         \
         uop_MOV_IMM(ir, IREG_tag(0), TAG_VALID);                                               \
                                                                                                \
         return op_pc + 1;                                                                      \
@@ -525,6 +560,7 @@ ropF_arith_mem(d, uop_MEM_LOAD_DOUBLE)
         uop_MEM_LOAD_REG(ir, temp_reg, ireg_seg_base(target_seg), IREG_eaaddr);                \
         uop_MOV_DOUBLE_INT(ir, IREG_temp0_D, temp_reg);                                        \
         uop_FDIV(ir, IREG_ST(0), IREG_temp0_D, IREG_ST(0));                                    \
+        uop_FROUND_PC(ir, IREG_ST(0));                                                         \
         uop_MOV_IMM(ir, IREG_tag(0), TAG_VALID);                                               \
                                                                                                \
         return op_pc + 1;                                                                      \
@@ -542,6 +578,7 @@ ropF_arith_mem(d, uop_MEM_LOAD_DOUBLE)
         uop_MEM_LOAD_REG(ir, temp_reg, ireg_seg_base(target_seg), IREG_eaaddr);                \
         uop_MOV_DOUBLE_INT(ir, IREG_temp0_D, temp_reg);                                        \
         uop_FMUL(ir, IREG_ST(0), IREG_ST(0), IREG_temp0_D);                                    \
+        uop_FROUND_PC(ir, IREG_ST(0));                                                         \
         uop_MOV_IMM(ir, IREG_tag(0), TAG_VALID);                                               \
                                                                                                \
         return op_pc + 1;                                                                      \
@@ -559,6 +596,7 @@ ropF_arith_mem(d, uop_MEM_LOAD_DOUBLE)
         uop_MEM_LOAD_REG(ir, temp_reg, ireg_seg_base(target_seg), IREG_eaaddr);                \
         uop_MOV_DOUBLE_INT(ir, IREG_temp0_D, temp_reg);                                        \
         uop_FSUB(ir, IREG_ST(0), IREG_ST(0), IREG_temp0_D);                                    \
+        uop_FROUND_PC(ir, IREG_ST(0));                                                         \
         uop_MOV_IMM(ir, IREG_tag(0), TAG_VALID);                                               \
                                                                                                \
         return op_pc + 1;                                                                      \
@@ -576,6 +614,7 @@ ropF_arith_mem(d, uop_MEM_LOAD_DOUBLE)
         uop_MEM_LOAD_REG(ir, temp_reg, ireg_seg_base(target_seg), IREG_eaaddr);                \
         uop_MOV_DOUBLE_INT(ir, IREG_temp0_D, temp_reg);                                        \
         uop_FSUB(ir, IREG_ST(0), IREG_temp0_D, IREG_ST(0));                                    \
+        uop_FROUND_PC(ir, IREG_ST(0));                                                         \
         uop_MOV_IMM(ir, IREG_tag(0), TAG_VALID);                                               \
                                                                                                \
         return op_pc + 1;                                                                      \
@@ -610,6 +649,7 @@ ropFSQRT(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), UNUS
 {
     uop_FP_ENTER(ir);
     uop_FSQRT(ir, IREG_ST(0), IREG_ST(0));
+    uop_FROUND_PC(ir, IREG_ST(0));
     uop_MOV_IMM(ir, IREG_tag(0), TAG_VALID);
 
     return op_pc;

--- a/src/cpu/386_dynarec.c
+++ b/src/cpu/386_dynarec.c
@@ -435,6 +435,14 @@ exec386_dynarec_dyn(void)
 #    endif
     int valid_block = 0;
 
+    /* Refresh before the lookup AND before a fresh compile: the old
+       dynarec skips the lookup on an empty hash slot, and the new block
+       still takes its key from cpu_cur_status. */
+    if (cpu_state.npxc & 0x300)
+        cpu_cur_status &= ~CPU_STATUS_FPU_PC24;
+    else
+        cpu_cur_status |= CPU_STATUS_FPU_PC24;
+
 #    ifdef USE_NEW_DYNAREC
     if (!cpu_state.abrt)
 #    else
@@ -442,11 +450,6 @@ exec386_dynarec_dyn(void)
 #    endif
     {
         page_t *page = &pages[phys_addr >> 12];
-
-        if (cpu_state.npxc & 0x300)
-            cpu_cur_status &= ~CPU_STATUS_FPU_PC24;
-        else
-            cpu_cur_status |= CPU_STATUS_FPU_PC24;
 
         /* Block must match current CS, PC, code segment size,
            and physical address. The physical address check will

--- a/src/cpu/386_dynarec.c
+++ b/src/cpu/386_dynarec.c
@@ -443,6 +443,11 @@ exec386_dynarec_dyn(void)
     {
         page_t *page = &pages[phys_addr >> 12];
 
+        if (cpu_state.npxc & 0x300)
+            cpu_cur_status &= ~CPU_STATUS_FPU_PC24;
+        else
+            cpu_cur_status |= CPU_STATUS_FPU_PC24;
+
         /* Block must match current CS, PC, code segment size,
            and physical address. The physical address check will
            also catch any page faults at this stage */

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -428,6 +428,10 @@ typedef struct {
 #define CPU_STATUS_PMODE   (1 << 2)
 #define CPU_STATUS_V86     (1 << 3)
 #define CPU_STATUS_SMM     (1 << 4)
+/* x87 precision control = 24-bit: the double-based FPU must round
+   ADD/SUB/MUL/DIV/SQRT results to single, so such blocks are compiled
+   with a round-to-single uop after each of those ops. */
+#define CPU_STATUS_FPU_PC24 (1 << 5)
 #ifdef USE_NEW_DYNAREC
 #    define CPU_STATUS_FLAGS 0xff
 #else

--- a/src/cpu/x86_ops_i686.h
+++ b/src/cpu/x86_ops_i686.h
@@ -274,10 +274,8 @@ fx_save_stor_common(uint32_t fetchdat, int bits)
 
     if (fxinst == 1) {
         /* FXRSTOR */
-        cpu_state.npxc = readmemw(easeg, cpu_state.eaaddr);
-        fpus           = readmemw(easeg, cpu_state.eaaddr + 2);
-        cpu_state.npxc = (cpu_state.npxc & ~FPU_CW_Reserved_Bits) | 0x0040;
-        codegen_set_rounding_mode((cpu_state.npxc >> 10) & 3);
+        fpus = readmemw(easeg, cpu_state.eaaddr + 2);
+        x87_set_control_word((readmemw(easeg, cpu_state.eaaddr) & ~FPU_CW_Reserved_Bits) | 0x0040);
         cpu_state.TOP = (fpus >> 11) & 7;
         /* Restore the full status word, like FRSTOR does (the previous AND-in
            dropped status bits the guest had set). */

--- a/src/cpu/x87_ops.h
+++ b/src/cpu/x87_ops.h
@@ -73,6 +73,30 @@ typedef union {
     };
 } double_decompose_t;
 
+/* Precision control: a host double already matches PC=53 (and is the
+   closest we can get to PC=64); PC=24 must round the result of
+   ADD/SUB/MUL/DIV/SQRT to single. Approximations: the float cast clamps
+   to the single exponent range (the chip keeps 15 exponent bits), rounds
+   in the host mode of the moment (nearest where the op already restored
+   it), and sets no PE/OE/UE flags. */
+#define FP_ROUND_PC(r)                        \
+    do {                                      \
+        if (!(cpu_state.npxc & 0x300))        \
+            (r) = (double) (float) (r);       \
+    } while (0)
+
+/* Dynarec blocks are keyed on PC=24, but FLDCW/FLDENV/FRSTOR/FSAVE run
+   as helper calls inside a block: a precision change must end the block
+   so the ops after it are compiled under the new precision. */
+#define x87_set_control_word(w)                                              \
+    do {                                                                     \
+        uint16_t old_npxc_ = cpu_state.npxc;                                 \
+        cpu_state.npxc     = (w);                                            \
+        codegen_set_rounding_mode((cpu_state.npxc >> 10) & 3);               \
+        if ((!(old_npxc_ & 0x300)) != (!(cpu_state.npxc & 0x300)))           \
+            CPU_BLOCK_END();                                                 \
+    } while (0)
+
 #ifdef FPU_8087
 #    define x87_div(dst, src1, src2)                    \
         do {                                            \

--- a/src/cpu/x87_ops_arith.h
+++ b/src/cpu/x87_ops_arith.h
@@ -51,7 +51,7 @@ static inline double float_add(double src, double val, int round)
         load_var = get();                                                                                                                          \
         if (cpu_state.abrt)                                                                                                                        \
             return 1;                                                                                                                              \
-        DO_FADD(use_var);                                                                                                                          \
+        DO_FADD(use_var); FP_ROUND_PC(ST(0));                                                                                                                          \
         FP_TAG_VALID;                                                                                                                              \
         CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fadd##cycle_postfix) : ((x87_timings.fadd##cycle_postfix) * cpu_multi));           \
         CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fadd##cycle_postfix) : ((x87_concurrency.fadd##cycle_postfix) * cpu_multi)); \
@@ -97,7 +97,7 @@ static inline double float_add(double src, double val, int round)
         load_var = get();                                                                                                                          \
         if (cpu_state.abrt)                                                                                                                        \
             return 1;                                                                                                                              \
-        x87_div(ST(0), ST(0), use_var);                                                                                                            \
+        x87_div(ST(0), ST(0), use_var); FP_ROUND_PC(ST(0)); \
         FP_TAG_VALID;                                                                                                                              \
         CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fdiv##cycle_postfix) : ((x87_timings.fdiv##cycle_postfix) * cpu_multi));           \
         CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fadd##cycle_postfix) : ((x87_concurrency.fadd##cycle_postfix) * cpu_multi)); \
@@ -112,7 +112,7 @@ static inline double float_add(double src, double val, int round)
         load_var = get();                                                                                                                          \
         if (cpu_state.abrt)                                                                                                                        \
             return 1;                                                                                                                              \
-        x87_div(ST(0), use_var, ST(0));                                                                                                            \
+        x87_div(ST(0), use_var, ST(0)); FP_ROUND_PC(ST(0)); \
         FP_TAG_VALID;                                                                                                                              \
         CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fdiv##cycle_postfix) : ((x87_timings.fdiv##cycle_postfix) * cpu_multi));           \
         CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fdiv##cycle_postfix) : ((x87_concurrency.fdiv##cycle_postfix) * cpu_multi)); \
@@ -127,7 +127,7 @@ static inline double float_add(double src, double val, int round)
         load_var = get();                                                                                                                          \
         if (cpu_state.abrt)                                                                                                                        \
             return 1;                                                                                                                              \
-        ST(0) *= use_var;                                                                                                                          \
+        ST(0) *= use_var; FP_ROUND_PC(ST(0));                                                                                                                          \
         FP_TAG_VALID;                                                                                                                              \
         CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fmul##cycle_postfix) : ((x87_timings.fmul##cycle_postfix) * cpu_multi));           \
         CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fmul##cycle_postfix) : ((x87_concurrency.fmul##cycle_postfix) * cpu_multi)); \
@@ -142,7 +142,7 @@ static inline double float_add(double src, double val, int round)
         load_var = get();                                                                                                                          \
         if (cpu_state.abrt)                                                                                                                        \
             return 1;                                                                                                                              \
-        ST(0) -= use_var;                                                                                                                          \
+        ST(0) -= use_var; FP_ROUND_PC(ST(0));                                                                                                                          \
         FP_TAG_VALID;                                                                                                                              \
         CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fadd##cycle_postfix) : ((x87_timings.fadd##cycle_postfix) * cpu_multi));           \
         CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fadd##cycle_postfix) : ((x87_concurrency.fadd##cycle_postfix) * cpu_multi)); \
@@ -157,7 +157,7 @@ static inline double float_add(double src, double val, int round)
         load_var = get();                                                                                                                          \
         if (cpu_state.abrt)                                                                                                                        \
             return 1;                                                                                                                              \
-        ST(0) = use_var - ST(0);                                                                                                                   \
+        ST(0) = use_var - ST(0); FP_ROUND_PC(ST(0));                                                                                                                   \
         FP_TAG_VALID;                                                                                                                              \
         CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fadd##cycle_postfix) : ((x87_timings.fadd##cycle_postfix) * cpu_multi));           \
         CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fadd##cycle_postfix) : ((x87_concurrency.fadd##cycle_postfix) * cpu_multi)); \
@@ -188,7 +188,7 @@ static int opFADD(uint32_t fetchdat)
 {
     FP_ENTER();
     cpu_state.pc++;
-    ST(0) = ST(0) + ST(fetchdat & 7);
+    ST(0) = ST(0) + ST(fetchdat & 7); FP_ROUND_PC(ST(0));
     FP_TAG_VALID;
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fadd) : (x87_timings.fadd * cpu_multi));
     CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fadd) : (x87_concurrency.fadd * cpu_multi));
@@ -199,7 +199,7 @@ opFADDr(uint32_t fetchdat)
 {
     FP_ENTER();
     cpu_state.pc++;
-    ST(fetchdat & 7) = ST(fetchdat & 7) + ST(0);
+    ST(fetchdat & 7) = ST(fetchdat & 7) + ST(0); FP_ROUND_PC(ST(fetchdat & 7));
     FP_TAG_VALID_F;
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fadd) : (x87_timings.fadd * cpu_multi));
     CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fadd) : (x87_concurrency.fadd * cpu_multi));
@@ -210,7 +210,7 @@ opFADDP(uint32_t fetchdat)
 {
     FP_ENTER();
     cpu_state.pc++;
-    ST(fetchdat & 7) = ST(fetchdat & 7) + ST(0);
+    ST(fetchdat & 7) = ST(fetchdat & 7) + ST(0); FP_ROUND_PC(ST(fetchdat & 7));
     FP_TAG_VALID_F;
     x87_pop();
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fadd) : (x87_timings.fadd * cpu_multi));
@@ -321,7 +321,7 @@ opFDIV(uint32_t fetchdat)
 {
     FP_ENTER();
     cpu_state.pc++;
-    x87_div(ST(0), ST(0), ST(fetchdat & 7));
+    x87_div(ST(0), ST(0), ST(fetchdat & 7)); FP_ROUND_PC(ST(0));
     FP_TAG_VALID;
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fdiv) : (x87_timings.fdiv * cpu_multi));
     CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fdiv) : (x87_concurrency.fdiv * cpu_multi));
@@ -332,7 +332,7 @@ opFDIVr(uint32_t fetchdat)
 {
     FP_ENTER();
     cpu_state.pc++;
-    x87_div(ST(fetchdat & 7), ST(fetchdat & 7), ST(0));
+    x87_div(ST(fetchdat & 7), ST(fetchdat & 7), ST(0)); FP_ROUND_PC(ST(fetchdat & 7));
     FP_TAG_VALID_F;
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fdiv) : (x87_timings.fdiv * cpu_multi));
     CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fdiv) : (x87_concurrency.fdiv * cpu_multi));
@@ -343,7 +343,7 @@ opFDIVP(uint32_t fetchdat)
 {
     FP_ENTER();
     cpu_state.pc++;
-    x87_div(ST(fetchdat & 7), ST(fetchdat & 7), ST(0));
+    x87_div(ST(fetchdat & 7), ST(fetchdat & 7), ST(0)); FP_ROUND_PC(ST(fetchdat & 7));
     FP_TAG_VALID_F;
     x87_pop();
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fdiv) : (x87_timings.fdiv * cpu_multi));
@@ -356,7 +356,7 @@ opFDIVR(uint32_t fetchdat)
 {
     FP_ENTER();
     cpu_state.pc++;
-    x87_div(ST(0), ST(fetchdat & 7), ST(0));
+    x87_div(ST(0), ST(fetchdat & 7), ST(0)); FP_ROUND_PC(ST(0));
     FP_TAG_VALID;
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fdiv) : (x87_timings.fdiv * cpu_multi));
     CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fdiv) : (x87_concurrency.fdiv * cpu_multi));
@@ -367,7 +367,7 @@ opFDIVRr(uint32_t fetchdat)
 {
     FP_ENTER();
     cpu_state.pc++;
-    x87_div(ST(fetchdat & 7), ST(0), ST(fetchdat & 7));
+    x87_div(ST(fetchdat & 7), ST(0), ST(fetchdat & 7)); FP_ROUND_PC(ST(fetchdat & 7));
     FP_TAG_VALID_F;
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fdiv) : (x87_timings.fdiv * cpu_multi));
     CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fdiv) : (x87_concurrency.fdiv * cpu_multi));
@@ -378,7 +378,7 @@ opFDIVRP(uint32_t fetchdat)
 {
     FP_ENTER();
     cpu_state.pc++;
-    x87_div(ST(fetchdat & 7), ST(0), ST(fetchdat & 7));
+    x87_div(ST(fetchdat & 7), ST(0), ST(fetchdat & 7)); FP_ROUND_PC(ST(fetchdat & 7));
     FP_TAG_VALID_F;
     x87_pop();
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fdiv) : (x87_timings.fdiv * cpu_multi));
@@ -391,7 +391,7 @@ opFMUL(uint32_t fetchdat)
 {
     FP_ENTER();
     cpu_state.pc++;
-    ST(0) = ST(0) * ST(fetchdat & 7);
+    ST(0) = ST(0) * ST(fetchdat & 7); FP_ROUND_PC(ST(0));
     FP_TAG_VALID;
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fmul) : (x87_timings.fmul * cpu_multi));
     CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fmul) : (x87_concurrency.fmul * cpu_multi));
@@ -402,7 +402,7 @@ opFMULr(uint32_t fetchdat)
 {
     FP_ENTER();
     cpu_state.pc++;
-    ST(fetchdat & 7) = ST(0) * ST(fetchdat & 7);
+    ST(fetchdat & 7) = ST(0) * ST(fetchdat & 7); FP_ROUND_PC(ST(fetchdat & 7));
     FP_TAG_VALID_F;
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fmul) : (x87_timings.fmul * cpu_multi));
     CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fmul) : (x87_concurrency.fmul * cpu_multi));
@@ -413,7 +413,7 @@ opFMULP(uint32_t fetchdat)
 {
     FP_ENTER();
     cpu_state.pc++;
-    ST(fetchdat & 7) = ST(0) * ST(fetchdat & 7);
+    ST(fetchdat & 7) = ST(0) * ST(fetchdat & 7); FP_ROUND_PC(ST(fetchdat & 7));
     FP_TAG_VALID_F;
     x87_pop();
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fmul) : (x87_timings.fmul * cpu_multi));
@@ -426,7 +426,7 @@ opFSUB(uint32_t fetchdat)
 {
     FP_ENTER();
     cpu_state.pc++;
-    ST(0) = ST(0) - ST(fetchdat & 7);
+    ST(0) = ST(0) - ST(fetchdat & 7); FP_ROUND_PC(ST(0));
     FP_TAG_VALID;
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fadd) : (x87_timings.fadd * cpu_multi));
     CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fadd) : (x87_concurrency.fadd * cpu_multi));
@@ -437,7 +437,7 @@ opFSUBr(uint32_t fetchdat)
 {
     FP_ENTER();
     cpu_state.pc++;
-    ST(fetchdat & 7) = ST(fetchdat & 7) - ST(0);
+    ST(fetchdat & 7) = ST(fetchdat & 7) - ST(0); FP_ROUND_PC(ST(fetchdat & 7));
     FP_TAG_VALID_F;
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fadd) : (x87_timings.fadd * cpu_multi));
     CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fadd) : (x87_concurrency.fadd * cpu_multi));
@@ -448,7 +448,7 @@ opFSUBP(uint32_t fetchdat)
 {
     FP_ENTER();
     cpu_state.pc++;
-    ST(fetchdat & 7) = ST(fetchdat & 7) - ST(0);
+    ST(fetchdat & 7) = ST(fetchdat & 7) - ST(0); FP_ROUND_PC(ST(fetchdat & 7));
     FP_TAG_VALID_F;
     x87_pop();
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fadd) : (x87_timings.fadd * cpu_multi));
@@ -461,7 +461,7 @@ opFSUBR(uint32_t fetchdat)
 {
     FP_ENTER();
     cpu_state.pc++;
-    ST(0) = ST(fetchdat & 7) - ST(0);
+    ST(0) = ST(fetchdat & 7) - ST(0); FP_ROUND_PC(ST(0));
     FP_TAG_VALID;
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fadd) : (x87_timings.fadd * cpu_multi));
     CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fadd) : (x87_concurrency.fadd * cpu_multi));
@@ -472,7 +472,7 @@ opFSUBRr(uint32_t fetchdat)
 {
     FP_ENTER();
     cpu_state.pc++;
-    ST(fetchdat & 7) = ST(0) - ST(fetchdat & 7);
+    ST(fetchdat & 7) = ST(0) - ST(fetchdat & 7); FP_ROUND_PC(ST(fetchdat & 7));
     FP_TAG_VALID_F;
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fadd) : (x87_timings.fadd * cpu_multi));
     CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fadd) : (x87_concurrency.fadd * cpu_multi));
@@ -483,7 +483,7 @@ opFSUBRP(uint32_t fetchdat)
 {
     FP_ENTER();
     cpu_state.pc++;
-    ST(fetchdat & 7) = ST(0) - ST(fetchdat & 7);
+    ST(fetchdat & 7) = ST(0) - ST(fetchdat & 7); FP_ROUND_PC(ST(fetchdat & 7));
     FP_TAG_VALID_F;
     x87_pop();
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fadd) : (x87_timings.fadd * cpu_multi));

--- a/src/cpu/x87_ops_misc.h
+++ b/src/cpu/x87_ops_misc.h
@@ -168,8 +168,7 @@ FSTOR(void)
     switch ((cr0 & 1) | (cpu_state.op32 & 0x100)) {
         case 0x000: /*16-bit real mode*/
         case 0x001: /*16-bit protected mode*/
-            cpu_state.npxc = readmemw(easeg, cpu_state.eaaddr);
-            codegen_set_rounding_mode((cpu_state.npxc >> 10) & 3);
+            x87_set_control_word(readmemw(easeg, cpu_state.eaaddr));
             cpu_state.npxs = readmemw(easeg, cpu_state.eaaddr + 2);
             x87_settag(readmemw(easeg, cpu_state.eaaddr + 4));
             cpu_state.TOP = (cpu_state.npxs >> 11) & 7;
@@ -177,8 +176,7 @@ FSTOR(void)
             break;
         case 0x100: /*32-bit real mode*/
         case 0x101: /*32-bit protected mode*/
-            cpu_state.npxc = readmemw(easeg, cpu_state.eaaddr);
-            codegen_set_rounding_mode((cpu_state.npxc >> 10) & 3);
+            x87_set_control_word(readmemw(easeg, cpu_state.eaaddr));
             cpu_state.npxs = readmemw(easeg, cpu_state.eaaddr + 4);
             x87_settag(readmemw(easeg, cpu_state.eaaddr + 8));
             cpu_state.TOP = (cpu_state.npxs >> 11) & 7;
@@ -417,8 +415,7 @@ FSAVE(void)
             break;
     }
 
-    cpu_state.npxc = 0x37F;
-    codegen_set_rounding_mode(X87_ROUNDING_NEAREST);
+    x87_set_control_word(0x37F);
 #ifdef FPU_8087
     cpu_state.npxs &= 0x4700;
 #else
@@ -840,6 +837,7 @@ opFSQRT(UNUSED(uint32_t fetchdat))
     FP_ENTER();
     cpu_state.pc++;
     ST(0) = sqrt(ST(0));
+    FP_ROUND_PC(ST(0));
     FP_TAG_VALID;
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fsqrt) : (x87_timings.fsqrt * cpu_multi));
     CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fsqrt) : (x87_concurrency.fsqrt * cpu_multi));
@@ -992,16 +990,14 @@ FLDENV(void)
     switch ((cr0 & 1) | (cpu_state.op32 & 0x100)) {
         case 0x000: /*16-bit real mode*/
         case 0x001: /*16-bit protected mode*/
-            cpu_state.npxc = readmemw(easeg, cpu_state.eaaddr);
-            codegen_set_rounding_mode((cpu_state.npxc >> 10) & 3);
+            x87_set_control_word(readmemw(easeg, cpu_state.eaaddr));
             cpu_state.npxs = readmemw(easeg, cpu_state.eaaddr + 2);
             x87_settag(readmemw(easeg, cpu_state.eaaddr + 4));
             cpu_state.TOP = (cpu_state.npxs >> 11) & 7;
             break;
         case 0x100: /*32-bit real mode*/
         case 0x101: /*32-bit protected mode*/
-            cpu_state.npxc = readmemw(easeg, cpu_state.eaaddr);
-            codegen_set_rounding_mode((cpu_state.npxc >> 10) & 3);
+            x87_set_control_word(readmemw(easeg, cpu_state.eaaddr));
             cpu_state.npxs = readmemw(easeg, cpu_state.eaaddr + 4);
             x87_settag(readmemw(easeg, cpu_state.eaaddr + 8));
             cpu_state.TOP = (cpu_state.npxs >> 11) & 7;
@@ -1043,8 +1039,7 @@ opFLDCW_a16(UNUSED(uint32_t fetchdat))
     tempw = geteaw();
     if (cpu_state.abrt)
         return 1;
-    cpu_state.npxc = tempw;
-    codegen_set_rounding_mode((cpu_state.npxc >> 10) & 3);
+    x87_set_control_word(tempw);
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fldcw) : (x87_timings.fldcw * cpu_multi));
     CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fldcw) : (x87_concurrency.fldcw * cpu_multi));
     return 0;
@@ -1060,8 +1055,7 @@ opFLDCW_a32(uint32_t fetchdat)
     tempw = geteaw();
     if (cpu_state.abrt)
         return 1;
-    cpu_state.npxc = tempw;
-    codegen_set_rounding_mode((cpu_state.npxc >> 10) & 3);
+    x87_set_control_word(tempw);
     CLOCK_CYCLES_FPU((fpu_type >= FPU_487SX) ? (x87_timings.fldcw) : (x87_timings.fldcw * cpu_multi));
     CONCURRENCY_CYCLES((fpu_type >= FPU_487SX) ? (x87_concurrency.fldcw) : (x87_concurrency.fldcw * cpu_multi));
     return 0;

--- a/src/cpu/x87_ops_sf_load_store.h
+++ b/src/cpu/x87_ops_sf_load_store.h
@@ -236,9 +236,9 @@ sf_FBLD_PACKED_BCD_a32(uint32_t fetchdat)
 
     FP_ENTER();
     FPU_check_pending_exceptions();
-    fetch_ea_16(fetchdat);
+    fetch_ea_32(fetchdat);
     SEG_CHECK_READ(cpu_state.ea_seg);
-    load_reg_hi = readmemw(easeg, (cpu_state.eaaddr + 8) & 0xffff);
+    load_reg_hi = readmemw(easeg, cpu_state.eaaddr + 8);
     load_reg_lo = readmemq(easeg, cpu_state.eaaddr);
     if (cpu_state.abrt)
         return 1;


### PR DESCRIPTION
Summary
=======
Three x87 fixes.

1. The default (non-softfloat) x87 computes in host doubles and ignored the control word's precision bits. With PC=24 the real chip rounds every ADD/SUB/MUL/DIV/SQRT result to a 24-bit significand; we kept 53 bits. Fix: round the result to single in the interpreter handlers when PC=24; the new dynarec emits a D->S->D round (FCVT on arm64, CVTSD2SS/CVTSS2SD on x86-64) after those ops, the PC=24 state is part of the block key, and control-word writes (FLDCW/FLDENV/FRSTOR/FSAVE/FXRSTOR) end the block when the PC=24 state flips. Rounding-control (RC) changes do not end the block: compiled code applies RC through the host rounding mode at run time, and MSVC's _ftol flips RC on every float-to-int conversion, so keying blocks on it would end them constantly for nothing. Softfloat already honored PC and is untouched.
2. The old dynarec's x86-64 backend gets the same single round in FP_OP_REG/FP_OP_MEM (FSQRT is not natively compiled there and rounds in the interpreter handler), and the PC=24 key refresh is moved ahead of the block lookup: the old dynarec skips the lookup branch on an empty hash slot, so a fresh block could be keyed with a stale bit.
3. Softfloat FBLD: sf_FBLD_PACKED_BCD_a32 was a copy of the a16 handler (fetch_ea_16 plus a 16-bit wrap), so a 32-bit `fbld [edx]` decoded as `[bp+si]`. The default FPU's FBLD_a32 was already correct. FBLD is never recompiled, so the interpreter fix covers both dynarecs.

Known approximations, 24-bit mode only: the result is clamped to the single exponent range (the chip keeps the 15-bit exponent), the round step uses the host rounding mode of the moment, and no PE/OE/UE status flags are raised.

Tested: GTA III 1.0 on Win98SE loads into the city with the new dynarec (arm64 host), the old dynarec (x86-64 host, NEW_DYNAREC=OFF), the interpreter, and the softfloat FPU (which previously faulted on an fbld before the main menu). Colin McRae Rally, Forsaken, Rollcage (Win98SE) and 3DMark2000 (Win2000) unchanged.

Checklist
=========
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set
* [ ] This pull request adds, changes or removes an external dependency

References
==========
Intel SDM Vol. 1, sec. 8.1.5.2 "Precision Control Field" and 8.3.3 "Data Transfer Instructions" (FBLD).


AI disclosure
=============
AI tooling assisted with analysis and drafting. All changes were reviewed
by me and verified on real guests as listed above.
