### PR TITLE
Add ability to load CD images into RAM

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -234,6 +234,8 @@ int      is_new_808x = 0;                                         /* (C) Use the
 
 int      gdbstub_port = 12345;                                    /* (C) The GDB stub port. */
 
+int      cdrom_ram_thread_enabled = 0;                            /* (C) Load CD images into RAM. */
+
 // Accelerator key array
 struct accelKey acc_keys[NUM_ACCELS];
 

--- a/src/cdrom/CMakeLists.txt
+++ b/src/cdrom/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(cdrom OBJECT
     cdrom_image_viso.c
     cdrom_mke.c
     cdrom_chd.c
+    cdrom_ram.c
 )
 target_link_libraries(cdrom chdr-static)
 if(NOT WIN32)

--- a/src/cdrom/cdrom.c
+++ b/src/cdrom/cdrom.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdatomic.h>
 #include <wchar.h>
 #include <86box/86box.h>
 #include <86box/device.h>
@@ -42,6 +43,7 @@
 #include <86box/scsi_cdrom.h>
 #include <86box/sound.h>
 #include <86box/ui.h>
+#include <86box/thread.h>
 
 #define RAW_SECTOR_SIZE    2352
 
@@ -3370,6 +3372,49 @@ cdrom_update_status(cdrom_t *dev)
     }
 }
 
+struct thread_ram_load_status_t
+{
+    _Atomic(uint64_t) cntr;
+    atomic_bool_t     finished;
+};
+
+typedef struct thread_ram_load_status_t thread_ram_load_status_t;
+
+struct thread_ram_load_ctx_t
+{
+    void* cd_image_ctx;
+    uint8_t* ram_image_to_read_info;
+    const cdrom_ops_t* ops;
+    uint64_t begin_pos;
+    uint64_t sectors_to_read;
+
+    thread_ram_load_status_t* load_status;
+};
+
+typedef struct thread_ram_load_ctx_t thread_ram_load_ctx_t;
+
+void
+display_cntr(void* param)
+{
+    thread_ram_load_status_t* cntr = (thread_ram_load_status_t*)param;
+
+    while (!atomic_load(&cntr->finished)) {
+        plat_delay_ms(1);
+        ui_set_prog_dialog(atomic_load(&cntr->cntr));
+    }
+}
+
+void
+ram_load_thread(void* param)
+{
+    thread_ram_load_ctx_t* load_param = (thread_ram_load_ctx_t*)param;
+
+    for (uint64_t i = 0; i < load_param->sectors_to_read; i++) {
+        load_param->ops->read_sector(load_param->cd_image_ctx, &load_param->ram_image_to_read_info[(i + load_param->begin_pos) * 2448], i + load_param->begin_pos);
+        atomic_fetch_add_explicit(&load_param->load_status->cntr, 1, memory_order_relaxed);
+    }
+}
+
 int
 cdrom_load(cdrom_t *dev, const char *fn, const int skip_insert)
 {
@@ -3393,6 +3438,90 @@ cdrom_load(cdrom_t *dev, const char *fn, const int skip_insert)
         dev->local = image_open(dev, dev->image_path);
         if (!dev->local)
             dev->local = aaru_image_open(dev, dev->image_path);
+    }
+
+    if (dev->local) {
+        if (cdrom_ram_thread_enabled && !(((strlen(dev->image_path) != 0) && (strstr(dev->image_path, "ioctl://") == dev->image_path)))) {
+            uint8_t rti_data[65536] = { 0 };
+            void* orig_local = dev->local;
+            int rti_size = 0;
+            
+            dev->ops->get_raw_track_info(orig_local, &rti_size, rti_data);
+
+            do {
+                int num_of_threads = cdrom_ram_thread_enabled;
+
+                if (num_of_threads == -1)
+                    num_of_threads = plat_get_ideal_thread_count();
+
+                uint32_t cd_size = dev->ops->get_last_block(dev->local) + 1;
+
+                uint8_t* ram_image_to_read_info = calloc(2448, cd_size);
+                if (!ram_image_to_read_info)
+                    break;
+
+                thread_t** cd_ram_threads = (thread_t**)calloc(sizeof(thread_t*), num_of_threads);
+                thread_ram_load_status_t* load_status = (thread_ram_load_status_t*)calloc(1, sizeof(thread_ram_load_status_t));
+                thread_ram_load_ctx_t* cd_ram_threads_data = (thread_ram_load_ctx_t*)calloc(sizeof(thread_ram_load_ctx_t), num_of_threads);
+
+                atomic_init(&load_status->cntr, 0);
+                atomic_init(&load_status->finished, 0);
+
+                uint64_t cd_size_chunk = cd_size / num_of_threads;
+
+                for (int i = 0; i < num_of_threads; i++) {
+                    if (cdrom_image_is_chd(dev->image_path))
+                        cd_ram_threads_data[i].cd_image_ctx = chd_image_open(dev, dev->image_path);
+                    else if (cdrom_image_is_aaru(dev->image_path))
+                        cd_ram_threads_data[i].cd_image_ctx = aaru_image_open(dev, dev->image_path);
+                    else {
+                        cd_ram_threads_data[i].cd_image_ctx = image_open(dev, dev->image_path);
+                        if (!cd_ram_threads_data[i].cd_image_ctx)
+                            cd_ram_threads_data[i].cd_image_ctx = aaru_image_open(dev, dev->image_path);
+                    }
+
+                    cd_ram_threads_data[i].load_status = load_status;
+                    cd_ram_threads_data[i].ops = dev->ops;
+                    cd_ram_threads_data[i].begin_pos = i * cd_size_chunk;
+                    cd_ram_threads_data[i].sectors_to_read = (i == (num_of_threads - 1)) ? (cd_size - ((num_of_threads - 1) * cd_size_chunk)) : cd_size_chunk;
+                    cd_ram_threads_data[i].ram_image_to_read_info = ram_image_to_read_info;
+                }
+
+                // Time to display the progress dialog.
+                ui_init_prog_dialog(strdup(dev->image_path), cd_size - 1);
+
+                // Start the counter thread.
+                thread_t* cntr_thread = thread_create(display_cntr, load_status);
+
+                // Now start all the RAM loading threads.
+                for (int i = 0; i < num_of_threads; i++)
+                    cd_ram_threads[i] = thread_create(ram_load_thread, &cd_ram_threads_data[i]);
+
+                // Wait for all threads.
+                for (int i = 0; i < num_of_threads; i++)
+                    thread_wait(cd_ram_threads[i]);
+
+                load_status->finished = 1;
+
+                // Wait for counter thread.
+                thread_wait(cntr_thread);
+
+                if (dev->close) {
+                    dev->close(orig_local);
+                    for (int i = 0; i < num_of_threads; i++) {
+                        dev->close(cd_ram_threads_data[i].cd_image_ctx);
+                    }
+                    free(cd_ram_threads_data);
+                }
+
+                free(load_status);
+                free(cd_ram_threads);
+
+                ui_end_prog_dialog();
+
+                dev->local = ram_image_open(dev, ram_image_to_read_info, cd_size - 1, (raw_track_info_t*)rti_data, rti_size);
+            } while(0);
+        }
     }
 
     dev->cached_sector  = -1;

--- a/src/cdrom/cdrom.c
+++ b/src/cdrom/cdrom.c
@@ -3375,7 +3375,6 @@ cdrom_update_status(cdrom_t *dev)
 struct thread_ram_load_status_t
 {
     _Atomic(uint64_t) cntr;
-    atomic_bool_t     finished;
 };
 
 typedef struct thread_ram_load_status_t thread_ram_load_status_t;
@@ -3387,22 +3386,12 @@ struct thread_ram_load_ctx_t
     const cdrom_ops_t* ops;
     uint64_t begin_pos;
     uint64_t sectors_to_read;
+    atomic_bool_t finished;
 
     thread_ram_load_status_t* load_status;
 };
 
 typedef struct thread_ram_load_ctx_t thread_ram_load_ctx_t;
-
-void
-display_cntr(void* param)
-{
-    thread_ram_load_status_t* cntr = (thread_ram_load_status_t*)param;
-
-    while (!atomic_load(&cntr->finished)) {
-        plat_delay_ms(1);
-        ui_set_prog_dialog(atomic_load(&cntr->cntr));
-    }
-}
 
 void
 ram_load_thread(void* param)
@@ -3413,6 +3402,7 @@ ram_load_thread(void* param)
         load_param->ops->read_sector(load_param->cd_image_ctx, &load_param->ram_image_to_read_info[(i + load_param->begin_pos) * 2448], i + load_param->begin_pos);
         atomic_fetch_add_explicit(&load_param->load_status->cntr, 1, memory_order_relaxed);
     }
+    load_param->finished = true;
 }
 
 int
@@ -3421,6 +3411,11 @@ cdrom_load(cdrom_t *dev, const char *fn, const int skip_insert)
     const int  was_empty = cdrom_is_empty(dev->id);
     int        ret       = 0;
 
+    if (!is_cpu_thread)
+        startblit();
+
+    cdrom_stop(dev);
+    sound_cd_thread_reset();
     /* Make sure to not STRCPY if the two are pointing
        at the same place. */
     if (fn != dev->image_path)
@@ -3465,7 +3460,6 @@ cdrom_load(cdrom_t *dev, const char *fn, const int skip_insert)
                 thread_ram_load_ctx_t* cd_ram_threads_data = (thread_ram_load_ctx_t*)calloc(sizeof(thread_ram_load_ctx_t), num_of_threads);
 
                 atomic_init(&load_status->cntr, 0);
-                atomic_init(&load_status->finished, 0);
 
                 uint64_t cd_size_chunk = cd_size / num_of_threads;
 
@@ -3490,21 +3484,21 @@ cdrom_load(cdrom_t *dev, const char *fn, const int skip_insert)
                 // Time to display the progress dialog.
                 ui_init_prog_dialog(strdup(dev->image_path), cd_size - 1);
 
-                // Start the counter thread.
-                thread_t* cntr_thread = thread_create(display_cntr, load_status);
-
-                // Now start all the RAM loading threads.
+                // Start all the RAM loading threads.
                 for (int i = 0; i < num_of_threads; i++)
                     cd_ram_threads[i] = thread_create(ram_load_thread, &cd_ram_threads_data[i]);
 
                 // Wait for all threads.
-                for (int i = 0; i < num_of_threads; i++)
-                    thread_wait(cd_ram_threads[i]);
-
-                load_status->finished = 1;
-
-                // Wait for counter thread.
-                thread_wait(cntr_thread);
+                while (1) {
+                    bool is_finished = true;
+                    for (int i = 0; i < num_of_threads; i++) {
+                        is_finished = is_finished && atomic_load(&cd_ram_threads_data[i].finished);
+                    }
+                    plat_delay_ms(1);
+                    ui_set_prog_dialog(atomic_load(&load_status->cntr));
+                    if (is_finished)
+                        break;
+                }
 
                 if (dev->close) {
                     dev->close(orig_local);
@@ -3572,6 +3566,9 @@ cdrom_load(cdrom_t *dev, const char *fn, const int skip_insert)
         if (was_empty)
             cdrom_insert(dev->id);
     }
+
+    if (!is_cpu_thread)
+        endblit();
 
     return ret;
 }

--- a/src/cdrom/cdrom_image.c
+++ b/src/cdrom/cdrom_image.c
@@ -60,7 +60,6 @@
 #define CROSS_LEN           512
 
 static char temp_keyword[1024];
-static char temp_file[260]     = { 0 };
 
 #pragma pack(push, 1)
 struct sbi_replacement_ent
@@ -148,6 +147,8 @@ typedef struct cd_image_t {
     uint64_t sector_subs_size;
 
     FILE *subs_file;
+    
+    char temp_file[1024];
 } cd_image_t;
 
 typedef enum
@@ -2633,16 +2634,16 @@ mds_decrypt_track_data(cd_image_t *img, const char *mdsfile, FILE **fp)
     *fp = NULL;
 
     /* Dump mdxHeader */
-    plat_tempfile(temp_file, "mds_v2", ".tmp");
-    image_log(img->log, "\nDumping header into %s... ", nvr_path(temp_file));
+    plat_tempfile(img->temp_file, "mds_v2", ".tmp");
+    image_log(img->log, "\nDumping header into %s... ", nvr_path(img->temp_file));
 
-    *fp = plat_fopen64(nvr_path(temp_file), "wb");
+    *fp = plat_fopen64(nvr_path(img->temp_file), "wb");
     fwrite(mdxHeader, 1, decSize + 0x12, *fp);
 
     fclose(*fp);
     *fp = NULL;
 
-    *fp = plat_fopen64(nvr_path(temp_file), "rb");
+    *fp = plat_fopen64(nvr_path(img->temp_file), "rb");
 
     image_log(img->log, "Done\n");
     return isDVD + 1;
@@ -3507,9 +3508,9 @@ image_close(void *local)
 
         free(img);
 
-        if (temp_file[0] != 0x00) {
-            remove(nvr_path(temp_file));
-            temp_file[0] = 0x00;
+        if (img->temp_file[0] != 0x00) {
+            remove(nvr_path(img->temp_file));
+            img->temp_file[0] = 0x00;
         }
     }
 }

--- a/src/cdrom/cdrom_image.c
+++ b/src/cdrom/cdrom_image.c
@@ -3506,12 +3506,12 @@ image_close(void *local)
         if (img->bad_sectors != NULL)
             free(img->bad_sectors);
 
-        free(img);
-
         if (img->temp_file[0] != 0x00) {
             remove(nvr_path(img->temp_file));
             img->temp_file[0] = 0x00;
         }
+
+        free(img);
     }
 }
 

--- a/src/cdrom/cdrom_image_viso.c
+++ b/src/cdrom/cdrom_image_viso.c
@@ -130,10 +130,10 @@ typedef struct {
     viso_entry_t  *file_fifo[VISO_OPEN_FILES];
 } viso_t;
 
-static const char rr_eid[]   = "RRIP_1991A"; /* identifiers used in ER field for Rock Ridge */
-static const char rr_edesc[] = "THE ROCK RIDGE INTERCHANGE PROTOCOL PROVIDES SUPPORT FOR POSIX FILE SYSTEM SEMANTICS.";
-static int        tz_offset_sec = 0;
-static int8_t     tz_offset_iso = 0;
+static const char rr_eid[]               = "RRIP_1991A"; /* identifiers used in ER field for Rock Ridge */
+static const char rr_edesc[]             = "THE ROCK RIDGE INTERCHANGE PROTOCOL PROVIDES SUPPORT FOR POSIX FILE SYSTEM SEMANTICS.";
+__thread static int        tz_offset_sec = 0;
+__thread static int8_t     tz_offset_iso = 0;
 
 #ifdef IMAGE_VISO_LOG
 int image_viso_do_log = IMAGE_VISO_LOG;

--- a/src/cdrom/cdrom_image_viso.c
+++ b/src/cdrom/cdrom_image_viso.c
@@ -130,10 +130,10 @@ typedef struct {
     viso_entry_t  *file_fifo[VISO_OPEN_FILES];
 } viso_t;
 
-static const char rr_eid[]               = "RRIP_1991A"; /* identifiers used in ER field for Rock Ridge */
-static const char rr_edesc[]             = "THE ROCK RIDGE INTERCHANGE PROTOCOL PROVIDES SUPPORT FOR POSIX FILE SYSTEM SEMANTICS.";
-__thread static int        tz_offset_sec = 0;
-__thread static int8_t     tz_offset_iso = 0;
+static const char      rr_eid[]      = "RRIP_1991A"; /* identifiers used in ER field for Rock Ridge */
+static const char      rr_edesc[]    = "THE ROCK RIDGE INTERCHANGE PROTOCOL PROVIDES SUPPORT FOR POSIX FILE SYSTEM SEMANTICS.";
+static __thread int    tz_offset_sec = 0;
+static __thread int8_t tz_offset_iso = 0;
 
 #ifdef IMAGE_VISO_LOG
 int image_viso_do_log = IMAGE_VISO_LOG;

--- a/src/cdrom/cdrom_ram.c
+++ b/src/cdrom/cdrom_ram.c
@@ -1,0 +1,248 @@
+#define __STDC_FORMAT_MACROS
+#include <ctype.h>
+#include <inttypes.h>
+#ifdef ENABLE_IMAGE_LOG
+#    include <stdarg.h>
+#endif
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <wchar.h>
+#include <zlib.h>
+#include <limits.h>
+#include <sys/stat.h>
+#ifndef _WIN32
+#    include <libgen.h>
+#endif
+
+#include <86box/86box.h>
+#include <86box/log.h>
+#include <86box/nvr.h>
+#include <86box/path.h>
+#include <86box/plat.h>
+#include <86box/bswap.h>
+#include <86box/cdrom.h>
+#include <86box/cdrom_image.h>
+#include <86box/cdrom_image_viso.h>
+#include <86box/plat_dynld.h>
+
+typedef struct ram_image_t {
+    cdrom_t *dev;
+    uint8_t* cd_image_data;
+
+    int64_t end_lba;
+
+    raw_track_info_t* rti_infos;
+    uint32_t rti_size; // NOT in bytes.
+} ram_image_t;
+
+static void
+ram_image_get_raw_track_info(UNUSED(const void *local), int *num, uint8_t *rti)
+{
+    ram_image_t *ioctl = (ram_image_t *) local;
+
+    *num = ioctl->rti_size;
+    memcpy(rti, ioctl->rti_infos, *num * 11);
+}
+
+static int
+ram_image_get_track_info(UNUSED(const void *local), UNUSED(const uint32_t track),
+                          UNUSED(int end), UNUSED(track_info_t *ti))
+{
+    const ram_image_t      *ioctl      = (const ram_image_t *) local;
+    const raw_track_info_t *rti        = (const raw_track_info_t *) ioctl->rti_infos;
+    int                     ret        = 1;
+    int                     trk        = -1;
+    int                     next       = -1;
+    uint32_t                blocks_num = (ioctl->rti_size);
+
+    if ((track >= 1) && (track < 99))
+        for (int i = 0; i < blocks_num; i++)
+            if (rti[i].point == track) {
+                trk = i;
+                break;
+            }
+
+    if ((track >= 1) && (track < 98))
+        for (int i = 0; i < blocks_num; i++)
+            if ((rti[i].point == (track + 1)) && (rti[i].session == rti[trk].session)) {
+                next = i;
+                break;
+            }
+
+    if ((track >= 1) && (track < 99) && (trk != -1) && (next == -1))
+        for (int i = 0; i < blocks_num; i++)
+            if ((rti[i].point == 0xa2) && (rti[i].session == rti[trk].session)) {
+                next = i;
+                break;
+            }
+
+    if ((track == 0xaa) || (trk == -1)) {
+        ret = 0;
+    } else {
+        if (end) {
+            if (next != -1) {
+                ti->m = rti[next].pm;
+                ti->s = rti[next].ps;
+                ti->f = rti[next].pf;
+            }
+        } else {
+            ti->m = rti[trk].pm;
+            ti->s = rti[trk].ps;
+            ti->f = rti[trk].pf;
+        }
+
+        ti->number = rti[trk].point;
+        ti->attr   = rti[trk].adr_ctl;
+    }
+
+    return ret;
+}
+
+static int
+ram_image_get_track(const ram_image_t *ioctl, const uint32_t sector)
+{
+    raw_track_info_t *rti    = (raw_track_info_t *) ioctl->rti_infos;
+    int               track  = -1;
+    int               tracks = ioctl->rti_size;
+
+    for (int i = (tracks - 1); i >= 0; i--) {
+        const raw_track_info_t *ct    = &(rti[i]);
+        const uint32_t          start = (ct->pm * 60 * 75) + (ct->ps * 75) + ct->pf - 150;
+
+        if ((ct->point >= 1) && (ct->point <= 99) && (sector >= start)) {
+            track = i;
+            break;
+        }
+    }
+
+    return track;
+}
+
+static int
+ram_image_has_audio(UNUSED(const void *local))
+{
+    ram_image_t *img = (ram_image_t *) local;
+    for (unsigned int i = 0; i < img->rti_size; i++) {
+        if (!(img->rti_infos[i].adr_ctl & 4))
+            return 1;
+    }
+    return 0;
+}
+
+static int
+ram_image_track_audio(const ram_image_t *ioctl, const uint32_t pos)
+{
+    raw_track_info_t *rti = (raw_track_info_t *) ioctl->rti_infos;
+    int               ret = 0;
+
+    if (1) {
+        const int track   = ram_image_get_track(ioctl, pos);
+        const int control = rti[track].adr_ctl;
+
+        ret = !(control & 0x04);
+    }
+
+    return ret;
+}
+
+static uint8_t
+ram_image_get_track_type(const void *local, const uint32_t sector)
+{
+    ram_image_t            *ioctl = (ram_image_t *) local;
+    int                     track = ram_image_get_track(ioctl, sector);
+    raw_track_info_t       *rti   = (raw_track_info_t *) (ioctl->rti_infos);
+    const raw_track_info_t *trk   = &(rti[track]);
+    uint8_t                 ret   = 0x00;
+
+    if (ram_image_track_audio(ioctl, sector))
+        ret = CD_TRACK_AUDIO;
+    else if (track != -1)
+        for (int i = 0; i < ioctl->rti_size; i++) {
+            const raw_track_info_t *ct = &(rti[i]);
+            const raw_track_info_t *nt = &(rti[i + 1]);
+
+            if (ct->point == 0xa0) {
+                uint8_t first = ct->pm;
+                uint8_t last  = nt->pm;
+
+                if ((trk->point >= first) && (trk->point <= last)) {
+                    ret = ct->ps;
+                    break;
+                }
+            }
+        }
+
+    return ret;
+}
+
+static int
+ram_image_read_dvd_structure(UNUSED(const void *local), UNUSED(const uint8_t layer), UNUSED(const uint8_t format),
+                              UNUSED(uint8_t *buffer), UNUSED(uint32_t *info))
+{
+    return 0;
+}
+
+static int
+ram_image_is_dvd(UNUSED(const void *local))
+{
+    return 0;
+}
+
+static uint32_t
+ram_image_get_last_block(const void *local)
+{
+    ram_image_t *ioctl = (ram_image_t *) local;
+
+    return ioctl->end_lba;
+}
+
+static int
+ram_image_read_sector(const void *local, UNUSED(uint8_t *buffer), UNUSED(uint32_t const sector))
+{
+    ram_image_t *ioctl = (ram_image_t *) local;
+    if (sector > ioctl->end_lba)
+        return 0;
+    memcpy(buffer, &ioctl->cd_image_data[(uint64_t)sector * (uint64_t)2448], 2448);
+    return 1;
+}
+
+static void
+ram_image_close(void *local)
+{
+    ram_image_t *img = local;
+    free(img->cd_image_data);
+    if (img->rti_infos)
+        free(img->rti_infos);
+    free(img);
+}
+
+static const cdrom_ops_t ram_image_ops = {
+    ram_image_get_track_info,
+    ram_image_get_raw_track_info,
+    ram_image_read_sector,
+    ram_image_get_track_type,
+    ram_image_get_last_block,
+    ram_image_read_dvd_structure,
+    ram_image_is_dvd,
+    ram_image_has_audio,
+    NULL,
+    ram_image_close,
+    NULL
+};
+
+void*
+ram_image_open(cdrom_t *dev, uint8_t* cd_image_data, int64_t end_lba, raw_track_info_t* rti_infos, uint32_t rti_size)
+{
+    ram_image_t* ram_img = (ram_image_t*)calloc(1, sizeof(ram_image_t));
+    ram_img->cd_image_data = cd_image_data;
+    ram_img->end_lba = end_lba;
+    ram_img->rti_infos = calloc(rti_size, sizeof(raw_track_info_t));
+    ram_img->rti_size  = rti_size;
+    ram_img->dev = dev;
+    memcpy(ram_img->rti_infos, rti_infos, rti_size * sizeof(raw_track_info_t));
+    dev->ops = &ram_image_ops;
+    return ram_img;
+}

--- a/src/config.c
+++ b/src/config.c
@@ -359,6 +359,8 @@ load_general(void)
         fixed_size_x = fixed_size_y = 120;
     }
 
+    cdrom_ram_thread_enabled = ini_section_get_int(cat, "cdrom_ram_thread_enabled", 0);
+
     sound_gain = ini_section_get_int(cat, "sound_gain", 0);
 
     kbd_req_capture = ini_section_get_int(cat, "kbd_req_capture", 0);
@@ -3168,6 +3170,11 @@ save_general(void)
         ini_section_delete_var(cat, "gdbstub_port");
     else
         ini_section_set_int(cat, "gdbstub_port", gdbstub_port);
+
+    if (cdrom_ram_thread_enabled == 0)
+        ini_section_delete_var(cat, "cdrom_ram_thread_enabled");
+    else
+        ini_section_set_int(cat, "cdrom_ram_thread_enabled", cdrom_ram_thread_enabled);
 
     ini_delete_section_if_empty(config, cat);
 }

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -248,6 +248,7 @@ extern int    hook_enabled;                 /* (C) Keyboard hook is enabled */
 extern int    vmm_disabled;                 /* (G) disable built-in manager */
 extern char   vmm_path_cfg[1024];           /* (G) VMs path (unless -E is used) */
 extern int    gdbstub_port;                 /* (C) The GDB stub port. */
+extern int    cdrom_ram_thread_enabled;     /* (C) Load CD images into RAM. */
 
 extern char exe_path[2048];        /* path (dir) of executable */
 extern char usr_path[1024];        /* path (dir) of user data */

--- a/src/include/86box/cdrom_image.h
+++ b/src/include/86box/cdrom_image.h
@@ -38,4 +38,6 @@ extern void *aaru_image_open(cdrom_t *dev, const char *path);
 extern void *chd_image_open(cdrom_t *dev, const char *path);
 extern void *ccd_image_open(cdrom_t *dev, const char *path);
 
+extern void *ram_image_open(cdrom_t *dev, uint8_t* cd_image_data, int64_t end_lba, raw_track_info_t* rti_infos, uint32_t rti_size);
+
 #endif /*CDROM_IMAGE_H*/

--- a/src/include/86box/plat.h
+++ b/src/include/86box/plat.h
@@ -164,6 +164,7 @@ extern void     plat_get_cpu_string(char *outbuf, uint8_t len);
 #ifdef _WIN32
 extern void     plat_get_system_directory(char *outbuf);
 #endif
+extern int      plat_get_ideal_thread_count(void);
 extern void     plat_set_thread_name(void *thread, const char *name);
 extern void     plat_break(void);
 extern void     plat_send_to_clipboard(unsigned char *rgb, int width, int height);

--- a/src/include/86box/ui.h
+++ b/src/include/86box/ui.h
@@ -64,6 +64,10 @@ extern void  ui_sb_set_text(char *str);
 extern void  ui_sb_bugui(char *str);
 extern void  ui_sb_mt32lcd(char *str);
 
+extern void  ui_init_prog_dialog(const char *str, uint64_t end);
+extern void  ui_set_prog_dialog(uint64_t progress);
+extern void  ui_end_prog_dialog(void);
+
 extern void     ui_update_force_interpreter(void);
 
 #ifdef __cplusplus

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -965,30 +965,40 @@ MainWindow::MainWindow(QWidget *parent)
     connect(this, &MainWindow::initProgressDialog, this, [this] (const char *text, uint64_t end) {
         isNonPause = true;
         prog_dialog = new QProgressDialog(this);
+        prog_dialog->setModal(true);
         prog_dialog->setMinimum(0);
         prog_dialog->setMaximum(end);
         prog_dialog->setAutoClose(false);
         prog_dialog->setAutoReset(false);
-        prog_dialog->setWindowTitle(text);
+        prog_dialog->setWindowTitle(EMU_NAME);
+        prog_dialog->setLabelText(text);
         prog_dialog->setValue(0);
+        prog_dialog->setCancelButton(nullptr);
         prog_dialog->show();
         free((void*)text);
     }, Qt::DirectConnection);
 
     connect(this, &MainWindow::setProgressDialogProg, this, [this] (uint64_t pos) {
-        if (prog_dialog)
+        if (prog_dialog) {
             prog_dialog->setValue(pos);
-    }, Qt::QueuedConnection);
+        }
+    }, Qt::DirectConnection);
 
     connect(this, &MainWindow::endProgressDialog, this, [this] () {
-        prog_dialog->deleteLater();
-        prog_dialog = nullptr;
+        if (prog_dialog) {
+            prog_dialog->deleteLater();
+            prog_dialog = nullptr;
+        }
         isNonPause = false;
     }, Qt::QueuedConnection);
 
     connect(this, &MainWindow::initProgressDialogForNonQtThread, this, [this] (const char *text, uint64_t end) {
         initProgressDialog(text, end);
     }, Qt::BlockingQueuedConnection);
+
+    connect(this, &MainWindow::setProgressDialogProgForNonQtThread, this, [this] (uint64_t progress) {
+        setProgressDialogProg(progress);
+    }, Qt::QueuedConnection);
 
 #ifdef XKBCOMMON
 #    ifdef XKBCOMMON_X11

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -962,6 +962,34 @@ MainWindow::MainWindow(QWidget *parent)
         ui->actionCursor_Puck->setChecked(true);
     }
 
+    connect(this, &MainWindow::initProgressDialog, this, [this] (const char *text, uint64_t end) {
+        isNonPause = true;
+        prog_dialog = new QProgressDialog(this);
+        prog_dialog->setMinimum(0);
+        prog_dialog->setMaximum(end);
+        prog_dialog->setAutoClose(false);
+        prog_dialog->setAutoReset(false);
+        prog_dialog->setWindowTitle(text);
+        prog_dialog->setValue(0);
+        prog_dialog->show();
+        free((void*)text);
+    }, Qt::DirectConnection);
+
+    connect(this, &MainWindow::setProgressDialogProg, this, [this] (uint64_t pos) {
+        if (prog_dialog)
+            prog_dialog->setValue(pos);
+    }, Qt::QueuedConnection);
+
+    connect(this, &MainWindow::endProgressDialog, this, [this] () {
+        prog_dialog->deleteLater();
+        prog_dialog = nullptr;
+        isNonPause = false;
+    }, Qt::QueuedConnection);
+
+    connect(this, &MainWindow::initProgressDialogForNonQtThread, this, [this] (const char *text, uint64_t end) {
+        initProgressDialog(text, end);
+    }, Qt::BlockingQueuedConnection);
+
 #ifdef XKBCOMMON
 #    ifdef XKBCOMMON_X11
     if (QApplication::platformName().contains("xcb"))

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -8,6 +8,7 @@
 #include <QLabel>
 #include <QShortcut>
 #include <QIcon>
+#include <QProgressDialog>
 
 #include <memory>
 #include <array>
@@ -64,6 +65,13 @@ signals:
     void destroyRendererMonitorForNonQtThread(int monitor_index);
     void forceInterpretationCompleted();
     void hardResetCompleted();
+
+    // Only strdup'd/malloc'd strings must be passed onto it!
+    void initProgressDialog(const char* text, uint64_t end);
+    void setProgressDialogProg(uint64_t progress);
+    void endProgressDialog();
+
+    void initProgressDialogForNonQtThread(const char* text, uint64_t end);
 
     void setTitle(const QString &title);
     void setFullscreen(bool state);
@@ -220,6 +228,8 @@ private:
     bool window_blocked = false;
 
     bool skip_exit_confirmation = false;
+
+    QProgressDialog* prog_dialog;
 };
 
 #endif // QT_MAINWINDOW_HPP

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -72,6 +72,7 @@ signals:
     void endProgressDialog();
 
     void initProgressDialogForNonQtThread(const char* text, uint64_t end);
+    void setProgressDialogProgForNonQtThread(uint64_t progress);
 
     void setTitle(const QString &title);
     void setFullscreen(bool state);

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -46,6 +46,7 @@
 #include <QProcess>
 #include <QRegularExpression>
 #include <QKeySequence>
+#include <QThread>
 
 #include <QLibrary>
 #include <QElapsedTimer>
@@ -621,6 +622,12 @@ void
 plat_remove(char *path)
 {
     QFile(path).remove();
+}
+
+int
+plat_get_ideal_thread_count(void)
+{
+    return QThread::idealThreadCount();
 }
 
 void *

--- a/src/qt/qt_preferencesemulator.cpp
+++ b/src/qt/qt_preferencesemulator.cpp
@@ -75,6 +75,23 @@ PreferencesEmulator::PreferencesEmulator(QWidget *parent)
     ui->radioButtonLight->setChecked(color_scheme == 1);
     ui->radioButtonDark->setChecked(color_scheme == 2);
 
+    ui->checkBoxCDDVDtoRam->setChecked(cdrom_ram_thread_enabled);
+    switch (cdrom_ram_thread_enabled) {
+        case -1:
+        default:
+            ui->comboBoxCDDVDtoRam->setCurrentIndex(0);
+            break;
+        case 2:
+            ui->comboBoxCDDVDtoRam->setCurrentIndex(1);
+            break;
+        case 4:
+            ui->comboBoxCDDVDtoRam->setCurrentIndex(2);
+            break;
+        case 8:
+            ui->comboBoxCDDVDtoRam->setCurrentIndex(3);
+            break;
+    }
+
 #ifndef Q_OS_WINDOWS
     ui->groupBox->setHidden(true);
 #endif
@@ -109,6 +126,27 @@ PreferencesEmulator::save()
 
     color_scheme       = (ui->radioButtonSystem->isChecked()) ? 0 : (ui->radioButtonLight->isChecked() ? 1 : 2);
 
+    bool ram_thread_enabled = ui->checkBoxCDDVDtoRam->isChecked();
+    if (ram_thread_enabled) {
+        switch (ui->comboBoxCDDVDtoRam->currentIndex())
+        {
+            case 1:
+                cdrom_ram_thread_enabled = 2;
+                break;
+            case 2:
+                cdrom_ram_thread_enabled = 4;
+                break;
+            case 3:
+                cdrom_ram_thread_enabled = 8;
+                break;
+            default:
+            case 0:
+                cdrom_ram_thread_enabled = -1;
+                break;
+        }
+    } else
+        cdrom_ram_thread_enabled = 0;
+
 #ifdef Q_OS_WINDOWS
     extern void selectDarkMode();
     selectDarkMode();
@@ -140,4 +178,11 @@ void
 PreferencesEmulator::on_pushButtonLanguage_released()
 {
     ui->comboBoxLanguage->setCurrentIndex(0);
+}
+
+void
+PreferencesEmulator::on_checkBoxCDDVDtoRam_stateChanged(int state)
+{
+    ui->comboBoxCDDVDtoRam->setEnabled(state == Qt::Checked);
+    ui->labelCDDVDtoRam->setEnabled(state == Qt::Checked);
 }

--- a/src/qt/qt_preferencesemulator.hpp
+++ b/src/qt/qt_preferencesemulator.hpp
@@ -23,6 +23,9 @@ public:
     int  changed();
     void save();
 
+public slots:
+    void on_checkBoxCDDVDtoRam_stateChanged(int state);
+
 private slots:
     void on_pushButtonLanguage_released();
 

--- a/src/qt/qt_preferencesemulator.ui
+++ b/src/qt/qt_preferencesemulator.ui
@@ -26,44 +26,17 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-
-   <item row="2" column="0">
+   <item>
     <layout class="QGridLayout" name="gridLayout">
      <property name="leftMargin">
       <number>0</number>
-       </property>
+     </property>
      <property name="topMargin">
       <number>0</number>
      </property>
      <property name="rightMargin">
       <number>0</number>
      </property>
-
-     <item row="0" column="0">
-      <widget class="QLabel" name="labelLanguage">
-       <property name="text">
-        <string>Language:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="comboBoxLanguage">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maxVisibleItems">
-        <number>30</number>
-       </property>
-       <item>
-        <property name="text">
-         <string>(System Default)</string>
-        </property>
-       </item>
-      </widget>
-     </item>
      <item row="0" column="2">
       <widget class="QPushButton" name="pushButtonLanguage">
        <property name="sizePolicy">
@@ -87,13 +60,6 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0" colspan="2">
-      <widget class="QCheckBox" name="checkBoxAutoPause">
-       <property name="text">
-        <string>Auto-pause on focus loss</string>
-       </property>
-      </widget>
-     </item>
      <item row="3" column="0" colspan="2">
       <widget class="QCheckBox" name="checkBoxAutoDialogPause">
        <property name="text">
@@ -101,24 +67,10 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0" colspan="2">
-      <widget class="QCheckBox" name="checkBoxConfirmSave">
+     <item row="2" column="0" colspan="2">
+      <widget class="QCheckBox" name="checkBoxAutoPause">
        <property name="text">
-        <string>Ask for confirmation before saving settings</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0" colspan="2">
-      <widget class="QCheckBox" name="checkBoxConfirmExit">
-       <property name="text">
-        <string>Ask for confirmation before quitting</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0" colspan="2">
-      <widget class="QCheckBox" name="checkBoxConfirmHardReset">
-       <property name="text">
-        <string>Ask for confirmation before hard resetting</string>
+        <string>Auto-pause on focus loss</string>
        </property>
       </widget>
      </item>
@@ -130,9 +82,16 @@
       </widget>
      </item>
      <item row="8" column="0" colspan="2">
+      <widget class="QCheckBox" name="checkBoxCDDVDtoRam">
+       <property name="text">
+        <string>Load CD/DVD images into memory</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0" colspan="2">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
-          <widget class="QGroupBox" name="groupBox">
+        <widget class="QGroupBox" name="groupBox">
          <property name="title">
           <string>Color scheme</string>
          </property>
@@ -154,7 +113,7 @@
           <item>
            <widget class="QRadioButton" name="radioButtonDark">
             <property name="text">
-               <string>Dark</string>
+             <string>Dark</string>
             </property>
            </widget>
           </item>
@@ -176,11 +135,86 @@
        </item>
       </layout>
      </item>
-
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelLanguage">
+       <property name="text">
+        <string>Language:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0" colspan="2">
+      <widget class="QCheckBox" name="checkBoxConfirmExit">
+       <property name="text">
+        <string>Ask for confirmation before quitting</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="comboBoxLanguage">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maxVisibleItems">
+        <number>30</number>
+       </property>
+       <item>
+        <property name="text">
+         <string>(System Default)</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="6" column="0" colspan="2">
+      <widget class="QCheckBox" name="checkBoxConfirmHardReset">
+       <property name="text">
+        <string>Ask for confirmation before hard resetting</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0" colspan="2">
+      <widget class="QCheckBox" name="checkBoxConfirmSave">
+       <property name="text">
+        <string>Ask for confirmation before saving settings</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0" colspan="2">
+      <widget class="QLabel" name="labelCDDVDtoRam">
+       <property name="text">
+        <string>Threads to use for loading into memory:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="2">
+      <widget class="QComboBox" name="comboBoxCDDVDtoRam">
+       <item>
+        <property name="text">
+         <string>Auto</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>2</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>4</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>8</string>
+        </property>
+       </item>
+      </widget>
+     </item>
     </layout>
    </item>
-
-   <item row="2" column="1">
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -193,7 +227,6 @@
      </property>
     </spacer>
    </item>
-
   </layout>
  </widget>
  <resources/>

--- a/src/qt/qt_ui.cpp
+++ b/src/qt/qt_ui.cpp
@@ -414,4 +414,26 @@ ui_sb_update_icon_write(int tag, int write)
             break;
     }
 }
+
+void
+ui_init_prog_dialog(const char *str, uint64_t end)
+{
+    if (QThread::currentThread() == main_window->thread()) {
+        emit main_window->initProgressDialog(str, end);
+    } else
+        emit main_window->initProgressDialogForNonQtThread(str, end);
+}
+
+void
+ui_set_prog_dialog(uint64_t progress)
+{
+    emit main_window->setProgressDialogProg(progress);
+}
+
+void
+ui_end_prog_dialog(void)
+{
+    emit main_window->endProgressDialog();
+}
+
 }

--- a/src/qt/qt_ui.cpp
+++ b/src/qt/qt_ui.cpp
@@ -427,7 +427,11 @@ ui_init_prog_dialog(const char *str, uint64_t end)
 void
 ui_set_prog_dialog(uint64_t progress)
 {
-    emit main_window->setProgressDialogProg(progress);
+    QApplication::processEvents();
+    if (QThread::currentThread() == main_window->thread()) {
+        emit main_window->setProgressDialogProg(progress);
+    } else
+        emit main_window->setProgressDialogProgForNonQtThread(progress);
 }
 
 void

--- a/src/unix/sdl_plat.c
+++ b/src/unix/sdl_plat.c
@@ -405,3 +405,13 @@ strnicmp(const char *s1, const char *s2, size_t n)
 {
     return strncasecmp(s1, s2, n);
 }
+
+int
+plat_get_ideal_thread_count(void)
+{
+#ifdef USE_SDL2_LIB
+    return SDL_GetCPUCount();
+#else
+    return SDL_GetNumLogicalCPUCores();
+#endif
+}

--- a/src/unix/sdl_ui.c
+++ b/src/unix/sdl_ui.c
@@ -135,3 +135,21 @@ ui_update_force_interpreter(void)
 {
     /* No-op. */
 }
+
+void
+ui_init_prog_dialog(const char *str, uint64_t end)
+{
+    /* No-op. */
+}
+
+void
+ui_set_prog_dialog(uint64_t progress)
+{
+    /* No-op. */
+}
+
+void
+ui_end_prog_dialog(void)
+{
+    /* No-op. */
+}


### PR DESCRIPTION
Summary
=======
Add ability to load CD images into RAM.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
