### PR TITLE
inboard386: the high shadow alias must read shadow RAM, not ROM

### DIFF
--- a/src/device/inboard386.c
+++ b/src/device/inboard386.c
@@ -542,6 +542,26 @@ static uint8_t
 inboard386_bios_shadow_read(uint32_t addr, void *priv)
 {
     const inboard386_t *dev = (inboard386_t *) priv;
+    /* Which window the access arrived through decides what it sees - not a global flag.
+       The low F0000-FFFFF window is where the CPU fetches BIOS code, so with shadowing
+       off it must return ROM. The high alias at 0x5F0000 is not a code-fetch window at
+       all: it is the card's bank-alias into the shadow buffer, which is how the driver
+       loads the shadow in the first place and how its memory diagnostic probes the
+       block. On the card that alias reads back the shadow RAM whether or not shadowing
+       is switched on for the F0000 window.
+
+       Keying both windows off rom_shadow_enabled is what left `bad extended memory: 64k`
+       standing. Writes were never gated (see the write handler below), so the driver's
+       diagnostic writes its test pattern through the alias - it lands in bios_shadow_ram -
+       then reads it straight back with shadowing still off and gets ROM. The block is
+       marked bad, and INBRDPC.SYS rejects the ENTIRE extended pool over one bad block,
+       which is why the panel reported `functional extended memory: 64k` on a 2048k board.
+
+       Making this window plain RAM in both directions also clears the diagnostic, but it
+       breaks the BIOS code-fetch path and resets the guest shortly after the driver loads.
+       Splitting on the address leaves the low window byte-for-byte as it was. */
+    if (addr >= 0x100000)
+        return dev->bios_shadow_ram[addr & 0xffff];
     if (dev->rom_shadow_enabled)
         return dev->bios_shadow_ram[addr & 0xffff];
     return dev->bios_rom_snapshot[addr & 0xffff];


### PR DESCRIPTION
Follow-up to #7761. This is the remaining half of #7638 — the `bad extended memory: 64k` that
#7761 deliberately left standing.

## The bug

`inboard386_bios_shadow_read()` served two different windows off one flag:

- the **low** `F0000-FFFFF` window — where the CPU fetches BIOS code. With shadowing off it has
  to return ROM.
- the **high** alias at `0x5F0000` — which is not a code-fetch window at all. It is the card's
  bank-alias into the shadow buffer: it is how `INBRDPC.SYS` loads the shadow, and how its memory
  diagnostic probes that block. On the card the alias reads back shadow RAM whether or not
  shadowing is switched on for `F0000`.

Writes were never gated, only reads. So the driver's diagnostic writes its test pattern through
the alias — it lands in `bios_shadow_ram` — reads it straight back with shadowing still off, and
gets **ROM**. The block is marked bad, and `INBRDPC.SYS` then rejects the **entire** extended pool
over that one bad block.

## Measured

Reporter's disk image from #7638, stock unpatched `INBRDPC.SYS` 1.1, diagnostics enabled (no
`NODIAGS`), `mem_size = 3072`:

| | before | after |
|---|---|---|
| `extended memory detected` | 2048k | 2048k |
| `extended memory diagnosed` | 2048k | 2048k |
| **`functional extended memory`** | **64k** | **2048k** |
| **`bad extended memory`** | **64k** | **0k** |

At `mem_size = 5120` the downstream effect is clearer — 386MAX installs instead of bailing out:

```
ILIM386 has set up  4736K bytes of total system memory as follows:
   640K bytes are conventional memory
  4096K bytes are extended memory, of which:
       140K bytes are used by the ILIM386 device driver
       516K bytes are available as extended memory
      3440K bytes are available as expanded memory
```

Previously that read *"Insufficient extended memory available […] Total available = 0 KB […]
Memory manager NOT installed."*

At `mem_size = 1024` the panel reports `extended memory detected: 0k`, which is correct — a 1 MB
board is 640 KB conventional plus the card's 384 KB reserved, and has no extended memory. Those
three sizes are the only configurations the card ships.

## Why not plain RAM

Making this window plain RAM in **both** directions also clears the diagnostic, but it breaks the
BIOS code-fetch path and resets the guest shortly after the driver loads — which is why it was
left out of #7761. Splitting on the address leaves the low window byte-for-byte as it was.

## Correction

I reported in #7638 that the A31 change in #7761 had finished this off. It had not. That change
fixed 386MAX's `CR3` walk — real, and it is why the guest gets as far as `AUTOEXEC.BAT` — but it
never touched this 64 KB, and my verification of that claim was run against a stale binary built
before the A31 commit landed. `bad: 64k` was still reproducible on the reporter's image this
morning. Apologies for the noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
