### PR TITLE
Add PC Convertible-style soft power card

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -64,6 +64,7 @@
 #include <86box/bugger.h>
 #include <86box/postcard.h>
 #include <86box/unittester.h>
+#include <86box/softpower.h>
 #include <86box/novell_cardkey.h>
 #include <86box/isamem.h>
 #include <86box/isarom.h>
@@ -168,6 +169,7 @@ int      bugger_enabled                         = 0;              /* (C) enable 
 int      novell_keycard_enabled                 = 0;              /* (C) enable Novell NetWare 2.x key card emulation. */
 int      postcard_enabled                       = 0;              /* (C) enable POST card */
 int      unittester_enabled                     = 0;              /* (C) enable unit tester device */
+int      softpower_enabled                      = 0;              /* (C) enable PC Convertible-style soft power card */
 int      gameport_type[GAMEPORT_MAX]            = { 0, 0 };       /* (C) enable gameports */
 int      isamem_type[ISAMEM_MAX]                = { 0, 0, 0, 0 }; /* (C) enable ISA mem cards */
 int      isarom_type[ISAROM_MAX]                = { 0, 0, 0, 0 }; /* (C) enable ISA ROM cards */
@@ -1874,6 +1876,8 @@ pc_reset_hard_init(void)
         device_add(&postcard_device);
     if (unittester_enabled)
         device_add(&unittester_device);
+    if (softpower_enabled)
+        device_add(&softpower_device);
 
     if (novell_keycard_enabled)
         device_add(&novell_keycard_device);

--- a/src/config.c
+++ b/src/config.c
@@ -2497,6 +2497,7 @@ load_other_peripherals(void)
     postcard_enabled       = !!ini_section_get_int(cat, "postcard_enabled", 0);
     unittester_enabled     = !!ini_section_get_int(cat, "unittester_enabled", 0);
     novell_keycard_enabled = !!ini_section_get_int(cat, "novell_keycard_enabled", 0);
+    softpower_enabled      = !!ini_section_get_int(cat, "softpower_enabled", 0);
 
     if (!bugger_enabled)
         ini_section_delete_var(cat, "bugger_enabled");
@@ -2509,6 +2510,9 @@ load_other_peripherals(void)
 
     if (!novell_keycard_enabled)
         ini_section_delete_var(cat, "novell_keycard_enabled");
+
+    if (!softpower_enabled)
+        ini_section_delete_var(cat, "softpower_enabled");
 
     // ISA RAM Boards
     for (uint8_t c = 0; c < ISAMEM_MAX; c++) {
@@ -3950,6 +3954,11 @@ save_other_peripherals(void)
         ini_section_delete_var(cat, "novell_keycard_enabled");
     else
         ini_section_set_int(cat, "novell_keycard_enabled", novell_keycard_enabled);
+
+    if (softpower_enabled == 0)
+        ini_section_delete_var(cat, "softpower_enabled");
+    else
+        ini_section_set_int(cat, "softpower_enabled", softpower_enabled);
 
     // ISA RAM Boards
     for (uint8_t c = 0; c < ISAMEM_MAX; c++) {

--- a/src/device/CMakeLists.txt
+++ b/src/device/CMakeLists.txt
@@ -62,6 +62,7 @@ add_library(dev OBJECT
     postcard.c
     radisys_config.c
     serial.c
+    softpower.c
     smbus_ali7101.c
     smbus_piix4.c
     smbus_sis5595.c

--- a/src/device/softpower.c
+++ b/src/device/softpower.c
@@ -1,0 +1,202 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          PC Convertible-style soft power control card.
+ *
+ *          Implements the IBM PC Convertible (5140) power system control
+ *          register as an ISA card, so guest software on pre-APM machines
+ *          can request a power-off the same way it would on a PC Convertible
+ *          (whose BIOS does this on behalf of INT 15h AH=42h):
+ *
+ *            bit 1 (REQ_POFF): request system power off. Raises the system
+ *                suspend NMI if enabled, then removes power after a fixed
+ *                delay (~2 seconds on real hardware, during which the NMI
+ *                handler saves the system state).
+ *            bit 2 (EN_SUS_NMI): gate for the system suspend NMI.
+ *            bit 3 (HDWR_RESET): cause a power-on reset.
+ *            bit 6 (EXLPWR): status; always set, as emulated systems run
+ *                on external power.
+ *
+ *          Reference: IBM PC Convertible Technical Reference Vol. 1
+ *          (6280655), Figures 2-5/2-6 and "Power System Control (Hex 07F)";
+ *          Vol. 2 (55X8817), SYS_POWER_OFF and SUSPEND BIOS listings.
+ *
+ * Authors: Josh Rodd
+ *
+ *          Copyright 2026 Josh Rodd.
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <wchar.h>
+#define HAVE_STDARG_H
+#include <86box/86box.h>
+#include "cpu.h"
+#include <86box/io.h>
+#include <86box/device.h>
+#include <86box/plat.h>
+#include <86box/timer.h>
+#include <86box/softpower.h>
+
+#define SOFTPOWER_EN_PON_ALRM 0x01 /* Enable power on by RTC alarm. */
+#define SOFTPOWER_REQ_POFF    0x02 /* Request system power off. */
+#define SOFTPOWER_EN_SUS_NMI  0x04 /* Enable system suspend NMI. */
+#define SOFTPOWER_HDWR_RESET  0x08 /* Cause power-on-reset. */
+#define SOFTPOWER_EXLPWR      0x40 /* Status: external power supplied. */
+
+#define SOFTPOWER_CTRL_MASK   0x0f
+
+typedef struct softpower_t {
+    uint8_t   ctrl;
+    uint16_t  base;
+    int       nmi_enabled;
+    int       delay_ms;
+    pc_timer_t power_off_timer;
+} softpower_t;
+
+static void
+softpower_power_off(UNUSED(void *priv))
+{
+    plat_power_off();
+}
+
+static void
+softpower_write(uint16_t port, uint8_t val, void *priv)
+{
+    softpower_t *dev = (softpower_t *) priv;
+    const uint8_t old = dev->ctrl;
+
+    dev->ctrl = val & SOFTPOWER_CTRL_MASK;
+
+    if ((dev->ctrl & SOFTPOWER_HDWR_RESET) && !(old & SOFTPOWER_HDWR_RESET)) {
+        /* Cause a power-on reset. */
+        dev->ctrl = 0x00;
+        timer_disable(&dev->power_off_timer);
+        softresetx86();
+        return;
+    }
+
+    if ((dev->ctrl & SOFTPOWER_REQ_POFF) && !(old & SOFTPOWER_REQ_POFF)) {
+        if (dev->nmi_enabled && (dev->ctrl & SOFTPOWER_EN_SUS_NMI))
+            nmi_raise(); /* System suspend NMI. */
+
+        /* The power supply shuts the system down ~2 seconds after the
+           request, giving the NMI handler time to save system state. */
+        timer_set_delay_u64(&dev->power_off_timer,
+                            (uint64_t) dev->delay_ms * 1000ULL * TIMER_USEC);
+    }
+}
+
+static uint8_t
+softpower_read(uint16_t port, void *priv)
+{
+    const softpower_t *dev = (const softpower_t *) priv;
+
+    /* Bit 6 is always set: the emulated system is on external power. */
+    return SOFTPOWER_EXLPWR | dev->ctrl;
+}
+
+static void
+softpower_reset(void *priv)
+{
+    softpower_t *dev = (softpower_t *) priv;
+
+    dev->ctrl = 0x00;
+    timer_disable(&dev->power_off_timer);
+}
+
+static void *
+softpower_init(UNUSED(const device_t *info))
+{
+    softpower_t *dev = (softpower_t *) calloc(1, sizeof(softpower_t));
+
+    dev->base       = device_get_config_hex16("base");
+    dev->delay_ms   = device_get_config_int("delay");
+    dev->nmi_enabled = !!device_get_config_int("nmi");
+
+    timer_add(&dev->power_off_timer, softpower_power_off, dev, 0);
+    io_sethandler(dev->base, 1,
+                  softpower_read, NULL, NULL,
+                  softpower_write, NULL, NULL, dev);
+
+    return dev;
+}
+
+static void
+softpower_close(void *priv)
+{
+    softpower_t *dev = (softpower_t *) priv;
+
+    io_removehandler(dev->base, 1,
+                     softpower_read, NULL, NULL,
+                     softpower_write, NULL, NULL, dev);
+    timer_disable(&dev->power_off_timer);
+    free(dev);
+}
+
+static const device_config_t softpower_config[] = {
+  // clang-format off
+    {
+        .name           = "base",
+        .description    = "I/O base",
+        .type           = CONFIG_HEX16,
+        .default_string = NULL,
+        .default_int    = 0x7f,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .selection      = {
+            { .description = "7Fh (PC Convertible default)", .value = 0x007f },
+            { .description = "6Fh",                          .value = 0x006f },
+            { .description = "1EFh",                         .value = 0x01ef },
+            { .description = ""                                             }
+        },
+        .bios           = { { 0 } }
+    },
+    {
+        .name           = "delay",
+        .description    = "Power-off delay (ms)",
+        .type           = CONFIG_SPINNER,
+        .default_string = NULL,
+        .default_int    = 2000,
+        .file_filter    = NULL,
+        .spinner        = {
+            .min  =     0,
+            .max  = 60000,
+            .step =   100
+        },
+        .selection      = { { 0 } },
+        .bios           = { { 0 } }
+    },
+    {
+        .name           = "nmi",
+        .description    = "Raise system suspend NMI when enabled",
+        .type           = CONFIG_BINARY,
+        .default_string = NULL,
+        .default_int    = 0,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .selection      = { { 0 } },
+        .bios           = { { 0 } }
+    },
+    { .name = "", .description = "", .type = CONFIG_END }
+  // clang-format on
+};
+
+const device_t softpower_device = {
+    .name          = "PC Convertible Soft Power Card",
+    .internal_name = "softpower",
+    .flags         = DEVICE_ISA,
+    .local         = 0,
+    .init          = softpower_init,
+    .close         = softpower_close,
+    .reset         = softpower_reset,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = softpower_config
+};

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -199,6 +199,7 @@ extern int      bugger_enabled;             /* (C) enable ISAbugger */
 extern int      novell_keycard_enabled;     /* (C) enable Novell NetWare 2.x key card emulation. */
 extern int      postcard_enabled;           /* (C) enable POST card */
 extern int      unittester_enabled;         /* (C) enable unit tester device */
+extern int      softpower_enabled;            /* (C) enable PC Convertible-style soft power card */
 extern int      gameport_type[];            /* (C) enable gameports */
 extern int      isamem_type[];              /* (C) enable ISA mem cards */
 extern int      isarom_type[];              /* (C) enable ISA ROM cards */

--- a/src/include/86box/softpower.h
+++ b/src/include/86box/softpower.h
@@ -1,0 +1,31 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          PC Convertible-style soft power control card.
+ *
+ * Authors: Josh Rodd
+ *
+ *          Copyright 2026 Josh Rodd.
+ */
+#ifndef SOFTPOWER_H
+#define SOFTPOWER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Global variables. */
+extern const device_t softpower_device;
+
+/* Functions. */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*SOFTPOWER_H*/

--- a/src/qt/qt_settingsotherperipherals.cpp
+++ b/src/qt/qt_settingsotherperipherals.cpp
@@ -25,6 +25,7 @@ extern "C" {
 #include <86box/isarom.h>
 #include <86box/isartc.h>
 #include <86box/unittester.h>
+#include <86box/softpower.h>
 #include <86box/novell_cardkey.h>
 }
 
@@ -64,6 +65,7 @@ SettingsOtherPeripherals::SettingsOtherPeripherals(QWidget *parent)
     isartc_cfg_changed         = 0;
 
     unittester_cfg_changed     = 0;
+    softpower_cfg_changed      = 0;
     novell_keycard_cfg_changed = 0;
 
     onCurrentMachineChanged(machine);
@@ -96,11 +98,14 @@ SettingsOtherPeripherals::onCurrentMachineChanged(int machineId)
     ui->pushButtonConfigureUT->setEnabled(unittester_enabled > 0);
     ui->checkBoxKeyCard->setEnabled(machineHasIsa);
     ui->pushButtonConfigureKeyCard->setEnabled(novell_keycard_enabled > 0);
+    ui->checkBoxSoftPower->setEnabled(machineHasIsa);
+    ui->pushButtonConfigureSoftPower->setEnabled((machineHasIsa && (softpower_enabled > 0)));
 
     ui->checkBoxISABugger->setChecked((machineHasIsa && (bugger_enabled > 0)) ? true : false);
     ui->checkBoxPOSTCard->setChecked(postcard_enabled > 0 ? true : false);
     ui->checkBoxUnitTester->setChecked(unittester_enabled > 0 ? true : false);
     ui->checkBoxKeyCard->setChecked((machineHasIsa && (novell_keycard_enabled > 0)) ? true : false);
+    ui->checkBoxSoftPower->setChecked((machineHasIsa && (softpower_enabled > 0)) ? true : false);
 
     scRTC->removeRows();
     ui->comboBoxRTC->clear();
@@ -236,6 +241,8 @@ SettingsOtherPeripherals::changed()
     has_changed |= (postcard_enabled       != (ui->checkBoxPOSTCard->isChecked() ? 1 : 0));
     has_changed |= (unittester_enabled     != (ui->checkBoxUnitTester->isChecked() ? 1 : 0));
     has_changed |= unittester_cfg_changed;
+    has_changed |= (softpower_enabled       != (ui->checkBoxSoftPower->isChecked() ? 1 : 0));
+    has_changed |= softpower_cfg_changed;
     has_changed |= (novell_keycard_enabled != (ui->checkBoxKeyCard->isChecked() ? 1 : 0));
     has_changed |= novell_keycard_cfg_changed;
 
@@ -272,6 +279,7 @@ SettingsOtherPeripherals::save(int soft)
     bugger_enabled         = ui->checkBoxISABugger->isChecked() ? 1 : 0;
     postcard_enabled       = ui->checkBoxPOSTCard->isChecked() ? 1 : 0;
     unittester_enabled     = ui->checkBoxUnitTester->isChecked() ? 1 : 0;
+    softpower_enabled       = ui->checkBoxSoftPower->isChecked() ? 1 : 0;
     novell_keycard_enabled = ui->checkBoxKeyCard->isChecked() ? 1 : 0;
 
     /* ISA memory boards. */
@@ -432,6 +440,18 @@ void
 SettingsOtherPeripherals::on_pushButtonConfigureUT_clicked()
 {
     unittester_cfg_changed |= DeviceConfig::ConfigureDevice(&unittester_device);
+}
+
+void
+SettingsOtherPeripherals::on_checkBoxSoftPower_stateChanged(int arg1)
+{
+    ui->pushButtonConfigureSoftPower->setEnabled(arg1 != 0);
+}
+
+void
+SettingsOtherPeripherals::on_pushButtonConfigureSoftPower_clicked()
+{
+    softpower_cfg_changed |= DeviceConfig::ConfigureDevice(&softpower_device);
 }
 
 void

--- a/src/qt/qt_settingsotherperipherals.hpp
+++ b/src/qt/qt_settingsotherperipherals.hpp
@@ -50,6 +50,9 @@ private slots:
     void on_checkBoxKeyCard_stateChanged(int arg1);
     void on_pushButtonConfigureKeyCard_clicked();
 
+    void on_checkBoxSoftPower_stateChanged(int arg1);
+    void on_pushButtonConfigureSoftPower_clicked();
+
 private:
     Ui::SettingsOtherPeripherals *ui;
     int                           machineId { 0 };
@@ -59,6 +62,7 @@ private:
     int                           isartc_cfg_changed         = 0;
     int                           unittester_cfg_changed     = 0;
     int                           novell_keycard_cfg_changed = 0;
+    int                           softpower_cfg_changed      = 0;
 
     SettingsCompleter            *scRTC;
 

--- a/src/qt/qt_settingsotherperipherals.ui
+++ b/src/qt/qt_settingsotherperipherals.ui
@@ -166,6 +166,38 @@
            </layout>
           </item>
 
+          <item row="4">
+           <layout class="QHBoxLayout" name="horizontalLayoutSoftPower">
+            <item>
+             <widget class="QCheckBox" name="checkBoxSoftPower">
+              <property name="text">
+               <string>Soft power card (PC Convertible-style)</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacerSoftPower">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QPushButton" name="pushButtonConfigureSoftPower">
+              <property name="text">
+               <string>Configure</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+
          </layout>
         </widget>
        </item>
@@ -518,6 +550,8 @@
   <tabstop>pushButtonConfigureUT</tabstop>
   <tabstop>checkBoxKeyCard</tabstop>
   <tabstop>pushButtonConfigureKeyCard</tabstop>
+  <tabstop>checkBoxSoftPower</tabstop>
+  <tabstop>pushButtonConfigureSoftPower</tabstop>
   <tabstop>comboBoxIsaMemCard1</tabstop>
   <tabstop>pushButtonConfigureIsaMemCard1</tabstop>
   <tabstop>comboBoxIsaMemCard2</tabstop>


### PR DESCRIPTION
Allow software-controlled power off ("soft power") from inside a VM, implemented per the IBM PC Convertible's hardware standard.

Summary
=======
This is the beginnings of PC Convertible support, starting with implementing just the power control system register. It can added from the GUI to an ISA-capable machine type. This allows software-controlled power off without APM or ACPI.

It implements the power control register operations, although the only one that will be of interest when not using a PC Convertible BIOS is writing "2" to port 0x7F, which will immediately power off the system.

A power-off utility is at https://github.com/JoshRodd/86Box-utility-poweroff/ although you can just as well fire up `DEBUG; A; OUT 7F,2; G;` which will accomplish the same. The IBM PC Convertible utility to power off will not work without the PC Convertible BIOS.

The main impetus for creating this was to allow other tools which instrument/control 86Box to cause the VM to power itself off, which is highly helpful in automated testing scenarios; 86Box can be started with a defined floppy image, run a task which writes files to that floppy image, and then power itself off. The configuration, NVRAM, etc. will be saved properly and a system monitor can observe that the 86Box process has ended.

The chipset functions outside of power off are not thoroughly tested because the PC Convertible's BIOS is not working yet. In particular, the NMI "sleep" function, etc. is barely tested.

AI assistance was used for analysis, development, and testing, but not used with this PR.


Checklist
=========
* [X] Closes #xxx - N/A, no issue made per "don't make an issue just for your PR"
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already - yes, on discord
* [ ] This pull request requires changes to the ROM set - no; doesn't require PC Convertible ROM
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set - no
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency - no, the POWEROFF.COM utility is not required but is for convenience only.
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
IBM PC Convertible Technical Reference Vol. 1 (6280655), Figures 2-5/2-6 and "Power System Control (Hex 07F)"; Vol. 2 (55X8817), SYS_POWER_OFF and SUSPEND BIOS listings:

http://bitsavers.informatik.uni-stuttgart.de/pdf/ibm/pc/convertable/6280655_PC_Convertable_Technical_Reference_Volume_1_Feb86.pdf

http://bitsavers.informatik.uni-stuttgart.de/pdf/ibm/pc/convertable/55X8817_PC_Convertable_Technical_Reference_Volume_2_Feb86.pdf