### PR TITLE
Implement the ESS AudioDrive ES488 and ES1488 sound cards

### DIFF
--- a/src/include/86box/snd_sb_dsp.h
+++ b/src/include/86box/snd_sb_dsp.h
@@ -4,26 +4,28 @@
 #include <86box/fifo.h>
 
 /*Sound Blaster Clones, for quirks*/
-#define SB_SUBTYPE_DEFAULT             0 /* Handle as a Creative card */
-#define SB_SUBTYPE_CLONE_AZT2316A_0X11 1 /* Aztech Sound Galaxy Pro 16 AB, DSP 3.1 - SBPRO2 clone */
-#define SB_SUBTYPE_CLONE_AZT1605_0X0C  2 /* Aztech Sound Galaxy Nova 16 Extra /
-                                            Packard Bell Forte 16, DSP 2.1 - SBPRO2 clone */
-#define SB_SUBTYPE_CLONE_AZTPR16_0X09  3 /* Aztech Sound Galaxy Pro 16 Extra */
-#define SB_SUBTYPE_CLONE_AZT2316R_0X12 4 /* Aztech Sound Galaxy Pro 16 II */
-#define SB_SUBTYPE_CLONE_AZT2320_0X13  5 /* Aztech AZT2320 */
-#define SB_SUBTYPE_MVD201              6 /* Mediavision MVD201, found on the thunderboard and PAS16 */
-#define SB_SUBTYPE_YMF7XX              7 /* Yamaha YMF-701/71x */
-#define SB_SUBTYPE_ESS_ES688           8 /* ESS Technology ES688 */
-#define SB_SUBTYPE_ESS_ES1688          9 /* ESS Technology ES1688 */
-#define SB_SUBTYPE_ESS_ES1788        0xa /* ESS Technology ES1788 */
-#define SB_SUBTYPE_ESS_ES1888        0xb /* ESS Technology ES1888 */
-#define SB_SUBTYPE_ESS_ES1887        0xc /* ESS Technology ES1887 */
-#define SB_SUBTYPE_ESS_ES1868        0xd /* ESS Technology ES1868 */
-#define SB_SUBTYPE_ESS_ES1869        0xe /* ESS Technology ES1869 */
+#define SB_SUBTYPE_DEFAULT             0  /* Handle as a Creative card */
+#define SB_SUBTYPE_CLONE_AZT2316A_0X11 1  /* Aztech Sound Galaxy Pro 16 AB, DSP 3.1 - SBPRO2 clone */
+#define SB_SUBTYPE_CLONE_AZT1605_0X0C  2  /* Aztech Sound Galaxy Nova 16 Extra /
+                                             Packard Bell Forte 16, DSP 2.1 - SBPRO2 clone */
+#define SB_SUBTYPE_CLONE_AZTPR16_0X09  3  /* Aztech Sound Galaxy Pro 16 Extra */
+#define SB_SUBTYPE_CLONE_AZT2316R_0X12 4  /* Aztech Sound Galaxy Pro 16 II */
+#define SB_SUBTYPE_CLONE_AZT2320_0X13  5  /* Aztech AZT2320 */
+#define SB_SUBTYPE_MVD201              6  /* Mediavision MVD201, found on the thunderboard and PAS16 */
+#define SB_SUBTYPE_YMF7XX              7  /* Yamaha YMF-701/71x */
+#define SB_SUBTYPE_ESS_ES488           8  /* ESS Technology ES488 */
+#define SB_SUBTYPE_ESS_ES1488          9  /* ESS Technology ES1488 */
+#define SB_SUBTYPE_ESS_ES688         0xa  /* ESS Technology ES688 */
+#define SB_SUBTYPE_ESS_ES1688        0xb  /* ESS Technology ES1688 */
+#define SB_SUBTYPE_ESS_ES1788        0xc  /* ESS Technology ES1788 */
+#define SB_SUBTYPE_ESS_ES1888        0xd  /* ESS Technology ES1888 */
+#define SB_SUBTYPE_ESS_ES1887        0xe  /* ESS Technology ES1887 */
+#define SB_SUBTYPE_ESS_ES1868        0xf  /* ESS Technology ES1868 */
+#define SB_SUBTYPE_ESS_ES1869        0x10 /* ESS Technology ES1869 */
 
 /* ESS-related */
-#define IS_ESS(dsp) ((dsp)->sb_subtype >= SB_SUBTYPE_ESS_ES688)    /* Check for future ESS cards here */
-#define IS_NOT_ESS(dsp) ((dsp)->sb_subtype < SB_SUBTYPE_ESS_ES688) /* Check for future ESS cards here */
+#define IS_ESS(dsp) ((dsp)->sb_subtype >= SB_SUBTYPE_ESS_ES488)    /* Check for future ESS cards here */
+#define IS_NOT_ESS(dsp) ((dsp)->sb_subtype < SB_SUBTYPE_ESS_ES488) /* Check for future ESS cards here */
 
 /* aztech-related */
 #define IS_AZTECH(dsp)     ((dsp)->sb_subtype == SB_SUBTYPE_CLONE_AZT2320_0X13 || (dsp)->sb_subtype == SB_SUBTYPE_CLONE_AZT2316R_0X12 || (dsp)->sb_subtype == SB_SUBTYPE_CLONE_AZT2316A_0X11 || (dsp)->sb_subtype == SB_SUBTYPE_CLONE_AZT1605_0X0C || (dsp)->sb_subtype == SB_SUBTYPE_CLONE_AZTPR16_0X09) /* check for future AZT cards here */
@@ -206,6 +208,11 @@ typedef struct sb_dsp_t {
 
     /* ESS ES1869 DAC1 divider mode */
     uint8_t  es1869_divider_mode;
+
+    /* ESS ES488 mixer */
+    double  es488_voice;
+    uint8_t es488_voice_reg;
+    uint8_t es488_source;
 
     mpu_t *mpu;
 } sb_dsp_t;

--- a/src/include/86box/snd_sb_dsp.h
+++ b/src/include/86box/snd_sb_dsp.h
@@ -174,6 +174,7 @@ typedef struct sb_dsp_t {
     uint8_t  ess_extended_mode;
     uint8_t  ess_reload_len;
     uint32_t ess_dma_counter;
+    uint8_t  ess_input_gain;
 
     /* IRQ status flags (0x22C) */
     uint8_t  ess_irq_generic;

--- a/src/include/86box/sound.h
+++ b/src/include/86box/sound.h
@@ -244,6 +244,8 @@ extern const device_t cs4237b_device;
 extern const device_t cs4238b_device;
 
 /* ESS Technology */
+extern const device_t ess_488_device;
+extern const device_t ess_1488_device;
 extern const device_t ess_688_device;
 extern const device_t ess_ess0100_pnp_device;
 extern const device_t ess_ess0968_pnp_688_device;

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -816,6 +816,51 @@ sb16_awe32_filter_midi(int channel, double *buffer, void *priv)
 void ess_dac2_update(void *priv);
 
 void
+sb_get_buffer_ess488(int32_t *buffer, uint16_t len, void *priv)
+{
+    sb_t              *ess   = (sb_t *) priv;
+
+    sb_dsp_update(&ess->dsp);
+
+    for (int c = 0; c < len * 2; c += 2) {
+        double out_l = 0.0;
+        double out_r = 0.0;
+
+        if (ess->dsp.sb_speaker)
+            out_l = out_r += (low_fir_sb16(1, (double) ess->dsp.buffer[c]) * ess->dsp.es488_voice) / 3.0;
+
+        buffer[c] += (int32_t) out_l;
+        buffer[c + 1] += (int32_t) out_r;
+    }
+
+    ess->dsp.pos = 0;
+}
+
+static void
+sb_get_music_buffer_ess488(int32_t *buffer, uint16_t len, void *priv)
+{
+    const sb_t              *ess      = (const sb_t *) priv;
+    const int32_t           *opl_buf = NULL;
+
+    opl_buf = ess->opl.update(ess->opl.priv);
+
+    for (uint16_t c = 0; c < len * 2; c += 2) {
+        double out_l = 0.0;
+        double out_r = 0.0;
+
+        const double out_mono = ((double) opl_buf[c]) * 0.7171630859375;
+
+        out_l += out_mono;
+        out_r += out_mono;
+
+        buffer[c] += (int32_t) out_l;
+        buffer[c + 1] += (int32_t) out_r;
+    }
+
+    ess->opl.reset_buffer(ess->opl.priv);
+}
+
+void
 sb_get_buffer_ess(int32_t *buffer, uint16_t len, void *priv)
 {
     sb_t              *ess   = (sb_t *) priv;
@@ -839,6 +884,9 @@ sb_get_buffer_ess(int32_t *buffer, uint16_t len, void *priv)
         /* TODO: recording from the mixer. */
         out_l *= mixer->master_l;
         out_r *= mixer->master_r;
+
+        if (ess->dsp.sb_subtype == SB_SUBTYPE_ESS_ES1488)
+            out_r = out_l;
 
         buffer[c] += (int32_t) out_l;
         buffer[c + 1] += (int32_t) out_r;
@@ -890,6 +938,9 @@ sb_get_music_buffer_ess(int32_t *buffer, uint16_t len, void *priv)
         /* TODO: recording from the mixer. */
         out_l *= mixer->master_l;
         out_r *= mixer->master_r;
+
+        if (ess->dsp.sb_subtype == SB_SUBTYPE_ESS_ES1488)
+            out_r = out_l;
 
         buffer[c] += (int32_t) out_l;
         buffer[c + 1] += (int32_t) out_r;
@@ -5478,6 +5529,84 @@ sb_awe32_pnp_init(const device_t *info)
 }
 
 static void *
+ess_x488_init(UNUSED(const device_t *info))
+{
+    sb_t          *ess      = calloc(sizeof(sb_t), 1);
+    const uint16_t addr     = device_get_config_hex16("base");
+
+    fm_driver_get(FM_YM3812, &ess->opl);
+
+    sb_dsp_set_real_opl(&ess->dsp, 1);
+    sb_dsp_init(&ess->dsp, SB_DSP_201, info->local ? SB_SUBTYPE_ESS_ES1488 : SB_SUBTYPE_ESS_ES488, ess);
+    sb_dsp_setaddr(&ess->dsp, addr);
+    sb_dsp_setirq(&ess->dsp, device_get_config_int("irq"));
+    sb_dsp_setdma8(&ess->dsp, device_get_config_int("dma"));
+    sb_dsp_setdma16_8(&ess->dsp, device_get_config_int("dma"));
+    sb_dsp_setdma16_supported(&ess->dsp, 0);
+
+    if (ess->dsp.sb_subtype == SB_SUBTYPE_ESS_ES1488)
+        ess_mixer_reset(ess);
+
+    /* DSP I/O handler is activated in sb_dsp_setaddr */
+    io_sethandler(addr, 0x0002,
+                  ess->opl.read, NULL, NULL,
+                  ess->opl.write, NULL, NULL,
+                  ess->opl.priv);
+    io_sethandler(addr + 8, 0x0002,
+                  ess->opl.read, NULL, NULL,
+                  ess->opl.write, NULL, NULL,
+                  ess->opl.priv);
+    io_sethandler(addr + 8, 0x0002,
+                  ess_fm_midi_read, NULL, NULL,
+                  ess_fm_midi_write, NULL, NULL,
+                  ess);
+    io_sethandler(0x0388, 0x0002,
+                  ess->opl.read, NULL, NULL,
+                  ess->opl.write, NULL, NULL,
+                  ess->opl.priv);
+    io_sethandler(0x0388, 0x0002,
+                  ess_fm_midi_read, NULL, NULL,
+                  ess_fm_midi_write, NULL, NULL,
+                  ess);
+    io_sethandler(addr + 2, 0x0003,
+                  ess_base_read, NULL, NULL,
+                  ess_base_write, NULL, NULL,
+                  ess);
+    io_sethandler(addr + 6, 0x0001,
+                  ess_base_read, NULL, NULL,
+                  ess_base_write, NULL, NULL,
+                  ess);
+    io_sethandler(addr + 0x0a, 0x0006,
+                  ess_base_read, NULL, NULL,
+                  ess_base_write, NULL, NULL,
+                  ess);
+    if (ess->dsp.sb_subtype == SB_SUBTYPE_ESS_ES1488) {
+        ess->mixer_enabled = 1;
+        ess->mixer_ess.regs[0x40] = 0x0a;
+        io_sethandler(addr + 2, 0x0002,
+                      ess_mixer_read, NULL, NULL,
+                      ess_mixer_write, NULL, NULL,
+                      ess);
+        sound_add_handler(sb_get_buffer_ess, ess);
+        music_add_handler(sb_get_music_buffer_ess, ess);
+        sound_set_cd_audio_filter(ess_filter_cd_audio, ess);
+    } else {
+        sound_add_handler(sb_get_buffer_ess488, ess);
+        music_add_handler(sb_get_music_buffer_ess488, ess);
+    }
+
+    if (device_get_config_int("receive_input"))
+        midi_in_handler(1, sb_dsp_input_msg, sb_dsp_input_sysex, &ess->dsp);
+
+    if (device_get_config_int("gameport")) {
+        ess->gameport      = gameport_add(&gameport_200_device);
+        ess->gameport_addr = 0x200;
+    }
+
+    return ess;
+}
+
+static void *
 ess_x688_init(UNUSED(const device_t *info))
 {
     sb_t          *ess      = calloc(sizeof(sb_t), 1);
@@ -7721,6 +7850,81 @@ static const device_config_t sb_awe64_gold_config[] = {
     { .name = "", .description = "", .type = CONFIG_END }
 };
 
+static const device_config_t ess_488_config[] = {
+    {
+        .name           = "base",
+        .description    = "Address",
+        .type           = CONFIG_HEX16,
+        .default_string = NULL,
+        .default_int    = 0x220,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .selection      = {
+            { .description = "0x220", .value = 0x220 },
+            { .description = "0x230", .value = 0x230 },
+            { .description = "0x240", .value = 0x240 },
+            { .description = "0x250", .value = 0x250 },
+            { .description = ""                      }
+        },
+        .bios           = { { 0 } }
+    },
+    {
+        .name           = "irq",
+        .description    = "IRQ",
+        .type           = CONFIG_SELECTION,
+        .default_string = NULL,
+        .default_int    = 5,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .selection      = {
+            { .description =  "IRQ 2", .value =  2 },
+            { .description =  "IRQ 3", .value =  3 },
+            { .description =  "IRQ 5", .value =  5 },
+            { .description =  "IRQ 7", .value =  7 },
+            { .description = ""                    }
+        },
+        .bios           = { { 0 } }
+    },
+    {
+        .name           = "dma",
+        .description    = "DMA",
+        .type           = CONFIG_SELECTION,
+        .default_string = NULL,
+        .default_int    = 1,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .selection      = {
+            { .description = "DMA 1", .value = 1 },
+            { .description = "DMA 3", .value = 3 },
+            { .description = ""                  }
+        },
+        .bios           = { { 0 } }
+    },
+    {
+        .name           = "gameport",
+        .description    = "Enable Game port",
+        .type           = CONFIG_BINARY,
+        .default_string = NULL,
+        .default_int    = 0,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .selection      = { { 0 } },
+        .bios           = { { 0 } }
+    },
+    {
+        .name           = "receive_input",
+        .description    = "Receive MIDI input",
+        .type           = CONFIG_BINARY,
+        .default_string = NULL,
+        .default_int    = 1,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .selection      = { { 0 } },
+        .bios           = { { 0 } }
+    },
+    { .name = "", .description = "", .type = CONFIG_END }
+};
+
 static const device_config_t ess_688_config[] = {
     {
         .name           = "base",
@@ -8509,6 +8713,34 @@ const device_t sb_awe64_gold_device = {
     .speed_changed = sb_speed_changed,
     .force_redraw  = NULL,
     .config        = sb_awe64_gold_config
+};
+
+const device_t ess_488_device = {
+    .name          = "ESS AudioDrive ES488",
+    .internal_name = "ess_es488",
+    .flags         = DEVICE_ISA,
+    .local         = 0,
+    .init          = ess_x488_init,
+    .close         = sb_close,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = sb_speed_changed,
+    .force_redraw  = NULL,
+    .config        = ess_488_config
+};
+
+const device_t ess_1488_device = {
+    .name          = "ESS AudioDrive ES1488",
+    .internal_name = "ess_es1488",
+    .flags         = DEVICE_ISA,
+    .local         = 1,
+    .init          = ess_x488_init,
+    .close         = sb_close,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = sb_speed_changed,
+    .force_redraw  = NULL,
+    .config        = ess_488_config
 };
 
 const device_t ess_688_device = {

--- a/src/sound/snd_sb_dsp.c
+++ b/src/sound/snd_sb_dsp.c
@@ -270,6 +270,14 @@ uint16_t espcm3_dpcm_tables[1024] =
        5,   7,   8,   9,  10,  11,  12, 270,   5,   7,   8,   9,  10,  11,  12, 270,
        6,   7,   8,   9,  10,  11,  13, 271,   6,   7,   8,   9,  10,  11,  13,  15
 };
+
+/* Attenuation table for ESS 4-bit mixer volume.
+ * The last step is a jump to -48 dB. */
+static const double es488_att_2dbstep_4bits[] = {
+      164.0,  1304.0,  1641.0,  2067.0,  2602.0,  3276.0,  4125.0,  5192.0,
+     6537.0,  8230.0, 10362.0, 13044.0, 16422.0, 20674.0, 26027.0, 32767.0
+};
+
 // clang-format on
 
 double low_fir_sb16_coef[SB16_NCoef];
@@ -1798,10 +1806,17 @@ sb_exec_command(sb_dsp_t *dsp)
             } else if (IS_ESS(dsp)) /* Unknown command, always returns 1 on newer chips per the datasheets */
                 sb_add_data(dsp, 1);
             break;
-        case 0xD6: /* Continue 16-bit DMA */
+        case 0xD6: /* Continue 16-bit DMA (SB16+)/Get Recording Source (ES488) */
             if (dsp->sb_type >= SB16_DSP_404) {
                 dsp->sb_16_pause = 0;
                 sb_resume_dma(dsp, 1);
+            } else if (IS_ESS(dsp) && (dsp->sb_subtype == SB_SUBTYPE_ESS_ES488))
+                sb_add_data(dsp, dsp->es488_source);
+            break;
+        case 0xD7: /* Set Recording Source (ES488) */
+            if (IS_ESS(dsp) && (dsp->sb_subtype == SB_SUBTYPE_ESS_ES488)) {
+                sb_dsp_log("ES488 set record source: val = %02X\n", dsp->sb_data[0]);
+                dsp->es488_source = dsp->sb_data[0];
             }
             break;
         case 0xD8: /* Get speaker status */
@@ -1823,6 +1838,18 @@ sb_exec_command(sb_dsp_t *dsp)
         case 0xDD: /* Write current input gain (ESS) */
             if (IS_ESS(dsp))
                 dsp->ess_input_gain = dsp->sb_data[0];
+            break;
+        case 0xDE: /* Get Wave Volume (ES488) */
+            if (IS_ESS(dsp) && (dsp->sb_subtype == SB_SUBTYPE_ESS_ES488))
+                sb_add_data(dsp, dsp->es488_voice_reg);
+            break;
+        case 0xDF: /* Set Wave Volume (ES488) */
+            sb_dsp_log("ES488 set volume command\n");
+            if (IS_ESS(dsp) && (dsp->sb_subtype == SB_SUBTYPE_ESS_ES488)) {
+                sb_dsp_log("ES488 set output volume: val = %02X\n", dsp->sb_data[0]);
+                dsp->es488_voice_reg = dsp->sb_data[0];
+                dsp->es488_voice = es488_att_2dbstep_4bits[dsp->es488_voice_reg & 0x0F] / 32767.0;
+            }
             break;
         case 0xE0: /* DSP identification */
             sb_add_data(dsp, ~dsp->sb_data[0]);
@@ -1846,7 +1873,7 @@ sb_exec_command(sb_dsp_t *dsp)
                    ES1888 datasheet and the probing of the real ES688 and ES1688 cards.
                  */
                 /* Some ES688/1688 ISA cards have a jumper to set DSP version 2.01 */
-                if (dsp->ess_dsp_v2_mode == 1) {
+                if ((dsp->ess_dsp_v2_mode == 1) || (dsp->sb_subtype == SB_SUBTYPE_ESS_ES488) || (dsp->sb_subtype == SB_SUBTYPE_ESS_ES1488)) {
                     sb_add_data(dsp, 0x2);
                     sb_add_data(dsp, 0x1);
                 } else {
@@ -1925,6 +1952,14 @@ sb_exec_command(sb_dsp_t *dsp)
             if (IS_ESS(dsp)) {
                 switch (dsp->sb_subtype) {
                     default:
+                        break;
+                    case SB_SUBTYPE_ESS_ES488:
+                        sb_add_data(dsp, 0x48);
+                        sb_add_data(dsp, 0x80 | 0x01);
+                        break;
+                    case SB_SUBTYPE_ESS_ES1488:
+                        sb_add_data(dsp, 0x48);
+                        sb_add_data(dsp, 0x80 | 0x09);
                         break;
                     case SB_SUBTYPE_ESS_ES688:
                         sb_add_data(dsp, 0x68);

--- a/src/sound/snd_sb_dsp.c
+++ b/src/sound/snd_sb_dsp.c
@@ -1411,8 +1411,21 @@ sb_exec_command(sb_dsp_t *dsp)
             ESSreg(0xA1) = 128 - (397700 / 22050);
             ESSreg(0xA2) = 256 - (7160000 / (82 * ((4 * 22050) / 10)));
             break;
+        case 0x11: /* ESS 16-bit direct mode */
+            if (IS_ESS(dsp)) {
+                sb_dsp_update(dsp);
+                dsp->sbdat = dsp->sbdatl = dsp->sbdatr = (int16_t) (((dsp->sb_data[1] ^ 0x80) << 8) | (dsp->sb_data[0] ^ 0x80));
+                // FIXME: What does the ESS AudioDrive do to its filter/sample rate divider registers when emulating this Sound Blaster command?
+                ESSreg(0xA1) = 128 - (397700 / 22050);
+                ESSreg(0xA2) = 256 - (7160000 / (82 * ((4 * 22050) / 10)));
+            }
+            break;
         case 0x14: /* 8-bit single cycle DMA output */
             sb_start_dma(dsp, 1, 0, 0, dsp->sb_data[0] + (dsp->sb_data[1] << 8));
+            break;
+        case 0x15: /* ESS 16-bit single cycle DMA output */
+            if (IS_ESS(dsp))
+                sb_start_dma(dsp, 0, 0, 0, dsp->sb_data[0] + (dsp->sb_data[1] << 8));
             break;
         case 0x17: /* 2-bit ADPCM output with reference */
             dsp->sbref  = dsp->dma_readb(dsp->dma_priv);
@@ -1431,6 +1444,12 @@ sb_exec_command(sb_dsp_t *dsp)
         case 0x1C: /* 8-bit autoinit DMA output */
             if (dsp->sb_type >= SB_DSP_200)
                 sb_start_dma(dsp, 1, 1, 0, dsp->sb_8_autolen);
+            break;
+        case 0x1D: /* ESS 16-bit autoinit DMA output */
+            if (IS_ESS(dsp)) {
+                dsp->sb_16_autolen = dsp->sb_8_autolen;
+                sb_start_dma(dsp, 0, 1, 0, dsp->sb_8_autolen);
+            }
             break;
         case 0x1F: /* 2-bit ADPCM autoinit output */
             if (dsp->sb_type >= SB_DSP_200) {
@@ -1452,14 +1471,39 @@ sb_exec_command(sb_dsp_t *dsp)
                 timer_set_delay_u64(&dsp->input_timer, (uint64_t) dsp->sblatchi);
             }
             break;
+        case 0x21: /* ESS 16-bit direct input */
+            if (IS_ESS(dsp)) {
+                sb_add_data(dsp, (dsp->record_buffer[dsp->record_pos_read]) ^ 0x80);
+                sb_add_data(dsp, (dsp->record_buffer[dsp->record_pos_read] >> 8) ^ 0x80);
+                /* Due to the current implementation, I need to emulate a samplerate, even if this
+                   mode does not imply such samplerate. Position is increased in sb_poll_i(). */
+                if (!timer_is_enabled(&dsp->input_timer)) {
+                    dsp->sb_timei = 256 - 22;
+                    dsp->sblatchi = (double) ((double) TIMER_USEC * 22.0);
+                    temp          = 1000000 / 22;
+                    dsp->sb_freq  = temp;
+                    timer_set_delay_u64(&dsp->input_timer, (uint64_t) dsp->sblatchi);
+                }
+            }
+            break;
         case 0x24: /* 8-bit single cycle DMA input */
             sb_start_dma_i(dsp, 1, 0, 0, dsp->sb_data[0] + (dsp->sb_data[1] << 8));
+            break;
+        case 0x25: /* ESS 16-bit single cycle DMA input */
+            if (IS_ESS(dsp))
+                sb_start_dma_i(dsp, 0, 0, 0, dsp->sb_data[0] + (dsp->sb_data[1] << 8));
             break;
         case 0x28: /* Direct ADC, 8-bit (Burst) */
             break;
         case 0x2C: /* 8-bit autoinit DMA input */
             if (dsp->sb_type >= SB_DSP_200)
                 sb_start_dma_i(dsp, 1, 1, 0, dsp->sb_data[0] + (dsp->sb_data[1] << 8));
+            break;
+        case 0x2D: /* ESS 16-bit autoinit DMA output */
+            if (IS_ESS(dsp)) {
+                dsp->sb_16_autolen = dsp->sb_data[0] + (dsp->sb_data[1] << 8);
+                sb_start_dma_i(dsp, 0, 1, 0, dsp->sb_data[0] + (dsp->sb_data[1] << 8));
+            }
             break;
         case 0x30: /* MIDI Polling mode input */
             sb_dsp_log("MIDI polling mode input\n");
@@ -1509,8 +1553,17 @@ sb_exec_command(sb_dsp_t *dsp)
                 sb_ess_update_filter_freq(dsp);
             }
             break;
-        case 0x41: /* Set output sampling rate */
-        case 0x42: /* Set input sampling rate */
+        case 0x41: /* Set output sampling rate (SB16+)/Alternate set time constant (ESS) */
+            if (IS_ESS(dsp)) {
+                dsp->sb_timei = dsp->sb_timeo = dsp->sb_data[0];
+                temp = dsp->sb_freq = (int) (1500000 / (256ul - dsp->sb_data[0]));
+                double newlatch = 1000000.0 / dsp->sb_freq;
+                dsp->sblatchi = dsp->sblatcho = ((double) TIMER_USEC * newlatch);
+                sb_dsp_log("Sample rate - %ihz (%f)\n", temp, dsp->sblatcho);
+                sb_ess_update_filter_freq(dsp);
+                break;
+            }
+        case 0x42: /* Set input sampling rate (SB16+)/Set filter clock (ESS) */
             if (dsp->sb_type >= SB16_DSP_404) {
                 dsp->sblatcho = (double) ((double) TIMER_USEC * (1000000.0 / (double) (dsp->sb_data[1] + (dsp->sb_data[0] << 8))));
                 sb_dsp_log("Sample rate - %ihz (%f)\n", dsp->sb_data[1] + (dsp->sb_data[0] << 8), dsp->sblatcho);
@@ -1523,6 +1576,13 @@ sb_exec_command(sb_dsp_t *dsp)
                     recalc_sb16_filter(dsp->sb_freq);
                 dsp->sb_8051_ram[0x13] = dsp->sb_freq & 0xff;
                 dsp->sb_8051_ram[0x14] = (dsp->sb_freq >> 8) & 0xff;
+            } else if (IS_ESS(dsp)) {
+                const double freq  = (7160000.0 / (256.0 - ((double) dsp->sb_data[0]))) * 41.0;
+                const int    temp  = (int) freq;
+
+                if (dsp->sb_freq != temp)
+                    recalc_sb16_filter(temp);
+                dsp->sb_freq = temp;
             }
             break;
         case 0x45: /* Continue Auto-Initialize DMA, 8-bit */
@@ -1731,11 +1791,12 @@ sb_exec_command(sb_dsp_t *dsp)
             dsp->sb_8_pause = 0;
             sb_resume_dma(dsp, 1);
             break;
-        case 0xD5: /* Pause 16-bit DMA */
+        case 0xD5: /* Pause 16-bit DMA (SB16+)/Unknown (ESS) */
             if (dsp->sb_type >= SB16_DSP_404) {
                 dsp->sb_16_pause = 1;
                 sb_stop_dma(dsp);
-            }
+            } else if (IS_ESS(dsp)) /* Unknown command, always returns 1 on newer chips per the datasheets */
+                sb_add_data(dsp, 1);
             break;
         case 0xD6: /* Continue 16-bit DMA */
             if (dsp->sb_type >= SB16_DSP_404) {
@@ -1754,6 +1815,14 @@ sb_exec_command(sb_dsp_t *dsp)
         case 0xDA: /* Exit 8-bit auto-init mode */
             if (dsp->sb_type >= SB_DSP_200)
                 dsp->sb_8_autoinit = 0;
+            break;
+        case 0xDC: /* Read current input gain (ESS) */
+            if (IS_ESS(dsp))
+                sb_add_data(dsp, dsp->ess_input_gain);
+            break;
+        case 0xDD: /* Write current input gain (ESS) */
+            if (IS_ESS(dsp))
+                dsp->ess_input_gain = dsp->sb_data[0];
             break;
         case 0xE0: /* DSP identification */
             sb_add_data(dsp, ~dsp->sb_data[0]);
@@ -2011,7 +2080,13 @@ sb_write(uint16_t addr, uint8_t val, void *priv)
                 if (val == 0x01)
                     sb_add_data(dsp, 0);
                 dsp->sb_data_stat++;
-                if (IS_ESS(dsp) && dsp->sb_command >= 0x64 && dsp->sb_command <= 0x6F) {
+                if (IS_ESS(dsp) && (dsp->sb_command == 0x11 || dsp->sb_command == 0x15 || dsp->sb_command == 0x25))
+                    sb_commands[dsp->sb_command] = 2;
+                else if (IS_ESS(dsp) && (dsp->sb_command == 0x41 || dsp->sb_command == 0x42 || dsp->sb_command == 0xD7 || dsp->sb_command == 0xDD || dsp->sb_command == 0xDF))
+                    sb_commands[dsp->sb_command] = 1;
+                else if (IS_ESS(dsp) && (dsp->sb_command == 0x1D || dsp->sb_command == 0x21 || dsp->sb_command == 0x2D || dsp->sb_command == 0xD5 || dsp->sb_command == 0xD6 || dsp->sb_command == 0xDC || dsp->sb_command == 0xDE))
+                    sb_commands[dsp->sb_command] = 0;
+                else if (IS_ESS(dsp) && dsp->sb_command >= 0x64 && dsp->sb_command <= 0x6F) {
                     sb_commands[dsp->sb_command] = 2;
                 } else if (IS_ESS(dsp) && dsp->sb_command >= 0xA0 && dsp->sb_command <= 0xCF) {
                     if (dsp->sb_command <= 0xC0
@@ -2825,7 +2900,10 @@ pollsb(void *priv)
                 if (data[0] == DMA_NODATA)
                     break;
                 dsp->sbdatl = dsp->sbdatr = (int16_t) ((data[0] & 0xffff) ^ 0x8000);
-                dsp->sb_16_length--;
+                if (IS_ESS(dsp) && !dsp->ess_playback_mode)
+                    dsp->sb_16_length -= 2;
+                else
+                    dsp->sb_16_length--;
                 dsp->ess_dma_counter += 2;
                 break;
             case 0x10: /* Mono signed */
@@ -3053,7 +3131,10 @@ sb_poll_i(void *priv)
             case 0x00: /* Unsigned mono. As the manual says, only the left channel is recorded */
                 if (dsp->dma_writew(dsp->dma_priv, dsp->record_buffer[dsp->record_pos_read] ^ 0x8000))
                     return;
-                dsp->sb_16_length--;
+                if (IS_ESS(dsp) && !dsp->ess_playback_mode)
+                    dsp->sb_16_length -= 2;
+                else
+                    dsp->sb_16_length--;
                 dsp->ess_dma_counter += 2;
                 dsp->record_pos_read += 2;
                 dsp->record_pos_read &= 0xFFFF;

--- a/src/sound/sound.c
+++ b/src/sound/sound.c
@@ -143,6 +143,8 @@ static const SOUND_CARD sound_cards[] = {
     { &adgold_device                },
     { &soundmaster_device           },
     { &cms_device                   },
+    { &ess_488_device               },
+    { &ess_1488_device              },
     { &imfc_device                  },
     { &ssi2001_device               },
     { &thunderboard_device          },


### PR DESCRIPTION
Summary
=======
Implement the ESS AudioDrive ES488 and ES1488 sound cards. These are SB 2.0-compatible chips with support for 16-bit mono unsigned PCM playback and a mixer (a very basic one in the case of the ES488 that uses undocumented DSP commands and one that is very similar to the ESx688 mixer in the case of the ES1488.)

Also implemented several ESS-specific DSP commands that some drivers for these chips require (and can be used on later ESS chips per the datasheets.)

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
