### PR TITLE
VISO: Fix folder remount failing on macOS after an eject

### DIFF
--- a/src/cdrom/cdrom_image_viso.c
+++ b/src/cdrom/cdrom_image_viso.c
@@ -857,7 +857,7 @@ viso_init(const uint8_t id, const char *dirname, int *error)
     image_viso_log(viso->tf.log, "[%08X] %s => [root]\n", dir, dir->path);
 
     /* Traverse directories, starting with the root. */
-    plat_dir_t     context         = { 0 };
+    plat_dir_t     context         = PLAT_DIR_INIT;
     viso_entry_t **dir_entries     = NULL;
     size_t         dir_entries_len = 0;
     while (LIKELY(dir)) {

--- a/src/include/86box/plat_dir.h
+++ b/src/include/86box/plat_dir.h
@@ -79,6 +79,12 @@ typedef struct {
     char            *temp;
 } plat_dir_t;
 
+/* Static initializer that puts a plat_dir_t in the "no directory open" state.
+   plat_dir_open() and plat_dir_close() test the handle against this value to
+   decide whether a previous handle needs to be closed, so a plain { 0 } is not
+   enough on platforms where the closed sentinel isn't zero (see macOS below). */
+#    define PLAT_DIR_INIT { .find = INVALID_HANDLE_VALUE }
+
 static inline int
 plat_dir_open(plat_dir_t *context, const char *path)
 {
@@ -254,6 +260,12 @@ typedef struct {
     } data;
     uint32_t dir_entrycount;
 } plat_dir_t;
+
+/* Static initializer that puts a plat_dir_t in the "no directory open" state.
+   Here the directory is held in a file descriptor whose unopened sentinel is -1,
+   so { 0 } would make plat_dir_open()/plat_dir_close() treat fd 0 (stdin, or
+   whatever has since been opened at that number) as a live handle and close it. */
+#    define PLAT_DIR_INIT { .find = -1 }
 
 static uint32_t
 plat_dir_fill_attributes(plat_dir_t *context, uint8_t *buf)
@@ -560,6 +572,12 @@ typedef struct {
     struct stat    stats;
     uint8_t        stats_valid;
 } plat_dir_t;
+
+/* Static initializer that puts a plat_dir_t in the "no directory open" state.
+   Here the directory is held in a DIR * whose unopened sentinel is NULL, so a
+   plain { 0 } is already correct; the macro exists for parity with the other
+   platforms. */
+#    define PLAT_DIR_INIT { 0 }
 
 static inline int
 plat_dir_open(plat_dir_t *context, const char *path)


### PR DESCRIPTION
Summary
=======
On macOS, mounting a host folder as a CD works the first time, but after
ejecting it and mounting **another** folder you get two "couldn't open image /
folder" dialogs and folder mounting stays broken until 86Box is restarted.

`viso_init()` initialised its `plat_dir_t` traversal context with `{ 0 }`
(introduced in 63bd158fb when the plat_dir API was reworked to reuse the
context across `plat_dir_open()` calls). On the macOS `getattrlistbulk()`
back-end the open directory is held in a plain file descriptor whose
"nothing open" sentinel is `-1`, not `0`, and `plat_dir_open()` /
`plat_dir_close()` do `close(context->find)` whenever it isn't `-1`. So the
first `plat_dir_open()` of every traversal executes `close(0)`.

- The **first** folder in a session still works: fd 0 is stdin, closing it is
  invisible, and the temporary ISO file was opened while stdin still held fd 0.
- Once fd 0 is free, the **next** VISO mount opens its temporary ISO file onto
  fd 0, and the first `plat_dir_open()` of the traversal closes that descriptor
  out from under the `FILE *`. The rest of `viso_init()` writes to a dead
  stream, image generation fails, and you get the two dialogs. Restarting puts
  stdin back on fd 0, which is why a restart "fixes" it.

Fix: add a per-platform `PLAT_DIR_INIT` static initialiser to `plat_dir.h`
that sets the handle to its real unopened sentinel (`-1` on macOS,
`INVALID_HANDLE_VALUE` on Windows, `NULL`/`{ 0 }` elsewhere) and use it in
`viso_init()`. This matches what the C++ `emu::filesystem` wrapper already
does in its constructor. As a side effect it also stops VISO from closing
stdin on every folder mount on macOS.

Testing
=======
Built on macOS (arm64, Qt5) — clean, no new warnings.

Verified with an A/B harness linking the real `cdrom_image_viso.c`
(unmodified source, same compiler flags) that runs two mount / read / eject
cycles back to back:

| build | cycle 1 | cycle 2 |
| --- | --- | --- |
| `{ 0 }` (before) | ok | `viso_init()` returns error, `tf == NULL` |
| `PLAT_DIR_INIT` (after) | ok | ok |

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set
* [ ] This pull request adds, changes or removes an external dependency

References
==========
Regression from 63bd158fb ("cdrom_image_viso: Update plat_dir API").
