### PR TITLE
rdisk: Fix sector counts of Jaz disks

### DIFF
--- a/src/include/86box/rdisk.h
+++ b/src/include/86box/rdisk.h
@@ -28,9 +28,9 @@
 
 #define ZIP_750_SECTORS     (1468596) /* Estimated */
 
-#define JAZ_1GB_SECTORS     (2045952)
+#define JAZ_1GB_SECTORS     (2091050)
 
-#define JAZ_2GB_SECTORS     (3903796)
+#define JAZ_2GB_SECTORS     (3915600)
 
 #define SUPERDISK_SECTORS      (963 * 256)
 


### PR DESCRIPTION
Summary
=======
rdisk: Fix sector counts of Jaz disks.

Checklist
=========
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
None.
