### PR TITLE
XT-IDE: open a log handle in xtide_init

### DIFF
--- a/src/disk/hdc_xtide.c
+++ b/src/disk/hdc_xtide.c
@@ -176,6 +176,10 @@ xtide_init(const device_t *info)
 {
     xtide_t *xtide = calloc(1, sizeof(xtide_t));
 
+#ifdef ENABLE_XTIDE_LOG
+    xtide->log = log_open("XTIDE");
+#endif
+
     rom_init(&xtide->bios_rom,
              device_get_bios_file(info, device_get_config_bios("bios"), 0),
              device_get_config_hex20("bios_addr"), 0x2000, 0x1fff, 0, MEM_MAPPING_EXTERNAL);


### PR DESCRIPTION
With `ENABLE_XTIDE_LOG` defined, the plain XT-IDE card produces no logging at all — just a single `WARNING: Logging called with a NULL log pointer` — because `log_open()` is only ever called in `jride_init()`. `xtide_init()` leaves `xtide->log` as NULL while five `xtide_log()` call sites dereference it. `xtide_close()` already closes the handle if one is set, so only the open was missing.

Four lines, mirroring the existing `jride_init()` pattern. It compiles out entirely when `ENABLE_XTIDE_LOG` is undefined, which is the default, so there is no change for normal builds.

**Tested:** Windows, MSYS2/MinGW. With `ENABLE_XTIDE_LOG=1` and this fix, an XT-IDE-equipped machine booting Windows 95 produced several million access lines; the same build without the fix produced the NULL-pointer warning and nothing else. Compile-checked both with and without the macro defined.

**Not tested:** the jrIDE path is untouched and was not re-exercised. No runtime testing in the default configuration, where the diff does not compile in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgZtgTA8QZdfzv7ReJxWGL
