### PR TITLE
char_pipe: Restore non-blocking Windows pipes

### DIFF
--- a/src/char/char_pipe.c
+++ b/src/char/char_pipe.c
@@ -146,7 +146,7 @@ char_pipe_connect(char_pipe_t *dev, int startup)
     char  fmt[512];
     DWORD create_err = 0;
     if (dev->mode != CHAR_PIPE_MODE_CLIENT) {
-        dev->fd = CreateNamedPipeA(dev->path, PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE, PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT, 1, 65536, 65536, NMPWAIT_USE_DEFAULT_WAIT, NULL);
+        dev->fd = CreateNamedPipeA(dev->path, PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE, PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_NOWAIT, 1, 65536, 65536, NMPWAIT_USE_DEFAULT_WAIT, NULL);
         if (CHAR_FD_VALID(dev->fd)) {
             char_pipe_log(dev->log, "Created new pipe: %s\n", dev->path);
             dev->block_connect = !dev->reconnect;
@@ -172,7 +172,7 @@ client:
             dev->server        = 0;
 
             /* Configure client pipe. */
-            DWORD mode = PIPE_READMODE_BYTE | PIPE_WAIT;
+            DWORD mode = PIPE_READMODE_BYTE | PIPE_NOWAIT;
             SetNamedPipeHandleState(dev->fd, &mode, NULL, NULL);
         } else {
             DWORD err = GetLastError();


### PR DESCRIPTION
Summary
=======
Build 8762, reported as the first bad build in #7294, introduced the new Windows named-pipe backend with blocking pipe handles. Both pipe reads and writes run on emulator timer callbacks, so a synchronous write can stop emulation while waiting for pipe capacity.

Restore `PIPE_NOWAIT` for both the server and client handles, matching the working 5.3 behavior while retaining the newer `PeekNamedPipe` and reconnect handling.

A standalone Win32 probe reproduced the backpressure failure: `PIPE_WAIT` blocked after filling the unread 65536-byte pipe buffer, while `PIPE_NOWAIT` returned immediately with a zero-byte write. The full macOS debug build passes, and the changed Windows translation unit passes a warning-enabled MinGW compile. I did not use the uploaded TDREMOTE virtual machines because their DOS software licensing is unclear, so confirmation with the original setup is still welcome.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
https://learn.microsoft.com/en-us/windows/win32/ipc/named-pipe-type-read-and-wait-modes