### PR TITLE
Additional mouse release method

### DIFF
--- a/src/device/mouse.c
+++ b/src/device/mouse.c
@@ -762,6 +762,29 @@ mouse_get_buttons(void)
     return mouse_nbut;
 }
 
+/*
+   Returns the host mouse buttons that release the mouse capture, as a
+   mouse_get_buttons_ex() mask.
+
+   The middle button is used as long as the guest can not see it. Once it can,
+   the thumb buttons take over, and once the guest can see those as well, there
+   is no button left to spare and only the keyboard shortcut remains.
+
+   The returned masks are mutually exclusive by construction.
+ */
+int
+mouse_get_release_buttons(void)
+{
+    int ret = 0x00;
+
+    if (mouse_nbut < 3)
+        ret = MOUSE_RELEASE_MIDDLE;
+    else if (mouse_nbut < 5)
+        ret = MOUSE_RELEASE_THUMB;
+
+    return ret;
+}
+
 /* Return number of MOUSE types we know about. */
 int
 mouse_get_ndev(void)

--- a/src/include/86box/mouse.h
+++ b/src/include/86box/mouse.h
@@ -45,6 +45,10 @@
 #define MOUSE_TYPE_QPORT     0x40 /* Mouse is an on-board version of one of the above. */
 #define MOUSE_TYPE_ONBOARD   0x80 /* Mouse is an on-board version of one of the above. */
 
+/* Masks returned by mouse_get_release_buttons(). */
+#define MOUSE_RELEASE_MIDDLE 0x04 /* Middle button */
+#define MOUSE_RELEASE_THUMB  0x18 /* Thumb buttons (buttons 4 and 5) */
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -133,6 +137,7 @@ extern const device_t *mouse_get_device(int mouse);
 extern const device_t *tablet_get_device(int mouse);
 #endif
 extern int             mouse_get_buttons(void);
+extern int             mouse_get_release_buttons(void);
 extern int             mouse_get_ndev(void);
 extern int             tablet_get_ndev(void);
 extern void            mouse_set_raw(int raw);

--- a/src/qt/languages/86box.pot
+++ b/src/qt/languages/86box.pot
@@ -936,6 +936,9 @@ msgstr ""
 msgid "Press %1 or middle button to release mouse"
 msgstr ""
 
+msgid "Press %1 or thumb button to release mouse"
+msgstr ""
+
 msgid "Bus"
 msgstr ""
 

--- a/src/qt/macos_event_filter.mm
+++ b/src/qt/macos_event_filter.mm
@@ -88,7 +88,12 @@ CocoaEventFilter::nativeEventFilter(const QByteArray &eventType, void *message, 
                     }
                 case NSEventTypeOtherMouseUp:
                     {
-                        if (mouse_get_buttons() < 3) {
+                        /*
+                           AppKit reports every non-left/right button as NSEventTypeOtherMouse*,
+                           and buttonNumber is not consulted here, so the thumb buttons are seen
+                           as the middle one and cannot act as release buttons on this platform.
+                         */
+                        if (mouse_get_release_buttons() & MOUSE_RELEASE_MIDDLE) {
                             plat_mouse_capture(0);
                             return true;
                         }

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -1158,7 +1158,16 @@ MainWindow::updateShortcuts()
 void
 MainWindow::updateMouseStrings()
 {
-    mouseStringCaptured = tr(mouse_get_buttons() > 2 ? "Press %1 to release mouse" : "Press %1 or middle button to release mouse").arg(QKeySequence(acc_keys[FindAccelerator("release_mouse")].seq, QKeySequence::PortableText).toString(QKeySequence::NativeText));
+    const int     release_buttons = mouse_get_release_buttons();
+    const QString seq             = QKeySequence(acc_keys[FindAccelerator("release_mouse")].seq, QKeySequence::PortableText).toString(QKeySequence::NativeText);
+
+    if (release_buttons & MOUSE_RELEASE_MIDDLE)
+        mouseStringCaptured = tr("Press %1 or middle button to release mouse").arg(seq);
+    else if (release_buttons & MOUSE_RELEASE_THUMB)
+        mouseStringCaptured = tr("Press %1 or thumb button to release mouse").arg(seq);
+    else
+        mouseStringCaptured = tr("Press %1 to release mouse").arg(seq);
+
     mouseStringUncaptured = tr("Click to capture mouse");
 }
 

--- a/src/qt/qt_rendererstack.cpp
+++ b/src/qt/qt_rendererstack.cpp
@@ -235,7 +235,13 @@ RendererStack::mouseReleaseEvent(QMouseEvent *event)
         isMouseDown &= ~1;
         return;
     }
-    if (mouse_capture && (event->button() == Qt::MiddleButton) && (mouse_get_buttons() < 3)) {
+    if (mouse_capture && (event->button() & mouse_get_release_buttons())) {
+        /*
+           On Windows the raw input thread sets the button bit behind our back and
+           stops processing as soon as the capture drops, so clear it here to keep it
+           from staying stuck down. Elsewhere the press was already consumed above.
+         */
+        mouse_set_buttons_ex(mouse_get_buttons_ex() & ~event->button());
         plat_mouse_capture(0);
         this->unsetCursor();
         isMouseDown &= ~1;
@@ -270,6 +276,11 @@ void
 RendererStack::mousePressEvent(QMouseEvent *event)
 {
     isMouseDown |= 1;
+    /* A button that releases the capture is consumed, not sent to the guest. */
+    if (mouse_capture && (event->button() & mouse_get_release_buttons())) {
+        event->accept();
+        return;
+    }
     if (mouse_capture || (mouse_input_mode >= 1)) {
         Qt::MouseButton button = event->button();
 #ifdef __APPLE__

--- a/src/unix/sdl_main.c
+++ b/src/unix/sdl_main.c
@@ -331,6 +331,36 @@ timer_onesec(UNUSED(void *param), UNUSED(SDL_TimerID timerID), uint32_t interval
     return interval;
 }
 
+/* Convert an SDL button number to a mouse_get_buttons_ex() mask. */
+static int
+sdl_mouse_buttonmask(uint8_t button)
+{
+    int ret;
+
+    switch (button) {
+        case SDL_BUTTON_LEFT:
+            ret = 1;
+            break;
+        case SDL_BUTTON_RIGHT:
+            ret = 2;
+            break;
+        case SDL_BUTTON_MIDDLE:
+            ret = 4;
+            break;
+        case SDL_BUTTON_X1:
+            ret = 8;
+            break;
+        case SDL_BUTTON_X2:
+            ret = 16;
+            break;
+        default:
+            ret = 0;
+            break;
+    }
+
+    return ret;
+}
+
 extern int gfxcard[GFXCARD_MAX];
 int
 main(int argc, char **argv)
@@ -521,27 +551,10 @@ main(int argc, char **argv)
                                 break;
                             }
                             if (mouse_capture || video_fullscreen) {
-                                int buttonmask = 0;
+                                int buttonmask = sdl_mouse_buttonmask(event.button.button);
 
-                                switch (event.button.button) {
-                                    case SDL_BUTTON_LEFT:
-                                        buttonmask = 1;
-                                        break;
-                                    case SDL_BUTTON_RIGHT:
-                                        buttonmask = 2;
-                                        break;
-                                    case SDL_BUTTON_MIDDLE:
-                                        buttonmask = 4;
-                                        break;
-                                    case SDL_BUTTON_X1:
-                                        buttonmask = 8;
-                                        break;
-                                    case SDL_BUTTON_X2:
-                                        buttonmask = 16;
-                                        break;
-                                    default:
-                                        printf("Unknown mouse button %d\n", event.button.button);
-                                }
+                                if (buttonmask == 0)
+                                    printf("Unknown mouse button %d\n", event.button.button);
                                 SDL_LockMutex(mousemutex);
 #ifdef USE_SDL2_LIB
                                 if (event.button.state == SDL_PRESSED)

--- a/src/unix/sdl_main.c
+++ b/src/unix/sdl_main.c
@@ -546,7 +546,7 @@ main(int argc, char **argv)
                                 plat_mouse_capture(1);
                                 break;
                             }
-                            if (mouse_get_buttons() < 3 && event.button.button == SDL_BUTTON_MIDDLE && !video_fullscreen) {
+                            if (mouse_capture && (sdl_mouse_buttonmask(event.button.button) & mouse_get_release_buttons()) && !video_fullscreen) {
                                 plat_mouse_capture(0);
                                 break;
                             }

--- a/src/unix/sdl_render.c
+++ b/src/unix/sdl_render.c
@@ -705,8 +705,17 @@ plat_resize(int w, int h, UNUSED(int monitor_index))
 void
 update_mouse_msg(void)
 {
-    char  cpufamily[128];
-    char *cp;
+    char        cpufamily[128];
+    char       *cp;
+    const int   release_buttons = mouse_get_release_buttons();
+    const char *release_msg;
+
+    if (release_buttons & MOUSE_RELEASE_MIDDLE)
+        release_msg = "Press CTRL-SHIFT-G or middle button to release mouse";
+    else if (release_buttons & MOUSE_RELEASE_THUMB)
+        release_msg = "Press CTRL-SHIFT-G or thumb button to release mouse";
+    else
+        release_msg = "Press CTRL-SHIFT-G to release mouse";
 
     if (!cpu_override)
         strncpy(cpufamily, cpu_f->name, sizeof(cpufamily) - 1);
@@ -721,7 +730,7 @@ update_mouse_msg(void)
              "Click to capture mouse");
     snprintf(mouse_msg[1], sizeof(mouse_msg[1]), "%s v%s - %%i%%%% - %s - %s/%s - %s",
              EMU_NAME, EMU_VERSION_FULL, machine_getname(machine), cpufamily, cpu_s->name,
-             (mouse_get_buttons() > 2) ? "Press CTRL-SHIFT-G to release mouse" : "Press CTRL-SHIFT-G or middle button to release mouse");
+             release_msg);
     snprintf(mouse_msg[2], sizeof(mouse_msg[2]), "%s v%s - %%i%%%% - %s - %s/%s",
              EMU_NAME, EMU_VERSION_FULL, machine_getname(machine), cpufamily, cpu_s->name);
 }


### PR DESCRIPTION
Summary
=======
Before this PR: If you have a 2-button mouse for the guest, then Mouse3 can release captured input. If you have 3-button, wheel, or more, you can only use the keyboard chord to release input.

After this PR: As above, but: If you have a 3-button or wheel mouse, Mouse4/Mouse5 can also release input:
<img width="412" height="47" alt="image" src="https://github.com/user-attachments/assets/2a5c8e7e-4939-4bde-8311-57f512927451" />

This allows those emulating Win95/98 with a wheel mouse (Intellimouse, etc) to have scrolling, 3 buttons, and also get out of the guest easily.

Tested on Windows and Linux (X). Mouse capture seems to be entirely broken on Wayland currently so I can't really test my Wayland builds! The text changes in the menu bar anyway.

Did not test MacOS or SDL. The changes should work for SDL but it's not provided in any release so I'm not too worried about that.

Sidenote: I think MacOS has a bug with mouse buttons above Mouse3 that is preexisting, but I have no mac to test on. It seems like Mouse4, Mouse5 will just go to the guest as Mouse3. My PR doesn't affect that, I can't test it, but just staring at the code seems to indicate that's the case.

Sidesidenote: mouse_get_buttons() is a poorly named preexisting function. Wheel mice = 4?

Checklist
=========
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
