### PR TITLE
Mitsumi fixture repair

### DIFF
--- a/src/cdrom/cdrom_mitsumi.c
+++ b/src/cdrom/cdrom_mitsumi.c
@@ -1227,8 +1227,7 @@ mitsumi_cdrom_out(uint16_t port, uint8_t val, void *priv)
                     }
                     break;
                 case CMD_GET_STAT:
-                    dev->stat   = mitsumi_status(dev);
-                    dev->cmdbuf[0] = dev->stat;
+                    /* The command prelude already captured and consumed status. */
                     break;
                 case CMD_SET_MODE:
                     dev->cmdrd_count = 1;

--- a/tests/cdrom/CMakeLists.txt
+++ b/tests/cdrom/CMakeLists.txt
@@ -5,13 +5,15 @@ if(BUILD_TESTING)
 
     target_include_directories(mitsumi_cdrom_tests PRIVATE
         ${PROJECT_SOURCE_DIR}/src/include
+        ${PROJECT_SOURCE_DIR}/src/cpu
         ${PROJECT_BINARY_DIR}/src/include
     )
     target_compile_options(mitsumi_cdrom_tests PRIVATE
-        $<$<CXX_COMPILER_ID:GNU,Clang>:-ffunction-sections;-fdata-sections>
+        $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-ffunction-sections;-fdata-sections>
     )
     target_link_options(mitsumi_cdrom_tests PRIVATE
-        $<$<CXX_COMPILER_ID:GNU,Clang>:-Wl,--gc-sections>
+        $<$<PLATFORM_ID:Darwin>:-Wl,-dead_strip>
+        $<$<AND:$<NOT:$<PLATFORM_ID:Darwin>>,$<CXX_COMPILER_ID:GNU,Clang>>:-Wl,--gc-sections>
     )
     target_link_libraries(mitsumi_cdrom_tests PRIVATE GTest::gtest_main)
 
@@ -25,13 +27,15 @@ if(BUILD_BENCHMARKS)
     )
     target_include_directories(mitsumi_cdrom_benchmarks PRIVATE
         ${PROJECT_SOURCE_DIR}/src/include
+        ${PROJECT_SOURCE_DIR}/src/cpu
         ${PROJECT_BINARY_DIR}/src/include
     )
     target_compile_options(mitsumi_cdrom_benchmarks PRIVATE
-        $<$<CXX_COMPILER_ID:GNU,Clang>:-ffunction-sections;-fdata-sections>
+        $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-ffunction-sections;-fdata-sections>
     )
     target_link_options(mitsumi_cdrom_benchmarks PRIVATE
-        $<$<CXX_COMPILER_ID:GNU,Clang>:-Wl,--gc-sections>
+        $<$<PLATFORM_ID:Darwin>:-Wl,-dead_strip>
+        $<$<AND:$<NOT:$<PLATFORM_ID:Darwin>>,$<CXX_COMPILER_ID:GNU,Clang>>:-Wl,--gc-sections>
     )
     target_link_libraries(mitsumi_cdrom_benchmarks PRIVATE benchmark::benchmark_main)
 endif()

--- a/tests/cdrom/cdrom_mitsumi_benchmark.cpp
+++ b/tests/cdrom/cdrom_mitsumi_benchmark.cpp
@@ -157,6 +157,8 @@ void timer_enable(pc_timer_t *timer) { timer->flags |= TIMER_ENABLED; }
 void timer_disable(pc_timer_t *timer) { timer->flags &= ~TIMER_ENABLED; }
 void timer_add(pc_timer_t *, void (*)(void *), void *, int) {}
 void cdrom_stop(cdrom_t *) {}
+int cdrom_has_data(cdrom_t *) { return 1; }
+double cdrom_seek_time(const cdrom_t *) { return 0.0; }
 int cdrom_read_toc(const cdrom_t *, uint8_t *buffer, int, uint8_t, int, int)
 {
     std::memset(buffer, 0, 4);

--- a/tests/cdrom/cdrom_mitsumi_test.cpp
+++ b/tests/cdrom/cdrom_mitsumi_test.cpp
@@ -58,6 +58,8 @@ protected:
         dev.cdrom_dev = &cd;
         dev.irq = 10;
         dev.dma = 5;
+        tsc = 0;
+        timer_add(&dev.read_timer, mitsumi_read_callback, &dev, 0);
         mitsumi_cdrom_reset(&dev);
         mock.irq_cleared = 0;
         mock.stop_calls = 0;
@@ -68,6 +70,17 @@ protected:
         mitsumi_cdrom_out(0, cmd, &dev);
         for (uint8_t arg : args)
             mitsumi_cdrom_out(0, arg, &dev);
+    }
+
+    void run_timers()
+    {
+        // Bound callback execution so a stuck state machine fails rather than hangs.
+        for (unsigned remaining = 16; dev.read_timer.flags & TIMER_ENABLED; --remaining) {
+            ASSERT_GT(remaining, 0u) << "Read timer did not quiesce";
+            tsc = dev.read_timer.ts_integer;
+            timer_disable(&dev.read_timer);
+            dev.read_timer.callback(dev.read_timer.priv);
+        }
     }
 
     std::vector<uint8_t> response()
@@ -241,6 +254,7 @@ TEST_F(MitsumiTest, CookedPioReadFetchesSectorAndAdvancesMsf)
 {
     dev.change = 0;
     command(CMD_READ2X, { 0x00, 0x02, 0x00, 0x00, 0x00, 0x01 });
+    ASSERT_NO_FATAL_FAILURE(run_timers());
     ASSERT_EQ(dev.buf_count, COOKED_SECTOR_SIZE);
     EXPECT_EQ(dev.readcount, 0u);
     EXPECT_EQ(mock.last_seek, 0u);
@@ -253,6 +267,7 @@ TEST_F(MitsumiTest, InvalidReadAddressReturnsCommandErrorAndSenseTwo)
 {
     dev.enable_irq = IRQ_ERROR;
     command(CMD_READ2X, { 0x00, 0x01, 0x99, 0x00, 0x00, 0x01 });
+    ASSERT_NO_FATAL_FAILURE(run_timers());
     EXPECT_EQ(dev.cur_sense, 2);
     const auto bytes = response();
     ASSERT_FALSE(bytes.empty());
@@ -362,6 +377,8 @@ void timer_add(pc_timer_t *timer, void (*callback)(void *), void *priv, int star
     timer->flags = start ? TIMER_ENABLED : 0;
 }
 void cdrom_stop(cdrom_t *) { ++mock.stop_calls; }
+int cdrom_has_data(cdrom_t *) { return 1; }
+double cdrom_seek_time(const cdrom_t *) { return 0.0; }
 int cdrom_read_toc(const cdrom_t *, uint8_t *buffer, int, uint8_t, int, int)
 {
     buffer[2] = 1;

--- a/tests/cdrom/cdrom_mitsumi_test.cpp
+++ b/tests/cdrom/cdrom_mitsumi_test.cpp
@@ -181,8 +181,9 @@ TEST_F(MitsumiTest, VersionUnknownStatusAndSenseCommandsReturnExpectedBytes)
 
     dev.change = 1;
     command(CMD_GET_STAT);
+    EXPECT_EQ(response(), (std::vector<uint8_t>{ STAT_READY | STAT_SERVO | STAT_CHANGE }));
+    command(CMD_GET_STAT);
     EXPECT_EQ(response(), (std::vector<uint8_t>{ STAT_READY | STAT_SERVO }));
-    EXPECT_EQ(dev.change, 0);
 }
 
 TEST_F(MitsumiTest, ModeVolumeLockAndControlRegistersAreProgrammable)


### PR DESCRIPTION
Summary
=======
The Mitsumi text fixtures have a few problems, particular one that can hang. This improves that.

This sits on top of PR's #7909 and #7910 and is not sensible to merge until those are

This does actually solve some test failures, specifically:
 - CookedPioReadFetchesSectorAndAdvancesMsf
 - InvalidReadAddressReturnsCommandErrorAndSenseTwo

Checklist
=========
* [X] Closes #xxx - N/A
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set - N/A
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/ - N/A
* [ ] This pull request requires changes to the asset set - N/A
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/ - N/A
* [ ] This pull request adds, changes or removes an external dependency - N/A
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/ - N/A

Details
=======

The current read tests inspect the device after issuing a command yet the way it completes its
seek+read+error processing is through a scheduled timer callback. The fixture also doesn't
register the read timer.

This fixes that.

Special caution has been taken to avoid trying to just get the tests to pass. The approach is to
evaluate what the tests are doing and compare it to real-world Mitsumi drivers and try to do that
instead.