### PR TITLE
XTA: Restore the missing break in the WDXT-150 case

### DIFF
--- a/src/disk/hdc_xta.c
+++ b/src/disk/hdc_xta.c
@@ -1042,6 +1042,8 @@ xta_init_common(const device_t *info, int type)
             dev->irq      = device_get_config_int("irq");
             dev->rom_addr = device_get_config_hex20("bios_addr");
             dev->dma      = 3;
+            break;
+
         case 1: /* Amstrad PC3086 */
             dev->name     = "WDXT-150 PC3086";
             dev->rom_addr = 0xc8000;


### PR DESCRIPTION
Summary
=======

Adding the "WDXT-150 (XTA)" ISA controller to a machine discards its BIOS address and IRQ settings and loads the wrong ROM for whichever BIOS revision is selected. The card instead loads `roms/machines/pc3086/c800.bin` at 0xC8000 on IRQ 5, or fails to load any option ROM if the PC3086 machine's ROM set is absent.

This is not limited to users who change a setting. At the dialog defaults (Revision 1.0, IRQ 5, C800H) the IRQ and BIOS address happen to match the values that get substituted, but the ROM file does not, so the card still loads the Amstrad image instead of `roms/hdd/xta/idexywd2.bin`.

The cause is a missing `break;` in the per-controller-type switch in `xta_init_common()`. Case 0 at src/disk/hdc_xta.c:1030 sets `dev->name`, `fn` from the selected BIOS revision, `dev->base`, `dev->irq`, `dev->rom_addr` and `dev->dma`, then falls straight through into `case 1`, the Amstrad PC3086 case at src/disk/hdc_xta.c:1045, which overwrites every one of those values. `fn` is what gets loaded at src/disk/hdc_xta.c:1292, so the generic card ends up with the Amstrad machine's ROM image. `dev->type` itself is not clobbered, so the later switch-byte encoding still takes the type 0 path at src/disk/hdc_xta.c:1127 and still reads `bios_rev`, pairing the switch table for the selected revision, revision 1 by default, with the PC3086 ROM. All line numbers here are on master, before the change.

`git show b5cb6ab894ac00e33e0d48eccb1a30f3810353eb` shows where this came from: the PC3086 case was inserted between the end of case 0's body and the `break;` that used to terminate it, so that `break;` now ends case 1 and case 0 has none. The generic card is reachable from the UI through the controller list at src/disk/hdc.c:74, while the PC3086 variant is only added by the machine itself at src/machine/m_amstrad.c:3078, so only the generic card is affected.

This gives case 0 its own `break;` again. Nothing else in the case needs to change, since case 0 already assigns everything it uses. Case 1 is entered directly for `.local = 1`, so PC3086 behaviour is identical.

Clang reports the fall-through with `-Wimplicit-fallthrough`, which is not in the default build flags:

    clang -fsyntax-only -Wall -Wextra -Wimplicit-fallthrough -std=gnu11 -I src/include -I src/include/86box -I src/cpu -I src -DUSE_DYNAREC -D_FILE_OFFSET_BITS=64 src/disk/hdc_xta.c
    src/disk/hdc_xta.c:1045:9: warning: unannotated fall-through between switch labels [-Wimplicit-fallthrough]

One warning before the change, none after, and no new warnings under plain `-Wall -Wextra`.

To check the effect without a full build, I compiled the switch body from both revisions into a small standalone harness with the config getters stubbed to return what the dialog returns. With Revision 2.0, IRQ 4 and CA00H selected, type 0 came out before the change as IRQ 5, ROM address 0C8000, file `roms/machines/pc3086/c800.bin`, and after it as IRQ 4, ROM address 0CA000, file `roms/hdd/xta/infowdbios.rom`; at the defaults only the file changed, from `roms/machines/pc3086/c800.bin` to `roms/hdd/xta/idexywd2.bin`. Type 1 was identical both ways. This is a code-level check rather than a guest boot.

Noticed while reading this but not changed here, since they look like separate decisions: `xta_wdxt150_pc3086_device` carries `.config = wdxt150_config` even though case 1 ignores every option in it, and it shares `.internal_name = "xta_wdxt150"` with `xta_wdxt150_device`.

Checklist
=========
* [x] I have tested my changes locally and validated that the functionality works as intended

References
==========

Commit that introduced the fall-through: https://github.com/86Box/86Box/commit/b5cb6ab894ac00e33e0d48eccb1a30f3810353eb - dated 2025-08-18, so the standalone card has been affected on master since then.

ROM files the card should be loading: https://github.com/86Box/roms/tree/master/hdd/xta