### PR TITLE
mem: don't dereference NULL when a page table sits in unbacked memory

### DIFF
--- a/src/mem/mem.c
+++ b/src/mem/mem.c
@@ -278,8 +278,26 @@ mem_flush_write_page(uint32_t addr, uint32_t virt)
 
 #define mmutranslate_read(addr)  mmutranslatereal(addr, 0)
 #define mmutranslate_write(addr) mmutranslatereal(addr, 1)
-#define rammap(x)                ((uint32_t *) (_mem_exec[(x) >> MEM_GRANULARITY_BITS]))[((x) >> 2) & MEM_GRANULARITY_QMASK]
-#define rammap64(x)              ((uint64_t *) (_mem_exec[(x) >> MEM_GRANULARITY_BITS]))[((x) >> 3) & MEM_GRANULARITY_PMASK]
+/* A page-table walk can legitimately land on a physical page with no RAM behind it:
+   `_mem_exec[]` is explicitly NULL both for addresses beyond installed RAM and for
+   MMIO-style mappings that have no exec pointer. The old macros cast that NULL and
+   indexed it, so a guest that merely pointed CR3 somewhere unbacked terminated the
+   emulator - observed as an access violation at the `rammap(addr2)` in
+   mmutranslatereal_normal() below, with an Intel Inboard 386/PC and Intel's own
+   INBRDPC.SYS, which does exactly that. Hardware has no notion of "absent" here; it
+   reads the bus and gets floating high bits. So substitute a shared page of 0xFF,
+   matching this file's own convention that an unmapped read returns 0xFF.
+
+   This keeps both macros usable as lvalues, which matters because several callers do
+   `rammap(x) |= ...` to set accessed/dirty bits. Those writes land in the scratch page
+   and are discarded, which is correct for memory that is not there - and the page stays
+   all-ones because the only writes are ORs of a few bits, so it cannot drift into
+   handing back a bogus present entry later. */
+static uint8_t mem_unbacked_pt_page[MEM_GRANULARITY_SIZE];
+
+#define rammap_backing(x)        (_mem_exec[(x) >> MEM_GRANULARITY_BITS] ? _mem_exec[(x) >> MEM_GRANULARITY_BITS] : mem_unbacked_pt_page)
+#define rammap(x)                ((uint32_t *) rammap_backing(x))[((x) >> 2) & MEM_GRANULARITY_QMASK]
+#define rammap64(x)              ((uint64_t *) rammap_backing(x))[((x) >> 3) & MEM_GRANULARITY_PMASK]
 
 static __inline uint64_t
 mmutranslatereal_normal(uint32_t addr, int rw)
@@ -2856,6 +2874,8 @@ mem_reset(void)
     }
 
     memset(_mem_exec, 0x00, sizeof(_mem_exec));
+    /* Reads of absent physical memory return floating high bits - see rammap() above. */
+    memset(mem_unbacked_pt_page, 0xff, sizeof(mem_unbacked_pt_page));
     memset(_mem_wp, 0x00, sizeof(_mem_wp));
     memset(_mem_wp_bus, 0x00, sizeof(_mem_wp_bus));
     memset(write_mapping, 0x00, sizeof(write_mapping));


### PR DESCRIPTION
A guest can terminate 86Box outright — no message, no dialog, just an access violation — by doing
nothing more exotic than pointing `CR3` at physical memory that has no RAM behind it.

`_mem_exec[]` is deliberately `NULL` in two cases: addresses beyond installed RAM, and mappings with
no exec pointer (MMIO-style). `rammap()` / `rammap64()` cast that `NULL` and indexed it:

```c
#define rammap(x)  ((uint32_t *) (_mem_exec[(x) >> MEM_GRANULARITY_BITS]))[((x) >> 2) & MEM_GRANULARITY_QMASK]
```

so the page-table walk in `mmutranslatereal_normal()` dereferences a null pointer:

```
#0  mmutranslatereal_normal (addr=3963, rw=0) at src/mem/mem.c:291
        temp = temp2 = rammap(addr2);
#1  mmutranslatereal
#2  readmembl
#3  exec386
```

### Reproducer

Intel Inboard 386/PC (`ibmxt_inboard386`), `mem_size = 5120`, `bios = ibm5160_050986`, with Intel's
own `INBRDPC.SYS` 1.1 (02/17/89) in `CONFIG.SYS`. The driver enables paging and lands `CR3` above the
top of installed RAM. On stock master (41193b7fe) the emulator exits at t≈20 s with
`0xC0000005`. This is not a contrived case — it is the card's shipping driver doing its normal
initialisation.

### The fix

Real hardware has no notion of "absent" memory here. It reads the bus and gets floating high bits.
So point the macros at a shared scratch page of `0xFF`, which matches the convention `mem.c` already
uses everywhere else — an unmapped read returns `0xFF`.

Keeping this as a macro rather than a function preserves lvalue use, which matters: several callers
do `rammap(x) |= ...` to set accessed and dirty bits. Those writes land in the scratch page and are
discarded, which is the correct outcome for memory that is not there. The page cannot drift into
handing back a bogus present entry later, because the only writes to it are ORs of a few bits into a
page that is already all-ones.

This also covers page tables placed in MMIO space — `NULL` for a different reason, crashing
identically.

### Verification

Same machine and configuration, before and after:

| | stock 41193b7fe | with this change |
|---|---|---|
| `mem_size = 5120` | exits at t≈20 s, `0xC0000005` | runs to completion, driver installs |

After the change the Inboard's driver reports `extended memory detected: 4096k`, `functional
extended memory: 4096k`, `bad extended memory: 0k`, `The iNBRDPC.SYS device driver is installed.`

This stands on its own. It is also a prerequisite for a follow-up fix to `inboard386.c` (#7638) —
without it, satisfying that device's self-test just moves the failure to this access violation.
