### PR TITLE
QL1XXX device queue commands

### DIFF
--- a/src/scsi/scsi_ql1xxx.c
+++ b/src/scsi/scsi_ql1xxx.c
@@ -93,6 +93,7 @@
 
 /* Maximum SCSI devices supported by the chip */
 #define QL_MAX_TID   16
+#define QL_MAX_LUNS  32
 
 #define QL_PCI_PM_BASE             0x44
 #define QL_PCI_IO_BAR_SIZE         0x100
@@ -285,11 +286,16 @@
 #define QL_CMD_ABORT_DEVICE                 0x0016
 #define QL_CMD_ABORT_TARGET                 0x0017
 #define QL_CMD_BUS_RESET                    0x0018
+#define QL_CMD_STOP_QUEUE                   0x0019
 #define QL_CMD_START_QUEUE                  0x001A
+#define QL_CMD_SINGLE_STEP_QUEUE            0x001B
+#define QL_CMD_ABORT_QUEUE                  0x001C
+#define QL_CMD_GET_DEVICE_QUEUE_STATUS      0x001D
 #define QL_CMD_GET_FIRMWARE_STATUS          0x001F
 #define QL_CMD_GET_RETRY_COUNT              0x0022
 #define QL_CMD_GET_ACT_NEG_STATE            0x0025
 #define QL_CMD_GET_TARGET_PARAMETERS        0x0028
+#define QL_CMD_GET_DEVICE_QUEUE_PARAMS      0x0029
 #define QL_CMD_SET_INITIATOR_ID             0x0030
 #define QL_CMD_SET_SELECTION_TIMEOUT        0x0031
 #define QL_CMD_SET_RETRY_COUNT              0x0032
@@ -320,6 +326,11 @@
 #define QL_MBOX_STATUS_TEST_FAILED          0x4003
 #define QL_MBOX_STATUS_CMD_ERROR            0x4005
 #define QL_MBOX_STATUS_CMD_PARAM_ERROR      0x4006
+
+#define QL_QUEUE_STOPPED                    0x0002
+#define QL_QUEUE_SINGLE_STEP                0x0004
+#define QL_QUEUE_DEFAULT_DEPTH              256
+#define QL_QUEUE_DEFAULT_THROTTLE           16
 
 /*
  * Mailbox asynchronous event status codes
@@ -650,6 +661,12 @@ typedef struct ql_fw_target_params {
     uint16_t sync_period;
 } ql_fw_target_params;
 
+typedef struct ql_fw_device_queue {
+    uint16_t flags;
+    uint16_t depth;
+    uint16_t throttle;
+} ql_fw_device_queue;
+
 typedef struct ql_t {
     /* Hardware registers */
     uint16_t reg_cdma_cfg;
@@ -723,6 +740,8 @@ typedef struct ql_t {
     pc_timer_t cmd_timer;
     /* Firmware device parameters */
     ql_fw_target_params fw_tid_params[2][QL_MAX_TID];
+    /* Per-LUN command queue state and limits */
+    ql_fw_device_queue fw_dev_queues[2][QL_MAX_TID][QL_MAX_LUNS];
     /* Firmware retry count and delay settings */
     uint16_t fw_retry_params[4];
     /* Size of the SCSI payload data */
@@ -818,11 +837,16 @@ ql_debug_cmd_to_name(uint16_t opcode)
         MAKE_CASE(QL_CMD_ABORT_DEVICE             );
         MAKE_CASE(QL_CMD_ABORT_TARGET             );
         MAKE_CASE(QL_CMD_BUS_RESET                );
+        MAKE_CASE(QL_CMD_STOP_QUEUE               );
         MAKE_CASE(QL_CMD_START_QUEUE              );
+        MAKE_CASE(QL_CMD_SINGLE_STEP_QUEUE        );
+        MAKE_CASE(QL_CMD_ABORT_QUEUE              );
+        MAKE_CASE(QL_CMD_GET_DEVICE_QUEUE_STATUS  );
         MAKE_CASE(QL_CMD_GET_FIRMWARE_STATUS      );
         MAKE_CASE(QL_CMD_GET_RETRY_COUNT          );
         MAKE_CASE(QL_CMD_GET_ACT_NEG_STATE        );
         MAKE_CASE(QL_CMD_GET_TARGET_PARAMETERS    );
+        MAKE_CASE(QL_CMD_GET_DEVICE_QUEUE_PARAMS  );
         MAKE_CASE(QL_CMD_SET_INITIATOR_ID         );
         MAKE_CASE(QL_CMD_SET_SELECTION_TIMEOUT    );
         MAKE_CASE(QL_CMD_SET_RETRY_COUNT          );
@@ -1350,6 +1374,16 @@ ql_reset_asic(ql_t *dev)
     dev->sxp_flags = 0;
     dev->sxp_state = SXP_STATE_IDLE;
 
+    memset(dev->fw_dev_queues, 0, sizeof(dev->fw_dev_queues));
+    for (uint32_t path_id = 0; path_id < 2; path_id++) {
+        for (uint32_t target_id = 0; target_id < QL_MAX_TID; target_id++) {
+            for (uint32_t lun = 0; lun < QL_MAX_LUNS; lun++) {
+                dev->fw_dev_queues[path_id][target_id][lun].depth = QL_QUEUE_DEFAULT_DEPTH;
+                dev->fw_dev_queues[path_id][target_id][lun].throttle = QL_QUEUE_DEFAULT_THROTTLE;
+            }
+        }
+    }
+
     ql_update_irq(dev);
 }
 
@@ -1407,6 +1441,146 @@ ql_sxp_abort_commands(ql_t *dev, uint8_t path_id, uint8_t target_id, uint8_t lun
     }
 
     return success;
+}
+
+static bool
+ql_get_device_queue(ql_t *dev, uint16_t address, uint8_t *path_id,
+                    uint8_t *target_id, uint8_t *lun,
+                    ql_fw_device_queue **queue)
+{
+    *path_id = (uint8_t)(address >> 15);
+    *target_id = (uint8_t)((address >> 8) & 0x7F);
+    *lun = (uint8_t)address;
+
+    if ((*path_id >= dev->max_bus_count) || (*target_id >= QL_MAX_TID) ||
+        (*lun >= QL_MAX_LUNS)) {
+        return false;
+    }
+
+    *queue = &dev->fw_dev_queues[*path_id][*target_id][*lun];
+    return true;
+}
+
+static bool
+ql_sxp_command_active(ql_t *dev, uint8_t path_id, uint8_t target_id,
+                      uint8_t lun)
+{
+    switch (dev->sxp_state) {
+        case SXP_STATE_SELECT_DEVICE:
+        case SXP_STATE_SELECTION_TIMEOUT:
+        case SXP_STATE_SEND_CDB:
+        case SXP_STATE_COMPLETE_COMMAND:
+            return (((dev->pkt.bus_target & 0x80) >> 7) == path_id) &&
+                   ((dev->pkt.bus_target & 0x7F) == target_id) &&
+                   (dev->pkt.lun == lun) &&
+                   ((dev->pkt.hdr.entry_type == RQSTYPE_REQUEST) ||
+                    (dev->pkt.hdr.entry_type == RQSTYPE_REQUEST_A64));
+        default:
+            return false;
+    }
+}
+
+static uint16_t
+ql_sxp_queued_commands(ql_t *dev, uint8_t path_id, uint8_t target_id,
+                       uint8_t lun)
+{
+    uint16_t cons, count = 0;
+    uint16_t scanned = 0;
+
+    if (!(dev->sxp_flags & SXP_FLAG_ENGINE_ACTIVE) ||
+        (dev->rqst_ring_size == 0)) {
+        return 0;
+    }
+
+    cons = QL_RQST_CONS(dev);
+    if (ql_sxp_command_active(dev, path_id, target_id, lun)) {
+        cons = (uint16_t)((cons + MAX(dev->pkt.hdr.entry_count, 1)) %
+                          dev->rqst_ring_size);
+    }
+
+    while ((cons != QL_RQST_PROD(dev)) && (scanned < dev->rqst_ring_size)) {
+        uint32_t address = dev->rqst_ring_base + cons * QENTRY_LEN;
+        ql_sxp_req_t pkt;
+        uint16_t entries = 1;
+
+        if (ql_sxp_fetch_request(&pkt, address)) {
+            entries = (uint16_t)MIN(MAX(pkt.hdr.entry_count, 1),
+                                    dev->rqst_ring_size - scanned);
+            if (((pkt.hdr.entry_type == RQSTYPE_REQUEST) ||
+                 (pkt.hdr.entry_type == RQSTYPE_REQUEST_A64)) &&
+                (((pkt.bus_target & 0x80) >> 7) == path_id) &&
+                ((pkt.bus_target & 0x7F) == target_id) &&
+                (pkt.lun == lun)) {
+                count++;
+            }
+        }
+        cons = (uint16_t)((cons + entries) % dev->rqst_ring_size);
+        scanned += entries;
+    }
+
+    return count;
+}
+
+static uint16_t
+ql_handle_cmd_device_queue_control(ql_t *dev, uint16_t command)
+{
+    ql_fw_device_queue *queue;
+    uint8_t path_id, target_id, lun;
+
+    if (!ql_get_device_queue(dev, dev->reg_mbox_in[1], &path_id,
+                             &target_id, &lun, &queue)) {
+        return QL_MBOX_STATUS_CMD_PARAM_ERROR;
+    }
+
+    switch (command) {
+        case QL_CMD_STOP_QUEUE:
+            queue->flags &= ~QL_QUEUE_SINGLE_STEP;
+            queue->flags |= QL_QUEUE_STOPPED;
+            break;
+        case QL_CMD_START_QUEUE:
+            queue->flags &= ~(QL_QUEUE_STOPPED | QL_QUEUE_SINGLE_STEP);
+            break;
+        case QL_CMD_SINGLE_STEP_QUEUE:
+            queue->flags |= QL_QUEUE_SINGLE_STEP;
+            break;
+        case QL_CMD_ABORT_QUEUE:
+            (void) ql_sxp_abort_commands(dev, path_id, target_id, lun, 0, false);
+            break;
+        default:
+            assert(false);
+            break;
+    }
+
+    ql_log("QL: [%u:%u:%u] Queue command 0x%X, flags 0x%X\n",
+           path_id, target_id, lun, command, queue->flags);
+
+    dev->mbox_out_mask |= QL_BIT(1) | QL_BIT(2);
+    dev->mbox_data[1] = dev->reg_mbox_in[1];
+    dev->mbox_data[2] = queue->flags;
+    return QL_MBOX_STATUS_COMPLETE;
+}
+
+static uint16_t
+ql_handle_cmd_get_device_queue_status(ql_t *dev)
+{
+    ql_fw_device_queue *queue;
+    uint8_t path_id, target_id, lun;
+
+    if (!ql_get_device_queue(dev, dev->reg_mbox_in[1], &path_id,
+                             &target_id, &lun, &queue)) {
+        return QL_MBOX_STATUS_CMD_PARAM_ERROR;
+    }
+
+    dev->mbox_out_mask |= QL_BIT(1) | QL_BIT(2) | QL_BIT(3) | QL_BIT(6);
+    dev->mbox_data[1] = queue->flags;
+    dev->mbox_data[2] = ql_sxp_queued_commands(dev, path_id, target_id, lun);
+    dev->mbox_data[3] = ql_sxp_command_active(dev, path_id, target_id, lun);
+    dev->mbox_data[6] = 0;
+
+    ql_log("QL: [%u:%u:%u] Queue status flags 0x%X queued %u active %u\n",
+           path_id, target_id, lun, dev->mbox_data[1],
+           dev->mbox_data[2], dev->mbox_data[3]);
+    return QL_MBOX_STATUS_COMPLETE;
 }
 
 static void
@@ -2004,12 +2178,42 @@ ql_handle_cmd_get_target_parameters(ql_t *dev)
 static uint16_t
 ql_handle_cmd_set_device_queue(ql_t *dev)
 {
-    ql_log("QL: Queue params 0x%X %u %u\n", dev->reg_mbox_in[1], dev->reg_mbox_in[2], dev->reg_mbox_in[3]);
+    ql_fw_device_queue *queue;
+    uint8_t path_id, target_id, lun;
+
+    if (!ql_get_device_queue(dev, dev->reg_mbox_in[1], &path_id,
+                             &target_id, &lun, &queue)) {
+        return QL_MBOX_STATUS_CMD_PARAM_ERROR;
+    }
+
+    queue->depth = dev->reg_mbox_in[2];
+    queue->throttle = dev->reg_mbox_in[3];
+
+    ql_log("QL: [%u:%u:%u] Queue depth %u, execution throttle %u\n",
+           path_id, target_id, lun, queue->depth, queue->throttle);
 
     dev->mbox_out_mask |= QL_BIT(1) | QL_BIT(2) | QL_BIT(3);
     dev->mbox_data[1] = dev->reg_mbox_in[1];
-    dev->mbox_data[2] = dev->reg_mbox_in[2];
-    dev->mbox_data[3] = 0x0064;
+    dev->mbox_data[2] = queue->depth;
+    dev->mbox_data[3] = queue->throttle;
+    return QL_MBOX_STATUS_COMPLETE;
+}
+
+static uint16_t
+ql_handle_cmd_get_device_queue_params(ql_t *dev)
+{
+    ql_fw_device_queue *queue;
+    uint8_t path_id, target_id, lun;
+
+    if (!ql_get_device_queue(dev, dev->reg_mbox_in[1], &path_id,
+                             &target_id, &lun, &queue)) {
+        return QL_MBOX_STATUS_CMD_PARAM_ERROR;
+    }
+
+    dev->mbox_out_mask |= QL_BIT(1) | QL_BIT(2) | QL_BIT(3);
+    dev->mbox_data[1] = dev->reg_mbox_in[1];
+    dev->mbox_data[2] = queue->depth;
+    dev->mbox_data[3] = queue->throttle;
     return QL_MBOX_STATUS_COMPLETE;
 }
 
@@ -2175,8 +2379,14 @@ ql_process_mailbox(ql_t *dev)
         case QL_CMD_BUS_RESET:
             status = ql_handle_cmd_bus_reset(dev);
             break;
+        case QL_CMD_STOP_QUEUE:
         case QL_CMD_START_QUEUE:
-            status = ql_handle_cmd_nop(dev);
+        case QL_CMD_SINGLE_STEP_QUEUE:
+        case QL_CMD_ABORT_QUEUE:
+            status = ql_handle_cmd_device_queue_control(dev, dev->reg_mbox_in[0]);
+            break;
+        case QL_CMD_GET_DEVICE_QUEUE_STATUS:
+            status = ql_handle_cmd_get_device_queue_status(dev);
             break;
         case QL_CMD_GET_RETRY_COUNT:
             status = ql_handle_cmd_get_retry_count(dev);
@@ -2186,6 +2396,9 @@ ql_process_mailbox(ql_t *dev)
             break;
         case QL_CMD_GET_TARGET_PARAMETERS:
             status = ql_handle_cmd_get_target_parameters(dev);
+            break;
+        case QL_CMD_GET_DEVICE_QUEUE_PARAMS:
+            status = ql_handle_cmd_get_device_queue_params(dev);
             break;
         case QL_CMD_GET_FIRMWARE_STATUS:
             status = ql_handle_cmd_get_firmware_status(dev);
@@ -2676,6 +2889,13 @@ ql_sxp_state_machine(ql_t *dev)
 
                         fifo8_drop(&dev->abort_iocbs_fifo, sizeof(rqst_idx));
 
+                        dev->pkt_address = dev->rqst_ring_base + QL_RQST_CONS(dev) * QENTRY_LEN;
+                        if (!ql_sxp_fetch_request(pkt, dev->pkt_address)) {
+                            pkt->hdr.entry_count = 1;
+                            dev->sxp_state = SXP_STATE_BAD_PACKET;
+                            break;
+                        }
+
                         ql_sxp_begin_response_entry(pkt, resp);
                         resp->scsi_status = SCSI_STATUS_OK;
                         resp->comp_status = RQCS_ABORTED;
@@ -2697,6 +2917,26 @@ ql_sxp_state_machine(ql_t *dev)
 
                 dev->sxp_state = SXP_STATE_BAD_PACKET;
                 break;
+            }
+
+            if ((pkt->hdr.entry_type == RQSTYPE_REQUEST) ||
+                (pkt->hdr.entry_type == RQSTYPE_REQUEST_A64)) {
+                ql_fw_device_queue *queue;
+                uint8_t path_id, target_id, lun;
+                uint16_t address = ((uint16_t)pkt->bus_target << 8) |
+                                   pkt->lun;
+
+                if (ql_get_device_queue(dev, address, &path_id, &target_id,
+                                        &lun, &queue)) {
+                    if ((queue->flags & QL_QUEUE_STOPPED) &&
+                        !(queue->flags & QL_QUEUE_SINGLE_STEP)) {
+                        return false;
+                    }
+                    if (queue->flags & QL_QUEUE_SINGLE_STEP) {
+                        queue->flags &= ~QL_QUEUE_SINGLE_STEP;
+                        queue->flags |= QL_QUEUE_STOPPED;
+                    }
+                }
             }
 
             dev->sxp_state = SXP_STATE_SELECT_DEVICE;
@@ -2736,6 +2976,13 @@ ql_sxp_state_machine(ql_t *dev)
 
             if (dev->curr_target_id >= MIN(QL_MAX_TID, SCSI_ID_MAX)) {
                 dev->sxp_state = SXP_STATE_SELECTION_TIMEOUT;
+                break;
+            }
+
+            if ((pkt->hdr.entry_type == RQSTYPE_REQUEST ||
+                 pkt->hdr.entry_type == RQSTYPE_REQUEST_A64) &&
+                pkt->cdb_length > sizeof(pkt->cdb)) {
+                dev->sxp_state = SXP_STATE_BAD_PACKET;
                 break;
             }
 
@@ -2781,6 +3028,13 @@ ql_sxp_state_machine(ql_t *dev)
                 dev->timer_period = ql_sxp_handle_state_send_cdb_sgl(dev, sd);
             }
             scsi_device_identify(sd, SCSI_LUN_USE_CDB);
+
+            if ((pkt->lun < QL_MAX_LUNS) &&
+                (resp->scsi_status == SCSI_STATUS_CHECK_CONDITION) &&
+                (dev->fw_tid_params[dev->curr_path_id][dev->curr_target_id].flags & DPARM_QFRZ)) {
+                dev->fw_dev_queues[dev->curr_path_id][dev->curr_target_id][pkt->lun].flags |=
+                    QL_QUEUE_STOPPED;
+            }
 
             dev->sxp_state = SXP_STATE_COMPLETE_COMMAND;
             break;
@@ -2873,9 +3127,13 @@ ql_sxp_state_machine(ql_t *dev)
             break;
         }
         case SXP_STATE_ACQUIRE_MBOX_SEMAPHORE: {
-            /* Wait for the mailbox semaphore to be released */
-            if (dev->reg_semaphore & QL_SEMAPHORE_LOCK) {
-                ql_log("Mailbox semaphore is not released\n");
+            /*
+             * Do not replace a mailbox result until the host has released
+             * its registers and acknowledged the interrupt for that result.
+             */
+            if ((dev->reg_semaphore & QL_SEMAPHORE_LOCK) ||
+                (dev->reg_intr_status & QL_RISC_INTR_REQ)) {
+                ql_log("Mailbox result is not released\n");
                 return false;
             }
 
@@ -3025,6 +3283,10 @@ ql_write_host_command(ql_t *dev, uint16_t val)
             dev->reg_host_cmd_flags &= ~QL_HC_FLAG_HOST_INTR;
             dev->reg_intr_status = 0;
             ql_update_irq(dev);
+
+            if (dev->sxp_state == SXP_STATE_ACQUIRE_MBOX_SEMAPHORE) {
+                ql_sxp_run_state_machine(dev);
+            }
             break;
         case QL_HC_DISABLE_BIOS:
             dev->reg_host_cmd_flags = 0;

--- a/src/scsi/scsi_ql1xxx.c
+++ b/src/scsi/scsi_ql1xxx.c
@@ -92,6 +92,7 @@
 #define QL_IOCB_FW_BASE     0x0700
 
 /* Maximum SCSI devices supported by the chip */
+#define QL_MAX_PATHS 2
 #define QL_MAX_TID   16
 #define QL_MAX_LUNS  32
 
@@ -517,15 +518,41 @@
 
 #define QL_BIT(b)   (1 << (b))
 
-#define ql_dma_write(address, buffer, size) dma_bm_write(address, (uint8_t *)(buffer), size, 4);
-#define ql_dma_write8(address, buffer)      dma_bm_write(address, (uint8_t *)(buffer), 1, 4);
-#define ql_dma_write16(address, buffer)     dma_bm_write(address, (uint8_t *)(buffer), 2, 4);
-#define ql_dma_write32(address, buffer)     dma_bm_write(address, (uint8_t *)(buffer), 4, 4);
+static bool
+ql_dma_range_supported(uint64_t address, uint32_t size)
+{
+    return (address <= UINT32_MAX) &&
+           ((size == 0) || ((uint64_t)size - 1 <= UINT32_MAX - address));
+}
 
-#define ql_dma_read(address, buffer, size)  dma_bm_read(address, (uint8_t *)(buffer), size, 4);
-#define ql_dma_read8(address, buffer)       dma_bm_read(address, (uint8_t *)(buffer), 1, 4);
-#define ql_dma_read16(address, buffer)      dma_bm_read(address, (uint8_t *)(buffer), 2, 4);
-#define ql_dma_read32(address, buffer)      dma_bm_read(address, (uint8_t *)(buffer), 4, 4);
+static void
+ql_dma_read(uint64_t address, void *buffer, uint32_t size)
+{
+    if (!ql_dma_range_supported(address, size)) {
+        memset(buffer, 0xff, size);
+        return;
+    }
+
+    dma_bm_read((uint32_t)address, (uint8_t *)buffer, size, 4);
+}
+
+static void
+ql_dma_write(uint64_t address, const void *buffer, uint32_t size)
+{
+    if (!ql_dma_range_supported(address, size)) {
+        return;
+    }
+
+    dma_bm_write((uint32_t)address, (const uint8_t *)buffer, size, 4);
+}
+
+#define ql_dma_write8(address, buffer)  ql_dma_write(address, (uint8_t *)(buffer), 1);
+#define ql_dma_write16(address, buffer) ql_dma_write(address, (uint8_t *)(buffer), 2);
+#define ql_dma_write32(address, buffer) ql_dma_write(address, (uint8_t *)(buffer), 4);
+
+#define ql_dma_read8(address, buffer)   ql_dma_read(address, (uint8_t *)(buffer), 1);
+#define ql_dma_read16(address, buffer)  ql_dma_read(address, (uint8_t *)(buffer), 2);
+#define ql_dma_read32(address, buffer)  ql_dma_read(address, (uint8_t *)(buffer), 4);
 
 typedef enum FlashMode {
     M_READ_ARRAY,
@@ -607,7 +634,7 @@ typedef struct isp_hdr_t {
 } isp_hdr_t;
 
 typedef struct isp_data_seg_t {
-    uint32_t address;
+    uint64_t address;
     uint32_t length;
 } isp_data_seg_t;
 
@@ -697,15 +724,15 @@ typedef struct ql_t {
     /* SXP flags */
     uint32_t sxp_flags;
     /* Physical address of the request ring */
-    uint32_t rqst_ring_base;
+    uint64_t rqst_ring_base;
     /* Request ring size */
     uint16_t rqst_ring_size;
     /* Response ring size */
     uint16_t resp_ring_size;
     /* Physical address of the response ring */
-    uint32_t resp_ring_base;
+    uint64_t resp_ring_base;
     /* Physical address of the current request IOCB */
-    uint32_t pkt_address;
+    uint64_t pkt_address;
     /* Current request IOCB */
     ql_sxp_req_t pkt;
     /* Current response IOCB */
@@ -718,8 +745,8 @@ typedef struct ql_t {
     uint8_t curr_target_id;
     /* Number of SCSI buses on this HBA */
     uint8_t max_bus_count;
-    /* SCSI bus emulation internal index */
-    uint8_t scsi_bus;
+    /* SCSI bus emulation internal indices */
+    uint8_t scsi_bus[QL_MAX_PATHS];
     /* ISP chip type */
     uint8_t isp_type;
     /* ISP chip revision */
@@ -739,9 +766,9 @@ typedef struct ql_t {
     /* Command timer */
     pc_timer_t cmd_timer;
     /* Firmware device parameters */
-    ql_fw_target_params fw_tid_params[2][QL_MAX_TID];
+    ql_fw_target_params fw_tid_params[QL_MAX_PATHS][QL_MAX_TID];
     /* Per-LUN command queue state and limits */
-    ql_fw_device_queue fw_dev_queues[2][QL_MAX_TID][QL_MAX_LUNS];
+    ql_fw_device_queue fw_dev_queues[QL_MAX_PATHS][QL_MAX_TID][QL_MAX_LUNS];
     /* Firmware retry count and delay settings */
     uint16_t fw_retry_params[4];
     /* Size of the SCSI payload data */
@@ -773,7 +800,7 @@ typedef struct ql_t {
 extern double cpuclock;
 
 static bool
-ql_sxp_fetch_request(ql_sxp_req_t* pkt, uint32_t address);
+ql_sxp_fetch_request(ql_sxp_req_t* pkt, uint64_t address);
 
 #ifdef ENABLE_QL_LOG
 int ql_do_log = ENABLE_QL_LOG;
@@ -1375,7 +1402,7 @@ ql_reset_asic(ql_t *dev)
     dev->sxp_state = SXP_STATE_IDLE;
 
     memset(dev->fw_dev_queues, 0, sizeof(dev->fw_dev_queues));
-    for (uint32_t path_id = 0; path_id < 2; path_id++) {
+    for (uint32_t path_id = 0; path_id < QL_MAX_PATHS; path_id++) {
         for (uint32_t target_id = 0; target_id < QL_MAX_TID; target_id++) {
             for (uint32_t lun = 0; lun < QL_MAX_LUNS; lun++) {
                 dev->fw_dev_queues[path_id][target_id][lun].depth = QL_QUEUE_DEFAULT_DEPTH;
@@ -1401,7 +1428,7 @@ ql_sxp_abort_commands(ql_t *dev, uint8_t path_id, uint8_t target_id, uint8_t lun
 
     /* Iterate over the request IOCBs looking for a match */
     for (cons = QL_RQST_CONS(dev); cons != QL_RQST_PROD(dev); cons = (cons + 1) % dev->rqst_ring_size) {
-        uint32_t pkt_address = dev->rqst_ring_base + cons * QENTRY_LEN;
+        uint64_t pkt_address = dev->rqst_ring_base + cons * QENTRY_LEN;
         ql_sxp_req_t pkt;
         uint8_t curr_path_id, curr_target_id;
 
@@ -1499,7 +1526,7 @@ ql_sxp_queued_commands(ql_t *dev, uint8_t path_id, uint8_t target_id,
     }
 
     while ((cons != QL_RQST_PROD(dev)) && (scanned < dev->rqst_ring_size)) {
-        uint32_t address = dev->rqst_ring_base + cons * QENTRY_LEN;
+        uint64_t address = dev->rqst_ring_base + cons * QENTRY_LEN;
         ql_sxp_req_t pkt;
         uint16_t entries = 1;
 
@@ -1599,11 +1626,17 @@ ql_sxp_initialize_queues(ql_t *dev)
     }
 }
 
-static uint32_t
-ql_mbox_get_phys_address(ql_t *dev, UNUSED(bool is_64bit_addr))
+static uint64_t
+ql_mbox_get_phys_address(ql_t *dev, bool is_64bit_addr)
 {
-    /* The high part of the address is ignored for 86Box */
-    return ((uint32_t)dev->reg_mbox_in[2] << 16) | dev->reg_mbox_in[3];
+    uint64_t address = ((uint32_t)dev->reg_mbox_in[2] << 16) |
+                       dev->reg_mbox_in[3];
+
+    if (is_64bit_addr) {
+        address |= (uint64_t)dev->reg_mbox_in[6] << 48;
+        address |= (uint64_t)dev->reg_mbox_in[7] << 32;
+    }
+    return address;
 }
 
 static uint16_t
@@ -1682,7 +1715,7 @@ ql_handle_cmd_load_ram_block(ql_t *dev, bool is_64bit_addr)
     uint32_t offset = dev->reg_mbox_in[1];
     uint32_t block_size_words = dev->reg_mbox_in[4];
     uint8_t *dest_address = (uint8_t *)&dev->cpu_mem[offset];
-    uint32_t src_address = ql_mbox_get_phys_address(dev, is_64bit_addr);
+    uint64_t src_address = ql_mbox_get_phys_address(dev, is_64bit_addr);
 
     if ((offset + block_size_words) > ARRAY_SIZE(dev->cpu_mem)) {
         return QL_MBOX_STATUS_CMD_PARAM_ERROR;
@@ -1698,7 +1731,7 @@ ql_handle_cmd_dump_ram_block(ql_t *dev, bool is_64bit_addr)
     uint32_t offset = dev->reg_mbox_in[1];
     uint32_t block_size_words = dev->reg_mbox_in[4];
     uint8_t *src_address = (uint8_t *)&dev->cpu_mem[offset];
-    uint32_t dest_address = ql_mbox_get_phys_address(dev, is_64bit_addr);
+    uint64_t dest_address = ql_mbox_get_phys_address(dev, is_64bit_addr);
 
     if ((offset + block_size_words) > ARRAY_SIZE(dev->cpu_mem)) {
         return QL_MBOX_STATUS_CMD_PARAM_ERROR;
@@ -1825,10 +1858,11 @@ ql_handle_cmd_about_firmware(ql_t *dev)
 static uint16_t
 ql_handle_cmd_init_request_queue(ql_t *dev, bool is_64bit_addr)
 {
-    uint32_t address = ql_mbox_get_phys_address(dev, is_64bit_addr);
+    uint64_t address = ql_mbox_get_phys_address(dev, is_64bit_addr);
     uint16_t queue_length = dev->reg_mbox_in[1];
 
-    ql_log("QL: REQ queue address 0x%X, length %u\n", address, queue_length);
+    ql_log("QL: REQ queue address 0x%llX, length %u\n",
+           (unsigned long long)address, queue_length);
 
     if ((address == 0) || (queue_length == 0)) {
         return QL_MBOX_STATUS_CMD_PARAM_ERROR;
@@ -1846,10 +1880,11 @@ ql_handle_cmd_init_request_queue(ql_t *dev, bool is_64bit_addr)
 static uint16_t
 ql_handle_cmd_init_response_queue(ql_t *dev, bool is_64bit_addr)
 {
-    uint32_t address = ql_mbox_get_phys_address(dev, is_64bit_addr);
+    uint64_t address = ql_mbox_get_phys_address(dev, is_64bit_addr);
     uint16_t queue_length = dev->reg_mbox_in[1];
 
-    ql_log("QL: RSP queue address 0x%X, length %u\n", address, queue_length);
+    ql_log("QL: RSP queue address 0x%llX, length %u\n",
+           (unsigned long long)address, queue_length);
 
     if ((address == 0) || (queue_length == 0)) {
         return QL_MBOX_STATUS_CMD_PARAM_ERROR;
@@ -1971,11 +2006,8 @@ ql_handle_cmd_bus_reset(ql_t *dev)
         return QL_MBOX_STATUS_CMD_PARAM_ERROR;
     }
 
-    /* 86Box supports one SCSI bus per controller for now */
-    if (path_id == 0) {
-        for (uint32_t i = 0; i < MIN(QL_MAX_TID, SCSI_ID_MAX); i++) {
-            scsi_device_reset(&scsi_devices[dev->scsi_bus][i]);
-        }
+    for (uint32_t i = 0; i < MIN(QL_MAX_TID, SCSI_ID_MAX); i++) {
+        scsi_device_reset(&scsi_devices[dev->scsi_bus[path_id]][i]);
     }
 
     /* Abort all active commands on the bus (PATH) */
@@ -2475,54 +2507,62 @@ ql_process_mailbox(ql_t *dev)
 
 /* RQSTYPE_REQUEST */
 static void
-ql_pkt_get_sgl_req(uint32_t address, uint32_t idx, isp_data_seg_t *data_seg)
+ql_pkt_get_sgl_req(uint64_t address, uint32_t idx, isp_data_seg_t *data_seg)
 {
-    uint32_t offset = address + 32 + idx * 8;
+    uint64_t offset = address + 32 + idx * 8;
+    uint32_t low;
 
-    ql_dma_read32(offset + 0, &data_seg->address);
+    ql_dma_read32(offset + 0, &low);
+    data_seg->address = low;
     ql_dma_read32(offset + 4, &data_seg->length);
 }
 
 /* RQSTYPE_REQUEST_A64 */
 static void
-ql_pkt_get_sgl_req64(uint32_t address, uint32_t idx, isp_data_seg_t *data_seg)
+ql_pkt_get_sgl_req64(uint64_t address, uint32_t idx, isp_data_seg_t *data_seg)
 {
-    uint32_t offset = address + 36 + idx * 12;
+    uint64_t offset = address + 40 + idx * 12;
+    uint32_t high, low;
 
-    /* The high part of the address is ignored for 86Box */
-    ql_dma_read32(offset + 0, &data_seg->address);
+    ql_dma_read32(offset + 0, &low);
+    ql_dma_read32(offset + 4, &high);
+    data_seg->address = (uint64_t)high << 32 | low;
     ql_dma_read32(offset + 8, &data_seg->length);
 }
 
 /* RQSTYPE_DATASEG */
 static void
-ql_pkt_get_sgl_cont(uint32_t address, uint32_t idx, isp_data_seg_t *data_seg)
+ql_pkt_get_sgl_cont(uint64_t address, uint32_t idx, isp_data_seg_t *data_seg)
 {
-    uint32_t offset = address + 8 + idx * 8;
+    uint64_t offset = address + 8 + idx * 8;
+    uint32_t low;
 
-    ql_dma_read32(offset + 0, &data_seg->address);
+    ql_dma_read32(offset + 0, &low);
+    data_seg->address = low;
     ql_dma_read32(offset + 4, &data_seg->length);
 }
 
 /* RQSTYPE_A64_CONT */
 static void
-ql_pkt_get_sgl_cont64(uint32_t address, uint32_t idx, isp_data_seg_t *data_seg)
+ql_pkt_get_sgl_cont64(uint64_t address, uint32_t idx, isp_data_seg_t *data_seg)
 {
-    uint32_t offset = address + 4 + idx * 12;
+    uint64_t offset = address + 4 + idx * 12;
+    uint32_t high, low;
 
-    /* The high part of the address is ignored for 86Box */
-    ql_dma_read32(offset + 0, &data_seg->address);
+    ql_dma_read32(offset + 0, &low);
+    ql_dma_read32(offset + 4, &high);
+    data_seg->address = (uint64_t)high << 32 | low;
     ql_dma_read32(offset + 8, &data_seg->length);
 }
 
 static void
-ql_pkt_get_entry_type(uint32_t address, uint8_t *entry_type)
+ql_pkt_get_entry_type(uint64_t address, uint8_t *entry_type)
 {
     ql_dma_read8(address + 0, entry_type);
 }
 
 static void
-ql_pkt_put_header(uint32_t address, isp_hdr_t *hdr)
+ql_pkt_put_header(uint64_t address, isp_hdr_t *hdr)
 {
     ql_dma_write8(address + 0, &hdr->entry_type);
     ql_dma_write8(address + 1, &hdr->entry_count);
@@ -2531,7 +2571,7 @@ ql_pkt_put_header(uint32_t address, isp_hdr_t *hdr)
 }
 
 static void
-ql_pkt_put_request_status(uint32_t address, isp_req_status_t *resp)
+ql_pkt_put_request_status(uint64_t address, isp_req_status_t *resp)
 {
     ql_pkt_put_header(address, &resp->hdr);
 
@@ -2563,7 +2603,7 @@ ql_pkt_put_request_status(uint32_t address, isp_req_status_t *resp)
 }
 
 static bool
-ql_sxp_fetch_request(ql_sxp_req_t* pkt, uint32_t address)
+ql_sxp_fetch_request(ql_sxp_req_t* pkt, uint64_t address)
 {
     /* Fetch the header */
     ql_dma_read8(address + 0, &pkt->hdr.entry_type);
@@ -2704,7 +2744,7 @@ ql_sxp_handle_state_send_cdb_sgl(ql_t *dev, scsi_device_t *sd)
         uint32_t dev_buffer_length = sd->buffer_length;
         uint8_t *dev_buffer = sd->sc->temp_buffer;
         uint8_t entry_type = pkt->hdr.entry_type;
-        uint32_t pkt_address = dev->pkt_address;
+        uint64_t pkt_address = dev->pkt_address;
         uint16_t pkt_entry_idx = QL_RQST_CONS(dev);
         uint32_t host_buffer_size = 0;
         uint32_t bytes_moved = 0;
@@ -2771,13 +2811,16 @@ ql_sxp_handle_state_send_cdb_sgl(ql_t *dev, scsi_device_t *sd)
             }
             host_buffer_size += data_seg.length;
             block_size = MIN(data_seg.length, dev_buffer_length - bytes_moved);
-            bytes_xfered += sizeof(data_seg);
+            bytes_xfered += entry_type == RQSTYPE_REQUEST ||
+                            entry_type == RQSTYPE_DATASEG ? 8 : 12;
 
             if (sd->phase == SCSI_PHASE_DATA_IN) {
-                ql_log("QL: DMA to 0x%lx %lu bytes\n", data_seg.address, block_size);
+                ql_log("QL: DMA to 0x%llx %u bytes\n",
+                       (unsigned long long)data_seg.address, block_size);
                 ql_dma_write(data_seg.address, &dev_buffer[bytes_moved], block_size);
             } else if (sd->phase == SCSI_PHASE_DATA_OUT) {
-                ql_log("QL: DMA from 0x%lx %lu bytes\n", data_seg.address, block_size);
+                ql_log("QL: DMA from 0x%llx %u bytes\n",
+                       (unsigned long long)data_seg.address, block_size);
                 ql_dma_read(data_seg.address, &dev_buffer[bytes_moved], block_size);
             }
             bytes_moved += block_size;
@@ -2968,12 +3011,6 @@ ql_sxp_state_machine(ql_t *dev)
                 break;
             }
 
-            /* 86Box supports one SCSI bus per controller for now */
-            if (dev->curr_path_id != 0) {
-                dev->sxp_state = SXP_STATE_SELECTION_TIMEOUT;
-                break;
-            }
-
             if (dev->curr_target_id >= MIN(QL_MAX_TID, SCSI_ID_MAX)) {
                 dev->sxp_state = SXP_STATE_SELECTION_TIMEOUT;
                 break;
@@ -2986,7 +3023,8 @@ ql_sxp_state_machine(ql_t *dev)
                 break;
             }
 
-            if (!scsi_device_present(&scsi_devices[dev->scsi_bus][dev->curr_target_id])) {
+            if (!scsi_device_present(
+                    &scsi_devices[dev->scsi_bus[dev->curr_path_id]][dev->curr_target_id])) {
                 dev->sxp_state = SXP_STATE_SELECTION_TIMEOUT;
                 break;
             }
@@ -2996,7 +3034,8 @@ ql_sxp_state_machine(ql_t *dev)
             break;
         }
         case SXP_STATE_SEND_CDB: {
-            scsi_device_t *sd = &scsi_devices[dev->scsi_bus][dev->curr_target_id];
+            scsi_device_t *sd =
+                &scsi_devices[dev->scsi_bus[dev->curr_path_id]][dev->curr_target_id];
             ql_sxp_req_t *pkt = &dev->pkt;
             isp_req_status_t *resp = &dev->pkt_resp;
 
@@ -4115,10 +4154,10 @@ static void ql_init_scsi(ql_t *dev) {
             break;
     }
 
-    /* 86Box supports one SCSI bus per controller for now */
-    dev->scsi_bus = scsi_get_bus();
-
-    scsi_bus_set_speed(dev->scsi_bus, dev->xfer_rate_bps);
+    for (uint32_t path_id = 0; path_id < dev->max_bus_count; path_id++) {
+        dev->scsi_bus[path_id] = scsi_get_bus();
+        scsi_bus_set_speed(dev->scsi_bus[path_id], dev->xfer_rate_bps);
+    }
 
     timer_add(&dev->cmd_timer, ql_sxp_timer_callback, dev, 0);
 }


### PR DESCRIPTION
Summary
=======
Add several device queue commands and fix mailbox result race to make Linux work. Also switch to 64-bit DMA and 2 channels to replicate real QL1XXX and allow it to work on other emulators.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
- https://github.com/torvalds/linux/blob/master/drivers/scsi/qla1280.c