### PR TITLE
Add the AwardBIOS v6.00PG Beta Evaluation Board

### DIFF
--- a/src/include/86box/machine.h
+++ b/src/include/86box/machine.h
@@ -1218,6 +1218,10 @@ extern int             machine_at_tx97xv_init(const machine_t *);
 extern const device_t  txp4x_device;
 #endif
 extern int             machine_at_txp4x_init(const machine_t *);
+#ifdef EMU_DEVICE_H
+extern const device_t  awardeval_device;
+#endif
+extern int             machine_at_awardeval_init(const machine_t *);
 extern void            machine_at_optiplex_21152_init(void);
 extern int             machine_at_optiplexgn_init(const machine_t *);
 extern int             machine_at_tomahawk_init(const machine_t *);

--- a/src/machine/m_at_socket7.c
+++ b/src/machine/m_at_socket7.c
@@ -1560,6 +1560,92 @@ machine_at_txp4x_init(const machine_t *model)
     return ret;
 }
 
+static const device_config_t awardeval_config[] = {
+    // clang-format off
+    {
+        .name           = "bios",
+        .description    = "BIOS Version",
+        .type           = CONFIG_BIOS,
+        .default_string = "awardeval",
+        .default_int    = 0,
+        .file_filter    = NULL,
+        .spinner        = { 0 },
+        .selection      = { { 0 } },
+        .bios           = {
+            {
+                .name          = "AwardBIOS v4.51PG (v6.00PG Beta) - Revision 11/21/97",
+                .internal_name = "awardeval_112197",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 131072,
+                .files         = { "roms/machines/awardeval/2a59ie39.bin", "" }
+            },
+            {
+                .name          = "AwardBIOS v4.51PG (v6.00PG Beta) - Revision 01/11/98",
+                .internal_name = "awardeval",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = 0,
+                .size          = 131072,
+                .files         = { "roms/machines/awardeval/test.bin", "" }
+            },
+            { .files_no = 0 }
+        }
+    },
+    { .name = "", .description = "", .type = CONFIG_END }
+    // clang-format on
+};
+
+const device_t awardeval_device = {
+    .name          = "AwardBIOS v6.00PG Beta Evaluation Board",
+    .internal_name = "awardeval",
+    .flags         = 0,
+    .local         = 0,
+    .init          = NULL,
+    .close         = NULL,
+    .reset         = NULL,
+    .available     = NULL,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .config        = awardeval_config
+};
+
+int
+machine_at_awardeval_init(const machine_t *model)
+{
+    int         ret = 0;
+    const char *fn;
+
+    /* No ROMs available */
+    if (!device_available(model->device))
+        return ret;
+
+    device_context(model->device);
+    fn  = device_get_bios_file(machine_get_device(machine), device_get_config_bios("bios"), 0);
+    ret = bios_load_linear(fn, 0x000e0000, 131072, 0);
+    device_context_restore();
+
+    machine_at_common_init(model);
+
+    pci_init(PCI_CONFIG_TYPE_1);
+    pci_register_slot(0x00, PCI_CARD_NORTHBRIDGE, 0, 0, 0, 0);
+    pci_register_slot(0x11, PCI_CARD_NORMAL,      1, 2, 3, 4);
+    pci_register_slot(0x12, PCI_CARD_NORMAL,      2, 3, 4, 1);
+    pci_register_slot(0x13, PCI_CARD_NORMAL,      3, 4, 1, 2);
+    pci_register_slot(0x14, PCI_CARD_NORMAL,      4, 1, 2, 3);
+    pci_register_slot(0x01, PCI_CARD_SOUTHBRIDGE, 1, 2, 3, 4);
+
+    device_add(&i430tx_device);
+    device_add(&piix4_device);
+    device_add_params(machine_get_kbc_device(machine), (void *) model->kbc_params);
+    device_add_params(&w83877_device, (void *) (W83877F | W83877_3F0));
+    device_add(&sst_flash_29ee010_device);
+    spd_register(SPD_TYPE_SDRAM, 0x3, 128);
+
+    return ret;
+}
+
 void
 machine_at_optiplex_21152_init(void)
 {

--- a/src/machine/machine_table.c
+++ b/src/machine/machine_table.c
@@ -19491,6 +19491,55 @@ const machine_t machines[] = {
         .net_device               = NULL,
         .aliases                  = { "" }
     },
+    /* This has an unknown KBC. Based on EFA 430TX boards with the same or similar BIOS
+       string, it may have a VIA VT82C42N KBC, which is a clone of AMIKEY type 'F'. */
+    {
+        .name              = "[i430TX] AwardBIOS v6.00PG Beta Evaluation Board",
+        .internal_name     = "awardeval",
+        .type              = MACHINE_TYPE_SOCKET7,
+        .chipset           = MACHINE_CHIPSET_INTEL_430TX,
+        .init              = machine_at_awardeval_init,
+        .p1_handler        = machine_generic_p1_handler,
+        .gpio_handler      = NULL,
+        .available_flag    = MACHINE_AVAILABLE,
+        .gpio_acpi_handler = NULL,
+        .cpu               = {
+            .package     = CPU_PKG_SOCKET5_7,
+            .block       = CPU_BLOCK_NONE,
+            .min_bus     = 50000000,
+            .max_bus     = 66666667,
+            .min_voltage = 2700,
+            .max_voltage = 3520,
+            .min_multi   = 1.5,
+            .max_multi   = 3.0
+        },
+        .bus_flags = MACHINE_PS2_PCI | MACHINE_BUS_USB,
+        .flags     = MACHINE_IDE_DUAL | MACHINE_APM | MACHINE_ACPI | MACHINE_USB,
+        .ram       = {
+            .min  = 4096,
+            .max  = 262144,
+            .step = 4096
+        },
+        .nvrmask                  = 255,
+        .jumpered_ecp_dma         = 0,
+        .default_jumpered_ecp_dma = -1,
+        .kbc_device               = &kbc_at_device,
+        .kbc_params               = KBC_VEN_VIA | 0x00424600,
+        .nvr_device               = NULL,
+        .nvr_params               = 0x00000000,
+        .sio_device               = NULL,
+        .sio_params               = 0x00000000,
+        .kbc_p1                   = 0x00000cf0,
+        .gpio                     = 0xffffffff,
+        .gpio_acpi                = 0xffffffff,
+        .device                   = &awardeval_device,
+        .kbd_device               = NULL,
+        .fdc_device               = NULL,
+        .vid_device               = NULL,
+        .snd_device               = NULL,
+        .net_device               = NULL,
+        .aliases                  = { "" }
+    },
     /*
        According to Dell specifications, it can have either National Semiconductor
        PC87307 or PC87309 Super I/O. All known instances have the former, although


### PR DESCRIPTION
Summary
=======
This is an implementation of the motherboard used by Award Software to evaluate what are assumed to be early betas of AwardBIOS v6.00PG from circa late-1997 and early-1998. Although both of the betas identify themselves as AwardBIOS v4.51PG in the POST screen, they use a completely irregular setup utility that matches the PhoenixBIOS 4.0x "NuBIOS" setup utility and is more in line with other known v6.00PG betas.

The motherboard is based on the 430TX chipset and the Socket 7 platform. Although it shares its POST string with the EFA P5TX-AT and E5TX-AT motherboards, it has some differences that make it incompatible with these boards, hence it is added as its own special machine rather than a BIOS option part of either one of those boards.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/545
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
Some of the specifications are roughly based on this motherboard due to lack of info, with testing to ensure the beta ROMs operate as ideally as possible:
https://theretroweb.com/motherboards/s/efa-p5tx-at