### PR TITLE
CPU: Fix debug/breakpoint handling in dynarec

### DIFF
--- a/src/cpu/386.c
+++ b/src/cpu/386.c
@@ -277,7 +277,12 @@ exec386_2386(int32_t cycs)
                 if (trap & 16)
                     dr[6] |= 0x2000;
                 trap = 0;
+                /* RF must be set in the EFLAGS image x86gen() pushes, so the
+                handler's IRET resumes the instruction instead of faulting on it
+                again; delivery itself leaves RF clear for the handler. */
+                cpu_state.eflags |= RF_FLAG;
                 x86gen();
+                cpu_state.eflags &= ~RF_FLAG;
                 /* No instructions executed at this point. */
                 break;
             } else if (cpu_16bitbus) {

--- a/src/cpu/386.c
+++ b/src/cpu/386.c
@@ -266,15 +266,20 @@ exec386_2386(int32_t cycs)
             if ((ol == 3) && opcode_has_modrm[fetchdat & 0xff] && (((fetchdat >> 14) & 0x03) == 0x03))
                 ol = 2;
 
-            if (is386)
-                ins_fetch_fault = cpu_386_check_instruction_fault();
-
-            /* Breakpoint fault has priority over other faults. */
-            if ((cpu_state.abrt == 0) & ins_fetch_fault) {
+            /* Breakpoint fault has priority over other faults. x86gen() delivers
+               #DB right away, so fold any still-pending trap into the same DR6
+               image and clear it, otherwise the epilogue raises a second #DB. A
+               pending BS is always stale here - trap's TF bit is only set further
+               down, once an instruction is about to retire - so it is dropped. */
+            if ((cpu_state.abrt == 0) && is386 && cpu_386_check_instruction_fault()) {
+                if (trap & 2)
+                    dr[6] |= 0x8000;
+                if (trap & 16)
+                    dr[6] |= 0x2000;
+                trap = 0;
                 x86gen();
-                ins_fetch_fault = 0;
                 /* No instructions executed at this point. */
-                goto block_ended;
+                break;
             } else if (cpu_16bitbus) {
                 CHECK_READ_CS(MIN(ol, 2));
             } else {

--- a/src/cpu/386_common.h
+++ b/src/cpu/386_common.h
@@ -693,6 +693,17 @@ seteaq(uint64_t v)
 #    define seteaw_mem(v) writememwl_2386(easeg + cpu_state.eaaddr, v);
 #    define seteal_mem(v) writememll_2386(easeg + cpu_state.eaaddr, v);
 #else
+/* The eal_r/eal_w effective-address fast path dereferences a cached host
+   pointer directly, bypassing the debug-register checks that the readmem and
+   writemem macros perform. It must therefore stay disabled while any
+   breakpoint is armed. Evaluated once per instruction in fetch_ea_*, not per
+   access. Folds to a constant when the option is off. */
+#        ifdef USE_DEBUG_REGS_486
+#            define EA_FASTPATH_OK() (!(dr[7] & 0xFF))
+#        else
+#            define EA_FASTPATH_OK() 1
+#        endif
+
 static __inline uint8_t
 getbyte(void)
 {

--- a/src/cpu/386_dynarec.c
+++ b/src/cpu/386_dynarec.c
@@ -351,7 +351,12 @@ exec386_dynarec_int(void)
             if (trap & 16)
                 dr[6] |= 0x2000;
             trap = 0;
+            /* RF must be set in the EFLAGS image x86gen() pushes, so the
+               handler's IRET resumes the instruction instead of faulting on it
+               again; delivery itself leaves RF clear for the handler. */
+            cpu_state.eflags |= RF_FLAG;
             x86gen();
+            cpu_state.eflags &= ~RF_FLAG;
             /* No instructions executed at this point. */
             break;
         }
@@ -1247,7 +1252,12 @@ exec386(int32_t cycs)
 
             /* Breakpoint fault has priority over other faults. */
             if ((cpu_state.abrt == 0) & ins_fetch_fault) {
+                /* RF must be set in the EFLAGS image x86gen() pushes, so the
+                   handler's IRET resumes the instruction instead of faulting on
+                   it again; delivery leaves RF clear for the handler. */
+                cpu_state.eflags |= RF_FLAG;
                 x86gen();
+                cpu_state.eflags &= ~RF_FLAG;
                 ins_fetch_fault = 0;
                 /* No instructions executed at this point. */
                 goto block_ended;

--- a/src/cpu/386_dynarec.c
+++ b/src/cpu/386_dynarec.c
@@ -331,9 +331,6 @@ exec386_dynarec_int(void)
     }
 
     while (!cpu_block_end) {
-#    ifdef USE_DEBUG_REGS_486
-        int ins_fetch_fault = 0;
-#    endif
         oldcs  = CS;
         oldcpl = CPL;
         cpu_state.oldpc = cpu_state.pc;
@@ -343,15 +340,20 @@ exec386_dynarec_int(void)
         cpu_state.ssegs  = 0;
 
 #    ifdef USE_DEBUG_REGS_486
-        if (is386)
-            ins_fetch_fault = cpu_386_check_instruction_fault();
-
-        /* Breakpoint fault has priority over other faults. */
-        if ((cpu_state.abrt == 0) & ins_fetch_fault) {
+        /* Breakpoint fault has priority over other faults. x86gen() delivers
+           #DB right away, so fold any still-pending trap into the same DR6
+           image and clear it, otherwise the epilogue raises a second #DB. A
+           pending BS is always stale here - trap's TF bit is only set further
+           down, once an instruction is about to retire - so it is dropped. */
+        if ((cpu_state.abrt == 0) && is386 && cpu_386_check_instruction_fault()) {
+            if (trap & 2)
+                dr[6] |= 0x8000;
+            if (trap & 16)
+                dr[6] |= 0x2000;
+            trap = 0;
             x86gen();
-            ins_fetch_fault = 0;
             /* No instructions executed at this point. */
-            goto block_ended;
+            break;
         }
 #    endif
 

--- a/src/cpu/386_dynarec.c
+++ b/src/cpu/386_dynarec.c
@@ -140,7 +140,7 @@ fetch_ea_32_long(uint32_t rmdat)
             cpu_state.eaaddr = getlong();
         }
     }
-    if (easeg != 0xFFFFFFFF && ((easeg + cpu_state.eaaddr) & 0xFFF) <= 0xFFC) {
+    if (easeg != 0xFFFFFFFF && EA_FASTPATH_OK() && ((easeg + cpu_state.eaaddr) & 0xFFF) <= 0xFFC) {
         uint32_t addr = easeg + cpu_state.eaaddr;
         if (readlookup2[addr >> 12] != (uintptr_t) -1)
             eal_r = (uint32_t *) (readlookup2[addr >> 12] + addr);
@@ -176,7 +176,7 @@ fetch_ea_16_long(uint32_t rmdat)
         }
         cpu_state.eaaddr &= 0xFFFF;
     }
-    if (easeg != 0xFFFFFFFF && ((easeg + cpu_state.eaaddr) & 0xFFF) <= 0xFFC) {
+    if (easeg != 0xFFFFFFFF && EA_FASTPATH_OK() && ((easeg + cpu_state.eaaddr) & 0xFFF) <= 0xFFC) {
         uint32_t addr = easeg + cpu_state.eaaddr;
         if (readlookup2[addr >> 12] != (uintptr_t) -1)
             eal_r = (uint32_t *) (readlookup2[addr >> 12] + addr);

--- a/src/cpu/386_dynarec.c
+++ b/src/cpu/386_dynarec.c
@@ -331,6 +331,9 @@ exec386_dynarec_int(void)
     }
 
     while (!cpu_block_end) {
+#    ifdef USE_DEBUG_REGS_486
+        int ins_fetch_fault = 0;
+#    endif
         oldcs  = CS;
         oldcpl = CPL;
         cpu_state.oldpc = cpu_state.pc;
@@ -338,6 +341,19 @@ exec386_dynarec_int(void)
 
         cpu_state.ea_seg = &cpu_state.seg_ds;
         cpu_state.ssegs  = 0;
+
+#    ifdef USE_DEBUG_REGS_486
+        if (is386)
+            ins_fetch_fault = cpu_386_check_instruction_fault();
+
+        /* Breakpoint fault has priority over other faults. */
+        if ((cpu_state.abrt == 0) & ins_fetch_fault) {
+            x86gen();
+            ins_fetch_fault = 0;
+            /* No instructions executed at this point. */
+            goto block_ended;
+        }
+#    endif
 
         fetchdat = fastreadl_fetch(cs + cpu_state.pc);
 #    ifdef ENABLE_386_DYNAREC_LOG

--- a/src/cpu/386_dynarec_ops.c
+++ b/src/cpu/386_dynarec_ops.c
@@ -41,7 +41,7 @@ fetch_ea_32_long(UNUSED(uint32_t rmdat))
 {
     eal_r = eal_w = NULL;
     easeg         = cpu_state.ea_seg->base;
-    if (easeg != 0xFFFFFFFF && ((easeg + cpu_state.eaaddr) & 0xFFF) <= 0xFFC) {
+    if (easeg != 0xFFFFFFFF && EA_FASTPATH_OK() && ((easeg + cpu_state.eaaddr) & 0xFFF) <= 0xFFC) {
         uint32_t addr = easeg + cpu_state.eaaddr;
         if (readlookup2[addr >> 12] != (uintptr_t) LOOKUP_INV)
             eal_r = (uint32_t *) (readlookup2[addr >> 12] + addr);
@@ -55,7 +55,7 @@ fetch_ea_16_long(UNUSED(uint32_t rmdat))
 {
     eal_r = eal_w = NULL;
     easeg         = cpu_state.ea_seg->base;
-    if (easeg != 0xFFFFFFFF && ((easeg + cpu_state.eaaddr) & 0xFFF) <= 0xFFC) {
+    if (easeg != 0xFFFFFFFF && EA_FASTPATH_OK() && ((easeg + cpu_state.eaaddr) & 0xFFF) <= 0xFFC) {
         uint32_t addr = easeg + cpu_state.eaaddr;
         if (readlookup2[addr >> 12] != (uintptr_t) LOOKUP_INV)
             eal_r = (uint32_t *) (readlookup2[addr >> 12] + addr);

--- a/src/mem/mem.c
+++ b/src/mem/mem.c
@@ -598,7 +598,6 @@ addreadlookup(uint32_t virt, uint32_t phys)
     int *    rln          = &(readlnext[is_compare]);
     int      cur_rln      = *rln | (int) small_offset;
 
-#ifndef USE_DEBUG_REGS_486
     if (virt == 0xffffffff)
         return;
 
@@ -611,8 +610,7 @@ addreadlookup(uint32_t virt, uint32_t phys)
     readlookup2[index] = (uintptr_t) &ram[(uintptr_t) (phys & ~0xFFF) - (uintptr_t) (virt & ~0xfff)];
 
     readlookup[cur_rln] = virt >> 12;
-    *rln = (*rln + 1) & (cachesize - 1);
-#endif
+    *rln                = (*rln + 1) & (cachesize - 1);
 
     cycles -= 9;
 }
@@ -620,7 +618,6 @@ addreadlookup(uint32_t virt, uint32_t phys)
 void
 addwritelookup(uint32_t virt, uint32_t phys)
 {
-#ifndef USE_DEBUG_REGS_486
     if (virt == 0xffffffff)
         return;
 
@@ -657,7 +654,6 @@ addwritelookup(uint32_t virt, uint32_t phys)
 
     writelookup[writelnext++] = virt >> 12;
     writelnext &= (cachesize - 1);
-#endif
 
     cycles -= 9;
 }


### PR DESCRIPTION
Summary
=======
_This was done using a Claude Opus session. Claude connected to the VM via GDB and performed testing. I monitored the VM, and I can say that it is visibly working. Since it touches emulation core, it needs review. It "works for me", but might break other stuff. Viewer's discretion is advised._

Yesterday, I was debugging Empire Earth, and found out that the game only works when the debug registers are enabled. I did this, and the game launched. As mentioned briefly yesterday, I ran into the issue that I could later NOT verify the results anymore.

The reason for this: GDBSTUB enabled forced 86Box to run in interpreter mode, and not with the dynarec engaged. When enabling the dynarec, the code path that triggers the debug breakpoints never triggered as soon as the VM even booted with dynarec, so flipping back to interpreter mode didn't help.

This is fixed by https://github.com/86Box/86Box/commit/dd804f8850dcb89ec7925fc9709ab1388f83a26c - the game launches, even if using the dynarec. I *manually* tested ODR and NDR. Having `-DDEBUGREGS486=ON` is STILL a requirement though.

https://github.com/86Box/86Box/commit/1f48eb29d386632961d58cba13a93dcaeedda5c8 and https://github.com/86Box/86Box/commit/a13b217a9907adb18490c10722b426feb10962e0 were reported as bugs by a sub-agent performing a review.

This had no visible outcome, and I couldn't see any regressions testing the game.

So, after the three first commits: **Empire Earth correctly launches using the dynarec*.

And finally: https://github.com/86Box/86Box/commit/1e72618991a212268c75c7726bc59fd1171b00c9

This is potentially the most "dangerous" one, but it lead to a _huge_ performance improvement. In Empire Earth as a test case, it performed almost as good with `-DDEBUGREGS486=OFF`, so the performance penalty introduced by the debug registers dropped by _a lot_. Probably needs more testing though...

Performance is not completely on par with the "regular" builds though, but my testing capabilities are a bit limited, given that I only have a Ryzen 5 3600 that tops out somewhere around 200 Mhz.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
* Tested with GDB inside the VM, hooking into the game process
* Reasoning: https://gist.github.com/lotharsm/d0bb822f405641d8bbcd2cfd8c248a20
* _NO_ outside documentation!
