### PR TITLE
CPU: NDR: Raise NDR code-block size limit; FPU rounding control improvement

### DIFF
--- a/src/codegen_new/codegen_allocator.c
+++ b/src/codegen_new/codegen_allocator.c
@@ -48,10 +48,11 @@ remove_from_block_list(mem_code_block_t* block)
             mem_code_block_tail = block->prev;
         }
     } else if (block->next) {
-        mem_code_block_head = block->next;
-        if (mem_code_block_head && mem_code_block_head->next) {
-            mem_code_block_head->next->prev = mem_code_block_head;
-        }
+        /* This node was head; its successor becomes head and must lose its
+           now-stale prev (it pointed at this node), or a later removal of
+           the new head takes the wrong branch below. */
+        mem_code_block_head       = block->next;
+        mem_code_block_head->prev = NULL;
     } else if (block == mem_code_block_head) {
         mem_code_block_head = mem_code_block_tail = NULL;
     }
@@ -131,10 +132,14 @@ codegen_allocator_allocate(mem_block_t *parent, int code_block)
         } else {
             mem_code_block_t* mem_code_block = mem_code_block_head;
             while (mem_code_block) {
+                /* Capture next before deleting: codegen_delete_block() frees
+                   this node via remove_from_block_list(), which nulls its
+                   ->next, so reading it after would end the walk early. */
+                mem_code_block_t *next = mem_code_block->next;
                 if (code_block != mem_code_block->number) {
                     codegen_delete_block(&codeblock[mem_code_block->number]);
                 }
-                mem_code_block = mem_code_block->next;
+                mem_code_block = next;
             }
 
             if (mem_block_free_list)

--- a/src/codegen_new/codegen_backend_arm64.h
+++ b/src/codegen_new/codegen_backend_arm64.h
@@ -1,7 +1,14 @@
 #include "codegen_backend_arm64_defs.h"
 
-#define BLOCK_SIZE  0x4000
-#define BLOCK_MASK  0x3fff
+/* Raised from 0x4000 (halves recompile thrash, measured on x86-64 - see
+   codegen_backend_x86-64.h, raised further there to 0x10000). Kept lower
+   here not for memory reasons - codeblock[] below is a plain data mmap
+   (see codegen_backend_arm64.c), not executable, so it doesn't compete
+   with ARM64's 128MB branch-range-limited code pool in codegen_allocator.c
+   - but because NEW_DYNAREC is mandatory on ARM64, so an untested value
+   would ship to every user by default. */
+#define BLOCK_SIZE  0x8000
+#define BLOCK_MASK  0x7fff
 #define BLOCK_START 0
 
 #define HASH_SIZE   0x20000

--- a/src/codegen_new/codegen_backend_x86-64.h
+++ b/src/codegen_new/codegen_backend_x86-64.h
@@ -1,7 +1,10 @@
 #include "codegen_backend_x86-64_defs.h"
 
-#define BLOCK_SIZE  0x4000
-#define BLOCK_MASK  0x3fff
+/* Raised from 0x4000 - too small to hold both status variants (16/32-bit,
+   flat/non-flat) of hot code at once, causing recompile thrash. This is the
+   max: block indices are uint16_t. */
+#define BLOCK_SIZE  0x10000
+#define BLOCK_MASK  0xffff
 #define BLOCK_START 0
 
 #define HASH_SIZE   0x20000

--- a/src/codegen_new/codegen_ops_fpu_arith.c
+++ b/src/codegen_new/codegen_ops_fpu_arith.c
@@ -32,6 +32,8 @@ ropFADD(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uint3
 {
     int src_reg = fetchdat & 7;
 
+    if ((cpu_state.npxc >> 10) & 3)
+        return 0;
     uop_FP_ENTER(ir);
     uop_FADD(ir, IREG_ST(0), IREG_ST(0), IREG_ST(src_reg));
     uop_FROUND_PC(ir, IREG_ST(0));
@@ -44,6 +46,8 @@ ropFADDr(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uint
 {
     int dest_reg = fetchdat & 7;
 
+    if ((cpu_state.npxc >> 10) & 3)
+        return 0;
     uop_FP_ENTER(ir);
     uop_FADD(ir, IREG_ST(dest_reg), IREG_ST(dest_reg), IREG_ST(0));
     uop_FROUND_PC(ir, IREG_ST(dest_reg));
@@ -56,6 +60,8 @@ ropFADDP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fet
 {
     int dest_reg = fetchdat & 7;
 
+    if ((cpu_state.npxc >> 10) & 3)
+        return 0;
     uop_FP_ENTER(ir);
     uop_FADD(ir, IREG_ST(dest_reg), IREG_ST(dest_reg), IREG_ST(0));
     uop_FROUND_PC(ir, IREG_ST(dest_reg));
@@ -107,6 +113,8 @@ ropFDIV(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uint3
 {
     int src_reg = fetchdat & 7;
 
+    if ((cpu_state.npxc >> 10) & 3)
+        return 0;
     uop_FP_ENTER(ir);
     uop_FDIV(ir, IREG_ST(0), IREG_ST(0), IREG_ST(src_reg));
     uop_FROUND_PC(ir, IREG_ST(0));
@@ -119,6 +127,8 @@ ropFDIVR(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uint
 {
     int src_reg = fetchdat & 7;
 
+    if ((cpu_state.npxc >> 10) & 3)
+        return 0;
     uop_FP_ENTER(ir);
     uop_FDIV(ir, IREG_ST(0), IREG_ST(src_reg), IREG_ST(0));
     uop_FROUND_PC(ir, IREG_ST(0));
@@ -131,6 +141,8 @@ ropFDIVr(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uint
 {
     int dest_reg = fetchdat & 7;
 
+    if ((cpu_state.npxc >> 10) & 3)
+        return 0;
     uop_FP_ENTER(ir);
     uop_FDIV(ir, IREG_ST(dest_reg), IREG_ST(dest_reg), IREG_ST(0));
     uop_FROUND_PC(ir, IREG_ST(dest_reg));
@@ -143,6 +155,8 @@ ropFDIVRr(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uin
 {
     int dest_reg = fetchdat & 7;
 
+    if ((cpu_state.npxc >> 10) & 3)
+        return 0;
     uop_FP_ENTER(ir);
     uop_FDIV(ir, IREG_ST(dest_reg), IREG_ST(0), IREG_ST(dest_reg));
     uop_FROUND_PC(ir, IREG_ST(dest_reg));
@@ -155,6 +169,8 @@ ropFDIVP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fet
 {
     int dest_reg = fetchdat & 7;
 
+    if ((cpu_state.npxc >> 10) & 3)
+        return 0;
     uop_FP_ENTER(ir);
     uop_FDIV(ir, IREG_ST(dest_reg), IREG_ST(dest_reg), IREG_ST(0));
     uop_FROUND_PC(ir, IREG_ST(dest_reg));
@@ -168,6 +184,8 @@ ropFDIVRP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fe
 {
     int dest_reg = fetchdat & 7;
 
+    if ((cpu_state.npxc >> 10) & 3)
+        return 0;
     uop_FP_ENTER(ir);
     uop_FDIV(ir, IREG_ST(dest_reg), IREG_ST(0), IREG_ST(dest_reg));
     uop_FROUND_PC(ir, IREG_ST(dest_reg));
@@ -182,6 +200,8 @@ ropFMUL(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uint3
 {
     int src_reg = fetchdat & 7;
 
+    if ((cpu_state.npxc >> 10) & 3)
+        return 0;
     uop_FP_ENTER(ir);
     uop_FMUL(ir, IREG_ST(0), IREG_ST(0), IREG_ST(src_reg));
     uop_FROUND_PC(ir, IREG_ST(0));
@@ -194,6 +214,8 @@ ropFMULr(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uint
 {
     int dest_reg = fetchdat & 7;
 
+    if ((cpu_state.npxc >> 10) & 3)
+        return 0;
     uop_FP_ENTER(ir);
     uop_FMUL(ir, IREG_ST(dest_reg), IREG_ST(dest_reg), IREG_ST(0));
     uop_FROUND_PC(ir, IREG_ST(dest_reg));
@@ -206,6 +228,8 @@ ropFMULP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fet
 {
     int dest_reg = fetchdat & 7;
 
+    if ((cpu_state.npxc >> 10) & 3)
+        return 0;
     uop_FP_ENTER(ir);
     uop_FMUL(ir, IREG_ST(dest_reg), IREG_ST(dest_reg), IREG_ST(0));
     uop_FROUND_PC(ir, IREG_ST(dest_reg));
@@ -220,6 +244,8 @@ ropFSUB(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uint3
 {
     int src_reg = fetchdat & 7;
 
+    if ((cpu_state.npxc >> 10) & 3)
+        return 0;
     uop_FP_ENTER(ir);
     uop_FSUB(ir, IREG_ST(0), IREG_ST(0), IREG_ST(src_reg));
     uop_FROUND_PC(ir, IREG_ST(0));
@@ -232,6 +258,8 @@ ropFSUBR(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uint
 {
     int src_reg = fetchdat & 7;
 
+    if ((cpu_state.npxc >> 10) & 3)
+        return 0;
     uop_FP_ENTER(ir);
     uop_FSUB(ir, IREG_ST(0), IREG_ST(src_reg), IREG_ST(0));
     uop_FROUND_PC(ir, IREG_ST(0));
@@ -244,6 +272,8 @@ ropFSUBr(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uint
 {
     int dest_reg = fetchdat & 7;
 
+    if ((cpu_state.npxc >> 10) & 3)
+        return 0;
     uop_FP_ENTER(ir);
     uop_FSUB(ir, IREG_ST(dest_reg), IREG_ST(dest_reg), IREG_ST(0));
     uop_FROUND_PC(ir, IREG_ST(dest_reg));
@@ -256,6 +286,8 @@ ropFSUBRr(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), uin
 {
     int dest_reg = fetchdat & 7;
 
+    if ((cpu_state.npxc >> 10) & 3)
+        return 0;
     uop_FP_ENTER(ir);
     uop_FSUB(ir, IREG_ST(dest_reg), IREG_ST(0), IREG_ST(dest_reg));
     uop_FROUND_PC(ir, IREG_ST(dest_reg));
@@ -268,6 +300,8 @@ ropFSUBP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fet
 {
     int dest_reg = fetchdat & 7;
 
+    if ((cpu_state.npxc >> 10) & 3)
+        return 0;
     uop_FP_ENTER(ir);
     uop_FSUB(ir, IREG_ST(dest_reg), IREG_ST(dest_reg), IREG_ST(0));
     uop_FROUND_PC(ir, IREG_ST(dest_reg));
@@ -281,6 +315,8 @@ ropFSUBRP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fe
 {
     int dest_reg = fetchdat & 7;
 
+    if ((cpu_state.npxc >> 10) & 3)
+        return 0;
     uop_FP_ENTER(ir);
     uop_FSUB(ir, IREG_ST(dest_reg), IREG_ST(0), IREG_ST(dest_reg));
     uop_FROUND_PC(ir, IREG_ST(dest_reg));
@@ -387,6 +423,8 @@ ropFUCOMPP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), UNUSED(uin
     {                                                                                          \
         x86seg *target_seg;                                                                    \
                                                                                                \
+        if ((cpu_state.npxc >> 10) & 3)                                                        \
+            return 0;                                                                          \
         uop_FP_ENTER(ir);                                                                      \
         uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);                                          \
         op_pc--;                                                                               \
@@ -404,6 +442,8 @@ ropFUCOMPP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), UNUSED(uin
     {                                                                                          \
         x86seg *target_seg;                                                                    \
                                                                                                \
+        if ((cpu_state.npxc >> 10) & 3)                                                        \
+            return 0;                                                                          \
         uop_FP_ENTER(ir);                                                                      \
         uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);                                          \
         op_pc--;                                                                               \
@@ -421,6 +461,8 @@ ropFUCOMPP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), UNUSED(uin
     {                                                                                          \
         x86seg *target_seg;                                                                    \
                                                                                                \
+        if ((cpu_state.npxc >> 10) & 3)                                                        \
+            return 0;                                                                          \
         uop_FP_ENTER(ir);                                                                      \
         uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);                                          \
         op_pc--;                                                                               \
@@ -438,6 +480,8 @@ ropFUCOMPP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), UNUSED(uin
     {                                                                                          \
         x86seg *target_seg;                                                                    \
                                                                                                \
+        if ((cpu_state.npxc >> 10) & 3)                                                        \
+            return 0;                                                                          \
         uop_FP_ENTER(ir);                                                                      \
         uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);                                          \
         op_pc--;                                                                               \
@@ -455,6 +499,8 @@ ropFUCOMPP(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), UNUSED(uin
     {                                                                                          \
         x86seg *target_seg;                                                                    \
                                                                                                \
+        if ((cpu_state.npxc >> 10) & 3)                                                        \
+            return 0;                                                                          \
         uop_FP_ENTER(ir);                                                                      \
         uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);                                          \
         op_pc--;                                                                               \
@@ -479,6 +525,8 @@ ropF_arith_mem(d, uop_MEM_LOAD_DOUBLE)
     {                                                                                          \
         x86seg *target_seg;                                                                    \
                                                                                                \
+        if ((cpu_state.npxc >> 10) & 3)                                                        \
+            return 0;                                                                          \
         uop_FP_ENTER(ir);                                                                      \
         uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);                                          \
         op_pc--;                                                                               \
@@ -534,6 +582,8 @@ ropF_arith_mem(d, uop_MEM_LOAD_DOUBLE)
     {                                                                                          \
         x86seg *target_seg;                                                                    \
                                                                                                \
+        if ((cpu_state.npxc >> 10) & 3)                                                        \
+            return 0;                                                                          \
         uop_FP_ENTER(ir);                                                                      \
         uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);                                          \
         op_pc--;                                                                               \
@@ -552,6 +602,8 @@ ropF_arith_mem(d, uop_MEM_LOAD_DOUBLE)
     {                                                                                          \
         x86seg *target_seg;                                                                    \
                                                                                                \
+        if ((cpu_state.npxc >> 10) & 3)                                                        \
+            return 0;                                                                          \
         uop_FP_ENTER(ir);                                                                      \
         uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);                                          \
         op_pc--;                                                                               \
@@ -570,6 +622,8 @@ ropF_arith_mem(d, uop_MEM_LOAD_DOUBLE)
     {                                                                                          \
         x86seg *target_seg;                                                                    \
                                                                                                \
+        if ((cpu_state.npxc >> 10) & 3)                                                        \
+            return 0;                                                                          \
         uop_FP_ENTER(ir);                                                                      \
         uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);                                          \
         op_pc--;                                                                               \
@@ -588,6 +642,8 @@ ropF_arith_mem(d, uop_MEM_LOAD_DOUBLE)
     {                                                                                          \
         x86seg *target_seg;                                                                    \
                                                                                                \
+        if ((cpu_state.npxc >> 10) & 3)                                                        \
+            return 0;                                                                          \
         uop_FP_ENTER(ir);                                                                      \
         uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);                                          \
         op_pc--;                                                                               \
@@ -606,6 +662,8 @@ ropF_arith_mem(d, uop_MEM_LOAD_DOUBLE)
     {                                                                                          \
         x86seg *target_seg;                                                                    \
                                                                                                \
+        if ((cpu_state.npxc >> 10) & 3)                                                        \
+            return 0;                                                                          \
         uop_FP_ENTER(ir);                                                                      \
         uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);                                          \
         op_pc--;                                                                               \
@@ -647,6 +705,8 @@ ropFCHS(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), UNUSE
 uint32_t
 ropFSQRT(UNUSED(codeblock_t *block), ir_data_t *ir, UNUSED(uint8_t opcode), UNUSED(uint32_t fetchdat), UNUSED(uint32_t op_32), uint32_t op_pc)
 {
+    if ((cpu_state.npxc >> 10) & 3)
+        return 0;
     uop_FP_ENTER(ir);
     uop_FSQRT(ir, IREG_ST(0), IREG_ST(0));
     uop_FROUND_PC(ir, IREG_ST(0));

--- a/src/cpu/386_dynarec.c
+++ b/src/cpu/386_dynarec.c
@@ -500,6 +500,10 @@ exec386_dynarec_dyn(void)
         cpu_cur_status &= ~CPU_STATUS_FPU_PC24;
     else
         cpu_cur_status |= CPU_STATUS_FPU_PC24;
+    if ((cpu_state.npxc >> 10) & 3)
+        cpu_cur_status |= CPU_STATUS_FPU_RC_NZ;
+    else
+        cpu_cur_status &= ~CPU_STATUS_FPU_RC_NZ;
 
 #    ifdef USE_NEW_DYNAREC
     if (!cpu_state.abrt)

--- a/src/cpu/cpu.h
+++ b/src/cpu/cpu.h
@@ -459,6 +459,10 @@ typedef struct {
    ADD/SUB/MUL/DIV/SQRT results to single, so such blocks are compiled
    with a round-to-single uop after each of those ops. */
 #define CPU_STATUS_FPU_PC24 (1 << 5)
+/* x87 rounding control != nearest: only FADD's memory-operand form
+   bails to the interpreter for it (other FPU arith always rounds to
+   nearest); such blocks must not be reused once RC changes. */
+#define CPU_STATUS_FPU_RC_NZ (1 << 6)
 #ifdef USE_NEW_DYNAREC
 #    define CPU_STATUS_FLAGS 0xff
 #else

--- a/src/cpu/x87_ops.h
+++ b/src/cpu/x87_ops.h
@@ -85,16 +85,16 @@ typedef union {
             (r) = (double) (float) (r);       \
     } while (0)
 
-/* Dynarec blocks are keyed on PC=24, but FLDCW/FLDENV/FRSTOR/FSAVE run
-   as helper calls inside a block: a precision change must end the block
-   so the ops after it are compiled under the new precision. */
-#define x87_set_control_word(w)                                              \
-    do {                                                                     \
-        uint16_t old_npxc_ = cpu_state.npxc;                                 \
-        cpu_state.npxc     = (w);                                            \
-        codegen_set_rounding_mode((cpu_state.npxc >> 10) & 3);               \
-        if ((!(old_npxc_ & 0x300)) != (!(cpu_state.npxc & 0x300)))           \
-            CPU_BLOCK_END();                                                 \
+/* Dynarec blocks are keyed on PC=24 and RC!=nearest, but FLDCW/FLDENV/
+   FRSTOR/FSAVE run as helper calls inside a block: a change to either must
+   end the block so the ops after it are compiled under the new value. */
+#define x87_set_control_word(w)                                                                                                 \
+    do {                                                                                                                        \
+        uint16_t old_npxc_ = cpu_state.npxc;                                                                                    \
+        cpu_state.npxc     = (w);                                                                                               \
+        codegen_set_rounding_mode((cpu_state.npxc >> 10) & 3);                                                                  \
+        if (((!(old_npxc_ & 0x300)) != (!(cpu_state.npxc & 0x300))) || ((!(old_npxc_ & 0xc00)) != (!(cpu_state.npxc & 0xc00)))) \
+            CPU_BLOCK_END();                                                                                                    \
     } while (0)
 
 #ifdef FPU_8087


### PR DESCRIPTION
Summary
=======
**_Note: AI-assisted with Claude Opus 5. As usual, I used Claude for the initial investigation and implementation, verified the VMs by myself. Impact of the code-block size limit was measured with instrumented builds, looking for cache misses. Tested on amd64. **Untested** on ARM64 since I don't have the proper hardware._**

**_The description of this PR is written by myself, representing my understanding of the code changes - correct me if I am wrong._**

The whole debugging and rewriting "saga" was done about multiple days in independent sessions.

This PR consists of two parts.

https://github.com/86Box/86Box/commit/8cd8365a1a3acba15d2eb164e564fffaeae5cd96 raises the limit for code that can reside recompiled and ready for re-use. I tried to trace back where the original values come from, but I couldn't find any evidence since this was bulk-imported into this repo. The new limits now match the theoretical ceilings for AMD64 and ARM64, so these should be the highest values possible.

**Impact:**
This solves frequent slowdowns in Windows 98 SE for me, the configuration I posted below now runs at a nearly consistent 100% in Windows 98 when using the "bare" system (like browsing around in the file browser, especially through "My Computer"). Previously, I had _frequent_ drops **below 70%** at each context switch. This also had a positive effect on some games I tested, but that's hard to measure.

I have an application that uses 32-16-bit thunking, at it still works as expected. I couldn't spot any regressions here during my tests.

https://github.com/86Box/86Box/commit/9ddbca7b62d908e3d74f72131a9c2d5bca40d8af and https://github.com/86Box/86Box/commit/f523faa5f2939ccb09a8cccbbc6355f8923bc16c are meant to fix accuracy issues with the FPU, where alignment issues between the "original" code and the recompiled one could lead to stale cache reads, which - to my understanding - would cause corrupt data.

**Impact:**
I tested the FPU with "Super Pi", and the effect to emulation speed is within the margin of error. However, after this patch, I lost about 200-300ms on a run that lasted for ~60 seconds, but I also experienced variations of 100-300ms _without_ it. I am not sure how to test this otherwise. Didn't experienced any crashes though, so it should not negatively impact accuracy.

---

**Source:**
A summary of Claude's reasoning is available here in Markdown format; I asked it to "write a summary about your changes".
https://gist.github.com/lotharsm/dcbed4d3e605ed4a439ed58fb5441d14

I checked this against my session transcripts, and it matches what I was seeing earlier when debugging this.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/
* [ ] This pull request adds, changes or removes an external dependency
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/

References
==========
* `src/cpu/cpu.h:377` - `double ST[8]`, the non-Softfloat FPU register storage (background context, not changed here)
* `src/codegen_new/codegen_allocator.c:40-60` (`remove_from_block_list`), `123-150` (`codegen_allocator_allocate`) - the two allocator bugs
* `src/codegen_new/codegen_block.c:388-408` - `codegen_delete_block`/`delete_block` call chain that confirms the use-after-unlink read
* `src/codegen_new/codegen_backend_arm64.c:292`, `src/codegen_new/codegen_backend_x86-64.c:299` - `codeblock[]` allocation (`plat_mmap`, non-executable)
* `src/include/86box/plat.h:150` - `plat_mmap`'s `executable` argument
* `src/codegen_new/codegen_allocator.h:20-26` - `MEM_BLOCK_NR`/`MEM_BLOCK_SIZE` (the actual 128 MB-constrained pool)
* `src/cpu/386_dynarec.c:496-506` - shared PC/RC status-bit tracking (both dynarecs)
* `src/cpu/x87_ops.h:88-96` - `x87_set_control_word` block-end logic
* `src/codegen_new/codegen_ops_fpu_arith.c` - all `ropF*`/`ropFI*` opcode implementations and the RC guard
* `src/codegen_new/codegen_backend_x86-64_uops.c:1394-1440` - `codegen_MOV_INT_DOUBLE`/`_64`, the only actual `LDMXCSR`/host-rounding consumers in the backend
* Git history: `552a87ea3d27977e74f5c0eaa44aaaa9b708bf2e`, `9e77acf6557dbad69c91b6a886b921cbc35371d6`, `f3ee26f1eb6d9a9064428c4bf28f2d3ff4e3ea15` (BLOCK_SIZE provenance)

VM configuration
==========
```
[General]
emu_build_dynarec_type = new
force_43 = 1
host_cpu = AMD Ryzen 5 3600 6-Core Processor              
mouse_sensitivity = 0.6
uuid = c0a0fb83-6a6b-5b5c-9e2a-eb17b8e64265
vid_renderer = qt_opengl3
vid_resize = 1
window_remember = 1

[Machine]
cpu_dyn_accurate_fpu_env = 1
cpu_family = pentium_p55c
cpu_multi = 2.5
cpu_speed = 166666666
cpu_use_dynarec = 1
cpu_use_dynarec_fast = 1
fpu_type = internal
machine = pb680
mem_size = 65536

[Video]
gfxcard = mystique_220
video_fullscreen_scale_maximized = 1

[Input devices]
keyboard_type = keyboard_ps2
mouse_type = ps2
tablet_type = none

[Network]
net_01_link = 0
net_02_link = 0
net_03_link = 0
net_04_link = 0

[Storage controllers]
fdc = none
hdc_1 = ide_pci_2ch

[PS/2 Mouse]
buttons = 4

[Ports (COM & LPT)]
lpt1_device = postscript

[Floppy and CD-ROM drives]
cdrom_01_ide_channel = 0:1
cdrom_01_image_history_01 = something.iso
cdrom_01_parameters = 1, atapi
cdrom_01_speed = 48
cdrom_01_type = 86dvd
fdd_01_type = 35_2hd
fdd_02_type = none

[Other peripherals]
unittester_enabled = 1

[Monitor #1]
window_coordinates = 347, 77, 1791, 1183

[Monitor #2]
window_coordinates = 0, 0, 0, 0

[BusLogic BT-958D PCI #1]
bios = 1

[ATI Rage Fury Pro AGP #1]
gpu_raster = 0
realtime_pacing = 1
render_threads = 1

[Gigabyte GA-686BX]
bios = pii3100

[Hard disks]
hdd_01_fn = something.vhd
hdd_01_ide_channel = 0:0
hdd_01_parameters = 63, 16, 33288, 0, ide
hdd_01_speed = 2000_7200rpm
hdd_01_vhd_blocksize = 4096

[Creative Sound Blaster PCI 128 (ES1373) #1]
receive_input = 0

[Sound]
sndcard = sb16

```