### PR TITLE
vid_s3.c: Allow 4MB VRAM on DECpc PCXAG-AL

### DIFF
--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -12378,16 +12378,6 @@ static const device_config_t s3_vision864_pci_config[] = {
         .spinner        = { 0 },
         .bios           = {
             {
-                .name          = "Digital (DEC) PCXAG-AL",
-                .internal_name = "dec_vision864_pci",
-                .bios_type     = BIOS_NORMAL,
-                .files_no      = 1,
-                .local         = S3_DEC_VISION864,
-                .size          = 32768,
-                .flags         = BIOS_LIMIT_MAX_MEMORY | (2 << 8),
-                .files         = { ROM_DEC_VISION864, "" }
-            },
-            {
                 .name          = "Diamond Stealth64 Graphics 2000",
                 .internal_name = "stealth64d_864_pci",
                 .bios_type     = BIOS_NORMAL,
@@ -12396,6 +12386,16 @@ static const device_config_t s3_vision864_pci_config[] = {
                 .size          = 32768,
                 .flags         = BIOS_LIMIT_MAX_MEMORY | (2 << 8),
                 .files         = { ROM_DIAMOND_STEALTH64_864, "" }
+            },
+            {
+                .name          = "Digital (DEC) PCXAG-AL",
+                .internal_name = "dec_vision864_pci",
+                .bios_type     = BIOS_NORMAL,
+                .files_no      = 1,
+                .local         = S3_DEC_VISION864,
+                .size          = 32768,
+                .flags         = 0,
+                .files         = { ROM_DEC_VISION864, "" }
             },
             {
                 .name          = "Leadtek WinFast S430", /* Also known as: ASUS VideoMagic PCI-V864 */


### PR DESCRIPTION
Summary
=======
Remove the 2MB VRAM limit from Digital (DEC) PCXAG-AL

Checklist
=========
* [ ] Closes #xxx
* [ ] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
I own a physical DEC PCXAG-AL card with 4 MB of installed VRAM, which functions properly.

Multiple listings of DEC PCXAG-AL boards on eBay show the full VRAM complement supporting 4 MB configurations like https://www.ebay.com/itm/201555438641.

Microsoft Windows NT Hardware Compatibility List lists the DEC PCXAG-AL with 4 MB VRAM support.
<img width="1379" height="1362" alt="image" src="https://github.com/user-attachments/assets/a1fef5bb-6e0f-49ee-a62f-8ab58b80b3bc" />
