### PR TITLE
Add the AMD Am29F002NBT Flash

### DIFF
--- a/src/include/86box/flash.h
+++ b/src/include/86box/flash.h
@@ -70,5 +70,6 @@ extern const device_t sst_flash_49lf160_device;
 
 extern const device_t amd_flash_29f010a_device;
 extern const device_t amd_flash_29f020a_device;
+extern const device_t amd_flash_29f002nbt_device;
 
 #endif /*EMU_FLASH_H*/

--- a/src/mem/sst_flash.c
+++ b/src/mem/sst_flash.c
@@ -133,7 +133,8 @@ static char flash_path[1024];
 
 #define AMD         0x01 /* AMD Manufacturer's ID */
 #define AMD29F010A  0x2000
-#define AMD29F020A  0xb000
+#define AMD29F020A    0xb000
+#define AMD29F002NBT  0xb000
 
 #define SIZE_512K   0x010000
 #define SIZE_1M     0x020000
@@ -1043,3 +1044,17 @@ const device_t amd_flash_29f020a_device = {
     .force_redraw  = NULL,
     .config        = NULL
 };
+const device_t amd_flash_29f002nbt_device = {
+    .name          = "AMD Am29F002NBT Flash BIOS",
+    .internal_name = "amd_flash_29f002nbt",
+    .flags         = 0,
+    .local         = AMD | AMD29F002NBT | SIZE_2M,
+    .init          = sst_init,
+    .close         = sst_close,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = NULL
+};
+


### PR DESCRIPTION
Summary
=======
Adds the flash chip used in the IN530

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended

References
==========
https://www.alldatasheet.com/datasheet-pdf/pdf/82694/AMD/AM29F002NBT-120.html and the real machine
