### PR TITLE
Fix disk lights in IBM PS/2 ESDI and SCSI adapter

### DIFF
--- a/src/disk/hdc_esdi_mca.c
+++ b/src/disk/hdc_esdi_mca.c
@@ -544,9 +544,10 @@ esdi_callback(void *priv)
                     dev->irq_in_progress = 1;
                     set_irq(dev);
 
+                    dev->data_pos = 0;
                     dev->cmd_state = 1;
                     esdi_mca_set_callback(dev, ESDI_TIME);
-                    dev->data_pos = 0;
+                    ui_sb_update_icon(SB_HDD | HDD_BUS_ESDI, 1);
                     break;
 
                 case 1:
@@ -630,9 +631,10 @@ esdi_callback(void *priv)
                     dev->irq_in_progress = 1;
                     set_irq(dev);
 
+                    dev->data_pos = 0;
                     dev->cmd_state = 1;
                     esdi_mca_set_callback(dev, ESDI_TIME);
-                    dev->data_pos = 0;
+                    ui_sb_update_icon_write(SB_HDD | HDD_BUS_ESDI, 1);
                     break;
 
                 case 1:
@@ -897,9 +899,10 @@ esdi_callback(void *priv)
                     dev->irq_in_progress = 1;
                     set_irq(dev);
 
+                    dev->data_pos = 0;
                     dev->cmd_state = 1;
                     esdi_mca_set_callback(dev, ESDI_TIME);
-                    dev->data_pos = 0;
+                    ui_sb_update_icon_write(SB_HDD | HDD_BUS_ESDI, 1);
                     break;
 
                 case 1:
@@ -956,9 +959,10 @@ esdi_callback(void *priv)
                     dev->irq_in_progress = 1;
                     set_irq(dev);
 
+                    dev->data_pos = 0;
                     dev->cmd_state = 1;
                     esdi_mca_set_callback(dev, ESDI_TIME);
-                    dev->data_pos = 0;
+                    ui_sb_update_icon(SB_HDD | HDD_BUS_ESDI, 1);
                     break;
 
                 case 1:
@@ -1337,7 +1341,6 @@ esdi_writew(uint16_t port, uint16_t val, void *priv)
                 esdi_mca_set_callback(dev, ESDI_TIME);
                 dev->status   = STATUS_BUSY;
                 dev->data_pos = 0;
-                ui_sb_update_icon(SB_HDD | HDD_BUS_ESDI, 1);
             }
             break;
 

--- a/src/scsi/scsi_disk.c
+++ b/src/scsi/scsi_disk.c
@@ -1138,7 +1138,7 @@ scsi_disk_command(scsi_common_t *sc, const uint8_t *cdb)
                     scsi_disk_data_command_finish(dev, alloc_length, 512,
                                                   alloc_length, 0);
 
-                    ui_sb_update_icon(SB_HDD, dev->packet_status != PHASE_COMPLETE);
+                    ui_sb_update_icon(SB_HDD | dev->drv->bus_type, dev->packet_status != PHASE_COMPLETE);
                 } else {
                     scsi_disk_set_phase(dev, SCSI_PHASE_STATUS);
                     dev->packet_status = (ret < 0) ? PHASE_ERROR : PHASE_COMPLETE;


### PR DESCRIPTION
Summary
=======
Fix only read disk light in IBM PS/2 ESDI adapter and write disk light in IBM PS/2 SCSI adapter being lit up.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
