### PR TITLE
Fix the IN530 hardware conflicts

### DIFF
--- a/src/chipset/sis_5513_ide.c
+++ b/src/chipset/sis_5513_ide.c
@@ -21,6 +21,7 @@
 #define HAVE_STDARG_H
 #include <86box/86box.h>
 #include <86box/device.h>
+#include <86box/machine.h>
 #include <86box/io.h>
 #include <86box/timer.h>
 #include <86box/dma.h>
@@ -285,6 +286,10 @@ sis_5513_ide_write(int addr, uint8_t val, void *priv)
                    break;
                 case 0xd0:
                    dev->pci_conf[addr] = val;
+                   break;
+                case 0xd1:
+                   if (machines[machine].init == machine_at_in530_init)
+                       dev->pci_conf[addr] = val;
                    break;
             }
             sis_5513_ide_handler(dev);

--- a/src/chipset/sis_5513_p2i.c
+++ b/src/chipset/sis_5513_p2i.c
@@ -48,6 +48,7 @@
 #include <86box/smbus.h>
 #include <86box/sis_55xx.h>
 #include <86box/chipset.h>
+#include <86box/sio.h>
 
 #ifdef ENABLE_SIS_5513_PCI_TO_ISA_LOG
 int sis_5513_pci_to_isa_do_log = ENABLE_SIS_5513_PCI_TO_ISA_LOG;
@@ -621,13 +622,49 @@ sis_5513_b0_pci_to_isa_write(int addr, uint8_t val, sis_5513_pci_to_isa_t *dev)
                  pci_set_mirq_routing(PCI_MIRQ3, val & 0xf);
             break;
 
-        case 0x63: /* PCI OutputBuffer Current Strength Register */
+        case 0x63: /* PCI OutputBuffer Current Strength Register */ {
+            const uint8_t reset_before = dev->pci_conf[addr];
+            const int     is_in530     = (machines[machine].init == machine_at_in530_init);
+
             dev->pci_conf[addr] = val;
             if ((dev->apc_regs[0x03] & 0x40) && (val & 0x04)) {
                 plat_power_off();
                 return;
             }
-            if ((val & 0x18) == 0x18) {
+
+            if (is_in530) {
+                const int sw_reset_trigger =
+                    (((val & 0x18) == 0x18) &&
+                     ((reset_before & 0x18) != 0x18));
+
+                if (sw_reset_trigger) {
+                    if (!cpu_cpurst_on_sr) {
+                        w83877_in530_master_reset();
+
+                        softresetx86();
+                        cpu_set_edx();
+
+                        mem_a20_reset_vector_bypass_once();
+                        flushmmucache();
+                    } else {
+                        dma_reset();
+                        dma_set_at(1);
+
+                        device_reset_all(DEVICE_ALL);
+
+                        cpu_alt_reset = 0;
+
+                        pci_reset();
+
+                        mem_a20_alt = 0;
+                        mem_a20_recalc();
+
+                        flushmmucache();
+
+                        resetx86();
+                    }
+                }
+            } else if ((val & 0x18) == 0x18) {
                 dma_reset();
                 dma_set_at(1);
 
@@ -645,6 +682,7 @@ sis_5513_b0_pci_to_isa_write(int addr, uint8_t val, sis_5513_pci_to_isa_t *dev)
                 resetx86();
             }
             break;
+        }
 
         case 0x64: /* INIT Enable Register */
             dev->pci_conf[addr] = val;

--- a/src/include/86box/mem.h
+++ b/src/include/86box/mem.h
@@ -446,6 +446,7 @@ extern void mem_debug_check_addr(uint32_t addr, int write);
 
 extern void mem_a20_init(void);
 extern void mem_a20_recalc(void);
+extern void mem_a20_reset_vector_bypass_once(void);
 
 extern void mem_init(void);
 extern void mem_close(void);

--- a/src/include/86box/sio.h
+++ b/src/include/86box/sio.h
@@ -198,6 +198,9 @@ extern const device_t w837x7_device;
 
 extern const device_t w83877_device;
 
+/* Reset the IN530's W83877TF through its board-level master reset path. */
+extern void w83877_in530_master_reset(void);
+
 #define W83977F             0x977100
 #define W83977TF            0x977300
 #define W83977EF            0x52f000

--- a/src/machine/m_at_sockets7.c
+++ b/src/machine/m_at_sockets7.c
@@ -651,6 +651,8 @@ machine_at_k6bv3p_a_init(const machine_t *model)
     return ret;
 }
 
+/* SiS 530 / 5595 */
+
 static int in530_boot_logo_enabled = 1;
 
 static const device_config_t in530_config[] = {
@@ -752,7 +754,6 @@ machine_in530_boot_logo_enabled(void)
     return in530_boot_logo_enabled;
 }
 
-/* SiS 530 / 5595 */
 int
 machine_at_in530_init(const machine_t *model)
 {
@@ -786,7 +787,8 @@ machine_at_in530_init(const machine_t *model)
     pci_register_slot(0x0C, PCI_CARD_SOUND,           4, 1, 2, 3);
 
     device_add(&sis_530_device);
-    device_add_params(&w83877_device, (void *) (W83877TF | W83877_3F0));
+    /* Ext func high, PNP conf low, BIOS assigns the legacy resources. */
+    device_add_params(&w83877_device, (void *) (W83877TF | (W83877_3F0 & ~0x04)));
     device_add(&amd_flash_29f002nbt_device);
     spd_register(SPD_TYPE_SDRAM, 0x3, 512);
 

--- a/src/mem/mem.c
+++ b/src/mem/mem.c
@@ -71,6 +71,15 @@ uint32_t pages_sz;    /* #pages in table */
 uint8_t *ram;  /* the virtual RAM */
 uint8_t  page_ff[4096];
 uint32_t rammask;
+
+/* IN530 INIT reset path. */
+static int mem_a20_reset_vector_bypass = 0;
+
+void
+mem_a20_reset_vector_bypass_once(void)
+{
+    mem_a20_reset_vector_bypass = 1;
+}
 uint32_t addr_space_size;
 
 uint8_t *rom; /* the virtual ROM */
@@ -673,7 +682,11 @@ getpccache(uint32_t a)
         if (a64 == 0xffffffffffffffffULL)
             return ram;
     }
-    a64 &= rammask;
+    if (mem_a20_reset_vector_bypass &&
+        ((a & 0xfffff000U) == 0xfffff000U))
+        mem_a20_reset_vector_bypass = 0;
+    else
+        a64 &= rammask;
 
     if (_mem_exec[a64 >> MEM_GRANULARITY_BITS]) {
         if (is286) {

--- a/src/sio/sio_w83877.c
+++ b/src/sio/sio_w83877.c
@@ -73,6 +73,8 @@ typedef struct w83877_t {
     lpt_t    *lpt;
 } w83877_t;
 
+static w83877_t *in530_w83877_mr_dev = NULL;
+
 static void    w83877_write(uint16_t port, uint8_t val, void *priv);
 static uint8_t w83877_read(uint16_t port, void *priv);
 
@@ -360,7 +362,24 @@ w83877_write(uint16_t port, uint8_t val, void *priv)
                 w83877_remap(dev);
             break;
         case 0x16:
-            if (valxor & 0x02) {
+            if (machines[machine].init == machine_at_in530_init) {
+                if (valxor & 0x04) {
+                    const uint8_t pnp_defaults = val & 0x04;
+
+                    dev->regs[0x20] = pnp_defaults ? 0xfc : 0x00;
+                    dev->regs[0x23] = pnp_defaults ? 0xde : 0x00;
+                    dev->regs[0x24] = pnp_defaults ? 0xfe : 0x00;
+                    dev->regs[0x25] = pnp_defaults ? 0xbe : 0x00;
+                    dev->regs[0x26] = pnp_defaults ? 0x23 : 0x00;
+                    dev->regs[0x27] = pnp_defaults ? 0x05 : 0x00;
+                    dev->regs[0x28] = pnp_defaults ? 0x43 : 0x00;
+                    dev->regs[0x29] = pnp_defaults ? 0x60 : 0x00;
+                    w83877_fdc_handler(dev);
+                    w83877_lpt_handler(dev);
+                    w83877_serial_handler(dev, 0);
+                    w83877_serial_handler(dev, 1);
+                }
+            } else if (valxor & 0x02) {
                 dev->regs[0x1e] = (val & 0x02) ? 0x81 : 0x00;
                 dev->regs[0x20] = (val & 0x02) ? 0xfc : 0x00;
                 dev->regs[0x21] = (val & 0x02) ? 0x7c : 0x00;
@@ -470,18 +489,33 @@ w83877_reset(w83877_t *dev)
     dev->regs[0x0a] = 0x1f;
     dev->regs[0x0c] = 0x28;
     dev->regs[0x0d] = 0xa3;
-    dev->regs[0x16] = (dev->reg_init & 0xff) | 0x02;
-    dev->regs[0x1e] = 0x81;
-    dev->regs[0x20] = 0xfc;
-    dev->regs[0x21] = 0x7c;
-    dev->regs[0x22] = 0xfd;
-    dev->regs[0x23] = 0xde;
-    dev->regs[0x24] = 0xfe;
-    dev->regs[0x25] = 0xbe;
-    dev->regs[0x26] = 0x23;
-    dev->regs[0x27] = 0x65;
-    dev->regs[0x28] = 0x43;
-    dev->regs[0x29] = 0x62;
+    if (machines[machine].init == machine_at_in530_init) {
+        dev->regs[0x16] = dev->reg_init & 0xff;
+        dev->regs[0x1e] = 0x81;
+        dev->regs[0x20] = (dev->regs[0x16] & 0x04) ? 0xfc : 0x00;
+        dev->regs[0x21] = 0x7c;
+        dev->regs[0x22] = 0xfd;
+        dev->regs[0x23] = (dev->regs[0x16] & 0x04) ? 0xde : 0x00;
+        dev->regs[0x24] = (dev->regs[0x16] & 0x04) ? 0xfe : 0x00;
+        dev->regs[0x25] = (dev->regs[0x16] & 0x04) ? 0xbe : 0x00;
+        dev->regs[0x26] = (dev->regs[0x16] & 0x04) ? 0x23 : 0x00;
+        dev->regs[0x27] = (dev->regs[0x16] & 0x04) ? 0x05 : 0x00;
+        dev->regs[0x28] = (dev->regs[0x16] & 0x04) ? 0x43 : 0x00;
+        dev->regs[0x29] = (dev->regs[0x16] & 0x04) ? 0x60 : 0x00;
+    } else {
+        dev->regs[0x16] = (dev->reg_init & 0xff) | 0x02;
+        dev->regs[0x1e] = 0x81;
+        dev->regs[0x20] = 0xfc;
+        dev->regs[0x21] = 0x7c;
+        dev->regs[0x22] = 0xfd;
+        dev->regs[0x23] = 0xde;
+        dev->regs[0x24] = 0xfe;
+        dev->regs[0x25] = 0xbe;
+        dev->regs[0x26] = 0x23;
+        dev->regs[0x27] = 0x65;
+        dev->regs[0x28] = 0x43;
+        dev->regs[0x29] = 0x62;
+    }
 
     w83877_fdc_handler(dev);
     fdc_clear_flags(dev->fdc, FDC_FLAG_PS2 | FDC_FLAG_PS2_MCA);
@@ -504,10 +538,24 @@ w83877_reset(w83877_t *dev)
     dev->rw_locked = 0;
 }
 
+void
+w83877_in530_master_reset(void)
+{
+    w83877_t *dev = in530_w83877_mr_dev;
+
+    if ((dev == NULL) || (dev->reg_init != (W83877TF | 0x0001)))
+        return;
+
+    w83877_reset(dev);
+}
+
 static void
 w83877_close(void *priv)
 {
     w83877_t *dev = (w83877_t *) priv;
+
+    if (in530_w83877_mr_dev == dev)
+        in530_w83877_mr_dev = NULL;
 
     free(dev);
 }
@@ -525,6 +573,10 @@ w83877_init(const device_t *info)
     dev->lpt = device_add_inst(&lpt_port_device, 1);
 
     dev->reg_init = info->local;
+
+    if ((machines[machine].init == machine_at_in530_init) &&
+        (dev->reg_init == (W83877TF | 0x0001)))
+        in530_w83877_mr_dev = dev;
 
     dev->has_ide = (info->local >> 16) & 0xff;
 


### PR DESCRIPTION
Summary
=======
This fixes the IN530's device IRQ/port conflicts made by the Super I/O chip and the BIOS' own PnP programming, which then also fixes a reboot error.  All changes are made to the IN530 only as they broke other machines using the same chipset.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended

References
==========
W83877TF datasheet
