### PR TITLE
Re-fix the Solo-1's name

### DIFF
--- a/src/sound/snd_solo1.c
+++ b/src/sound/snd_solo1.c
@@ -1104,7 +1104,7 @@ solo1_close(void *priv)
 }
 
 const device_t ess_solo1_device = {
-    .name          = "ESS Solo-1",
+    .name          = "ESS Solo-1 ES1938S",
     .internal_name = "ess_solo1",
     .flags         = DEVICE_PCI,
     .local         = 0,
@@ -1119,7 +1119,7 @@ const device_t ess_solo1_device = {
 };
 
 const device_t ess_solo1_onboard_device = {
-    .name          = "ESS Solo-1 (On-Board)",
+    .name          = "ESS Solo-1 ES1938S (On-Board)",
     .internal_name = "ess_solo1_onboard",
     .flags         = DEVICE_PCI,
     .local         = 1,


### PR DESCRIPTION
Summary
=======
The Solo-1's listed name was changed after its initial commit to something that didn't match the other ESS board styles.  This corrects that.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already

References
==========

