### PR TITLE
qt: Improve dynarec status bar icon

### DIFF
--- a/src/qt/qt_machinestatus.cpp
+++ b/src/qt/qt_machinestatus.cpp
@@ -392,7 +392,7 @@ struct MachineStatus::States {
     std::array<StateActive, HDD_BUS_USB>       hdds;
     std::array<StateEmptyActive, NET_CARD_MAX> net;
     std::unique_ptr<ClickableLabel>            sound;
-    std::unique_ptr<QLabel>                    dynarec;
+    std::unique_ptr<ClickableLabel>            dynarec;
     std::unique_ptr<QLabel>                    text;
 };
 
@@ -402,6 +402,7 @@ MachineStatus::MachineStatus(QObject *parent)
 {
     d         = std::make_unique<MachineStatus::States>(this);
     soundMenu = nullptr;
+    dynarecMenu = nullptr;
     connect(refreshTimer, &QTimer::timeout, this, &MachineStatus::refreshIcons);
     refreshTimer->start(75);
 }
@@ -412,6 +413,12 @@ void
 MachineStatus::setSoundMenu(QMenu *menu)
 {
     soundMenu = menu;
+}
+
+void
+MachineStatus::setDynarecMenu(QMenu *menu)
+{
+    dynarecMenu = menu;
 }
 
 bool
@@ -612,8 +619,12 @@ MachineStatus::refreshIcons()
     if (d->sound)
         d->sound->setPixmap((sound_muted || fast_forward) ? d->pixmaps.sound.disabled : d->pixmaps.sound.normal);
 
-    if (d->dynarec)
+    if (d->dynarec) {
+        d->dynarec->setVisible(cpu_use_dynarec);
         d->dynarec->setPixmap(!is_dynarec_active() ? d->pixmaps.dynarec.disabled : d->pixmaps.dynarec.normal);
+        d->dynarec->setToolTip(is_dynarec_active() ? tr("Dynamic recompiler is active") :
+                                                     tr("Dynamic recompiler is inactive"));
+    }
 
     /* Check if icons should show activity. */
     if (!update_icons)
@@ -1052,9 +1063,17 @@ MachineStatus::refresh(QStatusBar *sbar)
     d->sound->setToolTip(tr("Sound"));
     sbar->addWidget(d->sound.get());
 
-    d->dynarec = std::make_unique<QLabel>();
+    d->dynarec = std::make_unique<ClickableLabel>();
     d->dynarec->setPixmap(!is_dynarec_active() ? d->pixmaps.dynarec.disabled : d->pixmaps.dynarec.normal);
-    d->dynarec->setToolTip(tr("Dynamic recompiler"));
+    d->dynarec->setToolTip(is_dynarec_active() ? tr("Dynamic recompiler is active") :
+                                                 tr("Dynamic recompiler is inactive"));
+    d->dynarec->setVisible(cpu_use_dynarec);
+
+    connect(d->dynarec.get(), &ClickableLabel::clicked, this, [this](QPoint pos) {
+        if (this->dynarecMenu)
+            this->dynarecMenu->popup(pos - QPoint(0, this->dynarecMenu->sizeHint().height()));
+    });
+
     sbar->addWidget(d->dynarec.get());
 
     d->text = std::make_unique<QLabel>();

--- a/src/qt/qt_machinestatus.hpp
+++ b/src/qt/qt_machinestatus.hpp
@@ -80,6 +80,7 @@ public:
     QString getMessage();
     void    clearActivity();
     void    setSoundMenu(QMenu *menu);
+    void    setDynarecMenu(QMenu *menu);
 public slots:
     void refresh(QStatusBar *sbar);
     void message(const QString &msg);
@@ -93,6 +94,7 @@ private:
     std::unique_ptr<States> d;
     QTimer                 *refreshTimer;
     QMenu                  *soundMenu;
+    QMenu                  *dynarecMenu;
 };
 
 #endif // QT_MACHINESTATUS_HPP

--- a/src/qt/qt_mainwindow.cpp
+++ b/src/qt/qt_mainwindow.cpp
@@ -217,6 +217,9 @@ MainWindow::MainWindow(QWidget *parent)
     main_window = this;
     ui->setupUi(this);
     status->setSoundMenu(ui->menuSound);
+    dynarecMenu = new QMenu(this);
+    dynarecMenu->addAction(ui->actionForce_interpretation);
+    status->setDynarecMenu(dynarecMenu);
     ui->actionMute_Unmute->setText(sound_muted ? tr("&Unmute") : tr("&Mute"));
     ui->stackedWidget->setMouseTracking(true);
     statusBar()->setVisible(!hide_status_bar);
@@ -1847,6 +1850,7 @@ MainWindow::refreshMediaMenu()
 {
     mm->refresh(ui->menuMedia);
     status->setSoundMenu(ui->menuSound);
+    status->setDynarecMenu(dynarecMenu);
     status->refresh(ui->statusbar);
     ui->actionMCA_devices->setVisible(machine_has_bus(machine, MACHINE_BUS_MCA));
     if (acpi_enabled) {

--- a/src/qt/qt_mainwindow.hpp
+++ b/src/qt/qt_mainwindow.hpp
@@ -179,6 +179,7 @@ private:
     Ui::MainWindow                *ui;
     std::unique_ptr<MachineStatus> status;
     std::shared_ptr<MediaMenu>     mm;
+    QMenu                         *dynarecMenu = nullptr;
 
     void updateShortcuts();
     void processKeyboardInput(bool down, uint32_t keycode);


### PR DESCRIPTION
Summary
=======
Added current dynarec status to hover tooltip text and a context menu with the "force interpretation" command, also hided the icon altogether when dynarec is disabled for the config

<img width="201" height="68" alt="image" src="https://github.com/user-attachments/assets/d38ce5be-8a43-47b0-b043-6b7a6eaaa1ef" />
<img width="191" height="59" alt="image" src="https://github.com/user-attachments/assets/4532a489-5587-4c6e-8d7e-bf8d19aedbc0" />
<img width="270" height="65" alt="image" src="https://github.com/user-attachments/assets/3850d11d-fa76-46b6-b42b-dab848f7fc21" />


Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
_Provide links to datasheets or other documentation that helped you implement this pull request._
