### PR TITLE
Add IBM 512KB/2MB 286 Memory Expansion Adapter emulation (this time for real)

### DIFF
--- a/src/86box.c
+++ b/src/86box.c
@@ -66,6 +66,7 @@
 #include <86box/unittester.h>
 #include <86box/softpower.h>
 #include <86box/novell_cardkey.h>
+#include <86box/mcamem.h>
 #include <86box/isamem.h>
 #include <86box/isarom.h>
 #include <86box/isartc.h>
@@ -171,6 +172,7 @@ int      postcard_enabled                       = 0;              /* (C) enable 
 int      unittester_enabled                     = 0;              /* (C) enable unit tester device */
 int      softpower_enabled                      = 0;              /* (C) enable PC Convertible-style soft power card */
 int      gameport_type[GAMEPORT_MAX]            = { 0, 0 };       /* (C) enable gameports */
+int      mcamem_type[MCAMEM_MAX]                = { 0, 0, 0, 0 }; /* (C) enable MCA mem cards */
 int      isamem_type[ISAMEM_MAX]                = { 0, 0, 0, 0 }; /* (C) enable ISA mem cards */
 int      isarom_type[ISAROM_MAX]                = { 0, 0, 0, 0 }; /* (C) enable ISA ROM cards */
 int      isartc_type                            = 0;              /* (C) enable ISA RTC card */
@@ -1811,6 +1813,9 @@ pc_reset_hard_init(void)
 
     /* Reset and reconfigure the Network Card layer. */
     network_reset();
+
+    /* Reset and reconfigure the MCA memory expansion boards. */
+    mcamem_reset();
 
     /*
      * Reset the mouse, this will attach it to any port needed.

--- a/src/config.c
+++ b/src/config.c
@@ -54,6 +54,7 @@
 #include <86box/nvr.h>
 #include <86box/ini.h>
 #include <86box/config.h>
+#include <86box/mcamem.h>
 #include <86box/isamem.h>
 #include <86box/isarom.h>
 #include <86box/isartc.h>
@@ -2525,6 +2526,17 @@ load_other_peripherals(void)
     if (!softpower_enabled)
         ini_section_delete_var(cat, "softpower_enabled");
 
+    // MCA RAM Boards
+    for (uint8_t c = 0; c < MCAMEM_MAX; c++) {
+        sprintf(temp, "mcamem%d_type", c);
+
+        p              = ini_section_get_string(cat, temp, "none");
+        mcamem_type[c] = mcamem_get_from_internal_name(p);
+
+        if (!strcmp(p, "none"))
+            ini_section_delete_var(cat, temp);
+    }
+
     // ISA RAM Boards
     for (uint8_t c = 0; c < ISAMEM_MAX; c++) {
         sprintf(temp, "isamem%d_type", c);
@@ -2783,6 +2795,8 @@ config_load(void)
             isarom_type[i] = 0;
         for (i = 0; i < ISAMEM_MAX; i++)
             isamem_type[i] = 0;
+        for (i = 0; i < MCAMEM_MAX; i++)
+            mcamem_type[i] = 0;
 
         cassette_enable = 1;
         memset(cassette_fname, 0x00, sizeof(cassette_fname));
@@ -3957,6 +3971,16 @@ save_other_peripherals(void)
         ini_section_delete_var(cat, "softpower_enabled");
     else
         ini_section_set_int(cat, "softpower_enabled", softpower_enabled);
+
+    // MCA RAM Boards
+    for (uint8_t c = 0; c < MCAMEM_MAX; c++) {
+        sprintf(temp, "mcamem%d_type", c);
+        if (mcamem_type[c] == 0)
+            ini_section_delete_var(cat, temp);
+        else
+            ini_section_set_string(cat, temp,
+                                   mcamem_get_internal_name(mcamem_type[c]));
+    }
 
     // ISA RAM Boards
     for (uint8_t c = 0; c < ISAMEM_MAX; c++) {

--- a/src/device/CMakeLists.txt
+++ b/src/device/CMakeLists.txt
@@ -35,6 +35,8 @@ add_library(dev OBJECT
     i2c_gpio.c
     ibm_5161.c
     inboard386.c
+    ibm_xma.c
+    mcamem.c
     isamem.c
     isarom.c
     isartc.c

--- a/src/device/ibm_xma.c
+++ b/src/device/ibm_xma.c
@@ -1,0 +1,387 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          Emulation of the IBM Memory Expansion Option (MXO, a.k.a.
+ *          "Holster") memory card for PS/2 Model 50 and 60 systems.
+ *
+ *          NOTE: The register and translate table layout are from MS-DOS 4.0
+ *                XMA2EMS.ASM device driver source. For copyright information, 
+ *                see https://github.com/microsoft/MS-DOS/blob/main/v4.0/LICENSE
+ *                for more details.
+ *
+ * Authors: WNT50
+ * 
+ *          Copyright 2026 WNT50.
+ */
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <wchar.h>
+#define HAVE_STDARG_H
+#include <86box/86box.h>
+#include <86box/device.h>
+#include <86box/mca.h>
+#include <86box/mem.h>
+#include <86box/plat_unused.h>
+
+/* MXO translate table: 1K x 8-bit entries, 16 KB blocks. */
+#define MXO_TT_ENTRIES      1024U
+#define MXO_BLOCK_SHIFT     14
+#define MXO_BLOCK_SIZE      (1U << MXO_BLOCK_SHIFT)
+#define MXO_TT_ENABLE       0x80U   /* bit 7 set = mapping enabled */
+#define MXO_TT_BLOCK_MASK   0x7fU   /* bits 6-0 = 16 KB block number */
+
+/* Memory capacity, fitted as 512 KB kits (banks). */
+#define MXO_SIZE_2MB        (2 * 1024 * 1024U)
+#define MXO_KB_PER_BANK     512U    /* each 512 KB memory kit / bank */
+#define MXO_MAX_BANKS       (MXO_SIZE_2MB / MXO_BLOCK_SIZE / (MXO_KB_PER_BANK >> 4)) /* 4 */
+
+/* Extended-memory home; follows the planar memory size. */
+#define MXO_EXT_BASE        0x160000U /* 1M + 384K: default card home */
+#define MXO_EXT_FIRST_TT    (MXO_EXT_BASE >> MXO_BLOCK_SHIFT) /* 0x58 */
+
+/* EMS page-frame scan window (A0000h-E0000h), one 16K mapping per slot. */
+#define MXO_PF_SCAN_FIRST   (0xa0000U >> MXO_BLOCK_SHIFT)   /* 0x28 */
+#define MXO_PF_SCAN_LAST    (0xe0000U >> MXO_BLOCK_SHIFT)   /* 0x38 */
+#define MXO_PF_SLOTS        (MXO_PF_SCAN_LAST - MXO_PF_SCAN_FIRST) /* per-16K page-frame slots */
+
+#ifdef ENABLE_XMA_LOG
+int xma_do_log = ENABLE_XMA_LOG;
+
+static void
+xma_log(const char *fmt, ...)
+{
+    va_list ap;
+
+    if (xma_do_log) {
+        va_start(ap, fmt);
+        pclog_ex(fmt, ap);
+        va_end(ap);
+    }
+}
+#else
+#    define xma_log(fmt, ...)
+#endif
+
+/* Card RAM buffer and its fitted size. */
+typedef struct ram_t {
+    uint32_t  size_kb;  /* RAM size in KB */
+    uint8_t  *ptr;      /* card RAM buffer */
+} ram_t;
+
+typedef struct mxo_t {
+    ram_t         ram;     /* fitted card memory */
+    uint32_t      blocks;  /* usable capacity in blocks */
+
+    uint16_t      tt_ptr;  /* 10-bit translate table pointer */
+    uint8_t       tt[MXO_TT_ENTRIES];
+
+    mem_mapping_t pf_map[MXO_PF_SLOTS]; /* per-16K EMS page-frame slots */
+    mem_mapping_t ext_mapping;          /* extended memory at 1M + 384K */
+
+    uint8_t       pos_regs[8];
+} mxo_t;
+
+/* Translate table entry check: enabled and a valid block number. */
+static uint8_t
+mxo_tt_enabled(const mxo_t *dev, uint16_t idx)
+{
+    uint8_t entry;
+
+    if (idx >= MXO_TT_ENTRIES)
+        return 0;
+
+    entry = dev->tt[idx];
+    return ((entry & MXO_TT_ENABLE) && ((entry & MXO_TT_BLOCK_MASK) < dev->blocks));
+}
+
+/* TT-gated access: reads/writes only reach card RAM if the TT entry
+   covering the address is enabled and points to a valid block. */
+static uint8_t
+mxo_mem_read(uint32_t addr, void *priv)
+{
+    mxo_t *dev = (mxo_t *) priv;
+    uint16_t idx  = addr >> MXO_BLOCK_SHIFT;
+    uint8_t entry = dev->tt[idx];
+
+    if (!(entry & MXO_TT_ENABLE) || ((entry & MXO_TT_BLOCK_MASK) >= dev->blocks))
+        return 0xff;
+
+    return dev->ram.ptr[((uint32_t) (entry & MXO_TT_BLOCK_MASK) << MXO_BLOCK_SHIFT) + (addr & (MXO_BLOCK_SIZE - 1))];
+}
+
+static void
+mxo_mem_write(uint32_t addr, uint8_t val, void *priv)
+{
+    mxo_t *dev = (mxo_t *) priv;
+    uint16_t idx  = addr >> MXO_BLOCK_SHIFT;
+    uint8_t entry = dev->tt[idx];
+
+    if (!(entry & MXO_TT_ENABLE) || ((entry & MXO_TT_BLOCK_MASK) >= dev->blocks))
+        return;
+
+    dev->ram.ptr[((uint32_t) (entry & MXO_TT_BLOCK_MASK) << MXO_BLOCK_SHIFT) + (addr & (MXO_BLOCK_SIZE - 1))] = val;
+}
+
+/* Enable or disable the individual 16K page-frame mappings based on
+   TT entries. Each 16K slot is mapped separately so that a card never
+   claims an address whose own TT entry is disabled - this is what keeps
+   multiple memory cards from stealing each other's page-frame segments
+   (a single min..max window would span disabled holes and swallow the
+   other card's mappings). */
+static void
+mxo_pf_update(mxo_t *dev)
+{
+    for (uint16_t i = MXO_PF_SCAN_FIRST; i < MXO_PF_SCAN_LAST; i++) {
+        uint8_t k = i - MXO_PF_SCAN_FIRST;
+
+        if (mxo_tt_enabled(dev, i))
+            mem_mapping_enable(&dev->pf_map[k]);
+        else
+            mem_mapping_disable(&dev->pf_map[k]);
+    }
+}
+
+/* Position the extended-memory mapping over the currently enabled home
+   entries. The card's home depends on the planar memory size (1M+384K
+   with a 1MB planar, 2M+384K with a 2MB planar, etc.), so the mapping
+   follows wherever the BIOS/driver actually sets the translate table. */
+static void
+mxo_ext_update(mxo_t *dev)
+{
+    uint16_t first = 0;
+    uint16_t last  = 0;
+    uint8_t  any   = 0;
+
+    for (uint16_t i = MXO_EXT_FIRST_TT; i < MXO_TT_ENTRIES; i++) {
+        if (mxo_tt_enabled(dev, i)) {
+            if (!any)
+                first = i;
+            last = i;
+            any  = 1;
+        }
+    }
+
+    if (any) {
+        mem_mapping_set_addr(&dev->ext_mapping,
+                             (uint32_t) first << MXO_BLOCK_SHIFT,
+                             (uint32_t) (last - first + 1) << MXO_BLOCK_SHIFT);
+        mem_mapping_enable(&dev->ext_mapping);
+    } else
+        mem_mapping_disable(&dev->ext_mapping);
+}
+
+static uint8_t
+mxo_mca_read(const uint16_t port, void *priv)
+{
+    const mxo_t *dev = (const mxo_t *) priv;
+    uint8_t      ret;
+
+    switch (port & 7) {
+    /* The TT data port (0x03) is a live window into the translate table;
+       every other register echoes its stored pos_regs[] value. */
+        case 0x03: /* TT data: entry selected by the TT pointer */
+            ret = dev->tt[dev->tt_ptr & (MXO_TT_ENTRIES - 1)];
+            break;
+        default: 
+            ret = dev->pos_regs[port & 7];
+            break;
+    }
+
+    xma_log("mxo_mca_read: port=%04x ret=%02x\n", port, ret);
+    return ret;
+}
+
+static void
+mxo_mca_write(const uint16_t port, uint8_t val, void *priv)
+{
+    mxo_t    *dev = (mxo_t *) priv;
+    uint16_t  idx;
+#ifdef ENABLE_XMA_LOG
+    uint8_t   old;
+#endif
+
+    if ((port < 0x102) || (port == 0x102) || (port == 0x105))
+        return;
+
+    xma_log("mxo_mca_write: port=%04x val=%02x\n", port, val);
+
+    /* Save the new value. */
+    dev->pos_regs[port & 7] = val;
+
+    switch (port & 7) {
+        case 0x03: /* TT data: write into the entry the pointer selects */
+            idx = dev->tt_ptr & (MXO_TT_ENTRIES - 1);
+#ifdef ENABLE_XMA_LOG
+            old = dev->tt[idx];
+#endif
+            dev->tt[idx] = val;
+            mxo_ext_update(dev);
+            mxo_pf_update(dev); /* Update memory mappings with current TT contents */
+            xma_log("mxo_mca_write: TT [%03X] %02X -> %02X\n", idx, old, val);
+            break;
+
+        case 0x06: /* TT pointer (low byte) */
+            dev->tt_ptr = (uint16_t) ((dev->tt_ptr & 0xff00) | val);
+            break;
+
+        case 0x07: /* TT pointer (high byte) */
+            dev->tt_ptr = (uint16_t) ((dev->tt_ptr & 0x00ff) | (val << 8));
+            break;
+    }
+}
+
+static uint8_t
+mxo_mca_feedb(void *priv)
+{
+    const mxo_t *dev = (const mxo_t *) priv;
+
+    return (dev->pos_regs[2] & 1);
+}
+
+static void
+mxo_reset(void *priv)
+{
+    mxo_t *dev = (mxo_t *) priv;
+
+    dev->tt_ptr      = 0;
+    dev->pos_regs[6] = 0;
+    dev->pos_regs[7] = 0;
+
+    mxo_ext_update(dev);
+    mxo_pf_update(dev);
+}
+
+static void *
+mxo_init(UNUSED(const device_t *info))
+{
+    mxo_t *dev;
+    int    size_kb;
+
+    dev = (mxo_t *) calloc(1, sizeof(mxo_t));
+
+    size_kb = device_get_config_int("size");
+
+    dev->ram.size_kb  = (uint32_t) size_kb;
+    dev->ram.ptr      = (uint8_t *) calloc((size_t) size_kb << 10, 1);
+    dev->blocks       = (uint32_t) size_kb >> 4; /* KB -> 16 KB blocks */
+
+    /* POS registers: adapter card ID 0xFEFE. */
+    dev->pos_regs[0] = 0xfe;
+    dev->pos_regs[1] = 0xfe;
+
+    /* POS 102h describes the fitted memory: two bits per 512 KB bank,
+       '10' = fitted, '11' = empty. Bit 0 is the 'awake' enable bit: a
+       board reading 0 here is treated as absent by the BIOS and QEMM,
+       so all four banks fitted decode to 0xAB. */
+    dev->pos_regs[2] = 0x01; /* awake/enable */
+    {
+        uint32_t banks = dev->ram.size_kb / MXO_KB_PER_BANK;
+        dev->pos_regs[2] |= 0x02; /* bank 1 is always fitted */
+        for (uint32_t b = 1; b < MXO_MAX_BANKS; b++)
+            dev->pos_regs[2] |= (b < banks) ? (0x02U << (b << 1))   /* '10': fitted  */
+                                            : (0x03U << (b << 1));  /* '11': no mem  */
+    }
+    dev->pos_regs[4] = 0xff; /* reserved POS register */
+
+    /* POS 105h: bit 7 set for the Model 50Z BIOS to accept the card as
+       a valid memory adapter, bit 0 clear (bank 1 low presence bit). */
+    dev->pos_regs[5] = 0x80; /* channel check / bank-1 presence */
+
+    /* Default TT: identity-map the card's memory at its extended-memory
+       home, starting at 1M+384K. */
+    for (uint32_t i = 0; i < dev->blocks; i++)
+        dev->tt[MXO_EXT_FIRST_TT + i] = MXO_TT_ENABLE | i;
+
+    /* Register the card on the MCA bus. */
+    mca_add(mxo_mca_read, mxo_mca_write, mxo_mca_feedb, mxo_reset, dev);
+
+    /* Extended memory home, provided by the card through its TT.  The
+       default TT maps it at 1M+384K, so the memory is present right after
+       boot; mxo_ext_update() repositions the mapping wherever the BIOS
+       actually sets the translate table up. */
+    mem_mapping_add(&dev->ext_mapping,
+                    MXO_EXT_BASE,
+                    MXO_SIZE_2MB,
+                    mxo_mem_read,
+                    NULL,
+                    NULL,
+                    mxo_mem_write,
+                    NULL,
+                    NULL,
+                    NULL,
+                    0,
+                    dev);
+    mxo_ext_update(dev);
+
+    /* EMS page frame slots (A0000h-E0000h), one 16K mapping per slot.
+       mxo_pf_update() enables only the slots whose TT entry is active, 
+       so a card never claims a page-frame address it has not mapped. */
+    for (uint8_t k = 0; k < MXO_PF_SLOTS; k++) {
+        mem_mapping_add(&dev->pf_map[k],
+                        (uint32_t) (MXO_PF_SCAN_FIRST + k) << MXO_BLOCK_SHIFT,
+                        MXO_BLOCK_SIZE,
+                        mxo_mem_read,
+                        NULL,
+                        NULL,
+                        mxo_mem_write,
+                        NULL,
+                        NULL,
+                        NULL,
+                        0,
+                        dev);
+        mem_mapping_disable(&dev->pf_map[k]);
+    }
+    mxo_pf_update(dev);
+
+    return dev;
+}
+
+static void
+mxo_close(void *priv)
+{
+    mxo_t *dev = (mxo_t *) priv;
+
+    free(dev->ram.ptr);
+    free(dev);
+}
+
+static const device_config_t ibm_xma_mca_config[] = {
+    {
+        .name           = "size",
+        .description    = "Memory size",
+        .type           = CONFIG_SPINNER,
+        .default_string = NULL,
+        .default_int    = 2048,
+        .file_filter    = NULL,
+        .spinner        = {
+            .min  = 512,
+            .max  = 2048,
+            .step = 512
+        },
+        .selection      = { { 0 } },
+        .bios           = { { 0 } }
+    },
+    { .name = "", .description = "", .type = CONFIG_END }
+};
+
+const device_t ibm_xma_mca_2mb_device = {
+    .name          = "IBM 512KB/2MB 286 Memory Expansion Adapter",
+    .internal_name = "ibm_xma_mca_2mb_device",
+    .flags         = DEVICE_MCA,
+    .local         = 0,
+    .init          = mxo_init,
+    .close         = mxo_close,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = ibm_xma_mca_config
+};

--- a/src/device/mcamem.c
+++ b/src/device/mcamem.c
@@ -1,0 +1,113 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          Implementation of memory expansion boards for the MCA bus.
+ *
+ *          This module mirrors the ISA "isamem" memory-board model so
+ *          that up to MCAMEM_MAX boards can be configured in the same
+ *          way as ISA memory cards.
+ *
+ *          NOTE: unlike isamem_reset() (which runs before the machine is
+ *          set up), mcamem_reset() must be called AFTER the machine has
+ *          been initialized, because MCA boards need mca_init() to have
+ *          run before they can register themselves on the bus.
+ *
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
+ *          WNT50
+ *
+ *          Copyright 2018 Fred N. van Kempen.
+ *          Copyright 2026 WNT50.
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <86box/86box.h>
+#include <86box/device.h>
+#include <86box/machine.h>
+#include <86box/mcamem.h>
+
+/* Board list, structured like net_cards[] in src/network/network.c: each
+   entry holds a const device_t pointer, ended by a NULL sentinel.  The
+   individual board device_t symbols are declared in mcamem.h under
+   EMU_DEVICE_H (see the 86box/network.h pattern). */
+typedef struct {
+    const device_t *device;
+} MCAMEM_CARD;
+
+static const MCAMEM_CARD mcamem_cards[] = {
+    // clang-format off
+    { &device_none              },
+    /* MCA Memory Expansion Boards */
+    { &ibm_xma_mca_2mb_device   },
+    { NULL                      }
+    // clang-format on
+};
+
+void
+mcamem_reset(void)
+{
+    /* Add all configured MCA memory boards to the system. */
+    for (uint8_t i = 0; i < MCAMEM_MAX; i++) {
+        int k = mcamem_type[i];
+
+        if (k == 0)
+            continue;
+
+        /* Only add boards whose bus the current machine provides. */
+        if (mcamem_cards[k].device && !device_is_valid(mcamem_cards[k].device, machine))
+            continue;
+
+        device_add_inst(mcamem_cards[k].device, i + 1);
+    }
+}
+
+const char *
+mcamem_get_name(int board)
+{
+    if (mcamem_cards[board].device == NULL)
+        return (NULL);
+
+    return (mcamem_cards[board].device->name);
+}
+
+const char *
+mcamem_get_internal_name(int board)
+{
+    return device_get_internal_name(mcamem_cards[board].device);
+}
+
+int
+mcamem_get_from_internal_name(const char *str)
+{
+    int c = 0;
+
+    while (mcamem_cards[c].device != NULL) {
+        if (!strcmp(mcamem_cards[c].device->internal_name, str))
+            return c;
+        c++;
+    }
+
+    /* Not found. */
+    return 0;
+}
+
+const device_t *
+mcamem_get_device(int board)
+{
+    /* Add the instance to the system. */
+    return mcamem_cards[board].device;
+}
+
+int
+mcamem_has_config(int board)
+{
+    if (mcamem_cards[board].device == NULL)
+        return 0;
+
+    return (mcamem_cards[board].device->config ? 1 : 0);
+}

--- a/src/include/86box/86box.h
+++ b/src/include/86box/86box.h
@@ -201,6 +201,7 @@ extern int      postcard_enabled;           /* (C) enable POST card */
 extern int      unittester_enabled;         /* (C) enable unit tester device */
 extern int      softpower_enabled;            /* (C) enable PC Convertible-style soft power card */
 extern int      gameport_type[];            /* (C) enable gameports */
+extern int      mcamem_type[];              /* (C) enable MCA mem cards */
 extern int      isamem_type[];              /* (C) enable ISA mem cards */
 extern int      isarom_type[];              /* (C) enable ISA ROM cards */
 extern int      isartc_type;                /* (C) enable ISA RTC card */

--- a/src/include/86box/mcamem.h
+++ b/src/include/86box/mcamem.h
@@ -1,0 +1,45 @@
+/*
+ * 86Box    A hypervisor and IBM PC system emulator that specializes in
+ *          running old operating systems and software designed for IBM
+ *          PC systems and compatibles from 1981 through fairly recent
+ *          system designs based on the PCI bus.
+ *
+ *          This file is part of the 86Box distribution.
+ *
+ *          Definitions for the MCAMEM cards.
+ *
+ * Authors: Fred N. van Kempen, <decwiz@yahoo.com>
+ *          WNT50
+ *
+ *          Copyright 2018 Fred N. van Kempen.
+ *          Copyright 2026 WNT50.
+ */
+#ifndef EMU_MCAMEM_H
+#define EMU_MCAMEM_H
+
+#define MCAMEM_MAX 4 /* max #cards in system */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Functions. */
+extern void mcamem_reset(void);
+
+extern const char     *mcamem_get_name(int t);
+extern const char     *mcamem_get_internal_name(int t);
+extern int             mcamem_get_from_internal_name(const char *str);
+extern int             mcamem_has_config(int board);
+
+#ifdef EMU_DEVICE_H
+extern const device_t *mcamem_get_device(int t);
+
+/* MCA Memory Expansion Boards. */
+extern const device_t ibm_xma_mca_2mb_device;
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*EMU_MCAMEM_H*/

--- a/src/qt/qt_settingsotherperipherals.cpp
+++ b/src/qt/qt_settingsotherperipherals.cpp
@@ -52,14 +52,12 @@ SettingsOtherPeripherals::SettingsOtherPeripherals(QWidget *parent)
 {
     ui->setupUi(this);
 
-    for (uint8_t i = 0; i < MCAMEM_MAX; ++i) {
-        scMcaMemCard[i] = new SettingsCompleter(findChild<QComboBox *>(QString("comboBoxMcaMemCard%1").arg(i + 1)), nullptr);
-        mcamem_cfg_changed[i] = 0;
-    }
-
+    /* Memory expansion cards: one shared set of four slots, fed from the
+       ISA board list (isamem) on ISA machines and from the MCA board list
+       (mcamem) on MCA machines. */
     for (uint8_t i = 0; i < ISAMEM_MAX; ++i) {
-        scIsaMemCard[i] = new SettingsCompleter(findChild<QComboBox *>(QString("comboBoxIsaMemCard%1").arg(i + 1)), nullptr);
-        isamem_cfg_changed[i] = 0;
+        scMemExpCard[i] = new SettingsCompleter(findChild<QComboBox *>(QString("comboBoxMemExpCard%1").arg(i + 1)), nullptr);
+        memexp_cfg_changed[i] = 0;
     }
 
     for (uint8_t i = 0; i < ISAROM_MAX; ++i) {
@@ -79,11 +77,8 @@ SettingsOtherPeripherals::SettingsOtherPeripherals(QWidget *parent)
 
 SettingsOtherPeripherals::~SettingsOtherPeripherals()
 {
-    for (uint8_t i = 0; i < MCAMEM_MAX; ++i)
-        delete scMcaMemCard[i];
-
     for (uint8_t i = 0; i < ISAMEM_MAX; ++i)
-        delete scIsaMemCard[i];
+        delete scMemExpCard[i];
 
     for (uint8_t i = 0; i < ISAROM_MAX; ++i)
         delete scIsaRomCard[i];
@@ -119,15 +114,9 @@ SettingsOtherPeripherals::onCurrentMachineChanged(int machineId)
     scRTC->removeRows();
     ui->comboBoxRTC->clear();
 
-    for (uint8_t i = 0; i < MCAMEM_MAX; ++i) {
-        scMcaMemCard[i]->removeRows();
-        if (auto *cb = findChild<QComboBox *>(QString("comboBoxMcaMemCard%1").arg(i + 1)))
-            cb->clear();
-    }
-
     for (uint8_t i = 0; i < ISAMEM_MAX; ++i) {
-        scIsaMemCard[i]->removeRows();
-        if (auto *cb = findChild<QComboBox *>(QString("comboBoxIsaMemCard%1").arg(i + 1)))
+        scMemExpCard[i]->removeRows();
+        if (auto *cb = findChild<QComboBox *>(QString("comboBoxMemExpCard%1").arg(i + 1)))
             cb->clear();
     }
 
@@ -162,74 +151,49 @@ SettingsOtherPeripherals::onCurrentMachineChanged(int machineId)
     ui->comboBoxRTC->setCurrentIndex(selectedRow);
     ui->pushButtonConfigureRTC->setEnabled((isartc_type != 0) && isartc_has_config(isartc_type) && machineHasIsaOrSidecar);
 
-    // MCA Memory Expansion Cards
-    QComboBox          *mcamem_cbox[MCAMEM_MAX]         = { 0 };
-    QAbstractItemModel *mcamem_models[MCAMEM_MAX]       = { 0 };
-    int                 mcamem_removeRows_[MCAMEM_MAX]  = { 0 };
-    int                 mcamem_selectedRows[MCAMEM_MAX] = { 0 };
+    // Memory Expansion Cards (shared UI: ISA or MCA boards depending on
+    // the machine bus).  The isamem/mcamem databases and their config
+    // globals remain separate; only the four dropdown slots are shared.
+    const bool mca_bus = (machine_has_bus(machineId, MACHINE_BUS_MCA) > 0);
+    const bool isa_bus = !mca_bus && hasIsaOrSidecarBus(machineId);
 
-    for (uint8_t i = 0; i < MCAMEM_MAX; ++i) {
-        mcamem_cbox[i]        = findChild<QComboBox *>(QString("comboBoxMcaMemCard%1").arg(i + 1));
-        mcamem_models[i]      = mcamem_cbox[i]->model();
-        mcamem_removeRows_[i] = mcamem_models[i]->rowCount();
-    }
-
-    c = 0;
-    while (true) {
-        const QString name = DeviceConfig::DeviceName(mcamem_get_device(c),
-                                                      mcamem_get_internal_name(c), 0);
-
-        if (name.isEmpty())
-            break;
-
-        if (device_is_valid(mcamem_get_device(c), machineId)) {
-            for (uint8_t i = 0; i < MCAMEM_MAX; ++i) {
-                int row = Models::AddEntry(mcamem_models[i], name, c);
-                scMcaMemCard[i]->addDevice(nullptr, name);
-
-                if (c == mcamem_type[i])
-                    mcamem_selectedRows[i] = row - mcamem_removeRows_[i];
-            }
-        }
-
-        c++;
-    }
-
-    for (uint8_t i = 0; i < MCAMEM_MAX; ++i) {
-        mcamem_models[i]->removeRows(0, mcamem_removeRows_[i]);
-        mcamem_cbox[i]->setEnabled(mcamem_models[i]->rowCount() > 1);
-        mcamem_cbox[i]->setCurrentIndex(-1);
-        mcamem_cbox[i]->setCurrentIndex(mcamem_selectedRows[i]);
-        findChild<QPushButton *>(QString("pushButtonConfigureMcaMemCard%1").arg(i + 1))->setEnabled(device_is_valid(mcamem_get_device(mcamem_type[i]), machineId) && mcamem_has_config(mcamem_type[i]));
-    }
-
-    // ISA Memory Expansion Cards
-    QComboBox          *isamem_cbox[ISAMEM_MAX]         = { 0 };
-    QAbstractItemModel *isamem_models[ISAMEM_MAX]       = { 0 };
-    int                 isamem_removeRows_[ISAMEM_MAX]  = { 0 };
-    int                 isamem_selectedRows[ISAMEM_MAX] = { 0 };
+    QComboBox          *mem_cbox[ISAMEM_MAX]         = { 0 };
+    QAbstractItemModel *mem_models[ISAMEM_MAX]       = { 0 };
+    int                 mem_removeRows_[ISAMEM_MAX]  = { 0 };
+    int                 mem_selectedRows[ISAMEM_MAX] = { 0 };
 
     for (uint8_t i = 0; i < ISAMEM_MAX; ++i) {
-        isamem_cbox[i]        = findChild<QComboBox *>(QString("comboBoxIsaMemCard%1").arg(i + 1));
-        isamem_models[i]      = isamem_cbox[i]->model();
-        isamem_removeRows_[i] = isamem_models[i]->rowCount();
+        mem_cbox[i]        = findChild<QComboBox *>(QString("comboBoxMemExpCard%1").arg(i + 1));
+        mem_models[i]      = mem_cbox[i]->model();
+        mem_removeRows_[i] = mem_models[i]->rowCount();
     }
 
     c = 0;
     while (true) {
-        const QString name = DeviceConfig::DeviceName(isamem_get_device(c),
-                                                      isamem_get_internal_name(c), 0);
+        const device_t *dev   = NULL;
+        const char     *iname = NULL;
 
+        if (mca_bus) {
+            dev   = mcamem_get_device(c);
+            iname = mcamem_get_internal_name(c);
+        } else if (isa_bus) {
+            dev   = isamem_get_device(c);
+            iname = isamem_get_internal_name(c);
+        } else
+            break;
+
+        const QString name = DeviceConfig::DeviceName(dev, iname, 0);
         if (name.isEmpty())
             break;
 
-        if (device_is_valid(isamem_get_device(c), machineId)) {
+        if (device_is_valid(dev, machineId)) {
             for (uint8_t i = 0; i < ISAMEM_MAX; ++i) {
-                int row = Models::AddEntry(isamem_models[i], name, c);
-                scIsaMemCard[i]->addDevice(nullptr, name);
+                int cur = mca_bus ? mcamem_type[i] : isamem_type[i];
+                int row = Models::AddEntry(mem_models[i], name, c);
+                scMemExpCard[i]->addDevice(nullptr, name);
 
-                if (c == isamem_type[i])
-                    isamem_selectedRows[i] = row - isamem_removeRows_[i];
+                if (c == cur)
+                    mem_selectedRows[i] = row - mem_removeRows_[i];
             }
         }
 
@@ -237,11 +201,14 @@ SettingsOtherPeripherals::onCurrentMachineChanged(int machineId)
     }
 
     for (uint8_t i = 0; i < ISAMEM_MAX; ++i) {
-        isamem_models[i]->removeRows(0, isamem_removeRows_[i]);
-        isamem_cbox[i]->setEnabled(isamem_models[i]->rowCount() > 1);
-        isamem_cbox[i]->setCurrentIndex(-1);
-        isamem_cbox[i]->setCurrentIndex(isamem_selectedRows[i]);
-        findChild<QPushButton *>(QString("pushButtonConfigureIsaMemCard%1").arg(i + 1))->setEnabled((isamem_type[i] != 0) && isamem_has_config(isamem_type[i]) && machineHasIsaOrSidecar);
+        const device_t *seldev = mca_bus ? mcamem_get_device(mcamem_type[i]) : isamem_get_device(isamem_type[i]);
+        bool            hascfg = mca_bus ? (mcamem_has_config(mcamem_type[i]) != 0) : (isamem_has_config(isamem_type[i]) != 0);
+
+        mem_models[i]->removeRows(0, mem_removeRows_[i]);
+        mem_cbox[i]->setEnabled(mem_models[i]->rowCount() > 1);
+        mem_cbox[i]->setCurrentIndex(-1);
+        mem_cbox[i]->setCurrentIndex(mem_selectedRows[i]);
+        findChild<QPushButton *>(QString("pushButtonConfigureMemExpCard%1").arg(i + 1))->setEnabled(device_is_valid(seldev, machineId) && hascfg);
     }
 
     // ISA ROM Expansion Cards
@@ -302,18 +269,18 @@ SettingsOtherPeripherals::changed()
     has_changed |= (novell_keycard_enabled != (ui->checkBoxKeyCard->isChecked() ? 1 : 0));
     has_changed |= novell_keycard_cfg_changed;
 
-    /* MCA memory boards. */
-    for (int i = 0; i < MCAMEM_MAX; i++) {
-        auto *cbox     = findChild<QComboBox *>(QString("comboBoxMcaMemCard%1").arg(i + 1));
-        has_changed |= (mcamem_type[i]         != cbox->currentData().toInt());
-        has_changed |= mcamem_cfg_changed[i];
-    }
+    /* Memory expansion boards (shared slots; active family by machine). */
+    {
+        const bool mca_bus = (machine_has_bus(machineId, MACHINE_BUS_MCA) > 0);
 
-    /* ISA memory boards. */
-    for (int i = 0; i < ISAMEM_MAX; i++) {
-        auto *cbox     = findChild<QComboBox *>(QString("comboBoxIsaMemCard%1").arg(i + 1));
-        has_changed |= (isamem_type[i]         != cbox->currentData().toInt());
-        has_changed |= isamem_cfg_changed[i];
+        if (mca_bus || hasIsaOrSidecarBus(machineId)) {
+            for (int i = 0; i < ISAMEM_MAX; i++) {
+                auto *cbox    = findChild<QComboBox *>(QString("comboBoxMemExpCard%1").arg(i + 1));
+                int   cur     = mca_bus ? mcamem_type[i] : isamem_type[i];
+                has_changed  |= (cur != cbox->currentData().toInt());
+                has_changed  |= memexp_cfg_changed[i];
+            }
+        }
     }
 
     /* ISA ROM boards. */
@@ -345,16 +312,23 @@ SettingsOtherPeripherals::save(int soft)
     softpower_enabled       = ui->checkBoxSoftPower->isChecked() ? 1 : 0;
     novell_keycard_enabled = ui->checkBoxKeyCard->isChecked() ? 1 : 0;
 
-    /* MCA memory boards. */
-    for (int i = 0; i < MCAMEM_MAX; i++) {
-        auto *cbox     = findChild<QComboBox *>(QString("comboBoxMcaMemCard%1").arg(i + 1));
-        mcamem_type[i] = cbox->currentData().toInt();
-    }
+    /* Memory expansion boards (shared slots; write the active family and
+       clear the inactive one, matching the single-UI layout). */
+    {
+        const bool mca_bus = (machine_has_bus(machineId, MACHINE_BUS_MCA) > 0);
+        const bool isa_bus = !mca_bus && hasIsaOrSidecarBus(machineId);
 
-    /* ISA memory boards. */
-    for (int i = 0; i < ISAMEM_MAX; i++) {
-        auto *cbox     = findChild<QComboBox *>(QString("comboBoxIsaMemCard%1").arg(i + 1));
-        isamem_type[i] = cbox->currentData().toInt();
+        for (int i = 0; i < ISAMEM_MAX; i++) {
+            int val = (mca_bus || isa_bus) ? findChild<QComboBox *>(QString("comboBoxMemExpCard%1").arg(i + 1))->currentData().toInt() : 0;
+
+            if (mca_bus) {
+                mcamem_type[i] = val;
+                isamem_type[i] = 0;
+            } else {
+                isamem_type[i] = val;
+                mcamem_type[i] = 0;
+            }
+        }
     }
 
     /* ISA ROM boards. */
@@ -379,124 +353,86 @@ SettingsOtherPeripherals::on_pushButtonConfigureRTC_clicked()
     isartc_cfg_changed |= DeviceConfig::ConfigureDevice(isartc_get_device(ui->comboBoxRTC->currentData().toInt()));
 }
 
+/* Shared memory-expansion slot helpers: resolve the board device and its
+   config capability from the machine's active bus family (MCA or ISA). */
+static const device_t *
+memexp_slot_device(int idx, bool mca_bus)
+{
+    return mca_bus ? mcamem_get_device(idx) : isamem_get_device(idx);
+}
+
+static int
+memexp_slot_has_config(int idx, bool mca_bus)
+{
+    return mca_bus ? mcamem_has_config(idx) : isamem_has_config(idx);
+}
+
 void
-SettingsOtherPeripherals::on_comboBoxMcaMemCard1_currentIndexChanged(int index)
+SettingsOtherPeripherals::on_comboBoxMemExpCard1_currentIndexChanged(int index)
 {
     if (index < 0)
         return;
 
-    ui->pushButtonConfigureMcaMemCard1->setEnabled(device_is_valid(mcamem_get_device(index), machineId) && mcamem_has_config(index));
+    const bool mca_bus = (machine_has_bus(machineId, MACHINE_BUS_MCA) > 0);
+    ui->pushButtonConfigureMemExpCard1->setEnabled(device_is_valid(memexp_slot_device(index, mca_bus), machineId) && memexp_slot_has_config(index, mca_bus));
 }
 
 void
-SettingsOtherPeripherals::on_pushButtonConfigureMcaMemCard1_clicked()
+SettingsOtherPeripherals::on_pushButtonConfigureMemExpCard1_clicked()
 {
-    mcamem_cfg_changed[0] |= DeviceConfig::ConfigureDevice(mcamem_get_device(ui->comboBoxMcaMemCard1->currentData().toInt()), 1);
+    const bool mca_bus = (machine_has_bus(machineId, MACHINE_BUS_MCA) > 0);
+    memexp_cfg_changed[0] |= DeviceConfig::ConfigureDevice(memexp_slot_device(ui->comboBoxMemExpCard1->currentData().toInt(), mca_bus), 1);
 }
 
 void
-SettingsOtherPeripherals::on_comboBoxMcaMemCard2_currentIndexChanged(int index)
-{
-    if (index < 0)
-        return;
-
-    ui->pushButtonConfigureMcaMemCard2->setEnabled(device_is_valid(mcamem_get_device(index), machineId) && mcamem_has_config(index));
-}
-
-void
-SettingsOtherPeripherals::on_pushButtonConfigureMcaMemCard2_clicked()
-{
-    mcamem_cfg_changed[1] |= DeviceConfig::ConfigureDevice(mcamem_get_device(ui->comboBoxMcaMemCard2->currentData().toInt()), 2);
-}
-
-void
-SettingsOtherPeripherals::on_comboBoxMcaMemCard3_currentIndexChanged(int index)
+SettingsOtherPeripherals::on_comboBoxMemExpCard2_currentIndexChanged(int index)
 {
     if (index < 0)
         return;
 
-    ui->pushButtonConfigureMcaMemCard3->setEnabled(device_is_valid(mcamem_get_device(index), machineId) && mcamem_has_config(index));
+    const bool mca_bus = (machine_has_bus(machineId, MACHINE_BUS_MCA) > 0);
+    ui->pushButtonConfigureMemExpCard2->setEnabled(device_is_valid(memexp_slot_device(index, mca_bus), machineId) && memexp_slot_has_config(index, mca_bus));
 }
 
 void
-SettingsOtherPeripherals::on_pushButtonConfigureMcaMemCard3_clicked()
+SettingsOtherPeripherals::on_pushButtonConfigureMemExpCard2_clicked()
 {
-    mcamem_cfg_changed[2] |= DeviceConfig::ConfigureDevice(mcamem_get_device(ui->comboBoxMcaMemCard3->currentData().toInt()), 3);
+    const bool mca_bus = (machine_has_bus(machineId, MACHINE_BUS_MCA) > 0);
+    memexp_cfg_changed[1] |= DeviceConfig::ConfigureDevice(memexp_slot_device(ui->comboBoxMemExpCard2->currentData().toInt(), mca_bus), 2);
 }
 
 void
-SettingsOtherPeripherals::on_comboBoxMcaMemCard4_currentIndexChanged(int index)
-{
-    if (index < 0)
-        return;
-
-    ui->pushButtonConfigureMcaMemCard4->setEnabled(device_is_valid(mcamem_get_device(index), machineId) && mcamem_has_config(index));
-}
-
-void
-SettingsOtherPeripherals::on_pushButtonConfigureMcaMemCard4_clicked()
-{
-    mcamem_cfg_changed[3] |= DeviceConfig::ConfigureDevice(mcamem_get_device(ui->comboBoxMcaMemCard4->currentData().toInt()), 4);
-}
-
-void
-SettingsOtherPeripherals::on_comboBoxIsaMemCard1_currentIndexChanged(int index)
+SettingsOtherPeripherals::on_comboBoxMemExpCard3_currentIndexChanged(int index)
 {
     if (index < 0)
         return;
 
-    ui->pushButtonConfigureIsaMemCard1->setEnabled((index != 0) && isamem_has_config(index) && hasIsaOrSidecarBus(machineId));
+    const bool mca_bus = (machine_has_bus(machineId, MACHINE_BUS_MCA) > 0);
+    ui->pushButtonConfigureMemExpCard3->setEnabled(device_is_valid(memexp_slot_device(index, mca_bus), machineId) && memexp_slot_has_config(index, mca_bus));
 }
 
 void
-SettingsOtherPeripherals::on_pushButtonConfigureIsaMemCard1_clicked()
+SettingsOtherPeripherals::on_pushButtonConfigureMemExpCard3_clicked()
 {
-    isamem_cfg_changed[0] |= DeviceConfig::ConfigureDevice(isamem_get_device(ui->comboBoxIsaMemCard1->currentData().toInt()), 1);
+    const bool mca_bus = (machine_has_bus(machineId, MACHINE_BUS_MCA) > 0);
+    memexp_cfg_changed[2] |= DeviceConfig::ConfigureDevice(memexp_slot_device(ui->comboBoxMemExpCard3->currentData().toInt(), mca_bus), 3);
 }
 
 void
-SettingsOtherPeripherals::on_comboBoxIsaMemCard2_currentIndexChanged(int index)
-{
-    if (index < 0)
-        return;
-
-    ui->pushButtonConfigureIsaMemCard2->setEnabled((index != 0) && isamem_has_config(index) && hasIsaOrSidecarBus(machineId));
-}
-
-void
-SettingsOtherPeripherals::on_pushButtonConfigureIsaMemCard2_clicked()
-{
-    isamem_cfg_changed[1] |= DeviceConfig::ConfigureDevice(isamem_get_device(ui->comboBoxIsaMemCard2->currentData().toInt()), 2);
-}
-
-void
-SettingsOtherPeripherals::on_comboBoxIsaMemCard3_currentIndexChanged(int index)
+SettingsOtherPeripherals::on_comboBoxMemExpCard4_currentIndexChanged(int index)
 {
     if (index < 0)
         return;
 
-    ui->pushButtonConfigureIsaMemCard3->setEnabled((index != 0) && isamem_has_config(index) && hasIsaOrSidecarBus(machineId));
+    const bool mca_bus = (machine_has_bus(machineId, MACHINE_BUS_MCA) > 0);
+    ui->pushButtonConfigureMemExpCard4->setEnabled(device_is_valid(memexp_slot_device(index, mca_bus), machineId) && memexp_slot_has_config(index, mca_bus));
 }
 
 void
-SettingsOtherPeripherals::on_pushButtonConfigureIsaMemCard3_clicked()
+SettingsOtherPeripherals::on_pushButtonConfigureMemExpCard4_clicked()
 {
-    isamem_cfg_changed[2] |= DeviceConfig::ConfigureDevice(isamem_get_device(ui->comboBoxIsaMemCard3->currentData().toInt()), 3);
-}
-
-void
-SettingsOtherPeripherals::on_comboBoxIsaMemCard4_currentIndexChanged(int index)
-{
-    if (index < 0)
-        return;
-
-    ui->pushButtonConfigureIsaMemCard4->setEnabled((index != 0) && isamem_has_config(index) && hasIsaOrSidecarBus(machineId));
-}
-
-void
-SettingsOtherPeripherals::on_pushButtonConfigureIsaMemCard4_clicked()
-{
-    isamem_cfg_changed[3] |= DeviceConfig::ConfigureDevice(isamem_get_device(ui->comboBoxIsaMemCard4->currentData().toInt()), 4);
+    const bool mca_bus = (machine_has_bus(machineId, MACHINE_BUS_MCA) > 0);
+    memexp_cfg_changed[3] |= DeviceConfig::ConfigureDevice(memexp_slot_device(ui->comboBoxMemExpCard4->currentData().toInt(), mca_bus), 4);
 }
 
 void

--- a/src/qt/qt_settingsotherperipherals.cpp
+++ b/src/qt/qt_settingsotherperipherals.cpp
@@ -21,6 +21,7 @@ extern "C" {
 #include <86box/86box.h>
 #include <86box/device.h>
 #include <86box/machine.h>
+#include <86box/mcamem.h>
 #include <86box/isamem.h>
 #include <86box/isarom.h>
 #include <86box/isartc.h>
@@ -51,6 +52,11 @@ SettingsOtherPeripherals::SettingsOtherPeripherals(QWidget *parent)
 {
     ui->setupUi(this);
 
+    for (uint8_t i = 0; i < MCAMEM_MAX; ++i) {
+        scMcaMemCard[i] = new SettingsCompleter(findChild<QComboBox *>(QString("comboBoxMcaMemCard%1").arg(i + 1)), nullptr);
+        mcamem_cfg_changed[i] = 0;
+    }
+
     for (uint8_t i = 0; i < ISAMEM_MAX; ++i) {
         scIsaMemCard[i] = new SettingsCompleter(findChild<QComboBox *>(QString("comboBoxIsaMemCard%1").arg(i + 1)), nullptr);
         isamem_cfg_changed[i] = 0;
@@ -73,6 +79,9 @@ SettingsOtherPeripherals::SettingsOtherPeripherals(QWidget *parent)
 
 SettingsOtherPeripherals::~SettingsOtherPeripherals()
 {
+    for (uint8_t i = 0; i < MCAMEM_MAX; ++i)
+        delete scMcaMemCard[i];
+
     for (uint8_t i = 0; i < ISAMEM_MAX; ++i)
         delete scIsaMemCard[i];
 
@@ -110,6 +119,12 @@ SettingsOtherPeripherals::onCurrentMachineChanged(int machineId)
     scRTC->removeRows();
     ui->comboBoxRTC->clear();
 
+    for (uint8_t i = 0; i < MCAMEM_MAX; ++i) {
+        scMcaMemCard[i]->removeRows();
+        if (auto *cb = findChild<QComboBox *>(QString("comboBoxMcaMemCard%1").arg(i + 1)))
+            cb->clear();
+    }
+
     for (uint8_t i = 0; i < ISAMEM_MAX; ++i) {
         scIsaMemCard[i]->removeRows();
         if (auto *cb = findChild<QComboBox *>(QString("comboBoxIsaMemCard%1").arg(i + 1)))
@@ -146,6 +161,47 @@ SettingsOtherPeripherals::onCurrentMachineChanged(int machineId)
     }
     ui->comboBoxRTC->setCurrentIndex(selectedRow);
     ui->pushButtonConfigureRTC->setEnabled((isartc_type != 0) && isartc_has_config(isartc_type) && machineHasIsaOrSidecar);
+
+    // MCA Memory Expansion Cards
+    QComboBox          *mcamem_cbox[MCAMEM_MAX]         = { 0 };
+    QAbstractItemModel *mcamem_models[MCAMEM_MAX]       = { 0 };
+    int                 mcamem_removeRows_[MCAMEM_MAX]  = { 0 };
+    int                 mcamem_selectedRows[MCAMEM_MAX] = { 0 };
+
+    for (uint8_t i = 0; i < MCAMEM_MAX; ++i) {
+        mcamem_cbox[i]        = findChild<QComboBox *>(QString("comboBoxMcaMemCard%1").arg(i + 1));
+        mcamem_models[i]      = mcamem_cbox[i]->model();
+        mcamem_removeRows_[i] = mcamem_models[i]->rowCount();
+    }
+
+    c = 0;
+    while (true) {
+        const QString name = DeviceConfig::DeviceName(mcamem_get_device(c),
+                                                      mcamem_get_internal_name(c), 0);
+
+        if (name.isEmpty())
+            break;
+
+        if (device_is_valid(mcamem_get_device(c), machineId)) {
+            for (uint8_t i = 0; i < MCAMEM_MAX; ++i) {
+                int row = Models::AddEntry(mcamem_models[i], name, c);
+                scMcaMemCard[i]->addDevice(nullptr, name);
+
+                if (c == mcamem_type[i])
+                    mcamem_selectedRows[i] = row - mcamem_removeRows_[i];
+            }
+        }
+
+        c++;
+    }
+
+    for (uint8_t i = 0; i < MCAMEM_MAX; ++i) {
+        mcamem_models[i]->removeRows(0, mcamem_removeRows_[i]);
+        mcamem_cbox[i]->setEnabled(mcamem_models[i]->rowCount() > 1);
+        mcamem_cbox[i]->setCurrentIndex(-1);
+        mcamem_cbox[i]->setCurrentIndex(mcamem_selectedRows[i]);
+        findChild<QPushButton *>(QString("pushButtonConfigureMcaMemCard%1").arg(i + 1))->setEnabled(device_is_valid(mcamem_get_device(mcamem_type[i]), machineId) && mcamem_has_config(mcamem_type[i]));
+    }
 
     // ISA Memory Expansion Cards
     QComboBox          *isamem_cbox[ISAMEM_MAX]         = { 0 };
@@ -246,6 +302,13 @@ SettingsOtherPeripherals::changed()
     has_changed |= (novell_keycard_enabled != (ui->checkBoxKeyCard->isChecked() ? 1 : 0));
     has_changed |= novell_keycard_cfg_changed;
 
+    /* MCA memory boards. */
+    for (int i = 0; i < MCAMEM_MAX; i++) {
+        auto *cbox     = findChild<QComboBox *>(QString("comboBoxMcaMemCard%1").arg(i + 1));
+        has_changed |= (mcamem_type[i]         != cbox->currentData().toInt());
+        has_changed |= mcamem_cfg_changed[i];
+    }
+
     /* ISA memory boards. */
     for (int i = 0; i < ISAMEM_MAX; i++) {
         auto *cbox     = findChild<QComboBox *>(QString("comboBoxIsaMemCard%1").arg(i + 1));
@@ -282,6 +345,12 @@ SettingsOtherPeripherals::save(int soft)
     softpower_enabled       = ui->checkBoxSoftPower->isChecked() ? 1 : 0;
     novell_keycard_enabled = ui->checkBoxKeyCard->isChecked() ? 1 : 0;
 
+    /* MCA memory boards. */
+    for (int i = 0; i < MCAMEM_MAX; i++) {
+        auto *cbox     = findChild<QComboBox *>(QString("comboBoxMcaMemCard%1").arg(i + 1));
+        mcamem_type[i] = cbox->currentData().toInt();
+    }
+
     /* ISA memory boards. */
     for (int i = 0; i < ISAMEM_MAX; i++) {
         auto *cbox     = findChild<QComboBox *>(QString("comboBoxIsaMemCard%1").arg(i + 1));
@@ -308,6 +377,66 @@ void
 SettingsOtherPeripherals::on_pushButtonConfigureRTC_clicked()
 {
     isartc_cfg_changed |= DeviceConfig::ConfigureDevice(isartc_get_device(ui->comboBoxRTC->currentData().toInt()));
+}
+
+void
+SettingsOtherPeripherals::on_comboBoxMcaMemCard1_currentIndexChanged(int index)
+{
+    if (index < 0)
+        return;
+
+    ui->pushButtonConfigureMcaMemCard1->setEnabled(device_is_valid(mcamem_get_device(index), machineId) && mcamem_has_config(index));
+}
+
+void
+SettingsOtherPeripherals::on_pushButtonConfigureMcaMemCard1_clicked()
+{
+    mcamem_cfg_changed[0] |= DeviceConfig::ConfigureDevice(mcamem_get_device(ui->comboBoxMcaMemCard1->currentData().toInt()), 1);
+}
+
+void
+SettingsOtherPeripherals::on_comboBoxMcaMemCard2_currentIndexChanged(int index)
+{
+    if (index < 0)
+        return;
+
+    ui->pushButtonConfigureMcaMemCard2->setEnabled(device_is_valid(mcamem_get_device(index), machineId) && mcamem_has_config(index));
+}
+
+void
+SettingsOtherPeripherals::on_pushButtonConfigureMcaMemCard2_clicked()
+{
+    mcamem_cfg_changed[1] |= DeviceConfig::ConfigureDevice(mcamem_get_device(ui->comboBoxMcaMemCard2->currentData().toInt()), 2);
+}
+
+void
+SettingsOtherPeripherals::on_comboBoxMcaMemCard3_currentIndexChanged(int index)
+{
+    if (index < 0)
+        return;
+
+    ui->pushButtonConfigureMcaMemCard3->setEnabled(device_is_valid(mcamem_get_device(index), machineId) && mcamem_has_config(index));
+}
+
+void
+SettingsOtherPeripherals::on_pushButtonConfigureMcaMemCard3_clicked()
+{
+    mcamem_cfg_changed[2] |= DeviceConfig::ConfigureDevice(mcamem_get_device(ui->comboBoxMcaMemCard3->currentData().toInt()), 3);
+}
+
+void
+SettingsOtherPeripherals::on_comboBoxMcaMemCard4_currentIndexChanged(int index)
+{
+    if (index < 0)
+        return;
+
+    ui->pushButtonConfigureMcaMemCard4->setEnabled(device_is_valid(mcamem_get_device(index), machineId) && mcamem_has_config(index));
+}
+
+void
+SettingsOtherPeripherals::on_pushButtonConfigureMcaMemCard4_clicked()
+{
+    mcamem_cfg_changed[3] |= DeviceConfig::ConfigureDevice(mcamem_get_device(ui->comboBoxMcaMemCard4->currentData().toInt()), 4);
 }
 
 void

--- a/src/qt/qt_settingsotherperipherals.hpp
+++ b/src/qt/qt_settingsotherperipherals.hpp
@@ -26,23 +26,14 @@ private slots:
     void on_comboBoxRTC_currentIndexChanged(int index);
     void on_pushButtonConfigureRTC_clicked();
 
-    void on_comboBoxMcaMemCard1_currentIndexChanged(int index);
-    void on_pushButtonConfigureMcaMemCard1_clicked();
-    void on_comboBoxMcaMemCard2_currentIndexChanged(int index);
-    void on_pushButtonConfigureMcaMemCard2_clicked();
-    void on_comboBoxMcaMemCard3_currentIndexChanged(int index);
-    void on_pushButtonConfigureMcaMemCard3_clicked();
-    void on_comboBoxMcaMemCard4_currentIndexChanged(int index);
-    void on_pushButtonConfigureMcaMemCard4_clicked();
-
-    void on_comboBoxIsaMemCard1_currentIndexChanged(int index);
-    void on_pushButtonConfigureIsaMemCard1_clicked();
-    void on_comboBoxIsaMemCard2_currentIndexChanged(int index);
-    void on_pushButtonConfigureIsaMemCard2_clicked();
-    void on_comboBoxIsaMemCard3_currentIndexChanged(int index);
-    void on_pushButtonConfigureIsaMemCard3_clicked();
-    void on_comboBoxIsaMemCard4_currentIndexChanged(int index);
-    void on_pushButtonConfigureIsaMemCard4_clicked();
+    void on_comboBoxMemExpCard1_currentIndexChanged(int index);
+    void on_pushButtonConfigureMemExpCard1_clicked();
+    void on_comboBoxMemExpCard2_currentIndexChanged(int index);
+    void on_pushButtonConfigureMemExpCard2_clicked();
+    void on_comboBoxMemExpCard3_currentIndexChanged(int index);
+    void on_pushButtonConfigureMemExpCard3_clicked();
+    void on_comboBoxMemExpCard4_currentIndexChanged(int index);
+    void on_pushButtonConfigureMemExpCard4_clicked();
 
     void on_comboBoxIsaRomCard1_currentIndexChanged(int index);
     void on_pushButtonConfigureIsaRomCard1_clicked();
@@ -66,8 +57,7 @@ private:
     Ui::SettingsOtherPeripherals *ui;
     int                           machineId { 0 };
 
-    int                           mcamem_cfg_changed[4]      = { 0, 0, 0, 0 };
-    int                           isamem_cfg_changed[4]      = { 0, 0, 0, 0 };
+    int                           memexp_cfg_changed[4]      = { 0, 0, 0, 0 };
     int                           isarom_cfg_changed[4]      = { 0, 0, 0, 0 };
     int                           isartc_cfg_changed         = 0;
     int                           unittester_cfg_changed     = 0;
@@ -76,8 +66,7 @@ private:
 
     SettingsCompleter            *scRTC;
 
-    SettingsCompleter            *scMcaMemCard[4];
-    SettingsCompleter            *scIsaMemCard[4];
+    SettingsCompleter            *scMemExpCard[4];
     SettingsCompleter            *scIsaRomCard[4];
 };
 

--- a/src/qt/qt_settingsotherperipherals.hpp
+++ b/src/qt/qt_settingsotherperipherals.hpp
@@ -26,6 +26,15 @@ private slots:
     void on_comboBoxRTC_currentIndexChanged(int index);
     void on_pushButtonConfigureRTC_clicked();
 
+    void on_comboBoxMcaMemCard1_currentIndexChanged(int index);
+    void on_pushButtonConfigureMcaMemCard1_clicked();
+    void on_comboBoxMcaMemCard2_currentIndexChanged(int index);
+    void on_pushButtonConfigureMcaMemCard2_clicked();
+    void on_comboBoxMcaMemCard3_currentIndexChanged(int index);
+    void on_pushButtonConfigureMcaMemCard3_clicked();
+    void on_comboBoxMcaMemCard4_currentIndexChanged(int index);
+    void on_pushButtonConfigureMcaMemCard4_clicked();
+
     void on_comboBoxIsaMemCard1_currentIndexChanged(int index);
     void on_pushButtonConfigureIsaMemCard1_clicked();
     void on_comboBoxIsaMemCard2_currentIndexChanged(int index);
@@ -57,6 +66,7 @@ private:
     Ui::SettingsOtherPeripherals *ui;
     int                           machineId { 0 };
 
+    int                           mcamem_cfg_changed[4]      = { 0, 0, 0, 0 };
     int                           isamem_cfg_changed[4]      = { 0, 0, 0, 0 };
     int                           isarom_cfg_changed[4]      = { 0, 0, 0, 0 };
     int                           isartc_cfg_changed         = 0;
@@ -66,6 +76,7 @@ private:
 
     SettingsCompleter            *scRTC;
 
+    SettingsCompleter            *scMcaMemCard[4];
     SettingsCompleter            *scIsaMemCard[4];
     SettingsCompleter            *scIsaRomCard[4];
 };

--- a/src/qt/qt_settingsotherperipherals.ui
+++ b/src/qt/qt_settingsotherperipherals.ui
@@ -217,166 +217,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tabMcaMem">
-      <attribute name="icon">
-       <iconset resource="../qt_resources.qrc">
-        <normaloff>:/settings/qt/icons/isa_memory.ico</normaloff>:/settings/qt/icons/isa_memory.ico</iconset>
-      </attribute>
-      <attribute name="title">
-       <string>MCA Memory Expansion</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayoutMcaMem">
-
-       <item>
-        <widget class="QWidget" name="widget_4" native="true">
-         <layout class="QGridLayout" name="gridLayout_4">
-
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-
-          <item>
-           <layout class="QGridLayout" name="gridLayoutMcaMem">
-            <item row="0" column="0">
-             <widget class="QLabel" name="labelMcaMemCard1">
-              <property name="text">
-               <string>Card 1:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QComboBox" name="comboBoxMcaMemCard1">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maxVisibleItems">
-               <number>30</number>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="2">
-             <widget class="QPushButton" name="pushButtonConfigureMcaMemCard1">
-              <property name="text">
-               <string>Configure</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="labelMcaMemCard2">
-              <property name="text">
-               <string>Card 2:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QComboBox" name="comboBoxMcaMemCard2">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maxVisibleItems">
-               <number>30</number>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="2">
-             <widget class="QPushButton" name="pushButtonConfigureMcaMemCard2">
-              <property name="text">
-               <string>Configure</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="labelMcaMemCard3">
-              <property name="text">
-               <string>Card 3:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QComboBox" name="comboBoxMcaMemCard3">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maxVisibleItems">
-               <number>30</number>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="2">
-             <widget class="QPushButton" name="pushButtonConfigureMcaMemCard3">
-              <property name="text">
-               <string>Configure</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QLabel" name="labelMcaMemCard4">
-              <property name="text">
-               <string>Card 4:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="1">
-             <widget class="QComboBox" name="comboBoxMcaMemCard4">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maxVisibleItems">
-               <number>30</number>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="2">
-             <widget class="QPushButton" name="pushButtonConfigureMcaMemCard4">
-              <property name="text">
-               <string>Configure</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-
-         </layout>
-        </widget>
-       </item>
-
-       <item row="2" column="1">
-        <spacer name="verticalMcaMem">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="tabIsaMem">
+     <widget class="QWidget" name="tabMemExp">
       <attribute name="icon">
        <iconset resource="../qt_resources.qrc">
         <normaloff>:/settings/qt/icons/isa_memory.ico</normaloff>:/settings/qt/icons/isa_memory.ico</iconset>
@@ -384,11 +225,11 @@
       <attribute name="title">
        <string>ISA Memory Expansion</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayoutIsaMem">
+      <layout class="QVBoxLayout" name="verticalLayoutMemExp">
 
        <item>
-        <widget class="QWidget" name="widget_2" native="true">
-         <layout class="QGridLayout" name="gridLayout_2">
+        <widget class="QWidget" name="widgetMemExp" native="true">
+         <layout class="QGridLayout" name="gridLayoutMemExpOuter">
 
           <property name="leftMargin">
            <number>0</number>
@@ -404,16 +245,16 @@
           </property>
 
           <item>
-           <layout class="QGridLayout" name="gridLayoutMem">
+           <layout class="QGridLayout" name="gridLayoutMemExp">
             <item row="0" column="0">
-             <widget class="QLabel" name="labelIsaMemCard1">
+             <widget class="QLabel" name="labelMemExpCard1">
               <property name="text">
                <string>Card 1:</string>
               </property>
              </widget>
             </item>
             <item row="0" column="1">
-             <widget class="QComboBox" name="comboBoxIsaMemCard1">
+             <widget class="QComboBox" name="comboBoxMemExpCard1">
               <property name="sizePolicy">
                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -426,21 +267,21 @@
              </widget>
             </item>
             <item row="0" column="2">
-             <widget class="QPushButton" name="pushButtonConfigureIsaMemCard1">
+             <widget class="QPushButton" name="pushButtonConfigureMemExpCard1">
               <property name="text">
                <string>Configure</string>
               </property>
              </widget>
             </item>
             <item row="1" column="0">
-             <widget class="QLabel" name="labelIsaMemCard2">
+             <widget class="QLabel" name="labelMemExpCard2">
               <property name="text">
                <string>Card 2:</string>
               </property>
              </widget>
             </item>
             <item row="1" column="1">
-             <widget class="QComboBox" name="comboBoxIsaMemCard2">
+             <widget class="QComboBox" name="comboBoxMemExpCard2">
               <property name="sizePolicy">
                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -453,21 +294,21 @@
              </widget>
             </item>
             <item row="1" column="2">
-             <widget class="QPushButton" name="pushButtonConfigureIsaMemCard2">
+             <widget class="QPushButton" name="pushButtonConfigureMemExpCard2">
               <property name="text">
                <string>Configure</string>
               </property>
              </widget>
             </item>
             <item row="2" column="0">
-             <widget class="QLabel" name="labelIsaMemCard3">
+             <widget class="QLabel" name="labelMemExpCard3">
               <property name="text">
                <string>Card 3:</string>
               </property>
              </widget>
             </item>
             <item row="2" column="1">
-             <widget class="QComboBox" name="comboBoxIsaMemCard3">
+             <widget class="QComboBox" name="comboBoxMemExpCard3">
               <property name="sizePolicy">
                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -480,21 +321,21 @@
              </widget>
             </item>
             <item row="2" column="2">
-             <widget class="QPushButton" name="pushButtonConfigureIsaMemCard3">
+             <widget class="QPushButton" name="pushButtonConfigureMemExpCard3">
               <property name="text">
                <string>Configure</string>
               </property>
              </widget>
             </item>
             <item row="3" column="0">
-             <widget class="QLabel" name="labelIsaMemCard4">
+             <widget class="QLabel" name="labelMemExpCard4">
               <property name="text">
                <string>Card 4:</string>
               </property>
              </widget>
             </item>
             <item row="3" column="1">
-             <widget class="QComboBox" name="comboBoxIsaMemCard4">
+             <widget class="QComboBox" name="comboBoxMemExpCard4">
               <property name="sizePolicy">
                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -507,7 +348,7 @@
              </widget>
             </item>
             <item row="3" column="2">
-             <widget class="QPushButton" name="pushButtonConfigureIsaMemCard4">
+             <widget class="QPushButton" name="pushButtonConfigureMemExpCard4">
               <property name="text">
                <string>Configure</string>
               </property>
@@ -520,8 +361,8 @@
         </widget>
        </item>
 
-       <item row="2" column="1">
-        <spacer name="verticalIsaMem">
+      <item row="2" column="1">
+        <spacer name="verticalSpacerMemExp">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -719,6 +560,14 @@
   <tabstop>pushButtonConfigureIsaMemCard3</tabstop>
   <tabstop>comboBoxIsaMemCard4</tabstop>
   <tabstop>pushButtonConfigureIsaMemCard4</tabstop>
+  <tabstop>comboBoxMemExpCard1</tabstop>
+  <tabstop>pushButtonConfigureMemExpCard1</tabstop>
+  <tabstop>comboBoxMemExpCard2</tabstop>
+  <tabstop>pushButtonConfigureMemExpCard2</tabstop>
+  <tabstop>comboBoxMemExpCard3</tabstop>
+  <tabstop>pushButtonConfigureMemExpCard3</tabstop>
+  <tabstop>comboBoxMemExpCard4</tabstop>
+  <tabstop>pushButtonConfigureMemExpCard4</tabstop>
   <tabstop>comboBoxIsaRomCard1</tabstop>
   <tabstop>pushButtonConfigureIsaRomCard1</tabstop>
   <tabstop>comboBoxIsaRomCard2</tabstop>

--- a/src/qt/qt_settingsotherperipherals.ui
+++ b/src/qt/qt_settingsotherperipherals.ui
@@ -217,6 +217,165 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="tabMcaMem">
+      <attribute name="icon">
+       <iconset resource="../qt_resources.qrc">
+        <normaloff>:/settings/qt/icons/isa_memory.ico</normaloff>:/settings/qt/icons/isa_memory.ico</iconset>
+      </attribute>
+      <attribute name="title">
+       <string>MCA Memory Expansion</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayoutMcaMem">
+
+       <item>
+        <widget class="QWidget" name="widget_4" native="true">
+         <layout class="QGridLayout" name="gridLayout_4">
+
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+
+          <item>
+           <layout class="QGridLayout" name="gridLayoutMcaMem">
+            <item row="0" column="0">
+             <widget class="QLabel" name="labelMcaMemCard1">
+              <property name="text">
+               <string>Card 1:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="comboBoxMcaMemCard1">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maxVisibleItems">
+               <number>30</number>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QPushButton" name="pushButtonConfigureMcaMemCard1">
+              <property name="text">
+               <string>Configure</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="labelMcaMemCard2">
+              <property name="text">
+               <string>Card 2:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QComboBox" name="comboBoxMcaMemCard2">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maxVisibleItems">
+               <number>30</number>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="2">
+             <widget class="QPushButton" name="pushButtonConfigureMcaMemCard2">
+              <property name="text">
+               <string>Configure</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="labelMcaMemCard3">
+              <property name="text">
+               <string>Card 3:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QComboBox" name="comboBoxMcaMemCard3">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maxVisibleItems">
+               <number>30</number>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="2">
+             <widget class="QPushButton" name="pushButtonConfigureMcaMemCard3">
+              <property name="text">
+               <string>Configure</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="labelMcaMemCard4">
+              <property name="text">
+               <string>Card 4:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QComboBox" name="comboBoxMcaMemCard4">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maxVisibleItems">
+               <number>30</number>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="2">
+             <widget class="QPushButton" name="pushButtonConfigureMcaMemCard4">
+              <property name="text">
+               <string>Configure</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+
+         </layout>
+        </widget>
+       </item>
+
+       <item row="2" column="1">
+        <spacer name="verticalMcaMem">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
      <widget class="QWidget" name="tabIsaMem">
       <attribute name="icon">
        <iconset resource="../qt_resources.qrc">


### PR DESCRIPTION
Summary
=======
Add IBM 512KB/2MB 286 Memory Expansion Adapter emulation with proper XMA function. Tested with MS-DOS 4.00 XMA2EMS.SYS driver and QEMM 50-60 version 6.0. This PR needs to modify UI pages of the memory expansion parts, so reviews may be required.

Checklist
=========
* [x] Closes #2505
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
[MS-DOS 4.0 XMA2EMS.ASM](https://github.com/pintushaw/MS-DOS-2026/blob/main/v4.0/src/DEV/XMA2EMS/XMA2EMS.ASM)