### PR TITLE
Fix qt5 build with extra-cmake-modules

### DIFF
--- a/src/qt/wl_mouse.cpp
+++ b/src/qt/wl_mouse.cpp
@@ -14,6 +14,7 @@
  */
 #include "wl_mouse.hpp"
 #include <QGuiApplication>
+#include <QDebug>
 #include <wayland-client-core.h>
 #include <wayland-client-protocol.h>
 #include <wayland-relative-pointer-unstable-v1-client-protocol.h>


### PR DESCRIPTION
Summary
=======
This is a quick fix to previous PR for the Qt5 build specifically.

A user reported an issue with the Wayland mouse fix. It only applies to qt5, and only if you don't have extra-cmake-packages installed, where it will build a version of the bin for qt5 with no wayland-specific functions (so no mouse capture, no shortcut inhibiting, no keyboard capture).

If you DO have extra-cmake-modules installed then the qt5 build just fails entirely because of this missing include, which is not great.

I'm gonna make another PR for cleaning up the extra-cmake-modules branching in the makefile because it really shouldn't just silently build a bin without the wayland features if you don't have that package installed. It should warn you or something.

Checklist
=========
* [x] I have tested my changes locally and validated that the functionality works as intended
