### PR TITLE
CMS: Fix noise generation and stereo output

### DIFF
--- a/src/include/86box/snd_cms.h
+++ b/src/include/86box/snd_cms.h
@@ -29,7 +29,7 @@ typedef struct cms_s {
     float    count[2][6];
     uint8_t  vol[2][6][2];
     uint8_t  stat[2][6];
-    uint16_t noise[2][2];
+    uint32_t noise[2][2];
     uint16_t noisefreq[2][2];
     uint16_t noisecount[2][2];
     uint8_t  noisetype[2][2];

--- a/src/sound/snd_cms.c
+++ b/src/sound/snd_cms.c
@@ -92,16 +92,16 @@ cms_update(cms_t *cms)
                         if (cms->noise[c][d / 3] & 1)
                             out_l += (cms->vol[c][d][0] * 90);
                         if (cms->noise[c][d / 3] & 1)
-                            out_r += (cms->vol[c][d][0] * 90);
+                            out_r += (cms->vol[c][d][1] * 90);
                     }
                 }
                 for (uint8_t d = 0; d < 2; d++) {
                     cms->noisecount[c][d] += cms->noisefreq[c][d];
                     while (cms->noisecount[c][d] >= 24000) {
                         cms->noisecount[c][d] -= 24000;
-                        cms->noise[c][d] <<= 1;
-                        if (!(((cms->noise[c][d] & 0x4000) >> 8) ^ (cms->noise[c][d] & 0x40)))
-                            cms->noise[c][d] |= 1;
+                        const uint32_t noise    = cms->noise[c][d];
+                        const uint32_t feedback = !(((noise >> 17) ^ (noise >> 10)) & 1);
+                        cms->noise[c][d]        = (noise << 1) | feedback;
                     }
                 }
             }


### PR DESCRIPTION
Summary
=======
The CMS noise path used a 16-bit shift register and feedback taps that do not match the SAA1099's 18-bit noise generator. Widen the state and use the `x^18 + x^11 + x` feedback polynomial so sound effects get the full 262143-state noise sequence.

Noise-only output also used the left amplitude for both stereo channels. Use the right amplitude for the right output.

A focused harness checks the noise sequence, its period, and independent stereo levels. It passes with this change and fails against `master`. The full macOS arm64 build also completes successfully.

Checklist
=========
* [x] Closes #6557
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
* Philips SAA1099 data sheet: https://bitsavers.org/components/philips/_dataBooks/1986_IC01_Philips_Radio_Audio_and_Associated_Systems.pdf
* MAME SAA1099 implementation: https://github.com/mamedev/mame/blob/master/src/devices/sound/saa1099.cpp
