### PR TITLE
CPU: Only disable the recompiler for breakpoints it can hit

### DIFF
--- a/src/cpu/386_dynarec.c
+++ b/src/cpu/386_dynarec.c
@@ -246,7 +246,37 @@ fetch_ea_16_long(uint32_t rmdat)
 #include "386_ops.h"
 
 #ifdef USE_DEBUG_REGS_486
-#    define CACHE_ON() (!(cr0 & (1 << 30)) && !(cpu_state.flags & T_FLAG) && !(dr[7] & 0xFF))
+/* Compiled blocks hold no debug-register checks. Data and I/O breakpoints can
+   fire on any access, so they still disable the recompiler outright; an
+   execution breakpoint only blocks the block covering it, and a block spans at
+   most two pages. */
+static __inline int
+dr_blocks_cache(void)
+{
+    uint32_t page;
+
+    if (!(dr[7] & 0xFF))
+        return 0;
+
+    page = (cs + cpu_state.pc) >> 12;
+
+    for (uint8_t i = 0; i < 4; i++) {
+        /* Neither Ln nor Gn set - slot is disabled. */
+        if (!((dr[7] >> (i << 1)) & 0x03))
+            continue;
+
+        /* RW 00 is execution; DR0-3 and cs + pc are both linear. */
+        if ((dr[7] >> (16 + (i << 2))) & 0x03)
+            return 1;
+
+        if (((dr[i] >> 12) == page) || ((dr[i] >> 12) == (page + 1)))
+            return 1;
+    }
+
+    return 0;
+}
+
+#    define CACHE_ON() (!(cr0 & (1 << 30)) && !(cpu_state.flags & T_FLAG) && !dr_blocks_cache())
 #else
 #    define CACHE_ON() (!(cr0 & (1 << 30)) && !(cpu_state.flags & T_FLAG))
 #endif


### PR DESCRIPTION
Summary
=======
**AI assisted with Claude Opus**

Probably the last thing I'll do for the CPU side of things with the AI, depending on the output.

Previously, the VM would fall back to the interpreter every time a break point was hit, regardless of its type. This was visible when starting Empire Earth, were you could nicely see it with the dynarec indicator.

This patch disables the recompiler only when a breakpoint can actually hit and not unconditionally. I verified this with EE again, it now starts up a bit faster since there are less fallbacks to the interpreter.

Regarding the previous discussion regarding the debug registers. I tried various things and did a lot of assisted benchmarks used instrumented builds with additional logging, and the verdict is that there's no sensible way to make builds with debug registers enabled any faster, given that the last changes already gave a huge speed boost.

Claude then tried to inline various things, shuffled code around - it still worked, but with NO performance benefit at all, benchmarked in the same VM. That's where I decided to scrap it, since huge code changes without any benefit are _probably_ not a good idea.

According to AI review, we spend quite a bit of time on memory management, and it has a few "ideas" to improve this, that's what I'm currently testing. But this again would affect the whole dynarec, so...

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
No outside reference, but tested manually and "audited" by sub-agents.
