### PR TITLE
Make PCjr cartridges slightly more conform to the PCjr and PC JX Technical References

### DIFF
--- a/src/device/cartridge.c
+++ b/src/device/cartridge.c
@@ -31,14 +31,16 @@
 typedef struct cart_t {
     uint8_t *buf;
     uint32_t base;
+    uint32_t size;
 } cart_t;
 
-char cart_fns[2][MAX_IMAGE_PATH_LEN];
+char  cart_fns[2][MAX_IMAGE_PATH_LEN];
 char *cart_image_history[2][CART_IMAGE_HISTORY];
 
 static cart_t carts[2];
 
 static mem_mapping_t cart_mappings[2];
+static uint8_t       cart_mapping_registered[2];
 
 #ifdef ENABLE_CARTRIDGE_LOG
 int cartridge_do_log = ENABLE_CARTRIDGE_LOG;
@@ -63,7 +65,7 @@ cart_read(uint32_t addr, void *priv)
 {
     const cart_t *dev = (cart_t *) priv;
 
-    return dev->buf[addr - dev->base];
+    return (addr >= dev->base && addr - dev->base < dev->size) ? dev->buf[addr - dev->base] : 0xff;
 }
 
 static void
@@ -77,81 +79,97 @@ cart_load_error(int drive, UNUSED(char *fn))
 static void
 cart_image_close(int drive)
 {
-    if (carts[drive].buf != NULL) {
-        free(carts[drive].buf);
-        carts[drive].buf = NULL;
-    }
+    if (cart_mapping_registered[drive])
+        mem_mapping_disable(&cart_mappings[drive]);
 
-    carts[drive].base = 0x00000000;
-
-    mem_mapping_disable(&cart_mappings[drive]);
+    free(carts[drive].buf);
+    memset(&carts[drive], 0, sizeof(carts[drive]));
 }
 
-static void
+static int
 cart_image_load(int drive, char *fn)
 {
-    FILE    *fp   = NULL;
-    uint32_t size = 0;
-    uint32_t base = 0x00000000;
+    FILE         *fp;
+    uint8_t      *buf = NULL;
+    uint8_t       header[512];
+    uint32_t      size;
+    uint32_t      base;
+    long          length;
+    const cart_t *other = &carts[drive ^ 1];
 
     cart_image_close(drive);
 
-    fp = fopen(fn, "rb");
-    if (fseek(fp, 0, SEEK_END) == -1)
-        fatal("cart_image_load(): Error seeking to the end of the file\n");
-    size = ftell(fp);
-    if (size < 0x1200) {
-        cartridge_log("cart_image_load(): File size %i is too small\n", size);
-        cart_load_error(drive, fn);
-        fclose(fp);
-        return;
-    }
-    if (size & 0x00000fff) {
-        size -= 0x00000200;
-        fseek(fp, 0x000001ce, SEEK_SET);
-        (void) !fread(&base, 1, 2, fp);
-        base <<= 4;
-        fseek(fp, 0x00000200, SEEK_SET);
-        carts[drive].buf = (uint8_t *) calloc(1, size);
-        (void) !fread(carts[drive].buf, 1, size, fp);
-        fclose(fp);
-    } else {
+    fp = plat_fopen(fn, "rb");
+    if (!fp)
+        goto fail;
+    if (fseek(fp, 0, SEEK_END) != 0)
+        goto fail;
+    length = ftell(fp);
+    if (length < 0x1200 || length > 0x100200 || fseek(fp, 0, SEEK_SET) != 0)
+        goto fail;
+
+    size = (uint32_t) length;
+    if ((size & 0xfff) == 0x200) {
+        if (fread(header, 1, sizeof(header), fp) != sizeof(header))
+            goto fail;
+        size -= sizeof(header);
+        base = ((uint32_t) header[0x1ce] | ((uint32_t) header[0x1cf] << 8)) << 4;
+    } else if (!(size & 0xfff)) {
         base = drive ? 0xe0000 : 0xd0000;
-        if (size == 32768)
+        if (size == 0x8000)
             base += 0x8000;
-        fseek(fp, 0x00000000, SEEK_SET);
-        carts[drive].buf = (uint8_t *) calloc(1, size);
-        (void) !fread(carts[drive].buf, 1, size, fp);
-        fclose(fp);
+    } else
+        goto fail;
+
+    if (base >= 0x100000 || size > 0x100000 - base)
+        goto fail;
+    if (other->buf && base < other->base + other->size && other->base < base + size)
+        goto fail;
+
+    buf = malloc(size);
+    if (!buf || fread(buf, 1, size, fp) != size || fgetc(fp) != EOF || ferror(fp))
+        goto fail;
+    if (fclose(fp) != 0) {
+        fp = NULL;
+        goto fail;
     }
 
     cartridge_log("cart_image_load(): %s at %08X-%08X\n", fn, base, base + size - 1);
+    carts[drive].buf  = buf;
     carts[drive].base = base;
-    mem_mapping_set_addr(&cart_mappings[drive], base, size);
-    mem_mapping_set_exec(&cart_mappings[drive], carts[drive].buf);
-    mem_mapping_set_p(&cart_mappings[drive], &(carts[drive]));
+    carts[drive].size = size;
+    if (cart_mapping_registered[drive]) {
+        mem_mapping_set_addr(&cart_mappings[drive], base, size);
+        mem_mapping_set_exec(&cart_mappings[drive], buf);
+        mem_mapping_set_p(&cart_mappings[drive], &carts[drive]);
+    }
+    return 1;
+
+fail:
+    if (fp)
+        fclose(fp);
+    free(buf);
+    cart_load_error(drive, fn);
+    return 0;
 }
 
 static void
 cart_load_common(int drive, char *fn, uint8_t hard_reset)
 {
-    FILE *fp = NULL;
+    if (drive < 0 || drive >= 2 || !fn || !fn[0])
+        return;
 
     cartridge_log("Cartridge: loading drive %d with '%s'\n", drive, fn);
 
-    if (!fn)
-        return;
-    fp = plat_fopen(fn, "rb");
-    if (fp) {
-        fclose(fp);
-        strcpy(cart_fns[drive], fn);
-        cart_image_load(drive, cart_fns[drive]);
-        /* On the real PCjr, inserting a cartridge causes a reset
-           in order to boot from the cartridge. */
-        if (!hard_reset)
-            resetx86();
-    } else
+    if (strlen(fn) >= sizeof(cart_fns[drive])) {
+        cart_image_close(drive);
         cart_load_error(drive, fn);
+    } else if (cart_image_load(drive, fn))
+        memmove(cart_fns[drive], fn, strlen(fn) + 1);
+
+    /* Inserting or removing a cartridge resets the PCjr. */
+    if (!hard_reset)
+        resetx86();
 }
 
 void
@@ -163,6 +181,9 @@ cart_load(int drive, char *fn)
 void
 cart_close(int drive)
 {
+    if (drive < 0 || drive >= 2)
+        return;
+
     cartridge_log("Cartridge: closing drive %d\n", drive);
 
     cart_image_close(drive);
@@ -174,18 +195,19 @@ cart_close(int drive)
 void
 cart_reset(void)
 {
+    /* mem_reset has already discarded the previous machine's mappings. */
+    memset(cart_mapping_registered, 0, sizeof(cart_mapping_registered));
     cart_image_close(1);
     cart_image_close(0);
 
     if (!machine_has_cartridge(machine))
         return;
 
-    for (uint8_t i = 0; i < 2; i++) {
-        mem_mapping_add(&cart_mappings[i], 0x000d0000, 0x00002000,
-                        cart_read, NULL, NULL,
-                        NULL, NULL, NULL,
-                        NULL, MEM_MAPPING_EXTERNAL, NULL);
+    for (unsigned int i = 0; i < 2; i++) {
+        mem_mapping_add(&cart_mappings[i], 0xd0000, 0x2000, cart_read, NULL, NULL,
+                        NULL, NULL, NULL, NULL, MEM_MAPPING_EXTERNAL, &carts[i]);
         mem_mapping_disable(&cart_mappings[i]);
+        cart_mapping_registered[i] = 1;
     }
 
     cart_load_common(0, cart_fns[0], 1);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(cdrom)
+add_subdirectory(device)

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,3 +20,13 @@ Try to match your code's filename and append the type of test it is.
 # Mitsumi
 
 The Mitsumi tests exercise the device implementation in isolation using mocked CD-ROM, DMA, interrupt and timer dependencies. They are device-level unit tests, not full-emulator or guest-driver integration tests. The benchmark measures performance and is not a correctness test.
+
+# Cartridges
+
+The cartridge tests compile `src/device/cartridge.c` as C and exercise raw and headered image loading, replacement/ejection, overlap and address bounds, and hard-reset reloads. They use real temporary image files with a small external-memory mapping adapter; they do not emulate CPU execution, RAM/BIOS arbitration, or the real memory mapping cache.
+
+Build the `cartridge_tests` target with `BUILD_TESTING=ON`, then run:
+
+```sh
+ctest --test-dir build --output-on-failure -R '^CartridgeTest\.'
+```

--- a/tests/device/CMakeLists.txt
+++ b/tests/device/CMakeLists.txt
@@ -1,0 +1,24 @@
+if(BUILD_TESTING)
+    add_executable(cartridge_tests
+        cartridge_test.cpp
+        ../../src/device/cartridge.c
+    )
+
+    target_include_directories(cartridge_tests PRIVATE
+        ${PROJECT_SOURCE_DIR}/src/include
+        ${PROJECT_SOURCE_DIR}/src/cpu
+        ${PROJECT_BINARY_DIR}/src/include
+    )
+    target_compile_options(cartridge_tests PRIVATE
+        $<$<COMPILE_LANG_AND_ID:C,GNU,Clang,AppleClang>:-ffunction-sections;-fdata-sections>
+        $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang>:-ffunction-sections;-fdata-sections>
+    )
+    target_link_options(cartridge_tests PRIVATE
+        $<$<PLATFORM_ID:Darwin>:-Wl,-dead_strip>
+        $<$<AND:$<NOT:$<PLATFORM_ID:Darwin>>,$<CXX_COMPILER_ID:GNU,Clang>>:-Wl,--gc-sections>
+    )
+    target_link_libraries(cartridge_tests PRIVATE GTest::gtest_main)
+
+    include(GoogleTest)
+    gtest_discover_tests(cartridge_tests)
+endif()

--- a/tests/device/cartridge_test.cpp
+++ b/tests/device/cartridge_test.cpp
@@ -1,0 +1,375 @@
+#include <gtest/gtest.h>
+
+#include <cstdarg>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <system_error>
+#include <vector>
+
+extern "C" {
+#define HAVE_STDARG_H
+#include <86box/86box.h>
+#include <86box/cartridge.h>
+#include <86box/mem.h>
+#include <86box/plat.h>
+#include <86box/ui.h>
+}
+
+namespace {
+
+// Only external cartridge mappings participate: no RAM, BIOS, paging, or CPU
+// execution. Keep registration order and enable/set_addr semantics from mem.c;
+// reads use the loader's real callback and instruction fetches its exec buffer.
+std::vector<mem_mapping_t *> mappings;
+
+mem_mapping_t *
+mapping_at(uint32_t address)
+{
+    for (auto it = mappings.rbegin(); it != mappings.rend(); ++it) {
+        auto *mapping = *it;
+        if (mapping->enable && address >= mapping->base && address - mapping->base < mapping->size)
+            return mapping;
+    }
+    return nullptr;
+}
+
+uint8_t
+read_byte(uint32_t address)
+{
+    const auto *mapping = mapping_at(address);
+    return mapping && mapping->read_b ? mapping->read_b(address, mapping->priv) : 0xff;
+}
+
+uint8_t
+fetch_byte(uint32_t address)
+{
+    const auto *mapping = mapping_at(address);
+    return mapping && mapping->exec ? mapping->exec[address - mapping->base] : 0xff;
+}
+
+std::vector<uint8_t>
+payload(size_t size, uint8_t seed)
+{
+    std::vector<uint8_t> bytes(size);
+    for (size_t i = 0; i < size; ++i)
+        bytes[i] = static_cast<uint8_t>((seed + i * 37 + (i >> 8)) % 251);
+    return bytes;
+}
+
+std::vector<uint8_t>
+jrc_image(uint16_t segment, const std::vector<uint8_t> &bytes)
+{
+    std::vector<uint8_t> image(512, 0xa5);
+    image[0x1ce] = static_cast<uint8_t>(segment);
+    image[0x1cf] = static_cast<uint8_t>(segment >> 8);
+    image.insert(image.end(), bytes.begin(), bytes.end());
+    return image;
+}
+
+void
+expect_rom(uint32_t base, const std::vector<uint8_t> &bytes)
+{
+    for (size_t i = 0; i < bytes.size(); ++i) {
+        const auto address = base + static_cast<uint32_t>(i);
+        ASSERT_EQ(read_byte(address), bytes[i]) << "Read address " << address;
+        ASSERT_EQ(fetch_byte(address), bytes[i]) << "Fetch address " << address;
+    }
+}
+
+void
+expect_open_bus(uint32_t address)
+{
+    EXPECT_EQ(read_byte(address), 0xff) << "Read address " << address;
+    EXPECT_EQ(fetch_byte(address), 0xff) << "Fetch address " << address;
+}
+
+class CartridgeTest : public ::testing::Test {
+protected:
+    std::filesystem::path directory;
+
+    void SetUp() override
+    {
+        // Atomic directory creation isolates concurrent test processes while
+        // filenames and image contents remain deterministic.
+        std::error_code error;
+        const auto      root = std::filesystem::temp_directory_path(error);
+        ASSERT_FALSE(error) << error.message();
+        for (unsigned i = 0; i < 1024; ++i) {
+            const auto candidate = root / ("86box-cartridge-test-" + std::to_string(i));
+            if (std::filesystem::create_directory(candidate, error)) {
+                directory = candidate;
+                break;
+            }
+            ASSERT_TRUE(!error || error == std::errc::file_exists) << error.message();
+        }
+        ASSERT_FALSE(directory.empty()) << "No available cartridge test directory";
+        cart_fns[0][0] = cart_fns[1][0] = 0;
+        mappings.clear(); // A machine hard reset discards mappings before cart_reset.
+        cart_reset();
+    }
+
+    void TearDown() override
+    {
+        cart_close(1);
+        cart_close(0);
+        mappings.clear();
+        if (!directory.empty()) {
+            std::error_code error;
+            std::filesystem::remove_all(directory, error);
+            EXPECT_FALSE(error) << error.message();
+        }
+    }
+
+    void write_image(const char *name, const std::vector<uint8_t> &bytes)
+    {
+        std::ofstream file(directory / name, std::ios::binary | std::ios::trunc);
+        ASSERT_TRUE(file.is_open());
+        file.write(reinterpret_cast<const char *>(bytes.data()),
+                   static_cast<std::streamsize>(bytes.size()));
+        file.close();
+        ASSERT_TRUE(file.good()) << "Could not write " << name;
+    }
+
+    void load(int slot, const char *name)
+    {
+        auto filename = (directory / name).string();
+        cart_load(slot, filename.data());
+    }
+};
+
+TEST_F(CartridgeTest, RawSlotsRelocateWhenReplacedWith32KiBImages)
+{
+    const auto small = payload(0x2000, 17);
+    const auto large = payload(0x8000, 93);
+    ASSERT_NO_FATAL_FAILURE(write_image("small.bin", small));
+    ASSERT_NO_FATAL_FAILURE(write_image("large.bin", large));
+    load(0, "small.bin");
+    load(1, "small.bin");
+    ASSERT_NO_FATAL_FAILURE(expect_rom(0xd0000, small));
+    ASSERT_NO_FATAL_FAILURE(expect_rom(0xe0000, small));
+    expect_open_bus(0xcffff);
+    expect_open_bus(0xd2000);
+    expect_open_bus(0xdffff);
+    expect_open_bus(0xe2000);
+
+    load(0, "large.bin");
+    load(1, "large.bin");
+    ASSERT_NO_FATAL_FAILURE(expect_rom(0xd8000, large));
+    ASSERT_NO_FATAL_FAILURE(expect_rom(0xe8000, large));
+    expect_open_bus(0xd0000);
+    expect_open_bus(0xd7fff);
+    expect_open_bus(0xe0000);
+    expect_open_bus(0xe7fff);
+    expect_open_bus(0xf0000);
+}
+
+TEST_F(CartridgeTest, JrcUsesLittleEndianSegmentAndExcludesHeader)
+{
+    const auto bytes = payload(0x1000, 29);
+    ASSERT_NO_FATAL_FAILURE(write_image("header.jrc", jrc_image(0xc100, bytes)));
+    load(0, "header.jrc");
+    ASSERT_NO_FATAL_FAILURE(expect_rom(0xc1000, bytes));
+    expect_open_bus(0xc0fff);
+    expect_open_bus(0xc2000);
+    expect_open_bus(0xd0000);
+}
+
+TEST_F(CartridgeTest, MissingFileReplacementRemovesOldRom)
+{
+    const auto bytes = payload(0x2000, 41);
+    ASSERT_NO_FATAL_FAILURE(write_image("original.bin", bytes));
+    load(0, "original.bin");
+    ASSERT_NO_FATAL_FAILURE(expect_rom(0xd0000, bytes));
+
+    // Deliberately do not cart_close first: failed direct API replacement must
+    // eject the previous image rather than leave an invisible cartridge active.
+    load(0, "missing.bin");
+    EXPECT_EQ(cart_fns[0][0], '\0');
+    expect_open_bus(0xd0000);
+    expect_open_bus(0xd1fff);
+}
+
+TEST_F(CartridgeTest, MisalignedPayloadIsRejectedWithoutDisturbingOtherSlot)
+{
+    const auto first     = payload(0x2000, 53);
+    auto       malformed = jrc_image(0xc100, payload(0x1000, 67));
+    malformed.push_back(0x42);
+    ASSERT_NO_FATAL_FAILURE(write_image("first.bin", first));
+    ASSERT_NO_FATAL_FAILURE(write_image("misaligned.jrc", malformed));
+    load(0, "first.bin");
+    load(1, "misaligned.jrc");
+    EXPECT_EQ(cart_fns[1][0], '\0');
+    expect_open_bus(0xc1000);
+    expect_open_bus(0xc2000);
+    ASSERT_NO_FATAL_FAILURE(expect_rom(0xd0000, first));
+}
+
+TEST_F(CartridgeTest, Exact20BitEndIsAcceptedButOverflowingReplacementIsRejected)
+{
+    const auto bytes = payload(0x1000, 79);
+    ASSERT_NO_FATAL_FAILURE(write_image("last-page.jrc", jrc_image(0xff00, bytes)));
+    ASSERT_NO_FATAL_FAILURE(write_image("overflow.jrc", jrc_image(0xff01, bytes)));
+    load(0, "last-page.jrc");
+    ASSERT_NO_FATAL_FAILURE(expect_rom(0xff000, bytes));
+    expect_open_bus(0xfefff);
+    expect_open_bus(0x100000);
+
+    load(0, "overflow.jrc");
+    EXPECT_EQ(cart_fns[0][0], '\0');
+    expect_open_bus(0xff000);
+    expect_open_bus(0xff010);
+    expect_open_bus(0xfffff);
+    expect_open_bus(0x100000);
+}
+
+TEST_F(CartridgeTest, RawPayloadCannotExtendPast20BitAddressSpace)
+{
+    ASSERT_NO_FATAL_FAILURE(write_image("oversized.bin", payload(0x40000, 101)));
+    load(0, "oversized.bin");
+    EXPECT_EQ(cart_fns[0][0], '\0');
+    expect_open_bus(0xd0000);
+    expect_open_bus(0xfffff);
+    expect_open_bus(0x100000);
+}
+
+TEST_F(CartridgeTest, OverlappingSecondCartridgeIsRejectedButAdjacentOneIsAccepted)
+{
+    const auto first    = payload(0x2000, 113);
+    const auto adjacent = payload(0x1000, 127);
+    ASSERT_NO_FATAL_FAILURE(write_image("first.bin", first));
+    ASSERT_NO_FATAL_FAILURE(write_image("overlap.jrc", jrc_image(0xcf00, payload(0x3000, 139))));
+    ASSERT_NO_FATAL_FAILURE(write_image("adjacent.jrc", jrc_image(0xd200, adjacent)));
+    load(0, "first.bin");
+    load(1, "overlap.jrc");
+    EXPECT_EQ(cart_fns[1][0], '\0');
+    expect_open_bus(0xcf000);
+    ASSERT_NO_FATAL_FAILURE(expect_rom(0xd0000, first));
+
+    load(1, "adjacent.jrc");
+    ASSERT_NO_FATAL_FAILURE(expect_rom(0xd0000, first));
+    ASSERT_NO_FATAL_FAILURE(expect_rom(0xd2000, adjacent));
+    expect_open_bus(0xd3000);
+    cart_close(1);
+    expect_open_bus(0xd2000);
+    ASSERT_NO_FATAL_FAILURE(expect_rom(0xd0000, first));
+}
+
+TEST_F(CartridgeTest, HardResetReloadsBothSlotsAfterMappingsAreDiscarded)
+{
+    const auto first  = payload(0x2000, 151);
+    const auto second = payload(0x8000, 163);
+    ASSERT_NO_FATAL_FAILURE(write_image("first.bin", first));
+    ASSERT_NO_FATAL_FAILURE(write_image("second.bin", second));
+    load(0, "first.bin");
+    load(1, "second.bin");
+    mappings.clear();
+    cart_reset();
+    ASSERT_NO_FATAL_FAILURE(expect_rom(0xd0000, first));
+    ASSERT_NO_FATAL_FAILURE(expect_rom(0xe8000, second));
+    cart_close(0);
+    expect_open_bus(0xd0000);
+    ASSERT_NO_FATAL_FAILURE(expect_rom(0xe8000, second));
+}
+
+} // namespace
+
+extern "C" {
+
+int machine = 0;
+
+int
+machine_has_cartridge(int)
+{
+    return 1;
+}
+
+FILE *
+plat_fopen(const char *path, const char *mode)
+{
+    return std::fopen(path, mode);
+}
+
+// CPU reset and status-bar notification have no host side effects here. Hard
+// resets are exercised explicitly above, in the emulator's mem_reset order.
+void
+resetx86(void)
+{
+}
+void
+ui_sb_update_icon_state(int, int)
+{
+}
+
+void
+pclog_ex(const char *format, va_list args)
+{
+    std::vfprintf(stderr, format, args);
+}
+
+void
+fatal(const char *format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    std::vfprintf(stderr, format, args);
+    va_end(args);
+    std::abort();
+}
+
+void
+mem_mapping_add(mem_mapping_t *mapping, uint32_t base, uint32_t size,
+                uint8_t (*read_b)(uint32_t, void *),
+                uint16_t (*read_w)(uint32_t, void *),
+                uint32_t (*read_l)(uint32_t, void *),
+                void (*write_b)(uint32_t, uint8_t, void *),
+                void (*write_w)(uint32_t, uint16_t, void *),
+                void (*write_l)(uint32_t, uint32_t, void *),
+                uint8_t *exec, uint32_t flags, void *priv)
+{
+    *mapping         = {};
+    mapping->enable  = size != 0;
+    mapping->base    = base;
+    mapping->size    = size;
+    mapping->read_b  = read_b;
+    mapping->read_w  = read_w;
+    mapping->read_l  = read_l;
+    mapping->write_b = write_b;
+    mapping->write_w = write_w;
+    mapping->write_l = write_l;
+    mapping->exec    = exec;
+    mapping->flags   = flags;
+    mapping->priv    = priv;
+    mappings.push_back(mapping);
+}
+
+void
+mem_mapping_set_addr(mem_mapping_t *mapping, uint32_t base, uint32_t size)
+{
+    mapping->base   = base;
+    mapping->size   = size;
+    mapping->enable = 1;
+}
+
+void
+mem_mapping_set_exec(mem_mapping_t *mapping, uint8_t *exec)
+{
+    mapping->exec = exec;
+}
+
+void
+mem_mapping_set_p(mem_mapping_t *mapping, void *priv)
+{
+    mapping->priv = priv;
+}
+
+void
+mem_mapping_disable(mem_mapping_t *mapping)
+{
+    mapping->enable = 0;
+}
+
+} // extern "C"


### PR DESCRIPTION
Summary
=======
This makes a few changes to cartridge loading mostly around actually checking the cartridge size. This came out of work to load PC JX cartridges which have more flexible options (mostly relating to the Japanese IBM PC JX) than the PCjr had.

Tested against the PCjr with every cartridge .jrc file known to be in existence. No regressions were observed.

Checklist
=========
* [X] Closes #xxx - N/A
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set  - N/A
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/  - N/A
* [ ] This pull request requires changes to the asset set  - N/A
  * [ ] I have opened an assets pull request - https://github.com/86Box/assets/pull/changeme/  - N/A
* [ ] This pull request adds, changes or removes an external dependency  - N/A
  * [ ] I have opened a docs pull request - https://github.com/86Box/docs/pull/changeme/  - N/A

References
==========
The IBM PC JX and PCjr Technical References, including the ROM listings.
