### PR TITLE
Minor GUS fixes

### DIFF
--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -773,6 +773,7 @@ gus_write(uint16_t addr, uint8_t val, void *priv)
                 case 0x49: /*ADC Sample Control*/
                     /* This is the ADC equivalent of index 41h DMA Control and is relied on by MegaEM 3.x */
                     gus->adc_ctrl = val;
+                    gus->adc_ctrl &= ~0x40;
                     if (val & 1)
                         timer_set_delay_u64(&gus->sample_timer, (uint64_t) gus->inputlatch);
                     gus_log(gus->log, "GUS DMA Control write! new val = %02X\n", val);

--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -1867,7 +1867,6 @@ gus_reset(void *priv)
     gus->midi_r = 0;
     gus->midi_w = 0;
     gus->uart_in = 0;
-    gus->uart_out = 0;
     gus->sysex = 0;
 
     gus->gp1_in = 0;

--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -657,8 +657,6 @@ gus_write(uint16_t addr, uint8_t val, void *priv)
                                     if ((gus_addr + 1) < gus->gus_end_ram)
                                         d                 |= (gus->ram[gus_addr + 1] << 8);
 
-                                    if (val & 0x80)
-                                        d ^= 0x8080;
                                     dma_result = dma_channel_write(gus->dma, d);
                                     if (dma_result == DMA_NODATA)
                                         break;
@@ -668,8 +666,6 @@ gus_write(uint16_t addr, uint8_t val, void *priv)
                                     else
                                         d = 0x00;
 
-                                    if (val & 0x80)
-                                        d ^= 0x80;
                                     dma_result = dma_channel_write(gus->dma, d);
                                     if (dma_result == DMA_NODATA)
                                         break;

--- a/src/sound/snd_gus.c
+++ b/src/sound/snd_gus.c
@@ -371,16 +371,16 @@ gus_input_poll(void *priv)
     if (gus->adc_ctrl & 0x01) {
         if (gus->adc_ctrl & 0x02) {
             if (gus->adc_ctrl & 0x04)
-                dma_result = dma_channel_write(gus->dma, (gus->adc_ctrl & 0x80) ? 0x0000 : 0x8080);
+                dma_result = dma_channel_write(gus->dma2, (gus->adc_ctrl & 0x80) ? 0x0000 : 0x8080);
             else {
-                dma_result = dma_channel_write(gus->dma, (gus->adc_ctrl & 0x80) ? 0x00 : 0x80);
-                dma_result = dma_channel_write(gus->dma, (gus->adc_ctrl & 0x80) ? 0x00 : 0x80);
+                dma_result = dma_channel_write(gus->dma2, (gus->adc_ctrl & 0x80) ? 0x00 : 0x80);
+                dma_result = dma_channel_write(gus->dma2, (gus->adc_ctrl & 0x80) ? 0x00 : 0x80);
             }
         } else {
             if (gus->adc_ctrl & 0x04)
-                dma_result = dma_channel_write(gus->dma, (gus->adc_ctrl & 0x80) ? 0x0000 : 0x0080);
+                dma_result = dma_channel_write(gus->dma2, (gus->adc_ctrl & 0x80) ? 0x0000 : 0x0080);
             else
-                dma_result = dma_channel_write(gus->dma, (gus->adc_ctrl & 0x80) ? 0x00 : 0x80);
+                dma_result = dma_channel_write(gus->dma2, (gus->adc_ctrl & 0x80) ? 0x00 : 0x80);
         }
         if (dma_result & DMA_OVER) {
             gus->adc_ctrl &= 0xfe;


### PR DESCRIPTION
Summary
=======
Make the following changes to the GUS:
- Remove a redundant setting of gus->uart_out during device reset
- Use the correct recording DMA channel when GF1 record DMA is active
- Correctly make ADC Sample Control (49h) register's bit 6 read-only
- Do not invert the MSB when performing Local DRAM->System DRAM DMA transfers (per the documentation the Invert MSB bit only affects System DRAM->Local DRAM transfers).

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
-  AMD InterWave Programmer's Guide: http://hackipedia.org/browse.cgi/Computer/Platform/PC%2c%20IBM%20compatible/Sound%20and%20Music/Advanced%20Micro%20Devices%20%28AMD%29/Interwave/InterWave%20IC%20Am78C201%2d202%20Programmer%27s%20Guide%20%281996%29%20Revision%202%2epdf
- Gravis UltraSound Low-level Toolkit documentation: https://www.infania.net/misc1/GUS/docs/UltraSound%20Lowlevel%20ToolKit%20v2.22%20(21%20December%201994).pdf