### PR TITLE
fdc: report No Data with Wrong Cylinder

### DIFF
--- a/src/floppy/fdc.c
+++ b/src/floppy/fdc.c
@@ -2357,7 +2357,7 @@ void
 fdc_wrongcylinder(fdc_t *fdc)
 {
     fdc_log("FDC error: Wrong cylinder\n");
-    fdc_error(fdc, 0x00, 0x10);
+    fdc_error(fdc, 0x04, 0x10);
 }
 
 void


### PR DESCRIPTION
Summary
=======

A cylinder mismatch means the requested sector ID was not found. The uPD765 status definition relates ST2.WC to ST1.ND, so report both bits instead of WC alone.

The only code found so far dependent upon this behaviour is the 1986 IBM PC JX BIOS, which uses it to detect a 67.5 TPI 3.5" diskette, which is essentially formatted with every-other-track basically missing (with no sector marks), and the cylinder indices numbered 0-39. It detects such a diskette by attempting to read the cylinder index and sector index marks. If it reads cylinder 4 but gets index mark for 2, it knows it is a 67.5 TPI diskette. It actually requests physical cylinder 4 but asks the controller to expect 2, and then expects an error if it doesn't match. If the error is returned, then it knows it is a 135 TPI diskette (i.e. a normal 80 track diskette).

This also allows BIOS recovery paths which inspect ST1.ND, including the 1986 IBM PC JX alternate-stepping retry, to recognize the error. For an example of the BIOS code, see the IBM PC JX 1986 ROM in FE00:0D8D, with zero result at FE00:0D92 and recovery at FE00:0DA6.

Without fixing this bug, the 1986 JX BIOS cannot boot a 720kB diskette.

Astute readers will question why they didn't just make the 360kB diskette format use the first 40 tracks and leave the last 40 blank. The answer is: because they didn't.

The incoming PC JX code "simulates" the bizarre 67.5 TPI disk format if a 360kB diskette is mounted; otherwise, an .imd, .86f, etc. raw sector format must be used that recreates the double-stepping. For example, the copy-protected 3.5" Flight Simulator disk uses this double stepped format.

For a more detailed AI-written description, see:
https://gist.github.com/JoshRodd/cc052a86a23a4093bfbf59230d907be3

Testing:
Thoroughly tested against current head's PCjr and IBM PC code; small amount of testing against other machine types and other FDC types. No issues/errors reported. I did not find any other BIOS or copy protection dependent on this, so I can't find anything else to test other than regression.

Checklist
=========
* [X] Closes #xxx - per 86Box policy, did not create an issue just to create a PR
* [X] I have tested my changes locally and validated that the functionality works as intended - yes (see test plan)
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set - N/A
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/ - N/A
* [ ] This pull request requires changes to the asset set - N/A
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/ - N/A
* [ ] This pull request adds, changes or removes an external dependency - N/A
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/ - N/A

References
==========
NEC 765 data sheet available at your local data sheet repository, such as:
https://www.scribd.com/document/440411441/D765-pdf
