### PR TITLE
OSD: Add transient message overlay

### DIFF
--- a/src/osd/osd_core.cpp
+++ b/src/osd/osd_core.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cmath>
+#include <cstdarg>
 #include <cstdio>
 #include <cstring>
 #include <dirent.h>
@@ -65,6 +66,9 @@ static constexpr float OSD_MAX_SCALE        = 6.0f;
 static constexpr float OSD_REF_WIDTH        = 768.0f;
 static constexpr float OSD_REF_HEIGHT       = 576.0f;
 
+/* Seconds a message stays on screen before it expires. */
+static constexpr float OSD_MESSAGE_SECONDS  = 3.0f;
+
 /* ------------------------------------------------------------------ */
 /*  State                                                              */
 /* ------------------------------------------------------------------ */
@@ -101,6 +105,32 @@ static int         log_ring_head  = 0;   /* next write slot */
 static int         log_ring_count = 0;   /* entries populated */
 static std::mutex  log_mutex;
 static bool        log_scroll_pending = false;
+
+/* ------------------------------------------------------------------ */
+/*  Transient message                                                  */
+/* ------------------------------------------------------------------ */
+static char       message_text[OSD_LOG_LINE_LEN];
+static float      message_left = 0.0f; /* seconds remaining, set by osd_core_show_message() */
+static bool       message_close_pending = false;
+static std::mutex message_mutex;
+
+bool
+osd_core_message_active(void)
+{
+    std::lock_guard<std::mutex> lock(message_mutex);
+
+    return message_left > 0.0f;
+}
+
+/* A message is meant to be read with the OSD out of the way, so posting one
+ * asks osd_core_build_ui() to dismiss it. True once per message. */
+static bool
+consume_close_request(void)
+{
+    std::lock_guard<std::mutex> lock(message_mutex);
+
+    return std::exchange(message_close_pending, false);
+}
 
 static void show_main_menu(void);
 static bool focused_button(const char *label, bool focused);
@@ -744,10 +774,10 @@ static bool draw_browser(void)
         /* Record selected path in osd_last_mount for next run. */
         snprintf(osd_last_mount[current_view], OSD_PATH_CAPACITY, "%s", result.path.data());
 
-        /* Mount the image/folder and proceed. */
+        /* Mount the image/folder and report it. Posting the message dismisses
+         * the OSD, handing input back to the machine. */
         mount_path(result.path.data());
-        current_view       = VIEW_LOG;
-        log_scroll_pending = true;
+        osd_core_show_message("Loading %s", result.path.data());
     } else if (result.type == OsdExplorerResultType::Cancelled)
         show_main_menu();
 
@@ -774,6 +804,9 @@ void osd_core_set_title(const char *title)
 
 void osd_core_reset_to_menu(void)
 {
+    /* Drop a request left over from a message posted with the OSD already
+     * closed, so it cannot dismiss this one. */
+    consume_close_request();
     show_main_menu();
 }
 
@@ -787,11 +820,24 @@ bool osd_core_escape(void)
 
 bool osd_core_build_ui(void)
 {
+    bool keep_open;
+
     switch (current_view) {
-        case VIEW_MENU:      return draw_menu();
-        case VIEW_LOG:       return draw_log();
-        default:             return draw_browser();
+        case VIEW_MENU:
+            keep_open = draw_menu();
+            break;
+        case VIEW_LOG:
+            keep_open = draw_log();
+            break;
+        default:
+            keep_open = draw_browser();
+            break;
     }
+
+    /* A message posted while drawing closes the OSD so it can be read. */
+    const bool dismissed = consume_close_request();
+
+    return keep_open && !dismissed;
 }
 
 int osd_percentage = 0;
@@ -810,6 +856,57 @@ void osd_core_draw_indicators(void)
         ImGui::End();
     }
 #endif
+
+    char  text[OSD_LOG_LINE_LEN];
+    float left;
+
+    {
+        std::lock_guard<std::mutex> lock(message_mutex);
+
+        if (message_left <= 0.0f)
+            return;
+
+        message_left -= ImGui::GetIO().DeltaTime;
+        left = message_left;
+        snprintf(text, sizeof(text), "%s", message_text);
+    }
+
+    if (left <= 0.0f)
+        return;
+
+    /* Click-through overlay, so the emulator keeps all input. */
+    ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration;
+    flags |= ImGuiWindowFlags_NoInputs;
+    flags |= ImGuiWindowFlags_NoNav;
+    flags |= ImGuiWindowFlags_NoFocusOnAppearing;
+    flags |= ImGuiWindowFlags_NoSavedSettings;
+    flags |= ImGuiWindowFlags_AlwaysAutoResize;
+
+    ImGui::SetNextWindowPos(ImVec2(osd_core_scaled(8.0f), osd_core_scaled(8.0f)));
+    ImGui::PushStyleVar(ImGuiStyleVar_Alpha, std::min(1.0f, left)); /* fade out over the last second */
+    if (ImGui::Begin("##osd_message", nullptr, flags))
+        ImGui::TextUnformatted(text);
+    ImGui::End();
+    ImGui::PopStyleVar();
+}
+
+void
+osd_core_show_message(const char *text, ...)
+{
+    std::lock_guard<std::mutex> lock(message_mutex);
+
+    if (text == nullptr)
+        message_text[0] = '\0';
+    else {
+        va_list ap;
+
+        va_start(ap, text);
+        vsnprintf(message_text, sizeof(message_text), text, ap);
+        va_end(ap);
+    }
+
+    message_left          = (message_text[0] != '\0') ? OSD_MESSAGE_SECONDS : 0.0f;
+    message_close_pending = (message_left > 0.0f);
 }
 
 void osd_core_install_log_hook(void)

--- a/src/osd/osd_core.cpp
+++ b/src/osd/osd_core.cpp
@@ -114,8 +114,8 @@ static float      message_left = 0.0f; /* seconds remaining, set by osd_core_sho
 static bool       message_close_pending = false;
 static std::mutex message_mutex;
 
-bool
-osd_core_message_active(void)
+static bool
+message_active(void)
 {
     std::lock_guard<std::mutex> lock(message_mutex);
 
@@ -842,8 +842,20 @@ bool osd_core_build_ui(void)
 
 int osd_percentage = 0;
 
+/* Single point of truth for whether the indicator layer has anything to show.
+ * Indicators live alongside normal emulation, so this must never consult OSD
+ * visibility. */
+static bool
+indicators_active(void)
+{
+    return false; /* nothing to draw while the block below is #if 0 */
+}
+
 void osd_core_draw_indicators(void)
 {
+    if (!indicators_active())
+        return;
+
 #if 0
     ImGuiWindowFlags window_flags = 0;
     window_flags |= ImGuiWindowFlags_NoBackground;
@@ -856,7 +868,11 @@ void osd_core_draw_indicators(void)
         ImGui::End();
     }
 #endif
+}
 
+void
+osd_core_draw_message(void)
+{
     char  text[OSD_LOG_LINE_LEN];
     float left;
 
@@ -888,6 +904,15 @@ void osd_core_draw_indicators(void)
         ImGui::TextUnformatted(text);
     ImGui::End();
     ImGui::PopStyleVar();
+}
+
+/* True when the core wants a frame with the OSD closed. Frontends gate their
+ * rendering on this, so a new always-on layer only has to be taught to
+ * indicators_active() to start reaching the screen. */
+bool
+osd_core_needs_render(void)
+{
+    return indicators_active() || message_active();
 }
 
 void

--- a/src/osd/osd_core.hpp
+++ b/src/osd/osd_core.hpp
@@ -54,4 +54,12 @@ void osd_core_remove_log_hook(void);
 /* Draw OSD indicators */
 void osd_core_draw_indicators(void);
 
+/* Show a non-blocking message that expires after a fixed duration. The text is
+ * a printf-style format string for any additional arguments. Posting a message
+ * closes the OSD, so the machine keeps running while the message is read. */
+void osd_core_show_message(const char *text, ...) __attribute__((format(printf, 1, 2)));
+
+/* True while a message still needs drawing, even with the OSD closed. */
+bool osd_core_message_active(void);
+
 #endif /* OSD_CORE_HPP */

--- a/src/osd/osd_core.hpp
+++ b/src/osd/osd_core.hpp
@@ -51,15 +51,20 @@ bool osd_core_escape(void);
 void osd_core_install_log_hook(void);
 void osd_core_remove_log_hook(void);
 
-/* Draw OSD indicators */
+/* Draw the persistent indicator layer. */
 void osd_core_draw_indicators(void);
+
+/* Draw the transient message overlay, if one is still on screen. */
+void osd_core_draw_message(void);
 
 /* Show a non-blocking message that expires after a fixed duration. The text is
  * a printf-style format string for any additional arguments. Posting a message
  * closes the OSD, so the machine keeps running while the message is read. */
 void osd_core_show_message(const char *text, ...) __attribute__((format(printf, 1, 2)));
 
-/* True while a message still needs drawing, even with the OSD closed. */
-bool osd_core_message_active(void);
+/* True when the core has something to draw with the OSD closed: an active
+ * indicator layer, or a message still fading out. Frontends gate their
+ * rendering on this. */
+bool osd_core_needs_render(void);
 
 #endif /* OSD_CORE_HPP */

--- a/src/qt/qt_openglrenderer.cpp
+++ b/src/qt/qt_openglrenderer.cpp
@@ -1828,7 +1828,7 @@ OpenGLRenderer::render()
 
     /* Draw the OSD crisp on top of the shaded image, in the default
        framebuffer at full window resolution. */
-    if (qt_osd_is_visible()) {
+    if (qt_osd_needs_render()) {
         glw.glBindFramebuffer(GL_FRAMEBUFFER, 0);
         glw.glViewport(window_rect.x, window_rect.y, window_rect.w, window_rect.h);
         qt_osd_set_layout_scale_hint(osdLayoutScaleHint());

--- a/src/qt/qt_osd.cpp
+++ b/src/qt/qt_osd.cpp
@@ -367,6 +367,12 @@ qt_osd_is_visible(void)
     return g_visible;
 }
 
+bool
+qt_osd_needs_render(void)
+{
+    return g_visible || osd_core_message_active();
+}
+
 void
 qt_osd_toggle(void)
 {

--- a/src/qt/qt_osd.cpp
+++ b/src/qt/qt_osd.cpp
@@ -370,7 +370,7 @@ qt_osd_is_visible(void)
 bool
 qt_osd_needs_render(void)
 {
-    return g_visible || osd_core_message_active();
+    return g_visible || osd_core_needs_render();
 }
 
 void
@@ -448,6 +448,7 @@ qt_osd_render(int output_w, int output_h, float dpr, void* cmd_buf)
             osd_close();
     }
     osd_core_draw_indicators();
+    osd_core_draw_message();
 
     ImGui::Render();
     if (g_vk_enabled)
@@ -481,6 +482,7 @@ qt_osd_render_software(int logical_w, int logical_h, float dpr)
             osd_close();
     }
     osd_core_draw_indicators();
+    osd_core_draw_message();
     ImGui::Render();
 
     osd_raster_render(ImGui::GetDrawData(), g_software_surface, dpr);

--- a/src/qt/qt_osd.hpp
+++ b/src/qt/qt_osd.hpp
@@ -23,6 +23,10 @@ void qt_osd_shutdown(void);
 
 bool qt_osd_is_visible(void);
 
+/* Visible, or still drawing a message after being closed. Gates rendering
+   only: input keeps following qt_osd_is_visible(). */
+bool qt_osd_needs_render(void);
+
 void qt_osd_toggle(void);
 
 void qt_osd_set_layout_scale_hint(float scale);

--- a/src/qt/qt_osd.hpp
+++ b/src/qt/qt_osd.hpp
@@ -23,8 +23,8 @@ void qt_osd_shutdown(void);
 
 bool qt_osd_is_visible(void);
 
-/* Visible, or still drawing a message after being closed. Gates rendering
-   only: input keeps following qt_osd_is_visible(). */
+/* Visible, or the core still has an overlay to draw. Gates rendering only:
+   input keeps following qt_osd_is_visible(). */
 bool qt_osd_needs_render(void);
 
 void qt_osd_toggle(void);

--- a/src/qt/qt_softwarerenderer.cpp
+++ b/src/qt/qt_softwarerenderer.cpp
@@ -48,13 +48,13 @@ SoftwareRenderer::SoftwareRenderer(QWidget *parent)
     /* The OSD animates and reacts to input even when the machine is paused, so
      * keep refreshing while it is on screen. */
     connect(new QTimer(this), &QTimer::timeout, this, [this]() {
-        if (dopause && qt_osd_is_visible())
+        if (dopause && qt_osd_needs_render())
             this->render();
 
-        if (!qt_osd_is_visible() && was_osd_visible)
+        if (!qt_osd_needs_render() && was_osd_visible)
             this->render();
 
-        was_osd_visible = qt_osd_is_visible();
+        was_osd_visible = qt_osd_needs_render();
     });
 }
 
@@ -186,7 +186,7 @@ SoftwareRenderer::event(QEvent *event)
 void
 SoftwareRenderer::onPaint(QPaintDevice *device)
 {
-    const bool osd = qt_osd_is_visible();
+    const bool osd = qt_osd_needs_render();
     /* Repaint when the OSD is up, or once more right after it closes so a
      * lingering overlay is cleared even while the machine is paused. */
     if (cur_image == -1 && !osd && !osd_drawn_last)
@@ -217,7 +217,7 @@ SoftwareRenderer::onPaint(QPaintDevice *device)
 
     /* The OSD animates and reacts to input even when the machine is paused, so
      * keep refreshing while it is on screen. */
-    if (qt_osd_is_visible() && !dopause)
+    if (qt_osd_needs_render() && !dopause)
         QTimer::singleShot(16, this, [this] { update(); });
 }
 

--- a/src/qt/qt_vulkanwindowrenderer.cpp
+++ b/src/qt/qt_vulkanwindowrenderer.cpp
@@ -1017,8 +1017,8 @@ VulkanWindowRenderer::render()
     info.viewMask = 0;
     info.layerCount = 1;
     fn_vkCmdBeginRendering(cmdBufs, &info);
-    
-    if (qt_osd_is_visible()) {
+
+    if (qt_osd_needs_render()) {
         qt_osd_set_layout_scale_hint(osdLayoutScaleHint());
         qt_osd_render(width(), height(), devicePixelRatio(), (void*)cmdBufs);
     }

--- a/src/unix/sdl_main.c
+++ b/src/unix/sdl_main.c
@@ -675,6 +675,10 @@ check_flags:
             extern void sdl_blit(int x, int y, int w, int h);
             sdl_blit(params.x, params.y, params.w, params.h);
         }
+        /* Drawing the OSD can ask it to close -- posting a message does -- so
+         * finish that here instead of waiting for the next input event. */
+        if (flag_osd_open && osd_take_pending_close())
+            flag_osd_open = 0;
         if (title_set) {
             ui_window_title_real();
         }

--- a/src/unix/sdl_osd.cpp
+++ b/src/unix/sdl_osd.cpp
@@ -176,6 +176,8 @@ void osd_init(void)
 
     ImGuiIO &io = ImGui::GetIO();
     io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+    /* Leave the host cursor to the emulator; the OSD never sets it. */
+    io.ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange;
     io.IniFilename = nullptr; /* don't save layout */
 
     osd_set_scale(1.0f);
@@ -277,7 +279,11 @@ int osd_handle(SDL_Event event)
 /* ------------------------------------------------------------------ */
 void osd_present(int output_w, int output_h)
 {
-    if (!osd_visible || !osd_inited)
+    if (!osd_inited)
+        return;
+
+    /* Keep rendering after a close so a message can finish on screen. */
+    if (!osd_visible && !osd_core_message_active())
         return;
 
 #ifdef USE_SDL_SHADER_PIPELINE
@@ -303,8 +309,9 @@ void osd_present(int output_w, int output_h)
     ImGui_ImplSDL3_NewFrame();
 #endif
     ImGui::NewFrame();
-    if (!osd_core_build_ui())
+    if (osd_visible && !osd_core_build_ui())
         pending_close = true;
+    osd_core_draw_indicators();
     ImGui::Render();
     ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 #else
@@ -321,8 +328,9 @@ void osd_present(int output_w, int output_h)
     ImGui_ImplSDL3_NewFrame();
 #endif
     ImGui::NewFrame();
-    if (!osd_core_build_ui())
+    if (osd_visible && !osd_core_build_ui())
         pending_close = true;
+    osd_core_draw_indicators();
     ImGui::Render();
 #ifdef USE_SDL2_LIB
     ImGui_ImplSDLRenderer2_RenderDrawData(ImGui::GetDrawData(), sdl_render);

--- a/src/unix/sdl_osd.cpp
+++ b/src/unix/sdl_osd.cpp
@@ -237,6 +237,20 @@ int osd_close(SDL_Event event)
     return 1;
 }
 
+int osd_take_pending_close(void)
+{
+    if (!pending_close)
+        return 0;
+
+    pending_close = false;
+
+    /* osd_close() ignores the event; it only takes one to mirror osd_open(). */
+    SDL_Event dummy {};
+    osd_close(dummy);
+
+    return 1;
+}
+
 /* ------------------------------------------------------------------ */
 /*  Public API: event handling                                         */
 /* ------------------------------------------------------------------ */
@@ -259,11 +273,6 @@ int osd_handle(SDL_Event event)
                 return 0; /* close OSD entirely */
         }
         return 1; /* consume */
-    }
-
-    if (pending_close) {
-        pending_close = false;
-        return 0;
     }
 
 #ifdef USE_SDL2_LIB

--- a/src/unix/sdl_osd.cpp
+++ b/src/unix/sdl_osd.cpp
@@ -282,8 +282,8 @@ void osd_present(int output_w, int output_h)
     if (!osd_inited)
         return;
 
-    /* Keep rendering after a close so a message can finish on screen. */
-    if (!osd_visible && !osd_core_message_active())
+    /* Keep rendering while the core still has an overlay to draw. */
+    if (!osd_visible && !osd_core_needs_render())
         return;
 
 #ifdef USE_SDL_SHADER_PIPELINE
@@ -312,6 +312,7 @@ void osd_present(int output_w, int output_h)
     if (osd_visible && !osd_core_build_ui())
         pending_close = true;
     osd_core_draw_indicators();
+    osd_core_draw_message();
     ImGui::Render();
     ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 #else
@@ -331,6 +332,7 @@ void osd_present(int output_w, int output_h)
     if (osd_visible && !osd_core_build_ui())
         pending_close = true;
     osd_core_draw_indicators();
+    osd_core_draw_message();
     ImGui::Render();
 #ifdef USE_SDL2_LIB
     ImGui_ImplSDLRenderer2_RenderDrawData(ImGui::GetDrawData(), sdl_render);

--- a/src/unix/sdl_osd.h
+++ b/src/unix/sdl_osd.h
@@ -11,6 +11,10 @@ extern void osd_deinit(void);
 extern int osd_open(SDL_Event event);
 extern int osd_close(SDL_Event event);
 
+// Complete a close the OSD requested while drawing. Returns 1 when it closed,
+// so the caller can drop its own "OSD is open" state in the same step.
+extern int osd_take_pending_close(void);
+
 // keyboard event handler
 extern int osd_handle(SDL_Event event);
 


### PR DESCRIPTION
Summary
=======
Implements a simple non-blocking message for the OSD overlay.

Called with

	osd_core_show_message("foobar"); or
	osd_core_show_message("foobar %s", "additional string");

Only consumer right now is the OSD file browser when mounting an image.

Unfortunately, the "non-blocking nature" of the message required some glue in both the Qt and SDL backend, but this should hopefully help enabling stuff like drive activity indicators later.

AI-assisted with Claude Opus 5; manually tested on _both_ Qt and SDL.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
https://github.com/user-attachments/assets/8f80cf08-73fd-4396-b081-a6bbf711a4e4

