### PR TITLE
Input: Prevent menu activation on mouse release

### DIFF
--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -1696,6 +1696,9 @@ MainWindow::eventFilter(QObject *receiver, QEvent *event)
         QKeyEvent *ke = (QKeyEvent *) event;
         if (mouse_capture) {
             if ((QKeySequence) (ke->key() | (ke->modifiers() & ~Qt::KeypadModifier)) == FindAcceleratorSeq("release_mouse") || (QKeySequence) (ke->key() | ke->modifiers()) == FindAcceleratorSeq("release_mouse")) {
+                /* Prevent an Alt-based shortcut from looking like a standalone
+                 * Alt press to the guest when the held modifiers are released. */
+                this->keyReleaseEvent(ke);
                 keyboard_all_up();
                 plat_mouse_capture(0);
                 event->accept();

--- a/src/unix/sdl_main.c
+++ b/src/unix/sdl_main.c
@@ -617,6 +617,9 @@ main(int argc, char **argv)
                             const int key_down = event.key.down;
 #endif
                             if (key_down && (keyboard_get_shift() & 0x11) && (keyboard_get_shift() & 0x44) && (xtkey == 0x22) && mouse_capture) {
+                                /* Prevent an Alt-based shortcut from looking like a standalone
+                                 * Alt press to the guest when the held modifiers are released. */
+                                keyboard_input(0, xtkey);
                                 keyboard_all_up();
                                 plat_mouse_capture(0);
                                 break;


### PR DESCRIPTION
Summary
=======
Prevent the mouse release shortcut from activating a guest menu when its held modifiers are released. The trigger key is consumed before reaching the guest, but Ctrl and Alt have already been forwarded by the time the complete chord is recognized. Sending a break-only event for the trigger key before releasing the modifiers preserves the absence of a guest key press while preventing Windows from interpreting Alt as a standalone tap. Apply the same ordering to the Qt and SDL frontends.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

Testing
=======
Built the complete macOS Qt frontend from current master and compiled the changed SDL translation unit. Reproduced the regression in Windows 95 WordPad, then verified that Ctrl+Alt+G releases capture without entering text, moving guest content, or highlighting the File menu.

References
==========
Follow-up to #7779 and #7780. VirtualBox documents the same break-before-Alt-release technique for preventing unwanted Windows menu activation: https://www.virtualbox.org/ticket/2613