### PR TITLE
Add support for custom generic drive branding

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1578,6 +1578,21 @@ load_hard_disks(void)
                &hdd[c].spt, &hdd[c].hpc, &hdd[c].tracks, (int *) &hdd[c].wp, s);
 
         hdd[c].bus_type = hdd_string_to_bus(s, 0);
+        memset(hdd[c].custom_vendor, 0, sizeof(hdd[c].custom_vendor));
+        memset(hdd[c].custom_model, 0, sizeof(hdd[c].custom_model));
+        memset(hdd[c].custom_version, 0, sizeof(hdd[c].custom_version));
+        sprintf(temp, "hdd_%02i_vendor", c + 1);
+        p = ini_section_get_string(cat, temp, NULL);
+        if (p)
+            strncpy(hdd[c].custom_vendor, p, sizeof(hdd[c].custom_vendor) - 1);
+        sprintf(temp, "hdd_%02i_model", c + 1);
+        p = ini_section_get_string(cat, temp, NULL);
+        if (p)
+            strncpy(hdd[c].custom_model, p, sizeof(hdd[c].custom_model) - 1);
+        sprintf(temp, "hdd_%02i_revision", c + 1);
+        p = ini_section_get_string(cat, temp, NULL);
+        if (p)
+            strncpy(hdd[c].custom_version, p, sizeof(hdd[c].custom_version) - 1);
         switch (hdd[c].bus_type) {
             default:
             case HDD_BUS_DISABLED:
@@ -4169,6 +4184,25 @@ save_hard_disks(void)
             ini_section_delete_var(cat, temp);
         else
             ini_section_set_string(cat, temp, hdd_preset_get_internal_name(hdd[c].speed_preset));
+
+        sprintf(temp, "hdd_%02i_vendor", c + 1);
+        if ((hdd[c].bus_type == HDD_BUS_IDE || hdd[c].bus_type == HDD_BUS_ATAPI || hdd[c].bus_type == HDD_BUS_SCSI) &&
+            hdd_preset_is_generic(hdd[c].speed_preset) && hdd[c].custom_vendor[0])
+            ini_section_set_string(cat, temp, hdd[c].custom_vendor);
+        else
+            ini_section_delete_var(cat, temp);
+        sprintf(temp, "hdd_%02i_model", c + 1);
+        if ((hdd[c].bus_type == HDD_BUS_IDE || hdd[c].bus_type == HDD_BUS_ATAPI || hdd[c].bus_type == HDD_BUS_SCSI) &&
+            hdd_preset_is_generic(hdd[c].speed_preset) && hdd[c].custom_model[0])
+            ini_section_set_string(cat, temp, hdd[c].custom_model);
+        else
+            ini_section_delete_var(cat, temp);
+        sprintf(temp, "hdd_%02i_revision", c + 1);
+        if ((hdd[c].bus_type == HDD_BUS_IDE || hdd[c].bus_type == HDD_BUS_ATAPI || hdd[c].bus_type == HDD_BUS_SCSI) &&
+            hdd_preset_is_generic(hdd[c].speed_preset) && hdd[c].custom_version[0])
+            ini_section_set_string(cat, temp, hdd[c].custom_version);
+        else
+            ini_section_delete_var(cat, temp);
 
         sprintf(temp, "hdd_%02i_audio", c + 1);
         if (!hdd_is_valid(c) || hdd[c].audio_profile == 0) {

--- a/src/disk/hdc_ide.c
+++ b/src/disk/hdc_ide.c
@@ -655,6 +655,7 @@ static void
 ide_hd_identify(const ide_t *ide)
 {
     char device_identify[9] = { '8', '6', 'B', '_', 'H', 'D', '0', '0', 0 };
+    char model[41];
     const ide_bm_t *bm      = ide_boards[ide->board]->bm;
     uint64_t full_size      = (((uint64_t) hdd[ide->hdd_num].tracks) *
                               hdd[ide->hdd_num].hpc * hdd[ide->hdd_num].spt);
@@ -701,9 +702,15 @@ ide_hd_identify(const ide_t *ide)
     else
         ide_padstr((char *) (ide->buffer + 23), EMU_VERSION_EX, 8);
     /* Model */
-    if (hdd[ide->hdd_num].model)
-        ide_padstr((char *) (ide->buffer + 27), hdd[ide->hdd_num].model, 40);
-    else
+    if (hdd[ide->hdd_num].vendor || hdd[ide->hdd_num].model) {
+        if (hdd[ide->hdd_num].vendor && hdd[ide->hdd_num].model)
+            snprintf(model, sizeof(model), "%s %s", hdd[ide->hdd_num].vendor, hdd[ide->hdd_num].model);
+        else if (hdd[ide->hdd_num].vendor)
+            snprintf(model, sizeof(model), "%s %s", hdd[ide->hdd_num].vendor, device_identify);
+        else
+            snprintf(model, sizeof(model), "%s", hdd[ide->hdd_num].model);
+        ide_padstr((char *) (ide->buffer + 27), model, 40);
+    } else
         ide_padstr((char *) (ide->buffer + 27), device_identify, 40);
     /* Fixed drive */
     ide->buffer[0]  = (1 << 6);

--- a/src/disk/hdd.c
+++ b/src/disk/hdd.c
@@ -1107,6 +1107,13 @@ hdd_preset_get_from_internal_name(char *s)
     return 0;
 }
 
+int
+hdd_preset_is_generic(int preset)
+{
+    return (preset >= 0 && preset < hdd_preset_get_num() &&
+            !strncmp(hdd_speed_presets[preset].name, "[Generic]", 9));
+}
+
 void
 hdd_preset_apply(int hdd_id)
 {
@@ -1132,6 +1139,14 @@ hdd_preset_apply(int hdd_id)
     hd->vendor  = preset->vendor;
     hd->model   = preset->model;
     hd->version = preset->version;
+    if (hdd_preset_is_generic(hd->speed_preset)) {
+        if (hd->custom_vendor[0])
+            hd->vendor = hd->custom_vendor;
+        if (hd->custom_model[0])
+            hd->model = hd->custom_model;
+        if (hd->custom_version[0])
+            hd->version = hd->custom_version;
+    }
 
     if (!hd->speed_preset)
         return;

--- a/src/include/86box/hdd.h
+++ b/src/include/86box/hdd.h
@@ -194,6 +194,10 @@ typedef struct hard_disk_t {
 
     const char        *version;
 
+    char               custom_vendor[9];
+    char               custom_model[41];
+    char               custom_version[5];
+
     hdd_zone_t         zones[HDD_MAX_ZONES];
 
     hdd_cache_t        cache;
@@ -240,6 +244,7 @@ extern double      hdd_seek_get_time(hard_disk_t *hdd, uint32_t dst_addr, uint8_
 int                hdd_preset_get_num(void);
 const char        *hdd_preset_getname(int preset);
 extern const char *hdd_preset_get_internal_name(int preset);
+extern int         hdd_preset_is_generic(int preset);
 extern uint32_t    hdd_preset_get_rpm(int preset);
 extern int         hdd_preset_get_from_internal_name(char *s);
 extern void        hdd_preset_apply(int hdd_id);

--- a/src/qt/qt_settingsharddisks.cpp
+++ b/src/qt/qt_settingsharddisks.cpp
@@ -24,6 +24,10 @@ extern "C" {
 }
 
 #include <QStandardItemModel>
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QLineEdit>
+#include <QPushButton>
 
 #include "qt_settings_completer.hpp"
 
@@ -46,8 +50,18 @@ const int DataBus                = Qt::UserRole;
 const int DataBusChannel         = Qt::UserRole + 1;
 const int DataBusPrevious        = Qt::UserRole + 2;
 const int DataBusChannelPrevious = Qt::UserRole + 3;
+const int DataCustomVendor        = Qt::UserRole + 4;
+const int DataCustomModel         = Qt::UserRole + 5;
+const int DataCustomVersion       = Qt::UserRole + 6;
 
 QIcon hard_disk_icon;
+
+static bool
+genericHDD(uint32_t bus, uint32_t speed)
+{
+    return (bus == HDD_BUS_IDE || bus == HDD_BUS_ATAPI || bus == HDD_BUS_SCSI) &&
+           hdd_preset_is_generic(speed);
+}
 
 uint64_t               ic[HDD_NUM] = { 0 };
 uint64_t               ih[HDD_NUM] = { 0 };
@@ -118,6 +132,9 @@ SettingsHarddisks::addRow(QAbstractItemModel *model, void *priv)
     auto speedIndex = model->index(row, ColumnSpeed);
     model->setData(speedIndex, QObject::tr(hdd_preset_getname(hd->speed_preset)));
     model->setData(speedIndex, hd->speed_preset, Qt::UserRole);
+    model->setData(speedIndex, QString::fromUtf8(hd->custom_vendor), DataCustomVendor);
+    model->setData(speedIndex, QString::fromUtf8(hd->custom_model), DataCustomModel);
+    model->setData(speedIndex, QString::fromUtf8(hd->custom_version), DataCustomVersion);
    
 }
 
@@ -191,6 +208,9 @@ SettingsHarddisks::changed()
         has_changed |= (hdd[i].speed_preset  != idx.siblingAtColumn(ColumnSpeed).data(Qt::UserRole).toUInt());
         has_changed |= (hdd[i].audio_profile != ia[i]);
         has_changed |= (hdd[i].vhd_blocksize != ib[i]);
+        has_changed |= (QString::fromUtf8(hdd[i].custom_vendor) != idx.siblingAtColumn(ColumnSpeed).data(DataCustomVendor).toString());
+        has_changed |= (QString::fromUtf8(hdd[i].custom_model) != idx.siblingAtColumn(ColumnSpeed).data(DataCustomModel).toString());
+        has_changed |= (QString::fromUtf8(hdd[i].custom_version) != idx.siblingAtColumn(ColumnSpeed).data(DataCustomVersion).toString());
 
         QByteArray fileName  = idx.siblingAtColumn(ColumnFilename).data(Qt::UserRole).toString().toUtf8();
         has_changed |= strcmp(hdd[i].fn, fileName.data());
@@ -224,6 +244,12 @@ SettingsHarddisks::save(int soft)
         hdd[i].speed_preset  = idx.siblingAtColumn(ColumnSpeed).data(Qt::UserRole).toUInt();
         hdd[i].audio_profile = ia[i];
         hdd[i].vhd_blocksize = ib[i];
+        QByteArray customVendor = idx.siblingAtColumn(ColumnSpeed).data(DataCustomVendor).toString().toUtf8();
+        QByteArray customModel = idx.siblingAtColumn(ColumnSpeed).data(DataCustomModel).toString().toUtf8();
+        QByteArray customVersion = idx.siblingAtColumn(ColumnSpeed).data(DataCustomVersion).toString().toUtf8();
+        strncpy(hdd[i].custom_vendor, customVendor.constData(), sizeof(hdd[i].custom_vendor) - 1);
+        strncpy(hdd[i].custom_model, customModel.constData(), sizeof(hdd[i].custom_model) - 1);
+        strncpy(hdd[i].custom_version, customVersion.constData(), sizeof(hdd[i].custom_version) - 1);
 
         QByteArray fileName  = idx.siblingAtColumn(ColumnFilename).data(Qt::UserRole).toString().toUtf8();
         strncpy(hdd[i].fn, fileName.data(), sizeof(hdd[i].fn) - 1);
@@ -341,6 +367,44 @@ SettingsHarddisks::on_comboBoxSpeed_currentIndexChanged(int index)
     
     /* Repopulate audio profiles based on the selected speed preset's RPM */
     populateAudioProfiles();
+    onTableRowChanged(ui->treeView->selectionModel()->currentIndex());
+}
+
+void
+SettingsHarddisks::on_pushButtonConfigure_clicked()
+{
+    auto idx = ui->treeView->selectionModel()->currentIndex();
+    if (!idx.isValid())
+        return;
+
+    const uint32_t bus = idx.siblingAtColumn(ColumnBus).data(DataBus).toUInt();
+    const uint32_t speed = idx.siblingAtColumn(ColumnSpeed).data(Qt::UserRole).toUInt();
+    if (!genericHDD(bus, speed))
+        return;
+
+    QDialog dialog(this);
+    dialog.setWindowTitle(tr("[Generic HDD] Device Configuration"));
+    auto *layout = new QFormLayout(&dialog);
+    auto *vendor = new QLineEdit(idx.siblingAtColumn(ColumnSpeed).data(DataCustomVendor).toString(), &dialog);
+    auto *model = new QLineEdit(idx.siblingAtColumn(ColumnSpeed).data(DataCustomModel).toString(), &dialog);
+    auto *version = new QLineEdit(idx.siblingAtColumn(ColumnSpeed).data(DataCustomVersion).toString(), &dialog);
+    vendor->setMaxLength(8);
+    model->setMaxLength(40);
+    version->setMaxLength(4);
+    layout->addRow(tr("Branding:"), vendor);
+    layout->addRow(tr("Model:"), model);
+    layout->addRow(tr("Revision:"), version);
+    auto *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog);
+    layout->addRow(buttons);
+    connect(buttons, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+
+    if (dialog.exec() == QDialog::Accepted) {
+        auto *speedColumn = ui->treeView->model();
+        speedColumn->setData(idx.siblingAtColumn(ColumnSpeed), vendor->text(), DataCustomVendor);
+        speedColumn->setData(idx.siblingAtColumn(ColumnSpeed), model->text(), DataCustomModel);
+        speedColumn->setData(idx.siblingAtColumn(ColumnSpeed), version->text(), DataCustomVersion);
+    }
 }
 
 void
@@ -391,11 +455,14 @@ SettingsHarddisks::onTableRowChanged(const QModelIndex &current)
     ui->comboBoxChannel->setHidden(hidden);
     ui->comboBoxSpeed->setHidden(hidden);
     ui->comboBoxAudio->setHidden(hidden);
+    ui->pushButtonConfigure->setHidden(hidden);
 
     uint32_t bus        = current.siblingAtColumn(ColumnBus).data(DataBus).toUInt();
     uint32_t busChannel = current.siblingAtColumn(ColumnBus).data(DataBusChannel).toUInt();
     uint32_t speed      = current.siblingAtColumn(ColumnSpeed).data(Qt::UserRole).toUInt();
     uint32_t audio      = hidden ? -1 : ia[current.row()];
+    ui->pushButtonConfigure->setHidden(hidden ||
+                                       (bus != HDD_BUS_IDE && bus != HDD_BUS_ATAPI && bus != HDD_BUS_SCSI));
 
     auto *model = ui->comboBoxBus->model();
     auto  match = model->match(model->index(0, 0), Qt::UserRole, bus);
@@ -420,6 +487,7 @@ SettingsHarddisks::onTableRowChanged(const QModelIndex &current)
     if (!match.isEmpty())
         ui->comboBoxAudio->setCurrentIndex(match.first().row());
 
+    ui->pushButtonConfigure->setEnabled(genericHDD(bus, speed));
     reloadBusChannels();
 }
 

--- a/src/qt/qt_settingsharddisks.hpp
+++ b/src/qt/qt_settingsharddisks.hpp
@@ -28,6 +28,7 @@ private slots:
     void on_comboBoxChannel_currentIndexChanged(int index);
     void on_comboBoxSpeed_currentIndexChanged(int index);
     void on_comboBoxAudio_currentIndexChanged(int index);
+    void on_pushButtonConfigure_clicked();
 
     void on_pushButtonNew_clicked();
     void on_pushButtonExisting_clicked();

--- a/src/qt/qt_settingsharddisks.ui
+++ b/src/qt/qt_settingsharddisks.ui
@@ -112,6 +112,19 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="4">
+       <widget class="QPushButton" name="pushButtonConfigure">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Configure</string>
+       </property>
+       </widget>
+      </item>
       <item row="2" column="0">
        <widget class="QLabel" name="labelAudio">
         <property name="text">

--- a/src/scsi/scsi_disk.c
+++ b/src/scsi/scsi_disk.c
@@ -1439,12 +1439,13 @@ scsi_disk_command(scsi_common_t *sc, const uint8_t *cdb)
                 }
                 dev->temp_buffer[7] |= 0x02;
 
-                if (dev->drv->model) {
+                if (dev->drv->model || dev->drv->vendor || dev->drv->version) {
                     /* Vendor */
                     ide_padstr8(dev->temp_buffer + 8, 8,
                                 (dev->drv->vendor) ? dev->drv->vendor : EMU_NAME);
                     /* Product */
-                    ide_padstr8(dev->temp_buffer + 16, 16, dev->drv->model);
+                    ide_padstr8(dev->temp_buffer + 16, 16,
+                                (dev->drv->model) ? dev->drv->model : device_identify);
                     /* Revision */
                     ide_padstr8(dev->temp_buffer + 32, 4,
                                 (dev->drv->version) ? dev->drv->version : EMU_VERSION_EX);
@@ -1754,11 +1755,12 @@ scsi_disk_identify(const ide_t *ide, const int ide_has_dma)
     ide_padstr((char *) (ide->buffer + 10), "", 20);               /* Serial Number */
 
     memset(model, 0, 40);
-    if (dev->drv->model) {
+    if (dev->drv->model || dev->drv->vendor || dev->drv->version) {
+        const char *drive_model = dev->drv->model ? dev->drv->model : device_identify;
         if (dev->drv->vendor)
-            snprintf(model, 40, "%s %s", dev->drv->vendor, dev->drv->model);
+            snprintf(model, 40, "%s %s", dev->drv->vendor, drive_model);
         else
-            snprintf(model, 40, "%s", dev->drv->model);
+            snprintf(model, 40, "%s", drive_model);
         ide_padstr((char *) (ide->buffer + 23),
                    (dev->drv->version) ? dev->drv->version : EMU_VERSION_EX, 8);    /* Firmware */
         ide_padstr((char *) (ide->buffer + 27), model, 40);                         /* Model */


### PR DESCRIPTION
Summary
=======
Add support for custom branding for the generic HDDs on SCSI, IDE and ATAPI only
This adds a Configure button to the drive models.

Checklist
=========
* [X] I have tested my changes locally and validated that the functionality works as intended
* [X] I have discussed this with core contributors already
