### PR TITLE
Input: Map macOS Control-click to right button

### DIFF
--- a/src/qt/cocoa_mouse.hpp
+++ b/src/qt/cocoa_mouse.hpp
@@ -12,4 +12,8 @@ public:
     CocoaEventFilter() {};
     ~CocoaEventFilter();
     virtual bool nativeEventFilter(const QByteArray &eventType, void *message, result_t *result) override;
+
+private:
+    bool control_click_active = false;
+    bool right_button_active  = false;
 };

--- a/src/qt/macos_event_filter.mm
+++ b/src/qt/macos_event_filter.mm
@@ -46,25 +46,37 @@ CocoaEventFilter::nativeEventFilter(const QByteArray &eventType, void *message, 
                     return false;
                 case NSEventTypeLeftMouseDown:
                     {
-                        b = mouse_get_buttons_ex() | 1;
+                        if ([event modifierFlags] & NSEventModifierFlagControl) {
+                            control_click_active = true;
+                            b = mouse_get_buttons_ex() | 2;
+                        } else {
+                            b = mouse_get_buttons_ex() | 1;
+                        }
                         mouse_set_buttons_ex(b);
                         break;
                     }
                 case NSEventTypeLeftMouseUp:
                     {
-                        b = mouse_get_buttons_ex() & ~1;
+                        if (control_click_active) {
+                            control_click_active = false;
+                            b = right_button_active ? mouse_get_buttons_ex() : mouse_get_buttons_ex() & ~2;
+                        } else {
+                            b = mouse_get_buttons_ex() & ~1;
+                        }
                         mouse_set_buttons_ex(b);
                         break;
                     }
                 case NSEventTypeRightMouseDown:
                     {
+                        right_button_active = true;
                         b = mouse_get_buttons_ex() | 2;
                         mouse_set_buttons_ex(b);
                         break;
                     }
                 case NSEventTypeRightMouseUp:
                     {
-                        b = mouse_get_buttons_ex() & ~2;
+                        right_button_active = false;
+                        b = control_click_active ? mouse_get_buttons_ex() : mouse_get_buttons_ex() & ~2;
                         mouse_set_buttons_ex(b);
                         break;
                     }

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -243,6 +243,16 @@ RendererStack::mouseReleaseEvent(QMouseEvent *event)
         return;
     }
     if (mouse_capture || (mouse_input_mode >= 1)) {
+        Qt::MouseButton button = event->button();
+#ifdef __APPLE__
+        if ((button == Qt::LeftButton) && control_click_active) {
+            control_click_active = false;
+            button = right_button_active ? Qt::NoButton : Qt::RightButton;
+        } else if (button == Qt::RightButton) {
+            right_button_active = false;
+            button = control_click_active ? Qt::NoButton : Qt::RightButton;
+        }
+#endif
 #ifdef Q_OS_WINDOWS
         if (((m_monitor_index >= 1) && (mouse_input_mode >= 1) && mousedata.mouse_tablet_in_proximity) || ((m_monitor_index < 1) && (mouse_input_mode >= 1)))
 #else
@@ -252,7 +262,7 @@ RendererStack::mouseReleaseEvent(QMouseEvent *event)
         if (((m_monitor_index >= 1) && (mouse_input_mode >= 1) && mousedata.mouse_tablet_in_proximity) || (m_monitor_index < 1))
 #    endif
 #endif
-            mouse_set_buttons_ex(mouse_get_buttons_ex() & ~event->button());
+            mouse_set_buttons_ex(mouse_get_buttons_ex() & ~button);
     }
     isMouseDown &= ~1;
 }
@@ -262,6 +272,15 @@ RendererStack::mousePressEvent(QMouseEvent *event)
 {
     isMouseDown |= 1;
     if (mouse_capture || (mouse_input_mode >= 1)) {
+        Qt::MouseButton button = event->button();
+#ifdef __APPLE__
+        if ((button == Qt::LeftButton) && (event->modifiers() & Qt::ControlModifier)) {
+            control_click_active = true;
+            button = Qt::RightButton;
+        } else if (button == Qt::RightButton) {
+            right_button_active = true;
+        }
+#endif
 #ifdef Q_OS_WINDOWS
         if (((m_monitor_index >= 1) && (mouse_input_mode >= 1) && mousedata.mouse_tablet_in_proximity) || ((m_monitor_index < 1) && (mouse_input_mode >= 1)))
 #else
@@ -271,7 +290,7 @@ RendererStack::mousePressEvent(QMouseEvent *event)
         if (((m_monitor_index >= 1) && (mouse_input_mode >= 1) && mousedata.mouse_tablet_in_proximity) || (m_monitor_index < 1))
 #    endif
 #endif
-            mouse_set_buttons_ex(mouse_get_buttons_ex() | event->button());
+            mouse_set_buttons_ex(mouse_get_buttons_ex() | button);
     }
     event->accept();
 }

--- a/src/qt/qt_rendererstack.hpp
+++ b/src/qt/qt_rendererstack.hpp
@@ -110,6 +110,11 @@ public:
 
     void (*mouse_exit_func)() = nullptr;
 
+#ifdef __APPLE__
+    bool control_click_active = false;
+    bool right_button_active  = false;
+#endif
+
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     /* OpenGL/Vulkan renderers ARE QWindows; dynamic_cast returns the QWindow
      * for pointer capture (Wayland, xinput2). Software renderer returns nullptr


### PR DESCRIPTION
On macOS, Control-click is the standard way to perform a secondary click when using a one-button mouse configuration. The native Cocoa input path currently forwards it as a guest left click because it only considers the physical mouse button.

Map Control-left-click to the guest right button in both the captured Cocoa path and the Qt path used by absolute input. Track Control-click and physical right-button state separately so releasing either source does not release the guest button while the other source is still held.

Tested with a Qt 5 debug build on macOS and a Windows 95 guest using a PS/2 mouse. Context clicks, alternate release ordering, repeated clicks, normal left clicks and drags, right-button dragging, keyboard Control shortcuts, and follow-up physical secondary clicks behaved correctly.
