### PR TITLE
Add memdump server: CPU-suspension-free guest memory access

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -47,6 +47,7 @@
 #include <86box/86box.h>
 #include <86box/config.h>
 #include <86box/mem.h>
+#include <86box/memdump.h>
 #include "cpu.h"
 #ifdef USE_DYNAREC
 #    include "codegen_public.h"
@@ -235,6 +236,7 @@ int      fdd_sounds_enabled = 1;                                  /* (C) Floppy 
 int      is_new_808x = 0;                                         /* (C) Use the new 808x code. */
 
 int      gdbstub_port = 12345;                                    /* (C) The GDB stub port. */
+int      memdump_port = 0;                                       /* (C) The memory-dump server port (0 = disabled). */
 
 // Accelerator key array
 struct accelKey acc_keys[NUM_ACCELS];
@@ -1983,6 +1985,7 @@ pc_close(UNUSED(thread_t *ptr))
     scsi_disk_close();
 
     gdbstub_close();
+    memdump_close();
 
 }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,6 +65,8 @@ if(GDBSTUB)
     target_sources(86Box PRIVATE gdbstub.c)
 endif()
 
+target_sources(86Box PRIVATE memdump.c)
+
 if(NEW_DYNAREC)
     add_compile_definitions(USE_NEW_DYNAREC)
 endif()

--- a/src/config.c
+++ b/src/config.c
@@ -396,6 +396,7 @@ load_general(void)
         strncpy(uuid, "", sizeof(uuid) - 1);
 
     gdbstub_port = ini_section_get_int(cat, "gdbstub_port", 12345);
+    memdump_port = ini_section_get_int(cat, "memdump_port", 0);
 }
 
 /* Load monitor section. */
@@ -3179,6 +3180,11 @@ save_general(void)
         ini_section_delete_var(cat, "gdbstub_port");
     else
         ini_section_set_int(cat, "gdbstub_port", gdbstub_port);
+
+    if (memdump_port == 0)
+        ini_section_delete_var(cat, "memdump_port");
+    else
+        ini_section_set_int(cat, "memdump_port", memdump_port);
 
     ini_delete_section_if_empty(config, cat);
 }

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -249,6 +249,7 @@ extern int    hook_enabled;                 /* (C) Keyboard hook is enabled */
 extern int    vmm_disabled;                 /* (G) disable built-in manager */
 extern char   vmm_path_cfg[1024];           /* (G) VMs path (unless -E is used) */
 extern int    gdbstub_port;                 /* (C) The GDB stub port. */
+extern int    memdump_port;                 /* (C) The memory-dump server port. */
 
 extern char exe_path[2048];        /* path (dir) of executable */
 extern char usr_path[1024];        /* path (dir) of user data */

--- a/src/include/86box/memdump.h
+++ b/src/include/86box/memdump.h
@@ -1,0 +1,7 @@
+#ifndef MEMDUMP_H
+#define MEMDUMP_H
+
+extern void memdump_init(void);
+extern void memdump_close(void);
+
+#endif

--- a/src/machine/machine.c
+++ b/src/machine/machine.c
@@ -29,6 +29,7 @@
 #include <86box/pic.h>
 #include <86box/pit.h>
 #include <86box/mem.h>
+#include <86box/memdump.h>
 #include <86box/rom.h>
 #include <86box/lpt.h>
 #include <86box/serial.h>
@@ -153,6 +154,7 @@ machine_init(void)
     if (!gdbstub_started) {
         gdbstub_started = 1;
         gdbstub_init();
+        memdump_init();
     }
 
     (void) machine_init_ex(machine);

--- a/src/memdump.c
+++ b/src/memdump.c
@@ -1,0 +1,404 @@
+/*
+ * 86Box memory dump server.
+ *
+ * A small TCP server for driving and inspecting the emulated machine
+ * from outside the guest without ever suspending the CPU.  Memory reads
+ * go straight to the emulated arrays (device pages through their
+ * mapping handlers) and I/O writes use the same outb()/outw()/outl()
+ * dispatch the CPU uses; reads may tear against the emulation thread
+ * by design.  Enable per-VM with "memdump_port = <port>" under
+ * [General] in 86box.cfg (0, the default, disables it).
+ *
+ * Line-based commands, one per line; the connection stays open until
+ * "q".  The server emits a "- " prompt when the connection opens and
+ * after every reply; every reply ends with an empty line, and bad
+ * commands answer " ^ Error".  Numbers are hex, C/assembler style:
+ * optional 0x prefix, optional trailing h/H, and addresses may be
+ * absolute or 8086 segment:offset.
+ *
+ *   d  address [length]      dump memory, DEBUG-style lines
+ *   dr address [length]      dump raw hex
+ *   o[W|D] port value        I/O output (width sensed or forced)
+ *   q                        quit
+ *   ?                        help
+ *
+ * The full protocol description, the reference clients
+ * (screenmon.py/guest_console.py) and the conformance suite live in
+ * the 86Box-tool repository (MEMDUMP.md, memdump/).
+ */
+
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <86box/io.h>
+#include <86box/86box.h>
+#include <cpu.h>
+#include <86box/mem.h>
+#include <86box/memdump.h>
+#include <86box/thread.h>
+
+#ifdef _WIN32
+#    include <winsock2.h>
+#    include <ws2tcpip.h>
+#else
+#    include <arpa/inet.h>
+#    include <netinet/in.h>
+#    include <sys/socket.h>
+#    include <unistd.h>
+#endif
+
+static int       memdump_socket = -1;
+static volatile int memdump_running = 0;
+
+/* Read one guest-physical byte without involving the CPU. */
+static uint8_t
+memdump_read_byte(uint32_t addr)
+{
+    uintptr_t      ptr = readlookup2[addr >> 12];
+    mem_mapping_t *map;
+
+    if (ptr != (uintptr_t) LOOKUP_INV)
+        return *(uint8_t *) (ptr + addr);
+
+    map = read_mapping[addr >> MEM_GRANULARITY_BITS];
+    if (map && map->read_b)
+        return map->read_b(addr, map->priv);
+
+    return 0xff;
+}
+
+/* Parse one hexadecimal number: [0x|0X] <hex digits> [h|H].
+   Returns 1 on success, with the value and the digit count. */
+static int
+memdump_parse_hex(const char *s, uint32_t *val, int *digits)
+{
+    uint32_t v = 0;
+    int      n = 0;
+
+    if ((s[0] == '0') && ((s[1] == 'x') || (s[1] == 'X')))
+        s += 2;
+
+    for (; s[n] != '\0'; n++) {
+        const char c = s[n];
+        int        d;
+
+        if ((c >= '0') && (c <= '9'))
+            d = c - '0';
+        else if ((c >= 'a') && (c <= 'f'))
+            d = (c - 'a') + 10;
+        else if ((c >= 'A') && (c <= 'F'))
+            d = (c - 'A') + 10;
+        else
+            break;
+
+        if (n >= 8)
+            return 0; /* does not fit in 32 bits */
+        v = (v << 4) | (uint32_t) d;
+    }
+
+    if (n == 0)
+        return 0;
+    if ((s[n] == 'h') || (s[n] == 'H'))
+        n++; /* skip the suffix for the junk check */
+    if (s[n] != '\0')
+        return 0; /* trailing junk */
+
+    /* The h suffix is pure decoration: the digit count decides widths. */
+    while ((n > 0) && ((s[n - 1] == 'h') || (s[n - 1] == 'H')))
+        n--;
+
+    *val    = v;
+    *digits = n;
+    return 1;
+}
+
+/* Parse an address: absolute, or 8086 segment:offset.  Segmented
+   requests report the segment and offset so dumps can label lines
+   DEBUG-style; reads always proceed linearly from (seg << 4) + off. */
+static int
+memdump_parse_address(char *s, uint32_t *addr, uint16_t *seg, uint16_t *off,
+                      int *segmented)
+{
+    char     *colon = strchr(s, ':');
+    uint32_t  part;
+    uint32_t  part2;
+    int       digits;
+
+    if (colon != NULL) {
+        *colon = '\0';
+        if (!memdump_parse_hex(s, &part, &digits)
+            || !memdump_parse_hex(colon + 1, &part2, &digits))
+            return 0;
+        *addr      = (part << 4) + part2;
+        *seg       = (uint16_t) part;
+        *off       = (uint16_t) part2;
+        *segmented = 1;
+        return 1;
+    }
+
+    if (!memdump_parse_hex(s, addr, &digits))
+        return 0;
+    *segmented = 0;
+    return 1;
+}
+
+static const char *const memdump_help[] = {
+    "dump                   D address [length]\n",
+    "dump raw               DR address [length]\n",
+    "output                 O[W|D] port value\n",
+    "quit                   Q\n",
+    "help                   ?\n",
+    NULL
+};
+
+static void
+memdump_server_thread(void *priv)
+{
+    struct sockaddr_in client_addr;
+    socklen_t          client_len = sizeof(client_addr);
+    char               request[128];
+    char               reply[4096];
+    char              *buf = NULL;
+    uint32_t           addr;
+    uint32_t           len;
+    ssize_t            n;
+
+    (void) priv;
+
+    while (memdump_running) {
+        int conn = accept(memdump_socket, (struct sockaddr *) &client_addr, &client_len);
+        if (conn < 0) {
+            if (!memdump_running)
+                break;
+            continue;
+        }
+
+        for (;;) {
+            char *save = NULL;
+            char *cmd;
+            char *arg1;
+            char *arg2;
+            char *arg3;
+
+            send(conn, "- ", 2, 0); /* DEBUG-style prompt */
+            /* Read one command line. */
+            n = 0;
+            while (n < (ssize_t) (sizeof(request) - 1)) {
+                ssize_t r = recv(conn, request + n, 1, 0);
+                if (r <= 0)
+                    goto close_conn;
+                if (request[n] == '\n')
+                    break;
+                if (request[n] != '\r')
+                    n += r;
+            }
+            request[n] = '\0';
+
+            cmd = strtok_r(request, " \t", &save);
+            if (cmd == NULL) {
+                send(conn, " ^ Error\n\n", 10, 0);
+                continue;
+            }
+
+            if (!strcasecmp(cmd, "q"))
+                break; /* close the connection */
+
+            if (!strcmp(cmd, "?")) {
+                for (int i = 0; memdump_help[i] != NULL; i++)
+                    send(conn, memdump_help[i], (int) strlen(memdump_help[i]), 0);
+                send(conn, "\n", 1, 0);
+            } else if (!strcasecmp(cmd, "d") || !strcasecmp(cmd, "dr")) {
+                const int   raw = !strcasecmp(cmd, "dr");
+                uint16_t    seg = 0;
+                uint16_t    off = 0;
+                int         segmented = 0;
+                uint32_t    v;
+                int         digits;
+
+                arg1 = strtok_r(NULL, " \t", &save);
+                arg2 = strtok_r(NULL, " \t", &save);
+                arg3 = strtok_r(NULL, " \t", &save);
+
+                if ((arg1 == NULL) || (arg3 != NULL)
+                    || !memdump_parse_address(arg1, &addr, &seg, &off, &segmented)) {
+                    send(conn, " ^ Error\n\n", 10, 0);
+                    continue;
+                }
+
+                len = 128; /* DEBUG's default */
+                if ((arg2 != NULL) && !memdump_parse_hex(arg2, &v, &digits)) {
+                    send(conn, " ^ Error\n\n", 10, 0);
+                    continue;
+                }
+                if (arg2 != NULL)
+                    len = v;
+                if (len > 0x1000)
+                    len = 0x1000;
+
+                if (raw) {
+                    if (len * 2 + 1 <= sizeof(reply)) {
+                        for (uint32_t i = 0; i < len; i++)
+                            sprintf(reply + i * 2, "%02x", memdump_read_byte(addr + i));
+                        send(conn, reply, (int) (len * 2), 0);
+                    } else {
+                        buf = (char *) malloc((size_t) len * 2 + 1);
+                        if (buf != NULL) {
+                            for (uint32_t i = 0; i < len; i++)
+                                sprintf(buf + i * 2, "%02x", memdump_read_byte(addr + i));
+                            send(conn, buf, (int) (len * 2), 0);
+                            free(buf);
+                        }
+                    }
+                } else {
+                    /* DEBUG-style: address column, hex with a dash
+                       between bytes 8 and 9, then ASCII with '.' for
+                       non-printables.  Segmented requests label lines
+                       SEG:OFF (segment fixed, offset wrapping mod 64K,
+                       like DEBUG); absolute requests label lines with
+                       the 32-bit linear address.  Reads always advance
+                       linearly either way. */
+                    buf = (char *) malloc((((size_t) len + 15) >> 4) * 80 + 1);
+                    if (buf != NULL) {
+                        char *p = buf;
+
+                        for (uint32_t i = 0; i < len; i += 16) {
+                            const int n = ((len - i) < 16) ? (int) (len - i) : 16;
+
+                            if (segmented)
+                                p += sprintf(p, "%04X:%04X  ", (unsigned) seg,
+                                             (unsigned) ((off + i) & 0xffff));
+                            else
+                                p += sprintf(p, "%08X  ", (unsigned) (addr + i));
+
+                            for (int j = 0; j < 16; j++) {
+                                if (j > 0)
+                                    *p++ = (j == 8) ? '-' : ' ';
+                                if (j < n)
+                                    p += sprintf(p, "%02X", memdump_read_byte(addr + i + j));
+                                else
+                                    p += sprintf(p, "  ");
+                            }
+
+                            p += sprintf(p, "   ");
+                            for (int j = 0; j < n; j++) {
+                                const uint8_t b = memdump_read_byte(addr + i + j);
+                                *p++ = ((b >= 0x20) && (b < 0x7f)) ? (char) b : '.';
+                            }
+                            *p++ = '\n';
+                        }
+                        send(conn, buf, (int) (p - buf), 0);
+                        free(buf);
+                    }
+                }
+                send(conn, "\n", 1, 0);
+            } else if (!strcasecmp(cmd, "o") || !strcasecmp(cmd, "ow")
+                       || !strcasecmp(cmd, "od")) {
+                const int force_word = !strcasecmp(cmd, "ow");
+                const int force_dword = !strcasecmp(cmd, "od");
+                uint32_t port;
+                uint32_t val;
+                int      digits;
+
+                arg1 = strtok_r(NULL, " \t", &save);
+                arg2 = strtok_r(NULL, " \t", &save);
+                arg3 = strtok_r(NULL, " \t", &save);
+
+                if ((arg1 == NULL) || (arg2 == NULL) || (arg3 != NULL)
+                    || !memdump_parse_hex(arg1, &port, &digits)
+                    || !memdump_parse_hex(arg2, &val, &digits)) {
+                    send(conn, " ^ Error\n\n", 10, 0);
+                    continue;
+                }
+
+                /* Access width: OW and OD force a width; plain O senses
+                   it from the digit count and the value (8 digits or
+                   >16 bits = dword, >=3 digits or >8 bits = word,
+                   otherwise byte). */
+                if (force_dword || (!force_word
+                                    && ((digits >= 8) || (val > 0xffff))))
+                    outl((uint16_t) port, val);
+                else if (force_word || (digits >= 3) || (val > 0xff))
+                    outw((uint16_t) port, (uint16_t) val);
+                else
+                    outb((uint16_t) port, (uint8_t) val);
+
+                send(conn, "ok\n\n", 4, 0);
+            } else {
+                send(conn, " ^ Error\n\n", 10, 0);
+            }
+        }
+
+close_conn:
+#ifdef _WIN32
+        closesocket(conn);
+#else
+        close(conn);
+#endif
+    }
+}
+
+void
+memdump_init(void)
+{
+    struct sockaddr_in bind_addr;
+
+    if (memdump_port <= 0)
+        return;
+
+#ifdef _WIN32
+    WSADATA wsa;
+    WSAStartup(MAKEWORD(2, 2), &wsa);
+#endif
+
+    memdump_socket = socket(AF_INET, SOCK_STREAM, 0);
+    if (memdump_socket == -1) {
+        pclog("MemDump: failed to create socket\n");
+        return;
+    }
+
+    int yes = 1;
+    setsockopt(memdump_socket, SOL_SOCKET, SO_REUSEADDR,
+#ifdef _WIN32
+               (const char *) &yes,
+#else
+               &yes,
+#endif
+               sizeof(yes));
+
+    bind_addr.sin_family      = AF_INET;
+    bind_addr.sin_addr.s_addr = INADDR_ANY;
+    bind_addr.sin_port        = htons((uint16_t) memdump_port);
+
+    if (bind(memdump_socket, (struct sockaddr *) &bind_addr, sizeof(bind_addr)) == -1) {
+        pclog("MemDump: failed to bind on port %d\n", memdump_port);
+        return;
+    }
+    if (listen(memdump_socket, 1) == -1) {
+        pclog("MemDump: failed to listen on port %d\n", memdump_port);
+        return;
+    }
+
+    memdump_running = 1;
+    pclog("MemDump: Listening on port %d\n", memdump_port);
+    thread_create(memdump_server_thread, NULL);
+}
+
+void
+memdump_close(void)
+{
+    if (memdump_socket < 0)
+        return;
+
+    memdump_running = 0;
+#ifdef _WIN32
+    shutdown(memdump_socket, SD_BOTH);
+    closesocket(memdump_socket);
+    WSACleanup();
+#else
+    shutdown(memdump_socket, SHUT_RDWR);
+    close(memdump_socket);
+#endif
+    memdump_socket = -1;
+}


### PR DESCRIPTION
Summary
=======

This adds a small service that can be used to inspect a live, running VM without suspending it or otherwise interfering with the emulation; it allows memory to read and data to be written to an I/O port.

The user interface is similar to DOS `DEBUG`, and is set via a TCP/IP port exposed via `memdump_port = 12345`, similar in fashion to the gdb port option. Unlike the gdb option or builds with gdb enabled, it will not have the side effect that a VM is not running upon start, so this code is more suitable for general release builds.

The interface can be connected to with something like `netcat` or telnet; a short help message is offered with the `?` command. An example of intended use of this is in the 86Box-tool project at <https://github.com/JoshRodd/86Box-tool>; it's intended that other developers of testing tools, automation, and CI/CD builds will want to use a feature like this.

Future work could include providing a more gdb-like interface and/or providing more of the DOS DEBUG commands.

This original feature was written without AI assistance. Improvements, testing, and bugfixes were done using AI extensively. This PR was not written with any AI assistance.

Checklist
=========
* [X] Closes #xxx - N/A, no issue was created for this PR
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set - N/A, no ROM changes needed
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set - N/A, no asset changes needed
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency - N/A, no external dependencies
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
DEBUG commands based on DEBUGX documentation:

https://pcdosretro.gitlab.io/enhdebug.htm