### PR TITLE
Actually fix the Mach64 banking based on the byte/word/long sides

### DIFF
--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -255,7 +255,7 @@ CLAMP(int16_t in, int16_t min, int16_t max)
     if (ATI_MACH32) {                                                                                           \
         if (dev->bpp) {                                                                                         \
             vga_vram_w[((addr)) & (svga->vram_mask >> 1)]           = dat;                                      \
-            dev->changedvram[(((addr)) & (dev->vram_mask >> 1)) >> 11] = svga->monitor->mon_changeframecount;   \
+            svga->changedvram[(((addr)) & (svga->vram_mask >> 1)) >> 11] = svga->monitor->mon_changeframecount; \
         } else {                                                                                                \
             svga->vram[((addr)) & (svga->vram_mask)]                = dat;                                      \
             svga->changedvram[(((addr)) & (svga->vram_mask)) >> 12] = svga->monitor->mon_changeframecount;      \
@@ -986,10 +986,17 @@ ibm8514_accel_in(uint16_t port, svga_t *svga)
 
     switch (port) {
         case 0x2e8:
-            if (dev->vc == dev->v_syncstart) {
+            if (dev->vc == dev->dispend) {
                 if (dev->accel.advfunc_cntl & 0x04)
                     temp |= 0x02;
             }
+
+            if (((dev->_8514pal[0].r + dev->_8514pal[0].g + dev->_8514pal[0].b) >= 0x4e) ||
+                (dev->_8514pal[0].r >= 0x26) || (dev->_8514pal[0].g >= 0x26) ||
+                (dev->_8514pal[0].b >= 0x26))
+                temp |= 0x00;
+            else
+                temp |= 0x01;
 
             ibm8514_log(dev->log,"Read: Display Status1=%02x.\n", temp);
             break;
@@ -4045,7 +4052,7 @@ ibm8514_render_overscan_left(ibm8514_t *dev, svga_t *svga)
         if ((svga->displine + svga->y_add) < 0)
             return;
 
-        if (svga->scrblank || (svga->hdisp == 0))
+        if (svga->scrblank || (dev->h_disp == 0))
             return;
 
         for (int i = 0; i < svga->x_add; i++)
@@ -4071,7 +4078,7 @@ ibm8514_render_overscan_right(ibm8514_t *dev, svga_t *svga)
         if ((svga->displine + svga->y_add) < 0)
             return;
 
-        if (svga->scrblank || (svga->hdisp == 0))
+        if (svga->scrblank || (dev->h_disp == 0))
             return;
 
         right = (overscan_x >> 1);
@@ -4108,7 +4115,7 @@ ibm8514_poll(void *priv)
 
     ibm8514_log(dev->log,"IBM 8514/A poll=%x offtime=%" PRIu64 ", ontime=%" PRIu64 ".\n", dev->on, dev->dispofftime, dev->dispontime);
     if (dev->on) {
-        ibm8514_log(dev->log,"ON!\n");
+        ibm8514_log(dev->log, "ON!\n");
         if (svga->override)
             svga_set_poll(svga);
         else if (ATI_MACH32) {
@@ -4254,7 +4261,7 @@ ibm8514_poll(void *priv)
                 if (dev->vc == svga->vsyncstart) {
                     svga->dispon = 0;
                     svga->cgastat |= 8;
-                    x = svga->hdisp;
+                    x = dev->h_disp;
 
                     if (svga->interlace && !svga->oddeven)
                         svga->lastline++;
@@ -4286,9 +4293,6 @@ ibm8514_poll(void *priv)
                     svga->memaddr     = (svga->memaddr << 2);
                     svga->memaddr_backup = (svga->memaddr_backup << 2);
                     svga->cursoraddr     = (svga->cursoraddr << 2);
-
-                    if (svga->vsync_callback)
-                        svga->vsync_callback(svga);
 
                     video_lightpen_vsync();
 

--- a/src/video/vid_ati_mach64.c
+++ b/src/video/vid_ati_mach64.c
@@ -43,7 +43,7 @@ mach64_log(const char *fmt, ...);
         va_end(ap);
     }
 }
-#endif 
+#endif
 
 // x86 I/O port output function
 void
@@ -558,6 +558,18 @@ mach64_ext_readb(uint32_t addr, void *priv)
                 case 0xb0 ... 0xb3:
                     READ8(addr, mach64->mem_cntl);
                     break;
+                case 0xb4:
+                    ret = (mach64->bank_w[0] >> 15);
+                    break;
+                case 0xb6:
+                    ret = (mach64->bank_w[1] >> 15);
+                    break;
+                case 0xb8:
+                    ret = (mach64->bank_r[0] >> 15);
+                    break;
+                case 0xba:
+                    ret = (mach64->bank_r[0] >> 15);
+                    break;
                 case 0xc0 ... 0xc3:
                     if (mach64->type == MACH64_GX)
                         ret = ati68860_ramdac_in((addr & 3) | ((mach64->dac_cntl & 3) << 2), 0, mach64->svga.ramdac, &mach64->svga);
@@ -846,7 +858,7 @@ mach64_ext_readw(uint32_t addr, void *priv)
             ret = mach64_ext_readb(addr, priv);
             ret |= mach64_ext_readb(addr + 1, priv) << 8;
         } else // optimise
-            switch (addr & 0x3ff) {
+            switch (addr & 0x3fe) {
             case 0xb4: case 0xb6:
                     ret = (mach64->bank_w[(addr & 2) >> 1] >> 15);
                     break;
@@ -879,7 +891,7 @@ mach64_ext_readl(uint32_t addr, void *priv)
             ret = mach64_ext_readw(addr, priv);
             ret |= mach64_ext_readw(addr + 2, priv) << 16;
         } else
-            switch (addr & 0x3ff) {
+            switch (addr & 0x3fc) {
             case 0x18:
                     ret = mach64->crtc_int_cntl & ~1;
                     if (mach64->svga.cgastat & 8)
@@ -1116,7 +1128,7 @@ mach64_ext_writeb(uint32_t addr, uint8_t val, void *priv)
                     mach64->bank_w[0] = val << 15; // *32768
                     mach64_log("mach64 : write bank A0000-A7FFF set to %08X\n", mach64->bank_w[0]);
                     break;
-                case 0xb5: case 0xb6:
+                case 0xb6:
                     mach64->bank_w[1] = val << 15; // *32768
                     mach64_log("mach64 : write bank A8000-AFFFF set to %08X\n", mach64->bank_w[1]);
                     break;
@@ -1124,7 +1136,7 @@ mach64_ext_writeb(uint32_t addr, uint8_t val, void *priv)
                     mach64->bank_r[0] = val << 15; // *32768
                     mach64_log("mach64 :  read bank A0000-A7FFF set to %08X\n", mach64->bank_r[0]);
                     break;
-                case 0xb9: case 0xba:
+                case 0xba:
                     mach64->bank_r[1] = val << 15; // *32768
                     mach64_log("mach64 :  read bank A8000-AFFFF set to %08X\n", mach64->bank_r[1]);
                     break;
@@ -1188,8 +1200,20 @@ mach64_ext_writew(uint32_t addr, uint16_t val, void *priv)
         } else if (addr & 0x300) {
             mach64_queue(mach64, addr & 0x3fe, val, FIFO_WRITE_WORD);
         } else {
-            mach64_ext_writeb(addr, val, priv);
-            mach64_ext_writeb(addr + 1, val >> 8, priv);
+            switch (addr & 0x3fe) {
+                case 0xb4:
+                case 0xb6:
+                    mach64->bank_w[(addr & 2) >> 1] = val << 15;
+                    break;
+                case 0xb8:
+                case 0xba:
+                    mach64->bank_r[(addr & 2) >> 1] = val << 15;
+                    break;
+                default:
+                    mach64_ext_writeb(addr, val, priv);
+                    mach64_ext_writeb(addr + 1, val >> 8, priv);
+                    break;
+            }
         }
     }
 }
@@ -1212,8 +1236,20 @@ mach64_ext_writel(uint32_t addr, uint32_t val, void *priv)
         } else if (addr & 0x300) {
             mach64_queue(mach64, addr & 0x3fc, val, FIFO_WRITE_DWORD);
         } else {
-            mach64_ext_writew(addr, val, priv);
-            mach64_ext_writew(addr + 2, val >> 16, priv);
+            switch (addr & 0x3fc) {
+                case 0xb4:
+                    mach64->bank_w[0] = val << 15;
+                    mach64->bank_w[1] = ((val >> 16) << 15);
+                    break;
+                case 0xb8:
+                    mach64->bank_r[0] = val << 15;
+                    mach64->bank_r[1] = ((val >> 16) << 15);
+                    break;
+                default:
+                    mach64_ext_writew(addr, val, priv);
+                    mach64_ext_writew(addr + 2, val >> 16, priv);
+                    break;
+            }
         }
     }
 }
@@ -1246,25 +1282,23 @@ mach64_ext_inb(uint16_t port, void *priv)
         {
             // some special cases
             case 0x56: // 56ec-56ef
-            case 0x5a: 
+            case 0x5a: // 5aec-5aef
 
-                addr_or_value = 0xB4;
+                addr_or_value = 0xb4;
 
                 if (port_high == 0x5a)
-                    addr_or_value = 0xb8;    
+                    addr_or_value = 0xb8;
 
-                if (port_low == 0xEF)
-                    ret = 0x00;
-                else if (port_low == 0xEC)                 
+                if (port_low == 0xEC)
                     ret = mach64_ext_readb(0x400 | addr_or_value, priv);
-                else
-                    ret = mach64_ext_readb(0x400 | (addr_or_value + 1), priv);
-                break; 
+                else if (port_low == 0xEE)
+                    ret = mach64_ext_readb(0x400 | addr_or_value, priv);
+                break;
             case 0x5e: // 5eec-5eef
                 if (mach64->type == MACH64_GX)
                     ret = ati68860_ramdac_in((lane) | ((mach64->dac_cntl & 3) << 2), 0, mach64->svga.ramdac, &mach64->svga);
                 else {
-                    uint16_t port_list[4] = { 0x3c8, 0x3c9, 0x3c6, 0x3c7 }; 
+                    uint16_t port_list[4] = { 0x3c8, 0x3c9, 0x3c6, 0x3c7 };
                     ret = svga_in(port_list[lane], svga);
                 }
                 break;
@@ -1282,7 +1316,7 @@ mach64_ext_inb(uint16_t port, void *priv)
                     addr_or_value = port_high + 0x32;
                 else if ((port_high >= 0x42) && (port_high <= 0x46))
                     addr_or_value = port_high + 0x3E;
-                else if (port_high == 0x4A) 
+                else if (port_high == 0x4A)
                     addr_or_value = 0x90;
                 else if (port_high == 0x52)
                     addr_or_value = 0xb0;
@@ -1352,28 +1386,24 @@ mach64_ext_outb(uint16_t port, uint8_t val, void *priv)
         switch (port_high)
         {
              case 0x56: // 56ec-56ef
-                if (port_low == 0xEF)
-                    break;
-
-                if (port_low == 0xEC)                 
+                mach64_log("BankWrite portlow=%02x, val=%02x.\n", port_low, val);
+                if (port_low == 0xEC)
                     mach64_ext_writeb(0x400 | 0xb4, val, priv);
-                else
-                    mach64_ext_writeb(0x400 | 0xb5, val, priv);
-                break; 
+                else if (port_low == 0xEE)
+                    mach64_ext_writeb(0x400 | 0xb6, val, priv);
+                break;
             case 0x5a: // 5aec-5aef
-                if (port_low == 0xEF)
-                    break;
-
-                if (port_low == 0xEC)                 
+                mach64_log("BankRead portlow=%02x, val=%02x.\n", port_low, val);
+                if (port_low == 0xEC)
                     mach64_ext_writeb(0x400 | 0xb8, val, priv);
-                else
-                    mach64_ext_writeb(0x400 | 0xb9, val, priv);
-                break; 
+                else if (port_low == 0xEE)
+                    mach64_ext_writeb(0x400 | 0xba, val, priv);
+                break;
             case 0x5e: // 5eec-5eef
                 if (mach64->type == MACH64_GX)
                     ati68860_ramdac_out((port & 3) | ((mach64->dac_cntl & 3) << 2), val, 0, svga->ramdac, svga);
                 else {
-                    uint16_t port_list[4] = { 0x3c8, 0x3c9, 0x3c6, 0x3c7 }; 
+                    uint16_t port_list[4] = { 0x3c8, 0x3c9, 0x3c6, 0x3c7 };
                     svga_out(port_list[port & 3], val, svga);
                 }
                 break;
@@ -1395,7 +1425,7 @@ mach64_ext_outb(uint16_t port, uint8_t val, void *priv)
                     addr_or_value = port_high + 0x32;
                 else if ((port_high >= 0x42) && (port_high <= 0x46))
                     addr_or_value = port_high + 0x3E;
-                else if (port_high == 0x4A) 
+                else if (port_high == 0x4A)
                     addr_or_value = 0x90;
                 else if (port_high == 0x52)
                     addr_or_value = 0xb0;
@@ -1815,7 +1845,7 @@ mach64_writel_linear(uint32_t addr, uint32_t val, void *priv)
 
     if (((mach64->scaler_yuv_aper >> 4) & 0xc) && !!(addr & 0x800000) == !(mach64->scaler_yuv_aper & 0x20)) {
         uint32_t offset_from_base = addr & 0x7FFFFF;
-        if (addr & 0x800000) 
+        if (addr & 0x800000)
             bswap32s(&val);
         if (((mach64->scaler_yuv_aper >> 4) & 0xc) == 0x4) { // Y plane
             offset_from_base <<= 1;
@@ -1964,8 +1994,8 @@ mach64_pci_write(UNUSED(int func), int addr, UNUSED(int len), uint8_t val, void 
 {
     mach64_t *mach64 = (mach64_t *) priv;
 
-    // Addresses that DON'T need to 
-    bool dont_remap_io = (addr == PCI_REG_COMMAND // controls the mapping so we don't use the default behaviour  
+    // Addresses that DON'T need to
+    bool dont_remap_io = (addr == PCI_REG_COMMAND // controls the mapping so we don't use the default behaviour
     || addr == PCI_REG_BAR0_BYTE2
     || addr == PCI_REG_BAR0_BYTE3
     || (addr >= PCI_REG_ROM_BAR_BYTE0 || addr <= PCI_REG_ROM_BAR_BYTE3));
@@ -2009,7 +2039,7 @@ mach64_pci_write(UNUSED(int func), int addr, UNUSED(int len), uint8_t val, void 
             break;
         case PCI_REG_ROM_BAR_BYTE0:
         case PCI_REG_ROM_BAR_BYTE2 ... PCI_REG_ROM_BAR_BYTE3:
-            if (mach64->on_board) 
+            if (mach64->on_board)
                 return;
             mach64->pci_regs[addr] = val;
             if (mach64->pci_regs[PCI_REG_ROM_BAR_BYTE0] & 0x01) {

--- a/src/video/vid_ati_mach8.c
+++ b/src/video/vid_ati_mach8.c
@@ -5684,7 +5684,28 @@ mach_accel_in_call(uint16_t port, mach_t *mach, svga_t *svga, ibm8514_t *dev)
 
     switch (port) {
         case 0x2e8:
-        case 0x2e9:
+            if (ATI_MACH32) {
+                if (dev->vc == svga->dispend) {
+                    if (dev->accel.advfunc_cntl & 0x04)
+                        temp |= 0x02;
+                }
+            } else {
+                if (dev->vc == dev->dispend) {
+                    if (dev->accel.advfunc_cntl & 0x04)
+                        temp |= 0x02;
+                }
+            }
+
+            if (((dev->_8514pal[0].r + dev->_8514pal[0].g + dev->_8514pal[0].b) >= 0x4e) ||
+                (dev->_8514pal[0].r >= 0x26) || (dev->_8514pal[0].g >= 0x26) ||
+                (dev->_8514pal[0].b >= 0x26))
+                temp |= 0x00;
+            else
+                temp |= 0x01;
+
+            mach_log(mach->log, "Read: Display Status1=%02x.\n", temp);
+            break;
+
         case 0x6e8:
         case 0x22e8:
         case 0x26e8:
@@ -5698,8 +5719,13 @@ mach_accel_in_call(uint16_t port, mach_t *mach, svga_t *svga, ibm8514_t *dev)
         case 0x42e9:
             if (!(port & 1)) {
                 if ((dev->subsys_cntl & INT_VSY) && !(dev->subsys_stat & INT_VSY)) {
-                    if (dev->vc == dev->dispend)
-                        temp |= INT_VSY;
+                    if (ATI_MACH32) {
+                        if (dev->vc == svga->dispend)
+                            temp |= INT_VSY;
+                    } else {
+                        if (dev->vc == dev->dispend)
+                            temp |= INT_VSY;
+                    }
                 }
 
                 if (mach->accel.cmd_type == -1) {


### PR DESCRIPTION
Summary
=======
1. This makes the ISA and VLB (no aperture) variants usable.
2. Fixed leftover Mach32 part in the writing vram in the 8514/A accelerated commands (it was causing a segfault) when using High Color (15/16bpp).
3. Misc fixes for 0x2e8 reads and subsystem port stuff for the Mach8/32.


Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
[Mach64GX 1994 Reigster datasheet](https://www.vgamuseum.info/images/doc/ati/mach64/rrg-s00700-05_mach64_register_reference_guide_oct94.pdf)
