### PR TITLE
Machine & sound related changes (05/09/2026)

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -245,6 +245,10 @@ device_set_context(device_context_t *ctx, const device_t *dev, int inst)
         { .old = "3dfx Voodoo3 2000 (On-Board 8MB SGRAM)", .new = "3dfx Voodoo3 2000 (On-Board)" },
         { .old = "Gravis/Synergy Vipermax", .new = "Synergy ViperMAX" },
         { .old = "Colorplus", .new = "Plantronics Colorplus" },
+        { .old = "Sound Blaster PCI 128 (ES1373)", .new = "Creative Sound Blaster PCI 128 (ES1373)" },
+        { .old = "Sound Blaster PCI 128 (ES1373) (On-Board)", .new = "Creative Sound Blaster PCI 128 (ES1373) (On-Board)" },
+        { .old = "Sound Blaster PCI 4.1 (CT5880)", .new = "Creative Sound Blaster PCI 4.1 (CT5880)" },
+        { .old = "Sound Blaster PCI 4.1 (CT5880) (On-Board)", .new = "Creative Sound Blaster PCI 4.1 (CT5880) (On-Board)" },
         { 0 }
     };
 

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -20898,8 +20898,8 @@ const machine_t machines[] = {
             .min_multi   = 1.5,
             .max_multi   = 6.0
         },
-        .bus_flags = MACHINE_PS2_AGP | MACHINE_BUS_USB,
-        .flags     = MACHINE_SUPER_IO | MACHINE_IDE_DUAL | MACHINE_VIDEO | MACHINE_SOUND | MACHINE_APM | MACHINE_ACPI | MACHINE_AGP_INTERNAL | MACHINE_USB,
+        .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
+        .flags     = MACHINE_SUPER_IO | MACHINE_IDE_DUAL | MACHINE_SOUND | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
         .ram       = {
             .min  = 8192,
             .max  = 524288,

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -16725,6 +16725,55 @@ const machine_t machines[] = {
         .net_device               = NULL,
         .aliases                  = { "HP Chimay", "" }
     },
+    /* IBM's 6877 and 6887 share the same planar and differ in chassis/riser capacity. It was also seen with a i430JX chipset. */
+    {
+        .name              = "[i430FX] IBM PC 7x0 (type 68x7)",
+        .internal_name     = "ibm_pc700_6877_6887",
+        .type              = MACHINE_TYPE_SOCKET7_3V,
+        .chipset           = MACHINE_CHIPSET_INTEL_430FX,
+        .init              = machine_at_ibm_pc700_init,
+        .p1_handler        = machine_generic_p1_handler,
+        .gpio_handler      = machine_at_ibm_pc700_gpio_handler,
+        .available_flag    = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu               = {
+            .package     = CPU_PKG_SOCKET5_7,
+            .block       = CPU_BLOCK(CPU_K5, CPU_5K86, CPU_Cx6x86, CPU_WINCHIP, CPU_WINCHIP2, CPU_PENTIUMMMX),
+            .min_bus     = 50000000,
+            .max_bus     = 66666667,
+            .min_voltage = 3380,
+            .max_voltage = 3520,
+            .min_multi   = 1.5,
+            .max_multi   = 2.5
+        },
+        .bus_flags = MACHINE_PS2_PCI,
+        .flags     = MACHINE_IDE_DUAL | MACHINE_VIDEO | MACHINE_APM,
+        .ram       = {
+            .min  = 16384, /* 16mb memory is onboard */
+            .max  = 131072,
+            .step = 8192
+        },
+        .nvrmask                  = 255,
+        .jumpered_ecp_dma         = MACHINE_DMA_DISABLED | MACHINE_DMA_1 | MACHINE_DMA_3,
+        .default_jumpered_ecp_dma = 3,
+        .kbc_device               = NULL,
+        .kbc_params               = 0x00000000,
+        /* RTC/NVR is on the PC87306 Super I/O. */
+        .nvr_device               = NULL,
+        .nvr_params               = 0x00000000,
+        .sio_device               = NULL,
+        .sio_params               = 0x00000000,
+        .kbc_p1                   = 0x000044f0,
+        .gpio                     = 0xffffffff,
+        .gpio_acpi                = 0xffffffff,
+        .device                   = NULL,
+        .kbd_device               = NULL,
+        .fdc_device               = NULL,
+        .vid_device               = &s3_trio64vplus_onboard_pci_device,
+        .snd_device               = NULL,
+        .net_device               = NULL,
+        .aliases                  = { "IBM PC 730 type 6877", "IBM PC 750 type 6887", "IBM PC 700", "" }
+    },
     /* According to tests from real hardware: This has AMI MegaKey KBC firmware on the
        PC87306 Super I/O chip, command 0xA1 returns '5'.
        Command 0xA0 copyright string: (C)1994 AMI . */
@@ -17170,56 +17219,6 @@ const machine_t machines[] = {
         .snd_device               = NULL,
         .net_device               = NULL,
         .aliases                  = { "Suk Jung SJ-PENTIUM FX", "" }
-    },
-
-    /* IBM's 6877 and 6887 share the same planar and differ in chassis/riser capacity. */
-    {
-        .name              = "[i430FX] IBM PC 730/750 (type 6877/6887)",
-        .internal_name     = "ibm_pc700_6877_6887",
-        .type              = MACHINE_TYPE_SOCKET7_3V,
-        .chipset           = MACHINE_CHIPSET_INTEL_430FX,
-        .init              = machine_at_ibm_pc700_init,
-        .p1_handler        = machine_generic_p1_handler,
-        .gpio_handler      = machine_at_ibm_pc700_gpio_handler,
-        .available_flag    = MACHINE_AVAILABLE,
-        .gpio_acpi_handler = NULL,
-        .cpu               = {
-            .package     = CPU_PKG_SOCKET5_7,
-            .block       = CPU_BLOCK(CPU_K5, CPU_5K86, CPU_Cx6x86, CPU_WINCHIP, CPU_WINCHIP2, CPU_PENTIUMMMX),
-            .min_bus     = 50000000,
-            .max_bus     = 66666667,
-            .min_voltage = 3380,
-            .max_voltage = 3520,
-            .min_multi   = 1.5,
-            .max_multi   = 2.5
-        },
-        .bus_flags = MACHINE_PS2_PCI,
-        .flags     = MACHINE_IDE_DUAL | MACHINE_VIDEO | MACHINE_APM,
-        .ram       = {
-            .min  = 16384,
-            .max  = 131072,
-            .step = 8192
-        },
-        .nvrmask                  = 255,
-        .jumpered_ecp_dma         = MACHINE_DMA_DISABLED | MACHINE_DMA_1 | MACHINE_DMA_3,
-        .default_jumpered_ecp_dma = 3,
-        .kbc_device               = NULL,
-        .kbc_params               = 0x00000000,
-        /* RTC/NVR is on the PC87306 Super I/O. */
-        .nvr_device               = NULL,
-        .nvr_params               = 0x00000000,
-        .sio_device               = NULL,
-        .sio_params               = 0x00000000,
-        .kbc_p1                   = 0x000044f0,
-        .gpio                     = 0xffffffff,
-        .gpio_acpi                = 0xffffffff,
-        .device                   = NULL,
-        .kbd_device               = NULL,
-        .fdc_device               = NULL,
-        .vid_device               = &s3_trio64vplus_onboard_pci_device,
-        .snd_device               = NULL,
-        .net_device               = NULL,
-        .aliases                  = { "IBM PC 730 type 6877", "IBM PC 750 type 6887", "IBM PC 700", "" }
     },
     /* 430HX */
     /* Has SST Flash. */
@@ -23514,8 +23513,8 @@ const machine_t machines[] = {
             .min_multi   = 1.5,
             .max_multi   = 8.0
         },
-        .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB, /* AGP is reserved for the internal video */
-        .flags     = MACHINE_IDE_DUAL | MACHINE_AV | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
+        .bus_flags = MACHINE_PS2_AGP | MACHINE_BUS_USB, /* AGP is reserved for the internal video */
+        .flags     = MACHINE_IDE_DUAL | MACHINE_AV | MACHINE_AGP_INTERNAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
         .ram       = {
             .min  = 8192,
             .max  = 524288,
@@ -23563,8 +23562,8 @@ const machine_t machines[] = {
             .min_multi   = 1.5,
             .max_multi   = 8.0
         },
-        .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB, /* AGP is reserved for the internal video */
-        .flags     = MACHINE_IDE_DUAL | MACHINE_AV | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
+        .bus_flags = MACHINE_PS2_AGP | MACHINE_BUS_USB, /* AGP is reserved for the internal video */
+        .flags     = MACHINE_IDE_DUAL | MACHINE_AV | MACHINE_AGP_INTERNAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
         .ram       = {
             .min  = 8192,
             .max  = 524288,
@@ -24418,9 +24417,9 @@ const machine_t machines[] = {
             .min_multi   = 1.5,
             .max_multi   = 8.0 /* limits assumed */
         },
-        .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB, /* Machine has EISA, possibly for a riser? */
+        .bus_flags = MACHINE_PS2_AGP | MACHINE_BUS_USB, /* Machine has EISA, possibly for a riser? */
                                                         /* Yes, that's a riser slot, not EISA. */
-        .flags     = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB | MACHINE_VIDEO, /* Machine has internal video: C&T B69000, sound: ESS ES1938S (Solo-1) and NIC: Realtek RTL8139C */
+        .flags     = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB | MACHINE_AGP_INTERNAL | MACHINE_VIDEO, /* Machine has internal video: C&T B69000, sound: ESS ES1938S (Solo-1) and NIC: Realtek RTL8139C */
         .ram       = {
             .min  = 8192,
             .max  = 524288,
@@ -24569,7 +24568,7 @@ const machine_t machines[] = {
         .bus_flags = MACHINE_PS2_AGP | MACHINE_BUS_USB,
         .flags     = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB, 
         .ram       = {
-            .min  = 16384,
+            .min  = 16384, /* Machine does not start (hang) with 8mb memory */
             .max  = 524288,
             .step = 8192
         },

--- a/src/sound/snd_audiopci.c
+++ b/src/sound/snd_audiopci.c
@@ -2882,7 +2882,8 @@ const device_t es1370_device = {
     .available     = NULL,
     .speed_changed = es137x_speed_changed,
     .force_redraw  = NULL,
-    .config        = es1370_config
+    .config        = es1370_config,
+    .alias         = "Creative Sound Blaster PCI 64"
 };
 
 const device_t es1371_device = {
@@ -2914,7 +2915,7 @@ const device_t es1371_onboard_device = {
 };
 
 const device_t es1373_device = {
-    .name          = "Sound Blaster PCI 128 (ES1373)",
+    .name          = "Creative Sound Blaster PCI 128 (ES1373)",
     .internal_name = "es1373",
     .flags         = DEVICE_PCI,
     .local         = AUDIOPCI_ES1373,
@@ -2924,11 +2925,12 @@ const device_t es1373_device = {
     .available     = NULL,
     .speed_changed = es137x_speed_changed,
     .force_redraw  = NULL,
-    .config        = es1373_config
+    .config        = es1373_config,
+    .alias         = "Ensoniq AudioPCI (ES1373)"
 };
 
 const device_t es1373_onboard_device = {
-    .name          = "Sound Blaster PCI 128 (ES1373) (On-Board)",
+    .name          = "Creative Sound Blaster PCI 128 (ES1373) (On-Board)",
     .internal_name = "es1373_onboard",
     .flags         = DEVICE_PCI,
     .local         = AUDIOPCI_ES1373 | 1,
@@ -2942,7 +2944,7 @@ const device_t es1373_onboard_device = {
 };
 
 const device_t ct5880_device = {
-    .name          = "Sound Blaster PCI 4.1 (CT5880)",
+    .name          = "Creative Sound Blaster PCI 4.1 (CT5880)",
     .internal_name = "ct5880",
     .flags         = DEVICE_PCI,
     .local         = AUDIOPCI_CT5880,
@@ -2952,11 +2954,12 @@ const device_t ct5880_device = {
     .available     = NULL,
     .speed_changed = es137x_speed_changed,
     .force_redraw  = NULL,
-    .config        = ct5880_config
+    .config        = ct5880_config,
+    .alias         = "Creative CT2518"
 };
 
 const device_t ct5880_onboard_device = {
-    .name          = "Sound Blaster PCI 4.1 (CT5880) (On-Board)",
+    .name          = "Creative Sound Blaster PCI 4.1 (CT5880) (On-Board)",
     .internal_name = "ct5880_onboard",
     .flags         = DEVICE_PCI,
     .local         = AUDIOPCI_CT5880 | 1,

--- a/src/sound/snd_solo1.c
+++ b/src/sound/snd_solo1.c
@@ -1104,7 +1104,7 @@ solo1_close(void *priv)
 }
 
 const device_t ess_solo1_device = {
-    .name          = "ESS ES1938S Solo-1",
+    .name          = "ESS Solo-1",
     .internal_name = "ess_solo1",
     .flags         = DEVICE_PCI,
     .local         = 0,
@@ -1114,11 +1114,12 @@ const device_t ess_solo1_device = {
     .available     = NULL,
     .speed_changed = NULL,
     .force_redraw  = NULL,
-    .config        = NULL
+    .config        = NULL,
+    .alias         = "ESS ES1938S"
 };
 
 const device_t ess_solo1_onboard_device = {
-    .name          = "ESS ES1938S Solo-1 (On-Board)",
+    .name          = "ESS Solo-1 (On-Board)",
     .internal_name = "ess_solo1_onboard",
     .flags         = DEVICE_PCI,
     .local         = 1,

--- a/src/sound/sound.c
+++ b/src/sound/sound.c
@@ -235,10 +235,10 @@ static const SOUND_CARD sound_cards[] = {
     /* PCI */
     { &cmi8338_device               },
     { &cmi8738_device               },
-    { &es1370_device                },
-    { &es1371_device                },
     { &es1373_device                },
     { &ct5880_device                },
+    { &es1370_device                },
+    { &es1371_device                },
     { &ess_solo1_device             },
     /* AC97 */
     { &ad1881_device                },


### PR DESCRIPTION
Summary
=======
1. Alphabetize & slightly change the name for the recently-added IBM PC 700, as well as adding a note about its minimum memory. Also remove MACHINE_VIDEO as it has not-yet-unemulated internal video.
2. Add the recently-added 'MACHINE_AGP_INTERNAL' bus to the three machines (MSI MS-6168, Packard Bell Bora Pro, and AEWIN AW-O671R).
3. Add a note about its minimum memory on the latest-added RadiSys Endura EM440.
4. Add the "Creative" name to the ES137x series of PCI sound chips and their aliases.
5. Alphabetize & shorten the recently-added ESS Solo-1's name and added its alias. (Configuration coming soon)

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
