### PR TITLE
Add revised IBM PC 730/750 (types 6877/6887) support

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -1594,49 +1594,52 @@ pc_send_ca(uint16_t sc)
         /* Use R-Alt because PS/55 DOS and OS/2 assign L-Alt Kanji */
         keyboard_input(1, 0x1D);  /*  Ctrl key pressed */
         if (keyboard_get_in_reset())
-            return;
+            goto cleanup;
         keyboard_input(1, 0x138); /* R-Alt key pressed */
         if (keyboard_get_in_reset())
-            return;
+            goto cleanup;
         keyboard_input(1, sc);
         if (keyboard_get_in_reset())
-            return;
+            goto cleanup;
         usleep(50000);
         if (keyboard_get_in_reset())
-            return;
+            goto cleanup;
         keyboard_input(0, sc);
         if (keyboard_get_in_reset())
-            return;
+            goto cleanup;
         keyboard_input(0, 0x138); /* R-Alt key released */
         if (keyboard_get_in_reset())
-            return;
+            goto cleanup;
         keyboard_input(0, 0x1D);  /*  Ctrl key released */
         if (keyboard_get_in_reset())
-            return;
+            goto cleanup;
     } else {
         keyboard_input(1, 0x1D); /* Ctrl key pressed */
         if (keyboard_get_in_reset())
-            return;
+            goto cleanup;
         keyboard_input(1, 0x38); /* Alt key pressed */
         if (keyboard_get_in_reset())
-            return;
+            goto cleanup;
         keyboard_input(1, sc);
         if (keyboard_get_in_reset())
-            return;
+            goto cleanup;
         usleep(50000);
         if (keyboard_get_in_reset())
-            return;
+            goto cleanup;
         keyboard_input(0, sc);
         if (keyboard_get_in_reset())
-            return;
+            goto cleanup;
         keyboard_input(0, 0x38); /* Alt key released */
         if (keyboard_get_in_reset())
-            return;
+            goto cleanup;
         keyboard_input(0, 0x1D); /* Ctrl key released */
         if (keyboard_get_in_reset())
-            return;
+            goto cleanup;
     }
 
+cleanup:
+    if (keyboard_get_in_reset())
+        keyboard_all_up();
     keyboard_toggle_override();
 }
 

--- a/src/chipset/intel_4x0.c
+++ b/src/chipset/intel_4x0.c
@@ -97,7 +97,8 @@ i4x0_map(i4x0_t *dev, uint32_t addr, uint32_t size, int state)
     if (dev->mem_state[base] != state) {
         mem_set_mem_state_both(addr, size, states[state]);
         dev->mem_state[base] = state;
-        flushmmucache_nopc();
+        /* A PAM change can replace the backing of the current instruction page. */
+        flushmmucache();
     }
 }
 

--- a/src/chipset/intel_piix.c
+++ b/src/chipset/intel_piix.c
@@ -68,6 +68,7 @@ typedef struct _piix_ {
     uint16_t       func0_id;
     uint16_t       nvr_io_base;
     uint16_t       acpi_io_base;
+    uint16_t       irq_state;
     double         fast_off_period;
     sff8038i_t    *bm[2];
     smbus_piix4_t *smbus;
@@ -471,6 +472,29 @@ piix_trap_update(void *priv)
  */
 static piix_t *piix_ext = NULL;
 
+static void
+piix_irq(uint16_t num, int set, void *priv)
+{
+    piix_t        *dev    = (piix_t *) priv;
+    uint8_t       *fregs  = dev->regs[0];
+    const uint16_t rising = num & ~dev->irq_state;
+    uint8_t        status;
+
+    if (!set) {
+        dev->irq_state &= ~num;
+        return;
+    }
+
+    dev->irq_state |= num;
+    /* SMIEN/SMIREQ bits 0-4 correspond to IRQ1, IRQ3, IRQ4, IRQ8 and IRQ12. */
+    status = ((rising >> 1) & 0x01) | ((rising >> 2) & 0x06) |
+             ((rising >> 5) & 0x08) | ((rising >> 8) & 0x10);
+    status &= fregs[0xa2];
+    fregs[0xaa] |= status;
+    if (status && (fregs[0xa0] & 0x01))
+        smi_raise();
+}
+
 void
 piix_extsmi_raise(void)
 {
@@ -701,8 +725,12 @@ piix_write(int func, int addr, UNUSED(int len), uint8_t val, void *priv)
                 break;
             case 0xa0:
                 if (dev->type < 4) {
+                    const uint8_t old = fregs[addr];
+
                     fregs[addr] = val & 0x1f;
                     apm_set_do_smi(dev->apm, !!(val & 0x01) && !!(fregs[0xa2] & 0x80));
+                    if ((val & 0x01) && !(old & 0x01) && fregs[0xaa])
+                        smi_raise();
                     switch ((val & 0x18) >> 3) {
                         case 0x00:
                             dev->fast_off_period = PCICLK * 32768.0 * 60000.0;
@@ -1471,12 +1499,14 @@ piix_fast_off_count(void *priv)
 static void
 piix_reset(void *priv)
 {
-    const piix_t *dev = (piix_t *) priv;
+    piix_t *dev = (piix_t *) priv;
 
     if (dev->type > 3) {
         piix_write(3, 0x04, 1, 0x00, priv);
         piix_write(3, 0x5b, 1, 0x00, priv);
     } else {
+        dev->irq_state    = 0;
+        dev->regs[0][0xaa] = dev->regs[0][0xab] = 0;
         piix_write(0, 0xa0, 1, 0x08, priv);
         piix_write(0, 0xa2, 1, 0x00, priv);
         piix_write(0, 0xa4, 1, 0x00, priv);
@@ -1554,6 +1584,11 @@ piix_close(void *priv)
 {
     piix_t *dev = (piix_t *) priv;
 
+    if (dev->type < 4)
+        pic_set_irq_callback(NULL, NULL);
+    if (piix_ext == dev)
+        piix_ext = NULL;
+
     for (int i = 0; i < (sizeof(dev->io_traps) / sizeof(dev->io_traps[0])); i++)
         io_trap_remove(dev->io_traps[i].trap);
 
@@ -1582,6 +1617,8 @@ piix_init(const device_t *info)
     piix_ext = dev;
     
     dev->type = info->local & 0x0f;
+    if (dev->type < 4)
+        pic_set_irq_callback(piix_irq, dev);
     /* If (dev->type == 4) and (dev->rev & 0x08), then this is PIIX4E. */
     dev->rev        = (info->local >> 4) & 0x0f;
     dev->func_shift = (info->local >> 8) & 0x0f;

--- a/src/cpu/cpu.c
+++ b/src/cpu/cpu.c
@@ -425,6 +425,10 @@ cpu_is_eligible(const cpu_family_t *cpu_family, int cpu, int machine)
 
     bus_speed = cpu_s->rspeed / cpu_s->multi;
 
+    /* The IBM PC 700 firmware has no speed entry for the 50 MHz / 2x setting. */
+    if ((machine_s->init == machine_at_ibm_pc700_init) && (bus_speed == 50000000) && (cpu_s->multi == 2.0))
+        return 0;
+
     /* Minimum bus speed with ~0.84 MHz (for 8086) tolerance. */
     if (machine_s->cpu.min_bus && (bus_speed < (machine_s->cpu.min_bus - 840907)))
         return 0;

--- a/src/device/keyboard.c
+++ b/src/device/keyboard.c
@@ -397,9 +397,14 @@ keyboard_all_up(void)
 
         if (recv_key[i]) {
             recv_key[i] = 0;
-            key_process(i, 0);
+            if (kbd_in_reset)
+                oldkey[i] = 0;
+            else
+                key_process(i, 0);
         }
     }
+
+    shift = 0;
 }
 
 void

--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -1174,6 +1174,10 @@ extern int             machine_at_epc2102_init(const machine_t *);
 extern int             machine_at_pcv90_init(const machine_t *);
 extern int             machine_at_p55t2s_init(const machine_t *);
 
+/* IBM PC 730/750 (types 6877/6887) */
+extern uint32_t         machine_at_ibm_pc700_gpio_handler(uint8_t write, uint32_t val);
+extern int             machine_at_ibm_pc700_init(const machine_t *);
+
 /* i430VX */
 extern int             machine_at_ap5vm_init(const machine_t *);
 extern int             machine_at_p55tvp4_init(const machine_t *);

--- a/src/include/86box/nvr_ps2.h
+++ b/src/include/86box/nvr_ps2.h
@@ -35,7 +35,12 @@
 #ifndef EMU_NVRPS2_H
 #define EMU_NVRPS2_H
 
+#include <stdint.h>
+
 extern const device_t ps2_nvr_device;
 extern const device_t ps2_nvr_55ls_device;
+
+extern int  ps2_nvr_is_new(void *priv);
+extern void ps2_nvr_set_byte(void *priv, uint16_t addr, uint8_t val);
 
 #endif /*EMU_NVRPS2_H*/

--- a/src/include/86box/pic.h
+++ b/src/include/86box/pic.h
@@ -63,6 +63,7 @@ extern void     pic_reset_smi_irq_mask(void);
 extern void     pic_set_smi_irq_mask(int irq, int set);
 extern uint16_t pic_get_smi_irq_status(void);
 extern void     pic_clear_smi_irq_status(int irq);
+extern void     pic_set_irq_callback(void (*callback)(uint16_t, int, void *), void *priv);
 
 extern int     pic_elcr_get_enabled(void);
 extern void    pic_elcr_set_enabled(int enabled);

--- a/src/machine/CMakeLists.txt
+++ b/src/machine/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(mch OBJECT
     m_at_socket5.c
     m_at_socket7_3v.c
     m_at_socket7.c
+    m_at_ibm_pc700.c
     m_at_sockets7.c
     m_at_socket8.c
     m_at_slot1.c

--- a/src/machine/m_at_ibm_pc700.c
+++ b/src/machine/m_at_ibm_pc700.c
@@ -1,0 +1,460 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          IBM PC 730/750 (types 6877/6887) system board glue.
+ *
+ * Authors: The 86Box Project
+ *
+ *          Copyright 2026 The 86Box Project
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <86box/86box.h>
+#include <86box/device.h>
+#include <86box/chipset.h>
+#include <86box/io.h>
+#include <86box/machine.h>
+#include <86box/mem.h>
+#include <86box/nmc93cxx.h>
+#include <86box/nvr_ps2.h>
+#include <86box/pci.h>
+#include <86box/plat.h>
+#include <86box/plat_unused.h>
+#include <86box/rom.h>
+#include <86box/sio.h>
+#include <86box/timer.h>
+#include <86box/nvr.h>
+#include <86box/video.h>
+
+#include "cpu.h"
+
+#define IBM_PC700_FLASH_BANK_SIZE 0x20000
+
+typedef struct ibm_pc700_t {
+    nmc93cxx_eeprom_t *eeprom;
+    void            *riser_nvr;
+
+    uint8_t flash_bank;
+    uint8_t gpio[2];
+
+    uint8_t rapid_data;
+    uint8_t rapid_status_phase;
+    uint8_t rapid_command;
+    uint8_t rapid_command_phase;
+
+    uint8_t board_7c;
+    uint8_t board_7d;
+    uint8_t board_7e;
+    uint8_t board_7f;
+
+    uint8_t pos_94;
+    uint8_t pos[4];
+
+    uint16_t eeprom_default[64];
+} ibm_pc700_t;
+
+static ibm_pc700_t *ibm_pc700;
+
+static uint8_t
+ibm_pc700_flash_read(uint32_t addr, void *priv)
+{
+    const ibm_pc700_t *dev = (const ibm_pc700_t *) priv;
+    const uint32_t     off = ((uint32_t) dev->flash_bank << 17) | (addr & 0x1ffff);
+
+    return rom[off];
+}
+
+static uint16_t
+ibm_pc700_flash_readw(uint32_t addr, void *priv)
+{
+    uint16_t ret = ibm_pc700_flash_read(addr, priv);
+
+    ret |= ((uint16_t) ibm_pc700_flash_read(addr + 1, priv)) << 8;
+    return ret;
+}
+
+static uint32_t
+ibm_pc700_flash_readl(uint32_t addr, void *priv)
+{
+    uint32_t ret = ibm_pc700_flash_readw(addr, priv);
+
+    ret |= ((uint32_t) ibm_pc700_flash_readw(addr + 2, priv)) << 16;
+    return ret;
+}
+
+static void
+ibm_pc700_flash_map(ibm_pc700_t *dev, uint8_t bank, bool force)
+{
+    bank = !!bank;
+    if (!force && dev->flash_bank == bank)
+        return;
+
+    dev->flash_bank = bank;
+    mem_mapping_set_exec(&bios_mapping, &rom[bank * IBM_PC700_FLASH_BANK_SIZE]);
+    mem_mapping_set_exec(&bios_high_mapping, &rom[bank * IBM_PC700_FLASH_BANK_SIZE]);
+    flushmmucache();
+    pclog("IBM PC 700: Flash bank %u selected\n", bank);
+}
+
+static uint8_t
+ibm_pc700_cpu_straps(void)
+{
+    uint8_t ret;
+
+    /* SW1/4 and SW1/3 select the bus clock; an open switch reads as one. */
+    if (cpu_busspeed <= 50000000)
+        ret = 0x00;
+    else if (cpu_busspeed <= 60000000)
+        ret = 0x02;
+    else
+        ret = 0x01;
+
+    /* SW1/2 and SW1/1 select the multiplier. */
+    if (cpu_dmulti <= 1.5)
+        ret |= 0x0c;
+    else if (cpu_dmulti <= 2.0)
+        ret |= 0x08;
+    else if (cpu_dmulti > 2.5)
+        ret |= 0x04;
+
+    return ret;
+}
+
+uint32_t
+machine_at_ibm_pc700_gpio_handler(uint8_t write, uint32_t val)
+{
+    ibm_pc700_t *dev = ibm_pc700;
+
+    if (dev == NULL)
+        return 0xffffffff;
+
+    if (write) {
+        dev->gpio[0] = val & 0xff;
+        dev->gpio[1] = (val >> 8) & 0xff;
+
+        nmc93cxx_eeprom_write(dev->eeprom,
+                             !!(dev->gpio[1] & 0x04),
+                             !!(dev->gpio[1] & 0x08),
+                             !!(dev->gpio[1] & 0x10));
+
+        /* GPIO 78 bit 4 selects Flash A17; GPIO 79 bit 2 is EEPROM CS. */
+        ibm_pc700_flash_map(dev, !!(dev->gpio[0] & 0x10), false);
+    }
+
+    /* GPIO 78 bits 3:0 are SW1/2, SW1/1, SW1/4 and SW1/3. */
+    const uint8_t gpio_78 = (dev->gpio[0] & 0xf0) | ibm_pc700_cpu_straps();
+
+    /* GPIO 79 bits 7, 1 and 0 are inputs; the remaining bits are outputs. */
+    uint8_t gpio_79 = (dev->gpio[1] & 0x7c) | 0x81;
+    if (nmc93cxx_eeprom_read(dev->eeprom))
+        gpio_79 |= 0x02;
+
+    return 0xffff0000 | ((uint32_t) gpio_79 << 8) | gpio_78;
+}
+
+static uint8_t
+ibm_pc700_rapid_read(uint16_t port, void *priv)
+{
+    ibm_pc700_t *dev = (ibm_pc700_t *) priv;
+
+    if (port == 0x48)
+        return dev->rapid_data;
+
+    /*
+     * The controller's ready line pulses low after presence detection and
+     * after each nibble transfer. Alternating the sampled state models the
+     * observed transport without inventing command-level power semantics.
+     */
+    return (dev->rapid_status_phase++ & 1) ? 0x00 : 0x01;
+}
+
+static void
+ibm_pc700_rapid_write(uint16_t port, uint8_t val, void *priv)
+{
+    ibm_pc700_t *dev = (ibm_pc700_t *) priv;
+
+    if (port == 0x48) {
+        dev->rapid_data = val;
+
+        if (val & 0x80) {
+            dev->rapid_command_phase = 0;
+        } else if ((val & 0xf0) == 0x10) {
+            if (dev->rapid_command_phase == 0) {
+                dev->rapid_command = (val & 0x0f) << 4;
+                dev->rapid_command_phase = 1;
+            } else {
+                dev->rapid_command |= val & 0x0f;
+                dev->rapid_command_phase = 0;
+
+                /* Command 0Eh asserts the PC 700 power-supply Off signal. */
+                if (dev->rapid_command == 0x0e)
+                    plat_power_off();
+            }
+        } else {
+            dev->rapid_command_phase = 0;
+        }
+    } else {
+        dev->rapid_status_phase = 0;
+        dev->rapid_command_phase = 0;
+    }
+}
+
+static uint8_t
+ibm_pc700_board_read(uint16_t port, void *priv)
+{
+    ibm_pc700_t *dev = (ibm_pc700_t *) priv;
+
+    uint8_t ret;
+
+    switch (port) {
+        case 0x77:
+            ret = 0xff; /* Optional Data Collaboration Card absent. */
+            break;
+        case 0x7c:
+            ret = dev->board_7c;
+            break;
+        case 0x7d:
+            ret = dev->board_7d;
+            break;
+        case 0x7e:
+            ret = dev->board_7e;
+            break;
+        case 0x7f:
+            ret = dev->board_7f;
+            break;
+        case 0x94:
+            ret = dev->pos_94;
+            break;
+        case 0x102:
+        case 0x103:
+        case 0x104:
+        case 0x105:
+            ret = dev->pos[port - 0x102];
+            break;
+        default:
+            ret = 0xff;
+            break;
+    }
+
+    return ret;
+}
+
+static void
+ibm_pc700_board_write(uint16_t port, uint8_t val, void *priv)
+{
+    ibm_pc700_t *dev = (ibm_pc700_t *) priv;
+
+    switch (port) {
+        case 0x7c:
+            /* Bits 3:1 identify the standard 256 KiB L2 cache. Bit 0 is a latch. */
+            dev->board_7c = (dev->board_7c & 0xfe) | (val & 0x01);
+            break;
+        case 0x7d:
+            dev->board_7d = val;
+            break;
+        case 0x7e:
+            dev->board_7e = val;
+            break;
+        case 0x7f:
+            dev->board_7f = val;
+            break;
+        case 0x94:
+            dev->pos_94 = val;
+            break;
+        case 0x102:
+        case 0x103:
+        case 0x104:
+        case 0x105:
+            dev->pos[port - 0x102] = val;
+            break;
+        default:
+            break;
+    }
+}
+
+static void
+ibm_pc700_seed_nvr(nvr_t *nvr)
+{
+    uint16_t checksum = 0;
+
+    if (!nvr->is_new)
+        return;
+
+    nvr->regs[0x0e] &= ~0x60;
+    nvr->regs[0x2d] = 0x80;
+    for (uint8_t i = 0x10; i <= 0x2d; i++)
+        checksum += nvr->regs[i];
+    nvr->regs[0x2e] = checksum >> 8;
+    nvr->regs[0x2f] = checksum & 0xff;
+
+    checksum = 0;
+    for (uint8_t i = 0x35; i <= 0x3d; i++)
+        checksum += nvr->regs[i];
+    nvr->regs[0x3e] = checksum >> 8;
+    nvr->regs[0x3f] = checksum & 0xff;
+
+    /* Empty IBM variable-length CMOS record and its CRC-16. */
+    nvr->regs[0x40] = 0xe1;
+    nvr->regs[0x41] = 0xf0;
+    nvr->regs[0x42] = 0x00;
+}
+
+static void
+ibm_pc700_seed_riser_nvr(ibm_pc700_t *dev)
+{
+    if (!ps2_nvr_is_new(dev->riser_nvr))
+        return;
+
+    /* Known-good markers used by the IBM firmware. */
+    ps2_nvr_set_byte(dev->riser_nvr, 0x0186, 0x00);
+    ps2_nvr_set_byte(dev->riser_nvr, 0x018a, 0x6d);
+    ps2_nvr_set_byte(dev->riser_nvr, 0x018b, 0xb6);
+
+    /* Minimal empty additive-checksum record at 0500h. */
+    ps2_nvr_set_byte(dev->riser_nvr, 0x0500, 0x01);
+    ps2_nvr_set_byte(dev->riser_nvr, 0x0501, 0x00);
+    ps2_nvr_set_byte(dev->riser_nvr, 0x0502, 0x00);
+}
+
+static void
+ibm_pc700_reset(void *priv)
+{
+    ibm_pc700_t *dev = (ibm_pc700_t *) priv;
+
+    dev->gpio[0]             = 0xff;
+    dev->gpio[1]             = 0xff;
+    dev->rapid_data          = 0x00;
+    dev->rapid_status_phase  = 0;
+    dev->rapid_command       = 0x00;
+    dev->rapid_command_phase = 0;
+    dev->board_7c            = 0x0b; /* 256 KiB L2 cache, no tamper. */
+    dev->board_7d            = 0x00;
+    dev->board_7e            = 0x00;
+    dev->board_7f            = 0x00;
+
+    dev->pos_94 = 0xff;
+    memset(dev->pos, 0x00, sizeof(dev->pos));
+
+    nmc93cxx_eeprom_write(dev->eeprom, false, false, false);
+    mem_set_mem_state_both(0xfffe0000, IBM_PC700_FLASH_BANK_SIZE,
+                           MEM_READ_EXTANY | MEM_WRITE_EXTANY);
+    mem_mapping_enable(&bios_high_mapping);
+    ibm_pc700_flash_map(dev, 1, true);
+}
+
+static void
+ibm_pc700_close(void *priv)
+{
+    ibm_pc700_t *dev = (ibm_pc700_t *) priv;
+
+    if (ibm_pc700 == dev)
+        ibm_pc700 = NULL;
+    free(dev);
+}
+
+static void *
+ibm_pc700_init(UNUSED(const device_t *info))
+{
+    ibm_pc700_t             *dev = (ibm_pc700_t *) calloc(1, sizeof(ibm_pc700_t));
+    nmc93cxx_eeprom_params_t params;
+
+    memset(dev->eeprom_default, 0xff, sizeof(dev->eeprom_default));
+    for (uint8_t i = 0x08; i <= 0x28; i++)
+        dev->eeprom_default[i] = 0x0000;
+    /* BIOS-generated default security token and CRC for words 08h-28h. */
+    dev->eeprom_default[0x07] = 0x3cd1;
+    dev->eeprom_default[0x24] = 0x870c;
+    params.type            = NMC_93C46_x16_64;
+    params.filename        = "ibm_pc700_93c46.nvr";
+    params.default_content = dev->eeprom_default;
+
+    dev->eeprom    = device_add_params(&nmc93cxx_device, &params);
+    dev->riser_nvr = device_add(&ps2_nvr_device);
+    ibm_pc700_seed_riser_nvr(dev);
+
+    ibm_pc700 = dev;
+
+    mem_mapping_set_addr(&bios_high_mapping, 0xfffe0000, IBM_PC700_FLASH_BANK_SIZE);
+    mem_mapping_set_handler(&bios_mapping,
+                            ibm_pc700_flash_read, ibm_pc700_flash_readw, ibm_pc700_flash_readl,
+                            NULL, NULL, NULL);
+    mem_mapping_set_handler(&bios_high_mapping,
+                            ibm_pc700_flash_read, ibm_pc700_flash_readw, ibm_pc700_flash_readl,
+                            NULL, NULL, NULL);
+    mem_mapping_set_p(&bios_mapping, dev);
+    mem_mapping_set_p(&bios_high_mapping, dev);
+
+    io_sethandler(0x0048, 2,
+                  ibm_pc700_rapid_read, NULL, NULL, ibm_pc700_rapid_write, NULL, NULL, dev);
+    io_sethandler(0x0077, 1,
+                  ibm_pc700_board_read, NULL, NULL, ibm_pc700_board_write, NULL, NULL, dev);
+    io_sethandler(0x007c, 4,
+                  ibm_pc700_board_read, NULL, NULL, ibm_pc700_board_write, NULL, NULL, dev);
+    io_sethandler(0x0094, 1,
+                  ibm_pc700_board_read, NULL, NULL, ibm_pc700_board_write, NULL, NULL, dev);
+    io_sethandler(0x0102, 4,
+                  ibm_pc700_board_read, NULL, NULL, ibm_pc700_board_write, NULL, NULL, dev);
+
+    dev->flash_bank = 0;
+    ibm_pc700_reset(dev);
+
+    return dev;
+}
+
+static const device_t ibm_pc700_device = {
+    .name          = "IBM PC 730/750 (6877/6887) system board",
+    .internal_name = "ibm_pc700",
+    .flags         = DEVICE_SOFTRESET,
+    .local         = 0,
+    .init          = ibm_pc700_init,
+    .close         = ibm_pc700_close,
+    .reset         = ibm_pc700_reset,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = NULL
+};
+
+int
+machine_at_ibm_pc700_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/ibm_pc700/LQKT47A.BIN",
+                           0x000c0000, 262144, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_common_init(model);
+
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x01, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x06, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x07, PCI_CARD_NORMAL,      2, 1, 4, 3);
+    pci_register_slot(0x08, PCI_CARD_VIDEO,       4, 0, 0, 0);
+    pci_register_slot(0x0c, PCI_CARD_NORMAL,      2, 1, 4, 3);
+
+    device_add(&ibm_pc700_device);
+
+    if (gfxcard[0] == VID_INTERNAL)
+        device_add(machine_get_vid_device(machine));
+
+    device_add(&i430fx_device);
+    /* The photographed planar uses an SZ997 82371FB (PIIX A1, PCI revision 02h). */
+    device_add(&piix_rev02_device);
+    device_add_params(&pc87306_device, (void *) PCX730X_AMI);
+    ibm_pc700_seed_nvr(device_get_priv(&nvr_at_device));
+
+    return ret;
+}

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -17172,6 +17172,55 @@ const machine_t machines[] = {
         .aliases                  = { "Suk Jung SJ-PENTIUM FX", "" }
     },
 
+    /* IBM's 6877 and 6887 share the same planar and differ in chassis/riser capacity. */
+    {
+        .name              = "[i430FX] IBM PC 730/750 (type 6877/6887)",
+        .internal_name     = "ibm_pc700_6877_6887",
+        .type              = MACHINE_TYPE_SOCKET7_3V,
+        .chipset           = MACHINE_CHIPSET_INTEL_430FX,
+        .init              = machine_at_ibm_pc700_init,
+        .p1_handler        = machine_generic_p1_handler,
+        .gpio_handler      = machine_at_ibm_pc700_gpio_handler,
+        .available_flag    = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu               = {
+            .package     = CPU_PKG_SOCKET5_7,
+            .block       = CPU_BLOCK(CPU_K5, CPU_5K86, CPU_Cx6x86, CPU_WINCHIP, CPU_WINCHIP2, CPU_PENTIUMMMX),
+            .min_bus     = 50000000,
+            .max_bus     = 66666667,
+            .min_voltage = 3380,
+            .max_voltage = 3520,
+            .min_multi   = 1.5,
+            .max_multi   = 2.5
+        },
+        .bus_flags = MACHINE_PS2_PCI,
+        .flags     = MACHINE_IDE_DUAL | MACHINE_VIDEO | MACHINE_APM,
+        .ram       = {
+            .min  = 16384,
+            .max  = 131072,
+            .step = 8192
+        },
+        .nvrmask                  = 255,
+        .jumpered_ecp_dma         = MACHINE_DMA_DISABLED | MACHINE_DMA_1 | MACHINE_DMA_3,
+        .default_jumpered_ecp_dma = 3,
+        .kbc_device               = NULL,
+        .kbc_params               = 0x00000000,
+        /* RTC/NVR is on the PC87306 Super I/O. */
+        .nvr_device               = NULL,
+        .nvr_params               = 0x00000000,
+        .sio_device               = NULL,
+        .sio_params               = 0x00000000,
+        .kbc_p1                   = 0x000044f0,
+        .gpio                     = 0xffffffff,
+        .gpio_acpi                = 0xffffffff,
+        .device                   = NULL,
+        .kbd_device               = NULL,
+        .fdc_device               = NULL,
+        .vid_device               = &s3_trio64vplus_onboard_pci_device,
+        .snd_device               = NULL,
+        .net_device               = NULL,
+        .aliases                  = { "IBM PC 730 type 6877", "IBM PC 750 type 6887", "IBM PC 700", "" }
+    },
     /* 430HX */
     /* Has SST Flash. */
     /* Has a SM(S)C FDC37C935 Super I/O chip with on-chip KBC with Phoenix

--- a/src/nvr_ps2.c
+++ b/src/nvr_ps2.c
@@ -50,6 +50,7 @@
 
 typedef struct ps2_nvr_t {
     int addr;
+    int loaded;
 
     uint8_t *ram;
     int      size;
@@ -132,12 +133,30 @@ ps2_nvr_init(const device_t *info)
 
     nvr->ram = (uint8_t *) calloc(1, nvr->size);
     if (fp != NULL) {
+        nvr->loaded = 1;
         if ((cpu_s != NULL) && (fread(nvr->ram, 1, nvr->size, fp) != nvr->size))
             fatal("ps2_nvr_init(): Error reading EEPROM data\n");
         fclose(fp);
     }
 
     return nvr;
+}
+
+int
+ps2_nvr_is_new(void *priv)
+{
+    const ps2_nvr_t *nvr = (const ps2_nvr_t *) priv;
+
+    return !nvr->loaded;
+}
+
+void
+ps2_nvr_set_byte(void *priv, uint16_t addr, uint8_t val)
+{
+    ps2_nvr_t *nvr = (ps2_nvr_t *) priv;
+
+    if (addr < nvr->size)
+        nvr->ram[addr] = val;
 }
 
 static void

--- a/src/pic.c
+++ b/src/pic.c
@@ -64,6 +64,8 @@ static int mouse_latch = 0;
 
 static uint16_t smi_irq_mask   = 0x0000;
 static uint16_t smi_irq_status = 0x0000;
+static void (*irq_callback)(uint16_t, int, void *);
+static void *irq_callback_priv;
 
 static uint16_t latched_irqs   = 0x0000;
 static int16_t  irq_vector_override[8] = {
@@ -89,6 +91,13 @@ pic_log(const char *fmt, ...)
 #else
 #    define pic_log(fmt, ...)
 #endif
+
+void
+pic_set_irq_callback(void (*callback)(uint16_t, int, void *), void *priv)
+{
+    irq_callback      = callback;
+    irq_callback_priv = priv;
+}
 
 void
 pic_reset_smi_irq_mask(void)
@@ -792,6 +801,9 @@ picint_common(uint16_t num, int level, int set, uint8_t *irq_state)
        acpi_rtc_status = !!set;
 
    if (num) {
+       if (irq_callback != NULL)
+           irq_callback(num, set, irq_callback_priv);
+
        if (set) {
             if (smi_irq_mask & num) {
                 smi_raise();

--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -5032,7 +5032,11 @@ s3_trio64v_recalctimings(svga_t *svga)
 
     if (is_vga_mode) {
         svga->hoverride = 0;
-        if (enhanced_8bpp_modes)
+        /* Preserve the first character when blanking ends at line rollover.
+           A zero end value can also match before rollover on longer lines. */
+        if (enhanced_8bpp_modes || ((svga->hblank_end_val == 0) &&
+                                   ((svga->hblankstart + 1) == svga->hdisp_time) &&
+                                   ((svga->hblankstart >> 6) == ((svga->htotal - 1) >> 6))))
             svga->hoverride = 1;
     } else
         svga->hoverride = 1;


### PR DESCRIPTION
## Summary

I have reintroduces IBM PC 730/750 machine from #7818 with revised reset, configuration storage and power-management handling.

The shared fixes are separate commits

- invalidate instruction mappings when PAM changes the backing of the current page.
- clean up injected keyboard state when a reset interrupts Ctrl+Alt shortcuts.
- latch enabled PIIX/PIIX3 IRQ wake events and deliver pending requests when the SMI gate opens.
- preserve the first displayed character for the IBM VGA blanking rollover case without overriding other blank-end timings.
- expose fresh secondary NVRAM state so board defaults do not overwrite loaded data.

There is no BIOS-address-specific reset hook or deferred hard-reset workaround. IBM CMOS defaults are initialized by the board, not by the shared Super I/O implementation.

## Validation

I have tested with a Pentium 133 and 16 MB RAM configs

- BIOS setup save/exit with an existing configuration.
- Fresh configuration initialization, saving settings and a cold boot from the saved NVRAM.
- Windows 95 Restart twice, returning to the desktop.
- Restart in MS-DOS mode followed by Ctrl+Alt+Del, returning to Windows works.
- Windows 95 now completely shutdown.
- 3 bios APM standby/keyboard-wake cycles and two intervening reboots with APM available, using both dynamic recompilation and interpreter override.
- 13 S3s blanking regression cases,  +focused keyboard-state and PIIX IRQ-latch tests.

## Scope and limitations

Keyboard wake is guest-tested; IRQ3/4/8/12 have register-level checks but not guest wake tests. The fresh-saved configuration boots but reports AH=86h/CF=1 for the APM calls; it is not counted as a successful standby test. The board power-controller handshake remains a minimal model of the observed firmware protocol, not complete power-controller emulation.

CPU limited

- I have limits CPU to only Intel-based pentiums due to they doesn't know others CPU.

## Checklist

- [x] I have tested my changes locally and validated the functionality listed above.
- [ ] I have discussed this revision with core contributors already.
- [ ] This pull request requires new changes to the ROM set.
- [ ] This pull request requires changes to the asset set.
- [ ] This pull request adds, changes or removes an external dependency.

## References

- Previous PR: [86Box/86Box#7818](https://github.com/86Box/86Box/pull/7818).
- Intel 82371FB/82371SB datasheet, SMI control/enable/request registers: https://www.mouser.com/catalog/specsheets/intel%20corporation_29055002.pdf
- IBM PC 700 Series types 6877/6887 Hardware Maintenance Manual, publication 52H3381.



