### PR TITLE
ATI Mach32: do not use linedbl in accelerator mode.

### DIFF
--- a/src/video/vid_8514a.c
+++ b/src/video/vid_8514a.c
@@ -4187,13 +4187,7 @@ ibm8514_poll(void *priv)
                 if ((svga->scanline == (svga->crtc[11] & 31)) || (svga->scanline == svga->rowcount))
                     svga->cursorvisible = 0;
                 if (svga->dispon) {
-                    /* TODO: Verify real hardware behaviour for out-of-range fine vertical scroll
-                       - S3 Trio64V2/DX: scanline == rowcount, wrapping 5-bit counter. */
-                    if (svga->linedbl && !svga->linecountff) {
-                        svga->linecountff = 1;
-                        svga->memaddr          = svga->memaddr_backup;
-                    } else if (svga->scanline == svga->rowcount) {
-                        svga->linecountff = 0;
+                    if (svga->scanline == svga->rowcount) {
                         svga->scanline          = 0;
 
                         svga->memaddr_backup += (svga->rowoffset << 3);
@@ -4203,7 +4197,6 @@ ibm8514_poll(void *priv)
                         svga->memaddr_backup &= svga->vram_display_mask;
                         svga->memaddr = svga->memaddr_backup;
                     } else {
-                        svga->linecountff = 0;
                         svga->scanline++;
                         svga->scanline &= 0x1f;
                         svga->memaddr = svga->memaddr_backup;
@@ -4308,8 +4301,6 @@ ibm8514_poll(void *priv)
                     svga->half_pixel  = 0;
 
                     svga->x_add = svga->left_overscan;
-
-                    svga->linecountff = 0;
 
                     svga->hwcursor_on    = 0;
                     svga->hwcursor_latch = svga->hwcursor;


### PR DESCRIPTION
Summary
=======
Fixes doubled renderer in 8514/A/ATI mode.

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
