### PR TITLE
Change build to Mitsumi tests can build on macOS

### DIFF
--- a/tests/cdrom/CMakeLists.txt
+++ b/tests/cdrom/CMakeLists.txt
@@ -5,13 +5,15 @@ if(BUILD_TESTING)
 
     target_include_directories(mitsumi_cdrom_tests PRIVATE
         ${PROJECT_SOURCE_DIR}/src/include
+        ${PROJECT_SOURCE_DIR}/src/cpu
         ${PROJECT_BINARY_DIR}/src/include
     )
     target_compile_options(mitsumi_cdrom_tests PRIVATE
-        $<$<CXX_COMPILER_ID:GNU,Clang>:-ffunction-sections;-fdata-sections>
+        $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-ffunction-sections;-fdata-sections>
     )
     target_link_options(mitsumi_cdrom_tests PRIVATE
-        $<$<CXX_COMPILER_ID:GNU,Clang>:-Wl,--gc-sections>
+        $<$<PLATFORM_ID:Darwin>:-Wl,-dead_strip>
+        $<$<AND:$<NOT:$<PLATFORM_ID:Darwin>>,$<CXX_COMPILER_ID:GNU,Clang>>:-Wl,--gc-sections>
     )
     target_link_libraries(mitsumi_cdrom_tests PRIVATE GTest::gtest_main)
 
@@ -25,13 +27,15 @@ if(BUILD_BENCHMARKS)
     )
     target_include_directories(mitsumi_cdrom_benchmarks PRIVATE
         ${PROJECT_SOURCE_DIR}/src/include
+        ${PROJECT_SOURCE_DIR}/src/cpu
         ${PROJECT_BINARY_DIR}/src/include
     )
     target_compile_options(mitsumi_cdrom_benchmarks PRIVATE
-        $<$<CXX_COMPILER_ID:GNU,Clang>:-ffunction-sections;-fdata-sections>
+        $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-ffunction-sections;-fdata-sections>
     )
     target_link_options(mitsumi_cdrom_benchmarks PRIVATE
-        $<$<CXX_COMPILER_ID:GNU,Clang>:-Wl,--gc-sections>
+        $<$<PLATFORM_ID:Darwin>:-Wl,-dead_strip>
+        $<$<AND:$<NOT:$<PLATFORM_ID:Darwin>>,$<CXX_COMPILER_ID:GNU,Clang>>:-Wl,--gc-sections>
     )
     target_link_libraries(mitsumi_cdrom_benchmarks PRIVATE benchmark::benchmark_main)
 endif()


### PR DESCRIPTION
Summary
=======
The Mitsumi driver tests don't even build on macOS. This fixes that.

AI Usage
=======

Analysis assisted-by: oh-my-pi:gpt-6-astra  
No AI used to draft this PR.

Checklist
=========
* [X] Closes #xxx - N/A, no issue opened/
* [X] I have tested my changes locally and validated that the functionality works as intended - yes, build works on macOS and Linux now and build runs normally
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set - N/A
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/ - N/A
* [ ] This pull request requires changes to the asset set - N/A
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/ - N/A
* [ ] This pull request adds, changes or removes an external dependency - NA
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/ - NA

References
==========
None.