### PR TITLE
Add IBM Expanded Memory Adapter 0-8MB XMA emulation

### DIFF
--- a/src/device/ibm_xma.c
+++ b/src/device/ibm_xma.c
@@ -101,10 +101,15 @@ typedef struct xma_t {
     mem_mapping_t pf_map[XMA_PF_SLOTS]; /* per-4K EMS page-frame slots */
     mem_mapping_t ext_mapping;          /* extended memory at 1M + 384K */
 
+    uint8_t       pf_state[XMA_PF_SLOTS]; /* last programmed pf slot state (0 = off, 1 = on) */
+    uint16_t      ext_lo;                 /* last programmed ext window base TT index */
+    uint16_t      ext_hi;                 /* last programmed ext window top TT index */
+
     rom_t         bios_rom;   /* on-board 8KB init ROM */
     uint32_t      bios_base;  /* ROM window base (0 = disabled) */
     uint8_t       rom_space;  /* ROM space code from 104h bits 7-4 (1 = none, 4-15 = spaces) */
 
+    uint8_t       slot;       /* MCA slot index assigned by mca_add() */
     uint8_t       pos_regs[8];
 } xma_t;
 
@@ -549,7 +554,14 @@ xma_mem_write(uint32_t addr, uint8_t val, void *priv)
 
 /* Enable the per-4K page-frame slots whose TT entry is active. In
    virtual mode a slot is claimed if any of the 16 banks maps it; the
-   actual access is still gated by the currently selected bank. */
+   actual access is still gated by the currently selected bank.
+
+   The init ROM and the drivers program the translate table in bulk
+   loops (thousands of entries per run), and each of those writes
+   lands here. mem_mapping_enable/disable() each recalculate the whole
+   memory map and flush the TLB, so a slot is only touched when its
+   state actually changed - that keeps a table-fill pass from costing
+   one full recalculation per entry. */
 static void
 xma_pf_update(xma_t *dev)
 {
@@ -564,6 +576,10 @@ xma_pf_update(xma_t *dev)
         } else
             en = xma_tt_enabled(dev, i);
 
+        if (en == dev->pf_state[k])
+            continue;
+
+        dev->pf_state[k] = en;
         if (en)
             mem_mapping_enable(&dev->pf_map[k]);
         else
@@ -576,7 +592,14 @@ xma_pf_update(xma_t *dev)
    home.  The init ROM repositions the card's memory by rewriting the
    translate table (at POST the blocks live at the default 1M+384K home
    only until the ROM moves them above the system memory), so the
-   window must follow the table instead of being fixed at xma_init. */
+   window must follow the table instead of being fixed at xma_init.
+
+   During the ROM's bulk table fill the window changes only once per
+   reposition, so the last computed (lo, hi) pair is kept and the
+   mapping is only rewritten when the window actually moved -
+   mem_mapping_set_addr() recalculates the whole memory map and would
+   otherwise repeat that cost for every one of the thousands of writes
+   that make up a single window. */
 static void
 xma_map_update(xma_t *dev)
 {
@@ -590,6 +613,12 @@ xma_map_update(xma_t *dev)
             hi = i;
         }
     }
+
+    if ((lo == dev->ext_lo) && (hi == dev->ext_hi))
+        return; /* window unchanged - mapping is already correct */
+
+    dev->ext_lo = lo;
+    dev->ext_hi = hi;
 
     if (lo <= hi) {
         mem_mapping_set_addr(&dev->ext_mapping,
@@ -982,7 +1011,10 @@ xma_init(const device_t *info)
     mca_add(xma_mca_read, xma_mca_write, xma_mca_feedb, xma_reset, dev);
 
     /* Extended-memory home at 1M+384K; xma_mem_read/write() gate access
-       through the TT so inhibited entries simply read empty. */
+       through the TT so inhibited entries simply read empty. The mapping 
+       starts out disabled - the default all-inhibited table leaves no 
+       window - and xma_map_update() sizes and enables it as the init
+       ROM programs the table. */
     mem_mapping_add(&dev->ext_mapping,
                     XMA_EXT_BASE,
                     (uint32_t) dev->blocks << XMA_BLOCK_SHIFT,
@@ -995,6 +1027,7 @@ xma_init(const device_t *info)
                     NULL,
                     0,
                     dev);
+    mem_mapping_disable(&dev->ext_mapping);
 
     /* EMS page frame slots (A0000h-E0000h), one 4K mapping per slot.
        Only slots whose TT entry is active get enabled, so the card

--- a/src/device/ibm_xma.c
+++ b/src/device/ibm_xma.c
@@ -6,8 +6,9 @@
  *
  *          This file is part of the 86Box distribution.
  *
- *          Emulation of the IBM Memory Expansion Option (MXO, a.k.a.
- *          "Holster") memory card for PS/2 Model 50 and 60 systems.
+ *          Implementation of the IBM PS/2 Memory Expansion Option (MXO, 
+ *          a.k.a. "Holster"), and the 1-8MB 286 Memory Expansion Adapter
+ *          (XMA/A, a.k.a. "Catskill") with its 2-8MB 286/386SX variant.
  *
  *          NOTE: The register and translate table layout are from MS-DOS 4.0
  *                XMA2EMS.ASM device driver source. For copyright information, 
@@ -27,13 +28,87 @@
 #define HAVE_STDARG_H
 #include <86box/86box.h>
 #include <86box/device.h>
+#include <86box/io.h>
 #include <86box/mca.h>
 #include <86box/mem.h>
+#include <86box/rom.h>
 #include <86box/plat_unused.h>
+
+/* On-board 8KB init ROM. Its window is selected by the reference disk through
+   POS 104h bits 7-4 as listed by @F7FE.ADF: code 4-15 map ROM to the twelve 8KB
+   spaces C8000h-DFFFFh, code 1 means the ROM is not mapped. The 2-8MB variant
+   uses the same register logic with a different init ROM (57F2905, V3). */
+#define XMA_BIOS_FILE_F7FE   "roms/memcard/ibm_xma/11F8060.BIN"
+#define XMA_BIOS_FILE_F7F7   "roms/memcard/ibm_xma/57F2905.BIN"
+#define XMA_BIOS_SIZE        0x2000U
+#define XMA_BIOS_MASK        (XMA_BIOS_SIZE - 1)
 
 /* MXO translate table: 1K x 8-bit entries, 16 KB blocks. */
 #define MXO_TT_ENTRIES      1024U
 #define MXO_BLOCK_SHIFT     14
+
+/* XMA/A translate table: 4K entries holding 12-bit entries, 4 KB blocks. */
+#define XMA_TT_ENTRIES      4096U
+#define XMA_BLOCK_SHIFT     12
+
+/* EMS page-frame scan window (A0000h-E0000h), one mapping per slot. */
+#define MXO_PF_SCAN_FIRST   (0xa0000U >> MXO_BLOCK_SHIFT)   /* 0x28 */
+#define MXO_PF_SCAN_LAST    (0xe0000U >> MXO_BLOCK_SHIFT)   /* 0x38 */
+#define MXO_PF_SLOTS        (MXO_PF_SCAN_LAST - MXO_PF_SCAN_FIRST) /* per-16K page-frame slots */
+
+#define XMA_PF_SCAN_FIRST   (0xa0000U >> XMA_BLOCK_SHIFT)   /* 0xA0 */
+#define XMA_PF_SCAN_LAST    (0xe0000U >> XMA_BLOCK_SHIFT)   /* 0xE0 */
+#define XMA_PF_SLOTS        (XMA_PF_SCAN_LAST - XMA_PF_SCAN_FIRST) /* per-4K page-frame slots */
+
+/* Extended-memory home; follows the planar memory size. */
+#define MXO_EXT_BASE        0x160000U /* 1M + 384K: default card home */
+#define MXO_EXT_FIRST_TT    (MXO_EXT_BASE >> MXO_BLOCK_SHIFT) /* 0x58 */
+
+#define XMA_EXT_BASE        0x160000U /* 1M + 384K: default card home */
+#define XMA_EXT_FIRST_TT    (XMA_EXT_BASE >> XMA_BLOCK_SHIFT) /* 0x160 */
+
+typedef struct ram_t {
+    uint32_t  size_kb;  /* RAM size in KB */
+    uint8_t  *ptr;      /* card RAM buffer */
+} ram_t;
+
+typedef struct mxo_t {
+    ram_t         ram;     /* fitted card memory */
+    uint32_t      blocks;  /* usable capacity in blocks */
+
+    uint16_t      tt_ptr;  /* 10-bit translate table pointer */
+    uint8_t       tt[MXO_TT_ENTRIES];
+
+    mem_mapping_t pf_map[MXO_PF_SLOTS]; /* per-16K EMS page-frame slots */
+    mem_mapping_t ext_mapping;          /* extended memory at 1M + 384K */
+
+    uint8_t       pos_regs[8];
+} mxo_t;
+
+typedef struct xma_t {
+    ram_t         ram;     /* fitted card memory */
+    uint32_t      blocks;  /* usable capacity in 4K blocks */
+
+    uint16_t      tt[XMA_TT_ENTRIES];
+    uint16_t      tt_ptr;  /* 12-bit translate table pointer */
+    uint8_t       idreg;   /* selected bank/task (virtual mode) */
+    uint8_t       mode;    /* 31A7 mode register */
+    uint8_t       tt_hi;   /* pending TT data high byte */
+    uint8_t       tt_lo;   /* pending TT data low byte */
+    uint8_t       tt_hv;   /* high byte latched */
+    uint8_t       tt_lv;   /* low byte latched */
+
+    mem_mapping_t pf_map[XMA_PF_SLOTS]; /* per-4K EMS page-frame slots */
+    mem_mapping_t ext_mapping;          /* extended memory at 1M + 384K */
+
+    rom_t         bios_rom;   /* on-board 8KB init ROM */
+    uint32_t      bios_base;  /* ROM window base (0 = disabled) */
+    uint8_t       rom_space;  /* ROM space code from 104h bits 7-4 (1 = none, 4-15 = spaces) */
+
+    uint8_t       pos_regs[8];
+} xma_t;
+
+/* MXO entries: bit 7 = mapping enabled, bits 6-0 = 16 KB block number. */
 #define MXO_BLOCK_SIZE      (1U << MXO_BLOCK_SHIFT)
 #define MXO_TT_ENABLE       0x80U   /* bit 7 set = mapping enabled */
 #define MXO_TT_BLOCK_MASK   0x7fU   /* bits 6-0 = 16 KB block number */
@@ -43,14 +118,37 @@
 #define MXO_KB_PER_BANK     512U    /* each 512 KB memory kit / bank */
 #define MXO_MAX_BANKS       (MXO_SIZE_2MB / MXO_BLOCK_SIZE / (MXO_KB_PER_BANK >> 4)) /* 4 */
 
-/* Extended-memory home; follows the planar memory size. */
-#define MXO_EXT_BASE        0x160000U /* 1M + 384K: default card home */
-#define MXO_EXT_FIRST_TT    (MXO_EXT_BASE >> MXO_BLOCK_SHIFT) /* 0x58 */
+/* XMA entries: bit 11 = no translate, bits 10-0 = 4K block pointer. */
+#define XMA_BLOCK_SIZE      (1U << XMA_BLOCK_SHIFT)
+#define XMA_TT_INHIBIT      0x0800U /* bit 11 set = no translate */
+#define XMA_TT_MASK         0x0fffU /* keep the 12-bit entry */
+#define XMA_TT_BLOCK_MASK   0x07ffU /* bits 10-0 = 4K block pointer */
 
-/* EMS page-frame scan window (A0000h-E0000h), one 16K mapping per slot. */
-#define MXO_PF_SCAN_FIRST   (0xa0000U >> MXO_BLOCK_SHIFT)   /* 0x28 */
-#define MXO_PF_SCAN_LAST    (0xe0000U >> MXO_BLOCK_SHIFT)   /* 0x38 */
-#define MXO_PF_SLOTS        (MXO_PF_SCAN_LAST - MXO_PF_SCAN_FIRST) /* per-16K page-frame slots */
+/* Memory capacity, fitted as half-meg kits across up to four banks. */
+#define XMA_KB_PER_HALFM    512U    /* half-meg in KB */
+#define XMA_MAX_BLOCKS      2048U   /* 8 MB in 4K blocks */
+#define XMA_MAX_BANKS       4U      /* banks 1-4, 2 MB each max */
+#define XMA_ROM_SLEEP       0x20U   /* 102h bit 5 */
+
+/* Virtual (banked) mode registers, a fixed 16-bit window shared by the
+   XMA family (used for XMA/A when the WSP INDXMAA.SYS driver banks it):
+   31A0h word  TT pointer (bank in bits 11-8, 4K block in bits 7-0)
+   31A2h word  TT data (no pointer advance)
+   31A4h word  TT data with auto-increment of the pointer
+   31A6h       bank/task ID register
+   31A7h       mode register (bit 1 = virtual mode)
+   31A8h       DMA capture register (diagnostics only)
+   In virtual mode the 4096-entry TT is addressed as 16 banks x 256
+   4K entries, so each bank owns a 1 MB window; CPU accesses to the
+   first megabyte are translated through the currently selected bank. */
+#define XMA_TT_POINTER       0x31A0U
+#define XMA_TT_DATA          0x31A2U
+#define XMA_TT_AIDATA        0x31A4U
+#define XMA_ID_REG           0x31A6U
+#define XMA_MODE_REG         0x31A7U
+#define XMA_DMA_CAPT         0x31A8U
+#define XMA_VIRT_BIT         0x02U /* 31A7 bit 1 = banked (virtual) mode */
+#define XMA_TASKS            16U   /* bank/task contexts, 256 x 4K each */
 
 #ifdef ENABLE_XMA_LOG
 int xma_do_log = ENABLE_XMA_LOG;
@@ -70,24 +168,29 @@ xma_log(const char *fmt, ...)
 #    define xma_log(fmt, ...)
 #endif
 
-/* Card RAM buffer and its fitted size. */
-typedef struct ram_t {
-    uint32_t  size_kb;  /* RAM size in KB */
-    uint8_t  *ptr;      /* card RAM buffer */
-} ram_t;
-
-typedef struct mxo_t {
-    ram_t         ram;     /* fitted card memory */
-    uint32_t      blocks;  /* usable capacity in blocks */
-
-    uint16_t      tt_ptr;  /* 10-bit translate table pointer */
-    uint8_t       tt[MXO_TT_ENTRIES];
-
-    mem_mapping_t pf_map[MXO_PF_SLOTS]; /* per-16K EMS page-frame slots */
-    mem_mapping_t ext_mapping;          /* extended memory at 1M + 384K */
-
-    uint8_t       pos_regs[8];
-} mxo_t;
+/*
+ * MXO - IBM Memory Expansion Option (a.k.a. "Holster"), 512 KB - 2 MB
+ * for the PS/2 Model 50/60.
+ *
+ * The MXO uses a 1K-entry translate table holding 8-bit entries that
+ * select 16 KB blocks of card memory; bit 7 of an entry enables it.
+ * XMA2EMS.SYS drives the card through the real-mode 10X register set:
+ *
+ *   100h/101h  card ID (FE/FE, read-only)
+ *   102h       control register: bit 0 = awake/enable, bits 1-7 encode
+ *              which 512 KB banks are fitted
+ *   103h       translate table data: a write enters the byte selected
+ *              by the TT pointer
+ *   105h       channel check / bank presence (read-only)
+ *   106h/107h  translate table pointer (low/high byte)
+ *
+ * On reset the table maps the fitted memory identity-style at 1M + 384K
+ * (extended-memory home); the EMS page-frame slots A0000h-E0000h can be
+ * re-pointed at any 16 KB block of the card.
+ *
+ * The register and translate table layout follow the MS-DOS 4.0 XMA2EMS 
+ * device driver source (XMA2EMS.ASM / PS2_5060.INC).
+ */
 
 /* Translate table entry check: enabled and a valid block number. */
 static uint8_t
@@ -353,13 +456,623 @@ mxo_close(void *priv)
     free(dev);
 }
 
+/*
+ * XMA/A - IBM Expanded Memory Adapter, 0-8 MB XMA (a.k.a. "Catskill").
+ *
+ * The XMA/A uses a 4K-entry translate table holding 12-bit entries for
+ * 4 KB blocks.  On a PS/2 Model 50/60 the XMA2EMS.SYS driver drives the
+ * card through the real-mode 10X register set:
+ *
+ *   100h/101h  card ID (FE/F7 or F7/F7, read-only)
+ *   102h       control register: bits 7-6 = bank 4 descriptor, bit 5 =
+ *              ROM sleep (the driver clears bit 5 to put the init ROM to
+ *              sleep before touching the TT data high byte at 104h)
+ *   103h/104h  translate table data (low/high byte): the two accesses
+ *              latch one 12-bit entry which is written on the second
+ *              access, after which the TT pointer auto-increments
+ *   105h       config register: bits 5-4/3-2/1-0 = banks 3/2/1, upper
+ *              two bits are channel check (ignored for sizing)
+ *   106h/107h  translate table pointer (low/high byte)
+ *
+ * Each two-bit bank descriptor codes the two SIPs in that bank:
+ * '11' no memory, '10' 256K, '01' 512K, '00' 1M SIPs.  Flipping the
+ * descriptor gives the bank size in half-megabytes (128 x 4K blocks
+ * each), with '00' meaning 4 half-megs instead of 3.
+ *
+ * The register and translate table layout follow the MS-DOS 4.0 XMA2EMS 
+ * device driver source (XMA2EMS.ASM / PS2_5060.INC).
+ */
+
+/* Translate table entry check: not inhibited and a valid block number. */
+static uint8_t
+xma_tt_enabled(const xma_t *dev, uint16_t idx)
+{
+    uint16_t entry;
+
+    if (idx >= XMA_TT_ENTRIES)
+        return 0;
+
+    entry = dev->tt[idx];
+    return (!(entry & XMA_TT_INHIBIT) && ((entry & XMA_TT_BLOCK_MASK) < dev->blocks));
+}
+
+/* CPU address to TT index.  In real mode the table is addressed
+   linearly over the whole 16 MB; in virtual (banked) mode accesses to
+   the first megabyte go through the selected bank's 256-entry window
+   ((bank << 8) | block), matching how XMA2EMS.SYS writes the table. */
+static uint16_t
+xma_tt_index(const xma_t *dev, uint32_t addr)
+{
+    uint16_t idx = (uint16_t) (addr >> XMA_BLOCK_SHIFT);
+
+    if ((dev->mode & XMA_VIRT_BIT) && (idx < 256))
+        return (uint16_t) ((dev->idreg << 8) | idx);
+
+    return idx;
+}
+
+/* TT-gated access: reads/writes only reach card RAM if the TT entry
+   covering the address is enabled and points to a valid block. */
+static uint8_t
+xma_mem_read(uint32_t addr, void *priv)
+{
+    xma_t *dev = (xma_t *) priv;
+    uint16_t idx  = xma_tt_index(dev, addr);
+    uint16_t entry;
+
+    if (idx >= XMA_TT_ENTRIES)
+        return 0xff;
+
+    entry = dev->tt[idx];
+    if ((entry & XMA_TT_INHIBIT) || ((entry & XMA_TT_BLOCK_MASK) >= dev->blocks))
+        return 0xff;
+
+    return dev->ram.ptr[((uint32_t) (entry & XMA_TT_BLOCK_MASK) << XMA_BLOCK_SHIFT) + (addr & (XMA_BLOCK_SIZE - 1))];
+}
+
+static void
+xma_mem_write(uint32_t addr, uint8_t val, void *priv)
+{
+    xma_t *dev = (xma_t *) priv;
+    uint16_t idx  = xma_tt_index(dev, addr);
+    uint16_t entry;
+
+    if (idx >= XMA_TT_ENTRIES)
+        return;
+
+    entry = dev->tt[idx];
+    if ((entry & XMA_TT_INHIBIT) || ((entry & XMA_TT_BLOCK_MASK) >= dev->blocks))
+        return;
+
+    dev->ram.ptr[((uint32_t) (entry & XMA_TT_BLOCK_MASK) << XMA_BLOCK_SHIFT) + (addr & (XMA_BLOCK_SIZE - 1))] = val;
+}
+
+/* Enable the per-4K page-frame slots whose TT entry is active. In
+   virtual mode a slot is claimed if any of the 16 banks maps it; the
+   actual access is still gated by the currently selected bank. */
+static void
+xma_pf_update(xma_t *dev)
+{
+    for (uint16_t i = XMA_PF_SCAN_FIRST; i < XMA_PF_SCAN_LAST; i++) {
+        uint8_t k  = i - XMA_PF_SCAN_FIRST;
+        uint8_t en;
+
+        if (dev->mode & XMA_VIRT_BIT) {
+            en = 0;
+            for (uint16_t t = 0; t < XMA_TASKS && !en; t++)
+                en = xma_tt_enabled(dev, (uint16_t) ((t << 8) | i));
+        } else
+            en = xma_tt_enabled(dev, i);
+
+        if (en)
+            mem_mapping_enable(&dev->pf_map[k]);
+        else
+            mem_mapping_disable(&dev->pf_map[k]);
+    }
+}
+
+/* Re-map the linear extended-memory window so it covers exactly the
+   enabled (non-inhibited) TT entries at or above the card's power-on
+   home.  The init ROM repositions the card's memory by rewriting the
+   translate table (at POST the blocks live at the default 1M+384K home
+   only until the ROM moves them above the system memory), so the
+   window must follow the table instead of being fixed at xma_init. */
+static void
+xma_map_update(xma_t *dev)
+{
+    uint16_t lo = XMA_TT_ENTRIES;
+    uint16_t hi = 0;
+
+    for (uint16_t i = XMA_EXT_FIRST_TT; i < XMA_TT_ENTRIES; i++) {
+        if (xma_tt_enabled(dev, i)) {
+            if (lo == XMA_TT_ENTRIES)
+                lo = i;
+            hi = i;
+        }
+    }
+
+    if (lo <= hi) {
+        mem_mapping_set_addr(&dev->ext_mapping,
+                             (uint32_t) lo << XMA_BLOCK_SHIFT,
+                             ((uint32_t) (hi - lo + 1)) << XMA_BLOCK_SHIFT);
+        mem_mapping_enable(&dev->ext_mapping);
+        xma_log("xma_map_update: ext window %05X-%05X\n",
+                (uint32_t) lo << XMA_BLOCK_SHIFT,
+                ((uint32_t) (hi + 1)) << XMA_BLOCK_SHIFT);
+    } else {
+        mem_mapping_disable(&dev->ext_mapping);
+        xma_log("xma_map_update: ext window disabled\n");
+    }
+}
+
+/* Commit a full 12-bit TT entry at the pointer and advance it. */
+static void
+xma_tt_commit(xma_t *dev, uint16_t entry)
+{
+    uint16_t idx = dev->tt_ptr & (XMA_TT_ENTRIES - 1);
+
+    dev->tt[idx] = entry & XMA_TT_MASK;
+    dev->tt_ptr  = (uint16_t) ((dev->tt_ptr + 1) & (XMA_TT_ENTRIES - 1));
+    xma_pf_update(dev);
+    xma_map_update(dev);
+}
+
+static void xma_bios_update(xma_t *dev);
+
+static uint8_t
+xma_mca_read(const uint16_t port, void *priv)
+{
+    const xma_t *dev = (const xma_t *) priv;
+    uint8_t      ret;
+
+    switch (port & 7) {
+        case 0x03: /* TT data low byte */
+            ret = (uint8_t) (dev->tt[dev->tt_ptr & (XMA_TT_ENTRIES - 1)] & 0xff);
+            break;
+        case 0x04: /* TT data high byte: low nibble = TT bits 8-11, high
+                       nibble = on-board ROM space code (ADF pos[2]) */
+            ret = (uint8_t) (((dev->rom_space & 0x0f) << 4) |
+                             ((dev->tt[dev->tt_ptr & (XMA_TT_ENTRIES - 1)] >> 8) & 0x0f));
+            break;
+        case 0x06: /* TT pointer low byte */
+            ret = (uint8_t) dev->tt_ptr;
+            break;
+        case 0x07: /* TT pointer high byte */
+            ret = (uint8_t) (dev->tt_ptr >> 8);
+            break;
+        default:   /* 100h/101h ID, 102h control, 105h config */
+            ret = dev->pos_regs[port & 7];
+            break;
+    }
+
+    xma_log("xma_mca_read: port=%04x ret=%02x\n", port, ret);
+    return ret;
+}
+
+static void
+xma_mca_write(const uint16_t port, uint8_t val, void *priv)
+{
+    xma_t *dev = (xma_t *) priv;
+
+    /* Card ID and config registers are read-only; the control register
+       (102h) is written by the driver only to clear the ROM-sleep bit. */
+    if ((port < 0x102) || (port == 0x105))
+        return;
+
+    xma_log("xma_mca_write: port=%04x val=%02x\n", port, val);
+
+    switch (port & 7) {
+        case 0x02: /* control register: bits 7-6 (bank 4 descriptor) are
+                       read-only hardware, the rest is writable (bit 2 is
+                       the module/enable bit the init ROM toggles) */
+            dev->pos_regs[2] = (uint8_t) ((dev->pos_regs[2] & 0xc0) | (val & 0x3f));
+            break;
+
+        case 0x03: /* TT data low byte: finish an entry if high is pending */
+            if (dev->tt_hv) {
+                xma_tt_commit(dev, (uint16_t) ((dev->tt_hi << 8) | val));
+                dev->tt_hv = 0;
+            } else {
+                dev->tt_lo = val;
+                dev->tt_lv = 1;
+            }
+            break;
+
+        case 0x04: /* TT data high byte: finish an entry if low is pending.
+                       The upper nibble also carries the on-board ROM space
+                       code (ADF pos[2]): 1 = none, 4-15 = spaces 1-12, so
+                       the reference disk repositions the ROM this way. */
+            if ((val >> 4) != 0) {
+                dev->rom_space = (uint8_t) (val >> 4);
+                xma_bios_update(dev);
+            }
+            if (dev->tt_lv) {
+                xma_tt_commit(dev, (uint16_t) ((val << 8) | dev->tt_lo));
+                dev->tt_lv = 0;
+            } else {
+                dev->tt_hi = val;
+                dev->tt_hv = 1;
+            }
+            break;
+
+        case 0x06: /* TT pointer low byte */
+            dev->tt_ptr = (uint16_t) ((dev->tt_ptr & 0xff00) | val);
+            break;
+
+        case 0x07: /* TT pointer high byte */
+            dev->tt_ptr = (uint16_t) ((dev->tt_ptr & 0x00ff) | (val << 8));
+            break;
+    }
+}
+
+static uint8_t
+xma_mca_feedb(void *priv)
+{
+    const xma_t *dev = (const xma_t *) priv;
+
+    return (dev->pos_regs[2] & 1);
+}
+
+/* Virtual (banked) mode ports, 0x31A0h-0x31A8h */
+static uint16_t
+xma_tt_data16(const xma_t *dev)
+{
+    return (dev->tt[dev->tt_ptr & (XMA_TT_ENTRIES - 1)] & XMA_TT_MASK);
+}
+
+static uint8_t
+xma_io_readb(const uint16_t port, void *priv)
+{
+    xma_t    *dev = (xma_t *) priv;
+    uint16_t off = port & 0x000f;
+    uint8_t  ret;
+
+    switch (off) {
+        case 0x00: /* TT pointer low byte */
+            return (uint8_t) dev->tt_ptr;
+        case 0x01: /* TT pointer high byte (bank + block top) */
+            return (uint8_t) (dev->tt_ptr >> 8);
+        case 0x02: /* TT data low byte */
+            return (uint8_t) xma_tt_data16(dev);
+        case 0x03: /* TT data high byte */
+            return (uint8_t) (xma_tt_data16(dev) >> 8);
+        case 0x04: /* auto-increment data low byte (word access advances) */
+            return (uint8_t) xma_tt_data16(dev);
+        case 0x05: /* auto-increment data high byte: reading it advances */
+            ret = (uint8_t) (xma_tt_data16(dev) >> 8);
+            dev->tt_ptr = (uint16_t) ((dev->tt_ptr + 1) & (XMA_TT_ENTRIES - 1));
+            return ret;
+        case 0x06: /* bank/task ID */
+            return dev->idreg;
+        case 0x07: /* mode register */
+            return dev->mode;
+        case 0x08: /* DMA capture (diagnostics only) */
+            return 0xff;
+    }
+
+    return 0xff;
+}
+
+static uint16_t
+xma_io_readw(const uint16_t port, void *priv)
+{
+    xma_t    *dev = (xma_t *) priv;
+    uint16_t data;
+
+    switch (port) {
+        case XMA_TT_POINTER:
+            return dev->tt_ptr;
+        case XMA_TT_DATA:
+            return xma_tt_data16(dev);
+        case XMA_TT_AIDATA:
+            data = xma_tt_data16(dev);
+            dev->tt_ptr = (uint16_t) ((dev->tt_ptr + 1) & (XMA_TT_ENTRIES - 1));
+            return data;
+        case XMA_ID_REG:
+            return dev->idreg;
+        case XMA_MODE_REG:
+            return dev->mode;
+        case XMA_DMA_CAPT:
+            return 0xffff;
+    }
+
+    return 0xffff;
+}
+
+static void
+xma_io_writeb(const uint16_t port, uint8_t val, void *priv)
+{
+    xma_t    *dev = (xma_t *) priv;
+    uint16_t off = port & 0x000f;
+
+    switch (off) {
+        case 0x00: /* TT pointer low byte */
+            dev->tt_ptr = (uint16_t) ((dev->tt_ptr & 0xff00) | val);
+            break;
+        case 0x01: /* TT pointer high byte */
+            dev->tt_ptr = (uint16_t) ((dev->tt_ptr & 0x00ff) | ((val & 0x0f) << 8));
+            break;
+        case 0x02: /* TT data low byte */
+            dev->tt[dev->tt_ptr & (XMA_TT_ENTRIES - 1)] =
+                (uint16_t) ((dev->tt[dev->tt_ptr & (XMA_TT_ENTRIES - 1)] & 0xf00) | val);
+            xma_pf_update(dev);
+            xma_map_update(dev);
+            break;
+        case 0x03: /* TT data high byte */
+            dev->tt[dev->tt_ptr & (XMA_TT_ENTRIES - 1)] =
+                (uint16_t) (((uint16_t) (val & 0x0f) << 8) | (dev->tt[dev->tt_ptr & (XMA_TT_ENTRIES - 1)] & 0x0ff));
+            xma_pf_update(dev);
+            xma_map_update(dev);
+            break;
+        case 0x04: /* auto-increment data low byte */
+            dev->tt[dev->tt_ptr & (XMA_TT_ENTRIES - 1)] =
+                (uint16_t) ((dev->tt[dev->tt_ptr & (XMA_TT_ENTRIES - 1)] & 0xf00) | val);
+            xma_pf_update(dev);
+            xma_map_update(dev);
+            break;
+        case 0x05: /* auto-increment data high byte: write advances */
+            dev->tt[dev->tt_ptr & (XMA_TT_ENTRIES - 1)] =
+                (uint16_t) (((uint16_t) (val & 0x0f) << 8) | (dev->tt[dev->tt_ptr & (XMA_TT_ENTRIES - 1)] & 0x0ff));
+            dev->tt_ptr = (uint16_t) ((dev->tt_ptr + 1) & (XMA_TT_ENTRIES - 1));
+            xma_pf_update(dev);
+            xma_map_update(dev);
+            break;
+        case 0x06: /* bank/task ID */
+            dev->idreg = val & 0x0f;
+            xma_pf_update(dev);
+            break;
+        case 0x07: /* mode register */
+            dev->mode = val & 0x03;
+            xma_pf_update(dev);
+            break;
+        case 0x08: /* DMA capture: no effect */
+            break;
+    }
+}
+
+static void
+xma_io_writew(const uint16_t port, uint16_t val, void *priv)
+{
+    xma_t *dev = (xma_t *) priv;
+
+    switch (port) {
+        case XMA_TT_POINTER:
+            dev->tt_ptr = val & (XMA_TT_ENTRIES - 1);
+            break;
+        case XMA_TT_DATA:
+            dev->tt[dev->tt_ptr & (XMA_TT_ENTRIES - 1)] = val & XMA_TT_MASK;
+            xma_pf_update(dev);
+            xma_map_update(dev);
+            break;
+        case XMA_TT_AIDATA:
+            dev->tt[dev->tt_ptr & (XMA_TT_ENTRIES - 1)] = val & XMA_TT_MASK;
+            dev->tt_ptr = (uint16_t) ((dev->tt_ptr + 1) & (XMA_TT_ENTRIES - 1));
+            xma_pf_update(dev);
+            xma_map_update(dev);
+            break;
+        case XMA_ID_REG:
+            dev->idreg = val & 0x0f;
+            xma_pf_update(dev);
+            break;
+        case XMA_MODE_REG:
+            dev->mode = val & 0x03;
+            xma_pf_update(dev);
+            break;
+    }
+}
+
+static uint8_t
+xma_bios_read(const uint32_t addr, void *priv)
+{
+    xma_t *dev = (xma_t *) priv;
+
+    return rom_read(addr, &dev->bios_rom);
+}
+
+static uint16_t
+xma_bios_readw(const uint32_t addr, void *priv)
+{
+    xma_t *dev = (xma_t *) priv;
+
+    return rom_readw(addr, &dev->bios_rom);
+}
+
+static uint32_t
+xma_bios_readl(const uint32_t addr, void *priv)
+{
+    xma_t *dev = (xma_t *) priv;
+
+    return rom_readl(addr, &dev->bios_rom);
+}
+
+/* Put the init ROM at the window selected by the ROM space code
+   (4-15 = C8000h + (code-4)*2000h; anything else disables it). */
+static void
+xma_bios_update(xma_t *dev)
+{
+    if ((dev->rom_space >= 4) && (dev->rom_space <= 15) && dev->bios_rom.rom) {
+        dev->bios_base = 0xc8000U + ((uint32_t) (dev->rom_space - 4) << 13);
+        mem_mapping_enable(&dev->bios_rom.mapping);
+        mem_mapping_set_addr(&dev->bios_rom.mapping, dev->bios_base, XMA_BIOS_SIZE);
+        xma_log("xma_bios_update: ROM space %u -> %05X\n", dev->rom_space, dev->bios_base);
+    } else {
+        dev->bios_base = 0;
+        mem_mapping_disable(&dev->bios_rom.mapping);
+        xma_log("xma_bios_update: ROM disabled\n");
+    }
+}
+
+static void
+xma_reset(void *priv)
+{
+    xma_t *dev = (xma_t *) priv;
+
+    /* A reset takes the card back to the power-on state: the translate
+       table is cleared, so the card presents no memory until its init
+       ROM programs it again. This keeps the adapter invisible to the
+       POST memory count at the start of every boot. */
+    for (uint32_t i = 0; i < XMA_TT_ENTRIES; i++)
+        dev->tt[i] = XMA_TT_INHIBIT;
+    dev->tt_ptr = 0;
+    dev->tt_hv  = 0;
+    dev->tt_lv  = 0;
+    dev->idreg  = 0;
+    dev->mode  &= ~XMA_VIRT_BIT;
+
+    xma_pf_update(dev);
+    xma_map_update(dev);
+}
+
+static void *
+xma_init(const device_t *info)
+{
+    xma_t *dev;
+    int   size_kb;
+    uint32_t banks;
+    const char *bios_file = (info->local == 1) ? XMA_BIOS_FILE_F7F7 : XMA_BIOS_FILE_F7FE;
+
+    dev = (xma_t *) calloc(1, sizeof(xma_t));
+
+    /* Memory size comes from the config dialog: 1 - 8 MB in 1 MB steps.
+       Each 1 MB step is two half-megs, so every bank stays on a whole
+       MB boundary and the sizing math below always divides evenly. */
+    size_kb = device_get_config_int("size");
+
+    dev->ram.size_kb = (uint32_t) size_kb;
+    dev->ram.ptr     = (uint8_t *) calloc((size_t) size_kb << 10, 1);
+    dev->blocks      = (uint32_t) size_kb >> 2; /* KB -> 4 KB blocks */
+
+    /* POS registers: 1-8MB XMA/A (local 0) is FEF7, the 2-8MB 286/386SX
+       variant (local 1) is F7F7 (100h=F7, 101h=F7). */
+    dev->pos_regs[0] = (info->local == 1) ? 0xf7 : 0xfe;
+    dev->pos_regs[1] = 0xf7;
+
+    /* Encode the fitted memory into the config (105h, banks 1-3) and
+       control (102h bits 7-6, bank 4) registers: split the total size
+       in half-megs across the four banks, each bank taking 0, 2 or 4
+       half-megs (a whole number of MB).  A '00' descriptor reads back
+       as 4 half-megs after the driver flips it. */
+    banks = (uint32_t) size_kb / XMA_KB_PER_HALFM;
+    {
+        uint8_t hm[XMA_MAX_BANKS] = { 0, 0, 0, 0 };
+        uint8_t desc[XMA_MAX_BANKS];
+
+        for (uint32_t b = 0; b < XMA_MAX_BANKS && banks; b++) {
+            uint32_t t = (banks > 4) ? 4 : banks;
+
+            hm[b]    = (uint8_t) t;
+            banks   -= t;
+        }
+        for (uint32_t b = 0; b < XMA_MAX_BANKS; b++)
+            desc[b] = (hm[b] == 0) ? 3 : ((hm[b] == 2) ? 1 : 0);
+
+        dev->pos_regs[2] = (uint8_t) ((desc[3] << 6) | XMA_ROM_SLEEP);
+        /* 105h: bank 1-3 descriptors in bits 5-0; bits 7-6 read as 1s
+           (channel-check clear), which the init ROM checks after writing. */
+        dev->pos_regs[5] = (uint8_t) (0xc0 | desc[0] | (desc[1] << 2) | (desc[2] << 4));
+    }
+
+    /* Default TT: every entry inhibited.  The card presents no memory
+       to the system until its init ROM programs the translate table, so
+       the POST memory count does not see (and mis-size) the adapter. */
+    for (uint32_t i = 0; i < XMA_TT_ENTRIES; i++)
+        dev->tt[i] = XMA_TT_INHIBIT;
+
+    /* Register the card on the MCA bus. */
+    mca_add(xma_mca_read, xma_mca_write, xma_mca_feedb, xma_reset, dev);
+
+    /* Extended-memory home at 1M+384K; xma_mem_read/write() gate access
+       through the TT so inhibited entries simply read empty. */
+    mem_mapping_add(&dev->ext_mapping,
+                    XMA_EXT_BASE,
+                    (uint32_t) dev->blocks << XMA_BLOCK_SHIFT,
+                    xma_mem_read,
+                    NULL,
+                    NULL,
+                    xma_mem_write,
+                    NULL,
+                    NULL,
+                    NULL,
+                    0,
+                    dev);
+
+    /* EMS page frame slots (A0000h-E0000h), one 4K mapping per slot.
+       Only slots whose TT entry is active get enabled, so the card
+       never claims an address it has not mapped. */
+    for (uint8_t k = 0; k < XMA_PF_SLOTS; k++) {
+        mem_mapping_add(&dev->pf_map[k],
+                        (uint32_t) (XMA_PF_SCAN_FIRST + k) << XMA_BLOCK_SHIFT,
+                        XMA_BLOCK_SIZE,
+                        xma_mem_read,
+                        NULL,
+                        NULL,
+                        xma_mem_write,
+                        NULL,
+                        NULL,
+                        NULL,
+                        0,
+                        dev);
+        mem_mapping_disable(&dev->pf_map[k]);
+    }
+    xma_pf_update(dev);
+    xma_map_update(dev); /* size the linear window to the default TT map */
+
+    /* Load the 8KB init ROM.  It starts out at Space 1 (C8000h); the
+       reference disk can move it through POS 104h bits 7-4 later. */
+    dev->rom_space = 4;
+    rom_init(&dev->bios_rom, bios_file,
+             0xc8000U, XMA_BIOS_SIZE, XMA_BIOS_MASK, 0, MEM_MAPPING_EXTERNAL);
+    mem_mapping_set_handler(&dev->bios_rom.mapping,
+                            xma_bios_read, xma_bios_readw, xma_bios_readl,
+                            NULL, NULL, NULL);
+    mem_mapping_set_p(&dev->bios_rom.mapping, dev);
+    mem_mapping_set_exec(&dev->bios_rom.mapping, dev->bios_rom.rom);
+    xma_log("xma_init: on-board init ROM loaded from %s\n", bios_file);
+    xma_bios_update(dev);
+
+    /* Register the fixed virtual-mode window (0x31A0h-0x31A8h).  Only a
+       single card can be used in virtual mode, so a second XMA/A in the
+       same machine simply takes over the same window, like the hardware. */
+    io_sethandler(XMA_TT_POINTER, 0x000a,
+                  xma_io_readb, xma_io_readw, NULL,
+                  xma_io_writeb, xma_io_writew, NULL,
+                  dev);
+
+    return dev;
+}
+
+static void
+xma_close(void *priv)
+{
+    xma_t *dev = (xma_t *) priv;
+
+    io_removehandler(XMA_TT_POINTER, 0x000a,
+                     xma_io_readb, xma_io_readw, NULL,
+                     xma_io_writeb, xma_io_writew, NULL,
+                     dev);
+    free(dev->ram.ptr);
+    free(dev);
+}
+
+static int
+xma_f7fe_available(void)
+{
+    return rom_present(XMA_BIOS_FILE_F7FE);
+}
+
+static int
+xma_f7f7_available(void)
+{
+    return rom_present(XMA_BIOS_FILE_F7F7);
+}
+
 static const device_config_t ibm_xma_mca_config[] = {
     {
         .name           = "size",
         .description    = "Memory size",
         .type           = CONFIG_SPINNER,
         .default_string = NULL,
-        .default_int    = 2048,
+        .default_int    = 512,
         .file_filter    = NULL,
         .spinner        = {
             .min  = 512,
@@ -384,4 +1097,72 @@ const device_t ibm_xma_mca_2mb_device = {
     .speed_changed = NULL,
     .force_redraw  = NULL,
     .config        = ibm_xma_mca_config
+};
+
+static const device_config_t ibm_xma_mca_8mb_f7fe_config[] = {
+    {
+        .name           = "size",
+        .description    = "Memory size",
+        .type           = CONFIG_SPINNER,
+        .default_string = NULL,
+        .default_int    = 1024,
+        .file_filter    = NULL,
+        .spinner        = {
+            .min  = 1024,
+            .max  = 8192,
+            .step = 1024
+        },
+        .selection      = { { 0 } },
+        .bios           = { { 0 } }
+    },
+    { .name = "", .description = "", .type = CONFIG_END }
+};
+
+const device_t ibm_xma_mca_8mb_f7fe_device = {
+    .name          = "IBM 1-8MB 286 Memory Expansion Adapter",
+    .internal_name = "ibm_xma_mca_8mb_f7fe",
+    .flags         = DEVICE_MCA,
+    .local         = 0,
+    .init          = xma_init,
+    .close         = xma_close,
+    .reset         = NULL,
+    .available     = xma_f7fe_available,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .alias         = "IBM Expanded Memory Adapter 0-8MB XMA",
+    .config        = ibm_xma_mca_8mb_f7fe_config
+};
+
+static const device_config_t ibm_xma_mca_8mb_f7f7_config[] = {
+    {
+        .name           = "size",
+        .description    = "Memory size",
+        .type           = CONFIG_SPINNER,
+        .default_string = NULL,
+        .default_int    = 2048,
+        .file_filter    = NULL,
+        .spinner        = {
+            .min  = 2048,
+            .max  = 8192,
+            .step = 2048
+        },
+        .selection      = { { 0 } },
+        .bios           = { { 0 } }
+    },
+    { .name = "", .description = "", .type = CONFIG_END }
+};
+
+const device_t ibm_xma_mca_8mb_f7f7_device = {
+    .name          = "IBM 2-8MB Memory Expansion Adapter",
+    .internal_name = "ibm_xma_mca_8mb_f7f7",
+    .flags         = DEVICE_MCA,
+    .local         = 1,
+    .init          = xma_init,
+    .close         = xma_close,
+    .reset         = NULL,
+    .available     = xma_f7f7_available,
+    .speed_changed = NULL,
+    .force_redraw  = NULL,
+    .alias         = "IBM 2-8MB 286/386SX Memory Expansion Option",
+    .config        = ibm_xma_mca_8mb_f7f7_config
 };

--- a/src/device/ibm_xma.c
+++ b/src/device/ibm_xma.c
@@ -1051,11 +1051,16 @@ xma_init(const device_t *info)
     dev->pos_regs[0] = (info->local == 1) ? 0xf7 : 0xfe;
     dev->pos_regs[1] = 0xf7;
 
-    /* Encode the fitted memory into the config (105h, banks 1-3) and
-       control (102h bits 7-6, bank 4) registers: split the total size
-       in half-megs across the four banks, each bank taking 0, 2 or 4
-       half-megs (a whole number of MB).  A '00' descriptor reads back
-       as 4 half-megs after the driver flips it. */
+    /* Encode the fitted memory into the config (105h, banks 1-3) and control
+       (102h bits 7-6, bank 4) registers.  The two card variants have different
+       socket layouts and use different bank descriptor tables in their init ROMs:
+       - 2-8MB 286/386SX (F7F7): four SIMM sockets, one per bank, holding 1 MB or 
+         2 MB modules - descriptor '00' = 1 MB, '10' = 2 MB, '01'/'11' = empty
+         (the ROM sums the descriptors directly).
+       - 1-8MB 286 (F7FE): eight SIP sockets as four banks of SIPs, holding
+         up to 1 MB per SIP - descriptor '00' = 2 x 1 MB, '01' = 2 x 512 KB, 
+         '10' = 2 x 256 KB and '11' = empty. The ROM doubles the accumulated 
+         sum (shl 1), so '00' means 2 MB per bank. */
     banks = (uint32_t) size_kb / XMA_KB_PER_HALFM;
     {
         uint8_t hm[XMA_MAX_BANKS] = { 0, 0, 0, 0 };
@@ -1067,8 +1072,12 @@ xma_init(const device_t *info)
             hm[b]    = (uint8_t) t;
             banks   -= t;
         }
-        for (uint32_t b = 0; b < XMA_MAX_BANKS; b++)
-            desc[b] = (hm[b] == 0) ? 3 : ((hm[b] == 2) ? 1 : 0);
+        if (info->local == 1)
+            for (uint32_t b = 0; b < XMA_MAX_BANKS; b++)
+                desc[b] = (hm[b] == 0) ? 3 : ((hm[b] == 2) ? 0 : 2);
+        else
+            for (uint32_t b = 0; b < XMA_MAX_BANKS; b++)
+                desc[b] = (hm[b] == 0) ? 3 : ((hm[b] == 2) ? 1 : 0);
 
         dev->pos_regs[2] = (uint8_t) ((desc[3] << 6) | XMA_ROM_SLEEP);
         /* 105h: bank 1-3 descriptors in bits 5-0; bits 7-6 read as 1s

--- a/src/device/ibm_xma.c
+++ b/src/device/ibm_xma.c
@@ -488,6 +488,51 @@ mxo_close(void *priv)
  * device driver source (XMA2EMS.ASM / PS2_5060.INC).
  */
 
+/* The init ROMs claim 8KB windows inside C8000h-DFFFFh, the same range the
+   translate table's page-frame slots (A0000h-E0000h) can map card RAM onto.
+   On real hardware the two decodes coexist: while a TT entry covers the ROM
+   window the ROM keeps answering, and once that entry is unmapped the ROM
+   is simply reachable again. 86Box has a single flat mapping per address
+   however, so register a new mapping removes the old one, and card RAM
+   would shadow the init ROM while running its translate table self-test
+   (which writes entries covering the very window the ROM executes from).
+   Every mapped ROM window is registered and skipped by xma_pf_update()
+   to keep the card RAM from ever shadowing it. */
+static struct {
+    const xma_t *dev;
+    uint32_t     base;
+} xma_rom_windows[8];
+static uint8_t xma_rom_windows_nr;
+
+static uint8_t
+xma_addr_in_rom(uint32_t addr)
+{
+    for (uint8_t i = 0; i < xma_rom_windows_nr; i++) {
+        if ((addr >= xma_rom_windows[i].base) && (addr < (xma_rom_windows[i].base + XMA_BIOS_SIZE)))
+            return 1;
+    }
+
+    return 0;
+}
+
+static void
+xma_rom_register(const xma_t *dev, uint32_t base)
+{
+    /* Drop any previous window of this card first. */
+    for (uint8_t i = 0; i < xma_rom_windows_nr; i++) {
+        if (xma_rom_windows[i].dev == dev) {
+            xma_rom_windows[i] = xma_rom_windows[--xma_rom_windows_nr];
+            break;
+        }
+    }
+
+    if (base && (xma_rom_windows_nr < 8)) {
+        xma_rom_windows[xma_rom_windows_nr].dev  = dev;
+        xma_rom_windows[xma_rom_windows_nr].base = base;
+        xma_rom_windows_nr++;
+    }
+}
+
 /* Translate table entry check: not inhibited and a valid block number. */
 static uint8_t
 xma_tt_enabled(const xma_t *dev, uint16_t idx)
@@ -575,6 +620,13 @@ xma_pf_update(xma_t *dev)
                 en = xma_tt_enabled(dev, (uint16_t) ((t << 8) | i));
         } else
             en = xma_tt_enabled(dev, i);
+
+        /* Real hardware lets the ROM and the TT RAM coexist; 86Box cannot,
+           so a page-frame slot falling inside any card's init ROM window
+           stays unmapped and the ROM keeps executing while its own
+           self-test writes TT entries covering the window. */
+        if (en && xma_addr_in_rom((uint32_t) i << XMA_BLOCK_SHIFT))
+            en = 0;
 
         if (en == dev->pf_state[k])
             continue;
@@ -941,11 +993,17 @@ xma_bios_update(xma_t *dev)
         mem_mapping_enable(&dev->bios_rom.mapping);
         mem_mapping_set_addr(&dev->bios_rom.mapping, dev->bios_base, XMA_BIOS_SIZE);
         xma_log("xma_bios_update: ROM space %u -> %05X\n", dev->rom_space, dev->bios_base);
+        xma_rom_register(dev, dev->bios_base);
     } else {
         dev->bios_base = 0;
         mem_mapping_disable(&dev->bios_rom.mapping);
         xma_log("xma_bios_update: ROM disabled\n");
+        xma_rom_register(dev, 0);
     }
+
+    /* Re-evaluate the page-frame slots: slots leaving the ROM window may
+       become available, slots entering it must be masked off. */
+    xma_pf_update(dev);
 }
 
 static void
@@ -1067,9 +1125,12 @@ xma_init(const device_t *info)
     xma_pf_update(dev);
     xma_map_update(dev); /* size the linear window to the default TT map */
 
-    /* Load the 8KB init ROM.  It starts out at Space 1 (C8000h); the
-       reference disk can move it through POS 104h bits 7-4 later. */
-    dev->rom_space = 4;
+    /* Load the 8KB init ROM but keep it disabled until the reference disk
+       selects a window through POS 104h bits 7-4 (xma_bios_update). The ROM 
+       must not be mapped at power-on so that two adapters in one machine do
+       not shadow each other at a fixed address; the card only presents its
+       ROM at the POS-assigned window. */
+    dev->rom_space = 1; /* space 1 = ROM not mapped */
     rom_init(&dev->bios_rom, bios_file,
              0xc8000U, XMA_BIOS_SIZE, XMA_BIOS_MASK, 0, MEM_MAPPING_EXTERNAL);
     mem_mapping_set_handler(&dev->bios_rom.mapping,
@@ -1077,8 +1138,8 @@ xma_init(const device_t *info)
                             NULL, NULL, NULL);
     mem_mapping_set_p(&dev->bios_rom.mapping, dev);
     mem_mapping_set_exec(&dev->bios_rom.mapping, dev->bios_rom.rom);
-    xma_log("xma_init: on-board init ROM loaded from %s\n", bios_file);
-    xma_bios_update(dev);
+    xma_log("xma_init: on-board init ROM loaded from %s (waiting for POS)\n", bios_file);
+    mem_mapping_disable(&dev->bios_rom.mapping);
 
     /* Register the fixed virtual-mode window (0x31A0h-0x31A8h).  Only a
        single card can be used in virtual mode, so a second XMA/A in the
@@ -1100,6 +1161,7 @@ xma_close(void *priv)
                      xma_io_readb, xma_io_readw, NULL,
                      xma_io_writeb, xma_io_writew, NULL,
                      dev);
+    xma_rom_register(dev, 0);
     free(dev->ram.ptr);
     free(dev);
 }

--- a/src/device/ibm_xma.c
+++ b/src/device/ibm_xma.c
@@ -742,7 +742,12 @@ xma_mca_feedb(void *priv)
     return (dev->pos_regs[2] & 1);
 }
 
-/* Virtual (banked) mode ports, 0x31A0h-0x31A8h */
+/* Virtual (banked) mode ports, 0x31A0h-0x31A8h. On real hardware this
+   fixed window is shared by every XMA-family adapter, but only the card
+   whose MCA slot is currently selected (port 96h) responds to it - so a
+   multi-card machine keeps the cards' translate tables from interfering
+   with each other during the init-ROM memory test. A card that is not
+   selected must answer reads with 0xFF/0xFFFF and ignore writes. */
 static uint16_t
 xma_tt_data16(const xma_t *dev)
 {
@@ -755,6 +760,9 @@ xma_io_readb(const uint16_t port, void *priv)
     xma_t    *dev = (xma_t *) priv;
     uint16_t off = port & 0x000f;
     uint8_t  ret;
+
+    if (mca_get_index() != dev->slot)
+        return 0xff;
 
     switch (off) {
         case 0x00: /* TT pointer low byte */
@@ -788,6 +796,9 @@ xma_io_readw(const uint16_t port, void *priv)
     xma_t    *dev = (xma_t *) priv;
     uint16_t data;
 
+    if (mca_get_index() != dev->slot)
+        return 0xffff;
+
     switch (port) {
         case XMA_TT_POINTER:
             return dev->tt_ptr;
@@ -813,6 +824,9 @@ xma_io_writeb(const uint16_t port, uint8_t val, void *priv)
 {
     xma_t    *dev = (xma_t *) priv;
     uint16_t off = port & 0x000f;
+
+    if (mca_get_index() != dev->slot)
+        return;
 
     switch (off) {
         case 0x00: /* TT pointer low byte */
@@ -863,6 +877,9 @@ static void
 xma_io_writew(const uint16_t port, uint16_t val, void *priv)
 {
     xma_t *dev = (xma_t *) priv;
+
+    if (mca_get_index() != dev->slot)
+        return;
 
     switch (port) {
         case XMA_TT_POINTER:
@@ -1008,7 +1025,7 @@ xma_init(const device_t *info)
         dev->tt[i] = XMA_TT_INHIBIT;
 
     /* Register the card on the MCA bus. */
-    mca_add(xma_mca_read, xma_mca_write, xma_mca_feedb, xma_reset, dev);
+    dev->slot = mca_add(xma_mca_read, xma_mca_write, xma_mca_feedb, xma_reset, dev);
 
     /* Extended-memory home at 1M+384K; xma_mem_read/write() gate access
        through the TT so inhibited entries simply read empty. The mapping 

--- a/src/device/mcamem.c
+++ b/src/device/mcamem.c
@@ -41,10 +41,12 @@ typedef struct {
 
 static const MCAMEM_CARD mcamem_cards[] = {
     // clang-format off
-    { &device_none              },
+    { &device_none                 },
     /* MCA Memory Expansion Boards */
-    { &ibm_xma_mca_2mb_device   },
-    { NULL                      }
+    { &ibm_xma_mca_2mb_device      },
+    { &ibm_xma_mca_8mb_f7fe_device },
+    { &ibm_xma_mca_8mb_f7f7_device },
+    { NULL                         }
     // clang-format on
 };
 

--- a/src/include/86box/mca.h
+++ b/src/include/86box/mca.h
@@ -30,12 +30,14 @@ extern void mca_init(const uint8_t nr_cards);
  * @param priv   Pointer to the adapter's private state/context.
  * @note This function iterates through all slots and assigns the adapter to
  * the first one where both read and write callbacks are NULL.
+ * @return The slot index (0 to MCA_MAX_CARDS-1) the adapter was assigned,
+ * or 0xFF if no slot was available.
  */
-extern void mca_add(uint8_t (*read)(uint16_t port, void *priv),
-                    void (*write)(uint16_t port, uint8_t val, void *priv),
-                    uint8_t (*feedb)(void *priv),
-                    void (*reset)(void *priv),
-                    void *priv);
+extern uint8_t mca_add(uint8_t (*read)(uint16_t port, void *priv),
+                       void (*write)(uint16_t port, uint8_t val, void *priv),
+                       uint8_t (*feedb)(void *priv),
+                       void (*reset)(void *priv),
+                       void *priv);
 
 /**
  * @brief Registers an MCA adapter into a specific hardware slot.
@@ -62,6 +64,14 @@ extern void mca_add_to_slot(uint8_t (*read)(uint16_t port, void *priv),
  * @param index The slot index to select (0-indexed).
  */
 extern void mca_set_index(const uint8_t index);
+
+/**
+ * @brief Returns the index of the currently selected slot.
+ *
+ * @return uint8_t The slot index currently selected via the MCA slot select
+ * port (0x96); the value latched by the last mca_set_index() call.
+ */
+extern uint8_t mca_get_index(void);
 
 /**
  * @brief Performs a POS read operation from the currently selected slot.

--- a/src/include/86box/mcamem.h
+++ b/src/include/86box/mcamem.h
@@ -36,6 +36,8 @@ extern const device_t *mcamem_get_device(int t);
 
 /* MCA Memory Expansion Boards. */
 extern const device_t ibm_xma_mca_2mb_device;
+extern const device_t ibm_xma_mca_8mb_f7fe_device;
+extern const device_t ibm_xma_mca_8mb_f7f7_device;
 #endif
 
 #ifdef __cplusplus

--- a/src/mca.c
+++ b/src/mca.c
@@ -74,6 +74,12 @@ mca_set_index(const uint8_t index)
 }
 
 uint8_t
+mca_get_index(void)
+{
+    return mca_index;
+}
+
+uint8_t
 mca_read(const uint16_t port)
 {
     if ((mca_index >= mca_nr_cards) || (!mca_slots[mca_index].read))
@@ -141,7 +147,7 @@ mca_reset(void)
     }
 }
 
-void
+uint8_t
 mca_add(uint8_t (*read)(uint16_t port, void *priv),
         void (*write)(uint16_t port, uint8_t val, void *priv),
         uint8_t (*feedb)(void *priv),
@@ -157,9 +163,11 @@ mca_add(uint8_t (*read)(uint16_t port, void *priv),
                 .reset = reset,
                 .priv  = priv
             };
-            return;
+            return slot;
         }
     }
+
+    return 0xff;
 }
 
 void


### PR DESCRIPTION
Summary
=======
Add IBM 1-8MB 286 Memory Expansion Adapter (Card ID F7FE) and IBM 2-8MB Memory Expansion Adapter (Card ID F7F7)  emulation.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [x] This pull request requires changes to the ROM set
  * [x] I have opened a roms pull request - https://github.com/86Box/roms/pull/546
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
[MS-DOS 4.0 XMA2EMS.ASM](https://github.com/pintushaw/MS-DOS-2026/blob/main/v4.0/src/DEV/XMA2EMS/XMA2EMS.ASM)