### PR TITLE
Add Fujitsu ErgoPro x365/564/565 machine

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -1408,6 +1408,7 @@ extern int             machine_at_p3bf_init(const machine_t *);
 extern const device_t  optiplexgx1_device;
 #endif
 extern int             machine_at_optiplexgx1_init(const machine_t *);
+extern int             machine_at_ergox365_init(const machine_t *);
 #ifdef EMU_DEVICE_H
 extern const device_t  ga686_device;
 #endif

--- a/src/include/86box/network.h
+++ b/src/include/86box/network.h
@@ -253,6 +253,7 @@ extern const device_t rtl8139c_plus_device;
 extern const device_t i82557_device;
 extern const device_t i82558_device;
 extern const device_t i82557b_onboard_device;
+extern const device_t i82558b_onboard_device;
 extern const device_t nec_pk_ug_x006_device;
 extern const device_t i82559c_onboard_device;
 

--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -1879,10 +1879,13 @@ machine_at_ergox365_init(const machine_t *model)
     machine_at_common_init(model);
 
     pci_init(PCI_CONFIG_TYPE_1);
-    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
-    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
-    pci_register_slot(0x0E, PCI_CARD_NORMAL,      3, 4, 2, 1);
+    pci_register_slot(0x14, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x12, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x10, PCI_CARD_NORMAL,      3, 4, 1, 2);
     pci_register_slot(0x01, PCI_CARD_AGPBRIDGE,   1, 2, 3, 4);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x08, PCI_CARD_NETWORK,     3, 0, 0, 0);
 
     device_add(&i440bx_device);
     device_add(&piix4e_device);

--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -1865,6 +1865,37 @@ machine_at_optiplexgx1_init(const machine_t *model)
     return ret;
 }
 
+int
+machine_at_ergox365_init(const machine_t *model)
+{
+    int ret;
+
+    ret = bios_load_linear("roms/machines/ergox365/M63v115.rom",
+                           0x00080000, 524288, 0);
+
+    if (bios_only || !ret)
+        return ret;
+
+    machine_at_common_init(model);
+
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x07, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
+    pci_register_slot(0x0E, PCI_CARD_NORMAL,      3, 4, 2, 1);
+    pci_register_slot(0x01, PCI_CARD_AGPBRIDGE,   1, 2, 3, 4);
+
+    device_add(&i440bx_device);
+    device_add(&piix4e_device);
+    device_add_params(&fdc37c67x_device, (void *) (FDC37XXX5 | FDC37XXXX_370));
+    device_add(&intel_flash_bxt_device);
+    spd_register(SPD_TYPE_SDRAM, 0x7, 256);
+
+    if ((net_cards_conf[0].device_num == NET_INTERNAL) && machine_get_net_device(machine))
+        device_add(machine_get_net_device(machine));
+
+    return ret;
+}
+
 static const device_config_t ga686_config[] = {
     // clang-format off
     {

--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -1887,7 +1887,7 @@ machine_at_ergox365_init(const machine_t *model)
     device_add(&i440bx_device);
     device_add(&piix4e_device);
     device_add_params(&fdc37c67x_device, (void *) (FDC37XXX5 | FDC37XXXX_370));
-    device_add(&intel_flash_bxt_device);
+    device_add(&sst_flash_39sf040_device);
     spd_register(SPD_TYPE_SDRAM, 0x7, 256);
 
     if ((net_cards_conf[0].device_num == NET_INTERNAL) && machine_get_net_device(machine))

--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -1896,6 +1896,9 @@ machine_at_ergox365_init(const machine_t *model)
     if ((net_cards_conf[0].device_num == NET_INTERNAL) && machine_get_net_device(machine))
         device_add(machine_get_net_device(machine));
 
+    if (sound_card_current[0] == SOUND_INTERNAL)
+        device_add(machine_get_snd_device(machine));
+
     return ret;
 }
 

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -23297,6 +23297,55 @@ const machine_t machines[] = {
         .net_device               = NULL, /* not yet emulated */
         .aliases                  = { "Dell System Banff", "" }
     },
+    /* Has a SM(S)C FDC37C67x Super I/O chip with on-chip KBC with Phoenix or
+       AMIKey-2 KBC firmware. */
+    {
+        .name              = "[i440BX] Fujitsu ErgoPro x365",
+        .internal_name     = "ergox365",
+        .type              = MACHINE_TYPE_SLOT1,
+        .chipset           = MACHINE_CHIPSET_INTEL_440LX,
+        .init              = machine_at_ergox365_init,
+        .p1_handler        = machine_generic_p1_handler,
+        .gpio_handler      = machine_ap440fx_vs440fx_gpio_handler,
+        .available_flag    = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu               = {
+            .package     = CPU_PKG_SLOT1,
+            .block       = CPU_BLOCK_NONE,
+            .min_bus     = 66666667,
+            .max_bus     = 100000000,
+            .min_voltage = 1800,
+            .max_voltage = 3500,
+            .min_multi   = 1.5,
+            .max_multi   = 8.0
+        },
+        .bus_flags = MACHINE_PS2_AGP | MACHINE_BUS_USB, /* Has internal video: ATi 3D Rage Pro Turbo AGP, network: Intel 82558-based, and sound: Crystal CX4235 */
+        .flags     = MACHINE_AGP_INTERNAL | MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_NIC | MACHINE_USB,
+        .ram       = {
+            .min  = 8192,
+            .max  = 786432,
+            .step = 8192
+        },
+        .nvrmask                  = 255,
+        .jumpered_ecp_dma         = 0,
+        .default_jumpered_ecp_dma = -1,
+        .kbc_device               = NULL,
+        .kbc_params               = 0x00000000,
+        .nvr_device               = NULL,
+        .nvr_params               = 0x00000000,
+        .sio_device               = NULL,
+        .sio_params               = 0x00000000,
+        .kbc_p1                   = 0x0000044f0,
+        .gpio                     = 0xffffffff,
+        .gpio_acpi                = 0xffffffff,
+        .device                   = NULL,
+        .kbd_device               = NULL,
+        .fdc_device               = NULL,
+        .vid_device               = NULL,
+        .snd_device               = NULL,
+        .net_device               = &i82557b_onboard_device,
+        .aliases                  = { "Fujitsu ErgoPro x565", "" }
+    },
     /* Has a Winbond W83977TF Super I/O chip with on-chip KBC with AMIKey-2 KBC
        firmware. */
     {

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -23320,7 +23320,7 @@ const machine_t machines[] = {
             .max_multi   = 8.0
         },
         .bus_flags = MACHINE_PS2_AGP | MACHINE_BUS_USB, /* Has internal video: ATi 3D Rage Pro Turbo AGP, network: Intel 82558-based, and sound: Crystal CX4235 */
-        .flags     = MACHINE_AGP_INTERNAL | MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_NIC | MACHINE_USB,
+        .flags     = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_NIC | MACHINE_USB,
         .ram       = {
             .min  = 8192,
             .max  = 786432,

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -23319,7 +23319,7 @@ const machine_t machines[] = {
             .min_multi   = 1.5,
             .max_multi   = 8.0
         },
-        .bus_flags = MACHINE_PS2_AGP | MACHINE_BUS_USB, /* Has internal video: ATi 3D Rage Pro Turbo AGP, network: Intel 82558-based, and sound: Crystal CX4235 */
+        .bus_flags = MACHINE_PS2_AGP | MACHINE_BUS_USB, /* Has (optional) internal video: ATi 3D Rage Pro Turbo AGP, network: Intel 82558-based, and sound: Crystal CS4235B */
         .flags     = MACHINE_IDE_DUAL | MACHINE_SOUND | MACHINE_APM | MACHINE_ACPI | MACHINE_NIC | MACHINE_USB,
         .ram       = {
             .min  = 8192,

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -23343,7 +23343,7 @@ const machine_t machines[] = {
         .fdc_device               = NULL,
         .vid_device               = NULL,
         .snd_device               = NULL,
-        .net_device               = &i82557b_onboard_device,
+        .net_device               = &i82558b_onboard_device,
         .aliases                  = { "Fujitsu ErgoPro x565", "" }
     },
     /* Has a Winbond W83977TF Super I/O chip with on-chip KBC with AMIKey-2 KBC

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -23320,7 +23320,7 @@ const machine_t machines[] = {
             .max_multi   = 8.0
         },
         .bus_flags = MACHINE_PS2_AGP | MACHINE_BUS_USB, /* Has internal video: ATi 3D Rage Pro Turbo AGP, network: Intel 82558-based, and sound: Crystal CX4235 */
-        .flags     = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_NIC | MACHINE_USB,
+        .flags     = MACHINE_IDE_DUAL | MACHINE_SOUND | MACHINE_APM | MACHINE_ACPI | MACHINE_NIC | MACHINE_USB,
         .ram       = {
             .min  = 8192,
             .max  = 786432,
@@ -23342,9 +23342,9 @@ const machine_t machines[] = {
         .kbd_device               = NULL,
         .fdc_device               = NULL,
         .vid_device               = NULL,
-        .snd_device               = NULL,
+        .snd_device               = &cs4235_onboard_device,
         .net_device               = &i82558b_onboard_device,
-        .aliases                  = { "Fujitsu ErgoPro x565", "" }
+        .aliases                  = { "Fujitsu ErgoPro x564", "Fujitsu ErgoPro x565", "" }
     },
     /* Has a Winbond W83977TF Super I/O chip with on-chip KBC with AMIKey-2 KBC
        firmware. */

--- a/src/network/net_i8255x.c
+++ b/src/network/net_i8255x.c
@@ -2437,10 +2437,24 @@ static const device_config_t i8255x_onboard_config[] = {
 };
 
 const device_t i82557b_onboard_device = {
-    .name          = "Intel SB82558B (On-Board)",
+    .name          = "Intel SB82557B (On-Board)",
     .internal_name = "i82557b_onboard",
     .flags         = DEVICE_PCI,
     .local         = 0x0000 | 0x0100,
+    .init          = nic_init,
+    .close         = nic_close,
+    .reset         = eepro100_reset,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = i8255x_onboard_config
+};
+
+const device_t i82558b_onboard_device = {
+    .name          = "Intel SB82558B (On-Board)",
+    .internal_name = "i82558b_onboard",
+    .flags         = DEVICE_PCI,
+    .local         = 0x0002 | 0x0100,
     .init          = nic_init,
     .close         = nic_close,
     .reset         = eepro100_reset,

--- a/src/network/net_i8255x.c
+++ b/src/network/net_i8255x.c
@@ -1994,10 +1994,10 @@ eepro100_pci_read(UNUSED(int func), int addr, UNUSED(int len), void *priv)
             return (s->pci_conf[0x02]);
         case 0x03:
             return (s->pci_conf[0x03]);
-        case 0x07:
-            return s->pci_conf[addr & 0xFF] | 0x02;
         case 0x05:
             return s->pci_conf[addr & 0xFF] & 1;
+        case 0x07:
+            return s->pci_conf[addr & 0xFF] | 0x02;
         case 0x09:
             return 0x0;
         case 0x0a:
@@ -2071,6 +2071,11 @@ eepro100_pci_write(UNUSED(int func), int addr, UNUSED(int len), uint8_t val, voi
             break;
         case 0x05:
             s->pci_conf[addr & 0xFF] = val & 1;
+            break;
+        case 0x06:
+            break;
+        case 0x07:
+            s->pci_conf[addr & 0xFF] &= ~(val & 0xf9);
             break;
         case 0x0c:
             s->pci_conf[addr & 0xFF] = val;
@@ -2162,6 +2167,7 @@ nic_init_pci(eepro100_t *s)
     pci_conf[0x02] = (s->pci_device_id) & 0xff;
     pci_conf[0x03] = (s->pci_device_id) >> 8;
     pci_conf[0x04] = 0x07; /* command: IO, memory, bus master */
+    pci_conf[0x06] = 0x80;
     pci_conf[0x07] = 0x02; /* status */
     pci_conf[0x08] = s->pci_revision; /* revision */
     pci_conf[0x0b] = 0x02; /* class: network ethernet */


### PR DESCRIPTION
Summary
=======
Add the Fujitsu ErgoPro x365/564/565 machine with 440BX chipset and Slot 1 platform
(Special thanks to @OBattler for his major help with adding this)

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/543
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
https://theretroweb.com/motherboards/s/fujitsu-ergopro-x365
