### PR TITLE
video: pcjr: make 6845 positioning use an explicit sync reference

### DIFF
--- a/src/include/86box/video.h
+++ b/src/include/86box/video.h
@@ -299,6 +299,8 @@ extern void video_blit_complete_monitor(int monitor_index);
 extern void video_wait_for_blit_monitor(int monitor_index);
 extern void video_wait_for_buffer_monitor(int monitor_index);
 
+extern int video_6845_get_hsync_delay(const uint8_t *crtc, int hsync_width);
+
 extern bitmap_t *create_bitmap(int w, int h);
 extern void      destroy_bitmap(bitmap_t *b);
 extern void      cgapal_rebuild_monitor(int monitor_index);

--- a/src/video/vid_pcjr.c
+++ b/src/video/vid_pcjr.c
@@ -235,43 +235,44 @@ vid_read(uint32_t addr, void *priv)
 static int
 vid_get_h_overscan_delta(pcjr_t *pcjr)
 {
-    int def;
+    int def; /* Reference sync-start-to-display delay from the PCjr BIOS. */
     int coef;
     int ret;
 
     switch ((pcjr->array[0] & 0x13) | ((pcjr->array[3] & 0x08) << 5)) {
         case 0x13: /*320x200x16*/
-            def = 0x56;
+            def = 28;
             coef = 8;
             break;
         case 0x12: /*160x200x16*/
-            def = 0x2c; /* I'm going to assume a datasheet erratum here. */
+            def = 14;
             coef = 16;
             break;
         case 0x03: /*640x200x4*/
-            def = 0x56;
+            def = 28;
             coef = 8;
             break;
         case 0x01: /*80 column text*/
-            def = 0x5a;
+            def = 24;
             coef = 8;
             break;
         case 0x00: /*40 column text*/
         default:
-            def = 0x2c;
+            def = 13;
             coef = 16;
             break;
         case 0x02: /*320x200x4*/
-            def = 0x2b;
+            def = 14;
             coef = 16;
             break;
         case 0x102: /*640x200x2*/
-            def = 0x2b;
+            def = 14;
             coef = 16;
             break;
     }
 
-    ret = def - pcjr->crtc[0x02];
+    /* Preserve PCjr sync-start alignment; raw R3 width is not a viewport offset. */
+    ret = video_6845_get_hsync_delay(pcjr->crtc, 0) - def;
 
     if (ret < -8)
         ret = -8;

--- a/src/video/video.c
+++ b/src/video/video.c
@@ -449,6 +449,14 @@ video_blit_memtoscreen_monitor(int x, int y, int w, int h, int monitor_index)
     MTR_END("video", "video_blit_memtoscreen");
 }
 
+/* Character clocks from the selected HSYNC edge to the next line.
+   Pass zero for sync start, or the effective pulse width for sync end. */
+int
+video_6845_get_hsync_delay(const uint8_t *crtc, int hsync_width)
+{
+    return (crtc[0] + 1) - crtc[2] - hsync_width;
+}
+
 uint8_t
 pixels8(uint32_t *pixels)
 {


### PR DESCRIPTION
Summary
=======

The PC JX's ROM uses different CRTC sync timings than either the IBM PC's CGA BIOS or the PCjr's BIOS does, for no particular reason.

This change changes the PCjr's code only, although it probably should be performed for all video models, but limiting the scope of this to just the PCjr video controller means we only need to test PCjr / PC JX machines.

The change is to compute a delay in the character clock that has an explicit sync edge. We still use the PCjr sync start alignment. If we use the raw R3 sync end, Flight Simulator 2.1 shifts left by four (low bandwidth) character clocks (typically 32 character clocks).

So we change the PCjr reference delays to the BIOS line totals and the sync positions, including the 160 pixel mode's R2 set to 2Bh. We account for R0 whilst preserving manual R2 adjustments and the existing displacement clamp.

These changes should probably also be done to CGA, but we're leaving it alone for now; I couldn't find any bug reports against the CGA complaining about this.

An open question is "why did the PC JX do this?" The answer is: because they could.

Designed and tested using extensive AI assistance.

Checklist
=========
* [X] Closes #xxx - N/A
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set - N/A
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/ - N/A
* [ ] This pull request requires changes to the asset set - N/A
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/ - N/A
* [ ] This pull request adds, changes or removes an external dependency - N/A
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/ - N/A

References
==========
IBM PCjr Technical Reference; IBM PC JX Technical Reference, including the BIOS listings in each.