### PR TITLE
Miscellaneous machine table and init changes

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -1175,6 +1175,10 @@ extern int             machine_at_p55t2s_init(const machine_t *);
 extern int             machine_at_ap5vm_init(const machine_t *);
 extern int             machine_at_p55tvp4_init(const machine_t *);
 extern int             machine_at_5ivg_init(const machine_t *);
+#ifdef EMU_DEVICE_H
+extern const device_t  pb810_device;
+#endif
+extern int             machine_at_pb810_init(const machine_t *);
 extern int             machine_at_8500tvxa_init(const machine_t *);
 extern int             machine_at_presario2240_init(const machine_t *);
 extern int             machine_at_presario4500_init(const machine_t *);
@@ -1191,7 +1195,6 @@ extern const device_t  lgibmx52_device;
 #endif
 extern int             machine_at_lgibmx52_init(const machine_t *);
 extern int             machine_at_pb680_init(const machine_t *);
-extern int             machine_at_pb810_init(const machine_t *);
 extern int             machine_at_mb520n_init(const machine_t *);
 extern int             machine_at_i430vx_init(const machine_t *);
 

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -921,6 +921,10 @@ extern int             machine_at_hot433a_init(const machine_t *);
 extern int             machine_at_g486vpa_init(const machine_t *);
 extern int             machine_at_486vipio2_init(const machine_t *);
 
+/* m_at_socket3_4.c */
+/* OPTi 571 */
+extern int             machine_at_pat45pv_init(const machine_t *);
+
 /* m_at_stpc.c */
 /* STPC Client */
 extern int             machine_at_itoxstar_init(const machine_t *);
@@ -938,9 +942,6 @@ extern int             machine_at_pcm9340_init(const machine_t *);
 
 /* STPC Atlas */
 extern int             machine_at_pcm5330_init(const machine_t *);
-
-/* m_at_socket3_4.c */
-extern int             machine_at_pat45pv_init(const machine_t *);
 
 /* m_at_socket4.c */
 /* i430LX */

--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -223,7 +223,7 @@ static const device_config_t fic4386vcv_config[] = {
                 .files         = { "roms/machines/fic4386vcv/486-4386-VC.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.20 - Revision 1.15K",
+                .name          = "AwardBIOS v4.20 - Revision 1.15K",
                 .internal_name = "fic4386vcv",
                 .bios_type     = BIOS_NORMAL, 
                 .files_no      = 1,

--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -325,7 +325,7 @@ static const device_config_t lx6_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision LY",
+                .name          = "AwardBIOS v4.51PG - Revision LY",
                 .internal_name = "lx6",
                 .bios_type     = BIOS_NORMAL, 
                 .files_no      = 1,
@@ -334,7 +334,7 @@ static const device_config_t lx6_config[] = {
                 .files         = { "roms/machines/lx6/LX6C_LY.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision PZ (Beta)",
+                .name          = "AwardBIOS v4.51PG - Revision PZ (Beta)",
                 .internal_name = "lx6_pz",
                 .bios_type     = BIOS_NORMAL, 
                 .files_no      = 1,
@@ -514,7 +514,7 @@ static const device_config_t ms6117_config[] = {
                 .files         = { "roms/machines/ms6117/A617C410.ROM", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 3.2",
+                .name          = "AwardBIOS v4.51PG - Revision 3.2",
                 .internal_name = "ms6117w",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -523,7 +523,7 @@ static const device_config_t ms6117_config[] = {
                 .files         = { "roms/machines/ms6117/W617MS32.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 3.2 [Patched for larger drives]",
+                .name          = "AwardBIOS v4.51PG - Revision 3.2 [Patched for larger drives]",
                 .internal_name = "ms6117wp",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -532,7 +532,7 @@ static const device_config_t ms6117_config[] = {
                 .files         = { "roms/machines/ms6117/611732x_patched.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 1.4 (Fujitsu-Siemens OEM)",
+                .name          = "AwardBIOS v4.51PG - Revision 1.4 (Fujitsu-Siemens OEM)",
                 .internal_name = "ms6117wfs",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -541,7 +541,7 @@ static const device_config_t ms6117_config[] = {
                 .files         = { "roms/machines/ms6117/AWARD 1.04 .BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 1.02 (LG IBM Multinet x7E)",
+                .name          = "AwardBIOS v4.51PG - Revision 1.02 (LG IBM Multinet x7E)",
                 .internal_name = "ms6117wlg",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -550,7 +550,7 @@ static const device_config_t ms6117_config[] = {
                 .files         = { "roms/machines/ms6117/BIOS.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 1.5 (Viglen Vig67M)",
+                .name          = "AwardBIOS v4.51PG - Revision 1.5 (Viglen Vig67M)",
                 .internal_name = "ms6117wvi",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -864,7 +864,7 @@ static const device_config_t be6ii_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision 70",
+                .name          = "AwardBIOS v6.00PG - Revision 70",
                 .internal_name = "be6ii_70",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -873,7 +873,7 @@ static const device_config_t be6ii_config[] = {
                 .files         = { "roms/machines/be6ii/Beh_70.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision NP",
+                .name          = "AwardBIOS v6.00PG - Revision NP",
                 .internal_name = "be6ii_np",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -882,7 +882,7 @@ static const device_config_t be6ii_config[] = {
                 .files         = { "roms/machines/be6ii/BEH_NP.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision NY",
+                .name          = "AwardBIOS v6.00PG - Revision NY",
                 .internal_name = "be6ii_ny",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -891,7 +891,7 @@ static const device_config_t be6ii_config[] = {
                 .files         = { "roms/machines/be6ii/BEH_NY.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision NZ",
+                .name          = "AwardBIOS v6.00PG - Revision NZ",
                 .internal_name = "be6ii_nz",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -900,7 +900,7 @@ static const device_config_t be6ii_config[] = {
                 .files         = { "roms/machines/be6ii/BEH_NZ.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision PO",
+                .name          = "AwardBIOS v6.00PG - Revision PO",
                 .internal_name = "be6ii_po",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -909,7 +909,7 @@ static const device_config_t be6ii_config[] = {
                 .files         = { "roms/machines/be6ii/BEH_PO.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision QJ",
+                .name          = "AwardBIOS v6.00PG - Revision QJ",
                 .internal_name = "be6ii_qj",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -918,7 +918,7 @@ static const device_config_t be6ii_config[] = {
                 .files         = { "roms/machines/be6ii/BEH_QJ.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision RV",
+                .name          = "AwardBIOS v6.00PG - Revision RV",
                 .internal_name = "be6ii_rv",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -927,7 +927,7 @@ static const device_config_t be6ii_config[] = {
                 .files         = { "roms/machines/be6ii/BEH_RV.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision SH",
+                .name          = "AwardBIOS v6.00PG - Revision SH",
                 .internal_name = "be6ii_sh",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -936,7 +936,7 @@ static const device_config_t be6ii_config[] = {
                 .files         = { "roms/machines/be6ii/BEH_SH.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision UH",
+                .name          = "AwardBIOS v6.00PG - Revision UH",
                 .internal_name = "be6ii_uh",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -945,7 +945,7 @@ static const device_config_t be6ii_config[] = {
                 .files         = { "roms/machines/be6ii/BEH_UH.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision VN",
+                .name          = "AwardBIOS v6.00PG - Revision VN",
                 .internal_name = "be6ii_vn",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -954,7 +954,7 @@ static const device_config_t be6ii_config[] = {
                 .files         = { "roms/machines/be6ii/beh_vn.Bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision XU",
+                .name          = "AwardBIOS v6.00PG - Revision XU",
                 .internal_name = "be6ii_xu",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1039,7 +1039,7 @@ static const device_config_t bx6_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision EG",
+                .name          = "AwardBIOS v4.51PG - Revision EG",
                 .internal_name = "bx6",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1048,7 +1048,7 @@ static const device_config_t bx6_config[] = {
                 .files         = { "roms/machines/bx6/BX6_EG.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision CW",
+                .name          = "AwardBIOS v4.51PG - Revision CW",
                 .internal_name = "bx6_CW",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1057,7 +1057,7 @@ static const device_config_t bx6_config[] = {
                 .files         = { "roms/machines/bx6/BX6_CW.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision GQ",
+                .name          = "AwardBIOS v4.51PG - Revision GQ",
                 .internal_name = "bx6_GQ",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1066,7 +1066,7 @@ static const device_config_t bx6_config[] = {
                 .files         = { "roms/machines/bx6/BX6_GQ.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision JL",
+                .name          = "AwardBIOS v4.51PG - Revision JL",
                 .internal_name = "bx6_JL",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1075,7 +1075,7 @@ static const device_config_t bx6_config[] = {
                 .files         = { "roms/machines/bx6/BX6_JL.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision QS",
+                .name          = "AwardBIOS v4.51PG - Revision QS",
                 .internal_name = "bx6_qs",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1227,7 +1227,7 @@ static const device_config_t ax6bc_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v4.51PGM - Revision R1.10",
+                .name          = "AwardBIOS v4.51PGM - Revision R1.10",
                 .internal_name = "ax6bc_451pg",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1236,7 +1236,7 @@ static const device_config_t ax6bc_config[] = {
                 .files         = { "roms/machines/ax6bc/ax6bc110.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.60PGMA - Revision R2.20 (RM Accelerator 350P2XB/450P3XB)",
+                .name          = "AwardBIOS v4.60PGMA - Revision R2.20 (RM Accelerator 350P2XB/450P3XB)",
                 .internal_name = "ax6bc_rm",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1245,7 +1245,7 @@ static const device_config_t ax6bc_config[] = {
                 .files         = { "roms/machines/ax6bc/ax6bc220.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.60PGMA - Revision R2.59",
+                .name          = "AwardBIOS v4.60PGMA - Revision R2.59",
                 .internal_name = "ax6bc",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1324,7 +1324,7 @@ static const device_config_t ga686_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 5/11/1998 (Amptron PII-3100)",
+                .name          = "AwardBIOS v4.51PG - Revision 5/11/1998 (Amptron PII-3100)",
                 .internal_name = "pii3100",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1333,7 +1333,7 @@ static const device_config_t ga686_config[] = {
                 .files         = { "roms/machines/686bx/31nologo.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision F1",
+                .name          = "AwardBIOS v4.51PG - Revision F1",
                 .internal_name = "686bx_f1",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1342,7 +1342,7 @@ static const device_config_t ga686_config[] = {
                 .files         = { "roms/machines/686bx/6BX.F1", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision F2a (Beta)",
+                .name          = "AwardBIOS v4.51PG - Revision F2a (Beta)",
                 .internal_name = "686bx",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1443,7 +1443,7 @@ static const device_config_t ms6119_config[] = {
                 .files         = { "roms/machines/ms6119/A19P2190.ROM", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 2.10",
+                .name          = "AwardBIOS v4.51PG - Revision 2.10",
                 .internal_name = "ms6119",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1452,7 +1452,7 @@ static const device_config_t ms6119_config[] = {
                 .files         = { "roms/machines/ms6119/w6119ims.2a0", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 2.12 (Viglen Vig69M)",
+                .name          = "AwardBIOS v4.51PG - Revision 2.12 (Viglen Vig69M)",
                 .internal_name = "vig69m",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1461,7 +1461,7 @@ static const device_config_t ms6119_config[] = {
                 .files         = { "roms/machines/ms6119/vig69m.212", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 3.30b1 (LG IBM Multinet x7G)",
+                .name          = "AwardBIOS v4.51PG - Revision 3.30b1 (LG IBM Multinet x7G)",
                 .internal_name = "lgibmx7g",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1538,7 +1538,7 @@ static const device_config_t ms6147_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 1.2 (Fujitsu ErgoPro e368)",
+                .name          = "AwardBIOS v4.51PG - Revision 1.2 (Fujitsu ErgoPro e368)",
                 .internal_name = "ergoproe368",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1547,7 +1547,7 @@ static const device_config_t ms6147_config[] = {
                 .files         = { "roms/machines/ms6147/W647F412.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 1.8",
+                .name          = "AwardBIOS v4.51PG - Revision 1.8",
                 .internal_name = "ms6147",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1556,7 +1556,7 @@ static const device_config_t ms6147_config[] = {
                 .files         = { "roms/machines/ms6147/W647MS18.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 2.1 (Packard Bell Tempest)",
+                .name          = "AwardBIOS v4.51PG - Revision 2.1 (Packard Bell Tempest)",
                 .internal_name = "pbtempest",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1646,7 +1646,7 @@ static const device_config_t p6sba_config[] = {
                 .files         = { "roms/machines/p6sba/SBAB21.ROM", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.60PGA - Revision 05/07/1999 (Leadtek WinFast 8000BX)",
+                .name          = "AwardBIOS v4.60PGA - Revision 05/07/1999 (Leadtek WinFast 8000BX)",
                 .internal_name = "8000bx",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1820,7 +1820,7 @@ static const device_config_t vei8_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision 61100003 (beta)",
+                .name          = "AwardBIOS v6.00PG - Revision 61100003 (beta)",
                 .internal_name = "6110zu0003",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1829,7 +1829,7 @@ static const device_config_t vei8_config[] = {
                 .files         = { "roms/machines/vei8/61100003.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision R804",
+                .name          = "AwardBIOS v6.00PG - Revision R804",
                 .internal_name = "6110zu",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1838,7 +1838,7 @@ static const device_config_t vei8_config[] = {
                 .files         = { "roms/machines/vei8/r804.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision QHW.10.01 (HP Sherwood-B)",
+                .name          = "AwardBIOS v6.00PG - Revision QHW.10.01 (HP Sherwood-B)",
                 .internal_name = "vei8",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -2154,7 +2154,7 @@ static const device_config_t ms6199va_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 3.5",
+                .name          = "AwardBIOS v4.51PG - Revision 3.5",
                 .internal_name = "ms6199va",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -2163,7 +2163,7 @@ static const device_config_t ms6199va_config[] = {
                 .files         = { "roms/machines/ms6199va/w6199vms.350", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 2.0 (Compaq ProSignia/Deskpro 693A)",
+                .name          = "AwardBIOS v4.51PG - Revision 2.0 (Compaq ProSignia/Deskpro 693A)",
                 .internal_name = "ms6199va_200",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -2172,7 +2172,7 @@ static const device_config_t ms6199va_config[] = {
                 .files         = { "roms/machines/ms6199va/W6199VC8.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 2.0 (Compaq ProSignia/Deskpro 693A) [Patched for larger drives]",
+                .name          = "AwardBIOS v4.51PG - Revision 2.0 (Compaq ProSignia/Deskpro 693A) [Patched for larger drives]",
                 .internal_name = "ms6199va_200p",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -2181,7 +2181,7 @@ static const device_config_t ms6199va_config[] = {
                 .files         = { "roms/machines/ms6199va/W6199VC8.PCD", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 3.7 (Packard Bell Phoenix)",
+                .name          = "AwardBIOS v4.51PG - Revision 3.7 (Packard Bell Phoenix)",
                 .internal_name = "ms6199va_370",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,

--- a/src/machine/m_at_slot1_socket370.c
+++ b/src/machine/m_at_slot1_socket370.c
@@ -170,7 +170,7 @@ static const device_config_t prosignias31x_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 5.3",
+                .name          = "AwardBIOS v4.51PG - Revision 5.3",
                 .internal_name = "p6bxt_53",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -179,7 +179,7 @@ static const device_config_t prosignias31x_config[] = {
                 .files         = { "roms/machines/prosignias31x_bx/bxt53s.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 5.5 (Compaq ProSignia/Deskpro 440BX)",
+                .name          = "AwardBIOS v4.51PG - Revision 5.5 (Compaq ProSignia/Deskpro 440BX)",
                 .internal_name = "prosignias31x_bx",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -188,7 +188,7 @@ static const device_config_t prosignias31x_config[] = {
                 .files         = { "roms/machines/prosignias31x_bx/p6bxt-ap-092600.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 5.6",
+                .name          = "AwardBIOS v4.51PG - Revision 5.6",
                 .internal_name = "p6bxt",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,

--- a/src/machine/m_at_socket3.c
+++ b/src/machine/m_at_socket3.c
@@ -264,7 +264,7 @@ static const device_config_t j403tg_config[] = {
                 .files         = { "roms/machines/403tg/J403TGRevD.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.50G",
+                .name          = "AwardBIOS v4.50G",
                 .internal_name = "403tg_award",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,

--- a/src/machine/m_at_socket370.c
+++ b/src/machine/m_at_socket370.c
@@ -484,7 +484,7 @@ static const device_config_t ms6318_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision 1.1",
+                .name          = "AwardBIOS v6.00PG - Revision 1.1",
                 .internal_name = "ms6318_110",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -493,7 +493,7 @@ static const device_config_t ms6318_config[] = {
                 .files         = { "roms/machines/ms6318/w6318vms.110", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision 1.2",
+                .name          = "AwardBIOS v6.00PG - Revision 1.2",
                 .internal_name = "ms6318",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -502,7 +502,7 @@ static const device_config_t ms6318_config[] = {
                 .files         = { "roms/machines/ms6318/w6318vms.120", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision 1.8 (HP Pavilion A7xx)",
+                .name          = "AwardBIOS v6.00PG - Revision 1.8 (HP Pavilion A7xx)",
                 .internal_name = "ms6318_180",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -511,7 +511,7 @@ static const device_config_t ms6318_config[] = {
                 .files         = { "roms/machines/ms6318/med2000v2.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision 1.9 (HP Pavilion A8xx)",
+                .name          = "AwardBIOS v6.00PG - Revision 1.9 (HP Pavilion A8xx)",
                 .internal_name = "ms6318_190",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -520,7 +520,7 @@ static const device_config_t ms6318_config[] = {
                 .files         = { "roms/machines/ms6318/med2000.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision 2.02 (HP Medion 2000A)",
+                .name          = "AwardBIOS v6.00PG - Revision 2.02 (HP Medion 2000A)",
                 .internal_name = "ms6318_202",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -529,7 +529,7 @@ static const device_config_t ms6318_config[] = {
                 .files         = { "roms/machines/ms6318/ms6318hp.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v6.00PG - Revision 1.3 (Medion MED 2000)",
+                .name          = "AwardBIOS v6.00PG - Revision 1.3 (Medion MED 2000)",
                 .internal_name = "ms6318_130",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,

--- a/src/machine/m_at_socket3_pci.c
+++ b/src/machine/m_at_socket3_pci.c
@@ -1526,7 +1526,7 @@ static const device_config_t hot433a_config[] = {
                 .files         = { "roms/machines/hot433/433AUS33.ROM", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 2.5 (by eSupport)",
+                .name          = "AwardBIOS v4.51PG - Revision 2.5 (by eSupport)",
                 .internal_name = "hot433a_v451pg",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,

--- a/src/machine/m_at_socket4.c
+++ b/src/machine/m_at_socket4.c
@@ -171,7 +171,7 @@ static const device_config_t p5mp3_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v4.50 - Revision 0205",
+                .name          = "AwardBIOS v4.50 - Revision 0205",
                 .internal_name = "p5mp3",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -180,7 +180,7 @@ static const device_config_t p5mp3_config[] = {
                 .files         = { "roms/machines/p5mp3/0205.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51G - Revision 0402 (Beta)",
+                .name          = "AwardBIOS v4.51G - Revision 0402 (Beta)",
                 .internal_name = "p5mp3_0402",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -584,7 +584,7 @@ static const device_config_t pci58pl_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v4.50G - Revision D1-ZZ",
+                .name          = "AwardBIOS v4.50G - Revision D1-ZZ",
                 .internal_name = "pci58pl_d1",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -593,7 +593,7 @@ static const device_config_t pci58pl_config[] = {
                 .files         = { "roms/machines/pci58pl/586-014914716.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.50G - Revision D2-ZZ",
+                .name          = "AwardBIOS v4.50G - Revision D2-ZZ",
                 .internal_name = "pci58pl",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,

--- a/src/machine/m_at_socket5.c
+++ b/src/machine/m_at_socket5.c
@@ -439,7 +439,7 @@ static const device_config_t pt2000_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v4.50GP - Revision T1.01",
+                .name          = "AwardBIOS v4.50GP - Revision T1.01",
                 .internal_name = "pt2000",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -448,7 +448,7 @@ static const device_config_t pt2000_config[] = {
                 .files         = { "roms/machines/ficpt2000/PT2000_v1.01.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 3.072C806",
+                .name          = "AwardBIOS v4.51PG - Revision 3.072C806",
                 .internal_name = "pt2000_451pg",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,

--- a/src/machine/m_at_socket7.c
+++ b/src/machine/m_at_socket7.c
@@ -1209,16 +1209,80 @@ machine_at_pb680_init(const machine_t *model)
     return ret;
 }
 
+static const device_config_t pb810_config[] = {
+    // clang-format off
+    {
+        .name           = "bios",
+        .description    = "BIOS Version",
+        .type           = CONFIG_BIOS,
+        .default_string = "pb810",
+        .default_int    = 0,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .selection      = { { 0 } },
+        .bios           = {
+            {
+                .name          = "Award Modular BIOS v4.51PG - Revision 3.00 (AST Bravo EL)",
+                .internal_name = "pb810_ast300",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 131072,
+                .files         = { "roms/machines/pb810/JEWEL.BIN", "" }
+            },
+            {
+                .name          = "Award Modular BIOS v4.51PG - Revision 3.03 (AST Bravo EL)",
+                .internal_name = "pb810_ast",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 131072,
+                .files         = { "roms/machines/pb810/2a59gjew.bin", "" }
+            },
+            {
+                .name          = "Award Modular BIOS v4.51PG - Revision 1.25I (Packard Bell PB810)",
+                .internal_name = "pb810",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 131072,
+                .files         = { "roms/machines/pb810/G400125I.BIN", "" }
+            },
+            { .files_no = 0 }
+        }
+    },
+    { .name = "", .description = "", .type = CONFIG_END }
+    // clang-format on
+};
+
+const device_t pb810_device = {
+    .name          = "BCM FM530",
+    .internal_name = "pb810",
+    .flags         = 0,
+    .local         = 0,
+    .init          = NULL,
+    .close         = NULL,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = pb810_config
+};
+
 int
 machine_at_pb810_init(const machine_t *model)
 {
-    int ret;
+    int         ret = 0;
+    const char *fn;
 
-    ret = bios_load_linear("roms/machines/pb810/G400125I.BIN",
-                           0x000e0000, 131072, 0);
-
-    if (bios_only || !ret)
+    /* No ROMs available */
+    if (!device_available(model->device))
         return ret;
+
+    device_context(model->device);
+    fn  = device_get_bios_file(machine_get_device(machine), device_get_config_bios("bios"), 0);
+    ret = bios_load_linear(fn, 0x000e0000, 131072, 0);
+    device_context_restore();
 
     machine_at_common_init(model);
 

--- a/src/machine/m_at_socket7.c
+++ b/src/machine/m_at_socket7.c
@@ -913,7 +913,7 @@ static const device_config_t p5vxb_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v4.50PG - Revision 1.0",
+                .name          = "AwardBIOS v4.50PG - Revision 1.0",
                 .internal_name = "p5vxb",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -922,7 +922,7 @@ static const device_config_t p5vxb_config[] = {
                 .files         = { "roms/machines/p5vxb/P5VXB10.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 1.5c",
+                .name          = "AwardBIOS v4.51PG - Revision 1.5c",
                 .internal_name = "p5vxb_451pg",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1222,7 +1222,7 @@ static const device_config_t pb810_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 3.00 (AST Bravo EL)",
+                .name          = "AwardBIOS v4.51PG - Revision 3.00 (AST Bravo EL)",
                 .internal_name = "pb810_ast300",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1231,7 +1231,7 @@ static const device_config_t pb810_config[] = {
                 .files         = { "roms/machines/pb810/JEWEL.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 3.03 (AST Bravo EL)",
+                .name          = "AwardBIOS v4.51PG - Revision 3.03 (AST Bravo EL)",
                 .internal_name = "pb810_ast",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1240,7 +1240,7 @@ static const device_config_t pb810_config[] = {
                 .files         = { "roms/machines/pb810/2a59gjew.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 1.25I (Packard Bell PB810)",
+                .name          = "AwardBIOS v4.51PG - Revision 1.25I (Packard Bell PB810)",
                 .internal_name = "pb810",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1461,7 +1461,7 @@ static const device_config_t txp4x_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 0108el",
+                .name          = "AwardBIOS v4.51PG - Revision 0108el",
                 .internal_name = "txp4x_aw0108",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1470,7 +1470,7 @@ static const device_config_t txp4x_config[] = {
                 .files         = { "roms/machines/txp4x/XE5L0108.AWD", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 0112el-1 (Patched)",
+                .name          = "AwardBIOS v4.51PG - Revision 0112el-1 (Patched)",
                 .internal_name = "txp4x",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1793,7 +1793,7 @@ static const device_config_t ms5156_config[] = {
                 .files         = { "roms/machines/ms5156/A556C313.ROM", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 1.5",
+                .name          = "AwardBIOS v4.51PG - Revision 1.5",
                 .internal_name = "ms5156w",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1802,7 +1802,7 @@ static const device_config_t ms5156_config[] = {
                 .files         = { "roms/machines/ms5156/W556MS15.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 1.6B1 (ACPI Beta)",
+                .name          = "AwardBIOS v4.51PG - Revision 1.6B1 (ACPI Beta)",
                 .internal_name = "ms5156wab",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -2317,7 +2317,7 @@ static const device_config_t ms5146_config[] = {
                 .files         = { "roms/machines/ms5146/A546MS11.ROM", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 2.1",
+                .name          = "AwardBIOS v4.51PG - Revision 2.1",
                 .internal_name = "ms5146_451pg",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -2391,7 +2391,7 @@ static const device_config_t r534f_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 06/12/1998",
+                .name          = "AwardBIOS v4.51PG - Revision 06/12/1998",
                 .internal_name = "r534f_1998",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -2400,7 +2400,7 @@ static const device_config_t r534f_config[] = {
                 .files         = { "roms/machines/r534f/r534f008-1998.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 03/13/2000 (by Unicore Software)",
+                .name          = "AwardBIOS v4.51PG - Revision 03/13/2000 (by Unicore Software)",
                 .internal_name = "r534f",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -2561,7 +2561,7 @@ static const device_config_t m5ata_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 12/23/97",
+                .name          = "AwardBIOS v4.51PG - Revision 12/23/97",
                 .internal_name = "m5ata_1223",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -2570,7 +2570,7 @@ static const device_config_t m5ata_config[] = {
                 .files         = { "roms/machines/m5ata/ATA1223.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 05/27/98",
+                .name          = "AwardBIOS v4.51PG - Revision 05/27/98",
                 .internal_name = "m5ata",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,

--- a/src/machine/m_at_socket7_3v.c
+++ b/src/machine/m_at_socket7_3v.c
@@ -55,7 +55,7 @@ static const device_config_t p54tp4xe_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 0302",
+                .name          = "AwardBIOS v4.51PG - Revision 0302",
                 .internal_name = "p54tp4xe",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -896,7 +896,7 @@ static const device_config_t ms5119_config[] = {
                 .files         = { "roms/machines/ms5119/A37EB.ROM", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Release 2.3 (by Rainbow)",
+                .name          = "AwardBIOS v4.51PG - Release 2.3 (by Rainbow)",
                 .internal_name = "ms5119_451pg",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1077,7 +1077,7 @@ static const device_config_t fmb_config[] = {
                 .files         = { "roms/machines/fmb/P5IV183.ROM", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - 2001 Release (by Rainbow)",
+                .name          = "AwardBIOS v4.51PG - 2001 Release (by Rainbow)",
                 .internal_name = "fmb_451pg",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1485,7 +1485,7 @@ static const device_config_t c5sbm2_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v4.50GP - Revision 07/17/1995",
+                .name          = "AwardBIOS v4.50GP - Revision 07/17/1995",
                 .internal_name = "5sbm2_v450gp",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1494,7 +1494,7 @@ static const device_config_t c5sbm2_config[] = {
                 .files         = { "roms/machines/5sbm2/5SBM0717.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.50PG - Revision 03/26/1996",
+                .name          = "AwardBIOS v4.50PG - Revision 03/26/1996",
                 .internal_name = "5sbm2",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1503,7 +1503,7 @@ static const device_config_t c5sbm2_config[] = {
                 .files         = { "roms/machines/5sbm2/5SBM0326.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 2.2 (by Unicore Software)",
+                .name          = "AwardBIOS v4.51PG - Revision 2.2 (by Unicore Software)",
                 .internal_name = "5sbm2_451pg",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1610,7 +1610,7 @@ static const device_config_t ap5s_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v4.50PG - Revision R1.20",
+                .name          = "AwardBIOS v4.50PG - Revision R1.20",
                 .internal_name = "ap5s_450pg",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1619,7 +1619,7 @@ static const device_config_t ap5s_config[] = {
                 .files         = { "roms/machines/ap5s/ap5s120.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision R1.50",
+                .name          = "AwardBIOS v4.51PG - Revision R1.50",
                 .internal_name = "ap5s_r150",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1628,7 +1628,7 @@ static const device_config_t ap5s_config[] = {
                 .files         = { "roms/machines/ap5s/AP5S150.BIN", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision R1.60",
+                .name          = "AwardBIOS v4.51PG - Revision R1.60",
                 .internal_name = "ap5s",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -1774,7 +1774,7 @@ static const device_config_t ms5124_config[] = {
                 .files         = { "roms/machines/ms5124/AG77.ROM", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision WG72P",
+                .name          = "AwardBIOS v4.51PG - Revision WG72P",
                 .internal_name = "ms5124_451pg",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,

--- a/src/machine/m_at_socket8.c
+++ b/src/machine/m_at_socket8.c
@@ -568,7 +568,7 @@ static const device_config_t zida6dxp_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 1.02",
+                .name          = "AwardBIOS v4.51PG - Revision 1.02",
                 .internal_name = "6dxp102",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -577,7 +577,7 @@ static const device_config_t zida6dxp_config[] = {
                 .files         = { "roms/machines/6dxp/6dxp102e.bin", "" }
             },
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision 1.1",
+                .name          = "AwardBIOS v4.51PG - Revision 1.1",
                 .internal_name = "6dxp",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,

--- a/src/machine/m_at_sockets7.c
+++ b/src/machine/m_at_sockets7.c
@@ -190,7 +190,7 @@ static const device_config_t g5x_config[] = {
         .selection      = { { 0 } },
         .bios           = {
             {
-                .name          = "Award Modular BIOS v4.51PG - Revision F4",
+                .name          = "AwardBIOS v4.51PG - Revision F4",
                 .internal_name = "5ax",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,
@@ -199,7 +199,7 @@ static const device_config_t g5x_config[] = {
                 .files         = { "roms/machines/5ax/5AX.F4", "" }
             },
             {
-                .name          = "Phoenix - AwardBIOS v6.00PG - Release 4.1 (by eSupport)",
+                .name          = "AwardBIOS v6.00PG - Release 4.1 (by eSupport)",
                 .internal_name = "5ax_600pg",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 1,

--- a/src/machine/m_at_stpc.c
+++ b/src/machine/m_at_stpc.c
@@ -155,7 +155,7 @@ static const device_config_t arb1479_config[] = {
                 .files         = { "roms/machines/arb1479/1479b.rom", "" }
             },
             {
-                .name          = "Phoenix - AwardBIOS v6.00PG - Revision 1.2 (AR-B1479D)",
+                .name          = "AwardBIOS v6.00PG - Revision 1.2 (AR-B1479D)",
                 .internal_name = "arb1479d12",
                 .bios_type     = BIOS_NORMAL, 
                 .files_no      = 1,

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -18559,6 +18559,56 @@ const machine_t machines[] = {
         .net_device               = NULL,
         .aliases                  = { "" }
     },
+    /* Has a SM(S)C FDC37C935 Super I/O chip with on-chip KBC with Phoenix
+       MultiKey/42 (version 1.38) KBC firmware. */
+    {
+        .name              = "[i430VX] BCM FM530",
+        .internal_name     = "pb810",
+        .type              = MACHINE_TYPE_SOCKET7,
+        .chipset           = MACHINE_CHIPSET_INTEL_430VX,
+        .init              = machine_at_pb810_init,
+        .p1_handler        = machine_generic_p1_handler,
+        .gpio_handler      = NULL,
+        .available_flag    = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu               = {
+            .package     = CPU_PKG_SOCKET5_7,
+            .block       = CPU_BLOCK_NONE,
+            .min_bus     = 50000000,
+            .max_bus     = 83333333,
+            .min_voltage = 2500,
+            .max_voltage = 3520,
+            .min_multi   = 1.5,
+            .max_multi   = 4.0
+        },
+        .bus_flags = MACHINE_PS2_PCI,
+        .flags     = MACHINE_VIDEO | MACHINE_IDE_DUAL | MACHINE_SOUND | MACHINE_APM,
+        /* Machine has internal video: S3 Trio64V2/DX, S3 Trio32/64/64V+ or S3 ViRGE DX/GX */
+        .ram       = {
+            .min  = 4096,
+            .max  = 131072,
+            .step = 4096
+        },
+        .nvrmask                  = 511,
+        .jumpered_ecp_dma         = 0,
+        .default_jumpered_ecp_dma = -1,
+        .kbc_device               = NULL,
+        .kbc_params               = 0x00000000,
+        .nvr_device               = NULL,
+        .nvr_params               = 0x00000000,
+        .sio_device               = NULL,
+        .sio_params               = 0x00000000,
+        .kbc_p1                   = 0x00000cf0,
+        .gpio                     = 0xffffffff,
+        .gpio_acpi                = 0xffffffff,
+        .device                   = &pb810_device,
+        .kbd_device               = NULL,
+        .fdc_device               = NULL,
+        .vid_device               = &s3_trio64v2dx_onboard_pci_device,
+        .snd_device               = &cs4237b_device,
+        .net_device               = NULL,
+        .aliases                  = { "AST 221630-xxx", "AST Bravo EL", "Packard Bell PB810", "Packard Bell PB820", "" }
+    },
     /* [TEST] Has a VIA VT82C42N KBC. */
     {
         .name              = "[i430VX] Biostar MB-8500TVX-A",
@@ -19049,55 +19099,6 @@ const machine_t machines[] = {
         .snd_device               = NULL, /* Machine has Crystal CS4236-KQ onboard sound but it's unpopulated */
         .net_device               = NULL,
         .aliases                  = { "Packard Bell Orlando", "Packard Bell 2D", "Packard Bell 3D", "Packard Bell MMX", "Packard Bell R501", "Intel NV430VX", "Intel Orlando", "Intel Tampa", "" }
-    },
-    /* Has a SM(S)C FDC37C935 Super I/O chip with on-chip KBC with Phoenix
-       MultiKey/42 (version 1.38) KBC firmware. */
-    {
-        .name              = "[i430VX] Packard Bell PB810",
-        .internal_name     = "pb810",
-        .type              = MACHINE_TYPE_SOCKET7,
-        .chipset           = MACHINE_CHIPSET_INTEL_430VX,
-        .init              = machine_at_pb810_init,
-        .p1_handler        = machine_generic_p1_handler,
-        .gpio_handler      = NULL,
-        .available_flag    = MACHINE_AVAILABLE,
-        .gpio_acpi_handler = NULL,
-        .cpu               = {
-            .package     = CPU_PKG_SOCKET5_7,
-            .block       = CPU_BLOCK_NONE,
-            .min_bus     = 50000000,
-            .max_bus     = 83333333,
-            .min_voltage = 2500,
-            .max_voltage = 3520,
-            .min_multi   = 1.5,
-            .max_multi   = 4.0
-        },
-        .bus_flags = MACHINE_PS2_PCI,
-        .flags     = MACHINE_VIDEO | MACHINE_IDE_DUAL | MACHINE_SOUND | MACHINE_APM, /* Machine has internal video: S3 Trio64V2/DX */
-        .ram       = {
-            .min  = 4096,
-            .max  = 131072,
-            .step = 4096
-        },
-        .nvrmask                  = 511,
-        .jumpered_ecp_dma         = 0,
-        .default_jumpered_ecp_dma = -1,
-        .kbc_device               = NULL,
-        .kbc_params               = 0x00000000,
-        .nvr_device               = NULL,
-        .nvr_params               = 0x00000000,
-        .sio_device               = NULL,
-        .sio_params               = 0x00000000,
-        .kbc_p1                   = 0x00000cf0,
-        .gpio                     = 0xffffffff,
-        .gpio_acpi                = 0xffffffff,
-        .device                   = NULL,
-        .kbd_device               = NULL,
-        .fdc_device               = NULL,
-        .vid_device               = &s3_trio64v2dx_onboard_pci_device, /* Machine has also internal video: S3 ViRGE */
-        .snd_device               = &cs4237b_device,
-        .net_device               = NULL,
-        .aliases                  = { "Packard Bell PB820", "BCM FM530", "" }
     },
     /* This has the AMIKey 'H' firmware, possibly AMIKey-2. Photos show it with a BestKey, so it
        likely clones the behavior of AMIKey 'H'. */


### PR DESCRIPTION
Summary
=======
* Rename the "Packard Bell PB810" to "BCM FM530" and add the AST Bravo EL BIOS variants as a selectable option in the device configuration window
* Fix some mistakes with the TMC PAT45PV sections of machine.h
* Rename all instances of "Award Modular BIOS" and "Phoenix - AwardBIOS" to just "AwardBIOS" in the BIOS version selectors, to reduce the length of the device configuration windows 

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/528
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
https://theretroweb.com/motherboards/s/bcm-fm530
