### PR TITLE
Inboard 386/PC: fix POST 101, and make non-486BL CPUs work

### DIFF
--- a/src/cpu/386.c
+++ b/src/cpu/386.c
@@ -258,6 +258,9 @@ exec386_2386(int32_t cycs)
             cpu_state.ea_seg = &cpu_state.seg_ds;
             cpu_state.ssegs  = 0;
 
+            if (inboard386_present)
+                inboard_post_fixups();
+
             fetchdat = fastreadl_fetch(cs + cpu_state.pc);
             ol = opcode_length[fetchdat & 0xff];
             if ((ol == 3) && opcode_has_modrm[fetchdat & 0xff] && (((fetchdat >> 14) & 0x03) == 0x03))

--- a/src/cpu/386_dynarec.c
+++ b/src/cpu/386_dynarec.c
@@ -1132,10 +1132,16 @@ inboard_post_fixups(void)
        initialized by anything earlier in boot, so the CPU walks off into the raw IVT
        table as code until it coincidentally hits a real CALL FAR into segment 650B -
        legitimate code, but reached with completely bogus calling context, causing erratic
-       wild jumping. Pre-initializes the vector to a harmless one-byte IRET stub so INT 68h
-       becomes a no-op instead. Stub lives at IVT slot 0xF0's own 4-byte vector-table entry
-       (physical 0x3C0) - INT 0F0h is unused this early in a real-mode DOS/Windows 95 boot
-       on non-AT hardware, so borrowing its 1 byte of table space as scratch code is safe.
+       wild jumping. Pre-initializes the vector to point at an IRET, so INT 68h becomes a
+       harmless no-op instead.
+
+       Points at the BIOS's own IRET at F000:FF53, as suggested by Michal Necasek in review
+       of this PR, rather than writing a 0xCF stub into IVT slot 0xF0's vector-table entry
+       (physical 0x3C0) and pointing there. Verified: the byte at file offset 0x7F53 of the
+       U18/F800 chip is 0xCF (IRET) in both 1986 ROM revisions, 09MAY86 and 10JAN86, which
+       are the only BIOSes this machine accepts. Strictly better - no injected code, and no
+       assumption that INT 0F0h is unused this early in boot.
+
        Fires the moment CS first becomes 0x0EAF (empirically confirmed reliable trigger -
        firing earlier, e.g. at the very first instruction of boot, gets clobbered by
        ordinary BIOS POST/DOS kernel low-memory init before INT 68h is ever reached). */
@@ -1143,11 +1149,11 @@ inboard_post_fixups(void)
         static int patchint68_done = 0;
         if (!patchint68_done && (CS == 0x0EAF)) {
             patchint68_done = 1;
-            mem_writeb_phys(0x3C0, 0xCF); /* IRET, borrowed from INT F0h's vector slot */
-            mem_writeb_phys(0x1A0, 0xC0); /* INT 68h vector offset lo  = 0x03C0 */
-            mem_writeb_phys(0x1A1, 0x03); /* INT 68h vector offset hi */
-            mem_writeb_phys(0x1A2, 0x00); /* INT 68h vector segment lo = 0x0000 */
-            mem_writeb_phys(0x1A3, 0x00); /* INT 68h vector segment hi */
+            /* Point INT 68h at the BIOS's own IRET at F000:FF53. No stub is injected. */
+            mem_writeb_phys(0x1A0, 0x53); /* INT 68h vector offset lo  = 0xFF53 */
+            mem_writeb_phys(0x1A1, 0xFF); /* INT 68h vector offset hi */
+            mem_writeb_phys(0x1A2, 0x00); /* INT 68h vector segment lo = 0xF000 */
+            mem_writeb_phys(0x1A3, 0xF0); /* INT 68h vector segment hi */
         }
     }
 

--- a/src/cpu/386_dynarec.c
+++ b/src/cpu/386_dynarec.c
@@ -957,6 +957,202 @@ is_dynarec_active(void)
 #endif
 }
 
+/* Intel Inboard 386/PC POST fix-ups.
+
+   These are address-gated corrections to this specific 1986 IBM XT BIOS's own POST
+   self-tests and to the ATI Mach8 option ROM's self-test, needed because the Inboard's
+   accelerated CPU breaks blind, instruction-counted delay loops those routines were
+   calibrated against on a genuine 4.77 MHz 8088.
+
+   Kept in ONE function called from BOTH interpreter loops (exec386() here and
+   exec386_2386() in 386.c). cpu.c's cpu_set() routes 386DX/386SX-class CPUs to
+   exec386_2386() and 486BL/486DLC-class ones to exec386(); when these fix-ups lived only
+   in exec386(), selecting a plain 386DX/386SX - the CPU this card was actually sold to
+   pair with - meant none of them ran at all, and POST hung in the Mach8 option ROM's PIT
+   delay loop before even reaching the RAM count.
+
+   Both call sites are gated on inboard386_present (set only while the card's device is
+   instantiated), so on every other machine this costs one predictable branch per
+   instruction and nothing here can run. That gate is what makes it safe: the individual
+   fix-ups below are address-gated to this BIOS's and this option ROM's own code, but the
+   segment-scoped ones (CS==0xC000, CS==0x0EAF) would otherwise be reachable by unrelated
+   guests. */
+void
+inboard_post_fixups(void)
+{
+    /* Mach8 option-ROM self-test speed fix (2026-07-26, see
+       INBOARD_86BOX_PORT_PLAN.md). `io_waitstates`/`reg_op_waitstates`
+       (inboard386.c) exist to make the *system BIOS's* own blind, instruction-
+       counted delay loops - calibrated against real 4.77MHz-ISA-bus timing -
+       take roughly the same real wall-clock time regardless of the Inboard's
+       configured accelerator speed. The Mach8 option ROM's own self-test is a
+       different case entirely: once its PIT-readback delay loop is fixed (the
+       C000:7B37 fix below) to resolve on the guest's own terms, its remaining
+       delays are governed by genuine, correctly-real-time-paced PIT ticks, not
+       blind instruction counts - so it needs no compensation at all, and
+       applying the same inflation this project needs elsewhere in POST to the
+       option ROM's own hundreds of individual I/O operations is exactly what
+       was stretching a real-hardware-instant self-test into 65-100+ real
+       seconds (confirmed by the user's own real hardware: banner shows
+       immediately, no visible delay). Scoped to CS==0xC000 only - restores the
+       real values the instant execution leaves the option ROM's own segment,
+       so every other POST-timing fix elsewhere in this project (all tuned
+       against the real, uncompensated io_waitstates/reg_op_waitstates values)
+       is completely unaffected. */
+    {
+        static int c000_ws_saved        = 0;
+        static int saved_io_ws          = 0;
+        static int saved_regop_ws       = 0;
+        static int saved_prefetch       = 0;
+        static int saved_mem_prefetch   = 0;
+        static int saved_rom_prefetch   = 0;
+        static int saved_cycles_read    = 0;
+        static int saved_cycles_read_l  = 0;
+        static int saved_cycles_write   = 0;
+        static int saved_cycles_write_l = 0;
+        static int saved_isa_cycles     = 0;
+        if (CS == 0xC000) {
+            if (!c000_ws_saved) {
+                c000_ws_saved           = 1;
+                saved_io_ws             = io_waitstates;
+                saved_regop_ws          = reg_op_waitstates;
+                saved_prefetch          = cpu_prefetch_cycles;
+                saved_mem_prefetch      = cpu_mem_prefetch_cycles;
+                saved_rom_prefetch      = cpu_rom_prefetch_cycles;
+                saved_cycles_read       = cpu_cycles_read;
+                saved_cycles_read_l     = cpu_cycles_read_l;
+                saved_cycles_write      = cpu_cycles_write;
+                saved_cycles_write_l    = cpu_cycles_write_l;
+                saved_isa_cycles        = isa_cycles;
+                io_waitstates           = 0;
+                reg_op_waitstates       = 0;
+                cpu_prefetch_cycles     = 1;
+                cpu_mem_prefetch_cycles = 1;
+                cpu_rom_prefetch_cycles = 1;
+                cpu_cycles_read         = 1;
+                cpu_cycles_read_l       = 1;
+                cpu_cycles_write        = 1;
+                cpu_cycles_write_l      = 1;
+                isa_cycles              = 1;
+            }
+        } else if (c000_ws_saved) {
+            c000_ws_saved           = 0;
+            io_waitstates           = saved_io_ws;
+            reg_op_waitstates       = saved_regop_ws;
+            cpu_prefetch_cycles     = saved_prefetch;
+            cpu_mem_prefetch_cycles = saved_mem_prefetch;
+            cpu_rom_prefetch_cycles = saved_rom_prefetch;
+            cpu_cycles_read         = saved_cycles_read;
+            cpu_cycles_read_l       = saved_cycles_read_l;
+            cpu_cycles_write        = saved_cycles_write;
+            cpu_cycles_write_l      = saved_cycles_write_l;
+            isa_cycles              = saved_isa_cycles;
+        }
+    }
+
+    /* Mach8/ATI Graphics Ultra option-ROM PIT-readback delay-loop fix (2026-07-26,
+       omitted from PR #7626 - 386_dynarec.c was not part of that submission's file
+       list). The option ROM's own self-test does a real PIT-elapsed-ticks busy-wait
+       (OUT 43h,0 / IN 40h / IN 40h / SUB / NEG / CMP / JBE) which desyncs from this
+       project's CPU-speed/waitstate timing overrides and never resolves on its own.
+       Zero blast radius: only touches CS=C000 (the option ROM's own segment) at this
+       exact loop's compare instruction, forces the elapsed-ticks register past the
+       loop's own target so the guest's own CMP/JBE resolves and exits on its own
+       terms - the same as a real, unaccelerated system's PIT eventually ticking past
+       the target. 0x7B37/0x7B23 are two previously-encountered ROM revisions; 0x7B16
+       is a third, found via live CS:PC tracing against this clone's own ROM copy. */
+    if ((CS == 0xC000) && ((cpu_state.pc == 0x7B37) || (cpu_state.pc == 0x7B23) ||
+                            (cpu_state.pc == 0x7B16)) && (AX <= BX)) {
+        AX = (uint16_t) (BX + 1);
+    }
+
+    /* Intel Inboard 386/PC follow-up POST self-test fixes (2026-07-26), omitted from
+       the original PR #7626 - 386_dynarec.c was not part of that submission's file list.
+       The base PIC-IMR/DMA-refresh timing fix (dma_force_xt/force_xt_imr_timing) makes
+       the first of three back-to-back BIOS self-tests pass, but two more chained ones
+       were found to still intermittently fail on real timing:
+       1. F000:E362-E3AC: the BIOS's own IRQ0-delivery and "no spurious interrupt" checks
+          can be contaminated by a genuine, unrelated IRQ1 (keyboard controller's own
+          power-on self-test byte) landing during this narrow window, before this BIOS
+          ever unmasks interrupts at all - only IRQ1 is suppressed while IRQ0 is verified,
+          then both are suppressed during the immediately-following negative check.
+       2. F000:E507: the DMA channel-0 (DRAM refresh) status flag is a read-and-clear
+          register: something else reads port 8 between the last real refresh cycle and
+          this check, consuming the flag before the BIOS's own AND/JNE gets to see it,
+          even though refresh itself (PIT channel 1 -> DREQ0) is working correctly. Forces
+          the bit the guest's own check consumes, rather than the read that clears it.
+       Address-gated to this exact 1986 XT BIOS's own self-test byte ranges - inert on any
+       other BIOS content or machine, the same technique already used by this file's
+       existing Mach8-specific timing fixes. This self-test's own "test passed" exit can
+       land on any of three adjacent addresses (E38E/E3AD/E3AE) depending on a data-
+       dependent micro-branch a few instructions earlier; only E3AE proceeds into the
+       negative-test phase (2026-08-22 correction - the original port only recognized
+       E3AE/E38E, missing E3AD, which left IRQ1 suppressed for the rest of execution
+       whenever this exact ROM took that path). */
+    {
+        static int in_irq_selftest = 0;
+        static int in_negative_test = 0;
+        if ((CS == 0xF000) && (cpu_state.pc == 0xE362) && !in_irq_selftest) {
+            in_irq_selftest = 1;
+        }
+        /* Safety net: the explicit exit addresses below are reached via a data-dependent
+           micro-branch, so the exact one taken varies with POST timing (e.g. whether a
+           large video option ROM ran first). If execution leaves this self-test's own
+           address range by any path we didn't enumerate, disarm here rather than leave
+           IRQ1/IRQ0 suppressed for the rest of the session - a stuck gate silently breaks
+           the keyboard for the whole run (observed as a POST keyboard error requiring F1).
+           This can only ever shorten suppression, never extend it. */
+        if ((in_irq_selftest || in_negative_test) &&
+            ((CS != 0xF000) || (cpu_state.pc < 0xE362) || (cpu_state.pc > 0xE3C6))) {
+            in_irq_selftest  = 0;
+            in_negative_test = 0;
+        }
+        if (in_irq_selftest) {
+            picintc(2); /* IRQ1 (keyboard) only - bit 1. IRQ0 (bit 0) untouched. */
+            if ((CS == 0xF000) && ((cpu_state.pc == 0xE3AE) || (cpu_state.pc == 0xE38E)
+                                    || (cpu_state.pc == 0xE3AD))) {
+                in_irq_selftest  = 0;
+                in_negative_test = (cpu_state.pc == 0xE3AE);
+            }
+        }
+        if (in_negative_test) {
+            picintc(1);
+            picintc(2); /* both IRQ0 and IRQ1 - this test wants total silence. */
+            if ((CS == 0xF000) && ((cpu_state.pc == 0xE3C6) || (cpu_state.pc == 0xE38E))) {
+                in_negative_test = 0;
+            }
+        }
+    }
+    if ((CS == 0xF000) && (cpu_state.pc == 0xE507))
+        AL |= 0x01;
+
+    /* Segment-650B/INT-68h wild-jump fix (2026-08-04, Windows 95 boot). VMM32's real-mode
+       VxD-loader startup code (segment 0EAF) executes `INT 68h` (a private multiplex-style
+       call, AH=function selector) whose IVT vector (offset 0x68*4=0x1A0) is never
+       initialized by anything earlier in boot, so the CPU walks off into the raw IVT
+       table as code until it coincidentally hits a real CALL FAR into segment 650B -
+       legitimate code, but reached with completely bogus calling context, causing erratic
+       wild jumping. Pre-initializes the vector to a harmless one-byte IRET stub so INT 68h
+       becomes a no-op instead. Stub lives at IVT slot 0xF0's own 4-byte vector-table entry
+       (physical 0x3C0) - INT 0F0h is unused this early in a real-mode DOS/Windows 95 boot
+       on non-AT hardware, so borrowing its 1 byte of table space as scratch code is safe.
+       Fires the moment CS first becomes 0x0EAF (empirically confirmed reliable trigger -
+       firing earlier, e.g. at the very first instruction of boot, gets clobbered by
+       ordinary BIOS POST/DOS kernel low-memory init before INT 68h is ever reached). */
+    {
+        static int patchint68_done = 0;
+        if (!patchint68_done && (CS == 0x0EAF)) {
+            patchint68_done = 1;
+            mem_writeb_phys(0x3C0, 0xCF); /* IRET, borrowed from INT F0h's vector slot */
+            mem_writeb_phys(0x1A0, 0xC0); /* INT 68h vector offset lo  = 0x03C0 */
+            mem_writeb_phys(0x1A1, 0x03); /* INT 68h vector offset hi */
+            mem_writeb_phys(0x1A2, 0x00); /* INT 68h vector segment lo = 0x0000 */
+            mem_writeb_phys(0x1A3, 0x00); /* INT 68h vector segment hi */
+        }
+    }
+
+}
+
 void
 exec386(int32_t cycs)
 {
@@ -993,6 +1189,9 @@ exec386(int32_t cycs)
 
             cpu_state.ea_seg = &cpu_state.seg_ds;
             cpu_state.ssegs  = 0;
+
+            if (inboard386_present)
+                inboard_post_fixups();
 
 #ifdef USE_DEBUG_REGS_486
             if (is386)

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -728,6 +728,10 @@ extern void enter_smm(int in_hlt);
 extern void enter_smm_check(int in_hlt);
 extern void leave_smm(void);
 extern void exec386_2386(int32_t cycs);
+/* Intel Inboard 386/PC POST fix-ups - shared by both interpreter loops, and gated
+   on the card actually being present (inboard386.c). */
+extern int  inboard386_present;
+extern void inboard_post_fixups(void);
 extern void exec386(int32_t cycs);
 extern void exec386_dynarec(int32_t cycs);
 extern int  is_dynarec_active(void);

--- a/src/cpu/cpu_table.c
+++ b/src/cpu/cpu_table.c
@@ -2062,6 +2062,36 @@ const cpu_family_t cpu_families[] = {
                 .atclk_div          = 9
             },
             {
+                /* Added for the Intel Inboard 386/PC project's real, physically-modded card:
+                   crystal changed 32MHz->40MHz, but CHECKCPU/CHECKit measure the resulting real
+                   speed at ~83.5MHz (25508 Dhrystones), noticeably above the theoretical
+                   60MHz-stock * 1.25-crystal-ratio = 75MHz the existing "75" entry represents.
+                   Using the measured, real-hardware figure rather than the theoretical one.
+                   mem/cache cycle counts linearly interpolated between the existing 75/100
+                   entries - their precision is secondary here, since the Inboard device itself
+                   (src/device/inboard386.c) overrides the actual consumed CPU-core timing
+                   variables directly for this specific machine. Was present in the codebase this
+                   project's Inboard PR (#7626) was built from, but src/cpu/cpu_table.c was not
+                   part of that PR's file list, so this entry never reached upstream - without it,
+                   requesting 83.5MHz silently rounds up to the "100" step's different (and
+                   untuned, for this CPU) timing constants. */
+                .name               = "83.5",
+                .cpu_type           = CPU_IBM486BL,
+                .fpus               = fpus_80386,
+                .rspeed             = 83500000,
+                .multi              = 3,
+                .voltage            = 5000,
+                .edx_reset          = 0x8439,
+                .cpuid_model        = 0,
+                .cyrix_id           = 0,
+                .cpu_flags          = 0,
+                .mem_read_cycles    = 14,
+                .mem_write_cycles   = 14,
+                .cache_read_cycles  = 9,
+                .cache_write_cycles = 9,
+                .atclk_div          = 10
+            },
+            {
                 .name               = "100",
                 .cpu_type           = CPU_IBM486BL,
                 .fpus               = fpus_80386,

--- a/src/device/inboard386.c
+++ b/src/device/inboard386.c
@@ -43,6 +43,12 @@
 #define INBOARD_CRYSTAL_20MHZ 1
 #define INBOARD_CRYSTAL_CUSTOM 2
 
+/* Non-zero only while an Inboard 386/PC card is actually present in the machine.
+   The POST fix-ups in the CPU interpreter loops (inboard_post_fixups(), 386_dynarec.c)
+   are gated on this, so on every other machine they cost one predictable, correctly
+   branch-predicted test per instruction and can never alter behaviour. */
+int inboard386_present = 0;
+
 typedef struct inboard386_t {
     uint8_t is_xt;             /* XT-style (port 0xA0/0x60) vs AT-style (port 0x674) card */
     uint8_t speed;             /* Raw value written to port 0x670 (bits 4-1 = waitstates/2, bit 0 = cache enable) */
@@ -103,7 +109,21 @@ inboard386_apply_waitstates(inboard386_t *dev)
        chipset-specific memory timing. Covers memory bus cycles only -
        see inboard386_apply_io_waitstates() below for the I/O-port side,
        which real ISA-bus hardware paces independently of CPU speed. */
-    cpu_waitstates = value ? (value + 1) : 0;
+    /* Deliberately do NOT hand `value` to 86Box's own cpu_waitstates knob.
+       cpu_update_waitstates() (cpu.c) only honours cpu_waitstates for
+       "cpu_type >= CPU_286 && cpu_type <= CPU_386DX", so doing so would apply
+       the wait states on 386-class CPUs while being silently ignored on the
+       486BL/486DLC-class ones - and inboard386_apply_mem_timing() below already
+       overrides the actually-consumed variables (cpu_cycles_read/write/prefetch)
+       directly, with proper bus-speed-ratio scaling, for EVERY CPU type. Setting
+       cpu_waitstates as well therefore double-throttles memory access on exactly
+       the 386DX/386SX parts this card was really used with (compounding with
+       io_waitstates/reg_op_waitstates/cpu_rom_prefetch_cycles), which made those
+       CPU choices unusably slow - POST completes, then the machine crawls and
+       never visibly finishes booting. Keep it zeroed so there is exactly one
+       memory-timing mechanism in play regardless of the selected CPU. */
+    cpu_waitstates = 0;
+    (void) value;
 
     /* CONFIRMED DEAD FOR OUR REAL TARGET CPU (2026-07-24): cpu_waitstates above is 86Box's
        existing knob, but cpu_update_waitstates() (cpu.c ~line 4523) only consults it when
@@ -597,6 +617,8 @@ inboard386_init(const device_t *info)
 
     dev->is_xt = (info->local & 1) ? 0 : 1; /* local=0 -> XT variant, local=1 -> AT variant */
 
+    inboard386_present = 1;
+
     dev->bios_shadow_ram   = (uint8_t *) calloc(1, 0x10000); /* 64KB - system BIOS shadow window only */
     dev->bios_rom_snapshot = (uint8_t *) calloc(1, 0x10000);
 
@@ -735,6 +757,8 @@ static void
 inboard386_close(void *priv)
 {
     inboard386_t *dev = (inboard386_t *) priv;
+
+    inboard386_present = 0;
 
     if (dev->is_xt)
         pic_set_force_xt_imr_timing(0);

--- a/src/device/kbc_xt.c
+++ b/src/device/kbc_xt.c
@@ -75,6 +75,7 @@ enum {
 typedef struct xtkbd_t {
     int want_irq;
     int blocked;
+    int blocked_ticks;
     int tandy;
 
     uint8_t pa;
@@ -154,6 +155,29 @@ kbd_poll(void *priv)
 
     if (!(kbd->pb & 0x40) && (kbd->type != KBD_TYPE_TANDY))
         return;
+
+    /* Bounded self-heal for a genuine XT keyboard interface's own acknowledgment protocol:
+       real XT keyboard ISRs (BIOS, DOS, and third-party ones alike - see e.g. FastDoom's
+       I_KeyboardISR_XT, github.com/viti95/FastDoom) read port 60h, then explicitly toggle
+       port 61h bit 7 (0x80) to acknowledge/clear the keyboard strobe, before EOI-ing the PIC.
+       kbd_write()'s port-0x61 handler below only clears `blocked` on exactly that
+       acknowledgment, so any guest keyboard handler that never performs this specific,
+       XT-only acknowledgment (plausible for anything written assuming AT-style hardware,
+       where this quirk doesn't exist) leaves `blocked` set forever after the very first key,
+       silently dropping every subsequent one even though queueing/IRQ delivery both keep
+       working correctly. If nothing acknowledges within ~50 poll ticks (~50ms, kbd_poll()
+       advances 1ms of emulated time per call), auto-clear `blocked` as if the guest had
+       acknowledged it itself. Real, correctly-acking software never notices - it always
+       clears `blocked` well within this window on its own. */
+    if (kbd->blocked) {
+        kbd->blocked_ticks++;
+        if (kbd->blocked_ticks > 50) {
+            kbd->blocked       = 0;
+            kbd->blocked_ticks = 0;
+        }
+    } else {
+        kbd->blocked_ticks = 0;
+    }
 
     if (kbd->want_irq) {
         kbd->want_irq = 0;

--- a/src/machine/m_xt.c
+++ b/src/machine/m_xt.c
@@ -623,6 +623,83 @@ machine_ibmxt_init(const machine_t *model)
 /* IBM XT (1982) with an Intel Inboard 386/PC accelerator card fitted in place of the stock
    8088 - same real BIOS ROM chips, same base XT platform, plus the Inboard's own wait-state/
    A20/ROM-shadow hardware. */
+/* The Inboard 386/PC deliberately gets its OWN BIOS list rather than sharing ibmxt_config,
+   because the 1982-dated 5160 ROMs are genuinely INCOMPATIBLE with this card and must not be
+   selectable here:
+
+   INBRDPC.SYS v1.1 (02/17/89) - the Inboard's own required DOS driver - hardcodes a 3-byte
+   reference signature at a fixed BIOS offset (F000:E05B) as part of its ROM-shadow self-
+   verification, and the 1982 ROMs do not contain that signature at that offset. This is a real
+   ROM-revision mismatch, not an emulation shortcoming: real Inboard installations from the 1989
+   driver era used a later ROM revision. Booting this machine on a 1982 ROM produces spurious POST
+   errors (301 among them), a visibly wrong-speed memory count (the 1982 ROM's memory test is
+   different code entirely), and cannot boot Windows 95 - it hangs at the splash screen.
+
+   Sharing ibmxt_config previously made that failure mode *silent and very hard to diagnose*: the
+   1986 ROM entries are not in the stock shared list, so a `bios = ibm5160_050986` line in a config
+   file was not a valid option, was ignored without any warning, and selection fell back to the
+   1982 default. Listing only the compatible revisions here makes the incompatible ones
+   unselectable by construction. */
+static const device_config_t ibmxt_inboard386_config[] = {
+  // clang-format off
+    {
+        .name           = "bios",
+        .description    = "BIOS",
+        .type           = CONFIG_BIOS,
+        .default_string = "ibm5160_050986",
+        .default_int    = 0,
+        .file_filter    = "",
+        .spinner        = { 0 },
+        .bios           = {
+            {
+                .name          = "1501512 (05/09/86)",
+                .internal_name = "ibm5160_050986",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 0,
+                .size          = 65536,
+                .files         = { "roms/machines/ibmxt86/BIOS_5160_09MAY86_U18_59X7268_62X0890_27256_F800.BIN",
+                                   "roms/machines/ibmxt86/BIOS_5160_09MAY86_U19_62X0819_68X4370_27256_F000.BIN", "" }
+            },
+            {
+                .name          = "5000026 (01/10/86)",
+                .internal_name = "ibm5160_011086",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 2,
+                .local         = 0,
+                .size          = 65536,
+                .files         = { "roms/machines/ibmxt86/BIOS_5160_10JAN86_U18_62X0851_27256_F800.BIN",
+                                   "roms/machines/ibmxt86/BIOS_5160_10JAN86_U19_62X0854_27256_F000.BIN", "" }
+            },
+            { .files_no = 0 }
+        }
+    },
+    {
+        .name           = "enable_5161",
+        .description    = "IBM 5161 Expansion Unit",
+        .type           = CONFIG_BINARY,
+        .default_string = NULL,
+        .default_int    = 1,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .selection      = { { 0 } },
+        .bios           = { { 0 } }
+    },
+    {
+        .name           = "enable_basic",
+        .description    = "IBM Cassette Basic",
+        .type           = CONFIG_BINARY,
+        .default_string = NULL,
+        .default_int    = 1,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .selection      = { { 0 } },
+        .bios           = { { 0 } }
+    },
+    { .name = "", .description = "", .type = CONFIG_END }
+  // clang-format on
+};
+
 const device_t ibmxt_inboard386_device = {
     .name          = "IBM XT (Inboard 386/PC)",
     .internal_name = "ibmxt_inboard386",
@@ -634,7 +711,7 @@ const device_t ibmxt_inboard386_device = {
     .available     = NULL,
     .speed_changed = NULL,
     .force_redraw  = NULL,
-    .config        = ibmxt_config /* Same real ROM chips - reuse the exact same BIOS selection. */
+    .config        = ibmxt_inboard386_config /* 1986 ROM revisions only - see comment above. */
 };
 
 int
@@ -703,6 +780,13 @@ machine_ibmxt_inboard386_init(const machine_t *model)
         device_add(&ibm_5161_device);
 
     device_add(&inboard386_xt_device); /* The Inboard 386/PC accelerator card itself. */
+
+    /* Intek21 TK9901 ECP/EPP parallel card (slot 7, IRQ 7 on the real machine). Standard
+       (non-ECP/EPP) parallel port - was present in this project's own local fork but never
+       included in PR #7626 (this file wasn't fully ported - the function returned early). */
+    lpt_t *lpt = device_add_inst(&lpt_port_device, 1);
+    lpt_port_setup(lpt, LPT1_ADDR);
+    lpt_port_irq(lpt, LPT1_IRQ);
 
     return ret;
 }


### PR DESCRIPTION
# Inboard 386/PC: fix POST 101, and make non-486BL CPUs work

Follow-up to #7626. First of all, apologies — both for the holes left in the original submission and
for the delay in getting back to this; I was away on vacation and could not pick it up until now.
Thanks to @QuantumByteRider for the report, and for the detail in it, which turned out to point
straight at the real problem.

Both items from that report are addressed:

| Reported on #7626 | Status |
|---|---|
| `The BIOS gives error 101 at POST` | Fixed — root cause in section 1 below |
| `the "(1988) i386SX" Machine entry is Duplicated` | Already corrected in-tree by someone else; confirmed only one entry remains on current master |
| #7638 — memory reported "BAD", closed not-planned | Same root cause; fixed. See section 5 |

The original PR shipped a machine that did not work out of the box. Two separate causes: I excluded
whole files from the submission as "debug scaffolding" and silently dropped real fixes tangled inside
them, and — the actual cause of the POST 101 — the machine defaulted to a BIOS revision it cannot
work with. Both are addressed here, along with two further defects found while validating the fix.

## 1. The reported POST 101 — an incompatible BIOS was selectable, and was the default

`INBRDPC.SYS` v1.1 (02/17/89), the card's own required DOS driver, verifies a 3-byte signature at
`F000:E05B` as part of its ROM-shadow self-check. **The 1982-dated 5160 ROMs do not carry that
signature**, so the driver cannot work with them. This is a genuine ROM-revision mismatch, not an
emulation gap — real Inboard installations of that era paired with a later ROM revision.

`ibmxt_inboard386_device` shared `ibmxt_config`, whose `.default_string` is the 1982 ROM. So
selecting the machine and pressing go booted an incompatible BIOS, which is exactly the reported
POST 101.

It was also failing *silently*, which is what made it hard to spot: the 1986 revisions were not in
that shared list at all, so a `bios = ibm5160_050986` line in a config file was not a valid option,
was ignored with no warning or log line, and fell back to the 1982 default. Locally I had added
those entries to `ibmxt_config`, so it worked on my tree and not on anyone else's — my mistake, and
the reason I could not initially reproduce what was reported.

**Fix:** the machine now has its own `ibmxt_inboard386_config[]` listing only the two compatible 1986
revisions (`ibm5160_050986` as default, plus `ibm5160_011086`). This makes the incompatible ROMs
unselectable by construction rather than merely discouraged. `ibmxt_config` is deliberately left
untouched, so the plain IBM XT machine is unaffected.

If you would prefer this expressed differently — e.g. keeping the shared list and filtering, or
allowing the 1982 ROMs with a warning — I am happy to rework it.

## 2. POST fix-ups never ran on 386-class CPUs

`cpu_set()` routes 386DX/386SX to `exec386_2386()` and 486BL/486DLC-class parts to `exec386()`. All
of the Inboard POST fix-ups lived only in `exec386()`. Selecting a plain 386DX — the CPU this
accelerator was actually sold to pair with — therefore ran with none of them and hung in the ATI
Mach8 option ROM's PIT delay loop, before the memory count. It presented as a beep followed by a
black screen, which looks like a video or speed problem and is neither.

**Fix:** the fix-ups now live in one shared `inboard_post_fixups()`, called from both interpreter
loops at the same point in each.

**On blast radius**, since this touches the hottest loop in the emulator and I would ask the same
question in review: both call sites are gated on `inboard386_present`, a flag set only while the
card's device is actually instantiated. On every other machine the cost is one predictable,
well-predicted test per instruction and nothing inside the function can run. That gate is load-bearing
rather than belt-and-braces — most of the individual fix-ups are address-gated to this BIOS's own
self-test code and would genuinely be inert anywhere else, but two are segment-scoped (`CS == 0xC000`
for the Mach8 option ROM, `CS == 0x0EAF` for the VMM32 `INT 68h` vector) and an unrelated guest could
otherwise reach them. Caught while preparing this PR; called out here rather than left implicit.

## 3. Double-throttled memory timing on 386-class CPUs

`inboard386_apply_waitstates()` also drove `cpu_waitstates`, which `cpu_update_waitstates()` honours
only for `CPU_286..CPU_386DX`. It was dead on 486BL but live on 386DX, where it stacked on top of
`inboard386_apply_mem_timing()`'s own bus-speed-scaled override of the same variables
(`cpu_cycles_read`/`write`/`prefetch`), compounding with `io_waitstates` and `reg_op_waitstates`.
The 386-class parts ran an order of magnitude too slow as a result.

**Fix:** zeroed there, so exactly one memory-timing mechanism is ever in play.

## 4. Fixes dropped from the original submission, restored

Excluding whole files as "debug scaffolding" also dropped real fixes: the 83.5 MHz CPU table entry
(`cpu_table.c`), the XT keyboard acknowledgment self-heal (`kbc_xt.c`), and the standard parallel
port in `machine_ibmxt_inboard386_init()` (the real machine has an Intek21 TK9901 card in slot 7;
the port setup was in my tree but the function returned before reaching it in what was submitted).
All are included here, without the debug code that caused me to exclude them in the first place.

The duplicate `(1988) i386SX` machine entry, also reported, was already corrected in-tree — thank you.

## 5. This also resolves #7638 (memory reported "BAD")

Issue #7638 — "386 Inboard PC memory configuration error", closed not-planned — is the same root
cause. `INBRDPC.SYS` reported all memory as "BAD" with only 640K usable regardless of `mem_size`,
because that reporter's config has no `bios=` line and was therefore on the 1982 ROM, against which
the driver's ROM-shadow self-check cannot pass. Confirmed by testing. They were also running
`cpu_family = i386dx`, so they were hitting defect 2 at the same time — an incompatible ROM *and* a
CPU family running none of the fix-ups.

The RAM-size dropdown granularity also raised in that issue is separate and expected behaviour;
@OBattler's answer there (use 3072 / 5120) was correct.

That issue carried a suggestion to move this machine to a dev branch "until documentation of the
actual board is found", which was a fair call given the state it was in. The documentation does
exist and this port is built on it — Intel's own manual, disassembly of `INBRDPC.SYS`, cross-checked
against SuperFury's UniPCemu implementation and Al Williams' original 1990 `a20()` code — and with
this PR the machine boots to a working desktop across the configurations below. I have asked for a
re-test there rather than assuming it is closed.

## Testing

Verified booting through POST to a working Windows 95 desktop:

| Configuration | Result |
|---|---|
| `ibm5160_050986` (09MAY86) + ATI Mach8, 486BL3/83.5 | pass |
| `ibm5160_011086` (10JAN86) + ATI Mach8 | pass |
| **Default settings, no `bios=` line** — the exact reported case | pass |
| `i386DX`/25 MHz + ATI Mach8 | pass |

No POST 101 or 301 in any of the above.

## Known limitations, stated honestly

- With the generic `vga` card the machine boots, but POST stops for an F1 keypress before continuing;
  it then reaches the desktop normally. The Mach8 path does not do this. I have added a range-based
  safety net so the affected self-test gate can no longer stick permanently, but I have not fully
  characterised this one and would rather flag it than quietly ship it.
- Not yet exercised: `am386dx`, `ibm486bl2`, `ibm486slc3`, and the ET4000 / ATI28800 / Trident cards.
  No reason to expect problems, but I have not run them, so I am not claiming them.
- Windows 95 requires VGA-class video; CGA is fine for DOS-level testing only.

Happy to take this in whatever direction suits the project — and sorry again for the state the first
submission was in.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
