### PR TITLE
Add the BCM IN530 machine and the ESS Solo-1 Standalone Card

### DIFF
--- a/src/acpi.c
+++ b/src/acpi.c
@@ -2494,6 +2494,10 @@ acpi_reset(void *priv)
         dev->regs.gp_tmr = 0xff;
         dev->regs.gpe_io = 0x00030b9f;
         dev->regs.gpe_mul = 0x1001;
+
+        /* Fix for the IN530 CMOS reset jumper */
+        if (machines[machine].init == machine_at_in530_init)
+            dev->regs.gpe_pin = 0x0003ffff;
     }
 }
 

--- a/src/chipset/CMakeLists.txt
+++ b/src/chipset/CMakeLists.txt
@@ -70,6 +70,8 @@ add_library(chipset OBJECT
     sis_85c50x.c
     sis_5511.c
     sis_5571.c
+    sis_530.c
+    sis_530_h2p.c
     sis_5581.c
     sis_5591.c
     sis_5600.c

--- a/src/chipset/sis_530.c
+++ b/src/chipset/sis_530.c
@@ -1,0 +1,193 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          Implementation of the SiS 530/5595 Chipset.
+ *
+ * Authors: mw308
+ *
+ *          Copyright 2026 mw308
+ */
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+#define HAVE_STDARG_H
+#include <86box/86box.h>
+#include <86box/device.h>
+#include <86box/io.h>
+#include <86box/timer.h>
+#include <86box/mem.h>
+#include <86box/nvr.h>
+#include <86box/apm.h>
+#include <86box/acpi.h>
+#include <86box/keyboard.h>
+#include <86box/hdd.h>
+#include <86box/hdc.h>
+#include <86box/hdc_ide.h>
+#include <86box/hdc_ide_sff8038i.h>
+#include <86box/pci.h>
+#include <86box/pic.h>
+#include <86box/pit.h>
+#include <86box/pit_fast.h>
+#include <86box/plat.h>
+#include <86box/plat_unused.h>
+#include <86box/port_92.h>
+#include <86box/smram.h>
+#include <86box/spd.h>
+#include <86box/sis_55xx.h>
+#include <86box/chipset.h>
+
+#ifdef ENABLE_SIS_530_LOG
+int sis_530_do_log = ENABLE_SIS_530_LOG;
+
+static void
+sis_530_log(const char *fmt, ...)
+{
+    va_list ap;
+
+    if (sis_530_do_log) {
+        va_start(ap, fmt);
+        pclog_ex(fmt, ap);
+        va_end(ap);
+    }
+}
+#else
+#    define sis_530_log(fmt, ...)
+#endif
+
+typedef struct sis_530_t {
+    uint8_t            nb_slot;
+    uint8_t            sb_slot;
+
+    void              *h2p;
+    void              *p2i;
+    void              *ide;
+    void              *usb;
+    void              *pmu;
+
+    sis_55xx_common_t *sis;
+} sis_530_t;
+
+static void
+sis_530_write(int func, int addr, UNUSED(int len), uint8_t val, void *priv)
+{
+    const sis_530_t *dev = (sis_530_t *) priv;
+
+    sis_530_log("SiS 530: [W] dev->pci_conf[%02X] = %02X\n", addr, val);
+
+    if (func == 0x00)
+        sis_530_host_to_pci_write(addr, val, dev->h2p);
+    else if (func == 0x01)
+        sis_5513_ide_write(addr, val, dev->ide);
+}
+
+static uint8_t
+sis_530_read(int func, int addr, UNUSED(int len), void *priv)
+{
+    const sis_530_t *dev = (sis_530_t *) priv;
+    uint8_t ret = 0xff;
+
+    if (func == 0x00)
+        ret = sis_530_host_to_pci_read(addr, dev->h2p);
+    else if (func == 0x01)
+        ret = sis_5513_ide_read(addr, dev->ide);
+
+    sis_530_log("SiS 530: [R] dev->pci_conf[%02X] = %02X\n", addr, ret);
+
+    return ret;
+}
+
+static void
+sis_5595_write(int func, int addr, UNUSED(int len), uint8_t val, void *priv)
+{
+    const sis_530_t *dev = (sis_530_t *) priv;
+
+    sis_530_log("SiS 5595: [W] dev->pci_conf[%02X] = %02X\n", addr, val);
+
+    switch (func) {
+        case 0x00:
+            sis_5513_pci_to_isa_write(addr, val, dev->p2i);
+            break;
+        case 0x01:
+            sis_5595_pmu_write(addr, val, dev->pmu);
+            break;
+        case 0x02:
+            sis_5572_usb_write(addr, val, dev->usb);
+            break;
+    }
+}
+
+static uint8_t
+sis_5595_read(int func, int addr, UNUSED(int len), void *priv)
+{
+    const sis_530_t *dev = (sis_530_t *) priv;
+    uint8_t ret = 0xff;
+
+    switch (func) {
+        case 0x00:
+            ret = sis_5513_pci_to_isa_read(addr, dev->p2i);
+            break;
+        case 0x01:
+            ret = sis_5595_pmu_read(addr, dev->pmu);
+            break;
+        case 0x02:
+            ret = sis_5572_usb_read(addr, dev->usb);
+            break;
+    }
+
+    sis_530_log("SiS 5595: [R] dev->pci_conf[%02X] = %02X\n", addr, ret);
+
+    return ret;
+}
+
+static void
+sis_530_close(void *priv)
+{
+    sis_530_t *dev = (sis_530_t *) priv;
+
+    free(dev);
+}
+
+static void *
+sis_530_init(UNUSED(const device_t *info))
+{
+    sis_530_t *dev = (sis_530_t *) calloc(1, sizeof(sis_530_t));
+
+    /* Device 0: SiS 530 */
+    pci_add_card(PCI_ADD_NORTHBRIDGE, sis_530_read, sis_530_write, dev, &dev->nb_slot);
+    /* Device 1: SiS 5595 */
+    pci_add_card(PCI_ADD_SOUTHBRIDGE, sis_5595_read, sis_5595_write, dev, &dev->sb_slot);
+
+    dev->sis = device_add(&sis_55xx_common_device);
+
+    dev->ide = device_add_linked(&sis_5591_5600_ide_device, dev->sis);
+    dev->p2i = device_add_linked(&sis_5595_p2i_device, dev->sis);
+    dev->h2p = device_add_linked(&sis_530_h2p_device, dev->sis);
+    dev->usb = device_add_linked(&sis_5595_usb_device, dev->sis);
+    dev->pmu = device_add_linked(&sis_5595_pmu_device, dev->sis);
+
+    device_add_params(&kbc_at_device, (void *) KBC_VEN_SIS);
+
+    return dev;
+}
+
+const device_t sis_530_device = {
+    .name          = "SiS 530/5595",
+    .internal_name = "sis_530",
+    .flags         = DEVICE_PCI,
+    .local         = 0,
+    .init          = sis_530_init,
+    .close         = sis_530_close,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = NULL
+};

--- a/src/chipset/sis_530_h2p.c
+++ b/src/chipset/sis_530_h2p.c
@@ -1,0 +1,496 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          Implementation of the SiS 530 Host to PCI bridge.
+ *
+ * Authors: mw308
+ *
+ *          Copyright 2026 mw308
+ */
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+#define HAVE_STDARG_H
+#include <86box/86box.h>
+#include <86box/device.h>
+#include <86box/io.h>
+#include "cpu.h"
+#include <86box/timer.h>
+#include <86box/dma.h>
+#include <86box/mem.h>
+#include <86box/nvr.h>
+#include <86box/hdd.h>
+#include <86box/hdc.h>
+#include <86box/hdc_ide.h>
+#include <86box/hdc_ide_sff8038i.h>
+#include <86box/pci.h>
+#include <86box/pic.h>
+#include <86box/pit.h>
+#include <86box/pit_fast.h>
+#include <86box/plat.h>
+#include <86box/plat_unused.h>
+#include <86box/port_92.h>
+#include <86box/smram.h>
+#include <86box/spd.h>
+#include <86box/apm.h>
+#include <86box/ddma.h>
+#include <86box/acpi.h>
+#include <86box/smbus.h>
+#include <86box/sis_55xx.h>
+#include <86box/chipset.h>
+#include <86box/usb.h>
+#include <86box/agpgart.h>
+
+#ifdef ENABLE_SIS_530_HOST_TO_PCI_LOG
+int sis_530_host_to_pci_do_log = ENABLE_SIS_530_HOST_TO_PCI_LOG;
+
+static void
+sis_530_host_to_pci_log(const char *fmt, ...)
+{
+    va_list ap;
+
+    if (sis_530_host_to_pci_do_log) {
+        va_start(ap, fmt);
+        pclog_ex(fmt, ap);
+        va_end(ap);
+    }
+}
+#else
+#    define sis_530_host_to_pci_log(fmt, ...)
+#endif
+
+typedef struct {
+    uint8_t  installed;
+    uint8_t  code;
+    uint32_t phys_size;
+} ram_bank_t;
+
+typedef struct sis_530_host_to_pci_t {
+    uint8_t            pci_conf[256];
+
+    uint8_t            states[7];
+    uint8_t            states_bus[7];
+
+    ram_bank_t         ram_banks[3];
+
+    sis_55xx_common_t *sis;
+
+    smram_t           *smram;
+
+    agpgart_t         *agpgart;
+} sis_530_host_to_pci_t;
+
+static uint8_t  bank_codes[6] = { 0x00, 0x20, 0x24, 0x22, 0x26, 0x2a };
+
+static uint32_t bank_sizes[6] = { 0x00800000,      /*   8 MB */
+                                  0x01000000,      /*  16 MB */
+                                  0x02000000,      /*  32 MB */
+                                  0x04000000,      /*  64 MB */
+                                  0x08000000,      /* 128 MB */
+                                  0x10000000 };    /* 256 MB */
+
+static void
+sis_530_shadow_recalc(sis_530_host_to_pci_t *dev)
+{
+    uint32_t base;
+    uint32_t state;
+    uint8_t  val;
+
+    for (uint8_t i = 0x70; i <= 0x76; i++) {
+        if (i == 0x76) {
+            val = dev->pci_conf[i];
+            if ((dev->states[i & 0x0f] ^ val) & 0xa0) {
+                state = (val & 0x80) ? MEM_READ_INTERNAL : MEM_READ_EXTANY;
+                state |= (val & 0x20) ? MEM_WRITE_INTERNAL : MEM_WRITE_EXTANY;
+                mem_set_mem_state_cpu_both(0xf0000, 0x10000, state);
+                sis_530_host_to_pci_log("000F0000-000FFFFF\n");
+
+                dev->states[i & 0x0f] = val;
+            }
+
+            if (!(dev->pci_conf[0x76] & 0x08))
+                val &= 0x5f;
+            if ((dev->states_bus[i & 0x0f] ^ val) & 0xa0) {
+                state = (val & 0x80) ? MEM_READ_INTERNAL : MEM_READ_EXTANY;
+                state |= (val & 0x20) ? MEM_WRITE_INTERNAL : MEM_WRITE_EXTANY;
+                mem_set_mem_state_bus_both(0xf0000, 0x10000, state);
+                sis_530_host_to_pci_log("000F0000-000FFFFF\n");
+
+                dev->states_bus[i & 0x0f] = val;
+            }
+        } else {
+            base = ((i & 0x07) << 15) + 0xc0000;
+
+            val = dev->pci_conf[i];
+            if ((dev->states[i & 0x0f] ^ val) & 0xa0) {
+                state = (val & 0x80) ? MEM_READ_INTERNAL : MEM_READ_EXTANY;
+                state |= (val & 0x20) ? MEM_WRITE_INTERNAL : MEM_WRITE_EXTANY;
+                mem_set_mem_state_cpu_both(base, 0x4000, state);
+                sis_530_host_to_pci_log("%08X-%08X\n", base, base + 0x3fff);
+
+                dev->states[i & 0x0f] = (dev->states[i & 0x0f] & 0x0f) | (val & 0xf0);
+            }
+            if ((dev->states[i & 0x0f] ^ val) & 0x0a) {
+                state = (val & 0x08) ? MEM_READ_INTERNAL : MEM_READ_EXTANY;
+                state |= (val & 0x02) ? MEM_WRITE_INTERNAL : MEM_WRITE_EXTANY;
+                mem_set_mem_state_cpu_both(base + 0x4000, 0x4000, state);
+                sis_530_host_to_pci_log("%08X-%08X\n", base + 0x4000, base + 0x7fff);
+
+                dev->states[i & 0x0f] = (dev->states[i & 0x0f] & 0xf0) | (val & 0x0f);
+            }
+
+            if (!(dev->pci_conf[0x76] & 0x08))
+                val &= 0x55;
+            if ((dev->states_bus[i & 0x0f] ^ val) & 0xa0) {
+                state = (val & 0x80) ? MEM_READ_INTERNAL : MEM_READ_EXTANY;
+                state |= (val & 0x20) ? MEM_WRITE_INTERNAL : MEM_WRITE_EXTANY;
+                mem_set_mem_state_bus_both(base, 0x4000, state);
+                sis_530_host_to_pci_log("%08X-%08X\n", base, base + 0x3fff);
+
+                dev->states_bus[i & 0x0f] = (dev->states_bus[i & 0x0f] & 0x0f) | (val & 0xf0);
+            }
+            if ((dev->states_bus[i & 0x0f] ^ val) & 0x0a) {
+                state = (val & 0x08) ? MEM_READ_INTERNAL : MEM_READ_EXTANY;
+                state |= (val & 0x02) ? MEM_WRITE_INTERNAL : MEM_WRITE_EXTANY;
+                mem_set_mem_state_bus_both(base + 0x4000, 0x4000, state);
+                sis_530_host_to_pci_log("%08X-%08X\n", base + 0x4000, base + 0x7fff);
+
+                dev->states_bus[i & 0x0f] = (dev->states_bus[i & 0x0f] & 0xf0) | (val & 0x0f);
+            }
+        }
+    }
+
+    flushmmucache_nopc();
+}
+
+static void
+sis_530_smram_recalc(sis_530_host_to_pci_t *dev)
+{
+    smram_disable_all();
+
+    switch (dev->pci_conf[0x68] >> 6) {
+        case 0:
+            smram_enable(dev->smram, 0x000e0000, 0x000e0000, 0x8000, dev->pci_conf[0x68] & 0x10, 1);
+            break;
+        case 1:
+            smram_enable(dev->smram, 0x000e0000, 0x000a0000, 0x8000, dev->pci_conf[0x68] & 0x10, 1);
+            break;
+        case 2:
+            smram_enable(dev->smram, 0x000e0000, 0x000b0000, 0x8000, dev->pci_conf[0x68] & 0x10, 1);
+            break;
+        case 3:
+            smram_enable(dev->smram, 0x000a0000, 0x000a0000, 0x10000, dev->pci_conf[0x68] & 0x10, 1);
+            break;
+
+        default:
+            break;
+    }
+
+    flushmmucache();
+}
+
+static void
+sis_530_mask_bar(uint8_t *regs, void *agpgart)
+{
+    uint32_t bar;
+    uint32_t sizes[8] = { 0x00400000, 0x00800000, 0x01000000, 0x02000000, 0x04000000, 0x08000000,
+                          0x10000000, 0x00000000 } ;
+
+    /* Make sure the aperture's base is aligned to its size. */
+    bar = (regs[0x13] << 24) | (regs[0x12] << 16);
+    bar &= (sizes[(regs[0x94] >> 4) & 0x07] | 0xf0000000);
+    regs[0x12] = (bar >> 16) & 0xff;
+    regs[0x13] = (bar >> 24) & 0xff;
+
+    if (!agpgart)
+        return;
+
+    /* Map aperture and GART. */
+    agpgart_set_aperture(agpgart,
+                         bar,
+                         sizes[(regs[0x94] >> 4) & 0x07],
+                         !!(regs[0x94] & 0x02));
+    if (regs[0x94] & 0x01)
+        agpgart_set_gart(agpgart, (regs[0x91] << 8) | (regs[0x92] << 16) | (regs[0x93] << 24));
+    else
+        agpgart_set_gart(agpgart, 0x00000000);
+}
+
+void
+sis_530_host_to_pci_write(int addr, uint8_t val, void *priv)
+{
+    sis_530_host_to_pci_t *dev = (sis_530_host_to_pci_t *) priv;
+
+    sis_530_host_to_pci_log("SiS 530 H2P: [W] dev->pci_conf[%02X] = %02X\n", addr, val);
+
+    switch (addr) {
+        default:
+            break;
+
+        case 0x04: /* Command - Low Byte */
+            dev->pci_conf[addr] = (dev->pci_conf[addr] & 0xfd) | (val & 0x02);
+            break;
+        case 0x05: /* Command - High Byte */
+            dev->pci_conf[addr] = val & 0x03;
+            break;
+
+        case 0x07: /* Status - High Byte */
+            dev->pci_conf[addr] &= ~(val & 0xf0);
+            break;
+
+        case 0x12:
+            dev->pci_conf[addr] = val & 0xc0;
+            sis_530_mask_bar(dev->pci_conf, dev->agpgart);
+            break;
+        case 0x13:
+            dev->pci_conf[addr] = val;
+            sis_530_mask_bar(dev->pci_conf, dev->agpgart);
+            break;
+
+        case 0x51:
+            dev->pci_conf[addr] = val;
+            cpu_cache_ext_enabled = !!(val & 0x80);
+            cpu_update_waitstates();
+            break;
+
+        case 0x60 ... 0x62:
+            dev->pci_conf[addr] = dev->ram_banks[addr & 0x0f].code | 0xc0;
+            break;
+
+        case 0x63:
+            dev->pci_conf[addr] = dev->ram_banks[0].installed |
+                                  (dev->ram_banks[1].installed << 1) |
+                                  (dev->ram_banks[2].installed << 2);
+            break;
+
+        case 0x68:
+            dev->pci_conf[addr] = val;
+            sis_530_smram_recalc(dev);
+            break;
+
+        case 0x70 ... 0x75:
+            dev->pci_conf[addr] = val & 0xee;
+            sis_530_shadow_recalc(dev);
+            break;
+        case 0x76:
+            dev->pci_conf[addr] = val & 0xe8;
+            sis_530_shadow_recalc(dev);
+            break;
+
+        case 0x0d: /* Master latency timer */
+        case 0x50:
+        case 0x52:
+        case 0x54 ... 0x5a:
+        case 0x5c ... 0x5f:
+        case 0x64 ... 0x65:
+        case 0x69 ... 0x6c:
+        case 0x77 ... 0x7b:
+        case 0x80 ... 0x8d:
+        case 0x90:
+        case 0x97 ... 0xab:
+        case 0xb0:
+        case 0xc8 ... 0xcb:
+        case 0xd4 ... 0xda:
+        case 0xe0 ... 0xe3:
+        case 0xef:
+            dev->pci_conf[addr] = val;
+            break;
+
+        case 0x91 ... 0x93:
+            dev->pci_conf[addr] = val;
+            sis_530_mask_bar(dev->pci_conf, dev->agpgart);
+            break;
+        case 0x94:
+            dev->pci_conf[addr] = val & 0x7f;
+            sis_530_mask_bar(dev->pci_conf, dev->agpgart);
+            break;
+
+        case 0xb2:
+            dev->pci_conf[addr] &= ~(val & 0x01);
+            break;
+    }
+}
+
+uint8_t
+sis_530_host_to_pci_read(int addr, void *priv)
+{
+    const sis_530_host_to_pci_t *dev = (sis_530_host_to_pci_t *) priv;
+    uint8_t ret = 0xff;
+
+    ret = dev->pci_conf[addr];
+
+    sis_530_host_to_pci_log("SiS 530 H2P: [R] dev->pci_conf[%02X] = %02X\n", addr, ret);
+
+    return ret;
+}
+
+static void
+sis_530_host_to_pci_reset(void *priv)
+{
+    sis_530_host_to_pci_t *dev = (sis_530_host_to_pci_t *) priv;
+
+    unmask_a20_in_smm = 1;
+
+    dev->pci_conf[0x00] = 0x39;
+    dev->pci_conf[0x01] = 0x10;
+    dev->pci_conf[0x02] = 0x30;
+    dev->pci_conf[0x03] = 0x05;
+    dev->pci_conf[0x04] = 0x05;
+    dev->pci_conf[0x05] = 0x00;
+    dev->pci_conf[0x06] = 0x10;
+    dev->pci_conf[0x07] = 0x02;
+    dev->pci_conf[0x08] = 0x02;
+    dev->pci_conf[0x09] = dev->pci_conf[0x0a] = 0x00;
+    dev->pci_conf[0x0b] = 0x06;
+    dev->pci_conf[0x0c] = 0x00;
+    dev->pci_conf[0x0d] = 0xff;
+    dev->pci_conf[0x0e] = 0x80;
+    dev->pci_conf[0x0f] = 0x00;
+    dev->pci_conf[0x10] = dev->pci_conf[0x11] = 0x00;
+    dev->pci_conf[0x12] = dev->pci_conf[0x13] = 0x00;
+    dev->pci_conf[0x34] = 0xc0;
+    dev->pci_conf[0x50] = 0x00;
+    dev->pci_conf[0x51] = 0x18;
+    dev->pci_conf[0x52] = dev->pci_conf[0x54] = 0x00;
+    dev->pci_conf[0x55] = 0x0e;
+    dev->pci_conf[0x56] = 0x40;
+    dev->pci_conf[0x57] = 0x00;
+    dev->pci_conf[0x58] = 0x50;
+    dev->pci_conf[0x59] = dev->pci_conf[0x5a] = 0x00;
+    dev->pci_conf[0x5c] = dev->pci_conf[0x5d] = 0x00;
+    dev->pci_conf[0x5e] = dev->pci_conf[0x5f] = 0x00;
+    dev->pci_conf[0x60] = dev->pci_conf[0x61] = 0x00;
+    dev->pci_conf[0x62] = 0x00;
+    dev->pci_conf[0x63] = 0xff;
+    dev->pci_conf[0x64] = dev->pci_conf[0x65] = 0x00;
+    dev->pci_conf[0x68] = dev->pci_conf[0x69] = 0x00;
+    dev->pci_conf[0x6a] = dev->pci_conf[0x6b] = 0x00;
+    dev->pci_conf[0x6c] = 0x00;
+    dev->pci_conf[0x70] = dev->pci_conf[0x71] = 0x00;
+    dev->pci_conf[0x72] = dev->pci_conf[0x73] = 0x00;
+    dev->pci_conf[0x74] = dev->pci_conf[0x75] = 0x00;
+    dev->pci_conf[0x76] = dev->pci_conf[0x77] = 0x00;
+    dev->pci_conf[0x78] = dev->pci_conf[0x79] = 0x00;
+    dev->pci_conf[0x7a] = dev->pci_conf[0x7b] = 0x00;
+    dev->pci_conf[0x80] = dev->pci_conf[0x81] = 0x00;
+    dev->pci_conf[0x82] = dev->pci_conf[0x83] = 0x00;
+    dev->pci_conf[0x84] = dev->pci_conf[0x85] = 0xff;
+    dev->pci_conf[0x86] = 0xff;
+    dev->pci_conf[0x87] = 0x00;
+    dev->pci_conf[0x88] = dev->pci_conf[0x89] = 0x00;
+    dev->pci_conf[0x8a] = dev->pci_conf[0x8b] = 0x00;
+    dev->pci_conf[0x8c] = dev->pci_conf[0x8d] = 0x00;
+    dev->pci_conf[0x90] = dev->pci_conf[0x91] = 0x00;
+    dev->pci_conf[0x92] = dev->pci_conf[0x93] = 0x00;
+    dev->pci_conf[0x94] = dev->pci_conf[0x97] = 0x00;
+    dev->pci_conf[0x98] = dev->pci_conf[0x99] = 0x00;
+    dev->pci_conf[0x9a] = dev->pci_conf[0x9b] = 0x00;
+    dev->pci_conf[0x9c] = dev->pci_conf[0x9d] = 0x00;
+    dev->pci_conf[0x9e] = dev->pci_conf[0x9f] = 0x00;
+    dev->pci_conf[0xa0] = dev->pci_conf[0xa1] = 0x00;
+    dev->pci_conf[0xa2] = dev->pci_conf[0xa3] = 0x00;
+    dev->pci_conf[0xa4] = dev->pci_conf[0xa5] = 0x00;
+    dev->pci_conf[0xa6] = dev->pci_conf[0xa7] = 0x00;
+    dev->pci_conf[0xa8] = dev->pci_conf[0xa9] = 0x00;
+    dev->pci_conf[0xaa] = dev->pci_conf[0xab] = 0x00;
+    dev->pci_conf[0xb0] = dev->pci_conf[0xb2] = 0x00;
+    dev->pci_conf[0xc0] = 0x02;
+    dev->pci_conf[0xc1] = 0x00;
+    dev->pci_conf[0xc2] = 0x10;
+    dev->pci_conf[0xc3] = 0x00;
+    dev->pci_conf[0xc4] = 0x03;
+    dev->pci_conf[0xc5] = 0x02;
+    dev->pci_conf[0xc6] = 0x00;
+    dev->pci_conf[0xc7] = 0x1f;
+    dev->pci_conf[0xc8] = dev->pci_conf[0xc9] = 0x00;
+    dev->pci_conf[0xca] = dev->pci_conf[0xcb] = 0x00;
+    dev->pci_conf[0xd4] = dev->pci_conf[0xd5] = 0x00;
+    dev->pci_conf[0xd6] = dev->pci_conf[0xd7] = 0x00;
+    dev->pci_conf[0xd8] = dev->pci_conf[0xd9] = 0x00;
+    dev->pci_conf[0xda] = 0x00;
+    dev->pci_conf[0xe0] = dev->pci_conf[0xe1] = 0x00;
+    dev->pci_conf[0xe2] = dev->pci_conf[0xe3] = 0x00;
+    dev->pci_conf[0xef] = 0x00;
+
+    sis_530_mask_bar(dev->pci_conf, dev->agpgart);
+
+    cpu_cache_ext_enabled = 0;
+    cpu_update_waitstates();
+
+    sis_530_shadow_recalc(dev);
+
+    sis_530_smram_recalc(dev);
+}
+
+static void
+sis_530_host_to_pci_close(void *priv)
+{
+    sis_530_host_to_pci_t *dev = (sis_530_host_to_pci_t *) priv;
+
+    smram_del(dev->smram);
+    free(dev);
+}
+
+static void *
+sis_530_host_to_pci_init(UNUSED(const device_t *info))
+{
+    sis_530_host_to_pci_t *dev = (sis_530_host_to_pci_t *) calloc(1, sizeof(sis_530_host_to_pci_t));
+    uint32_t total_mem = mem_size << 10;
+    ram_bank_t *rb;
+
+    dev->sis = device_get_common_priv();
+
+    /* Calculate the physical RAM banks. */
+    for (uint8_t i = 0; i < 3; i++) {
+        rb = &(dev->ram_banks[i]);
+        uint32_t size = 0x00000000;
+        uint8_t  index = 0;
+        for (int8_t j = 5; j >= 0; j--) {
+            uint32_t *bs = &(bank_sizes[j]);
+            if (*bs <= total_mem) {
+                size = *bs;
+                index = j;
+                break;
+            }
+        }
+        if (size != 0x00000000) {
+            rb->installed = 1;
+            rb->code = bank_codes[index];
+            rb->phys_size = size;
+            total_mem -= size;
+        } else
+            rb->installed = 0;
+    }
+
+    /* SMRAM */
+    dev->smram = smram_add();
+
+    device_add(&sis_5xxx_agp_device);
+    dev->agpgart = device_add(&agpgart_device);
+
+    sis_530_host_to_pci_reset(dev);
+
+    return dev;
+}
+
+const device_t sis_530_h2p_device = {
+    .name          = "SiS 530 Host to PCI bridge",
+    .internal_name = "sis_530_host_to_pci",
+    .flags         = DEVICE_PCI,
+    .local         = 0x00,
+    .init          = sis_530_host_to_pci_init,
+    .close         = sis_530_host_to_pci_close,
+    .reset         = sis_530_host_to_pci_reset,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = NULL
+};

--- a/src/chipset/sis_5513_p2i.c
+++ b/src/chipset/sis_5513_p2i.c
@@ -800,6 +800,9 @@ sis_5513_pci_to_isa_write(int addr, uint8_t val, void *priv)
             pci_set_irq_routing(addr & 0x07, (val & 0x80) ? PCI_IRQ_DISABLED : (val & 0x0f));
             break;
         case 0x44: /* INTD# Remapping Control Register */
+            /* The onboard Solo-1 on the IN530 uses this for INTA for IRQ5 */
+            if (!strcmp(machine_get_internal_name(), "in530") && !(val & 0x80))
+                val = (val & 0xf0) | 0x05;
             if (dev->rev == 0x11) {
                 dev->pci_conf[addr] = val & 0xcf;
                 sis_5513_apc_recalc(dev, val & 0x10);

--- a/src/device.c
+++ b/src/device.c
@@ -1201,9 +1201,12 @@ device_is_valid(const device_t *device, int mch)
     int ret = 1;
 
     if ((device != NULL) && ((device->flags & DEVICE_BUS) != 0)) {
-        /* Hide PCI devices on machines with only an internal PCI bus. */
+        /* Hide PCI or AGP devices on machines with only an internal PCI or AGP bus. */
         if ((device->flags & DEVICE_PCI) &&
             machine_has_flags(mch, MACHINE_PCI_INTERNAL))
+            ret = 0;
+        else if ((device->flags & DEVICE_AGP) &&
+                 machine_has_flags_64(mch, MACHINE_AGP_INTERNAL))
             ret = 0;
         else
             ret = machine_has_bus(mch, device->flags & DEVICE_BUS);

--- a/src/include/86box/chipset.h
+++ b/src/include/86box/chipset.h
@@ -173,6 +173,7 @@ extern const device_t sis_5511_device;
 extern const device_t sis_5571_device;
 extern const device_t sis_5581_device;
 extern const device_t sis_5591_1997_device;
+extern const device_t sis_530_device;
 extern const device_t sis_5591_device;
 extern const device_t sis_5600_1997_device;
 extern const device_t sis_5600_device;

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -106,6 +106,7 @@
 #define MACHINE_APM               0x0000000000080000ULL /* sys has APM */
 #define MACHINE_ACPI              0x0000000000100000ULL /* sys has ACPI */
 #define MACHINE_PCI_INTERNAL      0x0000000000200000ULL /* sys has only internal PCI */
+#define MACHINE_AGP_INTERNAL      0x0000000200000000ULL /* sys has only internal AGP */
 #define MACHINE_CARTRIDGE         0x0000000000400000ULL /* sys has cartridge bays */
 /* Feature flags for internal storage controllers. */
 #define MACHINE_MFM               0x0000000000800000ULL /* sys has int MFM/RLL */
@@ -424,6 +425,7 @@ extern const char *    machine_get_internal_name_ex(int m);
 extern const char *    machine_get_nvr_name_ex(int m);
 extern int             machine_get_nvrmask(int m);
 extern int             machine_has_flags(int m, uintptr_t flags);
+extern uintptr_t       machine_has_flags_64(int m, uintptr_t flags);
 extern void            machine_set_ps2(void);
 extern void            machine_force_ps2(int is_ps2);
 extern int             machine_has_flags_ex(uintptr_t flags);

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -284,6 +284,7 @@ enum {
     MACHINE_CHIPSET_SIS_5511,
     MACHINE_CHIPSET_SIS_5571,
     MACHINE_CHIPSET_SIS_5581,
+    MACHINE_CHIPSET_SIS_530,
     MACHINE_CHIPSET_SIS_5591,
     MACHINE_CHIPSET_SIS_5600,
     MACHINE_CHIPSET_SMSC_VICTORYBX_66,
@@ -1278,6 +1279,13 @@ extern int             machine_at_g5x_init(const machine_t *);
 extern const device_t  ms5169_device;
 #endif
 extern int             machine_at_ms5169_init(const machine_t *);
+
+/* SiS 530/5595 */
+extern int             machine_at_in530_init(const machine_t *);
+extern int             machine_in530_boot_logo_enabled(void);
+#ifdef EMU_DEVICE_H
+extern const device_t  in530_device;
+#endif
 
 /* VIA MVP3 */
 extern int             machine_at_ax59pro_init(const machine_t *);

--- a/src/include/86box/sis_55xx.h
+++ b/src/include/86box/sis_55xx.h
@@ -36,6 +36,8 @@ extern void    sis_5581_host_to_pci_write(int addr, uint8_t val, void *priv);
 extern uint8_t sis_5581_host_to_pci_read(int addr, void *priv);
 extern void    sis_5591_host_to_pci_write(int addr, uint8_t val, void *priv);
 extern uint8_t sis_5591_host_to_pci_read(int addr, void *priv);
+extern void    sis_530_host_to_pci_write(int addr, uint8_t val, void *priv);
+extern uint8_t sis_530_host_to_pci_read(int addr, void *priv);
 extern void    sis_5600_host_to_pci_write(int addr, uint8_t val, void *priv);
 extern uint8_t sis_5600_host_to_pci_read(int addr, void *priv);
 
@@ -52,6 +54,7 @@ extern const device_t sis_5511_h2p_device;
 extern const device_t sis_5571_h2p_device;
 extern const device_t sis_5581_h2p_device;
 extern const device_t sis_5591_h2p_device;
+extern const device_t sis_530_h2p_device;
 extern const device_t sis_5600_h2p_device;
 
 extern const device_t sis_5513_p2i_device;

--- a/src/include/86box/snd_sb.h
+++ b/src/include/86box/snd_sb.h
@@ -289,4 +289,17 @@ extern void ess_filter_cd_audio(int channel, double *buffer, void *priv);
 extern void ess_filter_pc_speaker(int channel, double *buffer, void *priv);
 extern void ess_filter_midi(int channel, double *buffer, void *priv);
 
+extern void   *ess_solo1_legacy_init(void);
+extern void    ess_solo1_legacy_mix_esfm(void *priv, int32_t *buffer, uint16_t len);
+extern void    ess_solo1_legacy_config(void *priv, uint16_t sb_addr, int sb_enable,
+                                       int fm_enable, int fm_legacy_alias,
+                                       uint16_t mpu_addr, int mpu_enable,
+                                       int sb_irq, int mpu_irq, int dma, uint16_t game_addr);
+extern uint8_t ess_solo1_legacy_fm_read(void *priv, uint16_t addr);
+extern void    ess_solo1_legacy_fm_write(void *priv, uint16_t addr, uint8_t val);
+extern void    ess_solo1_legacy_mixer_write(void *priv, uint8_t index, uint8_t val);
+extern uint8_t ess_solo1_legacy_mpu_read(void *priv, uint16_t addr);
+extern void    ess_solo1_legacy_mpu_write(void *priv, uint16_t addr, uint8_t val);
+extern void    ess_solo1_legacy_close(void *priv);
+
 #endif /*SOUND_SND_SB_H*/

--- a/src/include/86box/sound.h
+++ b/src/include/86box/sound.h
@@ -262,6 +262,7 @@ extern const device_t ess_1888_compaq_device;
 extern const device_t ess_1887_device;
 extern const device_t ess_1868_device;
 extern const device_t ess_1869_device;
+extern const device_t ess_solo1_onboard_device;
 
 /* Ensoniq AudioPCI */
 extern const device_t es1370_device;

--- a/src/include/86box/sound.h
+++ b/src/include/86box/sound.h
@@ -262,6 +262,7 @@ extern const device_t ess_1888_compaq_device;
 extern const device_t ess_1887_device;
 extern const device_t ess_1868_device;
 extern const device_t ess_1869_device;
+extern const device_t ess_solo1_device;
 extern const device_t ess_solo1_onboard_device;
 
 /* Ensoniq AudioPCI */

--- a/src/machine/m_at_sockets7.c
+++ b/src/machine/m_at_sockets7.c
@@ -648,6 +648,152 @@ machine_at_k6bv3p_a_init(const machine_t *model)
     return ret;
 }
 
+static int in530_boot_logo_enabled = 1;
+
+static const device_config_t in530_config[] = {
+    // clang-format off
+    {
+        .name           = "bios",
+        .description    = "BIOS Version",
+        .type           = CONFIG_BIOS,
+        .default_string = "in530_pb_129",
+        .default_int    = 0,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .selection      = { { 0 } },
+        .bios           = {
+            {
+                .name          = "AMIBIOS 6 (071595) - Revision 1.11J (Packard Bell)",
+                .internal_name = "in530_pb_111j",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 262144,
+                .files         = {
+                    "roms/machines/in530/88200111.rom",
+                    ""
+                }
+            },
+            {
+                .name          = "AMIBIOS 6 (071595) - Revision 1.28 (Monorail)",
+                .internal_name = "in530_mono_128",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 262144,
+                .files         = {
+                    "roms/machines/in530/20888128.ROM",
+                    ""
+                }
+            },
+            {
+                .name          = "AMIBIOS 6 (071595) - Revision 1.29 (Packard Bell)",
+                .internal_name = "in530_pb_129",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 262144,
+                .files         = {
+                    "roms/machines/in530/52000129.rom",
+                    ""
+                }
+            },
+            {
+                .name          = "AMIBIOS 6 (071595) - Revision 1.36J (NEC)",
+                .internal_name = "in530_nec_136j",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 262144,
+                .files         = {
+                    "roms/machines/in530/0136J.ROM",
+                    ""
+                }
+            },
+            { .files_no = 0 }
+        }
+    },
+	/* Boot logo toggle doesn't work yet for the NEC, so disabling until it does */
+    /*{
+        .name           = "boot_logo",
+        .description    = "Enable Boot Logo",
+        .type           = CONFIG_BINARY,
+        .default_string = NULL,
+        .default_int    = 1,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .selection      = { { 0 } },
+        .bios           = { { 0 } }
+    },*/
+    { .name = "", .description = "", .type = CONFIG_END }
+    // clang-format on
+};
+
+const device_t in530_device = {
+    .name          = "BCM IN530",
+    .internal_name = "in530",
+    .flags         = 0,
+    .local         = 0,
+    .init          = NULL,
+    .close         = NULL,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = in530_config
+};
+
+int
+machine_in530_boot_logo_enabled(void)
+{
+    return in530_boot_logo_enabled;
+}
+
+/* SiS 530 / 5595 */
+int
+machine_at_in530_init(const machine_t *model)
+{
+    int         ret = 0;
+    const char *fn;
+
+    /* No ROMs available */
+    if (!device_available(model->device))
+        return ret;
+
+    device_context(model->device);
+    fn  = device_get_bios_file(machine_get_device(machine), device_get_config_bios("bios"), 0);
+    ret = bios_load_linear(fn, 0x000c0000, 262144, 0);
+	/* Force full screen boot logo on for now */
+    /* in530_boot_logo_enabled = device_get_config_int("boot_logo"); */
+    device_context_restore();
+
+    machine_at_common_init(model);
+
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE,     0, 0, 0, 0);
+    pci_register_slot(0x01, PCI_CARD_SOUTHBRIDGE,     0, 0, 0, 0);
+    /* Physical FR520 / IN530 PCI topology verified with PCITool:
+     *   device 09h - PCI slot 1
+     *   device 0Ah - PCI slot 2
+     *   device 0Bh - PCI slot 3
+     *   device 0Ch - on-board ESS ES1938S Solo-1
+     */
+    pci_register_slot(0x09, PCI_CARD_NORMAL,          1, 2, 3, 4);
+    pci_register_slot(0x0A, PCI_CARD_NORMAL,          2, 3, 4, 1);
+    pci_register_slot(0x0B, PCI_CARD_NORMAL,          3, 4, 1, 2);
+    pci_register_slot(0x0C, PCI_CARD_SOUND,           4, 1, 2, 3);
+
+    device_add(&sis_530_device);
+    device_add_params(&w83877_device, (void *) (W83877TF | W83877_3F0));
+    device_add(&amd_flash_29f002nbt_device);
+    spd_register(SPD_TYPE_SDRAM, 0x3, 512);
+
+    if (sound_card_current[0] == SOUND_INTERNAL)
+        device_add(machine_get_snd_device(machine));
+
+    return ret;
+}
+
 /* SiS 5591 */
 int
 machine_at_5sg100_init(const machine_t *model)

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -20829,6 +20829,55 @@ const machine_t machines[] = {
         .aliases                  = { "Matsonic MS-6260S", "" }
     },
 
+    /* SiS 530 / 5595 */
+    {
+        .name              = "[SiS 530] BCM IN530",
+        .internal_name     = "in530",
+        .type              = MACHINE_TYPE_SOCKETS7,
+        .chipset           = MACHINE_CHIPSET_SIS_530,
+        .init              = machine_at_in530_init,
+        .p1_handler        = machine_generic_p1_handler,
+        .gpio_handler      = NULL,
+        .available_flag    = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu               = {
+            .package     = CPU_PKG_SOCKET5_7,
+            .block       = CPU_BLOCK_NONE,
+            .min_bus     = 66666667,
+            .max_bus     = 100000000,
+            .min_voltage = 1800,
+            .max_voltage = 3520,
+            .min_multi   = 1.5,
+            .max_multi   = 6.0
+        },
+        .bus_flags = MACHINE_PS2_AGP | MACHINE_BUS_USB,
+        .flags     = MACHINE_SUPER_IO | MACHINE_IDE_DUAL | MACHINE_VIDEO | MACHINE_SOUND | MACHINE_APM | MACHINE_ACPI | MACHINE_AGP_INTERNAL | MACHINE_USB,
+        .ram       = {
+            .min  = 8192,
+            .max  = 524288,
+            .step = 8192
+        },
+        .nvrmask                  = 255,
+        .jumpered_ecp_dma         = 0,
+        .default_jumpered_ecp_dma = -1,
+        .kbc_device               = NULL,
+        .kbc_params               = 0x00000000,
+        .nvr_device               = NULL,
+        .nvr_params               = 0x00000000,
+        .sio_device               = NULL,
+        .sio_params               = 0x00000000,
+        .kbc_p1                   = 0x00000cf0,
+        .gpio                     = 0xffffffff,
+        .gpio_acpi                = 0xffffffff,
+        .device                   = &in530_device,
+        .kbd_device               = NULL,
+        .fdc_device               = NULL,
+        .vid_device               = NULL,
+        .snd_device               = &ess_solo1_onboard_device,
+        .net_device               = NULL,
+        .aliases                  = { "GVC FR520", "Packard Bell Miami", "NEC Valuestar U VU47L", "Packard Bell PB980", "" }
+    },
+
     /* SiS 5591 */
     /* Has the SiS 5591 chipset with on-chip KBC. */
     {

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -25393,6 +25393,19 @@ machine_has_flags(int m, uintptr_t flags)
     return ret;
 }
 
+uintptr_t
+machine_has_flags_64(int m, uintptr_t flags)
+{
+    uintptr_t ret = machines[m].flags & flags;
+
+    /* Can't have PS/2 ports with an AT KBC. */
+    if ((flags & MACHINE_PS2_KBC) &&
+        (machines[m].bus_flags & MACHINE_BUS_PS2_PORTS))
+        ret |= MACHINE_PS2_KBC;
+
+    return ret;
+}
+
 void
 machine_set_ps2(void)
 {

--- a/src/mem/sst_flash.c
+++ b/src/mem/sst_flash.c
@@ -562,6 +562,20 @@ sst_init(const device_t *info)
     } else
         dev->dirty = 1; /* It is by definition dirty on creation. */
 
+    /* This is currently forced on until the NEC variant can be fixed */
+    /* Edit the rom to enable/disable the full screen logo */
+    if ((machines[machine].init == machine_at_in530_init) &&
+        (info->local == (AMD | AMD29F002NBT | SIZE_2M))) {
+        const uint8_t old = dev->array[0x3af70];
+
+        dev->array[0x3af70] &= 0xf0;
+        if (machine_in530_boot_logo_enabled())
+            dev->array[0x3af70] |= 0x01;
+
+        if (dev->array[0x3af70] != old)
+            dev->dirty = 1;
+    }
+
     if (!dev->is_39)
         timer_add(&dev->page_write_timer, sst_page_write, dev, 0);
 

--- a/src/sound/CMakeLists.txt
+++ b/src/sound/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(snd OBJECT
     snd_cms.c
     snd_csm.c
     snd_cmi8x38.c
+    snd_solo1.c
     snd_covox.c
     snd_cs423x.c
     snd_imfc.cpp

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -6587,7 +6587,7 @@ ess_solo1_legacy_mix_esfm(void *priv, int32_t *buffer, uint16_t len)
 
     opl_buf = ess->opl.update(ess->opl.priv);
     if (opl_buf != NULL) {
-        for (uint16_t c = 0; c < len * 2; c++)
+        for (uint32_t c = 0; c < (uint32_t) len * 2; c++)
             buffer[c] += (int32_t) ((double) opl_buf[c] * 0.7171630859375);
     }
 

--- a/src/sound/snd_sb.c
+++ b/src/sound/snd_sb.c
@@ -165,6 +165,57 @@ static const uint8_t ess_4bit_xlat[] = {
 
 static double ess_att_6bits[64];
 
+/*
+ * ES1938S Solo-1 playback-mixer curves (datasheet Table 22).
+ *
+ * The Solo-1 has separate gain curves for each audio source, so they have
+ * been separated out so as to not break existing AudioDrive mixers
+ *
+ * Entry 0 is mute and is handled explicitly by ess_solo1_4bit_gain().
+ */
+static const double ess_solo1_audio1_db[16] = {
+     0.0, -30.0, -27.0, -24.0, -21.0, -18.0, -15.0, -12.0,
+    -9.0,  -7.5,  -6.0,  -4.5,  -3.0,  -1.5,   0.0,   1.5
+};
+
+static const double ess_solo1_audio2_db[16] = {
+      0.0, -31.5, -28.5, -25.5, -22.5, -19.5, -16.5, -13.5,
+    -10.5,  -9.0,  -7.5,  -6.0,  -4.5,  -3.0,  -1.5,   0.0
+};
+
+static const double ess_solo1_music_db[16] = {
+     0.0, -21.0, -18.0, -15.0, -12.0, -9.0, -6.0, -3.0,
+     0.0,   1.5,   3.0,   4.5,   6.0,  7.5,  9.0, 10.5
+};
+
+static const double ess_solo1_aux_db[16] = {
+      0.0, -28.5, -25.5, -22.5, -19.5, -16.5, -13.5, -10.5,
+     -7.5,  -6.0,  -4.5,  -3.0,  -1.5,   0.0,   1.5,   3.0
+};
+
+static double
+ess_solo1_4bit_gain(const double table[16], uint8_t value)
+{
+    value &= 0x0f;
+    if (value == 0)
+        return 0.0;
+
+    return pow(10.0, table[value] / 20.0);
+}
+
+static double
+ess_solo1_master_gain(uint8_t value)
+{
+    double db;
+
+    /* Bit 6 is mute; bits 5:0 are 0.75 dB steps, 3Fh = 0 dB. */
+    if (value & 0x40)
+        return 0.0;
+
+    db = -47.25 + (0.75 * (double) (value & 0x3f));
+    return pow(10.0, db / 20.0);
+}
+
 static const uint16_t sb_mcv_addr[8]     = { 0x200, 0x210, 0x220, 0x230, 0x240, 0x250, 0x260, 0x270 };
 static const int      sb_pro_mcv_irqs[4] = { 7, 5, 3, 3 };
 
@@ -2357,6 +2408,81 @@ ess_mixer_write(uint16_t addr, uint8_t val, void *priv)
     }
 }
 
+static void
+ess_solo1_mixer_recalc(sb_t *ess)
+{
+    ess_mixer_t *mixer;
+
+    if (ess == NULL)
+        return;
+
+    mixer = &ess->mixer_ess;
+
+    mixer->voice_l = ess_solo1_4bit_gain(ess_solo1_audio1_db,
+                                          (mixer->regs[0x14] >> 4) & 0x0f);
+    mixer->voice_r = ess_solo1_4bit_gain(ess_solo1_audio1_db,
+                                          mixer->regs[0x14] & 0x0f);
+
+    mixer->fm_l = ess_solo1_4bit_gain(ess_solo1_music_db,
+                                       (mixer->regs[0x36] >> 4) & 0x0f);
+    mixer->fm_r = ess_solo1_4bit_gain(ess_solo1_music_db,
+                                       mixer->regs[0x36] & 0x0f);
+
+    mixer->cd_l = ess_solo1_4bit_gain(ess_solo1_aux_db,
+                                       (mixer->regs[0x38] >> 4) & 0x0f);
+    mixer->cd_r = ess_solo1_4bit_gain(ess_solo1_aux_db,
+                                       mixer->regs[0x38] & 0x0f);
+
+    mixer->dac2_l = ess_solo1_4bit_gain(ess_solo1_audio2_db,
+                                         (mixer->regs[0x7c] >> 4) & 0x0f);
+    mixer->dac2_r = ess_solo1_4bit_gain(ess_solo1_audio2_db,
+                                         mixer->regs[0x7c] & 0x0f);
+
+    mixer->master_l = ess_solo1_master_gain(mixer->regs[0x60]);
+    mixer->master_r = ess_solo1_master_gain(mixer->regs[0x62]);
+}
+
+static void
+ess_solo1_mixer_set_reset_defaults(sb_t *ess)
+{
+    ess_mixer_t *mixer;
+
+    if (ess == NULL)
+        return;
+
+    mixer = &ess->mixer_ess;
+
+    mixer->regs[0x14] = 0x88; /* Audio 1 play volume. */
+    mixer->regs[0x32] = 0x88; /* Backward-compatible master volume. */
+    mixer->regs[0x36] = 0x88; /* Music DAC / ESFM volume. */
+    mixer->regs[0x38] = 0x00; /* AuxA / CD muted at reset. */
+    mixer->regs[0x3a] = 0x00;
+    mixer->regs[0x3c] = 0x04;
+    mixer->regs[0x3e] = 0x00;
+    mixer->regs[0x60] = 0x36; /* Actual left master hardware volume. */
+    mixer->regs[0x62] = 0x36; /* Actual right master hardware volume. */
+    mixer->regs[0x64] = 0x00; /* SB Pro master-volume emulation enabled. */
+    mixer->regs[0x7c] = 0x00; /* Audio 2 playback muted at reset. */
+}
+
+static void
+ess_solo1_mixer_write(uint16_t addr, uint8_t val, void *priv)
+{
+    sb_t *ess = (sb_t *) priv;
+    int   mixer_reset = 0;
+
+    if (ess != NULL && (addr & 1) && ess->mixer_ess.index == 0x00)
+        mixer_reset = 1;
+
+    ess_mixer_write(addr, val, priv);
+
+    if (ess != NULL && (addr & 1)) {
+        if (mixer_reset)
+            ess_solo1_mixer_set_reset_defaults(ess);
+        ess_solo1_mixer_recalc(ess);
+    }
+}
+
 uint8_t
 ess_mixer_read(uint16_t addr, void *priv)
 {
@@ -2555,6 +2681,15 @@ ess_mixer_reset(sb_t *ess)
 {
     ess_mixer_write(4, 0, ess);
     ess_mixer_write(5, 0, ess);
+}
+
+static void
+ess_solo1_mixer_reset(sb_t *ess)
+{
+    /* Preserve all generic reset side effects, then impose Solo-1 reset state. */
+    ess_mixer_reset(ess);
+    ess_solo1_mixer_set_reset_defaults(ess);
+    ess_solo1_mixer_recalc(ess);
 }
 
 void
@@ -6179,6 +6314,367 @@ ess_186x_init(const device_t *info)
     }
 
     return ess;
+}
+
+/*
+ * ESS Solo-1 DOS mode
+ */
+
+static int
+solo1_legacy_dma_readb(void *priv)
+{
+    sb_t *ess = (sb_t *) priv;
+    int ch = ess->dsp.sb_8_dmanum;
+    int ret = dma_channel_read(ch);
+
+
+    return ret;
+}
+
+static int
+solo1_legacy_dma_readw(void *priv)
+{
+    sb_t *ess = (sb_t *) priv;
+    int ch = ess->dsp.sb_16_dmanum;
+    int lo = dma_channel_read(ch);
+    int hi;
+
+    if (lo & DMA_NODATA)
+        return lo;
+
+    hi = dma_channel_read(ch);
+    if (hi & DMA_NODATA)
+        return hi;
+
+
+    return (lo & 0xff) | ((hi & 0xff) << 8);
+}
+
+static int
+solo1_legacy_dma_writeb(void *priv, uint8_t val)
+{
+    sb_t *ess = (sb_t *) priv;
+    int ch = ess->dsp.sb_8_dmanum;
+    int ret = dma_channel_write(ch, val);
+
+
+    return ret == DMA_NODATA;
+}
+
+static int
+solo1_legacy_dma_writew(void *priv, uint16_t val)
+{
+    sb_t *ess = (sb_t *) priv;
+    int ch = ess->dsp.sb_16_dmanum;
+    int ret;
+
+    ret = dma_channel_write(ch, val & 0xff);
+    if (ret == DMA_NODATA)
+        return 1;
+
+    ret = dma_channel_write(ch, val >> 8);
+
+
+    return ret == DMA_NODATA;
+}
+
+/* sb_doreset() is needed for the Solo-1 but appears to not be declared,
+ * so doing it here to keep it local
+ */
+extern void sb_doreset(sb_dsp_t *dsp);
+
+void *
+ess_solo1_legacy_init(void)
+{
+    sb_t *ess = calloc(1, sizeof(sb_t));
+
+
+    ess->opl_enabled = 1;
+    fm_driver_get_cs(FM_ESFM, &ess->opl);
+
+    sb_dsp_set_real_opl(&ess->dsp, 1);
+    sb_dsp_init(&ess->dsp, SBPRO_DSP_301, SB_SUBTYPE_ESS_ES1869, ess);
+    sb_dsp_dma_attach(&ess->dsp,
+                      solo1_legacy_dma_readb,
+                      solo1_legacy_dma_readw,
+                      solo1_legacy_dma_writeb,
+                      solo1_legacy_dma_writew,
+                      ess);
+    sb_dsp_setdma16_supported(&ess->dsp, 0);
+    ess_solo1_mixer_reset(ess);
+
+    ess->mixer_ess.input_filter  = 1;
+    ess->mixer_ess.output_filter = 1;
+    ess->mixer_enabled           = 1;
+
+    sound_add_handler(sb_get_buffer_ess, ess);
+    music_add_handler(sb_get_music_buffer_ess, ess);
+    sound_set_cd_audio_filter(ess_filter_cd_audio, ess);
+
+    ess->mpu = (mpu_t *) calloc(1, sizeof(mpu_t));
+    mpu401_init(ess->mpu, 0, -1, M_UART, 0);
+    sb_dsp_set_mpu(&ess->dsp, ess->mpu);
+
+    ess->gameport = gameport_add(&gameport_pnp_device);
+
+    sb_dsp_setaddr(&ess->dsp, 0);
+    sb_dsp_setirq(&ess->dsp, 0);
+    sb_dsp_setdma8(&ess->dsp, ISAPNP_DMA_DISABLED);
+    sb_dsp_setdma16_8(&ess->dsp, ISAPNP_DMA_DISABLED);
+    mpu401_change_addr(ess->mpu, 0);
+    mpu401_setirq(ess->mpu, -1);
+    gameport_remap(ess->gameport, 0);
+
+    return ess;
+}
+
+void
+ess_solo1_legacy_reset(void *priv)
+{
+    sb_t *ess = (sb_t *) priv;
+
+    if (ess == NULL)
+        return;
+
+    sb_doreset(&ess->dsp);
+
+    memset(ess->dsp.ess_regs, 0x00, sizeof(ess->dsp.ess_regs));
+    ess->dsp.ess_regs[0x05] = 0xf8; /* A5h reset value used by sb_doreset(). */
+    ess->dsp.ess_playback_mode = 0;
+    ess->dsp.ess_irq_generic   = 0;
+    ess->dsp.ess_irq_dmactr    = 0;
+    ess->dsp.ess_dma_counter   = 0;
+
+    ess_solo1_mixer_reset(ess);
+    ess->mixer_ess.input_filter  = 1;
+    ess->mixer_ess.output_filter = 1;
+    ess->mixer_enabled           = 1;
+}
+
+void
+ess_solo1_legacy_config(void *priv, uint16_t sb_addr, int sb_enable,
+                        int fm_enable, int fm_legacy_alias,
+                        uint16_t mpu_addr, int mpu_enable,
+                        int sb_irq, int mpu_irq, int dma, uint16_t game_addr)
+{
+    sb_t    *ess = (sb_t *) priv;
+    uint16_t old_sb;
+
+    if (ess == NULL)
+        return;
+
+    old_sb = ess->dsp.sb_addr;
+
+    if (old_sb) {
+        io_removehandler(old_sb, 0x0004,
+                         ess->opl.read, NULL, NULL,
+                         ess->opl.write, NULL, NULL,
+                         ess->opl.priv);
+        io_removehandler(old_sb + 8, 0x0002,
+                         ess->opl.read, NULL, NULL,
+                         ess->opl.write, NULL, NULL,
+                         ess->opl.priv);
+        io_removehandler(old_sb + 8, 0x0002,
+                         ess_fm_midi_read, NULL, NULL,
+                         ess_fm_midi_write, NULL, NULL,
+                         ess);
+        io_removehandler(old_sb + 4, 0x0002,
+                         ess_mixer_read, NULL, NULL,
+                         ess_solo1_mixer_write, NULL, NULL,
+                         ess);
+        io_removehandler(old_sb + 2, 0x0003,
+                         ess_base_read, NULL, NULL,
+                         ess_base_write, NULL, NULL,
+                         ess);
+        io_removehandler(old_sb + 6, 0x0001,
+                         ess_base_read, NULL, NULL,
+                         ess_base_write, NULL, NULL,
+                         ess);
+        io_removehandler(old_sb + 0x0a, 0x0006,
+                         ess_base_read, NULL, NULL,
+                         ess_base_write, NULL, NULL,
+                         ess);
+    }
+
+    if (ess->opl_pnp_addr) {
+        io_removehandler(ess->opl_pnp_addr, 0x0004,
+                         ess->opl.read, NULL, NULL,
+                         ess->opl.write, NULL, NULL,
+                         ess->opl.priv);
+        io_removehandler(ess->opl_pnp_addr, 0x0004,
+                         ess_fm_midi_read, NULL, NULL,
+                         ess_fm_midi_write, NULL, NULL,
+                         ess);
+        ess->opl_pnp_addr = 0;
+    }
+
+    sb_dsp_setaddr(&ess->dsp, 0);
+    mpu401_change_addr(ess->mpu, 0);
+    mpu401_setirq(ess->mpu, -1);
+    gameport_remap(ess->gameport, 0);
+
+    sb_dsp_setirq(&ess->dsp, sb_enable ? sb_irq : 0);
+    sb_dsp_setdma8(&ess->dsp, sb_enable ? dma : ISAPNP_DMA_DISABLED);
+    sb_dsp_setdma16_8(&ess->dsp, sb_enable ? dma : ISAPNP_DMA_DISABLED);
+
+    if (sb_enable) {
+        if (fm_enable) {
+            io_sethandler(sb_addr, 0x0004,
+                          ess->opl.read, NULL, NULL,
+                          ess->opl.write, NULL, NULL,
+                          ess->opl.priv);
+            io_sethandler(sb_addr + 8, 0x0002,
+                          ess->opl.read, NULL, NULL,
+                          ess->opl.write, NULL, NULL,
+                          ess->opl.priv);
+            io_sethandler(sb_addr + 8, 0x0002,
+                          ess_fm_midi_read, NULL, NULL,
+                          ess_fm_midi_write, NULL, NULL,
+                          ess);
+        }
+
+        io_sethandler(sb_addr + 4, 0x0002,
+                      ess_mixer_read, NULL, NULL,
+                      ess_solo1_mixer_write, NULL, NULL,
+                      ess);
+
+        sb_dsp_setaddr(&ess->dsp, sb_addr);
+        io_sethandler(sb_addr + 2, 0x0003,
+                      ess_base_read, NULL, NULL,
+                      ess_base_write, NULL, NULL,
+                      ess);
+        io_sethandler(sb_addr + 6, 0x0001,
+                      ess_base_read, NULL, NULL,
+                      ess_base_write, NULL, NULL,
+                      ess);
+        io_sethandler(sb_addr + 0x0a, 0x0006,
+                      ess_base_read, NULL, NULL,
+                      ess_base_write, NULL, NULL,
+                      ess);
+    }
+
+    if (fm_enable && fm_legacy_alias) {
+        ess->opl_pnp_addr = 0x0388;
+        io_sethandler(ess->opl_pnp_addr, 0x0004,
+                      ess->opl.read, NULL, NULL,
+                      ess->opl.write, NULL, NULL,
+                      ess->opl.priv);
+        io_sethandler(ess->opl_pnp_addr, 0x0004,
+                      ess_fm_midi_read, NULL, NULL,
+                      ess_fm_midi_write, NULL, NULL,
+                      ess);
+    }
+
+    if (mpu_enable) {
+        ess->midi_addr = mpu_addr;
+        mpu401_change_addr(ess->mpu, mpu_addr);
+        mpu401_setirq(ess->mpu, mpu_irq);
+    } else
+        ess->midi_addr = 0;
+
+    ess->gameport_addr = game_addr;
+    gameport_remap(ess->gameport, ess->gameport_addr);
+}
+
+void
+ess_solo1_legacy_mix_esfm(void *priv, int32_t *buffer, uint16_t len)
+{
+    sb_t          *ess = (sb_t *) priv;
+    const int32_t *opl_buf;
+
+    if (ess == NULL || !ess->opl_enabled || buffer == NULL || !len)
+        return;
+
+    opl_buf = ess->opl.update(ess->opl.priv);
+    if (opl_buf != NULL) {
+        for (uint16_t c = 0; c < len * 2; c++)
+            buffer[c] += (int32_t) ((double) opl_buf[c] * 0.7171630859375);
+    }
+
+    ess->opl.reset_buffer(ess->opl.priv);
+}
+
+uint8_t
+ess_solo1_legacy_fm_read(void *priv, uint16_t addr)
+{
+    sb_t *ess = (sb_t *) priv;
+
+    if (ess == NULL || !ess->opl_enabled)
+        return 0xff;
+
+    return ess->opl.read(addr, ess->opl.priv);
+}
+
+void
+ess_solo1_legacy_fm_write(void *priv, uint16_t addr, uint8_t val)
+{
+    sb_t *ess = (sb_t *) priv;
+
+    if (ess == NULL || !ess->opl_enabled)
+        return;
+
+    ess->opl.write(addr, val, ess->opl.priv);
+}
+
+void
+ess_solo1_legacy_mixer_write(void *priv, uint8_t index, uint8_t val)
+{
+    sb_t *ess = (sb_t *) priv;
+
+    if (ess == NULL)
+        return;
+
+    ess->mixer_ess.index = index;
+    ess_solo1_mixer_write(5, val, ess);
+}
+
+double
+ess_solo1_legacy_audio2_gain(void *priv, int channel)
+{
+    const sb_t        *ess;
+    const ess_mixer_t *mixer;
+    double             source;
+    double             master;
+
+    ess = (const sb_t *) priv;
+    if (ess == NULL)
+        return 0.0;
+
+    mixer  = &ess->mixer_ess;
+    source = channel ? mixer->dac2_r : mixer->dac2_l;
+    master = channel ? mixer->master_r : mixer->master_l;
+
+    return source * master;
+}
+
+uint8_t
+ess_solo1_legacy_mpu_read(void *priv, uint16_t addr)
+{
+    sb_t *ess = (sb_t *) priv;
+
+    if (ess == NULL || ess->mpu == NULL)
+        return 0xff;
+
+    return mpu401_read(addr, ess->mpu);
+}
+
+void
+ess_solo1_legacy_mpu_write(void *priv, uint16_t addr, uint8_t val)
+{
+    sb_t *ess = (sb_t *) priv;
+
+    if (ess == NULL || ess->mpu == NULL)
+        return;
+
+    mpu401_write(addr, val, ess->mpu);
+}
+
+void
+ess_solo1_legacy_close(void *priv)
+{
+    ess_solo1_legacy_config(priv, 0, 0, 0, 0, 0, 0, 0, 0,
+                            ISAPNP_DMA_DISABLED, 0);
+    sb_close(priv);
 }
 
 void

--- a/src/sound/snd_solo1.c
+++ b/src/sound/snd_solo1.c
@@ -1103,6 +1103,20 @@ solo1_close(void *priv)
     free(dev);
 }
 
+const device_t ess_solo1_device = {
+    .name          = "ESS ES1938S Solo-1",
+    .internal_name = "ess_solo1",
+    .flags         = DEVICE_PCI,
+    .local         = 0,
+    .init          = solo1_init,
+    .close         = solo1_close,
+    .reset         = solo1_reset,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = NULL
+};
+
 const device_t ess_solo1_onboard_device = {
     .name          = "ESS ES1938S Solo-1 (On-Board)",
     .internal_name = "ess_solo1_onboard",

--- a/src/sound/snd_solo1.c
+++ b/src/sound/snd_solo1.c
@@ -1,0 +1,1118 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          Implementation of the ESS Technology ES1938S Solo-1 PCI audio controller.
+ *
+ * Authors: mw308
+ *
+ *          Copyright 2026 mw308
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <86box/86box.h>
+#include <86box/device.h>
+#include <86box/pci.h>
+#include <86box/io.h>
+#include <86box/mem.h>
+#include <86box/sound.h>
+#include <86box/timer.h>
+#include <86box/snd_sb.h>
+#include <86box/plat_unused.h>
+
+/* Solo-1-only hooks for the nested ESS legacy compatibility core. */
+void   ess_solo1_legacy_reset(void *priv);
+double ess_solo1_legacy_audio2_gain(void *priv, int channel);
+
+typedef struct solo1_t {
+    uint8_t pci_regs[256];
+    uint8_t pci_slot;
+    uint8_t onboard;
+
+    void   *legacy;
+
+    uint16_t io_base_mapped;
+    uint16_t sb_base_mapped;
+    uint16_t mpu_base_mapped;
+    uint16_t gp_base_mapped;
+    uint16_t ddma_base_mapped;
+    uint8_t  io_regs[0x40];
+    uint8_t  sb_regs[0x10];
+    uint8_t  sb_reset_asserted;
+    uint8_t  sb_reset_response;
+    uint8_t  sb_read_fifo[4];
+    uint8_t  sb_read_fifo_r;
+    uint8_t  sb_read_fifo_w;
+    uint8_t  sb_read_fifo_count;
+    uint8_t  ess_ext_enabled;
+    uint8_t  ess_regs[0x30];          /* A0h-CFh */
+    uint8_t  dsp_pending_cmd;
+    uint8_t  dsp_pending_bytes;
+    uint8_t  dsp_pending_data[2];
+    uint8_t  mpu_regs[0x04];
+    uint8_t  mpu_ack_pending;
+    uint8_t  gp_regs[0x04];
+    uint8_t  ddma_regs[0x10];
+
+    /* Real indexed ESS mixer state. */
+    uint8_t  mixer_index;
+    uint8_t  mixer_regs[256];
+
+    /* Audio 2 native PCI bus-master playback state. */
+    uint32_t a2_base_addr;
+    uint32_t a2_cur_addr;
+    uint16_t a2_base_count;
+    uint16_t a2_cur_count;
+    uint32_t a2_rate_accum;
+    uint32_t a2_irq_bytes_left;
+    int16_t  a2_last_l;
+    int16_t  a2_last_r;
+    uint8_t  a2_irq_pending;
+    uint8_t  irq_state;
+
+    /* Audio 2 bus-master read cache. */
+    uint8_t  a2_dma_cache[128];
+    uint32_t a2_dma_cache_addr;
+    uint16_t a2_dma_cache_pos;
+    uint16_t a2_dma_cache_len;
+
+} solo1_t;
+
+static uint8_t
+solo1_pci_read(int func, int addr, UNUSED(int len), void *priv)
+{
+    solo1_t *dev = (solo1_t *) priv;
+
+    if (func || addr < 0 || addr > 0xff)
+        return 0xff;
+
+    return dev->pci_regs[addr];
+}
+
+
+static int
+solo1_decode_irq(unsigned sel)
+{
+    switch (sel & 7) {
+        case 0: return 5;
+        case 1: return 7;
+        case 2: return 9;
+        case 3: return 10;
+        case 4: return 11;
+        case 5: return 12;
+        case 6: return 13;
+        case 7: return 14;
+        default: return 5;
+    }
+}
+
+static int
+solo1_decode_dma(unsigned sel)
+{
+    switch (sel & 3) {
+        case 0: return 0;
+        case 1: return 1;
+        case 3: return 3;
+        default: return 1; /* 10b is reserved. */
+    }
+}
+
+static uint16_t
+solo1_decode_mpu_base(const solo1_t *dev)
+{
+    switch ((dev->pci_regs[0x50] >> 3) & 3) {
+        case 0: return 0x330;
+        case 1: return 0x300;
+        case 2: return 0x320;
+        case 3: return 0x340;
+        default: return 0x330;
+    }
+}
+
+
+static uint16_t
+solo1_bar_base(const solo1_t *dev, int bar, uint16_t mask)
+{
+    return (uint16_t) (((uint16_t) dev->pci_regs[bar + 1] << 8) |
+                       (dev->pci_regs[bar] & mask));
+}
+
+static uint32_t
+solo1_a2_sample_rate(const solo1_t *dev)
+{
+    const uint8_t r = dev->mixer_regs[0x70];
+    const uint32_t clock = (r & 0x80) ? 768000U : 793800U;
+    uint32_t divisor = 128U - (uint32_t) (r & 0x7f);
+
+    if (!divisor)
+        divisor = 1;
+
+    return clock / divisor;
+}
+
+static uint32_t
+solo1_a2_transfer_reload_bytes(const solo1_t *dev)
+{
+    uint16_t raw = (uint16_t) dev->mixer_regs[0x74] |
+                   ((uint16_t) dev->mixer_regs[0x76] << 8);
+    uint32_t n = (uint16_t) (0x10000U - raw);
+
+    if (!n)
+        n = 0x10000U;
+
+    return n;
+}
+
+static void
+solo1_update_irq(solo1_t *dev)
+{
+    const int a2_enabled = !!(dev->mixer_regs[0x7a] & 0x40);
+    const int io_enabled = !!(dev->io_regs[0x07] & 0x20);
+    const int active = dev->a2_irq_pending && a2_enabled && io_enabled;
+
+    if (active)
+        pci_set_irq(dev->pci_slot, PCI_INTA, &dev->irq_state);
+    else
+        pci_clear_irq(dev->pci_slot, PCI_INTA, &dev->irq_state);
+}
+
+static void solo1_a2_cache_invalidate(solo1_t *dev);
+
+static void
+solo1_a2_reload_dma(solo1_t *dev)
+{
+    dev->a2_cur_addr = dev->a2_base_addr;
+    dev->a2_cur_count = dev->a2_base_count;
+    dev->a2_irq_bytes_left = solo1_a2_transfer_reload_bytes(dev);
+    solo1_a2_cache_invalidate(dev);
+}
+
+static void
+solo1_a2_cache_invalidate(solo1_t *dev)
+{
+    dev->a2_dma_cache_addr = 0;
+    dev->a2_dma_cache_pos = 0;
+    dev->a2_dma_cache_len = 0;
+}
+
+static void
+solo1_a2_cache_fill(solo1_t *dev)
+{
+    uint32_t n;
+
+    solo1_a2_cache_invalidate(dev);
+
+    if (!dev->a2_cur_count)
+        return;
+
+    n = dev->a2_cur_count;
+    if (n > sizeof(dev->a2_dma_cache))
+        n = sizeof(dev->a2_dma_cache);
+
+    dev->a2_dma_cache_addr = dev->a2_cur_addr;
+
+	/* Windows Solo-1 playback buffers go into normal RAM, so use existing backing */
+    if (mem_addr_is_ram(dev->a2_cur_addr) &&
+        mem_addr_is_ram(dev->a2_cur_addr + n - 1) &&
+        ((dev->a2_cur_addr & rammask) + n <= (uint64_t) rammask + 1)) {
+        memcpy(dev->a2_dma_cache, ram + (dev->a2_cur_addr & rammask), n);
+    } else {
+        uint32_t i = 0;
+
+        while ((i + 4) <= n) {
+            uint32_t v = mem_readl_phys(dev->a2_cur_addr + i);
+            dev->a2_dma_cache[i + 0] = (uint8_t) v;
+            dev->a2_dma_cache[i + 1] = (uint8_t) (v >> 8);
+            dev->a2_dma_cache[i + 2] = (uint8_t) (v >> 16);
+            dev->a2_dma_cache[i + 3] = (uint8_t) (v >> 24);
+            i += 4;
+        }
+
+        while (i < n) {
+            dev->a2_dma_cache[i] = mem_readb_phys(dev->a2_cur_addr + i);
+            i++;
+        }
+    }
+
+    dev->a2_dma_cache_len = (uint16_t) n;
+}
+
+static uint8_t
+solo1_a2_read_byte(solo1_t *dev)
+{
+    uint8_t v;
+
+    if ((dev->a2_dma_cache_pos >= dev->a2_dma_cache_len) ||
+        (dev->a2_dma_cache_addr + dev->a2_dma_cache_pos != dev->a2_cur_addr)) {
+        solo1_a2_cache_fill(dev);
+    }
+
+    if (dev->a2_dma_cache_pos < dev->a2_dma_cache_len)
+        v = dev->a2_dma_cache[dev->a2_dma_cache_pos++];
+    else
+        v = mem_readb_phys(dev->a2_cur_addr);
+
+    dev->a2_cur_addr++;
+
+    if (dev->a2_cur_count > 1) {
+        dev->a2_cur_count--;
+    } else {
+        if (dev->io_regs[0x06] & 0x08) {
+            dev->a2_cur_addr = dev->a2_base_addr;
+            dev->a2_cur_count = dev->a2_base_count;
+            solo1_a2_cache_invalidate(dev);
+        } else {
+            dev->a2_cur_count = 0;
+            dev->io_regs[0x06] &= ~0x02;
+            solo1_a2_cache_invalidate(dev);
+        }
+    }
+
+    if (dev->a2_irq_bytes_left > 1) {
+        dev->a2_irq_bytes_left--;
+    } else {
+        dev->a2_irq_bytes_left = solo1_a2_transfer_reload_bytes(dev);
+        dev->a2_irq_pending = 1;
+        dev->mixer_regs[0x7a] |= 0x80;
+        solo1_update_irq(dev);
+
+        if (!(dev->mixer_regs[0x78] & 0x10))
+            dev->mixer_regs[0x78] &= ~0x02;
+    }
+
+    return v;
+}
+
+static void
+solo1_a2_fetch_frame(solo1_t *dev)
+{
+    const uint8_t fmt = dev->mixer_regs[0x7a];
+    const int is_signed = !!(fmt & 0x04);
+    const int stereo = !!(fmt & 0x02);
+    const int sixteen = !!(fmt & 0x01);
+
+    if (sixteen) {
+        uint16_t lo, hi;
+        int16_t l, r;
+
+        lo = solo1_a2_read_byte(dev);
+        hi = solo1_a2_read_byte(dev);
+        l = (int16_t) (lo | (hi << 8));
+        if (!is_signed)
+            l = (int16_t) ((uint16_t) l ^ 0x8000U);
+
+        if (stereo) {
+            lo = solo1_a2_read_byte(dev);
+            hi = solo1_a2_read_byte(dev);
+            r = (int16_t) (lo | (hi << 8));
+            if (!is_signed)
+                r = (int16_t) ((uint16_t) r ^ 0x8000U);
+        } else {
+            r = l;
+        }
+
+        dev->a2_last_l = l;
+        dev->a2_last_r = r;
+    } else {
+        uint8_t b = solo1_a2_read_byte(dev);
+        int16_t l = is_signed ? ((int16_t) (int8_t) b << 8)
+                              : ((int16_t) ((uint8_t) (b ^ 0x80)) << 8);
+        int16_t r = l;
+
+        if (stereo) {
+            b = solo1_a2_read_byte(dev);
+            r = is_signed ? ((int16_t) (int8_t) b << 8)
+                          : ((int16_t) ((uint8_t) (b ^ 0x80)) << 8);
+        }
+
+        dev->a2_last_l = l;
+        dev->a2_last_r = r;
+    }
+}
+
+static void
+solo1_mixer_reset_regs(solo1_t *dev)
+{
+    memset(dev->mixer_regs, 0, sizeof(dev->mixer_regs));
+
+    /* ES1938S mixer reset defaults from the Solo-1 data sheet. */
+    dev->mixer_regs[0x14] = 0x88;
+    dev->mixer_regs[0x32] = 0x88;
+    dev->mixer_regs[0x36] = 0x88;
+    dev->mixer_regs[0x38] = 0x00;
+    dev->mixer_regs[0x3c] = 0x04;
+    dev->mixer_regs[0x60] = 0x36;
+    dev->mixer_regs[0x62] = 0x36;
+    dev->mixer_regs[0x64] = 0x00;
+    dev->mixer_regs[0x7c] = 0x00;
+    dev->mixer_regs[0x7d] = 0x08;
+    dev->mixer_index      = 0;
+}
+
+static void
+solo1_get_buffer(int32_t *buffer, uint16_t len, void *priv)
+{
+    solo1_t *dev = (solo1_t *) priv;
+    uint32_t src_rate = solo1_a2_sample_rate(dev);
+    const double gain_l = ess_solo1_legacy_audio2_gain(dev->legacy, 0);
+    const double gain_r = ess_solo1_legacy_audio2_gain(dev->legacy, 1);
+
+    if (!src_rate)
+        src_rate = 8000;
+
+    for (uint16_t i = 0; i < len; i++) {
+        const int active = (dev->io_regs[0x06] & 0x02) &&
+                           ((dev->mixer_regs[0x78] & 0x03) == 0x03) &&
+                           dev->a2_cur_count;
+
+        if (active) {
+            dev->a2_rate_accum += src_rate;
+
+            while (dev->a2_rate_accum >= (uint32_t) sound_sample_rate) {
+                dev->a2_rate_accum -= (uint32_t) sound_sample_rate;
+                solo1_a2_fetch_frame(dev);
+            }
+
+            /* Apply the Solo-1 Audio 2 input curve and actual 6-bit master
+               volume from the synchronized legacy mixer state. */
+            buffer[i * 2]     += (int32_t) ((double) dev->a2_last_l * gain_l);
+            buffer[i * 2 + 1] += (int32_t) ((double) dev->a2_last_r * gain_r);
+        }
+    }
+}
+
+static uint8_t
+solo1_native_io_read(uint16_t addr, void *priv)
+{
+    solo1_t *dev = (solo1_t *) priv;
+    uint8_t off = (uint8_t) (addr - dev->io_base_mapped);
+    uint8_t ret = 0xff;
+
+    switch (off) {
+        case 0x00: ret = (uint8_t) (dev->a2_cur_addr); break;
+        case 0x01: ret = (uint8_t) (dev->a2_cur_addr >> 8); break;
+        case 0x02: ret = (uint8_t) (dev->a2_cur_addr >> 16); break;
+        case 0x03: ret = (uint8_t) (dev->a2_cur_addr >> 24); break;
+        case 0x04: ret = (uint8_t) (dev->a2_cur_count); break;
+        case 0x05: ret = (uint8_t) (dev->a2_cur_count >> 8); break;
+        case 0x06: ret = dev->io_regs[0x06]; break;
+        case 0x07:
+            ret = dev->io_regs[0x07] & 0xf0;
+            if (dev->a2_irq_pending)
+                ret |= 0x20;
+            break;
+        default:
+            if (off < sizeof(dev->io_regs))
+                ret = dev->io_regs[off];
+            break;
+    }
+
+    return ret;
+}
+
+static void
+solo1_native_io_write(uint16_t addr, uint8_t val, void *priv)
+{
+    solo1_t *dev = (solo1_t *) priv;
+    uint8_t off = (uint8_t) (addr - dev->io_base_mapped);
+
+    switch (off) {
+        case 0x00:
+        case 0x01:
+        case 0x02:
+        case 0x03: {
+            const unsigned shift = off * 8;
+            dev->a2_base_addr = (dev->a2_base_addr & ~(0xffU << shift)) |
+                                ((uint32_t) val << shift);
+            dev->a2_base_addr &= ~0x0fU;
+            if (!(dev->io_regs[0x06] & 0x02)) {
+                dev->a2_cur_addr = dev->a2_base_addr;
+                solo1_a2_cache_invalidate(dev);
+            }
+            break;
+        }
+
+        case 0x04:
+            dev->a2_base_count = (dev->a2_base_count & 0xff00U) | val;
+            dev->a2_base_count &= 0xfff0U;
+            if (!(dev->io_regs[0x06] & 0x02)) {
+                dev->a2_cur_count = dev->a2_base_count;
+                solo1_a2_cache_invalidate(dev);
+            }
+            break;
+
+        case 0x05:
+            dev->a2_base_count = (dev->a2_base_count & 0x00ffU) |
+                                 ((uint16_t) val << 8);
+            dev->a2_base_count &= 0xfff0U;
+            if (!(dev->io_regs[0x06] & 0x02)) {
+                dev->a2_cur_count = dev->a2_base_count;
+                solo1_a2_cache_invalidate(dev);
+            }
+            break;
+
+        case 0x06: {
+            const uint8_t old = dev->io_regs[0x06];
+            dev->io_regs[0x06] = val & 0x0f;
+
+            if (!(old & 0x02) && (dev->io_regs[0x06] & 0x02)) {
+                solo1_a2_reload_dma(dev);
+                dev->a2_rate_accum = 0;
+            }
+            break;
+        }
+
+        case 0x07:
+            dev->io_regs[0x07] = val & 0xf0;
+            solo1_update_irq(dev);
+            break;
+
+        default:
+            if (off < sizeof(dev->io_regs))
+                dev->io_regs[off] = val;
+            break;
+    }
+}
+
+static void
+solo1_sb_fifo_clear(solo1_t *dev)
+{
+    dev->sb_read_fifo_r = 0;
+    dev->sb_read_fifo_w = 0;
+    dev->sb_read_fifo_count = 0;
+}
+
+static void
+solo1_sb_fifo_put(solo1_t *dev, uint8_t val)
+{
+    if (dev->sb_read_fifo_count >= sizeof(dev->sb_read_fifo))
+        return;
+
+    dev->sb_read_fifo[dev->sb_read_fifo_w] = val;
+    dev->sb_read_fifo_w = (dev->sb_read_fifo_w + 1) % sizeof(dev->sb_read_fifo);
+    dev->sb_read_fifo_count++;
+}
+
+static uint8_t
+solo1_sb_fifo_get(solo1_t *dev)
+{
+    uint8_t ret = 0x00;
+
+    if (dev->sb_read_fifo_count) {
+        ret = dev->sb_read_fifo[dev->sb_read_fifo_r];
+        dev->sb_read_fifo_r = (dev->sb_read_fifo_r + 1) % sizeof(dev->sb_read_fifo);
+        dev->sb_read_fifo_count--;
+    }
+
+    return ret;
+}
+
+static void
+solo1_ess_reset_regs(solo1_t *dev)
+{
+    memset(dev->ess_regs, 0x00, sizeof(dev->ess_regs));
+
+    dev->ess_regs[0xA5 - 0xA0] = 0xF8;
+
+    dev->ess_ext_enabled = 0;
+    dev->dsp_pending_cmd = 0;
+    dev->dsp_pending_bytes = 0;
+    memset(dev->dsp_pending_data, 0x00, sizeof(dev->dsp_pending_data));
+}
+
+static uint8_t
+solo1_ess_reg_read(solo1_t *dev, uint8_t reg)
+{
+    if (reg >= 0xA0 && reg <= 0xCF)
+        return dev->ess_regs[reg - 0xA0];
+    return 0x00;
+}
+
+static void
+solo1_ess_reg_write(solo1_t *dev, uint8_t reg, uint8_t val)
+{
+    if (reg >= 0xA0 && reg <= 0xCF)
+        dev->ess_regs[reg - 0xA0] = val;
+}
+
+static void
+solo1_dsp_command_byte(solo1_t *dev, uint8_t val)
+{
+    if (dev->dsp_pending_bytes) {
+        uint8_t cmd = dev->dsp_pending_cmd;
+
+        dev->dsp_pending_data[0] = val;
+        dev->dsp_pending_bytes = 0;
+
+        if (cmd == 0xC0) {
+            uint8_t ret = solo1_ess_reg_read(dev, val);
+            solo1_sb_fifo_put(dev, ret);
+        } else if (cmd == 0xC2) {
+            solo1_ess_reg_write(dev, 0xC3, val);
+        } else if (cmd == 0xCF) {
+            solo1_ess_reg_write(dev, 0xCF, val);
+        } else if ((cmd >= 0xA0) && (cmd <= 0xBF) && dev->ess_ext_enabled) {
+            solo1_ess_reg_write(dev, cmd, val);
+        } else {
+        }
+        return;
+    }
+
+    switch (val) {
+        case 0xE1:
+            /* Solo-1 reports Sound Blaster Pro DSP version 3.1. */
+            solo1_sb_fifo_put(dev, 0x03);
+            solo1_sb_fifo_put(dev, 0x01);
+            break;
+
+        case 0xC6:
+            dev->ess_ext_enabled = 1;
+            break;
+
+        case 0xC7:
+            dev->ess_ext_enabled = 0;
+            break;
+
+        case 0xC0:
+        case 0xC2:
+        case 0xCF:
+            dev->dsp_pending_cmd = val;
+            dev->dsp_pending_bytes = 1;
+            break;
+
+        case 0xC3: {
+            uint8_t ret = solo1_ess_reg_read(dev, 0xC3);
+            solo1_sb_fifo_put(dev, ret);
+            break;
+        }
+
+        case 0xCE: {
+            uint8_t ret = solo1_ess_reg_read(dev, 0xCF);
+            solo1_sb_fifo_put(dev, ret);
+            break;
+        }
+
+        default:
+            if ((val >= 0xA0) && (val <= 0xBF) && dev->ess_ext_enabled) {
+                dev->dsp_pending_cmd = val;
+                dev->dsp_pending_bytes = 1;
+            } else {
+            }
+            break;
+    }
+}
+
+static uint8_t
+solo1_sb_read(uint16_t addr, void *priv)
+{
+    solo1_t *dev = (solo1_t *) priv;
+    uint8_t off = (uint8_t) (addr - dev->sb_base_mapped);
+    uint8_t ret;
+
+    /* BAR1 exposes the same ESFM register aliases as the legacy SB block. */
+    if ((off <= 0x03) || (off == 0x08) || (off == 0x09))
+        return ess_solo1_legacy_fm_read(dev->legacy, off);
+
+    if (off == 0x0e) {
+        ret = (dev->sb_reset_response || dev->sb_read_fifo_count) ? 0x80 : 0x00;
+    } else if (off == 0x0a) {
+        if (dev->sb_reset_response) {
+            ret = 0xaa;
+            dev->sb_reset_response = 0;
+        } else if (dev->sb_read_fifo_count) {
+            ret = solo1_sb_fifo_get(dev);
+        } else {
+            ret = 0x00;
+        }
+    } else if (off == 0x0c) {
+        ret = dev->sb_read_fifo_count ? 0x40 : 0x00;
+    } else if (off == 0x04) {
+        ret = dev->mixer_index;
+    } else if (off == 0x05) {
+        ret = dev->mixer_regs[dev->mixer_index];
+    } else {
+        ret = (off < sizeof(dev->sb_regs)) ? dev->sb_regs[off] : 0xff;
+    }
+
+    return ret;
+}
+
+static void
+solo1_sb_write(uint16_t addr, uint8_t val, void *priv)
+{
+    solo1_t *dev = (solo1_t *) priv;
+    uint8_t off = (uint8_t) (addr - dev->sb_base_mapped);
+
+    /* BAR1 exposes the same ESFM register aliases as the legacy SB block. */
+    if ((off <= 0x03) || (off == 0x08) || (off == 0x09)) {
+        ess_solo1_legacy_fm_write(dev->legacy, off, val);
+        return;
+    }
+
+    if (off < sizeof(dev->sb_regs))
+        dev->sb_regs[off] = val;
+
+    if (off == 0x04) {
+        dev->mixer_index = val;
+    } else if (off == 0x05) {
+        if (dev->mixer_index == 0x7a) {
+            /* Bit 7 is the Audio 2 IRQ latch and is cleared by writing 0. */
+            if (!(val & 0x80))
+                dev->a2_irq_pending = 0;
+        }
+
+        if (dev->mixer_index == 0x00)
+            solo1_mixer_reset_regs(dev);
+        else
+            dev->mixer_regs[dev->mixer_index] = val;
+
+        /* Native and legacy views share the physical ESS mixer/ESFM path. */
+        ess_solo1_legacy_mixer_write(dev->legacy, dev->mixer_index, val);
+
+        if (dev->mixer_index == 0x7a)
+            solo1_update_irq(dev);
+
+        if (dev->mixer_index == 0x78 || dev->mixer_index == 0x7a ||
+            dev->mixer_index == 0x70 || dev->mixer_index == 0x74 ||
+            dev->mixer_index == 0x76 || dev->mixer_index == 0x7c) {
+        }
+    }
+
+    if (off == 0x06) {
+        if (val & 0x01) {
+            dev->sb_reset_asserted = 1;
+            dev->sb_reset_response = 0;
+            solo1_sb_fifo_clear(dev);
+            solo1_ess_reset_regs(dev);
+        } else if (dev->sb_reset_asserted) {
+            dev->sb_reset_asserted = 0;
+            dev->sb_reset_response = 1;
+        }
+    } else if (off == 0x0c) {
+        solo1_dsp_command_byte(dev, val);
+    }
+
+}
+
+static uint8_t
+solo1_mpu_read(uint16_t addr, void *priv)
+{
+    solo1_t *dev = (solo1_t *) priv;
+    uint16_t off = (uint16_t) (addr - dev->mpu_base_mapped);
+
+    return ess_solo1_legacy_mpu_read(dev->legacy, off);
+}
+
+static void
+solo1_mpu_write(uint16_t addr, uint8_t val, void *priv)
+{
+    solo1_t *dev = (solo1_t *) priv;
+    uint16_t off = (uint16_t) (addr - dev->mpu_base_mapped);
+
+    ess_solo1_legacy_mpu_write(dev->legacy, off, val);
+}
+
+static uint8_t
+solo1_gp_read(uint16_t addr, void *priv)
+{
+    solo1_t *dev = (solo1_t *) priv;
+    uint8_t off = (uint8_t) (addr - dev->gp_base_mapped);
+    uint8_t ret = (off < sizeof(dev->gp_regs)) ? dev->gp_regs[off] : 0xff;
+
+    return ret;
+}
+
+static void
+solo1_gp_write(uint16_t addr, uint8_t val, void *priv)
+{
+    solo1_t *dev = (solo1_t *) priv;
+    uint8_t off = (uint8_t) (addr - dev->gp_base_mapped);
+
+    if (off < sizeof(dev->gp_regs))
+        dev->gp_regs[off] = val;
+
+}
+
+static uint8_t
+solo1_ddma_read(uint16_t addr, void *priv)
+{
+    solo1_t *dev = (solo1_t *) priv;
+    uint8_t off = (uint8_t) (addr - dev->ddma_base_mapped);
+    uint8_t ret = (off < sizeof(dev->ddma_regs)) ? dev->ddma_regs[off] : 0xff;
+
+    return ret;
+}
+
+static void
+solo1_ddma_write(uint16_t addr, uint8_t val, void *priv)
+{
+    solo1_t *dev = (solo1_t *) priv;
+    uint8_t off = (uint8_t) (addr - dev->ddma_base_mapped);
+
+    if (off < sizeof(dev->ddma_regs))
+        dev->ddma_regs[off] = val;
+
+    if (off == 0x0d)
+        memset(dev->ddma_regs, 0, sizeof(dev->ddma_regs));
+
+}
+
+static void solo1_update_legacy(solo1_t *dev);
+
+static void
+solo1_update_native_mappings(solo1_t *dev)
+{
+    const int pci_io = !!(dev->pci_regs[0x04] & 0x01);
+    const uint16_t io_base = solo1_bar_base(dev, 0x10, 0xc0);
+    const uint16_t sb_base = solo1_bar_base(dev, 0x14, 0xf0);
+    const uint16_t mpu_base = solo1_bar_base(dev, 0x1c, 0xfc);
+    const uint16_t gp_base = solo1_bar_base(dev, 0x20, 0xfc);
+    const uint16_t ddma_base = (uint16_t) ((((uint16_t) dev->pci_regs[0x61]) << 8) |
+                                           (dev->pci_regs[0x60] & 0xf0));
+    const int ddma_enable = !!(dev->pci_regs[0x60] & 0x01);
+
+    if (dev->io_base_mapped) {
+        io_removehandler(dev->io_base_mapped, 0x40,
+                         solo1_native_io_read, NULL, NULL,
+                         solo1_native_io_write, NULL, NULL, dev);
+        dev->io_base_mapped = 0;
+    }
+    if (dev->sb_base_mapped) {
+        io_removehandler(dev->sb_base_mapped, 0x10,
+                         solo1_sb_read, NULL, NULL,
+                         solo1_sb_write, NULL, NULL, dev);
+        dev->sb_base_mapped = 0;
+    }
+    if (dev->mpu_base_mapped) {
+        io_removehandler(dev->mpu_base_mapped, 0x04,
+                         solo1_mpu_read, NULL, NULL,
+                         solo1_mpu_write, NULL, NULL, dev);
+        dev->mpu_base_mapped = 0;
+    }
+    if (dev->gp_base_mapped) {
+        io_removehandler(dev->gp_base_mapped, 0x04,
+                         solo1_gp_read, NULL, NULL,
+                         solo1_gp_write, NULL, NULL, dev);
+        dev->gp_base_mapped = 0;
+    }
+    if (dev->ddma_base_mapped) {
+        io_removehandler(dev->ddma_base_mapped, 0x10,
+                         solo1_ddma_read, NULL, NULL,
+                         solo1_ddma_write, NULL, NULL, dev);
+        dev->ddma_base_mapped = 0;
+    }
+
+    if (pci_io && io_base) {
+        dev->io_base_mapped = io_base;
+        io_sethandler(io_base, 0x40,
+                      solo1_native_io_read, NULL, NULL,
+                      solo1_native_io_write, NULL, NULL, dev);
+    }
+    if (pci_io && sb_base) {
+        dev->sb_base_mapped = sb_base;
+        io_sethandler(sb_base, 0x10,
+                      solo1_sb_read, NULL, NULL,
+                      solo1_sb_write, NULL, NULL, dev);
+    }
+    if (pci_io && mpu_base) {
+        dev->mpu_base_mapped = mpu_base;
+        io_sethandler(mpu_base, 0x04,
+                      solo1_mpu_read, NULL, NULL,
+                      solo1_mpu_write, NULL, NULL, dev);
+    }
+    if (pci_io && gp_base) {
+        dev->gp_base_mapped = gp_base;
+        io_sethandler(gp_base, 0x04,
+                      solo1_gp_read, NULL, NULL,
+                      solo1_gp_write, NULL, NULL, dev);
+    }
+    if (pci_io && ddma_enable && ddma_base) {
+        dev->ddma_base_mapped = ddma_base;
+        io_sethandler(ddma_base, 0x10,
+                      solo1_ddma_read, NULL, NULL,
+                      solo1_ddma_write, NULL, NULL, dev);
+    }
+
+    /* Separate legacy core from PCI BARs to fix Win98 driver init */
+    solo1_update_legacy(dev);
+
+}
+
+static void
+solo1_update_legacy(solo1_t *dev)
+{
+    const uint8_t  lacr_lo = dev->pci_regs[0x40];
+    const uint8_t  lacr_hi = dev->pci_regs[0x41];
+    const int      legacy_enable = !(lacr_hi & 0x80);
+    const uint16_t sb_base = (dev->pci_regs[0x50] & 0x04) ? 0x240 : 0x220;
+    const uint16_t mpu_base = solo1_decode_mpu_base(dev);
+    const int      sb_irq = solo1_decode_irq(lacr_hi & 0x07);
+    const int      mpu_irq = solo1_decode_irq((lacr_hi >> 3) & 0x07);
+    const int      dma = solo1_decode_dma((lacr_lo >> 6) & 0x03);
+    const int      sb_enable = legacy_enable && (lacr_lo & 0x01);
+    const int      fm_enable = legacy_enable && (lacr_lo & 0x02);
+    const int      gp_enable = legacy_enable && (lacr_lo & 0x04);
+    const int      mpu_enable = legacy_enable && (lacr_lo & 0x08);
+    const int      mpu_irq_enable = legacy_enable && (lacr_lo & 0x10);
+
+    /* Legacy resources */
+    ess_solo1_legacy_config(dev->legacy,
+                            sb_base,
+                            sb_enable,
+                            fm_enable,
+                            fm_enable,
+                            mpu_base,
+                            mpu_enable,
+                            sb_irq,
+                            mpu_irq_enable ? mpu_irq : -1,
+                            dma,
+                            gp_enable ? 0x0200 : 0);
+
+}
+
+static void
+solo1_write_bar(solo1_t *dev, int addr, uint8_t val)
+{
+    int base = addr & ~3;
+    int off  = addr & 3;
+
+    /* Solo-1 decodes only 16 bits of each I/O BAR. */
+    if (off >= 2) {
+        dev->pci_regs[addr] = 0x00;
+        return;
+    }
+
+    if (off == 0) {
+        if (base == 0x10)
+            val = (val & 0xc0) | 0x01; /* BAR0: 64-byte I/O region */
+        else if (base == 0x14 || base == 0x18)
+            val = (val & 0xf0) | 0x01; /* BAR1/BAR2: 16-byte I/O regions */
+        else
+            val = (val & 0xfc) | 0x01; /* BAR3/BAR4: 4-byte I/O regions */
+    }
+
+    dev->pci_regs[addr] = val;
+}
+
+static void
+solo1_pci_write(int func, int addr, UNUSED(int len), uint8_t val, void *priv)
+{
+    solo1_t *dev = (solo1_t *) priv;
+
+    if (func || addr < 0 || addr > 0xff)
+        return;
+
+
+    switch (addr) {
+        case 0x04: /* Command low: I/O enable + bus master only. */
+            dev->pci_regs[addr] = val & 0x05;
+            break;
+
+        case 0x05:
+            dev->pci_regs[addr] = 0x00;
+            break;
+
+        case 0x06: /* Status low: fixed capability/DEVSEL-related bits. */
+            dev->pci_regs[addr] = 0x90;
+            break;
+
+        case 0x07: /* Abort status bits are write-one-to-clear. */
+            dev->pci_regs[addr] &= ~(val & 0x30);
+            break;
+
+        case 0x0d:
+            dev->pci_regs[addr] = val & 0xf0;
+            break;
+
+        case 0x10: case 0x11: case 0x12: case 0x13:
+        case 0x14: case 0x15: case 0x16: case 0x17:
+        case 0x18: case 0x19: case 0x1a: case 0x1b:
+        case 0x1c: case 0x1d: case 0x1e: case 0x1f:
+        case 0x20: case 0x21: case 0x22: case 0x23:
+            solo1_write_bar(dev, addr, val);
+            break;
+
+        case 0x2c: case 0x2d: case 0x2e: case 0x2f:
+            if (dev->pci_regs[0x50] & 0x01)
+                dev->pci_regs[addr] = val;
+            break;
+
+        case 0x3c:
+            /* Force IRQ5 only for onboard */
+            dev->pci_regs[addr] = dev->onboard ? 0x05 : val;
+            break;
+
+        case 0x40:
+        case 0x41:
+            dev->pci_regs[addr] = val;
+            break;
+
+        case 0x50:
+        case 0x51:
+        case 0x52:
+        case 0x53:
+            dev->pci_regs[addr] = val;
+            break;
+
+        case 0x60:
+            dev->pci_regs[addr] = (val & 0xf0) | (val & 0x01);
+            break;
+
+        case 0x61:
+            dev->pci_regs[addr] = val;
+            break;
+
+        case 0xc4:
+            dev->pci_regs[addr] = val & 0x03;
+            break;
+
+        case 0xc5:
+            dev->pci_regs[addr] = 0x00;
+            break;
+
+        default:
+            return;
+    }
+
+    if ((addr == 0x40) || (addr == 0x41) ||
+        ((addr >= 0x50) && (addr <= 0x53)))
+        solo1_update_legacy(dev);
+
+    if ((addr == 0x04) || (addr == 0x3c) ||
+        ((addr >= 0x10) && (addr <= 0x23)) ||
+        ((addr >= 0x40) && (addr <= 0x41)) ||
+        ((addr >= 0x50) && (addr <= 0x53)) ||
+        ((addr >= 0x60) && (addr <= 0x61)))
+        solo1_update_native_mappings(dev);
+}
+
+static void
+solo1_reset(void *priv)
+{
+    solo1_t *dev = (solo1_t *) priv;
+
+    if (dev->legacy != NULL)
+        ess_solo1_legacy_reset(dev->legacy);
+
+    memset(dev->pci_regs, 0x00, sizeof(dev->pci_regs));
+    memset(dev->io_regs, 0x00, sizeof(dev->io_regs));
+    memset(dev->sb_regs, 0x00, sizeof(dev->sb_regs));
+    memset(dev->mpu_regs, 0x00, sizeof(dev->mpu_regs));
+    dev->mpu_ack_pending = 0;
+    memset(dev->gp_regs, 0x00, sizeof(dev->gp_regs));
+    memset(dev->ddma_regs, 0x00, sizeof(dev->ddma_regs));
+    dev->sb_reset_asserted = 0;
+    dev->sb_reset_response = 0;
+    solo1_sb_fifo_clear(dev);
+    solo1_ess_reset_regs(dev);
+
+    dev->pci_regs[0x00] = 0x5d; /* VID 125Dh */
+    dev->pci_regs[0x01] = 0x12;
+    dev->pci_regs[0x02] = 0x69; /* DID 1969h */
+    dev->pci_regs[0x03] = 0x19;
+
+    dev->pci_regs[0x06] = 0x90; /* Status reset 0290h */
+    dev->pci_regs[0x07] = 0x02;
+
+    dev->pci_regs[0x08] = 0x00; /* Revision */
+    dev->pci_regs[0x09] = 0x00; /* Programming interface */
+    dev->pci_regs[0x0a] = 0x01; /* Audio */
+    dev->pci_regs[0x0b] = 0x04; /* Multimedia */
+    dev->pci_regs[0x0e] = 0x00; /* Single-function */
+
+    dev->pci_regs[0x10] = 0x01;
+    dev->pci_regs[0x14] = 0x01;
+    dev->pci_regs[0x18] = 0x01;
+    dev->pci_regs[0x1c] = 0x01;
+    dev->pci_regs[0x20] = 0x01;
+
+    dev->pci_regs[0x2c] = 0x5d; /* SVID 125Dh */
+    dev->pci_regs[0x2d] = 0x12;
+    dev->pci_regs[0x2e] = 0x18; /* SID 1818h */
+    dev->pci_regs[0x2f] = 0x18;
+
+    dev->pci_regs[0x34] = 0xc0;
+    dev->pci_regs[0x3c] = 0xff;
+    dev->pci_regs[0x3d] = 0x01; /* INTA */
+    dev->pci_regs[0x3e] = 0x02;
+    dev->pci_regs[0x3f] = 0x18;
+
+    dev->pci_regs[0x40] = 0x7f; /* Legacy Audio Control = 907Fh */
+    dev->pci_regs[0x41] = 0x90;
+
+    dev->pci_regs[0xc0] = 0x01; /* PCI PM capability */
+    dev->pci_regs[0xc1] = 0x00;
+    dev->pci_regs[0xc2] = 0x21; /* PM capabilities = 0621h */
+    dev->pci_regs[0xc3] = 0x06;
+    dev->pci_regs[0xc4] = 0x00; /* PMCSR = D0 */
+    dev->pci_regs[0xc5] = 0x00;
+
+    memset(dev->io_regs, 0, sizeof(dev->io_regs));
+    memset(dev->ddma_regs, 0, sizeof(dev->ddma_regs));
+    solo1_mixer_reset_regs(dev);
+
+    dev->a2_base_addr = 0;
+    dev->a2_cur_addr = 0;
+    dev->a2_base_count = 0;
+    dev->a2_cur_count = 0;
+    dev->a2_rate_accum = 0;
+    dev->a2_irq_bytes_left = 0;
+    dev->a2_last_l = 0;
+    dev->a2_last_r = 0;
+    dev->a2_irq_pending = 0;
+    solo1_a2_cache_invalidate(dev);
+    solo1_update_irq(dev);
+
+    solo1_update_legacy(dev);
+    solo1_update_native_mappings(dev);
+}
+
+static void *
+solo1_init(const device_t *info)
+{
+    solo1_t *dev = calloc(1, sizeof(solo1_t));
+
+    dev->onboard = (uint8_t) (info->local != 0);
+
+    dev->legacy = ess_solo1_legacy_init();
+    sound_add_handler(solo1_get_buffer, dev);
+
+    pci_add_card(PCI_ADD_SOUND, solo1_pci_read, solo1_pci_write,
+                 dev, &dev->pci_slot);
+    solo1_reset(dev);
+
+    return dev;
+}
+
+static void
+solo1_close(void *priv)
+{
+    solo1_t *dev = (solo1_t *) priv;
+    dev->pci_regs[0x04] &= ~0x01;
+    dev->pci_regs[0x60] &= ~0x01;
+    solo1_update_native_mappings(dev);
+    if (dev->legacy != NULL)
+        ess_solo1_legacy_close(dev->legacy);
+    free(dev);
+}
+
+const device_t ess_solo1_onboard_device = {
+    .name          = "ESS ES1938S Solo-1 (On-Board)",
+    .internal_name = "ess_solo1_onboard",
+    .flags         = DEVICE_PCI,
+    .local         = 1,
+    .init          = solo1_init,
+    .close         = solo1_close,
+    .reset         = solo1_reset,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = NULL
+};

--- a/src/sound/sound.c
+++ b/src/sound/sound.c
@@ -239,6 +239,7 @@ static const SOUND_CARD sound_cards[] = {
     { &es1371_device                },
     { &es1373_device                },
     { &ct5880_device                },
+    { &ess_solo1_device             },
     /* AC97 */
     { &ad1881_device                },
     { &cs4297a_device               },


### PR DESCRIPTION
Summary
=======
This adds the BCM IN530 (GVC FR520 / Packard Bell Miami/PB980 / NEC Valuestar U VU47L) except for the integrated SiS 6306 VGA GPU, as well as the ESS 1938S Solo-1 as a standalone card.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already (Mamoru gave permission to PR without the integrated gpu)
* [X] This pull request requires changes to the ROM set
  * [X] I have opened a roms pull request - https://github.com/86Box/roms/pull/539/

References
==========
https://theretroweb.com/motherboards/s/bcm-in530
Real machine for hardware testing/information gathering
