### PR TITLE
Input: Use Ctrl+Alt+G to release mouse

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -287,7 +287,7 @@ struct accelKey def_acc_keys[NUM_ACCELS] = {
     {
         .name="release_mouse",
         .desc="Release mouse pointer",
-        .seq="Ctrl+End"
+        .seq="Ctrl+Alt+G"
     },
     {
         .name="hard_reset",

--- a/src/unix/sdl_main.c
+++ b/src/unix/sdl_main.c
@@ -616,7 +616,7 @@ main(int argc, char **argv)
 #else
                             keyboard_input(event.key.down, xtkey);
 #endif
-                            if ((keyboard_get_shift() & 0x11) && keyboard_recv_ui(0x14f) && mouse_capture)
+                            if ((keyboard_get_shift() & 0x11) && (keyboard_get_shift() & 0x44) && keyboard_recv_ui(0x22) && mouse_capture)
                                 plat_mouse_capture(0);
                             break;
                         }

--- a/src/unix/sdl_render.c
+++ b/src/unix/sdl_render.c
@@ -720,7 +720,7 @@ update_mouse_msg(void)
              "Click to capture mouse");
     snprintf(mouse_msg[1], sizeof(mouse_msg[1]), "%s v%s - %%i%%%% - %s - %s/%s - %s",
              EMU_NAME, EMU_VERSION_FULL, machine_getname(machine), cpufamily, cpu_s->name,
-             (mouse_get_buttons() > 2) ? "Press CTRL-END to release mouse" : "Press CTRL-END or middle button to release mouse");
+             (mouse_get_buttons() > 2) ? "Press CTRL-ALT-G to release mouse" : "Press CTRL-ALT-G or middle button to release mouse");
     snprintf(mouse_msg[2], sizeof(mouse_msg[2]), "%s v%s - %%i%%%% - %s - %s/%s",
              EMU_NAME, EMU_VERSION_FULL, machine_getname(machine), cpufamily, cpu_s->name);
 }


### PR DESCRIPTION
Summary
=======
Change the default mouse release shortcut from Ctrl+End to Ctrl+Alt+G in the Qt and SDL frontends. Ctrl+End is difficult to discover on compact keyboards because End may require a platform-specific Fn chord, and Qt renders it as a diagonal arrow glyph on macOS. Ctrl+Alt+G is mnemonic for toggling the input grab, avoids navigation keys, does not conflict with another default 86Box binding, and is also the convention used by QEMU. Custom user bindings are preserved.

This depends on #7779, which prevents the release shortcut trigger from reaching the guest before capture is released.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

Testing
=======
Built the macOS Qt frontend successfully and compiled the changed SDL frontend translation units successfully.

References
==========
QEMU uses Ctrl+Alt+G to toggle mouse and keyboard grab: https://www.qemu.org/docs/master/system/keys.html