### PR TITLE
macOS: Fix process activity lifetime

### DIFF
--- a/src/qt/macos_event_filter.mm
+++ b/src/qt/macos_event_filter.mm
@@ -100,6 +100,7 @@ void enter_pause(void)
         return;
     
     [[NSProcessInfo processInfo] endActivity: process_activity];
+    [process_activity release];
     process_activity = nil;
     pause_entered = true;
 }
@@ -112,6 +113,6 @@ void exit_pause(void)
     // NSActivityUserInteractive is a bitwise OR of NSActivityUserInitiated and NSActivityLatencyCritical.
     // However, allow the system to sleep if needed by using NSActivityUserInitiatedAllowingIdleSystemSleep instead of NSActivityUserInitiated.
     // And allow the system to terminate it as needed.
-    process_activity = [[NSProcessInfo processInfo] beginActivityWithOptions: ((NSActivityUserInitiatedAllowingIdleSystemSleep &~ (NSActivitySuddenTerminationDisabled | NSActivityAutomaticTerminationDisabled)) | NSActivityLatencyCritical) reason:@"Unpaused."];
+    process_activity = [[[NSProcessInfo processInfo] beginActivityWithOptions: ((NSActivityUserInitiatedAllowingIdleSystemSleep &~ (NSActivitySuddenTerminationDisabled | NSActivityAutomaticTerminationDisabled)) | NSActivityLatencyCritical) reason:@"Unpaused."] retain];
     pause_entered = false;
 }


### PR DESCRIPTION
Summary
=======
The macOS App Nap integration stored the activity returned by `beginActivityWithOptions:reason:` in a static variable, but `macos_event_filter.mm` is compiled without ARC. The assignment therefore did not retain the activity. Once the surrounding autorelease pool drained, Foundation deallocated the activity and a later pause or Settings action passed a dangling pointer to `endActivity:`, crashing on the main thread.

Retain the activity for the unpaused interval and release it after `endActivity:`. This also keeps the App Nap assertion alive for the full interval it is intended to cover.

A focused harness linked the production `macos_event_filter.mm` object and drained an autorelease pool between each unpause and pause. Under Zombies, the object from `master` crashes on the first cycle with a message to a deallocated `_NSActivityAssertion`; the fixed object completes 1000 cycles. The full macOS arm64 debug build also completes successfully.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
