### PR TITLE
Fix mouse capture in some compositors on wayland

### DIFF
--- a/src/qt/wl_mouse.cpp
+++ b/src/qt/wl_mouse.cpp
@@ -37,6 +37,12 @@ static zwp_locked_pointer_v1                     *conf_pointer_toplevel  = nullp
 static zwp_keyboard_shortcuts_inhibit_manager_v1 *kbd_manager            = nullptr;
 static zwp_keyboard_shortcuts_inhibitor_v1       *kbd_inhibitor          = nullptr;
 
+/* Registry names of the globals bound below, so that a global_remove can be
+ * matched against the one global it actually refers to. */
+static uint32_t rel_manager_name  = 0;
+static uint32_t conf_pointer_name = 0;
+static uint32_t kbd_manager_name  = 0;
+
 static bool wl_init_ok     = false;
 static bool pointer_locked = false;
 
@@ -93,36 +99,67 @@ display_handle_global(void *data, struct wl_registry *registry, uint32_t id,
                       const char *interface, uint32_t version)
 {
     if (!strcmp(interface, "zwp_relative_pointer_manager_v1")) {
-        rel_manager = (zwp_relative_pointer_manager_v1 *) wl_registry_bind(registry, id, &zwp_relative_pointer_manager_v1_interface, version);
+        rel_manager      = (zwp_relative_pointer_manager_v1 *) wl_registry_bind(registry, id, &zwp_relative_pointer_manager_v1_interface, version);
+        rel_manager_name = id;
     }
     if (!strcmp(interface, "zwp_pointer_constraints_v1")) {
         conf_pointer_interface = (zwp_pointer_constraints_v1 *) wl_registry_bind(registry, id, &zwp_pointer_constraints_v1_interface, version);
+        conf_pointer_name      = id;
     }
     if (!strcmp(interface, "zwp_keyboard_shortcuts_inhibit_manager_v1")) {
-        kbd_manager = (zwp_keyboard_shortcuts_inhibit_manager_v1 *) wl_registry_bind(registry, id, &zwp_keyboard_shortcuts_inhibit_manager_v1_interface, version);
+        kbd_manager      = (zwp_keyboard_shortcuts_inhibit_manager_v1 *) wl_registry_bind(registry, id, &zwp_keyboard_shortcuts_inhibit_manager_v1_interface, version);
+        kbd_manager_name = id;
     }
 }
 
 static void
 display_global_remove(void *data, struct wl_registry *wl_registry, uint32_t name)
 {
-    plat_mouse_capture(0);
-    if (kbd_inhibitor) {
-        zwp_keyboard_shortcuts_inhibitor_v1_destroy(kbd_inhibitor);
-        kbd_inhibitor = nullptr;
-    }
-    if (kbd_manager) {
+    /* Only the objects derived from the global that went away become inert;
+     * anything else we hold stays valid. Globals come and go routinely - an
+     * output being enabled or disabled, for instance - so tearing down
+     * everything here would permanently disable mouse capture. */
+    bool lost_capture = false;
+
+    if (kbd_manager && (name == kbd_manager_name)) {
+        if (kbd_inhibitor) {
+            zwp_keyboard_shortcuts_inhibitor_v1_destroy(kbd_inhibitor);
+            kbd_inhibitor = nullptr;
+        }
         zwp_keyboard_shortcuts_inhibit_manager_v1_destroy(kbd_manager);
-        kbd_manager = nullptr;
+        kbd_manager      = nullptr;
+        kbd_manager_name = 0;
     }
-    if (rel_manager) {
+
+    if (rel_manager && (name == rel_manager_name)) {
+        if (rel_pointer) {
+            zwp_relative_pointer_v1_destroy(rel_pointer);
+            rel_pointer = nullptr;
+        }
         zwp_relative_pointer_manager_v1_destroy(rel_manager);
-        rel_manager = nullptr;
+        rel_manager      = nullptr;
+        rel_manager_name = 0;
+        lost_capture     = true;
     }
-    if (conf_pointer_interface) {
+
+    if (conf_pointer_interface && (name == conf_pointer_name)) {
+        if (conf_pointer) {
+            zwp_locked_pointer_v1_destroy(conf_pointer);
+            conf_pointer = nullptr;
+        }
+        if (conf_pointer_toplevel) {
+            zwp_locked_pointer_v1_destroy(conf_pointer_toplevel);
+            conf_pointer_toplevel = nullptr;
+        }
         zwp_pointer_constraints_v1_destroy(conf_pointer_interface);
         conf_pointer_interface = nullptr;
+        conf_pointer_name      = 0;
+        pointer_locked         = false;
+        lost_capture           = true;
     }
+
+    if (lost_capture)
+        plat_mouse_capture(0);
 }
 
 static const struct wl_registry_listener registry_listener = {

--- a/src/qt/wl_mouse.cpp
+++ b/src/qt/wl_mouse.cpp
@@ -33,10 +33,50 @@ static zwp_relative_pointer_manager_v1           *rel_manager            = nullp
 static zwp_relative_pointer_v1                   *rel_pointer            = nullptr;
 static zwp_pointer_constraints_v1                *conf_pointer_interface = nullptr;
 static zwp_locked_pointer_v1                     *conf_pointer           = nullptr;
+static zwp_locked_pointer_v1                     *conf_pointer_toplevel  = nullptr;
 static zwp_keyboard_shortcuts_inhibit_manager_v1 *kbd_manager            = nullptr;
 static zwp_keyboard_shortcuts_inhibitor_v1       *kbd_inhibitor          = nullptr;
 
-static bool wl_init_ok = false;
+static bool wl_init_ok     = false;
+static bool pointer_locked = false;
+
+static void
+locked_pointer_locked(void *data, zwp_locked_pointer_v1 *locked_pointer)
+{
+    pointer_locked = true;
+}
+
+static void
+locked_pointer_unlocked(void *data, zwp_locked_pointer_v1 *locked_pointer)
+{
+    pointer_locked = false;
+}
+
+static const struct zwp_locked_pointer_v1_listener locked_pointer_listener = {
+    locked_pointer_locked,
+    locked_pointer_unlocked
+};
+
+static wl_surface *
+surface_for(QWindow *window)
+{
+    if (!window)
+        return nullptr;
+    return (wl_surface *) QGuiApplication::platformNativeInterface()->nativeResourceForWindow("surface", window);
+}
+
+static zwp_locked_pointer_v1 *
+lock_pointer_to(wl_surface *surface, wl_pointer *pointer)
+{
+    if (!surface)
+        return nullptr;
+
+    auto *lock = zwp_pointer_constraints_v1_lock_pointer(conf_pointer_interface, surface, pointer,
+                                                         nullptr, ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT);
+    if (lock)
+        zwp_locked_pointer_v1_add_listener(lock, &locked_pointer_listener, nullptr);
+    return lock;
+}
 
 void
 rel_mouse_event(void *data, zwp_relative_pointer_v1 *zwp_relative_pointer_v1, uint32_t tstmp, uint32_t tstmpl, wl_fixed_t dx, wl_fixed_t dy, wl_fixed_t dx_real, wl_fixed_t dy_real)
@@ -124,17 +164,43 @@ wl_mouse_capture(QWindow *window)
         rel_pointer = zwp_relative_pointer_manager_v1_get_relative_pointer(rel_manager, (wl_pointer *) QGuiApplication::platformNativeInterface()->nativeResourceForIntegration("wl_pointer"));
         zwp_relative_pointer_v1_add_listener(rel_pointer, &rel_listener, nullptr);
     }
-    if (conf_pointer_interface)
-        conf_pointer = zwp_pointer_constraints_v1_lock_pointer(conf_pointer_interface, (wl_surface *) QGuiApplication::platformNativeInterface()->nativeResourceForWindow("surface", window), (wl_pointer *) QGuiApplication::platformNativeInterface()->nativeResourceForIntegration("wl_pointer"), nullptr, ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT);
+    if (conf_pointer_interface) {
+        auto *pointer = (wl_pointer *) QGuiApplication::platformNativeInterface()->nativeResourceForIntegration("wl_pointer");
+
+        QWindow *toplevel = window;
+        while (toplevel && toplevel->parent())
+            toplevel = toplevel->parent();
+
+        wl_surface *surface          = surface_for(window);
+        wl_surface *toplevel_surface = surface_for(toplevel);
+
+        /* Compositors disagree on which surface a constraint is resolved
+         * against: KWin uses the window's root surface, while Weston, Mutter
+         * and wlroots use the focused (sub)surface. With the OpenGL and Vulkan
+         * renderers those differ, so lock both and let the compositor activate
+         * whichever one it recognises. */
+        if (pointer) {
+            conf_pointer = lock_pointer_to(surface, pointer);
+            if (toplevel_surface != surface)
+                conf_pointer_toplevel = lock_pointer_to(toplevel_surface, pointer);
+        }
+    }
 }
 
 void
 wl_mouse_uncapture()
 {
+    if (conf_pointer_interface && !pointer_locked)
+        qWarning() << "Wayland: the compositor never activated the pointer lock";
+
     if (conf_pointer)
         zwp_locked_pointer_v1_destroy(conf_pointer);
+    if (conf_pointer_toplevel)
+        zwp_locked_pointer_v1_destroy(conf_pointer_toplevel);
     if (rel_pointer)
         zwp_relative_pointer_v1_destroy(rel_pointer);
-    rel_pointer  = nullptr;
-    conf_pointer = nullptr;
+    rel_pointer           = nullptr;
+    conf_pointer          = nullptr;
+    conf_pointer_toplevel = nullptr;
+    pointer_locked        = false;
 }

--- a/src/qt/wl_mouse.cpp
+++ b/src/qt/wl_mouse.cpp
@@ -211,11 +211,8 @@ wl_mouse_capture(QWindow *window)
         wl_surface *surface          = surface_for(window);
         wl_surface *toplevel_surface = surface_for(toplevel);
 
-        /* Compositors disagree on which surface a constraint is resolved
-         * against: KWin uses the window's root surface, while Weston, Mutter
-         * and wlroots use the focused (sub)surface. With the OpenGL and Vulkan
-         * renderers those differ, so lock both and let the compositor activate
-         * whichever one it recognises. */
+        /* Compositors disagree on whether a constraint is resolved against the
+         * focused surface or the window's top-level one, so lock both. */
         if (pointer) {
             conf_pointer = lock_pointer_to(surface, pointer);
             if (toplevel_surface != surface)
@@ -227,7 +224,7 @@ wl_mouse_capture(QWindow *window)
 void
 wl_mouse_uncapture()
 {
-    if (conf_pointer_interface && !pointer_locked)
+    if ((conf_pointer || conf_pointer_toplevel) && !pointer_locked)
         qWarning() << "Wayland: the compositor never activated the pointer lock";
 
     if (conf_pointer)


### PR DESCRIPTION
Summary
=======
Mouse capture doesn't work in compositors where they want you to ask to lock the mouse to the top level surface, not a subsurface. KWin and sway both want this (maybe others, I'm not gonna test every compositor that exists!)
Others want the subsurface if one exists.

If using a renderer other than the Qt (software) renderer, a subsurface does exist (both OpenGL and Vulkan render into a subsurface). Currently 86Box asks for either the parent surface (if in Qt render mode) or the subsurface (if in OpenGL or Vulkan) mode.

This makes it request locking for both surfaces, to account for the differences in compositors. It will also log a warning if 86Box requests the mouse be captured but nothing activates lock we requested (indicating that the current compositor has *yet another thing* that needs to probably be accounted for). If using the Qt renderer, there's just one request (that's the `if (toplevel_surface != surface)` down there).

Despite being specific to compositor, it doesn't affect things on X because X itself handles mouse locking, and subsurfaces don't exist on X. It also works with the .appimage build on Wayland because it uses xcb instead of the native Wayland methods for input locking.

Also d3900d0 is a bug fix that I feel is related, that can break captures. If any wayland global is removed, not even related to input, then we lose capture. That probably shouldn't happen. I can split this to a separate PR if preferred.

Sidenote: This is awful to test in VMs because of mouse integration stuff. Thankfully a lot of compositors let you start them 'nested' and you can run them inside your existing thing... except GNOME which refuses and starts headless. 

Checklist
=========
* [x] Resolves #7871
* [x] Resolves https://github.com/86Box/86Box/discussions/7874
* [x] I have tested my changes locally and validated that the functionality works as intended
(Tested on Wayland with: KWin (KDE), sway, mutter (GNOME)*, weston)
* [ ] I have discussed this with core contributors already

\*Extremely painful. Had to actually test a new machine with ubuntu 26 on bare metal because they removed the ability to start it nested.

References
==========
Referred to the wayland, kwin, mutter, weston, sway source code to understand how they decide to handle mouse locking requests.