### PR TITLE
 Add BIOS version option for the latest stock AN430TX BIOS and set it as default

### DIFF
--- a/src/machine/m_at_socket7.c
+++ b/src/machine/m_at_socket7.c
@@ -1939,7 +1939,7 @@ static const device_config_t an430tx_config[] = {
             },
             {
                 .name          = "PhoenixBIOS 4.0 Release 6.0 - Revision P09-0006 (Packard Bell PB79x)",
-                .internal_name = "an430tx",
+                .internal_name = "pb79x",
                 .bios_type     = BIOS_NORMAL,
                 .files_no      = 5,
                 .local         = 0,
@@ -1947,6 +1947,17 @@ static const device_config_t an430tx_config[] = {
                 .files         = { "roms/machines/an430tx/ANP0911A.BIO", "roms/machines/an430tx/ANP0911A.BI1",
                                    "roms/machines/an430tx/ANP0911A.BI2", "roms/machines/an430tx/ANP0911A.BI3",
                                    "roms/machines/an430tx/ANP0911A.RCV", "" }
+            },
+            {
+                .name          = "PhoenixBIOS 4.0 Release 6.0 - Revision P10-0095",
+                .internal_name = "an430tx",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 5,
+                .local         = 0,
+                .size          = 262144,
+                .files         = { "roms/machines/an430tx/P10-0095.BIO", "roms/machines/an430tx/P10-0095.BI1",
+                                   "roms/machines/an430tx/P10-0095.BI2", "roms/machines/an430tx/P10-0095.BI3",
+                                   "roms/machines/an430tx/P10-0095.RCV", "" }
             },
             { .files_no = 0 }
         }


### PR DESCRIPTION
Summary
=======
 Add BIOS version option for the latest stock AN430TX BIOS and set it as default, now that it works with the SMI fix

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
N/A
