### PR TITLE
Adds the string for FPU dynarec accuracy option to POT/PO files

### DIFF
--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -420,6 +420,9 @@ msgstr ""
 msgid "Dynamic recompiler"
 msgstr ""
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr ""
 

--- a/src/qt/languages/ca-ES.po
+++ b/src/qt/languages/ca-ES.po
@@ -426,6 +426,9 @@ msgstr "Utilitzeu l'intèrpret 486 per a processadors 286 i 386"
 msgid "Dynamic recompiler"
 msgstr "Recompilador dinàmic"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "Mida de blocs de la CPU"
 

--- a/src/qt/languages/cs-CZ.po
+++ b/src/qt/languages/cs-CZ.po
@@ -426,6 +426,9 @@ msgstr "Použít interpreter 486 pro procesory 286 a 386"
 msgid "Dynamic recompiler"
 msgstr "Dynamický překladač"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "Velikost CPU rámců"
 

--- a/src/qt/languages/de-DE.po
+++ b/src/qt/languages/de-DE.po
@@ -426,6 +426,9 @@ msgstr "Verwende den 486-Interpreter für 286- und 386-Prozessoren"
 msgid "Dynamic recompiler"
 msgstr "Dynamischer Recompiler"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "CPU-Framegröße"
 

--- a/src/qt/languages/el-GR.po
+++ b/src/qt/languages/el-GR.po
@@ -426,6 +426,9 @@ msgstr "Χρησιμοποιήστε τον διερμηνέα 486 για επε
 msgid "Dynamic recompiler"
 msgstr "Δυναμικός αναμεταγλωττιστής"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "Μέγεθος πλαισίου CPU"
 

--- a/src/qt/languages/es-ES.po
+++ b/src/qt/languages/es-ES.po
@@ -426,6 +426,9 @@ msgstr "Utilizar el interpretador 486 para los procesadores 286 y 386"
 msgid "Dynamic recompiler"
 msgstr "Recompilador dinámico"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "Tamaño de blocos de CPU"
 

--- a/src/qt/languages/fi-FI.po
+++ b/src/qt/languages/fi-FI.po
@@ -426,6 +426,9 @@ msgstr "Käytä 486-tulkintaa 286- ja 386-prosessoreille"
 msgid "Dynamic recompiler"
 msgstr "Dynaaminen uudelleenkääntäjä"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "CPU frame-koko"
 

--- a/src/qt/languages/fr-FR.po
+++ b/src/qt/languages/fr-FR.po
@@ -426,6 +426,9 @@ msgstr "Employer l'interprète 486 pour les processeurs 286 et 386"
 msgid "Dynamic recompiler"
 msgstr "Recompilateur dynamique"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "Taille du bloc de processeur"
 

--- a/src/qt/languages/hr-HR.po
+++ b/src/qt/languages/hr-HR.po
@@ -428,6 +428,9 @@ msgstr "Koristi interpretator za 486 i za procesore 286 i 386"
 msgid "Dynamic recompiler"
 msgstr "Dinamički rekompilator"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "Veličina blokova procesora"
 

--- a/src/qt/languages/it-IT.po
+++ b/src/qt/languages/it-IT.po
@@ -428,6 +428,9 @@ msgstr "Utilizza l'interprete 486 per i processori 286 e 386"
 msgid "Dynamic recompiler"
 msgstr "Ricompilatore dinamico"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "Dimensione blocchi CPU"
 

--- a/src/qt/languages/ja-JP.po
+++ b/src/qt/languages/ja-JP.po
@@ -427,6 +427,9 @@ msgstr "286および386プロセッサには486インタプリタを使用する
 msgid "Dynamic recompiler"
 msgstr "動的再コンパイル"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "CPUフレームサイズ"
 

--- a/src/qt/languages/ko-KR.po
+++ b/src/qt/languages/ko-KR.po
@@ -426,6 +426,9 @@ msgstr "286/386 프로세서에 486 인터프리터 사용"
 msgid "Dynamic recompiler"
 msgstr "동적 리컴파일러"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "CPU 프레임 크기"
 

--- a/src/qt/languages/nb-NO.po
+++ b/src/qt/languages/nb-NO.po
@@ -427,6 +427,9 @@ msgstr "Bruk 486-tolken for 286- og 386-prosessorer"
 msgid "Dynamic recompiler"
 msgstr "Dynamisk recompilator"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "CPU-rammestørrelse"
 

--- a/src/qt/languages/nl-NL.po
+++ b/src/qt/languages/nl-NL.po
@@ -426,6 +426,9 @@ msgstr "Gebruik de 486-interpreter voor 286- en 386-processoren"
 msgid "Dynamic recompiler"
 msgstr "Dynamische recompiler"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "CPU framegrootte"
 

--- a/src/qt/languages/pl-PL.po
+++ b/src/qt/languages/pl-PL.po
@@ -427,6 +427,9 @@ msgstr "Użyj interpretera 486 dla procesorów 286 i 386"
 msgid "Dynamic recompiler"
 msgstr "Dynamiczny rekompilator"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "Rozmiar ramki CPU"
 

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2026-08-15 17:18+0000\n"
+"PO-Revision-Date: 2026-08-25 16:50+0000\n"
 "Last-Translator: Nelson Kerber Hennemann Filho <nelsonhf@outlook.com>\n"
 "Language-Team: Portuguese (Brazil) <https://weblate.86box.net/projects/86box/"
 "86box/pt_BR/>\n"
@@ -428,7 +428,7 @@ msgid "Dynamic recompiler"
 msgstr "Recompilador dinâmico"
 
 msgid "Accurate FPU environment on the dynamic recompiler"
-msgstr ""
+msgstr "Ambiente FPU preciso no recompilador dinâmico"
 
 msgid "CPU frame size"
 msgstr "Tamanho do quadro da CPU"

--- a/src/qt/languages/pt-BR.po
+++ b/src/qt/languages/pt-BR.po
@@ -427,6 +427,9 @@ msgstr "Usar o interpretador 486 para processadores 286 e 386"
 msgid "Dynamic recompiler"
 msgstr "Recompilador dinâmico"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "Tamanho do quadro da CPU"
 

--- a/src/qt/languages/pt-PT.po
+++ b/src/qt/languages/pt-PT.po
@@ -427,6 +427,9 @@ msgstr "Utilizar o interpetador 486 para os processadores 286 e 386"
 msgid "Dynamic recompiler"
 msgstr "Recompilador dinâmico"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "Tamanho de blocos do CPU"
 

--- a/src/qt/languages/ru-RU.po
+++ b/src/qt/languages/ru-RU.po
@@ -427,6 +427,9 @@ msgstr "Использовать интерпретатор 486 для проц�
 msgid "Dynamic recompiler"
 msgstr "Динамический рекомпилятор"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "Размер кадра ЦП"
 

--- a/src/qt/languages/sk-SK.po
+++ b/src/qt/languages/sk-SK.po
@@ -426,6 +426,9 @@ msgstr "Použi interpret 486 pre procesory 286 a 386"
 msgid "Dynamic recompiler"
 msgstr "Dynamický prekladač"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "Veľkosť rámcov CPU"
 

--- a/src/qt/languages/sl-SI.po
+++ b/src/qt/languages/sl-SI.po
@@ -428,6 +428,9 @@ msgstr "Uporabi interpreter za 486 tudi za procesorje 286 in 386"
 msgid "Dynamic recompiler"
 msgstr "Dinamični prevajalnik"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "Velikost blokov procesorja"
 

--- a/src/qt/languages/sv-SE.po
+++ b/src/qt/languages/sv-SE.po
@@ -426,6 +426,9 @@ msgstr "Använd 486-programtolk för 286- och 386-processorer"
 msgid "Dynamic recompiler"
 msgstr "Dynamisk omkompilator"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "Ramstorlek för processor"
 

--- a/src/qt/languages/tr-TR.po
+++ b/src/qt/languages/tr-TR.po
@@ -426,6 +426,9 @@ msgstr "286 ve 386 işlemcilerde 486 yorumlayıcısını kullan"
 msgid "Dynamic recompiler"
 msgstr "Dinamik derleyici"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "İşlemci kare boyutu"
 

--- a/src/qt/languages/uk-UA.po
+++ b/src/qt/languages/uk-UA.po
@@ -428,6 +428,9 @@ msgstr "Використовувати інтерпретатор 486 для п�
 msgid "Dynamic recompiler"
 msgstr "Динамічний рекомпілятор"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "Розмір кадру ЦП"
 

--- a/src/qt/languages/vi-VN.po
+++ b/src/qt/languages/vi-VN.po
@@ -427,6 +427,9 @@ msgstr "Sử dụng trình thông dịch 486 cho các bộ xử lý 286 và 386"
 msgid "Dynamic recompiler"
 msgstr "Bộ tái biên dịch động (Dynamic recompiler)"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "Cỡ khung CPU"
 

--- a/src/qt/languages/zh-CN.po
+++ b/src/qt/languages/zh-CN.po
@@ -427,6 +427,9 @@ msgstr "为286及386处理器应用486解释器"
 msgid "Dynamic recompiler"
 msgstr "动态重编译器"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "CPU 执行帧大小"
 

--- a/src/qt/languages/zh-TW.po
+++ b/src/qt/languages/zh-TW.po
@@ -427,6 +427,9 @@ msgstr "啟用 486 直譯器於 286 及 386 處理器"
 msgid "Dynamic recompiler"
 msgstr "動態重編譯器"
 
+msgid "Accurate FPU environment on the dynamic recompiler"
+msgstr ""
+
 msgid "CPU frame size"
 msgstr "CPU 執行期框架大小"
 


### PR DESCRIPTION
Summary
=======
This PR adds the string added by the commit bd92e71 to the POT and PO files for translations. Also updates the pt-BR translation

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.