### PR TITLE
Integrate floppy and parallel tape properly into the user interface

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2392,7 +2392,21 @@ go_to_mo:
             tape_drives[c].medium_type = 0;
 
         /* Default values, needed for proper operation of the Settings dialog. */
-        tape_drives[c].scsi_device_id = c + 4;
+        tape_drives[c].res = 0;
+
+        if (tape_drives[c].bus_type == TAPE_BUS_FDC) {
+            sprintf(temp, "tape_%02i_fdd_unit", c + 1);
+            tape_drives[c].fdd_unit = ini_section_get_int(cat, temp, 0);
+            if (tape_drives[c].fdd_unit >= FDD_NUM)
+                tape_drives[c].fdd_unit = 0;
+        } else if (tape_drives[c].bus_type == TAPE_BUS_LPT) {
+            sprintf(temp, "tape_%02i_lpt_port", c + 1);
+            tape_drives[c].lpt_port = ini_section_get_int(cat, temp, 0);
+            if (tape_drives[c].lpt_port >= PARALLEL_MAX)
+                tape_drives[c].lpt_port = 0;
+        } else {
+            tape_drives[c].scsi_device_id = c + 4;
+        }
 
         if (tape_drives[c].bus_type == TAPE_BUS_ATAPI) {
             sprintf(temp, "tape_%02i_ide_channel", c + 1);
@@ -2436,6 +2450,16 @@ go_to_mo:
 
         sprintf(temp, "tape_%02i_scsi_id", c + 1);
         ini_section_delete_var(cat, temp);
+
+        if (tape_drives[c].bus_type != TAPE_BUS_FDC) {
+            sprintf(temp, "tape_%02i_fdd_unit", c + 1);
+            ini_section_delete_var(cat, temp);
+        }
+
+        if (tape_drives[c].bus_type != TAPE_BUS_LPT) {
+            sprintf(temp, "tape_%02i_lpt_port", c + 1);
+            ini_section_delete_var(cat, temp);
+        }
 
         sprintf(temp, "tape_%02i_image_path", c + 1);
         p = ini_section_get_string(cat, temp, "");
@@ -4443,6 +4467,18 @@ save_other_removable_devices(void)
 
         sprintf(temp, "tape_%02i_scsi_id", c + 1);
         ini_section_delete_var(cat, temp);
+
+        sprintf(temp, "tape_%02i_fdd_unit", c + 1);
+        if (tape_drives[c].bus_type != TAPE_BUS_FDC)
+            ini_section_delete_var(cat, temp);
+        else
+            ini_section_set_int(cat, temp, tape_drives[c].fdd_unit);
+
+        sprintf(temp, "tape_%02i_lpt_port", c + 1);
+        if (tape_drives[c].bus_type != TAPE_BUS_LPT)
+            ini_section_delete_var(cat, temp);
+        else
+            ini_section_set_int(cat, temp, tape_drives[c].lpt_port);
 
         sprintf(temp, "tape_%02i_writeprot", c + 1);
         ini_section_delete_var(cat, temp);

--- a/src/config.c
+++ b/src/config.c
@@ -1460,24 +1460,11 @@ load_storage_controllers(void)
     if (p != NULL)
         cdrom_interface_current = cdrom_interface_get_from_internal_name(p);
 
-    fdd_tape_enabled = !!ini_section_get_int(cat, "floppy_tape_enabled", 0);
-
-    fdd_tape_unit = ini_section_get_int(cat, "floppy_tape_unit", 1);
-    if ((fdd_tape_unit < 0) || (fdd_tape_unit >= FDD_NUM))
-        fdd_tape_unit = 1;
-
-    memset(fdd_tape_fn, 0x00, sizeof(fdd_tape_fn));
-    p = ini_section_get_string(cat, "floppy_tape_file", "");
-    if ((p != NULL) && (p[0] != 0x00)) {
-        if (load_image_file(fdd_tape_fn, p, NULL))
-            fatal("Configuration: Length of floppy_tape_file is more than %i\n",
-                  MAX_IMAGE_PATH_LEN - 1);
-    }
-
-    if (!fdd_tape_enabled) {
-        ini_section_delete_var(cat, "floppy_tape_unit");
-        ini_section_delete_var(cat, "floppy_tape_file");
-    }
+    /* The floppy tape is configured from the Tape drives tab now; the old
+       keys are stale and get cleaned up. */
+    ini_section_delete_var(cat, "floppy_tape_enabled");
+    ini_section_delete_var(cat, "floppy_tape_unit");
+    ini_section_delete_var(cat, "floppy_tape_file");
 
     if (machine_has_bus(machine, MACHINE_BUS_CASSETTE))
         cassette_enable = !!ini_section_get_int(cat, "cassette_enabled", 0);
@@ -2793,10 +2780,6 @@ config_load(void)
         for (i = 0; i < ISAMEM_MAX; i++)
             isamem_type[i] = 0;
 
-        fdd_tape_enabled = 0;
-        fdd_tape_unit    = 1;
-        memset(fdd_tape_fn, 0x00, sizeof(fdd_tape_fn));
-
         cassette_enable = 1;
         memset(cassette_fname, 0x00, sizeof(cassette_fname));
         memcpy(cassette_mode, "load", strlen("load") + 1);
@@ -3855,19 +3838,10 @@ save_storage_controllers(void)
         ini_section_set_string(cat, "cdrom_interface",
                                cdrom_interface_get_internal_name(cdrom_interface_current));
 
-    if (fdd_tape_enabled == 0) {
-        ini_section_delete_var(cat, "floppy_tape_enabled");
-        ini_section_delete_var(cat, "floppy_tape_unit");
-        ini_section_delete_var(cat, "floppy_tape_file");
-    } else {
-        ini_section_set_int(cat, "floppy_tape_enabled", fdd_tape_enabled);
-        ini_section_set_int(cat, "floppy_tape_unit", fdd_tape_unit);
-
-        if (strlen(fdd_tape_fn) == 0)
-            ini_section_delete_var(cat, "floppy_tape_file");
-        else
-            save_image_file(cat, "floppy_tape_file", fdd_tape_fn);
-    }
+    /* The floppy tape is configured from the Tape drives tab now. */
+    ini_section_delete_var(cat, "floppy_tape_enabled");
+    ini_section_delete_var(cat, "floppy_tape_unit");
+    ini_section_delete_var(cat, "floppy_tape_file");
 
     if (cassette_enable == 0)
         ini_section_delete_var(cat, "cassette_enabled");

--- a/src/device/lpt_ditto.c
+++ b/src/device/lpt_ditto.c
@@ -35,12 +35,13 @@
 #include <86box/scsi_tape.h>
 #include <86box/fdd_tape.h>
 #include <86box/plat.h>
+#include <86box/ui.h>
 #include <86box/tape_qic117.h>
 
 /*
    Whether debug logging is enabled.
  */
-#if 0
+#if 1
 #define ENABLE_LPT_DITTO_LOG 1
 #endif
 
@@ -483,6 +484,7 @@ typedef struct ditto_t {
     int      epp_warned;    /* the EPP-vs-port mismatch has been reported */
     uint32_t last_port_ms;  /* when the host last touched the port */
     uint8_t  dat_out;       /* last byte we put on the data lines */
+    uint8_t  ui_write;      /* the drive's current command writes to the tape */
 
     /* Counted for the format-rate summary, not used by the emulation. */
 
@@ -867,6 +869,30 @@ static int      ditto_live_tape_idx = -1;
 
 static void ditto_image_sync(ditto_t *dev);
 static void ditto_image_load(ditto_t *dev, const char *fn);
+static void ditto_ui_activity(int active, int write);
+
+/* Keeps the owning drive's status-bar icon in step with the drive. */
+static void
+ditto_ui_update(void)
+{
+    if ((ditto_live == NULL) || (ditto_live_tape_idx < 0))
+        return;
+
+    ui_sb_update_icon_state(SB_TAPE | ditto_live_tape_idx, !ditto_live->image_loaded);
+    ui_sb_update_icon_wp(SB_TAPE | ditto_live_tape_idx, ditto_live->readonly);
+}
+
+/* Transient read/write activity on the owning drive's icon. */
+static void
+ditto_ui_activity(int active, int write)
+{
+    if (ditto_live_tape_idx < 0)
+        return;
+
+    ui_sb_update_icon(SB_TAPE | ditto_live_tape_idx, active);
+    if (write)
+        ui_sb_update_icon_write(SB_TAPE | ditto_live_tape_idx, active);
+}
 
 int
 ditto_model_from_tape_type(uint32_t type)
@@ -950,6 +976,8 @@ lpt_ditto_eject(void)
     if ((ditto_live_tape_idx >= 0) && (tape_drives[ditto_live_tape_idx].image_path[0] != 0x00))
         tape_drives[ditto_live_tape_idx].image_path[0] = 0x00;
 
+    ditto_ui_update();
+
     ditto_log("Ditto: cartridge ejected\n");
 }
 
@@ -987,6 +1015,8 @@ lpt_ditto_load(const char *path, int read_only)
 
     ditto_log("Ditto: loaded %s%s\n", path,
               dev->image_loaded ? (dev->readonly ? " (read-only)" : "") : " (failed)");
+
+    ditto_ui_update();
 }
 
 /* Every byte the image holds once the ECC sectors are counted in too. */
@@ -1160,6 +1190,8 @@ ditto_image_write(ditto_t *dev, uint32_t offset, const uint8_t *buf, uint32_t le
     if ((offset + len) > dev->image_size)
         dev->image_size = offset + len;
 
+    ditto_ui_activity(1, 1);
+
     return 1;
 }
 
@@ -1171,6 +1203,8 @@ ditto_image_sync(ditto_t *dev)
 
     fflush(dev->fp);
     dev->image_dirty = 0;
+
+    ditto_ui_activity(0, 1);
 }
 
 /*
@@ -1488,6 +1522,11 @@ qic_motion_tick(void *priv)
     }
 
     timer_advance_u64(&dev->motion_timer, qic_stream_period_us(dev) * TIMER_USEC);
+
+    /* The tape is streaming: keep the drive's activity light lit. The
+       status bar samples the flag periodically and clears it after
+       displaying, so it has to be re-asserted as the tape runs. */
+    ditto_ui_activity(1, dev->ui_write);
 
     if (dev->qic_segment < end) {
         dev->qic_segment++;
@@ -2249,6 +2288,8 @@ fdc_transfer(ditto_t *dev, uint8_t unit, int writing)
     int       sector;
     uint32_t  offset;
 
+    dev->ui_write = !!writing;
+
     if (writing && (dev->readonly || (dev->fp == NULL))) {
         fdc_data_result(dev, (uint8_t) (FDC_ST0_ABNORMAL | unit),
                         FDC_ST1_WRITE_PROTECT, 0x00);
@@ -2423,6 +2464,8 @@ fdc_format(ditto_t *dev, uint8_t unit)
     UNUSED(int wrote)   = 0;
     UNUSED(int skipped) = 0;
 
+    dev->ui_write = 1;
+
     if (dev->readonly || (dev->fp == NULL)) {
         fdc_data_result(dev, (uint8_t) (FDC_ST0_ABNORMAL | unit),
                         FDC_ST1_WRITE_PROTECT, 0x00);
@@ -2577,6 +2620,7 @@ fdc_execute(ditto_t *dev)
             if (steps < 0)
                 steps = -steps;
 
+            dev->ui_write = 0;
             ditto_qic_step(dev, steps);
 
             dev->fdc_pcn = dev->fdc_cmd[2];
@@ -3444,6 +3488,15 @@ ditto_read_status(void *priv)
     uint8_t  ret;
 
     ditto_note_idle(dev);
+
+    /*
+       The host polls the status lines non-stop while it waits for the
+       drive - which is exactly while the drive is busy. The status bar
+       only samples the activity flag periodically and clears it after
+       displaying, so re-assert it on every poll.
+     */
+    if ((dev->fdc_phase == FDC_PHASE_EXEC) || dev->qic_busy || dev->qic_running)
+        ditto_ui_activity(1, dev->ui_write);
 
     if (dev->connected && dev->ident)
         ret = ditto_ident_response(dev);

--- a/src/device/lpt_ditto.c
+++ b/src/device/lpt_ditto.c
@@ -30,6 +30,9 @@
 #include <86box/device.h>
 #include <86box/timer.h>
 #include <86box/lpt.h>
+#include <86box/lpt_ditto.h>
+#include <86box/scsi_device.h>
+#include <86box/scsi_tape.h>
 #include <86box/fdd_tape.h>
 #include <86box/plat.h>
 #include <86box/tape_qic117.h>
@@ -847,6 +850,143 @@ ditto_cartridge(int value)
             return &ditto_cartridges[i];
 
     return &ditto_cartridges[0];
+}
+
+/* --------------------------------------------------------------------- */
+/* Tape drives tab mappings (shared with the settings UI)                */
+/* --------------------------------------------------------------------- */
+
+/* The tape_drive_types[] indices the three Ditto models live at; the
+   DITTO_MODEL_LIST order matches their order there. */
+#define DITTO_TAPE_TYPE_BASE 5
+
+/* The single live drive, and the tape_drives[] entry driving it (-1 when
+   configured from the legacy per-device section, or when not attached). */
+static ditto_t *ditto_live          = NULL;
+static int      ditto_live_tape_idx = -1;
+
+static void ditto_image_sync(ditto_t *dev);
+static void ditto_image_load(ditto_t *dev, const char *fn);
+
+int
+ditto_model_from_tape_type(uint32_t type)
+{
+    if ((type >= DITTO_TAPE_TYPE_BASE) &&
+        (type < (DITTO_TAPE_TYPE_BASE + (int) DITTO_MODELS)))
+        return (int) (type - DITTO_TAPE_TYPE_BASE);
+
+    return -1;
+}
+
+int
+ditto_tape_type_from_model(int model)
+{
+    if ((model >= 0) && (model < (int) DITTO_MODELS))
+        return (DITTO_TAPE_TYPE_BASE + model);
+
+    return -1;
+}
+
+/* Cartridges and tape_types[] media share their names, so the mapping
+   goes by name and survives table reordering on either side. */
+int
+ditto_cartridge_from_medium(uint32_t medium)
+{
+    if (medium >= KNOWN_TAPE_TYPES)
+        return -1;
+
+    for (size_t i = 0; i < DITTO_CARTRIDGES; i++)
+        if (!strcmp(ditto_cartridges[i].name, tape_types[medium].name))
+            return ditto_cartridges[i].value;
+
+    return -1;
+}
+
+int
+ditto_tape_medium_from_cartridge(int value)
+{
+    for (size_t i = 0; i < DITTO_CARTRIDGES; i++) {
+        if (ditto_cartridges[i].value == value) {
+            for (uint32_t m = 0; m < KNOWN_TAPE_TYPES; m++)
+                if (!strcmp(ditto_cartridges[i].name, tape_types[m].name))
+                    return (int) m;
+            break;
+        }
+    }
+
+    return -1;
+}
+
+/* The tape_drives[] entry configuring the given parallel port, if any. */
+static int
+ditto_find_tape_entry(int port)
+{
+    for (uint8_t c = 0; c < TAPE_NUM; c++) {
+        if ((tape_drives[c].bus_type == TAPE_BUS_LPT) &&
+            (tape_drives[c].lpt_port == port))
+            return (int) c;
+    }
+
+    return -1;
+}
+
+/* --------------------------------------------------------------------- */
+/* Runtime cartridge swap (used by the media menu in the UI)             */
+/* --------------------------------------------------------------------- */
+
+void
+lpt_ditto_eject(void)
+{
+    ditto_t *dev = ditto_live;
+
+    if (dev == NULL)
+        return;
+
+    ditto_image_sync(dev);
+    ditto_image_close(dev);
+
+    dev->qic_status &= ~QIC_STATUS_CARTRIDGE_PRESENT;
+
+    if ((ditto_live_tape_idx >= 0) && (tape_drives[ditto_live_tape_idx].image_path[0] != 0x00))
+        tape_drives[ditto_live_tape_idx].image_path[0] = 0x00;
+
+    ditto_log("Ditto: cartridge ejected\n");
+}
+
+void
+lpt_ditto_load(const char *path, int read_only)
+{
+    ditto_t *dev = ditto_live;
+
+    if ((dev == NULL) || (path == NULL))
+        return;
+
+    /* A wp:// prefix on the path means the same as the flag. */
+    if (strstr(path, "wp://") == path) {
+        path += 5;
+        read_only = 1;
+    }
+
+    dev->readonly = !!read_only;
+    ditto_image_load(dev, path);
+
+    if (dev->image_loaded) {
+        dev->qic_status |= QIC_STATUS_CARTRIDGE_PRESENT;
+        if (dev->readonly)
+            dev->qic_status |= QIC_STATUS_WRITE_PROTECT;
+        else
+            dev->qic_status &= ~QIC_STATUS_WRITE_PROTECT;
+    } else
+        dev->qic_status &= ~QIC_STATUS_CARTRIDGE_PRESENT;
+
+    if (ditto_live_tape_idx >= 0) {
+        strncpy(tape_drives[ditto_live_tape_idx].image_path, path, MAX_IMAGE_PATH_LEN - 1);
+        tape_drives[ditto_live_tape_idx].image_path[MAX_IMAGE_PATH_LEN - 1] = 0x00;
+        tape_drives[ditto_live_tape_idx].read_only = dev->readonly;
+    }
+
+    ditto_log("Ditto: loaded %s%s\n", path,
+              dev->image_loaded ? (dev->readonly ? " (read-only)" : "") : " (failed)");
 }
 
 /* Every byte the image holds once the ECC sectors are counted in too. */
@@ -2982,7 +3122,7 @@ ditto_connect(ditto_t *dev)
     if ((dev->proto >= DITTO_PROTO_EPP8) && !dev->epp_warned) {
         dev->epp_warned = 1;
         ditto_log("Ditto: EPP selected; the port %s carry EPP cycles\n",
-                  lpt_port_offers_epp(dev->lpt) ? "does" : "DOES NOT");
+                  ((lpt_t *) dev->lpt)->epp ? "does" : "DOES NOT");
     }
 }
 
@@ -3344,28 +3484,53 @@ ditto_init(UNUSED(const device_t *info))
     dev->unit     = 0;
     dev->max_proto = DITTO_PROTO_EPP8;
 
-    dev->readonly = device_get_config_int("writeprot");
+    /*
+       A tape_drives[] entry on the LPT bus (the Tape drives tab) takes
+       priority; the legacy per-device configuration section is honored
+       only in its absence, so old configs keep booting.
+     */
+    const int port     = device_get_instance() - 1;
+    const int tape_idx = ditto_find_tape_entry(port);
+
+    int         tape_model = -1;
+    int         tape_cart  = -1;
+    int         tape_ro    = -1;
+    const char *tape_fn    = NULL;
+
+    if (tape_idx >= 0) {
+        tape_model = ditto_model_from_tape_type(tape_drives[tape_idx].type);
+        tape_cart  = ditto_cartridge_from_medium(tape_drives[tape_idx].medium_type);
+        tape_ro    = tape_drives[tape_idx].read_only;
+        tape_fn    = tape_drives[tape_idx].image_path;
+    }
+
+    dev->readonly = (tape_ro >= 0) ? !!tape_ro : device_get_config_int("writeprot");
 
     /*
-       The drive's own identity, which the cartridge does not change. Set
-       before the geometry, which fills in the parts the cartridge does
-       decide - the extra length bit and the rate the drive comes up at.
+        The drive's own identity, which the cartridge does not change. Set
+        before the geometry, which fills in the parts the cartridge does
+        decide - the extra length bit and the rate the drive comes up at.
      */
-    model = ditto_model(device_get_config_int("model"));
+    model = ditto_model((tape_model >= 0) ? tape_model : device_get_config_int("model"));
 
     dev->qic_vendor_id   = model->vendor_id;
     dev->qic_rom_version = model->rom_version;
     dev->qic_config      = QIC_CONFIG_80;
 
-    dev->capacity = ditto_cartridge(device_get_config_int("capacity"))->value;
+    dev->capacity = ditto_cartridge((tape_cart >= 0) ? tape_cart : device_get_config_int("capacity"))->value;
 
     /* The geometry has to be settled before an image is measured
        against it. */
     ditto_set_geometry(dev);
 
-    fn = device_get_config_string("image");
-    if (fn != NULL)
-        strncpy(dev->image_fn, fn, sizeof(dev->image_fn) - 1);
+    if (tape_idx >= 0) {
+        if (tape_fn != NULL)
+            strncpy(dev->image_fn, tape_fn, sizeof(dev->image_fn) - 1);
+    } else {
+        fn = device_get_config_string("image");
+        if (fn != NULL)
+            strncpy(dev->image_fn, fn, sizeof(dev->image_fn) - 1);
+    }
 
     dev->buffer = calloc(1, DITTO_BUFFER_SIZE);
     if (dev->buffer == NULL) {
@@ -3406,11 +3571,15 @@ ditto_init(UNUSED(const device_t *info))
                           ditto_read_status, NULL,
                           ditto_epp_write_data, ditto_epp_request_read, dev);
     if (dev->lpt == NULL) {
-        /* Another device already has this port. */
+        /* Another device already has this port, or the port is absent. */
+        ditto_log("Ditto: port %i unavailable or already claimed, not attaching\n", port);
         free(dev->buffer);
         free(dev);
         return NULL;
     }
+
+    ditto_live          = dev;
+    ditto_live_tape_idx = tape_idx;
 
     ditto_log("Ditto: attached as %s (vendor ID %04X, ROM %02X), protocol "
               "ceiling %s, image \"%s\"%s\n",
@@ -3425,6 +3594,11 @@ static void
 ditto_close(void *priv)
 {
     ditto_t *dev = (ditto_t *) priv;
+
+    if (ditto_live == dev) {
+        ditto_live          = NULL;
+        ditto_live_tape_idx = -1;
+    }
 
     timer_disable(&dev->busy_timer);
     ditto_image_close(dev);

--- a/src/disk/hdd.c
+++ b/src/disk/hdd.c
@@ -26,6 +26,8 @@
 #include <86box/ui.h>
 #include <86box/hdd.h>
 #include <86box/cdrom.h>
+#include <86box/scsi_device.h>
+#include <86box/scsi_tape.h>
 #include <86box/video.h>
 #include <86box/hdd_audio.h>
 #include "cpu.h"
@@ -65,12 +67,19 @@ hdd_string_to_bus(char *str, int cdrom)
 
     if (!strcmp(str, "scsi"))
         return HDD_BUS_SCSI;
-    
+
     if (!strcmp(str, "mitsumi") && cdrom)
         return CDROM_BUS_MITSUMI;
 
     if (!strcmp(str, "mke") && cdrom)
         return CDROM_BUS_MKE;
+
+    /* Removable-mode only: the QIC-117 tape buses. */
+    if (!strcmp(str, "lpt") && cdrom)
+        return TAPE_BUS_LPT;
+
+    if (!strcmp(str, "fdc") && cdrom)
+        return TAPE_BUS_FDC;
 
     return HDD_BUS_DISABLED;
 }
@@ -119,6 +128,17 @@ hdd_bus_to_string(int bus, int cdrom)
         case CDROM_BUS_MKE:
             if (cdrom)
                 s = "mke";
+            break;
+
+        /* Removable-mode only: the QIC-117 tape buses. */
+        case TAPE_BUS_LPT:
+            if (cdrom)
+                s = "lpt";
+            break;
+
+        case TAPE_BUS_FDC:
+            if (cdrom)
+                s = "fdc";
             break;
     }
 

--- a/src/floppy/fdd_tape.c
+++ b/src/floppy/fdd_tape.c
@@ -281,12 +281,8 @@ static int        tape_busy_timer_added = 0;
  */
 #define TAPE_SCAN_SPEEDUP    32
 
-int  fdd_tape_enabled = 0;
-int  fdd_tape_unit    = 1;
-char fdd_tape_fn[MAX_IMAGE_PATH_LEN];
-
-/* The tape_drives[] entry this drive is configured from, or -1 while the
-   legacy globals above remain the source of truth (transition period). */
+/* The tape_drives[] entry this drive is configured from, or -1 when the
+   drive is not configured at all. */
 static int tape_entry = -1;
 
 #ifdef ENABLE_FDD_TAPE_LOG
@@ -371,6 +367,7 @@ static void tape_start_clock(void);
 static void tape_stop_clock(void);
 static void tape_start_motion(void);
 static void tape_stop_motion_clock(void);
+static void fdd_tape_ui_activity(int active, int write);
 
 /* The segment currently under the head. */
 static int
@@ -1508,6 +1505,9 @@ tape_stop_clock(void)
 {
     if (tape_timer_added)
         timer_disable(&tape_timer);
+
+    /* The transfer clock stopping means the drive has gone idle. */
+    fdd_tape_ui_activity(0, 0);
 }
 
 static void
@@ -1534,6 +1534,9 @@ tape_motion_tick(UNUSED(void *priv))
         tape_stop_motion_clock();
         return;
     }
+
+    /* The tape is moving: keep the drive's activity light lit. */
+    fdd_tape_ui_activity(1, tape.xfer_state == TAPE_XFER_WRITE);
 
     /*
        A physical wind runs the head toward the end it was sent to and comes
@@ -1626,6 +1629,8 @@ tape_setup_transfer(int state, int sector, int track, int side, int sector_size)
         tape_image_read(offset, tape.buffer, FDD_TAPE_SECTOR_SIZE);
     else
         memset(tape.buffer, 0x00, FDD_TAPE_SECTOR_SIZE);
+
+    fdd_tape_ui_activity(1, state == TAPE_XFER_WRITE);
 
     /* The segment under the head advances as sectors stream past. */
     tape_head_to_offset(offset);
@@ -1756,6 +1761,8 @@ tape_format(int drive, UNUSED(int side), UNUSED(int density), UNUSED(uint8_t fil
     tape.format_datac = 0;
     tape.format_count = 0;
 
+    fdd_tape_ui_activity(1, 1);
+
     tape_start_clock();
 }
 
@@ -1795,6 +1802,14 @@ tape_clock(UNUSED(void *priv))
         tape_stop_clock();
         return;
     }
+
+    /*
+       The transfer is in progress: keep the drive's activity light lit.
+       The status bar only samples the flag periodically and clears it
+       after displaying, so it has to be re-asserted as the transfer runs.
+     */
+    fdd_tape_ui_activity(1, (tape.xfer_state == TAPE_XFER_WRITE) ||
+                                (tape.xfer_state == TAPE_XFER_FORMAT));
 
     switch (tape.xfer_state) {
         case TAPE_XFER_READID:
@@ -2053,6 +2068,29 @@ tape_read_geometry(void)
                  "%i segments/head\n", tape.segs_per_cyl, tape.segs_per_head);
 }
 
+/* Keeps the owning drive's status-bar icon in step with the drive. */
+static void
+fdd_tape_ui_update(void)
+{
+    if (tape_entry < 0)
+        return;
+
+    ui_sb_update_icon_state(SB_TAPE | tape_entry, !tape_has_cartridge());
+    ui_sb_update_icon_wp(SB_TAPE | tape_entry, tape.readonly);
+}
+
+/* Transient read/write activity on the owning drive's icon. */
+static void
+fdd_tape_ui_activity(int active, int write)
+{
+    if (tape_entry < 0)
+        return;
+
+    ui_sb_update_icon(SB_TAPE | tape_entry, active);
+    if (write)
+        ui_sb_update_icon_write(SB_TAPE | tape_entry, active);
+}
+
 /* Releases the cartridge image without touching the owning tape_drives[]
    entry - the internal half of an eject. */
 static void
@@ -2079,6 +2117,8 @@ fdd_tape_eject(void)
     /* A runtime eject leaves the owning entry empty as well. */
     if ((tape_entry >= 0) && (tape_drives[tape_entry].image_path[0] != 0x00))
         tape_drives[tape_entry].image_path[0] = 0x00;
+
+    fdd_tape_ui_update();
 }
 
 void
@@ -2157,11 +2197,12 @@ fdd_tape_load(const char *fn)
 
     fdd_tape_log("Tape: loaded %s (%u bytes%s)\n", fn, tape.image_size,
                  tape.readonly ? ", read-only" : "");
+
+    fdd_tape_ui_update();
 }
 
-/* Queries whether a drive select line belongs to a tape drive, either
-   through a tape_drives[] entry or the legacy configuration. A floppy may
-   not be (re)loaded onto such a line. */
+/* Queries whether a drive select line belongs to a tape drive. A floppy
+   may not be (re)loaded onto such a line. */
 static int
 fdd_tape_line_owned(int drive)
 {
@@ -2174,38 +2215,31 @@ fdd_tape_line_owned(int drive)
             return 1;
     }
 
-    return (fdd_tape_enabled && (fdd_tape_unit == drive));
+    return 0;
 }
 
 void
 fdd_tape_init(void)
 {
     int drive;
-    int enabled;
 
     fdd_tape_close();
 
     /*
-       Resolve the configuration. A tape_drives[] entry on the FDC bus
-       takes priority; the legacy globals are honored only in its absence
-       (the fallback goes away once the old UI does).
+       Resolve the configuration from the tape_drives[] entry on the FDC
+       bus (the Tape drives tab).
      */
     tape_entry = -1;
-    enabled    = 0;
     for (uint8_t c = 0; c < TAPE_NUM; c++) {
         if (tape_drives[c].bus_type == TAPE_BUS_FDC) {
             tape_entry = c;
-            enabled    = 1;
             break;
         }
     }
     if (tape_entry < 0)
-        enabled = fdd_tape_enabled;
-
-    if (!enabled)
         return;
 
-    drive = (tape_entry >= 0) ? tape_drives[tape_entry].fdd_unit : fdd_tape_unit;
+    drive = tape_drives[tape_entry].fdd_unit;
     if ((drive < 0) || (drive >= FDD_NUM))
         drive = 1;
 
@@ -2255,17 +2289,14 @@ fdd_tape_init(void)
     drive_empty[drive] = 0;
     fdd_changed[drive] = 0;
 
-    if (tape_entry >= 0) {
-        char fn[MAX_IMAGE_PATH_LEN + 8];
+    char fn[MAX_IMAGE_PATH_LEN + 8];
 
-        if (tape_drives[tape_entry].read_only)
-            snprintf(fn, sizeof(fn), "wp://%s", tape_drives[tape_entry].image_path);
-        else
-            snprintf(fn, sizeof(fn), "%s", tape_drives[tape_entry].image_path);
+    if (tape_drives[tape_entry].read_only)
+        snprintf(fn, sizeof(fn), "wp://%s", tape_drives[tape_entry].image_path);
+    else
+        snprintf(fn, sizeof(fn), "%s", tape_drives[tape_entry].image_path);
 
-        fdd_tape_load(fn);
-    } else
-        fdd_tape_load(fdd_tape_fn);
+    fdd_tape_load(fn);
 
     /*
        A cartridge that was already in the drive when the power came on is

--- a/src/floppy/fdd_tape.c
+++ b/src/floppy/fdd_tape.c
@@ -48,6 +48,8 @@
 #include <86box/fdd.h>
 #include <86box/fdd_tape.h>
 #include <86box/fdc.h>
+#include <86box/scsi_device.h>
+#include <86box/scsi_tape.h>
 #include <86box/tape_qic117.h>
 
 /*
@@ -120,7 +122,7 @@ enum {
     TAPE_XFER_READID
 };
 
-typedef struct tape_t {
+typedef struct fdd_tape_state_t {
     int      attached;      /* drive is fitted to the cable */
     int      drive;         /* drive select line it answers to */
 
@@ -191,9 +193,9 @@ typedef struct tape_t {
     int      format_datac;
     int      format_count;
     uint32_t format_offset;
-} tape_t;
+} fdd_tape_state_t;
 
-static tape_t  tape;
+static fdd_tape_state_t  tape;
 static fdc_t  *tape_fdc = NULL;
 
 /*
@@ -201,7 +203,7 @@ static fdc_t  *tape_fdc = NULL;
    attention to the controller's motor line, so the transfer clock is ours
    rather than the floppy drive poll.
 
-   This lives outside tape_t deliberately: detaching the drive wipes the
+   This lives outside fdd_tape_state_t deliberately: detaching the drive wipes the
    rest of the state, and a registered timer must never be memset while it
    might still be linked into the timer list.
  */
@@ -212,7 +214,7 @@ static int        tape_timer_added = 0;
    QIC-117 delimits commands by time, not by seek boundaries: a pulse train
    ends when no further STEP pulse arrives for TTIMEOUT, and only then does
    the drive act on the count. This timer measures that gap. It lives
-   outside tape_t for the same reason as the transfer clock above.
+   outside fdd_tape_state_t for the same reason as the transfer clock above.
  */
 static pc_timer_t tape_cmd_timer;
 static int        tape_cmd_timer_added = 0;
@@ -237,7 +239,7 @@ static int        tape_motion_timer_added = 0;
    the instant it is asked can wedge a host whose completion check waits to
    first see the drive go busy: it never does, so the check keeps retrying
    and eventually gives up. This one-shot timer models the wind and drops the
-   busy state when it fires. It lives outside tape_t for the same reason as
+   busy state when it fires. It lives outside fdd_tape_state_t for the same reason as
    the timers above.
  */
 static pc_timer_t tape_busy_timer;
@@ -282,6 +284,10 @@ static int        tape_busy_timer_added = 0;
 int  fdd_tape_enabled = 0;
 int  fdd_tape_unit    = 1;
 char fdd_tape_fn[MAX_IMAGE_PATH_LEN];
+
+/* The tape_drives[] entry this drive is configured from, or -1 while the
+   legacy globals above remain the source of truth (transition period). */
+static int tape_entry = -1;
 
 #ifdef ENABLE_FDD_TAPE_LOG
 int fdd_tape_do_log = ENABLE_FDD_TAPE_LOG;
@@ -2047,8 +2053,10 @@ tape_read_geometry(void)
                  "%i segments/head\n", tape.segs_per_cyl, tape.segs_per_head);
 }
 
-void
-fdd_tape_eject(void)
+/* Releases the cartridge image without touching the owning tape_drives[]
+   entry - the internal half of an eject. */
+static void
+tape_image_release(void)
 {
     if (tape.fp != NULL) {
         fclose(tape.fp);
@@ -2064,11 +2072,21 @@ fdd_tape_eject(void)
 }
 
 void
+fdd_tape_eject(void)
+{
+    tape_image_release();
+
+    /* A runtime eject leaves the owning entry empty as well. */
+    if ((tape_entry >= 0) && (tape_drives[tape_entry].image_path[0] != 0x00))
+        tape_drives[tape_entry].image_path[0] = 0x00;
+}
+
+void
 fdd_tape_load(const char *fn)
 {
     FILE *fp;
 
-    fdd_tape_eject();
+    tape_image_release();
 
     if ((fn == NULL) || (fn[0] == 0x00))
         return;
@@ -2130,21 +2148,64 @@ fdd_tape_load(const char *fn)
     if (tape.attached)
         writeprot[tape.drive] = tape.readonly;
 
+    /* Keep the owning entry in step with what is actually in the drive. */
+    if (tape_entry >= 0) {
+        strncpy(tape_drives[tape_entry].image_path, fn, MAX_IMAGE_PATH_LEN - 1);
+        tape_drives[tape_entry].image_path[MAX_IMAGE_PATH_LEN - 1] = 0x00;
+        tape_drives[tape_entry].read_only = tape.readonly;
+    }
+
     fdd_tape_log("Tape: loaded %s (%u bytes%s)\n", fn, tape.image_size,
                  tape.readonly ? ", read-only" : "");
+}
+
+/* Queries whether a drive select line belongs to a tape drive, either
+   through a tape_drives[] entry or the legacy configuration. A floppy may
+   not be (re)loaded onto such a line. */
+static int
+fdd_tape_line_owned(int drive)
+{
+    if ((drive < 0) || (drive >= FDD_NUM))
+        return 0;
+
+    for (uint8_t c = 0; c < TAPE_NUM; c++) {
+        if ((tape_drives[c].bus_type == TAPE_BUS_FDC) &&
+            (tape_drives[c].fdd_unit == drive))
+            return 1;
+    }
+
+    return (fdd_tape_enabled && (fdd_tape_unit == drive));
 }
 
 void
 fdd_tape_init(void)
 {
     int drive;
+    int enabled;
 
     fdd_tape_close();
 
-    if (!fdd_tape_enabled)
+    /*
+       Resolve the configuration. A tape_drives[] entry on the FDC bus
+       takes priority; the legacy globals are honored only in its absence
+       (the fallback goes away once the old UI does).
+     */
+    tape_entry = -1;
+    enabled    = 0;
+    for (uint8_t c = 0; c < TAPE_NUM; c++) {
+        if (tape_drives[c].bus_type == TAPE_BUS_FDC) {
+            tape_entry = c;
+            enabled    = 1;
+            break;
+        }
+    }
+    if (tape_entry < 0)
+        enabled = fdd_tape_enabled;
+
+    if (!enabled)
         return;
 
-    drive = fdd_tape_unit;
+    drive = (tape_entry >= 0) ? tape_drives[tape_entry].fdd_unit : fdd_tape_unit;
     if ((drive < 0) || (drive >= FDD_NUM))
         drive = 1;
 
@@ -2194,7 +2255,17 @@ fdd_tape_init(void)
     drive_empty[drive] = 0;
     fdd_changed[drive] = 0;
 
-    fdd_tape_load(fdd_tape_fn);
+    if (tape_entry >= 0) {
+        char fn[MAX_IMAGE_PATH_LEN + 8];
+
+        if (tape_drives[tape_entry].read_only)
+            snprintf(fn, sizeof(fn), "wp://%s", tape_drives[tape_entry].image_path);
+        else
+            snprintf(fn, sizeof(fn), "%s", tape_drives[tape_entry].image_path);
+
+        fdd_tape_load(fn);
+    } else
+        fdd_tape_load(fdd_tape_fn);
 
     /*
        A cartridge that was already in the drive when the power came on is
@@ -2215,10 +2286,12 @@ fdd_tape_close(void)
     const int drive        = tape.drive;
     const int was_attached = tape.attached;
 
-    fdd_tape_eject();
+    /* Not fdd_tape_eject(): a close (e.g. on the re-attach path) must not
+       clear the owning entry's image, only a runtime eject does that. */
+    tape_image_release();
 
     /*
-       The timer is left alone on purpose. It lives outside tape_t, so the
+       The timer is left alone on purpose. It lives outside fdd_tape_state_t, so the
        wipe below cannot corrupt it, and it may legitimately still be in
        the timer list here or have been orphaned by a hard reset - calling
        timer_disable() in the latter case would trip the timer layer's own
@@ -2243,6 +2316,8 @@ fdd_tape_close(void)
     memset(&tape, 0x00, sizeof(tape));
     tape.report_pos = TAPE_REPORT_IDLE;
 
-    if (was_attached)
+    /* A line owned by a tape drive must not have a floppy resurrected
+       onto it - the tape (re)attaches right after this on the reset path. */
+    if (was_attached && !fdd_tape_line_owned(drive))
         fdd_load(drive, floppyfns[drive]);
 }

--- a/src/include/86box/fdd_tape.h
+++ b/src/include/86box/fdd_tape.h
@@ -25,7 +25,7 @@
 #define EMU_FDD_TAPE_H
 
 /* For logging detailed QIC-117 debugging into the emulator log. */
-#if 0
+#if 1
 #    define ENABLE_FDD_TAPE_LOG 1
 #endif
 
@@ -61,11 +61,8 @@
 extern "C" {
 #endif
 
-extern int  fdd_tape_enabled;                   /* drive fitted to the cable */
-extern int  fdd_tape_unit;                      /* drive select line, 0..3 */
-extern char fdd_tape_fn[MAX_IMAGE_PATH_LEN];    /* cartridge image */
-
-/* Attaches or detaches the drive according to the configuration above. */
+/* Attaches or detaches the drive according to its tape_drives[] entry
+   (TAPE_BUS_FDC). */
 extern void fdd_tape_init(void);
 extern void fdd_tape_close(void);
 

--- a/src/include/86box/lpt_ditto.h
+++ b/src/include/86box/lpt_ditto.h
@@ -1,0 +1,40 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          Definitions shared between the Iomega Ditto parallel-port
+ *          tape drive and the Tape drives settings tab / media menu.
+ */
+#ifndef EMU_LPT_DITTO_H
+#define EMU_LPT_DITTO_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* tape_drive_types[] index (Ditto models) <-> Ditto drive-model config
+   value. Both return -1 when there is no mapping. */
+extern int ditto_model_from_tape_type(uint32_t type);
+extern int ditto_tape_type_from_model(int model);
+
+/* tape_types[] (medium) index <-> Ditto cartridge config value. Both
+   return -1 when there is no mapping. */
+extern int ditto_cartridge_from_medium(uint32_t medium);
+extern int ditto_tape_medium_from_cartridge(int cartridge);
+
+/* Runtime cartridge swap on the (single) live parallel-port drive. Both
+   are no-ops when no drive is attached; load accepts a "wp://" prefix. */
+extern void lpt_ditto_eject(void);
+extern void lpt_ditto_load(const char *path, int read_only);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*EMU_LPT_DITTO_H*/

--- a/src/include/86box/scsi_tape.h
+++ b/src/include/86box/scsi_tape.h
@@ -28,6 +28,21 @@
 #define TAPE_SIMH_GAP      0xFFFFFFFE
 #define TAPE_SIMH_BAD_REC  0xFFFF0000
 
+enum {
+    TAPE_BUS_DISABLED = 0,
+    TAPE_BUS_LPT      = 6,  /* coincides with HDD_BUS_LPT/CDROM_BUS_LPT for config strings */
+    TAPE_BUS_ATAPI    = 8,  /* coincides with HDD_BUS_ATAPI */
+    TAPE_BUS_SCSI     = 9,  /* coincides with HDD_BUS_SCSI */
+    TAPE_BUS_FDC      = 11  /* no HDD_BUS counterpart */
+};
+
+#define TAPE_DRIVE_TYPE_LPT        TAPE_BUS_LPT
+#define TAPE_DRIVE_TYPE_ATAPI      TAPE_BUS_ATAPI
+#define TAPE_DRIVE_TYPE_SCSI       TAPE_BUS_SCSI
+#define TAPE_DRIVE_TYPE_FDC        TAPE_BUS_FDC
+#define TAPE_DRIVE_TYPE_SCSI_ATAPI -2
+#define TAPE_DRIVE_TYPE_NONE       -1
+
 /* Tape media type definitions. */
 typedef struct tape_type_t {
     const char *name;
@@ -36,7 +51,7 @@ typedef struct tape_type_t {
     uint8_t     density_code;
 } tape_type_t;
 
-#define KNOWN_TAPE_TYPES 7
+#define KNOWN_TAPE_TYPES 20
 static const tape_type_t tape_types[KNOWN_TAPE_TYPES] = {
     { "QIC-150",    157286400ULL, 512, 0x10 },
     { "QIC-525",    549978112ULL, 512, 0x11 },
@@ -45,6 +60,19 @@ static const tape_type_t tape_types[KNOWN_TAPE_TYPES] = {
     { "DDS-4",    20000000000ULL, 512, 0x26 },
     { "DAT-72",   36000000000ULL, 512, 0x47 },
     { "DDS-2",     4000000000ULL, 512, 0x24 },
+    { "Ditto 2 GB",              1184366592ULL, 512, 0 },
+    { "Ditto 3 GB",              1776549888ULL, 512, 0 },
+    { "Ditto 5 GB",              2963275776ULL, 512, 0 },
+    { "Ditto Max 7 GB",          4147642368ULL, 512, 0 },
+    { "QIC-80, DC-2080 (205 ft)",  91750400ULL, 512, 0 },
+    { "QIC-80, DC-2120 (307.5 ft)",137625600ULL, 512, 0 },
+    { "QIC-80, 425 ft",           189923328ULL, 512, 0 },
+    { "QIC-80, 1100 ft",          492699648ULL, 512, 0 },
+    { "QIC-3010 (255 MB)",        281804800ULL, 512, 0 },
+    { "QIC-3020 (500 MB)",        553123840ULL, 512, 0 },
+    { "Travan TR-1 (400 MB)",     431751168ULL, 512, 0 },
+    { "Travan TR-2 (800 MB)",     707788800ULL, 512, 0 },
+    { "Travan TR-3 (1.6 GB)",    1389363200ULL, 512, 0 },
 };
 
 /* Tape drive type definitions. */
@@ -53,21 +81,20 @@ typedef struct tape_drive_type_t {
     const char *model;
     const char *revision;
     uint8_t     default_media;
+    int         drive_type;
     int8_t      supported_media[KNOWN_TAPE_TYPES];
 } tape_drive_type_t;
 
-#define KNOWN_TAPE_DRIVE_TYPES 4
+#define KNOWN_TAPE_DRIVE_TYPES 8
 static const tape_drive_type_t tape_drive_types[KNOWN_TAPE_DRIVE_TYPES] = {
-    { "86BOX",   "TAPE",             "1.00", 0, { 1, 1, 1, 1, 1, 1, 1 } },
-    { "ARCHIVE", "VIPER 150 21247",  "2.10", 0, { 1, 0, 0, 0, 0, 0, 0 } },
-    { "86Box",   "DAT-72",           "1.00", 5, { 0, 0, 0, 1, 1, 1, 1 } },
-    { "ARCHIVE", "Python 04687-XXX", "4.CM", 6, { 0, 0, 0, 0, 0, 0, 1 } },
-};
-
-enum {
-    TAPE_BUS_DISABLED = 0,
-    TAPE_BUS_ATAPI    = 8,
-    TAPE_BUS_SCSI     = 9
+    { "86BOX",   "TAPE",             "1.00", 0, TAPE_DRIVE_TYPE_SCSI_ATAPI, { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 } },
+    { "ARCHIVE", "VIPER 150 21247",  "2.10", 0, TAPE_DRIVE_TYPE_SCSI_ATAPI, { 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
+    { "86Box",   "DAT-72",           "1.00", 5, TAPE_DRIVE_TYPE_SCSI_ATAPI, { 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
+    { "ARCHIVE", "Python 04687-XXX", "4.CM", 6, TAPE_DRIVE_TYPE_SCSI_ATAPI, { 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
+    { "Colorado", "250",             "",    11, TAPE_DRIVE_TYPE_FDC,        { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 0, 0 } },
+    { "Iomega",  "Ditto 2GB",        "",     7, TAPE_DRIVE_TYPE_LPT,        { 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 } },
+    { "Iomega",  "Ditto Max",        "",    10, TAPE_DRIVE_TYPE_LPT,        { 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 } },
+    { "Iomega",  "QIC-3020",         "",    15, TAPE_DRIVE_TYPE_LPT,        { 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 } },
 };
 
 typedef struct tape_drive_t {
@@ -80,6 +107,8 @@ typedef struct tape_drive_t {
         uint8_t            res1;
         uint8_t            ide_channel;
         uint8_t            scsi_device_id;
+        uint8_t            fdd_unit;
+        uint8_t            lpt_port;
     };
 
     uint8_t            bus_type;

--- a/src/include/86box/scsi_tape.h
+++ b/src/include/86box/scsi_tape.h
@@ -218,6 +218,10 @@ extern void tape_insert(tape_t *dev);
 extern void tape_global_init(void);
 extern void tape_hard_reset(void);
 
+/* Bus-agnostic runtime mount/eject, valid for every tape bus. */
+extern int  tape_drive_mount(int i, const char *path, int read_only);
+extern void tape_drive_eject(int i);
+
 extern void tape_reset(scsi_common_t *sc);
 extern int  tape_is_empty(const uint8_t id);
 extern void tape_load(const tape_t *dev, const char *fn, const int skip_insert);

--- a/src/network/net_plip.c
+++ b/src/network/net_plip.c
@@ -425,6 +425,13 @@ plip_init(const device_t *info)
     plip_log(dev->log, 1, "init()\n");
 
     dev->lpt  = lpt_attach_ex(device_get_config_int("port"), plip_write_data, plip_write_ctrl, NULL, plip_read_status, NULL, NULL, NULL, dev);
+    if (dev->lpt == NULL) {
+        /* Another device (e.g. a parallel-port tape drive) already has this port. */
+        plip_log(dev->log, 1, "parallel port already claimed by another device\n");
+        log_close(dev->log);
+        free(dev);
+        return NULL;
+    }
     dev->card = network_attach(dev, dev->mac, plip_rx, NULL);
 
     memset(dev->mac, 0xfc, 6); /* static MAC used by Linux; just a placeholder */

--- a/src/qt/qt_harddrive_common.cpp
+++ b/src/qt/qt_harddrive_common.cpp
@@ -19,9 +19,14 @@
 
 extern "C" {
 #include <86box/86box.h>
+#include <86box/timer.h>
 #include <86box/hdd.h>
 #include <86box/scsi.h>
 #include <86box/cdrom.h>
+#include <86box/scsi_device.h>
+#include <86box/scsi_tape.h>
+#include <86box/device.h>
+#include <86box/lpt.h>
 }
 
 #include <QAbstractItemModel>
@@ -161,6 +166,16 @@ Harddrives::populateBusChannels(QAbstractItemModel *model, int bus, SettingsBusT
             busRows = 4;
             busesToCheck.append(CDROM_BUS_MKE);
             break;
+        case TAPE_BUS_FDC:
+            busRows = 4;
+            busesToCheck.append(TAPE_BUS_FDC);
+            break;
+        case TAPE_BUS_LPT:
+            shifter = 0;
+            orer    = 0;
+            busRows = 4;
+            busesToCheck.append(TAPE_BUS_LPT);
+            break;
         default:
             break;
     }
@@ -173,12 +188,18 @@ Harddrives::populateBusChannels(QAbstractItemModel *model, int bus, SettingsBusT
     model->insertRows(0, busRows);
     for (int i = 0; i < busRows; ++i) {
         auto idx = model->index(i, 0);
-        model->setData(idx, QString("%1:%2").arg(i >> shifter).arg(i & orer, subChannelWidth, 10, QChar('0')));
+        if (bus == TAPE_BUS_LPT)
+            model->setData(idx, QString("LPT%1").arg(i + 1));
+        else
+            model->setData(idx, QString("%1:%2").arg(i >> shifter).arg(i & orer, subChannelWidth, 10, QChar('0')));
         model->setData(idx, ((i >> shifter) << shifter) | (i & orer), Qt::UserRole);
         const auto *channelModel = qobject_cast<QStandardItemModel *>(model);
         auto       *channelItem  = channelModel->item(i);
         if (channelItem) {
-            channelItem->setEnabled(!channelsInUse.contains(i));
+            bool enabled = !channelsInUse.contains(i);
+            if ((bus == TAPE_BUS_LPT) && (i < PARALLEL_MAX) && !lpt_ports[i].enabled)
+                enabled = false;
+            channelItem->setEnabled(enabled);
         }
     }
 }
@@ -214,6 +235,12 @@ Harddrives::BusChannelName(uint8_t bus, uint8_t channel)
             break;
         case CDROM_BUS_MKE:
             busName = QString("Panasonic/MKE (%1:%2)").arg(channel >> 2).arg(channel & 3);
+            break;
+        case TAPE_BUS_FDC:
+            busName = QString("FDC (%1:%2)").arg(channel >> 1).arg(channel & 1);
+            break;
+        case TAPE_BUS_LPT:
+            busName = QString("LPT%1").arg(channel + 1);
             break;
     }
 

--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -26,6 +26,7 @@ extern "C" {
 #include <86box/cdrom.h>
 #include <86box/cdrom_interface.h>
 #include <86box/fdd.h>
+#include <86box/lpt.h>
 #include <86box/hdc.h>
 #include <86box/scsi.h>
 #include <86box/scsi_device.h>
@@ -527,6 +528,10 @@ MachineStatus::iterateTape(const std::function<void(int)> &cb)
         if ((tape_drives[i].bus_type == TAPE_BUS_SCSI) && !hasSCSI() &&
             (scsi_card_current[0] == 0) && (scsi_card_current[1] == 0) &&
             (scsi_card_current[2] == 0) && (scsi_card_current[3] == 0))
+            continue;
+        /* A parallel-port tape needs the port it sits on to exist. */
+        if ((tape_drives[i].bus_type == TAPE_BUS_LPT) &&
+            !lpt_ports[tape_drives[i].lpt_port].enabled)
             continue;
         if (tape_drives[i].bus_type != 0) {
             cb(i);

--- a/src/qt/qt_mediamenu.cpp
+++ b/src/qt/qt_mediamenu.cpp
@@ -1267,6 +1267,28 @@ MediaMenu::tapeMount(int i, const QString &filename, bool wp)
     const auto dev       = static_cast<tape_t *>(tape_drives[i].priv);
     int        was_empty = (tape_drives[i].fp == NULL);
 
+    if ((tape_drives[i].bus_type == TAPE_BUS_FDC) || (tape_drives[i].bus_type == TAPE_BUS_LPT)) {
+        /* The floppy-tape and Ditto cores take care of their own
+           image handling through the bus-agnostic dispatch. */
+        if (!filename.isEmpty()) {
+            QByteArray filenameBytes = filename.toUtf8();
+            if (wp && (filename.left(5) != "wp://"))
+                filenameBytes = QString::asprintf(R"(wp://%s)", filename.toUtf8().data()).toUtf8();
+            tape_drive_mount(i, filenameBytes.data(), wp);
+        } else
+            tape_drive_eject(i);
+
+        mhm.addImageToHistory(i, ui::MediaType::Tape, tape_drives[i].prev_image_path, tape_drives[i].image_path);
+
+        ui_sb_update_icon_state(SB_TAPE | i, strlen(tape_drives[i].image_path) == 0);
+        ui_sb_update_icon_wp(SB_TAPE | i, tape_drives[i].read_only);
+        tapeUpdateMenu(i);
+        ui_sb_update_tip(SB_TAPE | i);
+
+        config_save();
+        return;
+    }
+
     tape_disk_close(dev);
     tape_drives[i].read_only = wp;
     if (!filename.isEmpty()) {
@@ -1301,6 +1323,18 @@ MediaMenu::tapeEject(int i)
 {
     const auto dev = static_cast<tape_t *>(tape_drives[i].priv);
 
+    if ((tape_drives[i].bus_type == TAPE_BUS_FDC) || (tape_drives[i].bus_type == TAPE_BUS_LPT)) {
+        mhm.addImageToHistory(i, ui::MediaType::Tape, tape_drives[i].image_path, QString());
+        tape_drive_eject(i);
+
+        ui_sb_update_icon_state(SB_TAPE | i, 1);
+        ui_sb_update_icon_wp(SB_TAPE | i, 0);
+        tapeUpdateMenu(i);
+        ui_sb_update_tip(SB_TAPE | i);
+        config_save();
+        return;
+    }
+
     mhm.addImageToHistory(i, ui::MediaType::Tape, tape_drives[i].image_path, QString());
     tape_disk_close(dev);
     tape_drives[i].image_path[0] = 0;
@@ -1319,6 +1353,29 @@ void
 MediaMenu::tapeReloadPrev(int i)
 {
     const auto dev = static_cast<tape_t *>(tape_drives[i].priv);
+
+    if ((tape_drives[i].bus_type == TAPE_BUS_FDC) || (tape_drives[i].bus_type == TAPE_BUS_LPT)) {
+        /* Re-mount whatever is still configured on the drive. */
+        if (tape_drives[i].image_path[0] != 0x00) {
+            char fn[MAX_IMAGE_PATH_LEN + 8];
+
+            if (tape_drives[i].read_only)
+                snprintf(fn, sizeof(fn), "wp://%s", tape_drives[i].image_path);
+            else
+                snprintf(fn, sizeof(fn), "%s", tape_drives[i].image_path);
+            tape_drive_mount(i, fn, tape_drives[i].read_only);
+        } else
+            tape_drive_eject(i);
+
+        ui_sb_update_icon_state(SB_TAPE | i, strlen(tape_drives[i].image_path) == 0);
+        ui_sb_update_icon_wp(SB_TAPE | i, tape_drives[i].read_only);
+
+        tapeUpdateMenu(i);
+        ui_sb_update_tip(SB_TAPE | i);
+
+        config_save();
+        return;
+    }
 
     tape_disk_reload(dev);
     if (strlen(tape_drives[i].image_path) == 0) {
@@ -1366,6 +1423,12 @@ MediaMenu::tapeUpdateMenu(int i)
             break;
         case TAPE_BUS_SCSI:
             busName = "SCSI";
+            break;
+        case TAPE_BUS_FDC:
+            busName = "FDC";
+            break;
+        case TAPE_BUS_LPT:
+            busName = "LPT";
             break;
     }
 

--- a/src/qt/qt_newfloppydialog.cpp
+++ b/src/qt/qt_newfloppydialog.cpp
@@ -836,6 +836,16 @@ NewFloppyDialog::createTapeSectorImage(const QString &filename, UNUSED(int8_t di
     }
     QDataStream stream(&file);
     stream.setByteOrder(QDataStream::LittleEndian);
+
+    if (disk_size >= 7) {
+        /* QIC-117 floppy-tape / Ditto cartridges: the cores create and
+           format their own blank images (a zero-length file), so keep
+           the cartridge byte-identical to an auto-created one. */
+        pbar.setMaximum(1);
+        fileProgress(1);
+        return true;
+    }
+
     stream << (uint32_t) TAPE_SIMH_EOD;
     pbar.setMaximum(1);
     fileProgress(1);

--- a/src/qt/qt_settings_bus_tracking.cpp
+++ b/src/qt/qt_settings_bus_tracking.cpp
@@ -24,6 +24,8 @@ extern "C" {
 #include "86box/hdd.h"
 #include "86box/scsi.h"
 #include "86box/cdrom.h"
+#include "86box/scsi_device.h"
+#include "86box/scsi_tape.h"
 }
 
 #include "qt_settings_bus_tracking.hpp"
@@ -148,6 +150,42 @@ SettingsBusTracking::next_free_scsi_id()
         mask    = 0xffULL << ((uint64_t) ((i << 3) & 0x3f));
 
         if (!(scsi_tracking[element] & mask)) {
+            ret = (uint8_t) i;
+            break;
+        }
+    }
+
+    return ret;
+}
+
+uint8_t
+SettingsBusTracking::next_free_fdc_unit()
+{
+    uint64_t mask;
+    uint8_t  ret = CHANNEL_NONE;
+
+    for (uint8_t i = 0; i < 4; i++) {
+        mask = 0xffULL << ((uint64_t) ((i << 3) & 0x3f));
+
+        if (!(fdc_tracking & mask)) {
+            ret = (uint8_t) i;
+            break;
+        }
+    }
+
+    return ret;
+}
+
+uint8_t
+SettingsBusTracking::next_free_lpt_port()
+{
+    uint64_t mask;
+    uint8_t  ret = CHANNEL_NONE;
+
+    for (uint8_t i = 0; i < 4; i++) {
+        mask = 0xffULL << ((uint64_t) ((i << 3) & 0x3f));
+
+        if (!(lpt_tracking & mask)) {
             ret = (uint8_t) i;
             break;
         }
@@ -304,6 +342,20 @@ SettingsBusTracking::busChannelsInUse(const int bus)
                     channelsInUse.append(i);
             }
             break;
+        case TAPE_BUS_FDC:
+            for (uint8_t i = 0; i < 4; i++) {
+                mask = 0xffULL << ((uint64_t) ((i << 3) & 0x3f));
+                if (fdc_tracking & mask)
+                    channelsInUse.append(i);
+            }
+            break;
+        case TAPE_BUS_LPT:
+            for (uint8_t i = 0; i < 4; i++) {
+                mask = 0xffULL << ((uint64_t) ((i << 3) & 0x3f));
+                if (lpt_tracking & mask)
+                    channelsInUse.append(i);
+            }
+            break;
         default:
             break;
     }
@@ -375,6 +427,23 @@ SettingsBusTracking::device_track(int set, uint8_t dev_type, int bus, int channe
                 scsi_tracking[element] |= mask;
             else
                 scsi_tracking[element] &= ~mask;
+            break;
+        case TAPE_BUS_FDC:
+            mask = ((uint64_t) dev_type) << ((uint64_t) ((channel << 3) & 0x3f));
+
+            if (set)
+                fdc_tracking |= mask;
+            else
+                fdc_tracking &= ~mask;
+            break;
+
+        case TAPE_BUS_LPT:
+            mask = ((uint64_t) dev_type) << ((uint64_t) ((channel << 3) & 0x3f));
+
+            if (set)
+                lpt_tracking |= mask;
+            else
+                lpt_tracking &= ~mask;
             break;
     }
 }

--- a/src/qt/qt_settings_bus_tracking.hpp
+++ b/src/qt/qt_settings_bus_tracking.hpp
@@ -11,6 +11,8 @@
 #define DEV_RDISK    0x04
 #define DEV_MO       0x08
 #define DEV_TAPE     0x10
+#define DEV_FDD      0x20
+#define DEV_LPT      0x40
 
 #define BUS_MFM      0
 #define BUS_ESDI     1
@@ -38,6 +40,8 @@ public:
     uint8_t next_free_xta_channel();
     uint8_t next_free_ide_channel();
     uint8_t next_free_scsi_id();
+    uint8_t next_free_fdc_unit();
+    uint8_t next_free_lpt_port();
 
     int mke_bus_full();
     int mfm_bus_full();
@@ -66,6 +70,10 @@ private:
        8 bits per device (future-proofing) = 2048 bits. */
     uint64_t scsi_tracking[32] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    /* 4 FDC drive lines, 8 bits per line. */
+    uint64_t fdc_tracking { 0 };
+    /* 4 LPT ports, 8 bits per port. */
+    uint64_t lpt_tracking { 0 };
 
     bool mitsumi_tracking;
 };

--- a/src/qt/qt_settingsfloppycdrom.cpp
+++ b/src/qt/qt_settingsfloppycdrom.cpp
@@ -29,6 +29,8 @@ extern "C" {
 #include <86box/timer.h>
 #include <86box/fdd.h>
 #include <86box/cdrom.h>
+#include <86box/scsi_device.h>
+#include <86box/scsi_tape.h>
 #include <86box/fdd_audio.h>
 }
 
@@ -163,6 +165,7 @@ SettingsFloppyCDROM::SettingsFloppyCDROM(QWidget *parent)
 #else
         ifa[i] = 0;
 #endif
+        Harddrives::busTrackClass->device_track(fdd_get_type(i) ? 1 : 0, DEV_FDD, TAPE_BUS_FDC, i);
     }
 
     for (int i = 0; i < model->columnCount(); i++)
@@ -498,7 +501,9 @@ SettingsFloppyCDROM::on_comboBoxFloppyType_activated(int index)
 {
     auto currentIndex = ui->treeViewFloppy->selectionModel()->currentIndex();
     auto typeIndex    = currentIndex.siblingAtColumn(0);
+    Harddrives::busTrackClass->device_track(0, DEV_FDD, TAPE_BUS_FDC, currentIndex.row());
     setFloppyType(ui->treeViewFloppy->model(), typeIndex, index);
+    Harddrives::busTrackClass->device_track(index ? 1 : 0, DEV_FDD, TAPE_BUS_FDC, currentIndex.row());
     ui->treeViewFloppy->resizeColumnToContents(0);
 
     // Trigger row changed to rebuild audio profile list

--- a/src/qt/qt_settingsotherremovable.cpp
+++ b/src/qt/qt_settingsotherremovable.cpp
@@ -55,6 +55,35 @@ tapeDriveTypeName(int i)
     return QString("%1 %2 %3").arg(tape_drive_types[i].vendor, tape_drive_types[i].model, tape_drive_types[i].revision);
 }
 
+static bool
+tapeTypeBusCompatible(int bus, uint32_t type)
+{
+    if (type >= KNOWN_TAPE_DRIVE_TYPES)
+        return false;
+
+    switch (tape_drive_types[type].drive_type) {
+        case TAPE_DRIVE_TYPE_SCSI_ATAPI:
+            return (bus == TAPE_BUS_ATAPI) || (bus == TAPE_BUS_SCSI);
+        case TAPE_DRIVE_TYPE_FDC:
+            return (bus == TAPE_BUS_FDC);
+        case TAPE_DRIVE_TYPE_LPT:
+            return (bus == TAPE_BUS_LPT);
+        default:
+            return false;
+    }
+}
+
+static int
+firstCompatibleTapeType(int bus)
+{
+    for (uint32_t i = 0; i < KNOWN_TAPE_DRIVE_TYPES; i++) {
+        if (tapeTypeBusCompatible(bus, i))
+            return (int) i;
+    }
+
+    return 0;
+}
+
 void
 SettingsOtherRemovable::setMOBus(QAbstractItemModel *model, const QModelIndex &idx, uint8_t bus, uint8_t channel)
 {
@@ -113,6 +142,8 @@ SettingsOtherRemovable::setTapeBus(QAbstractItemModel *model, const QModelIndex 
             break;
         case TAPE_BUS_ATAPI:
         case TAPE_BUS_SCSI:
+        case TAPE_BUS_FDC:
+        case TAPE_BUS_LPT:
             icon = tape_icon;
             break;
 
@@ -254,8 +285,15 @@ SettingsOtherRemovable::SettingsOtherRemovable(QWidget *parent)
     tape_icon          = QIcon(":/settings/qt/icons/tape.ico");
 
     Harddrives::populateRemovableBuses(ui->comboBoxTapeBus->model());
-    if ((ui->comboBoxTapeBus->model()->rowCount() - 3) > 0)
-        ui->comboBoxTapeBus->model()->removeRows(3, ui->comboBoxTapeBus->model()->rowCount() - 3);
+    {
+        auto *busModel = ui->comboBoxTapeBus->model();
+        int   row      = busModel->rowCount();
+        busModel->insertRows(row, 2);
+        busModel->setData(busModel->index(row, 0), "FDC");
+        busModel->setData(busModel->index(row, 0), TAPE_BUS_FDC, Qt::UserRole);
+        busModel->setData(busModel->index(row + 1, 0), "LPT");
+        busModel->setData(busModel->index(row + 1, 0), TAPE_BUS_LPT, Qt::UserRole);
+    }
     model = ui->comboBoxTapeType->model();
     for (uint32_t i = 0; i < KNOWN_TAPE_DRIVE_TYPES; i++) {
         Models::AddEntry(model, tapeDriveTypeName(i), i);
@@ -271,7 +309,7 @@ SettingsOtherRemovable::SettingsOtherRemovable(QWidget *parent)
         auto idx = model->index(i, 0);
         setTapeBus(model, idx, tape_drives[i].bus_type, tape_drives[i].res);
         setTapeType(model, idx.siblingAtColumn(1), tape_drives[i].type);
-        Harddrives::busTrackClass->device_track(1, DEV_TAPE, tape_drives[i].bus_type, tape_drives[i].bus_type == TAPE_BUS_ATAPI ? tape_drives[i].ide_channel : tape_drives[i].scsi_device_id);
+        Harddrives::busTrackClass->device_track(1, DEV_TAPE, tape_drives[i].bus_type, tape_drives[i].res);
     }
 
     for (int i = 0; i < model->columnCount(); i++)
@@ -571,6 +609,7 @@ SettingsOtherRemovable::onTapeRowChanged(const QModelIndex &current)
     if (!match.isEmpty())
         ui->comboBoxTapeChannel->setCurrentIndex(match.first().row());
     ui->comboBoxTapeType->setCurrentIndex(type);
+    updateTapeTypeCombo();
     enableCurrentlySelectedChannel_Tape();
 }
 
@@ -594,6 +633,37 @@ SettingsOtherRemovable::on_comboBoxTapeBus_currentIndexChanged(int index)
         ui->comboBoxTapeType->setEnabled(enabled);
         Harddrives::populateBusChannels(ui->comboBoxTapeChannel->model(), bus, Harddrives::busTrackClass);
     }
+    updateTapeTypeCombo();
+}
+
+void
+SettingsOtherRemovable::updateTapeTypeCombo()
+{
+    int  bus = ui->comboBoxTapeBus->currentData().toInt();
+    auto *model = qobject_cast<QStandardItemModel *>(ui->comboBoxTapeType->model());
+
+    for (int i = 0; i < model->rowCount(); i++) {
+        auto *item = model->item(i);
+        if (item)
+            item->setEnabled(tapeTypeBusCompatible(bus, item->data(Qt::UserRole).toUInt()));
+    }
+}
+
+static uint8_t
+nextFreeTapeChannel(SettingsBusTracking *sbt, int bus)
+{
+    switch (bus) {
+        case TAPE_BUS_ATAPI:
+            return sbt->next_free_ide_channel();
+        case TAPE_BUS_SCSI:
+            return sbt->next_free_scsi_id();
+        case TAPE_BUS_FDC:
+            return sbt->next_free_fdc_unit();
+        case TAPE_BUS_LPT:
+            return sbt->next_free_lpt_port();
+        default:
+            return 0;
+    }
 }
 
 void
@@ -601,8 +671,15 @@ SettingsOtherRemovable::on_comboBoxTapeBus_activated(int)
 {
     auto i = ui->treeViewTape->selectionModel()->currentIndex().siblingAtColumn(0);
     Harddrives::busTrackClass->device_track(0, DEV_TAPE, ui->treeViewTape->model()->data(i, Qt::UserRole).toInt(), ui->treeViewTape->model()->data(i, Qt::UserRole + 1).toInt());
-    ui->comboBoxTapeChannel->setCurrentIndex(ui->comboBoxTapeBus->currentData().toUInt() == TAPE_BUS_ATAPI ? Harddrives::busTrackClass->next_free_ide_channel() : Harddrives::busTrackClass->next_free_scsi_id());
+    uint8_t next_free = nextFreeTapeChannel(Harddrives::busTrackClass, ui->comboBoxTapeBus->currentData().toInt());
+    ui->comboBoxTapeChannel->setCurrentIndex(next_free == CHANNEL_NONE ? -1 : next_free);
     ui->treeViewTape->model()->data(i, Qt::UserRole + 1);
+
+    uint32_t type = ui->comboBoxTapeType->currentData().toUInt();
+    if (!tapeTypeBusCompatible(ui->comboBoxTapeBus->currentData().toInt(), type))
+        type = firstCompatibleTapeType(ui->comboBoxTapeBus->currentData().toInt());
+    ui->comboBoxTapeType->setCurrentIndex(type);
+
     setTapeBus(ui->treeViewTape->model(),
                ui->treeViewTape->selectionModel()->currentIndex(),
                ui->comboBoxTapeBus->currentData().toUInt(),

--- a/src/qt/qt_settingsotherremovable.hpp
+++ b/src/qt/qt_settingsotherremovable.hpp
@@ -54,6 +54,7 @@ private:
     void setRDiskBus(QAbstractItemModel *model, const QModelIndex &idx, uint8_t bus, uint32_t type, uint8_t channel);
     void setRDiskType(QAbstractItemModel *model, const QModelIndex &idx, uint8_t bus, uint32_t type);
     void setTapeBus(QAbstractItemModel *model, const QModelIndex &idx, uint8_t bus, uint8_t channel);
+    void updateTapeTypeCombo();
     void enableCurrentlySelectedChannel_MO();
     void enableCurrentlySelectedChannel_RDisk();
     void enableCurrentlySelectedChannel_Tape();

--- a/src/qt/qt_settingsports.cpp
+++ b/src/qt/qt_settingsports.cpp
@@ -24,6 +24,8 @@ extern "C" {
 #include <86box/device.h>
 #include <86box/machine.h>
 #include <86box/lpt.h>
+#include <86box/scsi_device.h>
+#include <86box/scsi_tape.h>
 #include <86box/serial.h>
 #include <86box/char.h>
 }
@@ -34,9 +36,13 @@ extern "C" {
 #include "qt_defs.hpp"
 
 #include "qt_settings_completer.hpp"
+#include "qt_settings_bus_tracking.hpp"
+#include "qt_harddrive_common.hpp"
 
 #include "qt_settingsports.hpp"
 #include "ui_qt_settingsports.h"
+
+#include <QStandardItem>
 
 SettingsPorts::SettingsPorts(QWidget *parent)
     : QWidget(parent)
@@ -65,6 +71,20 @@ SettingsPorts::~SettingsPorts()
         delete scCom[i];
 
     delete ui;
+}
+
+void
+SettingsPorts::updateLptPortTracking(int i)
+{
+    auto *comboBox = findChild<QComboBox *>(QString("comboBoxLpt%1").arg(i + 1));
+    if (comboBox == NULL)
+        return;
+
+    int  device   = comboBox->currentData().toInt();
+    bool occupied = (lpt_ports[i].enabled > 0) && (device > 0) &&
+                    (char_get_device(device) != &lpt_ditto_device);
+
+    Harddrives::busTrackClass->device_track(occupied ? 1 : 0, DEV_LPT, TAPE_BUS_LPT, i);
 }
 
 int
@@ -258,6 +278,8 @@ SettingsPorts::onCurrentMachineChanged(int machineId)
                 buttonCfg->setEnabled(device_has_config(char_get_device(lptDevice)) && (lpt_ports[i].enabled > 0));
             }
         }
+
+        updateLptPortTracking(i);
     }
 
     c = 0;
@@ -325,6 +347,7 @@ SettingsPorts::on_comboBoxLpt1_currentIndexChanged(int index)
 
     int lptDevice = ui->comboBoxLpt1->currentData().toInt();
 
+    updateLptPortTracking(0);
     ui->pushButtonConfigureLpt1->setEnabled(ui->comboBoxLpt1->isEnabled() && device_has_config(char_get_device(lptDevice)));
 }
 
@@ -345,6 +368,7 @@ SettingsPorts::on_comboBoxLpt2_currentIndexChanged(int index)
 
     int lptDevice = ui->comboBoxLpt2->currentData().toInt();
 
+    updateLptPortTracking(1);
     ui->pushButtonConfigureLpt2->setEnabled(ui->comboBoxLpt2->isEnabled() && device_has_config(char_get_device(lptDevice)));
 }
 
@@ -365,6 +389,7 @@ SettingsPorts::on_comboBoxLpt3_currentIndexChanged(int index)
 
     int lptDevice = ui->comboBoxLpt3->currentData().toInt();
 
+    updateLptPortTracking(2);
     ui->pushButtonConfigureLpt3->setEnabled(ui->comboBoxLpt3->isEnabled() && device_has_config(char_get_device(lptDevice)));
 }
 
@@ -385,6 +410,7 @@ SettingsPorts::on_comboBoxLpt4_currentIndexChanged(int index)
 
     int lptDevice = ui->comboBoxLpt4->currentData().toInt();
 
+    updateLptPortTracking(3);
     ui->pushButtonConfigureLpt4->setEnabled(ui->comboBoxLpt4->isEnabled() && device_has_config(char_get_device(lptDevice)));
 }
 

--- a/src/qt/qt_settingsports.hpp
+++ b/src/qt/qt_settingsports.hpp
@@ -57,6 +57,8 @@ private:
     Ui::SettingsPorts *ui;
     int                machineId = 0;
 
+    void updateLptPortTracking(int i);
+
     int                lpt_device_cfg_changed[4] = { 0, 0, 0, 0 };
     int                com_device_cfg_changed[SERIAL_MAX_UI] = { 0 };
 

--- a/src/qt/qt_settingsstoragecontrollers.cpp
+++ b/src/qt/qt_settingsstoragecontrollers.cpp
@@ -30,7 +30,6 @@ extern "C" {
 #include <86box/scsi_device.h>
 #include <86box/cassette.h>
 #include <86box/fdd.h>
-#include <86box/fdd_tape.h>
 }
 
 #include "qt_deviceconfig.hpp"
@@ -66,9 +65,6 @@ SettingsStorageControllers::SettingsStorageControllers(QWidget *parent)
 
     fdc_cfg_changed             = 0;
     cdrom_interface_cfg_changed = 0;
-
-    ui->fileFieldFloppyTape->setFilter(tr("Tape images") % util::DlgFilter({ "img", "tape", "qic" }) % tr("All files") % util::DlgFilter({ "*" }, true));
-    ui->fileFieldFloppyTape->setFileName(QString::fromUtf8(fdd_tape_fn));
 
     onCurrentMachineChanged(machine);
 }
@@ -110,10 +106,6 @@ SettingsStorageControllers::changed()
     has_changed |= cdrom_interface_cfg_changed;
     has_changed |= (cassette_enable         != (ui->checkBoxCassette->isChecked() ? 1 : 0));
 
-    has_changed |= (fdd_tape_enabled        != (ui->checkBoxFloppyTape->isChecked() ? 1 : 0));
-    has_changed |= (fdd_tape_unit           != ui->comboBoxFloppyTapeUnit->currentData().toInt());
-    has_changed |= (QString::fromUtf8(fdd_tape_fn) != ui->fileFieldFloppyTape->fileName());
-
     return has_changed ? (SETTINGS_CHANGED | SETTINGS_REQUIRE_HARD_RESET) : 0;
 }
 
@@ -142,13 +134,6 @@ SettingsStorageControllers::save(int soft)
     fdc_current[0]          = ui->comboBoxFD->currentData().toInt();
     cdrom_interface_current = ui->comboBoxCDInterface->currentData().toInt();
     cassette_enable         = ui->checkBoxCassette->isChecked() ? 1 : 0;
-
-    fdd_tape_enabled        = ui->checkBoxFloppyTape->isChecked() ? 1 : 0;
-    fdd_tape_unit           = ui->comboBoxFloppyTapeUnit->currentData().toInt();
-
-    const QByteArray tapeFn = ui->fileFieldFloppyTape->fileName().toUtf8();
-    memset(fdd_tape_fn, 0x00, sizeof(fdd_tape_fn));
-    strncpy(fdd_tape_fn, tapeFn.constData(), sizeof(fdd_tape_fn) - 1);
 }
 
 void
@@ -333,35 +318,6 @@ SettingsStorageControllers::onCurrentMachineChanged(int machineId)
         ui->checkBoxCassette->setChecked(false);
         ui->checkBoxCassette->setEnabled(false);
     }
-
-    /* Floppy tape drive */
-    auto *tapeModel = ui->comboBoxFloppyTapeUnit->model();
-    tapeModel->removeRows(0, tapeModel->rowCount());
-
-    int tapeSelectedRow = 0;
-    for (int i = 0; i < FDD_NUM; ++i) {
-        const int row = Models::AddEntry(tapeModel, tr("Drive %1:").arg(QChar('A' + i)), i);
-        if (i == fdd_tape_unit)
-            tapeSelectedRow = row;
-    }
-
-    ui->checkBoxFloppyTape->setChecked(fdd_tape_enabled > 0);
-    ui->comboBoxFloppyTapeUnit->setCurrentIndex(-1);
-    ui->comboBoxFloppyTapeUnit->setCurrentIndex(tapeSelectedRow);
-    ui->fileFieldFloppyTape->setFileName(QString::fromUtf8(fdd_tape_fn));
-
-    on_checkBoxFloppyTape_stateChanged(ui->checkBoxFloppyTape->isChecked() ? Qt::Checked : Qt::Unchecked);
-}
-
-void
-SettingsStorageControllers::on_checkBoxFloppyTape_stateChanged(int state)
-{
-    const bool enabled = (state != Qt::Unchecked);
-
-    ui->labelFloppyTapeUnit->setEnabled(enabled);
-    ui->comboBoxFloppyTapeUnit->setEnabled(enabled);
-    ui->labelFloppyTapeFile->setEnabled(enabled);
-    ui->fileFieldFloppyTape->setEnabled(enabled);
 }
 
 void

--- a/src/qt/qt_settingsstoragecontrollers.hpp
+++ b/src/qt/qt_settingsstoragecontrollers.hpp
@@ -47,8 +47,6 @@ private slots:
     void on_comboBoxSCSI4_currentIndexChanged(int index);
     void on_pushButtonSCSI4_clicked();
 
-    void on_checkBoxFloppyTape_stateChanged(int state);
-
 private:
     Ui::SettingsStorageControllers *ui;
     int                             machineId = 0;

--- a/src/qt/qt_settingsstoragecontrollers.ui
+++ b/src/qt/qt_settingsstoragecontrollers.ui
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>SettingsStorageControllers</class>
  <widget class="QWidget" name="SettingsStorageControllers">
@@ -394,82 +394,6 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tabFloppyTape">
-      <attribute name="title">
-       <string>Floppy tape drive</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayoutFloppyTape">
-       <item>
-        <widget class="QGroupBox" name="groupBoxFloppyTape">
-         <property name="title">
-          <string>Floppy tape drive</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayoutFloppyTape">
-          <item row="0" column="0" colspan="3">
-           <widget class="QCheckBox" name="checkBoxFloppyTape">
-            <property name="text">
-             <string>Floppy tape drive (QIC-117)</string>
-            </property>
-            <property name="toolTip">
-             <string>Attaches a Colorado 250 tape drive to the floppy disk controller's cable.</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="labelFloppyTapeUnit">
-            <property name="text">
-             <string>Drive select:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1" colspan="2">
-           <widget class="QComboBox" name="comboBoxFloppyTapeUnit">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>The drive select line the tape drive answers to. Any floppy drive configured on the same line is disconnected.</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="labelFloppyTapeFile">
-            <property name="text">
-             <string>Tape image:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1" colspan="2">
-           <widget class="FileField" name="fileFieldFloppyTape" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacerFloppyTape">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
     </widget>
    </item>
 
@@ -506,9 +430,6 @@
   <tabstop>pushButtonSCSI3</tabstop>
   <tabstop>comboBoxSCSI4</tabstop>
   <tabstop>pushButtonSCSI4</tabstop>
-  <tabstop>checkBoxFloppyTape</tabstop>
-  <tabstop>comboBoxFloppyTapeUnit</tabstop>
-  <tabstop>fileFieldFloppyTape</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/scsi/scsi_tape.c
+++ b/src/scsi/scsi_tape.c
@@ -40,6 +40,9 @@
 #include <86box/ui.h>
 #include <86box/hdc_ide.h>
 #include <86box/scsi_tape.h>
+#include <86box/lpt.h>
+#include <86box/fdd_tape.h>
+#include <86box/lpt_ditto.h>
 #include <86box/version.h>
 
 #ifdef _WIN32
@@ -3042,10 +3045,64 @@ tape_drive_reset(const int c)
     }
 }
 
+/* Tears a drive's resources down; safe on any bus (the FDC and LPT buses
+   own nothing here, their priv stays NULL). */
+static void
+tape_drive_close(const int c)
+{
+    if (tape_drives[c].bus_type == TAPE_BUS_SCSI) {
+        const uint8_t scsi_bus = (tape_drives[c].scsi_device_id >> 4) & 0x0f;
+        const uint8_t scsi_id  = tape_drives[c].scsi_device_id & 0x0f;
+
+        memset(&scsi_devices[scsi_bus][scsi_id], 0x00, sizeof(scsi_device_t));
+    }
+
+    tape_t *dev = (tape_t *) tape_drives[c].priv;
+
+    if (dev) {
+        tape_disk_unload(dev);
+
+        if (dev->rec_buf)
+            free(dev->rec_buf);
+
+        if (dev->aux_buf)
+            free(dev->aux_buf);
+
+        if (dev->tf)
+            free(dev->tf);
+
+        if (dev->log != NULL) {
+            tape_log(dev->log, "Log closed\n");
+            log_close(dev->log);
+            dev->log = NULL;
+        }
+
+        free(dev);
+        tape_drives[c].priv = NULL;
+    }
+}
+
 void
 tape_hard_reset(void)
 {
     for (uint8_t c = 0; c < TAPE_NUM; c++) {
+        if ((tape_drives[c].bus_type != TAPE_BUS_SCSI) &&
+            (tape_drives[c].bus_type != TAPE_BUS_ATAPI)) {
+            /* A drive that switched buses between resets has its previous
+               bus's resources torn down here. */
+            if (tape_drives[c].priv != NULL)
+                tape_drive_close(c);
+
+            if (tape_drives[c].bus_type == TAPE_BUS_LPT) {
+                /* Parallel-port tape: instantiate the drive and let it
+                   claim the port the standard way, with lpt_attach() -
+                   first-claim-wins against any other LPT device. */
+                device_add_inst(&lpt_ditto_device, tape_drives[c].lpt_port + 1);
+            }
+
+            continue;
+        }
+
         if (tape_drives[c].bus_type == TAPE_BUS_SCSI) {
             const uint8_t scsi_bus = (tape_drives[c].scsi_device_id >> 4) & 0x0f;
             const uint8_t scsi_id  = tape_drives[c].scsi_device_id & 0x0f;
@@ -3092,38 +3149,8 @@ void
 tape_close(void)
 {
     for (uint8_t c = 0; c < TAPE_NUM; c++) {
-        if ((tape_drives[c].bus_type == TAPE_BUS_SCSI) || (tape_drives[c].bus_type == TAPE_BUS_ATAPI)) {
-            if (tape_drives[c].bus_type == TAPE_BUS_SCSI) {
-                const uint8_t scsi_bus = (tape_drives[c].scsi_device_id >> 4) & 0x0f;
-                const uint8_t scsi_id  = tape_drives[c].scsi_device_id & 0x0f;
-
-                memset(&scsi_devices[scsi_bus][scsi_id], 0x00, sizeof(scsi_device_t));
-            }
-
-            tape_t *dev = (tape_t *) tape_drives[c].priv;
-
-            if (dev) {
-                tape_disk_unload(dev);
-
-                if (dev->rec_buf)
-                    free(dev->rec_buf);
-
-                if (dev->aux_buf)
-                    free(dev->aux_buf);
-
-                if (dev->tf)
-                    free(dev->tf);
-
-                if (dev->log != NULL) {
-                    tape_log(dev->log, "Log closed\n");
-                    log_close(dev->log);
-                    dev->log = NULL;
-                }
-
-                free(dev);
-                tape_drives[c].priv = NULL;
-            }
-        }
+        if ((tape_drives[c].bus_type == TAPE_BUS_SCSI) || (tape_drives[c].bus_type == TAPE_BUS_ATAPI))
+            tape_drive_close(c);
 
 #if defined(ENABLE_TAPE_LOG) && defined(TAPE_FILE_LOG)
         if (tape_log_file) {
@@ -3132,5 +3159,100 @@ tape_close(void)
             tape_log_file = NULL;
         }
 #endif
+    }
+}
+
+/* Bus-agnostic runtime mount/eject, callable from the UI for any tape
+   drive. The mount accepts a "wp://" prefix as well as the flag. */
+
+void
+tape_drive_eject(int i)
+{
+    if ((i < 0) || (i >= TAPE_NUM))
+        return;
+
+    switch (tape_drives[i].bus_type) {
+        case TAPE_BUS_SCSI:
+        case TAPE_BUS_ATAPI: {
+            tape_t *dev = (tape_t *) tape_drives[i].priv;
+
+            if (dev == NULL)
+                return;
+
+            tape_disk_close(dev);
+            tape_drives[i].image_path[0] = 0x00;
+            /* Signal media change to the emulated machine. */
+            tape_insert(dev);
+            break;
+        }
+
+        case TAPE_BUS_FDC:
+            fdd_tape_eject();
+            break;
+
+        case TAPE_BUS_LPT:
+            lpt_ditto_eject();
+            break;
+
+        default:
+            break;
+    }
+}
+
+int
+tape_drive_mount(int i, const char *path, int read_only)
+{
+    char fn[MAX_IMAGE_PATH_LEN + 8];
+    int  was_empty;
+
+    if ((i < 0) || (i >= TAPE_NUM) || (path == NULL) || (path[0] == 0x00))
+        return 0;
+
+    /* A "wp://" prefix on the path means the same as the flag. */
+    if (strstr(path, "wp://") == path) {
+        path += 5;
+        read_only = 1;
+    }
+
+    if (read_only)
+        snprintf(fn, sizeof(fn), "wp://%s", path);
+    else
+        snprintf(fn, sizeof(fn), "%s", path);
+
+    switch (tape_drives[i].bus_type) {
+        case TAPE_BUS_SCSI:
+        case TAPE_BUS_ATAPI: {
+            tape_t *dev = (tape_t *) tape_drives[i].priv;
+
+            if (dev == NULL)
+                return 0;
+
+            was_empty = (tape_drives[i].fp == NULL);
+
+            tape_disk_close(dev);
+            tape_drives[i].read_only = read_only;
+            tape_load(dev, fn, 1);
+
+            /* Signal media change to the emulated machine. */
+            tape_insert(dev);
+            if (was_empty)
+                tape_insert(dev);
+
+            /* tape_load() keeps image_path up to date. */
+            return 1;
+        }
+
+        case TAPE_BUS_FDC:
+            /* fdd_tape_load() writes the image and read-only flag back
+               into the owning tape_drives[] entry. */
+            fdd_tape_load(fn);
+            return 1;
+
+        case TAPE_BUS_LPT:
+            lpt_ditto_load(fn, read_only);
+            return 1;
+
+        default:
+            return 0;
     }
 }


### PR DESCRIPTION
Summary
=======
This PR integrates the FDC and LPT tape drives properly into the existing Tape Drives user interface and implements proper status bar icons for them.

<img width="722" height="499" alt="image" src="https://github.com/user-attachments/assets/ffa37786-1b7e-4bb9-9fdc-dbcd6f28ec80" />

<img width="367" height="50" alt="image" src="https://github.com/user-attachments/assets/8c045d2c-562b-4825-a900-babe90c1dc0f" />

AI disclosure - this PR was produced with large assistance from an AI agent (GLM 5.3 model)

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
