### PR TITLE
Thread: Free thread wrappers after joining

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -30,6 +30,7 @@ thread_wait(thread_t *arg)
         return 0;
     auto thread = reinterpret_cast<std::thread *>(arg);
     thread->join();
+    delete thread;
     return 0;
 }
 

--- a/src/unix/unix_thread.c
+++ b/src/unix/unix_thread.c
@@ -48,7 +48,10 @@ thread_create_named(void (*thread_rout)(void *param), void *param, const char *n
 int
 thread_wait(thread_t *arg)
 {
-    return pthread_join(*(pthread_t *) (arg), NULL);
+    int ret = pthread_join(*(pthread_t *) (arg), NULL);
+    if (!ret)
+        free(arg);
+    return ret;
 }
 
 event_t *


### PR DESCRIPTION
Summary
=======
The C++ and POSIX thread backends allocate opaque thread wrappers in `thread_create_named()`, but `thread_wait()` did not release them after a successful join. Release each wrapper once the join completes so repeated create/wait cycles do not leak one allocation per thread.

Tested with the default C++ thread backend and with the SDL/Unix `CPPTHREADS=OFF` configuration. Focused wrapper-lifetime tests pass for both backends and fail against the unmodified sources.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
