### PR TITLE
Fixed general read and performance issues within Mitsumi CD-ROM.

### DIFF
--- a/src/cdrom/cdrom_mitsumi.c
+++ b/src/cdrom/cdrom_mitsumi.c
@@ -38,7 +38,7 @@
 
 #define RAW_SECTOR_SIZE    2352
 #define COOKED_SECTOR_SIZE 2048
-#define DMA_SERVICE_BUDGET 256
+#define DMA_SERVICE_BUDGET 2048
 #define MITSUMI_1X_SECTOR_TIME_US (1000000 / 75)
 #define MITSUMI_2X_SECTOR_TIME_US (1000000 / 150)
 #define MITSUMI_DMA_COUNT_BIAS    7
@@ -431,7 +431,10 @@ mitsumi_cdrom_read_sector(mcd_t *dev, int first)
                        dev->cdrom_dev->seek_pos, ret, dev->readbuflen, mitsumi_dma_length(dev));
     if (ret <= 0)
         return -3;
-    dev->readmsf   = cdrom_lba_to_msf_accurate(dev->cdrom_dev->seek_pos + 1);
+    const uint32_t next_msf = cdrom_lba_to_msf_accurate(dev->cdrom_dev->seek_pos + 1);
+    dev->readmsf = (bin2bcd((next_msf >> 16) & 0xff) << 16) |
+                   (bin2bcd((next_msf >> 8) & 0xff) << 8) |
+                   bin2bcd(next_msf & 0xff);
     dev->buf_idx   = 0;
     if (dev->mode & 0x80) {
         if (!(dev->mode & MODE_DATA)) {
@@ -489,8 +492,21 @@ mitsumi_dma_transfer(mcd_t *dev)
 
         if (dma_result & DMA_OVER) {
             mitsumi_cdrom_log("Mitsumi: DMA terminal count at buffer offset %d\n", dev->buf_idx);
-            mitsumi_abort_read(dev);
+            dma_set_drq(dev->dma, 0);
+            dev->buf_count  = 0;
+            dev->buf_idx    = 0;
+            dev->readbuflen = 0;
+            dev->data       = 0;
             mitsumi_set_irq(dev, IRQ_DATACOMP);
+            if (dev->readcount && dev->enable_dma &&
+                (dev->drvmode == DRV_MODE_READ)) {
+                timer_set_delay_u64(&dev->dma_timer,
+                                    ((dev->cmd == CMD_READ2X) ? MITSUMI_2X_SECTOR_TIME_US :
+                                                               MITSUMI_1X_SECTOR_TIME_US) * TIMER_USEC);
+            } else {
+                timer_disable(&dev->dma_timer);
+                dev->drvmode = DRV_MODE_STOP;
+            }
             return 0;
         }
         if (--service_budget == 0)
@@ -527,6 +543,8 @@ mitsumi_dma_callback(void *priv)
             }
             return;
         }
+        if (dev->enable_dma)
+            dma_set_drq(dev->dma, 1);
     }
 
     result = mitsumi_dma_transfer(dev);
@@ -545,11 +563,12 @@ mitsumi_dma_callback(void *priv)
         /* The channel may still be masked or owned by another requester.
            Keep DRQ asserted and retry without blocking the emulation thread. */
         if ((dma[dev->dma].cc < 0) ||
+            (dma_m & (1 << dev->dma)) ||
             ((dma[dev->dma].mode & 0x0c) != 0x04)) {
             /* The DOS driver enables the interface before it finishes
-               programming the 8237 count and direction.  This is not a
-               read error. */
-            timer_set_delay_u64(&dev->dma_timer, 1ULL << 32);
+               programming and briefly unmasking the 8237 channel.  None of
+               those waiting states is a read error. */
+            timer_set_delay_u64(&dev->dma_timer, 100 * TIMER_USEC);
             return;
         }
         if (!dev->dma_retries)
@@ -1048,6 +1067,7 @@ mitsumi_cdrom_init(UNUSED(const device_t *info))
                   mitsumi_cdrom_in, NULL, NULL, mitsumi_cdrom_out, NULL, NULL, dev);
 
     timer_add(&dev->dma_timer, mitsumi_dma_callback, dev, 0);
+    dma_set_service_handler(dev->dma, mitsumi_dma_callback, dev);
     mitsumi_cdrom_reset(dev);
 
     return dev;
@@ -1059,6 +1079,7 @@ mitsumi_cdrom_close(void *priv)
     mcd_t *dev = (mcd_t *) priv;
 
     if (dev) {
+        dma_set_service_handler(dev->dma, NULL, NULL);
         mitsumi_abort_read(dev);
         io_removehandler(dev->base, 4,
                          mitsumi_cdrom_in, NULL, NULL, mitsumi_cdrom_out, NULL, NULL, dev);

--- a/src/dma.c
+++ b/src/dma.c
@@ -472,6 +472,19 @@ dma_set_drq(int channel, int set)
         dma_xt_refresh_reconcile();
 }
 
+static void (*dma_service_handler[8])(void *);
+static void  *dma_service_priv[8];
+
+void
+dma_set_service_handler(int channel, void (*handler)(void *), void *priv)
+{
+    if ((channel < 0) || (channel > 7))
+        return;
+
+    dma_service_handler[channel] = handler;
+    dma_service_priv[channel]    = priv;
+}
+
 void
 dma_set_eop(int channel, int set)
 {
@@ -985,6 +998,14 @@ dma_read_legacy(uint16_t addr, UNUSED(void *priv))
             break;
 
         case 8: /*Status register*/
+            /* A peripheral with DRQ asserted may complete its transfer while
+               software polls terminal count.  Service it before returning
+               the controller status so the completion is visible at once. */
+            for (channel = 0; channel < 4; channel++) {
+                if ((dma_stat_rq_pc & (1 << channel)) &&
+                    !(dma_m & (1 << channel)) && dma_service_handler[channel])
+                    dma_service_handler[channel](dma_service_priv[channel]);
+            }
             if (dma_ps2.is_ps2) {
                 ret = (dma_stat_rq & 0x0f) << 4;
                 ret |= dma_stat & 0x0f;
@@ -1366,6 +1387,12 @@ dma16_read(uint16_t addr, UNUSED(void *priv))
             break;
 
         case 8: /*Status register*/
+            /* See the primary-controller status path above. */
+            for (channel = 4; channel < 8; channel++) {
+                if ((dma_stat_rq_pc & (1 << channel)) &&
+                    !(dma_m & (1 << channel)) && dma_service_handler[channel])
+                    dma_service_handler[channel](dma_service_priv[channel]);
+            }
             if (dma_ps2.is_ps2) {
                 ret = dma_stat_rq & 0xf0;
                 ret |= (dma_stat & 0xf0) >> 4;

--- a/src/include/86box/dma.h
+++ b/src/include/86box/dma.h
@@ -94,6 +94,7 @@ extern void writedma2(uint8_t temp);
 extern int  dma_get_drq(int channel);
 extern void dma_set_drq(int channel, int set);
 extern void dma_set_eop(int channel, int set);
+extern void dma_set_service_handler(int channel, void (*handler)(void *), void *priv);
 
 extern int dma_channel_read_only(int channel);
 extern int dma_channel_advance(int channel);


### PR DESCRIPTION
Summary
=======
Improved read and performance issues of Mitsumi CD-ROM

- Enhanced DMA handling-increase service budget
- Added service handler support
- Improved read sector processing

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
Test evidences
<img width="720" height="400" alt="Monitor_1_20260902-102612-060" src="https://github.com/user-attachments/assets/cf2f8223-f5c5-460d-819d-5b875b1a7da1" />
<img width="720" height="400" alt="Monitor_1_20260902-102125-145" src="https://github.com/user-attachments/assets/9153f2be-97ba-4a53-880d-5e4db5a6395e" />
<img width="720" height="400" alt="Monitor_1_20260902-102808-158" src="https://github.com/user-attachments/assets/8d3a24bf-8784-43ec-a975-59fb3fd4217b" />

