### PR TITLE
Git: Add stray VM config and patch-related files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,9 @@ CMakeLists.txt.user
 
 # Jetbrains CLion
 .idea
+
+# General debugging sessions
+86box.cfg
+*.patch
+*.*.orig
+*.*.rej


### PR DESCRIPTION
Summary
=======
Got hit by this in a debugging session - there is no valid 86box.cfg file in-tree, and patch-related files that are created during debugging should not end up in git as well.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
not applicable.
