### PR TITLE
Fix Tandy Sensation internal audio emulation freezing the emulator

### DIFF
--- a/src/sound/snd_sensation.c
+++ b/src/sound/snd_sensation.c
@@ -1167,6 +1167,7 @@ sensation_init(UNUSED(const device_t *info))
 
     fm_driver_get_ex(FM_YMF262, &dev->opl, 3);
 
+    dev->visdac_freq = 44100;
     timer_add(&dev->sensation_mma_timer_count, sensation_mma_timer_poll, dev, 1);
     timer_add(&dev->visdac_timer_count, sensation_visdac_poll, dev, 1);
 


### PR DESCRIPTION
Summary
=======
Fix Tandy Sensation internal audio emulation freezing the emulator.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
