### PR TITLE
Mem: Preserve eviction links when remapping RAM

### DIFF
--- a/src/mem/mem.c
+++ b/src/mem/mem.c
@@ -2990,7 +2990,6 @@ mem_remap_top_ex_common(int kb, uint32_t start, int mid)
         pages[c].write_w = set ? mem_write_ramw_page : NULL;
         pages[c].write_l = set ? mem_write_raml_page : NULL;
 #ifdef USE_NEW_DYNAREC
-        pages[c].evict_prev             = EVICT_NOT_IN_LIST;
         pages[c].byte_dirty_mask        = &byte_dirty_mask[(addr >> 12) * 64];
         pages[c].byte_code_present_mask = &byte_code_present_mask[(addr >> 12) * 64];
 #endif
@@ -3017,7 +3016,6 @@ mem_remap_top_ex_common(int kb, uint32_t start, int mid)
             pages[c].write_l = NULL;
         }
 #ifdef USE_NEW_DYNAREC
-        pages[c].evict_prev             = EVICT_NOT_IN_LIST;
         pages[c].byte_dirty_mask        = &byte_dirty_mask[c * 64];
         pages[c].byte_code_present_mask = &byte_code_present_mask[c * 64];
 #endif


### PR DESCRIPTION
Summary
=======

Preserve new-dynarec page eviction-list metadata while conventional memory is remapped.

`mem_remap_top_ex_common()` changes the backing-memory pointers and byte masks for existing pages, but it also marked those pages as absent from the eviction list without unlinking them. After a Windows 95 soft restart on the VIA VT82C496G board, a remapped page could remain the list head while its membership marker said otherwise. The next purge then aborted with `page_remove_from_evict_list: not in evict list!`.

The page table already initializes eviction membership when it is allocated, so the remapping path should leave the live list links intact.

Checklist
=========

* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

Testing
=======

Reproduced with a 486-VIP-IO2 Windows 95 VM and a guest helper that calls `ExitWindowsEx(EWX_REBOOT)`. The unmodified debug/new-dynarec build aborted during the first soft restart. With this change, three consecutive guest-initiated soft restarts completed and returned to the Windows network logon dialog without the fatal error.

Built the macOS Qt and SDL frontends in Debug configuration with the new dynarec enabled.

References
==========

None.
