### PR TITLE
OSD: Add Aaru format related files to image extension list

### DIFF
--- a/src/osd/osd_core.cpp
+++ b/src/osd/osd_core.cpp
@@ -219,7 +219,7 @@ static const char *const floppy_exts[] = {
 
 /* .ccd/.nrg/.mdf not supported by backend; .mdx is encrypted MDS. */
 static const char *const cd_exts[] = {
-    ".iso", ".cue", ".toc", ".ccd", ".mds", ".mdx", nullptr
+    ".iso", ".cue", ".toc", ".ccd", ".mds", ".mdx", ".aaruf", ".aaruformat", ".aif", nullptr
 };
 
 static const char *const rdisk_exts[] = {


### PR DESCRIPTION
Summary
=======
This patch adds the officially-recognized Aaru extensions to the list of supported optical media images, so they are always available. Loading the images through the OSD worked fine in testing, using all extensions.

Note: Aaru can capture _A LOT_ of different formats, but since I only every used it for optical media, I didn't want to add it to the floppy disc extensions as well.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
Derived from https://github.com/86Box/86Box/commit/174ccdf9a174eb08b9a3395b8f7281fec1fb767a and https://github.com/86Box/86Box/pull/7450
