### PR TITLE
Add the onboard video to the Dell OptiPlex 560/L

### DIFF
--- a/src/machine/m_at_socket4.c
+++ b/src/machine/m_at_socket4.c
@@ -260,9 +260,8 @@ machine_at_opti560l_init(const machine_t *model)
 
     pci_init(PCI_CONFIG_TYPE_2);
     pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x03, PCI_CARD_NORMAL,      4, 4, 3, 3);
-    pci_register_slot(0x07, PCI_CARD_NORMAL,      1, 4, 3, 2);
-    pci_register_slot(0x08, PCI_CARD_NORMAL,      2, 1, 3, 4);
+    pci_register_slot(0x03, PCI_CARD_VIDEO, 3, 3, 3, 3);
+    pci_register_slot(0x07, PCI_CARD_NORMAL, 1, 4, 3, 2);
     pci_register_slot(0x02, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 0);
 
     device_add(&i430lx_device);
@@ -270,6 +269,9 @@ machine_at_opti560l_init(const machine_t *model)
     device_add(&sio_zb_device);
     device_add_params(&i82091aa_device, (void *) I82091AA_022);
     device_add(&intel_flash_bxt_ami_device);
+
+    if (gfxcard[0] == VID_INTERNAL)
+        device_add(&gd5430_onboard_pci_device);
 
     return ret;
 }

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -13844,7 +13844,7 @@ const machine_t machines[] = {
             .max_multi   = MACHINE_MULTIPLIER_FIXED
         },
         .bus_flags = MACHINE_PS2_PCI,
-        .flags     = MACHINE_IDE | MACHINE_APM, /* Machine has internal video: Cirrus Logic GD5430 */
+        .flags     = MACHINE_IDE | MACHINE_APM | MACHINE_VIDEO,
         .ram       = {
             .min  = 2048,
             .max  = 131072,
@@ -13865,7 +13865,7 @@ const machine_t machines[] = {
         .device                   = NULL,
         .kbd_device               = NULL,
         .fdc_device               = NULL,
-        .vid_device               = NULL,
+        .vid_device               = &gd5430_onboard_pci_device,
         .snd_device               = NULL,
         .net_device               = NULL,
         .aliases                  = { "" }


### PR DESCRIPTION
Summary
=======
This pull request will add the onboard video (Cirrus Logic CL-5430) to the Dell OptiPlex 560/L.

Checklist
=========
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already