### PR TITLE
Tape Backup and Restore with DDS/DAT-72 support.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2384,6 +2384,13 @@ go_to_mo:
             sscanf("00, none", "%u, %s", &tape_drives[c].type, s);
         tape_drives[c].bus_type = hdd_string_to_bus(s, 1);
 
+        sprintf(temp, "tape_%02i_medium_type", c + 1);
+        tape_drives[c].medium_type = ini_section_get_int(cat, temp,
+            (tape_drives[c].type < KNOWN_TAPE_DRIVE_TYPES) ?
+            tape_drive_types[tape_drives[c].type].default_media : 0);
+        if (tape_drives[c].medium_type >= KNOWN_TAPE_TYPES)
+            tape_drives[c].medium_type = 0;
+
         /* Default values, needed for proper operation of the Settings dialog. */
         tape_drives[c].scsi_device_id = c + 4;
 
@@ -2465,6 +2472,9 @@ go_to_mo:
             ini_section_delete_var(cat, temp);
 
             sprintf(temp, "tape_%02i_image_path", c + 1);
+            ini_section_delete_var(cat, temp);
+
+            sprintf(temp, "tape_%02i_medium_type", c + 1);
             ini_section_delete_var(cat, temp);
 
             for (int i = 0; i < MAX_PREV_IMAGES; i++) {
@@ -4451,6 +4461,12 @@ save_other_removable_devices(void)
             ini_section_delete_var(cat, temp);
         else
             save_image_file(cat, temp, tape_drives[c].image_path);
+
+        sprintf(temp, "tape_%02i_medium_type", c + 1);
+        if (tape_drives[c].bus_type == 0)
+            ini_section_delete_var(cat, temp);
+        else
+            ini_section_set_int(cat, temp, tape_drives[c].medium_type);
 
         for (int i = 0; i < MAX_PREV_IMAGES; i++) {
             sprintf(temp, "tape_%02i_image_history_%02i", c + 1, i + 1);

--- a/src/include/86box/scsi_device.h
+++ b/src/include/86box/scsi_device.h
@@ -231,6 +231,7 @@
 #define SENSE_UNIT_ATTENTION  6
 #define SENSE_DATA_PROTECT    7
 #define SENSE_BLANK_CHECK     8
+#define SENSE_VOLUME_OVERFLOW 13
 
 /* SCSI Additional Sense Codes */
 #define ASC_NONE                               0x00

--- a/src/include/86box/scsi_device.h
+++ b/src/include/86box/scsi_device.h
@@ -95,6 +95,8 @@
 #define GPCMD_PLAY_AUDIO_TRACK_RELATIVE_10            0x49
 #define GPCMD_GET_EVENT_STATUS_NOTIFICATION           0x4a
 #define GPCMD_PAUSE_RESUME                            0x4b
+#define GPCMD_LOG_SELECT                              0x4c
+#define GPCMD_LOG_SENSE                               0x4d
 #define GPCMD_STOP_PLAY_SCAN                          0x4e
 #define GPCMD_READ_DISC_INFORMATION                   0x51
 #define GPCMD_READ_TRACK_INFORMATION                  0x52

--- a/src/include/86box/scsi_tape.h
+++ b/src/include/86box/scsi_tape.h
@@ -154,8 +154,12 @@ typedef struct tape_t {
     int                bot;            /* Beginning-of-tape. */
     int                filemark_pending; /* A filemark was just encountered. */
     uint8_t            active_partition; /* Selected logical partition. */
-    uint8_t            aux_filemark;     /* Virtual auxiliary partition contents. */
-    uint8_t            aux_pos;          /* Position in the auxiliary partition. */
+    uint8_t            aux_filemark;     /* Filemark follows auxiliary data. */
+    uint8_t            aux_filemark_seen; /* Current position is past that mark. */
+    uint8_t           *aux_buf;          /* Virtual auxiliary partition data. */
+    uint32_t           aux_buf_size;     /* Allocated auxiliary buffer size. */
+    uint32_t           aux_data_len;     /* Bytes of valid auxiliary data. */
+    uint32_t           aux_pos;          /* Byte position in auxiliary data. */
 
     /* Read-ahead buffer for re-blocking: when a SIMH record is larger than
        the requested fixed block size, the unconsumed remainder is stored here

--- a/src/include/86box/scsi_tape.h
+++ b/src/include/86box/scsi_tape.h
@@ -18,6 +18,7 @@
 
 #define TAPE_NUM           4
 #define TAPE_BUF_SIZE      65536
+#define TAPE_MAX_TRANSFER  0x00ffffffU
 #define TAPE_TIME          10.0
 #define TAPE_IMAGE_HISTORY 10
 
@@ -27,19 +28,22 @@
 #define TAPE_SIMH_GAP      0xFFFFFFFE
 #define TAPE_SIMH_BAD_REC  0xFFFF0000
 
-/* QIC tape type definitions. */
+/* Tape media type definitions. */
 typedef struct tape_type_t {
     const char *name;
-    uint32_t    capacity_bytes;
+    uint64_t    capacity_bytes;
     uint16_t    default_block_size;
     uint8_t     density_code;
 } tape_type_t;
 
-#define KNOWN_TAPE_TYPES 3
+#define KNOWN_TAPE_TYPES 6
 static const tape_type_t tape_types[KNOWN_TAPE_TYPES] = {
-    { "QIC-150",  157286400, 512, 0x10 },
-    { "QIC-525",  549978112, 512, 0x11 },
-    { "QIC-1000", 1073741824, 512, 0x12 },
+    { "QIC-150",    157286400ULL, 512, 0x10 },
+    { "QIC-525",    549978112ULL, 512, 0x11 },
+    { "QIC-1000",  1073741824ULL, 512, 0x12 },
+    { "DDS-3",    12000000000ULL, 512, 0x25 },
+    { "DDS-4",    20000000000ULL, 512, 0x26 },
+    { "DAT-72",   36000000000ULL, 512, 0x47 },
 };
 
 /* Tape drive type definitions. */
@@ -47,13 +51,15 @@ typedef struct tape_drive_type_t {
     const char *vendor;
     const char *model;
     const char *revision;
+    uint8_t     default_media;
     int8_t      supported_media[KNOWN_TAPE_TYPES];
 } tape_drive_type_t;
 
-#define KNOWN_TAPE_DRIVE_TYPES 2
+#define KNOWN_TAPE_DRIVE_TYPES 3
 static const tape_drive_type_t tape_drive_types[KNOWN_TAPE_DRIVE_TYPES] = {
-    { "86BOX",   "TAPE",             "1.00", { 1, 1, 1 } },
-    { "ARCHIVE", "VIPER 150 21247",  "2.10", { 1, 0, 0 } },
+    { "86BOX",   "TAPE",             "1.00", 0, { 1, 1, 1, 1, 1, 1 } },
+    { "ARCHIVE", "VIPER 150 21247",  "2.10", 0, { 1, 0, 0, 0, 0, 0 } },
+    { "86Box",   "DAT-72",           "1.00", 5, { 0, 0, 0, 1, 1, 1 } },
 };
 
 enum {
@@ -137,10 +143,11 @@ typedef struct tape_t {
     uint8_t            (*ven_cmd)(void *sc, uint8_t *cdb, int32_t *BufLen);
 
     /* Tape-specific state. */
-    uint32_t           tape_pos;       /* Current byte position in the .tap file. */
+    uint64_t           tape_pos;       /* Current byte position in the .tap file. */
+    uint64_t           data_pos;       /* Logical data bytes before tape_pos. */
     uint32_t           block_size;     /* Current fixed block size (0 = variable block mode). */
     uint32_t           num_blocks;     /* Current logical block number. */
-    uint32_t           tape_length;    /* File size of the .tap image. */
+    uint64_t           tape_length;    /* File size of the .tap image. */
     int                eot;            /* End-of-tape reached. */
     int                bot;            /* Beginning-of-tape. */
     int                filemark_pending; /* A filemark was just encountered. */

--- a/src/include/86box/scsi_tape.h
+++ b/src/include/86box/scsi_tape.h
@@ -36,7 +36,7 @@ typedef struct tape_type_t {
     uint8_t     density_code;
 } tape_type_t;
 
-#define KNOWN_TAPE_TYPES 6
+#define KNOWN_TAPE_TYPES 7
 static const tape_type_t tape_types[KNOWN_TAPE_TYPES] = {
     { "QIC-150",    157286400ULL, 512, 0x10 },
     { "QIC-525",    549978112ULL, 512, 0x11 },
@@ -44,6 +44,7 @@ static const tape_type_t tape_types[KNOWN_TAPE_TYPES] = {
     { "DDS-3",    12000000000ULL, 512, 0x25 },
     { "DDS-4",    20000000000ULL, 512, 0x26 },
     { "DAT-72",   36000000000ULL, 512, 0x47 },
+    { "DDS-2",     4000000000ULL, 512, 0x24 },
 };
 
 /* Tape drive type definitions. */
@@ -55,11 +56,12 @@ typedef struct tape_drive_type_t {
     int8_t      supported_media[KNOWN_TAPE_TYPES];
 } tape_drive_type_t;
 
-#define KNOWN_TAPE_DRIVE_TYPES 3
+#define KNOWN_TAPE_DRIVE_TYPES 4
 static const tape_drive_type_t tape_drive_types[KNOWN_TAPE_DRIVE_TYPES] = {
-    { "86BOX",   "TAPE",             "1.00", 0, { 1, 1, 1, 1, 1, 1 } },
-    { "ARCHIVE", "VIPER 150 21247",  "2.10", 0, { 1, 0, 0, 0, 0, 0 } },
-    { "86Box",   "DAT-72",           "1.00", 5, { 0, 0, 0, 1, 1, 1 } },
+    { "86BOX",   "TAPE",             "1.00", 0, { 1, 1, 1, 1, 1, 1, 1 } },
+    { "ARCHIVE", "VIPER 150 21247",  "2.10", 0, { 1, 0, 0, 0, 0, 0, 0 } },
+    { "86Box",   "DAT-72",           "1.00", 5, { 0, 0, 0, 1, 1, 1, 1 } },
+    { "ARCHIVE", "Python 04687-XXX", "4.CM", 6, { 0, 0, 0, 0, 0, 0, 1 } },
 };
 
 enum {
@@ -151,6 +153,9 @@ typedef struct tape_t {
     int                eot;            /* End-of-tape reached. */
     int                bot;            /* Beginning-of-tape. */
     int                filemark_pending; /* A filemark was just encountered. */
+    uint8_t            active_partition; /* Selected logical partition. */
+    uint8_t            aux_filemark;     /* Virtual auxiliary partition contents. */
+    uint8_t            aux_pos;          /* Position in the auxiliary partition. */
 
     /* Read-ahead buffer for re-blocking: when a SIMH record is larger than
        the requested fixed block size, the unconsumed remainder is stored here

--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -1236,12 +1236,13 @@ MediaMenu::moReload(int index, int slot)
 void
 MediaMenu::tapeNewImage(int i)
 {
-    NewFloppyDialog dialog(NewFloppyDialog::MediaType::Tape, parentWidget);
+    NewFloppyDialog dialog(NewFloppyDialog::MediaType::Tape, parentWidget, tape_drives[i].type);
     switch (dialog.exec()) {
         default:
             break;
         case QDialog::Accepted:
             QByteArray filename = dialog.fileName().toUtf8();
+            tape_drives[i].medium_type = dialog.mediaTypeIndex();
             tapeMount(i, filename, false);
             break;
     }

--- a/src/qt/qt_newfloppydialog.cpp
+++ b/src/qt/qt_newfloppydialog.cpp
@@ -90,15 +90,7 @@ static const QStringList moTypes = {
     "5.25\" 1.3 GB",
 };
 
-static const QStringList tapeTypes = {
-    "QIC-150",
-#if 0
-    "QIC-525",
-    "QIC-1000",
-#endif
-};
-
-NewFloppyDialog::NewFloppyDialog(MediaType type, QWidget *parent)
+NewFloppyDialog::NewFloppyDialog(MediaType type, QWidget *parent, int tape_drive_type)
     : QDialog(parent)
     , ui(new Ui::NewFloppyDialog)
     , mediaType_(type)
@@ -129,8 +121,17 @@ NewFloppyDialog::NewFloppyDialog(MediaType type, QWidget *parent)
             ui->fileField->setFilter(tr("MO images") % util::DlgFilter({ "im?", "img", "mdi" }) % tr("All files") % util::DlgFilter({ "*" }, true));
             break;
         case MediaType::Tape:
-            for (int i = 0; i < tapeTypes.size(); ++i) {
-                Models::AddEntry(model, tr(tapeTypes[i].toUtf8().data()), i);
+            ui->labelSize->setText(tr("Tape type:"));
+            for (int i = 0; i < KNOWN_TAPE_TYPES; ++i) {
+                if ((tape_drive_type < 0) || (tape_drive_type >= KNOWN_TAPE_DRIVE_TYPES) ||
+                    tape_drive_types[tape_drive_type].supported_media[i])
+                    Models::AddEntry(model, tr(tape_types[i].name), i);
+            }
+            if ((tape_drive_type >= 0) && (tape_drive_type < KNOWN_TAPE_DRIVE_TYPES)) {
+                const auto matches = model->match(model->index(0, 0), Qt::UserRole,
+                                                  tape_drive_types[tape_drive_type].default_media);
+                if (!matches.isEmpty())
+                    ui->comboBoxSize->setCurrentIndex(matches.first().row());
             }
             ui->fileField->setFilter(tr("Tape images") % util::DlgFilter({ "tap" }) % tr("All files") % util::DlgFilter({ "*" }, true));
             break;
@@ -170,6 +171,12 @@ QString
 NewFloppyDialog::fileName() const
 {
     return ui->fileField->fileName();
+}
+
+int
+NewFloppyDialog::mediaTypeIndex() const
+{
+    return ui->comboBoxSize->currentData().toInt();
 }
 
 void
@@ -234,8 +241,9 @@ NewFloppyDialog::onCreate()
         case MediaType::Tape:
             {
                 std::atomic_bool res;
-                std::thread      t([this, &res, filename, &progress] {
-                    res = createTapeSectorImage(filename, ui->comboBoxSize->currentIndex(), progress);
+                const int        tape_type = mediaTypeIndex();
+                std::thread      t([this, &res, filename, tape_type, &progress] {
+                    res = createTapeSectorImage(filename, tape_type, progress);
                 });
                 progress.exec();
                 t.join();
@@ -826,6 +834,9 @@ NewFloppyDialog::createTapeSectorImage(const QString &filename, UNUSED(int8_t di
     if (!file.open(QIODevice::WriteOnly)) {
         return false;
     }
+    QDataStream stream(&file);
+    stream.setByteOrder(QDataStream::LittleEndian);
+    stream << (uint32_t) TAPE_SIMH_EOD;
     pbar.setMaximum(1);
     fileProgress(1);
 

--- a/src/qt/qt_newfloppydialog.hpp
+++ b/src/qt/qt_newfloppydialog.hpp
@@ -29,10 +29,11 @@ public:
         Zdi,
         Mdi,
     };
-    explicit NewFloppyDialog(MediaType type, QWidget *parent = nullptr);
+    explicit NewFloppyDialog(MediaType type, QWidget *parent = nullptr, int tape_drive_type = -1);
     ~NewFloppyDialog();
 
     QString fileName() const;
+    int mediaTypeIndex() const;
 
 signals:
     void fileProgress(int i);

--- a/src/scsi/scsi_tape.c
+++ b/src/scsi/scsi_tape.c
@@ -14,6 +14,10 @@
  *          Copyright 2025-2026 Plamen Ivanov.
  */
 #define _GNU_SOURCE
+#if defined(DEBUG) && !defined(ENABLE_TAPE_LOG)
+#    define ENABLE_TAPE_LOG 1
+#    define TAPE_FILE_LOG
+#endif
 #include <inttypes.h>
 #ifdef ENABLE_TAPE_LOG
 #include <stdarg.h>
@@ -67,6 +71,7 @@ const uint8_t tape_command_flags[0x100] = {
     [0x10]          = IMPLEMENTED | CHECK_READY,             /* WRITE FILEMARKS(6) */
     [0x11]          = IMPLEMENTED | CHECK_READY,             /* SPACE(6) */
     [0x12]          = IMPLEMENTED | ALLOW_UA,                /* INQUIRY */
+    [0x13]          = IMPLEMENTED | CHECK_READY,             /* VERIFY(6) */
     [0x15]          = IMPLEMENTED,                           /* MODE SELECT(6) */
     [0x16]          = IMPLEMENTED,                           /* RESERVE */
     [0x17]          = IMPLEMENTED,                           /* RELEASE */
@@ -77,6 +82,7 @@ const uint8_t tape_command_flags[0x100] = {
     [0x1e]          = IMPLEMENTED | CHECK_READY,             /* PREVENT/ALLOW MEDIUM REMOVAL */
     [0x2b]          = IMPLEMENTED | CHECK_READY,             /* LOCATE(10) */
     [0x34]          = IMPLEMENTED | CHECK_READY,             /* READ POSITION */
+    [0x4d]          = IMPLEMENTED,                           /* LOG SENSE(10) */
     [0x55]          = IMPLEMENTED,                           /* MODE SELECT(10) */
     [0x5a]          = IMPLEMENTED,                           /* MODE SENSE(10) */
 };
@@ -87,6 +93,7 @@ static uint64_t tape_mode_sense_page_flags =
     GPMODEP_DISCONNECT_PAGE |
     GPMODEP_DATA_COMPRESS_PAGE |
     GPMODEP_DEVICE_CONFIG_PAGE |
+    (1ULL << GPMODE_MEDIUM_PARTITION_PAGE) |
     GPMODEP_ALL_PAGES;
 
 static const mode_sense_pages_t tape_mode_sense_pages_default_scsi = {
@@ -111,6 +118,11 @@ static const mode_sense_pages_t tape_mode_sense_pages_default_scsi = {
             0x00, 0x00,                         /* DCE=0, DCC=0 (no compression) */
             0x00, 0x00, 0x00, 0x00,             /* Compression algorithm */
             0x00, 0x00, 0x00, 0x00,             /* Decompression algorithm */
+            0x00, 0x00, 0x00, 0x00
+        },
+        [GPMODE_MEDIUM_PARTITION_PAGE] = {
+            GPMODE_MEDIUM_PARTITION_PAGE, 0x06,
+            0x00, 0x00,                         /* No additional partitions */
             0x00, 0x00, 0x00, 0x00
         },
         [GPMODE_DEVICE_CONFIG_PAGE] = {
@@ -154,12 +166,22 @@ static const mode_sense_pages_t tape_mode_sense_pages_changeable = {
             0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00
         },
+        [GPMODE_MEDIUM_PARTITION_PAGE] = {
+            GPMODE_MEDIUM_PARTITION_PAGE, 0x06,
+            /* Backup applications may select FDP/IDP and append partition
+               size descriptors while initializing media. */
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff
+        },
         [GPMODE_DEVICE_CONFIG_PAGE] = {
             GPMODE_DEVICE_CONFIG_PAGE, 0x0E,
-            0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00
+            /* The virtual backend accepts and remembers configuration hints;
+               buffering, setmark and early-warning choices do not alter the
+               SIMH record representation. */
+            0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff
         },
     }
 };
@@ -167,6 +189,13 @@ static const mode_sense_pages_t tape_mode_sense_pages_changeable = {
 
 static void tape_command_complete(tape_t *dev);
 static void tape_init(tape_t *dev);
+
+static int
+tape_is_dat_drive(const tape_t *dev)
+{
+    /* Types 2 and 3 are the DAT-72 and Seagate/Archive DDS drives. */
+    return (dev->drv->type == 2) || (dev->drv->type == 3);
+}
 
 #ifdef ENABLE_TAPE_LOG
 int tape_do_log = ENABLE_TAPE_LOG;
@@ -371,6 +400,9 @@ tape_init(tape_t *dev)
         dev->bot         = 1;
         dev->eot         = 0;
         dev->filemark_pending = 0;
+        dev->active_partition = 0;
+        dev->aux_filemark     = 0;
+        dev->aux_pos          = 0;
         dev->rec_remaining    = 0;
     }
 }
@@ -417,10 +449,11 @@ tape_mode_sense_load(tape_t *dev)
     memcpy(&dev->ms_pages_saved, &tape_mode_sense_pages_default_scsi,
            sizeof(mode_sense_pages_t));
 
-    if (dev->drv->type == 2) {
-        /* DAT-72 implements DCLZ data compression. The image stores the
+    if (tape_is_dat_drive(dev)) {
+        /* DAT drives implement DCLZ data compression. The image stores the
            logical (decompressed) record stream. */
         dev->ms_pages_saved.pages[GPMODE_DATA_COMPRESS_PAGE][2]  = 0x40; /* DCC */
+        dev->ms_pages_saved.pages[GPMODE_DATA_COMPRESS_PAGE][3]  = 0x80; /* DDE */
         dev->ms_pages_saved.pages[GPMODE_DATA_COMPRESS_PAGE][7]  = 0x20;
         dev->ms_pages_saved.pages[GPMODE_DATA_COMPRESS_PAGE][11] = 0x20;
     }
@@ -450,12 +483,14 @@ static uint8_t
 tape_mode_sense_read(const tape_t *dev, const uint8_t pgctl,
                      const uint8_t page, const uint8_t pos)
 {
-    if ((dev->drv->type == 2) && (page == GPMODE_DATA_COMPRESS_PAGE)) {
+    if (tape_is_dat_drive(dev) && (page == GPMODE_DATA_COMPRESS_PAGE)) {
         if ((pgctl == 1) && (pos == 2))
             return 0x80; /* DCE is changeable. */
         if (pgctl == 2) {
             if (pos == 2)
                 return 0x40; /* DCC */
+            if (pos == 3)
+                return 0x80; /* DDE */
             if ((pos == 7) || (pos == 11))
                 return 0x20; /* DCLZ */
         }
@@ -1551,6 +1586,15 @@ tape_set_buf_len(const tape_t *dev, int32_t *BufLen, int32_t *src_len)
 static void
 tape_rewind(tape_t *dev)
 {
+    if (dev->active_partition != 0) {
+        dev->aux_pos          = 0;
+        dev->bot              = 1;
+        dev->eot              = 0;
+        dev->filemark_pending = 0;
+        dev->rec_remaining    = 0;
+        return;
+    }
+
     fseeko64(dev->drv->fp, 0, SEEK_SET);
     dev->tape_pos         = 0;
     dev->data_pos         = 0;
@@ -1662,9 +1706,9 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
             tape_buf_alloc(dev, len);
             memset(dev->buffer, 0, len);
 
-            /* DAT-72 accepts variable records from 1 byte through the
+            /* DAT drives accept variable records from 1 byte through the
                largest value representable by the SSC block-limit field. */
-            if (dev->drv->type == 2) {
+            if (tape_is_dat_drive(dev)) {
                 dev->buffer[1] = 0xff;
                 dev->buffer[2] = 0xff;
                 dev->buffer[3] = 0xff;
@@ -1681,10 +1725,47 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
             tape_set_buf_len(dev, BufLen, &len);
 
             tape_log(dev->log, "Block limits: min=%u, max=%u\n",
-                     dev->drv->type == 2 ? 1 : 512,
-                     dev->drv->type == 2 ? 0xffffff : 32768);
+                     tape_is_dat_drive(dev) ? 1 : 512,
+                     tape_is_dat_drive(dev) ? 0xffffff : 32768);
             tape_data_command_finish(dev, len, len, len, 0);
             break;
+
+        case GPCMD_VERIFY_6: {
+            /* VERIFY reads records internally and advances the tape without
+               transferring their contents to the initiator. */
+            const uint32_t verify_len = ((uint32_t) cdb[2] << 16) |
+                                        ((uint32_t) cdb[3] << 8) |
+                                         (uint32_t) cdb[4];
+
+            tape_log(dev->log, "VERIFY: fixed=%u, count=%u\n",
+                     cdb[1] & 1, verify_len);
+
+            /* Byte compare requires a host data-out phase, which these drives
+               do not support. Media verification (BYTCMP=0) is supported. */
+            if (cdb[1] & 0x02) {
+                tape_invalid_field(dev, cdb[1]);
+                break;
+            }
+
+            if (verify_len != 0) {
+                dev->filemark_pending = 0;
+                fseeko64(dev->drv->fp, (int64_t) dev->tape_pos, SEEK_SET);
+                const int32_t verified = tape_space_blocks_forward(dev, verify_len);
+
+                if (verified < 0) {
+                    const uint32_t residual = (uint32_t) -verified;
+                    if (dev->filemark_pending)
+                        tape_filemark_detected(dev, residual);
+                    else
+                        tape_blank_check(dev, residual);
+                    break;
+                }
+            }
+
+            tape_set_phase(dev, SCSI_PHASE_STATUS);
+            tape_command_complete(dev);
+            break;
+        }
 
         case GPCMD_REQUEST_SENSE:
             max_len = cdb[4];
@@ -1758,6 +1839,16 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
             uint32_t  xfer_len = ((uint32_t) cdb[2] << 16) |
                                  ((uint32_t) cdb[3] << 8) |
                                   (uint32_t) cdb[4];
+
+            if (dev->active_partition != 0) {
+                if (dev->aux_filemark && (dev->aux_pos == 0)) {
+                    dev->aux_pos = 1;
+                    dev->bot     = 0;
+                    tape_filemark_detected(dev, fixed ? xfer_len : 0);
+                } else
+                    tape_blank_check(dev, fixed ? xfer_len : 0);
+                return;
+            }
 
             tape_log(dev->log, "READ(6): fixed=%d, xfer_len=%u, block_size=%u, "
                      "filemark_pending=%d\n",
@@ -2055,6 +2146,16 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
 
             tape_log(dev->log, "WRITE FILEMARKS: count=%u\n", count);
 
+            if (dev->active_partition != 0) {
+                if (count != 0)
+                    dev->aux_filemark = 1;
+                dev->aux_pos = count != 0;
+                dev->bot     = count == 0;
+                tape_set_phase(dev, SCSI_PHASE_STATUS);
+                tape_command_complete(dev);
+                break;
+            }
+
             fseeko64(dev->drv->fp, (int64_t) dev->tape_pos, SEEK_SET);
 
             for (uint32_t i = 0; i < count; i++) {
@@ -2174,6 +2275,16 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
             }
 
             tape_log(dev->log, "ERASE\n");
+
+            if (dev->active_partition != 0) {
+                dev->aux_filemark = 0;
+                dev->aux_pos      = 0;
+                dev->bot          = 1;
+                dev->eot          = 0;
+                tape_set_phase(dev, SCSI_PHASE_STATUS);
+                tape_command_complete(dev);
+                break;
+            }
 
             fseeko64(dev->drv->fp, (int64_t) dev->tape_pos, SEEK_SET);
             tape_write_marker(dev, TAPE_SIMH_EOD);
@@ -2355,6 +2466,55 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
             tape_data_command_finish(dev, len, len, alloc_length, 0);
             return;
 
+        case GPCMD_LOG_SENSE: {
+            const uint8_t page_code = cdb[2] & 0x3f;
+            const uint16_t parameter = ((uint16_t) cdb[5] << 8) | cdb[6];
+            const uint16_t allocation = ((uint16_t) cdb[7] << 8) | cdb[8];
+
+            tape_set_phase(dev, SCSI_PHASE_DATA_IN);
+
+            if ((page_code != 0x31) || (parameter != 0)) {
+                tape_invalid_field(dev, page_code != 0x31 ? cdb[2] : parameter);
+                return;
+            }
+
+            /* Tape capacity log page. Capacity values are expressed in MB.
+               Parameters 1/3 are remaining/maximum main-partition capacity;
+               parameters 2/4 describe an unsupported alternate partition. */
+            tape_buf_alloc(dev, 36);
+            memset(dev->buffer, 0, 36);
+            dev->buffer[0] = 0x31;
+            dev->buffer[2] = 0x00;
+            dev->buffer[3] = 0x20;
+
+            const uint64_t capacity = tape_capacity(dev);
+            const uint64_t remaining = dev->data_pos < capacity ?
+                                       capacity - dev->data_pos : 0;
+            const uint32_t values[4] = {
+                (uint32_t) MIN(remaining / 1000000ULL, UINT32_MAX),
+                0,
+                (uint32_t) MIN(capacity / 1000000ULL, UINT32_MAX),
+                0
+            };
+
+            for (uint8_t i = 0; i < 4; i++) {
+                const uint32_t pos = 4 + (i * 8);
+                dev->buffer[pos]     = 0;
+                dev->buffer[pos + 1] = i + 1;
+                dev->buffer[pos + 2] = 0;
+                dev->buffer[pos + 3] = 4;
+                dev->buffer[pos + 4] = (values[i] >> 24) & 0xff;
+                dev->buffer[pos + 5] = (values[i] >> 16) & 0xff;
+                dev->buffer[pos + 6] = (values[i] >> 8) & 0xff;
+                dev->buffer[pos + 7] = values[i] & 0xff;
+            }
+
+            len = MIN(36, allocation);
+            tape_set_buf_len(dev, BufLen, &len);
+            tape_data_command_finish(dev, len, len, allocation, 0);
+            return;
+        }
+
         case GPCMD_MODE_SELECT_6:
         case GPCMD_MODE_SELECT_10:
             tape_set_phase(dev, SCSI_PHASE_DATA_OUT);
@@ -2443,6 +2603,15 @@ tape_phase_data_out(scsi_common_t *sc)
                                  ((uint32_t) dev->current_cdb[3] << 8) |
                                   (uint32_t) dev->current_cdb[4];
 
+            if (dev->active_partition != 0) {
+                /* The SIMH image stores partition zero. Auxiliary directory
+                   data remains virtual so it cannot overwrite that stream. */
+                dev->aux_pos = 1;
+                dev->bot     = 0;
+                ui_sb_update_icon_write(SB_TAPE | dev->id, 0);
+                break;
+            }
+
             fseeko64(dev->drv->fp, (int64_t) dev->tape_pos, SEEK_SET);
 
             if (fixed) {
@@ -2476,6 +2645,12 @@ tape_phase_data_out(scsi_common_t *sc)
 
         case GPCMD_MODE_SELECT_6:
         case GPCMD_MODE_SELECT_10:
+            tape_log(dev->log, "MODE SELECT parameter data (%u bytes):",
+                     dev->total_length);
+            for (uint32_t i = 0; i < (uint32_t) dev->total_length; i++)
+                tape_log(dev->log, " %02X", dev->buffer[i]);
+            tape_log(dev->log, "\n");
+
             if (dev->current_cdb[0] == GPCMD_MODE_SELECT_10) {
                 hdr_len        = 8;
                 param_list_len = dev->current_cdb[7];
@@ -2556,6 +2731,14 @@ tape_phase_data_out(scsi_common_t *sc)
                 }
 
                 pos += page_len;
+
+                if (page == GPMODE_DEVICE_CONFIG_PAGE) {
+                    dev->active_partition =
+                        dev->ms_pages_saved.pages[page][3];
+                    dev->aux_pos = 0;
+                    tape_log(dev->log, "MODE SELECT: active partition set to %u\n",
+                             dev->active_partition);
+                }
 
                 val = tape_mode_sense_pages_default_scsi.pages[page][0] & 0x80;
                 if (dev->do_page_save && val)

--- a/src/scsi/scsi_tape.c
+++ b/src/scsi/scsi_tape.c
@@ -49,9 +49,6 @@
 
 tape_drive_t tape_drives[TAPE_NUM];
 
-/* Default block size for fixed-mode operations. */
-#define TAPE_DEFAULT_BLOCK_SIZE 512
-
 // clang-format off
 /*
    Table of all SCSI commands and their flags, needed for the new disc change /
@@ -276,18 +273,17 @@ tape_load(const tape_t *dev, const char *fn, const int skip_insert)
 
         if (ret) {
             fseeko64(dev->drv->fp, 0, SEEK_END);
-            ((tape_t *) dev)->tape_length = (uint32_t) ftello64(dev->drv->fp);
+            ((tape_t *) dev)->tape_length = (uint64_t) ftello64(dev->drv->fp);
             fseeko64(dev->drv->fp, 0, SEEK_SET);
 
             ((tape_t *) dev)->tape_pos   = 0;
+            ((tape_t *) dev)->data_pos   = 0;
             ((tape_t *) dev)->bot        = 1;
             ((tape_t *) dev)->eot        = 0;
             ((tape_t *) dev)->num_blocks = 0;
 
-            if (dev->drv->image_path != (fn - offs)) {
-                const int len = MIN(strlen(fn - offs), (strlen(dev->drv->image_path) - 1));
-                strncpy(dev->drv->image_path, fn - offs, len);
-            }
+            if (dev->drv->image_path != (fn - offs))
+                snprintf(dev->drv->image_path, sizeof(dev->drv->image_path), "%s", fn - offs);
         }
     }
 
@@ -362,8 +358,15 @@ tape_init(tape_t *dev)
         dev->packet_status = PHASE_NONE;
         tape_sense_key = tape_asc = tape_ascq = dev->unit_attention = dev->transition = 0;
         tape_info      = 0x00000000;
-        dev->block_size  = TAPE_DEFAULT_BLOCK_SIZE;
+        if (dev->drv->type >= KNOWN_TAPE_DRIVE_TYPES)
+            dev->drv->type = 0;
+        if ((dev->drv->medium_type >= KNOWN_TAPE_TYPES) ||
+            !tape_drive_types[dev->drv->type].supported_media[dev->drv->medium_type])
+            dev->drv->medium_type = tape_drive_types[dev->drv->type].default_media;
+
+        dev->block_size  = tape_types[dev->drv->medium_type].default_block_size;
         dev->tape_pos    = 0;
+        dev->data_pos    = 0;
         dev->num_blocks  = 0;
         dev->bot         = 1;
         dev->eot         = 0;
@@ -414,6 +417,14 @@ tape_mode_sense_load(tape_t *dev)
     memcpy(&dev->ms_pages_saved, &tape_mode_sense_pages_default_scsi,
            sizeof(mode_sense_pages_t));
 
+    if (dev->drv->type == 2) {
+        /* DAT-72 implements DCLZ data compression. The image stores the
+           logical (decompressed) record stream. */
+        dev->ms_pages_saved.pages[GPMODE_DATA_COMPRESS_PAGE][2]  = 0x40; /* DCC */
+        dev->ms_pages_saved.pages[GPMODE_DATA_COMPRESS_PAGE][7]  = 0x20;
+        dev->ms_pages_saved.pages[GPMODE_DATA_COMPRESS_PAGE][11] = 0x20;
+    }
+
     sprintf(fn, "scsi_tape_%02i_mode_sense_bin", dev->id);
     FILE *fp = plat_fopen(nvr_path(fn), "rb");
     if (fp) {
@@ -439,6 +450,17 @@ static uint8_t
 tape_mode_sense_read(const tape_t *dev, const uint8_t pgctl,
                      const uint8_t page, const uint8_t pos)
 {
+    if ((dev->drv->type == 2) && (page == GPMODE_DATA_COMPRESS_PAGE)) {
+        if ((pgctl == 1) && (pos == 2))
+            return 0x80; /* DCE is changeable. */
+        if (pgctl == 2) {
+            if (pos == 2)
+                return 0x40; /* DCC */
+            if ((pos == 7) || (pos == 11))
+                return 0x20; /* DCLZ */
+        }
+    }
+
     switch (pgctl) {
         case 0:
         case 3:
@@ -491,6 +513,12 @@ tape_mode_sense(const tape_t *dev, uint8_t *buf, uint32_t pos,
     }
 
     return pos;
+}
+
+static uint8_t
+tape_medium_type_code(const tape_t *dev)
+{
+    return (dev->drv->medium_type == 5) ? 0x35 : 0x00;
 }
 
 static void
@@ -875,6 +903,37 @@ tape_bop_detected(tape_t *dev, uint32_t residual)
     tape_cmd_error(dev);
 }
 
+/* Report end-of-medium. */
+static void
+tape_eom_detected(tape_t *dev, uint32_t residual)
+{
+    tape_sense_key = SENSE_VOLUME_OVERFLOW;
+    tape_asc       = ASC_NONE;
+    tape_ascq      = ASCQ_EOM_DETECTED;
+    dev->sense[2] |= 0x40;
+    tape_info      =  (residual >> 24)        |
+                     ((residual >> 16) <<  8) |
+                     ((residual >> 8)  << 16) |
+                     ( residual        << 24);
+    dev->eot       = 1;
+    tape_cmd_error(dev);
+}
+
+static uint64_t
+tape_capacity(const tape_t *dev)
+{
+    const uint32_t medium = (dev->drv->medium_type < KNOWN_TAPE_TYPES) ?
+                            dev->drv->medium_type : 0;
+    return tape_types[medium].capacity_bytes;
+}
+
+static int
+tape_write_fits(const tape_t *dev, uint64_t len)
+{
+    const uint64_t capacity = tape_capacity(dev);
+    return (dev->data_pos <= capacity) && (len <= (capacity - dev->data_pos));
+}
+
 /* ==================== SIMH .tap I/O helpers ==================== */
 
 /*
@@ -916,6 +975,24 @@ tape_write_marker(const tape_t *dev, uint32_t marker)
     return 0;
 }
 
+static int
+tape_truncate(const tape_t *dev, uint64_t length)
+{
+#ifdef _WIN32
+    const int     fd = _fileno(dev->drv->fp);
+    const HANDLE  fh = (HANDLE) _get_osfhandle(fd);
+    LARGE_INTEGER li;
+
+    li.QuadPart = (LONGLONG) length;
+    if (!SetFilePointerEx(fh, li, NULL, FILE_BEGIN) || !SetEndOfFile(fh))
+        return -1;
+#else
+    if (ftruncate(fileno(dev->drv->fp), (off_t) length) != 0)
+        return -1;
+#endif
+    return 0;
+}
+
 /*
  * Read one SIMH record from the tape at the current position.
  * Returns: record length on success, 0 for filemark, -1 for EOD, -2 for error.
@@ -927,24 +1004,24 @@ tape_simh_read_record(tape_t *dev, uint8_t *buf, uint32_t buf_size)
     uint32_t trailing_len;
 
     if (tape_read_marker(dev, &leading_len) < 0) {
-        tape_log(dev->log, "  read_record: read_marker failed (past EOF), tape_pos=%u\n",
+        tape_log(dev->log, "  read_record: read_marker failed (past EOF), tape_pos=%" PRIu64 "\n",
                  dev->tape_pos);
         return -1; /* Past end of file = EOD. */
     }
 
-    tape_log(dev->log, "  read_record: leading_len=0x%08X (%u), tape_pos=%u\n",
+    tape_log(dev->log, "  read_record: leading_len=0x%08X (%u), tape_pos=%" PRIu64 "\n",
              leading_len, leading_len, dev->tape_pos);
 
     /* Filemark. */
     if (leading_len == TAPE_SIMH_FILEMARK) {
-        tape_log(dev->log, "  read_record: FILEMARK at tape_pos=%u\n", dev->tape_pos);
+        tape_log(dev->log, "  read_record: FILEMARK at tape_pos=%" PRIu64 "\n", dev->tape_pos);
         dev->tape_pos += 4;
         return 0;
     }
 
     /* End of data. */
     if (leading_len == TAPE_SIMH_EOD || leading_len == TAPE_SIMH_GAP) {
-        tape_log(dev->log, "  read_record: EOD/GAP at tape_pos=%u\n", dev->tape_pos);
+        tape_log(dev->log, "  read_record: EOD/GAP at tape_pos=%" PRIu64 "\n", dev->tape_pos);
         return -1;
     }
 
@@ -958,12 +1035,17 @@ tape_simh_read_record(tape_t *dev, uint8_t *buf, uint32_t buf_size)
     if (leading_len > buf_size)
         fseeko64(dev->drv->fp, (int64_t)(leading_len - buf_size), SEEK_CUR);
 
+    /* SIMH records are padded to an even byte boundary. */
+    if (leading_len & 1)
+        fseeko64(dev->drv->fp, 1, SEEK_CUR);
+
     /* Read the trailing length marker. */
     if (tape_read_marker(dev, &trailing_len) < 0)
         return -2;
 
     /* Advance position. */
-    dev->tape_pos += 4 + leading_len + 4;
+    dev->tape_pos += 4 + leading_len + (leading_len & 1) + 4;
+    dev->data_pos += leading_len;
     dev->num_blocks++;
     dev->bot = 0;
 
@@ -977,10 +1059,16 @@ tape_simh_read_record(tape_t *dev, uint8_t *buf, uint32_t buf_size)
 static int
 tape_simh_write_record(tape_t *dev, const uint8_t *buf, uint32_t len)
 {
+    if (!tape_write_fits(dev, len))
+        return -2;
+
     if (tape_write_marker(dev, len) < 0)
         return -1;
 
     if (fwrite(buf, 1, len, dev->drv->fp) != len)
+        return -1;
+
+    if ((len & 1) && (fputc(0, dev->drv->fp) == EOF))
         return -1;
 
     if (tape_write_marker(dev, len) < 0)
@@ -992,10 +1080,16 @@ tape_simh_write_record(tape_t *dev, const uint8_t *buf, uint32_t len)
 
     fflush(dev->drv->fp);
 
+    const uint64_t end_pos = dev->tape_pos + 4 + len + (len & 1) + 4 + 4;
+    if (tape_truncate(dev, end_pos) < 0)
+        return -1;
+
     /* Seek back to just after the trailing length (before the EOD marker). */
     fseeko64(dev->drv->fp, -4, SEEK_CUR);
 
-    dev->tape_pos += 4 + len + 4;
+    dev->tape_pos += 4 + len + (len & 1) + 4;
+    dev->data_pos += len;
+    dev->tape_length = end_pos;
     dev->num_blocks++;
     dev->bot = 0;
 
@@ -1017,10 +1111,15 @@ tape_simh_write_filemark(tape_t *dev)
 
     fflush(dev->drv->fp);
 
+    const uint64_t end_pos = dev->tape_pos + 8;
+    if (tape_truncate(dev, end_pos) < 0)
+        return -1;
+
     /* Seek back to just after the filemark (before the EOD marker). */
     fseeko64(dev->drv->fp, -4, SEEK_CUR);
 
     dev->tape_pos += 4;
+    dev->tape_length = end_pos;
     dev->bot = 0;
 
     return 0;
@@ -1056,8 +1155,9 @@ tape_seek_blocks_forward(tape_t *dev, int32_t count)
             tape_log(dev->log, "First data block after %i blocks, seek back\n", dev->num_blocks);
             break;
         } else {
-            fseeko64(dev->drv->fp, (int64_t)(leading_len + 4), SEEK_CUR);
-            dev->tape_pos += 4 + leading_len + 4;
+            fseeko64(dev->drv->fp, (int64_t)(leading_len + (leading_len & 1) + 4), SEEK_CUR);
+            dev->tape_pos += 4 + leading_len + (leading_len & 1) + 4;
+            dev->data_pos += leading_len;
             tape_log(dev->log, "Found %i blocks, increasing to %i\n", dev->num_blocks, dev->num_blocks + 1);
             dev->num_blocks++;
        }
@@ -1097,8 +1197,9 @@ tape_space_blocks_forward(tape_t *dev, int32_t count)
 
         /* Skip over the data and trailing length. */
         dev->bot = 0;
-        fseeko64(dev->drv->fp, (int64_t)(leading_len + 4), SEEK_CUR);
-        dev->tape_pos += 4 + leading_len + 4;
+        fseeko64(dev->drv->fp, (int64_t)(leading_len + (leading_len & 1) + 4), SEEK_CUR);
+        dev->tape_pos += 4 + leading_len + (leading_len & 1) + 4;
+        dev->data_pos += leading_len;
         dev->num_blocks++;
         spaced++;
     }
@@ -1139,7 +1240,8 @@ tape_space_blocks_backward(tape_t *dev, int32_t count)
         }
 
         /* Back up over: trailing_len(4) + data(trailing_len) + leading_len(4). */
-        dev->tape_pos -= (4 + trailing_len + 4);
+        dev->tape_pos -= (4 + trailing_len + (trailing_len & 1) + 4);
+        dev->data_pos -= MIN(dev->data_pos, (uint64_t) trailing_len);
         fseeko64(dev->drv->fp, (int64_t) dev->tape_pos, SEEK_SET);
         if (dev->num_blocks > 0)
             dev->num_blocks--;
@@ -1175,8 +1277,9 @@ tape_space_filemarks_forward(tape_t *dev, int32_t count)
             found++;
         } else {
             /* Skip data record. */
-            fseeko64(dev->drv->fp, (int64_t)(leading_len + 4), SEEK_CUR);
-            dev->tape_pos += 4 + leading_len + 4;
+            fseeko64(dev->drv->fp, (int64_t)(leading_len + (leading_len & 1) + 4), SEEK_CUR);
+            dev->tape_pos += 4 + leading_len + (leading_len & 1) + 4;
+            dev->data_pos += leading_len;
             dev->num_blocks++;
         }
 
@@ -1216,7 +1319,8 @@ tape_space_filemarks_backward(tape_t *dev, int32_t count)
         } else {
             /* Skip data record. */
             /* Back up over: trailing_len(4) + data(trailing_len) + leading_len(4). */
-            dev->tape_pos -= (4 + trailing_len + 4);
+            dev->tape_pos -= (4 + trailing_len + (trailing_len & 1) + 4);
+            dev->data_pos -= MIN(dev->data_pos, (uint64_t) trailing_len);
             fseeko64(dev->drv->fp, (int64_t) dev->tape_pos, SEEK_SET);
             if (dev->num_blocks > 0)
                 dev->num_blocks--;
@@ -1249,8 +1353,9 @@ tape_space_to_eod(tape_t *dev)
         if (leading_len == TAPE_SIMH_FILEMARK) {
             dev->tape_pos += 4;
         } else {
-            fseeko64(dev->drv->fp, (int64_t)(leading_len + 4), SEEK_CUR);
-            dev->tape_pos += 4 + leading_len + 4;
+            fseeko64(dev->drv->fp, (int64_t)(leading_len + (leading_len & 1) + 4), SEEK_CUR);
+            dev->tape_pos += 4 + leading_len + (leading_len & 1) + 4;
+            dev->data_pos += leading_len;
             dev->num_blocks++;
         }
 
@@ -1448,6 +1553,7 @@ tape_rewind(tape_t *dev)
 {
     fseeko64(dev->drv->fp, 0, SEEK_SET);
     dev->tape_pos         = 0;
+    dev->data_pos         = 0;
     dev->num_blocks       = 0;
     dev->bot              = 1;
     dev->eot              = 0;
@@ -1556,18 +1662,27 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
             tape_buf_alloc(dev, len);
             memset(dev->buffer, 0, len);
 
-            /* Byte 0: reserved */
-            /* Bytes 1-3: maximum block length (32KB = 0x008000) */
-            dev->buffer[1] = 0x00;
-            dev->buffer[2] = 0x80;
-            dev->buffer[3] = 0x00;
-            /* Bytes 4-5: minimum block length (512 bytes = 0x0200) */
-            dev->buffer[4] = 0x02;
-            dev->buffer[5] = 0x00;
+            /* DAT-72 accepts variable records from 1 byte through the
+               largest value representable by the SSC block-limit field. */
+            if (dev->drv->type == 2) {
+                dev->buffer[1] = 0xff;
+                dev->buffer[2] = 0xff;
+                dev->buffer[3] = 0xff;
+                dev->buffer[4] = 0x00;
+                dev->buffer[5] = 0x01;
+            } else {
+                dev->buffer[1] = 0x00;
+                dev->buffer[2] = 0x80;
+                dev->buffer[3] = 0x00;
+                dev->buffer[4] = 0x02;
+                dev->buffer[5] = 0x00;
+            }
 
             tape_set_buf_len(dev, BufLen, &len);
 
-            tape_log(dev->log, "Block limits: min=512, max=32768\n");
+            tape_log(dev->log, "Block limits: min=%u, max=%u\n",
+                     dev->drv->type == 2 ? 1 : 512,
+                     dev->drv->type == 2 ? 0xffffff : 32768);
             tape_data_command_finish(dev, len, len, len, 0);
             break;
 
@@ -1669,7 +1784,12 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
                    SIMH records may be larger than block_size, so we re-block:
                    read whole SIMH records and split them into fixed blocks.
                    Unconsumed data is kept in dev->rec_buf for subsequent reads. */
-                const uint32_t total_bytes = xfer_len * dev->block_size;
+                const uint64_t total_bytes64 = (uint64_t) xfer_len * dev->block_size;
+                if ((dev->block_size == 0) || (total_bytes64 > TAPE_MAX_TRANSFER)) {
+                    tape_invalid_field(dev, xfer_len);
+                    return;
+                }
+                const uint32_t total_bytes = (uint32_t) total_bytes64;
                 tape_buf_alloc(dev, total_bytes);
                 memset(dev->buffer, 0, total_bytes);
 
@@ -1711,6 +1831,9 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
                             break;
                         }
 
+                        if (peek_len & 1)
+                            fseeko64(dev->drv->fp, 1, SEEK_CUR);
+
                         /* Read trailing marker. */
                         uint32_t trail;
                         if (tape_read_marker(dev, &trail) < 0) {
@@ -1718,7 +1841,8 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
                             break;
                         }
 
-                        dev->tape_pos += 4 + peek_len + 4;
+                        dev->tape_pos += 4 + peek_len + (peek_len & 1) + 4;
+                        dev->data_pos += peek_len;
                         dev->num_blocks++;
                         dev->bot = 0;
 
@@ -1809,6 +1933,10 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
                     ui_sb_update_icon(SB_TAPE | dev->id, 0);
             } else {
                 /* Variable block mode: read one record, xfer_len = max bytes. */
+                if (xfer_len > TAPE_MAX_TRANSFER) {
+                    tape_invalid_field(dev, xfer_len);
+                    return;
+                }
                 tape_buf_alloc(dev, xfer_len);
                 memset(dev->buffer, 0, xfer_len);
 
@@ -1870,7 +1998,16 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
             tape_set_phase(dev, SCSI_PHASE_DATA_OUT);
 
             if (fixed) {
-                const uint32_t total_bytes = xfer_len * dev->block_size;
+                const uint64_t total_bytes64 = (uint64_t) xfer_len * dev->block_size;
+                if ((dev->block_size == 0) || (total_bytes64 > TAPE_MAX_TRANSFER)) {
+                    tape_invalid_field(dev, xfer_len);
+                    return;
+                }
+                if (!tape_write_fits(dev, total_bytes64)) {
+                    tape_eom_detected(dev, xfer_len);
+                    return;
+                }
+                const uint32_t total_bytes = (uint32_t) total_bytes64;
                 tape_buf_alloc(dev, total_bytes);
 
                 dev->requested_blocks = xfer_len;
@@ -1884,6 +2021,10 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
                                         dev->packet_status != PHASE_COMPLETE);
             } else {
                 /* Variable: xfer_len is the number of bytes for one record. */
+                if (!tape_write_fits(dev, xfer_len)) {
+                    tape_eom_detected(dev, 1);
+                    return;
+                }
                 tape_buf_alloc(dev, xfer_len);
 
                 dev->requested_blocks = 1;
@@ -2039,24 +2180,13 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
             fflush(dev->drv->fp);
 
             /* Truncate the file at the current position. */
-#ifdef _WIN32
-            {
-                int fd = _fileno(dev->drv->fp);
-                HANDLE fh = (HANDLE) _get_osfhandle(fd);
-                LARGE_INTEGER li;
-                li.QuadPart = (int64_t)(dev->tape_pos + 4);
-                SetFilePointerEx(fh, li, NULL, FILE_BEGIN);
-                SetEndOfFile(fh);
-            }
-#else
-            {
-                int fd = fileno(dev->drv->fp);
-                if (ftruncate(fd, (off_t)(dev->tape_pos + 4)) != 0)
-                    tape_log(dev->log, "Failed to truncate tape image\n");
-            }
-#endif
+            if (tape_truncate(dev, dev->tape_pos + 4) != 0)
+                tape_log(dev->log, "Failed to truncate tape image\n");
+            else
+                dev->tape_length = dev->tape_pos + 4;
             /* Seek back to just before the EOD. */
             fseeko64(dev->drv->fp, (int64_t) dev->tape_pos, SEEK_SET);
+            dev->eot = 0;
 
             tape_set_phase(dev, SCSI_PHASE_STATUS);
             tape_command_complete(dev);
@@ -2201,7 +2331,7 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
                 len            = tape_mode_sense(dev, dev->buffer, 4, cdb[2], block_desc);
                 len            = MIN(len, alloc_length);
                 dev->buffer[0] = len - 1;
-                dev->buffer[1] = 0; /* Medium type */
+                dev->buffer[1] = tape_medium_type_code(dev);
                 dev->buffer[2] = dev->drv->read_only ? 0x80 : 0x00; /* WP bit */
                 if (block_desc)
                     dev->buffer[3] = 8;
@@ -2210,7 +2340,7 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
                 len            = MIN(len, alloc_length);
                 dev->buffer[0] = (len - 2) >> 8;
                 dev->buffer[1] = (len - 2) & 255;
-                dev->buffer[2] = 0; /* Medium type */
+                dev->buffer[2] = tape_medium_type_code(dev);
                 dev->buffer[3] = dev->drv->read_only ? 0x80 : 0x00; /* WP bit */
                 if (block_desc) {
                     dev->buffer[6] = 0;
@@ -2368,6 +2498,24 @@ tape_phase_data_out(scsi_common_t *sc)
 
             /* If there's a block descriptor, parse the block size from it. */
             if (block_desc_len >= 8) {
+                const uint8_t density = dev->buffer[hdr_len];
+                if (density != 0) {
+                    int media = -1;
+                    for (int i = 0; i < KNOWN_TAPE_TYPES; i++) {
+                        if ((tape_types[i].density_code == density) &&
+                            tape_drive_types[dev->drv->type].supported_media[i]) {
+                            media = i;
+                            break;
+                        }
+                    }
+                    if (media < 0) {
+                        tape_invalid_field_pl(dev, density);
+                        tape_buf_free(dev);
+                        return 0;
+                    }
+                    dev->drv->medium_type = media;
+                }
+
                 uint32_t new_block_size = ((uint32_t) dev->buffer[hdr_len + 5] << 16) |
                                           ((uint32_t) dev->buffer[hdr_len + 6] << 8) |
                                            (uint32_t) dev->buffer[hdr_len + 7];
@@ -2394,16 +2542,16 @@ tape_phase_data_out(scsi_common_t *sc)
                 if (!(tape_mode_sense_page_flags & (1LL << ((uint64_t) page))))
                     error |= 1;
                 else for (uint8_t i = 0; i < page_len; i++) {
-                    const uint8_t ch      = tape_mode_sense_pages_changeable.pages[page][i + 2];
+                    const uint8_t ch      = tape_mode_sense_read(dev, 1, page, i + 2);
                     const uint8_t old_val = dev->ms_pages_saved.pages[page][i + 2];
                     val                   = dev->buffer[pos + i];
                     if (val != old_val) {
-                        if (ch)
-                            dev->ms_pages_saved.pages[page][i + 2] = val;
-                        else {
+                        if ((val & ~ch) != (old_val & ~ch)) {
                             error |= 1;
                             tape_invalid_field_pl(dev, val);
-                        }
+                        } else
+                            dev->ms_pages_saved.pages[page][i + 2] =
+                                (old_val & ~ch) | (val & ch);
                     }
                 }
 

--- a/src/scsi/scsi_tape.c
+++ b/src/scsi/scsi_tape.c
@@ -402,6 +402,8 @@ tape_init(tape_t *dev)
         dev->filemark_pending = 0;
         dev->active_partition = 0;
         dev->aux_filemark     = 0;
+        dev->aux_filemark_seen = 0;
+        dev->aux_data_len     = 0;
         dev->aux_pos          = 0;
         dev->rec_remaining    = 0;
     }
@@ -1588,6 +1590,7 @@ tape_rewind(tape_t *dev)
 {
     if (dev->active_partition != 0) {
         dev->aux_pos          = 0;
+        dev->aux_filemark_seen = 0;
         dev->bot              = 1;
         dev->eot              = 0;
         dev->filemark_pending = 0;
@@ -1812,13 +1815,28 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
             break;
 
         case GPCMD_LOCATE_10:
-            count = (cdb[2] << 24) | (cdb[3] << 16) | (cdb[4] << 8) | cdb[5];
+            /* SSC LOCATE(10) stores the logical object identifier in bytes
+               3 through 6. Byte 2 is reserved and byte 8 is the partition. */
+            count = ((uint32_t) cdb[3] << 24) |
+                    ((uint32_t) cdb[4] << 16) |
+                    ((uint32_t) cdb[5] << 8) |
+                     (uint32_t) cdb[6];
 
             if (cdb[1] & 0x06)
                 tape_invalid_field(dev, cdb[1]);
             else if (cdb[8] != 0x00)
                 tape_invalid_field(dev, cdb[8]);
             else {
+                if (dev->active_partition != 0) {
+                    uint64_t offset = (uint64_t) count * dev->block_size;
+                    dev->aux_pos = (uint32_t) MIN(offset, dev->aux_data_len);
+                    dev->aux_filemark_seen = 0;
+                    dev->bot = dev->aux_pos == 0;
+                    dev->eot = 0;
+                    tape_set_phase(dev, SCSI_PHASE_STATUS);
+                    tape_command_complete(dev);
+                    break;
+                }
                 tape_rewind(dev);
 
                 tape_seek_blocks_forward(dev, count);
@@ -1841,8 +1859,35 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
                                   (uint32_t) cdb[4];
 
             if (dev->active_partition != 0) {
-                if (dev->aux_filemark && (dev->aux_pos == 0)) {
-                    dev->aux_pos = 1;
+                uint64_t requested64 = fixed ?
+                    ((uint64_t) xfer_len * dev->block_size) : xfer_len;
+                if ((fixed && (dev->block_size == 0)) ||
+                    (requested64 > TAPE_MAX_TRANSFER)) {
+                    tape_invalid_field(dev, xfer_len);
+                    return;
+                }
+
+                if (dev->aux_pos < dev->aux_data_len) {
+                    uint32_t requested = (uint32_t) requested64;
+                    uint32_t available = dev->aux_data_len - dev->aux_pos;
+                    uint32_t actual    = MIN(requested, available);
+
+                    tape_set_phase(dev, SCSI_PHASE_DATA_IN);
+                    tape_buf_alloc(dev, requested);
+                    memset(dev->buffer, 0, requested);
+                    memcpy(dev->buffer, dev->aux_buf + dev->aux_pos, actual);
+                    dev->aux_pos += actual;
+                    dev->bot = 0;
+                    dev->packet_len = actual;
+                    dev->requested_blocks = fixed ? xfer_len : 1;
+                    tape_set_buf_len(dev, BufLen, (int32_t *) &dev->packet_len);
+                    tape_data_command_finish(dev, actual,
+                                             fixed ? dev->block_size : actual,
+                                             actual, 0);
+                    ui_sb_update_icon(SB_TAPE | dev->id,
+                                      dev->packet_status != PHASE_COMPLETE);
+                } else if (dev->aux_filemark && !dev->aux_filemark_seen) {
+                    dev->aux_filemark_seen = 1;
                     dev->bot     = 0;
                     tape_filemark_detected(dev, fixed ? xfer_len : 0);
                 } else
@@ -2094,7 +2139,8 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
                     tape_invalid_field(dev, xfer_len);
                     return;
                 }
-                if (!tape_write_fits(dev, total_bytes64)) {
+                if ((dev->active_partition == 0) &&
+                    !tape_write_fits(dev, total_bytes64)) {
                     tape_eom_detected(dev, xfer_len);
                     return;
                 }
@@ -2112,7 +2158,8 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
                                         dev->packet_status != PHASE_COMPLETE);
             } else {
                 /* Variable: xfer_len is the number of bytes for one record. */
-                if (!tape_write_fits(dev, xfer_len)) {
+                if ((dev->active_partition == 0) &&
+                    !tape_write_fits(dev, xfer_len)) {
                     tape_eom_detected(dev, 1);
                     return;
                 }
@@ -2149,7 +2196,7 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
             if (dev->active_partition != 0) {
                 if (count != 0)
                     dev->aux_filemark = 1;
-                dev->aux_pos = count != 0;
+                dev->aux_filemark_seen = count != 0;
                 dev->bot     = count == 0;
                 tape_set_phase(dev, SCSI_PHASE_STATUS);
                 tape_command_complete(dev);
@@ -2194,6 +2241,47 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
                      code, count, dev->filemark_pending);
 
             dev->rec_remaining = 0; /* Invalidate read-ahead buffer. */
+
+            if (dev->active_partition != 0) {
+                switch (code) {
+                    case 0:
+                        if (dev->block_size == 0) {
+                            tape_invalid_field(dev, cdb[1]);
+                            return;
+                        }
+                        {
+                            int64_t offset = (int64_t) dev->aux_pos +
+                                             ((int64_t) count * dev->block_size);
+                            if (offset < 0)
+                                offset = 0;
+                            if (offset > dev->aux_data_len)
+                                offset = dev->aux_data_len;
+                            dev->aux_pos = (uint32_t) offset;
+                            dev->aux_filemark_seen = 0;
+                        }
+                        break;
+                    case 1:
+                        if (count > 0 && dev->aux_filemark) {
+                            dev->aux_pos = dev->aux_data_len;
+                            dev->aux_filemark_seen = 1;
+                        } else if (count < 0 && dev->aux_filemark) {
+                            dev->aux_pos = dev->aux_data_len;
+                            dev->aux_filemark_seen = 0;
+                        }
+                        break;
+                    case 3:
+                        dev->aux_pos = dev->aux_data_len;
+                        dev->aux_filemark_seen = dev->aux_filemark;
+                        break;
+                    default:
+                        tape_invalid_field(dev, cdb[1]);
+                        return;
+                }
+                dev->bot = dev->aux_pos == 0;
+                tape_set_phase(dev, SCSI_PHASE_STATUS);
+                tape_command_complete(dev);
+                break;
+            }
 
             /* If a filemark was deferred from a previous read, the tape
                position is already past the filemark.  Account for it
@@ -2278,6 +2366,8 @@ tape_command(scsi_common_t *sc, const uint8_t *cdb)
 
             if (dev->active_partition != 0) {
                 dev->aux_filemark = 0;
+                dev->aux_filemark_seen = 0;
+                dev->aux_data_len = 0;
                 dev->aux_pos      = 0;
                 dev->bot          = 1;
                 dev->eot          = 0;
@@ -2604,9 +2694,32 @@ tape_phase_data_out(scsi_common_t *sc)
                                   (uint32_t) dev->current_cdb[4];
 
             if (dev->active_partition != 0) {
-                /* The SIMH image stores partition zero. Auxiliary directory
-                   data remains virtual so it cannot overwrite that stream. */
-                dev->aux_pos = 1;
+                uint32_t bytes = fixed ? xfer_len * dev->block_size : xfer_len;
+                uint64_t end64 = (uint64_t) dev->aux_pos + bytes;
+                if (end64 > UINT32_MAX) {
+                    tape_eom_detected(dev, fixed ? xfer_len : 1);
+                    tape_buf_free(dev);
+                    return 0;
+                }
+                uint32_t end = (uint32_t) end64;
+                if (end > dev->aux_buf_size) {
+                    uint8_t *buf = (uint8_t *) realloc(dev->aux_buf, end);
+                    if (buf == NULL) {
+                        tape_sense_key = SENSE_MEDIUM_ERROR;
+                        tape_asc       = ASC_WRITE_ERROR;
+                        tape_ascq      = 0;
+                        tape_cmd_error(dev);
+                        tape_buf_free(dev);
+                        return 0;
+                    }
+                    dev->aux_buf      = buf;
+                    dev->aux_buf_size = end;
+                }
+                memcpy(dev->aux_buf + dev->aux_pos, dev->buffer, bytes);
+                dev->aux_pos       = end;
+                dev->aux_data_len  = end;
+                dev->aux_filemark  = 0;
+                dev->aux_filemark_seen = 0;
                 dev->bot     = 0;
                 ui_sb_update_icon_write(SB_TAPE | dev->id, 0);
                 break;
@@ -2735,7 +2848,6 @@ tape_phase_data_out(scsi_common_t *sc)
                 if (page == GPMODE_DEVICE_CONFIG_PAGE) {
                     dev->active_partition =
                         dev->ms_pages_saved.pages[page][3];
-                    dev->aux_pos = 0;
                     tape_log(dev->log, "MODE SELECT: active partition set to %u\n",
                              dev->active_partition);
                 }
@@ -2995,6 +3107,9 @@ tape_close(void)
 
                 if (dev->rec_buf)
                     free(dev->rec_buf);
+
+                if (dev->aux_buf)
+                    free(dev->aux_buf);
 
                 if (dev->tf)
                     free(dev->tf);


### PR DESCRIPTION
Summary
=======
Improved tape backup drive support including DAT-72 and DDS based standards. I have implemented and tested with Gentoo Linux and Windows 98 backup utility to allow us to backup and restore to/from tape drives. Also fixed the issues with ARCHIVE tape backup drive in 86Box.

Checklist
=========
* [ ] Closes #xxx
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._

<img width="800" height="600" alt="Monitor_1_20260826-230501-171" src="https://github.com/user-attachments/assets/0f33a9b8-9233-4722-8d39-53ca64344c2a" />
<img width="800" height="600" alt="Monitor_1_20260826-213606-005" src="https://github.com/user-attachments/assets/b794c60f-74a6-447b-a343-10803c8ebe6f" />
