### PR TITLE
SDL: Fix black screen on SDL3 in 24/32bpp modes

### DIFF
--- a/src/unix/sdl_render.c
+++ b/src/unix/sdl_render.c
@@ -459,6 +459,7 @@ sdl_reinit_texture(void)
 
 #ifdef USE_SDL2_LIB
 #else
+    SDL_SetTextureBlendMode(sdl_tex, SDL_BLENDMODE_NONE);
     SDL_SetTextureScaleMode(sdl_tex, video_filter_method ? SDL_SCALEMODE_LINEAR : SDL_SCALEMODE_NEAREST);
 #endif
 


### PR DESCRIPTION
Summary
=======
SDL3 enabled `SDL_BLENDMODE_BLEND` by default, while this was (implicitly) set to `BLENDMODE_NONE` on SDL2. This causes rendering issues on guests using 24/32bpp color modes, since our pixel format `SDL_PIXELFORMAT_ARGB8888` requests an "unused" alpha channel.

For example, on Windows guests with 24bpp rendering, you'll either see a "black" mouse cursor or a normal mouse cursor in front of a totally black background. For 32bpp guests, the image will be entirely black, unless you use one of the cards that explicitly set `lut_map`.

Tested and verified on Voodoo 3000, Matrox, S3 ViRGE and more "generic" cards, Debian 13. Maybe someone can test this with SDL3 on Windows as well, since my development environment on Windows is currently SDL2-only.

SDL2 is unaffected by this, and also the cards that use `lut_map`.

Initially found by Claude Opus, verified and tested by me.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
https://wiki.libsdl.org/SDL3/README-migration:
"Textures are created with SDL_SCALEMODE_LINEAR by default, and use SDL_BLENDMODE_BLEND by default if they are created with a format that has an alpha channel."
