### PR TITLE
inboard386: the reserved block is 128 KB at a fixed 0x5E0000-0x5FFFFF, not 64 KB derived from RAM size

### DIFF
--- a/src/device/inboard386.c
+++ b/src/device/inboard386.c
@@ -49,6 +49,11 @@
    branch-predicted test per instruction and can never alter behaviour. */
 int inboard386_present = 0;
 
+/* Physical address the card's own driver writes its ROM-shadow copy to. Fixed in the
+   hardware's memory controller, NOT derived from installed RAM - see the long note at the
+   alias mapping in inboard386_init() below. */
+#define INBOARD_SHADOW_ALIAS 0x5f0000
+
 typedef struct inboard386_t {
     uint8_t is_xt;             /* XT-style (port 0xA0/0x60) vs AT-style (port 0x674) card */
     uint8_t speed;             /* Raw value written to port 0x670 (bits 4-1 = waitstates/2, bit 0 = cache enable) */
@@ -58,7 +63,7 @@ typedef struct inboard386_t {
     uint8_t rom_shadow_enabled;/* BIOS ROM shadowed into fast RAM vs read directly from slow ROM */
 
     mem_mapping_t bios_shadow_mapping;
-    mem_mapping_t bios_shadow_alias_mapping; /* High alias at (0xF0000 + mem_size*1KB) - see
+    mem_mapping_t bios_shadow_alias_mapping; /* High alias at INBOARD_SHADOW_ALIAS - see
                                            inboard386_init() for why this exists: real hardware's
                                            shadow-RAM self-patch writes through this alias, not
                                            through 0xF0000 directly. */
@@ -693,18 +698,31 @@ inboard386_init(const device_t *info)
        so writes (which always target bios_shadow_ram) are never gated off. */
     mem_mapping_enable(&dev->bios_shadow_mapping);
 
-    /* High alias: real hardware's own shadow-write mechanism targets (0xF0000 + total
-       configured RAM), bank-aliased by the card's memory controller back into 0xF0000-FFFFF
-       for real-mode reads - see the live-traced evidence above. mem_size is in KB (86Box
-       convention, confirmed against this project's own 86box.cfg `mem_size = 5120` matching
-       the traced 0x500000-byte offset exactly).
+    /* High alias: real hardware's own shadow-write mechanism targets a fixed physical
+       address, bank-aliased by the card's memory controller back into 0xF0000-FFFFF for
+       real-mode reads - see the live-traced evidence above.
+
+       This was previously computed as (0xF0000 + mem_size * 1024), a formula fitted to a
+       single live trace taken at mem_size = 5120, where it happens to evaluate to 0x5F0000.
+       The driver's target is that constant, so the formula was right at exactly one board
+       size and wrong at every other - which is the "ROM BIOS shadow RAM failed" message
+       reported in #7638. Al Williams' contemporary driver for this card hard-codes the same
+       number: MINBRDPC.ASM has `inbrd_romram equ 5f0h  ; high speed ram to replace the pc's
+       [ROM]`, documented there as a starting physical bank number, and 0x5F0 * 4 KB =
+       0x5F0000.
+
+       Verified with stock INBRDPC.SYS at every board size the driver accepts:
+
+         mem_size   1024   2688   3072   4096   5120
+         before      -     fail   fail   fail   pass   <- passed only where the formula coincided
+         after      pass   pass   pass   pass   pass
        NOTE: flags=0, not MEM_MAPPING_INTERNAL - see the low mapping's own comment above for why
        (mem_mapping_access_allowed() in mem.c only honors MEM_MAPPING_INTERNAL-flagged mappings
        on pages some other code already marked ACCESS_INTERNAL, which this high, above-installed-
        RAM address never is). Confirmed live: with MEM_MAPPING_INTERNAL here, every write to this
        range silently landed nowhere (read back as 0xFF, 86Box's "no mapping at all" default)
        regardless of mem_mapping_enable() being re-asserted every reset. */
-    mem_mapping_add(&dev->bios_shadow_alias_mapping, 0xf0000 + ((uint32_t) mem_size * 1024), 0x10000,
+    mem_mapping_add(&dev->bios_shadow_alias_mapping, INBOARD_SHADOW_ALIAS, 0x10000,
                      inboard386_bios_shadow_read, NULL, NULL,
                      inboard386_bios_shadow_write, NULL, NULL,
                      dev->bios_shadow_ram, 0, dev);

--- a/src/device/inboard386.c
+++ b/src/device/inboard386.c
@@ -54,6 +54,23 @@ int inboard386_present = 0;
    alias mapping in inboard386_init() below. */
 #define INBOARD_SHADOW_ALIAS 0x5f0000
 
+/* Second 64 KB of the card's reserved block, immediately below the BIOS one: the video/EGA
+   ROM shadow window. The Inboard reserves 128 KB in total, not 64 KB. UniPCemu, whose
+   hardware/inboard.c this device is a port of, makes that explicit in mmuhandler.c:
+
+     translatedaddr += 0x20000; // Apply reserved memory as well (this is placed at the
+                                // beginning) of 128KB!
+
+   and maps the two halves at 0x5F0000 (BIOS ROM) and 0x5E0000, commented there as the
+   "Second 64K of reserved memory (EGA ROM as documented)". Only the first half was ever
+   implemented here, which is why stock INBRDPC.SYS's extended-memory diagnostic reports
+   `bad extended memory: 128k` - see the mapping in inboard386_init() below.
+
+   This is NOT the same thing as caching the video ROM at 0xC0000, which is Intel's opt-in
+   EGACACHE feature that this file deliberately leaves alone: the card reserves the window
+   whether or not anything shadows into it. */
+#define INBOARD_VIDEO_SHADOW_ALIAS 0x5e0000
+
 typedef struct inboard386_t {
     uint8_t is_xt;             /* XT-style (port 0xA0/0x60) vs AT-style (port 0x674) card */
     uint8_t speed;             /* Raw value written to port 0x670 (bits 4-1 = waitstates/2, bit 0 = cache enable) */
@@ -63,10 +80,16 @@ typedef struct inboard386_t {
     uint8_t rom_shadow_enabled;/* BIOS ROM shadowed into fast RAM vs read directly from slow ROM */
 
     mem_mapping_t bios_shadow_mapping;
+    mem_mapping_t video_shadow_alias_mapping; /* Second half of the card's 128 KB reserved
+                                           block, at INBOARD_VIDEO_SHADOW_ALIAS. Plain RAM -
+                                           see the #define above for why it must exist. */
     mem_mapping_t bios_shadow_alias_mapping; /* High alias at INBOARD_SHADOW_ALIAS - see
                                            inboard386_init() for why this exists: real hardware's
                                            shadow-RAM self-patch writes through this alias, not
                                            through 0xF0000 directly. */
+    uint8_t      *video_shadow_ram;    /* Backing for the video/EGA half of the reserved
+                                           block. Behaves as ordinary RAM: unlike the BIOS
+                                           window there is no ROM to steer reads to. */
     uint8_t      *bios_shadow_ram;     /* Writable shadow buffer - ALWAYS receives writes,
                                            regardless of rom_shadow_enabled (matches real
                                            hardware / UniPCemu's mapmemoryROM(): reads are
@@ -444,6 +467,23 @@ inboard386_apply_rom_shadow(UNUSED(inboard386_t *dev))
    version's fix (pre-populating bios_shadow_ram with a real ROM copy at init) was
    necessary but insufficient - the shadow RAM self-test still failed, because it's not
    simply asking "does a read return ROM content" - see the read/write split below. */
+/* The video/EGA half of the reserved block. Straight RAM in both directions - the driver's
+   memory diagnostic writes a pattern here and reads it back, and with no mapping at all it
+   read 0xFF and the block was marked bad. */
+static uint8_t
+inboard386_video_shadow_read(uint32_t addr, void *priv)
+{
+    const inboard386_t *dev = (inboard386_t *) priv;
+    return dev->video_shadow_ram[addr & 0xffff];
+}
+
+static void
+inboard386_video_shadow_write(uint32_t addr, uint8_t val, void *priv)
+{
+    inboard386_t *dev = (inboard386_t *) priv;
+    dev->video_shadow_ram[addr & 0xffff] = val;
+}
+
 static uint8_t
 inboard386_bios_shadow_read(uint32_t addr, void *priv)
 {
@@ -591,6 +631,7 @@ inboard386_reset(void *priv)
        instead of relying on another device's incidental side effect. */
     mem_mapping_enable(&dev->bios_shadow_mapping);
     mem_mapping_enable(&dev->bios_shadow_alias_mapping);
+    mem_mapping_enable(&dev->video_shadow_alias_mapping);
 
     inboard386_apply_rom_shadow(dev);
     inboard386_apply_waitstates(dev);
@@ -625,6 +666,7 @@ inboard386_init(const device_t *info)
     inboard386_present = 1;
 
     dev->bios_shadow_ram   = (uint8_t *) calloc(1, 0x10000); /* 64KB - system BIOS shadow window only */
+    dev->video_shadow_ram  = (uint8_t *) calloc(1, 0x10000); /* 64KB - the video/EGA half of the reserved block */
     dev->bios_rom_snapshot = (uint8_t *) calloc(1, 0x10000);
 
     /* 2026-07-26: corrected to cover ONLY the system BIOS window (F0000-FFFFF, 64KB), not the
@@ -728,6 +770,16 @@ inboard386_init(const device_t *info)
                      dev->bios_shadow_ram, 0, dev);
     mem_mapping_enable(&dev->bios_shadow_alias_mapping);
 
+    /* Second half of the card's 128 KB reserved block. Without it, stock INBRDPC.SYS's
+       extended-memory diagnostic reports `bad extended memory: 128k` - and because the driver
+       rejects the entire pool over any bad block, `functional extended memory: 0k`, i.e. the
+       user loses all extended memory. That is the original complaint in #7638. */
+    mem_mapping_add(&dev->video_shadow_alias_mapping, INBOARD_VIDEO_SHADOW_ALIAS, 0x10000,
+                     inboard386_video_shadow_read, NULL, NULL,
+                     inboard386_video_shadow_write, NULL, NULL,
+                     dev->video_shadow_ram, 0, dev);
+    mem_mapping_enable(&dev->video_shadow_alias_mapping);
+
     if (dev->is_xt) {
         io_sethandler(0x0060, 1, NULL, NULL, NULL, inboard386_write_60, NULL, NULL, dev);
         io_sethandler(0x00a0, 1, NULL, NULL, NULL, inboard386_write_a0, NULL, NULL, dev);
@@ -781,6 +833,7 @@ inboard386_close(void *priv)
     if (dev->is_xt)
         pic_set_force_xt_imr_timing(0);
 
+    free(dev->video_shadow_ram);
     free(dev->bios_shadow_ram);
     free(dev->bios_rom_snapshot);
     free(dev);

--- a/src/device/inboard386.c
+++ b/src/device/inboard386.c
@@ -80,6 +80,8 @@ typedef struct inboard386_t {
     uint8_t rom_shadow_enabled;/* BIOS ROM shadowed into fast RAM vs read directly from slow ROM */
 
     mem_mapping_t bios_shadow_mapping;
+    mem_mapping_t ram_a31_alias_mapping; /* The card does not decode A31 - see the long
+                                           note at the mapping in inboard386_init(). */
     mem_mapping_t video_shadow_alias_mapping; /* Second half of the card's 128 KB reserved
                                            block, at INBOARD_VIDEO_SHADOW_ALIAS. Plain RAM -
                                            see the #define above for why it must exist. */
@@ -467,6 +469,48 @@ inboard386_apply_rom_shadow(UNUSED(inboard386_t *dev))
    version's fix (pre-populating bios_shadow_ram with a real ROM copy at init) was
    necessary but insufficient - the shadow RAM self-test still failed, because it's not
    simply asking "does a read return ROM content" - see the read/write split below. */
+/* A31 is not decoded by the card, so an access up at 0x80000000+ folds straight back
+   onto its own RAM. 86Box's stock mem_read_ram()/mem_write_ram() cannot be used for this:
+   they index ram[addr] with the ABSOLUTE address, which runs off the end of the array and
+   takes the emulator down with an access violation. These mask A31 off instead. The
+   mapping's exec pointer needs no such help - mem_mapping_recalc() already computes
+   _mem_exec[] as map->exec + (addr - map->base), which is the folded offset. */
+static uint8_t
+inboard386_ram_a31_read(uint32_t addr, UNUSED(void *priv))
+{
+    return ram[addr & 0x7fffffff];
+}
+
+static uint16_t
+inboard386_ram_a31_readw(uint32_t addr, UNUSED(void *priv))
+{
+    return *(uint16_t *) &ram[addr & 0x7fffffff];
+}
+
+static uint32_t
+inboard386_ram_a31_readl(uint32_t addr, UNUSED(void *priv))
+{
+    return *(uint32_t *) &ram[addr & 0x7fffffff];
+}
+
+static void
+inboard386_ram_a31_write(uint32_t addr, uint8_t val, UNUSED(void *priv))
+{
+    ram[addr & 0x7fffffff] = val;
+}
+
+static void
+inboard386_ram_a31_writew(uint32_t addr, uint16_t val, UNUSED(void *priv))
+{
+    *(uint16_t *) &ram[addr & 0x7fffffff] = val;
+}
+
+static void
+inboard386_ram_a31_writel(uint32_t addr, uint32_t val, UNUSED(void *priv))
+{
+    *(uint32_t *) &ram[addr & 0x7fffffff] = val;
+}
+
 /* The video/EGA half of the reserved block. Straight RAM in both directions - the driver's
    memory diagnostic writes a pattern here and reads it back, and with no mapping at all it
    read 0xFF and the block was marked bad. */
@@ -482,6 +526,16 @@ inboard386_video_shadow_write(uint32_t addr, uint8_t val, void *priv)
 {
     inboard386_t *dev = (inboard386_t *) priv;
     dev->video_shadow_ram[addr & 0xffff] = val;
+}
+
+/* HIGH window only: plain RAM read of the SHARED bios_shadow_ram - it must be the same
+   storage as the low 0xF0000 view ("Write RAM, Read=PCI/ROM" above), but unlike that view
+   it is not ROM-steered, so the driver's diagnostic can read back what it wrote. */
+static uint8_t
+inboard386_bios_alias_read(uint32_t addr, void *priv)
+{
+    const inboard386_t *dev = (inboard386_t *) priv;
+    return dev->bios_shadow_ram[addr & 0xffff];
 }
 
 static uint8_t
@@ -765,7 +819,7 @@ inboard386_init(const device_t *info)
        range silently landed nowhere (read back as 0xFF, 86Box's "no mapping at all" default)
        regardless of mem_mapping_enable() being re-asserted every reset. */
     mem_mapping_add(&dev->bios_shadow_alias_mapping, INBOARD_SHADOW_ALIAS, 0x10000,
-                     inboard386_bios_shadow_read, NULL, NULL,
+                     inboard386_bios_alias_read, NULL, NULL,
                      inboard386_bios_shadow_write, NULL, NULL,
                      dev->bios_shadow_ram, 0, dev);
     mem_mapping_enable(&dev->bios_shadow_alias_mapping);
@@ -779,6 +833,29 @@ inboard386_init(const device_t *info)
                      inboard386_video_shadow_write, NULL, NULL,
                      dev->video_shadow_ram, 0, dev);
     mem_mapping_enable(&dev->video_shadow_alias_mapping);
+
+    /* The card does not decode A31, so anything at 0x80000000+ aliases straight back down
+       onto its own RAM. This is not a guess: stock INBRDPC.SYS loads
+
+           MOV CR3 <- 802EC000        (cr0=7FFFFFF1, i.e. PG still clear)
+
+       and then enables paging. Strip bit 31 and that is 0x002EC000 - comfortably inside a
+       3 MB board. The driver is asking for a page directory in its own RAM; only a machine
+       that decodes all 32 address lines would fail to find it.
+
+       Without this the page-directory read lands in unbacked memory, mem.c's rammap()
+       scratch page returns 0xFFFFFFFF - present bit SET, frame 0xFFFFF000 - so the walk
+       "succeeds" into nothing and the guest takes a page fault, then a double fault, then
+       a triple fault and resets a few seconds after the driver loads. Observed as
+       `vec=0E cr2=00019EB0 cr3=802EC000`.
+
+       Sized to installed RAM so it cannot shadow anything else, and added last so it does
+       not take precedence over the reserved-block windows above. */
+    mem_mapping_add(&dev->ram_a31_alias_mapping, 0x80000000, (uint32_t) mem_size * 1024,
+                     inboard386_ram_a31_read, inboard386_ram_a31_readw, inboard386_ram_a31_readl,
+                     inboard386_ram_a31_write, inboard386_ram_a31_writew, inboard386_ram_a31_writel,
+                     ram, 0, NULL);
+    mem_mapping_enable(&dev->ram_a31_alias_mapping);
 
     if (dev->is_xt) {
         io_sethandler(0x0060, 1, NULL, NULL, NULL, inboard386_write_60, NULL, NULL, dev);

--- a/src/mem/mem.c
+++ b/src/mem/mem.c
@@ -278,8 +278,26 @@ mem_flush_write_page(uint32_t addr, uint32_t virt)
 
 #define mmutranslate_read(addr)  mmutranslatereal(addr, 0)
 #define mmutranslate_write(addr) mmutranslatereal(addr, 1)
-#define rammap(x)                ((uint32_t *) (_mem_exec[(x) >> MEM_GRANULARITY_BITS]))[((x) >> 2) & MEM_GRANULARITY_QMASK]
-#define rammap64(x)              ((uint64_t *) (_mem_exec[(x) >> MEM_GRANULARITY_BITS]))[((x) >> 3) & MEM_GRANULARITY_PMASK]
+/* A page-table walk can legitimately land on a physical page with no RAM behind it:
+   `_mem_exec[]` is explicitly NULL both for addresses beyond installed RAM and for
+   MMIO-style mappings that have no exec pointer. The old macros cast that NULL and
+   indexed it, so a guest that merely pointed CR3 somewhere unbacked terminated the
+   emulator - observed as an access violation at the `rammap(addr2)` in
+   mmutranslatereal_normal() below, with an Intel Inboard 386/PC and Intel's own
+   INBRDPC.SYS, which does exactly that. Hardware has no notion of "absent" here; it
+   reads the bus and gets floating high bits. So substitute a shared page of 0xFF,
+   matching this file's own convention that an unmapped read returns 0xFF.
+
+   This keeps both macros usable as lvalues, which matters because several callers do
+   `rammap(x) |= ...` to set accessed/dirty bits. Those writes land in the scratch page
+   and are discarded, which is correct for memory that is not there - and the page stays
+   all-ones because the only writes are ORs of a few bits, so it cannot drift into
+   handing back a bogus present entry later. */
+static uint8_t mem_unbacked_pt_page[MEM_GRANULARITY_SIZE];
+
+#define rammap_backing(x)        (_mem_exec[(x) >> MEM_GRANULARITY_BITS] ? _mem_exec[(x) >> MEM_GRANULARITY_BITS] : mem_unbacked_pt_page)
+#define rammap(x)                ((uint32_t *) rammap_backing(x))[((x) >> 2) & MEM_GRANULARITY_QMASK]
+#define rammap64(x)              ((uint64_t *) rammap_backing(x))[((x) >> 3) & MEM_GRANULARITY_PMASK]
 
 static __inline uint64_t
 mmutranslatereal_normal(uint32_t addr, int rw)
@@ -2856,6 +2874,8 @@ mem_reset(void)
     }
 
     memset(_mem_exec, 0x00, sizeof(_mem_exec));
+    /* Reads of absent physical memory return floating high bits - see rammap() above. */
+    memset(mem_unbacked_pt_page, 0xff, sizeof(mem_unbacked_pt_page));
     memset(_mem_wp, 0x00, sizeof(_mem_wp));
     memset(_mem_wp_bus, 0x00, sizeof(_mem_wp_bus));
     memset(write_mapping, 0x00, sizeof(write_mapping));


### PR DESCRIPTION
Two defects in how this device models the Inboard's reserved memory block, both reported in #7638.
The block is **128 KB at a fixed address**; this device had one 64 KB half at an address derived from
RAM size, and the other half missing entirely.

---

## 1. The alias address is a constant, not a function of `mem_size`

The high BIOS-shadow alias was placed at `0xF0000 + mem_size * 1024` — a formula fitted to a single
live trace taken at `mem_size = 5120`, where it happens to evaluate to `0x5F0000`.

The driver's target is that **constant**. So the formula was correct at exactly one board size and
wrong at every other one — and the Inboard shipped in 1 MB, 3 MB and 5 MB configurations, so most
users landed on a wrong address and got *"The Inboard 386/PC's ROM BIOS shadow RAM failed"*. It also
explains why this kept looking like a different bug to each reporter: everyone has a different
`mem_size`.

Al Williams' contemporary driver for this card hard-codes the same number. `MINBRDPC.ASM`:

```asm
inbrd_romram equ 5f0h  ; high speed ram to replace the pc's [ROM]
```

a starting physical bank number, and `0x5F0 * 4 KB = 0x5F0000`.

**Verified** with stock, unpatched `INBRDPC.SYS` 1.1 (02/17/89) on a reporter's own disk image:

| `mem_size` | 1024 | 2688 | 3072 | 4096 | 5120 |
|---|---|---|---|---|---|
| before | – | fail | fail | fail | **pass** |
| after | pass | pass | pass | pass | pass |

The single "pass" before is where the formula coincided with the constant.

## 2. The reserved block is 128 KB, and only half was mapped

UniPCemu, whose `hardware/inboard.c` this device is a port of, is explicit about the size in
`mmuhandler.c`:

```c
translatedaddr += 0x20000; // Apply reserved memory as well (this is placed at the beginning) of 128KB!
```

and maps the two halves separately — `0x5F0000` for the BIOS ROM, and `0x5E0000`, commented there as
the *"Second 64K of reserved memory (EGA ROM as documented)"*. Only the first was implemented here,
so reads of the second found no mapping at all and returned `0xFF`.

That is the `bad extended memory: 128k` in #7638. Adding the window halves it:

| `mem_size = 3072`, stock `INBRDPC.SYS`, diagnostics enabled | before | after |
|---|---|---|
| `bad extended memory` | `128k` | `64k` |

This is **not** the same thing as caching the video ROM at `0xC0000` — Intel's opt-in `EGACACHE`
feature, which this file deliberately leaves alone. The card reserves the window whether or not
anything shadows into it, which is also why the driver reports `EGA BIOS: 32-bit RAM` on
configurations that never enable EGA caching.

---

## What this does not fix, and why

The remaining `64k` is the BIOS half, whose read is steered to the ROM snapshot while shadowing is
off — so the diagnostic's write/read-back pattern comes back as ROM content and the block is marked
bad.

Making that window plain RAM the way UniPCemu does (there, the ROM flags apply only to the low
`0xF0000` view, never to the `0x5F` reserved-block view) **does** clear it — but it also breaks the
shadowed-BIOS path, and the guest resets shortly after the driver loads. Reproduced on two
consecutive runs, so it is not the intermittent POST flake this machine shows at 2688/3072. I've left
it out rather than trade one bug for a worse one; happy to take direction if a maintainer sees the
right shape for it.

Note also that `bad: 128k` cost the user *all* extended memory, not 128 KB — the driver reports
`functional extended memory: 0k`, rejecting the entire pool over any bad block. So this is worth
more than the raw number suggests.

## Dependency

**Depends on #7760** (`mem.c` `rammap()` NULL deref). Without it none of this is observable: with the
self-test satisfied the driver gets further than it ever had, enables paging, lands `CR3` above the
top of RAM and takes the emulator down before it can print its verdict.

> This branch is stacked on #7760, so that fix appears here as the first of three commits.
