### PR TITLE
Mitsumi tests need a mocked activity LED

### DIFF
--- a/tests/cdrom/cdrom_mitsumi_benchmark.cpp
+++ b/tests/cdrom/cdrom_mitsumi_benchmark.cpp
@@ -144,6 +144,8 @@ volatile int cpu_thread_run = 1;
 volatile int is_quit;
 int hard_reset_pending;
 
+void ui_sb_update_icon(int, int) {}
+
 void picint_common(uint16_t, int, int, uint8_t *) {}
 void dma_set_drq(int, int) {}
 void dma_set_service_handler(int, void (*)(void *), void *) {}

--- a/tests/cdrom/cdrom_mitsumi_test.cpp
+++ b/tests/cdrom/cdrom_mitsumi_test.cpp
@@ -353,6 +353,8 @@ volatile int cpu_thread_run = 1;
 volatile int is_quit;
 int hard_reset_pending;
 
+void ui_sb_update_icon(int, int) {}
+
 void picint_common(uint16_t mask, int, int set, uint8_t *)
 {
     if (set)


### PR DESCRIPTION
Summary
=======
Mitsumi tests broken yet again since they need a mock for the activity LED. Fixes that.

Checklist
=========
* [X] Closes #xxx - N/A
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set - N/A
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/ - N/A
* [ ] This pull request requires changes to the asset set - N/A
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/ - N/A
* [ ] This pull request adds, changes or removes an external dependency - N/A
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/ - N/A
