### PR TITLE
Network: Add IBM PS/2 Ethernet Adapter variants (EFE5, EFD5, EFD4)

### DIFF
--- a/src/include/86box/net_wd8003.h
+++ b/src/include/86box/net_wd8003.h
@@ -42,13 +42,16 @@
 #define NET_WD8003_H
 
 enum {
-    WD_NONE   = 0,
-    WD8003E   = 1, /* WD8003E   :  8-bit ISA, no  interface chip */
-    WD8003EB  = 2, /* WD8003EB  :  8-bit ISA, 5x3 interface chip */
-    WD8013EBT = 3, /* WD8013EBT : 16-bit ISA, no  interface chip */
-    WD8003ETA = 4, /* WD8003ET/A: 16-bit MCA, no  interface chip */
-    WD8003EA  = 5, /* WD8003E/A : 16-bit MCA, 5x3 interface chip */
-    WD8013EPA = 6
+    WD_NONE       = 0,
+    WD8003E       = 1, /* WD8003E   :  8-bit ISA, no  interface chip */
+    WD8003EB      = 2, /* WD8003EB  :  8-bit ISA, 5x3 interface chip */
+    WD8013EBT     = 3, /* WD8013EBT : 16-bit ISA, no  interface chip */
+    WD8003ETA     = 4, /* WD8003ET/A: 16-bit MCA, no  interface chip */
+    WD8003EA      = 5, /* WD8003E/A : 16-bit MCA, 5x3 interface chip */
+    WD8013EPA     = 6,
+    WD8013WPA_IBM = 7, /* IBM EFD4: 8013W, 594-style POS */
+    WD8013EPA_IBM = 8, /* IBM EFD5: 8013EP, 594-style POS */
+    WD8003EA_IBM  = 9  /* IBM EFE5: 8003E, older POS layout */
 };
 
 #endif /*NET_WD8003_H*/

--- a/src/include/86box/network.h
+++ b/src/include/86box/network.h
@@ -268,6 +268,9 @@ extern const device_t wd8013ebt_device;
 extern const device_t wd8003eta_device;
 extern const device_t wd8003ea_device;
 extern const device_t wd8013epa_device;
+extern const device_t ibm_ethernet_efd4_device;
+extern const device_t ibm_ethernet_efd5_device;
+extern const device_t ibm_ethernet_efe5_device;
 #endif
 
 #ifdef __cplusplus

--- a/src/network/net_wd8003.c
+++ b/src/network/net_wd8003.c
@@ -676,8 +676,11 @@ wd_init(const device_t *info)
         dev->maclocal[5] = (mac & 0xff);
     }
 
-    if ((dev->board == WD8003ETA) || (dev->board == WD8003EA) || dev->board == WD8013EPA) {
-        if (dev->board == WD8013EPA)
+    if ((dev->board == WD8003ETA) || (dev->board == WD8003EA) ||
+        (dev->board == WD8013EPA) || (dev->board == WD8013WPA_IBM) ||
+        (dev->board == WD8013EPA_IBM) || (dev->board == WD8003EA_IBM)) {
+        if ((dev->board == WD8013EPA) || (dev->board == WD8013WPA_IBM) ||
+            (dev->board == WD8013EPA_IBM))
             mca_add(wd_mca_read, wd_8013epa_mca_write, wd_mca_feedb, NULL, dev);
         else
             mca_add(wd_mca_read, wd_mca_write, wd_mca_feedb, NULL, dev);
@@ -748,6 +751,33 @@ wd_init(const device_t *info)
             dev->ram_size    = device_get_config_int("ram_size");
             dev->pos_regs[0] = 0xC8;
             dev->pos_regs[1] = 0x61;
+            dev->bit16       = 3;
+            break;
+
+        /* IBM EFE5: ENA 03E / WD8003E/A (AUI/BNC), with the older WD8003-style POS layout. */
+        case WD8003EA_IBM:
+            dev->board_chip  = WE_TYPE_WD8003EB | WE_ID_BUS_MCA;
+            dev->ram_size    = 0x4000;
+            dev->pos_regs[0] = 0xe5;
+            dev->pos_regs[1] = 0xef;
+            dev->bit16       = 3;
+            break;
+
+        /* IBM EFD5: ENA 13E / WD8013EP/A (AUI/BNC), with the 594-style POS layout. */
+        case WD8013EPA_IBM:
+            dev->board_chip  = WE_TYPE_WD8013EP | WE_ID_BUS_MCA;
+            dev->ram_size    = 0x4000;
+            dev->pos_regs[0] = 0xd5;
+            dev->pos_regs[1] = 0xef;
+            dev->bit16       = 3;
+            break;
+
+        /* IBM EFD4: ENA 13W / WD8013WP/A (AUI/RJ-45), FRU 92F0046, with the 594-style POS layout. */
+        case WD8013WPA_IBM:
+            dev->board_chip  = WE_TYPE_WD8013W | WE_ID_BUS_MCA;
+            dev->ram_size    = 0x4000;
+            dev->pos_regs[0] = 0xd4;
+            dev->pos_regs[1] = 0xef;
             dev->bit16       = 3;
             break;
 
@@ -1187,4 +1217,46 @@ const device_t wd8013epa_device = {
     .speed_changed = NULL,
     .force_redraw  = NULL,
     .config        = wd8013epa_config
+};
+
+const device_t ibm_ethernet_efd4_device = {
+    .name          = "IBM PS/2 Adapter/A for Ethernet Networks (WD8013WP/A, AUI/RJ-45, EFD4/92F0046)",
+    .internal_name = "ibm_ethernet_92f0046",
+    .flags         = DEVICE_MCA,
+    .local         = WD8013WPA_IBM,
+    .init          = wd_init,
+    .close         = wd_close,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = mca_mac_config
+};
+
+const device_t ibm_ethernet_efd5_device = {
+    .name          = "IBM PS/2 Adapter/A for Ethernet Networks (WD8013EP/A, AUI/BNC, EFD5)",
+    .internal_name = "ibm_ethernet_efd5",
+    .flags         = DEVICE_MCA,
+    .local         = WD8013EPA_IBM,
+    .init          = wd_init,
+    .close         = wd_close,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = mca_mac_config
+};
+
+const device_t ibm_ethernet_efe5_device = {
+    .name          = "IBM PS/2 Adapter/A for Ethernet Networks (WD8003E/A, AUI/BNC, EFE5)",
+    .internal_name = "ibm_ethernet_efe5",
+    .flags         = DEVICE_MCA,
+    .local         = WD8003EA_IBM,
+    .init          = wd_init,
+    .close         = wd_close,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = mca_mac_config
 };

--- a/src/network/network.c
+++ b/src/network/network.c
@@ -113,6 +113,9 @@ static const NETWORK_CARD net_cards[] = {
     { &wd8003ea_device            },
     { &wd8003eta_device           },
     { &wd8013epa_device           },
+    { &ibm_ethernet_efe5_device   },
+    { &ibm_ethernet_efd5_device   },
+    { &ibm_ethernet_efd4_device   },
     /* VLB */
     { &pcnet_am79c960_vlb_device  },
     /* PCI */


### PR DESCRIPTION
Summary
=======

This creates adapter types for Microchannel bus machines that match IBM's "PS/2 Adapter/A for Ethernet Networks" (which is rather confusingly named) which is yet another WD80x3 chipset-based Ethernet adapter. It has been tested that it works properly under Windows for Workgroups 3.11, AIX PS/2 1.3 (limited testing), OS/2 1.3 Extended Edition, OS/2 1.3 with IBM TCP/IP 1.2.1, and OS/2 4.52 ("Convenience Pack 2").

The main purpose of this is to be able to use AIX PS/2 or obscure network software stacks on OS/2 that only support these card, but don't support the otherwise identical WD cards with a different ADF adapter ID.

The ADFs were tested that are commonly available on the Ardent-Tool website. In addition, the AIX PS/2 driver was analysed in order to fill in some gaps about specific POS register assignments.

This PR and the code was not generated with AI assistance. AI assistance was used extensively for analysis, design, and testing.

Checklist
=========
* [X] Closes # -- see 2026-08-03 discussoin under #4823 
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set - no
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set - no
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
Refer to https://www.ardent-tool.com/AIX_1-3/AIX_NICs.html
