### PR TITLE
Fix machines and BIOS entries missing on case-sensitive filesystems

### DIFF
--- a/src/machine/m_at_286.c
+++ b/src/machine/m_at_286.c
@@ -961,7 +961,7 @@ machine_at_n8810m30_init(const machine_t *model) /* Onboard SCSI not yet emulate
 {
     int ret;
 
-    ret = bios_load_linear("roms/machines/n8810m30/at286bios_53889.00.0.17jr.BIN",
+    ret = bios_load_linear("roms/machines/n8810m30/at286bios_53889.00.0.17jr.bin",
                            0x000e0000, 131072, 0);
 
     if (bios_only || !ret)

--- a/src/machine/m_at_slot1.c
+++ b/src/machine/m_at_slot1.c
@@ -709,7 +709,7 @@ static const device_config_t ms6117_config[] = {
                 .files_no      = 1,
                 .local         = 0,
                 .size          = 131072,
-                .files         = { "roms/machines/ms6117/w617v115.BIN", "" }
+                .files         = { "roms/machines/ms6117/w617v115.bin", "" }
             },
             { .files_no = 0 }
         }
@@ -1524,7 +1524,7 @@ static const device_config_t bx6_config[] = {
                 .files_no      = 1,
                 .local         = 0,
                 .size          = 131072,
-                .files         = { "roms/machines/bx6/BX6_CW.bin", "" }
+                .files         = { "roms/machines/bx6/BX6_CW.BIN", "" }
             },
             {
                 .name          = "AwardBIOS v4.51PG - Revision GQ",
@@ -1533,7 +1533,7 @@ static const device_config_t bx6_config[] = {
                 .files_no      = 1,
                 .local         = 0,
                 .size          = 131072,
-                .files         = { "roms/machines/bx6/BX6_GQ.bin", "" }
+                .files         = { "roms/machines/bx6/BX6_GQ.BIN", "" }
             },
             {
                 .name          = "AwardBIOS v4.51PG - Revision JL",
@@ -1542,7 +1542,7 @@ static const device_config_t bx6_config[] = {
                 .files_no      = 1,
                 .local         = 0,
                 .size          = 131072,
-                .files         = { "roms/machines/bx6/BX6_JL.bin", "" }
+                .files         = { "roms/machines/bx6/BX6_JL.BIN", "" }
             },
             {
                 .name          = "AwardBIOS v4.51PG - Revision QS",

--- a/src/machine/m_at_socket3_pci.c
+++ b/src/machine/m_at_socket3_pci.c
@@ -417,7 +417,7 @@ static const device_config_t pb450_config[] = {
                 .files_no      = 1,
                 .local         = 0,
                 .size          = 131072,
-                .files         = { "roms/machines/pb450/p4hs20.bin", "" }
+                .files         = { "roms/machines/pb450/p4hs20.BIN", "" }
             },
             { .files_no = 0 }
         }

--- a/src/machine/m_ps1.c
+++ b/src/machine/m_ps1.c
@@ -333,7 +333,7 @@ static const device_config_t ps1_2011_config[] = {
                 .files_no      = 1,
                 .local         = 0,
                 .size          = 524288,
-                .files         = { "roms/machines/ibmps1es/F80000_ES.bin", "" }
+                .files         = { "roms/machines/ibmps1es/F80000_ES.BIN", "" }
             },
             { .files_no = 0 }
         }

--- a/src/scsi/scsi_buslogic.c
+++ b/src/scsi/scsi_buslogic.c
@@ -1669,7 +1669,7 @@ buslogic_init(const device_t *info)
             break;
         case CHIP_BUSLOGIC_ISA_545C_1994_12_01: /*Dated December 1st, 1994*/
             strcpy(dev->name, "BT-545C");
-            bios_rom_name     = "roms/scsi/buslogic/BT-545C_BIOS.rom";
+            bios_rom_name     = "roms/scsi/buslogic/BT-545C_BIOS.ROM";
             bios_rom_size     = 0x4000;
             bios_rom_mask     = 0x3fff;
             has_autoscsi_rom  = 1;
@@ -1709,7 +1709,7 @@ buslogic_init(const device_t *info)
             break;
         case CHIP_BUSLOGIC_VLB_445C_1994_12_01: /*Dated December 1st, 1994*/
             strcpy(dev->name, "BT-445C");
-            bios_rom_name     = "roms/scsi/buslogic/BT-445C_BIOS.rom";
+            bios_rom_name     = "roms/scsi/buslogic/BT-445C_BIOS.ROM";
             bios_rom_size     = 0x4000;
             bios_rom_mask     = 0x3fff;
             has_autoscsi_rom  = 1;

--- a/src/video/vid_s3_virge.c
+++ b/src/video/vid_s3_virge.c
@@ -61,7 +61,7 @@ static int dither[4][4] = {
 };
 
 #define ROM_VIRGE_325                 "roms/video/s3virge/86c325.bin"
-#define ROM_DIAMOND_STEALTH3D_2000    "roms/video/s3virge/s3virge.BIN"
+#define ROM_DIAMOND_STEALTH3D_2000    "roms/video/s3virge/s3virge.bin"
 #define ROM_MIROCRYSTAL_3D            "roms/video/s3virge/miro Crystal 3D 1.02.bin"
 #define ROM_DIAMOND_STEALTH3D_3000    "roms/video/s3virge/diamondstealth3000.vbi"
 #define ROM_STB_VELOCITY_3D           "roms/video/s3virge/stb_velocity3d_110.BIN"


### PR DESCRIPTION
Summary
=======

Ten ROM path literals in `src` name a file that the ROM set ships under a different case, so the file is never found on a case-sensitive filesystem. On Linux and on case-sensitive macOS volumes this hides a whole machine and several BIOS revisions, and stops two SCSI cards from mapping their boot ROM. All of it works on Windows.

The worst one is the Nixdorf 8810 M30. `src/machine/m_at_286.c:964` asks for `at286bios_53889.00.0.17jr.BIN` while the ROM set has `...17jr.bin`. Its machine table entry has `.device = NULL`, so `machine_available()` (`src/machine/machine.c:162`) falls through to `machine_init_ex()` with `bios_only` set, `bios_load_linear()` fails, and the entire machine is filtered out of the machine list rather than losing one option.

The `CONFIG_BIOS` ones each lose a single entry. `rom_present()` (`src/mem/rom.c:284`) calls `plat_file_check()`, a plain `stat()` off Windows, with no case folding, and both the settings dialog (`src/qt/qt_deviceconfig.cpp:300`) and `machine_device_available()` (`src/device.c:1265`) only keep a BIOS entry when every file it names is present.

The two BusLogic ones are a direct `rom_init()` in `buslogic_init()`. The cards themselves are not affected: every BusLogic `device_t` has `.available = NULL`, so they stay in the device list and stay usable as plain HBAs. What breaks is the option ROM. The load fails, its return value is ignored at `src/scsi/scsi_buslogic.c:1759`, and nothing is mapped, so once a BIOS address is selected the BT-545C and BT-445C cannot boot a SCSI disk. The `bios_addr` config defaults to Disabled, so this only bites a user who turns the BIOS on.

Source spelling to ROM set spelling:

* `src/machine/m_at_286.c:964` `n8810m30/at286bios_53889.00.0.17jr.BIN` to `.bin`, the whole Nixdorf 8810 M30 machine
* `src/video/vid_s3_virge.c:64` `s3virge/s3virge.BIN` to `s3virge.bin`, the Diamond Stealth 3D 2000 entry on the S3 ViRGE PCI card
* `src/machine/m_at_slot1.c:1527, 1536, 1545` `bx6/BX6_CW.bin`, `BX6_GQ.bin`, `BX6_JL.bin` to `.BIN`, three of the five Abit AB-BX6 BIOS revisions
* `src/machine/m_at_slot1.c:712` `ms6117/w617v115.BIN` to `w617v115.bin`, the MSI MS-6117 Viglen Vig67M BIOS
* `src/machine/m_at_socket3_pci.c:420` `pb450/p4hs20.bin` to `p4hs20.BIN`, the Packard Bell PB450 revision P4HS20 BIOS
* `src/machine/m_ps1.c:336` `ibmps1es/F80000_ES.bin` to `F80000_ES.BIN`, the IBM PS/1 model 2011 Spanish BIOS
* `src/scsi/scsi_buslogic.c:1672, 1712` `buslogic/BT-545C_BIOS.rom` and `BT-445C_BIOS.rom` to `.ROM`

No user config migration is needed. Only the `.files` paths change and every `internal_name` is untouched, so existing `.cfg` files keep selecting the same BIOS entry.

The case goes both ways, so each literal is matched to the file exactly as the ROM set ships it. No ROM set change is needed. Neighbouring names that look inconsistent are already right and are left alone: `bx6/BX6_QS.bin`, `ibmps1es/f80000.bin` and the two BusLogic AutoSCSI images really are lowercase.

How I checked this: I extracted every `"roms/..."` string literal in `src` (1379 unique) and compared them against the file list of `86Box/roms` master (1529 files, tree `0da0869`). 1360 matched exactly, these 10 differed only in case, and the remaining 9 are paths the ROM set does not contain under any spelling, which this change does not touch. After the change the same comparison finds 1370 exact matches and no case-only mismatches.

All six files still pass `clang -fsyntax-only -Wall -Wextra` with exactly the same warning count as before the change, and running clang-format over each file before and after gives outputs that differ only in those same ten strings, so no formatting drift is introduced.

Checklist
=========
* [x] I have tested my changes locally and validated that the functionality works as intended

References
==========
* Same class of fix, merged previously: https://github.com/86Box/86Box/pull/4358
* https://github.com/86Box/roms/tree/master/machines/n8810m30
* https://github.com/86Box/roms/tree/master/video/s3virge
* https://github.com/86Box/roms/tree/master/machines/bx6
* https://github.com/86Box/roms/tree/master/machines/ms6117
* https://github.com/86Box/roms/tree/master/machines/pb450
* https://github.com/86Box/roms/tree/master/machines/ibmps1es
* https://github.com/86Box/roms/tree/master/scsi/buslogic