### PR TITLE
Implement the ES1869 filter bypass

### DIFF
--- a/src/include/86box/snd_sb.h
+++ b/src/include/86box/snd_sb.h
@@ -164,6 +164,7 @@ typedef struct ess_mixer_t {
     int input_filter;
     int in_filter_freq;
     int output_filter;
+    int output_filter_dac2;
 
     int stereo;
     int stereo_isleft;

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -924,8 +924,13 @@ sb_get_buffer_ess_dac2(int32_t *buffer, uint16_t len, void *priv)
     for (int c = 0; c < len * 2; c += 2) {
         double out_l = 0.0;
         double out_r = 0.0;
-        out_l += (low_fir_ess_dac2(0, (double) ess->ess_dac2_buffer[c]) * mixer->dac2_l) / 3.0;
-        out_r += (low_fir_ess_dac2(1, (double) ess->ess_dac2_buffer[c + 1]) * mixer->dac2_r) / 3.0;
+        if (mixer->output_filter_dac2) {
+            out_l += (low_fir_ess_dac2(0, (double) ess->ess_dac2_buffer[c]) * mixer->dac2_l) / 3.0;
+            out_r += (low_fir_ess_dac2(1, (double) ess->ess_dac2_buffer[c + 1]) * mixer->dac2_r) / 3.0;
+        } else {
+            out_l += (ess->ess_dac2_buffer[c] * mixer->dac2_l) / 3.0;
+            out_r += (ess->ess_dac2_buffer[c + 1] * mixer->dac2_r) / 3.0;
+        }
         out_l *= mixer->master_l;
         out_r *= mixer->master_r;
         buffer[c] += (int32_t) out_l;
@@ -2129,6 +2134,9 @@ ess_mixer_write(uint16_t addr, uint8_t val, void *priv)
                     if (ess->dsp.sb_subtype == SB_SUBTYPE_ESS_ES1869) {
                         sb_log("ESS DAC2 Mode register write: val = %02X\n", val);
                         ess->dsp.es1869_divider_mode = (val & 0x20) ? 1 : 0;
+                        mixer->output_filter      = (val & 0x04) ? 1 : 0;
+                        mixer->input_filter       = (val & 0x04) ? 1 : 0;
+                        mixer->output_filter_dac2 = (val & 0x08) ? 1 : 0;
                     }
                     break;
                 case 0x72: /* DAC 2 Filter Clock Divider */
@@ -6015,6 +6023,7 @@ ess_1x88_onboard_init(const device_t *info)
         /* Initialize ESS filter to 8 kHz. This will be recalculated when a set frequency command is
            sent. */
         recalc_ess_dac2_filter(8000 * 2);
+        ess->mixer_ess.output_filter_dac2 = 1;
     }
 
     /* Calculate 6-bit attenuation values for ES1788+ master volume control */
@@ -6133,6 +6142,7 @@ ess_186x_init(const device_t *info)
     /* Initialize ESS filter to 8 kHz. This will be recalculated when a set frequency command is
        sent. */
     recalc_ess_dac2_filter(8000 * 2);
+    ess->mixer_ess.output_filter_dac2 = 1;
 
     /* Init read-only control registers */
     ess->es186x_ctrl_iregs[0x20] = 0x59;

--- a/src/sound/sound.c
+++ b/src/sound/sound.c
@@ -978,8 +978,6 @@ sound_cd_thread_reset(void)
 {
     int available_cdrom_drives = 0;
 
-    timer_disable(&cd_poll_timer);
-
     for (uint8_t i = 0; i < CDROM_NUM; i++) {
         cdrom_stop(&(cdrom[i]));
 


### PR DESCRIPTION
Summary
=======
Implement the ESS AudioDrive ES1869's filter bypass configured with bits 3-2 in mixer register 71h

Drive-by change: Revert the CD polling timer change from PR #7800 due to it causing 86Box to hang on hard resets with some machines.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
- ES1869 datasheet: http://hackipedia.org/browse.cgi/Computer/Platform/PC%2c%20IBM%20compatible/Sound%20and%20Music/Creative%20Labs/Sound%20Blaster/ESS%20AudioDrive%20%28compatible%29/ES1869%20AudioDrive%20Solution%20Data%20Sheet%20%281998%29%2epdf