### PR TITLE
G100: Fix pixel PLL reference frequency

### DIFF
--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -441,6 +441,8 @@ typedef struct mystique_t {
 
     int type, is_agp;
 
+    float pll_ref_clock;
+
     mem_mapping_t lfb_mapping, ctrl_mapping,
         iload_mapping;
 
@@ -929,7 +931,7 @@ mystique_getclock(int clock, void *priv)
     int n  = mystique->xpixpll[2].n;
     int pl = mystique->xpixpll[2].p;
 
-    float fvco = 14318181.0f * ((float) n + 1.0f) / ((float) m + 1.0f);
+    float fvco = mystique->pll_ref_clock * ((float) n + 1.0f) / ((float) m + 1.0f);
     float fo   = fvco / ((float) pl + 1.0);
 
     return fo;
@@ -6788,6 +6790,11 @@ mystique_init(const device_t *info)
 
     mystique->type   = info->local;
     mystique->is_agp = !!(info->flags & DEVICE_AGP);
+
+    if (mystique->type == MGA_G100)
+        mystique->pll_ref_clock = 27050000.0f;
+    else
+        mystique->pll_ref_clock = 14318181.0f;
 
     if (mystique->type == MGA_2064W)
         romfn = ROM_MILLENNIUM;


### PR DESCRIPTION
Summary
=======
The old one uses 14.318 MHz for _all_ cards which causes low refresh rate on G100.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
https://bitsavers.org/components/matrox/_dataSheets/MGA-G100_199802.pdf
