### PR TITLE
tests: cdrom/mitsumi: Fix Mitsumi GET_STAT consuming pending change twice

### DIFF
--- a/src/cdrom/cdrom_mitsumi.c
+++ b/src/cdrom/cdrom_mitsumi.c
@@ -1227,8 +1227,7 @@ mitsumi_cdrom_out(uint16_t port, uint8_t val, void *priv)
                     }
                     break;
                 case CMD_GET_STAT:
-                    dev->stat   = mitsumi_status(dev);
-                    dev->cmdbuf[0] = dev->stat;
+                    /* The command prelude already captured and consumed status. */
                     break;
                 case CMD_SET_MODE:
                     dev->cmdrd_count = 1;

--- a/tests/cdrom/cdrom_mitsumi_test.cpp
+++ b/tests/cdrom/cdrom_mitsumi_test.cpp
@@ -181,8 +181,9 @@ TEST_F(MitsumiTest, VersionUnknownStatusAndSenseCommandsReturnExpectedBytes)
 
     dev.change = 1;
     command(CMD_GET_STAT);
+    EXPECT_EQ(response(), (std::vector<uint8_t>{ STAT_READY | STAT_SERVO | STAT_CHANGE }));
+    command(CMD_GET_STAT);
     EXPECT_EQ(response(), (std::vector<uint8_t>{ STAT_READY | STAT_SERVO }));
-    EXPECT_EQ(dev.change, 0);
 }
 
 TEST_F(MitsumiTest, ModeVolumeLockAndControlRegistersAreProgrammable)


### PR DESCRIPTION
Summary
=======
Note: this PR is a companion to https://github.com/86Box/86Box/pull/7909

Mitsumi GET_STAT had its status calculated twice which would consume a pending media change before returning the response to the VM, would eat the change.

The current tests fail, and did reveal a small problem in the existing code, although it did not affect the actual function of the real Mitsumi drivers at all.

The number of tests failures has **remained the same**, because the old test expected the buggy response.

Several versions of the Mitsumi DOS drivers (MTMCDAE 1.16 and MTMCDAS 1.16) were used for testing along with static analysis of the Linux 2.0.40 Mitsumi card driver.

Assisted-by: oh-my-pi:gpt-6-astra  
AI assistance used heavily to diagnose problem and run through many different test scenarios.

Checklist
=========
* [X] Closes #xxx - N/A, no issue opened
* [X] I have tested my changes locally and validated that the functionality works as intended
* X ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set - N/A
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/ - N/A
* [ ] This pull request requires changes to the asset set - N/A
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/ - N/A
* [ ] This pull request adds, changes or removes an external dependency - N/A
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/ - N/A

References
==========
Linux 2.0.40 mcdx.c: https://git.kernel.org/pub/scm/linux/kernel/git/history/history.git/plain/drivers/cdrom/mcdx.c?h=2.0.40
Linux 2.0.40 mcdx.h:  https://git.kernel.org/pub/scm/linux/kernel/git/history/history.git/plain/include/linux/mcdx.h?h=2.0.40
Mitsumi drivers: https://files.mpoli.fi/hardware/CDROM/MITSUMI/MITS116.ZIP
Disassembly of MTMCDAE.SYS: https://github.com/Panda381/DOS-Progs/blob/main/CDDISK/MTMCDAE/MTMCDAE.ASM