### PR TITLE
bin/cue/ccd: Open all binary non-audio images on Windows with sequential access hint

### DIFF
--- a/src/cdrom/cdrom_image.c
+++ b/src/cdrom/cdrom_image.c
@@ -497,7 +497,11 @@ bin_init(const uint8_t id, const char *filename, int *error)
 
     memset(tf->fn, 0x00, sizeof(tf->fn));
     strncpy(tf->fn, filename, sizeof(tf->fn) - 1);
+#ifdef _WIN32
+    tf->fp = plat_fopen64(tf->fn, "rbS");
+#else
     tf->fp = plat_fopen64(tf->fn, "rb");
+#endif
     image_log(tf->log, "binary_open(%s) = %08lx\n", tf->fn, tf->fp);
 
     if (stat(tf->fn, &stats) != 0) {


### PR DESCRIPTION
Summary
=======
bin/cue/ccd: Open all binary non-audio images on Windows with sequential access hint.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=msvc-170.
