### PR TITLE
LPT: Add Raw SPP with handshaking pipe mode

### DIFF
--- a/src/char/char_pipe.c
+++ b/src/char/char_pipe.c
@@ -462,6 +462,10 @@ char_pipe_init(const device_t *info)
                 flags |= CHAR_LPT_PTI;
                 break;
 
+            case 3:
+                flags |= CHAR_LPT_NIBBLE | CHAR_LPT_USESTROBE;
+                break;
+
             default:
                 break;
         }
@@ -492,6 +496,7 @@ static const device_config_t char_pipe_config[] = {
             { .description = "Unidirectional (8-bit) / LapLink (4-bit)", .value = 0 },
             { .description = "Bidirectional (8-bit)",                    .value = 1 },
             { .description = "DirectParallel FAST",                      .value = 2 },
+            { .description = "Raw SPP with handshaking",                  .value = 3 },
             { NULL                                                                  }
         }
     },

--- a/src/device/lpt.c
+++ b/src/device/lpt.c
@@ -611,6 +611,13 @@ lpt_write(const uint16_t port, const uint8_t val, void *priv)
             break;
 
         case 0x0002:
+            /* A bidirectional port still latches DTR writes while its pins are
+               inputs. Drive that latched byte before an output-mode strobe. */
+            if (dev->output_enabled && (dev->ext || dev->epp) &&
+                (dev->ctrl & 0x20) && !(val & 0x20) && dev->dt &&
+                dev->dt->write_data && dev->dt->priv)
+                dev->dt->write_data(dev->dat, dev->dt->priv);
+
             if (dev->output_enabled && dev->dt && dev->dt->write_ctrl && dev->dt->priv)
                 dev->dt->write_ctrl(val, dev->dt->priv);
             dev->ctrl       = val;


### PR DESCRIPTION
Summary
=======
In LPT mode 1 (the default), data is written to the outgoing pipe (or file) immediately as soon as the guest writes to the LPT port (usually 378h). This can cause timing issues with some operating systems (specifically OS/2 1.3 or DOS with a print spooler such as PRINT.EXE) where the first character of a new print job gets eaten.

A new mode called "Raw SPP with handshaking" makes two changes:

- It enables outgoing strobe, which means the data byte isn't written to the pipe or file until the VM fires STROBE.
- It also provides a reverse channel (via the two-pipes method similar to what the LapLink mode uses) where 4-bit status data can be written back, so that a "virtual printer" device in a third-party program can perform handshaking with the VM's printer driver/OS.

An example of a third-party program to drive this is in <https://github.com/JoshRodd/86Box-tool/tree/master/fifo_printer>.

Tested operating systems with new mode:
- IBM OS/2 1.3 Extended Edition with IBM 4019 driver printing from MS Excel 3.0 for OS/2 PM
- IBM OS/2 1.3 Extended Edition with IBM DWScript printing directly to LPT1: print spooler
- IBM PC DOS 4.01 (with CSD applied)'s PRINT.EXE
- IBM PC DOS 4.01 (with CSD applied) running DWSCRIPT.EXE to LPT1: device directly, no print spooler
Host devices are PS/2 Model 80 Type 2 (standard PS/2 parallel port) and Type 3 (unique DMA based parallel port)

Code partially written with AI assistance. Testing extensively used AI assistance. This PR was written without AI assistance.

Checklist
=========
* [X] Closes #xxx - N/A, no issue for this had been created
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set - N/A
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set- N/A
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency - N/A
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
