### PR TITLE
MGA/ViRGE/Banshee: Enable the PCI capabilities bit in status register for AGP cards

### DIFF
--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -6385,7 +6385,7 @@ mystique_pci_read(UNUSED(int func), int addr, UNUSED(int len), void *priv)
                 break;
 
             case 0x06:
-                ret = 0x80;
+                ret = PCI_STATUS_L_FAST_B2B | (mystique->is_agp ? PCI_STATUS_L_CAPAB : 0);
                 break;
             case 0x07:
                 ret = mystique->pci_regs[0x07];
@@ -6486,7 +6486,7 @@ mystique_pci_read(UNUSED(int func), int addr, UNUSED(int len), void *priv)
                 break;
 
             case 0x34:
-                ret = (mystique->type == MGA_G100 || mystique->is_agp) ? 0xdc : 0x00;
+                ret = mystique->is_agp ? 0xdc : 0x00;
                 break;
 
             case 0x3c:

--- a/src/video/vid_s3_virge.c
+++ b/src/video/vid_s3_virge.c
@@ -6157,8 +6157,10 @@ s3_virge_init(const device_t *info)
             default:
                 break;
         }
-        if (virge->type == S3_VIRGE_GX)
+        if (virge->type == S3_VIRGE_GX) {
             virge->svga.crtc[0x36] |= (1 << 2);
+            virge->svga.crtc[0x6f] |= 1;
+        }
     }
 
     virge->svga.crtc[0x37] = 1 | (7 << 5);

--- a/src/video/vid_s3_virge.c
+++ b/src/video/vid_s3_virge.c
@@ -5616,6 +5616,10 @@ s3_virge_pci_read(UNUSED(int func), int addr, UNUSED(int len), void *priv)
             ret = virge->pci_regs[PCI_REG_COMMAND] & 0x27;
             break;
 
+        case 0x06:
+            ret = (virge->chip >= S3_VIRGEGX2) ? PCI_STATUS_L_CAPAB : 0x00;
+            break;
+
         case 0x07:
             ret = virge->pci_regs[0x07] & 0x36;
             break;

--- a/src/video/vid_voodoo_banshee.c
+++ b/src/video/vid_voodoo_banshee.c
@@ -3103,6 +3103,10 @@ banshee_pci_read(int func, int addr, UNUSED(int len), void *priv)
             ret = banshee->pci_regs[0x04] & 0x27;
             break;
 
+        case 0x06:
+            ret = PCI_STATUS_L_CAPAB | (banshee->agp ? PCI_STATUS_L_66MHZ : 0);
+            break;
+
         case 0x07:
             ret = banshee->pci_regs[0x07] & 0x36;
             break;


### PR DESCRIPTION
Summary
=======
Enable the capability bit in the lower PCI status register for graphics cards that have capabilities defined, namely AGP Matrox Millennium II/G100 and all S3 ViRGE/GX2, S3 Trio3D/2X and 3dfx Voodoo Banshee/3 cards (which also have the Power Management capability).

Fixes chipsets reporting AGP status as "disabled" even when an AGP card is installed.

Drive-by: fix ViRGE/GX's identification by setting the bit 0 of CRTC register 6F to 1, as per the recently discovered datasheet.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
* [ ] This pull request requires changes to the asset set
* [ ] This pull request adds, changes or removes an external dependency

References
==========
https://theretroweb.com/chip/documentation/virge-dx-gx-6a9ac4820d449118600093.pdf p. 38 - for the ViRGE/GX part