### PR TITLE
vid_s3_virge.c: Fix severely distorted rendering in S3 ViRGE high color modes (100x600 v.s. 800x600)

### DIFF
--- a/src/video/vid_s3_virge.c
+++ b/src/video/vid_s3_virge.c
@@ -941,7 +941,13 @@ s3_virge_recalctimings(svga_t *svga)
 
     svga->hdisp_time = svga->hdisp;
 
-    svga->hdisp *= svga->dots_per_clock;
+    int char_width = svga->dots_per_clock;
+    if (char_width < 8)
+        char_width = svga->hdisp_old / (svga->crtc[1] + 1);
+    if (char_width <= 0)
+        char_width = 8;
+
+    svga->hdisp *= char_width;
 
     svga->vtotal = svga->crtc[6];
     if (svga->crtc[7] & 0x01)


### PR DESCRIPTION
Summary
=======
_Briefly describe what you are submitting._

Checklist
=========
* [x] Closes #7844
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
