### PR TITLE
inboard386: don't attach a 5161 by default - it posts 1801 on every boot

### DIFF
--- a/src/machine/m_xt.c
+++ b/src/machine/m_xt.c
@@ -679,7 +679,18 @@ static const device_config_t ibmxt_inboard386_config[] = {
         .description    = "IBM 5161 Expansion Unit",
         .type           = CONFIG_BINARY,
         .default_string = NULL,
-        .default_int    = 1,
+        /* Defaults off on this machine, unlike the rest of the ibmxt family: a 5160 fitted
+           with an Inboard 386/PC has no expansion chassis.
+
+           With one attached the 5160 BIOS's expansion-unit probe at F000:E452 writes 0x55
+           then 0xAA to port 0x210 and reads both back successfully, concludes a receiver
+           card is present, reads the address latches at 0x215/0x216, gets 0x00, and posts
+           1801 - stopping every cold boot at ERROR. (RESUME = "F1" KEY).
+
+           (ibm_5161.c answers the presence probe but does not implement the address-latch
+           readback the BIOS then verifies, so an enabled 5161 fails POST on the other XT
+           machines too. That is a separate issue and is not addressed here.) */
+        .default_int    = 0,
         .file_filter    = NULL,
         .spinner        = { 0 },
         .selection      = { { 0 } },


### PR DESCRIPTION
Selecting **IBM XT (Inboard 386/PC)** currently stops at `ERROR. (RESUME = "F1" KEY)` on **every**
cold boot, after posting `1801`.

## Cause

The 5160 BIOS probes for an expansion unit at `F000:E452` by writing `0x55` then `0xAA` to port
`0x210` and reading each back. `enable_5161` defaults to `1`, so `ibm_5161_device` is attached and
both read-backs succeed — the BIOS concludes a receiver card is present, reads the address latches
at `0x215`/`0x216`, gets `0x00`, and posts `1801`.

Traced, with the default as-is:

```
[exp] IN 0210 -> 55 found=1 CS:PC=F000:0000E452
[exp] IN 0210 -> AA found=1 CS:PC=F000:0000E45C
[exp] IN 0215 -> 00 found=1 CS:PC=F000:0000E46E
[exp] IN 0216 -> 00 found=1 CS:PC=F000:0000E474
```

and with the 5161 not attached:

```
[exp] IN 0210 -> FF found=0 CS:PC=F000:0000E452
```

POST then goes straight to the memory count. No `1801`, no F1 prompt.

## Fix

A 5160 fitted with an Inboard 386/PC has no expansion chassis, so this machine's config defaults
`enable_5161` to `0`. **The other `ibmxt`-family machines are untouched** — they can legitimately
have one, and their default stays `1`.

## Why a default change rather than a docs note

Machine config is read from a section named after the machine **device's** `.name`:

```c
/* src/device.c, machine_get_config_int() */
const device_t *dev = machine_get_device(machine);
return config_get_int((char *) dev->name, str, cfg->default_int);
```

An existing `86box.cfg` written before this machine was renamed therefore has its `enable_5161` key
silently ignored and falls back to the compiled-in default. Changing the default is what actually
reaches those users — verified against an unmodified pre-existing config.

## Related, deliberately not fixed here

`ibm_5161.c` answers the presence probe but never implements the address-latch readback the BIOS
then verifies. So an **enabled** 5161 fails POST with `1801` on `ibmxt`/`ibmxt86` too — i.e. the
device as emulated cannot currently pass the BIOS's expansion-unit test on any XT machine. That
looked out of scope for this change, but I am happy to take a look separately if it is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
