### PR TITLE
Add ATAPI model/vendor information for CDROMs and add the Goldstar CRD-8400B v1.02

### DIFF
--- a/src/cdrom/cdrom.c
+++ b/src/cdrom/cdrom.c
@@ -1238,6 +1238,26 @@ cdrom_get_model(const int type, char *name, const int id)
 }
 
 char *
+cdrom_get_inquiry_vendor(const int type)
+{
+    if (cdrom_drive_types[type].inquiry_vendor != NULL)
+        return (char *) cdrom_drive_types[type].inquiry_vendor;
+
+    return (char *) cdrom_drive_types[type].vendor;
+}
+
+void
+cdrom_get_inquiry_model(const int type, char *name, const int id)
+{
+    if (cdrom_drive_types[type].inquiry_model != NULL) {
+        sprintf(name, "%s", cdrom_drive_types[type].inquiry_model);
+        return;
+    }
+
+    cdrom_get_model(type, name, id);
+}
+
+char *
 cdrom_get_revision(const int type)
 {
     return (char *) cdrom_drive_types[type].revision;
@@ -1336,6 +1356,11 @@ void
 cdrom_get_identify_model(const int type, char *name, const int id)
 {
     char  elements[3][512] = { 0 };
+
+    if (cdrom_drive_types[type].identify_model != NULL) {
+        sprintf(name, "%s", cdrom_drive_types[type].identify_model);
+        return;
+    }
 
     memcpy(elements[0], cdrom_drive_types[type].vendor,
            strlen(cdrom_drive_types[type].vendor) + 1);

--- a/src/include/86box/cdrom.h
+++ b/src/include/86box/cdrom.h
@@ -167,6 +167,7 @@ static const struct cdrom_drive_types_s {
     { "GOLDSTAR", "CRD-8160B",        "3.14", "",          "goldstar",       BUS_TYPE_IDE,  0, 16, 36, 0, 0, {  4,  2,  1, -1 } },
     { "GOLDSTAR", "CRD-8240B",        "1.11", "",          "goldstar_8240b", BUS_TYPE_IDE,  0, 24, 36, 0, 0, {  4,  2,  1, -1 } },
     { "GOLDSTAR", "CRD-8320B",        "1.10", "",          "goldstar_8320b", BUS_TYPE_IDE,  0, 32, 36, 0, 0, {  4,  2,  1, -1 } },
+    { "GOLDSTAR", "CRD-8400B",        "1.02", "",          "gs_8400b_102",   BUS_TYPE_IDE,  0, 40, 36, 0, 0, {  4,  2,  2, -1 }, "CRD-8400B", "LG", "CD-ROM CRD-8400B" },
     { "GOLDSTAR", "CRD-8400B",        "1.03", "",          "gs_8400b_103",   BUS_TYPE_IDE,  0, 40, 36, 0, 0, {  4,  2,  2, -1 }, "CRD-8400B", "LG", "CD-ROM CRD-8400B" },
     { "GOLDSTAR", "CRD-8400B",        "1.12", "",          "goldstar_8400b", BUS_TYPE_IDE,  0, 40, 36, 0, 0, {  4,  2,  2, -1 } },
     { "GOLDSTAR", "CRD-8484B",        "1.03", "",          "goldstar_8484b", BUS_TYPE_IDE,  0, 48, 36, 0, 0, {  4,  2,  2,  2 } },

--- a/src/include/86box/cdrom.h
+++ b/src/include/86box/cdrom.h
@@ -134,6 +134,10 @@ static const struct cdrom_drive_types_s {
     const int     caddy;
     const int     is_dvd;
     const int     transfer_max[4];
+    /* Optional protocol identity overrides. NULL preserves the existing generated identity. */
+    const char   *identify_model;
+    const char   *inquiry_vendor;
+    const char   *inquiry_model;
 } cdrom_drive_types[] = {
     { EMU_NAME,   "86B_CD",           CDV,    "",          "86cd",           BUS_TYPE_BOTH, 2, -1, 36, 0, 0, {  4,  2,  2,  5 } },
     { EMU_NAME,   "86B_CD",           "1.00", "",          "86cd100",        BUS_TYPE_BOTH, 1, -1, 36, 1, 0, {  0, -1, -1, -1 } }, /* SCSI-1 / early ATAPI generic - second on purpose so the later variant is the default. */
@@ -163,7 +167,7 @@ static const struct cdrom_drive_types_s {
     { "GOLDSTAR", "CRD-8160B",        "3.14", "",          "goldstar",       BUS_TYPE_IDE,  0, 16, 36, 0, 0, {  4,  2,  1, -1 } },
     { "GOLDSTAR", "CRD-8240B",        "1.11", "",          "goldstar_8240b", BUS_TYPE_IDE,  0, 24, 36, 0, 0, {  4,  2,  1, -1 } },
     { "GOLDSTAR", "CRD-8320B",        "1.10", "",          "goldstar_8320b", BUS_TYPE_IDE,  0, 32, 36, 0, 0, {  4,  2,  1, -1 } },
-    { "GOLDSTAR", "CRD-8400B",        "1.03", "",          "gs_8400b_103",   BUS_TYPE_IDE,  0, 40, 36, 0, 0, {  4,  2,  2, -1 } },
+    { "GOLDSTAR", "CRD-8400B",        "1.03", "",          "gs_8400b_103",   BUS_TYPE_IDE,  0, 40, 36, 0, 0, {  4,  2,  2, -1 }, "CRD-8400B", "LG", "CD-ROM CRD-8400B" },
     { "GOLDSTAR", "CRD-8400B",        "1.12", "",          "goldstar_8400b", BUS_TYPE_IDE,  0, 40, 36, 0, 0, {  4,  2,  2, -1 } },
     { "GOLDSTAR", "CRD-8484B",        "1.03", "",          "goldstar_8484b", BUS_TYPE_IDE,  0, 48, 36, 0, 0, {  4,  2,  2,  2 } },
     { "GOLDSTAR", "GCD-R542B",        "1.20", "",          "goldstar_r542b", BUS_TYPE_IDE,  0,  4, 36, 0, 0, {  3,  2,  1, -1 } },
@@ -540,6 +544,8 @@ bcd2bin(int x)
 
 extern char           *cdrom_get_vendor(const int type);
 extern void            cdrom_get_model(const int type, char *name, const int id);
+extern char           *cdrom_get_inquiry_vendor(const int type);
+extern void            cdrom_get_inquiry_model(const int type, char *name, const int id);
 extern char           *cdrom_get_revision(const int type);
 extern int             cdrom_get_scsi_std(const int type);
 extern int             cdrom_is_early(const int type);

--- a/src/scsi/scsi_cdrom.c
+++ b/src/scsi/scsi_cdrom.c
@@ -4007,10 +4007,10 @@ scsi_cdrom_command(scsi_common_t *sc, const uint8_t *cdb)
                         dev->buffer[idx++] = 34;
 
                         ide_padstr8(dev->buffer + idx,  8,
-                                    cdrom_get_vendor(dev->drv->type));    /* Vendor */
+                                    cdrom_get_inquiry_vendor(dev->drv->type));    /* Vendor */
                         idx += 8;
 
-                        cdrom_get_model(dev->drv->type, model, dev->id);
+                        cdrom_get_inquiry_model(dev->drv->type, model, dev->id);
                         ide_padstr8(dev->buffer + idx, 16, model);                               /* Product */
                         idx += 16;
 
@@ -4054,8 +4054,8 @@ scsi_cdrom_command(scsi_common_t *sc, const uint8_t *cdb)
                 }
 
                 ide_padstr8(dev->buffer + 8,   8,
-                            cdrom_get_vendor(dev->drv->type));      /* Vendor */
-                cdrom_get_model(dev->drv->type, model, dev->id);
+                            cdrom_get_inquiry_vendor(dev->drv->type));      /* Vendor */
+                cdrom_get_inquiry_model(dev->drv->type, model, dev->id);
                 ide_padstr8(dev->buffer + 16, 16, model);                                 /* Product */
                 ide_padstr8(dev->buffer + 32,  4,
                             cdrom_get_revision(dev->drv->type));    /* Revision */


### PR DESCRIPTION
Summary
=======
New function for processing the ATAPI Vendor and Model requests.  Only in use at the moment for the CRD-8400B v1.02 and v1.03 in order to fix the Packard Bell "Symphony" recovery media CDROM detection.  Other models might need this identity/model info too, but they can be added in as required.

Also adds v1.02 of this CDROM ready for the upcoming IN530, both of which are used in the Packard Bell 9401 Club.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended

References
==========
Data obtained from the real CDROM drive as well as the PB recovery media files.
