### PR TITLE
Fix low level disk format with IBM PS/2 ESDI controller

### DIFF
--- a/src/disk/hdc_esdi_mca.c
+++ b/src/disk/hdc_esdi_mca.c
@@ -14,8 +14,8 @@
  *            I/O base:        0x3510-0x3517
  *            IRQ:             14
  *
- *            Primary Board    pos[0]=XXxx xx0X    0x3510
- *            Secondary Board  pos[0]=XXxx xx1X    0x3518
+ *            Primary Board    pos[0]=XXXX XX0X    0x3510
+ *            Secondary Board  pos[0]=XXXX XX1X    0x3518
  *
  *            DMA 5            pos[0]=XX01 01XX
  *            DMA 6            pos[0]=XX01 10XX
@@ -103,6 +103,7 @@ typedef struct esdi_drive_t {
 
 typedef struct esdi_t {
     int8_t dma;
+    int    base;
 
     uint32_t bios;
     rom_t    bios_rom;
@@ -499,8 +500,8 @@ esdi_callback(void *priv)
     if (dev->in_reset) {
         esdi_mca_log("ESDI reset.\n");
         dev->in_reset   = 0;
-        dev->status     = STATUS_IRQ | STATUS_TRANSFER_REQ | STATUS_STATUS_OUT_FULL;
-        dev->status_len = 1; /*ToDo: better implementation for Xenix?*/
+        dev->status     = STATUS_IRQ | STATUS_STATUS_OUT_FULL;
+        dev->status_len = 1; /* Required by Xenix 386 2.3.4q */
         dev->status_data[0] = STATUS_LEN(1) | ATTN_HOST_ADAPTER;
         dev->irq_status = IRQ_HOST_ADAPTER | IRQ_RESET_COMPLETE;
         return;
@@ -841,7 +842,7 @@ esdi_callback(void *priv)
 
                 dev->status_len = 6;
                 dev->status_data[0] = CMD_GET_DEV_CONFIG | STATUS_LEN(6) | STATUS_DEVICE_HOST_ADAPTER;
-                dev->status_data[1] = 0x10; /*Zero defect*/
+                dev->status_data[1] = 0x08; /*Zero Defect flag (ZD, bit 3), no spares per cylinder*/
                 dev->status_data[2] = drive->sectors & 0xffff;
                 dev->status_data[3] = drive->sectors >> 16;
                 dev->status_data[4] = drive->tracks;
@@ -1369,7 +1370,7 @@ esdi_mca_write(const uint16_t port, uint8_t val, void *priv)
     /* Save the new value. */
     dev->pos_regs[port & 7] = val;
 
-    io_removehandler(ESDI_IOADDR_PRI, 8,
+    io_removehandler(dev->base, 8,
                      esdi_read, esdi_readw, NULL,
                      esdi_write, esdi_writew, NULL, dev);
     mem_mapping_disable(&dev->bios_rom.mapping);
@@ -1433,8 +1434,14 @@ esdi_mca_write(const uint16_t port, uint8_t val, void *priv)
     } else
         dev->bios = 0;
 
+    /* Set up controller I/O address. */
+    if (dev->pos_regs[2] & 0x02)
+        dev->base = ESDI_IOADDR_SEC;
+    else
+        dev->base = ESDI_IOADDR_PRI;
+
     if (dev->pos_regs[2] & 1) {
-        io_sethandler(ESDI_IOADDR_PRI, 8,
+        io_sethandler(dev->base, 8,
                       esdi_read, esdi_readw, NULL,
                       esdi_write, esdi_writew, NULL, dev);
 
@@ -1444,8 +1451,8 @@ esdi_mca_write(const uint16_t port, uint8_t val, void *priv)
         }
 
         /* Say hello. */
-        esdi_mca_log("ESDI: I/O=3510, IRQ=14, DMA=%d, BIOS @%05X\n",
-                     dev->dma, dev->bios);
+        esdi_mca_log("ESDI: I/O=%04X, IRQ=14, DMA=%d, BIOS @%05X\n",
+                     dev->base, dev->dma, dev->bios);
     }
 }
 
@@ -1537,6 +1544,7 @@ esdi_init(UNUSED(const device_t *info))
 
     /* Mark as unconfigured. */
     dev->irq_status = 0xff;
+    dev->base       = ESDI_IOADDR_PRI;
 
     if (info->local == ESDI_IS_ADAPTER) {
         rom_init_interleaved(&dev->bios_rom,
@@ -1548,7 +1556,7 @@ esdi_init(UNUSED(const device_t *info))
         mem_mapping_set_p(&dev->bios_rom.mapping, dev);
         /* Card Selected Feedback is a side effect of every adapter-ROM read,
            so reads must not bypass the handler through the direct ROM path. */
-        mem_mapping_set_exec(&dev->bios_rom.mapping, NULL);
+        mem_mapping_set_exec(&dev->bios_rom.mapping, dev->bios_rom.rom);
         mem_mapping_disable(&dev->bios_rom.mapping);
     }
 

--- a/src/disk/hdc_esdi_mca.c
+++ b/src/disk/hdc_esdi_mca.c
@@ -218,11 +218,21 @@ esdi_bios_readl(uint32_t addr, void *priv)
 #define CMD_WRITE_VERIFY           0x04
 #define CMD_SEEK                   0x05
 #define CMD_PARK_HEADS             0x06
+#define CMD_GET_CMD_STATUS         0x07
 #define CMD_GET_DEV_STATUS         0x08
 #define CMD_GET_DEV_CONFIG         0x09
 #define CMD_GET_POS_INFO           0x0a
+#define CMD_TRANSLATE_RBA          0x0b
+#define CMD_WRITE_BUFFER           0x10
+#define CMD_READ_BUFFER            0x11
+#define CMD_RUN_DIAG_TEST          0x12
+#define CMD_GET_DIAG_BLOCK         0x14
+#define CMD_GET_MFG_HEADER         0x15
 #define CMD_FORMAT_UNIT            0x16
 #define CMD_FORMAT_PREPARE         0x17
+#define CMD_SET_MAX_RBA            0x1a
+#define CMD_SET_PWR_MODE           0x1b
+#define CMD_PWR_CONSERVATION       0x1c
 
 #define STATUS_LEN(x)              ((x) << 8)
 #define STATUS_DEVICE(x)           ((x) << 5)
@@ -437,7 +447,7 @@ esdi_callback(void *priv)
     esdi_mca_log("Command=%02x.\n", dev->command);
     switch (dev->command) {
         case CMD_READ:
-        case 0x15:
+        case CMD_GET_MFG_HEADER:
             ESDI_DRIVE_ONLY();
 
             if (!drive->present) {
@@ -798,7 +808,7 @@ esdi_callback(void *priv)
             ui_sb_update_icon_write(SB_HDD | HDD_BUS_ESDI, 0);
             break;
 
-        case 0x10:
+        case CMD_WRITE_BUFFER:
             ESDI_ADAPTER_ONLY();
             switch (dev->cmd_state) {
                 case 0:
@@ -857,7 +867,7 @@ esdi_callback(void *priv)
             }
             break;
 
-        case 0x11:
+        case CMD_READ_BUFFER:
             ESDI_ADAPTER_ONLY();
             switch (dev->cmd_state) {
                 case 0:
@@ -917,7 +927,7 @@ esdi_callback(void *priv)
             }
             break;
 
-        case 0x12:
+        case CMD_RUN_DIAG_TEST:
             if (dev->cmd_dev != ATTN_DEVICE_0 &&
                 dev->cmd_dev != ATTN_DEVICE_1 &&
                 dev->cmd_dev != ATTN_HOST_ADAPTER) {
@@ -928,7 +938,7 @@ esdi_callback(void *priv)
                 fatal("IRQ in progress %02x %i\n", dev->status, dev->irq_in_progress);
 
             dev->status_len     = 5;
-            dev->status_data[0] = 0x12 | STATUS_LEN(5) | dev->cmd_dev;
+            dev->status_data[0] = CMD_RUN_DIAG_TEST | STATUS_LEN(5) | dev->cmd_dev;
             dev->status_data[1] = 0;
             dev->status_data[2] = 0;
             dev->status_data[3] = 0;
@@ -941,7 +951,7 @@ esdi_callback(void *priv)
             ui_sb_update_icon(SB_HDD | HDD_BUS_ESDI, 0);
             break;
 
-        case 0x14:
+        case CMD_GET_DIAG_BLOCK:
             if (dev->cmd_dev != ATTN_DEVICE_0 &&
                 dev->cmd_dev != ATTN_DEVICE_1 &&
                 dev->cmd_dev != ATTN_HOST_ADAPTER) {

--- a/src/disk/hdc_esdi_mca.c
+++ b/src/disk/hdc_esdi_mca.c
@@ -425,6 +425,68 @@ complete_command_status(esdi_t *dev)
         else                                                                  \
             drive = &dev->drives[1];
 
+/* Build the primary defect map (spec 9.2.4, Figure 66) which is returned
+   by the Get Manufacturing Header command. The map is generated defect-free,
+   so it fits in the initial record; any additional blocks are left all-ones
+   as unused map blocks. */
+static void
+esdi_build_mfg_header(esdi_t *dev, const drive_t *drive, uint16_t blocks)
+{
+    const char *model = hdd[drive->hdd_num].model;
+    uint8_t    *buf   = (uint8_t *) dev->sector_buffer;
+    uint8_t     sum;
+    uint32_t    rba;
+    int         i, j;
+
+    memset(buf, 0xff, (size_t) blocks * 512);
+
+    /* Primary Defect Map initial record */
+    memcpy(buf + 0, "DEFECT", 6); /* Header */
+    buf[6] = 0;      /* Count of Defects (LSB) */
+    buf[7] = 0;      /* Count of Defects (MSB) */
+    buf[8] = 0;      /* Number of Extension Records */
+    buf[9] = 0xff;   /* Reserved */
+
+    /* Drive Bar Code Number, ASCII, right justified. */
+    if (model) {
+        size_t len = strlen(model);
+
+        if (len > 16)
+            len = 16;
+        memcpy(buf + 10 + (16 - len), model, len);
+    }
+
+    memcpy(buf + 26, "01011980", 8); /* Date of Manufacture, MMDDYYYY */
+
+    rba = drive->sectors; /* # of RBA's required for capacity (LSB..MSB) */
+    buf[34] = rba & 0xff;
+    buf[35] = (rba >> 8) & 0xff;
+    buf[36] = (rba >> 16) & 0xff;
+    buf[37] = (rba >> 24) & 0xff;
+    buf[38] = 10;      /* Soft errors allowed on diagnostic read verify */
+    buf[39] = 0x03;    /* Errors in 64 reads to classify defect */
+    buf[40] = 0;       /* Skewed sectors, format #1 */
+    buf[41] = 0;       /* Spare sectors per track (not used) */
+    buf[42] = 0;       /* Spare sectors per cylinder */
+    buf[43] = 0xff;    /* Reserved */
+    buf[44] = 1;       /* Defect type: absolute block address */
+    buf[45] = 0;       /* Skewed sectors, format #2 */
+    buf[46] = 0;       /* Skewed sectors, format #3 */
+    /* buf[47..57]        reserved = FF (11 bytes)  */
+
+    /* defect absolute block addresses */
+    /* buf[58..505] = FF (4 * 112 bytes) */
+
+    /* buf[506..510] reserved = FF (5 bytes) */
+    /* Checksum each block so that the sum of all 512 bytes is zero. */
+    for (i = 0; i < blocks; i++) {
+        sum = 0;
+        for (j = 0; j < 511; j++)
+            sum += buf[i * 512 + j];
+        buf[i * 512 + 511] = (uint8_t) -sum;
+    }
+}
+
 static void
 esdi_callback(void *priv)
 {
@@ -457,13 +519,21 @@ esdi_callback(void *priv)
 
             switch (dev->cmd_state) {
                 case 0:
-                    if (dev->command == CMD_READ)
+                    if (dev->command == CMD_GET_MFG_HEADER) {
+                        /* Get Manufacturing Header: return the primary defect
+                           map via DMA like a read command. The block count
+                           is taken from word 1 of the command. */
+                        if (dev->cmd_data[1] > 256)
+                            fatal("Read MFG header count %04x\n", dev->cmd_data[1]);
+                        esdi_build_mfg_header(dev, drive, dev->cmd_data[1]);
+                    } else
                         dev->rba = (dev->cmd_data[2] | (dev->cmd_data[3] << 16)) & 0x0fffffff;
 
                     dev->sector_pos   = 0;
                     dev->sector_count = dev->cmd_data[1];
 
-                    if ((dev->rba + dev->sector_count) > hdd_image_get_last_sector(drive->hdd_num)) {
+                    if ((dev->command != CMD_GET_MFG_HEADER) &&
+                        ((dev->rba + dev->sector_count) > hdd_image_get_last_sector(drive->hdd_num))) {
                         rba_out_of_range(dev);
                         return;
                     }
@@ -486,13 +556,17 @@ esdi_callback(void *priv)
 
                     while (dev->sector_pos < dev->sector_count) {
                         if (!dev->data_pos) {
-                            if (dev->rba >= drive->sectors)
-                                fatal("Read past end of drive\n");
-                            if (hdd_image_read(drive->hdd_num, dev->rba, 1, (uint8_t *) dev->data) < 0) {
-                                defective_block(dev);
-                                return;
+                            if (dev->command == CMD_GET_MFG_HEADER)
+                                memcpy(dev->data, dev->sector_buffer[dev->sector_pos], 512);
+                            else {
+                                if (dev->rba >= drive->sectors)
+                                    fatal("Read past end of drive\n");
+                                if (hdd_image_read(drive->hdd_num, dev->rba, 1, (uint8_t *) dev->data) < 0) {
+                                    defective_block(dev);
+                                    return;
+                                }
+                                cmd_time += hdd_timing_read(&hdd[drive->hdd_num], dev->rba, 1);
                             }
-                            cmd_time += hdd_timing_read(&hdd[drive->hdd_num], dev->rba, 1);
                             cmd_time += esdi_mca_get_xfer_time(dev, 1);
                         }
 
@@ -979,7 +1053,6 @@ esdi_callback(void *priv)
             break;
 
         case CMD_FORMAT_UNIT:
-        case CMD_FORMAT_PREPARE:
             ESDI_DRIVE_ONLY();
 
             if (!drive->present) {
@@ -990,29 +1063,37 @@ esdi_callback(void *priv)
             switch (dev->cmd_state) {
                 case 0:
                     dev->rba = hdd_image_get_last_sector(drive->hdd_num);
+                    /* Word 1: format options in the high byte, number of
+                       defective blocks to deallocate in the low byte. */
+                    dev->sector_count = dev->cmd_data[1] & 0xff;
 
-                    if (dev->command == CMD_FORMAT_UNIT)
-                        dev->sector_count = dev->cmd_data[1];
-                    else
-                        dev->sector_count = 0;
+                    if (!dev->sector_count) {
+                        /* No defective ABA list to transfer: skip the data
+                           phase and proceed straight to formatting. */
+                        dev->status    = STATUS_CMD_IN_PROGRESS;
+                        dev->cmd_state = 1;
+                        esdi_mca_set_callback(dev, ESDI_TIME);
+                        break;
+                    }
 
                     dev->status          = STATUS_IRQ | STATUS_CMD_IN_PROGRESS | STATUS_TRANSFER_REQ;
                     dev->irq_status      = dev->cmd_dev | IRQ_DATA_TRANSFER_READY;
                     dev->irq_in_progress = 1;
                     set_irq(dev);
 
+                    dev->data_pos = 0;
                     dev->cmd_state = 1;
                     esdi_mca_set_callback(dev, ESDI_TIME);
                     break;
 
                 case 1:
-                    if (!(dev->basic_ctrl & CTRL_DMA_ENA)) {
+                    if (dev->sector_count && !(dev->basic_ctrl & CTRL_DMA_ENA)) {
+                        /* Wait for the host to enable DMA for the ABA list. */
                         esdi_mca_set_callback(dev, ESDI_TIME);
                         return;
                     }
 
-                    if (dev->command == CMD_FORMAT_UNIT)
-                        hdd_image_zero(drive->hdd_num, 0, hdd_image_get_last_sector(drive->hdd_num) + 1);
+                    hdd_image_zero(drive->hdd_num, 0, hdd_image_get_last_sector(drive->hdd_num) + 1);
 
                     dev->status    = STATUS_CMD_IN_PROGRESS;
                     dev->cmd_state = 2;
@@ -1030,6 +1111,27 @@ esdi_callback(void *priv)
                 default:
                     break;
             }
+            break;
+
+        case CMD_FORMAT_PREPARE:
+            ESDI_DRIVE_ONLY();
+
+            if (!drive->present) {
+                device_not_present(dev);
+                return;
+            }
+
+            if ((dev->status & STATUS_IRQ) || dev->irq_in_progress)
+                fatal("IRQ in progress %02x %i\n", dev->status, dev->irq_in_progress);
+
+            dev->rba = hdd_image_get_last_sector(drive->hdd_num);
+            /* Format Prepare has no data phase; complete it immediately
+               with a Command Complete status block. */
+            complete_command_status(dev);
+            dev->status          = STATUS_IRQ | STATUS_STATUS_OUT_FULL;
+            dev->irq_status      = dev->cmd_dev | IRQ_CMD_COMPLETE_SUCCESS;
+            dev->irq_in_progress = 1;
+            set_irq(dev);
             break;
 
         default:


### PR DESCRIPTION
Summary
=======
Fix low level disk format not working in IBM PS/2 reference disk with IBM PS/2 ESDI controller.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
https://www.ardent-tool.com/docs/pdf/j_mcspec.pdf
