### PR TITLE
Implement GUS MPU401 emulation regs and rev 3.4 card

### DIFF
--- a/src/include/86box/sound.h
+++ b/src/include/86box/sound.h
@@ -274,6 +274,7 @@ extern const device_t ct5880_onboard_device;
 
 /* Gravis UltraSound family */
 extern const device_t gus_device;
+extern const device_t gus_v34_device;
 extern const device_t gus_v37_device;
 extern const device_t gus_max_device;
 extern const device_t gus_ace_device;

--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -213,10 +213,14 @@ typedef struct gus_t {
     int     uart_out;
     int     sysex;
 
-    uint8_t  gp1;
-    uint8_t  gp2;
+    uint8_t  gp1_in;
+    uint8_t  gp1_out;
+    uint8_t  gp2_in;
+    uint8_t  gp2_out;
     uint16_t gp1_addr;
     uint16_t gp2_addr;
+    uint16_t cur_gp1;
+    uint16_t cur_gp2;
 
     uint8_t usrr;
 
@@ -387,6 +391,64 @@ gus_input_poll(void *priv)
     } else {
         timer_disable(&gus->sample_timer);
     }
+}
+
+void
+gus_gp_write(uint16_t addr, uint8_t val, void *priv)
+{
+    gus_t   *gus = (gus_t *) priv;
+
+    uint8_t port = addr & 1;
+
+    gus_log(gus->log, "GUS GP write: port = %i, val = %02X\n", port, val);
+
+    if (gus->reg_ctrl & 0x40) {
+        switch (port) {
+            case 0:
+                gus->gp1_in = val;
+                if (gus->reg_ctrl & 0x08)
+                    nmi_raise();
+                gus->usrr |= 0x08;
+                break;
+            case 1:
+                gus->gp2_in = val;
+                if (gus->reg_ctrl & 0x10)
+                    nmi_raise();
+                gus->usrr |= 0x20;
+                break;
+        }
+    }
+}
+
+uint8_t
+gus_gp_read(uint16_t addr, void *priv)
+{
+    gus_t   *gus = (gus_t *) priv;
+    uint8_t ret = 0;
+
+    uint8_t port = addr & 1;
+
+    if (gus->reg_ctrl & 0x40) {
+        switch (port) {
+            case 0:
+                if (gus->reg_ctrl & 0x08)
+                    nmi_raise();
+                ret = gus->gp1_out;
+                gus->usrr |= 0x10;
+                break;
+            case 1:
+                if (gus->reg_ctrl & 0x10)
+                    nmi_raise();
+                ret = gus->gp2_out;
+                gus->usrr |= 0x40;
+                break;
+        }
+    } else
+        ret = 0xff;
+
+    gus_log(gus->log, "GUS GP read: port = %i, val = %02X\n", port, ret);
+
+    return ret;
 }
 
 void
@@ -824,16 +886,32 @@ gus_write(uint16_t addr, uint8_t val, void *priv)
                     }
                     break;
                 case 1:
-                    gus->gp1 = val;
+                    if (gus->type > GUS_CLASSIC)
+                        gus->gp1_out = val;
                     break;
                 case 2:
-                    gus->gp2 = val;
+                    if (gus->type > GUS_CLASSIC)
+                        gus->gp2_out = val;
                     break;
                 case 3:
-                    gus->gp1_addr = val;
+                    if (gus->type > GUS_CLASSIC) {
+                        if (gus->cur_gp1)
+                            io_removehandler(0x300 + gus->gp1_addr, 0x0001, gus_gp_read, NULL, NULL, gus_gp_write, NULL, NULL, gus);
+                        gus->gp1_addr = val;
+                        io_sethandler(0x300 + gus->gp1_addr, 0x0001, gus_gp_read, NULL, NULL, gus_gp_write, NULL, NULL, gus);
+                        gus->cur_gp1 = 0x300 + gus->gp1_addr;
+                        gus_log(gus->log, "GUS GP 1 address change: new addr = %04X\n", gus->cur_gp1);
+                    }
                     break;
                 case 4:
-                    gus->gp2_addr = val;
+                    if (gus->type > GUS_CLASSIC) {
+                        if (gus->cur_gp2)
+                            io_removehandler(0x300 + gus->gp2_addr, 0x0001, gus_gp_read, NULL, NULL, gus_gp_write, NULL, NULL, gus);
+                        gus->gp2_addr = val;
+                        io_sethandler(0x300 + gus->gp2_addr, 0x0001, gus_gp_read, NULL, NULL, gus_gp_write, NULL, NULL, gus);
+                        gus->cur_gp2 = 0x300 + gus->gp2_addr;
+                        gus_log(gus->log, "GUS GP 2 address change: new addr = %04X\n", gus->cur_gp2);
+                    }
                     break;
                 case 5:
                     if (gus->type > GUS_CLASSIC)
@@ -1018,7 +1096,7 @@ gus_read(uint16_t addr, void *priv)
 
         case 0x20F:
             if (gus->type > GUS_CLASSIC)
-                val = gus->jumper;
+                val = gus->usrr;
             else
                 val = 0xff;
             break;
@@ -1205,10 +1283,10 @@ gus_read(uint16_t addr, void *priv)
             if (gus->type > GUS_CLASSIC) {
                 switch (gus->reg_ctrl & 0x07) {
                     case 1:
-                        val = gus->gp1;
+                        val = gus->gp1_in;
                         break;
                     case 2:
-                        val = gus->gp2;
+                        val = gus->gp2_in;
                         break;
                     case 3:
                         val = gus->gp1_addr;
@@ -1791,8 +1869,10 @@ gus_reset(void *priv)
     gus->uart_out = 0;
     gus->sysex = 0;
 
-    gus->gp1 = 0;
-    gus->gp2 = 0;
+    gus->gp1_in = 0;
+    gus->gp1_out = 0;
+    gus->gp2_in = 0;
+    gus->gp2_out = 0;
     gus->gp1_addr = 0;
     gus->gp2_addr = 0;
 

--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -1971,8 +1971,6 @@ gus_init(UNUSED(const device_t *info))
     if (gus->type == GUS_MAX) {
         ad1848_init(&gus->ad1848, AD1848_TYPE_CS4231);
         ad1848_set_cd_audio_channel(&gus->ad1848, AD1848_AUX2);
-        ad1848_setirq(&gus->ad1848, 5);
-        ad1848_setdma(&gus->ad1848, 3);
         gus->cur_codec_addr = gus->base + 0x10C;
         io_sethandler(0x10C + gus->base, 4,
                       ad1848_read, NULL, NULL, ad1848_write, NULL, NULL, &gus->ad1848);

--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -1905,7 +1905,7 @@ gus_init(UNUSED(const device_t *info))
 
     gus->log = log_open("GUS");
 
-    if ((info->local == GUS_CLASSIC) || (info->local == GUS_CLASSIC_37))
+    if ((info->local == GUS_CLASSIC) || (info->local == GUS_CLASSIC_34) || (info->local == GUS_CLASSIC_37))
         gus->gus_end_ram = gus_ram * 262144;
     else
         gus->gus_end_ram = 1 << (18 + gus_ram);

--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -1304,7 +1304,7 @@ gus_read(uint16_t addr, void *priv)
         case 0x20c:
             val = gus->sb_2xc;
             if (gus->reg_ctrl & 0x20)
-                gus->sb_2xc &= 0x80;
+                gus->sb_2xc ^= 0x80;
             break;
         case 0x20e:
             gus_log(gus->log, "GUS read: port = %04X, val = %02X\n", addr, gus->sb_2xe);

--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -93,11 +93,12 @@ enum {
 
 enum {
     GUS_CLASSIC    = 0,
-    GUS_CLASSIC_37 = 1,
-    GUS_MAX        = 2,
-    GUS_ACE        = 3,
-    GUS_VIPERMAX   = 4,
-    GUS_EXTREME    = 5
+    GUS_CLASSIC_34 = 1,
+    GUS_CLASSIC_37 = 2,
+    GUS_MAX        = 3,
+    GUS_ACE        = 4,
+    GUS_VIPERMAX   = 5,
+    GUS_EXTREME    = 6
 };
 
 enum {
@@ -2448,6 +2449,20 @@ const device_t gus_device = {
     .speed_changed = gus_speed_changed,
     .force_redraw  = NULL,
     .config        = gus_config
+};
+
+const device_t gus_v34_device = {
+    .name          = "Gravis UltraSound (rev 3.4)",
+    .internal_name = "gusv34",
+    .flags         = DEVICE_ISA16,
+    .local         = GUS_CLASSIC_34,
+    .init          = gus_init,
+    .close         = gus_close,
+    .reset         = gus_reset,
+    .available     = NULL,
+    .speed_changed = gus_speed_changed,
+    .force_redraw  = NULL,
+    .config        = gus_v37_config
 };
 
 const device_t gus_v37_device = {

--- a/src/sound/sound.c
+++ b/src/sound/sound.c
@@ -190,6 +190,7 @@ static const SOUND_CARD sound_cards[] = {
     { &ess_1868_device              },
     { &ess_1869_device              },
     { &gus_device                   },
+    { &gus_v34_device               },
     { &gus_v37_device               },
     { &gus_max_device               },
     { &gus_ace_device               },


### PR DESCRIPTION
Summary
=======
Make the following changes to the Gravis UltraSound cards:
- Implement the General Purpose/MPU401 emulation registers on GF1D1-equipped cards making MegaEM 3.x's MPU401 emulation functional
- Do not set the GUS MAX CS4231's IRQ/DMA at power-on, the DOS init utility and Windows drivers will set this
- Fix a long-standing mistake in how the Toggle UI2XCR[7] bit in Register Control affects reads of 2xCh: It now properly flips the bit instead of clearing bits 6-0
- Add the revision 3.4 variant of the GUS Classic: this card has the GF1D1 ASIC but lacks the 3.7's ICS mixer.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
- AMD InterWave Programmer's Guide: http://hackipedia.org/browse.cgi/Computer/Platform/PC%2c%20IBM%20compatible/Sound%20and%20Music/Advanced%20Micro%20Devices%20%28AMD%29/Interwave/InterWave%20IC%20Am78C201%2d202%20Programmer%27s%20Guide%20%281996%29%20Revision%202%2epdf