### PR TITLE
dma: honour dma_force_xt when latching the page register

### DIFF
--- a/src/dma.c
+++ b/src/dma.c
@@ -112,6 +112,18 @@ dma_set_force_xt(int enable)
     dma_force_xt = enable;
 }
 
+/* True when this machine latches only the low 4 bits of a DMA page register,
+   as the PC/XT does, rather than the full 8 bits an AT does. dma_at alone gets
+   this wrong for an XT board fitted with a 286-or-higher accelerator: dma_at is
+   assigned is286, so such a machine is handed a 24-bit DMA reach where the real
+   hardware has 20-bit, and a driver placing its buffer above 1 MB appears to
+   work in emulation while silently transferring from the wrong address. */
+static int
+dma_page_is_xt(void)
+{
+    return dma_force_xt || !dma_at;
+}
+
 int
 dma_xt8237_active(void)
 {
@@ -1513,7 +1525,7 @@ dma_page_write(uint16_t addr, uint8_t val, UNUSED(void *priv))
             dma[addr].ab   = (dma[addr].ab & 0xff01ffff & dma_mask) | (dma[addr].page << 16);
             dma[addr].ac   = (dma[addr].ac & 0xff01ffff & dma_mask) | (dma[addr].page << 16);
         } else {
-            dma[addr].page = dma_at ? val : val & 0xf;
+            dma[addr].page = dma_page_is_xt() ? (val & 0x0f) : val;
             dma[addr].ab   = (dma[addr].ab & 0xff00ffff & dma_mask) | (dma[addr].page << 16);
             dma[addr].ac   = (dma[addr].ac & 0xff00ffff & dma_mask) | (dma[addr].page << 16);
         }
@@ -1761,7 +1773,7 @@ dma_reset(void)
         dma[4].arb_level    = 4;
     }
 
-    if (!dma_at)
+    if (dma_page_is_xt())
         dma_m = (dma_m & 0xf0) | 0x0f;
 }
 


### PR DESCRIPTION
## The problem

`dma_page_write()` decides how many bits of a DMA page register to latch:

```c
dma[addr].page = dma_at ? val : val & 0xf;
```

`dma_at` is assigned `is286`. That conflates *CPU class* with *board class*, which is correct for
every stock machine but wrong for an XT motherboard fitted with a 286-or-higher accelerator — the
Intel Inboard 386/PC on a 5150/5160 being the case in tree today. The 8237 and its page latches are
the ones soldered to the XT board; putting a 386 in the CPU socket does not widen them.

The result is that such a machine is handed a **24-bit DMA reach where the real hardware has
20-bit**. A guest driver that places its DMA buffer above 1 MB then appears to work under emulation
while, on real hardware, the page register drops the high nibble and the 8237 transfers from a
completely different physical address.

`dma_force_xt` already exists for exactly this class of machine (added with the Inboard in #7626)
and is already consulted by `dma_xt8237_active()`. It simply was not consulted here.

## The change

Three lines, plus a comment. A helper expressing the predicate:

```c
static int
dma_page_is_xt(void)
{
    return dma_force_xt || !dma_at;
}
```

used at the two places that currently test `dma_at` / `!dma_at` for this purpose — the page
register latch, and the `dma_m` channel-mask default in `dma_reset()`.

## Why this is a no-op for every other machine

For any machine that never calls `dma_set_force_xt()`, `dma_force_xt` is 0 and
`dma_page_is_xt()` reduces to `!dma_at`. The two expressions are then identical:

| `dma_at` | before | after | same? |
|---|---|---|---|
| true  | `val`       | `dma_page_is_xt()` is false → `val`       | yes |
| false | `val & 0xf` | `dma_page_is_xt()` is true → `val & 0x0f` | yes |

Same for `dma_reset()`: `if (!dma_at)` becomes `if (dma_page_is_xt())`, which is the same
condition unless the machine opted in. The only machine in tree that opts in is the Inboard.

## What is verified, and what is not

**Verified:**
- Builds clean at `2f6fff3` (MinGW-w64 / Ninja, `RelWithDebInfo`, Qt off) — 285/285, no new warnings.
- The equivalence above is by inspection of the two expressions, not by assertion.
- The predicate itself is not speculative. It has been running in a downstream fork against a real
  IBM 5160 + Inboard 386/PC, where a page-register trace caught the truncation live:
  `MSSBLST.VXD` allocated a buffer at `0x4E0000`, the 4-bit latch reduced it to `0x0E0000`
  (adapter ROM space), and the Sound Blaster Pro played the contents of ROM. Correcting the
  driver's `_PageAllocate` `maxPhys` to keep the buffer under 1 MB produced clean audio on the
  real machine.

**Not verified:**
- I have not boot-tested other XT- or AT-class machines against this build. The argument that they
  are unaffected is the equivalence table above rather than a test matrix. If you would like a
  spot-check on specific machines before merging, say which and I will run them.

## Sources for the 20-bit figure

The 4-bit page register on the PC/XT, and the reach that follows from it:

- <https://www.os2museum.com/wp/8237a-dma-page-fun/>
- <https://www.os2museum.com/wp/386max-and-eisa-dma/>
- <https://book.martypc.net/support-chips/dma-8237>
- The open-source 386MAX memory manager, whose `MARK_XT` path sets `DMA_MAX = 0A0000h` — a
  primary-source confirmation, and in fact a stricter ceiling (640 KB) than the 1 MB this change
  enforces. This patch deliberately implements the 1 MB hardware limit, not the stricter figure a
  memory manager chooses to observe.

Credit for identifying the page register as the cause, before any of it was measured, belongs to
**@andrew-hoffman**.
