### PR TITLE
Input: Consume mouse release shortcut

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -1691,21 +1691,21 @@ MainWindow::eventFilter(QObject *receiver, QEvent *event)
     // TODO: Could this be simplified by proxying the event and manually
     // shoving it into the menubar?
     if (event->type() == QEvent::KeyPress) {
-        this->keyPressEvent((QKeyEvent *) event);
-
         // We check for mouse release even if we aren't fullscreen,
         // because it's not a menu accelerator.
-        if (event->type() == QEvent::KeyPress) {
-            QKeyEvent *ke = (QKeyEvent *) event;
+        QKeyEvent *ke = (QKeyEvent *) event;
+        if (mouse_capture) {
             if ((QKeySequence) (ke->key() | (ke->modifiers() & ~Qt::KeypadModifier)) == FindAcceleratorSeq("release_mouse") || (QKeySequence) (ke->key() | ke->modifiers()) == FindAcceleratorSeq("release_mouse")) {
+                keyboard_all_up();
                 plat_mouse_capture(0);
+                event->accept();
+                return true;
             }
-
         }
 
-        if (event->type() == QEvent::KeyPress && video_fullscreen != 0) {
-            QKeyEvent *ke = (QKeyEvent *) event;
+        this->keyPressEvent(ke);
 
+        if (event->type() == QEvent::KeyPress && video_fullscreen != 0) {
             if ((QKeySequence) (ke->key() | (ke->modifiers() & ~Qt::KeypadModifier)) == FindAcceleratorSeq("screenshot")
                 || (QKeySequence) (ke->key() | ke->modifiers()) == FindAcceleratorSeq("screenshot")) {
                 ui->actionTake_screenshot->trigger();

--- a/src/unix/sdl_main.c
+++ b/src/unix/sdl_main.c
@@ -612,12 +612,16 @@ main(int argc, char **argv)
                             }
 #endif
 #ifdef USE_SDL2_LIB
-                            keyboard_input(event.key.state == SDL_PRESSED, xtkey);
+                            const int key_down = event.key.state == SDL_PRESSED;
 #else
-                            keyboard_input(event.key.down, xtkey);
+                            const int key_down = event.key.down;
 #endif
-                            if ((keyboard_get_shift() & 0x11) && keyboard_recv_ui(0x14f) && mouse_capture)
+                            if (key_down && (xtkey == 0x14f) && (keyboard_get_shift() & 0x11) && mouse_capture) {
+                                keyboard_all_up();
                                 plat_mouse_capture(0);
+                                break;
+                            }
+                            keyboard_input(key_down, xtkey);
                             break;
                         }
 #ifdef USE_SDL2_LIB


### PR DESCRIPTION
Summary
=======
Consume the mouse release shortcut before forwarding its trigger key to the guest in the Qt and SDL frontends. Previously, the complete shortcut was delivered first, so the default Ctrl+End binding could move a guest list or caret immediately before mouse capture was released. This also releases guest-held keys when uncapturing so shortcut modifiers cannot remain stuck when keyboard input requires capture.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

Testing
=======
Built the macOS Qt frontend successfully and compiled the changed SDL input translation unit successfully. The full fresh SDL build later stopped at an unrelated missing AL/al.h header in the local macOS OpenAL framework.

References
==========
The defect was reproduced with the default Ctrl+End binding on the macOS Qt frontend: the guest processed End before capture was released.