### PR TITLE
Fix screenshot copy on Wayland

### DIFF
--- a/src/include/86box/plat.h
+++ b/src/include/86box/plat.h
@@ -166,7 +166,6 @@ extern void     plat_get_system_directory(char *outbuf);
 #endif
 extern void     plat_set_thread_name(void *thread, const char *name);
 extern void     plat_break(void);
-extern void     plat_send_to_clipboard(unsigned char *rgb, int width, int height);
 extern int      plat_run_command(const char *cmd, const char **env, const char *title);
 extern void     plat_clean_up(void);
 

--- a/src/qt/qt_openglrenderer.cpp
+++ b/src/qt/qt_openglrenderer.cpp
@@ -20,13 +20,13 @@
  */
 #include "qt_renderercommon.hpp"
 #include "qt_mainwindow.hpp"
+#include "qt_util.hpp"
 
 extern MainWindow *main_window;
 
 #include <QCoreApplication>
 #include <QMessageBox>
 #include <QWindow>
-#include <QClipboard>
 #include <QPainter>
 #include <QWidget>
 #include <QEvent>
@@ -1819,8 +1819,7 @@ OpenGLRenderer::render()
 
         int pitch_adj = (4 - ((width * 3) & 3)) & 3;
         QImage image((uchar*)rgb, width, height, (width * 3) + pitch_adj, QImage::Format_RGB888);
-        QClipboard *clipboard = QApplication::clipboard();
-        clipboard->setImage(image.IMG_FLIPPED, QClipboard::Clipboard);
+        util::copyImageToClipboard(image.IMG_FLIPPED);
         monitors[r_monitor_index].mon_screenshots_clipboard--;
         free(rgb);
     }

--- a/src/qt/qt_platform.cpp
+++ b/src/qt/qt_platform.cpp
@@ -33,7 +33,6 @@
 #include <QDebug>
 
 #include <QApplication>
-#include <QClipboard>
 #include <QDir>
 #include <QFileInfo>
 #include <QMimeData>
@@ -1217,40 +1216,6 @@ plat_break(void)
 #else
     raise(SIGTRAP);
 #endif
-}
-
-static unsigned char *rgb_    = NULL;
-static int            width_  = 0;
-static int            height_ = 0;
-static volatile int   waiting = 0;
-
-static void
-send_to_clipboard(void)
-{
-    unsigned char *rgb = (unsigned char *) calloc(1, height_ * width_ * 4);
-    memcpy(rgb, rgb_, height_ * width_ * 3);
-    QImage image(rgb, width_, height_, width_ * 3, QImage::Format_RGB888);
-    QClipboard *clipboard = QApplication::clipboard();
-    clipboard->setImage(image, QClipboard::Clipboard);
-    free(rgb);
-    waiting = 0;
-}
-
-void
-plat_send_to_clipboard(unsigned char *rgb, int width, int height)
-{
-    rgb_    = rgb;
-    width_  = width;
-    height_ = height;
-    waiting = 1;
-
-    QTimer::singleShot(0, main_window, &send_to_clipboard);
-    while (waiting)
-        ;
-
-    height_ = 0;
-    width_  = 0;
-    rgb_    = NULL;
 }
 
 #if !defined(Q_OS_WINDOWS) && !defined(Q_OS_MACOS)

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -528,9 +528,13 @@ take_screenshot_clipboard_monitor(int sx, int sy, int sw, int sh, int i)
         }
     }
 
+    /* screenshot_rgb is a persistent buffer that a later screenshot will
+       overwrite. QImage does not copy it and the clipboard only serialises
+       the image once another application asks to paste, so hand over a
+       deep copy to avoid publishing a torn or stale frame. */
     QImage image(screenshot_rgb, sw, sh, sw * 3, QImage::Format_RGB888);
     QClipboard *clipboard = QApplication::clipboard();
-    clipboard->setImage(image, QClipboard::Clipboard);
+    clipboard->setImage(image.copy(), QClipboard::Clipboard);
     monitors[i].mon_screenshots_raw_clipboard--;
 }
 

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -36,7 +36,6 @@
 #include <stdexcept>
 
 #include <QApplication>
-#include <QClipboard>
 
 #include <QScreen>
 #include <QMessageBox>
@@ -528,13 +527,8 @@ take_screenshot_clipboard_monitor(int sx, int sy, int sw, int sh, int i)
         }
     }
 
-    /* screenshot_rgb is a persistent buffer that a later screenshot will
-       overwrite. QImage does not copy it and the clipboard only serialises
-       the image once another application asks to paste, so hand over a
-       deep copy to avoid publishing a torn or stale frame. */
     QImage image(screenshot_rgb, sw, sh, sw * 3, QImage::Format_RGB888);
-    QClipboard *clipboard = QApplication::clipboard();
-    clipboard->setImage(image.copy(), QClipboard::Clipboard);
+    util::copyImageToClipboard(image);
     monitors[i].mon_screenshots_raw_clipboard--;
 }
 

--- a/src/qt/qt_softwarerenderer.cpp
+++ b/src/qt/qt_softwarerenderer.cpp
@@ -18,7 +18,6 @@
  */
 #include "qt_softwarerenderer.hpp"
 #include <QApplication>
-#include <QClipboard>
 #include <QPainter>
 #include <QResizeEvent>
 #include <QScreen>
@@ -160,8 +159,7 @@ SoftwareRenderer::onBlit(int buf_idx, int x, int y, int w, int h)
         else
             image = pixmap.toImage().scaled(qs * win_scale, Qt::IgnoreAspectRatio,
                                             Qt::SmoothTransformation);
-        QClipboard *clipboard = QApplication::clipboard();
-        clipboard->setImage(image, QClipboard::Clipboard);
+        util::copyImageToClipboard(image);
         monitors[r_monitor_index].mon_screenshots_clipboard--;
     }
     if (monitors[r_monitor_index].mon_screenshots_raw_clipboard) {

--- a/src/qt/qt_util.cpp
+++ b/src/qt/qt_util.cpp
@@ -18,6 +18,11 @@
 #include <QStringList>
 #include <QWidget>
 #include <QApplication>
+#include <QBuffer>
+#include <QClipboard>
+#include <QImage>
+#include <QImageWriter>
+#include <QMimeData>
 #if QT_VERSION <= QT_VERSION_CHECK(5, 14, 0)
 #    include <QDesktopWidget>
 #endif
@@ -197,6 +202,38 @@ hasConfiguredNICs()
         }
     }
     return false;
+}
+
+void
+copyImageToClipboard(const QImage &image)
+{
+    /* QImage does not take ownership of externally allocated pixels and the
+       clipboard only encodes the image once another application asks for it,
+       so hand over a copy the caller cannot invalidate. */
+    const QImage img = image.copy();
+
+    QByteArray png;
+    QBuffer    buf(&png);
+    buf.open(QIODevice::WriteOnly);
+    QImageWriter writer(&buf, "png");
+    writer.setCompression(100); /* Qt 6 maps 0-100 onto zlib levels 0-9 */
+    writer.setQuality(0);       /* Qt 5 uses quality as the compression lever */
+    writer.write(img);
+    buf.close();
+
+    /* Qt offers the clipboard image in every format the image plugins can
+       write, and encodes on demand. The first format offered is whichever
+       one was named first, and application/x-qt-image - which Qt's Wayland
+       backend serialises as an uncompressed BMP - otherwise leads the list.
+       Applications that take the first format on offer then receive a bitmap
+       several times the size of a PNG of the same screen. Naming image/png
+       before the image data puts it at the head of the list instead, while
+       still offering the image itself for the platforms and applications
+       that want it. */
+    auto *mime = new QMimeData;
+    mime->setData(QStringLiteral("image/png"), png);
+    mime->setImageData(img);
+    QApplication::clipboard()->setMimeData(mime, QClipboard::Clipboard);
 }
 
 }

--- a/src/qt/qt_util.hpp
+++ b/src/qt/qt_util.hpp
@@ -6,6 +6,7 @@
 
 #include <initializer_list>
 
+class QImage;
 class QScreen;
 namespace util {
 static constexpr auto UUID_MIN_LENGTH = 36;
@@ -14,6 +15,8 @@ QString DlgFilter(std::initializer_list<QString> extensions, bool last = false);
 QString DlgFilter(QStringList extensions, bool last = false);
 /* Returns screen the widget is on */
 QScreen *screenOfWidget(QWidget *widget);
+/* Puts an image on the clipboard, offering PNG ahead of the other formats */
+void     copyImageToClipboard(const QImage &image);
 #ifdef Q_OS_WINDOWS
 bool isWindowsLightTheme(void);
 void setWin11RoundedCorners(WId hwnd, bool enable);

--- a/src/qt/qt_vulkanwindowrenderer.cpp
+++ b/src/qt/qt_vulkanwindowrenderer.cpp
@@ -21,9 +21,9 @@
 #define VMA_DYNAMIC_VULKAN_FUNCTIONS 1
 #include "qt_vulkanwindowrenderer.hpp"
 #include "qt_vulkanshadermanagerdialog.hpp"
+#include "qt_util.hpp"
 
 #include <QApplication>
-#include <QClipboard>
 #include <QMessageBox>
 #include <QWindow>
 
@@ -1209,8 +1209,7 @@ VulkanWindowRenderer::render()
             }
 
             QImage image((uchar*)rgb, width, height, (scrShotImagePitch / 4) * 3, QImage::Format_RGB888);
-            QClipboard *clipboard = QApplication::clipboard();
-            clipboard->setImage(image.rgbSwapped(), QClipboard::Clipboard);
+            util::copyImageToClipboard(image.rgbSwapped());
             free(rgb);
             monitors[r_monitor_index].mon_screenshots_clipboard--;
         }


### PR DESCRIPTION
Summary
=======
There's a problem when copying screenshots (using the screenshot->clipboard buttons/menu items) on Wayland. Because of how Qt and Wayland interact, when something goes to consume the clipboard image, it ends up as a BMP instead of a PNG. I believe based on the 86Box behavior for saving screenshots to disk and behavior on Windows and X, that PNG is the intended format (and is sane, whereas BMP is... not!).

For example, on Wayland if I copy a screenshot from 86Box to Discord, or a file manager, or anywhere else really it ends up as a huge BMP file with a .png extension. The .png extension is a bug/oversight in Discord and Dolphin and won't be fixed here. That is just the extension they apply to clipboard images they don't have a hint as to a filename for.

It has to do with how Qt offers to provide the image data, the first item in the list of default formats is `application/x-qt-image` and the Wayland backend in Qt serializes that type for clipboard consumers as BMP. In their X backend it is PNG instead. That's the part that might be worth eventually sending a change to Qt for, since that's sort of nonsensical to have BMP as the primary choice for that. The option right after in the list of formats is of course the desired `image/png`, but consumers I tested don't seem to actually try to select a format they'd 'like', they just take the first format offered.

So, to fix it, we stick `image/png` at the top. See references below for KDE Spectacle (KDE's equivalent of the 'snipping tool') fixing this bug in the same way.

I tested it on my machine and didn't see any regressions, and the issue was resolved. I was able to paste much easier and it properly pasted PNG data. For reference, my machine is Arch, Wayland, KDE. Tested qt, gl, vk renderers since those are all different paths.

Also removes the unused `plat_send_to_clipboard`, which is unreachable code. I can undo that if you want, but it has a use_after_free bug in it so I feel like trimming it is the right choice.

Checklist
=========
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already

References
==========
[KDE Spectacle solving this same issue](https://invent.kde.org/plasma/spectacle/-/commit/83c9a81f3797140740ef9f31e2e6d4e1174115be)

The BMP default lives in Qt's Wayland backend, `QWaylandMimeHelper::getByteArray()`:
https://github.com/qt/qtwayland/blob/6.8/src/shared/qwaylandmimehelper.cpp

The format list is built by `QInternalMimeData::formatsHelper()`:
https://github.com/qt/qtbase/blob/6.8/src/gui/kernel/qinternalmimedata.cpp

[Wayland's wl_data_device protocol](https://gitlab.freedesktop.org/wayland/wayland)
describes the offer/receive model that makes the encoding lazy.