### PR TITLE
Remove extra-cmake-modules 'optional' dep

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -623,27 +623,37 @@ if (UNIX AND NOT APPLE AND NOT HAIKU)
         endif()
     endif()
 
-    find_package(ECM NO_MODULE)
-    if (ECM_FOUND)
-        list(APPEND CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
-        find_package(Wayland COMPONENTS Client)
-        if (Wayland_FOUND)
-            target_link_libraries(ui PRIVATE Wayland::Client)
-            find_package(WaylandScanner REQUIRED)
-            if (WaylandScanner_FOUND)
-                set(WL_SOURCE_VAR)
-                ecm_add_wayland_client_protocol(WL_SOURCE_VAR PROTOCOL ${CMAKE_SOURCE_DIR}/wl_protocols/relative-pointer-unstable-v1.xml BASENAME relative-pointer-unstable-v1)
-                ecm_add_wayland_client_protocol(WL_SOURCE_VAR PROTOCOL ${CMAKE_SOURCE_DIR}/wl_protocols/pointer-constraints-unstable-v1.xml BASENAME pointer-constraints-unstable-v1)
-                ecm_add_wayland_client_protocol(WL_SOURCE_VAR PROTOCOL ${CMAKE_SOURCE_DIR}/wl_protocols/keyboard-shortcuts-inhibit-unstable-v1.xml BASENAME keyboard-shortcuts-inhibit-unstable-v1)
-                target_include_directories(ui PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${Qt${QT_MAJOR}Gui_PRIVATE_INCLUDE_DIRS})
-                target_sources(ui PRIVATE ${WL_SOURCE_VAR} wl_mouse.cpp)
-                if (XKBCOMMON_FOUND)
-                    target_sources(ui PRIVATE xkbcommon_wl_keyboard.cpp)
-                endif()
-                target_compile_definitions(ui PRIVATE WAYLAND)
-                set(QT_PRIVATE_HEADERS ON)
-            endif()
+    # Wayland client protocols. wayland-scanner and the wayland-client
+    # pkg-config file both ship with wayland itself.
+    pkg_check_modules(WAYLAND_CLIENT IMPORTED_TARGET wayland-client)
+    find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
+    if (WAYLAND_CLIENT_FOUND AND WAYLAND_SCANNER_EXECUTABLE)
+        set(WL_SOURCE_VAR)
+        foreach(_wl_proto relative-pointer-unstable-v1
+                          pointer-constraints-unstable-v1
+                          keyboard-shortcuts-inhibit-unstable-v1)
+            set(_wl_xml ${CMAKE_SOURCE_DIR}/wl_protocols/${_wl_proto}.xml)
+            set(_wl_hdr ${CMAKE_CURRENT_BINARY_DIR}/wayland-${_wl_proto}-client-protocol.h)
+            set(_wl_src ${CMAKE_CURRENT_BINARY_DIR}/wayland-${_wl_proto}-protocol.c)
+            add_custom_command(OUTPUT ${_wl_hdr}
+                COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header ${_wl_xml} ${_wl_hdr}
+                DEPENDS ${_wl_xml} VERBATIM)
+            add_custom_command(OUTPUT ${_wl_src}
+                COMMAND ${WAYLAND_SCANNER_EXECUTABLE} public-code ${_wl_xml} ${_wl_src}
+                DEPENDS ${_wl_xml} ${_wl_hdr} VERBATIM)
+            set_property(SOURCE ${_wl_hdr} ${_wl_src} PROPERTY SKIP_AUTOMOC ON)
+            list(APPEND WL_SOURCE_VAR ${_wl_hdr} ${_wl_src})
+        endforeach()
+        target_link_libraries(ui PRIVATE PkgConfig::WAYLAND_CLIENT)
+        target_include_directories(ui PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${Qt${QT_MAJOR}Gui_PRIVATE_INCLUDE_DIRS})
+        target_sources(ui PRIVATE ${WL_SOURCE_VAR} wl_mouse.cpp)
+        if (XKBCOMMON_FOUND)
+            target_sources(ui PRIVATE xkbcommon_wl_keyboard.cpp)
         endif()
+        target_compile_definitions(ui PRIVATE WAYLAND)
+        set(QT_PRIVATE_HEADERS ON)
+    else()
+        message(WARNING "Wayland client development files not found; Wayland mouse capture will be disabled.")
     endif()
 
     # Add private headers for Qt5 if required.


### PR DESCRIPTION
Summary
=======
extra-cmake-modules is currently listed as a dep on the build guide, but there are some issues with the way it is used currently:
- Without it, builds silently omit the wayland input code (wl_mouse.cpp for example). This may not be obvious at runtime because xcb may be used instead if the user does not have qt6-wayland or qt5-wayland. Having those packages installed then breaks mouse input capture because 86Box auto-selects the wayland mouse handling, but the wayland code was compiled out, so no capture function is ever assigned and there is no fallback to the xinput2 path
- It is used one place in CMakeLists and can be replaced with a pkg-config alternative, and pkg-config is a hard dep already (cmake explodes without it: `find_package(PkgConfig REQUIRED)`)
- The github actions builds do not install extra-cmake-modules, so none of those have ever had the wayland tooling, anyone using them will have trouble on wayland
- Jenkins DOES build with extra-cmake-modules, but qt6 only, so there is no CI build for qt5-with-ecm (which is how a previous PR did not trigger a build error)

The CMakeLists relies on the optional presence of extra-cmake-modules to determine if we should build with wayland-specific things or not. We can use pkg-config (which is a hard dep already) instead of the optional extra-cmake-modules. This eliminates extra-cmake-modules as a dep entirely.

This is just a rewrite of the extra-cmake-modules 'is wayland here? do we build for wayland?' section of CMakeLists into pkg-config format.

If this is merged I'll go update the build guide in the docs also, but I don't want to make that PR if this one gets rejected!

Checklist
=========
* [x] I have tested my changes locally and validated that the functionality works as intended

References
==========
#2150 