### PR TITLE
Win: Fix dynamic builds for vcpkg

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -506,6 +506,15 @@ if(WIN32)
                 ")
             endif()
         endif()
+
+        # The Qt plugins live in the vcpkg tree rather than next to the
+        # binary, so point Qt at them to make the build tree runnable
+        # without going through `cmake --install` first.
+        if(VCPKG_TOOLCHAIN)
+            file(GENERATE
+                OUTPUT "$<TARGET_FILE_DIR:86Box>/qt.conf"
+                CONTENT "[Paths]\nPlugins = ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}$<$<CONFIG:Debug>:/debug>/Qt${QT_MAJOR}/plugins\n")
+        endif()
     endif()
 endif()
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -37,7 +37,11 @@
                         "vulkan",
                         "widgets",
                         "png",
-                        "zstd"
+                        "zstd",
+                        {
+                            "name": "windeployqt",
+                            "platform": "windows"
+                        }
                     ]
                 },
                 {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -15,7 +15,7 @@
     "dependencies": [
         "freetype",
         "libpng",
-        "sdl2",
+        "sdl3",
         "rtmidi",
         "libslirp",
         "fluidsynth",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -40,7 +40,7 @@
                         "zstd",
                         {
                             "name": "windeployqt",
-                            "platform": "windows"
+                            "platform": "windows & !static"
                         }
                     ]
                 },


### PR DESCRIPTION
Summary
=======
* Bumped SDL2 to SDL3
* Added missing windeployqt dependency for dynamic builds
* Fix Qt plugin installation in vcpkg, so dynamic builds run in-tree and don't require to be "installed" anymore.

https://github.com/86Box/86Box/commit/f2355622bfc7197550b443d487137b256a5f51fa assisted by Claude Opus, no assistence for the other commits.

Verified with Win11 25H2, CLion && MSYS2 toolchain.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
not applicable.
